### PR TITLE
feat(notes): compare prompt complexity metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,18 @@ entries land under a fresh dated heading the day they merge to `main`.
 - **`batch-runner/scripts/download_inference_from_hf.py`** — pass `HF_TOKEN` explicitly to `hf_hub_download()` (×2) and `snapshot_download()` via a new `_hf_token()` helper. The grade pipeline's "Download inference results from HF" step injects `HF_TOKEN` env, but `huggingface_hub` auto-pickup did not fire, so requests went out **anonymous** (CI log: `unauthenticated requests to HF Hub`). Under the sequential grade relay this tripped HTTP **429 Too Many Requests** on the inference parquet, breaking a chunk mid-run (e.g. 5.4 220 re-grade chunk-2 resume). Authenticated requests have a much higher rate limit → relay no longer 429s on repeated chunk downloads. No behavior change for single runs.
 
 ### Added
+- **Prompt-complexity Field Note** — add a sixth Korean RealWorks Field Note
+  comparing completion rate and Self-QA across the exp003 baseline, exp004
+  Elicit, and exp005 headless-Elicit subprocess runs. The article defines
+  Elicit as the GDPVal study's five-step verification prompt rather than a
+  separate model or service, and identifies headless-Elicit as the same design
+  with STEP 2 changed from display inspection to Pillow checks. It separates
+  surviving-result self-assessment from whole-run coverage and avoids treating
+  the comparison as a prompt-only A/B because runner settings also changed. A
+  dedicated responsive hero and dual Recharts comparison visualize
+  95.9/90.9/90.5% completion against 6.18/5.87/6.16 Self-QA, while the
+  prompt-strategy question, first timeline event, and exp003-exp005 detail pages
+  link to the new note.
 - **RealWorks Field Notes** — add lazy-loaded `/notes` and `/notes/:slug`
   routes with nine question-led experiment groups, a nine-event chronology,
   and five evidence-linked Korean columns spanning CI/runtime constraints,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "aggregate": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
-    "test:aggregate": "node --test scripts/__tests__/aggregate-experiments.test.mjs scripts/__tests__/aggregate-grades.test.mjs scripts/__tests__/official-filter.test.mjs",
+    "test:aggregate": "node --test scripts/__tests__/aggregate-experiments.test.mjs scripts/__tests__/aggregate-grades.test.mjs scripts/__tests__/field-notes.test.mjs scripts/__tests__/official-filter.test.mjs",
     "test:official-filter": "node --test scripts/__tests__/official-filter.test.mjs",
     "predev": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
     "dev": "vite",

--- a/scripts/__tests__/field-notes.test.mjs
+++ b/scripts/__tests__/field-notes.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const readSource = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
+
+test('prompt-complexity note keeps its experiment and navigation contracts', async () => {
+  const [journal, catalog] = await Promise.all([
+    readSource('src/data/journal.ts'),
+    readSource('src/data/journalLinks.ts'),
+  ])
+
+  assert.match(catalog, /'when-more-prompt-is-less':[\s\S]*relatedExperiments: \['exp003', 'exp004', 'exp005'\]/)
+  assert.match(journal, /articleSlug: 'when-more-prompt-is-less'/)
+  assert.match(journal, /articleSlugs: \['when-more-prompt-is-less', 'why-build-a-sandbox'\]/)
+  assert.match(journal, /\{ label: 'exp003 Baseline', primary: 95\.9, secondary: 6\.18 \}/)
+  assert.match(journal, /\{ label: 'exp004 Elicit', primary: 90\.9, secondary: 5\.87 \}/)
+  assert.match(journal, /\{ label: 'exp005 Headless', primary: 90\.5, secondary: 6\.16 \}/)
+  assert.match(journal, /Elicit은 별도 모델이나 서비스가 아니라[\s\S]*GDPVal 연구의 프롬프트 전략이다/)
+  assert.match(journal, /https:\/\/arxiv\.org\/pdf\/2510\.04374#page=37/)
+})
+
+test('prompt-complexity hero reflects the source five-step design', async () => {
+  const hero = await readSource('src/components/notes/NoteHeroVisual.tsx')
+
+  assert.match(hero, /mode: 'FIVE MANDATORY STEPS'/)
+  assert.match(hero, /'2 · DISPLAY PNG'/)
+  assert.match(hero, /mode: 'SAME FIVE STEPS · NEW STEP 2'/)
+  assert.match(hero, /'2 · PILLOW CHECK'/)
+  assert.doesNotMatch(hero, /checks: [367]/)
+  assert.doesNotMatch(hero, /MORE CHECKS · FEWER FINISHES/)
+})
+
+test('comparison chart preserves mobile labels and reduced-motion behavior', async () => {
+  const chart = await readSource('src/components/notes/NoteComparisonChart.tsx')
+
+  assert.match(chart, /interval=\{chart\.kind === 'dual' \? 0 : undefined\}/)
+  assert.match(chart, /const reduceMotion = useReducedMotion\(\)/)
+  assert.equal(chart.match(/isAnimationActive=\{!reduceMotion\}/g)?.length, 4)
+})

--- a/src/components/notes/NoteComparisonChart.tsx
+++ b/src/components/notes/NoteComparisonChart.tsx
@@ -10,6 +10,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
+import { useReducedMotion } from 'framer-motion'
 import type { JournalComparisonChart, JournalChartSeries } from '../../data/journal'
 
 const tickStyle = { fill: 'hsl(var(--dash-text-secondary))', fontSize: 11 }
@@ -24,6 +25,7 @@ const tooltipStyle = {
 const formatTick = (series: JournalChartSeries) => (value: number) => `${value}${series.unit.trim()}`
 
 export default function NoteComparisonChart({ chart }: { chart: JournalComparisonChart }) {
+  const reduceMotion = useReducedMotion()
   const ariaLabel = `${chart.title}. ${chart.data.map((datum) => {
     const values = [`${chart.primary.label} ${datum.primary}${chart.primary.unit}`]
     if (chart.secondary && datum.secondary != null) values.push(`${chart.secondary.label} ${datum.secondary}${chart.secondary.unit}`)
@@ -33,7 +35,13 @@ export default function NoteComparisonChart({ chart }: { chart: JournalCompariso
   const commonAxis = (
     <>
       <CartesianGrid stroke="hsl(var(--dash-border))" strokeDasharray="3 5" vertical={false} />
-      <XAxis dataKey="label" tick={tickStyle} tickLine={false} axisLine={{ stroke: 'hsl(var(--dash-border))' }} />
+      <XAxis
+        dataKey="label"
+        interval={chart.kind === 'dual' ? 0 : undefined}
+        tick={tickStyle}
+        tickLine={false}
+        axisLine={{ stroke: 'hsl(var(--dash-border))' }}
+      />
       <Tooltip contentStyle={tooltipStyle} cursor={{ fill: 'hsl(var(--dash-card-hover))', opacity: 0.5 }} />
       <Legend
         wrapperStyle={{ fontSize: '11px', paddingTop: '12px' }}
@@ -71,8 +79,8 @@ export default function NoteComparisonChart({ chart }: { chart: JournalCompariso
                 tickLine={false}
                 axisLine={false}
               />
-              <Bar yAxisId="primary" dataKey="primary" name={chart.primary.label} unit={chart.primary.unit} fill={chart.primary.color} radius={[4, 4, 0, 0]} maxBarSize={84} />
-              <Line yAxisId="secondary" dataKey="secondary" name={chart.secondary.label} unit={chart.secondary.unit} stroke={chart.secondary.color} strokeWidth={3} dot={{ r: 5 }} activeDot={{ r: 7 }} />
+              <Bar yAxisId="primary" dataKey="primary" name={chart.primary.label} unit={chart.primary.unit} fill={chart.primary.color} radius={[4, 4, 0, 0]} maxBarSize={84} isAnimationActive={!reduceMotion} />
+              <Line yAxisId="secondary" dataKey="secondary" name={chart.secondary.label} unit={chart.secondary.unit} stroke={chart.secondary.color} strokeWidth={3} dot={{ r: 5 }} activeDot={{ r: 7 }} isAnimationActive={!reduceMotion} />
             </ComposedChart>
           ) : (
             <BarChart data={chart.data} margin={{ top: 16, right: 8, left: -8, bottom: 4 }}>
@@ -92,6 +100,7 @@ export default function NoteComparisonChart({ chart }: { chart: JournalCompariso
                 fill={chart.primary.color}
                 radius={chart.kind === 'stacked' ? [0, 0, 0, 0] : [4, 4, 0, 0]}
                 maxBarSize={84}
+                isAnimationActive={!reduceMotion}
               />
               {chart.kind === 'stacked' && chart.secondary && (
                 <Bar
@@ -102,6 +111,7 @@ export default function NoteComparisonChart({ chart }: { chart: JournalCompariso
                   fill={chart.secondary.color}
                   radius={[4, 4, 0, 0]}
                   maxBarSize={84}
+                  isAnimationActive={!reduceMotion}
                 />
               )}
             </BarChart>

--- a/src/components/notes/NoteHeroVisual.tsx
+++ b/src/components/notes/NoteHeroVisual.tsx
@@ -5,6 +5,84 @@ const resolveAsset = (src: string) => (
   src.startsWith('http') ? src : `${import.meta.env.BASE_URL}${src.replace(/^\/+/, '')}`
 )
 
+function PromptComplexityVisual({ reduceMotion }: { reduceMotion: boolean | null }) {
+  const cards = [
+    {
+      x: 70,
+      title: 'exp003 · BASELINE',
+      mode: 'BASIC OUTPUT CONTRACT',
+      steps: ['CREATE FILE', 'INSPECT INPUT', 'TEXT SUMMARY'],
+      success: '211 / 220',
+      qa: 'Self-QA 6.18',
+      color: '#2563eb',
+    },
+    {
+      x: 450,
+      title: 'exp004 · ELICIT',
+      mode: 'FIVE MANDATORY STEPS',
+      steps: ['1 · RENDER TO PNG', '2 · DISPLAY PNG', '3 · PROGRAM CHECK', '4 · MATCH REQUEST', '5 · FINAL FILE CHECK'],
+      success: '200 / 220',
+      qa: 'Self-QA 5.87',
+      color: '#b45309',
+    },
+    {
+      x: 830,
+      title: 'exp005 · HEADLESS',
+      mode: 'SAME FIVE STEPS · NEW STEP 2',
+      steps: ['1 · RENDER TO PNG', '2 · PILLOW CHECK', '3 · PROGRAM CHECK', '4 · MATCH REQUEST', '5 · FINAL FILE CHECK'],
+      success: '199 / 220',
+      qa: 'Self-QA 6.16',
+      color: '#be123c',
+    },
+  ]
+
+  return (
+    <>
+      <text x="70" y="62" fill="hsl(var(--dash-text-secondary))" fontSize="18">BASELINE → FIVE-STEP ELICIT → HEADLESS ADAPTATION</text>
+      <text x="1130" y="62" fill="hsl(var(--dash-text-secondary))" fontSize="14" textAnchor="end">prompt structure from experiment YAML</text>
+      {cards.map((card) => (
+        <g key={card.title}>
+          <rect x={card.x} y="105" width="300" height="280" rx="8" fill="hsl(var(--dash-card))" stroke={card.color} strokeWidth="2" />
+          <text x={card.x + 24} y="145" fill="hsl(var(--dash-heading))" fontSize="18" fontWeight="700">{card.title}</text>
+          <text x={card.x + 24} y="174" fill="hsl(var(--dash-text-secondary))" fontSize="12">{card.mode}</text>
+          {card.steps.map((step, index) => (
+            <g key={step}>
+              <rect
+                x={card.x + 24}
+                y={190 + index * 23}
+                width="252"
+                height="18"
+                rx="3"
+                fill={card.color}
+                opacity={step.includes('PILLOW') || step.includes('DISPLAY') ? 0.26 : 0.1}
+              />
+              <text x={card.x + 32} y={203 + index * 23} fill="hsl(var(--dash-heading))" fontSize="11">{step}</text>
+            </g>
+          ))}
+          <text x={card.x + 24} y="330" fill="hsl(var(--dash-heading))" fontSize="28" fontWeight="700">{card.success}</text>
+          <text x={card.x + 24} y="360" fill="hsl(var(--dash-text-secondary))" fontSize="16">{card.qa}</text>
+        </g>
+      ))}
+      {reduceMotion ? (
+        <line x1="70" x2="1130" y1="260" y2="260" stroke="hsl(var(--dash-heading))" strokeWidth="2" opacity="0.35" />
+      ) : (
+        <motion.line
+          x1="70"
+          x2="1130"
+          y1="188"
+          y2="188"
+          stroke="hsl(var(--dash-heading))"
+          strokeWidth="2"
+          strokeDasharray="8 8"
+          initial={{ y: 0, opacity: 0.15 }}
+          animate={{ y: [0, 110], opacity: [0.15, 0.55, 0.15] }}
+          transition={{ duration: 4.5, repeat: Infinity, ease: 'easeInOut' }}
+        />
+      )}
+    </>
+  )
+}
+
 function RuntimeVisual({ reduceMotion }: { reduceMotion: boolean | null }) {
   const markers = [
     { x: 893, y: 176, value: '290', label: 'watchdog' },
@@ -181,6 +259,29 @@ function SandboxVisual({ reduceMotion }: { reduceMotion: boolean | null }) {
 }
 
 function MobileVisualSummary({ variant, alt }: { variant: Extract<JournalHero, { kind: 'visual' }>['variant']; alt: string }) {
+  if (variant === 'prompt-complexity') {
+    return (
+      <div role="img" aria-label={alt} className="md:hidden min-h-[220px] px-3 py-6 bg-dash-surface border-y border-dash-border">
+        <div className="font-mono text-[11px] text-dash-text-secondary mb-5">BASELINE → 5-STEP ELICIT → HEADLESS</div>
+        <div className="grid grid-cols-3 gap-2">
+          {[
+            ['Baseline', '기본 계약', '95.9%', 'QA 6.18', 'border-blue-700/70 bg-blue-500/10'],
+            ['Elicit', '5단계 검사', '90.9%', 'QA 5.87', 'border-amber-700/70 bg-amber-500/10'],
+            ['Headless', 'STEP 2 교체', '90.5%', 'QA 6.16', 'border-rose-700/70 bg-rose-500/10'],
+          ].map(([title, mode, completion, qa, style]) => (
+            <div key={title} className={`min-w-0 border px-2 py-4 text-center ${style}`}>
+              <div className="text-[11px] font-medium text-dash-text-secondary">{title}</div>
+              <div className="mt-1 text-[10px] leading-4 text-dash-text-secondary">{mode}</div>
+              <div className="mt-3 font-mono text-xl font-semibold text-dash-heading">{completion}</div>
+              <div className="mt-2 text-[11px] text-dash-text-secondary">{qa}</div>
+            </div>
+          ))}
+        </div>
+        <p className="mt-5 text-center text-xs/[1.7] text-pretty break-keep text-dash-text-secondary">5단계 도입 뒤 완료율은 낮았고, STEP 2 교체 뒤 Self-QA는 baseline 수준으로 돌아왔다.</p>
+      </div>
+    )
+  }
+
   if (variant === 'runtime') {
     return (
       <div role="img" aria-label={alt} className="md:hidden min-h-[220px] px-4 py-6 bg-dash-surface border-y border-dash-border">
@@ -325,6 +426,7 @@ export default function NoteHeroVisual({ hero }: { hero: JournalHero }) {
       <MobileVisualSummary variant={hero.variant} alt={hero.alt} />
       <div className="hidden md:block overflow-hidden border-y border-dash-border bg-dash-surface">
         <svg viewBox="0 0 1200 460" role="img" aria-label={hero.alt} className="block w-full aspect-[12/5]">
+          {hero.variant === 'prompt-complexity' && <PromptComplexityVisual reduceMotion={reduceMotion} />}
           {hero.variant === 'runtime' && <RuntimeVisual reduceMotion={reduceMotion} />}
           {hero.variant === 'integrity' && <IntegrityVisual />}
           {hero.variant === 'perception' && <PerceptionVisual reduceMotion={reduceMotion} />}

--- a/src/data/journal.ts
+++ b/src/data/journal.ts
@@ -30,7 +30,7 @@ export interface JournalEvidence {
 export type JournalHero =
   | {
       kind: 'visual'
-      variant: 'runtime' | 'integrity' | 'perception' | 'task-contrast' | 'sandbox'
+  variant: 'prompt-complexity' | 'runtime' | 'integrity' | 'perception' | 'task-contrast' | 'sandbox'
       alt: string
       caption: string
     }
@@ -107,6 +107,121 @@ const REPO = 'https://github.com/hyeonsangjeon/gdpval-realworks/blob/main'
 const HF_EXP026 = 'https://huggingface.co/datasets/HyeonSang/exp026_sandbox_skills_multimodal'
 
 export const journalArticles: JournalArticle[] = [
+  {
+    ...journalCatalog['when-more-prompt-is-less'],
+    dek: 'baseline 뒤 Elicit은 5단계 검증을 도입했고, headless-Elicit은 그중 화면 검사를 프로그램 검사로 바꿨다. 완료율과 Self-QA가 같은 답을 주는지 exp001–005의 설계와 결과를 분리해 읽었다.',
+    thesis: '이 기록에서 두 Elicit 실행은 baseline보다 적은 작업을 완료했지만, 끝까지 살아남은 결과의 자기평가는 서로 다른 방향으로 움직였다.',
+    publishedAt: '2026-07-16',
+    period: 'exp001 → exp005',
+    readingMinutes: 8,
+    metrics: [
+      { value: '95.9%', label: 'baseline 완료율' },
+      { value: '-5.5%p', label: 'baseline 대비 headless' },
+      { value: '6.18 ≈ 6.16', label: 'baseline ↔ headless Self-QA' },
+    ],
+    hero: {
+      kind: 'visual',
+      variant: 'prompt-complexity',
+      alt: 'exp003 baseline의 기본 계약과 exp004·005 Elicit의 5단계 검증 구조, 완료 작업 및 Self-QA를 비교하는 시각화',
+      caption: 'baseline 뒤 두 Elicit 실행은 같은 5단계를 사용하되 STEP 2의 검사 방식이 달랐다. 완료 작업은 211개에서 200개와 199개로 줄었지만, headless-Elicit의 Self-QA는 baseline과 거의 같았다.',
+    },
+    comparisonChart: {
+      kind: 'dual',
+      title: '완료율은 내려갔고 Self-QA는 돌아왔다',
+      description: 'subprocess로 실행한 exp003·004·005에서 완료율은 계속 낮아졌지만, Self-QA는 Elicit에서 하락한 뒤 headless-Elicit에서 baseline 수준으로 회복했다.',
+      primary: { label: 'Completion', unit: '%', color: '#2563eb', domain: [0, 100] },
+      secondary: { label: 'Self-QA', unit: '/10', color: '#059669', domain: [0, 10] },
+      data: [
+        { label: 'exp003 Baseline', primary: 95.9, secondary: 6.18 },
+        { label: 'exp004 Elicit', primary: 90.9, secondary: 5.87 },
+        { label: 'exp005 Headless', primary: 90.5, secondary: 6.16 },
+      ],
+      caveat: 'Self-QA는 외부 채점이 아니라 점수가 존재하는 결과의 자기평가다. exp004는 LibreOffice 설치 설정, exp005는 resume round도 함께 바뀌어 프롬프트 단독 효과로 읽을 수 없다.',
+    },
+    sections: [
+      {
+        heading: '질문: 검증을 더 많이 시키면 더 잘 끝낼까',
+        paragraphs: [
+          '이 글에서 Elicit은 별도 모델이나 서비스가 아니라, 모델에게 산출물 생성 뒤 5단계 렌더링·점검과 신뢰도 보고를 시키는 GDPVal 연구의 프롬프트 전략이다. headless-Elicit은 그중 화면으로 PNG를 보는 두 번째 단계를 Pillow 검사로 바꾼 버전이다.',
+          '첫 baseline은 비교적 짧았다. 실제 파일을 만들고, 참조 파일 구조를 살피고, 결과를 plain-text로 요약하라는 정도였다. Elicit은 여기에 PDF 변환, 폰트와 PNG 확인, 5단계 검사, 마지막 CONFIDENCE 보고를 더했다. headless-Elicit은 나머지 네 단계를 유지하고 이미지 확인 방식만 화면 없는 runner에 맞췄다.',
+          '가설은 자연스러웠다. 산출물을 더 꼼꼼히 확인하라고 하면 실행 성공과 결과의 자기평가가 함께 좋아질 것이라고 예상했다. 이 글은 그 두 신호가 실제로 같은 답을 줬는지 묻는다.',
+        ],
+      },
+      {
+        heading: '방법: 실행 모드를 섞지 않았다',
+        paragraphs: [
+          'exp001과 exp002는 code interpreter에서 baseline과 Elicit을 비교하도록 설계됐다. 하지만 현재 저장소와 공개 인덱스에는 이 canonical 두 실행의 report가 없다. 설정 차이는 읽을 수 있어도 성능 차이를 말할 수는 없다.',
+          '수치 비교는 같은 GPT-5.2-chat을 subprocess로 실행한 exp003, exp004, exp005로 한정했다. exp003은 baseline, exp004는 Elicit, exp005는 headless-Elicit이다. 다만 완전한 prompt-only A/B는 아니다. exp004에서는 LibreOffice 설치 설정이 함께 바뀌었고, exp005에서는 resume_max_rounds가 2에서 1로 줄었다.',
+        ],
+        callout: 'exp005 YAML의 생성일은 2026-02-28인데 report date는 2026-02-27이다. 저장소에는 이 불일치의 설명이 없어 날짜 순서를 성능 원인으로 사용하지 않았다.',
+      },
+      {
+        heading: '결과: 두 메트릭이 갈라졌다',
+        paragraphs: [
+          '완료율은 단순했다. baseline exp003은 211/220, 95.9%를 완료했다. 5단계를 도입한 Elicit exp004는 200/220, 90.9%, STEP 2를 바꾼 headless-Elicit exp005는 199/220, 90.5%였다. 관찰된 완료 수는 순서대로 211개, 200개, 199개였다.',
+          'Self-QA는 다른 모양이었다. 6.18에서 5.87로 내려갔다가 6.16으로 되돌아왔다. exp005는 baseline보다 12개를 덜 완료했지만, 점수가 남은 결과의 평균 자기평가는 baseline과 0.02점 차이였다. 완료율만 보면 악화였고 Self-QA만 보면 거의 회복이었다.',
+        ],
+      },
+      {
+        heading: '해석: 살아남은 결과의 평균은 전체 커버리지가 아니다',
+        paragraphs: [
+          'Self-QA 평균은 점수가 존재하는 결과를 중심으로 계산된다. 실행 단계에서 탈락해 산출물을 만들지 못한 작업은 높은 품질로 복구된 것이 아니라 평균 바깥으로 빠질 수 있다. 그래서 Self-QA가 비슷하다는 사실은 같은 수의 업무를 같은 품질로 끝냈다는 뜻이 아니다.',
+          'headless-Elicit이 보여준 것은 더 좁은 주장이다. 끝까지 도달한 결과의 자기평가는 baseline 수준으로 돌아왔지만, 전체 작업을 끝까지 통과시키는 능력은 돌아오지 않았다. 품질 게이트와 커버리지를 한 숫자로 합치면 이 차이가 사라진다.',
+        ],
+      },
+      {
+        heading: '실패: 검증 절차가 새로운 실패 표면이 됐다',
+        paragraphs: [
+          'exp004 report에는 `soffice`를 찾지 못한 실패가 7건 반복된다. 더 많은 문서 검사를 요구했지만 runner가 그 도구를 안정적으로 제공하지 못하면 검증 단계 자체가 실행 실패가 된다.',
+          'exp005에서는 `CONFIDENCE[...]`가 실행 코드로 새어 들어가 NameError를 만든 사례가 7건 반복된다. 결과를 설명하기 위한 출력 규약이 코드 경계와 섞인 것이다. 길어진 검증 프롬프트에는 모델이 지켜야 할 계약뿐 아니라 잘못 해석할 수 있는 표면도 함께 들어왔다.',
+        ],
+      },
+      {
+        heading: '결정: 검증을 버리지 않고 가볍게 만들기',
+        paragraphs: [
+          '후속 exp006은 검증 자체를 포기하지 않았다. 토큰 여유를 16k로 늘리고, 검사를 lightweight하게 줄였으며, CONFIDENCE를 코드 블록 밖에 두도록 경계를 명시했다. 더 많은 문장을 추가하는 대신 실패하기 쉬운 계약을 짧고 분명하게 다시 배치했다.',
+          '따라서 이 실험의 결론은 “짧은 프롬프트가 항상 낫다”가 아니다. 검증 지시는 실행 환경이 실제로 지원하고, 코드와 설명의 경계가 분명하며, 실패 시 무엇을 복구할지 알 수 있을 때만 도움이 된다. 복잡성은 품질을 공짜로 올리는 장식이 아니라 운영 비용을 가진 설계 변수였다.',
+        ],
+      },
+    ],
+    evidence: [
+      {
+        label: 'GDPVal 연구 Appendix A.3',
+        detail: 'Elicit Capabilities 프롬프트의 원문과 5단계 검사 설계',
+        href: 'https://arxiv.org/pdf/2510.04374#page=37',
+      },
+      {
+        label: 'exp001 baseline 설정',
+        detail: 'code interpreter baseline의 파일 생성·참조 검사 suffix',
+        href: `${REPO}/batch-runner/experiments/exp001_GPT52Chat_baseline.yaml`,
+      },
+      {
+        label: 'exp002 Elicit 설정',
+        detail: '추가된 5단계 검사와 CONFIDENCE 규약',
+        href: `${REPO}/batch-runner/experiments/exp002_GPT52Chat_elicit.yaml`,
+      },
+      {
+        label: 'exp003 baseline 리포트',
+        detail: '211/220 완료, Self-QA 6.18의 subprocess 기준선',
+        href: `${REPO}/batch-runner/results/exp003_GPT52Chat_baseline_runner_exec/report/report.md`,
+      },
+      {
+        label: 'exp004 Elicit 리포트',
+        detail: '200/220 완료와 반복된 soffice 실행 실패',
+        href: `${REPO}/batch-runner/results/exp004_GPT52Chat_elicit_runner_exec/report/report.md`,
+      },
+      {
+        label: 'exp005 headless-Elicit 리포트',
+        detail: '199/220 완료, Self-QA 6.16, CONFIDENCE NameError',
+        href: `${REPO}/batch-runner/results/exp005_GPT52Chat_elicit_v2_runner_exec/report/report.md`,
+      },
+      {
+        label: 'exp006 후속 설정',
+        detail: '16k, lightweight checks, 코드 블록 밖 CONFIDENCE로 이어진 결정',
+        href: `${REPO}/batch-runner/experiments/exp006_GPT52Chat_token16k_lite_elicit.yaml`,
+      },
+    ],
+  },
   {
     ...journalCatalog['360-minute-experiment'],
     dek: '장시간 CI 제한은 단순한 운영 불편이 아니었다. 어떤 작업이 결과에 남는지를 바꾸는 실험 조건이었다.',
@@ -554,6 +669,7 @@ export const experimentGroups: ExperimentGroup[] = [
     experiments: ['exp001', 'exp002', 'exp003', 'exp004', 'exp005'],
     finding: 'subprocess 비교에서는 baseline 완료율이 Elicit 계열보다 높았다.',
     caveat: 'code interpreter와 subprocess 결과를 하나의 직접 비교로 섞지 않는다.',
+    articleSlug: 'when-more-prompt-is-less',
     state: 'finding',
   },
   {
@@ -632,7 +748,7 @@ export const timelineEvents: TimelineEvent[] = [
     title: '관리형 실행에서 subprocess 실험으로 이동',
     description: 'baseline과 Elicit 전략을 직접 실행 가능한 runner에서 다시 비교하기 시작했다.',
     experiments: ['exp003', 'exp004'],
-    articleSlugs: ['why-build-a-sandbox'],
+    articleSlugs: ['when-more-prompt-is-less', 'why-build-a-sandbox'],
     kind: 'decision',
   },
   {

--- a/src/data/journalLinks.ts
+++ b/src/data/journalLinks.ts
@@ -15,6 +15,12 @@ export const lensLabels: Record<JournalLens, string> = {
 }
 
 export const journalCatalog = {
+  'when-more-prompt-is-less': {
+    slug: 'when-more-prompt-is-less',
+    title: '프롬프트를 더 복잡하게 만들면 실제 업무를 더 잘할까',
+    lens: 'experiment',
+    relatedExperiments: ['exp003', 'exp004', 'exp005'],
+  },
   '360-minute-experiment': {
     slug: '360-minute-experiment',
     title: '220개의 실제 업무를 360분 안에 실행한다는 것',

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,66 +4,58 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-16
-- Status: Vision path verified; malformed finalization recovery validated
+- Status: Prompt-complexity Field Note implemented and locally verified
 
 ## Task
 
-- Rerun the approved Azure Vision canary on exactly one pinned exp003 XLSX task
-  after merging the bounded empty-final recovery.
-- Accept only one render call, one perception call, complete usage accounting,
-  relative-path visual provenance, and effective cost below USD 1.
-- Revert any committed result that fails those gates and do not dispatch a
-  child, relay, or full grading run.
+- Write the missing Field Note for the question "Did a more complex prompt
+  outperform the baseline?" using the exp001-exp005 experiment record.
+- Compare completion rate and Self-QA without conflating whole-run coverage,
+  surviving-result self-assessment, execution modes, or runner changes.
+- Give first-time readers a plain definition of Elicit and headless-Elicit,
+  then connect the note to the question track, chronology, and relevant
+  experiment pages.
 
 ## Result
 
-- PR #81 merged as `a68a3efe`, and run
-  [29432455047](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29432455047)
-  used the approved experiment, `default_v2_mini.yaml`, inference revision
-  `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`, task
-  `83d10b06-26d1-4636-a32c-23f92c57f30b`, and selected `Sample.xlsx`.
-- Input validation, renderer installation/preflight, Azure OIDC, pinned HF
-  download, one XLSX render, and one vision request all passed. The visual item
-  returned `fail` with `perception_called=true`, complete usage, and one
-  provenance entry for relative path `Sample.xlsx`; no image payload, absolute
-  path, or traversal path was persisted.
-- The run produced 18 pass, 16 fail, 2 partial, and 2 `judge_error` verdicts
-  across 38 items. Text items `7c2d9c16-9c1b-481d-a34d-389dc96e7f88` and
-  `e52880a4-767f-47ea-97ea-a1cbc37256f6` returned non-empty but syntactically
-  malformed final JSON after five and four successful `read_deliverable` calls.
-  Empty-only recovery therefore did not fire. The task stopped with exit code
-  6, uploaded only a diagnostic artifact, and skipped grade commit, analysis,
-  relay, and all auto-dispatch steps.
-- Accounting was complete: 126 main calls plus one perception call, one render,
-  2,744,127 input tokens, 43,379 output tokens, and 915,712 cached tokens. The
-  repository price table estimates USD 0.73 raw / USD 0.62 cache-discounted;
-  the diagnostic task score was 54.07% but
-  remained excluded from the valid-task average because `error=judge_error`.
-- The same bounded finalization recovery now handles either empty final text or
-  syntactically unparseable final JSON. It still removes tools and parallel
-  tool settings, lowers reasoning to `low`, preserves ordered response context,
-  and accounts for every retry. Semantically invalid JSON objects are not
-  retried and continue through strict envelope validation; retry exhaustion
-  remains fail-closed.
+- Added `/notes/when-more-prompt-is-less` as the sixth RealWorks Field Note.
+  Its opening definition states that Elicit is not a separate model or service:
+  it is the GDPVal study's prompt strategy for making the model render, inspect,
+  and confidence-report its own deliverable in five steps. Headless-Elicit keeps
+  those five steps but changes STEP 2 from displaying PNGs to Pillow checks.
+- Restricted the quantitative comparison to the common subprocess surface:
+  exp003 completed 211/220 (95.9%) with 6.18 Self-QA, exp004 completed 200/220
+  (90.9%) with 5.87, and exp005 completed 199/220 (90.5%) with 6.16. The note
+  presents the divergence as lower coverage with a recovered average among
+  scored survivors, not as recovered end-to-end quality.
+- Excluded exp001 and exp002 from performance conclusions because their
+  canonical reports are unavailable. The article also identifies the
+  LibreOffice setting change in exp004 and resume-round change in exp005, so it
+  does not claim a causal prompt-only result.
+- Added a responsive prompt-complexity hero that shows the actual baseline,
+  five-step Elicit, and STEP 2 headless adaptation, plus a dual-axis
+  completion/Self-QA chart. The prompt-strategy question, first timeline event,
+  and exp003-exp005 Related Notes sections link to the article.
 
 ## Verification
 
-- Focused empty/malformed success, retry-budget exhaustion, and config-wiring
-  tests: **5 passed**; isolated affected suite: **147 passed**.
-- Broader non-integration suite excluding the unavailable local GDPVal parquet
-  fixture: **1,129 passed, 2 skipped, 37 deselected**. The omitted selector
-  module failed collection only because
-  `data/gdpval-local/data/train-00000-of-00001.parquet` is not present.
-- Tests explicitly loaded `core.tool_calling_judge` from this worktree before
-  running; both changed Python files compile, and static diagnostics found no
-  errors in the four changed Python files.
-- `git diff --check` passed.
+- `npm run build` passed after the article, hero, chart, and Elicit-definition
+  changes; TypeScript and Vite reported no errors.
+- `npm run test:aggregate` passed all 24 tests, including three new contracts
+  for the article links and metrics, source five-step design, mobile x-axis
+  labels, and reduced-motion series configuration.
+- VS Code diagnostics reported no errors in the four changed TypeScript files.
+- Production-preview checks passed at 1280x900 and 390x844 in light and dark
+  themes with no runtime errors or horizontal overflow. The page rendered one
+  hero, three completion bars, one Self-QA line, all three mobile x-axis labels,
+  and seven evidence links including the GDPVal Appendix A.3 source.
+- Reduced-motion emulation removed the animated SVG node and retained the
+  static scan line; after layout settled, the chart produced zero further path
+  mutations for one second. The question-track link and all exp003-exp005
+  Related Notes links resolved to the new article.
 
 ## Remaining Work
 
-- Merge the generic finalization retry and rerun the same one-task canary under
-  the owner's renewed monthly-credit approval.
-- Require successful main verdicts, exactly one render and perception call,
-  complete main/perception usage, valid relative-path provenance, and effective
-  cost below USD 1.
-- Do not expand to a full grading run from this canary.
+- Review and publish the validated branch, then verify the GitHub Pages route.
+- A controlled prompt-only rerun and external grading would still be required
+  before making a causal quality claim about Elicit versus baseline.


### PR DESCRIPTION
## Summary
- Publish a sixth RealWorks Field Note that defines Elicit as GDPVal's five-step verification prompt, not a separate model or service, and explains the headless STEP 2 adaptation.
- Compare exp003-exp005 completion and Self-QA while separating whole-run coverage from surviving-result self-assessment and documenting runner confounders.
- Add a responsive source-accurate hero, dual-axis chart, question/timeline/experiment links, and regression tests.

## Verification
- `npm run test:aggregate` — 24 passed
- `npm run build`
- `git diff --check origin/main...HEAD`
- Production preview at 1280x900 and 390x844, light/dark/reduced-motion: no runtime errors or overflow; 3 bars, 1 line, 3 mobile x labels; chart paths static after settling under reduced motion.
- first-reviewer: APPROVE
