### PR TITLE
docs: record renderer preflight success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **GitHub-hosted grading renderer verified** — model-free rerun 29393149367
+  passed on `main` commit `f97cc170` after PR #74 fixed the direct script import
+  boundary. Evidence recorded `ok=true`, exact Liberation Sans resolution,
+  LibreOffice 24.2.7.2, PyMuPDF 1.28.0, and successful XLSX/PPTX PNG renders.
+  No HF, Azure, batch, or model call was present in the workflow.
 - **Renderer preflight direct-entry import** — make
   `scripts/preflight_grading_renderer.py` add its own batch-runner root and load
   only the lightweight `core.tools` package surface when executed as a file.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,7 +1,7 @@
 # Latest Task Result
 
 - Updated: 2026-07-15
-- Status: Hosted import failure fixed; renderer rerun pending
+- Status: GitHub-hosted renderer preflight passed
 
 ## Task
 
@@ -24,6 +24,10 @@
   preserved that evidence. The script now inserts its own batch-runner root and
   bootstraps only the lightweight `core.tools` namespace, avoiding unrelated
   dataset/pyarrow imports.
+- Import fix PR #74 was squash-merged as `f97cc170`. The model-free rerun
+  [29393149367](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29393149367)
+  then completed successfully on that exact `main` SHA. Every workflow step,
+  including seven-day evidence artifact upload, passed.
 - Added `.github/workflows/grading-renderer-preflight.yml`, dispatched manually
   on `main` only with `contents: read`, no environment, no OIDC, and no secret
   references. Checkout, Python setup, and artifact upload actions are pinned to
@@ -56,12 +60,14 @@
 - `git diff --check` passed.
 - `extreme-reasoner` approved the no-secret/no-cost workflow design with the
   shared dependency and action-pinning conditions implemented.
+- Hosted evidence reported `ok=true`, exact font family `Liberation Sans`,
+  LibreOffice `24.2.7.2 420(Build:2)`, and PyMuPDF `1.28.0`. The synthetic XLSX
+  first workbook page rendered to a 17,358-byte PNG; PPTX slide 1 rendered to
+  an 18,637-byte PNG.
+- Run head SHA matched `f97cc170c1d3f79d7cadde24ae14d12682d1eabe`.
 
 ## Remaining Work
 
-- Merge the import fix PR and rerun the same model-free workflow from `main`.
-- Record the successful run SHA, conclusion, and evidence JSON. Do not bypass a
-  second failure.
 - This preflight does not approve paid grading. The limited Azure vision canary
   remains a separate owner-approved step after renderer success.
 - No HF/Azure request, batch run, or model call has been performed.


### PR DESCRIPTION
## Summary

- record successful model-free GitHub-hosted renderer preflight run 29393149367
- capture LibreOffice/PyMuPDF versions and XLSX/PPTX render evidence
- retain the limited paid Azure vision canary as a separate owner-approved step

## Evidence

- run conclusion: success
- head SHA: `f97cc170c1d3f79d7cadde24ae14d12682d1eabe`
- JSON: `ok=true`, Liberation Sans, LibreOffice 24.2.7.2, PyMuPDF 1.28.0
- XLSX PNG: 17,358 bytes; PPTX PNG: 18,637 bytes
- no HF, Azure, batch, or model call in the workflow

Only `CHANGELOG.md` and `tasks/LATEST_TASK_RESULT/README.md` change.