### PR TITLE
docs: finalize job metrics rollout status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ entries land under a fresh dated heading the day they merge to `main`.
   before opening either result destination, preventing split or non-standard
   JSON output. Giant JSON integers are rejected before float conversion, so
   progress merging and report aggregation cannot fail with numeric overflow.
+  Shipped through PR #76 (`3258b5c3`) and verified by successful automatic
+  `Aggregate Tests & Deploy` run 29423221608; no paid workflow was dispatched.
 - **`exp027_GPT54_default_subprocess_bridge50`** — checked-in 50-task,
   9-sector diagnostic subprocess comparator for the historical exp026
   Sandbox/Skills runner bundle. Includes pinned 42 non-success-union tasks, six

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,7 +1,7 @@
 # Latest Task Result
 
 - Updated: 2026-07-15
-- Status: Implemented and validated; merge pending
+- Status: Merged and deployed; runtime canary pending
 
 ## Task
 
@@ -42,6 +42,12 @@ available.
 - Added sandbox documentation for enabling and interpreting the metrics. No
   existing experiment config or result fixture was rewritten, and no paid model,
   batch, grading, or canary run was dispatched.
+- Feature PR [#76](https://github.com/hyeonsangjeon/gdpval-realworks/pull/76)
+  was squash-merged to `main` as `3258b5c3265136b06a4661c16a521bd8c4887005`.
+  Automatic `Aggregate Tests & Deploy` run
+  [29423221608](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29423221608)
+  completed successfully. It was the only workflow tied to the merge SHA; no
+  paid batch, grading, cost-sweep, or sandbox canary workflow ran.
 
 ## Verification
 


### PR DESCRIPTION
PR #76 merged/deployed, run 29423221608 success, canonical status `Merged and deployed; runtime canary pending`, no paid workflows, docs-only.