### PR TITLE
fix(grading): make inference downloader directly executable

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -247,7 +247,7 @@ jobs:
 
       - name: Commit grade result
         id: commit_grade
-        if: always() && (steps.grade.outputs.rc == '0' || steps.grade.outputs.rc == '7') && inputs.dry_run == false
+        if: always() && steps.grade.conclusion == 'success' && (steps.grade.outputs.rc == '0' || steps.grade.outputs.rc == '7') && inputs.dry_run == false
         run: |
           GRADE_FILE="${{ steps.grade.outputs.grade_file }}"
           if [[ -z "$GRADE_FILE" || ! -f "$GRADE_FILE" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **Grade downloader direct-entry import** — make
+  `scripts/download_inference_from_hf.py` bootstrap the batch-runner root and
+  lightweight `core.inference_manifest` package when executed as a file.
+  Approved canary run 29423860683 passed renderer preflight and Azure OIDC but
+  stopped before HF download or any model call because direct execution could
+  not resolve `core`; the grade commit step now also requires the grading step
+  itself to have completed successfully.
 - **GitHub-hosted grading renderer verified** — model-free rerun 29393149367
   passed on `main` commit `f97cc170` after PR #74 fixed the direct script import
   boundary. Evidence recorded `ok=true`, exact Liberation Sans resolution,

--- a/batch-runner/scripts/download_inference_from_hf.py
+++ b/batch-runner/scripts/download_inference_from_hf.py
@@ -16,7 +16,9 @@ import json
 import os
 import re
 import shutil
+import sys
 import tempfile
+import types
 import uuid
 from pathlib import Path
 
@@ -24,6 +26,15 @@ import pandas as pd
 import yaml
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.errors import EntryNotFoundError
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parent.parent
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+if "core" not in sys.modules:
+    core_package = types.ModuleType("core")
+    core_package.__path__ = [str(BATCH_RUNNER_ROOT / "core")]
+    core_package.__package__ = "core"
+    sys.modules["core"] = core_package
 
 from core.inference_manifest import (
     canonicalize_inference_payload,

--- a/batch-runner/tests/test_download_inference_from_hf.py
+++ b/batch-runner/tests/test_download_inference_from_hf.py
@@ -1,5 +1,7 @@
 import importlib.util
 import json
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -8,6 +10,25 @@ import pytest
 
 
 FULL_SHA = "a" * 40
+
+
+def test_direct_script_entrypoint_resolves_core_import():
+    batch_root = Path(__file__).resolve().parents[1]
+    script = batch_root / "scripts" / "download_inference_from_hf.py"
+
+    completed = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=batch_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    assert "--revision" in completed.stdout
+    assert completed.stderr == ""
+    assert "No module named 'core'" not in completed.stdout
 
 
 def _load_module():

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -1526,6 +1526,7 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
 
     script = commit["run"]
     assert commit["id"] == "commit_grade"
+    assert "steps.grade.conclusion == 'success'" in commit["if"]
     assert 'git add -- "$GRADE_FILE"' in script
     assert script.count("validate(instance=payload, schema=schema)") == 2
     assert "GRADE_BLOB_SHA=" in script

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,77 +1,54 @@
 # Latest Task Result
 
 - Updated: 2026-07-15
-- Status: Merged and deployed; runtime canary pending
+- Status: Vision canary stopped before model call; downloader fix verified
 
 ## Task
 
-Add job-performance metrics for the next sandbox experiment while keeping
-existing experiment JSON and dashboard behavior unchanged when metrics are not
-available.
+- Start the separately approved, limited Azure Vision canary after the
+  GitHub-hosted LibreOffice preflight passed.
+- Restrict the run to one existing XLSX task, one planned vision call, and an
+  expected total cost below USD 1.
+- Stop before model execution if source, renderer, authentication, or task-plan
+  gates do not match the approved scope.
 
 ## Result
 
-- Added explicit opt-in configuration through `execution.metrics.enabled` and
-  preserved it through config parsing, Step 1, executor construction, and the
-  prompt-architecture index. Only the literal boolean `true` enables metrics;
-  omitted, false, malformed, or string values do not emit metric keys, and
-  undeclared fields are discarded.
-- Sandbox attempts now measure model, tool, verification, and dependency time.
-  Step 2 aggregates those measurements across sandbox repair and Self-QA
-  regeneration, adds orchestration time, and preserves cumulative task lifetime
-  across resume rounds.
-- `time_to_valid_artifact_ms` is recorded only after a file is saved and the
-  sandbox reports `ok` or `repaired_ok` with at least one verified non-manifest
-  artifact. Text-only, manifest-only, and unsuccessful file tasks retain `null`.
-- Duration and count fields use finite 30-day/1,000,000 schema bounds, strict
-  integer counters, overflow-safe resume merging, and `allow_nan=False` JSON
-  serialization so persisted output remains standards-compliant. Giant JSON
-  integers are rejected before float conversion instead of raising overflow.
-- Wall-timeout checkpoints retain the original pending task object and relay
-  completion replaces it through the normal merge path, preserving prior phase
-  time, counts, job runs, and time-to-valid offsets without duplicate rows.
-- Step 3 strictly serializes the final result once before opening either output
-  file; invalid NaN/Infinity values cannot update one result while leaving the
-  other stale.
-- Step 6 emits an optional aggregate only when measured data exists: coverage,
-  average/P50/P95/max job time, successful and failed job averages,
-  time-to-valid-file, phase totals, and execution/tool/Self-QA/job-run counts.
-- The experiment detail page conditionally renders Job Performance metrics, a
-  sortable Job Time column, and per-task timing details. Legacy reports keep the
-  existing table, modal, and metric cards without placeholders for new fields.
-- Added sandbox documentation for enabling and interpreting the metrics. No
-  existing experiment config or result fixture was rewritten, and no paid model,
-  batch, grading, or canary run was dispatched.
-- Feature PR [#76](https://github.com/hyeonsangjeon/gdpval-realworks/pull/76)
-  was squash-merged to `main` as `3258b5c3265136b06a4661c16a521bd8c4887005`.
-  Automatic `Aggregate Tests & Deploy` run
-  [29423221608](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29423221608)
-  completed successfully. It was the only workflow tied to the merge SHA; no
-  paid batch, grading, cost-sweep, or sandbox canary workflow ran.
+- The original exp998 candidate was rejected before dispatch because its pinned
+  first task is DOCX and would produce zero vision calls. The canary was moved
+  to exp003 task `83d10b06-26d1-4636-a32c-23f92c57f30b`, whose selected
+  `Sample.xlsx` has exactly one planned Overall Style vision call.
+- Approved grade run
+  [29423860683](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29423860683)
+  started on `main` commit `3258b5c3` with pinned inference revision
+  `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`, `default_v2_mini.yaml`, and
+  `tasks_limit=1`.
+- Workflow input validation, dependency installation, LibreOffice renderer
+  preflight, and Azure OIDC all passed. Renderer evidence matched the approved
+  run: LibreOffice 24.2.7.2, PyMuPDF 1.28.0, XLSX 17,358 bytes, and PPTX 18,637
+  bytes.
+- The run failed at the HF downloader entrypoint with
+  `ModuleNotFoundError: core`. Grading was skipped, no child/relay run appeared,
+  no grade artifact or commit was produced, and Azure/model cost was USD 0.
+- The downloader now bootstraps only the required
+  `core.inference_manifest` namespace when run as a script. The workflow commit
+  step additionally checks `steps.grade.conclusion == 'success'`, preventing a
+  secondary missing-grade failure after an upstream stop.
 
 ## Verification
 
-- Latest-main integrated real-dependency regression: 200 passed, 1 skipped, 0
-  failed under Python 3.11 with installed `pyarrow`, `datasets`,
-  `huggingface_hub`, and `psutil`; no global dependency stubs were used. This
-  includes the renderer preflight tests added through main commit `129d13f2`.
-- Dashboard aggregate tests: 21 passed, 0 failed.
-- Focused review-fix tests cover strict opt-in normalization, numeric bounds,
-  overflow fallback, manifest-only exclusion, restored QA test collection,
-  resume-timeout relay accumulation, and Step 3 strict dual-output writes.
-- Python compilation, editor diagnostics, and `git diff --check`: passed.
-- TypeScript compilation and production Vite build: passed.
-- Browser-verified a metrics-enabled fixture at desktop and 390px mobile widths:
-  aggregate panel, Job Time column, sorting surface, and task modal values render.
-- Browser-verified a legacy fixture: zero Job Performance panels, zero Job Time
-  columns, and the existing Latency column remains visible.
-- Existing generated report data remains unchanged unless an experiment opts in.
+- Downloader direct-entry, downloader behavior, and step8 workflow tests:
+  **112 passed**.
+- Track 2 and shared grader regression suite: **449 passed** with one existing
+  PyPDF2 deprecation warning.
+- Direct `python scripts/download_inference_from_hf.py --help` succeeds and
+  exposes `--revision` without a `core` import error.
+- `git diff --check` passed.
 
 ## Remaining Work
 
-- Enable `execution.metrics.enabled: true` in the next experiment YAML; existing
-  experiment definitions intentionally remain unchanged.
-- Run an owner-approved bounded canary to validate live timing distributions
-  before using them for model or agent comparisons.
-- The proposed free-form tool-calling/install loop is a separate execution-mode
-  change and still needs an allowlisted package broker, budgets, and an A/B run.
+- Merge the downloader fix PR and rerun the exact same canary scope once from
+  the then-current `main`, retaining the pinned exp003 inference revision.
+- Accept only one task, one render call, one perception call,
+  `usage_complete=true`, valid visual provenance, and total cost below USD 1.
+- Do not expand to a full grading run from this canary.


### PR DESCRIPTION
## Summary

- fix direct execution of the pinned HF inference downloader
- bootstrap only the lightweight `core.inference_manifest` package surface
- prevent the grade commit step from running after an upstream workflow failure
- record the no-cost stopped canary and exact rerun gate

## Canary evidence

Run 29423860683 passed renderer preflight and Azure OIDC, then stopped before HF download/model execution with `ModuleNotFoundError: core`. No grade, artifact, commit, relay, or Azure/model cost was produced.

## Verification

- downloader + step8 focused suite: **112 passed**
- Track 2/shared grader suite: **449 passed**
- direct downloader `--help`: passed
- `git diff --check`: passed
- `first-reviewer`: APPROVE

After merge, rerun the same one-task exp003 canary with pinned inference SHA `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`.