### PR TITLE
fix(notes): source visuals from benchmark data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **Field Note benchmark data source** — replace duplicated completion and
+  Self-QA literals in the prompt-complexity article, SVG hero, metric strip,
+  result narrative, and comparison chart with an exact exp003-exp005 selector
+  over `generated/reports-index.json`. Experiment detail headers now apply the
+  same index `meta` and `summary` snapshot while retaining the lazy-loaded full
+  report for task-level evidence. The selector requires one unique row per ID,
+  the expected Baseline/Elicit/Elicit v2 conditions, subprocess mode, valid
+  finite ranges, and count/rate consistency; missing or invalid data renders an
+  explicit alert instead of stale fallback numbers. The article links directly
+  to the source JSON and all three experiment detail pages, including
+  accessible mobile card navigation.
 - **Public task-spec privacy cleanup** — remove a provider-account failover
   specification and unreferenced hidden sweep metadata, generalize
   organization-specific monthly budget and capacity statements, and keep

--- a/scripts/__tests__/field-notes.test.mjs
+++ b/scripts/__tests__/field-notes.test.mjs
@@ -1,8 +1,117 @@
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
+import ts from 'typescript'
 
 const readSource = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
+
+async function importTypeScriptModule(path) {
+  const source = await readSource(path)
+  const result = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2020 },
+    reportDiagnostics: true,
+  })
+  assert.equal(result.diagnostics?.length ?? 0, 0)
+  return import(`data:text/javascript;base64,${Buffer.from(result.outputText).toString('base64')}`)
+}
+
+test('prompt-complexity selector reads the report index used by experiment details', async () => {
+  const [{ selectPromptComplexityBenchmark }, reportsIndex] = await Promise.all([
+    importTypeScriptModule('src/lib/promptComplexityBenchmark.ts'),
+    readSource('public/generated/reports-index.json').then(JSON.parse),
+  ])
+
+  const selection = selectPromptComplexityBenchmark(reportsIndex.reports)
+  assert.equal(selection.status, 'ready')
+  assert.deepEqual(
+    selection.rows.map((row) => ({
+      shortId: row.shortId,
+      condition: row.condition,
+      mode: row.executionMode,
+      success: `${row.successCount}/${row.totalTasks}`,
+      completion: row.successRatePct,
+      qa: row.avgQaScore,
+    })),
+    [
+      { shortId: 'exp003', condition: 'Baseline', mode: 'subprocess', success: '211/220', completion: 95.9, qa: 6.18 },
+      { shortId: 'exp004', condition: 'Elicit', mode: 'subprocess', success: '200/220', completion: 90.9, qa: 5.87 },
+      { shortId: 'exp005', condition: 'Elicit v2', mode: 'subprocess', success: '199/220', completion: 90.5, qa: 6.16 },
+    ],
+  )
+  assert.equal(selection.completionDeltaPctPoints, -5.5)
+})
+
+test('prompt-complexity selector reports missing benchmark rows', async () => {
+  const { selectPromptComplexityBenchmark } = await importTypeScriptModule('src/lib/promptComplexityBenchmark.ts')
+  const selection = selectPromptComplexityBenchmark([])
+
+  assert.deepEqual(selection, {
+    status: 'missing',
+    missingIds: ['exp003', 'exp004', 'exp005'],
+  })
+})
+
+test('prompt-complexity selector rejects duplicate and invalid benchmark rows', async () => {
+  const [{ selectPromptComplexityBenchmark }, reportsIndex] = await Promise.all([
+    importTypeScriptModule('src/lib/promptComplexityBenchmark.ts'),
+    readSource('public/generated/reports-index.json').then(JSON.parse),
+  ])
+  const reports = reportsIndex.reports.filter((report) => ['exp003', 'exp004', 'exp005'].includes(report.short_id))
+
+  const duplicate = selectPromptComplexityBenchmark([...reports, reports.find((report) => report.short_id === 'exp003')])
+  assert.deepEqual(duplicate, { status: 'invalid', invalidIds: ['exp003'] })
+
+  const cases = [
+    ['non-string condition', (report) => { report.meta.condition_name = 42 }],
+    ['wrong condition', (report) => { report.meta.condition_name = 'Elicit' }],
+    ['non-string execution mode', (report) => { report.meta.execution_mode = 42 }],
+    ['wrong execution mode', (report) => { report.meta.execution_mode = 'code_interpreter' }],
+    ['zero total tasks', (report) => { report.summary.total_tasks = 0 }],
+    ['non-integer total tasks', (report) => { report.summary.total_tasks = 220.5 }],
+    ['negative success count', (report) => { report.summary.success_count = -1 }],
+    ['success count over total', (report) => { report.summary.success_count = 221 }],
+    ['non-integer success count', (report) => { report.summary.success_count = 210.5 }],
+    ['non-finite success rate', (report) => { report.summary.success_rate_pct = Number.NaN }],
+    ['negative success rate', (report) => { report.summary.success_rate_pct = -1 }],
+    ['success rate over 100', (report) => { report.summary.success_rate_pct = 101 }],
+    ['success rate inconsistent with counts', (report) => { report.summary.success_rate_pct = 95.8 }],
+    ['non-finite QA score', (report) => { report.summary.avg_qa_score = Number.NaN }],
+    ['negative QA score', (report) => { report.summary.avg_qa_score = -1 }],
+    ['QA score over 10', (report) => { report.summary.avg_qa_score = 11 }],
+  ]
+
+  for (const [name, mutate] of cases) {
+    const invalid = structuredClone(reports)
+    mutate(invalid.find((report) => report.short_id === 'exp003'))
+    assert.deepEqual(
+      selectPromptComplexityBenchmark(invalid),
+      { status: 'invalid', invalidIds: ['exp003'] },
+      name,
+    )
+  }
+})
+
+test('experiment detail summary uses the same report index snapshot as notes', async () => {
+  const [{ applyReportIndexSnapshot }, reportsIndex, hook] = await Promise.all([
+    importTypeScriptModule('src/lib/reportIndexSnapshot.ts'),
+    readSource('public/generated/reports-index.json').then(JSON.parse),
+    readSource('src/hooks/useReports.ts'),
+  ])
+  const entry = reportsIndex.reports.find((report) => report.short_id === 'exp003')
+  const fullReport = {
+    ...structuredClone(entry),
+    short_id: 'stale',
+    meta: { ...entry.meta, condition_name: 'stale condition' },
+    summary: { ...entry.summary, success_count: 0, success_rate_pct: 0, avg_qa_score: 0 },
+    task_results: [],
+  }
+
+  const merged = applyReportIndexSnapshot(fullReport, entry, 'exp003')
+  assert.equal(merged.short_id, 'exp003')
+  assert.deepEqual(merged.meta, entry.meta)
+  assert.deepEqual(merged.summary, entry.summary)
+  assert.match(hook, /applyReportIndexSnapshot\(data, entry, shortId\)/)
+})
 
 test('prompt-complexity note keeps its experiment and navigation contracts', async () => {
   const [journal, catalog] = await Promise.all([
@@ -13,22 +122,53 @@ test('prompt-complexity note keeps its experiment and navigation contracts', asy
   assert.match(catalog, /'when-more-prompt-is-less':[\s\S]*relatedExperiments: \['exp003', 'exp004', 'exp005'\]/)
   assert.match(journal, /articleSlug: 'when-more-prompt-is-less'/)
   assert.match(journal, /articleSlugs: \['when-more-prompt-is-less', 'why-build-a-sandbox'\]/)
-  assert.match(journal, /\{ label: 'exp003 Baseline', primary: 95\.9, secondary: 6\.18 \}/)
-  assert.match(journal, /\{ label: 'exp004 Elicit', primary: 90\.9, secondary: 5\.87 \}/)
-  assert.match(journal, /\{ label: 'exp005 Headless', primary: 90\.5, secondary: 6\.16 \}/)
+  assert.match(journal, /benchmark: \{ kind: 'prompt-complexity' \}/)
+  assert.match(journal, /benchmarkNarrative: 'prompt-complexity-results'/)
+  assert.doesNotMatch(journal, /\{ label: 'exp003 Baseline', primary:/)
   assert.match(journal, /Elicit은 별도 모델이나 서비스가 아니라[\s\S]*GDPVal 연구의 프롬프트 전략이다/)
   assert.match(journal, /https:\/\/arxiv\.org\/pdf\/2510\.04374#page=37/)
 })
 
 test('prompt-complexity hero reflects the source five-step design', async () => {
-  const hero = await readSource('src/components/notes/NoteHeroVisual.tsx')
+  const [hero, benchmark] = await Promise.all([
+    readSource('src/components/notes/NoteHeroVisual.tsx'),
+    readSource('src/lib/promptComplexityBenchmark.ts'),
+  ])
+  const promptSummary = hero.slice(
+    hero.indexOf("if (variant === 'prompt-complexity')"),
+    hero.indexOf("if (variant === 'runtime')"),
+  )
 
-  assert.match(hero, /mode: 'FIVE MANDATORY STEPS'/)
-  assert.match(hero, /'2 · DISPLAY PNG'/)
-  assert.match(hero, /mode: 'SAME FIVE STEPS · NEW STEP 2'/)
-  assert.match(hero, /'2 · PILLOW CHECK'/)
+  assert.match(benchmark, /mode: 'FIVE MANDATORY STEPS'/)
+  assert.match(benchmark, /'2 · DISPLAY PNG'/)
+  assert.match(benchmark, /mode: 'SAME FIVE STEPS · NEW STEP 2'/)
+  assert.match(benchmark, /'2 · PILLOW CHECK'/)
+  assert.match(hero, /promptBenchmark\.map/)
+  assert.match(hero, /getExperimentHref\(row\.shortId\)/)
+  assert.match(promptSummary, /aria-label="프롬프트 전략별 실험 상세"/)
+  assert.doesNotMatch(promptSummary, /role="img"/)
+  assert.doesNotMatch(hero, /success: '211 \/ 220'|\['Baseline', '기본 계약', '95\.9%'/)
   assert.doesNotMatch(hero, /checks: [367]/)
   assert.doesNotMatch(hero, /MORE CHECKS · FEWER FINISHES/)
+})
+
+test('journal article resolves visuals from reports and links to source details', async () => {
+  const [article, reportsHook] = await Promise.all([
+    readSource('src/pages/JournalArticle.tsx'),
+    readSource('src/hooks/useReports.ts'),
+  ])
+
+  assert.match(article, /selectPromptComplexityBenchmark\(reports\)/)
+  assert.match(article, /useReports\(usesPromptBenchmark\)/)
+  assert.match(article, /<JournalArticleContent key=\{slug \?\? 'missing'\} slug=\{slug\} \/>/)
+  assert.match(article, /generated\/reports-index\.json/)
+  assert.match(article, /getExperimentHref\(row\.shortId\)/)
+  assert.match(article, /promptBenchmark=\{readyPromptBenchmark\?\.rows\}/)
+  assert.match(article, /promptBenchmark\?\.status === 'invalid'/)
+  assert.match(reportsHook, /new AbortController\(\)/)
+  assert.match(reportsHook, /signal: controller\.signal/)
+  assert.match(reportsHook, /return \(\) => controller\.abort\(\)/)
+  assert.match(reportsHook, /if \(err\.name === 'AbortError'\) return/)
 })
 
 test('comparison chart preserves mobile labels and reduced-motion behavior', async () => {

--- a/src/components/notes/NoteHeroVisual.tsx
+++ b/src/components/notes/NoteHeroVisual.tsx
@@ -1,40 +1,27 @@
 import { motion, useReducedMotion } from 'framer-motion'
+import { Link } from 'react-router-dom'
 import type { JournalHero } from '../../data/journal'
+import { getExperimentHref } from '../../data/journalLinks'
+import type { PromptComplexityBenchmarkRow } from '../../lib/promptComplexityBenchmark'
 
 const resolveAsset = (src: string) => (
   src.startsWith('http') ? src : `${import.meta.env.BASE_URL}${src.replace(/^\/+/, '')}`
 )
 
-function PromptComplexityVisual({ reduceMotion }: { reduceMotion: boolean | null }) {
-  const cards = [
-    {
-      x: 70,
-      title: 'exp003 · BASELINE',
-      mode: 'BASIC OUTPUT CONTRACT',
-      steps: ['CREATE FILE', 'INSPECT INPUT', 'TEXT SUMMARY'],
-      success: '211 / 220',
-      qa: 'Self-QA 6.18',
-      color: '#2563eb',
-    },
-    {
-      x: 450,
-      title: 'exp004 · ELICIT',
-      mode: 'FIVE MANDATORY STEPS',
-      steps: ['1 · RENDER TO PNG', '2 · DISPLAY PNG', '3 · PROGRAM CHECK', '4 · MATCH REQUEST', '5 · FINAL FILE CHECK'],
-      success: '200 / 220',
-      qa: 'Self-QA 5.87',
-      color: '#b45309',
-    },
-    {
-      x: 830,
-      title: 'exp005 · HEADLESS',
-      mode: 'SAME FIVE STEPS · NEW STEP 2',
-      steps: ['1 · RENDER TO PNG', '2 · PILLOW CHECK', '3 · PROGRAM CHECK', '4 · MATCH REQUEST', '5 · FINAL FILE CHECK'],
-      success: '199 / 220',
-      qa: 'Self-QA 6.16',
-      color: '#be123c',
-    },
-  ]
+function PromptComplexityVisual({
+  reduceMotion,
+  benchmark,
+}: {
+  reduceMotion: boolean | null
+  benchmark: PromptComplexityBenchmarkRow[]
+}) {
+  const cards = benchmark.map((row, index) => ({
+    ...row,
+    x: 70 + index * 380,
+    title: `${row.shortId} · ${row.condition.toUpperCase()}`,
+    success: `${row.successCount} / ${row.totalTasks}`,
+    qa: `Self-QA ${row.avgQaScore.toFixed(2)}`,
+  }))
 
   return (
     <>
@@ -258,25 +245,41 @@ function SandboxVisual({ reduceMotion }: { reduceMotion: boolean | null }) {
   )
 }
 
-function MobileVisualSummary({ variant, alt }: { variant: Extract<JournalHero, { kind: 'visual' }>['variant']; alt: string }) {
+function MobileVisualSummary({
+  variant,
+  alt,
+  promptBenchmark,
+}: {
+  variant: Extract<JournalHero, { kind: 'visual' }>['variant']
+  alt: string
+  promptBenchmark?: PromptComplexityBenchmarkRow[]
+}) {
   if (variant === 'prompt-complexity') {
+    if (!promptBenchmark) return null
+    const styles = [
+      'border-blue-700/70 bg-blue-500/10',
+      'border-amber-700/70 bg-amber-500/10',
+      'border-rose-700/70 bg-rose-500/10',
+    ]
     return (
-      <div role="img" aria-label={alt} className="md:hidden min-h-[220px] px-3 py-6 bg-dash-surface border-y border-dash-border">
+      <div className="md:hidden min-h-[220px] px-3 py-6 bg-dash-surface border-y border-dash-border">
+        <span className="sr-only">{alt}</span>
         <div className="font-mono text-[11px] text-dash-text-secondary mb-5">BASELINE → 5-STEP ELICIT → HEADLESS</div>
-        <div className="grid grid-cols-3 gap-2">
-          {[
-            ['Baseline', '기본 계약', '95.9%', 'QA 6.18', 'border-blue-700/70 bg-blue-500/10'],
-            ['Elicit', '5단계 검사', '90.9%', 'QA 5.87', 'border-amber-700/70 bg-amber-500/10'],
-            ['Headless', 'STEP 2 교체', '90.5%', 'QA 6.16', 'border-rose-700/70 bg-rose-500/10'],
-          ].map(([title, mode, completion, qa, style]) => (
-            <div key={title} className={`min-w-0 border px-2 py-4 text-center ${style}`}>
-              <div className="text-[11px] font-medium text-dash-text-secondary">{title}</div>
-              <div className="mt-1 text-[10px] leading-4 text-dash-text-secondary">{mode}</div>
-              <div className="mt-3 font-mono text-xl font-semibold text-dash-heading">{completion}</div>
-              <div className="mt-2 text-[11px] text-dash-text-secondary">{qa}</div>
-            </div>
+        <nav className="grid grid-cols-3 gap-2" aria-label="프롬프트 전략별 실험 상세">
+          {promptBenchmark.map((row, index) => (
+            <Link
+              key={row.shortId}
+              to={getExperimentHref(row.shortId)}
+              className={`min-w-0 border px-2 py-4 text-center ${styles[index]}`}
+              aria-label={`${row.shortId} ${row.condition} 실험 상세 보기`}
+            >
+              <div className="text-[11px] font-medium text-dash-text-secondary">{row.condition}</div>
+              <div className="mt-1 text-[10px] leading-4 text-dash-text-secondary">{row.mobileMode}</div>
+              <div className="mt-3 font-mono text-xl font-semibold text-dash-heading">{row.successRatePct.toFixed(1)}%</div>
+              <div className="mt-2 text-[11px] text-dash-text-secondary">QA {row.avgQaScore.toFixed(2)}</div>
+            </Link>
           ))}
-        </div>
+        </nav>
         <p className="mt-5 text-center text-xs/[1.7] text-pretty break-keep text-dash-text-secondary">5단계 도입 뒤 완료율은 낮았고, STEP 2 교체 뒤 Self-QA는 baseline 수준으로 돌아왔다.</p>
       </div>
     )
@@ -396,7 +399,13 @@ function MobileVisualSummary({ variant, alt }: { variant: Extract<JournalHero, {
   )
 }
 
-export default function NoteHeroVisual({ hero }: { hero: JournalHero }) {
+export default function NoteHeroVisual({
+  hero,
+  promptBenchmark,
+}: {
+  hero: JournalHero
+  promptBenchmark?: PromptComplexityBenchmarkRow[]
+}) {
   const reduceMotion = useReducedMotion()
 
   if (hero.kind === 'video') {
@@ -423,10 +432,12 @@ export default function NoteHeroVisual({ hero }: { hero: JournalHero }) {
 
   return (
     <figure className="max-w-[1080px] mx-auto px-4 md:px-6 py-8 md:py-10">
-      <MobileVisualSummary variant={hero.variant} alt={hero.alt} />
+      <MobileVisualSummary variant={hero.variant} alt={hero.alt} promptBenchmark={promptBenchmark} />
       <div className="hidden md:block overflow-hidden border-y border-dash-border bg-dash-surface">
         <svg viewBox="0 0 1200 460" role="img" aria-label={hero.alt} className="block w-full aspect-[12/5]">
-          {hero.variant === 'prompt-complexity' && <PromptComplexityVisual reduceMotion={reduceMotion} />}
+          {hero.variant === 'prompt-complexity' && promptBenchmark && (
+            <PromptComplexityVisual reduceMotion={reduceMotion} benchmark={promptBenchmark} />
+          )}
           {hero.variant === 'runtime' && <RuntimeVisual reduceMotion={reduceMotion} />}
           {hero.variant === 'integrity' && <IntegrityVisual />}
           {hero.variant === 'perception' && <PerceptionVisual reduceMotion={reduceMotion} />}

--- a/src/data/journal.ts
+++ b/src/data/journal.ts
@@ -19,6 +19,7 @@ export interface JournalSection {
   paragraphs: string[]
   points?: string[]
   callout?: string
+  benchmarkNarrative?: 'prompt-complexity-results'
 }
 
 export interface JournalEvidence {
@@ -81,6 +82,7 @@ export interface JournalArticle {
   comparisonChart?: JournalComparisonChart
   sections: JournalSection[]
   evidence: JournalEvidence[]
+  benchmark?: { kind: 'prompt-complexity' }
   featured?: boolean
 }
 
@@ -114,16 +116,13 @@ export const journalArticles: JournalArticle[] = [
     publishedAt: '2026-07-16',
     period: 'exp001 → exp005',
     readingMinutes: 8,
-    metrics: [
-      { value: '95.9%', label: 'baseline 완료율' },
-      { value: '-5.5%p', label: 'baseline 대비 headless' },
-      { value: '6.18 ≈ 6.16', label: 'baseline ↔ headless Self-QA' },
-    ],
+    benchmark: { kind: 'prompt-complexity' },
+    metrics: [],
     hero: {
       kind: 'visual',
       variant: 'prompt-complexity',
       alt: 'exp003 baseline의 기본 계약과 exp004·005 Elicit의 5단계 검증 구조, 완료 작업 및 Self-QA를 비교하는 시각화',
-      caption: 'baseline 뒤 두 Elicit 실행은 같은 5단계를 사용하되 STEP 2의 검사 방식이 달랐다. 완료 작업은 211개에서 200개와 199개로 줄었지만, headless-Elicit의 Self-QA는 baseline과 거의 같았다.',
+      caption: '측정값은 benchmark report에서, 검증 구조는 각 experiment YAML에서 읽는다.',
     },
     comparisonChart: {
       kind: 'dual',
@@ -131,11 +130,7 @@ export const journalArticles: JournalArticle[] = [
       description: 'subprocess로 실행한 exp003·004·005에서 완료율은 계속 낮아졌지만, Self-QA는 Elicit에서 하락한 뒤 headless-Elicit에서 baseline 수준으로 회복했다.',
       primary: { label: 'Completion', unit: '%', color: '#2563eb', domain: [0, 100] },
       secondary: { label: 'Self-QA', unit: '/10', color: '#059669', domain: [0, 10] },
-      data: [
-        { label: 'exp003 Baseline', primary: 95.9, secondary: 6.18 },
-        { label: 'exp004 Elicit', primary: 90.9, secondary: 5.87 },
-        { label: 'exp005 Headless', primary: 90.5, secondary: 6.16 },
-      ],
+      data: [],
       caveat: 'Self-QA는 외부 채점이 아니라 점수가 존재하는 결과의 자기평가다. exp004는 LibreOffice 설치 설정, exp005는 resume round도 함께 바뀌어 프롬프트 단독 효과로 읽을 수 없다.',
     },
     sections: [
@@ -157,10 +152,8 @@ export const journalArticles: JournalArticle[] = [
       },
       {
         heading: '결과: 두 메트릭이 갈라졌다',
-        paragraphs: [
-          '완료율은 단순했다. baseline exp003은 211/220, 95.9%를 완료했다. 5단계를 도입한 Elicit exp004는 200/220, 90.9%, STEP 2를 바꾼 headless-Elicit exp005는 199/220, 90.5%였다. 관찰된 완료 수는 순서대로 211개, 200개, 199개였다.',
-          'Self-QA는 다른 모양이었다. 6.18에서 5.87로 내려갔다가 6.16으로 되돌아왔다. exp005는 baseline보다 12개를 덜 완료했지만, 점수가 남은 결과의 평균 자기평가는 baseline과 0.02점 차이였다. 완료율만 보면 악화였고 Self-QA만 보면 거의 회복이었다.',
-        ],
+        paragraphs: [],
+        benchmarkNarrative: 'prompt-complexity-results',
       },
       {
         heading: '해석: 살아남은 결과의 평균은 전체 커버리지가 아니다',
@@ -172,8 +165,8 @@ export const journalArticles: JournalArticle[] = [
       {
         heading: '실패: 검증 절차가 새로운 실패 표면이 됐다',
         paragraphs: [
-          'exp004 report에는 `soffice`를 찾지 못한 실패가 7건 반복된다. 더 많은 문서 검사를 요구했지만 runner가 그 도구를 안정적으로 제공하지 못하면 검증 단계 자체가 실행 실패가 된다.',
-          'exp005에서는 `CONFIDENCE[...]`가 실행 코드로 새어 들어가 NameError를 만든 사례가 7건 반복된다. 결과를 설명하기 위한 출력 규약이 코드 경계와 섞인 것이다. 길어진 검증 프롬프트에는 모델이 지켜야 할 계약뿐 아니라 잘못 해석할 수 있는 표면도 함께 들어왔다.',
+          'exp004 report에는 `soffice`를 찾지 못한 실패가 반복된다. 더 많은 문서 검사를 요구했지만 runner가 그 도구를 안정적으로 제공하지 못하면 검증 단계 자체가 실행 실패가 된다.',
+          'exp005에서는 `CONFIDENCE[...]`가 실행 코드로 새어 들어가 NameError를 만든 사례가 반복된다. 결과를 설명하기 위한 출력 규약이 코드 경계와 섞인 것이다. 길어진 검증 프롬프트에는 모델이 지켜야 할 계약뿐 아니라 잘못 해석할 수 있는 표면도 함께 들어왔다.',
         ],
       },
       {
@@ -202,17 +195,17 @@ export const journalArticles: JournalArticle[] = [
       },
       {
         label: 'exp003 baseline 리포트',
-        detail: '211/220 완료, Self-QA 6.18의 subprocess 기준선',
+        detail: 'subprocess baseline의 report와 결과 원문',
         href: `${REPO}/batch-runner/results/exp003_GPT52Chat_baseline_runner_exec/report/report.md`,
       },
       {
         label: 'exp004 Elicit 리포트',
-        detail: '200/220 완료와 반복된 soffice 실행 실패',
+        detail: 'Elicit report와 반복된 soffice 실행 실패 원문',
         href: `${REPO}/batch-runner/results/exp004_GPT52Chat_elicit_runner_exec/report/report.md`,
       },
       {
         label: 'exp005 headless-Elicit 리포트',
-        detail: '199/220 완료, Self-QA 6.16, CONFIDENCE NameError',
+        detail: 'headless-Elicit report와 CONFIDENCE NameError 원문',
         href: `${REPO}/batch-runner/results/exp005_GPT52Chat_elicit_v2_runner_exec/report/report.md`,
       },
       {

--- a/src/hooks/useReports.ts
+++ b/src/hooks/useReports.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { ReportData, ReportIndexEntry, ReportsIndex, ExperimentEntry, SectorMatrix } from '../types/report'
+import { applyReportIndexSnapshot } from '../lib/reportIndexSnapshot'
 
 export const HF_BASE = 'https://huggingface.co/datasets/HyeonSang'
 
@@ -8,7 +9,7 @@ export const HF_BASE = 'https://huggingface.co/datasets/HyeonSang'
  * Built at deploy time via aggregate-reports.mjs, which falls back to HuggingFace
  * when local report_data.json is absent.
  */
-export function useReports() {
+export function useReports(enabled = true) {
   const [reports, setReports] = useState<ReportIndexEntry[]>([])
   const [experiments, setExperiments] = useState<ExperimentEntry[]>([])
   const [sectorMatrix, setSectorMatrix] = useState<SectorMatrix>({})
@@ -17,7 +18,24 @@ export function useReports() {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    fetch(`${import.meta.env.BASE_URL}generated/reports-index.json?t=${Date.now()}`)
+    if (!enabled) {
+      setReports([])
+      setExperiments([])
+      setSectorMatrix({})
+      setGenerated('')
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setReports([])
+    setExperiments([])
+    setSectorMatrix({})
+    setGenerated('')
+    setLoading(true)
+    setError(null)
+    fetch(`${import.meta.env.BASE_URL}generated/reports-index.json?t=${Date.now()}`, { signal: controller.signal })
       .then((res) => {
         if (!res.ok) throw new Error(`Failed to fetch reports: ${res.status}`)
         return res.json() as Promise<ReportsIndex>
@@ -30,10 +48,13 @@ export function useReports() {
         setLoading(false)
       })
       .catch((err) => {
+        if (err.name === 'AbortError') return
         setError(err.message)
         setLoading(false)
       })
-  }, [])
+
+    return () => controller.abort()
+  }, [enabled])
 
   return { reports, experiments, sectorMatrix, generated, loading, error }
 }
@@ -68,15 +89,15 @@ export function useReport(shortId: string | undefined) {
         return res.json() as Promise<ReportData>
       })
       .then((data) => {
-        data.short_id = shortId
+        const reportWithIndexSnapshot = applyReportIndexSnapshot(data, entry, shortId)
         // Merge error messages from error_tasks into task_results
-        if (data.error_tasks?.length && data.task_results) {
-          const errorMap = new Map(data.error_tasks.map((et) => [et.task_id, et.error]))
-          for (const task of data.task_results) {
+        if (reportWithIndexSnapshot.error_tasks?.length && reportWithIndexSnapshot.task_results) {
+          const errorMap = new Map(reportWithIndexSnapshot.error_tasks.map((et) => [et.task_id, et.error]))
+          for (const task of reportWithIndexSnapshot.task_results) {
             if (errorMap.has(task.task_id)) task.error = errorMap.get(task.task_id)
           }
         }
-        setReport(data)
+        setReport(reportWithIndexSnapshot)
         setLoading(false)
       })
       .catch((err) => {

--- a/src/lib/promptComplexityBenchmark.ts
+++ b/src/lib/promptComplexityBenchmark.ts
@@ -1,0 +1,135 @@
+import type { ReportIndexEntry } from '../types/report'
+
+export const PROMPT_COMPLEXITY_REPORT_IDS = ['exp003', 'exp004', 'exp005'] as const
+
+export type PromptComplexityReportId = (typeof PROMPT_COMPLEXITY_REPORT_IDS)[number]
+
+interface PromptComplexityPresentation {
+  mode: string
+  mobileMode: string
+  steps: string[]
+  color: string
+}
+
+interface PromptComplexityDefinition extends PromptComplexityPresentation {
+  expectedCondition: string
+  expectedExecutionMode: string
+}
+
+const presentationById: Record<PromptComplexityReportId, PromptComplexityDefinition> = {
+  exp003: {
+    expectedCondition: 'Baseline',
+    expectedExecutionMode: 'subprocess',
+    mode: 'BASIC OUTPUT CONTRACT',
+    mobileMode: '기본 계약',
+    steps: ['CREATE FILE', 'INSPECT INPUT', 'TEXT SUMMARY'],
+    color: '#2563eb',
+  },
+  exp004: {
+    expectedCondition: 'Elicit',
+    expectedExecutionMode: 'subprocess',
+    mode: 'FIVE MANDATORY STEPS',
+    mobileMode: '5단계 검사',
+    steps: ['1 · RENDER TO PNG', '2 · DISPLAY PNG', '3 · PROGRAM CHECK', '4 · MATCH REQUEST', '5 · FINAL FILE CHECK'],
+    color: '#b45309',
+  },
+  exp005: {
+    expectedCondition: 'Elicit v2',
+    expectedExecutionMode: 'subprocess',
+    mode: 'SAME FIVE STEPS · NEW STEP 2',
+    mobileMode: 'STEP 2 교체',
+    steps: ['1 · RENDER TO PNG', '2 · PILLOW CHECK', '3 · PROGRAM CHECK', '4 · MATCH REQUEST', '5 · FINAL FILE CHECK'],
+    color: '#be123c',
+  },
+}
+
+export interface PromptComplexityBenchmarkRow extends PromptComplexityPresentation {
+  shortId: PromptComplexityReportId
+  condition: string
+  executionMode: string
+  successCount: number
+  totalTasks: number
+  successRatePct: number
+  avgQaScore: number
+}
+
+export type PromptComplexityBenchmarkSelection =
+  | {
+      status: 'ready'
+      rows: PromptComplexityBenchmarkRow[]
+      completionDeltaPctPoints: number
+    }
+  | {
+      status: 'missing'
+      missingIds: PromptComplexityReportId[]
+    }
+  | {
+      status: 'invalid'
+      invalidIds: PromptComplexityReportId[]
+    }
+
+const roundToOneDecimal = (value: number) => Math.round(value * 10) / 10
+
+function isValidBenchmarkReport(shortId: PromptComplexityReportId, report: ReportIndexEntry) {
+  const { meta, summary } = report
+  if (!meta || !summary) return false
+  if (typeof meta.condition_name !== 'string' || typeof meta.execution_mode !== 'string') return false
+
+  const presentation = presentationById[shortId]
+  if (meta.condition_name !== presentation.expectedCondition) return false
+  if (meta.execution_mode !== presentation.expectedExecutionMode) return false
+
+  const { total_tasks: totalTasks, success_count: successCount, success_rate_pct: successRate, avg_qa_score: avgQaScore } = summary
+  if (!Number.isInteger(totalTasks) || totalTasks <= 0) return false
+  if (!Number.isInteger(successCount) || successCount < 0 || successCount > totalTasks) return false
+  if (!Number.isFinite(successRate) || successRate < 0 || successRate > 100) return false
+  if (!Number.isFinite(avgQaScore) || avgQaScore < 0 || avgQaScore > 10) return false
+
+  return Math.abs(successRate - roundToOneDecimal((successCount / totalTasks) * 100)) < 0.05
+}
+
+export function selectPromptComplexityBenchmark(
+  reports: ReportIndexEntry[],
+): PromptComplexityBenchmarkSelection {
+  const matchingReports = new Map(
+    PROMPT_COMPLEXITY_REPORT_IDS.map((shortId) => [
+      shortId,
+      reports.filter((report) => report.short_id === shortId),
+    ]),
+  )
+  const missingIds = PROMPT_COMPLEXITY_REPORT_IDS.filter((shortId) => matchingReports.get(shortId)?.length === 0)
+
+  if (missingIds.length > 0) return { status: 'missing', missingIds }
+
+  const invalidIds = PROMPT_COMPLEXITY_REPORT_IDS.filter((shortId) => {
+    const matches = matchingReports.get(shortId) ?? []
+    return matches.length !== 1 || !isValidBenchmarkReport(shortId, matches[0])
+  })
+
+  if (invalidIds.length > 0) return { status: 'invalid', invalidIds }
+
+  const rows = PROMPT_COMPLEXITY_REPORT_IDS.map((shortId) => {
+    const report = matchingReports.get(shortId)![0]
+    return {
+      shortId,
+      condition: report.meta.condition_name,
+      executionMode: report.meta.execution_mode,
+      successCount: report.summary.success_count,
+      totalTasks: report.summary.total_tasks,
+      successRatePct: report.summary.success_rate_pct,
+      avgQaScore: report.summary.avg_qa_score,
+      mode: presentationById[shortId].mode,
+      mobileMode: presentationById[shortId].mobileMode,
+      steps: presentationById[shortId].steps,
+      color: presentationById[shortId].color,
+    }
+  })
+
+  const baseline = rows[0]
+  const headless = rows[rows.length - 1]
+  const completionDeltaPctPoints = roundToOneDecimal(
+    ((headless.successCount / headless.totalTasks) - (baseline.successCount / baseline.totalTasks)) * 100,
+  )
+
+  return { status: 'ready', rows, completionDeltaPctPoints }
+}

--- a/src/lib/reportIndexSnapshot.ts
+++ b/src/lib/reportIndexSnapshot.ts
@@ -1,0 +1,14 @@
+import type { ReportData, ReportIndexEntry } from '../types/report'
+
+export function applyReportIndexSnapshot(
+  report: ReportData,
+  entry: ReportIndexEntry,
+  shortId: string,
+): ReportData {
+  return {
+    ...report,
+    short_id: shortId,
+    meta: entry.meta,
+    summary: entry.summary,
+  }
+}

--- a/src/pages/JournalArticle.tsx
+++ b/src/pages/JournalArticle.tsx
@@ -13,10 +13,17 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useTheme } from '../contexts/ThemeContext'
 import NoteComparisonChart from '../components/notes/NoteComparisonChart'
 import NoteHeroVisual from '../components/notes/NoteHeroVisual'
+import { useReports } from '../hooks/useReports'
+import {
+  selectPromptComplexityBenchmark,
+  type PromptComplexityBenchmarkRow,
+  type PromptComplexityBenchmarkSelection,
+} from '../lib/promptComplexityBenchmark'
 import {
   getJournalArticle,
   journalArticles,
   lensLabels,
+  type JournalArticle as JournalArticleData,
   type JournalLens,
 } from '../data/journal'
 import { getExperimentHref, isExternalExperimentHref } from '../data/journalLinks'
@@ -28,11 +35,103 @@ const lensStyles: Record<JournalLens, string> = {
   domain: 'text-rose-700 dark:text-rose-300 bg-rose-500/10 border-rose-500/20',
 }
 
+type ReadyPromptBenchmark = Extract<PromptComplexityBenchmarkSelection, { status: 'ready' }>
+
+const formatSigned = (value: number, suffix: string) => `${value > 0 ? '+' : ''}${value.toFixed(1)}${suffix}`
+
+function resolvePromptComplexityArticle(article: JournalArticleData, benchmark: ReadyPromptBenchmark) {
+  const baseline = benchmark.rows[0]
+  const headless = benchmark.rows[benchmark.rows.length - 1]
+  const completedDifference = baseline.successCount - headless.successCount
+  const qaDifference = Math.abs(baseline.avgQaScore - headless.avgQaScore)
+
+  return {
+    metrics: [
+      { value: `${baseline.successRatePct.toFixed(1)}%`, label: `${baseline.condition} 완료율` },
+      { value: formatSigned(benchmark.completionDeltaPctPoints, '%p'), label: `${baseline.shortId} 대비 ${headless.shortId}`, note: 'success_count / total_tasks 기준' },
+      { value: `${baseline.avgQaScore.toFixed(2)} ≈ ${headless.avgQaScore.toFixed(2)}`, label: `${baseline.shortId} ↔ ${headless.shortId} Self-QA` },
+    ],
+    hero: article.hero ? {
+      ...article.hero,
+      caption: `report summary 기준 완료 작업은 ${benchmark.rows.map((row) => `${row.shortId} ${row.successCount}/${row.totalTasks}`).join(', ')}였다. Self-QA는 ${benchmark.rows.map((row) => row.avgQaScore.toFixed(2)).join(' → ')}로 움직였다.`,
+    } : undefined,
+    chart: article.comparisonChart ? {
+      ...article.comparisonChart,
+      data: benchmark.rows.map((row) => ({
+        label: `${row.shortId} ${row.condition}`,
+        primary: row.successRatePct,
+        secondary: row.avgQaScore,
+      })),
+    } : undefined,
+    sections: article.sections.map((section) => section.benchmarkNarrative === 'prompt-complexity-results' ? {
+      ...section,
+      paragraphs: [
+        `완료율은 ${benchmark.rows.map((row) => `${row.condition} ${row.shortId} ${row.successCount}/${row.totalTasks}, ${row.successRatePct.toFixed(1)}%`).join(' · ')}였다. 관찰된 완료 수는 순서대로 ${benchmark.rows.map((row) => `${row.successCount}개`).join(', ')}였다.`,
+        `Self-QA는 ${benchmark.rows.map((row) => row.avgQaScore.toFixed(2)).join(' → ')}로 움직였다. ${headless.shortId}는 ${baseline.shortId}보다 ${completedDifference}개를 덜 완료했지만, 점수가 남은 결과의 평균 자기평가는 ${qaDifference.toFixed(2)}점 차이였다. 완료율만 보면 악화였고 Self-QA만 보면 거의 회복이었다.`,
+      ],
+    } : section),
+  }
+}
+
+function BenchmarkDataSource({ rows, generated }: { rows: PromptComplexityBenchmarkRow[]; generated: string }) {
+  return (
+    <aside className="mb-10 border-y border-dash-border py-4 text-[11px]/[1.7] text-dash-text-secondary" aria-label="Benchmark data source">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <span className="font-mono text-[10px] font-semibold text-emerald-700 dark:text-emerald-400">BENCHMARK DATA</span>
+        <a
+          href={`${import.meta.env.BASE_URL}generated/reports-index.json`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400"
+        >
+          reports-index.json <ExternalLink className="h-3 w-3" />
+        </a>
+        {rows.map((row) => (
+          <Link
+            key={row.shortId}
+            to={getExperimentHref(row.shortId)}
+            className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400"
+          >
+            {row.shortId} 상세 <ArrowRight className="h-3 w-3" />
+          </Link>
+        ))}
+      </div>
+      <div className="mt-2 text-dash-text-muted">
+        측정값: reports-index.json report summary · 상세 페이지 상단과 동일 snapshot · 프롬프트 구조: experiment YAML{generated ? ` · index generated ${generated}` : ''}
+      </div>
+    </aside>
+  )
+}
+
+function BenchmarkDataState({ message, error }: { message: string; error?: boolean }) {
+  return (
+    <div className="max-w-[1080px] mx-auto px-4 md:px-6 py-8 md:py-10">
+      <div className="border-y border-dash-border bg-dash-surface px-5 py-8 text-sm text-dash-text-secondary" role={error ? 'alert' : 'status'}>
+        {message}
+      </div>
+    </div>
+  )
+}
+
 export default function JournalArticle() {
   const { slug } = useParams()
+
+  return <JournalArticleContent key={slug ?? 'missing'} slug={slug} />
+}
+
+function JournalArticleContent({ slug }: { slug: string | undefined }) {
   const navigate = useNavigate()
   const { isDark, toggle: toggleTheme } = useTheme()
   const article = getJournalArticle(slug)
+  const usesPromptBenchmark = article?.benchmark?.kind === 'prompt-complexity'
+  const { reports, generated, loading: reportsLoading, error: reportsError } = useReports(usesPromptBenchmark)
+  const promptBenchmark = usesPromptBenchmark && !reportsLoading && !reportsError
+    ? selectPromptComplexityBenchmark(reports)
+    : null
+  const readyPromptBenchmark = promptBenchmark?.status === 'ready' ? promptBenchmark : null
+  const resolved = article && readyPromptBenchmark
+    ? resolvePromptComplexityArticle(article, readyPromptBenchmark)
+    : null
 
   useEffect(() => {
     window.scrollTo(0, 0)
@@ -53,6 +152,10 @@ export default function JournalArticle() {
   const related = journalArticles
     .filter((item) => item.slug !== article.slug && item.relatedExperiments.some((id) => article.relatedExperiments.includes(id)))
     .slice(0, 2)
+  const displayedMetrics = resolved?.metrics ?? article.metrics
+  const displayedChart = resolved?.chart ?? article.comparisonChart
+  const displayedSections = (resolved?.sections ?? article.sections)
+    .filter((section) => !section.benchmarkNarrative || readyPromptBenchmark)
 
   return (
     <div lang="ko" className="min-h-screen bg-dash-page text-dash-text font-journal-sans">
@@ -98,9 +201,23 @@ export default function JournalArticle() {
           </div>
         </header>
 
-        {article.hero && <NoteHeroVisual hero={article.hero} />}
+        {article.hero && (!usesPromptBenchmark || readyPromptBenchmark) && (
+          <NoteHeroVisual
+            hero={resolved?.hero ?? article.hero}
+            promptBenchmark={readyPromptBenchmark?.rows}
+          />
+        )}
+        {usesPromptBenchmark && reportsLoading && <BenchmarkDataState message="benchmark report 데이터를 불러오는 중입니다." />}
+        {usesPromptBenchmark && reportsError && <BenchmarkDataState error message={`benchmark report를 불러오지 못했습니다: ${reportsError}`} />}
+        {usesPromptBenchmark && promptBenchmark?.status === 'missing' && (
+          <BenchmarkDataState error message={`benchmark report에서 ${promptBenchmark.missingIds.join(', ')} 행을 찾지 못했습니다.`} />
+        )}
+        {usesPromptBenchmark && promptBenchmark?.status === 'invalid' && (
+          <BenchmarkDataState error message={`benchmark report의 ${promptBenchmark.invalidIds.join(', ')} 행이 유효하지 않습니다.`} />
+        )}
 
         <div className="max-w-[760px] mx-auto px-4 md:px-6 py-12 md:py-16">
+          {readyPromptBenchmark && <BenchmarkDataSource rows={readyPromptBenchmark.rows} generated={generated} />}
           <div className="mb-14 md:mb-16">
             <div className="flex items-center gap-3 mb-4" aria-hidden="true">
               <span className="font-mono text-[10px] text-emerald-600 dark:text-emerald-400">THESIS</span>
@@ -111,20 +228,24 @@ export default function JournalArticle() {
             </blockquote>
           </div>
 
-          <div className="grid grid-cols-3 border-y border-dash-border mb-16 md:mb-20">
-            {article.metrics.map((metric) => (
-              <div key={metric.label} className="py-6 md:py-7 px-2 md:px-4 text-center border-r border-dash-border last:border-r-0">
-                <div className="font-mono text-xl md:text-[28px] font-semibold text-dash-heading mb-2">{metric.value}</div>
-                <div className="text-[10px] md:text-xs text-dash-text-muted leading-[1.5]">{metric.label}</div>
-                {metric.note && <div className="text-[9px] text-dash-text-faint mt-1.5">{metric.note}</div>}
-              </div>
-            ))}
-          </div>
+          {displayedMetrics.length > 0 && (
+            <div className="grid grid-cols-3 border-y border-dash-border mb-16 md:mb-20">
+              {displayedMetrics.map((metric) => (
+                <div key={metric.label} className="py-6 md:py-7 px-2 md:px-4 text-center border-r border-dash-border last:border-r-0">
+                  <div className="font-mono text-xl md:text-[28px] font-semibold text-dash-heading mb-2">{metric.value}</div>
+                  <div className="text-[10px] md:text-xs text-dash-text-muted leading-[1.5]">{metric.label}</div>
+                  {metric.note && <div className="text-[9px] text-dash-text-faint mt-1.5">{metric.note}</div>}
+                </div>
+              ))}
+            </div>
+          )}
 
-          {article.comparisonChart && <NoteComparisonChart chart={article.comparisonChart} />}
+          {displayedChart && (!usesPromptBenchmark || readyPromptBenchmark) && (
+            <NoteComparisonChart chart={displayedChart} />
+          )}
 
           <div className="space-y-16 md:space-y-20">
-            {article.sections.map((section, sectionIndex) => (
+            {displayedSections.map((section, sectionIndex) => (
               <section key={section.heading}>
                 <div className="mb-6 md:mb-8">
                   <div className="flex items-center gap-3 mb-3" aria-hidden="true">

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,68 +4,63 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-16
-- Status: Canary accepted; finalization guardrails merged
+- Status: Field Note benchmark data source implemented and locally verified
 
 ## Task
 
-- Verify the post-PR83 one-task Azure Vision canary against the approved XLSX
-  scope without dispatching another paid run.
-- Bound finalization recovery to at most one retry even when configuration asks
-  for more.
-- Reject unexpected function calls during tool-free finalization and prove that
-  latency, TPM guards, tokens, cache usage, and incomplete usage remain exact.
+- Make `/notes/when-more-prompt-is-less` derive its metrics, SVG, chart, and
+  result prose from benchmark data instead of duplicated literals.
+- Use the same build-time report snapshot as `/experiments/exp003`, exp004, and
+  exp005, and provide direct links to both the JSON source and detail pages.
+- Fail closed when required experiment rows are missing, duplicated, malformed,
+  or no longer match the intended subprocess comparison contract.
 
 ## Result
 
-- Post-PR83 run
-  [29435264166](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29435264166)
-  completed successfully on `1b1efd47` for the single approved exp003 task
-  `83d10b06-26d1-4636-a32c-23f92c57f30b`, pinned inference revision
-  `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`, `default_v2_mini.yaml`, and
-  `Sample.xlsx`.
-- All 38 item verdicts were valid: 17 pass, 18 fail, and 3 partial, with no
-  `judge_error` and no task error. The task received 31.9/63 (50.63%). A fail
-  verdict is a valid quality judgment here; it is distinct from runtime or
-  parser failure.
-- The visual acceptance path used exactly one render and one perception call.
-  Visual item `a64588ed-db04-4b8b-b3b8-3674ddcf10d1` routed to `visual`, set
-  `perception_called=true`, and retained relative provenance `Sample.xlsx`
-  without an absolute/traversal path or persisted image payload.
-- Usage accounting was complete: 127 main calls plus one perception call;
-  2,833,647 main input, 43,646 main output, 913,152 cached, 1,182 perception
-  input, and 176 perception output tokens. Analysis estimated USD 0.75 raw and
-  USD 0.64 cache-discounted, below the per-run USD 1 gate.
-- Grade commit `a7c76fa` and analysis commit `e0ea080` landed on `main`. Relay,
-  next-chunk, mini-full, and hybrid/mini comparison dispatches were skipped.
-- `ToolCallingJudge.finalization_retries` is now clamped to at most one while
-  preserving zero as disabled. This prevents larger `judge_max_retries` values
-  from silently increasing the finalization cost ceiling.
-- A function call returned during finalization now becomes
-  `unexpected_tool_call_during_finalization` without dispatching a file-read,
-  audio, vision, or other tool. The result remains score-excluded and
-  fail-closed.
-- Deterministic coverage proves both upstream guard invocations, summed latency,
-  input/output/cache totals, and `usage_complete=false` propagation when retry
-  usage is missing. No paid workflow was dispatched for this guardrail work.
-- Guardrails PR [#88](https://github.com/hyeonsangjeon/gdpval-realworks/pull/88)
-  was squash-merged to `main` as `2728ef7d5fa7d24c24401cf303a27e5fcd933e24`.
-  The merge triggered no GitHub Actions workflow, including no paid grading,
-  batch, cost-sweep, sandbox, or canary run.
+- Added a strict selector over `reports-index.json` that returns exp003, exp004,
+  and exp005 in comparison order. It reads condition, execution mode, success
+  count, total tasks, completion rate, and average Self-QA from each report's
+  `meta` and `summary` fields.
+- Removed the article's duplicated benchmark values. The top metrics, desktop
+  SVG, mobile cards, chart, caption, and result paragraphs now resolve from the
+  selected rows; only YAML-backed presentation labels such as the five steps
+  and Pillow replacement remain editorial data.
+- Added a visible `BENCHMARK DATA` source strip linking to
+  `generated/reports-index.json` and `/experiments/exp003`, exp004, and exp005.
+  Mobile comparison cards are accessible links to the same detail routes.
+- Detail pages continue to lazy-load full Hugging Face reports for task-level
+  content, but their header `meta` and `summary` are replaced with the matching
+  report-index entry. The article and detail header therefore use one immutable
+  build snapshot instead of potentially drifting summaries.
+- The selector rejects missing and duplicate IDs, non-string or unexpected
+  conditions/modes, zero or non-integer totals, invalid success counts,
+  non-finite/out-of-range rates and QA, and rates inconsistent with raw counts.
+  Missing, invalid, or failed JSON loads show an alert and render no benchmark
+  metrics, visual, chart, result paragraph, or numeric evidence fallback.
 
 ## Verification
 
-- Focused clamp, tool-rejection, malformed recovery, accounting, and config
-  wiring tests: **6 passed** under the real Python 3.11 sandbox environment.
-- Affected tool-calling, wiring, selector, and Step 8 suite: **166 passed**.
-- Broader non-integration suite excluding only the unavailable local GDPVal
-  parquet fixture: **1,128 passed, 6 skipped, 37 deselected**. The omitted
-  selector module requires
-  `data/gdpval-local/data/train-00000-of-00001.parquet`.
-- Python compilation, static diagnostics, and `git diff --check` passed.
+- Focused Field Note and selector contracts: **8 passed**; full aggregate suite:
+  **29 passed**. `npm run build`, static diagnostics, and `git diff --check`
+  passed.
+- Production-preview comparison read the actual JSON response and matched all
+  three rows to the metric strip, SVG labels, chart data/ARIA, and generated
+  result prose. The exp003 detail route showed the same 211/220, 95.9%, and
+  6.18/10 values.
+- Desktop and 390px dark/reduced-motion checks found no horizontal overflow.
+  The mobile visual exposed three detail links and all three chart labels.
+- Injecting an invalid exp005 row and aborting the JSON request each produced an
+  explicit alert with zero benchmark numbers, visual, chart, metric strip, or
+  numeric evidence in the full DOM.
+- Injecting a stale zeroed summary into the lazy HF exp003 response still left
+  the detail header at the index snapshot values and hid the stale condition,
+  proving the article/detail source contract at runtime.
+- SPA transitions from a normal note into a failed benchmark load produced no
+  false missing-row alert. After a successful benchmark load, leaving and
+  returning with a failed request also exposed no stale numbers, hero, or
+  chart; slug-keyed remounting and request abort cleanup reset the state.
 
 ## Remaining Work
 
-- No additional canary is needed because run 29435264166 already passed every
-  approved acceptance gate.
-- Do not expand this one-task canary into a full grading run without separate
-  scope and cost approval.
+- Review and publish the validated branch, then verify the public article and
+  detail links against the deployed generated JSON.


### PR DESCRIPTION
## Summary
- Derive the prompt-complexity Field Note metrics, SVG, mobile cards, chart, caption, and result prose from the exp003-exp005 rows in `generated/reports-index.json`.
- Keep experiment detail headers on the same index `meta`/`summary` snapshot while lazy-loading full reports for task-level evidence.
- Add JSON and exp003-exp005 source links, strict row validation, accessible mobile navigation, and fail-closed loading/error behavior.

## Verification
- `npm run test:aggregate` — 29 passed
- `npm run build`
- `git diff --check`
- first-reviewer: APPROVE
- Playwright: JSON ↔ metrics/SVG/chart/result exact match; exp003 detail uses same snapshot; desktop/mobile no overflow; invalid/network/stale-route states expose no fallback numbers.