### PR TITLE
fix(grader): drop seed/temperature from Responses API call

### DIFF
--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -496,12 +496,14 @@ class Grader:
             self._apply_tpm_delay()
             start = time.time()
             try:
+                # Azure OpenAI Responses API for reasoning models (e.g.,
+                # gpt-5.4-pro) does NOT accept temperature/seed. These values
+                # are kept in config as reproducibility metadata only and
+                # stamped into the grade JSON, but are not passed to the SDK.
                 response = self.client.responses.create(
                     model=self.model,
                     input=prompt,
-                    temperature=float(gen.get("temperature", 0)),
                     max_output_tokens=max_output,
-                    seed=int(gen.get("seed", 42)),
                     reasoning={"effort": reasoning.get("effort", "high")},
                 )
                 latency_ms = (time.time() - start) * 1000

--- a/batch-runner/tests/test_grader.py
+++ b/batch-runner/tests/test_grader.py
@@ -16,11 +16,13 @@ class _FakeClient:
     def __init__(self, error=None):
         self.responses = self
         self.calls = 0
+        self.last_kwargs = None
         self.error = error
         self._next_text = '{"verdict":"pass","partial_score":1.0,"evidence":"ok","confidence":0.8,"reasoning":"ok"}'
 
     def create(self, **kwargs):
         self.calls += 1
+        self.last_kwargs = kwargs
         if self.error:
             raise self.error
 
@@ -195,6 +197,28 @@ def test_tpm_delay_between_judge_calls(monkeypatch, tmp_path):
     grader._apply_tpm_delay()
 
     assert sleeps == [pytest.approx(0.4)]
+
+
+def test_call_judge_does_not_pass_seed_or_temperature(monkeypatch, tmp_path):
+    """Azure Responses API for reasoning models rejects seed/temperature.
+
+    Regression guard for run #26210354117 where every judge call failed with
+    'Responses.create() got an unexpected keyword argument seed'.
+    """
+    grader = _make_grader(monkeypatch, tmp_path)
+    deliverable = tmp_path / "d.txt"
+    deliverable.write_text("content", encoding="utf-8")
+    item = RubricItem("r1", "evaluate quality", 3, None)
+
+    grader._judge(_task(item), item, [deliverable])
+
+    kwargs = grader._fake_client.last_kwargs
+    assert kwargs is not None
+    assert "seed" not in kwargs
+    assert "temperature" not in kwargs
+    assert kwargs["model"] == "gpt-5.4-pro"
+    assert kwargs["reasoning"] == {"effort": "high"}
+    assert "max_output_tokens" in kwargs
 
 
 def test_aggregate_pct_calculation(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem
After PR #44 merge, the first real-grade smoke run (#26210354117) completed `success` at the workflow level but every LLM-judge call failed:

```
Judge call failed for <task_id> after retries: Responses.create() got an unexpected keyword argument 'seed'
```

Result: 84 / 84 judge items marked `judge_error`, `judge_err_rate = 1.0`, `input_tokens = 0`.

## Root cause
Azure OpenAI Responses API for reasoning models (e.g. `gpt-5.4-pro`) does NOT accept `seed` or `temperature` kwargs (those are Chat Completions only). `narrative_analyzer.py` already calls it correctly without these args; the grader did not.

## Fix
- Remove `seed` and `temperature` from `client.responses.create()` call in [batch-runner/core/grader.py](batch-runner/core/grader.py)
- Keep `seed: 42` / `temperature: 0` in grading config as reproducibility metadata only — they continue to be stamped into the grade JSON under `judge.seed` / `judge.temperature`
- Add regression test `test_call_judge_does_not_pass_seed_or_temperature` to ensure these kwargs never re-enter the call

## Validation
- `pytest -q tests/test_grader.py tests/test_step8_grade.py tests/test_grading_config.py tests/test_grade_schema.py tests/test_rubric_loader.py tests/test_download_inference_from_hf.py` → 39 passed
- Will re-dispatch `grade-run.yml` smoke (exp998, limit=3, dry_run=false) immediately after merge

## Scope
- Single file: `core/grader.py` (1 location) + 1 test addition
- No schema or workflow changes
