### PR TITLE
feat(dashboard): show Self-QA vs Rubric calibration on GradeDetail (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Added
+- `tasks/0523_saturday/TASK_GRADE_COST_OPTIMIZATION.md` — judge 채점 비용/시간 압축 계획 (smoke 142m → 30m, 풀런 ~$540 → ≤$120). reasoning_effort, precheck 확장, item batching, tiered judge routing(mini=extended precheck / standard=gpt-5.5 / pro=critical only), concurrency 상향의 단계별 실행안.
+- `tasks/0523_saturday/TASK_GRADE_COST_SWEEP.md` — 자율 dispatch sweep 사양. `scripts/grading_cost_sweep.py`가 16+5+6+1=28개 변종(Phase A 단축/Phase B 조합/Phase C 안정성/diversity)을 Global Standard API + prompt-level batching으로 실행하여 정확도 제약(critical=1.0, err≤5%, score±2pp) 내 Pareto 우승자를 자동 도출하고 `RESULTS.md` + `winner_config.yaml`을 생성. 사용 모델은 endpoint 가용 5.4 family(pro/std/mini/nano) + gpt-4o(diversity only). cost_cap_usd $80 강제.
+- Grade detail page: Self-QA vs Rubric calibration view (Phase 1). Three new columns (Self-QA, Δ Gap, Calibration), three new filters (Calibrated/Overconfident/Underconfident), Calibration MAE pill in Health Strip, and footer match-rate note. Build-time join via `aggregate-reports.mjs` enriching reports-index with compact `task_qa` map; `aggregate-grades.mjs` performs strict per-experiment lookup (no global task_id map). Dummy grades and unmatched experiments are explicitly handled. Spec: `tasks/0523_saturday/TASK_GRADE_DETAIL_SELF_QA_CALIBRATION.md`. Follow-up: `TASK_GRADE_SOURCE_LINKAGE_BACKEND.md`.
+
 ## [2026-05-23] — Phase A wow follow-up: dashboard cleanup + grading hotfix
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "version": "0.2.0",
   "type": "module",
   "scripts": {
-    "aggregate": "node scripts/aggregate-tests.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-experiments.mjs",
+    "aggregate": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
     "test:aggregate": "node --test scripts/__tests__/aggregate-grades.test.mjs",
-    "predev": "node scripts/aggregate-tests.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-experiments.mjs",
+    "predev": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
     "dev": "vite",
-    "prebuild": "node scripts/aggregate-tests.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-experiments.mjs",
+    "prebuild": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },

--- a/scripts/__tests__/aggregate-grades.test.mjs
+++ b/scripts/__tests__/aggregate-grades.test.mjs
@@ -112,3 +112,340 @@ test('processGradesFile: legacy dummy sets grade_status=legacy_dummy and judge_m
   assert.equal(out.schema_version, null);
   assert.equal(out.experiment_id, 'dummy_gpt5_baseline');
 });
+
+// ── Fixture D — v1 grade joined with taskQaByExperiment map ────────────────
+// Two tasks both matched: qa=8/10 + rubric=85% → delta=+5 (calibrated);
+//                          qa=9/10 + rubric=60% → delta=−30 (overconfident).
+// Expected MAE = (|+5| + |−30|) / 2 = 17.50.
+test('processGradesFile: v1 with per-experiment qa map decorates tasks and computes MAE/counts', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'exp998_smoke_baseline_sample',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4-pro' },
+    summary: {
+      total_tasks: 2,
+      graded_tasks: 2,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 72.5, ci_pct: 0,
+        perfect_count: 0, partial_count: 2, zero_count: 0, inconsistent_count: 0,
+      },
+      wow: {},
+    },
+    tasks: [
+      { task_id: 't_aligned', pct: 85, error: null },
+      { task_id: 't_over',    pct: 60, error: null },
+    ],
+  };
+  const taskQaByExperiment = new Map([
+    ['exp998_smoke_baseline_sample', { t_aligned: 8, t_over: 9 }],
+  ]);
+
+  const out = processGradesFile('exp998_smoke__judge__sha__v1.json', raw, taskQaByExperiment);
+
+  // qa_score is preserved on both legacy-shaped tasks and raw v1 tasks
+  assert.equal(out.tasks[0].qa_score, 8);
+  assert.equal(out.tasks[1].qa_score, 9);
+  assert.equal(out.tasks_v1[0].qa_score, 8);
+  assert.equal(out.tasks_v1[1].qa_score, 9);
+
+  // MAE = (5 + 30) / 2 = 17.50 (rounded to 2 decimals)
+  assert.equal(out.summary.calibration_mae, 17.5);
+  assert.equal(out.summary_v1.calibration_mae, 17.5);
+
+  // Δ +5 → calibrated; Δ −30 → overconfident; none underconfident; 0 unmatched
+  assert.deepEqual(out.summary.calibration_counts, {
+    calibrated: 1, overconfident: 1, underconfident: 0, unmatched: 0,
+  });
+});
+
+// ── Fixture E — v1 grade with no qa_score map (fresh repo) ──────────────────
+// All tasks get qa_score=null and land in `unmatched`; MAE must be null.
+test('processGradesFile: v1 with empty qa_score map yields null qa_score and null MAE', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'exp998_smoke_baseline_sample',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4-pro' },
+    summary: {
+      total_tasks: 2,
+      graded_tasks: 2,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 75, ci_pct: 0,
+        perfect_count: 0, partial_count: 2, zero_count: 0, inconsistent_count: 0,
+      },
+      wow: {},
+    },
+    tasks: [
+      { task_id: 't_a', pct: 80, error: null },
+      { task_id: 't_b', pct: 70, error: null },
+    ],
+  };
+
+  // No second arg → default empty Map ⇒ all tasks unmatched
+  const out = processGradesFile('exp998__judge__sha__v1.json', raw);
+
+  assert.equal(out.tasks[0].qa_score, null);
+  assert.equal(out.tasks[1].qa_score, null);
+  assert.equal(out.summary.calibration_mae, null);
+  assert.equal(out.summary_v1.calibration_mae, null);
+  assert.deepEqual(out.summary.calibration_counts, {
+    calibrated: 0, overconfident: 0, underconfident: 0, unmatched: 2,
+  });
+});
+
+// ── Fixture F — partial match (one task in map, one not) ────────────────────
+// Verifies unmatched counter and that MAE is computed only over matched samples.
+test('processGradesFile: v1 with partial qa_score match — only matched task contributes to MAE', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'exp_partial',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4-pro' },
+    summary: {
+      total_tasks: 2,
+      graded_tasks: 2,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 60, ci_pct: 0,
+        perfect_count: 0, partial_count: 2, zero_count: 0, inconsistent_count: 0,
+      },
+      wow: {},
+    },
+    tasks: [
+      { task_id: 't_matched',   pct: 50, error: null },
+      { task_id: 't_unmatched', pct: 70, error: null },
+    ],
+  };
+  // Only one task in the experiment's map; pct=50 ⇒ rubric=50%, qa=2 ⇒ self=20%, Δ=+30
+  const taskQaByExperiment = new Map([
+    ['exp_partial', { t_matched: 2 }],
+  ]);
+
+  const out = processGradesFile('exp_partial__judge__sha__v1.json', raw, taskQaByExperiment);
+
+  assert.equal(out.tasks[0].qa_score, 2);
+  assert.equal(out.tasks[1].qa_score, null);
+  assert.equal(out.summary.calibration_mae, 30, 'MAE = |+30| / 1 = 30');
+  assert.deepEqual(out.summary.calibration_counts, {
+    calibrated: 0, overconfident: 0, underconfident: 1, unmatched: 1,
+  });
+});
+
+// ── Fixture G — legacy dummy is ALWAYS unmatched regardless of qa map ──────
+// Per spec section 1b: dummy grades come from synthetic scores, NOT a real
+// inference run. They must never inherit qa_score from an unrelated report
+// even if a global / same-named map happens to contain matching task_ids.
+test('processGradesFile: legacy dummy ignores qa map and yields all-null qa_score', () => {
+  const raw = {
+    _meta: { is_dummy: true, model: 'GPT-5 (Baseline)' },
+    tasks: [
+      { task_id: 't1', num_grades: 1, scores: [1.0], avg_score: 1.0, error: false, error_messages: [] },
+      { task_id: 't2', num_grades: 1, scores: [0.0], avg_score: 0.0, error: false, error_messages: [] },
+    ],
+  };
+  // Even though this map names the dummy's experiment_id with valid scores,
+  // the resolver MUST return null for every task because is_dummy=true.
+  const taskQaByExperiment = new Map([
+    ['dummy_gpt5_baseline', { t1: 10, t2: 8 }],
+  ]);
+
+  const out = processGradesFile('dummy_gpt5_baseline.json', raw, taskQaByExperiment);
+
+  assert.equal(out.tasks[0].qa_score, null, 'dummy task 1 must be null');
+  assert.equal(out.tasks[1].qa_score, null, 'dummy task 2 must be null');
+  assert.equal(out.summary.calibration_mae, null);
+  assert.deepEqual(out.summary.calibration_counts, {
+    calibrated: 0, overconfident: 0, underconfident: 0, unmatched: 2,
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Strict per-experiment matching tests (T1-T5)
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── T1 — Real grade with matching report (mixed matched/unmatched) ────────
+test('T1: real grade matches reports-index by experiment_id (matched + unmatched)', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'expA',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4-pro' },
+    summary: {
+      total_tasks: 3,
+      graded_tasks: 3,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 65, ci_pct: 0,
+        perfect_count: 0, partial_count: 3, zero_count: 0, inconsistent_count: 0,
+      },
+      wow: {},
+    },
+    tasks: [
+      { task_id: 'uuid-1', pct: 85, error: null },  // qa=8 → Δ = 85-80 = +5  (calibrated)
+      { task_id: 'uuid-2', pct: 60, error: null },  // qa=5 → Δ = 60-50 = +10 (calibrated, boundary)
+      { task_id: 'uuid-3', pct: 50, error: null },  // no qa → unmatched
+    ],
+  };
+  const taskQaByExperiment = new Map([
+    ['expA', { 'uuid-1': 8, 'uuid-2': 5 }],
+  ]);
+
+  const out = processGradesFile('expA__judge__sha__v1.json', raw, taskQaByExperiment);
+
+  assert.equal(out.tasks[0].qa_score, 8);
+  assert.equal(out.tasks[1].qa_score, 5);
+  assert.equal(out.tasks[2].qa_score, null);
+  // MAE over the 2 matched samples = (|+5| + |+10|) / 2 = 7.5
+  assert.equal(out.summary.calibration_mae, 7.5);
+  assert.deepEqual(out.summary.calibration_counts, {
+    calibrated: 2, overconfident: 0, underconfident: 0, unmatched: 1,
+  });
+});
+
+// ── T2 — Dummy grade: all qa_score null regardless of reports content ─────
+test('T2: dummy grade yields all-null qa_score and MAE=null regardless of map content', () => {
+  const raw = {
+    _meta: { is_dummy: true, model: 'Dummy Model' },
+    tasks: Array.from({ length: 4 }, (_, i) => ({
+      task_id: `uuid-${i}`,
+      num_grades: 1,
+      scores: [0.5],
+      avg_score: 0.5,
+      error: false,
+      error_messages: [],
+    })),
+  };
+  // Map populated with the dummy's id and valid scores → MUST be ignored.
+  const taskQaByExperiment = new Map([
+    ['dummy_grade', { 'uuid-0': 1, 'uuid-1': 5, 'uuid-2': 9, 'uuid-3': 10 }],
+  ]);
+
+  const out = processGradesFile('dummy_grade.json', raw, taskQaByExperiment);
+
+  assert.equal(out.is_dummy, true);
+  for (const t of out.tasks) assert.equal(t.qa_score, null);
+  assert.equal(out.summary.calibration_mae, null);
+  assert.deepEqual(out.summary.calibration_counts, {
+    calibrated: 0, overconfident: 0, underconfident: 0, unmatched: 4,
+  });
+});
+
+// ── T3 — Non-dummy grade with no matching report entry ────────────────────
+test('T3: real grade with no matching report → all qa_score null, MAE=null, all unmatched', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'exp_no_report',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4-pro' },
+    summary: {
+      total_tasks: 2,
+      graded_tasks: 2,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 75, ci_pct: 0,
+        perfect_count: 0, partial_count: 2, zero_count: 0, inconsistent_count: 0,
+      },
+      wow: {},
+    },
+    tasks: [
+      { task_id: 'uuid-a', pct: 80, error: null },
+      { task_id: 'uuid-b', pct: 70, error: null },
+    ],
+  };
+  // Map contains a DIFFERENT experiment → strict matching must not leak.
+  const taskQaByExperiment = new Map([
+    ['some_other_exp', { 'uuid-a': 9, 'uuid-b': 7 }],
+  ]);
+
+  const out = processGradesFile('exp_no_report__j__s__v1.json', raw, taskQaByExperiment);
+
+  assert.equal(out.tasks[0].qa_score, null);
+  assert.equal(out.tasks[1].qa_score, null);
+  assert.equal(out.summary.calibration_mae, null);
+  assert.deepEqual(out.summary.calibration_counts, {
+    calibrated: 0, overconfident: 0, underconfident: 0, unmatched: 2,
+  });
+});
+
+// ── T4 — MAE calculation precision (canonical example) ────────────────────
+// Two matched tasks:
+//   qa=8/10, rubric=85% → Δ = 85 - 80 = +5  (|Δ|=5,  calibrated)
+//   qa=9/10, rubric=60% → Δ = 60 - 90 = -30 (|Δ|=30, overconfident)
+// Expected MAE = (5 + 30) / 2 = 17.5
+test('T4: MAE precision — (5 + 30) / 2 = 17.50; counts = 1 calibrated, 1 overconfident', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'expMAE',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4-pro' },
+    summary: {
+      total_tasks: 2,
+      graded_tasks: 2,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 72.5, ci_pct: 0,
+        perfect_count: 0, partial_count: 2, zero_count: 0, inconsistent_count: 0,
+      },
+      wow: {},
+    },
+    tasks: [
+      { task_id: 't_aligned', pct: 85, error: null },
+      { task_id: 't_over',    pct: 60, error: null },
+    ],
+  };
+  const taskQaByExperiment = new Map([
+    ['expMAE', { t_aligned: 8, t_over: 9 }],
+  ]);
+
+  const out = processGradesFile('expMAE__j__s__v1.json', raw, taskQaByExperiment);
+
+  assert.equal(out.summary.calibration_mae, 17.5);
+  assert.equal(out.summary_v1.calibration_mae, 17.5);
+  assert.deepEqual(out.summary.calibration_counts, {
+    calibrated: 1, overconfident: 1, underconfident: 0, unmatched: 0,
+  });
+});
+
+// ── T5 — Error tasks are excluded from calibration counts entirely ────────
+// A task with `error: 'something'` must not appear in samples nor in unmatched.
+test('T5: error tasks are excluded from calibration_counts (neither sampled nor unmatched)', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'expErr',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4-pro' },
+    summary: {
+      total_tasks: 3,
+      graded_tasks: 2,
+      error_tasks: 1,
+      openai_compat: {
+        avg_score_pct: 75, ci_pct: 0,
+        perfect_count: 0, partial_count: 2, zero_count: 0, inconsistent_count: 0,
+      },
+      wow: {},
+    },
+    tasks: [
+      { task_id: 'ok-1',  pct: 80,   error: null },          // qa=7 → Δ = 80-70 = +10 (calibrated)
+      { task_id: 'err-1', pct: null, error: 'judge failed' },// error → excluded
+      { task_id: 'ok-2',  pct: 70,   error: null },          // no qa → unmatched
+    ],
+  };
+  const taskQaByExperiment = new Map([
+    ['expErr', { 'ok-1': 7 }],
+  ]);
+
+  const out = processGradesFile('expErr__j__s__v1.json', raw, taskQaByExperiment);
+
+  // Error task must be marked as errored on the legacy-shaped tasks row.
+  assert.equal(out.tasks[1].error, true);
+
+  // calibration_counts: ok-1 = calibrated, ok-2 = unmatched, err-1 = excluded.
+  assert.deepEqual(out.summary.calibration_counts, {
+    calibrated: 1, overconfident: 0, underconfident: 0, unmatched: 1,
+  });
+  // MAE over the single matched sample = |+10| / 1 = 10.
+  assert.equal(out.summary.calibration_mae, 10);
+});

--- a/scripts/aggregate-grades.mjs
+++ b/scripts/aggregate-grades.mjs
@@ -36,11 +36,68 @@ function experimentIdFromFilename(filename) {
   return idx > 0 ? filename.slice(0, idx) : filename;
 }
 
+// ── Calibration helpers ────────────────────────────────────────────────────
+// Build summary-level calibration stats from a list of legacy-shaped task rows
+// already decorated with `qa_score` (0-10) and `avg_score` (0-1).
+// Convention: delta = (avg_score * 100) - (qa_score * 10). Positive Δ ⇒ rubric
+// > self (model underconfident); negative Δ ⇒ rubric < self (overconfident).
+function buildCalibration(tasks) {
+  const samples = [];
+  let unmatched = 0;
+  for (const t of tasks) {
+    if (t.error) continue;
+    if (t.qa_score == null) { unmatched++; continue; }
+    if (t.avg_score == null) continue;
+    const delta = (t.avg_score * 100) - (t.qa_score * 10);
+    samples.push(delta);
+  }
+  const calibration_mae = samples.length > 0
+    ? Number((samples.reduce((s, d) => s + Math.abs(d), 0) / samples.length).toFixed(2))
+    : null;
+  const calibration_counts = {
+    calibrated: samples.filter(d => Math.abs(d) <= 10).length,
+    overconfident: samples.filter(d => d < -10).length,
+    underconfident: samples.filter(d => d > 10).length,
+    unmatched,
+  };
+  return { calibration_mae, calibration_counts };
+}
+
+// ── qa_score resolution (strict per-experiment) ───────────────────────────
+// Returns a function (taskId) → qa_score|null for a given grade.
+// Strict rules:
+//   - Dummy grades have no real inference run → always null (caller must not
+//     accidentally pick up unrelated qa values from a same-task-id report).
+//   - Otherwise, look up the experiment's task_qa map by grade.experiment_id.
+//     Missing experiment or missing task → null. Never falls back to a
+//     global / cross-experiment map.
+function makeQaResolver(experiment_id, is_dummy, taskQaByExperiment) {
+  if (is_dummy) return () => null;
+  const qaMap = taskQaByExperiment?.get(experiment_id) ?? null;
+  if (!qaMap) return () => null;
+  return (taskId) => {
+    if (!taskId) return null;
+    const v = qaMap[taskId];
+    return typeof v === 'number' ? v : null;
+  };
+}
+
 // ── Legacy (dummy / _meta-based) format ────────────────────────────────────
-function processLegacyGradesFile(filePath, raw) {
+function processLegacyGradesFile(filePath, raw, taskQaByExperiment = new Map()) {
   const filename = basename(filePath, '.json');
   const meta = raw._meta || {};
-  const tasks = raw.tasks || raw; // support both { _meta, tasks } and bare array
+  const rawTasks = raw.tasks || raw; // support both { _meta, tasks } and bare array
+
+  const is_dummy = !!meta.is_dummy;
+  const experiment_id = meta.experiment_id || experimentIdFromFilename(filename);
+  const qaFor = makeQaResolver(experiment_id, is_dummy, taskQaByExperiment);
+
+  // Decorate each task with qa_score (null when no match) so the GradeDetail
+  // table can render Self-QA / Δ Gap / Calibration columns.
+  const tasks = rawTasks.map(t => ({
+    ...t,
+    qa_score: qaFor(t.task_id),
+  }));
 
   const gradedTasks = tasks.filter(t => !t.error && t.avg_score !== null);
   const errorTasks = tasks.filter(t => t.error);
@@ -68,12 +125,14 @@ function processLegacyGradesFile(filePath, raw) {
   const judge_model = null;
   const model = inference_model || '';
 
-  const is_dummy = !!meta.is_dummy;
   const grade_status = is_dummy ? 'legacy_dummy' : 'no_grade';
+
+  // Self-QA vs Rubric calibration stats (null when no tasks have qa_score).
+  const { calibration_mae, calibration_counts } = buildCalibration(tasks);
 
   return {
     id: filename,
-    experiment_id: meta.experiment_id || experimentIdFromFilename(filename),
+    experiment_id,
     grade_status,
     schema_version: null,
     is_dummy,
@@ -92,6 +151,8 @@ function processLegacyGradesFile(filePath, raw) {
       partial_score: partial,
       zero_score: zero,
       inconsistent_grades: inconsistent,
+      calibration_mae,
+      calibration_counts,
     },
     tasks,
   };
@@ -102,17 +163,27 @@ function processLegacyGradesFile(filePath, raw) {
 // Maps raw item-level grade JSON onto the dashboard's existing legacy shape
 // while preserving the full v1 payload in summary_v1 / tasks_v1 so WOW
 // components can consume rich item-level data.
-function processV1GradesFile(filePath, raw) {
+function processV1GradesFile(filePath, raw, taskQaByExperiment = new Map()) {
   const filename = basename(filePath, '.json');
   const rawTasks = Array.isArray(raw.tasks) ? raw.tasks : [];
   const summary = raw.summary || {};
   const openaiCompat = summary.openai_compat || {};
   const wow = summary.wow || {};
 
+  // v1 path: prefer human-readable label/title from raw, fall back through
+  // experiment_id, finally filename. Aggregator caller may add a `label`
+  // field to grade JSON in future spec versions; this is forward-compatible.
+  const label = raw.label || raw.title || raw.experiment_id || filename;
+  const experiment_id = raw.experiment_id || experimentIdFromFilename(filename);
+
+  // Strict per-experiment Self-QA resolver. v1 grades are never dummies.
+  const qaFor = makeQaResolver(experiment_id, false, taskQaByExperiment);
+
   // Convert v1 tasks → legacy-compatible task rows. Snap pct to exact 0/1
   // when it crosses the openai_compat thresholds (pct >= 99 → perfect,
   // pct <= 1 → zero) so legacy Status badges agree with summary counts.
   const tasks = rawTasks.map((t) => {
+    const qa_score = qaFor(t.task_id);
     const hasError = t.error !== null && t.error !== undefined && t.error !== '';
     if (hasError) {
       return {
@@ -122,6 +193,7 @@ function processV1GradesFile(filePath, raw) {
         avg_score: null,
         error: true,
         error_messages: [String(t.error)],
+        qa_score,
       };
     }
     const pct = typeof t.pct === 'number' ? t.pct : 0;
@@ -136,8 +208,12 @@ function processV1GradesFile(filePath, raw) {
       avg_score: avgScore,
       error: false,
       error_messages: [],
+      qa_score,
     };
   });
+
+  // Decorate raw v1 tasks too — GradeDetail page reads from tasks_v1 directly.
+  const tasks_v1 = rawTasks.map((t) => ({ ...t, qa_score: qaFor(t.task_id) }));
 
   const totalTasks = typeof summary.total_tasks === 'number'
     ? summary.total_tasks
@@ -149,12 +225,6 @@ function processV1GradesFile(filePath, raw) {
     ? summary.graded_tasks
     : totalTasks - errorTasks;
 
-  // v1 path: prefer human-readable label/title from raw, fall back through
-  // experiment_id, finally filename. Aggregator caller may add a `label`
-  // field to grade JSON in future spec versions; this is forward-compatible.
-  const label = raw.label || raw.title || raw.experiment_id || filename;
-  const experiment_id = raw.experiment_id || experimentIdFromFilename(filename);
-
   // Explicit fields with no silent fallback. Empty / missing inference_model
   // surfaces as null in the dashboard so the UI can render "unknown" instead
   // of inheriting the judge model name (the bug fixed in this PR).
@@ -164,6 +234,10 @@ function processV1GradesFile(filePath, raw) {
   const judge_model = raw.judge && raw.judge.model ? raw.judge.model : null;
   // Legacy `model` field: inference only. Never falls back to judge.
   const model = inference_model || '';
+
+  // Self-QA vs Rubric calibration stats — computed from legacy-shaped `tasks`
+  // (which carry the snapped avg_score) so MAE aligns with rendered scores.
+  const { calibration_mae, calibration_counts } = buildCalibration(tasks);
 
   return {
     id: filename,
@@ -188,6 +262,8 @@ function processV1GradesFile(filePath, raw) {
       partial_score: openaiCompat.partial_count ?? 0,
       zero_score: openaiCompat.zero_count ?? 0,
       inconsistent_grades: openaiCompat.inconsistent_count ?? 0,
+      calibration_mae,
+      calibration_counts,
     },
     tasks,
     // v1.0 provenance + full payload (for WOW dashboard components)
@@ -195,16 +271,46 @@ function processV1GradesFile(filePath, raw) {
     rubric: raw.rubric,
     prompt: raw.prompt,
     graded_at: raw.graded_at,
-    summary_v1: { ...summary, wow, openai_compat: openaiCompat },
-    tasks_v1: rawTasks,
+    summary_v1: { ...summary, wow, openai_compat: openaiCompat, calibration_mae, calibration_counts },
+    tasks_v1,
   };
 }
 
-export function processGradesFile(filePath, raw) {
+export function processGradesFile(filePath, raw, taskQaByExperiment = new Map()) {
   if (raw && raw.schema_version === '1.0') {
-    return processV1GradesFile(filePath, raw);
+    return processV1GradesFile(filePath, raw, taskQaByExperiment);
   }
-  return processLegacyGradesFile(filePath, raw);
+  return processLegacyGradesFile(filePath, raw, taskQaByExperiment);
+}
+
+// ── taskQaByExperiment lookup ─────────────────────────────────────────────
+// Build Map<experiment_id, Record<task_id, qa_score>> from reports-index.json.
+// STRICT: reports-index is the only source. No fallback to batch-runner/results/
+// — the previous global-task_id map produced incorrect cross-experiment matches
+// because GDPVal task_ids are shared across all experiments running the same
+// dataset. Missing reports-index ⇒ empty Map ⇒ all qa_score = null.
+async function buildTaskQaByExperiment() {
+  const map = new Map();
+  const indexPath = join(OUTPUT_DIR, 'reports-index.json');
+  let raw;
+  try {
+    raw = JSON.parse(await readFile(indexPath, 'utf-8'));
+  } catch (err) {
+    // ENOENT = file not yet generated (first build, fresh repo) — silent fallback.
+    // Other errors (parse failure, permission, etc.) deserve a warning so they
+    // are not silently masked as "no qa_score available".
+    if (err && err.code !== 'ENOENT') {
+      console.warn(`⚠️  reports-index.json unreadable (${err.message}); all qa_score will be null.`);
+    }
+    return map;
+  }
+  for (const report of raw.reports ?? []) {
+    const expId = report?.meta?.experiment_id;
+    if (expId && report.task_qa && typeof report.task_qa === 'object') {
+      map.set(expId, report.task_qa);
+    }
+  }
+  return map;
 }
 
 // ── Main ──
@@ -222,12 +328,19 @@ async function main() {
     return;
   }
 
+  // Build experiment_id → task_qa lookup once for all grade files.
+  // Strict per-experiment matching; reports-index.json is the sole source.
+  const taskQaByExperiment = await buildTaskQaByExperiment();
+  const totalQaTasks = Array.from(taskQaByExperiment.values())
+    .reduce((n, m) => n + Object.keys(m).length, 0);
+  console.log(`ℹ️  task_qa lookup built: ${taskQaByExperiment.size} experiment(s), ${totalQaTasks} task(s)`);
+
   const results = [];
   for (const file of jsonFiles) {
     const content = await readFile(join(GRADES_DIR, file), 'utf-8');
     try {
       const data = JSON.parse(content);
-      results.push(processGradesFile(file, data));
+      results.push(processGradesFile(file, data, taskQaByExperiment));
     } catch (err) {
       console.error(`⚠️  ${file} 파싱 실패:`, err.message);
     }

--- a/scripts/aggregate-reports.mjs
+++ b/scripts/aggregate-reports.mjs
@@ -53,8 +53,16 @@ async function loadAllReports() {
       const { data, source } = await fetchReportData(subdir.name, reportPath);
       if (source === 'hf') console.log(`  ↓ ${subdir.name}: fetched from HuggingFace`);
 
+      // Extract compact qa map (task_id → qa_score) before stripping the heavy task_results array.
+      // Used by aggregate-grades.mjs for per-experiment Self-QA ↔ Rubric calibration join.
+      const taskQa = {};
+      for (const t of (data.task_results ?? [])) {
+        if (t.task_id && t.qa_score != null) taskQa[t.task_id] = t.qa_score;
+      }
+
       // Strip task_results — heavy per-task data is lazy-loaded from HuggingFace on the detail page
       const { task_results: _ignored, ...indexEntry } = data;
+      indexEntry.task_qa = taskQa;
       indexEntry.short_id = shortId;
 
       reports.push(indexEntry);

--- a/src/components/wow/HealthStrip.tsx
+++ b/src/components/wow/HealthStrip.tsx
@@ -93,6 +93,13 @@ export default function HealthStrip({ summaryV1, delay = 0 }: Props) {
               value={fmtLatency(cost?.total_judge_latency_sec)}
               tooltip={tooltipTexts.health.judgeLatency}
             />
+            <NeutralPill
+              label="MAE"
+              value={summaryV1.calibration_mae != null
+                ? `${summaryV1.calibration_mae.toFixed(1)}pp`
+                : '—'}
+              tooltip={tooltipTexts.health.calibrationMae}
+            />
           </div>
         </CardContent>
       </Card>

--- a/src/data/tooltipTexts.ts
+++ b/src/data/tooltipTexts.ts
@@ -63,6 +63,18 @@ export const tooltipTexts = {
       'Total number of LLM-judge API calls used during grading. Per-experiment cost proxy.',
     judgeLatency:
       'Total wall-clock seconds spent inside the judge LLM during this grading run.',
+    calibrationMae:
+      'Mean Absolute Error of Self-QA vs Rubric across all tasks. Lower = better model self-awareness. <10pp is well-calibrated.',
+  },
+  calibration: {
+    selfQa:
+      'Self-rated quality score during inference (0-10). The inference model evaluates its own output. Distinct from external rubric judge.',
+    rubric:
+      'Independent rubric-based score by external judge LLM. Objective and decoupled from the inference model.',
+    gap:
+      'Rubric − Self-QA (percentage points). Negative = model overconfident (risk). Positive = model underconfident. |Δ| ≤ 10pp is well-calibrated.',
+    status:
+      'Aligned (|Δ|≤10): well-calibrated. Overconfident (Δ<-10): model overestimates its own work. Underconfident (Δ>10): model underestimates.',
   },
   badge: {
     selfAssessed:

--- a/src/hooks/useGrades.ts
+++ b/src/hooks/useGrades.ts
@@ -5,6 +5,7 @@ import type {
   JudgeProvenance,
   RubricProvenance,
   GradePromptInfo,
+  CalibrationCounts,
 } from '../types/grade'
 
 export interface TaskGrade {
@@ -14,6 +15,8 @@ export interface TaskGrade {
   avg_score: number | null
   error: boolean
   error_messages: string[]
+  /** Inference-time Self-QA score (0–10). Enriched from reports-index task_qa map. */
+  qa_score?: number | null
 }
 
 export interface GradeSummary {
@@ -26,6 +29,10 @@ export interface GradeSummary {
   partial_score: number
   zero_score: number
   inconsistent_grades: number
+  /** Mean |Rubric% − SelfQA%| across matched tasks. null when no samples. */
+  calibration_mae?: number | null
+  /** Distribution of calibration categories. null when no samples. */
+  calibration_counts?: CalibrationCounts | null
 }
 
 export interface GradeResult {

--- a/src/pages/GradeDetail.tsx
+++ b/src/pages/GradeDetail.tsx
@@ -12,6 +12,9 @@ import {
   ExternalLink,
   HelpCircle,
   BookOpen,
+  TrendingDown,
+  TrendingUp,
+  AlertTriangle,
 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card'
 import {
@@ -41,7 +44,16 @@ import {
 import InfoTooltip from '../components/common/InfoTooltip'
 import { tooltipTexts } from '../data/tooltipTexts'
 
-type TaskFilter = 'all' | 'perfect' | 'partial' | 'zero' | 'error' | 'inconsistent'
+type TaskFilter =
+  | 'all'
+  | 'perfect'
+  | 'partial'
+  | 'zero'
+  | 'error'
+  | 'inconsistent'
+  | 'calibrated'
+  | 'overconfident'
+  | 'underconfident'
 
 const TERM_DEFINITIONS: Record<string, string> = {
   graded: 'Tasks that received a score — excludes any that errored out.',
@@ -52,6 +64,9 @@ const TERM_DEFINITIONS: Record<string, string> = {
   errors: 'Tasks that could not be evaluated due to API failures, timeouts, or parsing issues.',
   inconsistent: 'Multiple graders scored the same task differently.',
   disagreement: 'Multiple graders scored the same task differently — indicates ambiguous rubric or borderline output.',
+  calibrated: 'Tasks where |Rubric − Self-QA| ≤ 10pp. Model self-assessment matches external rubric.',
+  overconfident: 'Tasks where Rubric − Self-QA < −10pp. Model rated itself higher than rubric. Risk signal.',
+  underconfident: 'Tasks where Rubric − Self-QA > +10pp. Model underestimated its own work.',
 }
 
 const FILTER_LABELS: Record<Exclude<TaskFilter, 'all'>, string> = {
@@ -60,6 +75,34 @@ const FILTER_LABELS: Record<Exclude<TaskFilter, 'all'>, string> = {
   zero: 'Zero',
   error: 'Error',
   inconsistent: 'Inconsistent',
+  calibrated: 'Calibrated',
+  overconfident: 'Overconfident',
+  underconfident: 'Underconfident',
+}
+
+// Compute Δ = Rubric% − SelfQA%. Returns null if any input is missing.
+function computeDelta(qa_score: number | null | undefined, avg_score: number | null | undefined): number | null {
+  if (qa_score == null || avg_score == null) return null
+  return (avg_score * 100) - (qa_score * 10)
+}
+
+function gapStyle(delta: number | null): { className: string; severe: boolean } {
+  if (delta == null) return { className: 'text-muted-foreground', severe: false }
+  const abs = Math.abs(delta)
+  if (abs <= 10) return { className: 'text-muted-foreground bg-muted/30', severe: false }
+  if (abs <= 30) return { className: 'text-amber-500 bg-amber-500/10', severe: false }
+  return { className: 'text-red-500 bg-red-500/10', severe: true }
+}
+
+function calibStatus(delta: number | null): {
+  icon: typeof Target | null
+  label: string
+  className: string
+} {
+  if (delta == null) return { icon: null, label: '—', className: 'text-muted-foreground' }
+  if (Math.abs(delta) <= 10) return { icon: Target, label: 'Aligned', className: 'text-muted-foreground' }
+  if (delta < -10) return { icon: TrendingDown, label: 'Over', className: 'text-red-500' }
+  return { icon: TrendingUp, label: 'Under', className: 'text-amber-500' }
 }
 
 function TermTooltip({ term, definition, className }: { term: string; definition?: string; className?: string }) {
@@ -144,6 +187,18 @@ function GradeDetail() {
           return t.error
         case 'inconsistent':
           return !t.error && t.scores.length > 1 && new Set(t.scores).size > 1
+        case 'calibrated': {
+          const delta = computeDelta(t.qa_score, t.avg_score)
+          return delta != null && Math.abs(delta) <= 10
+        }
+        case 'overconfident': {
+          const delta = computeDelta(t.qa_score, t.avg_score)
+          return delta != null && delta < -10
+        }
+        case 'underconfident': {
+          const delta = computeDelta(t.qa_score, t.avg_score)
+          return delta != null && delta > 10
+        }
         default:
           return true
       }
@@ -553,23 +608,27 @@ function GradeDetail() {
                 </div>
                 <div className="flex items-center gap-2 flex-wrap">
                   <Filter className="h-4 w-4 text-muted-foreground" />
-                  {(['all', 'perfect', 'partial', 'zero', 'error', 'inconsistent'] as TaskFilter[]).map((f) => (
-                    <button
-                      key={f}
-                      onClick={() => setTaskFilter(f)}
-                      className={`relative group px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
-                        taskFilter === f
-                          ? 'bg-primary text-primary-foreground'
-                          : 'bg-muted text-muted-foreground hover:bg-muted/80'
-                      }`}
-                    >
-                      {f === 'all' ? 'All' : FILTER_LABELS[f]}
-                      {f !== 'all' && (
-                        <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 w-52 rounded-md bg-popover border border-border text-xs text-popover-foreground px-2.5 py-2 opacity-0 group-hover:opacity-100 transition-opacity shadow-md text-center leading-relaxed whitespace-normal font-normal">
-                          {TERM_DEFINITIONS[f]}
-                        </span>
+                  {(['all', 'perfect', 'partial', 'zero', 'error', 'inconsistent', 'calibrated', 'overconfident', 'underconfident'] as TaskFilter[]).map((f, idx) => (
+                    <span key={f} className="inline-flex items-center">
+                      {idx === 6 && (
+                        <span className="mx-1 h-4 w-px bg-border" aria-hidden="true" />
                       )}
-                    </button>
+                      <button
+                        onClick={() => setTaskFilter(f)}
+                        className={`relative group px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
+                          taskFilter === f
+                            ? 'bg-primary text-primary-foreground'
+                            : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                        }`}
+                      >
+                        {f === 'all' ? 'All' : FILTER_LABELS[f]}
+                        {f !== 'all' && (
+                          <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 w-52 rounded-md bg-popover border border-border text-xs text-popover-foreground px-2.5 py-2 opacity-0 group-hover:opacity-100 transition-opacity shadow-md text-center leading-relaxed whitespace-normal font-normal">
+                            {TERM_DEFINITIONS[f]}
+                          </span>
+                        )}
+                      </button>
+                    </span>
                   ))}
                 </div>
               </div>
@@ -583,6 +642,15 @@ function GradeDetail() {
                       <th className="text-left py-2 px-3 text-muted-foreground font-medium">Task ID</th>
                       <th className="text-center py-2 px-3 text-muted-foreground font-medium">Scores</th>
                       <th className="text-center py-2 px-3 text-muted-foreground font-medium">Avg</th>
+                      <th className="text-center py-2 px-3 text-muted-foreground font-medium">
+                        <span title={tooltipTexts.calibration.selfQa}>Self-QA</span>
+                      </th>
+                      <th className="text-center py-2 px-3 text-muted-foreground font-medium">
+                        <span title={tooltipTexts.calibration.gap}>Δ Gap</span>
+                      </th>
+                      <th className="text-center py-2 px-3 text-muted-foreground font-medium">
+                        <span title={tooltipTexts.calibration.status}>Calib.</span>
+                      </th>
                       <th className="text-center py-2 px-3 text-muted-foreground font-medium">Status</th>
                     </tr>
                   </thead>
@@ -597,6 +665,19 @@ function GradeDetail() {
                     … and {filteredTasks.length - 50} more tasks (showing first 50 only)
                   </p>
                 )}
+                {(() => {
+                  const counts = s.calibration_counts
+                  if (!counts) return null
+                  const total = s.total_tasks ?? grade.tasks.length
+                  const errorCount = s.error_tasks ?? 0
+                  const evaluable = total - errorCount
+                  const matched = evaluable - counts.unmatched
+                  return (
+                    <p className="text-xs text-muted-foreground mt-2 text-center">
+                      Self-QA matched: {matched}/{evaluable} tasks{counts.unmatched > 0 && ` (${counts.unmatched} unmatched)`}
+                    </p>
+                  )
+                })()}
               </div>
             </CardContent>
           </Card>
@@ -688,6 +769,47 @@ function TaskRow({ task, index }: { task: TaskGrade; index: number }) {
       </td>
       <td className="py-2 px-3 text-center font-mono text-sm">
         {task.avg_score !== null ? `${(task.avg_score * 100).toFixed(0)}%` : '—'}
+      </td>
+      {/* Self-QA */}
+      <td className="py-2 px-3 text-center">
+        {task.qa_score != null ? (
+          <div className="flex flex-col items-center leading-tight">
+            <span className="font-semibold">{Math.round(task.qa_score * 10)}%</span>
+            <span className="text-xs text-muted-foreground">{task.qa_score.toFixed(1)}/10</span>
+          </div>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </td>
+      {/* Δ Gap */}
+      <td className="py-2 px-3 text-center">
+        {(() => {
+          const delta = computeDelta(task.qa_score, task.avg_score)
+          if (delta == null) return <span className="text-muted-foreground">—</span>
+          const { className, severe } = gapStyle(delta)
+          const sign = delta > 0 ? '▲' : delta < 0 ? '▼' : '─'
+          const num = delta > 0 ? `+${Math.round(delta)}` : `${Math.round(delta)}`
+          return (
+            <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono ${className}`}>
+              <span>{sign}</span>
+              <span>{num}</span>
+              {severe && <AlertTriangle className="h-3 w-3" />}
+            </span>
+          )
+        })()}
+      </td>
+      {/* Calibration status */}
+      <td className="py-2 px-3 text-center">
+        {(() => {
+          const delta = computeDelta(task.qa_score, task.avg_score)
+          const { icon: Icon, label, className } = calibStatus(delta)
+          return (
+            <span className={`inline-flex items-center gap-1 text-xs ${className}`}>
+              {Icon && <Icon className="h-3.5 w-3.5" />}
+              <span>{label}</span>
+            </span>
+          )
+        })()}
       </td>
       <td className="py-2 px-3 text-center">{getStatusBadge()}</td>
     </tr>

--- a/src/types/grade.ts
+++ b/src/types/grade.ts
@@ -35,6 +35,19 @@ export interface TaskGradeV1 {
   judge_output_tokens?: number
   error: string | null
   graded_at?: string
+  /** Inference-time Self-QA score (0–10). Phase 1: enriched from reports-index task_qa map. */
+  qa_score?: number | null
+}
+
+export interface CalibrationCounts {
+  /** |Rubric% − SelfQA%| ≤ 10 */
+  calibrated: number
+  /** Rubric% − SelfQA% < -10 (model overestimates its own work) */
+  overconfident: number
+  /** Rubric% − SelfQA% > 10 (model underestimates its own work) */
+  underconfident: number
+  /** Task has no qa_score (excluding errors) */
+  unmatched: number
 }
 
 export interface OpenAICompatSummary {
@@ -97,6 +110,10 @@ export interface GradeSummaryV1 {
   openai_compat: OpenAICompatSummary
   wow: WowSummary
   cost?: GradeCostSummary
+  /** Mean |Rubric% − SelfQA%| across matched tasks. null when no samples. */
+  calibration_mae?: number | null
+  /** Distribution of calibration categories. null when no samples. */
+  calibration_counts?: CalibrationCounts | null
 }
 
 export interface JudgeProvenance {

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -128,6 +128,8 @@ export interface ReportData {
   narrative: Narrative
   recovery_stats: RecoveryStats
   file_generation?: FileGeneration
+  /** task_id → Self-QA score (0–10). Enriched in scripts/aggregate-reports.mjs for Phase 1 calibration. */
+  task_qa?: Record<string, number>
 }
 
 export interface ExperimentEntry {

--- a/tasks/0523_saturday/TASK_GRADE_DETAIL_SELF_QA_CALIBRATION.md
+++ b/tasks/0523_saturday/TASK_GRADE_DETAIL_SELF_QA_CALIBRATION.md
@@ -1,0 +1,395 @@
+# TASK_GRADE_DETAIL_SELF_QA_CALIBRATION — Self-QA vs Rubric calibration view on GradeDetail page
+
+## TL;DR
+Grade detail 페이지의 **Task Details 테이블**에 Self-QA(인퍼런스 자기평가)와 Rubric judge(외부 채점)
+두 점수를 같이 보여 모델 **calibration**(자기 인식 정확도) 분석을 가능하게 한다.
+빌드 타임에 `aggregate-reports.mjs`가 per-task `qa_score`를 reports-index에 enrich하고, `aggregate-grades.mjs`가
+**experiment_id 기준 strict join**으로 grade에 qa_score를 결합한다. 매칭 실패는 unmatched로 정직하게 표시.
+
+**Phase 1 (이번 PR)**: Strict matching. 매칭 안 되는 grade는 `Self-QA matched: 0/N tasks`로 표시.
+**Phase 2 (별도 PR)**: `step8_grade.py`가 grade JSON에 `source_inference_experiment_id` 명시적 기록 — 별도 task로 분리 (`tasks/0523_saturday/TASK_GRADE_SOURCE_LINKAGE_BACKEND.md`).
+
+---
+
+## Background & Motivation
+
+### 현재 상태
+GradeDetail 페이지의 Task Details 테이블은 **Rubric judge 점수만** 보여준다:
+
+```
+#  Task ID    Scores    Avg    Status
+1  a328fe…    [0/0/0]   88%    Partial
+2  dfb4e0…    [0/0/0]   67%    Partial
+3  0419f1…    [0/0/0]   78%    Partial
+```
+
+한편 ExperimentDetail 페이지에는 **Self-QA score**(0-10)가 task별로 따로 표시된다.
+두 점수를 같은 화면에서 못 보기 때문에 **모델 자기 평가의 정확도(calibration)** 라는 가장 중요한 메타 신호가 가려져 있다.
+
+### 왜 가치 있는가
+LLM benchmarking에서 핵심 질문 중 하나는 *"모델이 자기 결과의 품질을 알아채는가?"* 이다.
+두 점수를 나란히 보면 4가지 패턴이 즉시 분류된다:
+
+| Self-QA | Rubric | 해석 |
+|---|---|---|
+| 9/10 | 0% | **과대평가** — 모델이 실패를 인식 못 함 (위험) |
+| 9/10 | 100% | **잘 알고 잘 함** — 신뢰 가능 |
+| 4/10 | 80% | 과소평가 — 보수적, 능력 발휘 가능 |
+| 4/10 | 20% | 자기 인식 정확 — 실패 알아챔 (안전) |
+
+→ 이 신호는 **모델 선택, 프롬프트 설계, 자기검증 전략**의 핵심 근거가 된다.
+
+---
+
+## Goal
+
+GradeDetail 페이지에서 모든 task에 대해:
+1. Self-QA score를 함께 보여준다 (0-10 원본 + % 정규화)
+2. 두 점수 차이(Δ Gap)와 calibration 상태(Aligned/Over/Under)를 시각적으로 강조한다
+3. 새 필터(Calibrated, Overconfident, Underconfident)로 패턴 필터링한다
+4. 전체 실험의 **Calibration MAE**(Mean Absolute Error)를 Health Strip에 추가한다
+
+핵심 불변식:
+- Self-QA가 없는 task는 calibration 컬럼에 `—`만 보여주고 에러 없음
+- 기존 컬럼(#, Task ID, Scores, Avg, Status) 픽셀 변화 0
+- 기존 필터(All/Perfect/Partial/Zero/Error/Inconsistent) 동작 변화 0
+- v1 grade 파일(qa_score 없음)에서도 정상 렌더
+
+---
+
+## Scope
+
+**수정/신규**:
+- `scripts/aggregate-reports.mjs` — 각 report에 compact `task_qa: { task_id: qa_score }` map 추가 (task_results strip 직전)
+- `scripts/aggregate-grades.mjs` — reports-index의 `task_qa`를 experiment_id 기준 strict join, dummy/unmatched 처리, summary에 `calibration_mae`, `calibration_counts` 추가
+- `package.json` — aggregate 스크립트 순서: `reports`를 `grades` 전에 실행
+- `src/types/grade.ts` — `TaskGradeV1.qa_score?`, `GradeSummary.calibration_mae?`, `GradeSummary.calibration_counts?` 추가
+- `src/types/report.ts` — `ReportData.task_qa?: Record<string, number>` 추가
+- `src/data/tooltipTexts.ts` — 4개 신규 툴팁 추가
+- `src/components/wow/HealthStrip.tsx` — Calibration MAE Pill 추가
+- `src/pages/GradeDetail.tsx` — 컬럼 3개 추가(Self-QA, Δ Gap, Calibration), 필터 3개 추가
+- `scripts/__tests__/aggregate-grades.test.mjs` — 매칭 케이스 (matched/unmatched/dummy/mixed) 테스트 추가
+
+**손대지 않을 곳 (Phase 1)**:
+- `batch-runner/` (Phase 2에서 별도 처리)
+- ExperimentDetail 페이지 (자기 자체로 완결됨)
+- 기존 Health Strip 메트릭 5종 (err / judge / precheck / calls / latency) 동작
+- 기존 grade JSON 파일 (마이그레이션 없음)
+
+---
+
+## Design
+
+### 1a. Reports-index enrichment: `scripts/aggregate-reports.mjs`
+
+현재 aggregate-reports.mjs는 `task_results` array를 **strip**하여 final reports-index에 포함시키지 않는다.
+Grade calibration을 위해 **compact task_qa map**을 각 report에 추가한다:
+
+```js
+// Before stripping task_results, extract compact qa map
+const taskQa = {};
+for (const t of (report.task_results ?? [])) {
+  if (t.task_id && t.qa_score != null) taskQa[t.task_id] = t.qa_score;
+}
+report.task_qa = taskQa;  // small payload: ~220 * (UUID + int) ≈ 12KB per report
+delete report.task_results;  // continue stripping the large field
+```
+
+결과: 각 report에 `task_qa: { "<task_id>": <qa_score 0-10>, ... }` 추가. 다른 필드는 그대로.
+
+### 1b. Build-time join: `scripts/aggregate-grades.mjs`
+
+**Strict per-experiment matching**. global map은 GDPVal task_id 공유로 잘못된 매칭을 만들기 때문에
+**grade.experiment_id ↔ report.meta.experiment_id**로만 매칭한다.
+
+```js
+// 1) Build experiment_id → task_qa lookup from reports-index
+const reportsIndex = safeReadJson('public/generated/reports-index.json');
+const taskQaByExperiment = new Map();
+for (const report of reportsIndex?.reports ?? []) {
+  const expId = report?.meta?.experiment_id;
+  if (expId && report.task_qa) taskQaByExperiment.set(expId, report.task_qa);
+}
+
+// 2) For each grade, look up that experiment's qa map (NOT global)
+function decorateGradeTasks(grade, tasks) {
+  if (grade.is_dummy) {
+    // Dummy grades have synthetic scores, no real inference run → leave unmatched
+    return tasks.map(t => ({ ...t, qa_score: null }));
+  }
+  const qaMap = taskQaByExperiment.get(grade.experiment_id) ?? null;
+  return tasks.map(t => ({
+    ...t,
+    qa_score: qaMap?.[t.task_id] ?? null,
+  }));
+}
+
+// 3) Compute calibration MAE & counts (unchanged from before)
+function buildCalibration(tasks) {
+  const samples = [];
+  let unmatched = 0;
+  for (const t of tasks) {
+    if (t.error) continue;
+    if (t.qa_score == null) { unmatched++; continue; }
+    if (t.avg_score == null) continue;
+    samples.push((t.avg_score * 100) - (t.qa_score * 10));
+  }
+  const mae = samples.length > 0
+    ? Number((samples.reduce((s, d) => s + Math.abs(d), 0) / samples.length).toFixed(2))
+    : null;
+  return {
+    calibration_mae: mae,
+    calibration_counts: {
+      calibrated:     samples.filter(d => Math.abs(d) <= 10).length,
+      overconfident:  samples.filter(d => d < -10).length,
+      underconfident: samples.filter(d => d > 10).length,
+      unmatched,
+    },
+  };
+}
+```
+
+**Pipeline ordering**: `aggregate-reports.mjs` MUST run before `aggregate-grades.mjs`.
+`package.json` `aggregate` script 순서를 확인하고, 필요하면 `reports → grades` 순으로 변경.
+현재 순서: `tests → grades → reports → experiments` → **`tests → reports → grades → experiments`**로 변경 필요.
+
+**Known Phase 1 limitation**: exp998 grade는 reports-index에 매칭되는 report가 없음 (HF fetch 실패).
+따라서 모든 3 task가 `unmatched`로 표시됨. 이는 의도된 동작이며 "데이터 정합성이 깨졌다"는 정직한 신호.
+Phase 2(별도 PR)에서 batch-runner step8_grade가 `source_inference_experiment_id`를 grade JSON에 직접 기록하도록 변경하여 영구 해결.
+
+### 2. Types: `src/types/grade.ts`
+
+```ts
+export interface TaskGradeV1 {
+  task_id: string
+  // ... 기존 필드
+  qa_score?: number | null  // 0-10, from inference self-QA
+}
+
+export interface GradeSummary {
+  // ... 기존
+  calibration_mae?: number | null  // mean |Rubric% - SelfQA%|
+  calibration_counts?: {
+    calibrated: number
+    overconfident: number
+    underconfident: number
+    unmatched: number
+  } | null
+}
+```
+
+### 3. Tooltips: `src/data/tooltipTexts.ts`
+
+`health` 객체에 추가:
+```ts
+calibrationMae:
+  'Mean Absolute Error of Self-QA vs Rubric across all tasks. Lower = better model self-awareness. <10pp is well-calibrated.',
+```
+
+새 객체 `calibration`:
+```ts
+calibration: {
+  selfQa: 'Self-rated quality score during inference (0-10). The inference model evaluates its own output. Distinct from external rubric judge.',
+  rubric: 'Independent rubric-based score by external judge LLM. Objective and decoupled from the inference model.',
+  gap: 'Rubric − Self-QA. Negative = model overconfident (risk). Positive = model underconfident. |Δ| ≤ 10pp is well-calibrated.',
+  status: 'Aligned (|Δ|≤10): well-calibrated. Overconfident (Δ<-10): model overestimates its own work. Underconfident (Δ>10): model underestimates.',
+}
+```
+
+### 4. Health Strip: `src/components/wow/HealthStrip.tsx`
+
+기존 5개 Pill 뒤에 추가:
+```tsx
+<NeutralPill
+  label="MAE"
+  value={summaryV1.calibration_mae != null ? `${summaryV1.calibration_mae.toFixed(1)}pp` : '—'}
+  tooltip={tooltipTexts.health.calibrationMae}
+/>
+```
+
+`pp` = percentage points.
+
+### 5. Task Details Table: `src/pages/GradeDetail.tsx`
+
+#### 컬럼 구조 변경
+기존: `# | Task ID | Scores | Avg | Status`
+신규: `# | Task ID | Scores | Avg | Self-QA | Δ Gap | Calib. | Status`
+
+#### Self-QA 컬럼 렌더
+```tsx
+<td className="py-2 px-3 text-center">
+  {task.qa_score != null ? (
+    <div className="flex flex-col items-center leading-tight">
+      <span className="font-semibold">{Math.round(task.qa_score * 10)}%</span>
+      <span className="text-xs text-muted-foreground">{task.qa_score.toFixed(1)}/10</span>
+    </div>
+  ) : (
+    <span className="text-muted-foreground">—</span>
+  )}
+</td>
+```
+
+#### Δ Gap 컬럼 렌더
+```tsx
+function gapColor(delta: number): { color: string; bg: string } {
+  const abs = Math.abs(delta)
+  if (abs <= 10) return { color: 'text-muted-foreground', bg: 'bg-muted/30' }
+  if (abs <= 30) return { color: 'text-amber-500', bg: 'bg-amber-500/10' }
+  return { color: 'text-red-500', bg: 'bg-red-500/10' }
+}
+
+// computed once: const delta = (task.avg_score * 100) - (task.qa_score * 10)
+```
+
+표시:
+```tsx
+<td className="py-2 px-3 text-center">
+  {delta != null ? (
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono ${color} ${bg}`}>
+      {delta > 0 ? '▲' : delta < 0 ? '▼' : '─'}
+      {delta > 0 ? '+' : ''}{Math.round(delta)}
+      {Math.abs(delta) > 30 && <AlertTriangle className="h-3 w-3" />}
+    </span>
+  ) : (
+    <span className="text-muted-foreground">—</span>
+  )}
+</td>
+```
+
+#### Calibration 컬럼 (lucide 아이콘 + 텍스트)
+```tsx
+import { Target, TrendingDown, TrendingUp } from 'lucide-react'
+
+function calibStatus(delta: number | null) {
+  if (delta == null) return { icon: null, label: '—', color: 'text-muted-foreground' }
+  if (Math.abs(delta) <= 10) return { icon: Target, label: 'Aligned', color: 'text-muted-foreground' }
+  if (delta < -10) return { icon: TrendingDown, label: 'Over', color: 'text-red-500' }
+  return { icon: TrendingUp, label: 'Under', color: 'text-amber-500' }
+}
+```
+
+#### 필터 확장
+기존 `TaskFilter`:
+```ts
+type TaskFilter = 'all' | 'perfect' | 'partial' | 'zero' | 'error' | 'inconsistent'
+```
+→ 신규:
+```ts
+type TaskFilter = 'all' | 'perfect' | 'partial' | 'zero' | 'error' | 'inconsistent'
+                | 'calibrated' | 'overconfident' | 'underconfident'
+```
+
+필터 버튼 UI: 기존 6개 뒤에 `|` divider, 그 다음 3개 calibration 필터.
+
+#### 푸터에 매칭률 표시
+```tsx
+{summary.calibration_counts && (
+  <p className="text-xs text-muted-foreground mt-3 py-2 text-center">
+    Self-QA matched: {totalTasks - unmatched}/{totalTasks} tasks
+    {unmatched > 0 && ` (${unmatched} unmatched)`}
+  </p>
+)}
+```
+
+---
+
+## Color & UX Rules
+
+| 임계값 (\|Δ\|) | 색상 | 라벨 | 의미 |
+|---|---|---|---|
+| ≤ 10pp | 회색 (muted) | Aligned | 잘 캘리브레이션됨 |
+| 11–30pp | 노란색 (amber-500) | Over/Under (mild) | 주의 |
+| > 30pp | 빨간색 (red-500) + ⚠️ | Over/Under (severe) | 심각한 miscalibration |
+
+**부호 규칙**:
+- `+` Δ = Rubric > Self-QA = 모델이 자신을 **과소평가** (보수적)
+- `−` Δ = Rubric < Self-QA = 모델이 **과대평가** (위험)
+
+---
+
+## Edge Cases
+
+| 케이스 | 처리 |
+|---|---|
+| reports-index에 task_id 없음 | task.qa_score = null, calibration 컬럼 `—`, calibration_counts.unmatched++ |
+| reports-index 자체가 없음 (fresh repo) | qaScoreByTaskId가 빈 맵, 모든 task `—`, MAE = null |
+| qa_score = 0 | 유효한 값으로 처리 (0%로 표시) |
+| qa_score = null in report | 그 task만 unmatched 취급 |
+| Δ Gap 정확히 ±10 | Aligned로 분류 (≤ 사용) |
+| 모든 task가 unmatched | MAE = null → Health Strip `—` 표시 |
+| Inconsistent task (multi-grader) | avg_score 그대로 사용 (현재 동작 유지) |
+
+---
+
+## Verification
+
+### Acceptance
+1. exp998 grade 페이지에서 (현재 데이터 상태 = unmatched 케이스):
+   - Task Details 테이블에 Self-QA / Δ Gap / Calib. 컬럼이 보임
+   - 모든 3 task에 `—` 표시 (reports-index에 exp998 report 없음 → unmatched)
+   - Health Strip의 `MAE` Pill은 `—`로 표시
+   - 푸터: `Self-QA matched: 0/3 tasks (3 unmatched)`
+2. Self-QA 없는 dummy grade(`dummy_gpt5_baseline`)에서:
+   - 새 컬럼들 모두 `—`로 표시, 에러 없음
+   - 푸터: `Self-QA matched: 0/220 tasks (220 unmatched)`
+3. **매칭되는 케이스 (현재 데이터엔 없지만 로직 검증용 — 테스트로 커버)**:
+   - 가짜 reports-index에 exp998 entry + 정확한 task_qa map을 추가하고 빌드 → exp998 grade가 정상 매칭됨
+   - 또는 새 grade가 매칭되는 report와 함께 생성될 때 자동 calibration
+4. 새 필터 클릭 시 (매칭된 task가 있을 때):
+   - Calibrated: |Δ|≤10 task만 보임
+   - Overconfident: Δ < -10 task만 보임
+   - Underconfident: Δ > 10 task만 보임
+5. 기존 필터(Perfect/Partial/Zero/Error/Inconsistent) 동작 변화 없음
+6. 헤더 호버 시 4개 신규 툴팁이 모두 표시
+
+### Tests
+- `scripts/__tests__/aggregate-grades.test.mjs`에 케이스 추가:
+  - reports에 일치하는 task_id 있을 때 qa_score 결합
+  - reports에 없는 task_id는 null 유지
+  - calibration_mae 계산 (수식 검증: 알려진 값 입력 후 결과 확인)
+  - calibration_counts 분류 (4가지 카테고리 카운트)
+- `npm run build` 성공
+- 빌드 후 `dist/generated/grades-index.json`에 `qa_score`, `calibration_mae`, `calibration_counts` 존재
+
+---
+
+## Risks & Mitigations
+
+| 리스크 | 완화 |
+|---|---|
+| aggregate 순서 의존성(reports → grades) | package.json `aggregate` 스크립트 순서 확인. test에서 reports-index 없을 때 graceful fallback 검증 |
+| ExperimentDetail에서 qa_score 의미와 그래도 일관성 | 같은 정의 사용. `qa_score`는 0-10 원본 스케일 유지 (×10 정규화는 GradeDetail만의 표시 결정) |
+| Task table 너비 폭주(8 컬럼) | `overflow-x-auto` 이미 존재. 모바일에서 가로 스크롤 허용 |
+| 220 task 전체 채점본에서 렌더 성능 | 이미 `.slice(0, 50)` 적용 중 → 영향 없음 |
+| Dummy grade에서 잘못된 MAE | qa_score = null이면 calibrationSamples에서 제외. MAE = null → Health Strip `—` |
+
+---
+
+## Out of Scope (Future)
+
+- **Phase 2 (별도 PR)**: `step8_grade.py`가 grade JSON에 `source_inference_experiment_id` 명시적 기록 → `experiment_id`가 변형되어도 강건한 매칭. 명세는 `tasks/0523_saturday/TASK_GRADE_SOURCE_LINKAGE_BACKEND.md` 참조.
+- Calibration scatter plot (Self-QA vs Rubric per task) — 시각화 추가
+- Sector별 Calibration breakdown
+- Leaderboard에 experiment 단위 Calibration MAE 컬럼 추가
+- 시간/실험 간 calibration trend 차트
+- Per-judge calibration (multi-judge grading 시 grader별 비교)
+
+---
+
+## Implementation Order (Subagent Dispatch Plan)
+
+1. **coder #1**: `scripts/aggregate-reports.mjs` 수정 (compact task_qa map 추가) + `scripts/aggregate-grades.mjs` 수정 (per-experiment strict join + dummy/unmatched 처리) + `package.json` aggregate 순서 변경 + 테스트 추가
+   - 검증: `npm run aggregate` 후 `public/generated/reports-index.json`에 `task_qa` 존재, `grades-index.json`에 `qa_score`/`calibration_*` 존재, exp998은 unmatched로 표시
+2. **coder #2**: `src/types/grade.ts` + `src/types/report.ts` + `src/data/tooltipTexts.ts` 업데이트
+3. **coder #3**: `src/components/wow/HealthStrip.tsx`에 MAE Pill 추가
+4. **coder #4**: `src/pages/GradeDetail.tsx` 컬럼 3개 + 필터 3개 + 푸터 추가
+5. **orchestrator (this agent)**: `npm run build` + 빌드 산출물 검증 + 로컬 dev preview 스크린샷 검증
+6. **first-reviewer**: 전체 diff 리뷰 (correctness, types, fallback 처리)
+7. **git-committer**: Conventional commit + push to feature branch + PR draft
+
+---
+
+## Branch & PR
+- Branch: `feat/grade-detail-self-qa-calibration`
+- PR title: `feat(dashboard): show Self-QA vs Rubric calibration on GradeDetail`
+- PR description: 이 문서 TL;DR 섹션 사용

--- a/tasks/0523_saturday/TASK_GRADE_SOURCE_LINKAGE_BACKEND.md
+++ b/tasks/0523_saturday/TASK_GRADE_SOURCE_LINKAGE_BACKEND.md
@@ -1,0 +1,56 @@
+# TASK_GRADE_SOURCE_LINKAGE_BACKEND — Embed inference source linkage in grade JSON
+
+## TL;DR
+`step8_grade.py`가 grade JSON \uc791\uc131 \uc2dc `source_inference_experiment_id` \ud544\ub4dc\ub97c \ud3ec\ud568\ud558\ub3c4\ub85d \ud55c\ub2e4.
+\uc774\ub85c\uc368 grade \u2194 inference run \uc5f0\uacb0\uc774 \ud30c\uc77c \uc790\uccb4 \ub0b4\uc5d0 \uba85\uc2dc\uc801\uc73c\ub85c \uae30\ub85d\ub418\uc5b4, \ub300\uc2dc\ubcf4\ub4dc calibration \ub9e4\uce6d\uc774 \uac15\uac74\ud574\uc9c4\ub2e4.
+
+## Why
+Phase 1\uc758 calibration \uae30\ub2a5(`TASK_GRADE_DETAIL_SELF_QA_CALIBRATION.md`)\uc740 `grade.experiment_id == report.experiment_id`\ub85c \ub9e4\uce6d\ud558\ub294\ub370,
+\uc774\ub984\uc774 \uc870\uae08\uc774\ub77c\ub3c4 \ub2e4\ub974\uba74 (\uc608: exp998 grade \u2194 exp999 inference) \ub9e4\uce6d \uc2e4\ud328 \u2192 unmatched\ub85c \ud45c\uc2dc.
+\uc785\ub825\ub3d8\ub418\ub294 \uc18c\uc2a4 ID\ub97c grade JSON\uc5d0 \uc9c1\uc811 \uae30\ub85d\ud558\uba74 \uc774 \ubaa8\ud638\uc131\uc774 \uc81c\uac70\ub41c\ub2e4.
+
+## Scope
+
+**\uc218\uc815**:
+- `batch-runner/step8_grade.py` \u2014 grade JSON \uc791\uc131 \uc2dc `source_inference_experiment_id`, `source_inference_run_dir` \ud544\ub4dc \ucd94\uac00
+- `batch-runner/schemas/grade.schema.json` (\uc788\ub2e4\uba74) \u2014 \uc2e0\uaddc \ud544\ub4dc \ucd94\uac00
+- `scripts/aggregate-grades.mjs` \u2014 \uadf8 \ud544\ub4dc\ub97c \uc6b0\uc120\uc801\uc73c\ub85c \uc0ac\uc6a9, \uc5c6\uc73c\uba74 `experiment_id`\ub85c fallback
+- `data/grades/exp998_smoke_baseline_sample__*.json` \u2014 1\ud68c\uc131 backfill\ub85c `source_inference_experiment_id: "exp999_smoke_baseline_sample"` \ucd94\uac00
+- `batch-runner/tests/test_step8_grade.py` \u2014 \uc2e0\uaddc \ud544\ub4dc \uac80\uc99d \ud14c\uc2a4\ud2b8 \ucd94\uac00
+
+**\uba85\uc138\uad6c\uc870**:
+
+```json
+{
+  "schema_version": "1.0",
+  "experiment_id": "exp998_smoke_baseline_sample",
+  "experiment_yaml_name": "exp998_smoke_baseline_sample",
+  "source_inference_experiment_id": "exp999_smoke_baseline_sample",  // \u2190 NEW
+  "source_inference_run_dir": "batch-runner/results/exp999_smoke_baseline_sample",  // \u2190 NEW (optional, debugging)
+  "inference_model": "gpt-5.2-chat",
+  ...
+}
+```
+
+### Step8 \ubcc0\uacbd \ud3ec\uc778\ud2b8
+- \uc774\ubbf8 step8_grade.py\ub294 inference run \ub514\ub809\ud1a0\ub9ac\ub97c \uc77d\uc5b4 \ucc44\uc810\ud568. \uadf8 \ub514\ub809\ud1a0\ub9ac\uc758 `experiment_id`\ub97c JSON\uc5d0 \uadf8\ub300\ub85c \uae30\ub85d.
+
+### Aggregate-grades \ubcc0\uacbd \ud3ec\uc778\ud2b8
+\uc6b0\uc120\uc21c\uc704:
+1. `grade.source_inference_experiment_id` (Phase 2 \uc2e0\uaddc \ud544\ub4dc) \u2192 \uc0ac\uc6a9
+2. `grade.experiment_id` (Phase 1 fallback) \u2192 \uc0ac\uc6a9
+3. \uc544\ubb34\uac83\ub3c4 \ub9e4\uce6d \uc548 \ub428 \u2192 unmatched
+
+## Verification
+
+1. `step8_grade.py` \uc2e4\ud589 \uc2dc \uc0dd\uc131\ub418\ub294 grade JSON\uc5d0 \uc2e0\uaddc \ud544\ub4dc \uc874\uc7ac
+2. \uae30\uc874 grade \ud30c\uc77c (Phase 1) \uc77d\uae30 \uacc4\uc18d \uc791\ub3d9 (backward compat)
+3. exp998 grade backfill \ud6c4 \ub300\uc2dc\ubcf4\ub4dc\uc5d0\uc11c calibration \ud45c\uc2dc\ub428 (3/3 matched)
+4. \ud14c\uc2a4\ud2b8: `python -m pytest batch-runner/tests/test_step8_grade.py -v`
+
+## Out of Scope
+- grade \uc7ac\ucc44\uc810 (Phase 1 grade\ub294 backfill\ub9cc \uc801\uc6a9, \uc810\uc218 \ubcc0\uacbd \uc5c6\uc74c)
+- \uc5ec\ub7ec inference run\uc744 \ud558\ub098\uc758 grade\ub85c \ubcd1\ud569\ud558\ub294 \uba40\ud2f0-\uc18c\uc2a4 \uc2dc\ub098\ub9ac\uc624
+
+## Dependencies
+- Phase 1 (`TASK_GRADE_DETAIL_SELF_QA_CALIBRATION.md`)\uac00 \uba38\uc9c0\ub41c \ud6c4 \uc2dc\uc791


### PR DESCRIPTION
## TL;DR

Grade detail 페이지의 Task Details 테이블에 **Self-QA(인퍼런스 모델 자기평가)** 와 **Rubric judge(외부 채점)** 두 점수를 함께 보여 모델의 **calibration**(자기 인식 정확도)을 분석할 수 있게 한다. 이는 모델 신뢰성 평가의 핵심 신호다.

빌드 타임에 `aggregate-reports.mjs`가 per-task `qa_score` 맵을 reports-index에 enrich하고, `aggregate-grades.mjs`가 **experiment_id 기준 strict join**으로 grade에 qa_score를 결합한다.

Spec: [tasks/0523_saturday/TASK_GRADE_DETAIL_SELF_QA_CALIBRATION.md](tasks/0523_saturday/TASK_GRADE_DETAIL_SELF_QA_CALIBRATION.md)

---

## Why

LLM benchmark에서 핵심 질문 중 하나: *"모델이 자기 결과의 품질을 알아채는가?"*

두 점수를 나란히 보면 4가지 패턴이 즉시 분류된다:

| Self-QA | Rubric | 해석 |
|---|---|---|
| 9/10 | 0% | **과대평가** — 모델이 실패를 인식 못 함 (위험) |
| 9/10 | 100% | **잘 알고 잘 함** — 신뢰 가능 |
| 4/10 | 80% | 과소평가 — 보수적, 능력 발휘 가능 |
| 4/10 | 20% | 자기 인식 정확 — 실패 알아챔 (안전) |

이 신호는 **모델 선택, 프롬프트 설계, 자기검증 전략**의 핵심 근거가 된다.

---

## 변경 사항

### Pipeline
- **`scripts/aggregate-reports.mjs`**: 각 report에 compact `task_qa: { task_id: qa_score }` 맵 enrich (task_results strip 직전).
- **`scripts/aggregate-grades.mjs`**: reports-index의 `task_qa`를 **experiment_id 기준 strict join**. global task_id 맵 사용 안 함(GDPVal task_id가 220 task 전체에서 공유되기 때문에 global 매칭은 false positive 발생).
- **`package.json`**: aggregate 순서 변경 — `reports` → `grades`.

### Dashboard
- **`src/pages/GradeDetail.tsx`**: Task Details 테이블에 3개 컬럼 추가 (Self-QA / Δ Gap / Calibration), 3개 필터 추가 (Calibrated / Overconfident / Underconfident) with 시각적 divider, footer 매칭률 표시.
- **`src/components/wow/HealthStrip.tsx`**: Calibration MAE Pill 추가 (정보용, alert 없음).
- **`src/data/tooltipTexts.ts`**: 4개 신규 툴팁.
- **`src/types/grade.ts` + `src/types/report.ts` + `src/hooks/useGrades.ts`**: 모든 신규 필드는 optional, 기존 grade 파일과 backward compatible.

### Color/UX 규칙
| 임계값 (\|Δ\|) | 색상 | 라벨 |
|---|---|---|
| ≤ 10pp | 회색 | Aligned |
| 11–30pp | 노란색 | Over/Under (mild) |
| > 30pp | 빨간색 + AlertTriangle | Over/Under (severe) |

부호: `+` = Rubric > Self-QA (과소평가), `−` = Rubric < Self-QA (과대평가, 위험)

---

## 검증

| 항목 | 결과 |
|---|---|
| `npm run test:aggregate` | ✅ **12/12 pass** (3 기존 + 4 업데이트 + 5 신규 T1–T5) |
| `npx tsc --noEmit` | ✅ no errors |
| `npm run build` | ✅ success, bundle 895.21 kB |
| first-reviewer | ✅ **APPROVE WITH SUGGESTIONS** (no critical, 1 polish 적용됨) |

신규 테스트 T1–T5 커버:
- T1: matched task with calibration
- T2: dummy grade → all null
- T3: no matching report → all unmatched
- T4: MAE precision (Δ=+5, Δ=−30 → MAE=17.5)
- T5: error tasks excluded from samples AND unmatched

---

## Known Limitation (의도된 동작, Phase 2로 해결)

- **`exp998` grade는 현재 `Self-QA matched: 0/3 tasks` 로 표시됨.**
- 원인: reports-index에 exp998 report가 없음 (HF fetch failure, 또는 inference run의 디렉토리 이름이 `exp999_smoke_baseline_sample` 으로 mismatch).
- 이는 **strict matching의 정확한 동작**이며, "데이터 정합성이 깨졌다"는 정직한 신호.
- 영구 해결: **Phase 2** PR — `step8_grade.py`가 grade JSON에 `source_inference_experiment_id` 명시적 기록. Spec: [tasks/0523_saturday/TASK_GRADE_SOURCE_LINKAGE_BACKEND.md](tasks/0523_saturday/TASK_GRADE_SOURCE_LINKAGE_BACKEND.md)

---

## Out of Scope (Future Work)

- Phase 2 — batch-runner에 grade↔inference source linkage 명시 (별도 PR)
- Calibration scatter plot (Self-QA vs Rubric per task)
- Sector별 Calibration breakdown
- Leaderboard에 experiment 단위 Calibration MAE 컬럼
- 시간/실험 간 calibration trend 차트

---

## 검증 방법

1. **Pull this branch** 후 `npm install && npm run dev`
2. Grade detail page 방문: `/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1`
3. 확인:
   - Health Strip에 `MAE —` pill 표시 (unmatched이므로 dash)
   - Task Details에 Self-QA / Δ Gap / Calib. 3개 컬럼 모두 `—` 표시
   - 푸터: `Self-QA matched: 0/3 tasks (3 unmatched)`
4. 새 필터 3개 (Calibrated/Overconfident/Underconfident) 클릭 시 빈 결과 정상 표시
5. 기존 필터 (Perfect/Partial/Zero/Error/Inconsistent) 동작 변화 없음
