### PR TITLE
fix(step2): add wall-timeout watchdog to Resume Round + widen step timeout margin

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -250,7 +250,9 @@ jobs:
 
       - name: 'Step 2a: Run inference (condition_a)'
         id: step2a
-        timeout-minutes: 330    # ← sufficient time for full run, adjust if needed  condition_a
+        # Must exceed wall_timeout (default 290min) by enough margin to
+        # cover checkpoint save + HF upload + relay re-trigger handoff.
+        timeout-minutes: 350    # = wall_timeout(290) + 60min margin for relay handoff
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # Removed AZURE_OPENAI_API_KEY — openai SDK auto-detects env key and overrides azure_ad_token_provider. OIDC only via DefaultAzureCredential / azure/login@v2.
@@ -366,7 +368,7 @@ jobs:
           echo "Condition B exists: $HAS_CONDITION_B"
 
       - name: 'Step 2b: Run inference (condition_b)'
-        timeout-minutes: 330
+        timeout-minutes: 350    # mirrors Step 2a — wall_timeout(290) + 60min relay margin
         if: steps.check_condition_b.outputs.has_condition_b == 'true' && steps.check_relay.outputs.needs_relay != 'true' && steps.step2a.outcome == 'success'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -1372,6 +1372,31 @@ def run_inference(
 
         recovered = 0
         for fi, fail_info in enumerate(failed, 1):
+            # ── Watchdog: wall-clock timeout check (resume round) ──
+            # Without this, a long Round 0 followed by heavy resume retries
+            # silently exceeds the GitHub Actions step timeout — preventing
+            # the relay handoff and forcing a full re-run from scratch.
+            if wall_deadline and time.time() >= wall_deadline:
+                still_remaining = failed[fi - 1:]
+                print(f"\n⏰ Wall timeout reached in Resume Round {round_num} "
+                      f"({wall_timeout}min). Saving checkpoint "
+                      f"({fi - 1}/{len(failed)} retried, "
+                      f"{len(still_remaining)} deferred to relay)...")
+                # Mark unfinished retriable tasks as pending → next relay picks them up
+                still_remaining_ids = {f["task_id"] for f in still_remaining}
+                for r in progress["results"]:
+                    if r["task_id"] in still_remaining_ids:
+                        r["status"] = "pending"
+                        r["error"] = "wall_timeout"
+                        r["timestamp"] = datetime.now(timezone.utc).isoformat()
+                progress["resume_round"] = round_num
+                _save_progress(
+                    experiment_id, condition_name, execution_mode,
+                    total, progress["results"], started_at, progress_path,
+                )
+                print(f"   💾 Checkpoint saved to {progress_path}")
+                sys.exit(EXIT_CHECKPOINT)
+
             task_id = fail_info["task_id"]
             task = task_map.get(task_id)
             if task is None:


### PR DESCRIPTION
## 🐛 Bug

When Round 0 completes within `wall_timeout`, the **Resume Round loop** (`step2_run_inference.py` L1360+) had **no `wall_deadline` check**. Heavy resume retries (Self-QA, audio preprocessor, video composition) then silently exceed the GitHub Actions step hard timeout (330min). On SIGKILL the run cannot save a checkpoint or mark `pending` tasks — so `needs_relay=false` and the relay handoff is bypassed entirely, requiring a **full re-run from scratch**.

### Repro (observed in run [#26018603400](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/26018603400), exp025)

| Phase | Time | Outcome |
|-------|------|---------|
| Round 0 (220 tasks) | ~250min | finished, 86 failed |
| Resume Round 1 | reached 63/86 at ~330min | **SIGKILL** by step timeout |
| Relay handoff | — | not triggered (`pending=0, needs_relay=false`) |
| Final | — | `Step 2a failed (not a relay timeout)` → exit 1 |

## 🔧 Fix

1. **`step2_run_inference.py`** — mirror the existing Round 0 / Relay-run watchdog inside the Resume Round loop. On `wall_timeout` fire:
   - mark all unfinished retriable tasks as `pending(error=wall_timeout)`
   - `_save_progress()`
   - `sys.exit(EXIT_CHECKPOINT)` (42) → workflow uploads checkpoint to HF and self-retriggers
2. **`.github/workflows/batch-run.yml`** — widen Step 2a/2b `timeout-minutes` 330 → 350. After `wall_timeout(290)` fires, this leaves a **60min margin** to save + upload the checkpoint and dispatch the relay run before the hard timeout kicks in.

## ✅ Tests

- `tests/test_relay_duration.py`: **4 passed**
- Manual smoke recommended (next sprint) with `execution.wall_timeout: 5` on an `exp998` YAML to verify relay#1 / relay#2 trigger from inside Resume Round.

## 🔁 Operational follow-up

Once merged, the failed exp025 run needs a clean re-trigger:

```
GH Actions → Run workflow:
  experiment_yaml: exp025_GPT54_high_postfix
  relay_run: 0
  wall_timeout: 290
  dry_run: false
```

The previous run never uploaded a checkpoint to HF, so no cleanup of `_checkpoint/` is required. The submission repo (`hyeonsangjeon/exp025_GPT54_high_postfix`) created by step0 is idempotent on re-bootstrap.

## 📋 Risk

- **Behavior change scope:** only the Resume Round loop. Round 0 and Relay-run paths are untouched (already had the watchdog).
- **Backward compat:** `wall_timeout=0` (no timeout) still works — the `if wall_deadline and ...` guard short-circuits.
- **Tests:** existing relay regression suite still green.

Closes the silent-relay-bypass condition observed in run 26018603400.