### PR TITLE
Adopt GPT-5.6 Sol Max for narrative and grading

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -285,7 +285,6 @@ jobs:
           from core.azure_ai_clients import (
             AzureAIWorkload,
             inference_route_workloads,
-            narrative_route_workloads,
           )
           from core.experiment_config import ExperimentConfig
           from core.repository_identity import validate_hf_dataset_repo_id
@@ -356,18 +355,13 @@ jobs:
             provider_requirements.add(condition.model.provider)
             for preprocessor in condition.preprocessors or []:
               provider_requirements.add(preprocessor["model"]["provider"])
-          azure_workloads = [(AzureAIWorkload.NARRATIVE, "gpt-5.4-pro")]
+          azure_workloads = [(AzureAIWorkload.NARRATIVE, "gpt-5.6-sol")]
           for condition_name in ("condition_a", "condition_b"):
             condition = config.get(condition_name)
             if condition is not None:
               azure_workloads.extend(
                 inference_route_workloads(condition, str(mode or "subprocess"))
               )
-              model = condition.get("model") or {}
-              if model.get("provider", "azure") in {"azure", "azure_openai"}:
-                azure_workloads.extend(
-                  narrative_route_workloads(str(model.get("deployment", "")))
-                )
           values = {
             "install_libreoffice": str(
               execution.get("install_libreoffice") is True
@@ -940,6 +934,10 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           EXPECTED_TARGET_HEAD: ${{ steps.step0.outputs.target_head }}
+          AZURE_AI_ROUTE_PROFILE: direct-v1
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
+          AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
         run: |
           cd batch-runner
           bash step7_upload_hf.sh --test
@@ -967,6 +965,10 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           SOURCE_REPO: ${{ steps.read_config.outputs.source_repo }}
           EXPECTED_GENERATION: ${{ inputs.relay_run > 0 && steps.restore_checkpoint.outputs.generation || '' }}
+          AZURE_AI_ROUTE_PROFILE: direct-v1
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
+          AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
         run: |
           set -euo pipefail
           cd batch-runner
@@ -978,10 +980,17 @@ jobs:
               load_publication_identity,
               verify_publication_finality,
           )
+          from core.narrative_analyzer import (
+              expected_narrative_publication_identity,
+          )
 
+          model, effort, fingerprint = expected_narrative_publication_identity()
           identity = load_publication_identity(
               Path("workspace/step1_tasks_prepared.json"),
               Path("workspace/step2_inference_results.json"),
+              expected_narrative_model=model,
+              expected_narrative_reasoning_effort=effort,
+              expected_narrative_runtime_fingerprint=fingerprint,
           )
           repo_id = os.environ["SOURCE_REPO"]
           if identity.repo_id != repo_id:

--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -11,7 +11,7 @@ on:
         description: "Grading config file under batch-runner/grading_configs/"
         required: true
         type: string
-        default: "default_gpt5pro.yaml"
+        default: "default_v2_sol_max.yaml"
       inference_revision:
         description: "Full HF dataset commit SHA for resume; blank resolves initial main"
         required: false
@@ -31,6 +31,11 @@ on:
         description: "Classify only, no LLM calls"
         required: false
         type: boolean
+        default: true
+      paid_approval:
+        description: "Explicitly authorize paid model calls (protected environment also required)"
+        required: false
+        type: boolean
         default: false
       resume:
         description: "Resume from existing partial grade JSON (chunked execution)"
@@ -44,16 +49,14 @@ on:
         default: 0
 
 permissions:
-  contents: write
-  id-token: write
-  actions: write  # required for self-retrigger via gh workflow run
+  contents: read
 
 concurrency:
   group: grade-${{ inputs.experiment_yaml }}-${{ inputs.grading_config }}
   cancel-in-progress: false
 
 jobs:
-  grade:
+  validate-request:
     runs-on: ubuntu-24.04
     env:
       GRADE_EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
@@ -62,14 +65,9 @@ jobs:
       GRADE_FORCE: ${{ inputs.force }}
       GRADE_TASKS_LIMIT: ${{ inputs.tasks_limit }}
       GRADE_DRY_RUN: ${{ inputs.dry_run }}
+      GRADE_PAID_APPROVAL: ${{ inputs.paid_approval }}
       GRADE_RESUME: ${{ inputs.resume }}
       GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
-    # GH Actions hosted runners have a HARD 6h (360min) timeout that cannot be
-    # extended. We set 320min so step8_grade.py's internal 4h time guard (env
-    # GRADER_TIME_BUDGET_SEC=14400) trips first, partial-saves, and exits 7,
-    # leaving ~40min headroom for the commit + retrigger steps below.
-    timeout-minutes: 320
-
     steps:
       - name: Validate workflow context and inputs
         shell: bash
@@ -110,13 +108,21 @@ jobs:
             exit 1
           fi
 
-          for boolean_name in GRADE_FORCE GRADE_DRY_RUN GRADE_RESUME; do
+          for boolean_name in GRADE_FORCE GRADE_DRY_RUN GRADE_PAID_APPROVAL GRADE_RESUME; do
             boolean_value="${!boolean_name}"
             if [[ "$boolean_value" != "true" && "$boolean_value" != "false" ]]; then
               echo "::error::$boolean_name must be exactly true or false"
               exit 1
             fi
           done
+          if [[ "$GRADE_DRY_RUN" != "true" && "$GRADE_PAID_APPROVAL" != "true" ]]; then
+            echo "::error::non-dry grading requires paid_approval=true"
+            exit 1
+          fi
+          if [[ "$GRADE_DRY_RUN" == "true" && "$GRADE_PAID_APPROVAL" != "false" ]]; then
+            echo "::error::dry-run grading must not request paid approval"
+            exit 1
+          fi
           if [[ ! "$GRADE_TASKS_LIMIT" =~ ^(0|[1-9][0-9]{0,2})$ ]] ||
              (( 10#$GRADE_TASKS_LIMIT > 220 )); then
             echo "::error::tasks_limit must be an integer between 0 and 220"
@@ -138,6 +144,145 @@ jobs:
             echo "::error::resume_chunk must be 0 when resume is false"
             exit 1
           fi
+
+  approve-paid:
+    name: Approve paid Sol Max grading (${{ inputs.experiment_yaml }}, ${{ inputs.grading_config }}, chunk ${{ inputs.resume_chunk }})
+    needs: validate-request
+    if: inputs.dry_run == false && inputs.paid_approval == true
+    runs-on: ubuntu-24.04
+    environment:
+      name: grading
+    steps:
+      - name: Record approved request
+        env:
+          GRADE_EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
+          GRADE_CONFIG: ${{ inputs.grading_config }}
+          GRADE_INFERENCE_REVISION: ${{ inputs.inference_revision }}
+          GRADE_TASKS_LIMIT: ${{ inputs.tasks_limit }}
+          GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
+        run: |
+          printf '%s\n' \
+            "Approved paid grading request:" \
+            "  experiment=$GRADE_EXPERIMENT_YAML" \
+            "  config=$GRADE_CONFIG" \
+            "  inference_revision=${GRADE_INFERENCE_REVISION:-initial-main-resolution}" \
+            "  tasks_limit=$GRADE_TASKS_LIMIT" \
+            "  resume_chunk=$GRADE_RESUME_CHUNK"
+
+  grade-dry-run:
+    needs: validate-request
+    if: inputs.dry_run == true
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      GRADE_EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
+      GRADE_CONFIG: ${{ inputs.grading_config }}
+      GRADE_INFERENCE_REVISION: ${{ inputs.inference_revision }}
+      GRADE_TASKS_LIMIT: ${{ inputs.tasks_limit }}
+      HF_HUB_DISABLE_IMPLICIT_TOKEN: '1'
+    steps:
+      - name: Checkout exact main revision (read-only)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Verify read-only checkout and input files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]]; then
+            echo "::error::checked out HEAD does not match the dispatched main SHA"
+            exit 1
+          fi
+          if [[ "$(git symbolic-ref --quiet --short HEAD)" != "main" ]]; then
+            echo "::error::checkout is not on the local main branch"
+            exit 1
+          fi
+          if [[ "$(git rev-parse refs/remotes/origin/main)" != "$GITHUB_SHA" ]]; then
+            echo "::error::origin/main moved after dispatch; retry from the new main"
+            exit 1
+          fi
+          if git config --local --name-only --get-regexp '^http\..*\.extraheader$' >/dev/null; then
+            echo "::error::dry-run checkout must not retain repository credentials"
+            exit 1
+          fi
+
+          EXPERIMENT_PATH="batch-runner/experiments/${GRADE_EXPERIMENT_YAML}.yaml"
+          CONFIG_PATH="batch-runner/grading_configs/${GRADE_CONFIG}"
+          for input_path in "$EXPERIMENT_PATH" "$CONFIG_PATH"; do
+            if [[ ! -f "$input_path" || -L "$input_path" ]]; then
+              echo "::error::required input must be a regular non-symlink file: $input_path"
+              exit 1
+            fi
+          done
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          cd batch-runner
+          pip install -r requirements.txt
+
+      - name: Download inference results anonymously
+        run: |
+          cd batch-runner
+          python scripts/download_inference_from_hf.py \
+            --experiment "$GRADE_EXPERIMENT_YAML" \
+            --output workspace/step2_inference_results.json \
+            --revision "$GRADE_INFERENCE_REVISION"
+
+      - name: Classify grading work only
+        run: |
+          cd batch-runner
+          ARGS=(
+            "$GRADE_EXPERIMENT_YAML"
+            --config "grading_configs/$GRADE_CONFIG"
+            --source local
+            --dry-run
+          )
+          if [[ "$GRADE_TASKS_LIMIT" != "0" ]]; then
+            ARGS+=(--limit "$GRADE_TASKS_LIMIT")
+          fi
+          python step8_grade.py "${ARGS[@]}"
+
+  grade:
+    needs: [validate-request, approve-paid]
+    if: >-
+      ${{
+        inputs.dry_run == false &&
+        inputs.paid_approval == true &&
+        needs.validate-request.result == 'success' &&
+        needs.approve-paid.result == 'success'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+      actions: write  # required for self-retrigger via gh workflow run
+    env:
+      GRADE_EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
+      GRADE_CONFIG: ${{ inputs.grading_config }}
+      GRADE_INFERENCE_REVISION: ${{ inputs.inference_revision }}
+      GRADE_FORCE: ${{ inputs.force }}
+      GRADE_TASKS_LIMIT: ${{ inputs.tasks_limit }}
+      GRADE_DRY_RUN: ${{ inputs.dry_run }}
+      GRADE_PAID_APPROVAL: ${{ inputs.paid_approval }}
+      GRADE_RESUME: ${{ inputs.resume }}
+      GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
+    # GH Actions hosted runners have a HARD 6h (360min) timeout that cannot be
+    # extended. We set 320min so step8_grade.py's internal 4h time guard (env
+    # GRADER_TIME_BUDGET_SEC=14400) trips first, partial-saves, and exits 7,
+    # leaving ~40min headroom for the commit + retrigger steps below.
+    timeout-minutes: 320
+
+    steps:
 
       - name: Checkout exact main revision
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -517,6 +662,7 @@ jobs:
             -f force=false \
             -f tasks_limit="$GRADE_TASKS_LIMIT" \
             -f dry_run=false \
+            -f paid_approval="$GRADE_PAID_APPROVAL" \
             -f resume=true \
             -f resume_chunk=$NEXT_CHUNK
           echo "[auto-resume] chunk $NEXT_CHUNK dispatched"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **GPT-5.6 Sol Max narrative and grading production policy** - move the
+  dashboard narrative analyzer and the default v2 grading profile to
+  `gpt-5.6-sol` with `reasoning_effort=max`; use the same identity for the
+  main judge, visual perception, and bounded no-tools finalization while
+  retaining `gpt-audio-1.5` for audio. Step 6 and Hugging Face publication now
+  bind model, effort, runtime fingerprint, and model-backed narrative content;
+  explicit all-null identity plus empty narrative remains the only model-free
+  fallback. Semantic-invalid final envelopes receive one independent bounded
+  retry, and grade schema 1.2 keeps unknown prices fail-closed as explicit
+  `null`/incomplete provenance tied to the persisted model set while retaining
+  numeric-cost compatibility for prior 1.0/1.1 payloads. The
+  grading workflow defaults to a credential-free read-only dry run. Paid runs
+  require `paid_approval=true`, a separate protected `grading` Environment
+  approval, and then execute Azure OIDC from the environment-free `main`
+  branch job so the federated subject remains branch-bound; chunk continuation
+  preserves the exact config, inference revision, task limit, and approval
+  input while requiring a fresh protected Environment approval for each newly
+  dispatched workflow run.
+  The remote `grading` Environment has one owner reviewer, administrator bypass
+  disabled, and a custom `main`-only deployment policy. Self-review prevention
+  remains disabled because no independent collaborator exists. Current manuals
+  and specs identify Sol Max as production while preserving historical 5.4
+  configs, results, and measurements. Final credential-free validation passes
+  **2,358 backend tests** with **6 skipped and 44 deselected**, **94 Node
+  contracts**, **9 analysis tests**, both changed workflows under actionlint
+  and Ruby Psych, the TypeScript/Vite production build, and all **4 Chromium
+  browser suites**. No Azure, model, paid grading, or Hugging Face execution
+  occurred.
 - **Dashboard source-build provenance** - derive the displayed dashboard
   version from `package.json`, bind Pages builds to the exact checked-out
   GitHub SHA and repository, and link the footer to that full commit only after

--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ Expected behavior:
 3. Step 2 calls `gpt-5.2-chat`, creates files, and can retry same-model Self-QA.
 4. Steps 3-4 write formatted results and a three-row Parquet artifact.
 5. Step 5 is skipped because this is both a dry run and a three-task sample.
-6. Step 6's primary report path makes up to two sequential `gpt-5.4-pro` calls.
-  Completed calls can be billed. Any setup, call, parse, or route-validation
-  failure immediately produces a model-free report; there is no second-model
-  fallback. Report identity must pass before publication.
+6. Step 6's primary report path makes up to two sequential `gpt-5.6-sol` calls
+  with `reasoning=max`. Its 1.05M context is a deployment capability, not an
+  extra request setting. Completed calls can be billed. Any setup, call, parse,
+  or route-validation failure immediately produces a model-free report; there
+  is no second-model fallback. Report identity must pass before publication.
 7. Step 7 and the result PR are skipped by `dry_run: true`.
 
 If the credentialed batch job reaches its final `always()` step, it attempts to

--- a/README_KR.md
+++ b/README_KR.md
@@ -171,10 +171,12 @@ sandbox와 agentic 통제는 각각 이름이 붙은 경로에만 적용됩니�
 3. Step 2가 `gpt-5.2-chat`을 호출하고 파일을 만든 뒤 같은 모델의 Self-QA를 재시도할 수 있습니다.
 4. Step 3-4가 포맷된 결과와 3-row Parquet artifact를 만듭니다.
 5. dry run이면서 3-task sample이므로 Step 5를 건너뜁니다.
-6. Step 6의 기본 report 경로는 `gpt-5.4-pro`를 순차적으로 최대 2회 호출하며,
-  완료된 호출은 과금될 수 있습니다. 설정, 호출, 파싱, route 검증 중 하나라도
-  실패하면 즉시 model-free report를 만들고 다른 모델 fallback은 호출하지
-  않습니다. 게시 전에 report identity 검증을 반드시 통과해야 합니다.
+6. Step 6의 기본 report 경로는 `gpt-5.6-sol`을 `reasoning=max`로 순차적으로
+  최대 2회 호출합니다. 1.05M context는 별도 요청 설정이 아니라 deployment
+  capability입니다. 완료된 호출은 과금될 수 있습니다. 설정, 호출, 파싱,
+  route 검증 중 하나라도 실패하면 즉시 model-free report를 만들고 다른 모델
+  fallback은 호출하지 않습니다. 게시 전에 report identity 검증을 반드시
+  통과해야 합니다.
 7. `dry_run: true`이므로 Step 7과 결과 PR을 건너뜁니다.
 
 인증된 batch job이 마지막 `always()` 단계에 도달하면

--- a/batch-runner/README.md
+++ b/batch-runner/README.md
@@ -200,10 +200,21 @@ For the workspace-owned result, `report_data.json` is also copied to
 `workspace/upload/self_report.json` for Step 7. HTML generation is disabled.
 External grading remains a separate pipeline.
 
-The default narrative path attempts up to two `gpt-5.4-pro` calls. Any setup,
-call, parse, or route-validation failure immediately produces a model-free
-report; no experiment-model fallback is called. The workflow verifies report
-identity before any publication.
+The default narrative path attempts up to two `gpt-5.6-sol` calls with
+`reasoning=max`. Its 1.05M context window is a deployment capability rather
+than a separate request parameter. Any setup, call, parse, or route-validation
+failure immediately produces a model-free report; no experiment-model fallback
+is called. The workflow verifies model, effort, runtime fingerprint, and report
+identity before publication.
+
+Production grading defaults to `grading_configs/default_v2_sol_max.yaml`: the
+main tool-calling judge, visual perception, and bounded finalization retry use
+GPT-5.6 Sol Max; audio perception remains on `gpt-audio-1.5`. The gpt-5.4 and
+legacy text-extract configs remain explicit historical comparison identities.
+`grade-run.yml` defaults to a model-free dry run. Paid grading additionally
+requires `paid_approval: true` and approval in the protected `grading`
+environment. Continuations preserve the approval input and exact run identity,
+but each newly dispatched chunk requires a fresh protected Environment approval.
 
 ### Step 7: Upload to HuggingFace (`step7_upload_hf.sh`)
 

--- a/batch-runner/README_KR.md
+++ b/batch-runner/README_KR.md
@@ -193,10 +193,21 @@ workspace 소유 결과에서는 `report_data.json`을
 `workspace/upload/self_report.json`으로도 복사합니다. HTML은 생성하지 않으며
 외부 채점은 별도 pipeline입니다.
 
-기본 narrative 경로는 `gpt-5.4-pro`를 최대 2회 호출합니다. 설정, 호출, 파싱,
-route 검증 중 하나라도 실패하면 즉시 model-free report를 만들며 실험 모델
-fallback은 호출하지 않습니다. workflow는 게시 전에 report identity를
-검증합니다.
+기본 narrative 경로는 `gpt-5.6-sol`을 `reasoning=max`로 최대 2회 호출합니다.
+1.05M context window는 별도 request parameter가 아니라 deployment
+capability입니다. 설정, 호출, 파싱, route 검증 중 하나라도 실패하면 즉시
+model-free report를 만들며 실험 모델 fallback은 호출하지 않습니다. workflow는
+게시 전에 model, effort, runtime fingerprint, report identity를 검증합니다.
+
+Production grading 기본값은 `grading_configs/default_v2_sol_max.yaml`입니다.
+메인 tool-calling judge, visual perception, bounded finalization retry는
+GPT-5.6 Sol Max를 사용하고 audio perception은 `gpt-audio-1.5`를 유지합니다.
+gpt-5.4와 legacy text-extract config는 명시적으로 선택하는 과거 비교
+identity로 보존됩니다.
+`grade-run.yml`은 model-free dry run이 기본입니다. 유료 grading은
+`paid_approval: true`와 보호된 `grading` environment 승인이 추가로 필요하며,
+continuation은 approval input과 exact run identity를 전달합니다. 다만 새로
+dispatch되는 각 chunk는 보호된 environment 승인을 다시 받아야 합니다.
 
 ### Step 7: HuggingFace 업로드 (`step7_upload_hf.sh`)
 

--- a/batch-runner/core/grade_payload.py
+++ b/batch-runner/core/grade_payload.py
@@ -14,7 +14,12 @@ FULL_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 def validate_grade_payload(payload: Any, schema: dict) -> None:
     """Validate one legacy or current grade payload before persistence."""
     validate(instance=payload, schema=schema)
-    if not isinstance(payload, dict) or "run_status" not in payload:
+    if not isinstance(payload, dict):
+        return
+    current_schema = payload.get("schema_version") == "1.2"
+    if current_schema and "run_status" not in payload:
+        raise ValueError("current grade lifecycle identity is missing")
+    if "run_status" not in payload:
         return
 
     status = payload.get("run_status")
@@ -23,6 +28,7 @@ def validate_grade_payload(payload: Any, schema: dict) -> None:
     tasks = payload.get("tasks")
     routes = payload.get("azure_ai_routes")
     primary_fingerprint = payload.get("azure_ai_runtime_fingerprint")
+    summary = payload.get("summary")
 
     if status not in {"partial", "final", "diagnostic"}:
         raise ValueError("grade run_status is invalid")
@@ -50,3 +56,50 @@ def validate_grade_payload(payload: Any, schema: dict) -> None:
         or primary_route.get("runtime_fingerprint") != primary_fingerprint
     ):
         raise ValueError("primary grader route fingerprint mismatch")
+    if not current_schema:
+        return
+    cost = summary.get("cost") if isinstance(summary, dict) else None
+    if not isinstance(cost, dict):
+        raise ValueError("grade cost provenance is missing")
+    required_cost_fields = {
+        "estimated_cost_usd",
+        "pricing_complete",
+        "unpriced_models",
+    }
+    if not required_cost_fields.issubset(cost):
+        raise ValueError("current grade cost provenance is incomplete")
+    if cost["estimated_cost_usd"] is not None:
+        raise ValueError("current grade estimated cost must remain unpriced")
+    if cost["pricing_complete"] is not False:
+        raise ValueError("current grade pricing must be incomplete")
+    unpriced_models = cost["unpriced_models"]
+    if (
+        not isinstance(unpriced_models, list)
+        or not unpriced_models
+        or any(not isinstance(model, str) or not model for model in unpriced_models)
+        or len(unpriced_models) != len(set(unpriced_models))
+    ):
+        raise ValueError("current grade unpriced model identity is invalid")
+    judge = payload.get("judge")
+    if not isinstance(judge, dict):
+        raise ValueError("current grade judge identity is missing")
+    expected_unpriced_models = {judge.get("model")}
+    perception = judge.get("perception", {})
+    if not isinstance(perception, dict):
+        raise ValueError("current grade perception identity is invalid")
+    for modality in perception.values():
+        if not isinstance(modality, dict):
+            raise ValueError("current grade perception identity is invalid")
+        expected_unpriced_models.add(
+            modality.get("model") or modality.get("deployment")
+        )
+    if (
+        any(
+            not isinstance(model, str) or not model
+            for model in expected_unpriced_models
+        )
+        or set(unpriced_models) != expected_unpriced_models
+    ):
+        raise ValueError(
+            "current grade unpriced models do not match persisted model identity"
+        )

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -1891,8 +1891,10 @@ class Grader:
                 client=self.client,
                 deployment=vision_deployment,
                 call_cap=int(vis_cfg.get("call_cap_per_task", 5)),
-                reasoning_effort=(judge_cfg.get("reasoning") or {})
-                    .get("effort", "medium"),
+                reasoning_effort=vis_cfg.get(
+                    "reasoning_effort",
+                    (judge_cfg.get("reasoning") or {}).get("effort", "medium"),
+                ),
                 before_upstream_call=self._apply_tpm_delay,
             )
         if aud_cfg.get("model") is not None or aud_cfg.get("deployment") is not None:
@@ -1920,6 +1922,8 @@ class Grader:
             finalization_retries=int(
                 self.config.get("grader", {}).get("judge_max_retries", 1)
             ),
+            finalization_reasoning_effort=(judge_cfg.get("generation") or {})
+                .get("finalization_reasoning_effort", "low"),
             model_read_ops=model_read_ops,
             vision_perception=vision_perception,
             audio_perception=audio_perception,

--- a/batch-runner/core/hf_publication.py
+++ b/batch-runner/core/hf_publication.py
@@ -132,6 +132,9 @@ class PublicationIdentity:
     results: tuple[PublicationTaskResult, ...]
     azure_ai_routes: tuple[dict[str, str], ...] = ()
     execution_mode: str = "subprocess"
+    expected_narrative_model: str | None = None
+    expected_narrative_reasoning_effort: str | None = None
+    expected_narrative_runtime_fingerprint: str | None = None
 
     def submitter_rows(self) -> list[dict]:
         return [result.as_dict() for result in self.results]
@@ -452,6 +455,10 @@ def write_publication_receipt(
 def load_publication_identity(
     prepared_path: Path,
     inference_path: Path,
+    *,
+    expected_narrative_model: str | None = None,
+    expected_narrative_reasoning_effort: str | None = None,
+    expected_narrative_runtime_fingerprint: str | None = None,
 ) -> PublicationIdentity:
     """Load one exact Step 1/2 identity or fail before publication."""
     prepared = _load_json_object(Path(prepared_path), "prepared task payload")
@@ -576,6 +583,11 @@ def load_publication_identity(
         results=tuple(publication_results),
         azure_ai_routes=azure_ai_routes,
         execution_mode=execution_mode,
+        expected_narrative_model=expected_narrative_model,
+        expected_narrative_reasoning_effort=expected_narrative_reasoning_effort,
+        expected_narrative_runtime_fingerprint=(
+            expected_narrative_runtime_fingerprint
+        ),
     )
 
 
@@ -810,6 +822,13 @@ def _publication_plan_sha256(
         "prepared_fingerprint": identity.prepared_fingerprint,
         "result_fingerprint": identity.result_fingerprint,
         "ordered_task_ids": list(identity.ordered_task_ids),
+        "expected_narrative_model": identity.expected_narrative_model,
+        "expected_narrative_reasoning_effort": (
+            identity.expected_narrative_reasoning_effort
+        ),
+        "expected_narrative_runtime_fingerprint": (
+            identity.expected_narrative_runtime_fingerprint
+        ),
         "additions": [
             {"path": record.path, "size": record.size, "sha256": record.sha256}
             for record in files
@@ -912,6 +931,48 @@ def _validate_self_report_payload(
         raise ValueError("self_report.json result fingerprint mismatch")
     if meta.get("publication_plan") != "step7_upload_requested":
         raise ValueError("self_report.json publication plan is not publishable")
+    narrative_identity_fields = (
+        "narrative_model",
+        "narrative_reasoning_effort",
+        "narrative_runtime_fingerprint",
+    )
+    if any(field not in meta for field in narrative_identity_fields):
+        raise ValueError("self_report.json narrative identity is incomplete")
+    actual_narrative = tuple(meta[field] for field in narrative_identity_fields)
+    narrative_fields = (
+        "overview",
+        "quality_analysis",
+        "failure_patterns",
+        "recommendations",
+    )
+    narrative = payload.get("narrative")
+    if actual_narrative == (None, None, None):
+        if not isinstance(narrative, dict) or any(
+            narrative.get(field) != "" for field in narrative_fields
+        ):
+            raise ValueError("self_report.json model-free narrative is invalid")
+    else:
+        if any(value is None for value in actual_narrative):
+            raise ValueError("self_report.json narrative identity is incomplete")
+        expected_narrative = (
+            identity.expected_narrative_model,
+            identity.expected_narrative_reasoning_effort,
+            identity.expected_narrative_runtime_fingerprint,
+        )
+        if any(value is None for value in expected_narrative):
+            raise ValueError("expected publication narrative identity is missing")
+        if actual_narrative[0] != expected_narrative[0]:
+            raise ValueError("self_report.json narrative model mismatch")
+        if actual_narrative[1] != expected_narrative[1]:
+            raise ValueError("self_report.json narrative reasoning mismatch")
+        if actual_narrative[2] != expected_narrative[2]:
+            raise ValueError("self_report.json narrative fingerprint mismatch")
+        if not isinstance(narrative, dict) or any(
+            not isinstance(narrative.get(field), str)
+            or not narrative[field].strip()
+            for field in narrative_fields
+        ):
+            raise ValueError("self_report.json model-backed narrative is invalid")
     if _ordered_task_ids(
         meta.get("ordered_task_ids"), "self-report scope"
     ) != identity.ordered_task_ids:
@@ -1177,6 +1238,21 @@ def _validate_publication_identity(
         identity.execution_mode,
         list(identity.azure_ai_routes),
     )
+    narrative_identity = (
+        identity.expected_narrative_model,
+        identity.expected_narrative_reasoning_effort,
+        identity.expected_narrative_runtime_fingerprint,
+    )
+    if narrative_identity != (None, None, None):
+        if (
+            not isinstance(narrative_identity[0], str)
+            or not narrative_identity[0]
+            or not isinstance(narrative_identity[1], str)
+            or not narrative_identity[1]
+            or not isinstance(narrative_identity[2], str)
+            or re.fullmatch(r"[0-9a-f]{64}", narrative_identity[2]) is None
+        ):
+            raise ValueError("expected publication narrative identity is invalid")
     if (
         not isinstance(identity.results, tuple)
         or any(

--- a/batch-runner/core/narrative_analyzer.py
+++ b/batch-runner/core/narrative_analyzer.py
@@ -1,11 +1,11 @@
-"""NarrativeAnalyzer — Standalone Responses API module for GPT-5.4 Pro.
+"""NarrativeAnalyzer — typed Responses API module for GPT-5.6 Sol 1M Max.
 
 Generates rich narrative analysis (overview, quality_analysis, failure_patterns,
 recommendations) for experiment reports using a 2-call sequential pattern.
 
-This module is intentionally standalone — it does NOT import or depend on
-core/llm_client.py (which uses Chat Completions API). GPT-5.4 Pro only
-supports the Responses API, so this module creates its own AzureOpenAI client.
+The analyzer uses the shared typed direct-v1 Azure AI client and performs two
+sequential Responses API calls. The 1.05M context window is a deployment
+capability; ``reasoning={"effort": "max"}`` is sent explicitly per request.
 
 Usage:
     from core.narrative_analyzer import create_narrative_analyzer
@@ -21,7 +21,10 @@ import threading
 import time
 from dataclasses import dataclass, field
 
-from core.azure_ai_clients import AzureAIClientFactory, AzureAIWorkload
+from core.azure_ai_clients import (
+    AzureAIClientFactory,
+    AzureAIWorkload,
+)
 from core.llm_client import ManagedAzureAIClient, create_typed_azure_client
 
 logger = logging.getLogger(__name__)
@@ -37,6 +40,8 @@ class NarrativeResult:
     quality_analysis: str = ""
     failure_patterns: str = ""
     recommendations: str = ""
+    narrative_model: str = ""
+    narrative_reasoning_effort: str = ""
     call_1_latency_ms: float = 0.0
     call_2_latency_ms: float = 0.0
     total_tokens: dict = field(default_factory=lambda: {"input": 0, "output": 0})
@@ -207,7 +212,7 @@ Failure pattern hint (precheck vs judge):
 
 
 class NarrativeAnalyzer:
-    """GPT-5.4 Pro narrative generator using Azure OpenAI Responses API.
+    """GPT-5.6 Sol Max narrative generator using Azure OpenAI Responses API.
 
     Architecture:
         Call 1: Sector-level analysis → overview + quality_analysis
@@ -217,10 +222,12 @@ class NarrativeAnalyzer:
         endpoint:    Azure OpenAI endpoint URL
         api_version: API version (default: 2025-04-01-preview)
         timeout:     Client-level timeout in seconds (default: 10000)
-        model:       Deployment name (default: gpt-5.4-pro)
+        model:       Deployment name (default: gpt-5.6-sol)
+        reasoning_effort: Responses API reasoning effort (default: max)
     """
 
-    DEFAULT_MODEL = "gpt-5.4-pro"
+    DEFAULT_MODEL = "gpt-5.6-sol"
+    DEFAULT_REASONING_EFFORT = "max"
     DEFAULT_API_VERSION = "2025-04-01-preview"
     DEFAULT_TIMEOUT = 10000
 
@@ -230,6 +237,7 @@ class NarrativeAnalyzer:
         api_version: str = DEFAULT_API_VERSION,
         timeout: int = DEFAULT_TIMEOUT,
         model: str = DEFAULT_MODEL,
+        reasoning_effort: str = DEFAULT_REASONING_EFFORT,
         client=None,
         client_factory: AzureAIClientFactory | None = None,
     ):
@@ -249,6 +257,7 @@ class NarrativeAnalyzer:
             client = self._managed_client.client
         self.client = client
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self._heartbeat_active = False
         self._heartbeat_thread: threading.Thread | None = None
 
@@ -331,6 +340,8 @@ class NarrativeAnalyzer:
             quality_analysis=call1_result.get("quality_analysis", ""),
             failure_patterns=call2_result.get("failure_patterns", ""),
             recommendations=call2_result.get("recommendations", ""),
+            narrative_model=self.model,
+            narrative_reasoning_effort=self.reasoning_effort,
             call_1_latency_ms=call1_latency,
             call_2_latency_ms=call2_latency,
             total_tokens={"input": total_input, "output": total_output},
@@ -498,6 +509,7 @@ Return ONLY valid JSON (no markdown code fences) with these exact keys:
             model=self.model,
             instructions=system_prompt,
             input=user_prompt,
+            reasoning={"effort": self.reasoning_effort},
             max_output_tokens=max_output_tokens,
         )
         latency_ms = (time.time() - start) * 1000
@@ -520,7 +532,7 @@ Return ONLY valid JSON (no markdown code fences) with these exact keys:
                 time.sleep(30)
                 if self._heartbeat_active:
                     print(
-                        f"   💓 [{time.strftime('%H:%M:%S')}] waiting for Pro response...",
+                        f"   💓 [{time.strftime('%H:%M:%S')}] waiting for narrative response...",
                         flush=True,
                     )
 
@@ -577,6 +589,29 @@ Return ONLY valid JSON (no markdown code fences) with these exact keys:
         return result
 
 
+def expected_narrative_publication_identity() -> tuple[str, str, str]:
+    """Return the model-free expected Sol Max publication identity."""
+    from core import azure_ai_clients
+
+    routes = azure_ai_clients.preflight_routes(
+        azure_ai_clients.narrative_route_workloads(
+            NarrativeAnalyzer.DEFAULT_MODEL
+        ),
+        timeout=NarrativeAnalyzer.DEFAULT_TIMEOUT,
+        legacy_api_version=NarrativeAnalyzer.DEFAULT_API_VERSION,
+    )
+    if len(routes) != 1:
+        raise ValueError("primary narrative route identity is ambiguous")
+    fingerprint = routes[0].get("runtime_fingerprint")
+    if not isinstance(fingerprint, str) or len(fingerprint) != 64:
+        raise ValueError("primary narrative route fingerprint is invalid")
+    return (
+        NarrativeAnalyzer.DEFAULT_MODEL,
+        NarrativeAnalyzer.DEFAULT_REASONING_EFFORT,
+        fingerprint,
+    )
+
+
 # ─── Factory Function ─────────────────────────────────────────────────────
 
 
@@ -584,6 +619,7 @@ def create_narrative_analyzer(
     endpoint: str | None = None,
     timeout: int = 10000,
     model: str = NarrativeAnalyzer.DEFAULT_MODEL,
+    reasoning_effort: str = NarrativeAnalyzer.DEFAULT_REASONING_EFFORT,
     client=None,
     client_factory: AzureAIClientFactory | None = None,
 ) -> NarrativeAnalyzer:
@@ -592,7 +628,8 @@ def create_narrative_analyzer(
     Args:
         endpoint: Deprecated. Explicit endpoint overrides are rejected.
         timeout:  Client timeout in seconds (default: 10000).
-        model:    Model deployment name (default: gpt-5.4-pro).
+        model:    Model deployment name (default: gpt-5.6-sol).
+        reasoning_effort: Responses API reasoning effort (default: max).
 
     Returns:
         Configured NarrativeAnalyzer instance.
@@ -601,6 +638,7 @@ def create_narrative_analyzer(
         endpoint=endpoint,
         timeout=timeout,
         model=model,
+        reasoning_effort=reasoning_effort,
         client=client,
         client_factory=client_factory,
     )

--- a/batch-runner/core/perception/__init__.py
+++ b/batch-runner/core/perception/__init__.py
@@ -2,8 +2,9 @@
 
 Two thin wrappers around Azure OpenAI Responses API:
 
-  - ``VisionPerception``  (task 205) — gpt-5.4 vision input, used when
-    the routing classifier marks a rubric item as ``VISUAL``.
+  - ``VisionPerception``  (task 205) — config-selected vision input. The
+    production profile uses GPT-5.6 Sol with reasoning=max when the routing
+    classifier marks a rubric item as ``VISUAL``.
   - ``AudioPerception``   (task 206) — gpt-audio-1.5, used when the
     routing classifier marks a rubric item as ``AUDIO``.
 

--- a/batch-runner/core/perception/vision.py
+++ b/batch-runner/core/perception/vision.py
@@ -8,17 +8,17 @@ appended to the judge's evidence chain.
 
 Design notes (task 205):
 
-* Same Azure deployment as the main judge — gpt-5.4 with vision
-  enabled. No separate model key.
+* Config-selected Azure deployment. Production uses GPT-5.6 Sol Max and
+    historical comparison configs retain their original model identities.
 * The client is **injected**, never constructed inside this class. The
   main judge owns the Responses API client and shares it; tests pass a
   ``FakeClient``.
 * Image cache: ``(path, page)`` rendered once per task and reused —
   prevents the judge from burning tokens re-rendering the same chart
   on a second item.
-* Per-task call cap = 5. The harness preflights the full bounded visual
-    plan against the remaining cap before rendering. A cap error is returned
-    to the grader as a score-excluded visual ``judge_error``.
+* The generic wrapper default cap is 5; production config explicitly raises it
+    to 72 after checking the 220-task visual inventory. The harness preflights
+    the full bounded plan before rendering.
 * Graceful degradation on dependency errors: a corrupt PNG or a
   Responses-API exception returns ``judge_error`` rather than raising.
 """
@@ -170,10 +170,10 @@ class VisionPerception:
         client:       any object exposing ``responses.create(**kwargs)`` ->
                       ``response.output_text`` (Azure OpenAI Responses API
                       shape; tests pass a fake with the same shape).
-        deployment:   Azure deployment name (e.g. ``"gpt-5.4"`` with
+        deployment:   Azure deployment name (e.g. ``"gpt-5.6-sol"`` with
                       vision enabled).
         call_cap:     optional override (default ``VISION_CALL_CAP``).
-        reasoning_effort: optional ``"low" | "medium" | "high"``.
+        reasoning_effort: optional Responses API reasoning effort.
     """
 
     client: Any

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -321,6 +321,41 @@ def _safe_json_loads(text: str) -> Optional[Dict[str, Any]]:
             return None
 
 
+def _validated_final_envelope(
+    parsed: Mapping[str, Any],
+) -> Optional[Tuple[str, float, float]]:
+    verdict_raw = parsed.get("verdict")
+    partial_raw = parsed.get("partial_score")
+    confidence_raw = parsed.get("confidence")
+    verdict = verdict_raw.lower() if isinstance(verdict_raw, str) else ""
+    if verdict not in {"pass", "partial", "fail"}:
+        return None
+    if isinstance(partial_raw, bool) or not isinstance(
+        partial_raw, (int, float)
+    ):
+        return None
+    if isinstance(confidence_raw, bool) or not isinstance(
+        confidence_raw, (int, float)
+    ):
+        return None
+    try:
+        partial = float(partial_raw)
+        confidence = float(confidence_raw)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    if not math.isfinite(partial) or not 0.0 <= partial <= 1.0:
+        return None
+    if not math.isfinite(confidence) or not 0.0 <= confidence <= 1.0:
+        return None
+    if (
+        (verdict == "pass" and partial != 1.0)
+        or (verdict == "fail" and partial != 0.0)
+        or (verdict == "partial" and not 0.0 < partial < 1.0)
+    ):
+        return None
+    return verdict, partial, confidence
+
+
 def _finalization_retry_reason(
     final_text: str,
     response: Any,
@@ -332,8 +367,11 @@ def _finalization_retry_reason(
             response, max_output_tokens, output_tokens
         )
         return f"empty_final_text:{finish_reason}"
-    if _safe_json_loads(final_text) is None:
+    parsed = _safe_json_loads(final_text)
+    if parsed is None:
         return "final_json_parse_failed"
+    if _validated_final_envelope(parsed) is None:
+        return "invalid_final_envelope"
     return None
 
 
@@ -349,13 +387,14 @@ class ToolCallingJudge:
     Args:
         client:                  object with ``.responses.create(**kwargs)``
                                  (Azure OpenAI Responses client or a fake).
-        model:                   deployment name (e.g. ``"gpt-5.4"``).
+        model:                   deployment name (e.g. ``"gpt-5.6-sol"``).
         prompt_template:         contents of ``prompts/grader_judge_v2.md``
                                  — must contain a ``<!-- ===SPLIT=== -->``
                                  marker separating the stable scaffold
                                  (sent as ``instructions=``, cached server-
                                  side) from the per-item variable content.
-        reasoning_effort:        ``"low" | "medium" | "high"``.
+        reasoning_effort:        ``"none" | "low" | "medium" | "high" |
+                     "xhigh" | "max"``.
         max_output_tokens:       per-call output budget.
         per_item_tool_call_cap:  hard upper bound on tool dispatches for
                                  a single rubric item. Loop exits with
@@ -366,6 +405,9 @@ class ToolCallingJudge:
                                  iteration).
         finalization_retries:    bounded retries when a final response is
                      missing or malformed after evidence is ready.
+        finalization_reasoning_effort: reasoning effort used for the bounded
+                 no-tools finalization retry. Defaults to ``"low"`` for
+                 existing configs.
         vision_perception:       optional ``VisionPerception`` instance.
                      For VISUAL items the harness renders and
                      invokes it before the first main request;
@@ -394,6 +436,7 @@ class ToolCallingJudge:
     per_item_tool_call_cap: int = 8
     max_iterations: int = 10
     finalization_retries: int = 1
+    finalization_reasoning_effort: str = "low"
     model_read_ops: Tuple[str, ...] = MODEL_READ_DELIVERABLE_OPS
     vision_perception: Any = None
     audio_perception: Any = None
@@ -414,6 +457,10 @@ class ToolCallingJudge:
         if self.finalization_retries < 0:
             raise ValueError("finalization_retries must be non-negative")
         self.finalization_retries = min(self.finalization_retries, 1)
+        if self.finalization_reasoning_effort not in {
+            "none", "low", "medium", "high", "xhigh", "max"
+        }:
+            raise ValueError("finalization_reasoning_effort is invalid")
         invalid_ops = set(self.model_read_ops) - set(MODEL_READ_DELIVERABLE_OPS)
         if invalid_ops:
             raise ValueError(
@@ -512,7 +559,9 @@ class ToolCallingJudge:
         finalization_only = False
         finalization_retries_used = 0
 
-        while iterations < self.max_iterations:
+        while iterations < self.max_iterations + (
+            finalization_retries_used if finalization_only else 0
+        ):
             iterations += 1
             call_started: Optional[float] = None
             try:
@@ -537,10 +586,12 @@ class ToolCallingJudge:
                 if finalization_only:
                     create_kwargs.pop("tools")
                     create_kwargs.pop("parallel_tool_calls")
-                    create_kwargs["reasoning"] = {"effort": "low"}
+                    create_kwargs["reasoning"] = {
+                        "effort": self.finalization_reasoning_effort
+                    }
                 # PR3 step 1b — context_management server-side compaction.
                 # The SDK signature exposes a dict shape but Azure's
-                # current API rev for gpt-5.4 rejects dict with HTTP 400
+                # legacy gpt-5.4 validation rejected dict with HTTP 400
                 # ('expected an array of objects'). Disabled by default
                 # until the array contract is documented; set
                 # compact_threshold=None to opt out (default).
@@ -574,7 +625,8 @@ class ToolCallingJudge:
                         model=self.model,
                         input=messages,
                         reasoning={
-                            "effort": "low" if finalization_only
+                            "effort": self.finalization_reasoning_effort
+                            if finalization_only
                             else self.reasoning_effort
                         },
                         max_output_tokens=self.max_output_tokens,
@@ -690,7 +742,6 @@ class ToolCallingJudge:
             if (
                 retry_reason is not None
                 and finalization_retries_used < self.finalization_retries
-                and iterations < self.max_iterations
             ):
                 logger.warning(
                     "ToolCallingJudge invalid final response for %s (%s); "
@@ -1456,55 +1507,8 @@ class ToolCallingJudge:
                 **instrumentation,
             )
 
-        verdict_raw = parsed.get("verdict")
-        partial_raw = parsed.get("partial_score")
-        confidence_raw = parsed.get("confidence")
-        invalid_envelope = False
-        verdict = verdict_raw.lower() if isinstance(verdict_raw, str) else ""
-        if verdict not in {"pass", "partial", "fail"}:
-            invalid_envelope = True
-
-        partial = 0.0
-        if (
-            isinstance(partial_raw, bool)
-            or not isinstance(partial_raw, (int, float))
-        ):
-            invalid_envelope = True
-        else:
-            try:
-                partial = float(partial_raw)
-            except (OverflowError, TypeError, ValueError):
-                invalid_envelope = True
-            else:
-                if not math.isfinite(partial) or not 0.0 <= partial <= 1.0:
-                    invalid_envelope = True
-
-        if not invalid_envelope and (
-            (verdict == "pass" and partial != 1.0)
-            or (verdict == "fail" and partial != 0.0)
-            or (verdict == "partial" and not 0.0 < partial < 1.0)
-        ):
-            invalid_envelope = True
-
-        confidence: Optional[float] = None
-        if (
-            isinstance(confidence_raw, bool)
-            or not isinstance(confidence_raw, (int, float))
-        ):
-            invalid_envelope = True
-        else:
-            try:
-                confidence = float(confidence_raw)
-            except (OverflowError, TypeError, ValueError):
-                invalid_envelope = True
-            else:
-                if (
-                    not math.isfinite(confidence)
-                    or not 0.0 <= confidence <= 1.0
-                ):
-                    invalid_envelope = True
-
-        if invalid_envelope:
+        validated_envelope = _validated_final_envelope(parsed)
+        if validated_envelope is None:
             return ToolCallingResult(
                 verdict="judge_error",
                 partial_score=0.0,
@@ -1526,6 +1530,8 @@ class ToolCallingJudge:
                 score_excluded=True,
                 **instrumentation,
             )
+
+        verdict, partial, confidence = validated_envelope
 
         evidence = str(parsed.get("evidence") or "").strip()[:200]
         if not evidence:

--- a/batch-runner/grading_configs/README.md
+++ b/batch-runner/grading_configs/README.md
@@ -4,13 +4,21 @@
 
 | file | path | grader path | when to use |
 |---|---|---|---|
-| `default_v2.yaml` | tool-calling judge | v2 (`ToolCallingJudge` via `judge.tools.read_deliverable`) | Explicit opt-in for new tool-calling runs. Single-tier gpt-5.4 medium, read_deliverable tool surface, vision/audio perception. |
-| `default_gpt5pro.yaml` | text-extract judge | v1 (`Judge` / `BatchJudge`) | Current workflow default while the v2 cost/capacity envelope remains a separate operator decision. |
+| `default_v2_sol_max.yaml` | tool-calling judge | v2 (`ToolCallingJudge` via `judge.tools.read_deliverable`) | **Production default.** GPT-5.6 Sol 1M Max for main, visual, and bounded finalization; gpt-audio-1.5 for audio perception. |
+| `default_v2.yaml` | tool-calling judge | v2 | Historical gpt-5.4 medium comparison identity. Pass explicitly when reproducing that condition. |
+| `default_gpt5pro.yaml` | text-extract judge | v1 (`Judge` / `BatchJudge`) | Historical mini/text-extract comparison identity. Pass explicitly only for provenance-compatible analysis. |
 
-`grade-run.yml`'s `grading_config` input default is **currently still
-`default_gpt5pro.yaml`**. v2 is opt-in by passing
-`default_v2.yaml` to the workflow input. There is no automatic hybrid follow-up
-or config flip in the active workflow.
+`grade-run.yml` defaults to `default_v2_sol_max.yaml`. The 1.05M context window
+belongs to the deployment and is not represented by a synthetic request field.
+There is no automatic hybrid follow-up in the active workflow.
+
+The workflow itself defaults to `dry_run: true`. Any non-dry invocation must
+set `paid_approval: true` and pass the protected `grading` GitHub Environment.
+If a time-bounded run needs another chunk, the exact config, inference revision,
+task limit, and paid-approval input are inherited by the continuation. Each new
+chunk is a separate workflow run and requires a fresh protected Environment
+approval. Model prices are not guessed: grade payloads and analyses remain
+explicitly `unpriced` until verified FDPO rates are configured.
 
 ## Provenance and diagnostic scopes
 
@@ -45,24 +53,24 @@ boundary.
 
 ## v1 vs v2 quick reference
 
-|  | v1 (`default_gpt5pro.yaml`) | v2 (`default_v2.yaml`) |
+|  | historical v1 (`default_gpt5pro.yaml`) | production v2 (`default_v2_sol_max.yaml`) |
 |---|---|---|
 | schema_version | `1.0` | `2.0` |
-| judge tier | mini / standard / pro routing | single (gpt-5.4) |
-| reasoning_effort | medium / high / mini-low (per tier) | medium |
+| judge tier | mini / standard / pro routing | single (gpt-5.6-sol) |
+| reasoning_effort | medium / high / mini-low (per tier) | max for main, visual, and finalization |
 | deliverable input | pre-extracted text, 1500 char cap | live file via `read_deliverable` tool |
 | `deliverable_extract_max_chars` | present | **removed** |
 | tools | none | `read_deliverable` + opt. `vision_judge` + opt. `audio_judge` |
-| perception | none | gpt-5.4 vision / gpt-audio-1.5 (modality-routed) |
+| perception | none | gpt-5.6-sol max vision / gpt-audio-1.5 (modality-routed) |
 | critical rule | `weight >= 4` | `\|max_score\| >= 4` (sign-aware, includes 94 penalty items) |
 | score math | clamp-hidden negatives | sign-aware, explicit non-positive total_max handling |
 | rubric execution | one final verdict per rubric item | one final verdict per rubric item (plus bounded tool/finalization calls) |
 
 ## How to add a new config
 
-1. Copy `default_v2.yaml` to `<your_name>.yaml` and edit only the
+1. Copy `default_v2_sol_max.yaml` to `<your_name>.yaml` and edit only the
    fields you mean to change. `schema_version` must stay `2.0`.
 2. `python step8_grade.py <exp_id> --config grading_configs/<your_name>.yaml --dry-run`
    to validate.
-3. Run on the smoke experiment (`exp998_smoke_baseline_sample`,
-   `--limit 3`) before triggering the full 220 to bound cost.
+3. Run the model-free `--dry-run` first. Any paid smoke or full 220 run requires
+   separate operator approval and artifact-level acceptance.

--- a/batch-runner/grading_configs/_archive_v1/README.md
+++ b/batch-runner/grading_configs/_archive_v1/README.md
@@ -22,5 +22,5 @@ the result as a new run identity. Never resume an old partial across that
 migration boundary.
 
 **Do not author new configs here.** Add new configs under
-`grading_configs/<name>.yaml` based on `default_v2.yaml`. See the
+`grading_configs/<name>.yaml` based on `default_v2_sol_max.yaml`. See the
 top-level `grading_configs/README.md` for the migration table.

--- a/batch-runner/grading_configs/default_v2_sol_max.yaml
+++ b/batch-runner/grading_configs/default_v2_sol_max.yaml
@@ -1,0 +1,94 @@
+schema_version: "2.0"
+config_name: "default_v2_sol_max"
+description: |
+  Production v2 grading config using GPT-5.6 Sol at reasoning=max for the
+  main tool-calling judge, visual perception, and bounded finalization retry.
+  Audio criteria retain the dedicated gpt-audio-1.5 perception model.
+
+  GPT-5.6 Sol's 1.05M context window is a deployment capability, not a request
+  parameter. This config deliberately sets no synthetic context-window field.
+  Existing v1, gpt-5.4, mini, tight, and validation configs remain immutable
+  comparison identities.
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.6-sol"
+  deployment: "gpt-5.6-sol"
+  api_version: "2025-04-01-preview"
+  timeout_sec: 600
+  reasoning:
+    effort: "max"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+    finalization_reasoning_effort: "max"
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.6-sol"
+      deployment: "gpt-5.6-sol"
+      reasoning_effort: "max"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      deployment: "gpt-audio-1.5"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  revision: "main"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v2"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -98,6 +98,40 @@
       "then": {
         "required": ["azure_ai_routes", "azure_ai_runtime_fingerprint"]
       }
+    },
+    {
+      "if": {
+        "required": ["schema_version"],
+        "properties": {"schema_version": {"const": "1.2"}}
+      },
+      "then": {
+        "required": [
+          "run_status",
+          "expected_task_count",
+          "expected_ordered_task_ids_sha256",
+          "azure_ai_routes",
+          "azure_ai_runtime_fingerprint"
+        ],
+        "properties": {
+          "summary": {
+            "properties": {
+              "cost": {
+                "required": ["estimated_cost_usd", "pricing_complete", "unpriced_models"],
+                "properties": {
+                  "estimated_cost_usd": {"type": "null"},
+                  "pricing_complete": {"const": false},
+                  "unpriced_models": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {"type": "string", "minLength": 1}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   ],
   "required": [
@@ -113,7 +147,7 @@
     "summary"
   ],
   "properties": {
-    "schema_version": {"enum": ["1.0", "1.1"], "description": "1.0 = v1 grade JSON (legacy, pre-sign-aware). 1.1 = v2sm-backfilled or freshly-graded with PR1 sign-aware math (model_did_right, |max_score|>=4 critical, positive-only denominator, pct_raw diagnostic)."},
+    "schema_version": {"enum": ["1.0", "1.1", "1.2"], "description": "1.0 = legacy item-level grade JSON. 1.1 = sign-aware backfill. 1.2 = current lifecycle and explicit unpriced-cost provenance."},
     "run_status": {"enum": ["partial", "final", "diagnostic"]},
     "expected_task_count": {"type": "integer", "minimum": 1},
     "expected_ordered_task_ids_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},

--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -5,7 +5,7 @@ Reads workspace/result.json and generates two output files under workspace/repor
   - report_data.json : structured JSON for dashboard rendering
   - report.md        : human-readable Markdown report
 
-Narrative sections use the two-call GPT-5.4 Pro analyzer with a sanitized
+Narrative sections use the two-call GPT-5.6 Sol 1M Max analyzer with a sanitized
 model-free fallback. Step 6 always emits a pre-grading report; external grading
 remains a separate pipeline.
 
@@ -487,6 +487,8 @@ def _model_free_narrative(error: Exception | None = None) -> dict:
         "recommendations": "",
         "grading_referenced": False,
         "grade_source": None,
+        "model": None,
+        "reasoning_effort": None,
         "runtime_fingerprint": None,
     }
     if error is not None:
@@ -525,6 +527,8 @@ def _build_report_data(data: dict, narrative: dict, summary: dict,
         "narrative_runtime_fingerprint": narrative.get(
             "runtime_fingerprint"
         ),
+        "narrative_model": narrative.get("model"),
+        "narrative_reasoning_effort": narrative.get("reasoning_effort"),
     }
     report_meta.update(_validated_report_provenance(data))
     report = {
@@ -1311,30 +1315,24 @@ def generate_report(
         narrative = _model_free_narrative()
         print("   Skipping narrative (--no-narrative)")
     else:
-        # Try GPT-5.4 Pro (Responses API) once, then fall back model-free.
+        # Try GPT-5.6 Sol Max (Responses API) once, then fall back model-free.
         try:
-            from core.azure_ai_clients import (
-                narrative_route_workloads,
-                preflight_routes,
-            )
             from core.narrative_analyzer import (
-                NarrativeAnalyzer,
                 create_narrative_analyzer,
+                expected_narrative_publication_identity,
             )
-            print("   Generating narrative via GPT-5.4 Pro (Responses API)…")
-            expected_routes = preflight_routes(
-                narrative_route_workloads(NarrativeAnalyzer.DEFAULT_MODEL),
-                timeout=NarrativeAnalyzer.DEFAULT_TIMEOUT,
-                legacy_api_version=NarrativeAnalyzer.DEFAULT_API_VERSION,
+            print("   Generating narrative via GPT-5.6 Sol Max (Responses API)…")
+            expected_model, expected_effort, expected_fingerprint = (
+                expected_narrative_publication_identity()
             )
             with create_narrative_analyzer() as analyzer:
-                if not any(
-                    route["runtime_fingerprint"]
-                    == analyzer.runtime_fingerprint
-                    for route in expected_routes
+                if (
+                    analyzer.model != expected_model
+                    or analyzer.reasoning_effort != expected_effort
+                    or analyzer.runtime_fingerprint != expected_fingerprint
                 ):
                     raise ValueError(
-                        "primary narrative route differs from preflight"
+                        "primary narrative identity differs from preflight"
                     )
                 result = analyzer.analyze(
                     data,
@@ -1351,13 +1349,15 @@ def generate_report(
                 "recommendations": result.recommendations,
                 "grading_referenced": result.grading_referenced,
                 "grade_source": result.grade_source,
+                "model": result.narrative_model,
+                "reasoning_effort": result.narrative_reasoning_effort,
                 "runtime_fingerprint": result.runtime_fingerprint,
             }
             total_ms = result.call_1_latency_ms + result.call_2_latency_ms
-            print(f"   ✅ Pro narrative generated ({total_ms:,.0f}ms, "
+            print(f"   ✅ Sol Max narrative generated ({total_ms:,.0f}ms, "
                   f"{result.total_tokens['input']:,}+{result.total_tokens['output']:,} tokens)")
         except Exception as exc:
-            print(f"   ⚠️ Pro narrative failed: {type(exc).__name__}")
+            print(f"   ⚠️ Sol Max narrative failed: {type(exc).__name__}")
             print("   Using model-free narrative fallback.")
             narrative = _model_free_narrative(exc)
 

--- a/batch-runner/step7_upload_hf.sh
+++ b/batch-runner/step7_upload_hf.sh
@@ -88,12 +88,17 @@ from core.hf_publication import (
   clear_publication_receipt,
   load_publication_identity,
 )
+from core.narrative_analyzer import expected_narrative_publication_identity
 from core.repo_bootstrapper import validate_pre_upload
 
 clear_publication_receipt()
+model, effort, fingerprint = expected_narrative_publication_identity()
 identity = load_publication_identity(
   Path("workspace/step1_tasks_prepared.json"),
   Path("workspace/step2_inference_results.json"),
+  expected_narrative_model=model,
+  expected_narrative_reasoning_effort=effort,
+  expected_narrative_runtime_fingerprint=fingerprint,
 )
 if identity.repo_id != os.environ["REPO_ID"]:
   raise SystemExit("publication repository differs from prepared identity")
@@ -129,6 +134,7 @@ from core.hf_publication import (
   load_publication_identity,
   publish_dataset_with_receipt,
 )
+from core.narrative_analyzer import expected_narrative_publication_identity
 from core.repo_bootstrapper import (
   TARGET_HEAD_FILENAME,
   load_target_head_identity,
@@ -168,9 +174,13 @@ if DELETE_PATTERNS != DELETE:
 repo_id = os.environ["REPO_ID"]
 data_dir = Path(os.environ["UPLOAD_DIR"])
 token = os.environ["HF_TOKEN"]
+model, effort, fingerprint = expected_narrative_publication_identity()
 identity = load_publication_identity(
   Path("workspace/step1_tasks_prepared.json"),
   Path("workspace/step2_inference_results.json"),
+  expected_narrative_model=model,
+  expected_narrative_reasoning_effort=effort,
+  expected_narrative_runtime_fingerprint=fingerprint,
 )
 if identity.repo_id != repo_id:
   raise SystemExit("publication repository differs from prepared identity")

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -3,7 +3,7 @@
 
 Usage:
     python step8_grade.py exp998_smoke_baseline_sample \
-      --config grading_configs/default_gpt5pro.yaml \
+    --config grading_configs/default_v2_sol_max.yaml \
       --dry-run --limit 3
 """
 
@@ -50,7 +50,7 @@ from core.public_error import public_provider_error_text
 from core.rubric_loader import RubricLoader
 from core.tools import ReadDeliverableError, get_renderer_fingerprint
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.2"
 GRADED_BY_VERSION = "0.1.0"
 FULL_HF_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 FULL_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -355,6 +355,28 @@ def validate_grading_config(config: dict) -> None:
         )
     if judge["model"] != judge["deployment"]:
         raise ValueError("judge.model and judge.deployment must match")
+    allowed_reasoning_efforts = {
+        "none", "low", "medium", "high", "xhigh", "max"
+    }
+    reasoning = judge.get("reasoning", {})
+    if not isinstance(reasoning, dict):
+        raise ValueError("judge.reasoning must be an object")
+    if (
+        "effort" in reasoning
+        and reasoning["effort"] not in allowed_reasoning_efforts
+    ):
+        raise ValueError("judge.reasoning.effort is invalid")
+    generation = judge.get("generation", {})
+    if not isinstance(generation, dict):
+        raise ValueError("judge.generation must be an object")
+    if (
+        "finalization_reasoning_effort" in generation
+        and generation["finalization_reasoning_effort"]
+        not in allowed_reasoning_efforts
+    ):
+        raise ValueError(
+            "judge.generation.finalization_reasoning_effort is invalid"
+        )
     grader_route_workloads(config)
 
     # --- v2 tool-calling block (optional) ------------------------------
@@ -384,16 +406,31 @@ def validate_grading_config(config: dict) -> None:
             )
 
     # --- v2 perception block (optional) --------------------------------
-    perception = (judge.get("perception") or {})
+    perception = judge.get("perception", {})
+    if not isinstance(perception, dict):
+        raise ValueError("judge.perception must be an object")
     if perception:
         for sub in ("visual", "audio"):
             sub_cfg = perception.get(sub)
-            if sub_cfg is not None and not any(
-                key in sub_cfg for key in ("model", "deployment")
-            ):
+            if sub_cfg is None:
+                continue
+            if not isinstance(sub_cfg, dict):
+                raise ValueError(
+                    f"judge.perception.{sub} must be an object"
+                )
+            if not any(key in sub_cfg for key in ("model", "deployment")):
                 raise ValueError(
                     f"judge.perception.{sub} present but missing model/deployment"
                 )
+        visual = perception.get("visual")
+        if (
+            isinstance(visual, dict)
+            and "reasoning_effort" in visual
+            and visual["reasoning_effort"] not in allowed_reasoning_efforts
+        ):
+            raise ValueError(
+                "judge.perception.visual.reasoning_effort is invalid"
+            )
 
     # --- v2 critical block (optional) ----------------------------------
     critical = (judge.get("critical") or {})
@@ -807,7 +844,24 @@ def _task_to_dict(task_grade) -> dict:
     return data
 
 
-def _compute_summary(task_dicts: list[dict]) -> dict:
+def _unpriced_models(config: dict) -> list[str]:
+    judge = config["judge"]
+    models = [canonical_deployment(judge, "judge")]
+    perception = judge.get("perception", {}) or {}
+    for modality_name, modality in perception.items():
+        if isinstance(modality, dict):
+            models.append(canonical_deployment(
+                modality,
+                f"judge.perception.{modality_name}",
+            ))
+    return sorted(set(models))
+
+
+def _compute_summary(
+    task_dicts: list[dict],
+    *,
+    unpriced_models: list[str] | None = None,
+) -> dict:
     total = len(task_dicts)
     scored_tasks = [task for task in task_dicts if not task.get("error")]
     graded_tasks = len(scored_tasks)
@@ -933,7 +987,9 @@ def _compute_summary(task_dicts: list[dict]) -> dict:
             "perception_input_tokens": perception_in_tok,
             "perception_output_tokens": perception_out_tok,
             "perception_cached_tokens": perception_cached_tok,
-            "estimated_cost_usd": 0.0,
+            "estimated_cost_usd": None,
+            "pricing_complete": False,
+            "unpriced_models": sorted(set(unpriced_models or [])),
             "total_judge_latency_sec": round(
                 (main_latency_ms + perception_latency_ms) / 1000.0, 2
             ),
@@ -1075,7 +1131,10 @@ def _build_grade_payload(
         "graded_by": "step8_grade.py",
         "graded_by_version": GRADED_BY_VERSION,
         "tasks": task_dicts,
-        "summary": _compute_summary(task_dicts),
+        "summary": _compute_summary(
+            task_dicts,
+            unpriced_models=_unpriced_models(config),
+        ),
     }
 
 

--- a/batch-runner/tests/test_grade_schema.py
+++ b/batch-runner/tests/test_grade_schema.py
@@ -152,6 +152,83 @@ def test_minimal_valid_grade_passes_schema():
     validate(instance=_minimal_payload(), schema=_load_schema())
 
 
+def test_current_grade_requires_explicit_unpriced_cost_provenance():
+    payload = _minimal_payload()
+    payload.update({
+        "schema_version": "1.2",
+        "run_status": "final",
+        "expected_task_count": 1,
+        "expected_ordered_task_ids_sha256": "a" * 64,
+        "azure_ai_routes": [{
+            "endpoint_kind": "direct-v1",
+            "profile": "direct-v1",
+            "workload": "grader",
+            "runtime_fingerprint": "b" * 64,
+        }],
+        "azure_ai_runtime_fingerprint": "b" * 64,
+    })
+    payload["summary"]["cost"].update({
+        "estimated_cost_usd": None,
+        "pricing_complete": False,
+        "unpriced_models": ["gpt-5.4-pro"],
+    })
+
+    validate_grade_payload(payload, _load_schema())
+
+    for field, value in (
+        ("estimated_cost_usd", 0.0),
+        ("pricing_complete", True),
+        ("unpriced_models", []),
+    ):
+        invalid = deepcopy(payload)
+        invalid["summary"]["cost"][field] = value
+        with pytest.raises((ValidationError, ValueError)):
+            validate_grade_payload(invalid, _load_schema())
+
+    for field in (
+        "estimated_cost_usd",
+        "pricing_complete",
+        "unpriced_models",
+    ):
+        invalid = deepcopy(payload)
+        del invalid["summary"]["cost"][field]
+        with pytest.raises(ValidationError):
+            validate_grade_payload(invalid, _load_schema())
+
+    invalid = deepcopy(payload)
+    invalid["summary"]["cost"]["unpriced_models"] = ["gpt-audio-1.5"]
+    with pytest.raises(ValueError, match="persisted model identity"):
+        validate_grade_payload(invalid, _load_schema())
+
+    invalid = deepcopy(payload)
+    del invalid["run_status"]
+    invalid["summary"]["cost"]["unpriced_models"] = ["wrong-model"]
+    with pytest.raises((ValidationError, ValueError)):
+        validate_grade_payload(invalid, _load_schema())
+
+
+@pytest.mark.parametrize("schema_version", ["1.0", "1.1"])
+def test_previous_lifecycle_grade_keeps_numeric_cost_compatibility(
+    schema_version
+):
+    payload = _minimal_payload()
+    payload.update({
+        "schema_version": schema_version,
+        "run_status": "final",
+        "expected_task_count": 1,
+        "expected_ordered_task_ids_sha256": "a" * 64,
+        "azure_ai_routes": [{
+            "endpoint_kind": "direct-v1",
+            "profile": "direct-v1",
+            "workload": "grader",
+            "runtime_fingerprint": "b" * 64,
+        }],
+        "azure_ai_runtime_fingerprint": "b" * 64,
+    })
+
+    validate_grade_payload(payload, _load_schema())
+
+
 def test_missing_required_field_fails():
     payload = _minimal_payload()
     del payload["judge"]
@@ -201,6 +278,7 @@ def test_present_grader_runtime_fingerprint_must_not_be_null():
 def _current_grade_payload() -> dict:
     payload = _minimal_payload()
     payload.update({
+        "schema_version": "1.2",
         "run_status": "partial",
         "expected_task_count": 1,
         "expected_ordered_task_ids_sha256": "a" * 64,
@@ -219,6 +297,11 @@ def _current_grade_payload() -> dict:
             },
         ],
         "azure_ai_runtime_fingerprint": "b" * 64,
+    })
+    payload["summary"]["cost"].update({
+        "estimated_cost_usd": None,
+        "pricing_complete": False,
+        "unpriced_models": ["gpt-5.4-pro"],
     })
     return payload
 

--- a/batch-runner/tests/test_grader_tool_dispatch.py
+++ b/batch-runner/tests/test_grader_tool_dispatch.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 
 def _final(text: str) -> dict:
@@ -32,6 +33,24 @@ class ScriptedResponses:
     def create(self, **kwargs):
         self.calls.append(kwargs)
         return self.script.pop(0)
+
+
+def test_production_sol_max_config_wires_all_grading_roles():
+    from core.grader import Grader
+
+    config_path = Path("grading_configs/default_v2_sol_max.yaml")
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    client = SimpleNamespace(responses=ScriptedResponses([]))
+
+    grader = Grader(config, rubric_loader=None, client=client)
+
+    assert grader.model == "gpt-5.6-sol"
+    assert grader._tool_judge.model == "gpt-5.6-sol"
+    assert grader._tool_judge.reasoning_effort == "max"
+    assert grader._tool_judge.finalization_reasoning_effort == "max"
+    assert grader._tool_judge.vision_perception.deployment == "gpt-5.6-sol"
+    assert grader._tool_judge.vision_perception.reasoning_effort == "max"
+    assert grader._tool_judge.audio_perception.deployment == "gpt-audio-1.5"
 
 
 def test_grader_dispatch_uses_tool_calling_judge_when_configured(monkeypatch, tmp_path):

--- a/batch-runner/tests/test_grading_config.py
+++ b/batch-runner/tests/test_grading_config.py
@@ -9,6 +9,7 @@ from step8_grade import (
     resolve_grade_output_path,
     validate_grading_config,
 )
+from core.azure_ai_clients import AzureAIWorkload, grader_route_workloads
 
 
 INFERENCE_SHA = "a" * 40
@@ -83,11 +84,94 @@ def test_default_v2_config_loads_and_validates():
     assert data["judge"]["critical"]["rule"] == "abs_max_score_threshold"
 
 
+def test_default_v2_sol_max_config_is_complete_production_identity():
+    path = Path("grading_configs/default_v2_sol_max.yaml")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    validate_grading_config(data)
+
+    judge = data["judge"]
+    assert judge["model"] == judge["deployment"] == "gpt-5.6-sol"
+    assert judge["reasoning"] == {"effort": "max"}
+    assert judge["generation"]["finalization_reasoning_effort"] == "max"
+    assert judge["perception"]["visual"]["model"] == "gpt-5.6-sol"
+    assert judge["perception"]["visual"]["deployment"] == "gpt-5.6-sol"
+    assert judge["perception"]["visual"]["reasoning_effort"] == "max"
+    assert judge["perception"]["audio"]["deployment"] == "gpt-audio-1.5"
+    assert "context_window" not in path.read_text(encoding="utf-8")
+    assert grader_route_workloads(data) == [
+        (AzureAIWorkload.GRADER, "gpt-5.6-sol"),
+        (AzureAIWorkload.GRADER, "gpt-5.6-sol"),
+        (AzureAIWorkload.GRADER, "gpt-audio-1.5"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("main", None, "judge.reasoning.effort is invalid"),
+        ("main", "maximum", "judge.reasoning.effort is invalid"),
+        (
+            "finalization",
+            None,
+            "judge.generation.finalization_reasoning_effort is invalid",
+        ),
+        (
+            "finalization",
+            "maximum",
+            "judge.generation.finalization_reasoning_effort is invalid",
+        ),
+        (
+            "visual",
+            None,
+            "judge.perception.visual.reasoning_effort is invalid",
+        ),
+        (
+            "visual",
+            "maximum",
+            "judge.perception.visual.reasoning_effort is invalid",
+        ),
+    ],
+)
+def test_reasoning_efforts_reject_null_and_unknown_values(
+    tmp_path, field, value, message
+):
+    cfg = _valid_config(tmp_path)
+    if field == "main":
+        cfg["judge"]["reasoning"] = {"effort": value}
+    elif field == "finalization":
+        cfg["judge"]["generation"] = {
+            "finalization_reasoning_effort": value,
+        }
+    else:
+        cfg["judge"]["perception"] = {
+            "visual": {
+                "model": "gpt-5.6-sol",
+                "reasoning_effort": value,
+            },
+        }
+
+    with pytest.raises(ValueError, match=message):
+        validate_grading_config(cfg)
+
+
+def test_grade_workflow_defaults_to_v2_sol_max():
+    workflow = yaml.safe_load(
+        Path("../.github/workflows/grade-run.yml").read_text(encoding="utf-8")
+    )
+    triggers = workflow.get("on") or workflow.get(True)
+    assert (
+        triggers["workflow_dispatch"]["inputs"]["grading_config"]["default"]
+        == "default_v2_sol_max.yaml"
+    )
+
+
 @pytest.mark.parametrize(
     "filename",
     [
         "default_gpt5pro.yaml",
         "default_v2.yaml",
+        "default_v2_sol_max.yaml",
         "default_v2_mini.yaml",
         "default_v2_tight.yaml",
         "validation_v2_mini_cohort3.yaml",

--- a/batch-runner/tests/test_hf_publication.py
+++ b/batch-runner/tests/test_hf_publication.py
@@ -219,7 +219,18 @@ def _identity() -> PublicationIdentity:
         result_fingerprint="e" * 64,
         ordered_task_ids=("task-1",),
         results=(PublicationTaskResult("task-1", "", (), (), ()),),
+        expected_narrative_model="gpt-5.6-sol",
+        expected_narrative_reasoning_effort="max",
+        expected_narrative_runtime_fingerprint="d" * 64,
     )
+
+
+def _narrative_identity_kwargs() -> dict:
+    return {
+        "expected_narrative_model": "gpt-5.6-sol",
+        "expected_narrative_reasoning_effort": "max",
+        "expected_narrative_runtime_fingerprint": "d" * 64,
+    }
 
 
 def _report_summary(**overrides) -> dict:
@@ -280,13 +291,22 @@ def _upload_root(
             "result_fingerprint": "e" * 64,
             "ordered_task_ids": ["task-1"],
             "publication_plan": "step7_upload_requested",
+            "narrative_model": "gpt-5.6-sol",
+            "narrative_reasoning_effort": "max",
+            "narrative_runtime_fingerprint": "d" * 64,
+        },
+        "narrative": {
+            "overview": "overview",
+            "quality_analysis": "quality",
+            "failure_patterns": "failures",
+            "recommendations": "recommendations",
         },
         "summary": _report_summary(),
         "task_results": [_report_task_row()],
         "error_tasks": [],
     }
     for key, value in (report_overrides or {}).items():
-        if key in {"summary", "task_results", "error_tasks"}:
+        if key in {"summary", "task_results", "error_tasks", "narrative"}:
             report[key] = value
         else:
             report["meta"][key] = value
@@ -1546,6 +1566,7 @@ def test_publication_rejects_same_path_byte_drift_before_remote_call(tmp_path):
             ),),
             status="success",
         ),),
+        **_narrative_identity_kwargs(),
     )
     report_path = root / "self_report.json"
     report = json.loads(report_path.read_text(encoding="utf-8"))
@@ -1625,6 +1646,111 @@ def test_publication_rejects_stale_self_report_identity(
     assert api.calls == []
 
 
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"narrative_model": "gpt-5.4-pro"}, "narrative model mismatch"),
+        ({"narrative_reasoning_effort": "high"}, "narrative reasoning mismatch"),
+        ({"narrative_runtime_fingerprint": "c" * 64}, "narrative fingerprint mismatch"),
+        ({"narrative_runtime_fingerprint": None}, "narrative identity is incomplete"),
+    ],
+)
+def test_publication_rejects_wrong_or_partial_narrative_identity(
+    tmp_path, overrides, message
+):
+    api = FakeApi()
+
+    with pytest.raises(ValueError, match=message):
+        publish_dataset(
+            "owner/repository",
+            _upload_root(tmp_path, report_overrides=overrides),
+            token="token",
+            expected_head="a" * 40,
+            identity=_identity(),
+            api=api,
+        )
+
+    assert api.calls == []
+
+
+def test_publication_rejects_missing_narrative_identity_keys(tmp_path):
+    api = FakeApi()
+    root = _upload_root(tmp_path)
+    report_path = root / "self_report.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    for field in (
+        "narrative_model",
+        "narrative_reasoning_effort",
+        "narrative_runtime_fingerprint",
+    ):
+        del report["meta"][field]
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="narrative identity is incomplete"):
+        publish_dataset(
+            "owner/repository",
+            root,
+            token="token",
+            expected_head="a" * 40,
+            identity=_identity(),
+            api=api,
+        )
+
+    assert api.calls == []
+
+
+@pytest.mark.parametrize("invalid_value", [None, 7, "", "   "])
+def test_publication_rejects_invalid_model_backed_narrative(
+    tmp_path, invalid_value
+):
+    api = FakeApi()
+    root = _upload_root(tmp_path, report_overrides={
+        "narrative": {
+            "overview": invalid_value,
+            "quality_analysis": "quality",
+            "failure_patterns": "failures",
+            "recommendations": "recommendations",
+        },
+    })
+
+    with pytest.raises(ValueError, match="model-backed narrative is invalid"):
+        publish_dataset(
+            "owner/repository",
+            root,
+            token="token",
+            expected_head="a" * 40,
+            identity=_identity(),
+            api=api,
+        )
+
+    assert api.calls == []
+
+
+def test_publication_accepts_exact_model_free_narrative_fallback(tmp_path):
+    root = _upload_root(tmp_path, report_overrides={
+        "narrative_model": None,
+        "narrative_reasoning_effort": None,
+        "narrative_runtime_fingerprint": None,
+        "narrative": {
+            "overview": "",
+            "quality_analysis": "",
+            "failure_patterns": "",
+            "recommendations": "",
+        },
+    })
+
+    result = publish_dataset(
+        "owner/repository",
+        root,
+        token="token",
+        expected_head="a" * 40,
+        identity=_identity(),
+        api=FakeApi(),
+    )
+
+    assert result.oid == "b" * 40
+
+
 def test_publication_accepts_exact_step6_projection_with_v2_task_fields(tmp_path):
     result = PublicationTaskResult(
         "task-1",
@@ -1654,6 +1780,7 @@ def test_publication_accepts_exact_step6_projection_with_v2_task_fields(tmp_path
         result_fingerprint="e" * 64,
         ordered_task_ids=("task-1",),
         results=(result,),
+        **_narrative_identity_kwargs(),
     )
     row = _report_task_row(
         sector="Financial Services",
@@ -1730,6 +1857,7 @@ def test_publication_binds_exact_ordered_truthy_error_projection(tmp_path):
         result_fingerprint="e" * 64,
         ordered_task_ids=("task-1", "task-2"),
         results=results,
+        **_narrative_identity_kwargs(),
     )
     error_tasks = [
         {
@@ -1835,6 +1963,7 @@ def test_publication_sends_more_than_250_files_in_one_create_commit(tmp_path):
             tuple(records),
             status="success",
         ),),
+        **_narrative_identity_kwargs(),
     )
     report_path = root / "self_report.json"
     report = json.loads(report_path.read_text(encoding="utf-8"))

--- a/batch-runner/tests/test_narrative_analyzer.py
+++ b/batch-runner/tests/test_narrative_analyzer.py
@@ -182,7 +182,7 @@ class TestFactory:
         assert analyzer.runtime_fingerprint == "fingerprint"
         factory.create.assert_called_once_with(
             AzureAIWorkload.NARRATIVE,
-            deployment="gpt-5.4-pro",
+            deployment="gpt-5.6-sol",
             timeout=10000,
             max_retries=None,
             legacy_api_version="2025-04-01-preview",
@@ -230,7 +230,8 @@ class TestAnalyze:
         """Create analyzer with mocked client and fast heartbeat."""
         analyzer = NarrativeAnalyzer.__new__(NarrativeAnalyzer)
         analyzer.client = MagicMock()
-        analyzer.model = "gpt-5.4-pro"
+        analyzer.model = "gpt-5.6-sol"
+        analyzer.reasoning_effort = "max"
         analyzer._heartbeat_active = False
         analyzer._heartbeat_thread = None
         # Disable heartbeat in tests to avoid 30s sleeps
@@ -279,9 +280,14 @@ class TestAnalyze:
         assert result.quality_analysis == "Test QA"
         assert result.failure_patterns == "Test FP"
         assert result.recommendations == "Test rec"
+        assert result.narrative_model == "gpt-5.6-sol"
+        assert result.narrative_reasoning_effort == "max"
         assert result.total_tokens["input"] == 9600
         assert result.total_tokens["output"] == 3900
         assert analyzer.client.responses.create.call_count == 2
+        for call in analyzer.client.responses.create.call_args_list:
+            assert call.kwargs["model"] == "gpt-5.6-sol"
+            assert call.kwargs["reasoning"] == {"effort": "max"}
 
     def test_analyze_call1_invalid_json(self):
         analyzer = self._make_analyzer()

--- a/batch-runner/tests/test_narrative_grade_integration.py
+++ b/batch-runner/tests/test_narrative_grade_integration.py
@@ -85,7 +85,8 @@ def _minimal_grade(model: str = "gpt-5.4-pro", avg: float = 67.4) -> dict:
 def _make_analyzer() -> NarrativeAnalyzer:
     analyzer = NarrativeAnalyzer.__new__(NarrativeAnalyzer)
     analyzer.client = None
-    analyzer.model = "gpt-5.4-pro"
+    analyzer.model = "gpt-5.6-sol"
+    analyzer.reasoning_effort = "max"
     analyzer._heartbeat_active = False
     analyzer._heartbeat_thread = None
     analyzer._start_heartbeat = lambda: None
@@ -220,6 +221,9 @@ def test_step6_report_is_always_pre_grading():
         "overview": "Execution evidence is available.",
         "grading_referenced": False,
         "grade_source": None,
+        "model": "gpt-5.6-sol",
+        "reasoning_effort": "max",
+        "runtime_fingerprint": "f" * 64,
     }
     report = step6_report._build_report_data(
         _result_identity(),
@@ -243,6 +247,9 @@ def test_step6_report_is_always_pre_grading():
     )
 
     assert report["meta"]["report_scope"] == "self_assessed_pre_grading"
+    assert report["meta"]["narrative_model"] == "gpt-5.6-sol"
+    assert report["meta"]["narrative_reasoning_effort"] == "max"
+    assert report["meta"]["narrative_runtime_fingerprint"] == "f" * 64
     markdown = step6_report._build_markdown(report)
     assert "Self-Assessed, Pre-Grading" in markdown
     assert "Awaiting external grading" in markdown

--- a/batch-runner/tests/test_step6_v2_fields.py
+++ b/batch-runner/tests/test_step6_v2_fields.py
@@ -417,9 +417,9 @@ def test_primary_narrative_failure_uses_sanitized_model_free_fallback(
 
     secret = "private endpoint and credential detail"
     monkeypatch.setattr(
-        azure_ai_clients,
-        "preflight_routes",
-        lambda workloads, **_kwargs: [],
+        narrative_analyzer,
+        "expected_narrative_publication_identity",
+        lambda: ("gpt-5.6-sol", "max", "f" * 64),
     )
     monkeypatch.setattr(
         narrative_analyzer,
@@ -450,7 +450,11 @@ def test_narrative_route_drift_falls_back_before_api_call(
     import core.azure_ai_clients as azure_ai_clients
     import core.narrative_analyzer as narrative_analyzer
 
-    analyzer = MagicMock(runtime_fingerprint="actual")
+    analyzer = MagicMock(
+        model="gpt-5.6-sol",
+        reasoning_effort="max",
+        runtime_fingerprint="a" * 64,
+    )
     analyzer.__enter__.return_value = analyzer
     analyzer.__exit__.return_value = None
     monkeypatch.setattr(
@@ -462,7 +466,7 @@ def test_narrative_route_drift_falls_back_before_api_call(
 
     def preflight(workloads, **kwargs):
         captured.update(kwargs)
-        return [{"runtime_fingerprint": "expected"}]
+        return [{"runtime_fingerprint": "e" * 64}]
 
     monkeypatch.setattr(azure_ai_clients, "preflight_routes", preflight)
     monkeypatch.setattr(step6_report, "WORKSPACE_DIR", tmp_path)

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -118,7 +118,10 @@ def test_compute_summary_includes_perception_in_total_cost_volume():
         "usage_complete": True,
     }
 
-    cost = s8._compute_summary([task])["cost"]
+    cost = s8._compute_summary(
+        [task],
+        unpriced_models=["gpt-5.6-sol", "gpt-audio-1.5"],
+    )["cost"]
 
     assert cost["total_judge_calls"] == 5
     assert cost["total_main_judge_calls"] == 2
@@ -132,6 +135,9 @@ def test_compute_summary_includes_perception_in_total_cost_volume():
     assert cost["total_render_calls"] == 3
     assert cost["total_render_latency_sec"] == 0.01
     assert cost["usage_complete"] is True
+    assert cost["estimated_cost_usd"] is None
+    assert cost["pricing_complete"] is False
+    assert cost["unpriced_models"] == ["gpt-5.6-sol", "gpt-audio-1.5"]
 
 
 def _setup_workspace(tmp_path: Path):
@@ -455,7 +461,7 @@ def test_force_overwrites(monkeypatch, tmp_path):
     code = s8.main()
     assert code == 0
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == "1.0"
+    assert payload["schema_version"] == "1.2"
 
 
 def test_main_preflight_matches_grader_transport_before_calls(
@@ -1211,7 +1217,7 @@ def _seed_partial_grade(
         )
     )
     payload = {
-        "schema_version": "1.0",
+        "schema_version": "1.2",
         "run_status": run_status,
         "expected_task_count": 3,
         "expected_ordered_task_ids_sha256": s8._ordered_task_ids_sha256(
@@ -1254,7 +1260,10 @@ def _seed_partial_grade(
         "graded_at": "2026-05-27T00:00:00Z",
         "graded_by": "step8_grade.py",
         "tasks": task_rows,
-        "summary": s8._compute_summary(task_rows),
+        "summary": s8._compute_summary(
+            task_rows,
+            unpriced_models=["gpt-5.4-pro"],
+        ),
     }
     payload["azure_ai_runtime_fingerprint"] = payload[
         "azure_ai_routes"
@@ -1555,7 +1564,10 @@ def test_track2_resume_rejects_runtime_failure_before_grader(
     payload = json.loads(out.read_text(encoding="utf-8"))
     payload["tasks"][0]["error"] = "judge_error"
     payload["tasks"][0]["usage_complete"] = False
-    payload["summary"] = s8._compute_summary(payload["tasks"])
+    payload["summary"] = s8._compute_summary(
+        payload["tasks"],
+        unpriced_models=["gpt-5.4-pro"],
+    )
     out.write_text(json.dumps(payload), encoding="utf-8")
     monkeypatch.setattr("sys.argv", [
         "step8_grade.py", "exp998_smoke_baseline_sample",
@@ -2023,7 +2035,7 @@ def test_time_budget_exit_7_writes_partial(monkeypatch, tmp_path, capsys):
     out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
     assert out.exists()
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == "1.0"
+    assert payload["schema_version"] == "1.2"
     assert [task["task_id"] for task in payload["tasks"]] == ["task-001"]
     stderr = capsys.readouterr().err
     assert "provider_error:OSError" in stderr
@@ -2131,16 +2143,63 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
         encoding="utf-8"
     )
     parsed = yaml.safe_load(workflow)
-    assert list(parsed["jobs"]) == ["grade"]
-    assert parsed["permissions"] == {
+    assert list(parsed["jobs"]) == [
+        "validate-request",
+        "approve-paid",
+        "grade-dry-run",
+        "grade",
+    ]
+    assert parsed["permissions"] == {"contents": "read"}
+
+    validate_job = parsed["jobs"]["validate-request"]
+    approval_job = parsed["jobs"]["approve-paid"]
+    dry_run_job = parsed["jobs"]["grade-dry-run"]
+    grade_job = parsed["jobs"]["grade"]
+    assert approval_job["needs"] == "validate-request"
+    assert approval_job["if"] == (
+        "inputs.dry_run == false && inputs.paid_approval == true"
+    )
+    assert approval_job["environment"] == {"name": "grading"}
+    assert "permissions" not in approval_job
+    assert dry_run_job["needs"] == "validate-request"
+    assert dry_run_job["if"] == "inputs.dry_run == true"
+    assert dry_run_job["permissions"] == {"contents": "read"}
+    assert "environment" not in dry_run_job
+    dry_steps = dry_run_job["steps"]
+    dry_by_name = {
+        step.get("name"): step for step in dry_steps if step.get("name")
+    }
+    assert dry_by_name["Checkout exact main revision (read-only)"]["with"] == {
+        "ref": "main",
+        "persist-credentials": False,
+    }
+    assert "repository credentials" in dry_by_name[
+        "Verify read-only checkout and input files"
+    ]["run"]
+    assert "--dry-run" in dry_by_name["Classify grading work only"]["run"]
+    assert "secrets." not in yaml.safe_dump(dry_run_job)
+    assert "id-token" not in yaml.safe_dump(dry_run_job)
+    assert "actions" not in dry_run_job["permissions"]
+    assert grade_job["needs"] == ["validate-request", "approve-paid"]
+    assert "inputs.dry_run == false" in grade_job["if"]
+    assert "inputs.paid_approval == true" in grade_job["if"]
+    assert "needs.validate-request.result == 'success'" in grade_job["if"]
+    assert "needs.approve-paid.result == 'success'" in grade_job["if"]
+    assert "environment" not in grade_job
+    assert grade_job["permissions"] == {
         "contents": "write",
         "id-token": "write",
         "actions": "write",
     }
 
-    steps = parsed["jobs"]["grade"]["steps"]
+    validate_steps = validate_job["steps"]
+    validate_inputs = next(
+        step
+        for step in validate_steps
+        if step.get("name") == "Validate workflow context and inputs"
+    )
+    steps = grade_job["steps"]
     by_name = {step.get("name"): step for step in steps if step.get("name")}
-    validate_inputs = by_name["Validate workflow context and inputs"]
     checkout = by_name["Checkout exact main revision"]
     verify_checkout = by_name["Verify checked out main and input files"]
     download = by_name["Download inference results from HF"]
@@ -2228,6 +2287,7 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
     assert "steps.commit_grade.outputs.committed == 'true'" in retrigger["if"]
     assert '-f inference_revision="$RESOLVED_INFERENCE_REVISION"' in retrigger["run"]
     assert '-f tasks_limit="$GRADE_TASKS_LIMIT"' in retrigger["run"]
+    assert '-f paid_approval="$GRADE_PAID_APPROVAL"' in retrigger["run"]
 
     assert workflow.index("- name: Validate workflow context and inputs") < workflow.index(
         "- name: Checkout exact main revision"
@@ -2246,7 +2306,7 @@ def _run_grade_workflow_input_preflight(**overrides):
     )
     validate_step = next(
         step
-        for step in workflow["jobs"]["grade"]["steps"]
+        for step in workflow["jobs"]["validate-request"]["steps"]
         if step.get("name") == "Validate workflow context and inputs"
     )
     sha = "a" * 40
@@ -2266,7 +2326,8 @@ def _run_grade_workflow_input_preflight(**overrides):
         "GRADE_INFERENCE_REVISION": "",
         "GRADE_FORCE": "false",
         "GRADE_TASKS_LIMIT": "0",
-        "GRADE_DRY_RUN": "false",
+        "GRADE_DRY_RUN": "true",
+        "GRADE_PAID_APPROVAL": "false",
         "GRADE_RESUME": "false",
         "GRADE_RESUME_CHUNK": "0",
         **overrides,
@@ -2286,6 +2347,8 @@ def _run_grade_workflow_input_preflight(**overrides):
         {},
         {
             "GRADE_INFERENCE_REVISION": "b" * 40,
+            "GRADE_DRY_RUN": "false",
+            "GRADE_PAID_APPROVAL": "true",
             "GRADE_RESUME": "true",
             "GRADE_RESUME_CHUNK": "1",
         },
@@ -2307,6 +2370,9 @@ def test_grade_workflow_input_preflight_accepts_valid_dispatch(overrides):
         ({"GRADE_CONFIG": "../config.yaml"}, "grading_config"),
         ({"GRADE_INFERENCE_REVISION": "A" * 40}, "inference_revision"),
         ({"GRADE_FORCE": "yes"}, "GRADE_FORCE"),
+        ({"GRADE_PAID_APPROVAL": "yes"}, "GRADE_PAID_APPROVAL"),
+        ({"GRADE_DRY_RUN": "false"}, "requires paid_approval=true"),
+        ({"GRADE_PAID_APPROVAL": "true"}, "must not request paid approval"),
         ({"GRADE_TASKS_LIMIT": "01"}, "tasks_limit"),
         ({"GRADE_TASKS_LIMIT": "221"}, "tasks_limit"),
         ({"GRADE_RESUME_CHUNK": "11"}, "resume_chunk"),

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -363,6 +363,144 @@ def test_empty_final_retry_budget_exhaustion_stays_fail_closed(
     assert len(client.responses.calls) == 2
 
 
+def test_finalization_retry_uses_configured_max_effort(
+    deliverable_dir, task_and_item
+):
+    task, item = task_and_item
+    empty = _response(
+        out_tok=2400,
+        status="incomplete",
+        incomplete_reason="max_output_tokens",
+    )
+    final = _response(
+        output=[_final(json.dumps({
+            "verdict": "pass",
+            "partial_score": 1.0,
+            "evidence": "validated from prior evidence",
+            "confidence": 0.9,
+            "reasoning": "finalized with max effort",
+        }))],
+    )
+    client = FakeClient(ScriptedResponses([empty, final]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.6-sol",
+        prompt_template=PROMPT_TEMPLATE,
+        reasoning_effort="max",
+        finalization_reasoning_effort="max",
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+    assert result.verdict == "pass"
+    assert client.responses.calls[0]["reasoning"] == {"effort": "max"}
+    assert client.responses.calls[1]["reasoning"] == {"effort": "max"}
+
+
+def test_semantic_invalid_final_retries_once_with_configured_max_effort(
+    deliverable_dir, task_and_item
+):
+    task, item = task_and_item
+    invalid = _response(output=[_final("{}")])
+    final = _response(
+        output=[_final(json.dumps({
+            "verdict": "pass",
+            "partial_score": 1.0,
+            "evidence": "validated from prior evidence",
+            "confidence": 0.9,
+            "reasoning": "semantic envelope recovered",
+        }))],
+    )
+    client = FakeClient(ScriptedResponses([invalid, final]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.6-sol",
+        prompt_template=PROMPT_TEMPLATE,
+        reasoning_effort="max",
+        finalization_reasoning_effort="max",
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+    assert result.verdict == "pass"
+    assert result.main_api_call_count == 2
+    assert "tools" not in client.responses.calls[1]
+    assert client.responses.calls[1]["reasoning"] == {"effort": "max"}
+
+
+def test_semantic_invalid_final_at_iteration_limit_uses_retry_budget(
+    deliverable_dir, task_and_item
+):
+    task, item = task_and_item
+    invalid = _response(output=[_final("{}")])
+    final = _response(output=[_final(json.dumps({
+        "verdict": "pass",
+        "partial_score": 1.0,
+        "evidence": "recovered after the normal iteration budget",
+        "confidence": 0.9,
+        "reasoning": "bounded finalization succeeded",
+    }))])
+    client = FakeClient(ScriptedResponses([invalid, final]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.6-sol",
+        prompt_template=PROMPT_TEMPLATE,
+        max_iterations=1,
+        finalization_retries=1,
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+    assert result.verdict == "pass"
+    assert result.main_api_call_count == 2
+    assert result.iterations == 2
+    assert "tools" not in client.responses.calls[1]
+
+
+def test_semantic_invalid_final_at_iteration_limit_retries_only_once(
+    deliverable_dir, task_and_item
+):
+    task, item = task_and_item
+    client = FakeClient(ScriptedResponses([
+        _response(output=[_final("{}")]),
+        _response(output=[_final("{}")]),
+    ]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.6-sol",
+        prompt_template=PROMPT_TEMPLATE,
+        max_iterations=1,
+        finalization_retries=1,
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+    assert result.verdict == "judge_error"
+    assert result.main_api_call_count == 2
+    assert result.iterations == 2
+    assert len(client.responses.calls) == 2
+
+
 def test_malformed_final_json_retries_once_without_tools(
     deliverable_dir, task_and_item, caplog
 ):
@@ -1682,6 +1820,7 @@ def test_invalid_numeric_final_envelope_is_score_excluded_judge_error(
         client=client,
         model="gpt-5.4",
         prompt_template=PROMPT_TEMPLATE,
+        finalization_retries=0,
     ).judge_item(
         task=task,
         item=item,
@@ -1713,7 +1852,8 @@ def test_missing_confidence_is_invalid_final_envelope(
     ]))
 
     result = ToolCallingJudge(
-        client=client, model="gpt-5.4", prompt_template=PROMPT_TEMPLATE
+        client=client, model="gpt-5.4", prompt_template=PROMPT_TEMPLATE,
+        finalization_retries=0,
     ).judge_item(
         task=task,
         item=item,
@@ -1742,7 +1882,8 @@ def test_five_thousand_digit_json_integer_is_invalid_not_an_exception(
     ]))
 
     result = ToolCallingJudge(
-        client=client, model="gpt-5.4", prompt_template=PROMPT_TEMPLATE
+        client=client, model="gpt-5.4", prompt_template=PROMPT_TEMPLATE,
+        finalization_retries=0,
     ).judge_item(
         task=task,
         item=item,

--- a/docs/first-experiment.md
+++ b/docs/first-experiment.md
@@ -57,8 +57,9 @@ access without storing an Azure client secret.
 
 The checked-in smoke config uses Azure deployment `gpt-5.2-chat`, selects three
 tasks, and can retry Self-QA up to three times. Step 6 attempts up to two
-sequential `gpt-5.4-pro` report calls; calls completed before an error can still
-be billed. Any setup, call, parse, or route-validation failure immediately
+sequential `gpt-5.6-sol` report calls with `reasoning=max`; calls completed
+before an error can still be billed. The 1.05M context window is supplied by
+the deployment. Any setup, call, parse, or route-validation failure immediately
 produces a model-free report and does not call the experiment model. Exact time
 and cost depend on output size, retries, quota, and your Azure pricing.
 
@@ -67,8 +68,8 @@ and cost depend on output size, retries, quota, and your Azure pricing.
 You need:
 
 - a GitHub account and a fork of this repository;
-- an Azure subscription with an Azure OpenAI resource and a required deployment
-   named `gpt-5.2-chat`; `gpt-5.4-pro` is optional but needed for the primary
+- an Azure subscription with an Azure OpenAI resource and required deployments
+   named `gpt-5.2-chat` and `gpt-5.6-sol`; the latter owns the primary Sol Max
    two-call report path;
 - permission to create a Microsoft Entra app registration and assign the
   **Cognitive Services OpenAI User** role on that Azure OpenAI resource; and
@@ -269,7 +270,7 @@ The expected path is:
 | Step 2 | Calls the model, creates deliverables, and runs same-model Self-QA |
 | Steps 3-4 | Writes JSON/Markdown results and a three-row Parquet file |
 | Step 5 | Skipped because `dry_run` is true and because this sample has three tasks |
-| Step 6 | Attempts up to two `gpt-5.4-pro` report calls; any narrative failure triggers an immediate model-free report before publication, with no experiment-model fallback |
+| Step 6 | Attempts up to two `gpt-5.6-sol` report calls with `reasoning=max`; any narrative failure triggers an immediate model-free report before publication, with no experiment-model fallback |
 | Step 7 and result PR | Skipped because `dry_run` is true |
 
 When the credentialed batch job reaches its final `always()` step, it attempts
@@ -313,7 +314,11 @@ size. Unchecking `dry_run` publishes results and opens a result pull request; it
 does not turn a three-task config into a 220-task run.
 
 Full runs can use substantial model quota and take multiple relay jobs. External
-grading is a separate pipeline. Read the
+grading is a separate pipeline. `grade-run.yml` starts as a model-free dry run;
+paid grading requires `paid_approval: true` plus approval in the protected
+`grading` GitHub Environment. Automatic grading continuations preserve the
+approval input, exact config, inference revision, and task limit, but each new
+chunk requires a fresh protected Environment approval. Read the
 [Batch Runner documentation](../batch-runner/README.md) and the
 [sandbox documentation](../batch-runner/sandbox/README.md) before changing the
 execution mode or scaling to all 220 tasks.

--- a/docs/first-experiment_KR.md
+++ b/docs/first-experiment_KR.md
@@ -58,18 +58,19 @@ job에서 이어갑니다. **OpenID Connect(OIDC)**는 Azure client secret을 �
 
 체크인된 스모크 설정은 Azure 배포 `gpt-5.2-chat`을 사용하고 3개 태스크를
 선택하며 Self-QA를 최대 3회 재시도할 수 있습니다. Step 6은
-`gpt-5.4-pro`를 순차적으로 최대 2회 호출하며 오류 전에 완료된 호출도 과금될
-수 있습니다. 설정, 호출, 파싱, route 검증 중 하나라도 실패하면 즉시
-model-free report를 만들고 실험 모델은 추가 호출하지 않습니다. 따라서 시간과
-비용은 출력 크기, 재시도, 쿼터, Azure 가격에 따라 달라집니다.
+`gpt-5.6-sol`을 `reasoning=max`로 순차적으로 최대 2회 호출하며 오류 전에
+완료된 호출도 과금될 수 있습니다. 1.05M context window는 deployment가
+제공합니다. 설정, 호출, 파싱, route 검증 중 하나라도 실패하면 즉시 model-free
+report를 만들고 실험 모델은 추가 호출하지 않습니다. 따라서 시간과 비용은
+출력 크기, 재시도, 쿼터, Azure 가격에 따라 달라집니다.
 
 ### 1. 계정 준비
 
 다음이 필요합니다.
 
 - GitHub 계정과 이 저장소의 fork
-- Azure 구독, Azure OpenAI 리소스, 필수 `gpt-5.2-chat` 배포. 기본 2-call
-   report 경로를 사용하려면 선택적으로 `gpt-5.4-pro` 배포도 필요
+- Azure 구독, Azure OpenAI 리소스, 필수 `gpt-5.2-chat` 및
+   `gpt-5.6-sol` 배포. 후자가 기본 Sol Max 2-call report 경로를 담당
 - Microsoft Entra 앱 등록 권한과 해당 Azure OpenAI 리소스에
   **Cognitive Services OpenAI User** 역할을 부여할 권한
 - 쓰기 토큰을 만들 수 있는 Hugging Face 계정
@@ -262,7 +263,7 @@ Docker sandbox나 agentic preflight를 실행하는 테스트가 아닙니다.
 | Step 2 | 모델 호출, 산출물 생성, 같은 모델의 Self-QA 실행 |
 | Steps 3-4 | JSON/Markdown 결과와 3-row Parquet 생성 |
 | Step 5 | `dry_run`이 true이고 sample도 3개이므로 건너뜀 |
-| Step 6 | `gpt-5.4-pro` report를 최대 2회 호출. Narrative 실패 시 실험 모델 fallback 없이 게시 전에 즉시 model-free report 생성 |
+| Step 6 | `gpt-5.6-sol` report를 `reasoning=max`로 최대 2회 호출. Narrative 실패 시 실험 모델 fallback 없이 게시 전에 즉시 model-free report 생성 |
 | Step 7과 결과 PR | `dry_run`이므로 건너뜀 |
 
 credentialed batch job이 마지막 `always()` 단계에 도달하면
@@ -305,8 +306,12 @@ Self-QA는 산출물을 만든 같은 모델의 재시도 신호입니다. 독�
 220-task 전체 실행으로 바뀌는 것은 아닙니다.
 
 전체 실행은 큰 모델 쿼터를 사용할 수 있고 여러 relay job이 필요할 수
-있습니다. 외부 채점은 별도 파이프라인입니다. 실행 모드를 바꾸거나 220개로
-확대하기 전에 [Batch Runner 문서](../batch-runner/README_KR.md)와
+있습니다. 외부 채점은 별도 pipeline입니다. `grade-run.yml`은 model-free
+dry run으로 시작하며, 유료 채점은 `paid_approval: true`와 보호된 `grading`
+GitHub Environment 승인이 모두 필요합니다. 자동 grading continuation은
+approval input과 exact config, inference revision, task limit을 전달하지만,
+새로 dispatch되는 각 chunk는 보호된 Environment 승인을 다시 받아야 합니다.
+실행 모드를 바꾸거나 220개로 확대하기 전에 [Batch Runner 문서](../batch-runner/README_KR.md)와
 [sandbox 문서](../batch-runner/sandbox/README.md)를 읽으세요.
 
 한 번만 시험했다면 일회성 Hugging Face dataset을 삭제하고, 전용 token을

--- a/scripts/__tests__/aggregate-grades.test.mjs
+++ b/scripts/__tests__/aggregate-grades.test.mjs
@@ -62,6 +62,29 @@ test('processGradesFile treats v1 as real even when contradictory legacy dummy m
   assert.equal(out.experiment_id, 'exp-v1-real');
 });
 
+test('processGradesFile routes current schema 1.2 through item-level grading', () => {
+  const raw = {
+    schema_version: '1.2',
+    experiment_id: 'exp-current',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.6-sol' },
+    summary: {
+      total_tasks: 0,
+      graded_tasks: 0,
+      error_tasks: 0,
+      openai_compat: {},
+      wow: {},
+    },
+    tasks: [],
+  };
+
+  const out = processGradesFile('current.json', raw);
+
+  assert.equal(out.grade_status, 'graded_v1');
+  assert.equal(out.schema_version, '1.2');
+  assert.equal(out.judge_model, 'gpt-5.6-sol');
+});
+
 // ── Fixture A — minimal v1 grade with empty `inference_model` ───────────────
 test('processGradesFile: v1 with empty inference_model does not fall back to judge.model', () => {
   const raw = {

--- a/scripts/__tests__/onboarding-contract.test.mjs
+++ b/scripts/__tests__/onboarding-contract.test.mjs
@@ -358,7 +358,7 @@ test('workflow input tables mirror defaults and watchdog delegation', async () =
     assert.match(await readFile(outputPath, 'utf8'), /^source_repo=openai\/gdpval$/m)
     assert.match(
       await readFile(outputPath, 'utf8'),
-      /^azure_ai_workloads_json=\["narrative=gpt-5\.4-pro","inference=main-deployment","inference=qa-deployment","inference=audio-deployment","code-interpreter=main-deployment","narrative=main-deployment"\]$/m,
+      /^azure_ai_workloads_json=\["narrative=gpt-5\.6-sol","inference=main-deployment","inference=qa-deployment","inference=audio-deployment","code-interpreter=main-deployment"\]$/m,
     )
     assert.match(await readFile(outputPath, 'utf8'), /^requires_openai_key=true$/m)
     assert.match(await readFile(outputPath, 'utf8'), /^requires_anthropic_key=true$/m)
@@ -809,7 +809,10 @@ test('report, publication, and artifact destinations follow Step 6 and Step 7', 
   assert.match(step6Text, /"ordered_task_ids": list\(ordered_task_ids\)/)
   assert.match(narrativeText, /Call 1: Sector-level analysis/)
   assert.match(narrativeText, /Call 2: Deep analysis/)
-  assert.match(narrativeText, /DEFAULT_MODEL = "gpt-5\.4-pro"/)
+  assert.match(narrativeText, /DEFAULT_MODEL = "gpt-5\.6-sol"/)
+  assert.match(narrativeText, /DEFAULT_REASONING_EFFORT = "max"/)
+  assert.match(step6Text, /"narrative_model": narrative\.get\("model"\)/)
+  assert.match(step6Text, /"narrative_reasoning_effort": narrative\.get\("reasoning_effort"\)/)
 
   assert.deepEqual(
     extractPythonStringList(publicationText, 'INCLUDE_PATTERNS'),
@@ -931,6 +934,55 @@ test('report, publication, and artifact destinations follow Step 6 and Step 7', 
     assert.doesNotMatch(runner, /results\/<experiment_id>\/report\/[^\n]*HuggingFace/)
     assert.match(runner, /step6_report\.sh --no-narrative/)
   }
+})
+
+test('current operator docs bind narrative and grading to Sol 1M Max', async () => {
+  const [
+    rootEnglish,
+    rootKorean,
+    runnerEnglish,
+    runnerKorean,
+    guideEnglish,
+    guideKorean,
+    gradingReadme,
+    gradeWorkflowText,
+    productionConfigText,
+  ] = await Promise.all([
+    readRepoFile('README.md'),
+    readRepoFile('README_KR.md'),
+    readRepoFile('batch-runner/README.md'),
+    readRepoFile('batch-runner/README_KR.md'),
+    readRepoFile('docs/first-experiment.md'),
+    readRepoFile('docs/first-experiment_KR.md'),
+    readRepoFile('batch-runner/grading_configs/README.md'),
+    readRepoFile('.github/workflows/grade-run.yml'),
+    readRepoFile('batch-runner/grading_configs/default_v2_sol_max.yaml'),
+  ])
+
+  for (const document of [
+    rootEnglish,
+    rootKorean,
+    runnerEnglish,
+    runnerKorean,
+    guideEnglish,
+    guideKorean,
+  ]) {
+    assert.match(document, /gpt-5\.6-sol/)
+    assert.match(document, /reasoning=max/)
+    assert.doesNotMatch(document, /gpt-5\.4-pro/)
+  }
+
+  const gradeWorkflow = parse(gradeWorkflowText)
+  assert.equal(
+    gradeWorkflow.on.workflow_dispatch.inputs.grading_config.default,
+    'default_v2_sol_max.yaml',
+  )
+  assert.match(gradingReadme, /Production default[\s\S]*GPT-5\.6 Sol 1M Max/)
+  assert.match(productionConfigText, /model: "gpt-5\.6-sol"/)
+  assert.match(productionConfigText, /effort: "max"/)
+  assert.match(productionConfigText, /finalization_reasoning_effort: "max"/)
+  assert.match(productionConfigText, /model: "gpt-audio-1\.5"/)
+  assert.doesNotMatch(productionConfigText, /^\s*context_window:/m)
 })
 
 test('English and Korean Batch Runner references retain structural parity', async () => {

--- a/scripts/__tests__/test_analyze_grade_run.py
+++ b/scripts/__tests__/test_analyze_grade_run.py
@@ -93,6 +93,44 @@ def test_single_model_cost_is_nonzero(tmp_path: Path):
     assert cost["cost_usd"] < 0.02
 
 
+def test_sol_max_and_audio_remain_explicitly_unpriced(tmp_path: Path):
+    grade = _grade_json(model="gpt-5.6-sol", n_tasks=1)
+    grade["judge"]["reasoning_effort"] = "max"
+    grade["judge"]["perception"] = {
+        "visual": {"model": "gpt-5.6-sol"},
+        "audio": {"model": "gpt-audio-1.5"},
+    }
+    task = grade["tasks"][0]
+    task.update({
+        "judge_cached_tokens": 100,
+        "perception_call_count": 1,
+        "perception_input_tokens": 1_000,
+        "perception_output_tokens": 100,
+        "perception_cached_tokens": 10,
+    })
+    task["items"] = [{
+        "routing_modality": "audio",
+        "perception_input_tokens": 1_000,
+        "perception_output_tokens": 100,
+        "perception_cached_tokens": 10,
+    }]
+
+    analyzed = _run(tmp_path, grade)["this"]
+    raw = analyzed["cost_estimate"]
+    effective = analyzed["effective_cost"]
+
+    assert raw["pricing_complete"] is False
+    assert raw["cost_usd"] is None
+    assert raw["unpriced_models"] == ["gpt-5.6-sol", "gpt-audio-1.5"]
+    assert effective["pricing_complete"] is False
+    assert effective["total_usd"] is None
+    assert effective["unpriced_models"] == ["gpt-5.6-sol", "gpt-audio-1.5"]
+
+    markdown = _run(tmp_path, grade, as_json=False)
+    assert "$0.00" not in markdown
+    assert "unpriced" in markdown
+
+
 def test_perception_usage_is_included_and_reported_separately(tmp_path: Path):
     grade = _grade_json(model="gpt-5.4", n_tasks=1)
     task = grade["tasks"][0]

--- a/scripts/aggregate-grades.mjs
+++ b/scripts/aggregate-grades.mjs
@@ -288,10 +288,9 @@ function processV1GradesFile(filePath, raw, taskQaByExperiment = new Map()) {
 }
 
 export function processGradesFile(filePath, raw, taskQaByExperiment = new Map()) {
-  // PR1 task 103 — schema 1.1 is a superset of 1.0 (adds model_did_right,
-  // pct_raw, sign-aware critical_item_pass_rate). Route both through the
-  // same v1 processor.
-  if (raw && (raw.schema_version === '1.0' || raw.schema_version === '1.1')) {
+  // All item-level 1.x payloads share the rich grade projection. Later minor
+  // versions add provenance contracts without changing dashboard score shape.
+  if (raw && ['1.0', '1.1', '1.2'].includes(raw.schema_version)) {
     return processV1GradesFile(filePath, raw, taskQaByExperiment);
   }
   return processLegacyGradesFile(filePath, raw, taskQaByExperiment);
@@ -389,7 +388,7 @@ async function main() {
   console.log(`✅ Aggregated ${results.length} grade file(s) → grades-index.json`);
   for (const r of results) {
     const dummy = r.is_dummy ? ' [DUMMY]' : '';
-    const v1 = r.schema_version === '1.0' ? ' [v1.0]' : '';
+    const v1 = r.schema_version ? ` [v${r.schema_version}]` : '';
     console.log(`   ${r.id}: ${r.summary.avg_score_pct}% avg (${r.summary.graded_tasks}/${r.summary.total_tasks} tasks)${dummy}${v1}`);
   }
 }

--- a/scripts/analyze_grade_run.py
+++ b/scripts/analyze_grade_run.py
@@ -5,10 +5,10 @@ Usage:
     python scripts/analyze_grade_run.py data/grades/<exp_id>__<judge>__<sha>__v1.json
     python scripts/analyze_grade_run.py <new.json> --compare <baseline.json>
 
-The pricing table is a coarse estimate (Azure OpenAI list prices, 2025-Q2);
-edit `PRICING_USD_PER_M_TOKENS` to keep current. `estimated_cost_usd` written
-by step8 is always 0.0; this script computes a price-table-based estimate from
-actual main-judge and perception input/output tokens.
+The pricing table is a coarse estimate for historical runs; unregistered models
+remain explicitly unpriced instead of being reported as zero. Step 8 records
+current payload cost as null/incomplete; this script computes an estimate only
+for models present in its reviewed price table.
 """
 from __future__ import annotations
 
@@ -52,6 +52,13 @@ def _price_for(model: str) -> tuple[float, float]:
 
 def _estimate_cost(in_tok: int, out_tok: int, model: str) -> dict:
     """Return cost as {input_usd, output_usd, total_usd} for transparency."""
+    if model not in PRICING_USD_PER_M_TOKENS:
+        return {
+            "input_usd": None,
+            "output_usd": None,
+            "total_usd": None,
+            "pricing_available": False,
+        }
     pi, po = _price_for(model)
     in_cost = (in_tok / 1_000_000.0) * pi
     out_cost = (out_tok / 1_000_000.0) * po
@@ -59,6 +66,7 @@ def _estimate_cost(in_tok: int, out_tok: int, model: str) -> dict:
         "input_usd": round(in_cost, 4),
         "output_usd": round(out_cost, 4),
         "total_usd": round(in_cost + out_cost, 4),
+        "pricing_available": True,
     }
 
 
@@ -79,6 +87,8 @@ def _hybrid_cost_estimate(grade: dict, total_in: int, total_out: int) -> dict:
             "cost_usd": c["total_usd"],
             "input_usd": c["input_usd"],
             "output_usd": c["output_usd"],
+            "pricing_complete": c["pricing_available"],
+            "unpriced_models": [] if c["pricing_available"] else [m],
         }
 
     # tier proxy: count items decided_by != precheck and split by ... we have
@@ -101,13 +111,24 @@ def _hybrid_cost_estimate(grade: dict, total_in: int, total_out: int) -> dict:
             "input_usd_at_100pct": c["input_usd"],
             "output_usd_at_100pct": c["output_usd"],
         })
-    costs = [p["cost_at_100pct"] for p in per_model]
+    unpriced_models = sorted({
+        entry["model"]
+        for entry in per_model
+        if entry["cost_at_100pct"] is None
+    })
+    costs = [
+        entry["cost_at_100pct"]
+        for entry in per_model
+        if entry["cost_at_100pct"] is not None
+    ]
     return {
         "mode": "routing_blended_estimate",
         "tier_models": tier_models,
-        "cost_usd_min": min(costs),
-        "cost_usd_max": max(costs),
+        "cost_usd_min": min(costs) if costs and not unpriced_models else None,
+        "cost_usd_max": max(costs) if costs and not unpriced_models else None,
         "per_model_if_100pct": per_model,
+        "pricing_complete": not unpriced_models,
+        "unpriced_models": unpriced_models,
         "note": "Token split per tier is not recorded; range = single-model bounds.",
     }
 
@@ -231,7 +252,7 @@ def _combined_cost_estimate(
     main_model = grade.get("judge", {}).get("model", "")
     perception_cfg = grade.get("judge", {}).get("perception", {}) or {}
     components = []
-    unpriced_models = []
+    unpriced_models = list(main.get("unpriced_models", []))
     perception_total = 0.0
     for modality, token_usage in sorted(perception_usage.items()):
         model = (
@@ -244,7 +265,8 @@ def _combined_cost_estimate(
         )
         if not priced:
             unpriced_models.append(model)
-        perception_total += estimate["total_usd"]
+        if estimate["total_usd"] is not None:
+            perception_total += estimate["total_usd"]
         components.append({
             "modality": modality,
             "model": model,
@@ -260,7 +282,13 @@ def _combined_cost_estimate(
         "pricing_complete": not unpriced_models,
         "unpriced_models": sorted(set(unpriced_models)),
     }
-    if main.get("mode") == "single":
+    if unpriced_models:
+        if main.get("mode") == "single":
+            out["cost_usd"] = None
+        else:
+            out["cost_usd_min"] = None
+            out["cost_usd_max"] = None
+    elif main.get("mode") == "single":
         out["cost_usd"] = round(main["cost_usd"] + perception_total, 4)
     else:
         out["cost_usd_min"] = round(
@@ -275,6 +303,14 @@ def _combined_cost_estimate(
 def _effective_component(
     in_tok: int, out_tok: int, cached_tok: int, model: str
 ) -> dict:
+    if model not in PRICING_USD_PER_M_TOKENS:
+        return {
+            "model": model,
+            "input_usd": None,
+            "output_usd": None,
+            "total_usd": None,
+            "pricing_available": False,
+        }
     pi, po = _price_for(model)
     input_usd = (
         (in_tok - cached_tok) * pi
@@ -424,16 +460,24 @@ def analyze(path: Path) -> dict:
                 token_usage["cached_tokens"],
                 model,
             ))
-        eff_in_cost = sum(component["input_usd"] for component in components)
-        eff_out_cost = sum(component["output_usd"] for component in components)
         unpriced_models = sorted({
             component["model"] for component in components
             if not component["pricing_available"]
         })
+        eff_in_cost = None if unpriced_models else sum(
+            component["input_usd"] for component in components
+        )
+        eff_out_cost = None if unpriced_models else sum(
+            component["output_usd"] for component in components
+        )
         effective_cost = {
-            "input_usd": round(eff_in_cost, 4),
-            "output_usd": round(eff_out_cost, 4),
-            "total_usd": round(eff_in_cost + eff_out_cost, 4),
+            "input_usd": round(eff_in_cost, 4) if eff_in_cost is not None else None,
+            "output_usd": round(eff_out_cost, 4) if eff_out_cost is not None else None,
+            "total_usd": (
+                round(eff_in_cost + eff_out_cost, 4)
+                if eff_in_cost is not None and eff_out_cost is not None
+                else None
+            ),
             "cache_hit_ratio": cache_hit_ratio,
             "cached_tokens": total_cached,
             "pricing_complete": not unpriced_models,
@@ -495,6 +539,8 @@ def analyze(path: Path) -> dict:
 
 
 def _fmt_cost(c: dict) -> str:
+    if not c.get("pricing_complete", True):
+        return f"unpriced ({','.join(c.get('unpriced_models', []))})"
     if c["mode"] == "single":
         return (
             f"${c['cost_usd']:.2f}  (model={c['model']}; "
@@ -559,11 +605,17 @@ def render_markdown(a: dict, base: dict | None = None) -> str:
     lines.append(f"- raw: {_fmt_cost(a['cost_estimate'])}")
     ec = a.get("effective_cost")
     if ec is not None:
-        lines.append(
-            f"- effective (cached-discounted): ${ec['total_usd']:.2f}  "
-            f"(cache_hit_ratio={ec['cache_hit_ratio']*100:.1f}%, "
-            f"cached_tokens={ec['cached_tokens']:,})"
-        )
+        if ec.get("pricing_complete", False):
+            lines.append(
+                f"- effective (cached-discounted): ${ec['total_usd']:.2f}  "
+                f"(cache_hit_ratio={ec['cache_hit_ratio']*100:.1f}%, "
+                f"cached_tokens={ec['cached_tokens']:,})"
+            )
+        else:
+            lines.append(
+                "- effective (cached-discounted): unpriced "
+                f"({','.join(ec.get('unpriced_models', []))})"
+            )
     lines.append("")
     lines.append("## Top-5 slowest tasks")
     lines.append("| task_id | latency (s) | calls | tokens (in,out) | pct | critical_fail |")

--- a/src/components/GradesSummary.tsx
+++ b/src/components/GradesSummary.tsx
@@ -101,7 +101,7 @@ function StatMini({ icon: Icon, label, value, color }: { icon: typeof Award; lab
 
 function GradeCard({ grade, index }: { grade: GradeResult; index: number }) {
   const s = grade.summary
-  const isV1 = grade.schema_version === '1.0'
+  const isV1 = grade.schema_version != null
   const isLegacyDummy = grade.grade_status === 'legacy_dummy'
 
   return (

--- a/src/hooks/useGrades.ts
+++ b/src/hooks/useGrades.ts
@@ -67,8 +67,8 @@ export interface GradeResult {
   summary: GradeSummary
   tasks: TaskGrade[]
 
-  // ── v1.0 additions (007 schema) ──
-  schema_version?: '1.0' | null
+  // ── Item-level grade schema additions ──
+  schema_version?: '1.0' | '1.1' | '1.2' | null
   judge?: JudgeProvenance
   rubric?: RubricProvenance
   prompt?: GradePromptInfo

--- a/src/pages/GradeDetail.tsx
+++ b/src/pages/GradeDetail.tsx
@@ -383,13 +383,13 @@ function GradeDetail() {
           </div>
         </motion.div>
 
-        {/* ── HealthStrip: judge run-quality diagnostics (v1.0 only) ── */}
-        {grade.schema_version === '1.0' && grade.summary_v1 ? (
+        {/* ── HealthStrip: item-level judge run-quality diagnostics ── */}
+        {grade.schema_version != null && grade.summary_v1 ? (
           <HealthStrip summaryV1={grade.summary_v1} delay={0.2} />
         ) : null}
 
-        {/* ── WOW: Item-level Rubric Insights (v1.0 only) ── */}
-        {grade.schema_version === '1.0' && grade.summary_v1 ? (
+        {/* ── WOW: Item-level Rubric Insights ── */}
+        {grade.schema_version != null && grade.summary_v1 ? (
           <WowSection summary={grade.summary_v1} tasksV1={grade.tasks_v1 ?? []} />
         ) : null}
 

--- a/src/types/grade.ts
+++ b/src/types/grade.ts
@@ -100,7 +100,15 @@ export interface GradeCostSummary {
   total_input_tokens?: number
   total_output_tokens?: number
   estimated_cost_usd?: number | null
+  pricing_complete?: boolean
+  unpriced_models?: string[]
   total_judge_latency_sec?: number
+}
+
+export interface CurrentGradeCostSummary extends GradeCostSummary {
+  estimated_cost_usd: null
+  pricing_complete: false
+  unpriced_models: string[]
 }
 
 export interface GradeSummaryV1 {
@@ -125,9 +133,9 @@ export interface JudgeTierConfig {
 
 /**
  * Tier-routing block emitted by hybrid grading configs (see
- * `batch-runner/grading_configs/validation_hybrid.yaml`). Present only
- * when the grade JSON was produced by a tiered judge config; absent for
- * single-model runs (default_gpt5pro, validation_pro_only, ...).
+ * the archived v1 validation configs). Present only when a historical grade
+ * JSON was produced by a tiered judge config; absent for current single-model
+ * runs such as `default_v2_sol_max`.
  */
 export interface JudgeRouting {
   tier_pro?: JudgeTierConfig
@@ -144,7 +152,7 @@ export interface JudgeProvenance {
   reasoning_effort: string
   temperature: number
   seed?: number
-  /** Grading config name (e.g. 'default_gpt5pro', 'validation_hybrid'). */
+  /** Grading config name (e.g. 'default_v2_sol_max'). */
   config_name?: string
   /** Stable 16-char hash of the config used as part of the cache key. */
   config_hash?: string

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -233,6 +233,9 @@ export interface ReportMeta {
   date: string
   duration: string
   report_scope: 'self_assessed_pre_grading' | 'graded'
+  narrative_model?: string | null
+  narrative_reasoning_effort?: string | null
+  narrative_runtime_fingerprint?: string | null
 }
 
 export interface ReportSummary {

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -3,110 +3,101 @@
 This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
-- Updated: 2026-07-25
-- Status: dashboard source-build provenance shipped through PR #142; automatic
-  PR validation, post-merge validation, Pages deployment, and live verification
-  passed
+- Updated: 2026-07-26
+- Status: GPT-5.6 Sol Max narrative and grading policy implemented and fully
+  validated; protected `grading` Environment configured; repository shipment
+  pending
 
 ## Task
 
-- Re-audit the supplied README/evidence improvement Bolt against current
-  `main` after the Foundry migration.
-- Save a refined repository task before implementation, defer already-shipped
-  or invalid work, and complete the remaining non-duplicative work.
-- Preserve batch, grading, publication, Foundry, permission, and paid-execution
-  semantics.
+- Set dashboard narrative and production grading to GPT-5.6 Sol 1M Max.
+- Apply the policy through runtime code, grading config, publication identity,
+  workflow guardrails, schemas, types, tests, and current operator manuals.
+- Find and correct current 5.4/5.4 Pro narrative or grading claims without
+  rewriting historical configs, results, measurements, or provenance.
+- Validate end to end, then commit, push, open a PR, pass checks, and merge.
 
 ## Result
 
-- Saved `tasks/0725_saturday/BOLT_README_EVIDENCE_AND_BUILD_PROVENANCE.md` with
-  current-main evidence, defer decisions, implementation boundaries,
-  acceptance criteria, and rollback.
-- Deferred README restructuring because the first screen already exposes live
-  evidence, credential-free local preview, a three-task cloud path, artifact
-  inspection, and explicit cost/write boundaries backed by onboarding tests.
-- Deferred a new fast PR workflow because `deploy.yml` already runs exact
-  checkout, aggregation, production build, aggregate contracts, and Chromium
-  checks with read-only PR permissions and main-only Pages deployment.
-- Deferred Action pin churn because the named workflow target no longer exists,
-  active relevant Actions are SHA-pinned, and no reviewed replacement pin set
-  was supplied.
-- Replaced the hardcoded footer version with package-derived dashboard build
-  provenance. A valid lowercase 40-character SHA and two-segment repository
-  slug produce a fixed GitHub full-commit link with a short visible SHA.
-- Missing or malformed version, SHA, or repository values fail closed to an
-  accessible, non-link local-build label.
-- Kept dashboard source-build identity separate from the generated-data
-  timestamp and from experiment, model, Foundry, and grading provenance.
-- Added exact compile-time declarations and limited the Build-step public inputs
-  to `${{ github.sha }}` and `${{ github.repository }}`. No environment object,
-  token, endpoint, ref, actor, or workflow payload enters the bundle.
-- Extended the existing PR validation job rather than creating another
-  workflow. Pages and OIDC write permissions remain isolated to the main-only
-  deploy job.
-- Added focused contracts and production-browser checks for exact links,
-  invalid-input fallback, accessible names, keyboard focus, and desktop/mobile
-  overflow.
-- External comparison used only commit/license metadata and a general
-  provenance pattern. No external code or copy was reused.
+- Narrative analysis now defaults to `gpt-5.6-sol` with `max` reasoning over
+  direct-v1. Step 6 persists model, effort, and runtime fingerprint; route or
+  model failure remains a model-free report and never falls back to the
+  experiment model.
+- Publication independently recomputes and verifies the expected narrative
+  identity. Model-backed publication also requires all four narrative fields
+  to be nonempty strings; model-free publication requires all three identity
+  keys to exist as `null` and all four narrative fields to be empty strings.
+- Added `grading_configs/default_v2_sol_max.yaml` as the workflow default:
+  `gpt-5.6-sol` Max for main judge, visual perception, and finalization;
+  `gpt-audio-1.5` remains the dedicated audio deployment. The 1.05M context is
+  documented as deployment-owned rather than a synthetic request field.
+- Main, visual, and finalization effort values share one fail-closed enum
+  contract. Explicit null or unknown values are rejected before API calls.
+- Semantic-invalid final JSON receives one no-tools retry with its own bounded
+  budget, including when the normal tool-loop iteration budget is exhausted.
+- Grade schema 1.2 costs remain explicitly unpriced: `estimated_cost_usd=null`,
+  `pricing_complete=false`, and a nonempty unique model set exactly matching
+  the persisted main and perception identities. Prior 1.0/1.1 lifecycle
+  payloads retain their numeric-cost compatibility.
+- Split the grading workflow into request validation, credential-free dry-run,
+  protected paid approval, and paid grading jobs. Dry-run has read-only contents
+  permission, does not retain checkout credentials, cannot mint OIDC tokens,
+  and receives no repository secret. Paid grading requires both explicit input
+  authorization and Environment approval; the Azure login job has no
+  Environment, preserving the `refs/heads/main` OIDC subject. Resume chunks
+  inherit exact config, resolved inference revision, task limit, and approval
+  input; each newly dispatched chunk requires a fresh Environment approval.
+- Created the remote `grading` Environment with required owner review,
+  `can_admins_bypass=false`, and one exact `main` custom branch policy.
+  `prevent_self_review=false` is explicit because the repository has no
+  independent collaborator; enabling it would make approval impossible.
+  Existing `copilot` Environment metadata, secrets, and variables were not
+  changed.
+- Updated English/Korean READMEs, first-experiment manuals, config guide,
+  authoritative grading specs, analysis semantics, and frontend types. Current
+  policy now consistently names Sol Max; 5.4 references are clearly historical
+  comparison, benchmark, or provenance identities.
 
 ## Verification
 
-- Base and current remote main:
-  `f849856c6a91c357becc74ae93b60a5c9289917f` with 0 ahead / 0 behind before
-  commit.
-- Focused build-provenance contracts: **3 passed, 0 failed**.
-- Frontend/data aggregate contracts: **92 passed, 0 failed, 0 skipped**.
-- Production TypeScript and Vite build passed with explicit exact SHA and
-  repository inputs.
-- The provenance browser matrix passed both the published exact-commit state
-  and a separately generated local-build fallback. It verified full-SHA href,
-  short-SHA display, accessible name, actual keyboard focus, visible focus
-  outline, and no horizontal overflow at mobile and desktop viewports.
-- Runtime, integrity, perception, and success browser suites all passed against
-  the production dist.
-- Editor diagnostics reported no errors in every changed source, test, config,
-  and workflow file.
-- `git diff --check` passed; no generated or dist artifact is modified or
-  untracked.
-- `actionlint` was unavailable locally. The changed workflow parsed with the
-  installed YAML parser, and the aggregate contract verifies exact Build and
-  browser-step wiring.
-- First review found one fail-closed defect where a slashless repository slug
-  could be accepted through regex coercion. The defect was reproduced, fixed by
-  requiring exactly two segments, and covered by a regression case. Subsequent
-  code and mandatory workflow/security re-reviews both returned **APPROVE** with
-  no remaining finding.
-- No workflow dispatch, deployment, credential or token acquisition, Azure or
-  model call, grading run, Hugging Face write, network checkpoint write, or paid
-  execution occurred during local work.
+- Full credential-free backend: **2,358 passed, 6 skipped, 44 deselected** in
+  130.59 seconds after all review fixes.
+- Frontend/data/onboarding contracts: **94 passed** using real Ruby 3.3 for the
+  embedded workflow syntax checks.
+- Grade analysis tests: **9 passed**.
+- Both changed workflows passed actionlint 1.7.7 and Ruby Psych 3.3 parsing.
+- TypeScript compilation and Vite production build passed after aggregation of
+  1 experiment, 23 reports, 17 grades, 28 prompt architectures, and 4 field
+  notes. Only the existing large-chunk and stale Browserslist-data warnings
+  remain.
+- Runtime, integrity, perception, and success browser suites passed in real
+  Chromium from Playwright 1.61.1: **4 passed, 0 failed**, with no console or
+  page errors.
+- Four independent review passes found publication-content, finalization-budget,
+  reasoning-effort, cost-identity, dry-run-permission, and dated-document
+  boundaries. Every finding was fixed and covered by focused tests before the
+  final full validation.
+- Remote GET verification confirms `grading` has one required owner reviewer,
+  administrator bypass disabled, custom branch policies enabled, and exactly
+  one `main` branch policy. `copilot` remains unprotected with no Environment
+  secrets or variables, matching its prior state.
+- No paid workflow, Azure login/token acquisition, model call, grading run,
+  Hugging Face read/write, or deployment was executed. The only remote mutation
+  was the explicitly requested GitHub `grading` Environment configuration.
 
 ## Shipment
 
-- Reviewed implementation head:
-  `a1353c14665d4da3c5bdfe02820f811bddfa0c69`.
-- PR [#142](https://github.com/hyeonsangjeon/gdpval-realworks/pull/142)
-  squash-merged as `a9cc93bb07297332d4f6cfe1a4dea54e07d28fef`
-  on 2026-07-25.
-- Automatic PR run
-  [30148221820](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/30148221820)
-  passed `validate` in 1 minute 54 seconds; `deploy` was skipped as required for
-  pull requests.
-- Automatic `main` push run
-  [30148302740](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/30148302740)
-  passed `validate` in 2 minutes 2 seconds and Pages `deploy` in 10 seconds.
-- The live dashboard at
-  [GitHub Pages](https://hyeonsangjeon.github.io/gdpval-realworks/) displays
-  `Dashboard build v0.2.0 · a9cc93b`. Its accessible label and href contain the
-  exact full merge SHA, `data-build-provenance` is `published`, and a 390px
-  viewport has no horizontal overflow.
-- These were free automatic repository checks. No manual workflow dispatch,
-  credential/token acquisition, Azure/model call, grading run, Hugging Face
-  write, network checkpoint write, or paid execution occurred.
+- Implementation is validated in the isolated
+  `feat/sol-max-narrative-grading` worktree based on
+  `ddc52ea3afc7f546ff210b6bbb7e13c180234295`.
+- Commit, push, pull request checks, merge, and post-merge verification remain
+  in progress and will replace this section before completion is reported.
 
 ## Remaining Work
 
-- No repository implementation or delivery work remains for this Bolt.
-- Future dependency-security maintenance may address the pre-existing `npm ci`
-  audit findings separately; this task changed neither dependency versions nor
-  the lockfile.
+- Commit the reviewed snapshot including the new production config, push the
+  branch, open a PR, wait for required checks, and merge.
+- Verify the merged `main` state and refresh this rolling record with exact PR,
+  merge SHA, and check results.
+- A live paid Sol Max canary remains intentionally outside this task and still
+  requires explicit owner input plus protected Environment approval.

--- a/tasks/rebuilding_grading_task/000-OVERVIEW.md
+++ b/tasks/rebuilding_grading_task/000-OVERVIEW.md
@@ -5,8 +5,10 @@
 
 ## 핵심 요약
 
-1. **단일 메인 judge**: `gpt-5.4` reasoning_effort=`medium`. tier 없음.
-2. **눈/귀 부착**: text 추출 폐기, judge가 `read_deliverable` tool로 파일 직접 조회. 시각 항목 → gpt-5.4 vision, 오디오 지각 → gpt-audio-1.5.
+1. **단일 메인 judge**: production은 `gpt-5.6-sol`
+	reasoning_effort=`max`. tier 없음. 최초 PR2 baseline인 `gpt-5.4 medium`은
+	`default_v2.yaml` 비교 identity로 보존.
+2. **눈/귀 부착**: text 추출 폐기, judge가 `read_deliverable` tool로 파일 직접 조회. production 시각 항목 → `gpt-5.6-sol` reasoning_effort=`max`, 오디오 지각 → `gpt-audio-1.5`.
 3. **score-math sign-bug fix**: `verdict='pass'` 부호 시멘틱 정규화, `|max_score|≥4` critical 재정의, `total_max≤0` degenerate 케이스 explicit 처리.
 4. **legacy 제거**: `deliverable_extract_max_chars`, tier 분기, `required` OR-가지 잔재 전부.
 
@@ -66,8 +68,8 @@
 | perception routing 테스트 위치 | 기존 `test_grader_routing.py`(tier routing)와 분리해 `test_perception_routing.py` 신규 | concern 분리 — 207에서 legacy tier 테스트 삭제해도 modality routing 테스트는 살아남 |
 | perception 클래스 의존성 주입 방향 | `client`을 생성자에 inject (클래스 내부 생성 X) | main judge가 Responses API 클라이언트 소유 + 테스트에서 FakeClient 제공 용이 |
 | audio deployment 누락 처리 | `judge()` 호출 시점에 endpoint env 체크, 누락이면 `judge_error=endpoint_missing` graceful return | import-time hard fail 피하고 audio 항목에서만 결속 (main judge는 계속 동작) |
-| grade-run.yml default config 교체 타이밍 | 208에서 교체 하지 않음 — PR3 task 302 비용 검증 이후 별도 commit으로 전환 | 명시적 테스트 없이 default를 v2로 돌리면 다음 trigger에서 러닝웨이 cost 위험. 사용자는 명시적으로 default_v2.yaml 지정 가능. |
-| 207 legacy 주니케이션 범위 | **조건부 PARTIAL**: v1 sweep/tier configs (`validation_*`, `tiered_*`, `_sweep_template`, `recommended_*`) 명시 아카이브 + README + `_archive_v1/README.md`. **하지만** `core/grader.py`의 `_use_batch`/`_tier_judges`/`_summarize_deliverables`/`deliverable_extract_max_chars` 코드 렌더링 변경 없음. `core/grader_batch.py`도 올. | 완전 삭제는 `default_gpt5pro.yaml` (현재 grade-run.yml default)과 30+ test_grader/test_grader_batch 케이스를 그대로 깨뜨림. 안전하게 하려면 (1) PR3의 v2 검증 완료 → (2) grade-run.yml default 전환 → (3) `default_gpt5pro.yaml` archive → (4) legacy 코드 일괄 드롭 순서 필요. PR2 테스트를 한 번에 깨뜨려서는 안 됨. 별도 cleanup PR로 처리. 207 acceptance grep 조건은 충족 안 됨 — PR3 종료 이후 완전 수행. |
+| grade-run.yml default config 교체 타이밍 | 2026-07-26 `default_v2_sol_max.yaml`로 전환 완료 | dry-run 기본, 명시적 paid 승인, protected `grading` environment를 함께 적용. 이전 5.4 config는 비교·재현용으로 보존. |
+| 207 legacy 주니케이션 범위 | **조건부 PARTIAL**: v1 sweep/tier configs (`validation_*`, `tiered_*`, `_sweep_template`, `recommended_*`) 명시 아카이브 + README + `_archive_v1/README.md`. **하지만** `core/grader.py`의 `_use_batch`/`_tier_judges`/`_summarize_deliverables`/`deliverable_extract_max_chars` 코드 렌더링 변경 없음. `core/grader_batch.py`도 올. | `default_gpt5pro.yaml`은 현재 default가 아니라 historical comparison identity로 보존. legacy 코드 제거는 별도 cleanup PR에서 기존 historical config 재현성과 함께 처리. |
 
 ## 작업 흐름 (자동, 사용자 개입 없음)
 

--- a/tasks/rebuilding_grading_task/PR3_VERIFICATION.md
+++ b/tasks/rebuilding_grading_task/PR3_VERIFICATION.md
@@ -1,5 +1,10 @@
 # PR3_VERIFICATION
 
+> **Historical (superseded 2026-07-26):** 아래의 "현재 default" 표현은 이
+> 검증이 수행된 당시 상태를 뜻한다. 현재 production grading default는
+> `default_v2_sol_max.yaml` (`gpt-5.6-sol`, Max)이며 기존 수치와 5.4
+> identity는 provenance 보존을 위해 수정하지 않는다.
+
 > READ-ONLY 진단. 코드 + 기존 `data/grades/*.json` 만으로 재계산. 어떤 grade run/네트워크/수정/commit 없음.
 > 모든 숫자는 파일에서 직접 재계산했고 방법을 명시함. 저장 위치: `tasks/rebuilding_grading_task/PR3_VERIFICATION.md`
 > (repo에 `outputs/` 디렉터리가 없어 PR3 산출물 형제 위치에 저장).

--- a/tasks/rebuilding_grading_task/SPEC_GRADING_PIPELINE_V2.md
+++ b/tasks/rebuilding_grading_task/SPEC_GRADING_PIPELINE_V2.md
@@ -2,7 +2,7 @@
 
 ## 0. 메타
 
-- **Status**: Draft → 작업 오푸스 핸드오프용
+- **Status**: Implemented; production model policy updated 2026-07-26
 - **Owner**: hyeonsangjeon
 - **Repo**: `hyeonsangjeon/gdpval-realworks`
 - **영향 범위**: `batch-runner/core/grader.py`, `core/rubric_loader.py`, grading 호출 경로 전체, `data/grades/*`
@@ -13,6 +13,13 @@
   - `scripts/stratify_critical_gap_v2.py`
 
 이 SPEC은 grading subsystem을 처음부터 다시 짜기 위한 것이다. inference / 220 deliverable 생성 경로는 **건드리지 않는다** (기존 산출물 신뢰).
+
+> **Production override (2026-07-26):** tool-calling architecture, scoring,
+> rubric, and modality routing remain unchanged. The production main judge,
+> visual judge, and bounded finalization retry now use `gpt-5.6-sol` with
+> `reasoning_effort=max`; audio perception remains `gpt-audio-1.5`. The 1.05M
+> context window is a deployment capability, not a request parameter. The
+> original `gpt-5.4 medium` policy remains reproducible as `default_v2.yaml`.
 
 ---
 
@@ -74,7 +81,7 @@ deliverable을 *생성*하는 모델은 라이브러리 접근이 있는 풍부�
 
 ```
 [task rubric (openai/gdpval)] ─┐
-                               ├─→ [MAIN JUDGE: gpt-5.4 medium]
+                               ├─→ [MAIN JUDGE: gpt-5.6-sol max]
 [deliverable file path] ───────┘        │
                                          │ tool calls (필요 시)
                                          ▼
@@ -103,8 +110,8 @@ deliverable을 *생성*하는 모델은 라이브러리 접근이 있는 풍부�
 
 ### 4.1 메인 rubric judge
 
-- **모델**: `gpt-5.4`, `reasoning_effort=medium`. 단일. tier 없음.
-- **근거**: content 항목에서 mini=standard=pro 동급(정확도 차이 無). standard를 쓰는 이유는 정확도가 아니라 **tool-use / agentic 신뢰도** — judge가 멀티스텝 tool 루프를 돌려야 하므로 mini의 tool 오케스트레이션 약점을 피하기 위함. mini→standard 비용 차는 mini→pro의 9×와 달리 modest.
+- **모델**: production은 `gpt-5.6-sol`, `reasoning_effort=max`. 단일, tier 없음. 시각 perception과 bounded finalization도 같은 model/effort를 사용한다.
+- **역사적 근거**: 최초 PR2 baseline은 tool-use 신뢰도를 위해 `gpt-5.4 medium`을 채택했다. 해당 byte identity는 `default_v2.yaml`에 보존되고, 현행 production은 별도 `default_v2_sol_max.yaml`이 소유한다.
 - **호출 API**: Azure OpenAI Responses API (`client.responses.create()`), function/tool calling 활성화. timeout은 per-request로 설정(client 생성 시점 X — NarrativeAnalyzer 교훈과 동일).
 - **프롬프트 계약**: "여기 루브릭이 있다. `read_deliverable` tool로 실제 deliverable 파일을 직접 열어 구조·서식·내용을 확인한 뒤, 각 루브릭 항목을 네가 *관찰한 사실*에 근거해 채점하라. 각 항목에 verdict + evidence(관찰 근거)를 남겨라." (기존 `prompts/grader_judge.md`를 tool-aware 버전으로 개정.)
 - temperature=0, seed 고정 유지.
@@ -133,7 +140,7 @@ judge에 노출할 tool 연산(operation) 제안:
 | 표/스프레드시트 | openpyxl (값·서식·차트) | — (대부분 라이브러리로 충분) |
 | 문서 | python-docx (스타일·구조) | — |
 | 슬라이드 | python-pptx (레이아웃) | — |
-| 시각 (차트 모양·polish) | render_to_image | **gpt-5.4 vision** |
+| 시각 (차트 모양·polish) | render_to_image | **gpt-5.6-sol**, reasoning_effort=`max` |
 | 오디오 | soundfile/ffmpeg (probe) | **gpt-audio-1.5** (믹싱/음질 등) |
 | 비디오 | ffmpeg (probe) | (이번 범위: 객관까지. 지각은 후속) |
 
@@ -207,8 +214,8 @@ judge에 노출할 tool 연산(operation) 제안:
 
 ```yaml
 judge:
-  model: gpt-5.4
-  reasoning_effort: medium        # mini→standard: tool-use 신뢰도. pro 아님
+  model: gpt-5.6-sol
+  reasoning_effort: max
   api: responses                  # Azure OpenAI Responses API, per-request timeout
   temperature: 0
   seed: 42
@@ -223,7 +230,7 @@ judge:
       read_only: true
 
   perception:
-    visual:  { model: gpt-5.4, vision: true }   # 차트·레이아웃 등 시각 항목만
+    visual:  { model: gpt-5.6-sol, reasoning_effort: max, vision: true }  # 차트·레이아웃 등 시각 항목만
     audio:   { model: gpt-audio-1.5 }           # 지각적 음질만
     # 구조/객관은 모델 아님 — tool(op) 직접 사용
 
@@ -246,7 +253,7 @@ judge:
 - **새 비용**: vision/audio 경로로 per-task 비용이 옛날 $18보다 오름. perception 라우팅으로 bound하되 **새 파이프라인 비용 재추정 필요**(아직 미산정). 운영 한도는 저장소 외부 설정으로 검증.
 - **env 가용성 확정**: ffmpeg/soundfile/openpyxl 등 실제 Dockerfile/requirements에서 검증 후 진행(내 기억 아닌 repo가 authoritative).
 - **threshold=4 적정성**: 저자 signal 부재 하의 임의 경계. gold-ceiling 검증과 함께 민감도 점검 여지.
-- **vision 모델 충분성**: gpt-5.4 vision이 시각 항목을 충분히 판단하는지 — 부족하면 해당 항목만 상향(전체 모델 교체 아님).
+- **vision 품질 모니터링**: production `gpt-5.6-sol` Max 시각 경로의 judge_error와 modality별 품질을 실제 paid run에서 별도 측정. 이번 정책 전환 작업에서는 유료 호출하지 않음.
 
 ---
 

--- a/tasks/rebuilding_grading_task/hybrid_routing_spec.md
+++ b/tasks/rebuilding_grading_task/hybrid_routing_spec.md
@@ -1,5 +1,10 @@
 # PR3 Step 6 — Hybrid Routing Spec (deterministic, rule-based)
 
+> **Historical (superseded 2026-07-26):** 이 문서는 당시 5.4 mini/standard
+> hybrid 실험을 기록한다. 현재 production grading default는
+> `default_v2_sol_max.yaml` (`gpt-5.6-sol`, Max)이며 아래 측정과 routing
+> identity는 재현을 위해 그대로 보존한다.
+
 > Required only if Step 5 PASS. Defines the rule-based router that
 > sends each task to `gpt-5.4-mini` (cheap default) or `gpt-5.4` standard
 > (expensive fallback). NOT LLM-routed — deterministic and inspectable.


### PR DESCRIPTION
Narrative and grading (main, visual, and finalization) processes have been updated to utilize GPT-5.6 Sol Max. Audio processing remains on GPT-Audio-1.5. This release hardens publication, finalization, and cost provenance, enabling credential-free dry-runs alongside protected, per-chunk paid approvals while preserving branch-subject OIDC credentials. Historical GPT-5.4 models are preserved. Validation totals: 2358 backend tests passed, 6 skipped, 44 deselected; 94 Node tests; 9 analysis tasks; actionlint/Psych; build; and 4 Chromium tests passed. No live Azure, Hugging Face, model, or paid runs were performed. The remote grading environment is configured with owner-review requirements, no administrator bypasses, main-only branch restrictions, and fresh approval required per individual chunk.