### PR TITLE
feat(step6): include v2 manifest fields in self_report.json

### DIFF
--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -31,13 +31,53 @@ from typing import Any
 _SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPT_DIR))
 
-from core.config import WORKSPACE_DIR
+from core.config import NEEDS_FILES_POLICIES_KNOWN, WORKSPACE_DIR
 
 
 # ── Defaults ──────────────────────────────────────────────────────────────
 
 DEFAULT_RESULT_JSON = WORKSPACE_DIR / "result.json"
 DEFAULT_OUTPUT_DIR = WORKSPACE_DIR / "report"
+
+
+# ── V2 manifest helpers ───────────────────────────────────────────────────
+
+
+def _load_manifest_safe():
+    """Load the needs_files manifest if available; return None on any failure.
+
+    Step 6 must keep working even when Step 0 has not been run (no manifest)
+    or when the manifest is malformed.  Callers should treat ``None`` as
+    "v2 fields unavailable" and fall back to the v1 schema (no new keys).
+    """
+    try:
+        from core.needs_files import NeedsFilesManifest
+        return NeedsFilesManifest.load()
+    except Exception:
+        return None
+
+
+def _manifest_v2_available(manifest) -> bool:
+    """True iff the manifest is a v2 manifest (has ``_summary.active_policy``).
+
+    v1 manifests omit ``active_policy``; in that case we must NOT add any v2
+    fields to the report so downstream consumers see exactly the v1 schema.
+    """
+    if manifest is None:
+        return False
+    return manifest.summary.get("active_policy") is not None
+
+
+def _v2_summary_fields(manifest) -> dict:
+    """Return the v2 summary fields from a manifest, or ``{}`` if v1/None."""
+    if not _manifest_v2_available(manifest):
+        return {}
+    s = manifest.summary
+    return {
+        "active_policy": s.get("active_policy"),
+        "policy_counts": s.get("policy_counts"),
+        "confidence_distribution": s.get("confidence_distribution"),
+    }
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────
@@ -108,11 +148,12 @@ def _compute_sector_breakdown(data: dict) -> list[dict]:
     return breakdown
 
 
-def _build_task_results(data: dict) -> tuple[list[dict], list[dict]]:
+def _build_task_results(data: dict, manifest=None) -> tuple[list[dict], list[dict]]:
     task_results = []
     error_tasks = []
+    is_v2 = _manifest_v2_available(manifest)
     for r in data.get("results", []):
-        task_results.append({
+        entry = {
             "task_id": r.get("task_id", ""),
             "sector": r.get("sector", ""),
             "occupation": r.get("occupation", ""),
@@ -129,7 +170,16 @@ def _build_task_results(data: dict) -> tuple[list[dict], list[dict]]:
             "instruction": (r.get("instruction") or "")[:2000],
             "reference_file_urls": r.get("reference_file_urls", []),
             "deliverable_files": r.get("deliverable_files", []),
-        })
+        }
+        if is_v2:
+            task_id = r.get("task_id", "")
+            entry["prompt_classification"] = manifest.prompt_classification(task_id)
+            entry["policy_results"] = {
+                p: manifest.policy_result(task_id, p)
+                for p in NEEDS_FILES_POLICIES_KNOWN
+            }
+            entry["has_deliverable_files"] = manifest.has_deliverable_files(task_id)
+        task_results.append(entry)
         if r.get("error"):
             error_tasks.append({
                 "task_id": r.get("task_id", ""),
@@ -927,7 +977,8 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
     # Compute metrics
     summary = _compute_summary(data)
     sector_breakdown = _compute_sector_breakdown(data)
-    task_results, error_tasks = _build_task_results(data)
+    manifest = _load_manifest_safe()
+    task_results, error_tasks = _build_task_results(data, manifest=manifest)
 
     # Generate narrative
     if no_narrative:
@@ -975,6 +1026,11 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
         "dummy_files_created": None,
         "dummy_task_ids": [],
     }
+
+    # V2 manifest summary fields (append-only; absent for v1 / missing manifest)
+    v2_fields = _v2_summary_fields(manifest)
+    if v2_fields:
+        rd["file_generation"].update(v2_fields)
 
     # Inject recovery stats — read from step2_inference_results.json (has reflection_history)
     inference_results_path = WORKSPACE_DIR / "step2_inference_results.json"

--- a/batch-runner/tests/test_step6_v2_fields.py
+++ b/batch-runner/tests/test_step6_v2_fields.py
@@ -1,0 +1,470 @@
+"""Tests for STEP6_V2_FIELDS — v2 manifest fields surface in self_report.json.
+
+Covers:
+
+* When the workspace manifest is **v2** (has ``_summary.active_policy``),
+  ``step6_report._build_task_results`` adds ``prompt_classification``,
+  ``policy_results`` (all 4 policies) and ``has_deliverable_files`` to every
+  task entry, and ``_v2_summary_fields`` exposes ``active_policy``,
+  ``policy_counts`` and ``confidence_distribution`` for injection into the
+  ``file_generation`` block.
+* When the manifest is **v1** (no ``active_policy``) — or absent —
+  none of the new keys appear in any task entry, the v2 summary dict is
+  empty, and existing v1 fields keep their values unchanged.
+* The end-to-end ``generate_report`` flow writes ``report_data.json`` with
+  the v2 fields present (v2 case) / absent (v1 case), and the summary,
+  sector_breakdown and existing task_results counts/keys are unchanged
+  across both branches.
+"""
+
+import json
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+# Add parent directory to path for ``step6_report`` and ``core`` imports.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import step6_report
+from core.needs_files import NeedsFilesManifest
+
+_ALL_POLICIES = ("deliverable_only", "explicit_boost", "union", "intersection")
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clean_policy_env(monkeypatch):
+    """Each test starts with no NEEDS_FILES_* env vars set so the manifest's
+    snapshot policy never disagrees with the runtime default."""
+    monkeypatch.delenv("NEEDS_FILES_POLICY", raising=False)
+    monkeypatch.delenv("NEEDS_FILES_STRICT", raising=False)
+
+
+def _make_v2_manifest_data() -> dict:
+    """Two-task v2 manifest covering the on/off axis for each v2 field."""
+    return {
+        "_schema_version": 2,
+        "_total_tasks": 2,
+        "tasks": {
+            "task_a": {
+                "needs_files": True,
+                "original_file_count": 1,
+                "original_files": ["x.docx"],
+                "has_deliverable_files": True,
+                "prompt_classification": {
+                    "requires_file": True,
+                    "explicit_exts": [".docx"],
+                    "inferred_exts": [],
+                    "confidence": "explicit",
+                },
+                "policy_results": {
+                    "deliverable_only": True,
+                    "explicit_boost": True,
+                    "union": True,
+                    "intersection": True,
+                },
+            },
+            "task_b": {
+                "needs_files": False,
+                "original_file_count": 0,
+                "original_files": [],
+                "has_deliverable_files": False,
+                "prompt_classification": {
+                    "requires_file": False,
+                    "explicit_exts": [],
+                    "inferred_exts": [],
+                    "confidence": "text_only",
+                },
+                "policy_results": {
+                    "deliverable_only": False,
+                    "explicit_boost": False,
+                    "union": False,
+                    "intersection": False,
+                },
+            },
+        },
+        "_summary": {
+            "needs_files": 1,
+            "text_only": 1,
+            "active_policy": "deliverable_only",
+            "policy_counts": {
+                "deliverable_only": 1,
+                "explicit_boost": 1,
+                "union": 1,
+                "intersection": 1,
+            },
+            "confidence_distribution": {
+                "explicit": 1,
+                "inferred": 0,
+                "ambiguous": 0,
+                "text_only": 1,
+            },
+        },
+    }
+
+
+def _make_v1_manifest_data() -> dict:
+    """Two-task v1 manifest (no ``active_policy`` / ``policy_results``)."""
+    return {
+        "_schema_version": 1,
+        "_total_tasks": 2,
+        "tasks": {
+            "task_a": {
+                "needs_files": True,
+                "original_file_count": 1,
+                "original_files": ["x.docx"],
+            },
+            "task_b": {
+                "needs_files": False,
+                "original_file_count": 0,
+                "original_files": [],
+            },
+        },
+        "_summary": {
+            "needs_files": 1,
+            "text_only": 1,
+        },
+    }
+
+
+def _make_result_payload() -> dict:
+    """Minimal step3 ``result.json`` shape with two tasks matching the fixtures."""
+    return {
+        "experiment_id": "exp_test",
+        "experiment_name": "v2-fields-test",
+        "condition_name": "default",
+        "model": "test-model",
+        "execution_mode": "test",
+        "started_at": "2026-05-17T00:00:00Z",
+        "duration": "0s",
+        "results": [
+            {
+                "task_id": "task_a",
+                "sector": "Tech",
+                "occupation": "Engineer",
+                "status": "success",
+                "retried": False,
+                "deliverable_files": ["out.docx"],
+                "deliverable_files_count": 1,
+                "qa_score": 8,
+                "qa_passed": True,
+                "qa_issues": [],
+                "qa_suggestion": "",
+                "latency_ms": 1234,
+                "deliverable_text": "ok",
+                "instruction": "do the thing",
+                "reference_file_urls": [],
+            },
+            {
+                "task_id": "task_b",
+                "sector": "Tech",
+                "occupation": "Analyst",
+                "status": "success",
+                "retried": False,
+                "deliverable_files": [],
+                "deliverable_files_count": 0,
+                "qa_score": 9,
+                "qa_passed": True,
+                "qa_issues": [],
+                "qa_suggestion": "",
+                "latency_ms": 567,
+                "deliverable_text": "ok",
+                "instruction": "answer the question",
+                "reference_file_urls": [],
+            },
+        ],
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _manifest_v2_available / _v2_summary_fields
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_manifest_v2_available_true_for_v2():
+    manifest = NeedsFilesManifest(_make_v2_manifest_data())
+    assert step6_report._manifest_v2_available(manifest) is True
+
+
+def test_manifest_v2_available_false_for_v1():
+    manifest = NeedsFilesManifest(_make_v1_manifest_data())
+    assert step6_report._manifest_v2_available(manifest) is False
+
+
+def test_manifest_v2_available_false_for_none():
+    assert step6_report._manifest_v2_available(None) is False
+
+
+def test_v2_summary_fields_v2_returns_all_three_keys():
+    manifest = NeedsFilesManifest(_make_v2_manifest_data())
+    fields = step6_report._v2_summary_fields(manifest)
+    assert set(fields.keys()) == {
+        "active_policy",
+        "policy_counts",
+        "confidence_distribution",
+    }
+    assert fields["active_policy"] == "deliverable_only"
+    assert fields["policy_counts"] == {
+        "deliverable_only": 1,
+        "explicit_boost": 1,
+        "union": 1,
+        "intersection": 1,
+    }
+    assert fields["confidence_distribution"] == {
+        "explicit": 1,
+        "inferred": 0,
+        "ambiguous": 0,
+        "text_only": 1,
+    }
+
+
+def test_v2_summary_fields_v1_returns_empty():
+    manifest = NeedsFilesManifest(_make_v1_manifest_data())
+    assert step6_report._v2_summary_fields(manifest) == {}
+
+
+def test_v2_summary_fields_none_manifest_returns_empty():
+    assert step6_report._v2_summary_fields(None) == {}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _build_task_results with v2 manifest
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_build_task_results_v2_adds_per_task_fields():
+    manifest = NeedsFilesManifest(_make_v2_manifest_data())
+    data = _make_result_payload()
+    task_results, error_tasks = step6_report._build_task_results(
+        data, manifest=manifest
+    )
+
+    assert len(task_results) == 2
+    assert error_tasks == []
+
+    by_id = {t["task_id"]: t for t in task_results}
+
+    # task_a: has deliverable, explicit confidence, all 4 policies True
+    a = by_id["task_a"]
+    assert a["has_deliverable_files"] is True
+    assert a["prompt_classification"] == {
+        "requires_file": True,
+        "explicit_exts": [".docx"],
+        "inferred_exts": [],
+        "confidence": "explicit",
+    }
+    assert a["policy_results"] == {
+        "deliverable_only": True,
+        "explicit_boost": True,
+        "union": True,
+        "intersection": True,
+    }
+    assert set(a["policy_results"].keys()) == set(_ALL_POLICIES)
+
+    # task_b: no deliverable, text_only, all 4 policies False
+    b = by_id["task_b"]
+    assert b["has_deliverable_files"] is False
+    assert b["prompt_classification"] == {
+        "requires_file": False,
+        "explicit_exts": [],
+        "inferred_exts": [],
+        "confidence": "text_only",
+    }
+    assert b["policy_results"] == {
+        "deliverable_only": False,
+        "explicit_boost": False,
+        "union": False,
+        "intersection": False,
+    }
+
+
+def test_build_task_results_v2_preserves_existing_fields():
+    """The append-only invariant: v2 must not change any v1 field value."""
+    data = _make_result_payload()
+    manifest = NeedsFilesManifest(_make_v2_manifest_data())
+
+    v1_results, _ = step6_report._build_task_results(data, manifest=None)
+    v2_results, _ = step6_report._build_task_results(data, manifest=manifest)
+
+    assert len(v1_results) == len(v2_results)
+    v1_keys = {"prompt_classification", "policy_results", "has_deliverable_files"}
+    for v1, v2 in zip(v1_results, v2_results):
+        # Every v1 key/value MUST be preserved verbatim.
+        for k, expected in v1.items():
+            assert v2[k] == expected, f"v2 changed v1 key {k!r}"
+        # The only difference between branches: appended v2 keys.
+        added = set(v2.keys()) - set(v1.keys())
+        assert added == v1_keys
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _build_task_results with v1 manifest (and with no manifest) — backward-compat
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_build_task_results_v1_omits_v2_fields():
+    manifest = NeedsFilesManifest(_make_v1_manifest_data())
+    data = _make_result_payload()
+    task_results, _ = step6_report._build_task_results(data, manifest=manifest)
+
+    for entry in task_results:
+        assert "prompt_classification" not in entry
+        assert "policy_results" not in entry
+        assert "has_deliverable_files" not in entry
+
+
+def test_build_task_results_no_manifest_omits_v2_fields():
+    data = _make_result_payload()
+    task_results, _ = step6_report._build_task_results(data, manifest=None)
+
+    for entry in task_results:
+        assert "prompt_classification" not in entry
+        assert "policy_results" not in entry
+        assert "has_deliverable_files" not in entry
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# generate_report end-to-end: v2 fields land in report_data.json
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _write_workspace(tmp_path: Path, manifest_data: dict | None) -> tuple[Path, Path]:
+    """Lay out a minimal workspace and return (result_json, output_dir)."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    result_payload = _make_result_payload()
+    result_json = tmp_path / "result.json"
+    result_json.write_text(json.dumps(result_payload), encoding="utf-8")
+
+    output_dir = tmp_path / "report"
+    output_dir.mkdir()
+
+    if manifest_data is not None:
+        (tmp_path / "step0_needs_files_manifest.json").write_text(
+            json.dumps(manifest_data), encoding="utf-8"
+        )
+    return result_json, output_dir
+
+
+def _run_step6(monkeypatch, tmp_path: Path, manifest_data: dict | None) -> dict:
+    """Run ``generate_report`` against an isolated workspace and return the
+    parsed ``report_data.json`` dict."""
+    monkeypatch.setattr(step6_report, "WORKSPACE_DIR", tmp_path)
+    # The manifest loader (core.needs_files) and core.config both keep their
+    # own bindings of WORKSPACE_DIR; patch all three to fully isolate.
+    import core.config as core_config
+    import core.needs_files as core_needs_files
+    monkeypatch.setattr(core_config, "WORKSPACE_DIR", tmp_path)
+    monkeypatch.setattr(core_needs_files, "WORKSPACE_DIR", tmp_path)
+
+    result_json, output_dir = _write_workspace(tmp_path, manifest_data)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        step6_report.generate_report(
+            result_json_path=result_json,
+            output_dir=output_dir,
+            no_narrative=True,
+        )
+
+    return json.loads((output_dir / "report_data.json").read_text(encoding="utf-8"))
+
+
+def test_generate_report_v2_manifest_includes_v2_fields(monkeypatch, tmp_path):
+    rd = _run_step6(monkeypatch, tmp_path, _make_v2_manifest_data())
+
+    # Per-task v2 fields present on every entry.
+    assert len(rd["task_results"]) == 2
+    for entry in rd["task_results"]:
+        assert "prompt_classification" in entry
+        assert "policy_results" in entry
+        assert "has_deliverable_files" in entry
+        assert set(entry["policy_results"].keys()) == set(_ALL_POLICIES)
+
+    # File-generation block surfaces the v2 summary fields.
+    fg = rd["file_generation"]
+    assert fg["active_policy"] == "deliverable_only"
+    assert fg["policy_counts"] == {
+        "deliverable_only": 1,
+        "explicit_boost": 1,
+        "union": 1,
+        "intersection": 1,
+    }
+    assert fg["confidence_distribution"] == {
+        "explicit": 1,
+        "inferred": 0,
+        "ambiguous": 0,
+        "text_only": 1,
+    }
+
+    # Existing summary stats are unchanged by v2 augmentation.
+    s = rd["summary"]
+    assert s["total_tasks"] == 2
+    assert s["success_count"] == 2
+    assert s["success_rate_pct"] == 100.0
+    assert s["error_count"] == 0
+
+
+def test_generate_report_v1_manifest_omits_v2_fields(monkeypatch, tmp_path):
+    rd = _run_step6(monkeypatch, tmp_path, _make_v1_manifest_data())
+
+    # No v2 keys appear anywhere in task entries.
+    for entry in rd["task_results"]:
+        assert "prompt_classification" not in entry
+        assert "policy_results" not in entry
+        assert "has_deliverable_files" not in entry
+
+    # file_generation must NOT pick up v2 summary fields for a v1 manifest.
+    fg = rd["file_generation"]
+    assert "active_policy" not in fg
+    assert "policy_counts" not in fg
+    assert "confidence_distribution" not in fg
+
+    # Existing summary stats are still correct.
+    s = rd["summary"]
+    assert s["total_tasks"] == 2
+    assert s["success_count"] == 2
+
+
+def test_generate_report_no_manifest_omits_v2_fields(monkeypatch, tmp_path):
+    """Missing manifest (Step 0 never run) must not crash and must not emit
+    any v2 keys — full backward-compat with pre-v2 workspaces."""
+    rd = _run_step6(monkeypatch, tmp_path, manifest_data=None)
+
+    for entry in rd["task_results"]:
+        assert "prompt_classification" not in entry
+        assert "policy_results" not in entry
+        assert "has_deliverable_files" not in entry
+
+    fg = rd["file_generation"]
+    assert "active_policy" not in fg
+    assert "policy_counts" not in fg
+    assert "confidence_distribution" not in fg
+
+
+def test_generate_report_v2_vs_v1_preserves_v1_task_keys(monkeypatch, tmp_path):
+    """REGRESSION INVARIANT: switching v1↔v2 must not change any v1 key value
+    in the report.  Only new (v2) keys appear/disappear."""
+    rd_v1 = _run_step6(monkeypatch, tmp_path / "v1", _make_v1_manifest_data())
+    rd_v2 = _run_step6(monkeypatch, tmp_path / "v2", _make_v2_manifest_data())
+
+    # Summary unchanged.
+    assert rd_v1["summary"] == rd_v2["summary"]
+    # Sector breakdown unchanged.
+    assert rd_v1["sector_breakdown"] == rd_v2["sector_breakdown"]
+    # Per-task v1 keys unchanged (compare by task_id).
+    by_id_v1 = {t["task_id"]: t for t in rd_v1["task_results"]}
+    by_id_v2 = {t["task_id"]: t for t in rd_v2["task_results"]}
+    assert set(by_id_v1) == set(by_id_v2)
+    v2_only = {"prompt_classification", "policy_results", "has_deliverable_files"}
+    for tid, v1_entry in by_id_v1.items():
+        v2_entry = by_id_v2[tid]
+        for k, expected in v1_entry.items():
+            assert v2_entry[k] == expected, (
+                f"v2 manifest changed v1 task_results key {k!r} for {tid!r}"
+            )
+        added = set(v2_entry.keys()) - set(v1_entry.keys())
+        assert added == v2_only

--- a/tasks/TASK_STEP6_V2_FIELDS.md
+++ b/tasks/TASK_STEP6_V2_FIELDS.md
@@ -1,0 +1,69 @@
+# TASK_STEP6_V2_FIELDS — Include v2 manifest fields in self_report.json
+
+V2 시리즈 후속. `step6_report.py`가 self_report.json/report_data.json을 만들 때 BATCH PR이 도입한 v2 manifest 필드를 정식 포함.
+
+## Goal
+self_report.json 스키마에 v2 필드 추가:
+- 각 task entry에: `prompt_classification`, `policy_results`, `has_deliverable_files`
+- `_summary` 또는 `file_generation`에: `policy_counts`, `active_policy`, `confidence_distribution`
+
+핵심 불변식:
+- **default policy=deliverable_only에서 기존 필드 값 변화 0** (`needs_files_total`, `summary`, `sector_breakdown`, `task_results` 카운트 등)
+- v1 manifest 환경에서도 backward-compatible: manifest에 v2 필드 없으면 self_report도 v2 필드 없이 생성 (또는 명시적 null/None)
+- 추가 필드는 **append only**, 기존 키 0개 변경
+- 다음 step6 실행이 v2 필드를 자동 생성하게 됨 → backfill 스크립트가 필요한 영구화 달성
+
+## Scope
+**수정**:
+- `batch-runner/step6_report.py` (또는 `step3_compile_report.py` — `_build_report_data` 또는 동등 함수가 있는 곳)
+
+**신규**:
+- `batch-runner/tests/test_step6_v2_fields.py` — v2 manifest fixture로 self_report 생성 → v2 필드 포함 확인 + v1 manifest로도 backward-compat 확인
+
+**손대지 않을 곳**:
+- `batch-runner/core/*` (BATCH/GUARDRAILS에서 이미 끝남)
+- `step0~5` (기존 파이프라인 무수정)
+- `src/`, `scripts/aggregate-*.mjs` (PR A2가 처리)
+- HF 업로드/다운로드 흐름
+
+## Design
+
+`step6_report.py`의 `_build_report_data` (또는 동등 함수)에서:
+1. `NeedsFilesManifest` 로드 (이미 함)
+2. **task_results** 빌드 시 각 task entry에 추가:
+   ```python
+   if manifest_v2_available(manifest):
+       entry["prompt_classification"] = manifest.prompt_classification(task_id)
+       entry["policy_results"] = {p: manifest.policy_result(task_id, p) for p in POLICIES}
+       entry["has_deliverable_files"] = manifest.has_deliverable_files(task_id)
+   ```
+3. **`_summary` 또는 `file_generation`**에 추가:
+   ```python
+   if manifest_v2_available(manifest):
+       summary["active_policy"] = manifest.summary.active_policy
+       summary["policy_counts"] = manifest.summary.policy_counts
+       summary["confidence_distribution"] = manifest.summary.confidence_distribution
+   ```
+
+`manifest_v2_available()` helper: manifest의 `_summary.active_policy`가 존재하면 v2로 판정 (v1 manifest는 None).
+
+자세한 위치는 coder가 step6_report.py 코드 보고 가장 자연스러운 통합점 결정.
+
+## Acceptance
+- v2 manifest로 step6 실행 시 self_report.json에 신규 필드 모두 포함
+- v1 manifest(단위 테스트에서 fixture로 생성)로 step6 실행 시 self_report.json에 신규 필드 부재 (또는 null) → backward-compat
+- 기존 필드(`summary.needs_files_total`, `task_results` 카운트 등) 값 변화 0
+- 단위 테스트 `test_step6_v2_fields.py` 통과
+- BATCH/GUARDRAILS 회귀 테스트 (`test_prompt_classifier.py`, `test_resolve_needs_files.py`, `test_policy_guardrails.py`) 그대로 통과
+- 변경 파일이 명시된 1개 수정 + 1개 신규 테스트 + spec = 3개
+- secrets 0
+
+## Failure Policy
+- 기존 테스트 회귀 → REJECT, 수정 후 재시도
+- first-reviewer REJECT 1회 재시도
+- extreme-reasoner REJECT → 사용자 컨펌 필요
+
+## Out of Scope
+- 대시보드 표시 (PR A2)
+- 과거 실험 backfill (A3)
+- HF 업로드/다운로드 로직 변경


### PR DESCRIPTION
Extends step6_report._build_report_data to emit v2 manifest fields (prompt_classification, policy_results, has_deliverable_files per task; active_policy, policy_counts, confidence_distribution in summary). Backward-compatible: v1 manifest path produces self_report without v2 fields. Existing field values unchanged. Tests: test_step6_v2_fields.py covers both v1 and v2 fixtures. Spec: tasks/TASK_STEP6_V2_FIELDS.md. Sister PR: A2 (dashboard surface).