### PR TITLE
fix(grading): retry empty final responses once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **Tool-calling empty-final recovery** — when a Responses API tool loop ends
+  with an empty final message (observed after five successful reads in canary
+  run 29429183215), issue at most one finalization-only retry using the existing
+  evidence. The retry removes tools and parallel tool calls, lowers reasoning
+  to `low`, preserves ordered response items, and keeps complete call, latency,
+  input, output, and cache accounting. Retry exhaustion remains a score-excluded
+  `empty_final_text` error and Track 2 still exits fail-closed.
 - **Grading canary runtime fail-closed guards** — revert the invalid grade and
   analysis produced by run 29424766879 after 35 Azure requests rejected a
   106-character `prompt_cache_key` and the single vision response failed its

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -2007,6 +2007,9 @@ class Grader:
                 .get("max_output_tokens", 2400)),
             per_item_tool_call_cap=per_item_cap,
             max_iterations=max_iter,
+            empty_final_retries=int(
+                self.config.get("grader", {}).get("judge_max_retries", 1)
+            ),
             model_read_ops=model_read_ops,
             vision_perception=vision_perception,
             audio_perception=audio_perception,

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -68,12 +68,32 @@ from core.tools import (
 logger = logging.getLogger(__name__)
 
 _PROMPT_CACHE_KEY_MAX_CHARS = 64
+_EMPTY_FINAL_RETRY_PROMPT = (
+    "Your previous response contained no final verdict. Do not call any more "
+    "tools. Using the evidence already returned, respond now with only the "
+    "required JSON verdict envelope."
+)
 
 
 def _bounded_prompt_cache_key(value: str) -> str:
     if len(value) <= _PROMPT_CACHE_KEY_MAX_CHARS:
         return value
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _response_finish_reason(
+    response: Any, max_output_tokens: int, output_tokens: int
+) -> str:
+    incomplete = getattr(response, "incomplete_details", None)
+    reason = getattr(incomplete, "reason", None) if incomplete is not None else None
+    if isinstance(reason, str) and reason:
+        return reason.lower()
+    status = getattr(response, "status", None)
+    if isinstance(status, str) and status:
+        return status.lower()
+    if max_output_tokens > 0 and output_tokens >= max_output_tokens:
+        return "max_output_tokens"
+    return "unknown"
 
 _VISUAL_RENDER_SCOPES: Dict[str, Dict[str, int]] = {
     ".pdf": {"page": 1},
@@ -327,6 +347,8 @@ class ToolCallingJudge:
         max_iterations:          hard upper bound on response.create
                                  iterations (one tool round = one
                                  iteration).
+        empty_final_retries:     bounded retries when a response contains no
+                     final message after tool evidence is ready.
         vision_perception:       optional ``VisionPerception`` instance.
                      For VISUAL items the harness renders and
                      invokes it before the first main request;
@@ -354,6 +376,7 @@ class ToolCallingJudge:
     max_output_tokens: int = 2400
     per_item_tool_call_cap: int = 8
     max_iterations: int = 10
+    empty_final_retries: int = 1
     model_read_ops: Tuple[str, ...] = MODEL_READ_DELIVERABLE_OPS
     vision_perception: Any = None
     audio_perception: Any = None
@@ -371,6 +394,8 @@ class ToolCallingJudge:
     def __post_init__(self) -> None:
         if not self.model_read_ops:
             raise ValueError("model_read_ops must contain at least one operation")
+        if self.empty_final_retries < 0:
+            raise ValueError("empty_final_retries must be non-negative")
         invalid_ops = set(self.model_read_ops) - set(MODEL_READ_DELIVERABLE_OPS)
         if invalid_ops:
             raise ValueError(
@@ -466,6 +491,8 @@ class ToolCallingJudge:
         usage_complete = prepass.usage_complete
         final_text = ""
         judge_error: Optional[str] = None
+        finalization_only = False
+        empty_final_retries_used = 0
 
         while iterations < self.max_iterations:
             iterations += 1
@@ -489,6 +516,10 @@ class ToolCallingJudge:
                     prompt_cache_key=self.prompt_cache_key,
                     parallel_tool_calls=False,
                 )
+                if finalization_only:
+                    create_kwargs.pop("tools")
+                    create_kwargs.pop("parallel_tool_calls")
+                    create_kwargs["reasoning"] = {"effort": "low"}
                 # PR3 step 1b — context_management server-side compaction.
                 # The SDK signature exposes a dict shape but Azure's
                 # current API rev for gpt-5.4 rejects dict with HTTP 400
@@ -521,13 +552,18 @@ class ToolCallingJudge:
                     self._guard_upstream_call()
                     call_started = time.perf_counter()
                     main_api_call_count += 1
-                    response = self.client.responses.create(
+                    fallback_kwargs = dict(
                         model=self.model,
                         input=messages,
-                        tools=tools,
-                        reasoning={"effort": self.reasoning_effort},
+                        reasoning={
+                            "effort": "low" if finalization_only
+                            else self.reasoning_effort
+                        },
                         max_output_tokens=self.max_output_tokens,
                     )
+                    if not finalization_only:
+                        fallback_kwargs["tools"] = tools
+                    response = self.client.responses.create(**fallback_kwargs)
                     main_latency_ms += (
                         time.perf_counter() - call_started
                     ) * 1000.0
@@ -557,8 +593,14 @@ class ToolCallingJudge:
                 for field_name in ("input_tokens", "output_tokens")
             ):
                 usage_complete = False
-            input_tok_total += int(getattr(usage, "input_tokens", 0) or 0)
-            output_tok_total += int(getattr(usage, "output_tokens", 0) or 0)
+            response_input_tokens = int(
+                getattr(usage, "input_tokens", 0) or 0
+            )
+            response_output_tokens = int(
+                getattr(usage, "output_tokens", 0) or 0
+            )
+            input_tok_total += response_input_tokens
+            output_tok_total += response_output_tokens
             # PR3 Step 0 — cached_tokens (Azure Responses API automatic prompt
             # caching). Field path: usage.input_tokens_details.cached_tokens.
             # Older SDKs may not expose the details object; default 0.
@@ -613,6 +655,33 @@ class ToolCallingJudge:
                 final_text = self._extract_text(messages_out[0])
             else:
                 final_text = getattr(response, "output_text", "") or ""
+            if (
+                not final_text.strip()
+                and empty_final_retries_used < self.empty_final_retries
+                and iterations < self.max_iterations
+            ):
+                finish_reason = _response_finish_reason(
+                    response,
+                    self.max_output_tokens,
+                    response_output_tokens,
+                )
+                logger.warning(
+                    "ToolCallingJudge empty final response for %s (%s); "
+                    "retrying finalization without tools",
+                    item.rubric_item_id,
+                    finish_reason,
+                )
+                messages.extend(
+                    self._serialize_output_item(output_item)
+                    for output_item in output_items
+                )
+                messages.append({
+                    "role": "user",
+                    "content": _EMPTY_FINAL_RETRY_PROMPT,
+                })
+                empty_final_retries_used += 1
+                finalization_only = True
+                continue
             break
         else:
             judge_error = "max_iterations_exceeded"

--- a/batch-runner/tests/test_perception_wiring.py
+++ b/batch-runner/tests/test_perception_wiring.py
@@ -153,6 +153,7 @@ def test_grader_wires_perception_subjudges(monkeypatch):
         raw_cache_key.encode("utf-8")
     ).hexdigest()
     assert len(tj.prompt_cache_key) == 64
+    assert tj.empty_final_retries == 1
     assert grader.prompt_version == "v2.2"
 
 

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -62,13 +62,17 @@ def _usage(
 
 def _response(*, output: list[dict] | None = None, output_text: str = "",
               in_tok: int = 100, out_tok: int = 30,
-              cached_tok: int = 7) -> SimpleNamespace:
+              cached_tok: int = 7, status: str | None = None,
+              incomplete_reason: str | None = None) -> SimpleNamespace:
     return SimpleNamespace(
         output=output or [],
         output_text=output_text,
         usage=_usage(in_tok, out_tok, cached_tok),
-        incomplete_details=None,
-        status=None,
+        incomplete_details=(
+            SimpleNamespace(reason=incomplete_reason)
+            if incomplete_reason is not None else None
+        ),
+        status=status,
     )
 
 
@@ -230,6 +234,103 @@ def test_tool_round_then_final(deliverable_dir, task_and_item):
     types = [m.get("type") for m in second_input if isinstance(m, dict)]
     assert "function_call" in types
     assert "function_call_output" in types
+
+
+def test_empty_final_response_retries_once_without_tools(
+    deliverable_dir, task_and_item, caplog
+):
+    task, item = task_and_item
+    first = _response(
+        output=[_fc(
+            "c1", "read_deliverable",
+            op="inspect_structure", path="report.xlsx",
+        )],
+        in_tok=100,
+        out_tok=30,
+        cached_tok=7,
+    )
+    empty = _response(
+        output=[{"type": "reasoning", "id": "r1", "summary": []}],
+        in_tok=200,
+        out_tok=2400,
+        cached_tok=50,
+        status="incomplete",
+        incomplete_reason="max_output_tokens",
+    )
+    final = _response(
+        output=[_final(json.dumps({
+            "verdict": "pass",
+            "partial_score": 1.0,
+            "evidence": "all subdivisions are represented",
+            "confidence": 0.9,
+            "reasoning": "verified from prior tool evidence",
+        }))],
+        in_tok=210,
+        out_tok=60,
+        cached_tok=55,
+    )
+    client = FakeClient(ScriptedResponses([first, empty, final]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.4-mini",
+        prompt_template=PROMPT_TEMPLATE,
+        empty_final_retries=1,
+    )
+
+    with caplog.at_level("WARNING", logger="core.tool_calling_judge"):
+        result = judge.judge_item(
+            task=task,
+            item=item,
+            deliverable_dir=str(deliverable_dir),
+            file_names=["report.xlsx"],
+        )
+
+    assert result.verdict == "pass"
+    assert result.main_api_call_count == 3
+    assert result.iterations == 3
+    assert result.input_tokens == 510
+    assert result.output_tokens == 2490
+    assert result.cached_tokens == 112
+    retry = client.responses.calls[2]
+    assert "tools" not in retry
+    assert "parallel_tool_calls" not in retry
+    assert retry["reasoning"] == {"effort": "low"}
+    assert retry["input"][-1]["content"] == (
+        tool_calling_judge_module._EMPTY_FINAL_RETRY_PROMPT
+    )
+    assert "max_output_tokens" in caplog.text
+    assert "all subdivisions are represented" not in caplog.text
+
+
+def test_empty_final_retry_budget_exhaustion_stays_fail_closed(
+    deliverable_dir, task_and_item
+):
+    task, item = task_and_item
+    empty = _response(
+        out_tok=2400,
+        status="incomplete",
+        incomplete_reason="max_output_tokens",
+    )
+    client = FakeClient(ScriptedResponses([empty, empty]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.4-mini",
+        prompt_template=PROMPT_TEMPLATE,
+        empty_final_retries=1,
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+    assert result.verdict == "judge_error"
+    assert result.judge_error == "empty_final_text"
+    assert result.main_api_call_count == 2
+    assert result.iterations == 2
+    assert len(client.responses.calls) == 2
 
 
 # ── Tool-cap enforcement ────────────────────────────────────────────

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,12 +4,12 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-15
-- Status: Vision canary acceptance failed; invalid results reverted and fixes verified
+- Status: Vision path verified; one text finalization failure stopped fail-closed
 
 ## Task
 
-- Merge the downloader direct-entry fix and rerun the separately approved
-  Azure Vision canary on exactly one pinned exp003 XLSX task.
+- Merge the canary runtime guards and rerun the separately approved Azure
+  Vision canary on exactly one pinned exp003 XLSX task.
 - Accept only one render call, one perception call, complete usage accounting,
   relative-path visual provenance, and effective cost below USD 1.
 - Revert any committed result that fails those gates and do not dispatch a
@@ -17,46 +17,51 @@ task. It must be refreshed before a task is reported complete.
 
 ## Result
 
-- PR #78 merged as `1f9a5a42`, and run
-  [29424766879](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29424766879)
+- PR #80 merged as `16a4e5d1`, and run
+  [29429183215](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29429183215)
   used the approved experiment, `default_v2_mini.yaml`, inference revision
   `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`, task
   `83d10b06-26d1-4636-a32c-23f92c57f30b`, and selected `Sample.xlsx`.
 - Input validation, renderer installation/preflight, Azure OIDC, pinned HF
-  download, one XLSX render, and one vision request ran. No child or relay run
-  was dispatched, and no API-key fallback or secret exposure was found.
-- Acceptance failed. All 35 main requests returned HTTP 400 because the
-  106-character `prompt_cache_key` exceeded Azure's 64-character limit. The
-  vision request recorded 1,108 input and 248 output tokens but returned an
-  invalid semantic envelope. All 36 judged items were `judge_error`, aggregate
-  usage was incomplete, and the score-only summary incorrectly displayed 100%.
-- The invalid grade commit `da1d57a8` and analysis commit `a1cc84da` are
-  reverted by this change; both generated files are absent from the resulting
-  tree.
-- Long cache identities now use a deterministic 64-character SHA-256 key. The
-  vision prompt states the exact envelope contract, semantic strings are safely
-  normalized and bounded, and validation failures log only their reason.
-- Track 2 now atomically persists a diagnostic but exits nonzero after a real
-  main/perception/render runtime failure or incomplete usage. Error tasks no
-  longer inflate score summaries, and cache/resume rejects failed diagnostics
-  before constructing a grader. Existing call-free `selection_error` and
-  `no_deliverables` diagnostics retain their prior behavior.
+  download, one XLSX render, and one vision request all passed. The visual item
+  returned `partial` with `perception_called=true`, complete usage, and one
+  provenance entry for relative path `Sample.xlsx`; no image payload, absolute
+  path, or traversal path was persisted.
+- The run produced 18 pass, 15 fail, 4 partial, and 1 `judge_error` across 38
+  items. The sole error was text item `e52880a4-767f-47ea-97ea-a1cbc37256f6`:
+  after five successful `read_deliverable` calls, its sixth main response
+  contained no final message (`empty_final_text`). The task stopped with exit
+  code 6, uploaded only a diagnostic artifact, and skipped grade commit,
+  analysis, relay, and all auto-dispatch steps.
+- Accounting was complete: 127 main calls plus one perception call, one render,
+  2,699,883 input tokens, 43,901 output tokens, and 828,416 cached tokens. The
+  repository price table estimates USD 0.72 raw / USD 0.62 cache-discounted,
+  below the approved per-run ceiling; the diagnostic task score was 57.21% but
+  remained excluded from the valid-task average because `error=judge_error`.
+- Tool-calling finalization now retries an empty final response at most once
+  using the evidence already collected. The retry removes all tools and
+  parallel-tool settings, lowers reasoning effort to `low`, preserves ordered
+  response context, and includes its calls, latency, and token usage in normal
+  accounting. A second empty or malformed response remains fail-closed.
 
 ## Verification
 
-- Affected wiring, vision, tool-calling, Step 8, cache, resume, and workflow
-  suite: **161 passed**.
+- Focused success, retry-budget exhaustion, and config-wiring tests: **3
+  passed**; affected tool-calling, wiring, and Step 8 suite: **145 passed**.
 - Broader non-integration suite excluding the unavailable local GDPVal parquet
-  fixture: **1,125 passed, 2 skipped, 37 deselected**. The omitted selector
+  fixture: **1,124 passed, 5 skipped, 37 deselected**. The omitted selector
   module failed collection only because
   `data/gdpval-local/data/train-00000-of-00001.parquet` is not present.
-- Static diagnostics found no errors in the seven changed Python files.
+- Static diagnostics found no errors in the four changed Python files, and an
+  independent review reported no blocking findings.
 - `git diff --check` passed.
 
 ## Remaining Work
 
-- Merge the canary hardening and artifact reverts, then rerun the exact same
-  one-task canary once from the resulting `main`.
+- Merge the bounded empty-final retry fix.
+- Do not rerun the paid task without renewed cost approval: another full task
+  run is expected to push cumulative canary spend above the original USD 1
+  approval even though a single run remains below USD 1.
 - Require successful main verdicts, exactly one render and perception call,
   complete main/perception usage, valid relative-path provenance, and effective
   cost below USD 1.


### PR DESCRIPTION
## Summary
- retry a tool-calling response with no final message at most once
- preserve prior tool evidence but remove tools/parallel calls and use low reasoning for finalization only
- retain complete call, latency, input, output, and cached-token accounting; a second empty response remains fail-closed

## Canary evidence
Run 29429183215 verified the vision path: one XLSX render, one perception call, valid relative-path provenance, and complete usage. The sole failure was text item e52880a4-767f-47ea-97ea-a1cbc37256f6 returning empty_final_text after five successful reads. Fail-closed rc=6 prevented grade commit, analysis, relay, or auto-dispatch.

## Verification
- focused retry/config tests: 3 passed
- affected tool-calling/wiring/Step 8 suite: 145 passed
- broad non-integration suite: 1,124 passed, 5 skipped, 37 deselected
- selector module omitted because the repository-local GDPVal parquet fixture is unavailable
- static diagnostics, independent review, and git diff --check passed

## Cost gate
The diagnostic run was USD 0.72 raw / USD 0.62 effective. No additional paid rerun is included because another full task run could exceed the original cumulative USD 1 approval.