### PR TITLE
fix(dashboard): isolate diagnostic experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **Dashboard diagnostic scope consistency** — register exp027 as a diagnostic
+  report hidden from every default cross-run surface, including leaderboard,
+  trends, error narratives, header scope, and future grade cards. `?debug=1`
+  restores the aligned experiment/report set, direct detail URLs remain
+  available, existing valid subsets such as exp012 stay visible, and global
+  benchmark KPI copy remains fixed at 220 tasks.
 - **Inference config and subset integrity** — preserve `model.reasoning_effort`
   from experiment YAML through prepared tasks, add validated ordered
   `data.filter.task_ids`, and carry canonical task scope through Steps 4 and 5.
@@ -32,9 +38,16 @@ entries land under a fresh dated heading the day they merge to `main`.
   Sandbox/Skills runner bundle. Includes pinned 42 non-success-union tasks, six
   media controls, two general controls, source revisions, selection provenance,
   and analysis guardrails against causal or population-level overclaiming. The
-  implementation landed through PR #64 (`4306fa55`); Actions run #93 was
-  dispatched from that merge commit and is currently executing Step 2a
-  inference, with no relay or result PR yet.
+  implementation landed through PR #64 (`4306fa55`). Actions run #93 completed
+  without relay in 2h47m54s: 23 success, 14 QA-failed, and 13 error tasks, with
+  a 5.08 average Self-QA. HF upload completed and result PR #66 is open pending
+  the dashboard diagnostic-scope guard.
+- **Pinned exp026/exp027 paired analysis** — add a standard-library analyzer,
+  immutable HF revisions and content hashes, deterministic 10,000-resample
+  bootstrap settings, unit tests, and a checked-in diagnostic report. The same
+  50 tasks show exp026 30/14/6 versus exp027 23/14/13
+  success/QA-failed/error, while paired Self-QA is effectively unchanged.
+  Outcome-selected statistics are explicitly non-confirmatory.
 - **Repository completion records** — `.github/copilot-instructions.md` now
   requires every repository-changing task to refresh
   `tasks/LATEST_TASK_RESULT/README.md` and the `[Unreleased]` changelog before

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "aggregate": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
-    "test:aggregate": "node --test scripts/__tests__/aggregate-grades.test.mjs",
+    "test:aggregate": "node --test scripts/__tests__/aggregate-grades.test.mjs scripts/__tests__/official-filter.test.mjs",
+    "test:official-filter": "node --test scripts/__tests__/official-filter.test.mjs",
     "predev": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
     "dev": "vite",
     "prebuild": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",

--- a/scripts/__tests__/official-filter.test.mjs
+++ b/scripts/__tests__/official-filter.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  filterDashboardExperiments,
+  filterDashboardReports,
+  getDashboardDisplayData,
+  HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS,
+  isHiddenDiagnosticExperimentId,
+  isHiddenOfficialExperiment,
+  OFFICIAL_TASK_COUNT,
+} from '../../src/lib/officialExperimentScope.js'
+
+test('official 220-task experiments remain visible', () => {
+  assert.equal(OFFICIAL_TASK_COUNT, 220)
+  assert.equal(isHiddenOfficialExperiment({
+    short_id: 'exp026',
+    experiment_name: 'Official 220',
+    total_tasks: 220,
+  }), false)
+})
+
+test('registered diagnostic experiments are hidden from the default view', () => {
+  assert.equal(HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS.has('exp027'), true)
+  assert.equal(isHiddenOfficialExperiment({
+    short_id: 'exp027',
+    experiment_name: 'Subprocess Bridge 50',
+    total_tasks: 50,
+  }), true)
+  assert.equal(
+    isHiddenDiagnosticExperimentId('exp027_GPT54_default_subprocess_bridge50'),
+    true,
+  )
+  assert.equal(
+    isHiddenDiagnosticExperimentId('exp027_GPT54_default_subprocess_bridge50__judge_v2'),
+    true,
+  )
+})
+
+test('existing non-diagnostic subsets remain visible', () => {
+  assert.equal(isHiddenOfficialExperiment({
+    short_id: 'exp012',
+    experiment_name: 'Audio Multi-Agent Information Sector',
+    total_tasks: 17,
+  }), false)
+})
+
+test('debug mode restores subsets and smoke reports', () => {
+  const experiments = [
+    { short_id: 'exp026', experiment_name: 'Official', total_tasks: 220, report_scope: 'self_assessed_pre_grading' },
+    { short_id: 'exp027', experiment_name: 'Bridge 50', total_tasks: 50, report_scope: 'self_assessed_pre_grading' },
+    { short_id: 'exp999', experiment_name: 'Smoke', total_tasks: 3, report_scope: 'self_assessed_pre_grading' },
+  ]
+
+  assert.deepEqual(
+    filterDashboardExperiments(experiments).map((experiment) => experiment.short_id),
+    ['exp026'],
+  )
+  assert.deepEqual(
+    filterDashboardExperiments(experiments, { debug: true }).map((experiment) => experiment.short_id),
+    ['exp026', 'exp027', 'exp999'],
+  )
+})
+
+test('reports use the exact visible experiment ID set', () => {
+  const reports = [
+    { short_id: 'exp026', narrative: 'official' },
+    { short_id: 'exp027', narrative: 'diagnostic' },
+  ]
+
+  assert.deepEqual(filterDashboardReports(reports, ['exp026']), [reports[0]])
+  assert.deepEqual(filterDashboardReports(reports, ['exp026', 'exp027']), reports)
+})
+
+test('Dashboard display data keeps default and debug reports aligned', () => {
+  const experiments = [
+    { short_id: 'exp026', experiment_name: 'Official', total_tasks: 220, report_scope: 'self_assessed_pre_grading' },
+    { short_id: 'exp027', experiment_name: 'Bridge 50', total_tasks: 50, report_scope: 'self_assessed_pre_grading' },
+  ]
+  const reports = [
+    { short_id: 'exp026', narrative: 'official errors' },
+    { short_id: 'exp027', narrative: 'diagnostic errors' },
+  ]
+
+  assert.deepEqual(getDashboardDisplayData(experiments, reports), {
+    experiments: [experiments[0]],
+    reports: [reports[0]],
+  })
+  assert.deepEqual(getDashboardDisplayData(experiments, reports, { debug: true }), {
+    experiments,
+    reports,
+  })
+})

--- a/scripts/__tests__/test_analyze_exp026_exp027.py
+++ b/scripts/__tests__/test_analyze_exp026_exp027.py
@@ -1,0 +1,107 @@
+"""Tests for the pinned paired diagnostic analysis."""
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "analyze_exp026_exp027.py"
+SPEC = importlib.util.spec_from_file_location("analyze_exp026_exp027", MODULE_PATH)
+analysis = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(analysis)
+
+
+def _report(statuses, scores, latencies):
+    return {
+        "task_results": [
+            {
+                "task_id": task_id,
+                "status": status,
+                "qa_score": scores[index],
+                "latency_ms": latencies[index],
+                "retried": index % 2 == 0,
+            }
+            for index, (task_id, status) in enumerate(statuses.items())
+        ]
+    }
+
+
+def test_analyze_builds_transition_matrix_and_paired_metrics():
+    selection = {
+        "groups": {
+            "group_a": ["a", "b"],
+            "group_b": ["c"],
+            "group_c": [],
+        }
+    }
+    exp026 = _report(
+        {"a": "success", "b": "qa_failed", "c": "error"},
+        [6, 4, None],
+        [100, 200, 300],
+    )
+    exp027 = _report(
+        {"a": "error", "b": "success", "c": "error"},
+        [None, 5, None],
+        [50, 150, 250],
+    )
+
+    result = analysis.analyze(exp026, exp027, selection)
+
+    assert result["status_transition_matrix"]["success"]["error"] == 1
+    assert result["status_transition_matrix"]["qa_failed"]["success"] == 1
+    assert result["status_transition_matrix"]["error"]["error"] == 1
+    assert result["ordered_outcome_change"] == {
+        "improved": 1,
+        "unchanged": 1,
+        "degraded": 1,
+    }
+    assert result["self_qa"]["both_scores"]["n"] == 1
+    assert result["self_qa"]["both_scores"]["mean_delta"] == 1
+    assert result["latency_ms"]["all_tasks"]["mean_delta"] == -50
+
+
+def test_exact_two_sided_binomial_matches_4_vs_11():
+    value = analysis._exact_two_sided_binomial(4, 11)
+    assert round(value, 6) == 0.118469
+
+
+def test_pinned_sources_and_bootstrap_constants_are_frozen():
+    assert "47aed3c0b13eaa90eb02803bec9d5c75e559f416" in analysis.DEFAULT_EXP026
+    assert "830d476f24da9d842882ac69ed785c546b362a91" in analysis.DEFAULT_EXP027
+    assert analysis.EXPECTED_EXP026_SHA256 == (
+        "ec93ad9ae193734bfc7cb78c1879328ef8a1ff6777af80dcd57b38acc5a0fa3a"
+    )
+    assert analysis.EXPECTED_EXP027_SHA256 == (
+        "783183dbc9d8aae3811b164c40ee8681998c005ebc8b63a8fcd943c829f72a80"
+    )
+    assert analysis.BOOTSTRAP_SEED == 20260714
+    assert analysis.BOOTSTRAP_RESAMPLES == 10_000
+    assert analysis.HTTP_TIMEOUT_SECONDS == 30
+
+
+def test_bootstrap_interval_is_deterministic():
+    assert analysis._bootstrap_mean_ci([1.0, 1.0, -1.0, 2.0]) == [-0.5, 1.75]
+
+
+def test_load_json_rejects_hash_drift(tmp_path):
+    source = tmp_path / "source.json"
+    source.write_text('{"ok": true}', encoding="utf-8")
+
+    try:
+        analysis._load_json(source, expected_sha256="0" * 64)
+    except ValueError as exc:
+        assert "SHA-256 mismatch" in str(exc)
+    else:
+        raise AssertionError("hash drift must fail")
+
+
+def test_duplicate_selection_ids_fail():
+    report = _report({"a": "success"}, [5], [100])
+    selection = {"groups": {"group_a": ["a"], "group_b": ["a"], "group_c": []}}
+
+    try:
+        analysis.analyze(report, report, selection)
+    except ValueError as exc:
+        assert "duplicate" in str(exc)
+    else:
+        raise AssertionError("duplicate selected IDs must fail")

--- a/scripts/analyze_exp026_exp027.py
+++ b/scripts/analyze_exp026_exp027.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Reproduce the pinned exp026/exp027 paired diagnostic metrics."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import random
+import statistics
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_EXP026 = (
+    "https://huggingface.co/datasets/HyeonSang/"
+    "exp026_sandbox_skills_multimodal/raw/"
+    "47aed3c0b13eaa90eb02803bec9d5c75e559f416/self_report.json"
+)
+DEFAULT_EXP027 = (
+    "https://huggingface.co/datasets/HyeonSang/"
+    "exp027_GPT54_default_subprocess_bridge50/raw/"
+    "830d476f24da9d842882ac69ed785c546b362a91/self_report.json"
+)
+EXPECTED_EXP026_SHA256 = "ec93ad9ae193734bfc7cb78c1879328ef8a1ff6777af80dcd57b38acc5a0fa3a"
+EXPECTED_EXP027_SHA256 = "783183dbc9d8aae3811b164c40ee8681998c005ebc8b63a8fcd943c829f72a80"
+DEFAULT_SELECTION = (
+    Path(__file__).resolve().parent.parent
+    / "tasks" / "0714_tuesday" / "exp027_bridge50_selection.json"
+)
+BOOTSTRAP_SEED = 20260714
+BOOTSTRAP_RESAMPLES = 10_000
+HTTP_TIMEOUT_SECONDS = 30
+STATUSES = ("success", "qa_failed", "error")
+
+
+def _read_bytes(source: str | Path) -> bytes:
+    value = str(source)
+    if value.startswith(("https://", "http://")):
+        request = urllib.request.Request(value, headers={"User-Agent": "gdpval-analysis"})
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return response.read()
+    return Path(value).read_bytes()
+
+
+def _load_json(
+    source: str | Path,
+    expected_sha256: str | None = None,
+) -> tuple[dict[str, Any], str]:
+    content = _read_bytes(source)
+    digest = hashlib.sha256(content).hexdigest()
+    if expected_sha256 is not None and digest != expected_sha256:
+        raise ValueError(
+            f"source SHA-256 mismatch: expected {expected_sha256}, got {digest}"
+        )
+    return json.loads(content), digest
+
+
+def _index_tasks(report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    tasks = report.get("task_results") or []
+    indexed = {task["task_id"]: task for task in tasks}
+    if len(indexed) != len(tasks):
+        raise ValueError("task_results contains duplicate task IDs")
+    return indexed
+
+
+def _mean(values: list[float]) -> float | None:
+    return statistics.fmean(values) if values else None
+
+
+def _quantile(sorted_values: list[float], probability: float) -> float:
+    if not sorted_values:
+        raise ValueError("quantile requires at least one value")
+    position = (len(sorted_values) - 1) * probability
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    weight = position - lower
+    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
+
+
+def _bootstrap_mean_ci(
+    deltas: list[float],
+    *,
+    seed: int = BOOTSTRAP_SEED,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+) -> list[float] | None:
+    if not deltas:
+        return None
+    rng = random.Random(seed)
+    means = sorted(
+        statistics.fmean(rng.choice(deltas) for _ in deltas)
+        for _ in range(resamples)
+    )
+    return [_quantile(means, 0.025), _quantile(means, 0.975)]
+
+
+def _paired_numeric(
+    ids: list[str],
+    left: dict[str, dict[str, Any]],
+    right: dict[str, dict[str, Any]],
+    field: str,
+    *,
+    both_success: bool = False,
+) -> dict[str, Any]:
+    pairs: list[tuple[float, float]] = []
+    for task_id in ids:
+        left_task = left[task_id]
+        right_task = right[task_id]
+        if both_success and (
+            left_task.get("status") != "success"
+            or right_task.get("status") != "success"
+        ):
+            continue
+        left_value = left_task.get(field)
+        right_value = right_task.get(field)
+        if isinstance(left_value, (int, float)) and isinstance(right_value, (int, float)):
+            pairs.append((float(left_value), float(right_value)))
+
+    deltas = [right_value - left_value for left_value, right_value in pairs]
+    return {
+        "n": len(pairs),
+        "exp026_mean": _mean([left_value for left_value, _ in pairs]),
+        "exp027_mean": _mean([right_value for _, right_value in pairs]),
+        "mean_delta": _mean(deltas),
+        "median_delta": statistics.median(deltas) if deltas else None,
+        "wins": sum(delta > 0 for delta in deltas),
+        "ties": sum(delta == 0 for delta in deltas),
+        "losses": sum(delta < 0 for delta in deltas),
+        "bootstrap_mean_95_ci": _bootstrap_mean_ci(deltas),
+    }
+
+
+def _exact_two_sided_binomial(discordant_left: int, discordant_right: int) -> float:
+    total = discordant_left + discordant_right
+    if total == 0:
+        return 1.0
+    tail = min(discordant_left, discordant_right)
+    probability = sum(math.comb(total, value) for value in range(tail + 1)) / (2 ** total)
+    return min(1.0, 2 * probability)
+
+
+def analyze(
+    exp026: dict[str, Any],
+    exp027: dict[str, Any],
+    selection: dict[str, Any],
+) -> dict[str, Any]:
+    left = _index_tasks(exp026)
+    right = _index_tasks(exp027)
+    groups = selection["groups"]
+    ids = sorted(task_id for group in groups.values() for task_id in group)
+    if len(ids) != len(set(ids)):
+        raise ValueError("selection groups contain duplicate task IDs")
+    missing_left = set(ids) - set(left)
+    missing_right = set(ids) - set(right)
+    if missing_left or missing_right:
+        raise ValueError(
+            f"selected task IDs missing from reports: exp026={len(missing_left)}, "
+            f"exp027={len(missing_right)}"
+        )
+
+    matrix = {
+        left_status: {right_status: 0 for right_status in STATUSES}
+        for left_status in STATUSES
+    }
+    order = {"error": 0, "qa_failed": 1, "success": 2}
+    ordered = {"improved": 0, "unchanged": 0, "degraded": 0}
+    for task_id in ids:
+        left_status = left[task_id]["status"]
+        right_status = right[task_id]["status"]
+        matrix[left_status][right_status] += 1
+        delta = order[right_status] - order[left_status]
+        ordered["improved" if delta > 0 else "degraded" if delta < 0 else "unchanged"] += 1
+
+    left_success_right_non = sum(matrix["success"][status] for status in ("qa_failed", "error"))
+    left_non_right_success = sum(matrix[status]["success"] for status in ("qa_failed", "error"))
+
+    group_metrics = {}
+    for group_name, group_ids in groups.items():
+        group_metrics[group_name] = {
+            "task_count": len(group_ids),
+            "exp026_status": {
+                status: sum(left[task_id]["status"] == status for task_id in group_ids)
+                for status in STATUSES
+            },
+            "exp027_status": {
+                status: sum(right[task_id]["status"] == status for task_id in group_ids)
+                for status in STATUSES
+            },
+            "qa": _paired_numeric(group_ids, left, right, "qa_score"),
+            "latency_ms": _paired_numeric(group_ids, left, right, "latency_ms"),
+        }
+
+    return {
+        "selection": {
+            "task_count": len(ids),
+            "group_counts": {name: len(group_ids) for name, group_ids in groups.items()},
+            "task_ids_sha256": hashlib.sha256(
+                ("\n".join(ids) + "\n").encode("utf-8")
+            ).hexdigest(),
+            "outcome_selected": True,
+        },
+        "status_transition_matrix": matrix,
+        "status_totals": {
+            "exp026": {
+                status: sum(left[task_id]["status"] == status for task_id in ids)
+                for status in STATUSES
+            },
+            "exp027": {
+                status: sum(right[task_id]["status"] == status for task_id in ids)
+                for status in STATUSES
+            },
+        },
+        "ordered_outcome_change": ordered,
+        "success_discordance": {
+            "exp026_non_success_to_exp027_success": left_non_right_success,
+            "exp026_success_to_exp027_non_success": left_success_right_non,
+            "exact_two_sided_binomial_descriptive": _exact_two_sided_binomial(
+                left_non_right_success, left_success_right_non
+            ),
+            "inferential_warning": (
+                "Outcome-based task selection violates the independence needed "
+                "for confirmatory significance interpretation."
+            ),
+        },
+        "self_qa": {
+            "both_scores": _paired_numeric(ids, left, right, "qa_score"),
+            "both_success": _paired_numeric(
+                ids, left, right, "qa_score", both_success=True
+            ),
+        },
+        "latency_ms": {
+            "all_tasks": _paired_numeric(ids, left, right, "latency_ms"),
+            "both_success": _paired_numeric(
+                ids, left, right, "latency_ms", both_success=True
+            ),
+        },
+        "retried_tasks": {
+            "exp026": sum(bool(left[task_id].get("retried")) for task_id in ids),
+            "exp027": sum(bool(right[task_id].get("retried")) for task_id in ids),
+        },
+        "groups": group_metrics,
+        "bootstrap": {
+            "seed": BOOTSTRAP_SEED,
+            "resamples": BOOTSTRAP_RESAMPLES,
+            "interval": "percentile 95%",
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp026", default=DEFAULT_EXP026)
+    parser.add_argument("--exp027", default=DEFAULT_EXP027)
+    parser.add_argument("--selection", default=str(DEFAULT_SELECTION))
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    exp026, exp026_hash = _load_json(
+        args.exp026,
+        EXPECTED_EXP026_SHA256 if args.exp026 == DEFAULT_EXP026 else None,
+    )
+    exp027, exp027_hash = _load_json(
+        args.exp027,
+        EXPECTED_EXP027_SHA256 if args.exp027 == DEFAULT_EXP027 else None,
+    )
+    selection, selection_hash = _load_json(args.selection)
+    result = analyze(exp026, exp027, selection)
+    result["sources"] = {
+        "exp026": {"location": args.exp026, "sha256": exp026_hash},
+        "exp027": {"location": args.exp027, "sha256": exp027_hash},
+        "selection": {"location": args.selection, "sha256": selection_hash},
+    }
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lib/officialExperimentScope.d.ts
+++ b/src/lib/officialExperimentScope.d.ts
@@ -1,0 +1,35 @@
+export const OFFICIAL_TASK_COUNT: 220
+export const HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS: ReadonlySet<string>
+export function isHiddenDiagnosticExperimentId(value: string | null | undefined): boolean
+export function isSmokeExperimentId(value: string | null | undefined): boolean
+
+interface DashboardExperimentScope {
+	short_id: string
+	experiment_name: string
+	total_tasks: number
+	report_scope: string
+}
+
+interface DashboardReportScope {
+	short_id: string
+}
+
+export function isHiddenOfficialExperiment(
+	experiment: Pick<DashboardExperimentScope, 'short_id' | 'experiment_name' | 'total_tasks'>,
+): boolean
+export function filterDashboardExperiments<T extends DashboardExperimentScope>(
+	experiments: T[],
+	options?: { debug?: boolean; demoMode?: boolean },
+): T[]
+export function filterDashboardReports<T extends DashboardReportScope>(
+	reports: T[],
+	visibleExperimentIds: string[],
+): T[]
+export function getDashboardDisplayData<
+	E extends DashboardExperimentScope,
+	R extends DashboardReportScope,
+>(
+	experiments: E[],
+	reports: R[],
+	options?: { debug?: boolean; demoMode?: boolean },
+): { experiments: E[]; reports: R[] }

--- a/src/lib/officialExperimentScope.js
+++ b/src/lib/officialExperimentScope.js
@@ -1,0 +1,58 @@
+/** Canonical GDPVal benchmark size used by the official dashboard view. */
+export const OFFICIAL_TASK_COUNT = 220
+
+/** Curated diagnostic reports excluded from the default cross-run dashboard. */
+export const HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS = new Set(['exp027'])
+
+/** Match a short id or a derived full experiment/grade id. */
+export function isHiddenDiagnosticExperimentId(value) {
+  if (!value) return false
+  return Array.from(HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS).some((shortId) => (
+    value === shortId || value.startsWith(`${shortId}_`)
+  ))
+}
+
+/** Smoke/test identifier shared by report and grade display filters. */
+export function isSmokeExperimentId(value) {
+  if (!value) return false
+  return /(^|[_-])exp99\d/i.test(value) || /smoke/i.test(value)
+}
+
+/** Default dashboard exclusion rule for inference reports. */
+export function isHiddenOfficialExperiment(experiment) {
+  return (
+    isSmokeExperimentId(experiment.short_id) ||
+    isSmokeExperimentId(experiment.experiment_name) ||
+    isHiddenDiagnosticExperimentId(experiment.short_id)
+  )
+}
+
+/** Apply the dashboard's demo/debug scope without mutating source data. */
+export function filterDashboardExperiments(experiments, options = {}) {
+  const { debug = false, demoMode = false } = options
+  let filtered = demoMode
+    ? experiments.filter((experiment) => (
+        experiment.report_scope === 'self_assessed_pre_grading'
+      ))
+    : [...experiments]
+  if (!debug) {
+    filtered = filtered.filter((experiment) => !isHiddenOfficialExperiment(experiment))
+  }
+  return filtered
+}
+
+/** Keep report narratives/errors aligned with the displayed experiments. */
+export function filterDashboardReports(reports, visibleExperimentIds) {
+  const visibleIds = new Set(visibleExperimentIds)
+  return reports.filter((report) => visibleIds.has(report.short_id))
+}
+
+/** Build the aligned experiment/report scope consumed by Dashboard. */
+export function getDashboardDisplayData(experiments, reports, options = {}) {
+  const visibleExperiments = filterDashboardExperiments(experiments, options)
+  const visibleReports = filterDashboardReports(
+    reports,
+    visibleExperiments.map((experiment) => experiment.short_id),
+  )
+  return { experiments: visibleExperiments, reports: visibleReports }
+}

--- a/src/lib/officialFilter.ts
+++ b/src/lib/officialFilter.ts
@@ -15,6 +15,14 @@
  */
 import type { GradeResult } from '../hooks/useGrades'
 import type { ExperimentEntry } from '../types/report'
+import {
+  isHiddenDiagnosticExperimentId,
+  isHiddenOfficialExperiment,
+  isSmokeExperimentId,
+  OFFICIAL_TASK_COUNT,
+} from './officialExperimentScope.js'
+
+export { OFFICIAL_TASK_COUNT }
 
 /**
  * Smoke / test identifier. `exp99x` is the reserved smoke namespace
@@ -22,8 +30,7 @@ import type { ExperimentEntry } from '../types/report'
  * literally contains "smoke". Never matches official ids exp003–exp025.
  */
 export function isSmokeId(s: string | null | undefined): boolean {
-  if (!s) return false
-  return /(^|[_-])exp99\d/i.test(s) || /smoke/i.test(s)
+  return isSmokeExperimentId(s)
 }
 
 /** Legacy demonstration grade (e.g. `dummy_gpt5_baseline`) — not a real run. */
@@ -72,16 +79,19 @@ export function isHiddenGrade(g: GradeResult): boolean {
     isDemoGrade(g) ||
     isSmokeId(g.experiment_id) ||
     isSmokeId(g.id) ||
+    isHiddenDiagnosticExperimentId(g.experiment_id) ||
+    isHiddenDiagnosticExperimentId(g.id) ||
     isLegacyExp003(g)
   )
 }
 
 /**
  * True when an experiment (inference report) should be hidden from the default
- * view — currently only smoke/test runs (the `exp999` "Smoke Baseline").
+ * view: smoke/test runs and explicitly registered diagnostic reports.
+ * `?debug=1` still exposes every underlying report.
  */
 export function isHiddenExperiment(
-  e: Pick<ExperimentEntry, 'short_id' | 'experiment_name'>,
+  e: Pick<ExperimentEntry, 'short_id' | 'experiment_name' | 'total_tasks'>,
 ): boolean {
-  return isSmokeId(e.short_id) || isSmokeId(e.experiment_name)
+  return isHiddenOfficialExperiment(e)
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -14,7 +14,10 @@ import { useTheme } from '../contexts/ThemeContext'
 import { tooltipTexts } from '../data/tooltipTexts'
 import { onboarding } from '../utils/onboarding'
 import { substituteTaskTotal } from '../lib/textFormat'
-import { isHiddenExperiment } from '../lib/officialFilter'
+import { OFFICIAL_TASK_COUNT } from '../lib/officialFilter'
+import {
+  getDashboardDisplayData,
+} from '../lib/officialExperimentScope.js'
 
 type TabKey = 'leaderboard' | 'trend' | 'errors' | 'grading'
 
@@ -28,8 +31,8 @@ const TABS: { id: TabKey; label: string; icon: React.ReactNode; color: string }[
 export default function Dashboard() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  // `?debug=1` reveals demo/smoke entries that are hidden in the default view.
-  // Display toggle only (not access control) — demo/smoke are not sensitive.
+  // `?debug=1` reveals demo/smoke/subset entries hidden in the default view.
+  // Display toggle only (not access control) — these reports are not sensitive.
   const debug = searchParams.get('debug') === '1'
   const { reports, experiments, sectorMatrix, generated, loading, error } = useReports()
   const { isDark, toggle: toggleTheme } = useTheme()
@@ -44,8 +47,6 @@ export default function Dashboard() {
     }
   }, [])
 
-  const displayReports = demoMode ? reports.filter((r) => r.meta.report_scope === 'self_assessed_pre_grading') : reports
-
   // Parse "138m 37s" → seconds for sorting
   const parseDuration = (d: string) => {
     const m = d.match(/(\d+)m/)
@@ -53,19 +54,22 @@ export default function Dashboard() {
     return (m ? parseInt(m[1]) * 60 : 0) + (s ? parseInt(s[1]) : 0)
   }
 
-  // Sort: date desc → duration desc
-  const displayExperiments = useMemo(() => {
-    let list = demoMode
-      ? experiments.filter((e) => e.report_scope === 'self_assessed_pre_grading')
-      : [...experiments]
-    // Phase 1: hide smoke/test runs from the default view (?debug=1 restores).
-    if (!debug) list = list.filter((e) => !isHiddenExperiment(e))
-    return list.sort((a, b) => {
+  // Scope experiments and report narratives/errors together, then sort.
+  const displayData = useMemo(() => {
+    const scoped = getDashboardDisplayData(
+      experiments,
+      reports,
+      { debug, demoMode },
+    )
+    scoped.experiments.sort((a, b) => {
       const dateDiff = new Date(b.date).getTime() - new Date(a.date).getTime()
       if (dateDiff !== 0) return dateDiff
       return parseDuration(b.duration) - parseDuration(a.duration)
     })
-  }, [experiments, demoMode, debug])
+    return scoped
+  }, [experiments, reports, demoMode, debug])
+  const displayExperiments = displayData.experiments
+  const displayReports = displayData.reports
 
   if (loading) {
     return (
@@ -92,7 +96,8 @@ export default function Dashboard() {
   // Calculate KPIs
   const bestRate = displayExperiments.length > 0 ? Math.max(...displayExperiments.map((e) => e.success_rate_pct)) : 0
   const bestQA = displayExperiments.length > 0 ? Math.max(...displayExperiments.map((e) => e.avg_qa_score)) : 0
-  const totalTasks = displayExperiments[0]?.total_tasks ?? 220
+  // Keep global benchmark copy stable even when debug mode reveals subsets.
+  const totalTasks = OFFICIAL_TASK_COUNT
 
   const handleSelectExperiment = (shortId: string) => {
     navigate(`/experiments/${shortId}`)
@@ -193,7 +198,7 @@ export default function Dashboard() {
             },
             {
               label: 'Tasks Evaluated',
-              value: displayExperiments.length > 0 ? displayExperiments[0].total_tasks : 0,
+              value: displayExperiments.length > 0 ? totalTasks : 0,
               unit: 'per experiment',
               tooltip: tooltipTexts.kpi.tasksEvaluated,
               valueColor: 'text-dash-heading',

--- a/tasks/0714_tuesday/EXP026_EXP027_PAIRED_ANALYSIS.md
+++ b/tasks/0714_tuesday/EXP026_EXP027_PAIRED_ANALYSIS.md
@@ -1,0 +1,132 @@
+# exp026 vs exp027 Paired Diagnostic Analysis
+
+## Scope
+
+This analysis compares the exact 50 task IDs pinned in
+`exp027_bridge50_selection.json`:
+
+- Group A: 42 tasks where exp025 or exp026 was not successful.
+- Group B: 6 paired-success media controls.
+- Group C: 2 paired-success general controls.
+
+The set was selected using historical outcomes. It is useful for diagnosing
+runner failures, but its success rate must not be extrapolated to the full
+220-task benchmark. Both reports are self-assessed and pre-grading; Self-QA is
+not an external rubric score.
+
+Sources:
+
+- exp026 pinned HF revision: `47aed3c0b13eaa90eb02803bec9d5c75e559f416`
+- exp027 pinned HF revision: `830d476f24da9d842882ac69ed785c546b362a91`
+- exp026 self-report SHA-256:
+  `ec93ad9ae193734bfc7cb78c1879328ef8a1ff6777af80dcd57b38acc5a0fa3a`
+- exp027 self-report SHA-256:
+  `783183dbc9d8aae3811b164c40ee8681998c005ebc8b63a8fcd943c829f72a80`
+- Task-list SHA-256:
+  `33b18c57f4a5227ebeccbdc68480b9b702df7927928ac086f63114bb5676a47a`
+
+Reproduce the calculations with:
+
+```bash
+python scripts/analyze_exp026_exp027.py
+```
+
+The script uses only the Python standard library. Bootstrap intervals use
+10,000 percentile resamples with seed `20260714`.
+
+## Status Transitions
+
+| exp026 ↓ / exp027 → | Success | QA Failed | Error | Total |
+|---|---:|---:|---:|---:|
+| Success | 19 | 5 | 6 | 30 |
+| QA Failed | 4 | 6 | 4 | 14 |
+| Error | 0 | 3 | 3 | 6 |
+| Total | 23 | 14 | 13 | 50 |
+
+- Success changed from 30 to 23 (`-7`).
+- Hard errors changed from 6 to 13 (`+7`).
+- Ordered outcome changes were 7 improved, 28 unchanged, and 15 degraded.
+- Success discordance was 4 tasks in exp027's favor versus 11 in exp026's
+  favor. The exact two-sided binomial value was `0.118469`.
+
+The direction favors the exp026 Sandbox/Skills/repair bundle for execution
+reliability, but the comparison does not isolate any single component. Because
+the task set was selected using historical exp026 outcomes, the exact value is
+reported only as an exploratory descriptive statistic. Confirmatory significance
+or threshold interpretation would require a pre-specified independent sample or
+the full benchmark.
+
+## Self-QA
+
+| Paired set | n | exp026 avg | exp027 avg | Mean Δ | Median Δ | Win / Tie / Loss |
+|---|---:|---:|---:|---:|---:|---:|
+| Both scores present | 34 | 5.206 | 5.265 | +0.059 | 0 | 11 / 11 / 12 |
+| Both successful | 19 | 6.263 | 6.316 | +0.053 | 0 | 6 / 7 / 6 |
+
+The deterministic bootstrap mean-delta intervals were `[-0.412, +0.559]` for
+both scores and `[-0.474, +0.579]` for both-success tasks. Both cross zero.
+There is no Self-QA evidence that removing Skills improved or degraded quality.
+These intervals are descriptive because of outcome-based task selection. No
+Skills selector change should be justified from this run alone.
+
+## Runtime
+
+- Mean task latency changed from 115.54s to 76.78s (`-38.76s`; descriptive
+  bootstrap interval `[-79.09s, -11.61s]`).
+- On the 19 tasks successful in both runs, mean latency changed from 84.78s to
+  65.72s (`-19.06s`).
+- exp027's 13 errors often terminated early, so the overall latency reduction
+  overstates useful throughput improvement.
+- exp027 retried 37 tasks; only 10 ended successful. Generic retry/reflection
+  within the same execution bundle was a weak recovery mechanism.
+
+## Media Results
+
+- Audio and Video Technicians: success remained 5/5; mean Self-QA increased
+  from 6.0 to 6.6.
+- Film and Video Editors: success changed from 3/5 to 1/5.
+- `75401f7c...` regressed to a binary stderr decoding error.
+- `a941b6d8...` regressed to an OpenCV out-of-memory error despite successful
+  video preprocessing.
+
+This does not estimate perception impact because both configurations retained
+audio/video preprocessors. A separate on/off ablation is required.
+
+## exp027 Hard Errors
+
+| Category | Count | Representative tasks |
+|---|---:|---|
+| Syntax / packaging | 3 | `4122f866...`, `7de33b48...`, `854f3814...` |
+| Input schema assumptions | 3 | `6a900a40...`, `7d7fc9a7...`, `e996036e...` |
+| API / data-shape / version compatibility | 5 | `02aa1805...`, `105f8ad0...`, `1752cb53...`, `1d4672c8...`, `f84ea6ac...` |
+| Binary ffmpeg output decoding | 1 | `75401f7c...` |
+| Video memory | 1 | `a941b6d8...` |
+
+Of these 13 tasks, exp026 had 6 successes, 4 QA failures, and 3 errors. The
+three errors shared by both runs were all Software Developer tasks with
+unterminated triple-quoted strings. This supports improving preflight and
+strategy-changing repair before changing skill selection.
+
+## Conclusions
+
+- **Sandbox bundle improves execution reliability:** directionally supported at
+  the bundle level, not causally isolated.
+- **Skills over-selection harms quality:** inconclusive.
+- **Perception improves media tasks:** inconclusive.
+- **Generic retries are effective:** not supported; most retried exp027 tasks
+  remained unsuccessful.
+
+## Engineering Priorities
+
+1. Run `ast.parse` and `py_compile` before executing generated code.
+2. Feed a normalized workbook/document schema manifest into generation and
+   repair: sheets, headers, merged ranges, and data types.
+3. Use exception-specific repair for syntax, schema, API compatibility, binary
+   decoding, and memory failures. Retry only when the strategy changes.
+4. Use binary-safe ffmpeg subprocess capture and explicit decoding policies.
+5. Stream/chunk video processing with ffmpeg-first fallbacks and memory limits.
+6. Capability-gate tasks requiring live web evidence; never treat fabricated
+   placeholders as successful completion.
+7. Keep execution manifests as sidecar provenance tied to the final attempt.
+8. Evaluate skill selection only in a controlled selector-vs-off ablation.
+9. Evaluate audio/video perception separately with a fixed on/off media subset.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,58 +1,56 @@
 # Latest Task Result
 
 - Updated: 2026-07-14
-- Status: Implementation merged; exp027 Actions run in progress
+- Status: exp027 completed; result PR held for dashboard scope guard
 
 ## Task
 
-Analyze `exp026_sandbox_skills_multimodal`, add behavior-neutral sandbox
-observability, and prepare one bounded subprocess comparator before changing
-Sandbox or Agent Skills behavior. Keep the canonical result synchronized after
-the implementation merge and experiment dispatch.
+Complete the bounded exp027 subprocess diagnostic, compare it with exp026 on
+the exact pinned 50-task set, and prevent the diagnostic subset from changing
+the default 220-task dashboard scope before its result report is merged.
 
 ## Result
 
-- Confirmed from Actions Runs #91/#92 and the Step 1/2 data path that historical
-  `exp025` and `exp026` dropped their declared `reasoning_effort`; both actually
-  used the deployment's server-default reasoning behavior.
-- Added privacy-bounded sandbox provenance: prompt/code hashes, token usage,
-  latency, stable error categories, skill match evidence, preprocessor status,
-  and CI run identity. Raw response text, stdout/stderr, exception messages,
-  generated filenames, and heavy verification reports are not persisted.
-- Added deterministic `data.filter.task_ids` support and propagated exact task
-  scope through task preparation, parquet filling, validation, formatting, and
-  self-report generation. Duplicate/missing/unexpected task IDs fail closed.
-- Added `exp027_GPT54_default_subprocess_bridge50`, an outcome-selected 50-task
-  diagnostic comparator covering 9 sectors and 26 occupations. It uses the
-  coherent post-fix subprocess prompt/QA/audio setup, the exp026 video
-  preprocessor, server-default reasoning, 32K code tokens, and a 1,200-second
-  timeout. The comparison measures the runner/prompt bundle and is not a causal
-  estimate of Sandbox or Skills alone.
-- Added checked-in 42/6/2 task-group provenance with task-list SHA-256
-  `33b18c57f4a5227ebeccbdc68480b9b702df7927928ac086f63114bb5676a47a`.
-- PR [#64](https://github.com/hyeonsangjeon/gdpval-realworks/pull/64)
-  was squash-merged to `main` as
-  `4306fa55d5df32314c449e89243638c24e1d686a`.
 - Actions run
   [#93](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29324114951)
-  was dispatched from that merge commit for
-  `exp027_GPT54_default_subprocess_bridge50`. Step 1 completed, the sandbox
-  image step was correctly skipped for subprocess mode, and Step 2a inference
-  is currently in progress. No relay or result PR exists yet.
+  completed successfully in 2h47m54s without a relay. Steps 1-7, exact 50-row
+  validation, report generation, and Hugging Face upload all passed.
+- exp027 produced 23 successes, 14 QA failures, and 13 errors across the
+  outcome-selected diagnostic set. Average Self-QA was 5.08 and average task
+  latency was 76.78s. Result PR
+  [#66](https://github.com/hyeonsangjeon/gdpval-realworks/pull/66) is open.
+- On identical task IDs, exp026 changed from 30/14/6 success/QA-failed/error to
+  exp027's 23/14/13. Paired Self-QA was effectively unchanged. This
+  directionally supports the complete sandbox/skills/repair bundle for
+  execution reliability, but does not isolate any individual component.
+- Added a standard-library reproducibility script with immutable HF revisions,
+  content hashes, deterministic bootstrap settings, and checked-in paired
+  analysis. Outcome-based selection is explicitly treated as diagnostic rather
+  than population-level or confirmatory inference.
+- Added a dashboard scope guard: exp027 is hidden from the default cross-run
+  views and error narratives but restored by `?debug=1`; direct detail access is
+  preserved. Existing valid subsets such as exp012 remain visible, and global
+  benchmark copy remains fixed at 220 tasks.
 
 ## Verification
 
-- Nine changed Python modules compile with `py_compile`.
-- Focused regression suite: 206 passed, 0 failed.
-- `git diff --check`: passed.
-- Independent final code review: APPROVE, with no blocker, major, or minor
-  findings.
-- GitHub confirms PR #64 is merged and Actions #93 is running on head SHA
-  `4306fa55d5df32314c449e89243638c24e1d686a`.
+- Actions #93 concluded with `success`; HF self-report and parquet both contain
+  exactly 50 tasks and matching metrics.
+- Dashboard/aggregate Node tests: 19 passed.
+- Paired-analysis Python tests: 6 passed; pinned live calculation reproduced
+  all checked metrics and source hashes.
+- TypeScript `--noEmit`: passed.
+- Production Vite build: passed.
+- Python compile and `git diff --check`: passed.
+- Validation-generated `public/generated`, `dist`, and cache directories were
+  removed from the worktree.
 
 ## Remaining Work
 
-- Monitor Actions #93 and any automatically triggered relay legs through Steps
-  3-7 and the generated result PR.
-- Compare exp027 and exp026 on the pinned 50-task set before changing Skills
-  selection, manifest delivery policy, or repair behavior.
+- Merge the dashboard diagnostic-scope guard before PR #66.
+- Merge PR #66, verify Pages deployment, and confirm exp027 is available only
+  via debug/direct detail without changing the default 220-task KPI.
+- Prioritize syntax preflight, schema introspection, exception-specific repair,
+  binary-safe ffmpeg handling, and bounded video memory before any Skills
+  selector change. Skills and perception changes still require separate
+  controlled ablations.


### PR DESCRIPTION
exp027 run #93 completed 23/14/13 on outcome-selected 50; PR #66 held because report would contaminate default dashboard scope/error narratives/KPI; explicit diagnostic registry hides exp027 and derived grades from default but debug/direct detail preserve access and exp012 remains; aligned experiments/reports; KPI 220; pinned/reproducible paired analyzer results (exp026 30/14/6 vs exp027 23/14/13, paired Self-QA unchanged, non-confirmatory); validation Node19, Python6, pinned live, py_compile, noEmit, Vite build, diff check, reviewer approve.