### PR TITLE
feat(notes): ground runtime retrospective in evidence

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,14 @@ on:
       - 'batch-runner/results/**'       # aggregate-reports → reports-index
       - 'src/**'                        # 소스 변경 시
       - 'scripts/**'                    # aggregate 스크립트 변경 시
+      - '.github/workflows/batch-run.yml' # runtime-note policy source
+      - 'data/notes/runtime-incidents.yaml' # runtime-note incident source
 
   workflow_dispatch:          # 수동 실행 가능
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -23,13 +29,15 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -60,6 +68,18 @@ jobs:
           # prebuild에서도 aggregate가 실행되지만,
           # 위에서 이미 실행했으므로 2번 실행됨 (멱등이라 OK)
           NODE_ENV: production
+
+      - name: Verify aggregate contracts and pinned history
+        timeout-minutes: 3
+        run: npm run test:aggregate
+
+      - name: Install Chromium headless shell
+        timeout-minutes: 10
+        run: ./node_modules/.bin/playwright install --with-deps --only-shell chromium
+
+      - name: Verify runtime note in browser
+        timeout-minutes: 5
+        run: npm run test:runtime-browser:dist
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **Evidence-backed runtime Field Note** — rebuild the `360-minute-experiment`
+  note around three explicit sources: exp008/010/025/026 report snapshots, the
+  current condition-a workflow policy, and a pinned exp025 incident record.
+  The note now separates the incident-time 330-minute hard stop from the
+  post-fix 290-minute watchdog, 350-minute step ceiling, and 360-minute job
+  ceiling; derives metrics, timeline SVG, resume chart, and numeric prose from
+  validated data; and fails closed on missing, malformed, stale, or mismatched
+  evidence. Five shorter chapter headings, chapter labels, wider section
+  spacing, 2.05 body leading, and quieter serif callouts give the retrospective
+  a deliberate 사건→편향→대응→결과→결정 reading rhythm on desktop and mobile.
+  The Pages workflow now regenerates this evidence when either runtime source
+  changes and gates deployment on all aggregate contracts plus pinned-history
+  and Chromium desktop/mobile checks. No model, batch, grading, HF upload, or
+  paid workflow is dispatched by this change.
 - **Agentic Sandbox implementation and experiment preregistration plan** — define a
   separate `agentic_sandbox` task-solving mode that lets the model choose among
   bounded workspace inspection, Python, ffmpeg, artifact inspection, and

--- a/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
+++ b/batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml
@@ -4,7 +4,7 @@
 #   hearing for audio) improve GDPVal deliverable quality vs. plain subprocess?
 # Base architecture: exp025 (GPT-5.4 high + gpt-audio-1.5 preprocessor)
 # New variables:
-#   - execution.mode: sandbox (container, graceful local fallback)
+#   - execution.mode: sandbox (required container, loud failure if unavailable)
 #   - skills/ injected into prompt + mounted in the sandbox
 #   - video_analyzer preprocessor (frame-by-frame vision)
 # Scope: All 220 tasks (9 sectors, 44 occupations)
@@ -18,8 +18,9 @@ experiment:
     famous Agent Skills (audio/video/document/image/data) mounted in the sandbox
     and documented in the prompt, and (3) multimodal perception — a gpt-audio-1.5
     audio preprocessor (hearing) plus a frame-by-frame video preprocessor
-    (vision). Sandbox uses Docker when available and gracefully falls back to the
-    hardened local subprocess otherwise. Full 220 tasks across 9 sectors.
+    (vision). Sandbox requires the preflighted Docker image and fails loudly if
+    container execution becomes unavailable; it does not fall back to local
+    subprocess execution. Full 220 tasks across 9 sectors.
   author: "Hyeonsang Jeon"
   created_at: "2026-05-18"
 

--- a/data/notes/runtime-incidents.yaml
+++ b/data/notes/runtime-incidents.yaml
@@ -1,0 +1,22 @@
+incidents:
+  exp025_resume_sigkill:
+    experiment_id: exp025
+    condition: condition_a
+    action_run_id: "26018603400"
+    approx_minute: 330
+    event: SIGKILL
+    started_at: "2026-05-18T07:02:37Z"
+    completed_at: "2026-05-18T12:36:00Z"
+    workflow_commit: 36b0e5bed5e9be2622e505f68d3746eec1b6cc12
+    incident_policy:
+      scope: condition_a
+      step_timeout_minutes: 330
+      job_timeout_minutes: 360
+      resume_watchdog_enabled: false
+    source_record_commit: 6e0001503ad4f3760c007dc1981d3bdc53dd785d
+    fix:
+      commit: 62471a4a682b2f2439bba81a7eb24335a8f4931f
+      applied_at: "2026-05-20"
+      step_timeout_before_minutes: 330
+      step_timeout_after_minutes: 350
+      resume_watchdog_enabled: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^11.3.0",
-        "js-yaml": "^5.2.1",
         "lucide-react": "^0.445.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1413,12 +1412,6 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
@@ -2077,28 +2070,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.mjs"
-      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^11.3.0",
+        "js-yaml": "^5.2.1",
         "lucide-react": "^0.445.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -21,6 +22,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
@@ -807,6 +809,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1394,6 +1412,12 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
@@ -2054,6 +2078,28 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -2282,6 +2328,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "version": "0.2.0",
   "type": "module",
   "scripts": {
-    "aggregate": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
-    "test:aggregate": "node --test scripts/__tests__/aggregate-experiments.test.mjs scripts/__tests__/aggregate-grades.test.mjs scripts/__tests__/field-notes.test.mjs scripts/__tests__/official-filter.test.mjs",
+    "aggregate": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs && node scripts/aggregate-runtime-note.mjs",
+    "test:aggregate": "node --test scripts/__tests__/aggregate-experiments.test.mjs scripts/__tests__/aggregate-grades.test.mjs scripts/__tests__/aggregate-runtime-note.test.mjs scripts/__tests__/field-notes.test.mjs scripts/__tests__/official-filter.test.mjs scripts/__tests__/runtime-note.test.mjs",
+    "test:runtime-data": "node --test scripts/__tests__/aggregate-runtime-note.test.mjs scripts/__tests__/runtime-note.test.mjs",
+    "test:runtime-browser:dist": "node scripts/__tests__/runtime-note.browser.mjs",
+    "test:runtime-browser": "npm run build && npm run test:runtime-browser:dist",
     "test:official-filter": "node --test scripts/__tests__/official-filter.test.mjs",
-    "predev": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
+    "predev": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs && node scripts/aggregate-runtime-note.mjs",
     "dev": "vite",
-    "prebuild": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs",
+    "prebuild": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs && node scripts/aggregate-runtime-note.mjs",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
@@ -18,6 +21,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^11.3.0",
+    "js-yaml": "^5.2.1",
     "lucide-react": "^0.445.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -27,6 +31,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^11.3.0",
-    "js-yaml": "^5.2.1",
     "lucide-react": "^0.445.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/scripts/__tests__/aggregate-runtime-note.test.mjs
+++ b/scripts/__tests__/aggregate-runtime-note.test.mjs
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { promisify } from 'node:util'
+import test from 'node:test'
+
+import { buildRuntimeNoteData, extractWorkflowPolicy } from '../aggregate-runtime-note.mjs'
+
+const readRepoFile = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
+const execFileAsync = promisify(execFile)
+
+test('runtime note data is derived from workflow and incident sources', async () => {
+  const [workflow, incidents] = await Promise.all([
+    readRepoFile('.github/workflows/batch-run.yml'),
+    readRepoFile('data/notes/runtime-incidents.yaml'),
+  ])
+  const data = buildRuntimeNoteData(workflow, incidents)
+
+  assert.deepEqual(data.current_policy, {
+    scope: 'condition_a',
+    watchdog_minutes: 290,
+    step_timeout_minutes: 350,
+    job_timeout_minutes: 360,
+    relay_handoff_margin_minutes: 60,
+  })
+  assert.deepEqual(data.incident, {
+    experiment_id: 'exp025',
+    condition: 'condition_a',
+    action_run_id: '26018603400',
+    approx_minute: 330,
+    event: 'SIGKILL',
+    started_at: '2026-05-18T07:02:37Z',
+    completed_at: '2026-05-18T12:36:00Z',
+    workflow_commit: '36b0e5bed5e9be2622e505f68d3746eec1b6cc12',
+    policy: {
+      scope: 'condition_a',
+      step_timeout_minutes: 330,
+      job_timeout_minutes: 360,
+      resume_watchdog_enabled: false,
+    },
+    source_record_commit: '6e0001503ad4f3760c007dc1981d3bdc53dd785d',
+    fix: {
+      commit: '62471a4a682b2f2439bba81a7eb24335a8f4931f',
+      applied_at: '2026-05-20',
+      step_timeout_before_minutes: 330,
+      step_timeout_after_minutes: 350,
+      resume_watchdog_enabled: true,
+    },
+  })
+})
+
+test('runtime note data rejects unsafe boundary ordering', () => {
+  const workflow = `
+on:
+  workflow_dispatch:
+    inputs:
+      wall_timeout: { default: 290 }
+jobs:
+  batch-run:
+    timeout-minutes: 360
+    steps:
+      - name: "Step 2a: Run inference (condition_a)"
+        timeout-minutes: 350
+        run: bash step2_run_inference.sh condition_a --wall-timeout "$WALL_TIMEOUT"
+      - name: "Step 2b: Run inference (condition_b)"
+        timeout-minutes: 350
+        run: bash step2_run_inference.sh condition_b
+`
+  const incidents = `
+incidents:
+  exp025_resume_sigkill:
+    experiment_id: exp025
+    condition: condition_a
+    action_run_id: "26018603400"
+    approx_minute: 355
+    event: SIGKILL
+    started_at: "2026-05-18T07:02:37Z"
+    completed_at: "2026-05-18T12:36:00Z"
+    workflow_commit: 36b0e5bed5e9be2622e505f68d3746eec1b6cc12
+    incident_policy:
+      scope: condition_a
+      step_timeout_minutes: 330
+      job_timeout_minutes: 360
+      resume_watchdog_enabled: false
+    source_record_commit: 6e0001503ad4f3760c007dc1981d3bdc53dd785d
+    fix:
+      commit: 62471a4a682b2f2439bba81a7eb24335a8f4931f
+      applied_at: "2026-05-20"
+      step_timeout_before_minutes: 330
+      step_timeout_after_minutes: 350
+      resume_watchdog_enabled: true
+`
+
+  assert.throws(() => buildRuntimeNoteData(workflow, incidents), /incident minute must match/)
+})
+
+test('runtime note data rejects duplicate inference steps', async () => {
+  const [workflow, incidents] = await Promise.all([
+    readRepoFile('.github/workflows/batch-run.yml'),
+    readRepoFile('data/notes/runtime-incidents.yaml'),
+  ])
+  const duplicate = workflow.replace(
+    "      - name: 'Step 2b: Run inference (condition_b)'",
+    "      - name: 'Step 2a: Run inference (condition_a)'\n        timeout-minutes: 350\n      - name: 'Step 2b: Run inference (condition_b)'",
+  )
+
+  assert.throws(() => buildRuntimeNoteData(duplicate, incidents), /must appear exactly once/)
+})
+
+test('pinned incident and fix commits preserve the before-after workflow history', async () => {
+  const incidents = await readRepoFile('data/notes/runtime-incidents.yaml')
+  const currentWorkflow = await readRepoFile('.github/workflows/batch-run.yml')
+  const data = buildRuntimeNoteData(currentWorkflow, incidents)
+  const path = '.github/workflows/batch-run.yml'
+  const [{ stdout: incidentWorkflow }, { stdout: fixedWorkflow }] = await Promise.all([
+    execFileAsync('git', ['show', `${data.incident.workflow_commit}:${path}`], { cwd: new URL('../..', import.meta.url) }),
+    execFileAsync('git', ['show', `${data.incident.fix.commit}:${path}`], { cwd: new URL('../..', import.meta.url) }),
+  ])
+
+  assert.deepEqual(extractWorkflowPolicy(incidentWorkflow), {
+    scope: 'condition_a',
+    watchdog_minutes: 290,
+    step_timeout_minutes: 330,
+    job_timeout_minutes: 360,
+    relay_handoff_margin_minutes: 40,
+  })
+  assert.deepEqual(extractWorkflowPolicy(fixedWorkflow), {
+    scope: 'condition_a',
+    watchdog_minutes: 290,
+    step_timeout_minutes: 350,
+    job_timeout_minutes: 360,
+    relay_handoff_margin_minutes: 60,
+  })
+})
+
+test('pinned runner history proves Resume Round watchdog was added by the fix', async () => {
+  const incidents = await readRepoFile('data/notes/runtime-incidents.yaml')
+  const currentWorkflow = await readRepoFile('.github/workflows/batch-run.yml')
+  const data = buildRuntimeNoteData(currentWorkflow, incidents)
+  const runnerPath = 'batch-runner/step2_run_inference.py'
+  const [{ stdout: beforeRunner }, { stdout: afterRunner }] = await Promise.all([
+    execFileAsync('git', ['show', `${data.incident.workflow_commit}:${runnerPath}`], { cwd: new URL('../..', import.meta.url) }),
+    execFileAsync('git', ['show', `${data.incident.fix.commit}:${runnerPath}`], { cwd: new URL('../..', import.meta.url) }),
+  ])
+  const extractResumeBlock = (source) => source.slice(
+    source.indexOf('# 7. Resume rounds:'),
+    source.indexOf('# 8. Final summary & save'),
+  )
+  const before = extractResumeBlock(beforeRunner)
+  const after = extractResumeBlock(afterRunner)
+  assert.ok(before.length > 0)
+  assert.ok(after.length > 0)
+
+  for (const marker of [
+    'Watchdog: wall-clock timeout check (resume round)',
+    'if wall_deadline and time.time() >= wall_deadline:',
+    'r["status"] = "pending"',
+    'sys.exit(EXIT_CHECKPOINT)',
+  ]) {
+    assert.equal(before.includes(marker), false, `before unexpectedly contains ${marker}`)
+    assert.equal(after.includes(marker), true, `after is missing ${marker}`)
+  }
+  assert.match(after, /_save_progress\([\s\S]*?progress_path/)
+})
+
+test('runtime note data rejects impossible and reversed incident timestamps', async () => {
+  const [workflow, incidents] = await Promise.all([
+    readRepoFile('.github/workflows/batch-run.yml'),
+    readRepoFile('data/notes/runtime-incidents.yaml'),
+  ])
+  assert.throws(
+    () => buildRuntimeNoteData(workflow, incidents.replace('2026-05-18T07:02:37Z', '2026-02-30T07:02:37Z')),
+    /valid UTC timestamp/,
+  )
+  assert.throws(
+    () => buildRuntimeNoteData(workflow, incidents.replace('2026-05-18T07:02:37Z', '2026-05-18T13:02:37Z')),
+    /start must precede completion/,
+  )
+})
+
+test('runtime source changes trigger serialized Pages deployment', async () => {
+  const deploy = await readRepoFile('.github/workflows/deploy.yml')
+
+  assert.match(deploy, /- '\.github\/workflows\/batch-run\.yml'/)
+  assert.match(deploy, /- 'data\/notes\/runtime-incidents\.yaml'/)
+  assert.match(deploy, /concurrency:\s+group: pages\s+cancel-in-progress: false/)
+  assert.match(deploy, /runs-on: ubuntu-24\.04/)
+  assert.match(deploy, /fetch-depth: 0/)
+  assert.match(deploy, /Verify aggregate contracts and pinned history[\s\S]*npm run test:aggregate/)
+  assert.match(deploy, /playwright install --with-deps --only-shell chromium/)
+  assert.match(deploy, /npm run test:runtime-browser:dist/)
+})

--- a/scripts/__tests__/field-notes.test.mjs
+++ b/scripts/__tests__/field-notes.test.mjs
@@ -110,6 +110,9 @@ test('experiment detail summary uses the same report index snapshot as notes', a
   assert.equal(merged.short_id, 'exp003')
   assert.deepEqual(merged.meta, entry.meta)
   assert.deepEqual(merged.summary, entry.summary)
+  assert.deepEqual(merged.recovery_stats, entry.recovery_stats)
+  assert.deepEqual(merged.narrative, entry.narrative)
+  assert.deepEqual(merged.task_results, [])
   assert.match(hook, /applyReportIndexSnapshot\(data, entry, shortId\)/)
 })
 
@@ -159,7 +162,7 @@ test('journal article resolves visuals from reports and links to source details'
   ])
 
   assert.match(article, /selectPromptComplexityBenchmark\(reports\)/)
-  assert.match(article, /useReports\(usesPromptBenchmark\)/)
+  assert.match(article, /useReports\(usesReportBenchmark\)/)
   assert.match(article, /<JournalArticleContent key=\{slug \?\? 'missing'\} slug=\{slug\} \/>/)
   assert.match(article, /generated\/reports-index\.json/)
   assert.match(article, /getExperimentHref\(row\.shortId\)/)

--- a/scripts/__tests__/runtime-note.browser.mjs
+++ b/scripts/__tests__/runtime-note.browser.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { chromium } from '@playwright/test'
+import { preview } from 'vite'
+
+const ROOT = fileURLToPath(new URL('../..', import.meta.url))
+const runtimePath = new URL('../../public/generated/runtime-note.json', import.meta.url)
+const reportsPath = new URL('../../public/generated/reports-index.json', import.meta.url)
+const chapterTitles = [
+  '같은 220개, 서로 다른 시간',
+  '빠른 작업만 남는 편향',
+  'Checkpoint, watchdog, relay',
+  '복구가 만든 새로운 경계',
+  '시간 제한도 실험 조건이다',
+]
+
+const clone = (value) => structuredClone(value)
+
+async function assertBenchmarkHidden(page) {
+  for (const title of chapterTitles) {
+    assert.equal(await page.getByRole('heading', { name: title, exact: true }).count(), 0)
+  }
+  assert.equal(await page.locator('.grid.grid-cols-3.border-y').count(), 0)
+  assert.equal(await page.getByRole('heading', { name: 'exp026 resume round별 회복 결과' }).count(), 0)
+  assert.equal(await page.getByRole('complementary', { name: 'Runtime evidence source' }).count(), 0)
+}
+
+async function main() {
+  const [runtimeNote, reportsIndex] = await Promise.all([
+    readFile(runtimePath, 'utf8').then(JSON.parse),
+    readFile(reportsPath, 'utf8').then(JSON.parse),
+  ])
+  const server = await preview({
+    root: ROOT,
+    preview: { host: '127.0.0.1', port: 0 },
+    logLevel: 'silent',
+  })
+  const address = server.httpServer.address()
+  if (!address || typeof address === 'string') throw new Error('Vite preview did not expose a TCP port')
+  const base = `http://127.0.0.1:${address.port}/gdpval-realworks`
+  const browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    colorScheme: 'dark',
+    reducedMotion: 'reduce',
+  })
+  const page = await context.newPage()
+
+  try {
+    await page.goto(`${base}/notes/360-minute-experiment`)
+    const source = page.getByRole('complementary', { name: 'Runtime evidence source' })
+    await source.waitFor()
+    assert.equal(await source.locator('a').count(), 11)
+    assert.equal(await page.getByRole('heading', { name: '같은 220개, 서로 다른 시간', exact: true }).count(), 1)
+    assert.equal(await page.getByRole('img', { name: /330분 step hard timeout/ }).count(), 1)
+    assert.deepEqual(
+      await page.getByRole('heading', { name: 'exp026 resume round별 회복 결과' })
+        .locator('xpath=ancestor::figure')
+        .locator('.recharts-xAxis .recharts-cartesian-axis-tick-value')
+        .allTextContents(),
+      ['Round 1', 'Round 2'],
+    )
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth), false)
+
+    await page.evaluate(() => {
+      globalThis.__runtimeChartMutations = 0
+      new MutationObserver((records) => {
+        for (const record of records) {
+          if (record.target instanceof SVGElement && record.target.closest('.recharts-wrapper')) {
+            globalThis.__runtimeChartMutations += 1
+          }
+        }
+      }).observe(document, { subtree: true, attributes: true, attributeFilter: ['d', 'width', 'height', 'transform'] })
+    })
+    await page.waitForTimeout(600)
+    assert.equal(await page.evaluate(() => globalThis.__runtimeChartMutations), 0)
+
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await page.reload()
+    await source.waitFor()
+    const desktopHero = page.locator('figure').first().locator('svg:visible')
+    assert.equal(await desktopHero.getByText('MAY 18 · INCIDENT', { exact: true }).count(), 1)
+    assert.equal(await desktopHero.getByText('AFTER MAY 20 FIX · CONDITION A', { exact: true }).count(), 1)
+    const labelBoxes = await desktopHero.locator('text').evaluateAll((nodes) => nodes
+      .filter((node) => ['350', '360', 'step ceiling', 'job cap', 'SIGKILL · 330 step hard stop'].includes(node.textContent ?? ''))
+      .map((node) => {
+        const box = node.getBoundingClientRect()
+        return { text: node.textContent, left: box.left, right: box.right, top: box.top }
+      }))
+    const overlaps = labelBoxes.some((box, index) => labelBoxes.some((other, otherIndex) => (
+      index < otherIndex
+      && Math.abs(box.top - other.top) < 4
+      && box.left < other.right
+      && other.left < box.right
+    )))
+    assert.equal(overlaps, false)
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth), false)
+
+    const invalidPolicy = clone(runtimeNote)
+    invalidPolicy.current_policy.step_timeout_minutes = 280
+    await page.route('**/generated/runtime-note.json*', (route) => route.fulfill({ json: invalidPolicy }))
+    await page.reload()
+    assert.match(await page.getByRole('alert').innerText(), /runtime-note\.json/)
+    await assertBenchmarkHidden(page)
+    await page.unroute('**/generated/runtime-note.json*')
+
+    await page.route('**/generated/runtime-note.json*', (route) => route.fulfill({ body: 'null', contentType: 'application/json' }))
+    await page.reload()
+    assert.match(await page.getByRole('alert').innerText(), /runtime-note\.json/)
+    await assertBenchmarkHidden(page)
+    await page.unroute('**/generated/runtime-note.json*')
+
+    const invalidReports = clone(reportsIndex)
+    invalidReports.reports.find((report) => report.short_id === 'exp026')
+      .recovery_stats.resume_rounds.per_round['1'] = null
+    await page.route('**/generated/reports-index.json*', (route) => route.fulfill({ json: invalidReports }))
+    await page.reload()
+    assert.match(await page.getByRole('alert').innerText(), /exp026/)
+    await assertBenchmarkHidden(page)
+    await page.unroute('**/generated/reports-index.json*')
+
+    await page.reload()
+    await source.waitFor()
+    await page.evaluate((url) => {
+      history.pushState({}, '', url)
+      dispatchEvent(new PopStateEvent('popstate'))
+    }, '/gdpval-realworks/notes/honest-pipeline-lower-score')
+    await page.getByRole('heading', { name: '성공으로 기록됐지만 정말 성공이었을까', exact: true }).waitFor()
+    await page.route('**/generated/runtime-note.json*', (route) => route.abort())
+    await page.evaluate((url) => {
+      history.pushState({}, '', url)
+      dispatchEvent(new PopStateEvent('popstate'))
+    }, '/gdpval-realworks/notes/360-minute-experiment')
+    assert.match(await page.getByRole('alert').innerText(), /Failed to fetch/)
+    await assertBenchmarkHidden(page)
+  } finally {
+    await context.close()
+    await browser.close()
+    await server.close()
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/__tests__/runtime-note.test.mjs
+++ b/scripts/__tests__/runtime-note.test.mjs
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import ts from 'typescript'
+
+import { buildRuntimeNoteData } from '../aggregate-runtime-note.mjs'
+
+const readRepoFile = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
+
+async function importTypeScriptModule(path) {
+  const source = await readRepoFile(path)
+  const result = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2020 },
+    reportDiagnostics: true,
+  })
+  assert.equal(result.diagnostics?.length ?? 0, 0)
+  return import(`data:text/javascript;base64,${Buffer.from(result.outputText).toString('base64')}`)
+}
+
+async function loadRuntimeFixture() {
+  const [selector, reportsIndex, workflow, incidents] = await Promise.all([
+    importTypeScriptModule('src/lib/runtimeNoteBenchmark.ts'),
+    readRepoFile('public/generated/reports-index.json').then(JSON.parse),
+    readRepoFile('.github/workflows/batch-run.yml'),
+    readRepoFile('data/notes/runtime-incidents.yaml'),
+  ])
+  const runtimeNote = {
+    ...buildRuntimeNoteData(workflow, incidents),
+    _generated: '2026-07-18T00:00:00.000Z',
+  }
+  return { ...selector, reports: reportsIndex.reports, runtimeNote }
+}
+
+test('runtime note selector joins report recovery with workflow policy', async () => {
+  const { selectRuntimeNoteBenchmark, reports, runtimeNote } = await loadRuntimeFixture()
+  const selection = selectRuntimeNoteBenchmark(reports, runtimeNote)
+
+  assert.equal(selection.status, 'ready')
+  assert.deepEqual(selection.rows.map((row) => ({
+    id: row.shortId,
+    mode: row.executionMode,
+    duration: row.duration,
+    success: `${row.successCount}/${row.totalTasks}`,
+    errors: row.errorCount,
+    retried: row.retriedCount,
+  })), [
+    { id: 'exp008', mode: 'subprocess', duration: '149m 7s', success: '215/220', errors: 5, retried: 26 },
+    { id: 'exp010', mode: 'code_interpreter', duration: '183m 22s', success: '219/220', errors: 1, retried: 21 },
+    { id: 'exp025', mode: 'subprocess', duration: '501m 32s', success: '181/220', errors: 17, retried: 66 },
+    { id: 'exp026', mode: 'sandbox', duration: '5171m 24s', success: '200/220', errors: 6, retried: 105 },
+  ])
+  assert.deepEqual(selection.exp026.recoveryRounds, [
+    { round: 1, attempted: 78, recovered: 78, stillFailed: 0 },
+    { round: 2, attempted: 27, recovered: 7, stillFailed: 20 },
+  ])
+  assert.deepEqual(selection.currentPolicy, {
+    scope: 'condition_a',
+    watchdog_minutes: 290,
+    step_timeout_minutes: 350,
+    job_timeout_minutes: 360,
+    relay_handoff_margin_minutes: 60,
+  })
+  assert.equal(selection.incident.approx_minute, 330)
+  assert.equal(selection.incident.policy.step_timeout_minutes, 330)
+  assert.equal(selection.incident.fix.step_timeout_after_minutes, 350)
+  assert.equal(selection.incident.workflow_commit, '36b0e5bed5e9be2622e505f68d3746eec1b6cc12')
+})
+
+test('runtime note selector reports missing and duplicate reports', async () => {
+  const { selectRuntimeNoteBenchmark, reports, runtimeNote } = await loadRuntimeFixture()
+  const matching = reports.filter((report) => ['exp008', 'exp010', 'exp025', 'exp026'].includes(report.short_id))
+
+  assert.deepEqual(
+    selectRuntimeNoteBenchmark(matching.filter((report) => report.short_id !== 'exp008'), runtimeNote),
+    { status: 'missing', missingIds: ['exp008'] },
+  )
+  assert.deepEqual(
+    selectRuntimeNoteBenchmark([...matching, matching.find((report) => report.short_id === 'exp026')], runtimeNote),
+    { status: 'invalid', invalidSources: ['exp026'] },
+  )
+})
+
+test('runtime note selector rejects invalid report and policy invariants independently', async () => {
+  const { selectRuntimeNoteBenchmark, reports, runtimeNote } = await loadRuntimeFixture()
+  const matching = reports.filter((report) => ['exp008', 'exp010', 'exp025', 'exp026'].includes(report.short_id))
+  const cases = [
+    ['wrong experiment ID', (report) => { report.meta.experiment_id = 'exp026_wrong' }],
+    ['wrong condition', (report) => { report.meta.condition_name = 'wrong condition' }],
+    ['wrong execution mode', (report) => { report.meta.execution_mode = 'subprocess' }],
+    ['wrong report scope', (report) => { report.meta.report_scope = 'graded' }],
+    ['invalid duration', (report) => { report.meta.duration = 'unknown' }],
+    ['non-benchmark total', (report) => { report.summary.total_tasks = 50 }],
+    ['invalid success count', (report) => { report.summary.success_count = 221 }],
+    ['invalid success rate', (report) => { report.summary.success_rate_pct = 90.8 }],
+    ['invalid error count', (report) => { report.summary.error_count = -1 }],
+    ['success and error exceed total', (report) => { report.summary.error_count = 21 }],
+    ['retried over total', (report) => { report.summary.retried_count = 221 }],
+    ['invalid QA', (report) => { report.summary.avg_qa_score = Number.NaN }],
+    ['round sum mismatch', (report) => { report.recovery_stats.resume_rounds.per_round['2'].still_failed = 19 }],
+    ['retried count mismatch', (report) => { report.summary.retried_count = 104 }],
+    ['null round', (report) => { report.recovery_stats.resume_rounds.per_round['1'] = null }],
+    ['missing round', (report) => { delete report.recovery_stats.resume_rounds.per_round['2'] }],
+    ['wrong round count', (report) => { report.recovery_stats.resume_rounds.rounds_used = 1 }],
+  ]
+
+  for (const [name, mutate] of cases) {
+    const invalid = structuredClone(matching)
+    mutate(invalid.find((report) => report.short_id === 'exp026'))
+    assert.deepEqual(
+      selectRuntimeNoteBenchmark(invalid, runtimeNote),
+      { status: 'invalid', invalidSources: ['exp026'] },
+      name,
+    )
+  }
+
+  const invalidPolicy = structuredClone(runtimeNote)
+  invalidPolicy.current_policy.step_timeout_minutes = 280
+  assert.deepEqual(
+    selectRuntimeNoteBenchmark(matching, invalidPolicy),
+    { status: 'invalid', invalidSources: ['runtime-note.json'] },
+  )
+  assert.deepEqual(
+    selectRuntimeNoteBenchmark(matching, null),
+    { status: 'invalid', invalidSources: ['runtime-note.json'] },
+  )
+  const invalidHistory = structuredClone(runtimeNote)
+  invalidHistory.incident.policy.step_timeout_minutes = 350
+  assert.deepEqual(
+    selectRuntimeNoteBenchmark(matching, invalidHistory),
+    { status: 'invalid', invalidSources: ['runtime-note.json'] },
+  )
+  const impossibleDate = structuredClone(runtimeNote)
+  impossibleDate.incident.started_at = '2026-02-30T07:02:37Z'
+  assert.deepEqual(
+    selectRuntimeNoteBenchmark(matching, impossibleDate),
+    { status: 'invalid', invalidSources: ['runtime-note.json'] },
+  )
+  const reversedDates = structuredClone(runtimeNote)
+  reversedDates.incident.started_at = '2026-05-18T13:02:37Z'
+  assert.deepEqual(
+    selectRuntimeNoteBenchmark(matching, reversedDates),
+    { status: 'invalid', invalidSources: ['runtime-note.json'] },
+  )
+  const invalidGenerated = structuredClone(runtimeNote)
+  invalidGenerated._generated = '2026-02-30T00:00:00.000Z'
+  assert.deepEqual(
+    selectRuntimeNoteBenchmark(matching, invalidGenerated),
+    { status: 'invalid', invalidSources: ['runtime-note.json'] },
+  )
+})
+
+test('runtime article keeps reflective chapter rhythm without static chart values', async () => {
+  const journal = await readRepoFile('src/data/journal.ts')
+  const start = journal.indexOf("...journalCatalog['360-minute-experiment']")
+  const end = journal.indexOf("...journalCatalog['honest-pipeline-lower-score']")
+  const article = journal.slice(start, end)
+
+  assert.match(article, /benchmark: \{ kind: 'runtime' \}/)
+  assert.match(article, /readingStyle: 'reflective'/)
+  assert.match(article, /metrics: \[\]/)
+  assert.match(article, /data: \[\]/)
+  assert.match(article, /label: '사건'[\s\S]*heading: '같은 220개, 서로 다른 시간'/)
+  assert.match(article, /label: '편향'[\s\S]*heading: '빠른 작업만 남는 편향'/)
+  assert.match(article, /label: '대응'[\s\S]*heading: 'Checkpoint, watchdog, relay'/)
+  assert.match(article, /label: '결과'[\s\S]*heading: '복구가 만든 새로운 경계'/)
+  assert.match(article, /label: '결정'[\s\S]*heading: '시간 제한도 실험 조건이다'/)
+  assert.match(article, /benchmarkNarrative: 'runtime-incident'/)
+  assert.match(article, /benchmarkNarrative: 'runtime-policy'/)
+  assert.match(article, /benchmarkNarrative: 'runtime-results'/)
+  assert.doesNotMatch(article, /primary: 78|secondary: 20|value: '360분'|value: '약 330분'/)
+
+  const timelineEvent = journal.slice(
+    journal.indexOf("title: '장시간 resume가 약 330분에 종료'") - 80,
+    journal.indexOf("title: '장시간 resume가 약 330분에 종료'") + 180,
+  )
+  assert.match(timelineEvent, /date: '2026-05-18'/)
+  assert.doesNotMatch(timelineEvent, /2026-05-17/)
+})
+
+test('runtime hero and article resolve visuals and prose from source data', async () => {
+  const [hero, page] = await Promise.all([
+    readRepoFile('src/components/notes/NoteHeroVisual.tsx'),
+    readRepoFile('src/pages/JournalArticle.tsx'),
+  ])
+  const runtimeHero = hero.slice(hero.indexOf('function RuntimeVisual'), hero.indexOf('function IntegrityVisual'))
+
+  assert.match(runtimeHero, /MAY 18 · INCIDENT/)
+  assert.match(runtimeHero, /AFTER MAY 20 FIX/)
+  assert.match(runtimeHero, /scaleX\(currentPolicy\.watchdog_minutes\)/)
+  assert.match(runtimeHero, /incident\.approx_minute/)
+  assert.match(runtimeHero, /incident\.policy\.step_timeout_minutes/)
+  assert.match(runtimeHero, /currentPolicy\.step_timeout_minutes/)
+  assert.match(runtimeHero, /currentPolicy\.job_timeout_minutes/)
+  assert.doesNotMatch(runtimeHero, /value: '290'|value: '330'|value: '350'|value: '360'/)
+  assert.match(page, /useRuntimeNote\(usesRuntimeBenchmark\)/)
+  assert.match(page, /selectRuntimeNoteBenchmark\(reports, runtimeNote\)/)
+  assert.match(page, /resolveRuntimeArticle\(article, readyRuntimeBenchmark\)/)
+  assert.match(page, /usesRuntimeBenchmark && !readyRuntimeBenchmark[\s\S]*\? \[\]/)
+  assert.match(page, /generated\/runtime-note\.json/)
+  assert.match(page, /actions\/runs\/\$\{benchmark\.incident\.action_run_id\}/)
+  assert.match(page, /blob\/\$\{benchmark\.incident\.workflow_commit\}/)
+  assert.match(page, /commit\/\$\{benchmark\.incident\.fix\.commit\}/)
+  assert.match(page, /blob\/\$\{benchmark\.incident\.source_record_commit\}\/CHANGELOG\.md/)
+  assert.match(page, /space-y-20 md:space-y-28/)
+  assert.match(page, /text-\[16px\]\/\[2\.05\]/)
+  assert.match(page, /현재 workflow의 condition_a 경로/)
+  assert.match(page, /exp008과 exp010은 이 수정 전에 실행됐으므로/)
+  assert.match(page, /relay가 이어진 exp025·exp026에서는 한 job의 실행 시간과 같지 않다/)
+})
+
+test('exp026 requires Docker and never advertises local fallback', async () => {
+  const config = await readRepoFile('batch-runner/experiments/exp026_sandbox_skills_multimodal.yaml')
+
+  assert.match(config, /use_docker: "always"/)
+  assert.match(config, /fails loudly if[\s\S]*container execution becomes unavailable/)
+  assert.match(config, /does not fall back to local[\s\S]*subprocess execution/)
+  assert.doesNotMatch(config, /graceful local fallback|gracefully falls back/)
+})

--- a/scripts/aggregate-runtime-note.mjs
+++ b/scripts/aggregate-runtime-note.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import YAML from 'yaml'
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url))
+const WORKFLOW_PATH = join(ROOT, '.github', 'workflows', 'batch-run.yml')
+const INCIDENTS_PATH = join(ROOT, 'data', 'notes', 'runtime-incidents.yaml')
+const OUTPUT_PATH = join(ROOT, 'public', 'generated', 'runtime-note.json')
+
+const requirePositiveInteger = (value, label) => {
+  if (!Number.isInteger(value) || value <= 0) throw new Error(`${label} must be a positive integer`)
+  return value
+}
+
+const requireString = (value, label, pattern) => {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} must be a non-empty string`)
+  if (pattern && !pattern.test(value)) throw new Error(`${label} has an invalid format`)
+  return value
+}
+
+const requireUtcSecond = (value, label) => {
+  const timestamp = requireString(value, label, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+  const milliseconds = Date.parse(timestamp)
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== timestamp.replace('Z', '.000Z')) {
+    throw new Error(`${label} must be a valid UTC timestamp`)
+  }
+  return timestamp
+}
+
+const requireCalendarDate = (value, label) => {
+  const date = requireString(value, label, /^\d{4}-\d{2}-\d{2}$/)
+  const timestamp = `${date}T00:00:00.000Z`
+  const milliseconds = Date.parse(timestamp)
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== timestamp) throw new Error(`${label} must be a valid date`)
+  return date
+}
+
+const findExactStep = (steps, name) => {
+  const matches = steps.filter((step) => step.name === name)
+  if (matches.length !== 1) throw new Error(`${name} must appear exactly once`)
+  return matches[0]
+}
+
+export function extractWorkflowPolicy(workflowSource) {
+  const workflow = YAML.parse(workflowSource)
+  const job = workflow?.jobs?.['batch-run']
+  const dispatch = workflow?.on?.workflow_dispatch
+  const steps = job?.steps ?? []
+  const step2a = findExactStep(steps, 'Step 2a: Run inference (condition_a)')
+  const step2b = findExactStep(steps, 'Step 2b: Run inference (condition_b)')
+
+  const watchdogMinutes = requirePositiveInteger(dispatch?.inputs?.wall_timeout?.default, 'wall timeout')
+  const step2aMinutes = requirePositiveInteger(step2a?.['timeout-minutes'], 'Step 2a timeout')
+  const step2bMinutes = requirePositiveInteger(step2b?.['timeout-minutes'], 'Step 2b timeout')
+  const jobMinutes = requirePositiveInteger(job?.['timeout-minutes'], 'job timeout')
+  const step2aRun = requireString(step2a?.run, 'Step 2a run')
+  const step2bRun = requireString(step2b?.run, 'Step 2b run')
+
+  if (step2aMinutes !== step2bMinutes) throw new Error('Step 2a and Step 2b timeouts must match')
+  if (!(watchdogMinutes < step2aMinutes && step2aMinutes < jobMinutes)) {
+    throw new Error('runtime boundaries must satisfy watchdog < step < job')
+  }
+  if (!step2aRun.includes('step2_run_inference.sh condition_a --wall-timeout "$WALL_TIMEOUT"')) {
+    throw new Error('Step 2a must forward the wall timeout')
+  }
+  if (step2bRun.includes('--wall-timeout') || !step2bRun.includes('step2_run_inference.sh condition_b')) {
+    throw new Error('Step 2b watchdog wiring changed; update the runtime policy scope')
+  }
+
+  return {
+    scope: 'condition_a',
+    watchdog_minutes: watchdogMinutes,
+    step_timeout_minutes: step2aMinutes,
+    job_timeout_minutes: jobMinutes,
+    relay_handoff_margin_minutes: step2aMinutes - watchdogMinutes,
+  }
+}
+
+export function buildRuntimeNoteData(workflowSource, incidentsSource) {
+  const incidents = YAML.parse(incidentsSource)
+  const currentPolicy = extractWorkflowPolicy(workflowSource)
+
+  const incident = incidents?.incidents?.exp025_resume_sigkill
+  const approxMinute = requirePositiveInteger(incident?.approx_minute, 'incident minute')
+  const incidentStepMinutes = requirePositiveInteger(incident?.incident_policy?.step_timeout_minutes, 'incident step timeout')
+  const incidentJobMinutes = requirePositiveInteger(incident?.incident_policy?.job_timeout_minutes, 'incident job timeout')
+  const fixBeforeMinutes = requirePositiveInteger(incident?.fix?.step_timeout_before_minutes, 'fix previous step timeout')
+  const fixAfterMinutes = requirePositiveInteger(incident?.fix?.step_timeout_after_minutes, 'fix next step timeout')
+
+  if (approxMinute !== incidentStepMinutes) throw new Error('incident minute must match the historical step timeout')
+  if (incidentJobMinutes !== currentPolicy.job_timeout_minutes) throw new Error('incident and current job timeouts must match')
+  if (fixBeforeMinutes !== incidentStepMinutes || fixAfterMinutes !== currentPolicy.step_timeout_minutes) {
+    throw new Error('fix timeout transition must match historical and current policies')
+  }
+  if (incident?.incident_policy?.resume_watchdog_enabled !== false || incident?.fix?.resume_watchdog_enabled !== true) {
+    throw new Error('fix must enable the Resume Round watchdog')
+  }
+  if (incident?.condition !== 'condition_a' || incident?.incident_policy?.scope !== 'condition_a') {
+    throw new Error('incident policy must be scoped to condition_a')
+  }
+  const startedAt = requireUtcSecond(incident?.started_at, 'incident start')
+  const completedAt = requireUtcSecond(incident?.completed_at, 'incident completion')
+  if (Date.parse(startedAt) >= Date.parse(completedAt)) throw new Error('incident start must precede completion')
+
+  return {
+    current_policy: currentPolicy,
+    incident: {
+      experiment_id: requireString(incident?.experiment_id, 'incident experiment', /^exp\d+$/),
+      condition: 'condition_a',
+      action_run_id: requireString(incident?.action_run_id, 'action run ID', /^\d+$/),
+      approx_minute: approxMinute,
+      event: requireString(incident?.event, 'incident event'),
+      started_at: startedAt,
+      completed_at: completedAt,
+      workflow_commit: requireString(incident?.workflow_commit, 'incident workflow commit', /^[0-9a-f]{40}$/),
+      policy: {
+        scope: 'condition_a',
+        step_timeout_minutes: incidentStepMinutes,
+        job_timeout_minutes: incidentJobMinutes,
+        resume_watchdog_enabled: false,
+      },
+      source_record_commit: requireString(incident?.source_record_commit, 'incident source record', /^[0-9a-f]{40}$/),
+      fix: {
+        commit: requireString(incident?.fix?.commit, 'fix commit', /^[0-9a-f]{40}$/),
+        applied_at: requireCalendarDate(incident?.fix?.applied_at, 'fix date'),
+        step_timeout_before_minutes: fixBeforeMinutes,
+        step_timeout_after_minutes: fixAfterMinutes,
+        resume_watchdog_enabled: true,
+      },
+    },
+    sources: {
+      workflow: '.github/workflows/batch-run.yml',
+      incidents: 'data/notes/runtime-incidents.yaml',
+    },
+  }
+}
+
+export async function aggregateRuntimeNote() {
+  const [workflowSource, incidentsSource] = await Promise.all([
+    readFile(WORKFLOW_PATH, 'utf8'),
+    readFile(INCIDENTS_PATH, 'utf8'),
+  ])
+  const data = {
+    ...buildRuntimeNoteData(workflowSource, incidentsSource),
+    _generated: new Date().toISOString(),
+  }
+
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true })
+  await writeFile(OUTPUT_PATH, `${JSON.stringify(data, null, 2)}\n`)
+  console.log(`✅ ${OUTPUT_PATH}`)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  aggregateRuntimeNote().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/src/components/notes/NoteComparisonChart.tsx
+++ b/src/components/notes/NoteComparisonChart.tsx
@@ -51,7 +51,7 @@ export default function NoteComparisonChart({ chart }: { chart: JournalCompariso
   )
 
   return (
-    <figure className="mb-16 md:mb-20 border-y border-dash-border py-7 md:py-9" aria-label={ariaLabel}>
+    <figure className="mb-16 md:mb-20 border-y border-dash-border py-7 md:py-9">
       <div className="mb-6">
         <div className="font-mono text-[10px] text-emerald-700 dark:text-emerald-400 mb-2">COMPARISON</div>
         <h2 className="font-journal-serif text-[22px] md:text-[26px] leading-[1.4] text-dash-heading mb-3">{chart.title}</h2>
@@ -118,7 +118,7 @@ export default function NoteComparisonChart({ chart }: { chart: JournalCompariso
           )}
         </ResponsiveContainer>
       </div>
-      <div className="sr-only">
+      <div className="sr-only" aria-hidden="true">
         {chart.data.map((datum) => (
           <p key={datum.label}>
             {datum.label}: {chart.primary.label} {datum.primary}{chart.primary.unit}

--- a/src/components/notes/NoteHeroVisual.tsx
+++ b/src/components/notes/NoteHeroVisual.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import type { JournalHero } from '../../data/journal'
 import { getExperimentHref } from '../../data/journalLinks'
 import type { PromptComplexityBenchmarkRow } from '../../lib/promptComplexityBenchmark'
+import type { RuntimeNoteBenchmarkSelection } from '../../lib/runtimeNoteBenchmark'
 
 const resolveAsset = (src: string) => (
   src.startsWith('http') ? src : `${import.meta.env.BASE_URL}${src.replace(/^\/+/, '')}`
@@ -70,49 +71,64 @@ function PromptComplexityVisual({
   )
 }
 
-function RuntimeVisual({ reduceMotion }: { reduceMotion: boolean | null }) {
-  const markers = [
-    { x: 893, y: 176, value: '290', label: 'watchdog' },
-    { x: 1000, y: 326, value: '330', label: 'interrupted' },
-    { x: 1053, y: 176, value: '350', label: 'step ceiling' },
-    { x: 1080, y: 326, value: '360', label: 'job cap' },
-  ]
+type ReadyRuntimeBenchmark = Extract<RuntimeNoteBenchmarkSelection, { status: 'ready' }>
+
+function RuntimeVisual({
+  reduceMotion,
+  benchmark,
+}: {
+  reduceMotion: boolean | null
+  benchmark: ReadyRuntimeBenchmark
+}) {
+  const { currentPolicy, incident } = benchmark
+  const scaleX = (minutes: number) => 210 + (minutes / currentPolicy.job_timeout_minutes) * 870
+  const incidentStepX = scaleX(incident.policy.step_timeout_minutes)
+  const watchdogX = scaleX(currentPolicy.watchdog_minutes)
+  const currentStepX = scaleX(currentPolicy.step_timeout_minutes)
+  const jobX = scaleX(currentPolicy.job_timeout_minutes)
 
   return (
     <>
-      <g opacity="0.45">
-        {[120, 280, 440, 600, 760, 920, 1080].map((x) => (
-          <line key={x} x1={x} y1="90" x2={x} y2="390" stroke="hsl(var(--dash-border))" strokeWidth="1" />
-        ))}
-      </g>
-      <text x="120" y="72" fill="hsl(var(--dash-text-secondary))" fontSize="18">RUNNING WINDOW</text>
-      <line x1="120" y1="250" x2="1080" y2="250" stroke="hsl(var(--dash-border-active))" strokeWidth="4" />
-      <line x1="120" y1="250" x2="893" y2="250" stroke="#10b981" strokeWidth="8" />
-      <line x1="893" y1="250" x2="1053" y2="250" stroke="#f59e0b" strokeWidth="8" />
-      <line x1="1053" y1="250" x2="1080" y2="250" stroke="#f43f5e" strokeWidth="8" />
-      <text x="120" y="286" fill="hsl(var(--dash-text-secondary))" fontSize="16">0 min</text>
-      {markers.map((marker) => (
-        <g key={marker.value}>
-          <line x1={marker.x} y1="224" x2={marker.x} y2="276" stroke="hsl(var(--dash-heading))" strokeWidth="2" />
-          <circle cx={marker.x} cy="250" r="9" fill="hsl(var(--dash-page))" stroke="hsl(var(--dash-heading))" strokeWidth="3" />
-          <text x={marker.x} y={marker.y} fill="hsl(var(--dash-heading))" fontSize="28" textAnchor="middle" fontWeight="700">{marker.value}</text>
-          <text x={marker.x} y={marker.y + 25} fill="hsl(var(--dash-text-secondary))" fontSize="14" textAnchor="middle">{marker.label}</text>
+      <text x="90" y="64" fill="hsl(var(--dash-text-secondary))" fontSize="18">INCIDENT → POLICY CHANGE</text>
+      <text x="90" y="142" fill="hsl(var(--dash-heading))" fontSize="16" fontWeight="700">MAY 18 · INCIDENT</text>
+      <text x="90" y="166" fill="hsl(var(--dash-text-secondary))" fontSize="13">Resume Round watchdog absent</text>
+      <line x1="210" y1="205" x2={jobX} y2="205" stroke="hsl(var(--dash-border-active))" strokeWidth="4" />
+      <line x1="210" y1="205" x2={incidentStepX} y2="205" stroke="#e11d48" strokeWidth="8" />
+      <line x1={incidentStepX} y1="178" x2={incidentStepX} y2="232" stroke="#e11d48" strokeWidth="3" />
+      <circle cx={incidentStepX} cy="205" r="9" fill="hsl(var(--dash-page))" stroke="#e11d48" strokeWidth="3" />
+      <text x={incidentStepX} y="154" fill="hsl(var(--dash-heading))" fontSize="27" textAnchor="middle" fontWeight="700">~{incident.approx_minute}</text>
+      <text x={incidentStepX - 12} y="258" fill="hsl(var(--dash-text-secondary))" fontSize="14" textAnchor="end">{incident.event} · {incident.policy.step_timeout_minutes} step hard stop</text>
+      <text x={jobX + 10} y="258" fill="hsl(var(--dash-text-secondary))" fontSize="13" textAnchor="start">{incident.policy.job_timeout_minutes} job cap</text>
+
+      <text x="90" y="322" fill="hsl(var(--dash-heading))" fontSize="16" fontWeight="700">AFTER MAY 20 FIX · CONDITION A</text>
+      <text x="90" y="346" fill="hsl(var(--dash-text-secondary))" fontSize="13">Resume Round watchdog enabled · step widened</text>
+      <line x1="210" y1="382" x2={jobX} y2="382" stroke="hsl(var(--dash-border-active))" strokeWidth="4" />
+      <line x1="210" y1="382" x2={watchdogX} y2="382" stroke="#10b981" strokeWidth="8" />
+      <line x1={watchdogX} y1="382" x2={currentStepX} y2="382" stroke="#f59e0b" strokeWidth="8" />
+      <line x1={currentStepX} y1="382" x2={jobX} y2="382" stroke="#e11d48" strokeWidth="8" />
+      {[
+        { x: watchdogX, textX: watchdogX, value: currentPolicy.watchdog_minutes, label: 'watchdog', anchor: 'middle' as const },
+        { x: currentStepX, textX: currentStepX - 10, value: currentPolicy.step_timeout_minutes, label: 'step ceiling', anchor: 'end' as const },
+        { x: jobX, textX: jobX + 10, value: currentPolicy.job_timeout_minutes, label: 'job cap', anchor: 'start' as const },
+      ].map((marker) => (
+        <g key={marker.label}>
+          <circle cx={marker.x} cy="382" r="8" fill="hsl(var(--dash-page))" stroke="hsl(var(--dash-heading))" strokeWidth="3" />
+          <text x={marker.textX} y="367" fill="hsl(var(--dash-heading))" fontSize="20" textAnchor={marker.anchor} fontWeight="700">{marker.value}</text>
+          <text x={marker.textX} y="420" fill="hsl(var(--dash-text-secondary))" fontSize="13" textAnchor={marker.anchor}>{marker.label}</text>
         </g>
       ))}
       {reduceMotion ? (
-        <line x1="893" x2="893" y1="112" y2="388" stroke="#2563eb" strokeWidth="3" strokeDasharray="7 7" opacity="0.8" />
+        <circle cx={watchdogX} cy="382" r="13" fill="none" stroke="#2563eb" strokeWidth="2" opacity="0.7" />
       ) : (
-        <motion.line
-          x1="120"
-          x2="120"
-          y1="112"
-          y2="388"
+        <motion.circle
+          cx="210"
+          cy="382"
+          r="7"
           stroke="#2563eb"
-          strokeWidth="3"
-          strokeDasharray="7 7"
+          fill="#2563eb"
           initial={{ x: 0, opacity: 0.25 }}
-          animate={{ x: [0, 960], opacity: [0.2, 0.9, 0.2] }}
-          transition={{ duration: 6, repeat: Infinity, ease: 'linear' }}
+          animate={{ x: [0, watchdogX - 210], opacity: [0.2, 0.9, 0.2] }}
+          transition={{ duration: 4.5, repeat: Infinity, ease: 'linear' }}
         />
       )}
     </>
@@ -249,10 +265,12 @@ function MobileVisualSummary({
   variant,
   alt,
   promptBenchmark,
+  runtimeBenchmark,
 }: {
   variant: Extract<JournalHero, { kind: 'visual' }>['variant']
   alt: string
   promptBenchmark?: PromptComplexityBenchmarkRow[]
+  runtimeBenchmark?: ReadyRuntimeBenchmark
 }) {
   if (variant === 'prompt-complexity') {
     if (!promptBenchmark) return null
@@ -286,22 +304,27 @@ function MobileVisualSummary({
   }
 
   if (variant === 'runtime') {
+    if (!runtimeBenchmark) return null
+    const { currentPolicy, incident } = runtimeBenchmark
     return (
       <div role="img" aria-label={alt} className="md:hidden min-h-[220px] px-4 py-6 bg-dash-surface border-y border-dash-border">
-        <div className="font-mono text-[11px] text-dash-text-secondary mb-8">RUNNING WINDOW</div>
-        <div className="relative">
-          <div className="absolute left-3 right-3 top-[25px] h-1 bg-gradient-to-r from-emerald-600 via-amber-600 to-rose-600" />
-          <div className="relative grid grid-cols-4 gap-2">
+        <div className="font-mono text-[11px] text-dash-text-secondary mb-5">INCIDENT → POLICY CHANGE</div>
+        <div className="border-l-2 border-rose-600 pl-4 py-2">
+          <div className="font-mono text-[10px] text-rose-700 dark:text-rose-400">MAY 18 · INCIDENT</div>
+          <div className="mt-2 flex items-baseline gap-2"><span className="font-mono text-2xl font-semibold text-dash-heading">~{incident.approx_minute}</span><span className="text-xs text-dash-text-secondary">{incident.event} · {incident.policy.step_timeout_minutes}분 hard stop</span></div>
+          <div className="mt-1 text-[11px] text-dash-text-muted">Resume Round watchdog 없음 · job cap {incident.policy.job_timeout_minutes}분</div>
+        </div>
+        <div className="mt-5 border-l-2 border-emerald-600 pl-4 py-2">
+          <div className="font-mono text-[10px] text-emerald-700 dark:text-emerald-400">AFTER MAY 20 FIX · CONDITION A</div>
+          <div className="mt-3 grid grid-cols-3 gap-2 text-center">
             {[
-              ['290', 'watchdog'],
-              ['330', '중단'],
-              ['350', 'step 종료'],
-              ['360', 'job cap'],
-            ].map(([value, label], index) => (
-              <div key={value} className={`text-center ${index % 2 === 1 ? 'pt-14' : ''}`}>
+              [String(currentPolicy.watchdog_minutes), 'watchdog'],
+              [String(currentPolicy.step_timeout_minutes), 'step'],
+              [String(currentPolicy.job_timeout_minutes), 'job'],
+            ].map(([value, label]) => (
+              <div key={label}>
                 <div className="font-mono text-xl font-semibold text-dash-heading">{value}</div>
-                <div className="mt-3 mx-auto w-3 h-3 rounded-full bg-dash-page border-2 border-dash-heading" />
-                <div className="mt-2 text-[11px] text-dash-text-secondary">{label}</div>
+                <div className="mt-1 text-[11px] text-dash-text-secondary">{label}</div>
               </div>
             ))}
           </div>
@@ -402,9 +425,11 @@ function MobileVisualSummary({
 export default function NoteHeroVisual({
   hero,
   promptBenchmark,
+  runtimeBenchmark,
 }: {
   hero: JournalHero
   promptBenchmark?: PromptComplexityBenchmarkRow[]
+  runtimeBenchmark?: ReadyRuntimeBenchmark
 }) {
   const reduceMotion = useReducedMotion()
 
@@ -432,13 +457,13 @@ export default function NoteHeroVisual({
 
   return (
     <figure className="max-w-[1080px] mx-auto px-4 md:px-6 py-8 md:py-10">
-      <MobileVisualSummary variant={hero.variant} alt={hero.alt} promptBenchmark={promptBenchmark} />
+      <MobileVisualSummary variant={hero.variant} alt={hero.alt} promptBenchmark={promptBenchmark} runtimeBenchmark={runtimeBenchmark} />
       <div className="hidden md:block overflow-hidden border-y border-dash-border bg-dash-surface">
         <svg viewBox="0 0 1200 460" role="img" aria-label={hero.alt} className="block w-full aspect-[12/5]">
           {hero.variant === 'prompt-complexity' && promptBenchmark && (
             <PromptComplexityVisual reduceMotion={reduceMotion} benchmark={promptBenchmark} />
           )}
-          {hero.variant === 'runtime' && <RuntimeVisual reduceMotion={reduceMotion} />}
+          {hero.variant === 'runtime' && runtimeBenchmark && <RuntimeVisual reduceMotion={reduceMotion} benchmark={runtimeBenchmark} />}
           {hero.variant === 'integrity' && <IntegrityVisual />}
           {hero.variant === 'perception' && <PerceptionVisual reduceMotion={reduceMotion} />}
           {hero.variant === 'task-contrast' && <TaskContrastVisual />}

--- a/src/data/journal.ts
+++ b/src/data/journal.ts
@@ -15,11 +15,12 @@ export interface JournalMetric {
 }
 
 export interface JournalSection {
+  label?: string
   heading: string
   paragraphs: string[]
   points?: string[]
   callout?: string
-  benchmarkNarrative?: 'prompt-complexity-results'
+  benchmarkNarrative?: 'prompt-complexity-results' | 'runtime-incident' | 'runtime-policy' | 'runtime-results'
 }
 
 export interface JournalEvidence {
@@ -82,7 +83,8 @@ export interface JournalArticle {
   comparisonChart?: JournalComparisonChart
   sections: JournalSection[]
   evidence: JournalEvidence[]
-  benchmark?: { kind: 'prompt-complexity' }
+  benchmark?: { kind: 'prompt-complexity' | 'runtime' }
+  readingStyle?: 'reflective'
   featured?: boolean
 }
 
@@ -222,41 +224,35 @@ export const journalArticles: JournalArticle[] = [
     publishedAt: '2026-07-15',
     period: '2026-03 — 2026-07',
     readingMinutes: 8,
+    readingStyle: 'reflective',
     featured: true,
-    metrics: [
-      { value: '220', label: '서로 다른 실제 업무' },
-      { value: '360분', label: '당시 workflow job cap' },
-      { value: '약 330분', label: 'exp025 중단 사건' },
-    ],
+    benchmark: { kind: 'runtime' },
+    metrics: [],
     hero: {
       kind: 'visual',
       variant: 'runtime',
-      alt: '290분 watchdog부터 360분 job cap까지 이어지는 실행 시간 경계',
-      caption: '한 번의 긴 실행이 아니라, 종료 전에 상태를 넘기는 여러 개의 시간 경계로 실험을 다시 설계했다.',
+      alt: 'watchdog, 중단 사건, step ceiling, job cap으로 이어지는 실행 시간 경계',
+      caption: '측정값은 workflow 정책, incident 기록, experiment report에서 읽는다.',
     },
     comparisonChart: {
       kind: 'stacked',
       title: 'exp026 resume round별 회복 결과',
-      description: '첫 relay는 시도한 78개 작업을 모두 회복했지만, 두 번째 relay에서는 27개 중 7개만 회복했다.',
+      description: '각 resume round의 attempted, recovered, still_failed를 report snapshot에서 비교한다.',
       primary: { label: 'Recovered', unit: ' tasks', color: '#059669' },
       secondary: { label: 'Still failed', unit: ' tasks', color: '#e11d48' },
-      data: [
-        { label: 'Round 1', primary: 78, secondary: 0 },
-        { label: 'Round 2', primary: 7, secondary: 20 },
-      ],
+      data: [],
       caveat: '각 막대의 합은 해당 round에서 다시 시도한 작업 수다. 외부 품질 점수가 아니라 실행 복구 결과다.',
     },
     sections: [
       {
-        heading: '상황: 같은 220개지만 같은 시간이 아니었다',
-        paragraphs: [
-          'GDPVal의 220개 작업은 짧은 문서 작성부터 스프레드시트 계산, 프레젠테이션, 코드와 미디어 처리까지 섞여 있다. 한 작업의 평균 시간만 보고 전체 실행 시간을 예상하면 긴 꼬리 작업이 사라진다.',
-          'exp025의 resume round는 약 330분 지점에서 SIGKILL로 끝났다. 당시 workflow에서 마주친 360분 job cap에 가까워지고 있었지만, 더 큰 문제는 마지막 상태가 안전하게 다음 실행으로 전달되지 않았다는 점이었다.',
-        ],
-        callout: '여기서 360분은 GitHub Actions 전체에 보편적으로 적용되는 규칙이라는 뜻이 아니라, 당시 사용한 workflow와 runner에서 실제로 작동한 job cap을 가리킨다.',
+        label: '사건',
+        heading: '같은 220개, 서로 다른 시간',
+        paragraphs: [],
+        benchmarkNarrative: 'runtime-incident',
       },
       {
-        heading: '과제: 빨리 끝난 작업만 남는 편향을 막기',
+        label: '편향',
+        heading: '빠른 작업만 남는 편향',
         paragraphs: [
           '중간에 종료된 실행을 처음부터 다시 시작하면 비용만 늘어나는 것이 아니다. 매번 앞쪽의 빠른 작업은 반복되고 뒤쪽의 느린 작업은 관측되지 않는다. 실행 순서가 표본 선택기가 되는 셈이다.',
           '필요한 것은 단순 재시도가 아니라, 완료된 작업을 정확히 식별하고 같은 입력으로 이어 실행해도 결과가 중복되거나 덮어써지지 않는 복구 계약이었다.',
@@ -269,21 +265,20 @@ export const journalArticles: JournalArticle[] = [
         ],
       },
       {
-        heading: '행동: checkpoint, watchdog, relay',
-        paragraphs: [
-          '중단 사건 이후 workflow에는 checkpoint relay가 들어갔다. inference 내부 watchdog은 기본 290분에 checkpoint를 남기고 종료하며, workflow step은 relay handoff를 위한 60분의 여유를 더해 350분에 닫힌다. 이 두 경계가 당시 360분 job cap 전에 상태를 다음 실행으로 넘긴다.',
-          '이 구조는 작업 실행과 workflow 수명을 분리했다. 한 번의 runner가 전체 실험을 소유하지 않고, 여러 runner가 동일한 실험 상태를 이어받을 수 있게 됐다.',
-        ],
+        label: '대응',
+        heading: 'Checkpoint, watchdog, relay',
+        paragraphs: [],
+        benchmarkNarrative: 'runtime-policy',
       },
       {
-        heading: '결과: 복구 가능성은 높아졌지만 새 경계가 나타났다',
-        paragraphs: [
-          'relay는 장시간 실행을 이어갈 수 있게 했지만 모든 실패를 해결하지는 않았다. exp026의 공개 self-report에서 첫 resume round는 시도한 78개 작업을 모두 회복했지만, 두 번째 round는 27개 중 7개만 회복하고 20개를 남겼다.',
-          '최종 self-report는 220개 중 200개 success, 6개 명시적 실행 오류, 105개 재시도를 기록한다. 복구 가능성은 높아졌지만 반복 시도가 남은 작업을 균일하게 해결하지는 못했다.',
-        ],
+        label: '결과',
+        heading: '복구가 만든 새로운 경계',
+        paragraphs: [],
+        benchmarkNarrative: 'runtime-results',
       },
       {
-        heading: '회고와 결정',
+        label: '결정',
+        heading: '시간 제한도 실험 조건이다',
         paragraphs: [
           '가장 큰 교훈은 CI 안정성을 벤치마크 바깥의 문제로 취급할 수 없다는 점이다. 특정 형식이나 도메인의 작업이 더 오래 걸린다면 시간 제한은 해당 도메인을 체계적으로 덜 관측하게 만든다.',
           '그래서 이후 기록에서는 실행 완료, 복구 완료, 파일 생성, Self-QA, 외부 채점을 서로 다른 층으로 분리한다. 하나의 success 비트가 이 모든 의미를 대신하지 않도록 하는 것이 다음 실험의 출발점이 됐다.',
@@ -293,7 +288,7 @@ export const journalArticles: JournalArticle[] = [
     evidence: [
       {
         label: 'Workflow 변경 기록',
-        detail: 'exp025 중단, 290분 watchdog, 350분 step ceiling과 relay 도입',
+        detail: 'exp025 중단 사건과 watchdog, step ceiling, relay 도입 기록',
         href: `${REPO}/CHANGELOG.md`,
       },
       {
@@ -303,7 +298,7 @@ export const journalArticles: JournalArticle[] = [
       },
       {
         label: 'exp025 리포트',
-        detail: '501분 실행, 181/220 완료, 66개 재시도',
+        detail: '중단 사건 전후 실행 결과와 resume round 원문',
         href: `${REPO}/batch-runner/results/exp025_GPT54_high_postfix/report/report.md`,
       },
     ],
@@ -769,7 +764,7 @@ export const timelineEvents: TimelineEvent[] = [
     kind: 'incident',
   },
   {
-    date: '2026-05-17',
+    date: '2026-05-18',
     title: '장시간 resume가 약 330분에 종료',
     description: '강제 종료 전에 checkpoint를 넘기기 위해 watchdog, step ceiling과 relay 구조를 도입했다.',
     experiments: ['exp025'],

--- a/src/hooks/useRuntimeNote.ts
+++ b/src/hooks/useRuntimeNote.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+export function useRuntimeNote(enabled: boolean) {
+  const [data, setData] = useState<unknown>(null)
+  const [loading, setLoading] = useState(enabled)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(null)
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    const controller = new AbortController()
+    setData(null)
+    setLoading(true)
+    setError(null)
+    fetch(`${import.meta.env.BASE_URL}generated/runtime-note.json?t=${Date.now()}`, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error(`Failed to fetch runtime note: ${response.status}`)
+        return response.json() as Promise<unknown>
+      })
+      .then((runtimeNote) => {
+        setData(runtimeNote)
+        setLoading(false)
+      })
+      .catch((fetchError) => {
+        if (fetchError.name === 'AbortError') return
+        setError(fetchError.message)
+        setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [enabled])
+
+  return { data, loading, error }
+}

--- a/src/lib/reportIndexSnapshot.ts
+++ b/src/lib/reportIndexSnapshot.ts
@@ -7,8 +7,8 @@ export function applyReportIndexSnapshot(
 ): ReportData {
   return {
     ...report,
+    ...entry,
     short_id: shortId,
-    meta: entry.meta,
-    summary: entry.summary,
+    task_results: report.task_results,
   }
 }

--- a/src/lib/runtimeNoteBenchmark.ts
+++ b/src/lib/runtimeNoteBenchmark.ts
@@ -1,0 +1,263 @@
+export const RUNTIME_REPORT_IDS = ['exp008', 'exp010', 'exp025', 'exp026'] as const
+
+export type RuntimeReportId = (typeof RUNTIME_REPORT_IDS)[number]
+
+const expectedReportById: Record<RuntimeReportId, { experimentId: string; condition: string; mode: string }> = {
+  exp008: {
+    experimentId: 'exp008_GPT52Chat_resume2_elicit_v2',
+    condition: 'Elicit v2 16k + resume_rounds 2',
+    mode: 'subprocess',
+  },
+  exp010: {
+    experimentId: 'exp010_GPT52Chat_resume2_elicit_v2',
+    condition: 'Elicit v2 16k + code_interpreter',
+    mode: 'code_interpreter',
+  },
+  exp025: {
+    experimentId: 'exp025_GPT54_high_postfix',
+    condition: 'GPT-5.4 reasoning=high + gpt-audio-1.5 preprocessor',
+    mode: 'subprocess',
+  },
+  exp026: {
+    experimentId: 'exp026_sandbox_skills_multimodal',
+    condition: 'GPT-5.4 low + sandbox + skills + audio/video perception',
+    mode: 'sandbox',
+  },
+}
+
+export interface RuntimeNoteData {
+  current_policy: {
+    scope: 'condition_a'
+    watchdog_minutes: number
+    step_timeout_minutes: number
+    job_timeout_minutes: number
+    relay_handoff_margin_minutes: number
+  }
+  incident: {
+    experiment_id: string
+    condition: 'condition_a'
+    action_run_id: string
+    approx_minute: number
+    event: string
+    started_at: string
+    completed_at: string
+    workflow_commit: string
+    policy: {
+      scope: 'condition_a'
+      step_timeout_minutes: number
+      job_timeout_minutes: number
+      resume_watchdog_enabled: false
+    }
+    source_record_commit: string
+    fix: {
+      commit: string
+      applied_at: string
+      step_timeout_before_minutes: number
+      step_timeout_after_minutes: number
+      resume_watchdog_enabled: true
+    }
+  }
+  sources: {
+    workflow: string
+    incidents: string
+  }
+  _generated: string
+}
+
+export interface RuntimeRecoveryRound {
+  round: number
+  attempted: number
+  recovered: number
+  stillFailed: number
+}
+
+export interface RuntimeBenchmarkRow {
+  shortId: RuntimeReportId
+  condition: string
+  executionMode: string
+  duration: string
+  totalTasks: number
+  successCount: number
+  errorCount: number
+  retriedCount: number
+  avgQaScore: number
+  recoveryRounds: RuntimeRecoveryRound[]
+}
+
+export type RuntimeNoteBenchmarkSelection =
+  | {
+      status: 'ready'
+      rows: RuntimeBenchmarkRow[]
+      exp025: RuntimeBenchmarkRow
+      exp026: RuntimeBenchmarkRow
+      currentPolicy: RuntimeNoteData['current_policy']
+      incident: RuntimeNoteData['incident']
+      sources: RuntimeNoteData['sources']
+      generated: string
+    }
+  | { status: 'missing'; missingIds: RuntimeReportId[] }
+  | { status: 'invalid'; invalidSources: string[] }
+
+const isNonNegativeInteger = (value: unknown): value is number => Number.isInteger(value) && Number(value) >= 0
+const isPositiveInteger = (value: unknown): value is number => Number.isInteger(value) && Number(value) > 0
+const isFiniteInRange = (value: unknown, min: number, max: number): value is number => (
+  typeof value === 'number' && Number.isFinite(value) && value >= min && value <= max
+)
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+)
+const isString = (value: unknown): value is string => typeof value === 'string'
+const isSha = (value: unknown): value is string => isString(value) && /^[0-9a-f]{40}$/.test(value)
+const parseUtcSecond = (value: unknown) => {
+  if (!isString(value) || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(value)) return null
+  const milliseconds = Date.parse(value)
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value.replace('Z', '.000Z')) return null
+  return milliseconds
+}
+const isCalendarDate = (value: unknown): value is string => {
+  if (!isString(value) || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const timestamp = `${value}T00:00:00.000Z`
+  const milliseconds = Date.parse(timestamp)
+  return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === timestamp
+}
+const roundToOneDecimal = (value: number) => Math.round(value * 10) / 10
+
+function parseRecoveryRounds(report: Record<string, unknown>, retriedCount: number): RuntimeRecoveryRound[] | null {
+  const recoveryStats = report.recovery_stats
+  if (!isRecord(recoveryStats) || !isRecord(recoveryStats.resume_rounds)) return null
+  const resume = recoveryStats.resume_rounds
+  if (resume.rounds_used !== 2 || !isRecord(resume.per_round)) return null
+  const perRound = resume.per_round
+  if (Object.keys(perRound).sort().join(',') !== '1,2') return null
+
+  const rounds = ['1', '2'].map((key) => {
+    const stats = perRound[key]
+    if (!isRecord(stats)) return null
+    if (!isNonNegativeInteger(stats.attempted) || !isNonNegativeInteger(stats.recovered) || !isNonNegativeInteger(stats.still_failed)) return null
+    if (stats.recovered + stats.still_failed !== stats.attempted) return null
+    return {
+      round: Number(key),
+      attempted: stats.attempted,
+      recovered: stats.recovered,
+      stillFailed: stats.still_failed,
+    }
+  })
+  if (rounds.some((round) => round === null)) return null
+
+  const validRounds = rounds as RuntimeRecoveryRound[]
+  const totalAttempted = validRounds.reduce((total, round) => total + round.attempted, 0)
+  if (totalAttempted !== retriedCount) return null
+  return validRounds
+}
+
+function parseRuntimeReport(shortId: RuntimeReportId, value: unknown): RuntimeBenchmarkRow | null {
+  if (!isRecord(value) || !isRecord(value.meta) || !isRecord(value.summary)) return null
+  const meta = value.meta
+  const summary = value.summary
+  const expected = expectedReportById[shortId]
+  if (value.short_id !== shortId) return null
+  if (meta.experiment_id !== expected.experimentId || meta.condition_name !== expected.condition || meta.execution_mode !== expected.mode) return null
+  if (meta.report_scope !== 'self_assessed_pre_grading') return null
+  if (!isString(meta.duration) || !/^\d+m \d+s$/.test(meta.duration)) return null
+  if (summary.total_tasks !== 220) return null
+  if (!isNonNegativeInteger(summary.success_count) || summary.success_count > summary.total_tasks) return null
+  if (!isFiniteInRange(summary.success_rate_pct, 0, 100)) return null
+  if (Math.abs(summary.success_rate_pct - roundToOneDecimal((summary.success_count / summary.total_tasks) * 100)) >= 0.05) return null
+  if (!isNonNegativeInteger(summary.error_count) || summary.error_count > summary.total_tasks) return null
+  if (summary.success_count + summary.error_count > summary.total_tasks) return null
+  if (!isNonNegativeInteger(summary.retried_count) || summary.retried_count > summary.total_tasks) return null
+  if (!isFiniteInRange(summary.avg_qa_score, 0, 10)) return null
+
+  const recoveryRounds = parseRecoveryRounds(value, summary.retried_count)
+  if (!recoveryRounds) return null
+
+  return {
+    shortId,
+    condition: expected.condition,
+    executionMode: expected.mode,
+    duration: meta.duration,
+    totalTasks: summary.total_tasks,
+    successCount: summary.success_count,
+    errorCount: summary.error_count,
+    retriedCount: summary.retried_count,
+    avgQaScore: summary.avg_qa_score,
+    recoveryRounds,
+  }
+}
+
+function parseRuntimeNote(value: unknown): RuntimeNoteData | null {
+  if (!isRecord(value) || !isRecord(value.current_policy) || !isRecord(value.incident) || !isRecord(value.sources)) return null
+  const currentPolicy = value.current_policy
+  const incident = value.incident
+  const sources = value.sources
+  if (!isRecord(incident.policy) || !isRecord(incident.fix)) return null
+  const incidentPolicy = incident.policy
+  const fix = incident.fix
+  const watchdogMinutes = currentPolicy.watchdog_minutes
+  const stepTimeoutMinutes = currentPolicy.step_timeout_minutes
+  const jobTimeoutMinutes = currentPolicy.job_timeout_minutes
+  const handoffMarginMinutes = currentPolicy.relay_handoff_margin_minutes
+
+  if (currentPolicy.scope !== 'condition_a') return null
+  if (!isPositiveInteger(watchdogMinutes) || !isPositiveInteger(stepTimeoutMinutes) || !isPositiveInteger(jobTimeoutMinutes) || !isPositiveInteger(handoffMarginMinutes)) return null
+  if (!(watchdogMinutes < stepTimeoutMinutes && stepTimeoutMinutes < jobTimeoutMinutes)) return null
+  if (handoffMarginMinutes !== stepTimeoutMinutes - watchdogMinutes) return null
+  if (incident.experiment_id !== 'exp025' || incident.condition !== 'condition_a' || incident.action_run_id !== '26018603400' || incident.event !== 'SIGKILL' || incident.approx_minute !== 330) return null
+  const startedAt = parseUtcSecond(incident.started_at)
+  const completedAt = parseUtcSecond(incident.completed_at)
+  if (startedAt === null || completedAt === null || startedAt >= completedAt) return null
+  if (incident.workflow_commit !== '36b0e5bed5e9be2622e505f68d3746eec1b6cc12') return null
+  if (incidentPolicy.scope !== 'condition_a' || incidentPolicy.step_timeout_minutes !== 330 || incidentPolicy.job_timeout_minutes !== 360 || incidentPolicy.resume_watchdog_enabled !== false) return null
+  if (incident.approx_minute !== incidentPolicy.step_timeout_minutes) return null
+  if (incident.source_record_commit !== '6e0001503ad4f3760c007dc1981d3bdc53dd785d') return null
+  if (fix.commit !== '62471a4a682b2f2439bba81a7eb24335a8f4931f' || fix.applied_at !== '2026-05-20' || !isCalendarDate(fix.applied_at)) return null
+  if (fix.step_timeout_before_minutes !== incidentPolicy.step_timeout_minutes || fix.step_timeout_after_minutes !== stepTimeoutMinutes || fix.resume_watchdog_enabled !== true) return null
+  if (incidentPolicy.job_timeout_minutes !== jobTimeoutMinutes) return null
+  if (!isString(value._generated)) return null
+  const generatedAt = Date.parse(value._generated)
+  if (!Number.isFinite(generatedAt) || new Date(generatedAt).toISOString() !== value._generated) return null
+  if (sources.workflow !== '.github/workflows/batch-run.yml' || sources.incidents !== 'data/notes/runtime-incidents.yaml') return null
+  if (!isSha(incident.workflow_commit) || !isSha(incident.source_record_commit) || !isSha(fix.commit)) return null
+  return value as unknown as RuntimeNoteData
+}
+
+export function selectRuntimeNoteBenchmark(
+  reports: unknown,
+  runtimeNote: unknown,
+): RuntimeNoteBenchmarkSelection {
+  if (!Array.isArray(reports)) return { status: 'invalid', invalidSources: ['reports-index.json'] }
+  const matchesById = new Map(
+    RUNTIME_REPORT_IDS.map((shortId) => [shortId, reports.filter((report) => isRecord(report) && report.short_id === shortId)]),
+  )
+  const missingIds = RUNTIME_REPORT_IDS.filter((shortId) => matchesById.get(shortId)?.length === 0)
+  if (missingIds.length > 0) return { status: 'missing', missingIds }
+
+  const invalidSources: string[] = []
+  const rows = RUNTIME_REPORT_IDS.map((shortId) => {
+    const matches = matchesById.get(shortId) ?? []
+    if (matches.length !== 1) {
+      invalidSources.push(shortId)
+      return null
+    }
+    const row = parseRuntimeReport(shortId, matches[0])
+    if (!row) invalidSources.push(shortId)
+    return row
+  })
+
+  const validRuntimeNote = parseRuntimeNote(runtimeNote)
+  if (!validRuntimeNote) invalidSources.push('runtime-note.json')
+  if (invalidSources.length > 0) return { status: 'invalid', invalidSources }
+
+  const validRows = rows as RuntimeBenchmarkRow[]
+  return {
+    status: 'ready',
+    rows: validRows,
+    exp025: validRows[2],
+    exp026: validRows[3],
+    currentPolicy: validRuntimeNote!.current_policy,
+    incident: validRuntimeNote!.incident,
+    sources: validRuntimeNote!.sources,
+    generated: validRuntimeNote!._generated,
+  }
+}

--- a/src/pages/JournalArticle.tsx
+++ b/src/pages/JournalArticle.tsx
@@ -14,11 +14,16 @@ import { useTheme } from '../contexts/ThemeContext'
 import NoteComparisonChart from '../components/notes/NoteComparisonChart'
 import NoteHeroVisual from '../components/notes/NoteHeroVisual'
 import { useReports } from '../hooks/useReports'
+import { useRuntimeNote } from '../hooks/useRuntimeNote'
 import {
   selectPromptComplexityBenchmark,
   type PromptComplexityBenchmarkRow,
   type PromptComplexityBenchmarkSelection,
 } from '../lib/promptComplexityBenchmark'
+import {
+  selectRuntimeNoteBenchmark,
+  type RuntimeNoteBenchmarkSelection,
+} from '../lib/runtimeNoteBenchmark'
 import {
   getJournalArticle,
   journalArticles,
@@ -36,6 +41,7 @@ const lensStyles: Record<JournalLens, string> = {
 }
 
 type ReadyPromptBenchmark = Extract<PromptComplexityBenchmarkSelection, { status: 'ready' }>
+type ReadyRuntimeBenchmark = Extract<RuntimeNoteBenchmarkSelection, { status: 'ready' }>
 
 const formatSigned = (value: number, suffix: string) => `${value > 0 ? '+' : ''}${value.toFixed(1)}${suffix}`
 
@@ -73,6 +79,66 @@ function resolvePromptComplexityArticle(article: JournalArticleData, benchmark: 
   }
 }
 
+function resolveRuntimeArticle(article: JournalArticleData, benchmark: ReadyRuntimeBenchmark) {
+  const firstRound = benchmark.exp026.recoveryRounds[0]
+  const secondRound = benchmark.exp026.recoveryRounds[1]
+  const policy = benchmark.currentPolicy
+  const incident = benchmark.incident
+
+  return {
+    metrics: [
+      { value: String(benchmark.exp026.totalTasks), label: '서로 다른 실제 업무', note: undefined },
+      { value: `${policy.job_timeout_minutes}분`, label: 'workflow job cap', note: undefined },
+      { value: `약 ${incident.approx_minute}분`, label: `${incident.policy.step_timeout_minutes}분 step hard stop`, note: undefined },
+    ],
+    hero: article.hero ? {
+      ...article.hero,
+      alt: `사건 당시 ${incident.policy.step_timeout_minutes}분 step hard timeout과 수정 후 ${policy.watchdog_minutes}분 watchdog, ${policy.step_timeout_minutes}분 step ceiling, ${policy.job_timeout_minutes}분 job cap 비교`,
+      caption: `사건 당시 ${incident.policy.step_timeout_minutes}분 step hard stop에서 ${incident.event}이 발생했다. 수정 후 condition_a 경로는 ${policy.watchdog_minutes}분 watchdog, ${policy.step_timeout_minutes}분 step ceiling, ${policy.job_timeout_minutes}분 job cap으로 분리됐다.`,
+    } : undefined,
+    chart: article.comparisonChart ? {
+      ...article.comparisonChart,
+      description: `첫 round는 ${firstRound.attempted}개 중 ${firstRound.recovered}개를 회복했고, 두 번째 round는 ${secondRound.attempted}개 중 ${secondRound.recovered}개를 회복했다.`,
+      data: benchmark.exp026.recoveryRounds.map((round) => ({
+        label: `Round ${round.round}`,
+        primary: round.recovered,
+        secondary: round.stillFailed,
+      })),
+    } : undefined,
+    sections: article.sections.map((section) => {
+      if (section.benchmarkNarrative === 'runtime-incident') {
+        return {
+          ...section,
+          paragraphs: [
+            `GDPVal의 ${benchmark.exp026.totalTasks}개 작업은 짧은 문서 작성부터 스프레드시트 계산, 프레젠테이션, 코드와 미디어 처리까지 섞여 있다. 한 작업의 평균 시간만 보고 전체 실행 시간을 예상하면 긴 꼬리 작업이 사라진다.`,
+            `${incident.experiment_id}의 resume round는 당시 ${incident.policy.step_timeout_minutes}분 step hard timeout에 닿아 약 ${incident.approx_minute}분 지점에서 ${incident.event}로 끝났다. job cap까지 남은 시간이 있었지만, 프로세스가 강제 종료되어 마지막 상태를 다음 실행으로 넘기지 못했다.`,
+          ],
+          callout: `여기서 ${policy.job_timeout_minutes}분은 GitHub Actions 전체에 보편적으로 적용되는 규칙이라는 뜻이 아니라, 이 기록의 workflow와 runner에서 작동한 job cap을 가리킨다.`,
+        }
+      }
+      if (section.benchmarkNarrative === 'runtime-policy') {
+        return {
+          ...section,
+          paragraphs: [
+            `중단 사건 뒤 Resume Round에도 watchdog이 들어갔고 step ceiling은 ${incident.fix.step_timeout_before_minutes}분에서 ${incident.fix.step_timeout_after_minutes}분으로 넓어졌다. 현재 workflow의 condition_a 경로에서 watchdog은 기본 ${policy.watchdog_minutes}분에 checkpoint를 남기고 종료하며, workflow step은 relay handoff를 위한 ${policy.relay_handoff_margin_minutes}분의 여유를 더해 ${policy.step_timeout_minutes}분에 닫힌다. exp008과 exp010은 이 수정 전에 실행됐으므로 현재 정책의 결과로 읽지 않는다.`,
+            '이 구조는 작업 실행과 workflow 수명을 분리했다. 한 번의 runner가 전체 실험을 소유하지 않고, 여러 runner가 동일한 실험 상태를 이어받을 수 있게 됐다.',
+          ],
+        }
+      }
+      if (section.benchmarkNarrative === 'runtime-results') {
+        return {
+          ...section,
+          paragraphs: [
+            `relay는 장시간 실행을 이어갈 수 있게 했지만 모든 실패를 해결하지는 않았다. ${benchmark.exp026.shortId} report에서 첫 resume round는 시도한 ${firstRound.attempted}개 작업 중 ${firstRound.recovered}개를 회복했고 ${firstRound.stillFailed}개를 남겼다. 두 번째 round는 ${secondRound.attempted}개 중 ${secondRound.recovered}개를 회복하고 ${secondRound.stillFailed}개를 남겼다.`,
+            `최종 report는 ${benchmark.exp026.totalTasks}개 중 ${benchmark.exp026.successCount}개 success, ${benchmark.exp026.errorCount}개 명시적 실행 오류, ${benchmark.exp026.retriedCount}개 재시도를 기록한다. 복구 가능성은 높아졌지만 반복 시도가 남은 작업을 균일하게 해결하지는 못했다.`,
+          ],
+        }
+      }
+      return section
+    }),
+  }
+}
+
 function BenchmarkDataSource({ rows, generated }: { rows: PromptComplexityBenchmarkRow[]; generated: string }) {
   return (
     <aside className="mb-10 border-y border-dash-border py-4 text-[11px]/[1.7] text-dash-text-secondary" aria-label="Benchmark data source">
@@ -103,6 +169,48 @@ function BenchmarkDataSource({ rows, generated }: { rows: PromptComplexityBenchm
   )
 }
 
+function RuntimeDataSource({ benchmark }: { benchmark: ReadyRuntimeBenchmark }) {
+  const repo = 'https://github.com/hyeonsangjeon/gdpval-realworks'
+  return (
+    <aside className="mb-12 border-y border-dash-border py-5 text-[11px]/[1.75] text-dash-text-secondary" aria-label="Runtime evidence source">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <span className="font-mono text-[10px] font-semibold text-emerald-700 dark:text-emerald-400">RUNTIME EVIDENCE</span>
+        <a href={`${import.meta.env.BASE_URL}generated/runtime-note.json`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400">
+          runtime-note.json <ExternalLink className="h-3 w-3" />
+        </a>
+        <a href={`${import.meta.env.BASE_URL}generated/reports-index.json`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400">
+          reports-index.json <ExternalLink className="h-3 w-3" />
+        </a>
+        <a href={`${repo}/blob/main/${benchmark.sources.workflow}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400">
+          workflow YAML <ExternalLink className="h-3 w-3" />
+        </a>
+        <a href={`${repo}/actions/runs/${benchmark.incident.action_run_id}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400">
+          incident run <ExternalLink className="h-3 w-3" />
+        </a>
+        <a href={`${repo}/blob/${benchmark.incident.workflow_commit}/${benchmark.sources.workflow}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400">
+          incident workflow <ExternalLink className="h-3 w-3" />
+        </a>
+        <a href={`${repo}/commit/${benchmark.incident.fix.commit}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400">
+          watchdog fix <ExternalLink className="h-3 w-3" />
+        </a>
+        <a href={`${repo}/blob/${benchmark.incident.source_record_commit}/CHANGELOG.md`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400">
+          incident record <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-x-3 gap-y-2">
+        {benchmark.rows.map((row) => (
+          <Link key={row.shortId} to={getExperimentHref(row.shortId)} className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400">
+            {row.shortId} · {row.executionMode} · {row.duration} <ArrowRight className="h-3 w-3" />
+          </Link>
+        ))}
+      </div>
+      <div className="mt-3 text-dash-text-muted">
+        290분 watchdog은 현재 workflow의 condition_a 경로 기준이다. duration은 실험 전체 경과시간이며, relay가 이어진 exp025·exp026에서는 한 job의 실행 시간과 같지 않다.
+      </div>
+    </aside>
+  )
+}
+
 function BenchmarkDataState({ message, error }: { message: string; error?: boolean }) {
   return (
     <div className="max-w-[1080px] mx-auto px-4 md:px-6 py-8 md:py-10">
@@ -124,13 +232,23 @@ function JournalArticleContent({ slug }: { slug: string | undefined }) {
   const { isDark, toggle: toggleTheme } = useTheme()
   const article = getJournalArticle(slug)
   const usesPromptBenchmark = article?.benchmark?.kind === 'prompt-complexity'
-  const { reports, generated, loading: reportsLoading, error: reportsError } = useReports(usesPromptBenchmark)
+  const isReflective = article?.readingStyle === 'reflective'
+  const usesRuntimeBenchmark = article?.benchmark?.kind === 'runtime'
+  const usesReportBenchmark = usesPromptBenchmark || usesRuntimeBenchmark
+  const { reports, generated, loading: reportsLoading, error: reportsError } = useReports(usesReportBenchmark)
+  const { data: runtimeNote, loading: runtimeLoading, error: runtimeError } = useRuntimeNote(usesRuntimeBenchmark)
   const promptBenchmark = usesPromptBenchmark && !reportsLoading && !reportsError
     ? selectPromptComplexityBenchmark(reports)
     : null
   const readyPromptBenchmark = promptBenchmark?.status === 'ready' ? promptBenchmark : null
+  const runtimeBenchmark = usesRuntimeBenchmark && !reportsLoading && !reportsError && !runtimeLoading && !runtimeError
+    ? selectRuntimeNoteBenchmark(reports, runtimeNote)
+    : null
+  const readyRuntimeBenchmark = runtimeBenchmark?.status === 'ready' ? runtimeBenchmark : null
   const resolved = article && readyPromptBenchmark
     ? resolvePromptComplexityArticle(article, readyPromptBenchmark)
+    : article && readyRuntimeBenchmark
+      ? resolveRuntimeArticle(article, readyRuntimeBenchmark)
     : null
 
   useEffect(() => {
@@ -154,8 +272,11 @@ function JournalArticleContent({ slug }: { slug: string | undefined }) {
     .slice(0, 2)
   const displayedMetrics = resolved?.metrics ?? article.metrics
   const displayedChart = resolved?.chart ?? article.comparisonChart
-  const displayedSections = (resolved?.sections ?? article.sections)
-    .filter((section) => !section.benchmarkNarrative || readyPromptBenchmark)
+  const benchmarkReady = readyPromptBenchmark || readyRuntimeBenchmark
+  const displayedSections = usesRuntimeBenchmark && !readyRuntimeBenchmark
+    ? []
+    : (resolved?.sections ?? article.sections)
+      .filter((section) => !section.benchmarkNarrative || benchmarkReady)
 
   return (
     <div lang="ko" className="min-h-screen bg-dash-page text-dash-text font-journal-sans">
@@ -201,10 +322,11 @@ function JournalArticleContent({ slug }: { slug: string | undefined }) {
           </div>
         </header>
 
-        {article.hero && (!usesPromptBenchmark || readyPromptBenchmark) && (
+        {article.hero && (!usesReportBenchmark || benchmarkReady) && (
           <NoteHeroVisual
             hero={resolved?.hero ?? article.hero}
             promptBenchmark={readyPromptBenchmark?.rows}
+            runtimeBenchmark={readyRuntimeBenchmark ?? undefined}
           />
         )}
         {usesPromptBenchmark && reportsLoading && <BenchmarkDataState message="benchmark report 데이터를 불러오는 중입니다." />}
@@ -215,9 +337,19 @@ function JournalArticleContent({ slug }: { slug: string | undefined }) {
         {usesPromptBenchmark && promptBenchmark?.status === 'invalid' && (
           <BenchmarkDataState error message={`benchmark report의 ${promptBenchmark.invalidIds.join(', ')} 행이 유효하지 않습니다.`} />
         )}
+        {usesRuntimeBenchmark && (reportsLoading || runtimeLoading) && <BenchmarkDataState message="runtime 근거 데이터를 불러오는 중입니다." />}
+        {usesRuntimeBenchmark && reportsError && <BenchmarkDataState error message={`runtime report를 불러오지 못했습니다: ${reportsError}`} />}
+        {usesRuntimeBenchmark && runtimeError && <BenchmarkDataState error message={`runtime policy를 불러오지 못했습니다: ${runtimeError}`} />}
+        {usesRuntimeBenchmark && runtimeBenchmark?.status === 'missing' && (
+          <BenchmarkDataState error message={`runtime report에서 ${runtimeBenchmark.missingIds.join(', ')} 행을 찾지 못했습니다.`} />
+        )}
+        {usesRuntimeBenchmark && runtimeBenchmark?.status === 'invalid' && (
+          <BenchmarkDataState error message={`runtime 근거의 ${runtimeBenchmark.invalidSources.join(', ')} 항목이 유효하지 않습니다.`} />
+        )}
 
         <div className="max-w-[760px] mx-auto px-4 md:px-6 py-12 md:py-16">
           {readyPromptBenchmark && <BenchmarkDataSource rows={readyPromptBenchmark.rows} generated={generated} />}
+          {readyRuntimeBenchmark && <RuntimeDataSource benchmark={readyRuntimeBenchmark} />}
           <div className="mb-14 md:mb-16">
             <div className="flex items-center gap-3 mb-4" aria-hidden="true">
               <span className="font-mono text-[10px] text-emerald-600 dark:text-emerald-400">THESIS</span>
@@ -240,29 +372,36 @@ function JournalArticleContent({ slug }: { slug: string | undefined }) {
             </div>
           )}
 
-          {displayedChart && (!usesPromptBenchmark || readyPromptBenchmark) && (
+          {displayedChart && (!usesReportBenchmark || benchmarkReady) && (
             <NoteComparisonChart chart={displayedChart} />
           )}
 
-          <div className="space-y-16 md:space-y-20">
+          <div className={isReflective ? 'space-y-20 md:space-y-28' : 'space-y-16 md:space-y-20'}>
             {displayedSections.map((section, sectionIndex) => (
-              <section key={section.heading}>
-                <div className="mb-6 md:mb-8">
-                  <div className="flex items-center gap-3 mb-3" aria-hidden="true">
+              <section key={section.heading} className={isReflective ? 'scroll-mt-24' : undefined}>
+                <div className={isReflective ? 'mb-8 md:mb-10' : 'mb-6 md:mb-8'}>
+                  <div className={isReflective ? 'flex items-center gap-3 mb-4' : 'flex items-center gap-3 mb-3'} aria-hidden="true">
                     <span className="font-mono text-[10px] text-emerald-600 dark:text-emerald-400">
                       {String(sectionIndex + 1).padStart(2, '0')}
                     </span>
                     <span className="h-px w-8 bg-dash-border-active" />
+                    {section.label && (
+                      <span className="font-mono text-[10px] text-dash-text-muted">{section.label}</span>
+                    )}
                   </div>
-                  <h2 className="font-journal-serif text-[26px] md:text-[30px] leading-[1.35] tracking-normal text-balance break-keep text-dash-heading">
+                  <h2 className={isReflective
+                    ? 'max-w-[660px] font-journal-serif text-[28px] md:text-[34px] leading-[1.42] tracking-normal text-balance break-keep text-dash-heading'
+                    : 'font-journal-serif text-[26px] md:text-[30px] leading-[1.35] tracking-normal text-balance break-keep text-dash-heading'}>
                     {section.heading}
                   </h2>
                 </div>
-                <div className="space-y-5">
-                  {section.paragraphs.map((paragraph) => (
+                <div className={isReflective ? 'space-y-7 md:space-y-8' : 'space-y-5'}>
+                  {section.paragraphs.map((paragraph, paragraphIndex) => (
                     <p
                       key={paragraph}
-                      className="text-[15px]/[1.9] md:text-[16px]/[1.9] text-pretty break-keep text-dash-text"
+                      className={isReflective
+                        ? `max-w-[700px] text-[16px]/[2.05] md:text-[17px]/[2.05] text-pretty break-keep ${paragraphIndex === 0 ? 'text-dash-heading' : 'text-dash-text'}`
+                        : 'text-[15px]/[1.9] md:text-[16px]/[1.9] text-pretty break-keep text-dash-text'}
                     >
                       {paragraph}
                     </p>
@@ -279,7 +418,9 @@ function JournalArticleContent({ slug }: { slug: string | undefined }) {
                   </ul>
                 )}
                 {section.callout && (
-                  <div className="mt-8 bg-dash-surface/60 border-y border-dash-border px-5 py-5 text-[13px] md:text-sm text-dash-text leading-7">
+                  <div className={isReflective
+                    ? 'mt-10 border-y border-dash-border px-1 md:px-6 py-6 font-journal-serif text-[15px]/[1.9] md:text-[16px]/[1.9] text-pretty break-keep text-dash-text-secondary'
+                    : 'mt-8 bg-dash-surface/60 border-y border-dash-border px-5 py-5 text-[13px] md:text-sm text-dash-text leading-7'}>
                     {section.callout}
                   </div>
                 )}

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,84 +4,74 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-18
-- Status: Agentic Sandbox plan approved; implementation pending plan merge
+- Status: Runtime Field Note grounded, restyled, and locally verified
 
 ## Task
 
-- Create a dated implementation and experiment plan for a full task-solving
-  agentic tool loop in the sandbox.
-- Preserve the current sandbox as the paired baseline and keep grading tool
-  behavior separate from task-solving behavior.
-- Define security, iteration, time, resource, usage, cost, experiment, and
-  retrospective gates before writing code or running a model.
+- Ground `220개의 실제 업무를 360분 안에 실행한다는 것` in structured report,
+  workflow, and incident evidence rather than duplicated numeric literals.
+- Separate the exp025 incident-time policy from the post-fix runtime policy so
+  the retrospective does not collapse two historical states onto one axis.
+- Refine the note's line spacing, heading rhythm, chapter transitions, and
+  callouts so readers can follow 사건→편향→대응→결과→결정 without losing the
+  evidence trail.
 
 ## Result
 
-- Added
-  `tasks/0717_friday/AGENTIC_SANDBOX_EXPERIMENT_PLAN.md` beside the existing
-  Track 2 cohort document without modifying that experiment record.
-- Fixed the proposed treatment as a separate `agentic_sandbox` execution mode.
-  The MVP supports Azure/OpenAI Responses function calls and preinstalled
-  capabilities only; runtime package installation, network, root, arbitrary
-  shell, Anthropic support, and capability-image selection are deferred.
-- Defined six model-visible tools: workspace inspection, environment inspection,
-  Python execution, ffmpeg execution, artifact inspection, and deterministic
-  finalization. Plain assistant text cannot complete a task.
-- Fixed the persistent workspace design: one disposable container per task,
-  `/inputs:ro`, quota-backed `/work` tmpfs, fixed nonzero UID, read-only rootfs,
-  dropped capabilities, no network/IPC, syscall-filtered generated Python, and
-  host-only source/control state and verified artifact snapshots.
-- Preregistered model/tool/finalization/repetition budgets and fail-closed path,
-  usage, verification, and security behavior.
-- Defined optional agentic observability that excludes raw prompts, code,
-  arguments, process output, image payloads, credentials, and absolute paths.
-- Defined non-paid scripted and real-image Docker validation, legacy report/UI
-  omission checks, broad regression, frontend build, and responsive fixture
-  verification. Actual API/model call count must remain zero during
-  implementation.
-- Fixed an outcome-free, seeded, stratified selector contract that emits
-  disjoint five-task canary and twenty-task diagnostic cohorts in one atomic
-  pre-outcome step. Exact task IDs and source identities are not yet frozen;
-  they must be generated, reviewed, and committed at a separate paid gate with
-  projected cost, hard caps, abort procedure, and explicit owner approval.
-- Added evidence, cost, and incident ledgers plus the structure for
-  `AGENTIC_SANDBOX_RETROSPECTIVE.md` so later experiment notes can distinguish
-  preregistered decisions from post-run interpretation.
-- Hardened the live boundary around separate credential and compute planes,
-  byte-identical baseline/treatment substrates, isolated artifact verification,
-  crash-safe shared budgets, signed single-use paid authorization, authenticated
-  anti-replay envelopes, and input-byte/provider-classification identities.
-- Preserved the concurrent Track 2 state from current `main`: its atomic-save
-  fix and model-free preflight passed, while a second paid Stage B attempt still
-  requires explicit owner deviation approval and remains out of scope here.
-
-## Concurrent Track 2 Guard
-
-- Rejected paid run `29591036089` has no resumable artifact; its unpersisted
-  usage remains conservatively booked at USD 3.81 raw.
-- Atomic-save fix PR #99 is merged and model-free preflight `29599249906`
-  passed against the corrected grader/output identity.
-- A fresh `resume=false` Stage B attempt remains prohibited until the owner
-  explicitly approves the deviation and cumulative USD 10 cap. This Agentic
-  plan does not grant or inherit that approval.
+- Added a structured exp025 incident record pinned to run `26018603400`, its
+  workflow SHA, the incident-time 330-minute step timeout, and the fix commit.
+  A generator parses the current workflow and emits
+  `public/generated/runtime-note.json` only when before/after policy and pinned
+  Resume Round watchdog history satisfy their invariants.
+- Added a strict runtime selector for the exact exp008, exp010, exp025, and
+  exp026 report identities. It requires condition-a scope, exact execution
+  modes, 220 tasks, self-assessed report scope, count/rate consistency, valid
+  timestamps, and internally consistent resume rounds. Invalid evidence hides
+  the full chapter sequence, metrics, hero, chart, and source strip behind an
+  explicit alert.
+- Replaced static `220/290/330/350/360`, exp026 summary, and round values with
+  selected evidence. The desktop and mobile hero now show two historical lanes:
+  incident-time `330 hard stop → SIGKILL`, then post-fix
+  `290 watchdog → 350 step → 360 job` for condition A.
+- Added direct links to generated runtime/report JSON, current and incident
+  workflow revisions, the fix commit, the failed Actions run, pinned incident
+  record, and four experiment details. Report duration is explicitly described
+  as experiment-wide elapsed time, not one job duration; exp008/010 are marked
+  as pre-fix comparison context.
+- Restyled only this article with five short chapter titles, small semantic
+  labels, wider vertical spacing, 2.05 body leading, and quieter serif callouts.
+  Other Field Notes retain their existing density.
+- Corrected exp026 prompt-architecture copy to match its actual Docker-always,
+  fail-loud sandbox policy instead of claiming a graceful local fallback.
+- Extended the Pages source paths and serialized Pages deployments. The build
+  now runs all aggregate contracts, pinned git-history checks, a production
+  build, and Chromium desktop/mobile/error-state verification before upload.
+  The batch workflow remains manual-only and is never dispatched here.
 
 ## Verification
 
-- Plan rebased for merge onto
-  `main@71902db3904a358e6f832caf8f39e807047f9bdf`.
-- `first-reviewer` and `extreme-reasoner` independently approved the final plan
-  with no mandatory blockers; both explicitly denied live model/API approval.
-- Focused documentation, security-gate, selection-formula, endpoint, and
-  Track 2 preservation checks passed with `git diff --check` clean.
-- Existing `tasks/0717_friday/TRACK2_COHORT_EXPANSION_EXPERIMENT.md` is
-  preserved.
-- No implementation code, workflow, model call, package installation, paid run,
-  or remote project mutation was performed while drafting the plan.
+- Rebased feature commit `73f6771d` onto `main@b040e6c8`; the worktree is clean
+  at the committed feature boundary. The remaining four-file documentation and
+  dependency-cleanup diff contains this rolling record, the changelog entry,
+  and removal of unused direct dependency `js-yaml` plus its lockfile-only
+  `argparse` child.
+- Full Node contracts: **42 passed, 0 failed**. Production TypeScript/Vite build
+  and `git diff --check` passed; static diagnostics found no errors in the
+  seven affected TypeScript files.
+- Checked-in Playwright passed against the built distribution across desktop,
+  390px dark/reduced-motion, invalid policy, null JSON, malformed nested rounds,
+  and normal-note→runtime-note stale-state transitions. There was no horizontal
+  overflow, marker overlap, or post-settle chart mutation.
+- Workflow parsing confirmed exactly eight Pages source paths, one serialized
+  build-and-deploy job, production build followed by full aggregate contracts,
+  Chromium verification before artifact upload, and a manual-only batch
+  workflow.
+- `first-reviewer` approved the final historical, selector, typography, and
+  browser-test design. `extreme-reasoner` approved the Pages change after the
+  unused dependency removal and confirmed automatic model, Azure, HF upload,
+  batch, grading, and paid-run impact is **zero**.
 
 ## Remaining Work
 
-- Merge the approved docs-only plan.
-- Create a fresh implementation branch from the plan merge SHA and implement
-  through the non-paid validation gate.
-- Stop before live model/API execution until the paid gate receives explicit
-  approval.
+- Commit the dependency cleanup and completion records, publish the reviewed
+  branch, and verify the deployed article and Pages run.


### PR DESCRIPTION
## Summary
- Ground the 360-minute Field Note in exact exp008/010/025/026 report snapshots, a structured exp025 incident record, and current condition-a workflow policy.
- Separate the incident-time 330-minute hard stop from the post-fix 290-minute watchdog, 350-minute step, and 360-minute job boundaries.
- Refine the article into five reflective chapters with shorter headings, wider spacing, 2.05 leading, and quieter callouts.
- Gate Pages on generated runtime evidence, all aggregate contracts, pinned-history checks, and desktop/mobile Chromium verification.

## Verification
- `npm ci`
- `npm run test:aggregate` — 42 passed
- `npm run build`
- `npm run test:runtime-browser:dist`
- workflow YAML assertions and `git diff --check`
- first-reviewer: APPROVE
- extreme-reasoner: APPROVE-WITH-CONDITIONS, all conditions satisfied

## Safety
- No model/API call, Azure login, HF upload, batch, grading, or paid workflow dispatch.
- Batch workflow remains manual-only; source changes trigger only serialized Pages deployment.
