### PR TITLE
fix(batch): bind relay cleanup commit identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,8 +109,12 @@ entries land under a fresh dated heading the day they merge to `main`.
   cleanup requires the exact restored generation. Step 0 records the validated
   target HEAD; one `create_commit` requires that HEAD as `parent_commit`, then
   verifies direct ancestry, plan marker, complete remote tree/hash, self-report
-  identity, and final HEAD, including response-loss reconciliation. No workflow,
-  Azure/model call, grading, HF write, or paid execution was dispatched.
+  identity, and final HEAD, including response-loss reconciliation. Relay
+  cleanup commits now store the short generation label in the Hub commit title
+  and the full 64-character generation marker in its description; response-loss
+  reconciliation and publication finality verify both SDK fields and the direct
+  parent before accepting cleanup. No workflow, Azure/model call, grading, HF
+  write, or paid execution was dispatched.
 - **Hermetic deliverable-selector contract tests** — replace import-time pandas
   and ignored local-parquet loading with a checked-in 28-task synthetic signal
   corpus. The 6,889-byte canonical fixture is self-hashed and binds exact public

--- a/batch-runner/core/hf_publication.py
+++ b/batch-runner/core/hf_publication.py
@@ -61,6 +61,8 @@ _PUBLICATION_RECEIPT_FIELDS = frozenset({
     "publication_generation",
     "ordered_task_ids",
 })
+_CLEANUP_COMMIT_TITLE_PREFIX = "Clean relay checkpoint "
+_CLEANUP_GENERATION_MARKER_PREFIX = "relay-cleanup-generation: "
 
 
 @dataclass(frozen=True)
@@ -1351,15 +1353,22 @@ def verify_publication_finality(
                     revision=final_head,
                     token=token,
                 ))
-                cleanup_message = (
-                    f"Clean relay checkpoint {expected_generation[:12]}"
+                cleanup_title = (
+                    f"{_CLEANUP_COMMIT_TITLE_PREFIX}"
+                    f"{expected_generation[:12]}"
+                )
+                cleanup_description = (
+                    f"{_CLEANUP_GENERATION_MARKER_PREFIX}"
+                    f"{expected_generation}"
                 )
                 if (
                     len(commits) < 2
                     or getattr(commits[0], "commit_id", None) != final_head
                     or getattr(commits[1], "commit_id", None)
                     != receipt.publication_revision
-                    or getattr(commits[0], "message", None) != cleanup_message
+                    or getattr(commits[0], "title", None) != cleanup_title
+                    or getattr(commits[0], "message", None)
+                    != cleanup_description
                 ):
                     raise ValueError(
                         "relay cleanup commit lineage or generation mismatch"

--- a/batch-runner/scripts/relay_checkpoint.py
+++ b/batch-runner/scripts/relay_checkpoint.py
@@ -34,6 +34,8 @@ SANDBOX_IMAGE_PATTERN = re.compile(
     r"ghcr\.io/hyeonsangjeon/gdpval-sandbox@sha256:[0-9a-f]{64}"
 )
 RESULT_STATUSES = frozenset({"success", "error", "qa_failed", "pending"})
+CLEANUP_COMMIT_TITLE_PREFIX = "Clean relay checkpoint "
+CLEANUP_GENERATION_MARKER_PREFIX = "relay-cleanup-generation: "
 
 
 def _validate_sandbox_image_digest(value: str) -> str:
@@ -59,6 +61,40 @@ def _marker_path(source_sha: str, lineage_id: str) -> str:
 
 def _generation_root(source_sha: str, lineage_id: str, generation: str) -> str:
     return f"{_lineage_root(source_sha, lineage_id)}/generations/{generation}"
+
+
+def _cleanup_commit_title(generation: str) -> str:
+    return f"{CLEANUP_COMMIT_TITLE_PREFIX}{generation[:12]}"
+
+
+def _cleanup_commit_description(generation: str) -> str:
+    return f"{CLEANUP_GENERATION_MARKER_PREFIX}{generation}"
+
+
+def _verify_cleanup_commit(
+    client: HfApi,
+    *,
+    repo_id: str,
+    token: str,
+    revision: str,
+    parent: str,
+    generation: str,
+) -> None:
+    commits = list(client.list_repo_commits(
+        repo_id=repo_id,
+        repo_type="dataset",
+        revision=revision,
+        token=token,
+    ))
+    if (
+        len(commits) < 2
+        or getattr(commits[0], "commit_id", None) != revision
+        or getattr(commits[1], "commit_id", None) != parent
+        or getattr(commits[0], "title", None) != _cleanup_commit_title(generation)
+        or getattr(commits[0], "message", None)
+        != _cleanup_commit_description(generation)
+    ):
+        raise ValueError("relay checkpoint cleanup commit identity mismatch")
 
 
 def _load_progress(path: Path) -> dict:
@@ -829,7 +865,8 @@ def cleanup_checkpoint(
                     is_folder=True,
                 ),
             ],
-            commit_message=f"Clean relay checkpoint {marker['generation'][:12]}",
+            commit_message=_cleanup_commit_title(marker["generation"]),
+            commit_description=_cleanup_commit_description(marker["generation"]),
             repo_type="dataset",
             token=token,
             parent_commit=head,
@@ -845,6 +882,14 @@ def cleanup_checkpoint(
             head=confirmed_head,
         )
         if remaining_marker_path is None:
+            _verify_cleanup_commit(
+                client,
+                repo_id=repo_id,
+                token=token,
+                revision=confirmed_head,
+                parent=head,
+                generation=expected_generation,
+            )
             print(f"Relay checkpoint cleaned from {repo_id}")
             return
         remaining_marker = _marker(remaining_marker_path.read_bytes())

--- a/batch-runner/tests/test_hf_publication.py
+++ b/batch-runner/tests/test_hf_publication.py
@@ -102,8 +102,12 @@ class FakeApi:
         history = self.commit_history.get(kwargs["revision"])
         if history is not None:
             return [
-                SimpleNamespace(commit_id=commit_id, message=message)
-                for commit_id, message in history
+                SimpleNamespace(
+                    commit_id=commit_id,
+                    title=title,
+                    message=message,
+                )
+                for commit_id, title, message in history
             ]
         message = self.marker_override or self.marker
         return [
@@ -304,7 +308,8 @@ def _add_cleanup_commit(
     *,
     head: str = "c" * 40,
     parent: str | None = None,
-    message: str | None = None,
+    title: str | None = None,
+    description: str | None = None,
     first_commit: str | None = None,
 ) -> str:
     api.head = head
@@ -312,9 +317,18 @@ def _add_cleanup_commit(
     api.commit_history[head] = [
         (
             first_commit or head,
-            message or f"Clean relay checkpoint {generation[:12]}",
+            (
+                title
+                if title is not None
+                else f"Clean relay checkpoint {generation[:12]}"
+            ),
+            (
+                description
+                if description is not None
+                else f"relay-cleanup-generation: {generation}"
+            ),
         ),
-        (parent or api.candidate, "publication"),
+        (parent or api.candidate, "publication", ""),
     ]
     return head
 
@@ -534,20 +548,39 @@ def test_publication_finality_rejects_malformed_cleanup_generation(
 
 
 @pytest.mark.parametrize(
-    "message",
+    ("title", "description"),
     [
-        f"Clean relay checkpoint {'2' * 12}",
-        f"prefix Clean relay checkpoint {'1' * 12}",
-        f"Clean relay checkpoint {'1' * 12} suffix",
+        (
+            f"Clean relay checkpoint {'2' * 12}",
+            f"relay-cleanup-generation: {'1' * 64}",
+        ),
+        (
+            f"prefix Clean relay checkpoint {'1' * 12}",
+            f"relay-cleanup-generation: {'1' * 64}",
+        ),
+        (
+            f"Clean relay checkpoint {'1' * 12}",
+            f"relay-cleanup-generation: {'2' * 64}",
+        ),
+        (
+            f"Clean relay checkpoint {'1' * 12}",
+            "",
+        ),
     ],
 )
-def test_publication_finality_rejects_cleanup_message_or_generation_mismatch(
+def test_publication_finality_rejects_cleanup_metadata_or_generation_mismatch(
     tmp_path,
-    message,
+    title,
+    description,
 ):
     generation = "1" * 64
     api, root, receipt_path, _publication = _published_state(tmp_path)
-    _add_cleanup_commit(api, generation, message=message)
+    _add_cleanup_commit(
+        api,
+        generation,
+        title=title,
+        description=description,
+    )
 
     with pytest.raises(RuntimeError, match="finality is unverified"):
         verify_publication_finality(
@@ -569,7 +602,7 @@ def test_publication_finality_rejects_unrelated_child_or_grandchild(
     generation = "1" * 64
     api, root, receipt_path, _publication = _published_state(tmp_path)
     if relationship == "unrelated-child":
-        _add_cleanup_commit(api, generation, message="Unrelated commit")
+        _add_cleanup_commit(api, generation, title="Unrelated commit")
     else:
         _add_cleanup_commit(api, generation, parent="d" * 40)
 

--- a/batch-runner/tests/test_relay_checkpoint.py
+++ b/batch-runner/tests/test_relay_checkpoint.py
@@ -73,6 +73,7 @@ class FakeApi:
         self.oid = oid
         self.files_by_revision = {}
         self.commit_parents = {}
+        self.commit_metadata = {}
         self.current_files = set()
         self.marker = None
         self.fail_upload_folder = False
@@ -117,7 +118,12 @@ class FakeApi:
         commits = []
         revision = kwargs["revision"]
         while revision is not None:
-            commits.append(SimpleNamespace(commit_id=revision))
+            title, message = self.commit_metadata.get(revision, ("", ""))
+            commits.append(SimpleNamespace(
+                commit_id=revision,
+                title=title,
+                message=message,
+            ))
             revision = self.commit_parents.get(revision)
         return commits
 
@@ -212,6 +218,10 @@ class StatefulApi(FakeApi):
                 self.current_files.discard(operation.path_in_repo)
         oid = self._oid()
         self.commit_parents[oid] = parent
+        self.commit_metadata[oid] = (
+            kwargs["commit_message"],
+            kwargs.get("commit_description", ""),
+        )
         self.files_by_revision[oid] = sorted(self.current_files)
         return SimpleNamespace(oid=oid)
 
@@ -966,6 +976,12 @@ def test_upload_marker_binds_payload_revision_and_cleanup_generation(tmp_path, m
     assert download_calls[0]["revision"] == api.head
     cleanup = next(call for call in api.calls if call[0] == "create_commit")
     assert cleanup[1]["parent_commit"] == api.head
+    assert cleanup[1]["commit_message"] == (
+        f"Clean relay checkpoint {marker['generation'][:12]}"
+    )
+    assert cleanup[1]["commit_description"] == (
+        f"relay-cleanup-generation: {marker['generation']}"
+    )
     operations = cleanup[1]["operations"]
     assert [operation.path_in_repo for operation in operations] == [
         relay._lineage_root(SOURCE_SHA, LINEAGE_ID),
@@ -1142,6 +1158,40 @@ def test_cleanup_retry_after_commit_response_loss_is_idempotent(tmp_path, monkey
         - repo_info_calls
         == 2
     )
+
+
+def test_cleanup_response_loss_rejects_full_generation_marker_drift(
+    tmp_path, monkeypatch
+):
+    api = _uploaded_stateful_checkpoint(tmp_path, monkeypatch, ResponseLossApi())
+    generation = json.loads(api.marker)["generation"]
+    api.lose_commit_response = True
+    original_create_commit = api.create_commit
+
+    def commit_with_tampered_description(**kwargs):
+        try:
+            return original_create_commit(**kwargs)
+        except RuntimeError:
+            title, _description = api.commit_metadata[api.head]
+            api.commit_metadata[api.head] = (
+                title,
+                f"relay-cleanup-generation: {'f' * 64}",
+            )
+            raise
+
+    api.create_commit = commit_with_tampered_description
+
+    with pytest.raises(ValueError, match="cleanup commit identity mismatch"):
+        relay.cleanup_checkpoint(
+            "owner/repository",
+            token="token",
+            source_sha=SOURCE_SHA,
+            lineage_id=LINEAGE_ID,
+            expected_generation=generation,
+            api=api,
+        )
+
+    assert [name for name, _kwargs in api.calls].count("create_commit") == 1
 
 
 def test_cleanup_response_loss_rejects_newer_lineage(tmp_path, monkeypatch):

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,7 +4,8 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-22
-- Status: Shipped via PR #129
+- Status: PR #129 shipped; cleanup commit identity follow-up locally verified,
+  PR pending
 
 ## Task
 
@@ -15,6 +16,8 @@ task. It must be refreshed before a task is reported complete.
 - Fail closed before Azure/model spend when dispatch identity, relay source,
   checkpoint/image identity, canonical task/reference semantics, write
   authorization, or publication output identity cannot be proven.
+- Bind relay cleanup finality to the actual Hugging Face SDK commit model:
+  `title` for `commit_message` and `message` for `commit_description`.
 
 ## Result
 
@@ -82,6 +85,12 @@ task. It must be refreshed before a task is reported complete.
   requires the exact restored checkpoint generation, and a private local
   receipt binds the publication plan so post-cleanup verification accepts only
   the exact cleanup child with an unchanged managed tree.
+- The follow-up cleanup commit writes a short generation label to the Hub commit
+  title and the full 64-character generation marker to its description.
+  Response-loss reconciliation and publication finality require that exact
+  `GitCommitInfo.title`, `GitCommitInfo.message`, and direct parent, preventing a
+  valid cleanup from failing due to SDK field confusion and preventing an
+  unrelated child commit from being accepted.
 - Added model-free checkpoint identity validation after Step 1 and before Azure
   login/model-client construction. Missing progress, lineage/fingerprint drift,
   or incomplete deliverables abort the continuation instead of rerunning tasks.
@@ -91,8 +100,8 @@ task. It must be refreshed before a task is reported complete.
 
 ## Verification
 
-- Rebased base: `origin/main@723826c9f8a1c3b6c9b10d8d3ad0082d5810e07a`.
-- Full backend non-integration suite: **1,851 passed, 6 skipped, 44 deselected,
+- Follow-up base: `origin/main@8e473361a12c348ee6fb4d4da6bbfb1d8a2b157f`.
+- Full backend non-integration suite: **1,852 passed, 6 skipped, 44 deselected,
   0 failed**.
 - Focused manifest/reference, relay, publication, output, bootstrap, inference,
   corruption, observability, and agentic trust matrix: **361 passed**.
@@ -105,7 +114,8 @@ task. It must be refreshed before a task is reported complete.
   manifest pre-client gates, Step 0 stale-state rejection, Step 4 current-run
   rebuilding, and Step 7 exact publication. The final Step 0 safety matrix is
   **65 passed**, relay checkpoint/status matrix is **82 passed**, and HF
-  publication/finality matrix is **85 passed**. These include source-first
+  publication/finality matrix is **86 passed**. The final relay plus publication
+  follow-up matrix is **168 passed**. These include source-first
   mutation ordering, post-create drift rejection, canonical target columns,
   exact-generation cleanup, realistic HF cache symlinks, and non-relay
   file-verification call bounds.
@@ -147,6 +157,8 @@ task. It must be refreshed before a task is reported complete.
 
 ## Remaining Work
 
-- No repository implementation work remains for this task. Repository branch
-  protection remains a separate administrative control; the exact-main
-  preflight does not replace a protected `main` ruleset.
+- Create, review, and merge the cleanup commit identity follow-up PR, then
+  confirm its free automatic PR validation and post-merge Pages run. Do not
+  dispatch a paid batch smoke for this metadata-contract correction.
+- Repository branch protection remains a separate administrative control; the
+  exact-main preflight does not replace a protected `main` ruleset.


### PR DESCRIPTION
## Summary
- write relay cleanup generation identity to the Hugging Face commit title and full description using the SDK's actual `commit_message -> title` and `commit_description -> message` contract
- require exact cleanup HEAD, direct publication parent, title, and full 64-character generation marker during response-loss reconciliation and publication finality
- update SDK-shaped regression tests and the repository completion records

## Validation
- `pytest -q`: 1,852 passed, 6 skipped, 44 deselected
- relay + publication focused matrix: 168 passed
- publication matrix: 86 passed
- Ruff and `py_compile`: passed
- `git diff --check`: passed
- independent high-risk review: APPROVE, no blocker/major/minor findings

## Safety
- no workflow dispatch, Azure/model call, grading run, Hugging Face write, or paid execution was performed
- no paid batch smoke is required; use only the automatic pull-request validation
