### PR TITLE
fix: allow main-only Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ on:
   workflow_dispatch:
     inputs:
       deploy_pages:
-        description: Deploy the validated artifact (protected main only)
+        description: Deploy the validated artifact (main only)
         required: true
         type: boolean
         default: true
@@ -99,10 +99,8 @@ jobs:
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             [[ "$GITHUB_REF" == "refs/heads/main" ]]
-            [[ "$GITHUB_REF_PROTECTED" == "true" ]]
           elif [[ "$DEPLOY_PAGES" == "true" ]]; then
             [[ "$GITHUB_REF" == "refs/heads/main" ]]
-            [[ "$GITHUB_REF_PROTECTED" == "true" ]]
             [[ -z "$EXPECTED_SHA" ]]
           else
             [[ "$GITHUB_REF" == refs/heads/experiment/* ]]
@@ -168,7 +166,6 @@ jobs:
       - name: Upload Pages artifact
         if: >-
           github.ref == 'refs/heads/main'
-          && github.ref_protected == true
           && (github.event_name == 'push'
               || (github.event_name == 'workflow_dispatch'
                   && inputs.deploy_pages == true))
@@ -180,7 +177,6 @@ jobs:
     needs: validate
     if: >-
       github.ref == 'refs/heads/main'
-      && github.ref_protected == true
       && (github.event_name == 'push'
           || (github.event_name == 'workflow_dispatch'
               && inputs.deploy_pages == true))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ entries land under a fresh dated heading the day they merge to `main`.
   OpenID Connect, disposable public Hugging Face targets, destructive bootstrap
   and upload boundaries, Self-QA vs external grading, report fallback cost,
   artifacts, troubleshooting, and cleanup. Pages automation separates a
-  read-only PR validation job from protected-main deployment; automated result
+  read-only PR validation job from main-only deployment; automated result
   PRs are proven before HF upload, rechecked after upload, and dispatched for
   exact-head-SHA validation without Pages/OIDC privileges.
 - **Success Field Note retrospective voice** — revise
@@ -42,6 +42,13 @@ entries land under a fresh dated heading the day they merge to `main`.
   and zero overflow or SVG label overlap.
 
 ### Fixed
+- **Pages main deployment gate** — remove the invalid assumption that the
+  repository's unprotected `main` branch reports `github.ref_protected=true`.
+  Push/manual deployment remains restricted to `refs/heads/main`, while
+  validation-only result-PR dispatches still require their exact branch,
+  `github.sha`, `github.workflow_sha`, and expected SHA. This repairs failed
+  post-merge run `29836869345` without granting Pages/OIDC permissions to PR
+  validation jobs.
 - **Inference/report identity and fallback integrity** — hash the complete
   canonical Step 1 prepared payload, persist that fingerprint through relay
   checkpoints and final inference, and reject stale or mixed Step 1/2 inputs in

--- a/scripts/__tests__/aggregate-runtime-note.test.mjs
+++ b/scripts/__tests__/aggregate-runtime-note.test.mjs
@@ -235,6 +235,9 @@ test('runtime source changes trigger isolated PR validation and serialized Pages
   const batch = parse(batchText)
   const validateJob = deploy.jobs.validate
   const deployJob = deploy.jobs.deploy
+  const eventContractStep = validateJob.steps.find(
+    (step) => step.name === 'Verify non-PR event contract',
+  )
   const uploadStep = validateJob.steps.find((step) => step.name === 'Upload Pages artifact')
   const createPullRequestStep = batch.jobs['batch-run'].steps.find(
     (step) => step.name === 'Create Pull Request with results',
@@ -276,12 +279,19 @@ test('runtime source changes trigger isolated PR validation and serialized Pages
   assert.ok(validateJob.steps.some((step) => step.run === 'npm run test:aggregate'))
   assert.ok(validateJob.steps.some((step) => step.run?.includes('playwright install --with-deps --only-shell chromium')))
   assert.ok(validateJob.steps.some((step) => step.run === 'npm run test:notes-browser:dist'))
+  assert.doesNotMatch(eventContractStep.run, /ref_protected/i)
+  assert.match(eventContractStep.run, /GITHUB_EVENT_NAME.*push[\s\S]*?GITHUB_REF.*refs\/heads\/main/)
+  assert.match(eventContractStep.run, /DEPLOY_PAGES.*true[\s\S]*?GITHUB_REF.*refs\/heads\/main[\s\S]*?-z.*EXPECTED_SHA/)
+  assert.match(eventContractStep.run, /GITHUB_REF.*refs\/heads\/experiment\/\*/)
+  assert.match(eventContractStep.run, /GITHUB_SHA.*EXPECTED_SHA/)
+  assert.match(eventContractStep.run, /WORKFLOW_SHA.*EXPECTED_SHA/)
   assert.match(uploadStep.if, /refs\/heads\/main/)
-  assert.match(uploadStep.if, /github\.ref_protected == true/)
+  assert.doesNotMatch(uploadStep.if, /ref_protected/)
   assert.deepEqual(deployJob.permissions, { pages: 'write', 'id-token': 'write' })
   assert.equal(deployJob.environment.name, 'github-pages')
   assert.match(deployJob.if, /refs\/heads\/main/)
   assert.match(deployJob.if, /inputs\.deploy_pages == true/)
+  assert.doesNotMatch(deployJob.if, /ref_protected/)
   assert.equal(createPullRequestStep.id, 'cpr')
   assert.equal(reportStep.id, 'step6')
   assert.match(

--- a/tasks/0720_monday/BOLT_README_EXECUTION_TRUST.md
+++ b/tasks/0720_monday/BOLT_README_EXECUTION_TRUST.md
@@ -156,7 +156,7 @@ Allowed implementation files:
 - Every operational guarantee links to an enforcing file or workflow that exists.
 - Pull requests execute aggregate, aggregate tests, browser contracts, and
   production build; automated result PRs receive the same read-only validation
-  through an exact-SHA dispatch. Pages upload/deploy remain protected-main only.
+  through an exact-SHA dispatch. Pages upload/deploy remain main-only.
 - Both READMEs have no broken local links or missing images.
 - All SVGs are valid XML, have unique IDs, and render nonblank at desktop and
   mobile widths without clipped text.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,7 +4,7 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-21
-- Status: Implementation complete and locally verified; remote canary pending
+- Status: PR #120 merged; Pages gate recovery pending
 
 ## Task
 
@@ -34,7 +34,7 @@ task. It must be refreshed before a task is reported complete.
   Mermaid renderer.
 - Split Pages validation from deployment. PRs run aggregation, production build,
   77 data contracts, and four browser contracts with only `contents: read`.
-  Pages/OIDC permissions exist only in the protected-main deploy job.
+  Pages/OIDC permissions exist only in the main-only deploy job.
 - Covered automated result PRs suppressed by the default `GITHUB_TOKEN`: the
   batch workflow creates and proves a one-file report PR, performs HF upload only
   after that contract passes, rechecks the PR head, then dispatches read-only
@@ -86,7 +86,18 @@ task. It must be refreshed before a task is reported complete.
 - TypeScript and Vite production build passed. Runtime, integrity, perception,
   and success browser suites all passed against the production build.
 - `git diff --check` passed. No model call, grading, batch run, HF write,
-  workflow dispatch, Pages deployment, commit, push, or paid action occurred.
+  manual workflow dispatch, or paid action occurred during implementation.
+- PR #120 squash-merged as `9892a4c7566a0c5ba24f876459d5932ee7284357`.
+  Its PR `validate` run `29836476672` passed and correctly skipped deployment.
+- The automatic post-merge Pages run `29836869345` failed before checkout
+  because `deploy.yml` incorrectly required `github.ref_protected=true` even
+  though this repository has no main branch protection rule. The follow-up
+  recovery keeps deployment main-only and validation-only dispatch exact-SHA.
+- The Pages recovery received final `first-reviewer` approval after its shell
+  contract test was strengthened to reject both lowercase and uppercase
+  `ref_protected` checks. Two mandatory high-risk workflow review requests
+  reached the external review service but both ended at its network boundary;
+  no second-review verdict was available.
 - The independent backend reviewer resolved multiple issues during iteration,
   but its final approval request failed repeatedly at the review service's
   network boundary. Completion therefore relies on the broad/focused automated
@@ -95,7 +106,8 @@ task. It must be refreshed before a task is reported complete.
 
 ## Remaining Work
 
-- Commit and push through a pull request; this task did not change remote state.
+- Merge the Pages gate recovery and confirm a successful automatic post-merge
+  build/deploy run for the recovery SHA.
 - On the next naturally occurring automated result PR, verify that the PR
   contract passes before HF upload, `validate` attaches to the exact final head
   SHA, and the validation-only run creates no Pages deployment. Do not run a paid


### PR DESCRIPTION
Cause: post-merge run 29836869345 failed because unprotected main cannot satisfy ref_protected. Fix: retain exact main-only push/manual deployment and exact-SHA validation-only dispatch while removing false protection assumption; PR validation remains contents:read and Pages/OIDC remains deploy-only. Verification: workflow contracts 7/7, aggregate 77/77, production build, browser 4/4, YAML/diff/diagnostics clean. Note completion records updated. Do not merge.