### PR TITLE
fix(ci): trigger Pages deploy on grade/experiment/result data changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches: [main]
     paths:
-      - 'data/tests/**'      # yaml 파일 변경 시
-      - 'src/**'              # 소스 변경 시
-      - 'scripts/**'          # 스크립트 변경 시
+      - 'data/tests/**'                 # aggregate-tests → tests-index
+      - 'data/grades/**'                # aggregate-grades → grades-index
+      - 'batch-runner/experiments/**'   # aggregate-experiments → experiments-index
+      - 'batch-runner/results/**'       # aggregate-reports → reports-index
+      - 'src/**'                        # 소스 변경 시
+      - 'scripts/**'                    # aggregate 스크립트 변경 시
 
   workflow_dispatch:          # 수동 실행 가능
 


### PR DESCRIPTION
## 문제
`deploy.yml`의 push 트리거 `paths`가 `data/tests/**`, `src/**`, `scripts/**`만 감시합니다. 그런데 대시보드 aggregate는 4개 입력을 읽습니다:

| aggregator | 입력 | deploy 트리거 |
|---|---|---|
| aggregate-tests | `data/tests/` | ✅ 있음 |
| aggregate-grades | `data/grades/` | ❌ **누락** |
| aggregate-experiments | `batch-runner/experiments/` | ❌ **누락** |
| aggregate-reports | `batch-runner/results/` | ❌ **누락** |

그래서 gpt-5.4 220 재채점 grade JSON 커밋(`9d9fd79`, 6/10)이 **배포를 트리거하지 못했고**, 라이브 대시보드가 6/3 배포 상태로 stale했습니다. (이번엔 `workflow_dispatch`로 수동 배포해 5.4를 즉시 반영함.)

## 변경
누락된 3개 대시보드 데이터 입력을 push `paths`에 추가 → 해당 데이터가 main에 들어오면 `grades-index` / `experiments-index` / `reports-index`가 자동 재생성·배포됩니다.

```yaml
- 'data/grades/**'                # aggregate-grades → grades-index
- 'batch-runner/experiments/**'   # aggregate-experiments → experiments-index
- 'batch-runner/results/**'       # aggregate-reports → reports-index
```

## 영향 / 리스크
- 워크플로 트리거 경로만 확장. 빌드/배포 로직·산출물 변경 없음.
- `public/generated/`는 gitignore라 빌드 시 재생성(기존 동작 유지).
- 워크플로 파일(`.github/**`) 자체는 paths에 없으므로 이 PR 머지만으로는 배포가 트리거되지 않습니다(의도된 동작; 다음 데이터 커밋부터 적용).

🤖 Generated with GitHub Copilot CLI