### PR TITLE
fix(sandbox): run containers as host uid to prevent cleanup EPERM

### DIFF
--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -858,14 +858,18 @@ class SandboxRunner:
             "--memory-swap", f"{self.memory_gb}g",
             "--pids-limit", "512",
             "--security-opt", "no-new-privileges",
+        ]
+        getuid = getattr(os, "getuid", None)
+        getgid = getattr(os, "getgid", None)
+        if callable(getuid) and callable(getgid):
+            cmd += ["--user", f"{getuid()}:{getgid()}"]
+        cmd += [
             "-v", f"{workdir}:/work:rw",
             "-w", "/work",
             "-e", "HOME=/work",
             "-e", "LANG=C.UTF-8",
             "-e", f"PYTHONPATH={pythonpath}",
-            # Container runs as root; without this, importing skills writes
-            # root-owned __pycache__/*.pyc into the bind-mounted tmpdir, which
-            # then breaks host cleanup (rmtree EPERM: Operation not permitted).
+            # Keep bytecode artifacts out of the bind-mounted workdir.
             "-e", "PYTHONDONTWRITEBYTECODE=1",
         ]
         if self.cpus:

--- a/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
+++ b/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
@@ -301,4 +301,6 @@ execution:
     json_render: 8000
   max_retries: 5
   resume_max_rounds: 2
-  relay_max_runs: 5
+  # Existing 220 checkpoint needs manual relay 6 continuation; heavy multimodal
+  # retries can span multiple ~290-minute legs.
+  relay_max_runs: 10

--- a/batch-runner/tests/test_sandbox_runner.py
+++ b/batch-runner/tests/test_sandbox_runner.py
@@ -152,17 +152,29 @@ def test_execute_auto_falls_back_when_no_docker():
 
 def test_docker_command_security_flags(tmp_path):
     runner = SandboxRunner(llm_client=object(), use_docker="never", memory_gb=3, cpus=1.5)
-    cmd = runner._docker_command(str(tmp_path), skills_mounted=True)
+    with patch.object(sr.os, "getuid", return_value=1234, create=True), \
+         patch.object(sr.os, "getgid", return_value=5678, create=True):
+        cmd = runner._docker_command(str(tmp_path), skills_mounted=True)
     joined = " ".join(cmd)
     assert "--network none" in joined
     assert "--memory 3g" in joined
     assert "--pids-limit 512" in joined
     assert "no-new-privileges" in joined
+    assert "--user 1234:5678" in joined
     assert "--cpus 1.5" in joined
     assert "/work:/opt/gdpval" in joined  # mounted + baked skills both on path
     # Prevent root-owned __pycache__ in the bind-mounted tmpdir (host rmtree EPERM).
     assert "PYTHONDONTWRITEBYTECODE=1" in joined
-    assert cmd[-3:] == ["python", "-u", "solution.py"]
+    assert cmd[-4:] == [runner.image, "python", "-u", "solution.py"]
+
+
+def test_docker_command_without_posix_ids_omits_user(tmp_path):
+    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    with patch.object(sr.os, "getuid", None, create=True), \
+         patch.object(sr.os, "getgid", None, create=True):
+        cmd = runner._docker_command(str(tmp_path), skills_mounted=False)
+    assert "--user" not in cmd
+    assert cmd[-4:] == [runner.image, "python", "-u", "solution.py"]
 
 
 def test_docker_command_pythonpath_without_mount(tmp_path):


### PR DESCRIPTION
## Summary

- run sandbox containers as the host numeric UID:GID on POSIX hosts
- preserve the existing network, memory, PID, privilege, CPU, and bytecode controls
- keep a non-POSIX fallback that omits `--user` when numeric IDs are unavailable
- raise `exp026_sandbox_skills_multimodal` relay cap from 5 to 10

## Incident

The existing HF checkpoint contains 114 success, 44 error, 1 qa_failed, and 61 pending tasks. All 44/44 errors were host cleanup EPERM failures caused by root-owned arbitrary nested directories in the `/work` bind mount; none were classified as model-code errors.

## Validation

- Docker command tests: 3 passed
- full `tests/test_sandbox_runner.py`: 24 passed, 7 skipped
- `py_compile core/sandbox_runner.py`: passed
- exp026 YAML parse and `relay_max_runs == 10`: passed
- pinned image: `sha256:ee6ef798631d3c3aeaed28658c640e6f5d021677449852bf2e1f18be5bd24edb`
- real NAS Docker smoke: process and nested files owned by `1026:100`; skills import, matplotlib output, LibreOffice 7.4.7.2, deliverable collection, and `TemporaryDirectory` cleanup all passed

## Resume plan

After merge and a green 1-task `exp026s_sandbox_ci_smoke`, resume the existing checkpoint with `relay_run=6` and the same pinned GHCR digest. Do not restart the 220-task run or delete `_checkpoint`. Grading remains out of scope.