### PR TITLE
fix(batch): propagate execution.sandbox + timeout into prepared tasks (+ CI smoke config)

### DIFF
--- a/batch-runner/core/experiment_config.py
+++ b/batch-runner/core/experiment_config.py
@@ -89,13 +89,14 @@ class OutputConfig:
 @dataclass
 class ExecutionConfig:
     """Execution mode configuration (Phase 5-3)"""
-    mode: Literal["code_interpreter", "subprocess", "json_renderer"] = "subprocess"
+    mode: Literal["code_interpreter", "subprocess", "json_renderer", "sandbox"] = "subprocess"
     score_type: Literal["tool_assisted", "portable"] = "tool_assisted"
     max_retries: int = 3           # Infrastructure retries within task execution
     resume_max_rounds: int = 3     # Auto-retry rounds for error tasks in progress.json
     install_libreoffice: bool = False  # Install LibreOffice + Noto Sans (for Elicit)
     tokens: Dict[str, int] = field(default_factory=lambda: dict(DEFAULT_TOKENS))
     timeout: Optional[int] = None  # subprocess timeout override (seconds)
+    sandbox: Optional[Dict[str, Any]] = None  # sandbox-mode settings (execution.sandbox block)
 
 
 class ExperimentConfig:
@@ -231,6 +232,7 @@ class ExperimentConfig:
             install_libreoffice=execution_data.get("install_libreoffice", False),
             tokens=execution_tokens,
             timeout=execution_data.get("timeout"),
+            sandbox=execution_data.get("sandbox"),
         )
 
         return cls(

--- a/batch-runner/experiments/exp026s_sandbox_ci_smoke.yaml
+++ b/batch-runner/experiments/exp026s_sandbox_ci_smoke.yaml
@@ -1,0 +1,317 @@
+# ══════════════════════════════════════════════════════════════════════════
+# 🚦 exp026s — Sandbox CI SMOKE (bounded live CI verification)
+# --------------------------------------------------------------------------
+# BOUNDED derivative of exp026 that runs EXACTLY ONE fast task (Accountants and
+# Auditors, sample_size: 1) so a live GitHub Actions run can cheaply prove the
+# end-to-end sandbox path WITHOUT a full 220-task spend:
+#   • the GHCR image pull/retag preflight in batch-run.yml, and
+#   • real in-container (Docker) execution of a single document deliverable.
+# All execution hardening below (mode: sandbox, timeout: 1200,
+# use_docker: always, memory_gb: 8) is IDENTICAL to exp026 — only the dataset
+# scope differs. Do NOT use this for benchmarking; it is a plumbing smoke.
+# ══════════════════════════════════════════════════════════════════════════
+
+# 🧪 Sandbox + Skills + Multimodal Perception (exp026)
+# Research Question: Does containerized execution with per-task dependency
+#   discovery, Agent Skills, and multimodal perception (vision for video,
+#   hearing for audio) improve GDPVal deliverable quality vs. plain subprocess?
+# Base architecture: exp025 (GPT-5.4 high + gpt-audio-1.5 preprocessor)
+# New variables:
+#   - execution.mode: sandbox (container, graceful local fallback)
+#   - skills/ injected into prompt + mounted in the sandbox
+#   - video_analyzer preprocessor (frame-by-frame vision)
+# Scope: bounded CI smoke — exactly 1 task (Accountants and Auditors)
+
+experiment:
+  id: "exp026s_sandbox_ci_smoke"
+  name: "Sandbox CI smoke (GPT-5.4 low) — bounded live CI verification"
+  description: >
+    Bounded live CI verification smoke derived from exp026. Runs exactly one fast
+    Accountants and Auditors task (sample_size: 1) through the full containerized
+    **sandbox** execution path — per-task dependency discovery, Agent Skills, and
+    multimodal perception — to prove, on GitHub Actions, the GHCR image
+    pull/retag preflight and real in-container (Docker) execution without a full
+    220-task model spend. Execution hardening (mode: sandbox, timeout: 1200,
+    use_docker: always, memory_gb: 8) is identical to exp026.
+  author: "Hyeonsang Jeon"
+  created_at: "2026-05-18"
+
+# Variable control
+control:
+  fixed:
+    - tasks               # All 220 tasks (9 sectors, 44 occupations)
+    - temperature         # 0.0
+    - reasoning_effort    # low (see condition_a note: high/medium starve sandbox codegen)
+    - domain_packages     # full exp011 environment (baked into sandbox image)
+  changed:
+    - execution_mode      # subprocess → sandbox
+    - skills              # NEW: Agent Skills injected + mounted
+    - perception          # NEW: audio (hearing) + video (vision) preprocessors
+
+# Data filter — bounded CI smoke: a single accountant/document task
+data:
+  source: "HyeonSang/exp026s_sandbox_ci_smoke"
+  filter:
+    sector: null                              # sector not constrained
+    occupation: "Accountants and Auditors"    # single fast document occupation
+    sample_size: 1                            # exactly 1 task for the CI smoke
+
+# Condition A: sandbox + skills + audio/video perception + reasoning=low
+condition_a:
+  name: "GPT-5.4 low + sandbox + skills + audio/video perception"
+  model:
+    provider: "azure"
+    deployment: "gpt-5.4"
+    temperature: 0.0
+    seed: null
+    # ── Sandbox reasoning-effort safety (PR #57 smoke + post-hardening probe) ─
+    # reasoning_effort must stay LOW for sandbox codegen. gpt-5.4 draws hidden
+    # reasoning tokens from the SAME completion budget as the visible code, so
+    # heavier reasoning empties the visible output ("No Python code found") and
+    # can exceed the 480s LLM-client timeout. Empirical probes on a representative
+    # reference-heavy accountant task (7d7fc9a7), code_generation=32768:
+    #   high   -> exceeded 480s client timeout (unusable)
+    #   medium -> MARGINAL: reasoning alone reached 22,790 tok and completion hit
+    #             31,146/32,768 (95%); a slightly larger reasoning draw returns
+    #             0 visible tokens -> "No Python code found" (reproduced live in
+    #             a real step2 run before this pass).
+    #   low    -> SAFE: 2,758 reasoning + ~7,381 visible = 10,139/32,768 (31%),
+    #             106s, finish=stop; ran end-to-end in Docker (final_status=ok).
+    # "low" keeps ~69% budget headroom and ~3.3x lower latency with comparable
+    # code output, so reasoning variance cannot intermittently starve the visible
+    # deliverable. See tasks/0702_thursday/
+    # sandbox_post_hardening_docker_verification_pr57.md.
+    reasoning_effort: "low"
+  prompt:
+    system: |
+      You are a helpful assistant that completes professional tasks.
+      When the task requires creating files (e.g., Excel, Word, PDF, PowerPoint),
+      write Python code that generates those files and save them to the current directory.
+      Use libraries such as openpyxl, python-docx, reportlab, python-pptx, and Pillow.
+      Always produce complete, runnable code.
+    prefix: null
+    body: null
+    suffix: |
+      If the task requires creating deliverable files (documents, spreadsheets,
+      presentations, reports, etc.), you MUST use Python code to generate the
+      actual file(s) and save them to the current directory.
+      Do NOT just describe what you would create — actually execute code to produce
+      downloadable files. The task is NOT complete unless the files are saved.
+
+      In your text response, do NOT include any file download links or sandbox URLs
+      (e.g. "[Download ...](sandbox:/mnt/data/...)" or similar).
+      Only provide a plain-text summary of what was produced.
+
+      IMPORTANT — Defensive coding:
+      Before writing any code, ALWAYS inspect the actual structure of any
+      reference files first (df.columns, df.dtypes, df.head()).
+      Never hardcode column names or assume data types.
+      Use the exact column names found in the file.
+
+      Special characters
+      - Never use the character ‑ (U+2011), since it will render poorly on some people's computers. Instead, always use - (U+002D) instead.
+      - Avoid emojis, nonstandard bullet points, and other special characters unless there is an extremely good reason to use them, since these render poorly on some people's computers.
+
+      Graphics embedded within PDFs/slides
+      - Make sure that any diagrams or plots are large enough to be legible (though not so large that they are ugly or cut off). In most cases they should be at least half the page width.
+      - Plots and charts to visualize data are good. Simple graphics (like a flowchart with arrows) are good. But complicated visuals constructed by overlaying shapes into an image often appear unprofessional.
+
+      PDFs
+      - Always use LibreOffice to create the PDF (it must be LibreOffice! If LibreOffice is not installed, you can install it yourself). Other libraries sometimes show weird artifacts on some computers.
+
+      Fonts
+      - Always use fonts which are available across all platforms. We recommend Noto Sans / Noto Serif unless there is an extremely good reason to use something else.
+      - If you must use another font, embed the font in the pptx/word/etc doc.
+
+      Deliverable text
+      - Do not link to submitted files in the deliverable text (links are not supported on the interface where these will be viewed).
+      - Ideal deliverable text is concise and to the point, without any unnecessary fluff. 4 sentences max.
+      - Any deliverables the user asked for should be in files in the container, NOT purely in the deliverable text.
+      - If a portion of the task was unsolvable (for instance, because internet was not available), mention this in the deliverable text.
+      - Your submission should be complete and self-contained. Even if you are unable to fully complete the task due to limitations in the environment, produce as close to a complete solution as possible.
+
+      Verbosity
+      - Always be clear and comprehensive, but avoid extra verbosity when possible.
+
+      Filetypes
+      - If the prompt does not request a specific filetype, use standard filetypes like PDF, PPTX, DOCX, XLSX, MP4, ZIP, etc.
+
+      Code structure:
+      Write all code in a SINGLE ```python``` code block.
+      Do not split code across multiple code blocks — this can cause
+      syntax errors when blocks are concatenated.
+
+      Lightweight mandatory checks
+      After generating files, do a quick validation pass (5 lines max):
+      - Verify each file exists and has non-zero size
+      - For Excel/DOCX/PPTX: open with the same library and confirm no exception
+      - Do NOT do multi-step visual inspection or PNG conversion
+      If any file is missing or corrupt, fix and regenerate.
+
+      Skills (preinstalled toolkits)
+      - A `skills/` package is available on the Python path inside the sandbox.
+        The "SKILLS AVAILABLE" section above lists the relevant skills and their
+        toolkit APIs for THIS task. Prefer those helpers — they wrap the famous
+        libraries correctly (e.g. `from skills.audio.toolkit import fft_summary`,
+        `from skills.video.toolkit import extract_frames`,
+        `from skills.document.toolkit import read_any`).
+      - If a needed package is listed under "DEPENDENCIES", assume it is already
+        installed in the sandbox image; just import and use it.
+
+      Perception data (vision + hearing)
+      - When an [AUDIO ANALYSIS] section is present, a specialized audio model
+        listened to the reference audio. Trust its findings (BPM, key, timing,
+        levels, etc.) instead of guessing.
+      - When a [VIDEO ANALYSIS] section is present, a vision model watched
+        frame-by-frame samples of the reference video. Trust its findings
+        (on-screen content, scene changes, timing, corruption checks) instead of
+        guessing. To inspect further, sample frames yourself with
+        `skills.video.toolkit.extract_frames`.
+
+      Available packages
+      - Audio: soundfile, pydub, pedalboard, pyloudnorm, librosa, mutagen, ffmpeg-python, moviepy, av
+      - Documents: aspose-words, camelot-py, docx2txt, fpdf2, PyMuPDF, weasyprint, cairosvg
+      - Data/ML: scikit-learn, xgboost, lightgbm, catboost, statsmodels, scipy, networkx
+      - NLP: nltk, textblob, fuzzywuzzy, rapidfuzz, wordcloud
+      - GIS: geopandas, geopy, folium, shapely, rasterio
+      - Vision: opencv-python, pytesseract, pdf2image, pyzbar, qrcode
+      - Visualization: bokeh, plotly, plotnine, seaborn, matplotlib-venn
+      - `ffmpeg`, `tesseract`, `graphviz`, `wkhtmltopdf` are available as system commands.
+      - `LibreOffice` is available for document conversion.
+
+  # Preprocessors: run before main execution (perception layer)
+  preprocessors:
+    - type: "audio_analyzer"          # hearing
+      model:
+        provider: "azure"
+        deployment: "gpt-audio-1.5"
+      trigger: "has_audio_files"
+      inject_as: "prompt_prefix"
+      include_task_instruction: true
+      system: |
+        You are an audio analysis agent.
+        You will receive a task description and one or more audio files.
+        Listen to the audio and provide analysis that is relevant
+        to completing the task.
+        Return your analysis as structured JSON.
+        Only include information you can actually determine from listening.
+        Do not guess or fabricate values.
+        Respond with JSON only. No prose.
+
+    - type: "video_analyzer"          # vision (frame-by-frame)
+      model:
+        provider: "azure"
+        deployment: "gpt-5.4"
+      trigger: "has_video_files"
+      inject_as: "prompt_prefix"
+      include_task_instruction: true
+      frames_per_video: 8
+      max_total_frames: 24
+      frame_max_width: 768
+      frame_detail: "auto"
+      system: |
+        You are a video analysis agent.
+        You will receive a task description, per-video metadata, and several
+        frames sampled across each video's timeline (each labeled with its
+        timestamp in seconds).
+        Examine the frames and describe what is happening on screen as it relates
+        to completing the task: visible content/text, scene changes, notable
+        timestamps, and whether any frame looks corrupted.
+        Return your analysis as structured JSON.
+        Only include information you can actually determine from the frames.
+        Do not guess or fabricate values.
+        Respond with JSON only. No prose.
+
+  # Self-QA: LLM inspects its own output
+  qa:
+    enabled: true
+    max_retries: 1
+    model: null
+    min_score: 5
+    prompt: |
+      You are a strict QA inspector for professional deliverables.
+
+      ## Original Task
+      {instruction}
+
+      ## Generated Output
+      - Text response: {deliverable_text}
+      - Files produced: {deliverable_files}
+
+      ## Inspection Criteria
+      1. Does the output address ALL requirements in the original task?
+      2. Are all required files produced with correct types and content?
+      3. Is the text response complete and professional?
+      4. Are there any obvious errors, missing elements, or placeholder content?
+
+      ## Response Format (JSON only)
+      ```json
+      {{
+        "passed": true,
+        "score": 8,
+        "issues": [],
+        "suggestion": ""
+      }}
+      ```
+
+# Execution settings
+execution:
+  mode: "sandbox"
+  # Video-heavy tasks (e.g. a 657 MB / 4K reference) are marginal at 720s: the
+  # A/B smoke saw the film/video task exhaust the timeout on the compositing
+  # pass. 1200s gives large ffmpeg/moviepy renders room before the resume round.
+  timeout: 1200
+  install_libreoffice: true
+  # Sandbox-specific settings (consumed by core/sandbox_runner.py).
+  sandbox:
+    image: "gdpval-sandbox:latest"
+    # Prompt structure/wording is authored in prompts/sandbox_occupation_codegen
+    # .yaml (sections, reflection_strings, perception placement). To A/B an
+    # alternate design without code changes, copy that file and set:
+    #   prompt_name: "your_variant"   # see prompts/sandbox_prompt_authoring.md
+    use_docker: "always"      # auto | never | always
+    # In CI the sandbox image is guaranteed present: batch-run.yml's
+    # "Sandbox: pull & verify image" preflight pulls it from GHCR and loud-fails
+    # before any model spend if it is missing. "always" therefore makes a mid-run
+    # Docker daemon loss fail LOUD per-task instead of silently falling back to
+    # local execution (fixes the pilot's silent-fallback finding).
+    # 5 GB OOM-killed the 657 MB / 4K video task (exit 137) in the A/B smoke.
+    # 8 GB covers 4K frame buffers + moviepy/ffmpeg working set for the full run.
+    memory_gb: 8
+    cpus: 2.0
+    max_skills: 5
+    # ── Output control loop (Phase 2) ────────────────────────────────────
+    # Skills give the sandbox eyes/ears on INPUTS; the blocks below verify
+    # the OUTPUTS the model generates and repair them when they fall short.
+    repair:
+      enabled: true
+      max_attempts: 1          # repair retries after attempt 0 (bounded)
+    output_qa:
+      enabled: true
+      render: true             # rasterize deliverables for deterministic QA
+      max_pages_per_artifact: 3
+      blank_page_threshold: 0.999   # per-page near-white warning ratio
+      vision:
+        enabled: false         # optional LLM vision QA (off by default)
+        provider: "azure"
+        deployment: "gpt-5.4"
+        max_images: 6
+    manifest:
+      enabled: true
+      filename: "manifest.json"
+    cache:
+      enabled: true            # cache rendered PNGs / perception by sha256
+  tokens:
+    # 16384 truncates gpt-5.4 sandbox codegen -> EMPTY visible output. 32768
+    # gives the visible code block ~69% headroom above low-reasoning usage
+    # (measured 10,139 completion tokens at reasoning_effort=low on a
+    # representative reference-heavy task). Raising this does NOT increase
+    # reasoning (that is controlled by reasoning_effort); it only prevents
+    # truncation. See tasks/0702_thursday/
+    # sandbox_post_hardening_docker_verification_pr57.md.
+    code_generation: 32768
+    qa_check: 4096
+    json_render: 8000
+  max_retries: 5
+  resume_max_rounds: 2
+  relay_max_runs: 5

--- a/batch-runner/step1_prepare_tasks.py
+++ b/batch-runner/step1_prepare_tasks.py
@@ -117,6 +117,8 @@ def prepare_tasks(config_path: str) -> dict:
             "max_retries": config.execution.max_retries,
             "resume_max_rounds": config.execution.resume_max_rounds,
             "tokens": dict(config.execution.tokens),
+            "timeout": config.execution.timeout,
+            "sandbox": config.execution.sandbox,
         },
         "total_tasks": len(task_list),
         "needs_files_count": sum(1 for t in task_list if t["needs_files"]),

--- a/batch-runner/tests/test_experiment_config.py
+++ b/batch-runner/tests/test_experiment_config.py
@@ -4,6 +4,11 @@ Usage:
     pytest tests/test_experiment_config.py -v
 """
 
+import json
+import sys
+import types
+from types import SimpleNamespace
+
 import pytest
 from pathlib import Path
 from core.experiment_config import (
@@ -352,3 +357,138 @@ class TestDataClasses:
         assert condition.name == "Test"
         assert condition.model.provider == "azure"
         assert condition.prompt.system == "test"
+
+
+# ── Regression: execution.sandbox + timeout propagation (config drop bug) ──────
+EXPERIMENTS_DIR = Path(__file__).resolve().parent.parent / "experiments"
+EXP026_YAML = EXPERIMENTS_DIR / "exp026_sandbox_skills_multimodal.yaml"
+EXP026S_YAML = EXPERIMENTS_DIR / "exp026s_sandbox_ci_smoke.yaml"
+
+
+def _fake_task(task_id: str, occupation: str):
+    """Minimal stand-in for a GDPValTask (no dataset snapshot required)."""
+    return SimpleNamespace(
+        task_id=task_id,
+        sector="Finance and Insurance",
+        occupation=occupation,
+        prompt="Prepare a short financial summary document.",
+        reference_files=[],
+        reference_file_urls=[],
+    )
+
+
+class TestExecutionSandboxPropagation:
+    """Guards the config-propagation fix.
+
+    Bug: ExecutionConfig never parsed ``execution.sandbox`` and step1 dropped
+    both ``timeout`` and ``sandbox`` from the prepared-tasks JSON, so a CI
+    sandbox run silently fell back to defaults (timeout 570 / use_docker auto /
+    memory 5GB) instead of the hardened 1200 / always / 8GB.
+    """
+
+    def test_execution_config_defaults_sandbox_to_none(self):
+        """New field exists and defaults to None (no behaviour change by default)."""
+        from core.experiment_config import ExecutionConfig
+
+        assert ExecutionConfig().sandbox is None
+
+    def test_from_dict_without_sandbox_is_none(self, sample_config_dict):
+        """A config with no execution.sandbox block yields sandbox=None."""
+        config = ExperimentConfig.from_dict(sample_config_dict)
+        assert config.execution.sandbox is None
+
+    def test_from_dict_parses_sandbox_block(self, sample_config_dict):
+        """execution.sandbox + timeout survive from_dict parsing."""
+        sample_config_dict["execution"]["mode"] = "sandbox"
+        sample_config_dict["execution"]["timeout"] = 1200
+        sample_config_dict["execution"]["sandbox"] = {
+            "use_docker": "always",
+            "memory_gb": 8,
+        }
+        config = ExperimentConfig.from_dict(sample_config_dict)
+
+        assert config.execution.mode == "sandbox"
+        assert config.execution.timeout == 1200
+        assert config.execution.sandbox == {"use_docker": "always", "memory_gb": 8}
+
+    def test_exp026_parses_sandbox_hardening(self):
+        """(a) The real exp026 YAML exposes the sandbox hardening + timeout."""
+        config = ExperimentConfig.from_yaml(str(EXP026_YAML))
+
+        assert config.execution.mode == "sandbox"
+        assert config.execution.timeout == 1200
+        assert isinstance(config.execution.sandbox, dict)
+        assert config.execution.sandbox["use_docker"] == "always"
+        assert config.execution.sandbox["memory_gb"] == 8
+
+    def test_exp026s_smoke_parses_bounded_scope(self):
+        """(b) The new CI smoke YAML keeps the hardening but bounds the scope."""
+        config = ExperimentConfig.from_yaml(str(EXP026S_YAML))
+
+        assert config.execution.mode == "sandbox"
+        assert config.execution.timeout == 1200
+        assert config.execution.sandbox["use_docker"] == "always"
+        assert config.execution.sandbox["memory_gb"] == 8
+        assert config.data_filter.sample_size == 1
+        assert config.data_filter.occupation == "Accountants and Auditors"
+
+    def test_step1_prepares_execution_sandbox_and_timeout(self, tmp_path, monkeypatch):
+        """(c) step1's prepared-tasks JSON now carries timeout + sandbox.
+
+        Exercises the REAL step1 output construction with the dataset loader and
+        needs-files manifest mocked out — no network, no model, no Docker, no
+        local snapshot. ``core.data_loader`` imports the heavy ``prepare_dataset``
+        (pyarrow) at module load, so in a minimal env we inject a lightweight
+        stub; in CI (pyarrow present) the real module imports and the stub is
+        never used.
+        """
+        try:
+            import prepare_dataset  # noqa: F401
+        except Exception:
+            stub = types.ModuleType("prepare_dataset")
+            stub.GDPValDataset = type("GDPValDataset", (), {})
+            stub.GDPValTask = type("GDPValTask", (), {})
+            monkeypatch.setitem(sys.modules, "prepare_dataset", stub)
+
+        import step1_prepare_tasks as step1
+
+        fake_tasks = [
+            _fake_task("acct-001", "Accountants and Auditors"),
+            _fake_task("dev-001", "Software Developers"),
+        ]
+
+        class _FakeLoader:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def load(self):
+                return fake_tasks
+
+        class _FakeManifest:
+            @staticmethod
+            def load():
+                raise FileNotFoundError
+
+        monkeypatch.setattr(step1, "GDPValDataLoader", _FakeLoader)
+        monkeypatch.setattr(step1, "NeedsFilesManifest", _FakeManifest)
+        monkeypatch.setattr(step1, "WORKSPACE_DIR", tmp_path)
+
+        output = step1.prepare_tasks(str(EXP026S_YAML))
+
+        exec_block = output["execution"]
+        assert "timeout" in exec_block, "step1 dropped execution.timeout"
+        assert "sandbox" in exec_block, "step1 dropped execution.sandbox"
+        assert exec_block["timeout"] == 1200
+        assert exec_block["sandbox"]["use_docker"] == "always"
+        assert exec_block["sandbox"]["memory_gb"] == 8
+        # occupation filter + sample_size:1 -> exactly one task
+        assert output["total_tasks"] == 1
+
+        # The persisted JSON (what step2 actually reads) mirrors it.
+        written = json.loads(
+            (tmp_path / "step1_tasks_prepared.json").read_text(encoding="utf-8")
+        )
+        assert written["execution"]["timeout"] == 1200
+        assert written["execution"]["sandbox"]["use_docker"] == "always"
+        assert written["execution"]["sandbox"]["memory_gb"] == 8
+        assert written["total_tasks"] == 1


### PR DESCRIPTION
## The bug (silent config drop)

The sandbox hardening block was silently dropped between step1 and step2, so a sandbox run reverted to unsafe defaults:

1. **`core/experiment_config.py`** — `ExecutionConfig` had no `sandbox` field, and `from_dict`/`from_yaml` never read `execution.sandbox`. The entire `execution.sandbox` block was discarded at **parse** time (`config.execution.sandbox` did not exist).
2. **`step1_prepare_tasks.py`** — the `output['execution']` dict written to `workspace/step1_tasks_prepared.json` only included `mode`/`max_retries`/`resume_max_rounds`/`tokens`. It dropped **both** `timeout` and `sandbox` at **prepare** time.
3. **`step2_run_inference.py`** — already reads them correctly: `timeout = execution_cfg.get("timeout")` and `sandbox_options = execution_cfg.get("sandbox", {})`, then passes `sandbox_options` into `TaskExecutor(...)`. So once step1 writes them, step2 consumes them — no step2 change needed.

## Impact

A CI sandbox run over the 220-task set would have executed heavy/video tasks with **defaults** instead of the exp026 hardening:

| Setting | Intended (exp026) | Silent fallback |
|---|---|---|
| `execution.timeout` | **1200s** | 570s (config default) |
| `sandbox.use_docker` | **always** | auto |
| `sandbox.memory_gb` | **8** | 5 |

That combination reproduces the pilot's failure modes: 5 GB OOM-kills the 657 MB / 4K video task (exit 137), 570s times out large ffmpeg/moviepy renders, and `auto` silently falls back to local execution instead of loud-failing on a lost Docker daemon.

## The fix

- **`core/experiment_config.py`**: add `ExecutionConfig.sandbox: Optional[Dict[str, Any]] = None`, parse `execution.sandbox` in `from_dict`, and document `mode: sandbox` in the `mode` `Literal`.
- **`step1_prepare_tasks.py`**: write `execution.timeout` and `execution.sandbox` into the prepared-tasks JSON (the two keys step2 reads).

## Tests

Extended `tests/test_experiment_config.py` (hermetic — no network/model/Docker/dataset snapshot; the dataset loader is mocked):

- `execution.sandbox` defaults to `None` and stays `None` when absent (no behaviour change for non-sandbox configs).
- The real `exp026` YAML parses `sandbox.use_docker == "always"`, `sandbox.memory_gb == 8`, `timeout == 1200`.
- The new `exp026s` smoke YAML keeps the same hardening but bounds scope (`sample_size == 1`, `occupation == "Accountants and Auditors"`).
- The **real** `step1.prepare_tasks()` output + persisted JSON now contain `execution.timeout == 1200` and `execution.sandbox.use_docker == "always"` with exactly 1 task.

All 28 tests in the file pass (22 pre-existing + 6 new).

## New bounded CI smoke experiment

`experiments/exp026s_sandbox_ci_smoke.yaml` is a byte-for-byte derivative of `exp026` that runs **exactly one** fast Accountants and Auditors task. Everything else (mode `sandbox`, `timeout: 1200`, `use_docker: always`, `memory_gb: 8`, cpus, repair, output_qa, manifest, cache, condition_a preprocessors/qa) is identical. It exists to cheaply verify, on a live GitHub Actions run, the GHCR image pull/retag preflight + real in-container execution **without** a full 220-task model spend.

## Scope / safety

Touches only the 4 intended files. No workflow dispatch, no image build, no step2, no model calls, no Docker run in this PR. Diff scanned for secrets, local absolute paths — none.