### PR TITLE
ci(sandbox): GHCR release build + batch-run image pull for reliable container runs

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -28,12 +28,18 @@ on:
         required: false
         type: number
         default: 290
+      sandbox_image_digest:
+        description: 'Pinned ghcr.io/...@sha256 digest forwarded across relay legs so every leg pulls the SAME immutable image. Leave empty on the manual leg 0 (it will be resolved automatically).'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write        # to commit yaml results
   pull-requests: write   # to create PRs
   actions: write          # for relay self-retrigger (gh workflow run)
   id-token: write         # for Azure OIDC authentication
+  packages: read          # to pull the sandbox image from GHCR (sandbox mode only)
 
 env:
   PYTHON_VERSION: '3.11'
@@ -144,10 +150,30 @@ jobs:
           owner = source.split('/')[0] if '/' in source else 'HyeonSang'
           print(owner)
           ")
+          # ── Sandbox mode detection (safe defaults; never exit/raise) ──
+          # These gate the GHCR image pull. Baselines have no execution.mode:
+          # sandbox, so uses_sandbox stays 'false' and the pull step is skipped
+          # entirely (strict NO-OP for non-sandbox experiments).
+          USES_SANDBOX=$(python3 -c "
+          import yaml
+          with open('$YAML_FILE') as f:
+              cfg = yaml.safe_load(f)
+          mode = cfg.get('execution', {}).get('mode')
+          print('true' if mode == 'sandbox' else 'false')
+          ")
+          SANDBOX_IMAGE=$(python3 -c "
+          import yaml
+          with open('$YAML_FILE') as f:
+              cfg = yaml.safe_load(f)
+          image = cfg.get('execution', {}).get('sandbox', {}).get('image') or 'gdpval-sandbox:latest'
+          print(image)
+          ")
           echo "install_libreoffice=$INSTALL_LO" >> $GITHUB_OUTPUT
           echo "wall_timeout=$WALL_TIMEOUT" >> $GITHUB_OUTPUT
           echo "relay_max_runs=$RELAY_MAX_RUNS" >> $GITHUB_OUTPUT
           echo "repo_owner=$REPO_OWNER" >> $GITHUB_OUTPUT
+          echo "uses_sandbox=$USES_SANDBOX" >> $GITHUB_OUTPUT
+          echo "sandbox_image=$SANDBOX_IMAGE" >> $GITHUB_OUTPUT
 
       - name: Install LibreOffice & Noto Sans fonts
         if: steps.read_config.outputs.install_libreoffice == 'True'
@@ -239,6 +265,66 @@ jobs:
         run: |
           cd batch-runner
           bash step1_prepare_tasks.sh experiments/${{ inputs.experiment_yaml }}.yaml
+
+      # ── Sandbox: pull the prebuilt image from GHCR & verify (sandbox mode only) ──
+      # Runs ONLY for execution.mode: sandbox experiments; baselines skip it
+      # entirely (strict NO-OP). NOT continue-on-error on purpose: if the image
+      # cannot be made available we abort HERE, before any Azure login or model
+      # spend, rather than silently falling back to slow/unhardened local exec.
+      - name: 'Sandbox: pull & verify image'
+        id: sandbox_pull
+        if: steps.read_config.outputs.uses_sandbox == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          INPUT_DIGEST: ${{ inputs.sandbox_image_digest }}
+          RETAG_TARGET: ${{ steps.read_config.outputs.sandbox_image }}
+        run: |
+          set -euo pipefail
+          IMAGE_REPO="ghcr.io/hyeonsangjeon/gdpval-sandbox"
+
+          echo "🔐 Logging in to GHCR..."
+          echo "$GH_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
+
+          # Resolve to an IMMUTABLE digest so every relay leg pulls the exact
+          # same image. Pinning the digest across legs prevents mid-run :latest
+          # drift (a rebuild between legs) from corrupting a single experiment.
+          if [ -n "$INPUT_DIGEST" ]; then
+            RESOLVED_DIGEST="$INPUT_DIGEST"
+            echo "📌 Using pinned digest forwarded from a previous relay leg: $RESOLVED_DIGEST"
+          else
+            echo "🔎 Resolving ${IMAGE_REPO}:latest to an immutable digest..."
+            DIGEST=$(docker buildx imagetools inspect "${IMAGE_REPO}:latest" --format '{{.Manifest.Digest}}' | tr -d '"' | tr -d '[:space:]')
+            if ! echo "$DIGEST" | grep -qE '^sha256:[0-9a-f]{64}$'; then
+              echo "FATAL: could not resolve an immutable digest for ${IMAGE_REPO}:latest (got '$DIGEST')"
+              exit 1
+            fi
+            RESOLVED_DIGEST="${IMAGE_REPO}@${DIGEST}"
+            echo "📌 Resolved digest: $RESOLVED_DIGEST"
+          fi
+
+          echo "⬇️  Pulling $RESOLVED_DIGEST ..."
+          docker pull "$RESOLVED_DIGEST"
+
+          # Retag to the name core/sandbox_runner.py actually looks for. The
+          # config image (execution.sandbox.image) WINS over the SANDBOX_IMAGE
+          # env var (self.image = image or DEFAULT_SANDBOX_IMAGE), so exporting
+          # an env var would be a silent no-op — we must retag to the config name.
+          echo "🏷️  Retagging to runner-resolved name: $RETAG_TARGET"
+          docker tag "$RESOLVED_DIGEST" "$RETAG_TARGET"
+
+          # Loud fail BEFORE any model spend if the image is somehow unavailable.
+          docker image inspect "$RETAG_TARGET" >/dev/null || { echo 'FATAL: sandbox image unavailable — aborting before any model spend'; exit 1; }
+
+          # Expose the pinned digest so the relay step can forward it to the next
+          # leg, keeping the whole experiment on one immutable image.
+          echo "digest=$RESOLVED_DIGEST" >> "$GITHUB_OUTPUT"
+          {
+            echo "### 🐳 Sandbox image ready"
+            echo ""
+            echo "- Pinned digest: \`$RESOLVED_DIGEST\`"
+            echo "- Retagged as: \`$RETAG_TARGET\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # ── Step 2a: Run Inference (condition_a) ──
       - name: 'Azure Login (OIDC)'
@@ -339,6 +425,10 @@ jobs:
         if: steps.check_relay.outputs.needs_relay == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pinned digest from the preflight (empty for non-sandbox runs, where
+          # the pull step is skipped). Forwarding it keeps every relay leg on the
+          # exact same immutable image.
+          SANDBOX_IMAGE_DIGEST: ${{ steps.sandbox_pull.outputs.digest }}
         run: |
           NEXT_RELAY=$(( ${{ inputs.relay_run }} + 1 ))
           MAX_RELAYS="${{ steps.read_config.outputs.relay_max_runs }}"
@@ -353,7 +443,8 @@ jobs:
             -f experiment_yaml="${{ inputs.experiment_yaml }}" \
             -f relay_run="$NEXT_RELAY" \
             -f wall_timeout="${{ inputs.wall_timeout }}" \
-            -f dry_run="${{ inputs.dry_run }}"
+            -f dry_run="${{ inputs.dry_run }}" \
+            -f sandbox_image_digest="$SANDBOX_IMAGE_DIGEST"
 
           echo "Relay run #$NEXT_RELAY triggered. This run will now exit."
           exit 0

--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -1,0 +1,72 @@
+# Build & publish the GDPVal sandbox image to GitHub Container Registry (GHCR).
+#
+# WHY THIS EXISTS
+#   The sandbox image is the execution backend for `execution.mode: sandbox`.
+#   It is large (~8.46 GB): LibreOffice, GDAL/GEOS/PROJ, the full scientific /
+#   multimodal Python stack, tesseract, graphviz, weasyprint, ffmpeg, etc.
+#   Building it on every batch run is wasteful and local Docker Desktop is
+#   flaky, so we build it ONCE here and have batch-run.yml PULL it.
+#
+#   amd64 ONLY. requirements.txt pins aspose-words>=25.0.0, which ships no
+#   arm64 wheel — an arm64 build fails outright. CI ubuntu-latest is amd64 and
+#   reliable, so we deliberately do not add linux/arm64.
+#
+# FIRST-BUILD FOLLOW-UP (manual, one time)
+#   The first push creates a PRIVATE GHCR package `gdpval-sandbox`. Verify it is
+#   linked to this repo with inherited "Actions read" access so batch-run.yml
+#   can pull it with the default GITHUB_TOKEN. If a pull 403s, either link the
+#   package to the repo (Package settings -> Manage Actions access) or make the
+#   package public.
+name: Build Sandbox Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - batch-runner/requirements.txt
+      - batch-runner/sandbox/Dockerfile
+      - 'batch-runner/skills/**'
+
+concurrency:
+  group: build-sandbox-image
+  cancel-in-progress: true
+
+# Least privilege: only what buildx needs to push to GHCR. No id-token, no
+# contents:write.
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-sandbox-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push sandbox image
+        uses: docker/build-push-action@v6
+        with:
+          context: batch-runner
+          file: batch-runner/sandbox/Dockerfile
+          # amd64 ONLY — arm64 fails on aspose-words>=25.0.0 (no arm64 wheel).
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/hyeonsangjeon/gdpval-sandbox:latest
+            ghcr.io/hyeonsangjeon/gdpval-sandbox:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-sandbox:buildcache
+          cache-to: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-sandbox:buildcache,mode=max

--- a/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
+++ b/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
@@ -256,7 +256,12 @@ execution:
     # .yaml (sections, reflection_strings, perception placement). To A/B an
     # alternate design without code changes, copy that file and set:
     #   prompt_name: "your_variant"   # see prompts/sandbox_prompt_authoring.md
-    use_docker: "auto"        # auto | never | always
+    use_docker: "always"      # auto | never | always
+    # In CI the sandbox image is guaranteed present: batch-run.yml's
+    # "Sandbox: pull & verify image" preflight pulls it from GHCR and loud-fails
+    # before any model spend if it is missing. "always" therefore makes a mid-run
+    # Docker daemon loss fail LOUD per-task instead of silently falling back to
+    # local execution (fixes the pilot's silent-fallback finding).
     # 5 GB OOM-killed the 657 MB / 4K video task (exit 137) in the A/B smoke.
     # 8 GB covers 4K frame buffers + moviepy/ffmpeg working set for the full run.
     memory_gb: 8


### PR DESCRIPTION
## What & why

Local Docker Desktop is flaky and **arm64 cannot build the sandbox image** (`aspose-words>=25.0.0` ships no arm64 wheel). CI `ubuntu-latest` (amd64) is reliable, so this implements **Option B**: build the ~8.46 GB sandbox image **once** on CI, push it to **GHCR**, and have `batch-run.yml` **pull** it for the 220-task `exp026` sandbox run.

> Author + validate only. This PR does **not** dispatch either workflow, and does **not** build or push any image. No CI minutes spent here.

## Changes

**1. NEW `.github/workflows/build-sandbox-image.yml`**
- Triggers: `workflow_dispatch` + `push` on `main` scoped to the image's inputs (`batch-runner/requirements.txt`, `batch-runner/sandbox/Dockerfile`, `batch-runner/skills/**`).
- `concurrency: build-sandbox-image` (cancel-in-progress).
- Least-privilege `permissions: {contents: read, packages: write}` — no `id-token`, no `contents:write`.
- checkout → buildx → GHCR login → `build-push-action@v6`: context `batch-runner`, `platforms: linux/amd64` **only**, tags `:latest` + `:${{ github.sha }}`, `org.opencontainers.image.revision` label, registry `buildcache` (`cache-from`/`cache-to mode=max`).

**2. EDIT `.github/workflows/batch-run.yml`**
- `permissions`: add `packages: read`.
- New `workflow_dispatch` input `sandbox_image_digest` (string, optional, default `''`).
- `read_config`: emit `uses_sandbox` (`execution.mode == 'sandbox'`) and `sandbox_image` (`execution.sandbox.image` or `gdpval-sandbox:latest`) using **safe `.get` defaults — no `exit`/`raise`**.
- New guarded step **`Sandbox: pull & verify image`** (after `read_config`, before `Azure Login`), `if: uses_sandbox == 'true'`, **not** `continue-on-error`: GHCR login → resolve immutable digest (input on relay legs, else `docker buildx imagetools inspect :latest`) → `docker pull` → **retag to the runner-resolved config image name** → `docker image inspect` loud-fail → expose `digest` output + step summary.
- `Retrigger relay run`: forward `-f sandbox_image_digest=<pinned digest>` (empty for non-sandbox).

**3. EDIT `batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml`**
- `execution.sandbox.use_docker`: `auto` → `always` (the CI preflight guarantees the image is present, so a mid-run daemon loss fails **loud per-task** instead of silently falling back to local — fixes the pilot's silent-fallback finding).

## Design conditions honored
- **Retag to resolved name** — `core/sandbox_runner.py` uses `self.image = image or DEFAULT_SANDBOX_IMAGE`, so the **config image wins** over the `SANDBOX_IMAGE` env var (that env is a silent no-op). We retag the pulled digest to `steps.read_config.outputs.sandbox_image`.
- **Preflight loud-fail before model spend** — the pull/verify step runs before Azure login and is not `continue-on-error`; a missing image aborts the run.
- **Relay digest pinning** — the resolved `@sha256` digest is forwarded to every relay leg, preventing mid-run `:latest` drift from corrupting one experiment.
- **Registry cache** — `type=registry` buildcache (no `type=gha`).
- **amd64-only** — no `linux/arm64` (aspose-words blocker).
- **Least-privilege build perms** — `contents:read` + `packages:write` only.
- **Non-sandbox NO-OP** — baselines have no `execution.mode: sandbox`, so `uses_sandbox=false`, the pull step is skipped, and the relay forwards an empty digest.

## One-time manual follow-up (after the first build)
The first push creates a **private** GHCR package `gdpval-sandbox`. Verify it is **linked to this repo with inherited "Actions read"** so `batch-run.yml` can pull it with the default `GITHUB_TOKEN`. If a pull **403s**, link the package to the repo (Package settings → Manage Actions access) or make it public.

## Non-blocking follow-ups (not in this PR)
- Pin the base image `python:3.11-slim-bookworm` by `@sha256` digest for reproducibility.
- Add a staleness guard comparing image `revision` / a `requirements.txt` hash so a stale `:latest` is detected.

## Validation
- `yaml.safe_load` — **passes** on all 3 files.
- `actionlint` (prebuilt v1.7.12) — **passes clean** on both workflows (exit 0).
- Diff scanned for secrets / local absolute paths / forbidden wording — none.
- **Gap:** neither workflow was dispatched and no image was built/pushed (per constraints), so the GHCR pull/login/retag path is validated by lint + review only, not a live run. `shellcheck` was not available to actionlint locally, so embedded `run:` scripts were not shellcheck-linted (actionlint's own checks passed).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>