### PR TITLE
feat(grading): Phase A wow — narrative + dashboard integration

### DIFF
--- a/batch-runner/core/narrative_analyzer.py
+++ b/batch-runner/core/narrative_analyzer.py
@@ -42,6 +42,166 @@ class NarrativeResult:
     call_1_latency_ms: float = 0.0
     call_2_latency_ms: float = 0.0
     total_tokens: dict = field(default_factory=lambda: {"input": 0, "output": 0})
+    grading_referenced: bool = False
+    grade_source: dict | None = None
+
+
+# ─── Grading Prompt Helpers ───────────────────────────────────────────────
+
+
+def _get_nested(source: dict | None, path: list[str], default=None):
+    """Read a nested dict key path without raising on malformed grade data."""
+    current = source
+    for key in path:
+        if not isinstance(current, dict):
+            return default
+        current = current.get(key)
+    return default if current is None else current
+
+
+def _format_pct(value, decimals: int = 1, scale_fraction: bool = True) -> str:
+    """Format a percent-like value, accepting either 0-1 rates or 0-100 values."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return "n/a"
+    if scale_fraction and abs(number) <= 1:
+        number *= 100
+    return f"{number:.{decimals}f}%"
+
+
+def _build_grade_source(grade: dict | None) -> dict | None:
+    """Return compact grade provenance for report_data.json."""
+    if grade is None:
+        return None
+    return {
+        "model": _get_nested(grade, ["judge", "model"], ""),
+        "rubric_sha": _get_nested(grade, ["rubric", "short_sha"], ""),
+        "prompt_v": _get_nested(grade, ["prompt", "version"], ""),
+        "graded_at": grade.get("graded_at", ""),
+    }
+
+
+def _build_grading_guard_clause(grade: dict | None) -> str:
+    """Return narrative guard text for pre-grading vs grade-aware prompts."""
+    if grade is None:
+        return (
+            "- Grading scores do NOT exist yet. Do NOT mention or predict "
+            "grades. Focus only on execution metrics and Self-QA scores."
+        )
+
+    judge_model = _get_nested(grade, ["judge", "model"], "unknown judge")
+    reasoning_effort = _get_nested(grade, ["judge", "reasoning_effort"], "unknown")
+    rubric_repo = _get_nested(grade, ["rubric", "repo_id"], "openai/gdpval")
+    rubric_sha = _get_nested(grade, ["rubric", "short_sha"], "unknown")
+
+    return f"""- Grading scores ARE available (see GRADING RESULTS section below).
+- Source: rubric-based LLM-judge ({judge_model}, reasoning_effort={reasoning_effort}).
+- This is NOT human expert review; it is an automated LLM-judge score
+  against open-sourced GDPval rubrics ({rubric_repo} @ {rubric_sha}).
+- Refer to scores as "LLM-judge grade" or "rubric-based score"; avoid
+  wording that implies human expert review or OpenAI-hosted official scoring.
+- Highlight: weakest sector, strongest sector, critical_item_pass_rate,
+  precheck vs judge breakdown."""
+
+
+def _build_grading_disclosure_paragraph(grade: dict | None) -> str:
+    """Disclosure paragraph the model must include in overview when grades exist."""
+    judge_model = _get_nested(grade, ["judge", "model"], "unknown judge")
+    rubric_sha = _get_nested(grade, ["rubric", "short_sha"], "unknown")
+    return (
+        f"The grading shown is automated via LLM-judge ({judge_model}) against "
+        "open-sourced GDPval rubrics ([openai/gdpval]"
+        "(https://huggingface.co/datasets/openai/gdpval), "
+        f"commit `{rubric_sha}`). OpenAI ended hosted grading and open-sourced "
+        "their rubrics for community self-evaluation."
+    )
+
+
+def _format_sector_grade_line(sector: str, metrics: dict) -> str:
+    """Format one sector line for the GRADING RESULTS prompt section."""
+    return (
+        f"  - {sector}: avg_pct={_format_pct(metrics.get('avg_pct'), decimals=1)}, "
+        f"crit={_format_pct(metrics.get('critical_item_pass_rate'), decimals=0)}, "
+        f"pre={_format_pct(metrics.get('precheck_pass_rate'), decimals=0)}, "
+        f"judge={_format_pct(metrics.get('judge_pass_rate'), decimals=0)}"
+    )
+
+
+def _rank_grade_sectors(grade: dict | None) -> tuple[list[str], list[str]]:
+    """Return formatted weakest and strongest sector lines, ranked by avg_pct."""
+    by_sector = _get_nested(grade, ["summary", "wow", "by_sector"], {})
+    if not isinstance(by_sector, dict):
+        return ["  - n/a"], ["  - n/a"]
+
+    ranked = []
+    for sector, metrics in by_sector.items():
+        if not isinstance(metrics, dict):
+            continue
+        try:
+            avg_pct = float(metrics.get("avg_pct"))
+        except (TypeError, ValueError):
+            avg_pct = float("-inf")
+        ranked.append((avg_pct, sector, metrics))
+
+    if not ranked:
+        return ["  - n/a"], ["  - n/a"]
+
+    weakest = [
+        _format_sector_grade_line(sector, metrics)
+        for _, sector, metrics in sorted(ranked, key=lambda item: item[0])[:3]
+    ]
+    strongest = [
+        _format_sector_grade_line(sector, metrics)
+        for _, sector, metrics in sorted(ranked, key=lambda item: item[0], reverse=True)[:3]
+    ]
+    return weakest, strongest
+
+
+def _build_grading_results_section(grade: dict | None) -> str:
+    """Build the optional GRADING RESULTS prompt section from schema v1 grade JSON."""
+    if grade is None:
+        return ""
+
+    openai_compat = _get_nested(grade, ["summary", "openai_compat"], {})
+    wow = _get_nested(grade, ["summary", "wow"], {})
+    if not isinstance(openai_compat, dict):
+        openai_compat = {}
+    if not isinstance(wow, dict):
+        wow = {}
+
+    total_tasks = (
+        openai_compat.get("total_tasks")
+        or _get_nested(grade, ["summary", "total_tasks"], "")
+        or ""
+    )
+    weakest, strongest = _rank_grade_sectors(grade)
+
+    return f"""
+## GRADING RESULTS (LLM-judge, rubric-based)
+
+Judge: {_get_nested(grade, ["judge", "model"], "unknown")} (reasoning_effort={_get_nested(grade, ["judge", "reasoning_effort"], "unknown")}, temperature={_get_nested(grade, ["judge", "temperature"], "unknown")})
+Rubric source: {_get_nested(grade, ["rubric", "repo_id"], "openai/gdpval")} @ {_get_nested(grade, ["rubric", "short_sha"], "unknown")}
+
+Overall:
+  - Average score: {_format_pct(openai_compat.get("avg_score_pct"), decimals=1)} (± {_format_pct(openai_compat.get("ci_pct"), decimals=1)})
+  - Perfect tasks (100%): {openai_compat.get("perfect_count", "n/a")}/{total_tasks or "n/a"}
+  - Zero tasks (0%): {openai_compat.get("zero_count", "n/a")}/{total_tasks or "n/a"}
+  - Critical item pass rate: {_format_pct(wow.get("critical_item_pass_rate"), decimals=0)}
+  - Precheck pass rate: {_format_pct(wow.get("precheck_pass_rate"), decimals=0)}
+  - Judge pass rate: {_format_pct(wow.get("judge_pass_rate"), decimals=0)}
+
+By sector (top 3 weakest):
+{chr(10).join(weakest)}
+
+By sector (top 3 strongest):
+{chr(10).join(strongest)}
+
+Failure pattern hint (precheck vs judge):
+  - Precheck failures dominate: deliverable structure issues (file naming, format)
+  - Judge failures dominate: content quality / domain reasoning issues
+  - Mixed: see by_rubric_category
+"""
 
 
 # ─── NarrativeAnalyzer ────────────────────────────────────────────────────
@@ -94,6 +254,7 @@ class NarrativeAnalyzer:
         sector_breakdown: list[dict],
         task_results: list[dict],
         error_tasks: list[dict],
+        grade: dict | None = None,
     ) -> NarrativeResult:
         """Run 2-call sequential analysis and return NarrativeResult.
 
@@ -103,6 +264,7 @@ class NarrativeAnalyzer:
             sector_breakdown: List of per-sector stat dicts
             task_results:     ALL task result dicts (full 220)
             error_tasks:      Error task dicts with error messages
+            grade:            Optional schema v1.0 grade JSON dict
 
         Returns:
             NarrativeResult with all four narrative sections + metrics
@@ -115,7 +277,7 @@ class NarrativeAnalyzer:
         self._start_heartbeat()
         try:
             call1_result, call1_latency, c1_in, c1_out = self._call_1_sector_analysis(
-                data, summary, sector_breakdown
+                data, summary, sector_breakdown, grade=grade
             )
         finally:
             self._stop_heartbeat()
@@ -129,7 +291,7 @@ class NarrativeAnalyzer:
         self._start_heartbeat()
         try:
             call2_result, call2_latency, c2_in, c2_out = self._call_2_deep_analysis(
-                call1_result, task_results, error_tasks
+                call1_result, task_results, error_tasks, grade=grade
             )
         finally:
             self._stop_heartbeat()
@@ -146,16 +308,36 @@ class NarrativeAnalyzer:
             call_1_latency_ms=call1_latency,
             call_2_latency_ms=call2_latency,
             total_tokens={"input": total_input, "output": total_output},
+            grading_referenced=grade is not None,
+            grade_source=_build_grade_source(grade),
         )
 
     # ── Call 1 ─────────────────────────────────────────────────────────
 
     def _call_1_sector_analysis(
-        self, data: dict, summary: dict, sector_breakdown: list[dict]
+        self,
+        data: dict,
+        summary: dict,
+        sector_breakdown: list[dict],
+        grade: dict | None = None,
     ) -> tuple[dict, float, int, int]:
         """Sector-level analysis → overview + quality_analysis."""
 
         meta = data.get("meta", data)  # support both report_data and raw data
+        grading_guard = _build_grading_guard_clause(grade)
+        grading_overview_instruction = ""
+        overview_grading_clause = ""
+        if grade is not None:
+            disclosure = _build_grading_disclosure_paragraph(grade)
+            grading_overview_instruction = (
+                '\n- In the "overview" field, you MUST include exactly one paragraph '
+                "explaining that grading is automated LLM-judge based, citing the "
+                "judge model and the rubric source/commit. Use this verbatim "
+                f"paragraph: {disclosure}"
+            )
+            overview_grading_clause = (
+                f" Include this exact disclosure paragraph once: {disclosure}"
+            )
 
         sector_lines = "\n".join(
             f"  - {s['sector']}: {s['success']}/{s['total']} success "
@@ -183,15 +365,15 @@ Sector breakdown:
 {sector_lines}
 
 IMPORTANT CONSTRAINTS:
-- Grading scores do NOT exist yet. Do NOT mention or predict grades.
+{grading_guard}
 - Focus ONLY on: task completion, Self-QA scores, latency patterns, sector/occupation observations, deliverable file generation quality.
 - Use "self-assessed confidence" / "LLM-evaluated quality" framing.
 - Write as a technical evaluator, NOT a marketer.
-- Be concise and factual.
+- Be concise and factual.{grading_overview_instruction}
 
 Return ONLY valid JSON (no markdown code fences) with these exact keys:
 {{
-  "overview": "3-4 paragraphs: what experiment was run, task execution outcomes based on Self-QA confidence scores, and key highlights. Use language like 'self-assessed confidence', 'task completion rate', 'LLM-evaluated quality'.",
+  "overview": "3-4 paragraphs: what experiment was run, task execution outcomes based on Self-QA confidence scores, and key highlights. Use language like 'self-assessed confidence', 'task completion rate', 'LLM-evaluated quality'.{overview_grading_clause}",
   "quality_analysis": "3-4 paragraphs: QA score distribution patterns, notable sector-level differences, occupation-specific observations, latency correlations with quality."
 }}"""
 
@@ -204,9 +386,15 @@ Return ONLY valid JSON (no markdown code fences) with these exact keys:
     # ── Call 2 ─────────────────────────────────────────────────────────
 
     def _call_2_deep_analysis(
-        self, call1_result: dict, task_results: list[dict], error_tasks: list[dict]
+        self,
+        call1_result: dict,
+        task_results: list[dict],
+        error_tasks: list[dict],
+        grade: dict | None = None,
     ) -> tuple[dict, float, int, int]:
         """Deep analysis with ALL task results → failure_patterns + recommendations."""
+        grading_guard = _build_grading_guard_clause(grade)
+        grading_results_section = _build_grading_results_section(grade)
 
         # Build compact task details for ALL tasks
         task_details = []
@@ -241,6 +429,11 @@ FULL TASK RESULTS ({len(task_results)} tasks):
 
 ERROR TASKS ({len(error_tasks)} errors):
 {error_json}
+
+IMPORTANT CONSTRAINTS:
+{grading_guard}
+
+{grading_results_section}
 
 ANALYSIS INSTRUCTIONS:
 1. Examine ALL {len(task_results)} tasks — not just failures.

--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -32,12 +32,18 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPT_DIR))
 
 from core.config import NEEDS_FILES_POLICIES_KNOWN, WORKSPACE_DIR
+from core.narrative_analyzer import (
+    _build_grade_source,
+    _build_grading_guard_clause,
+    _build_grading_results_section,
+)
 
 
 # ── Defaults ──────────────────────────────────────────────────────────────
 
 DEFAULT_RESULT_JSON = WORKSPACE_DIR / "result.json"
 DEFAULT_OUTPUT_DIR = WORKSPACE_DIR / "report"
+GRADE_DIR = _SCRIPT_DIR.parent / "data" / "grades"
 
 
 # ── V2 manifest helpers ───────────────────────────────────────────────────
@@ -92,6 +98,26 @@ def _find_result_json(default_path: Path) -> Path:
     print("   Run step3_format_results.sh first (it writes workspace/result.json),")
     print("   or specify --result-json path/to/result.json")
     sys.exit(1)
+
+
+def _load_grade_for_experiment(exp_id: str) -> dict | None:
+    """Load the most recent schema v1.0 grade JSON for an experiment."""
+    candidates = sorted(
+        GRADE_DIR.glob(f"{exp_id}__*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for path in candidates:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                grade = json.load(f)
+        except Exception:
+            continue
+        if grade.get("_meta", {}).get("is_dummy") is True:
+            continue
+        if grade.get("schema_version") == "1.0":
+            return grade
+    return None
 
 
 def _compute_summary(data: dict) -> dict:
@@ -193,13 +219,20 @@ def _build_task_results(data: dict, manifest=None) -> tuple[list[dict], list[dic
 # ── LLM Narrative ─────────────────────────────────────────────────────────
 
 
-def _generate_narrative(data: dict, summary: dict, sector_breakdown: list[dict]) -> dict:
+def _generate_narrative(
+    data: dict,
+    summary: dict,
+    sector_breakdown: list[dict],
+    grade: dict | None = None,
+) -> dict:
     """Call Azure OpenAI once and return narrative dict. Never crashes."""
     empty = {
         "overview": "",
         "quality_analysis": "",
         "failure_patterns": "",
         "recommendations": "",
+        "grading_referenced": grade is not None,
+        "grade_source": _build_grade_source(grade),
     }
 
     try:
@@ -216,6 +249,8 @@ def _generate_narrative(data: dict, summary: dict, sector_breakdown: list[dict])
 
         error_count = summary["error_count"]
         retried_count = summary["retried_count"]
+        grading_guard = _build_grading_guard_clause(grade)
+        grading_results_section = _build_grading_results_section(grade)
 
         prompt_content = f"""You are a technical evaluator reviewing an LLM experiment run.
 
@@ -237,10 +272,12 @@ Sector breakdown:
 {sector_lines}
 
 IMPORTANT CONSTRAINTS:
-- Grading scores do NOT exist yet. Do NOT mention or predict grades.
+{grading_guard}
 - Focus ONLY on: task completion, Self-QA scores, latency patterns, sector/occupation observations, deliverable file generation quality.
 - Write as a technical evaluator, NOT a marketer.
 - Be concise and factual.
+
+{grading_results_section}
 
 Return ONLY valid JSON with these exact keys (no markdown code fences):
 {{
@@ -267,6 +304,8 @@ Return ONLY valid JSON with these exact keys (no markdown code fences):
         for key in ("overview", "quality_analysis", "failure_patterns", "recommendations"):
             if key not in narrative:
                 narrative[key] = ""
+        narrative["grading_referenced"] = grade is not None
+        narrative["grade_source"] = _build_grade_source(grade)
         return narrative
 
     except Exception as exc:
@@ -303,6 +342,8 @@ def _build_report_data(data: dict, narrative: dict, summary: dict,
             "quality_analysis": narrative.get("quality_analysis", ""),
             "failure_patterns": narrative.get("failure_patterns", ""),
             "recommendations": narrative.get("recommendations", ""),
+            "grading_referenced": bool(narrative.get("grading_referenced", False)),
+            "grade_source": narrative.get("grade_source"),
         },
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
@@ -987,20 +1028,27 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
             "quality_analysis": "",
             "failure_patterns": "",
             "recommendations": "",
+            "grading_referenced": False,
+            "grade_source": None,
         }
         print("   Skipping narrative (--no-narrative)")
     else:
+        grade = _load_grade_for_experiment(data.get("experiment_id", ""))
         # Try GPT-5.4 Pro (Responses API) first, fallback to standard
         try:
             from core.narrative_analyzer import create_narrative_analyzer
             print("   Generating narrative via GPT-5.4 Pro (Responses API)…")
             analyzer = create_narrative_analyzer()
-            result = analyzer.analyze(data, summary, sector_breakdown, task_results, error_tasks)
+            result = analyzer.analyze(
+                data, summary, sector_breakdown, task_results, error_tasks, grade=grade
+            )
             narrative = {
                 "overview": result.overview,
                 "quality_analysis": result.quality_analysis,
                 "failure_patterns": result.failure_patterns,
                 "recommendations": result.recommendations,
+                "grading_referenced": result.grading_referenced,
+                "grade_source": result.grade_source,
             }
             total_ms = result.call_1_latency_ms + result.call_2_latency_ms
             print(f"   ✅ Pro narrative generated ({total_ms:,.0f}ms, "
@@ -1008,7 +1056,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
         except Exception as exc:
             print(f"   ⚠️ Pro narrative failed: {exc}")
             print(f"   Falling back to standard narrative…")
-            narrative = _generate_narrative(data, summary, sector_breakdown)
+            narrative = _generate_narrative(data, summary, sector_breakdown, grade=grade)
 
     # Build report_data.json
     rd = _build_report_data(data, narrative, summary, sector_breakdown, task_results, error_tasks)

--- a/batch-runner/tests/test_narrative_grade_integration.py
+++ b/batch-runner/tests/test_narrative_grade_integration.py
@@ -1,0 +1,227 @@
+"""Tests for grade-aware narrative integration."""
+
+import json
+import os
+from pathlib import Path
+
+from core.narrative_analyzer import NarrativeAnalyzer
+import step6_report
+
+
+def _minimal_grade(model: str = "gpt-5.4-pro", avg: float = 67.4) -> dict:
+    return {
+        "schema_version": "1.0",
+        "judge": {
+            "model": model,
+            "reasoning_effort": "high",
+            "temperature": 0,
+        },
+        "rubric": {
+            "repo_id": "openai/gdpval",
+            "short_sha": "11e7900",
+        },
+        "prompt": {"version": "v1"},
+        "graded_at": "2026-05-20T12:34:56Z",
+        "summary": {
+            "total_tasks": 5,
+            "openai_compat": {
+                "avg_score_pct": avg,
+                "ci_pct": 4.2,
+                "perfect_count": 1,
+                "zero_count": 1,
+                "total_tasks": 5,
+            },
+            "wow": {
+                "critical_item_pass_rate": 0.71,
+                "precheck_pass_rate": 0.92,
+                "judge_pass_rate": 0.64,
+                "by_sector": {
+                    "Information": {
+                        "avg_pct": 71.2,
+                        "critical_item_pass_rate": 0.75,
+                        "precheck_pass_rate": 0.91,
+                        "judge_pass_rate": 0.68,
+                        "task_count": 2,
+                    },
+                    "Finance": {
+                        "avg_pct": 42.5,
+                        "critical_item_pass_rate": 0.55,
+                        "precheck_pass_rate": 0.87,
+                        "judge_pass_rate": 0.43,
+                        "task_count": 1,
+                    },
+                    "Healthcare": {
+                        "avg_pct": 85.0,
+                        "critical_item_pass_rate": 0.82,
+                        "precheck_pass_rate": 0.96,
+                        "judge_pass_rate": 0.77,
+                        "task_count": 1,
+                    },
+                    "Retail": {
+                        "avg_pct": 63.9,
+                        "critical_item_pass_rate": 0.68,
+                        "precheck_pass_rate": 0.89,
+                        "judge_pass_rate": 0.59,
+                        "task_count": 1,
+                    },
+                },
+            },
+        },
+    }
+
+
+def _make_analyzer() -> NarrativeAnalyzer:
+    analyzer = NarrativeAnalyzer.__new__(NarrativeAnalyzer)
+    analyzer.client = None
+    analyzer.model = "gpt-5.4-pro"
+    analyzer._heartbeat_active = False
+    analyzer._heartbeat_thread = None
+    analyzer._start_heartbeat = lambda: None
+    analyzer._stop_heartbeat = lambda: None
+    return analyzer
+
+
+def _inputs() -> tuple[dict, dict, list[dict], list[dict], list[dict]]:
+    data = {
+        "meta": {
+            "experiment_id": "exp_test",
+            "experiment_name": "Test Experiment",
+            "model": "gpt-5.4",
+        }
+    }
+    summary = {
+        "total_tasks": 2,
+        "success_count": 2,
+        "success_rate_pct": 100.0,
+        "error_count": 0,
+        "retried_count": 0,
+        "avg_qa_score": 8.0,
+        "min_qa_score": 7,
+        "max_qa_score": 9,
+        "avg_latency_ms": 1234,
+    }
+    sectors = [
+        {
+            "sector": "Information",
+            "success": 2,
+            "total": 2,
+            "avg_qa_score": 8.0,
+            "avg_latency_ms": 1234,
+        }
+    ]
+    task_results = [
+        {
+            "task_id": "task-1",
+            "sector": "Information",
+            "occupation": "Analyst",
+            "status": "success",
+        }
+    ]
+    return data, summary, sectors, task_results, []
+
+
+def _capture_analyze_prompts(grade: dict | None) -> list[tuple[str, str]]:
+    analyzer = _make_analyzer()
+    captured: list[tuple[str, str]] = []
+
+    def fake_call(system_prompt: str, user_prompt: str, max_output_tokens: int = 4096):
+        captured.append((system_prompt, user_prompt))
+        if "CONTEXT FROM PRIOR ANALYSIS:" in user_prompt:
+            return (
+                json.dumps({
+                    "failure_patterns": "No failures.",
+                    "recommendations": "Keep configuration stable.",
+                }),
+                1.0,
+                10,
+                5,
+            )
+        return (
+            json.dumps({
+                "overview": "Overview.",
+                "quality_analysis": "Quality.",
+            }),
+            1.0,
+            10,
+            5,
+        )
+
+    analyzer._call_responses_api = fake_call
+    analyzer.analyze(*_inputs(), grade=grade)
+    return captured
+
+
+def test_analyze_without_grade_uses_legacy_guard():
+    captured = _capture_analyze_prompts(grade=None)
+    all_user_prompts = "\n".join(user for _, user in captured)
+
+    assert "Grading scores do NOT exist yet" in all_user_prompts
+    assert "Grading scores ARE available" not in all_user_prompts
+    assert "GRADING RESULTS" not in all_user_prompts
+
+
+def test_analyze_with_grade_includes_grading_results_section():
+    grade = _minimal_grade()
+    captured = _capture_analyze_prompts(grade=grade)
+    all_user_prompts = "\n".join(user for _, user in captured)
+
+    assert "GRADING RESULTS" in all_user_prompts
+    assert grade["judge"]["model"] in all_user_prompts
+    assert "Grading scores do NOT exist yet" not in all_user_prompts
+
+
+def test_overview_mentions_judge_model_and_rubric_source():
+    grade = _minimal_grade()
+    captured = _capture_analyze_prompts(grade=grade)
+    call1_prompt = "\n".join(captured[0])
+
+    assert "automated LLM-judge" in call1_prompt
+    assert "open-sourced GDPval rubrics" in call1_prompt
+    assert grade["judge"]["model"] in call1_prompt
+    assert grade["rubric"]["short_sha"] in call1_prompt
+
+
+def test_overview_does_not_claim_human_evaluation():
+    grade = _minimal_grade()
+    captured = _capture_analyze_prompts(grade=grade)
+    all_prompts = "\n".join(system + "\n" + user for system, user in captured)
+
+    assert "human evaluation" not in all_prompts.lower()
+    assert "official OpenAI grade" not in all_prompts
+    assert "human-graded" not in all_prompts
+
+
+def test_load_grade_skips_dummy_files(tmp_path, monkeypatch):
+    exp_id = "exp_test"
+    dummy = _minimal_grade(model="dummy-model")
+    dummy["_meta"] = {"is_dummy": True}
+    real = _minimal_grade(model="real-model")
+
+    (tmp_path / f"{exp_id}__a__sha__v1.json").write_text(json.dumps(dummy))
+    (tmp_path / f"{exp_id}__b__sha__v1.json").write_text(json.dumps(real))
+    monkeypatch.setattr(step6_report, "GRADE_DIR", tmp_path)
+
+    loaded = step6_report._load_grade_for_experiment(exp_id)
+    assert loaded == real
+
+
+def test_load_grade_returns_none_when_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(step6_report, "GRADE_DIR", tmp_path)
+
+    assert step6_report._load_grade_for_experiment("exp_missing") is None
+
+
+def test_load_grade_picks_most_recent(tmp_path, monkeypatch):
+    exp_id = "exp_test"
+    older = _minimal_grade(model="older-model", avg=50.0)
+    newer = _minimal_grade(model="newer-model", avg=80.0)
+    older_path = tmp_path / f"{exp_id}__older__sha__v1.json"
+    newer_path = tmp_path / f"{exp_id}__newer__sha__v1.json"
+    older_path.write_text(json.dumps(older))
+    newer_path.write_text(json.dumps(newer))
+    os.utime(older_path, (1000, 1000))
+    os.utime(newer_path, (2000, 2000))
+    monkeypatch.setattr(step6_report, "GRADE_DIR", tmp_path)
+
+    loaded = step6_report._load_grade_for_experiment(exp_id)
+    assert loaded == newer

--- a/scripts/aggregate-grades.mjs
+++ b/scripts/aggregate-grades.mjs
@@ -16,12 +16,14 @@ import { join, extname, basename } from 'path';
 const ROOT = new URL('..', import.meta.url).pathname;
 const GRADES_DIR = join(ROOT, 'data', 'grades');
 const OUTPUT_DIR = join(ROOT, 'public', 'generated');
+const PER_GRADE_DIR = join(OUTPUT_DIR, 'grades');
 
 async function dirExists(path) {
   try { await access(path); return true; } catch { return false; }
 }
 
-function processGradesFile(filePath, raw) {
+// ── Legacy (dummy / _meta-based) format ────────────────────────────────────
+function processLegacyGradesFile(filePath, raw) {
   const filename = basename(filePath, '.json');
   const meta = raw._meta || {};
   const tasks = raw.tasks || raw; // support both { _meta, tasks } and bare array
@@ -47,6 +49,7 @@ function processGradesFile(filePath, raw) {
 
   return {
     id: filename,
+    schema_version: null,
     is_dummy: !!meta.is_dummy,
     label: meta.label || filename,
     model: meta.model || 'Unknown',
@@ -64,6 +67,99 @@ function processGradesFile(filePath, raw) {
     },
     tasks,
   };
+}
+
+// ── v1.0 schema (007) ─────────────────────────────────────────────────────
+//
+// Maps raw item-level grade JSON onto the dashboard's existing legacy shape
+// while preserving the full v1 payload in summary_v1 / tasks_v1 so WOW
+// components can consume rich item-level data.
+function processV1GradesFile(filePath, raw) {
+  const filename = basename(filePath, '.json');
+  const rawTasks = Array.isArray(raw.tasks) ? raw.tasks : [];
+  const summary = raw.summary || {};
+  const openaiCompat = summary.openai_compat || {};
+  const wow = summary.wow || {};
+
+  // Convert v1 tasks → legacy-compatible task rows. Snap pct to exact 0/1
+  // when it crosses the openai_compat thresholds (pct >= 99 → perfect,
+  // pct <= 1 → zero) so legacy Status badges agree with summary counts.
+  const tasks = rawTasks.map((t) => {
+    const hasError = t.error !== null && t.error !== undefined && t.error !== '';
+    if (hasError) {
+      return {
+        task_id: t.task_id,
+        num_grades: 0,
+        scores: [],
+        avg_score: null,
+        error: true,
+        error_messages: [String(t.error)],
+      };
+    }
+    const pct = typeof t.pct === 'number' ? t.pct : 0;
+    let avgScore;
+    if (pct >= 99) avgScore = 1.0;
+    else if (pct <= 1) avgScore = 0.0;
+    else avgScore = pct / 100;
+    return {
+      task_id: t.task_id,
+      num_grades: 1,
+      scores: [avgScore],
+      avg_score: avgScore,
+      error: false,
+      error_messages: [],
+    };
+  });
+
+  const totalTasks = typeof summary.total_tasks === 'number'
+    ? summary.total_tasks
+    : rawTasks.length;
+  const errorTasks = typeof summary.error_tasks === 'number'
+    ? summary.error_tasks
+    : tasks.filter((t) => t.error).length;
+  const gradedTasks = typeof summary.graded_tasks === 'number'
+    ? summary.graded_tasks
+    : totalTasks - errorTasks;
+
+  const label = raw.experiment_id || filename;
+  const model = raw.inference_model || (raw.judge && raw.judge.model) || 'Unknown';
+
+  return {
+    id: filename,
+    schema_version: '1.0',
+    is_dummy: false,
+    label,
+    model,
+    dataset_url: null,
+    summary: {
+      total_tasks: totalTasks,
+      graded_tasks: gradedTasks,
+      error_tasks: errorTasks,
+      avg_score_pct: typeof openaiCompat.avg_score_pct === 'number'
+        ? openaiCompat.avg_score_pct
+        : 0,
+      ci_pct: typeof openaiCompat.ci_pct === 'number' ? openaiCompat.ci_pct : null,
+      perfect_score: openaiCompat.perfect_count ?? 0,
+      partial_score: openaiCompat.partial_count ?? 0,
+      zero_score: openaiCompat.zero_count ?? 0,
+      inconsistent_grades: openaiCompat.inconsistent_count ?? 0,
+    },
+    tasks,
+    // v1.0 provenance + full payload (for WOW dashboard components)
+    judge: raw.judge,
+    rubric: raw.rubric,
+    prompt: raw.prompt,
+    graded_at: raw.graded_at,
+    summary_v1: { ...summary, wow, openai_compat: openaiCompat },
+    tasks_v1: rawTasks,
+  };
+}
+
+function processGradesFile(filePath, raw) {
+  if (raw && raw.schema_version === '1.0') {
+    return processV1GradesFile(filePath, raw);
+  }
+  return processLegacyGradesFile(filePath, raw);
 }
 
 // ── Main ──
@@ -93,15 +189,25 @@ async function main() {
   }
 
   await mkdir(OUTPUT_DIR, { recursive: true });
+  await mkdir(PER_GRADE_DIR, { recursive: true });
   await writeFile(
     join(OUTPUT_DIR, 'grades-index.json'),
     JSON.stringify(results, null, 2),
   );
+  // Per-experiment full payloads (incl. tasks_v1 / summary_v1) — optional
+  // companion files for future detail routes; index file remains the contract.
+  for (const r of results) {
+    await writeFile(
+      join(PER_GRADE_DIR, `${r.id}.json`),
+      JSON.stringify(r, null, 2),
+    );
+  }
 
   console.log(`✅ Aggregated ${results.length} grade file(s) → grades-index.json`);
   for (const r of results) {
     const dummy = r.is_dummy ? ' [DUMMY]' : '';
-    console.log(`   ${r.id}: ${r.summary.avg_score_pct}% avg (${r.summary.graded_tasks}/${r.summary.total_tasks} tasks)${dummy}`);
+    const v1 = r.schema_version === '1.0' ? ' [v1.0]' : '';
+    console.log(`   ${r.id}: ${r.summary.avg_score_pct}% avg (${r.summary.graded_tasks}/${r.summary.total_tasks} tasks)${dummy}${v1}`);
   }
 }
 

--- a/src/components/GradesSummary.tsx
+++ b/src/components/GradesSummary.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import { Card, CardContent } from './ui/card'
-import { AlertTriangle, Award, Target, XCircle, BarChart3, AlertCircle, HelpCircle } from 'lucide-react'
+import { AlertTriangle, Award, Target, XCircle, BarChart3, AlertCircle, HelpCircle, Sparkles } from 'lucide-react'
 import { GradeResult } from '../hooks/useGrades'
 
 const STAT_TOOLTIPS: Record<string, string> = {
@@ -101,6 +101,7 @@ function StatMini({ icon: Icon, label, value, color }: { icon: typeof Award; lab
 
 function GradeCard({ grade, index }: { grade: GradeResult; index: number }) {
   const s = grade.summary
+  const isV1 = grade.schema_version === '1.0'
 
   return (
     <Link to={`/grades/${grade.id}`} className="block">
@@ -113,7 +114,7 @@ function GradeCard({ grade, index }: { grade: GradeResult; index: number }) {
         {/* Dummy banner */}
         {grade.is_dummy && (
           <div className="absolute top-0 left-0 right-0 bg-amber-500/90 text-amber-950 text-center text-[11px] font-bold py-1 tracking-wider uppercase">
-            ⏳ We're still waiting for grading results. This takes a while.
+            ⏳ Awaiting LLM-Judge Grade — run grade-run.yml to populate
           </div>
         )}
 
@@ -121,7 +122,18 @@ function GradeCard({ grade, index }: { grade: GradeResult; index: number }) {
           {/* Header */}
           <div className="flex items-start justify-between mb-4">
             <div>
-              <h3 className="text-lg font-semibold text-foreground">{grade.label}</h3>
+              <div className="flex items-center gap-2">
+                <h3 className="text-lg font-semibold text-foreground">{grade.label}</h3>
+                {isV1 && (
+                  <span
+                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-gradient-to-r from-fuchsia-500/15 to-violet-500/15 border border-fuchsia-400/30 text-[10px] font-bold uppercase tracking-wider text-fuchsia-400"
+                    title="Item-level rubric grading (schema v1.0)"
+                  >
+                    <Sparkles className="w-2.5 h-2.5" />
+                    WOW
+                  </span>
+                )}
+              </div>
               <p className="text-sm text-muted-foreground">{grade.model}</p>
               {grade.dataset_url && (
                 <a

--- a/src/components/ScopeBadge.tsx
+++ b/src/components/ScopeBadge.tsx
@@ -12,7 +12,7 @@ export default function ScopeBadge({ scope }: ScopeBadgeProps) {
       <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/30">
         <CheckCircle className="w-3.5 h-3.5 text-emerald-500" />
         <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-400">
-          ✓ Externally Graded
+          ✓ LLM-Judge Graded
         </span>
       </div>
     )
@@ -23,7 +23,7 @@ export default function ScopeBadge({ scope }: ScopeBadgeProps) {
     <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-500/10 border border-amber-500/30">
       <Clock className="w-3.5 h-3.5 text-amber-500" />
       <span className="text-[10px] font-semibold uppercase tracking-wider text-amber-400">
-        ⏰ Self-Assessed · Pre-Grading
+        ⏰ Awaiting LLM-Judge Grade
       </span>
       <InfoTooltip content={tooltipTexts.badge.selfAssessed} position="bottom" />
     </div>

--- a/src/components/dashboard/GradingAnalysisView.tsx
+++ b/src/components/dashboard/GradingAnalysisView.tsx
@@ -115,7 +115,7 @@ export default function GradingAnalysisView() {
         <Award className="w-10 h-10 text-dash-text-faint mx-auto mb-4" />
         <h3 className="text-base font-semibold text-dash-text mb-2">No Grading Data Yet</h3>
         <p className="text-sm text-dash-text-muted max-w-md mx-auto">
-          Grading results will appear here after the external evaluation pipeline completes.
+          Grading results will appear here after running the LLM-judge via <code className="text-dash-text-secondary">grade-run.yml</code>.
           This is separate from the self-assessed QA scores shown in other tabs.
         </p>
       </div>
@@ -128,7 +128,7 @@ export default function GradingAnalysisView() {
       transition={{ duration: 0.2 }}
       className="space-y-6"
     >
-      {/* ─── Dummy data banner ─── */}
+      {/* ─── Awaiting grade banner ─── */}
       {grades.some((g) => g.is_dummy) && (
         <motion.div
           initial={{ opacity: 0, scale: 0.97 }} animate={{ opacity: 1, scale: 1 }}
@@ -137,10 +137,10 @@ export default function GradingAnalysisView() {
           <div className="flex items-start gap-3">
             <Clock className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5" />
             <div>
-              <h3 className="text-sm font-semibold text-amber-300 mb-1">Grading In Progress</h3>
+              <h3 className="text-sm font-semibold text-amber-300 mb-1">Awaiting LLM-Judge Grade</h3>
               <p className="text-xs text-amber-300/80">
-                Some entries are placeholder data while we wait for the external grading pipeline to finish.
-                Results marked as dummy will be replaced with real scores.
+                Some entries are placeholder data while the LLM-judge grade is pending.
+                Run <code className="text-amber-200">grade-run.yml</code> for the experiment to populate real rubric-based scores.
               </p>
             </div>
           </div>

--- a/src/components/wow/CriticalItemCard.tsx
+++ b/src/components/wow/CriticalItemCard.tsx
@@ -1,0 +1,23 @@
+import { ShieldAlert } from 'lucide-react'
+import WowCard from './WowCard'
+import type { WowSummary } from '../../types/grade'
+import { tooltipTexts } from '../../data/tooltipTexts'
+
+interface Props {
+  wow: WowSummary
+  delay?: number
+}
+
+export default function CriticalItemCard({ wow, delay = 0 }: Props) {
+  const pct = (wow.critical_item_pass_rate * 100).toFixed(1)
+  return (
+    <WowCard
+      title="Critical Items (weight ≥ 3)"
+      value={`${pct}%`}
+      sub='Pass rate for high-weight rubric items — the "must-have" requirements.'
+      tooltip={tooltipTexts.wow.criticalItems}
+      icon={<ShieldAlert className="w-4 h-4 text-amber-400" />}
+      delay={delay}
+    />
+  )
+}

--- a/src/components/wow/RubricCoverageCard.tsx
+++ b/src/components/wow/RubricCoverageCard.tsx
@@ -1,0 +1,28 @@
+import { Layers } from 'lucide-react'
+import WowCard from './WowCard'
+import type { WowSummary } from '../../types/grade'
+import { tooltipTexts } from '../../data/tooltipTexts'
+
+interface Props {
+  wow: WowSummary
+  totalItems?: number
+  delay?: number
+}
+
+export default function RubricCoverageCard({ wow, totalItems, delay = 0 }: Props) {
+  const coverage = wow.rubric_item_coverage_avg
+  const pct = (coverage * 100).toFixed(1)
+  const itemsLabel = totalItems && totalItems > 0
+    ? ` across ~${totalItems.toLocaleString()} items`
+    : ''
+  return (
+    <WowCard
+      title="Rubric Item Coverage"
+      value={`${pct}%`}
+      sub={`OpenAI's task-level binary captures only {0, 33, 67, 100}%. We score every rubric item — averaging ${pct}%${itemsLabel}.`}
+      tooltip={tooltipTexts.wow.rubricCoverage}
+      icon={<Layers className="w-4 h-4 text-fuchsia-400" />}
+      delay={delay}
+    />
+  )
+}

--- a/src/components/wow/RubricSeverityCurve.tsx
+++ b/src/components/wow/RubricSeverityCurve.tsx
@@ -1,0 +1,98 @@
+import { motion } from 'framer-motion'
+import { TrendingDown, Sparkles } from 'lucide-react'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+import { Card, CardContent } from '../ui/card'
+import InfoTooltip from '../common/InfoTooltip'
+import type { WowSummary } from '../../types/grade'
+import { tooltipTexts } from '../../data/tooltipTexts'
+
+interface Props {
+  wow: WowSummary
+  delay?: number
+}
+
+export default function RubricSeverityCurve({ wow, delay = 0 }: Props) {
+  const points = (wow.rubric_severity_curve ?? []).map((p) => ({
+    weight: p.weight,
+    pass_rate_pct: Math.round(p.pass_rate * 1000) / 10,
+    n_items: p.n_items,
+  }))
+  const hasData = points.length > 0
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, delay }}
+    >
+      <Card className="bg-card/50 backdrop-blur border-border h-full">
+        <CardContent className="p-5">
+          <div className="flex items-start justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <TrendingDown className="w-4 h-4 text-rose-400" />
+              <span className="text-xs font-semibold tracking-wide text-foreground">
+                Rubric Severity Curve
+              </span>
+              <InfoTooltip content={tooltipTexts.wow.rubricSeverity} position="top" />
+            </div>
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-gradient-to-r from-fuchsia-500/15 to-violet-500/15 border border-fuchsia-400/30 text-[10px] font-bold uppercase tracking-wider text-fuchsia-400">
+              <Sparkles className="w-2.5 h-2.5" />
+              WOW
+            </span>
+          </div>
+
+          {!hasData ? (
+            <div className="py-6 text-center">
+              <p className="text-sm text-muted-foreground italic">Data not available</p>
+              <p className="text-[11px] text-muted-foreground/70 mt-1">
+                Severity curve populates after a full-scale grading run.
+              </p>
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height={200}>
+              <LineChart data={points} margin={{ top: 5, right: 10, bottom: 5, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis
+                  dataKey="weight"
+                  stroke="hsl(var(--muted-foreground))"
+                  tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
+                  label={{ value: 'Item weight', position: 'insideBottom', offset: -2, fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                />
+                <YAxis
+                  stroke="hsl(var(--muted-foreground))"
+                  domain={[0, 100]}
+                  tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
+                  label={{ value: 'Pass %', angle: -90, position: 'insideLeft', fontSize: 10, fill: 'hsl(var(--muted-foreground))' }}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: 'hsl(var(--card))',
+                    border: '1px solid hsl(var(--border))',
+                    borderRadius: '8px',
+                    fontSize: '12px',
+                  }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="pass_rate_pct"
+                  stroke="hsl(340, 80%, 60%)"
+                  strokeWidth={2}
+                  dot={{ r: 4 }}
+                  activeDot={{ r: 6 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}

--- a/src/components/wow/ScoreDensityHistogram.tsx
+++ b/src/components/wow/ScoreDensityHistogram.tsx
@@ -1,0 +1,118 @@
+import { motion } from 'framer-motion'
+import { BarChart3, Sparkles } from 'lucide-react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts'
+import { Card, CardContent } from '../ui/card'
+import InfoTooltip from '../common/InfoTooltip'
+import type { WowSummary, ScoreDensityBucket } from '../../types/grade'
+import { tooltipTexts } from '../../data/tooltipTexts'
+
+interface Props {
+  wow: WowSummary
+  fallbackPcts?: number[]
+  delay?: number
+}
+
+const BUCKETS = [
+  '0-10%', '10-20%', '20-30%', '30-40%', '40-50%',
+  '50-60%', '60-70%', '70-80%', '80-90%', '90-100%',
+]
+
+function bucketFromPct(pct: number): string {
+  if (pct >= 100) return '90-100%'
+  if (pct < 0) return '0-10%'
+  const idx = Math.min(9, Math.floor(pct / 10))
+  return BUCKETS[idx]
+}
+
+function colorForBucket(label: string): string {
+  // Match green gradient up the buckets
+  const idx = BUCKETS.indexOf(label)
+  if (idx < 0) return 'hsl(220, 10%, 50%)'
+  const hue = 0 + (idx / (BUCKETS.length - 1)) * 130
+  return `hsl(${hue}, 70%, 50%)`
+}
+
+export default function ScoreDensityHistogram({ wow, fallbackPcts, delay = 0 }: Props) {
+  let buckets: ScoreDensityBucket[] = wow.score_density_histogram ?? []
+  if (buckets.length === 0 && fallbackPcts && fallbackPcts.length > 0) {
+    const counts: Record<string, number> = Object.fromEntries(BUCKETS.map((b) => [b, 0]))
+    for (const p of fallbackPcts) counts[bucketFromPct(p)] = (counts[bucketFromPct(p)] ?? 0) + 1
+    buckets = BUCKETS.map((b) => ({ bucket: b, count: counts[b] ?? 0 }))
+  }
+  const hasData = buckets.length > 0 && buckets.some((b) => b.count > 0)
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, delay }}
+    >
+      <Card className="bg-card/50 backdrop-blur border-border h-full">
+        <CardContent className="p-5">
+          <div className="flex items-start justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <BarChart3 className="w-4 h-4 text-violet-400" />
+              <span className="text-xs font-semibold tracking-wide text-foreground">
+                Score Density (10 buckets)
+              </span>
+              <InfoTooltip content={tooltipTexts.wow.scoreDensity} position="top" />
+            </div>
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-gradient-to-r from-fuchsia-500/15 to-violet-500/15 border border-fuchsia-400/30 text-[10px] font-bold uppercase tracking-wider text-fuchsia-400">
+              <Sparkles className="w-2.5 h-2.5" />
+              WOW
+            </span>
+          </div>
+
+          {!hasData ? (
+            <div className="py-6 text-center">
+              <p className="text-sm text-muted-foreground italic">Data not available</p>
+              <p className="text-[11px] text-muted-foreground/70 mt-1">
+                Histogram populates once tasks are graded.
+              </p>
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart data={buckets} margin={{ top: 5, right: 10, bottom: 5, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis
+                  dataKey="bucket"
+                  stroke="hsl(var(--muted-foreground))"
+                  tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
+                />
+                <YAxis
+                  stroke="hsl(var(--muted-foreground))"
+                  tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
+                  allowDecimals={false}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: 'hsl(var(--card))',
+                    border: '1px solid hsl(var(--border))',
+                    borderRadius: '8px',
+                    fontSize: '12px',
+                  }}
+                  labelStyle={{ color: 'hsl(var(--foreground))' }}
+                  cursor={{ fill: 'hsl(var(--muted))' }}
+                />
+                <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+                  {buckets.map((b) => (
+                    <Cell key={b.bucket} fill={colorForBucket(b.bucket)} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}

--- a/src/components/wow/SectorHeatmap.tsx
+++ b/src/components/wow/SectorHeatmap.tsx
@@ -1,0 +1,134 @@
+import { motion } from 'framer-motion'
+import { Grid3x3, Sparkles } from 'lucide-react'
+import { Card, CardContent } from '../ui/card'
+import InfoTooltip from '../common/InfoTooltip'
+import type {
+  WowSummary,
+  RubricCategoryMetric,
+  SectorWowMetric,
+} from '../../types/grade'
+import { tooltipTexts } from '../../data/tooltipTexts'
+
+interface Props {
+  wow: WowSummary
+  delay?: number
+}
+
+function colorFor(rate: number): string {
+  // 0% red → 100% green via amber midpoint
+  const clamped = Math.max(0, Math.min(1, rate))
+  const hue = clamped * 130 // 0=red 130=green
+  return `hsl(${hue}, 70%, 45%)`
+}
+
+type Row = { name: string; values: { key: string; rate: number; label?: string }[] }
+
+function buildRubricCategoryRows(
+  bySector: Record<string, SectorWowMetric>,
+  byCategory: Record<string, RubricCategoryMetric>,
+): Row[] | null {
+  // Spec asks 11 sector × 3 category. We do not have per-sector
+  // breakdown by category in the schema, only global. If we have neither
+  // sector breakdown nor category breakdown, give up.
+  const sectorKeys = Object.keys(bySector)
+  const categoryKeys = Object.keys(byCategory)
+  if (sectorKeys.length === 0 && categoryKeys.length === 0) return null
+  return null
+}
+
+function buildSectorFallbackRows(
+  bySector: Record<string, SectorWowMetric>,
+): Row[] {
+  return Object.entries(bySector).map(([name, m]) => ({
+    name,
+    values: [
+      { key: 'precheck', rate: m.precheck_pass_rate, label: 'Precheck' },
+      { key: 'judge', rate: m.judge_pass_rate, label: 'Judge' },
+      { key: 'critical', rate: m.critical_item_pass_rate, label: 'Critical' },
+    ],
+  }))
+}
+
+export default function SectorHeatmap({ wow, delay = 0 }: Props) {
+  const bySector = wow.by_sector || {}
+  const byCategory = wow.by_rubric_category || {}
+
+  // Prefer sector × category, else sector × {precheck, judge, critical}
+  const categoryRows = buildRubricCategoryRows(bySector, byCategory)
+  const rows: Row[] = categoryRows ?? buildSectorFallbackRows(bySector)
+  const hasData = rows.length > 0
+
+  const header = !categoryRows ? ['Precheck', 'Judge', 'Critical ≥3'] : []
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, delay }}
+    >
+      <Card className="bg-card/50 backdrop-blur border-border h-full">
+        <CardContent className="p-5">
+          <div className="flex items-start justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <Grid3x3 className="w-4 h-4 text-teal-400" />
+              <span className="text-xs font-semibold tracking-wide text-foreground">
+                Sector × Rubric Heatmap
+              </span>
+              <InfoTooltip content={tooltipTexts.wow.sectorHeatmap} position="top" />
+            </div>
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-gradient-to-r from-fuchsia-500/15 to-violet-500/15 border border-fuchsia-400/30 text-[10px] font-bold uppercase tracking-wider text-fuchsia-400">
+              <Sparkles className="w-2.5 h-2.5" />
+              WOW
+            </span>
+          </div>
+
+          {!hasData ? (
+            <div className="py-6 text-center">
+              <p className="text-sm text-muted-foreground italic">
+                Data not available
+              </p>
+              <p className="text-[11px] text-muted-foreground/70 mt-1">
+                Per-sector breakdown populates after a full-scale grading run.
+              </p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr>
+                    <th className="text-left text-muted-foreground font-normal pb-2">Sector</th>
+                    {header.map((h) => (
+                      <th key={h} className="text-center text-muted-foreground font-normal pb-2">
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row) => (
+                    <tr key={row.name} className="border-t border-border/40">
+                      <td className="py-1.5 pr-3 text-foreground truncate max-w-[200px]" title={row.name}>
+                        {row.name}
+                      </td>
+                      {row.values.map((v) => (
+                        <td key={v.key} className="py-1.5 px-1">
+                          <div
+                            className="rounded text-center font-mono text-[11px] font-semibold text-white py-1"
+                            style={{ backgroundColor: colorFor(v.rate) }}
+                            title={`${v.label ?? v.key}: ${(v.rate * 100).toFixed(1)}%`}
+                          >
+                            {(v.rate * 100).toFixed(0)}%
+                          </div>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}

--- a/src/components/wow/StructureVsReasoning.tsx
+++ b/src/components/wow/StructureVsReasoning.tsx
@@ -1,0 +1,83 @@
+import { motion } from 'framer-motion'
+import { Sparkles, GitCompare } from 'lucide-react'
+import { Card, CardContent } from '../ui/card'
+import InfoTooltip from '../common/InfoTooltip'
+import type { WowSummary } from '../../types/grade'
+import { tooltipTexts } from '../../data/tooltipTexts'
+
+interface Props {
+  wow: WowSummary
+  delay?: number
+}
+
+function pctFmt(v: number): string {
+  return `${(v * 100).toFixed(1)}%`
+}
+
+function insightLabel(precheck: number, judge: number): string {
+  const gap = precheck - judge
+  if (Math.abs(gap) < 0.05) return 'Balanced structure and reasoning'
+  if (gap > 0.15) return 'Strong on structure, weak on reasoning'
+  if (gap < -0.15) return 'Strong on reasoning, weak on structure'
+  return gap > 0 ? 'Slightly stronger on structure' : 'Slightly stronger on reasoning'
+}
+
+export default function StructureVsReasoning({ wow, delay = 0 }: Props) {
+  const precheck = wow.precheck_pass_rate
+  const judge = wow.judge_pass_rate
+  const insight = insightLabel(precheck, judge)
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, delay }}
+    >
+      <Card className="bg-card/50 backdrop-blur border-border h-full">
+        <CardContent className="p-5">
+          <div className="flex items-start justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <GitCompare className="w-4 h-4 text-sky-400" />
+              <span className="text-xs font-semibold tracking-wide text-foreground">
+                Structure vs Reasoning
+              </span>
+              <InfoTooltip content={tooltipTexts.wow.structureVsReasoning} position="top" />
+            </div>
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-gradient-to-r from-fuchsia-500/15 to-violet-500/15 border border-fuchsia-400/30 text-[10px] font-bold uppercase tracking-wider text-fuchsia-400">
+              <Sparkles className="w-2.5 h-2.5" />
+              WOW
+            </span>
+          </div>
+
+          <div className="space-y-3 mt-3">
+            <BarRow label="Precheck (deterministic)" value={precheck} color="bg-emerald-500" />
+            <BarRow label="LLM Judge (reasoning)" value={judge} color="bg-sky-500" />
+          </div>
+
+          <p className="text-xs text-muted-foreground mt-4 italic">
+            {insight}
+          </p>
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}
+
+function BarRow({ label, value, color }: { label: string; value: number; color: string }) {
+  const pct = Math.max(0, Math.min(100, value * 100))
+  return (
+    <div>
+      <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+        <span>{label}</span>
+        <span className="font-mono text-foreground">{pctFmt(value)}</span>
+      </div>
+      <div className="h-2.5 w-full rounded-full overflow-hidden bg-muted">
+        <motion.div
+          initial={{ width: 0 }}
+          animate={{ width: `${pct}%` }}
+          transition={{ duration: 0.8, ease: 'easeOut' }}
+          className={`${color} h-full`}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/wow/WowCard.tsx
+++ b/src/components/wow/WowCard.tsx
@@ -1,0 +1,87 @@
+import { motion } from 'framer-motion'
+import type { ReactNode } from 'react'
+import { Sparkles } from 'lucide-react'
+import { Card, CardContent } from '../ui/card'
+import InfoTooltip from '../common/InfoTooltip'
+
+interface WowCardProps {
+  title: string
+  value: string
+  sub?: string
+  tooltip?: string
+  icon?: ReactNode
+  children?: ReactNode
+  delay?: number
+}
+
+export default function WowCard({
+  title,
+  value,
+  sub,
+  tooltip,
+  icon,
+  children,
+  delay = 0,
+}: WowCardProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, delay }}
+    >
+      <Card className="bg-card/50 backdrop-blur border-border h-full relative overflow-hidden">
+        <CardContent className="p-5">
+          <div className="flex items-start justify-between mb-3">
+            <div className="flex items-center gap-2">
+              {icon}
+              <span className="text-xs font-semibold tracking-wide text-foreground">
+                {title}
+              </span>
+              {tooltip && <InfoTooltip content={tooltip} position="top" />}
+            </div>
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-gradient-to-r from-fuchsia-500/15 to-violet-500/15 border border-fuchsia-400/30 text-[10px] font-bold uppercase tracking-wider text-fuchsia-400">
+              <Sparkles className="w-2.5 h-2.5" />
+              WOW
+            </span>
+          </div>
+          <p className="text-3xl font-bold text-foreground leading-none">
+            {value}
+          </p>
+          {sub && (
+            <p className="text-xs text-muted-foreground mt-2 leading-relaxed">
+              {sub}
+            </p>
+          )}
+          {children && <div className="mt-4">{children}</div>}
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}
+
+export function WowEmptyState({ title, tooltip }: { title: string; tooltip?: string }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35 }}
+    >
+      <Card className="bg-card/30 backdrop-blur border-border border-dashed h-full">
+        <CardContent className="p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-xs font-semibold tracking-wide text-muted-foreground">
+              {title}
+            </span>
+            {tooltip && <InfoTooltip content={tooltip} position="top" />}
+          </div>
+          <p className="text-sm text-muted-foreground italic">
+            Data not available
+          </p>
+          <p className="text-[11px] text-muted-foreground/70 mt-1">
+            Populates after a full-scale grading run.
+          </p>
+        </CardContent>
+      </Card>
+    </motion.div>
+  )
+}

--- a/src/components/wow/index.ts
+++ b/src/components/wow/index.ts
@@ -1,0 +1,7 @@
+export { default as WowCard, WowEmptyState } from './WowCard'
+export { default as RubricCoverageCard } from './RubricCoverageCard'
+export { default as CriticalItemCard } from './CriticalItemCard'
+export { default as StructureVsReasoning } from './StructureVsReasoning'
+export { default as SectorHeatmap } from './SectorHeatmap'
+export { default as ScoreDensityHistogram } from './ScoreDensityHistogram'
+export { default as RubricSeverityCurve } from './RubricSeverityCurve'

--- a/src/data/tooltipTexts.ts
+++ b/src/data/tooltipTexts.ts
@@ -3,13 +3,13 @@ export const TASK_TOTAL_PLACEHOLDER = '{TASK_TOTAL}'
 export const tooltipTexts = {
   kpi: {
     bestSuccessRate:
-      'Highest task-completion rate among all experiments. A task is "successful" when the LLM\'s self-assessed QA check passes (pre-grading).',
+      'Highest task-completion rate among all experiments. A task is "successful" when the LLM\'s self-assessed QA check passes (based on self-assessed QA — separate from LLM-judge grade).',
     experiments:
       `Total number of experiment runs. Each experiment tests a different prompt strategy or token configuration against the same ${TASK_TOTAL_PLACEHOLDER} tasks.`,
     tasksEvaluated:
       'Number of real-world professional tasks per experiment. Covers 9 industry sectors and 44 occupations from the GDPVal Gold Subset.',
     bestQaScore:
-      'Highest average Self-QA score (0–10) across experiments. The LLM inspects its own output after each task and scores it on completeness, accuracy, and format. This is a self-assessed quality measure, not an external grade.',
+      'Highest average Self-QA score (0–10) across experiments. The LLM inspects its own output after each task and scores it on completeness, accuracy, and format. This is a self-assessed quality measure, not an LLM-judge grade.',
   },
   leaderboard: {
     experiment:
@@ -38,11 +38,11 @@ export const tooltipTexts = {
   },
   grading: {
     perfect:
-      'Tasks scored 100% by the external grading pipeline. The LLM output fully met all rubric criteria.',
+      'Tasks scored 100% by the LLM-judge (rubric-based, automated). The LLM output fully met all rubric criteria.',
     partial:
-      'Tasks scored between 1–99%. The output met some but not all grading criteria.',
+      'Tasks scored between 1–99% by the LLM-judge. The output met some but not all rubric criteria.',
     zero:
-      'Tasks scored 0%. The output failed to meet any grading criteria or was completely off-target.',
+      'Tasks scored 0% by the LLM-judge. The output failed to meet any rubric criteria or was completely off-target.',
     graderDisagreement:
       'Cases where multiple graders scored the same task differently. High rates may indicate ambiguous rubric criteria.',
     ci:
@@ -50,7 +50,21 @@ export const tooltipTexts = {
   },
   badge: {
     selfAssessed:
-      "Scores are currently based on the LLM's own QA assessment, not external grading. Amber badge = awaiting external evaluation pipeline.",
+      "Score is based on the LLM's own QA self-assessment. Amber badge = LLM-judge grade not yet available (run grade-run.yml to populate).",
+  },
+  wow: {
+    rubricCoverage:
+      "Average pass rate across rubric items per task. OpenAI exposed only task-level 0/1; we expose item-level partial credit derived from the full rubric.",
+    criticalItems:
+      "Pass rate on rubric items with weight ≥ 3 — the highest-stakes 'must-have' requirements. Distinguishes decisive criteria from small formatting items.",
+    structureVsReasoning:
+      "Splits deterministic verification (file format, sheet names, etc.) from LLM judgement (content correctness). Large gap = strong structure but weak reasoning, or vice versa.",
+    sectorHeatmap:
+      "Visualizes per-sector pass rates so weak sector + weak category combinations stand out. Color: 0% red → 100% green.",
+    scoreDensity:
+      "OpenAI's hosted grader produced only 4 task-level scores (0/33/67/100). Our item-level partials roll up to 10 buckets across the full 0–100% range.",
+    rubricSeverity:
+      "Groups rubric items by weight and plots pass rate per weight. A sharp drop signals the difficulty threshold where the model breaks down.",
   },
 } as const
 
@@ -62,7 +76,7 @@ export const sectionHintTexts = {
   errors:
     'Runtime failures during task execution. "Recovered" means the task succeeded after automatic retry. AI Failure Insights are LLM-generated analysis of error patterns.',
   grading:
-    'External evaluation of LLM outputs by an independent grading pipeline. Scores: Perfect (100%), Partial (1-99%), Zero (0%). "Pre-grading" means awaiting external evaluation.',
+    'LLM-judge (rubric-based, automated). Scores: Perfect (100%), Partial (1-99%), Zero (0%). Grading runs separately from inference via grade-run.yml.',
 } as const
 
 export const aboutContent = {
@@ -81,7 +95,7 @@ export const aboutContent = {
       bullets: [
         'Success Rate — Did the LLM produce a valid deliverable?',
         'QA Score (0-10) — Self-assessed quality of the output',
-        'Grading — External evaluation (when available)',
+        'Grading — LLM-judge against open-sourced GDPval rubrics (when available)',
       ],
     },
   ],

--- a/src/hooks/useGrades.ts
+++ b/src/hooks/useGrades.ts
@@ -1,4 +1,11 @@
 import { useState, useEffect } from 'react'
+import type {
+  GradeSummaryV1,
+  TaskGradeV1,
+  JudgeProvenance,
+  RubricProvenance,
+  GradePromptInfo,
+} from '../types/grade'
 
 export interface TaskGrade {
   task_id: string
@@ -30,6 +37,15 @@ export interface GradeResult {
   experiment_type?: 'ab' | 'single'
   summary: GradeSummary
   tasks: TaskGrade[]
+
+  // ── v1.0 additions (007 schema) ──
+  schema_version?: '1.0' | null
+  judge?: JudgeProvenance
+  rubric?: RubricProvenance
+  prompt?: GradePromptInfo
+  graded_at?: string
+  summary_v1?: GradeSummaryV1
+  tasks_v1?: TaskGradeV1[]
 }
 
 export function useGrades() {

--- a/src/pages/GradeDetail.tsx
+++ b/src/pages/GradeDetail.tsx
@@ -28,6 +28,15 @@ import {
 } from 'recharts'
 import Header from '../components/Header'
 import { useGrades, TaskGrade } from '../hooks/useGrades'
+import type { GradeSummaryV1, TaskGradeV1 } from '../types/grade'
+import {
+  RubricCoverageCard,
+  CriticalItemCard,
+  StructureVsReasoning,
+  SectorHeatmap,
+  ScoreDensityHistogram,
+  RubricSeverityCurve,
+} from '../components/wow'
 
 type TaskFilter = 'all' | 'perfect' | 'partial' | 'zero' | 'error' | 'inconsistent'
 
@@ -295,6 +304,11 @@ function GradeDetail() {
             />
           </div>
         </motion.div>
+
+        {/* ── WOW: Item-level Rubric Insights (v1.0 only) ── */}
+        {grade.schema_version === '1.0' && grade.summary_v1 ? (
+          <WowSection summary={grade.summary_v1} tasksV1={grade.tasks_v1 ?? []} />
+        ) : null}
 
         {/* Score Distribution + Pie — side by side */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
@@ -653,3 +667,41 @@ function TaskRow({ task, index }: { task: TaskGrade; index: number }) {
 }
 
 export default GradeDetail
+
+function WowSection({ summary, tasksV1 }: { summary: GradeSummaryV1; tasksV1: TaskGradeV1[] }) {
+  const wow = summary.wow
+  const totalItems = tasksV1.reduce((acc, t) => acc + (Array.isArray(t.items) ? t.items.length : 0), 0)
+  const fallbackPcts = tasksV1
+    .filter((t) => !t.error && typeof t.pct === 'number')
+    .map((t) => t.pct)
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: 0.18 }}
+      className="mb-8"
+    >
+      <div className="flex items-end justify-between mb-4 flex-wrap gap-2">
+        <h2 className="text-xl md:text-2xl font-bold text-foreground">
+          WOW — Item-level Rubric Insights
+        </h2>
+        <p className="text-xs text-muted-foreground max-w-xl">
+          Item-level partial credit grading powered by our LLM-judge against
+          open-sourced GDPval rubrics — richer than the legacy task-level binary.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+        <RubricCoverageCard wow={wow} totalItems={totalItems} delay={0.0} />
+        <CriticalItemCard wow={wow} delay={0.05} />
+        <StructureVsReasoning wow={wow} delay={0.1} />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <ScoreDensityHistogram wow={wow} fallbackPcts={fallbackPcts} delay={0.15} />
+        <RubricSeverityCurve wow={wow} delay={0.2} />
+      </div>
+      <div className="mt-4">
+        <SectorHeatmap wow={wow} delay={0.25} />
+      </div>
+    </motion.section>
+  )
+}

--- a/src/types/grade.ts
+++ b/src/types/grade.ts
@@ -1,0 +1,124 @@
+// Grade v1.0 schema types (matches tasks/grading_task/007-grade-schema.md)
+
+export type Verdict = 'pass' | 'partial' | 'fail' | 'judge_error'
+export type DecidedBy = 'precheck' | 'judge'
+
+export interface ItemGrade {
+  rubric_item_id: string
+  criterion: string
+  max_score: number
+  awarded_score: number
+  verdict: Verdict
+  decided_by: DecidedBy
+  required: boolean | null
+  evidence: string
+  judge_confidence: number | null
+  judge_latency_ms: number | null
+  precheck_pattern_id: string | null
+  judge_raw_response?: string | null
+}
+
+export interface TaskGradeV1 {
+  task_id: string
+  sector: string
+  occupation: string
+  items: ItemGrade[]
+  total_awarded: number
+  total_max: number
+  pct: number
+  critical_fail: boolean
+  gold_referenced?: boolean
+  judge_call_count?: number
+  precheck_count?: number
+  judge_total_latency_ms?: number
+  judge_input_tokens?: number
+  judge_output_tokens?: number
+  error: string | null
+  graded_at?: string
+}
+
+export interface OpenAICompatSummary {
+  avg_score_pct: number
+  ci_pct: number
+  perfect_count: number
+  zero_count: number
+  partial_count: number
+  inconsistent_count: number
+}
+
+export interface SectorWowMetric {
+  task_count: number
+  avg_pct: number
+  critical_item_pass_rate: number
+  precheck_pass_rate: number
+  judge_pass_rate: number
+}
+
+export interface RubricCategoryMetric {
+  items: number
+  pass_rate: number
+}
+
+export interface ScoreDensityBucket {
+  bucket: string
+  count: number
+}
+
+export interface RubricSeverityPoint {
+  weight: number
+  n_items: number
+  pass_rate: number
+}
+
+export interface WowSummary {
+  rubric_item_coverage_avg: number
+  critical_item_pass_rate: number
+  precheck_pass_rate: number
+  judge_pass_rate: number
+  judge_error_rate?: number
+  by_sector?: Record<string, SectorWowMetric>
+  by_rubric_category?: Record<string, RubricCategoryMetric>
+  score_density_histogram?: ScoreDensityBucket[]
+  rubric_severity_curve?: RubricSeverityPoint[]
+}
+
+export interface GradeCostSummary {
+  total_judge_calls?: number
+  total_input_tokens?: number
+  total_output_tokens?: number
+  estimated_cost_usd?: number | null
+  total_judge_latency_sec?: number
+}
+
+export interface GradeSummaryV1 {
+  total_tasks: number
+  graded_tasks: number
+  error_tasks: number
+  openai_compat: OpenAICompatSummary
+  wow: WowSummary
+  cost?: GradeCostSummary
+}
+
+export interface JudgeProvenance {
+  provider: string
+  api: string
+  model: string
+  deployment?: string
+  api_version?: string
+  reasoning_effort: string
+  temperature: number
+  seed?: number
+}
+
+export interface RubricProvenance {
+  source: string
+  repo_id: string
+  revision: string
+  commit_sha: string
+  short_sha: string
+}
+
+export interface GradePromptInfo {
+  template: string
+  version: string
+}


### PR DESCRIPTION
# Phase A wow — Grading narrative + dashboard integration (PR #2)

> Spec source: `tasks/grading_task/008-narrative-integration.md` + `009-dashboard-wow-metrics.md`
>
> Builds on the already-merged PR #1 (Phase A core: rubric_loader, grader,
> step8_grade, grade-run.yml, schema v1.0).

## What this PR does

Threads schema v1.0 grade JSON (`data/grades/<exp>__...json`) into the two
consumers it was missing from:

1. **NarrativeAnalyzer / step6_report** (spec 008) — narrative summary now
   incorporates LLM-judge grades when a v1.0 grade file is on disk.
2. **Dashboard** (spec 009) — new "WOW" item-level rubric insight cards
   surface what OpenAI's task-level binary couldn't, and copy is swept of
   "external grading pipeline" / "Pre-Grading" language.

## Spec 008 — Backend (Python)

`batch-runner/core/narrative_analyzer.py`
- `analyze()` accepts `grade: dict | None = None` (backward compatible)
- Conditional guard clause via `_build_grading_guard_clause(grade)` —
  legacy "Grading scores do NOT exist yet" text when `grade is None`,
  new "Grading scores ARE available…" text otherwise
- `_build_grading_results_section(grade)` injects a GRADING RESULTS
  block into Call 2's user prompt: top-3 weakest + strongest sectors
  ranked by `avg_pct`, `openai_compat` + `wow` metrics
- N3 disclosure paragraph instruction added to Call 1 prompt (overview
  must cite judge model + rubric SHA verbatim)
- `NarrativeResult` gains `grading_referenced: bool` + `grade_source:
  dict | None` — written into `report_data.json` for downstream readers

`batch-runner/step6_report.py`
- New `_load_grade_for_experiment(exp_id)` helper — globs
  `data/grades/<exp>__*.json`, skips `_meta.is_dummy=true`, returns the
  most recent `schema_version=="1.0"` payload
- Fallback `_generate_narrative()` shares the same guard helpers
- `_build_report_data()` propagates `grading_referenced` + `grade_source`
  through to `report_data.json` narrative section
- `--no-narrative` path unchanged

Tests (`batch-runner/tests/test_narrative_grade_integration.py`, 7 new):
- `test_analyze_without_grade_uses_legacy_guard`
- `test_analyze_with_grade_includes_grading_results_section`
- `test_overview_mentions_judge_model_and_rubric_source`
- `test_overview_does_not_claim_human_evaluation` (negative defensive)
- `test_load_grade_skips_dummy_files`
- `test_load_grade_returns_none_when_missing`
- `test_load_grade_picks_most_recent`

All **42 backend tests pass** (test_narrative_analyzer 17 +
test_narrative_grade_integration 7 + test_grader 13 + test_grade_schema 5).

## Spec 009 — Frontend (TS / React)

`scripts/aggregate-grades.mjs`
- Detects `raw.schema_version === '1.0'` vs legacy dummy format
- v1.0 path: maps item-level `pct` → legacy `avg_score` (snaps to exact
  0/1 at openai_compat thresholds so status badges match summary counts),
  surfaces full v1 payload as `summary_v1` + `tasks_v1` for dashboard
  components, plus `judge` / `rubric` / `prompt` provenance
- Also emits per-experiment files to `public/generated/grades/<id>.json`
  (the `grades-index.json` array remains the contract for `useGrades.ts`)
- Legacy aggregation unchanged for `dummy_gpt5_baseline.json`

New types (`src/types/grade.ts`)
- `Verdict`, `DecidedBy`, `ItemGrade`, `TaskGradeV1`
- `OpenAICompatSummary`, `WowSummary`, `SectorWowMetric`,
  `RubricCategoryMetric`, `ScoreDensityBucket`, `RubricSeverityPoint`
- `GradeCostSummary`, `GradeSummaryV1`
- `JudgeProvenance`, `RubricProvenance`, `GradePromptInfo`

`src/hooks/useGrades.ts`
- `GradeResult` extended additively (all new fields optional, no breaking
  change for callers reading the legacy shape)

New WOW components (`src/components/wow/*`, 8 files)
- `WowCard` — reusable frame with WOW badge + InfoTooltip slot
- `RubricCoverageCard` (W1)
- `CriticalItemCard` (W2)
- `StructureVsReasoning` (W3, two-bar comparison)
- `SectorHeatmap` (W4, 11 × 3 grid; falls back to sector × {precheck,
  judge, critical} when `by_rubric_category` not broken down per sector)
- `ScoreDensityHistogram` (W5, falls back to `tasks_v1[*].pct` buckets
  when the schema histogram is empty — true for the 3-task smoke fixture)
- `RubricSeverityCurve` (W6, line chart by rubric weight)
- Only Recharts + framer-motion + lucide-react. No new npm deps.

`src/pages/GradeDetail.tsx`
- New `WowSection` rendered when `schema_version === '1.0' &&
  summary_v1 != null`, placed under the existing overview tiles
- Legacy v1 dummy view preserved unchanged

`src/components/GradesSummary.tsx`
- Adds a "WOW" badge on cards where `schema_version === '1.0'`

Copy sweep (spec 009 §C2)
- `tooltipTexts.ts` — replaces "external grading pipeline" /
  "external evaluation" / "pre-grading" language; adds
  `tooltipTexts.wow` block (6 keys for the W1-W6 cards)
- `ScopeBadge.tsx` — "Externally Graded" → "LLM-Judge Graded";
  "Self-Assessed · Pre-Grading" → "Awaiting LLM-Judge Grade"
- `GradingAnalysisView.tsx` — banner "Grading In Progress" →
  "Awaiting LLM-Judge Grade" with `grade-run.yml` CTA

## Verification

- `cd batch-runner && pytest tests/test_narrative_grade_integration.py
  tests/test_narrative_analyzer.py tests/test_grader.py
  tests/test_grade_schema.py` → **42/42 pass**
- `npm run aggregate` → both dummy (legacy) and exp998 (v1.0) processed
- `npm run build` (`tsc && vite build`) → succeeds, no `any` types added
- `grep -r "external grading|Pre-Grading|pre-grading|Grading In Progress" src/`
  → **no matches**

## Out of scope (intentional)

- W7 (Failure Mode Cluster) — spec says Phase A후반부 or Phase B
- Phase B cross-family judge calibration (separate PR, separate spec)
- The smoke run's `judge_error_rate=0.2381` issue (operational; tracked
  separately — suspected `per_item_max_output_tokens=800` truncation
  on reasoning-model outputs)
- evals_submitter.py removal — already done in PR #1

## Risk / rollback

- All Python changes are additive (`grade=None` default keeps legacy
  behaviour). Frontend types are all-optional additions. The aggregator
  preserves the legacy array contract for `grades-index.json`.
- Rollback: revert the two commits in this PR; no migrations, no
  schema/data file changes.
