### PR TITLE
fix(auth): Azure OIDC only — remove API key env that overrides token provider

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -253,7 +253,7 @@ jobs:
         timeout-minutes: 330    # ← sufficient time for full run, adjust if needed  condition_a
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          # Removed AZURE_OPENAI_API_KEY — openai SDK auto-detects env key and overrides azure_ad_token_provider. OIDC only via DefaultAzureCredential / azure/login@v2.
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
@@ -370,7 +370,7 @@ jobs:
         if: steps.check_condition_b.outputs.has_condition_b == 'true' && steps.check_relay.outputs.needs_relay != 'true' && steps.step2a.outcome == 'success'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          # Removed AZURE_OPENAI_API_KEY — openai SDK auto-detects env key and overrides azure_ad_token_provider. OIDC only via DefaultAzureCredential / azure/login@v2.
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
@@ -414,7 +414,7 @@ jobs:
         if: steps.check_relay.outputs.needs_relay != 'true' && steps.step2a.outcome == 'success'
         env:
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
-          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          # Removed AZURE_OPENAI_API_KEY — openai SDK auto-detects env key and overrides azure_ad_token_provider. OIDC only via DefaultAzureCredential / azure/login@v2.
         run: |
           cd batch-runner
           bash step6_report.sh

--- a/batch-runner/core/llm_client.py
+++ b/batch-runner/core/llm_client.py
@@ -150,25 +150,31 @@ def create_client(
     api_key: str | None = None,
     api_version: str | None = None,
 ) -> AzureOpenAI:
-    """AzureOpenAI 클라이언트 생성 (DefaultAzureCredential 우선, API Key fallback)
+    """AzureOpenAI 클라이언트 생성 (DefaultAzureCredential 전용 / OIDC only)
 
-    인증 우선순위:
-    1. DefaultAzureCredential (Entra ID 토큰) — az login / Managed Identity / OIDC
-    2. API Key fallback — AZURE_OPENAI_API_KEY 환경변수
+    인증 정책:
+    - DefaultAzureCredential (Entra ID 토큰) — az login / Managed Identity / OIDC 전용
+    - API Key fallback 비활성화 (Azure 리소스 disableLocalAuth=true). 또한 openai SDK 가
+      AZURE_OPENAI_API_KEY 환경변수를 자동 픽업해 azure_ad_token_provider 를 silently
+      덮어쓰는 문제 회피.
 
     Args:
         endpoint:    Azure endpoint (기본: AZURE_OPENAI_ENDPOINT 환경변수)
-        api_key:     API key       (기본: AZURE_API_KEY 환경변수)
+        api_key:     (deprecated) 사용되지 않음. fail-loud 진단 목적으로만 남김.
         api_version: API version   (기본: 2025-04-01-preview)
 
     Returns:
         openai.AzureOpenAI 클라이언트
+
+    Raises:
+        ValueError: DefaultAzureCredential 가 실패하면 항상 raise.
+                    로컬: `az login`. CI: azure/login@v2 OIDC step 확인.
     """
     endpoint = endpoint or os.getenv("AZURE_OPENAI_ENDPOINT", DEFAULT_ENDPOINT)
     api_key = api_key or os.getenv("AZURE_OPENAI_API_KEY") or os.getenv("AZURE_API_KEY")
     api_version = api_version or DEFAULT_API_VERSION
 
-    # Priority 1: DefaultAzureCredential (Entra ID token)
+    # OIDC only: DefaultAzureCredential (Entra ID token)
     try:
         from azure.identity import DefaultAzureCredential, get_bearer_token_provider
         credential = DefaultAzureCredential()
@@ -183,20 +189,16 @@ def create_client(
             timeout=480,
         )
     except Exception as e:
-        # Priority 2: API Key fallback
-        if api_key:
-            print(f"   🔑 Auth: API Key (DefaultAzureCredential unavailable: {e})")
-            return AzureOpenAI(
-                azure_endpoint=endpoint,
-                api_key=api_key,
-                api_version=api_version,
-                timeout=480,
-            )
+        # API Key fallback disabled — fail loud with OIDC debug guidance.
+        print(f"   ⚠️  DefaultAzureCredential failed: {e}")
+        print(f"   ⚠️  API Key fallback disabled (Azure disableLocalAuth=true)")
+        print(f"   ⚠️  Local: run 'az login' then retry")
+        print(f"   ⚠️  CI: verify azure/login@v2 OIDC step succeeded")
         raise ValueError(
-            f"No Azure credentials available.\n"
+            f"Azure authentication failed.\n"
             f"  - DefaultAzureCredential failed: {e}\n"
-            f"  - AZURE_OPENAI_API_KEY not set.\n"
-            f"  Run 'az login' or set AZURE_OPENAI_API_KEY."
+            f"  - API key fallback disabled (disableLocalAuth=true).\n"
+            f"  Fix: 'az login' locally, or check OIDC config in GitHub Actions."
         )
 
 
@@ -218,7 +220,7 @@ def create_provider_client(
         AzureOpenAI, openai.OpenAI, or AnthropicClient instance
 
     Environment variables (provider별):
-        azure:     AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY
+        azure:     AZURE_OPENAI_ENDPOINT (OIDC only — DefaultAzureCredential, no API key)
         openai:    OPENAI_API_KEY
         anthropic: ANTHROPIC_API_KEY
     """

--- a/batch-runner/tests/test_llm_client.py
+++ b/batch-runner/tests/test_llm_client.py
@@ -66,58 +66,57 @@ class TestCreateClient:
     """create_client() 팩토리 함수 테스트"""
 
     @patch("core.llm_client.AzureOpenAI")
-    def test_explicit_params_api_key_fallback(self, mock_cls):
-        """DefaultAzureCredential 실패 시 API Key fallback"""
+    def test_api_key_fallback_disabled_raises(self, mock_cls):
+        """DefaultAzureCredential 실패 시 API Key fallback 없이 즉시 raise (OIDC only)"""
         with patch.dict("sys.modules", {"azure.identity": None}):
-            # azure.identity import 실패 → API Key fallback
-            client = create_client(
-                endpoint="https://test.openai.azure.com/",
-                api_key="test-key",
-                api_version="2024-12-01-preview",
-            )
-            call_kwargs = mock_cls.call_args[1]
-            assert call_kwargs["azure_endpoint"] == "https://test.openai.azure.com/"
-            assert call_kwargs["api_key"] == "test-key"
-            assert call_kwargs["api_version"] == "2024-12-01-preview"
+            with pytest.raises(ValueError, match="Azure authentication failed"):
+                create_client(
+                    endpoint="https://test.openai.azure.com/",
+                    api_key="test-key",
+                    api_version="2024-12-01-preview",
+                )
+            mock_cls.assert_not_called()
 
     @patch("core.llm_client.AzureOpenAI")
-    def test_defaults_from_env_api_key_fallback(self, mock_cls):
-        """환경변수 fallback (DefaultAzureCredential 실패 시)"""
+    def test_env_api_key_ignored_when_oidc_unavailable(self, mock_cls):
+        """OIDC 실패 시 env AZURE_API_KEY 가 있어도 사용 안 함 (fail-loud)"""
         with patch.dict("sys.modules", {"azure.identity": None}):
             with patch.dict(os.environ, {
                 "AZURE_OPENAI_ENDPOINT": "https://env-endpoint.azure.com/",
                 "AZURE_API_KEY": "env-key",
             }):
-                create_client()
-                call_kwargs = mock_cls.call_args[1]
-                assert call_kwargs["azure_endpoint"] == "https://env-endpoint.azure.com/"
-                assert call_kwargs["api_key"] == "env-key"
-                assert call_kwargs["api_version"] == DEFAULT_API_VERSION
+                with pytest.raises(ValueError, match="API key fallback disabled"):
+                    create_client()
+                mock_cls.assert_not_called()
 
     @patch("core.llm_client.AzureOpenAI")
     def test_returns_azure_openai_instance(self, mock_cls):
-        """반환 타입이 AzureOpenAI mock 인스턴스"""
-        with patch.dict("sys.modules", {"azure.identity": None}):
-            client = create_client(endpoint="https://x.com/", api_key="k")
+        """반환 타입이 AzureOpenAI mock 인스턴스 (OIDC path)"""
+        mock_identity = MagicMock()
+        mock_identity.DefaultAzureCredential.return_value = MagicMock()
+        mock_identity.get_bearer_token_provider.return_value = MagicMock()
+        with patch.dict("sys.modules", {"azure.identity": mock_identity, "azure": MagicMock()}):
+            client = create_client(endpoint="https://x.com/")
             assert client == mock_cls.return_value
 
     @patch("core.llm_client.AzureOpenAI")
     def test_grok_different_endpoint(self, mock_cls):
-        """Grok용 다른 endpoint — 같은 SDK (API Key fallback)"""
-        with patch.dict("sys.modules", {"azure.identity": None}):
-            create_client(
-                endpoint="https://grok-resource.azure.com/",
-                api_key="grok-key",
-            )
+        """Grok용 다른 endpoint — 같은 SDK (OIDC token provider)"""
+        mock_identity = MagicMock()
+        mock_identity.DefaultAzureCredential.return_value = MagicMock()
+        mock_identity.get_bearer_token_provider.return_value = MagicMock()
+        with patch.dict("sys.modules", {"azure.identity": mock_identity, "azure": MagicMock()}):
+            create_client(endpoint="https://grok-resource.azure.com/")
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["azure_endpoint"] == "https://grok-resource.azure.com/"
-            assert call_kwargs["api_key"] == "grok-key"
+            assert "azure_ad_token_provider" in call_kwargs
+            assert "api_key" not in call_kwargs
 
     def test_no_credentials_raises(self):
-        """DefaultAzureCredential 실패 + API Key 없으면 ValueError"""
+        """DefaultAzureCredential 실패 시 항상 ValueError (OIDC only)"""
         with patch.dict("sys.modules", {"azure.identity": None}):
             with patch.dict(os.environ, {}, clear=True):
-                with pytest.raises(ValueError, match="No Azure credentials available"):
+                with pytest.raises(ValueError, match="Azure authentication failed"):
                     create_client(endpoint="https://x.com/")
 
     @patch("core.llm_client.AzureOpenAI")

--- a/tasks/TASK_FIX_AZURE_OIDC_ONLY.md
+++ b/tasks/TASK_FIX_AZURE_OIDC_ONLY.md
@@ -1,0 +1,80 @@
+# TASK_FIX_AZURE_OIDC_ONLY — Azure 인증 OIDC 전용 강제
+
+## 배경
+exp025 dry_run에서 220/220 inference 실패 (403 AuthenticationTypeDisabled).
+
+## 진단 (Claude Desktop 분석 정정)
+
+**Claude Desktop 분석은 부분 오류:**
+- spec 주장: "create_client() except의 API key fallback이 key 인증 시도"
+- **실제**: fallback **미도달**. OIDC try 블록 정상 성공:
+  ```
+  🔐 Auth: DefaultAzureCredential (Entra ID token)  ← 정상 출력됨
+  [1/220] ✗ 403 - AuthenticationTypeDisabled        ← 그래도 403
+  ```
+
+**진짜 원인 (검증 완료):**
+`openai` SDK의 `AzureOpenAI` 클래스가 환경변수 `AZURE_OPENAI_API_KEY`를 **자동 감지**해
+`api-key` 헤더로 전송. 우리가 명시한 `azure_ad_token_provider`를 silently 덮어씀.
+Azure 리소스 `disableLocalAuth=true`라 키 거부 → 403.
+
+검증 근거: `batch-runner/core/llm_client.py:172-184` 의 OIDC `try` 블록이
+`return AzureOpenAI(azure_ad_token_provider=token_provider, ...)` 로 정상 반환하며
+`🔐 Auth: DefaultAzureCredential` 로그가 실제 출력됨. except fallback(187-194)은
+도달조차 안 됨. 그럼에도 403 발생 → SDK가 env 의 키를 자동 픽업해 헤더에 실은 것.
+
+## 수정 사항
+
+### Fix A — `.github/workflows/batch-run.yml` (정확히 3곳)
+다음 3개 step 의 env 블록에서 `AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}` 줄 제거:
+1. **Step 2a** (line 256, `'Step 2a: Run inference (condition_a)'`)
+2. **Step 2b** (line 373, `'Step 2b: Run inference (condition_b)'`)
+3. **Step 6** (line 417, `'Step 6: Generate experiment report'` — Desktop spec 누락분, step6도
+   `step6_report.sh` → `create_client()` 호출, continue-on-error: true)
+
+유지: `AZURE_OPENAI_ENDPOINT`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` (다른 provider 용).
+(Step 6 env 는 원래 `AZURE_OPENAI_ENDPOINT` + `AZURE_OPENAI_API_KEY` 둘뿐 →
+ENDPOINT 만 남김)
+
+주석 추가 (각 제거 위치 또는 대표 위치):
+`# Removed AZURE_OPENAI_API_KEY — openai SDK auto-detects env key and overrides azure_ad_token_provider. OIDC only via DefaultAzureCredential / azure/login@v2.`
+
+### Fix B — `batch-runner/core/llm_client.py` `create_client()`
+except 블록(현 185-200)의 API key fallback `if api_key: return AzureOpenAI(api_key=...)`
+분기를 제거하고, 항상 명시적 raise 로 변경 (fail-loud):
+
+```python
+except Exception as e:
+    print(f"   ⚠️  DefaultAzureCredential failed: {e}")
+    print(f"   ⚠️  API Key fallback disabled (Azure disableLocalAuth=true)")
+    print(f"   ⚠️  Local: run 'az login' then retry")
+    print(f"   ⚠️  CI: verify azure/login@v2 OIDC step succeeded")
+    raise ValueError(
+        f"Azure authentication failed.\n"
+        f"  - DefaultAzureCredential failed: {e}\n"
+        f"  - API key fallback disabled (disableLocalAuth=true).\n"
+        f"  Fix: 'az login' locally, or check OIDC config in GitHub Actions."
+    )
+```
+
+(이 버그의 직접 fix 아님 — fail-loud 하드닝. 미래 다른 인증 실패를 silent 로 만들지 않음.
+docstring 의 "API Key fallback" 표현도 현실에 맞게 정정 권장.)
+
+## Acceptance
+- workflow YAML 3곳에서 AZURE_OPENAI_API_KEY 제거 (grep 결과 0건)
+- llm_client.py except 블록이 raise (api_key 분기 제거)
+- 다른 provider(anthropic, openai-native) 무영향
+- V2 + silent-corruption 회귀 0 (140+ passed 유지)
+- workflow YAML 정합성 OK (yaml.safe_load 통과)
+- secrets 0 (env 줄 제거하는 거지 노출 X)
+
+## Failure Policy
+- 기존 테스트 회귀 → REJECT
+- first-reviewer/extreme-reasoner REJECT → 1회 재시도
+- 분류기 차단 → 즉시 중단 + 보고
+
+## Out of Scope
+- Azure App Registration / OIDC 설정 변경
+- 다른 provider 로직
+- 다른 workflow 파일
+- 대시보드 / UI


### PR DESCRIPTION
Unblocks exp025 dry_run (220/220 403 AuthenticationTypeDisabled).

**Real cause** (Desktop spec was partially wrong): the `openai` SDK's `AzureOpenAI` auto-detects the `AZURE_OPENAI_API_KEY` env var and silently overrides our explicit `azure_ad_token_provider` → 403 on `disableLocalAuth=true`. The except-block fallback was never reached (OIDC `try` succeeds and logs `🔐 Auth: DefaultAzureCredential`).

**Fix:**
- Fix A: remove `AZURE_OPENAI_API_KEY` env from **3** workflow steps — Step 2a, Step 2b, **and Step 6** (which Desktop missed). `AZURE_OPENAI_ENDPOINT`/`OPENAI_API_KEY`/`ANTHROPIC_API_KEY` preserved.
- Fix B: `llm_client.create_client()` except block now fail-loud raises `ValueError` with OIDC debug guidance (no silent key fallback).
- Tests updated for the new OIDC-only contract; docstring corrected.

**Reviews:** first-reviewer **APPROVE** (0 BLOCK/MAJOR); extreme-reasoner **APPROVE-WITH-CONDITIONS** (verified: core 52 passed, full-suite 0 regressions vs baseline, YAML valid). Note: `code_interpreter.py`/`narrative_analyzer.py` share the same SDK pattern but are neutralized in CI by the env strip — local-dev hardening tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)