### PR TITLE
fix(grading): populate inference_model, bump judge token budget 800→1600

### DIFF
--- a/batch-runner/grading_configs/default_gpt5pro.yaml
+++ b/batch-runner/grading_configs/default_gpt5pro.yaml
@@ -29,7 +29,13 @@ grader:
   precheck_patterns_version: "v1"
   evidence_max_chars: 200
   judge_max_retries: 1
-  per_item_max_output_tokens: 800
+  per_item_max_output_tokens: 1600  # bumped from 800 — reasoning models
+                                    # (gpt-5.4-pro effort=high) consume
+                                    # large reasoning-token budgets that
+                                    # count against output_tokens. Smoke
+                                    # at 800 produced 23.8% judge_error
+                                    # (output truncated). 1600 ~ 2x
+                                    # safety margin.
   save_raw_responses: false
   fail_on_missing_evidence: true
   deliverable_extract_max_chars: 4000

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -261,8 +261,8 @@ def _resolve_inference_model(
         return candidate
     if exp_config is not None:
         deployment = getattr(getattr(exp_config.condition_a, "model", None), "deployment", "")
-        if deployment:
-            return str(deployment)
+        if deployment and str(deployment).strip():
+            return str(deployment).strip()
     return ""
 
 

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -242,6 +242,30 @@ def _compute_summary(task_dicts: list[dict]) -> dict:
     }
 
 
+def _resolve_inference_model(
+    inf_results: dict, exp_config: ExperimentConfig | None
+) -> str:
+    """Return the deployment that actually produced the inference output.
+
+    Priority:
+      1. inf_results['model']  — what step2 (or HF reconstruct) recorded
+      2. exp_config.condition_a.model.deployment — fallback to the
+         experiment yaml (source of truth for the inference run)
+      3. '' — defensive default
+
+    Inference vs judge are different pipelines. Never fall back to
+    config['judge']['model'] here — that would silently mislead the UI.
+    """
+    candidate = (inf_results.get("model") or "").strip()
+    if candidate:
+        return candidate
+    if exp_config is not None:
+        deployment = getattr(getattr(exp_config.condition_a, "model", None), "deployment", "")
+        if deployment:
+            return str(deployment)
+    return ""
+
+
 def _build_grade_payload(
     exp_name: str,
     inf_results: dict,
@@ -250,12 +274,13 @@ def _build_grade_payload(
     loader: RubricLoader,
     prompt_version: str,
     task_dicts: list[dict],
+    exp_config: ExperimentConfig | None = None,
 ) -> dict:
     return {
         "schema_version": SCHEMA_VERSION,
         "experiment_id": exp_name,
         "experiment_yaml_name": exp_name,
-        "inference_model": inf_results.get("model") or "",
+        "inference_model": _resolve_inference_model(inf_results, exp_config),
         "inference_completed_at": inf_results.get("completed_at"),
         "judge": {
             "provider": config["judge"]["provider"],
@@ -318,7 +343,7 @@ def main() -> int:
     config_hash = hash_config(str(config_path))
 
     try:
-        _ = load_experiment_yaml(args.experiment_yaml_name)
+        exp_config = load_experiment_yaml(args.experiment_yaml_name)
     except Exception as exc:
         print(f"ERROR: experiment yaml load failed: {exc}", file=sys.stderr)
         return 1
@@ -395,6 +420,7 @@ def main() -> int:
                 loader,
                 grader.prompt_version,
                 task_payloads,
+                exp_config=exp_config,
             )
             _validate_schema(partial)
             _save_json(out_path, partial)
@@ -407,6 +433,7 @@ def main() -> int:
         loader,
         grader.prompt_version,
         task_payloads,
+        exp_config=exp_config,
     )
     _validate_schema(final)
     _save_json(out_path, final)

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -213,3 +213,72 @@ def test_exit_2_when_no_inference_results(monkeypatch, tmp_path):
 
     monkeypatch.setattr("sys.argv", ["step8_grade.py", "exp998_smoke_baseline_sample", "--config", "grading_configs/default.yaml"])
     assert s8.main() == 2
+
+
+def test_inference_model_resolved_from_inf_results_when_present(monkeypatch, tmp_path):
+    """inf_results['model'] takes priority when populated."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+
+    monkeypatch.setattr("sys.argv", ["step8_grade.py", "exp998_smoke_baseline_sample", "--config", "grading_configs/default.yaml", "--force"])
+    assert s8.main() == 0
+
+    out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["inference_model"] == "gpt-5.2-chat"
+    # never silently fall back to the judge model
+    assert payload["inference_model"] != payload["judge"]["model"]
+
+
+def test_inference_model_falls_back_to_experiment_yaml(monkeypatch, tmp_path):
+    """When inf_results['model'] is blank, pull deployment from experiment yaml."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+
+    # Simulate HF-reconstruct path that leaves model="" on the inference dict.
+    inf_path = tmp_path / "workspace" / "step2_inference_results.json"
+    inf = json.loads(inf_path.read_text(encoding="utf-8"))
+    inf["model"] = ""
+    inf_path.write_text(json.dumps(inf), encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["step8_grade.py", "exp998_smoke_baseline_sample", "--config", "grading_configs/default.yaml", "--force"])
+    assert s8.main() == 0
+
+    out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["inference_model"] == "gpt-5.2-chat"  # from yaml.condition_a.model.deployment
+
+
+def test_inference_model_never_falls_back_to_judge_model(monkeypatch, tmp_path):
+    """Defensive: even with both inf model empty and a degenerate yaml, never
+    leak judge model into inference_model."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+
+    # Wipe model in both sources.
+    inf_path = tmp_path / "workspace" / "step2_inference_results.json"
+    inf = json.loads(inf_path.read_text(encoding="utf-8"))
+    inf["model"] = ""
+    inf_path.write_text(json.dumps(inf), encoding="utf-8")
+
+    # Patch _resolve_inference_model's exp_config branch by giving an
+    # experiment yaml with no deployment field.
+    yaml_path = tmp_path / "experiments" / "exp998_smoke_baseline_sample.yaml"
+    yaml_data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    yaml_data["condition_a"]["model"]["deployment"] = ""
+    yaml_path.write_text(yaml.safe_dump(yaml_data), encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["step8_grade.py", "exp998_smoke_baseline_sample", "--config", "grading_configs/default.yaml", "--force"])
+    # ExperimentConfig default deployment is "gpt-4" when empty — but the
+    # important guarantee is: inference_model must NEVER equal judge.model
+    # just because both sources were missing. Verify by reading the payload.
+    assert s8.main() == 0
+    out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["inference_model"] != "gpt-5.4-pro"  # judge model

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -275,10 +275,15 @@ def test_inference_model_never_falls_back_to_judge_model(monkeypatch, tmp_path):
     yaml_path.write_text(yaml.safe_dump(yaml_data), encoding="utf-8")
 
     monkeypatch.setattr("sys.argv", ["step8_grade.py", "exp998_smoke_baseline_sample", "--config", "grading_configs/default.yaml", "--force"])
-    # ExperimentConfig default deployment is "gpt-4" when empty — but the
-    # important guarantee is: inference_model must NEVER equal judge.model
-    # just because both sources were missing. Verify by reading the payload.
     assert s8.main() == 0
     out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert payload["inference_model"] != "gpt-5.4-pro"  # judge model
+    # Independent of the literal judge string: inference_model must
+    # never equal whatever judge.model resolved to.
+    assert payload["inference_model"] != payload["judge"]["model"], (
+        "inference_model leaked judge model — _resolve_inference_model "
+        "must never read config['judge']."
+    )
+    # And in this degraded case the resolver must surface an empty
+    # string (defensive default).
+    assert payload["inference_model"] == ""


### PR DESCRIPTION
# fix(grading): populate inference_model + bump judge token budget

Track 1 hotfix bundled before the upcoming `dashboard_cleanup` PR.
Two correctness fixes for the grading pipeline, discovered while
visually verifying PR #46's output.

## What this PR does

### 1. `inference_model` now reflects the actual inference deployment

**Symptom**: After PR #46 merged, the GradeDetail page showed
`gpt-5.4-pro` as the model. But the smoke experiment `exp998` was
inferred by `gpt-5.2-chat` — users would think the judge model itself
solved the tasks (= self-grading).

**Root cause**: `scripts/download_inference_from_hf.py`'s parquet
reconstruct path writes `{"model": ""}`, and `step8_grade.py` blindly
forwards `inf_results.get('model') or ''` into the grade JSON. The
dashboard's `aggregate-grades.mjs` then did
`model = inference_model || judge.model` — silent fallback to the judge.

**Fix** (`batch-runner/step8_grade.py`):
```python
def _resolve_inference_model(inf_results, exp_config):
    # priority: inf_results['model'] -> experiment yaml -> ''
    # NEVER fall back to config['judge']['model'].
```
And pass through the already-loaded `ExperimentConfig` so the experiment
YAML's `condition_a.model.deployment` is the source of truth when step2
metadata is missing.

### 2. `per_item_max_output_tokens` 800 → 1600

**Symptom**: The first smoke run (May 21, exp998, 3 tasks) produced
`judge_error_rate = 0.2381` (20 of 84 calls). For an "engine OK" gate
we need < 5%.

**Hypothesis**: `gpt-5.4-pro` with `reasoning_effort=high` spends most
of its output-token budget on reasoning tokens (visible/invisible),
leaving the 800-token ceiling insufficient for the verdict JSON. The
SDK then surfaces the truncation as an error.

**Fix** (`batch-runner/grading_configs/default_gpt5pro.yaml`):
- `grader.per_item_max_output_tokens: 800 → 1600` (≈2× safety margin)
- inline comment documenting the rationale

Cost impact: negligible. Smoke ran ~$0 worth of tokens; even at 2×
output, total spend for the 220-task experiment stays under $100.

## Tests

Run from `batch-runner/`:
```
pytest tests/test_step8_grade.py \
       tests/test_grade_schema.py \
       tests/test_grader.py \
       tests/test_narrative_grade_integration.py \
       tests/test_narrative_analyzer.py -q
```

→ **51/51 pass**, including 3 new cases in `test_step8_grade.py`:
- `test_inference_model_resolved_from_inf_results_when_present`
- `test_inference_model_falls_back_to_experiment_yaml`
- `test_inference_model_never_falls_back_to_judge_model`

## Verification plan (after merge)

1. Re-run `grade-run.yml` on `exp998_smoke_baseline_sample` with
   `force: true`.
2. Check the resulting grade JSON:
   ```
   jq '{inf: .inference_model, judge: .judge.model, err: .summary.wow.judge_error_rate}' \
     data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json
   ```
   Expected:
   ```json
   {"inf": "gpt-5.2-chat", "judge": "gpt-5.4-pro", "err": <0.05>}
   ```
3. If both green → proceed with the `dashboard_cleanup` PR
   (spec already merged to `main` under `tasks/dashboard_cleanup/`).
4. Then trigger Stage 2 (exp025, 220 tasks).

## Out of scope

- Dashboard rendering of `inference_model` vs `judge_model` — handled
  by the upcoming `feat/dashboard-cleanup` PR (spec already merged).
- `scripts/download_inference_from_hf.py` improvements — the YAML
  fallback covers the most common gap; the script can be improved
  separately.

## Rollback

`git revert <merge_commit>` — no schema migration, no data file
changes. The schema already permitted `inference_model: ''` so existing
graded files remain valid.
