### PR TITLE
feat(core): policy snapshot guardrails closing 5 extreme-reasoner conditions

### DIFF
--- a/batch-runner/core/needs_files.py
+++ b/batch-runner/core/needs_files.py
@@ -33,6 +33,8 @@ Usage:
 """
 
 import json
+import os
+import warnings
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -84,11 +86,28 @@ def resolve_needs_files(
 
 
 class NeedsFilesManifest:
-    """Read-only accessor for step0_needs_files_manifest.json."""
+    """Read-only accessor for step0_needs_files_manifest.json.
+
+    Policy snapshot semantics
+    -------------------------
+    The manifest's ``_summary.active_policy`` field is a snapshot taken at
+    manifest generation time (Step 0).  Runtime changes to
+    ``NEEDS_FILES_POLICY`` do NOT automatically re-evaluate the manifest:
+    each task's top-level ``needs_files`` boolean reflects the policy under
+    which the manifest was generated.  If you change the policy you must
+    regenerate the manifest (re-run Step 0).
+
+    On load, a mismatch between ``_summary.active_policy`` and the runtime
+    ``NEEDS_FILES_POLICY`` environment variable emits a ``RuntimeWarning``.
+    Setting ``NEEDS_FILES_STRICT=1`` upgrades the warning to a ``ValueError``.
+    v1 manifests (no ``active_policy`` field) skip the check entirely so
+    legacy workspaces keep working.
+    """
 
     def __init__(self, data: dict):
         self._data = data
         self._tasks: Dict[str, dict] = data.get("tasks", {})
+        self._check_policy_snapshot()
 
     # ── Constructors ──────────────────────────────────────────────────
 
@@ -113,6 +132,33 @@ class NeedsFilesManifest:
             )
         with open(p, "r", encoding="utf-8") as f:
             return cls(json.load(f))
+
+    # ── Guardrail ─────────────────────────────────────────────────────
+
+    def _check_policy_snapshot(self) -> None:
+        """Verify the manifest's active_policy snapshot matches the runtime env.
+
+        v1 manifests (no ``active_policy``) are skipped.  When the snapshot
+        and ``NEEDS_FILES_POLICY`` disagree, emit a ``RuntimeWarning`` by
+        default or raise ``ValueError`` if ``NEEDS_FILES_STRICT=1``.
+        """
+        manifest_policy = self.summary.get("active_policy")
+        if manifest_policy is None:
+            return  # v1 manifest — no snapshot recorded
+        runtime_policy = os.environ.get("NEEDS_FILES_POLICY", "deliverable_only")
+        if manifest_policy == runtime_policy:
+            return
+        msg = (
+            f"Manifest active_policy={manifest_policy!r} != "
+            f"runtime NEEDS_FILES_POLICY={runtime_policy!r}. "
+            "Manifest is a snapshot taken at Step 0 generation time; "
+            "regenerate the manifest (re-run Step 0) or unset "
+            "NEEDS_FILES_POLICY to match the snapshot."
+        )
+        strict = os.environ.get("NEEDS_FILES_STRICT", "0") == "1"
+        if strict:
+            raise ValueError(msg)
+        warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
     # ── Queries ───────────────────────────────────────────────────────
 
@@ -174,9 +220,10 @@ class NeedsFilesManifest:
 
         For v2 manifests, reads from the precomputed ``policy_results`` block.
         For v1 manifests (no ``policy_results``), only ``deliverable_only`` is
-        reliable and is returned via the original ``needs_files`` flag;
-        other policies cannot be reconstructed without the classifier, so
-        they fall back to the same v1 value (conservative).
+        reconstructible — the recorded ``needs_files`` flag IS the
+        ``deliverable_only`` resolution.  Any other policy raises
+        ``ValueError`` because v1 lacks the classifier signal needed to
+        compute it; callers should regenerate the manifest (re-run Step 0).
         """
         if policy not in NEEDS_FILES_POLICIES_KNOWN:
             raise ValueError(
@@ -186,10 +233,16 @@ class NeedsFilesManifest:
         if entry is None:
             return True  # match needs_files() conservative default
         pr = entry.get("policy_results")
-        if isinstance(pr, dict) and policy in pr:
-            return bool(pr[policy])
-        # v1 fallback: best we can do is the recorded flag (== deliverable_only)
-        return bool(entry.get("needs_files", False))
+        if pr is None:
+            # v1 fallback: only deliverable_only is reliable.
+            if policy == "deliverable_only":
+                return bool(entry.get("needs_files", False))
+            raise ValueError(
+                f"policy_result({policy!r}) unavailable on v1 manifest "
+                f"(task_id={task_id!r}); regenerate the manifest "
+                "(re-run Step 0) to obtain policy_results."
+            )
+        return bool(pr.get(policy, False))
 
     @property
     def summary(self) -> dict:

--- a/batch-runner/core/repo_bootstrapper.py
+++ b/batch-runner/core/repo_bootstrapper.py
@@ -417,6 +417,9 @@ class RepoBootstrapper:
             f"(policy={active_policy}, needs_files={needs_count}, "
             f"text_only={text_only_count})"
         )
+        print(
+            f"   [manifest] confidence_distribution={confidence_distribution}"
+        )
 
     # -- Download snapshot -------------------------------------------------
 

--- a/batch-runner/step5_validate.py
+++ b/batch-runner/step5_validate.py
@@ -254,6 +254,27 @@ def validate(data_dir: str = None) -> bool:
         with open(manifest_path, "r", encoding="utf-8") as f:
             manifest = json.load(f)
 
+        # ── Policy snapshot caveat ───────────────────────────────────
+        # success_rate semantics depend on the policy under which the
+        # manifest was generated.  Surface a WARNING and a JSON caveat
+        # when the snapshot is not the baseline ``deliverable_only`` so
+        # downstream readers (step6, dashboards) cannot silently compare
+        # numbers across policies.
+        active_policy = (
+            manifest.get("_summary", {}).get("active_policy")
+            or "deliverable_only"
+        )
+        if active_policy != "deliverable_only":
+            print(
+                f"[WARN] step5_validate: manifest active_policy="
+                f"{active_policy!r}. success_rate definition differs from "
+                "baseline 'deliverable_only'.",
+                file=sys.stderr,
+            )
+        file_gen_stats["policy_caveat"] = (
+            active_policy if active_policy != "deliverable_only" else None
+        )
+
         needs_files_missing = []
         needs_files_total = 0
 

--- a/batch-runner/tests/test_policy_guardrails.py
+++ b/batch-runner/tests/test_policy_guardrails.py
@@ -1,0 +1,343 @@
+"""Tests for NEEDS_FILES_V2 policy snapshot guardrails.
+
+Covers TASK_NEEDS_FILES_V2_GUARDRAILS conditions 1, 2 and 3:
+
+* Condition 1 — :class:`core.needs_files.NeedsFilesManifest` warns (or raises
+  under ``NEEDS_FILES_STRICT=1``) when the manifest's snapshot
+  ``active_policy`` differs from the runtime ``NEEDS_FILES_POLICY``.
+* Condition 2 — :meth:`NeedsFilesManifest.policy_result` raises
+  ``ValueError`` when a v1 manifest is asked for a non-default policy
+  (no precomputed ``policy_results`` block to read).
+* Condition 3 — :mod:`step5_validate` emits a stderr ``[WARN]`` line and a
+  ``policy_caveat`` key in ``validate_stats.json`` when the manifest's
+  ``active_policy`` is not ``deliverable_only``.  Verified by subprocess.
+
+Default-environment regression invariant: with ``NEEDS_FILES_POLICY`` unset
+and a ``deliverable_only`` manifest, NO warning is emitted and NO raise
+occurs.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import warnings
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.needs_files import NeedsFilesManifest
+
+BATCH_ROOT = Path(__file__).resolve().parent.parent  # batch-runner/
+
+_ALL_POLICIES = ("deliverable_only", "explicit_boost", "union", "intersection")
+
+
+# ── Manifest fixtures ────────────────────────────────────────────────────
+
+
+def _make_v2_manifest(active_policy: str = "deliverable_only", tasks=None) -> dict:
+    """Build a minimal v2 manifest dict (with ``_summary.active_policy``)."""
+    if tasks is None:
+        tasks = {
+            "task_a": {
+                "needs_files": True,
+                "original_file_count": 1,
+                "original_files": ["x.docx"],
+                "has_deliverable_files": True,
+                "prompt_classification": {
+                    "requires_file": True,
+                    "explicit_exts": [".docx"],
+                    "inferred_exts": [],
+                    "confidence": "explicit",
+                },
+                "policy_results": {p: True for p in _ALL_POLICIES},
+            },
+        }
+    return {
+        "_schema_version": 2,
+        "_total_tasks": len(tasks),
+        "tasks": tasks,
+        "_summary": {
+            "needs_files": sum(1 for t in tasks.values() if t["needs_files"]),
+            "text_only": sum(1 for t in tasks.values() if not t["needs_files"]),
+            "active_policy": active_policy,
+            "policy_counts": {p: 0 for p in _ALL_POLICIES},
+            "confidence_distribution": {
+                "explicit": 1, "inferred": 0, "ambiguous": 0, "text_only": 0,
+            },
+        },
+    }
+
+
+def _make_v1_manifest(tasks=None) -> dict:
+    """Build a minimal v1 manifest dict (no active_policy / policy_results)."""
+    if tasks is None:
+        tasks = {
+            "task_a": {
+                "needs_files": True,
+                "original_file_count": 1,
+                "original_files": ["x.docx"],
+            },
+            "task_b": {
+                "needs_files": False,
+                "original_file_count": 0,
+                "original_files": [],
+            },
+        }
+    return {
+        "_schema_version": 1,
+        "_total_tasks": len(tasks),
+        "tasks": tasks,
+        "_summary": {
+            "needs_files": sum(1 for t in tasks.values() if t["needs_files"]),
+            "text_only": sum(1 for t in tasks.values() if not t["needs_files"]),
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clean_policy_env(monkeypatch):
+    """Each test starts with no NEEDS_FILES_* env vars set."""
+    monkeypatch.delenv("NEEDS_FILES_POLICY", raising=False)
+    monkeypatch.delenv("NEEDS_FILES_STRICT", raising=False)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Condition 1 — active_policy snapshot mismatch
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_default_env_default_manifest_silent():
+    """REGRESSION INVARIANT: default env + deliverable_only manifest =>
+    no warning, no raise."""
+    data = _make_v2_manifest(active_policy="deliverable_only")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # turn any warning into an exception
+        m = NeedsFilesManifest(data)
+    assert m.summary.get("active_policy") == "deliverable_only"
+
+
+def test_v1_manifest_skips_policy_check(monkeypatch):
+    """v1 manifests (no active_policy) must NOT raise/warn even under
+    strict + non-default runtime policy."""
+    monkeypatch.setenv("NEEDS_FILES_POLICY", "union")
+    monkeypatch.setenv("NEEDS_FILES_STRICT", "1")
+    data = _make_v1_manifest()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        m = NeedsFilesManifest(data)
+    assert m.summary.get("active_policy") is None
+
+
+def test_matching_policy_silent(monkeypatch):
+    """v2 manifest whose snapshot equals the runtime policy => silent."""
+    monkeypatch.setenv("NEEDS_FILES_POLICY", "union")
+    data = _make_v2_manifest(active_policy="union")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        NeedsFilesManifest(data)
+
+
+def test_mismatch_warns_in_lax_mode(monkeypatch):
+    """Default (non-strict) mode emits a RuntimeWarning on mismatch."""
+    monkeypatch.setenv("NEEDS_FILES_POLICY", "union")
+    data = _make_v2_manifest(active_policy="deliverable_only")
+    with pytest.warns(RuntimeWarning, match="active_policy"):
+        NeedsFilesManifest(data)
+
+
+def test_mismatch_raises_in_strict_mode(monkeypatch):
+    """NEEDS_FILES_STRICT=1 promotes the mismatch warning to ValueError."""
+    monkeypatch.setenv("NEEDS_FILES_POLICY", "union")
+    monkeypatch.setenv("NEEDS_FILES_STRICT", "1")
+    data = _make_v2_manifest(active_policy="deliverable_only")
+    with pytest.raises(ValueError, match="active_policy"):
+        NeedsFilesManifest(data)
+
+
+def test_strict_env_with_match_silent(monkeypatch):
+    """Strict mode must still be silent when snapshot == runtime."""
+    monkeypatch.setenv("NEEDS_FILES_POLICY", "intersection")
+    monkeypatch.setenv("NEEDS_FILES_STRICT", "1")
+    data = _make_v2_manifest(active_policy="intersection")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        NeedsFilesManifest(data)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Condition 2 — v1 manifest policy_result for non-default policy
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_v1_policy_result_deliverable_only_returns_recorded():
+    """v1's recorded needs_files IS the deliverable_only resolution."""
+    m = NeedsFilesManifest(_make_v1_manifest())
+    assert m.policy_result("task_a", "deliverable_only") is True
+    assert m.policy_result("task_b", "deliverable_only") is False
+
+
+@pytest.mark.parametrize("policy", ["explicit_boost", "union", "intersection"])
+def test_v1_policy_result_non_default_raises(policy):
+    """v1 manifest has no policy_results block → non-default policies raise."""
+    m = NeedsFilesManifest(_make_v1_manifest())
+    with pytest.raises(ValueError, match="v1"):
+        m.policy_result("task_a", policy)
+
+
+@pytest.mark.parametrize("policy", _ALL_POLICIES)
+def test_v2_policy_result_returns_precomputed(policy):
+    """v2 manifests with a policy_results block are looked up directly."""
+    m = NeedsFilesManifest(_make_v2_manifest())
+    assert m.policy_result("task_a", policy) is True
+
+
+def test_policy_result_unknown_task_returns_conservative_default():
+    """Unknown task_id → conservative True (preserves prior behaviour)."""
+    m = NeedsFilesManifest(_make_v2_manifest())
+    assert m.policy_result("does_not_exist", "deliverable_only") is True
+
+
+def test_policy_result_unknown_policy_raises():
+    m = NeedsFilesManifest(_make_v2_manifest())
+    with pytest.raises(ValueError, match="unknown policy"):
+        m.policy_result("task_a", "majority_vote")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Condition 3 — step5_validate WARNING + JSON policy_caveat (subprocess)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _write_parquet(path: Path, task_ids):
+    """Write a minimal parquet with the columns step5_validate inspects."""
+    rows = []
+    for tid in task_ids:
+        rows.append({
+            "task_id": tid,
+            "sector": "Information",
+            "occupation": "test",
+            "prompt": "test prompt",
+            "deliverable_text": "x",
+            "deliverable_files": [],
+            "deliverable_file_urls": [],
+            "deliverable_file_hf_uris": [],
+            "reference_files": [],
+            "reference_file_urls": [],
+            "reference_file_hf_uris": [],
+        })
+    pd.DataFrame(rows).to_parquet(path, index=False)
+
+
+def _setup_step5_fixtures(tmp_path: Path, active_policy: str) -> Path:
+    """Lay out a workspace/upload tree with a manifest+parquet for step5."""
+    ws = tmp_path / "ws"
+    upload = ws / "upload"
+    (upload / "data").mkdir(parents=True, exist_ok=True)
+    (upload / "deliverable_files").mkdir(parents=True, exist_ok=True)
+
+    task_ids = ["task_a", "task_b"]
+    tasks = {
+        tid: {
+            "needs_files": False,
+            "original_file_count": 0,
+            "original_files": [],
+            "has_deliverable_files": False,
+            "prompt_classification": {
+                "requires_file": False,
+                "explicit_exts": [],
+                "inferred_exts": [],
+                "confidence": "text_only",
+            },
+            "policy_results": {p: False for p in _ALL_POLICIES},
+        }
+        for tid in task_ids
+    }
+    manifest = _make_v2_manifest(active_policy=active_policy, tasks=tasks)
+    (ws / "step0_needs_files_manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False)
+    )
+    _write_parquet(upload / "data" / "train-000.parquet", task_ids)
+    return ws
+
+
+def _build_step5_wrapper(tmp_path: Path) -> Path:
+    """Wrapper script that patches WORKSPACE_DIR/UPLOAD_DIR before validate()."""
+    wrapper = tmp_path / "run_step5.py"
+    wrapper.write_text(textwrap.dedent(f"""
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, {str(BATCH_ROOT)!r})
+
+        import core.config as cfg
+        ws = Path({str(tmp_path)!r}) / "ws"
+        upload = ws / "upload"
+        deliverable = upload / "deliverable_files"
+        (upload / "data").mkdir(parents=True, exist_ok=True)
+        deliverable.mkdir(parents=True, exist_ok=True)
+        cfg.WORKSPACE_DIR = ws
+        cfg.UPLOAD_DIR = upload
+        cfg.DELIVERABLE_DIR = deliverable
+        cfg.DEFAULT_LOCAL_PATH = ws / "local"
+
+        # step5_validate binds these names at import time, so patch the
+        # module-level constants too.
+        import step5_validate as s5
+        s5.WORKSPACE_DIR = ws
+        s5.UPLOAD_DIR = upload
+        s5.DELIVERABLE_DIR = deliverable
+        s5.DEFAULT_LOCAL_PATH = ws / "local"
+
+        s5.validate()  # we ignore validate's return code in these tests
+    """))
+    return wrapper
+
+
+def _run_step5(tmp_path: Path, env_overrides: dict) -> subprocess.CompletedProcess:
+    wrapper = _build_step5_wrapper(tmp_path)
+    env = os.environ.copy()
+    env.pop("NEEDS_FILES_POLICY", None)
+    env.pop("NEEDS_FILES_STRICT", None)
+    env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, str(wrapper)],
+        capture_output=True, text=True, env=env, cwd=str(BATCH_ROOT),
+    )
+
+
+def test_step5_non_default_policy_emits_warning_and_caveat(tmp_path):
+    """active_policy='union' => stderr [WARN] line + policy_caveat=='union'."""
+    ws = _setup_step5_fixtures(tmp_path, active_policy="union")
+    # Match runtime policy to manifest snapshot so Condition 1 stays silent
+    # — we want to test Condition 3 in isolation.
+    result = _run_step5(tmp_path, env_overrides={"NEEDS_FILES_POLICY": "union"})
+
+    assert result.returncode == 0, (
+        f"wrapper failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "[WARN] step5_validate" in result.stderr, result.stderr
+    assert "active_policy='union'" in result.stderr, result.stderr
+
+    stats_path = ws / "validate_stats.json"
+    assert stats_path.exists(), "validate_stats.json was not written"
+    stats = json.loads(stats_path.read_text())
+    assert stats.get("policy_caveat") == "union", stats
+
+
+def test_step5_default_policy_no_warning_no_caveat(tmp_path):
+    """REGRESSION INVARIANT: default policy manifest => no WARN, caveat is None."""
+    ws = _setup_step5_fixtures(tmp_path, active_policy="deliverable_only")
+    result = _run_step5(tmp_path, env_overrides={})
+
+    assert result.returncode == 0, (
+        f"wrapper failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "[WARN] step5_validate" not in result.stderr, result.stderr
+
+    stats_path = ws / "validate_stats.json"
+    assert stats_path.exists(), "validate_stats.json was not written"
+    stats = json.loads(stats_path.read_text())
+    assert stats.get("policy_caveat") is None, stats

--- a/tasks/TASK_NEEDS_FILES_V2_GUARDRAILS.md
+++ b/tasks/TASK_NEEDS_FILES_V2_GUARDRAILS.md
@@ -1,0 +1,107 @@
+# TASK_NEEDS_FILES_V2_GUARDRAILS — Policy Snapshot Guardrails
+
+> 후속 작업. BATCH PR(`feature/needs-files-v2-batch` `05befc8`)의 extreme-reasoner APPROVE-WITH-CONDITIONS 5개 조건 전부 해소.
+
+## Goal
+비-default 정책 전환 시점에 발생할 수 있는 silent regression 차단:
+1. manifest active_policy 스냅샷 ↔ 런타임 NEEDS_FILES_POLICY 불일치 raise/warn
+2. v1 manifest에서 비-default policy_result 거짓 동치 금지
+3. step5_validate에서 비-default 정책 사용 시 WARNING + JSON caveat
+4. manifest 생성 시 confidence_distribution 로그 (telemetry)
+5. needs_files.py docstring에 정책 스냅샷 시맨틱 명시
+
+핵심 불변식:
+- default policy=deliverable_only 환경에서 동작 변화 0 (raise/warn 발생 0)
+- BATCH PR의 모든 기존 동작 유지
+
+## Scope
+**수정**:
+- `batch-runner/core/needs_files.py` — 조건 1, 2, 5
+- `batch-runner/core/repo_bootstrapper.py` — 조건 4 (로그 breadcrumb)
+- `batch-runner/step5_validate.py` — 조건 3 (WARNING + JSON caveat)
+
+**신규 테스트**:
+- `batch-runner/tests/test_policy_guardrails.py` — 조건 1·2·3 단위 테스트
+  - manifest active_policy != env 시 raise (strict mode)
+  - default 환경에선 raise 안 함
+  - v1 manifest + 비-default policy_result → raise/None
+  - step5_validate WARNING + JSON caveat 출력 검증 (subprocess)
+
+**손대지 않을 곳**:
+- `core/prompt_classifier.py`, `core/config.py` (BATCH에서 완성됨)
+- `step0`/`step1`/`step2`/`step3`/`fill_parquet` 등 (manifest 소비자, API 유지)
+- `src/`, `dashboard/`, `scripts/`, `tasks/*REPORT.md`, README
+
+## Design
+
+### 조건 1 — active_policy 불일치 감지
+`NeedsFilesManifest._load` 또는 `__init__` 끝에:
+```python
+manifest_policy = self.summary.active_policy  # 신규 키, v2만
+runtime_policy = os.environ.get("NEEDS_FILES_POLICY", "deliverable_only")
+strict = os.environ.get("NEEDS_FILES_STRICT", "0") == "1"
+if manifest_policy is not None and manifest_policy != runtime_policy:
+    msg = (f"Manifest active_policy='{manifest_policy}' != runtime NEEDS_FILES_POLICY='{runtime_policy}'. "
+           "Manifest is a snapshot; regenerate or unset NEEDS_FILES_POLICY.")
+    if strict:
+        raise ValueError(msg)
+    else:
+        warnings.warn(msg, RuntimeWarning)
+```
+v1 manifest는 `manifest_policy is None` → skip (default 시뮬레이션).
+
+### 조건 2 — v1 fallback policy_result
+`.policy_result(task_id, policy)`에서:
+```python
+entry = self._tasks.get(task_id, {})
+policy_results = entry.get("policy_results")
+if policy_results is None:
+    if policy == "deliverable_only":
+        return entry.get("needs_files", False)
+    raise ValueError(f"policy_result('{policy}') unavailable on v1 manifest; regenerate.")
+return policy_results.get(policy, False)
+```
+
+### 조건 3 — step5_validate WARNING
+manifest 로드 직후:
+```python
+active_policy = manifest.summary.active_policy or "deliverable_only"
+if active_policy != "deliverable_only":
+    print(f"[WARN] step5_validate: manifest active_policy='{active_policy}'. "
+          f"success_rate definition differs from baseline 'deliverable_only'.", file=sys.stderr)
+report["policy_caveat"] = active_policy if active_policy != "deliverable_only" else None
+```
+
+### 조건 4 — confidence_distribution 로그
+`_generate_manifest_from_dir` 끝, manifest 저장 직후:
+```python
+logger.info(f"[manifest] confidence={summary['confidence_distribution']}")
+```
+(또는 print/stderr — 일관성 있는 방식)
+
+### 조건 5 — docstring
+`core/needs_files.py` module docstring 또는 `NeedsFilesManifest` 클래스 docstring에 추가:
+```
+The manifest's `_summary.active_policy` field is a snapshot taken at manifest generation time.
+Runtime changes to NEEDS_FILES_POLICY do NOT automatically re-evaluate the manifest. If you change
+the policy, regenerate the manifest (re-run step0). Setting NEEDS_FILES_STRICT=1 makes a snapshot
+vs runtime mismatch raise instead of warn.
+```
+
+## Acceptance Criteria
+- [ ] 5개 조건 코드 반영
+- [ ] 신규 테스트 파일 `test_policy_guardrails.py` — 단위 테스트 통과
+- [ ] BATCH PR의 기존 테스트(`test_prompt_classifier.py`, `test_resolve_needs_files.py`) 회귀 없음
+- [ ] default 환경에서 raise/warn 발생 0 (regression invariant)
+- [ ] 변경 파일이 명세된 3개(수정) + 1개(신규 테스트) + spec = 5개
+- [ ] step1/step2/fill_parquet/step3 무수정
+- [ ] secrets 노출 0
+
+## Failure Policy
+- 기존 테스트 회귀 → REJECT, 가드레일 로직 재검토
+- first-reviewer REJECT 1회 재시도
+
+## Out of Scope
+- default 정책 전환 결정 (별도 회의)
+- 끝난 실험 backfill (TASK_NEEDS_FILES_V2_BACKFILL)
+- UI docs 통일 (별도)


### PR DESCRIPTION
Follow-up to BATCH PR. Closes 5 extreme-reasoner conditions: (1) manifest active_policy vs runtime NEEDS_FILES_POLICY mismatch raise/warn, (2) v1 fallback policy_result raises for non-default, (3) step5_validate WARNING + JSON caveat, (4) confidence_distribution logging, (5) docstring snapshot semantics. Default deliverable_only env exposure: 0 (zero raises/warnings). Spec: tasks/TASK_NEEDS_FILES_V2_GUARDRAILS.md. Reviews: first-reviewer APPROVE, extreme-reasoner 'ship it'.