### PR TITLE
feat: rebuild README onboarding and publish gates

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       dry_run:
-        description: 'Dry run (skip HF upload and PR creation)'
+        description: 'Dry run (skip Step 5 validation, final HF upload, and PR creation)'
         required: false
         type: boolean
         default: false
@@ -23,6 +23,11 @@ on:
         required: false
         type: number
         default: 0
+      relay_lineage_id:
+        description: 'Stable lineage ID forwarded across relay legs; leave empty on leg 0'
+        required: false
+        type: string
+        default: ''
       wall_timeout:
         description: 'Wall-clock timeout in minutes for Step 2 (0=no limit, 270 recommended for code_interpreter)'
         required: false
@@ -67,7 +72,9 @@ jobs:
           require 'yaml'
 
           name = ENV.fetch('EXPERIMENT_YAML')
-          abort('invalid experiment YAML name') unless name.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]*\z/)
+          valid_name = name.match?(/\A[A-Za-z0-9][A-Za-z0-9_.-]{0,99}\z/) &&
+            !name.include?('..') && !name.end_with?('.', '.lock')
+          abort('invalid experiment YAML name') unless valid_name
           path = File.join('batch-runner', 'experiments', "#{name}.yaml")
           abort("experiment YAML not found: #{path}") unless File.file?(path)
           config = YAML.safe_load(
@@ -106,6 +113,7 @@ jobs:
       EXPERIMENT_YAML_INPUT: ${{ inputs.experiment_yaml }}
       EXPERIMENT_NAME_INPUT: ${{ inputs.experiment_name }}
       RELAY_RUN_INPUT: ${{ inputs.relay_run }}
+      RELAY_LINEAGE_ID_INPUT: ${{ inputs.relay_lineage_id }}
       WALL_TIMEOUT_INPUT: ${{ inputs.wall_timeout }}
       DRY_RUN_INPUT: ${{ inputs.dry_run }}
 
@@ -162,6 +170,24 @@ jobs:
             exit 1
           fi
           echo "✅ Found: $YAML_FILE"
+
+      - name: Validate full experiment config
+        run: |
+          cd batch-runner
+          python3 <<'PY'
+          import os
+
+          from core.experiment_config import ExperimentConfig
+
+          path = f"experiments/{os.environ['EXPERIMENT_YAML_INPUT']}.yaml"
+          config = ExperimentConfig.from_yaml(path)
+          errors = config.validate()
+          if errors:
+              raise SystemExit("Invalid experiment config: " + "; ".join(errors))
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as output:
+              output.write(f"EXPERIMENT_ID={config.experiment_id}\n")
+          print(f"Full experiment config valid: {config.experiment_id}")
+          PY
 
       # ── Extract experiment_name from YAML if not provided ──
       - name: Extract experiment name from YAML
@@ -421,6 +447,7 @@ jobs:
         # cover checkpoint save + HF upload + relay re-trigger handoff.
         timeout-minutes: 350    # = wall_timeout(290) + 60min margin for relay handoff
         env:
+          GDPVAL_RELAY_LINEAGE_ID: ${{ inputs.relay_lineage_id }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # Removed AZURE_OPENAI_API_KEY — openai SDK auto-detects env key and overrides azure_ad_token_provider. OIDC only via DefaultAzureCredential / azure/login@v2.
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
@@ -521,9 +548,14 @@ jobs:
           fi
 
           echo "Triggering relay run #$NEXT_RELAY..."
+          LINEAGE_ID="$RELAY_LINEAGE_ID_INPUT"
+          if [[ -z "$LINEAGE_ID" ]]; then
+            LINEAGE_ID="${EXPERIMENT_ID}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          fi
           gh workflow run batch-run.yml \
             -f experiment_yaml="$EXPERIMENT_YAML_INPUT" \
             -f relay_run="$NEXT_RELAY" \
+            -f relay_lineage_id="$LINEAGE_ID" \
             -f wall_timeout="$WALL_TIMEOUT_INPUT" \
             -f dry_run="$DRY_RUN_INPUT" \
             -f sandbox_image_digest="$SANDBOX_IMAGE_DIGEST"
@@ -544,6 +576,7 @@ jobs:
         timeout-minutes: 350    # mirrors Step 2a — wall_timeout(290) + 60min relay margin
         if: steps.check_condition_b.outputs.has_condition_b == 'true' && steps.check_relay.outputs.needs_relay != 'true' && steps.step2a.outcome == 'success'
         env:
+          GDPVAL_RELAY_LINEAGE_ID: ${{ inputs.relay_lineage_id }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # Removed AZURE_OPENAI_API_KEY — openai SDK auto-detects env key and overrides azure_ad_token_provider. OIDC only via DefaultAzureCredential / azure/login@v2.
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
@@ -586,27 +619,64 @@ jobs:
 
       # ── Step 6: Generate Experiment Report ──
       - name: 'Step 6: Generate experiment report'
+        id: step6
         if: steps.check_relay.outputs.needs_relay != 'true' && steps.step2a.outcome == 'success'
         env:
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           # Removed AZURE_OPENAI_API_KEY — openai SDK auto-detects env key and overrides azure_ad_token_provider. OIDC only via DefaultAzureCredential / azure/login@v2.
         run: |
           cd batch-runner
-          bash step6_report.sh
-        continue-on-error: true   # report failure must not block Step 7 upload
+          if [[ "$DRY_RUN_INPUT" == "true" ]]; then
+            bash step6_report.sh --dry-run
+          else
+            bash step6_report.sh
+          fi
+        continue-on-error: true
 
-      # ── Step 7: Upload to HuggingFace (only if not dry_run and not relay) ──
-      - name: 'Step 7: Upload to HuggingFace'
-        if: inputs.dry_run != true && steps.check_relay.outputs.needs_relay != 'true' && steps.step2a.outcome == 'success'
+      - name: Ensure model-free experiment report
+        if: steps.check_relay.outputs.needs_relay == 'false' && steps.step2a.outcome == 'success'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          STEP6_OUTCOME: ${{ steps.step6.outcome }}
         run: |
+          set -euo pipefail
           cd batch-runner
-          bash step7_upload_hf.sh --test
+          REPORT="results/${EXPERIMENT_ID}/report/report.md"
+          SELF_REPORT="workspace/upload/self_report.json"
+          if [[ -e "$REPORT" && ( -L "$REPORT" || ! -f "$REPORT" ) ]]; then
+            echo "FATAL: report target is not a regular file"
+            exit 1
+          fi
+          if [[ "$STEP6_OUTCOME" != "success" || ! -s "$REPORT" || ! -s "$SELF_REPORT" ]]; then
+            echo "Narrative report unavailable; generating model-free fallback."
+            if [[ "$DRY_RUN_INPUT" == "true" ]]; then
+              bash step6_report.sh --no-narrative --dry-run
+            else
+              bash step6_report.sh --no-narrative
+            fi
+          fi
+          [[ -f "$REPORT" && ! -L "$REPORT" && -s "$REPORT" ]]
+          REPORT_REAL=$(realpath "$REPORT")
+          RESULTS_REAL=$(realpath results)
+          [[ "$REPORT_REAL" == "$RESULTS_REAL"/* ]]
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          experiment_id = os.environ["EXPERIMENT_ID"]
+          result = json.loads(Path("workspace/result.json").read_text(encoding="utf-8"))
+          self_report_path = Path("workspace/upload/self_report.json")
+          self_report = json.loads(self_report_path.read_text(encoding="utf-8"))
+          if result.get("experiment_id") != experiment_id:
+              raise SystemExit("workspace result experiment identity mismatch")
+          if (self_report.get("meta") or {}).get("experiment_id") != experiment_id:
+              raise SystemExit("self-report experiment identity mismatch")
+          PY
 
       # ── Create Pull Request (only if not dry_run and not relay) ──
       - name: Create Pull Request with results
-        if: inputs.dry_run != true && steps.check_relay.outputs.needs_relay != 'true' && steps.step2a.outcome == 'success'
+        id: cpr
+        if: inputs.dry_run != true && steps.check_relay.outputs.needs_relay == 'false' && steps.step2a.outcome == 'success'
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -629,13 +699,92 @@ jobs:
             - ✅ Step 3: Format results
             - ✅ Step 4: Fill parquet
             - ✅ Step 5: Validate dataset — ${{ steps.check_smoke_test.outputs.is_smoke_test == 'true' && 'Skipped (smoke test)' || 'Run' }}
-            - ✅ Step 6: Generate experiment report
-            - ✅ Step 7: Upload to HuggingFace
+            - Step 6: Generate experiment report — ${{ steps.step6.outcome == 'success' && 'Narrative report' || 'Model-free fallback report' }}
+            - Step 7: Hugging Face upload — Runs only after this PR contract is verified
 
-            Results uploaded to HuggingFace dataset repository.
-            Review and merge to finalize the experiment.
+            This PR records the report before the workflow performs the remote
+            Hugging Face upload and dispatches exact-SHA dashboard validation.
           branch: experiment/${{ inputs.experiment_yaml }}
           labels: experiment,automated
+          add-paths: batch-runner/results/${{ env.EXPERIMENT_ID }}/report/report.md
+
+      - name: Verify result PR outputs and contract
+        if: inputs.dry_run != true && steps.check_relay.outputs.needs_relay == 'false' && steps.step2a.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          PR_BRANCH: ${{ steps.cpr.outputs.pull-request-branch }}
+          PR_HEAD_SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
+          EXPECTED_EXPERIMENT_ID: ${{ env.EXPERIMENT_ID }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$PR_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$PR_BRANCH" == "experiment/${EXPERIMENT_YAML_INPUT}" ]]
+          git check-ref-format --branch "$PR_BRANCH" >/dev/null
+          PR_JSON=$(gh pr view "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json state,baseRefName,headRefName,headRefOid,isCrossRepository,files)
+          export PR_JSON PR_BRANCH PR_HEAD_SHA
+          python3 - <<'PY'
+          import json
+          import os
+
+          pull_request = json.loads(os.environ["PR_JSON"])
+          paths = [entry["path"] for entry in pull_request["files"]]
+          expected_path = (
+              "batch-runner/results/"
+              + os.environ["EXPECTED_EXPERIMENT_ID"]
+              + "/report/report.md"
+            )
+          checks = {
+              "state": pull_request["state"] == "OPEN",
+              "base": pull_request["baseRefName"] == "main",
+              "branch": pull_request["headRefName"] == os.environ["PR_BRANCH"],
+              "sha": pull_request["headRefOid"] == os.environ["PR_HEAD_SHA"],
+              "same_repo": pull_request["isCrossRepository"] is False,
+              "files": paths == [expected_path],
+          }
+          failed = [name for name, passed in checks.items() if not passed]
+          if failed:
+              raise SystemExit(f"result PR validation contract failed: {failed}")
+          PY
+
+      # ── Step 7: Upload only after the result PR contract is proven ──
+      - name: 'Step 7: Upload to HuggingFace'
+        if: inputs.dry_run != true && steps.check_relay.outputs.needs_relay == 'false' && steps.step2a.outcome == 'success'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          cd batch-runner
+          bash step7_upload_hf.sh --test
+
+      - name: Recheck result PR head after upload
+        if: inputs.dry_run != true && steps.check_relay.outputs.needs_relay == 'false' && steps.step2a.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          PR_HEAD_SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
+        run: |
+          set -euo pipefail
+          CURRENT_HEAD=$(gh pr view "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json headRefOid --jq .headRefOid)
+          [[ "$CURRENT_HEAD" == "$PR_HEAD_SHA" ]]
+
+      - name: Dispatch exact result PR validation
+        if: inputs.dry_run != true && steps.check_relay.outputs.needs_relay == 'false' && steps.step2a.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BRANCH: ${{ steps.cpr.outputs.pull-request-branch }}
+          PR_HEAD_SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
+        run: |
+          set -euo pipefail
+          gh workflow run deploy.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$PR_BRANCH" \
+            --raw-field deploy_pages=false \
+            --raw-field expected_sha="$PR_HEAD_SHA"
 
       # ── Cleanup relay checkpoint on HF (only after successful completion) ──
       - name: 'Cleanup relay checkpoint'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,11 @@ on:
       - 'scripts/**'                    # aggregate 스크립트 변경 시
       - 'package.json'                  # aggregate/browser command wiring
       - 'package-lock.json'             # aggregate/browser dependency graph
+      - 'index.html'                    # Vite entry point
+      - 'vite.config.ts'                # Vite build and base-path config
+      - 'tsconfig*.json'                # TypeScript build config
+      - 'tailwind.config.js'            # dashboard styles config
+      - 'postcss.config.js'             # CSS build config
       - '.github/workflows/deploy.yml'  # Pages gate 자체 변경 시
       - '.github/workflows/batch-run.yml' # runtime-note policy source
       - 'data/notes/runtime-incidents.yaml' # runtime-note incident source
@@ -20,34 +25,106 @@ on:
       - 'data/notes/perception-pipeline.yaml' # perception-note architecture source
       - 'data/notes/success-layers.yaml' # success-note artifact and interpretation source
 
-  workflow_dispatch:          # 수동 실행 가능
+  pull_request:
+    branches: [main]
+    paths:
+      - 'data/tests/**'
+      - 'data/grades/**'
+      - 'batch-runner/experiments/**'
+      - 'batch-runner/results/**'
+      - 'batch-runner/skills/**'
+      - 'src/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'index.html'
+      - 'vite.config.ts'
+      - 'tsconfig*.json'
+      - 'tailwind.config.js'
+      - 'postcss.config.js'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/batch-run.yml'
+      - 'data/notes/runtime-incidents.yaml'
+      - 'data/notes/integrity-incidents.yaml'
+      - 'data/notes/perception-pipeline.yaml'
+      - 'data/notes/success-layers.yaml'
+      - 'README.md'
+      - 'README_KR.md'
+      - 'docs/**'
+
+  workflow_dispatch:
+    inputs:
+      deploy_pages:
+        description: Deploy the validated artifact (protected main only)
+        required: true
+        type: boolean
+        default: true
+      expected_sha:
+        description: Exact result-PR SHA for validation-only dispatches
+        required: false
+        type: string
+        default: ''
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: >-
+    ${{ github.event_name == 'pull_request'
+        && format('pages-pr-{0}', github.event.pull_request.number)
+        || (github.event_name == 'workflow_dispatch'
+            && inputs.deploy_pages == false
+            && format('pages-validate-{0}', github.ref)
+            || 'pages') }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request'
+        || (github.event_name == 'workflow_dispatch'
+            && inputs.deploy_pages == false) }}
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  build-and-deploy:
+  validate:
     runs-on: ubuntu-24.04
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    timeout-minutes: 45
     steps:
+      - name: Verify non-PR event contract
+        if: github.event_name != 'pull_request'
+        env:
+          DEPLOY_PAGES: ${{ inputs.deploy_pages }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            [[ "$GITHUB_REF" == "refs/heads/main" ]]
+            [[ "$GITHUB_REF_PROTECTED" == "true" ]]
+          elif [[ "$DEPLOY_PAGES" == "true" ]]; then
+            [[ "$GITHUB_REF" == "refs/heads/main" ]]
+            [[ "$GITHUB_REF_PROTECTED" == "true" ]]
+            [[ -z "$EXPECTED_SHA" ]]
+          else
+            [[ "$GITHUB_REF" == refs/heads/experiment/* ]]
+            [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+            [[ "$GITHUB_SHA" == "$EXPECTED_SHA" ]]
+            [[ "$WORKFLOW_SHA" == "$EXPECTED_SHA" ]]
+          fi
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify exact checkout
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]]
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm
@@ -89,10 +166,32 @@ jobs:
         run: npm run test:notes-browser:dist
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        if: >-
+          github.ref == 'refs/heads/main'
+          && github.ref_protected == true
+          && (github.event_name == 'push'
+              || (github.event_name == 'workflow_dispatch'
+                  && inputs.deploy_pages == true))
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./dist
 
+  deploy:
+    needs: validate
+    if: >-
+      github.ref == 'refs/heads/main'
+      && github.ref_protected == true
+      && (github.event_name == 'push'
+          || (github.event_name == 'workflow_dispatch'
+              && inputs.deploy_pages == true))
+    runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ tasks/0601_monday/smoke_regrade_outputs/
 tasks/**
 !tasks/LATEST_TASK_RESULT/
 !tasks/LATEST_TASK_RESULT/README.md
+!tasks/0720_monday/
+tasks/0720_monday/*
+!tasks/0720_monday/BOLT_README_EXECUTION_TRUST.md
 
 *.parquet
 .huggingface/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Changed
+- **Execution-first repository onboarding and publish gates** — reorganize both
+  root READMEs around live evidence, a credential-free local preview, and an
+  honest three-task cloud path. English/Korean beginner guides now explain
+  OpenID Connect, disposable public Hugging Face targets, destructive bootstrap
+  and upload boundaries, Self-QA vs external grading, report fallback cost,
+  artifacts, troubleshooting, and cleanup. Pages automation separates a
+  read-only PR validation job from protected-main deployment; automated result
+  PRs are proven before HF upload, rechecked after upload, and dispatched for
+  exact-head-SHA validation without Pages/OIDC privileges.
 - **Success Field Note retrospective voice** — revise
   `what-does-success-mean` without changing its evidence contract, metrics,
   source links, or fail-closed behavior. The six chapters now follow a
@@ -33,6 +42,20 @@ entries land under a fresh dated heading the day they merge to `main`.
   and zero overflow or SVG label overlap.
 
 ### Fixed
+- **Inference/report identity and fallback integrity** — hash the complete
+  canonical Step 1 prepared payload, persist that fingerprint through relay
+  checkpoints and final inference, and reject stale or mixed Step 1/2 inputs in
+  Step 3. Experiment IDs and HF targets are path/branch-safe before Step 0.
+  Step 6 is now strictly pre-grading, derives HF links from the run's source,
+  isolates explicit external result files from current workspace manifests and
+  recovery stats, distinguishes dry-run publication, and falls back to a
+  model-free report when narrative generation fails. Result PR output and its
+  one-file contract are mandatory before destructive HF publication, preventing
+  silent no-PR success or stale `self_report.json` upload.
+  Relay legs now carry a stable lineage ID across GitHub run IDs, while
+  condition A/B use isolated progress and result files. Canonical HF repository
+  validation rejects unsupported length and punctuation before credentialed
+  bootstrap.
 - **Archived v1 cost-sweep template resolution** — point the historical
   `grading_cost_sweep.py` renderer at the tracked
   `grading_configs/_archive_v1/_sweep_template.yaml` after task 207 moved the
@@ -47,6 +70,13 @@ entries land under a fresh dated heading the day they merge to `main`.
   `Aggregate Tests & Deploy` run `29731574595` executed, and it succeeded.
 
 ### Added
+- **Localized responsive README diagrams** — add twelve repository-owned SVGs:
+  English and Korean desktop/mobile versions of the first-run decision, system
+  map, and operational controls. Static SVG replaces remote Mermaid rendering;
+  each asset has intrinsic dimensions, accessible title/description, at least
+  6.04:1 primary text contrast, and a 960px responsive breakpoint. Browser
+  geometry checks cover nearest-card spacing and overflow across mobile,
+  tablet, and desktop widths.
 - **Evidence-backed success Field Note** — rebuild
   `what-does-success-mean` as a retrospective that separates the team's initial
   handoff-ready expectation from exp026's observed execution, artifact integrity,

--- a/README.md
+++ b/README.md
@@ -1,340 +1,266 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/GDPVal-Real%20Work%20Benchmark-blueviolet?style=for-the-badge" alt="GDPVal RealWorks" />
+  <img src="https://img.shields.io/badge/GDPVal-Real%20Work%20Benchmark-177f78?style=for-the-badge" alt="GDPVal RealWorks" />
 </p>
 
 <h1 align="center">GDPVal RealWorks</h1>
 
 <p align="center">
-  <strong>Benchmark LLMs on real expert work — not academic toy problems.</strong><br/>
-  <em>A YAML-driven experiment pipeline + live dashboard for the <a href="https://arxiv.org/abs/2510.04374">GDPVal</a> Gold Subset (220 tasks).</em>
+  <strong>Benchmark LLMs on real expert work, not toy prompts.</strong><br/>
+  <em>A reproducible experiment pipeline and evidence dashboard for the <a href="https://arxiv.org/abs/2510.04374">GDPVal</a> Gold Subset: 220 tasks across 9 sectors and 44 occupations.</em>
 </p>
 
 <p align="center">
   <a href="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/deploy.yml">
-    <img src="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/deploy.yml/badge.svg" alt="Deploy" />
+    <img src="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/deploy.yml/badge.svg" alt="Dashboard checks and deploy" />
   </a>
   <a href="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/batch-run.yml">
-    <img src="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/batch-run.yml/badge.svg" alt="Batch Run" />
+    <img src="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/batch-run.yml/badge.svg" alt="Batch experiment" />
   </a>
   <a href="LICENSE">
-    <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License" />
+    <img src="https://img.shields.io/badge/license-MIT-2f6b58.svg" alt="MIT License" />
   </a>
 </p>
 
 <p align="center">
-  <a href="https://hyeonsangjeon.github.io/gdpval-realworks/">🌐 Live Dashboard</a> · 
-  <a href="README_KR.md">🇰🇷 한국어</a> · 
-  <a href="batch-runner/README.md">📖 Batch Runner Docs</a> · 
-  <a href="https://arxiv.org/abs/2510.04374">📄 Paper</a>
+  <a href="https://hyeonsangjeon.github.io/gdpval-realworks/"><strong>Live Dashboard</strong></a> |
+  <a href="docs/first-experiment.md"><strong>First Experiment</strong></a> |
+  <a href="batch-runner/sandbox/README.md"><strong>Sandbox &amp; Security</strong></a> |
+  <a href="README_KR.md">한국어</a> |
+  <a href="https://arxiv.org/abs/2510.04374">Paper</a>
 </p>
 
 ---
 
-> 📊 **[Live Dashboard → https://hyeonsangjeon.github.io/gdpval-realworks/](https://hyeonsangjeon.github.io/gdpval-realworks/)**
->
-> Leaderboard · Trends · Execution Errors · Grading Analysis — all in one place.
+## Start here
 
----
+- **See the evidence:** [open the live dashboard](https://hyeonsangjeon.github.io/gdpval-realworks/).
+  A browser is enough.
+- **Preview locally:** run `npm ci && npm run dev`. You need Git and Node.js 20+,
+  but no cloud credentials.
+- **Run three real tasks:** follow the [beginner guide](docs/first-experiment.md).
+  You need a fork, Azure OIDC, a Hugging Face (HF) write token, and a real API
+  budget.
 
-## The Problem
-
-Most LLM benchmarks test **academic reasoning** — math, code puzzles, trivia.  
-None of that tells you whether a model can actually **do your job**.
-
-**GDPVal** (GDP-level Validation) is different: **220 real-world expert tasks** across 9 industry sectors and 44 occupations — Excel reports, legal docs, sales decks, the stuff people actually get paid for.
-
-This repo automates the entire loop: **configure → run → collect → visualize** — driven by a single YAML file, executed on GitHub Actions, results on a live dashboard.
-
-> 🎯 One YAML file. One button click. Full experiment lifecycle.
-
-<p align="center">
-  <img src="docs/images/dashboard-leaderboard.png" alt="Leaderboard — experiment rankings, KPI cards, sector heatmap" width="720" />
-</p>
-<p align="center"><em>Live Dashboard — leaderboard, success rates, QA scores across experiments</em></p>
-
-<p align="center">
-  <img src="docs/images/dashboard-experiment-tasks.png" alt="Task Detail — real professional task with reference files and deliverables" width="480" />
-</p>
-<p align="center"><em>Task Detail — real-world task description, reference files, and generated deliverables</em></p>
-
----
-
-## How It Works
-
-<table>
-<tr>
-<td align="center"><img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRECiAgICBBWyJTdGVwIDA6IEJvb3RzdHJhcDxicj5IRiByZXBvICsgc25hcHNob3QiXSAtLT4gQlsiU3RlcCAxOiBQcmVwYXJlPGJyPkZpbHRlciArIGxvYWQgdGFza3MiXQ==" alt="Preparation" width="350" /></td>
-<td align="center" style="font-size:2em;">→</td>
-<td align="center"><img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRECiAgICBDWyJTdGVwIDI6IEluZmVyZW5jZTxicj5MTE0gKyBTZWxmLVFBIl0gLS0-IERbIlN0ZXAgMzogRm9ybWF0PGJyPkpTT04gKyBNYXJrZG93biJd" alt="Execution" width="350" /></td>
-</tr>
-<tr>
-<td></td>
-<td align="center" style="font-size:2em;">↓</td>
-<td></td>
-</tr>
-<tr>
-<td align="center"><img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRECiAgICBFWyJTdGVwIDQ6IFBhcnF1ZXQ8YnI-TWVyZ2Ugc3VibWlzc2lvbiJdIC0tPiBGWyJTdGVwIDU6IFZhbGlkYXRlPGJyPkludGVncml0eSBjaGVjayJd" alt="Delivery" width="350" /></td>
-<td align="center" style="font-size:2em;">→</td>
-<td align="center"><img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRECiAgICBHWyJTdGVwIDY6IFJlcG9ydDxicj5IVE1MICsgSlNPTiJdIC0tPiBIWyJTdGVwIDc6IFVwbG9hZDxicj5IRiArIEF1dG8gUFIiXQ==" alt="Report & Upload" width="350" /></td>
-</tr>
-</table>
-
-
----
-
-## ⚡ Quick Start
-
-### 1. Fork & Clone
+The local dashboard path does not need cloud credentials and does not call an
+LLM:
 
 ```bash
 git clone https://github.com/hyeonsangjeon/gdpval-realworks.git
 cd gdpval-realworks
+npm ci
+npm run dev
 ```
 
-### 2. Configure GitHub Repository Settings
+> **Cloud-run boundary:** `dry_run: true` still calls the model, runs Self-QA,
+> and can create or update the configured Hugging Face dataset. It skips Step 5
+> validation, final result publication, and the result PR; it does not mean
+> "free" or "no writes." This three-task smoke also skips Step 5 because of its
+> sample size.
 
-#### 🔑 Secrets
+**[English first-run guide](docs/first-experiment.md)** |
+**[한국어 첫 실행 가이드](docs/first-experiment_KR.md)** |
+**[Batch Runner reference](batch-runner/README.md)**
 
-Go to **Settings → Secrets and variables → Actions → New repository secret** and add the secrets you need:
+---
 
-| Secret Name | Value | Required? |
+## Why RealWorks
+
+Many benchmarks stop at text answers. GDPVal asks models to complete work that
+looks like the job: spreadsheets, reports, presentations, media, and other
+reviewable files. The Gold Subset covers **220 tasks across 9 industry sectors
+and 44 occupations**.
+
+This repository turns those tasks into a repeatable loop:
+**configure -> execute -> preserve evidence -> grade -> compare**. A YAML file
+defines the intervention; GitHub Actions records the run; the dashboard keeps
+results, failures, artifacts, and research notes inspectable.
+
+It deliberately keeps four signals separate:
+
+| Signal | What it proves | What it does not prove |
 |---|---|---|
-| `AZURE_OPENAI_API_KEY` | Azure OpenAI API key | ✅ If using Azure |
-| `AZURE_OPENAI_ENDPOINT` | `https://your-resource.openai.azure.com/` | ✅ If using Azure |
-| `OPENAI_API_KEY` | OpenAI API key | If using OpenAI |
-| `ANTHROPIC_API_KEY` | Anthropic API key | If using Anthropic |
-| `HF_TOKEN` | HuggingFace write token ([get one here](https://huggingface.co/settings/tokens)) | ✅ For upload |
+| Execution completion | The pipeline reached a terminal task state | The file is correct |
+| Artifact integrity | Expected files exist and pass deterministic checks | The work satisfies every requirement |
+| Self-QA | The generating model accepted or retried its own output | Independent quality |
+| External grading | A separate rubric-based evaluation was recorded | Universal human agreement |
 
-> 💡 You don't need all of them — just the provider you'll actually use.  
-> For Azure users: `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` + `HF_TOKEN` is the minimum.
-
-#### 📄 GitHub Pages
-
-**Settings → Pages → Source** must be set to **"GitHub Actions"** (not "Deploy from a branch").
-The `deploy.yml` workflow uploads the build artifact via `actions/deploy-pages` — no `gh-pages` branch is used.
-
-#### 🔓 Workflow Permissions
-
-**Settings → Actions → General → Workflow permissions:**
-
-- ✅ Select **"Read and write permissions"**
-- ✅ Check **"Allow GitHub Actions to create and approve pull requests"**
-- Save
-
-#### 🧹 Auto-cleanup (recommended)
-
-**Settings → General** → ✅ Check **"Automatically delete head branches"**
-
-> This cleans up experiment branches automatically after PR merge.
+<p align="center">
+  <a href="https://hyeonsangjeon.github.io/gdpval-realworks/">
+    <img src="docs/images/dashboard-leaderboard.png" alt="GDPVal RealWorks dashboard with experiment rankings, KPI cards, and a sector heatmap" width="840" />
+  </a>
+</p>
+<p align="center"><em>Live evidence: experiment comparisons, failure analysis, external grades, and field notes.</em></p>
 
 ---
 
-### 3. Run Your First Experiment
+## System map
 
-1. Go to **Actions** tab → **"Run GDPVal Batch Experiment"**
-2. Click **"Run workflow"**
-3. Fill in:
-   - `experiment_yaml`: `exp998_smoke_baseline_sample` (smoke test, 3 tasks)
-   - `dry_run`: ✅ checked (first time — skip upload)
-4. Click **Run workflow** 🚀
+<p align="center">
+  <picture>
+    <source media="(max-width: 960px)" srcset="docs/images/readme-system-map-mobile.svg" />
+    <img src="docs/images/readme-system-map.svg" alt="GDPVal RealWorks system map from experiment YAML through execution, artifacts, grading, aggregation, and dashboard" />
+  </picture>
+</p>
 
-```
-✅ Step 0: Bootstrap        → HF repo ready
-✅ Step 1: Prepare tasks    → 3 tasks filtered
-✅ Step 2: Run inference    → LLM called for each task
-✅ Step 3: Format results   → JSON + Markdown generated
-✅ Step 4: Fill parquet     → Submission parquet ready
-⏭️ Step 5: Validate        → Skipped (smoke test)
-⏭️ Step 6: Upload          → Skipped (dry run)
-```
-
-> 🎉 If this passes, uncheck `dry_run` and run a full experiment!
+Steps 0-7 own experiment execution and publication. External grading is a
+separate pipeline, and the dashboard aggregates both without treating them as
+the same measurement.
 
 ---
 
-## 📝 Write Your Own Experiment
+## Operational controls
 
-Create a YAML file in `batch-runner/experiments/`:
+<p align="center">
+  <picture>
+    <source media="(max-width: 960px)" srcset="docs/images/readme-trust-boundaries-mobile.svg" />
+    <img src="docs/images/readme-trust-boundaries.svg" alt="Path-specific identity, input, runtime, publication, and agentic preflight controls" />
+  </picture>
+</p>
 
-```yaml
-experiment:
-  id: "exp001_GPT52Chat_baseline"
-  name: "GPT-5.2 Chat Baseline (Full 220 tasks)"
-  description: "Full baseline run with code_interpreter and Self-QA."
+These are code-backed, path-specific controls, not a blanket security claim:
 
-data:
-  source: "HyeonSang/exp001_GPT52Chat_baseline"
-  filter:
-    sector: null          # null = all sectors
-    sample_size: null     # null = all 220 tasks
-
-condition_a:
-  name: "Baseline"
-  model:
-    provider: "azure"
-    deployment: "gpt-5.2-chat"
-    temperature: 0.0
-    seed: 42
-  prompt:
-    system: "You are a helpful assistant that completes professional tasks."
-    suffix: "Generate actual files, not descriptions."
-  qa:
-    enabled: true
-    min_score: 6
-    max_retries: 3
-
-# condition_b:            ← Add for A/B comparison (optional)
-
-execution:
-  mode: "code_interpreter"
-  max_retries: 5
-  resume_max_rounds: 3
-```
-
-Then trigger it from **Actions → Run workflow** with `experiment_yaml: exp001_GPT52Chat_baseline`.
-
----
-
-## 🧠 Execution Modes
-
-| Mode | How It Works | Best For |
+| Boundary | Enforced today | Evidence |
 |---|---|---|
-| **`code_interpreter`** | LLM writes + runs code inside Azure/OpenAI's **secure sandbox**. Files generated in the cloud. | ✅ Production — safe, powerful |
-| **`subprocess`** | LLM generates code → executed locally in an isolated temp directory. | Non-OpenAI models (Anthropic, etc.) |
-| **`sandbox`** | 🐳 Container evolution of `subprocess`: per-task **dependency discovery** + famous **Agent Skills** (audio/video/document/image/data) + **multimodal perception** (vision for video, hearing for audio). Runs in an isolated Docker container (`--network none`, resource caps) with a hardened **local fallback** when Docker is unavailable. | Multimodal tasks; reproducible, skill-aware execution |
-| **`json_renderer`** | LLM outputs a JSON spec → a **fixed renderer** creates files. Same renderer for all models. | Fair A/B comparison across models |
+| Azure identity | The batch Azure path uses GitHub OIDC and does not inject `AZURE_OPENAI_API_KEY` | [`batch-run.yml`](.github/workflows/batch-run.yml), [`llm_client.py`](batch-runner/core/llm_client.py) |
+| Configuration input | A no-credential job validates the experiment name and safely parses YAML before the credentialed job; agentic modes are rejected from the general batch path | [`batch-run.yml`](.github/workflows/batch-run.yml) |
+| Container sandbox | Sandbox runs resolve an immutable image digest across relay jobs; Docker execution disables networking and applies resource limits | [`batch-run.yml`](.github/workflows/batch-run.yml), [`sandbox_runner.py`](batch-runner/core/sandbox_runner.py) |
+| Agentic image supply chain | Manual protected-main publication requires immutable dependency locks, a digest-pinned base, runtime audit, and SBOM evidence | [`build-sandbox-image.yml`](.github/workflows/build-sandbox-image.yml) |
+| Agentic containment preflight | A manual model-free job rejects model/HF credentials, requires an exact preloaded image and AppArmor input, runs containment tests, and asserts cleanup | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
+| Dashboard publication | Pull requests aggregate, build, and run data/browser contracts; only push/manual deploy jobs receive Pages/OIDC permissions | [`deploy.yml`](.github/workflows/deploy.yml) |
 
-> 🐳 `sandbox` mode realizes the **container-based** evolution of `subprocess`.
-> Build the image with `bash batch-runner/sandbox/build.sh`, then set
-> `execution.mode: sandbox` (see `batch-runner/sandbox/README.md` and
-> `experiments/exp026_sandbox_skills_multimodal.yaml`).
-
----
-
-## 🔬 Self-QA: Built-in Quality Reflection Gate
-
-Before acceptance, the same LLM working on the task inspects its own output:
-Self-QA scores each output on a 0-10 scale using rubric-based self-evaluation. If the score is below the configured threshold (default: 6), it enters a reflection loop and retries.
-
-<img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IExSCiAgICB0YXNrWyJUYXNrIl0gLS0-IGdlblsiTExNIEdlbmVyYXRlcyBPdXRwdXQiXSAtLT4gcWFbIlNlbGYtUUEgSW5zcGVjdHMiXSAtLT4gZ2F0ZXsiU2NvcmUgPj0gNj8ifQogICAgZ2F0ZSAtLT58WWVzfCBhY2NlcHRbIkFjY2VwdCJdCiAgICBnYXRlIC0tPnxOb3wgcmV0cnlbIlJldHJ5ICh1cCB0byAzeCkiXQo=" alt="Self-QA Flow" />
-
-
-Self-QA checks: Are all requirements met? Are files actually produced? Is the output professional?
+The default three-task smoke config uses provider-hosted `code_interpreter`.
+Docker sandbox and agentic controls apply only to their named paths. The general
+batch workflow currently rejects agentic execution before cloud credentials are
+used; the checked-in agentic workflow is a model-free preflight, not a paid run.
 
 ---
 
-## 🏗️ Architecture
+## First cloud experiment
 
-<img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRCCiAgICByb290WyJnZHB2YWwtcmVhbHdvcmtzLyJdCgogICAgd2ZbIi5naXRodWIvd29ya2Zsb3dzLzxici8-YmF0Y2gtcnVuLnltbCwgZGVwbG95LnltbCJdCiAgICBiclsiYmF0Y2gtcnVubmVyLzxici8-c3RlcCBzY3JpcHRzLCBjb3JlLCBleHBlcmltZW50cywgcHJvbXB0cywgdGVzdHMiXQogICAgc3JjWyJzcmMvPGJyLz5wYWdlcywgY29tcG9uZW50cyJdCiAgICBkYXRhWyJkYXRhLzxici8-dGVzdHMsIGdyYWRlcyJdCiAgICBzY3JpcHRzWyJzY3JpcHRzLzxici8-YWdncmVnYXRlLXRlc3RzLm1qcywgYWdncmVnYXRlLWdyYWRlcy5tanMiXQoKICAgIHJvb3QgLS0-IHdmCiAgICByb290IC0tPiBicgogICAgcm9vdCAtLT4gc3JjCiAgICByb290IC0tPiBkYXRhCiAgICByb290IC0tPiBzY3JpcHRzCg==" alt="Architecture" />
+Use the checked-in
+[`exp998_smoke_baseline_sample.yaml`](batch-runner/experiments/exp998_smoke_baseline_sample.yaml)
+only after changing `data.source` to a new dataset in your own Hugging Face
+namespace.
 
+From **Actions > Run GDPVal Batch Experiment**, use:
 
----
-
-## 🔄 GitHub Actions Workflows
-
-### `batch-run.yml` — Run Experiments
-
-| Feature | Detail |
+| Input | First-run value |
 |---|---|
-| **Trigger** | Manual (`workflow_dispatch`) from Actions tab |
-| **Input** | Experiment YAML filename + optional dry_run flag |
-| **Pipeline** | Step 0 → Step 7 (bootstrap → upload) |
-| **Smart skips** | Smoke tests skip validation; dry_run skips upload + PR |
-| **Auto PR** | Creates a Pull Request with experiment summary |
-| **Artifacts** | Full workspace uploaded for 30 days |
-| **Timeout** | 5 hours max |
+| `experiment_yaml` | `exp998_smoke_baseline_sample` |
+| `dry_run` | `true` |
+| `relay_run` | `0` |
+| `wall_timeout` | `290` |
+| `sandbox_image_digest` | leave empty |
 
-### `deploy.yml` — Deploy Dashboard
+Expected behavior:
 
-| Feature | Detail |
+1. Step 0 creates, recreates, or reuses the disposable Hugging Face dataset.
+2. Step 1 selects three tasks deterministically.
+3. Step 2 calls `gpt-5.2-chat`, creates files, and can retry same-model Self-QA.
+4. Steps 3-4 write formatted results and a three-row Parquet artifact.
+5. Step 5 is skipped because this is both a dry run and a three-task sample.
+6. Step 6's primary report path makes up to two sequential `gpt-5.4-pro` calls;
+  on error, it attempts one `gpt-5.2-chat` fallback call. Completed calls can
+  be billed. Narrative failure is non-blocking only because a mandatory
+  model-free report fallback and identity check run before publication.
+7. Step 7 and the result PR are skipped by `dry_run: true`.
+
+If the credentialed batch job reaches its final `always()` step, it attempts to
+upload `batch-results-<run_id>` for inspection and retain it for 30 days. The
+**[complete beginner guide](docs/first-experiment.md)** covers OIDC, required
+secrets, cost boundaries, artifacts, and common failures.
+
+---
+
+## Execution modes
+
+| Mode | Execution boundary | Use it for |
+|---|---|---|
+| `code_interpreter` | Provider-hosted code tools and file retrieval | The current Azure smoke path |
+| `subprocess` | Generated Python runs in a host temporary directory | Legacy/local compatibility; review the trust boundary first |
+| `sandbox` | Docker when available, with no network, resource caps, skills, verification, and render QA; `auto` can fall back locally | Reproducible document and multimodal work |
+| `json_renderer` | The model emits a spec and a deterministic renderer creates files | Renderer-controlled A/B comparisons |
+
+To require Docker rather than permit fallback, set `execution.sandbox.use_docker`
+to `always`. See the **[sandbox operator guide](batch-runner/sandbox/README.md)**
+before changing execution modes.
+
+### Self-QA is not external grading
+
+Self-QA asks the same model to inspect its own result and retry below a configured
+threshold. It is an inference-time reflection gate. Independent rubric grading
+is recorded by a separate pipeline and displayed as a separate signal.
+
+---
+
+## Dashboard
+
+The **[live dashboard](https://hyeonsangjeon.github.io/gdpval-realworks/)** is a
+static React application backed by generated repository data.
+
+| View | What you can inspect |
 |---|---|
-| **Trigger** | Push to `main` (auto, scoped to `data/`, `src/`, `scripts/`) or manual `workflow_dispatch` |
-| **Build** | Aggregate test/grade data → React build → `actions/deploy-pages` artifact upload |
-| **Source** | GitHub Pages **Source: GitHub Actions** (no `gh-pages` branch) |
+| Leaderboard and trends | Experiment-level completion, latency, and external grade comparisons |
+| Sector heatmap | Performance variation across 9 sectors |
+| Experiment detail | All 220 task states, files, prompts, retries, and errors |
+| Grading analysis | Evidence-linked rubric results and judge metadata |
+| RealWorks Field Notes | Chronological engineering decisions with explicit evidence caveats |
+
+Dashboard implementation details are in [`src/README.md`](src/README.md).
 
 ---
 
-## 🖥️ Dashboard
+## Develop and verify
 
-> **[→ Live Dashboard](https://hyeonsangjeon.github.io/gdpval-realworks/)**
+Dashboard checks require Node.js 20 or newer:
 
-Interactive experiment analytics — leaderboard, sector heatmaps, error analysis, prompt architecture viewer, and evidence-linked RealWorks field notes.
+```bash
+npm ci
+npm run aggregate
+npm run test:aggregate
+npm run build
+```
 
-| Feature | Description |
-|---------|-------------|
-| **Leaderboard** | Ranked experiments with strategy, success rate, QA scores |
-| **Sector Heatmap** | 9 sectors × N experiments success rate matrix |
-| **Trends** | Success rate / QA / latency trend lines across experiments |
-| **Execution Errors** | Exception type distribution chart, recovery funnel, AI failure insights narrative |
-| **Prompt Viewer** | See exactly what prompt was sent to the LLM — system, user, QA, config |
-| **Grading** | External evaluation scores (OpenAI Evals) |
-| **Experiment Detail** | Drill into 220 tasks — filter by sector, status, search |
-| **RealWorks Field Notes** | Independent reviews with responsive hero scenes, evidence-caveated comparison charts, and a chronological decision record |
-
-Built with React 18 + TypeScript + Vite + Tailwind + Recharts + Framer Motion.  
-Deployed automatically to GitHub Pages on every push to `main`.
-
-📖 **[Dashboard Documentation →](src/README.md)** · 🇰🇷 **[한국어 →](src/README_KR.md)**
-
----
-
-## 🧪 Testing
+Backend unit tests do not require model credentials:
 
 ```bash
 cd batch-runner
+python -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
-
-# Unit tests only (no API keys needed)
 pytest
-
-# Integration tests (requires real credentials)
-pytest -m integration
-
-# With coverage
-pytest --cov=core --cov-report=html
 ```
 
-### 🖥️ Run Locally (step by step)
+Integration tests, inference, grading, uploads, and workflow dispatches can use
+cloud credentials or incur cost; run them only when that is your intent.
 
-```bash
-cd batch-runner
-export HF_TOKEN="hf_xxx"
-export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
-export AZURE_OPENAI_API_KEY="xxx"
+## Repository map
 
-./step0_bootstrap.sh experiments/exp998_smoke_baseline_sample.yaml
-./step1_prepare_tasks.sh experiments/exp998_smoke_baseline_sample.yaml
-./step2_run_inference.sh condition_a
-./step3_format_results.sh
-./step4_fill_parquet.sh
-./step5_validate.sh
-./step6_report.sh
-./step7_upload_hf.sh --test
-```
-
-> 💡 Local execution works, but for full 220-task runs we recommend **GitHub Actions**.  
-> The batch workflow parallelizes as fast as your TPM (Tokens Per Minute) quota allows — let the cloud do the heavy lifting while you grab a coffee. ☕
+| Path | Responsibility |
+|---|---|
+| [`batch-runner/`](batch-runner/README.md) | Experiment configs, execution pipeline, grading, prompts, and tests |
+| [`batch-runner/sandbox/`](batch-runner/sandbox/README.md) | Container image, execution controls, skills, verification, and render QA |
+| [`src/`](src/README.md) | React dashboard pages, components, hooks, and data presentation |
+| [`scripts/`](scripts/) | Deterministic aggregation and analysis tools |
+| [`data/`](data/) | Checked-in experiment summaries and external grade records |
+| [`.github/workflows/`](.github/workflows/) | Batch, grading, sandbox, validation, and Pages automation |
 
 ---
 
-## 📚 References
+## References
 
-- **GDPVal Paper**: [arXiv:2510.04374](https://arxiv.org/abs/2510.04374)
-- **GDPVal Dataset**: [openai/gdpval](https://huggingface.co/datasets/openai/gdpval)
-- **GDPVal Grading**: [evals.openai.com](https://evals.openai.com/)
-- **Azure OpenAI Responses API**: [Documentation](https://learn.microsoft.com/azure/ai-services/openai/)
+- [GDPVal paper](https://arxiv.org/abs/2510.04374)
+- [GDPVal dataset](https://huggingface.co/datasets/openai/gdpval)
+- [OpenAI Evals](https://evals.openai.com/)
+- [Azure OpenAI documentation](https://learn.microsoft.com/azure/ai-services/openai/)
 
----
+## Author
 
-## 👤 Author
+**Hyeonsang Jeon**<br/>
+Sr. Solution Engineer, Global Black Belt - AI Apps | Microsoft Asia, Korea<br/>
+[GitHub](https://github.com/hyeonsangjeon) |
+[Live Dashboard](https://hyeonsangjeon.github.io/gdpval-realworks/)
 
-**Hyeonsang Jeon**  
-Sr. Solution Engineer · Global Black Belt — AI Apps | Microsoft Asia, Korea  
-[![GitHub](https://img.shields.io/badge/GitHub-hyeonsangjeon-181717?logo=github)](https://github.com/hyeonsangjeon)
-[![Dashboard](https://img.shields.io/badge/Live%20Dashboard-GDPVal-blueviolet?logo=react)](https://hyeonsangjeon.github.io/gdpval-realworks/)
+## License
 
----
-
-## 📄 License
-
-MIT — See [LICENSE](LICENSE) for details.
+MIT. See [`LICENSE`](LICENSE).

--- a/README_KR.md
+++ b/README_KR.md
@@ -1,336 +1,266 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/GDPVal-Real%20Work%20Benchmark-blueviolet?style=for-the-badge" alt="GDPVal RealWorks" />
+  <img src="https://img.shields.io/badge/GDPVal-Real%20Work%20Benchmark-177f78?style=for-the-badge" alt="GDPVal RealWorks" />
 </p>
 
 <h1 align="center">GDPVal RealWorks</h1>
 
 <p align="center">
-  <strong>LLM을 학문적 시험이 아닌, 실제 전문가 업무로 벤치마크하세요.</strong><br/>
-  <em>YAML 기반 실험 파이프라인 + 라이브 대시보드로 <a href="https://arxiv.org/abs/2510.04374">GDPVal</a> Gold Subset (220개 태스크)을 평가합니다.</em>
+  <strong>장난감 프롬프트가 아니라 실제 전문가 업무로 LLM을 벤치마크합니다.</strong><br/>
+  <em><a href="https://arxiv.org/abs/2510.04374">GDPVal</a> Gold Subset의 9개 산업, 44개 직종, 220개 태스크를 위한 재현 가능한 실험 파이프라인과 근거 대시보드입니다.</em>
 </p>
 
 <p align="center">
   <a href="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/deploy.yml">
-    <img src="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/deploy.yml/badge.svg" alt="Deploy" />
+    <img src="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/deploy.yml/badge.svg" alt="대시보드 검증 및 배포" />
   </a>
   <a href="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/batch-run.yml">
-    <img src="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/batch-run.yml/badge.svg" alt="Batch Run" />
+    <img src="https://github.com/hyeonsangjeon/gdpval-realworks/actions/workflows/batch-run.yml/badge.svg" alt="배치 실험" />
   </a>
   <a href="LICENSE">
-    <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License" />
+    <img src="https://img.shields.io/badge/license-MIT-2f6b58.svg" alt="MIT 라이선스" />
   </a>
 </p>
 
 <p align="center">
-  <a href="https://hyeonsangjeon.github.io/gdpval-realworks/">🌐 라이브 대시보드</a> · 
-  <a href="README.md">🇺🇸 English</a> · 
-  <a href="batch-runner/README.md">📖 Batch Runner 문서</a> · 
-  <a href="https://arxiv.org/abs/2510.04374">📄 논문</a>
+  <a href="https://hyeonsangjeon.github.io/gdpval-realworks/"><strong>라이브 대시보드</strong></a> |
+  <a href="docs/first-experiment_KR.md"><strong>첫 실험</strong></a> |
+  <a href="batch-runner/sandbox/README.md"><strong>샌드박스와 보안</strong></a> |
+  <a href="README.md">English</a> |
+  <a href="https://arxiv.org/abs/2510.04374">논문</a>
 </p>
 
 ---
 
-> 📊 **[라이브 대시보드 → https://hyeonsangjeon.github.io/gdpval-realworks/](https://hyeonsangjeon.github.io/gdpval-realworks/)**
->
-> Leaderboard · Trends · Execution Errors · Grading Analysis — 실험 결과를 한눈에 확인하세요.
+## 여기서 시작하세요
 
----
+- **근거 보기:** [라이브 대시보드](https://hyeonsangjeon.github.io/gdpval-realworks/)를
+  엽니다. 브라우저만 있으면 됩니다.
+- **로컬 미리보기:** `npm ci && npm run dev`를 실행합니다. Git과 Node.js 20+가
+  필요하지만 클라우드 인증 정보는 필요 없습니다.
+- **실제 태스크 3개 실행:** [초보자 가이드](docs/first-experiment_KR.md)를
+  따라갑니다. fork, Azure OIDC, Hugging Face(HF) 쓰기 토큰, 실제 API 예산이
+  필요합니다.
 
-## 문제 인식
-
-대부분의 LLM 벤치마크는 **학술적 추론** — 수학, 코드 퍼즐, 퀴즈를 테스트합니다.  
-그런 건 모델이 실제로 **내 업무를 해낼 수 있는지** 알려주지 않습니다.
-
-**GDPVal** (GDP-level Validation)은 다릅니다: 9개 산업, 44개 직종에 걸친 **220개 실무 태스크** — Excel 보고서, 법률 문서, 영업 프레젠테이션 등 사람들이 실제로 돈 받고 하는 일들.
-
-이 레포는 전체 루프를 자동화합니다: **설정 → 실행 → 수집 → 시각화** — YAML 하나로 구동, GitHub Actions에서 실행, 결과는 라이브 대시보드에.
-
-> 🎯 YAML 하나. 버튼 한 번. 실험 전체 라이프사이클.
-
-<p align="center">
-  <img src="docs/images/dashboard-leaderboard.png" alt="리더보드 — 실험 랭킹, KPI 카드, 섹터 히트맵" width="720" />
-</p>
-<p align="center"><em>라이브 대시보드 — 리더보드, 성공률, QA 점수 비교</em></p>
-
-<p align="center">
-  <img src="docs/images/dashboard-experiment-tasks.png" alt="태스크 상세 — 실제 전문가 태스크, 참조 파일, 산출물" width="480" />
-</p>
-<p align="center"><em>태스크 상세 — 실무 태스크 설명, 참조 파일, 생성된 산출물</em></p>
-
----
-
-## 동작 원리
-
-<table>
-<tr>
-<td align="center"><img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRECiAgICBBWyJTdGVwIDA6IOu2gO2KuOyKpO2KuOueqTxicj5IRiDroIjtj6wgKyDsiqTrg4Xsg7ciXSAtLT4gQlsiU3RlcCAxOiDtg5zsiqTtgawg7KSA67mEPGJyPu2VhO2EsCArIOuhnOuTnCJd" alt="준비" width="350" /></td>
-<td align="center" style="font-size:2em;">→</td>
-<td align="center"><img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRECiAgICBDWyJTdGVwIDI6IOy2lOuhoDxicj5MTE0gKyBTZWxmLVFBIl0gLS0-IERbIlN0ZXAgMzog7Y-s66e37YyFPGJyPkpTT04gKyBNYXJrZG93biJd" alt="실행" width="350" /></td>
-</tr>
-<tr>
-<td></td>
-<td align="center" style="font-size:2em;">↓</td>
-<td></td>
-</tr>
-<tr>
-<td align="center"><img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRECiAgICBFWyJTdGVwIDQ6IFBhcnF1ZXQ8YnI-7KCc7LacIOuNsOydtO2EsCDrs5HtlakiXSAtLT4gRlsiU3RlcCA1OiDqsoDspp08YnI-66y06rKw7ISxIOqygOyCrCJd" alt="산출물" width="350" /></td>
-<td align="center" style="font-size:2em;">→</td>
-<td align="center"><img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRECiAgICBHWyJTdGVwIDY6IOumrO2PrO2KuDxicj5IVE1MICsgSlNPTiJdIC0tPiBIWyJTdGVwIDc6IOyXheuhnOuTnDxicj5IRiArIFBSIOyDneyEsSJd" alt="리포트 & 업로드" width="350" /></td>
-</tr>
-</table>
-
-
----
-
-## ⚡ 빠른 시작
-
-### 1. Fork & Clone
+로컬 대시보드는 클라우드 인증 정보가 필요 없고 LLM을 호출하지 않습니다.
 
 ```bash
 git clone https://github.com/hyeonsangjeon/gdpval-realworks.git
 cd gdpval-realworks
+npm ci
+npm run dev
 ```
 
-### 2. GitHub 저장소 설정
+> **클라우드 실행 경계:** `dry_run: true`여도 모델 호출과 Self-QA를
+> 실행하고, 설정한 Hugging Face 데이터셋을 만들거나 수정할 수 있습니다.
+> Step 5 검증, 최종 결과 게시, 결과 PR을 건너뜁니다. "무료"나 "원격 쓰기
+> 없음"을 뜻하지 않습니다. 이 3-task smoke는 sample size 때문에도 Step 5를
+> 생략합니다.
 
-#### 🔑 Secrets 등록
+**[한국어 첫 실행 가이드](docs/first-experiment_KR.md)** |
+**[English first-run guide](docs/first-experiment.md)** |
+**[Batch Runner 문서](batch-runner/README_KR.md)**
 
-**Settings → Secrets and variables → Actions → New repository secret** 에서 필요한 시크릿을 추가하세요:
+---
 
-| Secret 이름 | 값 | 필수? |
+## 왜 RealWorks인가
+
+많은 벤치마크는 텍스트 답변에서 끝납니다. GDPVal은 모델에게 실제 업무와
+닮은 스프레드시트, 보고서, 프레젠테이션, 미디어 등 검토 가능한 파일을
+만들게 합니다. Gold Subset은 **9개 산업, 44개 직종, 220개 태스크**를
+포함합니다.
+
+이 저장소는 해당 태스크를 반복 가능한 루프로 만듭니다.
+**설정 -> 실행 -> 근거 보존 -> 채점 -> 비교**. YAML이 실험 변수를
+정의하고, GitHub Actions가 실행 기록을 남기며, 대시보드는 결과, 실패,
+산출물, 연구 기록을 함께 검토할 수 있게 합니다.
+
+다음 네 가지 신호는 의도적으로 분리합니다.
+
+| 신호 | 증명하는 것 | 증명하지 못하는 것 |
 |---|---|---|
-| `AZURE_OPENAI_API_KEY` | Azure OpenAI API 키 | ✅ Azure 사용 시 |
-| `AZURE_OPENAI_ENDPOINT` | `https://your-resource.openai.azure.com/` | ✅ Azure 사용 시 |
-| `OPENAI_API_KEY` | OpenAI API 키 | OpenAI 사용 시 |
-| `ANTHROPIC_API_KEY` | Anthropic API 키 | Anthropic 사용 시 |
-| `HF_TOKEN` | HuggingFace write 토큰 ([여기서 발급](https://huggingface.co/settings/tokens)) | ✅ 업로드용 |
+| 실행 완료 | 파이프라인이 태스크의 종료 상태에 도달함 | 파일이 정확함 |
+| 산출물 무결성 | 예상 파일이 있고 결정적 검사를 통과함 | 모든 요구사항을 충족함 |
+| Self-QA | 생성 모델이 자신의 출력을 수락하거나 재시도함 | 독립적인 품질 |
+| 외부 채점 | 별도 루브릭 평가가 기록됨 | 모든 사람의 보편적 동의 |
 
-> 💡 전부 다 등록할 필요 없습니다 — 실제로 쓸 provider 것만 먼저 넣으면 됩니다.  
-> Azure 사용자: `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` + `HF_TOKEN` 이 세 개가 우선입니다.
-
-#### 📄 GitHub Pages
-
-**Settings → Pages → Source** → **"GitHub Actions"** 으로 변경 (기본값 "Deploy from a branch" 말고)
-
-#### 🔓 Workflow 권한
-
-**Settings → Actions → General → Workflow permissions:**
-
-- ✅ **"Read and write permissions"** 선택
-- ✅ **"Allow GitHub Actions to create and approve pull requests"** 체크
-- 저장
-
-#### 🧹 자동 정리 (권장)
-
-**Settings → General** → ✅ **"Automatically delete head branches"** 체크
-
-> PR 머지 후 실험 브랜치가 자동으로 삭제됩니다. 깔끔!
+<p align="center">
+  <a href="https://hyeonsangjeon.github.io/gdpval-realworks/">
+    <img src="docs/images/dashboard-leaderboard.png" alt="실험 순위, KPI 카드, 섹터 히트맵이 표시된 GDPVal RealWorks 대시보드" width="840" />
+  </a>
+</p>
+<p align="center"><em>실험 비교, 실패 분석, 외부 채점, Field Notes를 연결한 실행 근거.</em></p>
 
 ---
 
-### 3. 첫 번째 실험 실행
+## 시스템 맵
 
-1. **Actions** 탭 → **"Run GDPVal Batch Experiment"** 선택
-2. **"Run workflow"** 클릭
-3. 입력:
-   - `experiment_yaml`: `exp998_smoke_baseline_sample` (스모크 테스트, 3개 태스크)
-   - `dry_run`: ✅ 체크 (처음엔 업로드 건너뛰기)
-4. **Run workflow** 클릭 🚀
+<p align="center">
+  <picture>
+    <source media="(max-width: 960px)" srcset="docs/images/readme-system-map-mobile-ko.svg" />
+    <img src="docs/images/readme-system-map-ko.svg" alt="실험 YAML에서 실행, 산출물, 채점, 집계, 대시보드로 이어지는 GDPVal RealWorks 시스템 맵" />
+  </picture>
+</p>
 
-```
-✅ Step 0: Bootstrap        → HF 레포 준비 완료
-✅ Step 1: Prepare tasks    → 3개 태스크 필터링 완료
-✅ Step 2: Run inference    → 각 태스크에 LLM 호출 완료
-✅ Step 3: Format results   → JSON + Markdown 생성 완료
-✅ Step 4: Fill parquet     → 제출용 Parquet 준비 완료
-⏭️ Step 5: Validate        → 스킵 (스모크 테스트)
-⏭️ Step 6: Upload          → 스킵 (dry run)
-```
-
-> 🎉 통과하면 `dry_run` 체크 해제하고 본격 실험을 돌리세요!
+Step 0-7은 실험 실행과 게시를 담당합니다. 외부 채점은 별도 파이프라인이며,
+대시보드는 두 결과를 집계하되 같은 측정값으로 취급하지 않습니다.
 
 ---
 
-## 📝 나만의 실험 만들기
+## 운영 통제
 
-`batch-runner/experiments/`에 YAML 파일을 만드세요:
+<p align="center">
+  <picture>
+    <source media="(max-width: 960px)" srcset="docs/images/readme-trust-boundaries-mobile-ko.svg" />
+    <img src="docs/images/readme-trust-boundaries-ko.svg" alt="경로별 인증, 입력, 실행, 게시, agentic preflight 통제" />
+  </picture>
+</p>
 
-```yaml
-experiment:
-  id: "exp001_GPT52Chat_baseline"
-  name: "GPT-5.2 Chat Baseline (전체 220 태스크)"
-  description: "code_interpreter + Self-QA를 사용한 풀 베이스라인 실행."
+아래 내용은 포괄적인 보안 보장이 아니라 코드로 확인할 수 있는 경로별
+통제입니다.
 
-data:
-  source: "HyeonSang/exp001_GPT52Chat_baseline"
-  filter:
-    sector: null          # null = 전체 섹터
-    sample_size: null     # null = 전체 220개
-
-condition_a:
-  name: "Baseline"
-  model:
-    provider: "azure"
-    deployment: "gpt-5.2-chat"
-    temperature: 0.0
-    seed: 42
-  prompt:
-    system: "You are a helpful assistant that completes professional tasks."
-    suffix: "Generate actual files, not descriptions."
-  qa:
-    enabled: true
-    min_score: 6
-    max_retries: 3
-
-# condition_b:            ← A/B 비교용 (선택 사항)
-
-execution:
-  mode: "code_interpreter"
-  max_retries: 5
-  resume_max_rounds: 3
-```
-
-**Actions → Run workflow**에서 `experiment_yaml: exp001_GPT52Chat_baseline`으로 실행하면 됩니다.
-
----
-
-## 🧠 실행 모드
-
-| 모드 | 동작 방식 | 적합한 용도 |
+| 경계 | 현재 강제되는 내용 | 근거 |
 |---|---|---|
-| **`code_interpreter`** | LLM이 Azure/OpenAI **보안 샌드박스** 안에서 코드를 작성하고 실행. 파일이 클라우드에서 생성됨. | ✅ 프로덕션 — 안전하고 강력 |
-| **`subprocess`** | LLM이 코드 생성 → 로컬 격리 임시 디렉토리에서 실행. | OpenAI 외 모델 (Anthropic 등) |
-| **`sandbox`** | 작업별 의존성 탐색, 문서·이미지·데이터·오디오·비디오 Agent Skills, audio/video perception을 격리 실행 경로에 결합. | 멀티모달·재현 가능한 실무 태스크 |
-| **`json_renderer`** | LLM이 JSON 스펙 출력 → **고정 렌더러**가 파일 생성. 모든 모델에 동일한 렌더러 사용. | 모델 간 공정한 A/B 비교 |
+| Azure identity | 배치의 Azure 경로는 GitHub OIDC를 사용하고 `AZURE_OPENAI_API_KEY`를 주입하지 않음 | [`batch-run.yml`](.github/workflows/batch-run.yml), [`llm_client.py`](batch-runner/core/llm_client.py) |
+| 설정 입력 | 인증 정보 없는 job이 실험 이름을 검사하고 YAML을 안전하게 파싱한 뒤 credential job을 시작하며, 일반 배치 경로는 agentic mode를 거부함 | [`batch-run.yml`](.github/workflows/batch-run.yml) |
+| Container sandbox | sandbox 실행은 relay 전체에 immutable image digest를 유지하며, Docker 실행은 network를 끄고 resource limit을 적용함 | [`batch-run.yml`](.github/workflows/batch-run.yml), [`sandbox_runner.py`](batch-runner/core/sandbox_runner.py) |
+| Agentic image supply chain | 수동 protected-main 게시에 immutable dependency lock, digest-pinned base, runtime audit, SBOM 근거를 요구함 | [`build-sandbox-image.yml`](.github/workflows/build-sandbox-image.yml) |
+| Agentic containment preflight | 수동 model-free job이 model/HF credential 부재, 정확한 preloaded image와 AppArmor 입력, containment test, 종료 후 정리를 검사함 | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
+| Dashboard publication | PR에서 aggregate, build, data/browser contract를 실행하고 push/manual deploy job만 Pages/OIDC 권한을 받음 | [`deploy.yml`](.github/workflows/deploy.yml) |
 
-> 🐳 `sandbox`는 `subprocess`에서 드러난 실행 환경의 한계를 분리·관찰하기 위한 후속 실행 모드입니다. 공개 결과는 [exp026 상세](https://hyeonsangjeon.github.io/gdpval-realworks/experiments/exp026)에서 확인할 수 있습니다.
-
----
-
-## 🔬 Self-QA: 내장 품질 리플렉션 게이트
-
-모든 태스크 출력물은 작업하고 있는 LLM이 스스로 검수한 후 수락됩니다:
-Self-QA는 각 산출물을 루브릭 기반 자기평가로 0~10점 척도에서 점수화합니다. 점수가 설정 임계값(기본 6점) 미만이면 리플렉션 루프로 들어가 재시도합니다.
-
-<img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IExSCiAgICB0YXNrWyLtg5zsiqTtgawiXSAtLT4gZ2VuWyJMTE0g7Lac66ClIOyDneyEsSJdIC0tPiBxYVsiU2VsZi1RQSDqsoDsiJgiXSAtLT4gZ2F0ZXsi7KCQ7IiYID49IDY_In0KICAgIGdhdGUgLS0-fOyYiHwgYWNjZXB0WyLsiJjrnb0iXQogICAgZ2F0ZSAtLT587JWE64uI7JikfCByZXRyeVsi7J6s7Iuc64-EICjstZzrjIAgM-2ajCkiXQo=" alt="Self-QA 흐름" />
-
-
-검수 항목: 모든 요구사항 충족? 파일이 실제로 생성됐나? 결과물이 전문적인가?
+기본 3-task smoke는 provider-hosted `code_interpreter`를 사용합니다. Docker
+sandbox와 agentic 통제는 각각 이름이 붙은 경로에만 적용됩니다. 일반 배치
+워크플로는 cloud credential을 사용하기 전에 agentic 실행을 거부하며,
+체크인된 agentic 워크플로는 유료 실행이 아니라 model-free preflight입니다.
 
 ---
 
-## 🏗️ 아키텍처
+## 첫 클라우드 실험
 
-<img src="https://mermaid.ink/img/Zmxvd2NoYXJ0IFRCCiAgICByb290WyJnZHB2YWwtcmVhbHdvcmtzLyJdCgogICAgd2ZbIi5naXRodWIvd29ya2Zsb3dzLzxici8-YmF0Y2gtcnVuLnltbCwgZGVwbG95LnltbCJdCiAgICBiclsiYmF0Y2gtcnVubmVyLzxici8-c3RlcCDsiqTtgazrpr3tirgsIGNvcmUsIGV4cGVyaW1lbnRzLCBwcm9tcHRzLCB0ZXN0cyJdCiAgICBzcmNbInNyYy88YnIvPnBhZ2VzLCBjb21wb25lbnRzIl0KICAgIGRhdGFbImRhdGEvPGJyLz50ZXN0cywgZ3JhZGVzIl0KICAgIHNjcmlwdHNbInNjcmlwdHMvPGJyLz5hZ2dyZWdhdGUtdGVzdHMubWpzLCBhZ2dyZWdhdGUtZ3JhZGVzLm1qcyJdCgogICAgcm9vdCAtLT4gd2YKICAgIHJvb3QgLS0-IGJyCiAgICByb290IC0tPiBzcmMKICAgIHJvb3QgLS0-IGRhdGEKICAgIHJvb3QgLS0-IHNjcmlwdHMK" alt="프로젝트 구조" />
+체크인된
+[`exp998_smoke_baseline_sample.yaml`](batch-runner/experiments/exp998_smoke_baseline_sample.yaml)을
+사용하되, 먼저 `data.source`를 내 Hugging Face namespace의 새 dataset으로
+바꾸세요.
 
+**Actions > Run GDPVal Batch Experiment**에서 다음 값을 사용합니다.
 
----
-
-## 🔄 GitHub Actions 워크플로우
-
-### `batch-run.yml` — 실험 실행
-
-| 항목 | 설명 |
+| 입력 | 첫 실행 값 |
 |---|---|
-| **트리거** | Actions 탭에서 수동 실행 (`workflow_dispatch`) |
-| **입력** | 실험 YAML 파일명 + dry_run 옵션 |
-| **파이프라인** | Step 0 → Step 6 (부트스트랩 → 업로드) |
-| **스마트 스킵** | 스모크 테스트는 검증 스킵; dry_run은 업로드 + PR 스킵 |
-| **자동 PR** | 실험 요약이 담긴 Pull Request 자동 생성 |
-| **아티팩트** | 전체 workspace 30일간 보관 |
-| **타임아웃** | 최대 5시간 |
+| `experiment_yaml` | `exp998_smoke_baseline_sample` |
+| `dry_run` | `true` |
+| `relay_run` | `0` |
+| `wall_timeout` | `290` |
+| `sandbox_image_digest` | 빈 값 |
 
-### `deploy.yml` — 대시보드 배포
+예상 동작은 다음과 같습니다.
 
-| 항목 | 설명 |
+1. Step 0이 일회성 Hugging Face dataset을 생성, 재생성 또는 재사용합니다.
+2. Step 1이 태스크 3개를 결정적으로 선택합니다.
+3. Step 2가 `gpt-5.2-chat`을 호출하고 파일을 만든 뒤 같은 모델의 Self-QA를 재시도할 수 있습니다.
+4. Step 3-4가 포맷된 결과와 3-row Parquet artifact를 만듭니다.
+5. dry run이면서 3-task sample이므로 Step 5를 건너뜁니다.
+6. Step 6의 기본 report 경로는 `gpt-5.4-pro`를 순차적으로 최대 2회 호출하고,
+  오류 시 `gpt-5.2-chat` fallback을 1회 시도합니다. 완료된 호출은 과금될
+  수 있습니다. Narrative 실패 자체는 막지 않지만, 게시 전에 model-free
+  report fallback과 identity 검증을 반드시 통과해야 합니다.
+7. `dry_run: true`이므로 Step 7과 결과 PR을 건너뜁니다.
+
+인증된 batch job이 마지막 `always()` 단계에 도달하면
+`batch-results-<run_id>` artifact 업로드와 30일 보관을 시도합니다. OIDC,
+필수 secret, 비용 경계, artifact, 자주 발생하는 오류는
+**[한국어 전체 가이드](docs/first-experiment_KR.md)**에서 설명합니다.
+
+---
+
+## 실행 모드
+
+| 모드 | 실행 경계 | 적합한 용도 |
+|---|---|---|
+| `code_interpreter` | Provider-hosted code tool과 파일 회수 | 현재 Azure smoke 경로 |
+| `subprocess` | 생성된 Python을 host 임시 디렉터리에서 실행 | 레거시/로컬 호환. 먼저 신뢰 경계를 검토해야 함 |
+| `sandbox` | 가능하면 Docker를 사용하고 network 차단, resource cap, skill, verification, render QA 적용. `auto`는 로컬 fallback 가능 | 재현 가능한 문서·멀티모달 작업 |
+| `json_renderer` | 모델은 spec을 내고 결정적 renderer가 파일 생성 | renderer가 통제된 A/B 비교 |
+
+Docker fallback을 허용하지 않으려면 `execution.sandbox.use_docker`를
+`always`로 설정합니다. 실행 모드를 바꾸기 전에
+**[sandbox 운영 가이드](batch-runner/sandbox/README.md)**를 읽으세요.
+
+### Self-QA는 외부 채점이 아닙니다
+
+Self-QA는 산출물을 만든 같은 모델에게 결과를 검사하게 하고 설정한
+threshold 아래에서 재시도합니다. inference-time reflection gate입니다.
+독립 루브릭 채점은 별도 파이프라인에서 기록하고 별도 신호로 표시합니다.
+
+---
+
+## 대시보드
+
+**[라이브 대시보드](https://hyeonsangjeon.github.io/gdpval-realworks/)**는
+저장소에서 생성한 데이터를 읽는 정적 React 애플리케이션입니다.
+
+| 화면 | 확인할 수 있는 것 |
 |---|---|
-| **트리거** | `main` 푸시 시 자동 실행 또는 수동 |
-| **빌드** | 테스트/채점 데이터 집계 → React 빌드 → GitHub Pages |
-| **범위** | `data/`, `src/`, `scripts/` 변경 시에만 실행 |
+| Leaderboard와 trends | 실험별 완료율, latency, 외부 채점 비교 |
+| Sector heatmap | 9개 산업의 성능 차이 |
+| Experiment detail | 220개 태스크 상태, 파일, prompt, retry, error |
+| Grading analysis | 근거가 연결된 rubric 결과와 judge metadata |
+| RealWorks Field Notes | 근거의 한계를 명시한 시간순 엔지니어링 의사결정 |
+
+구현 상세는 [`src/README_KR.md`](src/README_KR.md)에 있습니다.
 
 ---
 
-## 🖥️ 대시보드
+## 개발과 검증
 
-> **[→ 라이브 대시보드](https://hyeonsangjeon.github.io/gdpval-realworks/)**
+대시보드 검증에는 Node.js 20 이상이 필요합니다.
 
-인터랙티브 실험 분석 — 리더보드, 섹터 히트맵, 에러 분석, 프롬프트 아키텍처 뷰어, 근거가 연결된 RealWorks 독립 기록.
+```bash
+npm ci
+npm run aggregate
+npm run test:aggregate
+npm run build
+```
 
-| 기능 | 설명 |
-|------|------|
-| **리더보드** | 실험 랭킹 — 전략, 성공률, QA 점수 |
-| **섹터 히트맵** | 9개 섹터 × N개 실험 성공률 매트릭스 |
-| **트렌드** | 실험 간 성공률 / QA / 지연시간 추이 차트 |
-| **실행 에러** | 예외 유형 분포 차트, 복구 퍼널, AI 기반 실패 인사이트 내러티브 |
-| **프롬프트 뷰어** | LLM에 전달된 프롬프트 구조 확인 — system, user, QA, config |
-| **채점 분석** | 외부 평가 점수 (OpenAI Evals) |
-| **실험 상세** | 220개 태스크 드릴다운 — 섹터, 상태 필터, 검색 |
-| **RealWorks Field Notes** | 반응형 히어로 장면, 근거·주의가 포함된 비교 차트, 실패·의사결정의 독립 기록 |
-
-React 18 + TypeScript + Vite + Tailwind + Recharts + Framer Motion으로 구축.  
-`main` 브랜치 푸시 시 GitHub Pages에 자동 배포됩니다.
-
-📖 **[대시보드 문서 →](src/README_KR.md)** · 🇺🇸 **[English →](src/README.md)**
-
----
-
-## 🧪 테스트
+백엔드 unit test는 model credential 없이 실행할 수 있습니다.
 
 ```bash
 cd batch-runner
+python -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
-
-# 유닛 테스트만 (API 키 불필요)
 pytest
-
-# 통합 테스트 (실제 인증 정보 필요)
-pytest -m integration
-
-# 커버리지 포함
-pytest --cov=core --cov-report=html
 ```
 
-### 🖥️ 로컬 실행 (단계별)
+Integration test, inference, grading, upload, workflow dispatch는 cloud
+credential을 사용하거나 비용을 발생시킬 수 있습니다. 의도한 경우에만
+실행하세요.
 
-```bash
-cd batch-runner
-export HF_TOKEN="hf_xxx"
-export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
-export AZURE_OPENAI_API_KEY="xxx"
+## 저장소 구조
 
-./step0_bootstrap.sh experiments/exp998_smoke_baseline_sample.yaml
-./step1_prepare_tasks.sh experiments/exp998_smoke_baseline_sample.yaml
-./step2_run_inference.sh condition_a
-./step3_format_results.sh
-./step4_fill_parquet.sh
-./step5_validate.sh
-./step6_report.sh
-./step7_upload_hf.sh --test
-```
-
-> 💡 로컬에서도 실행 가능하지만, 220개 전체 태스크는 **GitHub Actions**를 추천합니다.  
-> 배치 워크플로우가 TPM (분당 토큰 수) 쿼터가 허용하는 만큼 병렬 처리합니다 — 클라우드에 맡기고 커피 한 잔 하세요. ☕
+| 경로 | 역할 |
+|---|---|
+| [`batch-runner/`](batch-runner/README_KR.md) | 실험 설정, 실행 파이프라인, 채점, prompt, test |
+| [`batch-runner/sandbox/`](batch-runner/sandbox/README.md) | Container image, 실행 통제, skill, verification, render QA |
+| [`src/`](src/README_KR.md) | React dashboard page, component, hook, data presentation |
+| [`scripts/`](scripts/) | 결정적 집계와 분석 도구 |
+| [`data/`](data/) | 체크인된 실험 요약과 외부 채점 기록 |
+| [`.github/workflows/`](.github/workflows/) | Batch, grading, sandbox, validation, Pages 자동화 |
 
 ---
 
-## 📚 참고 자료
+## 참고 자료
 
-- **GDPVal 논문**: [arXiv:2510.04374](https://arxiv.org/abs/2510.04374)
-- **GDPVal 데이터셋**: [openai/gdpval](https://huggingface.co/datasets/openai/gdpval)
-- **GDPVal 채점**: [evals.openai.com](https://evals.openai.com/)
-- **Azure OpenAI Responses API**: [공식 문서](https://learn.microsoft.com/azure/ai-services/openai/)
+- [GDPVal 논문](https://arxiv.org/abs/2510.04374)
+- [GDPVal 데이터셋](https://huggingface.co/datasets/openai/gdpval)
+- [OpenAI Evals](https://evals.openai.com/)
+- [Azure OpenAI 문서](https://learn.microsoft.com/azure/ai-services/openai/)
 
----
+## 저자
 
-## 👤 저자
+**전현상 (Hyeonsang Jeon)**<br/>
+Sr. Solution Engineer, Global Black Belt - AI Apps | Microsoft Asia, Korea<br/>
+[GitHub](https://github.com/hyeonsangjeon) |
+[라이브 대시보드](https://hyeonsangjeon.github.io/gdpval-realworks/)
 
-**전현상 (Hyeonsang Jeon)**  
-Sr. Solution Engineer · Global Black Belt — AI Apps | Microsoft Asia, Korea  
-[![GitHub](https://img.shields.io/badge/GitHub-hyeonsangjeon-181717?logo=github)](https://github.com/hyeonsangjeon)
-[![Dashboard](https://img.shields.io/badge/라이브%20대시보드-GDPVal-blueviolet?logo=react)](https://hyeonsangjeon.github.io/gdpval-realworks/)
+## 라이선스
 
----
-
-## 📄 라이선스
-
-MIT — 자세한 내용은 [LICENSE](LICENSE) 파일을 참고하세요.
+MIT. 자세한 내용은 [`LICENSE`](LICENSE)를 참고하세요.

--- a/batch-runner/core/experiment_config.py
+++ b/batch-runner/core/experiment_config.py
@@ -21,6 +21,10 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, Literal
 
 from core.config import DEFAULT_TOKENS
+from core.repository_identity import (
+    validate_experiment_id,
+    validate_hf_dataset_repo_id,
+)
 from core.agentic_experiments import (
     validate_agentic_budget_for_experiment,
     validate_agentic_experiment_identity,
@@ -409,8 +413,17 @@ class ExperimentConfig:
         # Check required fields
         if not self.experiment_id:
             errors.append("experiment.id is required")
+        else:
+            try:
+                validate_experiment_id(self.experiment_id)
+            except ValueError as exc:
+                errors.append(str(exc))
         if not self.name:
             errors.append("experiment.name is required")
+        try:
+            validate_hf_dataset_repo_id(self.data_filter.source)
+        except ValueError as exc:
+            errors.append(str(exc))
 
         # Check conditions
         if not self.condition_a.name:

--- a/batch-runner/core/prepared_fingerprint.py
+++ b/batch-runner/core/prepared_fingerprint.py
@@ -1,0 +1,40 @@
+"""Canonical identity for the prepared Step 1 payload."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+FINGERPRINT_RE = re.compile(r"[0-9a-f]{64}")
+
+
+def prepared_fingerprint(payload: dict[str, Any]) -> str:
+    """Hash the public prepared payload, excluding path and fingerprint fields."""
+    if not isinstance(payload, dict):
+        raise ValueError("prepared payload must be an object")
+    canonical = {
+        key: value
+        for key, value in payload.items()
+        if key not in {"config_path", "prepared_fingerprint"}
+    }
+    serialized = json.dumps(
+        canonical,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def validate_prepared_fingerprint(payload: dict[str, Any]) -> str:
+    """Return the fingerprint only when it matches the current payload bytes."""
+    claimed = payload.get("prepared_fingerprint")
+    if not isinstance(claimed, str) or not FINGERPRINT_RE.fullmatch(claimed):
+        raise ValueError("prepared task fingerprint is missing or invalid")
+    actual = prepared_fingerprint(payload)
+    if claimed != actual:
+        raise ValueError("prepared task fingerprint does not match payload")
+    return claimed

--- a/batch-runner/core/repository_identity.py
+++ b/batch-runner/core/repository_identity.py
@@ -1,0 +1,41 @@
+"""Validated repository and experiment identifiers used across the pipeline."""
+
+from __future__ import annotations
+
+import re
+
+_EXPERIMENT_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,99}")
+_HF_COMPONENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*")
+
+
+def validate_experiment_id(value: object) -> str:
+    """Return a Git path/ref-safe experiment identifier."""
+    if (
+        not isinstance(value, str)
+        or not _EXPERIMENT_ID_RE.fullmatch(value)
+        or ".." in value
+        or value.endswith((".", ".lock"))
+    ):
+        raise ValueError("experiment.id must be a safe identifier")
+    return value
+
+
+def validate_hf_dataset_repo_id(value: object) -> str:
+    """Return a canonical Hugging Face ``owner/repository`` dataset ID."""
+    if not isinstance(value, str) or len(value) > 96 or value.count("/") != 1:
+        raise ValueError("data.source must be a valid owner/repository ID")
+    owner, repo = value.split("/", 1)
+    if not owner or not repo:
+        raise ValueError("data.source must be a valid owner/repository ID")
+    for component in (owner, repo):
+        if (
+            not _HF_COMPONENT_RE.fullmatch(component)
+            or ".." in component
+            or "--" in component
+            or component.startswith((".", "-"))
+            or component.endswith((".", "-"))
+        ):
+            raise ValueError("data.source must be a valid owner/repository ID")
+    if repo.endswith(".git"):
+        raise ValueError("data.source must be a valid owner/repository ID")
+    return value

--- a/batch-runner/step1_prepare_tasks.py
+++ b/batch-runner/step1_prepare_tasks.py
@@ -21,6 +21,7 @@ from core.config import WORKSPACE_DIR
 from core.data_loader import GDPValDataLoader
 from core.experiment_config import ExperimentConfig
 from core.needs_files import NeedsFilesManifest
+from core.prepared_fingerprint import prepared_fingerprint
 
 
 def _public_agentic_config(value):
@@ -189,6 +190,7 @@ def prepare_tasks(config_path: str) -> dict:
         "condition_b": _condition_dict(config.condition_b) if config.condition_b else None,
         "tasks": task_list,
     }
+    output["prepared_fingerprint"] = prepared_fingerprint(output)
 
     # 7. Save
     output_path = WORKSPACE_DIR / "step1_tasks_prepared.json"

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -63,6 +63,7 @@ from core.execution_metrics import (
 from core.file_preview import generate_all_previews
 from core.llm_client import create_provider_client, complete
 from core.needs_files import NeedsFilesManifest
+from core.prepared_fingerprint import validate_prepared_fingerprint
 from core.audio_analyzer import analyze_audio_files, filter_audio_files
 from core.video_analyzer import (
     analyze_video_files,
@@ -1591,6 +1592,24 @@ def _execute_single_task(
 # ── Incremental save ──────────────────────────────────────────────────────
 
 
+def _resolve_run_identity(experiment_id: str) -> str:
+    lineage = os.getenv("GDPVAL_RELAY_LINEAGE_ID", "").strip()
+    if lineage:
+        return lineage
+    github_run = os.getenv("GITHUB_RUN_ID", "local")
+    github_attempt = os.getenv("GITHUB_RUN_ATTEMPT", "1")
+    return f"{experiment_id}:{github_run}:{github_attempt}"
+
+
+def _condition_workspace_paths(condition_key: str) -> tuple[Path, Path]:
+    if condition_key not in {"condition_a", "condition_b"}:
+        raise ValueError("condition key is invalid")
+    return (
+        WORKSPACE_DIR / f"step2_inference_progress_{condition_key}.json",
+        WORKSPACE_DIR / f"step2_inference_results_{condition_key}.json",
+    )
+
+
 def _save_progress(
     experiment_id: str,
     condition_name: str,
@@ -1603,6 +1622,7 @@ def _save_progress(
     run_id: str,
     condition_identity: str,
     ordered_task_ids: List[str],
+    prepared_fingerprint: str = "",
     resume_round: int = 0,
 ) -> None:
     """Atomic incremental save."""
@@ -1620,6 +1640,7 @@ def _save_progress(
         "run_id": run_id,
         "execution_mode": execution_mode,
         "ordered_task_ids": ordered_task_ids,
+        "prepared_fingerprint": prepared_fingerprint,
         "total_tasks": total_tasks,
         "started_at": started_at,
         "resume_round": resume_round,
@@ -1654,6 +1675,7 @@ def _load_and_validate_progress(
     run_id: str,
     execution_mode: str,
     ordered_task_ids: List[str],
+    prepared_fingerprint: str = "",
 ) -> dict:
     with path.open("r", encoding="utf-8") as stream:
         progress = json.load(stream)
@@ -1667,6 +1689,7 @@ def _load_and_validate_progress(
         "run_id": run_id,
         "execution_mode": execution_mode,
         "ordered_task_ids": ordered_task_ids,
+        "prepared_fingerprint": prepared_fingerprint,
         "total_tasks": len(ordered_task_ids),
     }
     if any(progress.get(key) != value for key, value in expected_identity.items()):
@@ -1803,6 +1826,11 @@ def run_inference(
         sys.exit(1)
 
     experiment_id = prepared["experiment_id"]
+    try:
+        prepared_fingerprint = validate_prepared_fingerprint(prepared)
+    except ValueError as exc:
+        print(f"❌ {exc}")
+        sys.exit(1)
     ordered_task_ids = [task["task_id"] for task in tasks]
     if (
         any(not isinstance(task_id, str) or not task_id for task_id in ordered_task_ids)
@@ -2097,9 +2125,7 @@ def run_inference(
         print(f"   Paired run:         {run_identity}")
         print(f"   Workflow audit:     {workflow_audit}")
     else:
-        github_run = os.getenv("GITHUB_RUN_ID", "local")
-        github_attempt = os.getenv("GITHUB_RUN_ATTEMPT", "1")
-        run_identity = f"{experiment_id}:{github_run}:{github_attempt}"
+        run_identity = _resolve_run_identity(experiment_id)
     try:
         executor = TaskExecutor(
             mode=execution_mode, llm_client=client, tokens=tokens_cfg,
@@ -2136,7 +2162,10 @@ def run_inference(
     if len(task_map) != len(tasks):
         raise AssertionError("prepared task map identity drift")
     total = len(tasks)
-    progress_path = WORKSPACE_DIR / "step2_inference_progress.json"
+    progress_path, output_path = _condition_workspace_paths(condition_key)
+    legacy_progress_path = WORKSPACE_DIR / "step2_inference_progress.json"
+    if condition_key == "condition_a" and not progress_path.exists() and legacy_progress_path.exists():
+        progress_path.write_bytes(legacy_progress_path.read_bytes())
     started_at = datetime.now(timezone.utc).isoformat()
 
     def _persist_progress(current: dict) -> None:
@@ -2151,8 +2180,11 @@ def run_inference(
             run_id=run_identity,
             condition_identity=execution_condition,
             ordered_task_ids=ordered_task_ids,
+            prepared_fingerprint=prepared_fingerprint,
             resume_round=int(current.get("resume_round", 0) or 0),
         )
+        if condition_key == "condition_a":
+            legacy_progress_path.write_bytes(progress_path.read_bytes())
 
     # ── Helper: execute one task with QA loop ──
 
@@ -2533,6 +2565,7 @@ def run_inference(
                 run_id=run_identity,
                 execution_mode=execution_mode,
                 ordered_task_ids=ordered_task_ids,
+                prepared_fingerprint=prepared_fingerprint,
             )
         except Exception as exc:
             print(f"❌ progress checkpoint rejected: {exc}")
@@ -2633,6 +2666,7 @@ def run_inference(
             "run_id": run_identity,
             "execution_mode": execution_mode,
             "ordered_task_ids": ordered_task_ids,
+            "prepared_fingerprint": prepared_fingerprint,
             "total_tasks": total,
             "started_at": started_at,
             "resume_round": 0,
@@ -2769,6 +2803,7 @@ def run_inference(
         "run_id": run_identity,
         "execution_mode": execution_mode,
         "ordered_task_ids": ordered_task_ids,
+        "prepared_fingerprint": prepared_fingerprint,
         "model": model,
         "started_at": started_at,
         "completed_at": datetime.now(timezone.utc).isoformat(),
@@ -2782,7 +2817,6 @@ def run_inference(
         "results": results,
     }
 
-    output_path = WORKSPACE_DIR / "step2_inference_results.json"
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(
             final_output,
@@ -2792,6 +2826,9 @@ def run_inference(
             default=str,
             allow_nan=False,
         )
+    if condition_key == "condition_a":
+        legacy_output_path = WORKSPACE_DIR / "step2_inference_results.json"
+        legacy_output_path.write_bytes(output_path.read_bytes())
 
     print(f"\n{'='*60}")
     print(f"✅ Step 2 complete: {output_path}")

--- a/batch-runner/step3_format_results.py
+++ b/batch-runner/step3_format_results.py
@@ -20,6 +20,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from core.config import WORKSPACE_DIR, BATCH_RUNNER_ROOT
+from core.prepared_fingerprint import validate_prepared_fingerprint
+from core.repository_identity import (
+    validate_experiment_id,
+    validate_hf_dataset_repo_id,
+)
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────
@@ -105,6 +110,84 @@ def _write_json_outputs(data: dict, *paths: Path) -> None:
         path.write_text(serialized, encoding="utf-8")
 
 
+def _source_repo_id(prepared: dict) -> str:
+    """Return the validated Hugging Face target carried by Step 1."""
+    try:
+        return validate_hf_dataset_repo_id(prepared.get("source"))
+    except ValueError as exc:
+        raise ValueError("Prepared tasks contain an invalid source repository") from exc
+
+
+def _ordered_task_ids(payload: dict, key: str, label: str) -> list[str]:
+    values = payload.get(key)
+    if (
+        not isinstance(values, list)
+        or not values
+        or not all(
+            isinstance(task_id, str)
+            and task_id.strip() == task_id
+            and task_id
+            for task_id in values
+        )
+        or len(values) != len(set(values))
+    ):
+        raise ValueError(f"{label} task order is invalid")
+    return values
+
+
+def _result_task_ids(payload: dict, label: str) -> list[str]:
+    results = payload.get("results") if label == "inference" else payload.get("tasks")
+    if not isinstance(results, list):
+        raise ValueError(f"{label} result task set is missing")
+    values = [item.get("task_id") for item in results if isinstance(item, dict)]
+    if len(values) != len(results):
+        raise ValueError(f"{label} result task set is invalid")
+    return _ordered_task_ids({"ids": values}, "ids", f"{label} result")
+
+
+def _validate_input_identity(prepared: dict, inference: dict) -> None:
+    """Reject stale/mixed Step 1 and Step 2 workspace inputs."""
+    prepared_experiment = prepared.get("experiment_id")
+    inference_experiment = inference.get("experiment_id")
+    try:
+        validate_experiment_id(prepared_experiment)
+        validate_experiment_id(inference_experiment)
+    except ValueError as exc:
+        raise ValueError("Prepared and inference experiment identity mismatch") from exc
+    if prepared_experiment != inference_experiment:
+        raise ValueError("Prepared and inference experiment identity mismatch")
+
+    prepared_source = _source_repo_id(prepared)
+    inference_source = inference.get("source")
+    if (
+        validate_hf_dataset_repo_id(inference_source) != prepared_source
+    ):
+        raise ValueError("Prepared and inference source repository mismatch")
+
+    task_scope = prepared.get("task_scope")
+    if not isinstance(task_scope, dict):
+        raise ValueError("Prepared task order is missing")
+    prepared_order = _ordered_task_ids(
+        task_scope, "task_ids", "prepared"
+    )
+    inference_order = _ordered_task_ids(
+        inference, "ordered_task_ids", "inference"
+    )
+    if prepared_order != inference_order:
+        raise ValueError("Prepared and inference task order mismatch")
+    prepared_fingerprint = validate_prepared_fingerprint(prepared)
+    inference_fingerprint = inference.get("prepared_fingerprint")
+    if (
+        not isinstance(inference_fingerprint, str)
+        or prepared_fingerprint != inference_fingerprint
+    ):
+        raise ValueError("Prepared and inference fingerprint mismatch")
+    if _result_task_ids(prepared, "prepared") != prepared_order:
+        raise ValueError("Prepared result task set does not match task order")
+    if _result_task_ids(inference, "inference") != inference_order:
+        raise ValueError("Inference result task set does not match task order")
+
+
 # ── Main ───────────────────────────────────────────────────────────────────
 
 
@@ -127,6 +210,8 @@ def format_results():
 
     with open(prepared_path, "r", encoding="utf-8") as f:
         prepared = json.load(f)
+
+    _validate_input_identity(prepared, inference)
 
     experiment_id = inference["experiment_id"]
     condition_name = inference["condition"]
@@ -196,6 +281,8 @@ def format_results():
     final_json = {
         "experiment_id": experiment_id,
         "experiment_name": prepared.get("experiment_name", ""),
+        "source_repo_id": _source_repo_id(prepared),
+        "prepared_fingerprint": prepared["prepared_fingerprint"],
         "condition_name": condition_name,
         "execution_mode": inference.get("execution_mode", ""),
         "model": inference.get("model", ""),
@@ -345,7 +432,7 @@ def format_results():
     md_path = results_dir / f"{experiment_id}.md"
     md_path.write_text("\n".join(md_lines), encoding="utf-8")
 
-    print(f"\n✅ Step 3 complete:")
+    print("\n✅ Step 3 complete:")
     print(f"   JSON: {json_path}")
     print(f"   MD:   {md_path}")
     print(f"   Duration: {duration}")

--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -5,14 +5,16 @@ Reads workspace/result.json and generates two output files under workspace/repor
   - report_data.json : structured JSON for dashboard rendering
   - report.md        : human-readable Markdown report
 
-Narrative sections (overview, quality_analysis, failure_patterns, recommendations) are
-generated via a single LLM call using the same model as the experiment.
+Narrative sections use the two-call GPT-5.4 Pro analyzer with a one-call
+experiment-model fallback. Step 6 always emits a pre-grading report; external
+grading remains a separate pipeline.
 
 Usage:
     python step6_report.py                          # default: workspace/result.json
     python step6_report.py --result-json path/to/result.json
     python step6_report.py --output-dir path/to/report/
     python step6_report.py --no-narrative           # skip LLM call
+    python step6_report.py --dry-run                 # mark report unpublished
 """
 
 from __future__ import annotations
@@ -39,13 +41,16 @@ from core.narrative_analyzer import (  # noqa: E402
     _build_grading_guard_clause,
     _build_grading_results_section,
 )
+from core.repository_identity import (  # noqa: E402
+    validate_experiment_id,
+    validate_hf_dataset_repo_id,
+)
 
 
 # ── Defaults ──────────────────────────────────────────────────────────────
 
 DEFAULT_RESULT_JSON = WORKSPACE_DIR / "result.json"
 DEFAULT_OUTPUT_DIR = WORKSPACE_DIR / "report"
-GRADE_DIR = _SCRIPT_DIR.parent / "data" / "grades"
 
 
 # ── V2 manifest helpers ───────────────────────────────────────────────────
@@ -102,24 +107,26 @@ def _find_result_json(default_path: Path) -> Path:
     sys.exit(1)
 
 
-def _load_grade_for_experiment(exp_id: str) -> dict | None:
-    """Load the most recent schema v1.0 grade JSON for an experiment."""
-    candidates = sorted(
-        GRADE_DIR.glob(f"{exp_id}__*.json"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    for path in candidates:
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                grade = json.load(f)
-        except Exception:
-            continue
-        if grade.get("_meta", {}).get("is_dummy") is True:
-            continue
-        if grade.get("schema_version") == "1.0":
-            return grade
-    return None
+def _validated_source_repo_id(data: dict) -> str | None:
+    """Return a safe HF repository ID, preserving old reports with no source."""
+    source = data.get("source_repo_id")
+    if source in (None, ""):
+        return None
+    try:
+        return validate_hf_dataset_repo_id(source)
+    except ValueError as exc:
+        raise ValueError(
+            "Result JSON contains an invalid source repository"
+        ) from exc
+
+
+def _validated_experiment_id(data: dict) -> str:
+    try:
+        return validate_experiment_id(data.get("experiment_id"))
+    except ValueError as exc:
+        raise ValueError(
+            "Result JSON contains an invalid experiment identifier"
+        ) from exc
 
 
 def _compute_summary(data: dict) -> dict:
@@ -454,6 +461,17 @@ def _generate_narrative(
         retried_count = summary["retried_count"]
         grading_guard = _build_grading_guard_clause(grade)
         grading_results_section = _build_grading_results_section(grade)
+        overview_instruction = (
+            "Describe execution outcomes as Self-QA signals, then separately "
+            "summarize the provided automated LLM-judge grade. Never present "
+            "either source as human expert review."
+            if grade is not None
+            else
+            "These are self-assessed scores from the LLM during execution, "
+            "not external grading results. Use language such as "
+            "'self-assessed confidence', 'task completion rate', and "
+            "'LLM-evaluated quality'."
+        )
 
         prompt_content = f"""You are a technical evaluator reviewing an LLM experiment run.
 
@@ -484,7 +502,7 @@ IMPORTANT CONSTRAINTS:
 
 Return ONLY valid JSON with these exact keys (no markdown code fences):
 {{
-  "overview": "2-3 paragraphs describing: what experiment was run, the task execution outcomes based on Self-QA confidence scores, and key highlights. IMPORTANT: These are self-assessed scores from the LLM during execution, NOT external grading results. Frame accordingly — use language like 'self-assessed confidence', 'task completion rate', 'LLM-evaluated quality' rather than 'performance score' or 'grading result'.",
+    "overview": "2-3 paragraphs describing what experiment was run, task execution outcomes, and key highlights. IMPORTANT: {overview_instruction}",
   "quality_analysis": "2-3 paragraphs: QA score patterns, notable issues, occupation/sector observations",
   "failure_patterns": "Analysis of errors and retries. Empty string if no failures.",
   "recommendations": "2-3 actionable suggestions for improving the next experiment run"
@@ -525,18 +543,28 @@ def _build_report_data(data: dict, narrative: dict, summary: dict,
                        sector_breakdown: list[dict], task_results: list[dict],
                        error_tasks: list[dict],
                        execution_metrics: dict | None = None,
-                       agentic_metrics: dict | None = None) -> dict:
+                       agentic_metrics: dict | None = None,
+                       dry_run: bool = False) -> dict:
     meta_date = (data.get("started_at") or "")[:10]
+    grading_referenced = bool(narrative.get("grading_referenced", False))
     report = {
         "meta": {
-            "experiment_id": data.get("experiment_id", ""),
+            "experiment_id": _validated_experiment_id(data),
             "experiment_name": data.get("experiment_name", ""),
             "condition_name": data.get("condition_name", ""),
             "model": data.get("model", ""),
             "execution_mode": data.get("execution_mode", ""),
             "date": meta_date,
             "duration": data.get("duration", ""),
-            "report_scope": "self_assessed_pre_grading",
+            "source_repo_id": _validated_source_repo_id(data),
+            "publication_plan": (
+                "dry_run_no_step7" if dry_run else "step7_upload_requested"
+            ),
+            "report_scope": (
+                "graded"
+                if grading_referenced
+                else "self_assessed_pre_grading"
+            ),
         },
         "summary": summary,
         "sector_breakdown": sector_breakdown,
@@ -547,7 +575,7 @@ def _build_report_data(data: dict, narrative: dict, summary: dict,
             "quality_analysis": narrative.get("quality_analysis", ""),
             "failure_patterns": narrative.get("failure_patterns", ""),
             "recommendations": narrative.get("recommendations", ""),
-            "grading_referenced": bool(narrative.get("grading_referenced", False)),
+            "grading_referenced": grading_referenced,
             "grade_source": narrative.get("grade_source"),
         },
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -672,9 +700,7 @@ def _build_markdown(rd: dict) -> str:
     lines: list[str] = []
 
     # 1. Header
-    hf_user = "HyeonSang"
     experiment_id = meta['experiment_id']
-    hf_base = f"https://huggingface.co/datasets/{hf_user}/{experiment_id}"
     lines += [
         f"# Experiment Report: {meta['experiment_name']}",
         "",
@@ -687,11 +713,33 @@ def _build_markdown(rd: dict) -> str:
         f"| **Date** | {meta['date']} |",
         f"| **Duration** | {meta['duration']} |",
         f"| **Generated At** | {rd['generated_at']} |",
-        f"| 🤗 HF Dataset | [{experiment_id}]({hf_base}) |",
-        f"| 📊 Self-Report | [self_report.json]({hf_base}/blob/main/self_report.json) |",
-        "| 📊 Grading | ⏳ Awaiting (`scores.json`) |",
-        "",
     ]
+    source_repo_id = meta.get("source_repo_id")
+    if source_repo_id:
+        hf_base = f"https://huggingface.co/datasets/{source_repo_id}"
+        if meta.get("publication_plan") == "dry_run_no_step7":
+            lines.append(
+                f"| 🤗 HF Target (bootstrap) | [{source_repo_id}]({hf_base}) |"
+            )
+            lines.append("| 📊 Self-Report | Local artifact only (dry run; not published) |")
+        else:
+            lines.append(f"| 🤗 HF Target | [{source_repo_id}]({hf_base}) |")
+            lines.append(
+                "| 📊 Self-Report | Prepared locally; Step 7 upload requested "
+                "but not verified by this report |"
+            )
+    else:
+        lines.append("| 🤗 HF Target | Not recorded in this legacy result |")
+    if narrative.get("grading_referenced"):
+        grade_source = narrative.get("grade_source") or {}
+        lines.append(
+            "| 📊 Grading | Automated LLM-judge: "
+            f"{grade_source.get('model', 'unknown')} / rubric "
+            f"{grade_source.get('rubric_sha', 'unknown')} |"
+        )
+    else:
+        lines.append("| 📊 Grading | ⏳ Awaiting external grading |")
+    lines.append("")
 
     execution_metrics = rd.get("execution_metrics")
     if execution_metrics:
@@ -730,12 +778,24 @@ def _build_markdown(rd: dict) -> str:
 
     # 2. Execution Summary
     if narrative.get("overview"):
+        if narrative.get("grading_referenced"):
+            summary_heading = "## Execution Summary *(Self-QA + Automated LLM-Judge)*"
+            summary_note = (
+                "> **Evidence boundary:** Task execution and retry observations use "
+                "same-model Self-QA. External quality signals come from the separately "
+                "provided automated LLM-judge grade; neither is human expert review."
+            )
+        else:
+            summary_heading = "## Execution Summary *(Self-Assessed, Pre-Grading)*"
+            summary_note = (
+                "> **Note:** This summary is based on the LLM's self-assessed "
+                "confidence scores (Self-QA) during task execution — not on external "
+                "grading results. Actual grading scores are not yet available."
+            )
         lines += [
-            "## Execution Summary *(Self-Assessed, Pre-Grading)*",
+            summary_heading,
             "",
-            "> **Note:** This summary is based on the LLM's self-assessed confidence scores (Self-QA)"
-            " during task execution — not on external grading results."
-            " Actual grading scores from evaluators are not yet available at this stage.",
+            summary_note,
             "",
             narrative["overview"],
             "",
@@ -1033,6 +1093,18 @@ def _build_html(rd: dict) -> str:
             <div class='narrative'><p>{nl2br(narrative['recommendations'])}</p></div>
         </section>"""
 
+    if narrative.get("grading_referenced"):
+        execution_summary_label = "Execution Summary (Self-QA + Automated LLM-Judge)"
+        execution_summary_note = (
+            "Execution signals use same-model Self-QA; external quality uses the "
+            "separately provided automated LLM-judge grade. Neither is human review."
+        )
+    else:
+        execution_summary_label = "Execution Summary (Self-Assessed)"
+        execution_summary_note = (
+            "Based on LLM Self-QA confidence scores; external grading is not yet available."
+        )
+
     qa_issues_section = ""
     if qa_issues_html:
         qa_issues_section = f"""
@@ -1148,8 +1220,8 @@ def _build_html(rd: dict) -> str:
 
   <!-- Execution Summary -->
   {f'''<section>
-    <h2>Execution Summary (Self-Assessed)</h2>
-    <p class="narrative" style="color:#888;font-size:0.85rem;margin-bottom:12px;">Based on LLM self-QA confidence scores · External grading scores not yet available</p>
+    <h2>{execution_summary_label}</h2>
+    <p class="narrative" style="color:#888;font-size:0.85rem;margin-bottom:12px;">{execution_summary_note}</p>
     <div class="narrative"><p>{nl2br(narrative['overview'])}</p></div>
   </section>''' if narrative.get('overview') else ''}
 
@@ -1207,13 +1279,15 @@ if (typeof window !== 'undefined') {{ window.report_data = report_data; }}
 # ── Output path resolution ────────────────────────────────────────────────
 
 
-def _resolve_output_dir(explicit_output_dir: Path = None) -> Path:
+def _resolve_output_dir(
+    explicit_output_dir: Path = None,
+    result_json_path: Path = DEFAULT_RESULT_JSON,
+) -> Path:
     """Resolve the report output directory.
 
     Priority:
       1. CLI --output-dir argument (explicit override)
-      2. results/<experiment_id>/report/  (experiment-scoped, preferred)
-      3. workspace/report/  (fallback)
+    2. results/<experiment_id>/report/ from the selected result JSON
 
     Creates the directory if it does not exist.
     """
@@ -1222,27 +1296,15 @@ def _resolve_output_dir(explicit_output_dir: Path = None) -> Path:
         out.mkdir(parents=True, exist_ok=True)
         return out
 
-    # Try to read experiment_id from workspace JSON files
-    experiment_id = None
-    for json_path in [
-        WORKSPACE_DIR / "step2_inference_results.json",
-        WORKSPACE_DIR / "step1_tasks_prepared.json",
-    ]:
-        if json_path.exists():
-            try:
-                data = json.loads(json_path.read_text())
-                experiment_id = data.get("experiment_id", "").strip()
-                if experiment_id:
-                    break
-            except Exception:
-                pass
-
-    if experiment_id:
-        # batch-runner/results/<experiment_id>/report/
-        out = _SCRIPT_DIR / "results" / experiment_id / "report"
-    else:
-        # fallback
-        out = WORKSPACE_DIR / "report"
+    result_path = _find_result_json(Path(result_json_path))
+    try:
+        data = json.loads(result_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Result JSON is malformed: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("Result JSON root must be an object")
+    experiment_id = _validated_experiment_id(data)
+    out = _SCRIPT_DIR / "results" / experiment_id / "report"
 
     out.mkdir(parents=True, exist_ok=True)
     return out
@@ -1251,7 +1313,12 @@ def _resolve_output_dir(explicit_output_dir: Path = None) -> Path:
 # ── Main ──────────────────────────────────────────────────────────────────
 
 
-def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool = False) -> None:
+def generate_report(
+    result_json_path: Path,
+    output_dir: Path,
+    no_narrative: bool = False,
+    dry_run: bool = False,
+) -> None:
     print("============================================================")
     print("📝 Step 6: Generate Experiment Report")
     print("============================================================")
@@ -1262,6 +1329,9 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
 
     with open(result_path, "r", encoding="utf-8") as f:
         data = json.load(f)
+    workspace_owned = result_path.resolve() == (
+        WORKSPACE_DIR / "result.json"
+    ).resolve()
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1270,7 +1340,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
     execution_metrics = _compute_execution_metrics(data)
     agentic_metrics = _compute_agentic_metrics(data)
     sector_breakdown = _compute_sector_breakdown(data)
-    manifest = _load_manifest_safe()
+    manifest = _load_manifest_safe() if workspace_owned else None
     task_results, error_tasks = _build_task_results(data, manifest=manifest)
 
     # Generate narrative
@@ -1285,14 +1355,13 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
         }
         print("   Skipping narrative (--no-narrative)")
     else:
-        grade = _load_grade_for_experiment(data.get("experiment_id", ""))
         # Try GPT-5.4 Pro (Responses API) first, fallback to standard
         try:
             from core.narrative_analyzer import create_narrative_analyzer
             print("   Generating narrative via GPT-5.4 Pro (Responses API)…")
             analyzer = create_narrative_analyzer()
             result = analyzer.analyze(
-                data, summary, sector_breakdown, task_results, error_tasks, grade=grade
+                data, summary, sector_breakdown, task_results, error_tasks, grade=None
             )
             narrative = {
                 "overview": result.overview,
@@ -1308,7 +1377,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
         except Exception as exc:
             print(f"   ⚠️ Pro narrative failed: {exc}")
             print("   Falling back to standard narrative…")
-            narrative = _generate_narrative(data, summary, sector_breakdown, grade=grade)
+            narrative = _generate_narrative(data, summary, sector_breakdown, grade=None)
 
     # Build report_data.json
     rd = _build_report_data(
@@ -1320,12 +1389,13 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
         error_tasks,
         execution_metrics=execution_metrics,
         agentic_metrics=agentic_metrics,
+        dry_run=dry_run,
     )
 
     # Inject file generation stats from step5_validate.py
     validate_stats_path = WORKSPACE_DIR / "validate_stats.json"
     file_generation = None
-    if validate_stats_path.exists():
+    if workspace_owned and validate_stats_path.exists():
         with open(validate_stats_path, "r", encoding="utf-8") as f:
             file_generation = json.load(f)
     rd["file_generation"] = file_generation or {
@@ -1343,7 +1413,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
 
     # Inject recovery stats — read from step2_inference_results.json (has reflection_history)
     inference_results_path = WORKSPACE_DIR / "step2_inference_results.json"
-    if inference_results_path.exists():
+    if workspace_owned and inference_results_path.exists():
         with open(inference_results_path, "r", encoding="utf-8") as f:
             inference_data = json.load(f)
         results_for_recovery = inference_data.get("results", [])
@@ -1372,7 +1442,7 @@ def generate_report(result_json_path: Path, output_dir: Path, no_narrative: bool
 
     # Copy report_data.json → workspace/upload/self_report.json (for step7 HF upload)
     upload_dir = WORKSPACE_DIR / "upload"
-    if upload_dir.exists():
+    if workspace_owned and upload_dir.exists():
         self_report_path = upload_dir / "self_report.json"
         shutil.copy2(json_path, self_report_path)
         print(f"   ✓ Copied self_report.json → {self_report_path}")
@@ -1408,14 +1478,20 @@ def main():
         action="store_true",
         help="Skip LLM narrative generation (metrics only)",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Mark HF self-report publication as skipped",
+    )
     args = parser.parse_args()
 
-    output_dir = _resolve_output_dir(args.output_dir)
+    output_dir = _resolve_output_dir(args.output_dir, args.result_json)
 
     generate_report(
         result_json_path=args.result_json,
         output_dir=output_dir,
         no_narrative=args.no_narrative,
+        dry_run=args.dry_run,
     )
 
 

--- a/batch-runner/tests/test_agentic_pipeline.py
+++ b/batch-runner/tests/test_agentic_pipeline.py
@@ -13,13 +13,14 @@ import step1_prepare_tasks as step1
 import step2_run_inference as step2
 from core.agentic_experiments import agentic_condition_identity
 from core.experiment_config import ExperimentConfig
+from core.prepared_fingerprint import prepared_fingerprint
 
 
 def _config() -> ExperimentConfig:
     return ExperimentConfig.from_dict({
         "experiment": {"id": "exp028", "name": "Agentic fixture"},
         "data": {
-            "source": "fixture",
+            "source": "fixture/agentic",
             "filter": {"task_ids": ["task-1"]},
         },
         "condition_a": {
@@ -59,10 +60,10 @@ def _config() -> ExperimentConfig:
 
 
 def _prepared(agentic: dict | None = None) -> dict:
-    return {
+    payload = {
         "experiment_id": "exp028",
         "experiment_name": "Agentic fixture",
-        "source": "fixture",
+        "source": "fixture/agentic",
         "execution": {
             "mode": "agentic_sandbox",
             "max_retries": 0,
@@ -100,6 +101,8 @@ def _prepared(agentic: dict | None = None) -> dict:
             "prompt": {"system": "system"},
         },
     }
+    payload["prepared_fingerprint"] = prepared_fingerprint(payload)
+    return payload
 
 
 def _patch_step2_workspace(tmp_path, monkeypatch, prepared):
@@ -519,6 +522,7 @@ def test_progress_checkpoint_requires_exact_identity_and_recovers_missing_tasks(
         "run_id": "paired-run",
         "execution_mode": "agentic_sandbox",
         "ordered_task_ids": ["task-1", "task-2"],
+        "prepared_fingerprint": "a" * 64,
         "total_tasks": 2,
         "started_at": "2026-07-17T00:00:00+00:00",
         "resume_round": 0,
@@ -534,6 +538,7 @@ def test_progress_checkpoint_requires_exact_identity_and_recovers_missing_tasks(
         run_id="paired-run",
         execution_mode="agentic_sandbox",
         ordered_task_ids=["task-1", "task-2"],
+        prepared_fingerprint="a" * 64,
     )
 
     assert [result["task_id"] for result in loaded["results"]] == [
@@ -551,6 +556,7 @@ def test_progress_checkpoint_requires_exact_identity_and_recovers_missing_tasks(
             run_id="other-run",
             execution_mode="agentic_sandbox",
             ordered_task_ids=["task-1", "task-2"],
+            prepared_fingerprint="a" * 64,
         )
 
 

--- a/batch-runner/tests/test_experiment_config.py
+++ b/batch-runner/tests/test_experiment_config.py
@@ -340,6 +340,55 @@ class TestExperimentConfigValidation:
         assert len(errors) > 0
         assert any("experiment.id" in e for e in errors)
 
+    @pytest.mark.parametrize(
+        "experiment_id",
+        [
+            "../outside",
+            "nested/path",
+            " space",
+            "exp id",
+            "foo..bar",
+            "foo.",
+            "foo.lock",
+            "a" * 101,
+        ],
+    )
+    def test_validate_rejects_unsafe_experiment_id(
+        self, sample_config_dict, experiment_id
+    ):
+        sample_config_dict["experiment"]["id"] = experiment_id
+        config = ExperimentConfig.from_dict(sample_config_dict)
+
+        assert "experiment.id must be a safe identifier" in config.validate()
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "owner",
+            "owner/repo/extra",
+            "../repo",
+            "owner/space repo",
+            "owner/foo..bar",
+            "owner/foo--bar",
+            "owner/.repo",
+            "owner/repo-",
+            "owner/repo.git",
+            "o" * 48 + "/" + "r" * 48,
+            "",
+        ],
+    )
+    def test_validate_rejects_invalid_data_source(self, sample_config_dict, source):
+        sample_config_dict["data"]["source"] = source
+        config = ExperimentConfig.from_dict(sample_config_dict)
+
+        assert "data.source must be a valid owner/repository ID" in config.validate()
+
+    def test_validate_accepts_public_openai_source(self, sample_config_dict):
+        sample_config_dict["data"]["source"] = "openai/gdpval"
+        config = ExperimentConfig.from_dict(sample_config_dict)
+
+        assert "data.source must be a valid owner/repository ID" not in config.validate()
+
     def test_validate_invalid_provider(self, sample_config_dict):
         """Test validation with invalid model provider"""
         sample_config_dict["condition_a"]["model"]["provider"] = "invalid"

--- a/batch-runner/tests/test_narrative_grade_integration.py
+++ b/batch-runner/tests/test_narrative_grade_integration.py
@@ -1,8 +1,8 @@
 """Tests for grade-aware narrative integration."""
 
 import json
-import os
-from pathlib import Path
+
+import pytest
 
 from core.narrative_analyzer import NarrativeAnalyzer
 import step6_report
@@ -11,6 +11,9 @@ import step6_report
 def _minimal_grade(model: str = "gpt-5.4-pro", avg: float = 67.4) -> dict:
     return {
         "schema_version": "1.0",
+        "source_inference_experiment_id": "exp_test",
+        "source_inference_repo_id": "student/exp_test",
+        "source_inference_revision": "c" * 40,
         "judge": {
             "model": model,
             "reasoning_effort": "high",
@@ -23,13 +26,17 @@ def _minimal_grade(model: str = "gpt-5.4-pro", avg: float = 67.4) -> dict:
         "prompt": {"version": "v1"},
         "graded_at": "2026-05-20T12:34:56Z",
         "summary": {
-            "total_tasks": 5,
+            "total_tasks": 2,
+            "graded_tasks": 2,
+            "error_tasks": 0,
             "openai_compat": {
                 "avg_score_pct": avg,
                 "ci_pct": 4.2,
                 "perfect_count": 1,
                 "zero_count": 1,
-                "total_tasks": 5,
+                "partial_count": 0,
+                "inconsistent_count": 0,
+                "total_tasks": 2,
             },
             "wow": {
                 "critical_item_pass_rate": 0.71,
@@ -66,7 +73,12 @@ def _minimal_grade(model: str = "gpt-5.4-pro", avg: float = 67.4) -> dict:
                     },
                 },
             },
+            "cost": {},
         },
+        "tasks": [
+            {"task_id": "task-1"},
+            {"task_id": "task-2"},
+        ],
     }
 
 
@@ -191,37 +203,76 @@ def test_overview_does_not_claim_human_evaluation():
     assert "human-graded" not in all_prompts
 
 
-def test_load_grade_skips_dummy_files(tmp_path, monkeypatch):
-    exp_id = "exp_test"
-    dummy = _minimal_grade(model="dummy-model")
-    dummy["_meta"] = {"is_dummy": True}
-    real = _minimal_grade(model="real-model")
-
-    (tmp_path / f"{exp_id}__a__sha__v1.json").write_text(json.dumps(dummy))
-    (tmp_path / f"{exp_id}__b__sha__v1.json").write_text(json.dumps(real))
-    monkeypatch.setattr(step6_report, "GRADE_DIR", tmp_path)
-
-    loaded = step6_report._load_grade_for_experiment(exp_id)
-    assert loaded == real
+def _result_identity() -> dict:
+    return {
+        "experiment_id": "exp_test",
+        "source_repo_id": "student/exp_test",
+        "source_revision": "c" * 40,
+        "results": [
+            {"task_id": "task-1"},
+            {"task_id": "task-2"},
+        ],
+    }
 
 
-def test_load_grade_returns_none_when_missing(tmp_path, monkeypatch):
-    monkeypatch.setattr(step6_report, "GRADE_DIR", tmp_path)
+def test_step6_report_is_always_pre_grading():
+    narrative = {
+        "overview": "Execution evidence is available.",
+        "grading_referenced": False,
+        "grade_source": None,
+    }
+    report = step6_report._build_report_data(
+        _result_identity(),
+        narrative,
+        {
+            "total_tasks": 2,
+            "success_count": 2,
+            "success_rate_pct": 100.0,
+            "error_count": 0,
+            "retried_count": 0,
+            "avg_qa_score": 0,
+            "min_qa_score": 0,
+            "max_qa_score": 0,
+            "avg_latency_ms": 0,
+            "max_latency_ms": 0,
+            "total_latency_ms": 0,
+        },
+        [],
+        [],
+        [],
+    )
 
-    assert step6_report._load_grade_for_experiment("exp_missing") is None
+    assert report["meta"]["report_scope"] == "self_assessed_pre_grading"
+    markdown = step6_report._build_markdown(report)
+    assert "Self-Assessed, Pre-Grading" in markdown
+    assert "Awaiting external grading" in markdown
+    assert "Self-QA + Automated LLM-Judge" not in markdown
 
 
-def test_load_grade_picks_most_recent(tmp_path, monkeypatch):
-    exp_id = "exp_test"
-    older = _minimal_grade(model="older-model", avg=50.0)
-    newer = _minimal_grade(model="newer-model", avg=80.0)
-    older_path = tmp_path / f"{exp_id}__older__sha__v1.json"
-    newer_path = tmp_path / f"{exp_id}__newer__sha__v1.json"
-    older_path.write_text(json.dumps(older))
-    newer_path.write_text(json.dumps(newer))
-    os.utime(older_path, (1000, 1000))
-    os.utime(newer_path, (2000, 2000))
-    monkeypatch.setattr(step6_report, "GRADE_DIR", tmp_path)
+def test_step6_cli_does_not_offer_grade_json(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["step6_report.py", "--grade-json", "grade.json"],
+    )
+    with pytest.raises(SystemExit) as error:
+        step6_report.main()
+    assert error.value.code == 2
 
-    loaded = step6_report._load_grade_for_experiment(exp_id)
-    assert loaded == newer
+
+@pytest.mark.parametrize(
+    "experiment_id",
+    [None, "", "../outside", "nested/path", "foo..bar", "foo.", "foo.lock"],
+)
+def test_report_data_rejects_unsafe_experiment_identity(experiment_id):
+    result = _result_identity()
+    result["experiment_id"] = experiment_id
+
+    with pytest.raises(ValueError, match="experiment identifier"):
+        step6_report._build_report_data(
+            result,
+            {"grading_referenced": False},
+            {},
+            [],
+            [],
+            [],
+        )

--- a/batch-runner/tests/test_relay_duration.py
+++ b/batch-runner/tests/test_relay_duration.py
@@ -2,7 +2,13 @@
 
 import json
 
-from step2_run_inference import _save_progress
+import pytest
+
+from step2_run_inference import (
+    _load_and_validate_progress,
+    _resolve_run_identity,
+    _save_progress,
+)
 
 
 def _identity(total_tasks):
@@ -10,6 +16,7 @@ def _identity(total_tasks):
         "run_id": "relay-test-run",
         "condition_identity": "condition_a",
         "ordered_task_ids": [f"t{index}" for index in range(1, total_tasks + 1)],
+        "prepared_fingerprint": "a" * 64,
     }
 
 
@@ -118,3 +125,57 @@ class TestSaveProgressStartedAt:
 
         assert progress_path.exists()
         assert not progress_path.with_suffix(".json.tmp").exists()
+
+    def test_progress_rejects_prepared_fingerprint_mismatch(self, tmp_path):
+        progress_path = tmp_path / "progress.json"
+        _save_progress(
+            experiment_id="exp_test",
+            condition_name="cond",
+            execution_mode="subprocess",
+            total_tasks=1,
+            results=[],
+            started_at="2026-01-01T00:00:00",
+            path=progress_path,
+            **_identity(1),
+        )
+
+        with pytest.raises(ValueError, match="identity mismatch"):
+            _load_and_validate_progress(
+                progress_path,
+                experiment_id="exp_test",
+                condition_name="cond",
+                condition_identity="condition_a",
+                run_id="relay-test-run",
+                execution_mode="subprocess",
+                ordered_task_ids=["t1"],
+                prepared_fingerprint="b" * 64,
+            )
+
+
+def test_relay_lineage_is_stable_across_github_run_ids(monkeypatch):
+    monkeypatch.setenv("GDPVAL_RELAY_LINEAGE_ID", "exp_test:100:1")
+    monkeypatch.setenv("GITHUB_RUN_ID", "200")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "3")
+
+    assert _resolve_run_identity("exp_test") == "exp_test:100:1"
+
+
+def test_initial_run_identity_uses_current_github_run(monkeypatch):
+    monkeypatch.delenv("GDPVAL_RELAY_LINEAGE_ID", raising=False)
+    monkeypatch.setenv("GITHUB_RUN_ID", "200")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "3")
+
+    assert _resolve_run_identity("exp_test") == "exp_test:200:3"
+
+
+def test_condition_workspace_paths_are_isolated(monkeypatch, tmp_path):
+    import step2_run_inference as step2
+
+    monkeypatch.setattr(step2, "WORKSPACE_DIR", tmp_path)
+    a_progress, a_result = step2._condition_workspace_paths("condition_a")
+    b_progress, b_result = step2._condition_workspace_paths("condition_b")
+
+    assert a_progress != b_progress
+    assert a_result != b_result
+    assert a_progress.name == "step2_inference_progress_condition_a.json"
+    assert b_progress.name == "step2_inference_progress_condition_b.json"

--- a/batch-runner/tests/test_silent_corruption_fixes.py
+++ b/batch-runner/tests/test_silent_corruption_fixes.py
@@ -319,10 +319,12 @@ class TestFix3RetrieableStatuses:
 
 def _build_step1_prepared(tmp_path: Path, task_id: str = "t1") -> Path:
     """Write a minimal step1_tasks_prepared.json for run_inference."""
+    from core.prepared_fingerprint import prepared_fingerprint
+
     prepared = {
         "experiment_id": "exp_test",
         "experiment_name": "qa_failed_regression",
-        "source": "test",
+        "source": "test/qa-failed-regression",
         "execution": {
             "mode": "subprocess",
             "max_retries": 1,
@@ -350,6 +352,7 @@ def _build_step1_prepared(tmp_path: Path, task_id: str = "t1") -> Path:
             },
         },
     }
+    prepared["prepared_fingerprint"] = prepared_fingerprint(prepared)
     prepared_path = tmp_path / "step1_tasks_prepared.json"
     prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
     return prepared_path
@@ -481,6 +484,8 @@ class TestFix3RunTaskWithQA:
         prepared_path = workspace / "step1_tasks_prepared.json"
         prepared = json.loads(prepared_path.read_text(encoding="utf-8"))
         prepared["execution"]["metrics"] = {"enabled": True}
+        from core.prepared_fingerprint import prepared_fingerprint
+        prepared["prepared_fingerprint"] = prepared_fingerprint(prepared)
         prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
 
         def execute_with_metrics(*args, **kwargs):
@@ -563,6 +568,8 @@ class TestFix3RunTaskWithQA:
         prepared_path = workspace / "step1_tasks_prepared.json"
         prepared = json.loads(prepared_path.read_text(encoding="utf-8"))
         prepared["execution"]["metrics"] = {"enabled": True}
+        from core.prepared_fingerprint import prepared_fingerprint
+        prepared["prepared_fingerprint"] = prepared_fingerprint(prepared)
         prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
 
         observability = {
@@ -828,6 +835,8 @@ def test_resume_timeout_relay_preserves_cumulative_task_metrics(
     prepared = json.loads(prepared_path.read_text(encoding="utf-8"))
     prepared["execution"]["mode"] = "sandbox"
     prepared["execution"]["metrics"] = {"enabled": True}
+    from core.prepared_fingerprint import prepared_fingerprint
+    prepared["prepared_fingerprint"] = prepared_fingerprint(prepared)
     prepared_path.write_text(json.dumps(prepared), encoding="utf-8")
 
     progress = {
@@ -838,6 +847,7 @@ def test_resume_timeout_relay_preserves_cumulative_task_metrics(
         "run_id": "exp_test:local:1",
         "execution_mode": "sandbox",
         "ordered_task_ids": ["t1"],
+        "prepared_fingerprint": prepared["prepared_fingerprint"],
         "total_tasks": 1,
         "started_at": "2026-07-15T00:00:00+00:00",
         "resume_round": 0,

--- a/batch-runner/tests/test_step3_format_results.py
+++ b/batch-runner/tests/test_step3_format_results.py
@@ -5,7 +5,81 @@ import math
 
 import pytest
 
-from step3_format_results import _write_json_outputs
+from core.prepared_fingerprint import prepared_fingerprint
+from step3_format_results import (
+    _source_repo_id,
+    _validate_input_identity,
+    _write_json_outputs,
+)
+
+
+def test_source_repo_id_is_carried_from_prepared_tasks():
+    assert _source_repo_id({"source": "student/exp998"}) == "student/exp998"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", "owner", "owner/repo/extra", "owner/foo..bar", "owner/repo.git"],
+)
+def test_source_repo_id_rejects_invalid_values(value):
+    with pytest.raises(ValueError, match="source repository"):
+        _source_repo_id({"source": value})
+
+
+def _prepared_identity() -> dict:
+    payload = {
+        "experiment_id": "exp998",
+        "source": "student/exp998",
+        "task_scope": {"task_ids": ["task-a", "task-b"]},
+        "tasks": [{"task_id": "task-a"}, {"task_id": "task-b"}],
+    }
+    payload["prepared_fingerprint"] = prepared_fingerprint(payload)
+    return payload
+
+
+def _inference_identity() -> dict:
+    prepared = _prepared_identity()
+    return {
+        "experiment_id": "exp998",
+        "source": "student/exp998",
+        "prepared_fingerprint": prepared["prepared_fingerprint"],
+        "ordered_task_ids": ["task-a", "task-b"],
+        "results": [{"task_id": "task-a"}, {"task_id": "task-b"}],
+    }
+
+
+def test_input_identity_accepts_exact_step1_step2_match():
+    _validate_input_identity(_prepared_identity(), _inference_identity())
+
+
+@pytest.mark.parametrize(
+    ("target", "field", "value", "message"),
+    [
+        ("prepared", "experiment_id", "other", "experiment"),
+        ("prepared", "source", "other/repo", "source repository"),
+        ("prepared", "experiment_id", "../outside", "experiment"),
+        ("inference", "experiment_id", "../outside", "experiment"),
+        ("inference", "ordered_task_ids", ["task-b", "task-a"], "task order"),
+        ("inference", "results", [{"task_id": "task-a"}], "result task"),
+        ("inference", "prepared_fingerprint", "b" * 64, "fingerprint"),
+    ],
+)
+def test_input_identity_rejects_mixed_workspace(target, field, value, message):
+    prepared = _prepared_identity()
+    inference = _inference_identity()
+    (prepared if target == "prepared" else inference)[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        _validate_input_identity(prepared, inference)
+
+
+def test_input_identity_rejects_mutated_prepared_payload_with_stale_fingerprint():
+    prepared = _prepared_identity()
+    inference = _inference_identity()
+    prepared["tasks"][0]["instruction"] = "mutated prompt"
+
+    with pytest.raises(ValueError, match="fingerprint does not match payload"):
+        _validate_input_identity(prepared, inference)
 
 
 def test_write_json_outputs_rejects_nan_before_opening_destinations(tmp_path):

--- a/batch-runner/tests/test_step6_v2_fields.py
+++ b/batch-runner/tests/test_step6_v2_fields.py
@@ -136,6 +136,7 @@ def _make_result_payload() -> dict:
     return {
         "experiment_id": "exp_test",
         "experiment_name": "v2-fields-test",
+        "source_repo_id": "student/v2-fields-test",
         "condition_name": "default",
         "model": "test-model",
         "execution_mode": "test",
@@ -358,6 +359,7 @@ def _run_step6(
     tmp_path: Path,
     manifest_data: dict | None,
     result_payload: dict | None = None,
+    dry_run: bool = False,
 ) -> dict:
     """Run ``generate_report`` against an isolated workspace and return the
     parsed ``report_data.json`` dict."""
@@ -381,9 +383,109 @@ def _run_step6(
             result_json_path=result_json,
             output_dir=output_dir,
             no_narrative=True,
+            dry_run=dry_run,
         )
 
     return json.loads((output_dir / "report_data.json").read_text(encoding="utf-8"))
+
+
+def test_dry_run_report_marks_hf_target_as_unpublished(monkeypatch, tmp_path):
+    rd = _run_step6(
+        monkeypatch,
+        tmp_path,
+        _make_v1_manifest_data(),
+        dry_run=True,
+    )
+    markdown = step6_report._build_markdown(rd)
+
+    assert rd["meta"]["source_repo_id"] == "student/v2-fields-test"
+    assert rd["meta"]["publication_plan"] == "dry_run_no_step7"
+    assert "HF Target (bootstrap)" in markdown
+    assert "student/v2-fields-test" in markdown
+    assert "Self-Report" in markdown
+    assert "not published" in markdown
+    assert "/blob/main/self_report.json" not in markdown
+
+
+def test_default_output_dir_uses_selected_result_json_not_stale_workspace(
+    monkeypatch, tmp_path
+):
+    selected = tmp_path / "selected.json"
+    selected.write_text(
+        json.dumps({"experiment_id": "selected_exp"}),
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "step2_inference_results.json").write_text(
+        json.dumps({"experiment_id": "../stale"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(step6_report, "WORKSPACE_DIR", workspace)
+    monkeypatch.setattr(step6_report, "_SCRIPT_DIR", tmp_path)
+
+    output = step6_report._resolve_output_dir(None, selected)
+
+    assert output == tmp_path / "results" / "selected_exp" / "report"
+
+
+@pytest.mark.parametrize("experiment_id", ["../outside", "nested/path", ""])
+def test_default_output_dir_rejects_unsafe_selected_result_id(
+    monkeypatch, tmp_path, experiment_id
+):
+    selected = tmp_path / "selected.json"
+    selected.write_text(
+        json.dumps({"experiment_id": experiment_id}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(step6_report, "_SCRIPT_DIR", tmp_path)
+
+    with pytest.raises(ValueError, match="experiment identifier"):
+        step6_report._resolve_output_dir(None, selected)
+
+
+def test_external_result_does_not_mix_workspace_auxiliary_data(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "validate_stats.json").write_text(
+        json.dumps({"needs_files_total": 999}), encoding="utf-8"
+    )
+    (workspace / "step2_inference_results.json").write_text(
+        json.dumps({
+            "experiment_id": "other",
+            "results": [{"task_id": "other", "status": "error"}],
+        }),
+        encoding="utf-8",
+    )
+    (workspace / "step0_needs_files_manifest.json").write_text(
+        json.dumps(_make_v2_manifest_data()), encoding="utf-8"
+    )
+    monkeypatch.setattr(step6_report, "WORKSPACE_DIR", workspace)
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    result_json = external_dir / "result.json"
+    result_json.write_text(
+        json.dumps(_make_result_payload()), encoding="utf-8"
+    )
+    output_dir = external_dir / "report"
+
+    step6_report.generate_report(
+        result_json_path=result_json,
+        output_dir=output_dir,
+        no_narrative=True,
+    )
+    report = json.loads(
+        (output_dir / "report_data.json").read_text(encoding="utf-8")
+    )
+
+    assert report["file_generation"]["needs_files_total"] is None
+    assert report["recovery_stats"]["resume_rounds"]["rounds_used"] == 0
+    assert all(
+        "prompt_classification" not in task
+        for task in report["task_results"]
+    )
 
 
 def test_generate_report_v2_manifest_includes_v2_fields(monkeypatch, tmp_path):

--- a/docs/first-experiment.md
+++ b/docs/first-experiment.md
@@ -1,0 +1,235 @@
+# Your First GDPVal RealWorks Run
+
+This guide starts with a free local dashboard, then walks through the current
+three-task cloud smoke test. You do not need prior GitHub Actions experience.
+
+## Choose the run you want
+
+- **Local dashboard:** about five minutes, free, and no cloud account required.
+- **Three-task smoke experiment:** setup time plus model runtime, with GitHub,
+  Azure, Hugging Face, and real API usage.
+
+> **Important:** `dry_run: true` is not a no-cost or no-write simulation. It
+> still calls the model, runs Self-QA, creates or reuses the configured Hugging
+> Face dataset, and may write relay checkpoints. It skips Step 5 validation,
+> the final Step 7 result upload, and the result pull request. This three-task
+> smoke also skips Step 5 because of its sample size.
+
+<p align="center">
+   <picture>
+      <source media="(max-width: 960px)" srcset="images/readme-first-run-mobile.svg" />
+      <img src="images/readme-first-run.svg" alt="A free local dashboard path and a credentialed three-task cloud smoke experiment" />
+   </picture>
+</p>
+
+## Path A: open the dashboard locally
+
+You need Git and Node.js 20 or newer. No API key or cloud account is required.
+
+```bash
+git clone https://github.com/hyeonsangjeon/gdpval-realworks.git
+cd gdpval-realworks
+npm ci
+npm run dev
+```
+
+Open the URL printed by Vite. Because the project has a GitHub Pages base path,
+the local URL normally ends in `/gdpval-realworks/`.
+
+To run the same data and production checks used by CI:
+
+```bash
+npm run aggregate
+npm run test:aggregate
+npm run build
+```
+
+The generated site is written to `dist/`. This path reads repository data and
+does not call an LLM.
+
+## Path B: run three real tasks in GitHub Actions
+
+A **smoke test** is a deliberately small real run used to catch setup problems.
+**Self-QA** asks the generating model to inspect and possibly retry its own work;
+it is not an independent grade. A **relay** continues unfinished tasks in a
+later Actions job. **OpenID Connect (OIDC)** gives that job short-lived Azure
+access without storing an Azure client secret.
+
+The checked-in smoke config uses Azure deployment `gpt-5.2-chat`, selects three
+tasks, and can retry Self-QA up to three times. Step 6 first attempts two
+sequential `gpt-5.4-pro` report calls. If that path raises an error, it attempts
+one `gpt-5.2-chat` fallback call; calls completed before the error can still be
+billed. The exact time and cost therefore depend on output size, retries, quota,
+available deployments, and your Azure pricing.
+
+### 1. Prepare the accounts
+
+You need:
+
+- a GitHub account and a fork of this repository;
+- an Azure subscription with an Azure OpenAI resource and a required deployment
+   named `gpt-5.2-chat`; `gpt-5.4-pro` is optional but needed for the primary
+   two-call report path;
+- permission to create a Microsoft Entra app registration and assign the
+  **Cognitive Services OpenAI User** role on that Azure OpenAI resource; and
+- a Hugging Face account with a write token.
+
+If your university or company owns the Azure tenant, ask its administrator for
+the app registration and role assignment. Do not replace OIDC with a client
+secret or Azure OpenAI API key: the batch workflow is designed for federated
+identity.
+
+### 2. Fork and use your own Hugging Face target
+
+Fork the repository on GitHub. In your fork, edit
+[`batch-runner/experiments/exp998_smoke_baseline_sample.yaml`](../batch-runner/experiments/exp998_smoke_baseline_sample.yaml)
+and change only the owner in `data.source`:
+
+```yaml
+data:
+  source: "YOUR_HF_USERNAME/exp998_smoke_baseline_sample"
+```
+
+Keep the repository name equal to the YAML stem. Use a new, disposable dataset.
+Step 0 creates new targets as **public** datasets. It considers an existing
+target bootstrapped only when at least one path starts with `data/`; otherwise
+it deletes the entire dataset repository, including unrelated README or metadata
+files, and recreates it. If a `data/` path already exists, Step 0 reuses that
+snapshot rather than replacing it.
+
+A later non-dry Step 7 deletes remote `data/**` and `deliverable_files/**` before
+uploading the new result. Do not point this config at a dataset you need to keep.
+
+Commit the edit to your fork's default `main` branch. Never put a token, key, or
+password in this YAML.
+
+### 3. Configure Azure OIDC once
+
+The workflow uses
+[`azure/login`](../.github/workflows/batch-run.yml) with a short-lived GitHub
+OIDC token. A straightforward portal setup is:
+
+1. In **Microsoft Entra admin center**, open **App registrations** and create an
+   app for this fork.
+2. Record its **Application (client) ID** and **Directory (tenant) ID**.
+3. Open **Certificates & secrets > Federated credentials > Add credential**.
+4. Choose **GitHub Actions deploying Azure resources**.
+5. Enter your GitHub owner and repository, select **Branch**, and set the branch
+   to `main`. The subject should represent
+   `repo:YOUR_GITHUB_OWNER/gdpval-realworks:ref:refs/heads/main`.
+6. On the Azure OpenAI resource, open **Access control (IAM)** and assign the
+   app's service principal the **Cognitive Services OpenAI User** role.
+7. Record the Azure subscription ID and the endpoint shown under the Azure
+   OpenAI resource's keys and endpoint page.
+
+Microsoft's reference setup is
+[Use OpenID Connect with GitHub Actions](https://learn.microsoft.com/azure/developer/github/connect-from-azure-openid-connect).
+If your fork or default branch has a different name, the federated credential
+must match it exactly.
+
+### 4. Create the Hugging Face token
+
+Create a token at [Hugging Face settings](https://huggingface.co/settings/tokens)
+that can read the public source dataset and create, write, and delete your
+disposable target dataset. Use a dedicated token scoped only to this work when
+your account supports fine-grained permissions.
+
+### 5. Add repository secrets
+
+In your GitHub fork, open **Settings > Secrets and variables > Actions > New
+repository secret** and add:
+
+| Secret | Value |
+|---|---|
+| `AZURE_CLIENT_ID` | Entra application client ID |
+| `AZURE_TENANT_ID` | Entra directory tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
+| `AZURE_OPENAI_ENDPOINT` | `https://YOUR_RESOURCE.openai.azure.com/` |
+| `HF_TOKEN` | Dedicated Hugging Face write token |
+
+Do not add `AZURE_OPENAI_API_KEY` for this path. `GITHUB_TOKEN` is supplied by
+GitHub automatically.
+
+For later non-dry runs, open **Settings > Actions > General > Workflow
+permissions**, select **Read and write permissions**, and allow GitHub Actions
+to create pull requests. Organization policy may require an administrator to do
+this.
+
+### 6. Run the smoke workflow
+
+1. Open your fork's **Actions** tab and enable workflows if GitHub asks.
+2. Select **Run GDPVal Batch Experiment**.
+3. Choose **Run workflow** on branch `main`.
+4. Enter `exp998_smoke_baseline_sample` for `experiment_yaml`.
+5. Leave `experiment_name` empty, `relay_run` at `0`, `wall_timeout` at `290`,
+   and `sandbox_image_digest` empty.
+6. Set `dry_run` to `true`, acknowledge the cost warning above, and run it.
+
+The smoke config uses provider-hosted `code_interpreter`; it does not exercise
+the repository's Docker sandbox or agentic preflight.
+
+### 7. Know what success looks like
+
+The expected path is:
+
+| Stage | Expected smoke behavior |
+|---|---|
+| Inspect mode | Checks the input filename, safe YAML shape, and whether the mode belongs in the general workflow; no cloud credentials are available |
+| Full config validation | Loads and validates the complete experiment config before any Hugging Face bootstrap |
+| Step 0 | Publicly creates, destructively recreates, or reuses your disposable Hugging Face dataset, then downloads its snapshot |
+| Step 1 | Deterministically selects three tasks |
+| Step 2 | Calls the model, creates deliverables, and runs same-model Self-QA |
+| Steps 3-4 | Writes JSON/Markdown results and a three-row Parquet file |
+| Step 5 | Skipped because `dry_run` is true and because this sample has three tasks |
+| Step 6 | Attempts two `gpt-5.4-pro` report calls, then a one-call `gpt-5.2-chat` fallback; narrative failure triggers a mandatory model-free report before publication |
+| Step 7 and result PR | Skipped because `dry_run` is true |
+
+When the credentialed batch job reaches its final `always()` step, it attempts
+to upload an Actions artifact named `batch-results-<run_id>`. An early
+inspect-mode rejection or job-start failure may produce no artifact. A successful
+upload is retained for 30 days. Open the completed Actions run, scroll to
+**Artifacts**, download `batch-results-<run_id>`, and unzip it. The archive root
+contains `workspace/` and `results/`.
+
+Check these first:
+
+- `workspace/step2_inference_results.json` for per-task status;
+- `workspace/upload/deliverable_files/<task_id>/` for generated files;
+- `results/exp998_smoke_baseline_sample/` for formatted results and report; and
+- the Actions log for retry, quota, or report warnings.
+
+Self-QA is a retry signal from the same model that produced the work. It is not
+independent grading and does not prove that a deliverable is professionally
+correct.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Workflow is missing | Workflows must be enabled and the YAML must be on the fork's default branch |
+| `AADSTS700213` or no matching federated identity | Owner, repository, branch, and federated subject must match the fork exactly |
+| Azure login succeeds but inference returns 403 | Confirm the OpenAI role assignment, endpoint, and deployment access |
+| Deployment not found | The smoke config expects an Azure deployment named `gpt-5.2-chat` |
+| Hugging Face 401 or 403 | Check token permissions and that `data.source` uses your namespace |
+| Hugging Face target behaves unexpectedly | Use a new disposable public dataset with the exact `exp998_smoke_baseline_sample` name; never reuse a dataset with files you need |
+| Step 6 is yellow but the job continues | The workflow must generate and identity-check a model-free fallback report before any PR or HF publication |
+| No result pull request appears | Expected when `dry_run` is true |
+| Step 5 is skipped | Expected for samples of three tasks or fewer |
+
+## After the smoke test
+
+Copy an existing experiment YAML to a new name, keep `sample_size: 3`, and
+change one variable at a time. Review the artifact before increasing the sample
+size. Unchecking `dry_run` publishes results and opens a result pull request; it
+does not turn a three-task config into a 220-task run.
+
+Full runs can use substantial model quota and take multiple relay jobs. External
+grading is a separate pipeline. Read the
+[Batch Runner documentation](../batch-runner/README.md) and the
+[sandbox documentation](../batch-runner/sandbox/README.md) before changing the
+execution mode or scaling to all 220 tasks.
+
+If this was a one-time evaluation, delete the disposable Hugging Face dataset,
+revoke its dedicated token, remove the five repository secrets, and delete the
+fork's federated credential. Keep them only when you intend to run more
+experiments.

--- a/docs/first-experiment_KR.md
+++ b/docs/first-experiment_KR.md
@@ -1,0 +1,229 @@
+# GDPVal RealWorks 첫 실행 가이드
+
+먼저 무료로 로컬 대시보드를 열고, 그다음 현재의 3개 태스크 클라우드
+스모크 테스트를 실행합니다. GitHub Actions를 처음 써도 따라갈 수 있도록
+계정과 권한부터 설명합니다.
+
+## 실행 경로 선택
+
+- **로컬 대시보드:** 약 5분, 무료, 클라우드 계정 불필요
+- **3개 태스크 smoke 실험:** 설정 시간 + 모델 실행 시간, GitHub, Azure,
+  Hugging Face, 실제 API 사용료 필요
+
+> **중요:** `dry_run: true`는 비용과 원격 쓰기가 없는 시뮬레이션이
+> 아닙니다. 모델 호출과 Self-QA를 실행하고, 설정한 Hugging Face 데이터셋을
+> 만들거나 재사용하며, 필요하면 relay 체크포인트도 씁니다. Step 5 검증,
+> 최종 Step 7 결과 업로드, 결과 PR을 건너뜁니다. 이 3-task smoke는 sample
+> size 때문에도 Step 5를 생략합니다.
+
+<p align="center">
+   <picture>
+      <source media="(max-width: 960px)" srcset="images/readme-first-run-mobile-ko.svg" />
+      <img src="images/readme-first-run-ko.svg" alt="무료 로컬 대시보드 경로와 인증 정보가 필요한 3개 태스크 클라우드 실험 경로" />
+   </picture>
+</p>
+
+## 경로 A: 로컬 대시보드 열기
+
+Git과 Node.js 20 이상이 필요합니다. API 키나 클라우드 계정은 필요 없습니다.
+
+```bash
+git clone https://github.com/hyeonsangjeon/gdpval-realworks.git
+cd gdpval-realworks
+npm ci
+npm run dev
+```
+
+Vite가 출력한 주소를 브라우저에서 여세요. GitHub Pages용 base path가 있어
+로컬 주소도 보통 `/gdpval-realworks/`로 끝납니다.
+
+CI와 같은 데이터·프로덕션 검증을 실행하려면 다음을 사용합니다.
+
+```bash
+npm run aggregate
+npm run test:aggregate
+npm run build
+```
+
+완성된 사이트는 `dist/`에 생성됩니다. 이 경로는 저장소 데이터를 읽을 뿐
+LLM을 호출하지 않습니다.
+
+## 경로 B: GitHub Actions에서 실제 태스크 3개 실행
+
+**Smoke test**는 설정 오류를 찾기 위해 실제 태스크를 소량만 실행하는
+테스트입니다. **Self-QA**는 생성 모델이 자기 결과를 검사하고 재시도하는
+과정이며 독립 채점이 아닙니다. **Relay**는 끝나지 않은 태스크를 다음 Actions
+job에서 이어갑니다. **OpenID Connect(OIDC)**는 Azure client secret을 저장하지
+않고 job에 단기 Azure 권한을 부여합니다.
+
+체크인된 스모크 설정은 Azure 배포 `gpt-5.2-chat`을 사용하고 3개 태스크를
+선택하며 Self-QA를 최대 3회 재시도할 수 있습니다. Step 6은 먼저
+`gpt-5.4-pro`를 순차적으로 최대 2회 호출합니다. 이 경로에서 오류가 나면
+`gpt-5.2-chat` fallback을 1회 시도하며, 오류 전에 완료된 호출도 과금될 수
+있습니다. 따라서 시간과 비용은 출력 크기, 재시도, 쿼터, 사용 가능한
+deployment, Azure 가격에 따라 달라집니다.
+
+### 1. 계정 준비
+
+다음이 필요합니다.
+
+- GitHub 계정과 이 저장소의 fork
+- Azure 구독, Azure OpenAI 리소스, 필수 `gpt-5.2-chat` 배포. 기본 2-call
+   report 경로를 사용하려면 선택적으로 `gpt-5.4-pro` 배포도 필요
+- Microsoft Entra 앱 등록 권한과 해당 Azure OpenAI 리소스에
+  **Cognitive Services OpenAI User** 역할을 부여할 권한
+- 쓰기 토큰을 만들 수 있는 Hugging Face 계정
+
+학교나 회사가 Azure tenant를 관리한다면 관리자에게 앱 등록과 역할 부여를
+요청하세요. OIDC를 client secret이나 Azure OpenAI API key로 바꾸지 마세요.
+배치 워크플로는 federated identity를 기준으로 설계되어 있습니다.
+
+### 2. Fork와 개인 Hugging Face 대상 설정
+
+GitHub에서 저장소를 fork합니다. 내 fork에서
+[`batch-runner/experiments/exp998_smoke_baseline_sample.yaml`](../batch-runner/experiments/exp998_smoke_baseline_sample.yaml)을
+열고 `data.source`의 소유자만 바꿉니다.
+
+```yaml
+data:
+  source: "YOUR_HF_USERNAME/exp998_smoke_baseline_sample"
+```
+
+데이터셋 저장소 이름은 YAML 파일 stem과 같게 유지하세요. 새로 만든 일회성
+테스트 dataset을 사용해야 합니다. Step 0은 새 대상을 기본적으로 **public
+dataset**으로 만듭니다. 기존 대상에 `data/`로 시작하는 경로가 하나도 없으면
+README나 metadata 같은 다른 파일이 있어도 dataset repository 전체를 삭제한
+뒤 다시 만듭니다. `data/` 경로가 있으면 기존 snapshot을 재사용합니다.
+
+나중에 non-dry Step 7을 실행하면 새 결과를 올리기 전에 원격 `data/**`와
+`deliverable_files/**`를 삭제합니다. 보존해야 할 dataset을 가리키면 안 됩니다.
+
+수정 내용을 fork의 기본 `main` 브랜치에 커밋하세요. YAML에 토큰, 키,
+비밀번호를 넣지 마세요.
+
+### 3. Azure OIDC 1회 설정
+
+워크플로는 [`azure/login`](../.github/workflows/batch-run.yml)과 GitHub의
+단기 OIDC 토큰을 사용합니다. 포털에서는 다음 순서로 설정할 수 있습니다.
+
+1. **Microsoft Entra admin center**에서 **App registrations**를 열고 이
+   fork용 앱을 만듭니다.
+2. **Application (client) ID**와 **Directory (tenant) ID**를 기록합니다.
+3. **Certificates & secrets > Federated credentials > Add credential**을
+   엽니다.
+4. **GitHub Actions deploying Azure resources**를 선택합니다.
+5. 내 GitHub owner와 repository를 입력하고 **Branch**, `main`을 선택합니다.
+   subject는
+   `repo:YOUR_GITHUB_OWNER/gdpval-realworks:ref:refs/heads/main`을 나타내야
+   합니다.
+6. Azure OpenAI 리소스의 **Access control (IAM)**에서 이 앱의 service
+   principal에 **Cognitive Services OpenAI User** 역할을 부여합니다.
+7. Azure 구독 ID와 Azure OpenAI 리소스의 endpoint를 기록합니다.
+
+Microsoft 공식 절차는
+[GitHub Actions에서 OpenID Connect 사용](https://learn.microsoft.com/azure/developer/github/connect-from-azure-openid-connect)을
+참고하세요. fork나 기본 브랜치 이름이 다르면 federated credential도 정확히
+같아야 합니다.
+
+### 4. Hugging Face 토큰 만들기
+
+[Hugging Face 토큰 설정](https://huggingface.co/settings/tokens)에서 공개
+원본 dataset을 읽고 일회성 대상 dataset을 생성, 수정, 삭제할 수 있는
+token을 만듭니다. 계정이 fine-grained 권한을 지원하면 이 작업에만 한정된
+전용 token을 사용하세요.
+
+### 5. Repository secrets 등록
+
+GitHub fork의 **Settings > Secrets and variables > Actions > New repository
+secret**에서 다음을 추가합니다.
+
+| Secret | 값 |
+|---|---|
+| `AZURE_CLIENT_ID` | Entra 앱의 client ID |
+| `AZURE_TENANT_ID` | Entra directory tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
+| `AZURE_OPENAI_ENDPOINT` | `https://YOUR_RESOURCE.openai.azure.com/` |
+| `HF_TOKEN` | Hugging Face 전용 write token |
+
+이 경로에는 `AZURE_OPENAI_API_KEY`를 추가하지 마세요. `GITHUB_TOKEN`은
+GitHub가 자동으로 제공합니다.
+
+나중에 non-dry run을 하려면 **Settings > Actions > General > Workflow
+permissions**에서 **Read and write permissions**와 Actions의 PR 생성을
+허용하세요. 조직 정책에 따라 관리자가 설정해야 할 수 있습니다.
+
+### 6. 스모크 워크플로 실행
+
+1. fork의 **Actions** 탭을 열고 요청이 나오면 workflow를 활성화합니다.
+2. **Run GDPVal Batch Experiment**를 선택합니다.
+3. `main` 브랜치에서 **Run workflow**를 누릅니다.
+4. `experiment_yaml`에 `exp998_smoke_baseline_sample`을 입력합니다.
+5. `experiment_name`은 비워 두고, `relay_run`은 `0`, `wall_timeout`은
+   `290`, `sandbox_image_digest`는 빈 값으로 둡니다.
+6. 위 비용 경고를 확인한 뒤 `dry_run`을 `true`로 설정하고 실행합니다.
+
+스모크 설정은 provider-hosted `code_interpreter`를 사용합니다. 저장소의
+Docker sandbox나 agentic preflight를 실행하는 테스트가 아닙니다.
+
+### 7. 성공 상태 확인
+
+예상 경로는 다음과 같습니다.
+
+| 단계 | 스모크에서 예상되는 동작 |
+|---|---|
+| Inspect mode | cloud credential 없이 입력 파일명, 안전한 YAML 구조, 일반 workflow 허용 mode를 사전 검사 |
+| 전체 config 검증 | Hugging Face bootstrap 전에 전체 experiment config를 load하고 validate |
+| Step 0 | 일회성 Hugging Face dataset을 공개 생성, 파괴적 재생성 또는 재사용한 뒤 snapshot 다운로드 |
+| Step 1 | seed에 따라 태스크 3개 선택 |
+| Step 2 | 모델 호출, 산출물 생성, 같은 모델의 Self-QA 실행 |
+| Steps 3-4 | JSON/Markdown 결과와 3-row Parquet 생성 |
+| Step 5 | `dry_run`이 true이고 sample도 3개이므로 건너뜀 |
+| Step 6 | `gpt-5.4-pro` 2-call report와 `gpt-5.2-chat` fallback을 시도. Narrative 실패 시 게시 전에 model-free report를 반드시 생성 |
+| Step 7과 결과 PR | `dry_run`이므로 건너뜀 |
+
+credentialed batch job이 마지막 `always()` 단계에 도달하면
+`batch-results-<run_id>` Actions artifact 업로드를 시도합니다. inspect-mode의
+초기 거부나 job 시작 실패에서는 artifact가 없을 수 있습니다. 업로드에
+성공하면 30일 보관됩니다. 완료된 Actions run 아래의 **Artifacts**에서
+`batch-results-<run_id>`를 내려받아 압축을 푸세요. archive root에는
+`workspace/`와 `results/`가 있습니다.
+
+먼저 다음을 확인하세요.
+
+- `workspace/step2_inference_results.json`: 태스크별 상태
+- `workspace/upload/deliverable_files/<task_id>/`: 생성 파일
+- `results/exp998_smoke_baseline_sample/`: 포맷된 결과와 리포트
+- Actions log: 재시도, 쿼터, 리포트 경고
+
+Self-QA는 산출물을 만든 같은 모델의 재시도 신호입니다. 독립 채점이 아니며
+산출물이 전문적으로 정확하다는 증거도 아닙니다.
+
+## 문제 해결
+
+| 증상 | 확인할 것 |
+|---|---|
+| workflow가 보이지 않음 | Actions가 활성화됐고 YAML이 fork 기본 브랜치에 있는지 확인 |
+| `AADSTS700213` 또는 federated identity 불일치 | owner, repository, branch, federated subject가 fork와 정확히 같은지 확인 |
+| Azure login은 성공하지만 inference가 403 | OpenAI 역할, endpoint, deployment 접근 권한 확인 |
+| deployment를 찾지 못함 | 스모크 설정은 `gpt-5.2-chat` 이름을 기대함 |
+| Hugging Face 401 또는 403 | token 권한과 `data.source`가 내 namespace인지 확인 |
+| HF 대상이 예상과 다르게 동작 | 정확히 `exp998_smoke_baseline_sample` 이름의 새 일회성 public dataset 사용. 필요한 파일이 있는 dataset은 재사용하지 않음 |
+| Step 6이 경고인데 job은 계속됨 | PR/HF 게시 전에 model-free fallback report 생성과 identity 검증을 반드시 통과해야 함 |
+| 결과 PR이 없음 | `dry_run: true`에서는 정상 |
+| Step 5가 생략됨 | 3개 이하 샘플에서는 정상 |
+
+## 스모크 다음 단계
+
+기존 실험 YAML을 새 이름으로 복사하고 `sample_size: 3`을 유지한 채 변수를
+하나씩 바꾸세요. 샘플을 늘리기 전에 artifact를 검토해야 합니다.
+`dry_run`을 해제하면 결과를 게시하고 결과 PR을 만들지만, 3-task 설정이
+220-task 전체 실행으로 바뀌는 것은 아닙니다.
+
+전체 실행은 큰 모델 쿼터를 사용할 수 있고 여러 relay job이 필요할 수
+있습니다. 외부 채점은 별도 파이프라인입니다. 실행 모드를 바꾸거나 220개로
+확대하기 전에 [Batch Runner 문서](../batch-runner/README_KR.md)와
+[sandbox 문서](../batch-runner/sandbox/README.md)를 읽으세요.
+
+한 번만 시험했다면 일회성 Hugging Face dataset을 삭제하고, 전용 token을
+폐기하며, 5개 repository secret과 fork용 federated credential을 삭제하세요.
+추가 실험을 할 계획일 때만 유지합니다.

--- a/docs/images/readme-first-run-ko.svg
+++ b/docs/images/readme-first-run-ko.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="512" viewBox="0 0 1200 640" role="img" aria-labelledby="frk-title frk-desc">
+  <title id="frk-title">GDPVal RealWorks 첫 실행 경로</title>
+  <desc id="frk-desc">무료 로컬 대시보드 경로와 실제 API 비용이 발생하는 3개 태스크 클라우드 실험 경로를 비교합니다.</desc>
+  <defs>
+    <marker id="frk-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#214c4a"/>
+    </marker>
+  </defs>
+  <style>
+    .bg { fill: #f5f3ed; }
+    .panel { fill: #fffefa; stroke: #18343b; stroke-width: 2; }
+    .ink { fill: #18343b; }
+    .muted { fill: #52656a; }
+    .teal { fill: #0f6762; }
+    .amber { fill: #7a4f00; }
+    .coral { fill: #9f3b2e; }
+    .line { fill: none; stroke: #214c4a; stroke-width: 3; marker-end: url(#frk-arrow); }
+    .divider { stroke: #c8d1cc; stroke-width: 2; }
+    .kicker { font: 700 17px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .title { font: 700 35px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .heading { font: 700 24px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .body { font: 500 18px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .small { font: 600 16px 'IBM Plex Mono', 'Noto Sans KR', monospace; }
+    .number { font: 700 18px 'IBM Plex Mono', monospace; fill: #fffefa; }
+  </style>
+  <rect class="bg" width="1200" height="640"/>
+  <text x="60" y="56" class="kicker teal">첫 실행 선택</text>
+  <text x="60" y="101" class="title ink">로컬에서 확인하고, 비용은 의도적으로 사용하세요.</text>
+  <text x="60" y="132" class="body muted">대시보드와 클라우드 실험은 인증과 비용 경계가 다릅니다.</text>
+
+  <rect x="60" y="168" width="500" height="350" rx="8" class="panel"/>
+  <rect x="60" y="168" width="500" height="8" rx="4" class="teal"/>
+  <text x="92" y="218" class="kicker teal">무료 / 약 5분</text>
+  <text x="92" y="253" class="heading ink">로컬 대시보드 열기</text>
+  <text x="92" y="282" class="body muted">클라우드 계정, API key, model call이 필요 없습니다.</text>
+  <circle cx="112" cy="337" r="20" class="teal"/>
+  <text x="102" y="344" class="number">01</text>
+  <text x="150" y="332" class="body ink">저장소 clone</text>
+  <text x="150" y="358" class="small muted">git clone ... &amp;&amp; cd gdpval-realworks</text>
+  <line x1="112" y1="362" x2="112" y2="390" class="divider"/>
+  <circle cx="112" cy="416" r="20" class="teal"/>
+  <text x="102" y="423" class="number">02</text>
+  <text x="150" y="411" class="body ink">Vite 개발 서버 시작</text>
+  <text x="150" y="437" class="small muted">npm ci &amp;&amp; npm run dev</text>
+  <rect x="92" y="469" width="436" height="32" rx="6" fill="#dcece8"/>
+  <text x="112" y="491" class="small ink">Vite가 출력한 URL 열기</text>
+
+  <rect x="620" y="168" width="520" height="350" rx="8" class="panel"/>
+  <rect x="620" y="168" width="520" height="8" rx="4" class="amber"/>
+  <text x="652" y="218" class="kicker amber">클라우드 / 실제 API 사용</text>
+  <text x="652" y="253" class="heading ink">3개 태스크 smoke 실행</text>
+  <text x="652" y="282" class="body muted">GitHub fork + Azure OIDC + Hugging Face token</text>
+  <rect x="652" y="313" width="186" height="70" rx="6" fill="#eef1ed" stroke="#9caaa7"/>
+  <text x="671" y="341" class="small teal">01 / 공개 대상</text>
+  <text x="671" y="367" class="body ink">Fork + HF dataset</text>
+  <path d="M 844 348 H 886" class="line"/>
+  <rect x="892" y="313" width="216" height="70" rx="6" fill="#eef1ed" stroke="#9caaa7"/>
+  <text x="911" y="341" class="small teal">02 / 인증</text>
+  <text x="911" y="367" class="body ink">OIDC + repo secrets</text>
+  <rect x="652" y="414" width="186" height="70" rx="6" fill="#eef1ed" stroke="#9caaa7"/>
+  <text x="671" y="442" class="small teal">03 / 실행</text>
+  <text x="671" y="468" class="body ink">Actions smoke run</text>
+  <path d="M 844 449 H 886" class="line"/>
+  <rect x="892" y="414" width="216" height="70" rx="6" fill="#eef1ed" stroke="#9caaa7"/>
+  <text x="911" y="442" class="small teal">04 / 확인</text>
+  <text x="911" y="468" class="body ink">Artifact 다운로드</text>
+
+  <rect x="60" y="550" width="1080" height="54" rx="8" fill="#f8ded7" stroke="#9f3b2e" stroke-width="2"/>
+  <circle cx="90" cy="577" r="10" class="coral"/>
+  <text x="114" y="584" class="body ink">dry_run도 model과 HF를 사용합니다. Step 5 검증, 최종 게시, 결과 PR을 건너뜁니다.</text>
+</svg>

--- a/docs/images/readme-first-run-mobile-ko.svg
+++ b/docs/images/readme-first-run-mobile-ko.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="542" viewBox="0 0 720 1090" role="img" aria-labelledby="frmk-title frmk-desc">
+  <title id="frmk-title">GDPVal RealWorks 모바일 첫 실행 경로</title>
+  <desc id="frmk-desc">무료 로컬 대시보드와 실제 API 비용이 발생하는 3개 태스크 클라우드 실험을 세로로 비교합니다.</desc>
+  <style>
+    .bg { fill: #f5f3ed; }.panel { fill: #fffefa; stroke: #18343b; stroke-width: 3; }.ink { fill: #18343b; }.muted { fill: #52656a; }
+    .teal { fill: #0f6762; }.amber { fill: #7a4f00; }.coral { fill: #9f3b2e; }
+    .kicker { font: 700 27px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }.title { font: 700 44px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .heading { font: 700 34px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }.body { font: 500 28px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .mono { font: 600 27px 'IBM Plex Mono', 'Noto Sans KR', monospace; }.number { font: 700 26px 'IBM Plex Mono', monospace; fill: #fffefa; }
+  </style>
+  <rect class="bg" width="720" height="1090"/>
+  <text x="44" y="58" class="kicker teal">첫 실행 선택</text>
+  <text x="44" y="112" class="title ink">로컬에서 확인하고,</text><text x="44" y="162" class="title ink">비용은 의도적으로 사용하세요.</text>
+  <rect x="44" y="202" width="632" height="318" rx="10" class="panel"/><rect x="44" y="202" width="632" height="10" rx="5" class="teal"/>
+  <text x="72" y="258" class="kicker teal">무료 / 약 5분</text><text x="72" y="306" class="heading ink">로컬 대시보드 열기</text>
+  <text x="72" y="347" class="body muted">클라우드 계정과 model call이 없습니다.</text>
+  <circle cx="98" cy="393" r="27" class="teal"/><text x="82" y="402" class="number">01</text><text x="144" y="388" class="body ink">저장소 clone</text><text x="144" y="426" class="mono muted">clone repo; cd gdpval-realworks</text>
+  <circle cx="98" cy="482" r="27" class="teal"/><text x="82" y="491" class="number">02</text><text x="144" y="465" class="body ink">Vite 개발 서버 시작</text><text x="144" y="505" class="mono muted">npm ci &amp;&amp; npm run dev</text>
+  <rect x="44" y="548" width="632" height="380" rx="10" class="panel"/><rect x="44" y="548" width="632" height="10" rx="5" class="amber"/>
+  <text x="72" y="604" class="kicker amber">클라우드 / 실제 API 사용</text><text x="72" y="652" class="heading ink">3개 태스크 smoke 실행</text>
+  <text x="72" y="693" class="body muted">GitHub fork + Azure OIDC + HF token</text>
+  <rect x="72" y="722" width="576" height="54" rx="8" fill="#e3efeb"/><text x="92" y="758" class="mono teal">01  Fork + 공개 HF dataset</text>
+  <rect x="72" y="790" width="576" height="54" rx="8" fill="#e3efeb"/><text x="92" y="826" class="mono teal">02  OIDC + secret 설정</text>
+  <rect x="72" y="858" width="576" height="54" rx="8" fill="#e3efeb"/><text x="92" y="894" class="mono teal">03-04  실행 + artifact 확인</text>
+  <rect x="44" y="958" width="632" height="104" rx="10" fill="#f8ded7" stroke="#9f3b2e" stroke-width="3"/>
+  <circle cx="76" cy="998" r="11" class="coral"/><text x="100" y="1006" class="body ink">dry_run도 model API와 HF를 사용합니다.</text><text x="100" y="1044" class="body ink">Step 5, 최종 게시, 결과 PR은 생략합니다.</text>
+</svg>

--- a/docs/images/readme-first-run-mobile.svg
+++ b/docs/images/readme-first-run-mobile.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="542" viewBox="0 0 720 1090" role="img" aria-labelledby="frm-title frm-desc">
+  <title id="frm-title">Two ways to start GDPVal RealWorks on a narrow screen</title>
+  <desc id="frm-desc">A vertical guide to the free local dashboard and the credentialed three-task cloud experiment, including the dry-run cost warning.</desc>
+  <style>
+    .bg { fill: #f5f3ed; }
+    .panel { fill: #fffefa; stroke: #18343b; stroke-width: 3; }
+    .ink { fill: #18343b; }
+    .muted { fill: #52656a; }
+    .teal { fill: #0f6762; }
+    .amber { fill: #7a4f00; }
+    .coral { fill: #9f3b2e; }
+    .kicker { font: 700 27px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .title { font: 700 44px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .heading { font: 700 34px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .body { font: 500 28px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .mono { font: 600 27px 'IBM Plex Mono', 'SFMono-Regular', monospace; }
+    .number { font: 700 26px 'IBM Plex Mono', 'SFMono-Regular', monospace; fill: #fffefa; }
+  </style>
+  <rect class="bg" width="720" height="1090"/>
+  <text x="44" y="58" class="kicker teal">CHOOSE YOUR FIRST RUN</text>
+  <text x="44" y="112" class="title ink">Inspect locally.</text>
+  <text x="44" y="162" class="title ink">Spend deliberately.</text>
+
+  <rect x="44" y="202" width="632" height="318" rx="10" class="panel"/>
+  <rect x="44" y="202" width="632" height="10" rx="5" class="teal"/>
+  <text x="72" y="258" class="kicker teal">FREE / ABOUT 5 MINUTES</text>
+  <text x="72" y="306" class="heading ink">Open the dashboard locally</text>
+  <text x="72" y="347" class="body muted">No cloud account, API key, or model call.</text>
+  <circle cx="98" cy="405" r="27" class="teal"/>
+  <text x="82" y="414" class="number">01</text>
+  <text x="144" y="400" class="body ink">Clone the repository</text>
+  <text x="144" y="438" class="mono muted">clone repo; cd gdpval-realworks</text>
+  <circle cx="98" cy="482" r="27" class="teal"/>
+  <text x="82" y="491" class="number">02</text>
+  <text x="144" y="477" class="body ink">Install and start Vite</text>
+  <text x="144" y="505" class="mono muted">npm ci &amp;&amp; npm run dev</text>
+
+  <rect x="44" y="548" width="632" height="380" rx="10" class="panel"/>
+  <rect x="44" y="548" width="632" height="10" rx="5" class="amber"/>
+  <text x="72" y="604" class="kicker amber">CLOUD / REAL API USAGE</text>
+  <text x="72" y="652" class="heading ink">Run the three-task smoke test</text>
+  <text x="72" y="693" class="body muted">GitHub fork + Azure OIDC + HF token</text>
+  <rect x="72" y="722" width="576" height="54" rx="8" fill="#e3efeb"/>
+  <text x="92" y="758" class="mono teal">01  Fork + public HF dataset</text>
+  <rect x="72" y="790" width="576" height="54" rx="8" fill="#e3efeb"/>
+  <text x="92" y="826" class="mono teal">02  Configure OIDC + secrets</text>
+  <rect x="72" y="858" width="576" height="54" rx="8" fill="#e3efeb"/>
+  <text x="92" y="894" class="mono teal">03-04  Run + inspect artifact</text>
+
+  <rect x="44" y="958" width="632" height="104" rx="10" fill="#f8ded7" stroke="#9f3b2e" stroke-width="3"/>
+  <circle cx="76" cy="998" r="11" class="coral"/>
+  <text x="100" y="1006" class="body ink">dry_run uses model APIs and HF bootstrap.</text>
+  <text x="100" y="1044" class="body ink">Skip Step 5 + final publish + result PR.</text>
+</svg>

--- a/docs/images/readme-first-run.svg
+++ b/docs/images/readme-first-run.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="512" viewBox="0 0 1200 640" role="img" aria-labelledby="fr-title fr-desc">
+  <title id="fr-title">Two ways to start GDPVal RealWorks</title>
+  <desc id="fr-desc">A free local dashboard path and a credentialed three-task cloud experiment path with a warning that dry run still uses paid APIs.</desc>
+  <defs>
+    <marker id="fr-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#214c4a"/>
+    </marker>
+  </defs>
+  <style>
+    .fr-bg { fill: #f5f3ed; }
+    .fr-panel { fill: #fffefa; stroke: #18343b; stroke-width: 2; }
+    .fr-ink { fill: #18343b; }
+    .fr-muted { fill: #52656a; }
+    .fr-teal { fill: #0f6762; }
+    .fr-amber { fill: #7a4f00; }
+    .fr-coral { fill: #9f3b2e; }
+    .fr-line { fill: none; stroke: #214c4a; stroke-width: 3; marker-end: url(#fr-arrow); }
+    .fr-divider { stroke: #c8d1cc; stroke-width: 2; }
+    .fr-kicker { font: 700 17px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .fr-title { font: 700 35px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .fr-heading { font: 700 24px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .fr-body { font: 500 18px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .fr-small { font: 600 16px 'IBM Plex Mono', 'SFMono-Regular', monospace; }
+    .fr-number { font: 700 18px 'IBM Plex Mono', 'SFMono-Regular', monospace; fill: #fffefa; }
+  </style>
+
+  <rect class="fr-bg" width="1200" height="640"/>
+  <text x="60" y="56" class="fr-kicker fr-teal">CHOOSE YOUR FIRST RUN</text>
+  <text x="60" y="101" class="fr-title fr-ink">Inspect locally. Spend deliberately.</text>
+  <text x="60" y="132" class="fr-body fr-muted">The dashboard and the cloud experiment have different trust and cost boundaries.</text>
+
+  <rect x="60" y="168" width="500" height="350" rx="8" class="fr-panel"/>
+  <rect x="60" y="168" width="500" height="8" rx="4" class="fr-teal"/>
+  <text x="92" y="218" class="fr-kicker fr-teal">FREE / ABOUT 5 MINUTES</text>
+  <text x="92" y="253" class="fr-heading fr-ink">Open the dashboard locally</text>
+  <text x="92" y="282" class="fr-body fr-muted">No cloud account. No API key. No model call.</text>
+
+  <circle cx="112" cy="337" r="20" class="fr-teal"/>
+  <text x="102" y="344" class="fr-number">01</text>
+  <text x="150" y="332" class="fr-body fr-ink">Clone the repository</text>
+  <text x="150" y="358" class="fr-small fr-muted">git clone ... &amp;&amp; cd gdpval-realworks</text>
+
+  <line x1="112" y1="362" x2="112" y2="390" class="fr-divider"/>
+  <circle cx="112" cy="416" r="20" class="fr-teal"/>
+  <text x="102" y="423" class="fr-number">02</text>
+  <text x="150" y="411" class="fr-body fr-ink">Install and start Vite</text>
+  <text x="150" y="437" class="fr-small fr-muted">npm ci &amp;&amp; npm run dev</text>
+
+  <rect x="92" y="469" width="436" height="32" rx="6" fill="#dcece8"/>
+  <text x="112" y="491" class="fr-small fr-ink">Open the URL printed by Vite</text>
+
+  <rect x="620" y="168" width="520" height="350" rx="8" class="fr-panel"/>
+  <rect x="620" y="168" width="520" height="8" rx="4" class="fr-amber"/>
+  <text x="652" y="218" class="fr-kicker fr-amber">CLOUD / REAL API USAGE</text>
+  <text x="652" y="253" class="fr-heading fr-ink">Run the three-task smoke test</text>
+  <text x="652" y="282" class="fr-body fr-muted">GitHub fork + Azure OIDC + Hugging Face token</text>
+
+  <rect x="652" y="313" width="186" height="70" rx="6" fill="#eef1ed" stroke="#9caaa7"/>
+  <text x="671" y="341" class="fr-small fr-teal">01 / PUBLIC TARGET</text>
+  <text x="671" y="367" class="fr-body fr-ink">Fork + HF dataset</text>
+  <path d="M 844 348 H 886" class="fr-line"/>
+  <rect x="892" y="313" width="216" height="70" rx="6" fill="#eef1ed" stroke="#9caaa7"/>
+  <text x="911" y="341" class="fr-small fr-teal">02 / IDENTITY</text>
+  <text x="911" y="367" class="fr-body fr-ink">OIDC + repo secrets</text>
+
+  <rect x="652" y="414" width="186" height="70" rx="6" fill="#eef1ed" stroke="#9caaa7"/>
+  <text x="671" y="442" class="fr-small fr-teal">03 / EXECUTE</text>
+  <text x="671" y="468" class="fr-body fr-ink">Actions smoke run</text>
+  <path d="M 844 449 H 886" class="fr-line"/>
+  <rect x="892" y="414" width="216" height="70" rx="6" fill="#eef1ed" stroke="#9caaa7"/>
+  <text x="911" y="442" class="fr-small fr-teal">04 / INSPECT</text>
+  <text x="911" y="468" class="fr-body fr-ink">Download artifact</text>
+
+  <rect x="60" y="550" width="1080" height="54" rx="8" fill="#f8ded7" stroke="#d75b45" stroke-width="2"/>
+  <circle cx="90" cy="577" r="10" class="fr-coral"/>
+  <text x="114" y="584" class="fr-body fr-ink">dry_run skips Step 5 validation, final publication, and the PR; model cost and HF bootstrap still run.</text>
+</svg>

--- a/docs/images/readme-system-map-ko.svg
+++ b/docs/images/readme-system-map-ko.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 1200 700" role="img" aria-labelledby="smk-title smk-desc">
+  <title id="smk-title">GDPVal RealWorks 시스템 맵</title>
+  <desc id="smk-desc">실험 YAML이 준비, 실행, 패키징, 검증, 게시를 거쳐 실행 근거 및 별도 외부 채점과 함께 대시보드로 집계되는 흐름입니다.</desc>
+  <defs>
+    <marker id="smk-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#274f55"/>
+    </marker>
+  </defs>
+  <style>
+    .bg { fill: #f3f5f1; }
+    .ink { fill: #17343d; }
+    .muted { fill: #53666b; }
+    .teal { fill: #0f6762; }
+    .amber { fill: #7a4f00; }
+    .coral { fill: #9f3b2e; }
+    .white { fill: #fffefa; }
+    .stage { fill: #fffefa; stroke: #214c4a; stroke-width: 2; }
+    .backend { fill: #e3efeb; stroke: #6f928d; stroke-width: 1.5; }
+    .output { fill: #f7e9c9; stroke: #7a4f00; stroke-width: 1.5; }
+    .arrow { fill: none; stroke: #274f55; stroke-width: 3; marker-end: url(#smk-arrow); }
+    .kicker { font: 700 17px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .title { font: 700 34px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .heading { font: 700 20px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .body { font: 500 16px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .small { font: 600 16px 'IBM Plex Mono', 'Noto Sans KR', monospace; }
+  </style>
+  <rect class="bg" width="1200" height="700"/>
+  <text x="60" y="55" class="kicker teal">시스템 맵</text>
+  <text x="60" y="99" class="title ink">YAML 하나가 들어가고, 여러 근거 신호가 나옵니다.</text>
+  <text x="60" y="130" class="body muted">실행 완료, 파일 무결성, Self-QA, 외부 채점은 서로 다른 신호입니다.</text>
+  <text x="60" y="181" class="kicker muted">실험 파이프라인</text>
+
+  <rect x="60" y="205" width="160" height="112" rx="8" class="stage"/><rect x="60" y="205" width="160" height="7" rx="3" class="teal"/>
+  <text x="80" y="245" class="small teal">설정</text><text x="80" y="274" class="heading ink">YAML + 범위</text><text x="80" y="299" class="body muted">모델 / 태스크</text>
+  <path d="M 225 261 H 237" class="arrow"/>
+  <rect x="244" y="205" width="160" height="112" rx="8" class="stage"/><rect x="244" y="205" width="160" height="7" rx="3" class="teal"/>
+  <text x="264" y="245" class="small teal">STEP 0-1</text><text x="264" y="274" class="heading ink">준비</text><text x="264" y="299" class="body muted">복제 + 선택</text>
+  <path d="M 409 261 H 421" class="arrow"/>
+  <rect x="428" y="205" width="160" height="112" rx="8" class="stage"/><rect x="428" y="205" width="160" height="7" rx="3" class="coral"/>
+  <text x="448" y="245" class="small coral">STEP 2</text><text x="448" y="274" class="heading ink">실행</text><text x="448" y="299" class="body muted">모델 + 파일</text>
+  <path d="M 593 261 H 605" class="arrow"/>
+  <rect x="612" y="205" width="160" height="112" rx="8" class="stage"/><rect x="612" y="205" width="160" height="7" rx="3" class="amber"/>
+  <text x="632" y="245" class="small amber">STEP 3-4</text><text x="632" y="274" class="heading ink">패키징</text><text x="632" y="299" class="body muted">JSON + Parquet</text>
+  <path d="M 777 261 H 789" class="arrow"/>
+  <rect x="796" y="205" width="160" height="112" rx="8" class="stage"/><rect x="796" y="205" width="160" height="7" rx="3" class="amber"/>
+  <text x="816" y="245" class="small amber">STEP 5-6</text><text x="816" y="274" class="heading ink">검증 + 리포트</text><text x="816" y="299" class="body muted">검사 + narrative</text>
+  <path d="M 961 261 H 973" class="arrow"/>
+  <rect x="980" y="205" width="160" height="112" rx="8" class="stage"/><rect x="980" y="205" width="160" height="7" rx="3" class="teal"/>
+  <text x="1000" y="245" class="small teal">STEP 7</text><text x="1000" y="274" class="heading ink">게시</text><text x="1000" y="299" class="body muted">HF + 결과 PR</text>
+
+  <path d="M 508 322 V 354" class="arrow"/>
+  <text x="60" y="383" class="kicker muted">STEP 2 실행 백엔드</text>
+  <rect x="60" y="405" width="245" height="76" rx="8" class="backend"/>
+  <text x="82" y="436" class="heading ink">Code Interpreter</text><text x="82" y="462" class="body muted">provider 도구 + 파일</text>
+  <rect x="325" y="405" width="245" height="76" rx="8" class="backend"/>
+  <text x="347" y="436" class="heading ink">Subprocess</text><text x="347" y="462" class="body muted">host 임시 디렉터리</text>
+  <rect x="590" y="405" width="285" height="76" rx="8" class="backend"/>
+  <text x="612" y="436" class="heading ink">Container sandbox</text><text x="612" y="462" class="body muted">offline + 자원 제한 + QA</text>
+  <rect x="895" y="405" width="245" height="76" rx="8" class="backend"/>
+  <text x="917" y="436" class="heading ink">JSON renderer</text><text x="917" y="462" class="body muted">spec + 결정적 출력</text>
+  <rect x="428" y="335" width="160" height="48" rx="8" fill="#f8ded7" stroke="#9f3b2e"/>
+  <text x="446" y="365" class="small ink">SELF-QA 재시도</text><text x="606" y="365" class="body muted">같은 모델; 외부 채점은 별도</text>
+
+  <text x="60" y="535" class="kicker muted">근거와 대시보드</text>
+  <rect x="60" y="559" width="260" height="82" rx="8" class="output"/>
+  <text x="82" y="590" class="small amber">실행 근거</text><text x="82" y="620" class="heading ink">파일 + manifest</text>
+  <text x="340" y="613" class="title amber">+</text>
+  <rect x="374" y="559" width="260" height="82" rx="8" class="output"/>
+  <text x="396" y="590" class="small amber">별도 파이프라인</text><text x="396" y="620" class="heading ink">외부 채점</text>
+  <path d="M 639 600 H 681" class="arrow"/>
+  <rect x="688" y="559" width="210" height="82" rx="8" class="output"/>
+  <text x="710" y="590" class="small amber">근거 집계</text><text x="710" y="620" class="heading ink">Generated JSON</text>
+  <path d="M 903 600 H 945" class="arrow"/>
+  <rect x="952" y="559" width="188" height="82" rx="8" fill="#17343d"/>
+  <text x="974" y="590" class="small" fill="#87d0c4">GITHUB PAGES</text><text x="974" y="620" class="heading white">라이브 대시보드</text>
+</svg>

--- a/docs/images/readme-system-map-mobile-ko.svg
+++ b/docs/images/readme-system-map-mobile-ko.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="696" viewBox="0 0 720 1400" role="img" aria-labelledby="smmk-title smmk-desc">
+  <title id="smmk-title">GDPVal RealWorks 모바일 시스템 맵</title>
+  <desc id="smmk-desc">YAML 설정부터 실행과 게시, 실행 근거 및 별도 외부 채점의 집계, 대시보드까지 이어지는 세로 흐름입니다.</desc>
+  <defs><marker id="smmk-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#274f55"/></marker></defs>
+  <style>
+    .bg { fill: #f3f5f1; }.stage { fill: #fffefa; stroke: #214c4a; stroke-width: 3; }.output { fill: #f7e9c9; stroke: #7a4f00; stroke-width: 2; }
+    .ink { fill: #17343d; }.muted { fill: #53666b; }.teal { fill: #0f6762; }.amber { fill: #7a4f00; }.coral { fill: #9f3b2e; }.white { fill: #fffefa; }
+    .flow { fill: none; stroke: #274f55; stroke-width: 4; marker-end: url(#smmk-arrow); }
+    .kicker { font: 700 27px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }.title { font: 700 44px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .heading { font: 700 33px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }.body { font: 500 28px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .mono { font: 600 27px 'IBM Plex Mono', 'Noto Sans KR', monospace; }
+  </style>
+  <rect class="bg" width="720" height="1400"/>
+  <text x="44" y="58" class="kicker teal">시스템 맵</text><text x="44" y="112" class="title ink">YAML 하나가 들어가고,</text><text x="44" y="166" class="title ink">여러 근거 신호가 나옵니다.</text>
+  <text x="44" y="210" class="body muted">실행 완료, 무결성, Self-QA, 외부 채점은</text><text x="44" y="248" class="body muted">서로 다른 신호로 유지됩니다.</text>
+  <text x="44" y="298" class="kicker muted">실험 파이프라인</text>
+  <rect x="64" y="322" width="592" height="82" rx="9" class="stage"/><rect x="64" y="322" width="10" height="82" rx="5" class="teal"/>
+  <text x="96" y="358" class="mono teal">설정</text><text x="308" y="358" class="heading ink">YAML + 범위</text><text x="308" y="386" class="body muted">모델 / 태스크</text><path d="M 360 404 V 418" class="flow"/>
+  <rect x="64" y="426" width="592" height="82" rx="9" class="stage"/><rect x="64" y="426" width="10" height="82" rx="5" class="teal"/>
+  <text x="96" y="462" class="mono teal">STEP 0-1</text><text x="308" y="462" class="heading ink">준비</text><text x="308" y="490" class="body muted">복제 + 선택</text><path d="M 360 508 V 522" class="flow"/>
+  <rect x="64" y="530" width="592" height="122" rx="9" class="stage"/><rect x="64" y="530" width="10" height="122" rx="5" class="coral"/>
+  <text x="96" y="566" class="mono coral">STEP 2</text><text x="308" y="566" class="heading ink">실행</text><text x="308" y="594" class="body muted">모델 + 파일</text><text x="96" y="634" class="body coral">4개 backend + Self-QA 재시도</text><path d="M 360 652 V 666" class="flow"/>
+  <rect x="64" y="674" width="592" height="82" rx="9" class="stage"/><rect x="64" y="674" width="10" height="82" rx="5" class="amber"/>
+  <text x="96" y="710" class="mono amber">STEP 3-4</text><text x="308" y="710" class="heading ink">패키징</text><text x="308" y="738" class="body muted">JSON + Parquet</text><path d="M 360 756 V 770" class="flow"/>
+  <rect x="64" y="778" width="592" height="82" rx="9" class="stage"/><rect x="64" y="778" width="10" height="82" rx="5" class="amber"/>
+  <text x="96" y="814" class="mono amber">STEP 5-6</text><text x="308" y="814" class="heading ink">검증 + 리포트</text><text x="308" y="842" class="body muted">검사 + narrative</text><path d="M 360 860 V 874" class="flow"/>
+  <rect x="64" y="882" width="592" height="82" rx="9" class="stage"/><rect x="64" y="882" width="10" height="82" rx="5" class="teal"/>
+  <text x="96" y="918" class="mono teal">STEP 7</text><text x="308" y="918" class="heading ink">게시</text><text x="308" y="946" class="body muted">Hugging Face + 결과 PR</text>
+  <text x="44" y="1018" class="kicker muted">근거 집계</text>
+  <rect x="64" y="1042" width="592" height="64" rx="9" class="output"/><text x="88" y="1084" class="body ink">실행 파일 + manifest</text><text x="346" y="1146" class="title amber">+</text>
+  <rect x="64" y="1162" width="592" height="64" rx="9" class="output"/><text x="88" y="1204" class="body ink">외부 채점 / 별도 파이프라인</text><path d="M 360 1226 V 1240" class="flow"/>
+  <rect x="64" y="1248" width="592" height="64" rx="9" class="output"/><text x="88" y="1290" class="body ink">Generated JSON / 근거 집계</text><path d="M 360 1312 V 1326" class="flow"/>
+  <rect x="64" y="1334" width="592" height="48" rx="9" fill="#17343d"/><text x="88" y="1362" class="body white">GitHub Pages / 라이브 대시보드</text>
+</svg>

--- a/docs/images/readme-system-map-mobile.svg
+++ b/docs/images/readme-system-map-mobile.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="696" viewBox="0 0 720 1400" role="img" aria-labelledby="smm-title smm-desc">
+  <title id="smm-title">GDPVal RealWorks vertical system map</title>
+  <desc id="smm-desc">A narrow-screen system map from YAML configuration through execution, separate run and grading evidence, aggregation, and the dashboard.</desc>
+  <defs>
+    <marker id="smm-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#274f55"/>
+    </marker>
+  </defs>
+  <style>
+    .bg { fill: #f3f5f1; }
+    .stage { fill: #fffefa; stroke: #214c4a; stroke-width: 3; }
+    .output { fill: #f7e9c9; stroke: #7a4f00; stroke-width: 2; }
+    .ink { fill: #17343d; }
+    .muted { fill: #53666b; }
+    .teal { fill: #0f6762; }
+    .amber { fill: #7a4f00; }
+    .coral { fill: #9f3b2e; }
+    .white { fill: #fffefa; }
+    .flow { fill: none; stroke: #274f55; stroke-width: 4; marker-end: url(#smm-arrow); }
+    .kicker { font: 700 27px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .title { font: 700 44px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .heading { font: 700 33px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .body { font: 500 28px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .mono { font: 600 27px 'IBM Plex Mono', 'SFMono-Regular', monospace; }
+  </style>
+  <rect class="bg" width="720" height="1400"/>
+  <text x="44" y="58" class="kicker teal">SYSTEM MAP</text>
+  <text x="44" y="112" class="title ink">One YAML enters.</text>
+  <text x="44" y="166" class="title ink">Several signals leave.</text>
+  <text x="44" y="210" class="body muted">Completion, integrity, Self-QA, and</text>
+  <text x="44" y="248" class="body muted">external grading remain separate.</text>
+
+  <text x="44" y="298" class="kicker muted">PIPELINE</text>
+  <rect x="64" y="322" width="592" height="82" rx="9" class="stage"/>
+  <rect x="64" y="322" width="10" height="82" rx="5" class="teal"/>
+  <text x="96" y="358" class="mono teal">CONFIGURE</text>
+  <text x="308" y="358" class="heading ink">YAML + scope</text>
+  <text x="308" y="386" class="body muted">model / tasks / mode</text>
+  <path d="M 360 404 V 418" class="flow"/>
+
+  <rect x="64" y="426" width="592" height="82" rx="9" class="stage"/>
+  <rect x="64" y="426" width="10" height="82" rx="5" class="teal"/>
+  <text x="96" y="462" class="mono teal">STEPS 0-1</text>
+  <text x="308" y="462" class="heading ink">Prepare</text>
+  <text x="308" y="490" class="body muted">clone + select</text>
+  <path d="M 360 508 V 522" class="flow"/>
+
+  <rect x="64" y="530" width="592" height="122" rx="9" class="stage"/>
+  <rect x="64" y="530" width="10" height="122" rx="5" class="coral"/>
+  <text x="96" y="566" class="mono coral">STEP 2</text>
+  <text x="308" y="566" class="heading ink">Execute</text>
+  <text x="308" y="594" class="body muted">model + files</text>
+  <text x="96" y="634" class="body coral">4 backends + same-model Self-QA retry</text>
+  <path d="M 360 652 V 666" class="flow"/>
+
+  <rect x="64" y="674" width="592" height="82" rx="9" class="stage"/>
+  <rect x="64" y="674" width="10" height="82" rx="5" class="amber"/>
+  <text x="96" y="710" class="mono amber">STEPS 3-4</text>
+  <text x="308" y="710" class="heading ink">Package</text>
+  <text x="308" y="738" class="body muted">JSON + Parquet</text>
+  <path d="M 360 756 V 770" class="flow"/>
+
+  <rect x="64" y="778" width="592" height="82" rx="9" class="stage"/>
+  <rect x="64" y="778" width="10" height="82" rx="5" class="amber"/>
+  <text x="96" y="814" class="mono amber">STEPS 5-6</text>
+  <text x="308" y="814" class="heading ink">Gate + report</text>
+  <text x="308" y="842" class="body muted">checks + report</text>
+  <path d="M 360 860 V 874" class="flow"/>
+
+  <rect x="64" y="882" width="592" height="82" rx="9" class="stage"/>
+  <rect x="64" y="882" width="10" height="82" rx="5" class="teal"/>
+  <text x="96" y="918" class="mono teal">STEP 7</text>
+  <text x="308" y="918" class="heading ink">Publish</text>
+  <text x="308" y="946" class="body muted">Hugging Face + result PR</text>
+
+  <text x="44" y="1018" class="kicker muted">EVIDENCE MERGE</text>
+  <rect x="64" y="1042" width="592" height="64" rx="9" class="output"/>
+  <text x="88" y="1084" class="body ink">Run artifacts + manifests</text>
+  <text x="346" y="1146" class="title amber">+</text>
+  <rect x="64" y="1162" width="592" height="64" rx="9" class="output"/>
+  <text x="88" y="1204" class="body ink">External grading / separate pipeline</text>
+  <path d="M 360 1226 V 1240" class="flow"/>
+  <rect x="64" y="1248" width="592" height="64" rx="9" class="output"/>
+  <text x="88" y="1290" class="body ink">Generated JSON / merged evidence</text>
+  <path d="M 360 1312 V 1326" class="flow"/>
+  <rect x="64" y="1334" width="592" height="48" rx="9" fill="#17343d"/>
+  <text x="88" y="1362" class="body white">GitHub Pages / live dashboard</text>
+</svg>

--- a/docs/images/readme-system-map.svg
+++ b/docs/images/readme-system-map.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 1200 700" role="img" aria-labelledby="sm-title sm-desc">
+  <title id="sm-title">GDPVal RealWorks system map</title>
+  <desc id="sm-desc">The path from experiment YAML and GDPVal tasks through preparation, execution, packaging, validation, reporting, publication, independent grading, aggregation, and the dashboard.</desc>
+  <defs>
+    <marker id="sm-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#274f55"/>
+    </marker>
+  </defs>
+  <style>
+    .sm-bg { fill: #f3f5f1; }
+    .sm-ink { fill: #17343d; }
+    .sm-muted { fill: #53666b; }
+    .sm-teal { fill: #0f6762; }
+    .sm-amber { fill: #7a4f00; }
+    .sm-coral { fill: #9f3b2e; }
+    .sm-white { fill: #fffefa; }
+    .sm-stage { fill: #fffefa; stroke: #214c4a; stroke-width: 2; }
+    .sm-backend { fill: #e3efeb; stroke: #6f928d; stroke-width: 1.5; }
+    .sm-output { fill: #f7e9c9; stroke: #7a4f00; stroke-width: 1.5; }
+    .sm-arrow { fill: none; stroke: #274f55; stroke-width: 3; marker-end: url(#sm-arrow); }
+    .sm-kicker { font: 700 17px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .sm-title { font: 700 34px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .sm-heading { font: 700 20px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .sm-body { font: 500 16px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .sm-small { font: 600 16px 'IBM Plex Mono', 'SFMono-Regular', monospace; }
+  </style>
+
+  <rect class="sm-bg" width="1200" height="700"/>
+  <text x="60" y="55" class="sm-kicker sm-teal">SYSTEM MAP</text>
+  <text x="60" y="99" class="sm-title sm-ink">One YAML enters. Several kinds of evidence leave.</text>
+  <text x="60" y="130" class="sm-body sm-muted">Inference completion, file integrity, Self-QA, and external grading remain separate signals.</text>
+
+  <text x="60" y="181" class="sm-kicker sm-muted">PIPELINE</text>
+  <rect x="60" y="205" width="160" height="112" rx="8" class="sm-stage"/>
+  <rect x="60" y="205" width="160" height="7" rx="3" class="sm-teal"/>
+  <text x="80" y="245" class="sm-small sm-teal">CONFIGURE</text>
+  <text x="80" y="274" class="sm-heading sm-ink">YAML scope</text>
+  <text x="80" y="299" class="sm-body sm-muted">model / tasks</text>
+
+  <path d="M 225 261 H 237" class="sm-arrow"/>
+  <rect x="244" y="205" width="160" height="112" rx="8" class="sm-stage"/>
+  <rect x="244" y="205" width="160" height="7" rx="3" class="sm-teal"/>
+  <text x="264" y="245" class="sm-small sm-teal">STEPS 0-1</text>
+  <text x="264" y="274" class="sm-heading sm-ink">Prepare</text>
+  <text x="264" y="299" class="sm-body sm-muted">clone + select</text>
+
+  <path d="M 409 261 H 421" class="sm-arrow"/>
+  <rect x="428" y="205" width="160" height="112" rx="8" class="sm-stage"/>
+  <rect x="428" y="205" width="160" height="7" rx="3" class="sm-coral"/>
+  <text x="448" y="245" class="sm-small sm-coral">STEP 2</text>
+  <text x="448" y="274" class="sm-heading sm-ink">Execute</text>
+  <text x="448" y="299" class="sm-body sm-muted">model + files</text>
+
+  <path d="M 593 261 H 605" class="sm-arrow"/>
+  <rect x="612" y="205" width="160" height="112" rx="8" class="sm-stage"/>
+  <rect x="612" y="205" width="160" height="7" rx="3" class="sm-amber"/>
+  <text x="632" y="245" class="sm-small sm-amber">STEPS 3-4</text>
+  <text x="632" y="274" class="sm-heading sm-ink">Package</text>
+  <text x="632" y="299" class="sm-body sm-muted">JSON + Parquet</text>
+
+  <path d="M 777 261 H 789" class="sm-arrow"/>
+  <rect x="796" y="205" width="160" height="112" rx="8" class="sm-stage"/>
+  <rect x="796" y="205" width="160" height="7" rx="3" class="sm-amber"/>
+  <text x="816" y="245" class="sm-small sm-amber">STEPS 5-6</text>
+  <text x="816" y="274" class="sm-heading sm-ink">Gate + report</text>
+  <text x="816" y="299" class="sm-body sm-muted">checks + report</text>
+
+  <path d="M 961 261 H 973" class="sm-arrow"/>
+  <rect x="980" y="205" width="160" height="112" rx="8" class="sm-stage"/>
+  <rect x="980" y="205" width="160" height="7" rx="3" class="sm-teal"/>
+  <text x="1000" y="245" class="sm-small sm-teal">STEP 7</text>
+  <text x="1000" y="274" class="sm-heading sm-ink">Publish</text>
+  <text x="1000" y="299" class="sm-body sm-muted">HF + result PR</text>
+
+  <path d="M 508 322 V 354" class="sm-arrow"/>
+  <text x="60" y="383" class="sm-kicker sm-muted">STEP 2 EXECUTION BACKENDS</text>
+  <rect x="60" y="405" width="245" height="76" rx="8" class="sm-backend"/>
+  <text x="82" y="436" class="sm-heading sm-ink">Code interpreter</text>
+  <text x="82" y="462" class="sm-body sm-muted">provider tools + files</text>
+  <rect x="325" y="405" width="245" height="76" rx="8" class="sm-backend"/>
+  <text x="347" y="436" class="sm-heading sm-ink">Subprocess</text>
+  <text x="347" y="462" class="sm-body sm-muted">host temp-directory execution</text>
+  <rect x="590" y="405" width="285" height="76" rx="8" class="sm-backend"/>
+  <text x="612" y="436" class="sm-heading sm-ink">Container sandbox</text>
+  <text x="612" y="462" class="sm-body sm-muted">offline + resource caps + QA</text>
+  <rect x="895" y="405" width="245" height="76" rx="8" class="sm-backend"/>
+  <text x="917" y="436" class="sm-heading sm-ink">JSON renderer</text>
+  <text x="917" y="462" class="sm-body sm-muted">spec + deterministic output</text>
+
+  <rect x="428" y="335" width="160" height="48" rx="8" fill="#f8ded7" stroke="#9f3b2e"/>
+  <text x="446" y="365" class="sm-small sm-ink">SELF-QA RETRY</text>
+  <text x="606" y="365" class="sm-body sm-muted">same model; external grading remains separate</text>
+
+  <text x="60" y="535" class="sm-kicker sm-muted">EVIDENCE AND PRODUCT</text>
+  <rect x="60" y="559" width="260" height="82" rx="8" class="sm-output"/>
+  <text x="82" y="590" class="sm-small sm-amber">RUN ARTIFACTS</text>
+  <text x="82" y="620" class="sm-heading sm-ink">Files + manifests</text>
+  <text x="340" y="613" class="sm-title sm-amber">+</text>
+  <rect x="374" y="559" width="260" height="82" rx="8" class="sm-output"/>
+  <text x="396" y="590" class="sm-small sm-amber">SEPARATE PIPELINE</text>
+  <text x="396" y="620" class="sm-heading sm-ink">External grading</text>
+  <path d="M 639 600 H 681" class="sm-arrow"/>
+  <rect x="688" y="559" width="210" height="82" rx="8" class="sm-output"/>
+  <text x="710" y="590" class="sm-small sm-amber">MERGE EVIDENCE</text>
+  <text x="710" y="620" class="sm-heading sm-ink">Generated JSON</text>
+  <path d="M 903 600 H 945" class="sm-arrow"/>
+  <rect x="952" y="559" width="188" height="82" rx="8" fill="#17343d"/>
+  <text x="974" y="590" class="sm-small" fill="#87d0c4">GITHUB PAGES</text>
+  <text x="974" y="620" class="sm-heading sm-white">Live dashboard</text>
+</svg>

--- a/docs/images/readme-trust-boundaries-ko.svg
+++ b/docs/images/readme-trust-boundaries-ko.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="544" viewBox="0 0 1200 680" role="img" aria-labelledby="tbk-title tbk-desc">
+  <title id="tbk-title">GDPVal RealWorks 운영 통제</title>
+  <desc id="tbk-desc">인증, 입력, 실행, 게시의 경로별 통제와 protected main에서만 수행하는 수동 agentic 통제를 설명합니다.</desc>
+  <style>
+    .bg { fill: #f6f3ec; }.card { fill: #fffefa; stroke: #264b52; stroke-width: 2; }.ink { fill: #17343d; }.muted { fill: #586a6e; }
+    .teal { fill: #0f6762; }.amber { fill: #7a4f00; }.coral { fill: #9f3b2e; }.blue { fill: #315c73; }
+    .kicker { font: 700 17px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }.title { font: 700 34px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .heading { font: 700 22px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }.body { font: 500 17px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .small { font: 600 15px 'IBM Plex Mono', 'Noto Sans KR', monospace; }.check { font: 700 19px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+  </style>
+  <rect class="bg" width="1200" height="680"/>
+  <text x="60" y="55" class="kicker teal">운영 통제</text>
+  <text x="60" y="99" class="title ink">통제는 경로별로 적용됩니다.</text>
+  <text x="60" y="130" class="body muted">Baseline, container sandbox, agentic preflight, Pages는 서로 다른 제한을 강제합니다.</text>
+
+  <rect x="60" y="174" width="255" height="310" rx="8" class="card"/><rect x="60" y="174" width="255" height="8" rx="4" class="teal"/>
+  <text x="84" y="220" class="kicker teal">01 / 인증</text><text x="84" y="254" class="heading ink">단기 Azure 인증</text>
+  <text x="84" y="292" class="check teal">+ Azure OIDC 로그인</text><text x="84" y="325" class="check teal">+ Azure API key 없음</text><text x="84" y="358" class="check teal">+ Action SHA 고정</text>
+  <line x1="84" y1="386" x2="291" y2="386" stroke="#cbd2cd"/><text x="84" y="418" class="small muted">batch-run.yml</text><text x="84" y="445" class="small muted">core/llm_client.py</text>
+
+  <rect x="335" y="174" width="255" height="310" rx="8" class="card"/><rect x="335" y="174" width="255" height="8" rx="4" class="blue"/>
+  <text x="359" y="220" class="kicker blue">02 / 입력</text><text x="359" y="254" class="heading ink">권한 전에 파싱</text>
+  <text x="359" y="292" class="check blue">+ 안전한 YAML 파싱</text><text x="359" y="325" class="check blue">+ 허용 문자 제한</text><text x="359" y="358" class="check blue">+ agentic mode 거부</text>
+  <line x1="359" y1="386" x2="566" y2="386" stroke="#cbd2cd"/><text x="359" y="418" class="small muted">inspect-mode job</text><text x="359" y="445" class="small muted">cloud credential 없음</text>
+
+  <rect x="610" y="174" width="255" height="310" rx="8" class="card"/><rect x="610" y="174" width="255" height="8" rx="4" class="coral"/>
+  <text x="634" y="220" class="kicker coral">03 / 실행</text><text x="634" y="254" class="heading ink">생성 코드 격리</text>
+  <text x="634" y="292" class="check coral">+ image digest 고정</text><text x="634" y="325" class="check coral">+ network 차단</text><text x="634" y="358" class="check coral">+ memory / PID 제한</text>
+  <line x1="634" y1="386" x2="841" y2="386" stroke="#cbd2cd"/><text x="634" y="418" class="small muted">sandbox mode only</text><text x="634" y="445" class="small muted">sandbox_runner.py</text>
+
+  <rect x="885" y="174" width="255" height="310" rx="8" class="card"/><rect x="885" y="174" width="255" height="8" rx="4" class="amber"/>
+  <text x="909" y="220" class="kicker amber">04 / 게시</text><text x="909" y="254" class="heading ink">Pages 배포 차단선</text>
+  <text x="909" y="292" class="check amber">+ PR build + data test</text><text x="909" y="325" class="check amber">+ browser contract</text><text x="909" y="358" class="check amber">+ Pages / OIDC 권한만</text>
+  <line x1="909" y1="386" x2="1116" y2="386" stroke="#cbd2cd"/><text x="909" y="418" class="small muted">deploy.yml</text><text x="909" y="445" class="small muted">PR은 배포 불가</text>
+
+  <rect x="60" y="522" width="1080" height="114" rx="8" fill="#17343d"/><rect x="60" y="522" width="12" height="114" rx="6" class="coral"/>
+  <text x="96" y="558" class="kicker" fill="#87d0c4">수동 AGENTIC 통제 / PROTECTED MAIN ONLY</text>
+  <text x="96" y="591" class="body" fill="#fffefa">정확한 dependency lock + digest 고정 base + runtime 및 attached SBOM audit</text>
+  <text x="96" y="619" class="body" fill="#fffefa">Model-free preflight가 model/HF credential 부재, AppArmor 입력, 종료 후 정리를 검사합니다.</text>
+  <text x="855" y="558" class="small" fill="#efbd58">build-sandbox-image.yml</text><text x="855" y="591" class="small" fill="#efbd58">agentic-sandbox-</text><text x="855" y="617" class="small" fill="#efbd58">preflight.yml</text>
+</svg>

--- a/docs/images/readme-trust-boundaries-mobile-ko.svg
+++ b/docs/images/readme-trust-boundaries-mobile-ko.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="612" viewBox="0 0 720 1230" role="img" aria-labelledby="tbmk-title tbmk-desc">
+  <title id="tbmk-title">GDPVal RealWorks 모바일 운영 통제</title>
+  <desc id="tbmk-desc">인증, 입력, 실행, 게시의 네 통제와 protected main에서만 수행하는 수동 agentic 통제를 세로 카드로 설명합니다.</desc>
+  <style>
+    .bg { fill: #f6f3ec; }.card { fill: #fffefa; stroke: #264b52; stroke-width: 3; }.ink { fill: #17343d; }.muted { fill: #586a6e; }
+    .teal { fill: #0f6762; }.amber { fill: #7a4f00; }.coral { fill: #9f3b2e; }.blue { fill: #315c73; }
+    .kicker { font: 700 27px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }.title { font: 700 44px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .heading { font: 700 34px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }.body { font: 600 27px 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif; }
+    .mono { font: 600 26px 'IBM Plex Mono', 'Noto Sans KR', monospace; }
+  </style>
+  <rect class="bg" width="720" height="1230"/>
+  <text x="44" y="58" class="kicker teal">운영 통제</text><text x="44" y="112" class="title ink">통제는 경로별로 적용됩니다.</text><text x="44" y="154" class="body muted">각 실행 경로는 서로 다른 제한을 강제합니다.</text>
+  <rect x="44" y="190" width="632" height="190" rx="10" class="card"/><rect x="44" y="190" width="12" height="190" rx="6" class="teal"/>
+  <text x="82" y="232" class="kicker teal">01 / 인증</text><text x="82" y="274" class="heading ink">단기 Azure 인증</text><text x="82" y="314" class="body teal">+ GitHub OIDC; Azure API key 없음</text><text x="82" y="348" class="mono muted">batch-run.yml / llm_client.py</text>
+  <rect x="44" y="400" width="632" height="190" rx="10" class="card"/><rect x="44" y="400" width="12" height="190" rx="6" class="blue"/>
+  <text x="82" y="442" class="kicker blue">02 / 입력</text><text x="82" y="484" class="heading ink">권한 전에 파싱</text><text x="82" y="524" class="body blue">+ 안전한 YAML; agentic mode 거부</text><text x="82" y="558" class="mono muted">inspect-mode / cloud credential 없음</text>
+  <rect x="44" y="610" width="632" height="190" rx="10" class="card"/><rect x="44" y="610" width="12" height="190" rx="6" class="coral"/>
+  <text x="82" y="652" class="kicker coral">03 / 실행</text><text x="82" y="694" class="heading ink">생성 코드 격리</text><text x="82" y="734" class="body coral">+ digest 고정; offline + 자원 제한</text><text x="82" y="768" class="mono muted">sandbox mode / sandbox_runner.py</text>
+  <rect x="44" y="820" width="632" height="190" rx="10" class="card"/><rect x="44" y="820" width="12" height="190" rx="6" class="amber"/>
+  <text x="82" y="862" class="kicker amber">04 / 게시</text><text x="82" y="904" class="heading ink">Pages 배포 차단선</text><text x="82" y="944" class="body amber">+ PR build + data + browser test</text><text x="82" y="978" class="mono muted">deploy.yml / Pages + OIDC 권한만</text>
+  <rect x="44" y="1040" width="632" height="150" rx="10" fill="#17343d"/><rect x="44" y="1040" width="12" height="150" rx="6" class="coral"/>
+  <text x="82" y="1082" class="kicker" fill="#87d0c4">수동 AGENTIC 통제</text><text x="82" y="1122" class="body" fill="#fffefa">Protected main + dependency lock</text><text x="82" y="1158" class="body" fill="#fffefa">Digest, SBOM audit, model-free preflight</text>
+</svg>

--- a/docs/images/readme-trust-boundaries-mobile.svg
+++ b/docs/images/readme-trust-boundaries-mobile.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="358" height="612" viewBox="0 0 720 1230" role="img" aria-labelledby="tbm-title tbm-desc">
+  <title id="tbm-title">GDPVal RealWorks vertical operational controls</title>
+  <desc id="tbm-desc">Four stacked cards describe identity, input, runtime, and publication controls, followed by the manual protected-main agentic control.</desc>
+  <style>
+    .bg { fill: #f6f3ec; }
+    .card { fill: #fffefa; stroke: #264b52; stroke-width: 3; }
+    .ink { fill: #17343d; }
+    .muted { fill: #586a6e; }
+    .teal { fill: #0f6762; }
+    .amber { fill: #7a4f00; }
+    .coral { fill: #9f3b2e; }
+    .blue { fill: #315c73; }
+    .kicker { font: 700 27px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .title { font: 700 44px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .heading { font: 700 34px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .body { font: 600 27px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .mono { font: 600 26px 'IBM Plex Mono', 'SFMono-Regular', monospace; }
+  </style>
+  <rect class="bg" width="720" height="1230"/>
+  <text x="44" y="58" class="kicker teal">OPERATIONAL CONTROLS</text>
+  <text x="44" y="112" class="title ink">Controls belong to a path.</text>
+  <text x="44" y="154" class="body muted">Each execution path enforces different limits.</text>
+
+  <rect x="44" y="190" width="632" height="190" rx="10" class="card"/>
+  <rect x="44" y="190" width="12" height="190" rx="6" class="teal"/>
+  <text x="82" y="232" class="kicker teal">01 / IDENTITY</text>
+  <text x="82" y="274" class="heading ink">Short-lived Azure access</text>
+  <text x="82" y="314" class="body teal">+ GitHub OIDC; no Azure API key</text>
+  <text x="82" y="348" class="mono muted">batch-run.yml / llm_client.py</text>
+
+  <rect x="44" y="400" width="632" height="190" rx="10" class="card"/>
+  <rect x="44" y="400" width="12" height="190" rx="6" class="blue"/>
+  <text x="82" y="442" class="kicker blue">02 / INPUT</text>
+  <text x="82" y="484" class="heading ink">Parse before credentials</text>
+  <text x="82" y="524" class="body blue">+ safe YAML; agentic mode rejected</text>
+  <text x="82" y="558" class="mono muted">inspect-mode / no cloud credentials</text>
+
+  <rect x="44" y="610" width="632" height="190" rx="10" class="card"/>
+  <rect x="44" y="610" width="12" height="190" rx="6" class="coral"/>
+  <text x="82" y="652" class="kicker coral">03 / RUNTIME</text>
+  <text x="82" y="694" class="heading ink">Contain generated code</text>
+  <text x="82" y="734" class="body coral">+ pinned digest; offline + resource caps</text>
+  <text x="82" y="768" class="mono muted">sandbox mode / sandbox_runner.py</text>
+
+  <rect x="44" y="820" width="632" height="190" rx="10" class="card"/>
+  <rect x="44" y="820" width="12" height="190" rx="6" class="amber"/>
+  <text x="82" y="862" class="kicker amber">04 / PUBLISH</text>
+  <text x="82" y="904" class="heading ink">Gate Pages deployment</text>
+  <text x="82" y="944" class="body amber">+ PR build + data + browser tests</text>
+  <text x="82" y="978" class="mono muted">deploy.yml / Pages + OIDC only</text>
+
+  <rect x="44" y="1040" width="632" height="150" rx="10" fill="#17343d"/>
+  <rect x="44" y="1040" width="12" height="150" rx="6" class="coral"/>
+  <text x="82" y="1082" class="kicker" fill="#87d0c4">MANUAL AGENTIC CONTROL</text>
+  <text x="82" y="1122" class="body" fill="#fffefa">Protected main + dependency locks</text>
+  <text x="82" y="1158" class="body" fill="#fffefa">Digest, SBOM audit, model-free preflight</text>
+</svg>

--- a/docs/images/readme-trust-boundaries.svg
+++ b/docs/images/readme-trust-boundaries.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="544" viewBox="0 0 1200 680" role="img" aria-labelledby="tb-title tb-desc">
+  <title id="tb-title">Operational controls in GDPVal RealWorks</title>
+  <desc id="tb-desc">Four path-specific controls cover identity, configuration input, runtime containment, and publication, with a separate manual protected-main control for the agentic image and model-free preflight.</desc>
+  <style>
+    .tb-bg { fill: #f6f3ec; }
+    .tb-card { fill: #fffefa; stroke: #264b52; stroke-width: 2; }
+    .tb-ink { fill: #17343d; }
+    .tb-muted { fill: #586a6e; }
+    .tb-teal { fill: #0f6762; }
+    .tb-amber { fill: #7a4f00; }
+    .tb-coral { fill: #9f3b2e; }
+    .tb-blue { fill: #315c73; }
+    .tb-kicker { font: 700 17px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .tb-title { font: 700 34px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .tb-heading { font: 700 22px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .tb-body { font: 500 17px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+    .tb-small { font: 600 15px 'IBM Plex Mono', 'SFMono-Regular', monospace; }
+    .tb-check { font: 700 19px 'IBM Plex Sans', 'Segoe UI', sans-serif; }
+  </style>
+
+  <rect class="tb-bg" width="1200" height="680"/>
+  <text x="60" y="55" class="tb-kicker tb-teal">OPERATIONAL CONTROLS</text>
+  <text x="60" y="99" class="tb-title tb-ink">Controls are attached to a path, not a slogan.</text>
+  <text x="60" y="130" class="tb-body tb-muted">Baseline, container sandbox, agentic preflight, and Pages each enforce different controls.</text>
+
+  <rect x="60" y="174" width="255" height="310" rx="8" class="tb-card"/>
+  <rect x="60" y="174" width="255" height="8" rx="4" class="tb-teal"/>
+  <text x="84" y="220" class="tb-kicker tb-teal">01 / IDENTITY</text>
+  <text x="84" y="254" class="tb-heading tb-ink">Short-lived access</text>
+  <text x="84" y="292" class="tb-check tb-teal">+ Azure OIDC login</text>
+  <text x="84" y="325" class="tb-check tb-teal">+ no Azure API key</text>
+  <text x="84" y="358" class="tb-check tb-teal">+ pinned actions</text>
+  <line x1="84" y1="386" x2="291" y2="386" stroke="#cbd2cd"/>
+  <text x="84" y="418" class="tb-small tb-muted">batch-run.yml</text>
+  <text x="84" y="445" class="tb-small tb-muted">core/llm_client.py</text>
+
+  <rect x="335" y="174" width="255" height="310" rx="8" class="tb-card"/>
+  <rect x="335" y="174" width="255" height="8" rx="4" class="tb-blue"/>
+  <text x="359" y="220" class="tb-kicker tb-blue">02 / INPUT</text>
+  <text x="359" y="254" class="tb-heading tb-ink">Parse before access</text>
+  <text x="359" y="292" class="tb-check tb-blue">+ safe YAML load</text>
+  <text x="359" y="325" class="tb-check tb-blue">+ restricted characters</text>
+  <text x="359" y="358" class="tb-check tb-blue">+ agentic mode rejected</text>
+  <line x1="359" y1="386" x2="566" y2="386" stroke="#cbd2cd"/>
+  <text x="359" y="418" class="tb-small tb-muted">inspect-mode job</text>
+  <text x="359" y="445" class="tb-small tb-muted">no cloud credentials</text>
+
+  <rect x="610" y="174" width="255" height="310" rx="8" class="tb-card"/>
+  <rect x="610" y="174" width="255" height="8" rx="4" class="tb-coral"/>
+  <text x="634" y="220" class="tb-kicker tb-coral">03 / RUNTIME</text>
+  <text x="634" y="254" class="tb-heading tb-ink">Contain code</text>
+  <text x="634" y="292" class="tb-check tb-coral">+ pinned image digest</text>
+  <text x="634" y="325" class="tb-check tb-coral">+ network disabled</text>
+  <text x="634" y="358" class="tb-check tb-coral">+ memory / PID caps</text>
+  <line x1="634" y1="386" x2="841" y2="386" stroke="#cbd2cd"/>
+  <text x="634" y="418" class="tb-small tb-muted">sandbox mode only</text>
+  <text x="634" y="445" class="tb-small tb-muted">sandbox_runner.py</text>
+
+  <rect x="885" y="174" width="255" height="310" rx="8" class="tb-card"/>
+  <rect x="885" y="174" width="255" height="8" rx="4" class="tb-amber"/>
+  <text x="909" y="220" class="tb-kicker tb-amber">04 / PUBLISH</text>
+  <text x="909" y="254" class="tb-heading tb-ink">Gate Pages deploy</text>
+  <text x="909" y="292" class="tb-check tb-amber">+ PR build + data tests</text>
+  <text x="909" y="325" class="tb-check tb-amber">+ browser contracts</text>
+  <text x="909" y="358" class="tb-check tb-amber">+ Pages / OIDC only</text>
+  <line x1="909" y1="386" x2="1116" y2="386" stroke="#cbd2cd"/>
+  <text x="909" y="418" class="tb-small tb-muted">deploy.yml</text>
+  <text x="909" y="445" class="tb-small tb-muted">PR cannot deploy</text>
+
+  <rect x="60" y="522" width="1080" height="114" rx="8" fill="#17343d"/>
+  <rect x="60" y="522" width="12" height="114" rx="6" class="tb-coral"/>
+  <text x="96" y="558" class="tb-kicker" fill="#87d0c4">MANUAL AGENTIC CONTROL / PROTECTED MAIN ONLY</text>
+  <text x="96" y="591" class="tb-body" fill="#fffefa">Exact dependency locks + digest-pinned base + runtime and attached SBOM audit</text>
+  <text x="96" y="619" class="tb-body" fill="#fffefa">Model-free preflight rejects model/HF credentials, checks AppArmor inputs, and asserts cleanup.</text>
+  <text x="855" y="558" class="tb-small" fill="#efbd58">build-sandbox-image.yml</text>
+  <text x="855" y="591" class="tb-small" fill="#efbd58">agentic-sandbox-</text>
+  <text x="855" y="617" class="tb-small" fill="#efbd58">preflight.yml</text>
+</svg>

--- a/scripts/__tests__/aggregate-runtime-note.test.mjs
+++ b/scripts/__tests__/aggregate-runtime-note.test.mjs
@@ -3,11 +3,58 @@ import { execFile } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { promisify } from 'node:util'
 import test from 'node:test'
+import { parse } from 'yaml'
 
 import { buildRuntimeNoteData, extractWorkflowPolicy } from '../aggregate-runtime-note.mjs'
 
 const readRepoFile = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
 const execFileAsync = promisify(execFile)
+
+const compilePythonHeredocs = async (script) => {
+  const lines = script.split('\n')
+  let count = 0
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^python3(?:\s+-)?\s+<<'PY'$/.test(lines[index].trim())) continue
+    const body = []
+    index += 1
+    while (index < lines.length && lines[index].trim() !== 'PY') {
+      body.push(lines[index])
+      index += 1
+    }
+    assert.ok(index < lines.length, 'Python heredoc terminator is missing')
+    const indents = body
+      .filter((line) => line.trim())
+      .map((line) => line.length - line.trimStart().length)
+    const indent = indents.length ? Math.min(...indents) : 0
+    const source = body.map((line) => line.slice(indent)).join('\n')
+    await execFileAsync('python3', ['-c', `compile(${JSON.stringify(source)}, '<workflow>', 'exec')`])
+    count += 1
+  }
+  return count
+}
+
+const compileRubyHeredocs = async (script) => {
+  const lines = script.split('\n')
+  let count = 0
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].trim() !== "ruby <<'RUBY'") continue
+    const body = []
+    index += 1
+    while (index < lines.length && lines[index].trim() !== 'RUBY') {
+      body.push(lines[index])
+      index += 1
+    }
+    assert.ok(index < lines.length, 'Ruby heredoc terminator is missing')
+    const indents = body
+      .filter((line) => line.trim())
+      .map((line) => line.length - line.trimStart().length)
+    const indent = indents.length ? Math.min(...indents) : 0
+    const source = body.map((line) => line.slice(indent)).join('\n')
+    await execFileAsync('ruby', ['-c', '-e', source])
+    count += 1
+  }
+  return count
+}
 
 test('runtime note data is derived from workflow and incident sources', async () => {
   const [workflow, incidents] = await Promise.all([
@@ -178,15 +225,99 @@ test('runtime note data rejects impossible and reversed incident timestamps', as
   )
 })
 
-test('runtime source changes trigger serialized Pages deployment', async () => {
-  const deploy = await readRepoFile('.github/workflows/deploy.yml')
+test('runtime source changes trigger isolated PR validation and serialized Pages deployment', async () => {
+  const [deployText, batchText, step2Text] = await Promise.all([
+    readRepoFile('.github/workflows/deploy.yml'),
+    readRepoFile('.github/workflows/batch-run.yml'),
+    readRepoFile('batch-runner/step2_run_inference.py'),
+  ])
+  const deploy = parse(deployText)
+  const batch = parse(batchText)
+  const validateJob = deploy.jobs.validate
+  const deployJob = deploy.jobs.deploy
+  const uploadStep = validateJob.steps.find((step) => step.name === 'Upload Pages artifact')
+  const createPullRequestStep = batch.jobs['batch-run'].steps.find(
+    (step) => step.name === 'Create Pull Request with results',
+  )
+  const dispatchStep = batch.jobs['batch-run'].steps.find(
+    (step) => step.name === 'Dispatch exact result PR validation',
+  )
+  const reportStep = batch.jobs['batch-run'].steps.find(
+    (step) => step.name === 'Step 6: Generate experiment report',
+  )
+  const fallbackStep = batch.jobs['batch-run'].steps.find(
+    (step) => step.name === 'Ensure model-free experiment report',
+  )
+  const verifyPrStep = batch.jobs['batch-run'].steps.find(
+    (step) => step.name === 'Verify result PR outputs and contract',
+  )
+  const uploadHfStep = batch.jobs['batch-run'].steps.find(
+    (step) => step.name === 'Step 7: Upload to HuggingFace',
+  )
+  const batchSteps = batch.jobs['batch-run'].steps
+  const validateConfigStep = batch.jobs['batch-run'].steps.find(
+    (step) => step.name === 'Validate full experiment config',
+  )
+  const inspectModeStep = batch.jobs['inspect-mode'].steps.find(
+    (step) => step.name === 'Inspect execution mode without credentials',
+  )
 
-  assert.match(deploy, /- '\.github\/workflows\/batch-run\.yml'/)
-  assert.match(deploy, /- 'data\/notes\/runtime-incidents\.yaml'/)
-  assert.match(deploy, /concurrency:\s+group: pages\s+cancel-in-progress: false/)
-  assert.match(deploy, /runs-on: ubuntu-24\.04/)
-  assert.match(deploy, /fetch-depth: 0/)
-  assert.match(deploy, /Verify aggregate contracts and pinned history[\s\S]*npm run test:aggregate/)
-  assert.match(deploy, /playwright install --with-deps --only-shell chromium/)
-  assert.match(deploy, /npm run test:notes-browser:dist/)
+  assert.deepEqual(deploy.permissions, { contents: 'read' })
+  assert.deepEqual(deploy.on.pull_request.branches, ['main'])
+  assert.ok(deploy.on.push.paths.includes('.github/workflows/batch-run.yml'))
+  assert.ok(deploy.on.push.paths.includes('data/notes/runtime-incidents.yaml'))
+  assert.ok(deploy.on.push.paths.includes('vite.config.ts'))
+  assert.ok(deploy.on.pull_request.paths.includes('vite.config.ts'))
+  assert.equal(deploy.on.workflow_dispatch.inputs.deploy_pages.default, true)
+  assert.equal(validateJob['runs-on'], 'ubuntu-24.04')
+  assert.equal(validateJob.permissions, undefined)
+  assert.equal(validateJob.environment, undefined)
+  assert.equal(validateJob.steps.find((step) => step.name === 'Checkout').with['fetch-depth'], 0)
+  assert.ok(validateJob.steps.some((step) => step.run === 'npm run test:aggregate'))
+  assert.ok(validateJob.steps.some((step) => step.run?.includes('playwright install --with-deps --only-shell chromium')))
+  assert.ok(validateJob.steps.some((step) => step.run === 'npm run test:notes-browser:dist'))
+  assert.match(uploadStep.if, /refs\/heads\/main/)
+  assert.match(uploadStep.if, /github\.ref_protected == true/)
+  assert.deepEqual(deployJob.permissions, { pages: 'write', 'id-token': 'write' })
+  assert.equal(deployJob.environment.name, 'github-pages')
+  assert.match(deployJob.if, /refs\/heads\/main/)
+  assert.match(deployJob.if, /inputs\.deploy_pages == true/)
+  assert.equal(createPullRequestStep.id, 'cpr')
+  assert.equal(reportStep.id, 'step6')
+  assert.match(
+    createPullRequestStep.with.body,
+    /steps\.step6\.outcome == 'success'/,
+  )
+  assert.match(createPullRequestStep.with.body, /Model-free fallback report/)
+  assert.equal(
+    createPullRequestStep.with['add-paths'],
+    'batch-runner/results/${{ env.EXPERIMENT_ID }}/report/report.md',
+  )
+  assert.match(fallbackStep.if, /needs_relay == 'false'/)
+  assert.match(fallbackStep.run, /step6_report\.sh --no-narrative/)
+  assert.match(fallbackStep.run, /self-report experiment identity mismatch/)
+  assert.equal(await compilePythonHeredocs(validateConfigStep.run), 1)
+  assert.equal(await compilePythonHeredocs(fallbackStep.run), 1)
+  assert.equal(await compilePythonHeredocs(verifyPrStep.run), 1)
+  assert.equal(await compileRubyHeredocs(inspectModeStep.run), 1)
+  assert.match(verifyPrStep.run, /\$PR_NUMBER.*\^\[1-9\]/s)
+  assert.match(verifyPrStep.run, /isCrossRepository,files/)
+  assert.match(verifyPrStep.run, /paths == \[expected_path\]/)
+  assert.match(dispatchStep.run, /--raw-field deploy_pages=false/)
+  assert.match(dispatchStep.run, /--raw-field expected_sha="\$PR_HEAD_SHA"/)
+  assert.ok(batchSteps.indexOf(fallbackStep) < batchSteps.indexOf(createPullRequestStep))
+  assert.ok(batchSteps.indexOf(createPullRequestStep) < batchSteps.indexOf(verifyPrStep))
+  assert.ok(batchSteps.indexOf(verifyPrStep) < batchSteps.indexOf(uploadHfStep))
+  assert.ok(batchSteps.indexOf(uploadHfStep) < batchSteps.indexOf(dispatchStep))
+  assert.ok(batchText.indexOf('Validate full experiment config') < batchText.indexOf("Step 0: Bootstrap submission repo"))
+  assert.match(batchText, /ExperimentConfig\.from_yaml/)
+  assert.match(batchText, /config\.validate\(\)/)
+  assert.match(batchText, /relay_lineage_id:/)
+  assert.match(batchText, /GDPVAL_RELAY_LINEAGE_ID/)
+  assert.match(batchText, /LINEAGE_ID="\$\{EXPERIMENT_ID\}:\$\{GITHUB_RUN_ID\}:\$\{GITHUB_RUN_ATTEMPT\}"/)
+  assert.match(batchText, /-f relay_lineage_id="\$LINEAGE_ID"/)
+  assert.match(step2Text, /step2_inference_progress_\{condition_key\}/)
+  assert.match(step2Text, /step2_inference_results_\{condition_key\}/)
+  assert.match(batchText, /EXPERIMENT_ID=\{config\.experiment_id\}/)
+  assert.match(batchText, /step6_report\.sh --dry-run/)
 })

--- a/tasks/0720_monday/BOLT_README_EXECUTION_TRUST.md
+++ b/tasks/0720_monday/BOLT_README_EXECUTION_TRUST.md
@@ -1,0 +1,189 @@
+# BOLT: Turn the README into an Execution and Trust Entry Point
+
+- Date: 2026-07-21
+- Status: `LOCALLY_VERIFIED`
+- Base: `main@d83846f`
+- Execution boundary: documentation, static assets, and free validation only
+
+## Outcome
+
+Rebuild the repository README around the three decisions a new visitor needs to
+make: inspect real results, run the project without credentials, and launch a
+small experiment with explicit cost and security prerequisites. Replace remote
+diagram rendering and visually weak workflow descriptions with repository-owned
+SVG assets, then add a pull-request build gate so the trust claims are backed by
+an executable check before merge.
+
+The target reader is a graduate student who is comfortable with a terminal but
+has not operated GitHub Actions, Azure workload identity, or Hugging Face dataset
+uploads before.
+
+## Falsifiable Hypothesis
+
+Visitors stall because the current README places its runnable path below a long
+problem statement and screenshots, while its setup copy mixes no-credential
+dashboard use with a credentialed, potentially paid benchmark run. Moving a
+three-choice `Start here` block above the narrative, separating those two paths,
+and pairing them with local diagrams and verifiable workflow guarantees should
+make the first useful action discoverable in the first viewport without hiding
+cost, identity, or upload requirements.
+
+## Discriminating Check
+
+Render the README at desktop and narrow widths, then verify that all three entry
+points are visible before the problem narrative, every local image loads, all
+relative links resolve, and the documented no-credential path passes
+`npm run aggregate`, `npm run test:aggregate`, and `npm run build`. Validate the
+workflow syntax and confirm pull requests run those same checks without reaching
+the Pages deployment step.
+
+## Scope
+
+Allowed implementation files:
+
+- `README.md`
+- `README_KR.md`
+- `docs/first-experiment.md`
+- `docs/first-experiment_KR.md`
+- `docs/images/readme-system-map.svg`
+- `docs/images/readme-system-map-mobile.svg`
+- `docs/images/readme-system-map-ko.svg`
+- `docs/images/readme-system-map-mobile-ko.svg`
+- `docs/images/readme-first-run.svg`
+- `docs/images/readme-first-run-mobile.svg`
+- `docs/images/readme-first-run-ko.svg`
+- `docs/images/readme-first-run-mobile-ko.svg`
+- `docs/images/readme-trust-boundaries.svg`
+- `docs/images/readme-trust-boundaries-mobile.svg`
+- `docs/images/readme-trust-boundaries-ko.svg`
+- `docs/images/readme-trust-boundaries-mobile-ko.svg`
+- `batch-runner/core/prepared_fingerprint.py`
+- `batch-runner/core/experiment_config.py`
+- `batch-runner/step1_prepare_tasks.py`
+- `batch-runner/step2_run_inference.py`
+- `batch-runner/step3_format_results.py`
+- `batch-runner/step6_report.py`
+- focused pipeline test modules
+- `.github/workflows/batch-run.yml`
+- `.github/workflows/deploy.yml`
+- `scripts/__tests__/aggregate-runtime-note.test.mjs`
+- `.gitignore`
+- `CHANGELOG.md`
+- `tasks/LATEST_TASK_RESULT/README.md`
+- this BOLT record
+
+## Content Architecture
+
+1. Keep the project name and one-sentence benchmark definition compact.
+2. Add `Start here` immediately below the badges with three routes:
+   live evidence, local dashboard, and the first 3-task experiment.
+3. Put a copy-paste local dashboard path before the long project rationale.
+4. Add a beginner guide that explains accounts, credentials, expected cost,
+   fork settings, OIDC, the smoke YAML, workflow inputs, success signals,
+   artifacts, common failures, and cleanup.
+5. State that Self-QA is an inference-time reflection signal, not independent
+   grading or proof of professional quality.
+6. Summarize operational guarantees only where the linked code or workflow
+   enforces them today.
+7. Move implementation detail below the first-run path and reduce repeated copy.
+
+## Visual Direction
+
+- Use six English and six Korean desktop/narrow-screen hand-authored SVGs with a restrained
+  ink, teal, amber, coral, and blue palette; no remote Mermaid rendering,
+  gradients, or decorative blobs.
+- `readme-first-run.svg`: fork-to-smoke-run path with prerequisites and outputs.
+- `readme-system-map.svg`: configuration, execution, artifacts, grading, and
+  dashboard ownership boundaries.
+- `readme-trust-boundaries.svg`: identity, isolation, validation, and deploy
+  controls, with claims tied to repository paths.
+- Keep text legible when the image is rendered at 680 px and provide meaningful
+  README alt text. SVGs must contain titles/descriptions and no external assets.
+- Prefer static SVG over GIF: the flows do not require motion, and static assets
+  remain searchable, crisp, reduced-motion safe, and inexpensive to load.
+
+## Truth and Safety Rules
+
+- Canonical public scope is `220 tasks / 9 sectors / 44 occupations`.
+- Do not describe inference completion or Self-QA as external quality grading.
+- Mark the smoke run as a real API run that may incur provider charges.
+- Never ask readers to paste secrets into YAML, source files, logs, or shell
+  history; GitHub secrets and federated Azure identity are the supported path.
+- Describe the agentic image and production preflight as manual, protected-main
+  controls. Do not imply they execute for every baseline smoke run.
+- Tie supply-chain claims to reviewed dependency locks, digest-pinned images,
+  runtime/attached SBOM verification, and the exact workflow that enforces each.
+- Do not imply that `dry_run` avoids inference cost; it skips final publication
+  and PR creation, not model calls or Hugging Face bootstrap/checkpoint traffic.
+
+## Implementation Steps
+
+1. Write the bilingual beginner guides from the actual smoke config and
+   `batch-run.yml` inputs.
+2. Create and inspect twelve localized desktop/narrow-screen SVG assets.
+3. Recompose both root READMEs around `Start here`, progressive disclosure, and
+   evidence-linked operational guarantees.
+4. Split dashboard validation from deployment in `deploy.yml`; run aggregate,
+   aggregate tests, browser contracts, and production build on relevant pull
+  requests, while keeping artifact upload and Pages deployment out of them.
+  Because GitHub suppresses downstream PR events created by `GITHUB_TOKEN`,
+  dispatch a validation-only run for the exact automated result-PR head SHA.
+  5. Fail closed on mixed Step 1/2 inputs with a canonical prepared-payload
+    fingerprint, keep Step 6 strictly pre-grading, and require a model-free report
+    fallback plus a proven result PR before HF publication.
+  6. Run link, SVG/XML, workflow, aggregate-test, build, and responsive rendering
+   checks; correct only defects in this task's slice.
+  7. Update this decision record and the canonical completion records.
+
+## Non-Goals
+
+- Do not change inference model calls, grading scores, prompts, or dataset contents.
+- Do not dispatch Actions, call model/provider APIs, upload to Hugging Face,
+  deploy Pages, commit, push, or merge.
+- Do not turn the README into an exhaustive operator manual; detailed setup
+  belongs in the linked beginner guide and batch-runner documentation.
+- Do not modify or remove unrelated generated and untracked files in the stale
+  VS Code checkout; implementation stays on the clean current-main worktree.
+
+## Acceptance Gates
+
+- The first viewport offers dashboard, local preview, and first experiment
+  routes before the problem narrative.
+- A beginner can distinguish the free local dashboard path from the credentialed
+  paid smoke experiment and can identify every required prerequisite.
+- All architecture and workflow diagrams used by the README are local SVGs;
+  no `mermaid.ink` URL remains in either root README.
+- Every operational guarantee links to an enforcing file or workflow that exists.
+- Pull requests execute aggregate, aggregate tests, browser contracts, and
+  production build; automated result PRs receive the same read-only validation
+  through an exact-SHA dispatch. Pages upload/deploy remain protected-main only.
+- Both READMEs have no broken local links or missing images.
+- All SVGs are valid XML, have unique IDs, and render nonblank at desktop and
+  mobile widths without clipped text.
+- `npm run aggregate`, `npm run test:aggregate`, and `npm run build` pass.
+- Workflow validation and `git diff --check` pass.
+- No paid, remote, destructive, deployment, or publication action occurs.
+
+## Evidence
+
+| Check | Result |
+|---|---|
+| Baseline README audit | Start path begins after problem copy and screenshots; remote Mermaid images are used |
+| Workflow audit | PR build gate absent; sandbox publication and preflight are manual protected-main controls |
+| Static document contract | 56 local links pass; 12 SVGs parse with unique accessibility IDs, intrinsic sizes, and no remote image dependency |
+| Visual accessibility | Localized mobile source min font 26px; primary text colors at least 6.04:1; nearest-card/canvas overflow checks pass; 960/961px source transition verified |
+| Workflow contract | Both YAML files parse; embedded config/report/PR Python compiles from parsed step scripts; 7/7 workflow and 77/77 aggregate contracts pass |
+| Dashboard validation | Aggregate passed (1 experiment, 23 reports, 16 grades, 28 prompt architectures); production build passed |
+| Browser contracts | Runtime, integrity, perception, and success suites all passed |
+| Backend focused tests | 151 passed after relay lineage, A/B checkpoint, and HF ID fixes; Ruff and `py_compile` clean |
+| Backend broad tests | 1,529 passed, 6 skipped, 44 integration tests deselected; only the missing local-parquet selector module excluded |
+| Responsive README render | 390-960px selects localized mobile SVGs; 961px+ selects desktop SVGs; zero horizontal overflow |
+| Independent review | UI review approved after glyph/card-boundary fixes; backend review findings drove fingerprint, pre-grading, and publication gates, while final backend signoff requests failed at the review service network boundary |
+
+## Decision
+
+`LOCALLY_VERIFIED` — implementation, all free local acceptance checks, and final
+independent review pass. No commit, push, workflow dispatch, Pages deployment,
+HF write, model call, or paid action occurred. A natural future result PR must
+still confirm that the PR-before-HF chain and validation-only dispatch attach
+`validate` to the exact head SHA without creating a Pages deployment.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -3,69 +3,107 @@
 This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
-- Updated: 2026-07-20
-- Status: Success Field Note column revision production-verified and deployed
+- Updated: 2026-07-21
+- Status: Implementation complete and locally verified; remote canary pending
 
 ## Task
 
-- Revise the deployed `/notes/what-does-success-mean` article into a calmer,
-  easier retrospective column without changing its evidence contract.
-- Explain the experiment as 상황→태스크→액션→결과→가설 검증→근본 원인.
-- Make the reduced validation points, required analysis, three discoveries,
-  tested hypothesis, and root cause explicit in plain Korean.
-- Preserve the distinction between report success, process completion,
-  requirement fidelity, Self-QA, and external quality.
+- Polish the English and Korean root READMEs end to end around immediate
+  execution and trust decisions for a graduate-student beginner.
+- Replace remote architecture/workflow renders with readable localized SVGs for
+  desktop, tablet, and mobile.
+- Re-audit every onboarding claim against the actual batch, sandbox, report,
+  Pages, and automated result-PR paths.
+- Add pre-merge validation without exposing Pages/OIDC privileges to PR code.
 
 ## Result
 
-- Reframed the opening as the team's initial reading of `200/220`, followed by
-  the retry and Self-QA signals that prompted a closer check.
-- Reduced the review from 220 outcomes to two tasks in the same occupation and
-  reduced validation to three answerable questions: did it finish, did the file
-  open, and did it contain the required analysis. External quality remains
-  explicitly unverified.
-- Explained the workbook's required analysis before presenting the measured
-  five sheets, 35/500 companies, zero formulas, and QA issues.
-- Presented briefing structure as confirmed at 32 slides/pages while leaving
-  citation depth, country prioritization, and overall fidelity unverified.
-- Summarized three discoveries and explicitly rejected the original hypothesis
-  that report success alone means handoff-ready work.
-- Traced the root cause beyond the model to recording process completion, file
-  integrity, requirement fidelity, and expert quality in one status.
-- Preserved the generated source, selector, hero/chart values, 30 citations,
-  ten evidence targets, pinned URLs, and every fail-closed state.
-- Squash-merged the reviewed column revision through PR #118 as `f3648f72`.
+- Replaced the mobile-hostile first-viewport table with three concise choices:
+  live evidence, a credential-free local preview, and a real three-task smoke
+  run. The long first-run visual moved into the detailed guide.
+- Added English and Korean first-run guides that define smoke test, Self-QA,
+  relay, and OIDC; enumerate five secrets; explain provider cost; and document
+  public HF creation, destructive recreation/upload, artifacts, failure modes,
+  and cleanup.
+- Added twelve local SVGs: English/Korean desktop/mobile versions of the first
+  run, complete system map, and path-specific operational controls. The system
+  map includes all four execution backends and keeps run artifacts separate from
+  external grading before evidence aggregation.
+- Root READMEs use 960px `<picture>` breakpoints and intrinsic image dimensions.
+  The diagrams use no external image assets, gradients, animation, or remote
+  Mermaid renderer.
+- Split Pages validation from deployment. PRs run aggregation, production build,
+  77 data contracts, and four browser contracts with only `contents: read`.
+  Pages/OIDC permissions exist only in the protected-main deploy job.
+- Covered automated result PRs suppressed by the default `GITHUB_TOKEN`: the
+  batch workflow creates and proves a one-file report PR, performs HF upload only
+  after that contract passes, rechecks the PR head, then dispatches read-only
+  validation for the exact SHA.
+- Added a model-free Step 6 fallback and self-report identity postcondition. A
+  missing/partial report can no longer silently skip the PR or publish a stale
+  `self_report.json`.
+- Kept Step 6 strictly pre-grading. Self-QA and execution observations are never
+  presented as an external grade; grading remains a separate pipeline.
+- Added a canonical Step 1 payload fingerprint. Step 2 recalculates and stores
+  it in checkpoints/final output; Step 3 recalculates it and rejects stale or
+  mixed experiment, source, task-order, result-set, model, prompt, or execution
+  inputs.
+- Added a relay-stable lineage ID passed across GitHub workflow legs and
+  condition-specific progress/result files, preventing new run IDs or condition
+  B from rejecting/overwriting condition A checkpoints.
+- Added path/branch-safe experiment IDs and canonical `owner/repository` source
+  validation before Step 0, including Hugging Face length and punctuation rules.
+- Synced old agentic and silent-corruption fixtures to the stronger identity
+  contract without weakening production validation.
 
 ## Verification
 
-- Success source, selector, pinned artifact, article, citation, and wiring
-  contracts: **10 passed, 0 failed**.
-- TypeScript and the production Vite build passed. The only build advisory is
-  the existing main chunk-size warning.
-- The success Playwright suite passed against the production build, including
-  the new six chapter titles, three validation questions, three discoveries,
-  rejected hypothesis, root-cause wording, 30 citations, ten evidence targets,
-  reduced motion, and fail-closed states.
-- Final full regression: **77 aggregate tests passed**, and runtime, integrity,
-  perception, and success browser suites all passed in **48.201 seconds**.
-- `git diff --check` passed after the final copy and regression-test updates.
-- Manual mobile inspection found 348px paragraph content/scroll widths, no
-  alerts, no horizontal overflow, and unchanged citation/evidence counts.
-- Static and browser negative assertions reject the previous `실행 완료율` and
-  `실행 경로를 완료` interpretation in the metric, hypothesis, and root-cause
-  sections. Briefing fidelity remains explicitly unverified.
-- Pages run
-  [29757449226](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29757449226)
-  completed successfully for exact merge SHA `f3648f72`. Build, all 77 aggregate
-  contracts, all four browser suites, artifact upload, and Pages deployment
-  passed in 2 minutes 15 seconds. It was the only workflow for the merge SHA.
-- Public mobile rendered the revised 상황→태스크→액션→결과→가설 검증→근본 원인
-  chapters, three validation questions, three discoveries, rejected hypothesis,
-  report-success metric, 30 citations, and ten evidence targets with no alert or
-  horizontal overflow.
-- Public desktop rendered a 1032×430 SVG with no overlapping labels, 34px
-  chapter headings, 34.85px body leading, no alert, and no horizontal overflow.
+- Latest-base audit: implementation was reapplied cleanly to
+  `origin/main@d83846f`; the two intervening success-note commits and their
+  completion history were preserved before updating this rolling record.
+- Documentation contract: **56 local links passed** across both READMEs and both
+  beginner guides; no `mermaid.ink` dependency remains.
+- SVG contract: **12/12 valid XML**, unique accessible IDs, intrinsic dimensions,
+  no external image nodes, and primary text contrast of at least **6.04:1**.
+- Browser geometry: localized mobile assets are selected through 960px and
+  desktop assets from 961px; nearest-card right/bottom spacing and canvas
+  overflow checks pass at mobile, tablet, and desktop widths.
+- `ui-designer` returned final **APPROVE** with no must-fix, major, or minor
+  finding after Chromium glyph-overlap and card-spacing corrections.
+- Backend focused regression: **151 passed, 0 failed** across fingerprint, relay,
+  Step 3, Step 6, config, agentic, and silent-corruption modules.
+- Backend broad regression: **1,529 passed, 6 skipped, 44 integration tests
+  deselected, 0 failed**. `test_deliverable_selector.py` was the only excluded
+  module because the local GDPVal parquet fixture is absent.
+- Python static checks: Ruff clean and `py_compile` passed for all six touched
+  implementation modules and changed tests.
+- Workflow contracts: **7 passed, 0 failed**; both workflow YAML files parse,
+  embedded Python heredocs compile from their parsed step scripts, action SHAs
+  are pinned, and VS Code diagnostics report no errors.
+- Frontend data contracts: **77 passed, 0 failed**. Aggregation found 1 test
+  experiment, 23 reports, 16 grades, 28 prompt architectures, and 4,439 task QA
+  lookups in the local snapshot.
+- TypeScript and Vite production build passed. Runtime, integrity, perception,
+  and success browser suites all passed against the production build.
+- `git diff --check` passed. No model call, grading, batch run, HF write,
+  workflow dispatch, Pages deployment, commit, push, or paid action occurred.
+- The independent backend reviewer resolved multiple issues during iteration,
+  but its final approval request failed repeatedly at the review service's
+  network boundary. Completion therefore relies on the broad/focused automated
+  suites, executable heredoc syntax checks, Ruff, `py_compile`, YAML parsing,
+  and direct final diff review rather than claiming an unavailable final signoff.
 
 ## Remaining Work
 
-- No implementation or deployment work remains for the success column revision.
+- Commit and push through a pull request; this task did not change remote state.
+- On the next naturally occurring automated result PR, verify that the PR
+  contract passes before HF upload, `validate` attaches to the exact final head
+  SHA, and the validation-only run creates no Pages deployment. Do not run a paid
+  experiment solely for this canary.
+- After the canary, require `validate` in the repository ruleset and keep the
+  `github-pages` environment restricted to protected `main`.
+- The broad backend suite still needs the local GDPVal parquet fixture to collect
+  `test_deliverable_selector.py`; all other model-free tests passed.
+- Existing frontend advisories remain outside this task: the main bundle is
+  above Vite's 500 kB warning threshold, local Browserslist data is stale, and
+  VS Code reports the existing TypeScript `baseUrl` deprecation in `tsconfig.json`.


### PR DESCRIPTION
**Summary**
- Execution-first bilingual README/guides
- 12 localized responsive SVGs
- Prepared fingerprint + relay/A-B/HF identity hardening
- PR-before-HF and read-only Pages validation

**Test Plan**
- Focused 151 pass
- Broad 1529 pass/6 skipped/44 deselected excluding missing parquet selector
- Aggregate 77; build
- 4 browser suites
- Workflow 7
- Ruff/py_compile/YAML/diff

**Remote note**
- No paid/model/HF/deploy action run
