### PR TITLE
test: make deliverable selector contracts hermetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Fixed
+- **Hermetic deliverable-selector contract tests** — replace import-time pandas
+  and ignored local-parquet loading with a checked-in 28-task synthetic signal
+  corpus. The 6,889-byte canonical fixture is self-hashed and binds exact public
+  `openai/gdpval@11e7900...` task identities to the source parquet SHA-256,
+  220-row count, and per-task prompt/ordered-rubric hashes without storing full
+  prompts, rubrics, references, deliverables, grades, or model output. A
+  stdlib-only verifier validates the fixture offline; optional delayed pandas
+  verification checks the known local public snapshot. Clean checkouts now
+  collect all selector tests without pandas, PyArrow, parquet, or network. The
+  selector/verifier suite passes 15/15, root scripts pass 44/44, and adjacent
+  grading tests pass 90 with 2 environment skips. Production selector and
+  grader code are unchanged; no grading, Step 8, model/API, HF upload, manual
+  workflow, or paid execution occurred.
+
 ### Changed
 - **Execution-first repository onboarding and publish gates** — reorganize both
   root READMEs around live evidence, a credential-free local preview, and an

--- a/batch-runner/tests/fixtures/deliverable_selector_contract_v1.json
+++ b/batch-runner/tests/fixtures/deliverable_selector_contract_v1.json
@@ -1,0 +1,197 @@
+{
+  "schema_version": "deliverable-selector-contract-v1",
+  "source": {
+    "repository": "openai/gdpval",
+    "revision": "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+    "parquet_path": "data/train-00000-of-00001.parquet",
+    "parquet_sha256": "f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202",
+    "row_count": 220,
+    "projection_policy": "synthetic-minimal-selector-signals-v1",
+    "source_content_included": false
+  },
+  "tasks": {
+    "0419f1c3": {
+      "task_id": "0419f1c3-d669-45d0-81cd-f4d5923b06a5",
+      "source_selector_input_sha256": "94278d12d26cd4c00f48e0cf6997653d7cd8009b680c6020b262645612a69a2f",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "1b1ade2d": {
+      "task_id": "1b1ade2d-f9f6-4a04-baa5-aa15012b53be",
+      "source_selector_input_sha256": "a5a54ea80991df4c9e75ac34a3bbcc7d67cde501d5f6bba4495696297830ca6f",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "27e8912c": {
+      "task_id": "27e8912c-8bd5-44ba-ad87-64066ea05264",
+      "source_selector_input_sha256": "97e89ecdf79156ea84515f1da7e5aef6718ccb1d8a3e0db8df15d56b3595f80e",
+      "instruction": "Provide two separate deliverable files: one Word document and one PDF.",
+      "rubric_items": []
+    },
+    "403b9234": {
+      "task_id": "403b9234-6299-4b5f-a106-70c1bc11ec4c",
+      "source_selector_input_sha256": "4f707455dc47b3d2c8ebc44ecd9acd7a2f1ab1faeafbe08055504c6c1846295f",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "43dc9778": {
+      "task_id": "43dc9778-450b-4b46-b77e-b6d82b202035",
+      "source_selector_input_sha256": "a446752ad5e8339cd7dc1e8031b6cd00a8b77f447f4cf750718921d15efc4055",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "575f8679": {
+      "task_id": "575f8679-b4c1-47a2-8e96-d570d4ed9269",
+      "source_selector_input_sha256": "8f533c2b6213fd83f51c40bd158ea24056bb81f3d917d60be998965cc3dfdf86",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "6dcae3f5": {
+      "task_id": "6dcae3f5-bf1c-48e0-8b4b-23e6486a934c",
+      "source_selector_input_sha256": "29df5c0d563c30d8705f2a3b3e54c012d6d1a788e5cefb61d87cc6f20e2ac45f",
+      "instruction": "Provide one Excel workbook and one Word document as separate files.",
+      "rubric_items": []
+    },
+    "75401f7c": {
+      "task_id": "75401f7c-396d-406d-b08e-938874ad1045",
+      "source_selector_input_sha256": "3a79dc0d64f217066cd41743d97c4cd28bc6f05d5b5f2db25b5bea9cf2fbef77",
+      "instruction": "Deliver a final MP4 video.",
+      "rubric_items": []
+    },
+    "7b08cd4d": {
+      "task_id": "7b08cd4d-df60-41ae-9102-8aaa49306ba2",
+      "source_selector_input_sha256": "3472dc3b04dd728ab23476ef8559e618d8760e51740b8be9abf5769ed69e4147",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "7bbfcfe9": {
+      "task_id": "7bbfcfe9-132d-4194-82bb-d6f29d001b01",
+      "source_selector_input_sha256": "5168f0de84f0f1c4ae2e8bca0c563c000e85bf800e37c85811d3f30c480657ce",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "7d7fc9a7": {
+      "task_id": "7d7fc9a7-21a7-4b83-906f-416dea5ad04f",
+      "source_selector_input_sha256": "02127e94f9b414ec78afb8aa9b4fb8877c7f6b90e012cf3a12f9730380193fff",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "83d10b06": {
+      "task_id": "83d10b06-26d1-4636-a32c-23f92c57f30b",
+      "source_selector_input_sha256": "c35d48fdc625c3b050c5a9fc95e840c40d23c9cb3e3756e98754fc6300c8afce",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "85d95ce5": {
+      "task_id": "85d95ce5-b20c-41e2-834e-e788ce9622b6",
+      "source_selector_input_sha256": "43d18c6fd47e226b3a18b7527ede8267bc0b23c581804128b01de5dcf082ba9b",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "93b336f3": {
+      "task_id": "93b336f3-61f3-4287-86d2-87445e1e0f90",
+      "source_selector_input_sha256": "88563e9535be4900e8a29033f4a632f8d7fc442133aa4bd4d8e780d8c32c7c63",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "99ac6944": {
+      "task_id": "99ac6944-4ec6-4848-959c-a460ac705c6f",
+      "source_selector_input_sha256": "753f3b874c22db7f920465f07cc018f6c1d844cd09a9f6063c4a23d03335beec",
+      "instruction": "The final deliverable consists of a single PDF report with supporting images and workbook.",
+      "rubric_items": []
+    },
+    "9a0d8d36": {
+      "task_id": "9a0d8d36-6233-4c76-9107-0d1f783c7340",
+      "source_selector_input_sha256": "188dc40b53e7eb1be43b372e2bfa4a6315200bcf8b26d24b4b2c08ccdc1325bc",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "a73fbc98": {
+      "task_id": "a73fbc98-90d4-4134-a54f-2b1d0c838791",
+      "source_selector_input_sha256": "0229df0089b80f058907a558dabf3ac299a20d108df6c10ac3a9397793ec05dc",
+      "instruction": "Provide one PDF and one spreadsheet as separate files.",
+      "rubric_items": [
+        {
+          "criterion": "Every assigned table ID in the spreadsheet also appears with the same ID labeled on the corresponding updated layout PDF",
+          "score": 1
+        }
+      ]
+    },
+    "a74ead3b": {
+      "task_id": "a74ead3b-f67d-4b1c-9116-f6bb81b29d4f",
+      "source_selector_input_sha256": "4c263094165e68c53e68888fefd3a9cb28e9724d6fbb824ffcb9325b4a80caad",
+      "instruction": "Provide two distinct .pptx files and a supporting image.",
+      "rubric_items": [
+        {
+          "criterion": "Provides two distinct .pptx files: one presentation for Session 13 and one for Session 14.",
+          "score": 1
+        },
+        {
+          "criterion": "Session 14 deck includes a title slide indicating it is Session 14 (wording may vary).",
+          "score": 1
+        }
+      ]
+    },
+    "a941b6d8": {
+      "task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724",
+      "source_selector_input_sha256": "5640131530fbc09edc457c0899d207faf6fec28d756b722b7f52faa39158c1c2",
+      "instruction": "Deliver a final MP4 video.",
+      "rubric_items": []
+    },
+    "a95a5829": {
+      "task_id": "a95a5829-34bb-40f3-993b-558aed6dcdef",
+      "source_selector_input_sha256": "19990fbc58e4566c295f782616cd6af876e50df9778776aeb2312fbc9476f8e8",
+      "instruction": "Deliver a final .pdf file.",
+      "rubric_items": []
+    },
+    "bbe0a93b": {
+      "task_id": "bbe0a93b-ebf0-40b0-98dc-8d9243099034",
+      "source_selector_input_sha256": "d2ebb2d80c9bccc817676873e31e153eadab412c3ce5aeda7ef6cd6aaa3639a3",
+      "instruction": "Provide three separate PDF files.",
+      "rubric_items": []
+    },
+    "c7d83f01": {
+      "task_id": "c7d83f01-2874-4876-b7fd-52582ec99e1a",
+      "source_selector_input_sha256": "99f7114dc7722d07355e87beacfc10f7e557f3623b4f9de7405bfbbcb1c18559",
+      "instruction": "Deliver a Python notebook (.ipynb).",
+      "rubric_items": []
+    },
+    "c94452e4": {
+      "task_id": "c94452e4-39cd-4846-b73a-ab75933d1ad7",
+      "source_selector_input_sha256": "9196b0ad496304d2a717f41bdcb369769ed5b347ea4b4516b17805ed2493fd7b",
+      "instruction": "Deliver a final MP4 video.",
+      "rubric_items": []
+    },
+    "e222075d": {
+      "task_id": "e222075d-5d62-4757-ae3c-e34b0846583b",
+      "source_selector_input_sha256": "a085378b0654a34b794e0582e777ec1f98119d51f46c5ede6ea18117201aa01f",
+      "instruction": "Deliver a final MP4 video and a final PDF.",
+      "rubric_items": []
+    },
+    "ec591973": {
+      "task_id": "ec591973-04d5-48c0-981c-1ab2fcec2dc1",
+      "source_selector_input_sha256": "805e31f277c5f700dc1c101e879df2e6c5d76953466f36a134e17d5c2bebb5ae",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "ee09d943": {
+      "task_id": "ee09d943-5a11-430a-b7a2-971b4e9b01b5",
+      "source_selector_input_sha256": "bebc9fd0c3813e84d98da221606922dcb431cef9190bf2057b3109626a3d424a",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "f9a1c16c": {
+      "task_id": "f9a1c16c-53fd-4c8f-88cc-5c325ec2f0bb",
+      "source_selector_input_sha256": "868a2916d35655a12230375ec610b39dd415d76e5969188617a6367e63c104fa",
+      "instruction": "",
+      "rubric_items": []
+    },
+    "ff85ee58": {
+      "task_id": "ff85ee58-bc9f-4aa2-806d-87edeabb1b81",
+      "source_selector_input_sha256": "902801061c5dda506da89de0add83b5a8db842e03a06137dd2ff1f6980e6cc89",
+      "instruction": "Deliver a final audio file.",
+      "rubric_items": []
+    }
+  },
+  "sha256": "1c2343be4fc85b7df9a4f778ad8daec466abc4a96e53d441312eadf5c4d71c6e"
+}

--- a/batch-runner/tests/test_deliverable_selector.py
+++ b/batch-runner/tests/test_deliverable_selector.py
@@ -1,24 +1,39 @@
 """Unit tests for the standalone deliverable selector.
 
-No Azure calls, no grading, no rendering. The task fixtures use the actual
-GDPVal ``rubric_json`` rows from the local parquet; only file lists and owner
-expected targets are fixture data.
+No Azure calls, grading, rendering, pandas, parquet, or network access. The
+checked-in contract fixture contains only synthetic selector signals and exact
+public task/source identities; file lists and owner expected targets remain in
+this test module.
 """
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
+import sys
 from typing import Any
 
-import pandas as pd
 import pytest
 
-from core.deliverable_selector import (
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.verify_deliverable_selector_fixture import (  # noqa: E402
+    canonical_json,
+    load_and_validate_fixture,
+)
+
+from core.deliverable_selector import (  # noqa: E402
     ITEM_TARGET_AUDIT_SCHEMA,
     DeliverableSelection,
     plan_targets_for_criterion,
     select_deliverables,
+)
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "deliverable_selector_contract_v1.json"
 )
 
 
@@ -31,23 +46,11 @@ def _ref_url(name: str) -> str:
     return f"https://huggingface.co/datasets/openai/gdpval/resolve/main/reference_files/hash/{encoded}"
 
 
-def _load_actual_task_data() -> dict[str, dict[str, Any]]:
-    repo_root = Path(__file__).resolve().parents[2]
-    parquet = repo_root / "data/gdpval-local/data/train-00000-of-00001.parquet"
-    df = pd.read_parquet(parquet)
-    data: dict[str, dict[str, Any]] = {}
-    for row in df.to_dict("records"):
-        rubric = row["rubric_json"]
-        if isinstance(rubric, str):
-            rubric = json.loads(rubric)
-        data[row["task_id"][:8]] = {
-            "prompt": row["prompt"],
-            "rubric_items": rubric,
-        }
-    return data
+def _load_task_data() -> dict[str, dict[str, Any]]:
+    return load_and_validate_fixture(FIXTURE_PATH)["tasks"]
 
 
-ACTUAL_TASK_DATA = _load_actual_task_data()
+CONTRACT_TASK_DATA = _load_task_data()
 
 
 def _selected_names(selection: DeliverableSelection) -> set[str]:
@@ -59,7 +62,7 @@ def _selected_names(selection: DeliverableSelection) -> set[str]:
 
 
 def _actual_criterion(task_id: str, contains: str) -> str:
-    for item in ACTUAL_TASK_DATA[task_id]["rubric_items"]:
+    for item in CONTRACT_TASK_DATA[task_id]["rubric_items"]:
         criterion = item["criterion"]
         if contains in criterion:
             return criterion
@@ -67,12 +70,12 @@ def _actual_criterion(task_id: str, contains: str) -> str:
 
 
 def _select(fixture: dict[str, Any]) -> DeliverableSelection:
-    task = ACTUAL_TASK_DATA[fixture["task_id"]]
+    task = CONTRACT_TASK_DATA[fixture["task_id"]]
     return select_deliverables(
         task_id=fixture["task_id"],
         deliverable_files=fixture["deliverable_files"],
         reference_file_urls=fixture.get("reference_file_urls", []),
-        instruction=task["prompt"],
+        instruction=task["instruction"],
         rubric_items=task["rubric_items"],
         deliverable_summary=fixture.get("deliverable_summary", ""),
     )
@@ -270,6 +273,28 @@ def test_gold_20_selector_targets_match_owner_targets():
     assert matches == 20
 
 
+def test_hermetic_contract_fixture_is_exact_minimal_and_source_bound():
+    document = load_and_validate_fixture(FIXTURE_PATH)
+    fixture_ids = {
+        fixture["task_id"]
+        for fixture in [*GOLD_FIXTURES, *WRONG_FORMAT_FIXTURES]
+    } | {"a73fbc98"}
+
+    assert set(document["tasks"]) == fixture_ids
+    assert len(canonical_json(document)) < 8 * 1024
+    assert document["source"] == {
+        "repository": "openai/gdpval",
+        "revision": "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+        "parquet_path": "data/train-00000-of-00001.parquet",
+        "parquet_sha256": (
+            "f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202"
+        ),
+        "row_count": 220,
+        "projection_policy": "synthetic-minimal-selector-signals-v1",
+        "source_content_included": False,
+    }
+
+
 def test_bug2_four_cases_are_corrected_to_generated_primary():
     bug2 = {
         "7d7fc9a7": {"Aurisic_Prepaid_Amortization_Schedule_Through_Apr2025.xlsx"},
@@ -339,7 +364,7 @@ WRONG_FORMAT_FIXTURES = [
 ]
 
 
-def test_wrong_format_primary_fires_for_ambiguous_seven_with_actual_rubrics():
+def test_wrong_format_primary_fires_for_seven_contract_signals():
     for fixture in WRONG_FORMAT_FIXTURES:
         selection = _select(fixture)
         assert selection.selection_status == "wrong_format_primary", fixture["task_id"]
@@ -405,8 +430,8 @@ def test_criterion_routing_manifest_file_specific_and_bundle_cases():
             _path("a73fbc98", "Spring_Bazaar_2025_Table_Assignment_Summary.pdf"),
             _path("a73fbc98", "Spring_Bazaar_2025_Vendor_Assignments.xlsx"),
         ],
-        instruction=ACTUAL_TASK_DATA["a73fbc98"]["prompt"],
-        rubric_items=ACTUAL_TASK_DATA["a73fbc98"]["rubric_items"],
+        instruction=CONTRACT_TASK_DATA["a73fbc98"]["instruction"],
+        rubric_items=CONTRACT_TASK_DATA["a73fbc98"]["rubric_items"],
     )
     bundle = plan_targets_for_criterion(
         bazaar,

--- a/scripts/__tests__/test_verify_deliverable_selector_fixture.py
+++ b/scripts/__tests__/test_verify_deliverable_selector_fixture.py
@@ -1,0 +1,149 @@
+"""Tests for the hermetic deliverable-selector fixture contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+import pytest
+
+from scripts import verify_deliverable_selector_fixture as verifier
+
+
+FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "batch-runner"
+    / "tests"
+    / "fixtures"
+    / "deliverable_selector_contract_v1.json"
+)
+
+
+def _document():
+    return verifier.load_and_validate_fixture(FIXTURE)
+
+
+def _reseal(document):
+    document["sha256"] = verifier.fixture_sha256(document)
+    return document
+
+
+def test_checked_in_fixture_is_valid_and_minimal():
+    document = _document()
+
+    assert document["schema_version"] == verifier.SCHEMA_VERSION
+    assert len(document["tasks"]) == 28
+    assert len(verifier.canonical_json(document)) < 8 * 1024
+    assert document["source"]["source_content_included"] is False
+
+
+def test_fixture_rejects_hash_and_identity_drift():
+    document = _document()
+    document["tasks"]["0419f1c3"]["instruction"] = "drift"
+    with pytest.raises(verifier.FixtureValidationError, match="hash_mismatch"):
+        verifier.validate_fixture(document)
+
+    document = _document()
+    document["tasks"]["1b1ade2d"]["task_id"] = document["tasks"][
+        "0419f1c3"
+    ]["task_id"]
+    with pytest.raises(verifier.FixtureValidationError, match="task_identity"):
+        verifier.validate_fixture(_reseal(document))
+
+
+def test_fixture_rejects_source_and_signal_contract_drift():
+    document = _document()
+    document["source"]["source_content_included"] = True
+    with pytest.raises(verifier.FixtureValidationError, match="source_identity"):
+        verifier.validate_fixture(_reseal(document))
+
+    document = _document()
+    document["tasks"]["0419f1c3"]["instruction"] = "copied source prompt"
+    with pytest.raises(verifier.FixtureValidationError, match="instruction_invalid"):
+        verifier.validate_fixture(_reseal(document))
+
+    document = _document()
+    document["tasks"]["0419f1c3"]["rubric_items"] = [
+        {"criterion": "x" * 513, "score": 1}
+    ]
+    with pytest.raises(verifier.FixtureValidationError, match="rubric_invalid"):
+        verifier.validate_fixture(_reseal(document))
+
+
+def test_selector_test_module_has_no_parquet_stack_dependency():
+    selector_test = (
+        Path(__file__).resolve().parents[2]
+        / "batch-runner"
+        / "tests"
+        / "test_deliverable_selector.py"
+    ).read_text(encoding="utf-8")
+
+    assert "import pandas" not in selector_test
+    assert "read_parquet" not in selector_test
+    assert "gdpval-local" not in selector_test
+
+
+def test_optional_source_verification_uses_delayed_reader(monkeypatch, tmp_path):
+    document = _document()
+    parquet = tmp_path / "source.parquet"
+    parquet.write_bytes(b"fixture")
+    source_hashes = {
+        task["task_id"]: task["source_selector_input_sha256"]
+        for task in document["tasks"].values()
+    }
+
+    class FakeFrame:
+        def __len__(self):
+            return 220
+
+        def to_dict(self, orient):
+            assert orient == "records"
+            return [
+                {"task_id": task_id, "prompt": task_id, "rubric_json": []}
+                for task_id in source_hashes
+            ]
+
+    def read_parquet(path, columns):
+        assert Path(path) == parquet
+        assert columns == ["task_id", "prompt", "rubric_json"]
+        return FakeFrame()
+
+    fake_pandas = SimpleNamespace(read_parquet=read_parquet)
+    monkeypatch.setattr(
+        verifier,
+        "_sha256_file",
+        lambda path: document["source"]["parquet_sha256"],
+    )
+    monkeypatch.setattr(
+        verifier,
+        "_source_selector_input_sha256",
+        lambda prompt, rubric: source_hashes[prompt],
+    )
+    monkeypatch.setitem(sys.modules, "pandas", fake_pandas)
+
+    verifier.verify_source_snapshot(
+        deepcopy(document),
+        parquet,
+        source_revision=document["source"]["revision"],
+    )
+
+    with pytest.raises(verifier.FixtureValidationError, match="revision_mismatch"):
+        verifier.verify_source_snapshot(
+            deepcopy(document),
+            parquet,
+            source_revision="0" * 40,
+        )
+
+    monkeypatch.setattr(
+        verifier,
+        "_source_selector_input_sha256",
+        lambda prompt, rubric: "0" * 64,
+    )
+    with pytest.raises(verifier.FixtureValidationError, match="selector_input"):
+        verifier.verify_source_snapshot(
+            deepcopy(document),
+            parquet,
+            source_revision=document["source"]["revision"],
+        )

--- a/scripts/verify_deliverable_selector_fixture.py
+++ b/scripts/verify_deliverable_selector_fixture.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Validate the hermetic deliverable-selector contract fixture."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FIXTURE = (
+    ROOT
+    / "batch-runner"
+    / "tests"
+    / "fixtures"
+    / "deliverable_selector_contract_v1.json"
+)
+SCHEMA_VERSION = "deliverable-selector-contract-v1"
+SOURCE_FIELDS = {
+    "repository",
+    "revision",
+    "parquet_path",
+    "parquet_sha256",
+    "row_count",
+    "projection_policy",
+    "source_content_included",
+}
+TASK_FIELDS = {
+    "task_id",
+    "source_selector_input_sha256",
+    "instruction",
+    "rubric_items",
+}
+RUBRIC_FIELDS = {"criterion", "score"}
+ALLOWED_SYNTHETIC_INSTRUCTIONS = {
+    "",
+    "Provide two separate deliverable files: one Word document and one PDF.",
+    "Provide one Excel workbook and one Word document as separate files.",
+    "Deliver a final MP4 video.",
+    "The final deliverable consists of a single PDF report with supporting images and workbook.",
+    "Provide one PDF and one spreadsheet as separate files.",
+    "Provide two distinct .pptx files and a supporting image.",
+    "Provide three separate PDF files.",
+    "Deliver a Python notebook (.ipynb).",
+    "Deliver a final MP4 video and a final PDF.",
+    "Deliver a final .pdf file.",
+    "Deliver a final audio file.",
+}
+ALLOWED_ROUTING_CRITERIA = {
+    "Provides two distinct .pptx files: one presentation for Session 13 and one for Session 14.",
+    "Session 14 deck includes a title slide indicating it is Session 14 (wording may vary).",
+    "Every assigned table ID in the spreadsheet also appears with the same ID labeled on the corresponding updated layout PDF",
+}
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+SHORT_ID_RE = re.compile(r"^[0-9a-f]{8}$")
+
+
+class FixtureValidationError(ValueError):
+    """Raised when the selector fixture contract is invalid."""
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def fixture_sha256(document: Mapping[str, Any]) -> str:
+    payload = {key: value for key, value in document.items() if key != "sha256"}
+    return hashlib.sha256(canonical_json(payload)).hexdigest()
+
+
+def load_and_validate_fixture(path: str | Path = DEFAULT_FIXTURE) -> dict[str, Any]:
+    fixture_path = Path(path)
+    try:
+        document = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FixtureValidationError("fixture_unreadable") from exc
+    validate_fixture(document)
+    return document
+
+
+def validate_fixture(document: Any) -> None:
+    if not isinstance(document, dict) or set(document) != {
+        "schema_version",
+        "source",
+        "tasks",
+        "sha256",
+    }:
+        raise FixtureValidationError("fixture_fields_invalid")
+    if document["schema_version"] != SCHEMA_VERSION:
+        raise FixtureValidationError("fixture_schema_invalid")
+    if document["sha256"] != fixture_sha256(document):
+        raise FixtureValidationError("fixture_hash_mismatch")
+
+    source = document["source"]
+    if not isinstance(source, dict) or set(source) != SOURCE_FIELDS:
+        raise FixtureValidationError("fixture_source_fields_invalid")
+    if (
+        source["repository"] != "openai/gdpval"
+        or FULL_SHA_RE.fullmatch(str(source["revision"])) is None
+        or source["parquet_path"] != "data/train-00000-of-00001.parquet"
+        or SHA256_RE.fullmatch(str(source["parquet_sha256"])) is None
+        or source["row_count"] != 220
+        or source["projection_policy"] != "synthetic-minimal-selector-signals-v1"
+        or source["source_content_included"] is not False
+    ):
+        raise FixtureValidationError("fixture_source_identity_invalid")
+
+    tasks = document["tasks"]
+    if not isinstance(tasks, dict) or len(tasks) != 28:
+        raise FixtureValidationError("fixture_task_count_invalid")
+    full_ids: set[str] = set()
+    for short_id, task in tasks.items():
+        if SHORT_ID_RE.fullmatch(str(short_id)) is None:
+            raise FixtureValidationError("fixture_short_id_invalid")
+        if not isinstance(task, dict) or set(task) != TASK_FIELDS:
+            raise FixtureValidationError("fixture_task_fields_invalid")
+        task_id = task["task_id"]
+        if (
+            not isinstance(task_id, str)
+            or UUID_RE.fullmatch(task_id) is None
+            or not task_id.startswith(f"{short_id}-")
+            or task_id in full_ids
+        ):
+            raise FixtureValidationError("fixture_task_identity_invalid")
+        full_ids.add(task_id)
+        if SHA256_RE.fullmatch(str(task["source_selector_input_sha256"])) is None:
+            raise FixtureValidationError("fixture_source_selector_hash_invalid")
+        instruction = task["instruction"]
+        if instruction not in ALLOWED_SYNTHETIC_INSTRUCTIONS:
+            raise FixtureValidationError("fixture_instruction_invalid")
+        rubric_items = task["rubric_items"]
+        if not isinstance(rubric_items, list) or len(rubric_items) > 8:
+            raise FixtureValidationError("fixture_rubrics_invalid")
+        for item in rubric_items:
+            if not isinstance(item, dict) or set(item) != RUBRIC_FIELDS:
+                raise FixtureValidationError("fixture_rubric_fields_invalid")
+            criterion = item["criterion"]
+            score = item["score"]
+            if (
+                not isinstance(criterion, str)
+                or criterion not in ALLOWED_ROUTING_CRITERIA
+                or isinstance(score, bool)
+                or not isinstance(score, (int, float))
+            ):
+                raise FixtureValidationError("fixture_rubric_invalid")
+
+
+def verify_source_snapshot(
+    document: Mapping[str, Any],
+    parquet_path: str | Path,
+    *,
+    source_revision: str,
+) -> None:
+    """Verify public source identity without importing pandas during test collection."""
+    validate_fixture(document)
+    source = document["source"]
+    if source_revision != source["revision"]:
+        raise FixtureValidationError("source_revision_mismatch")
+    path = Path(parquet_path)
+    if _sha256_file(path) != source["parquet_sha256"]:
+        raise FixtureValidationError("source_parquet_hash_mismatch")
+    try:
+        import pandas as pd
+    except ImportError as exc:
+        raise FixtureValidationError("source_reader_unavailable") from exc
+    frame = pd.read_parquet(path, columns=["task_id", "prompt", "rubric_json"])
+    if len(frame) != source["row_count"]:
+        raise FixtureValidationError("source_row_count_mismatch")
+    source_rows = {row["task_id"]: row for row in frame.to_dict("records")}
+    fixture_ids = {task["task_id"] for task in document["tasks"].values()}
+    if not fixture_ids <= set(source_rows):
+        raise FixtureValidationError("source_task_set_mismatch")
+    for task in document["tasks"].values():
+        row = source_rows[task["task_id"]]
+        if _source_selector_input_sha256(
+            row.get("prompt"), row.get("rubric_json")
+        ) != task["source_selector_input_sha256"]:
+            raise FixtureValidationError("source_selector_input_mismatch")
+
+
+def _source_selector_input_sha256(prompt: Any, rubric: Any) -> str:
+    if isinstance(rubric, str):
+        try:
+            rubric = json.loads(rubric)
+        except json.JSONDecodeError as exc:
+            raise FixtureValidationError("source_rubric_invalid") from exc
+    if not isinstance(prompt, str) or not isinstance(rubric, list):
+        raise FixtureValidationError("source_selector_input_invalid")
+    criteria = []
+    for item in rubric:
+        if not isinstance(item, Mapping) or not isinstance(item.get("criterion"), str):
+            raise FixtureValidationError("source_rubric_invalid")
+        criteria.append(item["criterion"])
+    return hashlib.sha256(canonical_json({
+        "prompt": prompt,
+        "rubric_criteria": criteria,
+    })).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise FixtureValidationError("source_parquet_unreadable") from exc
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", default=str(DEFAULT_FIXTURE))
+    parser.add_argument("--source-parquet")
+    parser.add_argument("--source-revision")
+    args = parser.parse_args()
+
+    document = load_and_validate_fixture(args.fixture)
+    if bool(args.source_parquet) != bool(args.source_revision):
+        parser.error("--source-parquet and --source-revision must be provided together")
+    if args.source_parquet:
+        verify_source_snapshot(
+            document,
+            args.source_parquet,
+            source_revision=args.source_revision,
+        )
+    print(json.dumps({
+        "fixture": "valid",
+        "schema_version": document["schema_version"],
+        "task_count": len(document["tasks"]),
+        "source_verified": bool(args.source_parquet),
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/0722_wednesday/BOLT_HERMETIC_DELIVERABLE_SELECTOR.md
+++ b/tasks/0722_wednesday/BOLT_HERMETIC_DELIVERABLE_SELECTOR.md
@@ -1,0 +1,110 @@
+# BOLT: Hermetic Deliverable Selector Contract Corpus
+
+- Date: 2026-07-22
+- Status: `APPROVED`
+- Base: `main@23e9cdea5bdd26205a2c1211415b3d8b5c3c1a42`
+- Branch: `bolt/hermetic-deliverable-selector`
+- Execution boundary: model-free, offline, no secrets
+
+## Outcome
+
+Make the complete deliverable-selector contract suite collect and pass in a
+clean checkout without the ignored 1.9 MB GDPVal parquet, pandas, PyArrow, or
+network access. Preserve the current 20 owner-gold targets, seven wrong-format
+guards, and criterion-routing cases with a compact, provenance-bound fixture.
+
+## Falsifiable Hypothesis
+
+`test_deliverable_selector.py` fails during collection only because it imports
+pandas and reads the ignored local parquet at module import time. Replacing that
+runtime dependency with a checked-in minimal selector-signal corpus should keep
+all selector outcomes identical while making collection hermetic.
+
+## Reproduction
+
+```text
+python3 -m pytest --collect-only \
+  batch-runner/tests/test_deliverable_selector.py
+
+FileNotFoundError:
+data/gdpval-local/data/train-00000-of-00001.parquet
+```
+
+The source snapshot is public `openai/gdpval` revision
+`11e7900cdcac61bc4daf59e65feb238acda98fbf`; its 220-row parquet SHA-256 is
+`f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202`.
+
+## Data-Minimization Contract
+
+The fixture is not a dataset mirror. It may contain only:
+
+- exact full and eight-character task identities for the 28 covered tasks;
+- synthetic minimal instruction signals needed by selector regex contracts;
+- the three exact criterion strings already asserted by routing tests;
+- source repository, revision, row count, parquet SHA-256, projection policy,
+  and a canonical self-hash.
+
+It must not contain full source prompts, full rubrics, reference bytes,
+deliverables, grades, model output, personal data, or secrets.
+
+## Scope
+
+- `batch-runner/tests/fixtures/deliverable_selector_contract_v1.json`
+- `batch-runner/tests/test_deliverable_selector.py`
+- `scripts/verify_deliverable_selector_fixture.py`
+- `scripts/__tests__/test_verify_deliverable_selector_fixture.py`
+- `CHANGELOG.md`
+- `tasks/LATEST_TASK_RESULT/README.md`
+- this BOLT record
+
+## Non-Goals
+
+- Do not change selector production behavior or grader routing.
+- Do not download, commit, or regenerate the GDPVal parquet.
+- Do not add pandas/PyArrow to test collection requirements.
+- Do not run grading, Step 8, model/API calls, HF uploads, or paid workflows.
+- Do not copy full benchmark prompts or rubric text into the repository.
+
+## Implementation Steps
+
+1. Add a schema-checked, self-hashed 28-task minimal signal corpus.
+2. Replace import-time parquet loading with strict fixture loading.
+3. Add an offline verifier for fixture structure and optional local source
+   provenance checks.
+4. Test unknown/missing/duplicate task IDs, self-hash drift, source identity,
+   and synthetic signal constraints.
+5. Run selector, root scripts, and broad model-free collection/regression gates.
+6. Update canonical completion records and obtain independent grading review.
+
+## Acceptance Gates
+
+- Clean checkout collects `test_deliverable_selector.py` without local data.
+- Existing owner-gold 20/20, wrong-format 7/7, and routing tests are unchanged.
+- Fixture has exactly 28 unique task IDs, a valid canonical self-hash, and a
+  canonical payload smaller than 8 KiB.
+- Fixture source metadata is exact and optional source verification passes
+  against the known local public snapshot.
+- Test module contains no pandas/PyArrow import or parquet read.
+- Root scripts and relevant grading tests remain green.
+- `git diff --check`, Ruff, compile, and diagnostics pass.
+- No model/API, grading, upload, manual workflow, or paid execution occurs.
+
+## Evidence
+
+| Check | Result |
+|---|---|
+| Clean-checkout reproduction | Collection fails on missing ignored parquet |
+| Fixture contract | 28 tasks, 6,889 canonical bytes, valid self-hash |
+| Selector + verifier tests | `15 passed` |
+| Source provenance verifier | Public revision, parquet SHA, 220 rows, 28 task/source hashes verified |
+| Root scripts suite | `44 passed` |
+| Adjacent grading suite | `90 passed`, `2 skipped` |
+| Static checks | Ruff, `py_compile`, diagnostics, and `git diff --check` passed |
+| Broad model-free regression | Collection blocked by missing local `datasets` and `ijson`; no code failure claimed |
+| Independent review | `grading-engineer` approved with 0 mandatory findings |
+
+## Decision
+
+`APPROVED` — selector contracts are hermetic and source-bound; production
+selector/grader behavior is unchanged. Merge the model-free BOLT without
+running grading, model/API, upload, or paid paths.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,72 +4,59 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-22
-- Status: Grading workflow trust hardening complete; live canary deferred
+- Status: APPROVED — deliverable-selector contracts are hermetic and source-bound
 
 ## Task
 
-- Disable the obsolete grading cost-sweep workflow without deleting its
-  historical source or results.
-- Harden the active grading workflow without changing its single-job runtime,
-  chunk resume, publication, analysis, or follow-up dispatch behavior.
-- Pin external actions, remove unused permissions, validate exact-main
-  execution, and prevent workflow-dispatch inputs from being interpolated
-  directly into shell scripts.
+- Make `test_deliverable_selector.py` collect and run in a clean checkout
+  without the ignored local GDPVal parquet, pandas, PyArrow, or network access.
+- Preserve the existing 20 owner-gold selections, seven wrong-format guards,
+  and criterion-routing contracts with a compact synthetic signal corpus.
+- Bind the fixture to exact public source identities and hashes without copying
+  full prompts, rubrics, reference bytes, deliverables, grades, or model output.
 
 ## Result
 
-- Moved `grade-cost-sweep.yml` unchanged from the active workflow directory to
-  its May 24 result archive. The historical workflow blob and documentation
-  remain available, but GitHub can no longer dispatch the obsolete USD 80-cap
-  sweep. Its former live status and trigger commands are explicitly marked as
-  archived historical records.
-- Kept `grade-run.yml` as one job with `contents: write`, `id-token: write`, and
-  `actions: write`; removed only unused `pull-requests: write`.
-- Pinned checkout, setup-python, Azure login, and artifact upload to reviewed
-  full commit SHAs. Checkout explicitly creates local `main`, tracks
-  `origin/main`, and preserves the credential used by the existing result
-  publication steps.
-- Added pre-checkout validation for workflow-dispatch identity, exact main ref,
-  workflow SHA/event SHA equality, safe experiment/config basenames, lowercase
-  inference identity, booleans, task limit, resume chunk, and force/resume
-  consistency.
-- Added post-checkout validation for HEAD, local branch, upstream, remote main,
-  credential configuration, and regular non-symlink experiment/config files
-  before dependency installation, Azure login, or HF access.
-- Routed all eight dispatch inputs used by shell through validated job
-  environment variables. No `run:` block interpolates `${{ inputs.* }}`.
-- Preserved the rc=7 partial-save/rebase/hash/schema contract, three `git push`
-  sites, two self/follow-up dispatches, analysis generation, and artifact path.
-- No workflow dispatch, Azure login, HF access/write, model/API call, grading
-  run, or paid execution occurred.
+- Added `tasks/0722_wednesday/BOLT_HERMETIC_DELIVERABLE_SELECTOR.md` with the
+  reproduction, data-minimization contract, bounded scope, gates, and evidence.
+- Added a schema-checked 28-task fixture containing exact task identities,
+  allowlisted synthetic selector signals, and only the three criterion strings
+  already required by routing assertions.
+- Bound the corpus to `openai/gdpval` revision
+  `11e7900cdcac61bc4daf59e65feb238acda98fbf`, parquet SHA-256
+  `f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202`,
+  220 rows, and 28 per-task prompt/ordered-rubric hashes.
+- Replaced import-time pandas/parquet loading in selector tests with strict
+  fixture loading. No production selector, grader, routing, or workflow code
+  changed.
+- Added a stdlib-only offline verifier plus an optional local-source mode that
+  delays pandas import until explicitly requested and checks the full source
+  identity chain without printing source content.
+- Committed the rebased implementation as
+  `f63638c5889b4bfeea0e18c6e6e78ad4bade5caa`.
 
 ## Verification
 
-- Base identity: exact `origin/main@d3fe7f793e202555f6f4df55922282e217494fc6`;
-  active grading and sweep runs were zero before implementation.
-- Focused workflow/input/archive matrix: **17 passed**. The Bash preflight was
-  executed against valid initial/resume inputs and thirteen invalid context,
-  traversal, identity, boolean, range, and resume combinations.
-- Full Step 8 suite: **114 passed, 0 failed** in 5.02 seconds.
-- Workflow invariants: one job, four 40-character action pins, three pushes,
-  two `grade-run.yml` dispatches, no input expression in any shell script, and
-  unchanged rc=7/schema/hash guards.
-- All active workflow YAML and the archived sweep parse successfully. Official
-  actionlint v1.7.7 was downloaded outside the repository, matched its published
-  SHA-256 checksum, and reported zero diagnostics for `grade-run.yml`.
-- Static diagnostics reported zero errors in the workflow and changed Python
-  test. `git diff --check` passed.
-- `extreme-reasoner` returned `SAFE_WITH_CONDITIONS`; all in-scope conditions
-  were implemented. It explicitly classified this same-job check as an
-  operational guard rather than a protected security boundary.
+- Clean-checkout reproduction before the fix: selector test collection failed
+  with `FileNotFoundError` for the ignored local parquet.
+- Hermetic selector and verifier contracts: **15 passed, 0 failed**.
+- Root `scripts/__tests__`: **44 passed, 0 failed**.
+- Adjacent selector/grader/routing/artifact suite: **90 passed, 2 skipped,
+  0 failed**.
+- Offline verifier: 28 tasks, valid self-hash, 6,889 canonical bytes.
+- Optional source verification passed against the known local public snapshot:
+  exact revision, parquet SHA, 220 rows, full task set, and all per-task source
+  hashes.
+- Ruff, `py_compile`, diagnostics, and `git diff --check` passed.
+- `grading-engineer` approved with zero mandatory findings.
+- The full batch-runner suite was attempted but not claimed as passing: system
+  Python lacks `datasets` for six unrelated modules and `ijson` for four.
+- No grading, Step 8, model/API call, HF upload, manual workflow, network fetch,
+  or paid execution occurred.
 
 ## Remaining Work
 
-- Add a repository ruleset for `main` and a protected grading environment before
-  treating exact-main validation as a security boundary.
-- Design any future read-only/privileged job split separately. It must transfer
-  the grade file, resolved inference revision, rc, hashes, and publication state
-  without breaking chunk resume, three pushes, or two follow-up dispatches.
-- Use a later operator-approved model-free `dry_run` to verify GitHub-hosted
-  checkout/upstream/credential behavior. Do not run a paid grading canary solely
-  for this hardening change.
+- No implementation work remains for the hermetic selector corpus BOLT.
+- Restore the repository's complete Python dependency environment before using
+  the broad batch-runner suite as a release gate; do not weaken imports or
+  production dependency contracts to accommodate this machine.


### PR DESCRIPTION
## BOLT
- adds tasks/0722_wednesday/BOLT_HERMETIC_DELIVERABLE_SELECTOR.md
- replaces import-time pandas/parquet test loading with a strict 28-task synthetic selector-signal corpus
- binds exact public task IDs to openai/gdpval revision 11e7900..., parquet SHA/220 rows, and per-task prompt+ordered-rubric hashes without storing source text
- adds stdlib offline verification and optional delayed-pandas source verification

## Contract
- preserves owner-gold 20/20, wrong-format 7/7, criterion routing
- exactly 28 IDs, 3 routing criteria, allowlisted synthetic signals, 6,889 canonical bytes, self-hash
- no production selector/grader/workflow changes

## Validation
- before: clean collection failed FileNotFoundError for ignored parquet
- selector+verifier 15/15
- root scripts 44/44
- adjacent grading 90 passed, 2 skipped
- offline and actual public source verification passed
- Ruff, py_compile, diagnostics, diff-check clean
- broad batch suite not claimed green: machine lacks datasets and ijson
- grading-engineer APPROVE, mandatory findings 0

## Scope
- no grading, Step 8, model/API, HF upload, manual workflow, network fetch, or paid execution
