### PR TITLE
ci(grading): add model-free renderer preflight

### DIFF
--- a/.github/workflows/grading-renderer-preflight.yml
+++ b/.github/workflows/grading-renderer-preflight.yml
@@ -1,0 +1,89 @@
+name: Grading Renderer Preflight
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: grading-renderer-preflight
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: batch-runner/requirements-renderer.txt
+
+      - name: Install document renderer
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            libreoffice-core \
+            libreoffice-calc \
+            libreoffice-impress \
+            fonts-dejavu-core \
+            fonts-liberation2 \
+            fontconfig
+          libreoffice --headless --version
+          FONT_FAMILIES="$(fc-match --format '%{family}\n' 'Liberation Sans')"
+          if ! printf '%s\n' "$FONT_FAMILIES" | tr ',' '\n' | awk '
+            {
+              gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+              if ($0 == "Liberation Sans") found = 1
+            }
+            END { exit(found ? 0 : 1) }
+          '; then
+            echo "::error::fc-match did not resolve exact family token Liberation Sans"
+            exit 1
+          fi
+
+      - name: Install renderer Python dependencies
+        run: python -m pip install --requirement batch-runner/requirements-renderer.txt
+
+      - name: Run renderer preflight
+        run: |
+          RESULT_PATH="$RUNNER_TEMP/grading-renderer-preflight.json"
+          set +e
+          (cd batch-runner && python scripts/preflight_grading_renderer.py) > "$RESULT_PATH"
+          PREFLIGHT_STATUS=$?
+          set -e
+          cat "$RESULT_PATH"
+          python - "$RESULT_PATH" "$PREFLIGHT_STATUS" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          result_path = Path(sys.argv[1])
+          process_status = int(sys.argv[2])
+          payload = json.loads(result_path.read_text(encoding="utf-8"))
+          if process_status != 0:
+              raise SystemExit(f"renderer preflight process failed: {process_status}")
+          if payload.get("ok") is not True:
+              raise SystemExit("renderer preflight JSON did not report ok=true")
+          PY
+
+      - name: Upload renderer evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: grading-renderer-preflight-${{ github.run_id }}
+          path: ${{ runner.temp }}/grading-renderer-preflight.json
+          if-no-files-found: error
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ entries land under a fresh dated heading the day they merge to `main`.
 - **`batch-runner/scripts/download_inference_from_hf.py`** — pass `HF_TOKEN` explicitly to `hf_hub_download()` (×2) and `snapshot_download()` via a new `_hf_token()` helper. The grade pipeline's "Download inference results from HF" step injects `HF_TOKEN` env, but `huggingface_hub` auto-pickup did not fire, so requests went out **anonymous** (CI log: `unauthenticated requests to HF Hub`). Under the sequential grade relay this tripped HTTP **429 Too Many Requests** on the inference parquet, breaking a chunk mid-run (e.g. 5.4 220 re-grade chunk-2 resume). Authenticated requests have a much higher rate limit → relay no longer 429s on repeated chunk downloads. No behavior change for single runs.
 
 ### Added
+- **Model-free grading renderer preflight** — add a manual, `main`-only Ubuntu
+  24.04 workflow with read-only repository permission, commit-pinned actions,
+  no credentials or model calls, exact LibreOffice/font checks, strict JSON
+  success validation, and seven-day evidence artifacts. A shared
+  `requirements-renderer.txt` keeps the dedicated workflow and full grading
+  environment on the same openpyxl, python-pptx, Pillow, and PyMuPDF lower
+  bounds.
 - **`exp027_GPT54_default_subprocess_bridge50`** — checked-in 50-task,
   9-sector diagnostic subprocess comparator for the historical exp026
   Sandbox/Skills runner bundle. Includes pinned 42 non-success-union tasks, six

--- a/batch-runner/requirements-renderer.txt
+++ b/batch-runner/requirements-renderer.txt
@@ -1,0 +1,5 @@
+# Shared by grade-run.yml and grading-renderer-preflight.yml.
+openpyxl>=3.1.0
+python-pptx>=0.6.0
+Pillow>=10.0.0
+PyMuPDF>=1.21.0

--- a/batch-runner/requirements.txt
+++ b/batch-runner/requirements.txt
@@ -1,5 +1,8 @@
 # GDPVal Batch Runner Dependencies
 
+# Grading renderer dependencies (shared with the model-free CI preflight)
+-r requirements-renderer.txt
+
 # Core dependencies
 datasets>=2.18.0
 huggingface-hub>=0.20.0
@@ -9,11 +12,8 @@ azure-identity>=1.15.0
 jsonschema>=4.21.0
 
 # Reference file readers
-openpyxl>=3.1.0
 pdfplumber>=0.10.0
 python-docx>=1.0.0
-python-pptx>=0.6.0
-Pillow>=10.0.0
 
 # File generation (Phase 5-3)
 reportlab>=4.0.0              # PDF generation
@@ -53,7 +53,6 @@ imgkit>=1.2.0
 markdownify>=0.9.0
 pdfkit>=0.6.0
 pdfrw>=0.4
-PyMuPDF>=1.21.0
 pypandoc>=1.6.0
 svglib>=1.1.0
 svgwrite>=1.4.1

--- a/batch-runner/tests/test_grading_renderer_preflight_workflow.py
+++ b/batch-runner/tests/test_grading_renderer_preflight_workflow.py
@@ -1,0 +1,88 @@
+"""Static security contract for the model-free renderer preflight workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/grading-renderer-preflight.yml"
+CHECKOUT = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+SETUP_PYTHON = "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
+UPLOAD_ARTIFACT = "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+
+
+def _workflow() -> tuple[str, dict]:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    parsed = yaml.load(text, Loader=yaml.BaseLoader)
+    assert isinstance(parsed, dict)
+    return text, parsed
+
+
+def test_workflow_is_manual_main_only_and_read_only():
+    _, workflow = _workflow()
+
+    assert workflow["on"] == {"workflow_dispatch": ""}
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"] == {
+        "group": "grading-renderer-preflight",
+        "cancel-in-progress": "false",
+    }
+    assert set(workflow["jobs"]) == {"preflight"}
+    job = workflow["jobs"]["preflight"]
+    assert job["if"] == "github.ref == 'refs/heads/main'"
+    assert job["runs-on"] == "ubuntu-24.04"
+    assert job["timeout-minutes"] == "20"
+    assert job["env"] == {"PYTHONDONTWRITEBYTECODE": "1"}
+    assert "environment" not in job
+
+
+def test_actions_are_allowlisted_and_pinned():
+    _, workflow = _workflow()
+    steps = workflow["jobs"]["preflight"]["steps"]
+    actions = [step["uses"] for step in steps if "uses" in step]
+
+    assert actions == [CHECKOUT, SETUP_PYTHON, UPLOAD_ARTIFACT]
+    assert steps[0]["with"]["persist-credentials"] == "false"
+    assert steps[1]["with"]["cache-dependency-path"] == (
+        "batch-runner/requirements-renderer.txt"
+    )
+    upload = steps[-1]
+    assert upload["if"] == "always()"
+    assert upload["with"]["retention-days"] == "7"
+    assert upload["with"]["if-no-files-found"] == "error"
+
+
+def test_workflow_installs_only_renderer_surface_and_validates_json():
+    text, workflow = _workflow()
+    steps = workflow["jobs"]["preflight"]["steps"]
+    runs = "\n".join(step.get("run", "") for step in steps)
+
+    for package in (
+        "libreoffice-core",
+        "libreoffice-calc",
+        "libreoffice-impress",
+        "fonts-dejavu-core",
+        "fonts-liberation2",
+        "fontconfig",
+    ):
+        assert package in runs
+    assert "batch-runner/requirements-renderer.txt" in runs
+    assert "python scripts/preflight_grading_renderer.py" in runs
+    assert 'payload.get("ok") is not True' in runs
+    assert "$RUNNER_TEMP/grading-renderer-preflight.json" in runs
+
+    lowered = text.lower()
+    for forbidden in (
+        "${{ secrets.",
+        "id-token",
+        "azure/login",
+        "hf_token",
+        "openai",
+        "step8_grade",
+        "git push",
+        "git commit",
+    ):
+        assert forbidden not in lowered

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,108 +1,52 @@
 # Latest Task Result
 
 - Updated: 2026-07-15
-- Status: Merged; runtime canary pending
+- Status: Renderer preflight implementation verified; runtime run pending
 
 ## Task
 
-Use the exp026/exp027 paired evidence to harden generated-code execution before
-changing Skills selection: reject invalid Python before its body runs, route
-runtime failures to category-specific repair strategies, and preserve bounded
-provenance across local and Docker backends.
+- Add a model-free GitHub-hosted LibreOffice preflight for the Track 2 grading
+  renderer.
+- Keep the preflight manual, read-only, secret-free, and isolated from HF,
+  Azure, batch inference, and paid model calls.
+- Share the renderer Python dependency declaration with the production grading
+  environment so both paths exercise the same package constraints.
 
 ## Result
 
-- Actions run
-  [#93](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29324114951)
-  completed successfully in 2h47m54s without a relay. Steps 1-7, exact 50-row
-  validation, report generation, and Hugging Face upload all passed.
-- exp027 produced 23 successes, 14 QA failures, and 13 errors across the
-  outcome-selected diagnostic set. Average Self-QA was 5.08 and average task
-  latency was 76.78s. Result PR
-  [#66](https://github.com/hyeonsangjeon/gdpval-realworks/pull/66) was merged.
-- On identical task IDs, exp026 changed from 30/14/6 success/QA-failed/error to
-  exp027's 23/14/13. Paired Self-QA was effectively unchanged. This
-  directionally supports the complete sandbox/skills/repair bundle for
-  execution reliability, but does not isolate any individual component.
-- Added a standard-library reproducibility script with immutable HF revisions,
-  content hashes, deterministic bootstrap settings, and checked-in paired
-  analysis. Outcome-based selection is explicitly treated as diagnostic rather
-  than population-level or confirmatory inference.
-- Added a dashboard scope guard: exp027 is hidden from the default cross-run
-  views and error narratives but restored by `?debug=1`; direct detail access is
-  preserved. Existing valid subsets such as exp012 remain visible, and global
-  benchmark copy remains fixed at 220 tasks.
-- Dashboard guard PR
-  [#67](https://github.com/hyeonsangjeon/gdpval-realworks/pull/67) was
-  squash-merged as `92efc10518e0cbcd23adcf54b68e8c7355228645`; Pages run
-  [29342635220](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29342635220)
-  succeeded.
-- Result PR [#66](https://github.com/hyeonsangjeon/gdpval-realworks/pull/66)
-  was then squash-merged as `2a33c99813bec08b598e5dd272916207c18594da`;
-  Pages run
-  [29342879619](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29342879619)
-  succeeded and published exp027.
-- Added a trusted launcher shared by local and Docker execution. It compiles the
-  untouched `solution.py` with the actual target interpreter, emits a bounded
-  schema-validated preflight record over stderr before untrusted code starts,
-  and executes with `runpy` so `_AVAILABLE_FILES` remains available without
-  breaking `from __future__` imports.
-- Invalid Python consumes the existing bounded repair attempt but never reaches
-  its body. Prompt-spec guidance now differs for syntax, input schema, API
-  compatibility, binary decode, and memory failures.
-- Added stable execution categories shared by local and Docker paths, including
-  chained-exception handling, real OOM variants, binary output, timeout,
-  backend-unavailable, and stderr-empty nonzero exits.
-- Removed the writable preflight sidecar design. The trusted protocol accepts
-  only the first 1,024-byte record, validates every field type, ignores later
-  spoof records, and survives `chdir`, `os._exit`, SIGKILL, and non-UTF-8 output.
-- Best-attempt selection now distinguishes compile-only failures from body
-  execution so a repaired runtime failure cannot be hidden behind an earlier
-  syntax failure. Manifests use `not_executed` unless compile success proves the
-  selected backend reached the generated body.
-- Sandbox preflight PR
-  [#71](https://github.com/hyeonsangjeon/gdpval-realworks/pull/71) was
-  squash-merged to `main` as
-  `aa6c35c985c3bdb11cf98f4e0c4a4747968d9f8c`. No workflow was automatically
-  dispatched by this backend-only merge.
+- Added `.github/workflows/grading-renderer-preflight.yml`, dispatched manually
+  on `main` only with `contents: read`, no environment, no OIDC, and no secret
+  references. Checkout, Python setup, and artifact upload actions are pinned to
+  full commits.
+- The workflow installs LibreOffice Calc/Impress plus the exact font surface,
+  runs the existing synthetic XLSX/PPTX renderer probe, requires both process
+  success and JSON `ok=true`, and retains the compact evidence JSON for seven
+  days even when the probe fails.
+- Added `batch-runner/requirements-renderer.txt`; full batch dependencies now
+  include this shared file instead of declaring the four renderer packages in
+  separate sections.
+- Added a static workflow contract test covering trigger, permissions, action
+  allowlist, package surface, result handling, and the absence of credential,
+  model, grading, and Git-write paths.
 
 ## Verification
 
-- Actions #93 concluded with `success`; HF self-report and parquet both contain
-  exactly 50 tasks and matching metrics.
-- Dashboard/aggregate Node tests: 19 passed.
-- Paired-analysis Python tests: 6 passed; pinned live calculation reproduced
-  all checked metrics and source hashes.
-- TypeScript `--noEmit`: passed.
-- Production Vite build: passed.
-- Python compile and `git diff --check`: passed.
-- Validation-generated `public/generated`, `dist`, and cache directories were
-  removed from the worktree.
-- Deployed `reports-index.json` contains 23 raw experiments, including exp027 at
-  23/50, 46.0%, and Self-QA 5.08; exp026 remains 200/220, 90.9%, and 6.24.
-- Browser default view shows 22 experiments, excludes exp027 from leaderboard
-  and Execution Errors, and keeps both KPI/copy values at 220 tasks.
-- Browser `?debug=1` view restores 23 experiments and exp027's 23/50 metrics
-  while retaining the 220-task global KPI.
-- Clicking exp027 and directly opening `/experiments/exp027` both render the
-  detail page with the expected metrics. GitHub Pages serves the direct SPA
-  deep link through its 404 fallback, so the initial HTTP response remains 404
-  even though the application recovers and renders correctly.
-- Four changed Python modules compile successfully.
-- Focused sandbox/local execution regression suite: 195 passed, 0 failed, 0
-  skipped, including the actual `gdpval-sandbox:latest` Python 3.11 boundary.
-- `git diff --check` passed; executable sidecar references are absent; editor
-  diagnostics and independent final review reported no findings.
+- Batch-runner non-integration regression coverage: **1,081 passed**, 5
+  skipped, and 37 deselected. This combines the broad suite, seven
+  data-module suites, and the actual-parquet selector suite without overlap.
+- Workflow contract, renderer script, and read-deliverable focused coverage is
+  included in that total; its direct run completed with **62 passed**.
+- Shared renderer requirements include and package set were verified, and all
+  four declarations parse successfully with the standard requirement parser.
+- `git diff --check` passed.
+- `extreme-reasoner` approved the no-secret/no-cost workflow design with the
+  shared dependency and action-pinning conditions implemented.
 
 ## Remaining Work
 
-- Add a normalized workbook/document schema manifest before generation and
-  repair, then harden ffmpeg/video execution with bounded output and explicit
-  container cleanup.
-- Skills and perception changes still require separate controlled ablations;
-  the paired run did not justify changing the selector yet.
-- Run rubric-based LLM-judge grading separately if exp027 needs quality
-  comparison beyond Self-QA.
-- Run an owner-approved bounded sandbox canary before treating the repair
-  strategy as production-validated; no paid model or batch run was dispatched
-  by PR #71.
+- Open and merge the dedicated workflow PR, then dispatch it once from `main`.
+- Record the GitHub-hosted run SHA, conclusion, and evidence JSON in this
+  rolling result. A failed preflight must be fixed and rerun without bypass.
+- This preflight does not approve paid grading. The limited Azure vision canary
+  remains a separate owner-approved step after renderer success.
+- No workflow, HF/Azure request, or model call has been performed yet.


### PR DESCRIPTION
## Summary

- add a manual, main-only Ubuntu 24.04 LibreOffice renderer preflight
- run with read-only permissions, commit-pinned actions, no secrets, OIDC, HF, Azure, or model calls
- share renderer Python requirements with the full grading environment
- retain a compact seven-day JSON evidence artifact on success or failure

## Verification

- batch-runner non-integration regression coverage: **1,081 passed**, 5 skipped, 37 deselected
- focused workflow/renderer/read-deliverable suite: **62 passed**
- shared requirements include/package parsing: passed
- `git diff --check`: passed
- `extreme-reasoner`: APPROVE-WITH-CONDITIONS, all conditions implemented
- `first-reviewer`: APPROVE

## Runtime plan

After merge, dispatch `Grading Renderer Preflight` once on `main`, inspect the compact JSON evidence, and record the run. This does not authorize or launch paid grading.