### PR TITLE
docs(notes): record runtime retrospective deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ entries land under a fresh dated heading the day they merge to `main`.
   The Pages workflow now regenerates this evidence when either runtime source
   changes and gates deployment on all aggregate contracts plus pinned-history
   and Chromium desktop/mobile checks. No model, batch, grading, HF upload, or
-  paid workflow is dispatched by this change.
+  paid workflow is dispatched by this change. Shipped through PR #102
+  (`fe222493`) and successful Pages run
+  [29628757147](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29628757147);
+  the deployed JSON, two-lane timeline, report-derived chart, source links, and
+  reflective typography were verified on desktop and mobile.
 - **Agentic Sandbox implementation and experiment preregistration plan** — define a
   separate `agentic_sandbox` task-solving mode that lets the model choose among
   bounded workspace inspection, Python, ffmpeg, artifact inspection, and

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,7 +4,7 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-18
-- Status: Runtime Field Note grounded, restyled, and locally verified
+- Status: Runtime Field Note published and production-verified
 
 ## Task
 
@@ -47,14 +47,17 @@ task. It must be refreshed before a task is reported complete.
   now runs all aggregate contracts, pinned git-history checks, a production
   build, and Chromium desktop/mobile/error-state verification before upload.
   The batch workflow remains manual-only and is never dispatched here.
+- Squash-merged the reviewed change through PR #102 as `fe222493`. Automatic
+  `Aggregate Tests & Deploy` run
+  [29628757147](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29628757147)
+  completed build, all 42 aggregate contracts, pinned-history checks, Chromium
+  installation, browser verification, artifact upload, and GitHub Pages deploy
+  successfully. No other workflow ran for that commit.
 
 ## Verification
 
-- Rebased feature commit `73f6771d` onto `main@b040e6c8`; the worktree is clean
-  at the committed feature boundary. The remaining four-file documentation and
-  dependency-cleanup diff contains this rolling record, the changelog entry,
-  and removal of unused direct dependency `js-yaml` plus its lockfile-only
-  `argparse` child.
+- The reviewed branch was based on `main@b040e6c8` and included removal of the
+  unused direct dependency `js-yaml` plus its lockfile-only `argparse` child.
 - Full Node contracts: **42 passed, 0 failed**. Production TypeScript/Vite build
   and `git diff --check` passed; static diagnostics found no errors in the
   seven affected TypeScript files.
@@ -70,8 +73,16 @@ task. It must be refreshed before a task is reported complete.
   browser-test design. `extreme-reasoner` approved the Pages change after the
   unused dependency removal and confirmed automatic model, Azure, HF upload,
   batch, grading, and paid-run impact is **zero**.
+- On the deployed site, `runtime-note.json` preserved the May 18 incident
+  workflow (`330`-minute hard stop, watchdog absent) separately from the post-
+  fix condition-a policy (`290` watchdog, `350` step, `360` job). The public
+  exp026 snapshot matched `220/200/6/105` and resume rounds `78/78/0` and
+  `27/7/20` across metrics, prose, SVG, and chart.
+- Public desktop verification found 34px chapter headings and 34.85px body
+  leading; 390px dark/reduced-motion verification found 28px headings, 32.8px
+  leading, all five chapter labels, eleven evidence links, both chart labels,
+  no horizontal overflow, and zero post-settle chart mutations.
 
 ## Remaining Work
 
-- Commit the dependency cleanup and completion records, publish the reviewed
-  branch, and verify the deployed article and Pages run.
+- No implementation or deployment work remains for this Runtime Field Note.


### PR DESCRIPTION
## Summary
- Record PR #102 and successful Pages deployment for the evidence-backed Runtime Field Note.
- Replace local verification status with GitHub-hosted contract, Chromium, and production evidence.
- Mark the Runtime Field Note implementation and deployment complete.

## Verification
- first-reviewer: APPROVE
- PR #102 merged as fe222493
- Pages run 29628757147: success
- Public incident/current policy, exp026 report, desktop/mobile typography, evidence links, and reduced-motion checks passed