### PR TITLE
feat(dashboard): surface v2 manifest fields (Policy Comparison + Confidence Distribution)

### DIFF
--- a/src/pages/ExperimentDetail.tsx
+++ b/src/pages/ExperimentDetail.tsx
@@ -8,6 +8,7 @@ import {
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
   ResponsiveContainer, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar,
+  PieChart, Pie, Cell, Legend,
 } from 'recharts'
 import { useReport, HF_BASE } from '../hooks/useReports'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -358,6 +359,160 @@ function ExperimentDetail() {
             </motion.div>
           )}
         </div>
+
+        {/* ── v2: Policy Comparison & Confidence Distribution ── */}
+        {(summary?.policy_counts || summary?.confidence_distribution) && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+            {/* Policy Comparison */}
+            {summary?.policy_counts && Object.keys(summary.policy_counts).length > 0 && (
+              <motion.div
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, delay: 0.13 }}
+                className="bg-dash-card border border-dash-border rounded-xl p-4"
+              >
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-sm font-semibold text-dash-heading">Policy Comparison</h3>
+                  {summary.active_policy && (
+                    <span
+                      className="text-[10px] font-mono px-2 py-0.5 rounded bg-dash-card-hover text-dash-text-secondary"
+                      title="Currently active policy"
+                    >
+                      active: <span className="text-emerald-400">{summary.active_policy}</span>
+                    </span>
+                  )}
+                </div>
+                <ResponsiveContainer width="100%" height={200}>
+                  <BarChart
+                    data={Object.entries(summary.policy_counts).map(([policy, count]) => ({
+                      policy,
+                      count: count ?? 0,
+                      isActive: policy === summary.active_policy,
+                    }))}
+                    margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
+                    <XAxis dataKey="policy" tick={{ ...tickStyle, fontSize: 10 }} />
+                    <YAxis tick={tickStyle} allowDecimals={false} />
+                    <Tooltip contentStyle={chartTooltipStyle} />
+                    <Bar dataKey="count" name="needs_files">
+                      {Object.entries(summary.policy_counts).map(([policy], i) => (
+                        <Cell
+                          key={i}
+                          fill={policy === summary.active_policy ? '#10b981' : '#6366f1'}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+                <table className="w-full text-xs mt-2">
+                  <thead>
+                    <tr className="text-[10px] text-dash-text-muted uppercase border-b border-dash-border">
+                      <th className="py-1.5 text-left">Policy</th>
+                      <th className="py-1.5 text-right">needs_files</th>
+                      <th className="py-1.5 text-right">Δ vs active</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(summary.policy_counts).map(([policy, count]) => {
+                      const active = summary.active_policy
+                      const activeCount = active && summary.policy_counts ? summary.policy_counts[active] ?? null : null
+                      const delta = activeCount != null && count != null ? count - activeCount : null
+                      const isActive = policy === active
+                      return (
+                        <tr key={policy} className="border-b border-dash-border-subtle last:border-0">
+                          <td className="py-1.5 text-dash-text font-mono">
+                            {policy}
+                            {isActive && (
+                              <span className="ml-1.5 text-[9px] text-emerald-400">●</span>
+                            )}
+                          </td>
+                          <td className="py-1.5 text-right text-dash-text-secondary font-mono">{count ?? 0}</td>
+                          <td className="py-1.5 text-right font-mono text-dash-text-muted">
+                            {delta == null || isActive ? '—' : delta > 0 ? `+${delta}` : `${delta}`}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </motion.div>
+            )}
+
+            {/* Confidence Distribution */}
+            {summary?.confidence_distribution && Object.keys(summary.confidence_distribution).length > 0 && (
+              <motion.div
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, delay: 0.14 }}
+                className="bg-dash-card border border-dash-border rounded-xl p-4"
+              >
+                <h3 className="text-sm font-semibold text-dash-heading mb-3">Confidence Distribution</h3>
+                {(() => {
+                  const CONFIDENCE_COLORS: Record<string, string> = {
+                    explicit: '#10b981',
+                    inferred: '#6366f1',
+                    ambiguous: '#f59e0b',
+                    text_only: '#6b7280',
+                  }
+                  const entries = Object.entries(summary.confidence_distribution!).map(([k, v]) => ({
+                    name: k,
+                    value: v ?? 0,
+                  }))
+                  const total = entries.reduce((s, e) => s + (e.value || 0), 0)
+                  return (
+                    <>
+                      <ResponsiveContainer width="100%" height={200}>
+                        <PieChart>
+                          <Pie
+                            data={entries}
+                            dataKey="value"
+                            nameKey="name"
+                            cx="50%"
+                            cy="50%"
+                            outerRadius={70}
+                            innerRadius={40}
+                            paddingAngle={2}
+                            label={(entry: { value?: number }) => (entry.value ? String(entry.value) : '')}
+                          >
+                            {entries.map((entry, i) => (
+                              <Cell key={i} fill={CONFIDENCE_COLORS[entry.name] ?? '#9ca3af'} />
+                            ))}
+                          </Pie>
+                          <Tooltip contentStyle={chartTooltipStyle} />
+                          <Legend
+                            verticalAlign="bottom"
+                            iconSize={8}
+                            wrapperStyle={{ fontSize: 10, color: isDark ? '#e5e7eb' : '#374151' }}
+                          />
+                        </PieChart>
+                      </ResponsiveContainer>
+                      <div className="grid grid-cols-2 gap-2 mt-2 text-xs">
+                        {entries.map((e) => {
+                          const pct = total > 0 ? ((e.value / total) * 100).toFixed(1) : '0.0'
+                          return (
+                            <div key={e.name} className="flex items-center justify-between py-1 border-b border-dash-border-subtle last:border-0">
+                              <span className="flex items-center gap-1.5 text-dash-text-secondary">
+                                <span
+                                  className="inline-block w-2 h-2 rounded-full"
+                                  style={{ background: CONFIDENCE_COLORS[e.name] ?? '#9ca3af' }}
+                                />
+                                <span className="font-mono">{e.name}</span>
+                              </span>
+                              <span className="font-mono text-dash-text">
+                                {e.value} <span className="text-dash-text-muted">({pct}%)</span>
+                              </span>
+                            </div>
+                          )
+                        })}
+                      </div>
+                    </>
+                  )
+                })()}
+              </motion.div>
+            )}
+          </div>
+        )}
 
         {/* Charts */}
         <motion.div

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -24,6 +24,17 @@ export interface TaskResult {
   instruction?: string
   reference_file_urls?: string[]
   deliverable_files?: string[]
+  // v2 manifest fields (optional — v1 self_reports do not include these)
+  prompt_classification?: PromptClassification | null
+  policy_results?: Record<string, boolean> | null
+  has_deliverable_files?: boolean | null
+}
+
+export interface PromptClassification {
+  requires_file: boolean
+  explicit_exts: string[]
+  inferred_exts: string[]
+  confidence: 'explicit' | 'inferred' | 'ambiguous' | 'text_only'
 }
 
 export interface SectorBreakdown {
@@ -79,6 +90,10 @@ export interface ReportSummary {
   avg_latency_ms: number
   max_latency_ms: number
   total_latency_ms: number
+  // v2 manifest fields (optional — v1 self_reports do not include these)
+  active_policy?: string | null
+  policy_counts?: Record<string, number> | null
+  confidence_distribution?: Record<string, number> | null
 }
 
 export interface Narrative {

--- a/tasks/TASK_DASHBOARD_V2_FIELDS.md
+++ b/tasks/TASK_DASHBOARD_V2_FIELDS.md
@@ -1,0 +1,93 @@
+# TASK_DASHBOARD_V2_FIELDS — Dashboard surfaces v2 manifest fields
+
+A1(step6 v2 확장)의 sister PR. self_report.json에 v2 필드가 추가됐을 때 대시보드가 그것을 읽고 표시. v1 self_report(필드 없음)에서도 graceful fallback.
+
+## Goal
+다음 v2 필드를 대시보드 UI에 노출:
+- 각 task의 `prompt_classification` (requires_file / explicit_exts / inferred_exts / confidence)
+- 각 task의 `policy_results` (4 policies)
+- 각 task의 `has_deliverable_files`
+- summary 레벨: `active_policy`, `policy_counts`, `confidence_distribution`
+
+핵심 불변식:
+- v1 self_report(필드 없음)에서 정상 렌더 (에러 0, fallback graceful)
+- v2 필드가 있을 때만 새 UI surface 표시
+- 기존 UI 요소(KPI cards, Leaderboard, Heatmap 등) 픽셀 단위 변화 0 (v2 필드 없는 상태에서)
+
+## Scope
+**수정/신규**:
+- `src/types/report.ts` — v2 필드 타입 추가 (모두 optional)
+- `scripts/aggregate-reports.mjs` — 신규 필드 pass-through (필요 시)
+- 신규 컴포넌트 또는 기존 컴포넌트 확장:
+  - `ExperimentDetail` 페이지에 "Policy Comparison" 섹션 — 4 정책별 needs_files count 비교
+  - "Confidence Distribution" mini-chart — explicit/inferred/ambiguous/text_only 분포
+  - task table에 `confidence` 컬럼 또는 badge (옵션, coder 판단)
+
+**손대지 않을 곳**:
+- `batch-runner/` (A1이 처리)
+- 기존 KPI cards / Leaderboard / Heatmap 동작 (회귀 0)
+
+## Design
+
+### 1. types/report.ts
+optional 필드 추가:
+```ts
+export interface TaskResult {
+  // ... existing fields
+  prompt_classification?: PromptClassification | null;
+  policy_results?: Record<string, boolean> | null;
+  has_deliverable_files?: boolean | null;
+}
+
+export interface PromptClassification {
+  requires_file: boolean;
+  explicit_exts: string[];
+  inferred_exts: string[];
+  confidence: "explicit" | "inferred" | "ambiguous" | "text_only";
+}
+
+export interface ReportSummary {
+  // ... existing
+  active_policy?: string | null;
+  policy_counts?: Record<string, number> | null;
+  confidence_distribution?: Record<string, number> | null;
+}
+```
+
+### 2. ExperimentDetail Policy Comparison 섹션
+`src/pages/ExperimentDetail.tsx`에서 `summary.policy_counts`가 있으면 표시:
+```tsx
+{summary.policy_counts && (
+  <Card>
+    <CardHeader>Policy Comparison</CardHeader>
+    <CardContent>
+      Table or bar chart: 4 policies × count + delta from active_policy
+    </CardContent>
+  </Card>
+)}
+```
+
+### 3. Confidence Distribution
+`summary.confidence_distribution`가 있으면 stacked bar 또는 pie chart로 분포 표시.
+
+### 4. aggregate-reports.mjs
+신규 필드를 reports-index에 포함 (필요 시). v1 데이터는 필드 없이 통과.
+
+## Acceptance
+- types/report.ts 신규 optional 필드 추가
+- v1 self_report에서 정상 렌더 (Console 에러 0, 신규 섹션은 conditional 미표시)
+- v2 self_report에서 신규 섹션(Policy Comparison + Confidence Distribution) 표시
+- `npm run build` 통과
+- 기존 KPI/Leaderboard/Heatmap 시각 회귀 0 (v1 fixture로 확인)
+- 변경 파일: types/report.ts + ExperimentDetail.tsx + (optional) aggregate-reports.mjs + 신규 컴포넌트 + spec = 5~6개 예상
+- secrets 0
+
+## Failure Policy
+- v1 fallback에서 렌더 에러 → REJECT, optional chaining 점검
+- npm build fail → REJECT
+- first-reviewer REJECT 1회 재시도
+
+## Out of Scope
+- step6 확장 (A1)
+- 과거 실험 backfill (A3, A1+A2 머지 후)
+- HF 업로드/다운로드 흐름


### PR DESCRIPTION
Sister PR to A1. Adds optional v2 fields to types/report.ts and renders Policy Comparison + Confidence Distribution sections in ExperimentDetail when self_report contains them. Graceful v1 fallback: v1 self_reports render without errors and the new sections are hidden. Spec: tasks/TASK_DASHBOARD_V2_FIELDS.md.