### PR TITLE
fix(grading): authenticate HF inference download (avoid relay 429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Fixed
+- **`batch-runner/scripts/download_inference_from_hf.py`** — pass `HF_TOKEN` explicitly to `hf_hub_download()` (×2) and `snapshot_download()` via a new `_hf_token()` helper. The grade pipeline's "Download inference results from HF" step injects `HF_TOKEN` env, but `huggingface_hub` auto-pickup did not fire, so requests went out **anonymous** (CI log: `unauthenticated requests to HF Hub`). Under the sequential grade relay this tripped HTTP **429 Too Many Requests** on the inference parquet, breaking a chunk mid-run (e.g. 5.4 220 re-grade chunk-2 resume). Authenticated requests have a much higher rate limit → relay no longer 429s on repeated chunk downloads. No behavior change for single runs.
+
 ### Changed
 - **`.github/agents/azure-infra-engineer.md`** — rebuilt for Opus 4.8 Copilot (`model: Claude Opus 4.8 (copilot)`, `tools: vscode, execute, read, edit, search, web, todo`). Reframed from a generic Azure/PowerShell advisor into an **end-to-end coding-agent infra provisioner** covering the full **Microsoft Fabric → networking/identity → Azure AI Foundry** estate as ordered layers (foundation, network/identity, Fabric capacity+OneLake+lakehouse, Foundry hub/project+model deployments+connections, operate/verify). Adds OIDC-only auth rule (no client secrets, mirrors grading pipeline), Bicep-first IaC conventions, runtime-proof verification (declaration ≠ wired), least-privilege RBAC, what-if-before-deploy, cost/destructive ops gated to owner, CHANGELOG discipline, and inter-agent handoffs (deployment-engineer / extreme-reasoner / first-reviewer / git-committer).
 

--- a/batch-runner/scripts/download_inference_from_hf.py
+++ b/batch-runner/scripts/download_inference_from_hf.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -21,6 +22,17 @@ import pandas as pd
 import yaml
 from huggingface_hub import hf_hub_download, snapshot_download
 from huggingface_hub.errors import EntryNotFoundError
+
+
+def _hf_token() -> str | None:
+    """Resolve the HF auth token from the standard env vars.
+
+    The workflow injects ``HF_TOKEN`` for the download step, but the
+    huggingface_hub auto-pickup does not always fire, so we pass it
+    explicitly. Without it the requests go out anonymous (low rate
+    limit) and the sequential relay trips HTTP 429 on repeated chunks.
+    """
+    return os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
 
 
 def parse_args() -> argparse.Namespace:
@@ -86,11 +98,13 @@ def _build_inference_from_parquet(parquet_path: str, experiment: str, repo_id: s
 
 
 def _download_or_reconstruct_inference(experiment: str, repo_id: str, out: Path) -> None:
+    token = _hf_token()
     try:
         step2_file = hf_hub_download(
             repo_id=repo_id,
             repo_type="dataset",
             filename="step2_inference_results.json",
+            token=token,
         )
         shutil.copy(step2_file, out)
         return
@@ -99,6 +113,7 @@ def _download_or_reconstruct_inference(experiment: str, repo_id: str, out: Path)
             repo_id=repo_id,
             repo_type="dataset",
             filename="data/train-00000-of-00001.parquet",
+            token=token,
         )
         reconstructed = _build_inference_from_parquet(parquet_file, experiment, repo_id)
         out.write_text(json.dumps(reconstructed, indent=2, ensure_ascii=False), encoding="utf-8")
@@ -119,6 +134,7 @@ def main() -> int:
             repo_type="dataset",
             local_dir=tmp,
             allow_patterns=["deliverable_files/**"],
+            token=_hf_token(),
         )
         src = Path(tmp) / "deliverable_files"
         dst = Path("workspace") / "upload" / "deliverable_files"


### PR DESCRIPTION
## What
Pass `HF_TOKEN` explicitly to `hf_hub_download()` (×2) and `snapshot_download()` in `batch-runner/scripts/download_inference_from_hf.py` via a new `_hf_token()` helper.

## Why
The grade pipeline's "Download inference results from HF" step injects `HF_TOKEN` env, but `huggingface_hub` auto-pickup did not fire — CI logged `unauthenticated requests to HF Hub`. Anonymous requests have a low rate limit, so under the **sequential grade relay** the inference parquet download tripped HTTP **429 Too Many Requests**, breaking a chunk mid-run (observed on the gpt-5.4 220 re-grade chunk-2 resume).

## Effect
Authenticated requests have a much higher rate limit → relay no longer 429s on repeated chunk downloads. No behavior change for single runs (token simply makes the existing request authenticated).

## Scope
- `_hf_token()` reads `HF_TOKEN` (or `HUGGING_FACE_HUB_TOKEN`) from env; returns `None` if absent (falls back to current anonymous behavior, so local public-dataset runs still work).
- No change to grading logic, judge config, or selector.
