### PR TITLE
fix(ci): resolve GHCR image digest via json manifest (multi-arch index + attestation)

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -294,7 +294,7 @@ jobs:
             echo "📌 Using pinned digest forwarded from a previous relay leg: $RESOLVED_DIGEST"
           else
             echo "🔎 Resolving ${IMAGE_REPO}:latest to an immutable digest..."
-            DIGEST=$(docker buildx imagetools inspect "${IMAGE_REPO}:latest" --format '{{.Manifest.Digest}}' | tr -d '"' | tr -d '[:space:]')
+            DIGEST=$(docker buildx imagetools inspect "${IMAGE_REPO}:latest" --format '{{json .Manifest}}' | jq -r '.digest')
             if ! echo "$DIGEST" | grep -qE '^sha256:[0-9a-f]{64}$'; then
               echo "FATAL: could not resolve an immutable digest for ${IMAGE_REPO}:latest (got '$DIGEST')"
               exit 1


### PR DESCRIPTION
## Summary

One-line hotfix to the sandbox preflight in `.github/workflows/batch-run.yml` (the "Sandbox: pull & verify image" step). It corrects only the digest-extraction command introduced in #58; the rest of that design is intact.

## The bug (empirically verified)

The `else` branch resolved the immutable digest with:

```sh
docker buildx imagetools inspect "${IMAGE_REPO}:latest" --format '{{.Manifest.Digest}}'
```

For the **multi-arch OCI image index + provenance attestation** that `docker/build-push-action` pushes, that Go-template does **not** return a bare digest — it renders the entire ~730-char human-readable inspect block. The existing guard `grep -qE '^sha256:[0-9a-f]{64}$'` then trips and the step exits 1 with `FATAL: could not resolve an immutable digest`, which **blocks every sandbox-mode batch-run at preflight** (a clean abort, not corruption — but still blocking).

Verified against the real pushed image `ghcr.io/hyeonsangjeon/gdpval-sandbox:latest` (index digest `sha256:afdc4db0ae33123115bc7d665912beb15c9898b0ae6f4e59d2f7241f74b6f8d2`).

## The fix

```sh
docker buildx imagetools inspect "${IMAGE_REPO}:latest" --format '{{json .Manifest}}' | jq -r '.digest'
```

This returns the clean index digest (`sha256:afdc4db0…`). `jq` is preinstalled on `ubuntu-latest` GitHub-hosted runners. Confirmed against the real image.

## Scope

- **Only** the single digest-resolution line changes.
- The `^sha256:[0-9a-f]{64}$` guard, the `INPUT_DIGEST` relay-forward path, the retag, the `docker image inspect` loud-fail, and the `$GITHUB_OUTPUT` digest export are all unchanged.
- No workflow was dispatched/run and no image was built or pushed — this is author + validate + commit only.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` → OK
- `actionlint` → clean
- diff scanned for secrets / local absolute paths → none

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>