### PR TITLE
docs(grading): record empty-final recovery merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ entries land under a fresh dated heading the day they merge to `main`.
   evidence. The retry removes tools and parallel tool calls, lowers reasoning
   to `low`, preserves ordered response items, and keeps complete call, latency,
   input, output, and cache accounting. Retry exhaustion remains a score-excluded
-  `empty_final_text` error and Track 2 still exits fail-closed.
+  `empty_final_text` error and Track 2 still exits fail-closed. Shipped through
+  PR #81 (`a68a3efe`).
 - **Grading canary runtime fail-closed guards** — revert the invalid grade and
   analysis produced by run 29424766879 after 35 Azure requests rejected a
   106-character `prompt_cache_key` and the single vision response failed its

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,7 +4,7 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-15
-- Status: Vision path verified; one text finalization failure stopped fail-closed
+- Status: Vision path verified; bounded finalization recovery merged
 
 ## Task
 
@@ -43,6 +43,8 @@ task. It must be refreshed before a task is reported complete.
   parallel-tool settings, lowers reasoning effort to `low`, preserves ordered
   response context, and includes its calls, latency, and token usage in normal
   accounting. A second empty or malformed response remains fail-closed.
+- The recovery shipped through PR #81 as `a68a3efe`. No further paid workflow
+  was dispatched after the fix.
 
 ## Verification
 
@@ -58,7 +60,6 @@ task. It must be refreshed before a task is reported complete.
 
 ## Remaining Work
 
-- Merge the bounded empty-final retry fix.
 - Do not rerun the paid task without renewed cost approval: another full task
   run is expected to push cumulative canary spend above the original USD 1
   approval even though a single run remains below USD 1.


### PR DESCRIPTION
## Summary
- record PR #81 merge SHA for the bounded empty-final recovery
- confirm no paid rerun was dispatched after the fix
- keep the next canary behind renewed cost approval because another full task run may exceed the original cumulative USD 1 budget

## Verification
- docs-only diff
- git diff --check passed