### PR TITLE
docs: record Pages deployment recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ entries land under a fresh dated heading the day they merge to `main`.
   artifacts, troubleshooting, and cleanup. Pages automation separates a
   read-only PR validation job from main-only deployment; automated result
   PRs are proven before HF upload, rechecked after upload, and dispatched for
-  exact-head-SHA validation without Pages/OIDC privileges.
+  exact-head-SHA validation without Pages/OIDC privileges. Shipped through PR
+  #120 (`9892a4c7566a0c5ba24f876459d5932ee7284357`).
 - **Success Field Note retrospective voice** — revise
   `what-does-success-mean` without changing its evidence contract, metrics,
   source links, or fail-closed behavior. The six chapters now follow a
@@ -48,7 +49,12 @@ entries land under a fresh dated heading the day they merge to `main`.
   validation-only result-PR dispatches still require their exact branch,
   `github.sha`, `github.workflow_sha`, and expected SHA. This repairs failed
   post-merge run `29836869345` without granting Pages/OIDC permissions to PR
-  validation jobs.
+  validation jobs. Shipped through PR #121
+  (`138e89a8e3a56e86a836656e2572669786cbc0cf`); PR validation run
+  [29843523709](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29843523709)
+  passed without deployment, and automatic main run
+  [29843751719](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29843751719)
+  completed validation, artifact upload, and Pages deployment successfully.
 - **Inference/report identity and fallback integrity** — hash the complete
   canonical Step 1 prepared payload, persist that fingerprint through relay
   checkpoints and final inference, and reject stale or mixed Step 1/2 inputs in

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,7 +4,7 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-21
-- Status: PR #120 merged; Pages gate recovery pending
+- Status: Complete; PR #120 and Pages recovery PR #121 merged and deployed
 
 ## Task
 
@@ -93,6 +93,12 @@ task. It must be refreshed before a task is reported complete.
   because `deploy.yml` incorrectly required `github.ref_protected=true` even
   though this repository has no main branch protection rule. The follow-up
   recovery keeps deployment main-only and validation-only dispatch exact-SHA.
+- Recovery PR #121 passed read-only PR run `29843523709`, which correctly
+  skipped deployment, and squash-merged as
+  `138e89a8e3a56e86a836656e2572669786cbc0cf`. Automatic main run
+  `29843751719` then passed validation, Pages artifact upload, and deployment.
+  GitHub reports the live site at
+  <https://hyeonsangjeon.github.io/gdpval-realworks/>.
 - The Pages recovery received final `first-reviewer` approval after its shell
   contract test was strengthened to reject both lowercase and uppercase
   `ref_protected` checks. Two mandatory high-risk workflow review requests
@@ -106,8 +112,6 @@ task. It must be refreshed before a task is reported complete.
 
 ## Remaining Work
 
-- Merge the Pages gate recovery and confirm a successful automatic post-merge
-  build/deploy run for the recovery SHA.
 - On the next naturally occurring automated result PR, verify that the PR
   contract passes before HF upload, `validate` attaches to the exact final head
   SHA, and the validation-only run creates no Pages deployment. Do not run a paid


### PR DESCRIPTION
This PR records the Pages deployment recovery details as part of documentation other than runtime code changes.

### Details:
- **PR #120 & PR #121 Merge SHAs**:
  - PR #120 (`feat: rebuild README onboarding and publish gates`) was merged as `9892a4c7566a0c5ba24f876459d5932ee7284357`.
  - PR #121 (`fix: allow main-only Pages deployment`) was merged as `138e89a8e3a56e86a836656e2572669786cbc0cf`.
- **Failed Run 29836869345 Root Cause**:
  - The workflow of deploy.yml failed post-merge run `29836869345` because it incorrectly required `github.ref_protected == 'true'`. However, `main` branch is not a protected branch under the repository configuration, causing the deploy validation check to fail.
- **Successful Runs**:
  - PR validation run: [29843523709](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29843523709) successfully validated PR #121 without creating a Pages deployment.
  - Automatic main run: [29843751719](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29843751719) successfully ran, created Pages artifact, and deployed.
- **Live Pages URL**:
  - Deployment is live at: https://hyeonsangjeon.github.io/gdpval-realworks/
- **Rolling Task Status**:
  - Closed rolling task status in `tasks/LATEST_TASK_RESULT/README.md` (updated from pending to Complete).

This PR contains documentation changes only, with no runtime behavior changes.
