### PR TITLE
fix(grading): retry malformed final responses once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **Tool-calling malformed-final recovery** — extend the bounded
+  finalization-only retry from empty output to syntactically unparseable final
+  JSON, as observed for two text criteria in canary run 29432455047. The retry
+  reuses ordered evidence with no tools, low reasoning, and complete usage
+  accounting. Valid JSON objects with invalid semantic envelopes are not
+  retried, and retry exhaustion remains fail-closed.
 - **Tool-calling empty-final recovery** — when a Responses API tool loop ends
   with an empty final message (observed after five successful reads in canary
   run 29429183215), issue at most one finalization-only retry using the existing

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -2007,7 +2007,7 @@ class Grader:
                 .get("max_output_tokens", 2400)),
             per_item_tool_call_cap=per_item_cap,
             max_iterations=max_iter,
-            empty_final_retries=int(
+            finalization_retries=int(
                 self.config.get("grader", {}).get("judge_max_retries", 1)
             ),
             model_read_ops=model_read_ops,

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -68,10 +68,10 @@ from core.tools import (
 logger = logging.getLogger(__name__)
 
 _PROMPT_CACHE_KEY_MAX_CHARS = 64
-_EMPTY_FINAL_RETRY_PROMPT = (
-    "Your previous response contained no final verdict. Do not call any more "
+_FINALIZATION_RETRY_PROMPT = (
+    "Your previous response was missing or malformed. Do not call any more "
     "tools. Using the evidence already returned, respond now with only the "
-    "required JSON verdict envelope."
+    "required valid JSON verdict envelope."
 )
 
 
@@ -320,6 +320,22 @@ def _safe_json_loads(text: str) -> Optional[Dict[str, Any]]:
             return None
 
 
+def _finalization_retry_reason(
+    final_text: str,
+    response: Any,
+    max_output_tokens: int,
+    output_tokens: int,
+) -> Optional[str]:
+    if not final_text.strip():
+        finish_reason = _response_finish_reason(
+            response, max_output_tokens, output_tokens
+        )
+        return f"empty_final_text:{finish_reason}"
+    if _safe_json_loads(final_text) is None:
+        return "final_json_parse_failed"
+    return None
+
+
 # ----------------------------------------------------------------------
 # Judge
 # ----------------------------------------------------------------------
@@ -347,8 +363,8 @@ class ToolCallingJudge:
         max_iterations:          hard upper bound on response.create
                                  iterations (one tool round = one
                                  iteration).
-        empty_final_retries:     bounded retries when a response contains no
-                     final message after tool evidence is ready.
+        finalization_retries:    bounded retries when a final response is
+                     missing or malformed after evidence is ready.
         vision_perception:       optional ``VisionPerception`` instance.
                      For VISUAL items the harness renders and
                      invokes it before the first main request;
@@ -376,7 +392,7 @@ class ToolCallingJudge:
     max_output_tokens: int = 2400
     per_item_tool_call_cap: int = 8
     max_iterations: int = 10
-    empty_final_retries: int = 1
+    finalization_retries: int = 1
     model_read_ops: Tuple[str, ...] = MODEL_READ_DELIVERABLE_OPS
     vision_perception: Any = None
     audio_perception: Any = None
@@ -394,8 +410,8 @@ class ToolCallingJudge:
     def __post_init__(self) -> None:
         if not self.model_read_ops:
             raise ValueError("model_read_ops must contain at least one operation")
-        if self.empty_final_retries < 0:
-            raise ValueError("empty_final_retries must be non-negative")
+        if self.finalization_retries < 0:
+            raise ValueError("finalization_retries must be non-negative")
         invalid_ops = set(self.model_read_ops) - set(MODEL_READ_DELIVERABLE_OPS)
         if invalid_ops:
             raise ValueError(
@@ -492,7 +508,7 @@ class ToolCallingJudge:
         final_text = ""
         judge_error: Optional[str] = None
         finalization_only = False
-        empty_final_retries_used = 0
+        finalization_retries_used = 0
 
         while iterations < self.max_iterations:
             iterations += 1
@@ -655,21 +671,22 @@ class ToolCallingJudge:
                 final_text = self._extract_text(messages_out[0])
             else:
                 final_text = getattr(response, "output_text", "") or ""
+            retry_reason = _finalization_retry_reason(
+                final_text,
+                response,
+                self.max_output_tokens,
+                response_output_tokens,
+            )
             if (
-                not final_text.strip()
-                and empty_final_retries_used < self.empty_final_retries
+                retry_reason is not None
+                and finalization_retries_used < self.finalization_retries
                 and iterations < self.max_iterations
             ):
-                finish_reason = _response_finish_reason(
-                    response,
-                    self.max_output_tokens,
-                    response_output_tokens,
-                )
                 logger.warning(
-                    "ToolCallingJudge empty final response for %s (%s); "
+                    "ToolCallingJudge invalid final response for %s (%s); "
                     "retrying finalization without tools",
                     item.rubric_item_id,
-                    finish_reason,
+                    retry_reason,
                 )
                 messages.extend(
                     self._serialize_output_item(output_item)
@@ -677,9 +694,9 @@ class ToolCallingJudge:
                 )
                 messages.append({
                     "role": "user",
-                    "content": _EMPTY_FINAL_RETRY_PROMPT,
+                    "content": _FINALIZATION_RETRY_PROMPT,
                 })
-                empty_final_retries_used += 1
+                finalization_retries_used += 1
                 finalization_only = True
                 continue
             break

--- a/batch-runner/tests/test_perception_wiring.py
+++ b/batch-runner/tests/test_perception_wiring.py
@@ -153,7 +153,7 @@ def test_grader_wires_perception_subjudges(monkeypatch):
         raw_cache_key.encode("utf-8")
     ).hexdigest()
     assert len(tj.prompt_cache_key) == 64
-    assert tj.empty_final_retries == 1
+    assert tj.finalization_retries == 1
     assert grader.prompt_version == "v2.2"
 
 

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -274,7 +274,7 @@ def test_empty_final_response_retries_once_without_tools(
         client=client,
         model="gpt-5.4-mini",
         prompt_template=PROMPT_TEMPLATE,
-        empty_final_retries=1,
+        finalization_retries=1,
     )
 
     with caplog.at_level("WARNING", logger="core.tool_calling_judge"):
@@ -296,7 +296,7 @@ def test_empty_final_response_retries_once_without_tools(
     assert "parallel_tool_calls" not in retry
     assert retry["reasoning"] == {"effort": "low"}
     assert retry["input"][-1]["content"] == (
-        tool_calling_judge_module._EMPTY_FINAL_RETRY_PROMPT
+        tool_calling_judge_module._FINALIZATION_RETRY_PROMPT
     )
     assert "max_output_tokens" in caplog.text
     assert "all subdivisions are represented" not in caplog.text
@@ -316,7 +316,7 @@ def test_empty_final_retry_budget_exhaustion_stays_fail_closed(
         client=client,
         model="gpt-5.4-mini",
         prompt_template=PROMPT_TEMPLATE,
-        empty_final_retries=1,
+        finalization_retries=1,
     )
 
     result = judge.judge_item(
@@ -328,6 +328,86 @@ def test_empty_final_retry_budget_exhaustion_stays_fail_closed(
 
     assert result.verdict == "judge_error"
     assert result.judge_error == "empty_final_text"
+    assert result.main_api_call_count == 2
+    assert result.iterations == 2
+    assert len(client.responses.calls) == 2
+
+
+def test_malformed_final_json_retries_once_without_tools(
+    deliverable_dir, task_and_item, caplog
+):
+    task, item = task_and_item
+    malformed = _response(
+        output=[_final('{"verdict":"pass","partial_score":')],
+        in_tok=200,
+        out_tok=80,
+        cached_tok=50,
+    )
+    final = _response(
+        output=[_final(json.dumps({
+            "verdict": "pass",
+            "partial_score": 1.0,
+            "evidence": "all divisions are represented",
+            "confidence": 0.9,
+            "reasoning": "verified from prior tool evidence",
+        }))],
+        in_tok=210,
+        out_tok=60,
+        cached_tok=55,
+    )
+    client = FakeClient(ScriptedResponses([malformed, final]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.4-mini",
+        prompt_template=PROMPT_TEMPLATE,
+        finalization_retries=1,
+    )
+
+    with caplog.at_level("WARNING", logger="core.tool_calling_judge"):
+        result = judge.judge_item(
+            task=task,
+            item=item,
+            deliverable_dir=str(deliverable_dir),
+            file_names=["report.xlsx"],
+        )
+
+    assert result.verdict == "pass"
+    assert result.main_api_call_count == 2
+    assert result.iterations == 2
+    assert result.input_tokens == 410
+    assert result.output_tokens == 140
+    assert result.cached_tokens == 105
+    retry = client.responses.calls[1]
+    assert "tools" not in retry
+    assert retry["reasoning"] == {"effort": "low"}
+    assert "final_json_parse_failed" in caplog.text
+    assert '"partial_score":' not in caplog.text
+
+
+def test_malformed_final_retry_budget_exhaustion_stays_fail_closed(
+    deliverable_dir, task_and_item
+):
+    task, item = task_and_item
+    malformed = _response(
+        output=[_final('{"verdict":"pass","partial_score":')]
+    )
+    client = FakeClient(ScriptedResponses([malformed, malformed]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.4-mini",
+        prompt_template=PROMPT_TEMPLATE,
+        finalization_retries=1,
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+    assert result.verdict == "judge_error"
+    assert result.judge_error == "final_json_parse_failed"
     assert result.main_api_call_count == 2
     assert result.iterations == 2
     assert len(client.responses.calls) == 2
@@ -1227,8 +1307,12 @@ def test_unparseable_final_text_is_judge_error(deliverable_dir, task_and_item):
     client = FakeClient(ScriptedResponses([_response(output=[_final(
         "this is not json at all"
     )])]))
-    judge = ToolCallingJudge(client=client, model="gpt-5.4",
-                             prompt_template=PROMPT_TEMPLATE)
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE,
+        finalization_retries=0,
+    )
     res = judge.judge_item(task=task, item=item,
                            deliverable_dir=str(deliverable_dir),
                            file_names=["report.xlsx"])

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -3,13 +3,13 @@
 This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
-- Updated: 2026-07-15
-- Status: Vision path verified; bounded finalization recovery merged
+- Updated: 2026-07-16
+- Status: Vision path verified; malformed finalization recovery validated
 
 ## Task
 
-- Merge the canary runtime guards and rerun the separately approved Azure
-  Vision canary on exactly one pinned exp003 XLSX task.
+- Rerun the approved Azure Vision canary on exactly one pinned exp003 XLSX task
+  after merging the bounded empty-final recovery.
 - Accept only one render call, one perception call, complete usage accounting,
   relative-path visual provenance, and effective cost below USD 1.
 - Revert any committed result that fails those gates and do not dispatch a
@@ -17,52 +17,52 @@ task. It must be refreshed before a task is reported complete.
 
 ## Result
 
-- PR #80 merged as `16a4e5d1`, and run
-  [29429183215](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29429183215)
+- PR #81 merged as `a68a3efe`, and run
+  [29432455047](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29432455047)
   used the approved experiment, `default_v2_mini.yaml`, inference revision
   `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`, task
   `83d10b06-26d1-4636-a32c-23f92c57f30b`, and selected `Sample.xlsx`.
 - Input validation, renderer installation/preflight, Azure OIDC, pinned HF
   download, one XLSX render, and one vision request all passed. The visual item
-  returned `partial` with `perception_called=true`, complete usage, and one
+  returned `fail` with `perception_called=true`, complete usage, and one
   provenance entry for relative path `Sample.xlsx`; no image payload, absolute
   path, or traversal path was persisted.
-- The run produced 18 pass, 15 fail, 4 partial, and 1 `judge_error` across 38
-  items. The sole error was text item `e52880a4-767f-47ea-97ea-a1cbc37256f6`:
-  after five successful `read_deliverable` calls, its sixth main response
-  contained no final message (`empty_final_text`). The task stopped with exit
-  code 6, uploaded only a diagnostic artifact, and skipped grade commit,
-  analysis, relay, and all auto-dispatch steps.
-- Accounting was complete: 127 main calls plus one perception call, one render,
-  2,699,883 input tokens, 43,901 output tokens, and 828,416 cached tokens. The
-  repository price table estimates USD 0.72 raw / USD 0.62 cache-discounted,
-  below the approved per-run ceiling; the diagnostic task score was 57.21% but
+- The run produced 18 pass, 16 fail, 2 partial, and 2 `judge_error` verdicts
+  across 38 items. Text items `7c2d9c16-9c1b-481d-a34d-389dc96e7f88` and
+  `e52880a4-767f-47ea-97ea-a1cbc37256f6` returned non-empty but syntactically
+  malformed final JSON after five and four successful `read_deliverable` calls.
+  Empty-only recovery therefore did not fire. The task stopped with exit code
+  6, uploaded only a diagnostic artifact, and skipped grade commit, analysis,
+  relay, and all auto-dispatch steps.
+- Accounting was complete: 126 main calls plus one perception call, one render,
+  2,744,127 input tokens, 43,379 output tokens, and 915,712 cached tokens. The
+  repository price table estimates USD 0.73 raw / USD 0.62 cache-discounted;
+  the diagnostic task score was 54.07% but
   remained excluded from the valid-task average because `error=judge_error`.
-- Tool-calling finalization now retries an empty final response at most once
-  using the evidence already collected. The retry removes all tools and
-  parallel-tool settings, lowers reasoning effort to `low`, preserves ordered
-  response context, and includes its calls, latency, and token usage in normal
-  accounting. A second empty or malformed response remains fail-closed.
-- The recovery shipped through PR #81 as `a68a3efe`. No further paid workflow
-  was dispatched after the fix.
+- The same bounded finalization recovery now handles either empty final text or
+  syntactically unparseable final JSON. It still removes tools and parallel
+  tool settings, lowers reasoning to `low`, preserves ordered response context,
+  and accounts for every retry. Semantically invalid JSON objects are not
+  retried and continue through strict envelope validation; retry exhaustion
+  remains fail-closed.
 
 ## Verification
 
-- Focused success, retry-budget exhaustion, and config-wiring tests: **3
-  passed**; affected tool-calling, wiring, and Step 8 suite: **145 passed**.
+- Focused empty/malformed success, retry-budget exhaustion, and config-wiring
+  tests: **5 passed**; isolated affected suite: **147 passed**.
 - Broader non-integration suite excluding the unavailable local GDPVal parquet
-  fixture: **1,124 passed, 5 skipped, 37 deselected**. The omitted selector
+  fixture: **1,129 passed, 2 skipped, 37 deselected**. The omitted selector
   module failed collection only because
   `data/gdpval-local/data/train-00000-of-00001.parquet` is not present.
-- Static diagnostics found no errors in the four changed Python files, and an
-  independent review reported no blocking findings.
+- Tests explicitly loaded `core.tool_calling_judge` from this worktree before
+  running; both changed Python files compile, and static diagnostics found no
+  errors in the four changed Python files.
 - `git diff --check` passed.
 
 ## Remaining Work
 
-- Do not rerun the paid task without renewed cost approval: another full task
-  run is expected to push cumulative canary spend above the original USD 1
-  approval even though a single run remains below USD 1.
+- Merge the generic finalization retry and rerun the same one-task canary under
+  the owner's renewed monthly-credit approval.
 - Require successful main verdicts, exactly one render and perception call,
   complete main/perception usage, valid relative-path provenance, and effective
   cost below USD 1.


### PR DESCRIPTION
## Summary
- extend bounded finalization recovery from empty output to syntactically malformed final JSON
- retry at most once with prior evidence, no tools/parallel calls, and low reasoning
- keep semantic-invalid JSON on the strict fail-closed path and preserve complete usage accounting

## Canary evidence
Run 29432455047 passed renderer, OIDC, pinned HF download, one render, and one vision call with complete relative-path provenance. Two text items returned non-empty malformed final JSON, so fail-closed rc=6 prevented grade commit, analysis, relay, and auto-dispatch.

## Verification
- focused empty/malformed success, exhaustion, and wiring: 5 passed
- isolated affected suite: 147 passed
- isolated broad suite: 1,129 passed, 2 skipped, 37 deselected
- selector module omitted because the local GDPVal parquet fixture is unavailable
- current-worktree import path verified; compile, static diagnostics, and git diff --check passed