### PR TITLE
fix(core): 3 silent corruption paths (Brilliant Top 2/3/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- **subprocess_runner: `_AVAILABLE_FILES` hint now actually executed.**
+  In `core/subprocess_runner.py::_execute_safely`, the `files_header`
+  (`_AVAILABLE_FILES = [...]`) prepended to the generated `code` string was
+  never persisted back to the executed script path, so the subprocess ran the
+  raw user code without the guarded hint. The header-prepended `code` is now
+  written to `code_path` end-to-end. The earlier redundant pre-prepend write
+  was removed; the file is written exactly once after the header is applied.
+
+- **llm_client (Anthropic): tolerant content parsing + `finish_reason`
+  surfaced.** `core/llm_client.py::AnthropicClient.chat_complete` previously
+  assumed `response.content[0].text`, which crashed when the first block was
+  a `thinking` or `tool_use` block. The parser now walks all content blocks
+  and concatenates only `type == "text"` segments. `response.stop_reason` is
+  mapped to an OpenAI-compatible `finish_reason` (`max_tokens` → `length`;
+  `end_turn` / `stop_sequence` / `tool_use` passed through) and exposed on
+  `_Choice` / `NormalizedResponse`, so the existing
+  `finish_reason == "length"` truncation guard in
+  `step2_run_inference.py:436` actually fires for Anthropic.
+
+- **step2_run_inference: `qa_failed` is now set on genuine Self-QA
+  failures.** Previously, when Self-QA scored `< min_score` and retries were
+  exhausted, the best result was returned with `status == "success"`, which
+  meant the `RETRIABLE_STATUSES` retry plumbing (resume rounds), the
+  `_print_status` `qa_failed` branch, and the summary counters at
+  `step2_run_inference.py:1419` / `1448` were all dead code paths.
+  `_run_task_with_qa` now sets `best_result["status"] = "qa_failed"` on
+  genuine quality failures, re-enabling auto-retry / resume.
+  The `undetermined` branch is intentionally left as `success` — it only
+  marks QA parse / API failures, not quality failures, and is not a retry
+  target.
+
+### Changed
+
+- **`qa_failed` semantics (BREAKING for comparability).** As a consequence
+  of the fix above, the dashboard / aggregated metric `qa_failed_count` is
+  no longer comparable across the boundary: pre-fix runs report
+  `qa_failed_count == 0` (the flag was never set even when QA genuinely
+  failed); post-fix runs report the true count. Treat pre/post
+  `qa_failed_count` as different metrics.
+
+- **`compact` mode parquet may now contain fewer rows.** When
+  `result_collector` is configured in compact mode it filters
+  `status == "success"`. Because genuine QA failures now flip to
+  `qa_failed`, those rows are excluded from the compact parquet that were
+  previously silently retained as `success`. The non-compact / per-task
+  JSON output is unaffected and remains the source of truth for QA failure
+  counts.
+
+- **`resume_rounds_used` will be non-zero on QA-enabled runs.** The same
+  fix re-enables the resume / retry loop for `qa_failed` tasks via
+  `RETRIABLE_STATUSES`, so QA-enabled runs that previously reported
+  `resume_rounds_used == 0` may now legitimately consume one or more
+  resume rounds. Worst-case per-task cost is capped by the existing
+  `qa_max_retries` × `resume_rounds` × infra-retry budget.
+
+### Notes
+
+- **Cost guardrail (re-validated post-fix).** Production experiment YAMLs
+  (`exp001`–`exp024`) keep worst-case per-task LLM call multiplier at ≤6×
+  (infra retries × QA retries × resume rounds, within previous SLOs).
+  Smoke YAMLs (`exp997` / `exp998` / `exp999`) sit higher at 12×–16× in the
+  worst case, but their `sample_size` of 2–3 tasks bounds total wall-clock
+  / spend impact to negligible levels. No YAML changes are required.
+

--- a/batch-runner/core/llm_client.py
+++ b/batch-runner/core/llm_client.py
@@ -20,8 +20,9 @@ class _Message:
 
 
 class _Choice:
-    def __init__(self, content: str):
+    def __init__(self, content: str, finish_reason: str | None = None):
         self.message = _Message(content)
+        self.finish_reason = finish_reason
 
 
 class _Usage:
@@ -33,8 +34,8 @@ class _Usage:
 
 class NormalizedResponse:
     """OpenAI-compatible response wrapper for non-OpenAI providers."""
-    def __init__(self, content: str, model: str = "", usage=None):
-        self.choices = [_Choice(content)]
+    def __init__(self, content: str, model: str = "", usage=None, finish_reason: str | None = None):
+        self.choices = [_Choice(content, finish_reason=finish_reason)]
         self.model = model
         self.usage = usage or _Usage()
 
@@ -96,13 +97,50 @@ class AnthropicClient:
 
         response = self.client.messages.create(**create_kwargs)
 
-        content = response.content[0].text if response.content else ""
+        # Anthropic returns a list of content blocks. Extended thinking and
+        # tool use produce ThinkingBlock / ToolUseBlock objects that have no
+        # `.text` attribute — accessing response.content[0].text on those
+        # would raise AttributeError. Concatenate the text from all text blocks
+        # and skip the rest.
+        text_parts = []
+        for block in (response.content or []):
+            if getattr(block, "type", None) == "text":
+                text_parts.append(getattr(block, "text", ""))
+        content = "".join(text_parts)
+
+        # Map Anthropic stop_reason to OpenAI-style finish_reason so callers
+        # that check choices[0].finish_reason == "length" (truncation guard)
+        # work for both providers.
+        finish_reason = self._map_stop_reason(getattr(response, "stop_reason", None))
+
         usage = _Usage(
             prompt_tokens=response.usage.input_tokens,
             completion_tokens=response.usage.output_tokens,
             total_tokens=response.usage.input_tokens + response.usage.output_tokens,
         )
-        return NormalizedResponse(content=content, model=response.model, usage=usage)
+        return NormalizedResponse(
+            content=content,
+            model=response.model,
+            usage=usage,
+            finish_reason=finish_reason,
+        )
+
+    @staticmethod
+    def _map_stop_reason(stop_reason: str | None) -> str | None:
+        """Translate Anthropic stop_reason to OpenAI-style finish_reason.
+
+        Anthropic values: "end_turn", "max_tokens", "stop_sequence", "tool_use".
+        OpenAI values:    "stop", "length", "tool_calls", ...
+        """
+        if stop_reason is None:
+            return None
+        mapping = {
+            "max_tokens": "length",
+            "end_turn": "stop",
+            "stop_sequence": "stop",
+            "tool_use": "tool_calls",
+        }
+        return mapping.get(stop_reason, stop_reason)
 
 
 # ─── Client Factory ──────────────────────────────────────────────────────

--- a/batch-runner/core/subprocess_runner.py
+++ b/batch-runner/core/subprocess_runner.py
@@ -243,9 +243,10 @@ class SubprocessRunner:
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             try:
-                # Save code to file
+                # Path of the script the subprocess will execute. Actual write
+                # happens after the _AVAILABLE_FILES header is prepended below
+                # so the persisted file matches the in-memory `code`.
                 code_path = Path(tmpdir) / "solution.py"
-                code_path.write_text(code, encoding="utf-8")
 
                 # Copy reference files to execution directory and track copied files
                 copied_files = []

--- a/batch-runner/core/subprocess_runner.py
+++ b/batch-runner/core/subprocess_runner.py
@@ -270,6 +270,10 @@ class SubprocessRunner:
                 else:
                     code = "# No reference files available\n\n" + code
 
+                # Persist the (possibly header-prepended) code so the subprocess
+                # actually executes the version with the _AVAILABLE_FILES hint.
+                code_path.write_text(code, encoding="utf-8")
+
                 # 🔒 Security: Whitelist environment variables
                 # Use current Python's PATH so venv packages are available
                 # but strip API keys and secrets

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -1001,8 +1001,11 @@ def run_inference(
 
         QA status handling:
         - passed=True  → success (QA 통과)
-        - passed=False → success (파일 생성 = LLM 성능, QA 점수만 낮음)
-        - undetermined → 재시도 후 마지막이면 success (score=None)
+        - passed=False → 재시도 후에도 score < min_score 면 qa_failed
+          (genuine 품질 실패. RETRIABLE_STATUSES 에 포함되어 있어
+          resume rounds / 자동 retry 가 다시 동작함)
+        - undetermined → 재시도 후 마지막이면 success (score=None,
+          QA parse/API 실패만 표시. 품질 실패가 아니므로 retry 대상 아님)
 
         Best-swap: QA 재시도 시 이전 best 파일을 백업.
         새 결과가 더 좋으면 백업 삭제, 더 나쁘면 백업에서 복원.

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -1154,6 +1154,15 @@ def run_inference(
                           f"(best score={best_score}) — "
                           f"saving as success",
                           end=" ", flush=True)
+                    # Genuine QA fail (determined, score < min_score, retries
+                    # exhausted): mark the best result as qa_failed so the
+                    # RETRIABLE_STATUSES retry plumbing (resume rounds) +
+                    # _print_status + summary counters fire. The undetermined
+                    # branch above is intentionally left as "success" — it
+                    # only marks QA parse/API failures, not genuine quality
+                    # failures.
+                    if best_result is not None:
+                        best_result["status"] = "qa_failed"
                     break
 
                 # Build structured reflection prompt for retry

--- a/batch-runner/tests/test_silent_corruption_fixes.py
+++ b/batch-runner/tests/test_silent_corruption_fixes.py
@@ -1,0 +1,508 @@
+"""Regression tests for the 3 silent corruption fixes (TASK_SILENT_CORRUPTION_FIXES).
+
+Each fix is locked by a focused regression test:
+
+Fix 1: _AVAILABLE_FILES dead-write in core/subprocess_runner.py
+   The files_header (`_AVAILABLE_FILES = [...]`) prepended to `code` was
+   never persisted back to `code_path`, so the subprocess executed the
+   original code without the hint. Tests verify the hint actually runs
+   inside the subprocess.
+
+Fix 2: Anthropic content[0].text crash + stop_reason ignored in
+   core/llm_client.py. AnthropicClient.chat_complete must (a) iterate
+   response.content blocks and concat only text-type blocks (no crash on
+   thinking/tool_use blocks), and (b) expose response.stop_reason as
+   choices[0].finish_reason (with "max_tokens" → "length" mapping) so
+   step2:436 truncation guard works for Anthropic.
+
+Fix 3: qa_failed dead invariant in step2_run_inference.py. When Self-QA
+   genuinely fails (score < min_score after retries exhausted), the
+   returned best_result must carry status="qa_failed" so the 4
+   read-sites + RETRIABLE_STATUSES retry plumbing fire. The undetermined
+   branch is intentionally left as "success".
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fix 1 — _AVAILABLE_FILES dead-write in subprocess_runner._execute_safely
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestFix1AvailableFilesPersisted:
+    """Verify the files_header prepend is actually written to the executed file."""
+
+    def _make_runner(self):
+        from core.subprocess_runner import SubprocessRunner
+        return SubprocessRunner(MagicMock())
+
+    def test_available_files_hint_is_executed_by_subprocess(self, tmp_path):
+        """With reference files, the subprocess must observe _AVAILABLE_FILES.
+
+        Before fix: header was prepended only to the local variable `code` and
+        never written back, so the subprocess executed the original solution
+        without _AVAILABLE_FILES defined → NameError if the code references it.
+
+        After fix: the modified `code` is persisted to code_path, so the
+        subprocess sees the hint.
+        """
+        runner = self._make_runner()
+        ref_file = tmp_path / "data.csv"
+        ref_file.write_text("col1,col2\n1,2\n", encoding="utf-8")
+
+        # Code that depends on the injected _AVAILABLE_FILES variable.
+        # Before fix, this would NameError because the variable is never defined
+        # in the executed file.
+        user_code = "print('FILES:', _AVAILABLE_FILES)"
+
+        result = runner._execute_safely(user_code, reference_files=[str(ref_file)])
+
+        assert result["success"] is True, f"subprocess failed: {result.get('error')}"
+        assert "FILES:" in result["text"]
+        assert "data.csv" in result["text"]
+
+    def test_no_reference_files_regression_marker_persisted(self, tmp_path):
+        """Without reference files, the 'No reference files available' marker
+        must also reach the executed file (else-branch of the prepend).
+
+        This locks the symmetric else-branch fix.
+        """
+        runner = self._make_runner()
+        # Use a tiny program that prints itself's first line via __file__.
+        user_code = (
+            "with open(__file__, 'r', encoding='utf-8') as fh:\n"
+            "    print(fh.readline().rstrip())\n"
+        )
+
+        result = runner._execute_safely(user_code, reference_files=None)
+
+        assert result["success"] is True, f"subprocess failed: {result.get('error')}"
+        # The else-branch prepends "# No reference files available\n\n" to code.
+        # After fix, that header is in the executed file, so __file__ readline
+        # returns the comment line.
+        assert "No reference files available" in result["text"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fix 2 — Anthropic content[0].text crash + stop_reason ignored
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_text_block(text):
+    return SimpleNamespace(type="text", text=text)
+
+
+def _make_thinking_block(text="internal monologue"):
+    # ThinkingBlock objects have no `.text` attribute (well, in some SDK
+    # versions they do as `.thinking`, not `.text`). The key invariant we test
+    # is that we skip them based on `.type != "text"`.
+    return SimpleNamespace(type="thinking", thinking=text)
+
+
+def _make_tool_use_block(name="search"):
+    return SimpleNamespace(type="tool_use", name=name, id="toolu_1", input={})
+
+
+def _make_anthropic_response(content_blocks, stop_reason="end_turn", model="claude-x"):
+    return SimpleNamespace(
+        content=content_blocks,
+        stop_reason=stop_reason,
+        model=model,
+        usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+    )
+
+
+@pytest.fixture
+def anthropic_client():
+    """Build AnthropicClient with the underlying SDK client mocked out."""
+    from core.llm_client import AnthropicClient
+
+    # Bypass __init__ to avoid needing the `anthropic` package or API key.
+    client = AnthropicClient.__new__(AnthropicClient)
+    client.client = MagicMock()
+    return client
+
+
+class TestFix2AnthropicContentExtraction:
+    """Iterate content blocks; only text blocks contribute to choices[0].message.content."""
+
+    def test_single_text_block_existing_behavior(self, anthropic_client):
+        """Sanity: single text block returns its text (no regression)."""
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            [_make_text_block("hello world")]
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert resp.choices[0].message.content == "hello world"
+
+    def test_thinking_then_text_does_not_raise(self, anthropic_client):
+        """First block thinking, then text → returns the text, no AttributeError.
+
+        Before fix: response.content[0].text crashed because thinking blocks
+        don't have a `.text` attribute (or have a different one).
+        """
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            [_make_thinking_block(), _make_text_block("real answer")]
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert resp.choices[0].message.content == "real answer"
+
+    def test_tool_use_then_text_does_not_raise(self, anthropic_client):
+        """First block tool_use, then text → returns the text, no AttributeError."""
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            [_make_tool_use_block(), _make_text_block("done")]
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert resp.choices[0].message.content == "done"
+
+    def test_multiple_text_blocks_concatenated(self, anthropic_client):
+        """Multiple text blocks are concatenated."""
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            [_make_text_block("part1"), _make_text_block("part2")]
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert resp.choices[0].message.content == "part1part2"
+
+    def test_empty_content_returns_empty_string(self, anthropic_client):
+        """No content blocks → empty content (no crash)."""
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            []
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert resp.choices[0].message.content == ""
+
+    def test_only_non_text_blocks_returns_empty_string(self, anthropic_client):
+        """If every block is thinking/tool_use → content is "" (no crash)."""
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            [_make_thinking_block(), _make_tool_use_block()]
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert resp.choices[0].message.content == ""
+
+
+class TestFix2FinishReasonExposed:
+    """stop_reason must be mapped to OpenAI-style finish_reason on choices[0]."""
+
+    def test_max_tokens_maps_to_length(self, anthropic_client):
+        """Anthropic 'max_tokens' → OpenAI 'length' so step2 truncation guard fires."""
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            [_make_text_block("truncated...")], stop_reason="max_tokens"
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        # step2_run_inference.py:436 — getattr(response.choices[0], "finish_reason", None)
+        finish_reason = getattr(resp.choices[0], "finish_reason", None)
+        assert finish_reason == "length"
+
+    def test_end_turn_maps_to_stop(self, anthropic_client):
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            [_make_text_block("complete")], stop_reason="end_turn"
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert getattr(resp.choices[0], "finish_reason", None) == "stop"
+
+    def test_stop_sequence_maps_to_stop(self, anthropic_client):
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            [_make_text_block("complete")], stop_reason="stop_sequence"
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert getattr(resp.choices[0], "finish_reason", None) == "stop"
+
+    def test_missing_stop_reason_is_none(self, anthropic_client):
+        anthropic_client.client.messages.create.return_value = _make_anthropic_response(
+            [_make_text_block("complete")], stop_reason=None
+        )
+        resp = anthropic_client.chat_complete(
+            model="claude-x",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert getattr(resp.choices[0], "finish_reason", None) is None
+
+
+class TestFix2AzureRegression:
+    """Verify the Azure/OpenAI completion path is unaffected by the wrapper changes."""
+
+    def test_choice_default_finish_reason_is_none(self):
+        """_Choice without explicit finish_reason → None (back-compat)."""
+        from core.llm_client import _Choice
+
+        c = _Choice("content")
+        assert c.message.content == "content"
+        assert c.finish_reason is None
+
+    def test_normalized_response_default_finish_reason_is_none(self):
+        from core.llm_client import NormalizedResponse
+
+        r = NormalizedResponse(content="hi")
+        assert r.choices[0].message.content == "hi"
+        assert r.choices[0].finish_reason is None
+
+    def test_complete_with_azure_response_passes_through(self):
+        """complete() returns the raw Azure SDK response (with whatever
+        finish_reason that SDK already provides).
+        """
+        from core.llm_client import complete
+
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = "azure says hi"
+        mock_resp.choices[0].finish_reason = "stop"
+        mock_client.chat.completions.create.return_value = mock_resp
+
+        response, _ = complete(mock_client, "gpt-x", [{"role": "user", "content": "x"}])
+        assert response is mock_resp
+        assert response.choices[0].finish_reason == "stop"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fix 3 — qa_failed dead invariant in step2_run_inference._run_task_with_qa
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestFix3RetrieableStatuses:
+    """qa_failed must be in RETRIABLE_STATUSES (already true; sanity lock)."""
+
+    def test_qa_failed_is_retriable(self):
+        from step2_run_inference import RETRIABLE_STATUSES
+
+        assert "qa_failed" in RETRIABLE_STATUSES
+
+    def test_get_failed_task_ids_picks_up_qa_failed(self):
+        """_get_failed_task_ids includes qa_failed entries → resume retry fires."""
+        from step2_run_inference import _get_failed_task_ids
+
+        progress = {
+            "results": [
+                {"task_id": "t1", "status": "success"},
+                {"task_id": "t2", "status": "qa_failed", "error": ""},
+                {"task_id": "t3", "status": "error", "error": "boom"},
+                {"task_id": "t4", "status": "pending"},
+            ]
+        }
+        failed = _get_failed_task_ids(progress)
+        ids = {f["task_id"] for f in failed}
+        # qa_failed must be picked up alongside error/pending
+        assert "t2" in ids
+        assert "t3" in ids
+        assert "t4" in ids
+        assert "t1" not in ids
+
+
+def _build_step1_prepared(tmp_path: Path, task_id: str = "t1") -> Path:
+    """Write a minimal step1_tasks_prepared.json for run_inference."""
+    prepared = {
+        "experiment_id": "exp_test",
+        "experiment_name": "qa_failed_regression",
+        "source": "test",
+        "execution": {
+            "mode": "subprocess",
+            "max_retries": 1,
+            "resume_max_rounds": 1,
+        },
+        "tasks": [
+            {
+                "task_id": task_id,
+                "sector": "test_sector",
+                "occupation": "test_occupation",
+                "instruction": "Do a thing.",
+                "reference_files": [],
+            }
+        ],
+        "condition_a": {
+            "name": "test_condition",
+            "model": {"provider": "azure", "deployment": "gpt-test"},
+            "prompt": {"system": "you are helpful"},
+            "qa": {
+                "enabled": True,
+                "min_score": 6,
+                "max_retries": 2,
+                "prompt": "Evaluate the output: {deliverable_text}",
+                "model": "gpt-qa",
+            },
+        },
+    }
+    prepared_path = tmp_path / "step1_tasks_prepared.json"
+    prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
+    return prepared_path
+
+
+@pytest.fixture
+def patched_run_inference(tmp_path, monkeypatch):
+    """Patch WORKSPACE_DIR/DELIVERABLE_DIR + dependencies so run_inference can
+    be driven by injected _execute_single_task / _run_self_qa stubs.
+    """
+    import step2_run_inference as s2
+
+    workspace = tmp_path / "workspace"
+    upload = workspace / "upload"
+    deliverables = upload / "deliverable_files"
+    deliverables.mkdir(parents=True)
+
+    monkeypatch.setattr(s2, "WORKSPACE_DIR", workspace, raising=True)
+    monkeypatch.setattr(s2, "UPLOAD_DIR", upload, raising=True)
+    monkeypatch.setattr(s2, "DELIVERABLE_DIR", deliverables, raising=True)
+
+    _build_step1_prepared(workspace)
+
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.test/")
+    monkeypatch.setattr(
+        s2, "create_provider_client", MagicMock(return_value=MagicMock())
+    )
+    monkeypatch.setattr(s2, "TaskExecutor", MagicMock(return_value=MagicMock()))
+    # Manifest is optional; FileNotFoundError path is fine.
+    monkeypatch.setattr(
+        s2.NeedsFilesManifest,
+        "load",
+        classmethod(lambda cls: (_ for _ in ()).throw(FileNotFoundError())),
+    )
+
+    return s2, workspace
+
+
+def _read_progress(workspace: Path) -> dict:
+    progress_path = workspace / "step2_inference_progress.json"
+    return json.loads(progress_path.read_text(encoding="utf-8"))
+
+
+class TestFix3RunTaskWithQA:
+    """Drive run_inference end-to-end with mocked _execute_single_task and
+    _run_self_qa to verify the qa_failed status is set on genuine fail and
+    preserved as success on undetermined / passing.
+    """
+
+    def _success_execute(self, *args, **kwargs):
+        return {
+            "task_id": "t1",
+            "status": "success",
+            "deliverable_text": "hello",
+            "deliverable_files": [],
+            "latency_ms": 10,
+        }
+
+    def test_genuine_qa_fail_marks_status_qa_failed(
+        self, patched_run_inference, monkeypatch
+    ):
+        """QA fails (score < min_score) → final result.status == "qa_failed"."""
+        s2, workspace = patched_run_inference
+
+        monkeypatch.setattr(s2, "_execute_single_task", self._success_execute)
+        monkeypatch.setattr(
+            s2,
+            "_run_self_qa",
+            lambda *a, **k: {
+                "passed": False,
+                "score": 3,
+                "issues": ["bad"],
+                "suggestion": "fix it",
+                "undetermined": False,
+                "llm_passed": False,
+            },
+        )
+
+        s2.run_inference(
+            condition_key="condition_a",
+            resume=False,
+            resume_max_rounds=1,
+        )
+
+        progress = _read_progress(workspace)
+        results = progress["results"]
+        assert len(results) == 1
+        assert results[0]["status"] == "qa_failed", (
+            f"Expected qa_failed, got {results[0]['status']!r}; "
+            f"qa={results[0].get('qa')}"
+        )
+
+    def test_qa_passes_keeps_status_success(
+        self, patched_run_inference, monkeypatch
+    ):
+        """QA passes → final result.status remains "success" (no regression)."""
+        s2, workspace = patched_run_inference
+
+        monkeypatch.setattr(s2, "_execute_single_task", self._success_execute)
+        monkeypatch.setattr(
+            s2,
+            "_run_self_qa",
+            lambda *a, **k: {
+                "passed": True,
+                "score": 9,
+                "issues": [],
+                "suggestion": "",
+                "undetermined": False,
+                "llm_passed": True,
+            },
+        )
+
+        s2.run_inference(
+            condition_key="condition_a",
+            resume=False,
+            resume_max_rounds=1,
+        )
+
+        progress = _read_progress(workspace)
+        results = progress["results"]
+        assert len(results) == 1
+        assert results[0]["status"] == "success"
+
+    def test_qa_undetermined_keeps_status_success(
+        self, patched_run_inference, monkeypatch
+    ):
+        """Undetermined-on-final-attempt → status remains "success" (intentional)."""
+        s2, workspace = patched_run_inference
+
+        monkeypatch.setattr(s2, "_execute_single_task", self._success_execute)
+        monkeypatch.setattr(
+            s2,
+            "_run_self_qa",
+            lambda *a, **k: {
+                "passed": None,
+                "score": None,
+                "issues": ["parse fail"],
+                "suggestion": "",
+                "undetermined": True,
+            },
+        )
+
+        s2.run_inference(
+            condition_key="condition_a",
+            resume=False,
+            resume_max_rounds=1,
+        )
+
+        progress = _read_progress(workspace)
+        results = progress["results"]
+        assert len(results) == 1
+        # The undetermined branch must remain status="success" — fix 3 only
+        # touches the genuine-fail branch.
+        assert results[0]["status"] == "success"

--- a/tasks/TASK_PR38_FOLLOWUP.md
+++ b/tasks/TASK_PR38_FOLLOWUP.md
@@ -1,0 +1,30 @@
+# TASK_PR38_FOLLOWUP — extreme-reasoner CONDITION + MINOR 정리 (CLAUDE.md 제외)
+
+PR #38(silent corruption fixes) 머지 전 보강. CLAUDE.md 트리거 정정은 gitignore라 로컬 only.
+
+## 처리 항목 (3개)
+
+### 1. CHANGELOG.md 엔트리 (CONDITION 2)
+`CHANGELOG.md` 신규 생성 (없으면) 또는 `[Unreleased]` 섹션 추가. 커버:
+- `qa_failed` 동작 변경 (이전 dead invariant)
+- pre/post `qa_failed_count` 비교 불가
+- compact-mode parquet 행 수 감소 가능 (`status=="success"` 필터)
+- `resume_rounds_used` QA-enabled run에서 비0
+- Cost guardrail 메모: 프로덕션 YAML(exp001~024) 전부 worst-case ≤6×, smoke YAMLs(exp997/998/999) 12~16× 이나 sample_size 2~3으로 실효 영향 미미
+- 3 silent corruption fix 요약
+
+### 2. step2_run_inference.py:1003-1005 docstring 정정 (MINOR 1)
+Fix 3 적용 후 docstring과 실제 동작 일치.
+
+### 3. subprocess_runner.py redundant write 제거 (MINOR 2)
+Fix 1로 두 번째 write가 추가됐으니 첫 번째 write(line 248 부근)는 redundant. 동작 동일 보장하면서 제거.
+
+## Out of Scope
+- CLAUDE.md 트리거 정정 (gitignore라 PR 불가, 로컬 적용 완료)
+- 3 silent corruption fix 본체 (4e0e43d, 이미 reviewed/locked)
+- CONDITION 3 (post-merge 운영 관측)
+
+## Acceptance
+- 위 3 항목 변경
+- V2 + silent-corruption 전 테스트 통과 (회귀 0)
+- secrets 0

--- a/tasks/TASK_SILENT_CORRUPTION_FIXES.md
+++ b/tasks/TASK_SILENT_CORRUPTION_FIXES.md
@@ -1,0 +1,93 @@
+# TASK_SILENT_CORRUPTION_FIXES — 3건 silent corruption fix bundle
+
+BRILLIANT_OPPORTUNITIES.md ⭐⭐⭐⭐⭐ Top 2 + 3 + 4. 셋 다 HF 배포 데이터·평가 결과에 직접 영향, 에러 안 남, 로그 안 찍힘. 한 PR로 묶어서 차단.
+
+> **경로 정정 노트**: 원 지시문은 Fix 2를 `core/providers/anthropic.py`, Fix 3을 `core/qa.py`로 추정했으나 그 파일들은 존재하지 않는다. BRILLIANT_OPPORTUNITIES.md가 명시한 실제 위치(아래 file:line)가 권위 있는 출처이며 이를 따른다. extreme-reasoner 의무 리뷰는 지시대로 그대로 유지(QA 동작 변경 검토 목적).
+
+## 핵심 불변식
+- 기존 정상 동작에 회귀 0 (default 환경에서 결과 변화 0건이거나, 변하면 그게 곧 fix 효과)
+- 각 fix는 명확한 regression test로 lock
+- secrets 노출 0
+
+## Fix 1 — `_AVAILABLE_FILES` Dead-Write
+**BRILLIANT 위치**: `batch-runner/core/subprocess_runner.py` — write@`code_path.write_text(code, ...)` → header prepend(`files_header = ... ; code = files_header + code`) → exec(`subprocess.run([python_executable, str(code_path)], ...)`).
+
+**현 코드 (검증 완료, `_execute` / `with tempfile.TemporaryDirectory()` 블록 내)**:
+1. `code_path = Path(tmpdir) / "solution.py"` → `code_path.write_text(code, encoding="utf-8")` — 원본 code를 디스크에 기록
+2. reference 파일 복사 → `copied_files` 수집
+3. `if copied_files:` → `files_header` (`import os` / `_AVAILABLE_FILES = [...]` / `# Available files:`) 를 **로컬 변수** `code`에 prepend. `else:` → `"# No reference files available\n\n" + code`
+4. `subprocess.run([python_executable, str(code_path)], ...)` — **디스크의 원본 파일**(힌트 없음)을 실행
+
+→ `_AVAILABLE_FILES` 힌트가 실행 코드에 절대 들어가지 않음 (dead-write).
+
+**Fix**: prepend(if/else) 직후 `code_path.write_text(code, encoding="utf-8")` 1회 추가하여 변형된 `code`를 실행 파일에 반영. (또는 동등하게 header 계산을 첫 write 이전으로 이동.) 최소 변경 — 한 줄 추가.
+
+**Test**: `subprocess_runner`를 reference 파일이 있는 상태로 호출 → 실행된 solution.py(또는 subprocess가 본 소스)에 `_AVAILABLE_FILES`가 정의돼 있고 그 리스트가 실제 복사된 파일명 목록과 일치하는지 검증. 권장: 생성 코드가 `print(_AVAILABLE_FILES)` 하도록 하여 stdout로 확인하거나, write 후 `code_path` 내용을 단언. reference 파일 없을 때 회귀 없음(기존 동작) 확인.
+
+## Fix 2 — Anthropic `content[0].text` 크래시 + `stop_reason` 미참조
+**BRILLIANT 위치**: `batch-runner/core/llm_client.py:99` — `content = response.content[0].text if response.content else ""` (`AnthropicClient.chat_complete`).
+
+**현 코드 구조**:
+- `NormalizedResponse(content, model, usage)` 는 OpenAI 호환 wrapper: `choices=[_Choice(content)]`, `_Choice.message.content`. **`finish_reason` 속성 없음**.
+- step2_run_inference.py:436 가 `finish_reason = getattr(response.choices[0], "finish_reason", None)` 후 `if finish_reason == "length":` 로 절단 경고. Anthropic 경로는 `_Choice`에 `finish_reason`이 없어 항상 `None` → 절단 영구 미감지.
+
+**문제**: extended thinking / tool_use 켜지면 `response.content[0]` 가 `ThinkingBlock`/`ToolUseBlock` → `.text` 없음 → `AttributeError` 로 태스크/배치 실패. `stop_reason` 도 버려져 `max_tokens` 절단이 "성공"으로 기록.
+
+**Fix**:
+- `response.content` 블록 리스트를 순회, `getattr(block, "type", None) == "text"` 인 블록들의 `.text` 만 결합(빈 경우 `""`). thinking/tool_use 블록은 skip.
+- Anthropic `response.stop_reason` 을 OpenAI 호환 `finish_reason` 으로 매핑하여 `_Choice`/`NormalizedResponse` 에 보존. 매핑: Anthropic `"max_tokens"` → `"length"` (step2:437 `== "length"` 분기 fire), 그 외(`"end_turn"`/`"stop_sequence"`/`"tool_use"`)는 그대로 전달하거나 합리적 호환값. `_Choice`/`NormalizedResponse` 시그니처에 `finish_reason` 인자 추가(기본값으로 기존 호출부 회귀 0).
+
+**Test**:
+- 첫 블록이 thinking, 이후 text 블록 mock → text 정상 추출, no AttributeError
+- 첫 블록이 tool_use, 이후 text → text 정상 추출
+- 첫 블록이 text (기존 케이스) → 기존 동작 동일
+- `stop_reason == "max_tokens"` mock → `response.choices[0].finish_reason == "length"` 확인 (step2 절단 감지 호환)
+- Azure 경로(`_Choice` 기존 사용처) 회귀 0 확인
+
+## Fix 3 — `qa_failed` Dead Invariant
+**BRILLIANT 위치**: `batch-runner/step2_run_inference.py:55`(`RETRIABLE_STATUSES = {"error","qa_failed","pending"}`), `:1208`(`_print_status` `elif result["status"] == "qa_failed"`), `:1410`/`:1426`(summary count). **set 지점 0건.**
+
+**현 코드 (`_run_task_with_qa` 내, while 루프)**:
+- QA 점수 `< min_score` 이고 `qa_attempts >= qa_max_retries` 일 때 `"saving as success"` 출력 후 `break` → best_result 가 `status="success"` 그대로 반환.
+- (별개) undetermined 경로는 의도적으로 `best_qa["passed"]=True`, `"saving as success (undetermined)"` — 이는 의도된 동작이므로 **건드리지 않음** (genuine fail 만 대상).
+
+**Fix**: QA 최종 미달(retry 소진 후에도 `best_score < min_score`, 즉 진짜 QA fail)일 때 반환되는 best_result 의 `status` 를 `"qa_failed"` 로 설정. undetermined 케이스는 제외. → 기존 4개 read site(RETRIABLE / _print_status / summary x2)와 resume `_get_failed_task_ids` retry 인프라가 정상 작동.
+
+**중요 (동작 변경 — extreme-reasoner 검토 필수)**: 지금까지 QA fail 이 silently `success` 통과했는데 이제 `qa_failed` → resume 시 retry 대상. run 시간 + 토큰 비용 증가, 그러나 README "re-runs error/qa_failed automatically" 약속 충족 + 데이터 품질 개선. pre/post-fix run 간 채점 비교가능성(comparability)에 영향 — extreme-reasoner 가 trade-off 판정.
+
+**Test**:
+- Self-QA 가 최종 fail (score < min_score, retry 소진) → 반환 result `status == "qa_failed"` 확인
+- 정상 통과 task → `status == "success"` 유지
+- undetermined 최종 → 기존대로 `"success"` 유지 (회귀 0)
+- `"qa_failed"` 가 `RETRIABLE_STATUSES` 에 의해 retry 대상으로 분기되는지 (state/mock 검증)
+
+## Scope
+**수정 대상**:
+- Fix 1: `batch-runner/core/subprocess_runner.py`
+- Fix 2: `batch-runner/core/llm_client.py`
+- Fix 3: `batch-runner/step2_run_inference.py`
+
+**신규 테스트**:
+- `batch-runner/tests/test_silent_corruption_fixes.py` — 3개 fix 각각의 regression test
+
+**손대지 않을 곳**:
+- `core/needs_files.py`, `core/prompt_classifier.py`, `core/repo_bootstrapper.py` (V2 영역, 회귀 0 유지)
+- step1~7 (step2_run_inference.py 의 위 3 fix 지점 외), `src/`, `scripts/`, `data/`, `tasks/` (이 spec 파일 외)
+- 기존 테스트 파일(test_llm_client.py / test_subprocess_runner.py 등)은 회귀 확인용으로만 실행, 수정 금지
+
+## Acceptance
+- 3개 fix 모두 적용 + 각각 regression test 통과
+- 기존 테스트 회귀 0 (V2: test_prompt_classifier, test_resolve_needs_files, test_policy_guardrails, test_step6_v2_fields) + test_llm_client / test_subprocess_runner 회귀 0
+- `git status`: 명시된 4개 파일(코드 3 + 테스트 1) + 이 spec 파일 외 변경 없음
+- secrets 0
+- extreme-reasoner DECISION: APPROVE 또는 APPROVE-WITH-CONDITIONS (REJECT 시 멈춰서 사용자 컨펌)
+
+## Failure Policy
+- 기존 테스트 회귀 → REJECT, fix 재검토
+- first-reviewer REJECT 1회 재시도
+- extreme-reasoner REJECT → 사용자 컨펌 필수
+
+## Out of Scope
+- Top 1 (main.py 부재) — 반나절 작업, 별도
+- Top 5 (relay 골든테스트) — 1일+ 작업, 별도
+- ⭐⭐⭐⭐ 이하 후보들


### PR DESCRIPTION
Fixes 3 silent corruption paths discovered in BRILLIANT_OPPORTUNITIES.md audit (all ⭐⭐⭐⭐⭐, orchestrator-verified):

## Fixes
1. **`_AVAILABLE_FILES` dead-write** (`batch-runner/core/subprocess_runner.py`): the file-list hint was prepended to a local `code` var but the subprocess executed the un-modified `solution.py` on disk. Now `code_path.write_text(code)` after the prepend so the hint actually reaches execution.
2. **Anthropic `content[0].text` crash + truncation blindness** (`batch-runner/core/llm_client.py`): extended-thinking/tool_use blocks crashed the batch with AttributeError; `stop_reason` was never read. Now iterates content blocks (skips thinking/tool_use) and maps `stop_reason`→OpenAI-style `finish_reason` (`max_tokens`→`length`) on `_Choice`/`NormalizedResponse` so the existing step2 truncation guard fires. Azure path zero-regression via default args.
3. **`qa_failed` dead invariant** (`batch-runner/step2_run_inference.py`): status was read in 4 sites but never set; genuine QA failures were silently saved as `success`. Now sets `best_result['status']='qa_failed'` in the genuine-fail branch only (undetermined branch intentionally untouched), enabling the existing RETRIABLE_STATUSES/resume retry plumbing and fulfilling the README "re-runs error/qa_failed automatically" contract.

## Behavior change note (Fix 3)
Fix 3 is a deliberate behavior change: QA-failed tasks now retry on resume rounds (token/runtime cost up, data quality up). Pre/post-fix run comparability is impacted — `qa_failed` counts were always 0 pre-fix (dead counter); compact-mode parquet may have fewer rows for the same experiment. Flagged and reviewed by extreme-reasoner.

## Tests
`batch-runner/tests/test_silent_corruption_fixes.py` (new, 20 regression tests) — inverse-check confirmed (each fix reverted → its tests fail). Full suite: 140 passed, 0 failures. V2 zero-regression invariant verified (test_prompt_classifier / test_resolve_needs_files / test_policy_guardrails / test_step6_v2_fields all green).

## Reviews
- first-reviewer: **APPROVE** (2 non-blocking MINOR notes)
- extreme-reasoner (mandatory per Fix 3 QA behavior change): **APPROVE-WITH-CONDITIONS** — see PR discussion for cost-guardrail / changelog / observability conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)