### PR TITLE
feat(executor): sandbox mode — containerized, skill-aware, multimodal execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,13 @@ Then trigger it from **Actions → Run workflow** with `experiment_yaml: exp001_
 |---|---|---|
 | **`code_interpreter`** | LLM writes + runs code inside Azure/OpenAI's **secure sandbox**. Files generated in the cloud. | ✅ Production — safe, powerful |
 | **`subprocess`** | LLM generates code → executed locally in an isolated temp directory. | Non-OpenAI models (Anthropic, etc.) |
+| **`sandbox`** | 🐳 Container evolution of `subprocess`: per-task **dependency discovery** + famous **Agent Skills** (audio/video/document/image/data) + **multimodal perception** (vision for video, hearing for audio). Runs in an isolated Docker container (`--network none`, resource caps) with a hardened **local fallback** when Docker is unavailable. | Multimodal tasks; reproducible, skill-aware execution |
 | **`json_renderer`** | LLM outputs a JSON spec → a **fixed renderer** creates files. Same renderer for all models. | Fair A/B comparison across models |
 
-> 🐳 `subprocess` mode is planned to evolve into a **container-based** execution mode — if time permits and coffee supply holds.
+> 🐳 `sandbox` mode realizes the **container-based** evolution of `subprocess`.
+> Build the image with `bash batch-runner/sandbox/build.sh`, then set
+> `execution.mode: sandbox` (see `batch-runner/sandbox/README.md` and
+> `experiments/exp026_sandbox_skills_multimodal.yaml`).
 
 ---
 

--- a/batch-runner/.dockerignore
+++ b/batch-runner/.dockerignore
@@ -1,0 +1,36 @@
+# Docker build context ignore list for the sandbox image.
+# Build context is batch-runner/; keep it small and reproducible.
+
+# VCS / tooling
+.git
+.gitignore
+.github
+
+# Python caches / build artifacts
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+.pytest_cache/
+.mypy_cache/
+*.egg-info/
+.coverage
+htmlcov/
+
+# Tests are not needed inside the image
+tests/
+
+# Local workspace / experiment outputs
+workspace/
+upload/
+results/
+*.log
+
+# Datasets / large local files
+data/
+*.parquet
+*.csv
+
+# Editor / OS cruft
+.vscode/
+.idea/
+.DS_Store

--- a/batch-runner/README.md
+++ b/batch-runner/README.md
@@ -228,10 +228,11 @@ bash sandbox/build.sh           # builds gdpval-sandbox:latest
 ```yaml
 execution:
   mode: sandbox
+  timeout: 1200                  # exec ceiling; 4K/video renders need >720s
   sandbox:
     image: gdpval-sandbox:latest
     use_docker: auto             # auto | never | always
-    memory_gb: 5
+    memory_gb: 8                 # video-heavy (4K) tasks; 5 GB OOM-killed a 657 MB clip
     cpus: 2.0
     max_skills: 5
     repair:                      # bounded output repair loop
@@ -249,6 +250,14 @@ execution:
     cache:                       # cache rendered PNGs / perception by sha256
       enabled: true
 ```
+
+> **Sandbox codegen safety:** keep `condition.model.reasoning_effort` at
+> `medium` or lower for `sandbox` mode. `high` reasoning on complex GDPVal
+> prompts can consume the entire completion budget on hidden reasoning (empty
+> visible output → "No Python code found") and exceed the 480s LLM-client
+> timeout. `SandboxRunner` warns at construction if `high` is paired with a
+> `code_generation` budget below 32768. See
+> `tasks/0701_wednesday/sandbox_ab_smoke_pr57.md`.
 
 | Mode | Compatible Providers | Security | Best For |
 |------|---------------------|----------|----------|

--- a/batch-runner/README.md
+++ b/batch-runner/README.md
@@ -252,12 +252,16 @@ execution:
 ```
 
 > **Sandbox codegen safety:** keep `condition.model.reasoning_effort` at
-> `medium` or lower for `sandbox` mode. `high` reasoning on complex GDPVal
-> prompts can consume the entire completion budget on hidden reasoning (empty
-> visible output → "No Python code found") and exceed the 480s LLM-client
-> timeout. `SandboxRunner` warns at construction if `high` is paired with a
-> `code_generation` budget below 32768. See
-> `tasks/0701_wednesday/sandbox_ab_smoke_pr57.md`.
+> `low` for `sandbox` mode. gpt-5.4 draws hidden reasoning tokens from the *same*
+> completion budget as the visible code, so `high` — and even `medium` on
+> reference-heavy tasks — can consume nearly the whole budget on reasoning,
+> emptying the visible output ("No Python code found") and exceeding the 480s
+> LLM-client timeout. A post-hardening probe on a representative task measured
+> `medium` at 31,146/32,768 completion tokens (95%, intermittently empty) vs
+> `low` at 10,139/32,768 (31%, stable, finish=stop). `SandboxRunner` still warns
+> at construction if `high` is paired with a `code_generation` budget below
+> 32768. See
+> `tasks/0702_thursday/sandbox_post_hardening_docker_verification_pr57.md`.
 
 | Mode | Compatible Providers | Security | Best For |
 |------|---------------------|----------|----------|

--- a/batch-runner/README.md
+++ b/batch-runner/README.md
@@ -205,6 +205,17 @@ code execution (see [`sandbox/README.md`](sandbox/README.md)):
   toolkits for audio/video/document/image/data are selected per task, documented
   in the prompt, and mounted in the sandbox, giving generated code *vision*
   (video frame-by-frame, image OCR) and *hearing* (audio FFT/sampling/loudness).
+- **Output control loop** (`core/deliverable_contract.py`,
+  `core/artifact_verifier.py`, `core/output_qa.py`) — skills perceive the
+  *inputs*; this layer verifies the *outputs*. Before codegen a deterministic
+  **deliverable contract** declares what file(s) the task should produce; after
+  execution the generated artifacts are selected (reference files excluded),
+  **verified** (non-empty, openable, correct type), and **render-QA'd** (PDF/Office
+  rasterized to PNG with blank-page detection; optional LLM vision QA behind
+  `output_qa.vision.enabled`). Blocking failures trigger a **bounded repair loop**
+  that feeds the concrete failure back to the model (default 1 retry). Every run
+  writes a `manifest.json` recording the contract, dependency probe, per-attempt
+  status, and `final_status` (`ok` / `repaired_ok` / `failed_*`).
 - Pairs with the `video_analyzer` (vision) and `audio_analyzer` (hearing)
   preprocessors. See `experiments/exp026_sandbox_skills_multimodal.yaml`.
 
@@ -223,6 +234,20 @@ execution:
     memory_gb: 5
     cpus: 2.0
     max_skills: 5
+    repair:                      # bounded output repair loop
+      enabled: true
+      max_attempts: 1
+    output_qa:                   # verify + render the generated deliverables
+      enabled: true
+      render: true
+      max_pages_per_artifact: 3
+      blank_page_threshold: 0.999
+      vision:                    # optional LLM vision QA (off by default)
+        enabled: false
+    manifest:                    # per-run manifest.json
+      enabled: true
+    cache:                       # cache rendered PNGs / perception by sha256
+      enabled: true
 ```
 
 | Mode | Compatible Providers | Security | Best For |

--- a/batch-runner/README.md
+++ b/batch-runner/README.md
@@ -150,7 +150,7 @@ condition_a:
     max_retries: 3
 
 execution:
-  mode: "code_interpreter"    # code_interpreter | subprocess | json_renderer
+  mode: "code_interpreter"    # code_interpreter | subprocess | sandbox | json_renderer
   max_retries: 5
   resume_max_rounds: 3
 ```
@@ -188,10 +188,48 @@ Designed for controlled A/B testing across different models.
 - Eliminates code generation skill as a variable — isolates the model's understanding of the task
 - Suitable for any model provider
 
+### `sandbox` — Containerized, Skill-Aware Multimodal Execution
+
+The container evolution of `subprocess`. Adds three capabilities on top of local
+code execution (see [`sandbox/README.md`](sandbox/README.md)):
+
+- **Container isolation** — generated `solution.py` runs in a disposable Docker
+  container (`--network none`, `--memory`, `--pids-limit`, `no-new-privileges`)
+  built from `requirements.txt` + system tools (ffmpeg, poppler, tesseract,
+  libreoffice, graphviz, GDAL, …). Falls back to the hardened local subprocess
+  when Docker is unavailable (`use_docker: auto`).
+- **Per-task dependency discovery** (`core/dependency_resolver.py`) — derives the
+  pip packages each task needs from reference-file extensions, task keywords, and
+  the generated code's imports, and flags anything missing from the image.
+- **Agent Skills** (`skills/` + `core/skills_registry.py`) — famous-library
+  toolkits for audio/video/document/image/data are selected per task, documented
+  in the prompt, and mounted in the sandbox, giving generated code *vision*
+  (video frame-by-frame, image OCR) and *hearing* (audio FFT/sampling/loudness).
+- Pairs with the `video_analyzer` (vision) and `audio_analyzer` (hearing)
+  preprocessors. See `experiments/exp026_sandbox_skills_multimodal.yaml`.
+
+Build the image once, then select the mode:
+
+```bash
+bash sandbox/build.sh           # builds gdpval-sandbox:latest
+```
+
+```yaml
+execution:
+  mode: sandbox
+  sandbox:
+    image: gdpval-sandbox:latest
+    use_docker: auto             # auto | never | always
+    memory_gb: 5
+    cpus: 2.0
+    max_skills: 5
+```
+
 | Mode | Compatible Providers | Security | Best For |
 |------|---------------------|----------|----------|
 | `code_interpreter` | Azure OpenAI, OpenAI | Sandboxed (cloud) | Production runs, complex file generation |
 | `subprocess` | Any | Isolated temp dir | Non-OpenAI models |
+| `sandbox` | Any | Container (`--network none`) + local fallback | Multimodal/skill-aware, reproducible execution |
 | `json_renderer` | Any | No code execution | Fair cross-model comparison |
 
 ## Multi-Provider Support

--- a/batch-runner/core/artifact_renderer.py
+++ b/batch-runner/core/artifact_renderer.py
@@ -1,0 +1,222 @@
+"""Render generated artifacts to PNG snapshots — the solver's *eyes on output*.
+
+GDPVal's "Overall Style" depends on how a deliverable actually *looks* once
+opened. This module rasterizes generated PDFs / Office docs / images so the
+output-QA layer (and, optionally, a vision model) can inspect appearance, and so
+deterministic checks (blank-page / empty-canvas detection) can run with zero LLM
+cost.
+
+Strategy by kind:
+* **pdf**      -> PyMuPDF renders the first N pages directly.
+* **pptx/docx/xlsx** -> LibreOffice headless converts to PDF, then PyMuPDF.
+* **image**    -> the original (optionally thumbnailed) is the snapshot.
+* everything else is skipped with a note.
+
+All heavy bits are lazily imported and failures become warnings, not crashes, so
+the renderer is safe in a light venv (it simply produces fewer snapshots).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+from core.artifact_verifier import classify_kind
+
+_OFFICE_KINDS = {"spreadsheet", "document", "presentation"}
+_RENDERABLE = _OFFICE_KINDS | {"pdf", "image"}
+
+
+@dataclass
+class RenderResult:
+    rel_path: str
+    kind: str
+    page_count: int = 0
+    rendered_images: List[str] = field(default_factory=list)
+    blank_pages: List[int] = field(default_factory=list)
+    page_white_fractions: List[float] = field(default_factory=list)
+    converted_via: Optional[str] = None
+    cached: bool = False
+    warnings: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _find_soffice() -> Optional[str]:
+    for name in ("soffice", "libreoffice"):
+        path = shutil.which(name)
+        if path:
+            return path
+    mac = "/Applications/LibreOffice.app/Contents/MacOS/soffice"
+    if Path(mac).exists():
+        return mac
+    return None
+
+
+def libreoffice_available() -> bool:
+    return _find_soffice() is not None
+
+
+def _blank_fraction(pix) -> float:
+    """Fraction of near-white pixels in a grayscale PyMuPDF pixmap."""
+    samples = pix.samples
+    if not samples:
+        return 1.0
+    try:
+        import numpy as np
+        arr = np.frombuffer(samples, dtype=np.uint8)
+        return float((arr >= 250).mean())
+    except Exception:
+        step = max(1, len(samples) // 4096)
+        sampled = samples[::step]
+        white = sum(1 for b in sampled if b >= 250)
+        return white / max(len(sampled), 1)
+
+
+def _render_pdf(
+    pdf_path: Path, out_dir: Path, stem: str, max_pages: int,
+    blank_threshold: float, dpi: int, result: RenderResult,
+) -> None:
+    try:
+        import fitz
+    except Exception:
+        result.warnings.append("PyMuPDF unavailable; cannot render to PNG")
+        return
+    try:
+        doc = fitz.open(str(pdf_path))
+    except Exception as e:
+        result.errors.append(f"could not open PDF for render: {e}")
+        return
+    result.page_count = doc.page_count
+    n = min(max_pages, doc.page_count)
+    for i in range(n):
+        try:
+            page = doc.load_page(i)
+            pix = page.get_pixmap(dpi=dpi)
+            img_path = out_dir / f"{stem}_p{i + 1}.png"
+            pix.save(str(img_path))
+            result.rendered_images.append(str(img_path))
+            gray = page.get_pixmap(dpi=72, colorspace=fitz.csGRAY)
+            white = _blank_fraction(gray)
+            result.page_white_fractions.append(round(white, 5))
+            if white >= blank_threshold:
+                result.blank_pages.append(i + 1)
+        except Exception as e:
+            result.warnings.append(f"page {i + 1} render failed: {e}")
+    doc.close()
+
+
+def _convert_office_to_pdf(src: Path, out_dir: Path, result: RenderResult) -> Optional[Path]:
+    soffice = _find_soffice()
+    if not soffice:
+        result.warnings.append("LibreOffice unavailable; cannot render office document")
+        return None
+    try:
+        proc = subprocess.run(
+            [soffice, "--headless", "--convert-to", "pdf", "--outdir",
+             str(out_dir), str(src)],
+            capture_output=True, text=True, timeout=120,
+        )
+        pdf_path = out_dir / (src.stem + ".pdf")
+        if pdf_path.exists():
+            result.converted_via = "libreoffice"
+            return pdf_path
+        result.warnings.append(
+            f"LibreOffice conversion produced no PDF: {proc.stderr[-200:]}"
+        )
+    except Exception as e:
+        result.warnings.append(f"LibreOffice conversion failed: {e}")
+    return None
+
+
+def _render_image(src: Path, out_dir: Path, stem: str, result: RenderResult) -> None:
+    try:
+        from PIL import Image
+        with Image.open(src) as im:
+            im = im.convert("RGB")
+            im.thumbnail((1600, 1600))
+            img_path = out_dir / f"{stem}_p1.png"
+            im.save(img_path)
+            result.rendered_images.append(str(img_path))
+            result.page_count = 1
+    except Exception as e:
+        result.warnings.append(f"image snapshot failed: {e}")
+
+
+def render_artifact(
+    artifact_path,
+    out_dir,
+    max_pages: int = 3,
+    blank_threshold: float = 0.999,
+    dpi: int = 120,
+    cache=None,
+) -> RenderResult:
+    """Render one artifact to PNG snapshot(s) under ``out_dir``."""
+    artifact_path = Path(artifact_path)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    kind = classify_kind(artifact_path.suffix)
+    result = RenderResult(rel_path=artifact_path.name, kind=kind)
+
+    if kind not in _RENDERABLE:
+        result.warnings.append(f"kind '{kind}' is not rendered")
+        return result
+    if not artifact_path.exists() or artifact_path.stat().st_size == 0:
+        result.errors.append("artifact missing or empty; nothing to render")
+        return result
+
+    stem = artifact_path.stem
+    cfg = {"max_pages": max_pages, "blank_threshold": blank_threshold, "dpi": dpi}
+    ckey = None
+    if cache is not None and getattr(cache, "enabled", False):
+        try:
+            ckey = cache.key(cache.hash_file(artifact_path), "render", cfg)
+            meta = cache.get_json(ckey)
+            if meta:
+                for i, b64name in enumerate(meta.get("image_keys", [])):
+                    data = cache.get_bytes(b64name, suffix=".png")
+                    if data:
+                        img_path = out_dir / f"{stem}_p{i + 1}.png"
+                        img_path.write_bytes(data)
+                        result.rendered_images.append(str(img_path))
+                result.page_count = meta.get("page_count", len(result.rendered_images))
+                result.blank_pages = meta.get("blank_pages", [])
+                result.page_white_fractions = meta.get("page_white_fractions", [])
+                result.converted_via = meta.get("converted_via")
+                result.cached = True
+                return result
+        except Exception:
+            ckey = None
+
+    if kind == "pdf":
+        _render_pdf(artifact_path, out_dir, stem, max_pages, blank_threshold, dpi, result)
+    elif kind == "image":
+        _render_image(artifact_path, out_dir, stem, result)
+    elif kind in _OFFICE_KINDS:
+        pdf_path = _convert_office_to_pdf(artifact_path, out_dir, result)
+        if pdf_path is not None:
+            _render_pdf(pdf_path, out_dir, stem, max_pages, blank_threshold, dpi, result)
+
+    if ckey is not None and result.rendered_images:
+        try:
+            image_keys = []
+            for i, img in enumerate(result.rendered_images):
+                page_key = f"{ckey}-p{i + 1}"
+                cache.put_bytes(page_key, Path(img).read_bytes(), suffix=".png")
+                image_keys.append(page_key)
+            cache.put_json(ckey, {
+                "page_count": result.page_count,
+                "blank_pages": result.blank_pages,
+                "page_white_fractions": result.page_white_fractions,
+                "converted_via": result.converted_via,
+                "image_keys": image_keys,
+            })
+        except Exception:
+            pass
+
+    return result

--- a/batch-runner/core/artifact_verifier.py
+++ b/batch-runner/core/artifact_verifier.py
@@ -1,0 +1,418 @@
+"""Deterministic output verifier for sandbox-generated artifacts.
+
+Where :mod:`core.deliverable_contract` decides *what* should be produced, this
+module checks that each produced file is **real**: it exists, is non-empty, lives
+safely under the work directory, and can actually be opened by the library that
+owns its format (openpyxl / python-docx / python-pptx / PyMuPDF / Pillow /
+pandas / zipfile / ffprobe).
+
+Everything is lazily imported and degrades gracefully — when an optional library
+is unavailable the artifact is marked ``openable = None`` (not checked) with a
+warning rather than a hard failure, so the verifier runs even in a light venv.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import mimetypes
+import shutil
+import subprocess
+import zipfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+# ── suffix → coarse kind ──────────────────────────────────────────────────
+_KIND_BY_SUFFIX = {
+    ".xlsx": "spreadsheet", ".xlsm": "spreadsheet", ".xls": "spreadsheet",
+    ".docx": "document", ".doc": "document",
+    ".pptx": "presentation", ".ppt": "presentation",
+    ".pdf": "pdf",
+    ".png": "image", ".jpg": "image", ".jpeg": "image", ".gif": "image",
+    ".bmp": "image", ".tiff": "image", ".tif": "image", ".webp": "image",
+    ".csv": "data", ".tsv": "data", ".json": "data", ".parquet": "data",
+    ".wav": "audio", ".mp3": "audio", ".flac": "audio", ".m4a": "audio",
+    ".aac": "audio", ".ogg": "audio",
+    ".mp4": "video", ".mov": "video", ".avi": "video", ".mkv": "video",
+    ".webm": "video",
+    ".zip": "archive",
+    ".txt": "text", ".md": "text", ".html": "text", ".htm": "text",
+    ".xml": "text", ".rtf": "text",
+}
+
+
+def classify_kind(suffix: str) -> str:
+    return _KIND_BY_SUFFIX.get(suffix.lower(), "unknown")
+
+
+@dataclass
+class ArtifactReport:
+    path: str
+    rel_path: str
+    exists: bool
+    size_bytes: int
+    suffix: str
+    kind: str
+    sha256: str = ""
+    mime: Optional[str] = None
+    openable: Optional[bool] = None  # True / False / None (not checked)
+    metadata: dict = field(default_factory=dict)
+    warnings: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class VerificationReport:
+    artifacts: List[ArtifactReport] = field(default_factory=list)
+    ok: bool = True
+    blocking_errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "blocking_errors": self.blocking_errors,
+            "warnings": self.warnings,
+            "artifacts": [a.to_dict() for a in self.artifacts],
+        }
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ── per-kind openability probes (all lazily imported, never raise) ─────────
+
+def _check_spreadsheet(path: Path, report: ArtifactReport) -> None:
+    if path.suffix.lower() == ".xls":
+        report.openable = None
+        report.warnings.append("legacy .xls not validated (openpyxl supports xlsx/xlsm)")
+        return
+    try:
+        from openpyxl import load_workbook
+    except Exception:
+        report.openable = None
+        report.warnings.append("openpyxl unavailable; spreadsheet not validated")
+        return
+    try:
+        wb = load_workbook(path, read_only=True)
+        visible = [ws.title for ws in wb.worksheets if ws.sheet_state == "visible"]
+        report.metadata.update(
+            {"sheet_count": len(wb.sheetnames), "sheet_names": wb.sheetnames[:20],
+             "visible_sheets": visible[:20]}
+        )
+        report.openable = True
+        wb.close()
+    except Exception as e:
+        report.openable = False
+        report.errors.append(f"openpyxl could not open workbook: {e}")
+
+
+def _check_document(path: Path, report: ArtifactReport) -> None:
+    if path.suffix.lower() != ".docx":
+        report.openable = None
+        report.warnings.append("legacy .doc not validated (python-docx supports docx)")
+        return
+    try:
+        from docx import Document
+    except Exception:
+        report.openable = None
+        report.warnings.append("python-docx unavailable; document not validated")
+        return
+    try:
+        doc = Document(str(path))
+        report.metadata.update(
+            {"paragraph_count": len(doc.paragraphs), "table_count": len(doc.tables)}
+        )
+        report.openable = True
+    except Exception as e:
+        report.openable = False
+        report.errors.append(f"python-docx could not open document: {e}")
+
+
+def _check_presentation(path: Path, report: ArtifactReport) -> None:
+    if path.suffix.lower() != ".pptx":
+        report.openable = None
+        report.warnings.append("legacy .ppt not validated (python-pptx supports pptx)")
+        return
+    try:
+        from pptx import Presentation
+    except Exception:
+        report.openable = None
+        report.warnings.append("python-pptx unavailable; presentation not validated")
+        return
+    try:
+        prs = Presentation(str(path))
+        report.metadata.update({"slide_count": len(prs.slides)})
+        report.openable = True
+    except Exception as e:
+        report.openable = False
+        report.errors.append(f"python-pptx could not open presentation: {e}")
+
+
+def _check_pdf(path: Path, report: ArtifactReport) -> None:
+    try:
+        import fitz  # PyMuPDF
+    except Exception:
+        report.openable = None
+        report.warnings.append("PyMuPDF unavailable; PDF not validated")
+        return
+    try:
+        doc = fitz.open(str(path))
+        page_count = doc.page_count
+        report.metadata.update({"page_count": page_count})
+        doc.close()
+        if page_count <= 0:
+            report.openable = False
+            report.errors.append("PDF has 0 pages")
+        else:
+            report.openable = True
+    except Exception as e:
+        report.openable = False
+        report.errors.append(f"PyMuPDF could not open PDF: {e}")
+
+
+def _check_image(path: Path, report: ArtifactReport) -> None:
+    try:
+        from PIL import Image
+    except Exception:
+        report.openable = None
+        report.warnings.append("Pillow unavailable; image not validated")
+        return
+    try:
+        with Image.open(path) as im:
+            im.verify()
+        with Image.open(path) as im2:
+            report.metadata.update({"width": im2.width, "height": im2.height,
+                                    "mode": im2.mode})
+        report.openable = True
+    except Exception as e:
+        report.openable = False
+        report.errors.append(f"Pillow could not open image: {e}")
+
+
+def _check_data(path: Path, report: ArtifactReport) -> None:
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                json.load(fh)
+            report.openable = True
+        except Exception as e:
+            report.openable = False
+            report.errors.append(f"invalid JSON: {e}")
+        return
+    if suffix == ".parquet":
+        try:
+            import pandas as pd
+            df = pd.read_parquet(path)
+            report.metadata.update({"rows": int(df.shape[0]), "cols": int(df.shape[1])})
+            report.openable = True
+        except Exception as e:
+            report.openable = None
+            report.warnings.append(f"parquet not validated: {e}")
+        return
+    # csv / tsv
+    sep = "\t" if suffix == ".tsv" else ","
+    try:
+        import pandas as pd
+        df = pd.read_csv(path, sep=sep, nrows=2000)
+        report.metadata.update({"rows_sampled": int(df.shape[0]), "cols": int(df.shape[1])})
+        report.openable = True
+    except Exception:
+        try:
+            with path.open("r", encoding="utf-8", errors="replace") as fh:
+                first = fh.readline()
+            report.metadata.update({"first_line_fields": len(first.split(sep))})
+            report.openable = True
+        except Exception as e:
+            report.openable = False
+            report.errors.append(f"could not read delimited file: {e}")
+
+
+def _ffprobe(path: Path) -> Optional[dict]:
+    if not shutil.which("ffprobe"):
+        return None
+    try:
+        proc = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_format", "-show_streams",
+             "-of", "json", str(path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        if proc.returncode != 0:
+            return {"_error": proc.stderr[-300:]}
+        return json.loads(proc.stdout or "{}")
+    except Exception:
+        return None
+
+
+def _check_audio(path: Path, report: ArtifactReport) -> None:
+    probe = _ffprobe(path)
+    if probe is not None and "_error" not in probe:
+        streams = probe.get("streams", [])
+        audio_streams = [s for s in streams if s.get("codec_type") == "audio"]
+        dur = (probe.get("format") or {}).get("duration")
+        report.metadata.update({"audio_streams": len(audio_streams), "duration": dur})
+        report.openable = bool(audio_streams)
+        if not audio_streams:
+            report.errors.append("no audio stream detected by ffprobe")
+        return
+    if path.suffix.lower() in (".wav", ".flac", ".ogg"):
+        try:
+            import soundfile as sf
+            info = sf.info(str(path))
+            report.metadata.update({"samplerate": info.samplerate,
+                                    "frames": info.frames, "channels": info.channels})
+            report.openable = info.frames > 0
+            if info.frames <= 0:
+                report.errors.append("audio has 0 frames")
+            return
+        except Exception:
+            pass
+    report.openable = None
+    report.warnings.append("audio not validated (ffprobe/soundfile unavailable)")
+
+
+def _check_video(path: Path, report: ArtifactReport) -> None:
+    probe = _ffprobe(path)
+    if probe is not None and "_error" not in probe:
+        streams = probe.get("streams", [])
+        video_streams = [s for s in streams if s.get("codec_type") == "video"]
+        dur = (probe.get("format") or {}).get("duration")
+        report.metadata.update({"video_streams": len(video_streams), "duration": dur})
+        report.openable = bool(video_streams)
+        if not video_streams:
+            report.errors.append("no video stream detected by ffprobe")
+        return
+    try:
+        import cv2
+        cap = cv2.VideoCapture(str(path))
+        opened = cap.isOpened()
+        frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) if opened else 0
+        cap.release()
+        report.metadata.update({"frame_count": frames})
+        report.openable = opened and frames > 0
+        if not report.openable:
+            report.errors.append("OpenCV could not read video frames")
+        return
+    except Exception:
+        pass
+    report.openable = None
+    report.warnings.append("video not validated (ffprobe/opencv unavailable)")
+
+
+def _check_archive(path: Path, report: ArtifactReport) -> None:
+    try:
+        with zipfile.ZipFile(path) as zf:
+            bad = zf.testzip()
+            report.metadata.update({"entries": len(zf.namelist())})
+            if bad is not None:
+                report.openable = False
+                report.errors.append(f"corrupt zip entry: {bad}")
+            else:
+                report.openable = True
+    except Exception as e:
+        report.openable = False
+        report.errors.append(f"could not open archive: {e}")
+
+
+def _check_text(path: Path, report: ArtifactReport) -> None:
+    try:
+        data = path.read_text(encoding="utf-8", errors="replace")
+        report.metadata.update({"char_count": len(data), "line_count": data.count("\n") + 1})
+        report.openable = True
+    except Exception as e:
+        report.openable = False
+        report.errors.append(f"could not read text file: {e}")
+
+
+_KIND_CHECKERS = {
+    "spreadsheet": _check_spreadsheet,
+    "document": _check_document,
+    "presentation": _check_presentation,
+    "pdf": _check_pdf,
+    "image": _check_image,
+    "data": _check_data,
+    "audio": _check_audio,
+    "video": _check_video,
+    "archive": _check_archive,
+    "text": _check_text,
+}
+
+
+def verify_one(path, workdir=None) -> ArtifactReport:
+    """Verify a single artifact; never raises."""
+    path = Path(path)
+    rel = path.name
+    if workdir is not None:
+        try:
+            rel = str(path.resolve().relative_to(Path(workdir).resolve()))
+        except Exception:
+            rel = path.name
+    suffix = path.suffix.lower()
+    report = ArtifactReport(
+        path=str(path), rel_path=rel, exists=path.exists(),
+        size_bytes=path.stat().st_size if path.exists() else 0,
+        suffix=suffix, kind=classify_kind(suffix),
+        mime=mimetypes.guess_type(str(path))[0],
+    )
+
+    if not report.exists:
+        report.errors.append("file does not exist")
+        return report
+
+    # Path safety: an artifact must live under the work directory.
+    if workdir is not None:
+        try:
+            Path(path).resolve().relative_to(Path(workdir).resolve())
+        except Exception:
+            report.errors.append("artifact path escapes the work directory")
+            return report
+
+    if report.size_bytes == 0:
+        report.errors.append("file is empty (0 bytes)")
+        report.openable = False
+        return report
+
+    try:
+        report.sha256 = _sha256(path)
+    except Exception as e:
+        report.warnings.append(f"could not hash file: {e}")
+
+    checker = _KIND_CHECKERS.get(report.kind)
+    if checker is None:
+        report.openable = None
+        report.warnings.append(f"no validator for '{suffix or 'extensionless'}' file")
+    else:
+        try:
+            checker(path, report)
+        except Exception as e:  # pragma: no cover - defensive
+            report.openable = False
+            report.errors.append(f"verification crashed: {e}")
+    return report
+
+
+def verify_artifacts(artifacts, contract=None, workdir=None) -> VerificationReport:
+    """Verify every artifact and roll up blocking errors / warnings."""
+    reports = [verify_one(a, workdir=workdir) for a in artifacts]
+    blocking: List[str] = []
+    warnings: List[str] = []
+    for r in reports:
+        for e in r.errors:
+            blocking.append(f"{r.rel_path}: {e}")
+        for w in r.warnings:
+            warnings.append(f"{r.rel_path}: {w}")
+    return VerificationReport(
+        artifacts=reports,
+        ok=not blocking,
+        blocking_errors=blocking,
+        warnings=warnings,
+    )

--- a/batch-runner/core/deliverable_contract.py
+++ b/batch-runner/core/deliverable_contract.py
@@ -1,0 +1,324 @@
+"""Deliverable contract & selector for the sandbox output control loop.
+
+Skills give the sandbox *eyes/ears/hands* on the **inputs**. This module answers
+the complementary question about the **outputs**: *"what file(s) is this task
+supposed to PRODUCE, and did the generated code actually produce them?"*
+
+It is deliberately deterministic (no LLM calls) so it can:
+
+1. Infer a :class:`DeliverableContract` from the task text + reference-file list
+   *before* code generation, and inject a compact ``DELIVERABLE CONTRACT`` block
+   into the codegen prompt so the model knows exactly what to emit.
+2. After execution, separate **generated** artifacts from **reference/input**
+   files (set-diff + explicit reference exclusion) so a copied input is never
+   mistaken for a deliverable.
+3. Validate the produced artifacts against the contract and surface blocking
+   failures (wrong/missing primary type, no deliverable at all) that the repair
+   loop can feed back to the model.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+# Control / bookkeeping files the runner writes into the workdir. They are never
+# counted as task deliverables even though they live alongside them.
+RESERVED_NAMES: Set[str] = {"solution.py", "manifest.json"}
+
+# Creation verbs that indicate the task expects a tangible file deliverable.
+_CREATION_VERBS = (
+    "create", "generate", "produce", "build", "make", "write", "draft",
+    "prepare", "design", "compose", "develop", "fill", "update", "complete",
+    "convert", "export", "save", "assemble", "compile", "format", "plot",
+    "chart", "summarize", "summarise", "analyze", "analyse", "calculate",
+)
+
+Confidence = str  # "high" | "medium" | "low"
+
+
+def _has_word(text: str, *words: str) -> bool:
+    for w in words:
+        if re.search(rf"(?<![a-z0-9]){re.escape(w)}(?![a-z0-9])", text):
+            return True
+    return False
+
+
+def _detect_extensions(text: str) -> List[Dict]:
+    """Return ordered ext detections: list of {ext, confidence, note}."""
+    t = text.lower()
+    hits: List[Dict] = []
+    seen: Set[str] = set()
+
+    def add(ext: str, confidence: Confidence, note: str) -> None:
+        if ext in seen:
+            return
+        seen.add(ext)
+        hits.append({"ext": ext, "confidence": confidence, "note": note})
+
+    # 1) Explicit extension tokens / unambiguous format words (highest signal).
+    #    Each entry: ext, HIGH-confidence words (literal type tokens), MEDIUM
+    #    words (format nouns that might instead refer to an *input* file).
+    explicit = [
+        (".xlsx", ("xlsx",), ("excel", "workbook", "spreadsheet"), "Excel/spreadsheet requested"),
+        (".pptx", ("pptx",), ("powerpoint", "slide deck", "slides", "deck", "presentation"), "PowerPoint/slides requested"),
+        (".docx", ("docx",), ("word document", "word doc"), "Word document requested"),
+        (".pdf", ("pdf",), (), "PDF requested"),
+        (".csv", ("csv",), (), "CSV requested"),
+        (".tsv", ("tsv",), (), "TSV requested"),
+        (".json", ("json",), (), "JSON requested"),
+        (".mp4", ("mp4",), ("video", "animation", "screencast", "montage"), "Video requested"),
+        (".mp3", ("mp3",), (), "MP3 audio requested"),
+        (".wav", ("wav",), (), "WAV audio requested"),
+        (".zip", ("zip",), ("archive", "bundle"), "Archive requested"),
+        (".md", ("markdown",), (), "Markdown requested"),
+        (".html", ("html",), ("webpage", "web page"), "HTML requested"),
+    ]
+    for ext, high_words, med_words, note in explicit:
+        if _has_word(t, *high_words):
+            add(ext, "high", note)
+        elif med_words and _has_word(t, *med_words):
+            add(ext, "medium", note)
+
+    # 2) Softer deliverable nouns -> a likely (medium-confidence) type, unless an
+    #    explicit type already covered it.
+    noun_rules = [
+        ((".docx",), ("memo", "letter", "report", "write-up", "writeup", "essay",
+                      "cover letter", "meeting notes", "minutes", "brief"),
+         "Prose deliverable (memo/report/letter)"),
+        ((".pdf",), ("flyer", "one-pager", "one pager", "brochure", "poster",
+                     "form", "datasheet", "fact sheet", "factsheet", "handout"),
+         "Print/layout deliverable"),
+        ((".png",), ("logo", "icon", "chart", "graph", "diagram", "screenshot",
+                     "infographic", "storyboard", "mockup", "wireframe",
+                     "figure", "plot", "image"),
+         "Graphic/image deliverable"),
+        ((".wav",), ("audio", "podcast", "voiceover", "voice-over", "soundtrack",
+                     "song", "music", "jingle", "narration"),
+         "Audio deliverable"),
+        ((".xlsx",), ("model", "tracker", "budget", "schedule", "roster",
+                      "dashboard", "pivot", "ledger"),
+         "Tabular deliverable"),
+    ]
+    for exts, words, note in noun_rules:
+        if _has_word(t, *words):
+            for ext in exts:
+                add(ext, "medium", note)
+
+    # 3) Explicit-override refinements.
+    refined: List[Dict] = []
+    for h in hits:
+        ext = h["ext"]
+        # "csv" explicitly trumps a generic spreadsheet guess.
+        if ext == ".xlsx" and _has_word(t, "csv") and not _has_word(
+            t, "xlsx", "excel", "workbook"
+        ):
+            continue
+        # "pdf" explicitly trumps a generic docx guess.
+        if ext == ".docx" and _has_word(t, "pdf") and not _has_word(
+            t, "docx", "word document", "word doc"
+        ):
+            continue
+        refined.append(h)
+    return refined
+
+
+@dataclass
+class DeliverableContract:
+    """What the task is expected to PRODUCE, inferred deterministically."""
+
+    expected_extensions: List[str] = field(default_factory=list)
+    min_count: int = 1
+    max_count: Optional[int] = None
+    required_keywords: List[str] = field(default_factory=list)
+    allow_extra_files: bool = True
+    requires_deliverable: bool = True
+    notes: List[str] = field(default_factory=list)
+    confidence: Confidence = "low"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_prompt_section(self) -> str:
+        """Compact block injected into the codegen prompt (no ``{`` / ``}``)."""
+        lines = ["DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):"]
+        if self.expected_extensions:
+            lines.append(
+                "- Expected file type(s): " + ", ".join(self.expected_extensions)
+            )
+        else:
+            lines.append(
+                "- Expected file type(s): a standard professional file "
+                "(PDF/DOCX/XLSX/PPTX/PNG/CSV as appropriate)"
+            )
+        lines.append(f"- Minimum deliverable files: {self.min_count}")
+        if self.required_keywords:
+            lines.append(
+                "- Deliverable name should reference: " + ", ".join(self.required_keywords)
+            )
+        lines.append(f"- Confidence in this contract: {self.confidence}")
+        for n in self.notes:
+            lines.append(f"- Note: {n}")
+        lines.append(
+            "Save real, openable file(s) of the expected type(s) to the working "
+            "directory. Do NOT count reference/input files as your deliverable, and "
+            "do NOT describe the file only in text. If you cannot produce the exact "
+            "type, produce the closest standard professional format and say so."
+        )
+        return "\n".join(lines)
+
+
+@dataclass
+class ContractValidation:
+    ok: bool = True
+    blocking_errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    matched_primary: List[str] = field(default_factory=list)
+    generated_count: int = 0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def infer_deliverable_contract(
+    task_text: str,
+    reference_files: Optional[List[str]] = None,
+    config: Optional[dict] = None,
+) -> DeliverableContract:
+    """Infer the deterministic deliverable contract for a task."""
+    config = config or {}
+    reference_files = reference_files or []
+    text = task_text or ""
+
+    detections = _detect_extensions(text)
+    expected = [d["ext"] for d in detections]
+    notes = [d["note"] for d in detections]
+
+    if detections:
+        confidence = "high" if any(d["confidence"] == "high" for d in detections) else "medium"
+    else:
+        confidence = "low"
+
+    has_creation_verb = _has_word(text.lower(), *_CREATION_VERBS)
+    requires_deliverable = bool(expected) or has_creation_verb or bool(reference_files)
+
+    # Config overrides (execution.sandbox.contract.*).
+    if "expected_extensions" in config and config["expected_extensions"]:
+        expected = [e if e.startswith(".") else f".{e}" for e in config["expected_extensions"]]
+        confidence = "high"
+        notes.append("Expected type(s) pinned by experiment config")
+    if config.get("requires_deliverable") is not None:
+        requires_deliverable = bool(config["requires_deliverable"])
+    min_count = int(config.get("min_count", 1))
+    max_count = config.get("max_count")
+    required_keywords = list(config.get("required_keywords", []) or [])
+    allow_extra = bool(config.get("allow_extra_files", True))
+
+    # Dedupe while preserving order.
+    seen: Set[str] = set()
+    expected = [e for e in expected if not (e in seen or seen.add(e))]
+
+    return DeliverableContract(
+        expected_extensions=expected,
+        min_count=max(min_count, 1) if requires_deliverable else 0,
+        max_count=max_count,
+        required_keywords=required_keywords,
+        allow_extra_files=allow_extra,
+        requires_deliverable=requires_deliverable,
+        notes=notes,
+        confidence=confidence,
+    )
+
+
+def select_generated_artifacts(
+    workdir,
+    reference_files: Optional[List[str]] = None,
+    before_snapshot: Optional[Set[str]] = None,
+) -> List[Path]:
+    """Return files in ``workdir`` that are generated deliverables.
+
+    Reference/input files (by basename), reserved control files, bytecode, and
+    anything present in ``before_snapshot`` (relative paths) are excluded.
+    """
+    workdir = Path(workdir)
+    if not workdir.exists():
+        return []
+    ref_names = {Path(r).name for r in reference_files or []}
+    before = before_snapshot or set()
+    out: List[Path] = []
+    for p in sorted(workdir.rglob("*")):
+        if p.is_dir():
+            continue
+        if p.suffix == ".pyc" or "__pycache__" in p.parts or "skills" in p.parts:
+            continue
+        rel = str(p.relative_to(workdir))
+        if p.name in ref_names or p.name in RESERVED_NAMES:
+            continue
+        if rel in before:
+            continue
+        out.append(p)
+    return out
+
+
+def snapshot_dir(workdir) -> Set[str]:
+    """Relative-path snapshot of files currently in ``workdir`` (for set-diff)."""
+    workdir = Path(workdir)
+    if not workdir.exists():
+        return set()
+    return {
+        str(p.relative_to(workdir))
+        for p in workdir.rglob("*")
+        if p.is_file()
+    }
+
+
+def validate_contract(
+    contract: DeliverableContract,
+    artifacts: List[Path],
+) -> ContractValidation:
+    """Check the produced artifacts against the contract."""
+    arts = [Path(a) for a in artifacts]
+    nonempty = [a for a in arts if a.exists() and a.stat().st_size > 0]
+    blocking: List[str] = []
+    warnings: List[str] = []
+
+    if contract.requires_deliverable and len(nonempty) < max(contract.min_count, 1):
+        blocking.append(
+            f"Expected at least {max(contract.min_count, 1)} non-empty deliverable "
+            f"file(s); found {len(nonempty)}."
+        )
+
+    matched: List[str] = []
+    if contract.expected_extensions:
+        want = {e.lower() for e in contract.expected_extensions}
+        matched = [a.name for a in arts if a.suffix.lower() in want]
+        if not matched and nonempty:
+            produced = sorted({a.suffix.lower() or "(none)" for a in arts})
+            msg = (
+                f"Expected a {'/'.join(contract.expected_extensions)} deliverable "
+                f"but produced {produced}."
+            )
+            (blocking if contract.confidence == "high" else warnings).append(msg)
+
+    if (
+        contract.max_count is not None
+        and not contract.allow_extra_files
+        and len(nonempty) > contract.max_count
+    ):
+        warnings.append(
+            f"Produced {len(nonempty)} files; contract allows at most {contract.max_count}."
+        )
+
+    for kw in contract.required_keywords:
+        if not any(kw.lower() in a.name.lower() for a in arts):
+            warnings.append(f"No deliverable filename references required keyword '{kw}'.")
+
+    return ContractValidation(
+        ok=not blocking,
+        blocking_errors=blocking,
+        warnings=warnings,
+        matched_primary=matched,
+        generated_count=len(nonempty),
+    )

--- a/batch-runner/core/deliverable_contract.py
+++ b/batch-runner/core/deliverable_contract.py
@@ -193,6 +193,18 @@ def infer_deliverable_contract(
     text = task_text or ""
 
     detections = _detect_extensions(text)
+
+    # A literal type token ("csv", "pdf", "xlsx", …) frequently names an *input*
+    # file rather than the deliverable. When a high-confidence detection matches a
+    # reference file's extension it is ambiguous, so downgrade it to "medium":
+    # the type is still expected (and a mismatch still warns), but a valid output
+    # of a different type is no longer hard-blocked / sent into a wasted repair.
+    ref_exts = {Path(r).suffix.lower() for r in reference_files if Path(r).suffix}
+    for d in detections:
+        if d["confidence"] == "high" and d["ext"].lower() in ref_exts:
+            d["confidence"] = "medium"
+            d["note"] = d["note"] + " — also an input file type; confidence reduced"
+
     expected = [d["ext"] for d in detections]
     notes = [d["note"] for d in detections]
 

--- a/batch-runner/core/dependency_resolver.py
+++ b/batch-runner/core/dependency_resolver.py
@@ -1,0 +1,323 @@
+"""Per-task Dependency Resolver for the sandbox.
+
+Answers: *"which pip packages does this GDPVal task need?"* by combining three
+signals:
+
+1. **Reference-file extensions** — e.g. a ``.mp4`` implies opencv/av/moviepy,
+   a ``.wav`` implies librosa/soundfile, a ``.pdf`` implies pdfplumber/PyMuPDF.
+2. **Task-text keywords** — e.g. "spectrogram" → librosa, "regression" →
+   scikit-learn, "shapefile" → geopandas.
+3. **Imports in the generated code** — AST scan of ``solution.py`` mapped from
+   import name to pip name (``cv2`` → opencv-python, ``fitz`` → PyMuPDF, …).
+
+Each discovered package is classified against the sandbox base image's
+``requirements.txt`` so the runner can warn when a task needs something the
+image does not provide (``missing_from_base``).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+REQUIREMENTS_TXT = Path(__file__).resolve().parent.parent / "requirements.txt"
+
+# Universally-present packages (transitive deps of the scientific stack and the
+# interpreter toolchain). Treated as base even if not pinned in requirements.txt
+# so the resolver never false-flags numpy as "missing from the image".
+_IMPLICIT_BASE = {"numpy", "pip", "setuptools", "wheel"}
+
+# ── import-name → pip-name (only where they differ) ───────────────────────────
+IMPORT_TO_PIP: Dict[str, str] = {
+    "cv2": "opencv-python",
+    "PIL": "Pillow",
+    "fitz": "PyMuPDF",
+    "docx": "python-docx",
+    "pptx": "python-pptx",
+    "sklearn": "scikit-learn",
+    "skimage": "scikit-image",
+    "bs4": "beautifulsoup4",
+    "yaml": "PyYAML",
+    "pyzbar": "pyzbar",
+    "numpy_financial": "numpy-financial",
+    "dateutil": "python-dateutil",
+    "Crypto": "pycryptodome",
+    "OpenSSL": "pyOpenSSL",
+    "fuzzywuzzy": "fuzzywuzzy",
+    "rapidfuzz": "rapidfuzz",
+    "google": "protobuf",
+    "av": "av",
+    "moviepy": "moviepy",
+    "librosa": "librosa",
+    "soundfile": "soundfile",
+    "pydub": "pydub",
+    "pyloudnorm": "pyloudnorm",
+    "geopandas": "geopandas",
+    "shapely": "shapely",
+    "fiona": "fiona",
+    "rasterio": "rasterio",
+    "folium": "folium",
+    "networkx": "networkx",
+    "statsmodels": "statsmodels",
+    "nltk": "nltk",
+    "h5py": "h5py",
+    "tables": "tables",
+    "lxml": "lxml",
+    "ezdxf": "ezdxf",
+    "qrcode": "qrcode",
+    "pytesseract": "pytesseract",
+    "reportlab": "reportlab",
+    "openpyxl": "openpyxl",
+    "pdfplumber": "pdfplumber",
+}
+
+# ── reference-file extension → pip packages ──────────────────────────────────
+EXT_PACKAGES: Dict[str, List[str]] = {
+    # audio
+    ".wav": ["librosa", "soundfile", "numpy", "scipy", "pyloudnorm"],
+    ".mp3": ["librosa", "soundfile", "numpy", "pydub"],
+    ".flac": ["librosa", "soundfile", "numpy"],
+    ".ogg": ["librosa", "soundfile", "numpy"],
+    ".m4a": ["librosa", "soundfile", "pydub"],
+    ".aac": ["librosa", "pydub"],
+    ".aiff": ["librosa", "soundfile"],
+    # video
+    ".mp4": ["opencv-python", "av", "moviepy", "numpy", "Pillow"],
+    ".mov": ["opencv-python", "av", "moviepy", "numpy", "Pillow"],
+    ".avi": ["opencv-python", "av", "moviepy", "numpy"],
+    ".mkv": ["opencv-python", "av", "moviepy"],
+    ".webm": ["opencv-python", "av", "moviepy"],
+    ".m4v": ["opencv-python", "av", "moviepy"],
+    ".mpg": ["opencv-python", "av"],
+    ".mpeg": ["opencv-python", "av"],
+    # image
+    ".png": ["Pillow", "numpy"],
+    ".jpg": ["Pillow", "numpy"],
+    ".jpeg": ["Pillow", "numpy"],
+    ".webp": ["Pillow"],
+    ".bmp": ["Pillow"],
+    ".tiff": ["Pillow"],
+    ".tif": ["Pillow"],
+    ".gif": ["Pillow"],
+    # documents
+    ".pdf": ["pdfplumber", "PyMuPDF", "reportlab"],
+    ".docx": ["python-docx"],
+    ".doc": ["python-docx"],
+    ".pptx": ["python-pptx"],
+    ".ppt": ["python-pptx"],
+    ".xlsx": ["openpyxl", "pandas"],
+    ".xls": ["xlrd", "pandas"],
+    ".rtf": ["pypandoc"],
+    ".odt": ["odfpy"],
+    # data
+    ".csv": ["pandas"],
+    ".tsv": ["pandas"],
+    ".parquet": ["pandas", "pyarrow"],
+    ".json": [],
+    ".xml": ["lxml"],
+    ".h5": ["h5py", "tables"],
+    ".hdf5": ["h5py", "tables"],
+    # geo / cad
+    ".shp": ["geopandas", "shapely", "fiona"],
+    ".geojson": ["geopandas", "shapely"],
+    ".kml": ["geopandas", "fiona"],
+    ".gpkg": ["geopandas", "fiona"],
+    ".dxf": ["ezdxf"],
+    ".dwg": ["ezdxf"],
+    # archives
+    ".rar": ["rarfile"],
+}
+
+# ── task-text keyword → pip packages ─────────────────────────────────────────
+KEYWORD_PACKAGES: Dict[str, List[str]] = {
+    "spectrogram": ["librosa", "matplotlib"],
+    "fft": ["numpy", "scipy"],
+    "frequency": ["librosa", "scipy"],
+    "loudness": ["pyloudnorm"],
+    "lufs": ["pyloudnorm"],
+    "tempo": ["librosa"],
+    "bpm": ["librosa"],
+    "waveform": ["librosa", "soundfile"],
+    "resample": ["librosa"],
+    "transcribe": ["librosa"],
+    "keyframe": ["opencv-python", "moviepy"],
+    "frame-by-frame": ["opencv-python"],
+    "storyboard": ["opencv-python", "Pillow"],
+    "scene": ["opencv-python"],
+    "subtitle": ["srt"],
+    "ocr": ["pytesseract"],
+    "qr": ["pyzbar", "qrcode"],
+    "barcode": ["pyzbar"],
+    "regression": ["scikit-learn", "statsmodels"],
+    "forecast": ["statsmodels", "scikit-learn"],
+    "cluster": ["scikit-learn"],
+    "classification": ["scikit-learn"],
+    "machine learning": ["scikit-learn"],
+    "correlation": ["pandas", "numpy"],
+    "chart": ["matplotlib"],
+    "plot": ["matplotlib"],
+    "visualiz": ["matplotlib", "seaborn"],
+    "heatmap": ["seaborn", "matplotlib"],
+    "shapefile": ["geopandas", "shapely"],
+    "geospatial": ["geopandas", "folium"],
+    "map": ["folium"],
+    "latitude": ["geopandas"],
+    "pivot": ["pandas"],
+    "dataframe": ["pandas"],
+    "sentiment": ["nltk", "textblob"],
+    "tokeniz": ["nltk"],
+    "network graph": ["networkx"],
+    "npv": ["numpy-financial"],
+    "irr": ["numpy-financial"],
+    "amortization": ["numpy-financial"],
+}
+
+# stdlib / always-present modules we never treat as a dependency.
+_STDLIB_SKIP = {
+    "os", "sys", "re", "json", "math", "csv", "io", "time", "datetime",
+    "pathlib", "collections", "itertools", "functools", "random", "string",
+    "typing", "dataclasses", "subprocess", "shutil", "tempfile", "glob",
+    "logging", "argparse", "base64", "hashlib", "struct", "wave", "zipfile",
+    "statistics", "decimal", "fractions", "textwrap", "unicodedata", "html",
+    "xml", "urllib", "http", "uuid", "warnings", "copy", "enum", "abc",
+    "contextlib", "operator", "bisect", "heapq", "calendar", "pprint",
+    "skills",  # our own injected package
+}
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 normalize a package name for comparison."""
+    name = name.split("[", 1)[0]  # drop extras
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def load_base_packages(requirements_path: Optional[Path] = None) -> Set[str]:
+    """Parse the sandbox base image's requirements.txt into normalized names."""
+    path = Path(requirements_path) if requirements_path else REQUIREMENTS_TXT
+    base: Set[str] = set()
+    if not path.exists():
+        return base
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        # strip inline comment, env markers, version specifiers
+        line = line.split("#", 1)[0].strip()
+        line = line.split(";", 1)[0].strip()
+        token = re.split(r"[<>=!~\s\[]", line, maxsplit=1)[0]
+        if token:
+            base.add(_normalize(token))
+    return base | _IMPLICIT_BASE
+
+
+@dataclass
+class DependencyManifest:
+    """Result of resolving a single task's dependencies."""
+
+    required: List[str] = field(default_factory=list)        # pip names, sorted
+    sources: Dict[str, List[str]] = field(default_factory=dict)  # pkg -> reasons
+    in_base: List[str] = field(default_factory=list)
+    missing_from_base: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "required": self.required,
+            "sources": self.sources,
+            "in_base": self.in_base,
+            "missing_from_base": self.missing_from_base,
+        }
+
+    def to_prompt_hint(self) -> str:
+        if not self.required:
+            return ""
+        line = ", ".join(self.required)
+        hint = f"📦 Likely libraries for this task (pre-installed): {line}"
+        if self.missing_from_base:
+            hint += (
+                "\n⚠️  Not guaranteed in the sandbox image: "
+                + ", ".join(self.missing_from_base)
+                + " — prefer alternatives that are pre-installed."
+            )
+        return hint
+
+
+def scan_imports(code: str) -> Set[str]:
+    """Return the set of top-level modules imported by ``code``."""
+    modules: Set[str] = set()
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        # Fall back to a regex scan on un-parseable / truncated code.
+        for m in re.finditer(r"^\s*(?:import|from)\s+([A-Za-z0-9_\.]+)", code,
+                             flags=re.MULTILINE):
+            modules.add(m.group(1).split(".")[0])
+        return {m for m in modules if m and m not in _STDLIB_SKIP}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                modules.add(node.module.split(".")[0])
+    return {m for m in modules if m and m not in _STDLIB_SKIP}
+
+
+def _pip_name_for_import(mod: str) -> str:
+    return IMPORT_TO_PIP.get(mod, mod)
+
+
+def resolve(
+    reference_files: Optional[List[str]] = None,
+    task_text: str = "",
+    code: Optional[str] = None,
+    base_packages: Optional[Set[str]] = None,
+) -> DependencyManifest:
+    """Resolve the pip packages a task is likely to need.
+
+    Args:
+        reference_files: paths whose extensions hint at modality libraries.
+        task_text:       task instruction scanned for keyword triggers.
+        code:            optional generated code scanned for imports.
+        base_packages:   optional override of the base-image package set.
+    """
+    base = base_packages if base_packages is not None else load_base_packages()
+    sources: Dict[str, List[str]] = {}
+
+    def add(pkg: str, reason: str) -> None:
+        sources.setdefault(pkg, [])
+        if reason not in sources[pkg]:
+            sources[pkg].append(reason)
+
+    # 1) reference-file extensions
+    for f in reference_files or []:
+        ext = Path(f).suffix.lower()
+        for pkg in EXT_PACKAGES.get(ext, []):
+            add(pkg, f"ext:{ext}")
+
+    # 2) task-text keywords
+    text = (task_text or "").lower()
+    for keyword, pkgs in KEYWORD_PACKAGES.items():
+        if keyword in text:
+            for pkg in pkgs:
+                add(pkg, f"keyword:{keyword}")
+
+    # 3) imports in generated code
+    if code:
+        for mod in scan_imports(code):
+            add(_pip_name_for_import(mod), f"import:{mod}")
+
+    required = sorted(sources.keys(), key=str.lower)
+    in_base, missing = [], []
+    for pkg in required:
+        (in_base if _normalize(pkg) in base else missing).append(pkg)
+
+    return DependencyManifest(
+        required=required,
+        sources=sources,
+        in_base=in_base,
+        missing_from_base=missing,
+    )

--- a/batch-runner/core/dependency_resolver.py
+++ b/batch-runner/core/dependency_resolver.py
@@ -321,3 +321,71 @@ def resolve(
         in_base=in_base,
         missing_from_base=missing,
     )
+
+
+# ── import-time probe (Part F) ───────────────────────────────────────────────
+# pip-name → import-name, derived by inverting IMPORT_TO_PIP. Lets us actually
+# *check* whether a predicted package can be imported in the execution env.
+PIP_TO_IMPORT: Dict[str, str] = {pip: imp for imp, pip in IMPORT_TO_PIP.items()}
+
+
+def _import_name_for_pip(pip_name: str) -> str:
+    if pip_name in PIP_TO_IMPORT:
+        return PIP_TO_IMPORT[pip_name]
+    # Common convention: distribution dashes become import underscores.
+    return pip_name.replace("-", "_")
+
+
+@dataclass
+class ImportProbe:
+    """Result of probing whether predicted packages are importable here."""
+
+    available: List[str] = field(default_factory=list)
+    missing: List[str] = field(default_factory=list)
+    not_checked: List[str] = field(default_factory=list)
+    env: str = "host"  # "host" (this interpreter) | "image" (informational)
+
+    def to_dict(self) -> dict:
+        return {
+            "available": self.available,
+            "missing": self.missing,
+            "not_checked": self.not_checked,
+            "env": self.env,
+        }
+
+
+def probe_imports(
+    packages: List[str],
+    finder=None,
+    enabled: bool = True,
+    env: str = "host",
+) -> ImportProbe:
+    """Probe importability of ``packages`` without importing them.
+
+    Uses :func:`importlib.util.find_spec` (injectable via ``finder`` for tests).
+    When ``enabled`` is False every package is reported ``not_checked`` — used for
+    Docker execution, where the host interpreter cannot see the image's packages.
+    """
+    pkgs = sorted({p for p in (packages or []) if p})
+    if not enabled:
+        return ImportProbe(not_checked=pkgs, env=env)
+
+    import importlib.util as _ilu
+    find = finder or _ilu.find_spec
+
+    available, missing, not_checked = [], [], []
+    for pkg in pkgs:
+        mod = _import_name_for_pip(pkg)
+        try:
+            spec = find(mod)
+            (available if spec is not None else missing).append(pkg)
+        except ModuleNotFoundError:
+            missing.append(pkg)
+        except Exception:
+            not_checked.append(pkg)
+    return ImportProbe(
+        available=sorted(available),
+        missing=sorted(missing),
+        not_checked=sorted(not_checked),
+        env=env,
+    )

--- a/batch-runner/core/executor.py
+++ b/batch-runner/core/executor.py
@@ -96,6 +96,11 @@ class TaskExecutor:
                 memory_gb=opts.get("memory_gb"),
                 cpus=opts.get("cpus"),
                 max_skills=opts.get("max_skills", 5),
+                repair=opts.get("repair"),
+                output_qa=opts.get("output_qa"),
+                manifest=opts.get("manifest"),
+                cache=opts.get("cache"),
+                contract=opts.get("contract"),
             )
 
         elif mode == "json_renderer":

--- a/batch-runner/core/executor.py
+++ b/batch-runner/core/executor.py
@@ -4,6 +4,7 @@ Task Executor - Mode dispatcher for file generation.
 Selects and delegates to appropriate runner based on execution mode:
 - code_interpreter: Azure OpenAI Responses API (OpenAI models only)
 - subprocess: LLM code generation + safe execution (all models)
+- sandbox: LLM code generation + skill-aware containerized execution (all models)
 - json_renderer: JSON spec + fixed renderer (fair comparison mode)
 """
 
@@ -12,10 +13,11 @@ from typing import Literal, Optional
 from core.code_interpreter import CodeInterpreterRunner
 from core.config import DEFAULT_TOKENS
 from core.subprocess_runner import SubprocessRunner
+from core.sandbox_runner import SandboxRunner
 from core.json_renderer import JsonRenderer
 
 # Execution modes
-ExecutionMode = Literal["code_interpreter", "subprocess", "json_renderer"]
+ExecutionMode = Literal["code_interpreter", "subprocess", "sandbox", "json_renderer"]
 
 
 class TaskExecutor:
@@ -31,19 +33,24 @@ class TaskExecutor:
         tokens: Optional[dict] = None,
         timeout: Optional[int] = None,
         reasoning_effort: Optional[str] = None,
+        sandbox_options: Optional[dict] = None,
     ):
         """
         Initialize executor with specified mode.
 
         Args:
-            mode: Execution mode (code_interpreter, subprocess, json_renderer)
-            llm_client: AzureOpenAI client (required for subprocess and json_renderer)
+            mode: Execution mode (code_interpreter, subprocess, sandbox, json_renderer)
+            llm_client: AzureOpenAI client (required for subprocess, sandbox, json_renderer)
             api_key: Azure OpenAI API key (optional, for code_interpreter)
             endpoint: Azure OpenAI endpoint (optional, for code_interpreter)
-            prompt_name: Prompt YAML name for subprocess mode (default: subprocess_occupation_codegen)
+            prompt_name: Prompt YAML name for subprocess/sandbox mode
             tokens: Optional token limit overrides
-            timeout: Subprocess timeout override in seconds (None = config default)
+            timeout: Subprocess/sandbox timeout override in seconds (None = config default)
             reasoning_effort: Optional reasoning effort level ("low", "medium", "high")
+            sandbox_options: Optional dict of sandbox-mode settings from the
+                experiment YAML ``execution.sandbox`` block. Keys: image (str),
+                use_docker ("auto"|"never"|"always"), memory_gb (int),
+                cpus (float), skills_dir (str), max_skills (int).
 
         Raises:
             ValueError: If required parameters are missing for the selected mode
@@ -71,6 +78,24 @@ class TaskExecutor:
                 max_completion_tokens=self.tokens.get("code_generation"),
                 timeout=timeout,
                 reasoning_effort=reasoning_effort,
+            )
+
+        elif mode == "sandbox":
+            if llm_client is None:
+                raise ValueError("sandbox mode requires llm_client")
+            opts = dict(sandbox_options or {})
+            self.runner = SandboxRunner(
+                llm_client,
+                prompt_name=prompt_name or opts.get("prompt_name") or SandboxRunner.DEFAULT_PROMPT,
+                max_completion_tokens=self.tokens.get("code_generation"),
+                timeout=timeout,
+                reasoning_effort=reasoning_effort,
+                skills_dir=opts.get("skills_dir"),
+                image=opts.get("image"),
+                use_docker=opts.get("use_docker", "auto"),
+                memory_gb=opts.get("memory_gb"),
+                cpus=opts.get("cpus"),
+                max_skills=opts.get("max_skills", 5),
             )
 
         elif mode == "json_renderer":
@@ -124,6 +149,15 @@ class TaskExecutor:
                 )
 
             elif self.mode == "subprocess":
+                return self.runner.run(
+                    task_prompt=task_prompt,
+                    model=model,
+                    reference_files=reference_files,
+                    occupation=occupation,
+                    experiment_prompt=experiment_prompt,
+                )
+
+            elif self.mode == "sandbox":
                 return self.runner.run(
                     task_prompt=task_prompt,
                     model=model,

--- a/batch-runner/core/executor.py
+++ b/batch-runner/core/executor.py
@@ -122,6 +122,7 @@ class TaskExecutor:
         occupation: str = "professional",
         experiment_prompt: Optional[dict] = None,
         verbose: bool = False,
+        perception_text: Optional[str] = None,
     ) -> dict:
         """
         Execute task using selected runner.
@@ -134,6 +135,10 @@ class TaskExecutor:
             experiment_prompt: Optional prompt overrides from experiment YAML
                 Keys: system (str), prefix (str|None), body (str|None), suffix (str|None)
             verbose: Print detailed debug info (code_interpreter mode only)
+            perception_text: Optional host audio/video analysis block. Only the
+                sandbox runner consumes it (it owns placement via the
+                ``perception_analysis`` spec section); other modes ignore it since
+                step2 still prepends perception to the task prompt for them.
 
         Returns:
             dict with standardized format:
@@ -169,6 +174,7 @@ class TaskExecutor:
                     reference_files=reference_files,
                     occupation=occupation,
                     experiment_prompt=experiment_prompt,
+                    perception_text=perception_text,
                 )
 
             elif self.mode == "json_renderer":

--- a/batch-runner/core/output_qa.py
+++ b/batch-runner/core/output_qa.py
@@ -1,0 +1,197 @@
+"""Output QA — render generated deliverables and judge their appearance.
+
+This wires :mod:`core.artifact_renderer` into a single report the runner can act
+on. By default it is **deterministic and LLM-free**: it records rendered page
+counts, image dimensions, blank-page detection, and conversion errors. A blank
+*primary* deliverable is treated as blocking (the repair loop can fix it).
+
+An optional model **vision QA** pass (disabled by default,
+``execution.sandbox.output_qa.vision.enabled``) samples a few rendered PNGs and
+asks the configured vision model for a concise JSON verdict. Its result is
+cached by image-set hash + config so repeated runs never re-pay the cost.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+from core.artifact_renderer import render_artifact
+from core.artifact_verifier import classify_kind
+
+_PRIMARY_KINDS = {"pdf", "presentation", "document", "spreadsheet", "image"}
+
+
+@dataclass
+class OutputQAReport:
+    enabled: bool = True
+    render_reports: List[dict] = field(default_factory=list)
+    vision_qa: Optional[dict] = None
+    ok: bool = True
+    blocking_errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _is_primary(path: Path, contract) -> bool:
+    if contract is not None and contract.expected_extensions:
+        return path.suffix.lower() in {e.lower() for e in contract.expected_extensions}
+    return classify_kind(path.suffix) in _PRIMARY_KINDS
+
+
+def _vision_qa(images, task_text, client, model, max_images, cache, cfg):
+    """Optional model vision pass over rendered PNGs → JSON verdict (cached)."""
+    images = images[:max_images]
+    if not images:
+        return None
+
+    cache_key = None
+    if cache is not None and getattr(cache, "enabled", False):
+        try:
+            digest = "".join(cache.hash_file(p)[:16] for p in images)
+            cache_key = cache.key(cache.hash_bytes(digest.encode()), "vision_qa", cfg)
+            hit = cache.get_json(cache_key)
+            if hit is not None:
+                hit["_cached"] = True
+                return hit
+        except Exception:
+            cache_key = None
+
+    if client is None:
+        return None
+
+    instruction = (
+        "You are a strict visual QA reviewer for professional deliverables. "
+        "Inspect the rendered page image(s) of a generated file. Judge only what "
+        "you can see: layout, legibility, blank/empty pages, overflow, broken "
+        "charts, obvious formatting defects. Respond with JSON only: "
+        '{"visual_ok": true/false, "issues": ["..."], "suggested_repair": "..."}'
+    )
+    content: List[dict] = [
+        {"type": "text", "text": instruction},
+        {"type": "text", "text": f"Task context: {task_text[:1200]}"},
+    ]
+    for p in images:
+        try:
+            b64 = base64.b64encode(Path(p).read_bytes()).decode("utf-8")
+        except Exception:
+            continue
+        content.append({
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{b64}", "detail": "auto"},
+        })
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": content}],
+            max_completion_tokens=600,
+        )
+        raw = (response.choices[0].message.content or "").strip()
+        if "```json" in raw:
+            raw = raw.split("```json")[1].split("```")[0].strip()
+        elif "```" in raw:
+            raw = raw.split("```")[1].split("```")[0].strip()
+        verdict = json.loads(raw) if raw else None
+    except Exception as e:
+        return {"visual_ok": None, "issues": [f"vision QA call failed: {e}"],
+                "suggested_repair": ""}
+
+    if verdict is not None and cache_key is not None:
+        try:
+            cache.put_json(cache_key, verdict)
+        except Exception:
+            pass
+    return verdict
+
+
+def run_output_qa(
+    artifacts,
+    contract=None,
+    config: Optional[dict] = None,
+    out_dir=None,
+    task_text: str = "",
+    vision_client=None,
+    cache=None,
+) -> OutputQAReport:
+    """Render artifacts and produce a deterministic (+ optional vision) QA report."""
+    config = config or {}
+    report = OutputQAReport(enabled=bool(config.get("enabled", True)))
+    if not report.enabled:
+        return report
+
+    do_render = bool(config.get("render", True))
+    max_pages = int(config.get("max_pages_per_artifact", 3))
+    blank_threshold = float(config.get("blank_page_threshold", 0.999))
+    dpi = int(config.get("dpi", 120))
+
+    arts = [Path(a) for a in artifacts]
+    if out_dir is not None:
+        out_dir = Path(out_dir)
+    elif arts:
+        out_dir = arts[0].parent / "_render"
+    else:
+        out_dir = None
+
+    all_images: List[Path] = []
+    if do_render and out_dir is not None:
+        render_dir = Path(out_dir)
+        render_dir.mkdir(parents=True, exist_ok=True)
+        for art in arts:
+            if classify_kind(art.suffix) not in _PRIMARY_KINDS:
+                continue
+            rr = render_artifact(
+                art, render_dir, max_pages=max_pages,
+                blank_threshold=blank_threshold, dpi=dpi, cache=cache,
+            )
+            report.render_reports.append(rr.to_dict())
+            all_images.extend(Path(i) for i in rr.rendered_images)
+
+            primary = _is_primary(art, contract)
+            if rr.errors:
+                msg = f"{art.name}: render error — {'; '.join(rr.errors)}"
+                report.warnings.append(msg)
+            if rr.blank_pages:
+                report.warnings.append(
+                    f"{art.name}: {len(rr.blank_pages)} blank page(s) detected "
+                    f"at {rr.blank_pages}."
+                )
+            # Blocking only when a *primary* deliverable is essentially pure white
+            # on EVERY rendered page (avoids false-failing sparse-but-valid pages).
+            fractions = rr.page_white_fractions
+            if (
+                primary
+                and rr.page_count > 0
+                and fractions
+                and all(f >= 0.9997 for f in fractions)
+            ):
+                report.blocking_errors.append(
+                    f"{art.name}: primary deliverable appears blank "
+                    f"(all {rr.page_count} rendered page(s) are empty)."
+                )
+
+    # Optional model vision QA (off by default).
+    vcfg = config.get("vision", {}) or {}
+    if vcfg.get("enabled") and all_images:
+        verdict = _vision_qa(
+            all_images, task_text, vision_client,
+            model=vcfg.get("deployment") or vcfg.get("model"),
+            max_images=int(vcfg.get("max_images", 6)),
+            cache=cache,
+            cfg={"v": 1, "blank_threshold": blank_threshold},
+        )
+        report.vision_qa = verdict
+        if verdict and verdict.get("visual_ok") is False:
+            issues = "; ".join(verdict.get("issues", []) or []) or "unspecified"
+            text = f"vision QA flagged issues: {issues}"
+            if vcfg.get("blocking"):
+                report.blocking_errors.append(text)
+            else:
+                report.warnings.append(text)
+
+    report.ok = not report.blocking_errors
+    return report

--- a/batch-runner/core/prompt_sections.py
+++ b/batch-runner/core/prompt_sections.py
@@ -1,0 +1,117 @@
+"""Spec-driven assembly of the sandbox codegen prompt (sandbox-only).
+
+P2 of the prompt-consolidation refactor. Historically ``SandboxRunner._augment_prompt``
+hardcoded both the *order* of the prompt sections and their separators. This module
+turns that structure into data: each section is produced by a thin **provider**
+(a pure ``SectionContext -> str | None`` function that adapts an existing fragment
+module), and the *order* is owned by the prompt spec (``sections:`` in
+``prompts/sandbox_occupation_codegen.yaml``), falling back to :data:`DEFAULT_SECTIONS`.
+
+No fragment logic lives here — providers only call the already-tested builders
+(``build_file_structure_info``, ``SkillsRegistry.render_manual``,
+``DependencyManifest.to_prompt_hint``, ``DeliverableContract.to_prompt_section``,
+``generate_all_previews``). A provider returning ``None``/"" means *omit this
+section*, preserving today's per-block emptiness rules. Unknown section ids raise
+loudly so a typo in the spec never silently drops a section.
+
+Privacy: providers surface only basenames/sanitized text (``available_files`` uses
+``os.path.basename``; previews render filename + structure, not host roots). The
+context carries host paths only to feed the fragment builders.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Union
+
+from core.file_preview import build_file_structure_info, generate_all_previews
+
+
+@dataclass(frozen=True)
+class SectionContext:
+    """Everything a section provider may read. Sandbox-only; never mutated."""
+
+    task_prompt: str
+    ref_files: List[str]
+    skills: object
+    manifest: object            # DependencyManifest (avoid import cycle in typing)
+    contract: object            # DeliverableContract | None
+    reflection: Optional[str]
+    registry: object            # SkillsRegistry
+    perception_text: Optional[str] = None   # P3; None in P0-P2
+
+
+def _available_files_line(ref_files: List[str]) -> str:
+    names = [os.path.basename(f) for f in ref_files]
+    return (
+        f"📁 Files available in the sandbox working directory "
+        f"(use them directly): {names}"
+    )
+
+
+# id -> provider. Each provider returns the section text, or None to omit it.
+# Keep these thin: adapt an existing module, do not add fragment logic here.
+SECTION_PROVIDERS: Dict[str, Callable[[SectionContext], Optional[str]]] = {
+    "reflection": lambda c: c.reflection or None,
+    "file_structure": lambda c: build_file_structure_info(c.ref_files or []) or None,
+    "skills_manual": lambda c: c.registry.render_manual(c.skills) or None,
+    "deps_hint": lambda c: c.manifest.to_prompt_hint() or None,
+    "contract": lambda c: (c.contract.to_prompt_section() if c.contract is not None else None),
+    "perception_analysis": lambda c: c.perception_text or None,   # P3
+    "task": lambda c: c.task_prompt or None,
+    "previews": lambda c: (generate_all_previews(c.ref_files) or None) if c.ref_files else None,
+    "available_files": lambda c: _available_files_line(c.ref_files) if c.ref_files else None,
+}
+
+
+# Fallback order, byte-identical to the pre-refactor hardcoded assembly. The
+# canonical order lives in the spec's ``sections:`` list; this reproduces it when
+# a spec omits the key. ``perception_analysis`` is intentionally absent here
+# (enabled via the spec in P3) so default output is unchanged.
+DEFAULT_SECTIONS: List[str] = [
+    "reflection",
+    "file_structure",
+    "skills_manual",
+    "deps_hint",
+    "contract",
+    "task",
+    "previews",
+    "available_files",
+]
+
+
+SectionEntry = Union[str, dict]
+
+
+def _parse_entry(entry: SectionEntry):
+    """A spec ``sections:`` entry is either a bare id string or ``{id, enabled?}``."""
+    if isinstance(entry, str):
+        return entry, True
+    if isinstance(entry, dict):
+        if "id" not in entry:
+            raise ValueError(f"prompt section entry missing 'id': {entry!r}")
+        return entry["id"], bool(entry.get("enabled", True))
+    raise ValueError(f"invalid prompt section entry (want str or mapping): {entry!r}")
+
+
+def assemble_sections(section_order: List[SectionEntry], ctx: SectionContext) -> str:
+    """Render ``section_order`` against ``ctx`` and join non-empty blocks with blank lines.
+
+    Entries with ``enabled: false`` are skipped; providers returning ``None``/""
+    are omitted; an unknown id raises ``ValueError`` (fail-fast, never silent).
+    """
+    parts: List[str] = []
+    for entry in section_order:
+        sid, enabled = _parse_entry(entry)
+        if not enabled:
+            continue
+        provider = SECTION_PROVIDERS.get(sid)
+        if provider is None:
+            raise ValueError(
+                f"unknown prompt section id: {sid!r}; known ids: {sorted(SECTION_PROVIDERS)}"
+            )
+        block = provider(ctx)
+        if block:
+            parts.append(block)
+    return "\n\n".join(parts)

--- a/batch-runner/core/sandbox_cache.py
+++ b/batch-runner/core/sandbox_cache.py
@@ -1,0 +1,125 @@
+"""Tiny file-hash cache for expensive sandbox-derived data.
+
+Render PNGs, perception/OCR summaries, and optional vision-QA verdicts are
+expensive to recompute. This is a *minimal* content-addressed cache — not a
+service — keyed by ``sha256(input bytes) + operation + config fingerprint``.
+
+Design goals:
+* **Disabled-safe** — when ``enabled`` is False every method is a cheap no-op, so
+  callers never branch on cache availability.
+* **Never committed** — the default cache directory lives outside the repo
+  (``$SANDBOX_CACHE_DIR`` or a per-user temp dir), and callers may point it at the
+  run's output directory. Nothing is written under the source tree.
+* **Best-effort** — any I/O error degrades to a miss; the cache never raises.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+
+def _fingerprint(config: Optional[dict]) -> str:
+    if not config:
+        return "default"
+    try:
+        blob = json.dumps(config, sort_keys=True, default=str)
+    except Exception:
+        blob = str(config)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:12]
+
+
+class FileCache:
+    """Content-addressed blob cache. All operations are best-effort."""
+
+    def __init__(self, enabled: bool = False, cache_dir=None, namespace: str = "sandbox"):
+        self.enabled = bool(enabled)
+        self.namespace = namespace
+        self._dir: Optional[Path] = None
+        if self.enabled:
+            base = (
+                cache_dir
+                or os.getenv("SANDBOX_CACHE_DIR")
+                or os.path.join(tempfile.gettempdir(), "gdpval_sandbox_cache")
+            )
+            try:
+                self._dir = Path(base) / namespace
+                self._dir.mkdir(parents=True, exist_ok=True)
+            except Exception:
+                self.enabled = False
+                self._dir = None
+
+    # ── key construction ─────────────────────────────────────────────────
+    @staticmethod
+    def hash_bytes(data: bytes) -> str:
+        return hashlib.sha256(data).hexdigest()
+
+    @staticmethod
+    def hash_file(path) -> str:
+        h = hashlib.sha256()
+        with Path(path).open("rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    def key(self, content_hash: str, operation: str, config: Optional[dict] = None) -> str:
+        return f"{operation}-{content_hash[:32]}-{_fingerprint(config)}"
+
+    def _path(self, key: str, suffix: str) -> Optional[Path]:
+        if not self.enabled or self._dir is None:
+            return None
+        safe = "".join(c for c in key if c.isalnum() or c in "-_.")
+        return self._dir / f"{safe}{suffix}"
+
+    # ── blob get/put ─────────────────────────────────────────────────────
+    def get_bytes(self, key: str, suffix: str = ".bin") -> Optional[bytes]:
+        p = self._path(key, suffix)
+        if p is None or not p.exists():
+            return None
+        try:
+            return p.read_bytes()
+        except Exception:
+            return None
+
+    def put_bytes(self, key: str, data: bytes, suffix: str = ".bin") -> Optional[Path]:
+        p = self._path(key, suffix)
+        if p is None:
+            return None
+        try:
+            tmp = p.with_suffix(p.suffix + ".tmp")
+            tmp.write_bytes(data)
+            tmp.replace(p)
+            return p
+        except Exception:
+            return None
+
+    # ── json get/put ─────────────────────────────────────────────────────
+    def get_json(self, key: str):
+        raw = self.get_bytes(key, suffix=".json")
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except Exception:
+            return None
+
+    def put_json(self, key: str, obj) -> Optional[Path]:
+        try:
+            data = json.dumps(obj, default=str).encode("utf-8")
+        except Exception:
+            return None
+        return self.put_bytes(key, data, suffix=".json")
+
+
+def build_cache(config: Optional[dict], output_dir=None) -> FileCache:
+    """Construct a :class:`FileCache` from an ``execution.sandbox.cache`` block."""
+    config = config or {}
+    enabled = bool(config.get("enabled", False))
+    cache_dir = config.get("dir")
+    if cache_dir is None and output_dir is not None and enabled:
+        cache_dir = os.path.join(str(output_dir), ".sandbox_cache")
+    return FileCache(enabled=enabled, cache_dir=cache_dir)

--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -62,6 +62,43 @@ def _sha256_text(text: str) -> str:
     import hashlib
     return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
 
+
+# Local filesystem roots that must never appear in the manifest or repair prompt.
+# Computed once; longest first so nested roots (e.g. the temp dir under $HOME) are
+# redacted before the shorter prefix.
+_REDACT_ROOTS = sorted(
+    {
+        r
+        for r in (
+            os.path.realpath(tempfile.gettempdir()),
+            tempfile.gettempdir(),
+            "/private/var/folders",
+            "/var/folders",
+            os.path.expanduser("~"),
+        )
+        if r and r not in ("/", "")
+    },
+    key=len,
+    reverse=True,
+)
+
+
+def _sanitize_tail(text: Optional[str], limit: int = 600) -> str:
+    """Trim to the last ``limit`` chars and redact local absolute paths.
+
+    stdout/stderr tails come from executed code (e.g. a traceback referencing the
+    sandbox temp dir). Redacting host roots keeps the manifest and repair prompt
+    free of local filesystem layout while preserving the useful error text.
+    """
+    if not text:
+        return ""
+    s = text[-limit:]
+    for root in _REDACT_ROOTS:
+        if root in s:
+            repl = "~" if root == os.path.expanduser("~") else "<tmp>"
+            s = s.replace(root, repl)
+    return s
+
 # Cache for the (relatively expensive) `docker info` probe.
 _DOCKER_AVAILABLE: Optional[bool] = None
 
@@ -323,11 +360,13 @@ class SandboxRunner:
         result["deliverable_text"] = deliverable_text
 
         # Inspect the produced artifacts in an isolated workspace.
-        analysis = self._analyze_output(result, ref_files, contract, task_prompt, executor_used)
+        analysis = self._analyze_output(
+            result, ref_files, contract, task_prompt, executor_used, manifest
+        )
 
         blocking = list(analysis["blocking_errors"])
         if not result.get("success"):
-            tail = (result.get("error") or "")[-600:]
+            tail = _sanitize_tail(result.get("error"), limit=600)
             blocking.insert(0, f"execution_failed: {tail}")
 
         status = self._status_for(attempt_idx, result, analysis, blocking)
@@ -355,8 +394,8 @@ class SandboxRunner:
                 "code_sha256": _sha256_text(code),
                 "blocking_errors": blocking,
                 "generated_artifacts": analysis["artifact_names"],
-                "stdout_tail": (result.get("text") or "")[-600:],
-                "stderr_tail": (result.get("error") or "")[-600:],
+                "stdout_tail": _sanitize_tail(result.get("text"), limit=600),
+                "stderr_tail": _sanitize_tail(result.get("error"), limit=600),
             },
         }
 
@@ -367,6 +406,7 @@ class SandboxRunner:
         contract: DeliverableContract,
         task_prompt: str,
         executor_used: str,
+        dep_manifest: Optional[DependencyManifest] = None,
     ) -> dict:
         """Materialize returned files and run contract + verify + render QA."""
         files = result.get("files") or []
@@ -403,10 +443,11 @@ class SandboxRunner:
             for rr in output_qa_dict.get("render_reports", []):
                 rr["rendered_images"] = [os.path.basename(p) for p in rr.get("rendered_images", [])]
 
-            # Importability probe (accurate only for local execution).
+            # Importability probe of the resolved dependencies (accurate only for
+            # local execution; for Docker the host can't see image packages).
+            required_pkgs = list(getattr(dep_manifest, "required", []) or [])
             probe = probe_imports(
-                result.get("metadata", {}).get("dependencies", {}).get("required", [])
-                if isinstance(result.get("metadata"), dict) else [],
+                required_pkgs,
                 enabled=(executor_used == "local"),
                 env="host" if executor_used == "local" else "image",
             )
@@ -595,8 +636,8 @@ class SandboxRunner:
         lines.append("")
         lines.append(contract.to_prompt_section())
 
-        stdout_tail = (result.get("text") or "")[-800:]
-        stderr_tail = (result.get("error") or "")[-800:]
+        stdout_tail = _sanitize_tail(result.get("text"), limit=800)
+        stderr_tail = _sanitize_tail(result.get("error"), limit=800)
         if stdout_tail.strip():
             lines += ["", "Previous stdout (tail):", stdout_tail]
         if stderr_tail.strip():

--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -1,0 +1,407 @@
+"""Sandbox Runner — containerized, skill-aware evolution of subprocess mode.
+
+This is the "new testing method" for GDPVal solving:
+
+* **Container sandbox** — LLM-generated ``solution.py`` runs inside a Docker
+  container (``--network none``, memory/CPU/PID caps) built from the project
+  ``requirements.txt`` plus system tools (ffmpeg, libreoffice, tesseract,
+  poppler). When the Docker daemon or image is unavailable (e.g. local dev) it
+  gracefully falls back to the hardened in-process subprocess sandbox.
+* **Per-task dependency discovery** — :mod:`core.dependency_resolver` derives the
+  pip packages each task needs from reference-file extensions, task keywords, and
+  the generated code's imports, and flags anything missing from the base image.
+* **Skills** — :mod:`core.skills_registry` selects the famous-library Agent
+  Skills relevant to the task (audio/video/document/image/data). Their manuals
+  are injected into the prompt and the ``skills`` package is mounted into the
+  sandbox, giving generated code *vision* (video frame-by-frame, image OCR) and
+  *hearing* (audio FFT / sampling / loudness).
+
+The public surface mirrors :class:`core.subprocess_runner.SubprocessRunner` so
+:class:`core.executor.TaskExecutor` can dispatch to it interchangeably.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from core.config import SUBPROCESS_TIMEOUT, SUBPROCESS_MEMORY_GB, DEFAULT_TOKENS
+from core.dependency_resolver import DependencyManifest, load_base_packages, resolve
+from core.file_preview import build_file_structure_info, generate_all_previews
+from core.llm_client import complete
+from core.prompt_loader import load_prompt, render_prompt
+from core.skills_registry import SkillsRegistry
+from core.subprocess_runner import SubprocessRunner, extract_code, extract_description
+
+DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "gdpval-sandbox:latest")
+
+# Cache for the (relatively expensive) `docker info` probe.
+_DOCKER_AVAILABLE: Optional[bool] = None
+
+
+def docker_available(refresh: bool = False) -> bool:
+    """Return True if a Docker CLI + responsive daemon are present (cached)."""
+    global _DOCKER_AVAILABLE
+    if _DOCKER_AVAILABLE is not None and not refresh:
+        return _DOCKER_AVAILABLE
+    available = False
+    if shutil.which("docker"):
+        try:
+            proc = subprocess.run(
+                ["docker", "info"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            available = proc.returncode == 0
+        except Exception:
+            available = False
+    _DOCKER_AVAILABLE = available
+    return available
+
+
+def docker_image_exists(image: str) -> bool:
+    """Return True if the sandbox image is present locally."""
+    try:
+        proc = subprocess.run(
+            ["docker", "image", "inspect", image],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+class SandboxRunner:
+    """LLM code generation → skill-aware, containerized execution."""
+
+    DEFAULT_PROMPT = "sandbox_occupation_codegen"
+
+    def __init__(
+        self,
+        llm_client,
+        prompt_name: str = DEFAULT_PROMPT,
+        max_completion_tokens: Optional[int] = None,
+        timeout: Optional[int] = None,
+        reasoning_effort: Optional[str] = None,
+        skills_dir: Optional[str] = None,
+        image: Optional[str] = None,
+        use_docker: str = "auto",          # "auto" | "never" | "always"
+        memory_gb: Optional[int] = None,
+        cpus: Optional[float] = None,
+        max_skills: int = 5,
+    ):
+        self.llm_client = llm_client
+        self.prompt_name = prompt_name
+        self.prompt_data = load_prompt(prompt_name)
+        self.max_completion_tokens = (
+            max_completion_tokens
+            if max_completion_tokens is not None
+            else DEFAULT_TOKENS["code_generation"]
+        )
+        self.timeout = timeout or SUBPROCESS_TIMEOUT
+        self.reasoning_effort = reasoning_effort
+        self.image = image or DEFAULT_SANDBOX_IMAGE
+        self.use_docker = use_docker
+        self.memory_gb = memory_gb or SUBPROCESS_MEMORY_GB
+        self.cpus = cpus
+        self.max_skills = max_skills
+
+        self.registry = SkillsRegistry(skills_dir)
+        self.skills_dir = str(self.registry.skills_dir)
+        self._base_packages = load_base_packages()
+        # Reused for local fallback execution (shares hardened security path).
+        self._local = SubprocessRunner(
+            llm_client,
+            prompt_name=SubprocessRunner.DEFAULT_PROMPT,
+            timeout=self.timeout,
+        )
+
+    # ── public API ───────────────────────────────────────────────────────
+    def run(
+        self,
+        task_prompt: str,
+        model: str,
+        reference_files: Optional[list] = None,
+        occupation: str = "professional",
+        experiment_prompt: Optional[dict] = None,
+    ) -> dict:
+        """Generate code with skill/dependency context and run it in the sandbox."""
+        try:
+            ref_files = reference_files or []
+
+            # 1) Perception context: select skills + resolve dependencies.
+            skills = self.registry.select(ref_files, task_prompt, max_skills=self.max_skills)
+            manifest = resolve(
+                reference_files=ref_files,
+                task_text=task_prompt,
+                base_packages=self._base_packages,
+            )
+
+            # 2) Build the augmented task prompt and generate code.
+            augmented = self._augment_prompt(task_prompt, ref_files, skills, manifest)
+            rendered = render_prompt(
+                self.prompt_data,
+                occupation=occupation,
+                task_prompt=augmented,
+                experiment_prompt=experiment_prompt,
+            )
+            messages = [
+                {"role": "system", "content": rendered["system_message"]},
+                {"role": "user", "content": rendered["user_prompt"]},
+            ]
+            response, _ = complete(
+                client=self.llm_client,
+                model=model,
+                messages=messages,
+                max_completion_tokens=self.max_completion_tokens,
+                reasoning_effort=self.reasoning_effort,
+            )
+            response_text = response.choices[0].message.content
+            code = extract_code(response_text)
+            if not code:
+                return {
+                    "success": False,
+                    "text": "",
+                    "deliverable_text": "",
+                    "files": [],
+                    "error": f"No Python code found in LLM response. Response: {response_text[:200]}...",
+                    "metadata": self._metadata("none", skills, manifest),
+                }
+            deliverable_text = extract_description(response_text)
+
+            # Re-resolve including the code's imports (better missing-dep signal).
+            manifest = resolve(
+                reference_files=ref_files,
+                task_text=task_prompt,
+                code=code,
+                base_packages=self._base_packages,
+            )
+
+            # 3) Execute (Docker when possible, else local fallback).
+            executor_used, result = self._execute(code, ref_files, manifest)
+            result["deliverable_text"] = deliverable_text
+            result["metadata"] = self._metadata(executor_used, skills, manifest)
+            return result
+
+        except Exception as e:  # pragma: no cover - defensive
+            return {
+                "success": False,
+                "text": "",
+                "files": [],
+                "error": f"Sandbox code generation failed: {str(e)}",
+            }
+
+    # ── prompt augmentation ──────────────────────────────────────────────
+    def _augment_prompt(
+        self,
+        task_prompt: str,
+        reference_files: List[str],
+        skills,
+        manifest: DependencyManifest,
+    ) -> str:
+        parts: List[str] = []
+
+        file_structure_info = build_file_structure_info(reference_files or [])
+        if file_structure_info:
+            parts.append(file_structure_info)
+
+        skills_manual = self.registry.render_manual(skills)
+        if skills_manual:
+            parts.append(skills_manual)
+
+        dep_hint = manifest.to_prompt_hint()
+        if dep_hint:
+            parts.append(dep_hint)
+
+        parts.append(task_prompt)
+
+        if reference_files:
+            previews = generate_all_previews(reference_files)
+            if previews:
+                parts.append(previews)
+            available_files = [os.path.basename(f) for f in reference_files]
+            parts.append(
+                f"📁 Files available in the sandbox working directory "
+                f"(use them directly): {available_files}"
+            )
+
+        return "\n\n".join(parts)
+
+    def _metadata(self, executor_used: str, skills, manifest: DependencyManifest) -> dict:
+        return {
+            "executor": executor_used,
+            "image": self.image if executor_used == "docker" else None,
+            "skills": [s.name for s in skills],
+            "skills_detail": [s.to_dict() for s in skills],
+            "dependencies": manifest.to_dict(),
+        }
+
+    # ── execution dispatch ───────────────────────────────────────────────
+    def _execute(
+        self,
+        code: str,
+        reference_files: List[str],
+        manifest: DependencyManifest,
+    ) -> Tuple[str, dict]:
+        if self.use_docker == "never":
+            return "local", self._local.run_code(code, reference_files, skills_dir=self.skills_dir)
+
+        if docker_available():
+            if docker_image_exists(self.image):
+                return "docker", self._execute_docker(code, reference_files)
+            if self.use_docker == "always":
+                return "docker", {
+                    "success": False,
+                    "text": "",
+                    "files": [],
+                    "error": f"Sandbox image '{self.image}' not found. Build it: "
+                             f"bash sandbox/build.sh",
+                }
+            print(f"      ⚠️  Sandbox image '{self.image}' missing — falling back to local execution")
+        elif self.use_docker == "always":
+            return "docker", {
+                "success": False,
+                "text": "",
+                "files": [],
+                "error": "Docker daemon unavailable but use_docker='always'.",
+            }
+        else:
+            print("      ⚠️  Docker unavailable — falling back to hardened local execution")
+
+        return "local", self._local.run_code(code, reference_files, skills_dir=self.skills_dir)
+
+    # ── Docker execution ─────────────────────────────────────────────────
+    def _execute_docker(self, code: str, reference_files: Optional[list]) -> dict:
+        """Run generated code inside the sandbox container."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                # Copy reference files into the bind-mounted workdir.
+                copied_files: List[str] = []
+                for src_path in reference_files or []:
+                    if os.path.exists(src_path):
+                        try:
+                            shutil.copy(src_path, tmpdir)
+                            copied_files.append(os.path.basename(src_path))
+                        except Exception as e:
+                            print(f"Warning: failed to copy reference file {src_path}: {e}")
+
+                # Mount the skills package.
+                skills_mounted = False
+                if self.skills_dir and os.path.isdir(self.skills_dir):
+                    try:
+                        shutil.copytree(
+                            self.skills_dir,
+                            os.path.join(tmpdir, "skills"),
+                            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+                        )
+                        skills_mounted = True
+                    except Exception as e:
+                        print(f"Warning: failed to mount skills package: {e}")
+
+                # Prepend the available-files hint (mirrors subprocess mode).
+                if copied_files:
+                    header = (
+                        "import os\n"
+                        f"_AVAILABLE_FILES = {copied_files}\n"
+                        f"# Available files: {', '.join(copied_files)}\n\n"
+                    )
+                    code = header + code
+                else:
+                    code = "# No reference files available\n\n" + code
+                (Path(tmpdir) / "solution.py").write_text(code, encoding="utf-8")
+
+                cmd = self._docker_command(tmpdir, skills_mounted)
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.timeout + 30,  # allow container start overhead
+                )
+
+                if result.returncode in (137, -9):
+                    return {
+                        "success": False,
+                        "text": result.stdout,
+                        "files": [],
+                        "error": f"memory_error: container killed "
+                                 f"(exit {result.returncode}, limit {self.memory_gb}GB)",
+                    }
+                if result.returncode != 0:
+                    return {
+                        "success": False,
+                        "text": result.stdout,
+                        "files": [],
+                        "error": f"Sandbox execution failed (exit {result.returncode}):\n{result.stderr[-1500:]}",
+                    }
+
+                return {
+                    "success": True,
+                    "text": result.stdout,
+                    "files": self._collect_output_files(tmpdir, copied_files),
+                }
+
+            except subprocess.TimeoutExpired:
+                return {
+                    "success": False,
+                    "text": "",
+                    "files": [],
+                    "error": f"Sandbox execution timeout ({self.timeout}s exceeded)",
+                }
+            except Exception as e:
+                return {
+                    "success": False,
+                    "text": "",
+                    "files": [],
+                    "error": f"Sandbox execution error: {str(e)}",
+                }
+
+    def _docker_command(self, workdir: str, skills_mounted: bool) -> List[str]:
+        # Baked-in skills live at /opt/gdpval; mounted skills (if any) at /work.
+        pythonpath = "/work:/opt/gdpval" if skills_mounted else "/opt/gdpval"
+        cmd = [
+            "docker", "run", "--rm",
+            "--network", "none",
+            "--memory", f"{self.memory_gb}g",
+            "--memory-swap", f"{self.memory_gb}g",
+            "--pids-limit", "512",
+            "--security-opt", "no-new-privileges",
+            "-v", f"{workdir}:/work:rw",
+            "-w", "/work",
+            "-e", "HOME=/work",
+            "-e", "LANG=C.UTF-8",
+            "-e", f"PYTHONPATH={pythonpath}",
+        ]
+        if self.cpus:
+            cmd += ["--cpus", str(self.cpus)]
+        cmd += [self.image, "python", "-u", "solution.py"]
+        return cmd
+
+    @staticmethod
+    def _collect_output_files(workdir: str, copied_files: List[str]) -> list:
+        """Collect generated files (exclude script, inputs, skills, bytecode)."""
+        output_files = []
+        skip_names = {"solution.py"} | set(copied_files)
+        for file_path in Path(workdir).iterdir():
+            if file_path.is_dir():           # skip skills/, __pycache__, etc.
+                continue
+            if file_path.name in skip_names:
+                continue
+            if file_path.suffix == ".pyc":
+                continue
+            try:
+                safe_name = re.sub(r'[:"<>|*?\r\n]', "_", file_path.name)
+                output_files.append({
+                    "filename": safe_name,
+                    "content": file_path.read_bytes(),
+                })
+            except Exception as e:
+                print(f"Warning: failed to read generated file {file_path}: {e}")
+        return output_files

--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -132,7 +132,17 @@ def docker_available(refresh: bool = False) -> bool:
 
 
 def docker_image_exists(image: str) -> bool:
-    """Return True if the sandbox image is present locally."""
+    """Return True if the sandbox image is present locally.
+
+    ``docker image inspect <name:tag>`` is the natural check, but under Docker
+    Desktop's containerd image store (the current default) tag→image resolution
+    for that endpoint intermittently fails with "No such image" even when the
+    tag is present and runnable — most reproducibly right after a daemon
+    restart. ``docker image ls -q <ref>`` resolves the same tag reliably in that
+    store, so we fall back to it before concluding the image is missing. Without
+    this, a present, working sandbox image is misdetected as absent and the
+    runner silently degrades to hardened local execution.
+    """
     try:
         proc = subprocess.run(
             ["docker", "image", "inspect", image],
@@ -140,7 +150,19 @@ def docker_image_exists(image: str) -> bool:
             text=True,
             timeout=15,
         )
-        return proc.returncode == 0
+        if proc.returncode == 0:
+            return True
+    except Exception:
+        pass
+    # Fallback: reliable under the containerd snapshotter image store.
+    try:
+        proc = subprocess.run(
+            ["docker", "image", "ls", "--quiet", image],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return proc.returncode == 0 and bool(proc.stdout.strip())
     except Exception:
         return False
 

--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -57,6 +57,13 @@ DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "gdpval-sandbox:latest")
 
 MANIFEST_SCHEMA_VERSION = "1.0"
 
+# Minimum code_generation budget considered safe when reasoning_effort is "high".
+# gpt-5.4 at high reasoning can spend >32k tokens on hidden reasoning on complex
+# GDPVal sandbox prompts, leaving no room for visible code ("No Python code
+# found") — and can also exceed the 480s LLM-client timeout. Below this budget
+# with high effort we warn loudly. See tasks/0701_wednesday/sandbox_ab_smoke_pr57.md.
+SAFE_HIGH_CODE_BUDGET = 32768
+
 
 def _sha256_text(text: str) -> str:
     import hashlib
@@ -177,6 +184,20 @@ class SandboxRunner:
         self.memory_gb = memory_gb or SUBPROCESS_MEMORY_GB
         self.cpus = cpus
         self.max_skills = max_skills
+
+        # Guard: a high-reasoning + small-budget sandbox codegen config is a known
+        # empty-output / timeout trap. Warn once at construction so a large run is
+        # never silently misconfigured (warning only — behavior is unchanged, and
+        # this is scoped to sandbox mode). See SAFE_HIGH_CODE_BUDGET above.
+        if (self.reasoning_effort or "").lower() == "high" \
+                and self.max_completion_tokens < SAFE_HIGH_CODE_BUDGET:
+            print(
+                f"⚠️  [sandbox] reasoning_effort='high' with code_generation="
+                f"{self.max_completion_tokens} risks EMPTY output (reasoning can "
+                f"consume the whole budget) and may exceed the 480s client timeout. "
+                f"Recommend reasoning_effort<=medium and/or code_generation>="
+                f"{SAFE_HIGH_CODE_BUDGET}."
+            )
 
         # Output control-loop configuration (conservative defaults).
         self.repair_cfg = {"enabled": True, "max_attempts": 1, **(repair or {})}

--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -283,6 +283,7 @@ class SandboxRunner:
         reference_files: Optional[list] = None,
         occupation: str = "professional",
         experiment_prompt: Optional[dict] = None,
+        perception_text: Optional[str] = None,
     ) -> dict:
         """Generate code, run it in the sandbox, then verify/QA/repair the output.
 
@@ -291,6 +292,10 @@ class SandboxRunner:
         the deliverable contract → deterministic verify + render QA. If blocking
         failures remain and the repair budget allows, build a focused reflection
         and regenerate. A ``manifest.json`` capturing every attempt is emitted.
+
+        ``perception_text`` is the optional host audio/video analysis block. The
+        sandbox owns its *placement* (the ``perception_analysis`` spec section),
+        so step2 passes it through here instead of prepending it to the task.
         """
         try:
             ref_files = reference_files or []
@@ -320,6 +325,7 @@ class SandboxRunner:
                     skills=skills,
                     contract=contract,
                     reflection=reflection,
+                    perception_text=perception_text,
                 )
                 attempts.append(attempt["report"])
 
@@ -357,6 +363,7 @@ class SandboxRunner:
         skills,
         contract: DeliverableContract,
         reflection: Optional[str],
+        perception_text: Optional[str] = None,
     ) -> dict:
         manifest = resolve(
             reference_files=ref_files,
@@ -364,7 +371,8 @@ class SandboxRunner:
             base_packages=self._base_packages,
         )
         augmented = self._augment_prompt(
-            task_prompt, ref_files, skills, manifest, contract, reflection
+            task_prompt, ref_files, skills, manifest, contract, reflection,
+            perception_text=perception_text,
         )
         rendered = render_prompt(
             self.prompt_data,
@@ -639,6 +647,7 @@ class SandboxRunner:
         manifest: DependencyManifest,
         contract: Optional[DeliverableContract] = None,
         reflection: Optional[str] = None,
+        perception_text: Optional[str] = None,
     ) -> str:
         """Assemble the sandbox prompt from spec-ordered sections.
 
@@ -646,6 +655,8 @@ class SandboxRunner:
         ``sections:`` list, falling back to ``DEFAULT_SECTIONS`` (today's order).
         Each section's text comes from a thin provider in ``core.prompt_sections``;
         this method only builds the context and delegates the assembly.
+        ``perception_text`` (host audio/video analysis) fills the optional
+        ``perception_analysis`` section when the spec enables it.
         """
         ctx = SectionContext(
             task_prompt=task_prompt,
@@ -655,6 +666,7 @@ class SandboxRunner:
             contract=contract,
             reflection=reflection,
             registry=self.registry,
+            perception_text=perception_text,
         )
         section_order = self.prompt_data.get("sections") or DEFAULT_SECTIONS
         return assemble_sections(section_order, ctx)

--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -22,6 +22,7 @@ The public surface mirrors :class:`core.subprocess_runner.SubprocessRunner` so
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -31,14 +32,35 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 from core.config import SUBPROCESS_TIMEOUT, SUBPROCESS_MEMORY_GB, DEFAULT_TOKENS
-from core.dependency_resolver import DependencyManifest, load_base_packages, resolve
+from core.artifact_verifier import verify_artifacts
+from core.deliverable_contract import (
+    DeliverableContract,
+    infer_deliverable_contract,
+    select_generated_artifacts,
+    validate_contract,
+)
+from core.dependency_resolver import (
+    DependencyManifest,
+    load_base_packages,
+    probe_imports,
+    resolve,
+)
 from core.file_preview import build_file_structure_info, generate_all_previews
 from core.llm_client import complete
+from core.output_qa import run_output_qa
 from core.prompt_loader import load_prompt, render_prompt
+from core.sandbox_cache import build_cache
 from core.skills_registry import SkillsRegistry
 from core.subprocess_runner import SubprocessRunner, extract_code, extract_description
 
 DEFAULT_SANDBOX_IMAGE = os.getenv("SANDBOX_IMAGE", "gdpval-sandbox:latest")
+
+MANIFEST_SCHEMA_VERSION = "1.0"
+
+
+def _sha256_text(text: str) -> str:
+    import hashlib
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
 
 # Cache for the (relatively expensive) `docker info` probe.
 _DOCKER_AVAILABLE: Optional[bool] = None
@@ -97,6 +119,11 @@ class SandboxRunner:
         memory_gb: Optional[int] = None,
         cpus: Optional[float] = None,
         max_skills: int = 5,
+        repair: Optional[dict] = None,
+        output_qa: Optional[dict] = None,
+        manifest: Optional[dict] = None,
+        cache: Optional[dict] = None,
+        contract: Optional[dict] = None,
     ):
         self.llm_client = llm_client
         self.prompt_name = prompt_name
@@ -113,6 +140,25 @@ class SandboxRunner:
         self.memory_gb = memory_gb or SUBPROCESS_MEMORY_GB
         self.cpus = cpus
         self.max_skills = max_skills
+
+        # Output control-loop configuration (conservative defaults).
+        self.repair_cfg = {"enabled": True, "max_attempts": 1, **(repair or {})}
+        self.output_qa_cfg = {
+            "enabled": True,
+            "render": True,
+            "max_pages_per_artifact": 3,
+            "blank_page_threshold": 0.999,
+            **(output_qa or {}),
+        }
+        self.manifest_cfg = {
+            "enabled": True,
+            "filename": "manifest.json",
+            "include_in_files": True,
+            **(manifest or {}),
+        }
+        self.cache_cfg = {"enabled": False, **(cache or {})}
+        self.contract_cfg = dict(contract or {})
+        self._cache = build_cache(self.cache_cfg)
 
         self.registry = SkillsRegistry(skills_dir)
         self.skills_dir = str(self.registry.skills_dir)
@@ -133,63 +179,58 @@ class SandboxRunner:
         occupation: str = "professional",
         experiment_prompt: Optional[dict] = None,
     ) -> dict:
-        """Generate code with skill/dependency context and run it in the sandbox."""
+        """Generate code, run it in the sandbox, then verify/QA/repair the output.
+
+        Flow per attempt: augment prompt (contract + skills + deps + reflection)
+        → generate code → execute → select generated artifacts → validate against
+        the deliverable contract → deterministic verify + render QA. If blocking
+        failures remain and the repair budget allows, build a focused reflection
+        and regenerate. A ``manifest.json`` capturing every attempt is emitted.
+        """
         try:
             ref_files = reference_files or []
 
-            # 1) Perception context: select skills + resolve dependencies.
+            # Perception context (skills) + deterministic deliverable contract.
             skills = self.registry.select(ref_files, task_prompt, max_skills=self.max_skills)
-            manifest = resolve(
-                reference_files=ref_files,
-                task_text=task_prompt,
-                base_packages=self._base_packages,
+            contract = infer_deliverable_contract(task_prompt, ref_files, self.contract_cfg)
+
+            max_attempts = (
+                int(self.repair_cfg.get("max_attempts", 1))
+                if self.repair_cfg.get("enabled", True)
+                else 0
             )
 
-            # 2) Build the augmented task prompt and generate code.
-            augmented = self._augment_prompt(task_prompt, ref_files, skills, manifest)
-            rendered = render_prompt(
-                self.prompt_data,
-                occupation=occupation,
-                task_prompt=augmented,
-                experiment_prompt=experiment_prompt,
-            )
-            messages = [
-                {"role": "system", "content": rendered["system_message"]},
-                {"role": "user", "content": rendered["user_prompt"]},
-            ]
-            response, _ = complete(
-                client=self.llm_client,
-                model=model,
-                messages=messages,
-                max_completion_tokens=self.max_completion_tokens,
-                reasoning_effort=self.reasoning_effort,
-            )
-            response_text = response.choices[0].message.content
-            code = extract_code(response_text)
-            if not code:
-                return {
-                    "success": False,
-                    "text": "",
-                    "deliverable_text": "",
-                    "files": [],
-                    "error": f"No Python code found in LLM response. Response: {response_text[:200]}...",
-                    "metadata": self._metadata("none", skills, manifest),
-                }
-            deliverable_text = extract_description(response_text)
+            attempts: List[dict] = []
+            reflection: Optional[str] = None
+            best: Optional[dict] = None
 
-            # Re-resolve including the code's imports (better missing-dep signal).
-            manifest = resolve(
-                reference_files=ref_files,
-                task_text=task_prompt,
-                code=code,
-                base_packages=self._base_packages,
-            )
+            for attempt_idx in range(max_attempts + 1):
+                attempt = self._run_attempt(
+                    attempt_idx=attempt_idx,
+                    task_prompt=task_prompt,
+                    model=model,
+                    ref_files=ref_files,
+                    occupation=occupation,
+                    experiment_prompt=experiment_prompt,
+                    skills=skills,
+                    contract=contract,
+                    reflection=reflection,
+                )
+                attempts.append(attempt["report"])
 
-            # 3) Execute (Docker when possible, else local fallback).
-            executor_used, result = self._execute(code, ref_files, manifest)
-            result["deliverable_text"] = deliverable_text
-            result["metadata"] = self._metadata(executor_used, skills, manifest)
-            return result
+                if best is None or self._is_better(attempt, best):
+                    best = attempt
+
+                # No code at all → terminal (regenerating a refusal rarely helps).
+                if attempt["no_code"]:
+                    break
+                if not attempt["blocking_errors"]:
+                    break
+                if attempt_idx >= max_attempts:
+                    break
+                reflection = attempt["reflection_for_next"]
+
+            return self._finalize(best, attempts, skills, contract, ref_files)
 
         except Exception as e:  # pragma: no cover - defensive
             return {
@@ -199,6 +240,287 @@ class SandboxRunner:
                 "error": f"Sandbox code generation failed: {str(e)}",
             }
 
+    # ── single attempt ────────────────────────────────────────────────────
+    def _run_attempt(
+        self,
+        attempt_idx: int,
+        task_prompt: str,
+        model: str,
+        ref_files: List[str],
+        occupation: str,
+        experiment_prompt: Optional[dict],
+        skills,
+        contract: DeliverableContract,
+        reflection: Optional[str],
+    ) -> dict:
+        manifest = resolve(
+            reference_files=ref_files,
+            task_text=task_prompt,
+            base_packages=self._base_packages,
+        )
+        augmented = self._augment_prompt(
+            task_prompt, ref_files, skills, manifest, contract, reflection
+        )
+        rendered = render_prompt(
+            self.prompt_data,
+            occupation=occupation,
+            task_prompt=augmented,
+            experiment_prompt=experiment_prompt,
+        )
+        messages = [
+            {"role": "system", "content": rendered["system_message"]},
+            {"role": "user", "content": rendered["user_prompt"]},
+        ]
+        response, _ = complete(
+            client=self.llm_client,
+            model=model,
+            messages=messages,
+            max_completion_tokens=self.max_completion_tokens,
+            reasoning_effort=self.reasoning_effort,
+        )
+        response_text = response.choices[0].message.content or ""
+        code = extract_code(response_text)
+
+        if not code:
+            return {
+                "no_code": True,
+                "executor": "none",
+                "result": {
+                    "success": False,
+                    "text": "",
+                    "deliverable_text": "",
+                    "files": [],
+                    "error": f"No Python code found in LLM response. "
+                             f"Response: {response_text[:200]}...",
+                },
+                "manifest": manifest,
+                "blocking_errors": ["no_code: model produced no runnable Python"],
+                "artifacts": [],
+                "contract_validation": None,
+                "verification": None,
+                "output_qa": None,
+                "reflection_for_next": None,
+                "report": {
+                    "attempt": attempt_idx,
+                    "status": "failed_execution",
+                    "executor": "none",
+                    "blocking_errors": ["no_code"],
+                    "stdout_tail": "",
+                    "stderr_tail": response_text[:300],
+                },
+            }
+
+        deliverable_text = extract_description(response_text)
+        # Re-resolve including the code's imports for a sharper missing-dep signal.
+        manifest = resolve(
+            reference_files=ref_files,
+            task_text=task_prompt,
+            code=code,
+            base_packages=self._base_packages,
+        )
+
+        executor_used, result = self._execute(code, ref_files, manifest)
+        result["deliverable_text"] = deliverable_text
+
+        # Inspect the produced artifacts in an isolated workspace.
+        analysis = self._analyze_output(result, ref_files, contract, task_prompt, executor_used)
+
+        blocking = list(analysis["blocking_errors"])
+        if not result.get("success"):
+            tail = (result.get("error") or "")[-600:]
+            blocking.insert(0, f"execution_failed: {tail}")
+
+        status = self._status_for(attempt_idx, result, analysis, blocking)
+        reflection_for_next = self._build_reflection(
+            contract, blocking, code, result, analysis
+        ) if blocking else None
+
+        return {
+            "no_code": False,
+            "executor": executor_used,
+            "result": result,
+            "manifest": manifest,
+            "code": code,
+            "blocking_errors": blocking,
+            "artifacts": analysis["artifact_names"],
+            "contract_validation": analysis["contract_validation"],
+            "verification": analysis["verification"],
+            "output_qa": analysis["output_qa"],
+            "import_probe": analysis["import_probe"],
+            "reflection_for_next": reflection_for_next,
+            "report": {
+                "attempt": attempt_idx,
+                "status": status,
+                "executor": executor_used,
+                "code_sha256": _sha256_text(code),
+                "blocking_errors": blocking,
+                "generated_artifacts": analysis["artifact_names"],
+                "stdout_tail": (result.get("text") or "")[-600:],
+                "stderr_tail": (result.get("error") or "")[-600:],
+            },
+        }
+
+    def _analyze_output(
+        self,
+        result: dict,
+        ref_files: List[str],
+        contract: DeliverableContract,
+        task_prompt: str,
+        executor_used: str,
+    ) -> dict:
+        """Materialize returned files and run contract + verify + render QA."""
+        files = result.get("files") or []
+        with tempfile.TemporaryDirectory(prefix="gdpval_qa_") as qa_root:
+            inspect_dir = Path(qa_root) / "artifacts"
+            inspect_dir.mkdir(parents=True, exist_ok=True)
+            for f in files:
+                try:
+                    (inspect_dir / f["filename"]).write_bytes(f.get("content", b""))
+                except Exception:
+                    continue
+
+            artifacts = select_generated_artifacts(inspect_dir, reference_files=[])
+            contract_validation = validate_contract(contract, artifacts)
+            verification = verify_artifacts(artifacts, contract, workdir=inspect_dir)
+            verification_dict = verification.to_dict()
+            # Strip ephemeral QA-workspace absolute paths from the manifest.
+            for art in verification_dict.get("artifacts", []):
+                art["path"] = art.get("rel_path", art.get("path"))
+
+            render_dir = Path(qa_root) / "render"
+            vcfg = self.output_qa_cfg.get("vision", {}) or {}
+            output_qa = run_output_qa(
+                artifacts,
+                contract=contract,
+                config=self.output_qa_cfg,
+                out_dir=render_dir,
+                task_text=task_prompt,
+                vision_client=self.llm_client if vcfg.get("enabled") else None,
+                cache=self._cache,
+            )
+
+            output_qa_dict = output_qa.to_dict()
+            for rr in output_qa_dict.get("render_reports", []):
+                rr["rendered_images"] = [os.path.basename(p) for p in rr.get("rendered_images", [])]
+
+            # Importability probe (accurate only for local execution).
+            probe = probe_imports(
+                result.get("metadata", {}).get("dependencies", {}).get("required", [])
+                if isinstance(result.get("metadata"), dict) else [],
+                enabled=(executor_used == "local"),
+                env="host" if executor_used == "local" else "image",
+            )
+
+            blocking: List[str] = []
+            blocking += contract_validation.blocking_errors
+            blocking += verification.blocking_errors
+            blocking += output_qa.blocking_errors
+
+            return {
+                "artifact_names": [a.name for a in artifacts],
+                "contract_validation": contract_validation.to_dict(),
+                "verification": verification_dict,
+                "output_qa": output_qa_dict,
+                "import_probe": probe.to_dict(),
+                "blocking_errors": blocking,
+                "warnings": (
+                    contract_validation.warnings
+                    + verification.warnings
+                    + output_qa.warnings
+                ),
+            }
+
+    @staticmethod
+    def _is_better(candidate: dict, current: dict) -> bool:
+        """Prefer clean > more artifacts > fewer blocking > executed."""
+        def score(a: dict):
+            ok = 1 if not a["blocking_errors"] else 0
+            ran = 1 if a["result"].get("success") else 0
+            nfiles = len(a["result"].get("files") or [])
+            return (ok, ran, nfiles, -len(a["blocking_errors"]))
+        return score(candidate) > score(current)
+
+    @staticmethod
+    def _status_for(attempt_idx: int, result: dict, analysis: dict, blocking: List[str]) -> str:
+        if not blocking:
+            return "ok" if attempt_idx == 0 else "repaired_ok"
+        if not result.get("success"):
+            return "failed_execution"
+        if analysis["contract_validation"] and analysis["contract_validation"]["blocking_errors"]:
+            return "failed_contract"
+        return "failed_verification"
+
+    def _finalize(
+        self,
+        best: dict,
+        attempts: List[dict],
+        skills,
+        contract: DeliverableContract,
+        ref_files: List[str],
+    ) -> dict:
+        result = dict(best["result"])
+        executor_used = best["executor"]
+        manifest = best["manifest"]
+
+        if not best["blocking_errors"]:
+            final_status = "ok" if best["report"]["attempt"] == 0 else "repaired_ok"
+        else:
+            final_status = best["report"]["status"]
+
+        metadata = self._metadata(executor_used, skills, manifest)
+        metadata.update({
+            "final_status": final_status,
+            "repaired": final_status == "repaired_ok",
+            "attempts": [a for a in attempts],
+            "deliverable_contract": contract.to_dict(),
+            "contract_validation": best.get("contract_validation"),
+            "verification": best.get("verification"),
+            "output_qa": best.get("output_qa"),
+            "import_probe": best.get("import_probe"),
+            "blocking_errors": best["blocking_errors"],
+        })
+        result["metadata"] = metadata
+        result["final_status"] = final_status
+        result["qa_ok"] = not best["blocking_errors"]
+
+        manifest_doc = self._build_manifest(
+            executor_used, skills, manifest, contract, attempts, best,
+            final_status, ref_files,
+        )
+        result["sandbox_manifest"] = manifest_doc
+        if self.manifest_cfg.get("enabled", True) and self.manifest_cfg.get("include_in_files", True):
+            files = list(result.get("files") or [])
+            files.append({
+                "filename": self.manifest_cfg.get("filename", "manifest.json"),
+                "content": json.dumps(manifest_doc, indent=2, default=str).encode("utf-8"),
+            })
+            result["files"] = files
+        return result
+
+    def _build_manifest(
+        self, executor_used, skills, manifest, contract, attempts, best,
+        final_status, ref_files,
+    ) -> dict:
+        return {
+            "schema_version": MANIFEST_SCHEMA_VERSION,
+            "execution_mode": "sandbox",
+            "sandbox_backend": "docker" if executor_used == "docker" else "local_fallback",
+            "selected_skills": [s.name for s in skills],
+            "dependency_resolution": manifest.to_dict(),
+            "dependency_import_probe": best.get("import_probe"),
+            "deliverable_contract": contract.to_dict(),
+            "reference_files": [os.path.basename(f) for f in ref_files],
+            "generated_artifacts": best.get("artifacts", []),
+            "selected_primary_artifacts": (
+                best.get("contract_validation", {}) or {}
+            ).get("matched_primary", []),
+            "verification_report": best.get("verification"),
+            "render_report": (best.get("output_qa") or {}).get("render_reports"),
+            "vision_qa_report": (best.get("output_qa") or {}).get("vision_qa"),
+            "attempts": attempts,
+            "final_status": final_status,
+        }
+
     # ── prompt augmentation ──────────────────────────────────────────────
     def _augment_prompt(
         self,
@@ -206,8 +528,14 @@ class SandboxRunner:
         reference_files: List[str],
         skills,
         manifest: DependencyManifest,
+        contract: Optional[DeliverableContract] = None,
+        reflection: Optional[str] = None,
     ) -> str:
         parts: List[str] = []
+
+        # A repair reflection (if any) goes first so the model addresses it.
+        if reflection:
+            parts.append(reflection)
 
         file_structure_info = build_file_structure_info(reference_files or [])
         if file_structure_info:
@@ -220,6 +548,9 @@ class SandboxRunner:
         dep_hint = manifest.to_prompt_hint()
         if dep_hint:
             parts.append(dep_hint)
+
+        if contract is not None:
+            parts.append(contract.to_prompt_section())
 
         parts.append(task_prompt)
 
@@ -234,6 +565,49 @@ class SandboxRunner:
             )
 
         return "\n\n".join(parts)
+
+    def _build_reflection(
+        self,
+        contract: DeliverableContract,
+        blocking_errors: List[str],
+        code: str,
+        result: dict,
+        analysis: dict,
+    ) -> str:
+        """A focused [REFLECTION] block fed back to the model for the next attempt."""
+        lines = [
+            "[REFLECTION]",
+            "Your previous attempt did NOT satisfy the deliverable contract. "
+            "Regenerate the COMPLETE solution and fix every issue below.",
+            "",
+            "Blocking problems to fix:",
+        ]
+        for err in blocking_errors[:12]:
+            lines.append(f"- {err}")
+
+        warnings = analysis.get("warnings") or []
+        if warnings:
+            lines.append("")
+            lines.append("Secondary warnings (address if relevant):")
+            for w in warnings[:6]:
+                lines.append(f"- {w}")
+
+        lines.append("")
+        lines.append(contract.to_prompt_section())
+
+        stdout_tail = (result.get("text") or "")[-800:]
+        stderr_tail = (result.get("error") or "")[-800:]
+        if stdout_tail.strip():
+            lines += ["", "Previous stdout (tail):", stdout_tail]
+        if stderr_tail.strip():
+            lines += ["", "Previous stderr/error (tail):", stderr_tail]
+
+        # Include the prior code when short enough to be useful context.
+        if code and len(code) <= 4000:
+            lines += ["", "Your previous code (fix and resend in full):",
+                      "----", code, "----"]
+        lines.append("[/REFLECTION]")
+        return "\n".join(lines)
 
     def _metadata(self, executor_used: str, skills, manifest: DependencyManifest) -> dict:
         return {

--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -106,6 +106,26 @@ def _sanitize_tail(text: Optional[str], limit: int = 600) -> str:
             s = s.replace(root, repl)
     return s
 
+
+# Built-in fallback for the self-repair reflection wording. The canonical copy
+# lives in the prompt spec (`reflection_strings:` in the codegen YAML) so it can
+# be edited in one place; these defaults keep _build_reflection working when a
+# spec omits the block. Keep them in sync with prompts/sandbox_occupation_codegen.yaml.
+_DEFAULT_REFLECTION_STRINGS = {
+    "open": "[REFLECTION]",
+    "intro": (
+        "Your previous attempt did NOT satisfy the deliverable contract. "
+        "Regenerate the COMPLETE solution and fix every issue below."
+    ),
+    "blocking_header": "Blocking problems to fix:",
+    "warnings_header": "Secondary warnings (address if relevant):",
+    "stdout_header": "Previous stdout (tail):",
+    "stderr_header": "Previous stderr/error (tail):",
+    "code_header": "Your previous code (fix and resend in full):",
+    "code_fence": "----",
+    "close": "[/REFLECTION]",
+}
+
 # Cache for the (relatively expensive) `docker info` probe.
 _DOCKER_AVAILABLE: Optional[bool] = None
 
@@ -658,13 +678,19 @@ class SandboxRunner:
         result: dict,
         analysis: dict,
     ) -> str:
-        """A focused [REFLECTION] block fed back to the model for the next attempt."""
+        """A focused [REFLECTION] block fed back to the model for the next attempt.
+
+        The wording is authored in the prompt spec (``reflection_strings:`` in the
+        codegen YAML) so a researcher can edit it in one place; this method owns
+        only the layout and the safety limits. Missing keys fall back to
+        ``_DEFAULT_REFLECTION_STRINGS``.
+        """
+        s = {**_DEFAULT_REFLECTION_STRINGS, **(self.prompt_data.get("reflection_strings") or {})}
         lines = [
-            "[REFLECTION]",
-            "Your previous attempt did NOT satisfy the deliverable contract. "
-            "Regenerate the COMPLETE solution and fix every issue below.",
+            s["open"],
+            s["intro"],
             "",
-            "Blocking problems to fix:",
+            s["blocking_header"],
         ]
         for err in blocking_errors[:12]:
             lines.append(f"- {err}")
@@ -672,7 +698,7 @@ class SandboxRunner:
         warnings = analysis.get("warnings") or []
         if warnings:
             lines.append("")
-            lines.append("Secondary warnings (address if relevant):")
+            lines.append(s["warnings_header"])
             for w in warnings[:6]:
                 lines.append(f"- {w}")
 
@@ -682,15 +708,15 @@ class SandboxRunner:
         stdout_tail = _sanitize_tail(result.get("text"), limit=800)
         stderr_tail = _sanitize_tail(result.get("error"), limit=800)
         if stdout_tail.strip():
-            lines += ["", "Previous stdout (tail):", stdout_tail]
+            lines += ["", s["stdout_header"], stdout_tail]
         if stderr_tail.strip():
-            lines += ["", "Previous stderr/error (tail):", stderr_tail]
+            lines += ["", s["stderr_header"], stderr_tail]
 
         # Include the prior code when short enough to be useful context.
         if code and len(code) <= 4000:
-            lines += ["", "Your previous code (fix and resend in full):",
-                      "----", code, "----"]
-        lines.append("[/REFLECTION]")
+            lines += ["", s["code_header"],
+                      s["code_fence"], code, s["code_fence"]]
+        lines.append(s["close"])
         return "\n".join(lines)
 
     def _metadata(self, executor_used: str, skills, manifest: DependencyManifest) -> dict:

--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -45,10 +45,15 @@ from core.dependency_resolver import (
     probe_imports,
     resolve,
 )
-from core.file_preview import build_file_structure_info, generate_all_previews
+
 from core.llm_client import complete
 from core.output_qa import run_output_qa
 from core.prompt_loader import load_prompt, render_prompt
+from core.prompt_sections import (
+    DEFAULT_SECTIONS,
+    SectionContext,
+    assemble_sections,
+)
 from core.sandbox_cache import build_cache
 from core.skills_registry import SkillsRegistry
 from core.subprocess_runner import SubprocessRunner, extract_code, extract_description
@@ -635,40 +640,24 @@ class SandboxRunner:
         contract: Optional[DeliverableContract] = None,
         reflection: Optional[str] = None,
     ) -> str:
-        parts: List[str] = []
+        """Assemble the sandbox prompt from spec-ordered sections.
 
-        # A repair reflection (if any) goes first so the model addresses it.
-        if reflection:
-            parts.append(reflection)
-
-        file_structure_info = build_file_structure_info(reference_files or [])
-        if file_structure_info:
-            parts.append(file_structure_info)
-
-        skills_manual = self.registry.render_manual(skills)
-        if skills_manual:
-            parts.append(skills_manual)
-
-        dep_hint = manifest.to_prompt_hint()
-        if dep_hint:
-            parts.append(dep_hint)
-
-        if contract is not None:
-            parts.append(contract.to_prompt_section())
-
-        parts.append(task_prompt)
-
-        if reference_files:
-            previews = generate_all_previews(reference_files)
-            if previews:
-                parts.append(previews)
-            available_files = [os.path.basename(f) for f in reference_files]
-            parts.append(
-                f"📁 Files available in the sandbox working directory "
-                f"(use them directly): {available_files}"
-            )
-
-        return "\n\n".join(parts)
+        Structure (section order + presence) is owned by the prompt spec's
+        ``sections:`` list, falling back to ``DEFAULT_SECTIONS`` (today's order).
+        Each section's text comes from a thin provider in ``core.prompt_sections``;
+        this method only builds the context and delegates the assembly.
+        """
+        ctx = SectionContext(
+            task_prompt=task_prompt,
+            ref_files=reference_files or [],
+            skills=skills,
+            manifest=manifest,
+            contract=contract,
+            reflection=reflection,
+            registry=self.registry,
+        )
+        section_order = self.prompt_data.get("sections") or DEFAULT_SECTIONS
+        return assemble_sections(section_order, ctx)
 
     def _build_reflection(
         self,

--- a/batch-runner/core/skills_registry.py
+++ b/batch-runner/core/skills_registry.py
@@ -1,0 +1,215 @@
+"""Skills Registry — discover, select, and render Agent Skills for the sandbox.
+
+Parses every ``skills/<name>/SKILL.md`` (YAML front-matter + markdown body),
+then selects the skills relevant to a task by matching reference-file extensions
+and task-text keywords. Selected skills' manuals are injected into the
+code-generation prompt so the model knows the exact callable API, and the
+``skills`` package is mounted into the sandbox so generated code can import it.
+
+Usage::
+
+    from core.skills_registry import SkillsRegistry
+
+    reg = SkillsRegistry()                       # auto-discovers batch-runner/skills
+    selected = reg.select(reference_files, task_text)
+    manual = reg.render_manual(selected)         # -> str for prompt injection
+    names = [s.name for s in selected]           # -> ['video', 'audio', ...]
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+# Default skills directory: batch-runner/skills
+DEFAULT_SKILLS_DIR = Path(__file__).resolve().parent.parent / "skills"
+
+# Per-extension weight is much higher than per-keyword so that a task whose
+# reference files clearly belong to a modality always pulls in that skill.
+_EXT_WEIGHT = 10
+_KW_WEIGHT = 1
+
+
+@dataclass
+class Skill:
+    """One parsed SKILL.md pack."""
+
+    name: str
+    title: str
+    description: str
+    modalities: List[str]
+    file_extensions: List[str]
+    keywords: List[str]
+    requires: List[str]
+    version: str
+    body: str
+    api: str
+    path: Path
+    # Populated during selection:
+    score: int = 0
+    matched_extensions: List[str] = field(default_factory=list)
+    matched_keywords: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "title": self.title,
+            "modalities": self.modalities,
+            "requires": self.requires,
+            "score": self.score,
+            "matched_extensions": self.matched_extensions,
+            "matched_keywords": self.matched_keywords,
+        }
+
+
+def _parse_front_matter(text: str) -> tuple[dict, str]:
+    """Split a SKILL.md into (front_matter_dict, body)."""
+    if text.lstrip().startswith("---"):
+        # Strip a leading BOM/whitespace, then split on the front-matter fences.
+        stripped = text.lstrip()
+        parts = stripped.split("---", 2)
+        if len(parts) >= 3:
+            meta = yaml.safe_load(parts[1]) or {}
+            return meta, parts[2].lstrip("\n")
+    return {}, text
+
+
+def _extract_api_section(body: str) -> str:
+    """Return the ``## Toolkit API`` section (heading + content) or ""."""
+    match = re.search(
+        r"(^##\s+Toolkit API\b.*?)(?=^##\s+|\Z)",
+        body,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    return match.group(1).strip() if match else ""
+
+
+def _norm_ext(ext: str) -> str:
+    ext = ext.strip().lower()
+    return ext if ext.startswith(".") else f".{ext}"
+
+
+class SkillsRegistry:
+    """Discovers and selects Agent Skills."""
+
+    def __init__(self, skills_dir: Optional[str | Path] = None):
+        self.skills_dir = Path(skills_dir) if skills_dir else DEFAULT_SKILLS_DIR
+        self._skills: Dict[str, Skill] = {}
+        self._load()
+
+    # ── discovery ────────────────────────────────────────────────────────
+    def _load(self) -> None:
+        if not self.skills_dir.exists():
+            return
+        for skill_md in sorted(self.skills_dir.glob("*/SKILL.md")):
+            try:
+                skill = self._parse_skill(skill_md)
+                self._skills[skill.name] = skill
+            except Exception as exc:  # pragma: no cover - defensive
+                print(f"⚠️  SkillsRegistry: failed to parse {skill_md}: {exc}")
+
+    def _parse_skill(self, skill_md: Path) -> Skill:
+        text = skill_md.read_text(encoding="utf-8")
+        meta, body = _parse_front_matter(text)
+        name = str(meta.get("name") or skill_md.parent.name)
+        return Skill(
+            name=name,
+            title=str(meta.get("title", name)),
+            description=str(meta.get("description", "")).strip(),
+            modalities=[str(m) for m in (meta.get("modalities") or [])],
+            file_extensions=[_norm_ext(e) for e in (meta.get("file_extensions") or [])],
+            keywords=[str(k).lower() for k in (meta.get("keywords") or [])],
+            requires=[str(r) for r in (meta.get("requires") or [])],
+            version=str(meta.get("version", "0.0.0")),
+            body=body,
+            api=_extract_api_section(body),
+            path=skill_md.parent,
+        )
+
+    # ── access ───────────────────────────────────────────────────────────
+    @property
+    def skills(self) -> Dict[str, Skill]:
+        return dict(self._skills)
+
+    def get(self, name: str) -> Optional[Skill]:
+        return self._skills.get(name)
+
+    def all_required_packages(self) -> List[str]:
+        """Union of ``requires:`` across every skill (for image provisioning)."""
+        seen: List[str] = []
+        for skill in self._skills.values():
+            for pkg in skill.requires:
+                if pkg not in seen:
+                    seen.append(pkg)
+        return seen
+
+    # ── selection ────────────────────────────────────────────────────────
+    def select(
+        self,
+        reference_files: Optional[List[str]] = None,
+        task_text: str = "",
+        max_skills: int = 5,
+    ) -> List[Skill]:
+        """Return skills relevant to a task, highest score first.
+
+        Scoring: each reference file whose extension belongs to a skill adds
+        ``_EXT_WEIGHT``; each task keyword found in ``task_text`` adds
+        ``_KW_WEIGHT``. Skills with a positive score are returned.
+        """
+        exts = [Path(f).suffix.lower() for f in (reference_files or [])]
+        text = (task_text or "").lower()
+
+        scored: List[Skill] = []
+        for skill in self._skills.values():
+            matched_ext = [e for e in exts if e in skill.file_extensions]
+            matched_kw = [k for k in skill.keywords if k in text]
+            score = len(matched_ext) * _EXT_WEIGHT + len(matched_kw) * _KW_WEIGHT
+            if score <= 0:
+                continue
+            # Return a per-selection copy so the registry stays reusable.
+            chosen = Skill(**{**skill.__dict__})
+            chosen.score = score
+            chosen.matched_extensions = sorted(set(matched_ext))
+            chosen.matched_keywords = matched_kw
+            scored.append(chosen)
+
+        scored.sort(key=lambda s: (-s.score, s.name))
+        return scored[:max_skills]
+
+    # ── prompt rendering ─────────────────────────────────────────────────
+    def render_manual(self, skills: List[Skill], max_chars: int = 7000) -> str:
+        """Render a compact skills manual for prompt injection."""
+        if not skills:
+            return ""
+        lines = [
+            "🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):",
+            "",
+            "Import with: `from skills import "
+            + ", ".join(s.name for s in skills)
+            + "`",
+            "Use these helpers instead of hand-rolling perception/IO. They wrap "
+            "famous libraries with safe defaults.",
+            "",
+        ]
+        for skill in skills:
+            why = []
+            if skill.matched_extensions:
+                why.append("files: " + ", ".join(skill.matched_extensions))
+            if skill.matched_keywords:
+                why.append("keywords: " + ", ".join(skill.matched_keywords[:6]))
+            reason = f"  (matched {'; '.join(why)})" if why else ""
+            lines.append(f"── Skill `{skill.name}` — {skill.title}{reason}")
+            if skill.description:
+                lines.append(skill.description)
+            if skill.api:
+                lines.append(skill.api)
+            lines.append("")
+
+        manual = "\n".join(lines).strip()
+        if len(manual) > max_chars:
+            manual = manual[:max_chars].rstrip() + "\n… (skills manual truncated)"
+        return manual

--- a/batch-runner/core/subprocess_runner.py
+++ b/batch-runner/core/subprocess_runner.py
@@ -27,6 +27,54 @@ from core.prompt_loader import load_prompt, render_prompt
 from core.file_preview import generate_all_previews, build_file_structure_info
 
 
+# ── Reusable, runner-agnostic helpers (shared with SandboxRunner) ────────────
+
+def sanitize_code(code: str) -> str:
+    """Strip evaluation harness tags that don't belong in executable code."""
+    return re.sub(
+        r'^\s*CONFIDENCE\s*\[\s*\d+\s*\]\s*$',
+        '',
+        code,
+        flags=re.MULTILINE,
+    ).strip()
+
+
+def extract_code(text: str) -> Optional[str]:
+    """Extract Python code from ```python``` fenced blocks (with fallbacks)."""
+    pattern = r"```python\s*\n(.*?)```"
+    matches = re.findall(pattern, text, re.DOTALL)
+    if matches:
+        combined = "\n\n".join(m.strip() for m in matches)
+        return sanitize_code(combined)
+
+    # Fallback: fenced block without a language specifier.
+    pattern = r"```\s*\n(.*?)```"
+    matches = re.findall(pattern, text, re.DOTALL)
+    if matches:
+        code = matches[0].strip()
+        if "import" in code or "def " in code or "print" in code:
+            return sanitize_code(code)
+
+    # Fallback: code block opened but never closed (LLM truncation).
+    pattern = r"```python\s*\n(.+)"
+    match = re.search(pattern, text, re.DOTALL)
+    if match:
+        code = match.group(1).strip()
+        code = re.sub(r'`{1,3}\s*$', '', code).strip()
+        if code:
+            return sanitize_code(code)
+
+    return None
+
+
+def extract_description(text: str) -> str:
+    """Return the non-code descriptive text from an LLM response."""
+    cleaned = re.sub(r"```[\w]*\s*\n.*?```", "", text, flags=re.DOTALL)
+    cleaned = re.sub(r"```[\w]*\s*\n.*$", "", cleaned, flags=re.DOTALL)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+    return cleaned
+
+
 class SubprocessRunner:
     """LLM code generation → safe subprocess execution"""
 
@@ -159,77 +207,42 @@ class SubprocessRunner:
     def _extract_description(self, text: str) -> str:
         """Extract non-code descriptive text from LLM response.
 
-        Strips code blocks and returns the remaining text as a
-        meta description of what deliverables were created.
-
-        Args:
-            text: Full LLM response text
-
-        Returns:
-            Descriptive text with code blocks removed
+        Delegates to the module-level :func:`extract_description` (shared with
+        SandboxRunner); kept as a method for backward compatibility.
         """
-        # Remove all closed code blocks (```python...``` or ```...```)
-        cleaned = re.sub(r"```[\w]*\s*\n.*?```", "", text, flags=re.DOTALL)
-        # Remove unclosed code blocks (LLM truncation or trailing code)
-        cleaned = re.sub(r"```[\w]*\s*\n.*$", "", cleaned, flags=re.DOTALL)
-        # Clean up excessive whitespace
-        cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
-        return cleaned
+        return extract_description(text)
 
     def _sanitize_code(self, code: str) -> str:
         """Strip evaluation harness tags that don't belong in executable code."""
-        return re.sub(
-            r'^\s*CONFIDENCE\s*\[\s*\d+\s*\]\s*$',
-            '',
-            code,
-            flags=re.MULTILINE,
-        ).strip()
+        return sanitize_code(code)
 
     def _extract_code(self, text: str) -> Optional[str]:
+        """Extract Python code from ```python``` code blocks.
+
+        Delegates to the module-level :func:`extract_code` (shared with
+        SandboxRunner); kept as a method for backward compatibility.
         """
-        Extract Python code from ```python``` code blocks.
+        return extract_code(text)
 
-        Args:
-            text: LLM response text
+    def run_code(
+        self,
+        code: str,
+        reference_files: Optional[list] = None,
+        skills_dir: Optional[str] = None,
+    ) -> dict:
+        """Execute already-extracted code in the hardened local sandbox.
 
-        Returns:
-            Extracted code or None if not found
+        Public wrapper around :meth:`_execute_safely` used by SandboxRunner's
+        local fallback so the Docker and local paths share identical security
+        controls and (optionally) the mounted ``skills`` package.
         """
-        # Pattern: ```python ... ``` (flexible whitespace)
-        pattern = r"```python\s*\n(.*?)```"
-        matches = re.findall(pattern, text, re.DOTALL)
-
-        if matches:
-            # Concatenate all code blocks if multiple
-            combined = "\n\n".join(m.strip() for m in matches)
-            return self._sanitize_code(combined)
-
-        # Fallback: Try without language specifier
-        pattern = r"```\s*\n(.*?)```"
-        matches = re.findall(pattern, text, re.DOTALL)
-
-        if matches:
-            # Check if it looks like Python code
-            code = matches[0].strip()
-            if "import" in code or "def " in code or "print" in code:
-                return self._sanitize_code(code)
-
-        # Fallback: Code block opened but never closed (LLM truncation)
-        pattern = r"```python\s*\n(.+)"
-        match = re.search(pattern, text, re.DOTALL)
-        if match:
-            code = match.group(1).strip()
-            # Remove trailing ``` if partially present
-            code = re.sub(r'`{1,3}\s*$', '', code).strip()
-            if code:
-                return self._sanitize_code(code)
-
-        return None
+        return self._execute_safely(code, reference_files, skills_dir=skills_dir)
 
     def _execute_safely(
         self,
         code: str,
-        reference_files: Optional[list] = None
+        reference_files: Optional[list] = None,
+        skills_dir: Optional[str] = None,
     ) -> dict:
         """
         Execute code in isolated temporary directory with security controls.
@@ -237,6 +250,9 @@ class SubprocessRunner:
         Args:
             code: Python code to execute
             reference_files: Optional list of file paths to copy
+            skills_dir: Optional path to the ``skills`` package. When provided it
+                is copied into the execution directory and added to PYTHONPATH so
+                generated code can ``from skills import audio, video, ...``.
 
         Returns:
             dict with success, text, files, error
@@ -259,6 +275,21 @@ class SubprocessRunner:
                                 copied_files.append(filename)
                             except Exception as e:
                                 print(f"Warning: Failed to copy reference file {src_path}: {e}")
+
+                # Mount the skills package so generated code can import it
+                # (`from skills import audio, video, ...`). Copied into the
+                # isolated tmpdir; PYTHONPATH is extended below.
+                skills_mounted = False
+                if skills_dir and os.path.isdir(skills_dir):
+                    try:
+                        shutil.copytree(
+                            skills_dir,
+                            os.path.join(tmpdir, "skills"),
+                            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+                        )
+                        skills_mounted = True
+                    except Exception as e:
+                        print(f"Warning: Failed to mount skills package: {e}")
 
                 # Inject available files list as runtime info (top of code)
                 if copied_files:
@@ -294,6 +325,10 @@ class SubprocessRunner:
                 # Preserve VIRTUAL_ENV and related paths for package access
                 if "VIRTUAL_ENV" in os.environ:
                     safe_env["VIRTUAL_ENV"] = os.environ["VIRTUAL_ENV"]
+
+                # Make the mounted skills package importable.
+                if skills_mounted:
+                    safe_env["PYTHONPATH"] = tmpdir
 
                 # Use the same Python interpreter (preserves venv)
                 python_executable = sys.executable

--- a/batch-runner/core/video_analyzer.py
+++ b/batch-runner/core/video_analyzer.py
@@ -78,6 +78,18 @@ def _select_backend() -> Optional[str]:
     return None
 
 
+def frame_backend_available() -> Optional[str]:
+    """Public host-side probe: which video frame backend (if any) is importable.
+
+    Returns "cv2", "av", or None. Used by the inference orchestrator to warn
+    (before a large run) when a ``video_analyzer`` preprocessor is configured but
+    the host lacks the frame backend it needs — in which case video preprocessing
+    silently no-ops. This does not import the generated task code; it only checks
+    optional package availability.
+    """
+    return _select_backend()
+
+
 def _encode_jpeg_from_bgr(frame, max_width: int) -> Optional[bytes]:
     """Resize a cv2 BGR frame and JPEG-encode it. Returns bytes or None."""
     import cv2

--- a/batch-runner/core/video_analyzer.py
+++ b/batch-runner/core/video_analyzer.py
@@ -1,0 +1,424 @@
+"""Video Analyzer — vision preprocessor for the multi-agent pipeline.
+
+This is the *seeing* counterpart of :mod:`core.audio_analyzer`. It gives the
+solving pipeline **vision** for video reference files:
+
+1. Sample keyframes from each video frame-by-frame (evenly spaced across the
+   timeline) using OpenCV (``cv2``) or PyAV (``av``) — whichever is available.
+2. Send the frames (as base64 JPEG images) together with per-video metadata and
+   the task instruction to a vision-capable model.
+3. Return a task-aware JSON analysis that is injected into the prompt *before*
+   the main executor runs, so the code-generating model can "watch" the video
+   instead of coding blind.
+
+Like the audio analyzer, every failure path is **non-fatal**: if no frame
+backend is installed, a file can't be decoded, or the API call errors, the
+function returns ``""`` and the main pipeline proceeds unaffected.
+
+Usage (called by step2_run_inference._run_preprocessors):
+
+    from core.video_analyzer import analyze_video_files, filter_video_files
+
+    result = analyze_video_files(
+        client=azure_client,
+        model_deployment="gpt-5.2",
+        system_prompt="You are a video analysis agent...",
+        video_paths=["/data/ref/clip.mp4"],
+        task_instruction="Summarize the on-screen actions...",
+    )
+    # result: "[VIDEO ANALYSIS]\n{...json...}\n[/VIDEO ANALYSIS]"
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import time
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+VIDEO_EXTENSIONS = {
+    ".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v",
+    ".mpeg", ".mpg", ".wmv", ".flv", ".3gp", ".ogv",
+}
+
+# Sampling / payload defaults (overridable via preprocessor YAML).
+DEFAULT_FRAMES_PER_VIDEO = 8
+DEFAULT_MAX_TOTAL_FRAMES = 24
+DEFAULT_FRAME_MAX_WIDTH = 768   # px; keeps vision token cost reasonable
+DEFAULT_FRAME_DETAIL = "auto"   # "low" | "high" | "auto"
+JPEG_QUALITY = 80
+
+
+# ── modality filter ─────────────────────────────────────────────────────────
+
+def filter_video_files(file_paths: List[str] | None) -> List[str]:
+    """Return only paths whose extension is a known video format."""
+    if not file_paths:
+        return []
+    return [p for p in file_paths if Path(p).suffix.lower() in VIDEO_EXTENSIONS]
+
+
+# ── frame-extraction backends (lazy, optional) ──────────────────────────────
+
+def _select_backend() -> Optional[str]:
+    """Return an available frame-extraction backend name, or None."""
+    try:
+        import cv2  # noqa: F401
+        return "cv2"
+    except Exception:
+        pass
+    try:
+        import av  # noqa: F401
+        return "av"
+    except Exception:
+        pass
+    return None
+
+
+def _encode_jpeg_from_bgr(frame, max_width: int) -> Optional[bytes]:
+    """Resize a cv2 BGR frame and JPEG-encode it. Returns bytes or None."""
+    import cv2
+
+    h, w = frame.shape[:2]
+    if w > max_width:
+        new_h = int(h * (max_width / float(w)))
+        frame = cv2.resize(frame, (max_width, new_h), interpolation=cv2.INTER_AREA)
+    ok, buf = cv2.imencode(".jpg", frame, [int(cv2.IMWRITE_JPEG_QUALITY), JPEG_QUALITY])
+    if not ok:
+        return None
+    return buf.tobytes()
+
+
+def _extract_frames_cv2(
+    video_path: str, max_frames: int, max_width: int
+) -> Tuple[dict, List[Tuple[float, bytes]]]:
+    """Extract evenly spaced keyframes with OpenCV."""
+    import cv2
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        return {}, []
+    try:
+        fps = cap.get(cv2.CAP_PROP_FPS) or 0.0
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
+        duration = (frame_count / fps) if fps else 0.0
+
+        info = {
+            "fps": round(fps, 3),
+            "frame_count": frame_count,
+            "duration_sec": round(duration, 3),
+            "resolution": f"{width}x{height}" if width and height else None,
+        }
+
+        if frame_count <= 0:
+            # Fall back to sequential read when frame count is unknown.
+            frames = _sequential_read_cv2(cap, max_frames, max_width, fps)
+            return info, frames
+
+        n = min(max_frames, frame_count)
+        if n <= 0:
+            return info, []
+        indices = [int(round(i * (frame_count - 1) / max(n - 1, 1))) for i in range(n)]
+
+        frames: List[Tuple[float, bytes]] = []
+        for idx in indices:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+            ok, frame = cap.read()
+            if not ok or frame is None:
+                continue
+            jpeg = _encode_jpeg_from_bgr(frame, max_width)
+            if jpeg is None:
+                continue
+            ts = (idx / fps) if fps else 0.0
+            frames.append((round(ts, 3), jpeg))
+        return info, frames
+    finally:
+        cap.release()
+
+
+def _sequential_read_cv2(cap, max_frames, max_width, fps) -> List[Tuple[float, bytes]]:
+    """Sample frames by stepping through the stream (unknown frame count)."""
+    import cv2
+
+    frames: List[Tuple[float, bytes]] = []
+    step = 30  # grab roughly 1 frame/sec at 30fps
+    i = 0
+    while len(frames) < max_frames:
+        ok, frame = cap.read()
+        if not ok or frame is None:
+            break
+        if i % step == 0:
+            jpeg = _encode_jpeg_from_bgr(frame, max_width)
+            if jpeg is not None:
+                ts = (i / fps) if fps else 0.0
+                frames.append((round(ts, 3), jpeg))
+        i += 1
+    return frames
+
+
+def _extract_frames_av(
+    video_path: str, max_frames: int, max_width: int
+) -> Tuple[dict, List[Tuple[float, bytes]]]:
+    """Extract evenly spaced keyframes with PyAV (+ Pillow for JPEG encode)."""
+    import av
+
+    container = av.open(video_path)
+    try:
+        stream = container.streams.video[0]
+        time_base = stream.time_base
+        fps = float(stream.average_rate) if stream.average_rate else 0.0
+        frame_count = stream.frames or 0
+        duration = 0.0
+        if stream.duration and time_base:
+            duration = float(stream.duration * time_base)
+        elif container.duration:
+            duration = container.duration / 1_000_000.0
+
+        info = {
+            "fps": round(fps, 3),
+            "frame_count": frame_count,
+            "duration_sec": round(duration, 3),
+            "resolution": (
+                f"{stream.codec_context.width}x{stream.codec_context.height}"
+                if stream.codec_context.width else None
+            ),
+        }
+
+        target_times = _target_times(duration, max_frames)
+        frames: List[Tuple[float, bytes]] = []
+
+        if target_times and duration > 0:
+            for t in target_times:
+                try:
+                    container.seek(int(t / time_base), stream=stream)
+                except Exception:
+                    pass
+                grabbed = False
+                for frame in container.decode(video=0):
+                    jpeg = _av_frame_to_jpeg(frame, max_width)
+                    if jpeg is not None:
+                        ts = float(frame.pts * time_base) if frame.pts is not None else t
+                        frames.append((round(ts, 3), jpeg))
+                        grabbed = True
+                    break
+                if len(frames) >= max_frames:
+                    break
+        else:
+            # No duration → decode sequentially, sample every Nth frame.
+            step = max(1, (frame_count // max_frames) if frame_count else 30)
+            for i, frame in enumerate(container.decode(video=0)):
+                if i % step == 0:
+                    jpeg = _av_frame_to_jpeg(frame, max_width)
+                    if jpeg is not None:
+                        ts = float(frame.pts * time_base) if frame.pts is not None else 0.0
+                        frames.append((round(ts, 3), jpeg))
+                if len(frames) >= max_frames:
+                    break
+
+        return info, frames
+    finally:
+        container.close()
+
+
+def _av_frame_to_jpeg(frame, max_width: int) -> Optional[bytes]:
+    """Convert a PyAV video frame to resized JPEG bytes via Pillow."""
+    try:
+        img = frame.to_image()  # PIL.Image
+    except Exception:
+        return None
+    if img.width > max_width:
+        new_h = int(img.height * (max_width / float(img.width)))
+        img = img.resize((max_width, new_h))
+    buf = io.BytesIO()
+    img.convert("RGB").save(buf, format="JPEG", quality=JPEG_QUALITY)
+    return buf.getvalue()
+
+
+def _target_times(duration: float, max_frames: int) -> List[float]:
+    """Evenly spaced timestamps across the clip (excludes exact end)."""
+    if duration <= 0 or max_frames <= 0:
+        return []
+    if max_frames == 1:
+        return [duration / 2.0]
+    return [i * duration / max_frames for i in range(max_frames)]
+
+
+def extract_keyframes(
+    video_path: str,
+    max_frames: int = DEFAULT_FRAMES_PER_VIDEO,
+    max_width: int = DEFAULT_FRAME_MAX_WIDTH,
+) -> Tuple[dict, List[Tuple[float, bytes]]]:
+    """Extract up to ``max_frames`` keyframes; returns (info, [(ts, jpeg)...]).
+
+    Returns ({}, []) when no backend is available or the file can't be read.
+    """
+    backend = _select_backend()
+    if backend is None:
+        return {}, []
+    try:
+        if backend == "cv2":
+            return _extract_frames_cv2(video_path, max_frames, max_width)
+        return _extract_frames_av(video_path, max_frames, max_width)
+    except Exception as exc:  # pragma: no cover - backend-specific
+        print(f"      ⚠️  Video preprocessor: frame extraction failed for "
+              f"{Path(video_path).name}: {exc}")
+        return {}, []
+
+
+# ── analysis API ────────────────────────────────────────────────────────────
+
+def _analyze_one(
+    client,
+    model_deployment: str,
+    system_prompt: str,
+    video_path: str,
+    task_instruction: Optional[str],
+    frames_per_video: int,
+    frame_max_width: int,
+    frame_detail: str,
+    max_completion_tokens: int,
+) -> Tuple[str, object]:
+    """Analyze a single video; returns (filename, parsed_json_or_text|None)."""
+    filename = Path(video_path).name
+    info, frames = extract_keyframes(video_path, frames_per_video, frame_max_width)
+    if not frames:
+        print(f"      ⚠️  Video preprocessor: no frames extracted from {filename}")
+        return filename, None
+
+    print(f"      🎬 Video preprocessor: {filename} → {len(frames)} frames "
+          f"({info.get('duration_sec', '?')}s, {info.get('resolution', '?')})")
+
+    text_content = system_prompt
+    if task_instruction:
+        text_content += f"\n\n[TASK]\n{task_instruction}\n[/TASK]"
+    text_content += (
+        f"\n\n[VIDEO METADATA]\nfile: {filename}\n"
+        f"duration_sec: {info.get('duration_sec')}\n"
+        f"fps: {info.get('fps')}\nframe_count: {info.get('frame_count')}\n"
+        f"resolution: {info.get('resolution')}\n"
+        f"sampled_frames: {len(frames)} (timestamps in seconds shown per image)\n"
+        f"[/VIDEO METADATA]"
+    )
+
+    content_parts: list[dict] = [{"type": "text", "text": text_content}]
+    for ts, jpeg in frames:
+        content_parts.append({"type": "text", "text": f"frame @ {ts}s:"})
+        b64 = base64.b64encode(jpeg).decode("utf-8")
+        content_parts.append({
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:image/jpeg;base64,{b64}",
+                "detail": frame_detail,
+            },
+        })
+
+    messages = [{"role": "user", "content": content_parts}]
+    try:
+        start = time.time()
+        response = client.chat.completions.create(
+            model=model_deployment,
+            messages=messages,
+            max_completion_tokens=max_completion_tokens,
+        )
+        latency_ms = (time.time() - start) * 1000
+        raw = response.choices[0].message.content or ""
+        if "```json" in raw:
+            raw = raw.split("```json")[1].split("```")[0].strip()
+        elif "```" in raw:
+            raw = raw.split("```")[1].split("```")[0].strip()
+
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            print(f"      🎬 Video analysis complete: {latency_ms:.0f}ms "
+                  f"(prompt={usage.prompt_tokens}, completion={usage.completion_tokens})")
+        else:
+            print(f"      🎬 Video analysis complete: {latency_ms:.0f}ms")
+
+        raw = raw.strip()
+        if not raw:
+            return filename, None
+        try:
+            return filename, json.loads(raw)
+        except json.JSONDecodeError:
+            return filename, raw
+    except Exception as exc:
+        print(f"      ⚠️  Video preprocessor API error (non-fatal): {exc}")
+        return filename, None
+
+
+def analyze_video_files(
+    client,
+    model_deployment: str,
+    system_prompt: str,
+    video_paths: List[str],
+    task_instruction: Optional[str] = None,
+    max_completion_tokens: int = 4096,
+    frames_per_video: int = DEFAULT_FRAMES_PER_VIDEO,
+    max_total_frames: int = DEFAULT_MAX_TOTAL_FRAMES,
+    frame_max_width: int = DEFAULT_FRAME_MAX_WIDTH,
+    frame_detail: str = DEFAULT_FRAME_DETAIL,
+) -> str:
+    """Sample keyframes from video files and send them to a vision model.
+
+    Args:
+        client:            AzureOpenAI (or OpenAI) client instance.
+        model_deployment:  Vision-capable deployment name (e.g. "gpt-5.2").
+        system_prompt:     System prompt from YAML preprocessor config.
+        video_paths:       Absolute paths to video files.
+        task_instruction:  Task prompt (injected when include_task_instruction=true).
+        max_completion_tokens: Max tokens for the analysis response.
+        frames_per_video:  Keyframes to sample per video.
+        max_total_frames:  Global cap across all videos (rebalances per-video count).
+        frame_max_width:   Max frame width in px before JPEG encoding.
+        frame_detail:      Vision ``detail`` hint ("low" | "high" | "auto").
+
+    Returns:
+        "[VIDEO ANALYSIS]\\n<json>\\n[/VIDEO ANALYSIS]" on success,
+        empty string on any failure (must not block main execution).
+    """
+    if not video_paths:
+        return ""
+
+    if _select_backend() is None:
+        print("      ⚠️  Video preprocessor: no frame backend (cv2/av) installed — skipping")
+        return ""
+
+    # Rebalance per-video frame budget so the total stays within max_total_frames.
+    n_videos = len(video_paths)
+    per_video = max(1, min(frames_per_video, max_total_frames // n_videos)) if n_videos else frames_per_video
+
+    analyses: dict = {}
+    for video_path in video_paths:
+        if not os.path.exists(video_path):
+            print(f"      ⚠️  Video preprocessor: missing file {video_path}")
+            continue
+        filename, parsed = _analyze_one(
+            client=client,
+            model_deployment=model_deployment,
+            system_prompt=system_prompt,
+            video_path=video_path,
+            task_instruction=task_instruction,
+            frames_per_video=per_video,
+            frame_max_width=frame_max_width,
+            frame_detail=frame_detail,
+            max_completion_tokens=max_completion_tokens,
+        )
+        if parsed is not None:
+            analyses[filename] = parsed
+
+    if not analyses:
+        return ""
+
+    # Single video → emit its analysis directly; multiple → keyed by filename.
+    if len(analyses) == 1:
+        only = next(iter(analyses.values()))
+        body = json.dumps(only, indent=2, ensure_ascii=False) if not isinstance(only, str) else only
+    else:
+        body = json.dumps(analyses, indent=2, ensure_ascii=False)
+
+    return f"[VIDEO ANALYSIS]\n{body}\n[/VIDEO ANALYSIS]"

--- a/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
+++ b/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
@@ -1,0 +1,245 @@
+# 🧪 Sandbox + Skills + Multimodal Perception (exp026)
+# Research Question: Does containerized execution with per-task dependency
+#   discovery, Agent Skills, and multimodal perception (vision for video,
+#   hearing for audio) improve GDPVal deliverable quality vs. plain subprocess?
+# Base architecture: exp025 (GPT-5.4 high + gpt-audio-1.5 preprocessor)
+# New variables:
+#   - execution.mode: sandbox (container, graceful local fallback)
+#   - skills/ injected into prompt + mounted in the sandbox
+#   - video_analyzer preprocessor (frame-by-frame vision)
+# Scope: All 220 tasks (9 sectors, 44 occupations)
+
+experiment:
+  id: "exp026_sandbox_skills_multimodal"
+  name: "Sandbox + Skills + Multimodal (GPT-5.4 high)"
+  description: >
+    Evolution of subprocess mode into a containerized **sandbox** execution mode
+    with three additions over exp025: (1) per-task dependency discovery, (2)
+    famous Agent Skills (audio/video/document/image/data) mounted in the sandbox
+    and documented in the prompt, and (3) multimodal perception — a gpt-audio-1.5
+    audio preprocessor (hearing) plus a frame-by-frame video preprocessor
+    (vision). Sandbox uses Docker when available and gracefully falls back to the
+    hardened local subprocess otherwise. Full 220 tasks across 9 sectors.
+  author: "Hyeonsang Jeon"
+  created_at: "2026-05-18"
+
+# Variable control
+control:
+  fixed:
+    - tasks               # All 220 tasks (9 sectors, 44 occupations)
+    - temperature         # 0.0
+    - reasoning_effort    # high (matches exp025)
+    - domain_packages     # full exp011 environment (baked into sandbox image)
+  changed:
+    - execution_mode      # subprocess → sandbox
+    - skills              # NEW: Agent Skills injected + mounted
+    - perception          # NEW: audio (hearing) + video (vision) preprocessors
+
+# Data filter — All sectors (full benchmark)
+data:
+  source: "HyeonSang/exp026_sandbox_skills_multimodal"
+  filter:
+    sector: null          # All 9 sectors
+    occupation: null      # All 44 occupations
+    sample_size: null     # All 220 tasks
+
+# Condition A: sandbox + skills + audio/video perception + reasoning=high
+condition_a:
+  name: "GPT-5.4 high + sandbox + skills + audio/video perception"
+  model:
+    provider: "azure"
+    deployment: "gpt-5.4"
+    temperature: 0.0
+    seed: null
+    reasoning_effort: "high"
+  prompt:
+    system: |
+      You are a helpful assistant that completes professional tasks.
+      When the task requires creating files (e.g., Excel, Word, PDF, PowerPoint),
+      write Python code that generates those files and save them to the current directory.
+      Use libraries such as openpyxl, python-docx, reportlab, python-pptx, and Pillow.
+      Always produce complete, runnable code.
+    prefix: null
+    body: null
+    suffix: |
+      If the task requires creating deliverable files (documents, spreadsheets,
+      presentations, reports, etc.), you MUST use Python code to generate the
+      actual file(s) and save them to the current directory.
+      Do NOT just describe what you would create — actually execute code to produce
+      downloadable files. The task is NOT complete unless the files are saved.
+
+      In your text response, do NOT include any file download links or sandbox URLs
+      (e.g. "[Download ...](sandbox:/mnt/data/...)" or similar).
+      Only provide a plain-text summary of what was produced.
+
+      IMPORTANT — Defensive coding:
+      Before writing any code, ALWAYS inspect the actual structure of any
+      reference files first (df.columns, df.dtypes, df.head()).
+      Never hardcode column names or assume data types.
+      Use the exact column names found in the file.
+
+      Special characters
+      - Never use the character ‑ (U+2011), since it will render poorly on some people's computers. Instead, always use - (U+002D) instead.
+      - Avoid emojis, nonstandard bullet points, and other special characters unless there is an extremely good reason to use them, since these render poorly on some people's computers.
+
+      Graphics embedded within PDFs/slides
+      - Make sure that any diagrams or plots are large enough to be legible (though not so large that they are ugly or cut off). In most cases they should be at least half the page width.
+      - Plots and charts to visualize data are good. Simple graphics (like a flowchart with arrows) are good. But complicated visuals constructed by overlaying shapes into an image often appear unprofessional.
+
+      PDFs
+      - Always use LibreOffice to create the PDF (it must be LibreOffice! If LibreOffice is not installed, you can install it yourself). Other libraries sometimes show weird artifacts on some computers.
+
+      Fonts
+      - Always use fonts which are available across all platforms. We recommend Noto Sans / Noto Serif unless there is an extremely good reason to use something else.
+      - If you must use another font, embed the font in the pptx/word/etc doc.
+
+      Deliverable text
+      - Do not link to submitted files in the deliverable text (links are not supported on the interface where these will be viewed).
+      - Ideal deliverable text is concise and to the point, without any unnecessary fluff. 4 sentences max.
+      - Any deliverables the user asked for should be in files in the container, NOT purely in the deliverable text.
+      - If a portion of the task was unsolvable (for instance, because internet was not available), mention this in the deliverable text.
+      - Your submission should be complete and self-contained. Even if you are unable to fully complete the task due to limitations in the environment, produce as close to a complete solution as possible.
+
+      Verbosity
+      - Always be clear and comprehensive, but avoid extra verbosity when possible.
+
+      Filetypes
+      - If the prompt does not request a specific filetype, use standard filetypes like PDF, PPTX, DOCX, XLSX, MP4, ZIP, etc.
+
+      Code structure:
+      Write all code in a SINGLE ```python``` code block.
+      Do not split code across multiple code blocks — this can cause
+      syntax errors when blocks are concatenated.
+
+      Lightweight mandatory checks
+      After generating files, do a quick validation pass (5 lines max):
+      - Verify each file exists and has non-zero size
+      - For Excel/DOCX/PPTX: open with the same library and confirm no exception
+      - Do NOT do multi-step visual inspection or PNG conversion
+      If any file is missing or corrupt, fix and regenerate.
+
+      Skills (preinstalled toolkits)
+      - A `skills/` package is available on the Python path inside the sandbox.
+        The "SKILLS AVAILABLE" section above lists the relevant skills and their
+        toolkit APIs for THIS task. Prefer those helpers — they wrap the famous
+        libraries correctly (e.g. `from skills.audio.toolkit import fft_summary`,
+        `from skills.video.toolkit import extract_frames`,
+        `from skills.document.toolkit import read_any`).
+      - If a needed package is listed under "DEPENDENCIES", assume it is already
+        installed in the sandbox image; just import and use it.
+
+      Perception data (vision + hearing)
+      - When an [AUDIO ANALYSIS] section is present, a specialized audio model
+        listened to the reference audio. Trust its findings (BPM, key, timing,
+        levels, etc.) instead of guessing.
+      - When a [VIDEO ANALYSIS] section is present, a vision model watched
+        frame-by-frame samples of the reference video. Trust its findings
+        (on-screen content, scene changes, timing, corruption checks) instead of
+        guessing. To inspect further, sample frames yourself with
+        `skills.video.toolkit.extract_frames`.
+
+      Available packages
+      - Audio: soundfile, pydub, pedalboard, pyloudnorm, librosa, mutagen, ffmpeg-python, moviepy, av
+      - Documents: aspose-words, camelot-py, docx2txt, fpdf2, PyMuPDF, weasyprint, cairosvg
+      - Data/ML: scikit-learn, xgboost, lightgbm, catboost, statsmodels, scipy, networkx
+      - NLP: nltk, textblob, fuzzywuzzy, rapidfuzz, wordcloud
+      - GIS: geopandas, geopy, folium, shapely, rasterio
+      - Vision: opencv-python, pytesseract, pdf2image, pyzbar, qrcode
+      - Visualization: bokeh, plotly, plotnine, seaborn, matplotlib-venn
+      - `ffmpeg`, `tesseract`, `graphviz`, `wkhtmltopdf` are available as system commands.
+      - `LibreOffice` is available for document conversion.
+
+  # Preprocessors: run before main execution (perception layer)
+  preprocessors:
+    - type: "audio_analyzer"          # hearing
+      model:
+        provider: "azure"
+        deployment: "gpt-audio-1.5"
+      trigger: "has_audio_files"
+      inject_as: "prompt_prefix"
+      include_task_instruction: true
+      system: |
+        You are an audio analysis agent.
+        You will receive a task description and one or more audio files.
+        Listen to the audio and provide analysis that is relevant
+        to completing the task.
+        Return your analysis as structured JSON.
+        Only include information you can actually determine from listening.
+        Do not guess or fabricate values.
+        Respond with JSON only. No prose.
+
+    - type: "video_analyzer"          # vision (frame-by-frame)
+      model:
+        provider: "azure"
+        deployment: "gpt-5.4"
+      trigger: "has_video_files"
+      inject_as: "prompt_prefix"
+      include_task_instruction: true
+      frames_per_video: 8
+      max_total_frames: 24
+      frame_max_width: 768
+      frame_detail: "auto"
+      system: |
+        You are a video analysis agent.
+        You will receive a task description, per-video metadata, and several
+        frames sampled across each video's timeline (each labeled with its
+        timestamp in seconds).
+        Examine the frames and describe what is happening on screen as it relates
+        to completing the task: visible content/text, scene changes, notable
+        timestamps, and whether any frame looks corrupted.
+        Return your analysis as structured JSON.
+        Only include information you can actually determine from the frames.
+        Do not guess or fabricate values.
+        Respond with JSON only. No prose.
+
+  # Self-QA: LLM inspects its own output
+  qa:
+    enabled: true
+    max_retries: 1
+    model: null
+    min_score: 5
+    prompt: |
+      You are a strict QA inspector for professional deliverables.
+
+      ## Original Task
+      {instruction}
+
+      ## Generated Output
+      - Text response: {deliverable_text}
+      - Files produced: {deliverable_files}
+
+      ## Inspection Criteria
+      1. Does the output address ALL requirements in the original task?
+      2. Are all required files produced with correct types and content?
+      3. Is the text response complete and professional?
+      4. Are there any obvious errors, missing elements, or placeholder content?
+
+      ## Response Format (JSON only)
+      ```json
+      {{
+        "passed": true,
+        "score": 8,
+        "issues": [],
+        "suggestion": ""
+      }}
+      ```
+
+# Execution settings
+execution:
+  mode: "sandbox"
+  timeout: 720
+  install_libreoffice: true
+  # Sandbox-specific settings (consumed by core/sandbox_runner.py).
+  sandbox:
+    image: "gdpval-sandbox:latest"
+    use_docker: "auto"        # auto | never | always
+    memory_gb: 5
+    cpus: 2.0
+    max_skills: 5
+  tokens:
+    code_generation: 16384
+    qa_check: 4096
+    json_render: 8000
+  max_retries: 5
+  resume_max_rounds: 2
+  relay_max_runs: 5

--- a/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
+++ b/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
@@ -11,7 +11,7 @@
 
 experiment:
   id: "exp026_sandbox_skills_multimodal"
-  name: "Sandbox + Skills + Multimodal (GPT-5.4 high)"
+  name: "Sandbox + Skills + Multimodal (GPT-5.4 medium)"
   description: >
     Evolution of subprocess mode into a containerized **sandbox** execution mode
     with three additions over exp025: (1) per-task dependency discovery, (2)
@@ -28,7 +28,7 @@ control:
   fixed:
     - tasks               # All 220 tasks (9 sectors, 44 occupations)
     - temperature         # 0.0
-    - reasoning_effort    # high (matches exp025)
+    - reasoning_effort    # medium (see condition_a note: "high" is unsafe in sandbox)
     - domain_packages     # full exp011 environment (baked into sandbox image)
   changed:
     - execution_mode      # subprocess → sandbox
@@ -43,15 +43,26 @@ data:
     occupation: null      # All 44 occupations
     sample_size: null     # All 220 tasks
 
-# Condition A: sandbox + skills + audio/video perception + reasoning=high
+# Condition A: sandbox + skills + audio/video perception + reasoning=medium
 condition_a:
-  name: "GPT-5.4 high + sandbox + skills + audio/video perception"
+  name: "GPT-5.4 medium + sandbox + skills + audio/video perception"
   model:
     provider: "azure"
     deployment: "gpt-5.4"
     temperature: 0.0
     seed: null
-    reasoning_effort: "high"
+    # ── Sandbox reasoning-effort safety (PR #57 A/B smoke finding) ────────
+    # reasoning_effort="high" is UNSAFE for sandbox codegen on complex GDPVal
+    # prompts: gpt-5.4 spends the entire completion budget on hidden reasoning
+    # (empty visible content -> "No Python code found") AND a single call
+    # exceeds the 480s LLM-client timeout (measured: high did not return within
+    # the timeout and retried). Empirical probe on a representative task:
+    #   high   -> exceeded 480s client timeout (unusable)
+    #   medium -> 15,732 reasoning + 9,048 visible = 24,780 tokens, 318s, finish=stop
+    # "medium" preserves strong reasoning while fitting the timeout and the
+    # 32768-token code_generation budget below. See
+    # tasks/0701_wednesday/sandbox_ab_smoke_pr57.md.
+    reasoning_effort: "medium"
   prompt:
     system: |
       You are a helpful assistant that completes professional tasks.
@@ -227,13 +238,18 @@ condition_a:
 # Execution settings
 execution:
   mode: "sandbox"
-  timeout: 720
+  # Video-heavy tasks (e.g. a 657 MB / 4K reference) are marginal at 720s: the
+  # A/B smoke saw the film/video task exhaust the timeout on the compositing
+  # pass. 1200s gives large ffmpeg/moviepy renders room before the resume round.
+  timeout: 1200
   install_libreoffice: true
   # Sandbox-specific settings (consumed by core/sandbox_runner.py).
   sandbox:
     image: "gdpval-sandbox:latest"
     use_docker: "auto"        # auto | never | always
-    memory_gb: 5
+    # 5 GB OOM-killed the 657 MB / 4K video task (exit 137) in the A/B smoke.
+    # 8 GB covers 4K frame buffers + moviepy/ffmpeg working set for the full run.
+    memory_gb: 8
     cpus: 2.0
     max_skills: 5
     # ── Output control loop (Phase 2) ────────────────────────────────────
@@ -258,7 +274,12 @@ execution:
     cache:
       enabled: true            # cache rendered PNGs / perception by sha256
   tokens:
-    code_generation: 16384
+    # 16384 truncates gpt-5.4 at medium reasoning (measured 24,780 completion
+    # tokens on a representative sandbox task) -> EMPTY visible output. 32768
+    # leaves ~8k headroom above that for the generated code block. Raising this
+    # does NOT increase reasoning (that is controlled by reasoning_effort); it
+    # only prevents truncation. See sandbox_ab_smoke_pr57.md.
+    code_generation: 32768
     qa_check: 4096
     json_render: 8000
   max_retries: 5

--- a/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
+++ b/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
@@ -236,6 +236,27 @@ execution:
     memory_gb: 5
     cpus: 2.0
     max_skills: 5
+    # ── Output control loop (Phase 2) ────────────────────────────────────
+    # Skills give the sandbox eyes/ears on INPUTS; the blocks below verify
+    # the OUTPUTS the model generates and repair them when they fall short.
+    repair:
+      enabled: true
+      max_attempts: 1          # repair retries after attempt 0 (bounded)
+    output_qa:
+      enabled: true
+      render: true             # rasterize deliverables for deterministic QA
+      max_pages_per_artifact: 3
+      blank_page_threshold: 0.999   # per-page near-white warning ratio
+      vision:
+        enabled: false         # optional LLM vision QA (off by default)
+        provider: "azure"
+        deployment: "gpt-5.4"
+        max_images: 6
+    manifest:
+      enabled: true
+      filename: "manifest.json"
+    cache:
+      enabled: true            # cache rendered PNGs / perception by sha256
   tokens:
     code_generation: 16384
     qa_check: 4096

--- a/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
+++ b/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
@@ -252,6 +252,10 @@ execution:
   # Sandbox-specific settings (consumed by core/sandbox_runner.py).
   sandbox:
     image: "gdpval-sandbox:latest"
+    # Prompt structure/wording is authored in prompts/sandbox_occupation_codegen
+    # .yaml (sections, reflection_strings, perception placement). To A/B an
+    # alternate design without code changes, copy that file and set:
+    #   prompt_name: "your_variant"   # see prompts/sandbox_prompt_authoring.md
     use_docker: "auto"        # auto | never | always
     # 5 GB OOM-killed the 657 MB / 4K video task (exit 137) in the A/B smoke.
     # 8 GB covers 4K frame buffers + moviepy/ffmpeg working set for the full run.

--- a/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
+++ b/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
@@ -11,7 +11,7 @@
 
 experiment:
   id: "exp026_sandbox_skills_multimodal"
-  name: "Sandbox + Skills + Multimodal (GPT-5.4 medium)"
+  name: "Sandbox + Skills + Multimodal (GPT-5.4 low)"
   description: >
     Evolution of subprocess mode into a containerized **sandbox** execution mode
     with three additions over exp025: (1) per-task dependency discovery, (2)
@@ -28,7 +28,7 @@ control:
   fixed:
     - tasks               # All 220 tasks (9 sectors, 44 occupations)
     - temperature         # 0.0
-    - reasoning_effort    # medium (see condition_a note: "high" is unsafe in sandbox)
+    - reasoning_effort    # low (see condition_a note: high/medium starve sandbox codegen)
     - domain_packages     # full exp011 environment (baked into sandbox image)
   changed:
     - execution_mode      # subprocess → sandbox
@@ -43,26 +43,32 @@ data:
     occupation: null      # All 44 occupations
     sample_size: null     # All 220 tasks
 
-# Condition A: sandbox + skills + audio/video perception + reasoning=medium
+# Condition A: sandbox + skills + audio/video perception + reasoning=low
 condition_a:
-  name: "GPT-5.4 medium + sandbox + skills + audio/video perception"
+  name: "GPT-5.4 low + sandbox + skills + audio/video perception"
   model:
     provider: "azure"
     deployment: "gpt-5.4"
     temperature: 0.0
     seed: null
-    # ── Sandbox reasoning-effort safety (PR #57 A/B smoke finding) ────────
-    # reasoning_effort="high" is UNSAFE for sandbox codegen on complex GDPVal
-    # prompts: gpt-5.4 spends the entire completion budget on hidden reasoning
-    # (empty visible content -> "No Python code found") AND a single call
-    # exceeds the 480s LLM-client timeout (measured: high did not return within
-    # the timeout and retried). Empirical probe on a representative task:
+    # ── Sandbox reasoning-effort safety (PR #57 smoke + post-hardening probe) ─
+    # reasoning_effort must stay LOW for sandbox codegen. gpt-5.4 draws hidden
+    # reasoning tokens from the SAME completion budget as the visible code, so
+    # heavier reasoning empties the visible output ("No Python code found") and
+    # can exceed the 480s LLM-client timeout. Empirical probes on a representative
+    # reference-heavy accountant task (7d7fc9a7), code_generation=32768:
     #   high   -> exceeded 480s client timeout (unusable)
-    #   medium -> 15,732 reasoning + 9,048 visible = 24,780 tokens, 318s, finish=stop
-    # "medium" preserves strong reasoning while fitting the timeout and the
-    # 32768-token code_generation budget below. See
-    # tasks/0701_wednesday/sandbox_ab_smoke_pr57.md.
-    reasoning_effort: "medium"
+    #   medium -> MARGINAL: reasoning alone reached 22,790 tok and completion hit
+    #             31,146/32,768 (95%); a slightly larger reasoning draw returns
+    #             0 visible tokens -> "No Python code found" (reproduced live in
+    #             a real step2 run before this pass).
+    #   low    -> SAFE: 2,758 reasoning + ~7,381 visible = 10,139/32,768 (31%),
+    #             106s, finish=stop; ran end-to-end in Docker (final_status=ok).
+    # "low" keeps ~69% budget headroom and ~3.3x lower latency with comparable
+    # code output, so reasoning variance cannot intermittently starve the visible
+    # deliverable. See tasks/0702_thursday/
+    # sandbox_post_hardening_docker_verification_pr57.md.
+    reasoning_effort: "low"
   prompt:
     system: |
       You are a helpful assistant that completes professional tasks.
@@ -274,11 +280,13 @@ execution:
     cache:
       enabled: true            # cache rendered PNGs / perception by sha256
   tokens:
-    # 16384 truncates gpt-5.4 at medium reasoning (measured 24,780 completion
-    # tokens on a representative sandbox task) -> EMPTY visible output. 32768
-    # leaves ~8k headroom above that for the generated code block. Raising this
-    # does NOT increase reasoning (that is controlled by reasoning_effort); it
-    # only prevents truncation. See sandbox_ab_smoke_pr57.md.
+    # 16384 truncates gpt-5.4 sandbox codegen -> EMPTY visible output. 32768
+    # gives the visible code block ~69% headroom above low-reasoning usage
+    # (measured 10,139 completion tokens at reasoning_effort=low on a
+    # representative reference-heavy task). Raising this does NOT increase
+    # reasoning (that is controlled by reasoning_effort); it only prevents
+    # truncation. See tasks/0702_thursday/
+    # sandbox_post_hardening_docker_verification_pr57.md.
     code_generation: 32768
     qa_check: 4096
     json_render: 8000

--- a/batch-runner/prompts/sandbox_occupation_codegen.yaml
+++ b/batch-runner/prompts/sandbox_occupation_codegen.yaml
@@ -117,7 +117,7 @@ sections:
   - id: skills_manual       # "AVAILABLE SKILLS" — selected Skills + their API
   - id: deps_hint           # "Likely libraries" pre-installed for this task
   - id: contract            # DELIVERABLE CONTRACT — expected output type(s)
-  # - id: perception_analysis  # host audio/video analysis (enabled via spec in P3)
+  - id: perception_analysis # host audio/video analysis block, placed before the task
   - id: task                # the task instruction text
   - id: previews            # reference-file content previews
   - id: available_files     # "Files available in the sandbox working directory: [...]"

--- a/batch-runner/prompts/sandbox_occupation_codegen.yaml
+++ b/batch-runner/prompts/sandbox_occupation_codegen.yaml
@@ -99,3 +99,27 @@ user_prompt: |
 
   TASK:
   {task_prompt}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Self-repair reflection wording (sandbox loop 2)
+# ─────────────────────────────────────────────────────────────────────────────
+# Emitted by core/sandbox_runner.py::_build_reflection when an attempt fails the
+# deliverable contract, so the model can fix the exact issues on the next attempt.
+# Edit the wording HERE — the runner owns only the layout and the safety limits
+# (at most 12 blocking errors, 6 warnings, and the prior code echoed when
+# <= 4000 chars). Any key omitted below falls back to the runner's built-in
+# default (core.sandbox_runner._DEFAULT_REFLECTION_STRINGS), so this block is
+# optional. NOTE: values beginning with '[' MUST stay quoted, or YAML parses
+# them as a flow sequence instead of a string.
+reflection_strings:
+  open: "[REFLECTION]"
+  intro: >-
+    Your previous attempt did NOT satisfy the deliverable contract. Regenerate
+    the COMPLETE solution and fix every issue below.
+  blocking_header: "Blocking problems to fix:"
+  warnings_header: "Secondary warnings (address if relevant):"
+  stdout_header: "Previous stdout (tail):"
+  stderr_header: "Previous stderr/error (tail):"
+  code_header: "Your previous code (fix and resend in full):"
+  code_fence: "----"
+  close: "[/REFLECTION]"

--- a/batch-runner/prompts/sandbox_occupation_codegen.yaml
+++ b/batch-runner/prompts/sandbox_occupation_codegen.yaml
@@ -1,0 +1,101 @@
+# SandboxRunner Code Generation Prompt
+# ─────────────────────────────────────
+# Used by core/sandbox_runner.py. Instructs the LLM to solve a desktop
+# productivity task with Python that runs inside a containerized sandbox,
+# leveraging the pre-installed multimodal Skills toolkit.
+#
+# Variables (str.format):
+#   {occupation}   - Professional role (e.g., "Financial Analyst")
+#   {task_prompt}  - Augmented task instruction (skills manual + deps hint +
+#                    file previews are pre-pended by the runner)
+#
+# IMPORTANT: keep literal '{' / '}' out of this template (format() placeholders
+# only) — code examples below deliberately avoid dict/set literals.
+
+name: sandbox_occupation_codegen
+description: >-
+  Skill-aware code generation prompt for SandboxRunner. The model acts as a
+  domain expert, picks the right Skills (audio/video/document/image/data) to
+  perceive multimodal reference files, then produces runnable Python that builds
+  the deliverables inside an isolated container.
+
+system_message: >-
+  You are a professional {occupation} working inside a secure, offline code
+  sandbox (a container with no network access). You can SEE and HEAR reference
+  files through the pre-installed Skills toolkit: read video frame-by-frame,
+  analyze audio via FFT/sampling, parse documents, OCR images, and crunch data.
+  Reply as an expert, then provide complete, runnable Python that builds the
+  deliverables. If you receive a [REFLECTION] block, address every listed issue
+  before regenerating your solution.
+
+user_prompt: |
+  You are a professional {occupation} completing a desktop productivity task
+  inside a containerized Python sandbox.
+
+  First, as an expert {occupation}, write a concise professional reply to the
+  task. Describe the deliverables you will create — their purpose, contents, and
+  file formats — so a human evaluator knows what to expect before opening them.
+
+  Then provide the complete Python code to generate the deliverables.
+
+  SANDBOX & SKILLS:
+  - The task text above may include an "AVAILABLE SKILLS" manual and a "Likely
+    libraries" hint. The Skills are pre-installed and importable directly:
+      from skills import audio, video, document, image, data
+  - Use Skills to PERCEIVE multimodal inputs before building output:
+      * VIDEO  -> look frame-by-frame:  frames = video.keyframes("clip.mp4", max_frames=8)
+                  inspect them, detect cuts with video.scene_changes(...),
+                  pull the audio track with video.extract_audio(...).
+      * AUDIO  -> listen via signal analysis:  peaks = audio.fft_summary("track.wav")
+                  render audio.spectrogram_png(...), measure audio.loudness_lufs(...),
+                  sample the envelope with audio.sample_waveform(...).
+      * DOCUMENT -> document.read_any(path), document.pdf_tables(path),
+                  document.pdf_to_images(path) to inspect layout visually.
+      * IMAGE  -> image.ocr_text(path), image.dominant_colors(path),
+                  image.read_codes(path).
+      * DATA   -> df = data.read_table(path); data.describe(df); data.quick_chart(...).
+  - Prefer the Skills helpers over hand-rolled DSP/parsing; they wrap famous
+    libraries (librosa, opencv, PyMuPDF, pdfplumber, pandas) with safe defaults.
+
+  RULES:
+  1. Use pre-installed libraries only — do NOT pip install and do NOT use the
+     network. If the "Likely libraries" hint marks something as not guaranteed,
+     pick a pre-installed alternative.
+  2. Save all deliverables to the current working directory with descriptive
+     names. The task is NOT complete unless real files are saved.
+  3. Wrap code in triple-backtick python blocks. Include all imports at the top.
+  4. Make the code complete and runnable — no placeholders, no TODOs.
+  5. Read reference files from the current directory (already copied there).
+  6. When reference-file previews are provided, use EXACT column names, sheet
+     names, and values — inspect structure first, never guess or hardcode.
+  7. Handle perception defensively: a Skill helper may raise if its library is
+     missing — wrap optional perception in try/except and continue with a
+     sensible fallback so the deliverable is still produced.
+
+  FORMAT:
+  1. Start with your professional reply describing the deliverables.
+  2. Then provide the complete Python code in triple-backtick python blocks.
+
+  EXAMPLE:
+  As a Media Analyst, I will watch the supplied clip frame-by-frame, build a
+  storyboard contact sheet (storyboard.png), and write an analysis memo
+  (analysis.docx) summarizing the key scenes and the audio profile.
+
+  ```python
+  from skills import video, document
+  frames = video.keyframes("clip.mp4", max_frames=8)
+  sheet = video.montage(frames, out="storyboard.png")
+  info = video.video_info("clip.mp4")
+  lines = ["Duration: " + str(info["duration_sec"]) + "s", "Frames sampled: " + str(len(frames))]
+  document.make_docx("Clip Analysis", lines, "analysis.docx")
+  print("Generated", sheet, "and analysis.docx")
+  ```
+
+  CONFIDENCE TAG:
+  On the VERY LAST LINE of your plain-text response (OUTSIDE and AFTER all code
+  blocks), write exactly:
+  CONFIDENCE[XX]
+  where XX is an integer 0-100. It must NOT appear inside any code block.
+
+  TASK:
+  {task_prompt}

--- a/batch-runner/prompts/sandbox_occupation_codegen.yaml
+++ b/batch-runner/prompts/sandbox_occupation_codegen.yaml
@@ -101,6 +101,28 @@ user_prompt: |
   {task_prompt}
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Sandbox prompt STRUCTURE (order + presence of the augmented sections)
+# ─────────────────────────────────────────────────────────────────────────────
+# Owned here so a researcher can reorder/drop sections in one place. The runner
+# (core/sandbox_runner.py::_augment_prompt) renders each id via a thin provider in
+# core/prompt_sections.py and joins non-empty blocks with a blank line. If this
+# key is removed, the runner falls back to core.prompt_sections.DEFAULT_SECTIONS
+# (this exact order). An unknown id fails loudly. Set `enabled: false` on an entry
+# to drop it without deleting the line. Known ids: reflection, file_structure,
+# skills_manual, deps_hint, contract, perception_analysis, task, previews,
+# available_files.
+sections:
+  - id: reflection          # self-repair block (loop 2), first so the model addresses it
+  - id: file_structure      # tabular reference-file schema (columns/sheets)
+  - id: skills_manual       # "AVAILABLE SKILLS" — selected Skills + their API
+  - id: deps_hint           # "Likely libraries" pre-installed for this task
+  - id: contract            # DELIVERABLE CONTRACT — expected output type(s)
+  # - id: perception_analysis  # host audio/video analysis (enabled via spec in P3)
+  - id: task                # the task instruction text
+  - id: previews            # reference-file content previews
+  - id: available_files     # "Files available in the sandbox working directory: [...]"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Self-repair reflection wording (sandbox loop 2)
 # ─────────────────────────────────────────────────────────────────────────────
 # Emitted by core/sandbox_runner.py::_build_reflection when an attempt fails the

--- a/batch-runner/prompts/sandbox_prompt_authoring.md
+++ b/batch-runner/prompts/sandbox_prompt_authoring.md
@@ -1,0 +1,179 @@
+# Authoring the sandbox prompt — one file, one place
+
+The container-sandbox solving path (`execution.mode: sandbox`) builds its prompt
+from a **single spec file**:
+
+```
+batch-runner/prompts/sandbox_occupation_codegen.yaml
+```
+
+A researcher or engineer edits *that file* to change how the model is briefed —
+persona, rules, the order of the injected context blocks, the self-repair wording,
+and where host audio/video perception is placed. The Python runner
+(`core/sandbox_runner.py`) only assembles what the spec declares; it does not own
+the wording or the section order. This guide is the map.
+
+> Scope: this affects **sandbox mode only**. `subprocess`, `code_interpreter`, and
+> `json_renderer` are untouched by anything here.
+
+---
+
+## 1. What the model actually receives
+
+For each attempt the runner produces two messages:
+
+- **system** — `system_message` from the spec, with `{occupation}` filled in.
+- **user** — `user_prompt` from the spec, with `{task_prompt}` filled in, where
+  `{task_prompt}` is the **assembled context** described below.
+
+The assembled context is an ordered list of *sections*, joined by blank lines. Each
+section is produced by a thin provider; empty sections are dropped automatically.
+
+```
+[ reflection ]            ← sandbox self-repair block (only on a repair attempt)
+[ file_structure ]        ← tabular schema of reference files (columns/sheets)
+[ skills_manual ]         ← "AVAILABLE SKILLS" — the selected Skills + their API
+[ deps_hint ]             ← "Likely libraries" pre-installed for this task
+[ contract ]              ← DELIVERABLE CONTRACT — the expected output type(s)
+[ perception_analysis ]   ← host audio/video analysis block (when perception ran)
+[ task ]                  ← the task instruction text
+[ previews ]              ← reference-file content previews
+[ available_files ]       ← "Files available in the sandbox working directory: [...]"
+```
+
+---
+
+## 2. The knobs (all in the spec file)
+
+### `system_message` / `user_prompt`
+Persona, rules, output format, the worked example, and the `CONFIDENCE[XX]` tag.
+Plain `str.format` templates — only `{occupation}` and `{task_prompt}` are
+substituted, so keep other literal `{` / `}` out (the code examples already avoid
+dict/set literals on purpose).
+
+### `sections:` — order and presence of the context blocks
+An ordered list. Each entry is either a bare id or `{id: ..., enabled: false}`.
+
+```yaml
+sections:
+  - id: reflection
+  - id: file_structure
+  - id: skills_manual
+  - id: deps_hint
+  - id: contract
+  - id: perception_analysis
+  - id: task
+  - id: previews
+  - id: available_files
+```
+
+- **Reorder** by moving lines. **Drop** a block with `enabled: false` (keeps the
+  line as documentation) or by deleting it.
+- **Known ids** (and the existing builder each maps to):
+
+  | id | source | omitted when |
+  |---|---|---|
+  | `reflection` | sandbox self-repair (`_build_reflection`) | not a repair attempt |
+  | `file_structure` | `file_preview.build_file_structure_info` | no tabular refs |
+  | `skills_manual` | `SkillsRegistry.render_manual` | no skills selected |
+  | `deps_hint` | `DependencyManifest.to_prompt_hint` | nothing to install |
+  | `contract` | `DeliverableContract.to_prompt_section` | no contract |
+  | `perception_analysis` | host audio/video analysis | perception didn't run |
+  | `task` | the task instruction | (always present) |
+  | `previews` | `file_preview.generate_all_previews` | no reference files |
+  | `available_files` | basenames of reference files | no reference files |
+
+- An **unknown id fails loudly** at assembly time — a typo never silently drops a
+  section.
+- If you remove the whole `sections:` key, the runner falls back to
+  `core.prompt_sections.DEFAULT_SECTIONS` (this same order).
+
+### `reflection_strings:` — the self-repair wording (loop 2)
+When an attempt fails the deliverable contract, the runner feeds a focused
+`[REFLECTION] … [/REFLECTION]` block back to the model. The *wording* lives here;
+the *layout* and safety limits (≤12 blocking errors, ≤6 warnings, prior code echoed
+when ≤4000 chars, host paths redacted) stay in Python.
+
+```yaml
+reflection_strings:
+  open: "[REFLECTION]"
+  intro: >-
+    Your previous attempt did NOT satisfy the deliverable contract. Regenerate
+    the COMPLETE solution and fix every issue below.
+  blocking_header: "Blocking problems to fix:"
+  warnings_header: "Secondary warnings (address if relevant):"
+  stdout_header: "Previous stdout (tail):"
+  stderr_header: "Previous stderr/error (tail):"
+  code_header: "Your previous code (fix and resend in full):"
+  code_fence: "----"
+  close: "[/REFLECTION]"
+```
+
+Any key you omit falls back to the built-in default
+(`core.sandbox_runner._DEFAULT_REFLECTION_STRINGS`). **Quote** values that begin
+with `[` or YAML will read them as a list.
+
+### `perception_analysis` placement
+Host audio/video analysis (the `[AUDIO ANALYSIS] … ` / `[VIDEO ANALYSIS] …` block
+from the preprocessors) is injected as its own section. The analyzers own their
+labels; the spec owns *where* the block sits. Move the `perception_analysis` line
+to reposition it. It is dropped automatically when no perception ran.
+
+---
+
+## 3. A/B a whole prompt without touching Python
+
+To try an alternative prompt design, copy the spec to a new name, edit it, and
+point the experiment condition at it — no code change:
+
+```bash
+cp prompts/sandbox_occupation_codegen.yaml prompts/sandbox_codegen_variantB.yaml
+# edit prompts/sandbox_codegen_variantB.yaml
+```
+
+```yaml
+# in your experiment YAML, under the sandbox condition:
+execution:
+  mode: "sandbox"
+  sandbox:
+    prompt_name: "sandbox_codegen_variantB"   # selects the alternate spec
+```
+
+Selection order in `core/executor.py`: explicit `prompt_name` →
+`execution.sandbox.prompt_name` → `SandboxRunner.DEFAULT_PROMPT`
+(`sandbox_occupation_codegen`).
+
+---
+
+## 4. Safety net: the golden tests
+
+`tests/test_sandbox_prompt_golden.py` freezes the exact assembled prompt for four
+representative tasks (audio, 4K video, doc-only, spreadsheet), the repair
+reflection, and a perception + repair combination. `tests/test_prompt_sections.py`
+covers the section engine (ordering, toggles, unknown-id failure).
+
+When you **intentionally** change the wording or order, regenerate the snapshots
+and review the diff before committing:
+
+```bash
+cd batch-runner
+REGEN_PROMPT_GOLDEN=1 python -m pytest tests/test_sandbox_prompt_golden.py
+git diff -- tests/fixtures/prompt/golden/   # eyeball the wording/order change
+```
+
+If a diff appears that you did **not** intend, you changed the prompt by accident —
+revert instead of regenerating.
+
+---
+
+## 5. What stays in Python (and why)
+
+- **Section builders** (`file_preview`, `skills_registry`, `deliverable_contract`,
+  `dependency_resolver`) — these compute content from the task/files; the spec only
+  orders their output.
+- **Reflection layout + limits** — bounded slicing keeps the repair prompt focused.
+- **Path redaction** (`_sanitize_tail`) — stdout/stderr tails and paths are
+  sanitized so the prompt never leaks host filesystem layout.
+
+Everything else — the words the model reads and the order it reads them in — is in
+the spec file. Edit there.

--- a/batch-runner/sandbox/Dockerfile
+++ b/batch-runner/sandbox/Dockerfile
@@ -1,0 +1,76 @@
+# GDPVal Sandbox Image — skill-aware, multimodal code-execution container.
+#
+# This image is the execution backend for `execution.mode: sandbox`. It bakes in
+# the same Python dependencies the CI host installs (batch-runner/requirements.txt)
+# plus the system libraries those packages need (ffmpeg, poppler, tesseract,
+# libreoffice, graphviz, GDAL/GEOS, weasyprint stack, …) so that LLM-generated
+# `solution.py` runs identically whether it touches audio, video, documents,
+# images, geo data, or ML.
+#
+# Build (from batch-runner/):   bash sandbox/build.sh
+# Pin Python to 3.11 to match the GitHub Actions runner.
+FROM python:3.11-slim-bookworm
+
+LABEL org.opencontainers.image.title="gdpval-sandbox" \
+      org.opencontainers.image.description="Skill-aware multimodal sandbox for GDPVal solving" \
+      org.opencontainers.image.source="https://github.com/hyeonsangjeon/gdpval-realworks"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    MPLBACKEND=Agg
+
+# ── System libraries ────────────────────────────────────────────────────────
+# Grouped by the Python packages that require them.
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+      # build toolchain (pygraphviz, h5py, native wheels)
+      build-essential pkg-config gfortran \
+      # audio / video  (librosa, soundfile, pydub, moviepy, av, ffmpeg-python)
+      ffmpeg libsndfile1 \
+      # opencv runtime
+      libgl1 libglib2.0-0 \
+      # documents / pdf  (pdfplumber, pdf2image, camelot, tabula, pypandoc)
+      poppler-utils pandoc default-jre-headless \
+      # office conversion (docx/pptx/xlsx ↔ pdf)
+      libreoffice \
+      # ocr / barcodes  (pytesseract, pyzbar)
+      tesseract-ocr libzbar0 \
+      # html → pdf/png  (weasyprint, pdfkit, imgkit, cairosvg)
+      libcairo2 libcairo2-dev libpango-1.0-0 libpangocairo-1.0-0 \
+      libgdk-pixbuf-2.0-0 libffi-dev wkhtmltopdf \
+      # graphs  (pygraphviz, pydot)
+      graphviz libgraphviz-dev \
+      # geo  (geopandas, fiona, rasterio, shapely, pyproj)
+      gdal-bin libgdal-dev libgeos-dev libproj-dev proj-bin proj-data \
+      # scientific i/o  (h5py, tables)
+      libhdf5-dev \
+      # xml / lxml, pillow
+      libxml2-dev libxslt1-dev libjpeg-dev zlib1g-dev \
+      # tts  (pyttsx3)
+      espeak-ng \
+      # fonts for rendered deliverables
+      fonts-dejavu fonts-liberation fonts-noto-cjk \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Python dependencies ─────────────────────────────────────────────────────
+# Copy only requirements first to maximize Docker layer caching.
+COPY requirements.txt /tmp/requirements.txt
+RUN python -m pip install --upgrade pip setuptools wheel \
+    && pip install -r /tmp/requirements.txt \
+    && rm -f /tmp/requirements.txt
+
+# ── Skills (baked-in fallback) ──────────────────────────────────────────────
+# The runner also bind-mounts skills/ into the work dir, but baking them here
+# guarantees `import skills` works even if the mount is skipped.
+COPY skills /opt/gdpval/skills
+ENV PYTHONPATH=/opt/gdpval
+
+# ── Working directory ───────────────────────────────────────────────────────
+# The runner bind-mounts a per-task tmpdir onto /work and runs solution.py here.
+RUN mkdir -p /work
+WORKDIR /work
+
+CMD ["python", "-u", "solution.py"]

--- a/batch-runner/sandbox/README.md
+++ b/batch-runner/sandbox/README.md
@@ -1,0 +1,77 @@
+# GDPVal Sandbox Image
+
+Skill-aware, multimodal **container sandbox** for the `execution.mode: sandbox`
+solving path. It is the container evolution of `subprocess` mode.
+
+## What it provides
+
+- **Isolation** — generated `solution.py` runs in a throwaway container with
+  `--network none`, a memory cap (`--memory`), `--pids-limit`, and
+  `--security-opt no-new-privileges`.
+- **Batteries included** — bakes in `batch-runner/requirements.txt` plus the
+  system libraries those packages need (ffmpeg, poppler, tesseract, libreoffice,
+  graphviz, GDAL/GEOS, the weasyprint stack, espeak-ng, CJK fonts, …) so audio,
+  video, document, image, geo, and ML tasks all run.
+- **Skills** — the `skills/` package is baked into `/opt/gdpval` (and also
+  bind-mounted into the work dir), giving generated code *vision* (video
+  frame-by-frame, image OCR) and *hearing* (audio FFT / sampling / loudness).
+
+## Build
+
+From the `batch-runner/` directory (build context must be `batch-runner/`):
+
+```bash
+bash sandbox/build.sh
+# or a custom tag:
+SANDBOX_IMAGE=myrepo/gdpval-sandbox:1.0 bash sandbox/build.sh
+```
+
+This produces `gdpval-sandbox:latest` (override with `SANDBOX_IMAGE`).
+
+> ⚠️ The image is large (LibreOffice, GDAL, full scientific stack). The first
+> build takes a while; subsequent builds reuse cached layers.
+
+## How the runner uses it
+
+`core/sandbox_runner.py` decides at runtime via `execution.sandbox.use_docker`:
+
+| `use_docker` | Behavior |
+|---|---|
+| `auto` (default) | Use Docker **if** the daemon is up and the image exists; otherwise fall back to the hardened in-process subprocess sandbox (with a warning). |
+| `never` | Always use the local subprocess fallback (handy for laptops/CI without Docker). |
+| `always` | Require Docker + image; error if either is missing. |
+
+For each task the runner:
+
+1. Selects relevant **skills** and resolves the **pip dependencies** the task
+   needs (from reference-file extensions, task keywords, and the generated
+   code's imports).
+2. Copies reference files and the `skills/` package into a temp dir.
+3. Writes `solution.py` and runs it as
+   `docker run --rm --network none … gdpval-sandbox:latest python -u solution.py`.
+4. Collects newly created files (excluding inputs, the script, and `skills/`) as
+   deliverables.
+
+## Configure in an experiment YAML
+
+```yaml
+execution:
+  mode: sandbox
+  sandbox:
+    image: gdpval-sandbox:latest   # or your custom tag
+    use_docker: auto               # auto | never | always
+    memory_gb: 5
+    cpus: 2.0                       # optional CPU cap
+    max_skills: 5                  # skill manuals injected into the prompt
+```
+
+The same `SANDBOX_IMAGE` env var read by `build.sh` is also the default image
+the runner looks for, so they stay in sync.
+
+## Security posture
+
+The threat model is *untrusted, LLM-generated code*. Isolation comes from the
+container namespaces, no network, and the resource caps above. Code runs as the
+image's default user inside a disposable container that is removed (`--rm`) after
+each task. When Docker is unavailable the local fallback still applies the
+existing subprocess hardening (isolated temp dir, restricted execution).

--- a/batch-runner/sandbox/README.md
+++ b/batch-runner/sandbox/README.md
@@ -45,12 +45,23 @@ For each task the runner:
 
 1. Selects relevant **skills** and resolves the **pip dependencies** the task
    needs (from reference-file extensions, task keywords, and the generated
-   code's imports).
-2. Copies reference files and the `skills/` package into a temp dir.
-3. Writes `solution.py` and runs it as
+   code's imports), and probes which are importable in the environment.
+2. Infers a deterministic **deliverable contract** (expected file types/count)
+   and injects it into the codegen prompt so the model knows what to produce.
+3. Copies reference files and the `skills/` package into a temp dir.
+4. Writes `solution.py` and runs it as
    `docker run --rm --network none … gdpval-sandbox:latest python -u solution.py`.
-4. Collects newly created files (excluding inputs, the script, and `skills/`) as
-   deliverables.
+5. Selects the **generated artifacts** (reference files and the script are
+   excluded via a before/after snapshot), then **verifies** them (non-empty,
+   openable, correct type) and runs **render QA** (PDF/Office rasterized to PNG
+   with blank-page detection; optional LLM vision QA behind config).
+6. If a blocking failure is found and repair is enabled, builds a focused
+   **repair prompt** with the concrete failure and retries (bounded; default 1).
+7. Writes a `manifest.json` (contract, dependency probe, per-attempt status,
+   verification/render reports, and `final_status`) alongside the deliverables.
+
+Skills give the sandbox eyes/ears on the **inputs**; the contract + verifier +
+render QA + repair loop verify and fix the **outputs**.
 
 ## Configure in an experiment YAML
 
@@ -63,6 +74,24 @@ execution:
     memory_gb: 5
     cpus: 2.0                       # optional CPU cap
     max_skills: 5                  # skill manuals injected into the prompt
+    repair:                        # bounded output repair loop
+      enabled: true
+      max_attempts: 1              # repair retries after attempt 0
+    output_qa:                     # verify + render generated deliverables
+      enabled: true
+      render: true                 # rasterize PDF/Office to PNG for QA
+      max_pages_per_artifact: 3
+      blank_page_threshold: 0.999  # per-page near-white warning ratio
+      vision:                      # optional LLM vision QA (off by default)
+        enabled: false
+        provider: azure
+        deployment: gpt-5.4
+        max_images: 6
+    manifest:                      # per-run manifest.json
+      enabled: true
+      filename: manifest.json
+    cache:                         # cache rendered PNGs / perception by sha256
+      enabled: true
 ```
 
 The same `SANDBOX_IMAGE` env var read by `build.sh` is also the default image

--- a/batch-runner/sandbox/README.md
+++ b/batch-runner/sandbox/README.md
@@ -31,6 +31,42 @@ This produces `gdpval-sandbox:latest` (override with `SANDBOX_IMAGE`).
 > ⚠️ The image is large (LibreOffice, GDAL, full scientific stack). The first
 > build takes a while; subsequent builds reuse cached layers.
 
+### Rebuild & arm64 recovery
+
+If Docker Desktop is reset (or the image is pruned), `gdpval-sandbox:latest`
+must be rebuilt before any Docker-backed run — `use_docker: auto` will otherwise
+fall back to the local subprocess sandbox. Rebuild with `bash sandbox/build.sh`
+from `batch-runner/`.
+
+**Known arm64 (Apple Silicon) blocker:** `requirements.txt` pins
+`aspose-words>=25.0.0`, which ships **no arm64 wheel**, so a native `arm64`
+build fails at that layer. Options for local verification on Apple Silicon:
+
+- Build for amd64 under emulation: `docker build --platform linux/amd64 …`
+  (slower, but matches CI), **or**
+- Build a temporary **trimmed** image with `aspose-words` removed from a scratch
+  copy of `requirements.txt` (only `.docx` via `aspose-words` is affected;
+  `python-docx`/LibreOffice paths still work). Do **not** commit the trimmed
+  requirements.
+- After a local `buildx` build, if `docker image inspect gdpval-sandbox:latest`
+  can't see the image (classic-store registration quirk), re-register it with
+  `docker tag <image-id> gdpval-sandbox:latest`.
+
+CI runners (`ubuntu-latest`, amd64) build the full image without this blocker.
+
+## Host-side perception dependencies (video preprocessing)
+
+The audio/video **preprocessors** run on the **host/orchestrator**, not inside
+the sandbox. Audio analysis only base64-encodes the file, but **video** frame
+sampling needs a frame backend — `opencv-python` (`cv2`) or `av` (PyAV), both
+pinned in `batch-runner/requirements.txt`. If neither is importable on the host,
+`video_analyzer` silently no-ops and no frames are ever sent to the model.
+
+`step2_run_inference.py` prints a one-time **preflight warning** at startup when
+a `video_analyzer` preprocessor is configured but no host frame backend is
+found, so a hybrid run never silently skips video perception. Install the host
+perception deps (`pip install -r requirements.txt`) to enable it.
+
 ## How the runner uses it
 
 `core/sandbox_runner.py` decides at runtime via `execution.sandbox.use_docker`:

--- a/batch-runner/sandbox/README.md
+++ b/batch-runner/sandbox/README.md
@@ -99,6 +99,13 @@ For each task the runner:
 Skills give the sandbox eyes/ears on the **inputs**; the contract + verifier +
 render QA + repair loop verify and fix the **outputs**.
 
+The codegen prompt itself — persona, rules, the order of the injected context
+blocks, the self-repair wording, and where perception is placed — is authored in a
+single spec file, `prompts/sandbox_occupation_codegen.yaml`. See
+[`prompts/sandbox_prompt_authoring.md`](../prompts/sandbox_prompt_authoring.md)
+for how to edit it (and how to A/B an alternate spec via `prompt_name` without
+touching Python).
+
 ## Configure in an experiment YAML
 
 ```yaml

--- a/batch-runner/sandbox/build.sh
+++ b/batch-runner/sandbox/build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Build the GDPVal sandbox image.
+#
+# Usage (run from the batch-runner/ directory):
+#     bash sandbox/build.sh
+#     SANDBOX_IMAGE=myrepo/gdpval-sandbox:1.0 bash sandbox/build.sh
+#
+# The build context is batch-runner/ so the Dockerfile can COPY both
+# requirements.txt and the skills/ package.
+set -euo pipefail
+
+IMAGE="${SANDBOX_IMAGE:-gdpval-sandbox:latest}"
+
+# Resolve batch-runner/ regardless of where the script is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTEXT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "🐳 Building sandbox image: ${IMAGE}"
+echo "   Context:    ${CONTEXT_DIR}"
+echo "   Dockerfile: ${SCRIPT_DIR}/Dockerfile"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "❌ docker CLI not found. Install Docker first." >&2
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "❌ Docker daemon is not running. Start Docker and retry." >&2
+  exit 1
+fi
+
+docker build \
+  -f "${SCRIPT_DIR}/Dockerfile" \
+  -t "${IMAGE}" \
+  "${CONTEXT_DIR}"
+
+echo "✅ Built ${IMAGE}"
+echo "   Set execution.mode: sandbox in your experiment YAML to use it."

--- a/batch-runner/skills/README.md
+++ b/batch-runner/skills/README.md
@@ -1,0 +1,46 @@
+# GDPVal Sandbox Skills
+
+Famous-library **Agent Skills** that give the sandbox *vision* and *hearing* so
+LLM-generated `solution.py` can perceive multimodal reference files and build
+deliverables instead of coding blind.
+
+| Skill | Modality | Famous libraries | What it does |
+|-------|----------|------------------|--------------|
+| [`audio`](audio/SKILL.md) | 🔊 hearing | librosa, soundfile, scipy, pyloudnorm | FFT / spectral peaks, spectrogram, sampling, loudness (LUFS), tempo, synthesis |
+| [`video`](video/SKILL.md) | 👁 vision | opencv-python, PyAV, moviepy, Pillow | frame-by-frame sampling, keyframes, scene-change detection, metadata, audio track extraction, contact-sheet montage |
+| [`document`](document/SKILL.md) | 📄 docs | pdfplumber, PyMuPDF, python-docx, python-pptx, openpyxl | read/extract + render PDF/DOCX/PPTX/XLSX, tables, page→image |
+| [`image`](image/SKILL.md) | 🖼 vision | Pillow, opencv-python, pytesseract, pyzbar | metadata, OCR, dominant colours, QR/barcode, resize/grayscale |
+| [`data`](data/SKILL.md) | 📊 analysis | pandas, numpy, matplotlib, scikit-learn | load tables, describe, charts, correlation, linear regression |
+
+## How the sandbox uses them
+
+1. `core/skills_registry.py` parses every `SKILL.md`, then **selects** the skills
+   relevant to a task by matching reference-file extensions and task keywords.
+2. The selected skills' manuals are injected into the code-generation prompt, so
+   the model knows the exact callable API.
+3. The whole `skills/` package is copied into the sandbox working directory and
+   added to `PYTHONPATH`, so generated code can `from skills import audio, video`.
+
+## Skill format (Agent Skills)
+
+Each `SKILL.md` starts with YAML front-matter:
+
+```yaml
+---
+name: audio
+title: Audio Perception & Synthesis
+description: >-
+  One-paragraph "what + when to use" used for skill selection.
+modalities: [audio]
+file_extensions: [".wav", ".mp3", ...]
+keywords: [spectrogram, fft, loudness, ...]
+requires: [librosa, soundfile, numpy, scipy]
+version: 1.0.0
+---
+```
+
+The body documents the toolkit. The `## Toolkit API` section is extracted
+verbatim and injected into the prompt.
+
+> All heavy imports are lazy. Importing `skills` never fails; calling a helper
+> whose library is missing raises `SkillDependencyError` naming the pip package.

--- a/batch-runner/skills/__init__.py
+++ b/batch-runner/skills/__init__.py
@@ -1,0 +1,45 @@
+"""GDPVal Sandbox Skills — Agent-Skill toolkits mounted inside the sandbox.
+
+Each sub-package (``audio``, ``video``, ``document``, ``image``, ``data``) ships
+a ``SKILL.md`` (Agent-Skill metadata + usage manual) and a ``toolkit.py`` with
+runnable helper functions. The whole ``skills`` package is copied into the
+sandbox working directory and added to ``PYTHONPATH`` so LLM-generated
+``solution.py`` can simply::
+
+    from skills import audio, video, document, image, data
+
+    info = video.video_info("clip.mp4")
+    frames = video.keyframes("clip.mp4", max_frames=8)
+    peaks = audio.fft_summary("track.wav")
+
+All heavy third-party imports inside the toolkits are *lazy* — importing the
+``skills`` package never fails even when librosa / opencv / pymupdf are absent.
+Calling a function that needs a missing library raises a clear
+``SkillDependencyError`` naming the pip package to install.
+"""
+
+from __future__ import annotations
+
+
+class SkillDependencyError(ImportError):
+    """Raised when a skill helper needs a library that is not installed.
+
+    The message always names the pip package(s) to install so the dependency
+    resolver / sandbox image can be fixed.
+    """
+
+
+def _require(module: str, pip_name: str | None = None):
+    """Lazy-import ``module`` or raise a clear :class:`SkillDependencyError`."""
+    import importlib
+
+    try:
+        return importlib.import_module(module)
+    except ImportError as exc:  # pragma: no cover - exercised via toolkits
+        pkg = pip_name or module
+        raise SkillDependencyError(
+            f"Skill needs '{module}' — install with: pip install {pkg}"
+        ) from exc
+
+
+__all__ = ["SkillDependencyError", "_require"]

--- a/batch-runner/skills/audio/SKILL.md
+++ b/batch-runner/skills/audio/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: audio
+title: Audio Perception & Synthesis
+description: >-
+  Hearing for the sandbox. Use for any task with audio reference files
+  (.wav/.mp3/.flac/.ogg/.m4a/.aac/.aiff) or that asks to analyze, transcribe,
+  measure, mix, master, or generate sound. Provides FFT / spectral-peak
+  analysis, mel-spectrogram rendering, waveform sampling/decimation, integrated
+  loudness (LUFS), tempo/BPM detection, resampling, and tone/clip synthesis.
+modalities: [audio]
+file_extensions: [".wav", ".mp3", ".flac", ".ogg", ".m4a", ".aac", ".aiff"]
+keywords:
+  [audio, sound, music, voice, speech, spectrogram, fft, frequency, spectral,
+   waveform, sample rate, sampling, resample, loudness, lufs, decibel, db,
+   tempo, bpm, beat, pitch, mix, master, mono, stereo, transcribe, podcast]
+requires: [librosa, soundfile, numpy, scipy, pyloudnorm]
+version: 1.0.0
+---
+
+# Audio Skill — give the sandbox *ears*
+
+Use this skill whenever the task involves listening to or producing sound.
+Prefer these helpers over hand-rolled DSP: they wrap **librosa**, **soundfile**,
+**scipy**, and **pyloudnorm** with safe defaults.
+
+A typical "audio problem" workflow:
+
+1. `info = audio.audio_info(path)` — duration, sample rate, channels.
+2. `peaks = audio.fft_summary(path)` — dominant frequencies ("what is in it").
+3. `audio.spectrogram_png(path, "spectrogram.png")` — a visual you can ship.
+4. Decide / transform (resample, normalise loudness, mix, synthesise).
+5. Save deliverables with `audio.save_wav(...)`.
+
+## Toolkit API
+
+```python
+from skills import audio
+
+audio.audio_info(path) -> dict
+    # {sample_rate, duration_sec, channels, n_samples, frames, format}
+
+audio.load_audio(path, sr=None, mono=True) -> (numpy.ndarray, int)
+    # waveform y in [-1, 1], native sample rate unless sr given
+
+audio.fft_summary(path, top_k=8, sr=22050) -> dict
+    # rFFT magnitude spectrum -> {dominant_hz:[...], magnitudes:[...],
+    #                             spectral_centroid_hz, rms, peak_hz}
+
+audio.sample_waveform(path, n=2000) -> list[float]
+    # amplitude envelope decimated to n points (cheap "shape" of the signal)
+
+audio.spectrogram_png(path, out="spectrogram.png", n_mels=128) -> str
+    # render a mel-spectrogram PNG; returns the output path
+
+audio.loudness_lufs(path) -> float
+    # ITU-R BS.1770 integrated loudness via pyloudnorm
+
+audio.tempo_bpm(path) -> float
+    # estimated tempo (beats per minute)
+
+audio.resample(path, target_sr, out) -> str
+    # write a resampled copy
+
+audio.synth_tone(freq_hz, seconds, sr=44100, amp=0.5) -> (numpy.ndarray, int)
+audio.save_wav(y, sr, out) -> str
+```
+
+Notes:
+- `fft_summary` loads at 22.05 kHz mono by default for speed; pass `sr=None` to
+  use the file's native rate.
+- All functions accept absolute or relative paths (reference files are copied
+  into the working directory).

--- a/batch-runner/skills/audio/__init__.py
+++ b/batch-runner/skills/audio/__init__.py
@@ -1,0 +1,27 @@
+"""Audio skill — re-exports the toolkit helpers."""
+
+from skills.audio.toolkit import (  # noqa: F401
+    audio_info,
+    fft_summary,
+    load_audio,
+    loudness_lufs,
+    resample,
+    sample_waveform,
+    save_wav,
+    spectrogram_png,
+    synth_tone,
+    tempo_bpm,
+)
+
+__all__ = [
+    "audio_info",
+    "fft_summary",
+    "load_audio",
+    "loudness_lufs",
+    "resample",
+    "sample_waveform",
+    "save_wav",
+    "spectrogram_png",
+    "synth_tone",
+    "tempo_bpm",
+]

--- a/batch-runner/skills/audio/toolkit.py
+++ b/batch-runner/skills/audio/toolkit.py
@@ -1,0 +1,173 @@
+"""Audio skill toolkit — FFT / sampling / spectrogram / loudness / tempo.
+
+Hearing for the sandbox. Heavy libraries (librosa, soundfile, scipy,
+pyloudnorm) are imported lazily so importing this module never fails.
+"""
+
+from __future__ import annotations
+
+import wave
+from pathlib import Path
+from typing import List, Tuple
+
+from skills import _require
+
+__all__ = [
+    "audio_info",
+    "load_audio",
+    "fft_summary",
+    "sample_waveform",
+    "spectrogram_png",
+    "loudness_lufs",
+    "tempo_bpm",
+    "resample",
+    "synth_tone",
+    "save_wav",
+]
+
+
+def audio_info(path: str) -> dict:
+    """Return basic metadata without a heavy decode when possible.
+
+    Falls back to soundfile for non-WAV containers.
+    """
+    p = str(path)
+    suffix = Path(p).suffix.lower()
+    if suffix == ".wav":
+        try:
+            with wave.open(p, "rb") as wf:
+                sr = wf.getframerate()
+                n = wf.getnframes()
+                ch = wf.getnchannels()
+                return {
+                    "sample_rate": sr,
+                    "duration_sec": (n / sr) if sr else 0.0,
+                    "channels": ch,
+                    "n_samples": n,
+                    "frames": n,
+                    "format": "wav",
+                }
+        except Exception:
+            pass
+    sf = _require("soundfile", "soundfile")
+    info = sf.info(p)
+    return {
+        "sample_rate": info.samplerate,
+        "duration_sec": float(info.duration),
+        "channels": info.channels,
+        "n_samples": int(info.frames),
+        "frames": int(info.frames),
+        "format": info.format,
+    }
+
+
+def load_audio(path: str, sr: int | None = None, mono: bool = True) -> Tuple["object", int]:
+    """Load a waveform as a float32 numpy array in [-1, 1] plus its sample rate."""
+    librosa = _require("librosa", "librosa")
+    y, out_sr = librosa.load(str(path), sr=sr, mono=mono)
+    return y, int(out_sr)
+
+
+def fft_summary(path: str, top_k: int = 8, sr: int | None = 22050) -> dict:
+    """Dominant frequencies and spectral statistics via a real FFT."""
+    np = _require("numpy", "numpy")
+    librosa = _require("librosa", "librosa")
+    y, out_sr = librosa.load(str(path), sr=sr, mono=True)
+    if y.size == 0:
+        return {"dominant_hz": [], "magnitudes": [], "spectral_centroid_hz": 0.0,
+                "rms": 0.0, "peak_hz": 0.0, "sample_rate": out_sr}
+    spectrum = np.abs(np.fft.rfft(y))
+    freqs = np.fft.rfftfreq(y.size, d=1.0 / out_sr)
+    k = int(max(1, min(top_k, spectrum.size)))
+    top_idx = np.argsort(spectrum)[::-1][:k]
+    top_idx = top_idx[np.argsort(freqs[top_idx])]
+    centroid = float((freqs * spectrum).sum() / spectrum.sum()) if spectrum.sum() else 0.0
+    return {
+        "dominant_hz": [round(float(f), 2) for f in freqs[top_idx]],
+        "magnitudes": [round(float(m), 4) for m in spectrum[top_idx]],
+        "spectral_centroid_hz": round(centroid, 2),
+        "rms": round(float(np.sqrt(np.mean(y ** 2))), 6),
+        "peak_hz": round(float(freqs[int(np.argmax(spectrum))]), 2),
+        "sample_rate": out_sr,
+    }
+
+
+def sample_waveform(path: str, n: int = 2000) -> List[float]:
+    """Decimate the absolute amplitude envelope to ``n`` points."""
+    np = _require("numpy", "numpy")
+    librosa = _require("librosa", "librosa")
+    y, _ = librosa.load(str(path), sr=None, mono=True)
+    if y.size == 0:
+        return []
+    env = np.abs(y)
+    if env.size <= n:
+        return [round(float(v), 5) for v in env]
+    step = env.size / n
+    out = [round(float(env[min(env.size - 1, int(i * step))]), 5) for i in range(n)]
+    return out
+
+
+def spectrogram_png(path: str, out: str = "spectrogram.png", n_mels: int = 128) -> str:
+    """Render a mel-spectrogram PNG and return its path."""
+    np = _require("numpy", "numpy")
+    librosa = _require("librosa", "librosa")
+    _require("matplotlib", "matplotlib")
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    y, sr = librosa.load(str(path), sr=None, mono=True)
+    mel = librosa.feature.melspectrogram(y=y, sr=sr, n_mels=n_mels)
+    mel_db = librosa.power_to_db(mel, ref=np.max)
+    fig, ax = plt.subplots(figsize=(10, 4))
+    img = librosa.display.specshow(mel_db, sr=sr, x_axis="time", y_axis="mel", ax=ax)
+    fig.colorbar(img, ax=ax, format="%+2.0f dB")
+    ax.set_title(f"Mel spectrogram — {Path(path).name}")
+    fig.tight_layout()
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    return out
+
+
+def loudness_lufs(path: str) -> float:
+    """Integrated loudness (LUFS) per ITU-R BS.1770 via pyloudnorm."""
+    sf = _require("soundfile", "soundfile")
+    pyln = _require("pyloudnorm", "pyloudnorm")
+    data, rate = sf.read(str(path))
+    meter = pyln.Meter(rate)
+    return float(meter.integrated_loudness(data))
+
+
+def tempo_bpm(path: str) -> float:
+    """Estimate tempo (beats per minute)."""
+    librosa = _require("librosa", "librosa")
+    y, sr = librosa.load(str(path), sr=None, mono=True)
+    tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
+    try:
+        return round(float(tempo), 2)
+    except TypeError:  # numpy array
+        return round(float(tempo[0]), 2)
+
+
+def resample(path: str, target_sr: int, out: str) -> str:
+    """Write a resampled copy at ``target_sr`` and return its path."""
+    librosa = _require("librosa", "librosa")
+    sf = _require("soundfile", "soundfile")
+    y, _ = librosa.load(str(path), sr=target_sr, mono=False)
+    sf.write(out, y.T if getattr(y, "ndim", 1) > 1 else y, target_sr)
+    return out
+
+
+def synth_tone(freq_hz: float, seconds: float, sr: int = 44100, amp: float = 0.5):
+    """Synthesise a sine tone. Returns ``(y, sr)``."""
+    np = _require("numpy", "numpy")
+    t = np.linspace(0, seconds, int(sr * seconds), endpoint=False)
+    y = (amp * np.sin(2 * np.pi * freq_hz * t)).astype("float32")
+    return y, sr
+
+
+def save_wav(y, sr: int, out: str) -> str:
+    """Write a waveform to a WAV file and return its path."""
+    sf = _require("soundfile", "soundfile")
+    sf.write(out, y, sr)
+    return out

--- a/batch-runner/skills/data/SKILL.md
+++ b/batch-runner/skills/data/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: data
+title: Tabular Data Analysis
+description: >-
+  Spreadsheet / tabular analysis and charting. Use for any task with tabular
+  reference files (.csv/.xlsx/.parquet/.tsv/.json) or that asks to analyze,
+  aggregate, model, forecast, or visualize data. Wraps pandas, numpy,
+  matplotlib, and scikit-learn for loading, describing, charting, correlation,
+  and quick linear regression.
+modalities: [data]
+file_extensions: [".csv", ".tsv", ".xlsx", ".xls", ".parquet", ".json"]
+keywords:
+  [data, dataset, table, csv, excel, spreadsheet, dataframe, analysis,
+   analytics, statistics, aggregate, pivot, chart, plot, graph, histogram,
+   correlation, regression, forecast, trend, kpi, metric, model, predict]
+requires: [pandas, numpy, matplotlib, scikit-learn]
+version: 1.0.0
+---
+
+# Data Skill — analyze & visualize tables
+
+Use this skill to load tabular reference files robustly and turn them into
+analysis + charts for the deliverable.
+
+A typical "data problem" workflow:
+
+1. `df = data.read_table(path)` — load CSV/XLSX/Parquet/JSON into a DataFrame.
+2. `summary = data.describe(df)` — shape, dtypes, numeric stats, nulls.
+3. `data.quick_chart(df, x, y, kind="bar", out="chart.png")` — a shippable PNG.
+4. (optional) `data.correlation(df)` / `data.linreg(df, x, y)` for modelling.
+
+## Toolkit API
+
+```python
+from skills import data
+
+data.read_table(path, **kw) -> pandas.DataFrame   # dispatch by extension
+data.describe(df) -> dict        # {shape, columns, dtypes, numeric, null_counts}
+data.quick_chart(df, x, y=None, kind="line", out="chart.png", title=None) -> str
+data.correlation(df, out=None) -> dict   # numeric correlation matrix (+ optional PNG)
+data.linreg(df, x, y) -> dict    # {slope, intercept, r2, predict_fn_repr}
+```
+
+Notes:
+- `read_table` always returns a real `pandas.DataFrame` — inspect
+  `df.columns`/`df.dtypes` before assuming names (never hardcode columns).
+- Charts render headless (Agg backend); always `out=` to a file.

--- a/batch-runner/skills/data/__init__.py
+++ b/batch-runner/skills/data/__init__.py
@@ -1,0 +1,11 @@
+"""Data skill — re-exports the toolkit helpers."""
+
+from skills.data.toolkit import (  # noqa: F401
+    correlation,
+    describe,
+    linreg,
+    quick_chart,
+    read_table,
+)
+
+__all__ = ["correlation", "describe", "linreg", "quick_chart", "read_table"]

--- a/batch-runner/skills/data/toolkit.py
+++ b/batch-runner/skills/data/toolkit.py
@@ -1,0 +1,122 @@
+"""Data skill toolkit — load / describe / chart / model tabular data.
+
+Heavy libraries (pandas, numpy, matplotlib, scikit-learn) are imported lazily so
+importing this module never fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from skills import _require
+
+__all__ = [
+    "read_table",
+    "describe",
+    "quick_chart",
+    "correlation",
+    "linreg",
+]
+
+
+def read_table(path: str, **kw):
+    """Load a tabular file into a pandas DataFrame, dispatching by extension."""
+    pd = _require("pandas", "pandas")
+    ext = Path(path).suffix.lower()
+    if ext in (".csv", ".tsv"):
+        sep = "\t" if ext == ".tsv" else kw.pop("sep", ",")
+        return pd.read_csv(path, sep=sep, **kw)
+    if ext in (".xlsx", ".xls"):
+        return pd.read_excel(path, **kw)
+    if ext == ".parquet":
+        return pd.read_parquet(path, **kw)
+    if ext == ".json":
+        return pd.read_json(path, **kw)
+    return pd.read_csv(path, **kw)
+
+
+def describe(df) -> dict:
+    """Compact, JSON-friendly summary of a DataFrame."""
+    numeric = df.select_dtypes("number")
+    return {
+        "shape": list(df.shape),
+        "columns": [str(c) for c in df.columns],
+        "dtypes": {str(c): str(t) for c, t in df.dtypes.items()},
+        "numeric": {
+            str(c): {
+                "min": float(numeric[c].min()) if not numeric[c].empty else None,
+                "max": float(numeric[c].max()) if not numeric[c].empty else None,
+                "mean": float(numeric[c].mean()) if not numeric[c].empty else None,
+            }
+            for c in numeric.columns
+        },
+        "null_counts": {str(c): int(df[c].isna().sum()) for c in df.columns},
+    }
+
+
+def quick_chart(df, x, y=None, kind: str = "line", out: str = "chart.png",
+                title: Optional[str] = None) -> str:
+    """Render a quick chart to PNG and return its path."""
+    _require("matplotlib", "matplotlib")
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    if kind == "hist":
+        df[x].plot(kind="hist", ax=ax)
+    elif y is None:
+        df[x].plot(kind=kind, ax=ax)
+    else:
+        df.plot(x=x, y=y, kind=kind, ax=ax)
+    ax.set_title(title or f"{kind} chart")
+    fig.tight_layout()
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    return out
+
+
+def correlation(df, out: Optional[str] = None) -> dict:
+    """Numeric correlation matrix, optionally rendered to a heatmap PNG."""
+    numeric = df.select_dtypes("number")
+    corr = numeric.corr()
+    if out:
+        _require("matplotlib", "matplotlib")
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots(figsize=(8, 7))
+        im = ax.imshow(corr.values, cmap="coolwarm", vmin=-1, vmax=1)
+        ax.set_xticks(range(len(corr.columns)))
+        ax.set_xticklabels(corr.columns, rotation=90)
+        ax.set_yticks(range(len(corr.columns)))
+        ax.set_yticklabels(corr.columns)
+        fig.colorbar(im, ax=ax)
+        fig.tight_layout()
+        fig.savefig(out, dpi=120)
+        plt.close(fig)
+    return {str(c): {str(k): round(float(v), 4) for k, v in row.items()}
+            for c, row in corr.to_dict().items()}
+
+
+def linreg(df, x, y) -> dict:
+    """Fit a 1-D ordinary least squares regression of ``y`` on ``x``."""
+    np = _require("numpy", "numpy")
+    _require("sklearn", "scikit-learn")
+    from sklearn.linear_model import LinearRegression
+    from sklearn.metrics import r2_score
+
+    sub = df[[x, y]].dropna()
+    xv = sub[[x]].to_numpy(dtype=float)
+    yv = sub[y].to_numpy(dtype=float)
+    model = LinearRegression().fit(xv, yv)
+    pred = model.predict(xv)
+    return {
+        "slope": float(model.coef_[0]),
+        "intercept": float(model.intercept_),
+        "r2": float(r2_score(yv, pred)),
+        "n": int(len(sub)),
+        "predict_fn_repr": f"y = {float(model.coef_[0]):.6g} * {x} + {float(model.intercept_):.6g}",
+    }

--- a/batch-runner/skills/document/SKILL.md
+++ b/batch-runner/skills/document/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: document
+title: Document Reading & Authoring
+description: >-
+  Read and author office documents. Use for any task with document reference
+  files (.pdf/.docx/.pptx/.xlsx/.csv) or that asks to produce reports,
+  contracts, decks, spreadsheets, or memos. Extracts text and tables, renders
+  PDF pages to images for visual inspection, and provides thin builders for
+  DOCX/PDF/PPTX/XLSX deliverables.
+modalities: [document]
+file_extensions:
+  [".pdf", ".docx", ".doc", ".pptx", ".ppt", ".xlsx", ".xls", ".csv", ".rtf", ".odt"]
+keywords:
+  [document, report, memo, contract, brief, letter, deck, slide, presentation,
+   spreadsheet, workbook, table, pdf, docx, pptx, xlsx, invoice, statement,
+   form, page, paragraph, heading]
+requires: [pdfplumber, PyMuPDF, python-docx, python-pptx, openpyxl, pandas]
+version: 1.0.0
+---
+
+# Document Skill — read & write office files
+
+Use this skill to *read* reference documents accurately (exact text, tables,
+and — via page images — layout) and to *author* polished deliverables.
+
+A typical "document problem" workflow:
+
+1. `text = document.read_any(path)` — extract text from PDF/DOCX/PPTX/XLSX/CSV.
+2. `tables = document.pdf_tables(path)` — pull tabular data from PDFs.
+3. (visual check) `imgs = document.pdf_to_images(path)` — render pages to PNG so
+   the vision layer / `image` skill can inspect layout, charts, signatures.
+4. Build the deliverable with the appropriate builder.
+
+## Toolkit API
+
+```python
+from skills import document
+
+document.read_any(path) -> str            # auto-dispatch by extension
+document.read_pdf_text(path) -> str       # pdfplumber text
+document.pdf_tables(path) -> list[list[list]]   # tables per page
+document.pdf_to_images(path, out_dir="pages", dpi=150) -> list[str]  # PyMuPDF
+document.read_docx(path) -> str
+document.read_pptx(path) -> list[str]     # text per slide
+document.read_xlsx(path) -> dict          # {sheet: [rows...]}
+
+document.make_docx(title, paragraphs, out) -> str
+document.make_pdf(title, lines, out) -> str
+document.make_pptx(title, slides, out) -> str   # slides = [(heading, [bullets])]
+document.make_xlsx(sheets, out) -> str          # sheets = {name: [rows...]}
+```
+
+Notes:
+- `pdf_to_images` is the bridge to *vision*: render pages, then inspect them with
+  the `image` skill (OCR / colours) or describe them.
+- Builders are intentionally thin — for rich formatting use python-docx /
+  python-pptx / reportlab / openpyxl directly (all pre-installed).

--- a/batch-runner/skills/document/__init__.py
+++ b/batch-runner/skills/document/__init__.py
@@ -1,0 +1,29 @@
+"""Document skill — re-exports the toolkit helpers."""
+
+from skills.document.toolkit import (  # noqa: F401
+    make_docx,
+    make_pdf,
+    make_pptx,
+    make_xlsx,
+    pdf_tables,
+    pdf_to_images,
+    read_any,
+    read_docx,
+    read_pdf_text,
+    read_pptx,
+    read_xlsx,
+)
+
+__all__ = [
+    "make_docx",
+    "make_pdf",
+    "make_pptx",
+    "make_xlsx",
+    "pdf_tables",
+    "pdf_to_images",
+    "read_any",
+    "read_docx",
+    "read_pdf_text",
+    "read_pptx",
+    "read_xlsx",
+]

--- a/batch-runner/skills/document/toolkit.py
+++ b/batch-runner/skills/document/toolkit.py
@@ -1,0 +1,168 @@
+"""Document skill toolkit — read & author PDF/DOCX/PPTX/XLSX/CSV.
+
+Heavy libraries (pdfplumber, fitz/PyMuPDF, docx, pptx, openpyxl) are imported
+lazily so importing this module never fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from skills import _require
+
+__all__ = [
+    "read_any",
+    "read_pdf_text",
+    "pdf_tables",
+    "pdf_to_images",
+    "read_docx",
+    "read_pptx",
+    "read_xlsx",
+    "make_docx",
+    "make_pdf",
+    "make_pptx",
+    "make_xlsx",
+]
+
+
+def read_any(path: str) -> str:
+    """Auto-dispatch text extraction by file extension."""
+    ext = Path(path).suffix.lower()
+    if ext == ".pdf":
+        return read_pdf_text(path)
+    if ext in (".docx", ".doc"):
+        return read_docx(path)
+    if ext in (".pptx", ".ppt"):
+        return "\n\n".join(read_pptx(path))
+    if ext in (".xlsx", ".xls"):
+        rows = read_xlsx(path)
+        return "\n\n".join(
+            f"# {sheet}\n" + "\n".join("\t".join(str(c) for c in r) for r in data)
+            for sheet, data in rows.items()
+        )
+    if ext == ".csv":
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    return Path(path).read_text(encoding="utf-8", errors="replace")
+
+
+def read_pdf_text(path: str) -> str:
+    pdfplumber = _require("pdfplumber", "pdfplumber")
+    out: List[str] = []
+    with pdfplumber.open(str(path)) as pdf:
+        for page in pdf.pages:
+            out.append(page.extract_text() or "")
+    return "\n\n".join(out)
+
+
+def pdf_tables(path: str) -> List[List[List]]:
+    """Return a list (one per page) of extracted tables."""
+    pdfplumber = _require("pdfplumber", "pdfplumber")
+    tables: List[List[List]] = []
+    with pdfplumber.open(str(path)) as pdf:
+        for page in pdf.pages:
+            for tbl in page.extract_tables() or []:
+                tables.append(tbl)
+    return tables
+
+
+def pdf_to_images(path: str, out_dir: str = "pages", dpi: int = 150) -> List[str]:
+    """Render each PDF page to a PNG via PyMuPDF; return saved paths."""
+    import os
+
+    fitz = _require("fitz", "PyMuPDF")
+    os.makedirs(out_dir, exist_ok=True)
+    saved: List[str] = []
+    doc = fitz.open(str(path))
+    zoom = dpi / 72.0
+    mat = fitz.Matrix(zoom, zoom)
+    for i, page in enumerate(doc):
+        pix = page.get_pixmap(matrix=mat)
+        out = os.path.join(out_dir, f"page_{i + 1:03d}.png")
+        pix.save(out)
+        saved.append(out)
+    doc.close()
+    return saved
+
+
+def read_docx(path: str) -> str:
+    docx = _require("docx", "python-docx")
+    doc = docx.Document(str(path))
+    return "\n".join(p.text for p in doc.paragraphs)
+
+
+def read_pptx(path: str) -> List[str]:
+    pptx = _require("pptx", "python-pptx")
+    prs = pptx.Presentation(str(path))
+    slides: List[str] = []
+    for slide in prs.slides:
+        texts = [shape.text for shape in slide.shapes if shape.has_text_frame]
+        slides.append("\n".join(texts))
+    return slides
+
+
+def read_xlsx(path: str) -> Dict[str, List[list]]:
+    openpyxl = _require("openpyxl", "openpyxl")
+    wb = openpyxl.load_workbook(str(path), data_only=True, read_only=True)
+    out: Dict[str, List[list]] = {}
+    for ws in wb.worksheets:
+        out[ws.title] = [list(row) for row in ws.iter_rows(values_only=True)]
+    wb.close()
+    return out
+
+
+def make_docx(title: str, paragraphs: List[str], out: str) -> str:
+    docx = _require("docx", "python-docx")
+    doc = docx.Document()
+    doc.add_heading(title, 0)
+    for para in paragraphs:
+        doc.add_paragraph(para)
+    doc.save(out)
+    return out
+
+
+def make_pdf(title: str, lines: List[str], out: str) -> str:
+    _require("reportlab", "reportlab")
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import getSampleStyleSheet
+    from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer
+
+    styles = getSampleStyleSheet()
+    doc = SimpleDocTemplate(out, pagesize=letter)
+    flow = [Paragraph(title, styles["Title"]), Spacer(1, 12)]
+    for line in lines:
+        flow.append(Paragraph(line, styles["BodyText"]))
+        flow.append(Spacer(1, 6))
+    doc.build(flow)
+    return out
+
+
+def make_pptx(title: str, slides: List[tuple], out: str) -> str:
+    """slides = [(heading, [bullet, ...]), ...]."""
+    pptx = _require("pptx", "python-pptx")
+    prs = pptx.Presentation()
+    title_layout = prs.slide_layouts[0]
+    s = prs.slides.add_slide(title_layout)
+    s.shapes.title.text = title
+    bullet_layout = prs.slide_layouts[1]
+    for heading, bullets in slides:
+        slide = prs.slides.add_slide(bullet_layout)
+        slide.shapes.title.text = heading
+        body = slide.placeholders[1].text_frame
+        for i, b in enumerate(bullets):
+            (body.paragraphs[0] if i == 0 else body.add_paragraph()).text = str(b)
+    prs.save(out)
+    return out
+
+
+def make_xlsx(sheets: Dict[str, List[list]], out: str) -> str:
+    """sheets = {sheet_name: [[row], [row], ...]}."""
+    openpyxl = _require("openpyxl", "openpyxl")
+    wb = openpyxl.Workbook()
+    wb.remove(wb.active)
+    for name, rows in sheets.items():
+        ws = wb.create_sheet(title=str(name)[:31])
+        for row in rows:
+            ws.append(list(row))
+    wb.save(out)
+    return out

--- a/batch-runner/skills/image/SKILL.md
+++ b/batch-runner/skills/image/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: image
+title: Image Perception
+description: >-
+  Vision for still images. Use for any task with image reference files
+  (.png/.jpg/.jpeg/.webp/.bmp/.tiff/.gif) or that asks to read text from an
+  image (OCR), analyze colours, detect QR/barcodes, or transform pictures.
+  Provides metadata, OCR, dominant-colour extraction, QR/barcode reading, and
+  resize/grayscale/thumbnail helpers.
+modalities: [image]
+file_extensions: [".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tiff", ".tif", ".gif"]
+keywords:
+  [image, picture, photo, png, jpg, jpeg, logo, screenshot, scan, ocr, text in
+   image, colour, color, palette, qr, barcode, thumbnail, resize, crop, chart
+   image, diagram]
+requires: [Pillow, opencv-python, pytesseract, pyzbar, numpy]
+version: 1.0.0
+---
+
+# Image Skill — read & transform pictures
+
+Use this skill to *see* still images: read embedded text, measure colours,
+decode QR/barcodes, and produce transformed image deliverables.
+
+A typical "image problem" workflow:
+
+1. `info = image.image_info(path)` — size, mode, format.
+2. `text = image.ocr_text(path)` — pull any text in the picture.
+3. `colors = image.dominant_colors(path)` — brand/palette analysis.
+4. Transform / annotate and save the deliverable.
+
+## Toolkit API
+
+```python
+from skills import image
+
+image.image_info(path) -> dict          # {width, height, mode, format, size_kb}
+image.ocr_text(path, lang="eng") -> str # pytesseract OCR
+image.dominant_colors(path, k=5) -> list[tuple[int,int,int]]
+image.read_codes(path) -> list[dict]    # QR / barcode payloads via pyzbar
+image.to_grayscale(path, out) -> str
+image.resize(path, width, out) -> str   # keep aspect ratio
+image.thumbnail(path, max_px=256, out=None) -> str
+```
+
+Notes:
+- OCR needs the system `tesseract` binary (present in the sandbox image).
+- `dominant_colors` uses k-means over down-sampled pixels (OpenCV).

--- a/batch-runner/skills/image/__init__.py
+++ b/batch-runner/skills/image/__init__.py
@@ -1,0 +1,21 @@
+"""Image skill — re-exports the toolkit helpers."""
+
+from skills.image.toolkit import (  # noqa: F401
+    dominant_colors,
+    image_info,
+    ocr_text,
+    read_codes,
+    resize,
+    thumbnail,
+    to_grayscale,
+)
+
+__all__ = [
+    "dominant_colors",
+    "image_info",
+    "ocr_text",
+    "read_codes",
+    "resize",
+    "thumbnail",
+    "to_grayscale",
+]

--- a/batch-runner/skills/image/toolkit.py
+++ b/batch-runner/skills/image/toolkit.py
@@ -1,0 +1,100 @@
+"""Image skill toolkit — metadata / OCR / colours / QR-barcode / transforms.
+
+Heavy libraries (PIL, cv2, pytesseract, pyzbar) are imported lazily so importing
+this module never fails.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from skills import _require
+
+__all__ = [
+    "image_info",
+    "ocr_text",
+    "dominant_colors",
+    "read_codes",
+    "to_grayscale",
+    "resize",
+    "thumbnail",
+]
+
+
+def image_info(path: str) -> dict:
+    Image = _require("PIL.Image", "Pillow")
+    with Image.open(str(path)) as im:
+        return {
+            "width": im.width,
+            "height": im.height,
+            "mode": im.mode,
+            "format": im.format,
+            "size_kb": round(os.path.getsize(path) / 1024, 1),
+        }
+
+
+def ocr_text(path: str, lang: str = "eng") -> str:
+    pytesseract = _require("pytesseract", "pytesseract")
+    Image = _require("PIL.Image", "Pillow")
+    with Image.open(str(path)) as im:
+        return pytesseract.image_to_string(im, lang=lang)
+
+
+def dominant_colors(path: str, k: int = 5) -> List[Tuple[int, int, int]]:
+    cv2 = _require("cv2", "opencv-python")
+    np = _require("numpy", "numpy")
+    img = cv2.imread(str(path))
+    if img is None:
+        raise ValueError(f"could not read image: {path}")
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    small = cv2.resize(img, (100, 100), interpolation=cv2.INTER_AREA)
+    pixels = small.reshape(-1, 3).astype("float32")
+    criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 20, 1.0)
+    k = max(1, min(k, len(pixels)))
+    _, labels, centers = cv2.kmeans(pixels, k, None, criteria, 3,
+                                    cv2.KMEANS_PP_CENTERS)
+    counts = np.bincount(labels.flatten(), minlength=k)
+    order = np.argsort(counts)[::-1]
+    return [tuple(int(v) for v in centers[i]) for i in order]
+
+
+def read_codes(path: str) -> List[dict]:
+    """Decode QR codes / barcodes via pyzbar."""
+    pyzbar = _require("pyzbar.pyzbar", "pyzbar")
+    Image = _require("PIL.Image", "Pillow")
+    with Image.open(str(path)) as im:
+        results = pyzbar.decode(im)
+    return [
+        {
+            "type": r.type,
+            "data": r.data.decode("utf-8", errors="replace"),
+            "rect": tuple(r.rect),
+        }
+        for r in results
+    ]
+
+
+def to_grayscale(path: str, out: str) -> str:
+    Image = _require("PIL.Image", "Pillow")
+    with Image.open(str(path)) as im:
+        im.convert("L").save(out)
+    return out
+
+
+def resize(path: str, width: int, out: str) -> str:
+    Image = _require("PIL.Image", "Pillow")
+    with Image.open(str(path)) as im:
+        ratio = width / im.width
+        im.resize((width, max(1, int(im.height * ratio)))).save(out)
+    return out
+
+
+def thumbnail(path: str, max_px: int = 256, out: Optional[str] = None) -> str:
+    Image = _require("PIL.Image", "Pillow")
+    out = out or f"thumb_{Path(path).stem}.png"
+    with Image.open(str(path)) as im:
+        im.thumbnail((max_px, max_px))
+        im.save(out)
+    return out

--- a/batch-runner/skills/video/SKILL.md
+++ b/batch-runner/skills/video/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: video
+title: Video Perception (frame-by-frame vision)
+description: >-
+  Vision for the sandbox. Use for any task with video reference files
+  (.mp4/.mov/.avi/.mkv/.webm/.m4v) or that asks to watch, summarize, caption,
+  storyboard, extract clips/frames, or analyze footage. Reads video
+  frame-by-frame: metadata (fps/resolution/duration), uniform keyframe
+  sampling, per-second frame extraction, scene-change detection, audio-track
+  extraction, and contact-sheet montage rendering.
+modalities: [video]
+file_extensions: [".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v", ".mpg", ".mpeg"]
+keywords:
+  [video, footage, clip, movie, film, frame, frames, frame-by-frame, keyframe,
+   scene, shot, storyboard, caption, subtitle, fps, resolution, timeline,
+   montage, thumbnail, screencast, recording]
+requires: [opencv-python, av, moviepy, numpy, Pillow]
+version: 1.0.0
+---
+
+# Video Skill — give the sandbox *eyes*
+
+Use this skill whenever the task involves watching or producing video. The
+helpers wrap **opencv-python** (cv2), **PyAV**, **moviepy**, and **Pillow** so
+you can look at footage *frame by frame* instead of guessing.
+
+A typical "video problem" workflow:
+
+1. `info = video.video_info(path)` — fps, frame count, duration, resolution.
+2. `frames = video.keyframes(path, max_frames=8)` — evenly spaced stills to
+   "see" the whole clip.
+3. (optional) `cuts = video.scene_changes(path)` — where the content jumps.
+4. (optional) `video.extract_audio(path, "audio.wav")` then use the `audio` skill.
+5. Build the deliverable (storyboard PNG via `montage`, captions, summary doc).
+
+## Toolkit API
+
+```python
+from skills import video
+
+video.video_info(path) -> dict
+    # {fps, frame_count, duration_sec, width, height, codec}
+
+video.extract_frames(path, every_sec=1.0, out_dir="frames", limit=None) -> list[str]
+    # save one frame per `every_sec`; returns saved PNG paths
+
+video.keyframes(path, max_frames=8, out_dir="keyframes") -> list[str]
+    # uniformly sample `max_frames` stills across the whole clip
+
+video.frame_at(path, t_sec, out=None) -> str
+    # extract a single frame at timestamp t_sec
+
+video.scene_changes(path, threshold=0.45, max_samples=300) -> list[float]
+    # timestamps (sec) where consecutive frames differ strongly (HSV histogram)
+
+video.extract_audio(path, out="audio.wav") -> str
+    # pull the audio track to WAV (then feed it to the `audio` skill)
+
+video.montage(frame_paths, out="storyboard.png", cols=4, thumb_w=320) -> str
+    # contact-sheet / storyboard grid from frame images
+```
+
+Notes:
+- Frame extraction uses cv2 when available and falls back to PyAV.
+- `keyframes` is the cheapest way to perceive a clip; prefer it before dense
+  per-second extraction on long videos.

--- a/batch-runner/skills/video/__init__.py
+++ b/batch-runner/skills/video/__init__.py
@@ -1,0 +1,21 @@
+"""Video skill — re-exports the toolkit helpers."""
+
+from skills.video.toolkit import (  # noqa: F401
+    extract_audio,
+    extract_frames,
+    frame_at,
+    keyframes,
+    montage,
+    scene_changes,
+    video_info,
+)
+
+__all__ = [
+    "extract_audio",
+    "extract_frames",
+    "frame_at",
+    "keyframes",
+    "montage",
+    "scene_changes",
+    "video_info",
+]

--- a/batch-runner/skills/video/toolkit.py
+++ b/batch-runner/skills/video/toolkit.py
@@ -1,0 +1,227 @@
+"""Video skill toolkit — frame-by-frame perception.
+
+Vision for the sandbox. Heavy libraries (cv2, av, moviepy, PIL) are imported
+lazily so importing this module never fails. Frame I/O prefers OpenCV and
+falls back to PyAV.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Optional
+
+from skills import _require
+
+__all__ = [
+    "video_info",
+    "extract_frames",
+    "keyframes",
+    "frame_at",
+    "scene_changes",
+    "extract_audio",
+    "montage",
+]
+
+
+def _cv2():
+    return _require("cv2", "opencv-python")
+
+
+def video_info(path: str) -> dict:
+    """Return fps, frame_count, duration, width, height, codec."""
+    cv2 = _cv2()
+    cap = cv2.VideoCapture(str(path))
+    try:
+        fps = float(cap.get(cv2.CAP_PROP_FPS)) or 0.0
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) or 0
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        fourcc = int(cap.get(cv2.CAP_PROP_FOURCC))
+        codec = "".join([chr((fourcc >> (8 * i)) & 0xFF) for i in range(4)]).strip("\x00")
+        return {
+            "fps": round(fps, 3),
+            "frame_count": frame_count,
+            "duration_sec": round(frame_count / fps, 3) if fps else 0.0,
+            "width": width,
+            "height": height,
+            "codec": codec,
+        }
+    finally:
+        cap.release()
+
+
+def extract_frames(path: str, every_sec: float = 1.0, out_dir: str = "frames",
+                   limit: Optional[int] = None) -> List[str]:
+    """Save one frame per ``every_sec`` seconds; return saved PNG paths."""
+    cv2 = _cv2()
+    os.makedirs(out_dir, exist_ok=True)
+    cap = cv2.VideoCapture(str(path))
+    saved: List[str] = []
+    try:
+        fps = float(cap.get(cv2.CAP_PROP_FPS)) or 25.0
+        stride = max(1, int(round(fps * every_sec)))
+        idx = 0
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            if idx % stride == 0:
+                t = idx / fps
+                out = os.path.join(out_dir, f"frame_{t:07.2f}s.png")
+                cv2.imwrite(out, frame)
+                saved.append(out)
+                if limit and len(saved) >= limit:
+                    break
+            idx += 1
+    finally:
+        cap.release()
+    return saved
+
+
+def keyframes(path: str, max_frames: int = 8, out_dir: str = "keyframes") -> List[str]:
+    """Uniformly sample ``max_frames`` stills across the whole clip."""
+    cv2 = _cv2()
+    os.makedirs(out_dir, exist_ok=True)
+    cap = cv2.VideoCapture(str(path))
+    saved: List[str] = []
+    try:
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) or 0
+        fps = float(cap.get(cv2.CAP_PROP_FPS)) or 25.0
+        if frame_count <= 0:
+            # Unknown length: read sequentially, keep every Nth up to max_frames.
+            frames = []
+            while True:
+                ok, frame = cap.read()
+                if not ok:
+                    break
+                frames.append(frame)
+                if len(frames) > 5000:
+                    break
+            if not frames:
+                return []
+            picks = [int(i * (len(frames) - 1) / max(1, max_frames - 1))
+                     for i in range(max_frames)]
+            for n, i in enumerate(sorted(set(picks))):
+                out = os.path.join(out_dir, f"keyframe_{n:02d}.png")
+                cv2.imwrite(out, frames[i])
+                saved.append(out)
+            return saved
+        picks = [int(i * (frame_count - 1) / max(1, max_frames - 1))
+                 for i in range(max_frames)]
+        for n, fno in enumerate(sorted(set(picks))):
+            cap.set(cv2.CAP_PROP_POS_FRAMES, fno)
+            ok, frame = cap.read()
+            if not ok:
+                continue
+            t = fno / fps
+            out = os.path.join(out_dir, f"keyframe_{n:02d}_{t:07.2f}s.png")
+            cv2.imwrite(out, frame)
+            saved.append(out)
+    finally:
+        cap.release()
+    return saved
+
+
+def frame_at(path: str, t_sec: float, out: Optional[str] = None) -> str:
+    """Extract a single frame at timestamp ``t_sec``."""
+    cv2 = _cv2()
+    cap = cv2.VideoCapture(str(path))
+    try:
+        cap.set(cv2.CAP_PROP_POS_MSEC, t_sec * 1000.0)
+        ok, frame = cap.read()
+        if not ok:
+            raise ValueError(f"could not read frame at {t_sec}s from {path}")
+        out = out or f"frame_{t_sec:07.2f}s.png"
+        cv2.imwrite(out, frame)
+        return out
+    finally:
+        cap.release()
+
+
+def scene_changes(path: str, threshold: float = 0.45, max_samples: int = 300) -> List[float]:
+    """Detect shot boundaries via HSV-histogram correlation between frames.
+
+    Returns a list of timestamps (seconds) where the content jumps.
+    """
+    cv2 = _cv2()
+    np = _require("numpy", "numpy")
+    cap = cv2.VideoCapture(str(path))
+    cuts: List[float] = []
+    try:
+        fps = float(cap.get(cv2.CAP_PROP_FPS)) or 25.0
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) or 0
+        stride = max(1, frame_count // max_samples) if frame_count else 1
+        prev_hist = None
+        idx = 0
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            if idx % stride == 0:
+                hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+                hist = cv2.calcHist([hsv], [0, 1], None, [50, 60], [0, 180, 0, 256])
+                cv2.normalize(hist, hist)
+                if prev_hist is not None:
+                    corr = cv2.compareHist(prev_hist, hist, cv2.HISTCMP_CORREL)
+                    if corr < (1.0 - threshold):
+                        cuts.append(round(idx / fps, 2))
+                prev_hist = hist
+            idx += 1
+    finally:
+        cap.release()
+    return cuts
+
+
+def extract_audio(path: str, out: str = "audio.wav") -> str:
+    """Extract the audio track to WAV (feed the result to the ``audio`` skill)."""
+    try:
+        moviepy = _require("moviepy.editor", "moviepy")
+        clip = moviepy.VideoFileClip(str(path))
+        if clip.audio is None:
+            clip.close()
+            raise ValueError(f"{path} has no audio track")
+        clip.audio.write_audiofile(out, logger=None)
+        clip.close()
+        return out
+    except Exception:
+        # Fall back to PyAV remux if moviepy/ffmpeg wrapper is unavailable.
+        av = _require("av", "av")
+        import fractions  # noqa: F401
+        container = av.open(str(path))
+        try:
+            astream = container.streams.audio[0]
+        except (IndexError, KeyError):
+            container.close()
+            raise ValueError(f"{path} has no audio track")
+        out_container = av.open(out, mode="w")
+        out_stream = out_container.add_stream("pcm_s16le", rate=astream.rate)
+        for frame in container.decode(audio=0):
+            for packet in out_stream.encode(frame):
+                out_container.mux(packet)
+        for packet in out_stream.encode():
+            out_container.mux(packet)
+        out_container.close()
+        container.close()
+        return out
+
+
+def montage(frame_paths: List[str], out: str = "storyboard.png", cols: int = 4,
+            thumb_w: int = 320) -> str:
+    """Build a contact-sheet / storyboard grid from frame images."""
+    Image = _require("PIL.Image", "Pillow")
+    if not frame_paths:
+        raise ValueError("montage requires at least one frame path")
+    thumbs = []
+    for fp in frame_paths:
+        im = Image.open(fp).convert("RGB")
+        ratio = thumb_w / im.width
+        thumbs.append(im.resize((thumb_w, max(1, int(im.height * ratio)))))
+    thumb_h = max(t.height for t in thumbs)
+    rows = (len(thumbs) + cols - 1) // cols
+    sheet = Image.new("RGB", (cols * thumb_w, rows * thumb_h), (16, 16, 16))
+    for i, t in enumerate(thumbs):
+        r, c = divmod(i, cols)
+        sheet.paste(t, (c * thumb_w, r * thumb_h))
+    sheet.save(out)
+    return out

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -48,7 +48,11 @@ from core.llm_client import create_client, create_provider_client, complete
 from core.needs_files import NeedsFilesManifest
 from core.prompt_builder import PromptBuilder, PromptConfig as BuilderPromptConfig
 from core.audio_analyzer import analyze_audio_files, filter_audio_files
-from core.video_analyzer import analyze_video_files, filter_video_files
+from core.video_analyzer import (
+    analyze_video_files,
+    filter_video_files,
+    frame_backend_available,
+)
 
 
 # ── Constants ──────────────────────────────────────────────────────────────
@@ -958,6 +962,27 @@ def run_inference(
     reasoning_effort_display = condition.get("model", {}).get("reasoning_effort")
     if reasoning_effort_display:
         print(f"   Reasoning effort:   {reasoning_effort_display}")
+
+    # Preflight: if a video_analyzer preprocessor is configured but the host has
+    # no frame backend (cv2/av), video preprocessing will silently no-op for the
+    # whole run. Surface that ONCE here so a hybrid run's "video perception" is
+    # never assumed to have happened when it did not. (Docker task execution is
+    # unaffected; this is about the host-side preprocessor only.)
+    _preprocs = condition.get("preprocessors", []) or []
+    _has_video_pp = any(
+        (pp or {}).get("type") == "video_analyzer" for pp in _preprocs
+    )
+    if _has_video_pp:
+        _backend = frame_backend_available()
+        if _backend:
+            print(f"   Video preproc:      host frame backend '{_backend}' available")
+        else:
+            print(
+                "   Video preproc:      ⚠️  configured but NO host frame backend "
+                "(cv2/av) — video preprocessing will be SKIPPED (no-op). Install "
+                "the host perception deps (opencv-python / av are pinned in "
+                "batch-runner/requirements.txt) to enable it."
+            )
 
     # Wall-clock deadline for relay runs
     wall_deadline = None

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -48,6 +48,7 @@ from core.llm_client import create_client, create_provider_client, complete
 from core.needs_files import NeedsFilesManifest
 from core.prompt_builder import PromptBuilder, PromptConfig as BuilderPromptConfig
 from core.audio_analyzer import analyze_audio_files, filter_audio_files
+from core.video_analyzer import analyze_video_files, filter_video_files
 
 
 # ── Constants ──────────────────────────────────────────────────────────────
@@ -110,6 +111,42 @@ def _run_preprocessors(
                     system_prompt=pp_system,
                     audio_paths=audio_files,
                     task_instruction=task_instruction if include_task else None,
+                )
+                if analysis:
+                    results.append(analysis)
+            except Exception as exc:
+                print(f"      ⚠️  Preprocessor '{pp_type}' error (non-fatal): {exc}")
+                continue
+        elif pp_type == "video_analyzer":
+            # Trigger: only run when video reference files are present.
+            video_files = filter_video_files(abs_ref_files)
+            if not video_files:
+                continue
+
+            pp_model = pp_cfg.get("model", {})
+            pp_provider = pp_model.get("provider", "azure")
+            pp_deployment = pp_model.get("deployment", "gpt-5.2")
+            pp_system = pp_cfg.get("system", "You are a video analysis agent.")
+            include_task = pp_cfg.get("include_task_instruction", False)
+
+            # Optional frame-sampling overrides from YAML.
+            frames_per_video = pp_cfg.get("frames_per_video", 8)
+            max_total_frames = pp_cfg.get("max_total_frames", 24)
+            frame_max_width = pp_cfg.get("frame_max_width", 768)
+            frame_detail = pp_cfg.get("frame_detail", "auto")
+
+            try:
+                pp_client = create_provider_client(pp_provider)
+                analysis = analyze_video_files(
+                    client=pp_client,
+                    model_deployment=pp_deployment,
+                    system_prompt=pp_system,
+                    video_paths=video_files,
+                    task_instruction=task_instruction if include_task else None,
+                    frames_per_video=frames_per_video,
+                    max_total_frames=max_total_frames,
+                    frame_max_width=frame_max_width,
+                    frame_detail=frame_detail,
                 )
                 if analysis:
                     results.append(analysis)
@@ -901,6 +938,8 @@ def run_inference(
             tokens_cfg_raw, "json_render", DEFAULT_TOKENS["json_render"]
         ),
     }
+    # Sandbox-mode settings (execution.sandbox block in the experiment YAML).
+    sandbox_options = execution_cfg.get("sandbox", {}) or {}
 
     print(f"\n{'='*60}")
     print(f"🚀 Step 2: Run Inference")
@@ -974,6 +1013,7 @@ def run_inference(
         executor = TaskExecutor(
             mode=execution_mode, llm_client=client, tokens=tokens_cfg,
             timeout=timeout, reasoning_effort=reasoning_effort,
+            sandbox_options=sandbox_options,
         )
     except Exception as e:
         print(f"❌ Executor init failed for mode '{execution_mode}': {e}")

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -698,10 +698,19 @@ def _execute_single_task(
         if not abs_ref_files:
             abs_ref_files = None  # all missing → treat as no files
 
-    # ── Preprocessor: enrich prompt with audio analysis (if configured) ──
+    # ── Preprocessor: enrich prompt with audio/video analysis (if configured) ──
     preprocessor_prefix = _run_preprocessors(condition, abs_ref_files, instruction)
+    perception_text = None
     if preprocessor_prefix:
-        instruction = preprocessor_prefix + "\n\n" + instruction
+        if execution_mode == "sandbox":
+            # Sandbox owns perception PLACEMENT via its `perception_analysis` spec
+            # section (prompts/sandbox_occupation_codegen.yaml), so pass the block
+            # through rather than prepending it here. This is byte-equivalent to the
+            # prepend (perception is the outermost prefix before the task either way)
+            # while making the section spec-controllable.
+            perception_text = preprocessor_prefix
+        else:
+            instruction = preprocessor_prefix + "\n\n" + instruction
         print(f"      🎵 Preprocessor injected {len(preprocessor_prefix)} chars into prompt")
 
     try:
@@ -741,6 +750,7 @@ def _execute_single_task(
             occupation=task_info.get("occupation", "professional"),
             experiment_prompt=experiment_prompt,
             verbose=verbose,
+            perception_text=perception_text,
         )
         latency_ms = (time.time() - start) * 1000
 

--- a/batch-runner/tests/fixtures/prompt/golden/accounting_spreadsheet.augmented.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/accounting_spreadsheet.augmented.txt
@@ -1,0 +1,38 @@
+## Reference File Structure (auto-detected)
+
+ledger.csv: ~2 rows × 3 cols
+  columns: ['date', 'account', 'amount']
+
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import data`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `data` — Data Toolkit  (matched files: .csv, .xlsx; keywords: spreadsheet, model)
+Load tables and build spreadsheets/charts.
+  data.read_table(path) -> df; data.quick_chart(df, out)
+
+📦 Likely libraries for this task (pre-installed): openpyxl, pandas
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .xlsx
+- Minimum deliverable files: 1
+- Deliverable name should reference: model
+- Confidence in this contract: high
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Build a quarterly financial model spreadsheet from the ledger and add a summary chart.
+
+═══ REFERENCE FILES PREVIEW ═══
+The following reference files are available in the current directory.
+Use EXACT column names, sheet names, and data values shown below.
+
+
+📊 ledger.csv (58 B)
+  Columns: date, account, amount
+  First 2 rows:
+    [1] 2026-01-01 | cash | 100
+    [2] 2026-01-02 | ar | 250
+═══ END REFERENCE FILES ═══
+
+📁 Files available in the sandbox working directory (use them directly): ['ledger.csv']

--- a/batch-runner/tests/fixtures/prompt/golden/accounting_spreadsheet.rendered_user.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/accounting_spreadsheet.rendered_user.txt
@@ -1,0 +1,107 @@
+You are a professional Accountant completing a desktop productivity task
+inside a containerized Python sandbox.
+
+First, as an expert Accountant, write a concise professional reply to the
+task. Describe the deliverables you will create — their purpose, contents, and
+file formats — so a human evaluator knows what to expect before opening them.
+
+Then provide the complete Python code to generate the deliverables.
+
+SANDBOX & SKILLS:
+- The task text above may include an "AVAILABLE SKILLS" manual and a "Likely
+  libraries" hint. The Skills are pre-installed and importable directly:
+    from skills import audio, video, document, image, data
+- Use Skills to PERCEIVE multimodal inputs before building output:
+    * VIDEO  -> look frame-by-frame:  frames = video.keyframes("clip.mp4", max_frames=8)
+                inspect them, detect cuts with video.scene_changes(...),
+                pull the audio track with video.extract_audio(...).
+    * AUDIO  -> listen via signal analysis:  peaks = audio.fft_summary("track.wav")
+                render audio.spectrogram_png(...), measure audio.loudness_lufs(...),
+                sample the envelope with audio.sample_waveform(...).
+    * DOCUMENT -> document.read_any(path), document.pdf_tables(path),
+                document.pdf_to_images(path) to inspect layout visually.
+    * IMAGE  -> image.ocr_text(path), image.dominant_colors(path),
+                image.read_codes(path).
+    * DATA   -> df = data.read_table(path); data.describe(df); data.quick_chart(...).
+- Prefer the Skills helpers over hand-rolled DSP/parsing; they wrap famous
+  libraries (librosa, opencv, PyMuPDF, pdfplumber, pandas) with safe defaults.
+
+RULES:
+1. Use pre-installed libraries only — do NOT pip install and do NOT use the
+   network. If the "Likely libraries" hint marks something as not guaranteed,
+   pick a pre-installed alternative.
+2. Save all deliverables to the current working directory with descriptive
+   names. The task is NOT complete unless real files are saved.
+3. Wrap code in triple-backtick python blocks. Include all imports at the top.
+4. Make the code complete and runnable — no placeholders, no TODOs.
+5. Read reference files from the current directory (already copied there).
+6. When reference-file previews are provided, use EXACT column names, sheet
+   names, and values — inspect structure first, never guess or hardcode.
+7. Handle perception defensively: a Skill helper may raise if its library is
+   missing — wrap optional perception in try/except and continue with a
+   sensible fallback so the deliverable is still produced.
+
+FORMAT:
+1. Start with your professional reply describing the deliverables.
+2. Then provide the complete Python code in triple-backtick python blocks.
+
+EXAMPLE:
+As a Media Analyst, I will watch the supplied clip frame-by-frame, build a
+storyboard contact sheet (storyboard.png), and write an analysis memo
+(analysis.docx) summarizing the key scenes and the audio profile.
+
+```python
+from skills import video, document
+frames = video.keyframes("clip.mp4", max_frames=8)
+sheet = video.montage(frames, out="storyboard.png")
+info = video.video_info("clip.mp4")
+lines = ["Duration: " + str(info["duration_sec"]) + "s", "Frames sampled: " + str(len(frames))]
+document.make_docx("Clip Analysis", lines, "analysis.docx")
+print("Generated", sheet, "and analysis.docx")
+```
+
+CONFIDENCE TAG:
+On the VERY LAST LINE of your plain-text response (OUTSIDE and AFTER all code
+blocks), write exactly:
+CONFIDENCE[XX]
+where XX is an integer 0-100. It must NOT appear inside any code block.
+
+TASK:
+## Reference File Structure (auto-detected)
+
+ledger.csv: ~2 rows × 3 cols
+  columns: ['date', 'account', 'amount']
+
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import data`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `data` — Data Toolkit  (matched files: .csv, .xlsx; keywords: spreadsheet, model)
+Load tables and build spreadsheets/charts.
+  data.read_table(path) -> df; data.quick_chart(df, out)
+
+📦 Likely libraries for this task (pre-installed): openpyxl, pandas
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .xlsx
+- Minimum deliverable files: 1
+- Deliverable name should reference: model
+- Confidence in this contract: high
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Build a quarterly financial model spreadsheet from the ledger and add a summary chart.
+
+═══ REFERENCE FILES PREVIEW ═══
+The following reference files are available in the current directory.
+Use EXACT column names, sheet names, and data values shown below.
+
+
+📊 ledger.csv (58 B)
+  Columns: date, account, amount
+  First 2 rows:
+    [1] 2026-01-01 | cash | 100
+    [2] 2026-01-02 | ar | 250
+═══ END REFERENCE FILES ═══
+
+📁 Files available in the sandbox working directory (use them directly): ['ledger.csv']

--- a/batch-runner/tests/fixtures/prompt/golden/audio_capstone.augmented.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/audio_capstone.augmented.txt
@@ -1,0 +1,35 @@
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import audio, document`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `audio` — Audio Perception  (matched files: .wav; keywords: mix, stem)
+Listen via FFT/sampling and edit waveforms.
+  audio.fft_summary(path) -> dict; audio.loudness_lufs(path) -> float
+
+── Skill `document` — Document Toolkit  (matched files: .docx; keywords: report, memo)
+Read and author documents.
+  document.make_docx(title, lines, out); document.read_any(path) -> str
+
+📦 Likely libraries for this task (pre-installed): librosa, python-docx, soundfile
+⚠️  Not guaranteed in the sandbox image: aspose-words — prefer alternatives that are pre-installed.
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .wav, .docx
+- Minimum deliverable files: 1
+- Deliverable name should reference: mix
+- Confidence in this contract: medium
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Edit the supplied stems, produce a balanced mix, and write an edit report.
+
+═══ REFERENCE FILES PREVIEW ═══
+The following reference files are available in the current directory.
+Use EXACT column names, sheet names, and data values shown below.
+
+
+📎 State_of_Affairs_STEM.wav (512 B)
+  Type: .wav — preview not supported, file is copied to working directory
+═══ END REFERENCE FILES ═══
+
+📁 Files available in the sandbox working directory (use them directly): ['State_of_Affairs_STEM.wav']

--- a/batch-runner/tests/fixtures/prompt/golden/audio_capstone.rendered_user.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/audio_capstone.rendered_user.txt
@@ -1,0 +1,104 @@
+You are a professional Audio Producer completing a desktop productivity task
+inside a containerized Python sandbox.
+
+First, as an expert Audio Producer, write a concise professional reply to the
+task. Describe the deliverables you will create — their purpose, contents, and
+file formats — so a human evaluator knows what to expect before opening them.
+
+Then provide the complete Python code to generate the deliverables.
+
+SANDBOX & SKILLS:
+- The task text above may include an "AVAILABLE SKILLS" manual and a "Likely
+  libraries" hint. The Skills are pre-installed and importable directly:
+    from skills import audio, video, document, image, data
+- Use Skills to PERCEIVE multimodal inputs before building output:
+    * VIDEO  -> look frame-by-frame:  frames = video.keyframes("clip.mp4", max_frames=8)
+                inspect them, detect cuts with video.scene_changes(...),
+                pull the audio track with video.extract_audio(...).
+    * AUDIO  -> listen via signal analysis:  peaks = audio.fft_summary("track.wav")
+                render audio.spectrogram_png(...), measure audio.loudness_lufs(...),
+                sample the envelope with audio.sample_waveform(...).
+    * DOCUMENT -> document.read_any(path), document.pdf_tables(path),
+                document.pdf_to_images(path) to inspect layout visually.
+    * IMAGE  -> image.ocr_text(path), image.dominant_colors(path),
+                image.read_codes(path).
+    * DATA   -> df = data.read_table(path); data.describe(df); data.quick_chart(...).
+- Prefer the Skills helpers over hand-rolled DSP/parsing; they wrap famous
+  libraries (librosa, opencv, PyMuPDF, pdfplumber, pandas) with safe defaults.
+
+RULES:
+1. Use pre-installed libraries only — do NOT pip install and do NOT use the
+   network. If the "Likely libraries" hint marks something as not guaranteed,
+   pick a pre-installed alternative.
+2. Save all deliverables to the current working directory with descriptive
+   names. The task is NOT complete unless real files are saved.
+3. Wrap code in triple-backtick python blocks. Include all imports at the top.
+4. Make the code complete and runnable — no placeholders, no TODOs.
+5. Read reference files from the current directory (already copied there).
+6. When reference-file previews are provided, use EXACT column names, sheet
+   names, and values — inspect structure first, never guess or hardcode.
+7. Handle perception defensively: a Skill helper may raise if its library is
+   missing — wrap optional perception in try/except and continue with a
+   sensible fallback so the deliverable is still produced.
+
+FORMAT:
+1. Start with your professional reply describing the deliverables.
+2. Then provide the complete Python code in triple-backtick python blocks.
+
+EXAMPLE:
+As a Media Analyst, I will watch the supplied clip frame-by-frame, build a
+storyboard contact sheet (storyboard.png), and write an analysis memo
+(analysis.docx) summarizing the key scenes and the audio profile.
+
+```python
+from skills import video, document
+frames = video.keyframes("clip.mp4", max_frames=8)
+sheet = video.montage(frames, out="storyboard.png")
+info = video.video_info("clip.mp4")
+lines = ["Duration: " + str(info["duration_sec"]) + "s", "Frames sampled: " + str(len(frames))]
+document.make_docx("Clip Analysis", lines, "analysis.docx")
+print("Generated", sheet, "and analysis.docx")
+```
+
+CONFIDENCE TAG:
+On the VERY LAST LINE of your plain-text response (OUTSIDE and AFTER all code
+blocks), write exactly:
+CONFIDENCE[XX]
+where XX is an integer 0-100. It must NOT appear inside any code block.
+
+TASK:
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import audio, document`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `audio` — Audio Perception  (matched files: .wav; keywords: mix, stem)
+Listen via FFT/sampling and edit waveforms.
+  audio.fft_summary(path) -> dict; audio.loudness_lufs(path) -> float
+
+── Skill `document` — Document Toolkit  (matched files: .docx; keywords: report, memo)
+Read and author documents.
+  document.make_docx(title, lines, out); document.read_any(path) -> str
+
+📦 Likely libraries for this task (pre-installed): librosa, python-docx, soundfile
+⚠️  Not guaranteed in the sandbox image: aspose-words — prefer alternatives that are pre-installed.
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .wav, .docx
+- Minimum deliverable files: 1
+- Deliverable name should reference: mix
+- Confidence in this contract: medium
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Edit the supplied stems, produce a balanced mix, and write an edit report.
+
+═══ REFERENCE FILES PREVIEW ═══
+The following reference files are available in the current directory.
+Use EXACT column names, sheet names, and data values shown below.
+
+
+📎 State_of_Affairs_STEM.wav (512 B)
+  Type: .wav — preview not supported, file is copied to working directory
+═══ END REFERENCE FILES ═══
+
+📁 Files available in the sandbox working directory (use them directly): ['State_of_Affairs_STEM.wav']

--- a/batch-runner/tests/fixtures/prompt/golden/audio_capstone.with_perception.augmented.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/audio_capstone.with_perception.augmented.txt
@@ -1,0 +1,43 @@
+[REFLECTION]
+Previous attempt produced no .wav. Regenerate.
+[/REFLECTION]
+
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import audio, document`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `audio` — Audio Perception  (matched files: .wav; keywords: mix, stem)
+Listen via FFT/sampling and edit waveforms.
+  audio.fft_summary(path) -> dict; audio.loudness_lufs(path) -> float
+
+── Skill `document` — Document Toolkit  (matched files: .docx; keywords: report, memo)
+Read and author documents.
+  document.make_docx(title, lines, out); document.read_any(path) -> str
+
+📦 Likely libraries for this task (pre-installed): librosa, python-docx, soundfile
+⚠️  Not guaranteed in the sandbox image: aspose-words — prefer alternatives that are pre-installed.
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .wav, .docx
+- Minimum deliverable files: 1
+- Deliverable name should reference: mix
+- Confidence in this contract: medium
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+[AUDIO ANALYSIS]
+Tempo ~120 BPM; integrated loudness -14 LUFS; 3 stems detected.
+[/AUDIO ANALYSIS]
+
+Edit the supplied stems, produce a balanced mix, and write an edit report.
+
+═══ REFERENCE FILES PREVIEW ═══
+The following reference files are available in the current directory.
+Use EXACT column names, sheet names, and data values shown below.
+
+
+📎 State_of_Affairs_STEM.wav (512 B)
+  Type: .wav — preview not supported, file is copied to working directory
+═══ END REFERENCE FILES ═══
+
+📁 Files available in the sandbox working directory (use them directly): ['State_of_Affairs_STEM.wav']

--- a/batch-runner/tests/fixtures/prompt/golden/audio_capstone.with_reflection.augmented.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/audio_capstone.with_reflection.augmented.txt
@@ -1,0 +1,39 @@
+[REFLECTION]
+Fix the missing .wav deliverable.
+[/REFLECTION]
+
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import audio, document`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `audio` — Audio Perception  (matched files: .wav; keywords: mix, stem)
+Listen via FFT/sampling and edit waveforms.
+  audio.fft_summary(path) -> dict; audio.loudness_lufs(path) -> float
+
+── Skill `document` — Document Toolkit  (matched files: .docx; keywords: report, memo)
+Read and author documents.
+  document.make_docx(title, lines, out); document.read_any(path) -> str
+
+📦 Likely libraries for this task (pre-installed): librosa, python-docx, soundfile
+⚠️  Not guaranteed in the sandbox image: aspose-words — prefer alternatives that are pre-installed.
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .wav, .docx
+- Minimum deliverable files: 1
+- Deliverable name should reference: mix
+- Confidence in this contract: medium
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Edit the supplied stems, produce a balanced mix, and write an edit report.
+
+═══ REFERENCE FILES PREVIEW ═══
+The following reference files are available in the current directory.
+Use EXACT column names, sheet names, and data values shown below.
+
+
+📎 State_of_Affairs_STEM.wav (512 B)
+  Type: .wav — preview not supported, file is copied to working directory
+═══ END REFERENCE FILES ═══
+
+📁 Files available in the sandbox working directory (use them directly): ['State_of_Affairs_STEM.wav']

--- a/batch-runner/tests/fixtures/prompt/golden/doc_only_no_refs.augmented.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/doc_only_no_refs.augmented.txt
@@ -1,0 +1,19 @@
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import document`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `document` — Document Toolkit  (matched files: .docx; keywords: report, memo)
+Read and author documents.
+  document.make_docx(title, lines, out); document.read_any(path) -> str
+
+📦 Likely libraries for this task (pre-installed): python-docx
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .docx
+- Minimum deliverable files: 1
+- Deliverable name should reference: memo
+- Confidence in this contract: medium
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Write a two-page strategy memo summarizing the market entry options.

--- a/batch-runner/tests/fixtures/prompt/golden/doc_only_no_refs.rendered_user.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/doc_only_no_refs.rendered_user.txt
@@ -1,0 +1,88 @@
+You are a professional Management Consultant completing a desktop productivity task
+inside a containerized Python sandbox.
+
+First, as an expert Management Consultant, write a concise professional reply to the
+task. Describe the deliverables you will create — their purpose, contents, and
+file formats — so a human evaluator knows what to expect before opening them.
+
+Then provide the complete Python code to generate the deliverables.
+
+SANDBOX & SKILLS:
+- The task text above may include an "AVAILABLE SKILLS" manual and a "Likely
+  libraries" hint. The Skills are pre-installed and importable directly:
+    from skills import audio, video, document, image, data
+- Use Skills to PERCEIVE multimodal inputs before building output:
+    * VIDEO  -> look frame-by-frame:  frames = video.keyframes("clip.mp4", max_frames=8)
+                inspect them, detect cuts with video.scene_changes(...),
+                pull the audio track with video.extract_audio(...).
+    * AUDIO  -> listen via signal analysis:  peaks = audio.fft_summary("track.wav")
+                render audio.spectrogram_png(...), measure audio.loudness_lufs(...),
+                sample the envelope with audio.sample_waveform(...).
+    * DOCUMENT -> document.read_any(path), document.pdf_tables(path),
+                document.pdf_to_images(path) to inspect layout visually.
+    * IMAGE  -> image.ocr_text(path), image.dominant_colors(path),
+                image.read_codes(path).
+    * DATA   -> df = data.read_table(path); data.describe(df); data.quick_chart(...).
+- Prefer the Skills helpers over hand-rolled DSP/parsing; they wrap famous
+  libraries (librosa, opencv, PyMuPDF, pdfplumber, pandas) with safe defaults.
+
+RULES:
+1. Use pre-installed libraries only — do NOT pip install and do NOT use the
+   network. If the "Likely libraries" hint marks something as not guaranteed,
+   pick a pre-installed alternative.
+2. Save all deliverables to the current working directory with descriptive
+   names. The task is NOT complete unless real files are saved.
+3. Wrap code in triple-backtick python blocks. Include all imports at the top.
+4. Make the code complete and runnable — no placeholders, no TODOs.
+5. Read reference files from the current directory (already copied there).
+6. When reference-file previews are provided, use EXACT column names, sheet
+   names, and values — inspect structure first, never guess or hardcode.
+7. Handle perception defensively: a Skill helper may raise if its library is
+   missing — wrap optional perception in try/except and continue with a
+   sensible fallback so the deliverable is still produced.
+
+FORMAT:
+1. Start with your professional reply describing the deliverables.
+2. Then provide the complete Python code in triple-backtick python blocks.
+
+EXAMPLE:
+As a Media Analyst, I will watch the supplied clip frame-by-frame, build a
+storyboard contact sheet (storyboard.png), and write an analysis memo
+(analysis.docx) summarizing the key scenes and the audio profile.
+
+```python
+from skills import video, document
+frames = video.keyframes("clip.mp4", max_frames=8)
+sheet = video.montage(frames, out="storyboard.png")
+info = video.video_info("clip.mp4")
+lines = ["Duration: " + str(info["duration_sec"]) + "s", "Frames sampled: " + str(len(frames))]
+document.make_docx("Clip Analysis", lines, "analysis.docx")
+print("Generated", sheet, "and analysis.docx")
+```
+
+CONFIDENCE TAG:
+On the VERY LAST LINE of your plain-text response (OUTSIDE and AFTER all code
+blocks), write exactly:
+CONFIDENCE[XX]
+where XX is an integer 0-100. It must NOT appear inside any code block.
+
+TASK:
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import document`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `document` — Document Toolkit  (matched files: .docx; keywords: report, memo)
+Read and author documents.
+  document.make_docx(title, lines, out); document.read_any(path) -> str
+
+📦 Likely libraries for this task (pre-installed): python-docx
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .docx
+- Minimum deliverable files: 1
+- Deliverable name should reference: memo
+- Confidence in this contract: medium
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Write a two-page strategy memo summarizing the market entry options.

--- a/batch-runner/tests/fixtures/prompt/golden/repair_accounting.reflection.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/repair_accounting.reflection.txt
@@ -1,0 +1,35 @@
+[REFLECTION]
+Your previous attempt did NOT satisfy the deliverable contract. Regenerate the COMPLETE solution and fix every issue below.
+
+Blocking problems to fix:
+- missing_expected_type: no .xlsx deliverable was produced
+- empty_output: execution wrote 0 files
+
+Secondary warnings (address if relevant):
+- render_qa: first page appears blank
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .xlsx
+- Minimum deliverable files: 1
+- Deliverable name should reference: model
+- Confidence in this contract: high
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Previous stdout (tail):
+Loaded ledger.csv
+Computed totals
+(no file written)
+
+Previous stderr/error (tail):
+Traceback (most recent call last):
+  File "~/run.py", line 3
+  File "/workspace/solution.py", line 9
+ValueError: bad column
+
+Your previous code (fix and resend in full):
+----
+import pandas as pd
+df = pd.read_csv('ledger.csv')
+print(df.sum())
+----
+[/REFLECTION]

--- a/batch-runner/tests/fixtures/prompt/golden/video_capstone.augmented.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/video_capstone.augmented.txt
@@ -1,0 +1,30 @@
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import video`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `video` — Video Perception  (matched files: .mp4; keywords: composite, shot)
+See a clip frame-by-frame and composite.
+  video.keyframes(path, max_frames=8) -> list; video.montage(frames, out)
+
+📦 Likely libraries for this task (pre-installed): opencv-python, numpy
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .mp4, .png
+- Minimum deliverable files: 1
+- Deliverable name should reference: composite
+- Confidence in this contract: medium
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Composite the actor between the two clips and make them vanish in a teleport effect.
+
+═══ REFERENCE FILES PREVIEW ═══
+The following reference files are available in the current directory.
+Use EXACT column names, sheet names, and data values shown below.
+
+
+📎 TWT_A001_03.mp4 (512 B)
+  Type: .mp4 — preview not supported, file is copied to working directory
+═══ END REFERENCE FILES ═══
+
+📁 Files available in the sandbox working directory (use them directly): ['TWT_A001_03.mp4']

--- a/batch-runner/tests/fixtures/prompt/golden/video_capstone.rendered_user.txt
+++ b/batch-runner/tests/fixtures/prompt/golden/video_capstone.rendered_user.txt
@@ -1,0 +1,99 @@
+You are a professional Film and Video Editor completing a desktop productivity task
+inside a containerized Python sandbox.
+
+First, as an expert Film and Video Editor, write a concise professional reply to the
+task. Describe the deliverables you will create — their purpose, contents, and
+file formats — so a human evaluator knows what to expect before opening them.
+
+Then provide the complete Python code to generate the deliverables.
+
+SANDBOX & SKILLS:
+- The task text above may include an "AVAILABLE SKILLS" manual and a "Likely
+  libraries" hint. The Skills are pre-installed and importable directly:
+    from skills import audio, video, document, image, data
+- Use Skills to PERCEIVE multimodal inputs before building output:
+    * VIDEO  -> look frame-by-frame:  frames = video.keyframes("clip.mp4", max_frames=8)
+                inspect them, detect cuts with video.scene_changes(...),
+                pull the audio track with video.extract_audio(...).
+    * AUDIO  -> listen via signal analysis:  peaks = audio.fft_summary("track.wav")
+                render audio.spectrogram_png(...), measure audio.loudness_lufs(...),
+                sample the envelope with audio.sample_waveform(...).
+    * DOCUMENT -> document.read_any(path), document.pdf_tables(path),
+                document.pdf_to_images(path) to inspect layout visually.
+    * IMAGE  -> image.ocr_text(path), image.dominant_colors(path),
+                image.read_codes(path).
+    * DATA   -> df = data.read_table(path); data.describe(df); data.quick_chart(...).
+- Prefer the Skills helpers over hand-rolled DSP/parsing; they wrap famous
+  libraries (librosa, opencv, PyMuPDF, pdfplumber, pandas) with safe defaults.
+
+RULES:
+1. Use pre-installed libraries only — do NOT pip install and do NOT use the
+   network. If the "Likely libraries" hint marks something as not guaranteed,
+   pick a pre-installed alternative.
+2. Save all deliverables to the current working directory with descriptive
+   names. The task is NOT complete unless real files are saved.
+3. Wrap code in triple-backtick python blocks. Include all imports at the top.
+4. Make the code complete and runnable — no placeholders, no TODOs.
+5. Read reference files from the current directory (already copied there).
+6. When reference-file previews are provided, use EXACT column names, sheet
+   names, and values — inspect structure first, never guess or hardcode.
+7. Handle perception defensively: a Skill helper may raise if its library is
+   missing — wrap optional perception in try/except and continue with a
+   sensible fallback so the deliverable is still produced.
+
+FORMAT:
+1. Start with your professional reply describing the deliverables.
+2. Then provide the complete Python code in triple-backtick python blocks.
+
+EXAMPLE:
+As a Media Analyst, I will watch the supplied clip frame-by-frame, build a
+storyboard contact sheet (storyboard.png), and write an analysis memo
+(analysis.docx) summarizing the key scenes and the audio profile.
+
+```python
+from skills import video, document
+frames = video.keyframes("clip.mp4", max_frames=8)
+sheet = video.montage(frames, out="storyboard.png")
+info = video.video_info("clip.mp4")
+lines = ["Duration: " + str(info["duration_sec"]) + "s", "Frames sampled: " + str(len(frames))]
+document.make_docx("Clip Analysis", lines, "analysis.docx")
+print("Generated", sheet, "and analysis.docx")
+```
+
+CONFIDENCE TAG:
+On the VERY LAST LINE of your plain-text response (OUTSIDE and AFTER all code
+blocks), write exactly:
+CONFIDENCE[XX]
+where XX is an integer 0-100. It must NOT appear inside any code block.
+
+TASK:
+🧰 AVAILABLE SKILLS (pre-installed in the sandbox; import directly):
+
+Import with: `from skills import video`
+Use these helpers instead of hand-rolling perception/IO. They wrap famous libraries with safe defaults.
+
+── Skill `video` — Video Perception  (matched files: .mp4; keywords: composite, shot)
+See a clip frame-by-frame and composite.
+  video.keyframes(path, max_frames=8) -> list; video.montage(frames, out)
+
+📦 Likely libraries for this task (pre-installed): opencv-python, numpy
+
+DELIVERABLE CONTRACT (what the evaluator expects you to PRODUCE):
+- Expected file type(s): .mp4, .png
+- Minimum deliverable files: 1
+- Deliverable name should reference: composite
+- Confidence in this contract: medium
+Save real, openable file(s) of the expected type(s) to the working directory. Do NOT count reference/input files as your deliverable, and do NOT describe the file only in text. If you cannot produce the exact type, produce the closest standard professional format and say so.
+
+Composite the actor between the two clips and make them vanish in a teleport effect.
+
+═══ REFERENCE FILES PREVIEW ═══
+The following reference files are available in the current directory.
+Use EXACT column names, sheet names, and data values shown below.
+
+
+📎 TWT_A001_03.mp4 (512 B)
+  Type: .mp4 — preview not supported, file is copied to working directory
+═══ END REFERENCE FILES ═══
+
+📁 Files available in the sandbox working directory (use them directly): ['TWT_A001_03.mp4']

--- a/batch-runner/tests/test_artifact_verifier.py
+++ b/batch-runner/tests/test_artifact_verifier.py
@@ -1,0 +1,157 @@
+"""Tests for core/artifact_verifier.py — open valid fixtures, flag bad ones.
+
+Fixtures are generated with the same libraries that validate them, so each test
+``importorskip``s its dependency and is robust in a light environment.
+"""
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from core.artifact_verifier import (
+    classify_kind,
+    verify_artifacts,
+    verify_one,
+)
+
+
+def test_classify_kind():
+    assert classify_kind(".xlsx") == "spreadsheet"
+    assert classify_kind(".PDF") == "pdf"
+    assert classify_kind(".mp4") == "video"
+    assert classify_kind(".unknownext") == "unknown"
+
+
+def test_empty_file_is_blocking(tmp_path):
+    f = tmp_path / "empty.xlsx"
+    f.write_bytes(b"")
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is False
+    assert any("empty" in e for e in r.errors)
+
+
+def test_missing_file(tmp_path):
+    r = verify_one(tmp_path / "nope.pdf", workdir=tmp_path)
+    assert r.exists is False
+    assert r.errors
+
+
+def test_path_escape_is_blocking(tmp_path):
+    outside = tmp_path.parent / "escape.txt"
+    outside.write_text("hi")
+    try:
+        r = verify_one(outside, workdir=tmp_path)
+        assert any("escape" in e for e in r.errors)
+    finally:
+        outside.unlink(missing_ok=True)
+
+
+def test_valid_xlsx(tmp_path):
+    openpyxl = pytest.importorskip("openpyxl")
+    f = tmp_path / "a.xlsx"
+    wb = openpyxl.Workbook()
+    wb.active["A1"] = "hi"
+    wb.save(f)
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is True
+    assert r.metadata["sheet_count"] == 1
+    assert r.sha256
+
+
+def test_corrupt_xlsx_flagged(tmp_path):
+    pytest.importorskip("openpyxl")
+    f = tmp_path / "bad.xlsx"
+    f.write_bytes(b"this is not a real workbook")
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is False
+    assert r.errors
+
+
+def test_valid_docx(tmp_path):
+    docx = pytest.importorskip("docx")
+    f = tmp_path / "b.docx"
+    d = docx.Document()
+    d.add_paragraph("hello world")
+    d.save(f)
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is True
+    assert r.metadata["paragraph_count"] >= 1
+
+
+def test_valid_pptx(tmp_path):
+    pptx = pytest.importorskip("pptx")
+    f = tmp_path / "c.pptx"
+    prs = pptx.Presentation()
+    prs.slides.add_slide(prs.slide_layouts[6])
+    prs.save(f)
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is True
+    assert r.metadata["slide_count"] == 1
+
+
+def test_valid_pdf(tmp_path):
+    fitz = pytest.importorskip("fitz")
+    f = tmp_path / "e.pdf"
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(f)
+    doc.close()
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is True
+    assert r.metadata["page_count"] == 1
+
+
+def test_valid_png(tmp_path):
+    PIL = pytest.importorskip("PIL.Image")
+    from PIL import Image
+    f = tmp_path / "f.png"
+    Image.new("RGB", (12, 8), "blue").save(f)
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is True
+    assert r.metadata["width"] == 12 and r.metadata["height"] == 8
+
+
+def test_valid_json(tmp_path):
+    f = tmp_path / "g.json"
+    f.write_text(json.dumps({"a": 1}))
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is True
+
+
+def test_invalid_json_flagged(tmp_path):
+    f = tmp_path / "g.json"
+    f.write_text("{not valid json,,")
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is False
+
+
+def test_valid_zip(tmp_path):
+    f = tmp_path / "h.zip"
+    with zipfile.ZipFile(f, "w") as z:
+        z.writestr("inner.txt", "data")
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is True
+    assert r.metadata["entries"] == 1
+
+
+def test_text_file(tmp_path):
+    f = tmp_path / "notes.txt"
+    f.write_text("some notes\nsecond line")
+    r = verify_one(f, workdir=tmp_path)
+    assert r.openable is True
+    assert r.metadata["line_count"] == 2
+
+
+def test_verify_artifacts_rollup(tmp_path):
+    pytest.importorskip("openpyxl")
+    import openpyxl
+    good = tmp_path / "good.xlsx"
+    wb = openpyxl.Workbook(); wb.active["A1"] = "x"; wb.save(good)
+    empty = tmp_path / "empty.docx"
+    empty.write_bytes(b"")
+    report = verify_artifacts([good, empty], workdir=tmp_path)
+    assert report.ok is False
+    assert any("empty.docx" in e for e in report.blocking_errors)
+    assert len(report.artifacts) == 2

--- a/batch-runner/tests/test_deliverable_contract.py
+++ b/batch-runner/tests/test_deliverable_contract.py
@@ -1,0 +1,154 @@
+"""Tests for core/deliverable_contract.py — inference, selection, validation."""
+
+from pathlib import Path
+
+import pytest
+
+from core.deliverable_contract import (
+    DeliverableContract,
+    ContractValidation,
+    infer_deliverable_contract,
+    select_generated_artifacts,
+    snapshot_dir,
+    validate_contract,
+)
+
+
+# ── inference per type ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("text,ext", [
+    ("Create an Excel workbook summarizing Q3 sales", ".xlsx"),
+    ("Build a PowerPoint deck for the board meeting", ".pptx"),
+    ("Write a memo to the team about the new policy", ".docx"),
+    ("Produce a one-page PDF flyer for the event", ".pdf"),
+    ("Design a logo for the new startup brand", ".png"),
+    ("Export the cleaned results as a CSV file", ".csv"),
+    ("Generate a 30 second audio jingle for the ad", ".wav"),
+    ("Render a short animation video of the logo", ".mp4"),
+])
+def test_infer_expected_extension(text, ext):
+    c = infer_deliverable_contract(text, [])
+    assert ext in c.expected_extensions, (text, c.expected_extensions)
+    assert c.requires_deliverable is True
+    assert c.min_count >= 1
+
+
+def test_explicit_extension_token_is_high_confidence():
+    c = infer_deliverable_contract("Save the output as a .csv file", [])
+    assert c.confidence == "high"
+
+
+def test_format_noun_only_is_medium_confidence():
+    # "spreadsheet" can refer to an input file, so don't over-commit.
+    c = infer_deliverable_contract("Summarize this spreadsheet of sales", [])
+    assert c.confidence == "medium"
+    assert ".xlsx" in c.expected_extensions
+
+
+def test_csv_explicit_overrides_generic_spreadsheet():
+    c = infer_deliverable_contract("Produce a spreadsheet exported as csv", [])
+    assert ".csv" in c.expected_extensions
+    assert ".xlsx" not in c.expected_extensions
+
+
+def test_pdf_explicit_overrides_generic_report():
+    c = infer_deliverable_contract("Write a report and deliver it as a PDF", [])
+    assert ".pdf" in c.expected_extensions
+    assert ".docx" not in c.expected_extensions
+
+
+def test_config_can_pin_expected_extensions():
+    c = infer_deliverable_contract("do the thing", [], {"expected_extensions": ["xlsx"]})
+    assert c.expected_extensions == [".xlsx"]
+    assert c.confidence == "high"
+
+
+def test_no_signal_low_confidence_but_still_requires_file():
+    c = infer_deliverable_contract("Create the deliverable for the client", [])
+    assert c.expected_extensions == []
+    assert c.confidence == "low"
+    assert c.requires_deliverable is True  # creation verb present
+
+
+# ── selection / reference exclusion ───────────────────────────────────────
+
+def test_reference_xlsx_not_counted_as_generated(tmp_path):
+    ref = tmp_path / "input_data.xlsx"
+    ref.write_bytes(b"PK\x03\x04ref")
+    gen = tmp_path / "report.xlsx"
+    gen.write_bytes(b"PK\x03\x04gen")
+    artifacts = select_generated_artifacts(tmp_path, reference_files=[str(ref)])
+    names = {a.name for a in artifacts}
+    assert "report.xlsx" in names
+    assert "input_data.xlsx" not in names
+
+
+def test_before_snapshot_excludes_preexisting(tmp_path):
+    pre = tmp_path / "already_here.txt"
+    pre.write_text("old")
+    before = snapshot_dir(tmp_path)
+    new = tmp_path / "fresh.pdf"
+    new.write_bytes(b"%PDF-1.4")
+    artifacts = select_generated_artifacts(tmp_path, [], before_snapshot=before)
+    names = {a.name for a in artifacts}
+    assert "fresh.pdf" in names
+    assert "already_here.txt" not in names
+
+
+def test_reserved_control_files_excluded(tmp_path):
+    (tmp_path / "manifest.json").write_text("{}")
+    (tmp_path / "solution.py").write_text("print(1)")
+    (tmp_path / "out.docx").write_bytes(b"PK\x03\x04")
+    names = {a.name for a in select_generated_artifacts(tmp_path, [])}
+    assert names == {"out.docx"}
+
+
+# ── validation ────────────────────────────────────────────────────────────
+
+def test_validate_missing_deliverable_is_blocking(tmp_path):
+    c = infer_deliverable_contract("Create a PDF report", [])
+    v = validate_contract(c, [])
+    assert v.ok is False
+    assert any("at least" in e for e in v.blocking_errors)
+
+
+def test_validate_wrong_primary_high_confidence_blocks(tmp_path):
+    docx = tmp_path / "out.docx"
+    docx.write_bytes(b"PK\x03\x04")
+    c = infer_deliverable_contract("Export results as a .xlsx file", [])  # high
+    v = validate_contract(c, [docx])
+    assert v.ok is False
+    assert any(".xlsx" in e for e in v.blocking_errors)
+
+
+def test_validate_wrong_primary_medium_confidence_only_warns(tmp_path):
+    docx = tmp_path / "out.docx"
+    docx.write_bytes(b"PK\x03\x04")
+    c = infer_deliverable_contract("Make a spreadsheet of the data", [])  # medium
+    v = validate_contract(c, [docx])
+    assert v.ok is True  # not blocking at medium confidence
+    assert v.warnings
+
+
+def test_validate_matching_primary_passes(tmp_path):
+    xlsx = tmp_path / "report.xlsx"
+    xlsx.write_bytes(b"PK\x03\x04data")
+    c = infer_deliverable_contract("Export as .xlsx", [])
+    v = validate_contract(c, [xlsx])
+    assert v.ok is True
+    assert v.matched_primary == ["report.xlsx"]
+
+
+def test_validate_empty_file_does_not_count(tmp_path):
+    empty = tmp_path / "report.xlsx"
+    empty.write_bytes(b"")
+    c = infer_deliverable_contract("Export as .xlsx", [])
+    v = validate_contract(c, [empty])
+    assert v.ok is False  # 0 non-empty files
+
+
+def test_contract_prompt_section_has_no_format_braces():
+    c = infer_deliverable_contract("Build a PowerPoint deck", [])
+    section = c.to_prompt_section()
+    assert "{" not in section and "}" not in section
+    assert "DELIVERABLE CONTRACT" in section

--- a/batch-runner/tests/test_deliverable_contract.py
+++ b/batch-runner/tests/test_deliverable_contract.py
@@ -152,3 +152,64 @@ def test_contract_prompt_section_has_no_format_braces():
     section = c.to_prompt_section()
     assert "{" not in section and "}" not in section
     assert "DELIVERABLE CONTRACT" in section
+
+
+# ── reference-aware confidence downgrade (regression) ─────────────────────
+
+def test_high_confidence_downgraded_when_token_matches_reference():
+    # "csv" is a literal (normally high-confidence) token, but here it names the
+    # INPUT file — so the contract must not stay high and hard-block a valid
+    # differently-typed output.
+    c = infer_deliverable_contract(
+        "Clean the attached CSV and return the deduplicated result.",
+        ["raw_sales.csv"],
+    )
+    assert ".csv" in c.expected_extensions
+    assert c.confidence == "medium"
+
+
+def test_high_confidence_kept_when_no_matching_reference():
+    # Same prompt, but no .csv input -> the token refers to the deliverable.
+    c = infer_deliverable_contract(
+        "Clean the attached CSV and return the deduplicated result.",
+        ["notes.txt"],
+    )
+    assert c.confidence == "high"
+
+
+def test_input_typed_token_does_not_block_valid_other_output(tmp_path):
+    c = infer_deliverable_contract(
+        "Review the attached PDF and produce your written analysis.",
+        ["brief.pdf"],
+    )
+    out = tmp_path / "analysis.docx"
+    out.write_bytes(b"PK\x03\x04realish")
+    v = validate_contract(c, [out])
+    assert v.ok is True          # not blocked: the pdf token referred to the input
+    assert v.warnings            # the mismatch is still surfaced as a warning
+
+
+def test_output_typed_token_still_blocks_when_distinct_from_input(tmp_path):
+    # xlsx names the INPUT (downgraded) but pptx is clearly the requested OUTPUT,
+    # so a wrong-typed deliverable must still block.
+    c = infer_deliverable_contract(
+        "Convert the attached xlsx workbook into a pptx slide deck.",
+        ["data.xlsx"],
+    )
+    assert c.confidence == "high"
+    wrong = tmp_path / "deck.docx"
+    wrong.write_bytes(b"PK\x03\x04realish")
+    v = validate_contract(c, [wrong])
+    assert v.ok is False
+    assert any(".pptx" in e or ".xlsx" in e for e in v.blocking_errors)
+
+
+def test_multi_type_contract_is_any_of(tmp_path):
+    # Documents current behavior: a multi-type contract is satisfied by producing
+    # at least one of the expected types (any-of, not all-of).
+    c = infer_deliverable_contract("Create a pptx deck and an xlsx model", [])
+    assert {".pptx", ".xlsx"} <= set(c.expected_extensions)
+    only_pptx = tmp_path / "deck.pptx"
+    only_pptx.write_bytes(b"PK\x03\x04realish")
+    v = validate_contract(c, [only_pptx])
+    assert v.ok is True

--- a/batch-runner/tests/test_dependency_resolver.py
+++ b/batch-runner/tests/test_dependency_resolver.py
@@ -1,0 +1,157 @@
+"""Tests for core/dependency_resolver.py"""
+
+from pathlib import Path
+
+import pytest
+
+from core.dependency_resolver import (
+    DependencyManifest,
+    load_base_packages,
+    resolve,
+    scan_imports,
+    _normalize,
+)
+
+
+# ── scan_imports ─────────────────────────────────────────────────────────
+
+def test_scan_imports_basic():
+    code = "import os\nimport cv2\nfrom librosa import load\nimport numpy as np"
+    mods = scan_imports(code)
+    assert "cv2" in mods
+    assert "librosa" in mods
+    assert "numpy" in mods
+    assert "os" not in mods  # stdlib skipped
+
+
+def test_scan_imports_skips_skills_package():
+    code = "from skills.video.toolkit import extract_frames\nimport pandas"
+    mods = scan_imports(code)
+    assert "skills" not in mods
+    assert "pandas" in mods
+
+
+def test_scan_imports_relative_ignored():
+    code = "from . import helper\nfrom .sub import thing\nimport scipy"
+    mods = scan_imports(code)
+    assert "scipy" in mods
+    assert "helper" not in mods
+
+
+def test_scan_imports_syntax_error_fallback():
+    # Unparseable code still yields imports via regex fallback.
+    code = "import cv2\nthis is not valid python <<<\nimport librosa"
+    mods = scan_imports(code)
+    assert "cv2" in mods
+    assert "librosa" in mods
+
+
+# ── load_base_packages ───────────────────────────────────────────────────
+
+def test_load_base_packages_real_requirements():
+    base = load_base_packages()
+    assert "librosa" in base
+    assert "opencv-python" in base
+    assert "pandas" in base
+    # implicit base always present even if only transitive
+    assert "numpy" in base
+
+
+def test_load_base_packages_custom_file(tmp_path):
+    req = tmp_path / "requirements.txt"
+    req.write_text(
+        "# comment\n"
+        "Pillow>=10.0.0\n"
+        "pandas==2.1.0  # inline comment\n"
+        "lxml>=4.0; python_version>='3.8'\n"
+        "-e .\n"
+        "\n"
+    )
+    base = load_base_packages(req)
+    assert "pillow" in base
+    assert "pandas" in base
+    assert "lxml" in base
+    assert "numpy" in base  # implicit
+
+
+def test_normalize():
+    assert _normalize("opencv_python") == "opencv-python"
+    assert _normalize("Pillow") == "pillow"
+    assert _normalize("scikit-learn[extra]") == "scikit-learn"
+
+
+# ── resolve ──────────────────────────────────────────────────────────────
+
+def test_resolve_video_extension():
+    m = resolve(reference_files=["/data/clip.mp4"], task_text="")
+    assert "opencv-python" in m.required
+    assert "av" in m.required
+    assert "moviepy" in m.required
+    assert any("ext:.mp4" in r for r in m.sources["opencv-python"])
+
+
+def test_resolve_audio_keyword():
+    m = resolve(reference_files=[], task_text="generate a spectrogram and measure loudness")
+    assert "librosa" in m.required
+    assert "pyloudnorm" in m.required
+    assert any("keyword:" in r for r in m.sources["librosa"])
+
+
+def test_resolve_code_imports():
+    code = "import cv2\nimport fitz\nimport ezdxf"
+    m = resolve(reference_files=[], task_text="", code=code)
+    assert "opencv-python" in m.required  # cv2 -> opencv-python
+    assert "PyMuPDF" in m.required        # fitz -> PyMuPDF
+    assert "ezdxf" in m.required
+
+
+def test_resolve_classifies_in_base_vs_missing():
+    base = load_base_packages()
+    # ezdxf is intentionally NOT in requirements.txt -> missing_from_base
+    m = resolve(reference_files=["/x.dxf"], task_text="", base_packages=base)
+    assert "ezdxf" in m.required
+    assert "ezdxf" in m.missing_from_base
+    assert "ezdxf" not in m.in_base
+
+
+def test_resolve_numpy_not_falsely_missing():
+    base = load_base_packages()
+    m = resolve(reference_files=["/x.png"], task_text="", base_packages=base)
+    assert "numpy" in m.required
+    assert "numpy" in m.in_base
+    assert "numpy" not in m.missing_from_base
+
+
+def test_resolve_empty_task():
+    m = resolve(reference_files=[], task_text="just write a poem")
+    assert m.required == []
+    assert m.to_prompt_hint() == ""
+
+
+def test_manifest_to_prompt_hint_with_missing():
+    base = load_base_packages()
+    m = resolve(reference_files=["/x.dxf"], task_text="", base_packages=base)
+    hint = m.to_prompt_hint()
+    assert "ezdxf" in hint
+    assert "Not guaranteed" in hint
+
+
+def test_manifest_to_dict_keys():
+    m = resolve(reference_files=["/a.csv"], task_text="")
+    d = m.to_dict()
+    assert set(d.keys()) == {"required", "sources", "in_base", "missing_from_base"}
+
+
+def test_resolve_combines_all_three_signals():
+    m = resolve(
+        reference_files=["/data/clip.mp4"],
+        task_text="extract keyframes",
+        code="import pytesseract",
+    )
+    # ext signal
+    assert "opencv-python" in m.required
+    # keyword signal (keyframe -> opencv-python/moviepy)
+    assert "moviepy" in m.required
+    # import signal
+    assert "pytesseract" in m.required
+    assert any("import:pytesseract" in r for r in m.sources["pytesseract"])

--- a/batch-runner/tests/test_executor.py
+++ b/batch-runner/tests/test_executor.py
@@ -181,3 +181,90 @@ def test_executor_json_renderer_passes_token_override():
 
         kwargs = mock_runner_cls.call_args.kwargs
         assert kwargs["max_completion_tokens"] == 6789
+
+
+# ── Sandbox mode ───────────────────────────────────────────────────────────
+
+
+def test_executor_initialization_sandbox():
+    """Test executor initializes sandbox mode with llm_client"""
+    mock_client = Mock()
+    executor = TaskExecutor(mode="sandbox", llm_client=mock_client)
+    assert executor.mode == "sandbox"
+    assert executor.runner is not None
+
+
+def test_executor_sandbox_requires_llm_client():
+    """Test sandbox mode raises error without llm_client"""
+    with pytest.raises(ValueError, match="sandbox mode requires llm_client"):
+        TaskExecutor(mode="sandbox")
+
+
+def test_executor_validate_mode_sandbox_all_providers():
+    """Sandbox mode works with all providers (no provider restriction)"""
+    for provider in ("azure", "openai", "anthropic"):
+        valid, error = TaskExecutor.validate_mode("sandbox", provider)
+        assert valid is True
+        assert error is None
+
+
+def test_executor_sandbox_passes_options_and_tokens():
+    """TaskExecutor should forward sandbox_options + token override to SandboxRunner"""
+    mock_client = Mock()
+    with patch("core.executor.SandboxRunner") as mock_runner_cls:
+        mock_runner_cls.return_value = Mock()
+
+        TaskExecutor(
+            mode="sandbox",
+            llm_client=mock_client,
+            tokens={"code_generation": 4242},
+            sandbox_options={
+                "image": "custom-sandbox:1.0",
+                "use_docker": "always",
+                "memory_gb": 7,
+                "cpus": 3.0,
+                "max_skills": 4,
+            },
+        )
+
+        kwargs = mock_runner_cls.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 4242
+        assert kwargs["image"] == "custom-sandbox:1.0"
+        assert kwargs["use_docker"] == "always"
+        assert kwargs["memory_gb"] == 7
+        assert kwargs["cpus"] == 3.0
+        assert kwargs["max_skills"] == 4
+
+
+def test_executor_sandbox_defaults_when_no_options():
+    """Sandbox mode should use sane defaults when no sandbox_options given"""
+    mock_client = Mock()
+    with patch("core.executor.SandboxRunner") as mock_runner_cls:
+        mock_runner_cls.return_value = Mock()
+
+        TaskExecutor(mode="sandbox", llm_client=mock_client)
+
+        kwargs = mock_runner_cls.call_args.kwargs
+        assert kwargs["use_docker"] == "auto"
+        assert kwargs["max_skills"] == 5
+
+
+def test_executor_execute_sandbox_delegates():
+    """Test executor.execute delegates to the sandbox runner"""
+    mock_client = Mock()
+    executor = TaskExecutor(mode="sandbox", llm_client=mock_client)
+    executor.runner.run = Mock(return_value={
+        "success": True,
+        "text": "sandbox response",
+        "files": [],
+    })
+
+    result = executor.execute(
+        task_prompt="Test task",
+        model="gpt-5.4",
+        reference_files=["/data/clip.mp4"],
+    )
+
+    assert result["success"] is True
+    assert result["text"] == "sandbox response"
+    executor.runner.run.assert_called_once()

--- a/batch-runner/tests/test_output_qa.py
+++ b/batch-runner/tests/test_output_qa.py
@@ -1,0 +1,102 @@
+"""Tests for core/artifact_renderer.py + core/output_qa.py.
+
+Render tests require PyMuPDF (skip gracefully otherwise). They never call an LLM:
+vision QA is exercised only with a fake client.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from core.artifact_renderer import render_artifact
+from core.deliverable_contract import infer_deliverable_contract
+from core.output_qa import run_output_qa
+
+
+def _make_pdf(path, lines):
+    fitz = pytest.importorskip("fitz")
+    doc = fitz.open()
+    page = doc.new_page()
+    y = 72
+    for ln in lines:
+        page.insert_text((72, y), ln)
+        y += 22
+    doc.save(str(path))
+    doc.close()
+
+
+def test_render_pdf_first_page(tmp_path):
+    pytest.importorskip("fitz")
+    pdf = tmp_path / "doc.pdf"
+    _make_pdf(pdf, ["Hello report", "Second line of content"])
+    out = tmp_path / "render"
+    rr = render_artifact(pdf, out, max_pages=3)
+    assert rr.page_count == 1
+    assert len(rr.rendered_images) == 1
+    assert Path(rr.rendered_images[0]).exists()
+
+
+def test_render_skips_non_renderable(tmp_path):
+    f = tmp_path / "data.csv"
+    f.write_text("a,b\n1,2\n")
+    rr = render_artifact(f, tmp_path / "render")
+    assert rr.rendered_images == []
+    assert any("not rendered" in w for w in rr.warnings)
+
+
+def test_sparse_text_page_not_flagged_blank(tmp_path):
+    pytest.importorskip("fitz")
+    pdf = tmp_path / "sparse.pdf"
+    _make_pdf(pdf, ["Just one short line"])
+    c = infer_deliverable_contract("Produce a PDF report", [])
+    rep = run_output_qa([pdf], contract=c, config={"enabled": True, "render": True},
+                        out_dir=tmp_path / "r", task_text="Produce a PDF report")
+    assert rep.ok is True, rep.blocking_errors
+
+
+def test_truly_blank_page_blocks_primary(tmp_path):
+    fitz = pytest.importorskip("fitz")
+    pdf = tmp_path / "blank.pdf"
+    doc = fitz.open(); doc.new_page(); doc.save(str(pdf)); doc.close()
+    c = infer_deliverable_contract("Produce a PDF report", [])
+    rep = run_output_qa([pdf], contract=c, config={"enabled": True, "render": True},
+                        out_dir=tmp_path / "r", task_text="Produce a PDF report")
+    assert rep.ok is False
+    assert any("blank" in e for e in rep.blocking_errors)
+
+
+def test_output_qa_disabled_is_noop(tmp_path):
+    fitz = pytest.importorskip("fitz")
+    pdf = tmp_path / "blank.pdf"
+    doc = fitz.open(); doc.new_page(); doc.save(str(pdf)); doc.close()
+    rep = run_output_qa([pdf], config={"enabled": False}, out_dir=tmp_path / "r")
+    assert rep.enabled is False
+    assert rep.ok is True
+    assert rep.render_reports == []
+
+
+def test_vision_qa_with_fake_client(tmp_path):
+    pytest.importorskip("fitz")
+    pdf = tmp_path / "doc.pdf"
+    _make_pdf(pdf, ["Content here"])
+
+    class _Msg:
+        content = '{"visual_ok": false, "issues": ["text too small"], "suggested_repair": "increase font"}'
+
+    class _FakeClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    from types import SimpleNamespace
+                    return SimpleNamespace(choices=[SimpleNamespace(message=_Msg())])
+
+    cfg = {"enabled": True, "render": True,
+           "vision": {"enabled": True, "deployment": "fake", "max_images": 2}}
+    rep = run_output_qa([pdf], config=cfg, out_dir=tmp_path / "r",
+                        task_text="t", vision_client=_FakeClient())
+    assert rep.vision_qa is not None
+    assert rep.vision_qa["visual_ok"] is False
+    # Non-blocking by default; surfaced as a warning.
+    assert any("vision QA" in w for w in rep.warnings)
+    assert rep.ok is True

--- a/batch-runner/tests/test_prompt_sections.py
+++ b/batch-runner/tests/test_prompt_sections.py
@@ -1,0 +1,82 @@
+"""Unit tests for the spec-driven section engine (core/prompt_sections.py).
+
+Complements the byte-identity goldens in test_sandbox_prompt_golden.py: those prove
+the *default* output is unchanged; these prove the engine is actually spec-driven —
+reordering/toggling entries changes the output and bad specs fail loudly.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.prompt_sections import (
+    DEFAULT_SECTIONS,
+    SectionContext,
+    assemble_sections,
+)
+
+
+def _ctx(reflection=None, contract=None, ref_files=None):
+    """Context with marker-returning fakes so section ordering is observable."""
+    return SectionContext(
+        task_prompt="TASK_BODY",
+        ref_files=ref_files or [],
+        skills=[],
+        manifest=SimpleNamespace(to_prompt_hint=lambda: "DEPS_HINT"),
+        contract=contract,
+        reflection=reflection,
+        registry=SimpleNamespace(render_manual=lambda skills: "SKILLS_MANUAL"),
+    )
+
+
+def test_default_order_matches_hardcoded_layout():
+    ctx = _ctx(reflection="REFL", contract=SimpleNamespace(to_prompt_section=lambda: "CONTRACT"))
+    out = assemble_sections(DEFAULT_SECTIONS, ctx)
+    # file_structure/previews/available_files skip on empty ref_files.
+    assert out == "REFL\n\nSKILLS_MANUAL\n\nDEPS_HINT\n\nCONTRACT\n\nTASK_BODY"
+
+
+def test_reordering_entries_reorders_output():
+    ctx = _ctx()
+    assert assemble_sections(["task", "deps_hint"], ctx) == "TASK_BODY\n\nDEPS_HINT"
+    assert assemble_sections(["deps_hint", "task"], ctx) == "DEPS_HINT\n\nTASK_BODY"
+
+
+def test_unknown_section_id_raises():
+    with pytest.raises(ValueError, match="unknown prompt section id"):
+        assemble_sections(["task", "does_not_exist"], _ctx())
+
+
+def test_enabled_false_drops_the_section():
+    ctx = _ctx()
+    out = assemble_sections([{"id": "deps_hint", "enabled": False}, {"id": "task"}], ctx)
+    assert out == "TASK_BODY"
+
+
+def test_dict_entry_requires_id():
+    with pytest.raises(ValueError, match="missing 'id'"):
+        assemble_sections([{"enabled": True}], _ctx())
+
+
+def test_invalid_entry_type_raises():
+    with pytest.raises(ValueError, match="invalid prompt section entry"):
+        assemble_sections([123], _ctx())
+
+
+def test_none_and_empty_blocks_are_omitted():
+    # reflection/contract None + empty ref_files → only skills/deps/task survive.
+    out = assemble_sections(DEFAULT_SECTIONS, _ctx())
+    assert out == "SKILLS_MANUAL\n\nDEPS_HINT\n\nTASK_BODY"
+
+
+def test_available_files_emits_basenames_only():
+    ctx = _ctx(ref_files=["/abs/secret/dir/quarterly_ledger.csv"])
+    out = assemble_sections(["available_files"], ctx)
+    assert "quarterly_ledger.csv" in out
+    assert "/abs/secret" not in out
+
+
+def test_string_and_dict_entries_interoperate():
+    ctx = _ctx()
+    out = assemble_sections(["deps_hint", {"id": "task"}], ctx)
+    assert out == "DEPS_HINT\n\nTASK_BODY"

--- a/batch-runner/tests/test_sandbox_cache_probe.py
+++ b/batch-runner/tests/test_sandbox_cache_probe.py
@@ -1,0 +1,92 @@
+"""Tests for core/sandbox_cache.py and the dependency import probe (Part F/G)."""
+
+from pathlib import Path
+
+from core.sandbox_cache import FileCache, build_cache
+from core.dependency_resolver import ImportProbe, probe_imports
+
+
+# ── cache ─────────────────────────────────────────────────────────────────
+
+def test_disabled_cache_is_noop():
+    c = FileCache(enabled=False)
+    k = c.key("abc", "render")
+    assert c.get_bytes(k) is None
+    assert c.put_bytes(k, b"data") is None
+    assert c.get_json(k) is None
+
+
+def test_enabled_cache_roundtrip_bytes(tmp_path):
+    c = FileCache(enabled=True, cache_dir=str(tmp_path))
+    k = c.key(c.hash_bytes(b"input"), "render", {"dpi": 120})
+    assert c.get_bytes(k) is None
+    c.put_bytes(k, b"png-bytes", suffix=".png")
+    assert c.get_bytes(k, suffix=".png") == b"png-bytes"
+
+
+def test_enabled_cache_roundtrip_json(tmp_path):
+    c = FileCache(enabled=True, cache_dir=str(tmp_path))
+    k = c.key("hash", "vision_qa")
+    c.put_json(k, {"visual_ok": True})
+    assert c.get_json(k) == {"visual_ok": True}
+
+
+def test_cache_key_varies_with_config(tmp_path):
+    c = FileCache(enabled=True, cache_dir=str(tmp_path))
+    k1 = c.key("h", "render", {"dpi": 100})
+    k2 = c.key("h", "render", {"dpi": 200})
+    assert k1 != k2
+
+
+def test_build_cache_disabled_default():
+    c = build_cache({})
+    assert c.enabled is False
+
+
+def test_build_cache_under_output_dir(tmp_path):
+    c = build_cache({"enabled": True}, output_dir=str(tmp_path))
+    assert c.enabled is True
+    assert str(tmp_path) in str(c._dir)
+
+
+# ── import probe ────────────────────────────────────────────────────────────
+
+def test_probe_disabled_marks_not_checked():
+    p = probe_imports(["numpy", "pandas"], enabled=False)
+    assert p.available == [] and p.missing == []
+    assert set(p.not_checked) == {"numpy", "pandas"}
+
+
+def test_probe_detects_available_and_missing():
+    def fake_finder(mod):
+        return object() if mod in {"numpy", "os"} else None
+    p = probe_imports(["numpy", "definitely-not-real-pkg"], finder=fake_finder)
+    assert "numpy" in p.available
+    assert "definitely-not-real-pkg" in p.missing
+
+
+def test_probe_maps_pip_to_import_name():
+    seen = {}
+
+    def fake_finder(mod):
+        seen[mod] = True
+        return object()
+    probe_imports(["opencv-python", "Pillow", "scikit-learn"], finder=fake_finder)
+    # pip names map to import names via the reverse table.
+    assert "cv2" in seen
+    assert "PIL" in seen
+    assert "sklearn" in seen
+
+
+def test_probe_handles_finder_exception_as_not_checked():
+    def boom(mod):
+        raise ValueError("weird")
+    p = probe_imports(["somepkg"], finder=boom)
+    assert p.not_checked == ["somepkg"]
+
+
+def test_import_probe_to_dict():
+    p = ImportProbe(available=["numpy"], missing=["foo"], env="host")
+    d = p.to_dict()
+    assert d["available"] == ["numpy"]
+    assert d["env"] == "host"

--- a/batch-runner/tests/test_sandbox_prompt_golden.py
+++ b/batch-runner/tests/test_sandbox_prompt_golden.py
@@ -258,3 +258,34 @@ def test_build_reflection_golden(runner):
     assert "/workspace/solution.py" in reflection
     _assert_no_host_roots(reflection)
     _assert_golden("repair_accounting.reflection.txt", reflection)
+
+
+def test_reflection_wording_is_spec_driven(runner):
+    """Editing reflection_strings in the spec must change the emitted wording.
+
+    Proves the P1 externalization is live (not dead config): overriding the open/
+    close markers on the loaded spec surfaces them in _build_reflection output.
+    """
+    r = SandboxRunner(llm_client=SimpleNamespace(), use_docker="never")
+    r.prompt_data = dict(r.prompt_data)  # shallow copy — don't mutate shared spec
+    r.prompt_data["reflection_strings"] = {
+        **(r.prompt_data.get("reflection_strings") or {}),
+        "open": "<<REPAIR-OPEN>>",
+        "close": "<<REPAIR-CLOSE>>",
+    }
+    out = r._build_reflection(
+        _contract([".xlsx"], "high"), ["missing .xlsx"], "", {"text": "", "error": ""}, {}
+    )
+    assert out.startswith("<<REPAIR-OPEN>>")
+    assert out.rstrip().endswith("<<REPAIR-CLOSE>>")
+
+
+def test_reflection_falls_back_when_spec_omits_strings():
+    """A spec without reflection_strings must still yield the built-in wording."""
+    r = SandboxRunner(llm_client=SimpleNamespace(), use_docker="never")
+    r.prompt_data = {k: v for k, v in r.prompt_data.items() if k != "reflection_strings"}
+    out = r._build_reflection(
+        _contract([".xlsx"], "high"), ["missing .xlsx"], "", {"text": "", "error": ""}, {}
+    )
+    assert out.startswith("[REFLECTION]")
+    assert out.rstrip().endswith("[/REFLECTION]")

--- a/batch-runner/tests/test_sandbox_prompt_golden.py
+++ b/batch-runner/tests/test_sandbox_prompt_golden.py
@@ -1,0 +1,260 @@
+"""Golden byte-identical snapshots of the sandbox prompt assembly.
+
+P0 of the prompt-consolidation refactor (design under tasks/0707_tuesday/). This
+test is the *arbiter of zero default drift*: it freezes the exact text produced by
+
+    SandboxRunner._augment_prompt(...)   — section assembly (order/labels/joining)
+    SandboxRunner._build_reflection(...) — self-QA repair wording (loop 2)
+
+so that the later phases (P1 externalize reflection strings, P2 spec-driven
+section ordering) can refactor the *internals* while proving the emitted prompt is
+unchanged. If a later phase legitimately changes the wording, regenerate the
+snapshots deliberately:
+
+    REGEN_PROMPT_GOLDEN=1 python -m pytest tests/test_sandbox_prompt_golden.py
+
+Design constraints honored here:
+* Model-free & Docker-free — we only call the pure assembly helpers, never the LLM
+  or a container (mirrors tests/test_sandbox_runner.py: use_docker="never").
+* Deterministic & hermetic — inputs are *canned* (fixed Skill/contract/manifest
+  objects and fixed-byte reference files created in a tmp dir), so snapshots are
+  stable across machines. Reference file paths are temp dirs but only basenames +
+  fixed sizes ever reach the prompt.
+* Privacy — asserts none of the real host-root redaction targets leak into the
+  assembled text.
+"""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.sandbox_runner import SandboxRunner, _REDACT_ROOTS
+from core.skills_registry import Skill
+from core.deliverable_contract import DeliverableContract
+from core.dependency_resolver import DependencyManifest
+from core.prompt_loader import render_prompt
+
+
+GOLDEN_DIR = Path(__file__).parent / "fixtures" / "prompt" / "golden"
+REGEN = os.environ.get("REGEN_PROMPT_GOLDEN") == "1"
+
+
+# ── canned fixture builders ───────────────────────────────────────────────
+
+def _skill(name, title, description, api, exts, kws):
+    """A fully-populated Skill as it looks *after* selection (score/matches set)."""
+    s = Skill(
+        name=name,
+        title=title,
+        description=description,
+        modalities=[name],
+        file_extensions=exts,
+        keywords=kws,
+        requires=[],
+        version="1",
+        body="",
+        api=api,
+        path=Path("."),
+    )
+    s.matched_extensions = list(exts)
+    s.matched_keywords = list(kws)
+    return s
+
+
+_SKILLS = {
+    "audio": _skill(
+        "audio", "Audio Perception", "Listen via FFT/sampling and edit waveforms.",
+        "  audio.fft_summary(path) -> dict; audio.loudness_lufs(path) -> float",
+        [".wav"], ["mix", "stem"],
+    ),
+    "video": _skill(
+        "video", "Video Perception", "See a clip frame-by-frame and composite.",
+        "  video.keyframes(path, max_frames=8) -> list; video.montage(frames, out)",
+        [".mp4"], ["composite", "shot"],
+    ),
+    "document": _skill(
+        "document", "Document Toolkit", "Read and author documents.",
+        "  document.make_docx(title, lines, out); document.read_any(path) -> str",
+        [".docx"], ["report", "memo"],
+    ),
+    "data": _skill(
+        "data", "Data Toolkit", "Load tables and build spreadsheets/charts.",
+        "  data.read_table(path) -> df; data.quick_chart(df, out)",
+        [".csv", ".xlsx"], ["spreadsheet", "model"],
+    ),
+}
+
+
+def _manifest(required, missing=None):
+    return DependencyManifest(required=list(required), missing_from_base=list(missing or []))
+
+
+def _contract(exts, confidence, keywords=None):
+    return DeliverableContract(
+        expected_extensions=list(exts),
+        confidence=confidence,
+        required_keywords=list(keywords or []),
+    )
+
+
+# ``refs`` are (filename, fixed_bytes) — written to a tmp dir per test so only the
+# basename + fixed size ever surface in the prompt (no host paths).
+SCENARIOS = {
+    "audio_capstone": dict(
+        occupation="Audio Producer",
+        task_prompt="Edit the supplied stems, produce a balanced mix, and write an edit report.",
+        refs=[("State_of_Affairs_STEM.wav", b"RIFF" + b"\x00" * 508)],
+        skills=["audio", "document"],
+        manifest=_manifest(["librosa", "python-docx", "soundfile"], missing=["aspose-words"]),
+        contract=_contract([".wav", ".docx"], "medium", ["mix"]),
+        reflection=None,
+    ),
+    "video_capstone": dict(
+        occupation="Film and Video Editor",
+        task_prompt="Composite the actor between the two clips and make them vanish in a teleport effect.",
+        refs=[("TWT_A001_03.mp4", b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 500)],
+        skills=["video"],
+        manifest=_manifest(["opencv-python", "numpy"]),
+        contract=_contract([".mp4", ".png"], "medium", ["composite"]),
+        reflection=None,
+    ),
+    "doc_only_no_refs": dict(
+        occupation="Management Consultant",
+        task_prompt="Write a two-page strategy memo summarizing the market entry options.",
+        refs=[],
+        skills=["document"],
+        manifest=_manifest(["python-docx"]),
+        contract=_contract([".docx"], "medium", ["memo"]),
+        reflection=None,
+    ),
+    "accounting_spreadsheet": dict(
+        occupation="Accountant",
+        task_prompt="Build a quarterly financial model spreadsheet from the ledger and add a summary chart.",
+        # CSV *input* (deterministic, stdlib preview) while the deliverable contract
+        # expects .xlsx — this is the contract-extension-inference coverage case.
+        refs=[("ledger.csv", b"date,account,amount\n2026-01-01,cash,100\n2026-01-02,ar,250\n")],
+        skills=["data"],
+        manifest=_manifest(["openpyxl", "pandas"]),
+        contract=_contract([".xlsx"], "high", ["model"]),
+        reflection=None,
+    ),
+}
+
+
+def _build_inputs(scenario: dict, base_dir: Path):
+    ref_paths = []
+    for fname, payload in scenario["refs"]:
+        p = base_dir / fname
+        p.write_bytes(payload)
+        ref_paths.append(str(p))
+    skills = [_SKILLS[k] for k in scenario["skills"]]
+    return (
+        scenario["task_prompt"],
+        ref_paths,
+        skills,
+        scenario["manifest"],
+        scenario["contract"],
+        scenario["reflection"],
+        scenario["occupation"],
+    )
+
+
+@pytest.fixture(scope="module")
+def runner():
+    # No client calls happen in the assembly helpers; a bare namespace is enough.
+    return SandboxRunner(llm_client=SimpleNamespace(), use_docker="never")
+
+
+def _assert_golden(name: str, actual: str):
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    path = GOLDEN_DIR / name
+    if REGEN:
+        path.write_text(actual, encoding="utf-8")
+        return
+    assert path.exists(), (
+        f"Missing golden {path.name}. Regenerate with "
+        f"REGEN_PROMPT_GOLDEN=1 python -m pytest {Path(__file__).name}"
+    )
+    expected = path.read_text(encoding="utf-8")
+    assert actual == expected, (
+        f"Prompt assembly drifted for {name}. If this change is intentional, "
+        f"regenerate goldens with REGEN_PROMPT_GOLDEN=1."
+    )
+
+
+def _assert_no_host_roots(text: str):
+    for root in _REDACT_ROOTS:
+        assert root not in text, f"host root leaked into prompt: {root!r}"
+
+
+# ── tests ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("name", list(SCENARIOS))
+def test_augment_prompt_golden(name, runner, tmp_path):
+    task_prompt, refs, skills, manifest, contract, reflection, occ = _build_inputs(
+        SCENARIOS[name], tmp_path
+    )
+    augmented = runner._augment_prompt(task_prompt, refs, skills, manifest, contract, reflection)
+    _assert_no_host_roots(augmented)
+    _assert_golden(f"{name}.augmented.txt", augmented)
+
+    # Also lock the template wrapping (render_prompt with no experiment override,
+    # which is the exp026 default) so P2 can't drift the final user message either.
+    rendered = render_prompt(
+        runner.prompt_data, occupation=occ, task_prompt=augmented, experiment_prompt=None
+    )
+    _assert_no_host_roots(rendered["user_prompt"])
+    _assert_golden(f"{name}.rendered_user.txt", rendered["user_prompt"])
+
+
+def test_augment_prompt_is_deterministic(runner, tmp_path):
+    """Same inputs → byte-identical output across calls (no ordering nondeterminism)."""
+    task_prompt, refs, skills, manifest, contract, reflection, _ = _build_inputs(
+        SCENARIOS["audio_capstone"], tmp_path
+    )
+    a = runner._augment_prompt(task_prompt, refs, skills, manifest, contract, reflection)
+    b = runner._augment_prompt(task_prompt, refs, skills, manifest, contract, reflection)
+    assert a == b
+
+
+def test_augment_prompt_prepends_reflection(runner, tmp_path):
+    """When a reflection is supplied it must lead the assembled prompt (repair path)."""
+    task_prompt, refs, skills, manifest, contract, _, _ = _build_inputs(
+        SCENARIOS["audio_capstone"], tmp_path
+    )
+    reflection = "[REFLECTION]\nFix the missing .wav deliverable.\n[/REFLECTION]"
+    augmented = runner._augment_prompt(task_prompt, refs, skills, manifest, contract, reflection)
+    assert augmented.startswith(reflection)
+    _assert_golden("audio_capstone.with_reflection.augmented.txt", augmented)
+
+
+def test_build_reflection_golden(runner):
+    """Loop-2 repair reflection wording, with real host-root redaction proven stable.
+
+    The stderr tail embeds the real home dir and a container path; the sanitizer
+    must turn the home dir into ``~`` (machine-stable) while leaving the container
+    path intact.
+    """
+    contract = _contract([".xlsx"], "high", ["model"])
+    blocking = [
+        "missing_expected_type: no .xlsx deliverable was produced",
+        "empty_output: execution wrote 0 files",
+    ]
+    warnings = ["render_qa: first page appears blank"]
+    home = os.path.expanduser("~")
+    result = {
+        "text": "Loaded ledger.csv\nComputed totals\n(no file written)",
+        "error": f"Traceback (most recent call last):\n  File \"{home}/run.py\", line 3\n"
+                 f"  File \"/workspace/solution.py\", line 9\nValueError: bad column",
+    }
+    code = "import pandas as pd\ndf = pd.read_csv('ledger.csv')\nprint(df.sum())"
+    reflection = runner._build_reflection(contract, blocking, code, result, {"warnings": warnings})
+
+    # Home dir redacted to ~, container path preserved, no raw host roots.
+    assert f"{home}/run.py" not in reflection
+    assert "~/run.py" in reflection
+    assert "/workspace/solution.py" in reflection
+    _assert_no_host_roots(reflection)
+    _assert_golden("repair_accounting.reflection.txt", reflection)

--- a/batch-runner/tests/test_sandbox_prompt_golden.py
+++ b/batch-runner/tests/test_sandbox_prompt_golden.py
@@ -289,3 +289,59 @@ def test_reflection_falls_back_when_spec_omits_strings():
     )
     assert out.startswith("[REFLECTION]")
     assert out.rstrip().endswith("[/REFLECTION]")
+
+
+_PERCEPTION_BLOCK = (
+    "[AUDIO ANALYSIS]\n"
+    "Tempo ~120 BPM; integrated loudness -14 LUFS; 3 stems detected.\n"
+    "[/AUDIO ANALYSIS]"
+)
+
+
+def test_perception_passthrough_equals_prepend(runner, tmp_path):
+    """Option A byte-identity: perception as a section == prepending it to the task.
+
+    Proves step2's sandbox pass-through (perception_text) produces exactly the same
+    assembled prompt as the legacy prepend-into-task behavior, so enabling the
+    perception_analysis section causes zero drift on real perception runs.
+    """
+    task_prompt, refs, skills, manifest, contract, _, _ = _build_inputs(
+        SCENARIOS["audio_capstone"], tmp_path
+    )
+    sandbox_reflection = "[REFLECTION]\nFix the missing mix.\n[/REFLECTION]"
+
+    old = runner._augment_prompt(  # perception glued to front of task, section off
+        _PERCEPTION_BLOCK + "\n\n" + task_prompt, refs, skills, manifest, contract,
+        sandbox_reflection, perception_text=None,
+    )
+    new = runner._augment_prompt(  # perception passed as its own section
+        task_prompt, refs, skills, manifest, contract,
+        sandbox_reflection, perception_text=_PERCEPTION_BLOCK,
+    )
+    assert new == old
+    assert (_PERCEPTION_BLOCK + "\n\n" + task_prompt) in new  # sits right before task
+
+
+def test_perception_section_golden(runner, tmp_path):
+    """Lock the assembled prompt when perception + a repair reflection are present."""
+    task_prompt, refs, skills, manifest, contract, _, _ = _build_inputs(
+        SCENARIOS["audio_capstone"], tmp_path
+    )
+    reflection = "[REFLECTION]\nPrevious attempt produced no .wav. Regenerate.\n[/REFLECTION]"
+    augmented = runner._augment_prompt(
+        task_prompt, refs, skills, manifest, contract, reflection,
+        perception_text=_PERCEPTION_BLOCK,
+    )
+    _assert_no_host_roots(augmented)
+    _assert_golden("audio_capstone.with_perception.augmented.txt", augmented)
+
+
+def test_perception_omitted_when_absent(runner, tmp_path):
+    """No perception_text → perception_analysis section is dropped (default output)."""
+    task_prompt, refs, skills, manifest, contract, _, _ = _build_inputs(
+        SCENARIOS["audio_capstone"], tmp_path
+    )
+    with_none = runner._augment_prompt(
+        task_prompt, refs, skills, manifest, contract, None, perception_text=None
+    )
+    assert "[AUDIO ANALYSIS]" not in with_none

--- a/batch-runner/tests/test_sandbox_runner.py
+++ b/batch-runner/tests/test_sandbox_runner.py
@@ -193,3 +193,141 @@ def test_run_selects_skills_for_video_task():
 def _dummy_manifest():
     from core.dependency_resolver import DependencyManifest
     return DependencyManifest()
+
+
+# ── output control loop: repair + manifest ───────────────────────────────
+
+def _docx_bytes(text="content"):
+    import io
+    docx = pytest.importorskip("docx")
+    buf = io.BytesIO()
+    d = docx.Document()
+    d.add_paragraph(text)
+    d.save(buf)
+    return buf.getvalue()
+
+
+def _pptx_bytes():
+    import io
+    pptx = pytest.importorskip("pptx")
+    buf = io.BytesIO()
+    prs = pptx.Presentation()
+    prs.slides.add_slide(prs.slide_layouts[6])
+    prs.save(buf)
+    return buf.getvalue()
+
+
+def _runner_no_render(**kw):
+    # Render off keeps the loop fast/hermetic; contract drives the repair.
+    return SandboxRunner(
+        llm_client=object(), use_docker="never",
+        output_qa={"enabled": True, "render": False}, **kw
+    )
+
+
+def test_repair_loop_produces_repaired_ok():
+    """Attempt 0 emits the wrong type, attempt 1 emits the right one."""
+    _pptx = _pptx_bytes()
+    _docx = _docx_bytes()
+    runner = _runner_no_render()
+    code = _fake_response("Deck.\n```python\nprint('build')\n```")
+    exec_results = [
+        ("local", {"success": True, "text": "r0",
+                   "files": [{"filename": "deck.docx", "content": _docx}]}),
+        ("local", {"success": True, "text": "r1",
+                   "files": [{"filename": "deck.pptx", "content": _pptx}]}),
+    ]
+    with patch.object(sr, "complete", lambda **k: (code, {})), \
+         patch.object(runner, "_execute", side_effect=exec_results):
+        result = runner.run(task_prompt="Create a PowerPoint pptx deck for the board",
+                            model="m", reference_files=[])
+
+    assert result["final_status"] == "repaired_ok"
+    assert result["qa_ok"] is True
+    statuses = [a["status"] for a in result["metadata"]["attempts"]]
+    assert statuses == ["failed_contract", "repaired_ok"]
+    names = [f["filename"] for f in result["files"]]
+    assert "deck.pptx" in names and "deck.docx" not in names
+
+
+def test_clean_first_attempt_does_not_repair():
+    _pptx = _pptx_bytes()
+    runner = _runner_no_render()
+    code = _fake_response("Deck.\n```python\nprint('build')\n```")
+    mock_exec = patch.object(
+        runner, "_execute",
+        return_value=("local", {"success": True, "text": "ok",
+                                "files": [{"filename": "deck.pptx", "content": _pptx}]}),
+    )
+    with patch.object(sr, "complete", lambda **k: (code, {})), mock_exec as m:
+        result = runner.run(task_prompt="Create a pptx deck", model="m", reference_files=[])
+    assert result["final_status"] == "ok"
+    assert len(result["metadata"]["attempts"]) == 1
+    m.assert_called_once()
+
+
+def test_repair_disabled_runs_single_attempt():
+    _docx = _docx_bytes()
+    runner = SandboxRunner(
+        llm_client=object(), use_docker="never",
+        repair={"enabled": False},
+        output_qa={"enabled": True, "render": False},
+    )
+    code = _fake_response("```python\nprint('x')\n```")
+    with patch.object(sr, "complete", lambda **k: (code, {})), \
+         patch.object(runner, "_execute",
+                      return_value=("local", {"success": True, "text": "",
+                                              "files": [{"filename": "out.docx", "content": _docx}]})):
+        result = runner.run(task_prompt="Create a pptx deck", model="m", reference_files=[])
+    assert len(result["metadata"]["attempts"]) == 1
+    assert result["final_status"] == "failed_contract"
+    # success still reflects that code executed and a file was produced.
+    assert result["success"] is True
+
+
+def test_failed_contract_after_repair_keeps_best():
+    _docx = _docx_bytes()
+    runner = _runner_no_render()
+    code = _fake_response("```python\nprint('x')\n```")
+    with patch.object(sr, "complete", lambda **k: (code, {})), \
+         patch.object(runner, "_execute",
+                      return_value=("local", {"success": True, "text": "",
+                                              "files": [{"filename": "out.docx", "content": _docx}]})):
+        result = runner.run(task_prompt="Create a pptx deck", model="m", reference_files=[])
+    assert result["final_status"] == "failed_contract"
+    assert len(result["metadata"]["attempts"]) == 2
+
+
+def test_manifest_schema_present():
+    _pptx = _pptx_bytes()
+    runner = _runner_no_render()
+    code = _fake_response("```python\nprint('x')\n```")
+    with patch.object(sr, "complete", lambda **k: (code, {})), \
+         patch.object(runner, "_execute",
+                      return_value=("local", {"success": True, "text": "",
+                                              "files": [{"filename": "deck.pptx", "content": _pptx}]})):
+        result = runner.run(task_prompt="Create a pptx deck", model="m", reference_files=[])
+    m = result["sandbox_manifest"]
+    for key in ["schema_version", "execution_mode", "sandbox_backend", "selected_skills",
+                "dependency_resolution", "dependency_import_probe", "deliverable_contract",
+                "generated_artifacts", "verification_report", "attempts", "final_status"]:
+        assert key in m, key
+    assert m["execution_mode"] == "sandbox"
+    assert m["final_status"] == "ok"
+    # manifest.json is also emitted as a deliverable file.
+    assert "manifest.json" in [f["filename"] for f in result["files"]]
+
+
+def test_manifest_has_no_temp_paths():
+    import json as _json
+    _pptx = _pptx_bytes()
+    runner = _runner_no_render()
+    code = _fake_response("```python\nprint('x')\n```")
+    with patch.object(sr, "complete", lambda **k: (code, {})), \
+         patch.object(runner, "_execute",
+                      return_value=("local", {"success": True, "text": "",
+                                              "files": [{"filename": "deck.pptx", "content": _pptx}]})):
+        result = runner.run(task_prompt="Create a pptx deck", model="m", reference_files=[])
+    blob = _json.dumps(result["sandbox_manifest"])
+    assert "gdpval_qa_" not in blob
+    assert "/var/folders" not in blob and "/tmp/" not in blob

--- a/batch-runner/tests/test_sandbox_runner.py
+++ b/batch-runner/tests/test_sandbox_runner.py
@@ -331,3 +331,70 @@ def test_manifest_has_no_temp_paths():
     blob = _json.dumps(result["sandbox_manifest"])
     assert "gdpval_qa_" not in blob
     assert "/var/folders" not in blob and "/tmp/" not in blob
+
+
+# ── import probe wiring (regression: probe was fed an empty list) ──────────
+
+def _xlsx_bytes():
+    import io
+    openpyxl = pytest.importorskip("openpyxl")
+    buf = io.BytesIO()
+    openpyxl.Workbook().save(buf)
+    return buf.getvalue()
+
+
+def test_manifest_import_probe_reflects_resolved_deps():
+    _xlsx = _xlsx_bytes()
+    runner = _runner_no_render()
+    code = _fake_response("```python\nprint('x')\n```")
+    task = "Create an Excel xlsx workbook from data.xlsx"
+    with patch.object(sr, "complete", lambda **k: (code, {})), \
+         patch.object(runner, "_execute",
+                      return_value=("local", {"success": True, "text": "",
+                                              "files": [{"filename": "report.xlsx", "content": _xlsx}]})):
+        result = runner.run(task_prompt=task, model="m", reference_files=["data.xlsx"])
+    probe = result["sandbox_manifest"]["dependency_import_probe"]
+    union = set(probe["available"]) | set(probe["missing"]) | set(probe["not_checked"])
+    # Regression guard: the probe must reflect the resolved deps, not be empty.
+    assert union, "import probe was empty — not wired to the resolved dependencies"
+    # openpyxl is predicted from the .xlsx reference and installed in the test env.
+    assert "openpyxl" in probe["available"]
+    assert probe["env"] == "host"  # local execution probes the host interpreter
+
+
+# ── tail redaction (regression: local crash leaked the temp path) ─────────
+
+def test_sanitize_tail_redacts_and_trims():
+    import os
+    import tempfile
+    from core.sandbox_runner import _sanitize_tail
+    tmp = tempfile.gettempdir()
+    redacted = _sanitize_tail(f'File "{tmp}/tmpABC/solution.py", line 3\nRuntimeError: boom')
+    assert tmp not in redacted
+    assert "<tmp>" in redacted
+    assert "RuntimeError: boom" in redacted          # useful text preserved
+    home = os.path.expanduser("~")
+    assert home not in _sanitize_tail(f"opened {home}/secret/data.xlsx")
+    assert _sanitize_tail("x" * 1000, limit=100) == "x" * 100   # trimming applied
+    assert _sanitize_tail(None) == ""
+
+
+def test_manifest_redacts_local_paths_on_real_crash():
+    """Exercise the REAL local runner so the traceback embeds an absolute path."""
+    import json as _json
+    import os
+    import tempfile
+    runner = SandboxRunner(
+        llm_client=object(), use_docker="never",
+        output_qa={"enabled": True, "render": False}, repair={"enabled": False},
+    )
+    code = _fake_response("Build it.\n```python\nraise RuntimeError('boom from solution')\n```")
+    with patch.object(sr, "complete", lambda **k: (code, {})):
+        result = runner.run(task_prompt="Create a PDF report", model="m", reference_files=[])
+    blob = _json.dumps(result["sandbox_manifest"])
+    assert tempfile.gettempdir() not in blob
+    assert "/var/folders" not in blob
+    assert os.path.expanduser("~") not in blob
+    # The error itself is preserved (redacted, not dropped).
+    tail = result["sandbox_manifest"]["attempts"][0]["stderr_tail"]
+    assert "RuntimeError" in tail and "<tmp>" in tail

--- a/batch-runner/tests/test_sandbox_runner.py
+++ b/batch-runner/tests/test_sandbox_runner.py
@@ -43,6 +43,46 @@ def test_docker_image_exists_handles_missing_daemon():
     assert isinstance(docker_image_exists("definitely-not-a-real-image:xyz"), bool)
 
 
+def _fake_run_factory(inspect_rc, ls_stdout, ls_rc=0):
+    """Build a fake subprocess.run that distinguishes the inspect vs ls calls."""
+    calls = []
+
+    def _fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        if cmd[:3] == ["docker", "image", "inspect"]:
+            return SimpleNamespace(returncode=inspect_rc, stdout="", stderr="")
+        if cmd[:3] == ["docker", "image", "ls"]:
+            return SimpleNamespace(returncode=ls_rc, stdout=ls_stdout, stderr="")
+        raise AssertionError(f"unexpected docker cmd: {cmd}")
+
+    return _fake_run, calls
+
+
+def test_docker_image_exists_falls_back_to_ls_under_containerd_store():
+    # Reproduces the Docker Desktop containerd-store quirk: `image inspect
+    # name:tag` fails with "No such image" but the tag IS present, so
+    # `image ls -q` resolves it. The runner must still report the image present.
+    fake_run, calls = _fake_run_factory(inspect_rc=1, ls_stdout="2df0878a9edf\n")
+    with patch.object(sr.subprocess, "run", fake_run):
+        assert docker_image_exists("gdpval-sandbox:latest") is True
+    # It must have consulted the reliable ls fallback after inspect failed.
+    assert any(c[:3] == ["docker", "image", "ls"] for c in calls)
+
+
+def test_docker_image_exists_false_when_both_inspect_and_ls_empty():
+    fake_run, _ = _fake_run_factory(inspect_rc=1, ls_stdout="")
+    with patch.object(sr.subprocess, "run", fake_run):
+        assert docker_image_exists("no-such-image:latest") is False
+
+
+def test_docker_image_exists_fast_path_skips_ls_when_inspect_ok():
+    fake_run, calls = _fake_run_factory(inspect_rc=0, ls_stdout="should-not-be-read")
+    with patch.object(sr.subprocess, "run", fake_run):
+        assert docker_image_exists("gdpval-sandbox:latest") is True
+    # inspect succeeded → the ls fallback must not run.
+    assert all(c[:3] != ["docker", "image", "ls"] for c in calls)
+
+
 # ── construction ─────────────────────────────────────────────────────────
 
 def test_init_wires_registry_and_base_packages():

--- a/batch-runner/tests/test_sandbox_runner.py
+++ b/batch-runner/tests/test_sandbox_runner.py
@@ -398,3 +398,39 @@ def test_manifest_redacts_local_paths_on_real_crash():
     # The error itself is preserved (redacted, not dropped).
     tail = result["sandbox_manifest"]["attempts"][0]["stderr_tail"]
     assert "RuntimeError" in tail and "<tmp>" in tail
+
+
+# ── reasoning-effort / budget guard (PR #57 hardening) ───────────────────
+
+def test_high_reasoning_low_budget_warns(capsys):
+    """high reasoning + small code budget is the known empty-output/timeout trap."""
+    SandboxRunner(
+        llm_client=object(), use_docker="never",
+        reasoning_effort="high", max_completion_tokens=16384,
+    )
+    out = capsys.readouterr().out
+    assert "reasoning_effort='high'" in out
+    assert "16384" in out
+    assert str(sr.SAFE_HIGH_CODE_BUDGET) in out
+
+
+def test_high_reasoning_safe_budget_no_warn(capsys):
+    """At/above SAFE_HIGH_CODE_BUDGET, high reasoning must not warn."""
+    SandboxRunner(
+        llm_client=object(), use_docker="never",
+        reasoning_effort="high", max_completion_tokens=sr.SAFE_HIGH_CODE_BUDGET,
+    )
+    assert "reasoning_effort='high'" not in capsys.readouterr().out
+
+
+def test_medium_reasoning_low_budget_no_warn(capsys):
+    """The guard is scoped to high effort; medium/low never warn."""
+    SandboxRunner(
+        llm_client=object(), use_docker="never",
+        reasoning_effort="medium", max_completion_tokens=16384,
+    )
+    assert "reasoning_effort='high'" not in capsys.readouterr().out
+
+
+def test_safe_high_code_budget_constant():
+    assert sr.SAFE_HIGH_CODE_BUDGET == 32768

--- a/batch-runner/tests/test_sandbox_runner.py
+++ b/batch-runner/tests/test_sandbox_runner.py
@@ -1,0 +1,195 @@
+"""Tests for core/sandbox_runner.py
+
+These tests never require Docker or the heavy multimodal deps: the end-to-end
+path is exercised through the hardened local fallback (use_docker="never") with
+the LLM call patched out.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import core.sandbox_runner as sr
+from core.sandbox_runner import (
+    SandboxRunner,
+    docker_available,
+    docker_image_exists,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+def _fake_response(content: str):
+    """Build a minimal object shaped like an OpenAI chat completion."""
+    msg = SimpleNamespace(content=content)
+    choice = SimpleNamespace(message=msg)
+    return SimpleNamespace(choices=[choice])
+
+
+def _patch_complete(content: str):
+    """Patch core.sandbox_runner.complete to return our canned response."""
+    return patch.object(sr, "complete", lambda **kwargs: (_fake_response(content), {}))
+
+
+# ── module-level probes ──────────────────────────────────────────────────
+
+def test_docker_available_returns_bool():
+    assert isinstance(docker_available(refresh=True), bool)
+
+
+def test_docker_image_exists_handles_missing_daemon():
+    # Whatever the environment, this must return a bool and never raise.
+    assert isinstance(docker_image_exists("definitely-not-a-real-image:xyz"), bool)
+
+
+# ── construction ─────────────────────────────────────────────────────────
+
+def test_init_wires_registry_and_base_packages():
+    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    assert runner.registry is not None
+    assert runner.skills_dir.endswith("skills")
+    assert "librosa" in runner._base_packages
+    assert runner.image  # default image name
+
+
+def test_default_prompt_name():
+    assert SandboxRunner.DEFAULT_PROMPT == "sandbox_occupation_codegen"
+
+
+# ── prompt augmentation ──────────────────────────────────────────────────
+
+def test_augment_prompt_includes_skill_and_dep_hints():
+    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    skills = runner.registry.select(["/data/clip.mp4"], "extract keyframes")
+    from core.dependency_resolver import resolve
+    manifest = resolve(reference_files=["/data/clip.mp4"], task_text="extract keyframes")
+    augmented = runner._augment_prompt("Summarize the video", [], skills, manifest)
+    assert "Summarize the video" in augmented
+    assert "AVAILABLE SKILLS" in augmented
+    assert "opencv-python" in augmented  # dependency hint
+
+
+# ── execution dispatch ───────────────────────────────────────────────────
+
+def test_execute_never_uses_local_fallback():
+    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    with patch.object(runner._local, "run_code", return_value={"success": True, "files": []}) as m:
+        used, result = runner._execute("print('x')", [], manifest=_dummy_manifest())
+    assert used == "local"
+    assert result["success"] is True
+    m.assert_called_once()
+
+
+def test_execute_always_without_docker_errors():
+    runner = SandboxRunner(llm_client=object(), use_docker="always")
+    with patch.object(sr, "docker_available", return_value=False):
+        used, result = runner._execute("print('x')", [], manifest=_dummy_manifest())
+    assert used == "docker"
+    assert result["success"] is False
+    assert "Docker daemon unavailable" in result["error"]
+
+
+def test_execute_always_missing_image_errors():
+    runner = SandboxRunner(llm_client=object(), use_docker="always")
+    with patch.object(sr, "docker_available", return_value=True), \
+         patch.object(sr, "docker_image_exists", return_value=False):
+        used, result = runner._execute("print('x')", [], manifest=_dummy_manifest())
+    assert result["success"] is False
+    assert "not found" in result["error"]
+
+
+def test_execute_auto_falls_back_when_no_docker():
+    runner = SandboxRunner(llm_client=object(), use_docker="auto")
+    with patch.object(sr, "docker_available", return_value=False), \
+         patch.object(runner._local, "run_code", return_value={"success": True, "files": []}) as m:
+        used, result = runner._execute("print('x')", [], manifest=_dummy_manifest())
+    assert used == "local"
+    m.assert_called_once()
+
+
+# ── docker command construction ──────────────────────────────────────────
+
+def test_docker_command_security_flags(tmp_path):
+    runner = SandboxRunner(llm_client=object(), use_docker="never", memory_gb=3, cpus=1.5)
+    cmd = runner._docker_command(str(tmp_path), skills_mounted=True)
+    joined = " ".join(cmd)
+    assert "--network none" in joined
+    assert "--memory 3g" in joined
+    assert "--pids-limit 512" in joined
+    assert "no-new-privileges" in joined
+    assert "--cpus 1.5" in joined
+    assert "/work:/opt/gdpval" in joined  # mounted + baked skills both on path
+    assert cmd[-3:] == ["python", "-u", "solution.py"]
+
+
+def test_docker_command_pythonpath_without_mount(tmp_path):
+    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    cmd = runner._docker_command(str(tmp_path), skills_mounted=False)
+    idx = cmd.index("PYTHONPATH=/opt/gdpval")
+    assert idx > 0
+
+
+# ── end-to-end via local fallback ────────────────────────────────────────
+
+def test_run_end_to_end_local_fallback():
+    """Full run(): generate code (patched LLM) → execute locally → collect file."""
+    code_block = (
+        "Here is the solution.\n\n"
+        "```python\n"
+        "with open('result.txt', 'w') as f:\n"
+        "    f.write('done')\n"
+        "print('finished')\n"
+        "```\n"
+    )
+    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    with _patch_complete(code_block):
+        result = runner.run(
+            task_prompt="Write the word done to a file",
+            model="fake-model",
+            reference_files=[],
+            occupation="analyst",
+        )
+    assert result["success"] is True, result.get("error")
+    assert "finished" in result["text"]
+    filenames = [f["filename"] for f in result["files"]]
+    assert "result.txt" in filenames
+    # metadata reflects local executor + selection/resolution ran
+    meta = result["metadata"]
+    assert meta["executor"] == "local"
+    assert meta["image"] is None
+    assert "skills" in meta
+    assert "dependencies" in meta
+
+
+def test_run_no_code_returns_failure():
+    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    with _patch_complete("I cannot help with that. No code here."):
+        result = runner.run(
+            task_prompt="Do something",
+            model="fake-model",
+            reference_files=[],
+        )
+    assert result["success"] is False
+    assert "No Python code" in result["error"]
+    assert result["metadata"]["executor"] == "none"
+
+
+def test_run_selects_skills_for_video_task():
+    code_block = "```python\nprint('ok')\n```"
+    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    with _patch_complete(code_block):
+        result = runner.run(
+            task_prompt="Make a storyboard from the clip",
+            model="fake-model",
+            reference_files=["/tmp/does_not_exist_clip.mp4"],
+        )
+    assert result["success"] is True
+    assert "video" in result["metadata"]["skills"]
+
+
+# ── shared fixtures ──────────────────────────────────────────────────────
+
+def _dummy_manifest():
+    from core.dependency_resolver import DependencyManifest
+    return DependencyManifest()

--- a/batch-runner/tests/test_skills_registry.py
+++ b/batch-runner/tests/test_skills_registry.py
@@ -1,0 +1,125 @@
+"""Tests for core/skills_registry.py"""
+
+from pathlib import Path
+
+import pytest
+
+from core.skills_registry import (
+    Skill,
+    SkillsRegistry,
+    _extract_api_section,
+    _parse_front_matter,
+)
+
+
+@pytest.fixture(scope="module")
+def registry():
+    return SkillsRegistry()
+
+
+def test_discovers_builtin_skills(registry):
+    """The five shipped skills should be discovered from batch-runner/skills."""
+    names = set(registry.skills.keys())
+    for expected in {"audio", "video", "document", "image", "data"}:
+        assert expected in names, f"missing skill: {expected}"
+
+
+def test_each_skill_has_metadata_and_api(registry):
+    for name, skill in registry.skills.items():
+        assert skill.title, f"{name} missing title"
+        assert skill.file_extensions or skill.keywords, f"{name} has no triggers"
+        # Toolkit API section is what gets injected into the prompt.
+        assert skill.api, f"{name} missing '## Toolkit API' section"
+
+
+def test_parse_front_matter_roundtrip():
+    text = (
+        "---\n"
+        "name: demo\n"
+        "title: Demo Skill\n"
+        "file_extensions: [.foo]\n"
+        "---\n"
+        "# Body\n## Toolkit API\nfoo()\n"
+    )
+    meta, body = _parse_front_matter(text)
+    assert meta["name"] == "demo"
+    assert meta["file_extensions"] == [".foo"]
+    assert body.startswith("# Body")
+    assert _extract_api_section(body).startswith("## Toolkit API")
+
+
+def test_select_by_extension_video(registry):
+    selected = registry.select(reference_files=["/data/clip.mp4"], task_text="")
+    names = [s.name for s in selected]
+    assert "video" in names
+    top = selected[0]
+    assert ".mp4" in top.matched_extensions
+    assert top.score >= 10  # one extension match = _EXT_WEIGHT
+
+
+def test_select_by_extension_audio(registry):
+    selected = registry.select(reference_files=["/data/track.wav"], task_text="")
+    assert "audio" in [s.name for s in selected]
+
+
+def test_select_by_keyword_only(registry):
+    selected = registry.select(reference_files=[], task_text="please draw a spectrogram")
+    assert "audio" in [s.name for s in selected]
+    audio = next(s for s in selected if s.name == "audio")
+    assert "spectrogram" in audio.matched_keywords
+
+
+def test_select_empty_returns_nothing(registry):
+    assert registry.select(reference_files=[], task_text="hello world") == []
+
+
+def test_select_respects_max_skills(registry):
+    selected = registry.select(
+        reference_files=["/a.mp4", "/b.wav", "/c.pdf", "/d.png", "/e.csv"],
+        task_text="spectrogram regression ocr chart map",
+        max_skills=2,
+    )
+    assert len(selected) <= 2
+
+
+def test_select_orders_by_score(registry):
+    # Two video files + a video keyword should outrank a single pdf.
+    selected = registry.select(
+        reference_files=["/a.mp4", "/b.mov", "/c.pdf"],
+        task_text="keyframe storyboard",
+    )
+    assert selected[0].name == "video"
+    scores = [s.score for s in selected]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_render_manual_contains_api(registry):
+    selected = registry.select(reference_files=["/data/clip.mp4"], task_text="")
+    manual = registry.render_manual(selected)
+    assert "AVAILABLE SKILLS" in manual
+    assert "from skills import" in manual
+    assert "Toolkit API" in manual
+
+
+def test_render_manual_empty():
+    assert SkillsRegistry().render_manual([]) == ""
+
+
+def test_render_manual_truncates(registry):
+    selected = registry.select(reference_files=["/data/clip.mp4"], task_text="")
+    manual = registry.render_manual(selected, max_chars=50)
+    assert len(manual) <= 80  # 50 + truncation marker
+    assert "truncated" in manual
+
+
+def test_all_required_packages(registry):
+    pkgs = registry.all_required_packages()
+    assert isinstance(pkgs, list)
+    # de-duplicated
+    assert len(pkgs) == len(set(pkgs))
+
+
+def test_missing_skills_dir_is_safe(tmp_path):
+    reg = SkillsRegistry(skills_dir=tmp_path / "does_not_exist")
+    assert reg.skills == {}
+    assert reg.select(["/a.mp4"], "spectrogram") == []

--- a/batch-runner/tests/test_video_analyzer.py
+++ b/batch-runner/tests/test_video_analyzer.py
@@ -170,3 +170,21 @@ def test_analyze_no_frames_extracted(tmp_path):
          patch.object(va, "extract_keyframes", lambda *a, **k: ({}, [])):
         out = analyze_video_files(client, "m", "sys", [str(clip)])
     assert out == ""
+
+
+# ── public host-backend probe (PR #57 preflight) ────────────────────────
+
+def test_frame_backend_available_aliases_select_backend():
+    from core.video_analyzer import frame_backend_available
+    # Mirrors _select_backend exactly (may be None when cv2/av absent).
+    with patch.object(va, "_select_backend", return_value="cv2"):
+        assert frame_backend_available() == "cv2"
+    with patch.object(va, "_select_backend", return_value="av"):
+        assert frame_backend_available() == "av"
+    with patch.object(va, "_select_backend", return_value=None):
+        assert frame_backend_available() is None
+
+
+def test_frame_backend_available_real_returns_str_or_none():
+    from core.video_analyzer import frame_backend_available
+    assert frame_backend_available() in (None, "cv2", "av")

--- a/batch-runner/tests/test_video_analyzer.py
+++ b/batch-runner/tests/test_video_analyzer.py
@@ -1,0 +1,172 @@
+"""Tests for core/video_analyzer.py
+
+No real video decoding is required: frame extraction is patched so the tests
+run without cv2/av installed.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import core.video_analyzer as va
+from core.video_analyzer import (
+    analyze_video_files,
+    filter_video_files,
+    _target_times,
+)
+
+
+# ── filter ───────────────────────────────────────────────────────────────
+
+def test_filter_video_files():
+    files = ["/a.mp4", "/b.MOV", "/c.txt", "/d.wav", "/e.webm"]
+    out = filter_video_files(files)
+    assert out == ["/a.mp4", "/b.MOV", "/e.webm"]
+
+
+def test_filter_video_files_empty():
+    assert filter_video_files(None) == []
+    assert filter_video_files([]) == []
+
+
+# ── target times ─────────────────────────────────────────────────────────
+
+def test_target_times_even_spacing():
+    ts = _target_times(10.0, 5)
+    assert len(ts) == 5
+    assert ts[0] == 0.0
+    assert all(0 <= t < 10.0 for t in ts)
+    assert ts == sorted(ts)
+
+
+def test_target_times_single_frame_midpoint():
+    assert _target_times(10.0, 1) == [5.0]
+
+
+def test_target_times_zero_duration():
+    assert _target_times(0.0, 5) == []
+
+
+# ── analyze with no backend ──────────────────────────────────────────────
+
+def test_analyze_no_backend_returns_empty():
+    with patch.object(va, "_select_backend", return_value=None):
+        out = analyze_video_files(
+            client=object(),
+            model_deployment="m",
+            system_prompt="sys",
+            video_paths=["/x.mp4"],
+        )
+    assert out == ""
+
+
+def test_analyze_empty_paths():
+    assert analyze_video_files(object(), "m", "sys", []) == ""
+
+
+# ── analyze with patched frame extraction + fake vision client ───────────
+
+class _FakeVisionClient:
+    """Mimics client.chat.completions.create returning JSON content."""
+
+    def __init__(self, content):
+        self._content = content
+        self.calls = []
+
+        outer = self
+
+        class _Completions:
+            def create(self, **kwargs):
+                outer.calls.append(kwargs)
+                msg = SimpleNamespace(content=outer._content)
+                choice = SimpleNamespace(message=msg)
+                usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+                return SimpleNamespace(choices=[choice], usage=usage)
+
+        self.chat = SimpleNamespace(completions=_Completions())
+
+
+def _fake_frames(*_args, **_kwargs):
+    info = {"fps": 30.0, "frame_count": 300, "duration_sec": 10.0, "resolution": "640x480"}
+    frames = [(0.0, b"\xff\xd8jpeg0"), (5.0, b"\xff\xd8jpeg1")]
+    return info, frames
+
+
+def test_analyze_single_video_json(tmp_path):
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"fake")
+    client = _FakeVisionClient('{"summary": "a person waves", "scenes": 2}')
+    with patch.object(va, "_select_backend", return_value="cv2"), \
+         patch.object(va, "extract_keyframes", _fake_frames):
+        out = analyze_video_files(
+            client=client,
+            model_deployment="gpt-5.4",
+            system_prompt="You are a video agent",
+            video_paths=[str(clip)],
+            task_instruction="describe it",
+        )
+    assert out.startswith("[VIDEO ANALYSIS]")
+    assert out.endswith("[/VIDEO ANALYSIS]")
+    assert "a person waves" in out
+    # One API call, and the payload carried image_url parts for the 2 frames.
+    assert len(client.calls) == 1
+    content = client.calls[0]["messages"][0]["content"]
+    image_parts = [p for p in content if p.get("type") == "image_url"]
+    assert len(image_parts) == 2
+    assert image_parts[0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_analyze_strips_markdown_fence(tmp_path):
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"fake")
+    client = _FakeVisionClient('```json\n{"k": 1}\n```')
+    with patch.object(va, "_select_backend", return_value="cv2"), \
+         patch.object(va, "extract_keyframes", _fake_frames):
+        out = analyze_video_files(client, "m", "sys", [str(clip)])
+    assert '"k": 1' in out
+    assert "```" not in out
+
+
+def test_analyze_multiple_videos_keyed_by_filename(tmp_path):
+    a = tmp_path / "a.mp4"
+    b = tmp_path / "b.mov"
+    a.write_bytes(b"fake")
+    b.write_bytes(b"fake")
+    client = _FakeVisionClient('{"ok": true}')
+    with patch.object(va, "_select_backend", return_value="cv2"), \
+         patch.object(va, "extract_keyframes", _fake_frames):
+        out = analyze_video_files(client, "m", "sys", [str(a), str(b)])
+    assert "a.mp4" in out
+    assert "b.mov" in out
+
+
+def test_analyze_api_error_is_non_fatal(tmp_path):
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"fake")
+
+    class _Boom:
+        def __init__(self):
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=self._raise
+                )
+            )
+
+        def _raise(self, **kwargs):
+            raise RuntimeError("api down")
+
+    with patch.object(va, "_select_backend", return_value="cv2"), \
+         patch.object(va, "extract_keyframes", _fake_frames):
+        out = analyze_video_files(_Boom(), "m", "sys", [str(clip)])
+    assert out == ""
+
+
+def test_analyze_no_frames_extracted(tmp_path):
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"fake")
+    client = _FakeVisionClient('{"x": 1}')
+    with patch.object(va, "_select_backend", return_value="cv2"), \
+         patch.object(va, "extract_keyframes", lambda *a, **k: ({}, [])):
+        out = analyze_video_files(client, "m", "sys", [str(clip)])
+    assert out == ""

--- a/tasks/0701_wednesday/exp_smoke_sandbox_ab.yaml
+++ b/tasks/0701_wednesday/exp_smoke_sandbox_ab.yaml
@@ -1,0 +1,286 @@
+# ⚠️  SMOKE BASE CONFIG (bounded A/B smoke, PR #57). Derived verbatim from
+# experiments/exp026_sandbox_skills_multimodal.yaml. This file is the
+# HYBRID (condition B) definition: skills + audio/video GPT preprocessors.
+# The SKILLS-ONLY (condition A) variant is produced at run time by
+# run_ab_smoke.py, which strips the condition_a.preprocessors block.
+# Task subset is pinned by run_ab_smoke.py (see smoke_task_ids.txt), not by
+# data.filter. output_qa.vision stays disabled in BOTH conditions.
+
+# 🧪 Sandbox + Skills + Multimodal Perception (exp026)
+# Research Question: Does containerized execution with per-task dependency
+#   discovery, Agent Skills, and multimodal perception (vision for video,
+#   hearing for audio) improve GDPVal deliverable quality vs. plain subprocess?
+# Base architecture: exp025 (GPT-5.4 high + gpt-audio-1.5 preprocessor)
+# New variables:
+#   - execution.mode: sandbox (container, graceful local fallback)
+#   - skills/ injected into prompt + mounted in the sandbox
+#   - video_analyzer preprocessor (frame-by-frame vision)
+# Scope: All 220 tasks (9 sectors, 44 occupations)
+
+experiment:
+  id: "exp_smoke_sandbox_ab"
+  name: "SMOKE base — Sandbox A/B (skills-only vs hybrid)"
+  description: >
+    Evolution of subprocess mode into a containerized **sandbox** execution mode
+    with three additions over exp025: (1) per-task dependency discovery, (2)
+    famous Agent Skills (audio/video/document/image/data) mounted in the sandbox
+    and documented in the prompt, and (3) multimodal perception — a gpt-audio-1.5
+    audio preprocessor (hearing) plus a frame-by-frame video preprocessor
+    (vision). Sandbox uses Docker when available and gracefully falls back to the
+    hardened local subprocess otherwise. Full 220 tasks across 9 sectors.
+  author: "Hyeonsang Jeon"
+  created_at: "2026-05-18"
+
+# Variable control
+control:
+  fixed:
+    - tasks               # All 220 tasks (9 sectors, 44 occupations)
+    - temperature         # 0.0
+    - reasoning_effort    # high (matches exp025)
+    - domain_packages     # full exp011 environment (baked into sandbox image)
+  changed:
+    - execution_mode      # subprocess → sandbox
+    - skills              # NEW: Agent Skills injected + mounted
+    - perception          # NEW: audio (hearing) + video (vision) preprocessors
+
+# Data filter — All sectors (full benchmark)
+data:
+  source: "HyeonSang/exp026_sandbox_skills_multimodal"
+  filter:
+    sector: null          # All 9 sectors
+    occupation: null      # All 44 occupations
+    sample_size: null     # All 220 tasks
+
+# Condition A: sandbox + skills + audio/video perception
+# SMOKE NOTE (reasoning_effort high -> low): on the verbose sandbox codegen prompt
+# PLUS the large experiment `suffix` guidance block, gpt-5.4 at "high" spends
+# >32k tokens on HIDDEN reasoning and returns EMPTY visible output at
+# code_generation<=32768 (finish=length, no code parsed); at "medium" it needs
+# ~40k+ tokens and 400-600s, colliding with the 480s client timeout. "low" emits
+# full code fast and well under the timeout. A/B fairness holds because effort is
+# constant across both conditions. This is a bounded harness smoke, NOT a quality
+# benchmark. See sandbox_ab_smoke_pr57.md "Token/latency finding".
+condition_a:
+  name: "GPT-5.4 low + sandbox + skills + audio/video perception"
+  model:
+    provider: "azure"
+    deployment: "gpt-5.4"
+    temperature: 0.0
+    seed: null
+    reasoning_effort: "low"
+  prompt:
+    system: |
+      You are a helpful assistant that completes professional tasks.
+      When the task requires creating files (e.g., Excel, Word, PDF, PowerPoint),
+      write Python code that generates those files and save them to the current directory.
+      Use libraries such as openpyxl, python-docx, reportlab, python-pptx, and Pillow.
+      Always produce complete, runnable code.
+    prefix: null
+    body: null
+    suffix: |
+      If the task requires creating deliverable files (documents, spreadsheets,
+      presentations, reports, etc.), you MUST use Python code to generate the
+      actual file(s) and save them to the current directory.
+      Do NOT just describe what you would create — actually execute code to produce
+      downloadable files. The task is NOT complete unless the files are saved.
+
+      In your text response, do NOT include any file download links or sandbox URLs
+      (e.g. "[Download ...](sandbox:/mnt/data/...)" or similar).
+      Only provide a plain-text summary of what was produced.
+
+      IMPORTANT — Defensive coding:
+      Before writing any code, ALWAYS inspect the actual structure of any
+      reference files first (df.columns, df.dtypes, df.head()).
+      Never hardcode column names or assume data types.
+      Use the exact column names found in the file.
+
+      Special characters
+      - Never use the character ‑ (U+2011), since it will render poorly on some people's computers. Instead, always use - (U+002D) instead.
+      - Avoid emojis, nonstandard bullet points, and other special characters unless there is an extremely good reason to use them, since these render poorly on some people's computers.
+
+      Graphics embedded within PDFs/slides
+      - Make sure that any diagrams or plots are large enough to be legible (though not so large that they are ugly or cut off). In most cases they should be at least half the page width.
+      - Plots and charts to visualize data are good. Simple graphics (like a flowchart with arrows) are good. But complicated visuals constructed by overlaying shapes into an image often appear unprofessional.
+
+      PDFs
+      - Always use LibreOffice to create the PDF (it must be LibreOffice! If LibreOffice is not installed, you can install it yourself). Other libraries sometimes show weird artifacts on some computers.
+
+      Fonts
+      - Always use fonts which are available across all platforms. We recommend Noto Sans / Noto Serif unless there is an extremely good reason to use something else.
+      - If you must use another font, embed the font in the pptx/word/etc doc.
+
+      Deliverable text
+      - Do not link to submitted files in the deliverable text (links are not supported on the interface where these will be viewed).
+      - Ideal deliverable text is concise and to the point, without any unnecessary fluff. 4 sentences max.
+      - Any deliverables the user asked for should be in files in the container, NOT purely in the deliverable text.
+      - If a portion of the task was unsolvable (for instance, because internet was not available), mention this in the deliverable text.
+      - Your submission should be complete and self-contained. Even if you are unable to fully complete the task due to limitations in the environment, produce as close to a complete solution as possible.
+
+      Verbosity
+      - Always be clear and comprehensive, but avoid extra verbosity when possible.
+
+      Filetypes
+      - If the prompt does not request a specific filetype, use standard filetypes like PDF, PPTX, DOCX, XLSX, MP4, ZIP, etc.
+
+      Code structure:
+      Write all code in a SINGLE ```python``` code block.
+      Do not split code across multiple code blocks — this can cause
+      syntax errors when blocks are concatenated.
+
+      Lightweight mandatory checks
+      After generating files, do a quick validation pass (5 lines max):
+      - Verify each file exists and has non-zero size
+      - For Excel/DOCX/PPTX: open with the same library and confirm no exception
+      - Do NOT do multi-step visual inspection or PNG conversion
+      If any file is missing or corrupt, fix and regenerate.
+
+      Skills (preinstalled toolkits)
+      - A `skills/` package is available on the Python path inside the sandbox.
+        The "SKILLS AVAILABLE" section above lists the relevant skills and their
+        toolkit APIs for THIS task. Prefer those helpers — they wrap the famous
+        libraries correctly (e.g. `from skills.audio.toolkit import fft_summary`,
+        `from skills.video.toolkit import extract_frames`,
+        `from skills.document.toolkit import read_any`).
+      - If a needed package is listed under "DEPENDENCIES", assume it is already
+        installed in the sandbox image; just import and use it.
+
+      Perception data (vision + hearing)
+      - When an [AUDIO ANALYSIS] section is present, a specialized audio model
+        listened to the reference audio. Trust its findings (BPM, key, timing,
+        levels, etc.) instead of guessing.
+      - When a [VIDEO ANALYSIS] section is present, a vision model watched
+        frame-by-frame samples of the reference video. Trust its findings
+        (on-screen content, scene changes, timing, corruption checks) instead of
+        guessing. To inspect further, sample frames yourself with
+        `skills.video.toolkit.extract_frames`.
+
+      Available packages
+      - Audio: soundfile, pydub, pedalboard, pyloudnorm, librosa, mutagen, ffmpeg-python, moviepy, av
+      - Documents: aspose-words, camelot-py, docx2txt, fpdf2, PyMuPDF, weasyprint, cairosvg
+      - Data/ML: scikit-learn, xgboost, lightgbm, catboost, statsmodels, scipy, networkx
+      - NLP: nltk, textblob, fuzzywuzzy, rapidfuzz, wordcloud
+      - GIS: geopandas, geopy, folium, shapely, rasterio
+      - Vision: opencv-python, pytesseract, pdf2image, pyzbar, qrcode
+      - Visualization: bokeh, plotly, plotnine, seaborn, matplotlib-venn
+      - `ffmpeg`, `tesseract`, `graphviz`, `wkhtmltopdf` are available as system commands.
+      - `LibreOffice` is available for document conversion.
+
+  # Preprocessors: run before main execution (perception layer)
+  preprocessors:
+    - type: "audio_analyzer"          # hearing
+      model:
+        provider: "azure"
+        deployment: "gpt-audio-1.5"
+      trigger: "has_audio_files"
+      inject_as: "prompt_prefix"
+      include_task_instruction: true
+      system: |
+        You are an audio analysis agent.
+        You will receive a task description and one or more audio files.
+        Listen to the audio and provide analysis that is relevant
+        to completing the task.
+        Return your analysis as structured JSON.
+        Only include information you can actually determine from listening.
+        Do not guess or fabricate values.
+        Respond with JSON only. No prose.
+
+    - type: "video_analyzer"          # vision (frame-by-frame)
+      model:
+        provider: "azure"
+        deployment: "gpt-5.4"
+      trigger: "has_video_files"
+      inject_as: "prompt_prefix"
+      include_task_instruction: true
+      frames_per_video: 8
+      max_total_frames: 24
+      frame_max_width: 768
+      frame_detail: "auto"
+      system: |
+        You are a video analysis agent.
+        You will receive a task description, per-video metadata, and several
+        frames sampled across each video's timeline (each labeled with its
+        timestamp in seconds).
+        Examine the frames and describe what is happening on screen as it relates
+        to completing the task: visible content/text, scene changes, notable
+        timestamps, and whether any frame looks corrupted.
+        Return your analysis as structured JSON.
+        Only include information you can actually determine from the frames.
+        Do not guess or fabricate values.
+        Respond with JSON only. No prose.
+
+  # Self-QA: LLM inspects its own output
+  qa:
+    enabled: true
+    max_retries: 1
+    model: null
+    min_score: 5
+    prompt: |
+      You are a strict QA inspector for professional deliverables.
+
+      ## Original Task
+      {instruction}
+
+      ## Generated Output
+      - Text response: {deliverable_text}
+      - Files produced: {deliverable_files}
+
+      ## Inspection Criteria
+      1. Does the output address ALL requirements in the original task?
+      2. Are all required files produced with correct types and content?
+      3. Is the text response complete and professional?
+      4. Are there any obvious errors, missing elements, or placeholder content?
+
+      ## Response Format (JSON only)
+      ```json
+      {{
+        "passed": true,
+        "score": 8,
+        "issues": [],
+        "suggestion": ""
+      }}
+      ```
+
+# Execution settings
+execution:
+  mode: "sandbox"
+  timeout: 720
+  install_libreoffice: true
+  # Sandbox-specific settings (consumed by core/sandbox_runner.py).
+  sandbox:
+    image: "gdpval-sandbox:latest"
+    use_docker: "auto"        # auto | never | always
+    memory_gb: 5
+    cpus: 2.0
+    max_skills: 5
+    # ── Output control loop (Phase 2) ────────────────────────────────────
+    # Skills give the sandbox eyes/ears on INPUTS; the blocks below verify
+    # the OUTPUTS the model generates and repair them when they fall short.
+    repair:
+      enabled: true
+      max_attempts: 1          # repair retries after attempt 0 (bounded)
+    output_qa:
+      enabled: true
+      render: true             # rasterize deliverables for deterministic QA
+      max_pages_per_artifact: 3
+      blank_page_threshold: 0.999   # per-page near-white warning ratio
+      vision:
+        enabled: false         # optional LLM vision QA (off by default)
+        provider: "azure"
+        deployment: "gpt-5.4"
+        max_images: 6
+    manifest:
+      enabled: true
+      filename: "manifest.json"
+    cache:
+      enabled: true            # cache rendered PNGs / perception by sha256
+  tokens:
+    # NOTE (smoke finding): reasoning_effort=high + the verbose sandbox codegen
+    # prompt (skills manual + deliverable/dependency contracts + reference data)
+    # can consume >16k reasoning tokens, starving visible output to empty.
+    # Bumped from exp026's 16384 so reasoning + code both fit. See smoke report.
+    code_generation: 32768
+    qa_check: 4096
+    json_render: 8000
+  max_retries: 5
+  resume_max_rounds: 2
+  relay_max_runs: 5

--- a/tasks/0701_wednesday/run_ab_smoke.py
+++ b/tasks/0701_wednesday/run_ab_smoke.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Bounded A/B sandbox smoke — prepared-JSON builder (PR #57).
+
+Writes ``workspace/step1_tasks_prepared.json`` for a *pinned* subset of GDPVal
+tasks so ``step2_run_inference.py`` runs only those tasks in sandbox mode.
+
+Why a bespoke builder instead of step1_prepare_tasks.py:
+  * step1 samples randomly and, more importantly, ``ExperimentConfig`` drops the
+    ``execution.sandbox`` block, so the sandbox output-control-loop settings
+    (repair / output_qa / manifest / cache) would never reach the runner.
+    This builder reads the raw YAML and preserves the full ``execution`` block.
+
+Two variants from one base YAML (the HYBRID/condition-B definition):
+  * ``hybrid``      — keep condition_a.preprocessors (audio_analyzer +
+                      video_analyzer GPT perception).
+  * ``skills_only`` — strip preprocessors entirely (provider-agnostic:
+                      main solving model + local skills only).
+
+Both variants disable the legacy LLM self-QA (condition.qa) so the smoke
+isolates the NEW output-control loop, and both keep output_qa.vision disabled.
+
+This is a smoke/test harness artifact — it does not modify any core module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+BATCH_RUNNER = Path(__file__).resolve().parents[2] / "batch-runner"
+sys.path.insert(0, str(BATCH_RUNNER))
+
+from core.config import WORKSPACE_DIR  # noqa: E402
+from core.data_loader import GDPValDataLoader  # noqa: E402
+
+
+def _load_tasks_by_id(ids: list[str]) -> dict:
+    loader = GDPValDataLoader(auto_download=False)
+    by_id = {t.task_id: t for t in loader.load()}
+    missing = [i for i in ids if i not in by_id]
+    if missing:
+        raise SystemExit(f"Task ids not found in snapshot: {missing}")
+    return {i: by_id[i] for i in ids}
+
+
+def _strip_qa(cond: dict) -> None:
+    """Disable the legacy LLM self-QA so the smoke isolates the new loop."""
+    if isinstance(cond.get("qa"), dict):
+        cond["qa"]["enabled"] = False
+
+
+def build_prepared(yaml_path: str, variant: str, ids: list[str]) -> dict:
+    raw = yaml.safe_load(Path(yaml_path).read_text(encoding="utf-8"))
+
+    execution = dict(raw.get("execution", {}))
+    # Bound the OUTER step2 resume/retry loop; the sandbox runner has its own
+    # bounded internal repair loop (execution.sandbox.repair.max_attempts).
+    execution["max_retries"] = 1
+    execution["resume_max_rounds"] = 1
+
+    cond_a = json.loads(json.dumps(raw["condition_a"]))  # deep copy
+    _strip_qa(cond_a)
+    if variant == "skills_only":
+        cond_a.pop("preprocessors", None)
+    elif variant != "hybrid":
+        raise SystemExit(f"unknown variant: {variant}")
+
+    tasks = _load_tasks_by_id(ids)
+    task_list = []
+    for tid, t in tasks.items():
+        task_list.append({
+            "task_id": t.task_id,
+            "sector": t.sector,
+            "occupation": t.occupation,
+            "instruction": t.prompt,
+            "reference_files": list(getattr(t, "reference_files", []) or []),
+            "reference_file_urls": list(getattr(t, "reference_file_urls", []) or []),
+            # Rely on manifest.final_status for pass/fail; keep step2 from adding
+            # outer resume rounds for "no files".
+            "needs_files": False,
+        })
+
+    return {
+        "experiment_id": f"{raw['experiment']['id']}__{variant}",
+        "experiment_name": f"{raw['experiment'].get('name','')} [{variant}]",
+        "description": f"Bounded A/B sandbox smoke ({variant}) — PR #57",
+        "config_path": str(yaml_path),
+        "source": raw.get("data", {}).get("source", ""),
+        "execution": execution,
+        "total_tasks": len(task_list),
+        "needs_files_count": 0,
+        "text_only_count": len(task_list),
+        "condition_a": cond_a,
+        "condition_b": None,
+        "tasks": task_list,
+        "_smoke": {"variant": variant, "task_ids": ids},
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Build prepared JSON for the A/B sandbox smoke")
+    ap.add_argument("--yaml", required=True, help="Base smoke YAML (hybrid/condition-B definition)")
+    ap.add_argument("--variant", required=True, choices=["hybrid", "skills_only"])
+    ap.add_argument("--task-ids-file", required=True, help="File with one task_id per line")
+    args = ap.parse_args()
+
+    ids = []
+    for ln in Path(args.task_ids_file).read_text().splitlines():
+        ln = ln.strip()
+        if not ln or ln.startswith("#"):
+            continue
+        ids.append(ln.split("#", 1)[0].strip())  # drop inline comment
+    prepared = build_prepared(args.yaml, args.variant, ids)
+
+    WORKSPACE_DIR.mkdir(parents=True, exist_ok=True)
+    out = WORKSPACE_DIR / "step1_tasks_prepared.json"
+    out.write_text(json.dumps(prepared, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    pp = "preprocessors" in prepared["condition_a"]
+    print(f"✅ wrote {out}")
+    print(f"   variant={args.variant}  tasks={len(ids)}  preprocessors={'ON' if pp else 'OFF'}  "
+          f"mode={prepared['execution'].get('mode')}  "
+          f"sandbox.use_docker={prepared['execution'].get('sandbox',{}).get('use_docker')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/0701_wednesday/sandbox_ab_smoke_pr57.json
+++ b/tasks/0701_wednesday/sandbox_ab_smoke_pr57.json
@@ -2,7 +2,7 @@
   "schema": "sandbox_ab_smoke/v1",
   "pr": 57,
   "branch": "hyeonsangjeon-sandbox-skills-multimodal-eval",
-  "date": "2025-07-01",
+  "date": "2026-07-01",
   "backend": "docker",
   "image": "gdpval-sandbox:latest",
   "config": {

--- a/tasks/0701_wednesday/sandbox_ab_smoke_pr57.json
+++ b/tasks/0701_wednesday/sandbox_ab_smoke_pr57.json
@@ -1,0 +1,320 @@
+{
+  "schema": "sandbox_ab_smoke/v1",
+  "pr": 57,
+  "branch": "hyeonsangjeon-sandbox-skills-multimodal-eval",
+  "date": "2025-07-01",
+  "backend": "docker",
+  "image": "gdpval-sandbox:latest",
+  "config": {
+    "reasoning_effort": "low",
+    "code_generation_tokens": 32768,
+    "repair_max_attempts": 1,
+    "resume_max_rounds": 1,
+    "output_qa_vision_enabled": false,
+    "output_control_loop": true
+  },
+  "conditions": {
+    "A": "skills_only (preprocessors stripped)",
+    "B": "hybrid (skills + gpt audio/video preprocessors)"
+  },
+  "aggregate": {
+    "A_ok": 6,
+    "A_total": 6,
+    "B_ok": 5,
+    "B_total": 6,
+    "B_failed": [
+      "a941b6d8-4289-4500-b45a-f8e4fc94a724"
+    ]
+  },
+  "preprocessor_evidence": {
+    "audio_injected_chars": {
+      "38889c3b": 820,
+      "ff85ee58": 2334
+    },
+    "video_preprocessor": "skipped_both_rounds_no_cv2_av_on_host"
+  },
+  "key_findings": [
+    "reasoning_high_yields_empty_output_used_low+32768",
+    "docker_image_store_needs_retag_for_inspect",
+    "video_657MB_marginal_vs_5GB_and_720s"
+  ],
+  "video_failure": {
+    "round0": "memory_error exit137 5GB limit",
+    "resume": "sandbox exit1 runtime crash in generated composite_final",
+    "classification": "harness_resource_limit + codegen_variance (NOT preprocessor)"
+  },
+  "merge_safety": "safe_from_smoke_perspective; no harness bug; manifests clean; recommendations non-blocking",
+  "pr_status": "open_unmerged",
+  "tasks": [
+    {
+      "task_id": "7d7fc9a7-21a7-4b83-906f-416dea5ad04f",
+      "label": "XLSX (+pdf ref) (Accountant)",
+      "A": {
+        "final_status": "ok",
+        "attempts": 1,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".xlsx",
+          ".pdf",
+          ".png"
+        ],
+        "contract_conf": "medium",
+        "blocking": [],
+        "skills": [
+          "document",
+          "data",
+          "audio",
+          "video"
+        ],
+        "gen_count": 4,
+        "primary_count": 3,
+        "latency_s": 99.3
+      },
+      "B": {
+        "final_status": "ok",
+        "attempts": 1,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".xlsx",
+          ".pdf",
+          ".png"
+        ],
+        "contract_conf": "medium",
+        "blocking": [],
+        "skills": [
+          "document",
+          "data",
+          "audio",
+          "video"
+        ],
+        "gen_count": 4,
+        "primary_count": 3,
+        "latency_s": 259.6,
+        "preprocessor": "none"
+      }
+    },
+    {
+      "task_id": "e6429658-4de1-42dd-a9e0-2d2b9b02fb10",
+      "label": "DOCX (+png ref) (Nurse Practitioner)",
+      "A": {
+        "final_status": "ok",
+        "attempts": 1,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".pdf",
+          ".png"
+        ],
+        "contract_conf": "high",
+        "blocking": [],
+        "skills": [
+          "document",
+          "image",
+          "data"
+        ],
+        "gen_count": 5,
+        "primary_count": 3,
+        "latency_s": 173.4
+      },
+      "B": {
+        "final_status": "ok",
+        "attempts": 1,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".pdf",
+          ".png"
+        ],
+        "contract_conf": "high",
+        "blocking": [],
+        "skills": [
+          "document",
+          "image",
+          "data"
+        ],
+        "gen_count": 5,
+        "primary_count": 3,
+        "latency_s": 123.3,
+        "preprocessor": "none"
+      }
+    },
+    {
+      "task_id": "5a2d70da-0a42-4a6b-a3ca-763e03f070a5",
+      "label": "PPTX multi-file (Mechanical Engineer)",
+      "A": {
+        "final_status": "repaired_ok",
+        "attempts": 2,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".xlsx",
+          ".png"
+        ],
+        "contract_conf": "medium",
+        "blocking": [],
+        "skills": [
+          "document",
+          "data",
+          "audio"
+        ],
+        "gen_count": 3,
+        "primary_count": 3,
+        "latency_s": 96.3
+      },
+      "B": {
+        "final_status": "ok",
+        "attempts": 1,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".xlsx",
+          ".png"
+        ],
+        "contract_conf": "medium",
+        "blocking": [],
+        "skills": [
+          "document",
+          "data",
+          "audio"
+        ],
+        "gen_count": 3,
+        "primary_count": 3,
+        "latency_s": 112.5,
+        "preprocessor": "none"
+      }
+    },
+    {
+      "task_id": "ff85ee58-bc9f-4aa2-806d-87edeabb1b81",
+      "label": "AUDIO .mp3+.wav (Sound Engineer)",
+      "A": {
+        "final_status": "ok",
+        "attempts": 1,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".mp3",
+          ".wav",
+          ".png"
+        ],
+        "contract_conf": "medium",
+        "blocking": [],
+        "skills": [
+          "audio",
+          "data",
+          "document",
+          "image"
+        ],
+        "gen_count": 2,
+        "primary_count": 2,
+        "latency_s": 142.1
+      },
+      "B": {
+        "final_status": "ok",
+        "attempts": 1,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".json",
+          ".mp3",
+          ".wav",
+          ".pdf",
+          ".png"
+        ],
+        "contract_conf": "high",
+        "blocking": [],
+        "skills": [
+          "audio",
+          "data",
+          "document",
+          "image"
+        ],
+        "gen_count": 7,
+        "primary_count": 6,
+        "latency_s": 241.6,
+        "preprocessor": "audio_injected"
+      }
+    },
+    {
+      "task_id": "38889c3b-e3d4-49c8-816a-3cc8e5313aba",
+      "label": "AUDIO .wav (Music Producer)",
+      "A": {
+        "final_status": "ok",
+        "attempts": 1,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".mp4",
+          ".wav",
+          ".zip"
+        ],
+        "contract_conf": "high",
+        "blocking": [],
+        "skills": [
+          "audio",
+          "video",
+          "data",
+          "document"
+        ],
+        "gen_count": 12,
+        "primary_count": 8,
+        "latency_s": 174.7
+      },
+      "B": {
+        "final_status": "ok",
+        "attempts": 1,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".mp4",
+          ".wav",
+          ".zip"
+        ],
+        "contract_conf": "high",
+        "blocking": [],
+        "skills": [
+          "audio",
+          "data",
+          "video",
+          "document"
+        ],
+        "gen_count": 9,
+        "primary_count": 7,
+        "latency_s": 159.8,
+        "preprocessor": "audio_injected"
+      }
+    },
+    {
+      "task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724",
+      "label": "VIDEO .mp4 (Film/Video Editor)",
+      "A": {
+        "final_status": "repaired_ok",
+        "attempts": 2,
+        "backend": "docker",
+        "verify_ok": true,
+        "contract_ext": [
+          ".mp4"
+        ],
+        "contract_conf": "medium",
+        "blocking": [],
+        "skills": [
+          "video",
+          "document",
+          "image"
+        ],
+        "gen_count": 1,
+        "primary_count": 1,
+        "latency_s": 938.2
+      },
+      "B": {
+        "final_status": "failed_execution",
+        "backend": "docker",
+        "gen_count": null,
+        "primary_count": 0,
+        "latency_s": 1052.4,
+        "preprocessor": "video_skipped_no_cv2_av"
+      }
+    }
+  ]
+}

--- a/tasks/0701_wednesday/sandbox_ab_smoke_pr57.md
+++ b/tasks/0701_wednesday/sandbox_ab_smoke_pr57.md
@@ -1,0 +1,191 @@
+# Sandbox A/B Smoke — PR #57 (skills-only vs hybrid perception)
+
+Branch: `hyeonsangjeon-sandbox-skills-multimodal-eval` · Scope: bounded smoke, **not** a full run · Date: 2025-07-01
+
+## Core question
+
+Can the sandbox harness solve representative GDPVal tasks with **only the main solving
+model + local open-source skills** (condition **A**, audio/video GPT preprocessors
+disabled), and how does that compare to the **current exp026 hybrid** (condition **B**,
+skills + GPT audio/video preprocessors)? This informs whether the harness is viable for
+future non-GPT providers (Grok/Llama) that lack GPT perception models.
+
+## TL;DR verdict
+
+- **Skills-only (A) is viable.** 6/6 representative tasks produced valid, verified
+  deliverables using only the main model + local skills. This is the provider-agnostic
+  signal the owner asked for: no GPT-specific perception was required for the harness to
+  produce openable, contract-valid outputs across document, spreadsheet, deck, audio, and
+  video modalities.
+- **Hybrid (B) did not categorically beat skills-only on pass/fail** in this smoke (5/6),
+  but the **audio preprocessor measurably enriched audio-task outputs** (more complete
+  deliverable sets, higher contract confidence). The single B failure was the hardest task
+  (657 MB 4K video) and is attributable to **resource limits + LLM code-gen variance**, not
+  to skills-vs-hybrid, because the **video preprocessor could not run in this environment**.
+- **PR #57 is safe to merge from a smoke perspective.** No harness bug was found. All
+  manifests are clean (relative paths, no secret/PII leakage). The findings below are
+  configuration/environment notes, not code defects. Two are worth folding into exp026
+  defaults before a large run (reasoning budget, video container memory/timeout).
+
+## Setup
+
+| Item | Value |
+|---|---|
+| Backend | **docker** (`gdpval-sandbox:latest`) for every non-failed task in both A and B |
+| Tasks | 6 pinned (`tasks/0701_wednesday/smoke_task_ids.txt`) |
+| Solving runs | 12 (6 × A, 6 × B) |
+| Repair | `max_attempts=1`, `resume_max_rounds=1` |
+| Output control loop | contract + verifier + manifest + render QA — **enabled** |
+| `output_qa.vision.enabled` | **false** in both (deterministic render/openability/blank-page QA only) |
+| Vision/LLM judge cost | none (disabled as required) |
+
+### Commands (per variant)
+
+```bash
+# from batch-runner/, venv = session testenv, PYTHONPATH=.
+# A: skills_only strips preprocessors; B: hybrid keeps them
+python tasks/0701_wednesday/run_ab_smoke.py \
+    --yaml tasks/0701_wednesday/exp_smoke_sandbox_ab.yaml \
+    --variant {skills_only|hybrid} \
+    --task-ids-file tasks/0701_wednesday/smoke_task_ids.txt
+
+# then, with Azure AAD token auth forced (see auth note):
+python step2_run_inference.py --condition condition_a
+```
+
+Config overrides live in `tasks/0701_wednesday/exp_smoke_sandbox_ab.yaml` (a copy of
+exp026 with two smoke deviations, documented inline and below). The driver
+`run_ab_smoke.py` pins the 6-task subset, strips `preprocessors:` for `skills_only`,
+keeps them for `hybrid`, forces `mode: sandbox`, `use_docker: auto`, and disables the
+legacy per-condition QA so only the new output control loop runs.
+
+### Task subset (representative modalities)
+
+| Task | Occupation | Modality / deliverable | Reference files |
+|---|---|---|---|
+| `7d7fc9a7` | Accountant | XLSX workbook | + `.pdf` ref |
+| `e6429658` | Nurse Practitioner | DOCX/PDF report | + `.png` ref |
+| `5a2d70da` | Mechanical Engineer | PPTX / multi-file | multi-ref |
+| `ff85ee58` | Sound Engineer | Audio (`.mp3`+`.wav`) | audio refs |
+| `38889c3b` | Music Producer | Audio (`.wav`) | audio ref |
+| `a941b6d8` | Film/Video Editor | Video (`.mp4`, 657 MB 4K) | video ref |
+
+The 3 document/deck tasks have no audio/video references, so A and B are configured
+identically for them — they are a control group. The 2 audio tasks and 1 video task are
+where A and B differ by design.
+
+## Results matrix
+
+| Task | Modality | A `final_status` | A att | B `final_status` | B att | Backend |
+|---|---|---|---|---|---|---|
+| `7d7fc9a7` | XLSX | `ok` | 1 | `ok` | 1 | docker |
+| `e6429658` | DOCX | `ok` | 1 | `ok` | 1 | docker |
+| `5a2d70da` | PPTX/multi | `repaired_ok` | 2 | `ok` | 1 | docker |
+| `ff85ee58` | Audio mp3+wav | `ok` | 1 | `ok` | 1 | docker |
+| `38889c3b` | Audio wav | `ok` | 1 | `ok` | 1 | docker |
+| `a941b6d8` | Video mp4 (657 MB) | `repaired_ok` | 2 | **`failed_execution`** | — | docker |
+| **Total** | | **6/6 ok** | | **5/6 ok** | | |
+
+Every completed task: `verify_ok=True`, zero blocking verification errors, zero render-QA
+warnings, manifest present with stable `schema_version`, and **no absolute-path / secret /
+PII leakage** (manifests use relative paths; stdout/stderr tails sanitized).
+
+## Preprocessor behavior (the A vs B mechanism)
+
+Confirmed from B's step2 log:
+
+```
+[music] 🎵 Preprocessor injected 820 chars into prompt      # audio_analyzer / gpt-audio-1.5
+[sound] 🎵 Preprocessor injected 2334 chars into prompt     # audio_analyzer / gpt-audio-1.5
+[video] ⚠️  Video preprocessor: no frame backend (cv2/av) installed — skipping   (×2)
+```
+
+- **Audio preprocessor ran in B** for both audio tasks and injected GPT audio analysis
+  into the prompt. Effect: on the Sound Engineer task the injected analysis (2334 chars)
+  raised the deterministic **contract confidence from `medium`→`high`** and expanded the
+  expected set (`.mp3/.wav/.png` → `.json/.mp3/.wav/.pdf/.png`), and B produced a **richer
+  deliverable set (7 artifacts vs A's 2)**: mix-report JSON, summary PDF, preview MP3,
+  spectrogram + alignment PNGs, plus the 24-bit master WAV. Both A and B verified `ok`, so
+  the preprocessor improved **output completeness/quality**, not pass/fail, on this smoke.
+- **Video preprocessor was skipped in both rounds of B.** The preprocessor runs on the
+  **host/orchestrator** (the step2 process), whose environment lacks the `cv2`/`av` frame
+  backend, so `video_analyzer` degraded gracefully to a no-op. Consequently **B's video arm
+  was effectively inactive** — for the video task, B ≡ A in perception. This must be kept
+  in mind when reading the video result: it is *not* evidence about hybrid video perception.
+
+## Harness failures vs model-quality failures
+
+| Observation | Classification |
+|---|---|
+| `5a2d70da` A needed 1 repair (`repaired_ok`), B passed first try | Model/code-gen variance (both succeeded) |
+| `a941b6d8` B: Round 0 OOM (exit 137, 5 GB container limit) then resume-round runtime crash (exit 1 in generated `composite_final(...)`) | **Harness/resource limit + code-gen variance.** 657 MB 4K video is marginal against the 5 GB memory cap and 720 s timeout. A happened to recover in its resume round; B did not. Not a skills-vs-hybrid signal (video preprocessor was skipped in both). |
+| All audio/doc/deck tasks | Clean harness behavior; no harness defects |
+
+No failure in this smoke was caused by a harness/control-loop bug. The contract, verifier,
+manifest, render-QA, and repair loop behaved correctly, including on the failed video task
+(it was correctly reported as `failed_execution`, not silently passed).
+
+## Key findings (fold into exp026 before a large run)
+
+1. **Reasoning-budget starvation at `reasoning_effort: high`.** gpt-5.4 at `high` on the
+   sandbox codegen prompt spends the entire completion budget on hidden reasoning and
+   returns **empty visible content** (finish=length) → the runner raises "No Python code
+   found". Probes: high/16384→empty, high/32768→empty; medium/32768→20k reasoning + 38k
+   chars but ~340 s latency. **Smoke used `reasoning_effort: low` + `code_generation:
+   32768`** to guarantee non-empty output under the 480 s client timeout. A/B fairness holds
+   because effort is constant across both conditions. **Recommendation:** exp026's
+   `reasoning: high` + `code_generation: 16384` will produce empty outputs on complex
+   sandbox tasks — raise the token budget and/or lower effort for sandbox mode.
+2. **Docker image-store registration.** Docker Desktop's buildx stored the image where
+   `docker images` lists it but classic `docker image inspect` (used by the runner's
+   `docker_image_exists()`) returned "No such image", forcing local fallback. Fix:
+   `docker tag <image_id> gdpval-sandbox:latest` re-registers it in the classic store so the
+   runner selects docker. No code change needed; environment/build note.
+3. **Video task is resource-marginal.** 657 MB 4K video + 5 GB container cap + 720 s timeout
+   is the failure envelope. **Recommendation:** for video-heavy tasks raise
+   `execution.sandbox` memory and `execution.timeout`, and/or have the video skill downsample
+   before compositing. This is the single most likely large-run flake source.
+
+## Deviations from the smoke spec (all documented, none affect A/B validity)
+
+- `reasoning_effort: low` (spec said "same as exp026 unless local config requires
+  otherwise"; empty-output starvation required it). Constant across A and B.
+- Video preprocessor did not execute in B (host lacks `cv2`/`av`). Reported, not hidden.
+- Docker image built once locally, trimmed to drop `aspose-words` (no arm64 wheel);
+  backend choice (docker) is reported per task, not hidden.
+
+## Merge safety (smoke perspective)
+
+**Safe to merge PR #57.** Rationale:
+
+- Output control loop is correct end-to-end: contracts inferred, artifacts selected with
+  reference exclusion, verifier + render QA deterministic, repair bounded, manifests clean.
+- Existing modes untouched (smoke only exercised `sandbox`).
+- No secret/PII/local-path leakage in any manifest or committed artifact.
+- The one failure is an expected resource-limit flake on the hardest task, correctly
+  surfaced as `failed_execution` — the harness did not mask it.
+
+**Non-blocking pre-large-run recommendations:** (1) fix sandbox reasoning/token budget so
+`high` effort cannot yield empty output; (2) raise video-task memory/timeout; (3) document
+that GPT audio/video preprocessors require their perception deps (`cv2`/`av`) on the
+orchestrator host, else they no-op.
+
+## Residual risks
+
+- **Non-determinism on marginal tasks** (video): a single run can pass or fail; a large run
+  needs the memory/timeout bump above to be reliable.
+- **Preprocessor host-dependency**: the "hybrid" advantage for video is unverified here
+  because the video preprocessor never ran; re-test on a host with `cv2`/`av` to measure it.
+- **Contract inference is prompt-sensitive**: injected preprocessor text legitimately raises
+  contract confidence/extension coverage (observed on the Sound Engineer task). Good for
+  hybrid, but means A and B contracts can differ on audio/video tasks by design.
+
+## Reproducibility notes
+
+- Auth: the SP client-secret in `.env` is invalid and the OpenAI SDK auto-prefers an API
+  key over the AAD token; the runner forces `DefaultAzureCredential` (az login token) by
+  unsetting `AZURE_CLIENT_*` / `AZURE_*_API_KEY` before step2. Keep `AZURE_OPENAI_ENDPOINT`.
+- Generated binary deliverables (video/wav/zip) are intentionally **not committed**; only
+  this report, the machine-readable summary, and the smoke config/driver are committed.
+
+PR #57 remains **open and unmerged**.

--- a/tasks/0701_wednesday/sandbox_ab_smoke_pr57.md
+++ b/tasks/0701_wednesday/sandbox_ab_smoke_pr57.md
@@ -1,6 +1,6 @@
 # Sandbox A/B Smoke — PR #57 (skills-only vs hybrid perception)
 
-Branch: `hyeonsangjeon-sandbox-skills-multimodal-eval` · Scope: bounded smoke, **not** a full run · Date: 2025-07-01
+Branch: `hyeonsangjeon-sandbox-skills-multimodal-eval` · Scope: bounded smoke, **not** a full run · Date: 2026-07-01
 
 ## Core question
 

--- a/tasks/0701_wednesday/smoke_task_ids.txt
+++ b/tasks/0701_wednesday/smoke_task_ids.txt
@@ -1,0 +1,13 @@
+# Bounded A/B sandbox smoke — pinned task subset (PR #57)
+# 6 representative GDPVal tasks. The 3 audio/video tasks are where conditions
+# A (skills-only) and B (hybrid) actually differ (audio/video GPT preprocessors
+# trigger only on those). The 3 doc/deck tasks are deliverable-type controls
+# (A and B are identical for them — no audio/video reference).
+#
+# id                                    category / why
+a941b6d8-4289-4500-b45a-f8e4fc94a724   # VIDEO .mp4 (Film/Video Editors) — A/B crux, video_analyzer
+38889c3b-e3d4-49c8-816a-3cc8e5313aba   # AUDIO .wav (Music Producer) — A/B crux, audio_analyzer
+ff85ee58-bc9f-4aa2-806d-87edeabb1b81   # AUDIO .mp3+.wav (Sound Engineer) — A/B crux, audio_analyzer
+7d7fc9a7-21a7-4b83-906f-416dea5ad04f   # XLSX deliverable + .pdf ref (Accountant) — spreadsheet + confusing-ext control
+e6429658-4de1-42dd-a9e0-2d2b9b02fb10   # DOCX report + .png ref (Nurse Practitioner) — document + image control
+5a2d70da-0a42-4a6b-a3ca-763e03f070a5   # PPTX/multi (.pdf/.pptx/.step/.xlsx, Mechanical Engineer) — deck + multi-file + confusing-ext

--- a/tasks/0702_thursday/sandbox_post_hardening_docker_verification_pr57.json
+++ b/tasks/0702_thursday/sandbox_post_hardening_docker_verification_pr57.json
@@ -1,0 +1,90 @@
+{
+  "report": "sandbox_post_hardening_docker_verification_pr57",
+  "pr": 57,
+  "branch": "hyeonsangjeon-sandbox-skills-multimodal-eval",
+  "pre_verification_head": "203790c",
+  "identity": "Hyeonsangjeon (owner identity configured in the worktree)",
+  "pr_state": {"state": "OPEN", "isDraft": false, "mergeable": "MERGEABLE", "forbidden_word_in_title": false},
+  "docker": {
+    "daemon_version": "29.1.3",
+    "images_before": 0,
+    "image": "gdpval-sandbox:latest",
+    "arch": "arm64",
+    "size_bytes": 2214283898,
+    "arm64_workaround": "aspose-words>=25.0.0 has no arm64 wheel; built from a temporary trimmed context, no tracked file modified",
+    "build_minutes_approx": 8
+  },
+  "disk_data_volume": {"free_before": "27Gi", "free_after": "12-13Gi", "used_after_pct": 94},
+  "checks": {
+    "docker_run_tool_smoke": {
+      "python": "3.11.15-aarch64",
+      "modules_ok": ["openpyxl", "fitz", "cv2", "av", "docx", "pptx", "pandas"],
+      "tools": ["libreoffice-7.4.7.2", "ffmpeg", "tesseract"],
+      "pass": true
+    },
+    "synthetic_harness_docker_smoke": {
+      "use_docker": "always",
+      "sandbox_backend": "docker",
+      "final_status": "ok",
+      "primary": "quarterly_revenue.xlsx",
+      "verifier_openable": true,
+      "path_leaks": false,
+      "pass": true
+    },
+    "host_video_preflight_warning": {
+      "host_cv2_av_present": false,
+      "frame_backend_available": null,
+      "warning_fires_on_exp026_condition_a": true,
+      "pass": true
+    },
+    "real_single_task_capstone": {
+      "task_id": "7d7fc9a7-21a7-4b83-906f-416dea5ad04f",
+      "occupation": "Accountants and Auditors",
+      "reference_files": 6,
+      "auth": "DefaultAzureCredential (Entra ID, owner az login)",
+      "code_generation_budget": 32768,
+      "probe": {
+        "high":   {"finish": "timeout>480s", "usable": false},
+        "medium": {"finish": "stop", "completion_tokens": 31146, "reasoning_tokens": 22790, "visible_chars": 30094, "budget_pct": 95, "latency_s": 347, "note": "MARGINAL; live step2 run returned empty ('No Python code found')"},
+        "low":    {"finish": "stop", "completion_tokens": 10139, "reasoning_tokens": 2758, "visible_chars": 28598, "budget_pct": 31, "latency_s": 106, "note": "SAFE; ~69% headroom, 3.3x faster"}
+      },
+      "end_to_end_low": {
+        "status": "success",
+        "sandbox_backend": "docker",
+        "final_status": "ok",
+        "execution_mode": "sandbox",
+        "selected_skills": ["document", "data", "audio", "video"],
+        "primary_artifacts": ["Schedule.xlsx", "Summary.pdf", "Reconciliation_Chart.png"],
+        "contract_extensions": [".xlsx", ".pdf", ".png"],
+        "verification_ok": true,
+        "blocking_errors": [],
+        "schema_version": "1.0",
+        "manifest_path_leaks": false,
+        "deliverable_count": 6,
+        "latency_s": 112
+      },
+      "classification": "model-quality/config (empty visible content), NOT a harness bug"
+    }
+  },
+  "fix": {
+    "file": "batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml",
+    "change": "condition_a.model.reasoning_effort medium -> low; code_generation stays 32768; labels/comments updated",
+    "docs": "batch-runner/README.md sandbox-safety caution updated to recommend low with measured headroom",
+    "guard_changed": false,
+    "modes_untouched": ["subprocess", "code_interpreter", "json_renderer"],
+    "tests": {"test_sandbox_runner": "pass", "test_video_analyzer": "pass", "test_executor": "pass", "total_passed": 65}
+  },
+  "verdict": {
+    "harness_merge_ready": true,
+    "empty_output_edge_removed": true,
+    "residual_risk": "low: 'low' reasoning trades depth for reliable visible output; deliverable quality judged downstream by grader",
+    "pr57_open_unmerged": true
+  },
+  "constraints_respected": {
+    "full_220_run": false,
+    "actions_dispatch": false,
+    "merged": false,
+    "pr_title_body_edited": false,
+    "committed_binaries_or_local_data": false
+  }
+}

--- a/tasks/0702_thursday/sandbox_post_hardening_docker_verification_pr57.md
+++ b/tasks/0702_thursday/sandbox_post_hardening_docker_verification_pr57.md
@@ -1,0 +1,217 @@
+# Post-Hardening Docker Verification — PR #57 (sandbox + skills + multimodal)
+
+**Branch:** `hyeonsangjeon-sandbox-skills-multimodal-eval`
+**Pre-verification HEAD:** `203790c` (pre-220 hardening pass)
+**Scope:** Prove the cleaned/reset Docker environment can rebuild
+`gdpval-sandbox:latest` and run the sandbox path end-to-end after the hardening,
+and classify any failure as **harness** vs **model-quality**. This is a
+verification pass; the one code change below is a narrow, evidence-backed fix for
+a real empty-output config bug surfaced during the run.
+
+**Result:** ✅ Docker path fully verified (rebuild + tool smoke + synthetic
+harness run + real GDPVal task end-to-end). One real bug found and fixed:
+`exp026` sandbox `reasoning_effort` was **marginal at `medium`** (intermittent
+empty output) → changed to **`low`**. PR #57 remains **OPEN / MERGEABLE**.
+
+---
+
+## 1. Environment state before touching anything
+
+| Check | Value |
+|---|---|
+| git identity | `Hyeonsangjeon` (owner identity configured in the worktree) |
+| branch / HEAD | `hyeonsangjeon-sandbox-skills-multimodal-eval` @ `203790c` (local == remote) |
+| dirty tracked files | none (only untracked `data/gdpval-local` symlink — not staged) |
+| Docker daemon | up, Docker `29.1.3` |
+| local images | **0** — `gdpval-sandbox:latest` absent (expected post-reset) |
+| Data volume free | **27 GiB** (86% used) before build |
+
+---
+
+## 2. Image rebuild (arm64 / aspose-words recovery)
+
+`requirements.txt` pins `aspose-words>=25.0.0`, which has **no arm64 (Apple
+Silicon) wheel**. Recovery followed the documented branch recipe: build from a
+**temporary context** with that one line trimmed — **no tracked file was
+modified**.
+
+```bash
+# temp context assembled under a session scratch dir (NOT the repo):
+#   Dockerfile, .dockerignore, skills/, requirements.txt (aspose-words commented)
+docker build -t gdpval-sandbox:latest <temp_context>
+```
+
+- Build time ≈ 8 min on this machine. apt LibreOffice layer ≈ 113 s; full pip
+  scientific stack (pandas, scipy, scikit-image, opencv, av, PyMuPDF, openpyxl,
+  python-docx/pptx, pdfplumber, …) succeeded. All 7 stages `DONE`.
+- Image: `gdpval-sandbox:latest`, `arch=arm64`, ≈ **2.21 GB** manifest.
+- Disk after build: **12–13 GiB** free (build cost ≈ 14 GiB).
+
+> Note: `aspose-words` is only needed for a niche doc-conversion path; the baked
+> LibreOffice + PyMuPDF + python-docx/pptx cover the sandbox deliverable
+> pipeline. The trim is arm64-local only; CI (`ubuntu-latest`, x86_64) builds the
+> unmodified `requirements.txt`.
+
+---
+
+## 3. `docker run` tool smoke (baked toolchain)
+
+```bash
+docker run --rm --network none gdpval-sandbox:latest \
+  python -c "import openpyxl, fitz, cv2, av, docx, pptx, pandas; print('ok')"
+```
+
+- Python **3.11.15** (`aarch64`); all key modules import OK.
+- CLI tools present: **LibreOffice 7.4.7.2**, **ffmpeg**, **tesseract**.
+
+---
+
+## 4. Synthetic harness Docker-path smoke (no model)
+
+`SandboxRunner(use_docker="always")` with `complete` patched to emit a small
+openpyxl program (writes `quarterly_revenue.xlsx`); render QA + repair off.
+
+| Check | Result |
+|---|---|
+| `sandbox_backend` | **docker** (container stdout marker present) |
+| artifact generated → selected primary | `quarterly_revenue.xlsx` |
+| verifier openability | openable, kind=spreadsheet, suffix `.xlsx` |
+| deliverable contract | inferred `.xlsx` |
+| manifest | written, `schema_version=1.0` |
+| path leaks (absolute paths, temp dirs, email) | **none** (relative paths only) |
+| `final_status` | **ok** |
+
+→ **Mount / execute / collect / select / verify / manifest all pass under
+Docker, independent of any model call.**
+
+---
+
+## 5. Host video preflight warning (Finding 3 regression check)
+
+The host test environment has **no `cv2`/`av`** → `video_analyzer.frame_backend_available()`
+returns `None` (a genuine "backend absent" host). Replaying the committed step2
+preflight block against the **real** `exp026` `condition_a` (which configures a
+`video_analyzer` preprocessor) fires the one-time warning branch as designed.
+→ **Preflight warning path verified.**
+
+---
+
+## 6. Real single-task capstone + the empty-output finding
+
+One real GDPVal task run through **step2** with the hardened `exp026` settings
+(Docker `auto`, timeout 1200, memory 8 GB, `code_generation` 32768). Task:
+accountant `7d7fc9a7-21a7-4b83-906f-416dea5ad04f` (spreadsheet+report, 6 reference
+files, no audio/video). Auth: `DefaultAzureCredential` (Entra ID / owner `az`
+login). Preprocessors disabled for this task subset.
+
+### 6.1 What happened
+
+The **first real run at `reasoning_effort: medium` failed** with
+`✗ No Python code found in LLM response` — empty visible content, the exact
+symptom the hardening targeted. An instrumented probe (recording `finish_reason`
++ token usage on the **real runner prompt**) explained why:
+
+| effort | finish | completion / budget | reasoning tok | visible chars | headroom | latency |
+|---|---|---|---|---|---|---|
+| `high` | — | exceeded 480 s client timeout | — | (unusable) | — | >480 s |
+| `medium` | stop | **31,146 / 32,768 (95%)** | 22,790 | 30,094 | ~1,600 (5%) | 347 s |
+| `low` | stop | **10,139 / 32,768 (31%)** | 2,758 | 28,598 | ~22,600 (69%) | 106 s |
+
+gpt-5.4 draws hidden reasoning tokens from the **same** completion budget as the
+visible code. At `medium`, reasoning alone reached 22,790 and completion hit 95%
+of the 32,768 budget — one slightly larger reasoning draw returns **0 visible
+tokens** → "No Python code found" (reproduced live). At `low`, reasoning is
+~2,758, leaving ~69% headroom and running **3.3× faster** with comparable code
+size.
+
+### 6.2 End-to-end at `low` (Docker)
+
+Re-running the same task at `low` through the real step2 runner succeeded fully:
+
+| Field | Value |
+|---|---|
+| status | **success** (112 s, 6 files) |
+| `sandbox_backend` | **docker** |
+| `final_status` | **ok** |
+| `execution_mode` | sandbox |
+| `selected_skills` | document, data, audio, video |
+| primary artifacts | `…Schedule.xlsx`, `…Summary.pdf`, `…Reconciliation_Chart.png` |
+| contract exts / conf | `.xlsx/.pdf/.png` / medium |
+| verification | `ok=True`, `blocking_errors=[]` |
+| `schema_version` | 1.0 |
+| manifest path leaks | **none** (relative reference/generated paths) |
+
+### 6.3 Classification — harness vs model-quality
+
+The empty output is a **model-quality / config-tuning** issue (empty visible
+content), **not a harness bug**: the runner correctly detected "no code" and
+triggered the bounded resume, and the Docker execution path is independently
+proven by §4 and by the successful `low` end-to-end run. Root cause = `medium`
+reasoning variance intermittently starving the shared completion budget.
+
+---
+
+## 7. Fix applied (narrow, evidence-backed)
+
+The hardening's `medium` default was still a *known* empty-output edge. Changed
+`exp026` sandbox codegen only:
+
+- `condition_a.model.reasoning_effort`: **`medium` → `low`** (comment updated with
+  the probe table above). `code_generation` stays `32768`.
+- Updated the `experiment.name` / `condition_a.name` labels and the control note.
+- Updated `batch-runner/README.md` sandbox-safety caution to recommend `low` and
+  cite the measured medium-vs-low headroom.
+
+Untouched: the `SandboxRunner` `high`+`<32768` guard (still valid; `medium`
+remains a legitimate setting for lighter non-sandbox experiments, so no new
+guard noise was added), and `subprocess` / `code_interpreter` / `json_renderer`
+behavior.
+
+**Tests:** `test_sandbox_runner.py`, `test_video_analyzer.py`, `test_executor.py`
+→ **65 passed**. exp026 YAML re-validated (`reasoning_effort=low`,
+`code_generation=32768`). No Python files changed (config + docs only).
+
+---
+
+## 8. Merge-readiness verdict
+
+- **Harness: safe to merge from the smoke perspective.** Cleaned Docker env
+  rebuilds the image and runs the full sandbox path (mount → execute → select →
+  verify → manifest) end-to-end on a real GDPVal task with `final_status=ok` and
+  no path leaks.
+- **Config bug fixed:** the last known empty-output edge (`medium`) is removed by
+  the `low` default, validated by a real end-to-end Docker run.
+- **Residual risk (low):** `low` reasoning trades some deep-reasoning depth for
+  reliable visible output; acceptable for the sandbox codegen step, whose job is
+  to emit runnable code. Deliverable *quality* is still judged downstream by the
+  grader, not by this harness.
+- **arm64-only build note:** the `aspose-words` trim is a local Apple-Silicon
+  workaround; CI x86_64 builds the unmodified requirements.
+
+**PR #57 remains OPEN, not draft, MERGEABLE.** No full 220 run, no Actions
+dispatch, no merge, no PR title/body edits performed.
+
+---
+
+## Appendix — commands (sanitized)
+
+```bash
+# state
+git fetch --all --prune && git rev-parse --abbrev-ref HEAD && git log --oneline -1
+docker version; docker images; df -h /System/Volumes/Data
+
+# rebuild (temporary trimmed context; no tracked files touched)
+docker build -t gdpval-sandbox:latest <temp_ctx>
+docker run --rm --network none gdpval-sandbox:latest python -c "import openpyxl,fitz,cv2,av,docx,pptx,pandas;print('ok')"
+docker run --rm --network none gdpval-sandbox:latest bash -lc "soffice --version; ffmpeg -version|head -1; tesseract --version|head -1"
+
+# synthetic harness Docker-path smoke (no model): SandboxRunner(use_docker="always")
+
+# real single-task capstone (owner Entra ID auth; DefaultAzureCredential)
+#   prepared single-task file built from exp026 (execution block preserved)
+PYTHONPATH=. python step2_run_inference.py --no-resume --condition condition_a
+#   instrumented probe recorded finish_reason + usage at medium and low
+```
+
+_Config/docs only. Generated deliverables, Docker artifacts, caches, and local
+data are intentionally excluded from the commit._

--- a/tasks/0706_monday/pre220_harness_readiness_pr57.json
+++ b/tasks/0706_monday/pre220_harness_readiness_pr57.json
@@ -1,0 +1,84 @@
+{
+  "report": "pre220_harness_readiness_pr57",
+  "method": "model-free deterministic sweep (no LLM, no Docker, no Azure auth)",
+  "n_tasks": 220,
+  "n_sectors": 9,
+  "harness_errors": 0,
+  "zero_skill_tasks": 0,
+  "contract_confidence_dist": {
+    "medium": 132,
+    "high": 80,
+    "low": 8
+  },
+  "contract_ext_dist": {
+    ".pdf": 108,
+    ".xlsx": 100,
+    ".docx": 78,
+    ".pptx": 33,
+    ".png": 32,
+    ".wav": 15,
+    ".mp4": 13,
+    ".zip": 7,
+    ".html": 6,
+    ".md": 4,
+    ".json": 3,
+    ".mp3": 2
+  },
+  "missing_from_base_pkg_dist": {},
+  "modality_counts": {
+    "audio": 4,
+    "video": 1,
+    "image": 8
+  },
+  "reference_data_gap": {
+    "declared_ref_files": 261,
+    "resolved": 255,
+    "missing": 6,
+    "tasks_with_all_refs_missing": [
+      "a941b6d8"
+    ],
+    "tasks_missing_some_refs": [
+      "4b894ae3 (3/6)",
+      "75401f7c (1/2)",
+      "a941b6d8 (2/2)"
+    ],
+    "note": "all 6 missing files are large A/V media in the Information sector; re-fetchable via reference_file_urls (HuggingFace)"
+  },
+  "empty_contract_ext_tasks": [
+    "36d567ba",
+    "a0ef404e",
+    "f3351922",
+    "c7d83f01",
+    "d4525420",
+    "74d6e8b0",
+    "0112fc9b",
+    "772e7524"
+  ],
+  "modality_task_ids": {
+    "audio": [
+      "38889c3b",
+      "ff85ee58",
+      "4b894ae3",
+      "75401f7c"
+    ],
+    "video": [
+      "a941b6d8"
+    ],
+    "image": [
+      "4d1a8410",
+      "b9665ca1",
+      "e6429658",
+      "e4f664ea",
+      "11593a50",
+      "94925f49",
+      "f2986c1f",
+      "fe0d3941"
+    ]
+  },
+  "verdict": {
+    "harness_robust_across_220": true,
+    "image_covers_predicted_deps": true,
+    "blocker_for_full_220": false,
+    "pre_220_action": "re-fetch 6 missing A/V media files before running the multimodal tasks; otherwise harness is ready"
+  }
+}

--- a/tasks/0706_monday/pre220_harness_readiness_pr57.md
+++ b/tasks/0706_monday/pre220_harness_readiness_pr57.md
@@ -1,0 +1,161 @@
+# Pre-220 Harness Readiness Sweep — PR #57 (sandbox + skills + multimodal)
+
+**Branch:** `hyeonsangjeon-sandbox-skills-multimodal-eval` @ `2507309`
+**Date:** 2026-07-06
+**Scope:** Before the (owner-gated) full 220-task run, cheaply de-risk the
+sandbox harness by exercising its **deterministic surface** on **all 220 GDPVal
+tasks** — with **no model call, no Docker, and no Azure auth**. Prior runtime
+verification (`tasks/0702_thursday/…`) proved the Docker path end-to-end on 1–2
+tasks; this pass proves the *task-independent* harness logic does not choke on
+any of the 220 task/reference shapes across all 9 sectors.
+
+**Result:** ✅ **Harness is robust across the full benchmark — 0 exceptions on
+220 tasks.** The only real pre-220 gap is **data provisioning**: 6 large
+audio/video reference files (3 tasks in the *Information* sector) are missing
+from the local snapshot and must be re-fetched before the multimodal path can be
+exercised. No code change required. PR #57 remains **OPEN / MERGEABLE**.
+
+---
+
+## 1. What was swept
+
+Per task, the model-free deterministic harness surface used by `SandboxRunner`
+before any code generation:
+
+| Step | Function | What it validates |
+|---|---|---|
+| Reference resolution | `DEFAULT_LOCAL_PATH / ref` + exists (step2 lines 686–700) | local data availability |
+| Deliverable contract | `infer_deliverable_contract(prompt, refs, {})` | expected extensions + confidence |
+| Skill selection | `SkillsRegistry(None).select(refs, prompt, 5)` | which skills each task activates |
+| Dependency resolution | `resolve(refs, prompt, base_packages)` | predicted pip deps vs the sandbox base image |
+
+All pure/deterministic — no LLM, no container, no network, no credentials.
+Runtime: a few seconds for all 220 tasks.
+
+---
+
+## 2. Headline results
+
+| Metric | Value |
+|---|---|
+| Tasks swept | **220** across **9** sectors |
+| **Harness exceptions** | **0** ✅ |
+| Zero-skill tasks | **0** ✅ (every task activates ≥1 skill) |
+| `missing_from_base` packages | **{}** ✅ (image covers every predicted dep) |
+| Contract confidence | medium **132**, high **80**, low **8** |
+| Reference files | 261 declared → **255 resolved, 6 missing** |
+| Modality (declared refs) | audio **4**, video **1**, image **8** |
+
+---
+
+## 3. Finding — harness robustness (GREEN)
+
+Running contract inference, skill selection, and dependency resolution across
+**all 220 tasks raised zero exceptions.** The harness handles the full diversity
+of prompts and reference-file shapes (0–8 refs per task, mixed extensions,
+95 tasks with no declared refs) without crashing. Combined with the 65 passing
+unit tests and the Docker end-to-end proof, the harness logic is merge-ready.
+
+## 4. Finding — dependency coverage (GREEN)
+
+Every package predicted by the dependency resolver across all 220 tasks is
+already in the sandbox base-package set (`missing_from_base = {}`). This matches
+the `docker run` tool smoke (openpyxl, PyMuPDF, opencv, av, python-docx/pptx,
+pandas, LibreOffice, ffmpeg, tesseract all present). No per-task pip install is
+predicted to be required for the baked image.
+
+## 5. Finding — reference-data gap (ACTION before the multimodal run)
+
+6 of 261 declared reference files do not resolve locally. **All 6 are large
+audio/video media in the _Information_ sector** — the media whose whole purpose
+is to exercise the "vision for video / hearing for audio" thesis:
+
+| Task | Occupation | Refs resolved | Missing |
+|---|---|---|---|
+| `4b894ae3` | Audio and Video Technician | 3 / 6 | 3 media files |
+| `75401f7c` | Film and Video Editors | 1 / 2 | 1 media file |
+| `a941b6d8` | Film and Video Editors | 0 / 2 | 2 `.mp4` (the only video task; 657 MB 4K) |
+
+These files existed during the 0701 A/B smoke (the video task ran under Docker
+then) but are absent now — cleaned during the earlier disk-full recovery. They
+are **re-fetchable** from HuggingFace via each task's `reference_file_urls`
+(`auto_download=False` means they will not be pulled automatically).
+
+- **Not a harness bug.** The harness degrades gracefully (treats missing refs as
+  fewer/no files; step2 already prints a per-file "Reference file not found"
+  warning). But a full 220 run today would **silently under-exercise the
+  audio/video perception path** for these 3 tasks.
+- **Pre-220 action:** re-fetch these 6 files before the multimodal run. Disk is
+  currently tight (~12 GiB free); the 4K video alone is ~657 MB, so provision
+  deliberately. Deferred here because the full run is owner-gated and disk is
+  constrained — provisioning now would be premature.
+
+## 6. Finding — 8 low-confidence / empty-extension contracts (BY DESIGN)
+
+8 tasks yield an empty `expected_extensions` with `confidence=low`. All 8 have
+prompts that name no file type **and** no reference files to infer one from
+(e.g. `36d567ba`, `f3351922`, `74d6e8b0`). This is the contract's intended
+behavior — it downgrades rather than guessing a wrong extension that could block
+a valid deliverable. For these 8, the deterministic extension guard is
+intentionally permissive and the model's own judgment drives the output type.
+Documented, not a defect.
+
+---
+
+## 7. Per-sector representative snapshot
+
+| Sector | contract ext | conf | skills |
+|---|---|---|---|
+| Professional, Scientific & Technical | `.xlsx` | medium | data, document |
+| Government | `.docx, .pdf` | medium | document, data, image |
+| Information | `.xlsx, .pdf, .png` | high | document, data, image, audio |
+| Manufacturing | `.docx, .xlsx` | medium | document, data, audio, video |
+| Real Estate & Rental | `.docx` | medium | document, data, video |
+| Finance & Insurance | — | low | document |
+| Wholesale Trade | `.pptx` | medium | document, audio, video |
+| Health Care & Social Assistance | `.xlsx, .docx, .pdf` | high | document, data |
+| Retail Trade | `.pptx, .pdf` | high | document |
+
+Skill activation and contract inference behave sensibly per sector.
+
+---
+
+## 8. Residual risks & recommended pre-220 actions
+
+1. **Re-fetch the 6 missing A/V media files** (tasks `4b894ae3`, `75401f7c`,
+   `a941b6d8`) before the multimodal run, or accept that those 3 tasks run
+   text-only. Highest-value pre-220 action.
+2. **Video-task resources** — the single 657 MB / 4K video task remains the
+   heaviest; exp026 already raised sandbox memory→8 GB and timeout→1200 s for it
+   (0702 hardening). Re-verify once its media is re-provisioned.
+3. **8 low-confidence contracts** — expected; no action, but worth watching in
+   grading to confirm the model chose a sensible deliverable type unaided.
+
+None of these block merging the harness. They are data-provisioning /
+run-configuration items for the eventual full run.
+
+---
+
+## 9. Verdict
+
+- **Harness: ready for the full 220 run** from a logic standpoint — 0 exceptions
+  across all 220 tasks, every task activates a skill, and the image covers every
+  predicted dependency.
+- **One real pre-220 gap:** re-provision 6 missing A/V media files so the
+  audio/video perception thesis is actually exercised. Data, not code.
+- **No code change made** (the sweep found no harness bug; the empty-extension
+  and missing-media findings are by-design and data-provisioning respectively).
+
+**PR #57 remains OPEN, not draft, MERGEABLE.** No full 220 run, no Actions
+dispatch, no merge, no PR title/body edits, no local data or binaries committed.
+
+---
+
+## Appendix — command
+
+```bash
+# model-free deterministic sweep over all 220 tasks (no LLM / Docker / auth)
+PYTHONPATH=. python pre220_readiness_sweep.py   # -> pre220_sweep.json
+```
+
+Machine-readable summary: `pre220_harness_readiness_pr57.json` (this directory).

--- a/tasks/0707_tuesday/prompt_consolidation_refactor_design.md
+++ b/tasks/0707_tuesday/prompt_consolidation_refactor_design.md
@@ -1,0 +1,579 @@
+# Sandbox Prompt Consolidation — Single Authoring Surface (Design)
+
+> **Scope:** sandbox execution mode only. `subprocess`, `code_interpreter`,
+> `json_renderer` stay behavior-unchanged. Owner: Hyeonsang Jeon. Tracks under
+> PR #57 (branch `hyeonsangjeon-sandbox-skills-multimodal-eval`) — this doc is a
+> design artifact only; **no code is changed by this document**.
+
+## TL;DR — biggest decisions & risks
+- **Decision:** Make `core/sandbox_runner.py::_augment_prompt` a *thin assembler*
+  that iterates an ordered `sections:` list authored in
+  `prompts/sandbox_occupation_codegen.yaml`, filling each slot from a small
+  `SectionProvider` registry. Order, labels, toggles, and reflection wording move
+  to YAML; the fragment modules stay put. Alternate specs are selected via the
+  **already-wired** `execution.sandbox.prompt_name` key — no new exp-YAML plumbing.
+- **Biggest risk:** silent **byte drift** in the assembled prompt (separator/empty
+  section semantics, `str.format` brace handling, and the step2↔runner perception
+  interplay). Mitigated by a **mandatory P0 golden snapshot test** that is the
+  arbiter of "zero default drift" before any extraction lands.
+- **Do-not-do:** do **not** merge the two reflection loops — the step2 QA-retry
+  loop is mode-agnostic; pulling its wording into a sandbox-only spec would change
+  behavior for `subprocess`/`code_interpreter` and violate the scope constraint.
+
+---
+
+## 1. Goal & non-goals
+
+**Goal.** One clear place — the sandbox prompt-spec YAML — where a researcher or
+engineer authors *all* sandbox prompt structure: section wording, section order,
+section toggles, the self-QA reflection/repair text, and the perception-injection
+label. A researcher should be able to reorder/re-word without reading Python.
+
+**Explicit goals**
+- **Single authoring surface** for sandbox prompt text + order + labels + reflection.
+- **Minimal experiment-YAML change** — reuse the existing prompt-override hook
+  (`condition.prompt` prefix/body/suffix) and the existing spec selector
+  (`execution.sandbox.prompt_name`); add nothing new unless it earns its keep.
+- **Zero default behavior drift** — byte-identical assembled prompt for exp026 by
+  default; a golden test enforces this in P0 before anything else lands.
+- **Other executor modes untouched** — no signature/branch changes that alter
+  `subprocess`, `code_interpreter`, or `json_renderer` output.
+
+**Non-goals**
+- Not changing *what* the fragment providers emit (skills manual, deps hint,
+  contract section, previews, perception JSON). Only their **order/labels/presence**
+  become spec-driven.
+- Not unifying the two reflection loops into one source of truth (documented,
+  deliberately deferred — see §8).
+- Not touching the container/executor/security path, caching, or the output-QA
+  render pipeline.
+- Not restructuring `render_prompt`'s system/user precedence.
+
+---
+
+## 2. Current-state architecture (verified file:line)
+
+The sandbox prompt is assembled across **three layers**.
+
+**Layer A — orchestration: `batch-runner/step2_run_inference.py`**
+- `step2:635` `instruction = task_info["instruction"]`.
+- `step2:649-656` "legacy mode" manual prefix/body/suffix assembly (legacy only).
+- `step2:658-685` retry paths: no-files feedback (`:662`), `[REFLECTION` prepend
+  (`:671`, `error_context + instruction`, no `\n\n`), infra-error append (`:676`).
+- `step2:71-163` `_run_preprocessors(...)` returns the perception prefix
+  (`[AUDIO ANALYSIS]…`/`[VIDEO ANALYSIS]…`); `include_task_instruction` toggles at
+  `:108` / `:134`.
+- `step2:702-705` **mode-agnostic** prepend: `instruction = preprocessor_prefix +
+  "\n\n" + instruction` (runs for *all* executor modes).
+- `step2:737-744` `executor.execute(task_prompt=instruction,
+  experiment_prompt=experiment_prompt, …)`.
+
+**Layer B — runner: `batch-runner/core/sandbox_runner.py`**
+- `run()` `:254`: `registry.select(...)` `:274`, `infer_deliverable_contract(...)`
+  `:275`, attempt loop `:287-311` bounded by `repair_cfg.max_attempts` (default 1).
+- `_run_attempt()` `:324`: `resolve(...)` deps manifest → `_augment_prompt()`
+  `:341` → `render_prompt()` `:344` → `messages=[system,user]` `:350` →
+  `complete(..., reasoning_effort=…)` `:354`.
+- `_augment_prompt()` **`:609-651`** — hardcoded order, joined by `"\n\n"`:
+  1. `reflection` (if any) 2. `build_file_structure_info(ref_files)`
+  3. `registry.render_manual(skills)` 4. `manifest.to_prompt_hint()`
+  5. `contract.to_prompt_section()` 6. `task_prompt`
+  7. `generate_all_previews(ref_files)` 8. `available files` f-string.
+  Emptiness rules differ per block (`if x:` for 1–4,7; unconditional for 5,6,8).
+- `_build_reflection()` **`:653-694`** — hardcoded `[REFLECTION]…[/REFLECTION]`
+  wording: blocking (`[:12]`), warnings (`[:6]`), `contract.to_prompt_section()`,
+  sanitized stdout/stderr tails (`_sanitize_tail`, limit 800), prior code if
+  `len ≤ 4000`. Fed to the **next attempt** (`reflection_for_next` `:416-418`).
+
+**Layer C — template: `batch-runner/core/prompt_loader.py` + `prompts/sandbox_occupation_codegen.yaml`**
+- `load_prompt()` `:36-69` requires keys `system_message`, `user_prompt` (`:64`).
+- `render_prompt()` `:72-127`: system = codegen `system_message` wins (persona,
+  `:100-106`); user = exp `prefix` + exp `body` + codegen `user_prompt` (with
+  `{task_prompt}`) + exp `suffix` (`:109-122`). Uses `str.format` on **templates
+  only**; exp `prefix/body/suffix` are `.strip()`+joined, **not** formatted.
+- The sandbox YAML already externalizes system persona + a rich user template
+  (SANDBOX & SKILLS, RULES, FORMAT, EXAMPLE, CONFIDENCE TAG, `TASK: {task_prompt}`).
+
+**Fragment providers (each already isolated, returns a labeled block):**
+`skills_registry.render_manual` (`:184`), `dependency_resolver.DependencyManifest.to_prompt_hint`
+(`:233`), `deliverable_contract.DeliverableContract.to_prompt_section` (`:144`),
+`file_preview.build_file_structure_info` (`:301`) + `generate_all_previews` (`:85`),
+and the step2 perception producers `audio_analyzer` (label at `:126`/`:217`) /
+`video_analyzer`.
+
+**Spec-selection chain (already wired — key finding):**
+`exp026 execution.sandbox.*` → `step2:946 sandbox_options = execution_cfg.get("sandbox")`
+→ `step2:1038-1041 TaskExecutor(sandbox_options=…)` → `executor.py:89
+prompt_name or opts.get("prompt_name") or DEFAULT_PROMPT` → `sandbox_runner:196
+load_prompt(prompt_name)`.
+
+```mermaid
+flowchart TD
+  subgraph A["Layer A — step2 orchestration"]
+    I["instruction (task)"] --> RC["retry/error_context :658-685"]
+    RC --> PP["perception prepend :702-705<br/>(mode-agnostic)"]
+    PP --> EX["executor.execute(task_prompt=instruction)"]
+  end
+  subgraph B["Layer B — sandbox_runner"]
+    EX --> AUG["_augment_prompt :609-651<br/>HARDCODED order+labels"]
+    AUG --> RP["render_prompt :344"]
+    RP --> MSG["messages[system,user] → complete"]
+    REP["_build_reflection :653-694<br/>self-QA repair (loop 2)"] -.next attempt.-> AUG
+  end
+  subgraph C["Layer C — template"]
+    Y["prompts/sandbox_occupation_codegen.yaml<br/>system_message + user_prompt"] --> RP
+  end
+  FP["file_preview"] --> AUG
+  SK["skills_registry.render_manual"] --> AUG
+  DR["dependency_resolver.to_prompt_hint"] --> AUG
+  DC["deliverable_contract.to_prompt_section"] --> AUG
+```
+
+**Two reflection loops (distinct, must not merge):**
+1. **Loop 1 — step2, mode-agnostic:** `step2:_build_reflection_prompt(qa_score,
+   qa_issues, qa_suggestion)` (`:558+`) driven by the experiment `qa:` block +
+   `error_context` retry (`:658-685`). Runs for **every** executor mode.
+2. **Loop 2 — runner, sandbox-only:** `sandbox_runner:_build_reflection` (`:653-694`)
+   self-QA repair inside `max_attempts`.
+Both emit `[REFLECTION…`-prefixed text but have **different producers and inputs**.
+
+---
+
+## 3. Pain points today
+
+| Persona | To change… | They must touch | Why it's error-prone |
+|---|---|---|---|
+| Researcher | section **order** or a **label** | `sandbox_runner.py:609-651` (Python) | order is a hardcoded list; must edit code + not break `"\n\n".join` semantics |
+| Researcher | the **repair reflection** wording | `sandbox_runner.py:653-694` (Python) | wording is interleaved with slicing/redaction logic; easy to break byte layout |
+| Researcher | the **perception label** | `audio_analyzer.py:126/217`, `video_analyzer.py` | label lives in two producers; open/close tag pair; audio≠video |
+| Engineer | add a new augmentation block | `_augment_prompt` + a provider module | insertion point, emptiness rule, and separator all hand-managed |
+| Anyone | tune the persona/user template | `sandbox_occupation_codegen.yaml` | `str.format` **brace pitfalls** — a stray `{`/`}` in the template raises at render |
+
+Net: a single conceptual change ("move perception above the contract") can require
+edits in **2–3 files across two layers**, with no guardrail proving the output
+didn't drift. The `str.format` brace trap (documented in the YAML header) is a
+latent footgun whenever template text grows.
+
+---
+
+## 4. Target architecture — single authoring surface
+
+The spec YAML becomes the **one place** that owns sandbox prompt *structure*. Python
+becomes a thin, dumb assembler over a provider registry.
+
+```mermaid
+flowchart LR
+  subgraph SPEC["prompts/sandbox_occupation_codegen.yaml (single surface)"]
+    S1["sections: [ordered, toggleable ids]"]
+    S2["reflection_template / reflection strings"]
+    S3["perception_header (optional, empty by default)"]
+    S4["system_message + user_prompt (existing)"]
+  end
+  subgraph ASM["sandbox_runner._augment_prompt (thin)"]
+    CTX["SectionContext(task, ref_files, skills,<br/>manifest, contract, reflection, perception)"]
+    LOOP["for id in spec.sections:<br/>block = PROVIDERS[id](ctx)"]
+    JOIN["join non-omitted blocks with \n\n"]
+  end
+  S1 --> LOOP
+  CTX --> LOOP --> JOIN
+  PROVID["SECTION_PROVIDERS registry<br/>→ existing fragment modules"] --> LOOP
+```
+
+**`SectionProvider` abstraction.** Each provider is a pure function
+`(ctx: SectionContext) -> Optional[str]`, where `None` means *omit this section*
+(preserving today's per-block emptiness rules) and a string is emitted verbatim.
+Providers are thin adapters over the **existing** modules — no fragment logic moves.
+
+```python
+# core/prompt_sections.py  (NEW, sandbox-only)
+@dataclass(frozen=True)
+class SectionContext:
+    task_prompt: str
+    ref_files: list[str]
+    skills: object
+    manifest: "DependencyManifest"
+    contract: "DeliverableContract | None"
+    reflection: str | None
+    perception_text: str | None            # P3; None in P0-P2
+    registry: "SkillsRegistry"
+
+SECTION_PROVIDERS: dict[str, Callable[[SectionContext], str | None]] = {
+    "reflection":       lambda c: c.reflection or None,
+    "file_structure":   lambda c: build_file_structure_info(c.ref_files) or None,
+    "skills_manual":    lambda c: c.registry.render_manual(c.skills) or None,
+    "deps_hint":        lambda c: c.manifest.to_prompt_hint() or None,
+    "contract":         lambda c: (c.contract.to_prompt_section()
+                                   if c.contract is not None else None),
+    "perception_analysis": lambda c: c.perception_text or None,   # P3
+    "task":             lambda c: c.task_prompt,                  # always emit
+    "previews":         lambda c: (generate_all_previews(c.ref_files) or None
+                                   if c.ref_files else None),
+    "available_files":  lambda c: (_available_files_line(c.ref_files)
+                                   if c.ref_files else None),
+}
+```
+
+**Spec-driven ordering/toggling.** `_augment_prompt` reads `prompt_data["sections"]`
+(falling back to a Python `DEFAULT_SECTIONS` constant that reproduces today's order
+for backward compatibility), iterates in order, skips `enabled: false` entries,
+skips providers returning `None`, and joins with `"\n\n"`. An unknown id raises
+loudly (fail-fast, never silently drops a section).
+
+**Per-section input plumbing (no absolute-path leakage).** Providers read only
+from `SectionContext`. `ref_files` are absolute host paths *inside the runner*, but
+the providers that surface filenames already basename them (`available_files` uses
+`os.path.basename`; previews render filename + structure, not host roots). Reflection
+tails are already redacted by `_sanitize_tail` (`:93-107`). The context therefore
+carries host paths only to feed `build_file_structure_info`/`generate_all_previews`,
+which are responsible for emitting *sanitized* text — an invariant we lock with a
+test asserting no `/Users/…`, temp roots, or `~` appear in the assembled prompt.
+
+---
+
+## 5. Concrete YAML spec schema + before/after
+
+Extend `prompts/sandbox_occupation_codegen.yaml`. **Brace discipline:** every
+template string below is `str.format`-ed **exactly once** with a fixed named-slot
+dict; **slot VALUES are never re-parsed** (so dynamic content like stdout tails or
+prior code may contain `{ }` safely). Literal braces *in the template text* must be
+escaped `{{` `}}`. Keep code examples brace-free (as the current file already does).
+
+```yaml
+# ── NEW: ordered, toggleable section list (owns ORDER + PRESENCE) ──────────
+# If this key is absent, the runner falls back to DEFAULT_SECTIONS (today's order).
+sections:
+  - id: reflection          # self-QA repair block (loop 2), first so model addresses it
+  - id: file_structure      # build_file_structure_info(ref_files)
+  - id: skills_manual       # registry.render_manual(skills) → "AVAILABLE SKILLS"
+  - id: deps_hint           # manifest.to_prompt_hint() → "Likely libraries"
+  - id: contract            # contract.to_prompt_section()
+  # - id: perception_analysis   # ENABLED IN P3 (see §7); placed immediately before task
+  - id: task                # the (possibly perception-prefixed in P0-P2) task text
+  - id: previews            # generate_all_previews(ref_files)
+  - id: available_files     # "Files available in the sandbox working directory: [...]"
+
+# ── NEW: optional perception label (empty by default → byte-identical) ─────
+# The analyzers already emit self-labeled [AUDIO ANALYSIS]…[/AUDIO ANALYSIS] /
+# [VIDEO ANALYSIS] blocks that the exp026 system prompt references by name.
+# Leave empty unless you deliberately want an extra wrapper (would double-label).
+perception_header: ""
+
+# ── NEW: reflection wording (owns loop-2 text only). Two supported shapes: ──
+# (Recommended P1) STRING-TABLE — Python keeps the layout/slicing; only literals move:
+reflection_strings:
+  open_tag: "[REFLECTION]"
+  close_tag: "[/REFLECTION]"
+  intro: >-
+    Your previous attempt did NOT satisfy the deliverable contract. Regenerate the
+    COMPLETE solution and fix every issue below.
+  blocking_title: "Blocking problems to fix:"
+  warnings_title: "Secondary warnings (address if relevant):"
+  stdout_title: "Previous stdout (tail):"
+  stderr_title: "Previous stderr/error (tail):"
+  prior_code_title: "Your previous code (fix and resend in full):"
+  prior_code_fence: "----"
+
+# (Optional, later) MONOLITHIC TEMPLATE — clearer to author, needs careful newline
+# matching; Python pre-renders each optional block to "" or a full chunk, then ONE format:
+# reflection_template: |
+#   {open_tag}
+#   {intro}
+#
+#   {blocking_title}
+#   {blocking_errors}{warnings_block}
+#   {contract_section}{stdout_block}{stderr_block}{prior_code_block}
+#   {close_tag}
+```
+
+**Before/after `_augment_prompt`.**
+
+```python
+# BEFORE (core/sandbox_runner.py:609-651) — hardcoded order + emptiness + separators
+def _augment_prompt(self, task_prompt, reference_files, skills, manifest,
+                    contract=None, reflection=None) -> str:
+    parts = []
+    if reflection:
+        parts.append(reflection)
+    fsi = build_file_structure_info(reference_files or [])
+    if fsi: parts.append(fsi)
+    sm = self.registry.render_manual(skills)
+    if sm: parts.append(sm)
+    dh = manifest.to_prompt_hint()
+    if dh: parts.append(dh)
+    if contract is not None: parts.append(contract.to_prompt_section())
+    parts.append(task_prompt)
+    if reference_files:
+        prev = generate_all_previews(reference_files)
+        if prev: parts.append(prev)
+        names = [os.path.basename(f) for f in reference_files]
+        parts.append(f"📁 Files available in the sandbox working directory "
+                     f"(use them directly): {names}")
+    return "\n\n".join(parts)
+
+# AFTER — thin, spec-driven; order/labels/toggles live in YAML
+def _augment_prompt(self, task_prompt, reference_files, skills, manifest,
+                    contract=None, reflection=None, perception_text=None) -> str:
+    ctx = SectionContext(task_prompt, reference_files or [], skills, manifest,
+                          contract, reflection, perception_text, self.registry)
+    spec = self.prompt_data.get("sections") or DEFAULT_SECTIONS
+    parts = []
+    for entry in spec:
+        if not entry.get("enabled", True):
+            continue
+        sid = entry["id"]
+        provider = SECTION_PROVIDERS.get(sid)
+        if provider is None:
+            raise ValueError(f"Unknown prompt section id: {sid!r}")  # fail loud
+        block = provider(ctx)
+        if block is not None:                 # None == omit (preserves emptiness rules)
+            parts.append(block)
+    return "\n\n".join(parts)
+```
+
+> **Byte-identity note:** `DEFAULT_SECTIONS` = the 8 ids in the exact order above.
+> The provider table reproduces each block's current emptiness rule (`or None` for
+> 1–4/7, unconditional for `contract`/`task`/`available_files`). The P0 golden test
+> is the arbiter that this matches `_augment_prompt` pre-refactor byte-for-byte.
+
+---
+
+## 6. Experiment-YAML impact (minimal)
+
+**exp026 stays essentially unchanged.** The default spec ships the `sections:` and
+reflection strings; exp026's `condition.prompt` (system/suffix) and
+`execution.sandbox.*` are untouched. The audio/video `preprocessors:` and `qa:`
+blocks are untouched.
+
+**Two existing override paths cover researcher needs — no new keys required:**
+
+1. **Wrap/inject text (unchanged hook):** `condition.prompt.prefix/body/suffix`
+   still wraps the assembled user prompt via `render_prompt` (`:109-122`).
+2. **Select a different structure (already wired):** point at an alternate spec file
+   with **one line** — `execution.sandbox.prompt_name` flows through
+   `step2:946 → executor.py:89 → load_prompt`:
+
+```yaml
+# exp026 (illustrative override — NOT needed for the default run)
+execution:
+  sandbox:
+    prompt_name: "sandbox_occupation_codegen_reorder"   # alternate sections/wording
+```
+
+> Recommendation: **reuse `prompt_name`** as the spec selector. If a friendlier
+> alias is desired, accept `execution.sandbox.prompt_spec` as a synonym in
+> `executor.py` (`opts.get("prompt_name") or opts.get("prompt_spec")`) — a 1-line,
+> additive, sandbox-only change. Do not invent a parallel loader.
+
+---
+
+## 7. Perception injection — options & recommendation
+
+Today perception is a **mode-agnostic** prefix glued onto `instruction` at
+`step2:702-705`, so it rides *inside* the `task` block (slot 6) of the assembled
+prompt. Labels (`[AUDIO ANALYSIS]…[/AUDIO ANALYSIS]`, `[VIDEO ANALYSIS]…`) are
+produced by the analyzers (`audio_analyzer.py:126/217`, `video_analyzer.py`), which
+own the open/close tag pair and the per-modality wording.
+
+| Option | What moves | Byte-identity | Touches other modes? | Single-surface win |
+|---|---|---|---|---|
+| **A — relocate to spec slot (recommended)** | ORDER+PRESENCE → spec `perception_analysis`; label stays with producer; step2 passes perception through for **sandbox only** | Provable (see below) | No — mode branch keeps non-sandbox prepend identical | High: perception becomes a real ordered/toggleable section |
+| B — relocate + spec-owned label | also move label into `perception_header`; analyzers return raw JSON | Higher risk (analyzer return-contract change; single header can't express open/close + audio≠video) | No, but more surgery | Highest, but violates zero-drift ease |
+| C — document in place | nothing moves; spec only *documents* that perception heads the task | Trivially identical | No | Low: order/presence not actually spec-controlled |
+
+**Recommended: Option A.** Rationale + byte proof:
+
+- Today (sandbox path): runner receives `task_prompt = perception + "\n\n" +
+  error_context + instruction`; assembled as `… contract \n\n [perception \n\n
+  error_context+instruction] \n\n previews …`.
+- Under A: step2 stops prepending **for sandbox mode only**, passes `perception_text`
+  through `executor.execute → run → _augment_prompt`; the spec places
+  `perception_analysis` immediately **before** `task`, joined by `"\n\n"`. Result:
+  `… contract \n\n perception \n\n (error_context+instruction) \n\n previews …`
+  — **identical bytes** (perception is the outermost prefix in both).
+- **Other modes untouched:** keep the `step2:702-705` prepend for
+  non-sandbox modes (a `if execution_mode == "sandbox": pass_through else: prepend`
+  branch). Add `perception_text: Optional[str] = None` to `executor.execute` and
+  `SandboxRunner.run`; other runners simply ignore it (no branch/behavior change).
+- **`perception_header` stays empty by default** — the analyzers already emit
+  self-labeled blocks that the exp026 system prompt references by name
+  (`exp026:148-156`); a non-empty header would double-label and drift.
+
+Ship A in **P3**, gated behind the golden harness, with a fixture that includes a
+retry/`error_context` **and** perception (the interplay is the sharp edge).
+
+---
+
+## 8. Reflection-loop reconciliation
+
+There are **two independent producers** of `[REFLECTION…`-shaped text:
+
+| | Loop 1 (step2) | Loop 2 (sandbox_runner) |
+|---|---|---|
+| Fn | `_build_reflection_prompt` `:558+` + `error_context` `:658-685` | `_build_reflection` `:653-694` |
+| Driver | experiment `qa:` block (score/issues/suggestion) + infra retries | contract/verify/render blocking errors |
+| Consumed by | next **step2 attempt** as `error_context` | next **runner attempt** as `reflection` |
+| Scope | **mode-agnostic** (all executors) | **sandbox-only** |
+
+```mermaid
+flowchart TD
+  subgraph L1["Loop 1 — step2 (mode-agnostic)"]
+    QA["qa: inspector → score/issues"] --> BRP["_build_reflection_prompt :558"]
+    BRP --> ERR["error_context → next step2 attempt"]
+  end
+  subgraph L2["Loop 2 — sandbox_runner (sandbox-only)"]
+    ANA["contract+verify+render blocking"] --> BR["_build_reflection :653"]
+    BR --> NEXT["reflection → next runner attempt"]
+  end
+```
+
+**Recommendation: keep them separate; give only Loop 2 a spec home in P1.**
+- The spec `reflection_strings`/`reflection_template` owns **Loop 2 only**.
+- **Do NOT** move Loop 1 wording into the sandbox spec: Loop 1 runs for
+  `subprocess`/`code_interpreter` too, so coupling it to a sandbox-only file would
+  change those modes' retry text — a direct scope violation.
+- Document both in the spec header comment so an author isn't surprised that editing
+  `reflection_strings` doesn't touch the step2 QA-retry text.
+- **Risk if ignored:** an author edits `reflection_strings` expecting all retry
+  prompts to change; only Loop 2 changes. Mitigate with an explicit header note and
+  a naming that says "sandbox self-QA repair (loop 2)".
+- **Optional future (out of scope):** a shared `reflection_templates:` map keyed by
+  loop, loaded by both step2 and the runner — only worth it if Loop 1 also migrates
+  to a per-mode spec, which is a separate initiative.
+
+---
+
+## 9. Phased migration plan (independently shippable)
+
+Each phase is small, reversible, and green-before-next. **P0 is mandatory first.**
+
+### P0 — Golden snapshot harness (no behavior change)
+- **Scope:** capture the *current* `_augment_prompt` and `_build_reflection` output
+  byte-for-byte on fixtures; add the test that will guard every later phase.
+- **Files:** `tests/test_sandbox_prompt_golden.py` (new), `tests/fixtures/prompt/*`
+  (canned skills/manifest/contract/ref-file previews/reflection inputs).
+- **Test:** assert assembled prompt == stored golden for (a) doc-only task,
+  (b) audio+video+doc task, (c) repair attempt with reflection + error_context.
+- **Rollback:** delete test file; zero prod impact.
+
+### P1 — Extract Loop-2 reflection wording → `reflection_strings`
+- **Scope:** `_build_reflection` reads literals from `prompt_data["reflection_strings"]`
+  (fallback to current constants); Python keeps slicing/redaction/layout.
+- **Files:** `core/sandbox_runner.py`, `prompts/sandbox_occupation_codegen.yaml`.
+- **Test:** P0 golden (byte-identical) + a unit test that overriding a string
+  changes exactly that literal.
+- **Rollback:** revert the file read to inline constants; YAML key is inert.
+
+### P2 — Spec-driven section ordering (`sections:` + `SECTION_PROVIDERS`)
+- **Scope:** introduce `core/prompt_sections.py`, `SectionContext`,
+  `SECTION_PROVIDERS`, `DEFAULT_SECTIONS`; convert `_augment_prompt` to the thin loop.
+- **Files:** `core/prompt_sections.py` (new), `core/sandbox_runner.py`,
+  `prompts/sandbox_occupation_codegen.yaml`.
+- **Test:** P0 golden unchanged; new tests for reorder/toggle and *unknown id →
+  raises*; schema-key assertions.
+- **Rollback:** `sections:` absent ⇒ `DEFAULT_SECTIONS` path ⇒ identical to pre-P2.
+
+### P3 — Perception label unification (Option A)
+- **Scope:** add `perception_analysis` provider + `perception_header` (empty
+  default); step2 passes perception through for **sandbox only**, keeps prepend for
+  other modes; enable the section in the shipped spec.
+- **Files:** `step2_run_inference.py` (mode branch at the perception injection),
+  `core/executor.py` (+`perception_text` kwarg), `core/sandbox_runner.py`,
+  `prompts/sandbox_occupation_codegen.yaml`.
+- **Test:** P0 golden re-baselined with the paired proof (perception+retry fixture);
+  a test asserting **non-sandbox** instruction bytes are unchanged.
+- **Rollback:** disable the `perception_analysis` section + revert step2 branch to
+  unconditional prepend.
+
+### P4 — Docs & authoring guide
+- **Scope:** spec header comments (brace rules, two-loops note), a short
+  `prompts/README` "how to author a sandbox spec", cross-links in exp026 comments.
+- **Files:** docs/comments only.
+- **Test:** none (doc); optional `str.format` self-render smoke on the shipped spec.
+- **Rollback:** trivial.
+
+---
+
+## 10. Risk analysis & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| **Byte drift** in assembled prompt (separators, per-block emptiness) | Med | P0 golden test is the gate; providers return `None` to preserve exact emptiness rules; `DEFAULT_SECTIONS` fallback for missing key |
+| **`str.format` brace injection** from dynamic content (stdout/prior code with `{ }`) | Med | Format each template **once** with named slots; dynamic values are passed as arguments (never re-parsed); escape literal braces `{{`; keep code examples brace-free; add a test formatting the reflection template with a `{payload}`-laden tail |
+| **Section-input plumbing regression** (perception threaded wrong) | Med | Optional `perception_text` kwarg, default `None`, ignored by other runners; mode branch in step2; test asserting non-sandbox bytes unchanged |
+| **Unknown/misordered section silently dropped** | Low | Assembler raises on unknown id; schema-key test; toggles are explicit `enabled: false` |
+| **Test flakiness** (LibreOffice/vision/Docker) | Low | Golden path is model-free via local fallback (`use_docker="never"`, `complete` patched, as existing `test_sandbox_runner.py` does); vision QA already `enabled: false` in exp026 |
+| **Privacy leakage** (`/Users/…`, temp roots, session-state, testenv, emails) into prompts/manifest | Med | `_sanitize_tail` redaction retained; `available_files` basenames; add an assertion that the assembled prompt and manifest contain no host roots / `~` / email-like tokens |
+| **Coupling Loop 1 into sandbox spec** breaks other modes | Low (if guarded) | §8 explicitly forbids it; header note; scope test |
+
+---
+
+## 11. Test strategy
+
+- **Golden byte-identical assembly (P0, mandatory):** fixture task set = {doc-only,
+  audio+video+doc, repair-with-reflection+error_context}. Assert
+  `_augment_prompt(...) == golden` and full `render_prompt` user message ==
+  golden. Model-free (patch `complete`, `use_docker="never"`), mirroring
+  `tests/test_sandbox_runner.py`.
+- **Per-section unit tests:** each provider returns expected text / `None` on empty
+  inputs; reorder changes only order; `enabled: false` omits a section;
+  perception slot emits only when `perception_text` present.
+- **Schema-key assertions:** `load_prompt` still enforces `system_message`,
+  `user_prompt`; new `sections` entries validate against the known id set;
+  `reflection_strings` keys present or fall back cleanly.
+- **Fail-loud guard:** unknown section id → `ValueError`; a mis-typed id in a test
+  spec must raise, not silently drop.
+- **Brace-safety test:** format the reflection template with a stdout tail
+  containing `"{oops} {0} {task_prompt}"` and prior code with dict/set literals;
+  assert no exception and literal preservation.
+- **Privacy guard:** assert assembled prompt + `manifest.json` contain no
+  `/Users/`, temp roots, `~`, or `user@host`-style tokens.
+- **Other-modes invariance:** run a non-sandbox path and assert the `instruction`
+  bytes (with perception) are unchanged by P3.
+
+---
+
+## 12. Definition of done & open questions
+
+**Definition of done**
+- [ ] P0 golden test committed and green; it fails if any later phase drifts a byte.
+- [ ] `_augment_prompt` is a thin spec-driven loop; order/labels/toggles live in
+      `prompts/sandbox_occupation_codegen.yaml`.
+- [ ] Loop-2 reflection wording authored in the spec; Loop 1 documented and untouched.
+- [ ] Perception is a spec-controlled, ordered section (Option A) with byte-identity
+      proven; non-sandbox modes verified unchanged.
+- [ ] exp026 runs byte-identical by default; a one-line `prompt_name` override
+      selects an alternate spec.
+- [ ] `subprocess`/`code_interpreter`/`json_renderer` tests unchanged and green.
+- [ ] Authoring guide (P4) explains brace rules and the two reflection loops.
+- [ ] PR #57 remains open; changes land as additive commits on the sandbox branch.
+
+**Open questions for the owner**
+1. **Spec selector ergonomics:** keep the existing `execution.sandbox.prompt_name`,
+   or add the `prompt_spec` synonym for readability? (1-line additive change.)
+2. **Reflection shape:** ship P1 as the safe **string-table**, or go straight to the
+   **monolithic `reflection_template`** (clearer authoring, stricter newline test)?
+3. **Perception depth:** accept Option A (label stays with analyzers), or is moving
+   labels into `perception_header` (Option B) worth the analyzer return-contract
+   change for full single-surface authoring?
+4. **Golden fixtures:** which real task ids should seed the fixtures (a
+   reference-heavy accountant task + the 4K video task are the known stress cases)?
+5. **Scope of `sections` toggling:** should we expose `enabled` to experiment YAML
+   (per-run section on/off) now, or keep toggles spec-only until there's demand?
+
+---
+
+### Suggested `task.md` entry
+
+```markdown
+### Phase 0-4: Sandbox Prompt Consolidation (single authoring surface)
+- **Decision:** Move sandbox prompt ORDER + LABELS + TOGGLES + loop-2 reflection
+  wording into prompts/sandbox_occupation_codegen.yaml; make _augment_prompt a thin
+  spec-driven assembler over a SectionProvider registry. Reuse the already-wired
+  execution.sandbox.prompt_name selector; keep other modes and Loop-1 untouched.
+- **Critical Path:**
+  - [ ] P0: golden byte-identical assembly test (doc / audio+video+doc / repair) — model-free
+  - [ ] P1: extract loop-2 reflection literals → reflection_strings (golden stays green)
+  - [ ] P2: sections: + SECTION_PROVIDERS + DEFAULT_SECTIONS; unknown id raises
+  - [ ] P3: perception_analysis section (Option A) + step2 sandbox-only pass-through; verify non-sandbox bytes unchanged
+  - [ ] P4: authoring guide (brace rules, two-loop note); exp026 byte-identical by default
+```

--- a/tasks/0707_tuesday/prompt_consolidation_refactor_design.md
+++ b/tasks/0707_tuesday/prompt_consolidation_refactor_design.md
@@ -5,6 +5,13 @@
 > PR #57 (branch `hyeonsangjeon-sandbox-skills-multimodal-eval`) — this doc is a
 > design artifact only; **no code is changed by this document**.
 
+> **Implementation status: SHIPPED on PR #57.** All phases landed behind the
+> golden harness (zero default byte-drift; the 9 pre-existing goldens are
+> unchanged). Commits: **P0** golden harness `047d9bb` · **P1** reflection
+> string-table `f791db7` · **P2** spec-driven sections `eec8a77` · **P3**
+> perception section (Option A) `99f3519` · **P4** authoring guide (this pass).
+> Researcher-facing guide: `batch-runner/prompts/sandbox_prompt_authoring.md`.
+
 ## TL;DR — biggest decisions & risks
 - **Decision:** Make `core/sandbox_runner.py::_augment_prompt` a *thin assembler*
   that iterates an ordered `sections:` list authored in

--- a/tasks/0707_tuesday/prompt_consolidation_refactor_design.md
+++ b/tasks/0707_tuesday/prompt_consolidation_refactor_design.md
@@ -547,18 +547,25 @@ Each phase is small, reversible, and green-before-next. **P0 is mandatory first.
 - [ ] Authoring guide (P4) explains brace rules and the two reflection loops.
 - [ ] PR #57 remains open; changes land as additive commits on the sandbox branch.
 
-**Open questions for the owner**
-1. **Spec selector ergonomics:** keep the existing `execution.sandbox.prompt_name`,
-   or add the `prompt_spec` synonym for readability? (1-line additive change.)
-2. **Reflection shape:** ship P1 as the safe **string-table**, or go straight to the
-   **monolithic `reflection_template`** (clearer authoring, stricter newline test)?
-3. **Perception depth:** accept Option A (label stays with analyzers), or is moving
-   labels into `perception_header` (Option B) worth the analyzer return-contract
-   change for full single-surface authoring?
-4. **Golden fixtures:** which real task ids should seed the fixtures (a
-   reference-heavy accountant task + the 4K video task are the known stress cases)?
-5. **Scope of `sections` toggling:** should we expose `enabled` to experiment YAML
-   (per-run section on/off) now, or keep toggles spec-only until there's demand?
+**Resolved decisions (owner, 2026-07-07)**
+1. **Spec selector:** Keep the existing `execution.sandbox.prompt_name` **only** —
+   no `prompt_spec` synonym. Zero new experiment-YAML wiring; avoids duplicate keys.
+2. **Reflection shape:** Ship P1 as the safe **string-table** (Python keeps
+   layout/slicing/redaction; only literals move to YAML). Promote to a monolithic
+   `reflection_template` later only if authors ask for it.
+3. **Perception depth:** **Option A** — analyzers keep their self-labeled
+   `[AUDIO ANALYSIS]`/`[VIDEO ANALYSIS]` blocks; sandbox receives that text as a
+   named `perception_analysis` section and controls only placement/order. No
+   analyzer return-contract change; non-sandbox modes untouched.
+4. **Golden fixtures:** **Four** — audio `4b894ae3` + 4K video `a941b6d8` (both
+   already run locally), one **doc-only/no-reference** task (covers empty
+   perception/preview sections), and one **accounting/spreadsheet** task (covers
+   contract extension inference). The concrete xlsx task id is picked during P0
+   from local reference-heavy data.
+5. **Section-toggle exposure:** **Spec-only for now** (YAGNI). Section on/off lives
+   in the prompt-spec YAML; per-run A/B is done via an alternate spec selected with
+   `prompt_name`. Do not add an experiment-YAML `sections` override layer until
+   there is real demand.
 
 ---
 

--- a/tasks/0707_tuesday/sandbox_multimodal_capstone_pr57.json
+++ b/tasks/0707_tuesday/sandbox_multimodal_capstone_pr57.json
@@ -1,0 +1,65 @@
+{
+  "pr": 57,
+  "branch": "hyeonsangjeon-sandbox-skills-multimodal-eval",
+  "pass": "runtime multimodal capstone (audio + 4K video), real Docker end-to-end",
+  "scope": "sandbox mode only; subprocess/code_interpreter/json_renderer unchanged",
+  "harness_bug_fixed": {
+    "symbol": "core/sandbox_runner.docker_image_exists",
+    "cause": "docker image inspect <name:tag> returns 'No such image' under Docker Desktop containerd image store even when image is present; caused silent local fallback",
+    "fix": "fall back to `docker image ls --quiet <image>` when inspect reports absent; fast path preserved",
+    "tests_added": 3,
+    "tests_file": "tests/test_sandbox_runner.py",
+    "test_sandbox_runner_pass": "30/30",
+    "py_compile": "ok"
+  },
+  "capstones": [
+    {
+      "task_id": "4b894ae3",
+      "modality": "audio",
+      "backend": "docker",
+      "execution_mode": "sandbox",
+      "reasoning_effort": "low",
+      "preprocessor": {"name": "audio_analyzer", "model": "gpt-audio-1.5", "ran": true, "chars_injected": 799},
+      "selected_skills": ["audio", "document", "data", "video"],
+      "deliverable_contract": {"expected_extensions": [".docx", ".wav"], "confidence": "medium"},
+      "primary_artifacts": ["EDIT_REPORT.docx", "FULL_EDIT_MIX.wav", "STEM_BASS_EDITED.wav"],
+      "verification_ok": true,
+      "blocking_errors": [],
+      "self_qa_score": 7,
+      "reflect_rounds": 1,
+      "final_status": "ok",
+      "runtime_sec": 269,
+      "files": 4
+    },
+    {
+      "task_id": "a941b6d8",
+      "modality": "video",
+      "backend": "docker",
+      "execution_mode": "sandbox",
+      "reasoning_effort": "low",
+      "preprocessor": {"name": "video_analyzer", "model": "gpt-5.4", "ran": true, "host_frame_backend": "cv2", "clips": 2, "resolution": "3840x2160", "frames_per_clip": 8, "vision_calls_ms": [27612, 25020], "chars_injected": 8814},
+      "selected_skills": ["video", "data", "document", "image"],
+      "deliverable_contract": {"expected_extensions": [".mp4", ".png"], "confidence": "medium"},
+      "primary_artifacts": ["teleportation_composite.mp4", "teleportation_composite_raw.mp4", "teleportation_preview.png", "teleportation_storyboard.png"],
+      "verification_ok": true,
+      "blocking_errors": [],
+      "self_qa_score": 6,
+      "reflect_rounds": 1,
+      "final_status": "ok",
+      "runtime_sec": 1211,
+      "files": 5,
+      "container_mem_peak_gib": 3.12,
+      "container_mem_limit_gib": 7.65,
+      "oom": false
+    }
+  ],
+  "resource_hardening_validated": {"memory_gb": 8, "timeout_sec": 1200, "oom_observed": false},
+  "manifest_quality": {"schema_version": "1.0", "relative_paths": true, "leak_scan_matches": 0},
+  "merge_readiness": "runtime-safe: reset Docker env rebuilds + runs sandbox path; both modalities end-to-end ok in Docker; one real bug fixed + regression-tested",
+  "residual_risks": [
+    "video_analyzer needs host cv2/av; no-ops with preflight warning if absent",
+    "deep audio validation needs host soundfile/ffprobe (non-blocking warning otherwise)",
+    "4K video tasks are time-heavy (~20 min each); schedule full 220 accordingly"
+  ],
+  "constraints": {"full_220_run": false, "actions_dispatch": false, "merged": false, "pr_body_edited": false, "committed": ["report", "sandbox_runner_fix", "sandbox_runner_tests"]}
+}

--- a/tasks/0707_tuesday/sandbox_multimodal_capstone_pr57.md
+++ b/tasks/0707_tuesday/sandbox_multimodal_capstone_pr57.md
@@ -1,0 +1,107 @@
+# Sandbox Multimodal Capstone — PR #57 (audio + 4K video, real Docker end-to-end)
+
+Branch: `hyeonsangjeon-sandbox-skills-multimodal-eval` · PR #57 (OPEN, unmerged)
+Scope: runtime proof only — sandbox mode. `subprocess` / `code_interpreter` /
+`json_renderer` untouched. No full 220 run, no Actions dispatch, no merge.
+
+## Goal
+Prove the container path works end-to-end on real multimodal reference files:
+one **audio** task and one **4K video** task, each running the main solving model
+(gpt-5.4, reasoning_effort=low) with local Skills inside Docker plus the
+host-side audio/video perception preprocessors. This is the runtime half that was
+intentionally deferred after the pre-220 hardening pass.
+
+## Harness bug found + fixed (only code change in this pass)
+`core/sandbox_runner.docker_image_exists()` used `docker image inspect <name:tag>`
+to decide whether the sandbox image is present. Under Docker Desktop's default
+**containerd image store** (`io.containerd.snapshotter.v1`), `docker image inspect
+<name:tag>` returns *"No such image"* even when the image is listed by
+`docker image ls <name:tag>` and inspectable by ID — most reproducibly right after
+a daemon restart. That misdetection silently routed the run to the local fallback,
+which then failed on host libs (e.g. `No module named 'soundfile'`).
+
+Fix: when `docker image inspect` reports absent, fall back to
+`docker image ls --quiet <image>` (returns the ID or empty). Fast path is
+preserved — the `ls` call only runs when `inspect` says "missing". Added 3
+regression tests (containerd-store fallback, both-empty → false, fast-path skips
+`ls` when inspect succeeds).
+
+- `core/sandbox_runner.py`: +24/-2 (hardened `docker_image_exists`)
+- `tests/test_sandbox_runner.py`: +40 (3 tests + fake-run factory)
+- 30/30 `test_sandbox_runner.py` pass; `py_compile` clean.
+
+## A — Audio capstone (task 4b894ae3, Information / audio production)
+3× 48 kHz stereo stem WAVs (~57 MB each). Deliverable: edited stems + mix + report.
+
+| field | value |
+|---|---|
+| runner backend | **docker** |
+| execution_mode | sandbox |
+| preprocessor | `audio_analyzer` (gpt-audio-1.5) ran → **799 chars** injected into prompt |
+| selected_skills | audio, document, data, video |
+| deliverable_contract | ext `[.docx, .wav]`, confidence **medium** |
+| primary artifacts | `…_EDIT_REPORT.docx`, `…_FULL_EDIT_MIX.wav`, `…_STEM_BASS_EDITED.wav` |
+| verification | **ok=True**, blocking_errors=[] |
+| self-QA | score **7** (≥5), 1 reflect round |
+| final_status | **ok** |
+| runtime | ~269 s (4.5 min), 4 files, host mem 171 MB |
+
+Note: the host verify env lacks `soundfile`/`ffprobe`, so deep WAV validation logs a
+non-blocking "not validated" warning — expected, does not affect final_status.
+
+## B — Video capstone (task a941b6d8, Information / Film & Video Editors)
+VFX teleportation shot: composite an actor between two 4K clips and make them
+vanish. Refs: `TWT_001_02.mp4` (~224 MB) + `TWT_A001_03.mp4` (~657 MB), both
+3840×2160 h264.
+
+| field | value |
+|---|---|
+| runner backend | **docker** |
+| execution_mode | sandbox |
+| preprocessor | `video_analyzer` (gpt-5.4 vision) **ran on host** via cv2: 8 frames/clip from both 4K clips → 2 vision calls (27.6 s / 25.0 s) → **8,814 chars** injected |
+| selected_skills | video, data, document, image |
+| deliverable_contract | ext `[.mp4, .png]`, confidence **medium** |
+| primary artifacts | `teleportation_composite.mp4`, `teleportation_composite_raw.mp4`, `teleportation_preview.png`, `teleportation_storyboard.png` |
+| in-container work | parsed base (204 f, 8.5 s) + overlay (638 f, 26.6 s) 4K h264, composited, wrote .mp4 + preview/storyboard |
+| verification | **ok=True**, blocking_errors=[] |
+| self-QA | score **6** (≥5), 1 reflect round |
+| final_status | **ok** |
+| runtime | ~1211 s (20.2 min), 5 files |
+
+### Resource stability (validates F2 hardening)
+Live `docker stats` during 4K compositing peaked at **~3.12 GiB / 7.65 GiB**
+(memory_gb=8), CPU ~190–204% (multi-core). Comfortable headroom — no OOM /
+exit-137 (the earlier 5 GB config was marginal on this task). Completed well
+inside the 1200 s timeout.
+
+## Pass/fail matrix
+| task | backend | preproc ran? | perception injected | artifacts | verify | final_status |
+|---|---|---|---|---|---|---|
+| audio 4b894ae3 | docker | yes (audio) | 799 chars | docx + 2 wav | ok | **ok** |
+| video a941b6d8 | docker | yes (video, 4K) | 8,814 chars | mp4 + raw + 2 png | ok | **ok** |
+
+Both are genuine harness successes (backend=docker, contract inferred, perception
+engaged, artifacts produced + verified). No harness failures. Deliverable
+*artistic* quality is model-dependent and out of scope for this runtime proof.
+
+## Merge-readiness verdict
+From the runtime perspective PR #57 is **safe to merge**:
+- Reset/clean Docker env rebuilds + runs the sandbox path.
+- Real audio and 4K-video tasks complete end-to-end in Docker with perception.
+- The one real bug surfaced (containerd image detection) is fixed + regression-tested.
+- Manifests are schema_version 1.0, relative-path, leak-clean; verification passes.
+
+## Residual risks / notes
+- Host perception deps: audio needs none; video needs host `cv2` (or `av`). If a
+  full hybrid run is launched on a host without them, `video_analyzer` no-ops —
+  the preflight warning (added earlier) makes this explicit; document/ensure host
+  deps before a large hybrid run.
+- Deep audio validation needs `soundfile`/`ffprobe` in the *host* verify env;
+  absence is a non-blocking warning only.
+- Video tasks are heavy (~20 min/task here). A full 220 run mixing 4K video will
+  be time-dominated by such tasks; schedule accordingly. Not a correctness risk.
+
+## Constraints honored
+No full 220 run · no Actions dispatch · no merge · PR title/body untouched ·
+subprocess/code_interpreter/json_renderer unchanged · only report + the
+sandbox_runner fix + its tests are committed (no binaries/caches/local data).


### PR DESCRIPTION
## Summary

Evolves the GDPVal solving path from `subprocess` into a **container sandbox** execution mode (`execution.mode: sandbox`) with three pillars, plus multimodal perception. Gracefully falls back to the hardened local subprocess when Docker is unavailable, so existing flows are unaffected.

### 1. 🐳 Container sandbox — `core/sandbox_runner.py` + `sandbox/`
- Runs LLM-generated `solution.py` in Docker: `--network none`, `--memory`, `--memory-swap`, `--pids-limit`, `--security-opt no-new-privileges`.
- `use_docker: auto | never | always` — `auto` uses Docker when the daemon + image are present, otherwise falls back to the existing isolated-subprocess path (shared hardening).
- `sandbox/Dockerfile` bakes `requirements.txt` + system tooling (ffmpeg, poppler, tesseract, libreoffice, graphviz, GDAL/GEOS, weasyprint stack, espeak-ng, CJK fonts) and the `skills/` package. Build with `bash sandbox/build.sh`.

### 2. 📦 Per-task dependency discovery — `core/dependency_resolver.py`
- Determines the pip packages each of the 220 tasks needs from **reference-file extensions**, **task keywords**, and an **AST scan** of the generated code's imports.
- Classifies each package against the base image and flags anything `missing_from_base` (e.g. `ezdxf`).

### 3. 🧰 Agent Skills + multimodal perception
- `skills/{audio,video,document,image,data}` — `SKILL.md` packs (Agent Skills format) with lazy-import toolkits wrapping famous libraries. `core/skills_registry.py` selects relevant skills per task, injects their toolkit API into the prompt, and mounts the package in the sandbox — giving generated code **vision** (video frame-by-frame, image OCR) and **hearing** (audio FFT/sampling/loudness).
- `core/video_analyzer.py` — frame-by-frame **vision** preprocessor (cv2/av → keyframes → vision model), mirroring `audio_analyzer` (**hearing**). Wired into `step2_run_inference._run_preprocessors` via a `has_video_files` trigger. Degrades to a no-op when cv2/av are missing.

### Wiring & config
- `core/executor.py`: new `sandbox` `ExecutionMode` + `sandbox_options` passthrough; permitted for all providers.
- `step2_run_inference.py`: reads the `execution.sandbox` block and runs the `video_analyzer` preprocessor.
- `prompts/sandbox_occupation_codegen.yaml`: skill-aware codegen prompt.
- `experiments/exp026_sandbox_skills_multimodal.yaml`: `mode: sandbox` + audio & video perception preprocessors.

---

## Phase 2 — Output control loop (verify & repair generated deliverables)

Skills give the sandbox eyes/ears on task **inputs**; this second layer verifies and repairs the **outputs** the model generates, so the runner never mistakes a reference for a deliverable or ships an empty/corrupt file. All new behavior is configurable under `execution.sandbox` and conservative by default (one repair retry, no network, vision off).

### A. Deliverable contract & selector — `core/deliverable_contract.py`
- Infers a deterministic contract (expected extensions, min/max count, required keywords, confidence) from the task text + reference files **before** codegen, and injects a compact `DELIVERABLE CONTRACT` section into the prompt.
- Selects generated artifacts via a before/after snapshot with **reference-file exclusion**, then validates them against the contract.

### B. Output verifier — `core/artifact_verifier.py`
- Per-type openability checks: `xlsx`/`xlsm` (openpyxl), `docx` (python-docx), `pptx` (python-pptx), `pdf` (PyMuPDF), images (Pillow), `csv`/`json`/`parquet`, audio/video (ffprobe/soundfile/PyAV/cv2 fallback), `zip`.
- Blocks on missing/empty/corrupt primaries, wrong primary extension at high confidence, and path-escape.

### C. Render + visual QA — `core/artifact_renderer.py` + `core/output_qa.py`
- Rasterizes deliverables to PNG (PDF via PyMuPDF; Office via LibreOffice headless → PDF → PNG) with deterministic **blank-page detection** (calibrated thresholds so sparse-but-valid pages aren't falsely flagged).
- Optional LLM **vision QA** behind `output_qa.vision.enabled` (off by default), cached by artifact sha256.

### D. Bounded repair loop — `core/sandbox_runner.py`
- Attempt 0 → verify/contract/render QA → on a blocking failure, build a focused repair prompt (contract, stdout/stderr tail, concrete required fixes) and retry. Bounded by `repair.max_attempts` (default 1); best attempt is kept. Surfaces `final_status`: `ok | repaired_ok | failed_contract | failed_verification | failed_execution`.

### E. Artifact manifest
- Every run writes a `manifest.json` (contract, dependency probe, selected artifacts, verification/render reports, per-attempt status, `final_status`) and emits it alongside deliverables. Temp paths are sanitized out.

### F. Dependency importability — `core/dependency_resolver.py`
- `probe_imports()` reports each package as `available | missing | not_checked` (host vs image env) so prompts can flag non-guaranteed deps for fallback instead of implying they exist.

### G. Cache hooks — `core/sandbox_cache.py`
- Disabled-safe, sha256-keyed file cache for expensive rendered PNGs / perception summaries. Off in code, enabled via `cache.enabled` in YAML; never committed.

### Phase 2 config (exp026)
```yaml
execution:
  sandbox:
    repair: { enabled: true, max_attempts: 1 }
    output_qa:
      enabled: true
      render: true
      max_pages_per_artifact: 3
      blank_page_threshold: 0.999
      vision: { enabled: false }
    manifest: { enabled: true }
    cache:   { enabled: true }
```

## Testing
- **Phase 1: 80 tests** (`test_skills_registry`, `test_dependency_resolver`, `test_sandbox_runner` via local fallback, `test_video_analyzer`, sandbox cases in `test_executor`).
- **Phase 2: 61 new tests** across `test_deliverable_contract`, `test_artifact_verifier`, `test_output_qa`, `test_sandbox_cache_probe`, plus repair-loop/manifest cases in `test_sandbox_runner` — covering contract inference (xlsx/pptx/docx/pdf/image/audio/video), reference exclusion, valid/empty/corrupt/wrong-extension verification, render QA, `repaired_ok` repair flow, manifest schema, and no temp-path leakage.
- All **141** sandbox/skills/dep/executor/video tests green, runnable **without Docker or the heavy multimodal deps** (optional deps use `importorskip`). Residual full-suite errors are pre-existing env gaps (`azure`/`PyPDF2`) in untouched grader modules.

## Docs
- Root `README.md` + `batch-runner/README.md` execution-modes table updated.
- `sandbox/README.md` and `skills/README.md` document the skills (input perception) and the output control loop (verify/repair).

## Backward compatibility
`code_interpreter`, `subprocess`, and `json_renderer` are unchanged; `sandbox` is opt-in via YAML. Offline sandbox guarantees are preserved — no pip install during task execution.