### PR TITLE
fix(docs): correct README sector/occupation counts to HF ground truth (9/44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 Most LLM benchmarks test **academic reasoning** — math, code puzzles, trivia.  
 None of that tells you whether a model can actually **do your job**.
 
-**GDPVal** (GDP-level Validation) is different: **220 real-world expert tasks** across 11 sectors and 55 occupations — Excel reports, legal docs, sales decks, the stuff people actually get paid for.
+**GDPVal** (GDP-level Validation) is different: **220 real-world expert tasks** across 9 industry sectors and 44 occupations — Excel reports, legal docs, sales decks, the stuff people actually get paid for.
 
 This repo automates the entire loop: **configure → run → collect → visualize** — driven by a single YAML file, executed on GitHub Actions, results on a live dashboard.
 

--- a/src/README.md
+++ b/src/README.md
@@ -7,7 +7,7 @@
 
 ## What This Is
 
-A React dashboard that visualizes LLM experiment results on **220 real-world expert tasks** across 11 sectors and 55 occupations. Compare prompt strategies, track sector-level performance, and drill into individual task outcomes — all without a backend server.
+A React dashboard that visualizes LLM experiment results on **220 real-world expert tasks** across 9 industry sectors and 44 occupations. Compare prompt strategies, track sector-level performance, and drill into individual task outcomes — all without a backend server.
 
 - **Static JSON** generated at build time → zero API calls at runtime
 - **GitHub Pages** auto-deployed on every push to `main`

--- a/tasks/TASK_DOCS_CLEANUP.md
+++ b/tasks/TASK_DOCS_CLEANUP.md
@@ -1,0 +1,27 @@
+# TASK_DOCS_CLEANUP — README sector/occupation consistency
+
+## Goal
+README들의 self-contradiction 정정. ground truth는 HF dataset(`openai/gdpval`,
+split `train`, 220 rows) 라이브 카운트로 확인됨: **sectors = 9, occupations = 44**.
+표기 패턴은 `src/data/tooltipTexts.ts`의 AboutModal 문구 스타일을 따른다
+("N industry sectors and M occupations").
+
+## Ground truth (HF dataset live count, verified this session)
+- unique sectors = **9**
+- unique occupations = **44**
+- 표기: `9 industry sectors and 44 occupations`
+
+## Scope
+- `README.md` — L44 "across 11 sectors and 55 occupations" → ground truth로 정정
+- `src/README.md` — L10 동일 정정
+
+손대지 않을 곳:
+- `src/data/tooltipTexts.ts` (UI PR에서 별도 처리 중 — scope 외)
+- 코드 파일, `batch-runner/`, `tests/`
+- README.md:261 / src/README.md:56 의 "9 sectors × N experiments" (이미 정확 — 유지)
+
+## Acceptance
+- 양 README에서 sector·occupation 카운트가 HF dataset 실제 값(9 / 44)과 일치
+- 일관된 표기 (양 README 동일 문구)
+- 코드 변경 0
+- secrets 0


### PR DESCRIPTION
## Summary
README self-contradiction 정정. `README.md`와 `src/README.md`가 "11 sectors and 55 occupations"로 표기되어 있었으나, HF dataset(`openai/gdpval`, split `train`, 220 rows) 라이브 카운트 기준 실제 값은 **9 sectors / 44 occupations**.

## Ground truth (verified)
```
unique sectors = 9
unique occupations = 44
```

## Changes
- `README.md` L44: `11 sectors and 55 occupations` → `9 industry sectors and 44 occupations`
- `src/README.md` L10: 동일 정정
- `tasks/TASK_DOCS_CLEANUP.md`: spec 추가
- 코드 변경 0 / secrets 0

## Out of scope (follow-up)
- `src/data/tooltipTexts.ts` (L8/L71): 아직 "11 industry sectors" — UI PR에서 별도 처리 중
- `README_KR.md`, `src/README_KR.md`: "11개 산업, 55개 직종" 잔존 → 별도 task 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)