### PR TITLE
feat: expose dashboard build provenance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,6 +150,8 @@ jobs:
           # prebuild에서도 aggregate가 실행되지만,
           # 위에서 이미 실행했으므로 2번 실행됨 (멱등이라 OK)
           NODE_ENV: production
+          VITE_BUILD_SHA: ${{ github.sha }}
+          VITE_BUILD_REPOSITORY: ${{ github.repository }}
 
       - name: Verify aggregate contracts and pinned history
         timeout-minutes: 3
@@ -162,6 +164,13 @@ jobs:
       - name: Verify Field Notes in browser
         timeout-minutes: 8
         run: npm run test:notes-browser:dist
+
+      - name: Verify dashboard build provenance in browser
+        timeout-minutes: 8
+        run: npm run test:build-provenance-browser:dist
+        env:
+          EXPECTED_BUILD_SHA: ${{ github.sha }}
+          EXPECTED_BUILD_REPOSITORY: ${{ github.repository }}
 
       - name: Upload Pages artifact
         if: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **Dashboard source-build provenance** - derive the displayed dashboard
+  version from `package.json`, bind Pages builds to the exact checked-out
+  GitHub SHA and repository, and link the footer to that full commit only after
+  strict public-value validation. Local or malformed builds fail closed to a
+  non-link label, while generated-data time remains a separate signal. The
+  existing read-only PR validation job now checks published and local browser
+  states, exact href and accessible name, keyboard focus, and desktop/mobile
+  overflow without adding a workflow or changing Pages permissions. The
+  accompanying refined Bolt records why README restructuring, a duplicate fast
+  gate, and Action pin churn were deferred. Validation passes **3 focused
+  contracts**, **92 aggregate contracts**, the production TypeScript/Vite
+  build, the provenance browser matrix, and all four existing Field Notes
+  browser suites. Independent code and workflow/security reviews returned
+  **APPROVE** after a malformed repository-slug edge case was fixed and covered.
+  No batch, grading, Azure, Hugging Face, deployment, or paid action ran during
+  local validation.
 - **Opt-in typed Azure AI Step 2 wiring** - activate the shipped typed route
   foundation only when `AZURE_AI_ROUTE_PROFILE` is nonempty, while preserving
   the profile-absent legacy constructors, progress shape, result shape, and

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "scripts": {
     "aggregate": "node scripts/aggregate-tests.mjs && node scripts/aggregate-reports.mjs && node scripts/aggregate-grades.mjs && node scripts/aggregate-experiments.mjs && node scripts/aggregate-runtime-note.mjs && node scripts/aggregate-integrity-note.mjs && node scripts/aggregate-perception-note.mjs && node scripts/aggregate-success-note.mjs",
-    "test:aggregate": "node --test scripts/__tests__/aggregate-experiments.test.mjs scripts/__tests__/aggregate-grades.test.mjs scripts/__tests__/aggregate-integrity-note.test.mjs scripts/__tests__/aggregate-perception-note.test.mjs scripts/__tests__/aggregate-runtime-note.test.mjs scripts/__tests__/aggregate-success-note.test.mjs scripts/__tests__/field-notes.test.mjs scripts/__tests__/integrity-note.test.mjs scripts/__tests__/official-filter.test.mjs scripts/__tests__/onboarding-contract.test.mjs scripts/__tests__/perception-note.test.mjs scripts/__tests__/runtime-note.test.mjs scripts/__tests__/success-note.test.mjs",
+    "test:aggregate": "node --test scripts/__tests__/aggregate-experiments.test.mjs scripts/__tests__/aggregate-grades.test.mjs scripts/__tests__/aggregate-integrity-note.test.mjs scripts/__tests__/aggregate-perception-note.test.mjs scripts/__tests__/aggregate-runtime-note.test.mjs scripts/__tests__/aggregate-success-note.test.mjs scripts/__tests__/build-provenance.test.mjs scripts/__tests__/field-notes.test.mjs scripts/__tests__/integrity-note.test.mjs scripts/__tests__/official-filter.test.mjs scripts/__tests__/onboarding-contract.test.mjs scripts/__tests__/perception-note.test.mjs scripts/__tests__/runtime-note.test.mjs scripts/__tests__/success-note.test.mjs",
+    "test:build-provenance": "node --test scripts/__tests__/build-provenance.test.mjs",
+    "test:build-provenance-browser:dist": "node scripts/__tests__/build-provenance.browser.mjs",
+    "test:build-provenance-browser": "npm run build && npm run test:build-provenance-browser:dist",
     "test:integrity-data": "node --test scripts/__tests__/aggregate-integrity-note.test.mjs scripts/__tests__/integrity-note.test.mjs",
     "test:runtime-data": "node --test scripts/__tests__/aggregate-runtime-note.test.mjs scripts/__tests__/runtime-note.test.mjs",
     "test:runtime-browser:dist": "node scripts/__tests__/runtime-note.browser.mjs",

--- a/scripts/__tests__/build-provenance.browser.mjs
+++ b/scripts/__tests__/build-provenance.browser.mjs
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium } from '@playwright/test'
+import { build, preview } from 'vite'
+
+const ROOT = fileURLToPath(new URL('../..', import.meta.url))
+const packageMetadata = JSON.parse(await readFile(new URL('../../package.json', import.meta.url), 'utf8'))
+const expectedSha = process.env.EXPECTED_BUILD_SHA
+const expectedRepository = process.env.EXPECTED_BUILD_REPOSITORY
+
+if (Boolean(expectedSha) !== Boolean(expectedRepository)) {
+  throw new Error('EXPECTED_BUILD_SHA and EXPECTED_BUILD_REPOSITORY must be set together')
+}
+
+async function startPreview(outDir = 'dist') {
+  const server = await preview({
+    root: ROOT,
+    build: { outDir },
+    preview: { host: '127.0.0.1', port: 0 },
+    logLevel: 'silent',
+  })
+  const address = server.httpServer.address()
+  if (!address || typeof address === 'string') throw new Error('Vite preview did not expose a TCP port')
+  return {
+    server,
+    base: `http://127.0.0.1:${address.port}/gdpval-realworks/`,
+  }
+}
+
+async function openDashboard(browser, base, viewport) {
+  const context = await browser.newContext({ viewport, colorScheme: 'dark', reducedMotion: 'reduce' })
+  await context.addInitScript(() => localStorage.setItem('gdpval-about-seen', 'true'))
+  const page = await context.newPage()
+  const runtimeErrors = []
+  page.on('pageerror', (error) => runtimeErrors.push(`pageerror: ${error.message}`))
+  page.on('console', (message) => {
+    if (message.type() === 'error') runtimeErrors.push(`console: ${message.text()}`)
+  })
+  const response = await page.goto(base)
+  try {
+    await page.getByRole('heading', { name: 'GDPVal RealWorks', exact: true }).waitFor()
+  } catch (error) {
+    const body = (await page.locator('body').innerText()).slice(0, 1_000)
+    throw new Error([
+      `Dashboard did not render at ${page.url()} (HTTP ${response?.status() ?? 'unknown'}).`,
+      ...runtimeErrors,
+      `Body: ${body || '<empty>'}`,
+    ].join('\n'), { cause: error })
+  }
+  return { context, page }
+}
+
+async function assertNoOverflow(page) {
+  assert.equal(
+    await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth),
+    false,
+  )
+}
+
+async function assertPublishedBuild(browser, base, sha, repository) {
+  assert.match(sha, /^[0-9a-f]{40}$/)
+  assert.match(repository, /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/)
+  const accessibleLabel = `Dashboard build version ${packageMetadata.version}, source commit ${sha}`
+  const displayLabel = `Dashboard build v${packageMetadata.version} · ${sha.slice(0, 7)}`
+  const commitUrl = `https://github.com/${repository}/commit/${sha}`
+  const { context, page } = await openDashboard(browser, base, { width: 390, height: 844 })
+
+  try {
+    const link = page.getByRole('link', { name: accessibleLabel, exact: true })
+    await link.scrollIntoViewIfNeeded()
+    assert.equal(await link.innerText(), displayLabel)
+    assert.equal(await link.getAttribute('href'), commitUrl)
+    assert.equal(await link.getAttribute('data-build-provenance'), 'published')
+
+    for (let index = 0; index < 250 && !await link.evaluate((node) => node === document.activeElement); index += 1) {
+      await page.keyboard.press('Tab')
+    }
+    assert.equal(await link.evaluate((node) => node === document.activeElement), true)
+    assert.equal(await link.evaluate((node) => node.matches(':focus-visible')), true)
+    assert.notEqual(await link.evaluate((node) => getComputedStyle(node).outlineStyle), 'none')
+    await assertNoOverflow(page)
+
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await page.reload()
+    await page.getByRole('link', { name: accessibleLabel, exact: true }).waitFor()
+    await assertNoOverflow(page)
+  } finally {
+    await context.close()
+  }
+}
+
+async function assertLocalBuild(browser, base) {
+  const accessibleLabel = `Dashboard build v${packageMetadata.version}, local build without a source commit link`
+  const displayLabel = `Dashboard build v${packageMetadata.version} · local build`
+  const { context, page } = await openDashboard(browser, base, { width: 390, height: 844 })
+
+  try {
+    const fallback = page.locator('[data-build-provenance="local"]')
+    await fallback.scrollIntoViewIfNeeded()
+    assert.equal(await fallback.innerText(), displayLabel)
+    assert.equal(await fallback.getAttribute('aria-label'), accessibleLabel)
+    assert.equal(await page.getByRole('link', { name: /Dashboard build/ }).count(), 0)
+    await assertNoOverflow(page)
+  } finally {
+    await context.close()
+  }
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  let localBuildRoot
+
+  try {
+    const publishedPreview = await startPreview()
+    try {
+      if (expectedSha && expectedRepository) {
+        await assertPublishedBuild(browser, publishedPreview.base, expectedSha, expectedRepository)
+      } else {
+        await assertLocalBuild(browser, publishedPreview.base)
+        return
+      }
+    } finally {
+      await publishedPreview.server.close()
+    }
+
+    localBuildRoot = await mkdtemp(join(tmpdir(), 'gdpval-build-provenance-'))
+    const localOutDir = join(localBuildRoot, 'dist')
+    const previousSha = process.env.VITE_BUILD_SHA
+    const previousRepository = process.env.VITE_BUILD_REPOSITORY
+    process.env.VITE_BUILD_SHA = ''
+    process.env.VITE_BUILD_REPOSITORY = ''
+    try {
+      await build({ root: ROOT, build: { outDir: localOutDir, emptyOutDir: true }, logLevel: 'silent' })
+    } finally {
+      if (previousSha === undefined) delete process.env.VITE_BUILD_SHA
+      else process.env.VITE_BUILD_SHA = previousSha
+      if (previousRepository === undefined) delete process.env.VITE_BUILD_REPOSITORY
+      else process.env.VITE_BUILD_REPOSITORY = previousRepository
+    }
+
+    const localPreview = await startPreview(localOutDir)
+    try {
+      await assertLocalBuild(browser, localPreview.base)
+    } finally {
+      await localPreview.server.close()
+    }
+  } finally {
+    await browser.close()
+    if (localBuildRoot) await rm(localBuildRoot, { recursive: true, force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/__tests__/build-provenance.test.mjs
+++ b/scripts/__tests__/build-provenance.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import ts from 'typescript'
+import { parse } from 'yaml'
+
+const readSource = (path) => readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
+
+async function importTypeScriptModule(path) {
+  const source = await readSource(path)
+  const result = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2020 },
+    reportDiagnostics: true,
+  })
+  assert.equal(result.diagnostics?.length ?? 0, 0)
+  return import(`data:text/javascript;base64,${Buffer.from(result.outputText).toString('base64')}`)
+}
+
+test('published build provenance links an exact validated commit', async () => {
+  const { resolveBuildProvenance } = await importTypeScriptModule('src/lib/buildProvenance.ts')
+  const sha = '0123456789abcdef0123456789abcdef01234567'
+
+  assert.deepEqual(resolveBuildProvenance({
+    version: '0.2.0',
+    sha,
+    repository: 'hyeonsangjeon/gdpval-realworks',
+  }), {
+    kind: 'published',
+    version: '0.2.0',
+    shortSha: '0123456',
+    fullSha: sha,
+    repository: 'hyeonsangjeon/gdpval-realworks',
+    commitUrl: `https://github.com/hyeonsangjeon/gdpval-realworks/commit/${sha}`,
+    displayLabel: 'Dashboard build v0.2.0 · 0123456',
+    accessibleLabel: `Dashboard build version 0.2.0, source commit ${sha}`,
+  })
+})
+
+test('local build provenance fails closed for malformed public values', async () => {
+  const { resolveBuildProvenance } = await importTypeScriptModule('src/lib/buildProvenance.ts')
+  const sha = '0123456789abcdef0123456789abcdef01234567'
+  const cases = [
+    { name: 'missing values', input: { version: '0.2.0' } },
+    { name: 'uppercase SHA', input: { version: '0.2.0', sha: sha.toUpperCase(), repository: 'owner/repo' } },
+    { name: 'short SHA', input: { version: '0.2.0', sha: sha.slice(0, -1), repository: 'owner/repo' } },
+    { name: 'missing repository name', input: { version: '0.2.0', sha, repository: 'owner' } },
+    { name: 'extra path segment', input: { version: '0.2.0', sha, repository: 'owner/repo/commit' } },
+    { name: 'URL injection', input: { version: '0.2.0', sha, repository: 'owner/repo?tab=readme' } },
+    { name: 'invalid owner', input: { version: '0.2.0', sha, repository: '-owner/repo' } },
+    { name: 'relative repository', input: { version: '0.2.0', sha, repository: 'owner/..' } },
+    { name: 'invalid version', input: { version: 'release/latest', sha, repository: 'owner/repo' } },
+  ]
+
+  for (const { name, input } of cases) {
+    const provenance = resolveBuildProvenance(input)
+    assert.equal(provenance.kind, 'local', name)
+    assert.equal(provenance.commitUrl, null, name)
+    assert.match(provenance.displayLabel, /local build$/, name)
+  }
+})
+
+test('build wiring exposes only exact public GitHub identity', async () => {
+  const [workflowText, viteSource, dashboardSource, declarations, packageMetadata] = await Promise.all([
+    readSource('.github/workflows/deploy.yml'),
+    readSource('vite.config.ts'),
+    readSource('src/pages/Dashboard.tsx'),
+    readSource('src/vite-env.d.ts'),
+    readSource('package.json').then(JSON.parse),
+  ])
+  const workflow = parse(workflowText)
+  const buildStep = workflow.jobs.validate.steps.find((step) => step.name === 'Build')
+  const browserStep = workflow.jobs.validate.steps.find(
+    (step) => step.name === 'Verify dashboard build provenance in browser',
+  )
+
+  assert.deepEqual(buildStep.env, {
+    NODE_ENV: 'production',
+    VITE_BUILD_SHA: '${{ github.sha }}',
+    VITE_BUILD_REPOSITORY: '${{ github.repository }}',
+  })
+  assert.deepEqual(browserStep.env, {
+    EXPECTED_BUILD_SHA: '${{ github.sha }}',
+    EXPECTED_BUILD_REPOSITORY: '${{ github.repository }}',
+  })
+  assert.match(viteSource, /readFileSync\(new URL\('\.\/package\.json', import\.meta\.url\)/)
+  assert.match(viteSource, /__APP_VERSION__: JSON\.stringify\(packageMetadata\.version\)/)
+  assert.match(declarations, /declare const __APP_VERSION__: string/)
+  assert.match(declarations, /readonly VITE_BUILD_SHA\?: string/)
+  assert.match(declarations, /readonly VITE_BUILD_REPOSITORY\?: string/)
+  assert.match(dashboardSource, /resolveBuildProvenance\(\{/)
+  assert.doesNotMatch(dashboardSource, /v0\.2\.0/)
+  assert.match(packageMetadata.scripts['test:aggregate'], /build-provenance\.test\.mjs/)
+  assert.equal(browserStep.run, 'npm run test:build-provenance-browser:dist')
+})

--- a/src/lib/buildProvenance.ts
+++ b/src/lib/buildProvenance.ts
@@ -1,0 +1,80 @@
+export interface BuildProvenanceInput {
+  version?: unknown
+  sha?: unknown
+  repository?: unknown
+}
+
+export type BuildProvenance =
+  | {
+      kind: 'published'
+      version: string
+      shortSha: string
+      fullSha: string
+      repository: string
+      commitUrl: string
+      displayLabel: string
+      accessibleLabel: string
+    }
+  | {
+      kind: 'local'
+      version: string | null
+      shortSha: null
+      fullSha: null
+      repository: null
+      commitUrl: null
+      displayLabel: string
+      accessibleLabel: string
+    }
+
+const VERSION_PATTERN = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+const SHA_PATTERN = /^[0-9a-f]{40}$/
+const OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
+const REPOSITORY_NAME_PATTERN = /^[A-Za-z0-9._-]{1,100}$/
+
+function validRepositorySlug(value: string): boolean {
+  const segments = value.split('/')
+  if (segments.length !== 2) return false
+  const [owner, repository] = segments
+  return OWNER_PATTERN.test(owner)
+    && REPOSITORY_NAME_PATTERN.test(repository)
+    && repository !== '.'
+    && repository !== '..'
+}
+
+export function resolveBuildProvenance(input: BuildProvenanceInput): BuildProvenance {
+  const version = typeof input.version === 'string' && VERSION_PATTERN.test(input.version)
+    ? input.version
+    : null
+  const sha = typeof input.sha === 'string' && SHA_PATTERN.test(input.sha)
+    ? input.sha
+    : null
+  const repository = typeof input.repository === 'string' && validRepositorySlug(input.repository)
+    ? input.repository
+    : null
+
+  if (version && sha && repository) {
+    const shortSha = sha.slice(0, 7)
+    return {
+      kind: 'published',
+      version,
+      shortSha,
+      fullSha: sha,
+      repository,
+      commitUrl: `https://github.com/${repository}/commit/${sha}`,
+      displayLabel: `Dashboard build v${version} · ${shortSha}`,
+      accessibleLabel: `Dashboard build version ${version}, source commit ${sha}`,
+    }
+  }
+
+  const versionLabel = version ? `v${version}` : 'version unavailable'
+  return {
+    kind: 'local',
+    version,
+    shortSha: null,
+    fullSha: null,
+    repository: null,
+    commitUrl: null,
+    displayLabel: `Dashboard build ${versionLabel} · local build`,
+    accessibleLabel: `Dashboard build ${versionLabel}, local build without a source commit link`,
+  }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@ import { tooltipTexts } from '../data/tooltipTexts'
 import { onboarding } from '../utils/onboarding'
 import { substituteTaskTotal } from '../lib/textFormat'
 import { OFFICIAL_TASK_COUNT } from '../lib/officialFilter'
+import { resolveBuildProvenance } from '../lib/buildProvenance'
 import {
   getDashboardDisplayData,
 } from '../lib/officialExperimentScope.js'
@@ -27,6 +28,12 @@ const TABS: { id: TabKey; label: string; icon: React.ReactNode; color: string }[
   { id: 'errors', label: 'Execution Errors', icon: <AlertTriangle className="w-4 h-4" />, color: '#ef4444' },
   { id: 'grading', label: 'Grading Analysis', icon: <Award className="w-4 h-4" />, color: '#f59e0b' },
 ]
+
+const BUILD_PROVENANCE = resolveBuildProvenance({
+  version: __APP_VERSION__,
+  sha: import.meta.env.VITE_BUILD_SHA,
+  repository: import.meta.env.VITE_BUILD_REPOSITORY,
+})
 
 export default function Dashboard() {
   const navigate = useNavigate()
@@ -316,14 +323,30 @@ export default function Dashboard() {
         className="border-t border-dash-border bg-dash-card/50 mt-16"
       >
         <div className="max-w-[1400px] mx-auto px-3 md:px-6 py-4 md:py-6 flex flex-col md:flex-row items-center justify-between gap-1 text-xs text-dash-text-faint">
-          <div>
-            {generated && (
-              <p>Generated {new Date(generated).toLocaleString()}</p>
-            )}
-          </div>
-          <a href="https://github.com/hyeonsangjeon/gdpval-realworks" className="hover:text-dash-text-secondary transition-colors">
-            GDPVal RealWorks • v0.2.0
-          </a>
+          {generated ? (
+            <p aria-label="Dashboard data generation time">
+              Data generated {new Date(generated).toLocaleString()}
+            </p>
+          ) : <span />}
+          {BUILD_PROVENANCE.kind === 'published' ? (
+            <a
+              href={BUILD_PROVENANCE.commitUrl}
+              aria-label={BUILD_PROVENANCE.accessibleLabel}
+              title={BUILD_PROVENANCE.accessibleLabel}
+              data-build-provenance="published"
+              className="max-w-full rounded-sm text-center font-mono text-[11px] text-dash-text-secondary hover:text-dash-heading transition-colors"
+            >
+              {BUILD_PROVENANCE.displayLabel}
+            </a>
+          ) : (
+            <span
+              aria-label={BUILD_PROVENANCE.accessibleLabel}
+              data-build-provenance="local"
+              className="max-w-full text-center font-mono text-[11px] text-dash-text-secondary"
+            >
+              {BUILD_PROVENANCE.displayLabel}
+            </span>
+          )}
         </div>
       </motion.footer>
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string
+
+interface ImportMetaEnv {
+	readonly VITE_BUILD_SHA?: string
+	readonly VITE_BUILD_REPOSITORY?: string
+}

--- a/tasks/0725_saturday/BOLT_README_EVIDENCE_AND_BUILD_PROVENANCE.md
+++ b/tasks/0725_saturday/BOLT_README_EVIDENCE_AND_BUILD_PROVENANCE.md
@@ -1,0 +1,143 @@
+# Bolt: README Evidence Audit and Dashboard Build Provenance
+
+- Date: 2026-07-25
+- Base: `f849856c6a91c357becc74ae93b60a5c9289917f`
+- Status: build-provenance slice implemented and locally validated
+- External reference: `open-webui/open-webui@ecd48e2f718220a6400ecf49eafd4867a38feb10`
+- External license signal: `NOASSERTION`; no external code or copy is reused
+
+## Decision
+
+The supplied improvement brief was re-audited against current `main` after the
+Foundry migration. Only dashboard build provenance remains non-duplicative.
+README conversion, a new fast PR workflow, and Action pin changes are deferred.
+This Bolt does not modify batch, grading, publication, or Foundry semantics.
+
+The traffic snapshot supplied with the brief informed prioritization but is not
+committed here: repository task records are public and traffic analytics are not
+an implementation acceptance source.
+
+## Evidence Reviewed
+
+- Complete `README.md`, including first-screen evidence, local preview,
+  three-task cloud run, result inspection, and trust-boundary sections.
+- Complete `.github/workflows/deploy.yml`, including path filters,
+  concurrency, exact checkout, PR validation, browser checks, permissions, and
+  main-only Pages deployment.
+- `package.json`, `package-lock.json`, `vite.config.ts`, and `src/vite-env.d.ts`.
+- Actual application shell and display surfaces under `src/`, including the
+  dashboard footer and About modal.
+- Existing browser-test harness under `scripts/__tests__`.
+- Current workflow list and Action references.
+- External comparison commit and license metadata only.
+
+## Defer Report
+
+### README evidence conversion: deferred as duplicate
+
+Current README first screen already exposes live evidence, a credential-free
+local preview, a three-task cloud path, result/artifact inspection, and explicit
+cost/write boundaries. Existing onboarding contracts enforce those links and
+semantics. No screenshot is added because it would duplicate current evidence
+paths and introduce an unowned freshness obligation.
+
+### Fast PR gate: deferred as duplicate
+
+`deploy.yml` already provides a read-only PR job with exact checkout, `npm ci`,
+aggregation, production build, aggregate contracts, Chromium installation, and
+browser verification. Pages permissions and deployment remain main-only. A
+second workflow would duplicate cost and feedback without adding a failure
+boundary.
+
+### Action pin changes: deferred
+
+The active deploy/preflight Actions are already pinned to 40-character SHAs.
+The brief's `validate-hybrid-and-decide.yml` target no longer exists. No
+reviewed replacement pin set is available, so no supply-chain churn is made.
+
+## Implementation Contract
+
+### Public inputs
+
+Expose only:
+
+- package version from `package.json`;
+- exact build SHA from `VITE_BUILD_SHA`;
+- repository slug from `VITE_BUILD_REPOSITORY`.
+
+Never expose the environment object, token, endpoint, workflow payload, actor,
+ref, or credential. Repository and SHA values are validated before producing a
+GitHub link.
+
+### Build behavior
+
+- `vite.config.ts` injects the package version as a compile-time constant.
+- The deploy Build step passes exact `${{ github.sha }}` and
+  `${{ github.repository }}` through the two public Vite variables.
+- The existing exact-checkout guard remains the source-to-artifact boundary.
+- Local builds or malformed public values display a non-link `local build`
+  state rather than constructing an untrusted URL.
+
+### UI behavior
+
+- Replace the hardcoded dashboard footer version with one compact provenance
+  label.
+- A valid build links to the exact GitHub commit using the full SHA while the
+  visible label uses the seven-character SHA.
+- The link has an explicit accessible name, visible keyboard focus, sufficient
+  contrast, and must not cause mobile overflow.
+- The build label is distinct from the generated-data timestamp and does not
+  imply experiment, model, or Foundry provenance.
+
+## File-Level Work Order
+
+- [x] `vite.config.ts`: inject the package version from parsed `package.json`.
+- [x] `.github/workflows/deploy.yml`: pass exact public SHA/repository values to
+      the Build step only.
+- [x] `src/vite-env.d.ts`: declare the compile-time version constant.
+- [x] `src/lib/buildProvenance.ts`: validate and project public build identity.
+- [x] `src/pages/Dashboard.tsx`: render the accessible footer provenance.
+- [x] `package.json`: wire focused unit and dist browser tests.
+- [x] `scripts/__tests__/build-provenance.test.mjs`: validate source/config/UI
+      contracts and invalid-value fallback.
+- [x] `scripts/__tests__/build-provenance.browser.mjs`: validate rendered text,
+      full-SHA link, keyboard focus, and mobile overflow.
+- [x] `CHANGELOG.md` and `tasks/LATEST_TASK_RESULT/README.md`: record the final
+      result after validation.
+
+## Validation Result
+
+- Focused build-provenance contracts: **3 passed, 0 failed**.
+- Frontend/data aggregate contracts: **92 passed, 0 failed**.
+- Production TypeScript and Vite build passed with an explicit 40-character
+  SHA and repository slug.
+- Published and local browser states passed exact-link, accessible-name,
+  keyboard-focus, and desktop/mobile overflow checks.
+- Runtime, integrity, perception, and success browser suites all passed.
+- Editor diagnostics and `git diff --check` passed.
+- Independent code and workflow/security re-reviews returned **APPROVE** after
+  a slashless repository-slug edge case was reproduced, repaired, and covered.
+- `actionlint` was unavailable locally; the changed workflow parsed with the
+  installed YAML parser and is covered by the aggregate wiring contract.
+- No batch, grading, Azure, Hugging Face, deployment, or paid action ran during
+  local validation.
+
+## Acceptance Criteria
+
+- `npm ci`, `npm run test:aggregate`, and `npm run build` pass.
+- Focused provenance unit and browser tests pass.
+- A build with a valid 40-character SHA displays package version plus short SHA
+  and links to the exact full commit.
+- A local or malformed build displays `local build` without a commit link.
+- The production Pages workflow injects the exact checked-out GitHub SHA.
+- Pull requests receive no Pages/OIDC write privileges.
+- The footer is keyboard accessible and has no horizontal overflow at desktop
+  and mobile viewports.
+- Existing Field Notes browser suites remain green.
+- No batch, grading, Azure, Hugging Face, or paid execution is performed.
+
+## Rollback
+
+Revert this provenance PR only. The fallback is the existing repository link in
+the dashboard footer; benchmark results, datasets, workflows outside
+`deploy.yml`, and remote project state are outside rollback scope.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -4,171 +4,90 @@ This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
 - Updated: 2026-07-25
-- Status: Foundry route migration shipped through PR #140; automatic PR
-  validation and the post-merge `main` validation/Pages deployment passed.
-  Separately approved remote paid/write validation remains pending
+- Status: refined Bolt implemented and locally validated; PR shipment pending
 
 ## Task
 
-- Complete the Microsoft Foundry migration on top of the already shipped typed
-  endpoint foundation, runtime adapters, and Step 2 wiring from PRs #134-#139.
-- Use direct `/openai/v1/` routes for inference, narrative, and grading; reserve
-  the project endpoint for Code Interpreter; keep dated Azure OpenAI as an
-  explicit rollback-only profile.
-- Enforce OIDC/`DefaultAzureCredential`, independent expected Azure identities,
-  route-specific token audiences, endpoint-free provenance, and deterministic
-  client ownership across workflows and consumers.
-- Bind the exact prepared, result, task, route, and runtime identity through
-  relay checkpoints, reports, HF publication, grading cache/resume, and
-  diagnostic outputs.
+- Re-audit the supplied README/evidence improvement Bolt against current
+  `main` after the Foundry migration.
+- Save a refined repository task before implementation, defer already-shipped
+  or invalid work, and complete the remaining non-duplicative work.
+- Preserve batch, grading, publication, Foundry, permission, and paid-execution
+  semantics.
 
 ## Result
 
-- Rebased onto `origin/main@bfa2bb70a063ba621f95929c69b7218e4dce9563`
-  and preserved the shipped BOLT documents plus the 2,567-line Step 2 wiring
-  regression layer unchanged except for intentional final-contract assertions.
-- Batch and grading workflows now preflight every config-derived Azure workload
-  before remote writes. Direct/project routes acquire
-  `https://ai.azure.com/.default`; only an explicitly authorized legacy route
-  acquires the Cognitive Services audience.
-- Added independent expected client, tenant, and subscription variables.
-  Configured secrets are checked before login; the active subscription/tenant
-  and Azure AI JWT `tid`, `azp`/`appid`, exact `aud`, `nbf`, and `exp` claims
-  are checked after login without printing IDs or tokens.
-- Strict endpoint identity is profile-specific, including
-  `AZURE_AI_EXPECTED_LEGACY_ACCOUNT` for rollback-only dated endpoints.
-- Code Interpreter is Azure project-route and injected-client only. Untyped
-  endpoint overrides, static API keys, and internal credential/client fallback
-  paths are removed; the Step 2 runtime owner closes the executor, provider
-  clients, managed clients, project owners, and shared factory exactly once.
-  Runtime mode selection, route selection, and restored-route validation reject
-  missing, direct, and legacy Code Interpreter profiles before any client is
-  constructed.
-- Step 2 verifies every managed main, Self-QA, Code Interpreter, and Azure
-  audio/video preprocessor client against the exact planned workload,
-  deployment, profile, endpoint kind, and runtime fingerprint before use.
-- Typed relay/wall-timeout checkpoints recompute and bind exact route records.
-  One shared versioned per-status result validator rejects unknown statuses,
-  missing terminal fields, output-free successes, and noncanonical deliverable
-  paths at local save, local restore, relay status, and relay upload boundaries.
-- Reserved Azure hardened/agentic runs require a typed route profile. Their
-  route plan is computed model-free, while credential and managed-client
-  construction remain deferred until after signed authorization and budget
-  reservation. The runner owns and closes the deferred client, including a
-  factory candidate that fails capability validation with `Exception` or
-  `SystemExit` before ownership transfer.
-- The common hardened baseline closes its deferred provider client after every
-  task and any residual client during idempotent runner shutdown. Normal,
-  failed, consecutive, and cleanup-failure paths close exactly once; cleanup
-  failures retain only `provider_cleanup_failed:<Type>`.
-- Provider failures are projected to stable endpoint- and message-free public
-  identities before checkpoint and final-result fingerprinting. Raw provider
-  URLs do not enter relay checkpoints, public self-reports, final Step 2
-  artifacts, v1 grade diagnostics, audio preparation/dispatch errors, or
-  agentic cleanup errors.
-- Step 6 makes only its primary `gpt-5.4-pro` narrative calls; any setup, call,
-  parse, or route-validation failure immediately emits a model-free report.
-  The unused experiment-model fallback path and its misleading cost contract
-  were removed. Invalid, partial, empty, or whitespace-only first-call fields
-  stop the second paid call.
-- Main, audio, and vision provider failures plus local tool exceptions are
-  projected to class-only stable identities before logs or grade diagnostics.
-  Deferred agentic-client cleanup clears the owned reference in `finally` and
-  exposes no raw exception cause or context if provider close fails.
-- Step 8 binds cache, resume, every partial/final/diagnostic payload, and the
-  constructed grader to the exact non-null primary grader route fingerprint;
-  matching a tier or perception route is insufficient. v1 batch errors and
-  init/cleanup failures are class-only, owned references clear on close failure,
-  and durable exit codes 0, 6, and 7 survive cleanup errors. A shared validator
-  enforces schema plus primary-route equality in Step 8 and both workflow
-  commit gates before and after rebase.
-- Perception-note skill discovery ignores generated hidden and `__pycache__`
-  directories, so compile validation cannot perturb frontend aggregation.
-- `inference_provenance.json` is mandatory for publishable grading, participates
-  in the HF CAS plan/receipt/finality tree, and binds exact prepared fingerprint,
-  ordered tasks, execution mode, and Azure routes. Schema v2 rejects route-less
-  or non-project Code Interpreter provenance throughout formatting, download,
-  bootstrap, and publication. Missing provenance is accepted only through an
-  explicit non-publishable legacy-analysis override.
-- Relay cleanup finality revalidates the exact cleanup child against the full
-  publication plan, including optional README bytes, not only managed data and
-  deliverable paths.
-- Any explicit `--tasks` or positive `--limit` grading run uses
-  `run_status: diagnostic` and a full ordered-task-hash path, even when it
-  selects every source task. Nested grade/analysis paths propagate through
-  exact workflow outputs, commits, and artifacts.
-- Cost sweeps remove archived endpoint fields, validate against the typed
-  config, hash repository-contained generated configs with symlink/outside
-  guards, and consume only Step 8's exact private `GITHUB_OUTPUT` path.
-- English/Korean onboarding documents the strict OIDC identities, direct,
-  project, and rollback-only routes, token audiences, provenance, and
-  diagnostic grading behavior.
+- Saved `tasks/0725_saturday/BOLT_README_EVIDENCE_AND_BUILD_PROVENANCE.md` with
+  current-main evidence, defer decisions, implementation boundaries,
+  acceptance criteria, and rollback.
+- Deferred README restructuring because the first screen already exposes live
+  evidence, credential-free local preview, a three-task cloud path, artifact
+  inspection, and explicit cost/write boundaries backed by onboarding tests.
+- Deferred a new fast PR workflow because `deploy.yml` already runs exact
+  checkout, aggregation, production build, aggregate contracts, and Chromium
+  checks with read-only PR permissions and main-only Pages deployment.
+- Deferred Action pin churn because the named workflow target no longer exists,
+  active relevant Actions are SHA-pinned, and no reviewed replacement pin set
+  was supplied.
+- Replaced the hardcoded footer version with package-derived dashboard build
+  provenance. A valid lowercase 40-character SHA and two-segment repository
+  slug produce a fixed GitHub full-commit link with a short visible SHA.
+- Missing or malformed version, SHA, or repository values fail closed to an
+  accessible, non-link local-build label.
+- Kept dashboard source-build identity separate from the generated-data
+  timestamp and from experiment, model, Foundry, and grading provenance.
+- Added exact compile-time declarations and limited the Build-step public inputs
+  to `${{ github.sha }}` and `${{ github.repository }}`. No environment object,
+  token, endpoint, ref, actor, or workflow payload enters the bundle.
+- Extended the existing PR validation job rather than creating another
+  workflow. Pages and OIDC write permissions remain isolated to the main-only
+  deploy job.
+- Added focused contracts and production-browser checks for exact links,
+  invalid-input fallback, accessible names, keyboard focus, and desktop/mobile
+  overflow.
+- External comparison used only commit/license metadata and a general
+  provenance pattern. No external code or copy was reused.
 
 ## Verification
 
-- Base: `origin/main@bfa2bb70a063ba621f95929c69b7218e4dce9563`.
-- Complete backend non-integration suite: **2,328 passed, 6 skipped,
-  44 integration tests deselected, 0 failed**.
-- Azure foundation and route-preflight regression: **229 passed, 0 failed**.
-- The exact failed CI command, `npm run test:aggregate`, now passes **89/89**;
-  a fresh subprocess explicitly blocks both `azure` and `openai` imports while
-  model-free route planning succeeds.
-- Final hardened lifecycle matrix: **172 passed, 0 failed**.
-- Final Code Interpreter, provenance, publication, grading schema, and workflow
-  follow-up matrix: **762 passed, 0 failed**; the complete suite above includes
-  the same fixes.
-- Final publication/narrative matrix: **157 passed, 0 failed**.
-- Frontend/data contracts: **89 passed, 0 failed**.
-- Root model-free cost-sweep and perception-probe tests: **16 passed**.
-- Executable onboarding contract: **9 passed, 0 failed**.
-- Production TypeScript/Vite build passed; runtime, integrity, perception, and
-  success browser suites all passed against the production build.
-- Ruff and `py_compile` passed for all **67 changed Python files**.
-- `actionlint` passed separately for `batch-run.yml` and `grade-run.yml`;
-  `bash -n` passed for `step7_upload_hf.sh`.
-- Mandatory workflow/publication/security review returned **GO**. Subsequent
-  exact-tree review found six route, checkpoint, grading identity/redaction,
-  agentic acquisition, and record gaps plus one token-claim advisory. Every
-  finding was reproduced and repaired; its re-review found two follow-up mode
-  and shared-validation gaps, which were also repaired and covered before the
-  final full-suite run. A later re-review found full-plan cleanup and empty
-  narrative gaps; both were repaired and covered. The final independent
-  re-review found one hardened deferred-client lifecycle leak; it was
-  reproduced, repaired, and covered before the final full-suite run. Exact
-  clean-tree head `c396ab5f5a4b1c9b07fabaac894642a41074c185` received final
-  independent **APPROVE** with no remaining blocker, major, or minor finding.
-- `git diff --check` passed. The latest-main candidate spans **97 files**.
-- Local pre-shipment validation used no workflow dispatch, credential or token
-  acquisition, Azure/model API call, grading run, Hugging Face write, network
-  checkpoint write, deployment, or paid execution.
+- Base and current remote main:
+  `f849856c6a91c357becc74ae93b60a5c9289917f` with 0 ahead / 0 behind before
+  commit.
+- Focused build-provenance contracts: **3 passed, 0 failed**.
+- Frontend/data aggregate contracts: **92 passed, 0 failed, 0 skipped**.
+- Production TypeScript and Vite build passed with explicit exact SHA and
+  repository inputs.
+- The provenance browser matrix passed both the published exact-commit state
+  and a separately generated local-build fallback. It verified full-SHA href,
+  short-SHA display, accessible name, actual keyboard focus, visible focus
+  outline, and no horizontal overflow at mobile and desktop viewports.
+- Runtime, integrity, perception, and success browser suites all passed against
+  the production dist.
+- Editor diagnostics reported no errors in every changed source, test, config,
+  and workflow file.
+- `git diff --check` passed; no generated or dist artifact is modified or
+  untracked.
+- `actionlint` was unavailable locally. The changed workflow parsed with the
+  installed YAML parser, and the aggregate contract verifies exact Build and
+  browser-step wiring.
+- First review found one fail-closed defect where a slashless repository slug
+  could be accepted through regex coercion. The defect was reproduced, fixed by
+  requiring exactly two segments, and covered by a regression case. Subsequent
+  code and mandatory workflow/security re-reviews both returned **APPROVE** with
+  no remaining finding.
+- No workflow dispatch, deployment, credential or token acquisition, Azure or
+  model call, grading run, Hugging Face write, network checkpoint write, or paid
+  execution occurred during local work.
 
 ## Shipment
 
-- PR #140 squash-merged as
-  `f730068a64b2ebe04c42eb68cea696fd69e1e978` on 2026-07-25 from exact head
-  `78fc4482f42bbcec8755457e355f66f9ff0963ed`.
-- The first PR run
-  [30145929181](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/30145929181)
-  exposed the eager Azure SDK import in the Node-only aggregate step. The lazy
-  import fix then passed the complete backend and exact aggregate command.
-- The updated PR run
-  [30146185099](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/30146185099)
-  completed `validate` successfully with `deploy` skipped.
-- Automatic `main` push run
-  [30146254229](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/30146254229)
-  completed both `validate` and GitHub Pages `deploy` successfully.
-- These were free automatic repository checks. No manual workflow dispatch,
-  Azure credential/token acquisition, model call, grading run, Hugging Face
-  write, network checkpoint write, or paid execution occurred.
+- Implementation branch: `feat/readme-evidence-paths`.
+- Commit, pull request, automatic validation, merge, and post-merge Pages
+  deployment are pending.
 
 ## Remaining Work
 
-- No repository implementation or delivery work remains for this task.
-- Configure the independent OIDC expected-ID variables and expected
-  direct/project account/project-name variables in repository settings.
-  Configure `AZURE_AI_EXPECTED_LEGACY_ACCOUNT` only for an explicitly approved
-  rollback exercise.
-- Run a separately approved real Foundry route/token smoke with artifact-level
-  acceptance before any paid batch or grading execution. Required deployment
-  aliases, expected identities, and complete audio coverage are not currently
-  available in one verified Azure account, so no values were guessed.
+- Commit and push the reviewed tree, open a pull request, wait for the automatic
+  read-only validation, and merge only after it passes.
+- Record the exact PR, merge SHA, and automatic `main` validation/Pages run in a
+  docs-only shipment follow-up.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,23 @@
+import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+
+const packageMetadata = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf8'),
+) as { version?: unknown }
+
+if (typeof packageMetadata.version !== 'string') {
+  throw new Error('package.json must define a string version')
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   base: '/gdpval-realworks/',
+  define: {
+    __APP_VERSION__: JSON.stringify(packageMetadata.version),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
- Summary: re-audited the supplied Bolt; deferred README rewrite, duplicate fast gate, and Action pin churn; implemented only dashboard source-build provenance.
- Implementation: package-derived version, strict lowercase 40-SHA + two-segment repo validation, exact full commit link, local non-link fallback, existing deploy validation wiring only.
- Security: only public github.sha/repository passed; PR stays contents:read; Pages/OIDC main-only; no Foundry/batch/grading/HF semantics.
- Validation: focused 3/3; aggregate 92/92; production tsc/Vite build; published+local provenance browser matrix including focus/overflow; existing browser suites 4/4; diff check; independent code/workflow reviews APPROVE; actionlint unavailable but YAML parse and wiring contract pass.
- No paid/cloud/write operations during local work.
