### PR TITLE
feat: add opt-in job performance metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,27 @@ entries land under a fresh dated heading the day they merge to `main`.
   `requirements-renderer.txt` keeps the dedicated workflow and full grading
   environment on the same openpyxl, python-pptx, Pillow, and PyMuPDF lower
   bounds.
+- **Opt-in job performance metrics** — experiments may enable
+  `execution.metrics.enabled` to record bounded per-task wall, model, tool,
+  verification, dependency, Self-QA, and orchestration times plus execution,
+  sandbox, tool-call, Self-QA-call, and resumed job-run counts. Resume rounds
+  preserve cumulative task lifetime, while `time_to_valid_artifact_ms` requires
+  a saved file and successful sandbox verification. Step 6 adds coverage,
+  average/P50/P95 job time, successful/failed averages, time-to-valid-file,
+  phase totals, and call totals only when measured data exists. The experiment
+  detail page conditionally exposes the aggregate panel, sortable Job Time
+  column, and per-task metrics; legacy configs, manifests, result JSON, and UI
+  remain unchanged when metrics are omitted. Activation requires the literal
+  boolean `true`; unrecognized fields are discarded. Durations and counters
+  use finite schema bounds with overflow-safe resume merging and strict JSON
+  serialization. Time-to-valid requires both a verified sandbox status and at
+  least one non-manifest artifact, so text-only and manifest-only tasks cannot
+  inflate the metric. Wall-timeout checkpoints retain pending task objects, and
+  relay completion replaces them through the same metric-merging path so prior
+  task lifetime is not lost. Step 3 serializes once with `allow_nan=False`
+  before opening either result destination, preventing split or non-standard
+  JSON output. Giant JSON integers are rejected before float conversion, so
+  progress merging and report aggregation cannot fail with numeric overflow.
 - **`exp027_GPT54_default_subprocess_bridge50`** — checked-in 50-task,
   9-sector diagnostic subprocess comparator for the historical exp026
   Sandbox/Skills runner bundle. Includes pinned 42 non-success-union tasks, six

--- a/batch-runner/core/execution_metrics.py
+++ b/batch-runner/core/execution_metrics.py
@@ -1,0 +1,47 @@
+"""Validation helpers for opt-in execution performance metrics."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+MAX_DURATION_MS = 30 * 24 * 60 * 60 * 1000
+MAX_COUNT = 1_000_000
+
+
+def bounded_duration_ms(value) -> Optional[float]:
+    """Return a finite 0..30-day duration, rejecting coercion from strings."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if isinstance(value, int) and not 0 <= value <= MAX_DURATION_MS:
+        return None
+    try:
+        parsed = float(value)
+    except OverflowError:
+        return None
+    if not math.isfinite(parsed) or not 0 <= parsed <= MAX_DURATION_MS:
+        return None
+    return round(parsed, 2)
+
+
+def bounded_count(value) -> Optional[int]:
+    """Return a strict non-negative integer count within the schema bound."""
+    if type(value) is not int or not 0 <= value <= MAX_COUNT:
+        return None
+    return value
+
+
+def add_durations_ms(*values) -> Optional[float]:
+    """Add per-task durations without allowing overflow or bound escape."""
+    parsed = [bounded_duration_ms(value) for value in values]
+    if any(value is None for value in parsed):
+        return None
+    return bounded_duration_ms(math.fsum(parsed))
+
+
+def add_counts(*values) -> Optional[int]:
+    """Add strict counts without allowing the cumulative bound to escape."""
+    parsed = [bounded_count(value) for value in values]
+    if any(value is None for value in parsed):
+        return None
+    return bounded_count(sum(parsed))

--- a/batch-runner/core/executor.py
+++ b/batch-runner/core/executor.py
@@ -34,6 +34,7 @@ class TaskExecutor:
         timeout: Optional[int] = None,
         reasoning_effort: Optional[str] = None,
         sandbox_options: Optional[dict] = None,
+        metrics_options: Optional[dict] = None,
     ):
         """
         Initialize executor with specified mode.
@@ -51,6 +52,7 @@ class TaskExecutor:
                 experiment YAML ``execution.sandbox`` block. Keys: image (str),
                 use_docker ("auto"|"never"|"always"), memory_gb (int),
                 cpus (float), skills_dir (str), max_skills (int).
+            metrics_options: Optional opt-in ``execution.metrics`` settings.
 
         Raises:
             ValueError: If required parameters are missing for the selected mode
@@ -84,6 +86,7 @@ class TaskExecutor:
             if llm_client is None:
                 raise ValueError("sandbox mode requires llm_client")
             opts = dict(sandbox_options or {})
+            metric_opts = metrics_options if isinstance(metrics_options, dict) else None
             self.runner = SandboxRunner(
                 llm_client,
                 prompt_name=prompt_name or opts.get("prompt_name") or SandboxRunner.DEFAULT_PROMPT,
@@ -101,6 +104,7 @@ class TaskExecutor:
                 manifest=opts.get("manifest"),
                 cache=opts.get("cache"),
                 contract=opts.get("contract"),
+                metrics=metric_opts,
             )
 
         elif mode == "json_renderer":

--- a/batch-runner/core/experiment_config.py
+++ b/batch-runner/core/experiment_config.py
@@ -98,6 +98,7 @@ class ExecutionConfig:
     tokens: Dict[str, int] = field(default_factory=lambda: dict(DEFAULT_TOKENS))
     timeout: Optional[int] = None  # subprocess timeout override (seconds)
     sandbox: Optional[Dict[str, Any]] = None  # sandbox-mode settings (execution.sandbox block)
+    metrics: Optional[Dict[str, Any]] = None  # opt-in job metrics (execution.metrics block)
 
 
 class ExperimentConfig:
@@ -235,6 +236,12 @@ class ExperimentConfig:
             tokens=execution_tokens,
             timeout=execution_data.get("timeout"),
             sandbox=execution_data.get("sandbox"),
+            metrics=(
+                {"enabled": True}
+                if isinstance(execution_data.get("metrics"), dict)
+                and execution_data["metrics"].get("enabled") is True
+                else None
+            ),
         )
 
         return cls(
@@ -341,6 +348,7 @@ class ExperimentConfig:
                 "tokens": dict(self.execution.tokens),
                 "timeout": self.execution.timeout,
                 "sandbox": self.execution.sandbox,
+                **({"metrics": self.execution.metrics} if self.execution.metrics is not None else {}),
             },
         }
 

--- a/batch-runner/core/sandbox_runner.py
+++ b/batch-runner/core/sandbox_runner.py
@@ -28,6 +28,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -46,6 +47,11 @@ from core.dependency_resolver import (
     resolve,
 )
 from core.execution_errors import classify_execution_error
+from core.execution_metrics import (
+    add_durations_ms,
+    bounded_count,
+    bounded_duration_ms,
+)
 
 from core.llm_client import complete
 from core.output_qa import run_output_qa
@@ -102,6 +108,11 @@ def _response_usage(response) -> Optional[dict]:
     if reasoning_tokens is not None:
         result["reasoning_tokens"] = reasoning_tokens
     return result
+
+
+def _numeric_metric(value) -> Optional[float]:
+    """Return a bounded timing value, otherwise ``None``."""
+    return bounded_duration_ms(value)
 
 
 def _github_run_context() -> dict:
@@ -289,6 +300,7 @@ class SandboxRunner:
         manifest: Optional[dict] = None,
         cache: Optional[dict] = None,
         contract: Optional[dict] = None,
+        metrics: Optional[dict] = None,
     ):
         self.llm_client = llm_client
         self.prompt_name = prompt_name
@@ -337,6 +349,9 @@ class SandboxRunner:
         }
         self.cache_cfg = {"enabled": False, **(cache or {})}
         self.contract_cfg = dict(contract or {})
+        self.metrics_enabled = (
+            isinstance(metrics, dict) and metrics.get("enabled") is True
+        )
         self._cache = build_cache(self.cache_cfg)
 
         self.registry = SkillsRegistry(skills_dir)
@@ -371,6 +386,7 @@ class SandboxRunner:
         sandbox owns its *placement* (the ``perception_analysis`` spec section),
         so step2 passes it through here instead of prepending it to the task.
         """
+        run_started = time.perf_counter()
         try:
             ref_files = reference_files or []
 
@@ -415,7 +431,14 @@ class SandboxRunner:
                     break
                 reflection = attempt["reflection_for_next"]
 
-            return self._finalize(best, attempts, skills, contract, ref_files)
+            finalized = self._finalize(best, attempts, skills, contract, ref_files)
+            if self.metrics_enabled:
+                task_wall_time_ms = bounded_duration_ms(
+                    (time.perf_counter() - run_started) * 1000,
+                )
+                if task_wall_time_ms is not None:
+                    finalized["execution_metrics"]["task_wall_time_ms"] = task_wall_time_ms
+            return finalized
 
         except Exception as e:  # pragma: no cover - defensive
             return {
@@ -439,11 +462,14 @@ class SandboxRunner:
         reflection: Optional[str],
         perception_text: Optional[str] = None,
     ) -> dict:
+        dependency_time_ms = 0.0
+        dependency_started = time.perf_counter()
         manifest = resolve(
             reference_files=ref_files,
             task_text=task_prompt,
             base_packages=self._base_packages,
         )
+        dependency_time_ms += (time.perf_counter() - dependency_started) * 1000
         augmented = self._augment_prompt(
             task_prompt, ref_files, skills, manifest, contract, reflection,
             perception_text=perception_text,
@@ -495,11 +521,12 @@ class SandboxRunner:
                     "status": "failed_execution",
                     "executor": "none",
                     "prompt_sha256": prompt_sha256,
-                    "llm_latency_ms": (
-                        round(float(llm_latency_ms), 2)
-                        if isinstance(llm_latency_ms, (int, float)) else None
-                    ),
+                    "llm_latency_ms": _numeric_metric(llm_latency_ms),
                     "usage": _response_usage(response),
+                    **self._attempt_metrics(
+                        llm_latency_ms=llm_latency_ms,
+                        dependency_time_ms=dependency_time_ms,
+                    ),
                     "blocking_error_count": 1,
                     "blocking_error_categories": ["no_code"],
                     "response": _text_fingerprint(response_text),
@@ -509,14 +536,18 @@ class SandboxRunner:
 
         deliverable_text = extract_description(response_text)
         # Re-resolve including the code's imports for a sharper missing-dep signal.
+        dependency_started = time.perf_counter()
         manifest = resolve(
             reference_files=ref_files,
             task_text=task_prompt,
             code=code,
             base_packages=self._base_packages,
         )
+        dependency_time_ms += (time.perf_counter() - dependency_started) * 1000
 
+        tool_started = time.perf_counter()
         executor_used, result = self._execute(code, ref_files, manifest)
+        tool_time_ms = (time.perf_counter() - tool_started) * 1000
         result["deliverable_text"] = deliverable_text
 
         preflight = result.get("preflight")
@@ -550,11 +581,14 @@ class SandboxRunner:
                     "executor": executor_used,
                     "prompt_sha256": prompt_sha256,
                     "code_sha256": _sha256_text(code),
-                    "llm_latency_ms": (
-                        round(float(llm_latency_ms), 2)
-                        if isinstance(llm_latency_ms, (int, float)) else None
-                    ),
+                    "llm_latency_ms": _numeric_metric(llm_latency_ms),
                     "usage": _response_usage(response),
+                    **self._attempt_metrics(
+                        llm_latency_ms=llm_latency_ms,
+                        tool_time_ms=tool_time_ms,
+                        dependency_time_ms=dependency_time_ms,
+                        tool_call_count=1,
+                    ),
                     "blocking_error_count": 1,
                     "blocking_error_categories": ["syntax_error"],
                     "generated_artifacts": [],
@@ -564,9 +598,11 @@ class SandboxRunner:
             }
 
         # Inspect the produced artifacts in an isolated workspace.
+        verification_started = time.perf_counter()
         analysis = self._analyze_output(
             result, ref_files, contract, task_prompt, executor_used, manifest
         )
+        verification_time_ms = (time.perf_counter() - verification_started) * 1000
 
         blocking = list(analysis["blocking_errors"])
         execution_error_category = (
@@ -604,11 +640,15 @@ class SandboxRunner:
                 "executor": executor_used,
                 "prompt_sha256": prompt_sha256,
                 "code_sha256": _sha256_text(code),
-                "llm_latency_ms": (
-                    round(float(llm_latency_ms), 2)
-                    if isinstance(llm_latency_ms, (int, float)) else None
-                ),
+                "llm_latency_ms": _numeric_metric(llm_latency_ms),
                 "usage": _response_usage(response),
+                **self._attempt_metrics(
+                    llm_latency_ms=llm_latency_ms,
+                    tool_time_ms=tool_time_ms,
+                    verification_time_ms=verification_time_ms,
+                    dependency_time_ms=dependency_time_ms,
+                    tool_call_count=1,
+                ),
                 "blocking_error_count": len(blocking),
                 "blocking_error_categories": _blocking_error_categories(blocking),
                 "generated_artifacts": analysis["artifact_names"],
@@ -754,6 +794,16 @@ class SandboxRunner:
         result["metadata"] = metadata
         result["final_status"] = final_status
         result["qa_ok"] = not best["blocking_errors"]
+        if self.metrics_enabled:
+            validated_artifact_count = (
+                len(best.get("artifacts") or [])
+                if final_status in {"ok", "repaired_ok"}
+                else 0
+            )
+            result["execution_metrics"] = self._aggregate_execution_metrics(
+                attempts,
+                validated_artifact_count=validated_artifact_count,
+            )
 
         manifest_doc = self._build_manifest(
             executor_used, skills, manifest, contract, attempts, best,
@@ -764,10 +814,74 @@ class SandboxRunner:
             files = list(result.get("files") or [])
             files.append({
                 "filename": self.manifest_cfg.get("filename", "manifest.json"),
-                "content": json.dumps(manifest_doc, indent=2, default=str).encode("utf-8"),
+                "content": json.dumps(
+                    manifest_doc,
+                    indent=2,
+                    default=str,
+                    allow_nan=False,
+                ).encode("utf-8"),
             })
             result["files"] = files
         return result
+
+    @staticmethod
+    def _aggregate_execution_metrics(
+        attempts: List[dict],
+        validated_artifact_count: int = 0,
+    ) -> dict:
+        """Aggregate bounded phase timings for a newly executed sandbox task."""
+        totals = {
+            "model_time_ms": 0.0,
+            "tool_time_ms": 0.0,
+            "verification_time_ms": 0.0,
+            "dependency_time_ms": 0.0,
+        }
+        for attempt in attempts:
+            phase_times = attempt.get("phase_times_ms") or {}
+            for output_key, phase_key in (
+                ("model_time_ms", "model"),
+                ("tool_time_ms", "tool"),
+                ("verification_time_ms", "verification"),
+                ("dependency_time_ms", "dependency"),
+            ):
+                value = _numeric_metric(phase_times.get(phase_key))
+                if value is not None:
+                    combined = add_durations_ms(totals[output_key], value)
+                    totals[output_key] = combined if combined is not None else totals[output_key]
+
+        attempt_count = bounded_count(len(attempts)) or 0
+        tool_call_count = bounded_count(sum(
+            int(attempt.get("tool_call_count") or 0) for attempt in attempts
+        )) or 0
+
+        return {
+            "schema_version": "1.0",
+            "task_wall_time_ms": 0.0,
+            **{key: round(value, 2) for key, value in totals.items()},
+            "attempt_count": attempt_count,
+            "tool_call_count": tool_call_count,
+            "validated_artifact_count": bounded_count(validated_artifact_count) or 0,
+        }
+
+    def _attempt_metrics(
+        self,
+        llm_latency_ms=None,
+        tool_time_ms: float = 0.0,
+        verification_time_ms: float = 0.0,
+        dependency_time_ms: float = 0.0,
+        tool_call_count: int = 0,
+    ) -> dict:
+        if not self.metrics_enabled:
+            return {}
+        return {
+            "phase_times_ms": {
+                "model": _numeric_metric(llm_latency_ms),
+                "tool": round(tool_time_ms, 2),
+                "verification": round(verification_time_ms, 2),
+                "dependency": round(dependency_time_ms, 2),
+            },
+            "tool_call_count": tool_call_count,
+        }
 
     def _build_manifest(
         self, executor_used, skills, manifest, contract, attempts, best,

--- a/batch-runner/sandbox/README.md
+++ b/batch-runner/sandbox/README.md
@@ -119,6 +119,8 @@ touching Python).
 ```yaml
 execution:
   mode: sandbox
+  metrics:
+    enabled: true                 # opt-in; omitted means no metrics keys
   sandbox:
     image: gdpval-sandbox:latest   # or your custom tag
     use_docker: auto               # auto | never | always
@@ -147,6 +149,26 @@ execution:
 
 The same `SANDBOX_IMAGE` env var read by `build.sh` is also the default image
 the runner looks for, so they stay in sync.
+
+## Job performance metrics
+
+Job metrics are opt-in through `execution.metrics.enabled`. Configs that omit
+the block keep the legacy prepared-task, manifest, result, and dashboard JSON
+shapes; no `metrics: null` or empty report block is emitted.
+
+Enabled runs record a bounded `observability.execution_metrics` object per
+task. It includes total wall time across generation and Self-QA retries, model,
+tool, verification, dependency, Self-QA, and orchestration time, plus execution,
+sandbox, tool-call, Self-QA-call, and resumed job-run counts. Resume rounds add
+to the same task lifetime instead of replacing earlier timing evidence.
+
+`time_to_valid_artifact_ms` is set only after a task saves a file and, for the
+sandbox backend, deterministic verification reports `ok` or `repaired_ok`.
+Text-only tasks and tasks that never produce a verified file keep it `null`.
+Step 6 emits the top-level `execution_metrics` aggregate only when at least one
+task has measured data. The dashboard then shows average/P50/P95 job time,
+successful and failed job averages, time to valid file, phase totals, and call
+counts; reports from earlier experiments render unchanged.
 
 ## Security posture
 

--- a/batch-runner/step1_prepare_tasks.py
+++ b/batch-runner/step1_prepare_tasks.py
@@ -154,6 +154,7 @@ def prepare_tasks(config_path: str) -> dict:
             "tokens": dict(config.execution.tokens),
             "timeout": config.execution.timeout,
             "sandbox": config.execution.sandbox,
+            **({"metrics": config.execution.metrics} if config.execution.metrics is not None else {}),
         },
         "total_tasks": len(task_list),
         "needs_files_count": sum(1 for t in task_list if t["needs_files"]),

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -44,6 +44,12 @@ from core.config import (
 )
 from core.data_loader import GDPValTask
 from core.executor import TaskExecutor
+from core.execution_metrics import (
+    add_counts,
+    add_durations_ms,
+    bounded_count,
+    bounded_duration_ms,
+)
 from core.file_preview import generate_all_previews
 from core.llm_client import create_client, create_provider_client, complete
 from core.needs_files import NeedsFilesManifest
@@ -65,6 +71,23 @@ EXIT_CHECKPOINT = 42  # checkpoint saved, relay retrigger needed
 
 # Cache of models that don't support temperature=0 (learned at runtime, reused in session)
 _MODELS_NO_TEMPERATURE: set = set()
+
+_METRIC_DURATION_FIELDS = (
+    "task_wall_time_ms",
+    "model_time_ms",
+    "tool_time_ms",
+    "verification_time_ms",
+    "dependency_time_ms",
+    "self_qa_time_ms",
+    "orchestration_time_ms",
+)
+_METRIC_COUNT_FIELDS = (
+    "execution_attempt_count",
+    "sandbox_attempt_count",
+    "tool_call_count",
+    "self_qa_call_count",
+    "job_run_count",
+)
 
 
 # ── Preprocessor helper ───────────────────────────────────────────────────
@@ -236,6 +259,11 @@ def _build_execution_observability(
 ) -> dict:
     """Build compact task provenance without duplicating heavy QA reports."""
     observability = {"preprocessors": preprocessor_observations}
+    execution_metrics = _bounded_execution_metrics(
+        (result or {}).get("execution_metrics")
+    )
+    if execution_metrics:
+        observability["execution_metrics"] = execution_metrics
     manifest = (result or {}).get("sandbox_manifest") or {}
     if manifest:
         attempts = []
@@ -283,6 +311,91 @@ def _build_execution_observability(
             "final_status": manifest.get("final_status"),
         }
     return observability
+
+
+def _bounded_execution_metrics(raw: Optional[dict]) -> Optional[dict]:
+    """Keep only finite, non-negative execution metrics and stable counters."""
+    if not isinstance(raw, dict):
+        return None
+
+    bounded = {"schema_version": "1.0"}
+    for key in (*_METRIC_DURATION_FIELDS, "time_to_valid_artifact_ms"):
+        value = raw.get(key)
+        if value is None and key == "time_to_valid_artifact_ms":
+            bounded[key] = None
+            continue
+        parsed = bounded_duration_ms(value)
+        if parsed is not None:
+            bounded[key] = parsed
+
+    for key in (*_METRIC_COUNT_FIELDS, "attempt_count"):
+        parsed = bounded_count(raw.get(key))
+        if parsed is not None:
+            bounded[key] = parsed
+
+    validated_artifact_count = bounded_count(raw.get("validated_artifact_count"))
+    if validated_artifact_count is not None:
+        bounded["validated_artifact_count"] = validated_artifact_count
+
+    wall_time = bounded.get("task_wall_time_ms")
+    if wall_time is None:
+        return None
+    valid_time = bounded.get("time_to_valid_artifact_ms")
+    if valid_time is not None and valid_time > wall_time:
+        bounded["time_to_valid_artifact_ms"] = None
+
+    return bounded if len(bounded) > 1 else None
+
+
+def _merge_execution_metrics(previous: Optional[dict], current: Optional[dict]) -> Optional[dict]:
+    """Combine opt-in metrics when a resume round replaces an earlier result."""
+    previous = _bounded_execution_metrics(previous)
+    current = _bounded_execution_metrics(current)
+    if not previous:
+        return current
+    if not current:
+        return previous
+
+    merged = {
+        "schema_version": current.get("schema_version", previous["schema_version"]),
+    }
+    for key in _METRIC_DURATION_FIELDS:
+        combined = add_durations_ms(
+            previous.get(key, 0) or 0,
+            current.get(key, 0) or 0,
+        )
+        if combined is None:
+            return current
+        merged[key] = combined
+    for key in _METRIC_COUNT_FIELDS:
+        combined = add_counts(
+            previous.get(key, 0) or 0,
+            current.get(key, 0) or 0,
+        )
+        if combined is None:
+            return current
+        merged[key] = combined
+
+    merged["validated_artifact_count"] = max(
+        previous.get("validated_artifact_count", 0) or 0,
+        current.get("validated_artifact_count", 0) or 0,
+    )
+
+    previous_valid = previous.get("time_to_valid_artifact_ms")
+    current_valid = current.get("time_to_valid_artifact_ms")
+    if previous_valid is not None:
+        merged["time_to_valid_artifact_ms"] = previous_valid
+    elif current_valid is not None:
+        merged_valid = add_durations_ms(
+            previous.get("task_wall_time_ms", 0) or 0,
+            current_valid,
+        )
+        if merged_valid is None:
+            return current
+        merged["time_to_valid_artifact_ms"] = merged_valid
+    else:
+        merged["time_to_valid_artifact_ms"] = None
+    return _bounded_execution_metrics(merged) or current
 
 
 # ── JSON extraction helper ─────────────────────────────────────────────────
@@ -996,7 +1109,14 @@ def _save_progress(
 
     tmp_path = path.with_suffix(".json.tmp")
     with open(tmp_path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False, default=str)
+        json.dump(
+            data,
+            f,
+            indent=2,
+            ensure_ascii=False,
+            default=str,
+            allow_nan=False,
+        )
     tmp_path.rename(path)
 
 
@@ -1022,6 +1142,11 @@ def _update_progress_result(progress: dict, new_result: dict) -> dict:
     replaced = False
     for r in progress.get("results", []):
         if r["task_id"] == new_result["task_id"]:
+            previous_metrics = (r.get("observability") or {}).get("execution_metrics")
+            current_metrics = (new_result.get("observability") or {}).get("execution_metrics")
+            merged_metrics = _merge_execution_metrics(previous_metrics, current_metrics)
+            if merged_metrics:
+                new_result.setdefault("observability", {})["execution_metrics"] = merged_metrics
             updated.append(new_result)
             replaced = True
         else:
@@ -1097,6 +1222,9 @@ def run_inference(
     }
     # Sandbox-mode settings (execution.sandbox block in the experiment YAML).
     sandbox_options = execution_cfg.get("sandbox", {}) or {}
+    metrics_cfg_raw = execution_cfg.get("metrics")
+    metrics_cfg = metrics_cfg_raw if isinstance(metrics_cfg_raw, dict) else {}
+    metrics_enabled = metrics_cfg.get("enabled") is True
 
     print(f"\n{'='*60}")
     print(f"🚀 Step 2: Run Inference")
@@ -1112,6 +1240,8 @@ def run_inference(
           f"qa={tokens_cfg['qa_check']}, render={tokens_cfg['json_render']}")
     if timeout:
         print(f"   Timeout:            {timeout}s (YAML override)")
+    if metrics_enabled:
+        print("   Job metrics:        enabled (optional execution_metrics v1.0)")
     reasoning_effort_display = condition.get("model", {}).get("reasoning_effort")
     if reasoning_effort_display:
         print(f"   Reasoning effort:   {reasoning_effort_display}")
@@ -1192,6 +1322,7 @@ def run_inference(
             mode=execution_mode, llm_client=client, tokens=tokens_cfg,
             timeout=timeout, reasoning_effort=reasoning_effort,
             sandbox_options=sandbox_options,
+            metrics_options=metrics_cfg,
         )
     except Exception as e:
         print(f"❌ Executor init failed for mode '{execution_mode}': {e}")
@@ -1232,6 +1363,20 @@ def run_inference(
         import tempfile
 
         task_id = task["task_id"]
+        job_started = time.perf_counter()
+        execution_attempt_count = 0
+        sandbox_attempt_count = 0
+        tool_call_count = 0
+        validated_artifact_count = 0
+        self_qa_call_count = 0
+        self_qa_time_ms = 0.0
+        phase_totals = {
+            "model_time_ms": 0.0,
+            "tool_time_ms": 0.0,
+            "verification_time_ms": 0.0,
+            "dependency_time_ms": 0.0,
+        }
+        time_to_valid_artifact_ms = None
         qa_attempts = 0
         last_qa_feedback = error_context
         reflection_history = []
@@ -1266,6 +1411,75 @@ def run_inference(
                 shutil.rmtree(backup_dir, ignore_errors=True)
                 backup_dir = None
 
+        def _record_execution_metrics(task_result: dict) -> None:
+            nonlocal execution_attempt_count, sandbox_attempt_count
+            nonlocal tool_call_count, validated_artifact_count
+            nonlocal time_to_valid_artifact_ms
+            execution_attempt_count += 1
+            raw = _bounded_execution_metrics(
+                (task_result.get("observability") or {}).get("execution_metrics")
+            ) or {}
+            sandbox_attempt_count += int(
+                raw.get("sandbox_attempt_count", raw.get("attempt_count", 0)) or 0
+            )
+            tool_call_count += int(raw.get("tool_call_count", 0) or 0)
+            validated_artifact_count = max(
+                validated_artifact_count,
+                int(raw.get("validated_artifact_count", 0) or 0),
+            )
+            for key in phase_totals:
+                phase_totals[key] += float(raw.get(key, 0) or 0)
+            sandbox_observability = (task_result.get("observability") or {}).get("sandbox")
+            sandbox_valid = (
+                isinstance(sandbox_observability, dict)
+                and sandbox_observability.get("final_status") in {"ok", "repaired_ok"}
+                and int(raw.get("validated_artifact_count", 0) or 0) > 0
+            )
+            if (
+                time_to_valid_artifact_ms is None
+                and task_result.get("status") == "success"
+                and task_result.get("deliverable_files")
+                and sandbox_valid
+            ):
+                time_to_valid_artifact_ms = round(
+                    (time.perf_counter() - job_started) * 1000,
+                    2,
+                )
+
+        def _attach_job_metrics(task_result: dict) -> dict:
+            if not metrics_enabled:
+                return task_result
+            task_wall_time_ms = round(
+                (time.perf_counter() - job_started) * 1000,
+                2,
+            )
+            measured_phase_time_ms = (
+                sum(phase_totals.values()) + self_qa_time_ms
+            )
+            metrics = {
+                "schema_version": "1.0",
+                "task_wall_time_ms": task_wall_time_ms,
+                "time_to_valid_artifact_ms": time_to_valid_artifact_ms,
+                **{key: round(value, 2) for key, value in phase_totals.items()},
+                "self_qa_time_ms": round(self_qa_time_ms, 2),
+                "orchestration_time_ms": round(
+                    max(0.0, task_wall_time_ms - measured_phase_time_ms),
+                    2,
+                ),
+                "execution_attempt_count": execution_attempt_count,
+                "sandbox_attempt_count": sandbox_attempt_count,
+                "tool_call_count": tool_call_count,
+                "self_qa_call_count": self_qa_call_count,
+                "job_run_count": 1,
+                "validated_artifact_count": validated_artifact_count,
+            }
+            bounded_metrics = _bounded_execution_metrics(metrics)
+            if bounded_metrics:
+                task_result.setdefault("observability", {})[
+                    "execution_metrics"
+                ] = bounded_metrics
+            return task_result
+
         try:
             while True:
                 if qa_attempts > 0:
@@ -1289,6 +1503,8 @@ def run_inference(
                     error_context=last_qa_feedback,
                     verbose=verbose,
                 )
+                if metrics_enabled:
+                    _record_execution_metrics(result)
 
                 # If execution failed, return best if available
                 if result["status"] != "success":
@@ -1298,13 +1514,14 @@ def run_inference(
                         print(f"\n      ⚠️  Re-execution failed, "
                               f"keeping best result (score={best_score})",
                               end=" ", flush=True)
-                        return best_result
+                        return _attach_job_metrics(best_result)
                     break
 
                 if not qa_enabled:
                     break
 
                 # Run Self-QA (파일이 workspace에 저장된 상태 → file_preview로 실제 내용 확인)
+                qa_started = time.perf_counter()
                 qa_result_info = _run_self_qa(
                     task, condition,
                     result.get("deliverable_text", ""),
@@ -1312,6 +1529,9 @@ def run_inference(
                     client,
                     qa_max_tokens=qa_max_tokens,
                 )
+                if metrics_enabled:
+                    self_qa_call_count += 1
+                    self_qa_time_ms += (time.perf_counter() - qa_started) * 1000
                 result["qa"] = qa_result_info
 
                 # Record this QA attempt in history
@@ -1407,12 +1627,12 @@ def run_inference(
             best_result["reflection_attempts"] = len(reflection_history)
             if len(reflection_history) > 0:
                 best_result["reflection_final_score"] = best_score
-            return best_result
+            return _attach_job_metrics(best_result)
         result["reflection_history"] = reflection_history
         result["reflection_attempts"] = len(reflection_history)
         if len(reflection_history) > 0 and result.get("status") == "success":
             result["reflection_final_score"] = best_score if best_score >= 0 else None
-        return result
+        return _attach_job_metrics(result)
 
     # ── Helper: print result status ──
 
@@ -1471,14 +1691,10 @@ def run_inference(
                 r["task_id"] for r in progress.get("results", [])
                 if r.get("status") == "pending"
             }
-            # Remove pending entries — they'll be re-executed below
-            progress["results"] = [
-                r for r in progress["results"] if r.get("status") != "pending"
-            ]
             remaining_tasks = [t for t in tasks if t["task_id"] in pending_task_ids]
 
             print(f"\n── Relay Run: {len(remaining_tasks)} pending tasks ──")
-            done_count = len(progress["results"])
+            done_count = len(progress["results"]) - pending_count
 
             for i, task in enumerate(remaining_tasks):
                 # ── Watchdog: wall-clock timeout check ──
@@ -1487,13 +1703,13 @@ def run_inference(
                     print(f"\n⏰ Wall timeout reached again ({wall_timeout}min). "
                           f"Saving checkpoint ({i} more completed, "
                           f"{len(still_remaining)} still pending)...")
-                    for rt in still_remaining:
-                        progress["results"].append({
-                            "task_id": rt["task_id"],
-                            "status": "pending",
-                            "error": "wall_timeout",
-                            "timestamp": datetime.now(timezone.utc).isoformat(),
-                        })
+                    pending_timestamp = datetime.now(timezone.utc).isoformat()
+                    still_remaining_ids = {rt["task_id"] for rt in still_remaining}
+                    for existing in progress["results"]:
+                        if existing["task_id"] in still_remaining_ids:
+                            existing["status"] = "pending"
+                            existing["error"] = "wall_timeout"
+                            existing["timestamp"] = pending_timestamp
                     _save_progress(
                         experiment_id, condition_name, execution_mode,
                         total, progress["results"], started_at, progress_path,
@@ -1507,7 +1723,7 @@ def run_inference(
                       end=" ", flush=True)
 
                 result = _run_task_with_qa(task)
-                progress["results"].append(result)
+                progress = _update_progress_result(progress, result)
                 _print_status(result)
 
                 if (i + 1) % 20 == 0:
@@ -1685,7 +1901,14 @@ def run_inference(
 
     output_path = WORKSPACE_DIR / "step2_inference_results.json"
     with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(final_output, f, indent=2, ensure_ascii=False, default=str)
+        json.dump(
+            final_output,
+            f,
+            indent=2,
+            ensure_ascii=False,
+            default=str,
+            allow_nan=False,
+        )
 
     print(f"\n{'='*60}")
     print(f"✅ Step 2 complete: {output_path}")

--- a/batch-runner/step3_format_results.py
+++ b/batch-runner/step3_format_results.py
@@ -91,6 +91,20 @@ def _build_sector_stats(results: list) -> dict:
     return out
 
 
+def _write_json_outputs(data: dict, *paths: Path) -> None:
+    """Serialize once with strict JSON, then write identical output files."""
+    serialized = json.dumps(
+        data,
+        indent=2,
+        ensure_ascii=False,
+        default=str,
+        allow_nan=False,
+    )
+    for path in paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(serialized, encoding="utf-8")
+
+
 # ── Main ───────────────────────────────────────────────────────────────────
 
 
@@ -203,14 +217,10 @@ def format_results():
     }
 
     json_path = results_dir / f"{experiment_id}.json"
-    with open(json_path, "w", encoding="utf-8") as f:
-        json.dump(final_json, f, indent=2, ensure_ascii=False, default=str)
-
-    # Also write to workspace/result.json so step6 reads it directly
     workspace_result = WORKSPACE_DIR / "result.json"
-    WORKSPACE_DIR.mkdir(parents=True, exist_ok=True)
-    with open(workspace_result, "w", encoding="utf-8") as f:
-        json.dump(final_json, f, indent=2, ensure_ascii=False, default=str)
+    # Serialize before either file is opened so invalid numeric values cannot
+    # leave one output updated and the other stale or emit non-standard JSON.
+    _write_json_outputs(final_json, json_path, workspace_result)
 
     # 5. Build Markdown report
     success_rate = round(summary["success"] / summary["total"] * 100) if summary["total"] else 0

--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -32,6 +32,7 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPT_DIR))
 
 from core.config import NEEDS_FILES_POLICIES_KNOWN, WORKSPACE_DIR
+from core.execution_metrics import bounded_count, bounded_duration_ms
 from core.narrative_analyzer import (
     _build_grade_source,
     _build_grading_guard_clause,
@@ -142,6 +143,102 @@ def _compute_summary(data: dict) -> dict:
         "avg_latency_ms": round(sum(latencies) / len(latencies)) if latencies else 0,
         "max_latency_ms": round(max(latencies)) if latencies else 0,
         "total_latency_ms": round(sum(latencies)) if latencies else 0,
+    }
+
+
+def _metric_number(value) -> float | None:
+    return bounded_duration_ms(value)
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    """Return a linearly interpolated percentile for a non-empty sample."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return round(ordered[0], 2)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return round(ordered[lower] * (1 - weight) + ordered[upper] * weight, 2)
+
+
+def _compute_execution_metrics(data: dict) -> dict | None:
+    """Aggregate opt-in job metrics; return ``None`` for legacy experiments."""
+    results = data.get("results", [])
+    measured: list[tuple[dict, dict, float]] = []
+    for result in results:
+        raw = (result.get("observability") or {}).get("execution_metrics")
+        if not isinstance(raw, dict):
+            continue
+        wall_time = _metric_number(raw.get("task_wall_time_ms"))
+        if wall_time is not None:
+            measured.append((result, raw, wall_time))
+
+    if not measured:
+        return None
+
+    wall_times = [wall_time for _, _, wall_time in measured]
+    successful_wall_times = [
+        wall_time for result, _, wall_time in measured
+        if result.get("status") == "success"
+    ]
+    failed_wall_times = [
+        wall_time for result, _, wall_time in measured
+        if result.get("status") != "success"
+    ]
+    valid_artifact_times = [
+        value
+        for _, raw, wall_time in measured
+        if (value := _metric_number(raw.get("time_to_valid_artifact_ms"))) is not None
+        and value <= wall_time
+        and (bounded_count(raw.get("validated_artifact_count")) or 0) > 0
+    ]
+
+    def average(values: list[float]) -> float | None:
+        return round(sum(values) / len(values), 2) if values else None
+
+    def total(field: str) -> float:
+        return round(sum(
+            value
+            for _, raw, _ in measured
+            if (value := _metric_number(raw.get(field))) is not None
+        ), 2)
+
+    def count(field: str) -> int:
+        return sum(
+            value
+            for _, raw, _ in measured
+            if (value := bounded_count(raw.get(field))) is not None
+        )
+
+    return {
+        "schema_version": "1.0",
+        "measured_tasks": len(measured),
+        "total_tasks": len(results),
+        "coverage_pct": round(len(measured) / len(results) * 100, 1) if results else 0.0,
+        "avg_task_wall_time_ms": average(wall_times),
+        "p50_task_wall_time_ms": _percentile(wall_times, 0.50),
+        "p95_task_wall_time_ms": _percentile(wall_times, 0.95),
+        "max_task_wall_time_ms": round(max(wall_times), 2),
+        "avg_successful_task_wall_time_ms": average(successful_wall_times),
+        "avg_failed_task_wall_time_ms": average(failed_wall_times),
+        "measured_time_to_valid_artifact_tasks": len(valid_artifact_times),
+        "avg_time_to_valid_artifact_ms": average(valid_artifact_times),
+        "p50_time_to_valid_artifact_ms": _percentile(valid_artifact_times, 0.50),
+        "p95_time_to_valid_artifact_ms": _percentile(valid_artifact_times, 0.95),
+        "total_model_time_ms": total("model_time_ms"),
+        "total_tool_time_ms": total("tool_time_ms"),
+        "total_verification_time_ms": total("verification_time_ms"),
+        "total_dependency_time_ms": total("dependency_time_ms"),
+        "total_self_qa_time_ms": total("self_qa_time_ms"),
+        "total_orchestration_time_ms": total("orchestration_time_ms"),
+        "total_execution_attempts": count("execution_attempt_count"),
+        "total_sandbox_attempts": count("sandbox_attempt_count"),
+        "total_tool_calls": count("tool_call_count"),
+        "total_self_qa_calls": count("self_qa_call_count"),
+        "total_job_runs": count("job_run_count"),
     }
 
 
@@ -321,7 +418,8 @@ Return ONLY valid JSON with these exact keys (no markdown code fences):
 
 def _build_report_data(data: dict, narrative: dict, summary: dict,
                        sector_breakdown: list[dict], task_results: list[dict],
-                       error_tasks: list[dict]) -> dict:
+                       error_tasks: list[dict],
+                       execution_metrics: dict | None = None) -> dict:
     meta_date = (data.get("started_at") or "")[:10]
     report = {
         "meta": {
@@ -350,6 +448,8 @@ def _build_report_data(data: dict, narrative: dict, summary: dict,
     }
     if "_narrative_error" in narrative:
         report["narrative_error"] = narrative["_narrative_error"]
+    if execution_metrics:
+        report["execution_metrics"] = execution_metrics
     return report
 
 
@@ -484,6 +584,24 @@ def _build_markdown(rd: dict) -> str:
         f"| 📊 Grading | ⏳ Awaiting (`scores.json`) |",
         "",
     ]
+
+    execution_metrics = rd.get("execution_metrics")
+    if execution_metrics:
+        valid_time = execution_metrics.get("avg_time_to_valid_artifact_ms")
+        lines += [
+            "## Job Performance",
+            "",
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Measured tasks | {execution_metrics['measured_tasks']} / {execution_metrics['total_tasks']} ({execution_metrics['coverage_pct']}%) |",
+            f"| Avg job time | {execution_metrics['avg_task_wall_time_ms']:,.0f}ms |",
+            f"| P50 job time | {execution_metrics['p50_task_wall_time_ms']:,.0f}ms |",
+            f"| P95 job time | {execution_metrics['p95_task_wall_time_ms']:,.0f}ms |",
+            f"| Avg time to valid artifact | {valid_time:,.0f}ms |" if valid_time is not None else "| Avg time to valid artifact | N/A |",
+            f"| Tool calls | {execution_metrics['total_tool_calls']} |",
+            f"| Execution attempts | {execution_metrics['total_execution_attempts']} |",
+            "",
+        ]
 
     # 2. Execution Summary
     if narrative.get("overview"):
@@ -675,7 +793,13 @@ def _build_html(rd: dict) -> str:
         return esc(s).replace("\n\n", "</p><p>").replace("\n", "<br>")
 
     # Embed report_data as inline JS
-    data_json = json.dumps(rd, ensure_ascii=False, indent=2, default=str)
+    data_json = json.dumps(
+        rd,
+        ensure_ascii=False,
+        indent=2,
+        default=str,
+        allow_nan=False,
+    )
 
     # File generation metric card
     fg = rd.get("file_generation") or {}
@@ -1018,6 +1142,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
 
     # Compute metrics
     summary = _compute_summary(data)
+    execution_metrics = _compute_execution_metrics(data)
     sector_breakdown = _compute_sector_breakdown(data)
     manifest = _load_manifest_safe()
     task_results, error_tasks = _build_task_results(data, manifest=manifest)
@@ -1060,7 +1185,15 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
             narrative = _generate_narrative(data, summary, sector_breakdown, grade=grade)
 
     # Build report_data.json
-    rd = _build_report_data(data, narrative, summary, sector_breakdown, task_results, error_tasks)
+    rd = _build_report_data(
+        data,
+        narrative,
+        summary,
+        sector_breakdown,
+        task_results,
+        error_tasks,
+        execution_metrics=execution_metrics,
+    )
 
     # Inject file generation stats from step5_validate.py
     validate_stats_path = WORKSPACE_DIR / "validate_stats.json"
@@ -1093,7 +1226,14 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
 
     json_path = output_dir / "report_data.json"
     with open(json_path, "w", encoding="utf-8") as f:
-        json.dump(rd, f, indent=2, ensure_ascii=False, default=str)
+        json.dump(
+            rd,
+            f,
+            indent=2,
+            ensure_ascii=False,
+            default=str,
+            allow_nan=False,
+        )
 
     # Build report.md
     md_path = output_dir / "report.md"

--- a/batch-runner/tests/test_execution_metrics.py
+++ b/batch-runner/tests/test_execution_metrics.py
@@ -1,0 +1,51 @@
+"""Numeric contract tests for opt-in execution performance metrics."""
+
+import math
+
+import pytest
+
+from core.execution_metrics import (
+    MAX_COUNT,
+    MAX_DURATION_MS,
+    add_counts,
+    add_durations_ms,
+    bounded_count,
+    bounded_duration_ms,
+)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        True,
+        False,
+        "1",
+        -1,
+        math.nan,
+        math.inf,
+        -math.inf,
+        MAX_DURATION_MS + 1,
+        10**400,
+    ],
+)
+def test_bounded_duration_rejects_invalid_values(value):
+    assert bounded_duration_ms(value) is None
+
+
+def test_bounded_duration_accepts_schema_boundary():
+    assert bounded_duration_ms(0) == 0
+    assert bounded_duration_ms(MAX_DURATION_MS) == MAX_DURATION_MS
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, True, False, "1", 1.0, -1, MAX_COUNT + 1],
+)
+def test_bounded_count_requires_strict_bounded_integer(value):
+    assert bounded_count(value) is None
+
+
+def test_add_helpers_reject_cumulative_bound_escape():
+    assert add_durations_ms(MAX_DURATION_MS, 1) is None
+    assert add_counts(MAX_COUNT, 1) is None

--- a/batch-runner/tests/test_executor.py
+++ b/batch-runner/tests/test_executor.py
@@ -218,6 +218,7 @@ def test_executor_sandbox_passes_options_and_tokens():
             mode="sandbox",
             llm_client=mock_client,
             tokens={"code_generation": 4242},
+            metrics_options={"enabled": True},
             sandbox_options={
                 "image": "custom-sandbox:1.0",
                 "use_docker": "always",
@@ -234,6 +235,7 @@ def test_executor_sandbox_passes_options_and_tokens():
         assert kwargs["memory_gb"] == 7
         assert kwargs["cpus"] == 3.0
         assert kwargs["max_skills"] == 4
+        assert kwargs["metrics"] == {"enabled": True}
 
 
 def test_executor_sandbox_defaults_when_no_options():

--- a/batch-runner/tests/test_experiment_config.py
+++ b/batch-runner/tests/test_experiment_config.py
@@ -204,6 +204,33 @@ class TestExperimentConfigFromDict:
         assert config.execution.tokens["code_generation"] == 12000
         assert config.execution.tokens["qa_check"] == 3000
         assert config.execution.tokens["json_render"] == 7000
+        assert config.execution.metrics is None
+        assert "metrics" not in config.to_dict()["execution"]
+
+    def test_from_dict_execution_metrics_opt_in(self, sample_config_dict):
+        sample_config_dict["execution"]["metrics"] = {
+            "enabled": True,
+            "raw_output": "must-not-survive",
+        }
+
+        config = ExperimentConfig.from_dict(sample_config_dict)
+
+        assert config.execution.metrics == {"enabled": True}
+        assert config.to_dict()["execution"]["metrics"] == {"enabled": True}
+
+    @pytest.mark.parametrize(
+        "metrics",
+        [{}, {"enabled": False}, {"enabled": "false"}, {"enabled": 1}, []],
+    )
+    def test_from_dict_execution_metrics_requires_literal_true(
+        self, sample_config_dict, metrics
+    ):
+        sample_config_dict["execution"]["metrics"] = metrics
+
+        config = ExperimentConfig.from_dict(sample_config_dict)
+
+        assert config.execution.metrics is None
+        assert "metrics" not in config.to_dict()["execution"]
 
 
 class TestExperimentConfigFromYaml:

--- a/batch-runner/tests/test_sandbox_runner.py
+++ b/batch-runner/tests/test_sandbox_runner.py
@@ -221,7 +221,11 @@ def test_run_end_to_end_local_fallback():
         "print('finished')\n"
         "```\n"
     )
-    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    runner = SandboxRunner(
+        llm_client=object(),
+        use_docker="never",
+        metrics={"enabled": True},
+    )
     with _patch_complete(code_block):
         result = runner.run(
             task_prompt="Write the word done to a file",
@@ -239,6 +243,47 @@ def test_run_end_to_end_local_fallback():
     assert meta["image"] is None
     assert "skills" in meta
     assert "dependencies" in meta
+    metrics = result["execution_metrics"]
+    assert metrics["schema_version"] == "1.0"
+    assert metrics["task_wall_time_ms"] >= metrics["tool_time_ms"] >= 0
+    assert metrics["model_time_ms"] >= 0
+    assert metrics["verification_time_ms"] >= 0
+    assert metrics["dependency_time_ms"] >= 0
+    assert metrics["attempt_count"] == 1
+    assert metrics["tool_call_count"] == 1
+
+
+def test_run_omits_execution_metrics_by_default():
+    code_block = "```python\nprint('finished')\n```"
+    runner = SandboxRunner(llm_client=object(), use_docker="never")
+    with _patch_complete(code_block):
+        result = runner.run(
+            task_prompt="Print a completion message",
+            model="fake-model",
+            reference_files=[],
+        )
+
+    assert result["success"] is True
+    assert "execution_metrics" not in result
+    assert "phase_times_ms" not in result["sandbox_manifest"]["attempts"][0]
+    assert "tool_call_count" not in result["sandbox_manifest"]["attempts"][0]
+
+
+@pytest.mark.parametrize("metrics", [{}, {"enabled": False}, {"enabled": "false"}])
+def test_run_requires_literal_true_to_enable_execution_metrics(metrics):
+    runner = SandboxRunner(
+        llm_client=object(),
+        use_docker="never",
+        metrics=metrics,
+    )
+    with _patch_complete("```python\nprint('finished')\n```"):
+        result = runner.run(
+            task_prompt="Print a completion message",
+            model="fake-model",
+            reference_files=[],
+        )
+
+    assert "execution_metrics" not in result
 
 
 def test_run_no_code_returns_failure():

--- a/batch-runner/tests/test_silent_corruption_fixes.py
+++ b/batch-runner/tests/test_silent_corruption_fixes.py
@@ -472,11 +472,149 @@ class TestFix3RunTaskWithQA:
         results = progress["results"]
         assert len(results) == 1
         assert results[0]["status"] == "success"
+        assert "execution_metrics" not in results[0].get("observability", {})
+
+    def test_opt_in_job_metrics_include_phase_times_and_counts(
+        self, patched_run_inference, monkeypatch
+    ):
+        s2, workspace = patched_run_inference
+        prepared_path = workspace / "step1_tasks_prepared.json"
+        prepared = json.loads(prepared_path.read_text(encoding="utf-8"))
+        prepared["execution"]["metrics"] = {"enabled": True}
+        prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
+
+        def execute_with_metrics(*args, **kwargs):
+            return {
+                "task_id": "t1",
+                "status": "success",
+                "deliverable_text": "hello",
+                "deliverable_files": ["deliverable_files/t1/out.pdf"],
+                "latency_ms": 10,
+                "observability": {
+                    "sandbox": {"final_status": "ok"},
+                    "execution_metrics": {
+                        "schema_version": "1.0",
+                        "task_wall_time_ms": 9,
+                        "model_time_ms": 4,
+                        "tool_time_ms": 2,
+                        "verification_time_ms": 1,
+                        "dependency_time_ms": 0.5,
+                        "attempt_count": 1,
+                        "tool_call_count": 1,
+                        "validated_artifact_count": 1,
+                    }
+                },
+            }
+
+        monkeypatch.setattr(s2, "_execute_single_task", execute_with_metrics)
+        monkeypatch.setattr(
+            s2,
+            "_run_self_qa",
+            lambda *a, **k: {
+                "passed": True,
+                "score": 9,
+                "issues": [],
+                "suggestion": "",
+                "undetermined": False,
+                "llm_passed": True,
+            },
+        )
+
+        s2.run_inference(
+            condition_key="condition_a",
+            resume=False,
+            resume_max_rounds=1,
+        )
+
+        result = _read_progress(workspace)["results"][0]
+        metrics = result["observability"]["execution_metrics"]
+        assert metrics["schema_version"] == "1.0"
+        assert metrics["task_wall_time_ms"] >= 0
+        assert metrics["time_to_valid_artifact_ms"] is not None
+        assert metrics["model_time_ms"] == 4
+        assert metrics["tool_time_ms"] == 2
+        assert metrics["verification_time_ms"] == 1
+        assert metrics["dependency_time_ms"] == 0.5
+        assert metrics["self_qa_time_ms"] >= 0
+        assert metrics["orchestration_time_ms"] >= 0
+        assert metrics["execution_attempt_count"] == 1
+        assert metrics["sandbox_attempt_count"] == 1
+        assert metrics["tool_call_count"] == 1
+        assert metrics["self_qa_call_count"] == 1
+        assert metrics["job_run_count"] == 1
+        assert metrics["validated_artifact_count"] == 1
+
+    @pytest.mark.parametrize(
+        ("sandbox", "validated_count", "files"),
+        [
+            (None, 1, ["deliverable_files/t1/out.pdf"]),
+            ({"final_status": "ok"}, 0, ["deliverable_files/t1/manifest.json"]),
+        ],
+    )
+    def test_time_to_valid_artifact_requires_sandbox_verification_and_real_artifact(
+        self,
+        patched_run_inference,
+        monkeypatch,
+        sandbox,
+        validated_count,
+        files,
+    ):
+        s2, workspace = patched_run_inference
+        prepared_path = workspace / "step1_tasks_prepared.json"
+        prepared = json.loads(prepared_path.read_text(encoding="utf-8"))
+        prepared["execution"]["metrics"] = {"enabled": True}
+        prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
+
+        observability = {
+            "execution_metrics": {
+                "schema_version": "1.0",
+                "task_wall_time_ms": 10,
+                "validated_artifact_count": validated_count,
+            }
+        }
+        if sandbox is not None:
+            observability["sandbox"] = sandbox
+
+        monkeypatch.setattr(
+            s2,
+            "_execute_single_task",
+            lambda *a, **k: {
+                "task_id": "t1",
+                "status": "success",
+                "deliverable_text": "hello",
+                "deliverable_files": files,
+                "latency_ms": 10,
+                "observability": observability,
+            },
+        )
+        monkeypatch.setattr(
+            s2,
+            "_run_self_qa",
+            lambda *a, **k: {
+                "passed": True,
+                "score": 9,
+                "issues": [],
+                "suggestion": "",
+                "undetermined": False,
+                "llm_passed": True,
+            },
+        )
+
+        s2.run_inference(
+            condition_key="condition_a",
+            resume=False,
+            resume_max_rounds=1,
+        )
+
+        metrics = _read_progress(workspace)["results"][0]["observability"][
+            "execution_metrics"
+        ]
+        assert metrics["time_to_valid_artifact_ms"] is None
 
     def test_qa_undetermined_keeps_status_success(
         self, patched_run_inference, monkeypatch
     ):
-        """Undetermined-on-final-attempt → status remains "success" (intentional)."""
+        """Undetermined-on-final-attempt remains a successful task."""
         s2, workspace = patched_run_inference
 
         monkeypatch.setattr(s2, "_execute_single_task", self._success_execute)
@@ -498,9 +636,243 @@ class TestFix3RunTaskWithQA:
             resume_max_rounds=1,
         )
 
-        progress = _read_progress(workspace)
-        results = progress["results"]
+        results = _read_progress(workspace)["results"]
         assert len(results) == 1
-        # The undetermined branch must remain status="success" — fix 3 only
-        # touches the genuine-fail branch.
         assert results[0]["status"] == "success"
+
+
+def test_update_progress_result_accumulates_metrics_across_resume_rounds():
+    from step2_run_inference import _update_progress_result
+
+    progress = {
+        "results": [{
+            "task_id": "t1",
+            "status": "error",
+            "observability": {"execution_metrics": {
+                "schema_version": "1.0",
+                "task_wall_time_ms": 100,
+                "model_time_ms": 40,
+                "tool_time_ms": 20,
+                "verification_time_ms": 10,
+                "dependency_time_ms": 5,
+                "self_qa_time_ms": 0,
+                "orchestration_time_ms": 25,
+                "time_to_valid_artifact_ms": None,
+                "execution_attempt_count": 1,
+                "sandbox_attempt_count": 1,
+                "tool_call_count": 1,
+                "self_qa_call_count": 0,
+                "job_run_count": 1,
+            }},
+        }]
+    }
+    new_result = {
+        "task_id": "t1",
+        "status": "success",
+        "observability": {"execution_metrics": {
+            "schema_version": "1.0",
+            "task_wall_time_ms": 70,
+            "model_time_ms": 30,
+            "tool_time_ms": 15,
+            "verification_time_ms": 8,
+            "dependency_time_ms": 2,
+            "self_qa_time_ms": 5,
+            "orchestration_time_ms": 10,
+            "time_to_valid_artifact_ms": 60,
+            "execution_attempt_count": 1,
+            "sandbox_attempt_count": 2,
+            "tool_call_count": 2,
+            "self_qa_call_count": 1,
+            "job_run_count": 1,
+        }},
+    }
+
+    merged = _update_progress_result(progress, new_result)
+    metrics = merged["results"][0]["observability"]["execution_metrics"]
+    assert metrics["task_wall_time_ms"] == 170
+    assert metrics["model_time_ms"] == 70
+    assert metrics["tool_time_ms"] == 35
+    assert metrics["orchestration_time_ms"] == 35
+    assert metrics["time_to_valid_artifact_ms"] == 160
+    assert metrics["execution_attempt_count"] == 2
+    assert metrics["sandbox_attempt_count"] == 3
+    assert metrics["tool_call_count"] == 3
+    assert metrics["self_qa_call_count"] == 1
+    assert metrics["job_run_count"] == 2
+
+
+def test_bounded_execution_metrics_rejects_invalid_time_to_valid_and_counts():
+    from step2_run_inference import _bounded_execution_metrics
+
+    bounded = _bounded_execution_metrics({
+        "schema_version": "untrusted",
+        "task_wall_time_ms": 100,
+        "time_to_valid_artifact_ms": 101,
+        "tool_call_count": 1.0,
+        "self_qa_call_count": "1",
+        "job_run_count": 1,
+    })
+
+    assert bounded["schema_version"] == "1.0"
+    assert bounded["time_to_valid_artifact_ms"] is None
+    assert "tool_call_count" not in bounded
+    assert "self_qa_call_count" not in bounded
+    assert bounded["job_run_count"] == 1
+
+
+def test_bounded_execution_metrics_rejects_giant_json_integer_without_raising():
+    from step2_run_inference import _bounded_execution_metrics
+
+    assert _bounded_execution_metrics({
+        "schema_version": "1.0",
+        "task_wall_time_ms": 10**400,
+        "job_run_count": 1,
+    }) is None
+
+
+def test_merge_execution_metrics_overflow_falls_back_to_current_run():
+    from core.execution_metrics import MAX_DURATION_MS
+    from step2_run_inference import _merge_execution_metrics
+
+    previous = {
+        "schema_version": "1.0",
+        "task_wall_time_ms": MAX_DURATION_MS,
+        "job_run_count": 1,
+    }
+    current = {
+        "schema_version": "1.0",
+        "task_wall_time_ms": 1,
+        "job_run_count": 1,
+    }
+
+    merged = _merge_execution_metrics(previous, current)
+    assert merged["task_wall_time_ms"] == 1
+    assert merged["job_run_count"] == 1
+    assert merged["time_to_valid_artifact_ms"] is None
+
+
+def test_resume_timeout_relay_preserves_cumulative_task_metrics(
+    patched_run_inference, monkeypatch
+):
+    s2, workspace = patched_run_inference
+    prepared_path = workspace / "step1_tasks_prepared.json"
+    prepared = json.loads(prepared_path.read_text(encoding="utf-8"))
+    prepared["execution"]["mode"] = "sandbox"
+    prepared["execution"]["metrics"] = {"enabled": True}
+    prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
+
+    progress = {
+        "experiment_id": "exp_test",
+        "condition": "test_condition",
+        "execution_mode": "sandbox",
+        "started_at": "2026-07-15T00:00:00+00:00",
+        "resume_round": 0,
+        "results": [{
+            "task_id": "t1",
+            "status": "error",
+            "error": "initial failure",
+            "observability": {"execution_metrics": {
+                "schema_version": "1.0",
+                "task_wall_time_ms": 100,
+                "model_time_ms": 40,
+                "tool_time_ms": 20,
+                "verification_time_ms": 10,
+                "dependency_time_ms": 5,
+                "self_qa_time_ms": 0,
+                "orchestration_time_ms": 25,
+                "time_to_valid_artifact_ms": None,
+                "execution_attempt_count": 1,
+                "sandbox_attempt_count": 1,
+                "tool_call_count": 1,
+                "self_qa_call_count": 0,
+                "job_run_count": 1,
+                "validated_artifact_count": 0,
+            }},
+        }],
+    }
+    (workspace / "step2_inference_progress.json").write_text(
+        json.dumps(progress),
+        encoding="utf-8",
+    )
+
+    first_time_values = iter([0, 61])
+    monkeypatch.setattr(s2.time, "time", lambda: next(first_time_values))
+    with pytest.raises(SystemExit) as exit_info:
+        s2.run_inference(
+            condition_key="condition_a",
+            resume=True,
+            resume_max_rounds=1,
+            wall_timeout=1,
+        )
+    assert exit_info.value.code == s2.EXIT_CHECKPOINT
+
+    checkpoint = _read_progress(workspace)
+    assert len(checkpoint["results"]) == 1
+    assert checkpoint["results"][0]["status"] == "pending"
+    assert checkpoint["results"][0]["observability"]["execution_metrics"][
+        "task_wall_time_ms"
+    ] == 100
+
+    monkeypatch.setattr(s2.time, "time", lambda: 0)
+    perf_values = iter([0, 0.060, 0.061, 0.066, 0.070])
+    monkeypatch.setattr(s2.time, "perf_counter", lambda: next(perf_values))
+    monkeypatch.setattr(
+        s2,
+        "_execute_single_task",
+        lambda *a, **k: {
+            "task_id": "t1",
+            "status": "success",
+            "deliverable_text": "recovered",
+            "deliverable_files": ["deliverable_files/t1/out.pdf"],
+            "latency_ms": 10,
+            "observability": {
+                "sandbox": {"final_status": "ok"},
+                "execution_metrics": {
+                    "schema_version": "1.0",
+                    "task_wall_time_ms": 55,
+                    "model_time_ms": 30,
+                    "tool_time_ms": 15,
+                    "verification_time_ms": 8,
+                    "dependency_time_ms": 2,
+                    "attempt_count": 2,
+                    "tool_call_count": 2,
+                    "validated_artifact_count": 1,
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(
+        s2,
+        "_run_self_qa",
+        lambda *a, **k: {
+            "passed": True,
+            "score": 9,
+            "issues": [],
+            "suggestion": "",
+            "undetermined": False,
+            "llm_passed": True,
+        },
+    )
+
+    s2.run_inference(
+        condition_key="condition_a",
+        resume=True,
+        resume_max_rounds=1,
+        wall_timeout=1,
+    )
+
+    final_progress = _read_progress(workspace)
+    assert len(final_progress["results"]) == 1
+    result = final_progress["results"][0]
+    assert result["status"] == "success"
+    metrics = result["observability"]["execution_metrics"]
+    assert metrics["task_wall_time_ms"] == 170
+    assert metrics["model_time_ms"] == 70
+    assert metrics["tool_time_ms"] == 35
+    assert metrics["time_to_valid_artifact_ms"] == 160
+    assert metrics["execution_attempt_count"] == 2
+    assert metrics["sandbox_attempt_count"] == 3
+    assert metrics["tool_call_count"] == 3
+    assert metrics["self_qa_call_count"] == 1
+    assert metrics["job_run_count"] == 2
+    assert metrics["validated_artifact_count"] == 1

--- a/batch-runner/tests/test_step3_format_results.py
+++ b/batch-runner/tests/test_step3_format_results.py
@@ -1,0 +1,41 @@
+"""Strict JSON output tests for Step 3 formatting."""
+
+import json
+import math
+
+import pytest
+
+from step3_format_results import _write_json_outputs
+
+
+def test_write_json_outputs_rejects_nan_before_opening_destinations(tmp_path):
+    result_path = tmp_path / "results" / "result.json"
+    workspace_path = tmp_path / "workspace" / "result.json"
+
+    with pytest.raises(ValueError, match="Out of range float values"):
+        _write_json_outputs(
+            {"observability": {"execution_metrics": {"task_wall_time_ms": math.nan}}},
+            result_path,
+            workspace_path,
+        )
+
+    assert not result_path.exists()
+    assert not workspace_path.exists()
+
+
+def test_write_json_outputs_writes_identical_standard_json(tmp_path):
+    result_path = tmp_path / "results" / "result.json"
+    workspace_path = tmp_path / "workspace" / "result.json"
+    payload = {
+        "observability": {
+            "execution_metrics": {
+                "schema_version": "1.0",
+                "task_wall_time_ms": 123.45,
+            }
+        }
+    }
+
+    _write_json_outputs(payload, result_path, workspace_path)
+
+    assert result_path.read_bytes() == workspace_path.read_bytes()
+    assert json.loads(result_path.read_text(encoding="utf-8")) == payload

--- a/batch-runner/tests/test_step6_v2_fields.py
+++ b/batch-runner/tests/test_step6_v2_fields.py
@@ -332,10 +332,14 @@ def test_build_task_results_no_manifest_omits_v2_fields():
 # ──────────────────────────────────────────────────────────────────────────
 
 
-def _write_workspace(tmp_path: Path, manifest_data: dict | None) -> tuple[Path, Path]:
+def _write_workspace(
+    tmp_path: Path,
+    manifest_data: dict | None,
+    result_payload: dict | None = None,
+) -> tuple[Path, Path]:
     """Lay out a minimal workspace and return (result_json, output_dir)."""
     tmp_path.mkdir(parents=True, exist_ok=True)
-    result_payload = _make_result_payload()
+    result_payload = result_payload or _make_result_payload()
     result_json = tmp_path / "result.json"
     result_json.write_text(json.dumps(result_payload), encoding="utf-8")
 
@@ -349,7 +353,12 @@ def _write_workspace(tmp_path: Path, manifest_data: dict | None) -> tuple[Path, 
     return result_json, output_dir
 
 
-def _run_step6(monkeypatch, tmp_path: Path, manifest_data: dict | None) -> dict:
+def _run_step6(
+    monkeypatch,
+    tmp_path: Path,
+    manifest_data: dict | None,
+    result_payload: dict | None = None,
+) -> dict:
     """Run ``generate_report`` against an isolated workspace and return the
     parsed ``report_data.json`` dict."""
     monkeypatch.setattr(step6_report, "WORKSPACE_DIR", tmp_path)
@@ -360,7 +369,11 @@ def _run_step6(monkeypatch, tmp_path: Path, manifest_data: dict | None) -> dict:
     monkeypatch.setattr(core_config, "WORKSPACE_DIR", tmp_path)
     monkeypatch.setattr(core_needs_files, "WORKSPACE_DIR", tmp_path)
 
-    result_json, output_dir = _write_workspace(tmp_path, manifest_data)
+    result_json, output_dir = _write_workspace(
+        tmp_path,
+        manifest_data,
+        result_payload=result_payload,
+    )
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)
@@ -443,6 +456,93 @@ def test_generate_report_no_manifest_omits_v2_fields(monkeypatch, tmp_path):
     assert "active_policy" not in fg
     assert "policy_counts" not in fg
     assert "confidence_distribution" not in fg
+    assert "execution_metrics" not in rd
+
+
+def test_generate_report_adds_execution_metrics_only_when_measured(monkeypatch, tmp_path):
+    payload = _make_result_payload()
+    payload["results"][0]["observability"] = {
+        "execution_metrics": {
+            "schema_version": "1.0",
+            "task_wall_time_ms": 100,
+            "time_to_valid_artifact_ms": 90,
+            "model_time_ms": 40,
+            "tool_time_ms": 20,
+            "verification_time_ms": 10,
+            "dependency_time_ms": 5,
+            "self_qa_time_ms": 8,
+            "orchestration_time_ms": 17,
+            "execution_attempt_count": 1,
+            "sandbox_attempt_count": 1,
+            "tool_call_count": 1,
+            "self_qa_call_count": 1,
+            "job_run_count": 1,
+            "validated_artifact_count": 1,
+        }
+    }
+    payload["results"][1]["status"] = "error"
+    payload["results"][1]["observability"] = {
+        "execution_metrics": {
+            "schema_version": "1.0",
+            "task_wall_time_ms": 300,
+            "time_to_valid_artifact_ms": None,
+            "model_time_ms": 100,
+            "tool_time_ms": 80,
+            "verification_time_ms": 20,
+            "dependency_time_ms": 7,
+            "self_qa_time_ms": 15,
+            "orchestration_time_ms": 78,
+            "execution_attempt_count": 2,
+            "sandbox_attempt_count": 3,
+            "tool_call_count": 3,
+            "self_qa_call_count": 2,
+            "job_run_count": 2,
+            "validated_artifact_count": 0,
+        }
+    }
+
+    rd = _run_step6(
+        monkeypatch,
+        tmp_path,
+        manifest_data=None,
+        result_payload=payload,
+    )
+
+    metrics = rd["execution_metrics"]
+    assert metrics["measured_tasks"] == 2
+    assert metrics["total_tasks"] == 2
+    assert metrics["coverage_pct"] == 100.0
+    assert metrics["avg_task_wall_time_ms"] == 200
+    assert metrics["p50_task_wall_time_ms"] == 200
+    assert metrics["p95_task_wall_time_ms"] == 290
+    assert metrics["max_task_wall_time_ms"] == 300
+    assert metrics["avg_successful_task_wall_time_ms"] == 100
+    assert metrics["avg_failed_task_wall_time_ms"] == 300
+    assert metrics["avg_time_to_valid_artifact_ms"] == 90
+    assert metrics["total_model_time_ms"] == 140
+    assert metrics["total_tool_time_ms"] == 100
+    assert metrics["total_verification_time_ms"] == 30
+    assert metrics["total_dependency_time_ms"] == 12
+    assert metrics["total_self_qa_time_ms"] == 23
+    assert metrics["total_orchestration_time_ms"] == 95
+    assert metrics["total_execution_attempts"] == 3
+    assert metrics["total_sandbox_attempts"] == 4
+    assert metrics["total_tool_calls"] == 4
+    assert metrics["total_self_qa_calls"] == 3
+    assert metrics["total_job_runs"] == 3
+    assert rd["task_results"][0]["observability"]["execution_metrics"]["task_wall_time_ms"] == 100
+
+
+def test_compute_execution_metrics_ignores_giant_json_integer():
+    payload = _make_result_payload()
+    payload["results"][0]["observability"] = {
+        "execution_metrics": {
+            "schema_version": "1.0",
+            "task_wall_time_ms": 10**400,
+        }
+    }
+
+    assert step6_report._compute_execution_metrics(payload) is None
 
 
 def test_generate_report_v2_vs_v1_preserves_v1_task_keys(monkeypatch, tmp_path):

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "aggregate": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
-    "test:aggregate": "node --test scripts/__tests__/aggregate-grades.test.mjs scripts/__tests__/official-filter.test.mjs",
+    "test:aggregate": "node --test scripts/__tests__/aggregate-experiments.test.mjs scripts/__tests__/aggregate-grades.test.mjs scripts/__tests__/official-filter.test.mjs",
     "test:official-filter": "node --test scripts/__tests__/official-filter.test.mjs",
     "predev": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
     "dev": "vite",

--- a/scripts/__tests__/aggregate-experiments.test.mjs
+++ b/scripts/__tests__/aggregate-experiments.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { normalizeExecutionMetrics } from '../aggregate-experiments.mjs'
+
+
+test('execution metrics require literal boolean true', () => {
+  assert.equal(normalizeExecutionMetrics(undefined), null)
+  assert.equal(normalizeExecutionMetrics(null), null)
+  assert.equal(normalizeExecutionMetrics({}), null)
+  assert.equal(normalizeExecutionMetrics({ enabled: false }), null)
+  assert.equal(normalizeExecutionMetrics({ enabled: 'false' }), null)
+  assert.equal(normalizeExecutionMetrics({ enabled: 1 }), null)
+})
+
+
+test('execution metrics discard undeclared fields when enabled', () => {
+  assert.deepEqual(
+    normalizeExecutionMetrics({ enabled: true, raw_output: 'must-not-leak' }),
+    { enabled: true },
+  )
+})

--- a/scripts/aggregate-experiments.mjs
+++ b/scripts/aggregate-experiments.mjs
@@ -8,13 +8,20 @@
  */
 
 import { readdir, readFile, writeFile, mkdir } from 'fs/promises';
-import { join } from 'path';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { parse as parseYaml } from 'yaml';
 
 const ROOT = new URL('..', import.meta.url).pathname;
 const EXPERIMENTS_DIR = join(ROOT, 'batch-runner', 'experiments');
 const PROMPTS_DIR = join(ROOT, 'batch-runner', 'prompts');
 const OUTPUT_DIR = join(ROOT, 'public', 'generated');
+
+export function normalizeExecutionMetrics(value) {
+  return value && typeof value === 'object' && value.enabled === true
+    ? { enabled: true }
+    : null;
+}
 
 async function main() {
   console.log('📦 Aggregating experiment prompt architectures...');
@@ -32,6 +39,7 @@ async function main() {
     const prompt = condition.prompt || {};
     const qa = condition.qa || {};
     const execution = expData.execution || {};
+    const metrics = normalizeExecutionMetrics(execution.metrics);
 
     experiments.push({
       exp_id: expData.experiment?.id || file.replace('.yaml', ''),
@@ -66,6 +74,7 @@ async function main() {
           resume_max_rounds: execution.resume_max_rounds ?? null,
           max_retries: execution.max_retries || 5,
           install_libreoffice: execution.install_libreoffice || false,
+          ...(metrics ? { metrics } : {}),
         },
       },
     });
@@ -79,4 +88,6 @@ async function main() {
   console.log(`   ✅ ${outputPath} (${experiments.length} experiments, ${(Buffer.byteLength(JSON.stringify(output, null, 2)) / 1024).toFixed(1)}KB)`);
 }
 
-main().catch(err => { console.error('❌ Aggregation failed:', err); process.exit(1); });
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch(err => { console.error('❌ Aggregation failed:', err); process.exit(1); });
+}

--- a/src/components/dashboard/PromptArchitectureView.tsx
+++ b/src/components/dashboard/PromptArchitectureView.tsx
@@ -149,6 +149,7 @@ export default function PromptArchitectureView({ prompt, shortId: _shortId }: { 
             { l: 'resume_rounds', v: ec.resume_max_rounds ?? '—' },
             { l: 'max_retries', v: ec.max_retries },
             { l: 'libreoffice', v: ec.install_libreoffice ? '✅' : '—' },
+            ...(ec.metrics ? [{ l: 'job_metrics', v: ec.metrics.enabled ? 'enabled' : 'disabled' }] : []),
           ].map(({ l, v }) => (
             <div key={l} className="flex justify-between">
               <span className="text-dash-text-muted">{l}</span>

--- a/src/hooks/useExperimentPrompt.ts
+++ b/src/hooks/useExperimentPrompt.ts
@@ -18,6 +18,7 @@ export interface PromptArchitecture {
     resume_max_rounds: number | null
     max_retries: number
     install_libreoffice: boolean
+    metrics?: { enabled?: boolean }
   }
 }
 

--- a/src/pages/ExperimentDetail.tsx
+++ b/src/pages/ExperimentDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   ArrowLeft, CheckCircle2, XCircle, RefreshCw,
-  X, Search, Sun, Moon, Code2, ChevronDown, ChevronRight,
+  X, Search, Sun, Moon, Code2, ChevronDown, ChevronRight, Timer,
 } from 'lucide-react'
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
@@ -34,6 +34,16 @@ function qaColor(score: number | null) {
   return '#ef4444'
 }
 
+function formatDuration(ms: number | null | undefined) {
+  if (ms == null) return '—'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const totalSeconds = Math.round(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}m ${seconds}s`
+}
+
 // Grade-derived scope wins over the meta-recorded scope when a grade row
 // exists for this experiment (match by exact experiment_id, never startsWith).
 function resolveScope(
@@ -48,7 +58,7 @@ function resolveScope(
   return 'self_assessed_pre_grading'
 }
 
-type SortKey = 'task_id' | 'sector' | 'occupation' | 'status' | 'qa_score' | 'latency_ms'
+type SortKey = 'task_id' | 'sector' | 'occupation' | 'status' | 'qa_score' | 'latency_ms' | 'task_wall_time_ms'
 type SortDir = 'asc' | 'desc'
 
 function ExperimentDetail() {
@@ -111,12 +121,16 @@ function ExperimentDetail() {
           ? a.qa_score ?? -1
           : sortKey === 'latency_ms'
             ? a.latency_ms
+            : sortKey === 'task_wall_time_ms'
+              ? a.observability?.execution_metrics?.task_wall_time_ms ?? -1
             : (a as any)[sortKey]
       const bv =
         sortKey === 'qa_score'
           ? b.qa_score ?? -1
           : sortKey === 'latency_ms'
             ? b.latency_ms
+            : sortKey === 'task_wall_time_ms'
+              ? b.observability?.execution_metrics?.task_wall_time_ms ?? -1
             : (b as any)[sortKey]
       if (av < bv) return sortDir === 'asc' ? -1 : 1
       if (av > bv) return sortDir === 'asc' ? 1 : -1
@@ -314,6 +328,62 @@ function ExperimentDetail() {
                   <div key={i}>
                     <div className="text-[10px] text-dash-text-muted uppercase mb-0.5">{m.label}</div>
                     <div className="text-dash-text font-mono font-semibold">{m.value}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </motion.div>
+        )}
+
+        {report.execution_metrics && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.09 }}
+            className="bg-dash-card border border-dash-border rounded-xl overflow-hidden mb-6"
+          >
+            <div className="px-4 py-3 border-b border-dash-border flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold text-dash-heading flex items-center gap-2">
+                <Timer className="h-4 w-4 text-emerald-500" />
+                Job Performance
+              </h3>
+              <span className="text-[10px] text-dash-text-muted font-mono">
+                {report.execution_metrics.measured_tasks}/{report.execution_metrics.total_tasks} measured
+              </span>
+            </div>
+            <div className="p-4">
+              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-x-5 gap-y-4 text-xs">
+                {[
+                  { label: 'Avg Job Time', value: formatDuration(report.execution_metrics.avg_task_wall_time_ms) },
+                  { label: 'P50 Job Time', value: formatDuration(report.execution_metrics.p50_task_wall_time_ms) },
+                  { label: 'P95 Job Time', value: formatDuration(report.execution_metrics.p95_task_wall_time_ms) },
+                  { label: 'Time to Valid File', value: formatDuration(report.execution_metrics.avg_time_to_valid_artifact_ms) },
+                  { label: 'Successful Job Avg', value: formatDuration(report.execution_metrics.avg_successful_task_wall_time_ms) },
+                  { label: 'Failed Job Avg', value: formatDuration(report.execution_metrics.avg_failed_task_wall_time_ms) },
+                ].map((metric) => (
+                  <div key={metric.label}>
+                    <div className="text-[10px] text-dash-text-muted uppercase mb-0.5">{metric.label}</div>
+                    <div className="text-dash-text font-mono font-semibold">{metric.value}</div>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-4 pt-4 border-t border-dash-border-subtle grid grid-cols-2 md:grid-cols-5 gap-x-5 gap-y-3 text-xs">
+                {[
+                  { label: 'Model', value: formatDuration(report.execution_metrics.total_model_time_ms) },
+                  { label: 'Tools', value: formatDuration(report.execution_metrics.total_tool_time_ms) },
+                  { label: 'Verification', value: formatDuration(report.execution_metrics.total_verification_time_ms) },
+                  { label: 'Dependencies', value: formatDuration(report.execution_metrics.total_dependency_time_ms) },
+                  { label: 'Self-QA', value: formatDuration(report.execution_metrics.total_self_qa_time_ms) },
+                  { label: 'Orchestration', value: formatDuration(report.execution_metrics.total_orchestration_time_ms) },
+                  { label: 'Execution Attempts', value: report.execution_metrics.total_execution_attempts },
+                  { label: 'Sandbox Attempts', value: report.execution_metrics.total_sandbox_attempts },
+                  { label: 'Tool Calls', value: report.execution_metrics.total_tool_calls },
+                  { label: 'Self-QA Calls', value: report.execution_metrics.total_self_qa_calls },
+                  { label: 'Coverage', value: `${report.execution_metrics.coverage_pct.toFixed(1)}%` },
+                ].map((metric) => (
+                  <div key={metric.label} className="flex justify-between md:block gap-2">
+                    <span className="text-dash-text-muted">{metric.label}</span>
+                    <span className="text-dash-text font-mono md:block md:mt-0.5">{metric.value}</span>
                   </div>
                 ))}
               </div>
@@ -785,6 +855,11 @@ function ExperimentDetail() {
                   <th className="px-3 py-2 text-right cursor-pointer" onClick={() => handleSort('latency_ms')}>
                     Latency
                   </th>
+                  {report.execution_metrics && (
+                    <th className="px-3 py-2 text-right cursor-pointer" onClick={() => handleSort('task_wall_time_ms')}>
+                      Job Time
+                    </th>
+                  )}
                 </tr>
               </thead>
               <tbody>
@@ -824,6 +899,11 @@ function ExperimentDetail() {
                     <td className="px-3 py-2 text-right font-mono text-dash-text-muted">
                       {task.latency_ms ? `${(task.latency_ms / 1000).toFixed(1)}s` : '—'}
                     </td>
+                    {report.execution_metrics && (
+                      <td className="px-3 py-2 text-right font-mono text-dash-text-muted">
+                        {formatDuration(task.observability?.execution_metrics?.task_wall_time_ms)}
+                      </td>
+                    )}
                   </tr>
                 ))}
               </tbody>
@@ -842,6 +922,7 @@ function ExperimentDetail() {
 
 function TaskDetailModal({ task, experimentId, onClose }: { task: TaskResult; experimentId?: string; onClose: () => void }) {
   const [showPrompt, setShowPrompt] = useState(false)
+  const executionMetrics = task.observability?.execution_metrics
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -868,6 +949,7 @@ function TaskDetailModal({ task, experimentId, onClose }: { task: TaskResult; ex
             )}
             <span className="text-sm font-semibold text-dash-heading font-mono break-all">{task.task_id}</span>
           </div>
+
           <button onClick={onClose} className="text-dash-text-muted hover:text-dash-heading p-1 rounded hover:bg-dash-card-hover">
             <X className="h-4 w-4" />
           </button>
@@ -893,6 +975,32 @@ function TaskDetailModal({ task, experimentId, onClose }: { task: TaskResult; ex
               <div className="text-dash-text font-mono">{task.latency_ms ? `${(task.latency_ms / 1000).toFixed(1)}s` : '—'}</div>
             </div>
           </div>
+
+          {executionMetrics && (
+            <div className="border border-dash-border rounded-lg p-3">
+              <div className="text-[10px] text-dash-text-muted uppercase mb-2 flex items-center gap-1.5">
+                <Timer className="h-3 w-3" /> Job Performance
+              </div>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                {[
+                  { label: 'Job Time', value: formatDuration(executionMetrics.task_wall_time_ms) },
+                  { label: 'Time to Valid File', value: formatDuration(executionMetrics.time_to_valid_artifact_ms) },
+                  { label: 'Model', value: formatDuration(executionMetrics.model_time_ms) },
+                  { label: 'Tools', value: formatDuration(executionMetrics.tool_time_ms) },
+                  { label: 'Verification', value: formatDuration(executionMetrics.verification_time_ms) },
+                  { label: 'Self-QA', value: formatDuration(executionMetrics.self_qa_time_ms) },
+                  { label: 'Orchestration', value: formatDuration(executionMetrics.orchestration_time_ms) },
+                  { label: 'Execution Attempts', value: executionMetrics.execution_attempt_count },
+                  { label: 'Tool Calls', value: executionMetrics.tool_call_count },
+                ].map((metric) => (
+                  <div key={metric.label} className="flex justify-between gap-2 border-b border-dash-border-subtle py-1 last:border-0">
+                    <span className="text-dash-text-muted">{metric.label}</span>
+                    <span className="text-dash-text font-mono">{metric.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* ★ Error Message (for error tasks) ★ */}
           {task.status === 'error' && task.error && (

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -28,6 +28,56 @@ export interface TaskResult {
   prompt_classification?: PromptClassification | null
   policy_results?: Record<string, boolean> | null
   has_deliverable_files?: boolean | null
+  observability?: {
+    execution_metrics?: TaskExecutionMetrics
+    [key: string]: unknown
+  }
+}
+
+export interface TaskExecutionMetrics {
+  schema_version: string
+  task_wall_time_ms: number
+  time_to_valid_artifact_ms: number | null
+  model_time_ms: number
+  tool_time_ms: number
+  verification_time_ms: number
+  dependency_time_ms: number
+  self_qa_time_ms: number
+  orchestration_time_ms: number
+  execution_attempt_count: number
+  sandbox_attempt_count: number
+  tool_call_count: number
+  self_qa_call_count: number
+  job_run_count: number
+  validated_artifact_count: number
+}
+
+export interface ExecutionMetricsSummary {
+  schema_version: string
+  measured_tasks: number
+  total_tasks: number
+  coverage_pct: number
+  avg_task_wall_time_ms: number
+  p50_task_wall_time_ms: number
+  p95_task_wall_time_ms: number
+  max_task_wall_time_ms: number
+  avg_successful_task_wall_time_ms: number | null
+  avg_failed_task_wall_time_ms: number | null
+  measured_time_to_valid_artifact_tasks: number
+  avg_time_to_valid_artifact_ms: number | null
+  p50_time_to_valid_artifact_ms: number | null
+  p95_time_to_valid_artifact_ms: number | null
+  total_model_time_ms: number
+  total_tool_time_ms: number
+  total_verification_time_ms: number
+  total_dependency_time_ms: number
+  total_self_qa_time_ms: number
+  total_orchestration_time_ms: number
+  total_execution_attempts: number
+  total_sandbox_attempts: number
+  total_tool_calls: number
+  total_self_qa_calls: number
+  total_job_runs: number
 }
 
 export interface PromptClassification {
@@ -128,6 +178,7 @@ export interface ReportData {
   narrative: Narrative
   recovery_stats: RecoveryStats
   file_generation?: FileGeneration
+  execution_metrics?: ExecutionMetricsSummary
   /** task_id → Self-QA score (0–10). Enriched in scripts/aggregate-reports.mjs for Phase 1 calibration. */
   task_qa?: Record<string, number>
 }

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,73 +1,71 @@
 # Latest Task Result
 
 - Updated: 2026-07-15
-- Status: GitHub-hosted renderer preflight passed
+- Status: Implemented and validated; merge pending
 
 ## Task
 
-- Add a model-free GitHub-hosted LibreOffice preflight for the Track 2 grading
-  renderer.
-- Keep the preflight manual, read-only, secret-free, and isolated from HF,
-  Azure, batch inference, and paid model calls.
-- Share the renderer Python dependency declaration with the production grading
-  environment so both paths exercise the same package constraints.
+Add job-performance metrics for the next sandbox experiment while keeping
+existing experiment JSON and dashboard behavior unchanged when metrics are not
+available.
 
 ## Result
 
-- Preflight workflow PR #73 was squash-merged to `main` as `fa8bf4f1` and
-  model-free run
-  [29392707519](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29392707519)
-  was dispatched. LibreOffice/font installation and renderer Python dependency
-  installation succeeded; no Azure, HF, batch, or model step existed.
-- The first run failed before rendering because direct execution from
-  `batch-runner/scripts` could not import `core`. The uploaded failure artifact
-  preserved that evidence. The script now inserts its own batch-runner root and
-  bootstraps only the lightweight `core.tools` namespace, avoiding unrelated
-  dataset/pyarrow imports.
-- Import fix PR #74 was squash-merged as `f97cc170`. The model-free rerun
-  [29393149367](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29393149367)
-  then completed successfully on that exact `main` SHA. Every workflow step,
-  including seven-day evidence artifact upload, passed.
-- Added `.github/workflows/grading-renderer-preflight.yml`, dispatched manually
-  on `main` only with `contents: read`, no environment, no OIDC, and no secret
-  references. Checkout, Python setup, and artifact upload actions are pinned to
-  full commits.
-- The workflow installs LibreOffice Calc/Impress plus the exact font surface,
-  runs the existing synthetic XLSX/PPTX renderer probe, requires both process
-  success and JSON `ok=true`, and retains the compact evidence JSON for seven
-  days even when the probe fails.
-- Added `batch-runner/requirements-renderer.txt`; full batch dependencies now
-  include this shared file instead of declaring the four renderer packages in
-  separate sections.
-- Added a static workflow contract test covering trigger, permissions, action
-  allowlist, package surface, result handling, and the absence of credential,
-  model, grading, and Git-write paths.
+- Added explicit opt-in configuration through `execution.metrics.enabled` and
+  preserved it through config parsing, Step 1, executor construction, and the
+  prompt-architecture index. Only the literal boolean `true` enables metrics;
+  omitted, false, malformed, or string values do not emit metric keys, and
+  undeclared fields are discarded.
+- Sandbox attempts now measure model, tool, verification, and dependency time.
+  Step 2 aggregates those measurements across sandbox repair and Self-QA
+  regeneration, adds orchestration time, and preserves cumulative task lifetime
+  across resume rounds.
+- `time_to_valid_artifact_ms` is recorded only after a file is saved and the
+  sandbox reports `ok` or `repaired_ok` with at least one verified non-manifest
+  artifact. Text-only, manifest-only, and unsuccessful file tasks retain `null`.
+- Duration and count fields use finite 30-day/1,000,000 schema bounds, strict
+  integer counters, overflow-safe resume merging, and `allow_nan=False` JSON
+  serialization so persisted output remains standards-compliant. Giant JSON
+  integers are rejected before float conversion instead of raising overflow.
+- Wall-timeout checkpoints retain the original pending task object and relay
+  completion replaces it through the normal merge path, preserving prior phase
+  time, counts, job runs, and time-to-valid offsets without duplicate rows.
+- Step 3 strictly serializes the final result once before opening either output
+  file; invalid NaN/Infinity values cannot update one result while leaving the
+  other stale.
+- Step 6 emits an optional aggregate only when measured data exists: coverage,
+  average/P50/P95/max job time, successful and failed job averages,
+  time-to-valid-file, phase totals, and execution/tool/Self-QA/job-run counts.
+- The experiment detail page conditionally renders Job Performance metrics, a
+  sortable Job Time column, and per-task timing details. Legacy reports keep the
+  existing table, modal, and metric cards without placeholders for new fields.
+- Added sandbox documentation for enabling and interpreting the metrics. No
+  existing experiment config or result fixture was rewritten, and no paid model,
+  batch, grading, or canary run was dispatched.
 
 ## Verification
 
-- Batch-runner non-integration regression coverage: **1,081 passed**, 5
-  skipped, and 37 deselected. This combines the broad suite, seven
-  data-module suites, and the actual-parquet selector suite without overlap.
-- Workflow contract, renderer script, and read-deliverable focused coverage is
-  included in that total. After the import fix, its direct run completed with
-  **63 passed**.
-- Overlay-free direct execution now emits one valid JSON line and reaches the
-  expected local `RendererDependencyError` because this SSH host has no
-  LibreOffice; it no longer raises `ModuleNotFoundError` for `core` or
-  `pyarrow`.
-- Shared renderer requirements include and package set were verified, and all
-  four declarations parse successfully with the standard requirement parser.
-- `git diff --check` passed.
-- `extreme-reasoner` approved the no-secret/no-cost workflow design with the
-  shared dependency and action-pinning conditions implemented.
-- Hosted evidence reported `ok=true`, exact font family `Liberation Sans`,
-  LibreOffice `24.2.7.2 420(Build:2)`, and PyMuPDF `1.28.0`. The synthetic XLSX
-  first workbook page rendered to a 17,358-byte PNG; PPTX slide 1 rendered to
-  an 18,637-byte PNG.
-- Run head SHA matched `f97cc170c1d3f79d7cadde24ae14d12682d1eabe`.
+- Latest-main integrated real-dependency regression: 200 passed, 1 skipped, 0
+  failed under Python 3.11 with installed `pyarrow`, `datasets`,
+  `huggingface_hub`, and `psutil`; no global dependency stubs were used. This
+  includes the renderer preflight tests added through main commit `129d13f2`.
+- Dashboard aggregate tests: 21 passed, 0 failed.
+- Focused review-fix tests cover strict opt-in normalization, numeric bounds,
+  overflow fallback, manifest-only exclusion, restored QA test collection,
+  resume-timeout relay accumulation, and Step 3 strict dual-output writes.
+- Python compilation, editor diagnostics, and `git diff --check`: passed.
+- TypeScript compilation and production Vite build: passed.
+- Browser-verified a metrics-enabled fixture at desktop and 390px mobile widths:
+  aggregate panel, Job Time column, sorting surface, and task modal values render.
+- Browser-verified a legacy fixture: zero Job Performance panels, zero Job Time
+  columns, and the existing Latency column remains visible.
+- Existing generated report data remains unchanged unless an experiment opts in.
 
 ## Remaining Work
 
-- This preflight does not approve paid grading. The limited Azure vision canary
-  remains a separate owner-approved step after renderer success.
-- No HF/Azure request, batch run, or model call has been performed.
+- Enable `execution.metrics.enabled: true` in the next experiment YAML; existing
+  experiment definitions intentionally remain unchanged.
+- Run an owner-approved bounded canary to validate live timing distributions
+  before using them for model or agent comparisons.
+- The proposed free-form tool-calling/install loop is a separate execution-mode
+  change and still needs an allowlisted package broker, budgets, and an A/B run.


### PR DESCRIPTION
This PR introduces opt-in job performance metrics.

### Key Details:
- **Opt-in Key**: Literal `execution.metrics.enabled: true` opt-in.
- **Legacy Compatibility**: Legacy configs, manifests, results, and dashboards emit no new metric keys when the key is absent.
- **Tracked Metrics**: Wall/model/tool/verification/dependency/Self-QA/orchestration timings, verified time-to-valid, and retry/tool counts.
- **Format & Reliability**: Strict bounded standard JSON with timeout/relay accumulation.
- **UI Features**: Conditional dashboard panel, job-time column, and task modal.
- **Validation**: Verified on integrated latest main using no-network real-dependency Docker Python 3.11 with 200 passed, 1 skipped; Node 21 passed, production build, and browser desktop/mobile metrics and legacy paths. First-reviewer APPROVE of these changes is expected/supported. No paid model/batch/grading/canary was run.
- **Documentation**: CHANGELOG and LATEST_TASK_RESULT have been updated.

Create PR only; do not merge, edit files, push, trigger workflows manually, delete branch, or use admin override.