### PR TITLE
feat(azure-ai): add typed endpoint foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Added
+- **Typed Azure AI endpoint foundation** - add exact HTTPS endpoint contracts
+  for direct Azure OpenAI v1, Foundry project, and explicitly authorized legacy
+  rollback routes. Parsing rejects non-ASCII/control normalization, empty ports,
+  malformed percent sequences, host lookalikes, and trailing dots before the
+  exact Microsoft suffix/path allowlist. Strict identity is profile-specific,
+  including direct verification of `AZURE_AI_EXPECTED_LEGACY_ACCOUNT`. The
+  current `CodeInterpreterRunner is Azure-only`; a missing deployment follows
+  the runtime's `gpt-4` default, while malformed model objects, explicit null
+  deployments, and native-provider Code Interpreter fail. Audio/video
+  preprocessors use only the runtime `deployment` field and defaults; other
+  types are excluded. `DefaultAzureCredential`-based settings reject known
+  static Azure key, token, secret, certificate, username, and password
+  variables while allowing `AZURE_FEDERATED_TOKEN_FILE` and native
+  `OPENAI_API_KEY`. Owned factory and token-check paths recheck the real process
+  environment before constructing a credential even with explicit route
+  settings; injected credentials remain caller-managed. Versioned fingerprints
+  bind effective token scope and
+  transport settings while emitted records remain endpoint-free, redacted
+  provenance; the digest is not a confidentiality boundary and not a secret.
+  Synchronous non-thread-safe factory/lease ownership and hardened one-write
+  `GITHUB_OUTPUT` behavior are covered directly. Exact pins are
+  `openai==2.46.0`, `azure-core==1.41.0`, `azure-identity==1.25.3`, and
+  `azure-ai-projects==2.3.0`. An offline real-SDK construction smoke verified
+  the canonical project OpenAI base URL and the exact capability contract:
+  `responses.create`, `files.create`, `files.delete`, fallback `files.content`,
+  `containers.create`, `containers.files.list`, and
+  `containers.files.content.retrieve`. The current runner uses auto-container
+  configuration rather than calling `containers.create` directly; that method
+  is retained as a project-client compatibility gate. Credential and HTTP send
+  counters remained zero and the credential stayed caller-owned. Raw and
+  serialized condition discovery produce the same main, QA, and preprocessor
+  workloads. A detached clean checkout passes the focused suite **224/224 in
+  20.79 seconds**, the exact real-SDK smoke **1/1 in 1.47 seconds**, and the
+  complete credential-free backend non-integration suite with **2,074 passed,
+  9 skipped, and 44 integration tests deselected in 126.02 seconds**. Ruff,
+  `py_compile`,
+  `pip check`, exact-pin, `git diff --check`, conflict-marker, and exact
+  eight-path scope checks pass. Runtime and workflow integration is `NOT WIRED`;
+  no token, network, Azure/model API, Hugging Face, workflow, or paid action
+  occurred.
+
 ### Changed
 - **GitHub repository About metadata** — replace the contradictory
   `220 tasks across 11 industries` description with a concise public value

--- a/batch-runner/core/azure_ai_clients.py
+++ b/batch-runner/core/azure_ai_clients.py
@@ -1,0 +1,980 @@
+"""Typed Microsoft Foundry and Azure OpenAI client routing.
+
+Authentication is based on ``DefaultAzureCredential``. Known static Azure
+credential environment variables are rejected before any client is built.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import inspect
+import ipaddress
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Mapping, Sequence
+from urllib.parse import urlsplit
+
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from openai import AzureOpenAI, OpenAI
+
+
+DIRECT_TOKEN_SCOPE = "https://ai.azure.com/.default"
+LEGACY_TOKEN_SCOPE = "https://cognitiveservices.azure.com/.default"
+DEFAULT_TIMEOUT = 480.0
+DEFAULT_LEGACY_API_VERSION = "2025-04-01-preview"
+ROUTE_FINGERPRINT_CONTRACT_VERSION = "azure-ai-route-v1"
+
+FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV = (
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_API_KEY",
+    "AZURE_AI_API_KEY",
+    "AZURE_AI_PROJECT_API_KEY",
+    "AZURE_OPENAI_AD_TOKEN",
+    "AZURE_CLIENT_SECRET",
+    "AZURE_CLIENT_CERTIFICATE_PATH",
+    "AZURE_CLIENT_CERTIFICATE_PASSWORD",
+    "AZURE_USERNAME",
+    "AZURE_PASSWORD",
+)
+FORBIDDEN_API_KEY_ENV = FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV
+
+_AZURE_PROVIDER_ALIASES = frozenset({"azure", "azure_openai"})
+_PREPROCESSOR_DEFAULT_DEPLOYMENTS = {
+    "audio_analyzer": "gpt-audio-1.5",
+    "video_analyzer": "gpt-5.2",
+}
+
+_ACCOUNT_PATTERN = re.compile(
+    r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?"
+)
+_PROJECT_PATTERN = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9._-]{0,126}[A-Za-z0-9])?"
+)
+class EndpointKind(str, Enum):
+    DIRECT_V1 = "direct-v1"
+    PROJECT = "project"
+    LEGACY_DATED = "legacy-dated"
+
+
+class RouteProfile(str, Enum):
+    DIRECT_V1 = "direct-v1"
+    PROJECT_CI = "project-ci"
+    LEGACY_ROLLBACK = "legacy-rollback"
+
+
+class AzureAIWorkload(str, Enum):
+    INFERENCE = "inference"
+    CODE_INTERPRETER = "code-interpreter"
+    NARRATIVE = "narrative"
+    GRADER = "grader"
+
+
+@dataclass(frozen=True)
+class ClassifiedEndpoint:
+    kind: EndpointKind
+    url: str = field(repr=False)
+    account: str
+    project: str | None = None
+
+
+@dataclass(frozen=True)
+class RouteSelection:
+    profile: RouteProfile
+    workload: AzureAIWorkload
+    endpoint: ClassifiedEndpoint
+    token_scope: str
+
+
+def _validate_account(account: str) -> str:
+    normalized = account.lower()
+    if not _ACCOUNT_PATTERN.fullmatch(normalized):
+        raise ValueError("Azure AI endpoint account name is invalid")
+    return normalized
+
+
+def _validate_project(project: str) -> str:
+    if not _PROJECT_PATTERN.fullmatch(project):
+        raise ValueError("Foundry project name is invalid")
+    return project
+
+
+def _validate_hostname(hostname: str) -> str:
+    host = hostname.lower()
+    if host.endswith("."):
+        raise ValueError("Azure AI endpoint hostname is invalid")
+    if host == "localhost":
+        raise ValueError("Azure AI endpoint must not use localhost")
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("Azure AI endpoint must not use an IP address")
+    return host
+
+
+def _resource_account(host: str, suffix: str) -> str | None:
+    marker = f".{suffix}"
+    if not host.endswith(marker):
+        return None
+    return _validate_account(host[: -len(marker)])
+
+
+def classify_endpoint(value: str) -> ClassifiedEndpoint:
+    """Classify and canonicalize one supported Microsoft endpoint shape."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("Azure AI endpoint is required")
+    if any(
+        ord(character) < 0x20
+        or 0x7F <= ord(character) <= 0x9F
+        or character in {"\u2028", "\u2029"}
+        for character in value
+    ):
+        raise ValueError("Azure AI endpoint contains control characters")
+    if not value.isascii():
+        raise ValueError("Azure AI endpoint must contain ASCII characters only")
+    raw = value.strip()
+    if "\\" in raw:
+        raise ValueError("Azure AI endpoint contains an invalid path separator")
+    if "?" in raw or "#" in raw:
+        raise ValueError("Azure AI endpoint must not contain query or fragment data")
+
+    try:
+        parsed = urlsplit(raw)
+    except ValueError:
+        raise ValueError("Azure AI endpoint URL is invalid") from None
+    if parsed.scheme != "https":
+        raise ValueError("Azure AI endpoint must use HTTPS")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("Azure AI endpoint must not contain user information")
+    if parsed.netloc.rsplit("@", 1)[-1].endswith(":"):
+        raise ValueError("Azure AI endpoint port must not be empty")
+    try:
+        port = parsed.port
+    except ValueError:
+        raise ValueError("Azure AI endpoint port is invalid") from None
+    if port not in (None, 443):
+        raise ValueError("Azure AI endpoint must use HTTPS port 443")
+    if not parsed.hostname:
+        raise ValueError("Azure AI endpoint hostname is missing")
+
+    host = _validate_hostname(parsed.hostname)
+    path = parsed.path
+    if "%" in path:
+        raise ValueError("Azure AI endpoint path must not use percent encoding")
+
+    openai_account = _resource_account(host, "openai.azure.com")
+    services_account = _resource_account(host, "services.ai.azure.com")
+
+    if path in ("/openai/v1", "/openai/v1/"):
+        account = openai_account or services_account
+        if account is not None:
+            return ClassifiedEndpoint(
+                kind=EndpointKind.DIRECT_V1,
+                url=f"https://{host}/openai/v1/",
+                account=account,
+            )
+
+    project_match = re.fullmatch(r"/api/projects/([^/]+)/?", path)
+    if project_match is not None and services_account is not None:
+        project = _validate_project(project_match.group(1))
+        return ClassifiedEndpoint(
+            kind=EndpointKind.PROJECT,
+            url=f"https://{host}/api/projects/{project}",
+            account=services_account,
+            project=project,
+        )
+
+    if path in ("", "/") and openai_account is not None:
+        return ClassifiedEndpoint(
+            kind=EndpointKind.LEGACY_DATED,
+            url=f"https://{host}/",
+            account=openai_account,
+        )
+
+    raise ValueError("Azure AI endpoint shape or Microsoft host kind is unsupported")
+
+
+def _env_value(env: Mapping[str, str], name: str) -> str:
+    value = env.get(name, "")
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    return value.strip()
+
+
+def _reject_static_azure_credential_env(env: Mapping[str, str]) -> None:
+    forbidden = [
+        name
+        for name in FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV
+        if env.get(name)
+    ]
+    if forbidden:
+        raise ValueError(
+            "static Azure credential environment variables are forbidden: "
+            + ", ".join(forbidden)
+        )
+
+
+def _classify_typed_endpoint(
+    env: Mapping[str, str],
+    variable: str,
+    required_kind: EndpointKind,
+) -> ClassifiedEndpoint | None:
+    raw = _env_value(env, variable)
+    if not raw:
+        return None
+    endpoint = classify_endpoint(raw)
+    if endpoint.kind is not required_kind:
+        raise ValueError(
+            f"{variable} must contain a {required_kind.value} endpoint"
+        )
+    return endpoint
+
+
+def _deprecated_endpoint_error(raw: str) -> ValueError:
+    try:
+        kind = classify_endpoint(raw).kind
+    except ValueError:
+        return ValueError(
+            "AZURE_OPENAI_ENDPOINT is deprecated and must be unset; use the "
+            "typed endpoint variable for the required endpoint kind"
+        )
+    variable = {
+        EndpointKind.DIRECT_V1: "AZURE_OPENAI_V1_ENDPOINT",
+        EndpointKind.PROJECT: "FOUNDRY_PROJECT_ENDPOINT",
+        EndpointKind.LEGACY_DATED: "AZURE_OPENAI_LEGACY_ENDPOINT",
+    }[kind]
+    return ValueError(
+        "AZURE_OPENAI_ENDPOINT is deprecated and must be unset; move the "
+        f"{kind.value} endpoint to {variable}"
+    )
+
+
+@dataclass(frozen=True)
+class AzureAIRouteSettings:
+    profile: RouteProfile
+    direct_v1: ClassifiedEndpoint | None = None
+    project: ClassifiedEndpoint | None = None
+    legacy: ClassifiedEndpoint | None = None
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "AzureAIRouteSettings":
+        values = os.environ if env is None else env
+        _reject_static_azure_credential_env(values)
+
+        raw_profile = _env_value(values, "AZURE_AI_ROUTE_PROFILE")
+        if not raw_profile:
+            raise ValueError("AZURE_AI_ROUTE_PROFILE is required")
+        try:
+            profile = RouteProfile(raw_profile)
+        except ValueError:
+            raise ValueError("AZURE_AI_ROUTE_PROFILE is unsupported") from None
+
+        deprecated = _env_value(values, "AZURE_OPENAI_ENDPOINT")
+        if deprecated:
+            raise _deprecated_endpoint_error(deprecated)
+
+        direct = _classify_typed_endpoint(
+            values,
+            "AZURE_OPENAI_V1_ENDPOINT",
+            EndpointKind.DIRECT_V1,
+        )
+        project = _classify_typed_endpoint(
+            values,
+            "FOUNDRY_PROJECT_ENDPOINT",
+            EndpointKind.PROJECT,
+        )
+        legacy = _classify_typed_endpoint(
+            values,
+            "AZURE_OPENAI_LEGACY_ENDPOINT",
+            EndpointKind.LEGACY_DATED,
+        )
+
+        if direct is None and project is not None:
+            direct = ClassifiedEndpoint(
+                kind=EndpointKind.DIRECT_V1,
+                url=(
+                    f"https://{project.account}.services.ai.azure.com/"
+                    "openai/v1/"
+                ),
+                account=project.account,
+            )
+
+        if profile is RouteProfile.DIRECT_V1 and direct is None:
+            raise ValueError("direct-v1 profile requires a direct-v1 endpoint")
+        if profile is RouteProfile.PROJECT_CI and (
+            direct is None or project is None
+        ):
+            raise ValueError(
+                "project-ci profile requires direct-v1 and project endpoints"
+            )
+        if profile is RouteProfile.LEGACY_ROLLBACK:
+            if _env_value(values, "AZURE_AI_ALLOW_LEGACY_ROLLBACK") != "1":
+                raise ValueError("legacy rollback is not explicitly authorized")
+            if legacy is None:
+                raise ValueError(
+                    "legacy-rollback profile requires a legacy-dated endpoint"
+                )
+
+        settings = cls(
+            profile=profile,
+            direct_v1=direct,
+            project=project,
+            legacy=legacy,
+        )
+        settings._verify_expected_identities(values)
+        settings._require_expected_identities(values)
+        return settings
+
+    def _require_expected_identities(self, env: Mapping[str, str]) -> None:
+        if _env_value(env, "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES") != "1":
+            return
+        required = {
+            RouteProfile.DIRECT_V1: ("AZURE_AI_EXPECTED_DIRECT_ACCOUNT",),
+            RouteProfile.PROJECT_CI: (
+                "AZURE_AI_EXPECTED_DIRECT_ACCOUNT",
+                "AZURE_AI_EXPECTED_PROJECT_ACCOUNT",
+                "AZURE_AI_EXPECTED_PROJECT_NAME",
+            ),
+            RouteProfile.LEGACY_ROLLBACK: (
+                "AZURE_AI_EXPECTED_LEGACY_ACCOUNT",
+            ),
+        }[self.profile]
+        missing = [name for name in required if not _env_value(env, name)]
+        if missing:
+            raise ValueError(
+                "required Azure AI endpoint identities are missing: "
+                + ", ".join(missing)
+            )
+
+    def _verify_expected_identities(self, env: Mapping[str, str]) -> None:
+        if self.profile in (RouteProfile.DIRECT_V1, RouteProfile.PROJECT_CI):
+            expected_direct = _env_value(
+                env, "AZURE_AI_EXPECTED_DIRECT_ACCOUNT"
+            )
+            if expected_direct:
+                expected_direct = _validate_account(expected_direct)
+                if (
+                    self.direct_v1 is None
+                    or self.direct_v1.account != expected_direct
+                ):
+                    raise ValueError("direct endpoint account identity mismatch")
+
+        if self.profile is RouteProfile.PROJECT_CI:
+            expected_project_account = _env_value(
+                env, "AZURE_AI_EXPECTED_PROJECT_ACCOUNT"
+            )
+            if expected_project_account:
+                expected_project_account = _validate_account(
+                    expected_project_account
+                )
+                if (
+                    self.project is None
+                    or self.project.account != expected_project_account
+                ):
+                    raise ValueError("project endpoint account identity mismatch")
+
+            expected_project = _env_value(
+                env, "AZURE_AI_EXPECTED_PROJECT_NAME"
+            )
+            if expected_project:
+                expected_project = _validate_project(expected_project)
+                if (
+                    self.project is None
+                    or self.project.project != expected_project
+                ):
+                    raise ValueError("Foundry project identity mismatch")
+
+        if self.profile is RouteProfile.LEGACY_ROLLBACK:
+            expected_legacy = _env_value(
+                env, "AZURE_AI_EXPECTED_LEGACY_ACCOUNT"
+            )
+            if expected_legacy:
+                expected_legacy = _validate_account(expected_legacy)
+                if (
+                    self.legacy is None
+                    or self.legacy.account != expected_legacy
+                ):
+                    raise ValueError("legacy endpoint account identity mismatch")
+
+    def select(self, workload: AzureAIWorkload | str) -> RouteSelection:
+        selected_workload = AzureAIWorkload(workload)
+        if (
+            self.profile is RouteProfile.PROJECT_CI
+            and selected_workload is AzureAIWorkload.CODE_INTERPRETER
+        ):
+            if self.project is None:
+                raise ValueError("Foundry project endpoint is unavailable")
+            return RouteSelection(
+                profile=self.profile,
+                workload=selected_workload,
+                endpoint=self.project,
+                token_scope=DIRECT_TOKEN_SCOPE,
+            )
+        if self.profile in (RouteProfile.DIRECT_V1, RouteProfile.PROJECT_CI):
+            if self.direct_v1 is None:
+                raise ValueError("direct v1 endpoint is unavailable")
+            return RouteSelection(
+                profile=self.profile,
+                workload=selected_workload,
+                endpoint=self.direct_v1,
+                token_scope=DIRECT_TOKEN_SCOPE,
+            )
+        if self.legacy is None:
+            raise ValueError("legacy endpoint is unavailable")
+        return RouteSelection(
+            profile=self.profile,
+            workload=selected_workload,
+            endpoint=self.legacy,
+            token_scope=LEGACY_TOKEN_SCOPE,
+        )
+
+
+def _close_sync(resource: object | None, role: str) -> None:
+    if resource is None:
+        return
+    close = getattr(resource, "close", None)
+    if not callable(close):
+        return
+    if inspect.iscoroutinefunction(close):
+        raise RuntimeError(
+            f"sync Azure AI client lifecycle does not support async {role} close"
+        )
+    result = close()
+    if inspect.isawaitable(result):
+        if inspect.iscoroutine(result):
+            result.close()
+        raise RuntimeError(
+            f"sync Azure AI client lifecycle does not support async {role} close"
+        )
+
+
+def _close_resources_sync(
+    resources: Sequence[tuple[str, object | None]],
+) -> None:
+    first_error: BaseException | None = None
+    seen: set[int] = set()
+    for role, resource in resources:
+        if resource is None or id(resource) in seen:
+            continue
+        seen.add(id(resource))
+        try:
+            _close_sync(resource, role)
+        except BaseException as exc:
+            if first_error is None:
+                first_error = exc
+    if first_error is not None:
+        raise first_error
+
+
+@dataclass
+class AzureAIClientLease:
+    """Explicit synchronous client lease; instances are not thread-safe.
+
+    Closing a lease closes its SDK client and project owner, but never the
+    shared factory or its credential. Async close implementations are rejected.
+    """
+
+    client: object
+    owner: object | None
+    route: RouteSelection
+    runtime_fingerprint: str
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        _close_resources_sync(
+            (
+                ("client", self.client),
+                ("project owner", self.owner),
+            )
+        )
+
+    def __enter__(self) -> "AzureAIClientLease":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.close()
+
+
+def _package_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "unavailable"
+
+
+def route_fingerprint(
+    route: RouteSelection,
+    deployment: str,
+    *,
+    timeout: float | None = DEFAULT_TIMEOUT,
+    max_retries: int | None = None,
+    legacy_api_version: str = DEFAULT_LEGACY_API_VERSION,
+) -> str:
+    """Hash endpoint-free, redacted route provenance.
+
+    The contract-versioned digest is a comparison identifier, not a
+    confidentiality boundary or secret. Raw endpoint and deployment values are
+    absent from emitted provenance records.
+    """
+    if not isinstance(deployment, str) or not deployment.strip():
+        raise ValueError("Azure AI deployment identity is required")
+    if not isinstance(legacy_api_version, str) or not legacy_api_version.strip():
+        raise ValueError("Azure AI legacy API version is required")
+
+    sdk_versions = {
+        "azure_core": _package_version("azure-core"),
+        "azure_identity": _package_version("azure-identity"),
+        "openai": _package_version("openai"),
+    }
+    if route.endpoint.kind is EndpointKind.PROJECT:
+        sdk_versions["azure_ai_projects"] = _package_version(
+            "azure-ai-projects"
+        )
+    identity = {
+        "contract_version": ROUTE_FINGERPRINT_CONTRACT_VERSION,
+        "deployment": deployment.strip(),
+        "endpoint_sha256": hashlib.sha256(
+            route.endpoint.url.encode("utf-8")
+        ).hexdigest(),
+        "kind": route.endpoint.kind.value,
+        "legacy_api_version": legacy_api_version.strip(),
+        "max_retries": max_retries,
+        "profile": route.profile.value,
+        "sdk_versions": sdk_versions,
+        "timeout": timeout,
+        "token_scope": route.token_scope,
+        "workload": route.workload.value,
+    }
+    encoded = json.dumps(
+        identity,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def preflight_routes(
+    workloads: Sequence[tuple[AzureAIWorkload | str, str]],
+    *,
+    settings: AzureAIRouteSettings | None = None,
+    timeout: float | None = DEFAULT_TIMEOUT,
+    max_retries: int | None = None,
+    legacy_api_version: str = DEFAULT_LEGACY_API_VERSION,
+) -> list[dict[str, str]]:
+    """Validate routes and return endpoint-free, redacted provenance records."""
+    resolved = settings or AzureAIRouteSettings.from_env()
+    if not workloads:
+        raise ValueError("at least one Azure AI workload is required")
+
+    records: list[dict[str, str]] = []
+    seen: set[tuple[AzureAIWorkload, str]] = set()
+    for raw_workload, raw_deployment in workloads:
+        workload = AzureAIWorkload(raw_workload)
+        deployment = (
+            raw_deployment.strip()
+            if isinstance(raw_deployment, str)
+            else ""
+        )
+        if not deployment:
+            raise ValueError("Azure AI deployment identity is required")
+        identity = (workload, deployment)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        route = resolved.select(workload)
+        records.append(
+            {
+                "endpoint_kind": route.endpoint.kind.value,
+                "profile": route.profile.value,
+                "runtime_fingerprint": route_fingerprint(
+                    route,
+                    deployment,
+                    timeout=timeout,
+                    max_retries=max_retries,
+                    legacy_api_version=legacy_api_version,
+                ),
+                "workload": workload.value,
+            }
+        )
+    return records
+
+
+def canonical_deployment(
+    config: Mapping[str, object],
+    path: str,
+    *,
+    fallback: str | None = None,
+) -> str:
+    """Resolve one SDK model identity and reject conflicting aliases."""
+    model = config.get("model")
+    deployment = config.get("deployment")
+    for field_name, value in (("model", model), ("deployment", deployment)):
+        if value is not None and (
+            not isinstance(value, str) or not value.strip()
+        ):
+            raise ValueError(f"{path}.{field_name} must be a nonempty string")
+    if isinstance(model, str) and isinstance(deployment, str):
+        if model.strip() != deployment.strip():
+            raise ValueError(f"{path}.model and {path}.deployment must match")
+    selected = deployment or model or fallback
+    if not isinstance(selected, str) or not selected.strip():
+        raise ValueError(f"{path} deployment identity is missing")
+    return selected.strip()
+
+
+def inference_route_workloads(
+    condition: Mapping[str, object],
+    execution_mode: str,
+) -> list[tuple[AzureAIWorkload, str]]:
+    """Return every Azure deployment the inference condition can call.
+
+    The current ``CodeInterpreterRunner`` is Azure-only, so Code Interpreter
+    discovery requires an explicit, well-formed Azure main-model mapping.
+    """
+    raw_model = condition.get("model", {})
+    if not isinstance(raw_model, Mapping):
+        raise ValueError("model must be an object")
+    model = raw_model
+    provider = model.get("provider", "azure")
+    if not isinstance(provider, str) or not provider.strip():
+        raise ValueError("model.provider must be a nonempty string")
+    azure_main = provider in _AZURE_PROVIDER_ALIASES
+    if execution_mode == "code_interpreter" and not azure_main:
+        raise ValueError(
+            "code_interpreter mode requires an Azure provider because the "
+            "current CodeInterpreterRunner is Azure-only"
+        )
+
+    main_deployment: str | None = None
+    workloads: list[tuple[AzureAIWorkload, str]] = []
+    if azure_main:
+        raw_main_deployment = model.get("deployment", "gpt-4")
+        if (
+            not isinstance(raw_main_deployment, str)
+            or not raw_main_deployment.strip()
+        ):
+            raise ValueError("model.deployment must be a nonempty string")
+        main_deployment = raw_main_deployment.strip()
+        workloads.append((AzureAIWorkload.INFERENCE, main_deployment))
+
+        qa = condition.get("qa")
+        if isinstance(qa, Mapping) and qa.get("enabled") is True:
+            raw_qa_model = qa.get("model")
+            if raw_qa_model in (None, ""):
+                qa_deployment = main_deployment
+            elif isinstance(raw_qa_model, str) and raw_qa_model.strip():
+                qa_deployment = raw_qa_model.strip()
+            else:
+                raise ValueError("qa.model must be a nonempty string or null")
+            workloads.append((AzureAIWorkload.INFERENCE, qa_deployment))
+
+    preprocessors = condition.get("preprocessors") or []
+    if not isinstance(preprocessors, list):
+        raise ValueError("Azure AI preprocessors must be a list")
+    for index, preprocessor in enumerate(preprocessors):
+        if not isinstance(preprocessor, Mapping):
+            raise ValueError("Azure AI preprocessor config must be an object")
+        preprocessor_type = preprocessor.get("type")
+        if preprocessor_type not in _PREPROCESSOR_DEFAULT_DEPLOYMENTS:
+            continue
+        raw_preprocessor_model = preprocessor.get("model")
+        if raw_preprocessor_model is None:
+            preprocessor_model: Mapping[str, object] = {}
+        elif isinstance(raw_preprocessor_model, Mapping):
+            preprocessor_model = raw_preprocessor_model
+        else:
+            raise ValueError("Azure AI preprocessor model must be an object")
+        preprocessor_provider = preprocessor_model.get("provider", "azure")
+        if not isinstance(preprocessor_provider, str):
+            raise ValueError(
+                "Azure AI preprocessor provider must be a string"
+            )
+        if preprocessor_provider not in _AZURE_PROVIDER_ALIASES:
+            continue
+        raw_deployment = preprocessor_model.get(
+            "deployment",
+            _PREPROCESSOR_DEFAULT_DEPLOYMENTS[preprocessor_type],
+        )
+        if not isinstance(raw_deployment, str) or not raw_deployment.strip():
+            raise ValueError(
+                f"preprocessors[{index}].model.deployment must be a "
+                "nonempty string"
+            )
+        preprocessor_deployment = raw_deployment.strip()
+        workloads.append(
+            (AzureAIWorkload.INFERENCE, preprocessor_deployment)
+        )
+
+    if execution_mode == "code_interpreter":
+        if main_deployment is None:
+            raise ValueError("code_interpreter deployment identity is missing")
+        workloads.append(
+            (AzureAIWorkload.CODE_INTERPRETER, main_deployment)
+        )
+    return workloads
+
+
+def grader_route_workloads(
+    config: Mapping[str, object],
+) -> list[tuple[AzureAIWorkload, str]]:
+    """Return every Azure deployment a grading config can call."""
+    judge = config.get("judge")
+    if not isinstance(judge, Mapping):
+        raise ValueError("judge config must be an object")
+    provider = judge.get("provider", "azure_openai")
+    if provider not in {"azure", "azure_openai"}:
+        return []
+    deployments = [canonical_deployment(judge, "judge")]
+
+    routing = config.get("judge_routing") or {}
+    if not isinstance(routing, Mapping):
+        raise ValueError("judge_routing must be an object")
+    for tier_name in ("tier_standard", "tier_pro", "tier_mini"):
+        tier = routing.get(tier_name) or {}
+        if not isinstance(tier, Mapping):
+            raise ValueError(f"judge_routing.{tier_name} must be an object")
+        if tier.get("deployment") is None and tier.get("model") is None:
+            continue
+        deployments.append(
+            canonical_deployment(tier, f"judge_routing.{tier_name}")
+        )
+
+    perception = judge.get("perception") or {}
+    if not isinstance(perception, Mapping):
+        raise ValueError("judge.perception must be an object")
+    for modality in ("visual", "audio"):
+        modality_config = perception.get(modality) or {}
+        if not isinstance(modality_config, Mapping):
+            raise ValueError(f"judge.perception.{modality} must be an object")
+        if (
+            modality_config.get("deployment") is None
+            and modality_config.get("model") is None
+        ):
+            continue
+        deployments.append(
+            canonical_deployment(
+                modality_config,
+                f"judge.perception.{modality}",
+            )
+        )
+
+    return [(AzureAIWorkload.GRADER, value) for value in deployments]
+
+
+def _narrative_deployment(
+    value: str | Mapping[str, object],
+    path: str,
+) -> str:
+    if isinstance(value, Mapping):
+        return canonical_deployment(value, path)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("narrative deployment identity is invalid")
+    return value.strip()
+
+
+def narrative_route_workloads(
+    primary_deployment: str | Mapping[str, object],
+    fallback_deployments: Sequence[str | Mapping[str, object]] = (),
+) -> list[tuple[AzureAIWorkload, str]]:
+    """Return primary and possible fallback narrative deployments."""
+    deployments = [primary_deployment, *fallback_deployments]
+    return [
+        (
+            AzureAIWorkload.NARRATIVE,
+            _narrative_deployment(value, f"narrative[{index}]"),
+        )
+        for index, value in enumerate(deployments)
+    ]
+
+
+def verify_direct_token(credential=None) -> None:
+    """Verify Entra token acquisition without calling a model endpoint."""
+    owns_credential = credential is None
+    if owns_credential:
+        _reject_static_azure_credential_env(os.environ)
+        active_credential = DefaultAzureCredential()
+    else:
+        active_credential = credential
+    try:
+        active_credential.get_token(DIRECT_TOKEN_SCOPE)
+    finally:
+        if owns_credential:
+            _close_sync(active_credential, "credential")
+
+
+def _require_attr_path(client: object, path: str) -> None:
+    current = client
+    for part in path.split("."):
+        try:
+            current = getattr(current, part)
+        except (AttributeError, TypeError):
+            raise RuntimeError(
+                f"Azure AI client lacks required capability: {path}"
+            ) from None
+    if not callable(current):
+        raise RuntimeError(
+            f"Azure AI client lacks required capability: {path}"
+        )
+
+
+def validate_client_capabilities(
+    client: object,
+    workload: AzureAIWorkload,
+) -> None:
+    required = {
+        AzureAIWorkload.INFERENCE: ("chat.completions.create",),
+        AzureAIWorkload.NARRATIVE: ("responses.create",),
+        AzureAIWorkload.GRADER: ("responses.create",),
+        AzureAIWorkload.CODE_INTERPRETER: (
+            "responses.create",
+            "files.create",
+            "files.delete",
+            "files.content",
+            "containers.create",
+            "containers.files.list",
+            "containers.files.content.retrieve",
+        ),
+    }[workload]
+    for path in required:
+        _require_attr_path(client, path)
+
+
+def _load_project_client_class():
+    try:
+        from azure.ai.projects import AIProjectClient
+    except ImportError as exc:
+        raise RuntimeError(
+            "project-ci requires azure-ai-projects==2.3.0"
+        ) from exc
+    return AIProjectClient
+
+
+class AzureAIClientFactory:
+    """Explicitly managed synchronous client factory; not thread-safe.
+
+    A shared factory survives lease closure and failed client construction.
+    Callers must close the factory explicitly; injected credentials remain
+    caller-owned. Async close implementations are rejected.
+    """
+
+    def __init__(
+        self,
+        settings: AzureAIRouteSettings | None = None,
+        credential=None,
+    ):
+        self.settings = settings or AzureAIRouteSettings.from_env()
+        self._owns_credential = credential is None
+        if self._owns_credential:
+            _reject_static_azure_credential_env(os.environ)
+            self.credential = DefaultAzureCredential()
+        else:
+            self.credential = credential
+        self._closed = False
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._owns_credential:
+            _close_sync(self.credential, "credential")
+
+    def __enter__(self) -> "AzureAIClientFactory":
+        if self._closed:
+            raise RuntimeError("Azure AI client factory is closed")
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.close()
+
+    def create(
+        self,
+        workload: AzureAIWorkload | str,
+        *,
+        deployment: str,
+        timeout: float | None = DEFAULT_TIMEOUT,
+        max_retries: int | None = None,
+        legacy_api_version: str = DEFAULT_LEGACY_API_VERSION,
+    ) -> AzureAIClientLease:
+        if self._closed:
+            raise RuntimeError("Azure AI client factory is closed")
+        route = self.settings.select(workload)
+        fingerprint = route_fingerprint(
+            route,
+            deployment,
+            timeout=timeout,
+            max_retries=max_retries,
+            legacy_api_version=legacy_api_version,
+        )
+        common: dict[str, object] = {"timeout": timeout}
+        if max_retries is not None:
+            common["max_retries"] = max_retries
+
+        if route.endpoint.kind is EndpointKind.PROJECT:
+            project = None
+            client = None
+            try:
+                project_class = _load_project_client_class()
+                project = project_class(
+                    endpoint=route.endpoint.url,
+                    credential=self.credential,
+                )
+                client = project.get_openai_client(**common)
+                validate_client_capabilities(client, route.workload)
+            except BaseException as creation_error:
+                try:
+                    _close_resources_sync(
+                        (
+                            ("client", client),
+                            ("project owner", project),
+                        )
+                    )
+                except BaseException as close_error:
+                    raise close_error from creation_error
+                raise
+            return AzureAIClientLease(
+                client=client,
+                owner=project,
+                route=route,
+                runtime_fingerprint=fingerprint,
+            )
+
+        token_provider = get_bearer_token_provider(
+            self.credential,
+            route.token_scope,
+        )
+        client = None
+        try:
+            if route.endpoint.kind is EndpointKind.DIRECT_V1:
+                client = OpenAI(
+                    base_url=route.endpoint.url,
+                    api_key=token_provider,
+                    **common,
+                )
+            else:
+                client = AzureOpenAI(
+                    azure_endpoint=route.endpoint.url,
+                    azure_ad_token_provider=token_provider,
+                    api_version=legacy_api_version,
+                    **common,
+                )
+            validate_client_capabilities(client, route.workload)
+        except BaseException as creation_error:
+            try:
+                _close_resources_sync((("client", client),))
+            except BaseException as close_error:
+                raise close_error from creation_error
+            raise
+        return AzureAIClientLease(
+            client=client,
+            owner=None,
+            route=route,
+            runtime_fingerprint=fingerprint,
+        )

--- a/batch-runner/requirements.txt
+++ b/batch-runner/requirements.txt
@@ -6,9 +6,11 @@
 # Core dependencies
 datasets>=2.18.0
 huggingface-hub==1.24.0
-openai>=1.12.0
+openai==2.46.0
 psutil>=5.9.0
-azure-identity>=1.15.0
+azure-core==1.41.0
+azure-identity==1.25.3
+azure-ai-projects==2.3.0
 jsonschema>=4.21.0
 cryptography>=42.0.0
 ijson>=3.3.0

--- a/batch-runner/scripts/azure_ai_route_preflight.py
+++ b/batch-runner/scripts/azure_ai_route_preflight.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Validate DefaultAzureCredential-based Azure AI routes without model calls."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+import unicodedata
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.azure_ai_clients import (  # noqa: E402
+    FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV,
+    AzureAIRouteSettings,
+    AzureAIWorkload,
+    preflight_routes,
+    verify_direct_token,
+)
+
+
+_ROUTE_ENV_NAMES = (
+    "AZURE_AI_ROUTE_PROFILE",
+    "AZURE_OPENAI_V1_ENDPOINT",
+    "FOUNDRY_PROJECT_ENDPOINT",
+    "AZURE_OPENAI_LEGACY_ENDPOINT",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_AI_ALLOW_LEGACY_ROLLBACK",
+    "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES",
+    "AZURE_AI_EXPECTED_DIRECT_ACCOUNT",
+    "AZURE_AI_EXPECTED_PROJECT_ACCOUNT",
+    "AZURE_AI_EXPECTED_PROJECT_NAME",
+    "AZURE_AI_EXPECTED_LEGACY_ACCOUNT",
+    *FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV,
+)
+
+
+def _contains_control(value: str) -> bool:
+    return any(
+        unicodedata.category(character) == "Cc"
+        or character in {"\u2028", "\u2029"}
+        for character in value
+    )
+
+
+def _plain_value(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    if _contains_control(value):
+        raise ValueError(
+            f"{label} must not contain newline or control characters"
+        )
+    return value
+
+
+def _workload(value: str) -> tuple[AzureAIWorkload, str]:
+    try:
+        plain = _plain_value(value, "workload")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from None
+    name, separator, deployment = plain.partition("=")
+    if not separator:
+        raise argparse.ArgumentTypeError("workload must use NAME=DEPLOYMENT")
+    try:
+        workload = AzureAIWorkload(name.strip())
+    except ValueError:
+        raise argparse.ArgumentTypeError("unsupported workload name") from None
+    if not deployment.strip():
+        raise argparse.ArgumentTypeError("deployment must be nonempty")
+    return workload, deployment.strip()
+
+
+def _environment_workloads(
+    parser: argparse.ArgumentParser,
+    env: Mapping[str, str],
+) -> list[tuple[AzureAIWorkload, str]]:
+    try:
+        encoded = _plain_value(
+            env.get("AZURE_AI_WORKLOADS_JSON", ""),
+            "AZURE_AI_WORKLOADS_JSON",
+        ).strip()
+    except ValueError as exc:
+        parser.error(str(exc))
+    if not encoded:
+        return []
+    try:
+        values = json.loads(encoded)
+    except json.JSONDecodeError:
+        parser.error("AZURE_AI_WORKLOADS_JSON is invalid JSON")
+    if not isinstance(values, list) or not all(
+        isinstance(value, str) for value in values
+    ):
+        parser.error("AZURE_AI_WORKLOADS_JSON must be a list of strings")
+
+    workloads: list[tuple[AzureAIWorkload, str]] = []
+    for value in values:
+        try:
+            workloads.append(_workload(value))
+        except argparse.ArgumentTypeError as exc:
+            parser.error(f"AZURE_AI_WORKLOADS_JSON: {exc}")
+    return workloads
+
+
+def _validate_route_environment(env: Mapping[str, str]) -> None:
+    for name in _ROUTE_ENV_NAMES:
+        if name in env:
+            _plain_value(env[name], name)
+
+
+def _absolute_output_path(raw_path: object) -> Path:
+    """Return an absolute output path after lexical injection checks."""
+    value = _plain_value(raw_path, "GITHUB_OUTPUT")
+    if not value:
+        raise ValueError("GITHUB_OUTPUT must be nonempty")
+    candidate = Path(value)
+    if ".." in candidate.parts:
+        raise ValueError("GITHUB_OUTPUT must not traverse parent directories")
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    return Path(os.path.abspath(candidate))
+
+
+def _append_github_output(raw_path: object, encoded: str) -> None:
+    """Append one record with one write through non-symlink path components."""
+    path = _absolute_output_path(raw_path)
+    if len(path.parts) < 2:
+        raise ValueError("GITHUB_OUTPUT must identify a file")
+    if _contains_control(encoded):
+        raise ValueError("routes output must not contain control characters")
+    payload = f"routes={encoded}\n".encode("utf-8")
+
+    directory_flags = (
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    )
+    directory_fd = os.open("/", directory_flags)
+    file_fd: int | None = None
+    try:
+        for component in path.parts[1:-1]:
+            next_fd = os.open(component, directory_flags, dir_fd=directory_fd)
+            os.close(directory_fd)
+            directory_fd = next_fd
+
+        target = path.parts[-1]
+        try:
+            target_stat = os.stat(
+                target,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            target_stat = None
+        if target_stat is not None and not stat.S_ISREG(target_stat.st_mode):
+            raise ValueError("GITHUB_OUTPUT target must be a regular file")
+
+        created = target_stat is None
+        file_flags = (
+            os.O_WRONLY
+            | os.O_APPEND
+            | os.O_NOFOLLOW
+            | os.O_CLOEXEC
+            | os.O_NONBLOCK
+        )
+        if created:
+            file_flags |= os.O_CREAT | os.O_EXCL
+        file_fd = os.open(
+            target,
+            file_flags,
+            0o600,
+            dir_fd=directory_fd,
+        )
+        if not stat.S_ISREG(os.fstat(file_fd).st_mode):
+            raise ValueError("GITHUB_OUTPUT target must be a regular file")
+        if created:
+            os.fchmod(file_fd, 0o600)
+        if os.write(file_fd, payload) != len(payload):
+            raise OSError("short write while appending GITHUB_OUTPUT")
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(directory_fd)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workload",
+        action="append",
+        type=_workload,
+        help="Typed workload and deployment as NAME=DEPLOYMENT",
+    )
+    parser.add_argument(
+        "--verify-token",
+        action="store_true",
+        help="Also acquire an ai.azure.com token from DefaultAzureCredential",
+    )
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    token_verifier: Callable[[], None] | None = None,
+) -> list[dict[str, str]]:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    values = os.environ if env is None else env
+
+    workloads = list(args.workload or [])
+    workloads.extend(_environment_workloads(parser, values))
+    if not workloads:
+        parser.error("at least one workload is required")
+
+    try:
+        _validate_route_environment(values)
+        settings = AzureAIRouteSettings.from_env(values)
+        records = preflight_routes(workloads, settings=settings)
+    except ValueError as exc:
+        parser.error(str(exc))
+    except Exception:
+        parser.error("Azure AI route preflight failed")
+
+    if args.verify_token:
+        try:
+            (token_verifier or verify_direct_token)()
+        except Exception:
+            parser.error("direct token verification failed")
+
+    encoded = json.dumps(records, sort_keys=True, separators=(",", ":"))
+    output_path = values.get("GITHUB_OUTPUT", "")
+    if output_path != "":
+        try:
+            _append_github_output(output_path, encoded)
+        except (OSError, ValueError):
+            parser.error(
+                "GITHUB_OUTPUT must be a regular non-symlink file with "
+                "non-symlink ancestors"
+            )
+    print(encoded)
+    return records
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/tests/test_azure_ai_clients.py
+++ b/batch-runner/tests/test_azure_ai_clients.py
@@ -1,0 +1,1814 @@
+import gc
+import importlib.metadata
+import re
+import warnings
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import core.azure_ai_clients as clients
+from core.experiment_config import ExperimentConfig
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FOUNDATION_DOCS = (
+    REPO_ROOT / "tasks/0723_thursday/BOLT_TYPED_AZURE_AI_ENDPOINT_CONTRACTS.md",
+    REPO_ROOT / "tasks/LATEST_TASK_RESULT/README.md",
+    REPO_ROOT / "CHANGELOG.md",
+)
+
+
+def _direct_settings(
+    host: str = "account.openai.azure.com",
+) -> clients.AzureAIRouteSettings:
+    return clients.AzureAIRouteSettings.from_env(
+        {
+            "AZURE_AI_ROUTE_PROFILE": "direct-v1",
+            "AZURE_OPENAI_V1_ENDPOINT": f"https://{host}/openai/v1/",
+        }
+    )
+
+
+def _project_settings() -> clients.AzureAIRouteSettings:
+    return clients.AzureAIRouteSettings.from_env(
+        {
+            "AZURE_AI_ROUTE_PROFILE": "project-ci",
+            "AZURE_OPENAI_V1_ENDPOINT": (
+                "https://account.services.ai.azure.com/openai/v1/"
+            ),
+            "FOUNDRY_PROJECT_ENDPOINT": (
+                "https://account.services.ai.azure.com/"
+                "api/projects/project-one"
+            ),
+        }
+    )
+
+
+def _legacy_settings() -> clients.AzureAIRouteSettings:
+    return clients.AzureAIRouteSettings.from_env(
+        {
+            "AZURE_AI_ROUTE_PROFILE": "legacy-rollback",
+            "AZURE_OPENAI_LEGACY_ENDPOINT": (
+                "https://account.openai.azure.com/"
+            ),
+            "AZURE_AI_ALLOW_LEGACY_ROLLBACK": "1",
+        }
+    )
+
+
+def _inference_client() -> SimpleNamespace:
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=MagicMock())
+        ),
+        close=MagicMock(),
+    )
+
+
+def _responses_client() -> SimpleNamespace:
+    return SimpleNamespace(
+        responses=SimpleNamespace(create=MagicMock()),
+        close=MagicMock(),
+    )
+
+
+def _code_interpreter_client() -> SimpleNamespace:
+    return SimpleNamespace(
+        responses=SimpleNamespace(create=MagicMock()),
+        files=SimpleNamespace(
+            create=MagicMock(),
+            delete=MagicMock(),
+            content=MagicMock(),
+        ),
+        containers=SimpleNamespace(
+            create=MagicMock(),
+            files=SimpleNamespace(
+                list=MagicMock(),
+                content=SimpleNamespace(retrieve=MagicMock()),
+            ),
+        ),
+        close=MagicMock(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "kind", "canonical", "account", "project"),
+    [
+        (
+            "https://account.openai.azure.com/openai/v1",
+            clients.EndpointKind.DIRECT_V1,
+            "https://account.openai.azure.com/openai/v1/",
+            "account",
+            None,
+        ),
+        (
+            "HTTPS://Account.Services.AI.Azure.Com:443/openai/v1/",
+            clients.EndpointKind.DIRECT_V1,
+            "https://account.services.ai.azure.com/openai/v1/",
+            "account",
+            None,
+        ),
+        (
+            "https://account.services.ai.azure.com/api/projects/project-one/",
+            clients.EndpointKind.PROJECT,
+            "https://account.services.ai.azure.com/api/projects/project-one",
+            "account",
+            "project-one",
+        ),
+        (
+            "https://account.openai.azure.com",
+            clients.EndpointKind.LEGACY_DATED,
+            "https://account.openai.azure.com/",
+            "account",
+            None,
+        ),
+        (
+            "https://a.openai.azure.com/",
+            clients.EndpointKind.LEGACY_DATED,
+            "https://a.openai.azure.com/",
+            "a",
+            None,
+        ),
+    ],
+)
+def test_classify_endpoint_accepts_only_canonical_contracts(
+    value,
+    kind,
+    canonical,
+    account,
+    project,
+):
+    classified = clients.classify_endpoint(value)
+
+    assert classified.kind is kind
+    assert classified.url == canonical
+    assert classified.account == account
+    assert classified.project == project
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://account.openai.azure.com/openai/v1/",
+        "https://user@account.openai.azure.com/openai/v1/",
+        "https://:password@account.openai.azure.com/openai/v1/",
+        "https://@account.openai.azure.com/openai/v1/",
+        "https://account.openai.azure.com:444/openai/v1/",
+        "https://account.openai.azure.com:invalid/openai/v1/",
+        "https://127.0.0.1/openai/v1/",
+        "https://[::1]/openai/v1/",
+        "https://localhost/openai/v1/",
+        "https://account.openai.azure.com/openai/v1/?x=1",
+        "https://account.openai.azure.com/openai/v1/?",
+        "https://account.openai.azure.com/openai/v1/#fragment",
+        "https://account.openai.azure.com/openai/v1/#",
+        "https://account.openai.azure.com\\openai\\v1\\",
+        "https://account.openai.azure.com/openai//v1/",
+        "https://account.openai.azure.com/openai/v1/extra",
+        "https://account.services.ai.azure.com/api/projects/a/extra",
+        "https://account.services.ai.azure.com/openai/deployments/model",
+        "https://account.services.ai.azure.com/",
+        "https://account.openai.azure.com/api/projects/project-one",
+        "https://example.com/openai/v1/",
+        "https://account.openai.azure.com.evil.test/openai/v1/",
+        "https://account.services.ai.azure.com.evil/openai/v1/",
+        "https://account.openai.azure.comm/openai/v1/",
+        "https://other.account.openai.azure.com/openai/v1/",
+        "https://account.openai.azure.com./openai/v1/",
+        "https://-account.openai.azure.com/openai/v1/",
+        "https://account-.openai.azure.com/openai/v1/",
+        "https://account_name.openai.azure.com/openai/v1/",
+        f"https://{'a' * 64}.openai.azure.com/openai/v1/",
+        "https://account.services.ai.azure.com/api/projects/.project",
+        "https://account.services.ai.azure.com/api/projects/project.",
+        "https://account.services.ai.azure.com/api/projects/project-",
+        "https://account.services.ai.azure.com/api/projects/_project",
+        f"https://account.services.ai.azure.com/api/projects/{'p' * 129}",
+    ],
+)
+def test_classify_endpoint_rejects_ambiguous_or_unsafe_values(value):
+    with pytest.raises(ValueError):
+        clients.classify_endpoint(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://account.openai.azure.com/openai%2fv1/",
+        "https://account.openai.azure.com/openai/%76%31/",
+        "https://account.openai.azure.com/%6fpenai/v1/",
+        "https://account.openai.azure.com/openai/v1%2f",
+        (
+            "https://account.services.ai.azure.com/"
+            "api/projects/%70roject-one"
+        ),
+        (
+            "https://account.services.ai.azure.com/"
+            "api/%70rojects/project-one"
+        ),
+        (
+            "https://account.services.ai.azure.com/"
+            "api/projects/project%2done"
+        ),
+    ],
+)
+def test_classify_endpoint_rejects_every_percent_encoded_path_component(value):
+    with pytest.raises(ValueError, match="percent encoding"):
+        clients.classify_endpoint(value)
+
+
+@pytest.mark.parametrize("character", ["\r", "\n", "\t"])
+def test_classify_endpoint_rejects_characters_urlsplit_would_normalize(character):
+    value = (
+        "https://account.openai.azure.com"
+        f"{character}/openai/v1/"
+    )
+
+    with pytest.raises(ValueError, match="control characters"):
+        clients.classify_endpoint(value)
+
+
+@pytest.mark.parametrize(
+    "character",
+    ["\x00", "\x1f", "\x7f", "\x80", "\x9f", "\u2028", "\u2029"],
+)
+def test_classify_endpoint_rejects_control_and_line_separator_characters(
+    character,
+):
+    value = f"https://account.openai.azure.com/{character}openai/v1/"
+
+    with pytest.raises(ValueError, match="control characters"):
+        clients.classify_endpoint(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://account.openai.azure.com/openai/%",
+        "https://account.openai.azure.com/openai/%2/v1/",
+        "https://account.openai.azure.com/openai/%GG/v1/",
+    ],
+)
+def test_classify_endpoint_rejects_malformed_percent_sequences(value):
+    with pytest.raises(ValueError, match="percent encoding"):
+        clients.classify_endpoint(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://account.openai.azure.com:/openai/v1/",
+        "https://account.openai.azure.com.evil/openai/v1/",
+        "https://account.openai.azure.com./openai/v1/",
+        "https://account.openai.azure.com/\uff0fopenai/v1/",
+    ],
+)
+def test_classify_endpoint_rejects_empty_port_and_host_path_lookalikes(value):
+    with pytest.raises(ValueError):
+        clients.classify_endpoint(value)
+
+
+def test_classify_endpoint_errors_do_not_echo_raw_endpoint():
+    endpoint = (
+        "https://user:private-value@account.openai.azure.com/openai/v1/"
+    )
+
+    with pytest.raises(ValueError) as error:
+        clients.classify_endpoint(endpoint)
+
+    assert endpoint not in str(error.value)
+    assert "private-value" not in str(error.value)
+
+
+def test_classified_endpoint_repr_hides_url():
+    endpoint = clients.classify_endpoint(
+        "https://account.openai.azure.com/openai/v1/"
+    )
+
+    assert endpoint.url not in repr(endpoint)
+
+
+def test_project_ci_routes_only_code_interpreter_through_project():
+    settings = _project_settings()
+
+    for workload in ("inference", "narrative", "grader"):
+        route = settings.select(workload)
+        assert route.endpoint.kind is clients.EndpointKind.DIRECT_V1
+        assert route.token_scope == clients.DIRECT_TOKEN_SCOPE
+
+    code_route = settings.select("code-interpreter")
+    assert code_route.endpoint.kind is clients.EndpointKind.PROJECT
+    assert code_route.token_scope == clients.DIRECT_TOKEN_SCOPE
+
+
+def test_direct_profile_routes_all_workloads_to_direct_v1():
+    settings = _direct_settings()
+
+    for workload in clients.AzureAIWorkload:
+        route = settings.select(workload)
+        assert route.endpoint.kind is clients.EndpointKind.DIRECT_V1
+        assert route.token_scope == "https://ai.azure.com/.default"
+
+
+def test_legacy_profile_routes_all_workloads_with_legacy_scope():
+    settings = _legacy_settings()
+
+    for workload in clients.AzureAIWorkload:
+        route = settings.select(workload)
+        assert route.endpoint.kind is clients.EndpointKind.LEGACY_DATED
+        assert route.token_scope == (
+            "https://cognitiveservices.azure.com/.default"
+        )
+
+
+def test_project_endpoint_derives_same_account_direct_v1_route():
+    settings = clients.AzureAIRouteSettings.from_env(
+        {
+            "AZURE_AI_ROUTE_PROFILE": "project-ci",
+            "FOUNDRY_PROJECT_ENDPOINT": (
+                "https://account.services.ai.azure.com/"
+                "api/projects/project-one"
+            ),
+        }
+    )
+
+    direct = settings.select("inference").endpoint
+    project = settings.select("code-interpreter").endpoint
+    assert direct.url == "https://account.services.ai.azure.com/openai/v1/"
+    assert direct.account == project.account
+
+
+def test_legacy_route_requires_explicit_authorization():
+    env = {
+        "AZURE_AI_ROUTE_PROFILE": "legacy-rollback",
+        "AZURE_OPENAI_LEGACY_ENDPOINT": (
+            "https://account.openai.azure.com/"
+        ),
+    }
+
+    with pytest.raises(ValueError, match="explicitly authorized"):
+        clients.AzureAIRouteSettings.from_env(env)
+
+    env["AZURE_AI_ALLOW_LEGACY_ROLLBACK"] = "1"
+    settings = clients.AzureAIRouteSettings.from_env(env)
+    assert settings.profile is clients.RouteProfile.LEGACY_ROLLBACK
+
+
+@pytest.mark.parametrize("name", clients.FORBIDDEN_API_KEY_ENV)
+def test_static_azure_keys_and_secrets_are_rejected(name):
+    with pytest.raises(ValueError, match="forbidden") as error:
+        clients.AzureAIRouteSettings.from_env(
+            {
+                "AZURE_AI_ROUTE_PROFILE": "direct-v1",
+                "AZURE_OPENAI_V1_ENDPOINT": (
+                    "https://account.openai.azure.com/openai/v1/"
+                ),
+                name: "not-a-real-secret",
+            }
+        )
+
+    assert "not-a-real-secret" not in str(error.value)
+
+
+@pytest.mark.parametrize("name", clients.FORBIDDEN_API_KEY_ENV)
+def test_owned_factory_rejects_process_static_secret_before_credential(
+    name, monkeypatch
+):
+    constructor = MagicMock()
+    monkeypatch.setattr(clients, "DefaultAzureCredential", constructor)
+    monkeypatch.setenv(name, "not-a-real-secret")
+
+    with pytest.raises(ValueError, match="forbidden") as error:
+        clients.AzureAIClientFactory(settings=_direct_settings())
+
+    constructor.assert_not_called()
+    assert "not-a-real-secret" not in str(error.value)
+
+
+def test_injected_credential_does_not_consult_process_secret_env(monkeypatch):
+    credential = object()
+    monkeypatch.setenv("AZURE_CLIENT_SECRET", "caller-managed-secret")
+
+    factory = clients.AzureAIClientFactory(
+        settings=_direct_settings(),
+        credential=credential,
+    )
+
+    assert factory.credential is credential
+
+
+def test_native_openai_key_can_coexist_with_typed_azure_route():
+    settings = clients.AzureAIRouteSettings.from_env(
+        {
+            "AZURE_AI_ROUTE_PROFILE": "direct-v1",
+            "AZURE_OPENAI_V1_ENDPOINT": (
+                "https://account.openai.azure.com/openai/v1/"
+            ),
+            "OPENAI_API_KEY": "native-provider-key",
+        }
+    )
+
+    assert settings.profile is clients.RouteProfile.DIRECT_V1
+
+
+def test_federated_token_file_can_coexist_with_typed_azure_route():
+    settings = clients.AzureAIRouteSettings.from_env(
+        {
+            "AZURE_AI_ROUTE_PROFILE": "direct-v1",
+            "AZURE_OPENAI_V1_ENDPOINT": (
+                "https://account.openai.azure.com/openai/v1/"
+            ),
+            "AZURE_FEDERATED_TOKEN_FILE": "/tmp/federated-token",
+        }
+    )
+
+    assert settings.profile is clients.RouteProfile.DIRECT_V1
+
+
+@pytest.mark.parametrize(
+    ("variable", "value"),
+    [
+        (
+            "AZURE_OPENAI_V1_ENDPOINT",
+            "https://account.openai.azure.com/",
+        ),
+        (
+            "FOUNDRY_PROJECT_ENDPOINT",
+            "https://account.services.ai.azure.com/openai/v1/",
+        ),
+        (
+            "AZURE_OPENAI_LEGACY_ENDPOINT",
+            "https://account.openai.azure.com/openai/v1/",
+        ),
+    ],
+)
+def test_typed_endpoint_variables_reject_wrong_endpoint_kinds(variable, value):
+    env = {
+        "AZURE_AI_ROUTE_PROFILE": "project-ci",
+        "AZURE_OPENAI_V1_ENDPOINT": (
+            "https://account.services.ai.azure.com/openai/v1/"
+        ),
+        "FOUNDRY_PROJECT_ENDPOINT": (
+            "https://account.services.ai.azure.com/api/projects/project-one"
+        ),
+        "AZURE_OPENAI_LEGACY_ENDPOINT": (
+            "https://account.openai.azure.com/"
+        ),
+        variable: value,
+    }
+
+    with pytest.raises(ValueError, match=variable):
+        clients.AzureAIRouteSettings.from_env(env)
+
+
+def test_deprecated_untyped_endpoint_has_endpoint_free_migration_guidance():
+    endpoint = (
+        "https://private-account.services.ai.azure.com/"
+        "api/projects/private-project"
+    )
+
+    with pytest.raises(ValueError, match="FOUNDRY_PROJECT_ENDPOINT") as error:
+        clients.AzureAIRouteSettings.from_env(
+            {
+                "AZURE_AI_ROUTE_PROFILE": "project-ci",
+                "AZURE_OPENAI_ENDPOINT": endpoint,
+            }
+        )
+
+    assert endpoint not in str(error.value)
+    assert "private-account" not in str(error.value)
+    assert "private-project" not in str(error.value)
+
+
+def test_deprecated_untyped_endpoint_is_rejected_with_typed_endpoint():
+    with pytest.raises(ValueError, match="must be unset"):
+        clients.AzureAIRouteSettings.from_env(
+            {
+                "AZURE_AI_ROUTE_PROFILE": "direct-v1",
+                "AZURE_OPENAI_V1_ENDPOINT": (
+                    "https://account.openai.azure.com/openai/v1/"
+                ),
+                "AZURE_OPENAI_ENDPOINT": (
+                    "https://other.openai.azure.com/openai/v1/"
+                ),
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "message"),
+    [
+        (
+            "AZURE_AI_EXPECTED_DIRECT_ACCOUNT",
+            "other",
+            "direct endpoint account identity mismatch",
+        ),
+        (
+            "AZURE_AI_EXPECTED_PROJECT_ACCOUNT",
+            "other",
+            "project endpoint account identity mismatch",
+        ),
+        (
+            "AZURE_AI_EXPECTED_PROJECT_NAME",
+            "other",
+            "Foundry project identity mismatch",
+        ),
+    ],
+)
+def test_expected_endpoint_identities_fail_closed(name, value, message):
+    env = {
+        "AZURE_AI_ROUTE_PROFILE": "project-ci",
+        "AZURE_OPENAI_V1_ENDPOINT": (
+            "https://account.services.ai.azure.com/openai/v1/"
+        ),
+        "FOUNDRY_PROJECT_ENDPOINT": (
+            "https://account.services.ai.azure.com/api/projects/project-one"
+        ),
+        name: value,
+    }
+
+    with pytest.raises(ValueError, match=message):
+        clients.AzureAIRouteSettings.from_env(env)
+
+
+def test_expected_identity_values_are_validated():
+    with pytest.raises(ValueError, match="account name is invalid"):
+        clients.AzureAIRouteSettings.from_env(
+            {
+                "AZURE_AI_ROUTE_PROFILE": "direct-v1",
+                "AZURE_OPENAI_V1_ENDPOINT": (
+                    "https://account.openai.azure.com/openai/v1/"
+                ),
+                "AZURE_AI_EXPECTED_DIRECT_ACCOUNT": "invalid.account",
+            }
+        )
+
+
+def test_strict_identity_mode_requires_profile_identities():
+    with pytest.raises(ValueError, match="EXPECTED_PROJECT_ACCOUNT"):
+        clients.AzureAIRouteSettings.from_env(
+            {
+                "AZURE_AI_ROUTE_PROFILE": "project-ci",
+                "FOUNDRY_PROJECT_ENDPOINT": (
+                    "https://account.services.ai.azure.com/"
+                    "api/projects/project-one"
+                ),
+                "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES": "1",
+                "AZURE_AI_EXPECTED_DIRECT_ACCOUNT": "account",
+            }
+        )
+
+
+def test_strict_identity_mode_accepts_exact_identities():
+    settings = clients.AzureAIRouteSettings.from_env(
+        {
+            "AZURE_AI_ROUTE_PROFILE": "project-ci",
+            "FOUNDRY_PROJECT_ENDPOINT": (
+                "https://account.services.ai.azure.com/"
+                "api/projects/project-one"
+            ),
+            "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES": "1",
+            "AZURE_AI_EXPECTED_DIRECT_ACCOUNT": "account",
+            "AZURE_AI_EXPECTED_PROJECT_ACCOUNT": "account",
+            "AZURE_AI_EXPECTED_PROJECT_NAME": "project-one",
+        }
+    )
+
+    assert settings.profile is clients.RouteProfile.PROJECT_CI
+
+
+def test_strict_legacy_identity_requires_and_verifies_active_legacy_account():
+    base = {
+        "AZURE_AI_ROUTE_PROFILE": "legacy-rollback",
+        "AZURE_OPENAI_LEGACY_ENDPOINT": (
+            "https://legacy-account.openai.azure.com/"
+        ),
+        "AZURE_AI_ALLOW_LEGACY_ROLLBACK": "1",
+        "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES": "1",
+    }
+
+    with pytest.raises(ValueError, match="EXPECTED_LEGACY_ACCOUNT"):
+        clients.AzureAIRouteSettings.from_env(base)
+
+    with pytest.raises(ValueError, match="legacy endpoint account identity"):
+        clients.AzureAIRouteSettings.from_env(
+            {**base, "AZURE_AI_EXPECTED_LEGACY_ACCOUNT": "other"}
+        )
+
+    settings = clients.AzureAIRouteSettings.from_env(
+        {
+            **base,
+            "AZURE_AI_EXPECTED_LEGACY_ACCOUNT": "legacy-account",
+            "AZURE_AI_EXPECTED_DIRECT_ACCOUNT": "untrusted-direct",
+        }
+    )
+
+    assert settings.direct_v1 is None
+    assert settings.legacy is not None
+    assert settings.legacy.account == "legacy-account"
+
+
+def test_strict_direct_identity_does_not_require_project_identity():
+    settings = clients.AzureAIRouteSettings.from_env(
+        {
+            "AZURE_AI_ROUTE_PROFILE": "direct-v1",
+            "AZURE_OPENAI_V1_ENDPOINT": (
+                "https://account.openai.azure.com/openai/v1/"
+            ),
+            "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES": "1",
+            "AZURE_AI_EXPECTED_DIRECT_ACCOUNT": "account",
+        }
+    )
+
+    assert settings.profile is clients.RouteProfile.DIRECT_V1
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {},
+        {"AZURE_AI_ROUTE_PROFILE": "unsupported"},
+        {"AZURE_AI_ROUTE_PROFILE": "direct-v1"},
+        {"AZURE_AI_ROUTE_PROFILE": "project-ci"},
+    ],
+)
+def test_route_profiles_require_explicit_valid_configuration(env):
+    with pytest.raises(ValueError):
+        clients.AzureAIRouteSettings.from_env(env)
+
+
+def test_route_fingerprint_binds_all_route_and_transport_inputs(monkeypatch):
+    versions = {
+        "azure-core": "core-1",
+        "azure-identity": "identity-1",
+        "openai": "openai-1",
+        "azure-ai-projects": "projects-1",
+    }
+    monkeypatch.setattr(
+        clients,
+        "_package_version",
+        lambda name: versions[name],
+    )
+    direct = _direct_settings("account.services.ai.azure.com")
+    project = _project_settings()
+    base_route = direct.select("inference")
+    base = clients.route_fingerprint(
+        base_route,
+        "deployment",
+        timeout=30,
+        max_retries=None,
+        legacy_api_version="legacy-v1",
+    )
+
+    alternatives = {
+        clients.route_fingerprint(
+            _direct_settings("other.services.ai.azure.com").select("inference"),
+            "deployment",
+            timeout=30,
+            max_retries=None,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            project.select("inference"),
+            "deployment",
+            timeout=30,
+            max_retries=None,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            project.select("code-interpreter"),
+            "deployment",
+            timeout=30,
+            max_retries=None,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            direct.select("narrative"),
+            "deployment",
+            timeout=30,
+            max_retries=None,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            base_route,
+            "other-deployment",
+            timeout=30,
+            max_retries=None,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            base_route,
+            "deployment",
+            timeout=31,
+            max_retries=None,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            base_route,
+            "deployment",
+            timeout=30,
+            max_retries=0,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            base_route,
+            "deployment",
+            timeout=30,
+            max_retries=None,
+            legacy_api_version="legacy-v2",
+        ),
+    }
+
+    assert len(base) == 64
+    assert base not in alternatives
+    assert len(alternatives) == 8
+
+    versions["openai"] = "openai-2"
+    assert clients.route_fingerprint(
+        base_route,
+        "deployment",
+        timeout=30,
+        max_retries=None,
+        legacy_api_version="legacy-v1",
+    ) != base
+
+
+def test_project_fingerprint_binds_project_sdk_version(monkeypatch):
+    versions = {
+        "azure-core": "core-1",
+        "azure-identity": "identity-1",
+        "openai": "openai-1",
+        "azure-ai-projects": "projects-1",
+    }
+    monkeypatch.setattr(clients, "_package_version", versions.__getitem__)
+    route = _project_settings().select("code-interpreter")
+    first = clients.route_fingerprint(route, "deployment")
+
+    versions["azure-ai-projects"] = "projects-2"
+
+    assert clients.route_fingerprint(route, "deployment") != first
+
+
+def test_fingerprint_binds_contract_scope_and_transport_settings(monkeypatch):
+    versions = {
+        "azure-core": "core-1",
+        "azure-identity": "identity-1",
+        "openai": "openai-1",
+    }
+    monkeypatch.setattr(clients, "_package_version", versions.__getitem__)
+    route = _direct_settings().select("grader")
+    base = clients.route_fingerprint(
+        route,
+        "deployment",
+        timeout=30,
+        max_retries=None,
+        legacy_api_version="legacy-v1",
+    )
+    alternatives = {
+        clients.route_fingerprint(
+            replace(route, token_scope="https://other.example/.default"),
+            "deployment",
+            timeout=30,
+            max_retries=None,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            route,
+            "deployment",
+            timeout=31,
+            max_retries=None,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            route,
+            "deployment",
+            timeout=30,
+            max_retries=0,
+            legacy_api_version="legacy-v1",
+        ),
+        clients.route_fingerprint(
+            route,
+            "deployment",
+            timeout=30,
+            max_retries=None,
+            legacy_api_version="legacy-v2",
+        ),
+    }
+    monkeypatch.setattr(
+        clients,
+        "ROUTE_FINGERPRINT_CONTRACT_VERSION",
+        "azure-ai-route-v2",
+    )
+    alternatives.add(
+        clients.route_fingerprint(
+            route,
+            "deployment",
+            timeout=30,
+            max_retries=None,
+            legacy_api_version="legacy-v1",
+        )
+    )
+
+    assert len(alternatives) == 5
+    assert base not in alternatives
+
+
+def test_route_fingerprint_does_not_expose_endpoint_or_deployment():
+    route = _direct_settings().select("grader")
+
+    fingerprint = clients.route_fingerprint(route, "private-deployment")
+
+    assert len(fingerprint) == 64
+    assert "account" not in fingerprint
+    assert "private-deployment" not in fingerprint
+
+
+def test_preflight_records_are_endpoint_and_deployment_free():
+    records = clients.preflight_routes(
+        [
+            ("narrative", "private-deployment"),
+            ("code-interpreter", "private-deployment"),
+            ("narrative", "private-deployment"),
+        ],
+        settings=_project_settings(),
+    )
+
+    assert len(records) == 2
+    assert records[0]["endpoint_kind"] == "direct-v1"
+    assert records[1]["endpoint_kind"] == "project"
+    for record in records:
+        assert set(record) == {
+            "endpoint_kind",
+            "profile",
+            "runtime_fingerprint",
+            "workload",
+        }
+    encoded = str(records)
+    assert "account" not in encoded
+    assert "project-one" not in encoded
+    assert "private-deployment" not in encoded
+
+
+def test_preflight_fingerprint_is_transport_sensitive():
+    workloads = [("grader", "deployment")]
+    settings = _direct_settings()
+
+    base = clients.preflight_routes(
+        workloads,
+        settings=settings,
+        timeout=30,
+        max_retries=None,
+        legacy_api_version="legacy-v1",
+    )[0]["runtime_fingerprint"]
+    retry = clients.preflight_routes(
+        workloads,
+        settings=settings,
+        timeout=30,
+        max_retries=0,
+        legacy_api_version="legacy-v1",
+    )[0]["runtime_fingerprint"]
+    timeout = clients.preflight_routes(
+        workloads,
+        settings=settings,
+        timeout=31,
+        max_retries=None,
+        legacy_api_version="legacy-v1",
+    )[0]["runtime_fingerprint"]
+
+    assert len({base, retry, timeout}) == 3
+
+
+def test_preflight_requires_at_least_one_workload():
+    with pytest.raises(ValueError, match="at least one"):
+        clients.preflight_routes([], settings=_direct_settings())
+
+
+def test_inference_workloads_discover_main_qa_preprocessor_and_ci():
+    condition = {
+        "model": {"provider": "azure", "deployment": "main"},
+        "qa": {"enabled": True, "model": "qa"},
+        "preprocessors": [
+            {
+                "type": "audio_analyzer",
+                "model": {
+                    "provider": "azure_openai",
+                    "deployment": "audio",
+                },
+            },
+            {
+                "type": "external",
+                "model": {
+                    "provider": "openai",
+                    "deployment": "external",
+                },
+            },
+        ],
+    }
+
+    assert clients.inference_route_workloads(condition, "code_interpreter") == [
+        (clients.AzureAIWorkload.INFERENCE, "main"),
+        (clients.AzureAIWorkload.INFERENCE, "qa"),
+        (clients.AzureAIWorkload.INFERENCE, "audio"),
+        (clients.AzureAIWorkload.CODE_INTERPRETER, "main"),
+    ]
+
+
+def test_inference_workloads_default_missing_provider_to_azure():
+    condition = {
+        "model": {"deployment": "main"},
+        "preprocessors": [
+            {"type": "audio_analyzer", "model": {"deployment": "audio"}}
+        ],
+    }
+
+    assert clients.inference_route_workloads(condition, "subprocess") == [
+        (clients.AzureAIWorkload.INFERENCE, "main"),
+        (clients.AzureAIWorkload.INFERENCE, "audio"),
+    ]
+
+
+@pytest.mark.parametrize("provider", ["azure", "azure_openai"])
+def test_inference_workloads_apply_runtime_preprocessor_defaults(provider):
+    condition = {
+        "model": {"provider": provider},
+        "preprocessors": [
+            {"type": "audio_analyzer", "model": {"provider": provider}},
+            {"type": "video_analyzer", "model": {"provider": provider}},
+        ],
+    }
+
+    assert clients.inference_route_workloads(condition, "subprocess") == [
+        (clients.AzureAIWorkload.INFERENCE, "gpt-4"),
+        (clients.AzureAIWorkload.INFERENCE, "gpt-audio-1.5"),
+        (clients.AzureAIWorkload.INFERENCE, "gpt-5.2"),
+    ]
+
+
+def test_inference_workloads_match_raw_and_serialized_condition_semantics():
+    raw = {
+        "model": {"provider": "azure", "model": "ignored-main-alias"},
+        "qa": {
+            "enabled": True,
+            "deployment": "ignored-qa-alias",
+        },
+        "preprocessors": [
+            {
+                "type": "audio_analyzer",
+                "model": {"provider": "azure", "model": "ignored-audio-alias"},
+            }
+        ],
+    }
+    parsed = ExperimentConfig._parse_condition(raw)
+    serialized = ExperimentConfig._condition_to_dict(parsed)
+
+    expected = [
+        (clients.AzureAIWorkload.INFERENCE, "gpt-4"),
+        (clients.AzureAIWorkload.INFERENCE, "gpt-4"),
+        (clients.AzureAIWorkload.INFERENCE, "gpt-audio-1.5"),
+    ]
+    assert clients.inference_route_workloads(raw, "subprocess") == expected
+    assert clients.inference_route_workloads(serialized, "subprocess") == expected
+
+
+def test_inference_workloads_ignore_runtime_unsupported_aliases():
+    condition = {
+        "model": {
+            "provider": "azure",
+            "model": "ignored-main-alias",
+            "deployment": "main",
+        },
+        "qa": {
+            "enabled": True,
+            "model": "qa",
+            "deployment": "ignored-qa-alias",
+        },
+    }
+
+    assert clients.inference_route_workloads(condition, "subprocess") == [
+        (clients.AzureAIWorkload.INFERENCE, "main"),
+        (clients.AzureAIWorkload.INFERENCE, "qa"),
+    ]
+
+
+def test_inference_discovers_azure_preprocessor_with_native_main():
+    condition = {
+        "model": {"provider": "openai", "deployment": "native-main"},
+        "preprocessors": [
+            {
+                "type": "audio_analyzer",
+                "model": {"provider": "azure", "deployment": "audio"},
+            }
+        ],
+    }
+
+    assert clients.inference_route_workloads(condition, "subprocess") == [
+        (clients.AzureAIWorkload.INFERENCE, "audio")
+    ]
+
+
+def test_native_main_discovers_defaulted_azure_preprocessor():
+    condition = {
+        "model": {"provider": "openai", "deployment": "native-main"},
+        "preprocessors": [
+            {
+                "type": "audio_analyzer",
+                "model": {"provider": "azure_openai"},
+            }
+        ],
+    }
+
+    assert clients.inference_route_workloads(condition, "subprocess") == [
+        (clients.AzureAIWorkload.INFERENCE, "gpt-audio-1.5")
+    ]
+
+
+def test_preprocessor_model_alias_does_not_override_runtime_default():
+    condition = {
+        "model": {"provider": "openai", "deployment": "native-main"},
+        "preprocessors": [
+            {
+                "type": "audio_analyzer",
+                "model": {"provider": "azure", "model": "ignored-alias"},
+            }
+        ],
+    }
+
+    assert clients.inference_route_workloads(condition, "subprocess") == [
+        (clients.AzureAIWorkload.INFERENCE, "gpt-audio-1.5")
+    ]
+
+
+def test_unknown_preprocessor_type_is_not_an_azure_workload():
+    condition = {
+        "model": {"provider": "openai", "deployment": "native-main"},
+        "preprocessors": [
+            {
+                "type": "custom",
+                "model": {"provider": "azure", "deployment": "unused"},
+            }
+        ],
+    }
+
+    assert clients.inference_route_workloads(condition, "subprocess") == []
+
+
+@pytest.mark.parametrize("preprocessor_type", ["audio_analyzer", "video_analyzer"])
+def test_runtime_preprocessor_rejects_explicit_null_deployment(
+    preprocessor_type,
+):
+    condition = {
+        "model": {"provider": "openai", "deployment": "native-main"},
+        "preprocessors": [
+            {
+                "type": preprocessor_type,
+                "model": {"provider": "azure", "deployment": None},
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="deployment must be a nonempty string"):
+        clients.inference_route_workloads(condition, "subprocess")
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [{"model": None}, {"model": []}, {"model": "azure"}],
+)
+def test_code_interpreter_rejects_missing_or_malformed_model(condition):
+    with pytest.raises(ValueError, match="model must be an object"):
+        clients.inference_route_workloads(condition, "code_interpreter")
+
+
+def test_code_interpreter_missing_model_uses_runtime_default():
+    assert clients.inference_route_workloads({}, "code_interpreter") == [
+        (clients.AzureAIWorkload.INFERENCE, "gpt-4"),
+        (clients.AzureAIWorkload.CODE_INTERPRETER, "gpt-4"),
+    ]
+
+
+def test_code_interpreter_rejects_non_azure_main_provider():
+    with pytest.raises(ValueError, match="requires an Azure provider"):
+        clients.inference_route_workloads(
+            {
+                "model": {
+                    "provider": "openai",
+                    "deployment": "native-main",
+                }
+            },
+            "code_interpreter",
+        )
+
+
+def test_grader_workloads_include_tiers_and_perception():
+    config = {
+        "judge": {
+            "provider": "azure_openai",
+            "deployment": "main",
+            "perception": {
+                "visual": {"model": "vision"},
+                "audio": {"deployment": "audio"},
+            },
+        },
+        "judge_routing": {
+            "tier_standard": {"deployment": "standard"},
+            "tier_pro": {"model": "pro"},
+        },
+    }
+
+    assert clients.grader_route_workloads(config) == [
+        (clients.AzureAIWorkload.GRADER, "main"),
+        (clients.AzureAIWorkload.GRADER, "standard"),
+        (clients.AzureAIWorkload.GRADER, "pro"),
+        (clients.AzureAIWorkload.GRADER, "vision"),
+        (clients.AzureAIWorkload.GRADER, "audio"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "judge": {"model": "main", "deployment": "main"},
+            "judge_routing": {
+                "tier_pro": {"model": "pro-a", "deployment": "pro-b"}
+            },
+        },
+        {
+            "judge": {
+                "model": "main",
+                "deployment": "main",
+                "perception": {
+                    "visual": {
+                        "model": "vision-a",
+                        "deployment": "vision-b",
+                    }
+                },
+            }
+        },
+    ],
+)
+def test_grader_workloads_reject_conflicting_nested_aliases(config):
+    with pytest.raises(ValueError, match="must match"):
+        clients.grader_route_workloads(config)
+
+
+def test_non_azure_grader_has_no_azure_workload():
+    assert clients.grader_route_workloads(
+        {"judge": {"provider": "openai", "model": "native"}}
+    ) == []
+
+
+def test_narrative_workloads_include_fallbacks_and_mapping_aliases():
+    assert clients.narrative_route_workloads(
+        {"model": "primary", "deployment": "primary"},
+        ["fallback-a", {"deployment": "fallback-b"}],
+    ) == [
+        (clients.AzureAIWorkload.NARRATIVE, "primary"),
+        (clients.AzureAIWorkload.NARRATIVE, "fallback-a"),
+        (clients.AzureAIWorkload.NARRATIVE, "fallback-b"),
+    ]
+
+
+def test_narrative_workloads_reject_conflicting_aliases():
+    with pytest.raises(ValueError, match="must match"):
+        clients.narrative_route_workloads(
+            {"model": "narrative-a", "deployment": "narrative-b"}
+        )
+
+
+def test_direct_factory_uses_openai_constructor_and_exact_scope(monkeypatch):
+    token_provider = object()
+    provider_factory = MagicMock(return_value=token_provider)
+    openai_client = _inference_client()
+    constructor = MagicMock(return_value=openai_client)
+    monkeypatch.setattr(clients, "get_bearer_token_provider", provider_factory)
+    monkeypatch.setattr(clients, "OpenAI", constructor)
+    credential = MagicMock()
+    factory = clients.AzureAIClientFactory(
+        settings=_direct_settings(),
+        credential=credential,
+    )
+
+    lease = factory.create(
+        "inference",
+        deployment="deployment",
+        timeout=31,
+        max_retries=0,
+    )
+
+    constructor.assert_called_once_with(
+        base_url="https://account.openai.azure.com/openai/v1/",
+        api_key=token_provider,
+        timeout=31,
+        max_retries=0,
+    )
+    provider_factory.assert_called_once_with(
+        credential,
+        "https://ai.azure.com/.default",
+    )
+    credential.get_token.assert_not_called()
+    assert lease.client is openai_client
+    assert lease.owner is None
+    assert not hasattr(lease, "factory")
+
+
+def test_direct_factory_omits_none_max_retries(monkeypatch):
+    constructor = MagicMock(return_value=_inference_client())
+    monkeypatch.setattr(clients, "OpenAI", constructor)
+    monkeypatch.setattr(
+        clients,
+        "get_bearer_token_provider",
+        MagicMock(return_value=object()),
+    )
+
+    clients.AzureAIClientFactory(
+        settings=_direct_settings(),
+        credential=object(),
+    ).create("inference", deployment="deployment")
+
+    constructor.assert_called_once_with(
+        base_url="https://account.openai.azure.com/openai/v1/",
+        api_key=pytest.ANY if hasattr(pytest, "ANY") else constructor.call_args.kwargs["api_key"],
+        timeout=clients.DEFAULT_TIMEOUT,
+    )
+
+
+def test_legacy_factory_uses_azure_constructor_scope_and_version(monkeypatch):
+    token_provider = object()
+    provider_factory = MagicMock(return_value=token_provider)
+    azure_client = _responses_client()
+    constructor = MagicMock(return_value=azure_client)
+    monkeypatch.setattr(clients, "get_bearer_token_provider", provider_factory)
+    monkeypatch.setattr(clients, "AzureOpenAI", constructor)
+    credential = object()
+
+    lease = clients.AzureAIClientFactory(
+        settings=_legacy_settings(),
+        credential=credential,
+    ).create(
+        "grader",
+        deployment="deployment",
+        timeout=45,
+        max_retries=3,
+        legacy_api_version="legacy-version",
+    )
+
+    constructor.assert_called_once_with(
+        azure_endpoint="https://account.openai.azure.com/",
+        azure_ad_token_provider=token_provider,
+        api_version="legacy-version",
+        timeout=45,
+        max_retries=3,
+    )
+    provider_factory.assert_called_once_with(
+        credential,
+        "https://cognitiveservices.azure.com/.default",
+    )
+    assert lease.client is azure_client
+
+
+def test_project_factory_uses_lazy_project_client_without_api_calls(monkeypatch):
+    openai_client = _code_interpreter_client()
+    project = SimpleNamespace(
+        get_openai_client=MagicMock(return_value=openai_client),
+        close=MagicMock(),
+    )
+    project_class = MagicMock(return_value=project)
+    provider_factory = MagicMock(return_value=object())
+    monkeypatch.setattr(clients, "_load_project_client_class", lambda: project_class)
+    monkeypatch.setattr(clients, "get_bearer_token_provider", provider_factory)
+    credential = MagicMock()
+
+    lease = clients.AzureAIClientFactory(
+        settings=_project_settings(),
+        credential=credential,
+    ).create(
+        "code-interpreter",
+        deployment="deployment",
+        timeout=52,
+        max_retries=1,
+    )
+
+    project_class.assert_called_once_with(
+        endpoint=(
+            "https://account.services.ai.azure.com/"
+            "api/projects/project-one"
+        ),
+        credential=credential,
+    )
+    project.get_openai_client.assert_called_once_with(
+        timeout=52,
+        max_retries=1,
+    )
+    provider_factory.assert_not_called()
+    credential.get_token.assert_not_called()
+    openai_client.responses.create.assert_not_called()
+    openai_client.files.create.assert_not_called()
+    openai_client.files.delete.assert_not_called()
+    openai_client.files.content.assert_not_called()
+    openai_client.containers.create.assert_not_called()
+    assert lease.client is openai_client
+    assert lease.owner is project
+
+
+def test_pinned_real_project_sdk_constructs_offline_without_credential_use(
+    monkeypatch,
+):
+    from azure.ai.projects import AIProjectClient
+
+    expected_versions = {
+        "openai": "2.46.0",
+        "azure-core": "1.41.0",
+        "azure-identity": "1.25.3",
+        "azure-ai-projects": "2.3.0",
+    }
+    assert {
+        package: importlib.metadata.version(package)
+        for package in expected_versions
+    } == expected_versions
+
+    class FakeSyncCredential:
+        def __init__(self):
+            self.get_token_calls = 0
+            self.close_calls = 0
+
+        def get_token(self, *_scopes, **_kwargs):
+            self.get_token_calls += 1
+            raise AssertionError("offline construction must not request a token")
+
+        def close(self):
+            self.close_calls += 1
+
+    endpoint = (
+        "https://account.services.ai.azure.com/api/projects/project-one"
+    )
+    credential = FakeSyncCredential()
+    network_send = MagicMock(
+        side_effect=AssertionError("offline construction must not use network")
+    )
+    monkeypatch.setattr("httpx.Client.send", network_send)
+    monkeypatch.setattr("requests.sessions.Session.send", network_send)
+    project = AIProjectClient(endpoint=endpoint, credential=credential)
+    openai_client = None
+    try:
+        openai_client = project.get_openai_client(
+            timeout=480,
+            max_retries=0,
+        )
+        assert str(openai_client.base_url) == f"{endpoint}/openai/v1/"
+        clients.validate_client_capabilities(
+            openai_client,
+            clients.AzureAIWorkload.CODE_INTERPRETER,
+        )
+        assert callable(openai_client.files.delete)
+        assert callable(openai_client.files.content)
+    finally:
+        if openai_client is not None:
+            openai_client.close()
+        project.close()
+
+    assert credential.get_token_calls == 0
+    assert credential.close_calls == 0
+    network_send.assert_not_called()
+
+
+def test_factory_and_lease_document_sync_lifetime_and_thread_safety():
+    factory_doc = clients.AzureAIClientFactory.__doc__ or ""
+    lease_doc = clients.AzureAIClientLease.__doc__ or ""
+
+    for doc in (factory_doc, lease_doc):
+        assert "synchronous" in doc
+        assert "not thread-safe" in doc
+    assert "survives lease closure and failed client construction" in factory_doc
+    assert "Async close implementations are rejected" in factory_doc
+
+
+def _foundation_record(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if path.name != "CHANGELOG.md":
+        return text
+    start = text.index("- **Typed Azure AI endpoint foundation**")
+    end = text.index("\n\n### Changed", start)
+    return text[start:end]
+
+
+@pytest.mark.parametrize("path", FOUNDATION_DOCS, ids=lambda path: path.name)
+def test_foundation_docs_use_precise_credential_and_provenance_language(path):
+    record = " ".join(_foundation_record(path).split())
+    lowered = record.lower()
+
+    assert "DefaultAzureCredential" in record
+    assert "endpoint-free" in record
+    assert "redacted provenance" in record
+    assert "not a confidentiality boundary" in record
+    assert "not a secret" in record
+    assert "CodeInterpreterRunner is Azure-only" in record
+    assert "NOT WIRED" in record
+    for requirement in (
+        "openai==2.46.0",
+        "azure-core==1.41.0",
+        "azure-identity==1.25.3",
+        "azure-ai-projects==2.3.0",
+    ):
+        assert requirement in record
+    for prohibited in ("cannot disclose", "oidc-only", "tested api"):
+        assert prohibited not in lowered
+
+
+def test_shared_factory_survives_lease_close_and_can_create_again(monkeypatch):
+    first_client = _inference_client()
+    second_client = _inference_client()
+    constructor = MagicMock(side_effect=[first_client, second_client])
+    monkeypatch.setattr(clients, "OpenAI", constructor)
+    monkeypatch.setattr(
+        clients,
+        "get_bearer_token_provider",
+        MagicMock(return_value=object()),
+    )
+    credential = MagicMock()
+    factory = clients.AzureAIClientFactory(
+        settings=_direct_settings(),
+        credential=credential,
+    )
+
+    first_lease = factory.create("inference", deployment="first")
+    first_lease.close()
+    second_lease = factory.create("inference", deployment="second")
+
+    first_client.close.assert_called_once_with()
+    credential.close.assert_not_called()
+    assert second_lease.client is second_client
+    assert constructor.call_count == 2
+
+
+def test_shared_factory_survives_failed_create(monkeypatch):
+    broken_client = SimpleNamespace(close=MagicMock())
+    healthy_client = _responses_client()
+    constructor = MagicMock(side_effect=[broken_client, healthy_client])
+    monkeypatch.setattr(clients, "OpenAI", constructor)
+    monkeypatch.setattr(
+        clients,
+        "get_bearer_token_provider",
+        MagicMock(return_value=object()),
+    )
+    credential = MagicMock()
+    factory = clients.AzureAIClientFactory(
+        settings=_direct_settings(),
+        credential=credential,
+    )
+
+    with pytest.raises(RuntimeError, match="responses.create"):
+        factory.create("grader", deployment="broken")
+    lease = factory.create("grader", deployment="healthy")
+
+    broken_client.close.assert_called_once_with()
+    credential.close.assert_not_called()
+    assert lease.client is healthy_client
+
+
+def test_owned_credential_closes_only_when_factory_closes(monkeypatch):
+    credential = MagicMock()
+    client = _inference_client()
+    monkeypatch.setattr(clients, "DefaultAzureCredential", lambda: credential)
+    monkeypatch.setattr(clients, "OpenAI", MagicMock(return_value=client))
+    monkeypatch.setattr(
+        clients,
+        "get_bearer_token_provider",
+        MagicMock(return_value=object()),
+    )
+    factory = clients.AzureAIClientFactory(settings=_direct_settings())
+    lease = factory.create("inference", deployment="deployment")
+
+    lease.close()
+    credential.close.assert_not_called()
+    factory.close()
+    factory.close()
+
+    credential.close.assert_called_once_with()
+
+
+def test_failed_create_does_not_close_owned_credential(monkeypatch):
+    credential = MagicMock()
+    broken_client = SimpleNamespace(close=MagicMock())
+    monkeypatch.setattr(clients, "DefaultAzureCredential", lambda: credential)
+    monkeypatch.setattr(
+        clients,
+        "OpenAI",
+        MagicMock(return_value=broken_client),
+    )
+    monkeypatch.setattr(
+        clients,
+        "get_bearer_token_provider",
+        MagicMock(return_value=object()),
+    )
+    factory = clients.AzureAIClientFactory(settings=_direct_settings())
+
+    with pytest.raises(RuntimeError, match="responses.create"):
+        factory.create("grader", deployment="deployment")
+
+    broken_client.close.assert_called_once_with()
+    credential.close.assert_not_called()
+    factory.close()
+    credential.close.assert_called_once_with()
+
+
+def test_injected_credential_is_never_closed_by_factory(monkeypatch):
+    credential = MagicMock()
+    monkeypatch.setattr(
+        clients,
+        "OpenAI",
+        MagicMock(return_value=_inference_client()),
+    )
+    monkeypatch.setattr(
+        clients,
+        "get_bearer_token_provider",
+        MagicMock(return_value=object()),
+    )
+
+    with clients.AzureAIClientFactory(
+        settings=_direct_settings(),
+        credential=credential,
+    ) as factory:
+        lease = factory.create("inference", deployment="deployment")
+        lease.close()
+
+    credential.close.assert_not_called()
+
+
+def test_closed_factory_rejects_create():
+    factory = clients.AzureAIClientFactory(
+        settings=_direct_settings(),
+        credential=object(),
+    )
+    factory.close()
+
+    with pytest.raises(RuntimeError, match="factory is closed"):
+        factory.create("inference", deployment="deployment")
+
+
+def test_project_failure_closes_client_and_project_not_credential(monkeypatch):
+    broken_client = SimpleNamespace(
+        responses=SimpleNamespace(create=MagicMock()),
+        files=SimpleNamespace(
+            create=MagicMock(),
+            delete=MagicMock(),
+            content=MagicMock(),
+        ),
+        close=MagicMock(),
+    )
+    project = SimpleNamespace(
+        get_openai_client=MagicMock(return_value=broken_client),
+        close=MagicMock(),
+    )
+    monkeypatch.setattr(
+        clients,
+        "_load_project_client_class",
+        lambda: MagicMock(return_value=project),
+    )
+    credential = MagicMock()
+    factory = clients.AzureAIClientFactory(
+        settings=_project_settings(),
+        credential=credential,
+    )
+
+    with pytest.raises(RuntimeError, match="containers.create"):
+        factory.create("code-interpreter", deployment="deployment")
+
+    broken_client.close.assert_called_once_with()
+    project.close.assert_called_once_with()
+    credential.close.assert_not_called()
+
+
+def test_project_get_client_failure_closes_partial_project(monkeypatch):
+    project = SimpleNamespace(
+        get_openai_client=MagicMock(side_effect=RuntimeError("creation failed")),
+        close=MagicMock(),
+    )
+    monkeypatch.setattr(
+        clients,
+        "_load_project_client_class",
+        lambda: MagicMock(return_value=project),
+    )
+    credential = MagicMock()
+    factory = clients.AzureAIClientFactory(
+        settings=_project_settings(),
+        credential=credential,
+    )
+
+    with pytest.raises(RuntimeError, match="creation failed"):
+        factory.create("code-interpreter", deployment="deployment")
+
+    project.close.assert_called_once_with()
+    credential.close.assert_not_called()
+
+
+def test_lease_close_attempts_project_after_client_failure():
+    client = _code_interpreter_client()
+    client.close.side_effect = RuntimeError("client close failed")
+    project = SimpleNamespace(close=MagicMock())
+    lease = clients.AzureAIClientLease(
+        client=client,
+        owner=project,
+        route=MagicMock(),
+        runtime_fingerprint="f" * 64,
+    )
+
+    with pytest.raises(RuntimeError, match="client close failed"):
+        lease.close()
+
+    project.close.assert_called_once_with()
+
+
+def test_lease_close_is_idempotent_and_deduplicates_owner():
+    client = _inference_client()
+    lease = clients.AzureAIClientLease(
+        client=client,
+        owner=client,
+        route=MagicMock(),
+        runtime_fingerprint="f" * 64,
+    )
+
+    lease.close()
+    lease.close()
+
+    client.close.assert_called_once_with()
+
+
+def test_lease_rejects_async_close_method_and_still_closes_owner():
+    class AsyncClient:
+        async def close(self):
+            return None
+
+    project = SimpleNamespace(close=MagicMock())
+    lease = clients.AzureAIClientLease(
+        client=AsyncClient(),
+        owner=project,
+        route=MagicMock(),
+        runtime_fingerprint="f" * 64,
+    )
+
+    with pytest.raises(RuntimeError, match="does not support async client close"):
+        lease.close()
+
+    project.close.assert_called_once_with()
+
+
+def test_lease_closes_awaitable_result_without_unawaited_warning():
+    async def async_close():
+        return None
+
+    class AwaitableCloseClient:
+        def close(self):
+            return async_close()
+
+    lease = clients.AzureAIClientLease(
+        client=AwaitableCloseClient(),
+        owner=None,
+        route=MagicMock(),
+        runtime_fingerprint="f" * 64,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(RuntimeError, match="does not support async client close"):
+            lease.close()
+        gc.collect()
+
+    assert not [
+        warning
+        for warning in caught
+        if "was never awaited" in str(warning.message)
+    ]
+
+
+def test_factory_rejects_async_owned_credential_close():
+    class AsyncCredential:
+        async def close(self):
+            return None
+
+    factory = clients.AzureAIClientFactory(
+        settings=_direct_settings(),
+        credential=object(),
+    )
+    factory.credential = AsyncCredential()
+    factory._owns_credential = True
+
+    with pytest.raises(RuntimeError, match="async credential close"):
+        factory.close()
+
+    factory.close()
+
+
+@pytest.mark.parametrize(
+    ("workload", "client", "missing"),
+    [
+        (
+            clients.AzureAIWorkload.INFERENCE,
+            SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace())),
+            "chat.completions.create",
+        ),
+        (
+            clients.AzureAIWorkload.NARRATIVE,
+            SimpleNamespace(responses=SimpleNamespace()),
+            "responses.create",
+        ),
+        (
+            clients.AzureAIWorkload.CODE_INTERPRETER,
+            SimpleNamespace(
+                responses=SimpleNamespace(create=lambda: None),
+                files=SimpleNamespace(
+                    create=lambda: None,
+                    delete=lambda: None,
+                    content=lambda: None,
+                ),
+                containers=SimpleNamespace(create=lambda: None),
+            ),
+            "containers.files.list",
+        ),
+    ],
+)
+def test_capability_validation_reports_missing_paths(workload, client, missing):
+    with pytest.raises(RuntimeError, match=missing):
+        clients.validate_client_capabilities(client, workload)
+
+
+def test_capability_validation_requires_callable_operation():
+    client = SimpleNamespace(
+        responses=SimpleNamespace(create=object()),
+    )
+
+    with pytest.raises(RuntimeError, match="responses.create"):
+        clients.validate_client_capabilities(
+            client,
+            clients.AzureAIWorkload.GRADER,
+        )
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "responses.create",
+        "files.create",
+        "files.delete",
+        "files.content",
+        "containers.create",
+        "containers.files.list",
+        "containers.files.content.retrieve",
+    ],
+)
+def test_code_interpreter_capability_requires_every_operation(missing):
+    client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda: None),
+        files=SimpleNamespace(
+            create=lambda: None,
+            delete=lambda: None,
+            content=lambda: None,
+        ),
+        containers=SimpleNamespace(
+            create=lambda: None,
+            files=SimpleNamespace(
+                list=lambda: None,
+                content=SimpleNamespace(retrieve=lambda: None),
+            ),
+        ),
+    )
+    parent = client
+    parts = missing.split(".")
+    for part in parts[:-1]:
+        parent = getattr(parent, part)
+    delattr(parent, parts[-1])
+
+    with pytest.raises(RuntimeError, match=re.escape(missing)):
+        clients.validate_client_capabilities(
+            client,
+            clients.AzureAIWorkload.CODE_INTERPRETER,
+        )
+
+
+def test_verify_direct_token_uses_scope_without_closing_injected_credential():
+    credential = MagicMock()
+
+    clients.verify_direct_token(credential)
+
+    credential.get_token.assert_called_once_with(
+        "https://ai.azure.com/.default"
+    )
+    credential.close.assert_not_called()
+
+
+@pytest.mark.parametrize("name", clients.FORBIDDEN_API_KEY_ENV)
+def test_owned_token_check_rejects_process_static_secret_before_credential(
+    name, monkeypatch
+):
+    constructor = MagicMock()
+    monkeypatch.setattr(clients, "DefaultAzureCredential", constructor)
+    monkeypatch.setenv(name, "not-a-real-secret")
+
+    with pytest.raises(ValueError, match="forbidden") as error:
+        clients.verify_direct_token()
+
+    constructor.assert_not_called()
+    assert "not-a-real-secret" not in str(error.value)

--- a/batch-runner/tests/test_azure_ai_route_preflight.py
+++ b/batch-runner/tests/test_azure_ai_route_preflight.py
@@ -1,0 +1,446 @@
+import importlib.util
+import json
+import os
+import socket
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+BATCH_RUNNER = Path(__file__).resolve().parents[1]
+SCRIPT = BATCH_RUNNER / "scripts" / "azure_ai_route_preflight.py"
+REQUIREMENTS = BATCH_RUNNER / "requirements.txt"
+
+SPEC = importlib.util.spec_from_file_location(
+    "azure_ai_route_preflight",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+preflight = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(preflight)
+
+
+def _env(**updates: str) -> dict[str, str]:
+    env = {
+        "PATH": os.defpath,
+        "PYTHONUTF8": "1",
+    }
+    env.update(updates)
+    return env
+
+
+def _direct_env(**updates: str) -> dict[str, str]:
+    return _env(
+        AZURE_AI_ROUTE_PROFILE="direct-v1",
+        AZURE_OPENAI_V1_ENDPOINT=(
+            "https://account.services.ai.azure.com/openai/v1/"
+        ),
+        **updates,
+    )
+
+
+def _run(*args: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=BATCH_RUNNER,
+        env=env,
+        check=False,
+    )
+
+
+def test_cli_emits_endpoint_and_deployment_free_route_records(tmp_path):
+    output = tmp_path / "github-output.txt"
+    direct = "https://account.services.ai.azure.com/openai/v1/"
+    project = (
+        "https://account.services.ai.azure.com/api/projects/project-one"
+    )
+    deployment = "private-deployment"
+
+    result = _run(
+        "--workload",
+        f"narrative={deployment}",
+        "--workload",
+        f"code-interpreter={deployment}",
+        env=_env(
+            AZURE_AI_ROUTE_PROFILE="project-ci",
+            AZURE_OPENAI_V1_ENDPOINT=direct,
+            FOUNDRY_PROJECT_ENDPOINT=project,
+            GITHUB_OUTPUT=str(output),
+        ),
+    )
+
+    assert result.returncode == 0, result.stderr
+    records = json.loads(result.stdout)
+    assert [record["endpoint_kind"] for record in records] == [
+        "direct-v1",
+        "project",
+    ]
+    assert all(len(record["runtime_fingerprint"]) == 64 for record in records)
+    output_lines = output.read_text(encoding="utf-8").splitlines()
+    assert output_lines == [f"routes={result.stdout.strip()}"]
+    emitted = result.stdout + output.read_text(encoding="utf-8")
+    for private_value in (direct, project, deployment, "account", "project-one"):
+        assert private_value not in emitted
+
+
+def test_cli_rejects_deprecated_endpoint_without_echoing_it():
+    endpoint = "https://private-account.openai.azure.com/"
+
+    result = _run(
+        "--workload",
+        "inference=private-deployment",
+        env=_direct_env(AZURE_OPENAI_ENDPOINT=endpoint),
+    )
+
+    assert result.returncode != 0
+    assert "deprecated" in result.stderr
+    assert endpoint not in result.stderr
+    assert "private-account" not in result.stderr
+    assert "private-deployment" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "name",
+    preflight.FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV,
+)
+def test_cli_rejects_static_azure_credentials_without_echoing_values(name):
+    endpoint = "https://account.services.ai.azure.com/openai/v1/"
+    deployment = "private-deployment"
+    secret = f"private-value-for-{name.lower()}"
+
+    result = _run(
+        "--workload",
+        f"inference={deployment}",
+        env=_env(
+            AZURE_AI_ROUTE_PROFILE="direct-v1",
+            AZURE_OPENAI_V1_ENDPOINT=endpoint,
+            **{name: secret},
+        ),
+    )
+
+    assert result.returncode != 0
+    assert "static Azure credential" in result.stderr
+    emitted = result.stdout + result.stderr
+    assert secret not in emitted
+    assert endpoint not in emitted
+    assert deployment not in emitted
+
+
+def test_cli_allows_federated_token_file_and_native_openai_key():
+    result = _run(
+        "--workload",
+        "inference=private-deployment",
+        env=_direct_env(
+            AZURE_FEDERATED_TOKEN_FILE="/tmp/federated-token",
+            OPENAI_API_KEY="native-provider-key",
+        ),
+    )
+
+    assert result.returncode == 0, result.stderr
+    emitted = result.stdout + result.stderr
+    assert "federated-token" not in emitted
+    assert "native-provider-key" not in emitted
+    assert "private-deployment" not in emitted
+
+
+def test_invalid_workload_fails_before_environment_resolution():
+    endpoint = "https://private-account.openai.azure.com/"
+
+    result = _run(
+        "--workload",
+        "unknown=private-deployment",
+        env=_env(AZURE_OPENAI_ENDPOINT=endpoint),
+    )
+
+    assert result.returncode != 0
+    assert "unsupported workload" in result.stderr
+    assert "AZURE_AI_ROUTE_PROFILE" not in result.stderr
+    assert "deprecated" not in result.stderr
+    assert endpoint not in result.stderr
+    assert "private-deployment" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("encoded", "message"),
+    [
+        ("{broken", "invalid JSON"),
+        ('{"not":"a-list"}', "must be a list of strings"),
+    ],
+)
+def test_cli_rejects_malformed_workload_json(encoded, message):
+    result = _run(
+        env=_direct_env(AZURE_AI_WORKLOADS_JSON=encoded),
+    )
+
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert encoded not in result.stderr
+
+
+def test_cli_deduplicates_identical_workloads_from_args_and_environment():
+    workload = "grader=private-deployment"
+
+    result = _run(
+        "--workload",
+        workload,
+        env=_direct_env(AZURE_AI_WORKLOADS_JSON=json.dumps([workload, workload])),
+    )
+
+    assert result.returncode == 0, result.stderr
+    records = json.loads(result.stdout)
+    assert len(records) == 1
+    assert records[0]["workload"] == "grader"
+    assert "private-deployment" not in result.stdout
+
+
+def test_main_does_not_acquire_token_by_default(capsys):
+    verifier = MagicMock()
+
+    records = preflight.main(
+        ["--workload", "inference=private-deployment"],
+        env=_direct_env(),
+        token_verifier=verifier,
+    )
+
+    verifier.assert_not_called()
+    assert records[0]["workload"] == "inference"
+    assert "private-deployment" not in capsys.readouterr().out
+
+
+def test_main_verifies_token_only_when_explicitly_requested(capsys):
+    verifier = MagicMock()
+
+    preflight.main(
+        [
+            "--workload",
+            "inference=private-deployment",
+            "--verify-token",
+        ],
+        env=_direct_env(),
+        token_verifier=verifier,
+    )
+
+    verifier.assert_called_once_with()
+    assert "private-deployment" not in capsys.readouterr().out
+
+
+def test_token_verification_error_is_sanitized(capsys):
+    verifier = MagicMock(
+        side_effect=RuntimeError(
+            "credential failed for https://private-account.openai.azure.com/ "
+            "and private-deployment"
+        )
+    )
+
+    with pytest.raises(SystemExit):
+        preflight.main(
+            [
+                "--workload",
+                "inference=private-deployment",
+                "--verify-token",
+            ],
+            env=_direct_env(),
+            token_verifier=verifier,
+        )
+
+    stderr = capsys.readouterr().err
+    assert "direct token verification failed" in stderr
+    assert "private-account" not in stderr
+    assert "private-deployment" not in stderr
+
+
+@pytest.mark.parametrize(
+    "workload",
+    [
+        "inference=private\nroutes=owned",
+        "inference=private\x1broutes=owned",
+    ],
+)
+def test_cli_rejects_workload_control_injection_without_echo(workload):
+    result = _run("--workload", workload, env=_direct_env())
+
+    assert result.returncode != 0
+    assert "control characters" in result.stderr
+    assert "routes=owned" not in result.stderr
+    assert "private" not in result.stderr
+
+
+def test_github_output_rejects_symlink_target(tmp_path):
+    target = tmp_path / "real-output.txt"
+    target.write_text("existing=1\n", encoding="utf-8")
+    output = tmp_path / "github-output.txt"
+    output.symlink_to(target)
+
+    result = _run(
+        "--workload",
+        "inference=private-deployment",
+        env=_direct_env(GITHUB_OUTPUT=str(output)),
+    )
+
+    assert result.returncode != 0
+    assert "regular non-symlink file" in result.stderr
+    assert target.read_text(encoding="utf-8") == "existing=1\n"
+    assert "private-deployment" not in result.stderr
+
+
+def test_github_output_rejects_symlink_ancestor(tmp_path):
+    real_directory = tmp_path / "real"
+    real_directory.mkdir()
+    linked_directory = tmp_path / "linked"
+    linked_directory.symlink_to(real_directory, target_is_directory=True)
+
+    result = _run(
+        "--workload",
+        "inference=private-deployment",
+        env=_direct_env(GITHUB_OUTPUT=str(linked_directory / "output.txt")),
+    )
+
+    assert result.returncode != 0
+    assert "non-symlink ancestors" in result.stderr
+    assert not (real_directory / "output.txt").exists()
+
+
+def test_github_output_appends_existing_file_in_one_append_write(
+    tmp_path,
+    monkeypatch,
+):
+    output = tmp_path / "github-output.txt"
+    output.write_text("existing=1\n", encoding="utf-8")
+    output.chmod(0o640)
+    real_open = preflight.os.open
+    real_write = preflight.os.write
+    open_flags = []
+    writes = []
+
+    def recording_open(path, flags, mode=0o777, *, dir_fd=None):
+        open_flags.append(flags)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    def recording_write(fd, payload):
+        writes.append(payload)
+        return real_write(fd, payload)
+
+    monkeypatch.setattr(preflight.os, "open", recording_open)
+    monkeypatch.setattr(preflight.os, "write", recording_write)
+
+    preflight._append_github_output(
+        str(output),
+        '[{"workload":"grader"}]',
+    )
+
+    assert output.read_text(encoding="utf-8") == (
+        'existing=1\nroutes=[{"workload":"grader"}]\n'
+    )
+    assert stat.S_IMODE(output.stat().st_mode) == 0o640
+    assert len(writes) == 1
+    assert open_flags[-1] & os.O_APPEND
+    assert not open_flags[-1] & os.O_TRUNC
+
+
+def test_github_output_created_file_has_mode_0600(tmp_path):
+    output = tmp_path / "github-output.txt"
+
+    preflight._append_github_output(str(output), "[]")
+
+    assert output.read_text(encoding="utf-8") == "routes=[]\n"
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize("target_kind", ["directory", "fifo", "socket"])
+def test_github_output_rejects_non_regular_target_types(tmp_path, target_kind):
+    output = tmp_path / "github-output"
+    unix_socket = None
+    if target_kind == "directory":
+        output.mkdir()
+    elif target_kind == "fifo":
+        os.mkfifo(output)
+    else:
+        unix_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        unix_socket.bind(str(output))
+
+    try:
+        with pytest.raises(ValueError, match="regular file"):
+            preflight._append_github_output(str(output), "[]")
+    finally:
+        if unix_socket is not None:
+            unix_socket.close()
+
+
+@pytest.mark.parametrize(
+    "raw_path",
+    ["../output.txt", "nested/../output.txt", "output\nowned.txt"],
+)
+def test_github_output_rejects_parent_and_control_bearing_paths(raw_path):
+    with pytest.raises(ValueError):
+        preflight._absolute_output_path(raw_path)
+
+
+def test_github_output_short_write_fails(tmp_path, monkeypatch):
+    output = tmp_path / "github-output.txt"
+    write = MagicMock(return_value=1)
+    monkeypatch.setattr(preflight.os, "write", write)
+
+    with pytest.raises(OSError, match="short write"):
+        preflight._append_github_output(str(output), "[]")
+
+    write.assert_called_once()
+
+
+def test_github_output_missing_ancestor_error_is_sanitized(tmp_path):
+    endpoint = "https://account.services.ai.azure.com/openai/v1/"
+    deployment = "private-deployment"
+    output = tmp_path / "missing" / "github-output.txt"
+
+    result = _run(
+        "--workload",
+        f"inference={deployment}",
+        env=_env(
+            AZURE_AI_ROUTE_PROFILE="direct-v1",
+            AZURE_OPENAI_V1_ENDPOINT=endpoint,
+            GITHUB_OUTPUT=str(output),
+        ),
+    )
+
+    assert result.returncode != 0
+    assert "non-symlink ancestors" in result.stderr
+    emitted = result.stdout + result.stderr
+    assert endpoint not in emitted
+    assert deployment not in emitted
+
+
+def test_subprocess_environment_does_not_inherit_cloud_credentials(monkeypatch):
+    monkeypatch.setenv("AZURE_CLIENT_ID", "real-client-id")
+    monkeypatch.setenv("OPENAI_API_KEY", "real-provider-key")
+    monkeypatch.setenv("HF_TOKEN", "real-hf-token")
+
+    env = _env()
+
+    assert "AZURE_CLIENT_ID" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "HF_TOKEN" not in env
+
+
+@pytest.mark.parametrize(
+    "requirement",
+    [
+        "openai==2.46.0",
+        "azure-core==1.41.0",
+        "azure-identity==1.25.3",
+        "azure-ai-projects==2.3.0",
+    ],
+)
+def test_sdk_requirement_is_exactly_pinned_once(requirement):
+    package = requirement.partition("==")[0]
+    matching = [
+        line.strip()
+        for line in REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith(package)
+    ]
+
+    assert matching == [requirement]

--- a/tasks/0723_thursday/BOLT_TYPED_AZURE_AI_ENDPOINT_CONTRACTS.md
+++ b/tasks/0723_thursday/BOLT_TYPED_AZURE_AI_ENDPOINT_CONTRACTS.md
@@ -1,0 +1,91 @@
+# BOLT: Typed Azure AI Endpoint Contracts
+
+- Date: 2026-07-23
+- Status: `LOCALLY_VERIFIED`
+- Base: `origin/main@b82d9fea95fb97a1fcbcea6cb6979d09b031afeb`
+- Execution boundary: model-free, local-only, offline, no credentials
+
+## Objective
+
+Establish a bounded foundation for typed Microsoft Foundry and Azure OpenAI
+routes. The foundation validates exact endpoint shapes, discovers every Azure
+deployment a condition can call, constructs synchronous clients, and exposes a
+standalone preflight without changing active runtime or workflow callers.
+
+## Contract
+
+- URL classification rejects non-ASCII text, C0/C1 controls, CR/LF/TAB,
+  Unicode line separators, explicit empty or non-443 ports, malformed percent
+  sequences, host lookalikes, and trailing-dot hosts before accepting the exact
+  Microsoft suffix/path allowlist.
+- Strict identity is profile-specific. Direct and project profiles verify the
+  active direct account; project additionally verifies project account/name;
+  legacy verifies only the active legacy endpoint through
+  `AZURE_AI_EXPECTED_LEGACY_ACCOUNT` and does not require or trust a direct
+  endpoint.
+- The current `CodeInterpreterRunner is Azure-only`. A missing main deployment
+  follows `ExperimentConfig`'s `gpt-4` default; malformed model objects,
+  explicit null deployments, and native-provider Code Interpreter fail. Azure
+  audio and video preprocessors default to `gpt-audio-1.5` and `gpt-5.2`;
+  preprocessor types that do not invoke a model are not route workloads. The
+  runtime reads only `deployment` for audio/video, so a `model` alias alone does
+  not override those defaults and an explicit null deployment fails.
+- Authentication is `DefaultAzureCredential`-based. Known static Azure key,
+  token, client-secret, certificate, username, and password environment
+  variables fail without value echo. `AZURE_FEDERATED_TOKEN_FILE` and the
+  native-provider `OPENAI_API_KEY` remain allowed. Internally owned factory and
+  token-verification paths recheck the real process environment before creating
+  a credential even when route settings were supplied explicitly; injected
+  credentials remain caller-managed.
+- The versioned fingerprint binds effective token scope, endpoint/deployment
+  identity, SDK versions, timeout, retry setting, workload, profile, and legacy
+  API version. Emitted records are endpoint-free, redacted provenance. The
+  digest is not a confidentiality boundary and not a secret.
+- Factory and lease lifetimes are synchronous, explicit, and not thread-safe.
+  Closing or failing a lease does not close the shared factory or an injected
+  caller-owned credential; async close implementations fail explicitly.
+- `GITHUB_OUTPUT` accepts only a regular non-symlink target beneath regular
+  non-symlink ancestors. Existing content and mode are preserved, new files are
+  mode `0600`, and one `O_APPEND` write must write the complete record.
+
+## SDK Contract
+
+The locally verified exact set occurs once each in `requirements.txt`:
+
+- `openai==2.46.0`
+- `azure-core==1.41.0`
+- `azure-identity==1.25.3`
+- `azure-ai-projects==2.3.0`
+
+An offline real-SDK construction smoke created `AIProjectClient` with a
+canonical project endpoint, called `get_openai_client(timeout=480,
+max_retries=0)`, verified the expected `/openai/v1/` base URL and the exact
+`responses.create`, `files.create`, `files.delete`, fallback `files.content`,
+`containers.create`, `containers.files.list`, and
+`containers.files.content.retrieve` capabilities, then closed both SDK clients.
+The current runner uses auto-container configuration rather than calling
+`containers.create` directly; that method is a project-client compatibility
+gate. Instrumented credential and HTTP send paths remained at zero; the injected
+credential remained caller-owned.
+
+## Evidence
+
+| Check | Result |
+|---|---|
+| Clean-checkout focused pytest | `224 passed in 20.79s` |
+| Clean-checkout SDK smoke | `1 passed in 1.47s`; exact versions/capabilities, zero token/network |
+| Clean-checkout backend non-integration | `2,074 passed, 9 skipped, 44 deselected in 126.02s` |
+| Credential and field parity | 20 owned-secret cases plus raw/serialized workload parity passed |
+| Ruff | Four Python files, `All checks passed!` |
+| `py_compile` | Four Python files, no diagnostics |
+| `pip check` | `No broken requirements found.` |
+| Exact SDK pins | Each exact pin and package prefix occurs once |
+| Diff and scope | `git diff --check` clean; zero conflict markers; exactly eight intended status paths |
+| Remote or paid execution | No token, network, Azure/model API, HF, workflow, or paid action |
+
+## Decision
+
+`LOCALLY_VERIFIED`. Runtime and workflow integration remains `NOT WIRED`.
+Inference, Code Interpreter, grading, reporting, and workflow callers are
+unchanged. No token acquisition, network request, Azure/model API operation,
+Hugging Face access, workflow run, or paid action occurred.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -3,167 +3,90 @@
 This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
-- Updated: 2026-07-22
-- Status: PR #129 and cleanup commit identity follow-up PR #131 shipped
+- Updated: 2026-07-23
+- Status: Mandatory foundation review findings locally resolved
 
 ## Task
 
-- Put direct dashboard, sample config, Batch workflow, and result/artifact paths
-  in the English and Korean root README start sections.
-- Align both Batch Runner references and beginner guides with the executable
-  OIDC, bootstrap, dry-run, report, publication, artifact, and relay contracts.
-- Fail closed before Azure/model spend when dispatch identity, relay source,
-  checkpoint/image identity, canonical task/reference semantics, write
-  authorization, or publication output identity cannot be proven.
-- Bind relay cleanup finality to the actual Hugging Face SDK commit model:
-  `title` for `commit_message` and `message` for `commit_description`.
+- Harden typed direct v1, Foundry project, and authorized legacy endpoint
+  contracts plus the standalone route preflight CLI.
+- Align workload discovery, identity, credential, fingerprint, lifecycle,
+  output-file, and SDK reproducibility contracts with the current runtime.
 
 ## Result
 
-- Added four fork-safe first-screen routes in both root READMEs and matching
-  English/Korean Batch Runner start sections. Local debugging now uses the real
-  YAML-driven wrappers and stops before destructive Step 7 publication.
-- Corrected OIDC-only workflow guidance, Azure OpenAI resource endpoint scope,
-  `dry_run` cost/write behavior, Step 0 fail-closed bootstrap, condition-specific
-  checkpoints, Step 6 JSON/Markdown report, Step 7 allowlist, eight dispatch
-  inputs/defaults, result PR ordering, and 30-day artifact layout.
-- Added exact-main/workflow-SHA preflight, canonical `wall_timeout=0..290` and
-  relay bounds, exact checkout checks, initial `source_sha` propagation, and
-  `--ref main` continuation dispatch.
-- Added fail-closed relay transport using the validated full `data.source`.
-  Each payload is a content-addressed generation at one immutable HF revision;
-  `current.json` advances only after exact-tree and SHA-256/size verification.
-  Marker restore/cleanup also require the expected source SHA, lineage, and
-  immutable trusted sandbox image digest. Manual leg 0 cannot inject internal
-  relay identity or image inputs.
-- Added a non-mutating HF write-access preflight after Step 0 and before task
-  preparation, Azure login, or model spend. Read-only sources such as the
-  official public dataset fail before paid execution.
-- Step 0 now treats only an explicit repository-not-found response as absence,
-  propagates 401/403/429/5xx/timeout failures, and refuses automatic deletion of
-  existing partial targets. Manifest schema v4 binds all 220 tasks to prompt,
-  taxonomy, rubric, ordered reference path/URL/URI semantics and 261 declared
-  reference SHA-256/size records from the pinned public source. Step 1 and Step
-  2 recheck that identity before prepared output or provider-client creation.
-- Every reference is copied to read-only private per-task staging before
-  preview, preprocessing, codegen, or execution. Same-file-descriptor hashing,
-  fatal provider upload/local/Docker copy errors, basename-collision rejection,
-  partial-copy cleanup, and best-effort provider input-file deletion prevent
-  missing or changed inputs from silently reaching a model or generated code.
-- Code Interpreter uploads retain the verified local basename so provider-side
-  file type and extension are explicit. The common sandbox still stages local
-  references privately, while the hardened remote backend carries opaque
-  reference IDs through to its compute backend without a second host-path copy.
-- Step 1 assigns a run-specific publication generation before its prepared
-  fingerprint is calculated. Fresh GitHub/local runs receive a new generation,
-  relay legs preserve the initial lineage, and Step 2 validates it before
-  manifest loading, provider-client construction, or model spend.
-- Relay checkpoints canonicalize ordered/result task IDs, reject unknown result
-  statuses, and require each deliverable path to be owned by its result task.
-  Before the first execution and each QA retry, Step 2 removes the prior task
-  output tree with symlink-aware file/directory handling instead of silently
-  retaining stale artifacts.
-- Condition A keeps the canonical publication/relay upload root while condition
-  B writes to an isolated root. Step 2 binds every selected file to its
-  same-descriptor SHA-256/size and includes those records in a canonical result
-  fingerprint, so later same-path byte drift fails before any HF call.
-- Step 0 always creates and clears all submitter columns and rejects stale text,
-  scalar/list manifests, URL/URI values, or physical outputs on reused targets.
-  Step 4 rebuilds production selected rows from current results. Step 7 requires
-  one canonical parquet shard, row-owned deliverable paths, canonical URLs/URIs,
-  and exact parquet-to-current-Step-2 text/file/URL/URI/byte equality. Step 3 and
-  publication use one shared production-shaped projection of prepared metadata
-  plus raw Step 2 nested QA/results. The non-dry self-report must match its run
-  generation, prepared/result fingerprints, task order, status, summary, and
-  files. Step 5 records missing file-required outputs as failed empty rows and
-  never creates dummy files or mutates the parquet after result identity binds.
-- Step 0 records the validated target HEAD. Step 7 performs one HF
-  `create_commit(parent_commit=...)`, then proves direct ancestry, plan marker,
-  exact remote tree/hashes, self-report identity, and final HEAD. Ambiguous
-  marker and publication responses are reconciled without retry. Relay cleanup
-  requires the exact restored checkpoint generation, and a private local
-  receipt binds the publication plan so post-cleanup verification accepts only
-  the exact cleanup child with an unchanged managed tree.
-- The follow-up cleanup commit writes a short generation label to the Hub commit
-  title and the full 64-character generation marker to its description.
-  Response-loss reconciliation and publication finality require that exact
-  `GitCommitInfo.title`, `GitCommitInfo.message`, and direct parent, preventing a
-  valid cleanup from failing due to SDK field confusion and preventing an
-  unrelated child commit from being accepted.
-- Added model-free checkpoint identity validation after Step 1 and before Azure
-  login/model-client construction. Missing progress, lineage/fingerprint drift,
-  or incomplete deliverables abort the continuation instead of rerunning tasks.
-- Renamed runtime evidence to `step_timeout_headroom_minutes`; the UI/docs state
-  that the nominal 60-minute difference is best-effort, not reserved handoff
-  time. Operators must not overlap runs sharing one HF target.
+- URL parsing now rejects non-ASCII text, C0/C1 controls, CR/LF/TAB, Unicode
+  line separators, explicit empty ports, malformed percent sequences,
+  lookalikes, and trailing-dot hosts before applying the exact Microsoft
+  suffix/path allowlist.
+- Strict identity is profile-specific. Direct/project routes bind the active
+  direct account, project also binds project account/name, and legacy binds the
+  active legacy endpoint through `AZURE_AI_EXPECTED_LEGACY_ACCOUNT` without
+  requiring or trusting a separate direct endpoint.
+- The current `CodeInterpreterRunner is Azure-only`. A missing main deployment
+  follows the runtime's `gpt-4` default; malformed model objects, explicit null
+  deployments, and native-provider Code Interpreter fail clearly. Azure
+  `audio_analyzer` and `video_analyzer` preprocessors inherit current runtime
+  defaults `gpt-audio-1.5` and `gpt-5.2`; other preprocessor types are not route
+  workloads. A `model` alias alone does not override the runtime's audio/video
+  `deployment` lookup. Native main models can still discover explicitly Azure
+  audio/video preprocessors.
+- Authentication is `DefaultAzureCredential`-based. Known static Azure keys,
+  tokens, client secrets, certificates, usernames, and passwords are rejected
+  without echoing values. `AZURE_FEDERATED_TOKEN_FILE` and native
+  `OPENAI_API_KEY` remain allowed. Internally owned factory and token-check paths
+  recheck the real process environment before credential construction even with
+  explicit route settings; injected credentials remain caller-managed.
+- Fingerprints now carry a stable contract version and effective token scope in
+  addition to endpoint/deployment identity, SDK versions, timeout, retries,
+  workload, profile, and legacy API version. Emitted output is endpoint-free,
+  redacted provenance; its digest is not a confidentiality boundary and not a
+  secret.
+- Factory and lease contracts explicitly document synchronous, managed,
+  non-thread-safe lifetimes, shared-factory survival, caller-owned injected
+  credentials, and rejection of async close implementations.
+- `GITHUB_OUTPUT` preserves existing contents/mode, creates new files at mode
+  `0600`, rejects directory/FIFO/socket/symlink/missing-ancestor/parent/control
+  paths, and fails on a short single `O_APPEND` write.
+- Exact local SDK pins now occur once each: `openai==2.46.0`,
+  `azure-core==1.41.0`, `azure-identity==1.25.3`, and
+  `azure-ai-projects==2.3.0`.
+- An offline real-SDK construction smoke created the project and OpenAI clients,
+  verified the canonical base URL plus exact `responses.create`, `files.create`,
+  `files.delete`, fallback `files.content`, `containers.create`,
+  `containers.files.list`, and `containers.files.content.retrieve`
+  capabilities, closed both clients, and proved zero token and HTTP send calls
+  while leaving the injected credential caller-owned. The current runner uses
+  auto-container configuration rather than calling `containers.create`
+  directly; that method remains a project-client compatibility gate.
+- Runtime and workflow integration remains `NOT WIRED`.
+- Raw and serialized `ExperimentConfig` conditions resolve to the same main,
+  QA, and audio/video workload identities.
 
 ## Verification
 
-- Follow-up base: `origin/main@8e473361a12c348ee6fb4d4da6bbfb1d8a2b157f`.
-- Full backend non-integration suite: **1,853 passed, 6 skipped, 44 deselected,
-  0 failed**.
-- Focused manifest/reference, relay, publication, output, bootstrap, inference,
-  corruption, observability, and agentic trust matrix: **361 passed**.
-- Final production-shaped publication/report/subset/relay matrix: **188 passed**;
-  condition isolation and byte-finality matrix: **136 passed**; final status,
-  no-dummy, and cleanup-generation matrix: **156 passed**. The full suite above
-  includes every current version of those tests.
-- Focused trust matrices passed for relay generation/marker/CAS, schema v4
-  source semantics, private reference staging, provider/local/Docker failures,
-  manifest pre-client gates, Step 0 stale-state rejection, Step 4 current-run
-  rebuilding, and Step 7 exact publication. The final Step 0 safety matrix is
-  **65 passed**, relay checkpoint/status matrix is **83 passed**, and HF
-  publication/finality matrix is **86 passed**. The final relay plus publication
-  follow-up matrix is **169 passed**. These include source-first
-  mutation ordering, post-create drift rejection, canonical target columns,
-  exact-generation cleanup, realistic HF cache symlinks, and non-relay
-  file-verification call bounds.
-- Exact public source verification downloaded **1,670,067,990 bytes** at pinned
-  revision `11e7900...`: parquet SHA-256 `f8422fab...`, 220 tasks, 301 physical
-  references, 261 declared references, and 220 unique task projections. Four
-  policy manifest v4 identities reproduced byte-for-byte three times; default
-  manifest SHA-256 is `463fc119...` with 185 needs-files / 35 text-only tasks.
-- Onboarding contracts: **8 passed**; complete frontend data contracts:
-  **85 passed**.
-- Production TypeScript/Vite build and runtime, integrity, perception, and
-  success browser suites all passed.
-- Documentation structure: **157 links**, **100 file/anchor targets**, **12
-  fork-relative Actions routes**, and four system-map SVGs validated with no
-  broken target, unbalanced fence, or `mermaid.ink` dependency.
-- The changed `batch-run.yml` parsed as YAML and its eight-test executable
-  onboarding contract passed; all six external actions remain pinned to
-  40-character SHAs. All eight active workflows parsed as YAML. System
-  `actionlint` was unavailable locally, so no unverified downloaded binary was
-  used. Ruff and `py_compile` passed for **43 changed Python files**; the
-  production TypeScript/Vite build and `git diff --check` also passed.
-  `huggingface-hub==1.24.0` pins the verified write-auth, immutable-revision,
-  and CAS API surface.
-- No workflow dispatch, Azure login, model/API call, batch/grading run, HF write,
-  network checkpoint write, or paid execution occurred. Public source bytes
-  were downloaded read-only to verify canonical identities.
-
-## Shipment
-
-- PR #129 squash-merged as
-  `2d4026056b6e27f5111a94d1089573f6b4938a58` on 2026-07-22.
-- Automatic pull-request run
-  [29919172383](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29919172383)
-  completed with `validate` successful and `deploy` skipped.
-- Automatic `main` push run
-  [29919336511](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/29919336511)
-  completed with both `validate` and GitHub Pages `deploy` successful.
-- These were free automatic repository checks. No `workflow_dispatch`, grading,
-  Step 8, Azure/model API, Hugging Face write, or paid execution ran.
-- Follow-up PR #131 squash-merged as
-  `576e6f4f4a72998f0311d74006373bcea40a3cf6` on 2026-07-22. Its changed paths
-  are outside the Pages workflow's PR/push filters, so GitHub attached no
-  automatic run or check to either the PR head or merge SHA. No manual workflow
-  dispatch was used; the exact PR head was covered by the local full suite and
-  two independent reviews before merge.
+- Base identity:
+  `origin/main@b82d9fea95fb97a1fcbcea6cb6979d09b031afeb`.
+- Detached clean-checkout focused core and CLI contracts: **224 passed in 20.79
+  seconds**.
+- Exact clean-checkout real-SDK smoke: **1 passed in 1.47 seconds**, with all
+  pinned versions and seven capabilities verified and zero token/network calls.
+- Detached clean-checkout credential-free backend non-integration suite:
+  **2,074 passed, 9 skipped, and 44 integration tests deselected in 126.02
+  seconds**.
+- All **20** internally owned credential secret cases and the independent
+  raw/serialized workload parity test passed before the full suite.
+- Ruff reported `All checks passed!` for the four Python implementation/test
+  files; `py_compile` completed with no diagnostics.
+- `pip check` reported `No broken requirements found.` The four exact SDK pins
+  and their package prefixes each occur once.
+- `git diff --check` passed, no conflict markers were found, and status contains
+  exactly the eight intended paths, including the ignored CLI and BOLT files.
+- No token acquisition, network access, Azure/model API call, grading, Hugging
+  Face access/write, workflow execution, or paid operation occurred.
 
 ## Remaining Work
 
-- No repository implementation work remains for this task. The cleanup commit
-  identity follow-up required no paid batch smoke or manual workflow dispatch.
-- Repository branch protection remains a separate administrative control; the
-  exact-main preflight does not replace a protected `main` ruleset.
+- Review and integrate this foundation separately.
+- Wire inference, Code Interpreter, narrative, grading, reporting, and workflow
+  callers only in a later bounded change with separate local validation.


### PR DESCRIPTION
This PR introduces the model-free typed endpoint and client-lifecycle primitives without wiring active runtime or workflows (**foundation only / runtime and workflows NOT WIRED**).

### Exact 8 Modified Paths
- CHANGELOG.md
- batch-runner/core/azure_ai_clients.py
- batch-runner/requirements.txt
- batch-runner/scripts/azure_ai_route_preflight.py
- batch-runner/tests/test_azure_ai_clients.py
- batch-runner/tests/test_azure_ai_route_preflight.py
- tasks/0723_thursday/BOLT_TYPED_AZURE_AI_ENDPOINT_CONTRACTS.md
- tasks/LATEST_TASK_RESULT/README.md

### Contract Principles & Controls
- **Endpoint Shape Validation**: URL classification rejects malformed ports, host lookalikes, non-ASCII text, and trailing dots.
- **Strict Identity Profiles**: Direct, project, and legacy profile configurations verify active environments safely.
- **Fingerprinting**: Captures token scope, endpoint/deployment identity, SDK versions, timeout, retry settings, and workload, creating redacted provenance.
- **Synchronous Lifecycle**: Factory and lease lifetimes are explicit, synchronous, and non-thread-safe.
- **GITHUB_OUTPUT Control**: Accepts only regular non-symlink target paths and target ancestors, ensuring secure mode 0600 output.

### Exact SDK Pins (requirements.txt)
- openai==2.46.0
- azure-core==1.41.0
- azure-identity==1.25.3
- azure-ai-projects==2.3.0

### Local Exact-Commit Detached Clean Evidence
- Focused tests: 224 passed
- SDK smoke test: 1 passed (exact versions/capabilities, zero token/network)
- Full backend non-integration tests: 2074 passed, 9 skipped, 44 deselected
- py_compile: Clean (no diagnostics)
- pip check: Clean (No broken requirements found)
- git diff --check: Clean
- No token/network/Azure/model/HF/workflow/paid execution

### Review & Risk Assessment
- Independent first-reviewer APPROVE and extreme SAFE_WITH_CONDITIONS mandatory 0.
- No token acquisition, network request, Azure/model API operation, HuggingFace lookup, or paid workflow execution.
- Later runtime wiring separate.