### PR TITLE
docs(notes): record benchmark deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ entries land under a fresh dated heading the day they merge to `main`.
   finite ranges, and count/rate consistency; missing or invalid data renders an
   explicit alert instead of stale fallback numbers. The article links directly
   to the source JSON and all three experiment detail pages, including
-  accessible mobile card navigation.
+  accessible mobile card navigation. Shipped through PR #90 (`b9e224a`) and
+  successful Pages run
+  [29475359417](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29475359417);
+  the deployed JSON, article, and exp003 detail values were verified to match.
 - **Public task-spec privacy cleanup** — remove a provider-account failover
   specification and unreferenced hidden sweep metadata, generalize
   organization-specific monthly budget and capacity statements, and keep

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,7 +4,7 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-16
-- Status: Field Note benchmark data source implemented and locally verified
+- Status: Field Note benchmark data source published and production-verified
 
 ## Task
 
@@ -37,6 +37,10 @@ task. It must be refreshed before a task is reported complete.
   non-finite/out-of-range rates and QA, and rates inconsistent with raw counts.
   Missing, invalid, or failed JSON loads show an alert and render no benchmark
   metrics, visual, chart, result paragraph, or numeric evidence fallback.
+- Squash-merged the reviewed change through PR #90 as `b9e224a`. Automatic
+  `Aggregate Tests & Deploy` run
+  [29475359417](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29475359417)
+  completed the build and GitHub Pages deployment successfully.
 
 ## Verification
 
@@ -59,8 +63,15 @@ task. It must be refreshed before a task is reported complete.
   false missing-row alert. After a successful benchmark load, leaving and
   returning with a failed request also exposed no stale numbers, hero, or
   chart; slug-keyed remounting and request abort cleanup reset the state.
+- On the deployed site, the public JSON rows for exp003-exp005 matched the
+  metric strip, SVG labels, chart data/ARIA, and result prose exactly. The
+  public exp003 detail page showed the same 211/220, 95.9%, 6.18/10, and
+  Baseline values.
+- Public 390px dark/reduced-motion verification exposed all three experiment
+  card links and chart labels with no horizontal overflow, no hero animation,
+  and zero post-settle chart mutations.
 
 ## Remaining Work
 
-- Review and publish the validated branch, then verify the public article and
-  detail links against the deployed generated JSON.
+- No implementation or deployment work remains for this Field Note data-source
+  change.


### PR DESCRIPTION
## Summary
- Record PR #90 and successful Pages deployment for the benchmark-backed Field Note.
- Replace local-verification status with deployed JSON/article/detail evidence.
- Mark the data-source change complete.

## Verification
- first-reviewer: APPROVE
- PR #90 merged as b9e224a
- Pages run 29475359417: success
- Public JSON ↔ article ↔ exp003 detail and mobile reduced-motion checks passed