### PR TITLE
fix(grading): make audio routing file-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **Track 2 isolated cohort configs** — add Stage A three-task and Stage B
+  ten-task validation configs whose parsed runtime semantics exactly match
+  `default_v2_mini`; distinct config names, hashes, grader-source identities,
+  and output paths prevent either stage from overwriting the accepted one-task
+  canary or each other.
 - **Track 2 cohort expansion preregistration** — add a dated, immutable
   two-stage plan for expanding the accepted exp003 one-task canary to three and
   then ten tasks without overwriting the canary artifact. The plan fixes task
@@ -22,6 +27,14 @@ entries land under a fresh dated heading the day they merge to `main`.
   implemented and the planned 5/27 render-perception call counts are rechecked.
 
 ### Fixed
+- **File-compatible audio routing** — retain criterion-level audio
+  classification for inventory, but downgrade runtime routing to text when the
+  selected targets contain no supported audio extension. This prevents an XLSX
+  `Sound Technician` cost criterion from suggesting `probe_audio`. Selection,
+  routing, and `read_deliverable` now share one WAV/MP3/FLAC/OGG/M4A/AAC set;
+  extensionless targets remain conservatively audio while known unsupported
+  suffixes downgrade to text. Recomputed cohort plans contain zero false audio
+  routes and preserve the preregistered 5/27 render-perception call counts.
 - **Field Note benchmark data source** — replace duplicated completion and
   Self-QA literals in the prompt-complexity article, SVG hero, metric strip,
   result narrative, and comparison chart with an exact exp003-exp005 selector

--- a/batch-runner/core/deliverable_selector.py
+++ b/batch-runner/core/deliverable_selector.py
@@ -14,6 +14,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from core.grader_routing import is_overall_style_criterion
+from core.media_types import GRADER_AUDIO_EXTENSIONS
 
 
 DOCUMENT_EXTENSIONS = {
@@ -26,8 +27,7 @@ DOCUMENT_EXTENSIONS = {
     ".ppt",
     ".pptx",
     ".zip",
-    ".wav",
-    ".mp3",
+    *GRADER_AUDIO_EXTENSIONS,
     ".mp4",
     ".mov",
     ".ipynb",
@@ -40,7 +40,7 @@ SPREADSHEET_EXTENSIONS = {".xls", ".xlsx", ".xlsm", ".csv"}
 WORD_EXTENSIONS = {".doc", ".docx"}
 PRESENTATION_EXTENSIONS = {".ppt", ".pptx"}
 VIDEO_EXTENSIONS = {".mp4", ".mov"}
-AUDIO_EXTENSIONS = {".wav", ".mp3"}
+AUDIO_EXTENSIONS = set(GRADER_AUDIO_EXTENSIONS)
 
 
 ITEM_TARGET_AUDIT_SCHEMA: dict[str, Any] = {
@@ -416,7 +416,7 @@ def _required_primary_extensions(text: str) -> set[str]:
         (r"(single|exactly one|final|primary|deliverable).*\.xlsx|single excel workbook|single workbook", SPREADSHEET_EXTENSIONS),
         (r"(single|exactly one|final|primary|deliverable).*\.pptx|single powerpoint|single presentation", PRESENTATION_EXTENSIONS),
         (r"(single|all content|deliverable).*\.zip|single \.zip|single zip", {".zip"}),
-        (r"(audio file|wav file|delivered audio|deliverable audio)", {".wav"}),
+        (r"(audio file|wav file|delivered audio|deliverable audio)", AUDIO_EXTENSIONS),
         (r"(final deliverable).*\.mp4|final .*mp4|mp4 video|final composited video|final video", VIDEO_EXTENSIONS),
         (r"python notebook|\.ipynb|notebook file", {".ipynb"}),
     ]

--- a/batch-runner/core/grader_routing.py
+++ b/batch-runner/core/grader_routing.py
@@ -23,6 +23,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Iterable
 
+from core.media_types import GRADER_AUDIO_EXTENSIONS
+
 
 class Modality(str, Enum):
     """Coarse classification of what a rubric criterion is actually
@@ -146,9 +148,10 @@ def resolve_runtime_routing(
     """Apply target-aware policy without changing criterion classification."""
     decision = classify_criterion(criterion_text)
     suffixes = {
-        Path(path).suffix.lower()
+        suffix
         for path in selected_paths
         if isinstance(path, str) and path
+        if (suffix := Path(path).suffix.lower())
     }
     if (
         is_overall_style_criterion(criterion_text)
@@ -158,6 +161,16 @@ def resolve_runtime_routing(
         return RoutingDecision(
             modality=Modality.FORMATTING,
             preferred_op="inspect_formatting",
+            matched_keywords=decision.matched_keywords,
+        )
+    if (
+        decision.modality is Modality.AUDIO
+        and suffixes
+        and suffixes.isdisjoint(GRADER_AUDIO_EXTENSIONS)
+    ):
+        return RoutingDecision(
+            modality=Modality.TEXT,
+            preferred_op="read_content",
             matched_keywords=decision.matched_keywords,
         )
     return decision

--- a/batch-runner/core/media_types.py
+++ b/batch-runner/core/media_types.py
@@ -1,0 +1,13 @@
+"""Shared media type sets for grader selection, routing, and tools."""
+
+from __future__ import annotations
+
+
+GRADER_AUDIO_EXTENSIONS = frozenset({
+    ".wav",
+    ".mp3",
+    ".flac",
+    ".ogg",
+    ".m4a",
+    ".aac",
+})

--- a/batch-runner/core/tools/read_deliverable.py
+++ b/batch-runner/core/tools/read_deliverable.py
@@ -38,6 +38,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from core.media_types import GRADER_AUDIO_EXTENSIONS
+
 # ── Constants ─────────────────────────────────────────────────────────
 
 #: Full public Python API. The harness uses render_to_image internally;
@@ -206,8 +208,7 @@ _EXT_KIND = {
     ".json": "txt",
     ".png": "image", ".jpg": "image", ".jpeg": "image",
     ".gif": "image", ".bmp": "image", ".webp": "image",
-    ".wav": "audio", ".mp3": "audio", ".flac": "audio",
-    ".ogg": "audio", ".m4a": "audio", ".aac": "audio",
+    **{extension: "audio" for extension in GRADER_AUDIO_EXTENSIONS},
     ".mp4": "video", ".mov": "video", ".webm": "video",
     ".mkv": "video", ".avi": "video",
 }

--- a/batch-runner/grading_configs/validation_v2_mini_cohort10.yaml
+++ b/batch-runner/grading_configs/validation_v2_mini_cohort10.yaml
@@ -1,0 +1,88 @@
+schema_version: "2.0"
+config_name: "validation_v2_mini_cohort10"
+description: |
+  Artifact-isolated Stage B clone of default_v2_mini for the preregistered
+  ten-task mixed-format Track 2 cohort. Runtime grading semantics must remain
+  identical to the baseline; only config identity and this description differ.
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.4-mini"
+  deployment: "gpt-5.4-mini"
+  api_version: "2025-04-01-preview"
+  endpoint_env: "AZURE_OPENAI_ENDPOINT"
+  timeout_sec: 600
+  reasoning:
+    effort: "medium"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.4"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      endpoint_env: "AZURE_AUDIO_ENDPOINT"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  revision: "main"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v1"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+  grades_per_task: 3
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"

--- a/batch-runner/grading_configs/validation_v2_mini_cohort3.yaml
+++ b/batch-runner/grading_configs/validation_v2_mini_cohort3.yaml
@@ -1,0 +1,88 @@
+schema_version: "2.0"
+config_name: "validation_v2_mini_cohort3"
+description: |
+  Artifact-isolated Stage A clone of default_v2_mini for the preregistered
+  three-task Track 2 cohort. Runtime grading semantics must remain identical
+  to the baseline; only config identity and this description differ.
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.4-mini"
+  deployment: "gpt-5.4-mini"
+  api_version: "2025-04-01-preview"
+  endpoint_env: "AZURE_OPENAI_ENDPOINT"
+  timeout_sec: 600
+  reasoning:
+    effort: "medium"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.4"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      endpoint_env: "AZURE_AUDIO_ENDPOINT"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  revision: "main"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v1"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+  grades_per_task: 3
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"

--- a/batch-runner/tests/test_grader_selector_integration.py
+++ b/batch-runner/tests/test_grader_selector_integration.py
@@ -9,6 +9,9 @@ from types import SimpleNamespace
 
 import pytest
 
+from core.deliverable_selector import AUDIO_EXTENSIONS, select_deliverables
+from core.media_types import GRADER_AUDIO_EXTENSIONS
+
 
 def _final(text: str) -> dict:
     return {"type": "message", "content": [{"type": "output_text", "text": text}]}
@@ -93,6 +96,31 @@ def _payload(verdict: str, partial: float, evidence: str) -> str:
             "tool_calls_made": 0,
         }
     )
+
+
+@pytest.mark.parametrize("suffix", sorted(GRADER_AUDIO_EXTENSIONS))
+def test_selector_preserves_supported_audio_primary(suffix: str):
+    selection = select_deliverables(
+        task_id="audio-task",
+        deliverable_files=[f"final_mix{suffix}", "production_notes.txt"],
+        instruction="Submit a single audio file with supporting notes.",
+    )
+
+    assert AUDIO_EXTENSIONS == set(GRADER_AUDIO_EXTENSIONS)
+    assert selection.selection_status == "ok"
+    assert selection.task_class == "main_plus_support"
+    assert selection.primary_targets[0].paths == [f"final_mix{suffix}"]
+    assert selection.support_artifacts == ["production_notes.txt"]
+
+
+def test_selector_rejects_known_unsupported_audio_primary():
+    selection = select_deliverables(
+        task_id="audio-task",
+        deliverable_files=["final_mix.wma", "production_notes.txt"],
+        instruction="Submit a single audio file with supporting notes.",
+    )
+
+    assert selection.selection_status == "wrong_format_primary"
 
 
 def _grader(monkeypatch, fake_client):

--- a/batch-runner/tests/test_grading_config.py
+++ b/batch-runner/tests/test_grading_config.py
@@ -83,6 +83,51 @@ def test_default_v2_config_loads_and_validates():
     assert data["judge"]["critical"]["rule"] == "abs_max_score_threshold"
 
 
+@pytest.mark.parametrize(
+    ("filename", "config_name"),
+    [
+        ("validation_v2_mini_cohort3.yaml", "validation_v2_mini_cohort3"),
+        ("validation_v2_mini_cohort10.yaml", "validation_v2_mini_cohort10"),
+    ],
+)
+def test_cohort_configs_only_change_baseline_identity(
+    filename: str, config_name: str
+):
+    baseline_path = Path("grading_configs/default_v2_mini.yaml")
+    candidate_path = Path("grading_configs") / filename
+    baseline = yaml.safe_load(baseline_path.read_text(encoding="utf-8"))
+    candidate = yaml.safe_load(candidate_path.read_text(encoding="utf-8"))
+
+    validate_grading_config(candidate)
+    assert candidate["config_name"] == config_name
+    baseline_hash = hash_config(str(baseline_path))
+    candidate_hash = hash_config(str(candidate_path))
+    assert candidate_hash != baseline_hash
+
+    common = {
+        "experiment_id": "exp003_GPT52Chat_baseline_runner_exec",
+        "judge_slug": "gpt-5_4-mini",
+        "rubric_sha": "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+        "rubric_short_sha": "11e7900",
+        "prompt_version": "v2.2",
+        "inference_sha": INFERENCE_SHA,
+        "grader_source_hash": GRADER_SOURCE_HASH,
+    }
+    baseline_output = resolve_grade_output_path(
+        baseline, config_hash=baseline_hash, **common
+    )
+    candidate_output = resolve_grade_output_path(
+        candidate, config_hash=candidate_hash, **common
+    )
+    assert candidate_output != baseline_output
+    assert f"__{config_name}__cfg_{candidate_hash}__" in candidate_output.name
+
+    for key in ("config_name", "description"):
+        baseline.pop(key)
+        candidate.pop(key)
+    assert candidate == baseline
+
+
 def test_v2_tools_block_requires_ops_list(tmp_path):
     cfg = _valid_config(tmp_path)
     cfg["schema_version"] = "2.0"

--- a/batch-runner/tests/test_perception_routing.py
+++ b/batch-runner/tests/test_perception_routing.py
@@ -101,6 +101,59 @@ def test_mixed_overall_style_target_remains_visual_at_parent_level():
     assert decision.modality is Modality.VISUAL
 
 
+def test_audio_keyword_with_xlsx_target_downgrades_to_text():
+    criterion = (
+        "Band and Crew includes Sound Technician fees attributed to the tour "
+        "manager."
+    )
+
+    assert classify_criterion(criterion).modality is Modality.AUDIO
+    decision = resolve_runtime_routing(criterion, ["tour_budget.xlsx"])
+
+    assert decision.modality is Modality.TEXT
+    assert decision.preferred_op == "read_content"
+    assert decision.matched_keywords == ("sound",)
+
+
+def test_audio_keyword_with_extensionless_target_stays_audio():
+    decision = resolve_runtime_routing(
+        "Audio mix avoids clipping", ["recording"]
+    )
+
+    assert decision.modality is Modality.AUDIO
+    assert decision.preferred_op == "probe_audio"
+
+
+def test_audio_keyword_with_known_unsupported_target_downgrades_to_text():
+    decision = resolve_runtime_routing(
+        "Audio mix avoids clipping", ["recording.wma"]
+    )
+
+    assert decision.modality is Modality.TEXT
+    assert decision.preferred_op == "read_content"
+
+
+@pytest.mark.parametrize("suffix", [".wav", ".mp3", ".flac", ".ogg", ".m4a", ".aac"])
+def test_audio_keyword_with_supported_audio_target_remains_audio(suffix: str):
+    decision = resolve_runtime_routing(
+        "Audio mix avoids clipping and excessive noise",
+        [f"deliverable{suffix}"],
+    )
+
+    assert decision.modality is Modality.AUDIO
+    assert decision.preferred_op == "probe_audio"
+
+
+def test_runtime_audio_resolution_is_target_specific():
+    criterion = "The sound is clear and free from clipping"
+
+    audio_child = resolve_runtime_routing(criterion, ["mix.wav"])
+    text_child = resolve_runtime_routing(criterion, ["budget.xlsx"])
+
+    assert audio_child.modality is Modality.AUDIO
+    assert text_child.modality is Modality.TEXT
+
+
 def test_routing_decision_to_prompt_hint_keys():
     d = classify_criterion("audio mix")
     hint = d.to_prompt_hint()

--- a/tasks/0717_friday/TRACK2_COHORT_EXPANSION_EXPERIMENT.md
+++ b/tasks/0717_friday/TRACK2_COHORT_EXPANSION_EXPERIMENT.md
@@ -1,7 +1,7 @@
 # Track 2 Cohort Expansion Experiment
 
 - Date: 2026-07-17
-- Status: `PREFLIGHT_BLOCKED`
+- Status: `IMPLEMENTATION_VALIDATED_DISPATCH_PENDING`
 - Owner: repository operator
 - Experiment family: rubric grading / harness-owned perception
 - Prior accepted run: GitHub Actions `29435264166`
@@ -151,12 +151,42 @@ supported audio extension. The focused regression must prove:
 
 - `Sound Technician` + XLSX routes to text;
 - a real audio criterion + WAV/MP3 remains audio;
-- mixed child routing preserves real audio children;
+- all six grader-supported audio suffixes remain selectable and probeable;
+- extensionless targets remain conservatively audio, while a known unsupported
+   suffix downgrades to text;
 - route totals become 142 text / 6 formatting / 5 visual for Stage A and
    401 text / 16 formatting / 17 visual / 1 mixed for Stage B;
 - planned render/vision calls remain 5 and 27 respectively.
 
 No paid run may be dispatched while this blocker is open.
+
+### Blocker Resolution
+
+Runtime routing now downgrades an audio-keyword decision to text when selected
+paths have known suffixes but none is a supported audio type. WAV, MP3, FLAC,
+OGG, M4A, and AAC targets remain audio. Selection, routing, and
+`read_deliverable` now import one shared extension set. The exact
+`Sound Technician` XLSX case, every supported primary format, extensionless
+paths, and known unsupported suffixes are covered by deterministic tests.
+
+Post-fix recomputation produced:
+
+| Cohort | Items | Prechecks | Text | Formatting | Visual | Audio | Mixed | Planned render/vision calls |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Stage A (3) | 153 | 9 | 142 | 6 | 5 | 0 | 0 | 5 |
+| Stage B (10) | 435 | 21 | 401 | 16 | 17 | 0 | 1 | 27 |
+
+Validation results:
+
+- perception-routing unit suite: 33 passed;
+- selector, mixed visual-child, visual-inventory, and tool-dispatch suite: 50
+   passed before the shared audio-format follow-up;
+- shared routing/selector/read-tool/config affected suite: 141 passed;
+- broad non-integration suite: 1,151 passed, 2 skipped, 37 deselected;
+- cohort config baseline-parity and output-isolation tests: 2 passed.
+
+The blocker is closed. Paid dispatch remains pending until this implementation
+is merged and its `main` SHA is written below.
 
 ## Stage Gates
 
@@ -221,30 +251,30 @@ audited, but they must not be committed as accepted grades.
 
 | Field | Planned / observed |
 |---|---|
-| Main SHA | pending |
-| Grader source hash | pending |
-| Config hash | pending |
-| Output path | pending |
-| Ordered task IDs | pending preflight |
+| Main SHA | pending implementation merge |
+| Grader source hash | `86a0061a58077438a9408dc3efc3c90173eaf2ccb232a0bfdf6a162018f1805e` |
+| Config hash | `0f76ea22614bdc13` |
+| Output path | `data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort3__cfg_0f76ea22614bdc13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_86a0061a58077438__v2.2.json` |
+| Ordered task IDs | verified first 3 pinned IDs |
 | Rubric items / prechecks | 153 / 9 |
-| Route counts | blocked: 141 text / 6 formatting / 5 visual / 1 false audio |
+| Route counts | 142 text / 6 formatting / 5 visual |
 | Render / perception calls | 5 / 5 planned |
 | Run ID | not dispatched |
 | Result | not started |
 | Raw / effective cost | not started |
-| Decision | `HOLD_ROUTING_FIX_REQUIRED` |
+| Decision | `READY_AFTER_MERGE` |
 
 ## Stage B Log
 
 | Field | Planned / observed |
 |---|---|
-| Main SHA | pending |
-| Grader source hash | pending |
-| Config hash | pending |
-| Output path | pending |
-| Ordered task IDs | pending preflight |
+| Main SHA | pending implementation merge |
+| Grader source hash | `2ff175c16298a23bb22952c84c5e2e1902829a69f74f4d104ac2016f29fd8745` |
+| Config hash | `9760999170801c4c` |
+| Output path | `data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort10__cfg_9760999170801c4c__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_2ff175c16298a23b__v2.2.json` |
+| Ordered task IDs | verified first 10 pinned IDs |
 | Rubric items / prechecks | 435 / 21 |
-| Route counts | blocked: 400 text / 16 formatting / 17 visual / 1 false audio / 1 mixed |
+| Route counts | 401 text / 16 formatting / 17 visual / 1 mixed |
 | Render / perception calls | 27 / 27 planned |
 | Run ID | not dispatched |
 | Result | not started |

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,55 +4,54 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-17
-- Status: Track 2 expansion planned; model-free preflight blocked paid run
+- Status: Track 2 routing blocker fixed; isolated cohort configs ready
 
 ## Task
 
-- Preregister the next Track 2 grading experiment before any paid dispatch.
-- Expand the accepted exp003 canary through a gated three-task cohort and then
-  a ten-task mixed-format cohort with immutable identities and isolated output
-  artifacts.
-- Preserve enough chronological, quantitative, and failure evidence for a
-  later experiment retrospective.
+- Resolve the file-incompatible audio route discovered by the 2026-07-17
+  Track 2 cohort preflight.
+- Preserve supported audio selection and probing while eliminating false audio
+  escalation for known non-audio deliverables.
+- Add artifact-isolated Stage A/B configs that are otherwise semantically
+  identical to `default_v2_mini`.
 
 ## Result
 
-- Added
-  `tasks/0717_friday/TRACK2_COHORT_EXPANSION_EXPERIMENT.md` with fixed source,
-  rubric, judge, prompt, ordered task IDs, artifact-isolation requirements,
-  stage gates, stop conditions, execution sequence, and retrospective prompts.
-- Stage A covers the first three pinned tasks (153 rubric items); Stage B covers
-  the first ten (435 items) and adds PDF, DOCX, PNG, multiple-primary, and mixed
-  child-routing surfaces.
-- Current-code model-free routing calculated Stage A as 141 text, 6 formatting,
-  5 visual, and 1 audio route with 5 planned render/perception calls. Stage B
-  calculated 400 text, 16 formatting, 17 visual, 1 audio, and 1 mixed route
-  with 27 planned calls.
-- Preflight found that the Stage A XLSX criterion `Sound Technician` is routed
-  to audio solely by the keyword `sound`, despite having no audio file. This is
-  a file-incompatible false positive. The plan is marked
-  `PREFLIGHT_BLOCKED`; no paid workflow was dispatched.
-- The prerequisite fix is explicit: downgrade audio classifications to text
-  when selected paths contain no supported audio extension, while preserving
-  real WAV/MP3 and mixed-child audio routing.
+- `resolve_runtime_routing()` now checks selected target suffixes. Audio
+  keyword matches downgrade to text only when known selected paths are disjoint
+  from WAV, MP3, FLAC, OGG, M4A, and AAC.
+- The exact XLSX `Sound Technician` criterion now routes to text. Supported
+  audio files remain audio, extensionless paths remain conservatively audio,
+  and known unsupported suffixes route to text.
+- Selection, runtime routing, and `read_deliverable` share one supported audio
+  extension set. Selector tests prove all six types remain primary deliverables
+  rather than becoming `wrong_format_primary`.
+- Post-fix model-free preflight now reports Stage A as 142 text, 6 formatting,
+  and 5 visual routes; Stage B reports 401 text, 16 formatting, 17 visual, and
+  1 mixed route. False audio routes are zero and planned render/perception
+  calls remain 5 and 27.
+- Added `validation_v2_mini_cohort3.yaml` and
+  `validation_v2_mini_cohort10.yaml`. Parsed config parity proves that only
+  `config_name` and description differ from `default_v2_mini`.
+- Stage A config hash is `0f76ea22614bdc13` with grader source hash
+  `86a0061a58077438a9408dc3efc3c90173eaf2ccb232a0bfdf6a162018f1805e`.
+  Stage B config hash is `9760999170801c4c` with grader source hash
+  `2ff175c16298a23bb22952c84c5e2e1902829a69f74f4d104ac2016f29fd8745`.
+- The dated plan is updated to
+  `IMPLEMENTATION_VALIDATED_DISPATCH_PENDING`. No paid workflow was dispatched.
 
 ## Verification
 
-- All ten planned IDs exactly match the first ten rows of the local exp003
-  snapshot, and the first ID matches the accepted canary task.
-- The pinned inference SHA and full rubric SHA are present in the plan.
-- Route totals and planned visual-call counts were recomputed with current
-  routing code over the historical 220-task grade's selected paths.
-- The plan contains no provider-account relationship or organization operating
-  budget details, and `git diff --check` passes.
-- The file is ignored by default under the privacy policy and will be
-  deliberately force-added because the owner requested it as a public
-  retrospective source.
+- Shared routing, selector, read-tool, config, visual-inventory, and
+  tool-dispatch suite: **141 passed**.
+- Broad non-integration suite excluding the unavailable local GDPVal parquet
+  fixture: **1,151 passed, 2 skipped, 37 deselected**.
+- Cohort config parity and output-isolation tests: **2 passed**.
+- Current-worktree import paths were verified before tests; cohort route totals
+  were recomputed with the modified module; `git diff --check` passes.
 
 ## Remaining Work
 
-- Merge the preregistration plan.
-- Implement and test file-compatible audio routing, then update the plan's
-  preflight route totals.
-- Add isolated Stage A/B grading configs, dispatch Stage A once, and advance to
-  Stage B only if every preregistered gate passes.
+- Merge this implementation and record the resulting `main` SHA in the plan.
+- Dispatch Stage A once with `tasks_limit=3` and the pinned inference revision.
+- Advance to Stage B only if every Stage A gate passes.


### PR DESCRIPTION
## Summary
- share one WAV/MP3/FLAC/OGG/M4A/AAC set across selection, runtime routing, and read_deliverable
- downgrade audio-keyword routes only for known non-audio suffixes; keep extensionless paths conservative
- add artifact-isolated 3-task and 10-task configs matching default_v2_mini semantics
- update the dated preregistration with resolved route totals, identities, gates, and retrospective fields

## Preflight result
- Stage A: 153 items, 142 text / 6 formatting / 5 visual, 5 planned visual calls
- Stage B: 435 items, 401 text / 16 formatting / 17 visual / 1 mixed, 27 planned visual calls
- false audio routes: 0

## Verification
- focused contracts: 58 passed
- affected suite: 141 passed
- broad non-integration suite: 1,151 passed, 2 skipped, 37 deselected
- static diagnostics, compile, config parity/output isolation, and git diff --check passed
- no paid workflow dispatched