### PR TITLE
feat(ui): dynamic task-total denominators + sector consistency

### DIFF
--- a/src/components/common/AboutModal.tsx
+++ b/src/components/common/AboutModal.tsx
@@ -4,15 +4,18 @@ import { X, Info } from 'lucide-react'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { onboarding } from '../../utils/onboarding'
 import { aboutContent } from '../../data/tooltipTexts'
+import { substituteTaskTotal } from '../../lib/textFormat'
 
 interface AboutModalProps {
   open: boolean
   onClose: () => void
+  totalTasks?: number
 }
 
-export default function AboutModal({ open, onClose }: AboutModalProps) {
+export default function AboutModal({ open, onClose, totalTasks }: AboutModalProps) {
   const isMobile = useIsMobile()
   const modalRef = useRef<HTMLDivElement>(null)
+  const effectiveTotalTasks = totalTasks ?? 220
 
   // Mark as seen + close
   const handleClose = () => {
@@ -104,7 +107,7 @@ export default function AboutModal({ open, onClose }: AboutModalProps) {
                   <h3 className="text-sm font-semibold text-dash-text mb-2">{section.heading}</h3>
                   {'body' in section && (
                     <p className="text-xs text-dash-text-secondary leading-relaxed">
-                      {section.body}
+                      {substituteTaskTotal(section.body, effectiveTotalTasks)}
                     </p>
                   )}
                   {'bullets' in section && section.bullets && (

--- a/src/components/common/InfoTooltip.tsx
+++ b/src/components/common/InfoTooltip.tsx
@@ -3,17 +3,20 @@ import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Info } from 'lucide-react'
 import { useIsMobile } from '../../hooks/useIsMobile'
+import { substituteTaskTotal } from '../../lib/textFormat'
 
 interface InfoTooltipProps {
   content: string
   position?: 'top' | 'bottom' | 'left' | 'right'
   className?: string
+  totalTasks?: number
 }
 
 const GAP = 8 // px between icon and tooltip
 const VIEWPORT_PAD = 16 // px padding from viewport edges
 
-export default function InfoTooltip({ content, position = 'top', className = '' }: InfoTooltipProps) {
+export default function InfoTooltip({ content, position = 'top', className = '', totalTasks }: InfoTooltipProps) {
+  const resolvedContent = totalTasks !== undefined ? substituteTaskTotal(content, totalTasks) : content
   const [visible, setVisible] = useState(false)
   const [coords, setCoords] = useState<{ top: number; left: number } | null>(null)
   const triggerRef = useRef<HTMLSpanElement>(null)
@@ -136,7 +139,7 @@ export default function InfoTooltip({ content, position = 'top', className = '' 
               overflowWrap: 'break-word',
             }}
           >
-            {content}
+            {resolvedContent}
           </div>
         </motion.div>
       )}

--- a/src/components/common/SectionHint.tsx
+++ b/src/components/common/SectionHint.tsx
@@ -2,14 +2,21 @@ import { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { X, Lightbulb } from 'lucide-react'
 import { onboarding } from '../../utils/onboarding'
+import { substituteTaskTotal } from '../../lib/textFormat'
 
 interface SectionHintProps {
   tabId: string
   children: React.ReactNode
+  totalTasks?: number
 }
 
-export default function SectionHint({ tabId, children }: SectionHintProps) {
+export default function SectionHint({ tabId, children, totalTasks }: SectionHintProps) {
   const [visible, setVisible] = useState(false)
+
+  const resolvedChildren =
+    totalTasks !== undefined && typeof children === 'string'
+      ? substituteTaskTotal(children, totalTasks)
+      : children
 
   useEffect(() => {
     // Show only if not already dismissed (delay to avoid SSR flash)
@@ -34,7 +41,7 @@ export default function SectionHint({ tabId, children }: SectionHintProps) {
           <div className="rounded-lg bg-amber-500/[0.06] border border-amber-500/20 border-l-2 border-l-amber-500/40 px-4 py-3 flex items-start gap-3">
             <Lightbulb className="w-3.5 h-3.5 text-amber-500/70 flex-shrink-0 mt-0.5" />
             <p className="text-xs text-dash-text-secondary leading-relaxed flex-1">
-              {children}
+              {resolvedChildren}
             </p>
             <button
               onClick={handleDismiss}

--- a/src/components/dashboard/LeaderboardView.tsx
+++ b/src/components/dashboard/LeaderboardView.tsx
@@ -6,11 +6,13 @@ import { useTheme } from '../../contexts/ThemeContext'
 import InfoTooltip from '../common/InfoTooltip'
 import SectionHint from '../common/SectionHint'
 import { tooltipTexts, sectionHintTexts } from '../../data/tooltipTexts'
+import { substituteTaskTotal } from '../../lib/textFormat'
 
 interface LeaderboardViewProps {
   experiments: ExperimentEntry[]
   sectorMatrix: SectorMatrix
   onSelectExperiment: (shortId: string) => void
+  totalTasks?: number
 }
 
 const EXPERIMENT_COLORS: Record<string, string> = {
@@ -112,6 +114,7 @@ export default function LeaderboardView({
   experiments,
   sectorMatrix,
   onSelectExperiment,
+  totalTasks,
 }: LeaderboardViewProps) {
   const [hoveredRow, setHoveredRow] = useState<string | null>(null)
   const [modelFilter, setModelFilter] = useState<string>('all')
@@ -120,6 +123,8 @@ export default function LeaderboardView({
   const [hoveredCell, setHoveredCell] = useState<string | null>(null)
   const [heatmapMode, setHeatmapMode] = useState<'qa' | 'rate'>('qa')
   const { isDark } = useTheme()
+
+  const effectiveTotalTasks = totalTasks ?? 220
 
   // Unique filter options
   const models = useMemo(
@@ -169,7 +174,7 @@ export default function LeaderboardView({
       className="space-y-6"
     >
       {/* ── Section Hint ── */}
-      <SectionHint tabId="leaderboard">{sectionHintTexts.leaderboard}</SectionHint>
+      <SectionHint tabId="leaderboard">{substituteTaskTotal(sectionHintTexts.leaderboard, effectiveTotalTasks)}</SectionHint>
 
       {/* ── Filter Bar ── */}
       <div className="flex flex-wrap items-center gap-3">
@@ -224,7 +229,7 @@ export default function LeaderboardView({
               <tr className="border-b border-dash-border">
                 <th className="px-4 py-3 text-left text-dash-text-muted font-semibold">Rank</th>
                 <th className="px-4 py-3 text-left text-dash-text-muted font-semibold">
-                  <span className="inline-flex items-center gap-1">Experiment <InfoTooltip content={tooltipTexts.leaderboard.experiment} position="bottom" /></span>
+                  <span className="inline-flex items-center gap-1">Experiment <InfoTooltip content={substituteTaskTotal(tooltipTexts.leaderboard.experiment, effectiveTotalTasks)} position="bottom" /></span>
                 </th>
                 <th className="px-4 py-3 text-left text-dash-text-muted font-semibold">
                   <span className="inline-flex items-center gap-1">Model <InfoTooltip content={tooltipTexts.leaderboard.model} position="bottom" /></span>
@@ -233,7 +238,7 @@ export default function LeaderboardView({
                   <span className="inline-flex items-center gap-1">Strategy <InfoTooltip content={tooltipTexts.leaderboard.strategy} position="bottom" /></span>
                 </th>
                 <th className="px-4 py-3 text-center text-dash-text-muted font-semibold">
-                  <span className="inline-flex items-center gap-1 justify-center">Progress <InfoTooltip content={tooltipTexts.leaderboard.progress} position="bottom" /></span>
+                  <span className="inline-flex items-center gap-1 justify-center">Progress <InfoTooltip content={substituteTaskTotal(tooltipTexts.leaderboard.progress, effectiveTotalTasks)} position="bottom" /></span>
                 </th>
                 <th className="px-4 py-3 text-right text-dash-text-muted font-semibold">
                   <span className="inline-flex items-center gap-1 justify-end">Success Rate <InfoTooltip content={tooltipTexts.leaderboard.successRate} position="bottom" /></span>

--- a/src/components/dashboard/TrendView.tsx
+++ b/src/components/dashboard/TrendView.tsx
@@ -95,6 +95,10 @@ export default function TrendView({ experiments }: TrendViewProps) {
     retries: exp.retried_count || 0,
   }))
 
+  const successRateDomain: [number, number] = chartData.length > 0
+    ? [Math.max(0, Math.floor(Math.min(...chartData.map((d) => d.successRate)) / 5) * 5 - 5), 100]
+    : [0, 100]
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 8 }}
@@ -114,7 +118,7 @@ export default function TrendView({ experiments }: TrendViewProps) {
             <LineChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 20 }}>
               <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
               <XAxis dataKey="name" tick={<ClickableAxisTick expMap={expMap} navigate={navigate} isDark={isDark} />} />
-              <YAxis tick={tickStyle} domain={[85, 100]} />
+              <YAxis tick={tickStyle} domain={successRateDomain} />
               <Tooltip {...chartTooltipStyle} />
               <Line
                 type="monotone"

--- a/src/data/tooltipTexts.ts
+++ b/src/data/tooltipTexts.ts
@@ -1,23 +1,25 @@
+export const TASK_TOTAL_PLACEHOLDER = '{TASK_TOTAL}'
+
 export const tooltipTexts = {
   kpi: {
     bestSuccessRate:
       'Highest task-completion rate among all experiments. A task is "successful" when the LLM\'s self-assessed QA check passes (pre-grading).',
     experiments:
-      'Total number of experiment runs. Each experiment tests a different prompt strategy or token configuration against the same 220 tasks.',
+      `Total number of experiment runs. Each experiment tests a different prompt strategy or token configuration against the same ${TASK_TOTAL_PLACEHOLDER} tasks.`,
     tasksEvaluated:
-      'Number of real-world professional tasks per experiment. Covers 11 industry sectors and 44 occupations from the GDPVal Gold Subset.',
+      'Number of real-world professional tasks per experiment. Covers 9 industry sectors and 44 occupations from the GDPVal Gold Subset.',
     bestQaScore:
       'Highest average Self-QA score (0–10) across experiments. The LLM inspects its own output after each task and scores it on completeness, accuracy, and format. This is a self-assessed quality measure, not an external grade.',
   },
   leaderboard: {
     experiment:
-      'Unique experiment identifier (e.g., exp003). Click a row to see all 220 task results.',
+      `Unique experiment identifier (e.g., exp003). Click a row to see all ${TASK_TOTAL_PLACEHOLDER} task results.`,
     model:
       'The LLM model used. Currently all experiments run on the same model for controlled comparison.',
     strategy:
       'Prompt strategy used for each experiment. Each experiment tests a different approach to task execution — strategies vary in prompting technique, reasoning steps, and token budget. See each row for the specific strategy applied.',
     progress:
-      'Fraction of tasks completed out of 220 total. Bar color matches the experiment\u2019s assigned color, not completion status.',
+      `Fraction of tasks completed out of ${TASK_TOTAL_PLACEHOLDER} total. Bar color matches the experiment\u2019s assigned color, not completion status.`,
     successRate:
       'Percentage of tasks that passed self-assessed QA. Higher is better. Color: ≥96% green, ≥90% amber, <90% red.',
     deltaBest:
@@ -54,7 +56,7 @@ export const tooltipTexts = {
 
 export const sectionHintTexts = {
   leaderboard:
-    'Each row is one experiment — same 220 real-world tasks, different prompt strategies. Click a row to drill into individual task results.',
+    `Each row is one experiment — same ${TASK_TOTAL_PLACEHOLDER} real-world tasks, different prompt strategies. Click a row to drill into individual task results.`,
   trend:
     'Track how success rates, QA scores, and error counts evolve across experiments. X-axis is ordered by experiment date.',
   errors:
@@ -68,11 +70,11 @@ export const aboutContent = {
   sections: [
     {
       heading: 'What is this?',
-      body: 'This dashboard visualizes results from GDPVal RealWorks — a benchmark that tests LLMs on 220 real-world professional tasks across 11 industry sectors and 44 occupations.',
+      body: `This dashboard visualizes results from GDPVal RealWorks — a benchmark that tests LLMs on ${TASK_TOTAL_PLACEHOLDER} real-world professional tasks across 9 industry sectors and 44 occupations.`,
     },
     {
       heading: 'How to read the data',
-      body: 'Each "experiment" runs the same 220 tasks with a different configuration (prompt strategy, token budget, etc.). Compare experiments on the Leaderboard tab, track progress in Trends, and investigate failures in Error Analysis.',
+      body: `Each "experiment" runs the same ${TASK_TOTAL_PLACEHOLDER} tasks with a different configuration (prompt strategy, token budget, etc.). Compare experiments on the Leaderboard tab, track progress in Trends, and investigate failures in Error Analysis.`,
     },
     {
       heading: 'Key Metrics',

--- a/src/lib/textFormat.ts
+++ b/src/lib/textFormat.ts
@@ -1,0 +1,11 @@
+import { TASK_TOTAL_PLACEHOLDER } from '../data/tooltipTexts'
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const PLACEHOLDER_PATTERN = new RegExp(escapeRegExp(TASK_TOTAL_PLACEHOLDER), 'g')
+
+export function substituteTaskTotal(text: string, total: number): string {
+  return text.replace(PLACEHOLDER_PATTERN, String(total))
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import { useReports } from '../hooks/useReports'
 import { useTheme } from '../contexts/ThemeContext'
 import { tooltipTexts } from '../data/tooltipTexts'
 import { onboarding } from '../utils/onboarding'
+import { substituteTaskTotal } from '../lib/textFormat'
 
 type TabKey = 'leaderboard' | 'trend' | 'errors' | 'grading'
 
@@ -84,6 +85,7 @@ export default function Dashboard() {
   // Calculate KPIs
   const bestRate = displayExperiments.length > 0 ? Math.max(...displayExperiments.map((e) => e.success_rate_pct)) : 0
   const bestQA = displayExperiments.length > 0 ? Math.max(...displayExperiments.map((e) => e.avg_qa_score)) : 0
+  const totalTasks = displayExperiments[0]?.total_tasks ?? 220
 
   const handleSelectExperiment = (shortId: string) => {
     navigate(`/experiments/${shortId}`)
@@ -167,7 +169,7 @@ export default function Dashboard() {
             {
               label: 'Best Success Rate',
               value: `${bestRate.toFixed(1)}%`,
-              unit: 'of 220 tasks',
+              unit: `of ${totalTasks} tasks`,
               tooltip: tooltipTexts.kpi.bestSuccessRate,
               valueColor: 'text-emerald-400',
               accentColor: '#10b981',
@@ -177,7 +179,7 @@ export default function Dashboard() {
               label: 'Experiments',
               value: displayExperiments.length,
               unit: 'total',
-              tooltip: tooltipTexts.kpi.experiments,
+              tooltip: substituteTaskTotal(tooltipTexts.kpi.experiments, totalTasks),
               valueColor: 'text-dash-heading',
               accentColor: '#3b82f6',
               tooltipDir: 'right' as const,
@@ -277,6 +279,7 @@ export default function Dashboard() {
                 experiments={displayExperiments}
                 sectorMatrix={sectorMatrix}
                 onSelectExperiment={handleSelectExperiment}
+                totalTasks={totalTasks}
               />
             )}
             {activeTab === 'trend' && <TrendView experiments={displayExperiments} />}
@@ -305,7 +308,7 @@ export default function Dashboard() {
       </motion.footer>
 
       {/* About Modal */}
-      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
+      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} totalTasks={totalTasks} />
     </motion.div>
   )
 }

--- a/tasks/TASK_NEEDS_FILES_V2_UI.md
+++ b/tasks/TASK_NEEDS_FILES_V2_UI.md
@@ -1,0 +1,71 @@
+# TASK_NEEDS_FILES_V2_UI — Dashboard Dynamic Denominators + Stale Labels
+
+> Policy V2 도입 시 stale 되는 `220` 매직넘버 7곳 + 보너스 발견 3건 fix.
+
+## Goal
+대시보드 UI 코드에서 task 분모 `220`을 runtime value 참조로 교체. stale label / chart clipping도 함께 fix.
+
+핵심 불변식:
+- 현재 표시 결과 동일 (default total_tasks=220에서 픽셀 단위 변화 0)
+- 분모 변경 시 7곳 모두 일관되게 따라옴
+- report_data.json 스키마는 안 건드림
+
+## Scope
+**수정**:
+- src/pages/Dashboard.tsx (L170)
+- src/data/tooltipTexts.ts (L6/14/20/57/71/75 + L8 sectors 자기모순)
+- src/components/dashboard/TrendView.tsx (L117 Y domain)
+- src/components/dashboard/LeaderboardView.tsx (L172/227/236 callsites + prop 받기)
+- src/components/common/InfoTooltip.tsx, SectionHint.tsx, AboutModal.tsx (totalTasks 받아서 substituteTaskTotal 적용)
+- 신규: src/lib/textFormat.ts (helper)
+
+**손대지 않을 곳**: README, types/report.ts, useReports.ts, aggregate-*.mjs, ExperimentDetail/ErrorAnalysisView (이미 runtime), batch-runner/
+
+## Design
+### Phase 1: Helper + placeholder
+src/data/tooltipTexts.ts 상단:
+```ts
+export const TASK_TOTAL_PLACEHOLDER = '{TASK_TOTAL}';
+```
+src/lib/textFormat.ts:
+```ts
+export function substituteTaskTotal(text: string, total: number): string {
+  return text.replaceAll(TASK_TOTAL_PLACEHOLDER, String(total));
+}
+```
+소비자(InfoTooltip/SectionHint/AboutModal)는 `totalTasks` prop 받아 helper 호출.
+
+### Phase 2: Dashboard.tsx:170
+```diff
+- unit: 'of 220 tasks'
++ unit: `of ${displayExperiments[0]?.total_tasks ?? 220} tasks`
+```
+
+### Phase 3: TrendView Y domain
+```diff
+- <YAxis domain={[85, 100]} ... />
++ <YAxis domain={[Math.max(0, Math.floor(Math.min(...data.map(d => d.success_rate))/5)*5 - 5), 100]} ... />
+```
+빈 데이터 가드 추가: `data.length > 0 ? ... : [0, 100]`.
+
+### Phase 4: tooltipTexts sectors
+L8, L71 모두 "11 industry sectors" → "9 industry sectors".
+
+### Phase 5: LeaderboardView prop drilling (REJECT 사유 반영)
+`LeaderboardView.tsx`에 `totalTasks?: number` prop 추가. Dashboard.tsx가 `<LeaderboardView totalTasks={displayExperiments[0]?.total_tasks ?? 220} ...>` 전달. LeaderboardView 내 callsite 3곳(L~172 SectionHint, L~227 InfoTooltip experiment, L~236 InfoTooltip progress)에서 `substituteTaskTotal(text, totalTasks ?? 220)` 적용.
+
+## Acceptance
+- 모든 7개 `220` 위치 runtime-bound (LeaderboardView 3개 포함)
+- substituteTaskTotal helper 사용
+- L8 + L71 "9 industry sectors" 통일
+- TrendView Y domain dynamic + 빈 데이터 가드
+- npm run build 통과
+- placeholder 토큰 dist 누출 0
+- LeaderboardView.tsx RGB 식 외 task-count 220 잔존 0
+- README/types/aggregator/batch-runner 무변경
+- secrets 0
+
+## Failure Policy
+- 시각 회귀 발견 → REJECT, helper 적용 누락 점검
+- placeholder 잔존 → REJECT, fallback 220 강제 적용 확인
+- first-reviewer REJECT 1회 재시도


### PR DESCRIPTION
Replace 7 hardcoded '220' magic numbers with runtime substitution via substituteTaskTotal helper. Full prop drilling to LeaderboardView. TrendView Success Rate Y-axis dynamic with empty-data guard. tooltipTexts.ts '9 industry sectors' consistency. Spec: tasks/TASK_NEEDS_FILES_V2_UI.md. Review: first-reviewer APPROVE.