### PR TITLE
feat: implement bounded agentic sandbox experiment

### DIFF
--- a/.github/workflows/agentic-sandbox-preflight.yml
+++ b/.github/workflows/agentic-sandbox-preflight.yml
@@ -1,0 +1,86 @@
+name: Agentic Sandbox Model-Free Preflight
+
+on:
+  workflow_dispatch:
+    inputs:
+      production_image:
+        description: Exact preloaded task/verifier image (repository@sha256:digest)
+        required: true
+        type: string
+      sbom_sha256:
+        description: Exact reviewed SPDX SBOM SHA-256
+        required: true
+        type: string
+      apparmor_profile:
+        description: Enforcing dedicated-runner AppArmor profile
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agentic-sandbox-model-free-preflight
+  cancel-in-progress: false
+
+jobs:
+  model-free-preflight:
+    runs-on: [self-hosted, linux, x64, agentic-sandbox]
+    timeout-minutes: 45
+    steps:
+      - name: Checkout exact implementation
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Verify no model or publication credentials
+        run: |
+          set -euo pipefail
+          for name in AZURE_OPENAI_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY HF_TOKEN; do
+            if [ -n "${!name:-}" ]; then
+              echo "FATAL: credential environment is present: $name"
+              exit 1
+            fi
+          done
+          test "$(docker ps -q | wc -l)" -eq 0
+          test "$(awk 'END {print NR}' /proc/swaps)" -eq 1
+
+      - name: Verify preloaded model-free test environment
+        run: |
+          python3.11 - <<'PY'
+          import sys
+
+          assert sys.version_info[:2] == (3, 11), sys.version
+          import cryptography
+          import jsonschema
+          import pytest
+          import yaml
+
+          print("preloaded-model-free-environment=pass")
+          PY
+
+      - name: Verify image is already present
+        env:
+          IMAGE: ${{ inputs.production_image }}
+        run: |
+          set -euo pipefail
+          echo "$IMAGE" | grep -Eq '^.+@sha256:[0-9a-f]{64}$'
+          docker image inspect "$IMAGE" >/dev/null
+
+      - name: Run production containment preflight
+        env:
+          AGENTIC_PRODUCTION_PREFLIGHT: '1'
+          AGENTIC_PRODUCTION_IMAGE: ${{ inputs.production_image }}
+          AGENTIC_PRODUCTION_SBOM_SHA256: ${{ inputs.sbom_sha256 }}
+          AGENTIC_PRODUCTION_APPARMOR_PROFILE: ${{ inputs.apparmor_profile }}
+        run: |
+          cd batch-runner
+          python3.11 -m pytest \
+            tests/test_agentic_sandbox_security.py::test_agentic_production_runner_preflight \
+            -m integration -q
+
+      - name: Assert terminal cleanup
+        if: always()
+        run: |
+          test -z "$(docker ps -aq --filter name=gdpval-agentic-)"
+          test -z "$(docker volume ls -q --filter name=gdpval-agentic-)"

--- a/.github/workflows/agentic-sandbox-preflight.yml
+++ b/.github/workflows/agentic-sandbox-preflight.yml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   model-free-preflight:
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true
     runs-on: [self-hosted, linux, x64, agentic-sandbox]
     timeout-minutes: 45
     steps:
@@ -32,6 +33,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Verify protected main checkout
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_REF_PROTECTED" = "true"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - name: Verify no model or publication credentials
         run: |
@@ -77,6 +86,7 @@ jobs:
           cd batch-runner
           python3.11 -m pytest \
             tests/test_agentic_sandbox_security.py::test_agentic_production_runner_preflight \
+            tests/test_agentic_sandbox_security.py::test_outer_seccomp_allows_inner_filter_and_blocks_raw_signal_syscalls \
             -m integration -q
 
       - name: Assert terminal cleanup

--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -46,16 +46,77 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
+  inspect-mode:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      uses_agentic: ${{ steps.mode.outputs.uses_agentic }}
+    steps:
+      - name: Checkout config only
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Inspect execution mode without credentials
+        id: mode
+        env:
+          EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
+        run: |
+          ruby <<'RUBY'
+          require 'yaml'
+
+          name = ENV.fetch('EXPERIMENT_YAML')
+          abort('invalid experiment YAML name') unless name.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]*\z/)
+          path = File.join('batch-runner', 'experiments', "#{name}.yaml")
+          abort("experiment YAML not found: #{path}") unless File.file?(path)
+          config = YAML.safe_load(
+            File.read(path), permitted_classes: [], permitted_symbols: [], aliases: false
+          ) || {}
+          abort('experiment YAML root must be a mapping') unless config.is_a?(Hash)
+          execution = config.fetch('execution', {}) || {}
+          abort('execution must be a mapping') unless execution.is_a?(Hash)
+          sandbox = execution.fetch('sandbox', {}) || {}
+          abort('execution.sandbox must be a mapping') unless sandbox.is_a?(Hash)
+          uses_agentic = execution['mode'] == 'agentic_sandbox' || sandbox['hardened_substrate'] == true
+          File.open(ENV.fetch('GITHUB_OUTPUT'), 'a') do |output|
+            output.puts("uses_agentic=#{uses_agentic}")
+          end
+          RUBY
+
+  reject-agentic:
+    needs: inspect-mode
+    if: needs.inspect-mode.outputs.uses_agentic == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Reject agentic mode in general workflow
+        run: |
+          echo "FATAL: agentic and hardened baseline modes require the dedicated"
+          echo "signed control/compute workflow. No credentialed job was started."
+          exit 1
+
   batch-run:
+    needs: inspect-mode
+    if: needs.inspect-mode.outputs.uses_agentic != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 360    # max 6 hours
+    env:
+      EXPERIMENT_YAML_INPUT: ${{ inputs.experiment_yaml }}
+      EXPERIMENT_NAME_INPUT: ${{ inputs.experiment_name }}
+      RELAY_RUN_INPUT: ${{ inputs.relay_run }}
+      WALL_TIMEOUT_INPUT: ${{ inputs.wall_timeout }}
+      DRY_RUN_INPUT: ${{ inputs.dry_run }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -95,7 +156,7 @@ jobs:
       # ── Validation: Check YAML file exists ──
       - name: Validate experiment YAML exists
         run: |
-          YAML_FILE="batch-runner/experiments/${{ inputs.experiment_yaml }}.yaml"
+          YAML_FILE="batch-runner/experiments/${EXPERIMENT_YAML_INPUT}.yaml"
           if [ ! -f "$YAML_FILE" ]; then
             echo "❌ Error: $YAML_FILE not found"
             exit 1
@@ -105,75 +166,94 @@ jobs:
       # ── Extract experiment_name from YAML if not provided ──
       - name: Extract experiment name from YAML
         run: |
-          YAML_PATH="batch-runner/experiments/${{ inputs.experiment_yaml }}.yaml"
-          if [ -z "${{ inputs.experiment_name }}" ]; then
-            EXPERIMENT_NAME=$(python3 -c "import yaml,sys; cfg=yaml.safe_load(open(sys.argv[1])); n=cfg.get('experiment',{}).get('name',''); (print(n) if n else sys.exit('ERROR: experiment.name not found'))" "$YAML_PATH")
-          else
-            EXPERIMENT_NAME="${{ inputs.experiment_name }}"
-          fi
-          echo "experiment_name=$EXPERIMENT_NAME" >> $GITHUB_ENV
-          echo "📝 Experiment: $EXPERIMENT_NAME"
+          python3 <<'PY'
+          import os
+          import pathlib
+          import yaml
+
+          path = pathlib.Path("batch-runner/experiments") / (
+              os.environ["EXPERIMENT_YAML_INPUT"] + ".yaml"
+          )
+          supplied = os.environ.get("EXPERIMENT_NAME_INPUT", "")
+          config = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+          name = supplied or (config.get("experiment") or {}).get("name", "")
+          if (
+              not isinstance(name, str)
+              or not name.strip()
+              or len(name) > 200
+              or any(ord(character) < 32 for character in name)
+          ):
+              raise SystemExit("ERROR: experiment name is invalid")
+          name = name.strip()
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as output:
+              output.write(f"experiment_name={name}\n")
+          print(f"Experiment: {name}")
+          PY
 
       # ── Conditional: LibreOffice + Noto Sans fonts ──
       - name: Read experiment config flags
         id: read_config
         run: |
-          YAML_FILE="batch-runner/experiments/${{ inputs.experiment_yaml }}.yaml"
-          INSTALL_LO=$(python3 -c "
+          python3 <<'PY'
+          import os
+          import pathlib
+          import re
           import yaml
-          with open('$YAML_FILE') as f:
-              cfg = yaml.safe_load(f)
-          print(cfg.get('execution', {}).get('install_libreoffice', False))
-          ")
-          WALL_TIMEOUT=$(python3 -c "
-          import yaml
-          with open('$YAML_FILE') as f:
-              cfg = yaml.safe_load(f)
-          print(cfg.get('execution', {}).get('wall_timeout', 0))
-          ")
-          RELAY_MAX_RUNS=$(python3 -c "
-          import yaml
-          with open('$YAML_FILE') as f:
-              cfg = yaml.safe_load(f)
-          print(cfg.get('execution', {}).get('relay_max_runs', 3))
-          ")
-          # Extract repo owner and data source for dynamic HF repo handling
-          REPO_SOURCE=$(python3 -c "
-          import yaml
-          with open('$YAML_FILE') as f:
-              cfg = yaml.safe_load(f)
-          source = cfg.get('data', {}).get('source', 'HyeonSang/${{ inputs.experiment_yaml }}')
-          print(source)
-          ")
-          REPO_OWNER=$(python3 -c "
-          source = '$REPO_SOURCE'
-          owner = source.split('/')[0] if '/' in source else 'HyeonSang'
-          print(owner)
-          ")
-          # ── Sandbox mode detection (safe defaults; never exit/raise) ──
-          # These gate the GHCR image pull. Baselines have no execution.mode:
-          # sandbox, so uses_sandbox stays 'false' and the pull step is skipped
-          # entirely (strict NO-OP for non-sandbox experiments).
-          USES_SANDBOX=$(python3 -c "
-          import yaml
-          with open('$YAML_FILE') as f:
-              cfg = yaml.safe_load(f)
-          mode = cfg.get('execution', {}).get('mode')
-          print('true' if mode == 'sandbox' else 'false')
-          ")
-          SANDBOX_IMAGE=$(python3 -c "
-          import yaml
-          with open('$YAML_FILE') as f:
-              cfg = yaml.safe_load(f)
-          image = cfg.get('execution', {}).get('sandbox', {}).get('image') or 'gdpval-sandbox:latest'
-          print(image)
-          ")
-          echo "install_libreoffice=$INSTALL_LO" >> $GITHUB_OUTPUT
-          echo "wall_timeout=$WALL_TIMEOUT" >> $GITHUB_OUTPUT
-          echo "relay_max_runs=$RELAY_MAX_RUNS" >> $GITHUB_OUTPUT
-          echo "repo_owner=$REPO_OWNER" >> $GITHUB_OUTPUT
-          echo "uses_sandbox=$USES_SANDBOX" >> $GITHUB_OUTPUT
-          echo "sandbox_image=$SANDBOX_IMAGE" >> $GITHUB_OUTPUT
+
+          path = pathlib.Path("batch-runner/experiments") / (
+            os.environ["EXPERIMENT_YAML_INPUT"] + ".yaml"
+          )
+          config = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+          execution = config.get("execution") or {}
+          sandbox = execution.get("sandbox") or {}
+          if not isinstance(execution, dict) or not isinstance(sandbox, dict):
+            raise SystemExit("execution and execution.sandbox must be mappings")
+          source = (config.get("data") or {}).get(
+            "source", f"HyeonSang/{os.environ['EXPERIMENT_YAML_INPUT']}"
+          )
+          owner = source.split("/", 1)[0] if isinstance(source, str) else ""
+          if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,99}", owner):
+            raise SystemExit("data source owner is invalid")
+          image = sandbox.get("image") or "gdpval-sandbox:latest"
+          if not isinstance(image, str) or not re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9._/@:-]{0,299}", image
+          ):
+            raise SystemExit("sandbox image reference is invalid")
+          wall_timeout = execution.get("wall_timeout", 0)
+          relay_max_runs = execution.get("relay_max_runs", 3)
+          if type(wall_timeout) is not int or not 0 <= wall_timeout <= 350:
+            raise SystemExit("execution.wall_timeout is invalid")
+          if type(relay_max_runs) is not int or not 0 <= relay_max_runs <= 10:
+            raise SystemExit("execution.relay_max_runs is invalid")
+          mode = execution.get("mode")
+          hardened = sandbox.get("hardened_substrate") is True
+          values = {
+            "install_libreoffice": str(
+              execution.get("install_libreoffice") is True
+            ),
+            "wall_timeout": str(wall_timeout),
+            "relay_max_runs": str(relay_max_runs),
+            "repo_owner": owner,
+            "uses_sandbox": str(mode == "sandbox").lower(),
+            "sandbox_image": image,
+            "uses_agentic": str(
+              mode == 'agentic_sandbox' or hardened
+            ).lower(),
+          }
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+            for key, value in values.items():
+              output.write(f"{key}={value}\n")
+          PY
+
+      - name: 'Block agentic modes in credentialed general workflow'
+        if: steps.read_config.outputs.uses_agentic == 'true'
+        run: |
+          echo "FATAL: agentic_sandbox and its hardened paired baseline are not"
+          echo "authorized in batch-run.yml. This workflow co-locates Docker,"
+          echo "Azure/HF credentials, relay, narrative, and upload permissions."
+          echo "Use the dedicated signed compute/control workflow only after the"
+          echo "paid gate is merged. No model client or cloud credential was used."
+          exit 1
 
       - name: Install LibreOffice & Noto Sans fonts
         if: steps.read_config.outputs.install_libreoffice == 'True'
@@ -215,14 +295,15 @@ jobs:
         if: inputs.relay_run > 0
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          REPO_OWNER: ${{ steps.read_config.outputs.repo_owner }}
         run: |
           cd batch-runner
-          echo "Relay run #${{ inputs.relay_run }}: Restoring checkpoint..."
+          echo "Relay run #${RELAY_RUN_INPUT}: Restoring checkpoint..."
           python3 -c "
           import shutil, os
           from huggingface_hub import hf_hub_download, snapshot_download
 
-          repo_id = '${{ steps.read_config.outputs.repo_owner }}/${{ inputs.experiment_yaml }}'
+          repo_id = os.environ['REPO_OWNER'] + '/' + os.environ['EXPERIMENT_YAML_INPUT']
           try:
               # Download progress.json
               progress_path = hf_hub_download(
@@ -258,13 +339,13 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           cd batch-runner
-          bash step0_bootstrap.sh experiments/${{ inputs.experiment_yaml }}.yaml
+          bash step0_bootstrap.sh "experiments/${EXPERIMENT_YAML_INPUT}.yaml"
 
       # ── Step 1: Prepare Tasks ──
       - name: 'Step 1: Prepare tasks'
         run: |
           cd batch-runner
-          bash step1_prepare_tasks.sh experiments/${{ inputs.experiment_yaml }}.yaml
+          bash step1_prepare_tasks.sh "experiments/${EXPERIMENT_YAML_INPUT}.yaml"
 
       # ── Sandbox: pull the prebuilt image from GHCR & verify (sandbox mode only) ──
       # Runs ONLY for execution.mode: sandbox experiments; baselines skip it
@@ -328,7 +409,7 @@ jobs:
 
       # ── Step 2a: Run Inference (condition_a) ──
       - name: 'Azure Login (OIDC)'
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -346,7 +427,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           cd batch-runner
-          WALL_TIMEOUT="${{ inputs.wall_timeout }}"
+          WALL_TIMEOUT="$WALL_TIMEOUT_INPUT"
           if [ "$WALL_TIMEOUT" = "0" ] && [ "${{ steps.read_config.outputs.wall_timeout }}" -gt 0 ] 2>/dev/null; then
             WALL_TIMEOUT="${{ steps.read_config.outputs.wall_timeout }}"
           fi
@@ -387,6 +468,7 @@ jobs:
         if: steps.check_relay.outputs.needs_relay == 'true'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          REPO_OWNER: ${{ steps.read_config.outputs.repo_owner }}
         run: |
           cd batch-runner
           python3 -c "
@@ -394,7 +476,7 @@ jobs:
           from huggingface_hub import HfApi
 
           api = HfApi(token=os.environ['HF_TOKEN'])
-          repo_id = '${{ steps.read_config.outputs.repo_owner }}/${{ inputs.experiment_yaml }}'
+          repo_id = os.environ['REPO_OWNER'] + '/' + os.environ['EXPERIMENT_YAML_INPUT']
 
           # Upload progress.json
           api.upload_file(
@@ -430,7 +512,7 @@ jobs:
           # exact same immutable image.
           SANDBOX_IMAGE_DIGEST: ${{ steps.sandbox_pull.outputs.digest }}
         run: |
-          NEXT_RELAY=$(( ${{ inputs.relay_run }} + 1 ))
+          NEXT_RELAY=$(( RELAY_RUN_INPUT + 1 ))
           MAX_RELAYS="${{ steps.read_config.outputs.relay_max_runs }}"
 
           if [ $NEXT_RELAY -gt $MAX_RELAYS ]; then
@@ -440,10 +522,10 @@ jobs:
 
           echo "Triggering relay run #$NEXT_RELAY..."
           gh workflow run batch-run.yml \
-            -f experiment_yaml="${{ inputs.experiment_yaml }}" \
+            -f experiment_yaml="$EXPERIMENT_YAML_INPUT" \
             -f relay_run="$NEXT_RELAY" \
-            -f wall_timeout="${{ inputs.wall_timeout }}" \
-            -f dry_run="${{ inputs.dry_run }}" \
+            -f wall_timeout="$WALL_TIMEOUT_INPUT" \
+            -f dry_run="$DRY_RUN_INPUT" \
             -f sandbox_image_digest="$SANDBOX_IMAGE_DIGEST"
 
           echo "Relay run #$NEXT_RELAY triggered. This run will now exit."
@@ -453,7 +535,7 @@ jobs:
       - name: 'Check if condition_b exists'
         id: check_condition_b
         run: |
-          YAML_PATH="batch-runner/experiments/${{ inputs.experiment_yaml }}.yaml"
+          YAML_PATH="batch-runner/experiments/${EXPERIMENT_YAML_INPUT}.yaml"
           HAS_CONDITION_B=$(python3 -c "import yaml; cfg=yaml.safe_load(open('${YAML_PATH}')); print('true' if 'condition_b' in cfg else 'false')")
           echo "has_condition_b=$HAS_CONDITION_B" >> $GITHUB_OUTPUT
           echo "Condition B exists: $HAS_CONDITION_B"
@@ -488,7 +570,7 @@ jobs:
       - name: 'Check if smoke test'
         id: check_smoke_test
         run: |
-          YAML_PATH="batch-runner/experiments/${{ inputs.experiment_yaml }}.yaml"
+          YAML_PATH="batch-runner/experiments/${EXPERIMENT_YAML_INPUT}.yaml"
           SAMPLE_SIZE=$(python3 -c "import yaml; cfg=yaml.safe_load(open('${YAML_PATH}')); s=cfg.get('data',{}).get('filter',{}).get('sample_size',220); print(s if s is not None else 220)")
           IS_SMOKE_TEST=$([ "$SAMPLE_SIZE" -le 3 ] && echo "true" || echo "false")
           echo "sample_size=$SAMPLE_SIZE" >> $GITHUB_OUTPUT
@@ -525,7 +607,7 @@ jobs:
       # ── Create Pull Request (only if not dry_run and not relay) ──
       - name: Create Pull Request with results
         if: inputs.dry_run != true && steps.check_relay.outputs.needs_relay != 'true' && steps.step2a.outcome == 'success'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "experiment: ${{ env.experiment_name }}"
@@ -560,6 +642,7 @@ jobs:
         if: inputs.relay_run > 0 && steps.check_relay.outputs.needs_relay != 'true'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          REPO_OWNER: ${{ steps.read_config.outputs.repo_owner }}
         continue-on-error: true
         run: |
           python3 -c "
@@ -567,7 +650,7 @@ jobs:
           from huggingface_hub import HfApi
 
           api = HfApi(token=os.environ['HF_TOKEN'])
-          repo_id = '${{ steps.read_config.outputs.repo_owner }}/${{ inputs.experiment_yaml }}'
+          repo_id = os.environ['REPO_OWNER'] + '/' + os.environ['EXPERIMENT_YAML_INPUT']
 
           try:
               # Delete progress checkpoint
@@ -594,15 +677,15 @@ jobs:
           echo "📊 Batch Experiment Complete"
           echo "════════════════════════════════════════"
           echo "Experiment: ${{ env.experiment_name }}"
-          echo "YAML Config: ${{ inputs.experiment_yaml }}"
-          echo "Dry Run: ${{ inputs.dry_run }}"
+          echo "YAML Config: $EXPERIMENT_YAML_INPUT"
+          echo "Dry Run: $DRY_RUN_INPUT"
           echo ""
           echo "Check artifacts for full pipeline output."
 
       # ── Upload artifacts ──
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: batch-results-${{ github.run_id }}
           path: |

--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -21,6 +21,12 @@ name: Build Sandbox Image
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_agentic:
+        description: Publish agentic image after immutable locks are reviewed
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: build-sandbox-image
@@ -34,14 +40,24 @@ permissions:
 
 jobs:
   build-sandbox-image:
+    if: github.ref == 'refs/heads/main' && github.ref_protected == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Verify protected main checkout
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_REF_PROTECTED" = "true"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - name: Require immutable dependency locks before publication
+        if: ${{ inputs.publish_agentic == true }}
         run: |
           python3 <<'PY'
           import pathlib
@@ -68,6 +84,42 @@ jobs:
           )
           if not apt_lock.is_file():
             violations.append(str(apt_lock))
+          else:
+            packages = [
+              line.strip()
+              for line in apt_lock.read_text(encoding="utf-8").splitlines()
+              if line.strip() and not line.lstrip().startswith("#")
+            ]
+            if len(packages) < 100:
+              violations.append(
+                "debian-packages.lock must contain the full installed inventory"
+              )
+            names = []
+            for package in packages:
+              if (
+                "=" not in package
+                or any(character.isspace() for character in package)
+              ):
+                violations.append(
+                  f"invalid Debian package lock entry: {package}"
+                )
+                continue
+              names.append(package.split("=", 1)[0])
+            if len(names) != len(set(names)):
+              violations.append("debian-packages.lock contains duplicate packages")
+          dockerfiles = [
+            pathlib.Path("batch-runner/sandbox/Dockerfile"),
+            pathlib.Path("batch-runner/sandbox/agentic.Dockerfile"),
+          ]
+          docker_text = "\n".join(
+            path.read_text(encoding="utf-8") for path in dockerfiles
+          )
+          if "GDPVAL_LOCKED_DEBIAN_PACKAGES" not in docker_text:
+            violations.append(
+              "Dockerfiles do not consume GDPVAL_LOCKED_DEBIAN_PACKAGES"
+            )
+          if "pip install --upgrade" in docker_text:
+            violations.append("Dockerfiles contain an unpinned pip bootstrap")
           if violations:
             raise SystemExit(
               "production image publication requires exact pip hashes and "
@@ -104,6 +156,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-sandbox:buildcache,mode=max
 
       - name: Build agentic sandbox audit candidate
+        if: ${{ inputs.publish_agentic == true }}
         id: agentic_candidate
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
@@ -121,6 +174,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox:buildcache
 
       - name: Audit agentic sandbox candidate before publication
+        if: ${{ inputs.publish_agentic == true }}
         id: candidate_audit
         env:
           IMAGE: gdpval-agentic-sandbox:audit-${{ github.run_id }}
@@ -137,6 +191,7 @@ jobs:
           echo "sbom_sha256=$RUNTIME_SBOM_SHA256" >> "$GITHUB_OUTPUT"
 
       - name: Build and push audited agentic sandbox image
+        if: ${{ inputs.publish_agentic == true }}
         id: agentic_build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
@@ -156,6 +211,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox:buildcache,mode=max
 
       - name: Verify published agentic digest and attestations
+        if: ${{ inputs.publish_agentic == true }}
         id: published_audit
         env:
           IMAGE: ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox@${{ steps.agentic_build.outputs.digest }}
@@ -215,6 +271,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Promote verified agentic digest to latest
+        if: ${{ inputs.publish_agentic == true }}
         env:
           IMAGE: ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox@${{ steps.agentic_build.outputs.digest }}
         run: |

--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -21,12 +21,6 @@ name: Build Sandbox Image
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - batch-runner/requirements.txt
-      - batch-runner/sandbox/Dockerfile
-      - 'batch-runner/skills/**'
 
 concurrency:
   group: build-sandbox-image
@@ -43,20 +37,58 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Require immutable dependency locks before publication
+        run: |
+          python3 <<'PY'
+          import pathlib
+
+          requirements = [
+            pathlib.Path("batch-runner/requirements.txt"),
+            pathlib.Path("batch-runner/requirements-renderer.txt"),
+          ]
+          violations = []
+          for path in requirements:
+            logical = ""
+            for raw in path.read_text(encoding="utf-8").splitlines():
+              line = raw.split("#", 1)[0].strip()
+              if not line or line.startswith("-r "):
+                continue
+              logical = f"{logical} {line}".strip()
+              if line.endswith("\\"):
+                continue
+              if "==" not in logical or "--hash=sha256:" not in logical:
+                violations.append(f"{path}:{logical}")
+              logical = ""
+          apt_lock = pathlib.Path(
+            "batch-runner/sandbox/debian-packages.lock"
+          )
+          if not apt_lock.is_file():
+            violations.append(str(apt_lock))
+          if violations:
+            raise SystemExit(
+              "production image publication requires exact pip hashes and "
+              "a reviewed Debian package lock:\n" + "\n".join(violations[:20])
+            )
+          print("immutable-dependency-locks=pass")
+          PY
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push sandbox image
-        uses: docker/build-push-action@v6
+        id: base_build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: batch-runner
           file: batch-runner/sandbox/Dockerfile
@@ -70,3 +102,123 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-sandbox:buildcache
           cache-to: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-sandbox:buildcache,mode=max
+
+      - name: Build agentic sandbox audit candidate
+        id: agentic_candidate
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: batch-runner
+          file: batch-runner/sandbox/agentic.Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          build-args: |
+            BASE_IMAGE=ghcr.io/hyeonsangjeon/gdpval-sandbox@${{ steps.base_build.outputs.digest }}
+          tags: gdpval-agentic-sandbox:audit-${{ github.run_id }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.base.name=ghcr.io/hyeonsangjeon/gdpval-sandbox@${{ steps.base_build.outputs.digest }}
+          cache-from: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox:buildcache
+
+      - name: Audit agentic sandbox candidate before publication
+        id: candidate_audit
+        env:
+          IMAGE: gdpval-agentic-sandbox:audit-${{ github.run_id }}
+          EXPECTED_BASE: ghcr.io/hyeonsangjeon/gdpval-sandbox@${{ steps.base_build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          ACTUAL_BASE=$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.base.name" }}' "$IMAGE")
+          test "$ACTUAL_BASE" = "$EXPECTED_BASE"
+          docker run --rm --entrypoint python "$IMAGE" \
+            -I -B /opt/gdpval/agentic_image_audit.py
+          docker run --rm --entrypoint cat "$IMAGE" \
+            /opt/gdpval/agentic-sbom.spdx.json > candidate-runtime-sbom.spdx.json
+          RUNTIME_SBOM_SHA256=$(sha256sum candidate-runtime-sbom.spdx.json | cut -d' ' -f1)
+          echo "sbom_sha256=$RUNTIME_SBOM_SHA256" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push audited agentic sandbox image
+        id: agentic_build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: batch-runner
+          file: batch-runner/sandbox/agentic.Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            BASE_IMAGE=ghcr.io/hyeonsangjeon/gdpval-sandbox@${{ steps.base_build.outputs.digest }}
+          tags: ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.base.name=ghcr.io/hyeonsangjeon/gdpval-sandbox@${{ steps.base_build.outputs.digest }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox:buildcache
+          cache-to: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox:buildcache,mode=max
+
+      - name: Verify published agentic digest and attestations
+        id: published_audit
+        env:
+          IMAGE: ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox@${{ steps.agentic_build.outputs.digest }}
+          EXPECTED_BASE: ghcr.io/hyeonsangjeon/gdpval-sandbox@${{ steps.base_build.outputs.digest }}
+          EXPECTED_SBOM_SHA256: ${{ steps.candidate_audit.outputs.sbom_sha256 }}
+        run: |
+          set -euo pipefail
+          docker pull "$IMAGE"
+          ACTUAL_BASE=$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.base.name" }}' "$IMAGE")
+          ACTUAL_REVISION=$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$IMAGE")
+          test "$ACTUAL_BASE" = "$EXPECTED_BASE"
+          test "$ACTUAL_REVISION" = "$GITHUB_SHA"
+          docker run --rm --entrypoint python "$IMAGE" \
+            -I -B /opt/gdpval/agentic_image_audit.py
+          docker run --rm --entrypoint cat "$IMAGE" \
+            /opt/gdpval/agentic-sbom.spdx.json > runtime-sbom.spdx.json
+          RUNTIME_SBOM_SHA256=$(sha256sum runtime-sbom.spdx.json | cut -d' ' -f1)
+          test "$RUNTIME_SBOM_SHA256" = "$EXPECTED_SBOM_SHA256"
+          docker buildx imagetools inspect "$IMAGE" \
+            --format '{{json .SBOM}}' > attached-sbom.json
+          test -s attached-sbom.json
+          python3 - <<'PY'
+          import json
+
+          runtime = json.load(open("runtime-sbom.spdx.json", encoding="utf-8"))
+          attached = json.load(open("attached-sbom.json", encoding="utf-8"))
+          assert runtime["spdxVersion"] == "SPDX-2.3"
+
+          def strings(value):
+            if isinstance(value, str):
+              yield value
+            elif isinstance(value, dict):
+              for item in value.values():
+                yield from strings(item)
+            elif isinstance(value, list):
+              for item in value:
+                yield from strings(item)
+
+          runtime_purls = {
+            reference["referenceLocator"]
+            for package in runtime["packages"]
+            for reference in package.get("externalRefs", [])
+            if reference.get("referenceType") == "purl"
+          }
+          attached_purls = {value for value in strings(attached) if value.startswith("pkg:")}
+          missing = sorted(runtime_purls - attached_purls)
+          assert not missing, missing[:20]
+          PY
+          ATTACHED_SBOM_SHA256=$(sha256sum attached-sbom.json | cut -d' ' -f1)
+          echo "sbom_sha256=$RUNTIME_SBOM_SHA256" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Agentic image supply-chain audit"
+            echo "- Image: \`$IMAGE\`"
+            echo "- Base: \`$EXPECTED_BASE\`"
+            echo "- Runtime SBOM SHA-256: \`$RUNTIME_SBOM_SHA256\`"
+            echo "- Attached SBOM evidence SHA-256: \`$ATTACHED_SBOM_SHA256\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Promote verified agentic digest to latest
+        env:
+          IMAGE: ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox@${{ steps.agentic_build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag ghcr.io/hyeonsangjeon/gdpval-agentic-sandbox:latest \
+            "$IMAGE"

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ batch-runner/local_repo/
 batch-runner/scripts/*
 !batch-runner/scripts/preflight_grading_renderer.py
 !batch-runner/scripts/preflight_track2_cohort.py
+!batch-runner/scripts/build_agentic_input_manifest.py
+!batch-runner/scripts/compare_agentic_conditions.py
+!batch-runner/scripts/select_agentic_tasks.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,18 +48,25 @@ entries land under a fresh dated heading the day they merge to `main`.
   [29628757147](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29628757147);
   the deployed JSON, two-lane timeline, report-derived chart, source links, and
   reflective typography were verified on desktop and mobile.
-- **Agentic Sandbox implementation and experiment preregistration plan** — define a
-  separate `agentic_sandbox` task-solving mode that lets the model choose among
-  bounded workspace inspection, Python, ffmpeg, artifact inspection, and
-  deterministic finalization tools while the harness retains no-network,
-  non-root, path, resource, usage, and cost controls. The dated plan fixes the
-  security invariants, hard budgets, optional metrics, non-paid Docker test
-  gates, an outcome-free selector contract for future disjoint five-task and
-  twenty-task cohorts, fixed paired endpoint denominators, a paid approval
-  boundary, evidence/cost/incident ledgers, and retrospective template. Exact
-  task IDs and immutable source identities must still be generated and
-  committed at the paid gate. Runtime package installation, model-visible
-  shell, Anthropic support, and all live model runs remain explicitly deferred.
+- **Bounded Agentic Sandbox runtime and preregistered experiment** — implement
+  separate `agentic_sandbox` and common hardened-baseline paths with ordered
+  Responses tools, deterministic finalization, exact task/request/input and
+  selection identities, crash-safe SQLite budgets, Ed25519 single-use live
+  approval, fixed-denominator comparison endpoints, optional dashboard fields,
+  and legacy omission. Split credential and compute planes use mTLS plus
+  deadline-bound HMAC envelopes, bounded streaming JSON, exact sequence retry,
+  no-network/non-root Docker, quota-backed work volumes, an in-process generated-
+  code seccomp launcher, isolated rendering/verifier containers, component/SBOM
+  identity, and auditable terminal cleanup. Manual image and dedicated-runner
+  workflows require a protected exact `main` SHA; unfinished agentic publication
+  remains opt-in and fails closed until immutable dependency locks exist. Local
+  model-free validation passed 1,485 Python tests, 54 Node aggregate tests,
+  TypeScript/Vite build, two Chromium suites, image audit/SBOM equality, and WAV,
+  XLSX, DOCX, and PPTX Docker E2E. No model/API call, task selection, workflow
+  dispatch, image publication, HF upload, grading, or paid run occurred. Exact
+  5/20 cohorts, production locks/image identities, dedicated-host preflight, and
+  signed owner approval remain required at the paid gate; package installation,
+  model-visible shell, and Anthropic support remain deferred.
 - **Model-free Track 2 preflight workflow** — add a main-only, read-only manual
   workflow for private pinned cohorts. It validates compact JSON identities
   before checkout, checks out the exact event SHA with credentials disabled,

--- a/batch-runner/core/agentic_authorization.py
+++ b/batch-runner/core/agentic_authorization.py
@@ -1,0 +1,478 @@
+"""Signed, single-use authorization gate for live agentic model calls."""
+
+from __future__ import annotations
+
+import base64
+import fcntl
+import hashlib
+import json
+import re
+import sqlite3
+import stat
+import subprocess
+import threading
+from urllib.parse import urlsplit
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+
+REQUIRED_FIELDS = {
+    "schema_version", "plan_sha", "implementation_sha", "run_id",
+    "conditions", "task_ids", "input_merkle_roots", "provider_classifications",
+    "provider", "model", "api_version", "endpoint_sha256", "workflow_sha",
+    "workflow_inputs_sha256",
+    "substrate_manifest_sha256", "price_table_sha256", "caps", "issued_at",
+    "expires_at", "nonce", "official_scope_excluded",
+    "approval_scope_sha256", "official_scope_registry_sha256",
+}
+MAX_APPROVAL_LIFETIME_SECONDS = 8 * 60 * 60
+
+
+class AuthorizationError(PermissionError):
+    pass
+
+
+@dataclass(frozen=True)
+class ApprovalExpectation:
+    plan_sha: str
+    implementation_sha: str
+    run_id: str
+    condition: str
+    provider: str
+    model: str
+    api_version: str
+    endpoint_sha256: str
+    workflow_sha: str
+    workflow_inputs_sha256: str
+    conditions: tuple[str, ...]
+    task_ids: tuple[str, ...]
+    input_merkle_roots: Mapping[str, str]
+    provider_classifications: Mapping[str, str]
+    approval_scope_sha256: str
+    official_scope_registry_sha256: str
+
+
+def load_approval_scope(
+    *, repository_root: str | Path, scope_path: str | Path
+) -> dict[str, Any]:
+    root = Path(repository_root).resolve()
+    candidate = Path(scope_path)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    candidate = candidate.absolute()
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("approval scope path escapes repository") from exc
+    current = root
+    for part in relative.parts:
+        current /= part
+        metadata = current.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError("approval scope path contains a symlink")
+    metadata = candidate.lstat()
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        raise ValueError("approval scope must be a single-link regular file")
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", relative.as_posix()],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if tracked.returncode != 0:
+        raise ValueError("approval scope must be tracked in the clean checkout")
+    document = json.loads(candidate.read_text(encoding="utf-8"))
+    required = {
+        "schema_version", "conditions", "ordered_task_ids",
+        "input_merkle_roots", "provider_classifications", "sha256",
+    }
+    if not isinstance(document, dict) or set(document) != required:
+        raise ValueError("approval scope fields are invalid")
+    canonical = {key: value for key, value in document.items() if key != "sha256"}
+    digest = hashlib.sha256(canonical_json(canonical)).hexdigest()
+    if document["schema_version"] != "agentic-approval-scope-v1":
+        raise ValueError("approval scope version is invalid")
+    if document["sha256"] != digest:
+        raise ValueError("approval scope hash mismatch")
+    conditions = document["conditions"]
+    task_ids = document["ordered_task_ids"]
+    roots = document["input_merkle_roots"]
+    classifications = document["provider_classifications"]
+    if (
+        not isinstance(conditions, list)
+        or not conditions
+        or len(conditions) != len(set(conditions))
+        or any(not isinstance(value, str) or not value for value in conditions)
+        or not isinstance(task_ids, list)
+        or not task_ids
+        or len(task_ids) > 25
+        or len(task_ids) != len(set(task_ids))
+        or any(not isinstance(value, str) or not value for value in task_ids)
+        or not isinstance(roots, dict)
+        or set(roots) != set(task_ids)
+        or any(
+            not isinstance(value, str)
+            or re.fullmatch(r"[0-9a-f]{64}", value) is None
+            for value in roots.values()
+        )
+        or not isinstance(classifications, dict)
+        or set(classifications) != set(task_ids)
+        or any(
+            not isinstance(value, str) or not value
+            for value in classifications.values()
+        )
+    ):
+        raise ValueError("approval scope identities are invalid")
+    registry = root / "src" / "lib" / "officialExperimentScope.js"
+    if not registry.is_file() or registry.is_symlink():
+        raise ValueError("official scope registry is missing or symlinked")
+    return {
+        "conditions": tuple(conditions),
+        "task_ids": tuple(task_ids),
+        "input_merkle_roots": dict(roots),
+        "provider_classifications": dict(classifications),
+        "approval_scope_sha256": digest,
+        "official_scope_registry_sha256": hashlib.sha256(
+            registry.read_bytes()
+        ).hexdigest(),
+    }
+
+
+class ApprovalNonceLedger:
+    """Atomically consume approval nonces across processes and restarts."""
+
+    def __init__(self, path: str | Path):
+        self.path = str(path)
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        with open(f"{self.path}.init.lock", "a", encoding="utf-8") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            with self._connect() as connection:
+                connection.execute("PRAGMA journal_mode=WAL")
+                connection.execute(
+                    """
+                CREATE TABLE IF NOT EXISTS approval_nonces (
+                    nonce TEXT PRIMARY KEY,
+                    envelope_sha256 TEXT NOT NULL,
+                    run_id TEXT NOT NULL,
+                    consumed_at TEXT NOT NULL
+                )
+                    """
+                )
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=30, isolation_level=None)
+        connection.execute("PRAGMA busy_timeout=30000")
+        connection.execute("PRAGMA synchronous=FULL")
+        return connection
+
+    def consume(self, *, nonce: str, envelope_sha256: str, run_id: str) -> None:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                """
+                INSERT INTO approval_nonces(nonce, envelope_sha256, run_id, consumed_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (nonce, envelope_sha256, run_id, datetime.now(timezone.utc).isoformat()),
+            )
+            connection.commit()
+        except sqlite3.IntegrityError as exc:
+            connection.rollback()
+            raise AuthorizationError("approval_nonce_already_consumed") from exc
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+
+class SignedApprovalGate:
+    """Verify immutable approval scope before a client can be constructed."""
+
+    def __init__(
+        self,
+        *,
+        signed_envelope_path: str | Path,
+        owner_public_key_path: str | Path,
+        nonce_ledger: ApprovalNonceLedger,
+        expectation: ApprovalExpectation,
+        now: Optional[datetime] = None,
+    ):
+        self.signed_envelope_path = Path(signed_envelope_path)
+        self.owner_public_key_path = Path(owner_public_key_path)
+        self.nonce_ledger = nonce_ledger
+        self.expectation = expectation
+        self.now = now
+        self._lock = threading.Lock()
+        self._active_digest: Optional[str] = None
+        self._envelope: Optional[dict] = None
+
+    def authorize_request(
+        self,
+        scope: str,
+        request_id: str,
+        runtime_context: Mapping[str, Any],
+    ) -> None:
+        if not scope or not request_id:
+            raise AuthorizationError("authorization_identity_missing")
+        expected_scope = json.dumps(
+            [
+                self.expectation.run_id,
+                self.expectation.condition,
+                runtime_context.get("task_id"),
+            ],
+            separators=(",", ":"),
+        )
+        if scope != expected_scope:
+            raise AuthorizationError("authorization_scope_mismatch")
+        if re.fullmatch(r"[0-9a-f]{64}", request_id) is None:
+            raise AuthorizationError("authorization_request_id_invalid")
+        with self._lock:
+            envelope, digest = self._load_and_verify(runtime_context)
+            if self._active_digest is not None:
+                if digest != self._active_digest:
+                    raise AuthorizationError("approval_changed_after_claim")
+                return
+            self.nonce_ledger.consume(
+                nonce=envelope["nonce"],
+                envelope_sha256=digest,
+                run_id=envelope["run_id"],
+            )
+            self._active_digest = digest
+            self._envelope = envelope
+
+    def _load_and_verify(self, runtime_context: Mapping[str, Any]) -> tuple[dict, str]:
+        try:
+            signed = json.loads(self.signed_envelope_path.read_text(encoding="utf-8"))
+            envelope = signed["envelope"]
+            signature = base64.b64decode(signed["signature"], validate=True)
+        except Exception as exc:
+            raise AuthorizationError("approval_envelope_invalid") from exc
+        if not isinstance(envelope, dict) or set(envelope) != REQUIRED_FIELDS:
+            raise AuthorizationError("approval_fields_invalid")
+        self._validate_structure(envelope)
+        canonical = canonical_json(envelope)
+        digest = hashlib.sha256(canonical).hexdigest()
+        try:
+            public_key = serialization.load_pem_public_key(
+                self.owner_public_key_path.read_bytes()
+            )
+        except Exception as exc:
+            raise AuthorizationError("approval_public_key_invalid") from exc
+        if not isinstance(public_key, Ed25519PublicKey):
+            raise AuthorizationError("approval_public_key_type_invalid")
+        try:
+            public_key.verify(signature, canonical)
+        except InvalidSignature as exc:
+            raise AuthorizationError("approval_signature_invalid") from exc
+
+        self._validate_time(envelope)
+        self._validate_expectation(envelope, runtime_context)
+        return envelope, digest
+
+    @staticmethod
+    def _validate_structure(envelope: Mapping[str, Any]) -> None:
+        if envelope.get("schema_version") != "1.0":
+            raise AuthorizationError("approval_schema_version_invalid")
+        conditions = envelope.get("conditions")
+        task_ids = envelope.get("task_ids")
+        roots = envelope.get("input_merkle_roots")
+        classifications = envelope.get("provider_classifications")
+        if (
+            not isinstance(conditions, list)
+            or not conditions
+            or len(conditions) > 3
+            or len(set(conditions)) != len(conditions)
+            or any(not isinstance(value, str) or not value for value in conditions)
+        ):
+            raise AuthorizationError("approval_conditions_invalid")
+        if (
+            not isinstance(task_ids, list)
+            or not task_ids
+            or len(task_ids) > 25
+            or len(set(task_ids)) != len(task_ids)
+            or any(not isinstance(value, str) or not value for value in task_ids)
+        ):
+            raise AuthorizationError("approval_tasks_invalid")
+        if not isinstance(roots, dict) or set(roots) != set(task_ids):
+            raise AuthorizationError("approval_input_roots_invalid")
+        if any(
+            not isinstance(value, str)
+            or re.fullmatch(r"[0-9a-f]{64}", value) is None
+            for value in roots.values()
+        ):
+            raise AuthorizationError("approval_input_roots_invalid")
+        if (
+            not isinstance(classifications, dict)
+            or set(classifications) != set(task_ids)
+            or any(
+                not isinstance(value, str) or not value
+                for value in classifications.values()
+            )
+        ):
+            raise AuthorizationError("approval_classifications_invalid")
+        nonce = envelope.get("nonce")
+        if (
+            not isinstance(nonce, str)
+            or len(nonce) < 32
+            or len(nonce) > 256
+        ):
+            raise AuthorizationError("approval_nonce_invalid")
+
+    def _validate_time(self, envelope: Mapping[str, Any]) -> None:
+        try:
+            issued = _timestamp(envelope["issued_at"])
+            expires = _timestamp(envelope["expires_at"])
+        except Exception as exc:
+            raise AuthorizationError("approval_time_invalid") from exc
+        now = self.now or datetime.now(timezone.utc)
+        lifetime = (expires - issued).total_seconds()
+        if (
+            issued > now
+            or expires <= now
+            or expires <= issued
+            or lifetime > MAX_APPROVAL_LIFETIME_SECONDS
+        ):
+            raise AuthorizationError("approval_expired_or_not_yet_valid")
+
+    def _validate_expectation(
+        self,
+        envelope: Mapping[str, Any],
+        runtime_context: Mapping[str, Any],
+    ) -> None:
+        expected = self.expectation
+        scalar_fields = {
+            "plan_sha": expected.plan_sha,
+            "implementation_sha": expected.implementation_sha,
+            "run_id": expected.run_id,
+            "provider": expected.provider,
+            "model": expected.model,
+            "api_version": expected.api_version,
+            "endpoint_sha256": expected.endpoint_sha256,
+            "workflow_sha": expected.workflow_sha,
+            "workflow_inputs_sha256": expected.workflow_inputs_sha256,
+        }
+        if any(envelope.get(key) != value for key, value in scalar_fields.items()):
+            raise AuthorizationError("approval_identity_mismatch")
+        if envelope.get("conditions") != list(expected.conditions):
+            raise AuthorizationError("approval_condition_mismatch")
+        if envelope.get("task_ids") != list(expected.task_ids):
+            raise AuthorizationError("approval_task_set_mismatch")
+        if envelope.get("input_merkle_roots") != dict(
+            expected.input_merkle_roots
+        ):
+            raise AuthorizationError("approval_input_set_mismatch")
+        if envelope.get("provider_classifications") != dict(
+            expected.provider_classifications
+        ):
+            raise AuthorizationError("approval_classification_set_mismatch")
+        if envelope.get("approval_scope_sha256") != expected.approval_scope_sha256:
+            raise AuthorizationError("approval_scope_identity_mismatch")
+        if (
+            envelope.get("official_scope_registry_sha256")
+            != expected.official_scope_registry_sha256
+        ):
+            raise AuthorizationError("official_scope_registry_mismatch")
+        task_id = runtime_context.get("task_id")
+        if not isinstance(task_id, str) or task_id not in expected.task_ids:
+            raise AuthorizationError("approval_task_mismatch")
+        input_merkle_root = expected.input_merkle_roots[task_id]
+        provider_classification = expected.provider_classifications[task_id]
+        if runtime_context.get("input_merkle_root") != input_merkle_root:
+            raise AuthorizationError("runtime_input_identity_mismatch")
+        if runtime_context.get("provider_classification") != provider_classification:
+            raise AuthorizationError("runtime_classification_mismatch")
+        runtime_scalars = {
+            "run_id": expected.run_id,
+            "condition": expected.condition,
+            "model": expected.model,
+            "provider": expected.provider,
+            "api_version": expected.api_version,
+            "endpoint_sha256": expected.endpoint_sha256,
+            "approval_scope_sha256": expected.approval_scope_sha256,
+            "official_scope_registry_sha256": (
+                expected.official_scope_registry_sha256
+            ),
+        }
+        if any(runtime_context.get(key) != value for key, value in runtime_scalars.items()):
+            raise AuthorizationError("runtime_scope_mismatch")
+        if runtime_context.get("runtime_preflight_passed") is not True:
+            raise AuthorizationError("runtime_preflight_missing")
+        if (
+            envelope.get("official_scope_excluded") is not True
+            or runtime_context.get("official_scope_excluded") is not True
+        ):
+            raise AuthorizationError("official_scope_exclusion_missing")
+        for field in (
+            "substrate_manifest_sha256", "price_table_sha256"
+        ):
+            value = runtime_context.get(field)
+            if (
+                not isinstance(value, str)
+                or not value
+                or envelope.get(field) != value
+            ):
+                raise AuthorizationError(f"approval_{field}_mismatch")
+        caps = envelope.get("caps")
+        runtime_caps = runtime_context.get("caps")
+        if (
+            not isinstance(caps, dict)
+            or not caps
+            or not isinstance(runtime_caps, dict)
+            or canonical_json(caps) != canonical_json(runtime_caps)
+        ):
+            raise AuthorizationError("approval_caps_invalid")
+
+
+def canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        dict(value), sort_keys=True, separators=(",", ":"),
+        ensure_ascii=True, allow_nan=False,
+    ).encode("utf-8")
+
+
+def provider_endpoint_sha256(provider: str, endpoint: Optional[str]) -> str:
+    normalized_provider = "azure" if provider == "azure_openai" else provider
+    if normalized_provider == "openai" and not endpoint:
+        endpoint = "https://api.openai.com/v1"
+    if normalized_provider not in {"azure", "openai"} or not isinstance(
+        endpoint, str
+    ):
+        raise ValueError("provider endpoint is required")
+    parsed = urlsplit(endpoint.strip())
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("provider endpoint must be an HTTPS origin")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("provider endpoint port is invalid") from exc
+    host = parsed.hostname.encode("idna").decode("ascii").lower()
+    origin = f"https://{host}"
+    if port not in (None, 443):
+        origin += f":{port}"
+    return hashlib.sha256(origin.encode("ascii")).hexdigest()
+
+
+def _timestamp(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("timestamp must be a string")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include timezone")
+    return parsed.astimezone(timezone.utc)

--- a/batch-runner/core/agentic_authorization.py
+++ b/batch-runner/core/agentic_authorization.py
@@ -25,6 +25,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 REQUIRED_FIELDS = {
     "schema_version", "plan_sha", "implementation_sha", "run_id",
     "conditions", "task_ids", "input_merkle_roots", "provider_classifications",
+    "task_request_sha256", "selection_recomputation_sha256",
     "provider", "model", "api_version", "endpoint_sha256", "workflow_sha",
     "workflow_inputs_sha256",
     "substrate_manifest_sha256", "price_table_sha256", "caps", "issued_at",
@@ -54,6 +55,8 @@ class ApprovalExpectation:
     task_ids: tuple[str, ...]
     input_merkle_roots: Mapping[str, str]
     provider_classifications: Mapping[str, str]
+    task_request_sha256: Mapping[str, str]
+    selection_recomputation_sha256: str
     approval_scope_sha256: str
     official_scope_registry_sha256: str
 
@@ -91,7 +94,8 @@ def load_approval_scope(
     document = json.loads(candidate.read_text(encoding="utf-8"))
     required = {
         "schema_version", "conditions", "ordered_task_ids",
-        "input_merkle_roots", "provider_classifications", "sha256",
+        "input_merkle_roots", "provider_classifications",
+        "task_request_sha256", "selection_recomputation_sha256", "sha256",
     }
     if not isinstance(document, dict) or set(document) != required:
         raise ValueError("approval scope fields are invalid")
@@ -105,6 +109,8 @@ def load_approval_scope(
     task_ids = document["ordered_task_ids"]
     roots = document["input_merkle_roots"]
     classifications = document["provider_classifications"]
+    request_digests = document["task_request_sha256"]
+    selection_hash = document["selection_recomputation_sha256"]
     if (
         not isinstance(conditions, list)
         or not conditions
@@ -128,6 +134,15 @@ def load_approval_scope(
             not isinstance(value, str) or not value
             for value in classifications.values()
         )
+        or not isinstance(request_digests, dict)
+        or set(request_digests) != set(task_ids)
+        or any(
+            not isinstance(value, str)
+            or re.fullmatch(r"[0-9a-f]{64}", value) is None
+            for value in request_digests.values()
+        )
+        or not isinstance(selection_hash, str)
+        or re.fullmatch(r"[0-9a-f]{64}", selection_hash) is None
     ):
         raise ValueError("approval scope identities are invalid")
     registry = root / "src" / "lib" / "officialExperimentScope.js"
@@ -138,6 +153,8 @@ def load_approval_scope(
         "task_ids": tuple(task_ids),
         "input_merkle_roots": dict(roots),
         "provider_classifications": dict(classifications),
+        "task_request_sha256": dict(request_digests),
+        "selection_recomputation_sha256": selection_hash,
         "approval_scope_sha256": digest,
         "official_scope_registry_sha256": hashlib.sha256(
             registry.read_bytes()
@@ -287,6 +304,8 @@ class SignedApprovalGate:
         task_ids = envelope.get("task_ids")
         roots = envelope.get("input_merkle_roots")
         classifications = envelope.get("provider_classifications")
+        request_digests = envelope.get("task_request_sha256")
+        selection_hash = envelope.get("selection_recomputation_sha256")
         if (
             not isinstance(conditions, list)
             or not conditions
@@ -320,6 +339,21 @@ class SignedApprovalGate:
             )
         ):
             raise AuthorizationError("approval_classifications_invalid")
+        if (
+            not isinstance(request_digests, dict)
+            or set(request_digests) != set(task_ids)
+            or any(
+                not isinstance(value, str)
+                or re.fullmatch(r"[0-9a-f]{64}", value) is None
+                for value in request_digests.values()
+            )
+        ):
+            raise AuthorizationError("approval_task_requests_invalid")
+        if (
+            not isinstance(selection_hash, str)
+            or re.fullmatch(r"[0-9a-f]{64}", selection_hash) is None
+        ):
+            raise AuthorizationError("approval_selection_identity_invalid")
         nonce = envelope.get("nonce")
         if (
             not isinstance(nonce, str)
@@ -375,6 +409,15 @@ class SignedApprovalGate:
             expected.provider_classifications
         ):
             raise AuthorizationError("approval_classification_set_mismatch")
+        if envelope.get("task_request_sha256") != dict(
+            expected.task_request_sha256
+        ):
+            raise AuthorizationError("approval_task_request_set_mismatch")
+        if (
+            envelope.get("selection_recomputation_sha256")
+            != expected.selection_recomputation_sha256
+        ):
+            raise AuthorizationError("approval_selection_identity_mismatch")
         if envelope.get("approval_scope_sha256") != expected.approval_scope_sha256:
             raise AuthorizationError("approval_scope_identity_mismatch")
         if (
@@ -391,6 +434,15 @@ class SignedApprovalGate:
             raise AuthorizationError("runtime_input_identity_mismatch")
         if runtime_context.get("provider_classification") != provider_classification:
             raise AuthorizationError("runtime_classification_mismatch")
+        if runtime_context.get("task_request_sha256") != expected.task_request_sha256[
+            task_id
+        ]:
+            raise AuthorizationError("runtime_task_request_mismatch")
+        if (
+            runtime_context.get("selection_recomputation_sha256")
+            != expected.selection_recomputation_sha256
+        ):
+            raise AuthorizationError("runtime_selection_identity_mismatch")
         runtime_scalars = {
             "run_id": expected.run_id,
             "condition": expected.condition,
@@ -440,6 +492,38 @@ def canonical_json(value: Mapping[str, Any]) -> bytes:
     ).encode("utf-8")
 
 
+def task_request_sha256(
+    *,
+    task_prompt: str,
+    occupation: str,
+    experiment_prompt: Optional[Mapping[str, Any]],
+    perception_text: Optional[str] = None,
+) -> str:
+    if not isinstance(task_prompt, str) or not isinstance(occupation, str):
+        raise ValueError("task request text fields are invalid")
+    prompt = dict(experiment_prompt or {})
+    if set(prompt) - {"system", "prefix", "body", "suffix"}:
+        raise ValueError("task request prompt fields are invalid")
+    if any(
+        value is not None and not isinstance(value, str)
+        for value in prompt.values()
+    ):
+        raise ValueError("task request prompt values are invalid")
+    if perception_text is not None and not isinstance(perception_text, str):
+        raise ValueError("task request perception text is invalid")
+    payload = {
+        "schema_version": "agentic-task-request-v1",
+        "task_prompt": task_prompt,
+        "occupation": occupation,
+        "experiment_prompt": {
+            key: prompt.get(key)
+            for key in ("system", "prefix", "body", "suffix")
+        },
+        "perception_text": perception_text,
+    }
+    return hashlib.sha256(canonical_json(payload)).hexdigest()
+
+
 def provider_endpoint_sha256(provider: str, endpoint: Optional[str]) -> str:
     normalized_provider = "azure" if provider == "azure_openai" else provider
     if normalized_provider == "openai" and not endpoint:
@@ -466,7 +550,20 @@ def provider_endpoint_sha256(provider: str, endpoint: Optional[str]) -> str:
     origin = f"https://{host}"
     if port not in (None, 443):
         origin += f":{port}"
-    return hashlib.sha256(origin.encode("ascii")).hexdigest()
+    path = parsed.path or "/"
+    if (
+        "\\" in path
+        or "%" in path
+        or "//" in path
+        or any(segment in {".", ".."} for segment in path.split("/"))
+    ):
+        raise ValueError("provider endpoint path is ambiguous")
+    canonical_path = "/" if path == "/" else path.rstrip("/")
+    try:
+        canonical = (origin + canonical_path).encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise ValueError("provider endpoint path must be ASCII") from exc
+    return hashlib.sha256(canonical).hexdigest()
 
 
 def _timestamp(value: object) -> datetime:

--- a/batch-runner/core/agentic_budget.py
+++ b/batch-runner/core/agentic_budget.py
@@ -1,0 +1,310 @@
+"""Crash-safe request and cost reservations for agentic solver calls."""
+
+from __future__ import annotations
+
+import sqlite3
+import fcntl
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class BudgetCaps:
+    attempts: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: Decimal
+
+
+@dataclass(frozen=True)
+class BudgetUsage:
+    attempts: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: Decimal
+
+
+class BudgetExceeded(RuntimeError):
+    pass
+
+
+class AgenticBudgetLedger:
+    """SQLite ledger whose reservations survive timeout, crash, and resume."""
+
+    def __init__(self, path: str | Path):
+        self.path = str(path)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=30, isolation_level=None)
+        connection.execute("PRAGMA busy_timeout=30000")
+        connection.execute("PRAGMA synchronous=FULL")
+        return connection
+
+    def _initialize(self) -> None:
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        with open(f"{self.path}.init.lock", "a", encoding="utf-8") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            with self._connect() as connection:
+                connection.execute("PRAGMA journal_mode=WAL")
+                connection.executescript(
+                    """
+                CREATE TABLE IF NOT EXISTS budget_usage (
+                    scope TEXT PRIMARY KEY,
+                    attempts INTEGER NOT NULL,
+                    input_tokens INTEGER NOT NULL,
+                    output_tokens INTEGER NOT NULL,
+                    cost_usd TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS reservations (
+                    scope TEXT NOT NULL,
+                    request_id TEXT NOT NULL,
+                    reserved_input INTEGER NOT NULL,
+                    reserved_output INTEGER NOT NULL,
+                    reserved_cost TEXT NOT NULL,
+                    actual_input INTEGER,
+                    actual_output INTEGER,
+                    actual_cost TEXT,
+                    PRIMARY KEY (scope, request_id)
+                );
+                    """
+                )
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+    def reserve(
+        self,
+        *,
+        scope: str,
+        request_id: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal,
+        caps: BudgetCaps,
+    ) -> BudgetUsage:
+        return self.reserve_many(
+            scopes={scope: caps},
+            request_id=request_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+        )[scope]
+
+    def reserve_many(
+        self,
+        *,
+        scopes: Mapping[str, BudgetCaps],
+        request_id: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal,
+    ) -> dict[str, BudgetUsage]:
+        """Atomically reserve one request against every supplied scope."""
+        _validate_nonnegative(input_tokens, "input_tokens")
+        _validate_nonnegative(output_tokens, "output_tokens")
+        cost = _decimal(cost_usd)
+        if not scopes or not request_id or any(not scope for scope in scopes):
+            raise ValueError("scopes and request_id are required")
+
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            proposed_by_scope: dict[str, BudgetUsage] = {}
+            for scope, caps in sorted(scopes.items()):
+                existing = connection.execute(
+                    "SELECT 1 FROM reservations WHERE scope=? AND request_id=?",
+                    (scope, request_id),
+                ).fetchone()
+                if existing:
+                    raise ValueError("request_id already reserved")
+                current = self._usage_row(connection, scope)
+                proposed = BudgetUsage(
+                    attempts=current.attempts + 1,
+                    input_tokens=current.input_tokens + input_tokens,
+                    output_tokens=current.output_tokens + output_tokens,
+                    cost_usd=current.cost_usd + cost,
+                )
+                self._check_caps(proposed, caps)
+                proposed_by_scope[scope] = proposed
+
+            for scope, proposed in proposed_by_scope.items():
+                connection.execute(
+                    """
+                    INSERT INTO budget_usage(
+                        scope, attempts, input_tokens, output_tokens, cost_usd
+                    ) VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(scope) DO UPDATE SET
+                        attempts=excluded.attempts,
+                        input_tokens=excluded.input_tokens,
+                        output_tokens=excluded.output_tokens,
+                        cost_usd=excluded.cost_usd
+                    """,
+                    (scope, proposed.attempts, proposed.input_tokens,
+                     proposed.output_tokens, str(proposed.cost_usd)),
+                )
+                connection.execute(
+                    """
+                    INSERT INTO reservations(
+                        scope, request_id, reserved_input, reserved_output,
+                        reserved_cost
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (scope, request_id, input_tokens, output_tokens, str(cost)),
+                )
+            connection.commit()
+            return proposed_by_scope
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def reconcile(
+        self,
+        *,
+        scope: str,
+        request_id: str,
+        actual_input_tokens: int,
+        actual_output_tokens: int,
+        actual_cost_usd: Decimal,
+    ) -> BudgetUsage:
+        return self.reconcile_many(
+            scopes=[scope],
+            request_id=request_id,
+            actual_input_tokens=actual_input_tokens,
+            actual_output_tokens=actual_output_tokens,
+            actual_cost_usd=actual_cost_usd,
+        )[scope]
+
+    def reconcile_many(
+        self,
+        *,
+        scopes: Iterable[str],
+        request_id: str,
+        actual_input_tokens: int,
+        actual_output_tokens: int,
+        actual_cost_usd: Decimal,
+    ) -> dict[str, BudgetUsage]:
+        """Atomically reconcile one request across all reserved scopes."""
+        _validate_nonnegative(actual_input_tokens, "actual_input_tokens")
+        _validate_nonnegative(actual_output_tokens, "actual_output_tokens")
+        actual_cost = _decimal(actual_cost_usd)
+        ordered_scopes = sorted(set(scopes))
+        if not ordered_scopes or not request_id:
+            raise ValueError("scopes and request_id are required")
+
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            rows = {}
+            for scope in ordered_scopes:
+                row = connection.execute(
+                    """
+                    SELECT reserved_input, reserved_output, reserved_cost,
+                           actual_input, actual_output, actual_cost
+                    FROM reservations WHERE scope=? AND request_id=?
+                    """,
+                    (scope, request_id),
+                ).fetchone()
+                if row is None:
+                    raise ValueError("unknown reservation")
+                if row[3] is not None or row[4] is not None or row[5] is not None:
+                    raise ValueError("reservation already reconciled")
+                reserved_input, reserved_output = int(row[0]), int(row[1])
+                reserved_cost = _decimal(row[2])
+                if (
+                    actual_input_tokens > reserved_input
+                    or actual_output_tokens > reserved_output
+                ):
+                    raise ValueError("actual token usage exceeds reservation")
+                if actual_cost > reserved_cost:
+                    raise ValueError("actual cost exceeds reservation")
+                rows[scope] = (reserved_input, reserved_output, reserved_cost)
+
+            reconciled_by_scope = {}
+            for scope, (reserved_input, reserved_output, reserved_cost) in rows.items():
+                current = self._usage_row(connection, scope)
+                reconciled = BudgetUsage(
+                    attempts=current.attempts,
+                    input_tokens=current.input_tokens - reserved_input + actual_input_tokens,
+                    output_tokens=current.output_tokens - reserved_output + actual_output_tokens,
+                    cost_usd=current.cost_usd - reserved_cost + actual_cost,
+                )
+                connection.execute(
+                    """
+                    UPDATE budget_usage
+                    SET input_tokens=?, output_tokens=?, cost_usd=?
+                    WHERE scope=?
+                    """,
+                    (reconciled.input_tokens, reconciled.output_tokens,
+                     str(reconciled.cost_usd), scope),
+                )
+                connection.execute(
+                    """
+                    UPDATE reservations
+                    SET actual_input=?, actual_output=?, actual_cost=?
+                    WHERE scope=? AND request_id=?
+                    """,
+                    (actual_input_tokens, actual_output_tokens, str(actual_cost),
+                     scope, request_id),
+                )
+                reconciled_by_scope[scope] = reconciled
+            connection.commit()
+            return reconciled_by_scope
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def usage(self, scope: str) -> BudgetUsage:
+        with self._connect() as connection:
+            return self._usage_row(connection, scope)
+
+    def reservation_ids(self, scope: str) -> set[str]:
+        if not scope:
+            raise ValueError("scope is required")
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT request_id FROM reservations WHERE scope=?",
+                (scope,),
+            ).fetchall()
+        return {str(row[0]) for row in rows}
+
+    @staticmethod
+    def _usage_row(connection: sqlite3.Connection, scope: str) -> BudgetUsage:
+        row = connection.execute(
+            "SELECT attempts, input_tokens, output_tokens, cost_usd "
+            "FROM budget_usage WHERE scope=?",
+            (scope,),
+        ).fetchone()
+        if row is None:
+            return BudgetUsage(0, 0, 0, Decimal("0"))
+        return BudgetUsage(int(row[0]), int(row[1]), int(row[2]), _decimal(row[3]))
+
+    @staticmethod
+    def _check_caps(usage: BudgetUsage, caps: BudgetCaps) -> None:
+        if usage.attempts > caps.attempts:
+            raise BudgetExceeded("api_attempt_cap")
+        if usage.input_tokens > caps.input_tokens:
+            raise BudgetExceeded("input_token_cap")
+        if usage.output_tokens > caps.output_tokens:
+            raise BudgetExceeded("output_token_cap")
+        if usage.cost_usd > _decimal(caps.cost_usd):
+            raise BudgetExceeded("cost_cap")
+
+
+def _validate_nonnegative(value: int, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+
+
+def _decimal(value: object) -> Decimal:
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        raise ValueError("cost must be a finite non-negative Decimal") from exc
+    if not result.is_finite() or result < 0:
+        raise ValueError("cost must be a finite non-negative Decimal")
+    return result

--- a/batch-runner/core/agentic_channel.py
+++ b/batch-runner/core/agentic_channel.py
@@ -9,11 +9,18 @@ import json
 import secrets
 import threading
 import time
+import math
 from dataclasses import dataclass
 from typing import Any, Callable, Mapping, Protocol
 
 
 PROTOCOL_VERSION = "agentic-compute-v1"
+MAX_CHANNEL_DEPTH = 32
+MAX_CHANNEL_NODES = 200_000
+MAX_CHANNEL_TEXT_BYTES = 256 * 1024
+MAX_CHANNEL_BYTE_STRING_BYTES = 512 * 1024
+MAX_CHANNEL_TOTAL_STRING_BYTES = 384 * 1024 * 1024
+CHANNEL_RAW_BYTE_CHUNK = 384 * 1024
 
 
 class ChannelError(RuntimeError):
@@ -21,7 +28,13 @@ class ChannelError(RuntimeError):
 
 
 class ComputeTransport(Protocol):
-    def exchange(self, envelope: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def exchange(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        timeout_seconds: float | None = None,
+        monotonic_deadline: float | None = None,
+    ) -> Mapping[str, Any]: ...
 
 
 @dataclass(frozen=True)
@@ -86,8 +99,13 @@ class EnvelopeAuthority:
         command: Mapping[str, Any],
         payload: Mapping[str, Any],
         expires_at: int,
+        deadline_at: float | None = None,
     ) -> dict:
-        encoded_payload = _encode_value(dict(payload))
+        _check_wall_deadline(deadline_at)
+        encoded_payload = _encode_value(
+            dict(payload), deadline_at=deadline_at
+        )
+        _check_wall_deadline(deadline_at)
         envelope = {
             "protocol_version": PROTOCOL_VERSION,
             "run_id": command["run_id"],
@@ -96,17 +114,24 @@ class EnvelopeAuthority:
             "sequence": command["sequence"],
             "nonce": command["nonce"],
             "expires_at": expires_at,
-            "command_sha256": _digest(_without_mac(command)),
+            "command_sha256": _digest(
+                _without_mac(command), deadline_at=deadline_at
+            ),
             "payload": encoded_payload,
-            "payload_sha256": _digest(encoded_payload),
+            "payload_sha256": _digest(
+                encoded_payload, deadline_at=deadline_at
+            ),
         }
-        envelope["mac"] = self._mac(envelope)
+        envelope["mac"] = self._mac(
+            envelope, deadline_at=deadline_at
+        )
+        _check_wall_deadline(deadline_at)
         return envelope
 
     def verify_command(
         self, envelope: Mapping[str, Any], *, now: int | None = None
     ) -> dict:
-        self._verify_common(envelope, now=now)
+        self._verify_common(envelope, now=now, max_future_seconds=330)
         required = {
             "protocol_version", "run_id", "condition", "task_id", "sequence",
             "nonce", "expires_at", "operation", "payload", "payload_sha256",
@@ -116,8 +141,50 @@ class EnvelopeAuthority:
             raise ChannelError("command_fields_invalid")
         if not isinstance(envelope.get("operation"), str) or not envelope["operation"]:
             raise ChannelError("command_operation_invalid")
-        self._consume(envelope)
         return _decode_value(envelope["payload"])
+
+    def commit_command(self, envelope: Mapping[str, Any]) -> None:
+        sequence = envelope.get("sequence")
+        nonce = envelope.get("nonce")
+        if sequence != self.expected_sequence or nonce in self.used_nonces:
+            raise ChannelError("command_commit_state_mismatch")
+        self._consume(envelope)
+
+    def verify_cached_retry(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        original: Mapping[str, Any],
+        cache_expires_at: int,
+        now: int | None = None,
+    ) -> None:
+        if not isinstance(envelope, Mapping) or dict(envelope) != dict(original):
+            raise ChannelError("cached_command_mismatch")
+        expected = {
+            "run_id": self.scope.run_id,
+            "condition": self.scope.condition,
+            "task_id": self.scope.task_id,
+        }
+        if (
+            envelope.get("protocol_version") != PROTOCOL_VERSION
+            or any(envelope.get(key) != value for key, value in expected.items())
+        ):
+            raise ChannelError("cached_command_scope_mismatch")
+        if envelope.get("sequence") != self.expected_sequence - 1:
+            raise ChannelError("cached_command_sequence_mismatch")
+        nonce = envelope.get("nonce")
+        if not isinstance(nonce, str) or nonce not in self.used_nonces:
+            raise ChannelError("cached_command_nonce_mismatch")
+        current = int(time.time()) if now is None else now
+        if type(cache_expires_at) is not int or cache_expires_at < current:
+            raise ChannelError("cached_result_expired")
+        if envelope.get("payload_sha256") != _digest(envelope.get("payload")):
+            raise ChannelError("payload_digest_mismatch")
+        supplied_mac = envelope.get("mac")
+        if not isinstance(supplied_mac, str) or not hmac.compare_digest(
+            supplied_mac, self._mac(envelope)
+        ):
+            raise ChannelError("envelope_mac_invalid")
 
     def verify_result(
         self,
@@ -125,8 +192,16 @@ class EnvelopeAuthority:
         *,
         command: Mapping[str, Any],
         now: int | None = None,
+        deadline_at: float | None = None,
+        monotonic_deadline: float | None = None,
     ) -> dict:
-        self._verify_common(envelope, now=now)
+        self._verify_common(
+            envelope,
+            now=now,
+            max_future_seconds=1500,
+            deadline_at=deadline_at,
+            monotonic_deadline=monotonic_deadline,
+        )
         required = {
             "protocol_version", "run_id", "condition", "task_id", "sequence",
             "nonce", "expires_at", "command_sha256", "payload",
@@ -134,16 +209,35 @@ class EnvelopeAuthority:
         }
         if set(envelope) != required:
             raise ChannelError("result_fields_invalid")
-        if envelope.get("command_sha256") != _digest(_without_mac(command)):
+        if envelope.get("command_sha256") != _digest(
+            _without_mac(command),
+            deadline_at=deadline_at,
+            monotonic_deadline=monotonic_deadline,
+        ):
             raise ChannelError("result_command_mismatch")
         if envelope.get("nonce") != command.get("nonce"):
             raise ChannelError("result_nonce_mismatch")
+        decoded = _decode_value(
+            envelope["payload"],
+            deadline_at=deadline_at,
+            monotonic_deadline=monotonic_deadline,
+        )
+        if not isinstance(decoded, dict):
+            raise ChannelError("compute_result_not_object")
+        _check_wall_deadline(deadline_at, monotonic_deadline)
         self._consume(envelope)
-        return _decode_value(envelope["payload"])
+        return decoded
 
     def _verify_common(
-        self, envelope: Mapping[str, Any], *, now: int | None
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        now: int | None,
+        max_future_seconds: int,
+        deadline_at: float | None = None,
+        monotonic_deadline: float | None = None,
     ) -> None:
+        _check_wall_deadline(deadline_at, monotonic_deadline)
         if not isinstance(envelope, Mapping):
             raise ChannelError("envelope_not_object")
         if envelope.get("protocol_version") != PROTOCOL_VERSION:
@@ -167,26 +261,45 @@ class EnvelopeAuthority:
         current = int(time.time()) if now is None else now
         if type(expires_at) is not int or expires_at < current:
             raise ChannelError("expired_envelope")
-        if expires_at > current + self.max_clock_skew_seconds + 300:
+        if expires_at > current + self.max_clock_skew_seconds + max_future_seconds:
             raise ChannelError("envelope_expiry_too_far")
-        if envelope.get("payload_sha256") != _digest(envelope.get("payload")):
+        if envelope.get("payload_sha256") != _digest(
+            envelope.get("payload"),
+            deadline_at=deadline_at,
+            monotonic_deadline=monotonic_deadline,
+        ):
             raise ChannelError("payload_digest_mismatch")
         supplied_mac = envelope.get("mac")
         if not isinstance(supplied_mac, str) or not hmac.compare_digest(
-            supplied_mac, self._mac(envelope)
+            supplied_mac,
+            self._mac(
+                envelope,
+                deadline_at=deadline_at,
+                monotonic_deadline=monotonic_deadline,
+            ),
         ):
             raise ChannelError("envelope_mac_invalid")
+        _check_wall_deadline(deadline_at, monotonic_deadline)
 
     def _consume(self, envelope: Mapping[str, Any]) -> None:
         self.used_nonces.add(str(envelope["nonce"]))
         self.expected_sequence += 1
 
-    def _mac(self, envelope: Mapping[str, Any]) -> str:
-        return hmac.new(
-            self.key,
-            _canonical(_without_mac(envelope)),
-            hashlib.sha256,
-        ).hexdigest()
+    def _mac(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        deadline_at: float | None = None,
+        monotonic_deadline: float | None = None,
+    ) -> str:
+        digest = hmac.new(self.key, digestmod=hashlib.sha256)
+        for chunk in _canonical_chunks(
+            _without_mac(envelope),
+            deadline_at=deadline_at,
+            monotonic_deadline=monotonic_deadline,
+        ):
+            digest.update(chunk)
+        return digest.hexdigest()
 
 
 class ComputeChannelServer:
@@ -213,20 +326,26 @@ class ComputeChannelServer:
         self.command_count = 0
         self.lock = threading.Lock()
         self._lease_timer: threading.Timer | None = None
-        self._last_command_sha256: str | None = None
+        self._last_command: dict | None = None
         self._last_result: dict | None = None
 
     def handle(self, envelope: Mapping[str, Any]) -> dict:
         with self.lock:
-            command_sha256 = _digest(_without_mac(envelope))
             if (
-                command_sha256 == self._last_command_sha256
+                self._last_command is not None
                 and self._last_result is not None
+                and _without_mac(envelope) == _without_mac(self._last_command)
             ):
+                self.authority.verify_cached_retry(
+                    envelope,
+                    original=self._last_command,
+                    cache_expires_at=int(self._last_result["expires_at"]),
+                )
                 return dict(self._last_result)
             if self.command_count >= self.max_commands:
                 raise ChannelError("compute_command_cap_exhausted")
             payload = self.authority.verify_command(envelope)
+            timeout = _payload_timeout(payload, require_deadline=True)
             operation = envelope["operation"]
             try:
                 if operation == "start":
@@ -236,52 +355,112 @@ class ComputeChannelServer:
                     if not isinstance(task_spec, dict):
                         raise ChannelError("task_spec_invalid")
                     self.backend = self.backend_factory(**task_spec)
-                    result = self.backend.start(payload["timeout_seconds"])
+                    self._arm_lease_locked()
+                    result = self.backend.start(timeout)
                 else:
                     if self.backend is None:
                         raise ChannelError("backend_not_started")
                     result = self._dispatch(operation, payload)
             except Exception:
+                error_type = "compute_dispatch_failed"
                 if operation == "start":
-                    self._close_backend_locked()
-                raise
+                    error_type = "compute_start_failed"
+                    try:
+                        self._close_backend_locked()
+                    except Exception:
+                        error_type = "compute_start_cleanup_failed"
+                        self._arm_lease_locked()
+                result = {
+                    "ok": False,
+                    "error_type": error_type,
+                    "retryable": False,
+                }
             self.command_count += 1
-            signed_result = self.authority.result(
-                command=envelope,
-                payload=dict(result),
-                expires_at=int(time.time()) + self.result_ttl_seconds,
-            )
-            self._last_command_sha256 = command_sha256
+            result_expires_at = int(time.time()) + self.result_ttl_seconds
+            if payload.get("deadline_at") is not None:
+                result_expires_at = max(
+                    result_expires_at,
+                    math.ceil(float(payload["deadline_at"]))
+                    + self.result_ttl_seconds,
+                )
+            try:
+                signed_result = self.authority.result(
+                    command=envelope,
+                    payload=dict(result),
+                    expires_at=result_expires_at,
+                    deadline_at=(
+                        float(payload["deadline_at"])
+                        if payload.get("deadline_at") is not None
+                        else None
+                    ),
+                )
+            except Exception:
+                cleanup_failed = False
+                try:
+                    self._close_backend_locked()
+                except Exception:
+                    cleanup_failed = True
+                signed_result = self.authority.result(
+                    command=envelope,
+                    payload={
+                        "ok": False,
+                        "error_type": (
+                            "post_dispatch_cleanup_failed"
+                            if cleanup_failed
+                            else "post_dispatch_result_failed"
+                        ),
+                        "retryable": False,
+                    },
+                    expires_at=result_expires_at,
+                )
+            self.authority.commit_command(envelope)
+            self._last_command = dict(envelope)
             self._last_result = dict(signed_result)
-            if operation == "close":
+            if self.backend is None:
                 self._cancel_lease_locked()
             else:
                 self._arm_lease_locked()
             return signed_result
 
     def _dispatch(self, operation: str, payload: Mapping[str, Any]):
+        timeout = _payload_timeout(payload, require_deadline=True)
         if operation == "inspect_workspace":
-            return self.backend.inspect_workspace(payload["timeout_seconds"])
+            return self.backend.inspect_workspace(timeout)
         if operation == "inspect_environment":
-            return self.backend.inspect_environment(payload["timeout_seconds"])
+            return self.backend.inspect_environment(timeout)
         if operation == "reset_work":
-            return self.backend.reset_work(payload["timeout_seconds"])
+            return self.backend.reset_work(timeout)
         if operation == "run_python":
             return self.backend.run_python(
-                payload["source"], payload["timeout_seconds"]
+                payload["source"], timeout
             )
         if operation == "run_ffmpeg":
             return self.backend.run_ffmpeg(
-                payload["operation"], payload["timeout_seconds"]
+                payload["operation"], timeout
             )
         if operation == "inspect_artifacts":
-            return self.backend.inspect_artifacts(payload["timeout_seconds"])
+            return self.backend.inspect_artifacts(timeout)
+        if operation == "export_best_snapshot":
+            terminal = self.backend.best_result(timeout)
+            if terminal is None:
+                return {
+                    "ok": False,
+                    "error_type": "best_snapshot_unavailable",
+                    "retryable": False,
+                }
+            return {
+                "ok": True,
+                "data": {"sealed": True},
+                "terminal_result": terminal,
+            }
         if operation == "finalize":
             result = self.backend.finalize(
                 payload["deliverables"], payload["summary"],
-                payload["timeout_seconds"],
+                timeout,
             )
-            terminal = self.backend.best_result()
+            terminal = self.backend.best_result(_payload_timeout(
+                payload, require_deadline=True
+            ))
             return {**dict(result), "terminal_result": terminal}
         if operation == "close":
             self._close_backend_locked()
@@ -309,14 +488,20 @@ class ComputeChannelServer:
 
     def _expire_backend(self) -> None:
         with self.lock:
-            self._close_backend_locked()
-            self._lease_timer = None
+            try:
+                self._close_backend_locked()
+                self._lease_timer = None
+            except Exception:
+                timer = threading.Timer(30.0, self._expire_backend)
+                timer.daemon = True
+                self._lease_timer = timer
+                timer.start()
 
     def _close_backend_locked(self) -> None:
         backend = self.backend
-        self.backend = None
         if backend is not None:
             backend.close()
+            self.backend = None
 
 
 class InMemoryComputeTransport:
@@ -325,8 +510,25 @@ class InMemoryComputeTransport:
     def __init__(self, server: ComputeChannelServer):
         self.server = server
 
-    def exchange(self, envelope: Mapping[str, Any]) -> Mapping[str, Any]:
-        return self.server.handle(envelope)
+    def exchange(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        timeout_seconds: float | None = None,
+        monotonic_deadline: float | None = None,
+    ) -> Mapping[str, Any]:
+        if (
+            monotonic_deadline is not None
+            and time.monotonic() >= monotonic_deadline
+        ):
+            raise TimeoutError("compute transport deadline exhausted")
+        result = self.server.handle(envelope)
+        if (
+            monotonic_deadline is not None
+            and time.monotonic() >= monotonic_deadline
+        ):
+            raise TimeoutError("compute transport deadline exhausted")
+        return result
 
 
 class AuthenticatedComputeBackend:
@@ -350,6 +552,7 @@ class AuthenticatedComputeBackend:
         self.max_transport_retries = max_transport_retries
         self.sequence = 0
         self._best_result = None
+        self._pending_exchange: dict[str, Any] | None = None
 
     def start(self, timeout_seconds=1200.0):
         return self._exchange("start", {
@@ -383,9 +586,24 @@ class AuthenticatedComputeBackend:
         })
 
     def inspect_artifacts(self, timeout_seconds=1200.0):
-        return self._exchange("inspect_artifacts", {
-            "timeout_seconds": timeout_seconds,
-        })
+        deadline = _deadline(timeout_seconds)
+        result = self._exchange("inspect_artifacts", {
+            "timeout_seconds": _remaining(deadline),
+        }, deadline=deadline)
+        if result.get("ok") is True:
+            sealed = self._exchange("export_best_snapshot", {
+                "timeout_seconds": _remaining(deadline),
+            }, deadline=deadline)
+            terminal = sealed.pop("terminal_result", None)
+            if (
+                sealed.get("ok") is False
+                and sealed.get("error_type") == "best_snapshot_unavailable"
+            ):
+                return result
+            if sealed.get("ok") is not True or terminal is None:
+                raise ChannelError("best_snapshot_export_failed")
+            self._best_result = terminal
+        return result
 
     def finalize(self, deliverables, summary, timeout_seconds=1200.0):
         result = self._exchange("finalize", {
@@ -393,35 +611,81 @@ class AuthenticatedComputeBackend:
             "summary": summary,
             "timeout_seconds": timeout_seconds,
         })
-        self._best_result = result.pop("terminal_result", None)
+        terminal = result.pop("terminal_result", None)
+        if terminal is not None:
+            self._best_result = terminal
         return result
 
     def best_result(self):
         return self._best_result
 
     def close(self):
-        try:
-            self._exchange("close", {})
-        except Exception:
-            pass
+        result = self._exchange("close", {"timeout_seconds": 30.0})
+        if result.get("ok") is not True:
+            raise ChannelError(
+                str(result.get("error_type") or "compute_close_failed")
+            )
+        return result
 
-    def _exchange(self, operation: str, payload: Mapping[str, Any]) -> dict:
-        self.sequence += 1
-        expires_at = int(time.time()) + self.ttl_seconds
-        command = self.authority.command(
-            sequence=self.sequence,
-            operation=operation,
-            payload=payload,
-            expires_at=expires_at,
-        )
+    def _exchange(
+        self,
+        operation: str,
+        payload: Mapping[str, Any],
+        *,
+        deadline: float | None = None,
+    ) -> dict:
+        requested_payload = dict(payload)
+        pending = self._pending_exchange
+        if pending is not None:
+            if (
+                pending["operation"] != operation
+                or pending["requested_payload"] != requested_payload
+            ):
+                raise ChannelError("compute_channel_state_indeterminate")
+            deadline = float(pending["deadline"])
+            command_deadline_at = float(pending["command_deadline_at"])
+            command = dict(pending["command"])
+            candidate_sequence = int(pending["sequence"])
+        else:
+            deadline = deadline or _deadline(
+                float(payload.get("timeout_seconds", self.ttl_seconds))
+            )
+            remaining = _remaining(deadline)
+            command_payload = dict(payload)
+            command_payload["timeout_seconds"] = remaining
+            command_payload["deadline_at"] = time.time() + remaining
+            command_deadline_at = float(command_payload["deadline_at"])
+            candidate_sequence = self.sequence + 1
+            expires_at = int(time.time()) + self.ttl_seconds
+            command = self.authority.command(
+                sequence=candidate_sequence,
+                operation=operation,
+                payload=command_payload,
+                expires_at=expires_at,
+            )
+            self._pending_exchange = {
+                "operation": operation,
+                "requested_payload": requested_payload,
+                "deadline": deadline,
+                "command_deadline_at": command_deadline_at,
+                "command": dict(command),
+                "sequence": candidate_sequence,
+            }
         last_error: Exception | None = None
         decoded = None
         for _ in range(self.max_transport_retries + 1):
             try:
-                raw_result = self.transport.exchange(command)
+                remaining = _remaining(deadline)
+                raw_result = self.transport.exchange(
+                    command,
+                    timeout_seconds=remaining,
+                    monotonic_deadline=deadline,
+                )
                 decoded = self.authority.verify_result(
                     raw_result,
                     command=command,
+                    deadline_at=command_deadline_at,
+                    monotonic_deadline=deadline,
                 )
                 break
             except Exception as exc:
@@ -431,40 +695,360 @@ class AuthenticatedComputeBackend:
             raise last_error
         if not isinstance(decoded, dict):
             raise ChannelError("compute_result_not_object")
+        self.sequence = candidate_sequence
+        self._pending_exchange = None
         return decoded
 
 
-def _encode_value(value: Any) -> Any:
+def _deadline(timeout_seconds: float) -> float:
+    if (
+        isinstance(timeout_seconds, bool)
+        or not isinstance(timeout_seconds, (int, float))
+        or not math.isfinite(float(timeout_seconds))
+        or not 0 < float(timeout_seconds) <= 1200
+    ):
+        raise ValueError("compute timeout must be in (0, 1200]")
+    return time.monotonic() + float(timeout_seconds)
+
+
+def _remaining(deadline: float) -> float:
+    value = deadline - time.monotonic()
+    if value <= 0:
+        raise TimeoutError("compute task deadline exhausted")
+    return max(0.001, min(1200.0, value))
+
+
+def _payload_timeout(
+    payload: Mapping[str, Any], *, require_deadline: bool = False
+) -> float:
+    raw_timeout = payload.get("timeout_seconds")
+    raw_deadline = payload.get("deadline_at")
+    if (
+        isinstance(raw_timeout, bool)
+        or not isinstance(raw_timeout, (int, float))
+        or not math.isfinite(float(raw_timeout))
+        or not 0 < float(raw_timeout) <= 1200
+    ):
+        raise ChannelError("compute_timeout_invalid")
+    if raw_deadline is None and require_deadline:
+        raise ChannelError("compute_deadline_missing")
+    if raw_deadline is None:
+        return float(raw_timeout)
+    if (
+        isinstance(raw_deadline, bool)
+        or not isinstance(raw_deadline, (int, float))
+        or not math.isfinite(float(raw_deadline))
+    ):
+        raise ChannelError("compute_deadline_invalid")
+    remaining = float(raw_deadline) - time.time()
+    if remaining <= 0:
+        raise ChannelError("compute_deadline_exhausted")
+    return max(0.001, min(float(raw_timeout), remaining))
+
+
+def _encode_value(
+    value: Any, *, deadline_at: float | None = None
+) -> Any:
+    _preflight_raw_channel_value(value, deadline_at=deadline_at)
+    return _encode_value_unchecked(value, deadline_at=deadline_at)
+
+
+def _encode_value_unchecked(
+    value: Any, *, deadline_at: float | None = None
+) -> Any:
+    _check_wall_deadline(deadline_at)
     if isinstance(value, bytes):
-        return {"$bytes": base64.b64encode(value).decode("ascii")}
+        chunks = []
+        for offset in range(0, len(value), CHANNEL_RAW_BYTE_CHUNK):
+            _check_wall_deadline(deadline_at)
+            chunks.append(base64.b64encode(
+                value[offset:offset + CHANNEL_RAW_BYTE_CHUNK]
+            ).decode("ascii"))
+        return {"$bytes_chunks": chunks}
     if isinstance(value, Mapping):
-        return {str(key): _encode_value(item) for key, item in value.items()}
+        return {
+            key: _encode_value_unchecked(item, deadline_at=deadline_at)
+            for key, item in value.items()
+        }
     if isinstance(value, (list, tuple)):
-        return [_encode_value(item) for item in value]
+        return [
+            _encode_value_unchecked(item, deadline_at=deadline_at)
+            for item in value
+        ]
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     raise TypeError(f"channel value is not serializable: {type(value).__name__}")
 
 
-def _decode_value(value: Any) -> Any:
+def _preflight_raw_channel_value(
+    value: Any, *, deadline_at: float | None = None
+) -> None:
+    nodes = 0
+    total_string_bytes = 0
+    stack: list[tuple[Any, int]] = [(value, 1)]
+
+    def charge_nodes(count: int) -> None:
+        nonlocal nodes
+        nodes += count
+        if nodes > MAX_CHANNEL_NODES:
+            raise ChannelError("channel_value_node_cap_exceeded")
+
+    def charge_string_size(size: int, maximum: int) -> None:
+        nonlocal total_string_bytes
+        if size > maximum:
+            raise ChannelError("channel_value_string_cap_exceeded")
+        total_string_bytes += size
+        if total_string_bytes > MAX_CHANNEL_TOTAL_STRING_BYTES:
+            raise ChannelError("channel_value_total_string_cap_exceeded")
+
+    def charge_text(item: str, maximum: int) -> None:
+        if len(item) > maximum:
+            raise ChannelError("channel_value_string_cap_exceeded")
+        try:
+            size = len(item.encode("utf-8"))
+        except UnicodeEncodeError as exc:
+            raise ChannelError("channel_value_string_invalid") from exc
+        charge_string_size(size, maximum)
+
+    while stack:
+        _check_wall_deadline(deadline_at)
+        item, depth = stack.pop()
+        if depth > MAX_CHANNEL_DEPTH:
+            raise ChannelError("channel_value_depth_cap_exceeded")
+        if isinstance(item, bytes):
+            chunk_count = (
+                math.ceil(len(item) / CHANNEL_RAW_BYTE_CHUNK)
+                if item else 0
+            )
+            deepest = depth + (2 if chunk_count else 1)
+            if deepest > MAX_CHANNEL_DEPTH:
+                raise ChannelError("channel_value_depth_cap_exceeded")
+            charge_nodes(3 + chunk_count)
+            charge_string_size(
+                len("$bytes_chunks".encode("utf-8")),
+                MAX_CHANNEL_TEXT_BYTES,
+            )
+            encoded_size = 4 * math.ceil(len(item) / 3) if item else 0
+            if item:
+                maximum_chunk_size = 4 * math.ceil(
+                    min(len(item), CHANNEL_RAW_BYTE_CHUNK) / 3
+                )
+                if maximum_chunk_size > MAX_CHANNEL_BYTE_STRING_BYTES:
+                    raise ChannelError(
+                        "channel_value_string_cap_exceeded"
+                    )
+            total_string_bytes += encoded_size
+            if total_string_bytes > MAX_CHANNEL_TOTAL_STRING_BYTES:
+                raise ChannelError(
+                    "channel_value_total_string_cap_exceeded"
+                )
+            continue
+        charge_nodes(1)
+        if isinstance(item, str):
+            charge_text(item, MAX_CHANNEL_TEXT_BYTES)
+        elif isinstance(item, Mapping):
+            for key, child in item.items():
+                if not isinstance(key, str):
+                    raise ChannelError("channel_value_key_invalid")
+                if depth + 1 > MAX_CHANNEL_DEPTH:
+                    raise ChannelError("channel_value_depth_cap_exceeded")
+                charge_nodes(1)
+                charge_text(key, MAX_CHANNEL_TEXT_BYTES)
+                stack.append((child, depth + 1))
+        elif isinstance(item, (list, tuple)):
+            stack.extend(
+                (child, depth + 1) for child in reversed(item)
+            )
+        elif item is None or isinstance(item, (bool, int)):
+            continue
+        elif isinstance(item, float) and math.isfinite(item):
+            continue
+        else:
+            raise ChannelError("channel_value_type_invalid")
+
+
+def _check_wall_deadline(
+    deadline_at: float | None,
+    monotonic_deadline: float | None = None,
+) -> None:
+    if deadline_at is not None and time.time() >= deadline_at:
+        raise ChannelError("compute_deadline_exhausted")
+    if (
+        monotonic_deadline is not None
+        and time.monotonic() >= monotonic_deadline
+    ):
+        raise ChannelError("compute_deadline_exhausted")
+
+
+def _decode_value(
+    value: Any,
+    *,
+    deadline_at: float | None = None,
+    monotonic_deadline: float | None = None,
+) -> Any:
+    _check_wall_deadline(deadline_at, monotonic_deadline)
     if isinstance(value, Mapping):
         if set(value) == {"$bytes"}:
-            return base64.b64decode(value["$bytes"], validate=True)
-        return {str(key): _decode_value(item) for key, item in value.items()}
+            return _decode_base64_text(
+                value["$bytes"], deadline_at, monotonic_deadline
+            )
+        if set(value) == {"$bytes_chunks"}:
+            chunks = value["$bytes_chunks"]
+            if not isinstance(chunks, list) or any(
+                not isinstance(chunk, str) for chunk in chunks
+            ):
+                raise ChannelError("byte_chunks_invalid")
+            output = bytearray()
+            for chunk in chunks:
+                output.extend(_decode_base64_text(
+                    chunk, deadline_at, monotonic_deadline
+                ))
+            _check_wall_deadline(deadline_at, monotonic_deadline)
+            return bytes(output)
+        return {
+            str(key): _decode_value(
+                item,
+                deadline_at=deadline_at,
+                monotonic_deadline=monotonic_deadline,
+            )
+            for key, item in value.items()
+        }
     if isinstance(value, list):
-        return [_decode_value(item) for item in value]
+        return [
+            _decode_value(
+                item,
+                deadline_at=deadline_at,
+                monotonic_deadline=monotonic_deadline,
+            )
+            for item in value
+        ]
     return value
+
+
+def _decode_base64_text(
+    value: Any,
+    deadline_at: float | None,
+    monotonic_deadline: float | None,
+) -> bytes:
+    if not isinstance(value, str):
+        raise ChannelError("byte_chunks_invalid")
+    output = bytearray()
+    encoded_chunk_size = 4 * 1024 * 1024
+    for offset in range(0, len(value), encoded_chunk_size):
+        _check_wall_deadline(deadline_at, monotonic_deadline)
+        output.extend(base64.b64decode(
+            value[offset:offset + encoded_chunk_size], validate=True
+        ))
+    _check_wall_deadline(deadline_at, monotonic_deadline)
+    return bytes(output)
 
 
 def _without_mac(value: Mapping[str, Any]) -> dict:
     return {key: item for key, item in value.items() if key != "mac"}
 
 
+def _canonical_chunks(
+    value: Any,
+    *,
+    deadline_at: float | None = None,
+    monotonic_deadline: float | None = None,
+):
+    _validate_channel_value_limits(
+        value,
+        deadline_at=deadline_at,
+        monotonic_deadline=monotonic_deadline,
+    )
+    encoder = json.JSONEncoder(
+        sort_keys=True, separators=(",", ":"), allow_nan=False
+    )
+    for chunk in encoder.iterencode(value):
+        _check_wall_deadline(deadline_at, monotonic_deadline)
+        yield chunk.encode("utf-8")
+    _check_wall_deadline(deadline_at, monotonic_deadline)
+
+
+def _validate_channel_value_limits(
+    value: Any,
+    *,
+    deadline_at: float | None,
+    monotonic_deadline: float | None,
+) -> None:
+    nodes = 0
+    total_string_bytes = 0
+    stack: list[tuple[Any, int, int]] = [
+        (value, 1, MAX_CHANNEL_TEXT_BYTES)
+    ]
+    while stack:
+        _check_wall_deadline(deadline_at, monotonic_deadline)
+        item, depth, string_limit = stack.pop()
+        if depth > MAX_CHANNEL_DEPTH:
+            raise ChannelError("channel_value_depth_cap_exceeded")
+        nodes += 1
+        if nodes > MAX_CHANNEL_NODES:
+            raise ChannelError("channel_value_node_cap_exceeded")
+        if isinstance(item, str):
+            if len(item) > string_limit:
+                raise ChannelError("channel_value_string_cap_exceeded")
+            try:
+                encoded_size = len(item.encode("utf-8"))
+            except UnicodeEncodeError as exc:
+                raise ChannelError("channel_value_string_invalid") from exc
+            if encoded_size > string_limit:
+                raise ChannelError("channel_value_string_cap_exceeded")
+            total_string_bytes += encoded_size
+            if total_string_bytes > MAX_CHANNEL_TOTAL_STRING_BYTES:
+                raise ChannelError(
+                    "channel_value_total_string_cap_exceeded"
+                )
+        elif isinstance(item, Mapping):
+            marker = set(item)
+            byte_marker = marker in ({"$bytes"}, {"$bytes_chunks"})
+            for key, child in reversed(list(item.items())):
+                if not isinstance(key, str):
+                    raise ChannelError("channel_value_key_invalid")
+                if byte_marker and key == "$bytes" and not isinstance(
+                    child, str
+                ):
+                    raise ChannelError("byte_chunks_invalid")
+                if byte_marker and key == "$bytes_chunks":
+                    if not isinstance(child, list) or any(
+                        not isinstance(chunk, str) for chunk in child
+                    ):
+                        raise ChannelError("byte_chunks_invalid")
+                child_limit = (
+                    MAX_CHANNEL_BYTE_STRING_BYTES
+                    if byte_marker else MAX_CHANNEL_TEXT_BYTES
+                )
+                stack.append((child, depth + 1, child_limit))
+                stack.append((key, depth + 1, MAX_CHANNEL_TEXT_BYTES))
+        elif isinstance(item, (list, tuple)):
+            stack.extend(
+                (child, depth + 1, string_limit)
+                for child in reversed(item)
+            )
+        elif item is None or isinstance(item, (bool, int)):
+            continue
+        elif isinstance(item, float) and math.isfinite(item):
+            continue
+        else:
+            raise ChannelError("channel_value_type_invalid")
+
+
 def _canonical(value: Any) -> bytes:
-    return json.dumps(
-        value, sort_keys=True, separators=(",", ":"), allow_nan=False
-    ).encode("utf-8")
+    return b"".join(_canonical_chunks(value))
 
 
-def _digest(value: Any) -> str:
-    return hashlib.sha256(_canonical(value)).hexdigest()
+def _digest(
+    value: Any,
+    *,
+    deadline_at: float | None = None,
+    monotonic_deadline: float | None = None,
+) -> str:
+    digest = hashlib.sha256()
+    for chunk in _canonical_chunks(
+        value,
+        deadline_at=deadline_at,
+        monotonic_deadline=monotonic_deadline,
+    ):
+        digest.update(chunk)
+    return digest.hexdigest()

--- a/batch-runner/core/agentic_channel.py
+++ b/batch-runner/core/agentic_channel.py
@@ -1,0 +1,470 @@
+"""Authenticated, ordered command channel between control and compute planes."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Protocol
+
+
+PROTOCOL_VERSION = "agentic-compute-v1"
+
+
+class ChannelError(RuntimeError):
+    pass
+
+
+class ComputeTransport(Protocol):
+    def exchange(self, envelope: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class ChannelScope:
+    run_id: str
+    condition: str
+    task_id: str
+
+    def __post_init__(self) -> None:
+        if any(not isinstance(value, str) or not value for value in (
+            self.run_id, self.condition, self.task_id
+        )):
+            raise ValueError("channel scope fields are required")
+
+
+class EnvelopeAuthority:
+    """Sign and consume one ordered envelope stream for one task scope."""
+
+    def __init__(
+        self,
+        key: bytes,
+        scope: ChannelScope,
+        *,
+        max_clock_skew_seconds: int = 30,
+    ):
+        if not isinstance(key, bytes) or len(key) < 32:
+            raise ValueError("channel key must contain at least 32 bytes")
+        self.key = key
+        self.scope = scope
+        self.max_clock_skew_seconds = max_clock_skew_seconds
+        self.expected_sequence = 1
+        self.used_nonces: set[str] = set()
+
+    def command(
+        self,
+        *,
+        sequence: int,
+        operation: str,
+        payload: Mapping[str, Any],
+        expires_at: int,
+        nonce: str | None = None,
+    ) -> dict:
+        encoded_payload = _encode_value(dict(payload))
+        envelope = {
+            "protocol_version": PROTOCOL_VERSION,
+            "run_id": self.scope.run_id,
+            "condition": self.scope.condition,
+            "task_id": self.scope.task_id,
+            "sequence": sequence,
+            "nonce": nonce or secrets.token_hex(24),
+            "expires_at": expires_at,
+            "operation": operation,
+            "payload": encoded_payload,
+            "payload_sha256": _digest(encoded_payload),
+        }
+        envelope["mac"] = self._mac(envelope)
+        return envelope
+
+    def result(
+        self,
+        *,
+        command: Mapping[str, Any],
+        payload: Mapping[str, Any],
+        expires_at: int,
+    ) -> dict:
+        encoded_payload = _encode_value(dict(payload))
+        envelope = {
+            "protocol_version": PROTOCOL_VERSION,
+            "run_id": command["run_id"],
+            "condition": command["condition"],
+            "task_id": command["task_id"],
+            "sequence": command["sequence"],
+            "nonce": command["nonce"],
+            "expires_at": expires_at,
+            "command_sha256": _digest(_without_mac(command)),
+            "payload": encoded_payload,
+            "payload_sha256": _digest(encoded_payload),
+        }
+        envelope["mac"] = self._mac(envelope)
+        return envelope
+
+    def verify_command(
+        self, envelope: Mapping[str, Any], *, now: int | None = None
+    ) -> dict:
+        self._verify_common(envelope, now=now)
+        required = {
+            "protocol_version", "run_id", "condition", "task_id", "sequence",
+            "nonce", "expires_at", "operation", "payload", "payload_sha256",
+            "mac",
+        }
+        if set(envelope) != required:
+            raise ChannelError("command_fields_invalid")
+        if not isinstance(envelope.get("operation"), str) or not envelope["operation"]:
+            raise ChannelError("command_operation_invalid")
+        self._consume(envelope)
+        return _decode_value(envelope["payload"])
+
+    def verify_result(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        command: Mapping[str, Any],
+        now: int | None = None,
+    ) -> dict:
+        self._verify_common(envelope, now=now)
+        required = {
+            "protocol_version", "run_id", "condition", "task_id", "sequence",
+            "nonce", "expires_at", "command_sha256", "payload",
+            "payload_sha256", "mac",
+        }
+        if set(envelope) != required:
+            raise ChannelError("result_fields_invalid")
+        if envelope.get("command_sha256") != _digest(_without_mac(command)):
+            raise ChannelError("result_command_mismatch")
+        if envelope.get("nonce") != command.get("nonce"):
+            raise ChannelError("result_nonce_mismatch")
+        self._consume(envelope)
+        return _decode_value(envelope["payload"])
+
+    def _verify_common(
+        self, envelope: Mapping[str, Any], *, now: int | None
+    ) -> None:
+        if not isinstance(envelope, Mapping):
+            raise ChannelError("envelope_not_object")
+        if envelope.get("protocol_version") != PROTOCOL_VERSION:
+            raise ChannelError("protocol_mismatch")
+        expected = {
+            "run_id": self.scope.run_id,
+            "condition": self.scope.condition,
+            "task_id": self.scope.task_id,
+        }
+        if any(envelope.get(key) != value for key, value in expected.items()):
+            raise ChannelError("cross_scope_envelope")
+        sequence = envelope.get("sequence")
+        if type(sequence) is not int or sequence != self.expected_sequence:
+            raise ChannelError("out_of_order_envelope")
+        nonce = envelope.get("nonce")
+        if not isinstance(nonce, str) or len(nonce) < 32:
+            raise ChannelError("nonce_invalid")
+        if nonce in self.used_nonces:
+            raise ChannelError("replayed_envelope")
+        expires_at = envelope.get("expires_at")
+        current = int(time.time()) if now is None else now
+        if type(expires_at) is not int or expires_at < current:
+            raise ChannelError("expired_envelope")
+        if expires_at > current + self.max_clock_skew_seconds + 300:
+            raise ChannelError("envelope_expiry_too_far")
+        if envelope.get("payload_sha256") != _digest(envelope.get("payload")):
+            raise ChannelError("payload_digest_mismatch")
+        supplied_mac = envelope.get("mac")
+        if not isinstance(supplied_mac, str) or not hmac.compare_digest(
+            supplied_mac, self._mac(envelope)
+        ):
+            raise ChannelError("envelope_mac_invalid")
+
+    def _consume(self, envelope: Mapping[str, Any]) -> None:
+        self.used_nonces.add(str(envelope["nonce"]))
+        self.expected_sequence += 1
+
+    def _mac(self, envelope: Mapping[str, Any]) -> str:
+        return hmac.new(
+            self.key,
+            _canonical(_without_mac(envelope)),
+            hashlib.sha256,
+        ).hexdigest()
+
+
+class ComputeChannelServer:
+    """Uncredentialed server-side dispatcher for one authenticated task."""
+
+    def __init__(
+        self,
+        authority: EnvelopeAuthority,
+        backend_factory: Callable[..., Any],
+        max_commands: int = 16,
+        result_ttl_seconds: int = 60,
+        backend_lease_seconds: float = 1260.0,
+    ):
+        if not 1 <= result_ttl_seconds <= 300:
+            raise ValueError("result TTL must be between 1 and 300 seconds")
+        if not 0 < backend_lease_seconds <= 1800:
+            raise ValueError("backend lease must be in (0, 1800] seconds")
+        self.authority = authority
+        self.backend_factory = backend_factory
+        self.backend: Any = None
+        self.max_commands = max_commands
+        self.result_ttl_seconds = result_ttl_seconds
+        self.backend_lease_seconds = backend_lease_seconds
+        self.command_count = 0
+        self.lock = threading.Lock()
+        self._lease_timer: threading.Timer | None = None
+        self._last_command_sha256: str | None = None
+        self._last_result: dict | None = None
+
+    def handle(self, envelope: Mapping[str, Any]) -> dict:
+        with self.lock:
+            command_sha256 = _digest(_without_mac(envelope))
+            if (
+                command_sha256 == self._last_command_sha256
+                and self._last_result is not None
+            ):
+                return dict(self._last_result)
+            if self.command_count >= self.max_commands:
+                raise ChannelError("compute_command_cap_exhausted")
+            payload = self.authority.verify_command(envelope)
+            operation = envelope["operation"]
+            try:
+                if operation == "start":
+                    if self.backend is not None:
+                        raise ChannelError("backend_already_started")
+                    task_spec = payload.get("task_spec")
+                    if not isinstance(task_spec, dict):
+                        raise ChannelError("task_spec_invalid")
+                    self.backend = self.backend_factory(**task_spec)
+                    result = self.backend.start(payload["timeout_seconds"])
+                else:
+                    if self.backend is None:
+                        raise ChannelError("backend_not_started")
+                    result = self._dispatch(operation, payload)
+            except Exception:
+                if operation == "start":
+                    self._close_backend_locked()
+                raise
+            self.command_count += 1
+            signed_result = self.authority.result(
+                command=envelope,
+                payload=dict(result),
+                expires_at=int(time.time()) + self.result_ttl_seconds,
+            )
+            self._last_command_sha256 = command_sha256
+            self._last_result = dict(signed_result)
+            if operation == "close":
+                self._cancel_lease_locked()
+            else:
+                self._arm_lease_locked()
+            return signed_result
+
+    def _dispatch(self, operation: str, payload: Mapping[str, Any]):
+        if operation == "inspect_workspace":
+            return self.backend.inspect_workspace(payload["timeout_seconds"])
+        if operation == "inspect_environment":
+            return self.backend.inspect_environment(payload["timeout_seconds"])
+        if operation == "reset_work":
+            return self.backend.reset_work(payload["timeout_seconds"])
+        if operation == "run_python":
+            return self.backend.run_python(
+                payload["source"], payload["timeout_seconds"]
+            )
+        if operation == "run_ffmpeg":
+            return self.backend.run_ffmpeg(
+                payload["operation"], payload["timeout_seconds"]
+            )
+        if operation == "inspect_artifacts":
+            return self.backend.inspect_artifacts(payload["timeout_seconds"])
+        if operation == "finalize":
+            result = self.backend.finalize(
+                payload["deliverables"], payload["summary"],
+                payload["timeout_seconds"],
+            )
+            terminal = self.backend.best_result()
+            return {**dict(result), "terminal_result": terminal}
+        if operation == "close":
+            self._close_backend_locked()
+            return {"ok": True, "data": {}}
+        raise ChannelError("unknown_compute_operation")
+
+    def close(self) -> None:
+        with self.lock:
+            self._close_backend_locked()
+            self._cancel_lease_locked()
+
+    def _arm_lease_locked(self) -> None:
+        self._cancel_lease_locked()
+        timer = threading.Timer(
+            self.backend_lease_seconds, self._expire_backend
+        )
+        timer.daemon = True
+        self._lease_timer = timer
+        timer.start()
+
+    def _cancel_lease_locked(self) -> None:
+        if self._lease_timer is not None:
+            self._lease_timer.cancel()
+            self._lease_timer = None
+
+    def _expire_backend(self) -> None:
+        with self.lock:
+            self._close_backend_locked()
+            self._lease_timer = None
+
+    def _close_backend_locked(self) -> None:
+        backend = self.backend
+        self.backend = None
+        if backend is not None:
+            backend.close()
+
+
+class InMemoryComputeTransport:
+    """Model-free transport used to falsify the envelope protocol."""
+
+    def __init__(self, server: ComputeChannelServer):
+        self.server = server
+
+    def exchange(self, envelope: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self.server.handle(envelope)
+
+
+class AuthenticatedComputeBackend:
+    """Control-plane proxy; transport must provide mTLS outside this module."""
+
+    def __init__(
+        self,
+        *,
+        authority: EnvelopeAuthority,
+        transport: ComputeTransport,
+        task_spec: Mapping[str, Any],
+        ttl_seconds: int = 60,
+        max_transport_retries: int = 1,
+    ):
+        self.authority = authority
+        self.transport = transport
+        self.task_spec = dict(task_spec)
+        self.ttl_seconds = ttl_seconds
+        if max_transport_retries not in (0, 1):
+            raise ValueError("compute transport retries must be 0 or 1")
+        self.max_transport_retries = max_transport_retries
+        self.sequence = 0
+        self._best_result = None
+
+    def start(self, timeout_seconds=1200.0):
+        return self._exchange("start", {
+            "task_spec": self.task_spec,
+            "timeout_seconds": timeout_seconds,
+        })
+
+    def inspect_workspace(self, timeout_seconds=1200.0):
+        return self._exchange("inspect_workspace", {
+            "timeout_seconds": timeout_seconds,
+        })
+
+    def inspect_environment(self, timeout_seconds=1200.0):
+        return self._exchange("inspect_environment", {
+            "timeout_seconds": timeout_seconds,
+        })
+
+    def reset_work(self, timeout_seconds=1200.0):
+        return self._exchange("reset_work", {"timeout_seconds": timeout_seconds})
+
+    def run_python(self, source, timeout_seconds):
+        return self._exchange("run_python", {
+            "source": source,
+            "timeout_seconds": timeout_seconds,
+        })
+
+    def run_ffmpeg(self, operation, timeout_seconds):
+        return self._exchange("run_ffmpeg", {
+            "operation": dict(operation),
+            "timeout_seconds": timeout_seconds,
+        })
+
+    def inspect_artifacts(self, timeout_seconds=1200.0):
+        return self._exchange("inspect_artifacts", {
+            "timeout_seconds": timeout_seconds,
+        })
+
+    def finalize(self, deliverables, summary, timeout_seconds=1200.0):
+        result = self._exchange("finalize", {
+            "deliverables": list(deliverables),
+            "summary": summary,
+            "timeout_seconds": timeout_seconds,
+        })
+        self._best_result = result.pop("terminal_result", None)
+        return result
+
+    def best_result(self):
+        return self._best_result
+
+    def close(self):
+        try:
+            self._exchange("close", {})
+        except Exception:
+            pass
+
+    def _exchange(self, operation: str, payload: Mapping[str, Any]) -> dict:
+        self.sequence += 1
+        expires_at = int(time.time()) + self.ttl_seconds
+        command = self.authority.command(
+            sequence=self.sequence,
+            operation=operation,
+            payload=payload,
+            expires_at=expires_at,
+        )
+        last_error: Exception | None = None
+        decoded = None
+        for _ in range(self.max_transport_retries + 1):
+            try:
+                raw_result = self.transport.exchange(command)
+                decoded = self.authority.verify_result(
+                    raw_result,
+                    command=command,
+                )
+                break
+            except Exception as exc:
+                last_error = exc
+        if decoded is None:
+            assert last_error is not None
+            raise last_error
+        if not isinstance(decoded, dict):
+            raise ChannelError("compute_result_not_object")
+        return decoded
+
+
+def _encode_value(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return {"$bytes": base64.b64encode(value).decode("ascii")}
+    if isinstance(value, Mapping):
+        return {str(key): _encode_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_encode_value(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise TypeError(f"channel value is not serializable: {type(value).__name__}")
+
+
+def _decode_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        if set(value) == {"$bytes"}:
+            return base64.b64decode(value["$bytes"], validate=True)
+        return {str(key): _decode_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_decode_value(item) for item in value]
+    return value
+
+
+def _without_mac(value: Mapping[str, Any]) -> dict:
+    return {key: item for key, item in value.items() if key != "mac"}
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()

--- a/batch-runner/core/agentic_compute.py
+++ b/batch-runner/core/agentic_compute.py
@@ -1,0 +1,1526 @@
+"""Uncredentialed persistent Docker compute plane for agentic tasks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import shutil
+import signal
+import stat
+import subprocess
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+
+MAX_INPUT_FILES = 256
+MAX_INPUT_TOTAL = 2 * 1024 * 1024 * 1024
+MAX_INPUT_SINGLE = 512 * 1024 * 1024
+MAX_WORK_FILES = 64
+MAX_WORK_TOTAL = 512 * 1024 * 1024
+MAX_WORK_SINGLE = 256 * 1024 * 1024
+MAX_DEPTH = 16
+MAX_PATH_BYTES = 240
+OUTPUT_LIMIT = 32768
+FFMPEG_INPUT_SUFFIXES = {
+    ".wav", ".mp3", ".m4a", ".flac", ".ogg", ".aac",
+    ".mp4", ".mov", ".avi", ".mkv", ".webm",
+}
+
+
+class AgenticDockerBackend:
+    """One persistent task container plus disposable verifier containers."""
+
+    def __init__(
+        self,
+        *,
+        task_prompt: str,
+        reference_files: list[Any],
+        occupation: str,
+        image: str,
+        verifier_image: Optional[str] = None,
+        seccomp_profile: Optional[str] = None,
+        apparmor_profile: str = "docker-default",
+        cpus: float = 2.0,
+        memory_gb: int = 8,
+        allow_unpinned_image: bool = False,
+        require_rootless_or_userns: bool = True,
+        enforce_cpu_limit: bool = True,
+        enforce_pid_limit: bool = True,
+        enforce_outer_seccomp: bool = True,
+        enforce_procfs_policy: bool = True,
+        provider_classification: str = "approved_public_gdpval",
+        approved_input_manifest: Optional[Mapping[str, Mapping[str, Any]]] = None,
+        require_approved_input_manifest: bool = True,
+        expected_input_merkle_root: Optional[str] = None,
+        sbom_sha256: Optional[str] = None,
+        require_supply_chain_identity: bool = True,
+        require_dedicated_host: bool = True,
+        local_root_parent: Optional[str] = None,
+        docker_root_parent: Optional[str] = None,
+        docker_binary: str = "docker",
+    ):
+        if not image or ("@sha256:" not in image and not allow_unpinned_image):
+            raise ValueError("agentic image must be pinned by sha256 digest")
+        if not isinstance(memory_gb, int) or memory_gb <= 0 or memory_gb > 8:
+            raise ValueError("memory_gb must be in [1, 8]")
+        if not isinstance(cpus, (int, float)) or cpus <= 0 or cpus > 2:
+            raise ValueError("cpus must be in (0, 2]")
+        self.task_prompt = task_prompt
+        self.reference_files = list(reference_files)
+        self.occupation = occupation
+        self.image = image
+        self.verifier_image = verifier_image or image
+        self.seccomp_profile = Path(
+            seccomp_profile
+            or Path(__file__).resolve().parent.parent / "sandbox" / "agentic-seccomp.json"
+        ).resolve()
+        if not self.seccomp_profile.is_file():
+            raise ValueError("agentic seccomp profile is missing")
+        self.apparmor_profile = apparmor_profile
+        if not apparmor_profile or apparmor_profile == "unconfined":
+            raise ValueError("an enforcing AppArmor profile is required")
+        self.cpus = float(cpus)
+        self.memory_gb = memory_gb
+        self.docker = docker_binary
+        self.require_rootless_or_userns = require_rootless_or_userns
+        self.enforce_cpu_limit = enforce_cpu_limit
+        self.enforce_pid_limit = enforce_pid_limit
+        self.enforce_outer_seccomp = enforce_outer_seccomp
+        self.enforce_procfs_policy = enforce_procfs_policy
+        if not provider_classification:
+            raise ValueError("provider_classification is required")
+        self.provider_classification = provider_classification
+        self.approved_input_manifest = (
+            dict(approved_input_manifest)
+            if isinstance(approved_input_manifest, Mapping)
+            else None
+        )
+        self.require_approved_input_manifest = require_approved_input_manifest
+        self.expected_input_merkle_root = expected_input_merkle_root
+        if require_supply_chain_identity and (
+            not isinstance(sbom_sha256, str)
+            or len(sbom_sha256) != 64
+        ):
+            raise ValueError("pinned agentic SBOM hash is required")
+        self.sbom_sha256 = sbom_sha256 or "nonpaid-unpinned"
+        self.require_supply_chain_identity = require_supply_chain_identity
+        self.require_dedicated_host = require_dedicated_host
+        if docker_root_parent and not local_root_parent:
+            raise ValueError("docker_root_parent requires local_root_parent")
+        if local_root_parent:
+            Path(local_root_parent).mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.root = Path(tempfile.mkdtemp(
+            prefix="gdpval-agentic-compute-",
+            dir=local_root_parent,
+        ))
+        self.docker_root = (
+            Path(docker_root_parent) / self.root.name
+            if docker_root_parent
+            else self.root
+        )
+        self.inputs_dir = self.root / "inputs"
+        self.snapshots_dir = self.root / "snapshots"
+        self.inputs_dir.mkdir(mode=0o700)
+        self.snapshots_dir.mkdir(mode=0o700)
+        self.container_name = f"gdpval-agentic-{uuid.uuid4().hex[:16]}"
+        self.work_volume_name = f"{self.container_name}-work"
+        self.container_started = False
+        self.work_volume_created = False
+        self.poisoned = False
+        self.input_records: list[dict] = []
+        self.input_hashes: set[str] = set()
+        self.input_merkle_root = ""
+        self.latest_snapshot: Optional[Path] = None
+        self.latest_verification: Optional[dict] = None
+        self._best_result: Optional[dict] = None
+        self.image_id = ""
+        self.verifier_image_id = ""
+
+    def start(self, timeout_seconds: float = 1200.0) -> Mapping[str, Any]:
+        deadline = _operation_deadline(timeout_seconds)
+        try:
+            self._verify_host_runtime()
+            _remaining_timeout(deadline, 1200.0)
+            self._verify_verifier_image_components()
+            _remaining_timeout(deadline, 1200.0)
+            self._stage_inputs()
+            _remaining_timeout(deadline, 1200.0)
+            if (
+                self.expected_input_merkle_root is not None
+                and self.input_merkle_root != self.expected_input_merkle_root
+            ):
+                return _error("approved_input_merkle_mismatch")
+            self._create_work_volume()
+            command = self._task_container_command()
+            result = self._run(
+                command, timeout=_remaining_timeout(deadline, 120.0)
+            )
+            if result.returncode != 0:
+                return _error("container_start_failed")
+            container_id = result.stdout.decode("utf-8", errors="replace").strip()
+            if not container_id:
+                return _error("container_start_failed")
+            self.container_started = True
+            self._verify_runtime()
+            self._assert_pid1_only()
+            _remaining_timeout(deadline, 1200.0)
+            return {
+                "ok": True,
+                "data": {
+                    "inputs": [
+                        {"path": record["model_path"], "size_bytes": record["size_bytes"]}
+                        for record in self.input_records
+                    ],
+                    "input_count": len(self.input_records),
+                    "input_merkle_root": self.input_merkle_root,
+                    "provider_classification": self.provider_classification,
+                    "substrate_manifest": self.substrate_manifest(),
+                },
+            }
+        except Exception:
+            self.poisoned = True
+            self._remove_container()
+            return _error("container_preflight_failed")
+
+    def inspect_workspace(
+        self, timeout_seconds: float = 1200.0
+    ) -> Mapping[str, Any]:
+        if not self._ready():
+            return _error("compute_unavailable")
+        try:
+            snapshot, _ = self._snapshot(
+                deadline=_operation_deadline(timeout_seconds)
+            )
+            files = self._strict_snapshot_files(snapshot)
+            return {
+                "ok": True,
+                "data": {
+                    "inputs": [
+                        {"path": item["model_path"], "size_bytes": item["size_bytes"]}
+                        for item in self.input_records
+                    ],
+                    "work": [
+                        {
+                            "path": f"work/{path.relative_to(snapshot).as_posix()}",
+                            "size_bytes": path.stat().st_size,
+                        }
+                        for path in files
+                        if not _is_internal(path.relative_to(snapshot))
+                    ],
+                },
+            }
+        except Exception:
+            self.poisoned = True
+            return _error("workspace_inspection_failed")
+
+    def inspect_environment(
+        self, timeout_seconds: float = 1200.0
+    ) -> Mapping[str, Any]:
+        if not self._ready():
+            return _error("compute_unavailable")
+        command = [
+            self.docker, "exec", "-i", "--user", "65532:65532",
+            self.container_name, "python", "-I", "-B", "-c",
+            "import pathlib,sys;print(pathlib.Path('/opt/gdpval/agentic-capabilities.json').read_text())",
+        ]
+        deadline = _operation_deadline(timeout_seconds)
+        result = self._run(
+            command, timeout=_remaining_timeout(deadline, 30.0)
+        )
+        try:
+            payload = json.loads(result.stdout.decode("utf-8"))
+        except Exception:
+            return _error("capability_manifest_unavailable")
+        return {"ok": True, "data": payload}
+
+    def reset_work(self, timeout_seconds: float = 1200.0) -> Mapping[str, Any]:
+        """Restore a fresh attempt workspace without replacing its quota mount."""
+        if not self._ready():
+            return _error("compute_unavailable")
+        script = (
+            "import pathlib,shutil;root=pathlib.Path('/work');"
+            "hidden={'.home','.tmp','.cache','.config'};"
+            "[(shutil.rmtree(p) if p.is_dir() else p.unlink()) "
+            "for p in list(root.iterdir()) if p.name not in hidden];"
+            "[(shutil.rmtree(p,ignore_errors=True),p.mkdir(mode=0o700,parents=True,exist_ok=True)) "
+            "for p in [root/name for name in hidden]]"
+        )
+        deadline = _operation_deadline(timeout_seconds)
+        result = self._run([
+            self.docker, "exec", "-i", "--user", "65532:65532",
+            self.container_name, "python", "-I", "-B", "-c", script,
+        ], timeout=_remaining_timeout(deadline, 30.0))
+        if result.returncode != 0:
+            self.poisoned = True
+            return _error("workspace_reset_failed")
+        try:
+            self._assert_pid1_only(deadline)
+        except Exception:
+            self.poisoned = True
+            return _error("process_leak")
+        self.latest_snapshot = None
+        self.latest_verification = None
+        self._best_result = None
+        return {"ok": True, "data": {}}
+
+    def substrate_manifest(self) -> dict:
+        manifest = {
+            "schema_version": "1.0",
+            "task_image": self.image,
+            "task_image_id": self.image_id,
+            "verifier_image": self.verifier_image,
+            "verifier_image_id": self.verifier_image_id,
+            "component_sha256": self._component_hashes(),
+            "sbom_sha256": self.sbom_sha256,
+            "uid": 65532,
+            "gid": 65532,
+            "network": "none",
+            "ipc": "none",
+            "pid_namespace": "private",
+            "read_only_rootfs": True,
+            "cap_drop": ["ALL"],
+            "no_new_privileges": True,
+            "work_tmpfs": {
+                "size_bytes": 536870912,
+                "nr_inodes": 1024,
+                "nosuid": True,
+                "nodev": True,
+                "noexec": True,
+            },
+            "memory_bytes": self.memory_gb * 1024 * 1024 * 1024,
+            "memory_swap_bytes": self.memory_gb * 1024 * 1024 * 1024,
+            "cpus": self.cpus,
+            "pids": 128,
+            "nofile": 256,
+            "apparmor_profile": self.apparmor_profile,
+        }
+        manifest["sha256"] = hashlib.sha256(
+            json.dumps(
+                manifest, sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+        ).hexdigest()
+        return manifest
+
+    def run_python(self, source: str, timeout_seconds: float) -> Mapping[str, Any]:
+        if not self._ready():
+            return _error("compute_unavailable")
+        command = [
+            self.docker, "exec", "-i", "--user", "65532:65532",
+            "--env", "HOME=/work/.home", "--env", "TMPDIR=/work/.tmp",
+            "--env", "XDG_CACHE_HOME=/work/.cache",
+            "--env", "XDG_CONFIG_HOME=/work/.config",
+            self.container_name, "python", "-I", "-B", "-u",
+            "/opt/gdpval/core/agentic_python_launcher.py",
+        ]
+        deadline = _operation_deadline(timeout_seconds)
+        try:
+            result = self._run_tool(
+                command,
+                input_data=source.encode("utf-8"),
+            timeout=_remaining_timeout(deadline, timeout_seconds),
+            )
+        except subprocess.TimeoutExpired:
+            self.poisoned = True
+            self._remove_container()
+            return _error("python_timeout")
+        if (
+            len(result.stdout) >= OUTPUT_LIMIT
+            or len(result.stderr) >= OUTPUT_LIMIT
+            or result.returncode == -signal.SIGXFSZ
+        ):
+            self.poisoned = True
+            self._remove_container()
+            return _error("python_output_limit")
+        try:
+            self._assert_pid1_only(deadline)
+        except Exception:
+            self.poisoned = True
+            self._remove_container()
+            return _error("process_leak")
+        return {
+            "ok": result.returncode == 0,
+            **({"error_type": "python_execution_failed", "retryable": True}
+               if result.returncode != 0 else {}),
+            "data": {
+                "returncode": result.returncode,
+                "stdout_tail": _bounded_text(result.stdout),
+                "stderr_tail": _bounded_text(result.stderr),
+            },
+        }
+
+    def run_ffmpeg(
+        self, operation: Mapping[str, Any], timeout_seconds: float = 660.0
+    ) -> Mapping[str, Any]:
+        if not self._ready():
+            return _error("compute_unavailable")
+        deadline = _operation_deadline(timeout_seconds)
+        try:
+            command = self._ffmpeg_command(operation)
+        except ValueError:
+            return _error("ffmpeg_path_violation")
+        try:
+            operation_timeout = min(
+                660.0,
+                float(operation.get("duration_seconds", 1)) + 60.0,
+                _remaining_timeout(deadline, timeout_seconds),
+            )
+            result = self._run_tool(command, timeout=operation_timeout)
+        except subprocess.TimeoutExpired:
+            self.poisoned = True
+            self._remove_container()
+            return _error("ffmpeg_timeout")
+        if (
+            len(result.stdout) >= OUTPUT_LIMIT
+            or len(result.stderr) >= OUTPUT_LIMIT
+            or result.returncode == -signal.SIGXFSZ
+        ):
+            self.poisoned = True
+            self._remove_container()
+            return _error("ffmpeg_output_limit")
+        try:
+            self._assert_pid1_only(deadline)
+        except Exception:
+            self.poisoned = True
+            self._remove_container()
+            return _error("process_leak")
+        data: dict[str, Any] = {
+            "returncode": result.returncode,
+            "stderr_tail": _bounded_text(result.stderr),
+        }
+        if operation.get("operation") == "probe" and result.returncode == 0:
+            try:
+                data["metadata"] = _normalize_probe_metadata(result.stdout)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                return _error("ffprobe_result_invalid")
+        return {
+            "ok": result.returncode == 0,
+            **({"error_type": "ffmpeg_execution_failed", "retryable": True}
+               if result.returncode != 0 else {}),
+            "data": data,
+        }
+
+    def inspect_artifacts(
+        self, timeout_seconds: float = 1200.0
+    ) -> Mapping[str, Any]:
+        if not self._ready():
+            return _error("compute_unavailable")
+        try:
+            snapshot, verification = self._snapshot(
+                verify=True,
+                deadline=_operation_deadline(timeout_seconds),
+            )
+            self._strict_snapshot_files(snapshot)
+            assert verification is not None
+            if verification.get("ok") is True:
+                if not self._verification_matches_snapshot(
+                    verification, snapshot
+                ):
+                    return _error("snapshot_hash_mismatch")
+                self.latest_snapshot = snapshot
+                self.latest_verification = verification
+                self._best_result = self._snapshot_result(
+                    snapshot, verification, success=False, summary=""
+                )
+            return verification
+        except Exception:
+            return _error("artifact_inspection_failed")
+
+    def finalize(
+        self,
+        deliverables: list[str],
+        summary: str,
+        timeout_seconds: float = 1200.0,
+    ) -> Mapping[str, Any]:
+        deadline = _operation_deadline(timeout_seconds)
+        inspected = self.inspect_artifacts(
+            _remaining_timeout(deadline, timeout_seconds)
+        )
+        if inspected.get("ok") is not True:
+            return inspected
+        assert self.latest_snapshot is not None
+        data = inspected.get("data") or {}
+        verified = {
+            item.get("path"): item
+            for item in data.get("artifacts", [])
+            if isinstance(item, dict)
+        }
+        normalized: list[str] = []
+        for raw in deliverables:
+            relative = _normalize_model_path(raw, output=True)
+            if relative not in verified:
+                return _error("unverified_deliverable")
+            if relative in normalized:
+                return _error("duplicate_deliverable")
+            normalized.append(relative)
+        try:
+            snapshot, selected_verification = self._snapshot(
+                verify=True,
+                selected_deliverables=normalized,
+                deadline=deadline,
+            )
+            if (
+                selected_verification is None
+                or selected_verification.get("ok") is not True
+                or not self._verification_matches_snapshot(
+                    selected_verification,
+                    snapshot,
+                    selected_deliverables=normalized,
+                )
+            ):
+                return _error("selected_deliverable_verification_failed")
+            self.latest_snapshot = snapshot
+            self.latest_verification = selected_verification
+            self._best_result = self._snapshot_result(
+                snapshot,
+                selected_verification,
+                success=True,
+                summary=summary,
+            )
+        except ValueError:
+            return _error("snapshot_hash_mismatch")
+        return {"ok": True, "data": {"artifact_count": len(normalized)}}
+
+    def best_result(self) -> Mapping[str, Any] | None:
+        return self._best_result
+
+    @staticmethod
+    def _snapshot_result(
+        snapshot: Path,
+        verification: Mapping[str, Any],
+        *,
+        success: bool,
+        summary: str,
+    ) -> dict:
+        data = verification.get("data") or {}
+        files = []
+        for item in data.get("artifacts", []):
+            if not isinstance(item, Mapping):
+                raise ValueError("invalid artifact verification")
+            relative = item.get("path")
+            expected_hash = item.get("sha256")
+            if not isinstance(relative, str) or not isinstance(expected_hash, str):
+                raise ValueError("invalid artifact verification")
+            path = snapshot / relative
+            content = path.read_bytes()
+            if hashlib.sha256(content).hexdigest() != expected_hash:
+                raise ValueError("snapshot hash mismatch")
+            files.append({"filename": relative, "content": content})
+        if not files:
+            raise ValueError("verified snapshot is empty")
+        return {
+            "success": success,
+            "text": summary,
+            "deliverable_text": summary,
+            "files": files,
+        }
+
+    def close(self) -> None:
+        self._remove_container()
+        self._remove_work_volume()
+        for directory in [
+            self.inputs_dir,
+            *(
+                path for path in self.inputs_dir.rglob("*")
+                if path.is_dir()
+            ),
+        ]:
+            try:
+                os.chmod(directory, 0o700, follow_symlinks=False)
+            except OSError:
+                pass
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _stage_inputs(self) -> None:
+        if self.require_approved_input_manifest and self.approved_input_manifest is None:
+            raise ValueError("approved input manifest is required")
+        if len(self.reference_files) > MAX_INPUT_FILES:
+            raise ValueError("input_file_count_limit")
+        total = 0
+        relative_paths: set[str] = set()
+        records: list[dict] = []
+        for raw_reference in self.reference_files:
+            if isinstance(raw_reference, Mapping):
+                source_value = raw_reference.get("source_path")
+                relative_value = raw_reference.get("relative_path")
+                if not isinstance(source_value, str) or not isinstance(
+                    relative_value, str
+                ):
+                    raise ValueError("input mapping requires source_path and relative_path")
+                source = Path(source_value)
+                relative = Path(relative_value)
+            else:
+                if self.require_approved_input_manifest:
+                    raise ValueError(
+                        "approved inputs require explicit canonical relative paths"
+                    )
+                source = Path(str(raw_reference))
+                relative = Path(source.name)
+            if (
+                relative.is_absolute()
+                or not relative.parts
+                or ".." in relative.parts
+                or any(part.startswith(".") for part in relative.parts)
+                or len(relative.parts) > MAX_DEPTH
+                or len(relative.as_posix().encode("utf-8")) > MAX_PATH_BYTES
+            ):
+                raise ValueError("input relative path violation")
+            relative_path = relative.as_posix()
+            if relative_path in relative_paths:
+                raise ValueError("input_name_violation")
+            relative_paths.add(relative_path)
+            try:
+                descriptor = _open_regular_nofollow(source)
+            except OSError as exc:
+                raise ValueError("input_type_or_link_violation") from exc
+            try:
+                metadata = os.fstat(descriptor)
+                if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                    raise ValueError("input_type_or_link_violation")
+                if metadata.st_size > MAX_INPUT_SINGLE:
+                    raise ValueError("input_file_size_limit")
+                destination = self.inputs_dir / relative
+                destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                digest = hashlib.sha256()
+                copied = 0
+                with os.fdopen(os.dup(descriptor), "rb") as input_stream, destination.open("xb") as output:
+                    for chunk in iter(lambda: input_stream.read(65536), b""):
+                        copied += len(chunk)
+                        if copied > MAX_INPUT_SINGLE:
+                            raise ValueError("input_file_size_limit")
+                        digest.update(chunk)
+                        output.write(chunk)
+                after = os.fstat(descriptor)
+                source_digest = _sha256_descriptor(descriptor)
+                if _source_identity(after) != _source_identity(metadata):
+                    raise ValueError("input_source_race")
+                if source_digest != digest.hexdigest() or copied != metadata.st_size:
+                    raise ValueError("input_source_race")
+            finally:
+                os.close(descriptor)
+            os.chmod(destination, 0o444)
+            total += copied
+            if total > MAX_INPUT_TOTAL:
+                raise ValueError("input_total_size_limit")
+            staged_digest = hashlib.sha256(destination.read_bytes()).hexdigest()
+            if staged_digest != digest.hexdigest():
+                raise ValueError("staged input hash mismatch")
+            staged = destination.lstat()
+            if (
+                not stat.S_ISREG(staged.st_mode)
+                or staged.st_nlink != 1
+                or staged.st_size != copied
+            ):
+                raise ValueError("staged input identity mismatch")
+            record = {
+                "path": relative_path,
+                "model_path": f"inputs/{relative_path}",
+                "type": "regular",
+                "link_count": 1,
+                "size_bytes": copied,
+                "source_allocated_bytes": metadata.st_blocks * 512,
+                "staged_allocated_bytes": staged.st_blocks * 512,
+                "sha256": digest.hexdigest(),
+                "provider_classification": (
+                    (self.approved_input_manifest or {}).get(
+                        relative_path, {}
+                    ).get(
+                        "provider_classification",
+                        self.provider_classification,
+                    )
+                ),
+            }
+            expected = (self.approved_input_manifest or {}).get(relative_path)
+            if expected is not None:
+                if not isinstance(expected, Mapping):
+                    raise ValueError("approved input record is invalid")
+                approved_fields = {
+                    "path", "type", "link_count", "size_bytes",
+                    "source_allocated_bytes", "sha256",
+                    "provider_classification",
+                }
+                if set(expected) != approved_fields:
+                    raise ValueError("approved input record fields are invalid")
+                comparable = {
+                    key: record[key]
+                    for key in approved_fields
+                }
+                if dict(expected) != comparable:
+                    raise ValueError("approved input identity mismatch")
+            records.append(record)
+        if self.approved_input_manifest is not None and set(
+            self.approved_input_manifest
+        ) != {record["path"] for record in records}:
+            raise ValueError("approved input manifest has missing or extra files")
+        for directory in sorted(
+            (path for path in self.inputs_dir.rglob("*") if path.is_dir()),
+            key=lambda path: len(path.parts),
+            reverse=True,
+        ):
+            os.chmod(directory, 0o555)
+        os.chmod(self.inputs_dir, 0o555)
+        self.input_records = sorted(records, key=lambda item: item["path"].encode("utf-8"))
+        self.input_hashes = {record["sha256"] for record in records}
+        self.input_merkle_root = hashlib.sha256(
+            json.dumps(
+                self.input_records, sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+        ).hexdigest()
+
+    def _task_container_command(self) -> list[str]:
+        memory = f"{self.memory_gb}g"
+        command = [
+            self.docker, "run", "--detach", "--rm", "--name", self.container_name,
+            "--network", "none", "--ipc", "none",
+            "--read-only", "--cap-drop", "ALL",
+            "--memory", memory, "--memory-swap", memory,
+            "--ulimit", "nofile=256:256", "--user", "65532:65532",
+            "--security-opt", "no-new-privileges",
+            "--security-opt", f"apparmor={self.apparmor_profile}",
+            "--env", "HOME=/verify-work/.home",
+            "--env", "TMPDIR=/verify-work/.tmp",
+            "--env", "XDG_CACHE_HOME=/verify-work/.cache",
+            "--env", "XDG_CONFIG_HOME=/verify-work/.config",
+            "--env", "MPLCONFIGDIR=/verify-work/.cache/matplotlib",
+            "--mount", (
+                f"type=volume,src={self.work_volume_name},dst=/work,"
+                "volume-nocopy"
+            ),
+            "--mount", (
+                f"type=bind,src={self._docker_path(self.inputs_dir)},"
+                "dst=/inputs,readonly,bind-propagation=rprivate"
+            ),
+            "--env", "HOME=/work/.home", "--env", "TMPDIR=/work/.tmp",
+            "--env", "XDG_CACHE_HOME=/work/.cache",
+            "--env", "XDG_CONFIG_HOME=/work/.config",
+        ]
+        if self.enforce_pid_limit:
+            command += ["--pids-limit", "128"]
+        if self.enforce_outer_seccomp:
+            command += ["--security-opt", f"seccomp={self.seccomp_profile}"]
+        if self.enforce_cpu_limit:
+            command += ["--cpus", str(self.cpus)]
+        command.append(self.image)
+        return command
+
+    def _verify_runtime(self) -> None:
+        inspected = self._run(
+            [self.docker, "inspect", self.container_name], timeout=30
+        )
+        documents = json.loads(inspected.stdout.decode("utf-8"))
+        if len(documents) != 1:
+            raise RuntimeError("unexpected inspect result")
+        document = documents[0]
+        config = document.get("Config") or {}
+        host = document.get("HostConfig") or {}
+        self.image_id = str(document.get("Image") or "")
+        if not self.image_id or not self.verifier_image_id:
+            raise RuntimeError("image identity missing")
+        if config.get("User") != "65532:65532":
+            raise RuntimeError("unexpected container user")
+        if host.get("NetworkMode") != "none" or host.get("IpcMode") != "none":
+            raise RuntimeError("network or IPC isolation missing")
+        if host.get("PidMode") not in ("", "private"):
+            raise RuntimeError("private PID namespace missing")
+        if host.get("ReadonlyRootfs") is not True:
+            raise RuntimeError("read-only rootfs missing")
+        if "ALL" not in (host.get("CapDrop") or []):
+            raise RuntimeError("capability drop missing")
+        if self.enforce_pid_limit and int(host.get("PidsLimit") or 0) != 128:
+            raise RuntimeError("PID limit missing")
+        expected_memory = self.memory_gb * 1024 * 1024 * 1024
+        if int(host.get("Memory") or 0) != expected_memory:
+            raise RuntimeError("memory limit missing")
+        if int(host.get("MemorySwap") or 0) != expected_memory:
+            raise RuntimeError("swap limit missing")
+        expected_nano_cpus = int(self.cpus * 1_000_000_000)
+        if (
+            self.enforce_cpu_limit
+            and int(host.get("NanoCpus") or 0) != expected_nano_cpus
+        ):
+            raise RuntimeError("CPU limit missing")
+        nofile = [
+            item for item in host.get("Ulimits") or []
+            if item.get("Name") == "nofile"
+        ]
+        if nofile != [{"Name": "nofile", "Hard": 256, "Soft": 256}]:
+            raise RuntimeError("nofile limit missing")
+        security = host.get("SecurityOpt") or []
+        if not any("no-new-privileges" in item for item in security):
+            raise RuntimeError("no-new-privileges missing")
+        if (
+            self.enforce_outer_seccomp
+            and not any("seccomp=" in item for item in security)
+        ):
+            raise RuntimeError("seccomp profile missing")
+        if document.get("AppArmorProfile") in (None, "", "unconfined"):
+            raise RuntimeError("AppArmor enforcement missing")
+        masked_paths = set(host.get("MaskedPaths") or [])
+        readonly_paths = set(host.get("ReadonlyPaths") or [])
+        if self.enforce_procfs_policy:
+            if not {
+                "/proc/acpi", "/proc/kcore", "/proc/keys", "/proc/latency_stats",
+                "/proc/timer_list", "/proc/timer_stats", "/proc/sched_debug",
+                "/sys/firmware",
+            }.issubset(masked_paths):
+                raise RuntimeError("procfs masked-path policy missing")
+            if not {
+                "/proc/asound", "/proc/bus", "/proc/fs", "/proc/irq",
+                "/proc/sys", "/proc/sysrq-trigger",
+            }.issubset(readonly_paths):
+                raise RuntimeError("procfs read-only policy missing")
+        work_mounts = [
+            mount for mount in document.get("Mounts", [])
+            if mount.get("Destination") == "/work"
+            and mount.get("Type") == "volume"
+            and mount.get("Name") == self.work_volume_name
+            and mount.get("RW") is True
+        ]
+        if len(work_mounts) != 1:
+            raise RuntimeError("work volume mount missing")
+        volume_result = self._run(
+            [self.docker, "volume", "inspect", self.work_volume_name],
+            timeout=30,
+            check=True,
+        )
+        volume_documents = json.loads(volume_result.stdout.decode("utf-8"))
+        if len(volume_documents) != 1:
+            raise RuntimeError("work volume inspection failed")
+        volume = volume_documents[0]
+        if volume.get("Driver") != "local":
+            raise RuntimeError("work volume driver mismatch")
+        options = volume.get("Options") or {}
+        if options.get("type") != "tmpfs" or options.get("device") != "tmpfs":
+            raise RuntimeError("work volume is not tmpfs")
+        mount_options = set(str(options.get("o", "")).split(","))
+        required_options = {
+            "size=536870912", "nr_inodes=1024", "uid=65532", "gid=65532",
+            "nosuid", "nodev", "noexec",
+        }
+        if not required_options.issubset(mount_options):
+            raise RuntimeError("work tmpfs quota or mount options missing")
+        readonly_inputs = [
+            mount for mount in document.get("Mounts", [])
+            if mount.get("Destination") == "/inputs" and mount.get("RW") is False
+        ]
+        if len(readonly_inputs) != 1:
+            raise RuntimeError("read-only inputs mount missing")
+        self._verify_runtime_components()
+        self._verify_fds()
+
+    def _verify_host_runtime(self) -> None:
+        if self.require_dedicated_host:
+            swaps = Path("/proc/swaps")
+            if swaps.is_file() and len(swaps.read_text(encoding="utf-8").splitlines()) > 1:
+                raise RuntimeError("compute runner swap must be disabled")
+            prohibited = (
+                "AZURE", "OPENAI", "ANTHROPIC", "HF_TOKEN", "HUGGINGFACE",
+                "AWS_", "GOOGLE_", "GITHUB_TOKEN", "GH_TOKEN",
+            )
+            exposed = [
+                name for name in os.environ
+                if any(marker in name.upper() for marker in prohibited)
+            ]
+            if exposed:
+                raise RuntimeError("compute runner contains credential environment")
+            running = self._run(
+                [self.docker, "ps", "--quiet"], timeout=30, check=True
+            )
+            if running.stdout.strip():
+                raise RuntimeError("compute runner has another running workload")
+        result = self._run(
+            [self.docker, "info", "--format", "{{json .SecurityOptions}}"],
+            timeout=30,
+            check=True,
+        )
+        try:
+            options = json.loads(result.stdout.decode("utf-8"))
+        except Exception as exc:
+            raise RuntimeError("Docker security options unavailable") from exc
+        normalized = " ".join(str(option).lower() for option in options or [])
+        if "apparmor" not in normalized and "selinux" not in normalized:
+            raise RuntimeError("mandatory access control is unavailable")
+        if self.require_rootless_or_userns and not any(
+            marker in normalized for marker in ("rootless", "userns")
+        ):
+            raise RuntimeError("rootless Docker or user namespaces are required")
+
+    def _verify_fds(self) -> None:
+        script = (
+            "import json,os;"
+            "scan=lambda root:{str(i):os.readlink(root+'/'+str(i)) "
+            "for i in range(256) if os.path.lexists(root+'/'+str(i))};"
+            "print(json.dumps({'uid':os.geteuid(),'gid':os.getegid(),"
+            "'groups':os.getgroups(),'probe_fds':scan('/proc/self/fd'),"
+            "'pid1_fds':scan('/proc/1/fd')},sort_keys=True))"
+        )
+        result = self._run([
+            self.docker, "exec", "-i", "--user", "65532:65532",
+            self.container_name, "python", "-I", "-B", "-c", script,
+        ], timeout=30)
+        identity = json.loads(result.stdout.decode("utf-8"))
+        if identity.get("uid") != 65532 or identity.get("gid") != 65532:
+            raise RuntimeError("runtime UID/GID mismatch")
+        if identity.get("groups") not in ([], [65532]):
+            raise RuntimeError("unexpected supplementary groups")
+        for process in ("probe", "pid1"):
+            fds = identity.get(f"{process}_fds") or {}
+            if set(fds) != {"0", "1", "2"}:
+                raise RuntimeError(
+                    f"unexpected inherited file descriptor: {process}"
+                )
+            if any("socket:" in target for target in fds.values()):
+                raise RuntimeError(f"inherited socket: {process}")
+
+    def _verify_runtime_components(self) -> None:
+        script = _runtime_component_hash_script()
+        result = self._run([
+            self.docker, "exec", "-i", "--user", "65532:65532",
+            self.container_name, "python", "-I", "-B", "-c", script,
+        ], timeout=30)
+        if result.returncode != 0:
+            raise RuntimeError("runtime component hashing failed")
+        observed = json.loads(result.stdout.decode("utf-8"))
+        expected = self.substrate_manifest()["component_sha256"]
+        for name in (
+            "python_launcher", "verifier", "capabilities", "core_tree"
+        ):
+            if observed.get(name) != expected.get(name):
+                raise RuntimeError(f"runtime component identity mismatch: {name}")
+        if (
+            self.require_supply_chain_identity
+            and observed.get("sbom") != self.sbom_sha256
+        ):
+            raise RuntimeError("runtime SBOM identity mismatch")
+
+    def _verify_verifier_image_components(self) -> None:
+        inspected = self._run(
+            [self.docker, "image", "inspect", self.verifier_image],
+            timeout=30,
+            check=True,
+        )
+        documents = json.loads(inspected.stdout.decode("utf-8"))
+        if len(documents) != 1:
+            raise RuntimeError("verifier image inspection failed")
+        self.verifier_image_id = str(documents[0].get("Id") or "")
+        if not self.verifier_image_id:
+            raise RuntimeError("verifier image identity missing")
+        script = _runtime_component_hash_script()
+        command = [
+            self.docker, "run", "--rm", "--network", "none", "--ipc", "none",
+            "--read-only", "--cap-drop", "ALL", "--user", "65532:65532",
+            "--security-opt", "no-new-privileges",
+            "--security-opt", f"apparmor={self.apparmor_profile}",
+            "--memory", "256m", "--memory-swap", "256m",
+            "--ulimit", "nofile=64:64", "--entrypoint", "python",
+        ]
+        if self.enforce_pid_limit:
+            command += ["--pids-limit", "16"]
+        if self.enforce_outer_seccomp:
+            command += ["--security-opt", f"seccomp={self.seccomp_profile}"]
+        if self.enforce_cpu_limit:
+            command += ["--cpus", "1"]
+        command += [self.verifier_image_id, "-I", "-B", "-c", script]
+        result = self._run(command, timeout=60)
+        if result.returncode != 0 or len(result.stdout) > OUTPUT_LIMIT:
+            raise RuntimeError("verifier component hashing failed")
+        try:
+            observed = json.loads(result.stdout.decode("utf-8"))
+        except Exception as exc:
+            raise RuntimeError("verifier component hashing failed") from exc
+        expected = self._component_hashes()
+        for name in ("verifier", "capabilities", "core_tree"):
+            if observed.get(name) != expected.get(name):
+                raise RuntimeError(
+                    f"verifier image component identity mismatch: {name}"
+                )
+        if (
+            self.require_supply_chain_identity
+            and observed.get("sbom") != self.sbom_sha256
+        ):
+            raise RuntimeError("verifier image SBOM identity mismatch")
+
+    def _component_hashes(self) -> dict[str, str]:
+        core_dir = Path(__file__).resolve().parent
+        sandbox_dir = core_dir.parent / "sandbox"
+        components = {
+            "python_launcher": core_dir / "agentic_python_launcher.py",
+            "ffmpeg_mapper": Path(__file__).resolve(),
+            "verifier": core_dir / "agentic_verifier.py",
+            "outer_seccomp": self.seccomp_profile,
+            "capabilities": sandbox_dir / "agentic-capabilities.json",
+        }
+        hashes = {name: _sha256_file(path) for name, path in components.items()}
+        hashes["core_tree"] = _sha256_python_tree(core_dir)
+        return hashes
+
+    def _snapshot(
+        self,
+        *,
+        verify: bool = False,
+        selected_deliverables: Optional[list[str]] = None,
+        deadline: Optional[float] = None,
+    ) -> tuple[Path, Optional[dict]]:
+        deadline = deadline or _operation_deadline(1200.0)
+        self._assert_pid1_only(deadline)
+        self._run(
+            [self.docker, "pause", self.container_name],
+            timeout=_remaining_timeout(deadline, 30.0),
+            check=True,
+        )
+        destination = self.snapshots_dir / f"snapshot-{uuid.uuid4().hex}"
+        destination.mkdir(mode=0o700)
+        helper_name = f"{self.container_name}-snapshot-{uuid.uuid4().hex[:8]}"
+        verification = None
+        try:
+            if verify:
+                verification = self._verify_work_volume(
+                    selected_deliverables, deadline
+                )
+            helper_command = [
+                self.docker, "run", "--detach", "--rm", "--name", helper_name,
+                "--network", "none", "--ipc", "none", "--read-only",
+                "--cap-drop", "ALL", "--memory", "512m", "--memory-swap", "512m",
+                "--ulimit", "nofile=128:128", "--user", "65532:65532",
+                "--security-opt", "no-new-privileges",
+                "--security-opt", f"apparmor={self.apparmor_profile}",
+                "--mount", (
+                    f"type=volume,src={self.work_volume_name},dst=/snapshot,"
+                    "readonly,volume-nocopy"
+                ),
+            ]
+            if self.enforce_pid_limit:
+                helper_command += ["--pids-limit", "32"]
+            if self.enforce_outer_seccomp:
+                helper_command += [
+                    "--security-opt", f"seccomp={self.seccomp_profile}"
+                ]
+            if self.enforce_cpu_limit:
+                helper_command += ["--cpus", "0.5"]
+            helper_command += [
+                self.image, "-c", "import signal;signal.pause()"
+            ]
+            self._run(
+                helper_command,
+                timeout=_remaining_timeout(deadline, 60.0),
+                check=True,
+            )
+            self._run(
+                [self.docker, "cp", f"{helper_name}:/snapshot/.", str(destination)],
+                timeout=_remaining_timeout(deadline, 120.0),
+                check=True,
+            )
+        finally:
+            self._run([self.docker, "rm", "-f", helper_name], timeout=30)
+            self._run([self.docker, "unpause", self.container_name], timeout=30)
+        self._strict_snapshot_files(destination)
+        return destination, verification
+
+    def _strict_snapshot_files(self, snapshot: Path) -> list[Path]:
+        files: list[Path] = []
+        total_logical = 0
+        total_allocated = 0
+        for path in sorted(snapshot.rglob("*")):
+            relative = path.relative_to(snapshot)
+            if len(relative.parts) > MAX_DEPTH or len(relative.as_posix().encode("utf-8")) > MAX_PATH_BYTES:
+                raise ValueError("workspace_path_limit")
+            metadata = path.lstat()
+            if stat.S_ISDIR(metadata.st_mode):
+                continue
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise ValueError("workspace_type_or_link_violation")
+            total_logical += metadata.st_size
+            total_allocated += metadata.st_blocks * 512
+            if metadata.st_size > MAX_WORK_SINGLE:
+                raise ValueError("workspace_single_file_limit")
+            if total_logical > MAX_WORK_TOTAL or total_allocated > MAX_WORK_TOTAL:
+                raise ValueError("workspace_total_size_limit")
+            files.append(path)
+            if len(files) > MAX_WORK_FILES:
+                raise ValueError("workspace_file_count_limit")
+        return files
+
+    def _verify_work_volume(
+        self,
+        selected_deliverables: Optional[list[str]] = None,
+        deadline: Optional[float] = None,
+    ) -> dict:
+        request = {
+            "task_prompt": self.task_prompt,
+            "reference_hashes": sorted(self.input_hashes),
+        }
+        if selected_deliverables is not None:
+            request["selected_deliverables"] = list(selected_deliverables)
+        payload = json.dumps(request, separators=(",", ":")).encode("utf-8")
+        command = [
+            self.docker, "run", "--rm", "-i", "--network", "none", "--ipc", "none",
+            "--read-only", "--cap-drop", "ALL",
+            "--memory", "2g", "--memory-swap", "2g",
+            "--ulimit", "nofile=128:128", "--user", "65532:65532",
+            "--security-opt", "no-new-privileges",
+            "--security-opt", f"apparmor={self.apparmor_profile}",
+            "--env", "HOME=/verify-work/.home",
+            "--env", "TMPDIR=/verify-work/.tmp",
+            "--env", "XDG_CACHE_HOME=/verify-work/.cache",
+            "--env", "XDG_CONFIG_HOME=/verify-work/.config",
+            "--env", "MPLCONFIGDIR=/verify-work/.cache/matplotlib",
+            "--mount", (
+                f"type=volume,src={self.work_volume_name},dst=/snapshot,"
+                "readonly,volume-nocopy"
+            ),
+            "--tmpfs", "/verify-work:rw,nosuid,nodev,noexec,size=134217728,nr_inodes=512,uid=65532,gid=65532,mode=700",
+        ]
+        if self.enforce_pid_limit:
+            command += ["--pids-limit", "64"]
+        if self.enforce_outer_seccomp:
+            command += ["--security-opt", f"seccomp={self.seccomp_profile}"]
+        if self.enforce_cpu_limit:
+            command += ["--cpus", "1"]
+        command += [
+            self.verifier_image_id,
+            "-c",
+            (
+                "import runpy,sys;sys.path.insert(0,'/opt/gdpval');"
+                "runpy.run_module('core.agentic_verifier',run_name='__main__')"
+            ),
+        ]
+        deadline = deadline or _operation_deadline(1200.0)
+        result = self._run(
+            command,
+            input_data=payload,
+            timeout=_remaining_timeout(deadline, 180.0),
+        )
+        if result.returncode != 0 or len(result.stdout) > OUTPUT_LIMIT:
+            return _error("verifier_container_failed")
+        try:
+            verification = json.loads(result.stdout.decode("utf-8"))
+        except Exception:
+            return _error("verifier_result_invalid")
+        if not isinstance(verification, dict) or verification.get("ok") not in (True, False):
+            return _error("verifier_result_invalid")
+        return verification
+
+    def _verification_matches_snapshot(
+        self,
+        verification: Mapping[str, Any],
+        snapshot: Path,
+        selected_deliverables: Optional[list[str]] = None,
+    ) -> bool:
+        data = verification.get("data")
+        artifacts = data.get("artifacts") if isinstance(data, Mapping) else None
+        if not isinstance(artifacts, list):
+            return False
+        expected = {
+            item.get("path"): item.get("sha256")
+            for item in artifacts
+            if isinstance(item, Mapping)
+            and isinstance(item.get("path"), str)
+            and isinstance(item.get("sha256"), str)
+        }
+        actual = {}
+        selected = (
+            set(selected_deliverables)
+            if selected_deliverables is not None
+            else None
+        )
+        for path in self._strict_snapshot_files(snapshot):
+            relative = path.relative_to(snapshot)
+            if _is_internal(relative):
+                continue
+            if selected is not None and relative.as_posix() not in selected:
+                continue
+            digest = hashlib.sha256()
+            with path.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(65536), b""):
+                    digest.update(chunk)
+            actual[relative.as_posix()] = digest.hexdigest()
+        return (
+            expected == actual
+            and bool(actual)
+            and (selected is None or set(actual) == selected)
+        )
+
+    def _ffmpeg_command(self, operation: Mapping[str, Any]) -> list[str]:
+        name = str(operation["operation"])
+        input_suffix = Path(str(operation["input"])).suffix.lower()
+        if input_suffix not in FFMPEG_INPUT_SUFFIXES:
+            raise ValueError("unsupported ffmpeg input suffix")
+        source = _container_path(str(operation["input"]), output=False)
+        base = [
+            self.docker, "exec", "-i", "--user", "65532:65532",
+            self.container_name,
+        ]
+        if name == "probe":
+            return base + [
+                "/usr/bin/ffprobe", "-v", "error", "-show_format", "-show_streams",
+                "-protocol_whitelist", "file", "-of", "json", source,
+            ]
+        output = _container_path(str(operation["output"]), output=True)
+        output_suffix = Path(output).suffix.lower()
+        expected_suffix = {
+            "extract_audio": f".{operation.get('format')}",
+            "transcode_audio": f".{operation.get('format')}",
+            "transcode_video": f".{operation.get('container')}",
+            "sample_frames": ".png",
+        }.get(name)
+        if output_suffix != expected_suffix:
+            raise ValueError("ffmpeg output extension differs from declared format")
+        timing = [
+            "-ss", str(operation["start_seconds"]),
+            "-t", str(operation["duration_seconds"]),
+        ]
+        command = base + [
+            "/usr/bin/ffmpeg", "-nostdin", "-n", "-hide_banner", "-loglevel", "error",
+            "-protocol_whitelist", "file", *timing, "-i", source,
+        ]
+        if name in {"extract_audio", "transcode_audio"}:
+            codec = "pcm_s16le" if operation["format"] == "wav" else "flac"
+            command += [
+                "-vn", "-ac", str(operation["channels"]), "-ar",
+                str(operation["sample_rate"]), "-c:a", codec, output,
+            ]
+        elif name == "transcode_video":
+            video_codec = "libx264" if operation["video_codec"] == "h264" else "libvpx-vp9"
+            audio_codec = "aac" if operation["audio_codec"] == "aac" else "libopus"
+            command += [
+                "-vf", f"scale={operation['width']}:{operation['height']}",
+                "-r", str(operation["fps"]), "-c:v", video_codec,
+                "-c:a", audio_codec, output,
+            ]
+        elif name == "sample_frames":
+            columns = min(4, int(operation["frame_count"]))
+            rows = math.ceil(int(operation["frame_count"]) / columns)
+            rate = float(operation["frame_count"]) / float(operation["duration_seconds"])
+            command += [
+                "-vf", f"fps={rate:.8f},scale={operation['width']}:-2,tile={columns}x{rows}",
+                "-frames:v", "1", output,
+            ]
+        else:
+            raise ValueError("unknown ffmpeg operation")
+        return command
+
+    def _assert_pid1_only(self, deadline: Optional[float] = None) -> None:
+        script = (
+            "import os;"
+            "pids={name for name in os.listdir('/proc') if name.isdigit()};"
+            "expected={'1',str(os.getpid())};"
+            "assert pids==expected,(pids,expected);print('ok')"
+        )
+        result = self._run([
+            self.docker, "exec", "-i", "--user", "65532:65532",
+            self.container_name, "python", "-I", "-B", "-c", script,
+        ], timeout=_remaining_timeout(
+            deadline or _operation_deadline(30.0), 30.0
+        ))
+        if result.returncode != 0 or result.stdout.strip() != b"ok":
+            raise RuntimeError("task container has descendant processes")
+
+    def _docker_path(self, local_path: Path) -> Path:
+        relative = local_path.resolve().relative_to(self.root.resolve())
+        return self.docker_root / relative
+
+    def _ready(self) -> bool:
+        return self.container_started and not self.poisoned
+
+    def _remove_container(self) -> None:
+        if not self.container_started:
+            return
+        self._run([self.docker, "rm", "-f", self.container_name], timeout=30)
+        self.container_started = False
+
+    def _create_work_volume(self) -> None:
+        result = self._run([
+            self.docker, "volume", "create", "--driver", "local",
+            "--opt", "type=tmpfs", "--opt", "device=tmpfs",
+            "--opt", (
+                "o=size=536870912,nr_inodes=1024,uid=65532,gid=65532,"
+                "nosuid,nodev,noexec"
+            ),
+            self.work_volume_name,
+        ], timeout=30)
+        if result.returncode != 0:
+            raise RuntimeError("work volume creation failed")
+        created_name = result.stdout.decode("utf-8", errors="replace").strip()
+        if created_name != self.work_volume_name:
+            raise RuntimeError("unexpected work volume identity")
+        self.work_volume_created = True
+
+    def _remove_work_volume(self) -> None:
+        if not self.work_volume_created:
+            return
+        self._run(
+            [self.docker, "volume", "rm", "-f", self.work_volume_name],
+            timeout=30,
+        )
+        self.work_volume_created = False
+
+    @staticmethod
+    def _run(
+        command: list[str],
+        *,
+        input_data: Optional[bytes] = None,
+        timeout: float,
+        check: bool = False,
+    ) -> subprocess.CompletedProcess:
+        result = subprocess.run(
+            command,
+            input=input_data,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+            env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "LANG": "C.UTF-8"},
+        )
+        if check and result.returncode != 0:
+            raise RuntimeError("compute command failed")
+        return result
+
+    @staticmethod
+    def _run_tool(
+        command: list[str],
+        *,
+        input_data: Optional[bytes] = None,
+        timeout: float,
+    ) -> subprocess.CompletedProcess:
+        import resource
+
+        def limit_output_files() -> None:
+            resource.setrlimit(
+                resource.RLIMIT_FSIZE,
+                (OUTPUT_LIMIT, OUTPUT_LIMIT),
+            )
+
+        with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+            process = subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE if input_data is not None else subprocess.DEVNULL,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                env={
+                    "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                    "LANG": "C.UTF-8",
+                },
+                preexec_fn=limit_output_files,
+            )
+            try:
+                process.communicate(input=input_data, timeout=max(0.001, timeout))
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+                raise
+            stdout_file.seek(0)
+            stderr_file.seek(0)
+            return subprocess.CompletedProcess(
+                command,
+                process.returncode,
+                stdout_file.read(OUTPUT_LIMIT),
+                stderr_file.read(OUTPUT_LIMIT),
+            )
+
+
+def _open_regular_nofollow(path: Path) -> int:
+    absolute = path.absolute()
+    if not absolute.is_absolute() or len(absolute.parts) < 2:
+        raise OSError("input path must identify a file")
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    nonblock = getattr(os, "O_NONBLOCK", 0)
+    directory = os.open(absolute.anchor, directory_flags | cloexec)
+    try:
+        for part in absolute.parts[1:-1]:
+            child = os.open(
+                part,
+                directory_flags | nofollow | cloexec,
+                dir_fd=directory,
+            )
+            os.close(directory)
+            directory = child
+        return os.open(
+            absolute.parts[-1],
+            os.O_RDONLY | nofollow | cloexec | nonblock,
+            dir_fd=directory,
+        )
+    finally:
+        os.close(directory)
+
+
+def _operation_deadline(timeout_seconds: float) -> float:
+    if (
+        isinstance(timeout_seconds, bool)
+        or not isinstance(timeout_seconds, (int, float))
+        or not math.isfinite(float(timeout_seconds))
+        or not 0 < float(timeout_seconds) <= 1200.0
+    ):
+        raise ValueError("operation timeout must be in (0, 1200]")
+    return time.monotonic() + float(timeout_seconds)
+
+
+def _source_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _sha256_descriptor(descriptor: int) -> str:
+    digest = hashlib.sha256()
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    while True:
+        chunk = os.read(descriptor, 65536)
+        if not chunk:
+            break
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _remaining_timeout(deadline: float, maximum: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("task wall time exhausted")
+    return max(0.001, min(float(maximum), remaining))
+
+
+def _normalize_probe_metadata(payload: bytes) -> dict[str, Any]:
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite ffprobe value: {value}")
+
+    parsed = json.loads(payload.decode("utf-8"), parse_constant=reject_constant)
+    if not isinstance(parsed, dict):
+        raise ValueError("ffprobe result must be an object")
+    format_fields = {
+        "format_name", "format_long_name", "start_time", "duration", "size",
+        "bit_rate", "probe_score", "nb_streams", "nb_programs",
+    }
+    stream_fields = {
+        "index", "codec_name", "codec_long_name", "profile", "codec_type",
+        "codec_tag_string", "width", "height", "coded_width", "coded_height",
+        "pix_fmt", "level", "color_range", "color_space", "color_transfer",
+        "color_primaries", "chroma_location", "field_order", "refs",
+        "r_frame_rate", "avg_frame_rate", "time_base", "start_pts",
+        "start_time", "duration_ts", "duration", "bit_rate",
+        "bits_per_raw_sample", "nb_frames", "sample_fmt", "sample_rate",
+        "channels", "channel_layout", "bits_per_sample", "id",
+    }
+
+    def allowed(source: object, fields: set[str]) -> dict[str, Any]:
+        if not isinstance(source, Mapping):
+            return {}
+        output: dict[str, Any] = {}
+        for key in sorted(fields):
+            value = source.get(key)
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, int):
+                output[key] = value
+            elif isinstance(value, str) and len(value) <= 256:
+                output[key] = value
+        return output
+
+    raw_streams = parsed.get("streams")
+    if raw_streams is None:
+        raw_streams = []
+    if not isinstance(raw_streams, list) or len(raw_streams) > 64:
+        raise ValueError("ffprobe stream count is invalid")
+    return {
+        "format": allowed(parsed.get("format"), format_fields),
+        "streams": [allowed(stream, stream_fields) for stream in raw_streams],
+    }
+
+
+def _normalize_model_path(raw: str, *, output: bool) -> str:
+    path = Path(raw)
+    if path.is_absolute() or ".." in path.parts or any(part.startswith(".") for part in path.parts):
+        raise ValueError("unsafe path")
+    parts = path.parts
+    if output:
+        if parts and parts[0] == "work":
+            parts = parts[1:]
+        if not parts or (parts and parts[0] == "inputs"):
+            raise ValueError("output must resolve under work")
+    else:
+        if not parts or parts[0] not in {"inputs", "work"}:
+            raise ValueError("input must start with inputs/ or work/")
+    relative = Path(*parts).as_posix()
+    if not relative or len(relative.encode("utf-8")) > MAX_PATH_BYTES:
+        raise ValueError("unsafe path")
+    return relative
+
+
+def _container_path(raw: str, *, output: bool) -> str:
+    relative = _normalize_model_path(raw, output=output)
+    if output:
+        return f"/work/{relative}"
+    prefix = Path(raw).parts[0]
+    return f"/{prefix}/{Path(*Path(raw).parts[1:]).as_posix()}"
+
+
+def _is_internal(relative: Path) -> bool:
+    return any(part.startswith(".") for part in relative.parts)
+
+
+def _bounded_text(value: bytes) -> str:
+    return value[-OUTPUT_LIMIT:].decode("utf-8", errors="replace")
+
+
+def _error(error_type: str) -> dict:
+    return {"ok": False, "error_type": error_type, "retryable": False}
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_python_tree(root: Path) -> str:
+    digest = hashlib.sha256(b"gdpval-core-tree-v1\0")
+    for path in sorted(root.rglob("*.py"), key=lambda item: item.as_posix()):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        content = path.read_bytes()
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest()
+
+
+def _runtime_component_hash_script() -> str:
+    return """
+import hashlib
+import json
+import pathlib
+
+core = pathlib.Path('/opt/gdpval/core')
+paths = {
+    'python_launcher': core / 'agentic_python_launcher.py',
+    'verifier': core / 'agentic_verifier.py',
+    'capabilities': pathlib.Path('/opt/gdpval/agentic-capabilities.json'),
+    'sbom': pathlib.Path('/opt/gdpval/agentic-sbom.spdx.json'),
+}
+observed = {
+    name: hashlib.sha256(path.read_bytes()).hexdigest()
+    for name, path in paths.items()
+}
+tree = hashlib.sha256(b'gdpval-core-tree-v1\\0')
+for path in sorted(core.rglob('*.py'), key=lambda item: item.as_posix()):
+    relative = path.relative_to(core).as_posix().encode('utf-8')
+    content = path.read_bytes()
+    tree.update(len(relative).to_bytes(8, 'big'))
+    tree.update(relative)
+    tree.update(len(content).to_bytes(8, 'big'))
+    tree.update(content)
+observed['core_tree'] = tree.hexdigest()
+print(json.dumps(observed, sort_keys=True))
+"""

--- a/batch-runner/core/agentic_compute.py
+++ b/batch-runner/core/agentic_compute.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import math
 import os
+import re
 import shutil
 import signal
 import stat
@@ -23,6 +24,7 @@ MAX_INPUT_SINGLE = 512 * 1024 * 1024
 MAX_WORK_FILES = 64
 MAX_WORK_TOTAL = 512 * 1024 * 1024
 MAX_WORK_SINGLE = 256 * 1024 * 1024
+MAX_TRANSFER_TOTAL = 256 * 1024 * 1024
 MAX_DEPTH = 16
 MAX_PATH_BYTES = 240
 OUTPUT_LIMIT = 32768
@@ -57,6 +59,7 @@ class AgenticDockerBackend:
         approved_input_manifest: Optional[Mapping[str, Mapping[str, Any]]] = None,
         require_approved_input_manifest: bool = True,
         expected_input_merkle_root: Optional[str] = None,
+        selection_recomputation_sha256: Optional[str] = None,
         sbom_sha256: Optional[str] = None,
         require_supply_chain_identity: bool = True,
         require_dedicated_host: bool = True,
@@ -102,6 +105,16 @@ class AgenticDockerBackend:
         )
         self.require_approved_input_manifest = require_approved_input_manifest
         self.expected_input_merkle_root = expected_input_merkle_root
+        if (
+            selection_recomputation_sha256 is not None
+            and re.fullmatch(
+                r"[0-9a-f]{64}", selection_recomputation_sha256
+            ) is None
+        ):
+            raise ValueError("selection recomputation identity is invalid")
+        self.selection_recomputation_sha256 = (
+            selection_recomputation_sha256
+        )
         if require_supply_chain_identity and (
             not isinstance(sbom_sha256, str)
             or len(sbom_sha256) != 64
@@ -131,6 +144,8 @@ class AgenticDockerBackend:
         self.work_volume_name = f"{self.container_name}-work"
         self.container_started = False
         self.work_volume_created = False
+        self._may_exist_containers: set[str] = set()
+        self._may_exist_volumes: set[str] = set()
         self.poisoned = False
         self.input_records: list[dict] = []
         self.input_hashes: set[str] = set()
@@ -138,25 +153,27 @@ class AgenticDockerBackend:
         self.latest_snapshot: Optional[Path] = None
         self.latest_verification: Optional[dict] = None
         self._best_result: Optional[dict] = None
+        self._verified_component_hashes: Optional[dict[str, str]] = None
         self.image_id = ""
         self.verifier_image_id = ""
 
     def start(self, timeout_seconds: float = 1200.0) -> Mapping[str, Any]:
         deadline = _operation_deadline(timeout_seconds)
         try:
-            self._verify_host_runtime()
+            self._verify_host_runtime(deadline)
             _remaining_timeout(deadline, 1200.0)
-            self._verify_verifier_image_components()
+            self._verify_verifier_image_components(deadline)
             _remaining_timeout(deadline, 1200.0)
-            self._stage_inputs()
+            self._stage_inputs(deadline)
             _remaining_timeout(deadline, 1200.0)
             if (
                 self.expected_input_merkle_root is not None
                 and self.input_merkle_root != self.expected_input_merkle_root
             ):
                 return _error("approved_input_merkle_mismatch")
-            self._create_work_volume()
+            self._create_work_volume(deadline)
             command = self._task_container_command()
+            self._may_exist_containers.add(self.container_name)
             result = self._run(
                 command, timeout=_remaining_timeout(deadline, 120.0)
             )
@@ -166,8 +183,8 @@ class AgenticDockerBackend:
             if not container_id:
                 return _error("container_start_failed")
             self.container_started = True
-            self._verify_runtime()
-            self._assert_pid1_only()
+            self._verify_runtime(deadline)
+            self._assert_pid1_only(deadline)
             _remaining_timeout(deadline, 1200.0)
             return {
                 "ok": True,
@@ -178,6 +195,9 @@ class AgenticDockerBackend:
                     ],
                     "input_count": len(self.input_records),
                     "input_merkle_root": self.input_merkle_root,
+                    "selection_recomputation_sha256": (
+                        self.selection_recomputation_sha256
+                    ),
                     "provider_classification": self.provider_classification,
                     "substrate_manifest": self.substrate_manifest(),
                 },
@@ -193,10 +213,11 @@ class AgenticDockerBackend:
         if not self._ready():
             return _error("compute_unavailable")
         try:
+            deadline = _operation_deadline(timeout_seconds)
             snapshot, _ = self._snapshot(
-                deadline=_operation_deadline(timeout_seconds)
+                deadline=deadline
             )
-            files = self._strict_snapshot_files(snapshot)
+            files = self._strict_snapshot_files(snapshot, deadline)
             return {
                 "ok": True,
                 "data": {
@@ -275,7 +296,11 @@ class AgenticDockerBackend:
             "task_image_id": self.image_id,
             "verifier_image": self.verifier_image,
             "verifier_image_id": self.verifier_image_id,
-            "component_sha256": self._component_hashes(),
+            "component_sha256": (
+                dict(self._verified_component_hashes)
+                if self._verified_component_hashes is not None
+                else self._component_hashes()
+            ),
             "sbom_sha256": self.sbom_sha256,
             "uid": 65532,
             "gid": 65532,
@@ -292,6 +317,7 @@ class AgenticDockerBackend:
                 "nodev": True,
                 "noexec": True,
             },
+            "selected_transfer_bytes": MAX_TRANSFER_TOTAL,
             "memory_bytes": self.memory_gb * 1024 * 1024 * 1024,
             "memory_swap_bytes": self.memory_gb * 1024 * 1024 * 1024,
             "cpus": self.cpus,
@@ -410,22 +436,21 @@ class AgenticDockerBackend:
         if not self._ready():
             return _error("compute_unavailable")
         try:
+            deadline = _operation_deadline(timeout_seconds)
             snapshot, verification = self._snapshot(
                 verify=True,
-                deadline=_operation_deadline(timeout_seconds),
+                deadline=deadline,
             )
-            self._strict_snapshot_files(snapshot)
+            self._strict_snapshot_files(snapshot, deadline)
             assert verification is not None
             if verification.get("ok") is True:
                 if not self._verification_matches_snapshot(
-                    verification, snapshot
+                    verification, snapshot, deadline=deadline
                 ):
                     return _error("snapshot_hash_mismatch")
                 self.latest_snapshot = snapshot
                 self.latest_verification = verification
-                self._best_result = self._snapshot_result(
-                    snapshot, verification, success=False, summary=""
-                )
+                self._best_result = None
             return verification
         except Exception:
             return _error("artifact_inspection_failed")
@@ -470,6 +495,7 @@ class AgenticDockerBackend:
                     selected_verification,
                     snapshot,
                     selected_deliverables=normalized,
+                    deadline=deadline,
                 )
             ):
                 return _error("selected_deliverable_verification_failed")
@@ -480,13 +506,30 @@ class AgenticDockerBackend:
                 selected_verification,
                 success=True,
                 summary=summary,
+                deadline=deadline,
             )
         except ValueError:
             return _error("snapshot_hash_mismatch")
         return {"ok": True, "data": {"artifact_count": len(normalized)}}
 
-    def best_result(self) -> Mapping[str, Any] | None:
-        return self._best_result
+    def best_result(
+        self, timeout_seconds: float = 1200.0
+    ) -> Mapping[str, Any] | None:
+        deadline = _operation_deadline(timeout_seconds)
+        if self._best_result is not None:
+            return self._best_result
+        if self.latest_snapshot is None or self.latest_verification is None:
+            return None
+        try:
+            return self._snapshot_result(
+                self.latest_snapshot,
+                self.latest_verification,
+                success=False,
+                summary="",
+                deadline=deadline,
+            )
+        except ValueError:
+            return None
 
     @staticmethod
     def _snapshot_result(
@@ -495,9 +538,11 @@ class AgenticDockerBackend:
         *,
         success: bool,
         summary: str,
+        deadline: Optional[float] = None,
     ) -> dict:
         data = verification.get("data") or {}
         files = []
+        total_bytes = 0
         for item in data.get("artifacts", []):
             if not isinstance(item, Mapping):
                 raise ValueError("invalid artifact verification")
@@ -506,8 +551,24 @@ class AgenticDockerBackend:
             if not isinstance(relative, str) or not isinstance(expected_hash, str):
                 raise ValueError("invalid artifact verification")
             path = snapshot / relative
-            content = path.read_bytes()
-            if hashlib.sha256(content).hexdigest() != expected_hash:
+            if deadline is not None:
+                _remaining_timeout(deadline, 1200.0)
+            total_bytes += path.stat().st_size
+            if total_bytes > MAX_TRANSFER_TOTAL:
+                raise ValueError("selected artifact transfer limit exceeded")
+            content_parts = []
+            digest = hashlib.sha256()
+            with path.open("rb") as stream:
+                while True:
+                    if deadline is not None:
+                        _remaining_timeout(deadline, 1200.0)
+                    chunk = stream.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+                    content_parts.append(chunk)
+            content = b"".join(content_parts)
+            if digest.hexdigest() != expected_hash:
                 raise ValueError("snapshot hash mismatch")
             files.append({"filename": relative, "content": content})
         if not files:
@@ -520,8 +581,21 @@ class AgenticDockerBackend:
         }
 
     def close(self) -> None:
-        self._remove_container()
-        self._remove_work_volume()
+        failures = []
+        for name in sorted(self._may_exist_containers):
+            try:
+                self._remove_named_container(name)
+            except Exception as exc:
+                failures.append(str(exc))
+        for name in sorted(self._may_exist_volumes):
+            try:
+                self._remove_named_volume(name)
+            except Exception as exc:
+                failures.append(str(exc))
+        self.container_started = self.container_name in self._may_exist_containers
+        self.work_volume_created = self.work_volume_name in self._may_exist_volumes
+        if failures:
+            raise RuntimeError("; ".join(failures))
         for directory in [
             self.inputs_dir,
             *(
@@ -533,9 +607,12 @@ class AgenticDockerBackend:
                 os.chmod(directory, 0o700, follow_symlinks=False)
             except OSError:
                 pass
-        shutil.rmtree(self.root, ignore_errors=True)
+        if self.root.exists():
+            shutil.rmtree(self.root)
+        if self.root.exists():
+            raise RuntimeError("compute host root cleanup failed")
 
-    def _stage_inputs(self) -> None:
+    def _stage_inputs(self, deadline: Optional[float] = None) -> None:
         if self.require_approved_input_manifest and self.approved_input_manifest is None:
             raise ValueError("approved input manifest is required")
         if len(self.reference_files) > MAX_INPUT_FILES:
@@ -544,8 +621,12 @@ class AgenticDockerBackend:
         relative_paths: set[str] = set()
         records: list[dict] = []
         for raw_reference in self.reference_files:
+            if deadline is not None:
+                _remaining_timeout(deadline, 1200.0)
+            source_root_value = None
             if isinstance(raw_reference, Mapping):
                 source_value = raw_reference.get("source_path")
+                source_root_value = raw_reference.get("source_root")
                 relative_value = raw_reference.get("relative_path")
                 if not isinstance(source_value, str) or not isinstance(
                     relative_value, str
@@ -574,7 +655,16 @@ class AgenticDockerBackend:
                 raise ValueError("input_name_violation")
             relative_paths.add(relative_path)
             try:
-                descriptor = _open_regular_nofollow(source)
+                if source_root_value is not None:
+                    if not isinstance(source_root_value, str):
+                        raise OSError("input source root is invalid")
+                    source_root = Path(source_root_value)
+                    descriptor = _open_regular_beneath_nofollow(
+                        source_root, source
+                    )
+                    source = source_root / source
+                else:
+                    descriptor = _open_regular_nofollow(source)
             except OSError as exc:
                 raise ValueError("input_type_or_link_violation") from exc
             try:
@@ -589,13 +679,15 @@ class AgenticDockerBackend:
                 copied = 0
                 with os.fdopen(os.dup(descriptor), "rb") as input_stream, destination.open("xb") as output:
                     for chunk in iter(lambda: input_stream.read(65536), b""):
+                        if deadline is not None:
+                            _remaining_timeout(deadline, 1200.0)
                         copied += len(chunk)
                         if copied > MAX_INPUT_SINGLE:
                             raise ValueError("input_file_size_limit")
                         digest.update(chunk)
                         output.write(chunk)
                 after = os.fstat(descriptor)
-                source_digest = _sha256_descriptor(descriptor)
+                source_digest = _sha256_descriptor(descriptor, deadline)
                 if _source_identity(after) != _source_identity(metadata):
                     raise ValueError("input_source_race")
                 if source_digest != digest.hexdigest() or copied != metadata.st_size:
@@ -606,7 +698,7 @@ class AgenticDockerBackend:
             total += copied
             if total > MAX_INPUT_TOTAL:
                 raise ValueError("input_total_size_limit")
-            staged_digest = hashlib.sha256(destination.read_bytes()).hexdigest()
+            staged_digest = _sha256_file(destination, deadline)
             if staged_digest != digest.hexdigest():
                 raise ValueError("staged input hash mismatch")
             staged = destination.lstat()
@@ -707,9 +799,11 @@ class AgenticDockerBackend:
         command.append(self.image)
         return command
 
-    def _verify_runtime(self) -> None:
+    def _verify_runtime(self, deadline: Optional[float] = None) -> None:
+        deadline = deadline or _operation_deadline(1200.0)
         inspected = self._run(
-            [self.docker, "inspect", self.container_name], timeout=30
+            [self.docker, "inspect", self.container_name],
+            timeout=_remaining_timeout(deadline, 30.0),
         )
         documents = json.loads(inspected.stdout.decode("utf-8"))
         if len(documents) != 1:
@@ -784,7 +878,7 @@ class AgenticDockerBackend:
             raise RuntimeError("work volume mount missing")
         volume_result = self._run(
             [self.docker, "volume", "inspect", self.work_volume_name],
-            timeout=30,
+            timeout=_remaining_timeout(deadline, 30.0),
             check=True,
         )
         volume_documents = json.loads(volume_result.stdout.decode("utf-8"))
@@ -809,10 +903,11 @@ class AgenticDockerBackend:
         ]
         if len(readonly_inputs) != 1:
             raise RuntimeError("read-only inputs mount missing")
-        self._verify_runtime_components()
-        self._verify_fds()
+        self._verify_runtime_components(deadline)
+        self._verify_fds(deadline)
 
-    def _verify_host_runtime(self) -> None:
+    def _verify_host_runtime(self, deadline: Optional[float] = None) -> None:
+        deadline = deadline or _operation_deadline(1200.0)
         if self.require_dedicated_host:
             swaps = Path("/proc/swaps")
             if swaps.is_file() and len(swaps.read_text(encoding="utf-8").splitlines()) > 1:
@@ -828,13 +923,15 @@ class AgenticDockerBackend:
             if exposed:
                 raise RuntimeError("compute runner contains credential environment")
             running = self._run(
-                [self.docker, "ps", "--quiet"], timeout=30, check=True
+                [self.docker, "ps", "--quiet"],
+                timeout=_remaining_timeout(deadline, 30.0),
+                check=True,
             )
             if running.stdout.strip():
                 raise RuntimeError("compute runner has another running workload")
         result = self._run(
             [self.docker, "info", "--format", "{{json .SecurityOptions}}"],
-            timeout=30,
+            timeout=_remaining_timeout(deadline, 30.0),
             check=True,
         )
         try:
@@ -849,7 +946,8 @@ class AgenticDockerBackend:
         ):
             raise RuntimeError("rootless Docker or user namespaces are required")
 
-    def _verify_fds(self) -> None:
+    def _verify_fds(self, deadline: Optional[float] = None) -> None:
+        deadline = deadline or _operation_deadline(1200.0)
         script = (
             "import json,os;"
             "scan=lambda root:{str(i):os.readlink(root+'/'+str(i)) "
@@ -861,7 +959,7 @@ class AgenticDockerBackend:
         result = self._run([
             self.docker, "exec", "-i", "--user", "65532:65532",
             self.container_name, "python", "-I", "-B", "-c", script,
-        ], timeout=30)
+        ], timeout=_remaining_timeout(deadline, 30.0))
         identity = json.loads(result.stdout.decode("utf-8"))
         if identity.get("uid") != 65532 or identity.get("gid") != 65532:
             raise RuntimeError("runtime UID/GID mismatch")
@@ -876,16 +974,22 @@ class AgenticDockerBackend:
             if any("socket:" in target for target in fds.values()):
                 raise RuntimeError(f"inherited socket: {process}")
 
-    def _verify_runtime_components(self) -> None:
+    def _verify_runtime_components(
+        self, deadline: Optional[float] = None
+    ) -> None:
+        deadline = deadline or _operation_deadline(1200.0)
         script = _runtime_component_hash_script()
         result = self._run([
             self.docker, "exec", "-i", "--user", "65532:65532",
             self.container_name, "python", "-I", "-B", "-c", script,
-        ], timeout=30)
+        ], timeout=_remaining_timeout(deadline, 30.0))
         if result.returncode != 0:
             raise RuntimeError("runtime component hashing failed")
         observed = json.loads(result.stdout.decode("utf-8"))
-        expected = self.substrate_manifest()["component_sha256"]
+        expected = (
+            self._verified_component_hashes
+            or self._component_hashes(deadline)
+        )
         for name in (
             "python_launcher", "verifier", "capabilities", "core_tree"
         ):
@@ -897,10 +1001,13 @@ class AgenticDockerBackend:
         ):
             raise RuntimeError("runtime SBOM identity mismatch")
 
-    def _verify_verifier_image_components(self) -> None:
+    def _verify_verifier_image_components(
+        self, deadline: Optional[float] = None
+    ) -> None:
+        deadline = deadline or _operation_deadline(1200.0)
         inspected = self._run(
             [self.docker, "image", "inspect", self.verifier_image],
-            timeout=30,
+            timeout=_remaining_timeout(deadline, 30.0),
             check=True,
         )
         documents = json.loads(inspected.stdout.decode("utf-8"))
@@ -910,8 +1017,11 @@ class AgenticDockerBackend:
         if not self.verifier_image_id:
             raise RuntimeError("verifier image identity missing")
         script = _runtime_component_hash_script()
+        probe_name = f"{self.container_name}-component-{uuid.uuid4().hex[:8]}"
+        self._may_exist_containers.add(probe_name)
         command = [
-            self.docker, "run", "--rm", "--network", "none", "--ipc", "none",
+            self.docker, "run", "--name", probe_name,
+            "--network", "none", "--ipc", "none",
             "--read-only", "--cap-drop", "ALL", "--user", "65532:65532",
             "--security-opt", "no-new-privileges",
             "--security-opt", f"apparmor={self.apparmor_profile}",
@@ -925,14 +1035,20 @@ class AgenticDockerBackend:
         if self.enforce_cpu_limit:
             command += ["--cpus", "1"]
         command += [self.verifier_image_id, "-I", "-B", "-c", script]
-        result = self._run(command, timeout=60)
+        try:
+            result = self._run(
+                command, timeout=_remaining_timeout(deadline, 60.0)
+            )
+        finally:
+            self._remove_named_container(probe_name)
         if result.returncode != 0 or len(result.stdout) > OUTPUT_LIMIT:
             raise RuntimeError("verifier component hashing failed")
         try:
             observed = json.loads(result.stdout.decode("utf-8"))
         except Exception as exc:
             raise RuntimeError("verifier component hashing failed") from exc
-        expected = self._component_hashes()
+        expected = self._component_hashes(deadline)
+        self._verified_component_hashes = dict(expected)
         for name in ("verifier", "capabilities", "core_tree"):
             if observed.get(name) != expected.get(name):
                 raise RuntimeError(
@@ -944,7 +1060,9 @@ class AgenticDockerBackend:
         ):
             raise RuntimeError("verifier image SBOM identity mismatch")
 
-    def _component_hashes(self) -> dict[str, str]:
+    def _component_hashes(
+        self, deadline: Optional[float] = None
+    ) -> dict[str, str]:
         core_dir = Path(__file__).resolve().parent
         sandbox_dir = core_dir.parent / "sandbox"
         components = {
@@ -954,8 +1072,11 @@ class AgenticDockerBackend:
             "outer_seccomp": self.seccomp_profile,
             "capabilities": sandbox_dir / "agentic-capabilities.json",
         }
-        hashes = {name: _sha256_file(path) for name, path in components.items()}
-        hashes["core_tree"] = _sha256_python_tree(core_dir)
+        hashes = {
+            name: _sha256_file(path, deadline)
+            for name, path in components.items()
+        }
+        hashes["core_tree"] = _sha256_python_tree(core_dir, deadline)
         return hashes
 
     def _snapshot(
@@ -967,20 +1088,24 @@ class AgenticDockerBackend:
     ) -> tuple[Path, Optional[dict]]:
         deadline = deadline or _operation_deadline(1200.0)
         self._assert_pid1_only(deadline)
-        self._run(
-            [self.docker, "pause", self.container_name],
-            timeout=_remaining_timeout(deadline, 30.0),
-            check=True,
-        )
         destination = self.snapshots_dir / f"snapshot-{uuid.uuid4().hex}"
-        destination.mkdir(mode=0o700)
         helper_name = f"{self.container_name}-snapshot-{uuid.uuid4().hex[:8]}"
         verification = None
+        pause_may_have_applied = False
         try:
+            pause_timeout = _remaining_timeout(deadline, 30.0)
+            pause_may_have_applied = True
+            self._run(
+                [self.docker, "pause", self.container_name],
+                timeout=pause_timeout,
+                check=True,
+            )
+            destination.mkdir(mode=0o700)
             if verify:
                 verification = self._verify_work_volume(
                     selected_deliverables, deadline
                 )
+            self._may_exist_containers.add(helper_name)
             helper_command = [
                 self.docker, "run", "--detach", "--rm", "--name", helper_name,
                 "--network", "none", "--ipc", "none", "--read-only",
@@ -1015,16 +1140,43 @@ class AgenticDockerBackend:
                 check=True,
             )
         finally:
-            self._run([self.docker, "rm", "-f", helper_name], timeout=30)
-            self._run([self.docker, "unpause", self.container_name], timeout=30)
-        self._strict_snapshot_files(destination)
+            if pause_may_have_applied:
+                self._cleanup_snapshot_resources(helper_name)
+        self._strict_snapshot_files(destination, deadline)
         return destination, verification
 
-    def _strict_snapshot_files(self, snapshot: Path) -> list[Path]:
+    def _cleanup_snapshot_resources(self, helper_name: str) -> None:
+        failures = []
+        if helper_name in self._may_exist_containers:
+            try:
+                self._remove_named_container(helper_name)
+            except Exception as exc:
+                failures.append(str(exc))
+        try:
+            unpaused = self._run(
+                [self.docker, "unpause", self.container_name], timeout=30
+            )
+            if unpaused.returncode != 0:
+                failures.append("task container unpause failed")
+        except Exception:
+            failures.append("task container unpause failed")
+        if failures:
+            self.poisoned = True
+            try:
+                self._remove_container()
+            except Exception:
+                pass
+            raise RuntimeError("; ".join(failures))
+
+    def _strict_snapshot_files(
+        self, snapshot: Path, deadline: Optional[float] = None
+    ) -> list[Path]:
         files: list[Path] = []
         total_logical = 0
         total_allocated = 0
         for path in sorted(snapshot.rglob("*")):
+            if deadline is not None:
+                _remaining_timeout(deadline, 1200.0)
             relative = path.relative_to(snapshot)
             if len(relative.parts) > MAX_DEPTH or len(relative.as_posix().encode("utf-8")) > MAX_PATH_BYTES:
                 raise ValueError("workspace_path_limit")
@@ -1056,8 +1208,11 @@ class AgenticDockerBackend:
         if selected_deliverables is not None:
             request["selected_deliverables"] = list(selected_deliverables)
         payload = json.dumps(request, separators=(",", ":")).encode("utf-8")
+        verifier_name = f"{self.container_name}-verify-{uuid.uuid4().hex[:8]}"
+        self._may_exist_containers.add(verifier_name)
         command = [
-            self.docker, "run", "--rm", "-i", "--network", "none", "--ipc", "none",
+            self.docker, "run", "--name", verifier_name, "-i",
+            "--network", "none", "--ipc", "none",
             "--read-only", "--cap-drop", "ALL",
             "--memory", "2g", "--memory-swap", "2g",
             "--ulimit", "nofile=128:128", "--user", "65532:65532",
@@ -1073,6 +1228,7 @@ class AgenticDockerBackend:
                 "readonly,volume-nocopy"
             ),
             "--tmpfs", "/verify-work:rw,nosuid,nodev,noexec,size=134217728,nr_inodes=512,uid=65532,gid=65532,mode=700",
+            "--tmpfs", "/tmp:rw,nosuid,nodev,noexec,size=67108864,nr_inodes=256,uid=65532,gid=65532,mode=700",
         ]
         if self.enforce_pid_limit:
             command += ["--pids-limit", "64"]
@@ -1089,11 +1245,18 @@ class AgenticDockerBackend:
             ),
         ]
         deadline = deadline or _operation_deadline(1200.0)
-        result = self._run(
-            command,
-            input_data=payload,
-            timeout=_remaining_timeout(deadline, 180.0),
-        )
+        try:
+            result = self._run(
+                command,
+                input_data=payload,
+                timeout=_remaining_timeout(deadline, 180.0),
+            )
+        finally:
+            try:
+                self._remove_named_container(verifier_name)
+            except Exception as exc:
+                self.poisoned = True
+                raise RuntimeError("verifier container cleanup failed") from exc
         if result.returncode != 0 or len(result.stdout) > OUTPUT_LIMIT:
             return _error("verifier_container_failed")
         try:
@@ -1109,6 +1272,7 @@ class AgenticDockerBackend:
         verification: Mapping[str, Any],
         snapshot: Path,
         selected_deliverables: Optional[list[str]] = None,
+        deadline: Optional[float] = None,
     ) -> bool:
         data = verification.get("data")
         artifacts = data.get("artifacts") if isinstance(data, Mapping) else None
@@ -1127,17 +1291,13 @@ class AgenticDockerBackend:
             if selected_deliverables is not None
             else None
         )
-        for path in self._strict_snapshot_files(snapshot):
+        for path in self._strict_snapshot_files(snapshot, deadline):
             relative = path.relative_to(snapshot)
             if _is_internal(relative):
                 continue
             if selected is not None and relative.as_posix() not in selected:
                 continue
-            digest = hashlib.sha256()
-            with path.open("rb") as stream:
-                for chunk in iter(lambda: stream.read(65536), b""):
-                    digest.update(chunk)
-            actual[relative.as_posix()] = digest.hexdigest()
+            actual[relative.as_posix()] = _sha256_file(path, deadline)
         return (
             expected == actual
             and bool(actual)
@@ -1227,12 +1387,17 @@ class AgenticDockerBackend:
         return self.container_started and not self.poisoned
 
     def _remove_container(self) -> None:
-        if not self.container_started:
+        if (
+            not self.container_started
+            and self.container_name not in self._may_exist_containers
+        ):
             return
-        self._run([self.docker, "rm", "-f", self.container_name], timeout=30)
+        self._remove_named_container(self.container_name)
         self.container_started = False
 
-    def _create_work_volume(self) -> None:
+    def _create_work_volume(self, deadline: Optional[float] = None) -> None:
+        deadline = deadline or _operation_deadline(1200.0)
+        self._may_exist_volumes.add(self.work_volume_name)
         result = self._run([
             self.docker, "volume", "create", "--driver", "local",
             "--opt", "type=tmpfs", "--opt", "device=tmpfs",
@@ -1241,7 +1406,7 @@ class AgenticDockerBackend:
                 "nosuid,nodev,noexec"
             ),
             self.work_volume_name,
-        ], timeout=30)
+        ], timeout=_remaining_timeout(deadline, 30.0))
         if result.returncode != 0:
             raise RuntimeError("work volume creation failed")
         created_name = result.stdout.decode("utf-8", errors="replace").strip()
@@ -1250,13 +1415,49 @@ class AgenticDockerBackend:
         self.work_volume_created = True
 
     def _remove_work_volume(self) -> None:
-        if not self.work_volume_created:
+        if (
+            not self.work_volume_created
+            and self.work_volume_name not in self._may_exist_volumes
+        ):
             return
-        self._run(
-            [self.docker, "volume", "rm", "-f", self.work_volume_name],
-            timeout=30,
-        )
+        self._remove_named_volume(self.work_volume_name)
         self.work_volume_created = False
+
+    def _remove_named_container(self, name: str) -> None:
+        result = self._run(
+            [self.docker, "rm", "-f", name], timeout=30
+        )
+        if result.returncode != 0:
+            inspected = self._run(
+                [self.docker, "inspect", name], timeout=30
+            )
+            if inspected.returncode == 0:
+                self.poisoned = True
+                raise RuntimeError(f"container cleanup failed: {name}")
+            if not _docker_not_found(inspected.stderr, "container"):
+                self.poisoned = True
+                raise RuntimeError(
+                    f"container cleanup could not be verified: {name}"
+                )
+        self._may_exist_containers.discard(name)
+
+    def _remove_named_volume(self, name: str) -> None:
+        result = self._run(
+            [self.docker, "volume", "rm", "-f", name], timeout=30
+        )
+        if result.returncode != 0:
+            inspected = self._run(
+                [self.docker, "volume", "inspect", name], timeout=30
+            )
+            if inspected.returncode == 0:
+                self.poisoned = True
+                raise RuntimeError(f"volume cleanup failed: {name}")
+            if not _docker_not_found(inspected.stderr, "volume"):
+                self.poisoned = True
+                raise RuntimeError(
+                    f"volume cleanup could not be verified: {name}"
+                )
+        self._may_exist_volumes.discard(name)
 
     @staticmethod
     def _run(
@@ -1349,6 +1550,96 @@ def _open_regular_nofollow(path: Path) -> int:
         os.close(directory)
 
 
+def _open_regular_beneath_nofollow(root: Path, relative: Path) -> int:
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or ".." in relative.parts
+        or any(part in {"", "."} for part in relative.parts)
+    ):
+        raise OSError("input source path is invalid")
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    nonblock = getattr(os, "O_NONBLOCK", 0)
+    directory = os.open(
+        root.absolute(), directory_flags | nofollow | cloexec
+    )
+    expected_mount = _descriptor_mount_id(directory)
+    try:
+        for part in relative.parts[:-1]:
+            child = os.open(
+                part,
+                directory_flags | nofollow | cloexec,
+                dir_fd=directory,
+            )
+            if _descriptor_mount_id(child) != expected_mount:
+                os.close(child)
+                raise OSError("input source crosses a mount boundary")
+            os.close(directory)
+            directory = child
+        descriptor = os.open(
+            relative.parts[-1],
+            os.O_RDONLY | nofollow | cloexec | nonblock,
+            dir_fd=directory,
+        )
+        if _descriptor_mount_id(descriptor) != expected_mount:
+            os.close(descriptor)
+            raise OSError("input source crosses a mount boundary")
+        return descriptor
+    finally:
+        os.close(directory)
+
+
+def _descriptor_mount_id(descriptor: int) -> int:
+    path = Path(f"/proc/self/fdinfo/{descriptor}")
+    try:
+        lines = path.read_text(encoding="ascii").splitlines()
+    except OSError as exc:
+        raise OSError("input mount identity is unavailable") from exc
+    for line in lines:
+        if line.startswith("mnt_id:"):
+            try:
+                return int(line.split(":", 1)[1].strip())
+            except ValueError as exc:
+                raise OSError("input mount identity is invalid") from exc
+    try:
+        target_value = os.readlink(f"/proc/self/fd/{descriptor}")
+        if target_value.endswith(" (deleted)"):
+            raise OSError("input descriptor target was deleted")
+        target = Path(target_value)
+        if not target.is_absolute():
+            raise OSError("input descriptor target is not absolute")
+        mount_lines = Path("/proc/self/mountinfo").read_text(
+            encoding="utf-8"
+        ).splitlines()
+    except OSError as exc:
+        raise OSError("input mount identity is unavailable") from exc
+    matches = []
+    for line in mount_lines:
+        fields = line.split()
+        if len(fields) < 6:
+            continue
+        try:
+            mount_id = int(fields[0])
+        except ValueError:
+            continue
+        mount_value = re.sub(
+            r"\\([0-7]{3})",
+            lambda match: chr(int(match.group(1), 8)),
+            fields[4],
+        )
+        mountpoint = Path(mount_value)
+        try:
+            target.relative_to(mountpoint)
+        except ValueError:
+            continue
+        matches.append((len(mountpoint.parts), mount_id))
+    if not matches:
+        raise OSError("input mount identity is unavailable")
+    return max(matches)[1]
+
+
 def _operation_deadline(timeout_seconds: float) -> float:
     if (
         isinstance(timeout_seconds, bool)
@@ -1372,10 +1663,14 @@ def _source_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
-def _sha256_descriptor(descriptor: int) -> str:
+def _sha256_descriptor(
+    descriptor: int, deadline: Optional[float] = None
+) -> str:
     digest = hashlib.sha256()
     os.lseek(descriptor, 0, os.SEEK_SET)
     while True:
+        if deadline is not None:
+            _remaining_timeout(deadline, 1200.0)
         chunk = os.read(descriptor, 65536)
         if not chunk:
             break
@@ -1476,17 +1771,34 @@ def _error(error_type: str) -> dict:
     return {"ok": False, "error_type": error_type, "retryable": False}
 
 
-def _sha256_file(path: Path) -> str:
+def _sha256_file(
+    path: Path, deadline: Optional[float] = None
+) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
         for chunk in iter(lambda: stream.read(65536), b""):
+            if deadline is not None:
+                _remaining_timeout(deadline, 1200.0)
             digest.update(chunk)
     return digest.hexdigest()
 
 
-def _sha256_python_tree(root: Path) -> str:
+def _docker_not_found(stderr: bytes, resource: str) -> bool:
+    text = stderr.decode("utf-8", errors="replace").lower()
+    markers = {
+        "container": ("no such object", "no such container"),
+        "volume": ("no such volume",),
+    }
+    return any(marker in text for marker in markers[resource])
+
+
+def _sha256_python_tree(
+    root: Path, deadline: Optional[float] = None
+) -> str:
     digest = hashlib.sha256(b"gdpval-core-tree-v1\0")
     for path in sorted(root.rglob("*.py"), key=lambda item: item.as_posix()):
+        if deadline is not None:
+            _remaining_timeout(deadline, 1200.0)
         relative = path.relative_to(root).as_posix().encode("utf-8")
         content = path.read_bytes()
         digest.update(len(relative).to_bytes(8, "big"))

--- a/batch-runner/core/agentic_compute_service.py
+++ b/batch-runner/core/agentic_compute_service.py
@@ -8,6 +8,9 @@ import hashlib
 import json
 import ssl
 import tempfile
+import time
+import math
+import re
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Mapping
@@ -37,7 +40,10 @@ class ApprovedDockerBackendFactory:
         cpus: float = 2,
         memory_gb: int = 8,
     ):
-        self.dataset_root = Path(dataset_root).resolve()
+        raw_dataset_root = Path(dataset_root)
+        if raw_dataset_root.is_symlink():
+            raise ValueError("compute dataset root must not be a symlink")
+        self.dataset_root = raw_dataset_root.resolve()
         if not self.dataset_root.is_dir():
             raise ValueError("compute dataset root is missing")
         document = json.loads(
@@ -45,6 +51,7 @@ class ApprovedDockerBackendFactory:
         )
         if not isinstance(document, dict) or set(document) != {
             "schema_version", "provider_classification",
+            "selection_recomputation_sha256",
             "staging_filesystem_device", "tasks", "sha256"
         }:
             raise ValueError("input manifest fields are invalid")
@@ -60,6 +67,18 @@ class ApprovedDockerBackendFactory:
         ).hexdigest()
         if document["sha256"] != actual_hash:
             raise ValueError("input manifest hash mismatch")
+        selection_hash = document["selection_recomputation_sha256"]
+        if (
+            not isinstance(selection_hash, str)
+            or re.fullmatch(r"[0-9a-f]{64}", selection_hash) is None
+        ):
+            raise ValueError("input manifest selection identity is invalid")
+        provider_classification = document["provider_classification"]
+        if (
+            not isinstance(provider_classification, str)
+            or not provider_classification
+        ):
+            raise ValueError("input manifest provider classification is invalid")
         if document["staging_filesystem_device"] != Path(
             tempfile.gettempdir()
         ).stat().st_dev:
@@ -67,6 +86,8 @@ class ApprovedDockerBackendFactory:
         if not isinstance(document["tasks"], dict):
             raise ValueError("input manifest tasks are invalid")
         self.tasks = document["tasks"]
+        self.selection_recomputation_sha256 = selection_hash
+        self.provider_classification = provider_classification
         self.image = image
         self.verifier_image = verifier_image
         self.seccomp_profile = seccomp_profile
@@ -103,6 +124,13 @@ class ApprovedDockerBackendFactory:
             }
             if not isinstance(item, Mapping) or set(item) != required:
                 raise ValueError("approved input file record is invalid")
+            if (
+                item["provider_classification"]
+                != self.provider_classification
+            ):
+                raise ValueError(
+                    "approved input provider classification differs from manifest"
+                )
             if item["reference_id"] not in reference_ids:
                 raise ValueError("approved input file has unknown reference ID")
             source_relative = Path(str(item["source_path"]))
@@ -113,12 +141,12 @@ class ApprovedDockerBackendFactory:
                 or any(part.startswith(".") for part in source_relative.parts)
             ):
                 raise ValueError("approved source path is invalid")
-            source = self.dataset_root / source_relative
             relative = str(item["relative_path"])
             if item["path"] != relative:
                 raise ValueError("approved relative path identity mismatch")
             reference_files.append({
-                "source_path": str(source),
+                "source_root": str(self.dataset_root),
+                "source_path": source_relative.as_posix(),
                 "relative_path": relative,
             })
             approved[relative] = {
@@ -134,11 +162,11 @@ class ApprovedDockerBackendFactory:
             reference_files=reference_files,
             occupation=occupation,
             approved_input_manifest=approved,
-            provider_classification=(
-                str(next(iter(approved.values()))["provider_classification"])
-                if approved else "approved_public_gdpval"
-            ),
+            provider_classification=self.provider_classification,
             expected_input_merkle_root=str(task["input_merkle_root"]),
+            selection_recomputation_sha256=(
+                self.selection_recomputation_sha256
+            ),
             image=self.image,
             verifier_image=self.verifier_image,
             seccomp_profile=self.seccomp_profile,
@@ -172,24 +200,33 @@ class ComputeRequestHandler(BaseHTTPRequestHandler):
             return
         try:
             envelope = json.loads(self.rfile.read(length))
+            deadline_at = _command_deadline(envelope)
             compute_server = getattr(self.server, "compute_server", None)
             if compute_server is None:
                 raise RuntimeError("compute server is unavailable")
             result = compute_server.handle(envelope)
-            body = json.dumps(
-                result, sort_keys=True, separators=(",", ":"), allow_nan=False
-            ).encode("utf-8")
-            if len(body) > MAX_RESULT_BYTES:
-                raise RuntimeError("compute result exceeds byte cap")
+            body = _encode_response_before_deadline(result, deadline_at)
         except Exception:
             self.send_error(400)
             return
+        if time.time() >= deadline_at:
+            self.send_error(408)
+            return
+        self.connection.settimeout(max(0.001, deadline_at - time.time()))
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Connection", "close")
         self.end_headers()
-        self.wfile.write(body)
+        view = memoryview(body)
+        for offset in range(0, len(view), 64 * 1024):
+            remaining = deadline_at - time.time()
+            if remaining <= 0:
+                self.close_connection = True
+                return
+            self.connection.settimeout(max(0.001, remaining))
+            self.wfile.write(view[offset:offset + 64 * 1024])
+        self.wfile.flush()
 
     def log_message(self, format: str, *args: Any) -> None:
         return
@@ -205,6 +242,39 @@ class ComputeHTTPServer(ThreadingHTTPServer):
     def server_close(self) -> None:
         self.compute_server.close()
         super().server_close()
+
+
+def _command_deadline(envelope: Any) -> float:
+    payload = envelope.get("payload") if isinstance(envelope, Mapping) else None
+    value = payload.get("deadline_at") if isinstance(payload, Mapping) else None
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) <= time.time()
+        or float(value) > time.time() + 1200
+    ):
+        raise ValueError("compute command deadline is invalid")
+    return float(value)
+
+
+def _encode_response_before_deadline(
+    result: Mapping[str, Any], deadline_at: float
+) -> bytes:
+    encoder = json.JSONEncoder(
+        sort_keys=True, separators=(",", ":"), allow_nan=False
+    )
+    chunks = []
+    total = 0
+    for text in encoder.iterencode(dict(result)):
+        if time.time() >= deadline_at:
+            raise TimeoutError("compute response encoding deadline exhausted")
+        chunk = text.encode("utf-8")
+        total += len(chunk)
+        if total > MAX_RESULT_BYTES:
+            raise RuntimeError("compute result exceeds byte cap")
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def main() -> None:

--- a/batch-runner/core/agentic_compute_service.py
+++ b/batch-runner/core/agentic_compute_service.py
@@ -1,0 +1,259 @@
+"""Dedicated uncredentialed HTTPS service for one approved agentic task."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import ssl
+import tempfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Mapping
+
+from core.agentic_channel import (
+    ChannelScope,
+    ComputeChannelServer,
+    EnvelopeAuthority,
+)
+from core.agentic_compute import AgenticDockerBackend
+from core.agentic_remote_compute import MAX_COMMAND_BYTES, MAX_RESULT_BYTES
+
+
+class ApprovedDockerBackendFactory:
+    """Resolve immutable reference IDs to compute-runner-local approved bytes."""
+
+    def __init__(
+        self,
+        *,
+        input_manifest_path: str | Path,
+        dataset_root: str | Path,
+        image: str,
+        verifier_image: str,
+        seccomp_profile: str,
+        apparmor_profile: str,
+        sbom_sha256: str,
+        cpus: float = 2,
+        memory_gb: int = 8,
+    ):
+        self.dataset_root = Path(dataset_root).resolve()
+        if not self.dataset_root.is_dir():
+            raise ValueError("compute dataset root is missing")
+        document = json.loads(
+            Path(input_manifest_path).read_text(encoding="utf-8")
+        )
+        if not isinstance(document, dict) or set(document) != {
+            "schema_version", "provider_classification",
+            "staging_filesystem_device", "tasks", "sha256"
+        }:
+            raise ValueError("input manifest fields are invalid")
+        if document["schema_version"] != "agentic-input-manifest-v1":
+            raise ValueError("input manifest version is invalid")
+        canonical = {
+            key: value for key, value in document.items() if key != "sha256"
+        }
+        actual_hash = hashlib.sha256(
+            json.dumps(
+                canonical, sort_keys=True, separators=(",", ":"), allow_nan=False
+            ).encode("utf-8")
+        ).hexdigest()
+        if document["sha256"] != actual_hash:
+            raise ValueError("input manifest hash mismatch")
+        if document["staging_filesystem_device"] != Path(
+            tempfile.gettempdir()
+        ).stat().st_dev:
+            raise ValueError("input manifest staging filesystem mismatch")
+        if not isinstance(document["tasks"], dict):
+            raise ValueError("input manifest tasks are invalid")
+        self.tasks = document["tasks"]
+        self.image = image
+        self.verifier_image = verifier_image
+        self.seccomp_profile = seccomp_profile
+        self.apparmor_profile = apparmor_profile
+        self.sbom_sha256 = sbom_sha256
+        self.cpus = cpus
+        self.memory_gb = memory_gb
+
+    def __call__(
+        self,
+        *,
+        task_prompt: str,
+        reference_ids: list,
+        occupation: str,
+        task_id: str,
+    ) -> AgenticDockerBackend:
+        task = self.tasks.get(task_id)
+        if not isinstance(task, dict) or set(task) != {
+            "reference_ids", "files", "input_merkle_root"
+        }:
+            raise ValueError("task input manifest is missing or invalid")
+        if reference_ids != task["reference_ids"]:
+            raise ValueError("task reference IDs differ from approved manifest")
+        files = task["files"]
+        if not isinstance(files, list):
+            raise ValueError("task input files are invalid")
+        reference_files = []
+        approved = {}
+        for item in files:
+            required = {
+                "reference_id", "source_path", "relative_path", "path", "type",
+                "link_count", "size_bytes", "source_allocated_bytes",
+                "staged_allocated_bytes", "sha256", "provider_classification",
+            }
+            if not isinstance(item, Mapping) or set(item) != required:
+                raise ValueError("approved input file record is invalid")
+            if item["reference_id"] not in reference_ids:
+                raise ValueError("approved input file has unknown reference ID")
+            source_relative = Path(str(item["source_path"]))
+            if (
+                source_relative.is_absolute()
+                or not source_relative.parts
+                or ".." in source_relative.parts
+                or any(part.startswith(".") for part in source_relative.parts)
+            ):
+                raise ValueError("approved source path is invalid")
+            source = self.dataset_root / source_relative
+            relative = str(item["relative_path"])
+            if item["path"] != relative:
+                raise ValueError("approved relative path identity mismatch")
+            reference_files.append({
+                "source_path": str(source),
+                "relative_path": relative,
+            })
+            approved[relative] = {
+                key: item[key]
+                for key in (
+                    "path", "type", "link_count", "size_bytes",
+                    "source_allocated_bytes", "sha256",
+                    "provider_classification",
+                )
+            }
+        backend = AgenticDockerBackend(
+            task_prompt=task_prompt,
+            reference_files=reference_files,
+            occupation=occupation,
+            approved_input_manifest=approved,
+            provider_classification=(
+                str(next(iter(approved.values()))["provider_classification"])
+                if approved else "approved_public_gdpval"
+            ),
+            expected_input_merkle_root=str(task["input_merkle_root"]),
+            image=self.image,
+            verifier_image=self.verifier_image,
+            seccomp_profile=self.seccomp_profile,
+            apparmor_profile=self.apparmor_profile,
+            sbom_sha256=self.sbom_sha256,
+            cpus=self.cpus,
+            memory_gb=self.memory_gb,
+        )
+        return backend
+
+
+class ComputeRequestHandler(BaseHTTPRequestHandler):
+    server_version = "GDPValAgenticCompute/1"
+
+    def do_POST(self) -> None:
+        self.connection.settimeout(10.0)
+        if self.path != "/v1/agentic/compute":
+            self.send_error(404)
+            return
+        if self.connection.getpeercert() is None:
+            self.send_error(403)
+            return
+        raw_length = self.headers.get("Content-Length")
+        try:
+            length = int(raw_length or "")
+        except ValueError:
+            self.send_error(411)
+            return
+        if length <= 0 or length > MAX_COMMAND_BYTES:
+            self.send_error(413)
+            return
+        try:
+            envelope = json.loads(self.rfile.read(length))
+            compute_server = getattr(self.server, "compute_server", None)
+            if compute_server is None:
+                raise RuntimeError("compute server is unavailable")
+            result = compute_server.handle(envelope)
+            body = json.dumps(
+                result, sort_keys=True, separators=(",", ":"), allow_nan=False
+            ).encode("utf-8")
+            if len(body) > MAX_RESULT_BYTES:
+                raise RuntimeError("compute result exceeds byte cap")
+        except Exception:
+            self.send_error(400)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+
+class ComputeHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address, compute_server):
+        super().__init__(address, ComputeRequestHandler)
+        self.compute_server = compute_server
+
+    def server_close(self) -> None:
+        self.compute_server.close()
+        super().server_close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bind", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--server-cert", required=True)
+    parser.add_argument("--server-key", required=True)
+    parser.add_argument("--client-ca", required=True)
+    parser.add_argument("--channel-key-file", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--condition", required=True)
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--input-manifest", required=True)
+    parser.add_argument("--dataset-root", required=True)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--verifier-image", required=True)
+    parser.add_argument("--seccomp-profile", required=True)
+    parser.add_argument("--apparmor-profile", required=True)
+    parser.add_argument("--sbom-sha256", required=True)
+    args = parser.parse_args()
+
+    key = base64.b64decode(
+        Path(args.channel_key_file).read_text(encoding="ascii").strip(),
+        validate=True,
+    )
+    authority = EnvelopeAuthority(
+        key,
+        ChannelScope(args.run_id, args.condition, args.task_id),
+    )
+    backend_factory = ApprovedDockerBackendFactory(
+        input_manifest_path=args.input_manifest,
+        dataset_root=args.dataset_root,
+        image=args.image,
+        verifier_image=args.verifier_image,
+        seccomp_profile=args.seccomp_profile,
+        apparmor_profile=args.apparmor_profile,
+        sbom_sha256=args.sbom_sha256,
+    )
+    compute_server = ComputeChannelServer(authority, backend_factory)
+    server = ComputeHTTPServer((args.bind, args.port), compute_server)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    context.load_cert_chain(args.server_cert, args.server_key)
+    context.load_verify_locations(args.client_ca)
+    context.verify_mode = ssl.CERT_REQUIRED
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/core/agentic_endpoints.py
+++ b/batch-runner/core/agentic_endpoints.py
@@ -1,0 +1,425 @@
+"""Preregistered fixed-denominator endpoints for the 20-task paired diagnostic."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Mapping, Sequence
+
+from core.agentic_budget import AgenticBudgetLedger
+
+
+N_DIAGNOSTIC = 20
+WALL_CAP_MS = 1_200_000.0
+ITEM_STATES = ("missing", "judge_error", "score_excluded", "scored")
+
+
+def compute_paired_endpoints(
+    *,
+    expected_task_ids: Sequence[str],
+    baseline_results: Sequence[Mapping[str, Any]],
+    treatment_results: Sequence[Mapping[str, Any]],
+    rubric_maxima: Mapping[str, Sequence[Mapping[str, Any]]],
+    baseline_grades: Mapping[str, Any],
+    treatment_grades: Mapping[str, Any],
+    budget_ledger: AgenticBudgetLedger,
+    paired_run_id: str,
+    baseline_task_scopes: Mapping[str, str],
+    treatment_task_scopes: Mapping[str, str],
+) -> dict:
+    expected = list(expected_task_ids)
+    if len(expected) != N_DIAGNOSTIC or len(set(expected)) != N_DIAGNOSTIC:
+        raise ValueError("paired endpoint requires 20 unique frozen task IDs")
+    baseline = _index_exact(baseline_results, expected, "baseline")
+    treatment = _index_exact(treatment_results, expected, "treatment")
+    maxima = _validate_maxima(rubric_maxima, expected)
+    substrate_hashes = {
+        _substrate_hash(result)
+        for result in [*baseline.values(), *treatment.values()]
+    }
+    if len(substrate_hashes) != 1:
+        raise ValueError(
+            "baseline and treatment substrate manifests are not byte-identical"
+        )
+    substrate_sha256 = next(iter(substrate_hashes))
+
+    baseline_complete = {
+        task_id: _completed(baseline[task_id], treatment=False)
+        for task_id in expected
+    }
+    treatment_complete = {
+        task_id: _completed(treatment[task_id], treatment=True)
+        for task_id in expected
+    }
+    completion_baseline = sum(baseline_complete.values()) / N_DIAGNOSTIC
+    completion_treatment = sum(treatment_complete.values()) / N_DIAGNOSTIC
+
+    baseline_quality = _quality(
+        expected,
+        maxima,
+        _normalize_grade_document(baseline_grades, expected, "baseline"),
+        baseline_complete,
+    )
+    treatment_quality = _quality(
+        expected,
+        maxima,
+        _normalize_grade_document(treatment_grades, expected, "treatment"),
+        treatment_complete,
+    )
+    baseline_times = [_time_to_valid(baseline[task_id]) for task_id in expected]
+    treatment_times = [_time_to_valid(treatment[task_id]) for task_id in expected]
+    baseline_p95 = _nearest_rank_p95(baseline_times)
+    treatment_p95 = _nearest_rank_p95(treatment_times)
+    baseline_cost_by_task = _ledger_costs(
+        budget_ledger, paired_run_id, baseline_task_scopes, expected, "baseline"
+    )
+    treatment_cost_by_task = _ledger_costs(
+        budget_ledger, paired_run_id, treatment_task_scopes, expected, "treatment"
+    )
+    _validate_aggregate_reservation_sets(
+        budget_ledger,
+        paired_run_id,
+        baseline_task_scopes,
+        treatment_task_scopes,
+    )
+    baseline_costs = [baseline_cost_by_task[task_id] for task_id in expected]
+    treatment_costs = [treatment_cost_by_task[task_id] for task_id in expected]
+    baseline_mean_cost = sum(baseline_costs) / N_DIAGNOSTIC
+    treatment_mean_cost = sum(treatment_costs) / N_DIAGNOSTIC
+
+    return {
+        "schema_version": "agentic-paired-endpoints-v1",
+        "denominator_tasks": N_DIAGNOSTIC,
+        "ordered_task_ids": expected,
+        "common_substrate_sha256": substrate_sha256,
+        "completion": {
+            "baseline": completion_baseline,
+            "treatment": completion_treatment,
+            "delta_percentage_points": round(
+                100 * (completion_treatment - completion_baseline), 8
+            ),
+            "baseline_by_task": baseline_complete,
+            "treatment_by_task": treatment_complete,
+        },
+        "quality": {
+            "baseline": baseline_quality,
+            "treatment": treatment_quality,
+            "task_macro_delta": round(
+                treatment_quality["task_macro"]
+                - baseline_quality["task_macro"],
+                8,
+            ),
+        },
+        "timing": {
+            "missing_artifact_value_ms": WALL_CAP_MS,
+            "baseline_values_ms": baseline_times,
+            "treatment_values_ms": treatment_times,
+            "baseline_p95_ms": baseline_p95,
+            "treatment_p95_ms": treatment_p95,
+            "p95_ratio": _ratio(treatment_p95, baseline_p95),
+        },
+        "cost": {
+            "baseline_values_usd": baseline_costs,
+            "treatment_values_usd": treatment_costs,
+            "baseline_mean_usd": round(baseline_mean_cost, 8),
+            "treatment_mean_usd": round(treatment_mean_cost, 8),
+            "ratio": _ratio(treatment_mean_cost, baseline_mean_cost),
+            "basis": "settled finite usage plus unreconciled reservation",
+        },
+    }
+
+
+def _index_exact(
+    results: Sequence[Mapping[str, Any]], expected: list[str], label: str
+) -> dict[str, Mapping[str, Any]]:
+    indexed = {}
+    for result in results:
+        task_id = result.get("task_id")
+        if not isinstance(task_id, str) or task_id in indexed:
+            raise ValueError(f"{label} contains missing or duplicate task ID")
+        indexed[task_id] = result
+    if set(indexed) != set(expected):
+        raise ValueError(f"{label} task IDs differ from frozen paired set")
+    return indexed
+
+
+def _validate_maxima(
+    raw: Mapping[str, Sequence[Mapping[str, Any]]], expected: list[str]
+) -> dict[str, list[tuple[str, float]]]:
+    if set(raw) != set(expected):
+        raise ValueError("rubric maxima task IDs differ from frozen paired set")
+    output = {}
+    for task_id in expected:
+        raw_items = raw[task_id]
+        if not isinstance(raw_items, Sequence) or isinstance(
+            raw_items, (str, bytes)
+        ):
+            raise ValueError("rubric items must be a sequence")
+        values: list[tuple[str, float]] = []
+        seen = set()
+        for item in raw_items:
+            if not isinstance(item, Mapping) or set(item) != {
+                "rubric_item_id", "max_score"
+            }:
+                raise ValueError("rubric item identity fields are invalid")
+            item_id = item.get("rubric_item_id")
+            maximum = item.get("max_score")
+            if (
+                not isinstance(item_id, str)
+                or not item_id
+                or item_id in seen
+                or isinstance(maximum, bool)
+                or not isinstance(maximum, (int, float))
+                or not math.isfinite(float(maximum))
+            ):
+                raise ValueError("rubric item identity or maximum is invalid")
+            seen.add(item_id)
+            values.append((item_id, float(maximum)))
+        if not any(maximum > 0 for _, maximum in values):
+            raise ValueError(f"task has zero positive rubric denominator: {task_id}")
+        output[task_id] = values
+    return output
+
+
+def _normalize_grade_document(
+    raw: Mapping[str, Any], expected: list[str], label: str
+) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw, Mapping) or not isinstance(raw.get("tasks"), list):
+        raise ValueError(f"{label} grade must use the Step 8 tasks schema")
+    output = {}
+    expected_set = set(expected)
+    for task in raw["tasks"]:
+        if not isinstance(task, Mapping):
+            raise ValueError(f"{label} grade task is invalid")
+        task_id = task.get("task_id")
+        if (
+            not isinstance(task_id, str)
+            or task_id not in expected_set
+            or task_id in output
+        ):
+            raise ValueError(f"{label} grade has unknown or duplicate task ID")
+        raw_items = task.get("items")
+        if not isinstance(raw_items, list):
+            raise ValueError(f"{label} grade task items are invalid")
+        items = {}
+        for item in raw_items:
+            if not isinstance(item, Mapping):
+                raise ValueError(f"{label} grade item is invalid")
+            item_id = item.get("rubric_item_id")
+            if not isinstance(item_id, str) or not item_id or item_id in items:
+                raise ValueError(
+                    f"{label} grade has missing or duplicate rubric item ID"
+                )
+            items[item_id] = item
+        task_error = task.get("error")
+        if task_error is not None and not isinstance(task_error, str):
+            raise ValueError(f"{label} grade task error is invalid")
+        output[task_id] = {"items": items, "error": task_error}
+    return output
+
+
+def _completed(result: Mapping[str, Any], *, treatment: bool) -> int:
+    if result.get("status") != "success" or not result.get("deliverable_files"):
+        return 0
+    observability = result.get("observability") or {}
+    if treatment:
+        metrics = observability.get("agentic_metrics")
+        return int(
+            isinstance(metrics, Mapping)
+            and metrics.get("terminal_error_category") is None
+            and (metrics.get("finalize_attempts") or 0) > 0
+        )
+    sandbox = observability.get("sandbox")
+    return int(
+        isinstance(sandbox, Mapping)
+        and sandbox.get("final_status") in {"ok", "repaired_ok"}
+    )
+
+
+def _quality(
+    expected: list[str],
+    maxima: Mapping[str, list[tuple[str, float]]],
+    grades: Mapping[str, Mapping[str, Any]],
+    completion: Mapping[str, int],
+) -> dict:
+    task_scores = []
+    state_counts = {state: 0 for state in ITEM_STATES}
+    total_awarded = 0.0
+    total_maximum = sum(
+        sum(maximum for _, maximum in maxima[task_id] if maximum > 0)
+        for task_id in expected
+    )
+    expected_items = sum(len(maxima[task_id]) for task_id in expected)
+    missing_task_grades = 0
+    task_errors = {}
+    for task_id in expected:
+        grade = grades.get(task_id)
+        if grade is None:
+            missing_task_grades += 1
+            items = {}
+            task_error = None
+        else:
+            items = grade["items"]
+            task_error = grade.get("error")
+            if task_error:
+                task_errors[task_id] = task_error[:200]
+        expected_item_ids = {item_id for item_id, _ in maxima[task_id]}
+        if not set(items) <= expected_item_ids:
+            raise ValueError("grade contains rubric item outside frozen rubric")
+        awarded = 0.0
+        for item_id, maximum in maxima[task_id]:
+            item = items.get(item_id)
+            state = _grade_item_state(item, task_error)
+            state_counts[state] += 1
+            if state == "scored" and completion[task_id]:
+                assert item is not None
+                value = item.get("awarded_score")
+                if (
+                    isinstance(value, bool)
+                    or not isinstance(value, (int, float))
+                    or not math.isfinite(float(value))
+                ):
+                    raise ValueError("scored grade item must have finite award")
+                if maximum > 0:
+                    awarded += min(max(float(value), 0.0), maximum)
+                elif maximum < 0:
+                    awarded += min(max(float(value), maximum), 0.0)
+        awarded = awarded if completion[task_id] else 0.0
+        total_awarded += awarded
+        positive_maximum = sum(
+            maximum for _, maximum in maxima[task_id] if maximum > 0
+        )
+        task_scores.append(
+            100 * min(max(awarded / positive_maximum, 0.0), 1.0)
+        )
+    return {
+        "task_macro": round(sum(task_scores) / N_DIAGNOSTIC, 8),
+        "rubric_weighted": round(
+            100 * min(max(total_awarded / total_maximum, 0.0), 1.0), 8
+        ),
+        "task_scores": task_scores,
+        "expected_item_denominator": expected_items,
+        "item_state_counts": state_counts,
+        "item_state_rates": {
+            state: round(count / expected_items, 8)
+            for state, count in state_counts.items()
+        },
+        "missing_task_grade_count": missing_task_grades,
+        "task_error_count": len(task_errors),
+        "task_errors_by_task": task_errors,
+    }
+
+
+def _grade_item_state(
+    item: Any, task_error: Any
+) -> str:
+    if item is None:
+        return "missing"
+    if not isinstance(item, Mapping):
+        raise ValueError("grade item is invalid")
+    verdict = item.get("verdict")
+    if task_error or verdict == "judge_error":
+        return "judge_error"
+    if item.get("score_excluded") is True:
+        return "score_excluded"
+    if verdict not in {"pass", "partial", "fail"}:
+        raise ValueError("grade item verdict is invalid")
+    return "scored"
+
+
+def _time_to_valid(result: Mapping[str, Any]) -> float:
+    metrics = (result.get("observability") or {}).get("execution_metrics") or {}
+    value = metrics.get("time_to_valid_artifact_ms")
+    if (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+        and 0 <= value <= WALL_CAP_MS
+    ):
+        return float(value)
+    return WALL_CAP_MS
+
+
+def _nearest_rank_p95(values: list[float]) -> float:
+    ordered = sorted(values)
+    return ordered[math.ceil(0.95 * N_DIAGNOSTIC) - 1]
+
+
+def _ledger_costs(
+    ledger: AgenticBudgetLedger,
+    paired_run_id: str,
+    scopes: Mapping[str, str],
+    expected: list[str],
+    condition: str,
+) -> dict[str, float]:
+    if not isinstance(paired_run_id, str) or not paired_run_id:
+        raise ValueError("paired run ID is required")
+    if set(scopes) != set(expected):
+        raise ValueError(f"{condition} ledger scopes differ from frozen paired set")
+    if len(set(scopes.values())) != len(expected):
+        raise ValueError(f"{condition} ledger scopes must be unique")
+    costs = {}
+    for task_id in expected:
+        scope = scopes[task_id]
+        try:
+            parsed = json.loads(scope)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"{condition} ledger scope is invalid") from exc
+        if (
+            not isinstance(parsed, list)
+            or len(parsed) != 3
+            or not isinstance(parsed[0], str)
+            or not parsed[0]
+            or parsed != [paired_run_id, condition, task_id]
+            or json.dumps(parsed, separators=(",", ":")) != scope
+        ):
+            raise ValueError(f"{condition} ledger scope is invalid")
+        value = float(ledger.usage(scope).cost_usd)
+        if not math.isfinite(value) or value < 0:
+            raise ValueError("ledger cost must be finite and non-negative")
+        costs[task_id] = value
+    return costs
+
+
+def _validate_aggregate_reservation_sets(
+    ledger: AgenticBudgetLedger,
+    paired_run_id: str,
+    baseline_scopes: Mapping[str, str],
+    treatment_scopes: Mapping[str, str],
+) -> None:
+    unions = {}
+    for condition, scopes in (
+        ("baseline", baseline_scopes), ("treatment", treatment_scopes)
+    ):
+        task_requests = set().union(
+            *(ledger.reservation_ids(scope) for scope in scopes.values())
+        )
+        condition_scope = json.dumps(
+            ["condition", paired_run_id, condition], separators=(",", ":")
+        )
+        if ledger.reservation_ids(condition_scope) != task_requests:
+            raise ValueError(
+                f"{condition} aggregate reservations differ from task requests"
+            )
+        unions[condition] = task_requests
+    paired_scope = json.dumps(
+        ["paired_run", paired_run_id], separators=(",", ":")
+    )
+    if ledger.reservation_ids(paired_scope) != (
+        unions["baseline"] | unions["treatment"]
+    ):
+        raise ValueError("paired aggregate reservations differ from task requests")
+
+
+def _substrate_hash(result: Mapping[str, Any]) -> str:
+    substrate = (result.get("observability") or {}).get("substrate") or {}
+    value = substrate.get("sha256")
+    if not isinstance(value, str) or len(value) != 64:
+        raise ValueError("paired task is missing substrate manifest identity")
+    return value
+
+
+def _ratio(numerator: float, denominator: float) -> float | str:
+    if denominator == 0:
+        return 1.0 if numerator == 0 else "infinity"
+    return round(numerator / denominator, 8)

--- a/batch-runner/core/agentic_endpoints.py
+++ b/batch-runner/core/agentic_endpoints.py
@@ -66,8 +66,14 @@ def compute_paired_endpoints(
         _normalize_grade_document(treatment_grades, expected, "treatment"),
         treatment_complete,
     )
-    baseline_times = [_time_to_valid(baseline[task_id]) for task_id in expected]
-    treatment_times = [_time_to_valid(treatment[task_id]) for task_id in expected]
+    baseline_times = [
+        _time_to_valid(baseline[task_id], treatment=False)
+        for task_id in expected
+    ]
+    treatment_times = [
+        _time_to_valid(treatment[task_id], treatment=True)
+        for task_id in expected
+    ]
     baseline_p95 = _nearest_rank_p95(baseline_times)
     treatment_p95 = _nearest_rank_p95(treatment_times)
     baseline_cost_by_task = _ledger_costs(
@@ -226,13 +232,17 @@ def _completed(result: Mapping[str, Any], *, treatment: bool) -> int:
         metrics = observability.get("agentic_metrics")
         return int(
             isinstance(metrics, Mapping)
+            and metrics.get("usage_complete") is True
             and metrics.get("terminal_error_category") is None
             and (metrics.get("finalize_attempts") or 0) > 0
         )
     sandbox = observability.get("sandbox")
+    budget = observability.get("budget_metrics")
     return int(
         isinstance(sandbox, Mapping)
         and sandbox.get("final_status") in {"ok", "repaired_ok"}
+        and isinstance(budget, Mapping)
+        and budget.get("usage_complete") is True
     )
 
 
@@ -327,9 +337,31 @@ def _grade_item_state(
     return "scored"
 
 
-def _time_to_valid(result: Mapping[str, Any]) -> float:
-    metrics = (result.get("observability") or {}).get("execution_metrics") or {}
-    value = metrics.get("time_to_valid_artifact_ms")
+def _time_to_valid(
+    result: Mapping[str, Any], *, treatment: bool
+) -> float:
+    observability = result.get("observability") or {}
+    generic = (observability.get("execution_metrics") or {}).get(
+        "time_to_valid_artifact_ms"
+    )
+    specialized_block = (
+        observability.get("agentic_metrics")
+        if treatment else observability.get("budget_metrics")
+    ) or {}
+    specialized = specialized_block.get("time_to_valid_artifact_ms")
+    generic_value = _valid_time(generic)
+    specialized_value = _valid_time(specialized)
+    if (
+        generic_value is not None
+        and specialized_value is not None
+        and generic_value != specialized_value
+    ):
+        raise ValueError("first-valid timing metrics disagree")
+    value = specialized_value if specialized_value is not None else generic_value
+    return WALL_CAP_MS if value is None else value
+
+
+def _valid_time(value: Any) -> float | None:
     if (
         isinstance(value, (int, float))
         and not isinstance(value, bool)
@@ -337,7 +369,7 @@ def _time_to_valid(result: Mapping[str, Any]) -> float:
         and 0 <= value <= WALL_CAP_MS
     ):
         return float(value)
-    return WALL_CAP_MS
+    return None
 
 
 def _nearest_rank_p95(values: list[float]) -> float:

--- a/batch-runner/core/agentic_experiments.py
+++ b/batch-runner/core/agentic_experiments.py
@@ -1,0 +1,72 @@
+"""Reserved diagnostic experiment identities for Agentic Sandbox."""
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping
+
+AGENTIC_CANARY_ID = "exp028"
+AGENTIC_BASELINE_ID = "exp029"
+AGENTIC_TREATMENT_ID = "exp030"
+AGENTIC_EXPERIMENT_IDS = {
+    AGENTIC_CANARY_ID,
+    AGENTIC_BASELINE_ID,
+    AGENTIC_TREATMENT_ID,
+}
+AGENTIC_CONDITIONS = {
+    AGENTIC_CANARY_ID: "canary",
+    AGENTIC_BASELINE_ID: "baseline",
+    AGENTIC_TREATMENT_ID: "treatment",
+}
+
+
+def agentic_condition_identity(experiment_id: str) -> str:
+    try:
+        return AGENTIC_CONDITIONS[experiment_id]
+    except KeyError as exc:
+        raise ValueError("unknown agentic experiment ID") from exc
+
+
+def validate_agentic_budget_for_experiment(
+    experiment_id: str, budget: Any
+) -> None:
+    if not isinstance(budget, Mapping) or set(budget) != {
+        "paired_run_id", "condition", "paired_run"
+    }:
+        raise ValueError("agentic budget fields are invalid")
+    if experiment_id != AGENTIC_CANARY_ID:
+        return
+    count_maxima = {
+        "attempts": 30,
+        "input_tokens": 1_500_000,
+        "output_tokens": 163_840,
+    }
+    cost_maximum = Decimal("6.25")
+    for scope_name in ("condition", "paired_run"):
+        scope = budget.get(scope_name)
+        if not isinstance(scope, Mapping):
+            raise ValueError(f"canary {scope_name} budget is invalid")
+        for field in ("attempts", "input_tokens", "output_tokens"):
+            value = scope.get(field)
+            if type(value) is not int or not 0 < value <= count_maxima[field]:
+                raise ValueError(f"canary {scope_name}.{field} exceeds hard cap")
+        try:
+            cost = Decimal(str(scope.get("cost_usd")))
+        except (InvalidOperation, ValueError, TypeError) as exc:
+            raise ValueError(f"canary {scope_name}.cost_usd is invalid") from exc
+        if not cost.is_finite() or not 0 < cost <= cost_maximum:
+            raise ValueError(f"canary {scope_name}.cost_usd exceeds hard cap")
+
+
+def validate_agentic_experiment_identity(
+    experiment_id: str,
+    execution_mode: str,
+    hardened_baseline: bool,
+) -> None:
+    if execution_mode == "agentic_sandbox":
+        if experiment_id not in {AGENTIC_CANARY_ID, AGENTIC_TREATMENT_ID}:
+            raise ValueError(
+                "agentic_sandbox experiment ID must be exp028 or exp030"
+            )
+        return
+    if execution_mode == "sandbox" and hardened_baseline:
+        if experiment_id != AGENTIC_BASELINE_ID:
+            raise ValueError("hardened sandbox baseline experiment ID must be exp029")

--- a/batch-runner/core/agentic_idle.py
+++ b/batch-runner/core/agentic_idle.py
@@ -1,0 +1,21 @@
+"""PID 1 for a disposable agentic task container."""
+
+from __future__ import annotations
+
+import os
+import signal
+from pathlib import Path
+
+
+def main() -> None:
+    if os.geteuid() == 0:
+        raise SystemExit("agentic task container refuses UID 0")
+    for relative in (".home", ".cache", ".config", ".tmp"):
+        path = Path("/work") / relative
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    while True:
+        signal.pause()
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/core/agentic_input_manifest.py
+++ b/batch-runner/core/agentic_input_manifest.py
@@ -1,0 +1,176 @@
+"""Build approved input identities on the exact compute-runner filesystem."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+from core.agentic_compute import (
+    MAX_DEPTH,
+    MAX_INPUT_FILES,
+    MAX_INPUT_SINGLE,
+    MAX_INPUT_TOTAL,
+    MAX_PATH_BYTES,
+    _open_regular_nofollow,
+    _sha256_descriptor,
+    _source_identity,
+)
+
+
+def build_input_manifest(
+    *,
+    selection_manifest: Mapping[str, Any],
+    dataset_root: str | Path,
+    staging_parent: str | Path,
+    provider_classification: str,
+) -> dict:
+    root = Path(dataset_root).resolve()
+    staging_parent = Path(staging_parent).resolve()
+    if not root.is_dir() or not staging_parent.is_dir():
+        raise ValueError("dataset root and staging parent must exist")
+    if not provider_classification:
+        raise ValueError("provider classification is required")
+    selected = selection_manifest.get("selected_tasks")
+    if not isinstance(selected, list) or len(selected) != 25:
+        raise ValueError("selection manifest must contain exactly 25 tasks")
+
+    tasks = {}
+    with tempfile.TemporaryDirectory(
+        prefix="agentic-input-manifest-", dir=staging_parent
+    ) as temporary:
+        temporary_root = Path(temporary)
+        for task in selected:
+            if not isinstance(task, Mapping):
+                raise ValueError("selected task record is invalid")
+            task_id = task.get("task_id")
+            paths = task.get("reference_paths")
+            sizes = task.get("reference_sizes")
+            if (
+                not isinstance(task_id, str)
+                or task_id in tasks
+                or not isinstance(paths, list)
+                or not isinstance(sizes, list)
+                or len(paths) != len(sizes)
+            ):
+                raise ValueError("selected task input metadata is invalid")
+            if len(paths) > MAX_INPUT_FILES:
+                raise ValueError("selected task exceeds input file count")
+            task_staging = temporary_root / task_id
+            task_staging.mkdir(mode=0o700)
+            file_records: list[dict[str, Any]] = []
+            merkle_records: list[dict[str, Any]] = []
+            total = 0
+            for relative_value, expected_size in zip(paths, sizes):
+                relative = Path(relative_value)
+                if (
+                    relative.is_absolute()
+                    or not relative.parts
+                    or ".." in relative.parts
+                    or any(part.startswith(".") for part in relative.parts)
+                    or len(relative.parts) > MAX_DEPTH
+                    or len(relative.as_posix().encode("utf-8")) > MAX_PATH_BYTES
+                ):
+                    raise ValueError("selected reference path is invalid")
+                source = root / relative
+                destination = task_staging / relative
+                destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                digest = hashlib.sha256()
+                try:
+                    descriptor = _open_regular_nofollow(source)
+                except OSError as exc:
+                    raise ValueError(
+                        "selected source path contains a link or invalid component"
+                    ) from exc
+                try:
+                    metadata = os.fstat(descriptor)
+                    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                        raise ValueError(
+                            "selected source is not a single-link regular file"
+                        )
+                    if metadata.st_size != expected_size:
+                        raise ValueError(
+                            "selected source size differs from selection manifest"
+                        )
+                    if metadata.st_size > MAX_INPUT_SINGLE:
+                        raise ValueError("selected source exceeds single-file limit")
+                    total += metadata.st_size
+                    if total > MAX_INPUT_TOTAL:
+                        raise ValueError("selected sources exceed total input limit")
+                    with os.fdopen(os.dup(descriptor), "rb") as input_stream, destination.open("xb") as output:
+                        for chunk in iter(lambda: input_stream.read(65536), b""):
+                            digest.update(chunk)
+                            output.write(chunk)
+                    after = os.fstat(descriptor)
+                    source_hash = _sha256_descriptor(descriptor)
+                    if _source_identity(after) != _source_identity(metadata):
+                        raise ValueError("selected source changed during staging")
+                    if source_hash != digest.hexdigest():
+                        raise ValueError("selected source changed during staging")
+                finally:
+                    os.close(descriptor)
+                staged = destination.lstat()
+                staged_hash = _sha256_file(destination)
+                if staged_hash != digest.hexdigest():
+                    raise ValueError("staged input hash mismatch")
+                relative_path = relative.as_posix()
+                approved: dict[str, Any] = {
+                    "path": relative_path,
+                    "type": "regular",
+                    "link_count": 1,
+                    "size_bytes": metadata.st_size,
+                    "source_allocated_bytes": metadata.st_blocks * 512,
+                    "staged_allocated_bytes": staged.st_blocks * 512,
+                    "sha256": staged_hash,
+                    "provider_classification": provider_classification,
+                }
+                merkle_records.append({
+                    **approved,
+                    "model_path": f"inputs/{relative_path}",
+                })
+                file_records.append({
+                    "reference_id": relative_path,
+                    "source_path": relative_path,
+                    "relative_path": relative_path,
+                    **approved,
+                })
+            merkle_records.sort(
+                key=lambda item: str(item["path"]).encode("utf-8")
+            )
+            input_root = hashlib.sha256(
+                json.dumps(
+                    merkle_records,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                ).encode("utf-8")
+            ).hexdigest()
+            tasks[task_id] = {
+                "reference_ids": list(paths),
+                "files": file_records,
+                "input_merkle_root": input_root,
+            }
+    manifest = {
+        "schema_version": "agentic-input-manifest-v1",
+        "provider_classification": provider_classification,
+        "staging_filesystem_device": staging_parent.stat().st_dev,
+        "tasks": tasks,
+    }
+    manifest["sha256"] = hashlib.sha256(
+        json.dumps(
+            manifest, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+    ).hexdigest()
+    return manifest
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/batch-runner/core/agentic_input_manifest.py
+++ b/batch-runner/core/agentic_input_manifest.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
+import re
 import stat
 import tempfile
 from pathlib import Path
@@ -16,9 +18,30 @@ from core.agentic_compute import (
     MAX_INPUT_SINGLE,
     MAX_INPUT_TOTAL,
     MAX_PATH_BYTES,
-    _open_regular_nofollow,
+    _open_regular_beneath_nofollow,
     _sha256_descriptor,
     _source_identity,
+)
+
+
+SELECTION_FIELDS = {
+    "schema_version", "seed", "eligible_frame_count", "strata",
+    "canary_task_ids", "diagnostic_task_ids", "selected_tasks",
+    "selection_domains", "tie_break", "selected_before_outcomes",
+    "dataset", "rubric", "selector", "inclusion_validation",
+    "exclusion_validation", "recomputation_sha256",
+}
+SELECTION_DOMAINS = {
+    "select": "agentic-select-v1",
+    "canary": "agentic-canary-v1",
+    "order_canary": "agentic-order-canary-v1",
+    "order_diagnostic": "agentic-order-diagnostic-v1",
+}
+FULL_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+REPOSITORY_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}/"
+    r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}$"
 )
 
 
@@ -29,15 +52,17 @@ def build_input_manifest(
     staging_parent: str | Path,
     provider_classification: str,
 ) -> dict:
-    root = Path(dataset_root).resolve()
+    selection = validate_selection_manifest(selection_manifest)
+    raw_root = Path(dataset_root)
+    if raw_root.is_symlink():
+        raise ValueError("dataset root must not be a symlink")
+    root = raw_root.resolve()
     staging_parent = Path(staging_parent).resolve()
     if not root.is_dir() or not staging_parent.is_dir():
         raise ValueError("dataset root and staging parent must exist")
     if not provider_classification:
         raise ValueError("provider classification is required")
-    selected = selection_manifest.get("selected_tasks")
-    if not isinstance(selected, list) or len(selected) != 25:
-        raise ValueError("selection manifest must contain exactly 25 tasks")
+    selected = selection["selected_tasks"]
 
     tasks = {}
     with tempfile.TemporaryDirectory(
@@ -58,9 +83,20 @@ def build_input_manifest(
                 or len(paths) != len(sizes)
             ):
                 raise ValueError("selected task input metadata is invalid")
+            if (
+                task_id in {".", ".."}
+                or task_id.startswith(".")
+                or "/" in task_id
+                or "\\" in task_id
+                or len(task_id.encode("utf-8")) > MAX_PATH_BYTES
+                or any(ord(character) < 32 for character in task_id)
+            ):
+                raise ValueError("selected task ID is not a canonical component")
             if len(paths) > MAX_INPUT_FILES:
                 raise ValueError("selected task exceeds input file count")
-            task_staging = temporary_root / task_id
+            task_staging = temporary_root / hashlib.sha256(
+                task_id.encode("utf-8")
+            ).hexdigest()
             task_staging.mkdir(mode=0o700)
             file_records: list[dict[str, Any]] = []
             merkle_records: list[dict[str, Any]] = []
@@ -76,12 +112,13 @@ def build_input_manifest(
                     or len(relative.as_posix().encode("utf-8")) > MAX_PATH_BYTES
                 ):
                     raise ValueError("selected reference path is invalid")
-                source = root / relative
                 destination = task_staging / relative
                 destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
                 digest = hashlib.sha256()
                 try:
-                    descriptor = _open_regular_nofollow(source)
+                    descriptor = _open_regular_beneath_nofollow(
+                        root, relative
+                    )
                 except OSError as exc:
                     raise ValueError(
                         "selected source path contains a link or invalid component"
@@ -156,6 +193,9 @@ def build_input_manifest(
             }
     manifest = {
         "schema_version": "agentic-input-manifest-v1",
+        "selection_recomputation_sha256": selection[
+            "recomputation_sha256"
+        ],
         "provider_classification": provider_classification,
         "staging_filesystem_device": staging_parent.stat().st_dev,
         "tasks": tasks,
@@ -166,6 +206,206 @@ def build_input_manifest(
         ).encode("utf-8")
     ).hexdigest()
     return manifest
+
+
+def validate_selection_manifest(
+    selection_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(selection_manifest, Mapping):
+        raise ValueError("selection manifest must be an object")
+    document = dict(selection_manifest)
+    if set(document) != SELECTION_FIELDS:
+        raise ValueError("selection manifest fields are invalid")
+    if (
+        document["schema_version"] != "agentic-task-subset-v1"
+        or document["seed"] != "20260717"
+        or document["selection_domains"] != SELECTION_DOMAINS
+        or document["tie_break"] != "ascending UTF-8 bytes"
+        or document["selected_before_outcomes"] is not True
+        or document["inclusion_validation"]
+        != "all structural checks passed"
+        or document["exclusion_validation"]
+        != "outcome fields were not accepted by selector"
+    ):
+        raise ValueError("selection manifest frozen identity is invalid")
+    expected_hash = document["recomputation_sha256"]
+    if (
+        not isinstance(expected_hash, str)
+        or SHA256_RE.fullmatch(expected_hash) is None
+    ):
+        raise ValueError("selection recomputation hash is invalid")
+    canonical = {
+        key: value
+        for key, value in document.items()
+        if key != "recomputation_sha256"
+    }
+    actual_hash = hashlib.sha256(
+        json.dumps(
+            canonical, sort_keys=True, separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+    if actual_hash != expected_hash:
+        raise ValueError("selection recomputation hash mismatch")
+
+    canary_ids = _task_id_list(document["canary_task_ids"], 5)
+    diagnostic_ids = _task_id_list(document["diagnostic_task_ids"], 20)
+    ordered_ids = canary_ids + diagnostic_ids
+    if len(set(ordered_ids)) != 25:
+        raise ValueError("selection cohorts overlap or contain duplicates")
+    selected = document["selected_tasks"]
+    if not isinstance(selected, list) or len(selected) != 25:
+        raise ValueError("selection manifest must contain exactly 25 tasks")
+    selected_ids = [
+        _validate_selected_task(task)
+        for task in selected
+    ]
+    if selected_ids != ordered_ids:
+        raise ValueError("selection task order differs from 5/20 cohorts")
+
+    eligible_count = document["eligible_frame_count"]
+    strata = document["strata"]
+    if type(eligible_count) is not int or eligible_count < 25:
+        raise ValueError("selection eligible frame count is invalid")
+    if not isinstance(strata, list) or not strata:
+        raise ValueError("selection strata are invalid")
+    seen_strata = set()
+    eligible_total = selected_total = canary_total = 0
+    for item in strata:
+        required = {
+            "sector", "input_class", "eligible_count",
+            "selected_quota", "canary_quota",
+        }
+        if not isinstance(item, Mapping) or set(item) != required:
+            raise ValueError("selection stratum fields are invalid")
+        identity = (item["sector"], item["input_class"])
+        if (
+            any(not isinstance(value, str) or not value for value in identity)
+            or identity in seen_strata
+        ):
+            raise ValueError("selection stratum identity is invalid")
+        seen_strata.add(identity)
+        counts = (
+            item["eligible_count"], item["selected_quota"],
+            item["canary_quota"],
+        )
+        if (
+            any(type(value) is not int or value < 0 for value in counts)
+            or counts[0] < counts[1]
+            or counts[1] < counts[2]
+        ):
+            raise ValueError("selection stratum quota is invalid")
+        eligible_total += counts[0]
+        selected_total += counts[1]
+        canary_total += counts[2]
+    if (
+        eligible_total != eligible_count
+        or selected_total != 25
+        or canary_total != 5
+    ):
+        raise ValueError("selection stratum totals are invalid")
+
+    for label in ("dataset", "rubric"):
+        provenance = document[label]
+        if not isinstance(provenance, Mapping) or set(provenance) != {
+            "repository", "revision", "source_path", "sha256"
+        }:
+            raise ValueError(f"selection {label} provenance is invalid")
+        if (
+            not isinstance(provenance["repository"], str)
+            or REPOSITORY_RE.fullmatch(provenance["repository"]) is None
+            or not isinstance(provenance["revision"], str)
+            or FULL_COMMIT_RE.fullmatch(provenance["revision"]) is None
+            or not _canonical_relative_path(provenance["source_path"])
+            or not isinstance(provenance["sha256"], str)
+            or SHA256_RE.fullmatch(provenance["sha256"]) is None
+        ):
+            raise ValueError(f"selection {label} provenance is invalid")
+    selector = document["selector"]
+    if not isinstance(selector, Mapping) or set(selector) != {
+        "path", "source_commit", "sha256"
+    }:
+        raise ValueError("selection selector provenance is invalid")
+    if (
+        not _canonical_relative_path(selector["path"])
+        or not isinstance(selector["source_commit"], str)
+        or FULL_COMMIT_RE.fullmatch(selector["source_commit"]) is None
+        or not isinstance(selector["sha256"], str)
+        or SHA256_RE.fullmatch(selector["sha256"]) is None
+    ):
+        raise ValueError("selection selector provenance is invalid")
+    return document
+
+
+def _task_id_list(value: Any, count: int) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or len(value) != count
+        or any(not isinstance(item, str) or not item for item in value)
+    ):
+        raise ValueError("selection cohort task IDs are invalid")
+    return list(value)
+
+
+def _validate_selected_task(value: Any) -> str:
+    required = {
+        "task_id", "sector", "occupation", "input_class",
+        "reference_paths", "reference_suffixes", "reference_sizes",
+        "positive_rubric_max",
+    }
+    if not isinstance(value, Mapping) or set(value) != required:
+        raise ValueError("selected task fields are invalid")
+    for field in ("task_id", "sector", "occupation", "input_class"):
+        if not isinstance(value[field], str) or not value[field]:
+            raise ValueError("selected task text identity is invalid")
+    paths = value["reference_paths"]
+    suffixes = value["reference_suffixes"]
+    sizes = value["reference_sizes"]
+    if (
+        not isinstance(paths, list)
+        or not isinstance(suffixes, list)
+        or not isinstance(sizes, list)
+        or len(paths) != len(suffixes)
+        or len(paths) != len(sizes)
+        or len(paths) > MAX_INPUT_FILES
+    ):
+        raise ValueError("selected task reference metadata is invalid")
+    total = 0
+    for path, suffix, size in zip(paths, suffixes, sizes):
+        if (
+            not _canonical_relative_path(path)
+            or not isinstance(suffix, str)
+            or suffix != Path(path).suffix.lower().lstrip(".")
+            or type(size) is not int
+            or not 0 <= size <= MAX_INPUT_SINGLE
+        ):
+            raise ValueError("selected task reference identity is invalid")
+        total += size
+    if total > MAX_INPUT_TOTAL:
+        raise ValueError("selected task references exceed input limit")
+    maximum = value["positive_rubric_max"]
+    if (
+        isinstance(maximum, bool)
+        or not isinstance(maximum, (int, float))
+        or not math.isfinite(float(maximum))
+        or maximum <= 0
+    ):
+        raise ValueError("selected task rubric denominator is invalid")
+    return value["task_id"]
+
+
+def _canonical_relative_path(value: Any) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    path = Path(value)
+    return (
+        not path.is_absolute()
+        and path.as_posix() == value
+        and ".." not in path.parts
+        and all(part not in {"", "."} and not part.startswith(".") for part in path.parts)
+        and len(path.parts) <= MAX_DEPTH
+        and len(value.encode("utf-8")) <= MAX_PATH_BYTES
+    )
 
 
 def _sha256_file(path: Path) -> str:

--- a/batch-runner/core/agentic_pricing.py
+++ b/batch-runner/core/agentic_pricing.py
@@ -1,0 +1,65 @@
+"""Immutable model pricing table loader for conservative reservations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def load_pinned_model_pricing(
+    *,
+    path: str | Path,
+    expected_sha256: str,
+    provider: str,
+    model: str,
+) -> dict:
+    price_path = Path(path)
+    if not price_path.is_file():
+        raise ValueError("agentic price table is missing")
+    raw = price_path.read_bytes()
+    actual_sha256 = hashlib.sha256(raw).hexdigest()
+    if actual_sha256 != expected_sha256:
+        raise ValueError("agentic price table hash mismatch")
+    try:
+        document = json.loads(raw)
+    except Exception as exc:
+        raise ValueError("agentic price table is invalid JSON") from exc
+    if not isinstance(document, Mapping) or set(document) != {
+        "schema_version", "models"
+    }:
+        raise ValueError("agentic price table fields are invalid")
+    if document["schema_version"] != "agentic-pricing-v1":
+        raise ValueError("unsupported agentic price table version")
+    models = document["models"]
+    key = f"{provider}:{model}"
+    if not isinstance(models, Mapping) or key not in models:
+        raise ValueError("agentic model has no pinned price entry")
+    entry = models[key]
+    required = {
+        "input_per_million", "output_per_million",
+        "cached_input_per_million", "currency",
+    }
+    if not isinstance(entry, Mapping) or set(entry) != required:
+        raise ValueError("agentic model price fields are invalid")
+    if entry["currency"] != "USD":
+        raise ValueError("agentic price table currency must be USD")
+    output = {"price_table_sha256": actual_sha256}
+    for field in (
+        "input_per_million", "output_per_million", "cached_input_per_million"
+    ):
+        value = _decimal(entry[field])
+        output[field] = str(value)
+    return output
+
+
+def _decimal(value: Any) -> Decimal:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError("agentic price must be a finite non-negative decimal") from exc
+    if not parsed.is_finite() or parsed < 0:
+        raise ValueError("agentic price must be a finite non-negative decimal")
+    return parsed

--- a/batch-runner/core/agentic_python_launcher.py
+++ b/batch-runner/core/agentic_python_launcher.py
@@ -1,0 +1,132 @@
+"""Compile generated Python, then irreversibly apply its syscall sandbox."""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import platform
+import sys
+
+
+MAX_SOURCE_BYTES = 131072
+PR_SET_NO_NEW_PRIVS = 38
+SCMP_ACT_ALLOW = 0x7FFF0000
+SCMP_ACT_ERRNO = 0x00050000
+SCMP_FLTATR_CTL_TSYNC = 4
+SCMP_CMP_MASKED_EQ = 7
+CLONE_THREAD = 0x00010000
+
+DENIED_SYSCALLS = (
+    "execve", "execveat", "fork", "vfork", "clone3",
+    "socket", "socketpair", "connect", "bind", "listen", "accept", "accept4",
+    "mount", "umount2", "pivot_root", "chroot", "setns", "unshare",
+    "ptrace", "process_vm_readv", "process_vm_writev",
+    "kill", "tkill", "tgkill", "pidfd_send_signal",
+    "add_key", "request_key", "keyctl", "bpf", "perf_event_open",
+    "userfaultfd", "io_uring_setup", "io_uring_enter", "io_uring_register",
+    "kexec_load", "finit_module", "init_module", "delete_module",
+    "open_by_handle_at", "name_to_handle_at",
+)
+
+
+class ScmpArgCmp(ctypes.Structure):
+    _fields_ = [
+        ("arg", ctypes.c_uint),
+        ("op", ctypes.c_uint),
+        ("datum_a", ctypes.c_uint64),
+        ("datum_b", ctypes.c_uint64),
+    ]
+
+
+def _install_filter() -> None:
+    if platform.machine().lower() not in {"x86_64", "amd64"}:
+        raise RuntimeError("unsupported seccomp architecture")
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+        raise OSError(ctypes.get_errno(), "PR_SET_NO_NEW_PRIVS failed")
+
+    seccomp = ctypes.CDLL("libseccomp.so.2", use_errno=True)
+    seccomp.seccomp_init.argtypes = [ctypes.c_uint32]
+    seccomp.seccomp_init.restype = ctypes.c_void_p
+    seccomp.seccomp_release.argtypes = [ctypes.c_void_p]
+    seccomp.seccomp_syscall_resolve_name.argtypes = [ctypes.c_char_p]
+    seccomp.seccomp_syscall_resolve_name.restype = ctypes.c_int
+    seccomp.seccomp_rule_add.argtypes = [
+        ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int, ctypes.c_uint,
+    ]
+    seccomp.seccomp_rule_add.restype = ctypes.c_int
+    seccomp.seccomp_rule_add_array.argtypes = [
+        ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int, ctypes.c_uint,
+        ctypes.POINTER(ScmpArgCmp),
+    ]
+    seccomp.seccomp_rule_add_array.restype = ctypes.c_int
+    seccomp.seccomp_attr_set.argtypes = [ctypes.c_void_p, ctypes.c_uint, ctypes.c_uint32]
+    seccomp.seccomp_attr_set.restype = ctypes.c_int
+    seccomp.seccomp_load.argtypes = [ctypes.c_void_p]
+    seccomp.seccomp_load.restype = ctypes.c_int
+
+    context = seccomp.seccomp_init(SCMP_ACT_ALLOW)
+    if not context:
+        raise RuntimeError("seccomp_init failed")
+    deny_action = SCMP_ACT_ERRNO | errno.EPERM
+    try:
+        if seccomp.seccomp_attr_set(context, SCMP_FLTATR_CTL_TSYNC, 1) != 0:
+            raise RuntimeError("seccomp TSYNC unavailable")
+        for name in DENIED_SYSCALLS:
+            number = seccomp.seccomp_syscall_resolve_name(name.encode("ascii"))
+            if number < 0:
+                raise RuntimeError(f"required syscall is unknown: {name}")
+            if seccomp.seccomp_rule_add(context, deny_action, number, 0) != 0:
+                raise RuntimeError(f"failed to deny syscall: {name}")
+
+        clone_number = seccomp.seccomp_syscall_resolve_name(b"clone")
+        if clone_number >= 0:
+            comparison = ScmpArgCmp(0, SCMP_CMP_MASKED_EQ, CLONE_THREAD, 0)
+            if seccomp.seccomp_rule_add_array(
+                context, deny_action, clone_number, 1, ctypes.byref(comparison)
+            ) != 0:
+                raise RuntimeError("failed to restrict clone")
+        if seccomp.seccomp_load(context) != 0:
+            raise RuntimeError("seccomp_load failed")
+    finally:
+        seccomp.seccomp_release(context)
+
+
+def _verify_file_descriptors() -> None:
+    descriptors = {
+        descriptor: os.readlink(f"/proc/self/fd/{descriptor}")
+        for descriptor in range(256)
+        if os.path.lexists(f"/proc/self/fd/{descriptor}")
+    }
+    if set(descriptors) != {0, 1, 2}:
+        raise RuntimeError("unexpected inherited file descriptor")
+    if any("socket:" in target for target in descriptors.values()):
+        raise RuntimeError("inherited socket")
+
+
+def main() -> None:
+    if os.geteuid() == 0:
+        raise SystemExit("generated Python refuses UID 0")
+    source = sys.stdin.buffer.read(MAX_SOURCE_BYTES + 1)
+    if len(source) > MAX_SOURCE_BYTES:
+        raise SystemExit("source_too_large")
+    try:
+        text = source.decode("utf-8", errors="strict")
+        code = compile(text, "<agentic-generated>", "exec")
+    except (UnicodeDecodeError, SyntaxError) as exc:
+        print(f"compile_failed:{type(exc).__name__}:{exc}", file=sys.stderr)
+        raise SystemExit(2)
+    os.chdir("/work")
+    _verify_file_descriptors()
+    _install_filter()
+    globals_dict = {
+        "__name__": "__main__",
+        "__file__": "<agentic-generated>",
+        "__package__": None,
+    }
+    exec(code, globals_dict, globals_dict)
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/core/agentic_python_launcher.py
+++ b/batch-runner/core/agentic_python_launcher.py
@@ -23,10 +23,12 @@ DENIED_SYSCALLS = (
     "mount", "umount2", "pivot_root", "chroot", "setns", "unshare",
     "ptrace", "process_vm_readv", "process_vm_writev",
     "kill", "tkill", "tgkill", "pidfd_send_signal",
+    "rt_sigqueueinfo", "rt_tgsigqueueinfo",
     "add_key", "request_key", "keyctl", "bpf", "perf_event_open",
     "userfaultfd", "io_uring_setup", "io_uring_enter", "io_uring_register",
     "kexec_load", "finit_module", "init_module", "delete_module",
     "open_by_handle_at", "name_to_handle_at",
+    "seccomp",
 )
 
 

--- a/batch-runner/core/agentic_remote_compute.py
+++ b/batch-runner/core/agentic_remote_compute.py
@@ -8,6 +8,10 @@ import json
 import os
 import ssl
 import math
+import sys
+import time
+import ijson
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, cast
 from urllib.parse import urlsplit
@@ -21,6 +25,10 @@ from core.agentic_channel import (
 
 MAX_COMMAND_BYTES = 256 * 1024
 MAX_RESULT_BYTES = 384 * 1024 * 1024
+MAX_JSON_DEPTH = 32
+MAX_JSON_NODES = 200_000
+MAX_JSON_STRING_BYTES = 512 * 1024
+MAX_JSON_MATERIALIZED_BYTES = 384 * 1024 * 1024
 
 
 class MutualTLSComputeTransport:
@@ -70,7 +78,13 @@ class MutualTLSComputeTransport:
             connection_factory or http.client.HTTPSConnection
         )
 
-    def exchange(self, envelope: Mapping[str, Any]) -> Mapping[str, Any]:
+    def exchange(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        timeout_seconds: float | None = None,
+        monotonic_deadline: float | None = None,
+    ) -> Mapping[str, Any]:
         body = json.dumps(
             dict(envelope),
             sort_keys=True,
@@ -92,13 +106,42 @@ class MutualTLSComputeTransport:
             or not 0 < float(operation_timeout) <= 1200
         ):
             raise ValueError("compute operation timeout is invalid")
+        attempt_timeout = min(
+            self.timeout_seconds,
+            float(operation_timeout),
+            (
+                float(timeout_seconds)
+                if timeout_seconds is not None
+                else float(operation_timeout)
+            ),
+        )
+        if not math.isfinite(attempt_timeout) or attempt_timeout <= 0:
+            raise ValueError("compute transport timeout is invalid")
+        now = time.monotonic()
+        relative_deadline = now + attempt_timeout
+        if monotonic_deadline is not None:
+            if (
+                isinstance(monotonic_deadline, bool)
+                or not isinstance(monotonic_deadline, (int, float))
+                or not math.isfinite(float(monotonic_deadline))
+                or float(monotonic_deadline) <= now
+            ):
+                raise TimeoutError("compute transport deadline exhausted")
+            deadline = min(relative_deadline, float(monotonic_deadline))
+        else:
+            deadline = relative_deadline
         connection = self.connection_factory(
             self.host,
             self.port,
-            timeout=min(self.timeout_seconds, float(operation_timeout)),
+            timeout=attempt_timeout,
             context=self.context,
         )
         try:
+            _set_deadline_timeout(connection, deadline)
+            connect = getattr(connection, "connect", None)
+            if callable(connect):
+                connect()
+            _set_deadline_timeout(connection, deadline)
             connection.request(
                 "POST",
                 self.path,
@@ -109,9 +152,15 @@ class MutualTLSComputeTransport:
                     "Connection": "close",
                 },
             )
+            _set_deadline_timeout(connection, deadline)
             response = connection.getresponse()
             if response.status != 200:
-                response.read(min(self.max_result_bytes, 4096))
+                _read_bounded_response(
+                    connection,
+                    response,
+                    min(self.max_result_bytes, 4096),
+                    deadline,
+                )
                 raise RuntimeError("compute transport rejected request")
             content_length = response.getheader("Content-Length")
             if content_length is None:
@@ -122,15 +171,236 @@ class MutualTLSComputeTransport:
                 raise RuntimeError("compute response length is invalid") from exc
             if length < 0 or length > self.max_result_bytes:
                 raise RuntimeError("compute response exceeds byte cap")
-            payload = response.read(length + 1)
-            if len(payload) != length:
+            reader = _DeadlineResponseReader(
+                connection, response, length, deadline
+            )
+            try:
+                decoded = _json_load_before_deadline(reader, deadline)
+            except RuntimeError as exc:
+                if reader.bytes_read != length:
+                    raise RuntimeError(
+                        "compute response length mismatch"
+                    ) from exc
+                raise
+            if reader.bytes_read != length:
                 raise RuntimeError("compute response length mismatch")
-            decoded = json.loads(payload)
             if not isinstance(decoded, dict):
                 raise RuntimeError("compute response is not an object")
             return decoded
         finally:
             connection.close()
+
+
+def _remaining_attempt(deadline: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("compute transport deadline exhausted")
+    return max(0.001, remaining)
+
+
+def _set_deadline_timeout(connection: Any, deadline: float) -> None:
+    remaining = _remaining_attempt(deadline)
+    if hasattr(connection, "timeout"):
+        connection.timeout = remaining
+    sock = getattr(connection, "sock", None)
+    if sock is not None:
+        sock.settimeout(remaining)
+
+
+def _read_bounded_response(
+    connection: Any,
+    response: Any,
+    maximum: int,
+    deadline: float,
+) -> bytes:
+    chunks = []
+    total = 0
+    while total < maximum:
+        _set_deadline_timeout(connection, deadline)
+        chunk = response.read(min(64 * 1024, maximum - total))
+        _remaining_attempt(deadline)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+    return b"".join(chunks)
+
+
+class _DeadlineResponseReader:
+    def __init__(
+        self,
+        connection: Any,
+        response: Any,
+        expected_bytes: int,
+        deadline: float,
+    ):
+        self.connection = connection
+        self.response = response
+        self.expected_bytes = expected_bytes
+        self.deadline = deadline
+        self.bytes_read = 0
+
+    def read(self, size: int = -1) -> bytes:
+        _set_deadline_timeout(self.connection, self.deadline)
+        if size == 0 or self.bytes_read >= self.expected_bytes:
+            return b""
+        bounded = 64 * 1024 if size < 0 else min(size, 64 * 1024)
+        bounded = min(bounded, self.expected_bytes - self.bytes_read)
+        chunk = self.response.read(bounded)
+        _remaining_attempt(self.deadline)
+        if len(chunk) > bounded:
+            raise RuntimeError("compute response exceeded declared length")
+        self.bytes_read += len(chunk)
+        return chunk
+
+
+class _DeadlineBytesReader:
+    def __init__(self, payload: bytes, deadline: float):
+        self.payload = memoryview(payload)
+        self.deadline = deadline
+        self.offset = 0
+
+    def read(self, size: int = -1) -> bytes:
+        _remaining_attempt(self.deadline)
+        if size == 0:
+            return b""
+        bounded = 64 * 1024 if size < 0 else min(size, 64 * 1024)
+        end = min(len(self.payload), self.offset + bounded)
+        chunk = self.payload[self.offset:end].tobytes()
+        self.offset = end
+        _remaining_attempt(self.deadline)
+        return chunk
+
+
+def _json_loads_before_deadline(payload: bytes, deadline: float) -> Any:
+    reader = _DeadlineBytesReader(payload, deadline)
+    return _json_load_before_deadline(reader, deadline)
+
+
+def _json_load_before_deadline(reader: Any, deadline: float) -> Any:
+    stack: list[dict[str, Any]] = []
+    root: Any = None
+    root_set = False
+    nodes = 0
+    materialized_bytes = 0
+
+    def charge(value: Any) -> None:
+        nonlocal materialized_bytes
+        materialized_bytes += sys.getsizeof(value)
+        if materialized_bytes > MAX_JSON_MATERIALIZED_BYTES:
+            raise RuntimeError("compute response materialized byte cap exceeded")
+
+    def count_node() -> None:
+        nonlocal nodes
+        nodes += 1
+        if nodes > MAX_JSON_NODES:
+            raise RuntimeError("compute response node cap exceeded")
+
+    def validate_string(value: Any) -> str:
+        if not isinstance(value, str):
+            raise RuntimeError("compute response string is invalid")
+        if (
+            len(value) > MAX_JSON_STRING_BYTES
+            or len(value.encode("utf-8")) > MAX_JSON_STRING_BYTES
+        ):
+            raise RuntimeError("compute response string cap exceeded")
+        return value
+
+    def attach(value: Any) -> None:
+        nonlocal root, root_set, materialized_bytes
+        if not stack:
+            if root_set:
+                raise RuntimeError("compute response contains multiple values")
+            root = value
+            root_set = True
+            return
+        frame = stack[-1]
+        container = frame["container"]
+        before = sys.getsizeof(container)
+        if isinstance(container, list):
+            container.append(value)
+        else:
+            key = frame.get("key")
+            if not isinstance(key, str):
+                raise RuntimeError("compute response map key is missing")
+            if key in container:
+                raise RuntimeError("compute response contains duplicate keys")
+            container[key] = value
+            frame["key"] = None
+        materialized_bytes += max(0, sys.getsizeof(container) - before)
+        if materialized_bytes > MAX_JSON_MATERIALIZED_BYTES:
+            raise RuntimeError("compute response materialized byte cap exceeded")
+
+    try:
+        for event, raw_value in ijson.basic_parse(
+            reader, use_float=False
+        ):
+            _remaining_attempt(deadline)
+            if event in {"start_map", "start_array"}:
+                if len(stack) + 1 > MAX_JSON_DEPTH:
+                    raise RuntimeError("compute response depth cap exceeded")
+                value: Any = {} if event == "start_map" else []
+                count_node()
+                charge(value)
+                attach(value)
+                stack.append({"container": value, "key": None})
+            elif event == "map_key":
+                if not stack or not isinstance(stack[-1]["container"], dict):
+                    raise RuntimeError("compute response map key is misplaced")
+                key = validate_string(raw_value)
+                count_node()
+                charge(key)
+                if stack[-1].get("key") is not None:
+                    raise RuntimeError("compute response map value is missing")
+                stack[-1]["key"] = key
+            elif event in {"end_map", "end_array"}:
+                if not stack:
+                    raise RuntimeError("compute response container is unbalanced")
+                frame = stack.pop()
+                container = frame["container"]
+                if (
+                    event == "end_map" and not isinstance(container, dict)
+                ) or (
+                    event == "end_array" and not isinstance(container, list)
+                ):
+                    raise RuntimeError("compute response container is unbalanced")
+                if isinstance(container, dict) and frame.get("key") is not None:
+                    raise RuntimeError("compute response map value is missing")
+            else:
+                if event == "string":
+                    value = validate_string(raw_value)
+                elif event in {"number", "integer", "double"}:
+                    if isinstance(raw_value, Decimal):
+                        value = float(raw_value)
+                        if not math.isfinite(value):
+                            raise RuntimeError(
+                                "compute response number is not finite"
+                            )
+                    elif type(raw_value) is int:
+                        value = raw_value
+                    else:
+                        raise RuntimeError("compute response number is invalid")
+                elif event == "boolean":
+                    if type(raw_value) is not bool:
+                        raise RuntimeError("compute response boolean is invalid")
+                    value = raw_value
+                elif event == "null":
+                    value = None
+                else:
+                    raise RuntimeError("compute response event is invalid")
+                count_node()
+                charge(value)
+                attach(value)
+    except TimeoutError:
+        raise
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        raise RuntimeError("compute response JSON is invalid") from exc
+    if stack or not root_set:
+        raise RuntimeError("compute response JSON is incomplete")
+    _remaining_attempt(deadline)
+    return root
 
 
 class RemoteBackendFactory:

--- a/batch-runner/core/agentic_remote_compute.py
+++ b/batch-runner/core/agentic_remote_compute.py
@@ -1,0 +1,227 @@
+"""Mutual-TLS transport for the split Agentic Sandbox compute plane."""
+
+from __future__ import annotations
+
+import base64
+import http.client
+import json
+import os
+import ssl
+import math
+from pathlib import Path
+from typing import Any, Mapping, cast
+from urllib.parse import urlsplit
+
+from core.agentic_channel import (
+    AuthenticatedComputeBackend,
+    ChannelScope,
+    EnvelopeAuthority,
+)
+
+
+MAX_COMMAND_BYTES = 256 * 1024
+MAX_RESULT_BYTES = 384 * 1024 * 1024
+
+
+class MutualTLSComputeTransport:
+    """One-request HTTPS transport with mandatory server and client identity."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        ca_path: str | Path,
+        client_cert_path: str | Path,
+        client_key_path: str | Path,
+        timeout_seconds: float = 1200,
+        max_result_bytes: int = MAX_RESULT_BYTES,
+        connection_factory=None,
+    ):
+        parsed = urlsplit(endpoint)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("compute endpoint must be a plain HTTPS origin/path")
+        self.host = parsed.hostname
+        self.port = parsed.port or 443
+        self.path = parsed.path or "/v1/agentic/compute"
+        if not self.path.startswith("/"):
+            raise ValueError("compute endpoint path is invalid")
+        for path in (ca_path, client_cert_path, client_key_path):
+            if not Path(path).is_file():
+                raise ValueError("compute mTLS material is missing")
+        self.context = ssl.create_default_context(
+            ssl.Purpose.SERVER_AUTH, cafile=str(ca_path)
+        )
+        self.context.minimum_version = ssl.TLSVersion.TLSv1_2
+        self.context.check_hostname = True
+        self.context.verify_mode = ssl.CERT_REQUIRED
+        self.context.load_cert_chain(
+            certfile=str(client_cert_path), keyfile=str(client_key_path)
+        )
+        self.timeout_seconds = timeout_seconds
+        self.max_result_bytes = max_result_bytes
+        self.connection_factory = (
+            connection_factory or http.client.HTTPSConnection
+        )
+
+    def exchange(self, envelope: Mapping[str, Any]) -> Mapping[str, Any]:
+        body = json.dumps(
+            dict(envelope),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        if len(body) > MAX_COMMAND_BYTES:
+            raise ValueError("compute command exceeds byte cap")
+        payload = envelope.get("payload")
+        operation_timeout = (
+            payload.get("timeout_seconds")
+            if isinstance(payload, Mapping)
+            else None
+        )
+        if (
+            isinstance(operation_timeout, bool)
+            or not isinstance(operation_timeout, (int, float))
+            or not math.isfinite(float(operation_timeout))
+            or not 0 < float(operation_timeout) <= 1200
+        ):
+            raise ValueError("compute operation timeout is invalid")
+        connection = self.connection_factory(
+            self.host,
+            self.port,
+            timeout=min(self.timeout_seconds, float(operation_timeout)),
+            context=self.context,
+        )
+        try:
+            connection.request(
+                "POST",
+                self.path,
+                body=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(len(body)),
+                    "Connection": "close",
+                },
+            )
+            response = connection.getresponse()
+            if response.status != 200:
+                response.read(min(self.max_result_bytes, 4096))
+                raise RuntimeError("compute transport rejected request")
+            content_length = response.getheader("Content-Length")
+            if content_length is None:
+                raise RuntimeError("compute response length is required")
+            try:
+                length = int(content_length)
+            except ValueError as exc:
+                raise RuntimeError("compute response length is invalid") from exc
+            if length < 0 or length > self.max_result_bytes:
+                raise RuntimeError("compute response exceeds byte cap")
+            payload = response.read(length + 1)
+            if len(payload) != length:
+                raise RuntimeError("compute response length mismatch")
+            decoded = json.loads(payload)
+            if not isinstance(decoded, dict):
+                raise RuntimeError("compute response is not an object")
+            return decoded
+        finally:
+            connection.close()
+
+
+class RemoteBackendFactory:
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        ca_path: str,
+        client_cert_path: str,
+        client_key_path: str,
+        channel_key: bytes,
+        run_id: str,
+        condition_name: str,
+        timeout_seconds: float = 1200,
+        transport_factory=MutualTLSComputeTransport,
+    ):
+        self.endpoint = endpoint
+        self.ca_path = ca_path
+        self.client_cert_path = client_cert_path
+        self.client_key_path = client_key_path
+        self.channel_key = channel_key
+        self.run_id = run_id
+        self.condition_name = condition_name
+        self.timeout_seconds = timeout_seconds
+        self.transport_factory = transport_factory
+
+    def __call__(
+        self,
+        *,
+        task_prompt: str,
+        reference_files: list,
+        occupation: str,
+        run_id: str,
+        condition_name: str,
+        task_id: str,
+    ):
+        if run_id != self.run_id or condition_name != self.condition_name:
+            raise ValueError("remote compute scope mismatch")
+        if not all(isinstance(path, str) and path for path in reference_files):
+            raise ValueError("remote compute reference IDs must be strings")
+        scope = ChannelScope(run_id, condition_name, task_id)
+        authority = EnvelopeAuthority(self.channel_key, scope)
+        transport = self.transport_factory(
+            endpoint=self.endpoint,
+            ca_path=self.ca_path,
+            client_cert_path=self.client_cert_path,
+            client_key_path=self.client_key_path,
+            timeout_seconds=self.timeout_seconds,
+        )
+        return AuthenticatedComputeBackend(
+            authority=authority,
+            transport=transport,
+            task_spec={
+                "task_prompt": task_prompt,
+                "reference_ids": list(reference_files),
+                "occupation": occupation,
+                "task_id": task_id,
+            },
+        )
+
+
+def remote_backend_factory_from_environment(
+    *,
+    run_id: str,
+    condition_name: str,
+) -> RemoteBackendFactory:
+    required = {
+        "endpoint": os.getenv("AGENTIC_COMPUTE_ENDPOINT"),
+        "ca_path": os.getenv("AGENTIC_COMPUTE_CA_PATH"),
+        "client_cert_path": os.getenv("AGENTIC_COMPUTE_CLIENT_CERT_PATH"),
+        "client_key_path": os.getenv("AGENTIC_COMPUTE_CLIENT_KEY_PATH"),
+        "channel_key": os.getenv("AGENTIC_COMPUTE_CHANNEL_KEY_B64"),
+    }
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        raise ValueError(f"remote compute environment is incomplete: {missing}")
+    endpoint = cast(str, required["endpoint"])
+    ca_path = cast(str, required["ca_path"])
+    client_cert_path = cast(str, required["client_cert_path"])
+    client_key_path = cast(str, required["client_key_path"])
+    encoded_key = cast(str, required["channel_key"])
+    try:
+        key = base64.b64decode(encoded_key, validate=True)
+    except Exception as exc:
+        raise ValueError("remote compute channel key is invalid") from exc
+    return RemoteBackendFactory(
+        endpoint=endpoint,
+        ca_path=ca_path,
+        client_cert_path=client_cert_path,
+        client_key_path=client_key_path,
+        channel_key=key,
+        run_id=run_id,
+        condition_name=condition_name,
+    )

--- a/batch-runner/core/agentic_runtime_identity.py
+++ b/batch-runner/core/agentic_runtime_identity.py
@@ -1,0 +1,93 @@
+"""Derive immutable live identities from checked-out bytes, not YAML claims."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping
+
+
+PLAN_MERGE_SHA = "b6408bc5e393748475d28beb1ca472eff75bf547"
+
+
+def derive_runtime_identity(
+    *,
+    repository_root: str | Path,
+    workflow_path: str | Path,
+    workflow_inputs: Mapping[str, Any],
+) -> dict:
+    root = Path(repository_root).resolve()
+    workflow = (root / workflow_path).resolve()
+    try:
+        workflow.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("workflow path escapes repository") from exc
+    if not workflow.is_file():
+        raise ValueError("workflow source is missing")
+    git_environment = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+    top_level = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=git_environment,
+    ).stdout.strip()
+    if Path(top_level).resolve() != root:
+        raise ValueError("repository root differs from Git top level")
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=git_environment,
+    ).stdout
+    if status.strip():
+        raise ValueError("live agentic execution requires a clean checkout")
+    implementation_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=git_environment,
+    ).stdout.strip()
+    if len(implementation_sha) != 40:
+        raise ValueError("implementation Git identity is invalid")
+    canonical_inputs = json.dumps(
+        dict(workflow_inputs),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return {
+        "plan_sha": PLAN_MERGE_SHA,
+        "implementation_sha": implementation_sha,
+        "workflow_sha": hashlib.sha256(workflow.read_bytes()).hexdigest(),
+        "workflow_inputs_sha256": hashlib.sha256(canonical_inputs).hexdigest(),
+    }
+
+
+def derive_runtime_identity_from_environment(
+    repository_root: str | Path,
+) -> dict:
+    workflow_path = os.getenv("AGENTIC_WORKFLOW_PATH")
+    raw_inputs = os.getenv("AGENTIC_WORKFLOW_INPUTS_JSON")
+    if not workflow_path or not raw_inputs:
+        raise ValueError("agentic workflow identity environment is incomplete")
+    try:
+        workflow_inputs = json.loads(raw_inputs)
+    except json.JSONDecodeError as exc:
+        raise ValueError("agentic workflow inputs are invalid JSON") from exc
+    if not isinstance(workflow_inputs, dict):
+        raise ValueError("agentic workflow inputs must be a JSON object")
+    return derive_runtime_identity(
+        repository_root=repository_root,
+        workflow_path=workflow_path,
+        workflow_inputs=workflow_inputs,
+    )

--- a/batch-runner/core/agentic_sandbox_runner.py
+++ b/batch-runner/core/agentic_sandbox_runner.py
@@ -1,0 +1,788 @@
+"""Bounded Responses API loop for model-directed sandbox task solving."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+
+import yaml
+
+from core.agentic_budget import (
+    AgenticBudgetLedger,
+    BudgetCaps,
+    BudgetExceeded,
+)
+from core.agentic_tools import (
+    AgenticComputeBackend,
+    AgenticToolDispatcher,
+    responses_tool_definitions,
+)
+
+
+DEFAULT_PROMPT = "agentic_sandbox_solver"
+PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+
+@dataclass(frozen=True)
+class AgenticLimits:
+    max_api_attempts: int = 6
+    max_model_iterations: int = 6
+    max_output_tokens: int = 8192
+    max_input_tokens: int = 300000
+    max_cumulative_output_tokens: int = 32768
+    max_task_seconds: int = 1200
+    max_cost_usd: Decimal = Decimal("1.25")
+    max_tool_calls: int = 8
+    max_run_python: int = 4
+    max_run_ffmpeg: int = 2
+    max_inspect_artifacts: int = 4
+    max_finalize: int = 2
+    max_identical_errors: int = 2
+
+    @classmethod
+    def from_options(cls, options: Optional[Mapping[str, Any]]) -> "AgenticLimits":
+        values = dict(options or {})
+        known = {
+            "max_api_attempts", "max_model_iterations", "max_output_tokens",
+            "max_input_tokens", "max_cumulative_output_tokens",
+            "max_task_seconds", "max_cost_usd", "max_tool_calls",
+            "max_run_python", "max_run_ffmpeg", "max_inspect_artifacts",
+            "max_finalize", "max_identical_errors",
+        }
+        unknown = set(values) - known
+        if unknown:
+            raise ValueError(f"unknown agentic limit(s): {sorted(unknown)}")
+        defaults = cls()
+        absolute_counts = {
+            "max_api_attempts": 6,
+            "max_model_iterations": 6,
+            "max_output_tokens": 8192,
+            "max_input_tokens": 300000,
+            "max_cumulative_output_tokens": 32768,
+            "max_task_seconds": 1200,
+            "max_tool_calls": 8,
+            "max_run_python": 4,
+            "max_run_ffmpeg": 2,
+            "max_inspect_artifacts": 4,
+            "max_finalize": 2,
+            "max_identical_errors": 2,
+        }
+        parsed: dict[str, Any] = {}
+        for name, maximum in absolute_counts.items():
+            raw = values.get(name, getattr(defaults, name))
+            if isinstance(raw, bool):
+                raise ValueError(f"{name} must be a positive integer")
+            try:
+                value = int(raw)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"{name} must be a positive integer") from exc
+            if value <= 0 or value > maximum:
+                raise ValueError(f"{name} must be in [1, {maximum}]")
+            parsed[name] = value
+        maximum_cost = Decimal("1.25")
+        cost = Decimal(str(values.get("max_cost_usd", defaults.max_cost_usd)))
+        if not cost.is_finite() or cost <= 0 or cost > maximum_cost:
+            raise ValueError(f"max_cost_usd must be in (0, {maximum_cost}]")
+        parsed["max_cost_usd"] = cost
+        return cls(**parsed)
+
+
+@dataclass(frozen=True)
+class AgenticPricing:
+    input_per_million: Decimal
+    output_per_million: Decimal
+    cached_input_per_million: Decimal
+    price_table_sha256: str = "nonpaid-unpinned"
+
+    @classmethod
+    def from_options(cls, options: Optional[Mapping[str, Any]]) -> "AgenticPricing":
+        if not isinstance(options, Mapping):
+            raise ValueError("agentic pricing is required")
+        result = cls(
+            input_per_million=Decimal(str(options.get("input_per_million"))),
+            output_per_million=Decimal(str(options.get("output_per_million"))),
+            cached_input_per_million=Decimal(str(
+                options.get("cached_input_per_million", options.get("input_per_million"))
+            )),
+            price_table_sha256=str(
+                options.get("price_table_sha256", "nonpaid-unpinned")
+            ),
+        )
+        for value in (
+            result.input_per_million,
+            result.output_per_million,
+            result.cached_input_per_million,
+        ):
+            if not value.is_finite() or value < 0:
+                raise ValueError("agentic prices must be finite non-negative decimals")
+        if not result.price_table_sha256:
+            raise ValueError("agentic price table identity is required")
+        return result
+
+    def worst_case(self, input_tokens: int, output_tokens: int) -> Decimal:
+        million = Decimal(1000000)
+        return (
+            Decimal(input_tokens) * self.input_per_million
+            + Decimal(output_tokens) * self.output_per_million
+        ) / million
+
+    def actual(self, input_tokens: int, output_tokens: int, cached_tokens: int) -> Decimal:
+        uncached = max(0, input_tokens - cached_tokens)
+        million = Decimal(1000000)
+        return (
+            Decimal(uncached) * self.input_per_million
+            + Decimal(cached_tokens) * self.cached_input_per_million
+            + Decimal(output_tokens) * self.output_per_million
+        ) / million
+
+
+@dataclass(frozen=True)
+class AgenticAggregateBudget:
+    paired_run_id: str
+    condition: BudgetCaps
+    paired_run: BudgetCaps
+
+    @classmethod
+    def from_options(
+        cls, options: Optional[Mapping[str, Any]]
+    ) -> Optional["AgenticAggregateBudget"]:
+        if options is None:
+            return None
+        if not isinstance(options, Mapping):
+            raise ValueError("agentic aggregate budget must be an object")
+        if set(options) != {"paired_run_id", "condition", "paired_run"}:
+            raise ValueError("agentic aggregate budget fields are invalid")
+        paired_run_id = options.get("paired_run_id")
+        if not isinstance(paired_run_id, str) or not paired_run_id:
+            raise ValueError("paired_run_id is required")
+        condition = _aggregate_caps(options.get("condition"), "condition", Decimal("25"))
+        paired = _aggregate_caps(options.get("paired_run"), "paired_run", Decimal("50"))
+        if (
+            condition.attempts > paired.attempts
+            or condition.input_tokens > paired.input_tokens
+            or condition.output_tokens > paired.output_tokens
+            or condition.cost_usd > paired.cost_usd
+        ):
+            raise ValueError("condition budget cannot exceed paired-run budget")
+        return cls(paired_run_id, condition, paired)
+
+class AgenticSandboxRunner:
+    """Run one task through a strictly bounded model-directed tool loop."""
+
+    DEFAULT_PROMPT = DEFAULT_PROMPT
+
+    def __init__(
+        self,
+        llm_client: Any = None,
+        *,
+        client_factory: Optional[Callable[[], Any]] = None,
+        non_paid_test_mode: bool = False,
+        backend_factory: Callable[..., AgenticComputeBackend],
+        budget_ledger: AgenticBudgetLedger,
+        authorize_request: Callable[[str, str, Mapping[str, Any]], None],
+        prompt_name: str = DEFAULT_PROMPT,
+        reasoning_effort: Optional[str] = None,
+        provider: str = "nonpaid-test",
+        api_version: str = "nonpaid-test",
+        endpoint_sha256: str = "nonpaid-test",
+        approval_scope_sha256: str = "nonpaid-test",
+        official_scope_registry_sha256: str = "nonpaid-test",
+        limits: Optional[Mapping[str, Any]] = None,
+        pricing: Optional[Mapping[str, Any]] = None,
+        aggregate_budget: Optional[Mapping[str, Any]] = None,
+    ):
+        if not callable(backend_factory):
+            raise ValueError("backend_factory is required")
+        if not callable(authorize_request):
+            raise ValueError("authorize_request is required")
+        if llm_client is not None and not non_paid_test_mode:
+            raise ValueError("direct agentic clients are allowed only in non-paid tests")
+        if llm_client is None and not callable(client_factory):
+            raise ValueError("agentic_sandbox requires a deferred client_factory")
+        if llm_client is not None:
+            self._validate_client(llm_client)
+        self.client = llm_client
+        self.client_factory = client_factory
+        self.backend_factory = backend_factory
+        self.ledger = budget_ledger
+        self.authorize_request = authorize_request
+        self.reasoning_effort = reasoning_effort or "medium"
+        self.provider = provider
+        self.api_version = api_version
+        self.endpoint_sha256 = endpoint_sha256
+        self.approval_scope_sha256 = approval_scope_sha256
+        self.official_scope_registry_sha256 = official_scope_registry_sha256
+        self.limits = AgenticLimits.from_options(limits)
+        self.pricing = AgenticPricing.from_options(pricing)
+        self.aggregate_budget = AgenticAggregateBudget.from_options(
+            aggregate_budget
+        )
+        self.instructions = self._load_instructions(prompt_name)
+
+    def run(
+        self,
+        task_prompt: str,
+        model: str,
+        reference_files: Optional[list] = None,
+        occupation: str = "professional",
+        experiment_prompt: Optional[dict] = None,
+        perception_text: Optional[str] = None,
+        *,
+        run_id: str = "local-nonpaid",
+        condition_name: str = "condition_a",
+        task_id: str = "unknown-task",
+    ) -> dict:
+        started = time.monotonic()
+        scope = self._scope(run_id, condition_name, task_id)
+        backend = self.backend_factory(
+            task_prompt=task_prompt,
+            reference_files=list(reference_files or []),
+            occupation=occupation,
+            run_id=run_id,
+            condition_name=condition_name,
+            task_id=task_id,
+        )
+        dispatcher = AgenticToolDispatcher(
+            backend,
+            max_total_calls=self.limits.max_tool_calls,
+            per_tool_limits={
+                "inspect_workspace": 4,
+                "inspect_environment": 2,
+                "run_python": self.limits.max_run_python,
+                "run_ffmpeg": self.limits.max_run_ffmpeg,
+                "inspect_artifacts": self.limits.max_inspect_artifacts,
+                "finalize": self.limits.max_finalize,
+            },
+        )
+        metrics = self._new_metrics()
+        first_model_dispatch: Optional[float] = None
+        existing_usage = self.ledger.usage(scope)
+        metrics.update({
+            "model_api_calls": existing_usage.attempts,
+            "input_tokens": existing_usage.input_tokens,
+            "output_tokens": existing_usage.output_tokens,
+            "conservative_cost_usd": str(existing_usage.cost_usd),
+        })
+        error_counts: dict[str, int] = {}
+        terminal_error = "unknown_error"
+        try:
+            startup = dict(backend.start(self.limits.max_task_seconds))
+            if startup.get("ok") is not True:
+                terminal_error = str(startup.get("error_type") or "compute_start_failed")
+                return self._failure(backend, metrics, terminal_error, started)
+            substrate_manifest = (startup.get("data") or {}).get(
+                "substrate_manifest"
+            )
+            if not isinstance(substrate_manifest, dict):
+                return self._failure(
+                    backend, metrics, "substrate_manifest_missing", started
+                )
+
+            messages: list[dict] = [{
+                "role": "user",
+                "content": self._initial_content(
+                    task_prompt, occupation, startup, experiment_prompt, perception_text
+                ),
+            }]
+            finalize_correction_used = False
+
+            while metrics["model_iterations"] < self.limits.max_model_iterations:
+                if time.monotonic() - started >= self.limits.max_task_seconds:
+                    terminal_error = "task_wall_time_exhausted"
+                    break
+                metrics["model_iterations"] += 1
+                request_id = self._request_id(scope, metrics["model_iterations"], messages)
+                request_payload = {
+                    "model": model,
+                    "instructions": self.instructions,
+                    "input": list(messages),
+                    "tools": responses_tool_definitions(),
+                    "reasoning": {"effort": self.reasoning_effort},
+                    "max_output_tokens": self.limits.max_output_tokens,
+                    "parallel_tool_calls": False,
+                    "timeout": max(
+                        1.0,
+                        min(
+                            480.0,
+                            self.limits.max_task_seconds
+                            - (time.monotonic() - started),
+                        ),
+                    ),
+                }
+                estimated_input = len(
+                    json.dumps(
+                        request_payload,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                )
+                reserved_cost = self.pricing.worst_case(
+                    estimated_input, self.limits.max_output_tokens
+                )
+                try:
+                    budget_scopes = self._budget_scopes(
+                        scope, condition_name
+                    )
+                    usage_by_scope = self.ledger.reserve_many(
+                        scopes=budget_scopes,
+                        request_id=request_id,
+                        input_tokens=estimated_input,
+                        output_tokens=self.limits.max_output_tokens,
+                        cost_usd=reserved_cost,
+                    )
+                    metrics["conservative_cost_usd"] = str(
+                        usage_by_scope[scope].cost_usd
+                    )
+                    self.authorize_request(
+                        scope,
+                        request_id,
+                        {
+                            "runtime_preflight_passed": True,
+                            "input_merkle_root": (startup.get("data") or {}).get(
+                                "input_merkle_root"
+                            ),
+                            "provider_classification": (startup.get("data") or {}).get(
+                                "provider_classification"
+                            ),
+                            "model": model,
+                            "provider": self.provider,
+                            "api_version": self.api_version,
+                            "endpoint_sha256": self.endpoint_sha256,
+                            "approval_scope_sha256": self.approval_scope_sha256,
+                            "official_scope_registry_sha256": (
+                                self.official_scope_registry_sha256
+                            ),
+                            "run_id": run_id,
+                            "condition": condition_name,
+                            "task_id": task_id,
+                            "caps": self._authorization_caps(),
+                            "price_table_sha256": self.pricing.price_table_sha256,
+                            "substrate_manifest_sha256": substrate_manifest.get(
+                                "sha256"
+                            ),
+                            "official_scope_excluded": True,
+                        },
+                    )
+                    if self.client is None:
+                        assert self.client_factory is not None
+                        client = self.client_factory()
+                        self._validate_client(client)
+                        self.client = client
+                except BudgetExceeded as exc:
+                    terminal_error = str(exc)
+                    break
+                except Exception:
+                    terminal_error = "authorization_or_reservation_failed"
+                    break
+
+                metrics["model_api_calls"] += 1
+                request_started = time.monotonic()
+                if first_model_dispatch is None:
+                    first_model_dispatch = request_started
+                try:
+                    assert self.client is not None
+                    response = self.client.responses.create(**request_payload)
+                except Exception:
+                    metrics["model_time_ms"] += _elapsed_ms(request_started)
+                    terminal_error = "model_api_error"
+                    break
+                metrics["model_time_ms"] += _elapsed_ms(request_started)
+
+                extracted = self._usage(response)
+                if extracted is None:
+                    terminal_error = "usage_incomplete"
+                    break
+                input_tokens, output_tokens, cached_tokens = extracted
+                actual_cost = self.pricing.actual(
+                    input_tokens, output_tokens, cached_tokens
+                )
+                try:
+                    reconciled_by_scope = self.ledger.reconcile_many(
+                        scopes=budget_scopes,
+                        request_id=request_id,
+                        actual_input_tokens=input_tokens,
+                        actual_output_tokens=output_tokens,
+                        actual_cost_usd=actual_cost,
+                    )
+                except Exception:
+                    terminal_error = "usage_reconciliation_failed"
+                    break
+                metrics["input_tokens"] += input_tokens
+                metrics["output_tokens"] += output_tokens
+                metrics["cached_tokens"] += cached_tokens
+                metrics["conservative_cost_usd"] = str(
+                    reconciled_by_scope[scope].cost_usd
+                )
+
+                output_items = list(_get(response, "output", []) or [])
+                function_calls = [
+                    item for item in output_items if _item_type(item) == "function_call"
+                ]
+                if function_calls:
+                    call_ids = [str(_get(call, "call_id", "")) for call in function_calls]
+                    if (
+                        any(not call_id for call_id in call_ids)
+                        or len(set(call_ids)) != len(call_ids)
+                    ):
+                        terminal_error = "invalid_function_call_id"
+                        metrics["tool_errors"] += 1
+                        break
+                    prepared_calls, preflight_error = dispatcher.prepare_batch([
+                        (
+                            str(_get(call, "name", "")),
+                            _get(call, "arguments", "{}"),
+                        )
+                        for call in function_calls
+                    ])
+                    if preflight_error is not None:
+                        terminal_error = preflight_error
+                        metrics["tool_errors"] += 1
+                        break
+                    messages.extend(_serialize_output_item(item) for item in output_items)
+                    for call, prepared_call in zip(function_calls, prepared_calls):
+                        tool_started = time.monotonic()
+                        name = prepared_call.name
+                        remaining_seconds = (
+                            self.limits.max_task_seconds
+                            - (time.monotonic() - started)
+                        )
+                        dispatch = dispatcher.dispatch_prepared(
+                            prepared_call,
+                            remaining_seconds=remaining_seconds,
+                        )
+                        duration = _elapsed_ms(tool_started)
+                        metrics["tool_time_ms"] += duration
+                        metrics["tool_calls"] += 1
+                        metrics["tool_calls_by_name"][name] = (
+                            metrics["tool_calls_by_name"].get(name, 0) + 1
+                        )
+                        if name == "finalize":
+                            metrics["finalize_attempts"] += 1
+                        if (
+                            name in {"inspect_artifacts", "finalize"}
+                            and dispatch.result.get("ok") is True
+                            and first_model_dispatch is not None
+                            and metrics["time_to_valid_artifact_ms"] is None
+                        ):
+                            metrics["time_to_valid_artifact_ms"] = _elapsed_ms(
+                                first_model_dispatch
+                            )
+                        if dispatch.result.get("ok") is not True:
+                            metrics["tool_errors"] += 1
+                            category = str(
+                                dispatch.result.get("error_type") or "unknown_tool_error"
+                            )
+                            error_counts[category] = error_counts.get(category, 0) + 1
+                            if category == "capability_missing":
+                                metrics["capability_misses"] += 1
+                            if error_counts[category] > self.limits.max_identical_errors:
+                                terminal_error = "repeated_error_limit"
+                                return self._failure(
+                                    backend, metrics, terminal_error, started
+                                )
+                            if category in {
+                                "compute_backend_error",
+                                "invalid_compute_result",
+                                "tool_result_too_large",
+                                "finalize_result_missing",
+                                "task_wall_time_exhausted",
+                            }:
+                                terminal_error = category
+                                return self._failure(
+                                    backend, metrics, terminal_error, started
+                                )
+                        messages.append(_function_output(call, dispatch.result))
+                        if dispatch.finalized:
+                            result = dict(dispatch.terminal_result or {})
+                            if result.get("success") is not True:
+                                terminal_error = "invalid_finalize_result"
+                                return self._failure(backend, metrics, terminal_error, started)
+                            metrics["terminal_error_category"] = None
+                            metrics["recovered_after_tool_error"] = (
+                                metrics["tool_errors"] > 0
+                            )
+                            metrics["task_wall_time_ms"] = _elapsed_ms(started)
+                            result["agentic_metrics"] = metrics
+                            result["substrate_manifest"] = substrate_manifest
+                            return result
+                    continue
+
+                messages.extend(_serialize_output_item(item) for item in output_items)
+                if not finalize_correction_used:
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            "A task is complete only after a successful finalize tool call. "
+                            "Inspect or repair artifacts, then call finalize."
+                        ),
+                    })
+                    finalize_correction_used = True
+                    metrics["finalize_required_corrections"] = 1
+                    continue
+                terminal_error = "finalize_not_called"
+                break
+
+            else:
+                terminal_error = "model_iteration_cap"
+            return self._failure(backend, metrics, terminal_error, started)
+        except Exception:
+            return self._failure(backend, metrics, "runner_internal_error", started)
+        finally:
+            try:
+                backend.close()
+            except Exception:
+                pass
+
+    @staticmethod
+    def _validate_client(client: Any) -> None:
+        responses = getattr(client, "responses", None)
+        if not callable(getattr(responses, "create", None)):
+            raise ValueError("agentic_sandbox requires a Responses API client")
+
+    @staticmethod
+    def _scope(run_id: str, condition_name: str, task_id: str) -> str:
+        values = (run_id, condition_name, task_id)
+        if any(not isinstance(value, str) or not value for value in values):
+            raise ValueError("run, condition, and task identity are required")
+        return json.dumps(values, separators=(",", ":"))
+
+    def _budget_scopes(
+        self, task_scope: str, condition_name: str
+    ) -> dict[str, BudgetCaps]:
+        scopes = {
+            task_scope: BudgetCaps(
+                attempts=self.limits.max_api_attempts,
+                input_tokens=self.limits.max_input_tokens,
+                output_tokens=self.limits.max_cumulative_output_tokens,
+                cost_usd=self.limits.max_cost_usd,
+            )
+        }
+        if self.aggregate_budget is not None:
+            paired_id = self.aggregate_budget.paired_run_id
+            scopes[json.dumps(
+                ["condition", paired_id, condition_name], separators=(",", ":")
+            )] = self.aggregate_budget.condition
+            scopes[json.dumps(
+                ["paired_run", paired_id], separators=(",", ":")
+            )] = self.aggregate_budget.paired_run
+        return scopes
+
+    def _authorization_caps(self) -> dict:
+        caps: dict[str, Any] = {
+            "task": {
+                "api_attempts": self.limits.max_api_attempts,
+                "model_iterations": self.limits.max_model_iterations,
+                "input_tokens": self.limits.max_input_tokens,
+                "output_tokens": self.limits.max_cumulative_output_tokens,
+                "max_output_tokens_per_response": self.limits.max_output_tokens,
+                "cost_usd": str(self.limits.max_cost_usd),
+                "wall_seconds": self.limits.max_task_seconds,
+            }
+        }
+        if self.aggregate_budget is not None:
+            caps["condition"] = _caps_dict(self.aggregate_budget.condition)
+            caps["paired_run"] = _caps_dict(self.aggregate_budget.paired_run)
+            caps["paired_run_id"] = self.aggregate_budget.paired_run_id
+        return caps
+
+    @staticmethod
+    def _request_id(scope: str, iteration: int, messages: list[dict]) -> str:
+        return hashlib.sha256(
+            json.dumps(
+                [scope, iteration, messages], sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+        ).hexdigest()
+
+    @staticmethod
+    def _initial_content(
+        task_prompt: str,
+        occupation: str,
+        startup: Mapping[str, Any],
+        experiment_prompt: Optional[dict],
+        perception_text: Optional[str],
+    ) -> str:
+        payload = {
+            "task": task_prompt,
+            "occupation": occupation,
+            "workspace": startup.get("data", {}),
+            "prompt_suffix": (experiment_prompt or {}).get("suffix"),
+            "perception": perception_text,
+        }
+        return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+
+    @staticmethod
+    def _usage(response: Any) -> Optional[tuple[int, int, int]]:
+        usage = _get(response, "usage")
+        if usage is None:
+            return None
+        raw_input = _get(usage, "input_tokens")
+        raw_output = _get(usage, "output_tokens")
+        if not _valid_count(raw_input) or not _valid_count(raw_output):
+            return None
+        details = _get(usage, "input_tokens_details")
+        raw_cached = _get(details, "cached_tokens", 0) if details is not None else 0
+        if not _valid_count(raw_cached) or int(raw_cached) > int(raw_input):
+            return None
+        return int(raw_input), int(raw_output), int(raw_cached)
+
+    @staticmethod
+    def _new_metrics() -> dict:
+        return {
+            "schema_version": "1.0",
+            "ledger_cumulative": True,
+            "model_api_calls": 0,
+            "model_iterations": 0,
+            "tool_calls": 0,
+            "tool_errors": 0,
+            "tool_calls_by_name": {},
+            "model_time_ms": 0.0,
+            "tool_time_ms": 0.0,
+            "task_wall_time_ms": None,
+            "time_to_valid_artifact_ms": None,
+            "finalize_required_corrections": 0,
+            "finalize_attempts": 0,
+            "capability_misses": 0,
+            "recovered_after_tool_error": False,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached_tokens": 0,
+            "conservative_cost_usd": "0",
+            "usage_complete": True,
+            "terminal_error_category": None,
+        }
+
+    @staticmethod
+    def _failure(
+        backend: AgenticComputeBackend,
+        metrics: dict,
+        category: str,
+        started: float,
+    ) -> dict:
+        metrics["terminal_error_category"] = category
+        metrics["task_wall_time_ms"] = _elapsed_ms(started)
+        if category in {
+            "usage_incomplete", "model_api_error", "usage_reconciliation_failed",
+            "authorization_or_reservation_failed",
+        }:
+            metrics["usage_complete"] = False
+        best = backend.best_result()
+        result = dict(best or {})
+        result.update({
+            "success": False,
+            "text": result.get("text", ""),
+            "files": result.get("files", []),
+            "error": category,
+            "agentic_metrics": metrics,
+        })
+        return result
+
+    @staticmethod
+    def _load_instructions(prompt_name: str) -> str:
+        path = PROMPTS_DIR / f"{prompt_name}.yaml"
+        if not path.is_file():
+            raise FileNotFoundError(f"Agentic prompt not found: {path}")
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        instructions = data.get("instructions") if isinstance(data, dict) else None
+        if not isinstance(instructions, str) or not instructions.strip():
+            raise ValueError("Agentic prompt must contain non-empty instructions")
+        return instructions.strip()
+
+
+def _get(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _item_type(item: Any) -> str:
+    return str(_get(item, "type", ""))
+
+
+def _serialize_output_item(item: Any) -> dict:
+    if isinstance(item, Mapping):
+        return dict(item)
+    dump = getattr(item, "model_dump", None)
+    if callable(dump):
+        try:
+            result = dump(mode="json", exclude_none=True)
+        except TypeError:
+            result = dump()
+        if isinstance(result, Mapping):
+            return dict(result)
+    return {
+        name: _get(item, name)
+        for name in (
+            "type", "id", "status", "role", "content", "summary",
+            "call_id", "name", "arguments",
+        )
+        if _get(item, name) is not None
+    }
+
+
+def _function_output(call: Any, result: Mapping[str, Any]) -> dict:
+    return {
+        "type": "function_call_output",
+        "call_id": str(_get(call, "call_id", "")),
+        "output": json.dumps(
+            dict(result), sort_keys=True, separators=(",", ":"), allow_nan=False
+        ),
+    }
+
+
+def _valid_count(value: Any) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value >= 0
+    )
+
+
+def _elapsed_ms(started: float) -> float:
+    return round(max(0.0, (time.monotonic() - started) * 1000.0), 3)
+
+
+def _aggregate_caps(
+    value: Any, label: str, maximum_cost: Decimal
+) -> BudgetCaps:
+    if not isinstance(value, Mapping) or set(value) != {
+        "attempts", "input_tokens", "output_tokens", "cost_usd"
+    }:
+        raise ValueError(f"{label} budget fields are invalid")
+    absolute_counts = {
+        "condition": {
+            "attempts": 120,
+            "input_tokens": 6_000_000,
+            "output_tokens": 655_360,
+        },
+        "paired_run": {
+            "attempts": 240,
+            "input_tokens": 12_000_000,
+            "output_tokens": 1_310_720,
+        },
+    }[label]
+    counts = {}
+    for field_name in ("attempts", "input_tokens", "output_tokens"):
+        raw = value.get(field_name)
+        if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+            raise ValueError(f"{label}.{field_name} must be a positive integer")
+        if raw > absolute_counts[field_name]:
+            raise ValueError(f"{label}.{field_name} exceeds its absolute maximum")
+        counts[field_name] = raw
+    cost = Decimal(str(value.get("cost_usd")))
+    if not cost.is_finite() or cost <= 0 or cost > maximum_cost:
+        raise ValueError(f"{label}.cost_usd must be in (0, {maximum_cost}]")
+    return BudgetCaps(cost_usd=cost, **counts)
+
+
+def _caps_dict(caps: BudgetCaps) -> dict:
+    return {
+        "attempts": caps.attempts,
+        "input_tokens": caps.input_tokens,
+        "output_tokens": caps.output_tokens,
+        "cost_usd": str(caps.cost_usd),
+    }

--- a/batch-runner/core/agentic_sandbox_runner.py
+++ b/batch-runner/core/agentic_sandbox_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import time
 from dataclasses import dataclass
 from decimal import Decimal
@@ -12,6 +13,7 @@ from typing import Any, Callable, Mapping, Optional
 
 import yaml
 
+from core.agentic_authorization import task_request_sha256
 from core.agentic_budget import (
     AgenticBudgetLedger,
     BudgetCaps,
@@ -126,8 +128,12 @@ class AgenticPricing:
 
     def worst_case(self, input_tokens: int, output_tokens: int) -> Decimal:
         million = Decimal(1000000)
+        conservative_input_price = max(
+            self.input_per_million,
+            self.cached_input_per_million,
+        )
         return (
-            Decimal(input_tokens) * self.input_per_million
+            Decimal(input_tokens) * conservative_input_price
             + Decimal(output_tokens) * self.output_per_million
         ) / million
 
@@ -270,18 +276,27 @@ class AgenticSandboxRunner:
         })
         error_counts: dict[str, int] = {}
         terminal_error = "unknown_error"
+        outcome: Optional[dict] = None
+
+        def finish(result: Mapping[str, Any]) -> dict:
+            nonlocal outcome
+            outcome = dict(result)
+            return outcome
+
         try:
             startup = dict(backend.start(self.limits.max_task_seconds))
             if startup.get("ok") is not True:
                 terminal_error = str(startup.get("error_type") or "compute_start_failed")
-                return self._failure(backend, metrics, terminal_error, started)
+                return finish(self._failure(
+                    backend, metrics, terminal_error, started
+                ))
             substrate_manifest = (startup.get("data") or {}).get(
                 "substrate_manifest"
             )
             if not isinstance(substrate_manifest, dict):
-                return self._failure(
+                return finish(self._failure(
                     backend, metrics, "substrate_manifest_missing", started
-                )
+                ))
 
             messages: list[dict] = [{
                 "role": "user",
@@ -346,6 +361,9 @@ class AgenticSandboxRunner:
                             "input_merkle_root": (startup.get("data") or {}).get(
                                 "input_merkle_root"
                             ),
+                            "selection_recomputation_sha256": (
+                                startup.get("data") or {}
+                            ).get("selection_recomputation_sha256"),
                             "provider_classification": (startup.get("data") or {}).get(
                                 "provider_classification"
                             ),
@@ -360,6 +378,12 @@ class AgenticSandboxRunner:
                             "run_id": run_id,
                             "condition": condition_name,
                             "task_id": task_id,
+                            "task_request_sha256": task_request_sha256(
+                                task_prompt=task_prompt,
+                                occupation=occupation,
+                                experiment_prompt=experiment_prompt,
+                                perception_text=perception_text,
+                            ),
                             "caps": self._authorization_caps(),
                             "price_table_sha256": self.pricing.price_table_sha256,
                             "substrate_manifest_sha256": substrate_manifest.get(
@@ -380,6 +404,13 @@ class AgenticSandboxRunner:
                     terminal_error = "authorization_or_reservation_failed"
                     break
 
+                remaining_before_api = self.limits.max_task_seconds - (
+                    time.monotonic() - started
+                )
+                if remaining_before_api < 1.0:
+                    terminal_error = "task_wall_time_exhausted"
+                    break
+                request_payload["timeout"] = min(480.0, remaining_before_api)
                 metrics["model_api_calls"] += 1
                 request_started = time.monotonic()
                 if first_model_dispatch is None:
@@ -477,14 +508,22 @@ class AgenticSandboxRunner:
                             category = str(
                                 dispatch.result.get("error_type") or "unknown_tool_error"
                             )
-                            error_counts[category] = error_counts.get(category, 0) + 1
+                            fingerprint = _error_fingerprint(
+                                name, dispatch.result
+                            )
+                            error_counts[fingerprint] = (
+                                error_counts.get(fingerprint, 0) + 1
+                            )
                             if category == "capability_missing":
                                 metrics["capability_misses"] += 1
-                            if error_counts[category] > self.limits.max_identical_errors:
+                            if (
+                                error_counts[fingerprint]
+                                >= self.limits.max_identical_errors
+                            ):
                                 terminal_error = "repeated_error_limit"
-                                return self._failure(
+                                return finish(self._failure(
                                     backend, metrics, terminal_error, started
-                                )
+                                ))
                             if category in {
                                 "compute_backend_error",
                                 "invalid_compute_result",
@@ -493,15 +532,17 @@ class AgenticSandboxRunner:
                                 "task_wall_time_exhausted",
                             }:
                                 terminal_error = category
-                                return self._failure(
+                                return finish(self._failure(
                                     backend, metrics, terminal_error, started
-                                )
+                                ))
                         messages.append(_function_output(call, dispatch.result))
                         if dispatch.finalized:
                             result = dict(dispatch.terminal_result or {})
                             if result.get("success") is not True:
                                 terminal_error = "invalid_finalize_result"
-                                return self._failure(backend, metrics, terminal_error, started)
+                                return finish(self._failure(
+                                    backend, metrics, terminal_error, started
+                                ))
                             metrics["terminal_error_category"] = None
                             metrics["recovered_after_tool_error"] = (
                                 metrics["tool_errors"] > 0
@@ -509,7 +550,7 @@ class AgenticSandboxRunner:
                             metrics["task_wall_time_ms"] = _elapsed_ms(started)
                             result["agentic_metrics"] = metrics
                             result["substrate_manifest"] = substrate_manifest
-                            return result
+                            return finish(result)
                     continue
 
                 messages.extend(_serialize_output_item(item) for item in output_items)
@@ -529,14 +570,43 @@ class AgenticSandboxRunner:
 
             else:
                 terminal_error = "model_iteration_cap"
-            return self._failure(backend, metrics, terminal_error, started)
+            return finish(self._failure(
+                backend, metrics, terminal_error, started
+            ))
         except Exception:
-            return self._failure(backend, metrics, "runner_internal_error", started)
+            return finish(self._failure(
+                backend, metrics, "runner_internal_error", started
+            ))
         finally:
             try:
                 backend.close()
             except Exception:
-                pass
+                if outcome is None:
+                    outcome = self._failure(
+                        backend, metrics, "compute_cleanup_failed", started
+                    )
+                prior_error = outcome.get("error")
+                candidate = None
+                if not outcome.get("files"):
+                    try:
+                        candidate = backend.best_result()
+                    except Exception:
+                        candidate = None
+                if (
+                    isinstance(candidate, Mapping)
+                    and candidate.get("files")
+                    and not outcome.get("files")
+                ):
+                    outcome["files"] = list(candidate["files"])
+                    outcome["text"] = outcome.get("text") or candidate.get(
+                        "text", ""
+                    )
+                outcome["success"] = False
+                outcome["prior_error"] = prior_error
+                outcome["error"] = "compute_cleanup_failed"
+                metrics["terminal_error_category"] = "compute_cleanup_failed"
+                metrics["task_wall_time_ms"] = _elapsed_ms(started)
+                outcome["agentic_metrics"] = metrics
 
     @staticmethod
     def _validate_client(client: Any) -> None:
@@ -740,6 +810,41 @@ def _valid_count(value: Any) -> bool:
         and not isinstance(value, bool)
         and value >= 0
     )
+
+
+def _error_fingerprint(tool_name: str, result: Mapping[str, Any]) -> str:
+    category = str(result.get("error_type") or "unknown_tool_error")[:80]
+
+    def normalize(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {
+                str(key)[:80]: normalize(item)
+                for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+                if str(key) not in {"raw_arguments", "source", "content"}
+            }
+        if isinstance(value, list):
+            return [normalize(item) for item in value[:20]]
+        if isinstance(value, str):
+            text = value.lower()[:2048]
+            text = re.sub(
+                r"(?:[a-z]:)?(?:/[a-z0-9._-]+)+", "<path>", text
+            )
+            text = re.sub(r"\b[0-9a-f]{16,}\b", "<hex>", text)
+            text = re.sub(r"\b\d+(?:\.\d+)?\b", "<number>", text)
+            return " ".join(text.split())
+        if value is None or isinstance(value, (bool, int, float)):
+            return value
+        return type(value).__name__
+
+    diagnostic = normalize(result.get("data") or {})
+    return hashlib.sha256(
+        json.dumps(
+            [tool_name, category, diagnostic],
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
 
 
 def _elapsed_ms(started: float) -> float:

--- a/batch-runner/core/agentic_selector.py
+++ b/batch-runner/core/agentic_selector.py
@@ -1,0 +1,461 @@
+"""Outcome-free deterministic selector for agentic canary/diagnostic tasks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+SEED = "20260717"
+TABULAR = {"csv", "tsv", "xls", "xlsx", "xlsm", "ods", "parquet"}
+DOCUMENT = {"pdf", "doc", "docx", "ppt", "pptx", "txt", "md", "rtf"}
+MEDIA = {
+    "png", "jpg", "jpeg", "gif", "webp", "tif", "tiff", "bmp", "svg",
+    "wav", "mp3", "m4a", "flac", "ogg", "mp4", "mov", "avi", "mkv",
+    "webm",
+}
+FORBIDDEN_OUTCOME_PATHS = (
+    "data/grades",
+    "batch-runner/results",
+    "batch-runner/workspace",
+    "batch-output",
+    "run-logs",
+    "logs",
+    ".cache/huggingface",
+)
+MAX_INPUT_FILES = 256
+MAX_INPUT_TOTAL = 2 * 1024 * 1024 * 1024
+MAX_INPUT_SINGLE = 512 * 1024 * 1024
+FULL_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}/"
+    r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}$"
+)
+
+
+@dataclass(frozen=True)
+class EligibleTask:
+    task_id: str
+    sector: str
+    occupation: str
+    input_class: str
+    reference_paths: tuple[str, ...]
+    reference_suffixes: tuple[str, ...]
+    reference_sizes: tuple[int, ...]
+    positive_rubric_max: float
+
+    @property
+    def stratum(self) -> tuple[str, str]:
+        return self.sector, self.input_class
+
+
+def select_agentic_tasks(
+    records: Sequence[Mapping[str, Any]],
+    rubrics: Mapping[str, Any],
+    *,
+    dataset_sha: str,
+    seed: str = SEED,
+) -> dict:
+    """Return exact ordered canary/diagnostic IDs and selection provenance."""
+    if seed != SEED:
+        raise ValueError(f"selector seed must be the preregistered literal {SEED}")
+    if not isinstance(dataset_sha, str) or FULL_COMMIT_RE.fullmatch(
+        dataset_sha
+    ) is None:
+        raise ValueError("full immutable dataset revision is required")
+    eligible = _eligible_frame(records, rubrics)
+    if len(eligible) < 25:
+        raise ValueError("eligible frame must contain at least 25 tasks")
+
+    by_stratum: dict[tuple[str, str], list[EligibleTask]] = {}
+    for task in eligible:
+        by_stratum.setdefault(task.stratum, []).append(task)
+    counts = {stratum: len(tasks) for stratum, tasks in by_stratum.items()}
+    seats = _largest_remainder(counts, 25)
+
+    selected_by_stratum: dict[tuple[str, str], list[EligibleTask]] = {}
+    for stratum, tasks in by_stratum.items():
+        ordered = sorted(
+            tasks,
+            key=lambda task: (
+                _digest("agentic-select-v1", seed, dataset_sha, task.task_id),
+                task.task_id.encode("utf-8"),
+            ),
+        )
+        selected_by_stratum[stratum] = ordered[:seats[stratum]]
+
+    canary_seats = _largest_remainder(seats, 5, denominator=25)
+    canary: list[EligibleTask] = []
+    diagnostic: list[EligibleTask] = []
+    for stratum, tasks in selected_by_stratum.items():
+        canary_count = canary_seats[stratum]
+        stratum_canary_ids = {
+            task.task_id
+            for task in sorted(
+                tasks,
+                key=lambda task: (
+                    _digest(
+                        "agentic-canary-v1", seed, dataset_sha, task.task_id
+                    ),
+                    task.task_id.encode("utf-8"),
+                ),
+            )[:canary_count]
+        }
+        for task in tasks:
+            (
+                canary
+                if task.task_id in stratum_canary_ids
+                else diagnostic
+            ).append(task)
+
+    canary = _ordered(
+        canary, "agentic-order-canary-v1", seed, dataset_sha
+    )
+    diagnostic = _ordered(
+        diagnostic, "agentic-order-diagnostic-v1", seed, dataset_sha
+    )
+    canary_ids = [task.task_id for task in canary]
+    diagnostic_ids = [task.task_id for task in diagnostic]
+    if len(canary_ids) != 5 or len(diagnostic_ids) != 20:
+        raise AssertionError("selector did not produce exact 5/20 cohorts")
+    if set(canary_ids) & set(diagnostic_ids):
+        raise AssertionError("canary and diagnostic cohorts overlap")
+    selected = canary + diagnostic
+    if any(task.positive_rubric_max <= 0 for task in selected):
+        raise ValueError("selected task has zero positive rubric denominator")
+
+    return {
+        "schema_version": "agentic-task-subset-v1",
+        "seed": seed,
+        "eligible_frame_count": len(eligible),
+        "strata": [
+            {
+                "sector": stratum[0],
+                "input_class": stratum[1],
+                "eligible_count": counts[stratum],
+                "selected_quota": seats[stratum],
+                "canary_quota": canary_seats[stratum],
+            }
+            for stratum in sorted(counts, key=_stratum_sort_key)
+        ],
+        "canary_task_ids": canary_ids,
+        "diagnostic_task_ids": diagnostic_ids,
+        "selected_tasks": [
+            {
+                "task_id": task.task_id,
+                "sector": task.sector,
+                "occupation": task.occupation,
+                "input_class": task.input_class,
+                "reference_paths": list(task.reference_paths),
+                "reference_suffixes": list(task.reference_suffixes),
+                "reference_sizes": list(task.reference_sizes),
+                "positive_rubric_max": task.positive_rubric_max,
+            }
+            for task in selected
+        ],
+        "selection_domains": {
+            "select": "agentic-select-v1",
+            "canary": "agentic-canary-v1",
+            "order_canary": "agentic-order-canary-v1",
+            "order_diagnostic": "agentic-order-diagnostic-v1",
+        },
+        "tie_break": "ascending UTF-8 bytes",
+        "selected_before_outcomes": True,
+    }
+
+
+def build_selection_manifest(
+    selection: Mapping[str, Any],
+    *,
+    dataset_repo: str,
+    dataset_sha: str,
+    rubric_repo: str,
+    rubric_sha: str,
+    selector_path: str | Path,
+    repository_root: str | Path,
+    source_commit: str,
+) -> dict:
+    for label, repository in (
+        ("dataset", dataset_repo), ("rubric", rubric_repo)
+    ):
+        if not isinstance(repository, str) or REPOSITORY_RE.fullmatch(
+            repository
+        ) is None:
+            raise ValueError(f"{label} repository identity is invalid")
+    for label, revision in (
+        ("dataset", dataset_sha), ("rubric", rubric_sha),
+        ("selector source", source_commit),
+    ):
+        if not isinstance(revision, str) or FULL_COMMIT_RE.fullmatch(
+            revision
+        ) is None:
+            raise ValueError(f"{label} revision must be a full commit SHA")
+    root = Path(repository_root).resolve()
+    selector = resolve_outcome_free_file(root, selector_path, "selector source")
+    actual_commit = _git_output(root, "rev-parse", "HEAD")
+    if source_commit != actual_commit:
+        raise ValueError("selector source commit differs from clean checkout")
+    selector_relative = selector.relative_to(root).as_posix()
+    manifest = dict(selection)
+    manifest.update({
+        "dataset": {"repository": dataset_repo, "revision": dataset_sha},
+        "rubric": {"repository": rubric_repo, "revision": rubric_sha},
+        "selector": {
+            "path": selector_relative,
+            "source_commit": source_commit,
+            "sha256": _sha256_file(selector),
+        },
+        "inclusion_validation": "all structural checks passed",
+        "exclusion_validation": "outcome fields were not accepted by selector",
+    })
+    manifest["recomputation_sha256"] = hashlib.sha256(
+        json.dumps(
+            manifest, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+    ).hexdigest()
+    return manifest
+
+
+def assert_outcome_free_checkout(root: str | Path) -> str:
+    root = Path(root).resolve()
+    if not root.is_dir():
+        raise ValueError("outcome-free root is missing")
+    present = [path for path in FORBIDDEN_OUTCOME_PATHS if (root / path).exists()]
+    if present:
+        raise ValueError(
+            "selector checkout can read forbidden outcome paths: "
+            + ", ".join(present)
+        )
+    if Path(_git_output(root, "rev-parse", "--show-toplevel")).resolve() != root:
+        raise ValueError("outcome-free root differs from Git top level")
+    status_output = _git_output(
+        root, "status", "--porcelain=v1", "--untracked-files=all"
+    )
+    if status_output:
+        raise ValueError("outcome-free selector requires a clean checkout")
+    commit = _git_output(root, "rev-parse", "HEAD")
+    if len(commit) != 40:
+        raise ValueError("outcome-free source commit is invalid")
+    return commit
+
+
+def resolve_outcome_free_file(
+    root: str | Path, value: str | Path, label: str
+) -> Path:
+    root = Path(root).resolve()
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    absolute = candidate.absolute()
+    try:
+        relative = absolute.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{label} escapes outcome-free root") from exc
+    current = root
+    for part in relative.parts:
+        current /= part
+        try:
+            metadata = current.lstat()
+        except OSError as exc:
+            raise ValueError(f"{label} is missing") from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError(f"{label} contains a symlink")
+    metadata = absolute.lstat()
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        raise ValueError(f"{label} must be a single-link regular file")
+    return absolute
+
+
+def _git_output(root: Path, *arguments: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+            env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError("outcome-free Git identity is unavailable") from exc
+    return result.stdout.strip()
+
+
+def _eligible_frame(
+    records: Sequence[Mapping[str, Any]], rubrics: Mapping[str, Any]
+) -> list[EligibleTask]:
+    if not isinstance(records, Sequence) or isinstance(records, (str, bytes)):
+        raise ValueError("dataset records must be a sequence")
+    seen: set[str] = set()
+    output = []
+    forbidden_fields = {
+        "grade", "grades", "score", "completion", "retry", "cost",
+        "human_label", "prior_run", "outcome",
+    }
+    for raw in records:
+        if not isinstance(raw, Mapping):
+            raise ValueError("every dataset record must be an object")
+        if forbidden_fields & set(raw):
+            raise ValueError("dataset record contains forbidden outcome field")
+        task_id = _required_text(raw, "task_id")
+        if task_id in seen:
+            raise ValueError(f"duplicate task_id: {task_id}")
+        seen.add(task_id)
+        sector = _required_text(raw, "sector")
+        occupation = _required_text(raw, "occupation")
+        _required_text(raw, "prompt")
+        references = _reference_metadata(raw.get("reference_files", []))
+        if task_id not in rubrics:
+            raise ValueError(f"missing rubric for task: {task_id}")
+        positive_max = _positive_rubric_max(rubrics[task_id])
+        paths = tuple(reference[0] for reference in references)
+        suffixes = tuple(reference[1] for reference in references)
+        sizes = tuple(reference[2] for reference in references)
+        output.append(EligibleTask(
+            task_id=task_id,
+            sector=sector,
+            occupation=occupation,
+            input_class=_input_class(suffixes),
+            reference_paths=paths,
+            reference_suffixes=suffixes,
+            reference_sizes=sizes,
+            positive_rubric_max=positive_max,
+        ))
+    return output
+
+
+def _reference_metadata(value: Any) -> list[tuple[str, str, int]]:
+    if value is None:
+        value = []
+    if not isinstance(value, list):
+        raise ValueError("reference_files must be a list")
+    if len(value) > MAX_INPUT_FILES:
+        raise ValueError("reference file count exceeds agentic input limit")
+    records = []
+    total = 0
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise ValueError("reference metadata must contain path and size")
+        path = item.get("path") or item.get("name")
+        size = item.get("size_bytes")
+        if not isinstance(path, str) or not path or Path(path).is_absolute():
+            raise ValueError("reference path must be non-empty and relative")
+        if ".." in Path(path).parts:
+            raise ValueError("reference path traversal is forbidden")
+        if type(size) is not int or size < 0 or size > MAX_INPUT_SINGLE:
+            raise ValueError("reference size exceeds agentic input limit")
+        total += size
+        if total > MAX_INPUT_TOTAL:
+            raise ValueError("reference total exceeds agentic input limit")
+        suffix = Path(path).suffix.lower().lstrip(".")
+        records.append((Path(path).as_posix(), suffix, size))
+    return records
+
+
+def _positive_rubric_max(value: Any) -> float:
+    items = value.get("rubric_items") if isinstance(value, Mapping) else value
+    if not isinstance(items, list):
+        raise ValueError("rubric must be a list or contain rubric_items")
+    total = 0.0
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise ValueError("rubric item must be an object")
+        maximum = item.get("max_score", item.get("score"))
+        if isinstance(maximum, bool) or not isinstance(maximum, (int, float)):
+            raise ValueError("rubric maximum must be numeric")
+        if maximum > 0:
+            total += float(maximum)
+    return total
+
+
+def _input_class(suffixes: tuple[str, ...]) -> str:
+    if not suffixes:
+        return "none"
+    values = set(suffixes)
+    if values <= TABULAR:
+        return "tabular"
+    if values <= DOCUMENT:
+        return "document"
+    if values <= MEDIA:
+        return "media"
+    return "mixed_or_other"
+
+
+def _largest_remainder(
+    counts: Mapping[tuple[str, str], int],
+    total_seats: int,
+    *,
+    denominator: int | None = None,
+) -> dict[tuple[str, str], int]:
+    denominator = denominator or sum(counts.values())
+    if total_seats <= 0 or denominator <= 0:
+        raise ValueError("largest-remainder inputs must be positive")
+    exact = {
+        key: Fraction(total_seats * value, denominator)
+        for key, value in counts.items()
+    }
+    seats = {key: int(value) for key, value in exact.items()}
+    remaining = total_seats - sum(seats.values())
+    ranked = sorted(
+        counts,
+        key=lambda key: (
+            -(exact[key] - seats[key]),
+            _stratum_sort_key(key),
+        ),
+    )
+    for key in ranked[:remaining]:
+        seats[key] += 1
+    if sum(seats.values()) != total_seats:
+        raise AssertionError("largest-remainder allocation failed")
+    return seats
+
+
+def _ordered(
+    tasks: Iterable[EligibleTask], domain: str, seed: str, dataset_sha: str
+) -> list[EligibleTask]:
+    return sorted(
+        tasks,
+        key=lambda task: (
+            _digest(domain, seed, dataset_sha, task.task_id),
+            task.task_id.encode("utf-8"),
+        ),
+    )
+
+
+def _digest(domain: str, seed: str, dataset_sha: str, task_id: str) -> bytes:
+    preimage = (
+        domain + "\0" + seed + "\0" + dataset_sha + "\0" + task_id
+    ).encode("utf-8")
+    return hashlib.sha256(preimage).digest()
+
+
+def _stratum_sort_key(stratum: tuple[str, str]) -> bytes:
+    output = bytearray()
+    for value in stratum:
+        encoded = value.encode("utf-8")
+        output.extend(len(encoded).to_bytes(4, "big"))
+        output.extend(encoded)
+    return bytes(output)
+
+
+def _required_text(record: Mapping[str, Any], field: str) -> str:
+    value = record.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/batch-runner/core/agentic_selector.py
+++ b/batch-runner/core/agentic_selector.py
@@ -179,6 +179,8 @@ def build_selection_manifest(
     dataset_sha: str,
     rubric_repo: str,
     rubric_sha: str,
+    dataset_path: str | Path,
+    rubric_path: str | Path,
     selector_path: str | Path,
     repository_root: str | Path,
     source_commit: str,
@@ -199,6 +201,12 @@ def build_selection_manifest(
         ) is None:
             raise ValueError(f"{label} revision must be a full commit SHA")
     root = Path(repository_root).resolve()
+    dataset_source = resolve_outcome_free_file(
+        root, dataset_path, "dataset JSON"
+    )
+    rubric_source = resolve_outcome_free_file(
+        root, rubric_path, "rubric JSON"
+    )
     selector = resolve_outcome_free_file(root, selector_path, "selector source")
     actual_commit = _git_output(root, "rev-parse", "HEAD")
     if source_commit != actual_commit:
@@ -206,8 +214,18 @@ def build_selection_manifest(
     selector_relative = selector.relative_to(root).as_posix()
     manifest = dict(selection)
     manifest.update({
-        "dataset": {"repository": dataset_repo, "revision": dataset_sha},
-        "rubric": {"repository": rubric_repo, "revision": rubric_sha},
+        "dataset": {
+            "repository": dataset_repo,
+            "revision": dataset_sha,
+            "source_path": dataset_source.relative_to(root).as_posix(),
+            "sha256": _sha256_file(dataset_source),
+        },
+        "rubric": {
+            "repository": rubric_repo,
+            "revision": rubric_sha,
+            "source_path": rubric_source.relative_to(root).as_posix(),
+            "sha256": _sha256_file(rubric_source),
+        },
         "selector": {
             "path": selector_relative,
             "source_commit": source_commit,

--- a/batch-runner/core/agentic_tools.py
+++ b/batch-runner/core/agentic_tools.py
@@ -175,7 +175,9 @@ class AgenticComputeBackend(Protocol):
         self, deliverables: list[str], summary: str,
         timeout_seconds: float = 1200.0,
     ) -> Mapping[str, Any]: ...
-    def best_result(self) -> Mapping[str, Any] | None: ...
+    def best_result(
+        self, timeout_seconds: float = 1200.0
+    ) -> Mapping[str, Any] | None: ...
     def close(self) -> None: ...
 
 
@@ -211,6 +213,7 @@ class AgenticToolDispatcher:
     total_calls: int = 0
     calls_by_name: Dict[str, int] = field(default_factory=dict)
     seen_requests: set[str] = field(default_factory=set)
+    mutation_epoch: int = 0
 
     def dispatch(self, name: str, raw_arguments: Any) -> ToolDispatch:
         prepared, error = self.prepare_batch([(name, raw_arguments)])
@@ -230,6 +233,7 @@ class AgenticToolDispatcher:
             return [], "tool_budget_exhausted"
 
         prospective = dict(self.calls_by_name)
+        prospective_epoch = self.mutation_epoch
         prepared: list[PreparedToolCall] = []
         batch_fingerprints: set[str] = set()
         for name, raw_arguments in calls:
@@ -256,10 +260,22 @@ class AgenticToolDispatcher:
             )
             if errors:
                 return [], "invalid_arguments"
+            if not _within_utf8_limits(name, arguments):
+                return [], "argument_byte_limit_exceeded"
 
             fingerprint = hashlib.sha256(
                 json.dumps(
-                    [name, arguments], sort_keys=True, separators=(",", ":")
+                    [
+                        name,
+                        arguments,
+                        (
+                            prospective_epoch
+                            if name in {"inspect_workspace", "inspect_artifacts"}
+                            else None
+                        ),
+                    ],
+                    sort_keys=True,
+                    separators=(",", ":"),
                 ).encode("utf-8")
             ).hexdigest()
             if (
@@ -269,10 +285,13 @@ class AgenticToolDispatcher:
                 return [], "duplicate_tool_request"
             batch_fingerprints.add(fingerprint)
             prepared.append(PreparedToolCall(name, dict(arguments), fingerprint))
+            if name in {"run_python", "run_ffmpeg"}:
+                prospective_epoch += 1
 
         self.total_calls += len(prepared)
         self.calls_by_name = prospective
         self.seen_requests.update(batch_fingerprints)
+        self.mutation_epoch = prospective_epoch
         return prepared, None
 
     def dispatch_prepared(
@@ -330,6 +349,36 @@ class AgenticToolDispatcher:
 
 def _error(error_type: str, *, retryable: bool) -> dict:
     return {"ok": False, "error_type": error_type, "retryable": retryable}
+
+
+def _within_utf8_limits(name: str, arguments: Mapping[str, Any]) -> bool:
+    try:
+        encoded = json.dumps(
+            dict(arguments),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        return False
+    if len(encoded) > 131072:
+        return False
+    if name == "run_python" and len(arguments["source"].encode("utf-8")) > 131072:
+        return False
+    if name == "finalize" and len(arguments["summary"].encode("utf-8")) > 2048:
+        return False
+    path_values = []
+    for field_name in ("input", "output"):
+        value = arguments.get(field_name)
+        if isinstance(value, str):
+            path_values.append(value)
+    deliverables = arguments.get("deliverables")
+    if isinstance(deliverables, list):
+        path_values.extend(
+            value for value in deliverables if isinstance(value, str)
+        )
+    return all(len(value.encode("utf-8")) <= 240 for value in path_values)
 
 
 def _bounded_envelope(payload: Mapping[str, Any], limit: int) -> dict:

--- a/batch-runner/core/agentic_tools.py
+++ b/batch-runner/core/agentic_tools.py
@@ -1,0 +1,347 @@
+"""Strict model-visible tools for the task-solving agentic sandbox."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Protocol
+
+from jsonschema import Draft202012Validator
+
+
+TOOL_NAMES = (
+    "inspect_workspace",
+    "inspect_environment",
+    "run_python",
+    "run_ffmpeg",
+    "inspect_artifacts",
+    "finalize",
+)
+
+_EMPTY_SCHEMA = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+_PATH_SCHEMA = {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 240,
+    "pattern": r"^(?!/)(?!.*(?:^|/)\.\.(?:/|$))(?!.*[:\\\x00-\x1f]).+$",
+}
+
+_TIMING_PROPERTIES = {
+    "start_seconds": {"type": "number", "minimum": 0, "maximum": 3600},
+    "duration_seconds": {"type": "number", "minimum": 0.1, "maximum": 600},
+}
+
+_AUDIO_PROPERTIES = {
+    "input": _PATH_SCHEMA,
+    "output": _PATH_SCHEMA,
+    "format": {"enum": ["wav", "flac"]},
+    "sample_rate": {"enum": [8000, 16000, 22050, 44100, 48000]},
+    "channels": {"enum": [1, 2]},
+    **_TIMING_PROPERTIES,
+}
+
+
+def _operation_schema(operation: str, properties: dict, required: list[str]) -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "operation": {"const": operation},
+            **properties,
+        },
+        "required": ["operation", *required],
+        "additionalProperties": False,
+    }
+
+
+FFMPEG_SCHEMA = {
+    "oneOf": [
+        _operation_schema("probe", {"input": _PATH_SCHEMA}, ["input"]),
+        _operation_schema(
+            "extract_audio",
+            _AUDIO_PROPERTIES,
+            ["input", "output", "format", "sample_rate", "channels",
+             "start_seconds", "duration_seconds"],
+        ),
+        _operation_schema(
+            "transcode_audio",
+            _AUDIO_PROPERTIES,
+            ["input", "output", "format", "sample_rate", "channels",
+             "start_seconds", "duration_seconds"],
+        ),
+        _operation_schema(
+            "transcode_video",
+            {
+                "input": _PATH_SCHEMA,
+                "output": _PATH_SCHEMA,
+                "container": {"enum": ["mp4", "webm"]},
+                "video_codec": {"enum": ["h264", "vp9"]},
+                "audio_codec": {"enum": ["aac", "opus"]},
+                "width": {"type": "integer", "minimum": 64, "maximum": 1920},
+                "height": {"type": "integer", "minimum": 64, "maximum": 1920},
+                "fps": {"enum": [1, 5, 10, 15, 24, 25, 30]},
+                **_TIMING_PROPERTIES,
+            },
+            ["input", "output", "container", "video_codec", "audio_codec",
+             "width", "height", "fps", "start_seconds", "duration_seconds"],
+        ),
+        _operation_schema(
+            "sample_frames",
+            {
+                "input": _PATH_SCHEMA,
+                "output": _PATH_SCHEMA,
+                "frame_count": {"type": "integer", "minimum": 1, "maximum": 16},
+                "width": {"type": "integer", "minimum": 64, "maximum": 1920},
+                **_TIMING_PROPERTIES,
+            },
+            ["input", "output", "frame_count", "width", "start_seconds",
+             "duration_seconds"],
+        ),
+    ]
+}
+
+TOOL_SCHEMAS: Dict[str, dict] = {
+    "inspect_workspace": _EMPTY_SCHEMA,
+    "inspect_environment": _EMPTY_SCHEMA,
+    "run_python": {
+        "type": "object",
+        "properties": {
+            "source": {"type": "string", "minLength": 1, "maxLength": 131072},
+            "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 1200},
+        },
+        "required": ["source", "timeout_seconds"],
+        "additionalProperties": False,
+    },
+    "run_ffmpeg": FFMPEG_SCHEMA,
+    "inspect_artifacts": _EMPTY_SCHEMA,
+    "finalize": {
+        "type": "object",
+        "properties": {
+            "deliverables": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 64,
+                "uniqueItems": True,
+                "items": _PATH_SCHEMA,
+            },
+            "summary": {"type": "string", "minLength": 1, "maxLength": 2048},
+        },
+        "required": ["deliverables", "summary"],
+        "additionalProperties": False,
+    },
+}
+
+
+def responses_tool_definitions() -> list[dict]:
+    """Return Responses API function definitions in a stable order."""
+    descriptions = {
+        "inspect_workspace": "List bounded metadata for inputs and generated workspace files.",
+        "inspect_environment": "Return the checked-in runtime capability manifest.",
+        "run_python": "Run Python source in the isolated task workspace.",
+        "run_ffmpeg": "Run one closed, validated local-media operation.",
+        "inspect_artifacts": "Deterministically inspect generated deliverables.",
+        "finalize": "Submit verified deliverables and finish the task.",
+    }
+    return [
+        {
+            "type": "function",
+            "name": name,
+            "description": descriptions[name],
+            "parameters": TOOL_SCHEMAS[name],
+            "strict": True,
+        }
+        for name in TOOL_NAMES
+    ]
+
+
+class AgenticComputeBackend(Protocol):
+    """Uncredentialed compute-plane contract used by the solver loop."""
+
+    def start(self, timeout_seconds: float = 1200.0) -> Mapping[str, Any]: ...
+    def inspect_workspace(self, timeout_seconds: float = 1200.0) -> Mapping[str, Any]: ...
+    def inspect_environment(self, timeout_seconds: float = 1200.0) -> Mapping[str, Any]: ...
+    def reset_work(self, timeout_seconds: float = 1200.0) -> Mapping[str, Any]: ...
+    def run_python(self, source: str, timeout_seconds: float) -> Mapping[str, Any]: ...
+    def run_ffmpeg(
+        self, operation: Mapping[str, Any], timeout_seconds: float
+    ) -> Mapping[str, Any]: ...
+    def inspect_artifacts(self, timeout_seconds: float = 1200.0) -> Mapping[str, Any]: ...
+    def finalize(
+        self, deliverables: list[str], summary: str,
+        timeout_seconds: float = 1200.0,
+    ) -> Mapping[str, Any]: ...
+    def best_result(self) -> Mapping[str, Any] | None: ...
+    def close(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class ToolDispatch:
+    result: dict
+    finalized: bool = False
+    terminal_result: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class PreparedToolCall:
+    name: str
+    arguments: dict
+    fingerprint: str
+
+
+@dataclass
+class AgenticToolDispatcher:
+    """Validate, bound, and sequentially dispatch model tool calls."""
+
+    backend: AgenticComputeBackend
+    max_total_calls: int = 8
+    per_tool_limits: Mapping[str, int] = field(default_factory=lambda: {
+        "inspect_workspace": 4,
+        "inspect_environment": 2,
+        "run_python": 4,
+        "run_ffmpeg": 2,
+        "inspect_artifacts": 4,
+        "finalize": 2,
+    })
+    max_result_bytes: int = 32768
+    total_calls: int = 0
+    calls_by_name: Dict[str, int] = field(default_factory=dict)
+    seen_requests: set[str] = field(default_factory=set)
+
+    def dispatch(self, name: str, raw_arguments: Any) -> ToolDispatch:
+        prepared, error = self.prepare_batch([(name, raw_arguments)])
+        if error is not None:
+            return ToolDispatch(_error(error, retryable=False))
+        return self.dispatch_prepared(prepared[0])
+
+    def prepare_batch(
+        self, calls: list[tuple[str, Any]]
+    ) -> tuple[list[PreparedToolCall], str | None]:
+        """Validate an entire ordered response before reserving tool budgets."""
+        if not calls:
+            return [], "empty_tool_batch"
+        if any(name == "finalize" for name, _ in calls) and len(calls) != 1:
+            return [], "invalid_finalize_batch"
+        if self.total_calls + len(calls) > self.max_total_calls:
+            return [], "tool_budget_exhausted"
+
+        prospective = dict(self.calls_by_name)
+        prepared: list[PreparedToolCall] = []
+        batch_fingerprints: set[str] = set()
+        for name, raw_arguments in calls:
+            if name not in TOOL_SCHEMAS:
+                return [], "unknown_tool"
+            prospective[name] = prospective.get(name, 0) + 1
+            if prospective[name] > self.per_tool_limits.get(name, 0):
+                return [], "tool_budget_exhausted"
+
+            try:
+                arguments = (
+                    json.loads(raw_arguments)
+                    if isinstance(raw_arguments, str)
+                    else raw_arguments
+                )
+            except (TypeError, ValueError, json.JSONDecodeError):
+                return [], "malformed_arguments"
+            if not isinstance(arguments, dict):
+                return [], "malformed_arguments"
+
+            errors = sorted(
+                Draft202012Validator(TOOL_SCHEMAS[name]).iter_errors(arguments),
+                key=lambda error: list(error.path),
+            )
+            if errors:
+                return [], "invalid_arguments"
+
+            fingerprint = hashlib.sha256(
+                json.dumps(
+                    [name, arguments], sort_keys=True, separators=(",", ":")
+                ).encode("utf-8")
+            ).hexdigest()
+            if (
+                fingerprint in self.seen_requests
+                or fingerprint in batch_fingerprints
+            ):
+                return [], "duplicate_tool_request"
+            batch_fingerprints.add(fingerprint)
+            prepared.append(PreparedToolCall(name, dict(arguments), fingerprint))
+
+        self.total_calls += len(prepared)
+        self.calls_by_name = prospective
+        self.seen_requests.update(batch_fingerprints)
+        return prepared, None
+
+    def dispatch_prepared(
+        self,
+        call: PreparedToolCall,
+        *,
+        remaining_seconds: float | None = None,
+    ) -> ToolDispatch:
+        name = call.name
+        arguments = call.arguments
+        timeout = remaining_seconds if remaining_seconds is not None else 1200.0
+        if timeout <= 0:
+            return ToolDispatch(
+                _error("task_wall_time_exhausted", retryable=False)
+            )
+        try:
+            if name == "inspect_workspace":
+                payload = self.backend.inspect_workspace(timeout)
+            elif name == "inspect_environment":
+                payload = self.backend.inspect_environment(timeout)
+            elif name == "run_python":
+                timeout = float(arguments["timeout_seconds"])
+                if remaining_seconds is not None:
+                    timeout = min(timeout, remaining_seconds)
+                if timeout <= 0:
+                    return ToolDispatch(
+                        _error("task_wall_time_exhausted", retryable=False)
+                    )
+                payload = self.backend.run_python(
+                    arguments["source"], timeout
+                )
+            elif name == "run_ffmpeg":
+                timeout = remaining_seconds if remaining_seconds is not None else 660.0
+                if timeout <= 0:
+                    return ToolDispatch(
+                        _error("task_wall_time_exhausted", retryable=False)
+                    )
+                payload = self.backend.run_ffmpeg(arguments, timeout)
+            elif name == "inspect_artifacts":
+                payload = self.backend.inspect_artifacts(timeout)
+            else:
+                payload = self.backend.finalize(
+                    arguments["deliverables"], arguments["summary"], timeout
+                )
+        except Exception:
+            return ToolDispatch(_error("compute_backend_error", retryable=False))
+
+        result = _bounded_envelope(payload, self.max_result_bytes)
+        finalized = name == "finalize" and result.get("ok") is True
+        terminal_result = self.backend.best_result() if finalized else None
+        if finalized and terminal_result is None:
+            return ToolDispatch(_error("finalize_result_missing", retryable=False))
+        return ToolDispatch(result, finalized=finalized, terminal_result=terminal_result)
+
+
+def _error(error_type: str, *, retryable: bool) -> dict:
+    return {"ok": False, "error_type": error_type, "retryable": retryable}
+
+
+def _bounded_envelope(payload: Mapping[str, Any], limit: int) -> dict:
+    result = dict(payload)
+    if result.get("ok") not in (True, False):
+        result = _error("invalid_compute_result", retryable=False)
+    try:
+        encoded = json.dumps(
+            result, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        return _error("invalid_compute_result", retryable=False)
+    if len(encoded) > limit:
+        return _error("tool_result_too_large", retryable=False)
+    return result

--- a/batch-runner/core/agentic_verifier.py
+++ b/batch-runner/core/agentic_verifier.py
@@ -1,0 +1,181 @@
+"""No-network verifier-container entrypoint for private artifact snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+from core.artifact_verifier import verify_artifacts
+from core.deliverable_contract import infer_deliverable_contract, validate_contract
+from core.output_qa import run_output_qa
+
+
+SNAPSHOT_ROOT = Path("/snapshot")
+MAX_FILES = 64
+MAX_TOTAL_BYTES = 512 * 1024 * 1024
+MAX_SINGLE_BYTES = 256 * 1024 * 1024
+MAX_DEPTH = 16
+MAX_PATH_BYTES = 240
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _strict_files() -> list[Path]:
+    files: list[Path] = []
+    total = 0
+    for path in sorted(SNAPSHOT_ROOT.rglob("*")):
+        relative = path.relative_to(SNAPSHOT_ROOT)
+        if any(part.startswith(".") for part in relative.parts):
+            continue
+        encoded = relative.as_posix().encode("utf-8")
+        if len(relative.parts) > MAX_DEPTH or len(encoded) > MAX_PATH_BYTES:
+            raise ValueError("artifact_path_limit")
+        metadata = path.lstat()
+        if stat.S_ISDIR(metadata.st_mode):
+            continue
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise ValueError("artifact_type_or_link_violation")
+        if metadata.st_size <= 0 or metadata.st_size > MAX_SINGLE_BYTES:
+            raise ValueError("artifact_size_limit")
+        total += metadata.st_size
+        if total > MAX_TOTAL_BYTES:
+            raise ValueError("artifact_total_size_limit")
+        files.append(path)
+        if len(files) > MAX_FILES:
+            raise ValueError("artifact_file_count_limit")
+    return files
+
+
+def verify(payload: dict) -> dict:
+    if not isinstance(payload, dict) or not set(payload) <= {
+        "task_prompt", "reference_hashes", "selected_deliverables"
+    }:
+        return {"ok": False, "error_type": "invalid_verifier_request"}
+    task_prompt = payload.get("task_prompt")
+    reference_hashes = set(payload.get("reference_hashes") or [])
+    if not isinstance(task_prompt, str):
+        return {"ok": False, "error_type": "invalid_verifier_request"}
+    files = _strict_files()
+    if not files:
+        return {"ok": False, "error_type": "no_artifacts"}
+
+    selected = payload.get("selected_deliverables")
+    if selected is not None:
+        if not isinstance(selected, list) or not selected:
+            return {"ok": False, "error_type": "invalid_selected_deliverables"}
+        by_name = {
+            path.relative_to(SNAPSHOT_ROOT).as_posix(): path for path in files
+        }
+        normalized = []
+        for value in selected:
+            if not isinstance(value, str) or "\\" in value:
+                return {"ok": False, "error_type": "invalid_selected_deliverables"}
+            relative = Path(value)
+            if (
+                relative.is_absolute()
+                or not relative.parts
+                or relative.as_posix() != value
+                or ".." in relative.parts
+                or any(part.startswith(".") for part in relative.parts)
+                or value not in by_name
+                or value in normalized
+            ):
+                return {"ok": False, "error_type": "invalid_selected_deliverables"}
+            normalized.append(value)
+        files = [by_name[value] for value in normalized]
+
+    copied_inputs = [path for path in files if _sha256(path) in reference_hashes]
+    if copied_inputs:
+        return {"ok": False, "error_type": "copied_input"}
+
+    contract = infer_deliverable_contract(task_prompt, [])
+    contract_report = validate_contract(contract, files)
+    verification = verify_artifacts(files, contract=contract, workdir=SNAPSHOT_ROOT)
+    output_qa = run_output_qa(
+        files,
+        contract=contract,
+        config={
+            "enabled": True,
+            "render": True,
+            "max_pages_per_artifact": 3,
+            "blank_page_threshold": 0.999,
+            "vision": {"enabled": False},
+        },
+        out_dir=Path("/verify-work/render"),
+        task_text=task_prompt,
+    )
+    uncertain = any(report.openable is None for report in verification.artifacts)
+    render_errors = any(
+        report.get("errors") for report in output_qa.render_reports
+    )
+    ok = (
+        contract_report.ok
+        and verification.ok
+        and output_qa.ok
+        and not uncertain
+        and not render_errors
+    )
+    return {
+        "ok": ok,
+        "error_type": None if ok else "artifact_verification_failed",
+        "data": {
+            "artifact_count": len(files),
+            "artifacts": [
+                {
+                    "path": path.relative_to(SNAPSHOT_ROOT).as_posix(),
+                    "size_bytes": path.stat().st_size,
+                    "sha256": _sha256(path),
+                    "kind": report.kind,
+                    "openable": report.openable,
+                }
+                for path, report in zip(files, verification.artifacts)
+            ],
+            "contract": contract_report.to_dict(),
+            "blocking_error_count": (
+                len(contract_report.blocking_errors)
+                + len(verification.blocking_errors)
+                + len(output_qa.blocking_errors)
+                + int(uncertain)
+                + int(render_errors)
+            ),
+            "warning_count": (
+                len(contract_report.warnings)
+                + len(verification.warnings)
+                + len(output_qa.warnings)
+            ),
+        },
+    }
+
+
+def main() -> None:
+    if os.geteuid() == 0:
+        raise SystemExit("verifier refuses UID 0")
+    try:
+        for relative in (".home", ".tmp", ".cache", ".config"):
+            (Path("/verify-work") / relative).mkdir(
+                mode=0o700, parents=True, exist_ok=True
+            )
+        payload = json.loads(sys.stdin.buffer.read(131073))
+        result = verify(payload)
+        encoded = json.dumps(
+            result, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+        if len(encoded) > 32768:
+            encoded = b'{"ok":false,"error_type":"verifier_result_too_large"}'
+        sys.stdout.buffer.write(encoded)
+    except Exception:
+        sys.stdout.write('{"ok":false,"error_type":"verifier_internal_error"}')
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/core/agentic_verifier.py
+++ b/batch-runner/core/agentic_verifier.py
@@ -115,15 +115,11 @@ def verify(payload: dict) -> dict:
         task_text=task_prompt,
     )
     uncertain = any(report.openable is None for report in verification.artifacts)
-    render_errors = any(
-        report.get("errors") for report in output_qa.render_reports
-    )
     ok = (
         contract_report.ok
         and verification.ok
         and output_qa.ok
         and not uncertain
-        and not render_errors
     )
     return {
         "ok": ok,
@@ -146,7 +142,6 @@ def verify(payload: dict) -> dict:
                 + len(verification.blocking_errors)
                 + len(output_qa.blocking_errors)
                 + int(uncertain)
-                + int(render_errors)
             ),
             "warning_count": (
                 len(contract_report.warnings)

--- a/batch-runner/core/artifact_renderer.py
+++ b/batch-runner/core/artifact_renderer.py
@@ -48,7 +48,14 @@ class RenderResult:
 
 
 def _find_soffice() -> Optional[str]:
-    for name in ("soffice", "libreoffice"):
+    for fixed in (
+        "/usr/lib/libreoffice/program/soffice.bin",
+        "/opt/libreoffice/program/soffice.bin",
+    ):
+        path = Path(fixed)
+        if path.is_file() and path.stat().st_mode & 0o111:
+            return str(path)
+    for name in ("soffice.bin", "soffice", "libreoffice"):
         path = shutil.which(name)
         if path:
             return path
@@ -85,7 +92,7 @@ def _render_pdf(
     try:
         import fitz
     except Exception:
-        result.warnings.append("PyMuPDF unavailable; cannot render to PNG")
+        result.errors.append("PyMuPDF unavailable; cannot render to PNG")
         return
     try:
         doc = fitz.open(str(pdf_path))
@@ -107,45 +114,82 @@ def _render_pdf(
             if white >= blank_threshold:
                 result.blank_pages.append(i + 1)
         except Exception as e:
-            result.warnings.append(f"page {i + 1} render failed: {e}")
+            result.errors.append(f"page {i + 1} render failed: {e}")
     doc.close()
+    if result.page_count <= 0:
+        result.errors.append("PDF contains no renderable pages")
+    elif not result.rendered_images:
+        result.errors.append("PDF produced no rendered page images")
 
 
 def _convert_office_to_pdf(src: Path, out_dir: Path, result: RenderResult) -> Optional[Path]:
     soffice = _find_soffice()
     if not soffice:
-        result.warnings.append("LibreOffice unavailable; cannot render office document")
+        result.errors.append("LibreOffice unavailable; cannot render office document")
         return None
     try:
+        profile = out_dir.parent / ".config" / "libreoffice"
+        profile.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        command = [
+            soffice,
+            f"-env:UserInstallation={profile.as_uri()}",
+            "--headless",
+            "--norestore",
+            "--nodefault",
+            "--nofirststartwizard",
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            str(out_dir),
+            str(src),
+        ]
         proc = subprocess.run(
-            [soffice, "--headless", "--convert-to", "pdf", "--outdir",
-             str(out_dir), str(src)],
-            capture_output=True, text=True, timeout=120,
+            command, capture_output=True, text=True, timeout=120,
         )
+        if proc.returncode == 81:
+            proc = subprocess.run(
+                command, capture_output=True, text=True, timeout=120,
+            )
         pdf_path = out_dir / (src.stem + ".pdf")
-        if pdf_path.exists():
+        if proc.returncode == 0 and pdf_path.is_file() and pdf_path.stat().st_size > 0:
             result.converted_via = "libreoffice"
             return pdf_path
-        result.warnings.append(
-            f"LibreOffice conversion produced no PDF: {proc.stderr[-200:]}"
+        result.errors.append(
+            "LibreOffice conversion produced no PDF "
+            f"(exit {proc.returncode}): {proc.stderr[-200:]}"
         )
     except Exception as e:
-        result.warnings.append(f"LibreOffice conversion failed: {e}")
+        result.errors.append(f"LibreOffice conversion failed: {e}")
     return None
 
 
-def _render_image(src: Path, out_dir: Path, stem: str, result: RenderResult) -> None:
+def _render_image(
+    src: Path,
+    out_dir: Path,
+    stem: str,
+    blank_threshold: float,
+    result: RenderResult,
+) -> None:
     try:
         from PIL import Image
         with Image.open(src) as im:
-            im = im.convert("RGB")
-            im.thumbnail((1600, 1600))
+            rgba = im.convert("RGBA")
+            rgba.thumbnail((1600, 1600))
+            background = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+            background.alpha_composite(rgba)
+            rendered = background.convert("RGB")
             img_path = out_dir / f"{stem}_p1.png"
-            im.save(img_path)
+            rendered.save(img_path)
             result.rendered_images.append(str(img_path))
             result.page_count = 1
+            histogram = rendered.convert("L").histogram()
+            total = sum(histogram)
+            white = sum(histogram[250:]) / max(total, 1)
+            result.page_white_fractions.append(round(white, 5))
+            if white >= blank_threshold:
+                result.blank_pages.append(1)
     except Exception as e:
-        result.warnings.append(f"image snapshot failed: {e}")
+        result.errors.append(f"image snapshot failed: {e}")
 
 
 def render_artifact(
@@ -196,7 +240,9 @@ def render_artifact(
     if kind == "pdf":
         _render_pdf(artifact_path, out_dir, stem, max_pages, blank_threshold, dpi, result)
     elif kind == "image":
-        _render_image(artifact_path, out_dir, stem, result)
+        _render_image(
+            artifact_path, out_dir, stem, blank_threshold, result
+        )
     elif kind in _OFFICE_KINDS:
         pdf_path = _convert_office_to_pdf(artifact_path, out_dir, result)
         if pdf_path is not None:

--- a/batch-runner/core/executor.py
+++ b/batch-runner/core/executor.py
@@ -5,19 +5,58 @@ Selects and delegates to appropriate runner based on execution mode:
 - code_interpreter: Azure OpenAI Responses API (OpenAI models only)
 - subprocess: LLM code generation + safe execution (all models)
 - sandbox: LLM code generation + skill-aware containerized execution (all models)
+- agentic_sandbox: bounded Responses tool loop (Azure/OpenAI only)
 - json_renderer: JSON spec + fixed renderer (fair comparison mode)
 """
 
-from typing import Literal, Optional
+import os
+from pathlib import Path
+from typing import Callable, Literal, Mapping, Optional
 
+from core.agentic_authorization import (
+    ApprovalExpectation,
+    ApprovalNonceLedger,
+    SignedApprovalGate,
+    load_approval_scope,
+    provider_endpoint_sha256,
+)
+from core.agentic_budget import AgenticBudgetLedger
+from core.agentic_sandbox_runner import AgenticSandboxRunner
+from core.agentic_pricing import load_pinned_model_pricing
+from core.agentic_runtime_identity import derive_runtime_identity_from_environment
+from core.agentic_remote_compute import remote_backend_factory_from_environment
 from core.code_interpreter import CodeInterpreterRunner
 from core.config import DEFAULT_TOKENS
 from core.subprocess_runner import SubprocessRunner
 from core.sandbox_runner import SandboxRunner
 from core.json_renderer import JsonRenderer
+from core.hardened_sandbox_runner import HardenedSandboxRunner
 
 # Execution modes
-ExecutionMode = Literal["code_interpreter", "subprocess", "sandbox", "json_renderer"]
+ExecutionMode = Literal[
+    "code_interpreter", "subprocess", "sandbox", "agentic_sandbox",
+    "json_renderer",
+]
+
+
+def _load_live_approval_scope(
+    *, repository_root: Path, condition_name: str, classification: str
+) -> dict:
+    scope_path = os.getenv("AGENTIC_APPROVAL_SCOPE_PATH")
+    if not scope_path:
+        raise ValueError("agentic approval scope path is required")
+    scope = load_approval_scope(
+        repository_root=repository_root,
+        scope_path=scope_path,
+    )
+    if scope["conditions"] != (condition_name,):
+        raise ValueError("approval scope condition set is not exact")
+    expected_count = 5 if condition_name == "canary" else 20
+    if len(scope["task_ids"]) != expected_count:
+        raise ValueError("approval scope task count differs from preregistration")
+    if set(scope["provider_classifications"].values()) != {classification}:
+        raise ValueError("approval scope provider classifications differ")
+    return scope
 
 
 class TaskExecutor:
@@ -35,6 +74,20 @@ class TaskExecutor:
         reasoning_effort: Optional[str] = None,
         sandbox_options: Optional[dict] = None,
         metrics_options: Optional[dict] = None,
+        provider: Optional[str] = None,
+        client_factory: Optional[Callable[[], object]] = None,
+        agentic_options: Optional[dict] = None,
+        run_id: Optional[str] = None,
+        condition_name: Optional[str] = None,
+        model_name: Optional[str] = None,
+        agentic_backend_factory=None,
+        agentic_authorize_request=None,
+        agentic_budget_ledger=None,
+        agentic_remote_backend_factory=None,
+        agentic_runtime_identity: Optional[Mapping[str, str]] = None,
+        agentic_price_table_path: Optional[str] = None,
+        agentic_endpoint: Optional[str] = None,
+        non_paid_test_mode: bool = False,
     ):
         """
         Initialize executor with specified mode.
@@ -53,11 +106,16 @@ class TaskExecutor:
                 use_docker ("auto"|"never"|"always"), memory_gb (int),
                 cpus (float), skills_dir (str), max_skills (int).
             metrics_options: Optional opt-in ``execution.metrics`` settings.
+            provider: Explicit model provider for provider-restricted modes.
+            client_factory: Deferred provider client constructor used only after
+                the agentic runtime and signed approval gate pass.
+            agentic_options: Strict ``execution.agentic`` settings.
 
         Raises:
             ValueError: If required parameters are missing for the selected mode
         """
         self.mode = mode
+        self.hardened_sandbox = False
         self.tokens = dict(DEFAULT_TOKENS)
         if isinstance(tokens, dict):
             self.tokens.update({k: v for k, v in tokens.items() if v is not None})
@@ -83,29 +141,394 @@ class TaskExecutor:
             )
 
         elif mode == "sandbox":
-            if llm_client is None:
-                raise ValueError("sandbox mode requires llm_client")
             opts = dict(sandbox_options or {})
             metric_opts = metrics_options if isinstance(metrics_options, dict) else None
-            self.runner = SandboxRunner(
-                llm_client,
-                prompt_name=prompt_name or opts.get("prompt_name") or SandboxRunner.DEFAULT_PROMPT,
-                max_completion_tokens=self.tokens.get("code_generation"),
-                timeout=timeout,
-                reasoning_effort=reasoning_effort,
-                skills_dir=opts.get("skills_dir"),
-                image=opts.get("image"),
-                use_docker=opts.get("use_docker", "auto"),
-                memory_gb=opts.get("memory_gb"),
-                cpus=opts.get("cpus"),
-                max_skills=opts.get("max_skills", 5),
-                repair=opts.get("repair"),
-                output_qa=opts.get("output_qa"),
-                manifest=opts.get("manifest"),
-                cache=opts.get("cache"),
-                contract=opts.get("contract"),
-                metrics=metric_opts,
-            )
+            if opts.get("hardened_substrate") is True:
+                normalized_provider = (
+                    "azure" if provider == "azure_openai" else provider
+                )
+                valid, error = self.validate_mode(
+                    "agentic_sandbox", normalized_provider or ""
+                )
+                if not valid:
+                    raise ValueError(error)
+                common = dict(agentic_options or {})
+                pricing_config = common.get("pricing")
+                if non_paid_test_mode:
+                    if (
+                        agentic_backend_factory is None
+                        or agentic_authorize_request is None
+                        or agentic_budget_ledger is None
+                    ):
+                        raise ValueError(
+                            "non-paid hardened sandbox tests require explicit fakes"
+                        )
+                    factory = client_factory or (lambda: llm_client)
+                    backend_factory = agentic_backend_factory
+                    authorizer = agentic_authorize_request
+                    ledger = agentic_budget_ledger
+                else:
+                    if llm_client is not None:
+                        raise ValueError(
+                            "hardened sandbox requires deferred client construction"
+                        )
+                    required_identity = (run_id, condition_name, model_name)
+                    if any(not value for value in required_identity):
+                        raise ValueError(
+                            "hardened sandbox requires run, condition, and model identity"
+                        )
+                    authorization = common.get("authorization")
+                    if not isinstance(authorization, dict):
+                        raise ValueError("execution.agentic.authorization is required")
+                    required_authorization = (
+                        "api_version", "provider_classification", "endpoint_sha256",
+                    )
+                    missing = [
+                        key for key in required_authorization
+                        if not authorization.get(key)
+                    ]
+                    if missing:
+                        raise ValueError(
+                            f"missing agentic authorization setting(s): {missing}"
+                        )
+                    runtime_identity = dict(
+                        agentic_runtime_identity
+                        or derive_runtime_identity_from_environment(
+                            Path(__file__).resolve().parents[2]
+                        )
+                    )
+                    endpoint_sha256 = provider_endpoint_sha256(
+                        normalized_provider or "", agentic_endpoint
+                    )
+                    if endpoint_sha256 != authorization["endpoint_sha256"]:
+                        raise ValueError("agentic provider endpoint identity mismatch")
+                    repository_root = Path(__file__).resolve().parents[2]
+                    approval_scope = _load_live_approval_scope(
+                        repository_root=repository_root,
+                        condition_name=condition_name or "",
+                        classification=authorization["provider_classification"],
+                    )
+                    signed_envelope_path = os.getenv(
+                        "AGENTIC_SIGNED_APPROVAL_PATH"
+                    )
+                    nonce_ledger_path = os.getenv("AGENTIC_NONCE_LEDGER_PATH")
+                    owner_public_key_path = (
+                        Path(__file__).resolve().parents[1]
+                        / "security" / "agentic-owner-ed25519.pub"
+                    )
+                    if not signed_envelope_path or not nonce_ledger_path:
+                        raise ValueError(
+                            "agentic approval environment paths are required"
+                        )
+                    gate = SignedApprovalGate(
+                        signed_envelope_path=signed_envelope_path,
+                        owner_public_key_path=owner_public_key_path,
+                        nonce_ledger=ApprovalNonceLedger(
+                            nonce_ledger_path
+                        ),
+                        expectation=ApprovalExpectation(
+                            plan_sha=runtime_identity["plan_sha"],
+                            implementation_sha=runtime_identity[
+                                "implementation_sha"
+                            ],
+                            run_id=run_id,
+                            condition=condition_name,
+                            provider=normalized_provider or "",
+                            model=model_name,
+                            api_version=authorization["api_version"],
+                            endpoint_sha256=endpoint_sha256,
+                            workflow_sha=runtime_identity["workflow_sha"],
+                            workflow_inputs_sha256=runtime_identity[
+                                "workflow_inputs_sha256"
+                            ],
+                            conditions=approval_scope["conditions"],
+                            task_ids=approval_scope["task_ids"],
+                            input_merkle_roots=approval_scope[
+                                "input_merkle_roots"
+                            ],
+                            provider_classifications=approval_scope[
+                                "provider_classifications"
+                            ],
+                            approval_scope_sha256=approval_scope[
+                                "approval_scope_sha256"
+                            ],
+                            official_scope_registry_sha256=approval_scope[
+                                "official_scope_registry_sha256"
+                            ],
+                        ),
+                    )
+                    ledger_path = os.getenv("AGENTIC_BUDGET_LEDGER_PATH")
+                    image = common.get("image")
+                    if not ledger_path or not image:
+                        raise ValueError(
+                            "hardened sandbox requires common image and budget ledger"
+                        )
+                    factory = client_factory
+                    authorizer = gate.authorize_request
+                    ledger = AgenticBudgetLedger(ledger_path)
+                    if common.get("compute_transport") != "remote":
+                        raise ValueError(
+                            "production hardened sandbox requires a remote "
+                            "authenticated compute backend"
+                        )
+                    backend_factory = (
+                        agentic_remote_backend_factory
+                        if callable(agentic_remote_backend_factory)
+                        else remote_backend_factory_from_environment(
+                            run_id=run_id,
+                            condition_name=condition_name,
+                        )
+                    )
+                    price_table = common.get("pricing_table")
+                    if not isinstance(price_table, dict):
+                        raise ValueError("execution.agentic.pricing_table is required")
+                    pricing_config = load_pinned_model_pricing(
+                        path=(
+                            agentic_price_table_path
+                            or Path(__file__).resolve().parents[1]
+                            / "security" / "agentic-pricing.json"
+                        ),
+                        expected_sha256=price_table.get("sha256", ""),
+                        provider=normalized_provider or "",
+                        model=model_name,
+                    )
+                self.hardened_sandbox = True
+                self.runner = HardenedSandboxRunner(
+                    client_factory=factory,
+                    backend_factory=backend_factory,
+                    budget_ledger=ledger,
+                    authorize_request=authorizer,
+                    run_id=run_id or "local-nonpaid",
+                    condition_name=condition_name or "condition_a",
+                    model_name=model_name or "test-model",
+                    provider=normalized_provider or "",
+                    api_version=(
+                        (common.get("authorization") or {}).get("api_version")
+                        or "nonpaid-test"
+                    ),
+                    endpoint_sha256=(
+                        (common.get("authorization") or {}).get("endpoint_sha256")
+                        or "nonpaid-test"
+                    ),
+                    approval_scope_sha256=(
+                        approval_scope["approval_scope_sha256"]
+                        if not non_paid_test_mode else "nonpaid-test"
+                    ),
+                    official_scope_registry_sha256=(
+                        approval_scope["official_scope_registry_sha256"]
+                        if not non_paid_test_mode else "nonpaid-test"
+                    ),
+                    limits=common.get("limits"),
+                    pricing=pricing_config,
+                    aggregate_budget=common.get("budget"),
+                    prompt_name=(
+                        prompt_name
+                        or opts.get("prompt_name")
+                        or SandboxRunner.DEFAULT_PROMPT
+                    ),
+                    max_completion_tokens=self.tokens.get("code_generation"),
+                    timeout=timeout,
+                    reasoning_effort=reasoning_effort,
+                    skills_dir=opts.get("skills_dir"),
+                    image=common.get("image") or opts.get("image"),
+                    memory_gb=common.get("memory_gb"),
+                    cpus=common.get("cpus"),
+                    max_skills=opts.get("max_skills", 5),
+                    repair=opts.get("repair"),
+                    output_qa=opts.get("output_qa"),
+                    manifest=opts.get("manifest"),
+                    cache=opts.get("cache"),
+                    contract=opts.get("contract"),
+                    metrics=metric_opts,
+                )
+            else:
+                if llm_client is None:
+                    raise ValueError("sandbox mode requires llm_client")
+                self.runner = SandboxRunner(
+                    llm_client,
+                    prompt_name=prompt_name or opts.get("prompt_name") or SandboxRunner.DEFAULT_PROMPT,
+                    max_completion_tokens=self.tokens.get("code_generation"),
+                    timeout=timeout,
+                    reasoning_effort=reasoning_effort,
+                    skills_dir=opts.get("skills_dir"),
+                    image=opts.get("image"),
+                    use_docker=opts.get("use_docker", "auto"),
+                    memory_gb=opts.get("memory_gb"),
+                    cpus=opts.get("cpus"),
+                    max_skills=opts.get("max_skills", 5),
+                    repair=opts.get("repair"),
+                    output_qa=opts.get("output_qa"),
+                    manifest=opts.get("manifest"),
+                    cache=opts.get("cache"),
+                    contract=opts.get("contract"),
+                    metrics=metric_opts,
+                )
+
+        elif mode == "agentic_sandbox":
+            normalized_provider = "azure" if provider == "azure_openai" else provider
+            valid, error = self.validate_mode(mode, normalized_provider or "")
+            if not valid:
+                raise ValueError(error)
+            opts = dict(agentic_options or {})
+            limits = opts.get("limits")
+            pricing = opts.get("pricing")
+
+            if non_paid_test_mode:
+                if agentic_backend_factory is None or agentic_authorize_request is None:
+                    raise ValueError(
+                        "non-paid agentic tests require explicit backend and authorization fakes"
+                    )
+                ledger = agentic_budget_ledger
+                if ledger is None:
+                    raise ValueError("non-paid agentic tests require an explicit budget ledger")
+                self.runner = AgenticSandboxRunner(
+                    llm_client,
+                    client_factory=client_factory,
+                    non_paid_test_mode=llm_client is not None,
+                    backend_factory=agentic_backend_factory,
+                    budget_ledger=ledger,
+                    authorize_request=agentic_authorize_request,
+                    prompt_name=prompt_name or AgenticSandboxRunner.DEFAULT_PROMPT,
+                    reasoning_effort=reasoning_effort,
+                    limits=limits,
+                    pricing=pricing,
+                    aggregate_budget=opts.get("budget"),
+                )
+            else:
+                required_identity = {
+                    "run_id": run_id,
+                    "condition_name": condition_name,
+                    "model_name": model_name,
+                }
+                if any(not value for value in required_identity.values()):
+                    raise ValueError(
+                        "agentic_sandbox requires run_id, condition_name, and model_name"
+                    )
+                authorization = opts.get("authorization")
+                if not isinstance(authorization, dict):
+                    raise ValueError("execution.agentic.authorization is required")
+                required_authorization = (
+                    "api_version", "provider_classification", "endpoint_sha256",
+                )
+                missing = [
+                    key for key in required_authorization if not authorization.get(key)
+                ]
+                if missing:
+                    raise ValueError(
+                        f"missing agentic authorization setting(s): {missing}"
+                    )
+                runtime_identity = dict(
+                    agentic_runtime_identity
+                    or derive_runtime_identity_from_environment(
+                        Path(__file__).resolve().parents[2]
+                    )
+                )
+                endpoint_sha256 = provider_endpoint_sha256(
+                    normalized_provider or "", agentic_endpoint
+                )
+                if endpoint_sha256 != authorization["endpoint_sha256"]:
+                    raise ValueError("agentic provider endpoint identity mismatch")
+                repository_root = Path(__file__).resolve().parents[2]
+                approval_scope = _load_live_approval_scope(
+                    repository_root=repository_root,
+                    condition_name=condition_name or "",
+                    classification=authorization["provider_classification"],
+                )
+                signed_envelope_path = os.getenv("AGENTIC_SIGNED_APPROVAL_PATH")
+                nonce_ledger_path = os.getenv("AGENTIC_NONCE_LEDGER_PATH")
+                owner_public_key_path = (
+                    Path(__file__).resolve().parents[1]
+                    / "security" / "agentic-owner-ed25519.pub"
+                )
+                if not signed_envelope_path or not nonce_ledger_path:
+                    raise ValueError("agentic approval environment paths are required")
+                gate = SignedApprovalGate(
+                    signed_envelope_path=signed_envelope_path,
+                    owner_public_key_path=owner_public_key_path,
+                    nonce_ledger=ApprovalNonceLedger(nonce_ledger_path),
+                    expectation=ApprovalExpectation(
+                        plan_sha=runtime_identity["plan_sha"],
+                        implementation_sha=runtime_identity[
+                            "implementation_sha"
+                        ],
+                        run_id=run_id,
+                        condition=condition_name,
+                        provider=normalized_provider or "",
+                        model=model_name,
+                        api_version=authorization["api_version"],
+                        endpoint_sha256=endpoint_sha256,
+                        workflow_sha=runtime_identity["workflow_sha"],
+                        workflow_inputs_sha256=runtime_identity[
+                            "workflow_inputs_sha256"
+                        ],
+                        conditions=approval_scope["conditions"],
+                        task_ids=approval_scope["task_ids"],
+                        input_merkle_roots=approval_scope["input_merkle_roots"],
+                        provider_classifications=approval_scope[
+                            "provider_classifications"
+                        ],
+                        approval_scope_sha256=approval_scope[
+                            "approval_scope_sha256"
+                        ],
+                        official_scope_registry_sha256=approval_scope[
+                            "official_scope_registry_sha256"
+                        ],
+                    ),
+                )
+                ledger_path = os.getenv("AGENTIC_BUDGET_LEDGER_PATH")
+                if not ledger_path:
+                    raise ValueError("execution.agentic.budget_ledger_path is required")
+                if not isinstance(opts.get("budget"), dict):
+                    raise ValueError("execution.agentic.budget is required")
+                image = opts.get("image")
+                if not image:
+                    raise ValueError("execution.agentic.image is required")
+                if opts.get("compute_transport") != "remote":
+                    raise ValueError(
+                        "production agentic_sandbox requires a remote "
+                        "authenticated compute backend"
+                    )
+                backend_factory = (
+                    agentic_remote_backend_factory
+                    if callable(agentic_remote_backend_factory)
+                    else remote_backend_factory_from_environment(
+                        run_id=run_id,
+                        condition_name=condition_name,
+                    )
+                )
+                price_table = opts.get("pricing_table")
+                if not isinstance(price_table, dict):
+                    raise ValueError("execution.agentic.pricing_table is required")
+                pricing = load_pinned_model_pricing(
+                    path=(
+                        agentic_price_table_path
+                        or Path(__file__).resolve().parents[1]
+                        / "security" / "agentic-pricing.json"
+                    ),
+                    expected_sha256=price_table.get("sha256", ""),
+                    provider=normalized_provider or "",
+                    model=model_name,
+                )
+                self.runner = AgenticSandboxRunner(
+                    client_factory=client_factory,
+                    backend_factory=backend_factory,
+                    budget_ledger=AgenticBudgetLedger(ledger_path),
+                    authorize_request=gate.authorize_request,
+                    prompt_name=prompt_name or AgenticSandboxRunner.DEFAULT_PROMPT,
+                    reasoning_effort=reasoning_effort,
+                    limits=limits,
+                    pricing=pricing,
+                    aggregate_budget=opts["budget"],
+                    provider=normalized_provider or "",
+                    api_version=authorization["api_version"],
+                    endpoint_sha256=endpoint_sha256,
+                    approval_scope_sha256=approval_scope[
+                        "approval_scope_sha256"
+                    ],
+                    official_scope_registry_sha256=approval_scope[
+                        "official_scope_registry_sha256"
+                    ],
+                )
 
         elif mode == "json_renderer":
             if llm_client is None:
@@ -127,6 +550,9 @@ class TaskExecutor:
         experiment_prompt: Optional[dict] = None,
         verbose: bool = False,
         perception_text: Optional[str] = None,
+        run_id: Optional[str] = None,
+        condition_name: Optional[str] = None,
+        task_id: Optional[str] = None,
     ) -> dict:
         """
         Execute task using selected runner.
@@ -171,7 +597,14 @@ class TaskExecutor:
                     experiment_prompt=experiment_prompt,
                 )
 
-            elif self.mode == "sandbox":
+            elif self.mode in {"sandbox", "agentic_sandbox"}:
+                extra = {}
+                if self.mode == "agentic_sandbox" or self.hardened_sandbox:
+                    extra = {
+                        "run_id": run_id or "local-nonpaid",
+                        "condition_name": condition_name or "condition_a",
+                        "task_id": task_id or "unknown-task",
+                    }
                 return self.runner.run(
                     task_prompt=task_prompt,
                     model=model,
@@ -179,6 +612,7 @@ class TaskExecutor:
                     occupation=occupation,
                     experiment_prompt=experiment_prompt,
                     perception_text=perception_text,
+                    **extra,
                 )
 
             elif self.mode == "json_renderer":
@@ -208,12 +642,12 @@ class TaskExecutor:
         Returns:
             (is_valid, error_message) tuple
         """
-        if mode == "code_interpreter":
+        if mode in {"code_interpreter", "agentic_sandbox"}:
             # Code Interpreter only works with OpenAI/Azure OpenAI
             if model_provider not in ["azure", "openai"]:
                 return (
                     False,
-                    f"code_interpreter mode requires OpenAI/Azure OpenAI, got {model_provider}"
+                    f"{mode} mode requires OpenAI/Azure OpenAI, got {model_provider}"
                 )
 
         return (True, None)

--- a/batch-runner/core/executor.py
+++ b/batch-runner/core/executor.py
@@ -40,7 +40,12 @@ ExecutionMode = Literal[
 
 
 def _load_live_approval_scope(
-    *, repository_root: Path, condition_name: str, classification: str
+    *,
+    repository_root: Path,
+    condition_name: str,
+    classification: str,
+    ordered_task_ids: Optional[list[str]],
+    task_request_digests: Optional[Mapping[str, str]],
 ) -> dict:
     scope_path = os.getenv("AGENTIC_APPROVAL_SCOPE_PATH")
     if not scope_path:
@@ -54,6 +59,12 @@ def _load_live_approval_scope(
     expected_count = 5 if condition_name == "canary" else 20
     if len(scope["task_ids"]) != expected_count:
         raise ValueError("approval scope task count differs from preregistration")
+    if ordered_task_ids is None or tuple(ordered_task_ids) != scope["task_ids"]:
+        raise ValueError("prepared ordered task IDs differ from approval scope")
+    if task_request_digests is None or dict(task_request_digests) != scope[
+        "task_request_sha256"
+    ]:
+        raise ValueError("prepared task requests differ from approval scope")
     if set(scope["provider_classifications"].values()) != {classification}:
         raise ValueError("approval scope provider classifications differ")
     return scope
@@ -87,6 +98,8 @@ class TaskExecutor:
         agentic_runtime_identity: Optional[Mapping[str, str]] = None,
         agentic_price_table_path: Optional[str] = None,
         agentic_endpoint: Optional[str] = None,
+        agentic_ordered_task_ids: Optional[list[str]] = None,
+        agentic_task_request_sha256: Optional[Mapping[str, str]] = None,
         non_paid_test_mode: bool = False,
     ):
         """
@@ -207,6 +220,8 @@ class TaskExecutor:
                         repository_root=repository_root,
                         condition_name=condition_name or "",
                         classification=authorization["provider_classification"],
+                        ordered_task_ids=agentic_ordered_task_ids,
+                        task_request_digests=agentic_task_request_sha256,
                     )
                     signed_envelope_path = os.getenv(
                         "AGENTIC_SIGNED_APPROVAL_PATH"
@@ -248,6 +263,12 @@ class TaskExecutor:
                             ],
                             provider_classifications=approval_scope[
                                 "provider_classifications"
+                            ],
+                            task_request_sha256=approval_scope[
+                                "task_request_sha256"
+                            ],
+                            selection_recomputation_sha256=approval_scope[
+                                "selection_recomputation_sha256"
                             ],
                             approval_scope_sha256=approval_scope[
                                 "approval_scope_sha256"
@@ -433,6 +454,8 @@ class TaskExecutor:
                     repository_root=repository_root,
                     condition_name=condition_name or "",
                     classification=authorization["provider_classification"],
+                    ordered_task_ids=agentic_ordered_task_ids,
+                    task_request_digests=agentic_task_request_sha256,
                 )
                 signed_envelope_path = os.getenv("AGENTIC_SIGNED_APPROVAL_PATH")
                 nonce_ledger_path = os.getenv("AGENTIC_NONCE_LEDGER_PATH")
@@ -466,6 +489,12 @@ class TaskExecutor:
                         input_merkle_roots=approval_scope["input_merkle_roots"],
                         provider_classifications=approval_scope[
                             "provider_classifications"
+                        ],
+                        task_request_sha256=approval_scope[
+                            "task_request_sha256"
+                        ],
+                        selection_recomputation_sha256=approval_scope[
+                            "selection_recomputation_sha256"
                         ],
                         approval_scope_sha256=approval_scope[
                             "approval_scope_sha256"

--- a/batch-runner/core/experiment_config.py
+++ b/batch-runner/core/experiment_config.py
@@ -15,11 +15,16 @@ Usage:
 """
 
 import yaml
+import re
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, Literal
 
 from core.config import DEFAULT_TOKENS
+from core.agentic_experiments import (
+    validate_agentic_budget_for_experiment,
+    validate_agentic_experiment_identity,
+)
 
 
 @dataclass
@@ -90,7 +95,10 @@ class OutputConfig:
 @dataclass
 class ExecutionConfig:
     """Execution mode configuration (Phase 5-3)"""
-    mode: Literal["code_interpreter", "subprocess", "json_renderer", "sandbox"] = "subprocess"
+    mode: Literal[
+        "code_interpreter", "subprocess", "json_renderer", "sandbox",
+        "agentic_sandbox",
+    ] = "subprocess"
     score_type: Literal["tool_assisted", "portable"] = "tool_assisted"
     max_retries: int = 3           # Infrastructure retries within task execution
     resume_max_rounds: int = 3     # Auto-retry rounds for error tasks in progress.json
@@ -98,6 +106,7 @@ class ExecutionConfig:
     tokens: Dict[str, int] = field(default_factory=lambda: dict(DEFAULT_TOKENS))
     timeout: Optional[int] = None  # subprocess timeout override (seconds)
     sandbox: Optional[Dict[str, Any]] = None  # sandbox-mode settings (execution.sandbox block)
+    agentic: Optional[Dict[str, Any]] = None  # agentic-mode settings (execution.agentic block)
     metrics: Optional[Dict[str, Any]] = None  # opt-in job metrics (execution.metrics block)
 
 
@@ -236,6 +245,11 @@ class ExperimentConfig:
             tokens=execution_tokens,
             timeout=execution_data.get("timeout"),
             sandbox=execution_data.get("sandbox"),
+            agentic=(
+                dict(execution_data["agentic"])
+                if isinstance(execution_data.get("agentic"), dict)
+                else None
+            ),
             metrics=(
                 {"enabled": True}
                 if isinstance(execution_data.get("metrics"), dict)
@@ -348,6 +362,7 @@ class ExperimentConfig:
                 "tokens": dict(self.execution.tokens),
                 "timeout": self.execution.timeout,
                 "sandbox": self.execution.sandbox,
+                **({"agentic": self.execution.agentic} if self.execution.agentic is not None else {}),
                 **({"metrics": self.execution.metrics} if self.execution.metrics is not None else {}),
             },
         }
@@ -414,7 +429,10 @@ class ExperimentConfig:
                 errors.append(f"condition_b.model.provider must be one of {valid_providers}")
 
         # Validate execution mode (Phase 5-3)
-        valid_modes = ["code_interpreter", "subprocess", "sandbox", "json_renderer"]
+        valid_modes = [
+            "code_interpreter", "subprocess", "sandbox", "agentic_sandbox",
+            "json_renderer",
+        ]
         if self.execution.mode not in valid_modes:
             errors.append(f"execution.mode must be one of {valid_modes}")
 
@@ -436,6 +454,60 @@ class ExperimentConfig:
             if self.condition_b and self.condition_b.model.provider not in ["azure", "openai"]:
                 errors.append("code_interpreter mode requires azure or openai provider for condition_b")
 
+        if self.execution.mode == "agentic_sandbox":
+            if self.condition_a.model.provider not in ["azure", "openai"]:
+                errors.append("agentic_sandbox mode requires azure or openai provider for condition_a")
+            if self.condition_b and self.condition_b.model.provider not in ["azure", "openai"]:
+                errors.append("agentic_sandbox mode requires azure or openai provider for condition_b")
+
+        hardened = (
+            self.execution.mode == "agentic_sandbox"
+            or (
+                self.execution.mode == "sandbox"
+                and isinstance(self.execution.sandbox, dict)
+                and self.execution.sandbox.get("hardened_substrate") is True
+            )
+        )
+        if hardened:
+            if self.condition_b is not None:
+                errors.append(
+                    "reserved hardened experiments require exactly condition_a"
+                )
+            try:
+                validate_agentic_experiment_identity(
+                    self.experiment_id,
+                    self.execution.mode,
+                    (
+                        self.execution.mode == "sandbox"
+                        and isinstance(self.execution.sandbox, dict)
+                        and self.execution.sandbox.get("hardened_substrate") is True
+                    ),
+                )
+            except ValueError as exc:
+                errors.append(str(exc))
+            errors.extend(_validate_agentic_config(self.execution.agentic))
+            try:
+                validate_agentic_budget_for_experiment(
+                    self.experiment_id,
+                    (self.execution.agentic or {}).get("budget"),
+                )
+            except ValueError as exc:
+                errors.append(str(exc))
+            for label, condition in (
+                ("condition_a", self.condition_a),
+                ("condition_b", self.condition_b),
+            ):
+                if condition is None:
+                    continue
+                if condition.qa and condition.qa.enabled:
+                    errors.append(
+                        f"{label}.qa must be disabled for hardened execution"
+                    )
+                if condition.preprocessors:
+                    errors.append(
+                        f"{label}.preprocessors must be empty for hardened execution"
+                    )
+
         # Warning: portable score_type should use json_renderer
         if self.execution.score_type == "portable" and self.execution.mode != "json_renderer":
             # This is a warning, not an error - don't block execution
@@ -445,3 +517,58 @@ class ExperimentConfig:
 
     def __repr__(self) -> str:
         return f"ExperimentConfig(id='{self.experiment_id}', name='{self.name}')"
+
+
+def _validate_agentic_config(value: Any) -> List[str]:
+    if not isinstance(value, dict):
+        return ["execution.agentic is required for hardened execution"]
+    allowed = {
+        "compute_transport", "image", "verifier_image", "memory_gb", "cpus",
+        "limits", "budget", "pricing_table", "authorization",
+        "seccomp_profile", "apparmor_profile",
+    }
+    errors = []
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        errors.append(f"execution.agentic contains unknown fields: {unknown}")
+    if value.get("compute_transport") != "remote":
+        errors.append("execution.agentic.compute_transport must be remote")
+    digest_pattern = re.compile(r"^.+@sha256:[0-9a-f]{64}$")
+    for field_name in ("image", "verifier_image"):
+        image = value.get(field_name)
+        if not isinstance(image, str) or digest_pattern.fullmatch(image) is None:
+            errors.append(
+                f"execution.agentic.{field_name} must be pinned by sha256 digest"
+            )
+    limits = value.get("limits")
+    if not isinstance(limits, dict):
+        errors.append("execution.agentic.limits is required")
+    else:
+        allowed_limits = {
+            "max_api_attempts", "max_model_iterations", "max_output_tokens",
+            "max_input_tokens", "max_cumulative_output_tokens",
+            "max_task_seconds", "max_cost_usd", "max_tool_calls",
+            "max_run_python", "max_run_ffmpeg", "max_inspect_artifacts",
+            "max_finalize", "max_identical_errors",
+        }
+        if set(limits) - allowed_limits:
+            errors.append("execution.agentic.limits contains unknown fields")
+    budget = value.get("budget")
+    if not isinstance(budget, dict) or set(budget) != {
+        "paired_run_id", "condition", "paired_run"
+    }:
+        errors.append("execution.agentic.budget fields are invalid")
+    pricing = value.get("pricing_table")
+    if (
+        not isinstance(pricing, dict)
+        or set(pricing) != {"sha256"}
+        or not isinstance(pricing.get("sha256"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", pricing["sha256"]) is None
+    ):
+        errors.append("execution.agentic.pricing_table must contain sha256")
+    authorization = value.get("authorization")
+    if not isinstance(authorization, dict) or set(authorization) != {
+        "api_version", "provider_classification", "endpoint_sha256"
+    }:
+        errors.append("execution.agentic.authorization fields are invalid")
+    return errors

--- a/batch-runner/core/experiment_config.py
+++ b/batch-runner/core/experiment_config.py
@@ -507,6 +507,11 @@ class ExperimentConfig:
                     errors.append(
                         f"{label}.preprocessors must be empty for hardened execution"
                     )
+                if condition.prompt.prefix or condition.prompt.body:
+                    errors.append(
+                        f"{label}.prompt prefix/body are unsupported for "
+                        "hardened paired execution"
+                    )
 
         # Warning: portable score_type should use json_renderer
         if self.execution.score_type == "portable" and self.execution.mode != "json_renderer":

--- a/batch-runner/core/hardened_sandbox_runner.py
+++ b/batch-runner/core/hardened_sandbox_runner.py
@@ -1,0 +1,563 @@
+"""Current sandbox solver semantics on the common hardened compute substrate."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from types import SimpleNamespace
+from typing import Any, Callable, Mapping, Optional
+
+from core.agentic_budget import AgenticBudgetLedger, BudgetCaps
+from core.agentic_sandbox_runner import (
+    AgenticAggregateBudget,
+    AgenticLimits,
+    AgenticPricing,
+    _elapsed_ms,
+)
+from core.agentic_tools import AgenticComputeBackend
+from core.sandbox_runner import SandboxRunner
+
+
+class _BudgetedChatCompletions:
+    def __init__(self, owner: "HardenedSandboxRunner"):
+        self.owner = owner
+
+    def create(self, **kwargs):
+        return self.owner._create_chat_completion(kwargs)
+
+
+class _BudgetedChatClient:
+    def __init__(self, owner: "HardenedSandboxRunner"):
+        self.chat = SimpleNamespace(completions=_BudgetedChatCompletions(owner))
+
+
+class HardenedSandboxRunner(SandboxRunner):
+    """One initial generation plus at most one full hardened regeneration."""
+
+    def __init__(
+        self,
+        *,
+        client_factory: Callable[[], Any],
+        backend_factory: Callable[..., AgenticComputeBackend],
+        budget_ledger: AgenticBudgetLedger,
+        authorize_request: Callable[[str, str, Mapping[str, Any]], None],
+        run_id: str,
+        condition_name: str,
+        model_name: str,
+        provider: str = "nonpaid-test",
+        api_version: str = "nonpaid-test",
+        endpoint_sha256: str = "nonpaid-test",
+        approval_scope_sha256: str = "nonpaid-test",
+        official_scope_registry_sha256: str = "nonpaid-test",
+        limits: Mapping[str, Any],
+        pricing: Mapping[str, Any],
+        aggregate_budget: Mapping[str, Any],
+        **sandbox_options: Any,
+    ):
+        if not all((run_id, condition_name, model_name)):
+            raise ValueError("hardened baseline run identity is required")
+        if not callable(client_factory) or not callable(backend_factory):
+            raise ValueError("hardened baseline factories are required")
+        if not callable(authorize_request):
+            raise ValueError("hardened baseline authorization is required")
+        self.client_factory = client_factory
+        self.backend_factory = backend_factory
+        self.budget_ledger = budget_ledger
+        self.authorize_request = authorize_request
+        self.run_id = run_id
+        self.condition_name = condition_name
+        self.model_name = model_name
+        self.provider = provider
+        self.api_version = api_version
+        self.endpoint_sha256 = endpoint_sha256
+        self.approval_scope_sha256 = approval_scope_sha256
+        self.official_scope_registry_sha256 = official_scope_registry_sha256
+        self.agentic_limits = AgenticLimits.from_options(limits)
+        self.agentic_pricing = AgenticPricing.from_options(pricing)
+        aggregate = AgenticAggregateBudget.from_options(aggregate_budget)
+        if aggregate is None:
+            raise ValueError("hardened baseline aggregate budget is required")
+        self.aggregate_budget = aggregate
+        self._provider_client = None
+        self._backend: Optional[AgenticComputeBackend] = None
+        self._startup: Optional[dict] = None
+        self._task_id = ""
+        self._request_index = 0
+        self._run_started = 0.0
+        self._first_model_dispatch: Optional[float] = None
+        self._budget_metrics = self._new_budget_metrics()
+        proxy = _BudgetedChatClient(self)
+        repair = {"enabled": True, "max_attempts": 1}
+        repair.update(sandbox_options.pop("repair", {}) or {})
+        if repair != {"enabled": True, "max_attempts": 1}:
+            raise ValueError(
+                "paired hardened baseline fixes repair.enabled=true and max_attempts=1"
+            )
+        super().__init__(
+            proxy,
+            repair=repair,
+            use_docker="always",
+            image=sandbox_options.pop("image", None),
+            **sandbox_options,
+        )
+
+    def run(
+        self,
+        task_prompt: str,
+        model: str,
+        reference_files: Optional[list] = None,
+        occupation: str = "professional",
+        experiment_prompt: Optional[dict] = None,
+        perception_text: Optional[str] = None,
+        *,
+        run_id: Optional[str] = None,
+        condition_name: Optional[str] = None,
+        task_id: Optional[str] = None,
+    ) -> dict:
+        if model != self.model_name:
+            return self._terminal_failure("baseline_model_identity_mismatch")
+        if run_id != self.run_id or condition_name != self.condition_name or not task_id:
+            return self._terminal_failure("baseline_run_identity_mismatch")
+        backend = self.backend_factory(
+            task_prompt=task_prompt,
+            reference_files=list(reference_files or []),
+            occupation=occupation,
+            run_id=run_id,
+            condition_name=condition_name,
+            task_id=task_id,
+        )
+        self._backend = backend
+        self._task_id = task_id
+        self._request_index = 0
+        self._run_started = time.monotonic()
+        self._first_model_dispatch = None
+        self._budget_metrics = self._new_budget_metrics()
+        task_scope = json.dumps(
+            [self.run_id, self.condition_name, task_id], separators=(",", ":")
+        )
+        existing_usage = self.budget_ledger.usage(task_scope)
+        self._budget_metrics.update({
+            "model_api_calls": existing_usage.attempts,
+            "input_tokens": existing_usage.input_tokens,
+            "output_tokens": existing_usage.output_tokens,
+            "conservative_cost_usd": str(existing_usage.cost_usd),
+        })
+        self._provider_client = None
+        try:
+            startup = dict(backend.start(self.agentic_limits.max_task_seconds))
+            if startup.get("ok") is not True:
+                return self._terminal_failure(
+                    str(startup.get("error_type") or "compute_start_failed")
+                )
+            data = startup.get("data")
+            if not isinstance(data, dict) or not isinstance(
+                data.get("substrate_manifest"), dict
+            ):
+                return self._terminal_failure("substrate_manifest_missing")
+            self._startup = startup
+            result = super().run(
+                task_prompt=task_prompt,
+                model=model,
+                reference_files=reference_files,
+                occupation=occupation,
+                experiment_prompt=experiment_prompt,
+                perception_text=perception_text,
+            )
+            result["substrate_manifest"] = data["substrate_manifest"]
+            result["budget_metrics"] = dict(self._budget_metrics)
+            return result
+        finally:
+            backend.close()
+            self._backend = None
+            self._startup = None
+            self._task_id = ""
+
+    def _execute(self, code, reference_files, manifest):
+        backend = self._backend
+        if backend is None:
+            return "docker", self._execution_failure("compute_unavailable")
+        remaining = self.agentic_limits.max_task_seconds - (
+            time.monotonic() - self._run_started
+        )
+        if remaining <= 0:
+            return "docker", self._execution_failure(
+                "baseline_task_wall_time_exhausted"
+            )
+        reset = dict(backend.reset_work(remaining))
+        if reset.get("ok") is not True:
+            return "docker", self._execution_failure(
+                str(reset.get("error_type") or "workspace_reset_failed")
+            )
+        remaining = self.agentic_limits.max_task_seconds - (
+            time.monotonic() - self._run_started
+        )
+        if remaining <= 0:
+            return "docker", self._execution_failure(
+                "baseline_task_wall_time_exhausted"
+            )
+        executed = dict(backend.run_python(
+            code, min(float(self.timeout), remaining)
+        ))
+        stderr = str((executed.get("data") or {}).get("stderr_tail") or "")
+        if executed.get("ok") is not True:
+            compile_failed = stderr.startswith("compile_failed:")
+            result = self._execution_failure(
+                str(executed.get("error_type") or "python_execution_failed")
+            )
+            result["text"] = str((executed.get("data") or {}).get("stdout_tail") or "")
+            result["error"] = stderr or result["error"]
+            result["preflight"] = {
+                "ok": not compile_failed,
+                "stage": "compile" if compile_failed else "runtime",
+                "error_type": "SyntaxError" if compile_failed else "RuntimeError",
+                "line": None,
+                "offset": None,
+                "target_python": "3.11",
+            }
+            return "docker", result
+
+        remaining = self.agentic_limits.max_task_seconds - (
+            time.monotonic() - self._run_started
+        )
+        if remaining <= 0:
+            return "docker", self._execution_failure(
+                "baseline_task_wall_time_exhausted"
+            )
+        inspection = dict(backend.inspect_artifacts(remaining))
+        data = inspection.get("data") if isinstance(inspection.get("data"), dict) else {}
+        result = {
+            "success": False,
+            "text": str((executed.get("data") or {}).get("stdout_tail") or ""),
+            "files": [],
+            "preflight": {
+                "ok": True,
+                "stage": "compile",
+                "error_type": None,
+                "line": None,
+                "offset": None,
+                "target_python": "3.11",
+            },
+            "_hardened_verification": inspection,
+        }
+        if inspection.get("ok") is not True:
+            result["error_category"] = "artifact_verification_failed"
+            result["error"] = str(
+                inspection.get("error_type") or "artifact_verification_failed"
+            )
+            return "docker", result
+        if (
+            self._first_model_dispatch is not None
+            and self._budget_metrics["time_to_valid_artifact_ms"] is None
+        ):
+            self._budget_metrics["time_to_valid_artifact_ms"] = _elapsed_ms(
+                self._first_model_dispatch
+            )
+        deliverables = [
+            item.get("path")
+            for item in data.get("artifacts", [])
+            if isinstance(item, dict) and isinstance(item.get("path"), str)
+        ]
+        remaining = self.agentic_limits.max_task_seconds - (
+            time.monotonic() - self._run_started
+        )
+        if remaining <= 0:
+            return "docker", self._execution_failure(
+                "baseline_task_wall_time_exhausted"
+            )
+        finalized = dict(backend.finalize(
+            deliverables, "Hardened sandbox deliverables", remaining
+        ))
+        terminal = backend.best_result()
+        if finalized.get("ok") is not True or terminal is None:
+            result["error_category"] = "artifact_finalization_failed"
+            result["error"] = str(
+                finalized.get("error_type") or "artifact_finalization_failed"
+            )
+            return "docker", result
+        result.update(dict(terminal))
+        result["preflight"] = {
+            "ok": True,
+            "stage": "compile",
+            "error_type": None,
+            "line": None,
+            "offset": None,
+            "target_python": "3.11",
+        }
+        result["_hardened_verification"] = inspection
+        return "docker", result
+
+    def _analyze_output(
+        self,
+        result,
+        ref_files,
+        contract,
+        task_prompt,
+        executor_used,
+        dep_manifest=None,
+    ):
+        verification = result.get("_hardened_verification") or {}
+        data = verification.get("data") if isinstance(verification, dict) else {}
+        data = data if isinstance(data, dict) else {}
+        artifacts = [
+            item for item in data.get("artifacts", []) if isinstance(item, dict)
+        ]
+        blocking = []
+        if verification.get("ok") is not True:
+            blocking.append(
+                "hardened_verifier_failed:"
+                + str(verification.get("error_type") or "unknown")
+            )
+        contract_report = data.get("contract")
+        if not isinstance(contract_report, dict):
+            contract_report = {
+                "ok": not blocking,
+                "blocking_errors": list(blocking),
+                "warnings": [],
+                "matched_primary": [],
+                "generated_count": len(artifacts),
+            }
+        return {
+            "artifact_names": [str(item.get("path")) for item in artifacts],
+            "contract_validation": contract_report,
+            "verification": {
+                "ok": verification.get("ok") is True,
+                "blocking_errors": list(blocking),
+                "warnings": [],
+                "artifacts": artifacts,
+            },
+            "output_qa": {
+                "enabled": True,
+                "ok": verification.get("ok") is True,
+                "blocking_errors": list(blocking),
+                "warnings": [],
+                "render_reports": [],
+                "vision_qa": None,
+            },
+            "import_probe": {
+                "enabled": False,
+                "environment": "common_hardened_image",
+                "ok": True,
+                "packages": [],
+            },
+            "blocking_errors": blocking,
+            "warnings": [],
+        }
+
+    def _finalize(self, *args, **kwargs):
+        result = super()._finalize(*args, **kwargs)
+        result["files"] = [
+            item
+            for item in result.get("files", [])
+            if item.get("filename") != self.manifest_cfg.get("filename", "manifest.json")
+        ]
+        result["success"] = bool(
+            result.get("success")
+            and result.get("final_status") in {"ok", "repaired_ok"}
+        )
+        return result
+
+    def _create_chat_completion(self, kwargs: Mapping[str, Any]):
+        if self._backend is None or self._startup is None or not self._task_id:
+            raise RuntimeError("hardened baseline is not preflighted")
+        self._request_index += 1
+        task_scope = json.dumps(
+            [self.run_id, self.condition_name, self._task_id],
+            separators=(",", ":"),
+        )
+        request_id = hashlib.sha256(
+            json.dumps(
+                [task_scope, self._request_index, kwargs],
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+        ).hexdigest()
+        estimated_input = len(
+            json.dumps(kwargs, sort_keys=True, separators=(",", ":"), default=str)
+            .encode("utf-8")
+        )
+        output_tokens = int(
+            kwargs.get("max_completion_tokens")
+            or self.agentic_limits.max_output_tokens
+        )
+        output_tokens = min(output_tokens, self.agentic_limits.max_output_tokens)
+        reserved_cost = self.agentic_pricing.worst_case(
+            estimated_input, output_tokens
+        )
+        scopes = self._budget_scopes(task_scope)
+        reserved_by_scope = self.budget_ledger.reserve_many(
+            scopes=scopes,
+            request_id=request_id,
+            input_tokens=estimated_input,
+            output_tokens=output_tokens,
+            cost_usd=reserved_cost,
+        )
+        self._budget_metrics["conservative_cost_usd"] = str(
+            reserved_by_scope[task_scope].cost_usd
+        )
+        startup_data = self._startup.get("data") or {}
+        self.authorize_request(
+            task_scope,
+            request_id,
+            {
+                "runtime_preflight_passed": True,
+                "input_merkle_root": startup_data.get("input_merkle_root"),
+                "provider_classification": startup_data.get(
+                    "provider_classification"
+                ),
+                "substrate_manifest_sha256": (
+                    startup_data.get("substrate_manifest") or {}
+                ).get("sha256"),
+                "model": self.model_name,
+                "provider": self.provider,
+                "api_version": self.api_version,
+                "endpoint_sha256": self.endpoint_sha256,
+                "approval_scope_sha256": self.approval_scope_sha256,
+                "official_scope_registry_sha256": (
+                    self.official_scope_registry_sha256
+                ),
+                "run_id": self.run_id,
+                "condition": self.condition_name,
+                "task_id": self._task_id,
+                "caps": self._authorization_caps(),
+                "price_table_sha256": self.agentic_pricing.price_table_sha256,
+                "official_scope_excluded": True,
+            },
+        )
+        if self._provider_client is None:
+            self._provider_client = self.client_factory()
+        provider_client = self._provider_client
+        if provider_client is None:
+            raise RuntimeError("baseline provider client unavailable")
+        self._budget_metrics["model_api_calls"] += 1
+        remaining = self.agentic_limits.max_task_seconds - (
+            time.monotonic() - self._run_started
+        )
+        if remaining <= 0:
+            raise RuntimeError("baseline_task_wall_time_exhausted")
+        request_kwargs = dict(kwargs)
+        request_kwargs["max_completion_tokens"] = output_tokens
+        request_kwargs["timeout"] = max(1.0, min(480.0, remaining))
+        if self._first_model_dispatch is None:
+            self._first_model_dispatch = time.monotonic()
+        try:
+            response = provider_client.chat.completions.create(
+                **request_kwargs
+            )
+        except Exception:
+            self._budget_metrics["usage_complete"] = False
+            raise
+        usage = getattr(response, "usage", None)
+        input_tokens = getattr(usage, "prompt_tokens", None)
+        output_tokens_actual = getattr(usage, "completion_tokens", None)
+        if not _valid_count(input_tokens) or not _valid_count(output_tokens_actual):
+            self._budget_metrics["usage_complete"] = False
+            raise RuntimeError("baseline_usage_incomplete")
+        input_count = int(input_tokens)
+        output_count = int(output_tokens_actual)
+        details = getattr(usage, "prompt_tokens_details", None)
+        cached_tokens = getattr(details, "cached_tokens", 0) if details else 0
+        if not _valid_count(cached_tokens) or int(cached_tokens) > input_count:
+            self._budget_metrics["usage_complete"] = False
+            raise RuntimeError("baseline_usage_incomplete")
+        cached_count = int(cached_tokens)
+        actual_cost = self.agentic_pricing.actual(
+            input_count, output_count, cached_count
+        )
+        reconciled = self.budget_ledger.reconcile_many(
+            scopes=scopes,
+            request_id=request_id,
+            actual_input_tokens=input_count,
+            actual_output_tokens=output_count,
+            actual_cost_usd=actual_cost,
+        )
+        self._budget_metrics["input_tokens"] += input_count
+        self._budget_metrics["output_tokens"] += output_count
+        self._budget_metrics["cached_tokens"] += cached_count
+        self._budget_metrics["conservative_cost_usd"] = str(
+            reconciled[task_scope].cost_usd
+        )
+        return response
+
+    def _budget_scopes(self, task_scope: str) -> dict[str, BudgetCaps]:
+        task_caps = BudgetCaps(
+            attempts=self.agentic_limits.max_api_attempts,
+            input_tokens=self.agentic_limits.max_input_tokens,
+            output_tokens=self.agentic_limits.max_cumulative_output_tokens,
+            cost_usd=self.agentic_limits.max_cost_usd,
+        )
+        paired_id = self.aggregate_budget.paired_run_id
+        return {
+            task_scope: task_caps,
+            json.dumps(
+                ["condition", paired_id, self.condition_name],
+                separators=(",", ":"),
+            ): self.aggregate_budget.condition,
+            json.dumps(
+                ["paired_run", paired_id], separators=(",", ":")
+            ): self.aggregate_budget.paired_run,
+        }
+
+    def _authorization_caps(self) -> dict:
+        task = {
+            "api_attempts": self.agentic_limits.max_api_attempts,
+            "model_iterations": self.agentic_limits.max_model_iterations,
+            "input_tokens": self.agentic_limits.max_input_tokens,
+            "output_tokens": self.agentic_limits.max_cumulative_output_tokens,
+            "max_output_tokens_per_response": self.agentic_limits.max_output_tokens,
+            "cost_usd": str(self.agentic_limits.max_cost_usd),
+            "wall_seconds": self.agentic_limits.max_task_seconds,
+        }
+        return {
+            "task": task,
+            "condition": _caps_dict(self.aggregate_budget.condition),
+            "paired_run": _caps_dict(self.aggregate_budget.paired_run),
+            "paired_run_id": self.aggregate_budget.paired_run_id,
+        }
+
+    @staticmethod
+    def _execution_failure(category: str) -> dict:
+        return {
+            "success": False,
+            "text": "",
+            "files": [],
+            "preflight": None,
+            "error_category": category,
+            "error": category,
+        }
+
+    @staticmethod
+    def _terminal_failure(category: str) -> dict:
+        return {
+            "success": False,
+            "text": "",
+            "files": [],
+            "error": category,
+        }
+
+    @staticmethod
+    def _new_budget_metrics() -> dict:
+        return {
+            "schema_version": "1.0",
+            "model_api_calls": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached_tokens": 0,
+            "conservative_cost_usd": "0",
+            "usage_complete": True,
+            "time_to_valid_artifact_ms": None,
+        }
+
+
+def _caps_dict(caps: BudgetCaps) -> dict:
+    return {
+        "attempts": caps.attempts,
+        "input_tokens": caps.input_tokens,
+        "output_tokens": caps.output_tokens,
+        "cost_usd": str(caps.cost_usd),
+    }
+
+
+def _valid_count(value: Any) -> bool:
+    return type(value) is int and value >= 0

--- a/batch-runner/core/hardened_sandbox_runner.py
+++ b/batch-runner/core/hardened_sandbox_runner.py
@@ -8,6 +8,7 @@ import time
 from types import SimpleNamespace
 from typing import Any, Callable, Mapping, Optional
 
+from core.agentic_authorization import task_request_sha256
 from core.agentic_budget import AgenticBudgetLedger, BudgetCaps
 from core.agentic_sandbox_runner import (
     AgenticAggregateBudget,
@@ -83,6 +84,7 @@ class HardenedSandboxRunner(SandboxRunner):
         self._backend: Optional[AgenticComputeBackend] = None
         self._startup: Optional[dict] = None
         self._task_id = ""
+        self._task_request_sha256 = ""
         self._request_index = 0
         self._run_started = 0.0
         self._first_model_dispatch: Optional[float] = None
@@ -129,6 +131,12 @@ class HardenedSandboxRunner(SandboxRunner):
         )
         self._backend = backend
         self._task_id = task_id
+        self._task_request_sha256 = task_request_sha256(
+            task_prompt=task_prompt,
+            occupation=occupation,
+            experiment_prompt=experiment_prompt,
+            perception_text=perception_text,
+        )
         self._request_index = 0
         self._run_started = time.monotonic()
         self._first_model_dispatch = None
@@ -144,17 +152,26 @@ class HardenedSandboxRunner(SandboxRunner):
             "conservative_cost_usd": str(existing_usage.cost_usd),
         })
         self._provider_client = None
+        outcome: Optional[dict] = None
+
+        def finish(result: Mapping[str, Any]) -> dict:
+            nonlocal outcome
+            outcome = dict(result)
+            return outcome
+
         try:
             startup = dict(backend.start(self.agentic_limits.max_task_seconds))
             if startup.get("ok") is not True:
-                return self._terminal_failure(
+                return finish(self._terminal_failure(
                     str(startup.get("error_type") or "compute_start_failed")
-                )
+                ))
             data = startup.get("data")
             if not isinstance(data, dict) or not isinstance(
                 data.get("substrate_manifest"), dict
             ):
-                return self._terminal_failure("substrate_manifest_missing")
+                return finish(self._terminal_failure(
+                    "substrate_manifest_missing"
+                ))
             self._startup = startup
             result = super().run(
                 task_prompt=task_prompt,
@@ -166,12 +183,43 @@ class HardenedSandboxRunner(SandboxRunner):
             )
             result["substrate_manifest"] = data["substrate_manifest"]
             result["budget_metrics"] = dict(self._budget_metrics)
-            return result
+            return finish(result)
+        except Exception:
+            failure = self._terminal_failure("runner_internal_error")
+            self._budget_metrics["usage_complete"] = False
+            failure["budget_metrics"] = dict(self._budget_metrics)
+            return finish(failure)
         finally:
-            backend.close()
+            try:
+                backend.close()
+            except Exception:
+                if outcome is None:
+                    outcome = self._terminal_failure("compute_cleanup_failed")
+                prior_error = outcome.get("error")
+                candidate = None
+                if not outcome.get("files"):
+                    try:
+                        candidate = backend.best_result()
+                    except Exception:
+                        candidate = None
+                if (
+                    isinstance(candidate, Mapping)
+                    and candidate.get("files")
+                    and not outcome.get("files")
+                ):
+                    outcome["files"] = list(candidate["files"])
+                    outcome["text"] = outcome.get("text") or candidate.get(
+                        "text", ""
+                    )
+                outcome["success"] = False
+                outcome["prior_error"] = prior_error
+                outcome["error"] = "compute_cleanup_failed"
+                self._budget_metrics["usage_complete"] = False
+                outcome["budget_metrics"] = dict(self._budget_metrics)
             self._backend = None
             self._startup = None
             self._task_id = ""
+            self._task_request_sha256 = ""
 
     def _execute(self, code, reference_files, manifest):
         backend = self._backend
@@ -246,6 +294,21 @@ class HardenedSandboxRunner(SandboxRunner):
                 inspection.get("error_type") or "artifact_verification_failed"
             )
             return "docker", result
+        candidate = backend.best_result()
+
+        def preserve_candidate(failure: dict) -> dict:
+            if (
+                isinstance(candidate, Mapping)
+                and candidate.get("files")
+            ):
+                failure["files"] = list(candidate["files"])
+                failure["text"] = failure.get("text") or candidate.get(
+                    "text", ""
+                )
+                failure["deliverable_text"] = candidate.get(
+                    "deliverable_text", ""
+                )
+            return failure
         if (
             self._first_model_dispatch is not None
             and self._budget_metrics["time_to_valid_artifact_ms"] is None
@@ -262,19 +325,25 @@ class HardenedSandboxRunner(SandboxRunner):
             time.monotonic() - self._run_started
         )
         if remaining <= 0:
-            return "docker", self._execution_failure(
+            return "docker", preserve_candidate(self._execution_failure(
                 "baseline_task_wall_time_exhausted"
-            )
-        finalized = dict(backend.finalize(
-            deliverables, "Hardened sandbox deliverables", remaining
-        ))
+            ))
+        try:
+            finalized = dict(backend.finalize(
+                deliverables, "Hardened sandbox deliverables", remaining
+            ))
+        except Exception:
+            finalized = {
+                "ok": False,
+                "error_type": "artifact_finalization_failed",
+            }
         terminal = backend.best_result()
         if finalized.get("ok") is not True or terminal is None:
             result["error_category"] = "artifact_finalization_failed"
             result["error"] = str(
                 finalized.get("error_type") or "artifact_finalization_failed"
             )
-            return "docker", result
+            return "docker", preserve_candidate(result)
         result.update(dict(terminal))
         result["preflight"] = {
             "ok": True,
@@ -403,6 +472,9 @@ class HardenedSandboxRunner(SandboxRunner):
             {
                 "runtime_preflight_passed": True,
                 "input_merkle_root": startup_data.get("input_merkle_root"),
+                "selection_recomputation_sha256": startup_data.get(
+                    "selection_recomputation_sha256"
+                ),
                 "provider_classification": startup_data.get(
                     "provider_classification"
                 ),
@@ -420,6 +492,7 @@ class HardenedSandboxRunner(SandboxRunner):
                 "run_id": self.run_id,
                 "condition": self.condition_name,
                 "task_id": self._task_id,
+                "task_request_sha256": self._task_request_sha256,
                 "caps": self._authorization_caps(),
                 "price_table_sha256": self.agentic_pricing.price_table_sha256,
                 "official_scope_excluded": True,
@@ -434,11 +507,11 @@ class HardenedSandboxRunner(SandboxRunner):
         remaining = self.agentic_limits.max_task_seconds - (
             time.monotonic() - self._run_started
         )
-        if remaining <= 0:
+        if remaining < 1.0:
             raise RuntimeError("baseline_task_wall_time_exhausted")
         request_kwargs = dict(kwargs)
         request_kwargs["max_completion_tokens"] = output_tokens
-        request_kwargs["timeout"] = max(1.0, min(480.0, remaining))
+        request_kwargs["timeout"] = min(480.0, remaining)
         if self._first_model_dispatch is None:
             self._first_model_dispatch = time.monotonic()
         try:
@@ -465,13 +538,17 @@ class HardenedSandboxRunner(SandboxRunner):
         actual_cost = self.agentic_pricing.actual(
             input_count, output_count, cached_count
         )
-        reconciled = self.budget_ledger.reconcile_many(
-            scopes=scopes,
-            request_id=request_id,
-            actual_input_tokens=input_count,
-            actual_output_tokens=output_count,
-            actual_cost_usd=actual_cost,
-        )
+        try:
+            reconciled = self.budget_ledger.reconcile_many(
+                scopes=scopes,
+                request_id=request_id,
+                actual_input_tokens=input_count,
+                actual_output_tokens=output_count,
+                actual_cost_usd=actual_cost,
+            )
+        except Exception:
+            self._budget_metrics["usage_complete"] = False
+            raise
         self._budget_metrics["input_tokens"] += input_count
         self._budget_metrics["output_tokens"] += output_count
         self._budget_metrics["cached_tokens"] += cached_count

--- a/batch-runner/core/llm_client.py
+++ b/batch-runner/core/llm_client.py
@@ -149,6 +149,7 @@ def create_client(
     endpoint: str | None = None,
     api_key: str | None = None,
     api_version: str | None = None,
+    max_retries: int | None = None,
 ) -> AzureOpenAI:
     """AzureOpenAI 클라이언트 생성 (DefaultAzureCredential 전용 / OIDC only)
 
@@ -182,11 +183,19 @@ def create_client(
             credential, "https://cognitiveservices.azure.com/.default"
         )
         print("   🔐 Auth: DefaultAzureCredential (Entra ID token)")
+        if max_retries is None:
+            return AzureOpenAI(
+                azure_endpoint=endpoint,
+                azure_ad_token_provider=token_provider,
+                api_version=api_version,
+                timeout=480,
+            )
         return AzureOpenAI(
             azure_endpoint=endpoint,
             azure_ad_token_provider=token_provider,
             api_version=api_version,
             timeout=480,
+            max_retries=max_retries,
         )
     except Exception as e:
         # API Key fallback disabled — fail loud with OIDC debug guidance.
@@ -207,6 +216,7 @@ def create_provider_client(
     endpoint: str | None = None,
     api_key: str | None = None,
     api_version: str | None = None,
+    max_retries: int | None = None,
 ):
     """Provider별 클라이언트 생성.
 
@@ -229,14 +239,22 @@ def create_provider_client(
             endpoint=endpoint,
             api_key=api_key,
             api_version=api_version,
+            max_retries=max_retries,
         )
 
     elif provider == "openai":
         from openai import OpenAI
+        if max_retries is None:
+            return OpenAI(
+                api_key=api_key or os.getenv("OPENAI_API_KEY"),
+                base_url=endpoint or None,
+                timeout=480,
+            )
         return OpenAI(
             api_key=api_key or os.getenv("OPENAI_API_KEY"),
             base_url=endpoint or None,
             timeout=480,
+            max_retries=max_retries,
         )
 
     elif provider == "anthropic":

--- a/batch-runner/core/llm_client.py
+++ b/batch-runner/core/llm_client.py
@@ -5,8 +5,6 @@ from openai import AzureOpenAI
 
 from core.config import (
     DEFAULT_ENDPOINT,
-    DEFAULT_MODEL,
-    DEFAULT_DEPLOYMENT,
     DEFAULT_API_VERSION,
     DEFAULT_TOKENS,
 )
@@ -200,9 +198,9 @@ def create_client(
     except Exception as e:
         # API Key fallback disabled — fail loud with OIDC debug guidance.
         print(f"   ⚠️  DefaultAzureCredential failed: {e}")
-        print(f"   ⚠️  API Key fallback disabled (Azure disableLocalAuth=true)")
-        print(f"   ⚠️  Local: run 'az login' then retry")
-        print(f"   ⚠️  CI: verify azure/login@v2 OIDC step succeeded")
+        print("   ⚠️  API Key fallback disabled (Azure disableLocalAuth=true)")
+        print("   ⚠️  Local: run 'az login' then retry")
+        print("   ⚠️  CI: verify azure/login@v2 OIDC step succeeded")
         raise ValueError(
             f"Azure authentication failed.\n"
             f"  - DefaultAzureCredential failed: {e}\n"

--- a/batch-runner/core/output_qa.py
+++ b/batch-runner/core/output_qa.py
@@ -154,7 +154,14 @@ def run_output_qa(
             primary = _is_primary(art, contract)
             if rr.errors:
                 msg = f"{art.name}: render error — {'; '.join(rr.errors)}"
-                report.warnings.append(msg)
+                if primary:
+                    report.blocking_errors.append(msg)
+                else:
+                    report.warnings.append(msg)
+            if primary and not rr.rendered_images:
+                report.blocking_errors.append(
+                    f"{art.name}: primary deliverable produced no rendered image."
+                )
             if rr.blank_pages:
                 report.warnings.append(
                     f"{art.name}: {len(rr.blank_pages)} blank page(s) detected "

--- a/batch-runner/prompts/agentic_sandbox_solver.yaml
+++ b/batch-runner/prompts/agentic_sandbox_solver.yaml
@@ -1,0 +1,10 @@
+version: agentic-sandbox-v1
+instructions: |-
+  You solve the user's task by choosing only from the provided tools.
+  Inspect inputs and capabilities before relying on them. Create deliverables
+  under the task workspace, inspect them, repair blocking failures, and call
+  finalize with the exact deliverable paths. Plain assistant text never
+  completes a task. Do not request package installation, network access, a
+  shell, elevated privileges, or files outside the task workspace. Tool errors
+  are bounded evidence; choose a different safe action or finalize the best
+  verified result within the remaining budget.

--- a/batch-runner/requirements.txt
+++ b/batch-runner/requirements.txt
@@ -11,6 +11,7 @@ psutil>=5.9.0
 azure-identity>=1.15.0
 jsonschema>=4.21.0
 cryptography>=42.0.0
+ijson>=3.3.0
 
 # Reference file readers
 pdfplumber>=0.10.0

--- a/batch-runner/requirements.txt
+++ b/batch-runner/requirements.txt
@@ -10,6 +10,7 @@ openai>=1.12.0
 psutil>=5.9.0
 azure-identity>=1.15.0
 jsonschema>=4.21.0
+cryptography>=42.0.0
 
 # Reference file readers
 pdfplumber>=0.10.0

--- a/batch-runner/sandbox/Dockerfile
+++ b/batch-runner/sandbox/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Build (from batch-runner/):   bash sandbox/build.sh
 # Pin Python to 3.11 to match the GitHub Actions runner.
-FROM python:3.11-slim-bookworm
+FROM python:3.11-slim-bookworm@sha256:28255a3ace7eb4c48bc1b57b90af29e1bc82b4fd6c60614a8e3dce61b87ff941
 
 LABEL org.opencontainers.image.title="gdpval-sandbox" \
       org.opencontainers.image.description="Skill-aware multimodal sandbox for GDPVal solving" \
@@ -57,11 +57,11 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Python dependencies ─────────────────────────────────────────────────────
-# Copy only requirements first to maximize Docker layer caching.
-COPY requirements.txt /tmp/requirements.txt
+# Copy the complete recursive requirements input before installation.
+COPY requirements.txt requirements-renderer.txt /tmp/
 RUN python -m pip install --upgrade pip setuptools wheel \
     && pip install -r /tmp/requirements.txt \
-    && rm -f /tmp/requirements.txt
+    && rm -f /tmp/requirements.txt /tmp/requirements-renderer.txt
 
 # ── Skills (baked-in fallback) ──────────────────────────────────────────────
 # The runner also bind-mounts skills/ into the work dir, but baking them here

--- a/batch-runner/sandbox/agentic-capabilities.json
+++ b/batch-runner/sandbox/agentic-capabilities.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "python": "3.11",
+  "uid": 65532,
+  "gid": 65532,
+  "network": false,
+  "runtime_install": false,
+  "shell": false,
+  "generated_python_exec": false,
+  "tools": {
+    "ffmpeg": true,
+    "ffprobe": true,
+    "libreoffice_binary": true,
+    "python_document_libraries": true,
+    "python_media_libraries": true,
+    "python_data_libraries": true
+  }
+}

--- a/batch-runner/sandbox/agentic-seccomp.json
+++ b/batch-runner/sandbox/agentic-seccomp.json
@@ -38,6 +38,7 @@
         "renameat", "renameat2", "restart_syscall", "rmdir", "rseq",
         "rt_sigaction", "rt_sigpending", "rt_sigprocmask", "rt_sigqueueinfo",
         "rt_sigreturn", "rt_sigsuspend", "rt_sigtimedwait", "sched_getaffinity",
+        "seccomp",
         "sched_getattr", "sched_getparam", "sched_getscheduler", "sched_yield",
         "select", "semctl", "semget", "semop", "semtimedop", "sendfile",
         "sendmmsg", "sendmsg", "sendto", "set_robust_list", "set_tid_address",

--- a/batch-runner/sandbox/agentic-seccomp.json
+++ b/batch-runner/sandbox/agentic-seccomp.json
@@ -1,0 +1,58 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "defaultErrnoRet": 1,
+  "architectures": [
+    "SCMP_ARCH_X86_64",
+    "SCMP_ARCH_X86",
+    "SCMP_ARCH_X32"
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "accept", "accept4", "access", "arch_prctl", "bind", "brk",
+        "capget", "capset", "chdir", "chmod", "chown", "clock_getres",
+        "clock_gettime", "clock_nanosleep", "clone", "clone3", "close",
+        "close_range", "connect", "copy_file_range", "creat", "dup",
+        "dup2", "dup3", "epoll_create", "epoll_create1", "epoll_ctl",
+        "epoll_pwait", "epoll_pwait2", "epoll_wait", "eventfd", "eventfd2",
+        "execve", "execveat", "exit", "exit_group", "faccessat",
+        "faccessat2", "fadvise64", "fallocate", "fanotify_mark", "fchdir",
+        "fchmod", "fchmodat", "fchown", "fchownat", "fcntl", "fdatasync",
+        "flock", "fork", "fstat", "fstatfs", "fsync", "ftruncate",
+        "futex", "futex_waitv", "getcpu", "getcwd", "getdents",
+        "getdents64", "getegid", "geteuid", "getgid", "getgroups",
+        "getitimer", "getpeername", "getpgid", "getpgrp", "getpid",
+        "getppid", "getpriority", "getrandom", "getresgid", "getresuid",
+        "getrlimit", "getrusage", "getsid", "getsockname", "getsockopt",
+        "gettid", "gettimeofday", "getuid", "getxattr", "inotify_add_watch",
+        "inotify_init", "inotify_init1", "inotify_rm_watch", "ioctl", "kill",
+        "lchown", "link", "linkat", "listen", "listxattr", "llseek",
+        "lseek", "lstat", "madvise", "memfd_create", "mincore", "mkdir",
+        "mkdirat", "mknod", "mknodat", "mlock", "mlock2", "mlockall",
+        "mmap", "mmap2", "mprotect", "mremap", "msync", "munlock",
+        "munlockall", "munmap", "nanosleep", "newfstatat", "open", "openat",
+        "openat2", "pause", "pipe", "pipe2", "poll", "ppoll", "prctl",
+        "pread64", "preadv", "preadv2", "prlimit64", "pselect6", "pwrite64",
+        "pwritev", "pwritev2", "read", "readahead", "readlink", "readlinkat",
+        "readv", "recvfrom", "recvmmsg", "recvmsg", "removexattr", "rename",
+        "renameat", "renameat2", "restart_syscall", "rmdir", "rseq",
+        "rt_sigaction", "rt_sigpending", "rt_sigprocmask", "rt_sigqueueinfo",
+        "rt_sigreturn", "rt_sigsuspend", "rt_sigtimedwait", "sched_getaffinity",
+        "sched_getattr", "sched_getparam", "sched_getscheduler", "sched_yield",
+        "select", "semctl", "semget", "semop", "semtimedop", "sendfile",
+        "sendmmsg", "sendmsg", "sendto", "set_robust_list", "set_tid_address",
+        "setitimer", "setpgid", "setpriority", "setsid", "setsockopt", "shmat",
+        "shmctl", "shmdt", "shmget", "shutdown", "sigaltstack", "signalfd",
+        "signalfd4", "socket", "socketcall", "socketpair", "splice", "stat",
+        "statfs", "statx", "symlink", "symlinkat", "sync", "sync_file_range",
+        "syncfs", "sysinfo", "tee", "tgkill", "time", "timer_create",
+        "timer_delete", "timer_getoverrun", "timer_gettime", "timer_settime",
+        "timerfd_create", "timerfd_gettime", "timerfd_settime", "times", "tkill",
+        "truncate", "umask", "uname", "unlink", "unlinkat", "utime",
+        "utimensat", "utimes", "vfork", "vmsplice", "wait4", "waitid",
+        "waitpid", "write", "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    }
+  ]
+}

--- a/batch-runner/sandbox/agentic.Dockerfile
+++ b/batch-runner/sandbox/agentic.Dockerfile
@@ -1,0 +1,58 @@
+# Hardened task/verifier image for execution.mode=agentic_sandbox.
+ARG BASE_IMAGE=gdpval-sandbox:latest
+FROM ${BASE_IMAGE}
+
+USER 0:0
+
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends libseccomp2 \
+    && groupadd --gid 65532 agentic \
+    && useradd --uid 65532 --gid 65532 --no-create-home --home-dir /work/.home agentic \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -qq \
+    && apt-get purge -y --auto-remove \
+        build-essential gfortran gcc g++ cpp make cmake binutils dpkg-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY core /opt/gdpval/core
+COPY sandbox/agentic-capabilities.json /opt/gdpval/agentic-capabilities.json
+COPY sandbox/agentic_image_prepare.py /opt/gdpval/agentic_image_prepare.py
+COPY sandbox/agentic_image_audit.py /opt/gdpval/agentic_image_audit.py
+COPY sandbox/agentic_sbom.py /opt/gdpval/agentic_sbom.py
+
+ENV PYTHONPATH=/opt/gdpval \
+    HOME=/work/.home \
+    TMPDIR=/work/.tmp \
+    XDG_CACHE_HOME=/work/.cache \
+    XDG_CONFIG_HOME=/work/.config \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    MPLCONFIGDIR=/work/.cache/matplotlib \
+    FONTCONFIG_PATH=/etc/fonts
+
+# Generated code is additionally constrained by an in-process seccomp filter.
+# Removing package/download/build entrypoints keeps accidental invocation from
+# trusted helper processes fail-closed as well.
+RUN python /opt/gdpval/agentic_image_prepare.py \
+    && rm -f /opt/gdpval/agentic_image_prepare.py
+
+RUN python /opt/gdpval/agentic_sbom.py > /opt/gdpval/agentic-sbom.spdx.json \
+    && chmod 0444 /opt/gdpval/agentic-sbom.spdx.json
+
+RUN mkdir -p /work /inputs /verify-work \
+    && chown 65532:65532 /work /verify-work \
+    && chmod 0700 /work /verify-work \
+    && chmod -R a-w /opt/gdpval
+
+# This must be the final RUN instruction: Docker's shell-form RUN needs /bin/sh.
+RUN find / -xdev -type f \( -perm -4000 -o -perm -2000 \) -exec chmod a-s {} + \
+    && find /usr/local/bin /usr/bin /bin -xdev -type f -perm -0002 -exec chmod o-w {} + \
+    && rm -f /bin/sh /bin/bash /usr/bin/dash /usr/bin/bash
+
+USER 65532:65532
+WORKDIR /work
+
+ENTRYPOINT ["python", "-I", "-B", "-u"]
+CMD ["/opt/gdpval/core/agentic_idle.py"]

--- a/batch-runner/sandbox/agentic_image_audit.py
+++ b/batch-runner/sandbox/agentic_image_audit.py
@@ -1,0 +1,93 @@
+"""Fail-closed runtime audit for the hardened agentic image."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import stat
+from pathlib import Path
+
+
+EXECUTABLE_ROOTS = (
+    Path("/bin"),
+    Path("/sbin"),
+    Path("/usr/bin"),
+    Path("/usr/sbin"),
+    Path("/usr/local/bin"),
+    Path("/usr/local/sbin"),
+)
+FORBIDDEN_EXECUTABLES = {
+    "pip", "pip3", "pip3.11", "apt", "apt-get", "apt-cache", "dpkg",
+    "gcc", "g++", "cc", "c++", "cpp", "gfortran", "make", "cmake",
+    "curl", "wget", "ssh", "scp", "sftp", "git", "nc", "ncat", "socat",
+    "gdb", "strace", "ltrace", "sh", "bash", "dash",
+}
+TOOLCHAIN_PATTERN = re.compile(
+    r"^(?:[A-Za-z0-9_.+]+-)*(?:gcc|g\+\+|cc|c\+\+|cpp|gfortran|"
+    r"ld|as|ar|nm|objcopy|objdump|ranlib|readelf|size|strings|strip)"
+    r"(?:-\d+(?:\.\d+)*)?(?:\.(?:bfd|gold))?$"
+)
+
+
+def audit() -> dict:
+    if os.geteuid() != 65532 or os.getegid() != 65532:
+        raise RuntimeError("agentic image UID/GID is not fixed at 65532")
+    for module in ("pip", "ensurepip", "setuptools"):
+        if importlib.util.find_spec(module) is not None:
+            raise RuntimeError(f"forbidden Python module survived: {module}")
+
+    violations: list[str] = []
+    capabilities: list[str] = []
+    for root in EXECUTABLE_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            try:
+                metadata = path.lstat()
+                if (
+                    path.name in FORBIDDEN_EXECUTABLES
+                    or TOOLCHAIN_PATTERN.fullmatch(path.name)
+                ):
+                    violations.append(path.as_posix())
+                if stat.S_ISREG(metadata.st_mode) and metadata.st_mode & (
+                    stat.S_ISUID | stat.S_ISGID | stat.S_IWOTH
+                ):
+                    violations.append(path.as_posix())
+                if stat.S_ISREG(metadata.st_mode):
+                    capability = os.getxattr(
+                        path, "security.capability", follow_symlinks=False
+                    )
+                    if capability:
+                        capabilities.append(path.as_posix())
+            except (FileNotFoundError, PermissionError, OSError):
+                continue
+    if violations:
+        raise RuntimeError(
+            "forbidden or privileged executable survived: "
+            + ", ".join(sorted(set(violations))[:20])
+        )
+    if capabilities:
+        raise RuntimeError(
+            "file capability survived: "
+            + ", ".join(sorted(set(capabilities))[:20])
+        )
+    sbom = Path("/opt/gdpval/agentic-sbom.spdx.json")
+    document = json.loads(sbom.read_text(encoding="utf-8"))
+    if document.get("spdxVersion") != "SPDX-2.3" or not document.get("packages"):
+        raise RuntimeError("runtime SPDX SBOM is missing or invalid")
+    return {
+        "audit": "pass",
+        "uid": os.geteuid(),
+        "gid": os.getegid(),
+        "sbom_packages": len(document["packages"]),
+    }
+
+
+def main() -> None:
+    print(json.dumps(audit(), sort_keys=True, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/sandbox/agentic_image_prepare.py
+++ b/batch-runner/sandbox/agentic_image_prepare.py
@@ -1,0 +1,72 @@
+"""Remove runtime installation, download, build, and debugging entrypoints."""
+
+from pathlib import Path
+import os
+import re
+import shutil
+
+
+FORBIDDEN_EXECUTABLES = (
+    "pip", "pip3", "pip3.11", "apt", "apt-get", "apt-cache", "dpkg",
+    "gcc", "g++", "cc", "c++", "cpp", "gfortran", "make", "cmake",
+    "curl", "wget", "ssh", "scp", "sftp", "git", "nc", "ncat", "socat",
+    "gdb", "strace", "ltrace",
+)
+EXECUTABLE_ROOTS = (
+    Path("/bin"), Path("/sbin"), Path("/usr/bin"), Path("/usr/sbin"),
+    Path("/usr/local/bin"), Path("/usr/local/sbin"),
+)
+TOOLCHAIN_PATTERN = re.compile(
+    r"^(?:[A-Za-z0-9_.+]+-)*(?:gcc|g\+\+|cc|c\+\+|cpp|gfortran|"
+    r"ld|as|ar|nm|objcopy|objdump|ranlib|readelf|size|strings|strip)"
+    r"(?:-\d+(?:\.\d+)*)?(?:\.(?:bfd|gold))?$"
+)
+
+
+def _is_forbidden_executable(name: str) -> bool:
+    return name in FORBIDDEN_EXECUTABLES or TOOLCHAIN_PATTERN.fullmatch(name) is not None
+
+
+def _matching_executables() -> list[Path]:
+    matches = set()
+    for root in EXECUTABLE_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            try:
+                executable = path.is_symlink() or (
+                    path.is_file() and os.access(path, os.X_OK)
+                )
+            except OSError:
+                continue
+            if executable and _is_forbidden_executable(path.name):
+                matches.add(path)
+    return sorted(matches, key=lambda path: path.as_posix())
+
+
+def main() -> None:
+    for executable in FORBIDDEN_EXECUTABLES:
+        path = shutil.which(executable)
+        if path:
+            Path(path).unlink(missing_ok=True)
+    for path in _matching_executables():
+        path.unlink(missing_ok=True)
+
+    site_packages = Path("/usr/local/lib/python3.11/site-packages")
+    for name in ("pip", "setuptools"):
+        for candidate in site_packages.glob(f"{name}*"):
+            if candidate.is_dir():
+                shutil.rmtree(candidate)
+            else:
+                candidate.unlink(missing_ok=True)
+    shutil.rmtree(Path("/usr/local/lib/python3.11/ensurepip"), ignore_errors=True)
+    survivors = _matching_executables()
+    if survivors:
+        raise RuntimeError(
+            "forbidden executable survived image preparation: "
+            + ", ".join(path.as_posix() for path in survivors[:20])
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/sandbox/agentic_sbom.py
+++ b/batch-runner/sandbox/agentic_sbom.py
@@ -1,0 +1,97 @@
+"""Emit a deterministic SPDX 2.3 SBOM from image-local package metadata."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+from pathlib import Path
+
+
+def _spdx_id(kind: str, name: str, version: str) -> str:
+    digest = hashlib.sha256(f"{kind}\0{name}\0{version}".encode("utf-8")).hexdigest()
+    return f"SPDXRef-Package-{digest[:24]}"
+
+
+def _package(kind: str, name: str, version: str) -> dict:
+    return {
+        "SPDXID": _spdx_id(kind, name, version),
+        "name": name,
+        "versionInfo": version,
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": False,
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "supplier": "NOASSERTION",
+        "externalRefs": [{
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": f"pkg:{kind}/{name}@{version}",
+        }],
+    }
+
+
+def _python_packages() -> list[dict]:
+    packages = {
+        (distribution.metadata.get("Name") or distribution.name, distribution.version)
+        for distribution in importlib.metadata.distributions()
+    }
+    return [
+        _package("pypi", name, version)
+        for name, version in sorted(packages, key=lambda item: item[0].lower())
+    ]
+
+
+def _debian_packages() -> list[dict]:
+    status_path = Path("/var/lib/dpkg/status")
+    if not status_path.is_file():
+        return []
+    packages = []
+    for stanza in status_path.read_text(encoding="utf-8", errors="replace").split("\n\n"):
+        fields = {}
+        for line in stanza.splitlines():
+            if ": " in line:
+                key, value = line.split(": ", 1)
+                fields[key] = value
+        if fields.get("Status") == "install ok installed" and fields.get("Package"):
+            packages.append(_package(
+                "deb/debian",
+                fields["Package"],
+                fields.get("Version", "NOASSERTION"),
+            ))
+    return sorted(packages, key=lambda package: package["name"])
+
+
+def main() -> None:
+    packages = _debian_packages() + _python_packages()
+    namespace_digest = hashlib.sha256(
+        json.dumps(packages, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    document = {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "gdpval-agentic-sandbox",
+        "documentNamespace": (
+            "https://github.com/hyeonsangjeon/gdpval-realworks/"
+            f"sbom/gdpval-agentic-sandbox/{namespace_digest}"
+        ),
+        "creationInfo": {
+            "created": "1970-01-01T00:00:00Z",
+            "creators": ["Tool: gdpval-agentic-sbom-v1"],
+        },
+        "packages": packages,
+        "relationships": [
+            {
+                "spdxElementId": "SPDXRef-DOCUMENT",
+                "relationshipType": "DESCRIBES",
+                "relatedSpdxElement": package["SPDXID"],
+            }
+            for package in packages
+        ],
+    }
+    print(json.dumps(document, sort_keys=True, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/sandbox/build_agentic.sh
+++ b/batch-runner/sandbox/build_agentic.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${AGENTIC_SANDBOX_IMAGE:-gdpval-agentic-sandbox:local}"
+BASE_IMAGE="${SANDBOX_IMAGE:-gdpval-sandbox:latest}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTEXT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SBOM_PATH="${AGENTIC_SBOM_PATH:-${CONTEXT_DIR}/sandbox/agentic-sbom.spdx.json}"
+
+command -v docker >/dev/null
+command -v python3 >/dev/null
+docker info >/dev/null
+docker image inspect "${BASE_IMAGE}" >/dev/null
+
+docker build \
+  --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+  -f "${SCRIPT_DIR}/agentic.Dockerfile" \
+  -t "${IMAGE}" \
+  "${CONTEXT_DIR}"
+
+docker run --rm --entrypoint python "${IMAGE}" \
+  -I -B /opt/gdpval/agentic_image_audit.py
+
+docker run --rm --entrypoint python "${IMAGE}" \
+  -I -B /opt/gdpval/agentic_sbom.py > "${SBOM_PATH}"
+EMBEDDED_SBOM="$(mktemp)"
+trap 'rm -f "${EMBEDDED_SBOM}"' EXIT
+docker run --rm --entrypoint cat "${IMAGE}" \
+  /opt/gdpval/agentic-sbom.spdx.json > "${EMBEDDED_SBOM}"
+cmp --silent "${SBOM_PATH}" "${EMBEDDED_SBOM}"
+python3 -c '
+import json, pathlib, sys
+document = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert document["spdxVersion"] == "SPDX-2.3"
+assert len(document["packages"]) > 20
+' "${SBOM_PATH}"
+
+docker image inspect --format '{{.Id}}' "${IMAGE}"
+sha256sum "${SCRIPT_DIR}/agentic-seccomp.json" \
+  "${SCRIPT_DIR}/agentic-capabilities.json" "${SBOM_PATH}"

--- a/batch-runner/scripts/build_agentic_input_manifest.py
+++ b/batch-runner/scripts/build_agentic_input_manifest.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Build exact approved input identities on the dedicated compute runner."""
+
+import argparse
+import json
+from pathlib import Path
+
+from core.agentic_input_manifest import build_input_manifest
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--selection-manifest", required=True)
+    parser.add_argument("--dataset-root", required=True)
+    parser.add_argument("--staging-parent", required=True)
+    parser.add_argument("--provider-classification", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    selection = json.loads(
+        Path(args.selection_manifest).read_text(encoding="utf-8")
+    )
+    manifest = build_input_manifest(
+        selection_manifest=selection,
+        dataset_root=args.dataset_root,
+        staging_parent=args.staging_parent,
+        provider_classification=args.provider_classification,
+    )
+    Path(args.output).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/scripts/compare_agentic_conditions.py
+++ b/batch-runner/scripts/compare_agentic_conditions.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Compute preregistered paired Agentic Sandbox endpoints from frozen JSON."""
+
+import argparse
+import json
+from pathlib import Path
+
+from core.agentic_budget import AgenticBudgetLedger
+from core.agentic_endpoints import compute_paired_endpoints
+
+
+def _load(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--task-manifest", required=True)
+    parser.add_argument("--baseline-results", required=True)
+    parser.add_argument("--treatment-results", required=True)
+    parser.add_argument("--rubric-maxima", required=True)
+    parser.add_argument("--baseline-grades", required=True)
+    parser.add_argument("--treatment-grades", required=True)
+    parser.add_argument("--budget-ledger", required=True)
+    parser.add_argument("--scope-manifest", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    manifest = _load(args.task_manifest)
+    baseline = _load(args.baseline_results)
+    treatment = _load(args.treatment_results)
+    scopes = _load(args.scope_manifest)
+    if not isinstance(scopes, dict) or set(scopes) != {
+        "schema_version", "paired_run_id", "baseline_task_scopes",
+        "treatment_task_scopes",
+    }:
+        raise ValueError("budget scope manifest fields are invalid")
+    if scopes["schema_version"] != "agentic-budget-scope-manifest-v1":
+        raise ValueError("budget scope manifest version is invalid")
+    endpoints = compute_paired_endpoints(
+        expected_task_ids=manifest["diagnostic_task_ids"],
+        baseline_results=baseline["results"],
+        treatment_results=treatment["results"],
+        rubric_maxima=_load(args.rubric_maxima),
+        baseline_grades=_load(args.baseline_grades),
+        treatment_grades=_load(args.treatment_grades),
+        budget_ledger=AgenticBudgetLedger(args.budget_ledger),
+        paired_run_id=scopes["paired_run_id"],
+        baseline_task_scopes=scopes["baseline_task_scopes"],
+        treatment_task_scopes=scopes["treatment_task_scopes"],
+    )
+    Path(args.output).write_text(
+        json.dumps(endpoints, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/scripts/compare_agentic_conditions.py
+++ b/batch-runner/scripts/compare_agentic_conditions.py
@@ -2,15 +2,168 @@
 """Compute preregistered paired Agentic Sandbox endpoints from frozen JSON."""
 
 import argparse
+import hashlib
 import json
+import re
 from pathlib import Path
 
 from core.agentic_budget import AgenticBudgetLedger
 from core.agentic_endpoints import compute_paired_endpoints
 
 
-def _load(path):
-    return json.loads(Path(path).read_text(encoding="utf-8"))
+FULL_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+FULL_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _read(path):
+    content = Path(path).read_bytes()
+    return json.loads(content), hashlib.sha256(content).hexdigest()
+
+
+def _canonical_sha256(value):
+    return hashlib.sha256(json.dumps(
+        value, sort_keys=True, separators=(",", ":"), allow_nan=False,
+    ).encode("utf-8")).hexdigest()
+
+
+def _validate_scope(scopes, documents, hashes):
+    required = {
+        "schema_version", "paired_run_id", "ordered_task_ids",
+        "dataset_revision", "rubric_commit", "baseline_inference_revision",
+        "treatment_inference_revision", "judge_config_hash", "prompt_version",
+        "grader_source_hash", "baseline_task_scopes",
+        "treatment_task_scopes", "artifact_sha256", "sha256",
+    }
+    if not isinstance(scopes, dict) or set(scopes) != required:
+        raise ValueError("budget scope manifest fields are invalid")
+    canonical = {key: value for key, value in scopes.items() if key != "sha256"}
+    if (
+        scopes["schema_version"] != "agentic-budget-scope-manifest-v2"
+        or scopes["sha256"] != _canonical_sha256(canonical)
+    ):
+        raise ValueError("budget scope manifest identity is invalid")
+    ordered = scopes["ordered_task_ids"]
+    if (
+        not isinstance(scopes["paired_run_id"], str)
+        or not scopes["paired_run_id"]
+        or not isinstance(ordered, list)
+        or len(ordered) != 20
+        or len(ordered) != len(set(ordered))
+        or any(not isinstance(task_id, str) or not task_id for task_id in ordered)
+    ):
+        raise ValueError("paired scope task identity is invalid")
+    for field in (
+        "dataset_revision", "rubric_commit", "baseline_inference_revision",
+        "treatment_inference_revision",
+    ):
+        if FULL_COMMIT_RE.fullmatch(str(scopes[field])) is None:
+            raise ValueError(f"paired scope {field} is invalid")
+    if FULL_SHA256_RE.fullmatch(str(scopes["grader_source_hash"])) is None:
+        raise ValueError("paired scope grader source hash is invalid")
+    if not all(
+        isinstance(scopes[field], str) and scopes[field]
+        for field in ("judge_config_hash", "prompt_version")
+    ):
+        raise ValueError("paired grade configuration identity is invalid")
+    expected_names = {
+        "task_manifest", "baseline_results", "treatment_results",
+        "rubric_maxima", "baseline_grades", "treatment_grades",
+    }
+    if (
+        not isinstance(scopes["artifact_sha256"], dict)
+        or set(scopes["artifact_sha256"]) != expected_names
+        or any(
+            FULL_SHA256_RE.fullmatch(str(value)) is None
+            for value in scopes["artifact_sha256"].values()
+        )
+        or scopes["artifact_sha256"] != hashes
+    ):
+        raise ValueError("paired artifact byte identity mismatch")
+
+    manifest = documents["task_manifest"]
+    if (
+        manifest.get("diagnostic_task_ids") != ordered
+        or (manifest.get("dataset") or {}).get("revision")
+        != scopes["dataset_revision"]
+        or (manifest.get("rubric") or {}).get("revision")
+        != scopes["rubric_commit"]
+    ):
+        raise ValueError("task manifest provenance mismatch")
+    maxima = documents["rubric_maxima"]
+    if (
+        not isinstance(maxima, dict)
+        or set(maxima) != {"schema_version", "rubric_commit", "tasks"}
+        or maxima["schema_version"] != "agentic-rubric-maxima-v1"
+        or maxima["rubric_commit"] != scopes["rubric_commit"]
+        or set(maxima["tasks"]) != set(ordered)
+    ):
+        raise ValueError("rubric maxima provenance mismatch")
+
+    _validate_results(
+        documents["baseline_results"], scopes, "exp029", "baseline",
+        "sandbox",
+    )
+    _validate_results(
+        documents["treatment_results"], scopes, "exp030", "treatment",
+        "agentic_sandbox",
+    )
+    _validate_grade(
+        documents["baseline_grades"], scopes, "exp029",
+        scopes["baseline_inference_revision"],
+    )
+    _validate_grade(
+        documents["treatment_grades"], scopes, "exp030",
+        scopes["treatment_inference_revision"],
+    )
+
+
+def _validate_results(document, scopes, experiment_id, condition, mode):
+    expected = {
+        "experiment_id": experiment_id,
+        "condition_identity": condition,
+        "execution_mode": mode,
+        "run_id": scopes["paired_run_id"],
+        "ordered_task_ids": scopes["ordered_task_ids"],
+    }
+    if not isinstance(document, dict) or any(
+        document.get(key) != value for key, value in expected.items()
+    ):
+        raise ValueError(f"{condition} inference provenance mismatch")
+    results = document.get("results")
+    if not isinstance(results, list) or [
+        result.get("task_id") for result in results if isinstance(result, dict)
+    ] != scopes["ordered_task_ids"]:
+        raise ValueError(f"{condition} inference task order mismatch")
+
+
+def _validate_grade(document, scopes, experiment_id, inference_revision):
+    expected = {
+        "experiment_id": experiment_id,
+        "source_inference_experiment_id": experiment_id,
+        "source_inference_revision": inference_revision,
+        "grader_source_hash": scopes["grader_source_hash"],
+    }
+    if not isinstance(document, dict) or any(
+        document.get(key) != value for key, value in expected.items()
+    ):
+        raise ValueError(f"{experiment_id} grade provenance mismatch")
+    if (
+        (document.get("rubric") or {}).get("commit_sha")
+        != scopes["rubric_commit"]
+        or (document.get("judge") or {}).get("config_hash")
+        != scopes["judge_config_hash"]
+        or (document.get("prompt") or {}).get("version")
+        != scopes["prompt_version"]
+    ):
+        raise ValueError(f"{experiment_id} grade configuration mismatch")
+    tasks = document.get("tasks")
+    if not isinstance(tasks, list):
+        raise ValueError(f"{experiment_id} grade tasks are invalid")
+    task_ids = [task.get("task_id") for task in tasks if isinstance(task, dict)]
+    if len(task_ids) != len(set(task_ids)) or not set(task_ids) <= set(
+        scopes["ordered_task_ids"]
+    ):
+        raise ValueError(f"{experiment_id} grade task identity mismatch")
 
 
 def main():
@@ -25,29 +178,41 @@ def main():
     parser.add_argument("--scope-manifest", required=True)
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
-    manifest = _load(args.task_manifest)
-    baseline = _load(args.baseline_results)
-    treatment = _load(args.treatment_results)
-    scopes = _load(args.scope_manifest)
-    if not isinstance(scopes, dict) or set(scopes) != {
-        "schema_version", "paired_run_id", "baseline_task_scopes",
-        "treatment_task_scopes",
-    }:
-        raise ValueError("budget scope manifest fields are invalid")
-    if scopes["schema_version"] != "agentic-budget-scope-manifest-v1":
-        raise ValueError("budget scope manifest version is invalid")
+    input_paths = {
+        "task_manifest": args.task_manifest,
+        "baseline_results": args.baseline_results,
+        "treatment_results": args.treatment_results,
+        "rubric_maxima": args.rubric_maxima,
+        "baseline_grades": args.baseline_grades,
+        "treatment_grades": args.treatment_grades,
+    }
+    loaded = {name: _read(path) for name, path in input_paths.items()}
+    documents = {name: value[0] for name, value in loaded.items()}
+    hashes = {name: value[1] for name, value in loaded.items()}
+    scopes, _ = _read(args.scope_manifest)
+    _validate_scope(scopes, documents, hashes)
     endpoints = compute_paired_endpoints(
-        expected_task_ids=manifest["diagnostic_task_ids"],
-        baseline_results=baseline["results"],
-        treatment_results=treatment["results"],
-        rubric_maxima=_load(args.rubric_maxima),
-        baseline_grades=_load(args.baseline_grades),
-        treatment_grades=_load(args.treatment_grades),
+        expected_task_ids=scopes["ordered_task_ids"],
+        baseline_results=documents["baseline_results"]["results"],
+        treatment_results=documents["treatment_results"]["results"],
+        rubric_maxima=documents["rubric_maxima"]["tasks"],
+        baseline_grades=documents["baseline_grades"],
+        treatment_grades=documents["treatment_grades"],
         budget_ledger=AgenticBudgetLedger(args.budget_ledger),
         paired_run_id=scopes["paired_run_id"],
         baseline_task_scopes=scopes["baseline_task_scopes"],
         treatment_task_scopes=scopes["treatment_task_scopes"],
     )
+    endpoints["provenance"] = {
+        key: scopes[key]
+        for key in (
+            "paired_run_id", "ordered_task_ids", "dataset_revision",
+            "rubric_commit", "baseline_inference_revision",
+            "treatment_inference_revision", "judge_config_hash",
+            "prompt_version", "grader_source_hash", "artifact_sha256",
+            "sha256",
+        )
+    }
     Path(args.output).write_text(
         json.dumps(endpoints, indent=2, sort_keys=True, allow_nan=False) + "\n",
         encoding="utf-8",

--- a/batch-runner/scripts/select_agentic_tasks.py
+++ b/batch-runner/scripts/select_agentic_tasks.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Create the preregistered agentic task subset from outcome-free JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from core.agentic_selector import (
+    assert_outcome_free_checkout,
+    build_selection_manifest,
+    select_agentic_tasks,
+    resolve_outcome_free_file,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset-json", required=True)
+    parser.add_argument("--rubric-json", required=True)
+    parser.add_argument("--dataset-repo", required=True)
+    parser.add_argument("--dataset-sha", required=True)
+    parser.add_argument("--rubric-repo", required=True)
+    parser.add_argument("--rubric-sha", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--outcome-free-root", required=True)
+    args = parser.parse_args()
+
+    root = Path(args.outcome_free_root).resolve()
+    source_commit = assert_outcome_free_checkout(root)
+    dataset_path = resolve_outcome_free_file(
+        root, args.dataset_json, "dataset JSON"
+    )
+    rubric_path = resolve_outcome_free_file(
+        root, args.rubric_json, "rubric JSON"
+    )
+    selector_path = resolve_outcome_free_file(
+        root,
+        "batch-runner/core/agentic_selector.py",
+        "selector source",
+    )
+    records = json.loads(dataset_path.read_text(encoding="utf-8"))
+    rubrics = json.loads(rubric_path.read_text(encoding="utf-8"))
+    selection = select_agentic_tasks(
+        records, rubrics, dataset_sha=args.dataset_sha
+    )
+    manifest = build_selection_manifest(
+        selection,
+        dataset_repo=args.dataset_repo,
+        dataset_sha=args.dataset_sha,
+        rubric_repo=args.rubric_repo,
+        rubric_sha=args.rubric_sha,
+        selector_path=selector_path,
+        repository_root=root,
+        source_commit=source_commit,
+    )
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/scripts/select_agentic_tasks.py
+++ b/batch-runner/scripts/select_agentic_tasks.py
@@ -51,6 +51,8 @@ def main() -> None:
         dataset_sha=args.dataset_sha,
         rubric_repo=args.rubric_repo,
         rubric_sha=args.rubric_sha,
+        dataset_path=dataset_path,
+        rubric_path=rubric_path,
         selector_path=selector_path,
         repository_root=root,
         source_commit=source_commit,

--- a/batch-runner/security/README.md
+++ b/batch-runner/security/README.md
@@ -1,0 +1,11 @@
+# Agentic Live Authorization
+
+No live Agentic Sandbox key or approval is checked in during non-paid
+implementation. Before an approved live phase, the owner must add the reviewed
+Ed25519 public key at `agentic-owner-ed25519.pub`; the private key must remain
+outside this repository and outside every compute runner.
+
+The dedicated live control workflow must provide runtime-only
+`AGENTIC_SIGNED_APPROVAL_PATH` and `AGENTIC_NONCE_LEDGER_PATH` values. The
+general batch workflow rejects agentic treatment and hardened baseline modes
+before any cloud or Hugging Face credential step.

--- a/batch-runner/step1_prepare_tasks.py
+++ b/batch-runner/step1_prepare_tasks.py
@@ -16,8 +16,6 @@ Usage:
 import argparse
 import json
 import random
-import sys
-from pathlib import Path
 
 from core.config import WORKSPACE_DIR
 from core.data_loader import GDPValDataLoader

--- a/batch-runner/step1_prepare_tasks.py
+++ b/batch-runner/step1_prepare_tasks.py
@@ -25,6 +25,26 @@ from core.experiment_config import ExperimentConfig
 from core.needs_files import NeedsFilesManifest
 
 
+def _public_agentic_config(value):
+    """Keep public experiment metadata while dropping control-plane paths."""
+    if not isinstance(value, dict):
+        return None
+    output = {}
+    for key in ("compute_transport", "image", "verifier_image", "memory_gb", "cpus"):
+        if key in value:
+            output[key] = value[key]
+    if isinstance(value.get("limits"), dict):
+        output["limits"] = dict(value["limits"])
+    if isinstance(value.get("budget"), dict):
+        output["budget"] = dict(value["budget"])
+    pricing_table = value.get("pricing_table")
+    if isinstance(pricing_table, dict) and isinstance(
+        pricing_table.get("sha256"), str
+    ):
+        output["pricing_table"] = {"sha256": pricing_table["sha256"]}
+    return output or None
+
+
 def prepare_tasks(config_path: str) -> dict:
     """Load data, apply filters, enrich with needs_files, save to workspace."""
 
@@ -32,6 +52,9 @@ def prepare_tasks(config_path: str) -> dict:
 
     # 1. Load experiment config
     config = ExperimentConfig.from_yaml(config_path)
+    validation_errors = config.validate()
+    if validation_errors:
+        raise ValueError("Invalid experiment config: " + "; ".join(validation_errors))
     print(f"📋 Experiment: {config.experiment_id} — {config.name}")
     print(f"   Description: {config.description}")
 
@@ -154,6 +177,11 @@ def prepare_tasks(config_path: str) -> dict:
             "tokens": dict(config.execution.tokens),
             "timeout": config.execution.timeout,
             "sandbox": config.execution.sandbox,
+            **({
+                "agentic": public_agentic
+            } if (public_agentic := _public_agentic_config(
+                config.execution.agentic
+            )) is not None else {}),
             **({"metrics": config.execution.metrics} if config.execution.metrics is not None else {}),
         },
         "total_tasks": len(task_list),

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -38,15 +38,18 @@ from pathlib import Path
 from typing import Optional, List
 
 from core.config import (
+    BATCH_OUTPUT_DIR,
     WORKSPACE_DIR,
     UPLOAD_DIR,
     DELIVERABLE_DIR,
     DEFAULT_LOCAL_PATH,
     DEFAULT_TOKENS,
 )
-from core.data_loader import GDPValTask
+from core.agentic_authorization import task_request_sha256
 from core.executor import TaskExecutor
 from core.agentic_experiments import (
+    AGENTIC_BASELINE_ID,
+    AGENTIC_EXPERIMENT_IDS,
     agentic_condition_identity,
     validate_agentic_budget_for_experiment,
     validate_agentic_experiment_identity,
@@ -58,9 +61,8 @@ from core.execution_metrics import (
     bounded_duration_ms,
 )
 from core.file_preview import generate_all_previews
-from core.llm_client import create_client, create_provider_client, complete
+from core.llm_client import create_provider_client, complete
 from core.needs_files import NeedsFilesManifest
-from core.prompt_builder import PromptBuilder, PromptConfig as BuilderPromptConfig
 from core.audio_analyzer import analyze_audio_files, filter_audio_files
 from core.video_analyzer import (
     analyze_video_files,
@@ -465,6 +467,9 @@ def _bounded_substrate_manifest(raw: Optional[dict]) -> Optional[dict]:
         "read_only_rootfs": raw.get("read_only_rootfs") is True,
         "cap_drop": ["ALL"] if raw.get("cap_drop") == ["ALL"] else [],
         "no_new_privileges": raw.get("no_new_privileges") is True,
+        "selected_transfer_bytes": _bounded_resource_integer(
+            raw.get("selected_transfer_bytes"), 512 * 1024 * 1024
+        ),
         "memory_bytes": _bounded_resource_integer(
             raw.get("memory_bytes"), 16 * 1024 * 1024 * 1024
         ),
@@ -985,11 +990,11 @@ def _run_self_qa(
         # Check finish_reason — detect truncated responses
         finish_reason = getattr(response.choices[0], "finish_reason", None)
         if finish_reason == "length":
-            print(f"  ⚠️  QA response truncated (finish_reason=length)")
+            print("  ⚠️  QA response truncated (finish_reason=length)")
 
         raw = (response.choices[0].message.content or "").strip()
         if not raw:
-            print(f"  ⚠️  QA returned empty response")
+            print("  ⚠️  QA returned empty response")
             return {
                 "passed": None, "score": None,
                 "issues": ["QA returned empty response"],
@@ -1121,6 +1126,125 @@ def _save_files(files: List[dict], task_id: str) -> List[str]:
     return saved_paths
 
 
+def _save_hardened_failure_evidence(
+    files: List[dict],
+    *,
+    experiment_id: str,
+    run_id: str,
+    condition_identity: str,
+    task_id: str,
+) -> dict:
+    import shutil
+    import tempfile
+
+    if not files or not all(
+        isinstance(value, str) and value
+        for value in (experiment_id, run_id, condition_identity, task_id)
+    ):
+        raise ValueError("failure evidence identity is invalid")
+    for value in (experiment_id, condition_identity):
+        if (
+            value in {".", ".."}
+            or value.startswith(".")
+            or "/" in value
+            or "\\" in value
+            or any(ord(character) < 32 for character in value)
+        ):
+            raise ValueError("failure evidence identity is not canonical")
+    run_component = hashlib.sha256(run_id.encode("utf-8")).hexdigest()
+    task_component = hashlib.sha256(task_id.encode("utf-8")).hexdigest()
+    parent = (
+        BATCH_OUTPUT_DIR
+        / "agentic-sandbox"
+        / experiment_id
+        / run_component
+        / condition_identity
+        / "failed-evidence"
+    )
+    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    destination = parent / task_component
+    if destination.exists() or destination.is_symlink():
+        raise ValueError("failure evidence already exists")
+    staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=parent))
+    records = []
+    try:
+        seen = set()
+        for file_data in files:
+            if (
+                not isinstance(file_data, dict)
+                or set(file_data) != {"filename", "content"}
+            ):
+                raise ValueError("failure evidence file record is invalid")
+            filename = file_data["filename"]
+            relative = Path(filename) if isinstance(filename, str) else Path()
+            if (
+                not isinstance(filename, str)
+                or "\\" in filename
+                or relative.is_absolute()
+                or not relative.parts
+                or relative.as_posix() != filename
+                or ".." in relative.parts
+                or any(part.startswith(".") for part in relative.parts)
+                or len(relative.parts) > 16
+                or len(filename.encode("utf-8")) > 240
+                or filename in seen
+            ):
+                raise ValueError("failure evidence filename is invalid")
+            content = file_data["content"]
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            if not isinstance(content, bytes):
+                raise ValueError("failure evidence content is invalid")
+            seen.add(filename)
+            target = staging / "artifacts" / relative
+            target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            target.write_bytes(content)
+            target.chmod(0o600)
+            records.append({
+                "path": filename,
+                "size_bytes": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            })
+        records.sort(key=lambda item: item["path"].encode("utf-8"))
+        evidence_sha256 = hashlib.sha256(json.dumps(
+            records, sort_keys=True, separators=(",", ":"), allow_nan=False,
+        ).encode("utf-8")).hexdigest()
+        manifest = {
+            "schema_version": "agentic-failure-evidence-v1",
+            "experiment_id": experiment_id,
+            "run_id_sha256": run_component,
+            "condition_identity": condition_identity,
+            "task_id_sha256": task_component,
+            "artifact_count": len(records),
+            "artifacts": records,
+            "sha256": evidence_sha256,
+        }
+        metadata_dir = staging / ".evidence"
+        metadata_dir.mkdir(mode=0o700)
+        (metadata_dir / "manifest.json").write_text(
+            json.dumps(manifest, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        for record in records:
+            persisted = staging / "artifacts" / record["path"]
+            if (
+                persisted.stat().st_size != record["size_bytes"]
+                or hashlib.sha256(persisted.read_bytes()).hexdigest()
+                != record["sha256"]
+            ):
+                raise ValueError("failure evidence persistence hash mismatch")
+        os.replace(staging, destination)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return {
+        "schema_version": "agentic-failure-evidence-v1",
+        "artifact_count": len(records),
+        "sha256": evidence_sha256,
+        "root": destination.relative_to(BATCH_OUTPUT_DIR.parent).as_posix(),
+    }
+
+
 # ── Reflection prompt builder ─────────────────────────────────────────────
 
 
@@ -1199,6 +1323,7 @@ def _execute_single_task(
     run_id: Optional[str] = None,
     condition_name: Optional[str] = None,
     strict_inputs: bool = False,
+    experiment_id: Optional[str] = None,
 ) -> dict:
     """Execute a single task and return result dict."""
     task_id = task_info["task_id"]
@@ -1402,6 +1527,32 @@ def _execute_single_task(
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
         else:
+            failure_evidence = None
+            if strict_inputs and result.get("files"):
+                try:
+                    failure_evidence = _save_hardened_failure_evidence(
+                        result["files"],
+                        experiment_id=experiment_id or "",
+                        run_id=run_id or "",
+                        condition_identity=condition_name or "",
+                        task_id=task_id,
+                    )
+                except Exception as exc:
+                    return {
+                        "task_id": task_id,
+                        "status": "error",
+                        "error": f"failed_evidence_persistence_failed:{exc}",
+                        "content": result.get("text"),
+                        "deliverable_text": result.get("deliverable_text"),
+                        "deliverable_files": [],
+                        "model": model,
+                        "usage": None,
+                        "observability": _build_execution_observability(
+                            result, preprocessor_observations
+                        ),
+                        "latency_ms": round(latency_ms, 2),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }
             return {
                 "task_id": task_id,
                 "status": "error",
@@ -1409,6 +1560,7 @@ def _execute_single_task(
                 "content": result.get("text"),
                 "deliverable_text": result.get("deliverable_text"),
                 "deliverable_files": [],
+                "failure_evidence": failure_evidence,
                 "model": model,
                 "usage": None,
                 "observability": _build_execution_observability(
@@ -1651,14 +1803,24 @@ def run_inference(
         sys.exit(1)
 
     experiment_id = prepared["experiment_id"]
+    ordered_task_ids = [task["task_id"] for task in tasks]
+    if (
+        any(not isinstance(task_id, str) or not task_id for task_id in ordered_task_ids)
+        or len(ordered_task_ids) != len(set(ordered_task_ids))
+    ):
+        print("❌ prepared task set contains invalid or duplicate task IDs")
+        sys.exit(1)
     model = condition["model"]["deployment"]
     condition_name = condition["name"]
 
     # Resolve settings: CLI override > YAML execution block > defaults
     execution_cfg = prepared.get("execution", {})
     timeout = execution_cfg.get("timeout")  # None = config.py 기본값 사용
+    configured_execution_mode = execution_cfg.get(
+        "mode", prepared.get("execution_mode", "subprocess")
+    )
     if execution_mode is None:
-        execution_mode = execution_cfg.get("mode", prepared.get("execution_mode", "subprocess"))
+        execution_mode = configured_execution_mode
     if max_retries is None:
         max_retries = execution_cfg.get("max_retries", prepared.get("max_retries", 3))
     if resume_max_rounds is None:
@@ -1685,6 +1847,26 @@ def run_inference(
             and sandbox_options.get("hardened_substrate") is True
         )
     )
+    if experiment_id in AGENTIC_EXPERIMENT_IDS:
+        expected_mode = (
+            "sandbox" if experiment_id == AGENTIC_BASELINE_ID
+            else "agentic_sandbox"
+        )
+        expected_hardened = experiment_id == AGENTIC_BASELINE_ID
+        if (
+            configured_execution_mode != expected_mode
+            or execution_mode != expected_mode
+            or (
+                expected_hardened
+                and sandbox_options.get("hardened_substrate") is not True
+            )
+            or (
+                not expected_hardened
+                and sandbox_options.get("hardened_substrate") is True
+            )
+        ):
+            print("❌ reserved agentic experiment mode cannot be overridden")
+            sys.exit(1)
     if hardened_requested:
         try:
             validate_agentic_experiment_identity(
@@ -1703,9 +1885,20 @@ def run_inference(
                 raise ValueError(
                     "reserved hardened experiments require exactly condition_a"
                 )
+            prompt_config = condition.get("prompt") or {}
+            if prompt_config.get("prefix") or prompt_config.get("body"):
+                raise ValueError(
+                    "hardened paired execution does not support prompt prefix/body"
+                )
         except Exception as exc:
             print("❌ failed to reload hardened execution config")
             print(f"   {exc}")
+            sys.exit(1)
+        if max_retries != 0 or resume_max_rounds != 0:
+            print(
+                "❌ hardened execution fixes max_retries=0 and "
+                "resume_max_rounds=0 until all task resource caps are durable"
+            )
             sys.exit(1)
     execution_condition = (
         agentic_condition_identity(experiment_id)
@@ -1717,7 +1910,7 @@ def run_inference(
     metrics_enabled = metrics_cfg.get("enabled") is True
 
     print(f"\n{'='*60}")
-    print(f"🚀 Step 2: Run Inference")
+    print("🚀 Step 2: Run Inference")
     print(f"{'='*60}")
     print(f"   Experiment:         {experiment_id}")
     print(f"   Condition:          {condition_name}")
@@ -1855,7 +2048,7 @@ def run_inference(
             print("❌ Missing OpenAI credentials. Set OPENAI_API_KEY")
             sys.exit(1)
         client = create_provider_client("openai", api_key=api_key)
-        print(f"   Client:             OpenAI (native)")
+        print("   Client:             OpenAI (native)")
 
     elif provider == "anthropic":
         api_key = os.getenv("ANTHROPIC_API_KEY")
@@ -1863,7 +2056,7 @@ def run_inference(
             print("❌ Missing Anthropic credentials. Set ANTHROPIC_API_KEY")
             sys.exit(1)
         client = create_provider_client("anthropic", api_key=api_key)
-        print(f"   Client:             Anthropic")
+        print("   Client:             Anthropic")
 
     else:
         print(f"❌ Unsupported provider: '{provider}'. Use: azure, openai, anthropic")
@@ -1871,7 +2064,23 @@ def run_inference(
 
     # 3. Initialize executor (no silent fallback — fail loudly)
     reasoning_effort = condition.get("model", {}).get("reasoning_effort")
+    agentic_task_requests = None
     if hardened_requested:
+        prompt_cfg = condition["prompt"]
+        experiment_prompt = {
+            "system": prompt_cfg.get("system", "You are a helpful assistant."),
+            "prefix": prompt_cfg.get("prefix"),
+            "body": prompt_cfg.get("body"),
+            "suffix": prompt_cfg.get("suffix"),
+        }
+        agentic_task_requests = {
+            task["task_id"]: task_request_sha256(
+                task_prompt=task["instruction"],
+                occupation=task.get("occupation", "professional"),
+                experiment_prompt=experiment_prompt,
+            )
+            for task in tasks
+        }
         aggregate_budget = agentic_options.get("budget")
         run_identity = (
             aggregate_budget.get("paired_run_id")
@@ -1901,13 +2110,17 @@ def run_inference(
             client_factory=client_factory,
             agentic_options=agentic_options,
             agentic_endpoint=(approved_endpoint if hardened_requested else None),
+            agentic_ordered_task_ids=(
+                ordered_task_ids if hardened_requested else None
+            ),
+            agentic_task_request_sha256=agentic_task_requests,
             run_id=run_identity,
             condition_name=execution_condition,
             model_name=model,
         )
     except Exception as e:
         print(f"❌ Executor init failed for mode '{execution_mode}': {e}")
-        print(f"   Fix the issue or change execution.mode in your YAML config.")
+        print("   Fix the issue or change execution.mode in your YAML config.")
         sys.exit(1)
 
     # 4. Load manifest
@@ -1920,10 +2133,8 @@ def run_inference(
 
     # 5. Build task lookup
     task_map = {t["task_id"]: t for t in tasks}
-    ordered_task_ids = [t["task_id"] for t in tasks]
     if len(task_map) != len(tasks):
-        print("❌ prepared task set contains duplicate task IDs")
-        sys.exit(1)
+        raise AssertionError("prepared task map identity drift")
     total = len(tasks)
     progress_path = WORKSPACE_DIR / "step2_inference_progress.json"
     started_at = datetime.now(timezone.utc).isoformat()
@@ -2147,6 +2358,7 @@ def run_inference(
                     run_id=run_identity,
                     condition_name=execution_condition,
                     strict_inputs=hardened_requested,
+                    experiment_id=experiment_id,
                 )
                 if metrics_enabled:
                     _record_execution_metrics(result)
@@ -2219,11 +2431,11 @@ def run_inference(
                             best_qa["passed"] = True
                         if best_result:
                             best_result["qa"] = best_qa
-                        print(f"\n      ⚠️  QA undetermined on final attempt — "
-                              f"saving as success (undetermined)",
+                        print("\n      ⚠️  QA undetermined on final attempt — "
+                            "saving as success (undetermined)",
                               end=" ", flush=True)
                         break
-                    print(f"\n      ⚠️  QA undetermined, "
+                    print("\n      ⚠️  QA undetermined, "
                           f"retrying ({qa_attempts}/{qa_max_retries})...",
                           end=" ", flush=True)
                     last_qa_feedback = None
@@ -2325,6 +2537,29 @@ def run_inference(
         except Exception as exc:
             print(f"❌ progress checkpoint rejected: {exc}")
             sys.exit(1)
+        if hardened_requested:
+            unsafe_resume = [
+                result.get("task_id")
+                for result in progress["results"]
+                if (
+                    result.get("status") in {"error", "qa_failed"}
+                    or (
+                        result.get("status") == "pending"
+                        and (
+                            result.get("error") not in {
+                                "wall_timeout", "checkpoint_missing_task"
+                            }
+                            or bool(result.get("observability"))
+                        )
+                    )
+                )
+            ]
+            if unsafe_resume:
+                print(
+                    "❌ hardened failed tasks cannot be resumed: "
+                    + ", ".join(str(task_id) for task_id in unsafe_resume)
+                )
+                sys.exit(1)
 
         # Relay duration fix: preserve original started_at from first run
         if "started_at" in progress:
@@ -2446,7 +2681,7 @@ def run_inference(
         failed = _get_failed_task_ids(progress)
 
         if not failed:
-            print(f"\n✅ No failed tasks — skipping resume rounds")
+            print("\n✅ No failed tasks — skipping resume rounds")
             break
 
         print(f"\n── Resume Round {round_num}/{resume_max_rounds}: "
@@ -2510,7 +2745,7 @@ def run_inference(
               f"{len(still_failed)} still failing")
 
         if not still_failed:
-            print(f"   🎉 All tasks recovered!")
+            print("   🎉 All tasks recovered!")
             break
 
     # ══════════════════════════════════════════════════════════════════════

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -29,8 +29,10 @@ import json
 import os
 import psutil
 import re
+import stat
 import sys
 import time
+import yaml
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, List
@@ -44,6 +46,11 @@ from core.config import (
 )
 from core.data_loader import GDPValTask
 from core.executor import TaskExecutor
+from core.agentic_experiments import (
+    agentic_condition_identity,
+    validate_agentic_budget_for_experiment,
+    validate_agentic_experiment_identity,
+)
 from core.execution_metrics import (
     add_counts,
     add_durations_ms,
@@ -88,6 +95,22 @@ _METRIC_COUNT_FIELDS = (
     "self_qa_call_count",
     "job_run_count",
 )
+
+
+def _load_private_agentic_config(prepared: dict) -> dict:
+    config_path = Path(prepared.get("config_path", "")).resolve()
+    experiments_root = (Path(__file__).resolve().parent / "experiments").resolve()
+    try:
+        config_path.relative_to(experiments_root)
+    except ValueError as exc:
+        raise ValueError(
+            "hardened execution requires a checked-in experiments/*.yaml config"
+        ) from exc
+    raw_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    raw_agentic = (raw_config.get("execution") or {}).get("agentic")
+    if not isinstance(raw_agentic, dict):
+        raise ValueError("execution.agentic must be present for hardened execution")
+    return raw_agentic
 
 
 # ── Preprocessor helper ───────────────────────────────────────────────────
@@ -264,6 +287,17 @@ def _build_execution_observability(
     )
     if execution_metrics:
         observability["execution_metrics"] = execution_metrics
+    agentic_metrics = _bounded_agentic_metrics((result or {}).get("agentic_metrics"))
+    if agentic_metrics:
+        observability["agentic_metrics"] = agentic_metrics
+    budget_metrics = _bounded_budget_metrics((result or {}).get("budget_metrics"))
+    if budget_metrics:
+        observability["budget_metrics"] = budget_metrics
+    substrate = _bounded_substrate_manifest(
+        (result or {}).get("substrate_manifest")
+    )
+    if substrate:
+        observability["substrate"] = substrate
     manifest = (result or {}).get("sandbox_manifest") or {}
     if manifest:
         attempts = []
@@ -311,6 +345,246 @@ def _build_execution_observability(
             "final_status": manifest.get("final_status"),
         }
     return observability
+
+
+def _bounded_agentic_metrics(raw: Optional[dict]) -> Optional[dict]:
+    """Allow only bounded aggregate tool-loop metrics into persisted output."""
+    if not isinstance(raw, dict):
+        return None
+    output = {
+        "schema_version": "1.0",
+        "ledger_cumulative": raw.get("ledger_cumulative") is True,
+        "model_api_calls": bounded_count(raw.get("model_api_calls")),
+        "model_iterations": bounded_count(raw.get("model_iterations")),
+        "tool_calls": bounded_count(raw.get("tool_calls")),
+        "tool_errors": bounded_count(raw.get("tool_errors")),
+        "model_time_ms": bounded_duration_ms(raw.get("model_time_ms")),
+        "tool_time_ms": bounded_duration_ms(raw.get("tool_time_ms")),
+        "task_wall_time_ms": bounded_duration_ms(raw.get("task_wall_time_ms")),
+        "time_to_valid_artifact_ms": bounded_duration_ms(
+            raw.get("time_to_valid_artifact_ms")
+        ),
+        "finalize_required_corrections": bounded_count(
+            raw.get("finalize_required_corrections")
+        ),
+        "finalize_attempts": bounded_count(raw.get("finalize_attempts")),
+        "capability_misses": bounded_count(raw.get("capability_misses")),
+        "recovered_after_tool_error": raw.get("recovered_after_tool_error") is True,
+        "input_tokens": bounded_count(raw.get("input_tokens")),
+        "output_tokens": bounded_count(raw.get("output_tokens")),
+        "cached_tokens": bounded_count(raw.get("cached_tokens")),
+        "usage_complete": raw.get("usage_complete") is True,
+        "terminal_error_category": (
+            str(raw.get("terminal_error_category"))[:80]
+            if raw.get("terminal_error_category")
+            else None
+        ),
+    }
+    calls_by_name = raw.get("tool_calls_by_name")
+    if isinstance(calls_by_name, dict):
+        output["tool_calls_by_name"] = {
+            name: bounded_count(calls_by_name.get(name))
+            for name in (
+                "inspect_workspace", "inspect_environment", "run_python",
+                "run_ffmpeg", "inspect_artifacts", "finalize",
+            )
+            if bounded_count(calls_by_name.get(name)) is not None
+        }
+    try:
+        cost = float(raw.get("conservative_cost_usd", 0))
+    except (TypeError, ValueError):
+        cost = -1
+    if 0 <= cost < float("inf"):
+        output["conservative_cost_usd"] = round(cost, 8)
+    bounded = {key: value for key, value in output.items() if value is not None}
+    bounded["terminal_error_category"] = output["terminal_error_category"]
+    return bounded
+
+
+def _bounded_budget_metrics(raw: Optional[dict]) -> Optional[dict]:
+    if not isinstance(raw, dict):
+        return None
+    output = {
+        "schema_version": "1.0",
+        "model_api_calls": bounded_count(raw.get("model_api_calls")),
+        "input_tokens": bounded_count(raw.get("input_tokens")),
+        "output_tokens": bounded_count(raw.get("output_tokens")),
+        "cached_tokens": bounded_count(raw.get("cached_tokens")),
+        "usage_complete": raw.get("usage_complete") is True,
+        "time_to_valid_artifact_ms": bounded_duration_ms(
+            raw.get("time_to_valid_artifact_ms")
+        ),
+    }
+    try:
+        cost = float(raw.get("conservative_cost_usd", 0))
+    except (TypeError, ValueError):
+        return None
+    if not 0 <= cost < float("inf"):
+        return None
+    output["conservative_cost_usd"] = round(cost, 8)
+    return {
+        key: value for key, value in output.items() if value is not None
+    }
+
+
+def _bounded_substrate_manifest(raw: Optional[dict]) -> Optional[dict]:
+    if not isinstance(raw, dict):
+        return None
+    hash_pattern = re.compile(r"^[0-9a-f]{64}$")
+    if hash_pattern.fullmatch(str(raw.get("sha256", ""))) is None:
+        return None
+    component_names = (
+        "python_launcher", "ffmpeg_mapper", "verifier", "outer_seccomp",
+        "capabilities", "core_tree",
+    )
+    raw_components = raw.get("component_sha256")
+    if not isinstance(raw_components, dict):
+        return None
+    components = {
+        name: value
+        for name in component_names
+        if isinstance((value := raw_components.get(name)), str)
+        and hash_pattern.fullmatch(value)
+    }
+    if set(components) != set(component_names):
+        return None
+    output = {
+        "schema_version": "1.0",
+        "sha256": raw["sha256"],
+        "task_image": str(raw.get("task_image", ""))[:300],
+        "task_image_id": str(raw.get("task_image_id", ""))[:100],
+        "verifier_image": str(raw.get("verifier_image", ""))[:300],
+        "verifier_image_id": str(raw.get("verifier_image_id", ""))[:100],
+        "component_sha256": components,
+        "sbom_sha256": str(raw.get("sbom_sha256", ""))[:64],
+        "uid": bounded_count(raw.get("uid")),
+        "gid": bounded_count(raw.get("gid")),
+        "network": raw.get("network"),
+        "ipc": raw.get("ipc"),
+        "pid_namespace": raw.get("pid_namespace"),
+        "read_only_rootfs": raw.get("read_only_rootfs") is True,
+        "cap_drop": ["ALL"] if raw.get("cap_drop") == ["ALL"] else [],
+        "no_new_privileges": raw.get("no_new_privileges") is True,
+        "memory_bytes": _bounded_resource_integer(
+            raw.get("memory_bytes"), 16 * 1024 * 1024 * 1024
+        ),
+        "memory_swap_bytes": _bounded_resource_integer(
+            raw.get("memory_swap_bytes"), 16 * 1024 * 1024 * 1024
+        ),
+        "pids": bounded_count(raw.get("pids")),
+        "nofile": bounded_count(raw.get("nofile")),
+        "apparmor_profile": str(raw.get("apparmor_profile", ""))[:100],
+    }
+    cpus = raw.get("cpus")
+    if isinstance(cpus, (int, float)) and not isinstance(cpus, bool) and 0 < cpus <= 2:
+        output["cpus"] = float(cpus)
+    work = raw.get("work_tmpfs")
+    if isinstance(work, dict):
+        output["work_tmpfs"] = {
+            "size_bytes": _bounded_resource_integer(
+                work.get("size_bytes"), 2 * 1024 * 1024 * 1024
+            ),
+            "nr_inodes": bounded_count(work.get("nr_inodes")),
+            "nosuid": work.get("nosuid") is True,
+            "nodev": work.get("nodev") is True,
+            "noexec": work.get("noexec") is True,
+        }
+    return output
+
+
+def _bounded_resource_integer(value, maximum: int) -> Optional[int]:
+    if type(value) is not int or not 0 <= value <= maximum:
+        return None
+    return value
+
+
+def _merge_agentic_metrics(
+    previous: Optional[dict], current: Optional[dict]
+) -> Optional[dict]:
+    previous = _bounded_agentic_metrics(previous)
+    current = _bounded_agentic_metrics(current)
+    if not previous:
+        return current
+    if not current:
+        return previous
+    ledger_cumulative = current.get("ledger_cumulative") is True
+    merged = {
+        "schema_version": "1.0",
+        "ledger_cumulative": ledger_cumulative,
+    }
+    for key in ("model_api_calls", "input_tokens", "output_tokens"):
+        if ledger_cumulative:
+            merged[key] = max(
+                previous.get(key, 0) or 0,
+                current.get(key, 0) or 0,
+            )
+        else:
+            combined = add_counts(
+                previous.get(key, 0) or 0,
+                current.get(key, 0) or 0,
+            )
+            if combined is None:
+                return current
+            merged[key] = combined
+    for key in (
+        "model_iterations", "tool_calls", "tool_errors",
+        "finalize_required_corrections", "finalize_attempts",
+        "capability_misses", "cached_tokens",
+    ):
+        combined = add_counts(
+            previous.get(key, 0) or 0,
+            current.get(key, 0) or 0,
+        )
+        if combined is None:
+            return current
+        merged[key] = combined
+    for key in ("model_time_ms", "tool_time_ms", "task_wall_time_ms"):
+        combined = add_durations_ms(
+            previous.get(key, 0) or 0,
+            current.get(key, 0) or 0,
+        )
+        if combined is None:
+            return current
+        merged[key] = combined
+    merged["time_to_valid_artifact_ms"] = (
+        previous.get("time_to_valid_artifact_ms")
+        if previous.get("time_to_valid_artifact_ms") is not None
+        else current.get("time_to_valid_artifact_ms")
+    )
+    tool_names = (
+        "inspect_workspace", "inspect_environment", "run_python",
+        "run_ffmpeg", "inspect_artifacts", "finalize",
+    )
+    previous_calls = previous.get("tool_calls_by_name") or {}
+    current_calls = current.get("tool_calls_by_name") or {}
+    merged["tool_calls_by_name"] = {}
+    for name in tool_names:
+        combined = add_counts(
+            previous_calls.get(name, 0) or 0,
+            current_calls.get(name, 0) or 0,
+        )
+        if combined:
+            merged["tool_calls_by_name"][name] = combined
+    merged["usage_complete"] = (
+        previous.get("usage_complete") is True
+        and current.get("usage_complete") is True
+    )
+    merged["recovered_after_tool_error"] = (
+        previous.get("recovered_after_tool_error") is True
+        or current.get("recovered_after_tool_error") is True
+        or (
+            (previous.get("tool_errors", 0) or 0) > 0
+            and not current.get("terminal_error_category")
+        )
+    )
+    merged["terminal_error_category"] = current.get(
+        "terminal_error_category"
+    )
+    merged["conservative_cost_usd"] = max(
+        float(previous.get("conservative_cost_usd", 0) or 0),
+        float(current.get("conservative_cost_usd", 0) or 0),
+    )
+    return _bounded_agentic_metrics(merged) or current
 
 
 def _bounded_execution_metrics(raw: Optional[dict]) -> Optional[dict]:
@@ -763,20 +1037,80 @@ def _save_files(files: List[dict], task_id: str) -> List[str]:
     """Save generated files to workspace/upload/deliverable_files/<task_id>/."""
     if not files:
         return []
+    if (
+        not isinstance(task_id, str)
+        or not task_id
+        or task_id in {".", ".."}
+        or task_id.startswith(".")
+        or "/" in task_id
+        or "\\" in task_id
+        or len(task_id.encode("utf-8")) > 240
+    ):
+        raise ValueError("deliverable task ID is invalid")
 
+    DELIVERABLE_DIR.mkdir(parents=True, exist_ok=True)
+    root_metadata = DELIVERABLE_DIR.lstat()
+    if not stat.S_ISDIR(root_metadata.st_mode):
+        raise ValueError("deliverable root is not a directory")
     output_dir = DELIVERABLE_DIR / task_id
-    output_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(mode=0o700, exist_ok=True)
+    output_metadata = output_dir.lstat()
+    if not stat.S_ISDIR(output_metadata.st_mode):
+        raise ValueError("deliverable task path is not a directory")
+
+    prepared = []
+    seen: set[str] = set()
+    for file_data in files:
+        if not isinstance(file_data, dict) or set(file_data) != {"filename", "content"}:
+            raise ValueError("deliverable file record is invalid")
+        filename = file_data["filename"]
+        if not isinstance(filename, str) or "\\" in filename:
+            raise ValueError("deliverable filename is invalid")
+        relative = Path(filename)
+        canonical = relative.as_posix()
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or canonical != filename
+            or ".." in relative.parts
+            or any(part.startswith(".") for part in relative.parts)
+            or len(relative.parts) > 16
+            or len(canonical.encode("utf-8")) > 240
+            or canonical in seen
+        ):
+            raise ValueError("deliverable filename is invalid or duplicated")
+        content = file_data["content"]
+        if isinstance(content, str):
+            encoded = content.encode("utf-8")
+        elif isinstance(content, bytes):
+            encoded = content
+        else:
+            raise ValueError("deliverable content must be bytes or text")
+        seen.add(canonical)
+        prepared.append((relative, encoded))
 
     saved_paths = []
-    for file_data in files:
-        filename = file_data["filename"]
-        content = file_data["content"]
-        filepath = output_dir / filename
-
-        if isinstance(content, bytes):
-            filepath.write_bytes(content)
-        else:
-            filepath.write_bytes(content.encode("utf-8"))
+    for relative, content in prepared:
+        parent = output_dir
+        for part in relative.parts[:-1]:
+            parent /= part
+            parent.mkdir(mode=0o700, exist_ok=True)
+            metadata = parent.lstat()
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise ValueError("deliverable parent is not a directory")
+        filepath = output_dir / relative
+        if filepath.exists() or filepath.is_symlink():
+            metadata = filepath.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise ValueError("deliverable target is not a single-link file")
+        descriptor = os.open(
+            filepath,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+        )
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(content)
 
         try:
             rel_path = filepath.relative_to(UPLOAD_DIR)
@@ -862,6 +1196,9 @@ def _execute_single_task(
     manifest: Optional[NeedsFilesManifest] = None,
     error_context: Optional[str] = None,
     verbose: bool = False,
+    run_id: Optional[str] = None,
+    condition_name: Optional[str] = None,
+    strict_inputs: bool = False,
 ) -> dict:
     """Execute a single task and return result dict."""
     task_id = task_info["task_id"]
@@ -922,16 +1259,35 @@ def _execute_single_task(
     # Resolve reference file paths to absolute + validate existence
     abs_ref_files = None
     ref_files = task_info.get("reference_files", [])
+    missing_ref_files = []
     if ref_files:
-        abs_ref_files = []
-        for ref_path in ref_files:
-            abs_path = DEFAULT_LOCAL_PATH / ref_path
-            if abs_path.exists():
-                abs_ref_files.append(str(abs_path))
-            else:
-                print(f"      ⚠️  Reference file not found: {abs_path}")
-        if not abs_ref_files:
-            abs_ref_files = None  # all missing → treat as no files
+        if strict_inputs:
+            abs_ref_files = list(ref_files)
+        else:
+            abs_ref_files = []
+            for ref_path in ref_files:
+                abs_path = DEFAULT_LOCAL_PATH / ref_path
+                if abs_path.exists():
+                    abs_ref_files.append(str(abs_path))
+                else:
+                    missing_ref_files.append(ref_path)
+                    print(f"      ⚠️  Reference file not found: {abs_path}")
+            if not abs_ref_files:
+                abs_ref_files = None  # all missing → treat as no files
+    if strict_inputs and missing_ref_files:
+        return {
+            "task_id": task_id,
+            "status": "error",
+            "error": "approved_reference_input_missing",
+            "content": None,
+            "deliverable_text": None,
+            "deliverable_files": [],
+            "model": model,
+            "usage": None,
+            "observability": _build_execution_observability(None, []),
+            "latency_ms": None,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
 
     # ── Preprocessor: enrich prompt with audio/video analysis (if configured) ──
     preprocessor_observations: list[dict] = []
@@ -943,7 +1299,7 @@ def _execute_single_task(
     )
     perception_text = None
     if preprocessor_prefix:
-        if execution_mode == "sandbox":
+        if execution_mode in {"sandbox", "agentic_sandbox"}:
             # Sandbox owns perception PLACEMENT via its `perception_analysis` spec
             # section (prompts/sandbox_occupation_codegen.yaml), so pass the block
             # through rather than prepending it here. This is byte-equivalent to the
@@ -995,6 +1351,9 @@ def _execute_single_task(
             experiment_prompt=experiment_prompt,
             verbose=verbose,
             perception_text=perception_text,
+            run_id=run_id,
+            condition_name=condition_name,
+            task_id=task_id,
         )
         latency_ms = (time.time() - start) * 1000
 
@@ -1088,16 +1447,30 @@ def _save_progress(
     results: List[dict],
     started_at: str,
     path: Path,
+    *,
+    run_id: str,
+    condition_identity: str,
+    ordered_task_ids: List[str],
+    resume_round: int = 0,
 ) -> None:
     """Atomic incremental save."""
+    _validate_result_task_set(
+        results, ordered_task_ids, allow_missing=True
+    )
     success = sum(1 for r in results if r.get("status") == "success")
     error = sum(1 for r in results if r.get("status") == "error")
 
     data = {
+        "schema_version": "step2-progress-v2",
         "experiment_id": experiment_id,
         "condition": condition_name,
+        "condition_identity": condition_identity,
+        "run_id": run_id,
         "execution_mode": execution_mode,
+        "ordered_task_ids": ordered_task_ids,
+        "total_tasks": total_tasks,
         "started_at": started_at,
+        "resume_round": resume_round,
         "summary": {
             "total": total_tasks,
             "completed": len(results),
@@ -1118,6 +1491,75 @@ def _save_progress(
             allow_nan=False,
         )
     tmp_path.rename(path)
+
+
+def _load_and_validate_progress(
+    path: Path,
+    *,
+    experiment_id: str,
+    condition_name: str,
+    condition_identity: str,
+    run_id: str,
+    execution_mode: str,
+    ordered_task_ids: List[str],
+) -> dict:
+    with path.open("r", encoding="utf-8") as stream:
+        progress = json.load(stream)
+    if not isinstance(progress, dict):
+        raise ValueError("progress checkpoint must be an object")
+    expected_identity = {
+        "schema_version": "step2-progress-v2",
+        "experiment_id": experiment_id,
+        "condition": condition_name,
+        "condition_identity": condition_identity,
+        "run_id": run_id,
+        "execution_mode": execution_mode,
+        "ordered_task_ids": ordered_task_ids,
+        "total_tasks": len(ordered_task_ids),
+    }
+    if any(progress.get(key) != value for key, value in expected_identity.items()):
+        raise ValueError("progress checkpoint identity mismatch")
+    results = progress.get("results")
+    if not isinstance(results, list):
+        raise ValueError("progress checkpoint results must be a list")
+    _validate_result_task_set(results, ordered_task_ids, allow_missing=True)
+    indexed = {result["task_id"]: result for result in results}
+    timestamp = datetime.now(timezone.utc).isoformat()
+    progress["results"] = [
+        indexed.get(task_id, {
+            "task_id": task_id,
+            "status": "pending",
+            "error": "checkpoint_missing_task",
+            "timestamp": timestamp,
+        })
+        for task_id in ordered_task_ids
+    ]
+    return progress
+
+
+def _validate_result_task_set(
+    results: List[dict],
+    ordered_task_ids: List[str],
+    *,
+    allow_missing: bool,
+) -> None:
+    if (
+        not ordered_task_ids
+        or len(ordered_task_ids) != len(set(ordered_task_ids))
+        or any(not isinstance(task_id, str) or not task_id for task_id in ordered_task_ids)
+    ):
+        raise ValueError("ordered task identity is invalid")
+    result_ids = []
+    for result in results:
+        if not isinstance(result, dict) or not isinstance(result.get("task_id"), str):
+            raise ValueError("progress result task identity is invalid")
+        result_ids.append(result["task_id"])
+    if len(result_ids) != len(set(result_ids)):
+        raise ValueError("progress checkpoint contains duplicate task IDs")
+    if not set(result_ids) <= set(ordered_task_ids):
+        raise ValueError("progress checkpoint contains unexpected task IDs")
+    if not allow_missing and result_ids != ordered_task_ids:
+        raise ValueError("final result task IDs differ from ordered task set")
 
 
 # ── Progress helpers ───────────────────────────────────────────────────────
@@ -1147,6 +1589,19 @@ def _update_progress_result(progress: dict, new_result: dict) -> dict:
             merged_metrics = _merge_execution_metrics(previous_metrics, current_metrics)
             if merged_metrics:
                 new_result.setdefault("observability", {})["execution_metrics"] = merged_metrics
+            previous_agentic = (r.get("observability") or {}).get(
+                "agentic_metrics"
+            )
+            current_agentic = (new_result.get("observability") or {}).get(
+                "agentic_metrics"
+            )
+            merged_agentic = _merge_agentic_metrics(
+                previous_agentic, current_agentic
+            )
+            if merged_agentic:
+                new_result.setdefault("observability", {})[
+                    "agentic_metrics"
+                ] = merged_agentic
             updated.append(new_result)
             replaced = True
         else:
@@ -1222,6 +1677,41 @@ def run_inference(
     }
     # Sandbox-mode settings (execution.sandbox block in the experiment YAML).
     sandbox_options = execution_cfg.get("sandbox", {}) or {}
+    agentic_options = execution_cfg.get("agentic", {}) or {}
+    hardened_requested = (
+        execution_mode == "agentic_sandbox"
+        or (
+            execution_mode == "sandbox"
+            and sandbox_options.get("hardened_substrate") is True
+        )
+    )
+    if hardened_requested:
+        try:
+            validate_agentic_experiment_identity(
+                experiment_id,
+                execution_mode,
+                hardened_baseline=(
+                    execution_mode == "sandbox"
+                    and sandbox_options.get("hardened_substrate") is True
+                ),
+            )
+            agentic_options = _load_private_agentic_config(prepared)
+            validate_agentic_budget_for_experiment(
+                experiment_id, agentic_options.get("budget")
+            )
+            if condition_key != "condition_a" or prepared.get("condition_b") is not None:
+                raise ValueError(
+                    "reserved hardened experiments require exactly condition_a"
+                )
+        except Exception as exc:
+            print("❌ failed to reload hardened execution config")
+            print(f"   {exc}")
+            sys.exit(1)
+    execution_condition = (
+        agentic_condition_identity(experiment_id)
+        if hardened_requested
+        else condition_key
+    )
     metrics_cfg_raw = execution_cfg.get("metrics")
     metrics_cfg = metrics_cfg_raw if isinstance(metrics_cfg_raw, dict) else {}
     metrics_enabled = metrics_cfg.get("enabled") is True
@@ -1284,10 +1774,74 @@ def run_inference(
               f"max_retries={qa_max_retries}, model={qa_model}, "
               f"max_tokens={qa_max_tokens})")
 
-    # 2. Create LLM client (provider-aware)
+    # 2. Create LLM client (provider-aware). Agentic mode defers construction
+    # until its compute preflight and signed approval gate pass.
     provider = condition.get("model", {}).get("provider", "azure")
+    validation_provider = "azure" if provider == "azure_openai" else provider
+    if (
+        (
+            execution_mode == "agentic_sandbox"
+            or (
+                execution_mode == "sandbox"
+                and sandbox_options.get("hardened_substrate") is True
+            )
+        )
+        and validation_provider not in {"azure", "openai"}
+    ):
+        print(
+            "❌ agentic_sandbox mode requires OpenAI/Azure OpenAI, "
+            f"got {provider}"
+        )
+        sys.exit(1)
 
-    if provider in ("azure", "azure_openai"):
+    client_factory = None
+    hardened_baseline = (
+        execution_mode == "sandbox"
+        and sandbox_options.get("hardened_substrate") is True
+    )
+
+    if execution_mode == "agentic_sandbox" or hardened_baseline:
+        if condition.get("qa", {}).get("enabled"):
+            print("❌ paired hardened modes disable Self-QA until it shares the signed budget ledger")
+            sys.exit(1)
+        if condition.get("preprocessors"):
+            print("❌ paired hardened modes disable preprocessors until they share the signed budget ledger")
+            sys.exit(1)
+
+        authorization_config = agentic_options.get("authorization") or {}
+        approved_api_version = authorization_config.get("api_version")
+        if provider in ("azure", "azure_openai"):
+            approved_endpoint = (
+                os.getenv("AZURE_OPENAI_ENDPOINT") or os.getenv("AZURE_ENDPOINT")
+            )
+            def client_factory():
+                if not approved_endpoint:
+                    raise RuntimeError("Missing AZURE_OPENAI_ENDPOINT")
+                return create_provider_client(
+                    "azure",
+                    endpoint=approved_endpoint,
+                    api_version=approved_api_version,
+                    max_retries=0,
+                )
+        elif provider == "openai":
+            approved_endpoint = "https://api.openai.com/v1"
+            def client_factory():
+                api_key = os.getenv("OPENAI_API_KEY")
+                if not api_key:
+                    raise RuntimeError("Missing OPENAI_API_KEY")
+                return create_provider_client(
+                    "openai",
+                    endpoint=approved_endpoint,
+                    api_key=api_key,
+                    max_retries=0,
+                )
+        else:
+            print(f"❌ paired hardened modes do not support provider '{provider}'")
+            sys.exit(1)
+        client = None
+        print("   Client:             deferred until signed hardened preflight")
+
+    elif provider in ("azure", "azure_openai"):
         endpoint = os.getenv("AZURE_OPENAI_ENDPOINT") or os.getenv("AZURE_ENDPOINT")
         if not endpoint:
             print("❌ Missing AZURE_OPENAI_ENDPOINT. Set AZURE_OPENAI_ENDPOINT env var.")
@@ -1317,12 +1871,39 @@ def run_inference(
 
     # 3. Initialize executor (no silent fallback — fail loudly)
     reasoning_effort = condition.get("model", {}).get("reasoning_effort")
+    if hardened_requested:
+        aggregate_budget = agentic_options.get("budget")
+        run_identity = (
+            aggregate_budget.get("paired_run_id")
+            if isinstance(aggregate_budget, dict)
+            else None
+        )
+        if not isinstance(run_identity, str) or not run_identity:
+            print("❌ hardened execution requires budget.paired_run_id")
+            sys.exit(1)
+        workflow_audit = (
+            f"{os.getenv('GITHUB_RUN_ID', 'local')}:"
+            f"{os.getenv('GITHUB_RUN_ATTEMPT', '1')}"
+        )
+        print(f"   Paired run:         {run_identity}")
+        print(f"   Workflow audit:     {workflow_audit}")
+    else:
+        github_run = os.getenv("GITHUB_RUN_ID", "local")
+        github_attempt = os.getenv("GITHUB_RUN_ATTEMPT", "1")
+        run_identity = f"{experiment_id}:{github_run}:{github_attempt}"
     try:
         executor = TaskExecutor(
             mode=execution_mode, llm_client=client, tokens=tokens_cfg,
             timeout=timeout, reasoning_effort=reasoning_effort,
             sandbox_options=sandbox_options,
             metrics_options=metrics_cfg,
+            provider=provider,
+            client_factory=client_factory,
+            agentic_options=agentic_options,
+            agentic_endpoint=(approved_endpoint if hardened_requested else None),
+            run_id=run_identity,
+            condition_name=execution_condition,
+            model_name=model,
         )
     except Exception as e:
         print(f"❌ Executor init failed for mode '{execution_mode}': {e}")
@@ -1339,9 +1920,28 @@ def run_inference(
 
     # 5. Build task lookup
     task_map = {t["task_id"]: t for t in tasks}
+    ordered_task_ids = [t["task_id"] for t in tasks]
+    if len(task_map) != len(tasks):
+        print("❌ prepared task set contains duplicate task IDs")
+        sys.exit(1)
     total = len(tasks)
     progress_path = WORKSPACE_DIR / "step2_inference_progress.json"
     started_at = datetime.now(timezone.utc).isoformat()
+
+    def _persist_progress(current: dict) -> None:
+        _save_progress(
+            experiment_id,
+            condition_name,
+            execution_mode,
+            total,
+            current["results"],
+            started_at,
+            progress_path,
+            run_id=run_identity,
+            condition_identity=execution_condition,
+            ordered_task_ids=ordered_task_ids,
+            resume_round=int(current.get("resume_round", 0) or 0),
+        )
 
     # ── Helper: execute one task with QA loop ──
 
@@ -1416,9 +2016,39 @@ def run_inference(
             nonlocal tool_call_count, validated_artifact_count
             nonlocal time_to_valid_artifact_ms
             execution_attempt_count += 1
+            task_observability = task_result.get("observability") or {}
             raw = _bounded_execution_metrics(
-                (task_result.get("observability") or {}).get("execution_metrics")
+                task_observability.get("execution_metrics")
             ) or {}
+            agentic = _bounded_agentic_metrics(
+                task_observability.get("agentic_metrics")
+            ) or {}
+            budget = _bounded_budget_metrics(
+                task_observability.get("budget_metrics")
+            ) or {}
+            if agentic and not raw:
+                raw = {
+                    "model_time_ms": agentic.get("model_time_ms", 0),
+                    "tool_time_ms": agentic.get("tool_time_ms", 0),
+                    "tool_call_count": agentic.get("tool_calls", 0),
+                    "time_to_valid_artifact_ms": agentic.get(
+                        "time_to_valid_artifact_ms"
+                    ),
+                    "validated_artifact_count": (
+                        1
+                        if (
+                            task_result.get("status") == "success"
+                            and task_result.get("deliverable_files")
+                            and agentic.get("terminal_error_category") is None
+                            and (agentic.get("finalize_attempts", 0) or 0) > 0
+                        )
+                        else 0
+                    ),
+                }
+            if budget.get("time_to_valid_artifact_ms") is not None:
+                raw["time_to_valid_artifact_ms"] = budget[
+                    "time_to_valid_artifact_ms"
+                ]
             sandbox_attempt_count += int(
                 raw.get("sandbox_attempt_count", raw.get("attempt_count", 0)) or 0
             )
@@ -1429,17 +2059,29 @@ def run_inference(
             )
             for key in phase_totals:
                 phase_totals[key] += float(raw.get(key, 0) or 0)
-            sandbox_observability = (task_result.get("observability") or {}).get("sandbox")
+            measured_valid_time = raw.get("time_to_valid_artifact_ms")
+            if (
+                time_to_valid_artifact_ms is None
+                and measured_valid_time is not None
+            ):
+                time_to_valid_artifact_ms = float(measured_valid_time)
+            sandbox_observability = task_observability.get("sandbox")
             sandbox_valid = (
                 isinstance(sandbox_observability, dict)
                 and sandbox_observability.get("final_status") in {"ok", "repaired_ok"}
+                and int(raw.get("validated_artifact_count", 0) or 0) > 0
+            )
+            agentic_valid = (
+                bool(agentic)
+                and agentic.get("terminal_error_category") is None
+                and (agentic.get("finalize_attempts", 0) or 0) > 0
                 and int(raw.get("validated_artifact_count", 0) or 0) > 0
             )
             if (
                 time_to_valid_artifact_ms is None
                 and task_result.get("status") == "success"
                 and task_result.get("deliverable_files")
-                and sandbox_valid
+                and (sandbox_valid or agentic_valid)
             ):
                 time_to_valid_artifact_ms = round(
                     (time.perf_counter() - job_started) * 1000,
@@ -1502,6 +2144,9 @@ def run_inference(
                     client, model, manifest,
                     error_context=last_qa_feedback,
                     verbose=verbose,
+                    run_id=run_identity,
+                    condition_name=execution_condition,
+                    strict_inputs=hardened_requested,
                 )
                 if metrics_enabled:
                     _record_execution_metrics(result)
@@ -1667,8 +2312,19 @@ def run_inference(
 
     progress = None
     if resume and progress_path.exists():
-        with open(progress_path, "r", encoding="utf-8") as f:
-            progress = json.load(f)
+        try:
+            progress = _load_and_validate_progress(
+                progress_path,
+                experiment_id=experiment_id,
+                condition_name=condition_name,
+                condition_identity=execution_condition,
+                run_id=run_identity,
+                execution_mode=execution_mode,
+                ordered_task_ids=ordered_task_ids,
+            )
+        except Exception as exc:
+            print(f"❌ progress checkpoint rejected: {exc}")
+            sys.exit(1)
 
         # Relay duration fix: preserve original started_at from first run
         if "started_at" in progress:
@@ -1710,10 +2366,7 @@ def run_inference(
                             existing["status"] = "pending"
                             existing["error"] = "wall_timeout"
                             existing["timestamp"] = pending_timestamp
-                    _save_progress(
-                        experiment_id, condition_name, execution_mode,
-                        total, progress["results"], started_at, progress_path,
-                    )
+                    _persist_progress(progress)
                     print(f"   💾 Checkpoint saved to {progress_path}")
                     sys.exit(EXIT_CHECKPOINT)
 
@@ -1729,10 +2382,7 @@ def run_inference(
                 if (i + 1) % 20 == 0:
                     gc.collect()
 
-                _save_progress(
-                    experiment_id, condition_name, execution_mode,
-                    total, progress["results"], started_at, progress_path,
-                )
+                _persist_progress(progress)
 
             # After relay, set progress so we skip to resume rounds
             # (progress is now not None, so initial run block is skipped)
@@ -1741,9 +2391,13 @@ def run_inference(
         # === INITIAL RUN: 모든 태스크 실행 ===
         print(f"\n── Round 0: Initial Run ({total} tasks) ──")
         progress = {
+            "schema_version": "step2-progress-v2",
             "experiment_id": experiment_id,
             "condition": condition_name,
+            "condition_identity": execution_condition,
+            "run_id": run_identity,
             "execution_mode": execution_mode,
+            "ordered_task_ids": ordered_task_ids,
             "total_tasks": total,
             "started_at": started_at,
             "resume_round": 0,
@@ -1764,10 +2418,7 @@ def run_inference(
                         "error": "wall_timeout",
                         "timestamp": datetime.now(timezone.utc).isoformat(),
                     })
-                _save_progress(
-                    experiment_id, condition_name, execution_mode,
-                    total, progress["results"], started_at, progress_path,
-                )
+                _persist_progress(progress)
                 print(f"   💾 Checkpoint saved to {progress_path}")
                 sys.exit(EXIT_CHECKPOINT)
 
@@ -1785,10 +2436,7 @@ def run_inference(
                 gc.collect()
 
             # Incremental save
-            _save_progress(
-                experiment_id, condition_name, execution_mode,
-                total, progress["results"], started_at, progress_path,
-            )
+            _persist_progress(progress)
 
     # ══════════════════════════════════════════════════════════════════════
     # 7. Resume rounds: progress.json의 error 태스크를 자동 재실행
@@ -1824,10 +2472,7 @@ def run_inference(
                         r["error"] = "wall_timeout"
                         r["timestamp"] = datetime.now(timezone.utc).isoformat()
                 progress["resume_round"] = round_num
-                _save_progress(
-                    experiment_id, condition_name, execution_mode,
-                    total, progress["results"], started_at, progress_path,
-                )
+                _persist_progress(progress)
                 print(f"   💾 Checkpoint saved to {progress_path}")
                 sys.exit(EXIT_CHECKPOINT)
 
@@ -1854,10 +2499,7 @@ def run_inference(
                 gc.collect()
 
             # Incremental save
-            _save_progress(
-                experiment_id, condition_name, execution_mode,
-                total, progress["results"], started_at, progress_path,
-            )
+            _persist_progress(progress)
 
             if result["status"] == "success":
                 recovered += 1
@@ -1876,6 +2518,9 @@ def run_inference(
     # ══════════════════════════════════════════════════════════════════════
 
     results = progress.get("results", [])
+    _validate_result_task_set(
+        results, ordered_task_ids, allow_missing=False
+    )
     success = sum(1 for r in results if r["status"] == "success")
     errors = sum(1 for r in results if r["status"] == "error")
     qa_failed = sum(1 for r in results if r.get("status") == "qa_failed")
@@ -1885,7 +2530,10 @@ def run_inference(
         "experiment_name": prepared.get("experiment_name", ""),
         "source": prepared.get("source", ""),
         "condition": condition_name,
+        "condition_identity": execution_condition,
+        "run_id": run_identity,
         "execution_mode": execution_mode,
+        "ordered_task_ids": ordered_task_ids,
         "model": model,
         "started_at": started_at,
         "completed_at": datetime.now(timezone.utc).isoformat(),

--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -32,9 +32,9 @@ from typing import Any
 _SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPT_DIR))
 
-from core.config import NEEDS_FILES_POLICIES_KNOWN, WORKSPACE_DIR
-from core.execution_metrics import bounded_count, bounded_duration_ms
-from core.narrative_analyzer import (
+from core.config import NEEDS_FILES_POLICIES_KNOWN, WORKSPACE_DIR  # noqa: E402
+from core.execution_metrics import bounded_count, bounded_duration_ms  # noqa: E402
+from core.narrative_analyzer import (  # noqa: E402
     _build_grade_source,
     _build_grading_guard_clause,
     _build_grading_results_section,
@@ -678,8 +678,8 @@ def _build_markdown(rd: dict) -> str:
     lines += [
         f"# Experiment Report: {meta['experiment_name']}",
         "",
-        f"| Field | Value |",
-        f"|-------|-------|",
+        "| Field | Value |",
+        "|-------|-------|",
         f"| **Experiment ID** | `{experiment_id}` |",
         f"| **Condition** | {meta['condition_name']} |",
         f"| **Model** | {meta['model']} |",
@@ -689,7 +689,7 @@ def _build_markdown(rd: dict) -> str:
         f"| **Generated At** | {rd['generated_at']} |",
         f"| 🤗 HF Dataset | [{experiment_id}]({hf_base}) |",
         f"| 📊 Self-Report | [self_report.json]({hf_base}/blob/main/self_report.json) |",
-        f"| 📊 Grading | ⏳ Awaiting (`scores.json`) |",
+        "| 📊 Grading | ⏳ Awaiting (`scores.json`) |",
         "",
     ]
 
@@ -1307,7 +1307,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
                   f"{result.total_tokens['input']:,}+{result.total_tokens['output']:,} tokens)")
         except Exception as exc:
             print(f"   ⚠️ Pro narrative failed: {exc}")
-            print(f"   Falling back to standard narrative…")
+            print("   Falling back to standard narrative…")
             narrative = _generate_narrative(data, summary, sector_breakdown, grade=grade)
 
     # Build report_data.json
@@ -1377,7 +1377,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
         shutil.copy2(json_path, self_report_path)
         print(f"   ✓ Copied self_report.json → {self_report_path}")
 
-    print(f"\n✅ Step 6 complete:")
+    print("\n✅ Step 6 complete:")
     print(f"   {json_path}")
     print(f"   {md_path}")
     print(f"\n   Tasks: {summary['total_tasks']}  "

--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import shutil
 import sys
 from collections import defaultdict
@@ -242,6 +243,110 @@ def _compute_execution_metrics(data: dict) -> dict | None:
     }
 
 
+def _compute_agentic_metrics(data: dict) -> dict | None:
+    """Aggregate privacy-bounded agentic metrics; omit for legacy runs."""
+    results = data.get("results", [])
+    measured: list[tuple[dict, dict, float]] = []
+    for result in results:
+        raw = (result.get("observability") or {}).get("agentic_metrics")
+        if not isinstance(raw, dict):
+            continue
+        wall_time = _metric_number(raw.get("task_wall_time_ms"))
+        if wall_time is not None:
+            measured.append((result, raw, wall_time))
+    if not measured:
+        return None
+
+    def count(field: str) -> int:
+        return sum(
+            value
+            for _, raw, _ in measured
+            if (value := bounded_count(raw.get(field))) is not None
+        )
+
+    tool_times = [
+        value
+        for _, raw, _ in measured
+        if (value := _metric_number(raw.get("tool_time_ms"))) is not None
+    ]
+    total_tool_calls = count("tool_calls")
+    total_tool_errors = count("tool_errors")
+    tasks_with_tool_errors = sum(
+        1
+        for _, raw, _ in measured
+        if (bounded_count(raw.get("tool_errors")) or 0) > 0
+    )
+    recovered_tasks = sum(
+        1
+        for result, raw, _ in measured
+        if result.get("status") == "success"
+        and raw.get("recovered_after_tool_error") is True
+    )
+    tool_names = (
+        "inspect_workspace", "inspect_environment", "run_python",
+        "run_ffmpeg", "inspect_artifacts", "finalize",
+    )
+    calls_by_name = {name: 0 for name in tool_names}
+    terminal_categories: dict[str, int] = {}
+    conservative_cost = 0.0
+    for _, raw, _ in measured:
+        raw_calls = raw.get("tool_calls_by_name")
+        if isinstance(raw_calls, dict):
+            for name in tool_names:
+                calls_by_name[name] += bounded_count(raw_calls.get(name)) or 0
+        category = raw.get("terminal_error_category")
+        if isinstance(category, str) and category and len(category) <= 80:
+            terminal_categories[category] = terminal_categories.get(category, 0) + 1
+        value = raw.get("conservative_cost_usd")
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+            and 0 <= value <= 1_000_000
+        ):
+            conservative_cost += float(value)
+
+    usage_complete_tasks = sum(
+        1 for _, raw, _ in measured if raw.get("usage_complete") is True
+    )
+    return {
+        "schema_version": "1.0",
+        "measured_tasks": len(measured),
+        "total_tasks": len(results),
+        "coverage_pct": round(len(measured) / len(results) * 100, 1)
+        if results else 0.0,
+        "total_model_api_calls": count("model_api_calls"),
+        "total_model_iterations": count("model_iterations"),
+        "total_tool_calls": total_tool_calls,
+        "total_tool_errors": total_tool_errors,
+        "tool_error_rate_pct": round(
+            total_tool_errors / total_tool_calls * 100, 2
+        ) if total_tool_calls else 0.0,
+        "tasks_with_tool_errors": tasks_with_tool_errors,
+        "recovered_tasks": recovered_tasks,
+        "recovery_rate_pct": round(
+            recovered_tasks / tasks_with_tool_errors * 100, 2
+        ) if tasks_with_tool_errors else 0.0,
+        "total_finalize_attempts": count("finalize_attempts"),
+        "total_finalize_required_corrections": count(
+            "finalize_required_corrections"
+        ),
+        "total_capability_misses": count("capability_misses"),
+        "p50_tool_time_ms": _percentile(tool_times, 0.50),
+        "p95_tool_time_ms": _percentile(tool_times, 0.95),
+        "total_input_tokens": count("input_tokens"),
+        "total_output_tokens": count("output_tokens"),
+        "total_cached_tokens": count("cached_tokens"),
+        "usage_complete_tasks": usage_complete_tasks,
+        "usage_coverage_pct": round(
+            usage_complete_tasks / len(measured) * 100, 1
+        ),
+        "conservative_cost_usd": round(conservative_cost, 8),
+        "tool_calls_by_name": calls_by_name,
+        "terminal_error_categories": dict(sorted(terminal_categories.items())),
+    }
+
+
 def _compute_sector_breakdown(data: dict) -> list[dict]:
     buckets: dict[str, dict[str, Any]] = defaultdict(
         lambda: {"total": 0, "success": 0, "scores": [], "latencies": []}
@@ -419,7 +524,8 @@ Return ONLY valid JSON with these exact keys (no markdown code fences):
 def _build_report_data(data: dict, narrative: dict, summary: dict,
                        sector_breakdown: list[dict], task_results: list[dict],
                        error_tasks: list[dict],
-                       execution_metrics: dict | None = None) -> dict:
+                       execution_metrics: dict | None = None,
+                       agentic_metrics: dict | None = None) -> dict:
     meta_date = (data.get("started_at") or "")[:10]
     report = {
         "meta": {
@@ -450,6 +556,8 @@ def _build_report_data(data: dict, narrative: dict, summary: dict,
         report["narrative_error"] = narrative["_narrative_error"]
     if execution_metrics:
         report["execution_metrics"] = execution_metrics
+    if agentic_metrics:
+        report["agentic_metrics"] = agentic_metrics
     return report
 
 
@@ -600,6 +708,23 @@ def _build_markdown(rd: dict) -> str:
             f"| Avg time to valid artifact | {valid_time:,.0f}ms |" if valid_time is not None else "| Avg time to valid artifact | N/A |",
             f"| Tool calls | {execution_metrics['total_tool_calls']} |",
             f"| Execution attempts | {execution_metrics['total_execution_attempts']} |",
+            "",
+        ]
+
+    agentic_metrics = rd.get("agentic_metrics")
+    if agentic_metrics:
+        lines += [
+            "## Agentic Tool Loop",
+            "",
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Measured tasks | {agentic_metrics['measured_tasks']} / {agentic_metrics['total_tasks']} ({agentic_metrics['coverage_pct']}%) |",
+            f"| Model API calls / iterations | {agentic_metrics['total_model_api_calls']} / {agentic_metrics['total_model_iterations']} |",
+            f"| Tool calls / errors | {agentic_metrics['total_tool_calls']} / {agentic_metrics['total_tool_errors']} ({agentic_metrics['tool_error_rate_pct']}%) |",
+            f"| Recovered tasks | {agentic_metrics['recovered_tasks']} / {agentic_metrics['tasks_with_tool_errors']} ({agentic_metrics['recovery_rate_pct']}%) |",
+            f"| Finalize attempts | {agentic_metrics['total_finalize_attempts']} |",
+            f"| P50 / P95 tool time | {agentic_metrics['p50_tool_time_ms']:,.0f}ms / {agentic_metrics['p95_tool_time_ms']:,.0f}ms |",
+            f"| Conservative model cost | USD {agentic_metrics['conservative_cost_usd']:.4f} |",
             "",
         ]
 
@@ -1143,6 +1268,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
     # Compute metrics
     summary = _compute_summary(data)
     execution_metrics = _compute_execution_metrics(data)
+    agentic_metrics = _compute_agentic_metrics(data)
     sector_breakdown = _compute_sector_breakdown(data)
     manifest = _load_manifest_safe()
     task_results, error_tasks = _build_task_results(data, manifest=manifest)
@@ -1193,6 +1319,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
         task_results,
         error_tasks,
         execution_metrics=execution_metrics,
+        agentic_metrics=agentic_metrics,
     )
 
     # Inject file generation stats from step5_validate.py

--- a/batch-runner/tests/test_agentic_authorization.py
+++ b/batch-runner/tests/test_agentic_authorization.py
@@ -1,0 +1,344 @@
+"""Tests for signed, single-use agentic approval envelopes."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from core.agentic_authorization import (
+    ApprovalExpectation,
+    ApprovalNonceLedger,
+    AuthorizationError,
+    SignedApprovalGate,
+    canonical_json,
+    load_approval_scope,
+    provider_endpoint_sha256,
+)
+
+
+def _expectation():
+    return ApprovalExpectation(
+        plan_sha="a" * 40,
+        implementation_sha="b" * 40,
+        run_id="run-1",
+        condition="treatment",
+        provider="azure",
+        model="deployment",
+        api_version="2025-04-01-preview",
+        endpoint_sha256="9" * 64,
+        workflow_sha="d" * 40,
+        workflow_inputs_sha256="e" * 64,
+        conditions=("treatment",),
+        task_ids=("task-1",),
+        input_merkle_roots={"task-1": "c" * 64},
+        provider_classifications={
+            "task-1": "approved_public_gdpval",
+        },
+        approval_scope_sha256="7" * 64,
+        official_scope_registry_sha256="8" * 64,
+    )
+
+
+def _envelope(now):
+    expected = _expectation()
+    return {
+        "schema_version": "1.0",
+        "plan_sha": expected.plan_sha,
+        "implementation_sha": expected.implementation_sha,
+        "run_id": expected.run_id,
+        "conditions": list(expected.conditions),
+        "task_ids": list(expected.task_ids),
+        "input_merkle_roots": dict(expected.input_merkle_roots),
+        "provider_classifications": dict(expected.provider_classifications),
+        "provider": expected.provider,
+        "model": expected.model,
+        "api_version": expected.api_version,
+        "endpoint_sha256": expected.endpoint_sha256,
+        "workflow_sha": expected.workflow_sha,
+        "workflow_inputs_sha256": expected.workflow_inputs_sha256,
+        "substrate_manifest_sha256": "1" * 64,
+        "price_table_sha256": "2" * 64,
+        "official_scope_excluded": True,
+        "approval_scope_sha256": expected.approval_scope_sha256,
+        "official_scope_registry_sha256": (
+            expected.official_scope_registry_sha256
+        ),
+        "caps": {"cost_usd": "6.25", "api_attempts": 30},
+        "issued_at": (now - timedelta(minutes=1)).isoformat(),
+        "expires_at": (now + timedelta(minutes=10)).isoformat(),
+        "nonce": "single-use-nonce-" + "f" * 32,
+    }
+
+
+def _write_signed(tmp_path, envelope):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+    key_path = tmp_path / "owner.pub.pem"
+    key_path.write_bytes(public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ))
+    signature = private_key.sign(canonical_json(envelope))
+    envelope_path = tmp_path / "approval.json"
+    envelope_path.write_text(json.dumps({
+        "envelope": envelope,
+        "signature": base64.b64encode(signature).decode("ascii"),
+    }), encoding="utf-8")
+    return envelope_path, key_path
+
+
+def _gate(tmp_path, envelope, now, ledger_path=None):
+    envelope_path, key_path = _write_signed(tmp_path, envelope)
+    return SignedApprovalGate(
+        signed_envelope_path=envelope_path,
+        owner_public_key_path=key_path,
+        nonce_ledger=ApprovalNonceLedger(ledger_path or tmp_path / "nonces.sqlite3"),
+        expectation=_expectation(),
+        now=now,
+    ), envelope_path
+
+
+def _context():
+    expected = _expectation()
+    return {
+        "runtime_preflight_passed": True,
+        "input_merkle_root": expected.input_merkle_roots["task-1"],
+        "provider_classification": expected.provider_classifications["task-1"],
+        "task_id": "task-1",
+        "run_id": expected.run_id,
+        "condition": expected.condition,
+        "model": expected.model,
+        "provider": expected.provider,
+        "api_version": expected.api_version,
+        "endpoint_sha256": expected.endpoint_sha256,
+        "approval_scope_sha256": expected.approval_scope_sha256,
+        "official_scope_registry_sha256": (
+            expected.official_scope_registry_sha256
+        ),
+        "caps": {"cost_usd": "6.25", "api_attempts": 30},
+        "substrate_manifest_sha256": "1" * 64,
+        "price_table_sha256": "2" * 64,
+        "official_scope_excluded": True,
+    }
+
+
+def test_valid_envelope_claims_once_and_allows_same_active_gate(tmp_path):
+    now = datetime.now(timezone.utc)
+    gate, _ = _gate(tmp_path, _envelope(now), now)
+
+    scope = '["run-1","treatment","task-1"]'
+    gate.authorize_request(scope, "a" * 64, _context())
+    gate.authorize_request(scope, "b" * 64, _context())
+
+
+def test_signature_tamper_and_expiry_fail_closed(tmp_path):
+    now = datetime.now(timezone.utc)
+    gate, envelope_path = _gate(tmp_path, _envelope(now), now)
+    signed = json.loads(envelope_path.read_text(encoding="utf-8"))
+    signed["envelope"]["model"] = "other-deployment"
+    envelope_path.write_text(json.dumps(signed), encoding="utf-8")
+
+    with pytest.raises(AuthorizationError, match="signature_invalid"):
+        gate.authorize_request(
+            '["run-1","treatment","task-1"]', "a" * 64, _context()
+        )
+
+    expired = _envelope(now)
+    expired["issued_at"] = (now - timedelta(hours=2)).isoformat()
+    expired["expires_at"] = (now - timedelta(hours=1)).isoformat()
+    expired_gate, _ = _gate(tmp_path / "expired", expired, now)
+    with pytest.raises(AuthorizationError, match="expired"):
+        expired_gate.authorize_request(
+            '["run-1","treatment","task-1"]', "a" * 64, _context()
+        )
+
+
+def test_runtime_caps_must_exactly_match_signed_caps(tmp_path):
+    now = datetime.now(timezone.utc)
+    gate, _ = _gate(tmp_path, _envelope(now), now)
+    context = _context()
+    context["caps"] = {"cost_usd": "6.26", "api_attempts": 30}
+
+    with pytest.raises(AuthorizationError, match="approval_caps_invalid"):
+        gate.authorize_request(
+            '["run-1","treatment","task-1"]', "a" * 64, context
+        )
+
+
+def test_official_scope_exclusion_must_be_signed_and_runtime_true(tmp_path):
+    now = datetime.now(timezone.utc)
+    envelope = _envelope(now)
+    envelope["official_scope_excluded"] = False
+    gate, _ = _gate(tmp_path, envelope, now)
+
+    with pytest.raises(AuthorizationError, match="official_scope"):
+        gate.authorize_request(
+            '["run-1","treatment","task-1"]', "a" * 64, _context()
+        )
+
+
+def test_replay_in_new_process_identity_is_rejected(tmp_path):
+    now = datetime.now(timezone.utc)
+    ledger_path = tmp_path / "nonces.sqlite3"
+    envelope = _envelope(now)
+    first, _ = _gate(tmp_path / "first", envelope, now, ledger_path)
+    second, _ = _gate(tmp_path / "second", envelope, now, ledger_path)
+
+    scope = '["run-1","treatment","task-1"]'
+    first.authorize_request(scope, "a" * 64, _context())
+    with pytest.raises(AuthorizationError, match="already_consumed"):
+        second.authorize_request(scope, "a" * 64, _context())
+
+
+def test_concurrent_nonce_claim_has_exactly_one_winner(tmp_path):
+    now = datetime.now(timezone.utc)
+    ledger_path = tmp_path / "nonces.sqlite3"
+    envelope = _envelope(now)
+    gates = [
+        _gate(tmp_path / f"gate-{index}", envelope, now, ledger_path)[0]
+        for index in range(2)
+    ]
+
+    def claim(gate):
+        try:
+            gate.authorize_request(
+                '["run-1","treatment","task-1"]', "a" * 64, _context()
+            )
+            return "accepted"
+        except AuthorizationError:
+            return "rejected"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(claim, gates))
+
+    assert sorted(outcomes) == ["accepted", "rejected"]
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        (lambda envelope: envelope.update(schema_version="2.0"), "schema_version"),
+        (lambda envelope: envelope.update(task_ids=["task-1", "task-1"]), "tasks_invalid"),
+        (
+            lambda envelope: envelope["input_merkle_roots"].update(
+                {"unexpected": "0" * 64}
+            ),
+            "input_roots_invalid",
+        ),
+        (
+            lambda envelope: envelope.update(
+                expires_at=(
+                    datetime.now(timezone.utc) + timedelta(hours=9)
+                ).isoformat()
+            ),
+            "expired_or_not_yet_valid",
+        ),
+    ],
+)
+def test_approval_structure_and_lifetime_are_strict(
+    tmp_path, mutation, match
+):
+    now = datetime.now(timezone.utc)
+    envelope = _envelope(now)
+    mutation(envelope)
+    gate, _ = _gate(tmp_path, envelope, now)
+
+    with pytest.raises(AuthorizationError, match=match):
+        gate.authorize_request(
+            '["run-1","treatment","task-1"]', "a" * 64, _context()
+        )
+
+
+def test_provider_endpoint_hash_normalizes_https_origin_and_rejects_unsafe():
+    expected = provider_endpoint_sha256(
+        "azure", "https://Example.OpenAI.Azure.com/path/"
+    )
+
+    assert expected == provider_endpoint_sha256(
+        "azure_openai", "https://example.openai.azure.com/other"
+    )
+    assert expected != provider_endpoint_sha256(
+        "azure", "https://other.openai.azure.com"
+    )
+    with pytest.raises(ValueError, match="HTTPS origin"):
+        provider_endpoint_sha256("azure", "http://example.test")
+    with pytest.raises(ValueError, match="HTTPS origin"):
+        provider_endpoint_sha256("openai", "https://user@example.test")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("task_ids", ["task-1", "task-2"], "task_set_mismatch"),
+        (
+            "input_merkle_roots",
+            {"task-1": "0" * 64},
+            "input_set_mismatch",
+        ),
+        (
+            "provider_classifications",
+            {"task-1": "other-provider-class"},
+            "classification_set_mismatch",
+        ),
+        ("official_scope_registry_sha256", "0" * 64, "registry_mismatch"),
+    ],
+)
+def test_signed_phase_scope_must_exactly_match_preregistered_scope(
+    tmp_path, field, value, match
+):
+    now = datetime.now(timezone.utc)
+    envelope = _envelope(now)
+    envelope[field] = value
+    if field == "task_ids":
+        envelope["input_merkle_roots"]["task-2"] = "d" * 64
+        envelope["provider_classifications"][
+            "task-2"
+        ] = "approved_public_gdpval"
+    gate, _ = _gate(tmp_path, envelope, now)
+
+    with pytest.raises(AuthorizationError, match=match):
+        gate.authorize_request(
+            '["run-1","treatment","task-1"]', "a" * 64, _context()
+        )
+
+
+def test_load_approval_scope_requires_tracked_exact_manifest(tmp_path):
+    repository = tmp_path / "repository"
+    registry = repository / "src" / "lib" / "officialExperimentScope.js"
+    scope_path = repository / "approval-scope.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text("export const hidden = ['exp030']\n", encoding="utf-8")
+    body = {
+        "schema_version": "agentic-approval-scope-v1",
+        "conditions": ["treatment"],
+        "ordered_task_ids": ["task-1"],
+        "input_merkle_roots": {"task-1": "c" * 64},
+        "provider_classifications": {
+            "task-1": "approved_public_gdpval",
+        },
+    }
+    body["sha256"] = hashlib.sha256(canonical_json(body)).hexdigest()
+    scope_path.write_text(json.dumps(body), encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+    subprocess.run(["git", "add", "."], cwd=repository, check=True)
+
+    scope = load_approval_scope(
+        repository_root=repository,
+        scope_path="approval-scope.json",
+    )
+
+    assert scope["conditions"] == ("treatment",)
+    assert scope["task_ids"] == ("task-1",)
+    assert scope["approval_scope_sha256"] == body["sha256"]
+    assert scope["official_scope_registry_sha256"] == hashlib.sha256(
+        registry.read_bytes()
+    ).hexdigest()

--- a/batch-runner/tests/test_agentic_authorization.py
+++ b/batch-runner/tests/test_agentic_authorization.py
@@ -21,6 +21,7 @@ from core.agentic_authorization import (
     canonical_json,
     load_approval_scope,
     provider_endpoint_sha256,
+    task_request_sha256,
 )
 
 
@@ -42,6 +43,8 @@ def _expectation():
         provider_classifications={
             "task-1": "approved_public_gdpval",
         },
+        task_request_sha256={"task-1": "6" * 64},
+        selection_recomputation_sha256="5" * 64,
         approval_scope_sha256="7" * 64,
         official_scope_registry_sha256="8" * 64,
     )
@@ -58,6 +61,10 @@ def _envelope(now):
         "task_ids": list(expected.task_ids),
         "input_merkle_roots": dict(expected.input_merkle_roots),
         "provider_classifications": dict(expected.provider_classifications),
+        "task_request_sha256": dict(expected.task_request_sha256),
+        "selection_recomputation_sha256": (
+            expected.selection_recomputation_sha256
+        ),
         "provider": expected.provider,
         "model": expected.model,
         "api_version": expected.api_version,
@@ -114,6 +121,10 @@ def _context():
         "input_merkle_root": expected.input_merkle_roots["task-1"],
         "provider_classification": expected.provider_classifications["task-1"],
         "task_id": "task-1",
+        "task_request_sha256": expected.task_request_sha256["task-1"],
+        "selection_recomputation_sha256": (
+            expected.selection_recomputation_sha256
+        ),
         "run_id": expected.run_id,
         "condition": expected.condition,
         "model": expected.model,
@@ -169,6 +180,18 @@ def test_runtime_caps_must_exactly_match_signed_caps(tmp_path):
     context["caps"] = {"cost_usd": "6.26", "api_attempts": 30}
 
     with pytest.raises(AuthorizationError, match="approval_caps_invalid"):
+        gate.authorize_request(
+            '["run-1","treatment","task-1"]', "a" * 64, context
+        )
+
+
+def test_runtime_selection_identity_must_match_signed_scope(tmp_path):
+    now = datetime.now(timezone.utc)
+    gate, _ = _gate(tmp_path, _envelope(now), now)
+    context = _context()
+    context["selection_recomputation_sha256"] = "0" * 64
+
+    with pytest.raises(AuthorizationError, match="selection_identity_mismatch"):
         gate.authorize_request(
             '["run-1","treatment","task-1"]', "a" * 64, context
         )
@@ -260,19 +283,24 @@ def test_approval_structure_and_lifetime_are_strict(
 
 def test_provider_endpoint_hash_normalizes_https_origin_and_rejects_unsafe():
     expected = provider_endpoint_sha256(
-        "azure", "https://Example.OpenAI.Azure.com/path/"
+        "azure", "https://Example.OpenAI.Azure.com/approved/"
     )
 
     assert expected == provider_endpoint_sha256(
-        "azure_openai", "https://example.openai.azure.com/other"
+        "azure_openai", "https://example.openai.azure.com/approved"
     )
     assert expected != provider_endpoint_sha256(
         "azure", "https://other.openai.azure.com"
+    )
+    assert expected != provider_endpoint_sha256(
+        "azure", "https://example.openai.azure.com/other-route"
     )
     with pytest.raises(ValueError, match="HTTPS origin"):
         provider_endpoint_sha256("azure", "http://example.test")
     with pytest.raises(ValueError, match="HTTPS origin"):
         provider_endpoint_sha256("openai", "https://user@example.test")
+    with pytest.raises(ValueError, match="path is ambiguous"):
+        provider_endpoint_sha256("azure", "https://example.test/a/../b")
 
 
 @pytest.mark.parametrize(
@@ -290,6 +318,16 @@ def test_provider_endpoint_hash_normalizes_https_origin_and_rejects_unsafe():
             "classification_set_mismatch",
         ),
         ("official_scope_registry_sha256", "0" * 64, "registry_mismatch"),
+        (
+            "task_request_sha256",
+            {"task-1": "0" * 64},
+            "task_request_set_mismatch",
+        ),
+        (
+            "selection_recomputation_sha256",
+            "0" * 64,
+            "selection_identity_mismatch",
+        ),
     ],
 )
 def test_signed_phase_scope_must_exactly_match_preregistered_scope(
@@ -303,6 +341,7 @@ def test_signed_phase_scope_must_exactly_match_preregistered_scope(
         envelope["provider_classifications"][
             "task-2"
         ] = "approved_public_gdpval"
+        envelope["task_request_sha256"]["task-2"] = "e" * 64
     gate, _ = _gate(tmp_path, envelope, now)
 
     with pytest.raises(AuthorizationError, match=match):
@@ -325,6 +364,8 @@ def test_load_approval_scope_requires_tracked_exact_manifest(tmp_path):
         "provider_classifications": {
             "task-1": "approved_public_gdpval",
         },
+        "task_request_sha256": {"task-1": "6" * 64},
+        "selection_recomputation_sha256": "5" * 64,
     }
     body["sha256"] = hashlib.sha256(canonical_json(body)).hexdigest()
     scope_path.write_text(json.dumps(body), encoding="utf-8")
@@ -338,7 +379,36 @@ def test_load_approval_scope_requires_tracked_exact_manifest(tmp_path):
 
     assert scope["conditions"] == ("treatment",)
     assert scope["task_ids"] == ("task-1",)
+    assert scope["selection_recomputation_sha256"] == "5" * 64
     assert scope["approval_scope_sha256"] == body["sha256"]
     assert scope["official_scope_registry_sha256"] == hashlib.sha256(
         registry.read_bytes()
     ).hexdigest()
+
+
+def test_task_request_digest_binds_instruction_occupation_and_prompt():
+    base = task_request_sha256(
+        task_prompt="Create report.xlsx",
+        occupation="Analyst",
+        experiment_prompt={
+            "system": "system", "prefix": None, "body": None,
+            "suffix": "Use concise labels.",
+        },
+    )
+
+    assert base != task_request_sha256(
+        task_prompt="Create report.xlsx with hidden content",
+        occupation="Analyst",
+        experiment_prompt={
+            "system": "system", "prefix": None, "body": None,
+            "suffix": "Use concise labels.",
+        },
+    )
+    assert base != task_request_sha256(
+        task_prompt="Create report.xlsx",
+        occupation="Auditor",
+        experiment_prompt={
+            "system": "system", "prefix": None, "body": None,
+            "suffix": "Use concise labels.",
+        },
+    )

--- a/batch-runner/tests/test_agentic_budget.py
+++ b/batch-runner/tests/test_agentic_budget.py
@@ -1,0 +1,131 @@
+"""Tests for crash-safe agentic budget reservations."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
+
+import pytest
+
+from core.agentic_budget import AgenticBudgetLedger, BudgetCaps, BudgetExceeded
+
+
+def _caps(**overrides):
+    values = {
+        "attempts": 2,
+        "input_tokens": 100,
+        "output_tokens": 100,
+        "cost_usd": Decimal("1.00"),
+    }
+    values.update(overrides)
+    return BudgetCaps(**values)
+
+
+def test_reservation_survives_reopen_and_timeout(tmp_path):
+    path = tmp_path / "budget.sqlite3"
+    ledger = AgenticBudgetLedger(path)
+    ledger.reserve(
+        scope="run/a/task", request_id="r1", input_tokens=40,
+        output_tokens=50, cost_usd=Decimal("0.40"), caps=_caps(),
+    )
+
+    reopened = AgenticBudgetLedger(path)
+    usage = reopened.usage("run/a/task")
+
+    assert usage.attempts == 1
+    assert usage.input_tokens == 40
+    assert usage.output_tokens == 50
+    assert usage.cost_usd == Decimal("0.40")
+
+
+def test_reconcile_only_moves_reservation_downward(tmp_path):
+    ledger = AgenticBudgetLedger(tmp_path / "budget.sqlite3")
+    ledger.reserve(
+        scope="scope", request_id="r1", input_tokens=40,
+        output_tokens=50, cost_usd=Decimal("0.40"), caps=_caps(),
+    )
+
+    usage = ledger.reconcile(
+        scope="scope", request_id="r1", actual_input_tokens=20,
+        actual_output_tokens=10, actual_cost_usd=Decimal("0.12"),
+    )
+
+    assert usage.attempts == 1
+    assert usage.input_tokens == 20
+    assert usage.output_tokens == 10
+    assert usage.cost_usd == Decimal("0.12")
+    with pytest.raises(ValueError, match="already reconciled"):
+        ledger.reconcile(
+            scope="scope", request_id="r1", actual_input_tokens=20,
+            actual_output_tokens=10, actual_cost_usd=Decimal("0.12"),
+        )
+
+
+def test_concurrent_reservations_cannot_cross_cap(tmp_path):
+    path = tmp_path / "budget.sqlite3"
+
+    def reserve(request_id):
+        ledger = AgenticBudgetLedger(path)
+        try:
+            ledger.reserve(
+                scope="paired", request_id=request_id, input_tokens=60,
+                output_tokens=10, cost_usd=Decimal("0.10"),
+                caps=_caps(attempts=10),
+            )
+            return "accepted"
+        except BudgetExceeded:
+            return "rejected"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(reserve, ["r1", "r2"]))
+
+    assert sorted(outcomes) == ["accepted", "rejected"]
+    assert AgenticBudgetLedger(path).usage("paired").input_tokens == 60
+
+
+def test_multi_scope_reservation_rolls_back_all_scopes_on_one_cap(tmp_path):
+    ledger = AgenticBudgetLedger(tmp_path / "budget.sqlite3")
+
+    with pytest.raises(BudgetExceeded, match="input_token_cap"):
+        ledger.reserve_many(
+            scopes={
+                "task": _caps(input_tokens=100),
+                "condition": _caps(input_tokens=50),
+                "paired": _caps(input_tokens=100),
+            },
+            request_id="r1",
+            input_tokens=60,
+            output_tokens=10,
+            cost_usd=Decimal("0.10"),
+        )
+
+    for scope in ("task", "condition", "paired"):
+        assert ledger.usage(scope).attempts == 0
+
+
+def test_concurrent_tasks_share_one_atomic_paired_cap(tmp_path):
+    path = tmp_path / "budget.sqlite3"
+
+    def reserve(task_id):
+        ledger = AgenticBudgetLedger(path)
+        try:
+            ledger.reserve_many(
+                scopes={
+                    f"task:{task_id}": _caps(attempts=10),
+                    f"condition:{task_id}": _caps(attempts=10),
+                    "paired": _caps(attempts=10, input_tokens=100),
+                },
+                request_id=f"request:{task_id}",
+                input_tokens=60,
+                output_tokens=10,
+                cost_usd=Decimal("0.10"),
+            )
+            return "accepted"
+        except BudgetExceeded:
+            return "rejected"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(reserve, ["a", "b"]))
+
+    assert sorted(outcomes) == ["accepted", "rejected"]
+    assert AgenticBudgetLedger(path).usage("paired").input_tokens == 60

--- a/batch-runner/tests/test_agentic_channel.py
+++ b/batch-runner/tests/test_agentic_channel.py
@@ -14,6 +14,8 @@ from core.agentic_channel import (
     ComputeChannelServer,
     EnvelopeAuthority,
     InMemoryComputeTransport,
+    _digest,
+    _encode_value,
 )
 
 
@@ -54,6 +56,11 @@ class FakeBackend:
 
     def inspect_artifacts(self, timeout_seconds=1200.0):
         self.calls.append("inspect_artifacts")
+        self.terminal = {
+            "success": False,
+            "text": "",
+            "files": [{"filename": "report.txt", "content": b"candidate"}],
+        }
         return {"ok": True, "data": {"artifacts": [{"path": "report.txt"}]}}
 
     def finalize(self, deliverables, summary, timeout_seconds=1200.0):
@@ -65,7 +72,7 @@ class FakeBackend:
         }
         return {"ok": True, "data": {"artifact_count": 1}}
 
-    def best_result(self):
+    def best_result(self, timeout_seconds=1200.0):
         return self.terminal
 
     def close(self):
@@ -101,14 +108,318 @@ def test_authenticated_backend_roundtrip_preserves_bytes_and_order():
     assert client.best_result()["files"][0]["content"] == b"bytes"
     client.close()
 
-    assert backends[0].calls == [
-        "start",
-        ("run_python", "print('ok')", 2.5),
-        ("finalize", ["report.txt"], "done"),
+    assert backends[0].calls[0] == "start"
+    assert backends[0].calls[1][0:2] == ("run_python", "print('ok')")
+    assert backends[0].calls[1][2] == pytest.approx(2.5, abs=0.01)
+    assert backends[0].calls[2] == (
+        "finalize", ["report.txt"], "done"
+    )
+    assert backends[0].closed is True
+    assert client_auth.expected_sequence == 5
+    assert server_auth.expected_sequence == 5
+
+
+def test_authenticated_inspection_seals_best_snapshot_before_close():
+    client, _, client_auth, server_auth, backends = _channel()
+
+    assert client.start()["ok"] is True
+    inspected = client.inspect_artifacts()
+    candidate = client.best_result()
+    client.close()
+
+    assert inspected["ok"] is True
+    assert candidate["success"] is False
+    assert candidate["files"] == [
+        {"filename": "report.txt", "content": b"candidate"}
     ]
     assert backends[0].closed is True
     assert client_auth.expected_sequence == 5
     assert server_auth.expected_sequence == 5
+
+
+def test_unavailable_full_snapshot_still_allows_subset_finalize():
+    class OversizedCandidateBackend(FakeBackend):
+        def inspect_artifacts(self, timeout_seconds=1200.0):
+            self.calls.append("inspect_artifacts")
+            self.terminal = None
+            return {
+                "ok": True,
+                "data": {
+                    "artifacts": [
+                        {"path": "large.bin", "size_bytes": 200 << 20},
+                        {"path": "report.txt", "size_bytes": 1},
+                    ]
+                },
+            }
+
+    server = ComputeChannelServer(
+        EnvelopeAuthority(KEY, SCOPE), OversizedCandidateBackend
+    )
+    client = AuthenticatedComputeBackend(
+        authority=EnvelopeAuthority(KEY, SCOPE),
+        transport=InMemoryComputeTransport(server),
+        task_spec={"task_prompt": "task"},
+    )
+
+    assert client.start()["ok"] is True
+    assert client.inspect_artifacts()["ok"] is True
+    assert client.best_result() is None
+    assert client.finalize(["report.txt"], "done")["ok"] is True
+    assert client.best_result()["files"] == [
+        {"filename": "report.txt", "content": b"bytes"}
+    ]
+    client.close()
+
+
+def test_finalize_result_signing_failure_preserves_sealed_candidate():
+    class FailingFinalizeResultAuthority(EnvelopeAuthority):
+        failed = False
+
+        def result(self, *, command, payload, expires_at, deadline_at=None):
+            if command["operation"] == "finalize" and not self.failed:
+                self.failed = True
+                raise RuntimeError("result signing failed")
+            return super().result(
+                command=command,
+                payload=payload,
+                expires_at=expires_at,
+                deadline_at=deadline_at,
+            )
+
+    server = ComputeChannelServer(
+        FailingFinalizeResultAuthority(KEY, SCOPE), FakeBackend
+    )
+    client = AuthenticatedComputeBackend(
+        authority=EnvelopeAuthority(KEY, SCOPE),
+        transport=InMemoryComputeTransport(server),
+        task_spec={"task_prompt": "task"},
+    )
+    assert client.start()["ok"] is True
+    assert client.inspect_artifacts()["ok"] is True
+    previous = client.best_result()
+
+    result = client.finalize(["report.txt"], "done")
+
+    assert result["ok"] is False
+    assert result["error_type"] == "post_dispatch_result_failed"
+    assert client.best_result() == previous
+    assert server.backend is None
+
+
+def test_large_bytes_use_bounded_chunks_and_roundtrip():
+    client_authority = EnvelopeAuthority(KEY, SCOPE)
+    server_authority = EnvelopeAuthority(KEY, SCOPE)
+    command = client_authority.command(
+        sequence=1,
+        operation="export_best_snapshot",
+        payload={"timeout_seconds": 60, "deadline_at": time.time() + 60},
+        expires_at=int(time.time()) + 60,
+    )
+    content = b"x" * (7 * 1024 * 1024)
+
+    result = server_authority.result(
+        command=command,
+        payload={"ok": True, "content": content},
+        expires_at=int(time.time()) + 60,
+        deadline_at=time.time() + 60,
+    )
+
+    encoded = result["payload"]["content"]
+    assert set(encoded) == {"$bytes_chunks"}
+    assert len(encoded["$bytes_chunks"]) == 19
+    assert max(
+        len(chunk.encode("utf-8"))
+        for chunk in encoded["$bytes_chunks"]
+    ) <= 512 * 1024
+    assert client_authority.verify_result(
+        result, command=command
+    )["content"] == content
+
+
+def test_canonical_digest_checks_deadline_between_chunks(monkeypatch):
+    checks = []
+
+    def expire_after_several_chunks(deadline_at, monotonic_deadline=None):
+        checks.append((deadline_at, monotonic_deadline))
+        if len(checks) == 5:
+            raise ChannelError("compute_deadline_exhausted")
+
+    monkeypatch.setattr(
+        "core.agentic_channel._check_wall_deadline",
+        expire_after_several_chunks,
+    )
+
+    with pytest.raises(ChannelError, match="deadline_exhausted"):
+        _digest(
+            {"chunks": ["a" * 1024 for _ in range(100)]},
+            deadline_at=1.0,
+        )
+
+    assert len(checks) == 5
+
+
+def test_client_result_verification_stops_at_exchange_deadline(monkeypatch):
+    client_authority = EnvelopeAuthority(KEY, SCOPE)
+    server_authority = EnvelopeAuthority(KEY, SCOPE)
+    command = client_authority.command(
+        sequence=1,
+        operation="export_best_snapshot",
+        payload={"timeout_seconds": 60, "deadline_at": 1_060.0},
+        expires_at=1_060,
+    )
+    result = server_authority.result(
+        command=command,
+        payload={"ok": True, "items": ["x" * 1024 for _ in range(100)]},
+        expires_at=1_060,
+    )
+    current = [100.0]
+
+    def monotonic():
+        value = current[0]
+        current[0] += 0.2
+        return value
+
+    monkeypatch.setattr("core.agentic_channel.time.time", lambda: 1_000.0)
+    monkeypatch.setattr("core.agentic_channel.time.monotonic", monotonic)
+
+    with pytest.raises(ChannelError, match="deadline_exhausted"):
+        client_authority.verify_result(
+            result,
+            command=command,
+            deadline_at=1_060.0,
+            monotonic_deadline=100.8,
+        )
+
+    assert client_authority.expected_sequence == 1
+
+
+def test_client_base64_decode_stops_at_exchange_deadline(monkeypatch):
+    client_authority = EnvelopeAuthority(KEY, SCOPE)
+    server_authority = EnvelopeAuthority(KEY, SCOPE)
+    command = client_authority.command(
+        sequence=1,
+        operation="export_best_snapshot",
+        payload={"timeout_seconds": 60, "deadline_at": 1_060.0},
+        expires_at=1_060,
+    )
+    result = server_authority.result(
+        command=command,
+        payload={"ok": True, "content": b"x" * (7 * 1024 * 1024)},
+        expires_at=1_060,
+    )
+    original_digest = client_authority._mac(result)
+    assert original_digest == result["mac"]
+    checks = [0]
+    original_decode = __import__("base64").b64decode
+
+    def advancing_decode(value, validate=False):
+        checks[0] += 1
+        decoded = original_decode(value, validate=validate)
+        if checks[0] == 1:
+            current[0] = 101.0
+        return decoded
+
+    current = [100.0]
+    monkeypatch.setattr("core.agentic_channel.time.time", lambda: 1_000.0)
+    monkeypatch.setattr("core.agentic_channel.time.monotonic", lambda: current[0])
+    monkeypatch.setattr("core.agentic_channel.base64.b64decode", advancing_decode)
+
+    with pytest.raises(ChannelError, match="deadline_exhausted"):
+        client_authority.verify_result(
+            result,
+            command=command,
+            deadline_at=1_060.0,
+            monotonic_deadline=100.5,
+        )
+
+    assert checks[0] == 1
+    assert client_authority.expected_sequence == 1
+
+
+def test_large_result_signing_stops_when_deadline_expires(monkeypatch):
+    client_authority = EnvelopeAuthority(KEY, SCOPE)
+    server_authority = EnvelopeAuthority(KEY, SCOPE)
+    command = client_authority.command(
+        sequence=1,
+        operation="export_best_snapshot",
+        payload={"timeout_seconds": 60, "deadline_at": time.time() + 60},
+        expires_at=int(time.time()) + 60,
+    )
+    current = [1_000.0]
+
+    def advancing_time():
+        value = current[0]
+        current[0] += 0.2
+        return value
+
+    monkeypatch.setattr("core.agentic_channel.time.time", advancing_time)
+
+    with pytest.raises(ChannelError, match="deadline_exhausted"):
+        server_authority.result(
+            command=command,
+            payload={"ok": True, "content": b"x" * (7 * 1024 * 1024)},
+            expires_at=1_060,
+            deadline_at=1_000.8,
+        )
+
+
+def test_legacy_byte_string_has_a_strict_canonical_cap():
+    with pytest.raises(ChannelError, match="string_cap_exceeded"):
+        _digest({"content": {"$bytes": "A" * (512 * 1024 + 4)}})
+
+
+def test_raw_tree_depth_is_rejected_before_recursive_encoding(monkeypatch):
+    monkeypatch.setattr("core.agentic_channel.MAX_CHANNEL_DEPTH", 4)
+    value = "leaf"
+    for index in range(5):
+        value = {f"level-{index}": value}
+
+    with pytest.raises(ChannelError, match="depth_cap_exceeded"):
+        _encode_value(value)
+
+
+def test_raw_bytes_total_is_rejected_before_base64_allocation(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "core.agentic_channel.MAX_CHANNEL_TOTAL_STRING_BYTES", 32
+    )
+    monkeypatch.setattr(
+        "core.agentic_channel.base64.b64encode",
+        lambda value: calls.append(value),
+    )
+
+    with pytest.raises(ChannelError, match="total_string_cap_exceeded"):
+        _encode_value({"content": b"x" * 100})
+
+    assert calls == []
+
+
+def test_raw_text_is_rejected_before_tree_copy(monkeypatch):
+    monkeypatch.setattr("core.agentic_channel.MAX_CHANNEL_TEXT_BYTES", 8)
+
+    with pytest.raises(ChannelError, match="string_cap_exceeded"):
+        _encode_value({"content": "x" * 9})
+
+
+def test_byte_marker_list_counts_toward_canonical_depth(monkeypatch):
+    monkeypatch.setattr("core.agentic_channel.MAX_CHANNEL_DEPTH", 2)
+
+    with pytest.raises(ChannelError, match="depth_cap_exceeded"):
+        _digest({"outer": {"$bytes_chunks": []}})
+
+
+def test_empty_byte_markers_count_toward_raw_and_canonical_nodes(
+    monkeypatch
+):
+    monkeypatch.setattr("core.agentic_channel.MAX_CHANNEL_NODES", 6)
+
+    with pytest.raises(ChannelError, match="node_cap_exceeded"):
+        _encode_value([b"", b""])
+    with pytest.raises(ChannelError, match="node_cap_exceeded"):
+        _digest([
+            {"$bytes_chunks": []},
+            {"$bytes_chunks": []},
+        ])
 
 
 def test_tampered_payload_is_rejected_before_backend_creation():
@@ -155,6 +466,26 @@ def test_cross_scope_and_expired_commands_do_not_mutate_server():
     assert server_auth.expected_sequence == 1
 
 
+def test_missing_signed_deadline_rejects_before_backend_creation():
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    backends = []
+    server = ComputeChannelServer(
+        EnvelopeAuthority(KEY, SCOPE),
+        lambda **kwargs: backends.append(FakeBackend(**kwargs)),
+    )
+    command = client_auth.command(
+        sequence=1,
+        operation="start",
+        payload={"task_spec": {}, "timeout_seconds": 60},
+        expires_at=int(time.time()) + 60,
+    )
+
+    with pytest.raises(ChannelError, match="deadline_missing"):
+        server.handle(command)
+
+    assert backends == []
+
+
 def test_out_of_order_and_reused_nonce_are_rejected_without_dispatch():
     _, transport, _, server_auth, backends = _channel()
     signer = EnvelopeAuthority(KEY, SCOPE)
@@ -170,7 +501,10 @@ def test_out_of_order_and_reused_nonce_are_rejected_without_dispatch():
     first = signer.command(
         sequence=1,
         operation="start",
-        payload={"task_spec": {}, "timeout_seconds": 60},
+        payload={
+            "task_spec": {}, "timeout_seconds": 60,
+            "deadline_at": time.time() + 60,
+        },
         expires_at=int(time.time()) + 60,
         nonce="n" * 48,
     )
@@ -216,6 +550,30 @@ def test_result_must_bind_the_exact_outstanding_command():
     assert client_auth.expected_sequence == 1
 
 
+def test_signed_non_object_result_does_not_consume_sequence():
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+    command = client_auth.command(
+        sequence=1,
+        operation="inspect_workspace",
+        payload={"timeout_seconds": 60, "deadline_at": time.time() + 60},
+        expires_at=int(time.time()) + 60,
+    )
+    result = server_auth.result(
+        command=command,
+        payload={"ok": True},
+        expires_at=int(time.time()) + 60,
+    )
+    result["payload"] = ["not", "an", "object"]
+    result["payload_sha256"] = _digest(result["payload"])
+    result["mac"] = server_auth._mac(result)
+
+    with pytest.raises(ChannelError, match="result_not_object"):
+        client_auth.verify_result(result, command=command)
+
+    assert client_auth.expected_sequence == 1
+
+
 def test_compute_command_cap_stops_before_dispatch():
     client_auth = EnvelopeAuthority(KEY, SCOPE)
     server_auth = EnvelopeAuthority(KEY, SCOPE)
@@ -231,7 +589,10 @@ def test_compute_command_cap_stops_before_dispatch():
     start = client_auth.command(
         sequence=1,
         operation="start",
-        payload={"task_spec": {}, "timeout_seconds": 60},
+        payload={
+            "task_spec": {}, "timeout_seconds": 60,
+            "deadline_at": time.time() + 60,
+        },
         expires_at=int(time.time()) + 60,
     )
     assert transport.exchange(start)
@@ -259,7 +620,7 @@ def test_long_running_command_gets_fresh_result_expiry(monkeypatch):
 
     class LongRunningBackend(FakeBackend):
         def run_python(self, source, timeout_seconds):
-            current_time[0] += 1_201
+            current_time[0] += 61
             return super().run_python(source, timeout_seconds)
 
     server = ComputeChannelServer(server_auth, LongRunningBackend)
@@ -271,7 +632,7 @@ def test_long_running_command_gets_fresh_result_expiry(monkeypatch):
     )
 
     assert client.start()["ok"] is True
-    assert client.run_python("print('done')", 1_200)["ok"] is True
+    assert client.run_python("print('done')", 120)["ok"] is True
     assert client_auth.expected_sequence == 3
     assert server_auth.expected_sequence == 3
 
@@ -290,9 +651,14 @@ def test_transport_retry_returns_cached_result_without_redispatch():
 
     class LostFirstResponse:
         attempts = 0
+        timeouts = []
 
-        def exchange(self, envelope):
+        def exchange(
+            self, envelope, *, timeout_seconds=None,
+            monotonic_deadline=None,
+        ):
             self.attempts += 1
+            self.timeouts.append(timeout_seconds)
             result = server.handle(envelope)
             if self.attempts == 1:
                 raise TimeoutError("response lost")
@@ -307,8 +673,280 @@ def test_transport_retry_returns_cached_result_without_redispatch():
 
     assert client.start()["ok"] is True
     assert transport.attempts == 2
+    assert transport.timeouts[1] <= transport.timeouts[0]
     assert backends[0].calls == ["start"]
     server.close()
+
+
+def test_cached_retry_requires_exact_valid_mac_and_unexpired_command():
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+    backends = []
+
+    def factory(**task_spec):
+        backend = FakeBackend(**task_spec)
+        backends.append(backend)
+        return backend
+
+    server = ComputeChannelServer(server_auth, factory)
+    command = client_auth.command(
+        sequence=1,
+        operation="start",
+        payload={
+            "task_spec": {}, "timeout_seconds": 60,
+            "deadline_at": time.time() + 60,
+        },
+        expires_at=int(time.time()) + 60,
+    )
+    assert server.handle(command)
+    tampered = dict(command)
+    tampered["mac"] = "0" * 64
+
+    with pytest.raises(ChannelError, match="cached_command_mismatch"):
+        server.handle(tampered)
+    with pytest.raises(ChannelError, match="cached_result_expired"):
+        server_auth.verify_cached_retry(
+            command,
+            original=command,
+            cache_expires_at=int(command["expires_at"]),
+            now=int(command["expires_at"]) + 1,
+        )
+
+    assert backends[0].calls == ["start"]
+    server.close()
+
+
+def test_long_command_lost_response_uses_fresh_cached_result_ttl(monkeypatch):
+    current_time = [1_000]
+    monkeypatch.setattr(
+        "core.agentic_channel.time.time", lambda: current_time[0]
+    )
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+
+    class LongBackend(FakeBackend):
+        def run_python(self, source, timeout_seconds):
+            current_time[0] += 61
+            return super().run_python(source, timeout_seconds)
+
+    server = ComputeChannelServer(server_auth, LongBackend)
+
+    class LostResponse:
+        attempts = 0
+
+        def exchange(
+            self, envelope, *, timeout_seconds=None,
+            monotonic_deadline=None,
+        ):
+            self.attempts += 1
+            result = server.handle(envelope)
+            if self.attempts == 2:
+                raise TimeoutError("long command response lost")
+            return result
+
+    transport = LostResponse()
+    client = AuthenticatedComputeBackend(
+        authority=client_auth,
+        transport=transport,
+        task_spec={"task_prompt": "task"},
+        ttl_seconds=60,
+    )
+
+    assert client.start()["ok"] is True
+    assert client.run_python("print('done')", 120)["ok"] is True
+    assert transport.attempts == 3
+    assert server.backend.calls[0] == "start"
+    assert server.backend.calls[1][0:2] == ("run_python", "print('done')")
+    assert server.backend.calls[1][2] == pytest.approx(120, abs=0.01)
+
+
+def test_failed_close_retains_backend_and_sequence_for_exact_retry():
+    close_attempts = []
+
+    class RetryCloseBackend(FakeBackend):
+        def close(self):
+            close_attempts.append("close")
+            if len(close_attempts) == 1:
+                raise RuntimeError("transient cleanup failure")
+            super().close()
+
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+    server = ComputeChannelServer(
+        server_auth, lambda **task_spec: RetryCloseBackend(**task_spec)
+    )
+    start = client_auth.command(
+        sequence=1,
+        operation="start",
+        payload={
+            "task_spec": {}, "timeout_seconds": 60,
+            "deadline_at": time.time() + 60,
+        },
+        expires_at=int(time.time()) + 60,
+    )
+    start_result = server.handle(start)
+    assert client_auth.verify_result(start_result, command=start)["ok"] is True
+    close = client_auth.command(
+        sequence=2,
+        operation="close",
+        payload={
+            "timeout_seconds": 30,
+            "deadline_at": time.time() + 30,
+        },
+        expires_at=int(time.time()) + 60,
+    )
+
+    first_result = server.handle(close)
+    first_decoded = client_auth.verify_result(first_result, command=close)
+
+    assert first_decoded["ok"] is False
+    assert first_decoded["error_type"] == "compute_dispatch_failed"
+    assert server.backend is not None
+    assert server_auth.expected_sequence == 3
+    retry_close = client_auth.command(
+        sequence=3,
+        operation="close",
+        payload={
+            "timeout_seconds": 30,
+            "deadline_at": time.time() + 30,
+        },
+        expires_at=int(time.time()) + 60,
+    )
+    result = server.handle(retry_close)
+    decoded = client_auth.verify_result(result, command=retry_close)
+
+    assert decoded["ok"] is True
+    assert server.backend is None
+    assert server_auth.expected_sequence == 4
+    assert close_attempts == ["close", "close"]
+
+
+def test_pre_dispatch_failure_reuses_exact_pending_sequence():
+    server = ComputeChannelServer(
+        EnvelopeAuthority(KEY, SCOPE), FakeBackend
+    )
+
+    class FailBeforeDispatchOnce:
+        envelopes = []
+        attempts = 0
+
+        def exchange(
+            self, envelope, *, timeout_seconds=None,
+            monotonic_deadline=None,
+        ):
+            self.envelopes.append(dict(envelope))
+            self.attempts += 1
+            if self.attempts == 1:
+                raise TimeoutError("connect failed before dispatch")
+            return server.handle(envelope)
+
+    transport = FailBeforeDispatchOnce()
+    client = AuthenticatedComputeBackend(
+        authority=EnvelopeAuthority(KEY, SCOPE),
+        transport=transport,
+        task_spec={"task_prompt": "task"},
+        max_transport_retries=0,
+    )
+
+    with pytest.raises(TimeoutError, match="before dispatch"):
+        client.start(10)
+
+    assert client.sequence == 0
+    assert server.authority.expected_sequence == 1
+    assert client.start(10)["ok"] is True
+    assert transport.envelopes[0] == transport.envelopes[1]
+    assert transport.envelopes[0]["sequence"] == 1
+    assert client.sequence == 1
+    assert server.authority.expected_sequence == 2
+    client.close()
+
+
+def test_pending_exchange_blocks_a_different_operation():
+    class AlwaysFailsBeforeDispatch:
+        attempts = 0
+
+        def exchange(
+            self, envelope, *, timeout_seconds=None,
+            monotonic_deadline=None,
+        ):
+            self.attempts += 1
+            raise TimeoutError("connect failed before dispatch")
+
+    transport = AlwaysFailsBeforeDispatch()
+    client = AuthenticatedComputeBackend(
+        authority=EnvelopeAuthority(KEY, SCOPE),
+        transport=transport,
+        task_spec={"task_prompt": "task"},
+        max_transport_retries=0,
+    )
+    with pytest.raises(TimeoutError):
+        client.start(10)
+
+    with pytest.raises(ChannelError, match="state_indeterminate"):
+        client.inspect_workspace(10)
+
+    assert transport.attempts == 1
+    assert client.sequence == 0
+
+
+def test_proxy_close_raises_signed_cleanup_failure():
+    class RetryCloseBackend(FakeBackend):
+        attempts = 0
+
+        def close(self):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise RuntimeError("transient cleanup failure")
+            super().close()
+
+    server = ComputeChannelServer(
+        EnvelopeAuthority(KEY, SCOPE), RetryCloseBackend
+    )
+    client = AuthenticatedComputeBackend(
+        authority=EnvelopeAuthority(KEY, SCOPE),
+        transport=InMemoryComputeTransport(server),
+        task_spec={"task_prompt": "task"},
+    )
+
+    assert client.start()["ok"] is True
+    with pytest.raises(ChannelError, match="compute_dispatch_failed"):
+        client.close()
+
+    assert server.backend is not None
+    server.close()
+    assert server.backend is None
+
+
+def test_failed_explicit_close_rearms_cleanup_lease():
+    cleaned = threading.Event()
+
+    class RetryCloseBackend(FakeBackend):
+        attempts = 0
+
+        def close(self):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise RuntimeError("transient cleanup failure")
+            super().close()
+            cleaned.set()
+
+    server = ComputeChannelServer(
+        EnvelopeAuthority(KEY, SCOPE),
+        RetryCloseBackend,
+        backend_lease_seconds=0.05,
+    )
+    client = AuthenticatedComputeBackend(
+        authority=EnvelopeAuthority(KEY, SCOPE),
+        transport=InMemoryComputeTransport(server),
+        task_spec={"task_prompt": "task"},
+    )
+
+    assert client.start()["ok"] is True
+    with pytest.raises(ChannelError, match="compute_dispatch_failed"):
+        client.close()
+
+    assert cleaned.wait(timeout=1)
+    assert server.backend is None
 
 
 def test_backend_idle_lease_closes_without_client_close():
@@ -329,10 +967,181 @@ def test_backend_idle_lease_closes_without_client_close():
     command = client_auth.command(
         sequence=1,
         operation="start",
-        payload={"task_spec": {}, "timeout_seconds": 60},
+        payload={
+            "task_spec": {}, "timeout_seconds": 60,
+            "deadline_at": time.time() + 60,
+        },
         expires_at=int(time.time()) + 60,
     )
 
     assert transport.exchange(command)
     assert closed.wait(timeout=1)
     assert server.backend is None
+
+
+def test_start_cleanup_failure_commits_result_and_lease_retries_cleanup():
+    closed = threading.Event()
+    close_attempts = []
+
+    class FailingStartBackend(FakeBackend):
+        def start(self, timeout_seconds=1200.0):
+            raise RuntimeError("start failed")
+
+        def close(self):
+            close_attempts.append("close")
+            if len(close_attempts) == 1:
+                raise RuntimeError("first cleanup failed")
+            self.closed = True
+            closed.set()
+
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+    server = ComputeChannelServer(
+        server_auth,
+        lambda **kwargs: FailingStartBackend(**kwargs),
+        backend_lease_seconds=0.01,
+    )
+    command = client_auth.command(
+        sequence=1,
+        operation="start",
+        payload={
+            "task_spec": {},
+            "timeout_seconds": 60,
+            "deadline_at": time.time() + 60,
+        },
+        expires_at=int(time.time()) + 60,
+    )
+
+    result = server.handle(command)
+    decoded = client_auth.verify_result(result, command=command)
+
+    assert decoded["ok"] is False
+    assert decoded["error_type"] == "compute_start_cleanup_failed"
+    assert server_auth.expected_sequence == 2
+    assert closed.wait(timeout=1)
+    assert server.backend is None
+    assert close_attempts == ["close", "close"]
+
+
+def test_inspection_and_snapshot_export_share_one_deadline(monkeypatch):
+    monotonic = [100.0]
+    monkeypatch.setattr(
+        "core.agentic_channel.time.monotonic", lambda: monotonic[0]
+    )
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+    backend = FakeBackend()
+
+    class TimeAdvancingTransport:
+        timeouts = []
+
+        def exchange(
+            self, envelope, *, timeout_seconds=None,
+            monotonic_deadline=None,
+        ):
+            self.timeouts.append(timeout_seconds)
+            result = server.handle(envelope)
+            monotonic[0] += 3.0
+            return result
+
+    server = ComputeChannelServer(server_auth, lambda **kwargs: backend)
+    transport = TimeAdvancingTransport()
+    client = AuthenticatedComputeBackend(
+        authority=client_auth,
+        transport=transport,
+        task_spec={"task_prompt": "task"},
+        max_transport_retries=0,
+    )
+    assert client.start(10)["ok"] is True
+
+    inspected = client.inspect_artifacts(10)
+
+    assert inspected["ok"] is True
+    inspect_timeout, export_timeout = transport.timeouts[-2:]
+    assert inspect_timeout == pytest.approx(10, abs=0.01)
+    assert export_timeout == pytest.approx(7, abs=0.01)
+    client.close()
+
+
+def test_finalize_and_candidate_export_share_one_deadline(monkeypatch):
+    current_time = [1_000.0]
+    monkeypatch.setattr(
+        "core.agentic_channel.time.time", lambda: current_time[0]
+    )
+
+    class FinalizeBackend(FakeBackend):
+        finalize_timeout = None
+        export_timeout = None
+
+        def finalize(
+            self, deliverables, summary, timeout_seconds=1200.0
+        ):
+            self.finalize_timeout = timeout_seconds
+            self.terminal = {
+                "success": True,
+                "text": summary,
+                "files": [
+                    {"filename": deliverables[0], "content": b"bytes"}
+                ],
+            }
+            current_time[0] += 3.0
+            return {"ok": True, "data": {"artifact_count": 1}}
+
+        def best_result(self, timeout_seconds=1200.0):
+            self.export_timeout = timeout_seconds
+            return self.terminal
+
+    server = ComputeChannelServer(
+        EnvelopeAuthority(KEY, SCOPE), FinalizeBackend
+    )
+    client = AuthenticatedComputeBackend(
+        authority=EnvelopeAuthority(KEY, SCOPE),
+        transport=InMemoryComputeTransport(server),
+        task_spec={"task_prompt": "task"},
+    )
+    assert client.start(10)["ok"] is True
+
+    result = client.finalize(["report.txt"], "done", 10)
+
+    assert result["ok"] is True
+    assert server.backend.finalize_timeout == pytest.approx(10, abs=0.01)
+    assert server.backend.export_timeout == pytest.approx(7, abs=0.01)
+    client.close()
+
+
+def test_post_dispatch_result_deadline_commits_failure_and_cleans_backend(
+    monkeypatch
+):
+    current = [1_000.0]
+    monkeypatch.setattr("core.agentic_channel.time.time", lambda: current[0])
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+    backend = FakeBackend()
+
+    class ExpiringBackend(FakeBackend):
+        def start(self, timeout_seconds=1200.0):
+            result = super().start(timeout_seconds)
+            current[0] += 2
+            return result
+
+    backend = ExpiringBackend()
+    server = ComputeChannelServer(server_auth, lambda **kwargs: backend)
+    command = client_auth.command(
+        sequence=1,
+        operation="start",
+        payload={
+            "task_spec": {},
+            "timeout_seconds": 1,
+            "deadline_at": current[0] + 1,
+        },
+        expires_at=int(current[0]) + 60,
+    )
+
+    result_envelope = server.handle(command)
+    decoded = client_auth.verify_result(result_envelope, command=command)
+
+    assert decoded["ok"] is False
+    assert decoded["error_type"] == "post_dispatch_result_failed"
+    assert backend.closed is True
+    assert server.backend is None
+    assert server_auth.expected_sequence == 2

--- a/batch-runner/tests/test_agentic_channel.py
+++ b/batch-runner/tests/test_agentic_channel.py
@@ -1,0 +1,338 @@
+"""Tests for authenticated control/compute command envelopes."""
+
+from __future__ import annotations
+
+import time
+import threading
+
+import pytest
+
+from core.agentic_channel import (
+    AuthenticatedComputeBackend,
+    ChannelError,
+    ChannelScope,
+    ComputeChannelServer,
+    EnvelopeAuthority,
+    InMemoryComputeTransport,
+)
+
+
+KEY = b"k" * 32
+SCOPE = ChannelScope("run-1", "treatment", "task-1")
+
+
+class FakeBackend:
+    def __init__(self, **task_spec):
+        self.task_spec = task_spec
+        self.calls = []
+        self.closed = False
+        self.terminal = None
+
+    def start(self, timeout_seconds=1200.0):
+        self.calls.append("start")
+        return {"ok": True, "data": {"substrate_manifest": {"sha256": "a" * 64}}}
+
+    def inspect_workspace(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_workspace")
+        return {"ok": True, "data": {"work": []}}
+
+    def inspect_environment(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_environment")
+        return {"ok": True, "data": {"python": "3.11"}}
+
+    def reset_work(self, timeout_seconds=1200.0):
+        self.calls.append("reset_work")
+        return {"ok": True, "data": {}}
+
+    def run_python(self, source, timeout_seconds):
+        self.calls.append(("run_python", source, timeout_seconds))
+        return {"ok": True, "data": {"returncode": 0}}
+
+    def run_ffmpeg(self, operation, timeout_seconds):
+        self.calls.append(("run_ffmpeg", operation["operation"], timeout_seconds))
+        return {"ok": True, "data": {"returncode": 0}}
+
+    def inspect_artifacts(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_artifacts")
+        return {"ok": True, "data": {"artifacts": [{"path": "report.txt"}]}}
+
+    def finalize(self, deliverables, summary, timeout_seconds=1200.0):
+        self.calls.append(("finalize", deliverables, summary))
+        self.terminal = {
+            "success": True,
+            "text": summary,
+            "files": [{"filename": deliverables[0], "content": b"bytes"}],
+        }
+        return {"ok": True, "data": {"artifact_count": 1}}
+
+    def best_result(self):
+        return self.terminal
+
+    def close(self):
+        self.closed = True
+
+
+def _channel():
+    client_authority = EnvelopeAuthority(KEY, SCOPE)
+    server_authority = EnvelopeAuthority(KEY, SCOPE)
+    backends = []
+
+    def factory(**task_spec):
+        backend = FakeBackend(**task_spec)
+        backends.append(backend)
+        return backend
+
+    server = ComputeChannelServer(server_authority, factory)
+    transport = InMemoryComputeTransport(server)
+    client = AuthenticatedComputeBackend(
+        authority=client_authority,
+        transport=transport,
+        task_spec={"task_prompt": "task", "reference_ids": ["input-1"]},
+    )
+    return client, transport, client_authority, server_authority, backends
+
+
+def test_authenticated_backend_roundtrip_preserves_bytes_and_order():
+    client, _, client_auth, server_auth, backends = _channel()
+
+    assert client.start()["ok"] is True
+    assert client.run_python("print('ok')", 2.5)["ok"] is True
+    assert client.finalize(["report.txt"], "done")["ok"] is True
+    assert client.best_result()["files"][0]["content"] == b"bytes"
+    client.close()
+
+    assert backends[0].calls == [
+        "start",
+        ("run_python", "print('ok')", 2.5),
+        ("finalize", ["report.txt"], "done"),
+    ]
+    assert backends[0].closed is True
+    assert client_auth.expected_sequence == 5
+    assert server_auth.expected_sequence == 5
+
+
+def test_tampered_payload_is_rejected_before_backend_creation():
+    _, transport, _, server_auth, backends = _channel()
+    command = EnvelopeAuthority(KEY, SCOPE).command(
+        sequence=1,
+        operation="start",
+        payload={"task_spec": {"task_prompt": "task"}},
+        expires_at=int(time.time()) + 60,
+    )
+    command["payload"]["task_spec"]["task_prompt"] = "tampered"
+
+    with pytest.raises(ChannelError, match="payload_digest_mismatch"):
+        transport.exchange(command)
+
+    assert backends == []
+    assert server_auth.expected_sequence == 1
+
+
+def test_cross_scope_and_expired_commands_do_not_mutate_server():
+    _, transport, _, server_auth, backends = _channel()
+    other = EnvelopeAuthority(
+        KEY, ChannelScope("run-2", "treatment", "task-1")
+    )
+    cross_scope = other.command(
+        sequence=1,
+        operation="start",
+        payload={"task_spec": {}, "timeout_seconds": 60},
+        expires_at=int(time.time()) + 60,
+    )
+    with pytest.raises(ChannelError, match="cross_scope"):
+        transport.exchange(cross_scope)
+
+    expired = EnvelopeAuthority(KEY, SCOPE).command(
+        sequence=1,
+        operation="start",
+        payload={"task_spec": {}, "timeout_seconds": 60},
+        expires_at=int(time.time()) - 1,
+    )
+    with pytest.raises(ChannelError, match="expired"):
+        transport.exchange(expired)
+
+    assert backends == []
+    assert server_auth.expected_sequence == 1
+
+
+def test_out_of_order_and_reused_nonce_are_rejected_without_dispatch():
+    _, transport, _, server_auth, backends = _channel()
+    signer = EnvelopeAuthority(KEY, SCOPE)
+    future = signer.command(
+        sequence=2,
+        operation="start",
+        payload={"task_spec": {}},
+        expires_at=int(time.time()) + 60,
+    )
+    with pytest.raises(ChannelError, match="out_of_order"):
+        transport.exchange(future)
+
+    first = signer.command(
+        sequence=1,
+        operation="start",
+        payload={"task_spec": {}, "timeout_seconds": 60},
+        expires_at=int(time.time()) + 60,
+        nonce="n" * 48,
+    )
+    assert transport.exchange(first)
+    reused = signer.command(
+        sequence=2,
+        operation="inspect_workspace",
+        payload={},
+        expires_at=int(time.time()) + 60,
+        nonce="n" * 48,
+    )
+    with pytest.raises(ChannelError, match="replayed"):
+        transport.exchange(reused)
+
+    assert backends[0].calls == ["start"]
+    assert server_auth.expected_sequence == 2
+
+
+def test_result_must_bind_the_exact_outstanding_command():
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+    command = client_auth.command(
+        sequence=1,
+        operation="inspect_workspace",
+        payload={},
+        expires_at=int(time.time()) + 60,
+    )
+    other_command = client_auth.command(
+        sequence=1,
+        operation="inspect_environment",
+        payload={},
+        expires_at=int(time.time()) + 60,
+    )
+    result = server_auth.result(
+        command=other_command,
+        payload={"ok": True, "data": {}},
+        expires_at=int(time.time()) + 60,
+    )
+
+    with pytest.raises(ChannelError, match="result_command_mismatch"):
+        client_auth.verify_result(result, command=command)
+
+    assert client_auth.expected_sequence == 1
+
+
+def test_compute_command_cap_stops_before_dispatch():
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+    backends = []
+
+    def factory(**task_spec):
+        backend = FakeBackend(**task_spec)
+        backends.append(backend)
+        return backend
+
+    server = ComputeChannelServer(server_auth, factory, max_commands=1)
+    transport = InMemoryComputeTransport(server)
+    start = client_auth.command(
+        sequence=1,
+        operation="start",
+        payload={"task_spec": {}, "timeout_seconds": 60},
+        expires_at=int(time.time()) + 60,
+    )
+    assert transport.exchange(start)
+    second = client_auth.command(
+        sequence=2,
+        operation="inspect_workspace",
+        payload={},
+        expires_at=int(time.time()) + 60,
+    )
+
+    with pytest.raises(ChannelError, match="command_cap"):
+        transport.exchange(second)
+
+    assert backends[0].calls == ["start"]
+    assert server_auth.expected_sequence == 2
+
+
+def test_long_running_command_gets_fresh_result_expiry(monkeypatch):
+    current_time = [1_000]
+    monkeypatch.setattr(
+        "core.agentic_channel.time.time", lambda: current_time[0]
+    )
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+
+    class LongRunningBackend(FakeBackend):
+        def run_python(self, source, timeout_seconds):
+            current_time[0] += 1_201
+            return super().run_python(source, timeout_seconds)
+
+    server = ComputeChannelServer(server_auth, LongRunningBackend)
+    client = AuthenticatedComputeBackend(
+        authority=client_auth,
+        transport=InMemoryComputeTransport(server),
+        task_spec={"task_prompt": "task"},
+        ttl_seconds=60,
+    )
+
+    assert client.start()["ok"] is True
+    assert client.run_python("print('done')", 1_200)["ok"] is True
+    assert client_auth.expected_sequence == 3
+    assert server_auth.expected_sequence == 3
+
+
+def test_transport_retry_returns_cached_result_without_redispatch():
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server_auth = EnvelopeAuthority(KEY, SCOPE)
+    backends = []
+
+    def factory(**task_spec):
+        backend = FakeBackend(**task_spec)
+        backends.append(backend)
+        return backend
+
+    server = ComputeChannelServer(server_auth, factory)
+
+    class LostFirstResponse:
+        attempts = 0
+
+        def exchange(self, envelope):
+            self.attempts += 1
+            result = server.handle(envelope)
+            if self.attempts == 1:
+                raise TimeoutError("response lost")
+            return result
+
+    transport = LostFirstResponse()
+    client = AuthenticatedComputeBackend(
+        authority=client_auth,
+        transport=transport,
+        task_spec={"task_prompt": "task"},
+    )
+
+    assert client.start()["ok"] is True
+    assert transport.attempts == 2
+    assert backends[0].calls == ["start"]
+    server.close()
+
+
+def test_backend_idle_lease_closes_without_client_close():
+    closed = threading.Event()
+
+    class LeaseBackend(FakeBackend):
+        def close(self):
+            super().close()
+            closed.set()
+
+    client_auth = EnvelopeAuthority(KEY, SCOPE)
+    server = ComputeChannelServer(
+        EnvelopeAuthority(KEY, SCOPE),
+        lambda **task_spec: LeaseBackend(**task_spec),
+        backend_lease_seconds=0.01,
+    )
+    transport = InMemoryComputeTransport(server)
+    command = client_auth.command(
+        sequence=1,
+        operation="start",
+        payload={"task_spec": {}, "timeout_seconds": 60},
+        expires_at=int(time.time()) + 60,
+    )
+
+    assert transport.exchange(command)
+    assert closed.wait(timeout=1)
+    assert server.backend is None

--- a/batch-runner/tests/test_agentic_endpoints.py
+++ b/batch-runner/tests/test_agentic_endpoints.py
@@ -1,0 +1,424 @@
+"""Tests for fixed-denominator paired Agentic Sandbox endpoints."""
+
+import json
+import os
+import subprocess
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from core.agentic_budget import AgenticBudgetLedger, BudgetCaps
+from core.agentic_endpoints import WALL_CAP_MS, compute_paired_endpoints
+
+
+def _fixture():
+    task_ids = [f"task-{index:02d}" for index in range(20)]
+    baseline = []
+    treatment = []
+    maxima = {
+        task_id: [
+            {"rubric_item_id": "quality", "max_score": 5},
+            {"rubric_item_id": "accuracy", "max_score": 5},
+        ]
+        for task_id in task_ids
+    }
+    grades = {
+        "schema_version": "1.1",
+        "tasks": [
+            {
+                "task_id": task_id,
+                "error": None,
+                "items": [
+                    {
+                        "rubric_item_id": "accuracy",
+                        "verdict": "pass",
+                        "awarded_score": 5,
+                        "score_excluded": False,
+                    },
+                    {
+                        "rubric_item_id": "quality",
+                        "verdict": "pass",
+                        "awarded_score": 5,
+                        "score_excluded": False,
+                    },
+                ],
+            }
+            for task_id in task_ids
+        ],
+    }
+    for index, task_id in enumerate(task_ids):
+        baseline.append({
+            "task_id": task_id,
+            "status": "success",
+            "deliverable_files": ["report.txt"],
+            "observability": {
+                "substrate": {"sha256": "a" * 64},
+                "sandbox": {"final_status": "ok"},
+                "execution_metrics": {
+                    "time_to_valid_artifact_ms": (index + 1) * 100,
+                },
+                "budget_metrics": {"conservative_cost_usd": 0.1},
+            },
+        })
+        treatment.append({
+            "task_id": task_id,
+            "status": "error" if index == 19 else "success",
+            "deliverable_files": [] if index == 19 else ["report.txt"],
+            "observability": {
+                "substrate": {"sha256": "a" * 64},
+                "agentic_metrics": {
+                    "terminal_error_category": (
+                        "finalize_not_called" if index == 19 else None
+                    ),
+                    "finalize_attempts": 0 if index == 19 else 1,
+                    "conservative_cost_usd": 0.2,
+                },
+                "execution_metrics": {
+                    "time_to_valid_artifact_ms": (
+                        None if index == 19 else (index + 1) * 100
+                    ),
+                },
+            },
+        })
+    return task_ids, baseline, treatment, maxima, grades
+
+
+def _ledger_inputs(tmp_path, task_ids, baseline_cost="0.1", treatment_cost="0.2"):
+    ledger = AgenticBudgetLedger(tmp_path / "budget.sqlite3")
+    caps = BudgetCaps(100, 1_000_000, 1_000_000, Decimal("100"))
+    scope_maps = {}
+    for condition, cost in (
+        ("baseline", baseline_cost), ("treatment", treatment_cost)
+    ):
+        scopes = {}
+        for task_id in task_ids:
+            scope = json.dumps(["paired-run", condition, task_id], separators=(",", ":"))
+            ledger.reserve_many(
+                scopes={
+                    scope: caps,
+                    json.dumps(
+                        ["condition", "paired-run", condition],
+                        separators=(",", ":"),
+                    ): caps,
+                    json.dumps(
+                        ["paired_run", "paired-run"], separators=(",", ":")
+                    ): caps,
+                },
+                request_id=f"{condition}:{task_id}",
+                input_tokens=0,
+                output_tokens=0,
+                cost_usd=Decimal(cost),
+            )
+            scopes[task_id] = scope
+        scope_maps[condition] = scopes
+    return ledger, scope_maps["baseline"], scope_maps["treatment"]
+
+
+def test_fixed_denominator_completion_quality_timing_and_cost(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(
+        tmp_path, task_ids
+    )
+
+    result = compute_paired_endpoints(
+        expected_task_ids=task_ids,
+        baseline_results=baseline,
+        treatment_results=treatment,
+        rubric_maxima=maxima,
+        baseline_grades=grades,
+        treatment_grades=grades,
+        budget_ledger=ledger,
+        paired_run_id="paired-run",
+        baseline_task_scopes=baseline_scopes,
+        treatment_task_scopes=treatment_scopes,
+    )
+
+    assert result["denominator_tasks"] == 20
+    assert result["common_substrate_sha256"] == "a" * 64
+    assert result["completion"]["baseline"] == 1.0
+    assert result["completion"]["treatment"] == 0.95
+    assert result["completion"]["delta_percentage_points"] == -5.0
+    assert result["quality"]["baseline"]["task_macro"] == 100.0
+    assert result["quality"]["treatment"]["task_macro"] == 95.0
+    assert result["quality"]["treatment"]["expected_item_denominator"] == 40
+    assert result["timing"]["treatment_values_ms"][-1] == WALL_CAP_MS
+    assert result["timing"]["baseline_p95_ms"] == 1900
+    assert result["timing"]["treatment_p95_ms"] == 1900
+    assert result["timing"]["p95_ratio"] == 1.0
+    assert result["cost"]["baseline_mean_usd"] == 0.1
+    assert result["cost"]["treatment_mean_usd"] == 0.2
+    assert result["cost"]["ratio"] == 2.0
+
+
+def test_missing_grade_items_remain_in_fixed_item_denominator(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(
+        tmp_path, task_ids
+    )
+    treatment_grades = json.loads(json.dumps(grades))
+    treatment_grades["tasks"][0]["items"] = []
+
+    result = compute_paired_endpoints(
+        expected_task_ids=task_ids,
+        baseline_results=baseline,
+        treatment_results=treatment,
+        rubric_maxima=maxima,
+        baseline_grades=grades,
+        treatment_grades=treatment_grades,
+        budget_ledger=ledger,
+        paired_run_id="paired-run",
+        baseline_task_scopes=baseline_scopes,
+        treatment_task_scopes=treatment_scopes,
+    )
+
+    quality = result["quality"]["treatment"]
+    assert quality["expected_item_denominator"] == 40
+    assert quality["item_state_counts"]["missing"] == 2
+    assert quality["task_macro"] == 90.0
+
+
+def test_endpoint_rejects_intersection_or_duplicate_denominators(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(
+        tmp_path, task_ids
+    )
+    with pytest.raises(ValueError, match="differ from frozen"):
+        compute_paired_endpoints(
+            expected_task_ids=task_ids,
+            baseline_results=baseline[:-1],
+            treatment_results=treatment,
+            rubric_maxima=maxima,
+            baseline_grades=grades,
+            treatment_grades=grades,
+            budget_ledger=ledger,
+            paired_run_id="paired-run",
+            baseline_task_scopes=baseline_scopes,
+            treatment_task_scopes=treatment_scopes,
+        )
+    with pytest.raises(ValueError, match="20 unique"):
+        compute_paired_endpoints(
+            expected_task_ids=task_ids[:-1] + [task_ids[0]],
+            baseline_results=baseline,
+            treatment_results=treatment,
+            rubric_maxima=maxima,
+            baseline_grades=grades,
+            treatment_grades=grades,
+            budget_ledger=ledger,
+            paired_run_id="paired-run",
+            baseline_task_scopes=baseline_scopes,
+            treatment_task_scopes=treatment_scopes,
+        )
+
+
+def test_zero_baseline_cost_ratio_is_json_safe(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(
+        tmp_path, task_ids, baseline_cost="0"
+    )
+
+    endpoints = compute_paired_endpoints(
+        expected_task_ids=task_ids,
+        baseline_results=baseline,
+        treatment_results=treatment,
+        rubric_maxima=maxima,
+        baseline_grades=grades,
+        treatment_grades=grades,
+        budget_ledger=ledger,
+        paired_run_id="paired-run",
+        baseline_task_scopes=baseline_scopes,
+        treatment_task_scopes=treatment_scopes,
+    )
+
+    assert endpoints["cost"]["ratio"] == "infinity"
+
+
+def test_endpoint_rejects_substrate_parity_drift(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(
+        tmp_path, task_ids
+    )
+    treatment[0]["observability"]["substrate"]["sha256"] = "b" * 64
+
+    with pytest.raises(ValueError, match="not byte-identical"):
+        compute_paired_endpoints(
+            expected_task_ids=task_ids,
+            baseline_results=baseline,
+            treatment_results=treatment,
+            rubric_maxima=maxima,
+            baseline_grades=grades,
+            treatment_grades=grades,
+            budget_ledger=ledger,
+            paired_run_id="paired-run",
+            baseline_task_scopes=baseline_scopes,
+            treatment_task_scopes=treatment_scopes,
+        )
+
+
+def test_endpoint_rejects_cross_run_scope_and_missing_aggregate_link(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(tmp_path, task_ids)
+    cross_run = dict(treatment_scopes)
+    cross_run[task_ids[0]] = json.dumps(
+        ["other-run", "treatment", task_ids[0]], separators=(",", ":")
+    )
+    with pytest.raises(ValueError, match="ledger scope is invalid"):
+        compute_paired_endpoints(
+            expected_task_ids=task_ids,
+            baseline_results=baseline,
+            treatment_results=treatment,
+            rubric_maxima=maxima,
+            baseline_grades=grades,
+            treatment_grades=grades,
+            budget_ledger=ledger,
+            paired_run_id="paired-run",
+            baseline_task_scopes=baseline_scopes,
+            treatment_task_scopes=cross_run,
+        )
+
+    unlinked_scope = json.dumps(
+        ["paired-run", "treatment", task_ids[0]], separators=(",", ":")
+    )
+    unlinked_ledger = AgenticBudgetLedger(tmp_path / "unlinked.sqlite3")
+    unlinked_ledger.reserve(
+        scope=unlinked_scope,
+        request_id="unlinked",
+        input_tokens=0,
+        output_tokens=0,
+        cost_usd=Decimal("0.2"),
+        caps=BudgetCaps(1, 1, 1, Decimal("1")),
+    )
+    with pytest.raises(ValueError, match="treatment aggregate reservations"):
+        from core.agentic_endpoints import _validate_aggregate_reservation_sets
+
+        _validate_aggregate_reservation_sets(
+            unlinked_ledger,
+            "paired-run",
+            {},
+            {task_ids[0]: unlinked_scope},
+        )
+
+
+def test_endpoint_rejects_extra_aggregate_reservation(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(tmp_path, task_ids)
+    caps = BudgetCaps(100, 1_000_000, 1_000_000, Decimal("100"))
+    ledger.reserve_many(
+        scopes={
+            json.dumps(
+                ["condition", "paired-run", "baseline"], separators=(",", ":")
+            ): caps,
+            json.dumps(["paired_run", "paired-run"], separators=(",", ":")): caps,
+        },
+        request_id="unapproved-extra-task-request",
+        input_tokens=0,
+        output_tokens=0,
+        cost_usd=Decimal("0.1"),
+    )
+
+    with pytest.raises(ValueError, match="baseline aggregate reservations"):
+        compute_paired_endpoints(
+            expected_task_ids=task_ids,
+            baseline_results=baseline,
+            treatment_results=treatment,
+            rubric_maxima=maxima,
+            baseline_grades=grades,
+            treatment_grades=grades,
+            budget_ledger=ledger,
+            paired_run_id="paired-run",
+            baseline_task_scopes=baseline_scopes,
+            treatment_task_scopes=treatment_scopes,
+        )
+
+
+def test_quality_joins_item_ids_and_handles_penalty_and_grade_errors(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(tmp_path, task_ids)
+    maxima[task_ids[0]].append({
+        "rubric_item_id": "penalty",
+        "max_score": -5,
+    })
+    for document in (grades,):
+        document["tasks"][0]["items"].insert(1, {
+            "rubric_item_id": "penalty",
+            "verdict": "pass",
+            "awarded_score": -5,
+            "score_excluded": False,
+        })
+    treatment_grades = json.loads(json.dumps(grades))
+    treatment_grades["tasks"][1]["error"] = "judge transport failed"
+    treatment_grades["tasks"][1]["items"][0]["verdict"] = "judge_error"
+
+    result = compute_paired_endpoints(
+        expected_task_ids=task_ids,
+        baseline_results=baseline,
+        treatment_results=treatment,
+        rubric_maxima=maxima,
+        baseline_grades=grades,
+        treatment_grades=treatment_grades,
+        budget_ledger=ledger,
+        paired_run_id="paired-run",
+        baseline_task_scopes=baseline_scopes,
+        treatment_task_scopes=treatment_scopes,
+    )
+
+    baseline_quality = result["quality"]["baseline"]
+    treatment_quality = result["quality"]["treatment"]
+    assert baseline_quality["task_scores"][0] == 50.0
+    assert treatment_quality["task_error_count"] == 1
+    assert treatment_quality["item_state_counts"]["judge_error"] == 2
+    assert treatment_quality["task_errors_by_task"] == {
+        task_ids[1]: "judge transport failed"
+    }
+
+
+def test_compare_cli_reads_authoritative_ledger_and_scope_manifest(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(tmp_path, task_ids)
+    inputs = {
+        "task-manifest": {"diagnostic_task_ids": task_ids},
+        "baseline-results": {"results": baseline},
+        "treatment-results": {"results": treatment},
+        "rubric-maxima": maxima,
+        "baseline-grades": grades,
+        "treatment-grades": grades,
+        "scope-manifest": {
+            "schema_version": "agentic-budget-scope-manifest-v1",
+            "paired_run_id": "paired-run",
+            "baseline_task_scopes": baseline_scopes,
+            "treatment_task_scopes": treatment_scopes,
+        },
+    }
+    arguments = []
+    for name, value in inputs.items():
+        path = tmp_path / f"{name}.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        arguments.extend([f"--{name}", str(path)])
+    output = tmp_path / "endpoints.json"
+    script = Path(__file__).resolve().parents[1] / "scripts" / (
+        "compare_agentic_conditions.py"
+    )
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            *arguments,
+            "--budget-ledger",
+            ledger.path,
+            "--output",
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+
+    assert result.returncode == 0, result.stderr
+    endpoints = json.loads(output.read_text(encoding="utf-8"))
+    assert endpoints["cost"]["baseline_mean_usd"] == 0.1
+    assert endpoints["cost"]["treatment_mean_usd"] == 0.2

--- a/batch-runner/tests/test_agentic_endpoints.py
+++ b/batch-runner/tests/test_agentic_endpoints.py
@@ -1,5 +1,6 @@
 """Tests for fixed-denominator paired Agentic Sandbox endpoints."""
 
+import hashlib
 import json
 import os
 import subprocess
@@ -69,6 +70,7 @@ def _fixture():
             "observability": {
                 "substrate": {"sha256": "a" * 64},
                 "agentic_metrics": {
+                    "usage_complete": True,
                     "terminal_error_category": (
                         "finalize_not_called" if index == 19 else None
                     ),
@@ -82,6 +84,9 @@ def _fixture():
                 },
             },
         })
+        baseline[-1]["observability"]["budget_metrics"][
+            "usage_complete"
+        ] = True
     return task_ids, baseline, treatment, maxima, grades
 
 
@@ -177,6 +182,75 @@ def test_missing_grade_items_remain_in_fixed_item_denominator(tmp_path):
     assert quality["expected_item_denominator"] == 40
     assert quality["item_state_counts"]["missing"] == 2
     assert quality["task_macro"] == 90.0
+
+
+def test_incomplete_usage_forces_completion_to_zero(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(tmp_path, task_ids)
+    baseline[0]["observability"]["budget_metrics"]["usage_complete"] = False
+    treatment[1]["observability"]["agentic_metrics"]["usage_complete"] = False
+
+    result = compute_paired_endpoints(
+        expected_task_ids=task_ids,
+        baseline_results=baseline,
+        treatment_results=treatment,
+        rubric_maxima=maxima,
+        baseline_grades=grades,
+        treatment_grades=grades,
+        budget_ledger=ledger,
+        paired_run_id="paired-run",
+        baseline_task_scopes=baseline_scopes,
+        treatment_task_scopes=treatment_scopes,
+    )
+
+    assert result["completion"]["baseline_by_task"][task_ids[0]] == 0
+    assert result["completion"]["treatment_by_task"][task_ids[1]] == 0
+
+
+def test_condition_specific_first_valid_timing_is_authoritative(tmp_path):
+    task_ids, baseline, treatment, maxima, grades = _fixture()
+    ledger, baseline_scopes, treatment_scopes = _ledger_inputs(tmp_path, task_ids)
+    baseline[0]["observability"]["execution_metrics"] = {}
+    baseline[0]["observability"]["budget_metrics"][
+        "time_to_valid_artifact_ms"
+    ] = 321
+    treatment[0]["observability"]["execution_metrics"] = {}
+    treatment[0]["observability"]["agentic_metrics"][
+        "time_to_valid_artifact_ms"
+    ] = 654
+
+    result = compute_paired_endpoints(
+        expected_task_ids=task_ids,
+        baseline_results=baseline,
+        treatment_results=treatment,
+        rubric_maxima=maxima,
+        baseline_grades=grades,
+        treatment_grades=grades,
+        budget_ledger=ledger,
+        paired_run_id="paired-run",
+        baseline_task_scopes=baseline_scopes,
+        treatment_task_scopes=treatment_scopes,
+    )
+
+    assert result["timing"]["baseline_values_ms"][0] == 321
+    assert result["timing"]["treatment_values_ms"][0] == 654
+
+    treatment[0]["observability"]["execution_metrics"] = {
+        "time_to_valid_artifact_ms": 999,
+    }
+    with pytest.raises(ValueError, match="timing metrics disagree"):
+        compute_paired_endpoints(
+            expected_task_ids=task_ids,
+            baseline_results=baseline,
+            treatment_results=treatment,
+            rubric_maxima=maxima,
+            baseline_grades=grades,
+            treatment_grades=grades,
+            budget_ledger=ledger,
+            paired_run_id="paired-run",
+            baseline_task_scopes=baseline_scopes,
+            treatment_task_scopes=treatment_scopes,
+        )
 
 
 def test_endpoint_rejects_intersection_or_duplicate_denominators(tmp_path):
@@ -376,25 +450,86 @@ def test_quality_joins_item_ids_and_handles_penalty_and_grade_errors(tmp_path):
 def test_compare_cli_reads_authoritative_ledger_and_scope_manifest(tmp_path):
     task_ids, baseline, treatment, maxima, grades = _fixture()
     ledger, baseline_scopes, treatment_scopes = _ledger_inputs(tmp_path, task_ids)
+    dataset_revision = "a" * 40
+    rubric_commit = "b" * 40
+    baseline_revision = "c" * 40
+    treatment_revision = "d" * 40
+    grader_source_hash = "e" * 64
+
+    def inference(experiment_id, condition, mode, results):
+        return {
+            "experiment_id": experiment_id,
+            "condition_identity": condition,
+            "execution_mode": mode,
+            "run_id": "paired-run",
+            "ordered_task_ids": task_ids,
+            "results": results,
+        }
+
+    def grade(experiment_id, revision):
+        return {
+            **json.loads(json.dumps(grades)),
+            "experiment_id": experiment_id,
+            "source_inference_experiment_id": experiment_id,
+            "source_inference_revision": revision,
+            "grader_source_hash": grader_source_hash,
+            "rubric": {"commit_sha": rubric_commit},
+            "judge": {"config_hash": "track2-config"},
+            "prompt": {"version": "track2-prompt-v1"},
+        }
+
     inputs = {
-        "task-manifest": {"diagnostic_task_ids": task_ids},
-        "baseline-results": {"results": baseline},
-        "treatment-results": {"results": treatment},
-        "rubric-maxima": maxima,
-        "baseline-grades": grades,
-        "treatment-grades": grades,
-        "scope-manifest": {
-            "schema_version": "agentic-budget-scope-manifest-v1",
-            "paired_run_id": "paired-run",
-            "baseline_task_scopes": baseline_scopes,
-            "treatment_task_scopes": treatment_scopes,
+        "task-manifest": {
+            "diagnostic_task_ids": task_ids,
+            "dataset": {"revision": dataset_revision},
+            "rubric": {"revision": rubric_commit},
         },
+        "baseline-results": inference(
+            "exp029", "baseline", "sandbox", baseline
+        ),
+        "treatment-results": inference(
+            "exp030", "treatment", "agentic_sandbox",
+            treatment,
+        ),
+        "rubric-maxima": {
+            "schema_version": "agentic-rubric-maxima-v1",
+            "rubric_commit": rubric_commit,
+            "tasks": maxima,
+        },
+        "baseline-grades": grade("exp029", baseline_revision),
+        "treatment-grades": grade("exp030", treatment_revision),
     }
     arguments = []
+    artifact_hashes = {}
     for name, value in inputs.items():
         path = tmp_path / f"{name}.json"
-        path.write_text(json.dumps(value), encoding="utf-8")
+        content = json.dumps(value)
+        path.write_text(content, encoding="utf-8")
+        artifact_hashes[name.replace("-", "_")] = hashlib.sha256(
+            content.encode("utf-8")
+        ).hexdigest()
         arguments.extend([f"--{name}", str(path)])
+    scope = {
+        "schema_version": "agentic-budget-scope-manifest-v2",
+        "paired_run_id": "paired-run",
+        "ordered_task_ids": task_ids,
+        "dataset_revision": dataset_revision,
+        "rubric_commit": rubric_commit,
+        "baseline_inference_revision": baseline_revision,
+        "treatment_inference_revision": treatment_revision,
+        "judge_config_hash": "track2-config",
+        "prompt_version": "track2-prompt-v1",
+        "grader_source_hash": grader_source_hash,
+        "baseline_task_scopes": baseline_scopes,
+        "treatment_task_scopes": treatment_scopes,
+        "artifact_sha256": artifact_hashes,
+    }
+    scope["sha256"] = hashlib.sha256(json.dumps(
+        scope, sort_keys=True, separators=(",", ":"), allow_nan=False,
+    ).encode("utf-8")).hexdigest()
+    scope_path = tmp_path / "scope-manifest.json"
+    scope_path.write_text(json.dumps(scope), encoding="utf-8")
+    arguments.extend(["--scope-manifest", str(scope_path)])
     output = tmp_path / "endpoints.json"
     script = Path(__file__).resolve().parents[1] / "scripts" / (
         "compare_agentic_conditions.py"
@@ -422,3 +557,30 @@ def test_compare_cli_reads_authoritative_ledger_and_scope_manifest(tmp_path):
     endpoints = json.loads(output.read_text(encoding="utf-8"))
     assert endpoints["cost"]["baseline_mean_usd"] == 0.1
     assert endpoints["cost"]["treatment_mean_usd"] == 0.2
+    assert endpoints["provenance"]["artifact_sha256"] == artifact_hashes
+    assert endpoints["provenance"]["rubric_commit"] == rubric_commit
+
+    swapped = json.loads(
+        (tmp_path / "baseline-grades.json").read_text(encoding="utf-8")
+    )
+    swapped["experiment_id"] = "exp030"
+    (tmp_path / "baseline-grades.json").write_text(
+        json.dumps(swapped), encoding="utf-8"
+    )
+    rejected = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            *arguments,
+            "--budget-ledger",
+            ledger.path,
+            "--output",
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+    assert rejected.returncode != 0
+    assert "artifact byte identity mismatch" in rejected.stderr

--- a/batch-runner/tests/test_agentic_input_manifest.py
+++ b/batch-runner/tests/test_agentic_input_manifest.py
@@ -1,0 +1,127 @@
+"""Tests for exact approved input identities built on compute storage."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from core.agentic_input_manifest import build_input_manifest
+
+
+def _selection(dataset_root):
+    selected = []
+    for index in range(25):
+        relative = f"task-{index:02d}/input.txt"
+        path = dataset_root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"input-{index}", encoding="utf-8")
+        selected.append({
+            "task_id": f"task-{index:02d}",
+            "reference_paths": [relative],
+            "reference_sizes": [path.stat().st_size],
+        })
+    return {"selected_tasks": selected}
+
+
+def test_build_input_manifest_is_deterministic_and_complete(tmp_path):
+    dataset = tmp_path / "dataset"
+    staging = tmp_path / "staging"
+    dataset.mkdir()
+    staging.mkdir()
+    selection = _selection(dataset)
+
+    first = build_input_manifest(
+        selection_manifest=selection,
+        dataset_root=dataset,
+        staging_parent=staging,
+        provider_classification="approved_public_gdpval",
+    )
+    second = build_input_manifest(
+        selection_manifest=selection,
+        dataset_root=dataset,
+        staging_parent=staging,
+        provider_classification="approved_public_gdpval",
+    )
+
+    assert first == second
+    assert first["schema_version"] == "agentic-input-manifest-v1"
+    assert first["staging_filesystem_device"] == staging.stat().st_dev
+    assert len(first["tasks"]) == 25
+    assert len(first["sha256"]) == 64
+    task = first["tasks"]["task-00"]
+    assert task["reference_ids"] == ["task-00/input.txt"]
+    assert len(task["input_merkle_root"]) == 64
+    record = task["files"][0]
+    assert record["source_path"] == "task-00/input.txt"
+    assert record["relative_path"] == "task-00/input.txt"
+    assert record["staged_allocated_bytes"] > 0
+    assert len(record["sha256"]) == 64
+    assert not any(staging.iterdir())
+    json.dumps(first, allow_nan=False)
+
+
+def test_build_input_manifest_rejects_selection_size_drift(tmp_path):
+    dataset = tmp_path / "dataset"
+    staging = tmp_path / "staging"
+    dataset.mkdir()
+    staging.mkdir()
+    selection = _selection(dataset)
+    selection["selected_tasks"][0]["reference_sizes"][0] += 1
+
+    with pytest.raises(ValueError, match="size differs"):
+        build_input_manifest(
+            selection_manifest=selection,
+            dataset_root=dataset,
+            staging_parent=staging,
+            provider_classification="approved_public_gdpval",
+        )
+
+
+@pytest.mark.parametrize("link_kind", ["file", "ancestor"])
+def test_build_input_manifest_rejects_symlink_components(tmp_path, link_kind):
+    dataset = tmp_path / "dataset"
+    staging = tmp_path / "staging"
+    dataset.mkdir()
+    staging.mkdir()
+    selection = _selection(dataset)
+    source = dataset / "task-00" / "input.txt"
+
+    if link_kind == "file":
+        target = dataset / "target.txt"
+        target.write_bytes(source.read_bytes())
+        source.unlink()
+        source.symlink_to(target)
+    else:
+        original_parent = source.parent
+        target_parent = dataset / "target-parent"
+        original_parent.rename(target_parent)
+        original_parent.symlink_to(target_parent, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="contains a link"):
+        build_input_manifest(
+            selection_manifest=selection,
+            dataset_root=dataset,
+            staging_parent=staging,
+            provider_classification="approved_public_gdpval",
+        )
+
+
+def test_build_input_manifest_rejects_fifo_without_blocking(tmp_path):
+    dataset = tmp_path / "dataset"
+    staging = tmp_path / "staging"
+    dataset.mkdir()
+    staging.mkdir()
+    selection = _selection(dataset)
+    source = dataset / "task-00" / "input.txt"
+    source.unlink()
+    os.mkfifo(source)
+
+    with pytest.raises(ValueError, match="single-link regular file"):
+        build_input_manifest(
+            selection_manifest=selection,
+            dataset_root=dataset,
+            staging_parent=staging,
+            provider_classification="approved_public_gdpval",
+        )

--- a/batch-runner/tests/test_agentic_input_manifest.py
+++ b/batch-runner/tests/test_agentic_input_manifest.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
+from pathlib import Path
 
 import pytest
 
 from core.agentic_input_manifest import build_input_manifest
+from core.agentic_compute import _open_regular_beneath_nofollow
 
 
 def _selection(dataset_root):
@@ -19,10 +22,75 @@ def _selection(dataset_root):
         path.write_text(f"input-{index}", encoding="utf-8")
         selected.append({
             "task_id": f"task-{index:02d}",
+            "sector": "Test",
+            "occupation": "Analyst",
+            "input_class": "document",
             "reference_paths": [relative],
+            "reference_suffixes": ["txt"],
             "reference_sizes": [path.stat().st_size],
+            "positive_rubric_max": 1,
         })
-    return {"selected_tasks": selected}
+    task_ids = [task["task_id"] for task in selected]
+    document = {
+        "schema_version": "agentic-task-subset-v1",
+        "seed": "20260717",
+        "eligible_frame_count": 25,
+        "strata": [{
+            "sector": "Test",
+            "input_class": "document",
+            "eligible_count": 25,
+            "selected_quota": 25,
+            "canary_quota": 5,
+        }],
+        "canary_task_ids": task_ids[:5],
+        "diagnostic_task_ids": task_ids[5:],
+        "selected_tasks": selected,
+        "selection_domains": {
+            "select": "agentic-select-v1",
+            "canary": "agentic-canary-v1",
+            "order_canary": "agentic-order-canary-v1",
+            "order_diagnostic": "agentic-order-diagnostic-v1",
+        },
+        "tie_break": "ascending UTF-8 bytes",
+        "selected_before_outcomes": True,
+        "dataset": {
+            "repository": "owner/dataset",
+            "revision": "a" * 40,
+            "source_path": "dataset.json",
+            "sha256": "b" * 64,
+        },
+        "rubric": {
+            "repository": "owner/rubric",
+            "revision": "c" * 40,
+            "source_path": "rubric.json",
+            "sha256": "d" * 64,
+        },
+        "selector": {
+            "path": "core/agentic_selector.py",
+            "source_commit": "e" * 40,
+            "sha256": "f" * 64,
+        },
+        "inclusion_validation": "all structural checks passed",
+        "exclusion_validation": (
+            "outcome fields were not accepted by selector"
+        ),
+    }
+    _rehash_selection(document)
+    return document
+
+
+def _rehash_selection(document):
+    canonical = {
+        key: value
+        for key, value in document.items()
+        if key != "recomputation_sha256"
+    }
+    document["recomputation_sha256"] = hashlib.sha256(
+        json.dumps(
+            canonical, sort_keys=True, separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
 
 
 def test_build_input_manifest_is_deterministic_and_complete(tmp_path):
@@ -47,6 +115,9 @@ def test_build_input_manifest_is_deterministic_and_complete(tmp_path):
 
     assert first == second
     assert first["schema_version"] == "agentic-input-manifest-v1"
+    assert first["selection_recomputation_sha256"] == selection[
+        "recomputation_sha256"
+    ]
     assert first["staging_filesystem_device"] == staging.stat().st_dev
     assert len(first["tasks"]) == 25
     assert len(first["sha256"]) == 64
@@ -69,6 +140,7 @@ def test_build_input_manifest_rejects_selection_size_drift(tmp_path):
     staging.mkdir()
     selection = _selection(dataset)
     selection["selected_tasks"][0]["reference_sizes"][0] += 1
+    _rehash_selection(selection)
 
     with pytest.raises(ValueError, match="size differs"):
         build_input_manifest(
@@ -124,4 +196,120 @@ def test_build_input_manifest_rejects_fifo_without_blocking(tmp_path):
             dataset_root=dataset,
             staging_parent=staging,
             provider_classification="approved_public_gdpval",
+        )
+
+
+@pytest.mark.parametrize("task_id", ["../escaped", "/absolute", ".hidden", "a/b"])
+def test_build_input_manifest_rejects_task_id_path_components(
+    tmp_path, task_id
+):
+    dataset = tmp_path / "dataset"
+    staging = tmp_path / "staging"
+    dataset.mkdir()
+    staging.mkdir()
+    selection = _selection(dataset)
+    selection["selected_tasks"][0]["task_id"] = task_id
+    selection["canary_task_ids"][0] = task_id
+    _rehash_selection(selection)
+
+    with pytest.raises(ValueError, match="canonical component"):
+        build_input_manifest(
+            selection_manifest=selection,
+            dataset_root=dataset,
+            staging_parent=staging,
+            provider_classification="approved_public_gdpval",
+        )
+
+    assert not (tmp_path / "escaped").exists()
+
+
+def test_build_input_manifest_rejects_stale_selection_hash_before_staging(
+    tmp_path
+):
+    dataset = tmp_path / "dataset"
+    staging = tmp_path / "staging"
+    dataset.mkdir()
+    staging.mkdir()
+    selection = _selection(dataset)
+    selection["selected_tasks"][0]["reference_paths"][0] = (
+        "task-01/input.txt"
+    )
+
+    with pytest.raises(ValueError, match="recomputation hash mismatch"):
+        build_input_manifest(
+            selection_manifest=selection,
+            dataset_root=dataset,
+            staging_parent=staging,
+            provider_classification="approved_public_gdpval",
+        )
+
+    assert not any(staging.iterdir())
+
+
+def test_build_input_manifest_rejects_5_20_order_drift(tmp_path):
+    dataset = tmp_path / "dataset"
+    staging = tmp_path / "staging"
+    dataset.mkdir()
+    staging.mkdir()
+    selection = _selection(dataset)
+    selection["canary_task_ids"][0], selection["canary_task_ids"][1] = (
+        selection["canary_task_ids"][1],
+        selection["canary_task_ids"][0],
+    )
+    _rehash_selection(selection)
+
+    with pytest.raises(ValueError, match="task order differs"):
+        build_input_manifest(
+            selection_manifest=selection,
+            dataset_root=dataset,
+            staging_parent=staging,
+            provider_classification="approved_public_gdpval",
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("repository", "https://example.test/dataset"),
+        ("revision", "main"),
+        ("source_path", "../dataset.json"),
+        ("sha256", "not-a-sha256"),
+    ],
+)
+def test_build_input_manifest_rejects_invalid_dataset_provenance(
+    tmp_path, field, value
+):
+    dataset = tmp_path / "dataset"
+    staging = tmp_path / "staging"
+    dataset.mkdir()
+    staging.mkdir()
+    selection = _selection(dataset)
+    selection["dataset"][field] = value
+    _rehash_selection(selection)
+
+    with pytest.raises(ValueError, match="dataset provenance"):
+        build_input_manifest(
+            selection_manifest=selection,
+            dataset_root=dataset,
+            staging_parent=staging,
+            provider_classification="approved_public_gdpval",
+        )
+
+
+def test_approved_input_open_rejects_nested_mount_identity(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "dataset"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (nested / "input.txt").write_text("input", encoding="utf-8")
+    mount_ids = iter([100, 200])
+    monkeypatch.setattr(
+        "core.agentic_compute._descriptor_mount_id",
+        lambda descriptor: next(mount_ids),
+    )
+
+    with pytest.raises(OSError, match="mount boundary"):
+        _open_regular_beneath_nofollow(
+            root, Path("nested/input.txt")
         )

--- a/batch-runner/tests/test_agentic_pipeline.py
+++ b/batch-runner/tests/test_agentic_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -247,6 +248,63 @@ def test_step2_rejects_second_condition_for_reserved_experiment(
         step2.run_inference(
             condition_key="condition_a", resume=False, resume_max_rounds=0
         )
+
+
+def test_reserved_agentic_experiment_rejects_mode_downgrade_before_client(
+    tmp_path, monkeypatch
+):
+    _patch_step2_workspace(tmp_path, monkeypatch, _prepared())
+    provider_factory = MagicMock()
+    monkeypatch.setattr(step2, "create_provider_client", provider_factory)
+
+    with pytest.raises(SystemExit):
+        step2.run_inference(
+            execution_mode="subprocess",
+            condition_key="condition_a",
+            resume=False,
+            resume_max_rounds=0,
+        )
+
+    provider_factory.assert_not_called()
+
+
+def test_hardened_execution_rejects_task_resume_rounds_before_client(
+    tmp_path, monkeypatch
+):
+    _patch_step2_workspace(tmp_path, monkeypatch, _prepared())
+    provider_factory = MagicMock()
+    monkeypatch.setattr(step2, "create_provider_client", provider_factory)
+
+    with pytest.raises(SystemExit):
+        step2.run_inference(
+            condition_key="condition_a",
+            resume=False,
+            max_retries=0,
+            resume_max_rounds=1,
+        )
+
+    provider_factory.assert_not_called()
+
+
+@pytest.mark.parametrize("field", ["prefix", "body"])
+def test_hardened_execution_rejects_unpaired_prompt_override_before_client(
+    tmp_path, monkeypatch, field
+):
+    prepared = _prepared()
+    prepared["condition_a"]["prompt"][field] = "unpaired override"
+    _patch_step2_workspace(tmp_path, monkeypatch, prepared)
+    provider_factory = MagicMock()
+    monkeypatch.setattr(step2, "create_provider_client", provider_factory)
+
+    with pytest.raises(SystemExit):
+        step2.run_inference(
+            condition_key="condition_a",
+            resume=False,
+            max_retries=0,
+            resume_max_rounds=0,
+        )
+
+    provider_factory.assert_not_called()
 
 
 @pytest.mark.parametrize("blocked_field", ["qa", "preprocessors"])
@@ -516,6 +574,106 @@ def test_progress_task_set_rejects_duplicate_extra_and_final_reordering():
         )
 
 
+def test_failed_hardened_snapshot_is_saved_as_non_deliverable_evidence(
+    tmp_path, monkeypatch
+):
+    evidence_root = tmp_path / "batch-output"
+    monkeypatch.setattr(step2, "BATCH_OUTPUT_DIR", evidence_root)
+    executor = MagicMock()
+    executor.execute.return_value = {
+        "success": False,
+        "error": "model_api_error",
+        "text": "",
+        "deliverable_text": "",
+        "files": [{"filename": "report.txt", "content": b"verified"}],
+        "agentic_metrics": {
+            "schema_version": "1.0",
+            "ledger_cumulative": True,
+            "model_api_calls": 2,
+            "model_iterations": 2,
+            "tool_calls": 1,
+            "tool_errors": 0,
+            "tool_calls_by_name": {"inspect_artifacts": 1},
+            "model_time_ms": 1,
+            "tool_time_ms": 1,
+            "task_wall_time_ms": 2,
+            "finalize_required_corrections": 0,
+            "finalize_attempts": 0,
+            "capability_misses": 0,
+            "recovered_after_tool_error": False,
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "cached_tokens": 0,
+            "conservative_cost_usd": "0.1",
+            "usage_complete": False,
+            "terminal_error_category": "model_api_error",
+        },
+    }
+    task = {
+        "task_id": "task-1",
+        "instruction": "Create report.txt",
+        "occupation": "Analyst",
+        "reference_files": [],
+        "needs_files": True,
+    }
+    condition = {
+        "prompt": {
+            "system": "system", "prefix": None, "body": None, "suffix": None,
+        },
+        "preprocessors": [],
+    }
+
+    result = step2._execute_single_task(
+        task,
+        condition,
+        executor,
+        "agentic_sandbox",
+        None,
+        "model",
+        strict_inputs=True,
+        experiment_id="exp030",
+        run_id="paired-run",
+        condition_name="treatment",
+    )
+
+    assert result["status"] == "error"
+    assert result["deliverable_files"] == []
+    assert result["failure_evidence"]["artifact_count"] == 1
+    evidence_dir = evidence_root.parent / result["failure_evidence"]["root"]
+    assert (evidence_dir / "artifacts" / "report.txt").read_bytes() == b"verified"
+    manifest = json.loads(
+        (evidence_dir / ".evidence" / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["sha256"] == result["failure_evidence"]["sha256"]
+
+
+def test_failure_evidence_metadata_cannot_overwrite_same_named_artifact(
+    tmp_path, monkeypatch
+):
+    evidence_root = tmp_path / "batch-output"
+    monkeypatch.setattr(step2, "BATCH_OUTPUT_DIR", evidence_root)
+
+    result = step2._save_hardened_failure_evidence(
+        [{"filename": "evidence-manifest.json", "content": b"user artifact"}],
+        experiment_id="exp030",
+        run_id="paired-run-collision",
+        condition_identity="treatment",
+        task_id="task-collision",
+    )
+
+    evidence_dir = evidence_root.parent / result["root"]
+    artifact = evidence_dir / "artifacts" / "evidence-manifest.json"
+    metadata = evidence_dir / ".evidence" / "manifest.json"
+    assert artifact.read_bytes() == b"user artifact"
+    document = json.loads(metadata.read_text(encoding="utf-8"))
+    assert document["artifacts"][0]["sha256"] == hashlib.sha256(
+        b"user artifact"
+    ).hexdigest()
+    assert hashlib.sha256(artifact.read_bytes()).hexdigest() == document[
+        "artifacts"
+    ][0]["sha256"]
+
+
 def test_baseline_budget_observability_uses_strict_allowlist():
     secret = "/private/ledger.sqlite3"
     observed = step2._build_execution_observability({
@@ -569,6 +727,7 @@ def test_substrate_observability_keeps_hashes_and_drops_paths():
         "read_only_rootfs": True,
         "cap_drop": ["ALL"],
         "no_new_privileges": True,
+        "selected_transfer_bytes": 256 * 1024 * 1024,
         "memory_bytes": 8 * 1024 * 1024 * 1024,
         "memory_swap_bytes": 8 * 1024 * 1024 * 1024,
         "cpus": 2,

--- a/batch-runner/tests/test_agentic_pipeline.py
+++ b/batch-runner/tests/test_agentic_pipeline.py
@@ -1,0 +1,594 @@
+"""Model-free pipeline wiring tests for execution.mode=agentic_sandbox."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import step1_prepare_tasks as step1
+import step2_run_inference as step2
+from core.agentic_experiments import agentic_condition_identity
+from core.experiment_config import ExperimentConfig
+
+
+def _config() -> ExperimentConfig:
+    return ExperimentConfig.from_dict({
+        "experiment": {"id": "exp028", "name": "Agentic fixture"},
+        "data": {
+            "source": "fixture",
+            "filter": {"task_ids": ["task-1"]},
+        },
+        "condition_a": {
+            "name": "Treatment",
+            "model": {"provider": "azure", "deployment": "test-deployment"},
+            "prompt": {"system": "system"},
+        },
+        "execution": {
+            "mode": "agentic_sandbox",
+            "agentic": {
+                "compute_transport": "remote",
+                "image": "image@sha256:" + "a" * 64,
+                "verifier_image": "verifier@sha256:" + "b" * 64,
+                "limits": {"max_model_iterations": 3},
+                "budget": {
+                    "paired_run_id": "paired-run",
+                    "condition": {
+                        "attempts": 30, "input_tokens": 1000000,
+                        "output_tokens": 100000, "cost_usd": "6.25",
+                    },
+                    "paired_run": {
+                        "attempts": 30, "input_tokens": 1500000,
+                        "output_tokens": 163840, "cost_usd": "6.25",
+                    },
+                },
+                "pricing_table": {
+                    "sha256": "c" * 64,
+                },
+                "authorization": {
+                    "api_version": "2025-04-01-preview",
+                    "provider_classification": "approved_public_gdpval",
+                    "endpoint_sha256": "d" * 64,
+                },
+            },
+        },
+    })
+
+
+def _prepared(agentic: dict | None = None) -> dict:
+    return {
+        "experiment_id": "exp028",
+        "experiment_name": "Agentic fixture",
+        "source": "fixture",
+        "execution": {
+            "mode": "agentic_sandbox",
+            "max_retries": 0,
+            "resume_max_rounds": 0,
+            "agentic": agentic or {
+                "pricing": {},
+                "budget": {
+                    "paired_run_id": "paired-run",
+                    "condition": {
+                        "attempts": 30,
+                        "input_tokens": 1_000_000,
+                        "output_tokens": 100_000,
+                        "cost_usd": "6.25",
+                    },
+                    "paired_run": {
+                        "attempts": 30,
+                        "input_tokens": 1_500_000,
+                        "output_tokens": 163_840,
+                        "cost_usd": "6.25",
+                    },
+                },
+            },
+        },
+        "tasks": [{
+            "task_id": "task-1",
+            "sector": "test",
+            "occupation": "Analyst",
+            "instruction": "Create a report",
+            "reference_files": [],
+            "needs_files": False,
+        }],
+        "condition_a": {
+            "name": "Treatment",
+            "model": {"provider": "azure", "deployment": "test-deployment"},
+            "prompt": {"system": "system"},
+        },
+    }
+
+
+def _patch_step2_workspace(tmp_path, monkeypatch, prepared):
+    workspace = tmp_path / "workspace"
+    upload = workspace / "upload"
+    deliverables = upload / "deliverable_files"
+    deliverables.mkdir(parents=True)
+    (workspace / "step1_tasks_prepared.json").write_text(
+        json.dumps(prepared), encoding="utf-8"
+    )
+    monkeypatch.setattr(step2, "WORKSPACE_DIR", workspace)
+    monkeypatch.setattr(step2, "UPLOAD_DIR", upload)
+    monkeypatch.setattr(step2, "DELIVERABLE_DIR", deliverables)
+    monkeypatch.setattr(
+        step2,
+        "_load_private_agentic_config",
+        lambda data: dict(data["execution"].get("agentic") or {}),
+    )
+    monkeypatch.setattr(
+        step2.NeedsFilesManifest,
+        "load",
+        classmethod(lambda cls: (_ for _ in ()).throw(FileNotFoundError())),
+    )
+    return workspace
+
+
+def test_step1_preserves_agentic_config_only_when_present(tmp_path, monkeypatch):
+    config = _config()
+    task = SimpleNamespace(
+        task_id="task-1",
+        sector="test",
+        occupation="Analyst",
+        prompt="Create a report",
+        reference_files=[],
+        reference_file_urls=[],
+    )
+    monkeypatch.setattr(step1, "WORKSPACE_DIR", tmp_path)
+    monkeypatch.setattr(step1.ExperimentConfig, "from_yaml", lambda path: config)
+    monkeypatch.setattr(
+        step1,
+        "GDPValDataLoader",
+        lambda auto_download=False: SimpleNamespace(load=lambda: [task]),
+    )
+    monkeypatch.setattr(
+        step1.NeedsFilesManifest,
+        "load",
+        classmethod(lambda cls: (_ for _ in ()).throw(FileNotFoundError())),
+    )
+
+    result = step1.prepare_tasks("fixture.yaml")
+
+    assert result["execution"]["mode"] == "agentic_sandbox"
+    assert result["execution"]["agentic"] == {
+        "compute_transport": "remote",
+        "image": "image@sha256:" + "a" * 64,
+        "verifier_image": "verifier@sha256:" + "b" * 64,
+        "limits": {"max_model_iterations": 3},
+        "budget": config.execution.agentic["budget"],
+        "pricing_table": {"sha256": "c" * 64},
+    }
+
+
+def test_step1_redacts_agentic_control_plane_paths(tmp_path, monkeypatch):
+    config = _config()
+    config.execution.agentic.update({
+        "compute_transport": "remote",
+        "pricing_table": {
+            "sha256": "f" * 64,
+        },
+    })
+    task = SimpleNamespace(
+        task_id="task-1", sector="test", occupation="Analyst",
+        prompt="Create a report", reference_files=[], reference_file_urls=[],
+    )
+    monkeypatch.setattr(step1, "WORKSPACE_DIR", tmp_path)
+    monkeypatch.setattr(step1.ExperimentConfig, "from_yaml", lambda path: config)
+    monkeypatch.setattr(
+        step1, "GDPValDataLoader",
+        lambda auto_download=False: SimpleNamespace(load=lambda: [task]),
+    )
+    monkeypatch.setattr(
+        step1.NeedsFilesManifest, "load",
+        classmethod(lambda cls: (_ for _ in ()).throw(FileNotFoundError())),
+    )
+
+    result = step1.prepare_tasks("fixture.yaml")
+    serialized = json.dumps(result["execution"]["agentic"])
+
+    assert result["execution"]["agentic"]["compute_transport"] == "remote"
+    assert result["execution"]["agentic"]["pricing_table"] == {
+        "sha256": "f" * 64
+    }
+    assert "/private/" not in serialized
+
+
+def test_step2_defers_provider_client_and_passes_factory(tmp_path, monkeypatch):
+    _patch_step2_workspace(tmp_path, monkeypatch, _prepared())
+    provider_factory = MagicMock(side_effect=AssertionError("must stay deferred"))
+    executor_instance = MagicMock()
+    executor_class = MagicMock(return_value=executor_instance)
+    monkeypatch.setattr(step2, "create_provider_client", provider_factory)
+    monkeypatch.setattr(step2, "TaskExecutor", executor_class)
+    monkeypatch.setattr(
+        step2,
+        "_execute_single_task",
+        lambda *args, **kwargs: {
+            "task_id": "task-1",
+            "status": "success",
+            "deliverable_text": "done",
+            "deliverable_files": [],
+            "latency_ms": 1,
+        },
+    )
+
+    step2.run_inference(
+        condition_key="condition_a", resume=False, resume_max_rounds=0
+    )
+
+    provider_factory.assert_not_called()
+    kwargs = executor_class.call_args.kwargs
+    assert kwargs["llm_client"] is None
+    assert callable(kwargs["client_factory"])
+    assert kwargs["provider"] == "azure"
+    assert kwargs["run_id"] == "paired-run"
+    assert kwargs["condition_name"] == "canary"
+    assert kwargs["model_name"] == "test-deployment"
+
+
+def test_reserved_experiments_have_distinct_condition_budget_identities():
+    assert agentic_condition_identity("exp028") == "canary"
+    assert agentic_condition_identity("exp029") == "baseline"
+    assert agentic_condition_identity("exp030") == "treatment"
+    with pytest.raises(ValueError, match="unknown agentic experiment ID"):
+        agentic_condition_identity("exp027")
+
+
+def test_step2_rejects_second_condition_for_reserved_experiment(
+    tmp_path, monkeypatch
+):
+    prepared = _prepared()
+    prepared["condition_b"] = dict(prepared["condition_a"])
+    _patch_step2_workspace(tmp_path, monkeypatch, prepared)
+    monkeypatch.setattr(step2, "create_provider_client", MagicMock())
+
+    with pytest.raises(SystemExit):
+        step2.run_inference(
+            condition_key="condition_a", resume=False, resume_max_rounds=0
+        )
+
+
+@pytest.mark.parametrize("blocked_field", ["qa", "preprocessors"])
+def test_step2_blocks_unledgered_agentic_auxiliary_calls(
+    tmp_path, monkeypatch, blocked_field
+):
+    prepared = _prepared()
+    if blocked_field == "qa":
+        prepared["condition_a"]["qa"] = {"enabled": True}
+    else:
+        prepared["condition_a"]["preprocessors"] = [{"type": "audio_analyzer"}]
+    _patch_step2_workspace(tmp_path, monkeypatch, prepared)
+    provider_factory = MagicMock()
+    monkeypatch.setattr(step2, "create_provider_client", provider_factory)
+
+    with pytest.raises(SystemExit):
+        step2.run_inference(
+            condition_key="condition_a", resume=False, resume_max_rounds=0
+        )
+
+    provider_factory.assert_not_called()
+
+
+def test_agentic_observability_drops_raw_model_and_compute_content():
+    secret = "/private/client/raw-solution.py --dangerous-argv"
+    observed = step2._build_execution_observability({
+        "agentic_metrics": {
+            "schema_version": "1.0",
+            "model_api_calls": 2,
+            "model_iterations": 2,
+            "tool_calls": 3,
+            "tool_errors": 1,
+            "tool_calls_by_name": {"run_python": 1, secret: 99},
+            "model_time_ms": 12.5,
+            "tool_time_ms": 3.5,
+            "task_wall_time_ms": 20,
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cached_tokens": 5,
+            "conservative_cost_usd": "0.0123456789",
+            "usage_complete": True,
+            "terminal_error_category": "verification_failed",
+            "raw_code": secret,
+            "raw_arguments": secret,
+            "stdout": secret,
+        }
+    }, [])
+
+    metrics = observed["agentic_metrics"]
+    assert metrics["model_api_calls"] == 2
+    assert metrics["tool_calls_by_name"] == {"run_python": 1}
+    assert metrics["conservative_cost_usd"] == 0.01234568
+    assert secret not in str(observed)
+
+
+def test_resume_merge_does_not_double_count_ledger_cumulative_usage():
+    previous = {
+        "schema_version": "1.0",
+        "ledger_cumulative": True,
+        "model_api_calls": 1,
+        "model_iterations": 1,
+        "tool_calls": 2,
+        "tool_errors": 0,
+        "tool_calls_by_name": {"run_python": 1, "inspect_artifacts": 1},
+        "model_time_ms": 10,
+        "tool_time_ms": 5,
+        "task_wall_time_ms": 20,
+        "finalize_required_corrections": 0,
+        "finalize_attempts": 0,
+        "capability_misses": 0,
+        "recovered_after_tool_error": False,
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cached_tokens": 5,
+        "conservative_cost_usd": 0.1,
+        "usage_complete": True,
+        "terminal_error_category": "model_api_error",
+    }
+    current = {
+        **previous,
+        "model_api_calls": 2,
+        "model_iterations": 1,
+        "tool_calls": 1,
+        "tool_calls_by_name": {"finalize": 1},
+        "input_tokens": 220,
+        "output_tokens": 50,
+        "cached_tokens": 7,
+        "conservative_cost_usd": 0.25,
+        "terminal_error_category": None,
+    }
+
+    merged = step2._merge_agentic_metrics(previous, current)
+
+    assert merged["model_api_calls"] == 2
+    assert merged["input_tokens"] == 220
+    assert merged["output_tokens"] == 50
+    assert merged["model_iterations"] == 2
+    assert merged["tool_calls"] == 3
+    assert merged["cached_tokens"] == 12
+    assert merged["conservative_cost_usd"] == 0.25
+
+
+def test_hardened_task_passes_relative_reference_ids_without_host_reads(
+    tmp_path, monkeypatch
+):
+    executor = MagicMock()
+    executor.execute.return_value = {
+        "success": False,
+        "error": "remote_compute_rejected_input",
+        "text": "",
+        "files": [],
+    }
+    monkeypatch.setattr(step2, "DEFAULT_LOCAL_PATH", tmp_path)
+    task = {
+        "task_id": "task-1",
+        "instruction": "Create a report",
+        "occupation": "Analyst",
+        "reference_files": ["missing.xlsx"],
+    }
+    condition = {
+        "prompt": {"system": "system"},
+        "preprocessors": [],
+    }
+
+    result = step2._execute_single_task(
+        task,
+        condition,
+        executor,
+        "agentic_sandbox",
+        None,
+        "model",
+        strict_inputs=True,
+    )
+
+    assert result["status"] == "error"
+    assert result["error"] == "remote_compute_rejected_input"
+    assert executor.execute.call_args.kwargs["reference_files"] == [
+        "missing.xlsx"
+    ]
+
+
+def test_save_files_accepts_nested_canonical_deliverable(tmp_path, monkeypatch):
+    upload = tmp_path / "upload"
+    deliverables = upload / "deliverable_files"
+    monkeypatch.setattr(step2, "UPLOAD_DIR", upload)
+    monkeypatch.setattr(step2, "DELIVERABLE_DIR", deliverables)
+
+    saved = step2._save_files(
+        [{"filename": "reports/final.pdf", "content": b"pdf"}],
+        "task-1",
+    )
+
+    assert saved == ["deliverable_files/task-1/reports/final.pdf"]
+    assert (deliverables / "task-1" / "reports" / "final.pdf").read_bytes() == b"pdf"
+
+
+@pytest.mark.parametrize(
+    ("task_id", "filename"),
+    [
+        ("../other-task", "report.txt"),
+        ("task-1", "../escape.txt"),
+        ("task-1", "/tmp/escape.txt"),
+        ("task-1", ".hidden.txt"),
+    ],
+)
+def test_save_files_rejects_task_and_filename_traversal(
+    tmp_path, monkeypatch, task_id, filename
+):
+    upload = tmp_path / "upload"
+    monkeypatch.setattr(step2, "UPLOAD_DIR", upload)
+    monkeypatch.setattr(step2, "DELIVERABLE_DIR", upload / "deliverable_files")
+
+    with pytest.raises(ValueError, match="deliverable"):
+        step2._save_files([{"filename": filename, "content": b"x"}], task_id)
+
+
+def test_save_files_rejects_symlink_parent_and_duplicate_name(tmp_path, monkeypatch):
+    upload = tmp_path / "upload"
+    deliverables = upload / "deliverable_files"
+    task_dir = deliverables / "task-1"
+    task_dir.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (task_dir / "reports").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(step2, "UPLOAD_DIR", upload)
+    monkeypatch.setattr(step2, "DELIVERABLE_DIR", deliverables)
+
+    with pytest.raises(ValueError, match="parent"):
+        step2._save_files(
+            [{"filename": "reports/final.pdf", "content": b"x"}],
+            "task-1",
+        )
+    with pytest.raises(ValueError, match="duplicated"):
+        step2._save_files(
+            [
+                {"filename": "report.txt", "content": b"one"},
+                {"filename": "report.txt", "content": b"two"},
+            ],
+            "task-2",
+        )
+
+
+def test_progress_checkpoint_requires_exact_identity_and_recovers_missing_tasks(
+    tmp_path
+):
+    path = tmp_path / "progress.json"
+    document = {
+        "schema_version": "step2-progress-v2",
+        "experiment_id": "exp030",
+        "condition": "Treatment",
+        "condition_identity": "treatment",
+        "run_id": "paired-run",
+        "execution_mode": "agentic_sandbox",
+        "ordered_task_ids": ["task-1", "task-2"],
+        "total_tasks": 2,
+        "started_at": "2026-07-17T00:00:00+00:00",
+        "resume_round": 0,
+        "results": [{"task_id": "task-1", "status": "success"}],
+    }
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+    loaded = step2._load_and_validate_progress(
+        path,
+        experiment_id="exp030",
+        condition_name="Treatment",
+        condition_identity="treatment",
+        run_id="paired-run",
+        execution_mode="agentic_sandbox",
+        ordered_task_ids=["task-1", "task-2"],
+    )
+
+    assert [result["task_id"] for result in loaded["results"]] == [
+        "task-1", "task-2"
+    ]
+    assert loaded["results"][1]["status"] == "pending"
+    assert loaded["results"][1]["error"] == "checkpoint_missing_task"
+
+    with pytest.raises(ValueError, match="identity mismatch"):
+        step2._load_and_validate_progress(
+            path,
+            experiment_id="exp030",
+            condition_name="Treatment",
+            condition_identity="treatment",
+            run_id="other-run",
+            execution_mode="agentic_sandbox",
+            ordered_task_ids=["task-1", "task-2"],
+        )
+
+
+def test_progress_task_set_rejects_duplicate_extra_and_final_reordering():
+    ordered = ["task-1", "task-2"]
+    with pytest.raises(ValueError, match="duplicate"):
+        step2._validate_result_task_set(
+            [{"task_id": "task-1"}, {"task_id": "task-1"}],
+            ordered,
+            allow_missing=True,
+        )
+    with pytest.raises(ValueError, match="unexpected"):
+        step2._validate_result_task_set(
+            [{"task_id": "task-3"}], ordered, allow_missing=True
+        )
+    with pytest.raises(ValueError, match="differ from ordered"):
+        step2._validate_result_task_set(
+            [{"task_id": "task-2"}, {"task_id": "task-1"}],
+            ordered,
+            allow_missing=False,
+        )
+
+
+def test_baseline_budget_observability_uses_strict_allowlist():
+    secret = "/private/ledger.sqlite3"
+    observed = step2._build_execution_observability({
+        "budget_metrics": {
+            "schema_version": "1.0",
+            "model_api_calls": 2,
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cached_tokens": 5,
+            "conservative_cost_usd": "0.5",
+            "usage_complete": True,
+            "ledger_path": secret,
+        }
+    }, [])
+
+    assert observed["budget_metrics"] == {
+        "schema_version": "1.0",
+        "model_api_calls": 2,
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cached_tokens": 5,
+        "conservative_cost_usd": 0.5,
+        "usage_complete": True,
+    }
+    assert secret not in str(observed)
+
+
+def test_substrate_observability_keeps_hashes_and_drops_paths():
+    secret = "/private/seccomp.json"
+    manifest = {
+        "schema_version": "1.0",
+        "sha256": "a" * 64,
+        "task_image": "image@sha256:" + "b" * 64,
+        "task_image_id": "sha256:" + "c" * 64,
+        "verifier_image": "image@sha256:" + "b" * 64,
+        "verifier_image_id": "sha256:" + "c" * 64,
+        "component_sha256": {
+            "python_launcher": "d" * 64,
+            "ffmpeg_mapper": "e" * 64,
+            "verifier": "f" * 64,
+            "outer_seccomp": "1" * 64,
+            "capabilities": "2" * 64,
+            "core_tree": "4" * 64,
+        },
+        "sbom_sha256": "3" * 64,
+        "uid": 65532,
+        "gid": 65532,
+        "network": "none",
+        "ipc": "none",
+        "pid_namespace": "private",
+        "read_only_rootfs": True,
+        "cap_drop": ["ALL"],
+        "no_new_privileges": True,
+        "memory_bytes": 8 * 1024 * 1024 * 1024,
+        "memory_swap_bytes": 8 * 1024 * 1024 * 1024,
+        "cpus": 2,
+        "pids": 128,
+        "nofile": 256,
+        "apparmor_profile": "gdpval-agentic",
+        "work_tmpfs": {
+            "size_bytes": 512 * 1024 * 1024,
+            "nr_inodes": 1024,
+            "nosuid": True,
+            "nodev": True,
+            "noexec": True,
+        },
+        "seccomp_path": secret,
+    }
+
+    observed = step2._build_execution_observability(
+        {"substrate_manifest": manifest}, []
+    )
+
+    assert observed["substrate"]["sha256"] == "a" * 64
+    assert observed["substrate"]["memory_bytes"] == 8 * 1024 * 1024 * 1024
+    assert secret not in str(observed)

--- a/batch-runner/tests/test_agentic_pricing.py
+++ b/batch-runner/tests/test_agentic_pricing.py
@@ -1,0 +1,61 @@
+"""Tests for immutable agentic model pricing tables."""
+
+import hashlib
+import json
+
+import pytest
+
+from core.agentic_pricing import load_pinned_model_pricing
+
+
+def _table(tmp_path):
+    path = tmp_path / "pricing.json"
+    path.write_text(json.dumps({
+        "schema_version": "agentic-pricing-v1",
+        "models": {
+            "azure:deployment": {
+                "input_per_million": "1.25",
+                "output_per_million": "10.00",
+                "cached_input_per_million": "0.125",
+                "currency": "USD",
+            }
+        },
+    }, sort_keys=True), encoding="utf-8")
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return path, digest
+
+
+def test_loads_only_exact_hash_and_model(tmp_path):
+    path, digest = _table(tmp_path)
+
+    result = load_pinned_model_pricing(
+        path=path,
+        expected_sha256=digest,
+        provider="azure",
+        model="deployment",
+    )
+
+    assert result == {
+        "input_per_million": "1.25",
+        "output_per_million": "10.00",
+        "cached_input_per_million": "0.125",
+        "price_table_sha256": digest,
+    }
+
+
+def test_rejects_hash_drift_and_unknown_model(tmp_path):
+    path, digest = _table(tmp_path)
+    with pytest.raises(ValueError, match="hash mismatch"):
+        load_pinned_model_pricing(
+            path=path,
+            expected_sha256="0" * 64,
+            provider="azure",
+            model="deployment",
+        )
+    with pytest.raises(ValueError, match="no pinned price entry"):
+        load_pinned_model_pricing(
+            path=path,
+            expected_sha256=digest,
+            provider="openai",
+            model="deployment",
+        )

--- a/batch-runner/tests/test_agentic_pricing.py
+++ b/batch-runner/tests/test_agentic_pricing.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from core.agentic_pricing import load_pinned_model_pricing
+from core.agentic_sandbox_runner import AgenticPricing
 
 
 def _table(tmp_path):
@@ -59,3 +60,16 @@ def test_rejects_hash_drift_and_unknown_model(tmp_path):
             provider="openai",
             model="deployment",
         )
+
+
+def test_worst_case_uses_higher_cached_input_price():
+    pricing = AgenticPricing.from_options({
+        "input_per_million": "1",
+        "cached_input_per_million": "3",
+        "output_per_million": "10",
+    })
+
+    reserved = pricing.worst_case(1_000_000, 100_000)
+    all_cached_actual = pricing.actual(1_000_000, 100_000, 1_000_000)
+
+    assert reserved == all_cached_actual == 4

--- a/batch-runner/tests/test_agentic_remote_compute.py
+++ b/batch-runner/tests/test_agentic_remote_compute.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import tempfile
 import threading
+import ijson
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -21,9 +22,14 @@ from core.agentic_channel import (
     EnvelopeAuthority,
 )
 from core.agentic_compute_service import ApprovedDockerBackendFactory
-from core.agentic_compute_service import ComputeHTTPServer
+from core.agentic_compute_service import (
+    ComputeHTTPServer,
+    _command_deadline,
+    _encode_response_before_deadline,
+)
 from core.agentic_remote_compute import (
     MutualTLSComputeTransport,
+    _json_loads_before_deadline,
     remote_backend_factory_from_environment,
 )
 
@@ -43,6 +49,7 @@ class FakeResponse:
     def __init__(self, body, status=200, declared_length=None):
         self.body = body
         self.status = status
+        self.offset = 0
         self.declared_length = (
             len(body) if declared_length is None else declared_length
         )
@@ -51,7 +58,9 @@ class FakeResponse:
         return str(self.declared_length) if name == "Content-Length" else None
 
     def read(self, length):
-        return self.body[:length]
+        chunk = self.body[self.offset:self.offset + length]
+        self.offset += len(chunk)
+        return chunk
 
 
 class FakeConnection:
@@ -140,6 +149,202 @@ def test_mtls_transport_rejects_oversized_declared_result(
         })
 
 
+def test_compute_response_encoding_stops_at_signed_deadline(monkeypatch):
+    current = [100.0]
+
+    def now():
+        current[0] += 0.4
+        return current[0]
+
+    monkeypatch.setattr("core.agentic_compute_service.time.time", now)
+
+    with pytest.raises(TimeoutError, match="encoding deadline"):
+        _encode_response_before_deadline(
+            {"payload": ["x"] * 100}, deadline_at=100.5
+        )
+
+
+def test_compute_service_requires_bounded_deadline_before_dispatch(monkeypatch):
+    monkeypatch.setattr("core.agentic_compute_service.time.time", lambda: 100.0)
+
+    with pytest.raises(ValueError, match="deadline is invalid"):
+        _command_deadline({"payload": {"timeout_seconds": 60}})
+    with pytest.raises(ValueError, match="deadline is invalid"):
+        _command_deadline({
+            "payload": {"timeout_seconds": 60, "deadline_at": 1_301.0}
+        })
+    assert _command_deadline({
+        "payload": {"timeout_seconds": 60, "deadline_at": 160.0}
+    }) == 160.0
+
+
+def test_mtls_chunked_read_enforces_one_attempt_deadline(
+    tmp_path, monkeypatch
+):
+    body = json.dumps({"value": "x" * 70_000}).encode("utf-8")
+    response = FakeResponse(body)
+    transport, _ = _transport(tmp_path, monkeypatch, response)
+    current = [0.0]
+
+    def monotonic():
+        return current[0]
+
+    original_read = response.read
+
+    def slow_read(length):
+        chunk = original_read(length)
+        current[0] += 0.6
+        return chunk
+
+    response.read = slow_read
+    monkeypatch.setattr(
+        "core.agentic_remote_compute.time.monotonic", monotonic
+    )
+
+    with pytest.raises(TimeoutError, match="transport deadline"):
+        transport.exchange(
+            {
+                "payload": {"timeout_seconds": 1},
+            },
+            timeout_seconds=1,
+        )
+
+
+def test_mtls_json_parse_enforces_one_attempt_deadline(monkeypatch):
+    payload = json.dumps({"value": "x" * 200_000}).encode("utf-8")
+    current = [0.0]
+
+    def monotonic():
+        current[0] += 0.2
+        return current[0]
+
+    monkeypatch.setattr(
+        "core.agentic_remote_compute.time.monotonic", monotonic
+    )
+
+    with pytest.raises(TimeoutError, match="transport deadline"):
+        _json_loads_before_deadline(payload, 1.0)
+
+
+def test_streaming_json_preserves_numbers_and_byte_encodings():
+    client = EnvelopeAuthority(
+        b"k" * 32, ChannelScope("run", "condition", "task")
+    )
+    server = EnvelopeAuthority(
+        b"k" * 32, ChannelScope("run", "condition", "task")
+    )
+    command = client.command(
+        sequence=1,
+        operation="export_best_snapshot",
+        payload={"timeout_seconds": 60, "deadline_at": 10_060.0},
+        expires_at=10_060,
+    )
+    result = server.result(
+        command=command,
+        payload={
+            "ok": True,
+            "huge_integer": 2 ** 100,
+            "fraction": 1.25,
+            "legacy": {"$bytes": "eA=="},
+            "current": b"y",
+        },
+        expires_at=10_060,
+    )
+    payload = json.dumps(
+        result, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+    parsed = _json_loads_before_deadline(
+        payload, __import__("time").monotonic() + 10
+    )
+    decoded = client.verify_result(parsed, command=command, now=10_000)
+
+    assert decoded["huge_integer"] == 2 ** 100
+    assert type(decoded["huge_integer"]) is int
+    assert decoded["fraction"] == 1.25
+    assert type(decoded["fraction"]) is float
+    assert decoded["legacy"] == b"x"
+    assert decoded["current"] == b"y"
+    assert isinstance(ijson.backend, str) and ijson.backend
+
+
+@pytest.mark.parametrize(
+    ("constant", "value", "payload", "match"),
+    [
+        (
+            "MAX_JSON_DEPTH",
+            3,
+            json.dumps({"a": [[[[1]]]]}).encode("utf-8"),
+            "depth cap",
+        ),
+        (
+            "MAX_JSON_NODES",
+            8,
+            json.dumps({"a": list(range(20))}).encode("utf-8"),
+            "node cap",
+        ),
+        (
+            "MAX_JSON_STRING_BYTES",
+            8,
+            json.dumps({"a": "x" * 20}).encode("utf-8"),
+            "string cap",
+        ),
+        (
+            "MAX_JSON_MATERIALIZED_BYTES",
+            256,
+            json.dumps({"a": ["value"] * 20}).encode("utf-8"),
+            "materialized byte cap",
+        ),
+    ],
+)
+def test_streaming_json_rejects_amplification_shapes(
+    monkeypatch, constant, value, payload, match
+):
+    monkeypatch.setattr(
+        f"core.agentic_remote_compute.{constant}", value
+    )
+
+    with pytest.raises(RuntimeError, match=match):
+        _json_loads_before_deadline(
+            payload, __import__("time").monotonic() + 10
+        )
+
+
+def test_streaming_json_rejects_duplicate_keys():
+    with pytest.raises(RuntimeError, match="duplicate keys"):
+        _json_loads_before_deadline(
+            b'{"value":1,"value":2}',
+            __import__("time").monotonic() + 10,
+        )
+
+
+def test_mtls_transport_does_not_reset_callers_absolute_deadline(
+    tmp_path, monkeypatch
+):
+    body = json.dumps({"ok": True}).encode("utf-8")
+    response = FakeResponse(body)
+    transport, _ = _transport(tmp_path, monkeypatch, response)
+    current = [100.8]
+    original_read = response.read
+
+    def slow_read(length):
+        current[0] += 0.3
+        return original_read(length)
+
+    response.read = slow_read
+    monkeypatch.setattr(
+        "core.agentic_remote_compute.time.monotonic",
+        lambda: current[0],
+    )
+
+    with pytest.raises(TimeoutError, match="transport deadline"):
+        transport.exchange(
+            {"payload": {"timeout_seconds": 10}},
+            timeout_seconds=10,
+            monotonic_deadline=101.0,
+        )
+
+
 def test_remote_factory_environment_is_fail_closed(monkeypatch):
     for name in (
         "AGENTIC_COMPUTE_ENDPOINT", "AGENTIC_COMPUTE_CA_PATH",
@@ -178,6 +383,7 @@ def test_approved_compute_factory_maps_only_frozen_reference_ids(
     manifest = tmp_path / "inputs.json"
     manifest_body = {
         "schema_version": "agentic-input-manifest-v1",
+        "selection_recomputation_sha256": "e" * 64,
         "provider_classification": "approved_public_gdpval",
         "staging_filesystem_device": Path(tempfile.gettempdir()).stat().st_dev,
         "tasks": {
@@ -229,7 +435,8 @@ def test_approved_compute_factory_maps_only_frozen_reference_ids(
 
     assert backend.start()["ok"] is True
     assert captured["reference_files"] == [{
-        "source_path": str(source),
+        "source_root": str(dataset),
+        "source_path": "source.txt",
         "relative_path": "inputs/source.txt",
     }]
     assert captured["approved_input_manifest"] == {
@@ -242,6 +449,8 @@ def test_approved_compute_factory_maps_only_frozen_reference_ids(
             )
         }
     }
+    assert captured["selection_recomputation_sha256"] == "e" * 64
+    assert captured["provider_classification"] == "approved_public_gdpval"
 
     with pytest.raises(ValueError, match="reference IDs differ"):
         factory(
@@ -250,6 +459,123 @@ def test_approved_compute_factory_maps_only_frozen_reference_ids(
             occupation="Analyst",
             task_id="task-1",
         )
+
+
+def test_approved_compute_factory_rejects_mixed_provider_classification(
+    tmp_path, monkeypatch
+):
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    source = dataset / "source.txt"
+    source.write_text("approved", encoding="utf-8")
+    metadata = source.stat()
+    body = {
+        "schema_version": "agentic-input-manifest-v1",
+        "selection_recomputation_sha256": "e" * 64,
+        "provider_classification": "approved_public_gdpval",
+        "staging_filesystem_device": Path(tempfile.gettempdir()).stat().st_dev,
+        "tasks": {
+            "task-1": {
+                "reference_ids": ["ref-1"],
+                "files": [{
+                    "reference_id": "ref-1",
+                    "source_path": "source.txt",
+                    "relative_path": "source.txt",
+                    "path": "source.txt",
+                    "type": "regular",
+                    "link_count": 1,
+                    "size_bytes": metadata.st_size,
+                    "source_allocated_bytes": metadata.st_blocks * 512,
+                    "staged_allocated_bytes": metadata.st_blocks * 512,
+                    "sha256": "a" * 64,
+                    "provider_classification": "different_classification",
+                }],
+                "input_merkle_root": "b" * 64,
+            }
+        },
+    }
+    document = {
+        **body,
+        "sha256": hashlib.sha256(json.dumps(
+            body, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")).hexdigest(),
+    }
+    path = tmp_path / "inputs.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    factory = ApprovedDockerBackendFactory(
+        input_manifest_path=path,
+        dataset_root=dataset,
+        image="image@sha256:" + "c" * 64,
+        verifier_image="image@sha256:" + "c" * 64,
+        seccomp_profile="seccomp.json",
+        apparmor_profile="agentic-profile",
+        sbom_sha256="d" * 64,
+    )
+
+    with pytest.raises(ValueError, match="classification differs"):
+        factory(
+            task_prompt="task",
+            reference_ids=["ref-1"],
+            occupation="Analyst",
+            task_id="task-1",
+        )
+
+
+def test_approved_compute_factory_uses_manifest_classification_for_empty_task(
+    tmp_path, monkeypatch
+):
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    body = {
+        "schema_version": "agentic-input-manifest-v1",
+        "selection_recomputation_sha256": "e" * 64,
+        "provider_classification": "approved_zero_input",
+        "staging_filesystem_device": Path(tempfile.gettempdir()).stat().st_dev,
+        "tasks": {
+            "task-empty": {
+                "reference_ids": [],
+                "files": [],
+                "input_merkle_root": "b" * 64,
+            }
+        },
+    }
+    document = {
+        **body,
+        "sha256": hashlib.sha256(json.dumps(
+            body, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")).hexdigest(),
+    }
+    path = tmp_path / "inputs.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    captured = {}
+
+    class FakeBackend:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "core.agentic_compute_service.AgenticDockerBackend", FakeBackend
+    )
+    factory = ApprovedDockerBackendFactory(
+        input_manifest_path=path,
+        dataset_root=dataset,
+        image="image@sha256:" + "c" * 64,
+        verifier_image="image@sha256:" + "c" * 64,
+        seccomp_profile="seccomp.json",
+        apparmor_profile="agentic-profile",
+        sbom_sha256="d" * 64,
+    )
+
+    factory(
+        task_prompt="task",
+        reference_ids=[],
+        occupation="Analyst",
+        task_id="task-empty",
+    )
+
+    assert captured["reference_files"] == []
+    assert captured["approved_input_manifest"] == {}
+    assert captured["provider_classification"] == "approved_zero_input"
 
 
 def _certificate_fixture(tmp_path):
@@ -327,15 +653,19 @@ def test_real_mutual_tls_authenticated_roundtrip(tmp_path):
     scope = ChannelScope("run", "treatment", "task")
     key = b"m" * 32
 
+    backends = []
+
     class Backend:
         def __init__(self, **kwargs):
             self.kwargs = kwargs
+            self.closed = False
+            backends.append(self)
 
         def start(self, timeout_seconds=1200.0):
             return {"ok": True, "data": {"started": True}}
 
         def close(self):
-            return None
+            self.closed = True
 
     compute = ComputeChannelServer(
         EnvelopeAuthority(key, scope), lambda **kwargs: Backend(**kwargs)
@@ -356,6 +686,7 @@ def test_real_mutual_tls_authenticated_roundtrip(tmp_path):
             payload={
                 "task_spec": {"task_prompt": "task"},
                 "timeout_seconds": 60,
+                "deadline_at": datetime.now(timezone.utc).timestamp() + 60,
             },
             expires_at=int(datetime.now(timezone.utc).timestamp()) + 60,
         )
@@ -372,6 +703,21 @@ def test_real_mutual_tls_authenticated_roundtrip(tmp_path):
         decoded = authority.verify_result(response, command=command)
 
         assert decoded == {"ok": True, "data": {"started": True}}
+        close_command = authority.command(
+            sequence=2,
+            operation="close",
+            payload={
+                "timeout_seconds": 30.0,
+                "deadline_at": datetime.now(timezone.utc).timestamp() + 30,
+            },
+            expires_at=int(datetime.now(timezone.utc).timestamp()) + 60,
+        )
+        close_response = transport.exchange(close_command)
+        close_decoded = authority.verify_result(
+            close_response, command=close_command
+        )
+        assert close_decoded == {"ok": True, "data": {}}
+        assert backends[0].closed is True
     finally:
         server.shutdown()
         server.server_close()

--- a/batch-runner/tests/test_agentic_remote_compute.py
+++ b/batch-runner/tests/test_agentic_remote_compute.py
@@ -1,0 +1,378 @@
+"""Tests for mutual-TLS remote compute wiring without network calls."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from core.agentic_channel import (
+    ChannelScope,
+    ComputeChannelServer,
+    EnvelopeAuthority,
+)
+from core.agentic_compute_service import ApprovedDockerBackendFactory
+from core.agentic_compute_service import ComputeHTTPServer
+from core.agentic_remote_compute import (
+    MutualTLSComputeTransport,
+    remote_backend_factory_from_environment,
+)
+
+
+class FakeSSLContext:
+    def __init__(self):
+        self.minimum_version = None
+        self.check_hostname = None
+        self.verify_mode = None
+        self.cert_chain = None
+
+    def load_cert_chain(self, certfile, keyfile):
+        self.cert_chain = (certfile, keyfile)
+
+
+class FakeResponse:
+    def __init__(self, body, status=200, declared_length=None):
+        self.body = body
+        self.status = status
+        self.declared_length = (
+            len(body) if declared_length is None else declared_length
+        )
+
+    def getheader(self, name):
+        return str(self.declared_length) if name == "Content-Length" else None
+
+    def read(self, length):
+        return self.body[:length]
+
+
+class FakeConnection:
+    response = None
+    calls = []
+
+    def __init__(self, host, port, **kwargs):
+        self.host = host
+        self.port = port
+        self.kwargs = kwargs
+
+    def request(self, method, path, body, headers):
+        self.calls.append((method, path, body, headers))
+
+    def getresponse(self):
+        return self.response
+
+    def close(self):
+        pass
+
+
+def _transport(tmp_path, monkeypatch, response):
+    for name in ("ca.pem", "client.pem", "client.key"):
+        (tmp_path / name).write_text("fixture", encoding="utf-8")
+    context = FakeSSLContext()
+    monkeypatch.setattr(
+        "core.agentic_remote_compute.ssl.create_default_context",
+        lambda purpose, cafile: context,
+    )
+    FakeConnection.response = response
+    FakeConnection.calls = []
+    return MutualTLSComputeTransport(
+        endpoint="https://compute.example.test/v1/agentic/compute",
+        ca_path=tmp_path / "ca.pem",
+        client_cert_path=tmp_path / "client.pem",
+        client_key_path=tmp_path / "client.key",
+        connection_factory=FakeConnection,
+    ), context
+
+
+def test_mtls_transport_requires_https_and_exact_response_length(
+    tmp_path, monkeypatch
+):
+    body = json.dumps({"ok": True}).encode("utf-8")
+    transport, context = _transport(
+        tmp_path, monkeypatch, FakeResponse(body)
+    )
+
+    result = transport.exchange({
+        "command": "fixture",
+        "payload": {"timeout_seconds": 7.5},
+    })
+
+    assert result == {"ok": True}
+    assert context.cert_chain == (
+        str(tmp_path / "client.pem"), str(tmp_path / "client.key")
+    )
+    assert FakeConnection.calls[0][0:2] == (
+        "POST", "/v1/agentic/compute"
+    )
+    assert FakeConnection.calls
+
+    with pytest.raises(ValueError, match="plain HTTPS"):
+        MutualTLSComputeTransport(
+            endpoint="http://compute.example.test/path",
+            ca_path=tmp_path / "ca.pem",
+            client_cert_path=tmp_path / "client.pem",
+            client_key_path=tmp_path / "client.key",
+        )
+
+
+def test_mtls_transport_rejects_oversized_declared_result(
+    tmp_path, monkeypatch
+):
+    transport, _ = _transport(
+        tmp_path,
+        monkeypatch,
+        FakeResponse(b"{}", declared_length=999),
+    )
+    transport.max_result_bytes = 100
+
+    with pytest.raises(RuntimeError, match="exceeds byte cap"):
+        transport.exchange({
+            "command": "fixture",
+            "payload": {"timeout_seconds": 10},
+        })
+
+
+def test_remote_factory_environment_is_fail_closed(monkeypatch):
+    for name in (
+        "AGENTIC_COMPUTE_ENDPOINT", "AGENTIC_COMPUTE_CA_PATH",
+        "AGENTIC_COMPUTE_CLIENT_CERT_PATH", "AGENTIC_COMPUTE_CLIENT_KEY_PATH",
+        "AGENTIC_COMPUTE_CHANNEL_KEY_B64",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(ValueError, match="environment is incomplete"):
+        remote_backend_factory_from_environment(
+            run_id="run", condition_name="treatment"
+        )
+
+
+def test_approved_compute_factory_maps_only_frozen_reference_ids(
+    tmp_path, monkeypatch
+):
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    source = dataset / "source.txt"
+    source.write_text("approved", encoding="utf-8")
+    metadata = source.stat()
+    record = {
+        "reference_id": "ref-1",
+        "source_path": "source.txt",
+        "relative_path": "inputs/source.txt",
+        "path": "inputs/source.txt",
+        "type": "regular",
+        "link_count": 1,
+        "size_bytes": metadata.st_size,
+        "source_allocated_bytes": metadata.st_blocks * 512,
+        "staged_allocated_bytes": metadata.st_blocks * 512,
+        "sha256": "a" * 64,
+        "provider_classification": "approved_public_gdpval",
+    }
+    manifest = tmp_path / "inputs.json"
+    manifest_body = {
+        "schema_version": "agentic-input-manifest-v1",
+        "provider_classification": "approved_public_gdpval",
+        "staging_filesystem_device": Path(tempfile.gettempdir()).stat().st_dev,
+        "tasks": {
+            "task-1": {
+                "reference_ids": ["ref-1"],
+                "files": [record],
+                "input_merkle_root": "b" * 64,
+            }
+        },
+    }
+    manifest_document = {
+        **manifest_body,
+        "sha256": hashlib.sha256(json.dumps(
+            manifest_body, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")).hexdigest(),
+    }
+    manifest.write_text(json.dumps(manifest_document), encoding="utf-8")
+    captured = {}
+
+    class FakeBackend:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def start(self, timeout_seconds=1200.0):
+            return {"ok": True, "data": {"input_merkle_root": "b" * 64}}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "core.agentic_compute_service.AgenticDockerBackend", FakeBackend
+    )
+    factory = ApprovedDockerBackendFactory(
+        input_manifest_path=manifest,
+        dataset_root=dataset,
+        image="image@sha256:" + "c" * 64,
+        verifier_image="image@sha256:" + "c" * 64,
+        seccomp_profile="seccomp.json",
+        apparmor_profile="agentic-profile",
+        sbom_sha256="d" * 64,
+    )
+
+    backend = factory(
+        task_prompt="task",
+        reference_ids=["ref-1"],
+        occupation="Analyst",
+        task_id="task-1",
+    )
+
+    assert backend.start()["ok"] is True
+    assert captured["reference_files"] == [{
+        "source_path": str(source),
+        "relative_path": "inputs/source.txt",
+    }]
+    assert captured["approved_input_manifest"] == {
+        "inputs/source.txt": {
+            key: record[key]
+            for key in (
+                "path", "type", "link_count", "size_bytes",
+                "source_allocated_bytes", "sha256",
+                "provider_classification",
+            )
+        }
+    }
+
+    with pytest.raises(ValueError, match="reference IDs differ"):
+        factory(
+            task_prompt="task",
+            reference_ids=[],
+            occupation="Analyst",
+            task_id="task-1",
+        )
+
+
+def _certificate_fixture(tmp_path):
+    now = datetime.now(timezone.utc)
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Agentic Test CA")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(hours=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    def issue(name, usage, dns_name=None):
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, name)]))
+            .issuer_name(ca_name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=1))
+            .not_valid_after(now + timedelta(hours=1))
+            .add_extension(x509.ExtendedKeyUsage([usage]), critical=False)
+        )
+        if dns_name:
+            builder = builder.add_extension(
+                x509.SubjectAlternativeName([x509.DNSName(dns_name)]),
+                critical=False,
+            )
+        return key, builder.sign(ca_key, hashes.SHA256())
+
+    server_key, server_cert = issue(
+        "localhost", ExtendedKeyUsageOID.SERVER_AUTH, "localhost"
+    )
+    client_key, client_cert = issue(
+        "agentic-control", ExtendedKeyUsageOID.CLIENT_AUTH
+    )
+    ca_path = tmp_path / "ca.pem"
+    server_cert_path = tmp_path / "server.pem"
+    server_key_path = tmp_path / "server.key"
+    client_cert_path = tmp_path / "client.pem"
+    client_key_path = tmp_path / "client.key"
+    ca_path.write_bytes(ca_cert.public_bytes(serialization.Encoding.PEM))
+    for path, value in (
+        (server_cert_path, server_cert),
+        (client_cert_path, client_cert),
+    ):
+        path.write_bytes(value.public_bytes(serialization.Encoding.PEM))
+    for path, value in (
+        (server_key_path, server_key),
+        (client_key_path, client_key),
+    ):
+        path.write_bytes(value.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ))
+    return (
+        ca_path, server_cert_path, server_key_path,
+        client_cert_path, client_key_path,
+    )
+
+
+def test_real_mutual_tls_authenticated_roundtrip(tmp_path):
+    (
+        ca_path, server_cert_path, server_key_path,
+        client_cert_path, client_key_path,
+    ) = _certificate_fixture(tmp_path)
+    scope = ChannelScope("run", "treatment", "task")
+    key = b"m" * 32
+
+    class Backend:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def start(self, timeout_seconds=1200.0):
+            return {"ok": True, "data": {"started": True}}
+
+        def close(self):
+            return None
+
+    compute = ComputeChannelServer(
+        EnvelopeAuthority(key, scope), lambda **kwargs: Backend(**kwargs)
+    )
+    server = ComputeHTTPServer(("127.0.0.1", 0), compute)
+    context = __import__("ssl").SSLContext(__import__("ssl").PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(server_cert_path, server_key_path)
+    context.load_verify_locations(ca_path)
+    context.verify_mode = __import__("ssl").CERT_REQUIRED
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        authority = EnvelopeAuthority(key, scope)
+        command = authority.command(
+            sequence=1,
+            operation="start",
+            payload={
+                "task_spec": {"task_prompt": "task"},
+                "timeout_seconds": 60,
+            },
+            expires_at=int(datetime.now(timezone.utc).timestamp()) + 60,
+        )
+        transport = MutualTLSComputeTransport(
+            endpoint=(
+                f"https://localhost:{server.server_address[1]}"
+                "/v1/agentic/compute"
+            ),
+            ca_path=ca_path,
+            client_cert_path=client_cert_path,
+            client_key_path=client_key_path,
+        )
+        response = transport.exchange(command)
+        decoded = authority.verify_result(response, command=command)
+
+        assert decoded == {"ok": True, "data": {"started": True}}
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/batch-runner/tests/test_agentic_runtime_identity.py
+++ b/batch-runner/tests/test_agentic_runtime_identity.py
@@ -1,0 +1,93 @@
+"""Tests for runtime-derived signed approval identities."""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from core.agentic_runtime_identity import (
+    PLAN_MERGE_SHA,
+    derive_runtime_identity,
+    derive_runtime_identity_from_environment,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = Path(".github/workflows/batch-run.yml")
+
+
+def _clean_repository(tmp_path):
+    repository = tmp_path / "repository"
+    workflow = repository / WORKFLOW
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("name: Agentic fixture\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+    subprocess.run(["git", "add", "."], cwd=repository, check=True)
+    subprocess.run(
+        [
+            "git", "-c", "user.name=Agentic Test",
+            "-c", "user.email=agentic@example.invalid",
+            "commit", "-qm", "fixture",
+        ],
+        cwd=repository,
+        check=True,
+    )
+    return repository
+
+
+def test_runtime_identity_uses_actual_git_and_workflow_bytes(tmp_path):
+    repository = _clean_repository(tmp_path)
+    first = derive_runtime_identity(
+        repository_root=repository,
+        workflow_path=WORKFLOW,
+        workflow_inputs={"condition": "a", "tasks": 5},
+    )
+    second = derive_runtime_identity(
+        repository_root=repository,
+        workflow_path=WORKFLOW,
+        workflow_inputs={"tasks": 5, "condition": "a"},
+    )
+
+    assert first == second
+    assert first["plan_sha"] == PLAN_MERGE_SHA
+    assert first["implementation_sha"] == subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert first["workflow_sha"] == hashlib.sha256(
+        (repository / WORKFLOW).read_bytes()
+    ).hexdigest()
+    assert len(first["workflow_inputs_sha256"]) == 64
+
+
+def test_runtime_identity_rejects_dirty_checkout(tmp_path):
+    repository = _clean_repository(tmp_path)
+    (repository / "untracked.py").write_text("print('changed')\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="clean checkout"):
+        derive_runtime_identity(
+            repository_root=repository,
+            workflow_path=WORKFLOW,
+            workflow_inputs={},
+        )
+
+
+def test_environment_identity_requires_object_inputs(monkeypatch):
+    monkeypatch.setenv("AGENTIC_WORKFLOW_PATH", str(WORKFLOW))
+    monkeypatch.setenv("AGENTIC_WORKFLOW_INPUTS_JSON", "[]")
+
+    with pytest.raises(ValueError, match="JSON object"):
+        derive_runtime_identity_from_environment(ROOT)
+
+
+def test_workflow_path_cannot_escape_repository():
+    with pytest.raises(ValueError, match="escapes repository"):
+        derive_runtime_identity(
+            repository_root=ROOT,
+            workflow_path="../outside.yml",
+            workflow_inputs={},
+        )

--- a/batch-runner/tests/test_agentic_sandbox_runner.py
+++ b/batch-runner/tests/test_agentic_sandbox_runner.py
@@ -122,12 +122,14 @@ class FakeBackend:
         self.closed = True
 
 
-def _runner(tmp_path, responses, **limit_overrides):
+def _runner(
+    tmp_path, responses, backend_class=FakeBackend, **limit_overrides
+):
     scripted = ScriptedResponses(responses)
     backends = []
 
     def backend_factory(**kwargs):
-        backend = FakeBackend(**kwargs)
+        backend = backend_class(**kwargs)
         backends.append(backend)
         return backend
 
@@ -239,6 +241,40 @@ def test_repeated_identical_tool_error_stops_loop(tmp_path):
     assert result["error"] == "duplicate_tool_request"
 
 
+def test_normalized_identical_errors_stop_after_second_dispatch(tmp_path):
+    class ErrorBackend(FakeBackend):
+        def run_python(self, source, timeout_seconds):
+            self.calls.append("run_python")
+            suffix = "123 at /tmp/first" if len(self.calls) == 1 else "999 at /tmp/second"
+            return {
+                "ok": False,
+                "error_type": "python_execution_failed",
+                "retryable": True,
+                "data": {"stderr_tail": f"ValueError item {suffix}"},
+            }
+
+    runner, scripted, backends = _runner(
+        tmp_path,
+        [
+            _response(_call("c1", "run_python", {
+                "source": "raise ValueError('first')", "timeout_seconds": 5,
+            })),
+            _response(_call("c2", "run_python", {
+                "source": "raise ValueError('second')", "timeout_seconds": 5,
+            })),
+        ],
+        backend_class=ErrorBackend,
+    )
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["error"] == "repeated_error_limit"
+    assert result["agentic_metrics"]["tool_calls"] == 2
+    assert result["agentic_metrics"]["model_api_calls"] == 2
+    assert backends[0].calls == ["run_python", "run_python"]
+    assert len(scripted.calls) == 2
+
+
 def test_invalid_tool_batch_executes_nothing(tmp_path):
     runner, _, backends = _runner(tmp_path, [
         _response(
@@ -348,3 +384,51 @@ def test_later_model_failure_preserves_best_verified_files(tmp_path):
     ]
     assert result["agentic_metrics"]["usage_complete"] is False
     assert result["agentic_metrics"]["time_to_valid_artifact_ms"] is not None
+
+
+def test_success_is_not_returned_when_compute_cleanup_fails(tmp_path):
+    class CleanupFailureBackend(FakeBackend):
+        def close(self):
+            raise RuntimeError("remote close failed")
+
+    runner, _, _ = _runner(
+        tmp_path,
+        [_response(_call("c1", "finalize", {
+            "deliverables": ["report.txt"], "summary": "complete",
+        }))],
+        backend_class=CleanupFailureBackend,
+    )
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "compute_cleanup_failed"
+    assert result["prior_error"] is None
+    assert result["files"] == [
+        {"filename": "report.txt", "content": b"ok"}
+    ]
+
+
+def test_model_failure_and_cleanup_failure_preserve_sealed_evidence(tmp_path):
+    class CleanupFailureBackend(FakeBackend):
+        def close(self):
+            raise RuntimeError("remote close failed")
+
+    runner, _, _ = _runner(
+        tmp_path,
+        [
+            _response(_call("c1", "inspect_artifacts", {})),
+            RuntimeError("upstream failed"),
+        ],
+        backend_class=CleanupFailureBackend,
+    )
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "compute_cleanup_failed"
+    assert result["prior_error"] == "model_api_error"
+    assert result["files"] == [
+        {"filename": "report.txt", "content": b"verified"}
+    ]
+    assert result["agentic_metrics"]["usage_complete"] is False

--- a/batch-runner/tests/test_agentic_sandbox_runner.py
+++ b/batch-runner/tests/test_agentic_sandbox_runner.py
@@ -1,0 +1,350 @@
+"""Scripted, model-free tests for the agentic solver state machine."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from core.agentic_budget import AgenticBudgetLedger
+from core.agentic_sandbox_runner import AgenticPricing, AgenticSandboxRunner
+
+
+def _usage(input_tokens=100, output_tokens=20, cached_tokens=5):
+    return SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        input_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
+    )
+
+
+def _response(*items, usage=True):
+    return SimpleNamespace(
+        output=list(items),
+        usage=_usage() if usage else None,
+    )
+
+
+def _call(call_id, name, arguments):
+    return {
+        "type": "function_call",
+        "call_id": call_id,
+        "name": name,
+        "arguments": json.dumps(arguments),
+    }
+
+
+def _message(text="done"):
+    return {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": text}],
+    }
+
+
+class ScriptedResponses:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if not self.responses:
+            raise AssertionError("script exhausted")
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class FakeClient:
+    def __init__(self, responses):
+        self.responses = responses
+
+
+class FakeBackend:
+    def __init__(self, **_):
+        self.calls = []
+        self.closed = False
+        self.result = None
+
+    def start(self, timeout_seconds=1200.0):
+        return {
+            "ok": True,
+            "data": {
+                "input_count": 1,
+                "substrate_manifest": {
+                    "schema_version": "1.0",
+                    "sha256": "a" * 64,
+                },
+            },
+        }
+
+    def inspect_workspace(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_workspace")
+        return {"ok": True, "data": {"input_count": 1, "work_count": 0}}
+
+    def inspect_environment(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_environment")
+        return {"ok": True, "data": {"python": "3.11"}}
+
+    def run_python(self, source, timeout_seconds):
+        self.calls.append("run_python")
+        return {"ok": True, "data": {"returncode": 0}}
+
+    def run_ffmpeg(self, operation, timeout_seconds):
+        self.calls.append("run_ffmpeg")
+        return {"ok": True, "data": {"returncode": 0}}
+
+    def inspect_artifacts(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_artifacts")
+        self.result = {
+            "success": False,
+            "text": "",
+            "deliverable_text": "",
+            "files": [{"filename": "report.txt", "content": b"verified"}],
+        }
+        return {"ok": True, "data": {"verified_count": 1}}
+
+    def finalize(self, deliverables, summary, timeout_seconds=1200.0):
+        self.calls.append("finalize")
+        self.result = {
+            "success": True,
+            "text": summary,
+            "deliverable_text": summary,
+            "files": [{"filename": deliverables[0], "content": b"ok"}],
+        }
+        return {"ok": True, "data": {"verified_count": 1}}
+
+    def best_result(self):
+        return self.result
+
+    def close(self):
+        self.closed = True
+
+
+def _runner(tmp_path, responses, **limit_overrides):
+    scripted = ScriptedResponses(responses)
+    backends = []
+
+    def backend_factory(**kwargs):
+        backend = FakeBackend(**kwargs)
+        backends.append(backend)
+        return backend
+
+    runner = AgenticSandboxRunner(
+        FakeClient(scripted),
+        non_paid_test_mode=True,
+        backend_factory=backend_factory,
+        budget_ledger=AgenticBudgetLedger(tmp_path / "budget.sqlite3"),
+        authorize_request=lambda scope, request_id, context: None,
+        limits=limit_overrides,
+        pricing={
+            "input_per_million": "0",
+            "output_per_million": "0",
+            "cached_input_per_million": "0",
+        },
+    )
+    return runner, scripted, backends
+
+
+def test_inspect_run_inspect_finalize_success(tmp_path):
+    runner, scripted, backends = _runner(tmp_path, [
+        _response(_call("c1", "inspect_workspace", {})),
+        _response(_call("c2", "run_python", {
+            "source": "print('ok')", "timeout_seconds": 5,
+        })),
+        _response(_call("c3", "inspect_artifacts", {})),
+        _response(_call("c4", "finalize", {
+            "deliverables": ["report.txt"], "summary": "complete",
+        })),
+    ])
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["success"] is True
+    assert result["text"] == "complete"
+    assert result["agentic_metrics"]["model_api_calls"] == 4
+    assert result["agentic_metrics"]["tool_calls"] == 4
+    assert backends[0].calls == [
+        "inspect_workspace", "run_python", "inspect_artifacts", "finalize",
+    ]
+    assert backends[0].closed is True
+    assert all(call["parallel_tool_calls"] is False for call in scripted.calls)
+
+
+def test_plain_final_gets_one_finalize_required_correction(tmp_path):
+    runner, scripted, _ = _runner(tmp_path, [
+        _response(_message()),
+        _response(_call("c1", "finalize", {
+            "deliverables": ["report.txt"], "summary": "complete",
+        })),
+    ])
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["success"] is True
+    assert result["agentic_metrics"]["finalize_required_corrections"] == 1
+    assert "successful finalize tool call" in scripted.calls[1]["input"][-1]["content"]
+
+
+def test_missing_usage_fails_closed_and_keeps_reservation(tmp_path):
+    runner, _, _ = _runner(tmp_path, [_response(_message(), usage=False)])
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "usage_incomplete"
+    assert result["agentic_metrics"]["usage_complete"] is False
+    usage = runner.ledger.usage('["local-nonpaid","condition_a","task-1"]')
+    assert usage.attempts == 1
+    assert usage.output_tokens == 8192
+
+
+def test_resume_after_unreconciled_reservation_reports_ledger_cost(tmp_path):
+    runner, scripted, _ = _runner(
+        tmp_path, [_response(_message(), usage=False)]
+    )
+    runner.pricing = AgenticPricing.from_options({
+        "input_per_million": "1",
+        "output_per_million": "10",
+        "cached_input_per_million": "1",
+    })
+
+    first = runner.run("Create a report", "model", task_id="task-1")
+    second = runner.run("Create a report", "model", task_id="task-1")
+
+    assert first["agentic_metrics"]["conservative_cost_usd"] != "0"
+    assert second["error"] == "authorization_or_reservation_failed"
+    assert second["agentic_metrics"]["conservative_cost_usd"] == first[
+        "agentic_metrics"
+    ]["conservative_cost_usd"]
+    assert second["agentic_metrics"]["usage_complete"] is False
+    assert len(scripted.calls) == 1
+
+
+def test_repeated_identical_tool_error_stops_loop(tmp_path):
+    duplicate = _call("c1", "run_python", {
+        "source": "print('ok')", "timeout_seconds": 5,
+    })
+    runner, _, _ = _runner(tmp_path, [
+        _response(duplicate),
+        _response({**duplicate, "call_id": "c2"}),
+        _response({**duplicate, "call_id": "c3"}),
+        _response({**duplicate, "call_id": "c4"}),
+    ])
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "duplicate_tool_request"
+
+
+def test_invalid_tool_batch_executes_nothing(tmp_path):
+    runner, _, backends = _runner(tmp_path, [
+        _response(
+            _call("c1", "inspect_workspace", {}),
+            _call("c2", "unexpected_tool", {}),
+        ),
+    ])
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "unknown_tool"
+    assert backends[0].calls == []
+
+
+def test_duplicate_function_call_ids_execute_nothing(tmp_path):
+    runner, _, backends = _runner(tmp_path, [
+        _response(
+            _call("same", "inspect_workspace", {}),
+            _call("same", "inspect_environment", {}),
+        ),
+    ])
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["error"] == "invalid_function_call_id"
+    assert backends[0].calls == []
+
+
+def test_authorization_failure_occurs_before_api_call(tmp_path):
+    scripted = ScriptedResponses([_response(_message())])
+    backend = FakeBackend()
+    runner = AgenticSandboxRunner(
+        FakeClient(scripted),
+        non_paid_test_mode=True,
+        backend_factory=lambda **_: backend,
+        budget_ledger=AgenticBudgetLedger(tmp_path / "budget.sqlite3"),
+        authorize_request=lambda scope, request_id, context: (_ for _ in ()).throw(
+            PermissionError("not approved")
+        ),
+        pricing={
+            "input_per_million": "0", "output_per_million": "0",
+            "cached_input_per_million": "0",
+        },
+    )
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["error"] == "authorization_or_reservation_failed"
+    assert scripted.calls == []
+    assert runner.ledger.usage(
+        '["local-nonpaid","condition_a","task-1"]'
+    ).attempts == 1
+
+
+def test_authorization_happens_before_deferred_client_factory(tmp_path):
+    events = []
+    scripted = ScriptedResponses([_response(_message())])
+    backend = FakeBackend()
+
+    def authorize(scope, request_id, context):
+        events.append("authorize")
+        assert context["runtime_preflight_passed"] is True
+
+    def client_factory():
+        events.append("client_factory")
+        return FakeClient(scripted)
+
+    ledger = AgenticBudgetLedger(tmp_path / "budget.sqlite3")
+    original_reserve_many = ledger.reserve_many
+
+    def reserve_many(**kwargs):
+        events.append("reserve")
+        return original_reserve_many(**kwargs)
+
+    ledger.reserve_many = reserve_many
+    runner = AgenticSandboxRunner(
+        client_factory=client_factory,
+        backend_factory=lambda **_: backend,
+        budget_ledger=ledger,
+        authorize_request=authorize,
+        pricing={
+            "input_per_million": "0", "output_per_million": "0",
+            "cached_input_per_million": "0",
+        },
+    )
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert events[:3] == ["reserve", "authorize", "client_factory"]
+    assert scripted.calls
+    assert result["success"] is False
+
+
+def test_later_model_failure_preserves_best_verified_files(tmp_path):
+    runner, _, _ = _runner(tmp_path, [
+        _response(_call("c1", "inspect_artifacts", {})),
+        RuntimeError("upstream failed"),
+    ])
+
+    result = runner.run("Create a report", "model", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "model_api_error"
+    assert result["files"] == [
+        {"filename": "report.txt", "content": b"verified"}
+    ]
+    assert result["agentic_metrics"]["usage_complete"] is False
+    assert result["agentic_metrics"]["time_to_valid_artifact_ms"] is not None

--- a/batch-runner/tests/test_agentic_sandbox_security.py
+++ b/batch-runner/tests/test_agentic_sandbox_security.py
@@ -1,0 +1,783 @@
+"""Non-paid security tests for the agentic compute plane."""
+
+from __future__ import annotations
+
+import os
+import json
+import hashlib
+import struct
+import subprocess
+import sys
+import wave
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.agentic_compute import AgenticDockerBackend, _container_path
+from core import agentic_verifier
+from sandbox.agentic_image_prepare import _is_forbidden_executable
+
+
+SECCOMP = Path(__file__).resolve().parent.parent / "sandbox" / "agentic-seccomp.json"
+LAUNCHER = Path(__file__).resolve().parent.parent / "core" / "agentic_python_launcher.py"
+
+
+def _backend(tmp_path, reference_files=None):
+    return AgenticDockerBackend(
+        task_prompt="Create report.txt",
+        reference_files=list(reference_files or []),
+        occupation="Analyst",
+        image="gdpval-agentic-sandbox:test",
+        seccomp_profile=str(SECCOMP),
+        allow_unpinned_image=True,
+        require_rootless_or_userns=False,
+        require_approved_input_manifest=False,
+        require_supply_chain_identity=False,
+        require_dedicated_host=False,
+    )
+
+
+def test_task_container_command_has_hardening_flags(tmp_path):
+    backend = _backend(tmp_path)
+    try:
+        command = backend._task_container_command()
+        joined = " ".join(command)
+
+        for required in (
+            "--network none", "--ipc none", "--read-only",
+            "--cap-drop ALL", "--pids-limit 128", "--ulimit nofile=256:256",
+            "--user 65532:65532", "--security-opt no-new-privileges",
+            "type=volume", "dst=/work", "volume-nocopy",
+            "readonly", "bind-propagation=rprivate",
+        ):
+            assert required in joined
+        assert "--pid host" not in joined
+    finally:
+        backend.close()
+
+
+def test_outer_seccomp_is_default_deny_allowlist():
+    profile = json.loads(SECCOMP.read_text(encoding="utf-8"))
+    allowed = {
+        name
+        for rule in profile["syscalls"]
+        if rule["action"] == "SCMP_ACT_ALLOW"
+        for name in rule["names"]
+    }
+
+    assert profile["defaultAction"] == "SCMP_ACT_ERRNO"
+    for denied in (
+        "bpf", "mount", "setns", "unshare", "ptrace", "keyctl",
+        "io_uring_setup", "userfaultfd", "process_vm_readv",
+    ):
+        assert denied not in allowed
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "gcc", "gcc-12", "x86_64-linux-gnu-gcc", "x86_64-linux-gnu-gcc-12",
+        "g++-12", "x86_64-linux-gnu-ld.bfd", "as", "objcopy", "pip3.11",
+    ],
+)
+def test_image_preparation_detects_versioned_and_prefixed_build_tools(name):
+    assert _is_forbidden_executable(name) is True
+
+
+def test_production_backend_requires_pinned_sbom_identity():
+    with pytest.raises(ValueError, match="SBOM hash is required"):
+        AgenticDockerBackend(
+            task_prompt="task",
+            reference_files=[],
+            occupation="Analyst",
+            image="image@sha256:" + "a" * 64,
+            approved_input_manifest={},
+        )
+
+
+def test_substrate_manifest_is_condition_neutral(tmp_path):
+    first = _backend(tmp_path)
+    second = _backend(tmp_path)
+    try:
+        first.image_id = second.image_id = "sha256:" + "a" * 64
+        first.verifier_image_id = second.verifier_image_id = "sha256:" + "a" * 64
+        assert first.substrate_manifest() == second.substrate_manifest()
+        serialized = json.dumps(first.substrate_manifest(), sort_keys=True)
+        assert "baseline" not in serialized
+        assert "treatment" not in serialized
+    finally:
+        first.close()
+        second.close()
+
+
+def test_verifier_image_components_are_hashed_from_actual_image_id(tmp_path):
+    backend = _backend(tmp_path)
+    expected = backend._component_hashes()
+    commands = []
+
+    def run(command, **_):
+        commands.append(command)
+        if command[1:3] == ["image", "inspect"]:
+            output = json.dumps([{"Id": "sha256:" + "f" * 64}]).encode()
+        else:
+            output = json.dumps({
+                "verifier": expected["verifier"],
+                "capabilities": expected["capabilities"],
+                "core_tree": expected["core_tree"],
+                "sbom": backend.sbom_sha256,
+            }).encode()
+        return SimpleNamespace(returncode=0, stdout=output, stderr=b"")
+
+    backend._run = run
+    try:
+        backend._verify_verifier_image_components()
+    finally:
+        backend.close()
+
+    verifier_command = commands[1]
+    assert "sha256:" + "f" * 64 in verifier_command
+    assert verifier_command[verifier_command.index("--network") + 1] == "none"
+    assert "--read-only" in verifier_command
+
+
+def test_verifier_image_component_mismatch_fails_closed(tmp_path):
+    backend = _backend(tmp_path)
+
+    def run(command, **_):
+        if command[1:3] == ["image", "inspect"]:
+            output = json.dumps([{"Id": "sha256:" + "f" * 64}]).encode()
+        else:
+            output = json.dumps({
+                "verifier": "0" * 64,
+                "capabilities": "0" * 64,
+                "core_tree": "0" * 64,
+            }).encode()
+        return SimpleNamespace(returncode=0, stdout=output, stderr=b"")
+
+    backend._run = run
+    try:
+        with pytest.raises(RuntimeError, match="verifier image component"):
+            backend._verify_verifier_image_components()
+    finally:
+        backend.close()
+
+
+def test_production_verifier_image_sbom_mismatch_fails_closed(tmp_path):
+    backend = _backend(tmp_path)
+    backend.require_supply_chain_identity = True
+    backend.sbom_sha256 = "a" * 64
+    expected = backend._component_hashes()
+
+    def run(command, **_):
+        if command[1:3] == ["image", "inspect"]:
+            output = json.dumps([{"Id": "sha256:" + "f" * 64}]).encode()
+        else:
+            output = json.dumps({
+                "verifier": expected["verifier"],
+                "capabilities": expected["capabilities"],
+                "core_tree": expected["core_tree"],
+                "sbom": "b" * 64,
+            }).encode()
+        return SimpleNamespace(returncode=0, stdout=output, stderr=b"")
+
+    backend._run = run
+    try:
+        with pytest.raises(RuntimeError, match="SBOM identity mismatch"):
+            backend._verify_verifier_image_components()
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize(
+    "pid1_fds",
+    [
+        {"0": "/dev/null", "1": "pipe:[1]", "2": "pipe:[2]", "3": "/tmp/x"},
+        {"0": "/dev/null", "1": "socket:[1]", "2": "pipe:[2]"},
+    ],
+)
+def test_runtime_fd_probe_rejects_pid1_fd_or_socket(tmp_path, pid1_fds):
+    backend = _backend(tmp_path)
+    identity = {
+        "uid": 65532,
+        "gid": 65532,
+        "groups": [],
+        "probe_fds": {"0": "/dev/null", "1": "pipe:[1]", "2": "pipe:[2]"},
+        "pid1_fds": pid1_fds,
+    }
+    backend._run = lambda *args, **kwargs: SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps(identity).encode(),
+        stderr=b"",
+    )
+    try:
+        with pytest.raises(RuntimeError, match="pid1"):
+            backend._verify_fds()
+    finally:
+        backend.close()
+
+
+def test_input_staging_records_exact_hash_and_merkle_root(tmp_path):
+    source = tmp_path / "source.txt"
+    source.write_text("approved input", encoding="utf-8")
+    backend = _backend(tmp_path, [source])
+    try:
+        backend._stage_inputs()
+
+        assert len(backend.input_records) == 1
+        assert backend.input_records[0]["model_path"] == "inputs/source.txt"
+        assert len(backend.input_records[0]["sha256"]) == 64
+        assert len(backend.input_merkle_root) == 64
+        assert (backend.inputs_dir / "source.txt").read_bytes() == source.read_bytes()
+        assert (backend.inputs_dir / "source.txt").stat().st_mode & 0o222 == 0
+    finally:
+        backend.close()
+
+
+def test_input_staging_rejects_symlink_and_hardlink(tmp_path):
+    source = tmp_path / "source.txt"
+    source.write_text("input", encoding="utf-8")
+    symlink = tmp_path / "link.txt"
+    symlink.symlink_to(source)
+    backend = _backend(tmp_path, [symlink])
+    try:
+        with pytest.raises(ValueError, match="input_type_or_link_violation"):
+            backend._stage_inputs()
+    finally:
+        backend.close()
+
+
+def test_input_staging_requires_exact_approved_manifest(tmp_path):
+    source = tmp_path / "source.txt"
+    source.write_text("approved input", encoding="utf-8")
+    metadata = source.lstat()
+    expected = {
+        "documents/source.txt": {
+            "path": "documents/source.txt",
+            "type": "regular",
+            "link_count": 1,
+            "size_bytes": metadata.st_size,
+            "source_allocated_bytes": metadata.st_blocks * 512,
+            "sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
+            "provider_classification": "approved_public_gdpval",
+        }
+    }
+    backend = AgenticDockerBackend(
+        task_prompt="Create report.txt",
+        reference_files=[{
+            "source_path": str(source),
+            "relative_path": "documents/source.txt",
+        }],
+        occupation="Analyst",
+        image="gdpval-agentic-sandbox:test",
+        seccomp_profile=str(SECCOMP),
+        allow_unpinned_image=True,
+        require_rootless_or_userns=False,
+        approved_input_manifest=expected,
+        require_supply_chain_identity=False,
+        require_dedicated_host=False,
+    )
+    try:
+        backend._stage_inputs()
+        assert backend.input_records[0]["sha256"] == expected[
+            "documents/source.txt"
+        ][
+            "sha256"
+        ]
+        assert backend.input_records[0]["model_path"] == (
+            "inputs/documents/source.txt"
+        )
+        assert backend.input_records[0]["staged_allocated_bytes"] > 0
+    finally:
+        backend.close()
+
+    expected["documents/source.txt"]["sha256"] = "0" * 64
+    backend = AgenticDockerBackend(
+        task_prompt="Create report.txt",
+        reference_files=[{
+            "source_path": str(source),
+            "relative_path": "documents/source.txt",
+        }],
+        occupation="Analyst",
+        image="gdpval-agentic-sandbox:test",
+        seccomp_profile=str(SECCOMP),
+        allow_unpinned_image=True,
+        require_rootless_or_userns=False,
+        approved_input_manifest=expected,
+        require_supply_chain_identity=False,
+        require_dedicated_host=False,
+    )
+    try:
+        with pytest.raises(ValueError, match="approved input identity mismatch"):
+            backend._stage_inputs()
+    finally:
+        backend.close()
+
+    hardlink = tmp_path / "hard.txt"
+    os.link(source, hardlink)
+    backend = _backend(tmp_path, [source])
+    try:
+        with pytest.raises(ValueError, match="input_type_or_link_violation"):
+            backend._stage_inputs()
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize(
+    ("path", "output"),
+    [
+        ("../escape", True),
+        ("/etc/passwd", False),
+        ("source.mov", False),
+        ("inputs/source.mov", True),
+        ("work/.hidden", True),
+    ],
+)
+def test_container_path_rejects_escape_and_wrong_roots(path, output):
+    with pytest.raises(ValueError):
+        _container_path(path, output=output)
+
+
+def test_ffmpeg_command_is_closed_and_shell_free(tmp_path):
+    backend = _backend(tmp_path)
+    try:
+        command = backend._ffmpeg_command({
+            "operation": "sample_frames",
+            "input": "inputs/source.mp4",
+            "output": "work/contact.png",
+            "frame_count": 4,
+            "width": 640,
+            "start_seconds": 0,
+            "duration_seconds": 10,
+        })
+
+        assert command[-1] == "/work/contact.png"
+        assert "/usr/bin/ffmpeg" in command
+        assert "-nostdin" in command
+        assert "-n" in command
+        assert command[command.index("-protocol_whitelist") + 1] == "file"
+        assert not any(token in command for token in ("sh", "bash", "-c"))
+        assert len([token for token in command if token == "/work/contact.png"]) == 1
+        with pytest.raises(ValueError, match="unsupported ffmpeg input suffix"):
+            backend._ffmpeg_command({
+                "operation": "probe",
+                "input": "inputs/playlist.m3u8",
+            })
+        with pytest.raises(ValueError, match="output extension"):
+            backend._ffmpeg_command({
+                "operation": "transcode_video",
+                "input": "inputs/source.mov",
+                "output": "work/report.webm",
+                "container": "mp4",
+                "video_codec": "h264",
+                "audio_codec": "aac",
+                "width": 640,
+                "height": 360,
+                "fps": 24,
+                "start_seconds": 0,
+                "duration_seconds": 1,
+            })
+        with pytest.raises(ValueError, match="output extension"):
+            backend._ffmpeg_command({
+                "operation": "extract_audio",
+                "input": "inputs/source.mov",
+                "output": "work/report.flac",
+                "format": "wav",
+                "sample_rate": 16000,
+                "channels": 1,
+                "start_seconds": 0,
+                "duration_seconds": 1,
+            })
+    finally:
+        backend.close()
+
+
+def test_ffprobe_returns_only_allowlisted_bounded_metadata(tmp_path):
+    backend = _backend(tmp_path)
+    backend.container_started = True
+    backend._assert_pid1_only = lambda deadline=None: None
+    backend._run_tool = lambda *args, **kwargs: subprocess.CompletedProcess(
+        args[0],
+        0,
+        stdout=json.dumps({
+            "format": {
+                "filename": "/inputs/private-name.mov",
+                "format_name": "mov,mp4",
+                "duration": "1.250000",
+                "tags": {"comment": "secret"},
+            },
+            "streams": [{
+                "index": 0,
+                "codec_name": "h264",
+                "codec_type": "video",
+                "width": 640,
+                "height": 360,
+                "tags": {"handler_name": "private"},
+            }],
+        }).encode(),
+        stderr=b"",
+    )
+    try:
+        result = backend.run_ffmpeg({
+            "operation": "probe",
+            "input": "inputs/source.mov",
+        })
+    finally:
+        backend.container_started = False
+        backend.close()
+
+    assert result["ok"] is True
+    assert result["data"]["metadata"] == {
+        "format": {"duration": "1.250000", "format_name": "mov,mp4"},
+        "streams": [{
+            "codec_name": "h264",
+            "codec_type": "video",
+            "height": 360,
+            "index": 0,
+            "width": 640,
+        }],
+    }
+    assert "private" not in json.dumps(result)
+
+
+def test_verifier_rechecks_contract_on_exact_selected_deliverables(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "report.pdf").write_bytes(b"full-workspace-primary")
+    (tmp_path / "notes.txt").write_text("notes", encoding="utf-8")
+    monkeypatch.setattr(agentic_verifier, "SNAPSHOT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        agentic_verifier,
+        "run_output_qa",
+        lambda *args, **kwargs: SimpleNamespace(
+            ok=True,
+            render_reports=[],
+            blocking_errors=[],
+            warnings=[],
+        ),
+    )
+
+    result = agentic_verifier.verify({
+        "task_prompt": "Create a PDF report",
+        "reference_hashes": [],
+        "selected_deliverables": ["notes.txt"],
+    })
+
+    assert result["ok"] is False
+    assert result["error_type"] == "artifact_verification_failed"
+    assert result["data"]["artifact_count"] == 1
+    assert result["data"]["artifacts"][0]["path"] == "notes.txt"
+
+
+def test_tool_output_is_bounded_before_host_memory_capture():
+    result = AgenticDockerBackend._run_tool(
+        [sys.executable, "-c", "import sys;sys.stdout.write('x' * 1000000)"],
+        timeout=10,
+    )
+
+    assert len(result.stdout) <= 32768
+    assert result.returncode != 0
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="libseccomp launcher is Linux-only")
+def test_generated_python_launcher_denies_exec_and_network():
+    source = b"""
+import os
+import socket
+
+denied = []
+for action in (
+    lambda: os.system('/bin/true'),
+    lambda: socket.socket(socket.AF_INET, socket.SOCK_STREAM),
+):
+    try:
+        action()
+    except OSError as exc:
+        denied.append(exc.errno)
+assert len(denied) == 2, denied
+print('blocked')
+"""
+    harness = (
+        "import sys;"
+        "from core.agentic_python_launcher import _install_filter;"
+        "code=compile(sys.stdin.buffer.read(),'<security-test>','exec');"
+        "_install_filter();exec(code,{'__name__':'__main__'})"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", harness],
+        input=source,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=20,
+        check=False,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    if b"seccomp TSYNC unavailable" in result.stderr:
+        pytest.skip("host runtime does not expose seccomp TSYNC; Docker gate remains required")
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    assert result.stdout.strip() == b"blocked"
+
+
+@pytest.mark.integration
+def test_agentic_docker_backend_end_to_end(tmp_path):
+    image = os.environ.get(
+        "AGENTIC_TEST_IMAGE", "gdpval-agentic-sandbox:local"
+    )
+    inspect = subprocess.run(
+        ["docker", "image", "inspect", image],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if inspect.returncode != 0:
+        pytest.skip(f"agentic test image is unavailable: {image}")
+
+    source = tmp_path / "input.wav"
+    with wave.open(str(source), "wb") as audio:
+        audio.setnchannels(1)
+        audio.setsampwidth(2)
+        audio.setframerate(16000)
+        audio.writeframes(struct.pack("<h", 0) * 16000)
+    backend = AgenticDockerBackend(
+        task_prompt="Create a professional WAV audio report named report.wav",
+        reference_files=[str(source)],
+        occupation="Analyst",
+        image=image,
+        seccomp_profile=str(SECCOMP),
+        allow_unpinned_image=True,
+        require_rootless_or_userns=False,
+        require_approved_input_manifest=False,
+        require_supply_chain_identity=False,
+        require_dedicated_host=False,
+        enforce_cpu_limit=False,
+        enforce_pid_limit=False,
+        enforce_outer_seccomp=False,
+        enforce_procfs_policy=False,
+        local_root_parent=os.environ.get("AGENTIC_TEST_LOCAL_ROOT_PARENT"),
+        docker_root_parent=os.environ.get("AGENTIC_TEST_DOCKER_ROOT_PARENT"),
+    )
+    container_name = backend.container_name
+    try:
+        startup = backend.start()
+        assert startup["ok"] is True, startup
+        assert startup["data"]["input_count"] == 1
+        assert len(startup["data"]["input_merkle_root"]) == 64
+        assert backend.inspect_environment()["ok"] is True
+
+        first = backend.run_ffmpeg({
+            "operation": "extract_audio",
+            "input": "inputs/input.wav",
+            "output": "work/stage.flac",
+            "format": "flac",
+            "sample_rate": 16000,
+            "channels": 1,
+            "start_seconds": 0,
+            "duration_seconds": 0.5,
+        })
+        assert first["ok"] is True, first
+        workspace = backend.inspect_workspace()
+        assert workspace["ok"] is True, workspace
+        assert any(
+            item["path"] == "work/stage.flac"
+            for item in workspace["data"]["work"]
+        )
+
+        second = backend.run_ffmpeg({
+            "operation": "transcode_audio",
+            "input": "work/stage.flac",
+            "output": "work/report.wav",
+            "format": "wav",
+            "sample_rate": 16000,
+            "channels": 1,
+            "start_seconds": 0,
+            "duration_seconds": 0.4,
+        })
+        assert second["ok"] is True, second
+
+        inspection = backend.inspect_artifacts()
+        assert inspection["ok"] is True, inspection
+        assert inspection["data"]["artifact_count"] >= 2
+
+        finalized = backend.finalize(
+            ["report.wav"], "Verified professional audio report"
+        )
+        assert finalized["ok"] is True, finalized
+        result = backend.best_result()
+        assert result is not None and result["success"] is True
+        assert len(result["files"]) == 1
+        assert result["files"][0]["filename"] == "report.wav"
+        assert len(result["files"][0]["content"]) > 44
+    finally:
+        backend.close()
+
+    remaining = subprocess.run(
+        ["docker", "ps", "-a", "--filter", f"name=^{container_name}$", "-q"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        text=True,
+    )
+    assert remaining.stdout.strip() == ""
+
+
+@pytest.mark.integration
+def test_agentic_docker_generated_python_denies_exec_and_network(tmp_path):
+    image = os.environ.get(
+        "AGENTIC_TEST_IMAGE", "gdpval-agentic-sandbox:local"
+    )
+    source = tmp_path / "input.txt"
+    source.write_text("approved input", encoding="utf-8")
+    backend = AgenticDockerBackend(
+        task_prompt="Create report.txt",
+        reference_files=[str(source)],
+        occupation="Analyst",
+        image=image,
+        seccomp_profile=str(SECCOMP),
+        allow_unpinned_image=True,
+        require_rootless_or_userns=False,
+        require_approved_input_manifest=False,
+        require_supply_chain_identity=False,
+        require_dedicated_host=False,
+        enforce_cpu_limit=False,
+        enforce_pid_limit=False,
+        enforce_outer_seccomp=False,
+        enforce_procfs_policy=False,
+        local_root_parent=os.environ.get("AGENTIC_TEST_LOCAL_ROOT_PARENT"),
+        docker_root_parent=os.environ.get("AGENTIC_TEST_DOCKER_ROOT_PARENT"),
+    )
+    try:
+        startup = backend.start()
+        assert startup["ok"] is True, startup
+        result = backend.run_python(
+            """
+from pathlib import Path
+import socket
+import subprocess
+blocked = 0
+for action in (
+    lambda: socket.socket(socket.AF_INET, socket.SOCK_STREAM),
+    lambda: subprocess.run(['/usr/bin/ffprobe', '-version']),
+):
+    try:
+        action()
+    except OSError:
+        blocked += 1
+assert blocked == 2, blocked
+Path('report.txt').write_text('blocked')
+""",
+            30,
+        )
+        if "seccomp TSYNC unavailable" in result.get("data", {}).get(
+            "stderr_tail", ""
+        ):
+            pytest.skip(
+                "local kernel lacks seccomp TSYNC; generated Python stayed fail-closed"
+            )
+        assert result["ok"] is True, result
+    finally:
+        backend.close()
+
+
+@pytest.mark.integration
+def test_agentic_production_runner_preflight(tmp_path):
+    if os.environ.get("AGENTIC_PRODUCTION_PREFLIGHT") != "1":
+        pytest.skip("dedicated production runner preflight not requested")
+    image = os.environ["AGENTIC_PRODUCTION_IMAGE"]
+    sbom_sha256 = os.environ["AGENTIC_PRODUCTION_SBOM_SHA256"]
+    apparmor_profile = os.environ["AGENTIC_PRODUCTION_APPARMOR_PROFILE"]
+    if "@sha256:" not in image:
+        pytest.fail("production image must be digest-pinned")
+    source = tmp_path / "source.txt"
+    source.write_text("approved public fixture", encoding="utf-8")
+
+    probe = AgenticDockerBackend(
+        task_prompt="Create report.txt",
+        reference_files=[str(source)],
+        occupation="Analyst",
+        image=image,
+        verifier_image=image,
+        apparmor_profile=apparmor_profile,
+        sbom_sha256=sbom_sha256,
+        allow_unpinned_image=False,
+        require_rootless_or_userns=True,
+        require_approved_input_manifest=False,
+        require_supply_chain_identity=True,
+        require_dedicated_host=True,
+    )
+    try:
+        probe._stage_inputs()
+        record = probe.input_records[0]
+        expected_root = probe.input_merkle_root
+        approved = {
+            record["path"]: {
+                key: record[key]
+                for key in (
+                    "path", "type", "link_count", "size_bytes",
+                    "source_allocated_bytes", "sha256",
+                    "provider_classification",
+                )
+            }
+        }
+    finally:
+        probe.close()
+
+    backend = AgenticDockerBackend(
+        task_prompt="Create report.txt",
+        reference_files=[{
+            "source_path": str(source),
+            "relative_path": "source.txt",
+        }],
+        occupation="Analyst",
+        image=image,
+        verifier_image=image,
+        apparmor_profile=apparmor_profile,
+        sbom_sha256=sbom_sha256,
+        approved_input_manifest=approved,
+        expected_input_merkle_root=expected_root,
+    )
+    container_name = backend.container_name
+    volume_name = backend.work_volume_name
+    try:
+        startup = backend.start()
+        assert startup["ok"] is True, startup
+        result = backend.run_python(
+            """
+from pathlib import Path
+import socket
+import subprocess
+blocked = 0
+for action in (
+    lambda: socket.socket(socket.AF_INET, socket.SOCK_STREAM),
+    lambda: subprocess.run(['/usr/bin/ffprobe', '-version']),
+):
+    try:
+        action()
+    except OSError:
+        blocked += 1
+assert blocked == 2, blocked
+Path('report.txt').write_text('verified production preflight')
+""",
+            30,
+        )
+        assert result["ok"] is True, result
+        inspection = backend.inspect_artifacts()
+        assert inspection["ok"] is True, inspection
+        finalized = backend.finalize(
+            ["report.txt"], "production preflight"
+        )
+        assert finalized["ok"] is True, finalized
+    finally:
+        backend.close()
+
+    assert subprocess.run(
+        ["docker", "container", "inspect", container_name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).returncode != 0
+    assert subprocess.run(
+        ["docker", "volume", "inspect", volume_name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).returncode != 0

--- a/batch-runner/tests/test_agentic_sandbox_security.py
+++ b/batch-runner/tests/test_agentic_sandbox_security.py
@@ -67,11 +67,20 @@ def test_outer_seccomp_is_default_deny_allowlist():
     }
 
     assert profile["defaultAction"] == "SCMP_ACT_ERRNO"
+    assert "seccomp" in allowed
     for denied in (
         "bpf", "mount", "setns", "unshare", "ptrace", "keyctl",
         "io_uring_setup", "userfaultfd", "process_vm_readv",
     ):
         assert denied not in allowed
+
+
+def test_inner_filter_denies_seccomp_and_queued_signals():
+    from core.agentic_python_launcher import DENIED_SYSCALLS
+
+    assert {"seccomp", "rt_sigqueueinfo", "rt_tgsigqueueinfo"} <= set(
+        DENIED_SYSCALLS
+    )
 
 
 @pytest.mark.parametrize(
@@ -139,6 +148,116 @@ def test_verifier_image_components_are_hashed_from_actual_image_id(tmp_path):
     assert "sha256:" + "f" * 64 in verifier_command
     assert verifier_command[verifier_command.index("--network") + 1] == "none"
     assert "--read-only" in verifier_command
+
+
+def test_verifier_component_probe_timeout_remains_registered_until_cleanup(
+    tmp_path
+):
+    backend = _backend(tmp_path)
+    commands = []
+
+    def run(command, **kwargs):
+        commands.append(command)
+        if command[1:3] == ["image", "inspect"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"Id": "sha256:" + "f" * 64}]).encode(),
+                stderr=b"",
+            )
+        if command[1] == "run":
+            raise subprocess.TimeoutExpired(command, 1)
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    backend._run = run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            backend._verify_verifier_image_components()
+    finally:
+        backend.close()
+
+    run_command = next(command for command in commands if command[1] == "run")
+    probe_name = run_command[run_command.index("--name") + 1]
+    assert ["docker", "rm", "-f", probe_name] in commands
+    assert probe_name not in backend._may_exist_containers
+
+
+def test_startup_passes_one_deadline_to_every_stage(tmp_path, monkeypatch):
+    backend = _backend(tmp_path)
+    deadlines = []
+
+    def stage(name):
+        def call(deadline):
+            deadlines.append((name, deadline))
+            if name == "verifier":
+                backend.verifier_image_id = "sha256:" + "f" * 64
+                backend._verified_component_hashes = backend._component_hashes()
+            if name == "volume":
+                backend.work_volume_created = True
+                backend._may_exist_volumes.add(backend.work_volume_name)
+        return call
+
+    monkeypatch.setattr(backend, "_verify_host_runtime", stage("host"))
+    monkeypatch.setattr(
+        backend, "_verify_verifier_image_components", stage("verifier")
+    )
+    monkeypatch.setattr(backend, "_stage_inputs", stage("inputs"))
+    monkeypatch.setattr(backend, "_create_work_volume", stage("volume"))
+    monkeypatch.setattr(backend, "_verify_runtime", stage("runtime"))
+    monkeypatch.setattr(backend, "_assert_pid1_only", stage("pid"))
+    monkeypatch.setattr(
+        backend,
+        "_run",
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command, 0, stdout=b"container-id\n", stderr=b""
+        ),
+    )
+    try:
+        result = backend.start(5)
+        assert result["ok"] is True, result
+    finally:
+        backend._may_exist_containers.clear()
+        backend._may_exist_volumes.clear()
+        backend.container_started = False
+        backend.work_volume_created = False
+        backend.close()
+
+    assert [name for name, _ in deadlines] == [
+        "host", "verifier", "inputs", "volume", "runtime", "pid"
+    ]
+    first = deadlines[0][1]
+    assert all(deadline == first for _, deadline in deadlines)
+
+
+def test_startup_exhausted_deadline_stops_before_next_stage(
+    tmp_path, monkeypatch
+):
+    backend = _backend(tmp_path)
+    current = [100.0]
+    calls = []
+    monkeypatch.setattr(
+        "core.agentic_compute.time.monotonic", lambda: current[0]
+    )
+
+    def verify_host(deadline):
+        calls.append("host")
+        current[0] = deadline + 0.01
+
+    def verify_components(deadline):
+        calls.append("verifier")
+
+    monkeypatch.setattr(backend, "_verify_host_runtime", verify_host)
+    monkeypatch.setattr(
+        backend, "_verify_verifier_image_components", verify_components
+    )
+
+    try:
+        result = backend.start(0.01)
+    finally:
+        backend.close()
+
+    assert result["ok"] is False
+    assert result["error_type"] == "container_preflight_failed"
+    assert calls == ["host"]
 
 
 def test_verifier_image_component_mismatch_fails_closed(tmp_path):
@@ -479,6 +598,207 @@ def test_tool_output_is_bounded_before_host_memory_capture():
     assert result.returncode != 0
 
 
+def test_inspection_preserves_oversized_snapshot_for_smaller_finalize_subset(
+    tmp_path, monkeypatch
+):
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_bytes(b"123")
+    second.write_bytes(b"456")
+    artifacts = [
+        {
+            "path": path.name,
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+        for path in (first, second)
+    ]
+    verification = {"ok": True, "data": {"artifacts": artifacts}}
+    backend = _backend(tmp_path)
+    backend.container_started = True
+    monkeypatch.setattr("core.agentic_compute.MAX_TRANSFER_TOTAL", 4)
+    backend._snapshot = lambda **kwargs: (tmp_path, verification)
+    backend._strict_snapshot_files = (
+        lambda snapshot, deadline=None: [first, second]
+    )
+    backend._verification_matches_snapshot = lambda *args, **kwargs: True
+    try:
+        inspected = backend.inspect_artifacts()
+        assert inspected["ok"] is True
+        assert backend.latest_snapshot == tmp_path
+        assert backend.best_result() is None
+        selected = {"ok": True, "data": {"artifacts": [artifacts[0]]}}
+        result = backend._snapshot_result(
+            tmp_path, selected, success=True, summary="selected"
+        )
+        assert result["files"] == [
+            {"filename": "first.txt", "content": b"123"}
+        ]
+    finally:
+        backend.container_started = False
+        backend.close()
+
+
+@pytest.mark.parametrize("failure", ["helper", "unpause"])
+def test_snapshot_cleanup_failure_poisons_and_removes_task_container(
+    tmp_path, failure
+):
+    backend = _backend(tmp_path)
+    backend.container_started = True
+    backend._may_exist_containers.add("snapshot-helper")
+    commands = []
+
+    def run(command, **kwargs):
+        commands.append(command)
+        if (
+            failure == "helper"
+            and command[1:3] == ["rm", "-f"]
+            and command[-1] == "snapshot-helper"
+        ):
+            return subprocess.CompletedProcess(command, 1, b"", b"busy")
+        if failure == "helper" and command[1] == "inspect":
+            return subprocess.CompletedProcess(command, 0, b"{}", b"")
+        if failure == "unpause" and command[1] == "unpause":
+            return subprocess.CompletedProcess(command, 1, b"", b"failed")
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    backend._run = run
+    with pytest.raises(RuntimeError, match="failed"):
+        backend._cleanup_snapshot_resources("snapshot-helper")
+
+    assert backend.poisoned is True
+    assert backend.container_started is False
+    assert ["docker", "rm", "-f", backend.container_name] in commands
+
+
+def test_ambiguous_pause_timeout_unpauses_or_removes_task_container(tmp_path):
+    backend = _backend(tmp_path)
+    backend.container_started = True
+    backend._may_exist_containers.add(backend.container_name)
+    commands = []
+
+    def run(command, **kwargs):
+        commands.append(command)
+        if command[1] == "pause":
+            raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+        if command[1] == "exec":
+            return subprocess.CompletedProcess(command, 0, b"ok\n", b"")
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    backend._run = run
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            backend._snapshot()
+
+        assert ["docker", "unpause", backend.container_name] in commands
+        assert backend.container_started is True
+    finally:
+        backend.close()
+
+
+def test_snapshot_rehash_stops_at_absolute_deadline(tmp_path, monkeypatch):
+    artifact = tmp_path / "large.bin"
+    artifact.write_bytes(b"x" * (2 * 1024 * 1024))
+    verification = {
+        "ok": True,
+        "data": {
+            "artifacts": [{
+                "path": artifact.name,
+                "sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+            }]
+        },
+    }
+    times = iter([100.0, 100.0, 102.0])
+    monkeypatch.setattr(
+        "core.agentic_compute.time.monotonic", lambda: next(times)
+    )
+    backend = _backend(tmp_path)
+    try:
+        with pytest.raises(TimeoutError, match="wall time exhausted"):
+            backend._verification_matches_snapshot(
+                verification, tmp_path, deadline=101.0
+            )
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize("resource", ["container", "volume"])
+def test_cleanup_verification_requires_explicit_docker_not_found(
+    tmp_path, resource
+):
+    backend = _backend(tmp_path)
+    if resource == "container":
+        backend.container_started = True
+    else:
+        backend.work_volume_created = True
+
+    def run(command, **kwargs):
+        return subprocess.CompletedProcess(
+            command, 1, stdout=b"", stderr=b"daemon unavailable"
+        )
+
+    backend._run = run
+    method = (
+        backend._remove_container
+        if resource == "container"
+        else backend._remove_work_volume
+    )
+
+    with pytest.raises(RuntimeError, match="could not be verified"):
+        method()
+
+    assert backend.poisoned is True
+    if resource == "container":
+        backend.container_started = False
+    else:
+        backend.work_volume_created = False
+    backend.close()
+
+
+def test_host_root_cleanup_failure_is_not_ignored(tmp_path, monkeypatch):
+    backend = _backend(tmp_path)
+    original = __import__("shutil").rmtree
+
+    def fail_target(path, *args, **kwargs):
+        if Path(path) == backend.root:
+            raise PermissionError("read-only host root")
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr("core.agentic_compute.shutil.rmtree", fail_target)
+
+    with pytest.raises(PermissionError, match="read-only host root"):
+        backend.close()
+
+    original(backend.root)
+
+
+def test_close_removes_may_exist_resources_without_creation_flags(tmp_path):
+    backend = _backend(tmp_path)
+    helper = f"{backend.container_name}-snapshot-lost"
+    verifier = f"{backend.container_name}-verify-lost"
+    backend._may_exist_containers.update({
+        backend.container_name, helper, verifier,
+    })
+    backend._may_exist_volumes.add(backend.work_volume_name)
+    backend.container_started = False
+    backend.work_volume_created = False
+    commands = []
+
+    def run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    backend._run = run
+    backend.close()
+
+    for name in (backend.container_name, helper, verifier):
+        assert ["docker", "rm", "-f", name] in commands
+    assert [
+        "docker", "volume", "rm", "-f", backend.work_volume_name
+    ] in commands
+    assert backend._may_exist_containers == set()
+    assert backend._may_exist_volumes == set()
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="libseccomp launcher is Linux-only")
 def test_generated_python_launcher_denies_exec_and_network():
     source = b"""
@@ -621,6 +941,98 @@ def test_agentic_docker_backend_end_to_end(tmp_path):
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize("extension", ["xlsx", "docx", "pptx"])
+def test_agentic_verifier_renders_primary_office_artifacts(
+    tmp_path, extension
+):
+    image = os.environ.get(
+        "AGENTIC_TEST_IMAGE", "gdpval-agentic-sandbox:local"
+    )
+    if subprocess.run(
+        ["docker", "image", "inspect", image],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).returncode != 0:
+        pytest.skip(f"agentic test image is unavailable: {image}")
+    artifact = tmp_path / f"report.{extension}"
+    if extension == "xlsx":
+        from openpyxl import Workbook
+
+        workbook = Workbook()
+        workbook.active["A1"] = "Professional report"
+        workbook.active["A2"] = 42
+        workbook.save(artifact)
+    elif extension == "docx":
+        from docx import Document
+
+        document = Document()
+        document.add_heading("Professional report", 0)
+        document.add_paragraph("Verified document content.")
+        document.save(artifact)
+    else:
+        from pptx import Presentation
+
+        presentation = Presentation()
+        slide = presentation.slides.add_slide(presentation.slide_layouts[0])
+        slide.shapes.title.text = "Professional report"
+        presentation.save(artifact)
+
+    backend = AgenticDockerBackend(
+        task_prompt=(
+            f"Create a professional {extension.upper()} report named "
+            f"report.{extension}"
+        ),
+        reference_files=[],
+        occupation="Analyst",
+        image=image,
+        seccomp_profile=str(SECCOMP),
+        allow_unpinned_image=True,
+        require_rootless_or_userns=False,
+        require_approved_input_manifest=False,
+        require_supply_chain_identity=False,
+        require_dedicated_host=False,
+        enforce_cpu_limit=False,
+        enforce_pid_limit=False,
+        enforce_outer_seccomp=False,
+        enforce_procfs_policy=False,
+        local_root_parent=os.environ.get("AGENTIC_TEST_LOCAL_ROOT_PARENT"),
+        docker_root_parent=os.environ.get("AGENTIC_TEST_DOCKER_ROOT_PARENT"),
+    )
+    try:
+        startup = backend.start()
+        assert startup["ok"] is True, startup
+        copied = subprocess.run(
+            [
+                "docker",
+                "cp",
+                str(artifact),
+                f"{backend.container_name}:/work/report.{extension}",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        assert copied.returncode == 0, copied.stderr.decode(
+            "utf-8", errors="replace"
+        )
+        inspection = backend.inspect_artifacts(180)
+        assert inspection["ok"] is True, inspection
+        assert len(inspection["data"]["artifacts"]) == 1
+        assert inspection["data"]["artifacts"][0]["path"] == (
+            f"report.{extension}"
+        )
+        assert inspection["data"]["artifacts"][0]["openable"] is True
+        finalized = backend.finalize(
+            [f"report.{extension}"], "Rendered primary artifact", 180
+        )
+        assert finalized["ok"] is True, finalized
+        assert backend.best_result()["success"] is True
+    finally:
+        backend.close()
+
+
+@pytest.mark.integration
 def test_agentic_docker_generated_python_denies_exec_and_network(tmp_path):
     image = os.environ.get(
         "AGENTIC_TEST_IMAGE", "gdpval-agentic-sandbox:local"
@@ -673,6 +1085,83 @@ Path('report.txt').write_text('blocked')
             pytest.skip(
                 "local kernel lacks seccomp TSYNC; generated Python stayed fail-closed"
             )
+        assert result["ok"] is True, result
+    finally:
+        backend.close()
+
+
+@pytest.mark.integration
+def test_outer_seccomp_allows_inner_filter_and_blocks_raw_signal_syscalls(
+    tmp_path
+):
+    image = os.environ.get(
+        "AGENTIC_TEST_IMAGE", "gdpval-agentic-sandbox:local"
+    )
+    profile_probe = subprocess.run(
+        [
+            "docker", "run", "--rm", "--network", "none", "--ipc", "none",
+            "--read-only", "--cap-drop", "ALL", "--user", "65532:65532",
+            "--security-opt", "no-new-privileges",
+            "--security-opt", f"seccomp={SECCOMP}",
+            "--entrypoint", "python", image, "-I", "-B", "-c",
+            "print('outer-seccomp-ready')",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if b"seccomp profiles are not supported" in profile_probe.stderr:
+        pytest.skip("local Docker daemon does not support custom seccomp profiles")
+    assert profile_probe.returncode == 0, profile_probe.stderr.decode(
+        "utf-8", errors="replace"
+    )
+    backend = AgenticDockerBackend(
+        task_prompt="Create report.txt",
+        reference_files=[],
+        occupation="Analyst",
+        image=image,
+        seccomp_profile=str(SECCOMP),
+        allow_unpinned_image=True,
+        require_rootless_or_userns=False,
+        require_approved_input_manifest=False,
+        require_supply_chain_identity=False,
+        require_dedicated_host=False,
+        enforce_cpu_limit=False,
+        enforce_pid_limit=False,
+        enforce_outer_seccomp=True,
+        enforce_procfs_policy=False,
+        local_root_parent=os.environ.get("AGENTIC_TEST_LOCAL_ROOT_PARENT"),
+        docker_root_parent=os.environ.get("AGENTIC_TEST_DOCKER_ROOT_PARENT"),
+    )
+    try:
+        startup = backend.start()
+        assert startup["ok"] is True, startup
+        result = backend.run_python(
+            """
+import ctypes
+import errno
+from pathlib import Path
+
+libc = ctypes.CDLL(None, use_errno=True)
+blocked = 0
+for number, arguments in (
+    (317, (0, 0, 0)),
+    (129, (1, 0, 0)),
+    (297, (1, 1, 0, 0)),
+):
+    ctypes.set_errno(0)
+    returned = libc.syscall(number, *arguments)
+    if returned == -1 and ctypes.get_errno() == errno.EPERM:
+        blocked += 1
+assert blocked == 3, blocked
+Path('report.txt').write_text('blocked')
+""",
+            30,
+        )
+        if "seccomp TSYNC unavailable" in result.get("data", {}).get(
+            "stderr_tail", ""
+        ):
+            pytest.skip("local nested kernel lacks seccomp TSYNC")
         assert result["ok"] is True, result
     finally:
         backend.close()

--- a/batch-runner/tests/test_agentic_selector.py
+++ b/batch-runner/tests/test_agentic_selector.py
@@ -1,0 +1,239 @@
+"""Tests for the preregistered outcome-free 5/20 selector."""
+
+from __future__ import annotations
+
+import random
+import subprocess
+
+import pytest
+
+from core.agentic_selector import (
+    SEED,
+    assert_outcome_free_checkout,
+    build_selection_manifest,
+    select_agentic_tasks,
+    resolve_outcome_free_file,
+)
+
+
+def _clean_repository(tmp_path):
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+    return repository
+
+
+def _commit(repository):
+    subprocess.run(["git", "add", "."], cwd=repository, check=True)
+    subprocess.run(
+        [
+            "git", "-c", "user.name=Agentic Test",
+            "-c", "user.email=agentic@example.invalid",
+            "commit", "-qm", "fixture",
+        ],
+        cwd=repository,
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _fixture():
+    records = []
+    rubrics = {}
+    strata = [
+        ("Finance", "xlsx", 12),
+        ("Health", "pdf", 9),
+        ("Media", "mp4", 7),
+        ("Technology", "", 5),
+    ]
+    index = 0
+    for sector, suffix, count in strata:
+        for _ in range(count):
+            task_id = f"task-{index:03d}"
+            references = [] if not suffix else [{
+                "path": f"input-{index}.{suffix}",
+                "size_bytes": 100 + index,
+            }]
+            records.append({
+                "task_id": task_id,
+                "sector": sector,
+                "occupation": f"Occupation {index}",
+                "prompt": "Create a professional deliverable",
+                "reference_files": references,
+            })
+            rubrics[task_id] = {
+                "rubric_items": [{"score": 5}, {"score": 3}]
+            }
+            index += 1
+    return records, rubrics
+
+
+def test_selector_is_shuffle_invariant_and_exactly_disjoint_5_20():
+    records, rubrics = _fixture()
+    dataset_sha = "a" * 40
+    first = select_agentic_tasks(
+        records, rubrics, dataset_sha=dataset_sha
+    )
+    shuffled = list(records)
+    random.Random(42).shuffle(shuffled)
+    second = select_agentic_tasks(
+        shuffled, rubrics, dataset_sha=dataset_sha
+    )
+
+    assert first == second
+    assert first["seed"] == SEED
+    assert len(first["canary_task_ids"]) == 5
+    assert len(first["diagnostic_task_ids"]) == 20
+    assert not (
+        set(first["canary_task_ids"]) & set(first["diagnostic_task_ids"])
+    )
+    assert sum(item["selected_quota"] for item in first["strata"]) == 25
+    assert sum(item["canary_quota"] for item in first["strata"]) == 5
+    assert {
+        item["sector"]: item["selected_quota"] for item in first["strata"]
+    } == {
+        "Finance": 9,
+        "Health": 7,
+        "Media": 5,
+        "Technology": 4,
+    }
+
+
+def test_selector_domains_and_metadata_are_frozen():
+    records, rubrics = _fixture()
+    result = select_agentic_tasks(records, rubrics, dataset_sha="b" * 40)
+
+    assert result["selection_domains"] == {
+        "select": "agentic-select-v1",
+        "canary": "agentic-canary-v1",
+        "order_canary": "agentic-order-canary-v1",
+        "order_diagnostic": "agentic-order-diagnostic-v1",
+    }
+    by_id = {item["task_id"]: item for item in result["selected_tasks"]}
+    assert set(by_id) == set(result["canary_task_ids"] + result["diagnostic_task_ids"])
+    assert all(item["positive_rubric_max"] == 8 for item in by_id.values())
+    assert {item["input_class"] for item in by_id.values()} <= {
+        "none", "tabular", "document", "media"
+    }
+
+
+@pytest.mark.parametrize(
+    "mutation,match",
+    [
+        (lambda records, rubrics: records[0].update({"grade": 100}), "outcome"),
+        (lambda records, rubrics: records[0].update({"task_id": ""}), "task_id"),
+        (lambda records, rubrics: rubrics.pop("task-000"), "missing rubric"),
+        (
+            lambda records, rubrics: records[0]["reference_files"][0].update(
+                {"size_bytes": 600 * 1024 * 1024}
+            ),
+            "input limit",
+        ),
+    ],
+)
+def test_selector_rejects_structural_and_outcome_inputs(mutation, match):
+    records, rubrics = _fixture()
+    mutation(records, rubrics)
+
+    with pytest.raises(ValueError, match=match):
+        select_agentic_tasks(records, rubrics, dataset_sha="c" * 40)
+
+
+@pytest.mark.parametrize("revision", ["main", "abc1234", "A" * 40, "g" * 40])
+def test_selector_rejects_mutable_or_noncanonical_dataset_revision(revision):
+    records, rubrics = _fixture()
+
+    with pytest.raises(ValueError, match="full immutable dataset revision"):
+        select_agentic_tasks(records, rubrics, dataset_sha=revision)
+
+
+def test_manifest_records_selector_hash_and_recomputation_identity(tmp_path):
+    records, rubrics = _fixture()
+    selection = select_agentic_tasks(records, rubrics, dataset_sha="d" * 40)
+    repository = _clean_repository(tmp_path)
+    selector = repository / "selector.py"
+    selector.write_text("print('selector')\n", encoding="utf-8")
+    commit = _commit(repository)
+
+    manifest = build_selection_manifest(
+        selection,
+        dataset_repo="owner/dataset",
+        dataset_sha="d" * 40,
+        rubric_repo="owner/rubric",
+        rubric_sha="e" * 40,
+        selector_path=selector,
+        repository_root=repository,
+        source_commit=commit,
+    )
+
+    assert len(manifest["selector"]["sha256"]) == 64
+    assert manifest["selector"]["path"] == "selector.py"
+    assert len(manifest["recomputation_sha256"]) == 64
+    assert manifest["selected_before_outcomes"] is True
+
+
+def test_manifest_rejects_mutable_rubric_revision_and_invalid_repository(
+    tmp_path
+):
+    records, rubrics = _fixture()
+    selection = select_agentic_tasks(records, rubrics, dataset_sha="d" * 40)
+    repository = _clean_repository(tmp_path)
+    selector = repository / "selector.py"
+    selector.write_text("print('selector')\n", encoding="utf-8")
+    commit = _commit(repository)
+
+    with pytest.raises(ValueError, match="rubric revision"):
+        build_selection_manifest(
+            selection,
+            dataset_repo="owner/dataset",
+            dataset_sha="d" * 40,
+            rubric_repo="owner/rubric",
+            rubric_sha="main",
+            selector_path=selector,
+            repository_root=repository,
+            source_commit=commit,
+        )
+    with pytest.raises(ValueError, match="dataset repository"):
+        build_selection_manifest(
+            selection,
+            dataset_repo="https://example.test/dataset",
+            dataset_sha="d" * 40,
+            rubric_repo="owner/rubric",
+            rubric_sha="e" * 40,
+            selector_path=selector,
+            repository_root=repository,
+            source_commit=commit,
+        )
+
+
+def test_outcome_free_checkout_rejects_forbidden_paths(tmp_path):
+    repository = _clean_repository(tmp_path)
+    (repository / "README.md").write_text("fixture\n", encoding="utf-8")
+    commit = _commit(repository)
+    assert assert_outcome_free_checkout(repository) == commit
+    forbidden = repository / "data" / "grades"
+    forbidden.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="forbidden outcome paths"):
+        assert_outcome_free_checkout(repository)
+
+
+def test_outcome_free_file_rejects_escape_and_symlink(tmp_path):
+    repository = _clean_repository(tmp_path)
+    source = repository / "dataset.json"
+    source.write_text("[]", encoding="utf-8")
+    outside = tmp_path / "outside.json"
+    outside.write_text("[]", encoding="utf-8")
+    link = repository / "link.json"
+    link.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="escapes"):
+        resolve_outcome_free_file(repository, outside, "dataset JSON")
+    with pytest.raises(ValueError, match="symlink"):
+        resolve_outcome_free_file(repository, link, "dataset JSON")

--- a/batch-runner/tests/test_agentic_selector.py
+++ b/batch-runner/tests/test_agentic_selector.py
@@ -158,7 +158,11 @@ def test_manifest_records_selector_hash_and_recomputation_identity(tmp_path):
     selection = select_agentic_tasks(records, rubrics, dataset_sha="d" * 40)
     repository = _clean_repository(tmp_path)
     selector = repository / "selector.py"
+    dataset = repository / "dataset.json"
+    rubric = repository / "rubric.json"
     selector.write_text("print('selector')\n", encoding="utf-8")
+    dataset.write_text("[]\n", encoding="utf-8")
+    rubric.write_text("{}\n", encoding="utf-8")
     commit = _commit(repository)
 
     manifest = build_selection_manifest(
@@ -167,6 +171,8 @@ def test_manifest_records_selector_hash_and_recomputation_identity(tmp_path):
         dataset_sha="d" * 40,
         rubric_repo="owner/rubric",
         rubric_sha="e" * 40,
+        dataset_path=dataset,
+        rubric_path=rubric,
         selector_path=selector,
         repository_root=repository,
         source_commit=commit,
@@ -174,6 +180,11 @@ def test_manifest_records_selector_hash_and_recomputation_identity(tmp_path):
 
     assert len(manifest["selector"]["sha256"]) == 64
     assert manifest["selector"]["path"] == "selector.py"
+    assert manifest["dataset"]["source_path"] == "dataset.json"
+    assert manifest["dataset"]["sha256"] == __import__("hashlib").sha256(
+        dataset.read_bytes()
+    ).hexdigest()
+    assert manifest["rubric"]["source_path"] == "rubric.json"
     assert len(manifest["recomputation_sha256"]) == 64
     assert manifest["selected_before_outcomes"] is True
 
@@ -185,7 +196,11 @@ def test_manifest_rejects_mutable_rubric_revision_and_invalid_repository(
     selection = select_agentic_tasks(records, rubrics, dataset_sha="d" * 40)
     repository = _clean_repository(tmp_path)
     selector = repository / "selector.py"
+    dataset = repository / "dataset.json"
+    rubric = repository / "rubric.json"
     selector.write_text("print('selector')\n", encoding="utf-8")
+    dataset.write_text("[]\n", encoding="utf-8")
+    rubric.write_text("{}\n", encoding="utf-8")
     commit = _commit(repository)
 
     with pytest.raises(ValueError, match="rubric revision"):
@@ -195,6 +210,8 @@ def test_manifest_rejects_mutable_rubric_revision_and_invalid_repository(
             dataset_sha="d" * 40,
             rubric_repo="owner/rubric",
             rubric_sha="main",
+            dataset_path=dataset,
+            rubric_path=rubric,
             selector_path=selector,
             repository_root=repository,
             source_commit=commit,
@@ -206,6 +223,8 @@ def test_manifest_rejects_mutable_rubric_revision_and_invalid_repository(
             dataset_sha="d" * 40,
             rubric_repo="owner/rubric",
             rubric_sha="e" * 40,
+            dataset_path=dataset,
+            rubric_path=rubric,
             selector_path=selector,
             repository_root=repository,
             source_commit=commit,

--- a/batch-runner/tests/test_agentic_tools.py
+++ b/batch-runner/tests/test_agentic_tools.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from core.agentic_tools import AgenticToolDispatcher, responses_tool_definitions
 
 
@@ -164,3 +166,45 @@ def test_run_python_timeout_is_clamped_to_remaining_task_time():
 
     assert result.result["ok"] is True
     assert backend.calls == [("run_python", "print('ok')", 2.5)]
+
+
+def test_same_inspection_is_allowed_after_workspace_mutation():
+    backend = FakeBackend()
+    dispatcher = AgenticToolDispatcher(backend)
+
+    first = dispatcher.dispatch("inspect_workspace", {})
+    duplicate = dispatcher.dispatch("inspect_workspace", {})
+    mutated = dispatcher.dispatch("run_python", {
+        "source": "print('changed')", "timeout_seconds": 5,
+    })
+    second = dispatcher.dispatch("inspect_workspace", {})
+
+    assert first.result["ok"] is True
+    assert duplicate.result["error_type"] == "duplicate_tool_request"
+    assert mutated.result["ok"] is True
+    assert second.result["ok"] is True
+    assert backend.calls == [
+        "inspect_workspace",
+        ("run_python", "print('changed')", 5.0),
+        "inspect_workspace",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments"),
+    [
+        ("run_python", {"source": "가" * 50_000, "timeout_seconds": 5}),
+        ("finalize", {"deliverables": ["report.txt"], "summary": "😀" * 600}),
+        ("inspect_artifacts", {"unexpected": "x"}),
+    ],
+)
+def test_tool_arguments_enforce_utf8_byte_limits(name, arguments):
+    backend = FakeBackend()
+    dispatcher = AgenticToolDispatcher(backend)
+
+    result = dispatcher.dispatch(name, arguments)
+
+    assert result.result["ok"] is False
+    assert result.result["error_type"] in {
+        "argument_byte_limit_exceeded", "invalid_arguments",
+    }

--- a/batch-runner/tests/test_agentic_tools.py
+++ b/batch-runner/tests/test_agentic_tools.py
@@ -1,0 +1,166 @@
+"""Tests for strict agentic tool schemas and dispatch budgets."""
+
+from __future__ import annotations
+
+import json
+
+from core.agentic_tools import AgenticToolDispatcher, responses_tool_definitions
+
+
+class FakeBackend:
+    def __init__(self):
+        self.calls = []
+        self.result = None
+
+    def start(self, timeout_seconds=1200.0):
+        return {"ok": True, "data": {}}
+
+    def inspect_workspace(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_workspace")
+        return {"ok": True, "data": {"file_count": 0}}
+
+    def inspect_environment(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_environment")
+        return {"ok": True, "data": {"python": "3.11"}}
+
+    def run_python(self, source, timeout_seconds):
+        self.calls.append(("run_python", source, timeout_seconds))
+        return {"ok": True, "data": {"returncode": 0}}
+
+    def run_ffmpeg(self, operation, timeout_seconds):
+        self.calls.append(("run_ffmpeg", operation["operation"]))
+        return {"ok": True, "data": {"returncode": 0}}
+
+    def inspect_artifacts(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_artifacts")
+        return {"ok": True, "data": {"verified": 1}}
+
+    def finalize(self, deliverables, summary, timeout_seconds=1200.0):
+        self.calls.append(("finalize", deliverables, summary))
+        self.result = {"success": True, "text": summary, "files": []}
+        return {"ok": True, "data": {"artifact_count": len(deliverables)}}
+
+    def best_result(self):
+        return self.result
+
+    def close(self):
+        pass
+
+
+def test_tool_definitions_are_strict_and_stable():
+    tools = responses_tool_definitions()
+
+    assert [tool["name"] for tool in tools] == [
+        "inspect_workspace", "inspect_environment", "run_python",
+        "run_ffmpeg", "inspect_artifacts", "finalize",
+    ]
+    assert all(tool["strict"] is True for tool in tools)
+
+
+def test_dispatch_rejects_malformed_unknown_and_duplicate_calls():
+    backend = FakeBackend()
+    dispatcher = AgenticToolDispatcher(backend)
+
+    assert dispatcher.dispatch("unknown", "{}").result["error_type"] == "unknown_tool"
+    assert dispatcher.dispatch("run_python", "{").result["error_type"] == "malformed_arguments"
+    assert dispatcher.dispatch("run_python", json.dumps({
+        "source": "print('ok')",
+        "timeout_seconds": 5,
+        "extra": True,
+    })).result["error_type"] == "invalid_arguments"
+
+    arguments = json.dumps({"source": "print('ok')", "timeout_seconds": 5})
+    assert dispatcher.dispatch("run_python", arguments).result["ok"] is True
+    assert dispatcher.dispatch("run_python", arguments).result["error_type"] == "duplicate_tool_request"
+
+
+def test_ffmpeg_is_closed_schema_with_one_new_output():
+    backend = FakeBackend()
+    dispatcher = AgenticToolDispatcher(backend)
+
+    invalid = {
+        "operation": "transcode_video",
+        "input": "inputs/source.mov",
+        "output": "out.mp4",
+        "container": "mp4",
+        "video_codec": "h264",
+        "audio_codec": "aac",
+        "width": 1920,
+        "height": 1080,
+        "fps": 30,
+        "start_seconds": 0,
+        "duration_seconds": 10,
+        "arbitrary_ffmpeg_args": ["-f", "concat"],
+    }
+    assert dispatcher.dispatch("run_ffmpeg", invalid).result["error_type"] == "invalid_arguments"
+
+    valid = dict(invalid)
+    valid.pop("arbitrary_ffmpeg_args")
+    assert dispatcher.dispatch("run_ffmpeg", valid).result["ok"] is True
+    assert backend.calls == [("run_ffmpeg", "transcode_video")]
+
+
+def test_finalize_requires_relative_unique_paths_and_terminal_result():
+    backend = FakeBackend()
+    dispatcher = AgenticToolDispatcher(backend)
+
+    rejected = dispatcher.dispatch("finalize", {
+        "deliverables": ["../escape.pdf"],
+        "summary": "done",
+    })
+    assert rejected.result["error_type"] == "invalid_arguments"
+
+    accepted = dispatcher.dispatch("finalize", {
+        "deliverables": ["report.pdf"],
+        "summary": "done",
+    })
+    assert accepted.finalized is True
+    assert accepted.terminal_result["success"] is True
+
+
+def test_batch_preflight_rejects_all_calls_before_any_dispatch():
+    backend = FakeBackend()
+    dispatcher = AgenticToolDispatcher(backend)
+
+    prepared, error = dispatcher.prepare_batch([
+        ("inspect_workspace", "{}"),
+        ("unexpected_tool", "{}"),
+    ])
+
+    assert prepared == []
+    assert error == "unknown_tool"
+    assert backend.calls == []
+    assert dispatcher.total_calls == 0
+
+
+def test_finalize_must_be_the_only_call_in_a_response():
+    backend = FakeBackend()
+    dispatcher = AgenticToolDispatcher(backend)
+
+    prepared, error = dispatcher.prepare_batch([
+        ("inspect_artifacts", "{}"),
+        ("finalize", json.dumps({
+            "deliverables": ["report.pdf"], "summary": "done",
+        })),
+    ])
+
+    assert prepared == []
+    assert error == "invalid_finalize_batch"
+    assert backend.calls == []
+
+
+def test_run_python_timeout_is_clamped_to_remaining_task_time():
+    backend = FakeBackend()
+    dispatcher = AgenticToolDispatcher(backend)
+    prepared, error = dispatcher.prepare_batch([(
+        "run_python",
+        json.dumps({"source": "print('ok')", "timeout_seconds": 100}),
+    )])
+
+    assert error is None
+    result = dispatcher.dispatch_prepared(
+        prepared[0], remaining_seconds=2.5
+    )
+
+    assert result.result["ok"] is True
+    assert backend.calls == [("run_python", "print('ok')", 2.5)]

--- a/batch-runner/tests/test_agentic_workflows.py
+++ b/batch-runner/tests/test_agentic_workflows.py
@@ -95,6 +95,10 @@ def test_agentic_image_build_is_sha_bound_and_attested():
     steps = _steps(BUILD_WORKFLOW)
     workflow = yaml.safe_load(BUILD_WORKFLOW.read_text(encoding="utf-8"))
     assert set(workflow[True]) == {"workflow_dispatch"}
+    job = workflow["jobs"]["build-sandbox-image"]
+    assert job["if"] == (
+        "github.ref == 'refs/heads/main' && github.ref_protected == true"
+    )
     assert all(
         not str(step.get("uses", "")).endswith(("@v3", "@v4", "@v6"))
         for step in steps
@@ -116,6 +120,13 @@ def test_agentic_image_build_is_sha_bound_and_attested():
         step for step in steps
         if step.get("name") == "Require immutable dependency locks before publication"
     )
+    checkout = next(
+        step for step in steps if step.get("name") == "Checkout"
+    )
+    main_guard = next(
+        step for step in steps
+        if step.get("name") == "Verify protected main checkout"
+    )
 
     assert "agentic.Dockerfile" in config["file"]
     assert (
@@ -123,9 +134,18 @@ def test_agentic_image_build_is_sha_bound_and_attested():
         in config["build-args"]
     )
     assert base["id"] == "base_build"
+    assert "if" not in base
+    assert checkout["with"]["ref"] == "${{ github.sha }}"
+    assert "refs/heads/main" in main_guard["run"]
+    assert "GITHUB_REF_PROTECTED" in main_guard["run"]
+    assert "git rev-parse HEAD" in main_guard["run"]
     assert steps.index(lock_gate) < steps.index(base)
+    assert lock_gate["if"] == "${{ inputs.publish_agentic == true }}"
     assert "--hash=sha256:" in lock_gate["run"]
     assert "debian-packages.lock" in lock_gate["run"]
+    assert "len(packages) < 100" in lock_gate["run"]
+    assert "GDPVAL_LOCKED_DEBIAN_PACKAGES" in lock_gate["run"]
+    assert "pip install --upgrade" in lock_gate["run"]
     dockerfile = (
         ROOT / "batch-runner" / "sandbox" / "Dockerfile"
     ).read_text(encoding="utf-8")
@@ -147,6 +167,10 @@ def test_agentic_image_build_is_sha_bound_and_attested():
         step for step in steps
         if step.get("name") == "Promote verified agentic digest to latest"
     )
+    assert all(
+        step["if"] == "${{ inputs.publish_agentic == true }}"
+        for step in (candidate, candidate_audit, agentic, published_audit, promote)
+    )
     assert candidate["with"]["load"] is True
     assert candidate["with"]["push"] is False
     assert "agentic_image_audit.py" in candidate_audit["run"]
@@ -166,6 +190,9 @@ def test_agentic_preflight_is_dedicated_and_model_free():
     text = PREFLIGHT_WORKFLOW.read_text(encoding="utf-8")
 
     assert job["runs-on"] == ["self-hosted", "linux", "x64", "agentic-sandbox"]
+    assert job["if"] == (
+        "github.ref == 'refs/heads/main' && github.ref_protected == true"
+    )
     assert document["permissions"] == {"contents": "read"}
     assert "azure/login" not in text
     assert "HF_TOKEN: ${{" not in text
@@ -174,7 +201,19 @@ def test_agentic_preflight_is_dedicated_and_model_free():
     assert "setup-python" not in text
     assert "preloaded-model-free-environment=pass" in text
     assert "test_agentic_production_runner_preflight" in text
+    assert (
+        "test_outer_seccomp_allows_inner_filter_and_blocks_raw_signal_syscalls"
+        in text
+    )
     checkout = next(
         step for step in job["steps"] if step.get("name") == "Checkout exact implementation"
     )
     assert checkout["with"]["persist-credentials"] is False
+    assert checkout["with"]["ref"] == "${{ github.sha }}"
+    main_guard = next(
+        step for step in job["steps"]
+        if step.get("name") == "Verify protected main checkout"
+    )
+    assert "refs/heads/main" in main_guard["run"]
+    assert "GITHUB_REF_PROTECTED" in main_guard["run"]
+    assert "git rev-parse HEAD" in main_guard["run"]

--- a/batch-runner/tests/test_agentic_workflows.py
+++ b/batch-runner/tests/test_agentic_workflows.py
@@ -1,0 +1,180 @@
+"""Static fail-closed checks for agentic GitHub workflows."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BATCH_WORKFLOW = ROOT / ".github" / "workflows" / "batch-run.yml"
+BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "build-sandbox-image.yml"
+PREFLIGHT_WORKFLOW = (
+    ROOT / ".github" / "workflows" / "agentic-sandbox-preflight.yml"
+)
+
+
+def _steps(path):
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return next(iter(document["jobs"].values()))["steps"]
+
+
+def _assert_actions_are_commit_pinned(path):
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    references = [
+        str(step["uses"])
+        for job in document["jobs"].values()
+        for step in job.get("steps", [])
+        if "uses" in step
+    ]
+    assert references
+    assert all(
+        re.search(r"@[0-9a-f]{40}$", reference) is not None
+        for reference in references
+    )
+
+
+def test_general_batch_blocks_agentic_before_any_credential_step():
+    _assert_actions_are_commit_pinned(BATCH_WORKFLOW)
+    document = yaml.safe_load(BATCH_WORKFLOW.read_text(encoding="utf-8"))
+    inspect_job = document["jobs"]["inspect-mode"]
+    reject_job = document["jobs"]["reject-agentic"]
+    batch_job = document["jobs"]["batch-run"]
+    steps = batch_job["steps"]
+    names = [step.get("name", "") for step in steps]
+    block_index = names.index("Block agentic modes in credentialed general workflow")
+
+    assert inspect_job["permissions"] == {"contents": "read"}
+    assert inspect_job["outputs"]["uses_agentic"] == (
+        "${{ steps.mode.outputs.uses_agentic }}"
+    )
+    inspect_checkout = next(
+        step for step in inspect_job["steps"] if step.get("name") == "Checkout config only"
+    )
+    assert inspect_checkout["with"]["persist-credentials"] is False
+    assert "YAML.safe_load" in inspect_job["steps"][-1]["run"]
+    assert "mode'] == 'agentic_sandbox'" in inspect_job["steps"][-1]["run"]
+    assert reject_job["if"] == (
+        "needs.inspect-mode.outputs.uses_agentic == 'true'"
+    )
+    assert batch_job["needs"] == "inspect-mode"
+    assert batch_job["if"] == (
+        "needs.inspect-mode.outputs.uses_agentic != 'true'"
+    )
+    batch_checkout = next(
+        step for step in steps if step.get("name") == "Checkout"
+    )
+    assert batch_checkout["with"]["persist-credentials"] is False
+    assert steps[block_index]["if"] == (
+        "steps.read_config.outputs.uses_agentic == 'true'"
+    )
+    assert "mode == 'agentic_sandbox' or hardened" in steps[
+        names.index("Read experiment config flags")
+    ]["run"]
+    credential_indices = [
+        index
+        for index, step in enumerate(steps)
+        if (
+            "azure/login" in str(step.get("uses", ""))
+            or "HF_TOKEN" in str(step.get("env", {}))
+            or "OPENAI_API_KEY" in str(step.get("env", {}))
+        )
+    ]
+    assert credential_indices
+    assert block_index < min(credential_indices)
+    assert all(
+        "${{ inputs." not in str(step.get("run", ""))
+        for job in document["jobs"].values()
+        for step in job.get("steps", [])
+    )
+
+
+def test_agentic_image_build_is_sha_bound_and_attested():
+    _assert_actions_are_commit_pinned(BUILD_WORKFLOW)
+    text = BUILD_WORKFLOW.read_text(encoding="utf-8")
+    steps = _steps(BUILD_WORKFLOW)
+    workflow = yaml.safe_load(BUILD_WORKFLOW.read_text(encoding="utf-8"))
+    assert set(workflow[True]) == {"workflow_dispatch"}
+    assert all(
+        not str(step.get("uses", "")).endswith(("@v3", "@v4", "@v6"))
+        for step in steps
+    )
+    candidate = next(
+        step for step in steps
+        if step.get("name") == "Build agentic sandbox audit candidate"
+    )
+    agentic = next(
+        step for step in steps
+        if step.get("name") == "Build and push audited agentic sandbox image"
+    )
+    config = agentic["with"]
+    base = next(
+        step for step in steps
+        if step.get("name") == "Build and push sandbox image"
+    )
+    lock_gate = next(
+        step for step in steps
+        if step.get("name") == "Require immutable dependency locks before publication"
+    )
+
+    assert "agentic.Dockerfile" in config["file"]
+    assert (
+        "BASE_IMAGE=ghcr.io/hyeonsangjeon/gdpval-sandbox@${{ steps.base_build.outputs.digest }}"
+        in config["build-args"]
+    )
+    assert base["id"] == "base_build"
+    assert steps.index(lock_gate) < steps.index(base)
+    assert "--hash=sha256:" in lock_gate["run"]
+    assert "debian-packages.lock" in lock_gate["run"]
+    dockerfile = (
+        ROOT / "batch-runner" / "sandbox" / "Dockerfile"
+    ).read_text(encoding="utf-8")
+    assert re.search(r"^FROM python:3\.11-slim-bookworm@sha256:[0-9a-f]{64}$", dockerfile, re.MULTILINE)
+    assert "COPY requirements.txt requirements-renderer.txt /tmp/" in dockerfile
+    assert agentic["id"] == "agentic_build"
+    assert config["provenance"] == "mode=max"
+    assert config["sbom"] is True
+    assert "batch-runner/sandbox/agentic.Dockerfile" in text
+    candidate_audit = next(
+        step for step in steps
+        if step.get("name") == "Audit agentic sandbox candidate before publication"
+    )
+    published_audit = next(
+        step for step in steps
+        if step.get("name") == "Verify published agentic digest and attestations"
+    )
+    promote = next(
+        step for step in steps
+        if step.get("name") == "Promote verified agentic digest to latest"
+    )
+    assert candidate["with"]["load"] is True
+    assert candidate["with"]["push"] is False
+    assert "agentic_image_audit.py" in candidate_audit["run"]
+    assert "steps.agentic_build.outputs.digest" in published_audit["env"]["IMAGE"]
+    assert "steps.base_build.outputs.digest" in published_audit["env"]["EXPECTED_BASE"]
+    assert "agentic-sbom.spdx.json" in published_audit["run"]
+    assert "attached-sbom.json" in published_audit["run"]
+    assert "imagetools create" in promote["run"]
+    assert steps.index(candidate_audit) < steps.index(agentic)
+    assert steps.index(published_audit) < steps.index(promote)
+
+
+def test_agentic_preflight_is_dedicated_and_model_free():
+    _assert_actions_are_commit_pinned(PREFLIGHT_WORKFLOW)
+    document = yaml.safe_load(PREFLIGHT_WORKFLOW.read_text(encoding="utf-8"))
+    job = document["jobs"]["model-free-preflight"]
+    text = PREFLIGHT_WORKFLOW.read_text(encoding="utf-8")
+
+    assert job["runs-on"] == ["self-hosted", "linux", "x64", "agentic-sandbox"]
+    assert document["permissions"] == {"contents": "read"}
+    assert "azure/login" not in text
+    assert "HF_TOKEN: ${{" not in text
+    assert "OPENAI_API_KEY: ${{" not in text
+    assert "pip install" not in text
+    assert "setup-python" not in text
+    assert "preloaded-model-free-environment=pass" in text
+    assert "test_agentic_production_runner_preflight" in text
+    checkout = next(
+        step for step in job["steps"] if step.get("name") == "Checkout exact implementation"
+    )
+    assert checkout["with"]["persist-credentials"] is False

--- a/batch-runner/tests/test_executor.py
+++ b/batch-runner/tests/test_executor.py
@@ -1,10 +1,10 @@
 """Tests for core/executor.py"""
 
 import pytest
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import Mock, patch
 
 from core.agentic_authorization import provider_endpoint_sha256
-from core.executor import TaskExecutor, ExecutionMode
+from core.executor import TaskExecutor
 
 
 def test_executor_initialization_code_interpreter():
@@ -397,6 +397,10 @@ def test_executor_production_agentic_refuses_local_compute_fallback(
             "provider_classifications": {
                 task_id: "approved_public_gdpval" for task_id in task_ids
             },
+            "task_request_sha256": {
+                task_id: "d" * 64 for task_id in task_ids
+            },
+            "selection_recomputation_sha256": "e" * 64,
             "approval_scope_sha256": "b" * 64,
             "official_scope_registry_sha256": "c" * 64,
         },
@@ -410,6 +414,10 @@ def test_executor_production_agentic_refuses_local_compute_fallback(
             condition_name="treatment",
             model_name="model",
             agentic_endpoint=endpoint,
+            agentic_ordered_task_ids=list(task_ids),
+            agentic_task_request_sha256={
+                task_id: "d" * 64 for task_id in task_ids
+            },
             agentic_runtime_identity={
                 "plan_sha": "b" * 40,
                 "implementation_sha": "c" * 40,

--- a/batch-runner/tests/test_executor.py
+++ b/batch-runner/tests/test_executor.py
@@ -3,6 +3,7 @@
 import pytest
 from unittest.mock import Mock, MagicMock, patch
 
+from core.agentic_authorization import provider_endpoint_sha256
 from core.executor import TaskExecutor, ExecutionMode
 
 
@@ -236,6 +237,216 @@ def test_executor_sandbox_passes_options_and_tokens():
         assert kwargs["cpus"] == 3.0
         assert kwargs["max_skills"] == 4
         assert kwargs["metrics"] == {"enabled": True}
+
+
+# ── Agentic sandbox mode ──────────────────────────────────────────────────
+
+
+def test_executor_validate_mode_agentic_openai_only():
+    for provider in ("azure", "openai"):
+        valid, error = TaskExecutor.validate_mode("agentic_sandbox", provider)
+        assert valid is True
+        assert error is None
+
+    valid, error = TaskExecutor.validate_mode("agentic_sandbox", "anthropic")
+    assert valid is False
+    assert "agentic_sandbox mode requires OpenAI/Azure OpenAI" in error
+
+
+def test_executor_agentic_nonpaid_requires_explicit_fakes():
+    with pytest.raises(ValueError, match="explicit backend and authorization fakes"):
+        TaskExecutor(
+            mode="agentic_sandbox",
+            llm_client=Mock(),
+            provider="azure",
+            non_paid_test_mode=True,
+            agentic_options={"pricing": {}},
+        )
+
+
+def test_executor_agentic_forwards_scoped_identity():
+    fake_client = Mock()
+    backend_factory = Mock()
+    authorizer = Mock()
+    ledger = Mock()
+    with patch("core.executor.AgenticSandboxRunner") as runner_cls:
+        runner = Mock()
+        runner.run.return_value = {"success": True, "text": "ok", "files": []}
+        runner_cls.return_value = runner
+        runner_cls.DEFAULT_PROMPT = "agentic_sandbox_solver"
+
+        executor = TaskExecutor(
+            mode="agentic_sandbox",
+            llm_client=fake_client,
+            provider="azure",
+            non_paid_test_mode=True,
+            agentic_backend_factory=backend_factory,
+            agentic_authorize_request=authorizer,
+            agentic_budget_ledger=ledger,
+            agentic_options={
+                "limits": {"max_model_iterations": 3},
+                "pricing": {
+                    "input_per_million": "0",
+                    "output_per_million": "0",
+                },
+            },
+        )
+        result = executor.execute(
+            task_prompt="task",
+            model="deployment",
+            task_id="task-1",
+            run_id="run-1",
+            condition_name="treatment",
+        )
+
+        assert result["success"] is True
+        constructor = runner_cls.call_args.kwargs
+        assert constructor["backend_factory"] is backend_factory
+        assert constructor["authorize_request"] is authorizer
+        assert constructor["limits"] == {"max_model_iterations": 3}
+        run_kwargs = runner.run.call_args.kwargs
+        assert run_kwargs["task_id"] == "task-1"
+        assert run_kwargs["run_id"] == "run-1"
+        assert run_kwargs["condition_name"] == "treatment"
+
+
+def test_executor_hardened_sandbox_is_explicit_opt_in():
+    fake_client = Mock()
+    backend_factory = Mock()
+    authorizer = Mock()
+    ledger = Mock()
+    with patch("core.executor.HardenedSandboxRunner") as runner_cls:
+        runner = Mock()
+        runner.run.return_value = {"success": True, "text": "ok", "files": []}
+        runner_cls.return_value = runner
+
+        executor = TaskExecutor(
+            mode="sandbox",
+            llm_client=fake_client,
+            provider="azure",
+            non_paid_test_mode=True,
+            run_id="paired-run",
+            condition_name="baseline",
+            model_name="model",
+            sandbox_options={"hardened_substrate": True},
+            agentic_backend_factory=backend_factory,
+            agentic_authorize_request=authorizer,
+            agentic_budget_ledger=ledger,
+            agentic_options={
+                "limits": {"max_api_attempts": 2, "max_model_iterations": 2},
+                "pricing": {
+                    "input_per_million": "0",
+                    "output_per_million": "0",
+                },
+                "budget": {
+                    "paired_run_id": "paired-run",
+                    "condition": {
+                        "attempts": 40,
+                        "input_tokens": 1000000,
+                        "output_tokens": 100000,
+                        "cost_usd": "25",
+                    },
+                    "paired_run": {
+                        "attempts": 80,
+                        "input_tokens": 2000000,
+                        "output_tokens": 200000,
+                        "cost_usd": "50",
+                    },
+                },
+            },
+        )
+        result = executor.execute(
+            task_prompt="task",
+            model="model",
+            task_id="task-1",
+            run_id="paired-run",
+            condition_name="baseline",
+        )
+
+        assert result["success"] is True
+        assert executor.hardened_sandbox is True
+        assert runner_cls.call_args.kwargs["backend_factory"] is backend_factory
+        run_kwargs = runner.run.call_args.kwargs
+        assert run_kwargs["task_id"] == "task-1"
+        assert run_kwargs["run_id"] == "paired-run"
+        assert run_kwargs["condition_name"] == "baseline"
+
+
+def test_executor_production_agentic_refuses_local_compute_fallback(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv(
+        "AGENTIC_SIGNED_APPROVAL_PATH", str(tmp_path / "approval.json")
+    )
+    monkeypatch.setenv(
+        "AGENTIC_NONCE_LEDGER_PATH", str(tmp_path / "nonce.sqlite3")
+    )
+    monkeypatch.setenv(
+        "AGENTIC_BUDGET_LEDGER_PATH", str(tmp_path / "budget.sqlite3")
+    )
+    endpoint = "https://fixture.openai.azure.com"
+    task_ids = tuple(f"task-{index:02d}" for index in range(20))
+    monkeypatch.setattr(
+        "core.executor._load_live_approval_scope",
+        lambda **kwargs: {
+            "conditions": ("treatment",),
+            "task_ids": task_ids,
+            "input_merkle_roots": {
+                task_id: "a" * 64 for task_id in task_ids
+            },
+            "provider_classifications": {
+                task_id: "approved_public_gdpval" for task_id in task_ids
+            },
+            "approval_scope_sha256": "b" * 64,
+            "official_scope_registry_sha256": "c" * 64,
+        },
+    )
+    with pytest.raises(ValueError, match="remote authenticated compute backend"):
+        TaskExecutor(
+            mode="agentic_sandbox",
+            provider="azure",
+            client_factory=Mock(),
+            run_id="run-1",
+            condition_name="treatment",
+            model_name="model",
+            agentic_endpoint=endpoint,
+            agentic_runtime_identity={
+                "plan_sha": "b" * 40,
+                "implementation_sha": "c" * 40,
+                "workflow_sha": "d" * 64,
+                "workflow_inputs_sha256": "e" * 64,
+            },
+            agentic_options={
+                "image": "image@sha256:" + "a" * 64,
+                "limits": {},
+                "pricing": {
+                    "input_per_million": "1",
+                    "output_per_million": "2",
+                },
+                "budget": {
+                    "paired_run_id": "run-1",
+                    "condition": {
+                        "attempts": 40,
+                        "input_tokens": 1000000,
+                        "output_tokens": 100000,
+                        "cost_usd": "25",
+                    },
+                    "paired_run": {
+                        "attempts": 80,
+                        "input_tokens": 2000000,
+                        "output_tokens": 200000,
+                        "cost_usd": "50",
+                    },
+                },
+                "authorization": {
+                    "api_version": "version",
+                    "provider_classification": "approved_public_gdpval",
+                    "endpoint_sha256": provider_endpoint_sha256(
+                        "azure", endpoint
+                    ),
+                },
+            },
+        )
 
 
 def test_executor_sandbox_defaults_when_no_options():

--- a/batch-runner/tests/test_experiment_config.py
+++ b/batch-runner/tests/test_experiment_config.py
@@ -393,6 +393,20 @@ class TestExperimentConfigValidation:
 
         assert any("condition_a.qa must be disabled" in error for error in errors)
 
+    def test_validate_hardened_rejects_prompt_prefix_and_body(
+        self, sample_config_dict
+    ):
+        sample_config_dict["execution"]["mode"] = "agentic_sandbox"
+        sample_config_dict["experiment"]["id"] = "exp028"
+        sample_config_dict["execution"]["agentic"] = _valid_agentic_config()
+        del sample_config_dict["condition_b"]
+        sample_config_dict["condition_a"]["prompt"]["prefix"] = "prefix"
+        sample_config_dict["condition_a"]["prompt"]["body"] = "body"
+
+        errors = ExperimentConfig.from_dict(sample_config_dict).validate()
+
+        assert any("prompt prefix/body" in error for error in errors)
+
     def test_validate_agentic_ids_are_reserved(self, sample_config_dict):
         sample_config_dict["execution"]["mode"] = "agentic_sandbox"
         sample_config_dict["execution"]["agentic"] = _valid_agentic_config()

--- a/batch-runner/tests/test_experiment_config.py
+++ b/batch-runner/tests/test_experiment_config.py
@@ -23,6 +23,44 @@ from core.experiment_config import (
 )
 
 
+def _valid_agentic_config():
+    return {
+        "compute_transport": "remote",
+        "image": "task@sha256:" + "a" * 64,
+        "verifier_image": "verifier@sha256:" + "b" * 64,
+        "memory_gb": 8,
+        "cpus": 2,
+        "limits": {
+            "max_api_attempts": 6,
+            "max_model_iterations": 6,
+            "max_tool_calls": 8,
+        },
+        "budget": {
+            "paired_run_id": "paired-run",
+            "condition": {
+                "attempts": 30,
+                "input_tokens": 1000000,
+                "output_tokens": 100000,
+                "cost_usd": "6.25",
+            },
+            "paired_run": {
+                "attempts": 30,
+                "input_tokens": 1500000,
+                "output_tokens": 163840,
+                "cost_usd": "6.25",
+            },
+        },
+        "pricing_table": {
+            "sha256": "c" * 64,
+        },
+        "authorization": {
+            "api_version": "2025-04-01-preview",
+            "provider_classification": "approved_public_gdpval",
+                "endpoint_sha256": "d" * 64,
+        },
+    }
+
+
 @pytest.fixture
 def sample_config_dict():
     """Create a sample configuration dictionary"""
@@ -218,6 +256,20 @@ class TestExperimentConfigFromDict:
         assert config.execution.metrics == {"enabled": True}
         assert config.to_dict()["execution"]["metrics"] == {"enabled": True}
 
+    def test_from_dict_agentic_config_is_opt_in(self, sample_config_dict):
+        config = ExperimentConfig.from_dict(sample_config_dict)
+        assert config.execution.agentic is None
+        assert "agentic" not in config.to_dict()["execution"]
+
+        sample_config_dict["execution"]["mode"] = "agentic_sandbox"
+        sample_config_dict["experiment"]["id"] = "exp028"
+        sample_config_dict["execution"]["agentic"] = _valid_agentic_config()
+
+        config = ExperimentConfig.from_dict(sample_config_dict)
+
+        assert config.execution.agentic == _valid_agentic_config()
+        assert config.to_dict()["execution"]["agentic"] == config.execution.agentic
+
     @pytest.mark.parametrize(
         "metrics",
         [{}, {"enabled": False}, {"enabled": "false"}, {"enabled": 1}, []],
@@ -296,6 +348,59 @@ class TestExperimentConfigValidation:
 
         assert len(errors) > 0
         assert any("provider" in e for e in errors)
+
+    def test_validate_agentic_sandbox_provider(self, sample_config_dict):
+        sample_config_dict["execution"]["mode"] = "agentic_sandbox"
+        sample_config_dict["experiment"]["id"] = "exp028"
+        sample_config_dict["execution"]["agentic"] = _valid_agentic_config()
+        del sample_config_dict["condition_b"]
+        assert ExperimentConfig.from_dict(sample_config_dict).validate() == []
+
+        sample_config_dict["condition_a"]["model"]["provider"] = "anthropic"
+        errors = ExperimentConfig.from_dict(sample_config_dict).validate()
+
+        assert errors == [
+            "agentic_sandbox mode requires azure or openai provider for condition_a"
+        ]
+
+    def test_validate_agentic_sandbox_rejects_unsafe_config(
+        self, sample_config_dict
+    ):
+        sample_config_dict["execution"]["mode"] = "agentic_sandbox"
+        sample_config_dict["experiment"]["id"] = "exp028"
+        config = _valid_agentic_config()
+        config["image"] = "latest"
+        config["unexpected"] = True
+        sample_config_dict["execution"]["agentic"] = config
+
+        errors = ExperimentConfig.from_dict(sample_config_dict).validate()
+
+        assert any("image must be pinned" in error for error in errors)
+        assert any("unknown fields" in error for error in errors)
+
+    def test_validate_hardened_sandbox_rejects_self_qa(
+        self, sample_config_dict
+    ):
+        sample_config_dict["execution"]["mode"] = "sandbox"
+        sample_config_dict["experiment"]["id"] = "exp029"
+        sample_config_dict["execution"]["sandbox"] = {
+            "hardened_substrate": True
+        }
+        sample_config_dict["execution"]["agentic"] = _valid_agentic_config()
+        sample_config_dict["condition_a"]["qa"] = {"enabled": True}
+
+        errors = ExperimentConfig.from_dict(sample_config_dict).validate()
+
+        assert any("condition_a.qa must be disabled" in error for error in errors)
+
+    def test_validate_agentic_ids_are_reserved(self, sample_config_dict):
+        sample_config_dict["execution"]["mode"] = "agentic_sandbox"
+        sample_config_dict["execution"]["agentic"] = _valid_agentic_config()
+        sample_config_dict["experiment"]["id"] = "exp031"
+
+        errors = ExperimentConfig.from_dict(sample_config_dict).validate()
+
+        assert any("must be exp028 or exp030" in error for error in errors)
 
     def test_validate_task_ids_rejects_duplicates_and_sampling(self, sample_config_dict):
         sample_config_dict["data"]["filter"]["task_ids"] = ["task-1", "task-1"]

--- a/batch-runner/tests/test_hardened_sandbox_runner.py
+++ b/batch-runner/tests/test_hardened_sandbox_runner.py
@@ -1,0 +1,232 @@
+"""Tests for current sandbox semantics on the common hardened substrate."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core.agentic_budget import AgenticBudgetLedger
+from core.hardened_sandbox_runner import HardenedSandboxRunner
+
+
+SUBSTRATE = {
+    "schema_version": "1.0",
+    "task_image": "image@sha256:" + "a" * 64,
+    "sha256": "b" * 64,
+}
+
+
+class ScriptedCompletions:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if not self.responses:
+            raise AssertionError("completion script exhausted")
+        return self.responses.pop(0)
+
+
+class FakeProviderClient:
+    def __init__(self, responses):
+        self.chat = SimpleNamespace(
+            completions=ScriptedCompletions(responses)
+        )
+
+
+def _response(code, description="generated"):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(
+            content=f"```python\n{code}\n```\n{description}"
+        ))],
+        usage=SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=20,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=5),
+        ),
+    )
+
+
+class FakeBackend:
+    def __init__(self, inspections, **_):
+        self.inspections = list(inspections)
+        self.calls = []
+        self.closed = False
+        self._best = None
+
+    def start(self, timeout_seconds=1200.0):
+        self.calls.append("start")
+        return {
+            "ok": True,
+            "data": {
+                "input_merkle_root": "c" * 64,
+                "provider_classification": "approved_public_gdpval",
+                "substrate_manifest": SUBSTRATE,
+            },
+        }
+
+    def reset_work(self, timeout_seconds=1200.0):
+        self.calls.append("reset_work")
+        return {"ok": True, "data": {}}
+
+    def run_python(self, source, timeout_seconds):
+        self.calls.append(("run_python", source, timeout_seconds))
+        return {
+            "ok": True,
+            "data": {"returncode": 0, "stdout_tail": "", "stderr_tail": ""},
+        }
+
+    def inspect_artifacts(self, timeout_seconds=1200.0):
+        self.calls.append("inspect_artifacts")
+        return self.inspections.pop(0)
+
+    def finalize(self, deliverables, summary, timeout_seconds=1200.0):
+        self.calls.append(("finalize", list(deliverables)))
+        self._best = {
+            "success": True,
+            "text": summary,
+            "deliverable_text": summary,
+            "files": [{"filename": "report.txt", "content": b"report"}],
+        }
+        return {"ok": True, "data": {"artifact_count": 1}}
+
+    def best_result(self):
+        return self._best
+
+    def close(self):
+        self.closed = True
+
+
+def _inspection(ok):
+    return {
+        "ok": ok,
+        "error_type": None if ok else "artifact_verification_failed",
+        "data": {
+            "artifacts": ([{
+                "path": "report.txt",
+                "size_bytes": 6,
+                "sha256": "d" * 64,
+                "kind": "text",
+                "openable": True,
+            }] if ok else []),
+            "contract": {
+                "ok": ok,
+                "blocking_errors": [] if ok else ["missing report"],
+                "warnings": [],
+                "matched_primary": ["report.txt"] if ok else [],
+                "generated_count": 1 if ok else 0,
+            },
+        },
+    }
+
+
+def _runner(tmp_path, responses, inspections):
+    provider = FakeProviderClient(responses)
+    backends = []
+
+    def backend_factory(**kwargs):
+        backend = FakeBackend(inspections, **kwargs)
+        backends.append(backend)
+        return backend
+
+    authorization = []
+    runner = HardenedSandboxRunner(
+        client_factory=lambda: provider,
+        backend_factory=backend_factory,
+        budget_ledger=AgenticBudgetLedger(tmp_path / "budget.sqlite3"),
+        authorize_request=lambda scope, request_id, context: authorization.append(
+            (scope, request_id, context)
+        ),
+        run_id="paired-run",
+        condition_name="baseline",
+        model_name="model",
+        limits={"max_api_attempts": 2, "max_model_iterations": 2},
+        pricing={
+            "input_per_million": "0",
+            "output_per_million": "0",
+            "cached_input_per_million": "0",
+        },
+        aggregate_budget={
+            "paired_run_id": "paired-run",
+            "condition": {
+                "attempts": 40,
+                "input_tokens": 1000000,
+                "output_tokens": 100000,
+                "cost_usd": "25",
+            },
+            "paired_run": {
+                "attempts": 80,
+                "input_tokens": 2000000,
+                "output_tokens": 200000,
+                "cost_usd": "50",
+            },
+        },
+        image=SUBSTRATE["task_image"],
+        metrics={"enabled": True},
+        manifest={"enabled": True, "include_in_files": True},
+    )
+    return runner, provider, backends, authorization
+
+
+def test_hardened_baseline_runs_once_on_verified_first_attempt(tmp_path):
+    runner, provider, backends, authorization = _runner(
+        tmp_path,
+        [_response("open('report.txt', 'w').write('report')")],
+        [_inspection(True), _inspection(True)],
+    )
+
+    result = runner.run(
+        "Create report.txt",
+        "model",
+        run_id="paired-run",
+        condition_name="baseline",
+        task_id="task-1",
+    )
+
+    assert result["success"] is True
+    assert result["final_status"] == "ok"
+    assert result["substrate_manifest"] == SUBSTRATE
+    assert [item["filename"] for item in result["files"]] == ["report.txt"]
+    assert len(provider.chat.completions.calls) == 1
+    assert provider.chat.completions.calls[0]["max_completion_tokens"] == 8192
+    assert len(authorization) == 1
+    timing = result["budget_metrics"].pop("time_to_valid_artifact_ms")
+    assert timing is not None and timing >= 0
+    assert result["budget_metrics"] == {
+        "schema_version": "1.0",
+        "model_api_calls": 1,
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cached_tokens": 5,
+        "conservative_cost_usd": "0",
+        "usage_complete": True,
+    }
+    assert backends[0].calls.count("reset_work") == 1
+    assert backends[0].closed is True
+
+
+def test_hardened_baseline_regenerates_complete_solution_once(tmp_path):
+    runner, provider, backends, authorization = _runner(
+        tmp_path,
+        [
+            _response("open('bad.txt', 'w').write('bad')"),
+            _response("open('report.txt', 'w').write('report')", "repaired"),
+        ],
+        [_inspection(False), _inspection(True), _inspection(True)],
+    )
+
+    result = runner.run(
+        "Create report.txt",
+        "model",
+        run_id="paired-run",
+        condition_name="baseline",
+        task_id="task-1",
+    )
+
+    assert result["success"] is True
+    assert result["final_status"] == "repaired_ok"
+    assert len(provider.chat.completions.calls) == 2
+    assert len(authorization) == 2
+    assert backends[0].calls.count("reset_work") == 2
+    assert len([call for call in backends[0].calls if isinstance(call, tuple) and call[0] == "run_python"]) == 2
+    assert runner.budget_ledger.usage('["paired_run","paired-run"]').attempts == 2

--- a/batch-runner/tests/test_hardened_sandbox_runner.py
+++ b/batch-runner/tests/test_hardened_sandbox_runner.py
@@ -60,6 +60,7 @@ class FakeBackend:
             "ok": True,
             "data": {
                 "input_merkle_root": "c" * 64,
+                "selection_recomputation_sha256": "e" * 64,
                 "provider_classification": "approved_public_gdpval",
                 "substrate_manifest": SUBSTRATE,
             },
@@ -190,6 +191,7 @@ def test_hardened_baseline_runs_once_on_verified_first_attempt(tmp_path):
     assert len(provider.chat.completions.calls) == 1
     assert provider.chat.completions.calls[0]["max_completion_tokens"] == 8192
     assert len(authorization) == 1
+    assert authorization[0][2]["selection_recomputation_sha256"] == "e" * 64
     timing = result["budget_metrics"].pop("time_to_valid_artifact_ms")
     assert timing is not None and timing >= 0
     assert result["budget_metrics"] == {
@@ -230,3 +232,89 @@ def test_hardened_baseline_regenerates_complete_solution_once(tmp_path):
     assert backends[0].calls.count("reset_work") == 2
     assert len([call for call in backends[0].calls if isinstance(call, tuple) and call[0] == "run_python"]) == 2
     assert runner.budget_ledger.usage('["paired_run","paired-run"]').attempts == 2
+
+
+def test_hardened_reconciliation_failure_marks_usage_incomplete(tmp_path):
+    runner, _, _, _ = _runner(
+        tmp_path,
+        [_response("open('report.txt', 'w').write('report')")],
+        [_inspection(True)],
+    )
+
+    def fail_reconciliation(**kwargs):
+        raise ValueError("reservation mismatch")
+
+    runner.budget_ledger.reconcile_many = fail_reconciliation
+    result = runner.run(
+        "Create report.txt",
+        "model",
+        run_id="paired-run",
+        condition_name="baseline",
+        task_id="task-1",
+    )
+
+    assert result["success"] is False
+    assert result["budget_metrics"]["usage_complete"] is False
+
+
+def test_hardened_finalize_failure_preserves_verified_candidate(tmp_path):
+    runner, _, _, _ = _runner(tmp_path, [], [])
+
+    class CandidateBackend(FakeBackend):
+        def inspect_artifacts(self, timeout_seconds=1200.0):
+            self.calls.append("inspect_artifacts")
+            self._best = {
+                "success": False,
+                "text": "candidate",
+                "deliverable_text": "candidate",
+                "files": [{"filename": "report.txt", "content": b"candidate"}],
+            }
+            return _inspection(True)
+
+        def finalize(self, deliverables, summary, timeout_seconds=1200.0):
+            self.calls.append(("finalize", list(deliverables)))
+            return {
+                "ok": False,
+                "error_type": "selected_deliverable_verification_failed",
+            }
+
+    backend = CandidateBackend([])
+    runner._backend = backend
+    runner._run_started = __import__("time").monotonic()
+    runner._first_model_dispatch = runner._run_started
+
+    _, result = runner._execute(
+        "open('report.txt','w').write('report')", [], {}
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "selected_deliverable_verification_failed"
+    assert result["files"] == [
+        {"filename": "report.txt", "content": b"candidate"}
+    ]
+
+
+def test_hardened_start_and_close_failure_returns_structured_metrics(tmp_path):
+    runner, _, _, _ = _runner(tmp_path, [], [])
+
+    class StartCloseFailureBackend(FakeBackend):
+        def start(self, timeout_seconds=1200.0):
+            raise RuntimeError("startup exploded")
+
+        def close(self):
+            raise RuntimeError("cleanup exploded")
+
+    runner.backend_factory = lambda **kwargs: StartCloseFailureBackend([])
+
+    result = runner.run(
+        "Create report.txt",
+        "model",
+        run_id="paired-run",
+        condition_name="baseline",
+        task_id="task-1",
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "compute_cleanup_failed"
+    assert result["prior_error"] == "runner_internal_error"
+    assert result["budget_metrics"]["usage_complete"] is False

--- a/batch-runner/tests/test_llm_client.py
+++ b/batch-runner/tests/test_llm_client.py
@@ -11,7 +11,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from types import SimpleNamespace
 
-from core.llm_client import create_client, complete
+from core.llm_client import create_client, create_provider_client, complete
 from core.config import (
     DEFAULT_ENDPOINT,
     DEFAULT_MODEL,
@@ -111,6 +111,27 @@ class TestCreateClient:
             assert call_kwargs["azure_endpoint"] == "https://grok-resource.azure.com/"
             assert "azure_ad_token_provider" in call_kwargs
             assert "api_key" not in call_kwargs
+
+    @patch("core.llm_client.AzureOpenAI")
+    def test_explicit_zero_transport_retries_reach_azure_sdk(self, mock_cls):
+        mock_identity = MagicMock()
+        mock_identity.DefaultAzureCredential.return_value = MagicMock()
+        mock_identity.get_bearer_token_provider.return_value = MagicMock()
+        with patch.dict(
+            "sys.modules", {"azure.identity": mock_identity, "azure": MagicMock()}
+        ):
+            create_provider_client(
+                "azure", endpoint="https://x.com/", max_retries=0
+            )
+
+        assert mock_cls.call_args.kwargs["max_retries"] == 0
+
+    def test_explicit_zero_transport_retries_reach_openai_sdk(self):
+        openai_module = MagicMock()
+        with patch.dict("sys.modules", {"openai": openai_module}):
+            create_provider_client("openai", api_key="test", max_retries=0)
+
+        assert openai_module.OpenAI.call_args.kwargs["max_retries"] == 0
 
     def test_no_credentials_raises(self):
         """DefaultAzureCredential 실패 시 항상 ValueError (OIDC only)"""

--- a/batch-runner/tests/test_output_qa.py
+++ b/batch-runner/tests/test_output_qa.py
@@ -8,7 +8,11 @@ from pathlib import Path
 
 import pytest
 
-from core.artifact_renderer import render_artifact
+from core.artifact_renderer import (
+    RenderResult,
+    _convert_office_to_pdf,
+    render_artifact,
+)
 from core.deliverable_contract import infer_deliverable_contract
 from core.output_qa import run_output_qa
 
@@ -44,6 +48,41 @@ def test_render_skips_non_renderable(tmp_path):
     assert any("not rendered" in w for w in rr.warnings)
 
 
+def test_office_conversion_retries_profile_restart_code_once(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "report.xlsx"
+    source.write_bytes(b"fixture")
+    output = tmp_path / "verify-work" / "render"
+    output.mkdir(parents=True)
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        if len(calls) == 1:
+            return __import__("subprocess").CompletedProcess(
+                command, 81, stdout="", stderr=""
+            )
+        (output / "report.pdf").write_bytes(b"pdf")
+        return __import__("subprocess").CompletedProcess(
+            command, 0, stdout="", stderr=""
+        )
+
+    monkeypatch.setattr(
+        "core.artifact_renderer._find_soffice",
+        lambda: "/usr/lib/libreoffice/program/soffice.bin",
+    )
+    monkeypatch.setattr("core.artifact_renderer.subprocess.run", run)
+    result = RenderResult(rel_path="report.xlsx", kind="spreadsheet")
+
+    pdf = _convert_office_to_pdf(source, output, result)
+
+    assert pdf == output / "report.pdf"
+    assert result.converted_via == "libreoffice"
+    assert len(calls) == 2
+    assert any(arg.startswith("-env:UserInstallation=file://") for arg in calls[0])
+
+
 def test_sparse_text_page_not_flagged_blank(tmp_path):
     pytest.importorskip("fitz")
     pdf = tmp_path / "sparse.pdf"
@@ -57,7 +96,10 @@ def test_sparse_text_page_not_flagged_blank(tmp_path):
 def test_truly_blank_page_blocks_primary(tmp_path):
     fitz = pytest.importorskip("fitz")
     pdf = tmp_path / "blank.pdf"
-    doc = fitz.open(); doc.new_page(); doc.save(str(pdf)); doc.close()
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(str(pdf))
+    doc.close()
     c = infer_deliverable_contract("Produce a PDF report", [])
     rep = run_output_qa([pdf], contract=c, config={"enabled": True, "render": True},
                         out_dir=tmp_path / "r", task_text="Produce a PDF report")
@@ -65,10 +107,96 @@ def test_truly_blank_page_blocks_primary(tmp_path):
     assert any("blank" in e for e in rep.blocking_errors)
 
 
+def test_primary_image_must_render_successfully(tmp_path):
+    image = tmp_path / "broken.png"
+    image.write_bytes(b"not-a-png")
+    contract = infer_deliverable_contract("Create a PNG image", [])
+
+    report = run_output_qa(
+        [image],
+        contract=contract,
+        config={"enabled": True, "render": True},
+        out_dir=tmp_path / "render",
+        task_text="Create a PNG image",
+    )
+
+    assert report.ok is False
+    assert any("render error" in error for error in report.blocking_errors)
+    assert any("no rendered image" in error for error in report.blocking_errors)
+
+
+@pytest.mark.parametrize(
+    ("mode", "color"),
+    [("RGB", (255, 255, 255)), ("RGBA", (0, 0, 0, 0))],
+)
+def test_white_or_transparent_primary_image_is_blocked(
+    tmp_path, mode, color
+):
+    image_module = pytest.importorskip("PIL.Image")
+    image = tmp_path / "blank.png"
+    image_module.new(mode, (64, 64), color).save(image)
+    contract = infer_deliverable_contract("Create a PNG image", [])
+
+    report = run_output_qa(
+        [image],
+        contract=contract,
+        config={"enabled": True, "render": True},
+        out_dir=tmp_path / "render",
+        task_text="Create a PNG image",
+    )
+
+    assert report.ok is False
+    assert report.render_reports[0]["page_white_fractions"] == [1.0]
+    assert report.render_reports[0]["blank_pages"] == [1]
+    assert any("appears blank" in error for error in report.blocking_errors)
+
+
+@pytest.mark.parametrize("kind", ["xlsx", "docx", "pptx"])
+def test_primary_office_artifact_renders_at_least_one_page(tmp_path, kind):
+    from core.artifact_renderer import libreoffice_available
+
+    if not libreoffice_available():
+        pytest.skip("LibreOffice is unavailable")
+    path = tmp_path / f"report.{kind}"
+    if kind == "xlsx":
+        openpyxl = pytest.importorskip("openpyxl")
+        workbook = openpyxl.Workbook()
+        workbook.active["A1"] = "Professional report"
+        workbook.save(path)
+    elif kind == "docx":
+        docx = pytest.importorskip("docx")
+        document = docx.Document()
+        document.add_heading("Professional report", level=1)
+        document.save(path)
+    else:
+        pptx = pytest.importorskip("pptx")
+        presentation = pptx.Presentation()
+        slide = presentation.slides.add_slide(presentation.slide_layouts[0])
+        slide.shapes.title.text = "Professional report"
+        presentation.save(path)
+    contract = infer_deliverable_contract(
+        f"Create a {kind.upper()} professional report", []
+    )
+
+    report = run_output_qa(
+        [path],
+        contract=contract,
+        config={"enabled": True, "render": True},
+        out_dir=tmp_path / "render",
+        task_text=f"Create a {kind.upper()} professional report",
+    )
+
+    assert report.ok is True, report.blocking_errors
+    assert report.render_reports[0]["rendered_images"]
+
+
 def test_output_qa_disabled_is_noop(tmp_path):
     fitz = pytest.importorskip("fitz")
     pdf = tmp_path / "blank.pdf"
-    doc = fitz.open(); doc.new_page(); doc.save(str(pdf)); doc.close()
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(str(pdf))
+    doc.close()
     rep = run_output_qa([pdf], config={"enabled": False}, out_dir=tmp_path / "r")
     assert rep.enabled is False
     assert rep.ok is True

--- a/batch-runner/tests/test_relay_duration.py
+++ b/batch-runner/tests/test_relay_duration.py
@@ -1,10 +1,6 @@
 """Tests for relay duration fix: started_at preservation in progress.json."""
 
 import json
-import tempfile
-from pathlib import Path
-
-import pytest
 
 from step2_run_inference import _save_progress
 

--- a/batch-runner/tests/test_relay_duration.py
+++ b/batch-runner/tests/test_relay_duration.py
@@ -9,6 +9,14 @@ import pytest
 from step2_run_inference import _save_progress
 
 
+def _identity(total_tasks):
+    return {
+        "run_id": "relay-test-run",
+        "condition_identity": "condition_a",
+        "ordered_task_ids": [f"t{index}" for index in range(1, total_tasks + 1)],
+    }
+
+
 class TestSaveProgressStartedAt:
     """Verify _save_progress persists started_at in progress.json."""
 
@@ -25,6 +33,7 @@ class TestSaveProgressStartedAt:
             results=[{"task_id": "t1", "status": "success"}],
             started_at=original_time,
             path=progress_path,
+            **_identity(220),
         )
 
         with open(progress_path) as f:
@@ -50,6 +59,7 @@ class TestSaveProgressStartedAt:
             ],
             started_at=original_time,
             path=progress_path,
+            **_identity(220),
         )
 
         # Simulate relay resume: new started_at would be set, then overridden
@@ -84,6 +94,7 @@ class TestSaveProgressStartedAt:
             results=results,
             started_at="2026-01-01T00:00:00",
             path=progress_path,
+            **_identity(10),
         )
 
         with open(progress_path) as f:
@@ -106,6 +117,7 @@ class TestSaveProgressStartedAt:
             results=[],
             started_at="2026-01-01T00:00:00",
             path=progress_path,
+            **_identity(1),
         )
 
         assert progress_path.exists()

--- a/batch-runner/tests/test_silent_corruption_fixes.py
+++ b/batch-runner/tests/test_silent_corruption_fixes.py
@@ -701,6 +701,75 @@ def test_update_progress_result_accumulates_metrics_across_resume_rounds():
     assert metrics["job_run_count"] == 2
 
 
+def test_update_progress_result_accumulates_agentic_metrics_without_double_cost():
+    from step2_run_inference import _update_progress_result
+
+    progress = {"results": [{
+        "task_id": "t1",
+        "status": "error",
+        "observability": {"agentic_metrics": {
+            "schema_version": "1.0",
+            "task_wall_time_ms": 100,
+            "model_time_ms": 40,
+            "tool_time_ms": 20,
+            "model_api_calls": 1,
+            "model_iterations": 1,
+            "tool_calls": 2,
+            "tool_errors": 1,
+            "tool_calls_by_name": {"run_python": 1, "inspect_artifacts": 1},
+            "finalize_attempts": 0,
+            "finalize_required_corrections": 0,
+            "capability_misses": 0,
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cached_tokens": 5,
+            "conservative_cost_usd": 0.4,
+            "usage_complete": True,
+            "terminal_error_category": "artifact_verification_failed",
+        }},
+    }]}
+    new_result = {
+        "task_id": "t1",
+        "status": "success",
+        "observability": {"agentic_metrics": {
+            "schema_version": "1.0",
+            "task_wall_time_ms": 70,
+            "model_time_ms": 30,
+            "tool_time_ms": 15,
+            "model_api_calls": 1,
+            "model_iterations": 1,
+            "tool_calls": 2,
+            "tool_errors": 0,
+            "tool_calls_by_name": {"inspect_artifacts": 1, "finalize": 1},
+            "finalize_attempts": 1,
+            "finalize_required_corrections": 0,
+            "capability_misses": 0,
+            "input_tokens": 80,
+            "output_tokens": 10,
+            "cached_tokens": 4,
+            "conservative_cost_usd": 0.55,
+            "usage_complete": False,
+            "terminal_error_category": None,
+        }},
+    }
+
+    merged = _update_progress_result(progress, new_result)
+    metrics = merged["results"][0]["observability"]["agentic_metrics"]
+
+    assert metrics["task_wall_time_ms"] == 170
+    assert metrics["model_api_calls"] == 2
+    assert metrics["tool_calls"] == 4
+    assert metrics["tool_calls_by_name"] == {
+        "run_python": 1,
+        "inspect_artifacts": 2,
+        "finalize": 1,
+    }
+    assert metrics["conservative_cost_usd"] == 0.55
+    assert metrics["usage_complete"] is False
+    assert metrics["recovered_after_tool_error"] is True
+    assert metrics["terminal_error_category"] is None
+
+
 def test_bounded_execution_metrics_rejects_invalid_time_to_valid_and_counts():
     from step2_run_inference import _bounded_execution_metrics
 
@@ -762,9 +831,14 @@ def test_resume_timeout_relay_preserves_cumulative_task_metrics(
     prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
 
     progress = {
+        "schema_version": "step2-progress-v2",
         "experiment_id": "exp_test",
         "condition": "test_condition",
+        "condition_identity": "condition_a",
+        "run_id": "exp_test:local:1",
         "execution_mode": "sandbox",
+        "ordered_task_ids": ["t1"],
+        "total_tasks": 1,
         "started_at": "2026-07-15T00:00:00+00:00",
         "resume_round": 0,
         "results": [{

--- a/batch-runner/tests/test_silent_corruption_fixes.py
+++ b/batch-runner/tests/test_silent_corruption_fixes.py
@@ -25,7 +25,7 @@ Fix 3: qa_failed dead invariant in step2_run_inference.py. When Self-QA
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/batch-runner/tests/test_step6_v2_fields.py
+++ b/batch-runner/tests/test_step6_v2_fields.py
@@ -533,6 +533,118 @@ def test_generate_report_adds_execution_metrics_only_when_measured(monkeypatch, 
     assert rd["task_results"][0]["observability"]["execution_metrics"]["task_wall_time_ms"] == 100
 
 
+def test_generate_report_adds_agentic_metrics_only_when_measured(monkeypatch, tmp_path):
+    payload = _make_result_payload()
+    payload["results"][0]["observability"] = {
+        "agentic_metrics": {
+            "schema_version": "1.0",
+            "task_wall_time_ms": 100,
+            "model_api_calls": 3,
+            "model_iterations": 3,
+            "tool_calls": 4,
+            "tool_errors": 1,
+            "tool_calls_by_name": {
+                "inspect_workspace": 1,
+                "run_python": 1,
+                "inspect_artifacts": 1,
+                "finalize": 1,
+            },
+            "tool_time_ms": 20,
+            "finalize_attempts": 1,
+            "finalize_required_corrections": 0,
+            "capability_misses": 0,
+            "recovered_after_tool_error": True,
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cached_tokens": 10,
+            "usage_complete": True,
+            "conservative_cost_usd": 0.25,
+            "terminal_error_category": None,
+        }
+    }
+    payload["results"][1]["status"] = "error"
+    payload["results"][1]["observability"] = {
+        "agentic_metrics": {
+            "schema_version": "1.0",
+            "task_wall_time_ms": 300,
+            "model_api_calls": 2,
+            "model_iterations": 2,
+            "tool_calls": 2,
+            "tool_errors": 1,
+            "tool_calls_by_name": {
+                "inspect_environment": 1,
+                "run_ffmpeg": 1,
+            },
+            "tool_time_ms": 80,
+            "finalize_attempts": 0,
+            "finalize_required_corrections": 1,
+            "capability_misses": 1,
+            "recovered_after_tool_error": False,
+            "input_tokens": 200,
+            "output_tokens": 40,
+            "cached_tokens": 20,
+            "usage_complete": False,
+            "conservative_cost_usd": 0.5,
+            "terminal_error_category": "capability_missing",
+        }
+    }
+
+    rd = _run_step6(
+        monkeypatch,
+        tmp_path,
+        manifest_data=None,
+        result_payload=payload,
+    )
+
+    metrics = rd["agentic_metrics"]
+    assert metrics["measured_tasks"] == 2
+    assert metrics["coverage_pct"] == 100.0
+    assert metrics["total_model_api_calls"] == 5
+    assert metrics["total_model_iterations"] == 5
+    assert metrics["total_tool_calls"] == 6
+    assert metrics["total_tool_errors"] == 2
+    assert metrics["tool_error_rate_pct"] == 33.33
+    assert metrics["tasks_with_tool_errors"] == 2
+    assert metrics["recovered_tasks"] == 1
+    assert metrics["recovery_rate_pct"] == 50.0
+    assert metrics["total_finalize_attempts"] == 1
+    assert metrics["total_finalize_required_corrections"] == 1
+    assert metrics["total_capability_misses"] == 1
+    assert metrics["p50_tool_time_ms"] == 50
+    assert metrics["p95_tool_time_ms"] == 77
+    assert metrics["total_input_tokens"] == 300
+    assert metrics["total_output_tokens"] == 60
+    assert metrics["total_cached_tokens"] == 30
+    assert metrics["usage_complete_tasks"] == 1
+    assert metrics["usage_coverage_pct"] == 50.0
+    assert metrics["conservative_cost_usd"] == 0.75
+    assert metrics["tool_calls_by_name"] == {
+        "inspect_workspace": 1,
+        "inspect_environment": 1,
+        "run_python": 1,
+        "run_ffmpeg": 1,
+        "inspect_artifacts": 1,
+        "finalize": 1,
+    }
+    assert metrics["terminal_error_categories"] == {"capability_missing": 1}
+    assert rd["task_results"][0]["observability"]["agentic_metrics"][
+        "model_api_calls"
+    ] == 3
+
+
+def test_compute_agentic_metrics_omits_unmeasured_and_rejects_nonfinite():
+    payload = _make_result_payload()
+    assert step6_report._compute_agentic_metrics(payload) is None
+
+    payload["results"][0]["observability"] = {
+        "agentic_metrics": {
+            "task_wall_time_ms": float("nan"),
+            "conservative_cost_usd": float("inf"),
+        }
+    }
+    assert step6_report._compute_agentic_metrics(payload) is None
+
+
 def test_compute_execution_metrics_ignores_giant_json_integer():
     payload = _make_result_payload()
     payload["results"][0]["observability"] = {

--- a/scripts/__tests__/aggregate-experiments.test.mjs
+++ b/scripts/__tests__/aggregate-experiments.test.mjs
@@ -1,7 +1,55 @@
-import assert from 'node:assert/strict'
-import test from 'node:test'
+import assert from 'node:assert/strict';
+import test from 'node:test';
 
-import { normalizeExecutionMetrics } from '../aggregate-experiments.mjs'
+import {
+  normalizeAgenticConfig,
+  normalizeExecutionMetrics,
+} from '../aggregate-experiments.mjs';
+
+
+test('legacy execution config omits optional agentic config', () => {
+  assert.equal(normalizeAgenticConfig(undefined), null);
+});
+
+
+test('agentic config uses a public allowlist', () => {
+  const normalized = normalizeAgenticConfig({
+    compute_transport: 'remote',
+    image: `image@sha256:${'a'.repeat(64)}`,
+    verifier_image: `verifier@sha256:${'b'.repeat(64)}`,
+    memory_gb: 8,
+    cpus: 2,
+    limits: {
+      max_model_iterations: 6,
+      max_tool_calls: 8,
+      secret_limit: 99,
+    },
+    pricing_table: {
+      path: '/private/pricing.json',
+      sha256: 'c'.repeat(64),
+    },
+    authorization: {
+      signed_envelope_path: '/private/approval.json',
+      owner_public_key_path: '/private/owner.pem',
+    },
+    budget_ledger_path: '/private/budget.sqlite3',
+    seccomp_profile: '/private/seccomp.json',
+  });
+
+  assert.deepEqual(normalized, {
+    compute_transport: 'remote',
+    image: `image@sha256:${'a'.repeat(64)}`,
+    verifier_image: `verifier@sha256:${'b'.repeat(64)}`,
+    memory_gb: 8,
+    cpus: 2,
+    limits: {
+      max_model_iterations: 6,
+      max_tool_calls: 8,
+    },
+    pricing_table: { sha256: 'c'.repeat(64) },
+  });
+  assert.equal(JSON.stringify(normalized).includes('/private/'), false);
+});
 
 
 test('execution metrics require literal boolean true', () => {

--- a/scripts/__tests__/official-filter.test.mjs
+++ b/scripts/__tests__/official-filter.test.mjs
@@ -45,11 +45,24 @@ test('existing non-diagnostic subsets remain visible', () => {
   }), false)
 })
 
+test('all preregistered agentic experiment IDs are hidden by default', () => {
+  for (const id of ['exp028', 'exp029', 'exp030']) {
+    assert.equal(HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS.has(id), true)
+    assert.equal(isHiddenDiagnosticExperimentId(id), true)
+    assert.equal(isHiddenOfficialExperiment({
+      short_id: id,
+      experiment_name: id,
+      total_tasks: id === 'exp028' ? 5 : 20,
+    }), true)
+  }
+})
+
 test('debug mode restores subsets and smoke reports', () => {
   const experiments = [
     { short_id: 'exp026', experiment_name: 'Official', total_tasks: 220, report_scope: 'self_assessed_pre_grading' },
     { short_id: 'exp027', experiment_name: 'Bridge 50', total_tasks: 50, report_scope: 'self_assessed_pre_grading' },
     { short_id: 'exp999', experiment_name: 'Smoke', total_tasks: 3, report_scope: 'self_assessed_pre_grading' },
+    { short_id: 'exp028', experiment_name: 'Agentic canary', total_tasks: 5, report_scope: 'self_assessed_pre_grading' },
   ]
 
   assert.deepEqual(
@@ -58,7 +71,7 @@ test('debug mode restores subsets and smoke reports', () => {
   )
   assert.deepEqual(
     filterDashboardExperiments(experiments, { debug: true }).map((experiment) => experiment.short_id),
-    ['exp026', 'exp027', 'exp999'],
+    ['exp026', 'exp027', 'exp999', 'exp028'],
   )
 })
 

--- a/scripts/aggregate-experiments.mjs
+++ b/scripts/aggregate-experiments.mjs
@@ -23,6 +23,34 @@ export function normalizeExecutionMetrics(value) {
     : null;
 }
 
+export function normalizeAgenticConfig(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const limits = value.limits && typeof value.limits === 'object' && !Array.isArray(value.limits)
+    ? Object.fromEntries(Object.entries(value.limits).filter(([key, item]) => (
+        [
+          'max_api_attempts', 'max_model_iterations', 'max_output_tokens',
+          'max_input_tokens', 'max_cumulative_output_tokens', 'max_task_seconds',
+          'max_cost_usd', 'max_tool_calls', 'max_run_python', 'max_run_ffmpeg',
+          'max_inspect_artifacts', 'max_finalize', 'max_identical_errors',
+        ].includes(key) && (typeof item === 'number' || typeof item === 'string')
+      )))
+    : null;
+  const pricingTable = value.pricing_table && typeof value.pricing_table === 'object'
+    && !Array.isArray(value.pricing_table) && typeof value.pricing_table.sha256 === 'string'
+    ? { sha256: value.pricing_table.sha256 }
+    : null;
+  const normalized = {
+    ...(value.compute_transport === 'remote' ? { compute_transport: 'remote' } : {}),
+    ...(typeof value.image === 'string' ? { image: value.image } : {}),
+    ...(typeof value.verifier_image === 'string' ? { verifier_image: value.verifier_image } : {}),
+    ...(typeof value.memory_gb === 'number' ? { memory_gb: value.memory_gb } : {}),
+    ...(typeof value.cpus === 'number' ? { cpus: value.cpus } : {}),
+    ...(limits && Object.keys(limits).length ? { limits } : {}),
+    ...(pricingTable ? { pricing_table: pricingTable } : {}),
+  };
+  return Object.keys(normalized).length ? normalized : null;
+}
+
 async function main() {
   console.log('📦 Aggregating experiment prompt architectures...');
   const codegen = parseYaml(await readFile(join(PROMPTS_DIR, 'subprocess_occupation_codegen.yaml'), 'utf-8'));
@@ -40,6 +68,7 @@ async function main() {
     const qa = condition.qa || {};
     const execution = expData.execution || {};
     const metrics = normalizeExecutionMetrics(execution.metrics);
+    const agentic = normalizeAgenticConfig(execution.agentic);
 
     experiments.push({
       exp_id: expData.experiment?.id || file.replace('.yaml', ''),
@@ -75,6 +104,7 @@ async function main() {
           max_retries: execution.max_retries || 5,
           install_libreoffice: execution.install_libreoffice || false,
           ...(metrics ? { metrics } : {}),
+          ...(agentic ? { agentic } : {}),
         },
       },
     });

--- a/src/lib/officialExperimentScope.js
+++ b/src/lib/officialExperimentScope.js
@@ -2,14 +2,21 @@
 export const OFFICIAL_TASK_COUNT = 220
 
 /** Curated diagnostic reports excluded from the default cross-run dashboard. */
-export const HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS = new Set(['exp027'])
+export const HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS = new Set([
+  'exp027',
+  'exp028', // Agentic Sandbox canary
+  'exp029', // Hardened current-sandbox baseline
+  'exp030', // Agentic Sandbox treatment
+])
 
 /** Match a short id or a derived full experiment/grade id. */
 export function isHiddenDiagnosticExperimentId(value) {
   if (!value) return false
-  return Array.from(HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS).some((shortId) => (
-    value === shortId || value.startsWith(`${shortId}_`)
-  ))
+  return (
+    Array.from(HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS).some((shortId) => (
+      value === shortId || value.startsWith(`${shortId}_`)
+    ))
+  )
 }
 
 /** Smoke/test identifier shared by report and grade display filters. */

--- a/src/pages/ExperimentDetail.tsx
+++ b/src/pages/ExperimentDetail.tsx
@@ -203,6 +203,7 @@ function ExperimentDetail() {
               <span className="text-[10px] bg-dash-card-hover px-2 py-0.5 rounded text-dash-text-secondary" title={meta?.execution_mode}>
                 {meta?.execution_mode === 'code_interpreter' ? '☁️ CI' :
                  meta?.execution_mode === 'subprocess' ? '🖥️ Sub' :
+                 meta?.execution_mode === 'agentic_sandbox' ? 'Agent' :
                  meta?.execution_mode === 'json_renderer' ? '📄 JSON' :
                  meta?.execution_mode}
               </span>
@@ -272,6 +273,7 @@ function ExperimentDetail() {
               label: 'Exec Mode',
               value: meta?.execution_mode === 'code_interpreter' ? '☁️ CI'
                 : meta?.execution_mode === 'subprocess' ? '🖥️ Sub'
+                : meta?.execution_mode === 'agentic_sandbox' ? 'Agent'
                 : meta?.execution_mode === 'json_renderer' ? '📄 JSON'
                 : meta?.execution_mode ?? '—',
               color: '#6b7280',
@@ -428,6 +430,56 @@ function ExperimentDetail() {
                   <div key={metric.label} className="flex justify-between md:block gap-2">
                     <span className="text-dash-text-muted">{metric.label}</span>
                     <span className="text-dash-text font-mono md:block md:mt-0.5">{metric.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </motion.div>
+        )}
+
+        {report.agentic_metrics && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.1 }}
+            className="bg-dash-card border border-dash-border rounded-xl overflow-hidden mb-6"
+          >
+            <div className="px-4 py-3 border-b border-dash-border flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold text-dash-heading flex items-center gap-2">
+                <Code2 className="h-4 w-4 text-emerald-500" />
+                Agentic Tool Loop
+              </h3>
+              <span className="text-[10px] text-dash-text-muted font-mono">
+                {report.agentic_metrics.measured_tasks}/{report.agentic_metrics.total_tasks} measured
+              </span>
+            </div>
+            <div className="p-4">
+              <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-x-5 gap-y-4 text-xs">
+                {[
+                  { label: 'API Calls', value: report.agentic_metrics.total_model_api_calls },
+                  { label: 'Model Iterations', value: report.agentic_metrics.total_model_iterations },
+                  { label: 'Tool Calls', value: report.agentic_metrics.total_tool_calls },
+                  { label: 'Tool Error Rate', value: `${report.agentic_metrics.tool_error_rate_pct.toFixed(1)}%` },
+                  { label: 'Recovery Rate', value: `${report.agentic_metrics.recovery_rate_pct.toFixed(1)}%` },
+                  { label: 'Finalize Attempts', value: report.agentic_metrics.total_finalize_attempts },
+                  { label: 'P50 Tool Time', value: formatDuration(report.agentic_metrics.p50_tool_time_ms) },
+                  { label: 'P95 Tool Time', value: formatDuration(report.agentic_metrics.p95_tool_time_ms) },
+                  { label: 'Usage Coverage', value: `${report.agentic_metrics.usage_coverage_pct.toFixed(1)}%` },
+                  { label: 'Cached Tokens', value: report.agentic_metrics.total_cached_tokens.toLocaleString() },
+                  { label: 'Capability Misses', value: report.agentic_metrics.total_capability_misses },
+                  { label: 'Conservative Cost', value: `$${report.agentic_metrics.conservative_cost_usd.toFixed(4)}` },
+                ].map((metric) => (
+                  <div key={metric.label}>
+                    <div className="text-[10px] text-dash-text-muted uppercase mb-0.5">{metric.label}</div>
+                    <div className="text-dash-text font-mono font-semibold">{metric.value}</div>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-4 pt-4 border-t border-dash-border-subtle grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-x-5 gap-y-3 text-xs">
+                {Object.entries(report.agentic_metrics.tool_calls_by_name).map(([name, count]) => (
+                  <div key={name} className="flex justify-between md:block gap-2">
+                    <span className="text-dash-text-muted">{name.split('_').join(' ')}</span>
+                    <span className="text-dash-text font-mono md:block md:mt-0.5">{count}</span>
                   </div>
                 ))}
               </div>
@@ -967,6 +1019,7 @@ function ExperimentDetail() {
 function TaskDetailModal({ task, experimentId, onClose }: { task: TaskResult; experimentId?: string; onClose: () => void }) {
   const [showPrompt, setShowPrompt] = useState(false)
   const executionMetrics = task.observability?.execution_metrics
+  const agenticMetrics = task.observability?.agentic_metrics
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -1040,6 +1093,35 @@ function TaskDetailModal({ task, experimentId, onClose }: { task: TaskResult; ex
                   <div key={metric.label} className="flex justify-between gap-2 border-b border-dash-border-subtle py-1 last:border-0">
                     <span className="text-dash-text-muted">{metric.label}</span>
                     <span className="text-dash-text font-mono">{metric.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {agenticMetrics && (
+            <div className="border border-dash-border rounded-lg p-3">
+              <div className="text-[10px] text-dash-text-muted uppercase mb-2 flex items-center gap-1.5">
+                <Code2 className="h-3 w-3" /> Agentic Tool Loop
+              </div>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                {[
+                  { label: 'API Calls', value: agenticMetrics.model_api_calls },
+                  { label: 'Iterations', value: agenticMetrics.model_iterations },
+                  { label: 'Tool Calls', value: agenticMetrics.tool_calls },
+                  { label: 'Tool Errors', value: agenticMetrics.tool_errors },
+                  { label: 'Finalize Attempts', value: agenticMetrics.finalize_attempts },
+                  { label: 'Finalize Corrections', value: agenticMetrics.finalize_required_corrections },
+                  { label: 'Input Tokens', value: agenticMetrics.input_tokens.toLocaleString() },
+                  { label: 'Output Tokens', value: agenticMetrics.output_tokens.toLocaleString() },
+                  { label: 'Cached Tokens', value: agenticMetrics.cached_tokens.toLocaleString() },
+                  { label: 'Conservative Cost', value: `$${agenticMetrics.conservative_cost_usd.toFixed(4)}` },
+                  { label: 'Usage Complete', value: agenticMetrics.usage_complete ? 'Yes' : 'No' },
+                  { label: 'Terminal Category', value: agenticMetrics.terminal_error_category || 'none' },
+                ].map((metric) => (
+                  <div key={metric.label} className="flex justify-between gap-2 border-b border-dash-border-subtle py-1 last:border-0">
+                    <span className="text-dash-text-muted">{metric.label}</span>
+                    <span className="text-dash-text font-mono text-right break-all">{metric.value}</span>
                   </div>
                 ))}
               </div>

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -30,8 +30,114 @@ export interface TaskResult {
   has_deliverable_files?: boolean | null
   observability?: {
     execution_metrics?: TaskExecutionMetrics
+    agentic_metrics?: TaskAgenticMetrics
+    budget_metrics?: TaskBudgetMetrics
+    substrate?: TaskSubstrateManifest
     [key: string]: unknown
   }
+}
+
+export interface TaskSubstrateManifest {
+  schema_version: string
+  sha256: string
+  task_image: string
+  task_image_id: string
+  verifier_image: string
+  verifier_image_id: string
+  component_sha256: Record<string, string>
+  sbom_sha256: string
+  uid: number
+  gid: number
+  network: string
+  ipc: string
+  pid_namespace: string
+  read_only_rootfs: boolean
+  cap_drop: string[]
+  no_new_privileges: boolean
+  memory_bytes: number
+  memory_swap_bytes: number
+  cpus: number
+  pids: number
+  nofile: number
+  apparmor_profile: string
+  work_tmpfs: {
+    size_bytes: number
+    nr_inodes: number
+    nosuid: boolean
+    nodev: boolean
+    noexec: boolean
+  }
+}
+
+export interface TaskBudgetMetrics {
+  schema_version: string
+  model_api_calls: number
+  input_tokens: number
+  output_tokens: number
+  cached_tokens: number
+  conservative_cost_usd: number
+  usage_complete: boolean
+  time_to_valid_artifact_ms?: number | null
+}
+
+export interface TaskAgenticMetrics {
+  schema_version: string
+  ledger_cumulative?: boolean
+  model_api_calls: number
+  model_iterations: number
+  tool_calls: number
+  tool_errors: number
+  tool_calls_by_name: Partial<Record<AgenticToolName, number>>
+  model_time_ms: number
+  tool_time_ms: number
+  task_wall_time_ms: number
+  time_to_valid_artifact_ms?: number | null
+  finalize_attempts: number
+  finalize_required_corrections: number
+  capability_misses: number
+  recovered_after_tool_error: boolean
+  input_tokens: number
+  output_tokens: number
+  cached_tokens: number
+  conservative_cost_usd: number
+  usage_complete: boolean
+  terminal_error_category: string | null
+}
+
+export type AgenticToolName =
+  | 'inspect_workspace'
+  | 'inspect_environment'
+  | 'run_python'
+  | 'run_ffmpeg'
+  | 'inspect_artifacts'
+  | 'finalize'
+
+export interface AgenticMetricsSummary {
+  schema_version: string
+  measured_tasks: number
+  total_tasks: number
+  coverage_pct: number
+  total_model_api_calls: number
+  total_model_iterations: number
+  total_tool_calls: number
+  total_tool_errors: number
+  tool_error_rate_pct: number
+  tasks_with_tool_errors: number
+  recovered_tasks: number
+  recovery_rate_pct: number
+  total_finalize_attempts: number
+  total_finalize_required_corrections: number
+  total_capability_misses: number
+  p50_tool_time_ms: number | null
+  p95_tool_time_ms: number | null
+  total_input_tokens: number
+  total_output_tokens: number
+  total_cached_tokens: number
+  usage_complete_tasks: number
+  usage_coverage_pct: number
+  conservative_cost_usd: number
+  tool_calls_by_name: Record<AgenticToolName, number>
+  terminal_error_categories: Record<string, number>
 }
 
 export interface TaskExecutionMetrics {
@@ -179,6 +285,7 @@ export interface ReportData {
   recovery_stats: RecoveryStats
   file_generation?: FileGeneration
   execution_metrics?: ExecutionMetricsSummary
+  agentic_metrics?: AgenticMetricsSummary
   /** task_id → Self-QA score (0–10). Enriched in scripts/aggregate-reports.mjs for Phase 1 calibration. */
   task_qa?: Record<string, number>
 }

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -54,6 +54,7 @@ export interface TaskSubstrateManifest {
   read_only_rootfs: boolean
   cap_drop: string[]
   no_new_privileges: boolean
+  selected_transfer_bytes: number
   memory_bytes: number
   memory_swap_bytes: number
   cpus: number

--- a/tasks/0717_friday/AGENTIC_SANDBOX_EXPERIMENT_PLAN.md
+++ b/tasks/0717_friday/AGENTIC_SANDBOX_EXPERIMENT_PLAN.md
@@ -1,8 +1,10 @@
 # Agentic Sandbox Experiment Plan
 
 - Date: 2026-07-17
-- Status: `PLAN_APPROVED_PENDING_MERGE`
+- Status: `NON_PAID_IMPLEMENTATION_COMPLETE_PAID_GATE_BLOCKED`
 - Plan base: `main@71902db3904a358e6f832caf8f39e807047f9bdf`
+- Implementation validation base: `main@ff02ef3a73d3de8de7d681a01ac6955be5911a57`
+- Validated implementation commits: `a26cab3`, `d6cebe6`
 - Experiment family: task-solving / sandbox execution
 - Comparison baseline: current `sandbox` execution mode
 - Proposed treatment: new `agentic_sandbox` execution mode
@@ -856,18 +858,27 @@ Promotion candidate:
 |---|---|---|---|---|
 | 2026-07-17 | Plan | `main@6bdcfcf9` | Initial plan drafted; no code or paid run | Revise after review |
 | 2026-07-18 | Plan | `main@71902db3` | Docs validation passed; `first-reviewer` and `extreme-reasoner` found no mandatory blocker | Approved for docs merge and non-paid implementation |
+| 2026-07-18 | Implementation | `a26cab3`, `d6cebe6` rebased on `main@ff02ef3a` | Added the bounded Responses state machine, common hardened baseline, split mTLS/HMAC compute plane, Ed25519 approval and SQLite budget gates, exact input/selection identity chain, isolated verifier, fixed-denominator endpoints, pipeline/report/UI wiring, protected model-free workflows, and fail-closed cleanup/deadline handling | Non-paid implementation complete |
+| 2026-07-18 | Review | local worktree at `d6cebe6` | Repeated independent `first-reviewer` passes closed transport deadline, parser amplification, sequence recovery, provider classification, snapshot cleanup, publication guard, and selection provenance findings; final verdict `APPROVE`, mandatory findings 0 | Proceed to release validation only |
+| 2026-07-18 | Model-free validation | local Python/Node/browser/Docker evidence | Python `1485 passed, 6 skipped, 44 deselected`; Node aggregate `54 passed`; Ruff clean on all 54 branch-changed Python files; mypy clean on 18 agentic files; TypeScript/Vite build and two Chromium note suites passed; all nine workflow YAML files parsed | Pass |
+| 2026-07-18 | Image validation | `gdpval-agentic-sandbox:local@sha256:a6d43c2929b0de1823c393d558bed373c3850ee06a15fd75c24f1fa93a14309b` | Runtime audit passed at UID:GID 65532 with 965 SBOM packages; generated and embedded SPDX documents matched; SBOM SHA-256 `d7ca2c2f4eab49d3777744a9a5b1beea69523cb7d6cbbe9638034c4fd2743132` | Pass for local model-free image only |
+| 2026-07-18 | Docker E2E | local nested daemon | WAV lifecycle plus XLSX, DOCX, and PPTX verifier/render/finalize tests passed 4/4 in 157.50 seconds; terminal container and volume cleanup passed | Pass for locally supported substrate |
+| 2026-07-18 | Live gate | none | No model/API call, workflow dispatch, image publication, HF upload, task selection, grading, or paid execution occurred | Stop at paid gate |
 
 ## Cost Ledger
 
 | UTC time | Run | Scope | Raw | Effective | Cumulative | Gate |
 |---|---|---|---:|---:|---:|---|
 | 2026-07-17 | none | Planning only | USD 0 | USD 0 | USD 0 | Pass |
+| 2026-07-18 | none | Non-paid implementation and local validation | USD 0 | USD 0 | USD 0 | Pass |
 
 ## Incident Log
 
 | UTC time | Phase | Category | Evidence | Containment | Follow-up |
 |---|---|---|---|---|---|
 | 2026-07-17 | Plan | None | No execution performed | N/A | Begin non-paid implementation after plan merge |
+| 2026-07-18 | Local containment | Host lacks seccomp TSYNC and the nested Docker daemon rejects custom seccomp profiles | Generated-code and outer-seccomp integration tests skipped explicitly; generated-code path remained fail closed | No live credential or model path was enabled | Require the dedicated production runner preflight before credential release |
+| 2026-07-18 | Legacy root test | Archived v1 `_sweep_template.yaml` is absent | Root `scripts/__tests__` produced 36 passes and the two already documented sweep-template failures | Kept outside the agentic change; authoritative `batch-runner` suite passed | Resolve under the existing legacy grading cleanup task |
 
 ## Retrospective Template
 
@@ -892,6 +903,12 @@ paths, hashes, and carefully selected non-sensitive artifact descriptions.
 
 ## Current Decision
 
-`PLAN_APPROVED_NON_PAID_ONLY` — merge this plan first. Then implement through
-non-paid validation. Stop before any live model/API run until the signed,
-single-use paid authorization gate is explicitly approved and consumed.
+`NON_PAID_IMPLEMENTATION_COMPLETE_PAID_GATE_BLOCKED` — the bounded runtime,
+security controls, pipeline integration, evidence contracts, and local
+model-free validation are complete. Do not publish the agentic image or run a
+live canary until immutable Python and Debian locks, the exact outcome-free
+5/20 selection manifest, production image/SBOM identities, dedicated-host
+containment preflight, official-scope exclusions, price table, owner public
+key, paid-gate record, and a fresh signed single-use approval envelope all
+exist and pass. No live model/API run is authorized by the implementation or
+this validation result.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,84 +4,86 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-18
-- Status: Integrity Field Note published and production-verified
+- Status: Agentic Sandbox non-paid implementation complete; paid gate blocked
 
 ## Task
 
-- Ground `성공으로 기록됐지만 정말 성공이었을까` in exp013/exp025 report
-  snapshots, checked-in experiment settings, and pinned PR #38 code history.
-- Separate the observed completion gap from changes in success/retry semantics
-  and stop before making an unsupported causal claim.
-- Refine the note's line spacing, chapter titles, transitions, and callouts so
-  readers can follow 관측→불변식→판정→비교→결정 without losing the evidence trail.
+- Implement the preregistered bounded `agentic_sandbox` solver and common
+  hardened baseline without making any live model/API request.
+- Close authorization, budget, transport, input identity, container lifecycle,
+  artifact verification, fixed-denominator reporting, workflow, and dashboard
+  trust boundaries under repeated independent review.
+- Rebase onto current `main`, run the complete available model-free validation,
+  and leave publication and paid execution fail closed until their separate
+  immutable-input and signed-approval gates exist.
 
 ## Result
 
-- Added `integrity-incidents.yaml` and a generator that verifies the exact
-  exp013/exp025 `data.filter`, `condition_a`, and `execution` projections,
-  Azure/model/mode/scope contracts, pinned PR #38 history, exact compared-field
-  and missing-identity lists, and a permanently disabled causal-attribution
-  flag before emitting `integrity-note.json`.
-- Added a strict report selector for exact exp013/exp025 identity, date,
-  condition, model, mode, 220-task scope, count/rate consistency, finite QA,
-  duplicates, and malformed source data. Missing or invalid evidence hides all
-  chapters, metrics, SVG, chart, mobile navigation, and source strip.
-- Removed duplicated `95.9/82.3`, success counts, retry count, and chart values
-  from the article and hero. The deployed data path now derives an observed
-  `-13.6%p` and `-30` success difference from report snapshots while labeling
-  both as observations rather than PR #38 effects.
-- Pinned history tests prove that `_AVAILABLE_FILES` changed only in memory
-  before the fix and was persisted afterward, and that determined QA failure
-  began setting `qa_failed`. The article also preserves the undetermined-QA
-  exception and notes that the Anthropic parsing fix is irrelevant to two
-  Azure runs.
-- Added eight direct links to generated evidence, pre-fix runner, core fix,
-  follow-up, PR #38 merge, and both experiment details. Report data is labeled
-  as a deployment-time snapshot rather than an execution-time revision.
-- Restyled only this note with five short chapter headings, semantic labels,
-  wider vertical spacing, 2.05 body leading, and quieter serif callouts. Other
-  Field Notes retain their existing density.
-- Extended Pages freshness to the integrity source and combined the existing
-  runtime browser suite with integrity desktop/mobile/null/duplicate/invalid-
-  list/stale-route verification before artifact upload. Batch remains manual.
-- Squash-merged the reviewed change through PR #105 as `8a64f1bf`. Automatic
-  `Aggregate Tests & Deploy` run
-  [29649567174](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29649567174)
-  completed build, all 51 aggregate and pinned-history contracts, Chromium
-  installation, both Field Note browser suites, artifact upload, and GitHub
-  Pages deployment successfully. No other workflow ran for that commit.
+- Added a bounded Responses state machine with strict ordered tools for
+  workspace/environment inspection, generated Python, mapped ffmpeg operations,
+  artifact inspection, and mandatory deterministic finalization. The paired
+  baseline retains one full-regeneration repair on the same hardened substrate.
+- Split the credentialed control plane from an uncredentialed Docker compute
+  plane. mTLS and canonical HMAC envelopes bind run/condition/task, exact
+  sequence, nonce, payload, command, expiry, and one absolute deadline; bounded
+  streaming parsing, exact-envelope recovery, and post-decode sequence commits
+  fail closed on ambiguity or amplification.
+- Added exact outcome-free selection and input-manifest validation, canonical
+  source/staged hashes, Merkle roots, provider classifications, task-request
+  digests, component/SBOM identities, and a signed approval chain shared by
+  treatment and baseline before deferred client construction.
+- Added crash-safe task/condition/paired budget reservations, conservative
+  unreconciled usage, fixed-denominator completion/quality/time/cost endpoints,
+  optional report/UI fields, and strict omission for legacy experiments.
+- Hardened Docker lifecycle handling for may-exist containers/volumes, startup
+  deadlines, verifier probes, paused snapshots, helper cleanup, selected
+  artifact revalidation, candidate preservation, and signed close/finalize
+  failures. The image removes package managers, shells, toolchains, download
+  clients, privileged bits, and applies the generated-code syscall filter.
+- Protected image-build and dedicated-preflight workflows now require the
+  protected exact `main` event SHA. Existing base-image publication remains
+  available, while agentic publication is separately opt-in and blocked by
+  missing immutable Python/Debian locks.
+- Rebased the implementation commits `a26cab3` and `d6cebe6` onto
+  `main@ff02ef3a`. Repeated `first-reviewer` passes ended with `APPROVE` and zero
+  mandatory code/config findings.
+- No model/API call, paid workflow, task selection, image push, HF upload,
+  grading run, or live experiment was executed.
 
 ## Verification
 
-- Focused integrity source/selector contracts: **9 passed**; full aggregate
-  suite: **51 passed, 0 failed**. Production TypeScript/Vite build and
-  `git diff --check` passed.
-- Pinned git-history checks verified both core/follow-up ancestry and exact
-  before/after code behavior. Exact-list tests reject null, duplicate,
-  replacement, and added compared fields or missing identities.
-- Checked-in Playwright passed for runtime and integrity notes against the same
-  production build. Integrity coverage includes 1280px desktop, 390px
-  dark/reduced-motion, source URLs, both experiment links, null/malformed/
-  duplicate/invalid-list data, and stale route transitions.
-- Browser measurements found 34px/34.85px desktop heading/body rhythm and
-  28px/32.8px mobile rhythm, all five chapter labels, two chart ticks, eight
-  evidence links, no horizontal overflow, and zero post-settle chart mutation.
-- `first-reviewer` approved the final causal boundary, strict parsing,
-  typography, and browser coverage. `extreme-reasoner` approved the Pages gate
-  after full-suite rerun and confirmed model/API, Azure, HF write, batch,
-  grading, and paid-workflow impact is **zero**.
-- On the deployed site, `integrity-note.json` preserved the exact checked-in
-  config projection, PR #38 SHAs, disabled causal-attribution flag, and four
-  missing execution identities. The public report snapshot matched exp013
-  `211/220` (`95.9%`) and exp025 `181/220` (`82.3%`) across metrics, hero, chart,
-  and prose while labeling `-13.6%p` as an observed, non-causal gap.
-- Public desktop verification found both chart labels, five 34px chapter
-  headings, 34.85px body leading, and eight source links. Public 390px
-  dark/reduced-motion verification found 28px headings, 32.8px leading, both
-  experiment links, all five semantic labels, no horizontal overflow, and zero
-  post-settle chart mutations. The exp013 detail route showed the same
-  `211/220`, `95.9%`, and `6.07/10` snapshot.
+- Authoritative `batch-runner` model-free suite: **1,485 passed, 6 skipped,
+  44 deselected**. The focused agentic suite previously passed **228** tests;
+  Ruff passed on all 54 branch-changed Python files and mypy reported zero
+  issues in 18 agentic source files.
+- Node aggregate contracts: **54 passed, 0 failed**. TypeScript and Vite
+  production build passed; both runtime and integrity desktop/mobile Chromium
+  suites passed against the same built distribution. All nine workflow YAML
+  files parsed successfully.
+- Rebuilt local image
+  `sha256:a6d43c2929b0de1823c393d558bed373c3850ee06a15fd75c24f1fa93a14309b`.
+  Its UID:GID 65532 audit passed with 965 SBOM packages; generated and embedded
+  SPDX documents matched at SHA-256
+  `d7ca2c2f4eab49d3777744a9a5b1beea69523cb7d6cbbe9638034c4fd2743132`.
+- Nested-Docker WAV lifecycle and XLSX/DOCX/PPTX render/verify/finalize E2E
+  passed **4/4** in 157.50 seconds. No task container or work volume remained.
+- The local host lacks seccomp TSYNC and its Docker daemon rejects custom
+  seccomp profiles, so generated-code and outer-seccomp integration checks
+  skipped explicitly and remained fail closed. The dedicated production-runner
+  preflight is still mandatory before any credential can be released.
+- Root `scripts/__tests__` produced 36 passes and two pre-existing failures
+  because archived v1 `_sweep_template.yaml` is absent; this regression is
+  already recorded in `tasks/rebuilding_grading_task/DEVIATIONS.md` and is
+  outside the authoritative agentic gate.
 
 ## Remaining Work
 
-- No implementation or deployment work remains for this Integrity Field Note.
+- Generate and commit the immutable outcome-free 5/20 cohort and exact approval
+  scope; add reviewed Python hash locks and the full Debian package lock; pin
+  production image/SBOM, price, workflow, official-scope, and owner-key
+  identities; then pass the real dedicated-host AppArmor/rootless-or-userns/
+  seccomp preflight.
+- Create and explicitly sign a fresh single-use paid gate before any five-task
+  canary. Canary expansion, paired baseline/treatment, and grading each require
+  separate renewed approval. Until then, agentic publication and every live
+  model/API phase remain blocked.


### PR DESCRIPTION
## Summary
- implements the preregistered separate agentic_sandbox solver and common hardened baseline
- adds split mTLS/HMAC compute plane, exact selection/input/request identities, Ed25519 single-use approval, crash-safe budget reservations, isolated verifier/finalization, fixed-denominator endpoints, optional UI/report fields, protected model-free workflows
- keeps base image publication available while agentic publication remains separately opt-in and lock-gated

## Security boundary
- no network/root/shell/package installation for model code; generated Python gets an in-process seccomp filter; ffmpeg is closed-schema argv mapping
- one absolute deadline and exact ordered authenticated envelopes; bounded streaming JSON and candidate/cleanup preservation
- live credentials remain unavailable until exact scope, production substrate, dedicated-host preflight, and signed owner approval pass

## Validation
- authoritative model-free Python: 1,485 passed, 6 skipped, 44 deselected
- Ruff clean on 54 branch-changed Python files; mypy clean on 18 agentic files
- Node aggregate: 54 passed; TypeScript/Vite build; runtime+integrity Chromium suites; 9 workflow YAML parses
- rebuilt image audit UID:GID 65532, 965 SBOM packages, generated/embedded SPDX equality
- WAV/XLSX/DOCX/PPTX Docker E2E: 4/4; terminal cleanup clean
- repeated first-reviewer final verdict APPROVE, mandatory findings 0

## Explicitly deferred
- no model/API call, paid workflow, task selection, image publication, HF upload, grading, or live experiment was run
- exact 5/20 cohort, immutable Python/Debian locks, production image/SBOM, dedicated-host AppArmor/rootless-or-userns/seccomp preflight, official-scope exclusion, owner key, and fresh signed approval remain required
- local host seccomp TSYNC/custom-profile checks skipped fail-closed; root scripts suite retains the documented two archived `_sweep_template.yaml` fixture failures (36 other tests passed)
