### PR TITLE
fix(grading): bound atomic save temp filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ entries land under a fresh dated heading the day they merge to `main`.
   Stage B is now limited to exact first-10 model-free preflight before dispatch.
 
 ### Fixed
+- **Long grade output atomic persistence** — bound `_save_json` temporary
+  basenames with a 16-hex SHA-256 identity instead of copying the full final
+  filename. Stage B run `29591036089` completed all ten paid tasks but the
+  legacy 242-byte basename plus temp decorations reached 256 bytes and failed
+  Linux `NAME_MAX=255` before any JSON, commit, analysis, resume, or artifact.
+  The final output name and same-directory atomic replace remain unchanged;
+  exact 242-byte round-trip, replace-failure cleanup, Step 8, and broad tests
+  pass. A second paid attempt remains approval-gated.
 - **Mixed-format visual bundle preflight** — filter harness rendering to stable
   supported paths while retaining all selected paths for main-judge evidence.
   Stage B preflight run `29583415563` exposed nine organization-chart criteria

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -661,12 +661,13 @@ def _read_schema() -> dict:
 def _save_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_path: Path | None = None
+    temp_identity = hashlib.sha256(os.fsencode(path.name)).hexdigest()[:16]
     try:
         with tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
             dir=path.parent,
-            prefix=f".{path.name}.",
+            prefix=f".grade-{temp_identity}.",
             suffix=".tmp",
             delete=False,
         ) as handle:

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -1640,7 +1641,25 @@ def test_atomic_save_failure_preserves_existing_file(monkeypatch, tmp_path):
         s8._save_json(output, {"new": True})
 
     assert output.read_text(encoding="utf-8") == '{"old":true}'
-    assert list(tmp_path.glob(".grade.json.*.tmp")) == []
+    assert list(tmp_path.glob(".grade-*.tmp")) == []
+
+
+def test_atomic_save_supports_stage_b_output_basename(tmp_path):
+    output = tmp_path / (
+        "exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__"
+        "validation_v2_mini_cohort10__cfg_b11acba425087d85__rubric_"
+        "11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_"
+        "9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_"
+        "ab8704b10f2e39a2__v2.2.json"
+    )
+    payload = {"tasks": 10, "usage_complete": True}
+
+    assert len(os.fsencode(output.name)) == 242
+
+    s8._save_json(output, payload)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == payload
+    assert list(tmp_path.glob(".grade-*.tmp")) == []
 
 
 def test_grade_workflow_rc7_requires_valid_committed_partial():

--- a/tasks/0717_friday/TRACK2_COHORT_EXPANSION_EXPERIMENT.md
+++ b/tasks/0717_friday/TRACK2_COHORT_EXPANSION_EXPERIMENT.md
@@ -1,7 +1,7 @@
 # Track 2 Cohort Expansion Experiment
 
 - Date: 2026-07-17
-- Status: `STAGE_A_ACCEPTED_STAGE_B_PREFLIGHT_PASSED_DISPATCH_PENDING`
+- Status: `STAGE_A_ACCEPTED_STAGE_B_PAID_ATTEMPT_1_PERSISTENCE_FAILED`
 - Owner: repository operator
 - Experiment family: rubric grading / harness-owned perception
 - Prior accepted run: GitHub Actions `29435264166`
@@ -383,18 +383,18 @@ audited, but they must not be committed as accepted grades.
 
 | Field | Planned / observed |
 |---|---|
-| Main SHA | attempt 1 `1294d11aa00ddd7d34a6d7cd804bab9ed534eca8`; corrected plan `51839d64ea854a0de1420beb7541b369f55bea6e` |
-| Grader source hash | `ab8704b10f2e39a26bbb443b49c8c4e1a2697a6a31c74258d4af8ebc3ba8b551` |
+| Main SHA | paid attempt 1 `6bdcfcf9dd4d5feb8890e13d9f69baefc4162b38`; corrected rerun SHA pending merge |
+| Grader source hash | paid attempt 1 `ab8704b10f2e39a26bbb443b49c8c4e1a2697a6a31c74258d4af8ebc3ba8b551`; corrected `011ef05cf7f7a951b9bc2322888605549ee4fa9486c775f4154b89c83526d270` |
 | Config hash | `b11acba425087d85` |
-| Output path | `data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort10__cfg_b11acba425087d85__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_ab8704b10f2e39a2__v2.2.json` |
+| Output path | corrected `data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort10__cfg_b11acba425087d85__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_011ef05cf7f7a951__v2.2.json` |
 | Ordered task IDs | verified first 10 pinned IDs |
 | Rubric items / prechecks | 435 / 0 |
 | Route counts | 402 text / 16 formatting / 16 visual / 1 mixed; 0 audio |
 | Render / perception calls | 26 / 26 planned; 0 audio |
-| Run ID | preflight attempt 1 `29583415563` failed; corrected preflight `29589077065` passed; paid run pending |
-| Result | exact first-10 plan, 436 main judgments, zero planner errors |
-| Raw / effective cost | not started |
-| Decision | `PASS_PAID_STAGE_B_DISPATCH_ALLOWED_AFTER_FINAL_MAIN_IDENTITY_AND_ACTIVE_RUN_GUARDS` |
+| Run ID | preflight `29589077065` passed; paid attempt 1 `29591036089` rejected |
+| Result | 10/10 graded; atomic temp filename overflow before JSON persistence |
+| Raw / effective cost | no usage artifact; attempt 1 booked at conservative raw estimate USD 3.81 |
+| Decision | `ATOMIC_FIX_MERGE_PREFLIGHT_AND_OWNER_RERUN_APPROVAL_REQUIRED` |
 
 The local shell has no private dataset token, so a selective pinned download
 failed closed with HTTP 401 before any model/Azure call and left no partial
@@ -447,6 +447,30 @@ cost, time, usage, provenance, judge errors, and 26/26 calls must be audited fro
 the paid Stage B artifact. The result-record merge changes only repository
 documentation, so a final model-free run on that new `main` SHA must confirm the
 same plan before dispatch. An active grade workflow remains a stop.
+
+### Stage B Paid Attempt 1
+
+Run `29591036089` executed once from `main` commit
+`6bdcfcf9dd4d5feb8890e13d9f69baefc4162b38`. All ten task progress lines were
+printed over 1h25m58s and seven empty max-output finals recovered with the
+bounded tool-free retry. No runtime, task, or judge error appeared before
+persistence.
+
+At the task-10 partial-save boundary, `NamedTemporaryFile` failed with
+`OSError: [Errno 36] File name too long`. The final filename was 242 bytes and
+valid; the legacy hidden prefix plus random component and `.tmp` made the temp
+component 256 bytes, one over Linux `NAME_MAX`. Step 8 exited 1. No grade JSON,
+analysis, commit, durable resume, child dispatch, or artifact exists, so this
+attempt is rejected rather than quality-scored.
+
+The correction hashes the final basename into a bounded temp prefix while
+preserving same-directory atomic replace and the public output template. The
+actual failed-run usage cannot be recovered. For the Stage B cap, attempt 1 is
+conservatively counted at USD 3.81 raw, the higher preflight sensitivity
+estimate. A fresh rerun at the same ceiling would produce USD 7.62 cumulative
+estimated raw spend, below USD 10. Because the preregistration allowed one paid
+dispatch, a second attempt is a deviation and requires explicit owner approval
+after merge, clean-main preflight, and active-run checks.
 
 ## Retrospective Notes
 

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,50 +4,50 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-17
-- Status: Corrected Stage B preflight passed; paid dispatch pending
+- Status: Stage B paid attempt failed persistence; rerun approval pending
 
 ## Task
 
-- Rerun the exact first-10 Stage B model-free preflight after the mixed-format
-  visual bundle correction merged.
-- Audit every plan identity, item route, call count, filtered path, environment,
-  and privacy boundary before permitting paid Stage B.
+- Run paid Stage B once from the fully recorded, preflighted `main` identity.
+- Diagnose the absence of a grade artifact after all ten tasks completed.
+- Fix persistence without changing cohort, rubric, prompt, or grading semantics.
 
 ## Result
 
-- Corrected model-free run `29589077065` passed in 40 seconds from
-  `main@51839d64ea854a0de1420beb7541b369f55bea6e`. Plan artifact SHA-256 is
-  `db40b02e08f5c40a62f4b7dd85be12c69732da7b25c8c11f4224485953406b9d`.
-- All exact first-10 and repository/planner/config/grader/inference/rubric
-  identities matched. Planner/config/grader identities are
-  `c8fab307fa40b3f0036c6a5c9249b42ed2ec0f971faf6bcdb32aa5e8872c7d7f`,
-  `b11acba425087d85`, and
-  `ab8704b10f2e39a26bbb443b49c8c4e1a2697a6a31c74258d4af8ebc3ba8b551`.
-- Exact plan: 435 items, 436 main judgments, 402 text / 16 formatting / 16
-  visual / 1 mixed, 26 render/perception, and zero prechecks/audio/errors.
-- Nine organization-chart items retain their DOCX briefing note in selected
-  paths while perception uses PDF+XLSX. The cohort audit records exactly that
-  one filtered DOCX path.
-- All 435 item invariants, selector manifests, split-child accounting, caps,
-  relative paths, locked environment, and recursive payload/path/secret scans
-  passed. No Azure/model/Step 8/child-dispatch path ran.
-- Stage A-based scale estimates are USD 3.77 raw / USD 3.07 effective and
-  71-83 minutes, under the USD 10 / 240-minute Stage B caps.
+- Paid run `29591036089` graded all 10 tasks from
+  `main@6bdcfcf9dd4d5feb8890e13d9f69baefc4162b38` in 1h25m58s. Seven empty
+  max-output finals recovered and no runtime/task/judge error appeared.
+- At task 10 persistence failed before any JSON existed:
+  `OSError: [Errno 36] File name too long`. The 242-byte final basename was
+  valid, but the atomic temp format added two dots, an 8-byte random name, and
+  `.tmp`, producing 256 bytes against Linux `NAME_MAX=255`.
+- Step 8 exited 1. Grade/analysis commits, durable resume, child dispatch, and
+  uploaded grade artifact were all absent. The run is rejected and cannot be
+  resumed because no partial JSON exists.
+- `_save_json` now derives a bounded 16-hex SHA-256 temp identity while keeping
+  same-directory `fsync` and atomic replace. The corrected grader hash is
+  `011ef05cf7f7a951b9bc2322888605549ee4fa9486c775f4154b89c83526d270`.
+- Usage was not persisted, so attempt-1 spend is conservatively booked at the
+  higher preflight raw sensitivity estimate, USD 3.81. A same-envelope rerun
+  would put estimated cumulative raw Stage B spend at USD 7.62, below the USD
+  10 cap. This is an estimate, not billing evidence.
 
 ## Verification
 
-- Workflow `29589077065`: **PASS**, exact pinned download and plan artifact.
-- Full 435-item plan, identity, selector, route/call/cap, filtered-path,
-  environment, and privacy audit: **PASS** with zero violations.
-- Independent grading-engineer pre-dispatch review: all artifact gates **PASS**.
-- Paid workflow was not dispatched; no active-run claim is stored in the
-  artifact and must be checked immediately before dispatch.
+- Failure audit: 10/10 task progress lines, seven recovered finalization
+  retries, no runtime/judge errors before atomic save, `rc=1`, no artifact.
+- Exact overflow reproduction: 242-byte target, 256-byte legacy temp basename.
+- Atomic-save focused tests: **2 passed**; full Step 8 suite: **98 passed**.
+- Broad non-integration suite: **1,225 passed, 5 skipped, 37 deselected**.
+- Real 242-byte output probe: JSON round-trip **PASS**, temp residue zero.
+- Independent grading-engineer review found no code blocker; docs and explicit
+  owner deviation approval are required before any second paid attempt.
 
 ## Remaining Work
 
-- Merge this result record, then rerun model-free preflight on the resulting
-  documentation-only `main` SHA and require the same exact plan.
-- Confirm no grade/preflight workflow is queued or running, then dispatch paid
-  Stage B exactly once with the recorded config/inference identity.
-- Audit every Stage B runtime, usage, provenance, cost, and wall-clock gate
-  before considering a full 220-task run.
+- Merge the bounded atomic-save fix, recompute the grader/output identity, and
+  rerun model-free preflight on clean current `main`.
+- Obtain explicit owner approval for a second paid Stage B attempt and for
+  counting failed attempt 1 as USD 3.81 raw toward a cumulative USD 10 cap.
+- Only after approval and active-run guard, run a fresh `resume=false` attempt;
+  audit actual cumulative cost and every Stage B gate before any full run.


### PR DESCRIPTION
## Summary
- fix Stage B persistence failure after all ten paid tasks completed
- replace the full-output temporary prefix with a bounded 16-hex SHA-256 identity while preserving same-directory fsync and atomic replace
- retain the final output template and isolate the corrected run under a new grader-source identity
- record failed run `29591036089`, missing usage artifact, conservative USD 3.81 attempt-1 cost estimate, and approval-gated rerun deviation

## Root cause
The final Stage B basename is a valid 242 bytes. The prior hidden temp name added two dots, an 8-byte random component, and `.tmp`, reaching 256 bytes and exceeding Linux `NAME_MAX=255`. Step 8 exited 1 before any JSON, commit, analysis, durable resume, or artifact.

## Verification
- exact 242-byte executable save probe: PASS, no temp residue
- atomic save tests: 2 passed
- full Step 8 suite: 98 passed
- broad non-integration: 1,225 passed, 5 skipped, 37 deselected
- static diagnostics and git diff check: clean
- independent grading-engineer review: no code or merge blocker

## Paid rerun gate
This PR does not rerun Stage B. After merge, run model-free preflight on clean main with the new grader/output identity. A second paid Stage B attempt requires explicit owner deviation approval, `resume=false`, active-run guard, and conservative cumulative raw cost accounting: USD 3.81 for failed attempt 1 plus actual rerun cost, capped at USD 10.

Do not merge yet or trigger workflows. Report PR number/URL/readiness/checks.
