### PR TITLE
fix(grading): make renderer preflight directly executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **Renderer preflight direct-entry import** — make
+  `scripts/preflight_grading_renderer.py` add its own batch-runner root and load
+  only the lightweight `core.tools` package surface when executed as a file.
+  GitHub-hosted run 29392707519 had installed LibreOffice and renderer Python
+  dependencies successfully but failed before rendering because direct script
+  execution could not resolve `core`; the fix also avoids pulling unrelated
+  dataset/pyarrow imports into the four-package renderer environment.
 - **Sandbox generated-code preflight and targeted repair** — local and Docker
   backends now execute untouched `solution.py` through a trusted launcher that
   compiles with the actual target Python before `runpy` starts untrusted code.

--- a/batch-runner/scripts/preflight_grading_renderer.py
+++ b/batch-runner/scripts/preflight_grading_renderer.py
@@ -13,9 +13,19 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import types
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parent.parent
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+if "core" not in sys.modules:
+    core_package = types.ModuleType("core")
+    core_package.__path__ = [str(BATCH_RUNNER_ROOT / "core")]
+    core_package.__package__ = "core"
+    sys.modules["core"] = core_package
 
 from core.tools import get_renderer_fingerprint, read_deliverable
 from core.tools.read_deliverable import MAX_IMAGE_BYTES

--- a/batch-runner/tests/test_preflight_grading_renderer.py
+++ b/batch-runner/tests/test_preflight_grading_renderer.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import base64
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -15,6 +17,28 @@ FINGERPRINT = {
     "pymupdf_version": "1.26.3",
 }
 PNG = preflight.PNG_SIGNATURE + b"mock-rendered-png"
+
+
+def test_direct_script_entrypoint_resolves_core_import():
+    batch_root = Path(__file__).resolve().parents[1]
+    script = batch_root / "scripts" / "preflight_grading_renderer.py"
+
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=batch_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode in {0, 1}
+    assert completed.stderr == ""
+    lines = completed.stdout.splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert isinstance(payload.get("ok"), bool)
+    assert "No module named 'core'" not in completed.stdout
 
 
 def _successful_render(source_kind, scope):

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,7 +1,7 @@
 # Latest Task Result
 
 - Updated: 2026-07-15
-- Status: Renderer preflight implementation verified; runtime run pending
+- Status: Hosted import failure fixed; renderer rerun pending
 
 ## Task
 
@@ -14,6 +14,16 @@
 
 ## Result
 
+- Preflight workflow PR #73 was squash-merged to `main` as `fa8bf4f1` and
+  model-free run
+  [29392707519](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29392707519)
+  was dispatched. LibreOffice/font installation and renderer Python dependency
+  installation succeeded; no Azure, HF, batch, or model step existed.
+- The first run failed before rendering because direct execution from
+  `batch-runner/scripts` could not import `core`. The uploaded failure artifact
+  preserved that evidence. The script now inserts its own batch-runner root and
+  bootstraps only the lightweight `core.tools` namespace, avoiding unrelated
+  dataset/pyarrow imports.
 - Added `.github/workflows/grading-renderer-preflight.yml`, dispatched manually
   on `main` only with `contents: read`, no environment, no OIDC, and no secret
   references. Checkout, Python setup, and artifact upload actions are pinned to
@@ -35,7 +45,12 @@
   skipped, and 37 deselected. This combines the broad suite, seven
   data-module suites, and the actual-parquet selector suite without overlap.
 - Workflow contract, renderer script, and read-deliverable focused coverage is
-  included in that total; its direct run completed with **62 passed**.
+  included in that total. After the import fix, its direct run completed with
+  **63 passed**.
+- Overlay-free direct execution now emits one valid JSON line and reaches the
+  expected local `RendererDependencyError` because this SSH host has no
+  LibreOffice; it no longer raises `ModuleNotFoundError` for `core` or
+  `pyarrow`.
 - Shared renderer requirements include and package set were verified, and all
   four declarations parse successfully with the standard requirement parser.
 - `git diff --check` passed.
@@ -44,9 +59,9 @@
 
 ## Remaining Work
 
-- Open and merge the dedicated workflow PR, then dispatch it once from `main`.
-- Record the GitHub-hosted run SHA, conclusion, and evidence JSON in this
-  rolling result. A failed preflight must be fixed and rerun without bypass.
+- Merge the import fix PR and rerun the same model-free workflow from `main`.
+- Record the successful run SHA, conclusion, and evidence JSON. Do not bypass a
+  second failure.
 - This preflight does not approve paid grading. The limited Azure vision canary
   remains a separate owner-approved step after renderer success.
-- No workflow, HF/Azure request, or model call has been performed yet.
+- No HF/Azure request, batch run, or model call has been performed.


### PR DESCRIPTION
## Summary

- fix direct execution of `scripts/preflight_grading_renderer.py` on GitHub-hosted runners
- load only the lightweight `core.tools` package surface instead of unrelated dataset/pyarrow imports
- add a subprocess regression for the exact CI entrypoint
- record failed model-free run 29392707519 and the no-cost fix path

## Root cause

The first hosted preflight installed LibreOffice/fonts and renderer Python packages successfully, then failed before rendering with `ModuleNotFoundError: core`. No Azure, HF, batch, or model step existed or ran.

## Verification

- focused preflight/workflow/read-deliverable suite: **63 passed**
- overlay-free direct execution: one valid JSON line; no `core` or `pyarrow` import error
- `git diff --check`: passed
- `first-reviewer`: APPROVE

After merge, rerun only `Grading Renderer Preflight` on `main`.