### PR TITLE
fix(grading): support mixed-format visual bundles

### DIFF
--- a/.github/workflows/preflight-track2-cohort.yml
+++ b/.github/workflows/preflight-track2-cohort.yml
@@ -337,6 +337,7 @@ jobs:
               "planned_render_calls",
               "planned_audio_calls",
               "planned_perception_calls",
+              "unsupported_visual_paths",
               "errors",
           )
           summary = {key: plan[key] for key in keys}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ entries land under a fresh dated heading the day they merge to `main`.
   Stage B is now limited to exact first-10 model-free preflight before dispatch.
 
 ### Fixed
+- **Mixed-format visual bundle preflight** — filter harness rendering to stable
+  supported paths while retaining all selected paths for main-judge evidence.
+  Stage B preflight run `29583415563` exposed nine organization-chart criteria
+  whose DOCX/PDF/XLSX bundle was rejected solely because DOCX is not renderable;
+  the corrected boundary renders PDF/XLSX, records the filtered DOCX, and keeps
+  unsupported-only visual targets fail closed. Runtime and planner now validate
+  split children and item/task caps in the same pre-render order.
 - **Exact planner perception accounting** — bump the planner contract to v2,
   count audio separately from harness-owned visual calls, enforce visual/audio
   task caps, and fail closed whenever an audio route exists because the main

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -215,6 +215,7 @@ class _RuntimeCriterionPlan:
     item_decision: RoutingDecision
     target_decisions: dict[str, RoutingDecision]
     visual_paths: tuple[str, ...]
+    visual_preflight_error: Optional[str]
     supported_visual_call_count: int
     requires_visual: bool
 
@@ -579,6 +580,35 @@ class Grader:
                 items.append(ig)
                 continue
 
+            if runtime_plan.visual_preflight_error:
+                if plan.target_scope == "split_children":
+                    ig, in_tok, out_tok, calls, latency, cached = self._judge_split_children(
+                        task,
+                        item,
+                        selection,
+                        deliverable_path,
+                        reference_file_names,
+                        plan,
+                        runtime_plan=runtime_plan,
+                        preflight_error=runtime_plan.visual_preflight_error,
+                    )
+                    judge_call_count += calls
+                    judge_total_latency_ms += latency
+                    judge_input_tokens += in_tok
+                    judge_output_tokens += out_tok
+                    judge_cached_tokens += cached
+                else:
+                    ig = self._selection_ungraded_item(
+                        item,
+                        runtime_plan.visual_preflight_error,
+                        selection,
+                        plan,
+                    )
+                    ig.routing_modality = Modality.VISUAL.value
+                    ig.tools_used = []
+                items.append(ig)
+                continue
+
             if visual_budget_error and runtime_plan.requires_visual:
                 if plan.target_scope == "split_children":
                     ig, in_tok, out_tok, calls, latency, cached = self._judge_split_children(
@@ -703,6 +733,8 @@ class Grader:
         )
         target_decisions: dict[str, RoutingDecision] = {}
         raw_visual_paths: list[str] = []
+        supported_visual_paths: list[str] = []
+        visual_preflight_error: str | None = None
         if plan.target_scope == "split_children":
             target_by_id = {
                 target.target_id: target for target in selection.primary_targets
@@ -715,21 +747,44 @@ class Grader:
                 target_decisions[target_id] = decision
                 if decision.modality is Modality.VISUAL:
                     raw_visual_paths.extend(target.paths)
+                    planned_names, child_error = (
+                        self._tool_judge.validate_planned_visual_names(
+                            target.paths
+                        )
+                    )
+                    supported_visual_paths.extend(planned_names)
+                    if child_error is not None and visual_preflight_error is None:
+                        visual_preflight_error = (
+                            f"{target_id}: {child_error}"
+                        )
         elif item_decision.modality is Modality.VISUAL:
             raw_visual_paths.extend(plan.selected_paths)
+            supported_visual_paths, visual_preflight_error = (
+                self._tool_judge.validate_planned_visual_names(
+                    plan.selected_paths
+                )
+            )
 
-        visual_paths = tuple(sorted(
-            dict.fromkeys(raw_visual_paths),
-            key=lambda path: (path.casefold(), path),
-        ))
-        supported_visual_call_count = len(
-            self._tool_judge.planned_supported_visual_names(raw_visual_paths)
+        if (
+            plan.target_scope == "split_children"
+            and supported_visual_paths
+            and visual_preflight_error is None
+        ):
+            supported_visual_paths, visual_preflight_error = (
+                self._tool_judge.validate_planned_visual_names(
+                    supported_visual_paths
+                )
+            )
+        visual_paths = tuple(supported_visual_paths)
+        supported_visual_call_count = (
+            len(visual_paths) if visual_preflight_error is None else 0
         )
         return _RuntimeCriterionPlan(
             target_plan=plan,
             item_decision=item_decision,
             target_decisions=target_decisions,
             visual_paths=visual_paths,
+            visual_preflight_error=visual_preflight_error,
             supported_visual_call_count=supported_visual_call_count,
             requires_visual=bool(raw_visual_paths),
         )
@@ -870,112 +925,119 @@ class Grader:
             )
             entry_paths = {entry.path for entry in visual_prepass.entries}
             all_children_covered = all(
-                set(target_by_id[target_id].paths).issubset(entry_paths)
+                bool(expected_paths)
+                and set(expected_paths).issubset(entry_paths)
                 for target_id in plan.target_ids
                 if target_id in target_by_id and target_id in visual_target_ids
+                for expected_paths in [
+                    self._tool_judge.planned_supported_visual_names(
+                        target_by_id[target_id].paths
+                    )
+                ]
             )
             if visual_prepass.judge_error is None and not all_children_covered:
                 visual_prepass.judge_error = (
                     "required_visual_prepass_incomplete_for_split_children"
                 )
-            if visual_prepass.judge_error is not None:
-                for target_id in plan.target_ids:
-                    target = target_by_id.get(target_id)
-                    if target is None:
-                        continue
-                    child_decision = runtime_plan.target_decisions[target_id]
-                    child_prepass = (
-                        visual_prepass.subset(list(target.paths))
-                        if child_decision.modality is Modality.VISUAL else None
-                    )
-                    child_grades.append({
-                        "target_id": target_id,
-                        "selected_paths": list(target.paths),
-                        "verdict": "judge_error",
-                        "awarded_score": 0.0,
-                        "evidence": visual_prepass.judge_error[:200],
-                        "judge_confidence": None,
-                        "routing_modality": child_decision.modality.value,
-                        "perception_called": (
-                            child_prepass is not None
-                            and child_prepass.perception_call_count > 0
-                        ),
-                        "tools_used": (
-                            list(child_prepass.tools_used)
-                            if child_prepass is not None else []
-                        ),
-                        "visual_provenance": (
-                            child_prepass.to_provenance()
-                            if child_prepass is not None else []
-                        ),
-                        "score_excluded": True,
-                        "judge_call_count": 0,
-                        "judge_input_tokens": 0,
-                        "judge_output_tokens": 0,
-                        "judge_cached_tokens": 0,
-                        "perception_call_count": (
-                            child_prepass.perception_call_count
-                            if child_prepass is not None else 0
-                        ),
-                        "perception_input_tokens": (
-                            child_prepass.perception_input_tokens
-                            if child_prepass is not None else 0
-                        ),
-                        "perception_output_tokens": (
-                            child_prepass.perception_output_tokens
-                            if child_prepass is not None else 0
-                        ),
-                        "perception_cached_tokens": (
-                            child_prepass.perception_cached_tokens
-                            if child_prepass is not None else 0
-                        ),
-                        "perception_total_latency_ms": round(
-                            child_prepass.perception_total_latency_ms, 2
-                        ) if child_prepass is not None else 0.0,
-                        "render_call_count": (
-                            child_prepass.render_call_count
-                            if child_prepass is not None else 0
-                        ),
-                        "render_total_latency_ms": round(
-                            child_prepass.render_total_latency_ms, 2
-                        ) if child_prepass is not None else 0.0,
-                        "usage_complete": (
-                            child_prepass.usage_complete
-                            if child_prepass is not None else True
-                        ),
-                    })
-                ig = ItemGrade(
-                    rubric_item_id=item.rubric_item_id,
-                    criterion=item.criterion,
-                    max_score=item.score,
-                    awarded_score=0.0,
-                    verdict="judge_error",
-                    decided_by="judge",
-                    required=item.required,
-                    evidence=visual_prepass.judge_error[:200],
-                    judge_confidence=None,
-                    judge_latency_ms=0.0,
-                    routing_modality=parent_routing_modality,
-                    perception_called=(visual_prepass.perception_call_count > 0),
-                    tools_used=list(visual_prepass.tools_used),
-                    visual_provenance=visual_prepass.to_provenance(),
-                    child_grades=child_grades,
-                    score_excluded=True,
-                    perception_call_count=visual_prepass.perception_call_count,
-                    perception_input_tokens=visual_prepass.perception_input_tokens,
-                    perception_output_tokens=visual_prepass.perception_output_tokens,
-                    perception_cached_tokens=visual_prepass.perception_cached_tokens,
-                    perception_total_latency_ms=round(
-                        visual_prepass.perception_total_latency_ms, 2
-                    ),
-                    render_call_count=visual_prepass.render_call_count,
-                    render_total_latency_ms=round(
-                        visual_prepass.render_total_latency_ms, 2
-                    ),
-                    usage_complete=visual_prepass.usage_complete,
+
+        if visual_prepass is not None and visual_prepass.judge_error is not None:
+            for target_id in plan.target_ids:
+                target = target_by_id.get(target_id)
+                if target is None:
+                    continue
+                child_decision = runtime_plan.target_decisions[target_id]
+                child_prepass = (
+                    visual_prepass.subset(list(target.paths))
+                    if child_decision.modality is Modality.VISUAL else None
                 )
-                self._attach_target_audit(ig, plan, selection)
-                return ig, 0, 0, 0, 0.0, 0
+                child_grades.append({
+                    "target_id": target_id,
+                    "selected_paths": list(target.paths),
+                    "verdict": "judge_error",
+                    "awarded_score": 0.0,
+                    "evidence": visual_prepass.judge_error[:200],
+                    "judge_confidence": None,
+                    "routing_modality": child_decision.modality.value,
+                    "perception_called": (
+                        child_prepass is not None
+                        and child_prepass.perception_call_count > 0
+                    ),
+                    "tools_used": (
+                        list(child_prepass.tools_used)
+                        if child_prepass is not None else []
+                    ),
+                    "visual_provenance": (
+                        child_prepass.to_provenance()
+                        if child_prepass is not None else []
+                    ),
+                    "score_excluded": True,
+                    "judge_call_count": 0,
+                    "judge_input_tokens": 0,
+                    "judge_output_tokens": 0,
+                    "judge_cached_tokens": 0,
+                    "perception_call_count": (
+                        child_prepass.perception_call_count
+                        if child_prepass is not None else 0
+                    ),
+                    "perception_input_tokens": (
+                        child_prepass.perception_input_tokens
+                        if child_prepass is not None else 0
+                    ),
+                    "perception_output_tokens": (
+                        child_prepass.perception_output_tokens
+                        if child_prepass is not None else 0
+                    ),
+                    "perception_cached_tokens": (
+                        child_prepass.perception_cached_tokens
+                        if child_prepass is not None else 0
+                    ),
+                    "perception_total_latency_ms": round(
+                        child_prepass.perception_total_latency_ms, 2
+                    ) if child_prepass is not None else 0.0,
+                    "render_call_count": (
+                        child_prepass.render_call_count
+                        if child_prepass is not None else 0
+                    ),
+                    "render_total_latency_ms": round(
+                        child_prepass.render_total_latency_ms, 2
+                    ) if child_prepass is not None else 0.0,
+                    "usage_complete": (
+                        child_prepass.usage_complete
+                        if child_prepass is not None else True
+                    ),
+                })
+            ig = ItemGrade(
+                rubric_item_id=item.rubric_item_id,
+                criterion=item.criterion,
+                max_score=item.score,
+                awarded_score=0.0,
+                verdict="judge_error",
+                decided_by="judge",
+                required=item.required,
+                evidence=visual_prepass.judge_error[:200],
+                judge_confidence=None,
+                judge_latency_ms=0.0,
+                routing_modality=parent_routing_modality,
+                perception_called=(visual_prepass.perception_call_count > 0),
+                tools_used=list(visual_prepass.tools_used),
+                visual_provenance=visual_prepass.to_provenance(),
+                child_grades=child_grades,
+                score_excluded=True,
+                perception_call_count=visual_prepass.perception_call_count,
+                perception_input_tokens=visual_prepass.perception_input_tokens,
+                perception_output_tokens=visual_prepass.perception_output_tokens,
+                perception_cached_tokens=visual_prepass.perception_cached_tokens,
+                perception_total_latency_ms=round(
+                    visual_prepass.perception_total_latency_ms, 2
+                ),
+                render_call_count=visual_prepass.render_call_count,
+                render_total_latency_ms=round(
+                    visual_prepass.render_total_latency_ms, 2
+                ),
+                usage_complete=visual_prepass.usage_complete,
+            )
+            self._attach_target_audit(ig, plan, selection)
+            return ig, 0, 0, 0, 0.0, 0
 
         for target_id in plan.target_ids:
             target = target_by_id.get(target_id)

--- a/batch-runner/core/grader_preflight.py
+++ b/batch-runner/core/grader_preflight.py
@@ -59,6 +59,10 @@ def plan_task_runtime(
             "target_scope": target_plan.target_scope,
             "selected_paths": list(target_plan.selected_paths),
             "precheck_pattern_id": pattern_id,
+            "planned_main_judgments": 0,
+            "planned_render_calls": 0,
+            "planned_audio_calls": 0,
+            "planned_perception_calls": 0,
         }
 
         if target_plan.target_scope == "selection_error":
@@ -68,19 +72,42 @@ def plan_task_runtime(
 
         if target_plan.target_scope == "split_children":
             child_routes: list[str] = []
-            raw_visual_paths: list[str] = []
+            child_errors: list[dict[str, str]] = []
+            supported_visual_paths: list[str] = []
+            visual_error: str | None = None
             raw_audio_routes = 0
             for target_id in target_plan.target_ids:
                 target = targets.get(target_id)
                 if target is None:
-                    errors.append(
-                        f"{item.rubric_item_id}: missing target {target_id}"
-                    )
+                    child_error = {
+                        "target_id": target_id,
+                        "error": "missing target",
+                    }
+                    child_errors.append(child_error)
+                    if visual_error is None:
+                        visual_error = f"{target_id}: missing target"
                     continue
                 decision = resolve_runtime_routing(item.criterion, target.paths)
                 child_routes.append(decision.modality.value)
                 if decision.modality is Modality.VISUAL:
-                    raw_visual_paths.extend(target.paths)
+                    planned_names, child_visual_error = (
+                        ToolCallingJudge.validate_planned_visual_names(
+                            target.paths
+                        )
+                    )
+                    unsupported_visual_paths.extend(
+                        sorted(set(target.paths) - set(planned_names))
+                    )
+                    if child_visual_error is not None and visual_error is None:
+                        visual_error = (
+                            f"{target_id}: {child_visual_error}"
+                        )
+                    if child_visual_error is not None:
+                        child_errors.append({
+                            "target_id": target_id,
+                            "error": child_visual_error,
+                        })
+                    supported_visual_paths.extend(planned_names)
                 elif decision.modality is Modality.AUDIO:
                     raw_audio_routes += 1
             parent_route = (
@@ -90,40 +117,42 @@ def plan_task_runtime(
             )
             routes[parent_route] += 1
             visual_paths: list[str] = []
-            visual_error: str | None = None
-            if raw_visual_paths:
-                planned_names, visual_error = (
+            if supported_visual_paths and visual_error is None:
+                planned_names, parent_visual_error = (
                     ToolCallingJudge.validate_planned_visual_names(
-                        raw_visual_paths
+                        supported_visual_paths
                     )
                 )
-                if visual_error is not None:
-                    errors.append(f"{item.rubric_item_id}: {visual_error}")
-                    unsupported_visual_paths.extend(
-                        sorted(
-                            set(planned_names)
-                            - set(
-                                ToolCallingJudge.planned_supported_visual_names(
-                                    planned_names
-                                )
-                            )
-                        )
-                    )
+                if parent_visual_error is not None:
+                    visual_error = parent_visual_error
                 else:
                     visual_paths = planned_names
                     planned_visual_calls += len(visual_paths)
+            if visual_error is not None:
+                errors.append(f"{item.rubric_item_id}: {visual_error}")
             if visual_error is None:
-                planned_main_judgments += len(child_routes)
+                item_main_judgments = len(child_routes)
+                planned_main_judgments += item_main_judgments
                 planned_audio_calls += raw_audio_routes
+            else:
+                item_main_judgments = 0
             item_plan.update({
                 "outcome": (
                     "judge" if visual_error is None else "preflight_error"
                 ),
                 "routing_modality": parent_route,
                 "child_routes": child_routes,
+                "child_errors": child_errors,
+                "preflight_error": visual_error,
                 "planned_visual_paths": visual_paths,
+                "planned_main_judgments": item_main_judgments,
+                "planned_render_calls": len(visual_paths),
                 "planned_audio_calls": (
                     raw_audio_routes if visual_error is None else 0
+                ),
+                "planned_perception_calls": (
+                    len(visual_paths) + raw_audio_routes
+                    if visual_error is None else 0
                 ),
             })
             item_plans.append(item_plan)
@@ -166,31 +195,37 @@ def plan_task_runtime(
             if visual_error is not None:
                 errors.append(f"{item.rubric_item_id}: {visual_error}")
                 unsupported_visual_paths.extend(
-                    sorted(
-                        set(planned_names)
-                        - set(
-                            ToolCallingJudge.planned_supported_visual_names(
-                                planned_names
-                            )
-                        )
-                    )
+                    sorted(set(target_plan.selected_paths) - set(planned_names))
                 )
             else:
                 supported = planned_names
                 planned_visual_calls += len(supported)
+                unsupported_visual_paths.extend(
+                    sorted(set(target_plan.selected_paths) - set(supported))
+                )
         if visual_error is None:
-            planned_main_judgments += 1
+            item_main_judgments = 1
+            planned_main_judgments += item_main_judgments
             if decision.modality is Modality.AUDIO:
                 planned_audio_calls += 1
+        else:
+            item_main_judgments = 0
         item_plan.update({
             "outcome": (
                 "judge" if visual_error is None else "preflight_error"
             ),
             "routing_modality": decision.modality.value,
+            "preflight_error": visual_error,
             "matched_keywords": list(decision.matched_keywords),
             "planned_visual_paths": supported,
+            "planned_main_judgments": item_main_judgments,
+            "planned_render_calls": len(supported),
             "planned_audio_calls": (
                 1 if decision.modality is Modality.AUDIO else 0
+            ),
+            "planned_perception_calls": (
+                len(supported)
+                + (1 if decision.modality is Modality.AUDIO else 0)
             ),
         })
         item_plans.append(item_plan)
@@ -207,10 +242,27 @@ def plan_task_runtime(
         isinstance(visual_cap, int)
         and planned_visual_calls > visual_cap
     ):
-        errors.append(
+        budget_error = (
             "task visual budget exceeded: "
             f"planned={planned_visual_calls}, cap={visual_cap}"
         )
+        errors.append(budget_error)
+        for item_plan in item_plans:
+            if (
+                item_plan.get("outcome") == "judge"
+                and item_plan.get("planned_render_calls", 0) > 0
+            ):
+                planned_main_judgments -= item_plan["planned_main_judgments"]
+                planned_visual_calls -= item_plan["planned_render_calls"]
+                planned_audio_calls -= item_plan["planned_audio_calls"]
+                item_plan.update({
+                    "outcome": "preflight_error",
+                    "preflight_error": budget_error,
+                    "planned_main_judgments": 0,
+                    "planned_render_calls": 0,
+                    "planned_audio_calls": 0,
+                    "planned_perception_calls": 0,
+                })
     audio_cap = audio_config.get("call_cap_per_task")
     if isinstance(audio_cap, int) and planned_audio_calls > audio_cap:
         errors.append(
@@ -276,6 +328,11 @@ def summarize_cohort(task_plans: list[dict[str, Any]]) -> dict[str, Any]:
         "planned_perception_calls": sum(
             task["planned_perception_calls"] for task in task_plans
         ),
+        "unsupported_visual_paths": sorted({
+            path
+            for task in task_plans
+            for path in task["unsupported_visual_paths"]
+        }),
         "errors": [
             f"{task['task_id']}: {error}"
             for task in task_plans

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -467,7 +467,7 @@ class ToolCallingJudge:
                     deliverable_dir=deliverable_dir,
                     file_names=file_names,
                 )
-            expected_paths = self._planned_visual_names(file_names)
+            expected_paths = self.planned_supported_visual_names(file_names)
             observed_paths = [entry.path for entry in prepass.entries]
             if prepass.judge_error is None and observed_paths != expected_paths:
                 prepass.judge_error = (
@@ -1229,7 +1229,7 @@ class ToolCallingJudge:
         cls, file_names: List[str]
     ) -> Tuple[List[str], Optional[str]]:
         """Apply the exact runtime target, cap, and format checks."""
-        planned_names = cls._planned_visual_names(file_names)
+        planned_names = cls.planned_supported_visual_names(file_names)
         if not planned_names:
             return [], "required_visual_render_target_unavailable"
         if len(planned_names) > _VISUAL_FILE_CAP:
@@ -1237,13 +1237,6 @@ class ToolCallingJudge:
                 "required_visual_file_cap_exceeded:"
                 f"planned={len(planned_names)},cap={_VISUAL_FILE_CAP}"
             )
-        for file_name in planned_names:
-            if Path(file_name).suffix.lower() not in _VISUAL_RENDER_SCOPES:
-                return planned_names, (
-                    "required_visual_render_unsupported_path:"
-                    f"{file_name}:supported extensions are "
-                    f"{sorted(_VISUAL_RENDER_SCOPES)}"
-                )
         return planned_names, None
 
     @staticmethod

--- a/batch-runner/scripts/preflight_track2_cohort.py
+++ b/batch-runner/scripts/preflight_track2_cohort.py
@@ -236,6 +236,7 @@ def main() -> int:
             "planned_render_calls",
             "planned_audio_calls",
             "planned_perception_calls",
+            "unsupported_visual_paths",
             "errors",
         )
     }, ensure_ascii=False))

--- a/batch-runner/tests/test_grader_preflight.py
+++ b/batch-runner/tests/test_grader_preflight.py
@@ -116,6 +116,7 @@ def test_summarize_cohort_preserves_order_and_sums_counts(tmp_path: Path):
     assert summary["ordered_task_ids"] == ["task-1", "task-2"]
     assert summary["rubric_items"] == 2
     assert summary["judge_routes"] == {"text": 2}
+    assert summary["unsupported_visual_paths"] == []
     assert summary["errors"] == []
 
 
@@ -154,7 +155,13 @@ def test_plan_enforces_visual_call_cap(tmp_path: Path):
         tmp_path,
     )
 
-    assert plan["planned_render_calls"] == 1
+    assert plan["planned_main_judgments"] == 0
+    assert plan["planned_render_calls"] == 0
+    assert plan["planned_perception_calls"] == 0
+    assert plan["items"][0]["outcome"] == "preflight_error"
+    assert plan["items"][0]["preflight_error"] == (
+        "task visual budget exceeded: planned=1, cap=0"
+    )
     assert plan["errors"] == [
         "task visual budget exceeded: planned=1, cap=0"
     ]
@@ -191,6 +198,46 @@ def test_plan_enforces_runtime_visual_file_cap(monkeypatch, tmp_path: Path):
     assert plan["errors"] == [
         "visual: required_visual_file_cap_exceeded:planned=4,cap=3"
     ]
+
+
+def test_plan_filters_unsupported_paths_from_visual_bundle(
+    monkeypatch, tmp_path: Path
+):
+    paths = ["Brief.docx", "Chart.pdf", "Report.xlsx"]
+    for path in paths:
+        (tmp_path / path).write_bytes(path.encode("utf-8"))
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="task-1",
+        task_class="main_bundle",
+        primary_targets=[SelectionTarget("bundle", paths, "mixed")],
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader_preflight.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="primary_bundle",
+            target_ids=["bundle"],
+            selected_paths=paths,
+        ),
+    )
+
+    plan = plan_task_runtime(
+        {},
+        _task([RubricItem("visual", "The org chart layout is readable.", 1, None)]),
+        tmp_path,
+    )
+
+    assert plan["judge_routes"] == {"visual": 1}
+    assert plan["planned_main_judgments"] == 1
+    assert plan["planned_render_calls"] == 2
+    assert plan["planned_perception_calls"] == 2
+    assert plan["items"][0]["planned_visual_paths"] == [
+        "Chart.pdf",
+        "Report.xlsx",
+    ]
+    assert plan["unsupported_visual_paths"] == ["Brief.docx"]
+    assert plan["errors"] == []
 
 
 def test_plan_counts_audio_routes_and_fails_closed_on_model_selected_calls(
@@ -300,3 +347,104 @@ def test_plan_split_children_enforces_parent_visual_file_cap(
     assert plan["errors"] == [
         "style: required_visual_file_cap_exceeded:planned=4,cap=3"
     ]
+
+
+def test_plan_split_children_fails_when_visual_child_has_no_render_target(
+    monkeypatch, tmp_path: Path
+):
+    paths = ["Notes.txt", "Chart.pdf"]
+    for path in paths:
+        (tmp_path / path).write_bytes(path.encode("utf-8"))
+    targets = [
+        SelectionTarget("notes", ["Notes.txt"], "txt"),
+        SelectionTarget("chart", ["Chart.pdf"], "pdf"),
+    ]
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="task-1",
+        task_class="separate_equivalent",
+        primary_targets=targets,
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader_preflight.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="split_children",
+            target_ids=["notes", "chart"],
+            selected_paths=paths,
+            aggregation_rule="blocking_min_else_mean",
+        ),
+    )
+
+    plan = plan_task_runtime(
+        {"judge": {"perception": {"visual": {"call_cap_per_task": 0}}}},
+        _task([RubricItem("style", "Overall Style", 1, None)]),
+        tmp_path,
+    )
+
+    assert plan["judge_routes"] == {"visual": 1}
+    assert plan["planned_main_judgments"] == 0
+    assert plan["planned_render_calls"] == 0
+    assert plan["planned_perception_calls"] == 0
+    assert plan["unsupported_visual_paths"] == ["Notes.txt"]
+    assert plan["items"][0]["outcome"] == "preflight_error"
+    assert plan["items"][0]["preflight_error"] == (
+        "notes: required_visual_render_target_unavailable"
+    )
+    assert plan["items"][0]["child_errors"] == [{
+        "target_id": "notes",
+        "error": "required_visual_render_target_unavailable",
+    }]
+    assert plan["errors"] == [
+        "style: notes: required_visual_render_target_unavailable"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("second_name", "visual_cap", "expected_error"),
+    [
+        (
+            "Notes.txt",
+            5,
+            "style: notes: required_visual_render_target_unavailable",
+        ),
+        (
+            "Chart.pdf",
+            0,
+            "task visual budget exceeded: planned=1, cap=0",
+        ),
+    ],
+)
+def test_plan_mixed_split_preflight_error_blocks_all_main_calls(
+    tmp_path: Path, second_name: str, visual_cap: int, expected_error: str
+):
+    (tmp_path / "Brief.docx").write_bytes(b"docx")
+    (tmp_path / second_name).write_bytes(b"secondary")
+    second_kind = "PDF" if second_name.endswith(".pdf") else "text file"
+    task = TaskRubric(
+        task_id="task-1",
+        sector="test",
+        occupation="test",
+        prompt=(
+            "Create two separate deliverables: a Word document and a "
+            f"{second_kind}."
+        ),
+        rubric_items=[RubricItem("style", "Overall Style", 1, None)],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+    config = {
+        "judge": {
+            "perception": {"visual": {"call_cap_per_task": visual_cap}}
+        }
+    }
+
+    plan = plan_task_runtime(config, task, tmp_path)
+
+    assert plan["judge_routes"] == {"mixed": 1}
+    assert plan["planned_main_judgments"] == 0
+    assert plan["planned_render_calls"] == 0
+    assert plan["planned_perception_calls"] == 0
+    assert plan["items"][0]["outcome"] == "preflight_error"
+    assert plan["errors"] == [expected_error]

--- a/batch-runner/tests/test_grader_selector_integration.py
+++ b/batch-runner/tests/test_grader_selector_integration.py
@@ -770,7 +770,7 @@ def test_split_preflight_failure_records_prior_perception_call(
     assert style.perception_called is True
 
 
-def test_explicit_visual_docx_remains_fail_closed_unsupported(
+def test_explicit_visual_docx_remains_fail_closed_without_render_target(
     monkeypatch, tmp_path
 ):
     from core.rubric_loader import RubricItem, TaskRubric
@@ -807,8 +807,132 @@ def test_explicit_visual_docx_remains_fail_closed_unsupported(
     assert item.routing_modality == "visual"
     assert item.verdict == "judge_error"
     assert item.score_excluded is True
-    assert "unsupported_path" in item.evidence
+    assert item.evidence == "required_visual_render_target_unavailable"
     assert item.render_call_count == 0
+    assert vision.calls == []
+    assert responses.calls == []
+
+
+def test_split_visual_child_validation_precedes_task_budget_and_render(
+    monkeypatch, tmp_path
+):
+    from core.rubric_loader import RubricItem, TaskRubric
+    import core.tool_calling_judge as tool_judge_mod
+
+    responses = ScriptedResponses([])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision(call_cap=0)
+    grader._tool_judge.vision_perception = vision
+    monkeypatch.setattr(
+        tool_judge_mod,
+        "read_deliverable",
+        lambda *args, **kwargs: pytest.fail("child validation must precede render"),
+    )
+    deliverable_dir = tmp_path / "task"
+    deliverable_dir.mkdir()
+    (deliverable_dir / "Notes.txt").write_bytes(b"text")
+    (deliverable_dir / "Chart.pdf").write_bytes(b"pdf")
+    task = TaskRubric(
+        task_id="t-split-unsupported",
+        sector="Information",
+        occupation="Analyst",
+        prompt="Create two separate deliverables: a text file and a PDF.",
+        rubric_items=[RubricItem("style", "Overall Style", 4, None)],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+    grade = grader.grade_task(task, str(deliverable_dir))
+    item = grade.items[0]
+
+    assert item.target_scope == "split_children"
+    assert item.routing_modality == "visual"
+    assert item.verdict == "judge_error"
+    assert item.score_excluded is True
+    assert item.evidence == (
+        "notes: required_visual_render_target_unavailable"
+    )
+    assert all(
+        child["evidence"].endswith(
+            "required_visual_render_target_unavailable"
+        )
+        for child in item.child_grades
+    )
+    assert item.judge_call_count == 0
+    assert item.render_call_count == 0
+    assert item.perception_call_count == 0
+    assert all(child["score_excluded"] for child in item.child_grades)
+    assert vision.calls == []
+    assert responses.calls == []
+
+
+@pytest.mark.parametrize(
+    ("second_name", "vision_cap", "expected_error"),
+    [
+        (
+            "Notes.txt",
+            5,
+            "notes: required_visual_render_target_unavailable",
+        ),
+        (
+            "Chart.pdf",
+            0,
+            "task_visual_budget_exceeded:required_calls=1,cap=0",
+        ),
+    ],
+)
+def test_mixed_split_preflight_error_blocks_formatting_child_main(
+    monkeypatch, tmp_path, second_name, vision_cap, expected_error
+):
+    from core.rubric_loader import RubricItem, TaskRubric
+    import core.tool_calling_judge as tool_judge_mod
+
+    responses = ScriptedResponses([])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision(call_cap=vision_cap)
+    grader._tool_judge.vision_perception = vision
+    monkeypatch.setattr(
+        tool_judge_mod,
+        "read_deliverable",
+        lambda *args, **kwargs: pytest.fail("preflight error must precede render"),
+    )
+    deliverable_dir = tmp_path / "task"
+    deliverable_dir.mkdir()
+    (deliverable_dir / "Brief.docx").write_bytes(b"docx")
+    (deliverable_dir / second_name).write_bytes(b"secondary")
+    second_kind = "PDF" if second_name.endswith(".pdf") else "text file"
+    task = TaskRubric(
+        task_id="t-mixed-preflight",
+        sector="Information",
+        occupation="Analyst",
+        prompt=(
+            "Create two separate deliverables: a Word document and a "
+            f"{second_kind}."
+        ),
+        rubric_items=[RubricItem("style", "Overall Style", 4, None)],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+    grade = grader.grade_task(task, str(deliverable_dir))
+    item = grade.items[0]
+
+    assert item.target_scope == "split_children"
+    assert item.routing_modality == "mixed"
+    assert item.verdict == "judge_error"
+    assert item.score_excluded is True
+    assert item.judge_call_count == 0
+    assert item.render_call_count == 0
+    assert item.perception_call_count == 0
+    assert {child["routing_modality"] for child in item.child_grades} == {
+        "formatting",
+        "visual",
+    }
+    assert all(
+        child["evidence"] == expected_error for child in item.child_grades
+    )
     assert vision.calls == []
     assert responses.calls == []
 

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -1280,6 +1280,87 @@ def test_visual_preflight_processes_bounded_paths_in_stable_order(
     ) < prompt.index('"path": "z.png"')
 
 
+def test_visual_preflight_filters_unsupported_bundle_paths(
+    deliverable_dir, task_and_item, monkeypatch
+):
+    task, _ = task_and_item
+    visual_item = RubricItem(
+        rubric_item_id="r-bundle",
+        criterion="The organizational chart layout is readable",
+        score=4,
+        required=None,
+    )
+    (deliverable_dir / "Brief.docx").write_bytes(b"docx")
+    (deliverable_dir / "Chart.pdf").write_bytes(b"pdf")
+
+    PIL = pytest.importorskip("PIL")
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color="blue").save(buf, format="PNG")
+    fake_b64 = base64.b64encode(buf.getvalue()).decode()
+    render_order = []
+
+    def fake_render(op, path, *, base_dir, scope=None):
+        render_order.append(path)
+        source_kind = Path(path).suffix.lower().lstrip(".")
+        data = {
+            "source_kind": source_kind,
+            "scope": scope or {},
+            "renderer": {
+                "converter": "libreoffice",
+                "rasterizer": "pymupdf",
+                "libreoffice_binary": "soffice",
+                "libreoffice_version": "LibreOffice 24.2.7.2",
+                "pymupdf_version": "1.28.0",
+            },
+            "byte_size": 64,
+            "base64": fake_b64,
+        }
+        if source_kind == "pdf":
+            data["source_page_count"] = 1
+        else:
+            data["source_sheet_count"] = 1
+            data["converted_page_count"] = 1
+        return {"ok": True, "data": data}
+
+    monkeypatch.setattr(
+        tool_calling_judge_module,
+        "read_deliverable",
+        fake_render,
+    )
+    final = _response(output=[_final(json.dumps({
+        "verdict": "pass",
+        "partial_score": 1.0,
+        "evidence": "the chart tiers are readable",
+        "confidence": 0.9,
+        "reasoning": "ok",
+    }))])
+    client = FakeClient(ScriptedResponses([final]))
+    vision = StubVision(remaining_calls=2)
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE,
+        vision_perception=vision,
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=visual_item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["Brief.docx", "Chart.pdf", "report.xlsx"],
+    )
+
+    assert result.verdict == "pass"
+    assert render_order == ["Chart.pdf", "report.xlsx"]
+    assert result.render_call_count == result.perception_call_count == 2
+    assert [entry["path"] for entry in result.visual_provenance] == [
+        "Chart.pdf",
+        "report.xlsx",
+    ]
+    assert "Brief.docx" in client.responses.calls[0]["input"][0]["content"]
+
+
 def test_visual_file_cap_fails_before_render_vision_or_main(
     deliverable_dir, task_and_item, monkeypatch
 ):

--- a/tasks/0717_friday/TRACK2_COHORT_EXPANSION_EXPERIMENT.md
+++ b/tasks/0717_friday/TRACK2_COHORT_EXPANSION_EXPERIMENT.md
@@ -1,7 +1,7 @@
 # Track 2 Cohort Expansion Experiment
 
 - Date: 2026-07-17
-- Status: `STAGE_A_ACCEPTED_STAGE_B_PREFLIGHT_PENDING`
+- Status: `STAGE_A_ACCEPTED_STAGE_B_PREFLIGHT_FIX_RERUN_PENDING`
 - Owner: repository operator
 - Experiment family: rubric grading / harness-owned perception
 - Prior accepted run: GitHub Actions `29435264166`
@@ -383,18 +383,18 @@ audited, but they must not be committed as accepted grades.
 
 | Field | Planned / observed |
 |---|---|
-| Main SHA | pending merge of model-free private-data preflight workflow |
-| Grader source hash | pending recomputation; prior hash invalidated by config/import corrections |
-| Config hash | pending recomputation after dead metadata removal |
-| Output path | pending recomputation from corrected config/grader identities |
+| Main SHA | attempt 1 `1294d11aa00ddd7d34a6d7cd804bab9ed534eca8`; corrected rerun SHA pending merge |
+| Grader source hash | attempt 1 `d2fe2661af800b09e203ac146eae226eb898a2ff1975c8233f122242531c6841`; corrected `ab8704b10f2e39a26bbb443b49c8c4e1a2697a6a31c74258d4af8ebc3ba8b551` |
+| Config hash | `b11acba425087d85` |
+| Output path | `data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort10__cfg_b11acba425087d85__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_ab8704b10f2e39a2__v2.2.json` |
 | Ordered task IDs | verified first 10 pinned IDs |
-| Rubric items / prechecks | pending exact planner on first-10 tree |
-| Route counts | pending exact planner |
-| Render / perception calls | pending exact planner |
-| Run ID | not dispatched |
-| Result | not started |
+| Rubric items / prechecks | 435 / 0; corrected rerun required |
+| Route counts | 402 text / 16 formatting / 16 visual / 1 mixed; 0 audio |
+| Render / perception calls | attempt 1 incomplete 8 / 8; corrected expected 26 / 26 |
+| Run ID | model-free preflight attempt 1 `29583415563`; paid run not dispatched |
+| Result | nine task-10 mixed-bundle visual errors; fix validated, rerun pending |
 | Raw / effective cost | not started |
-| Decision | `WORKFLOW_MERGE_THEN_PREFLIGHT_REQUIRED_BEFORE_DISPATCH` |
+| Decision | `FIX_MERGE_THEN_MODEL_FREE_PREFLIGHT_RERUN_REQUIRED` |
 
 The local shell has no private dataset token, so a selective pinned download
 failed closed with HTTP 401 before any model/Azure call and left no partial
@@ -403,6 +403,22 @@ main-only model-free workflow. That workflow downloads the exact first-ten
 source prefix, has no Azure or Step 8 path, and records a hash-locked environment
 and plan artifact. Any precheck, audio route, planner error, identity mismatch,
 or active grade workflow remains a paid-dispatch stop.
+
+### Stage B Preflight Attempt 1
+
+Run `29583415563` completed the main-only input, checkout, hash-lock, identity,
+and exact first-ten private download gates without Azure or model calls. The
+planner emitted a 435-item plan with zero prechecks/audio and failed on nine
+task-10 organization-chart criteria. All nine selected the same DOCX/PDF/XLSX
+primary bundle; rejecting the supported PDF/XLSX because DOCX was also present
+was a renderer-boundary bug, not a cohort identity error.
+
+The correction filters harness visual prepass paths to supported formats while
+keeping DOCX visible to the main judge. Unsupported-only visual children still
+fail before any sibling render, task budget, or main call. Runtime and planner
+share this ordering. Artifact re-evaluation predicts 436 main judgments and
+26/26 render-perception calls with one filtered DOCX path and no errors. These
+remain planned values until a clean merged-main preflight rerun confirms them.
 
 ## Retrospective Notes
 

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,53 +4,56 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-17
-- Status: Stage A accepted; Stage B model-free preflight workflow validated
+- Status: Stage B preflight failed closed; visual bundle fix validated
 
 ## Task
 
-- Prepare the exact first-10 Stage B model-free preflight after Stage A passed.
-- Preserve private pinned inference identity without exposing HF credentials or
-  introducing any Azure/model paid-call path.
-- Remove remaining planner/config claims that were not executable contracts.
+- Run the exact first-10 Stage B model-free preflight from merged `main`.
+- Audit every planner error before allowing any paid Stage B dispatch.
+- Correct mixed-format visual prepass behavior without weakening
+  unsupported-only or split-child fail-closed semantics.
 
 ## Result
 
-- Local selective download correctly failed with HTTP 401 because the private
-  pinned inference repository requires `HF_TOKEN`, which is not exposed to the
-  local shell. No model or Azure call occurred and no partial data remained.
-- Added a manual `Preflight Track 2 Cohort` workflow with `contents: read`,
-  main-only dispatch, exact `GITHUB_SHA` checkout, pinned Action commits,
-  Python 3.11.9, and a 27-package binary-only hash lock. `HF_TOKEN` is visible
-  only to the pinned downloader step after source/planner/config/grader checks.
-- The downloader now requires an exact ordered source prefix and downloads only
-  those task directories. Stage B will therefore fetch exactly the first ten
-  tasks rather than the full private 220-task deliverable tree.
-- Planner contract v2 counts visual and audio perception separately, enforces
-  both task caps, and fails closed on every audio route because audio tool calls
-  are model-selected rather than model-free exact. Stage B must plan zero audio
-  routes before paid dispatch.
-- Removed dead `grades_per_task: 3` metadata from active v2 configs. The actual
-  contract is one final verdict per rubric item, plus bounded tool and
-  finalization calls; no new repeat grading or paid behavior was introduced.
-- Grader Azure/OpenAI imports and legacy `core` package exports are lazy, so the
-  planner runs in the minimal environment with Azure/OpenAI/datasets absent.
+- Model-free workflow `29583415563` validated exact `main@1294d11a`, all pinned
+  identities, hash-locked environment, private selective first-10 download,
+  435 rubric items, zero prechecks, and zero audio routes. It made no Azure or
+  model calls and preserved its error plan/environment artifact.
+- The planner failed closed on nine task-10 visual criteria. Each selected a
+  DOCX briefing note, PDF organization chart, and XLSX FTE report; the visual
+  validator rejected the whole bundle because DOCX is not a harness render
+  target even though PDF/XLSX are supported.
+- The shared boundary now preflights only stable supported paths while retaining
+  every selected path in the main judge prompt/tool allowlist. Unsupported-only
+  visual targets still fail before render or main calls.
+- Runtime and planner now validate every visual split child before task budget
+  checks or rendering, then apply item and task caps in the same order. Filtered
+  paths are recorded at task and cohort level for audit.
+- Re-evaluating all nine failed items predicts 435 items, 402 text / 16
+  formatting / 16 visual / 1 mixed, 436 main judgments, 26
+  render/perception calls, zero audio, and zero errors.
+- Corrected pending identities are planner
+  `c8fab307fa40b3f0036c6a5c9249b42ed2ec0f971faf6bcdb32aa5e8872c7d7f`,
+  config `b11acba425087d85`, and grader
+  `ab8704b10f2e39a26bbb443b49c8c4e1a2697a6a31c74258d4af8ebc3ba8b551`.
 
 ## Verification
 
-- Workflow/input/lock contract tests: **7 passed**.
-- Selective downloader, workflow, planner, and routing suite: **55 passed**.
-- Final focused lazy-import/planner/workflow/config/grader suite: **129 passed**.
-- Broad non-integration suite: **1,219 passed, 2 skipped, 37 deselected**.
-- Real Python 3.11.9 minimal environment: hash-locked install succeeded;
-  downloader/planner direct entry and imports passed with Azure/OpenAI absent.
-- Independent grading-engineer review found no remaining code correctness or
-  security blocker after completion records are updated.
+- Failed plan artifact: exact first-10 order and identities, 435 items, nine
+  same-boundary errors, zero prechecks/audio, artifact SHA-256
+  `d50e074ae300cdd85e07acd71004bcc6822910cf2c3b5458be86a3520328a0f5`.
+- Visual runtime/planner/workflow affected suite: **166 passed**.
+- Split-child error-priority integration suite: **38 passed**.
+- Broad non-integration suite: **1,227 passed, 2 skipped, 37 deselected**.
+- All nine artifact errors re-evaluate to the same PDF/XLSX paths and one
+  filtered DOCX audit path; corrected predicted totals match the values above.
 
 ## Remaining Work
 
-- Merge the model-free preflight workflow and recompute all identities on the
-  resulting current `main`; old Stage B config/grader hashes are invalidated.
-- Dispatch the preflight workflow once from `main`, audit its exact first-10
-  plan artifact, and require zero errors, prechecks, and audio routes.
+- Merge the visual bundle parity fix and recompute identities on the resulting
+  clean `main`.
+- Rerun first-10 preflight once and require exact 435 items, 436 judgments,
+  26/26 render-perception, zero errors/prechecks/audio, and the expected single
+  filtered DOCX audit path.
 - Dispatch paid Stage B only after that plan is recorded and no grade workflow
   is active; then audit every Stage B gate before considering a full run.


### PR DESCRIPTION
## Summary
- fix Stage B preflight failure where nine DOCX/PDF/XLSX organization-chart bundles were rejected because DOCX is not a harness render target
- render and perceive only stable supported selected paths while retaining every selected path in the main judge prompt and tool allowlist
- keep unsupported-only visual targets and visual split children fail closed before any sibling render, task-budget, or main call
- align runtime and planner error priority, task-cap accounting, structured child errors, and filtered-path audit fields
- preserve failed model-free run `29583415563` and keep paid Stage B blocked pending a clean rerun

## Evidence
- failed plan identity/order/download gates passed; 435 items, zero prechecks/audio, nine same-boundary task-10 errors
- all nine errors re-evaluate to PDF+XLSX render targets and one filtered DOCX audit path
- corrected expected plan: 402 text / 16 formatting / 16 visual / 1 mixed, 436 main judgments, 26 render/perception, zero errors/audio
- planner/selector integration: 38 passed
- affected runtime/planner/workflow suite: 166 passed
- broad non-integration: 1,227 passed, 2 skipped, 37 deselected
- static diagnostics and git diff check: clean
- independent grading-engineer review: APPROVE, no merge blocker

## Dispatch gate
This PR does not run paid Stage B. After merge, recompute repository/planner/config/grader identities on clean main and rerun only the model-free preflight. Paid dispatch remains blocked unless the exact corrected values above are observed.

Do not merge yet or trigger workflows manually. Report PR number/URL, readiness, checks, and reviewDecision.
