### PR TITLE
feat(agentic): add sandbox v2 foundation

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -130,7 +130,9 @@ jobs:
           abort('execution must be a mapping') unless execution.is_a?(Hash)
           sandbox = execution.fetch('sandbox', {}) || {}
           abort('execution.sandbox must be a mapping') unless sandbox.is_a?(Hash)
-          uses_agentic = execution['mode'] == 'agentic_sandbox' || sandbox['hardened_substrate'] == true
+          uses_agentic = ['agentic_sandbox', 'agentic_sandbox_v2'].include?(
+            execution['mode']
+          ) || sandbox['hardened_substrate'] == true
           File.open(ENV.fetch('GITHUB_OUTPUT'), 'a') do |output|
             output.puts("uses_agentic=#{uses_agentic}")
           end
@@ -372,7 +374,7 @@ jobs:
             "uses_sandbox": str(mode == "sandbox").lower(),
             "sandbox_image": image,
             "uses_agentic": str(
-              mode == 'agentic_sandbox' or hardened
+              mode in {"agentic_sandbox", "agentic_sandbox_v2"} or hardened
             ).lower(),
             "uses_code_interpreter": str(
               mode == "code_interpreter"
@@ -400,7 +402,7 @@ jobs:
       - name: 'Block agentic modes in credentialed general workflow'
         if: steps.read_config.outputs.uses_agentic == 'true'
         run: |
-          echo "FATAL: agentic_sandbox and its hardened paired baseline are not"
+          echo "FATAL: agentic sandbox modes and the hardened paired baseline are not"
           echo "authorized in batch-run.yml. This workflow co-locates Docker,"
           echo "Azure/HF credentials, relay, narrative, and upload permissions."
           echo "Use the dedicated signed compute/control workflow only after the"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **Agentic Sandbox V2 model-free foundation** - add an explicitly
+  non-production `agentic_sandbox_v2` execution contract with eight versioned
+  tools, strict lifecycle and result schemas, three policy profiles, and a
+  required `foundation_only=true` marker. The shared executor accepts only the
+  built-in scripted fixture in non-paid mode and rejects model, client,
+  credential, prompt, provider, custom-backend, publication, grading, and
+  preprocessing inputs. Each fixture run uses a task-local process group with
+  hard wall-time termination, descendant cleanup, descriptor-relative
+  filesystem containment, prospective file/entry/byte caps, immutable package
+  locks, exact terminal artifact byte binding, and canonical source/runtime
+  identity. Private audit and public-redacted traces independently bind
+  requests, results, state continuity, replay history, capability/package
+  semantics, failures, and final deliverables. General Batch and Step 2 reject
+  configured or overridden V2 mode before credentials or provider construction;
+  V1 prompt, tool, limit, checkpoint, result, restore, import, and default-mode
+  identities remain frozen. Final model-free validation passes **196 focused
+  contracts** and the complete credential-free backend with **2,551 passed, 6
+  host-dependent skipped, and 44 integration tests deselected**, with no
+  warnings, clean static diagnostics, clean diff checks, and an independent
+  security/release **APPROVE** after seven high-stakes review rounds and an
+  iterative full-diff review. PyYAML parsing passes;
+  actionlint and Ruby are unavailable in the local validation environment. No
+  model, credential, Azure, Hugging Face, grading, deployment, workflow,
+  network-write, or paid operation ran. Real compute, package broker, web,
+  model-loop, publication, and microVM integration remain deferred to later
+  phases.
 - **GPT-5.6 Sol Max narrative and grading production policy** - move the
   dashboard narrative analyzer and the default v2 grading profile to
   `gpt-5.6-sol` with `reasoning_effort=max`; use the same identity for the

--- a/batch-runner/core/agentic_v2_contract.py
+++ b/batch-runner/core/agentic_v2_contract.py
@@ -1,0 +1,656 @@
+"""Versioned model-visible contract for Agentic Sandbox V2."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+from jsonschema import Draft202012Validator
+
+
+TOOL_CONTRACT_VERSION = "2.0"
+FOUNDATION_BACKEND_ID = "agentic-v2-fixture-v1"
+POLICY_PROFILE_IDS = (
+    "offline-full-v1",
+    "package-broker-v1",
+    "web-augmented-v1",
+)
+
+TOOL_NAMES = (
+    "capabilities_query",
+    "workspace_apply",
+    "exec_run",
+    "environment_resolve",
+    "environment_activate",
+    "browser_run",
+    "verify_public",
+    "finalize",
+)
+
+_PATH_PATTERN = (
+    r"^(?!/)(?!.*(?:^|/)\.\.(?:/|$))"
+    r"(?!.*[:\\\x00-\x1f\x7f-\x9f]).+$"
+)
+_DIGEST_PATTERN = r"^[0-9a-f]{64}$"
+_PACKAGE_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}(?:==[A-Za-z0-9][A-Za-z0-9.!+_-]{0,127})?$"
+
+ERROR_TYPES = (
+    "artifact_not_openable",
+    "call_id_conflict",
+    "cancelled",
+    "capability_unavailable",
+    "compute_backend_error",
+    "compute_cleanup_failed",
+    "compute_start_failed",
+    "finalize_not_called",
+    "finalize_result_mismatch",
+    "finalize_result_missing",
+    "fixture_backend_error",
+    "invalid_arguments",
+    "invalid_backend_result",
+    "invalid_backend_state",
+    "invalid_call_id",
+    "invalid_lifecycle_transition",
+    "invalid_result_envelope",
+    "package_not_in_snapshot",
+    "path_not_directory",
+    "runner_internal_error",
+    "substrate_manifest_missing",
+    "task_wall_time_exhausted",
+    "tool_budget_exhausted",
+    "tool_not_allowed_in_state",
+    "tool_result_too_large",
+    "unapproved_lock",
+    "unknown_tool",
+)
+
+_PATH_SCHEMA = {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 240,
+    "pattern": _PATH_PATTERN,
+}
+
+
+def _strict_object(
+    properties: Mapping[str, Any],
+    required: tuple[str, ...] = (),
+) -> dict:
+    return {
+        "type": "object",
+        "properties": dict(properties),
+        "required": list(required),
+        "additionalProperties": False,
+    }
+
+
+TOOL_SCHEMAS: dict[str, dict] = {
+    "capabilities_query": _strict_object({
+        "kind": {
+            "enum": ["commands", "runtimes", "packages", "formats", "budgets"]
+        },
+        "query": {"type": "string", "maxLength": 256},
+        "cursor": {"type": "string", "maxLength": 128},
+    }, ("kind",)),
+    "workspace_apply": {
+        "oneOf": [
+            _strict_object({
+                "operation": {"const": "list"},
+                "path": _PATH_SCHEMA,
+            }, ("operation", "path")),
+            _strict_object({
+                "operation": {"const": "read"},
+                "path": _PATH_SCHEMA,
+                "offset": {"type": "integer", "minimum": 0},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 1048576},
+            }, ("operation", "path")),
+            _strict_object({
+                "operation": {"enum": ["write", "patch"]},
+                "path": _PATH_SCHEMA,
+                "content": {"type": "string", "maxLength": 1048576},
+            }, ("operation", "path", "content")),
+            _strict_object({
+                "operation": {"enum": ["delete", "mkdir"]},
+                "path": _PATH_SCHEMA,
+            }, ("operation", "path")),
+            _strict_object({
+                "operation": {"const": "copy"},
+                "source": _PATH_SCHEMA,
+                "destination": _PATH_SCHEMA,
+            }, ("operation", "source", "destination")),
+        ]
+    },
+    "exec_run": {
+        "oneOf": [
+            _strict_object({
+                "argv": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 128,
+                    "items": {"type": "string", "maxLength": 4096},
+                },
+                "cwd": _PATH_SCHEMA,
+                "stdin": {"type": "string", "maxLength": 1048576},
+                "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 2700},
+            }, ("argv", "cwd", "timeout_seconds")),
+            _strict_object({
+                "interpreter": {"enum": ["python", "node", "r", "bash"]},
+                "script": {"type": "string", "minLength": 1, "maxLength": 262144},
+                "cwd": _PATH_SCHEMA,
+                "stdin": {"type": "string", "maxLength": 1048576},
+                "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 2700},
+            }, ("interpreter", "script", "cwd", "timeout_seconds")),
+        ]
+    },
+    "environment_resolve": _strict_object({
+        "ecosystem": {"enum": ["python", "npm", "debian"]},
+        "requirements": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 64,
+            "uniqueItems": True,
+            "items": {
+                "type": "string",
+                "pattern": _PACKAGE_PATTERN,
+                "maxLength": 256,
+            },
+        },
+    }, ("ecosystem", "requirements")),
+    "environment_activate": _strict_object({
+        "lock_digest": {"type": "string", "pattern": _DIGEST_PATTERN},
+    }, ("lock_digest",)),
+    "browser_run": {
+        "oneOf": [
+            _strict_object({
+                "operation": {"enum": ["open_local", "snapshot", "screenshot"]},
+                "path": _PATH_SCHEMA,
+            }, ("operation", "path")),
+            _strict_object({
+                "operation": {"const": "search"},
+                "query": {"type": "string", "minLength": 1, "maxLength": 512},
+            }, ("operation", "query")),
+            _strict_object({
+                "operation": {"const": "open_url"},
+                "url": {"type": "string", "format": "uri", "maxLength": 2048},
+            }, ("operation", "url")),
+        ]
+    },
+    "verify_public": _strict_object({
+        "deliverables": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 64,
+            "uniqueItems": True,
+            "items": _PATH_SCHEMA,
+        },
+    }, ("deliverables",)),
+    "finalize": _strict_object({
+        "deliverables": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 64,
+            "uniqueItems": True,
+            "items": _PATH_SCHEMA,
+        },
+        "summary": {"type": "string", "minLength": 1, "maxLength": 2048},
+    }, ("deliverables", "summary")),
+}
+
+_ARTIFACT_SCHEMA = _strict_object({
+    "path": _PATH_SCHEMA,
+    "sha256": {"type": "string", "pattern": _DIGEST_PATTERN},
+    "size": {"type": "integer", "minimum": 1, "maximum": 536870912},
+}, ("path", "sha256", "size"))
+
+_LOCK_SCHEMA = _strict_object({
+    "ecosystem": {"enum": ["python", "npm", "debian"]},
+    "requirements": {
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 64,
+        "uniqueItems": True,
+        "items": {"type": "string", "pattern": _PACKAGE_PATTERN},
+    },
+    "blobs": {
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 64,
+        "items": {"type": "string", "pattern": _DIGEST_PATTERN},
+    },
+}, ("ecosystem", "requirements", "blobs"))
+
+TOOL_DATA_SCHEMAS: dict[str, dict] = {
+    "capabilities_query": _strict_object({
+        "kind": {
+            "enum": ["commands", "runtimes", "packages", "formats", "budgets"]
+        },
+        "items": {
+            "type": "array",
+            "maxItems": 512,
+            "items": {"type": "string", "maxLength": 512},
+        },
+    }, ("kind", "items")),
+    "workspace_apply": {
+        "oneOf": [
+            _strict_object({
+                "entries": {
+                    "type": "array",
+                    "maxItems": 1024,
+                    "items": {"type": "string", "maxLength": 240},
+                },
+            }, ("entries",)),
+            _strict_object({
+                "content": {"type": "string", "maxLength": 1048576},
+                "content_sha256": {"type": "string", "pattern": _DIGEST_PATTERN},
+            }, ("content", "content_sha256")),
+            _strict_object({"path": _PATH_SCHEMA}, ("path",)),
+        ]
+    },
+    "exec_run": _strict_object({
+        "returncode": {"type": "integer", "minimum": 0, "maximum": 255},
+    }, ("returncode",)),
+    "environment_resolve": _strict_object({
+        "lock_digest": {"type": "string", "pattern": _DIGEST_PATTERN},
+        "lock": _LOCK_SCHEMA,
+    }, ("lock_digest", "lock")),
+    "environment_activate": _strict_object({
+        "environment_id": {"type": "string", "pattern": _DIGEST_PATTERN},
+    }, ("environment_id",)),
+    "browser_run": _strict_object({
+        "path": _PATH_SCHEMA,
+        "sha256": {"type": "string", "pattern": _DIGEST_PATTERN},
+    }, ("path", "sha256")),
+    "verify_public": _strict_object({
+        "artifacts": {
+            "type": "array", "minItems": 1, "maxItems": 64,
+            "items": _ARTIFACT_SCHEMA,
+        },
+    }, ("artifacts",)),
+    "finalize": _strict_object({
+        "artifacts": {
+            "type": "array", "minItems": 1, "maxItems": 64,
+            "items": _ARTIFACT_SCHEMA,
+        },
+    }, ("artifacts",)),
+}
+
+USAGE_DELTA_SCHEMA = _strict_object({
+    "tool_calls": {"type": "integer", "minimum": 0, "maximum": 1},
+    "wall_ms": {"type": "integer", "minimum": 0, "maximum": 3600000},
+    "output_bytes": {"type": "integer", "minimum": 0, "maximum": 16777216},
+}, ("tool_calls", "wall_ms", "output_bytes"))
+
+TOOL_RESULT_SCHEMA = _strict_object({
+    "schema_version": {"const": TOOL_CONTRACT_VERSION},
+    "call_id": {"type": "string", "minLength": 1, "maxLength": 128},
+    "tool_name": {"type": ["string", "null"], "enum": [*TOOL_NAMES, None]},
+    "request_sha256": {"type": ["string", "null"], "pattern": _DIGEST_PATTERN},
+    "result_sha256": {"type": "string", "pattern": _DIGEST_PATTERN},
+    "ok": {"type": "boolean"},
+    "error_type": {"type": ["string", "null"], "enum": [*ERROR_TYPES, None]},
+    "data": {"type": "object"},
+    "usage_delta": USAGE_DELTA_SCHEMA,
+    "state_before_sha256": {
+        "type": ["string", "null"], "pattern": _DIGEST_PATTERN
+    },
+    "state_after_sha256": {
+        "type": ["string", "null"], "pattern": _DIGEST_PATTERN
+    },
+}, (
+    "schema_version", "call_id", "tool_name", "request_sha256",
+    "result_sha256", "ok", "error_type", "data", "usage_delta",
+    "state_before_sha256", "state_after_sha256",
+))
+
+PUBLIC_RESULT_COMMITMENT_SCHEMA = _strict_object({
+    "call_id": {"type": "string", "minLength": 1, "maxLength": 128},
+    "tool_name": {"type": ["string", "null"], "enum": [*TOOL_NAMES, None]},
+    "request_sha256": {"type": ["string", "null"], "pattern": _DIGEST_PATTERN},
+    "result_sha256": {"type": "string", "pattern": _DIGEST_PATTERN},
+    "ok": {"type": "boolean"},
+    "error_type": {"type": ["string", "null"], "enum": [*ERROR_TYPES, None]},
+    "usage_delta": USAGE_DELTA_SCHEMA,
+    "state_before_sha256": {
+        "type": ["string", "null"], "pattern": _DIGEST_PATTERN
+    },
+    "state_after_sha256": {
+        "type": ["string", "null"], "pattern": _DIGEST_PATTERN
+    },
+}, (
+    "call_id", "tool_name", "request_sha256", "result_sha256", "ok",
+    "error_type", "usage_delta", "state_before_sha256", "state_after_sha256",
+))
+
+EVENT_SCHEMA = _strict_object({
+    "schema_version": {"const": TOOL_CONTRACT_VERSION},
+    "sequence": {"type": "integer", "minimum": 0},
+    "kind": {"type": "string", "minLength": 1, "maxLength": 128},
+    "payload": {"type": "object"},
+    "state_sha256": {"type": "string", "pattern": _DIGEST_PATTERN},
+    "previous_sha256": {"type": "string", "pattern": _DIGEST_PATTERN},
+    "event_sha256": {"type": "string", "pattern": _DIGEST_PATTERN},
+}, (
+    "schema_version", "sequence", "kind", "payload", "state_sha256",
+    "previous_sha256", "event_sha256",
+))
+
+
+class LifecycleState(str, Enum):
+    CREATED = "created"
+    STARTED = "started"
+    ACTIVE = "active"
+    FINALIZING = "finalizing"
+    FINALIZED = "finalized"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+_TRANSITIONS = {
+    LifecycleState.CREATED: frozenset({LifecycleState.STARTED, LifecycleState.CANCELLED}),
+    LifecycleState.STARTED: frozenset({LifecycleState.ACTIVE, LifecycleState.FAILED, LifecycleState.CANCELLED}),
+    LifecycleState.ACTIVE: frozenset({LifecycleState.FINALIZING, LifecycleState.FAILED, LifecycleState.CANCELLED}),
+    LifecycleState.FINALIZING: frozenset({LifecycleState.ACTIVE, LifecycleState.FINALIZED, LifecycleState.FAILED, LifecycleState.CANCELLED}),
+    LifecycleState.FINALIZED: frozenset(),
+    LifecycleState.FAILED: frozenset(),
+    LifecycleState.CANCELLED: frozenset(),
+}
+
+_MUTATING_TOOLS = frozenset({
+    "workspace_apply",
+    "exec_run",
+    "environment_activate",
+    "browser_run",
+})
+
+
+@dataclass(frozen=True)
+class AgenticV2Profile:
+    tool_contract_version: str
+    policy_profile_id: str
+    foundation_only: bool
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> "AgenticV2Profile":
+        if not isinstance(value, Mapping):
+            raise ValueError("execution.agentic_v2 must be an object")
+        expected = {
+            "tool_contract_version", "policy_profile_id", "foundation_only"
+        }
+        unknown = set(value) - expected
+        if unknown:
+            raise ValueError(f"unknown agentic v2 setting(s): {sorted(unknown)}")
+        version = value.get("tool_contract_version")
+        profile = value.get("policy_profile_id")
+        foundation_only = value.get("foundation_only")
+        if version != TOOL_CONTRACT_VERSION:
+            raise ValueError("agentic v2 tool_contract_version must be '2.0'")
+        if profile not in POLICY_PROFILE_IDS:
+            raise ValueError("agentic v2 policy_profile_id is invalid")
+        if foundation_only is not True:
+            raise ValueError("agentic v2 foundation_only must be true")
+        return cls(version, str(profile), True)
+
+
+@dataclass
+class AgenticV2Lifecycle:
+    state: LifecycleState = LifecycleState.CREATED
+
+    @property
+    def terminal(self) -> bool:
+        return not _TRANSITIONS[self.state]
+
+    def transition(self, target: LifecycleState | str) -> LifecycleState:
+        try:
+            next_state = LifecycleState(target)
+        except ValueError as exc:
+            raise ValueError("unknown agentic v2 lifecycle state") from exc
+        if next_state not in _TRANSITIONS[self.state]:
+            raise ValueError(
+                f"invalid agentic v2 transition: {self.state.value}->{next_state.value}"
+            )
+        self.state = next_state
+        return self.state
+
+    def require_tool_allowed(self, name: str) -> None:
+        if name not in TOOL_SCHEMAS:
+            raise ValueError("unknown agentic v2 tool")
+        if self.terminal:
+            raise ValueError("agentic v2 lifecycle is terminal")
+        if self.state not in {LifecycleState.ACTIVE, LifecycleState.FINALIZING}:
+            raise ValueError("agentic v2 tool call is not active")
+        if self.state is LifecycleState.FINALIZING and name in _MUTATING_TOOLS:
+            raise ValueError("agentic v2 mutation is forbidden while finalizing")
+
+
+def responses_tool_definitions() -> list[dict]:
+    descriptions = {
+        "capabilities_query": "Discover actual task-environment capabilities and remaining budgets.",
+        "workspace_apply": "Perform one bounded operation in the task-local workspace.",
+        "exec_run": "Run one bounded argv command or interpreter script in the task workspace.",
+        "environment_resolve": "Resolve package coordinates without mutating the task environment.",
+        "environment_activate": "Atomically activate an approved content-addressed package lock.",
+        "browser_run": "Inspect a local page or use a policy-gated web capability.",
+        "verify_public": "Run public structural and openability checks on deliverables.",
+        "finalize": "Commit declared deliverables and finish the task.",
+    }
+    return [
+        {
+            "type": "function",
+            "name": name,
+            "description": descriptions[name],
+            "parameters": TOOL_SCHEMAS[name],
+            "strict": True,
+        }
+        for name in TOOL_NAMES
+    ]
+
+
+def validate_tool_arguments(name: str, arguments: Any) -> dict:
+    if name not in TOOL_SCHEMAS:
+        raise ValueError("unknown agentic v2 tool")
+    if not isinstance(arguments, dict):
+        raise ValueError("agentic v2 tool arguments must be an object")
+    errors = sorted(
+        Draft202012Validator(TOOL_SCHEMAS[name]).iter_errors(arguments),
+        key=lambda error: list(error.path),
+    )
+    if errors:
+        raise ValueError("invalid agentic v2 tool arguments")
+    result = dict(arguments)
+    for field_name in ("path", "source", "destination", "cwd"):
+        value = result.get(field_name)
+        if isinstance(value, str):
+            canonical_relative_path(value)
+    deliverables = result.get("deliverables")
+    if isinstance(deliverables, list):
+        canonical = [canonical_relative_path(value) for value in deliverables]
+        if len(canonical) != len(set(canonical)):
+            raise ValueError("agentic v2 deliverable paths must be unique")
+    if name == "browser_run" and result.get("operation") == "open_url":
+        validate_public_https_url(result.get("url"))
+    return result
+
+
+def validate_tool_result_data(
+    name: str,
+    arguments: Mapping[str, Any],
+    ok: bool,
+    data: Any,
+) -> dict:
+    if not isinstance(data, dict):
+        raise ValueError("agentic v2 tool result data must be an object")
+    if not ok:
+        if data:
+            raise ValueError("agentic v2 failed result data must be empty")
+        return {}
+    schema = TOOL_DATA_SCHEMAS.get(name)
+    if schema is None or list(Draft202012Validator(schema).iter_errors(data)):
+        raise ValueError("agentic v2 tool result data is invalid")
+    result = dict(data)
+    if name == "capabilities_query" and result["kind"] != arguments["kind"]:
+        raise ValueError("agentic v2 capability result kind mismatch")
+    if name == "workspace_apply":
+        operation = arguments["operation"]
+        expected_shape = (
+            "entries" if operation == "list"
+            else "content" if operation == "read"
+            else "path"
+        )
+        if expected_shape not in result:
+            raise ValueError("agentic v2 workspace result operation mismatch")
+        if expected_shape == "path":
+            expected_path = (
+                arguments["destination"]
+                if operation == "copy"
+                else arguments["path"]
+            )
+            if result["path"] != expected_path:
+                raise ValueError("agentic v2 workspace result path mismatch")
+        if expected_shape == "content" and result["content_sha256"] != (
+            hashlib.sha256(result["content"].encode("utf-8")).hexdigest()
+        ):
+            raise ValueError("agentic v2 workspace content hash mismatch")
+    if name == "environment_resolve":
+        lock = result["lock"]
+        if (
+            lock["ecosystem"] != arguments["ecosystem"]
+            or lock["requirements"] != sorted(arguments["requirements"])
+            or result["lock_digest"] != hashlib.sha256(
+                json.dumps(
+                    lock, sort_keys=True, separators=(",", ":")
+                ).encode("utf-8")
+            ).hexdigest()
+        ):
+            raise ValueError("agentic v2 package lock result mismatch")
+    if name == "environment_activate" and (
+        result["environment_id"] != arguments["lock_digest"]
+    ):
+        raise ValueError("agentic v2 environment activation result mismatch")
+    if name == "browser_run":
+        canonical_relative_path(result["path"])
+    if name == "browser_run" and arguments["operation"] in {
+        "open_local", "snapshot", "screenshot"
+    } and result["path"] != arguments["path"]:
+        raise ValueError("agentic v2 browser result path mismatch")
+    for artifact in result.get("artifacts", []):
+        canonical_relative_path(artifact["path"])
+    if name in {"verify_public", "finalize"} and [
+        artifact["path"] for artifact in result["artifacts"]
+    ] != arguments["deliverables"]:
+        raise ValueError("agentic v2 artifact result scope mismatch")
+    return result
+
+
+def canonical_relative_path(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value.encode("utf-8")) > 240
+        or "\\" in value
+        or ":" in value
+        or any(
+            ord(character) < 32 or 127 <= ord(character) <= 159
+            for character in value
+        )
+    ):
+        raise ValueError("agentic v2 path must be canonical relative POSIX")
+    if value == ".":
+        return value
+    if any(
+        part in {"", ".", ".."} or len(part.encode("utf-8")) > 255
+        for part in value.split("/")
+    ):
+        raise ValueError("agentic v2 path must be canonical relative POSIX")
+    path = PurePosixPath(value)
+    if path.is_absolute() or path.as_posix() != value:
+        raise ValueError("agentic v2 path must be canonical relative POSIX")
+    return value
+
+
+def validate_public_https_url(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > 2048
+        or any(character.isspace() or ord(character) < 32 or 127 <= ord(character) <= 159
+               for character in value)
+        or "\\" in value
+        or "%" in value
+    ):
+        raise ValueError("agentic v2 URL is invalid")
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("agentic v2 URL is invalid") from exc
+    if (
+        parsed.scheme != "https"
+        or not hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+        or parsed.netloc.endswith(":")
+        or hostname.endswith(".")
+        or (port is not None and port < 1)
+    ):
+        raise ValueError("agentic v2 URL must be public HTTPS")
+    hostname = hostname.lower()
+    if hostname == "localhost" or hostname.endswith(".local"):
+        raise ValueError("agentic v2 URL must be public HTTPS")
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        address = None
+    if address is not None and not address.is_global:
+        raise ValueError("agentic v2 URL must be public HTTPS")
+    if address is None and (
+        len(hostname) > 253
+        or re.fullmatch(
+            r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?"
+            r"(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*",
+            hostname,
+        ) is None
+        or hostname.replace(".", "").isdigit()
+        or any(
+            re.fullmatch(r"0x[0-9a-f]+", label) is not None
+            for label in hostname.split(".")
+        )
+    ):
+        raise ValueError("agentic v2 URL must be public HTTPS")
+    if any(segment in {".", ".."} for segment in parsed.path.split("/")):
+        raise ValueError("agentic v2 URL must be canonical public HTTPS")
+    return value
+
+
+def contract_fingerprint() -> str:
+    payload = {
+        "tool_contract_version": TOOL_CONTRACT_VERSION,
+        "profiles": list(POLICY_PROFILE_IDS),
+        "error_types": list(ERROR_TYPES),
+        "tools": responses_tool_definitions(),
+        "tool_data_schemas": TOOL_DATA_SCHEMAS,
+        "tool_result_schema": TOOL_RESULT_SCHEMA,
+        "public_result_commitment_schema": PUBLIC_RESULT_COMMITMENT_SCHEMA,
+        "event_schema": EVENT_SCHEMA,
+        "lifecycle": {
+            state.value: sorted(target.value for target in targets)
+            for state, targets in _TRANSITIONS.items()
+        },
+        "semantic_validator_source_sha256": hashlib.sha256(
+            Path(__file__).read_bytes()
+        ).hexdigest(),
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def is_sha256(value: str) -> bool:
+    return bool(re.fullmatch(_DIGEST_PATTERN, value))

--- a/batch-runner/core/agentic_v2_fixture_backend.py
+++ b/batch-runner/core/agentic_v2_fixture_backend.py
@@ -1,0 +1,720 @@
+"""Deterministic, model-free backend for Agentic Sandbox V2 contract tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from core.agentic_v2_contract import (
+    FOUNDATION_BACKEND_ID,
+    AgenticV2Profile,
+    canonical_relative_path,
+)
+from core.agentic_v2_provenance import (
+    canonical_sha256,
+    foundation_fixture_identity,
+)
+
+
+_MAX_FILE_BYTES = 1048576
+_MAX_WORKSPACE_BYTES = 64 * 1024 * 1024
+_MAX_FINAL_BYTES = 64 * 1024 * 1024
+_MAX_WORKSPACE_ENTRIES = 4096
+_MAX_DIRECTORY_ENTRIES = 1024
+
+
+class AgenticV2FixtureBackend:
+    """A deliberately non-production backend with no shell or network access."""
+
+    def __init__(
+        self,
+        *,
+        root: str | Path,
+        profile: AgenticV2Profile,
+        package_catalog: Mapping[str, str] | None = None,
+        budget_caps: Mapping[str, Any] | None = None,
+        **_: Any,
+    ):
+        lexical_root = Path(root)
+        if lexical_root.is_symlink():
+            raise ValueError("fixture root symlink is forbidden")
+        lexical_root.mkdir(parents=True, exist_ok=True)
+        self.root = lexical_root.resolve()
+        work = self.root / "work"
+        if work.is_symlink():
+            raise ValueError("fixture work root symlink is forbidden")
+        work.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.work = work.resolve()
+        self._root_fd = os.open(
+            self.work,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+        )
+        opened = os.fstat(self._root_fd)
+        lexical = self.work.lstat()
+        if (opened.st_dev, opened.st_ino) != (lexical.st_dev, lexical.st_ino):
+            os.close(self._root_fd)
+            raise ValueError("fixture work root identity changed")
+        self._root_identity = (opened.st_dev, opened.st_ino)
+        self.profile = profile
+        package_catalog_value = dict(
+            {"python:demo-pkg==1.0.0": "d" * 64}
+            if package_catalog is None
+            else package_catalog
+        )
+        for coordinate, digest in package_catalog_value.items():
+            if (
+                not isinstance(coordinate, str)
+                or re.fullmatch(
+                    r"(?:python|npm|debian):[A-Za-z0-9][A-Za-z0-9._-]{0,127}"
+                    r"(?:==[A-Za-z0-9][A-Za-z0-9.!+_-]{0,127})?",
+                    coordinate,
+                ) is None
+                or not isinstance(digest, str)
+                or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+            ):
+                raise ValueError("fixture package catalog identity is invalid")
+        canonical_identity = foundation_fixture_identity(
+            profile.policy_profile_id,
+            dict(budget_caps or {"tool_calls": 32, "wall_seconds": 1200}),
+        )
+        if tuple(sorted(package_catalog_value.items())) != tuple(
+            canonical_identity["package_records"]
+        ):
+            raise ValueError("fixture package catalog must match canonical identity")
+        self._package_records = tuple(sorted(package_catalog_value.items()))
+        self.package_catalog = MappingProxyType(dict(self._package_records))
+        self.budget_caps = dict(
+            budget_caps or {"tool_calls": 32, "wall_seconds": 1200}
+        )
+        self._locks: dict[str, bytes] = {}
+        self._active_locks: set[str] = set()
+        self._result: dict | None = None
+        self.closed = False
+
+    def start(self, timeout_seconds: float) -> Mapping[str, Any]:
+        del timeout_seconds
+        identity = foundation_fixture_identity(
+            self.profile.policy_profile_id,
+            self.budget_caps,
+        )
+        return {
+            "ok": True,
+            "data": {
+                "substrate_manifest": {
+                    "schema_version": "2.0-fixture",
+                    "sha256": identity["substrate_manifest_sha256"],
+                },
+                "backend_identity": identity["backend_identity"],
+                "package_snapshot_sha256": identity[
+                    "package_snapshot_sha256"
+                ],
+                "browser_build_sha256": identity["browser_build_sha256"],
+                "capabilities": identity["capabilities"],
+            },
+        }
+
+    def state_sha256(self) -> str:
+        root_mode, entries, _ = self._workspace_snapshot()
+        return canonical_sha256({
+            "root_mode": root_mode,
+            "profile": self.profile.policy_profile_id,
+            "package_catalog": self._package_records,
+            "budget_caps": self.budget_caps,
+            "entries": entries,
+            "active_locks": sorted(self._active_locks),
+            "terminal_result_sha256": (
+                canonical_sha256(_result_identity(self._result))
+                if self._result is not None else None
+            ),
+        })
+
+    def workspace_state_sha256(self) -> str:
+        _, entries, _ = self._workspace_snapshot()
+        return canonical_sha256(entries)
+
+    def capabilities_query(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        kind = str(arguments["kind"])
+        return {
+            "ok": True,
+            "data": {"kind": kind, "items": self._capabilities()[kind]},
+        }
+
+    def expected_capabilities(self) -> Mapping[str, Any]:
+        return self._capabilities()
+
+    def workspace_apply(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        operation = str(arguments["operation"])
+        if operation == "copy":
+            source = str(arguments["source"])
+            destination = str(arguments["destination"])
+            self._write_bytes(destination, self._read_bytes(source))
+            return {"ok": True, "data": {"path": destination}}
+        relative = str(arguments["path"])
+        if operation == "list":
+            try:
+                descriptor = self._open_directory(relative)
+            except (FileNotFoundError, NotADirectoryError, ValueError):
+                return {"ok": False, "error_type": "path_not_directory"}
+            try:
+                entries = sorted(os.listdir(descriptor))
+                if len(entries) > _MAX_DIRECTORY_ENTRIES:
+                    raise ValueError("fixture directory entry limit exceeded")
+                return {"ok": True, "data": {"entries": entries}}
+            finally:
+                os.close(descriptor)
+        if operation == "read":
+            content = self._read_bytes(relative).decode("utf-8")
+            offset = int(arguments.get("offset", 0))
+            limit = int(arguments.get("limit", 1048576))
+            selected = content[offset:offset + limit]
+            return {"ok": True, "data": {
+                "content": selected,
+                "content_sha256": hashlib.sha256(selected.encode("utf-8")).hexdigest(),
+            }}
+        if operation in {"write", "patch"}:
+            content = str(arguments["content"]).encode("utf-8")
+            if len(content) > 1048576:
+                raise ValueError("fixture workspace write exceeds byte limit")
+            self._write_bytes(relative, content)
+        elif operation == "delete":
+            self._delete(relative)
+        else:
+            self._reserve_entries(relative, temporary_leaf=False)
+            descriptor = self._open_directory(relative, create=True)
+            os.close(descriptor)
+        return {"ok": True, "data": {"path": relative}}
+
+    def exec_run(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        argv = arguments.get("argv")
+        if not isinstance(argv, list) or not argv:
+            return {"ok": False, "error_type": "capability_unavailable"}
+        if argv[0] == "fixture-upper" and len(argv) == 3:
+            cwd = str(arguments["cwd"])
+            try:
+                descriptor = self._open_directory(cwd)
+            except (FileNotFoundError, NotADirectoryError, ValueError):
+                return {"ok": False, "error_type": "path_not_directory"}
+            else:
+                os.close(descriptor)
+            source = _join_relative(cwd, str(argv[1]))
+            destination = _join_relative(cwd, str(argv[2]))
+            self._write_bytes(destination, self._read_bytes(source).upper())
+            return {"ok": True, "data": {"returncode": 0}}
+        return {"ok": False, "error_type": "capability_unavailable"}
+
+    def environment_resolve(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        if self.profile.policy_profile_id == "offline-full-v1":
+            return {"ok": False, "error_type": "capability_unavailable"}
+        ecosystem = str(arguments["ecosystem"])
+        requirements = sorted(str(item) for item in arguments["requirements"])
+        coordinates = [f"{ecosystem}:{item}" for item in requirements]
+        if any(item not in self.package_catalog for item in coordinates):
+            return {"ok": False, "error_type": "package_not_in_snapshot"}
+        lock = {
+            "ecosystem": ecosystem,
+            "requirements": requirements,
+            "blobs": [self.package_catalog[item] for item in coordinates],
+        }
+        digest = canonical_sha256(lock)
+        self._locks[digest] = json.dumps(
+            lock, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+        return {"ok": True, "data": {"lock_digest": digest, "lock": lock}}
+
+    def environment_activate(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        if self.profile.policy_profile_id == "offline-full-v1":
+            return {"ok": False, "error_type": "capability_unavailable"}
+        digest = str(arguments["lock_digest"])
+        lock_bytes = self._locks.get(digest)
+        if lock_bytes is None:
+            return {"ok": False, "error_type": "unapproved_lock"}
+        try:
+            lock = json.loads(lock_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return {"ok": False, "error_type": "unapproved_lock"}
+        coordinates = [
+            f"{lock.get('ecosystem')}:{requirement}"
+            for requirement in lock.get("requirements", [])
+        ]
+        if (
+            canonical_sha256(lock) != digest
+            or coordinates != [
+                f"{lock['ecosystem']}:{value}"
+                for value in sorted(lock.get("requirements", []))
+            ]
+            or any(value not in self.package_catalog for value in coordinates)
+            or lock.get("blobs") != [
+                self.package_catalog[value] for value in coordinates
+            ]
+        ):
+            return {"ok": False, "error_type": "unapproved_lock"}
+        self._active_locks.add(digest)
+        return {"ok": True, "data": {"environment_id": digest}}
+
+    def browser_run(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        operation = str(arguments["operation"])
+        if operation in {"search", "open_url"}:
+            return {"ok": False, "error_type": "capability_unavailable"}
+        relative = str(arguments["path"])
+        content = self._read_bytes(relative)
+        return {
+            "ok": True,
+            "data": {
+                "path": relative,
+                "sha256": hashlib.sha256(content).hexdigest(),
+            },
+        }
+
+    def verify_public(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        try:
+            artifacts, _ = self._collect_artifacts(arguments["deliverables"])
+        except (FileNotFoundError, OSError, ValueError):
+            return {"ok": False, "error_type": "artifact_not_openable"}
+        return {"ok": True, "data": {"artifacts": artifacts}}
+
+    def finalize(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        try:
+            artifacts, files = self._collect_artifacts(arguments["deliverables"])
+        except (FileNotFoundError, OSError, ValueError):
+            return {"ok": False, "error_type": "artifact_not_openable"}
+        self._result = {
+            "success": True,
+            "text": str(arguments["summary"]),
+            "deliverable_text": str(arguments["summary"]),
+            "files": files,
+        }
+        return {"ok": True, "data": {"artifacts": artifacts}}
+
+    def best_result(self) -> Mapping[str, Any] | None:
+        return dict(self._result) if self._result is not None else None
+
+    def close(self) -> None:
+        if not self.closed:
+            try:
+                self._purge_directory(self._root_fd)
+            finally:
+                os.close(self._root_fd)
+            try:
+                metadata = self.work.lstat()
+            except FileNotFoundError:
+                pass
+            else:
+                if (
+                    stat.S_ISDIR(metadata.st_mode)
+                    and metadata.st_dev == self._root_identity[0]
+                    and metadata.st_ino == self._root_identity[1]
+                ):
+                    self.work.rmdir()
+        self.closed = True
+
+    def _capabilities(self) -> dict:
+        return foundation_fixture_identity(
+            self.profile.policy_profile_id,
+            self.budget_caps,
+        )["capabilities"]
+
+    def _read_bytes(self, relative: str) -> bytes:
+        descriptor = self._open_regular(relative)
+        try:
+            return _read_regular_descriptor(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _write_bytes(self, relative: str, content: bytes) -> None:
+        if len(content) > _MAX_FILE_BYTES:
+            raise ValueError("fixture workspace write exceeds byte limit")
+        self._reserve_entries(relative, temporary_leaf=True)
+        _, _, current_bytes = self._workspace_snapshot()
+        try:
+            existing = self._open_regular(relative)
+        except FileNotFoundError:
+            pass
+        else:
+            os.close(existing)
+        if current_bytes + len(content) > _MAX_WORKSPACE_BYTES:
+            raise ValueError("fixture workspace byte limit exceeded")
+        parent_fd, name = self._open_parent(relative, create=True)
+        temporary = None
+        try:
+            self._assert_directory_beneath_root(parent_fd)
+            descriptor, temporary = self._open_owned_temporary(parent_fd, name)
+            try:
+                with os.fdopen(descriptor, "wb", closefd=False) as stream:
+                    stream.write(content)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+            finally:
+                os.close(descriptor)
+            self._assert_directory_beneath_root(parent_fd)
+            os.replace(temporary, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            try:
+                self._assert_directory_beneath_root(parent_fd)
+            except Exception:
+                os.unlink(name, dir_fd=parent_fd)
+                raise
+        finally:
+            if temporary is not None:
+                try:
+                    os.unlink(temporary, dir_fd=parent_fd)
+                except FileNotFoundError:
+                    pass
+            os.close(parent_fd)
+
+    def _open_owned_temporary(
+        self,
+        parent_fd: int,
+        destination_name: str,
+    ) -> tuple[int, str]:
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
+        for _ in range(32):
+            candidate = f".agentic-v2-{secrets.token_hex(8)}.tmp"
+            try:
+                descriptor = os.open(
+                    candidate,
+                    flags,
+                    0o600,
+                    dir_fd=parent_fd,
+                )
+            except FileExistsError:
+                continue
+            return descriptor, candidate
+        raise ValueError("fixture temporary file allocation failed")
+
+    def _open_directory(self, relative: str, *, create: bool = False) -> int:
+        canonical_relative_path(relative)
+        self._assert_root_identity()
+        descriptor = os.dup(self._root_fd)
+        if relative == ".":
+            return descriptor
+        try:
+            for part in PurePosixPath(relative).parts:
+                self._assert_directory_beneath_root(descriptor)
+                if create:
+                    try:
+                        os.mkdir(part, mode=0o700, dir_fd=descriptor)
+                    except FileExistsError:
+                        pass
+                child = os.open(
+                    part,
+                    os.O_RDONLY
+                    | getattr(os, "O_DIRECTORY", 0)
+                    | getattr(os, "O_NOFOLLOW", 0)
+                    | getattr(os, "O_CLOEXEC", 0),
+                    dir_fd=descriptor,
+                )
+                try:
+                    self._assert_directory_beneath_root(descriptor)
+                    self._assert_directory_beneath_root(child)
+                except Exception:
+                    os.close(child)
+                    raise
+                os.close(descriptor)
+                descriptor = child
+            return descriptor
+        except Exception:
+            os.close(descriptor)
+            raise
+
+    def _open_parent(self, relative: str, *, create: bool = False) -> tuple[int, str]:
+        canonical_relative_path(relative)
+        if relative == ".":
+            raise ValueError("fixture file path must not be workspace root")
+        path = PurePosixPath(relative)
+        parent = path.parent.as_posix()
+        return self._open_directory(parent, create=create), path.name
+
+    def _open_regular(self, relative: str) -> int:
+        parent_fd, name = self._open_parent(relative)
+        descriptor = None
+        try:
+            self._assert_directory_beneath_root(parent_fd)
+            descriptor = os.open(
+                name,
+                os.O_RDONLY
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_NONBLOCK", 0)
+                | getattr(os, "O_CLOEXEC", 0),
+                dir_fd=parent_fd,
+            )
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise ValueError(
+                    "fixture workspace file must be single-link regular"
+                )
+            self._assert_directory_beneath_root(parent_fd)
+            self._assert_descriptor_beneath_root(descriptor)
+            return descriptor
+        except Exception:
+            if descriptor is not None:
+                os.close(descriptor)
+            raise
+        finally:
+            os.close(parent_fd)
+
+    def _delete(self, relative: str) -> None:
+        parent_fd, name = self._open_parent(relative)
+        try:
+            self._assert_directory_beneath_root(parent_fd)
+            metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            if stat.S_ISDIR(metadata.st_mode):
+                os.rmdir(name, dir_fd=parent_fd)
+            elif stat.S_ISREG(metadata.st_mode) and metadata.st_nlink == 1:
+                os.unlink(name, dir_fd=parent_fd)
+            else:
+                raise ValueError("fixture workspace entry is unsafe")
+            self._assert_directory_beneath_root(parent_fd)
+        finally:
+            os.close(parent_fd)
+
+    def _workspace_snapshot(self) -> tuple[int, list[dict], int]:
+        self._assert_root_identity()
+        entries: list[dict] = []
+        total_bytes = 0
+
+        def visit(directory_fd: int, prefix: str) -> None:
+            nonlocal total_bytes
+            self._assert_directory_beneath_root(directory_fd)
+            names = sorted(os.listdir(directory_fd))
+            if len(names) > _MAX_DIRECTORY_ENTRIES:
+                raise ValueError("fixture directory entry limit exceeded")
+            for name in names:
+                self._assert_directory_beneath_root(directory_fd)
+                if len(entries) >= _MAX_WORKSPACE_ENTRIES:
+                    raise ValueError("fixture workspace entry limit exceeded")
+                relative = f"{prefix}/{name}" if prefix else name
+                metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+                if stat.S_ISDIR(metadata.st_mode):
+                    child = os.open(
+                        name,
+                        os.O_RDONLY
+                        | getattr(os, "O_DIRECTORY", 0)
+                        | getattr(os, "O_NOFOLLOW", 0)
+                        | getattr(os, "O_CLOEXEC", 0),
+                        dir_fd=directory_fd,
+                    )
+                    try:
+                        self._assert_directory_beneath_root(directory_fd)
+                        self._assert_directory_beneath_root(child)
+                        opened = os.fstat(child)
+                        entries.append({
+                            "path": relative,
+                            "kind": "directory",
+                            "mode": stat.S_IMODE(opened.st_mode),
+                        })
+                        visit(child, relative)
+                    finally:
+                        os.close(child)
+                elif stat.S_ISREG(metadata.st_mode):
+                    descriptor = os.open(
+                        name,
+                        os.O_RDONLY
+                        | getattr(os, "O_NOFOLLOW", 0)
+                        | getattr(os, "O_NONBLOCK", 0)
+                        | getattr(os, "O_CLOEXEC", 0),
+                        dir_fd=directory_fd,
+                    )
+                    try:
+                        self._assert_directory_beneath_root(directory_fd)
+                        self._assert_descriptor_beneath_root(descriptor)
+                        opened = os.fstat(descriptor)
+                        if (
+                            not stat.S_ISREG(opened.st_mode)
+                            or opened.st_nlink != 1
+                        ):
+                            raise ValueError(
+                                "fixture workspace contains unsafe entry"
+                            )
+                        content = _read_regular_descriptor(descriptor)
+                        self._assert_directory_beneath_root(directory_fd)
+                        self._assert_descriptor_beneath_root(descriptor)
+                        total_bytes += len(content)
+                        if total_bytes > _MAX_WORKSPACE_BYTES:
+                            raise ValueError("fixture workspace byte limit exceeded")
+                        entries.append({
+                            "path": relative,
+                            "kind": "file",
+                            "sha256": hashlib.sha256(content).hexdigest(),
+                            "size": len(content),
+                            "mode": stat.S_IMODE(opened.st_mode),
+                        })
+                    finally:
+                        os.close(descriptor)
+                else:
+                    raise ValueError("fixture workspace contains unsafe entry")
+
+        root = os.dup(self._root_fd)
+        try:
+            root_mode = stat.S_IMODE(os.fstat(root).st_mode)
+            visit(root, "")
+        finally:
+            os.close(root)
+        return root_mode, entries, total_bytes
+
+    def _reserve_entries(self, relative: str, *, temporary_leaf: bool) -> None:
+        canonical_relative_path(relative)
+        _, entries, _ = self._workspace_snapshot()
+        existing = {entry["path"] for entry in entries}
+        planned = []
+        current = ""
+        for part in PurePosixPath(relative).parts:
+            current = f"{current}/{part}" if current else part
+            if current not in existing:
+                planned.append(current)
+        leaf_exists = relative in existing
+        peak_extra = len(planned) + int(temporary_leaf and leaf_exists)
+        if len(entries) + peak_extra > _MAX_WORKSPACE_ENTRIES:
+            raise ValueError("fixture workspace entry limit exceeded")
+        child_counts: dict[str, int] = {}
+        for path in existing:
+            parent = PurePosixPath(path).parent.as_posix()
+            child_counts[parent] = child_counts.get(parent, 0) + 1
+        for path in planned:
+            parent = PurePosixPath(path).parent.as_posix()
+            child_counts[parent] = child_counts.get(parent, 0) + 1
+        if temporary_leaf and leaf_exists:
+            parent = PurePosixPath(relative).parent.as_posix()
+            child_counts[parent] = child_counts.get(parent, 0) + 1
+        if any(count > _MAX_DIRECTORY_ENTRIES for count in child_counts.values()):
+            raise ValueError("fixture directory entry limit exceeded")
+
+    def _assert_root_identity(self) -> None:
+        try:
+            lexical = self.work.lstat()
+        except FileNotFoundError as exc:
+            raise ValueError("fixture work root identity changed") from exc
+        opened = os.fstat(self._root_fd)
+        identity = (opened.st_dev, opened.st_ino)
+        if (
+            not stat.S_ISDIR(lexical.st_mode)
+            or identity != self._root_identity
+            or (lexical.st_dev, lexical.st_ino) != self._root_identity
+        ):
+            raise ValueError("fixture work root identity changed")
+
+    def _assert_directory_beneath_root(self, descriptor: int) -> None:
+        try:
+            self._assert_descriptor_beneath_root(descriptor, require_directory=True)
+        except Exception:
+            self._purge_directory(descriptor)
+            raise
+
+    def _assert_descriptor_beneath_root(
+        self,
+        descriptor: int,
+        *,
+        require_directory: bool = False,
+    ) -> None:
+        self._assert_root_identity()
+        target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
+        try:
+            target.relative_to(self.work)
+        except ValueError as exc:
+            raise ValueError("fixture descriptor moved outside work root") from exc
+        lexical = target.lstat()
+        opened = os.fstat(descriptor)
+        if (
+            (require_directory and not stat.S_ISDIR(opened.st_mode))
+            or (lexical.st_dev, lexical.st_ino) != (opened.st_dev, opened.st_ino)
+        ):
+            raise ValueError("fixture descriptor identity changed")
+
+    def _purge_directory(self, descriptor: int) -> None:
+        for name in os.listdir(descriptor):
+            metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+            if stat.S_ISDIR(metadata.st_mode):
+                child = os.open(
+                    name,
+                    os.O_RDONLY
+                    | getattr(os, "O_DIRECTORY", 0)
+                    | getattr(os, "O_NOFOLLOW", 0)
+                    | getattr(os, "O_CLOEXEC", 0),
+                    dir_fd=descriptor,
+                )
+                try:
+                    self._purge_directory(child)
+                finally:
+                    os.close(child)
+                os.rmdir(name, dir_fd=descriptor)
+            else:
+                os.unlink(name, dir_fd=descriptor)
+
+    def _collect_artifacts(self, deliverables: Any) -> tuple[list[dict], list[dict]]:
+        artifacts = []
+        files = []
+        total_bytes = 0
+        for value in deliverables:
+            relative = canonical_relative_path(str(value))
+            descriptor = self._open_regular(relative)
+            try:
+                content = _read_regular_descriptor(descriptor)
+            finally:
+                os.close(descriptor)
+            if not content:
+                raise ValueError("fixture artifact is empty")
+            total_bytes += len(content)
+            if total_bytes > _MAX_FINAL_BYTES:
+                raise ValueError("fixture final artifact byte limit exceeded")
+            artifacts.append({
+                "path": relative,
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "size": len(content),
+            })
+            files.append({"filename": relative, "content": content})
+        return artifacts, files
+
+
+def _read_regular_descriptor(descriptor: int) -> bytes:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    chunks = []
+    total = 0
+    while True:
+        chunk = os.read(descriptor, 65536)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > _MAX_FILE_BYTES:
+            raise ValueError("fixture workspace file exceeds byte limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _join_relative(directory: str, child: str) -> str:
+    canonical_relative_path(directory)
+    canonical_relative_path(child)
+    if child == ".":
+        raise ValueError("fixture file name must not be a directory")
+    return child if directory == "." else f"{directory}/{child}"
+
+
+def _result_identity(result: Mapping[str, Any] | None) -> dict | None:
+    if result is None:
+        return None
+    return {
+        "success": result.get("success"),
+        "text": result.get("text"),
+        "files": [
+            {
+                "filename": item.get("filename"),
+                "sha256": hashlib.sha256(item.get("content", b"")).hexdigest(),
+            }
+            for item in result.get("files", [])
+            if isinstance(item, Mapping)
+            and isinstance(item.get("content"), bytes)
+        ],
+    }

--- a/batch-runner/core/agentic_v2_provenance.py
+++ b/batch-runner/core/agentic_v2_provenance.py
@@ -1,0 +1,1534 @@
+"""Deterministic provenance primitives for Agentic Sandbox V2."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator
+
+from core.agentic_v2_contract import (
+    ERROR_TYPES,
+    EVENT_SCHEMA,
+    FOUNDATION_BACKEND_ID,
+    POLICY_PROFILE_IDS,
+    PUBLIC_RESULT_COMMITMENT_SCHEMA,
+    TOOL_CONTRACT_VERSION,
+    TOOL_RESULT_SCHEMA,
+    TOOL_SCHEMAS,
+    canonical_relative_path,
+    contract_fingerprint,
+    is_sha256,
+    validate_tool_arguments,
+    validate_tool_result_data,
+)
+
+
+_FOUNDATION_MODULES = (
+    "agentic_v2_contract.py",
+    "agentic_v2_fixture_backend.py",
+    "agentic_v2_provenance.py",
+    "agentic_v2_runner.py",
+    "agentic_v2_tools.py",
+)
+_EVENT_KINDS = frozenset({
+    "started", "tool_result", "tool_result_public", "failure"
+})
+_PUBLIC_COMMITMENT_FIELDS = (
+    "call_id",
+    "tool_name",
+    "request_sha256",
+    "result_sha256",
+    "ok",
+    "error_type",
+    "usage_delta",
+    "state_before_sha256",
+    "state_after_sha256",
+)
+_FAILURE_STAGE_ERRORS = {
+    "backend": frozenset({"compute_backend_error"}),
+    "startup": frozenset({
+        "compute_start_failed",
+        "substrate_manifest_missing",
+    }),
+    "control": frozenset({
+        "cancelled",
+        "task_wall_time_exhausted",
+    }),
+    "cleanup": frozenset({"compute_cleanup_failed"}),
+    "runtime": frozenset({
+        "artifact_not_openable",
+        "call_id_conflict",
+        "capability_unavailable",
+        "finalize_not_called",
+        "finalize_result_mismatch",
+        "finalize_result_missing",
+        "fixture_backend_error",
+        "invalid_arguments",
+        "invalid_backend_result",
+        "invalid_backend_state",
+        "invalid_call_id",
+        "invalid_lifecycle_transition",
+        "invalid_result_envelope",
+        "package_not_in_snapshot",
+        "path_not_directory",
+        "runner_internal_error",
+        "tool_budget_exhausted",
+        "tool_not_allowed_in_state",
+        "tool_result_too_large",
+        "unapproved_lock",
+        "unknown_tool",
+    }),
+}
+_FOUNDATION_PACKAGE_RECORDS = (
+    ("python:demo-pkg==1.0.0", "d" * 64),
+)
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def validate_failure_stage(error_type: Any, stage: Any) -> tuple[str, str]:
+    if (
+        not isinstance(error_type, str)
+        or not isinstance(stage, str)
+        or stage not in _FAILURE_STAGE_ERRORS
+        or error_type not in _FAILURE_STAGE_ERRORS[stage]
+    ):
+        raise ValueError("agentic v2 failure stage is invalid")
+    return error_type, stage
+
+
+def foundation_implementation_fingerprint() -> str:
+    root = Path(__file__).resolve().parent
+    return canonical_sha256({
+        "schema_version": "2.0",
+        "modules": {
+            name: hashlib.sha256((root / name).read_bytes()).hexdigest()
+            for name in _FOUNDATION_MODULES
+        },
+    })
+
+
+def foundation_fixture_identity(
+    policy_profile_id: str,
+    budget_caps: Mapping[str, Any],
+) -> dict:
+    if policy_profile_id not in POLICY_PROFILE_IDS:
+        raise ValueError("agentic v2 fixture profile is invalid")
+    if not _valid_budget_capabilities(
+        [
+            f"tool_calls={budget_caps.get('tool_calls')}",
+            f"wall_seconds={budget_caps.get('wall_seconds')}",
+        ],
+        budget_caps,
+    ):
+        raise ValueError("agentic v2 fixture budget is invalid")
+    packages = (
+        []
+        if policy_profile_id == "offline-full-v1"
+        else [coordinate for coordinate, _ in _FOUNDATION_PACKAGE_RECORDS]
+    )
+    capabilities = {
+        "commands": ["fixture-upper"],
+        "runtimes": ["fixture"],
+        "packages": packages,
+        "formats": ["html", "txt"],
+        "budgets": [
+            f"tool_calls={budget_caps['tool_calls']}",
+            f"wall_seconds={budget_caps['wall_seconds']}",
+        ],
+    }
+    return {
+        "backend_identity": {
+            "backend_id": FOUNDATION_BACKEND_ID,
+            "foundation_only": True,
+            "implementation_sha256": foundation_implementation_fingerprint(),
+        },
+        "substrate_manifest_sha256": canonical_sha256({
+            "backend": FOUNDATION_BACKEND_ID,
+            "profile": policy_profile_id,
+        }),
+        "package_snapshot_sha256": canonical_sha256(
+            _FOUNDATION_PACKAGE_RECORDS
+        ),
+        "browser_build_sha256": canonical_sha256({
+            "browser": "fixture-local-only-v1"
+        }),
+        "capabilities": capabilities,
+        "package_records": _FOUNDATION_PACKAGE_RECORDS,
+    }
+
+
+def runtime_fingerprint(
+    *,
+    policy_profile_id: str,
+    substrate_manifest_sha256: str,
+    package_snapshot_sha256: str,
+    browser_build_sha256: str,
+    backend_implementation_sha256: str,
+    capabilities_sha256: str,
+    budget_caps: Mapping[str, Any],
+) -> str:
+    digests = (
+        substrate_manifest_sha256,
+        package_snapshot_sha256,
+        browser_build_sha256,
+        backend_implementation_sha256,
+        capabilities_sha256,
+    )
+    if any(not is_sha256(value) for value in digests):
+        raise ValueError("agentic v2 runtime component digest is invalid")
+    return canonical_sha256({
+        "schema_version": "2.0",
+        "tool_contract_sha256": contract_fingerprint(),
+        "policy_profile_id": policy_profile_id,
+        "substrate_manifest_sha256": substrate_manifest_sha256,
+        "package_snapshot_sha256": package_snapshot_sha256,
+        "browser_build_sha256": browser_build_sha256,
+        "backend_implementation_sha256": backend_implementation_sha256,
+        "capabilities_sha256": capabilities_sha256,
+        "budget_caps": dict(budget_caps),
+    })
+
+
+@dataclass
+class AgenticV2EventChain:
+    """Append-only hash chain used by private and public execution traces."""
+
+    events: list[dict] = field(default_factory=list)
+    _head: str = "0" * 64
+
+    @property
+    def head_sha256(self) -> str:
+        return self._head
+
+    def append(
+        self,
+        kind: str,
+        payload: Mapping[str, Any],
+        *,
+        state_sha256: str,
+    ) -> dict:
+        if kind not in _EVENT_KINDS:
+            raise ValueError("agentic v2 event kind is invalid")
+        if not is_sha256(state_sha256):
+            raise ValueError("agentic v2 event state digest is invalid")
+        event = {
+            "schema_version": "2.0",
+            "sequence": len(self.events),
+            "kind": kind,
+            "payload": deepcopy(dict(payload)),
+            "state_sha256": state_sha256,
+            "previous_sha256": self._head,
+        }
+        event["event_sha256"] = canonical_sha256(event)
+        self.events.append(event)
+        self._head = event["event_sha256"]
+        return deepcopy(event)
+
+
+def verify_event_chain(events: Any, expected_head_sha256: str) -> None:
+    if not isinstance(events, list) or not events:
+        raise ValueError("agentic v2 event chain is missing")
+    previous = "0" * 64
+    previous_state = None
+    tool_event_kind = None
+    call_ledger: dict[str, dict] = {}
+    semantic_ledger: dict[str, Any] = {}
+    started_payload = None
+    last_tool_result = None
+    last_tool_name = None
+    started_seen = False
+    for sequence, event in enumerate(events):
+        if not isinstance(event, dict):
+            raise ValueError("agentic v2 event is invalid")
+        if list(Draft202012Validator(EVENT_SCHEMA).iter_errors(event)):
+            raise ValueError("agentic v2 event schema is invalid")
+        if event.get("sequence") != sequence or event.get("previous_sha256") != previous:
+            raise ValueError("agentic v2 event chain ordering is invalid")
+        claimed = event.get("event_sha256")
+        if not is_sha256(claimed):
+            raise ValueError("agentic v2 event hash is invalid")
+        unsigned = dict(event)
+        del unsigned["event_sha256"]
+        if canonical_sha256(unsigned) != claimed:
+            raise ValueError("agentic v2 event hash mismatch")
+        payload = event.get("payload")
+        kind = event.get("kind")
+        if sequence == 0 and kind == "started":
+            if not _valid_started_payload(payload):
+                raise ValueError("agentic v2 started event is invalid")
+            started_payload = payload
+            started_seen = True
+            semantic_ledger = _new_fixture_semantic_ledger(payload)
+            if event.get("state_sha256") != _fixture_state_sha256(
+                semantic_ledger
+            ):
+                raise ValueError("agentic v2 initial fixture state mismatch")
+        elif kind == "started" or kind not in _EVENT_KINDS:
+            raise ValueError("agentic v2 event kind is invalid")
+        elif kind == "failure":
+            if sequence != len(events) - 1 or not _valid_failure_payload(payload):
+                raise ValueError("agentic v2 failure event is invalid")
+            expected_state = canonical_sha256({
+                "schema_version": "2.0",
+                "error_type": payload["error_type"],
+                "lifecycle_state": payload["lifecycle_state"],
+                "stage": payload["stage"],
+            })
+            if event.get("state_sha256") != expected_state:
+                raise ValueError("agentic v2 failure state mismatch")
+            _verify_failure_causality(
+                payload,
+                started_seen=started_seen,
+                last_tool_name=last_tool_name,
+                last_tool_result=last_tool_result,
+            )
+        elif tool_event_kind is None:
+            tool_event_kind = kind
+        elif kind != tool_event_kind:
+            raise ValueError("agentic v2 event trace classification is mixed")
+        if kind in {"tool_result", "tool_result_public"} and isinstance(
+            last_tool_result, Mapping
+        ) and (
+            last_tool_result.get("ok") is False
+            or (
+                last_tool_name == "finalize"
+                and last_tool_result.get("ok") is True
+            )
+        ):
+            raise ValueError("agentic v2 tool event follows terminal result")
+        if kind == "tool_result":
+            if not isinstance(payload, dict) or set(payload) != {
+                "request", "result", "replayed"
+            } or not isinstance(payload.get("replayed"), bool):
+                raise ValueError("agentic v2 private result payload is invalid")
+            result = payload.get("result") if isinstance(payload, dict) else None
+            if (
+                not isinstance(result, dict)
+                or list(Draft202012Validator(TOOL_RESULT_SCHEMA).iter_errors(result))
+            ):
+                raise ValueError("agentic v2 tool result commitment is invalid")
+            claimed_result = result.get("result_sha256")
+            unsigned_result = dict(result)
+            del unsigned_result["result_sha256"]
+            if canonical_sha256(unsigned_result) != claimed_result:
+                raise ValueError("agentic v2 tool result hash mismatch")
+            request = payload.get("request")
+            _verify_private_result_semantics(
+                request,
+                result,
+                replayed=payload["replayed"],
+                previous_state=previous_state,
+                event_state=event.get("state_sha256"),
+                call_ledger=call_ledger,
+                semantic_ledger=semantic_ledger,
+                started_payload=started_payload,
+            )
+            last_tool_result = result
+            last_tool_name = request.get("name") if isinstance(request, dict) else None
+            if result.get("request_sha256") is not None:
+                if not isinstance(request, dict) or set(request) != {
+                    "call_id", "name", "arguments"
+                }:
+                    raise ValueError("agentic v2 tool request commitment is invalid")
+                try:
+                    arguments = validate_tool_arguments(
+                        request.get("name"), request.get("arguments")
+                    )
+                except ValueError as exc:
+                    raise ValueError(
+                        "agentic v2 tool request commitment is invalid"
+                    ) from exc
+                request_sha256 = canonical_sha256({
+                    "tool_contract_version": "2.0",
+                    "call_id": request.get("call_id"),
+                    "name": request.get("name"),
+                    "arguments": arguments,
+                })
+                if request_sha256 != result.get("request_sha256"):
+                    raise ValueError("agentic v2 tool request hash mismatch")
+        if kind == "tool_result_public":
+            if not isinstance(payload, dict) or set(payload) != {
+                "result_commitment", "replayed"
+            } or not isinstance(payload.get("replayed"), bool):
+                raise ValueError("agentic v2 public result payload is invalid")
+            commitment = payload.get("result_commitment") if isinstance(
+                payload, dict
+            ) else None
+            if (
+                not isinstance(commitment, dict)
+                or list(Draft202012Validator(
+                    PUBLIC_RESULT_COMMITMENT_SCHEMA
+                ).iter_errors(commitment))
+            ):
+                raise ValueError("agentic v2 public result commitment is invalid")
+            last_tool_result = commitment
+            last_tool_name = commitment.get("tool_name")
+        previous = claimed
+        previous_state = event.get("state_sha256")
+    if previous != expected_head_sha256:
+        raise ValueError("agentic v2 event chain head mismatch")
+    terminal_kind = events[-1].get("kind")
+    if terminal_kind != "failure" and not (
+        last_tool_name == "finalize"
+        and isinstance(last_tool_result, Mapping)
+        and last_tool_result.get("ok") is True
+    ):
+        raise ValueError("agentic v2 trace terminal state is invalid")
+
+
+def verify_trace_pair(
+    private_trace: Any,
+    public_trace: Any,
+    expected_pair_sha256: str,
+) -> None:
+    if (
+        not isinstance(private_trace, dict)
+        or set(private_trace) != {
+            "classification", "event_chain_head_sha256", "events"
+        }
+        or private_trace.get("classification") != "private"
+        or not isinstance(public_trace, dict)
+        or set(public_trace) != {
+            "classification", "event_chain_head_sha256", "events"
+        }
+        or public_trace.get("classification") != "public_redacted"
+    ):
+        raise ValueError("agentic v2 trace pair classification is invalid")
+    verify_event_chain(
+        private_trace["events"], private_trace["event_chain_head_sha256"]
+    )
+    verify_event_chain(
+        public_trace["events"], public_trace["event_chain_head_sha256"]
+    )
+    private_events = private_trace["events"]
+    public_events = public_trace["events"]
+    if len(private_events) != len(public_events):
+        raise ValueError("agentic v2 trace pair length mismatch")
+    for sequence, (private_event, public_event) in enumerate(zip(
+        private_events, public_events
+    )):
+        if (
+            private_event.get("sequence") != sequence
+            or public_event.get("sequence") != sequence
+            or private_event.get("state_sha256") != public_event.get(
+                "state_sha256"
+            )
+        ):
+            raise ValueError("agentic v2 trace pair ordering mismatch")
+        if sequence == 0:
+            if (
+                private_event.get("kind") != public_event.get("kind")
+                or private_event.get("payload") != public_event.get("payload")
+            ):
+                raise ValueError("agentic v2 trace pair startup mismatch")
+            continue
+        if private_event.get("kind") == "failure":
+            if (
+                public_event.get("kind") != "failure"
+                or private_event.get("payload") != public_event.get("payload")
+            ):
+                raise ValueError("agentic v2 trace pair failure mismatch")
+            continue
+        if (
+            private_event.get("kind") != "tool_result"
+            or public_event.get("kind") != "tool_result_public"
+        ):
+            raise ValueError("agentic v2 trace pair kind mismatch")
+        private_payload = private_event["payload"]
+        public_payload = public_event["payload"]
+        expected_commitment = {
+            field: deepcopy(private_payload["result"].get(field))
+            for field in _PUBLIC_COMMITMENT_FIELDS
+        }
+        if (
+            public_payload.get("result_commitment") != expected_commitment
+            or public_payload.get("replayed") != private_payload.get("replayed")
+        ):
+            raise ValueError("agentic v2 trace pair commitment mismatch")
+    actual_pair = trace_pair_fingerprint(private_trace, public_trace)
+    if actual_pair != expected_pair_sha256:
+        raise ValueError("agentic v2 trace pair hash mismatch")
+
+
+def trace_pair_fingerprint(private_trace: Any, public_trace: Any) -> str:
+    return canonical_sha256({
+        "schema_version": "2.0",
+        "private_head_sha256": private_trace.get("event_chain_head_sha256"),
+        "public_head_sha256": public_trace.get("event_chain_head_sha256"),
+        "event_count": len(private_trace.get("events", [])),
+    })
+
+
+def verify_agentic_v2_metadata(value: Any) -> None:
+    expected_keys = {
+        "schema_version",
+        "tool_contract_version",
+        "policy_profile_id",
+        "foundation_only",
+        "lifecycle_state",
+        "backend_identity",
+        "capabilities_sha256",
+        "runtime_fingerprint",
+        "private_audit",
+        "public_trace",
+        "trace_pair_sha256",
+    }
+    if (
+        not isinstance(value, dict)
+        or set(value) != expected_keys
+        or value.get("schema_version") != TOOL_CONTRACT_VERSION
+        or value.get("tool_contract_version") != TOOL_CONTRACT_VERSION
+        or value.get("foundation_only") is not True
+        or value.get("lifecycle_state") != "finalized"
+    ):
+        raise ValueError("agentic v2 metadata is invalid")
+    verify_trace_pair(
+        value["private_audit"],
+        value["public_trace"],
+        value["trace_pair_sha256"],
+    )
+    first = value["private_audit"]["events"][0]
+    if first.get("kind") != "started":
+        raise ValueError("agentic v2 metadata startup is missing")
+    started = first["payload"]
+    if (
+        value.get("policy_profile_id") != started.get("policy_profile_id")
+        or value.get("backend_identity") != started.get("backend_identity")
+        or value.get("capabilities_sha256") != canonical_sha256(
+            started.get("capabilities")
+        )
+    ):
+        raise ValueError("agentic v2 metadata startup identity mismatch")
+    runtime = started["runtime"]
+    canonical = foundation_fixture_identity(
+        started["policy_profile_id"], runtime["budget_caps"]
+    )
+    if (
+        started["backend_identity"] != canonical["backend_identity"]
+        or started["capabilities"] != canonical["capabilities"]
+        or runtime["substrate_manifest_sha256"] != canonical[
+            "substrate_manifest_sha256"
+        ]
+        or runtime["package_snapshot_sha256"] != canonical[
+            "package_snapshot_sha256"
+        ]
+        or runtime["browser_build_sha256"] != canonical[
+            "browser_build_sha256"
+        ]
+    ):
+        raise ValueError("agentic v2 canonical fixture identity mismatch")
+    actual_runtime = runtime_fingerprint(
+        policy_profile_id=started["policy_profile_id"],
+        substrate_manifest_sha256=runtime["substrate_manifest_sha256"],
+        package_snapshot_sha256=runtime["package_snapshot_sha256"],
+        browser_build_sha256=runtime["browser_build_sha256"],
+        backend_implementation_sha256=started["backend_identity"][
+            "implementation_sha256"
+        ],
+        capabilities_sha256=canonical_sha256(started["capabilities"]),
+        budget_caps=runtime["budget_caps"],
+    )
+    if actual_runtime != value.get("runtime_fingerprint"):
+        raise ValueError("agentic v2 runtime fingerprint mismatch")
+    _terminal_finalize_event(value["private_audit"])
+
+
+def verify_agentic_v2_result(value: Any) -> None:
+    if not isinstance(value, Mapping) or set(value) != {
+        "success", "text", "deliverable_text", "files", "agentic_v2"
+    }:
+        raise ValueError("agentic v2 success result is invalid")
+    if (
+        value.get("success") is not True
+        or not isinstance(value.get("text"), str)
+        or value.get("deliverable_text") != value.get("text")
+        or not isinstance(value.get("files"), list)
+    ):
+        raise ValueError("agentic v2 success result is invalid")
+    metadata = value.get("agentic_v2")
+    verify_agentic_v2_metadata(metadata)
+    terminal = _terminal_finalize_event(metadata["private_audit"])
+    request = terminal["payload"]["request"]
+    result = terminal["payload"]["result"]
+    if (
+        request["arguments"]["summary"] != value["text"]
+        or terminal["payload"]["replayed"] is not False
+        or result.get("ok") is not True
+        or result.get("error_type") is not None
+    ):
+        raise ValueError("agentic v2 terminal summary is invalid")
+    artifacts = result.get("data", {}).get("artifacts")
+    files = value["files"]
+    if not isinstance(artifacts, list) or len(artifacts) != len(files):
+        raise ValueError("agentic v2 terminal artifact count mismatch")
+    for artifact, file_value in zip(artifacts, files):
+        if not isinstance(artifact, Mapping) or not isinstance(file_value, Mapping):
+            raise ValueError("agentic v2 terminal artifact is invalid")
+        content = file_value.get("content")
+        if (
+            file_value.get("filename") != artifact.get("path")
+            or not isinstance(content, bytes)
+            or len(content) != artifact.get("size")
+            or hashlib.sha256(content).hexdigest() != artifact.get("sha256")
+        ):
+            raise ValueError("agentic v2 terminal artifact bytes mismatch")
+
+
+def verify_agentic_v2_failure_result(value: Any) -> None:
+    if not isinstance(value, Mapping) or set(value) != {
+        "success",
+        "text",
+        "deliverable_text",
+        "files",
+        "error",
+        "agentic_v2",
+    }:
+        raise ValueError("agentic v2 failure result is invalid")
+    metadata = value.get("agentic_v2")
+    if (
+        value.get("success") is not False
+        or value.get("text") != ""
+        or value.get("deliverable_text") != ""
+        or value.get("files") != []
+        or value.get("error") not in ERROR_TYPES
+        or not isinstance(metadata, dict)
+        or set(metadata) != {
+            "schema_version",
+            "foundation_only",
+            "lifecycle_state",
+            "private_audit",
+            "public_trace",
+            "trace_pair_sha256",
+        }
+        or metadata.get("schema_version") != TOOL_CONTRACT_VERSION
+        or metadata.get("foundation_only") is not True
+        or metadata.get("lifecycle_state") not in {"failed", "cancelled"}
+    ):
+        raise ValueError("agentic v2 failure result is invalid")
+    verify_trace_pair(
+        metadata["private_audit"],
+        metadata["public_trace"],
+        metadata["trace_pair_sha256"],
+    )
+    terminal = metadata["private_audit"]["events"][-1]
+    payload = terminal.get("payload") if isinstance(terminal, dict) else None
+    if (
+        terminal.get("kind") != "failure"
+        or not isinstance(payload, dict)
+        or payload.get("error_type") != value["error"]
+        or payload.get("lifecycle_state") != metadata["lifecycle_state"]
+    ):
+        raise ValueError("agentic v2 failure result does not match trace")
+
+
+def _terminal_finalize_event(private_trace: Mapping[str, Any]) -> dict:
+    events = private_trace.get("events")
+    if not isinstance(events, list) or not events:
+        raise ValueError("agentic v2 terminal finalize is missing")
+    terminal = events[-1]
+    payload = terminal.get("payload") if isinstance(terminal, dict) else None
+    request = payload.get("request") if isinstance(payload, dict) else None
+    result = payload.get("result") if isinstance(payload, dict) else None
+    if (
+        terminal.get("kind") != "tool_result"
+        or not isinstance(request, dict)
+        or request.get("name") != "finalize"
+        or not isinstance(result, dict)
+        or result.get("tool_name") != "finalize"
+        or result.get("ok") is not True
+        or payload.get("replayed") is not False
+    ):
+        raise ValueError("agentic v2 terminal finalize is missing")
+    return terminal
+
+
+def _valid_started_payload(value: Any) -> bool:
+    if not isinstance(value, dict) or set(value) != {
+        "run_id", "condition", "task_id", "backend_identity", "capabilities",
+        "policy_profile_id", "runtime",
+    }:
+        return False
+    identity = value.get("backend_identity")
+    capabilities = value.get("capabilities")
+    runtime = value.get("runtime")
+    budget_caps = runtime.get("budget_caps") if isinstance(runtime, dict) else None
+    structurally_valid = (
+        all(
+            isinstance(value.get(name), str) and bool(value[name])
+            for name in ("run_id", "condition", "task_id", "policy_profile_id")
+        )
+        and isinstance(identity, dict)
+        and set(identity) == {
+            "backend_id", "foundation_only", "implementation_sha256"
+        }
+        and identity.get("backend_id") == FOUNDATION_BACKEND_ID
+        and identity.get("foundation_only") is True
+        and identity.get("implementation_sha256") == (
+            foundation_implementation_fingerprint()
+        )
+        and value.get("policy_profile_id") in POLICY_PROFILE_IDS
+        and isinstance(capabilities, dict)
+        and set(capabilities) == {
+            "commands", "runtimes", "packages", "formats", "budgets"
+        }
+        and capabilities.get("commands") == ["fixture-upper"]
+        and capabilities.get("runtimes") == ["fixture"]
+        and capabilities.get("formats") == ["html", "txt"]
+        and _valid_package_capabilities(
+            capabilities.get("packages"), value.get("policy_profile_id")
+        )
+        and _valid_budget_capabilities(capabilities.get("budgets"), budget_caps)
+        and isinstance(runtime, dict)
+        and set(runtime) == {
+            "substrate_manifest_sha256",
+            "package_snapshot_sha256",
+            "browser_build_sha256",
+            "budget_caps",
+        }
+        and all(is_sha256(runtime.get(name)) for name in (
+            "substrate_manifest_sha256",
+            "package_snapshot_sha256",
+            "browser_build_sha256",
+        ))
+    )
+    if not structurally_valid:
+        return False
+    try:
+        canonical = foundation_fixture_identity(
+            value["policy_profile_id"], budget_caps
+        )
+    except ValueError:
+        return False
+    return (
+        identity == canonical["backend_identity"]
+        and capabilities == canonical["capabilities"]
+        and runtime["substrate_manifest_sha256"] == canonical[
+            "substrate_manifest_sha256"
+        ]
+        and runtime["package_snapshot_sha256"] == canonical[
+            "package_snapshot_sha256"
+        ]
+        and runtime["browser_build_sha256"] == canonical[
+            "browser_build_sha256"
+        ]
+    )
+
+
+def _valid_failure_payload(value: Any) -> bool:
+    if (
+        not isinstance(value, dict)
+        or set(value) != {"error_type", "lifecycle_state", "stage"}
+        or value.get("lifecycle_state") not in {"failed", "cancelled"}
+    ):
+        return False
+    try:
+        validate_failure_stage(value.get("error_type"), value.get("stage"))
+    except ValueError:
+        return False
+    return True
+
+
+def _verify_private_result_semantics(
+    request: Any,
+    result: Mapping[str, Any],
+    *,
+    replayed: bool,
+    previous_state: Any,
+    event_state: Any,
+    call_ledger: dict[str, dict],
+    semantic_ledger: dict[str, Any],
+    started_payload: Any,
+) -> None:
+    if not isinstance(request, dict) or set(request) != {
+        "call_id", "name", "arguments"
+    }:
+        raise ValueError("agentic v2 tool request commitment is invalid")
+    if result.get("ok") is True:
+        if result.get("error_type") is not None:
+            raise ValueError("agentic v2 result status mismatch")
+    elif result.get("error_type") is None:
+        raise ValueError("agentic v2 result status mismatch")
+    request_call_id = request.get("call_id")
+    request_name = request.get("name")
+    request_error = _request_error_type(request)
+    prior = call_ledger.get(request_call_id)
+    expected_call_id = "invalid" if request_error == "invalid_call_id" else request_call_id
+    expected_tool_name = (
+        request_name
+        if request_error not in {"invalid_call_id", "unknown_tool"}
+        else None
+    )
+    if (
+        result.get("call_id") != expected_call_id
+        or result.get("tool_name") != expected_tool_name
+    ):
+        raise ValueError("agentic v2 result call identity mismatch")
+    if prior is not None and request_error is not None:
+        if (
+            replayed
+            or not _is_exact_unexecuted_error(result, "call_id_conflict")
+            or event_state != previous_state
+        ):
+            raise ValueError("agentic v2 replay history mismatch")
+        return
+    if request_error is not None:
+        if replayed or not _is_exact_unexecuted_error(result, request_error):
+            raise ValueError("agentic v2 invalid request result mismatch")
+        if event_state != previous_state:
+            raise ValueError("agentic v2 result state continuity mismatch")
+        return
+
+    try:
+        validated_arguments = validate_tool_arguments(
+            request_name, request.get("arguments")
+        )
+    except ValueError as exc:
+        raise ValueError("agentic v2 tool request commitment is invalid") from exc
+    request_sha256 = canonical_sha256({
+        "tool_contract_version": TOOL_CONTRACT_VERSION,
+        "call_id": request_call_id,
+        "name": request_name,
+        "arguments": validated_arguments,
+    })
+    if prior is not None:
+        same_request = prior["request_sha256"] == request_sha256
+        same_state = prior["result"].get("state_after_sha256") == previous_state
+        if same_request and same_state:
+            if (
+                not replayed
+                or prior["result"] != result
+                or event_state != previous_state
+            ):
+                raise ValueError("agentic v2 replay history mismatch")
+        elif (
+            replayed
+            or not _is_exact_unexecuted_error(result, "call_id_conflict")
+            or event_state != previous_state
+        ):
+            raise ValueError("agentic v2 replay history mismatch")
+        return
+    if replayed:
+        raise ValueError("agentic v2 replay history mismatch")
+
+    if result.get("request_sha256") is not None:
+        if semantic_ledger["executed_calls"] >= started_payload["runtime"][
+            "budget_caps"
+        ]["tool_calls"]:
+            raise ValueError("agentic v2 tool budget state mismatch")
+        if result.get("request_sha256") != request_sha256:
+            raise ValueError("agentic v2 tool request hash mismatch")
+        try:
+            validate_tool_result_data(
+                request_name,
+                validated_arguments,
+                result.get("ok") is True,
+                result.get("data"),
+            )
+        except ValueError as exc:
+            raise ValueError("agentic v2 result data mismatch") from exc
+        _verify_fixture_result_semantics(
+            request_name,
+            validated_arguments,
+            result,
+            previous_state=previous_state,
+            semantic_ledger=semantic_ledger,
+            started_payload=started_payload,
+        )
+    else:
+        if not _is_exact_unexecuted_error(result, "tool_budget_exhausted"):
+            raise ValueError("agentic v2 unexecuted result mismatch")
+        if semantic_ledger["executed_calls"] < started_payload["runtime"][
+            "budget_caps"
+        ]["tool_calls"]:
+            raise ValueError("agentic v2 tool budget state mismatch")
+
+    usage = result.get("usage_delta") or {}
+    executed = usage.get("tool_calls") == 1
+    if executed and usage != {
+        "tool_calls": 1,
+        "wall_ms": 0,
+        "output_bytes": len(json.dumps(
+            result.get("data"),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")),
+    }:
+        raise ValueError("agentic v2 result usage mismatch")
+    state_before = result.get("state_before_sha256")
+    state_after = result.get("state_after_sha256")
+    if executed:
+        if (
+            result.get("request_sha256") is None
+            or not is_sha256(state_before)
+            or not is_sha256(state_after)
+            or event_state != state_after
+            or previous_state is None
+            or (
+                replayed
+                and state_after != previous_state
+            )
+            or (
+                not replayed
+                and state_before != previous_state
+            )
+        ):
+            raise ValueError("agentic v2 result state continuity mismatch")
+    elif (
+        usage.get("tool_calls") != 0
+        or result.get("request_sha256") is not None
+        or state_before is not None
+        or state_after is not None
+        or event_state != previous_state
+    ):
+        raise ValueError("agentic v2 result state continuity mismatch")
+    if executed:
+        semantic_ledger["executed_calls"] += 1
+        call_ledger[request_call_id] = {
+            "request_sha256": request_sha256,
+            "result": deepcopy(dict(result)),
+        }
+
+
+def _request_error_type(request: Mapping[str, Any]) -> str | None:
+    call_id = request.get("call_id")
+    if not isinstance(call_id, str) or re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", call_id
+    ) is None:
+        return "invalid_call_id"
+    name = request.get("name")
+    if name not in TOOL_SCHEMAS:
+        return "unknown_tool"
+    try:
+        validate_tool_arguments(name, request.get("arguments"))
+    except ValueError:
+        return "invalid_arguments"
+    return None
+
+
+def _is_exact_unexecuted_error(
+    result: Mapping[str, Any],
+    error_types: str | set[str],
+) -> bool:
+    allowed = {error_types} if isinstance(error_types, str) else error_types
+    return (
+        result.get("ok") is False
+        and result.get("error_type") in allowed
+        and result.get("request_sha256") is None
+        and result.get("data") == {}
+        and result.get("usage_delta") == {
+            "tool_calls": 0,
+            "wall_ms": 0,
+            "output_bytes": 0,
+        }
+        and result.get("state_before_sha256") is None
+        and result.get("state_after_sha256") is None
+    )
+
+
+def _valid_package_capabilities(value: Any, profile_id: Any) -> bool:
+    if not isinstance(value, list) or value != sorted(set(value)):
+        return False
+    expected = (
+        []
+        if profile_id == "offline-full-v1"
+        else [coordinate for coordinate, _ in _FOUNDATION_PACKAGE_RECORDS]
+    )
+    return value == expected
+
+
+def _valid_budget_capabilities(value: Any, budget_caps: Any) -> bool:
+    if not isinstance(budget_caps, dict) or set(budget_caps) != {
+        "tool_calls", "wall_seconds"
+    }:
+        return False
+    if (
+        type(budget_caps["tool_calls"]) is not int
+        or not 1 <= budget_caps["tool_calls"] <= 256
+        or type(budget_caps["wall_seconds"]) is not int
+        or not 1 <= budget_caps["wall_seconds"] <= 3600
+    ):
+        return False
+    return value == [
+        f"tool_calls={budget_caps['tool_calls']}",
+        f"wall_seconds={budget_caps['wall_seconds']}",
+    ]
+
+
+def _verify_fixture_result_semantics(
+    name: str,
+    arguments: Mapping[str, Any],
+    result: Mapping[str, Any],
+    *,
+    previous_state: Any,
+    semantic_ledger: dict[str, Any],
+    started_payload: Any,
+) -> None:
+    if not isinstance(started_payload, dict):
+        raise ValueError("agentic v2 fixture semantics lack startup identity")
+    profile = started_payload["policy_profile_id"]
+    runtime = started_payload["runtime"]
+    canonical = foundation_fixture_identity(profile, runtime["budget_caps"])
+    if previous_state != _fixture_state_sha256(semantic_ledger):
+        raise ValueError("agentic v2 fixture state-before mismatch")
+    ok = result.get("ok") is True
+    error_type = result.get("error_type")
+    data = result.get("data") or {}
+    expected = _replay_fixture_tool(
+        name,
+        arguments,
+        semantic_ledger,
+        canonical=canonical,
+    )
+    expected_state_after = _fixture_state_sha256(semantic_ledger)
+    expected_result = _fixture_result_envelope(
+        name=name,
+        arguments=arguments,
+        call_id=result["call_id"],
+        payload=expected,
+        state_before=previous_state,
+        state_after=expected_state_after,
+    )
+    encoded = json.dumps(
+        expected_result,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    if len(encoded) > 65536:
+        expected_result = _fixture_executed_error(
+            expected_result, "tool_result_too_large"
+        )
+    elif error_type in {
+        "tool_result_too_large",
+        "finalize_result_mismatch",
+        "invalid_result_envelope",
+        "task_wall_time_exhausted",
+    }:
+        raise ValueError("agentic v2 fixture wrapper condition mismatch")
+    if result != expected_result:
+        raise ValueError("agentic v2 fixture tool result mismatch")
+
+
+def _fixture_result_envelope(
+    *,
+    name: str,
+    arguments: Mapping[str, Any],
+    call_id: str,
+    payload: Mapping[str, Any],
+    state_before: str,
+    state_after: str,
+) -> dict:
+    ok = payload.get("ok") is True
+    error_type = None if ok else payload.get("error_type")
+    data = deepcopy(payload.get("data", {})) if ok else {}
+    request_sha256 = canonical_sha256({
+        "tool_contract_version": TOOL_CONTRACT_VERSION,
+        "call_id": call_id,
+        "name": name,
+        "arguments": dict(arguments),
+    })
+    value = {
+        "schema_version": TOOL_CONTRACT_VERSION,
+        "call_id": call_id,
+        "tool_name": name,
+        "request_sha256": request_sha256,
+        "ok": ok,
+        "error_type": error_type,
+        "data": data,
+        "usage_delta": {
+            "tool_calls": 1,
+            "wall_ms": 0,
+            "output_bytes": len(json.dumps(
+                data,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8")),
+        },
+        "state_before_sha256": state_before,
+        "state_after_sha256": state_after,
+    }
+    value["result_sha256"] = canonical_sha256(value)
+    return value
+
+
+def _fixture_executed_error(
+    result: Mapping[str, Any],
+    error_type: str,
+) -> dict:
+    value = deepcopy(dict(result))
+    value.pop("result_sha256", None)
+    value["ok"] = False
+    value["error_type"] = error_type
+    value["data"] = {}
+    value["usage_delta"] = {**value["usage_delta"], "output_bytes": 2}
+    value["result_sha256"] = canonical_sha256(value)
+    return value
+
+
+def _new_fixture_semantic_ledger(started_payload: Mapping[str, Any]) -> dict:
+    runtime = started_payload["runtime"]
+    canonical = foundation_fixture_identity(
+        started_payload["policy_profile_id"], runtime["budget_caps"]
+    )
+    return {
+        "profile": started_payload["policy_profile_id"],
+        "budget_caps": deepcopy(runtime["budget_caps"]),
+        "package_records": tuple(canonical["package_records"]),
+        "directories": {"."},
+        "files": {},
+        "resolved_locks": set(),
+        "active_locks": set(),
+        "terminal_identity": None,
+        "executed_calls": 0,
+    }
+
+
+def _verify_failure_causality(
+    payload: Mapping[str, Any],
+    *,
+    started_seen: bool,
+    last_tool_name: Any,
+    last_tool_result: Any,
+) -> None:
+    error_type = payload["error_type"]
+    lifecycle_state = payload["lifecycle_state"]
+    stage = payload["stage"]
+    if lifecycle_state == "cancelled" and error_type != "cancelled":
+        raise ValueError("agentic v2 failure lifecycle mismatch")
+    if lifecycle_state == "failed" and error_type == "cancelled":
+        raise ValueError("agentic v2 failure lifecycle mismatch")
+    if not started_seen:
+        if stage not in {"backend", "startup", "control", "cleanup"}:
+            raise ValueError("agentic v2 pre-start failure stage mismatch")
+        return
+    if stage not in {"runtime", "control", "cleanup"}:
+        raise ValueError("agentic v2 runtime failure stage mismatch")
+    if stage == "cleanup":
+        if error_type != "compute_cleanup_failed":
+            raise ValueError("agentic v2 cleanup failure mismatch")
+        return
+    if stage == "control":
+        if isinstance(last_tool_result, Mapping) and (
+            last_tool_result.get("ok") is False
+            or (
+                last_tool_name == "finalize"
+                and error_type == "cancelled"
+            )
+        ):
+            raise ValueError("agentic v2 control failure cause mismatch")
+        return
+    if isinstance(last_tool_result, Mapping):
+        if last_tool_result.get("ok") is False:
+            if error_type != last_tool_result.get("error_type"):
+                raise ValueError("agentic v2 failure cause mismatch")
+            return
+        if last_tool_name == "finalize":
+            if error_type not in {
+                "compute_cleanup_failed",
+                "runner_internal_error",
+                "task_wall_time_exhausted",
+            }:
+                raise ValueError("agentic v2 post-finalize failure mismatch")
+            return
+        if error_type not in {
+            "cancelled",
+            "finalize_not_called",
+            "runner_internal_error",
+            "task_wall_time_exhausted",
+        }:
+            raise ValueError("agentic v2 failure cause mismatch")
+        return
+    if error_type not in {
+        "cancelled",
+        "finalize_not_called",
+        "runner_internal_error",
+        "task_wall_time_exhausted",
+    }:
+        raise ValueError("agentic v2 failure cause mismatch")
+
+
+def _fixture_state_sha256(ledger: Mapping[str, Any]) -> str:
+    entries = []
+
+    def visit(directory: str) -> None:
+        prefix = "" if directory == "." else f"{directory}/"
+        children = set()
+        for path in ledger["directories"]:
+            if path == "." or not path.startswith(prefix):
+                continue
+            remainder = path[len(prefix):]
+            if "/" not in remainder:
+                children.add(remainder)
+        for path in ledger["files"]:
+            if not path.startswith(prefix):
+                continue
+            remainder = path[len(prefix):]
+            if "/" not in remainder:
+                children.add(remainder)
+        for name in sorted(children):
+            path = name if directory == "." else f"{directory}/{name}"
+            if path in ledger["directories"]:
+                entries.append({
+                    "path": path,
+                    "kind": "directory",
+                    "mode": 0o700,
+                })
+                visit(path)
+            else:
+                content = ledger["files"][path]
+                entries.append({
+                    "path": path,
+                    "kind": "file",
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                    "size": len(content),
+                    "mode": 0o600,
+                })
+
+    visit(".")
+    terminal = ledger["terminal_identity"]
+    return canonical_sha256({
+        "root_mode": 0o700,
+        "profile": ledger["profile"],
+        "package_catalog": ledger["package_records"],
+        "budget_caps": ledger["budget_caps"],
+        "entries": entries,
+        "active_locks": sorted(ledger["active_locks"]),
+        "terminal_result_sha256": (
+            canonical_sha256(terminal) if terminal is not None else None
+        ),
+    })
+
+
+def _replay_fixture_tool(
+    name: str,
+    arguments: Mapping[str, Any],
+    ledger: dict[str, Any],
+    *,
+    canonical: Mapping[str, Any],
+) -> dict:
+    if name == "capabilities_query":
+        kind = arguments["kind"]
+        return {
+            "ok": True,
+            "data": {
+                "kind": kind,
+                "items": canonical["capabilities"][kind],
+            },
+        }
+    if name == "workspace_apply":
+        return _replay_workspace_apply(arguments, ledger)
+    if name == "exec_run":
+        return _replay_exec_run(arguments, ledger)
+    if name == "environment_resolve":
+        return _replay_environment_resolve(arguments, ledger, canonical)
+    if name == "environment_activate":
+        return _replay_environment_activate(arguments, ledger)
+    if name == "browser_run":
+        return _replay_browser_run(arguments, ledger)
+    if name in {"verify_public", "finalize"}:
+        return _replay_artifact_tool(name, arguments, ledger)
+    raise ValueError("agentic v2 fixture tool is unsupported")
+
+
+def _replay_workspace_apply(
+    arguments: Mapping[str, Any],
+    ledger: dict[str, Any],
+) -> dict:
+    operation = arguments["operation"]
+    if operation == "copy":
+        source = arguments["source"]
+        if source == "." or arguments["destination"] == ".":
+            return {"ok": False, "error_type": "fixture_backend_error"}
+        content = ledger["files"].get(source)
+        if content is None:
+            return {"ok": False, "error_type": "fixture_backend_error"}
+        error = _virtual_write(ledger, arguments["destination"], content)
+        if error is not None:
+            return {"ok": False, "error_type": error}
+        return {"ok": True, "data": {"path": arguments["destination"]}}
+    path = arguments["path"]
+    if operation == "list":
+        if path not in ledger["directories"]:
+            return {"ok": False, "error_type": "path_not_directory"}
+        return {
+            "ok": True,
+            "data": {"entries": _virtual_list(path, ledger)},
+        }
+    if operation == "read":
+        if path == ".":
+            return {"ok": False, "error_type": "fixture_backend_error"}
+        content = ledger["files"].get(path)
+        if content is None:
+            return {"ok": False, "error_type": "fixture_backend_error"}
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            return {"ok": False, "error_type": "fixture_backend_error"}
+        selected = text[
+            int(arguments.get("offset", 0)):
+            int(arguments.get("offset", 0))
+            + int(arguments.get("limit", 1048576))
+        ]
+        return {"ok": True, "data": {
+            "content": selected,
+            "content_sha256": hashlib.sha256(
+                selected.encode("utf-8")
+            ).hexdigest(),
+        }}
+    if operation in {"write", "patch"}:
+        if path == "." or path in ledger["directories"]:
+            return {"ok": False, "error_type": "fixture_backend_error"}
+        error = _virtual_write(
+            ledger, path, str(arguments["content"]).encode("utf-8")
+        )
+        if error is not None:
+            return {"ok": False, "error_type": error}
+    elif operation == "delete":
+        if path == ".":
+            return {"ok": False, "error_type": "fixture_backend_error"}
+        if path in ledger["files"]:
+            del ledger["files"][path]
+        elif path in ledger["directories"] and not _virtual_list(path, ledger):
+            ledger["directories"].remove(path)
+        else:
+            return {"ok": False, "error_type": "fixture_backend_error"}
+    else:
+        error = _virtual_reserve_entries(
+            ledger, path, temporary_leaf=False
+        )
+        if error is not None:
+            return {"ok": False, "error_type": error}
+        error = _virtual_mkdir(ledger, path)
+        if error is not None:
+            return {"ok": False, "error_type": error}
+    return {"ok": True, "data": {"path": path}}
+
+
+def _replay_exec_run(
+    arguments: Mapping[str, Any],
+    ledger: dict[str, Any],
+) -> dict:
+    argv = arguments.get("argv")
+    if not isinstance(argv, list) or not argv:
+        return {"ok": False, "error_type": "capability_unavailable"}
+    if argv[0] != "fixture-upper" or len(argv) != 3:
+        return {"ok": False, "error_type": "capability_unavailable"}
+    cwd = arguments["cwd"]
+    if cwd not in ledger["directories"]:
+        return {"ok": False, "error_type": "path_not_directory"}
+    source = _virtual_join(cwd, argv[1])
+    destination = _virtual_join(cwd, argv[2])
+    if (
+        source is None
+        or destination is None
+        or source not in ledger["files"]
+        or destination in ledger["directories"]
+    ):
+        return {"ok": False, "error_type": "fixture_backend_error"}
+    error = _virtual_write(
+        ledger, destination, ledger["files"][source].upper()
+    )
+    if error is not None:
+        return {"ok": False, "error_type": error}
+    return {"ok": True, "data": {"returncode": 0}}
+
+
+def _replay_environment_resolve(
+    arguments: Mapping[str, Any],
+    ledger: dict[str, Any],
+    canonical: Mapping[str, Any],
+) -> dict:
+    if ledger["profile"] == "offline-full-v1":
+        return {"ok": False, "error_type": "capability_unavailable"}
+    requirements = sorted(arguments["requirements"])
+    coordinates = [
+        f"{arguments['ecosystem']}:{requirement}"
+        for requirement in requirements
+    ]
+    catalog = dict(canonical["package_records"])
+    if any(coordinate not in catalog for coordinate in coordinates):
+        return {"ok": False, "error_type": "package_not_in_snapshot"}
+    lock = {
+        "ecosystem": arguments["ecosystem"],
+        "requirements": requirements,
+        "blobs": [catalog[coordinate] for coordinate in coordinates],
+    }
+    digest = canonical_sha256(lock)
+    ledger["resolved_locks"].add(digest)
+    return {"ok": True, "data": {"lock_digest": digest, "lock": lock}}
+
+
+def _replay_environment_activate(
+    arguments: Mapping[str, Any],
+    ledger: dict[str, Any],
+) -> dict:
+    if ledger["profile"] == "offline-full-v1":
+        return {"ok": False, "error_type": "capability_unavailable"}
+    digest = arguments["lock_digest"]
+    if digest not in ledger["resolved_locks"]:
+        return {"ok": False, "error_type": "unapproved_lock"}
+    ledger["active_locks"].add(digest)
+    return {"ok": True, "data": {"environment_id": digest}}
+
+
+def _replay_browser_run(
+    arguments: Mapping[str, Any],
+    ledger: Mapping[str, Any],
+) -> dict:
+    operation = arguments["operation"]
+    if operation in {"search", "open_url"}:
+        return {"ok": False, "error_type": "capability_unavailable"}
+    path = arguments["path"]
+    content = ledger["files"].get(path)
+    if content is None:
+        return {"ok": False, "error_type": "fixture_backend_error"}
+    return {"ok": True, "data": {
+        "path": path,
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }}
+
+
+def _replay_artifact_tool(
+    name: str,
+    arguments: Mapping[str, Any],
+    ledger: dict[str, Any],
+) -> dict:
+    artifacts = []
+    terminal_files = []
+    total = 0
+    for path in arguments["deliverables"]:
+        content = ledger["files"].get(path)
+        if not content:
+            return {"ok": False, "error_type": "artifact_not_openable"}
+        total += len(content)
+        if total > 64 * 1024 * 1024:
+            return {"ok": False, "error_type": "artifact_not_openable"}
+        artifacts.append({
+            "path": path,
+            "sha256": hashlib.sha256(content).hexdigest(),
+            "size": len(content),
+        })
+        terminal_files.append({
+            "filename": path,
+            "sha256": hashlib.sha256(content).hexdigest(),
+        })
+    if name == "finalize":
+        ledger["terminal_identity"] = {
+            "success": True,
+            "text": arguments["summary"],
+            "files": terminal_files,
+        }
+    return {"ok": True, "data": {"artifacts": artifacts}}
+
+
+def _virtual_write(ledger: dict[str, Any], path: str, content: bytes) -> str | None:
+    if path == "." or path in ledger["directories"] or len(content) > 1048576:
+        return "fixture_backend_error"
+    error = _virtual_reserve_entries(ledger, path, temporary_leaf=True)
+    if error is not None:
+        return error
+    if sum(len(value) for value in ledger["files"].values()) + len(content) > (
+        64 * 1024 * 1024
+    ):
+        return "fixture_backend_error"
+    error = _virtual_mkdir(ledger, _virtual_parent(path))
+    if error is not None:
+        return error
+    ledger["files"][path] = content
+    return None
+
+
+def _virtual_mkdir(ledger: dict[str, Any], path: str) -> str | None:
+    if path == ".":
+        return None
+    current = ""
+    for part in path.split("/"):
+        current = f"{current}/{part}" if current else part
+        if current in ledger["files"]:
+            return "fixture_backend_error"
+        ledger["directories"].add(current)
+    return None
+
+
+def _virtual_reserve_entries(
+    ledger: Mapping[str, Any],
+    path: str,
+    *,
+    temporary_leaf: bool,
+) -> str | None:
+    if path == ".":
+        return None
+    existing = set(ledger["directories"]) - {"."} | set(ledger["files"])
+    planned = []
+    current = ""
+    for part in path.split("/"):
+        current = f"{current}/{part}" if current else part
+        if current not in existing:
+            planned.append(current)
+    leaf_exists = path in existing
+    peak_extra = len(planned) + int(temporary_leaf and leaf_exists)
+    if len(existing) + peak_extra > 4096:
+        return "fixture_backend_error"
+    child_counts: dict[str, int] = {}
+    for value in existing:
+        parent = _virtual_parent(value)
+        child_counts[parent] = child_counts.get(parent, 0) + 1
+    for value in planned:
+        parent = _virtual_parent(value)
+        child_counts[parent] = child_counts.get(parent, 0) + 1
+    if temporary_leaf and leaf_exists:
+        parent = _virtual_parent(path)
+        child_counts[parent] = child_counts.get(parent, 0) + 1
+    if any(count > 1024 for count in child_counts.values()):
+        return "fixture_backend_error"
+    return None
+
+
+def _virtual_list(path: str, ledger: Mapping[str, Any]) -> list[str]:
+    prefix = "" if path == "." else f"{path}/"
+    children = set()
+    for value in set(ledger["directories"]) | set(ledger["files"]):
+        if value == "." or not value.startswith(prefix):
+            continue
+        remainder = value[len(prefix):]
+        if "/" not in remainder:
+            children.add(remainder)
+    return sorted(children)
+
+
+def _virtual_parent(path: str) -> str:
+    return path.rsplit("/", 1)[0] if "/" in path else "."
+
+
+def _virtual_join(directory: str, child: Any) -> str | None:
+    try:
+        canonical_relative_path(directory)
+        canonical_relative_path(child)
+    except ValueError:
+        return None
+    if child == ".":
+        return None
+    combined = child if directory == "." else f"{directory}/{child}"
+    try:
+        return canonical_relative_path(combined)
+    except ValueError:
+        return None

--- a/batch-runner/core/agentic_v2_runner.py
+++ b/batch-runner/core/agentic_v2_runner.py
@@ -1,0 +1,802 @@
+"""Model-free scripted runner for the Agentic Sandbox V2 foundation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import multiprocessing
+import os
+import signal
+import shutil
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Optional
+
+from core.agentic_v2_contract import (
+    ERROR_TYPES,
+    FOUNDATION_BACKEND_ID,
+    TOOL_CONTRACT_VERSION,
+    AgenticV2Lifecycle,
+    AgenticV2Profile,
+    LifecycleState,
+    is_sha256,
+)
+from core.agentic_v2_provenance import (
+    AgenticV2EventChain,
+    canonical_sha256,
+    foundation_implementation_fingerprint,
+    runtime_fingerprint,
+    trace_pair_fingerprint,
+    validate_failure_stage,
+    verify_agentic_v2_failure_result,
+    verify_agentic_v2_result,
+)
+from core.agentic_v2_tools import AgenticV2Backend, AgenticV2ToolDispatcher
+
+
+class AgenticV2IsolatedFixtureRunner:
+    """Run the model-free fixture in a killable task-local worker process."""
+
+    def __init__(
+        self,
+        *,
+        fixture_root: str | Path,
+        scripted_calls: Iterable[Mapping[str, Any]],
+        profile: Mapping[str, Any],
+        budget_caps: Optional[Mapping[str, Any]] = None,
+        cancel_requested: Optional[Callable[[], bool]] = None,
+    ):
+        root = Path(fixture_root)
+        if root.is_symlink():
+            raise ValueError("agentic v2 fixture root symlink is forbidden")
+        root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.fixture_root = root.resolve()
+        self.scripted_calls = tuple(deepcopy(dict(call)) for call in scripted_calls)
+        self.profile = AgenticV2Profile.from_mapping(profile)
+        self.budget_caps = _validate_budget_caps(budget_caps)
+        self.cancel_requested = cancel_requested or (lambda: False)
+        self._context = multiprocessing.get_context("fork")
+        self._active_process = None
+        self._active_process_group = None
+        self._last_process = None
+        self._closed = False
+
+    def close(self) -> None:
+        self._closed = True
+        if self._active_process is not None:
+            _stop_process(
+                self._active_process,
+                self._active_process_group,
+            )
+            self._active_process = None
+            self._active_process_group = None
+
+    def run(
+        self,
+        task_prompt: str,
+        reference_files: Optional[list] = None,
+        occupation: str = "professional",
+        experiment_prompt: Optional[dict] = None,
+        perception_text: Optional[str] = None,
+        *,
+        run_id: str = "local-nonpaid",
+        condition_name: str = "condition_a",
+        task_id: str = "unknown-task",
+    ) -> dict:
+        if self._closed:
+            raise RuntimeError("agentic v2 runner is closed")
+        run_root = Path(tempfile.mkdtemp(
+            prefix=".agentic-v2-run-", dir=self.fixture_root
+        ))
+        receiver, sender = self._context.Pipe(duplex=False)
+        request = {
+            "task_prompt": task_prompt,
+            "reference_files": list(reference_files or []),
+            "occupation": occupation,
+            "experiment_prompt": experiment_prompt,
+            "perception_text": perception_text,
+            "run_id": run_id,
+            "condition_name": condition_name,
+            "task_id": task_id,
+        }
+        process = self._context.Process(
+            target=_run_fixture_worker,
+            args=(
+                sender,
+                str(run_root),
+                self.scripted_calls,
+                {
+                    "tool_contract_version": self.profile.tool_contract_version,
+                    "policy_profile_id": self.profile.policy_profile_id,
+                    "foundation_only": True,
+                },
+                self.budget_caps,
+                request,
+            ),
+            name="agentic-v2-fixture",
+            daemon=True,
+        )
+        self._last_process = process
+        result = None
+        error = None
+        started = False
+        process_group = None
+        deadline = time.monotonic() + self.budget_caps["wall_seconds"]
+        try:
+            process.start()
+            started = True
+            self._active_process = process
+            sender.close()
+            while process_group is None and error is None:
+                if self.cancel_requested():
+                    error = "cancelled"
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    error = "task_wall_time_exhausted"
+                    break
+                if receiver.poll(min(remaining, 0.05)):
+                    try:
+                        message = receiver.recv()
+                    except (EOFError, OSError):
+                        error = "compute_backend_error"
+                    else:
+                        if (
+                            isinstance(message, dict)
+                            and message.get("kind") == "ready"
+                            and message.get("process_group") == process.pid
+                        ):
+                            process_group = process.pid
+                            self._active_process_group = process_group
+                        else:
+                            error = "compute_backend_error"
+                    continue
+                if not process.is_alive():
+                    error = "compute_backend_error"
+                    break
+            while result is None and error is None:
+                if self.cancel_requested():
+                    error = "cancelled"
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    error = "task_wall_time_exhausted"
+                    break
+                if receiver.poll(min(remaining, 0.05)):
+                    try:
+                        message = receiver.recv()
+                    except (EOFError, OSError):
+                        error = "compute_backend_error"
+                    else:
+                        if (
+                            isinstance(message, dict)
+                            and message.get("kind") == "result"
+                            and isinstance(message.get("result"), dict)
+                        ):
+                            candidate = message["result"]
+                            try:
+                                _verify_worker_result(candidate)
+                            except Exception:
+                                error = "compute_backend_error"
+                            else:
+                                result = candidate
+                        else:
+                            error = "compute_backend_error"
+                    break
+                if not process.is_alive():
+                    process.join()
+                    if receiver.poll():
+                        try:
+                            message = receiver.recv()
+                        except (EOFError, OSError):
+                            error = "compute_backend_error"
+                        else:
+                            candidate = (
+                                message.get("result")
+                                if isinstance(message, dict)
+                                and message.get("kind") == "result"
+                                and isinstance(message.get("result"), dict)
+                                else None
+                            )
+                            if candidate is None:
+                                error = "compute_backend_error"
+                            else:
+                                try:
+                                    _verify_worker_result(candidate)
+                                except Exception:
+                                    error = "compute_backend_error"
+                                else:
+                                    result = candidate
+                    else:
+                        error = "compute_backend_error"
+                    break
+        except Exception:
+            result = None
+            error = "compute_backend_error"
+        finally:
+            if started:
+                _stop_process(process, process_group)
+            self._active_process = None
+            self._active_process_group = None
+            receiver.close()
+            try:
+                sender.close()
+            except OSError:
+                pass
+        cleanup_failed = False
+        try:
+            shutil.rmtree(run_root)
+        except OSError:
+            cleanup_failed = True
+        if result is None:
+            state = (
+                LifecycleState.CANCELLED
+                if error == "cancelled"
+                else LifecycleState.FAILED
+            )
+            result = _failure(
+                error or "compute_backend_error",
+                AgenticV2Lifecycle(state),
+                AgenticV2EventChain(),
+                AgenticV2EventChain(),
+                stage=(
+                    "control"
+                    if error in {"cancelled", "task_wall_time_exhausted"}
+                    else "backend"
+                ),
+            )
+        if cleanup_failed and result.get("success") is True:
+            result = _failure(
+                "compute_cleanup_failed",
+                AgenticV2Lifecycle(LifecycleState.FAILED),
+                AgenticV2EventChain(),
+                AgenticV2EventChain(),
+                stage="cleanup",
+            )
+        return result
+
+
+def _run_fixture_worker(
+    connection,
+    run_root: str,
+    scripted_calls: Iterable[Mapping[str, Any]],
+    profile: Mapping[str, Any],
+    budget_caps: Mapping[str, Any],
+    request: Mapping[str, Any],
+) -> None:
+    sent_result = False
+    try:
+        os.setsid()
+        os.environ.clear()
+        connection.send({
+            "kind": "ready",
+            "process_group": os.getpgrp(),
+        })
+        from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+
+        runner = AgenticV2ScriptedRunner(
+            backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+                root=run_root, **kwargs
+            ),
+            scripted_calls=scripted_calls,
+            profile=profile,
+            budget_caps=budget_caps,
+            required_backend_type=AgenticV2FixtureBackend,
+        )
+        connection.send({
+            "kind": "result",
+            "result": runner.run(**dict(request)),
+        })
+        sent_result = True
+    except Exception:
+        try:
+            connection.send({
+                "kind": "result",
+                "result": _failure(
+                    "compute_backend_error",
+                    AgenticV2Lifecycle(LifecycleState.FAILED),
+                    AgenticV2EventChain(),
+                    AgenticV2EventChain(),
+                    stage="backend",
+                ),
+            })
+            sent_result = True
+        except (BrokenPipeError, EOFError, OSError):
+            pass
+    finally:
+        if sent_result:
+            threading.Event().wait()
+        connection.close()
+
+
+def _verify_worker_result(value: Mapping[str, Any]) -> None:
+    if value.get("success") is True:
+        verify_agentic_v2_result(value)
+    elif value.get("success") is False:
+        verify_agentic_v2_failure_result(value)
+    else:
+        raise ValueError("agentic v2 worker result status is invalid")
+
+
+def _stop_process(process, process_group: int | None) -> None:
+    if process_group is None:
+        try:
+            candidate = os.getpgid(process.pid)
+        except (ProcessLookupError, OSError):
+            candidate = None
+        if candidate == process.pid:
+            process_group = candidate
+    if process_group is not None and (
+        process_group != process.pid or process_group == os.getpgrp()
+    ):
+        process_group = None
+    if process_group is None:
+        if process.is_alive():
+            process.terminate()
+    else:
+        try:
+            os.killpg(process_group, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    process.join(timeout=0.5)
+    if process_group is not None:
+        try:
+            os.killpg(process_group, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    elif process.is_alive():
+        process.kill()
+    process.join()
+
+
+class AgenticV2ScriptedRunner:
+    """Exercise the V2 state machine without constructing a model client."""
+
+    def __init__(
+        self,
+        *,
+        backend_factory: Callable[..., AgenticV2Backend],
+        scripted_calls: Iterable[Mapping[str, Any]],
+        profile: Mapping[str, Any],
+        budget_caps: Optional[Mapping[str, Any]] = None,
+        cancel_requested: Optional[Callable[[], bool]] = None,
+        clock: Callable[[], float] = time.monotonic,
+        required_backend_type: type | None = None,
+    ):
+        if not callable(backend_factory):
+            raise ValueError("agentic v2 backend_factory is required")
+        self.backend_factory = backend_factory
+        self.scripted_calls = tuple(dict(call) for call in scripted_calls)
+        self.profile = AgenticV2Profile.from_mapping(profile)
+        self.budget_caps = _validate_budget_caps(budget_caps)
+        self.cancel_requested = cancel_requested or (lambda: False)
+        self.clock = clock
+        self.required_backend_type = required_backend_type
+        self._closed = False
+
+    def close(self) -> None:
+        self._closed = True
+
+    def run(
+        self,
+        task_prompt: str,
+        reference_files: Optional[list] = None,
+        occupation: str = "professional",
+        experiment_prompt: Optional[dict] = None,
+        perception_text: Optional[str] = None,
+        *,
+        run_id: str = "local-nonpaid",
+        condition_name: str = "condition_a",
+        task_id: str = "unknown-task",
+    ) -> dict:
+        del experiment_prompt, perception_text
+        if self._closed:
+            raise RuntimeError("agentic v2 runner is closed")
+        lifecycle = AgenticV2Lifecycle()
+        audit_chain = AgenticV2EventChain()
+        public_chain = AgenticV2EventChain()
+        started_at = self.clock()
+        max_task_seconds = float(self.budget_caps.get("wall_seconds", 1200))
+        deadline = started_at + max_task_seconds
+        backend: AgenticV2Backend | None = None
+        result: dict | None = None
+
+        def finish(value: Mapping[str, Any]) -> dict:
+            nonlocal result
+            result = dict(value)
+            return result
+
+        try:
+            try:
+                backend = self.backend_factory(
+                    task_prompt=task_prompt,
+                    reference_files=list(reference_files or []),
+                    occupation=occupation,
+                    run_id=run_id,
+                    condition_name=condition_name,
+                    task_id=task_id,
+                    profile=self.profile,
+                    budget_caps=self.budget_caps,
+                )
+                if (
+                    self.required_backend_type is not None
+                    and type(backend) is not self.required_backend_type
+                ):
+                    raise ValueError("agentic v2 foundation backend type mismatch")
+            except Exception:
+                lifecycle.transition(LifecycleState.STARTED)
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "compute_backend_error", lifecycle, audit_chain, public_chain,
+                    stage="backend",
+                ))
+            lifecycle.transition(LifecycleState.STARTED)
+            startup_started = self.clock()
+            if startup_started >= deadline:
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "task_wall_time_exhausted", lifecycle, audit_chain, public_chain,
+                    stage="control",
+                ))
+            try:
+                startup = dict(backend.start(deadline - startup_started))
+            except Exception:
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "compute_start_failed", lifecycle, audit_chain, public_chain,
+                    stage="startup",
+                ))
+            if self.clock() >= deadline:
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "task_wall_time_exhausted", lifecycle, audit_chain, public_chain,
+                    stage="control",
+                ))
+            if startup.get("ok") is not True:
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "compute_start_failed",
+                    lifecycle,
+                    audit_chain,
+                    public_chain,
+                    stage="startup",
+                ))
+            startup_data = startup.get("data") or {}
+            identity = startup_data.get("backend_identity") or {}
+            expected_implementation_sha = foundation_implementation_fingerprint()
+            if identity != {
+                "backend_id": FOUNDATION_BACKEND_ID,
+                "foundation_only": True,
+                "implementation_sha256": expected_implementation_sha,
+            }:
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "compute_start_failed", lifecycle, audit_chain, public_chain,
+                    stage="startup",
+                ))
+            capabilities = startup_data.get("capabilities")
+            try:
+                expected_capabilities = dict(backend.expected_capabilities())
+            except Exception:
+                expected_capabilities = None
+            if (
+                not _valid_capabilities(capabilities)
+                or capabilities != expected_capabilities
+            ):
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "compute_start_failed", lifecycle, audit_chain, public_chain,
+                    stage="startup",
+                ))
+            substrate = startup_data.get("substrate_manifest") or {}
+            substrate_sha = substrate.get("sha256")
+            package_snapshot_sha = startup_data.get(
+                "package_snapshot_sha256"
+            )
+            browser_build_sha = startup_data.get(
+                "browser_build_sha256"
+            )
+            if not all(is_sha256(value) for value in (
+                substrate_sha, package_snapshot_sha, browser_build_sha
+            )):
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "substrate_manifest_missing", lifecycle, audit_chain, public_chain,
+                    stage="startup",
+                ))
+            lifecycle.transition(LifecycleState.ACTIVE)
+            try:
+                initial_state = backend.state_sha256()
+            except Exception:
+                lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "compute_start_failed", lifecycle, audit_chain, public_chain,
+                    stage="startup",
+                ))
+            started_payload = {
+                "run_id": run_id,
+                "condition": condition_name,
+                "task_id": task_id,
+                "backend_identity": deepcopy(identity),
+                "capabilities": deepcopy(capabilities),
+                "policy_profile_id": self.profile.policy_profile_id,
+                "runtime": {
+                    "substrate_manifest_sha256": substrate_sha,
+                    "package_snapshot_sha256": package_snapshot_sha,
+                    "browser_build_sha256": browser_build_sha,
+                    "budget_caps": deepcopy(self.budget_caps),
+                },
+            }
+            audit_chain.append(
+                "started", started_payload, state_sha256=initial_state
+            )
+            public_chain.append(
+                "started", started_payload, state_sha256=initial_state
+            )
+            dispatcher = AgenticV2ToolDispatcher(
+                backend,
+                lifecycle,
+                max_total_calls=int(self.budget_caps.get("tool_calls", 32)),
+                deadline=None,
+                clock=self.clock,
+                record_wall_time=False,
+            )
+            current_state = initial_state
+            for call in self.scripted_calls:
+                if self.cancel_requested():
+                    lifecycle.transition(LifecycleState.CANCELLED)
+                    return finish(_failure(
+                        "cancelled", lifecycle, audit_chain, public_chain,
+                        stage="control",
+                    ))
+                if self.clock() >= deadline:
+                    lifecycle.transition(LifecycleState.FAILED)
+                    return finish(_failure(
+                        "task_wall_time_exhausted",
+                        lifecycle,
+                        audit_chain,
+                        public_chain,
+                        stage="control",
+                    ))
+                dispatch = dispatcher.dispatch(
+                    call_id=str(call.get("call_id", "")),
+                    name=str(call.get("name", "")),
+                    arguments=call.get("arguments"),
+                )
+                request = {
+                    "call_id": str(call.get("call_id", "")),
+                    "name": str(call.get("name", "")),
+                    "arguments": deepcopy(call.get("arguments")),
+                }
+                state_commitment = (
+                    dispatch.result.get("state_after_sha256")
+                    or dispatch.result.get("state_before_sha256")
+                    or current_state
+                )
+                audit_chain.append(
+                    "tool_result",
+                    {
+                        "request": request,
+                        "result": deepcopy(dispatch.result),
+                        "replayed": dispatch.replayed,
+                    },
+                    state_sha256=state_commitment,
+                )
+                current_state = state_commitment
+                public_chain.append(
+                    "tool_result_public",
+                    {
+                        "result_commitment": _public_result_commitment(
+                            dispatch.result
+                        ),
+                        "replayed": dispatch.replayed,
+                    },
+                    state_sha256=state_commitment,
+                )
+                if dispatch.result.get("ok") is not True:
+                    if not lifecycle.terminal:
+                        lifecycle.transition(LifecycleState.FAILED)
+                    return finish(_failure(
+                        str(dispatch.result.get("error_type") or "tool_error"),
+                        lifecycle,
+                        audit_chain,
+                        public_chain,
+                        stage="runtime",
+                    ))
+                if self.clock() >= deadline:
+                    failure_lifecycle = lifecycle
+                    if not lifecycle.terminal:
+                        lifecycle.transition(LifecycleState.FAILED)
+                    elif lifecycle.state is not LifecycleState.FAILED:
+                        failure_lifecycle = AgenticV2Lifecycle(
+                            LifecycleState.FAILED
+                        )
+                    return finish(_failure(
+                        "task_wall_time_exhausted",
+                        failure_lifecycle,
+                        audit_chain,
+                        public_chain,
+                        stage="control",
+                    ))
+                if dispatch.finalized:
+                    result = dict(dispatch.terminal_result or {})
+                    break
+            if result is None:
+                if not lifecycle.terminal:
+                    lifecycle.transition(LifecycleState.FAILED)
+                return finish(_failure(
+                    "finalize_not_called", lifecycle, audit_chain, public_chain,
+                    stage="runtime",
+                ))
+            runtime_sha = runtime_fingerprint(
+                policy_profile_id=self.profile.policy_profile_id,
+                substrate_manifest_sha256=substrate_sha,
+                package_snapshot_sha256=package_snapshot_sha,
+                browser_build_sha256=browser_build_sha,
+                backend_implementation_sha256=expected_implementation_sha,
+                capabilities_sha256=canonical_sha256(capabilities),
+                budget_caps=self.budget_caps,
+            )
+            private_trace = _trace_payload("private", audit_chain)
+            public_trace = _trace_payload("public_redacted", public_chain)
+            result["agentic_v2"] = {
+                "schema_version": "2.0",
+                "tool_contract_version": self.profile.tool_contract_version,
+                "policy_profile_id": self.profile.policy_profile_id,
+                "foundation_only": True,
+                "lifecycle_state": lifecycle.state.value,
+                "backend_identity": deepcopy(identity),
+                "capabilities_sha256": canonical_sha256(capabilities),
+                "runtime_fingerprint": runtime_sha,
+                "private_audit": private_trace,
+                "public_trace": public_trace,
+                "trace_pair_sha256": trace_pair_fingerprint(
+                    private_trace, public_trace
+                ),
+            }
+            verify_agentic_v2_result(result)
+            return finish(result)
+        except Exception:
+            if not lifecycle.terminal:
+                try:
+                    lifecycle.transition(LifecycleState.FAILED)
+                except ValueError:
+                    pass
+            return finish(_failure(
+                (
+                    "runner_internal_error"
+                    if audit_chain.events
+                    else "compute_start_failed"
+                ),
+                lifecycle,
+                audit_chain,
+                public_chain,
+                stage="runtime" if audit_chain.events else "startup",
+            ))
+        finally:
+            if backend is not None:
+                try:
+                    backend.close()
+                except Exception:
+                    if result is None or result.get("success") is True:
+                        cleanup_failure = _failure(
+                            "compute_cleanup_failed",
+                            lifecycle,
+                            audit_chain,
+                            public_chain,
+                            stage="cleanup",
+                        )
+                        if result is None:
+                            result = cleanup_failure
+                        else:
+                            result.clear()
+                            result.update(cleanup_failure)
+
+
+def _failure(
+    error: str,
+    lifecycle: AgenticV2Lifecycle,
+    audit_chain: AgenticV2EventChain,
+    public_chain: AgenticV2EventChain,
+    *,
+    stage: str,
+) -> dict:
+    public_error = error if error in ERROR_TYPES else "runner_internal_error"
+    validate_failure_stage(public_error, stage)
+    terminal_state = (
+        "cancelled"
+        if lifecycle.state is LifecycleState.CANCELLED
+        else "failed"
+    )
+    failure_payload = {
+        "error_type": public_error,
+        "lifecycle_state": terminal_state,
+        "stage": stage,
+    }
+    failure_state = canonical_sha256({
+        "schema_version": "2.0",
+        **failure_payload,
+    })
+    audit_chain.append("failure", failure_payload, state_sha256=failure_state)
+    public_chain.append("failure", failure_payload, state_sha256=failure_state)
+    private_trace = _trace_payload("private", audit_chain)
+    public_trace = _trace_payload("public_redacted", public_chain)
+    value = {
+        "success": False,
+        "text": "",
+        "deliverable_text": "",
+        "files": [],
+        "error": public_error,
+        "agentic_v2": {
+            "schema_version": "2.0",
+            "foundation_only": True,
+            "lifecycle_state": terminal_state,
+            "private_audit": private_trace,
+            "public_trace": public_trace,
+            "trace_pair_sha256": trace_pair_fingerprint(
+                private_trace, public_trace
+            ),
+        },
+    }
+    return value
+
+
+def _trace_payload(classification: str, chain: AgenticV2EventChain) -> dict:
+    return {
+        "classification": classification,
+        "event_chain_head_sha256": chain.head_sha256,
+        "events": deepcopy(chain.events),
+    }
+
+
+def _public_result_commitment(result: Mapping[str, Any]) -> dict:
+    fields = (
+        "call_id",
+        "tool_name",
+        "request_sha256",
+        "result_sha256",
+        "ok",
+        "error_type",
+        "usage_delta",
+        "state_before_sha256",
+        "state_after_sha256",
+    )
+    return {field: deepcopy(result.get(field)) for field in fields}
+
+
+def _validate_budget_caps(value: Optional[Mapping[str, Any]]) -> dict[str, int]:
+    raw = dict(value or {"tool_calls": 32, "wall_seconds": 1200})
+    allowed = {"tool_calls", "wall_seconds"}
+    unknown = set(raw) - allowed
+    if unknown:
+        raise ValueError(f"unknown agentic v2 budget cap(s): {sorted(unknown)}")
+    result = {}
+    for name, maximum in (("tool_calls", 256), ("wall_seconds", 3600)):
+        candidate = raw.get(name, 32 if name == "tool_calls" else 1200)
+        if isinstance(candidate, bool):
+            raise ValueError(f"agentic v2 {name} must be a positive integer")
+        try:
+            parsed = int(candidate)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"agentic v2 {name} must be a positive integer"
+            ) from exc
+        if parsed <= 0 or parsed > maximum:
+            raise ValueError(f"agentic v2 {name} must be in [1, {maximum}]")
+        result[name] = parsed
+    return result
+
+
+def _valid_capabilities(value: Any) -> bool:
+    expected = {"commands", "runtimes", "packages", "formats", "budgets"}
+    return (
+        isinstance(value, dict)
+        and set(value) == expected
+        and all(
+            isinstance(value[name], list)
+            and len(value[name]) <= 512
+            and all(isinstance(item, str) and len(item) <= 512 for item in value[name])
+            for name in expected
+        )
+    )

--- a/batch-runner/core/agentic_v2_tools.py
+++ b/batch-runner/core/agentic_v2_tools.py
@@ -1,0 +1,426 @@
+"""Strict dispatcher for the Agentic Sandbox V2 tool contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Protocol
+
+from core.agentic_v2_contract import (
+    ERROR_TYPES,
+    TOOL_CONTRACT_VERSION,
+    TOOL_SCHEMAS,
+    TOOL_RESULT_SCHEMA,
+    AgenticV2Lifecycle,
+    LifecycleState,
+    is_sha256,
+    validate_tool_arguments,
+    validate_tool_result_data,
+)
+from jsonschema import Draft202012Validator
+from core.agentic_v2_provenance import canonical_sha256
+
+
+class AgenticV2Backend(Protocol):
+    def start(self, timeout_seconds: float) -> Mapping[str, Any]: ...
+    def expected_capabilities(self) -> Mapping[str, Any]: ...
+    def state_sha256(self) -> str: ...
+    def capabilities_query(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def workspace_apply(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def exec_run(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def environment_resolve(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def environment_activate(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def browser_run(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def verify_public(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def finalize(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def best_result(self) -> Mapping[str, Any] | None: ...
+    def close(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class AgenticV2Dispatch:
+    result: dict
+    finalized: bool = False
+    terminal_result: Mapping[str, Any] | None = None
+    replayed: bool = False
+
+
+@dataclass
+class AgenticV2ToolDispatcher:
+    backend: AgenticV2Backend
+    lifecycle: AgenticV2Lifecycle
+    max_total_calls: int = 32
+    max_result_bytes: int = 65536
+    deadline: float | None = None
+    clock: Callable[[], float] = time.monotonic
+    record_wall_time: bool = True
+    total_calls: int = 0
+    _call_fingerprints: dict[str, str] = field(default_factory=dict)
+    _cached_results: dict[str, AgenticV2Dispatch] = field(default_factory=dict)
+
+    def dispatch(
+        self,
+        *,
+        call_id: str,
+        name: str,
+        arguments: Any,
+    ) -> AgenticV2Dispatch:
+        if not isinstance(call_id, str) or re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", call_id
+        ) is None:
+            return AgenticV2Dispatch(
+                _error("invalid_call_id", call_id="invalid", tool_name=None)
+            )
+        prior = self._call_fingerprints.get(call_id)
+        try:
+            validated = validate_tool_arguments(name, arguments)
+        except ValueError as exc:
+            if prior is not None:
+                return AgenticV2Dispatch(
+                    _error("call_id_conflict", call_id=call_id, tool_name=name)
+                )
+            return AgenticV2Dispatch(
+                _error(_public_error_type(exc), call_id=call_id, tool_name=name)
+            )
+
+        request_sha256 = canonical_sha256({
+            "tool_contract_version": TOOL_CONTRACT_VERSION,
+            "call_id": call_id,
+            "name": name,
+            "arguments": validated,
+        })
+        if prior is not None:
+            if prior != request_sha256:
+                return AgenticV2Dispatch(
+                    _error("call_id_conflict", call_id=call_id, tool_name=name)
+                )
+            cached = self._cached_results[call_id]
+            if not _valid_cached_dispatch(
+                cached,
+                call_id=call_id,
+                name=name,
+                request_sha256=request_sha256,
+            ):
+                return AgenticV2Dispatch(
+                    _error(
+                        "invalid_result_envelope",
+                        call_id=call_id,
+                        tool_name=name,
+                    )
+                )
+            cached_state_after = cached.result.get("state_after_sha256")
+            if cached_state_after is not None:
+                try:
+                    current_state = self.backend.state_sha256()
+                except Exception:
+                    current_state = None
+                if current_state != cached_state_after:
+                    return AgenticV2Dispatch(
+                        _error(
+                            "call_id_conflict",
+                            call_id=call_id,
+                            tool_name=name,
+                        )
+                    )
+            return AgenticV2Dispatch(
+                deepcopy(cached.result),
+                finalized=cached.finalized,
+                terminal_result=deepcopy(cached.terminal_result),
+                replayed=True,
+            )
+        try:
+            self.lifecycle.require_tool_allowed(name)
+        except ValueError as exc:
+            return AgenticV2Dispatch(
+                _error(_public_error_type(exc), call_id=call_id, tool_name=name)
+            )
+        if self.total_calls >= self.max_total_calls:
+            return AgenticV2Dispatch(
+                _error("tool_budget_exhausted", call_id=call_id, tool_name=name)
+            )
+        dispatch_started = self.clock()
+        if self.deadline is not None and dispatch_started >= self.deadline:
+            return AgenticV2Dispatch(
+                _error(
+                    "task_wall_time_exhausted",
+                    call_id=call_id,
+                    tool_name=name,
+                )
+            )
+
+        try:
+            state_before = self.backend.state_sha256()
+        except Exception:
+            state_before = ""
+        if not is_sha256(state_before):
+            return AgenticV2Dispatch(
+                _error("invalid_backend_state", call_id=call_id, tool_name=name)
+            )
+
+        finalizing = name == "finalize"
+        if finalizing:
+            try:
+                self.lifecycle.transition(LifecycleState.FINALIZING)
+            except ValueError:
+                return AgenticV2Dispatch(_error(
+                    "invalid_lifecycle_transition", call_id=call_id,
+                    tool_name=name,
+                ))
+
+        self.total_calls += 1
+        self._call_fingerprints[call_id] = request_sha256
+        try:
+            payload = self._invoke(name, validated)
+        except Exception:
+            payload = {"ok": False, "error_type": "fixture_backend_error"}
+
+        if not isinstance(payload, Mapping) or payload.get("ok") not in (True, False):
+            payload = {"ok": False, "error_type": "invalid_backend_result"}
+        backend_claimed_success = payload.get("ok") is True
+        try:
+            state_after = self.backend.state_sha256()
+        except Exception:
+            state_after = ""
+        dispatch_finished = self.clock()
+        wall_ms = (
+            min(
+                3600000,
+                max(0, int((dispatch_finished - dispatch_started) * 1000)),
+            )
+            if self.record_wall_time
+            else 0
+        )
+        if not is_sha256(state_after):
+            payload = {"ok": False, "error_type": "invalid_backend_state"}
+            state_after = state_before
+        if (
+            self.record_wall_time
+            and self.deadline is not None
+            and dispatch_finished >= self.deadline
+        ):
+            payload = {"ok": False, "error_type": "task_wall_time_exhausted"}
+
+        terminal_result = None
+        terminal_valid = not finalizing
+        if finalizing and backend_claimed_success:
+            try:
+                terminal_result = self.backend.best_result()
+            except Exception:
+                terminal_result = None
+
+        result = _result_envelope(
+            name=name,
+            arguments=validated,
+            call_id=call_id,
+            request_sha256=request_sha256,
+            payload=payload,
+            state_before=state_before,
+            state_after=state_after,
+            wall_ms=wall_ms,
+        )
+        if finalizing and backend_claimed_success:
+            terminal_valid = result.get("ok") is True and _valid_terminal_result(
+                terminal_result,
+                result.get("data", {}).get("artifacts"),
+                summary=str(validated["summary"]),
+            )
+            if result.get("ok") is True and not terminal_valid:
+                result = _executed_error(result, "finalize_result_mismatch")
+        encoded = json.dumps(
+            result, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+        if len(encoded) > self.max_result_bytes:
+            result = _executed_error(result, "tool_result_too_large")
+        elif list(Draft202012Validator(TOOL_RESULT_SCHEMA).iter_errors(result)):
+            result = _executed_error(result, "invalid_result_envelope")
+
+        finalized = (
+            finalizing
+            and backend_claimed_success
+            and terminal_valid
+            and result.get("ok") is True
+        )
+        if finalizing:
+            transition_target = (
+                LifecycleState.FINALIZED
+                if finalized
+                else LifecycleState.FAILED
+                if backend_claimed_success
+                else LifecycleState.ACTIVE
+            )
+            try:
+                self.lifecycle.transition(transition_target)
+            except ValueError:
+                result = _error(
+                    "invalid_lifecycle_transition",
+                    call_id=call_id,
+                    tool_name=name,
+                )
+                finalized = False
+                terminal_result = None
+        if not finalized:
+            terminal_result = None
+        dispatch = AgenticV2Dispatch(
+            deepcopy(result),
+            finalized=finalized,
+            terminal_result=deepcopy(terminal_result),
+        )
+        self._cached_results[call_id] = AgenticV2Dispatch(
+            deepcopy(result),
+            finalized=finalized,
+            terminal_result=deepcopy(terminal_result),
+        )
+        return dispatch
+
+    def _invoke(self, name: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        method = getattr(self.backend, name)
+        return method(arguments)
+
+
+def _result_envelope(
+    *,
+    name: str,
+    arguments: Mapping[str, Any],
+    call_id: str,
+    request_sha256: str,
+    payload: Mapping[str, Any],
+    state_before: str,
+    state_after: str,
+    wall_ms: int,
+) -> dict:
+    ok = payload.get("ok") is True
+    error_type = None if ok else str(
+        payload.get("error_type") or "invalid_backend_result"
+    )
+    if error_type is not None and error_type not in ERROR_TYPES:
+        error_type = "invalid_backend_result"
+        ok = False
+    try:
+        data = validate_tool_result_data(
+            name, arguments, ok, payload.get("data", {})
+        )
+    except ValueError:
+        ok = False
+        error_type = "invalid_backend_result"
+        data = {}
+    usage_delta = {
+        "tool_calls": 1,
+        "wall_ms": wall_ms,
+        "output_bytes": len(json.dumps(
+            data, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")),
+    }
+    result = {
+        "schema_version": TOOL_CONTRACT_VERSION,
+        "call_id": call_id,
+        "tool_name": name,
+        "request_sha256": request_sha256,
+        "ok": ok,
+        "error_type": error_type,
+        "data": data,
+        "usage_delta": usage_delta,
+        "state_before_sha256": state_before,
+        "state_after_sha256": state_after,
+    }
+    result["result_sha256"] = canonical_sha256(result)
+    return result
+
+
+def _executed_error(result: Mapping[str, Any], error_type: str) -> dict:
+    value = deepcopy(dict(result))
+    value.pop("result_sha256", None)
+    value["ok"] = False
+    value["error_type"] = error_type
+    value["data"] = {}
+    value["usage_delta"] = {
+        **value["usage_delta"],
+        "output_bytes": 2,
+    }
+    value["result_sha256"] = canonical_sha256(value)
+    return value
+
+
+def _error(
+    error_type: str,
+    *,
+    call_id: str,
+    tool_name: str | None,
+) -> dict:
+    result = {
+        "schema_version": TOOL_CONTRACT_VERSION,
+        "call_id": call_id,
+        "tool_name": tool_name if tool_name in TOOL_SCHEMAS else None,
+        "request_sha256": None,
+        "ok": False,
+        "error_type": error_type,
+        "data": {},
+        "usage_delta": {"tool_calls": 0, "wall_ms": 0, "output_bytes": 0},
+        "state_before_sha256": None,
+        "state_after_sha256": None,
+    }
+    result["result_sha256"] = canonical_sha256(result)
+    return result
+
+
+def _valid_terminal_result(
+    value: Any,
+    artifacts: Any,
+    *,
+    summary: str,
+) -> bool:
+    if (
+        not isinstance(value, Mapping)
+        or value.get("success") is not True
+        or value.get("text") != summary
+        or value.get("deliverable_text") != summary
+        or not isinstance(value.get("files"), list)
+        or not isinstance(artifacts, list)
+        or len(value["files"]) != len(artifacts)
+    ):
+        return False
+    for file_value, artifact in zip(value["files"], artifacts):
+        if not isinstance(file_value, Mapping) or not isinstance(artifact, Mapping):
+            return False
+        content = file_value.get("content")
+        if (
+            file_value.get("filename") != artifact.get("path")
+            or not isinstance(content, bytes)
+            or len(content) != artifact.get("size")
+            or hashlib.sha256(content).hexdigest() != artifact.get("sha256")
+        ):
+            return False
+    return True
+
+
+def _valid_cached_dispatch(
+    dispatch: AgenticV2Dispatch,
+    *,
+    call_id: str,
+    name: str,
+    request_sha256: str,
+) -> bool:
+    result = dispatch.result
+    if (
+        not isinstance(result, dict)
+        or list(Draft202012Validator(TOOL_RESULT_SCHEMA).iter_errors(result))
+        or result.get("call_id") != call_id
+        or result.get("tool_name") != name
+        or result.get("request_sha256") != request_sha256
+    ):
+        return False
+    unsigned = dict(result)
+    claimed = unsigned.pop("result_sha256", None)
+    return is_sha256(claimed) and canonical_sha256(unsigned) == claimed
+
+
+def _public_error_type(exc: ValueError) -> str:
+    message = str(exc)
+    if "unknown agentic v2 tool" in message:
+        return "unknown_tool"
+    if "terminal" in message or "not active" in message or "finalizing" in message:
+        return "tool_not_allowed_in_state"
+    return "invalid_arguments"

--- a/batch-runner/core/executor.py
+++ b/batch-runner/core/executor.py
@@ -35,7 +35,7 @@ from core.hardened_sandbox_runner import HardenedSandboxRunner
 # Execution modes
 ExecutionMode = Literal[
     "code_interpreter", "subprocess", "sandbox", "agentic_sandbox",
-    "json_renderer",
+    "agentic_sandbox_v2", "json_renderer",
 ]
 
 
@@ -88,6 +88,7 @@ class TaskExecutor:
         provider: Optional[str] = None,
         client_factory: Optional[Callable[[], object]] = None,
         agentic_options: Optional[dict] = None,
+        agentic_v2_options: Optional[dict] = None,
         run_id: Optional[str] = None,
         condition_name: Optional[str] = None,
         model_name: Optional[str] = None,
@@ -100,6 +101,9 @@ class TaskExecutor:
         agentic_endpoint: Optional[str] = None,
         agentic_ordered_task_ids: Optional[list[str]] = None,
         agentic_task_request_sha256: Optional[Mapping[str, str]] = None,
+        agentic_v2_backend_factory=None,
+        agentic_v2_fixture_root: Optional[str | Path] = None,
+        agentic_v2_scripted_calls=None,
         non_paid_test_mode: bool = False,
         code_interpreter_client=None,
         redact_provider_errors: bool = False,
@@ -564,6 +568,57 @@ class TaskExecutor:
                     ],
                 )
 
+        elif mode == "agentic_sandbox_v2":
+            from core.agentic_v2_runner import AgenticV2IsolatedFixtureRunner
+
+            if not non_paid_test_mode:
+                raise ValueError(
+                    "agentic_sandbox_v2 foundation is model-free only"
+                )
+            if llm_client is not None or client_factory is not None:
+                raise ValueError(
+                    "agentic_sandbox_v2 foundation refuses model clients"
+                )
+            if any(value is not None for value in (
+                api_key,
+                endpoint,
+                code_interpreter_client,
+            )):
+                raise ValueError(
+                    "agentic_sandbox_v2 foundation refuses credential inputs"
+                )
+            if any(value is not None for value in (
+                prompt_name,
+                tokens,
+                timeout,
+                reasoning_effort,
+                sandbox_options,
+                metrics_options,
+                provider,
+                agentic_options,
+                model_name,
+            )):
+                raise ValueError(
+                    "agentic_sandbox_v2 foundation refuses model inputs"
+                )
+            if agentic_v2_backend_factory is not None:
+                raise ValueError(
+                    "agentic_sandbox_v2 foundation rejects custom backend factories"
+                )
+            if agentic_v2_fixture_root is None:
+                raise ValueError(
+                    "agentic_sandbox_v2 foundation requires a fixture root"
+                )
+            if not isinstance(agentic_v2_scripted_calls, (list, tuple)):
+                raise ValueError(
+                    "agentic_sandbox_v2 foundation requires scripted calls"
+                )
+            self.runner = AgenticV2IsolatedFixtureRunner(
+                fixture_root=agentic_v2_fixture_root,
+                scripted_calls=agentic_v2_scripted_calls,
+                profile=agentic_v2_options or {},
+            )
+
         elif mode == "json_renderer":
             if llm_client is None:
                 raise ValueError("json_renderer mode requires llm_client")
@@ -649,6 +704,25 @@ class TaskExecutor:
                     experiment_prompt=experiment_prompt,
                 )
 
+            elif self.mode == "agentic_sandbox_v2":
+                if model:
+                    raise ValueError(
+                        "agentic_sandbox_v2 foundation refuses model input"
+                    )
+                if experiment_prompt is not None:
+                    raise ValueError(
+                        "agentic_sandbox_v2 foundation refuses model prompts"
+                    )
+                return self.runner.run(
+                    task_prompt=task_prompt,
+                    reference_files=reference_files,
+                    occupation=occupation,
+                    perception_text=perception_text,
+                    run_id=run_id or "local-nonpaid",
+                    condition_name=condition_name or "condition_a",
+                    task_id=task_id or "unknown-task",
+                )
+
             elif self.mode in {"sandbox", "agentic_sandbox"}:
                 extra = {}
                 if self.mode == "agentic_sandbox" or self.hardened_sandbox:
@@ -708,7 +782,6 @@ class TaskExecutor:
                     "agentic_sandbox mode requires OpenAI/Azure OpenAI, "
                     f"got {model_provider}"
                 )
-
         return (True, None)
 
     @staticmethod

--- a/batch-runner/core/experiment_config.py
+++ b/batch-runner/core/experiment_config.py
@@ -101,7 +101,7 @@ class ExecutionConfig:
     """Execution mode configuration (Phase 5-3)"""
     mode: Literal[
         "code_interpreter", "subprocess", "json_renderer", "sandbox",
-        "agentic_sandbox",
+        "agentic_sandbox", "agentic_sandbox_v2",
     ] = "subprocess"
     score_type: Literal["tool_assisted", "portable"] = "tool_assisted"
     max_retries: int = 3           # Infrastructure retries within task execution
@@ -111,6 +111,7 @@ class ExecutionConfig:
     timeout: Optional[int] = None  # subprocess timeout override (seconds)
     sandbox: Optional[Dict[str, Any]] = None  # sandbox-mode settings (execution.sandbox block)
     agentic: Optional[Dict[str, Any]] = None  # agentic-mode settings (execution.agentic block)
+    agentic_v2: Optional[Dict[str, Any]] = None  # v2 contract/profile identity
     metrics: Optional[Dict[str, Any]] = None  # opt-in job metrics (execution.metrics block)
 
 
@@ -295,6 +296,11 @@ class ExperimentConfig:
                 if isinstance(execution_data.get("agentic"), dict)
                 else None
             ),
+            agentic_v2=(
+                dict(execution_data["agentic_v2"])
+                if isinstance(execution_data.get("agentic_v2"), dict)
+                else None
+            ),
             metrics=(
                 {"enabled": True}
                 if isinstance(execution_data.get("metrics"), dict)
@@ -408,6 +414,7 @@ class ExperimentConfig:
                 "timeout": self.execution.timeout,
                 "sandbox": self.execution.sandbox,
                 **({"agentic": self.execution.agentic} if self.execution.agentic is not None else {}),
+                **({"agentic_v2": self.execution.agentic_v2} if self.execution.agentic_v2 is not None else {}),
                 **({"metrics": self.execution.metrics} if self.execution.metrics is not None else {}),
             },
         }
@@ -491,7 +498,7 @@ class ExperimentConfig:
         # Validate execution mode (Phase 5-3)
         valid_modes = [
             "code_interpreter", "subprocess", "sandbox", "agentic_sandbox",
-            "json_renderer",
+            "agentic_sandbox_v2", "json_renderer",
         ]
         if self.execution.mode not in valid_modes:
             errors.append(f"execution.mode must be one of {valid_modes}")
@@ -519,6 +526,36 @@ class ExperimentConfig:
                 errors.append("agentic_sandbox mode requires azure or openai provider for condition_a")
             if self.condition_b and self.condition_b.model.provider not in ["azure", "openai"]:
                 errors.append("agentic_sandbox mode requires azure or openai provider for condition_b")
+
+        if self.execution.mode == "agentic_sandbox_v2":
+            from core.agentic_v2_contract import AgenticV2Profile
+
+            if self.condition_b is not None:
+                errors.append(
+                    "agentic_sandbox_v2 foundation requires exactly condition_a"
+                )
+            if self.output.publish_to_hf or self.output.submit_to_evals:
+                errors.append(
+                    "agentic_sandbox_v2 foundation cannot publish or submit"
+                )
+            if self.condition_a.qa and self.condition_a.qa.enabled:
+                errors.append(
+                    "condition_a.qa must be disabled for agentic_sandbox_v2 "
+                    "foundation"
+                )
+            if self.condition_a.preprocessors:
+                errors.append(
+                    "condition_a.preprocessors must be empty for "
+                    "agentic_sandbox_v2 foundation"
+                )
+            try:
+                AgenticV2Profile.from_mapping(self.execution.agentic_v2)
+            except ValueError as exc:
+                errors.append(str(exc))
+        elif self.execution.agentic_v2 is not None:
+            errors.append(
+                "execution.agentic_v2 is only valid for agentic_sandbox_v2 mode"
+            )
 
         hardened = (
             self.execution.mode == "agentic_sandbox"

--- a/batch-runner/step1_prepare_tasks.py
+++ b/batch-runner/step1_prepare_tasks.py
@@ -202,6 +202,9 @@ def prepare_tasks(config_path: str) -> dict:
             } if (public_agentic := _public_agentic_config(
                 config.execution.agentic
             )) is not None else {}),
+            **({
+                "agentic_v2": dict(config.execution.agentic_v2)
+            } if config.execution.agentic_v2 is not None else {}),
             **({"metrics": config.execution.metrics} if config.execution.metrics is not None else {}),
         },
         "total_tasks": len(task_list),

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -132,6 +132,25 @@ def _require_code_interpreter_route_profile(execution_mode: str) -> None:
         )
 
 
+def _require_runnable_execution_mode(execution_mode: str) -> None:
+    if execution_mode == "agentic_sandbox_v2":
+        raise ValueError(
+            "agentic_sandbox_v2 foundation is model-free and must run through "
+            "the scripted fixture harness"
+        )
+
+
+def _resolve_runnable_execution_mode(
+    configured_execution_mode: str,
+    override_execution_mode: Optional[str],
+) -> str:
+    _require_runnable_execution_mode(configured_execution_mode)
+    if override_execution_mode is not None:
+        _require_runnable_execution_mode(override_execution_mode)
+        return override_execution_mode
+    return configured_execution_mode
+
+
 def _raise_redacted_azure_ai_error(error_type: str):
     raise RuntimeError(
         f"Typed Azure AI provider error ({error_type})"
@@ -2443,6 +2462,7 @@ def validate_restored_checkpoint(condition_key: str = "condition_a") -> dict:
         "mode", prepared.get("execution_mode", "subprocess")
     )
     _require_code_interpreter_route_profile(execution_mode)
+    _require_runnable_execution_mode(execution_mode)
     if execution_mode == "agentic_sandbox" or (
         execution_mode == "sandbox" and sandbox.get("hardened_substrate") is True
     ):
@@ -2684,9 +2704,11 @@ def _run_inference_impl(
     configured_execution_mode = execution_cfg.get(
         "mode", prepared.get("execution_mode", "subprocess")
     )
-    if execution_mode is None:
-        execution_mode = configured_execution_mode
     try:
+        execution_mode = _resolve_runnable_execution_mode(
+            configured_execution_mode,
+            execution_mode,
+        )
         _require_code_interpreter_route_profile(execution_mode)
     except ValueError as exc:
         print(f"❌ {exc}")

--- a/batch-runner/tests/test_agentic_v2_compatibility.py
+++ b/batch-runner/tests/test_agentic_v2_compatibility.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import textwrap
+from dataclasses import asdict
+from decimal import Decimal
+from pathlib import Path
+
+import step2_run_inference as step2
+from core.agentic_sandbox_runner import AgenticLimits
+from core.agentic_tools import responses_tool_definitions
+from core.executor import TaskExecutor
+from core.experiment_config import ExperimentConfig
+from core.result_fingerprint import inference_result_fingerprint
+
+
+V1_PROMPT_SHA256 = "58ad33a5cf7169a224dd973be2c6b5554933c8ee8232720be4edfd26ef28547c"
+V1_TOOLS_SHA256 = "383c5f730237960cbfa7e0646d50e51f2468e7f6c63eac2b5225fe95ecad99c2"
+V1_CHECKPOINT_SHA256 = "54eceac55422e151f08032ad70ff4ef451b90ec31b3d013216f5cee7b5bcff43"
+V1_RESULT_FINGERPRINT = "b05aabba5ca21eb62de4a4bd6faf803425dec7650dd8a7e45f7faa0de5188718"
+
+
+def test_v1_agentic_prompt_and_tool_contract_identity_is_frozen():
+    prompt = Path("prompts/agentic_sandbox_solver.yaml").read_bytes()
+    tools = json.dumps(
+        responses_tool_definitions(),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    assert hashlib.sha256(prompt).hexdigest() == V1_PROMPT_SHA256
+    assert hashlib.sha256(tools).hexdigest() == V1_TOOLS_SHA256
+
+
+def test_v1_agentic_default_limits_are_frozen():
+    assert asdict(AgenticLimits()) == {
+        "max_api_attempts": 6,
+        "max_model_iterations": 6,
+        "max_output_tokens": 8192,
+        "max_input_tokens": 300000,
+        "max_cumulative_output_tokens": 32768,
+        "max_task_seconds": 1200,
+        "max_cost_usd": Decimal("1.25"),
+        "max_tool_calls": 8,
+        "max_run_python": 4,
+        "max_run_ffmpeg": 2,
+        "max_inspect_artifacts": 4,
+        "max_finalize": 2,
+        "max_identical_errors": 2,
+    }
+
+
+def test_v1_agentic_checkpoint_and_result_manifest_identity_is_frozen(tmp_path):
+    result = _v1_result_fixture()
+    checkpoint = tmp_path / "progress.json"
+    step2._save_progress(
+        "exp-v1-identity",
+        "V1 Agentic",
+        "agentic_sandbox",
+        1,
+        [result],
+        "2026-07-27T12:00:00+00:00",
+        checkpoint,
+        run_id="run-v1-identity",
+        condition_identity="condition_a",
+        ordered_task_ids=["task-v1"],
+        prepared_fingerprint="e" * 64,
+        resume_round=0,
+    )
+
+    assert hashlib.sha256(checkpoint.read_bytes()).hexdigest() == (
+        V1_CHECKPOINT_SHA256
+    )
+    restored = step2._load_and_validate_progress(
+        checkpoint,
+        experiment_id="exp-v1-identity",
+        condition_name="V1 Agentic",
+        condition_identity="condition_a",
+        run_id="run-v1-identity",
+        execution_mode="agentic_sandbox",
+        ordered_task_ids=["task-v1"],
+        prepared_fingerprint="e" * 64,
+        allow_missing_results=False,
+    )
+    restored_checkpoint = tmp_path / "restored-progress.json"
+    step2._save_progress(
+        "exp-v1-identity",
+        "V1 Agentic",
+        "agentic_sandbox",
+        1,
+        restored["results"],
+        restored["started_at"],
+        restored_checkpoint,
+        run_id="run-v1-identity",
+        condition_identity="condition_a",
+        ordered_task_ids=["task-v1"],
+        prepared_fingerprint="e" * 64,
+        resume_round=restored["resume_round"],
+    )
+    assert restored_checkpoint.read_bytes() == checkpoint.read_bytes()
+
+    final_result = dict(result)
+    final_result["deliverable_file_records"] = [{
+        "path": "deliverable_files/task-v1/report.txt",
+        "sha256": hashlib.sha256(b"fixed v1 report\n").hexdigest(),
+        "size": 16,
+    }]
+    manifest = {
+        "experiment_id": "exp-v1-identity",
+        "publication_generation": "generation-v1",
+        "experiment_name": "V1 identity fixture",
+        "source": "fixture/gdpval",
+        "condition": "V1 Agentic",
+        "condition_identity": "condition_a",
+        "run_id": "run-v1-identity",
+        "execution_mode": "agentic_sandbox",
+        "ordered_task_ids": ["task-v1"],
+        "prepared_fingerprint": "e" * 64,
+        "model": "v1-model",
+        "started_at": "2026-07-27T12:00:00+00:00",
+        "completed_at": "2026-07-27T12:01:00+00:00",
+        "resume_rounds_used": 0,
+        "summary": {"total": 1, "success": 1, "error": 0, "qa_failed": 0},
+        "results": [final_result],
+    }
+
+    assert inference_result_fingerprint(manifest) == V1_RESULT_FINGERPRINT
+
+
+def test_v1_import_and_default_config_do_not_require_v2_modules():
+    script = textwrap.dedent("""
+        import builtins
+        original_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name.startswith("core.agentic_v2"):
+                raise ImportError("v2 intentionally unavailable")
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = guarded_import
+        from core.executor import TaskExecutor
+        from core.experiment_config import ExperimentConfig
+
+        config = ExperimentConfig.from_dict({
+            "experiment": {"id": "exp001", "name": "legacy"},
+            "data": {"source": "openai/gdpval"},
+            "condition_a": {
+                "name": "legacy",
+                "model": {"provider": "azure", "deployment": "model"},
+                "prompt": {"system": "system"},
+            },
+        })
+        assert config.execution.mode == "subprocess"
+        assert TaskExecutor.recommend_mode("azure") == "code_interpreter"
+    """)
+
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
+def test_v2_is_never_selected_by_legacy_defaults_or_recommendations():
+    config = ExperimentConfig.from_dict({
+        "experiment": {"id": "exp001", "name": "Legacy default"},
+        "data": {"source": "openai/gdpval"},
+        "condition_a": {
+            "name": "Default",
+            "model": {"provider": "azure", "deployment": "model"},
+            "prompt": {"system": "system"},
+        },
+    })
+
+    assert config.execution.mode == "subprocess"
+    assert config.execution.agentic_v2 is None
+    assert TaskExecutor.recommend_mode("azure", "tool_assisted") == "code_interpreter"
+    assert TaskExecutor.recommend_mode("openai", "tool_assisted") == "subprocess"
+    assert TaskExecutor.recommend_mode("anthropic", "portable") == "json_renderer"
+
+
+def _v1_result_fixture() -> dict:
+    components = {
+        name: str(index) * 64
+        for index, name in enumerate((
+            "python_launcher",
+            "ffmpeg_mapper",
+            "verifier",
+            "outer_seccomp",
+            "capabilities",
+            "core_tree",
+        ), 1)
+    }
+    observability = step2._build_execution_observability({
+        "agentic_metrics": {
+            "ledger_cumulative": True,
+            "model_api_calls": 2,
+            "model_iterations": 2,
+            "tool_calls": 2,
+            "tool_errors": 0,
+            "tool_calls_by_name": {"run_python": 1, "finalize": 1},
+            "task_wall_time_ms": 250,
+            "finalize_attempts": 1,
+            "input_tokens": 1000,
+            "output_tokens": 250,
+            "cached_tokens": 100,
+            "usage_complete": True,
+            "terminal_error_category": None,
+            "conservative_cost_usd": "0.125",
+        },
+        "substrate_manifest": {
+            "sha256": "a" * 64,
+            "task_image": f"task@sha256:{'b' * 64}",
+            "task_image_id": f"sha256:{'b' * 64}",
+            "verifier_image": f"verifier@sha256:{'c' * 64}",
+            "verifier_image_id": f"sha256:{'c' * 64}",
+            "component_sha256": components,
+            "sbom_sha256": "d" * 64,
+            "uid": 1000,
+            "gid": 1000,
+            "network": "none",
+            "ipc": "private",
+            "pid_namespace": "private",
+            "read_only_rootfs": True,
+            "cap_drop": ["ALL"],
+            "no_new_privileges": True,
+        },
+    }, [])
+    return {
+        "task_id": "task-v1",
+        "status": "success",
+        "content": "completed",
+        "deliverable_text": "report ready",
+        "deliverable_files": ["deliverable_files/task-v1/report.txt"],
+        "model": "v1-model",
+        "usage": {"input_tokens": 1000, "output_tokens": 250},
+        "observability": observability,
+        "latency_ms": 250.0,
+        "timestamp": "2026-07-27T12:00:00+00:00",
+    }

--- a/batch-runner/tests/test_agentic_v2_contract.py
+++ b/batch-runner/tests/test_agentic_v2_contract.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from core.agentic_v2_contract import (
+    EVENT_SCHEMA,
+    TOOL_CONTRACT_VERSION,
+    TOOL_NAMES,
+    TOOL_SCHEMAS,
+    TOOL_RESULT_SCHEMA,
+    AgenticV2Lifecycle,
+    AgenticV2Profile,
+    LifecycleState,
+    contract_fingerprint,
+    is_sha256,
+    responses_tool_definitions,
+    validate_tool_arguments,
+    validate_tool_result_data,
+)
+import core.agentic_v2_contract as contract_module
+
+
+def test_v2_tool_definitions_are_stable_strict_and_valid():
+    definitions = responses_tool_definitions()
+
+    assert tuple(item["name"] for item in definitions) == TOOL_NAMES
+    assert all(item["strict"] is True for item in definitions)
+    assert all(item["type"] == "function" for item in definitions)
+    for schema in TOOL_SCHEMAS.values():
+        Draft202012Validator.check_schema(schema)
+    Draft202012Validator.check_schema(TOOL_RESULT_SCHEMA)
+    Draft202012Validator.check_schema(EVENT_SCHEMA)
+
+
+@pytest.mark.parametrize("name", TOOL_NAMES)
+def test_v2_tool_schemas_reject_unknown_fields(name):
+    schema = TOOL_SCHEMAS[name]
+    candidate = _minimal_arguments(name)
+    candidate["unexpected"] = True
+
+    with pytest.raises(ValueError, match="invalid agentic v2 tool arguments"):
+        validate_tool_arguments(name, candidate)
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments"),
+    [
+        ("workspace_apply", {"operation": "read", "path": "../secret"}),
+        ("workspace_apply", {"operation": "copy", "source": "/etc/passwd", "destination": "copy"}),
+        ("exec_run", {"argv": ["python"], "cwd": "/root", "timeout_seconds": 1}),
+        ("environment_resolve", {"ecosystem": "python", "requirements": ["pkg @ https://example.com/pkg.whl"]}),
+        ("environment_activate", {"lock_digest": "mutable-tag"}),
+        ("finalize", {"deliverables": ["../output"], "summary": "done"}),
+    ],
+)
+def test_v2_contract_rejects_escape_and_mutable_coordinates(name, arguments):
+    with pytest.raises(ValueError, match="invalid agentic v2 tool arguments"):
+        validate_tool_arguments(name, arguments)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["./a", "a//b", "a/./b", "a/../b", "/a", "a\\b", "report\u0085.txt"],
+)
+def test_v2_contract_rejects_noncanonical_path_aliases(path):
+    with pytest.raises(ValueError, match="invalid agentic v2 tool arguments|canonical"):
+        validate_tool_arguments(
+            "workspace_apply", {"operation": "read", "path": path}
+        )
+
+
+def test_v2_contract_enforces_utf8_byte_path_limit():
+    ascii_boundary = "a" * 240
+    multibyte_boundary = "é" * 120
+
+    assert validate_tool_arguments(
+        "workspace_apply",
+        {"operation": "read", "path": ascii_boundary},
+    )["path"] == ascii_boundary
+    assert validate_tool_arguments(
+        "workspace_apply",
+        {"operation": "read", "path": multibyte_boundary},
+    )["path"] == multibyte_boundary
+
+    with pytest.raises(ValueError, match="canonical relative POSIX"):
+        validate_tool_arguments(
+            "workspace_apply",
+            {"operation": "read", "path": "é" * 121},
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com",
+        "https://user:pass@example.com/path",
+        "https://localhost/path",
+        "https://127.0.0.1/path",
+        "https://169.254.169.254/latest/meta-data",
+        "https://example.com./path",
+        "https://example.com:/path",
+        "https://example.com:99999/path",
+        "https://example.com/a/../secret",
+        "https://example.com/%2e%2e/secret",
+        "https://example.com/%252e%252e/secret",
+        "https://example.com/a%2fb",
+        "https://example.com/line\nbreak",
+        "https://2130706433/",
+        "https://0x7f000001/",
+        "https://0x7f.0x0.0x0.0x1/",
+        "https://example.com/%c0%80",
+        "https://example.com/%E2%80%A8",
+        "https://example.com/\u0080",
+        "https://example.com/?value=\u009f",
+        "file:///etc/passwd",
+        "not-a-url",
+    ],
+)
+def test_v2_contract_rejects_nonpublic_or_malformed_urls(url):
+    with pytest.raises(
+        ValueError,
+        match="invalid agentic v2 tool arguments|public HTTPS|URL is invalid",
+    ):
+        validate_tool_arguments(
+            "browser_run", {"operation": "open_url", "url": url}
+        )
+
+
+def test_v2_contract_accepts_canonical_public_https_url():
+    arguments = {
+        "operation": "open_url",
+        "url": "https://example.com/report?id=42",
+    }
+
+    assert validate_tool_arguments("browser_run", arguments) == arguments
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["report\u0085.txt", "report\x7f.txt", "é" * 121],
+)
+def test_v2_contract_rejects_noncanonical_browser_result_path(path):
+    with pytest.raises(ValueError, match="result data is invalid|canonical"):
+        validate_tool_result_data(
+            "browser_run",
+            {"operation": "search", "query": "offline"},
+            True,
+            {"path": path, "sha256": "a" * 64},
+        )
+
+
+def test_v2_profile_requires_exact_version_and_known_profile():
+    profile = AgenticV2Profile.from_mapping({
+        "tool_contract_version": TOOL_CONTRACT_VERSION,
+        "policy_profile_id": "offline-full-v1",
+        "foundation_only": True,
+    })
+
+    assert profile.tool_contract_version == "2.0"
+    assert profile.policy_profile_id == "offline-full-v1"
+
+    with pytest.raises(ValueError, match="tool_contract_version"):
+        AgenticV2Profile.from_mapping({
+            "tool_contract_version": "1.0",
+            "policy_profile_id": "offline-full-v1",
+            "foundation_only": True,
+        })
+    with pytest.raises(ValueError, match="policy_profile_id"):
+        AgenticV2Profile.from_mapping({
+            "tool_contract_version": "2.0",
+            "policy_profile_id": "unrestricted",
+            "foundation_only": True,
+        })
+    with pytest.raises(ValueError, match="unknown agentic v2 setting"):
+        AgenticV2Profile.from_mapping({
+            "tool_contract_version": "2.0",
+            "policy_profile_id": "offline-full-v1",
+            "foundation_only": True,
+            "fallback": "host",
+        })
+    with pytest.raises(ValueError, match="foundation_only"):
+        AgenticV2Profile.from_mapping({
+            "tool_contract_version": "2.0",
+            "policy_profile_id": "offline-full-v1",
+        })
+
+
+def test_v2_lifecycle_accepts_legal_completion_path():
+    lifecycle = AgenticV2Lifecycle()
+
+    assert lifecycle.transition("started") is LifecycleState.STARTED
+    assert lifecycle.transition("active") is LifecycleState.ACTIVE
+    lifecycle.require_tool_allowed("exec_run")
+    assert lifecycle.transition("finalizing") is LifecycleState.FINALIZING
+    lifecycle.require_tool_allowed("verify_public")
+    lifecycle.require_tool_allowed("finalize")
+    assert lifecycle.transition("finalized") is LifecycleState.FINALIZED
+    assert lifecycle.terminal is True
+
+
+def test_v2_lifecycle_rejects_invalid_transition_and_terminal_tools():
+    lifecycle = AgenticV2Lifecycle()
+
+    with pytest.raises(ValueError, match="created->finalized"):
+        lifecycle.transition("finalized")
+    lifecycle.transition("started")
+    lifecycle.transition("active")
+    lifecycle.transition("failed")
+    with pytest.raises(ValueError, match="lifecycle is terminal"):
+        lifecycle.require_tool_allowed("capabilities_query")
+
+
+def test_v2_lifecycle_forbids_mutation_while_finalizing():
+    lifecycle = AgenticV2Lifecycle(LifecycleState.FINALIZING)
+
+    for name in ("workspace_apply", "exec_run", "environment_activate", "browser_run"):
+        with pytest.raises(ValueError, match="mutation is forbidden"):
+            lifecycle.require_tool_allowed(name)
+
+
+def test_v2_contract_fingerprint_is_deterministic_and_sensitive(monkeypatch):
+    first = contract_fingerprint()
+    second = contract_fingerprint()
+
+    assert first == second
+    assert is_sha256(first)
+
+    changed = deepcopy(responses_tool_definitions())
+    changed[0]["description"] += " changed"
+    assert changed != responses_tool_definitions()
+
+    source = Path(contract_module.__file__).read_bytes()
+
+    class ChangedSourcePath:
+        def __init__(self, _value):
+            pass
+
+        def read_bytes(self):
+            return source + b"\n# changed"
+
+    monkeypatch.setattr(contract_module, "Path", ChangedSourcePath)
+    assert contract_fingerprint() != first
+
+
+def _minimal_arguments(name):
+    return {
+        "capabilities_query": {"kind": "commands"},
+        "workspace_apply": {"operation": "list", "path": "."},
+        "exec_run": {"argv": ["python", "--version"], "cwd": ".", "timeout_seconds": 30},
+        "environment_resolve": {"ecosystem": "python", "requirements": ["pandas==2.2.3"]},
+        "environment_activate": {"lock_digest": "a" * 64},
+        "browser_run": {"operation": "open_local", "path": "report.html"},
+        "verify_public": {"deliverables": ["report.pdf"]},
+        "finalize": {"deliverables": ["report.pdf"], "summary": "done"},
+    }[name]

--- a/batch-runner/tests/test_agentic_v2_foundation.py
+++ b/batch-runner/tests/test_agentic_v2_foundation.py
@@ -1,0 +1,3513 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import inspect
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import psutil
+from jsonschema import Draft202012Validator
+
+import step1_prepare_tasks as step1
+import step2_run_inference as step2
+import core.agentic_v2_provenance as agentic_v2_provenance
+import core.agentic_v2_runner as agentic_v2_runner
+from core.agentic_v2_contract import (
+    EVENT_SCHEMA,
+    TOOL_RESULT_SCHEMA,
+    AgenticV2Lifecycle,
+    AgenticV2Profile,
+    LifecycleState,
+)
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+from core.agentic_v2_runner import (
+    AgenticV2IsolatedFixtureRunner,
+    AgenticV2ScriptedRunner,
+)
+from core.agentic_v2_provenance import (
+    canonical_sha256,
+    foundation_implementation_fingerprint,
+    runtime_fingerprint,
+    trace_pair_fingerprint,
+    verify_agentic_v2_failure_result,
+    verify_agentic_v2_metadata,
+    verify_agentic_v2_result,
+    verify_event_chain,
+    verify_trace_pair,
+)
+from core.agentic_v2_tools import AgenticV2ToolDispatcher
+from core.executor import TaskExecutor
+from core.experiment_config import ExperimentConfig
+from core.prepared_fingerprint import prepared_fingerprint
+from core.source_identity import source_task_projection_sha256
+
+
+PROFILE = {
+    "tool_contract_version": "2.0",
+    "policy_profile_id": "offline-full-v1",
+    "foundation_only": True,
+}
+
+
+def _block_forever(*_args, **_kwargs):
+    threading.Event().wait()
+
+
+_DESCENDANT_PID_PATH = None
+
+
+def _spawn_ignoring_descendant_and_block(*_args, **_kwargs):
+    descendant = subprocess.Popen([
+        sys.executable,
+        "-c",
+        (
+            "import signal, threading; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "threading.Event().wait()"
+        ),
+    ])
+    Path(_DESCENDANT_PID_PATH).write_text(
+        str(descendant.pid), encoding="utf-8"
+    )
+    threading.Event().wait()
+
+
+def _spawn_ignoring_descendant_and_return(_self, arguments):
+    _spawn_ignoring_descendant()
+    return {
+        "ok": True,
+        "data": {"kind": arguments["kind"], "items": ["fixture-upper"]},
+    }
+
+
+def _spawn_ignoring_descendant_and_crash(*_args, **_kwargs):
+    _spawn_ignoring_descendant()
+    os._exit(19)
+
+
+def _spawn_ignoring_descendant():
+    descendant = subprocess.Popen([
+        sys.executable,
+        "-c",
+        (
+            "import signal, threading; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "threading.Event().wait()"
+        ),
+    ])
+    Path(_DESCENDANT_PID_PATH).write_text(
+        str(descendant.pid), encoding="utf-8"
+    )
+    return descendant
+
+
+def _send_forged_success_and_wait(
+    connection, _run_root, _calls, _profile, _budgets, _request
+):
+    os.setsid()
+    connection.send({"kind": "ready", "process_group": os.getpgrp()})
+    connection.send({"kind": "result", "result": {"success": True}})
+    threading.Event().wait()
+
+
+def _send_malformed_failure_and_exit(
+    connection, _run_root, _calls, _profile, _budgets, _request
+):
+    os.setsid()
+    connection.send({"kind": "ready", "process_group": os.getpgrp()})
+    connection.send({"kind": "result", "result": {"success": False}})
+    connection.close()
+
+
+def _backend(tmp_path):
+    return AgenticV2FixtureBackend(
+        root=tmp_path,
+        profile=AgenticV2Profile.from_mapping(PROFILE),
+    )
+
+
+def test_fixture_dispatcher_replays_identical_call_without_mutation(tmp_path):
+    backend = _backend(tmp_path)
+    lifecycle = AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    dispatcher = AgenticV2ToolDispatcher(backend, lifecycle)
+    arguments = {
+        "operation": "write",
+        "path": "report.txt",
+        "content": "hello",
+    }
+
+    first = dispatcher.dispatch(call_id="write-1", name="workspace_apply", arguments=arguments)
+    state_after_first = backend.state_sha256()
+    replay = dispatcher.dispatch(call_id="write-1", name="workspace_apply", arguments=arguments)
+
+    assert first.result["ok"] is True
+    assert replay.result == first.result
+    assert replay.replayed is True
+    assert backend.state_sha256() == state_after_first
+    assert dispatcher.total_calls == 1
+
+
+def test_fixture_dispatcher_replay_is_immutable_and_revalidated(tmp_path):
+    backend = _backend(tmp_path)
+    dispatcher = AgenticV2ToolDispatcher(
+        backend, AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    )
+    arguments = {"kind": "commands"}
+    first = dispatcher.dispatch(
+        call_id="cap-1", name="capabilities_query", arguments=arguments
+    )
+    expected = deepcopy(first.result)
+
+    first.result["data"]["items"].append("caller-tamper")
+    replay = dispatcher.dispatch(
+        call_id="cap-1", name="capabilities_query", arguments=arguments
+    )
+
+    assert replay.result == expected
+    dispatcher._cached_results["cap-1"].result["data"]["items"].append(
+        "cache-tamper"
+    )
+    rejected = dispatcher.dispatch(
+        call_id="cap-1", name="capabilities_query", arguments=arguments
+    )
+    assert rejected.result["error_type"] == "invalid_result_envelope"
+
+
+def test_fixture_dispatcher_rejects_call_id_conflict(tmp_path):
+    backend = _backend(tmp_path)
+    dispatcher = AgenticV2ToolDispatcher(
+        backend, AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    )
+    dispatcher.dispatch(
+        call_id="call-1",
+        name="capabilities_query",
+        arguments={"kind": "commands"},
+    )
+
+    conflict = dispatcher.dispatch(
+        call_id="call-1",
+        name="capabilities_query",
+        arguments={"kind": "runtimes"},
+    )
+
+    assert conflict.result["error_type"] == "call_id_conflict"
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments", "initial_error"),
+    [
+        ("unknown", {}, "unknown_tool"),
+        ("capabilities_query", {"kind": "invalid"}, "invalid_arguments"),
+    ],
+)
+def test_reused_call_id_prioritizes_exact_conflict_for_malformed_request(
+    tmp_path, name, arguments, initial_error
+):
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "call-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "commands"},
+            },
+            {"call_id": "call-1", "name": name, "arguments": arguments},
+        ],
+        profile=PROFILE,
+    )
+
+    result = runner.run("task", task_id="task-1")
+    trace = result["agentic_v2"]["private_audit"]
+
+    assert trace["events"][2]["payload"]["result"]["error_type"] == (
+        "call_id_conflict"
+    )
+    verify_event_chain(trace["events"], trace["event_chain_head_sha256"])
+
+    forged = deepcopy(trace["events"])
+    envelope = forged[2]["payload"]["result"]
+    envelope["error_type"] = initial_error
+    _rehash_result(envelope)
+    head = _rehash_events(forged)
+    with pytest.raises(ValueError, match="replay history mismatch"):
+        verify_event_chain(forged, head)
+
+
+def test_fixture_dispatcher_rejects_replay_after_state_change(tmp_path):
+    backend = _backend(tmp_path)
+    dispatcher = AgenticV2ToolDispatcher(
+        backend, AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    )
+    first_arguments = {
+        "operation": "write",
+        "path": "report.txt",
+        "content": "first",
+    }
+    dispatcher.dispatch(
+        call_id="write-1",
+        name="workspace_apply",
+        arguments=first_arguments,
+    )
+    dispatcher.dispatch(
+        call_id="write-2",
+        name="workspace_apply",
+        arguments={
+            "operation": "write",
+            "path": "report.txt",
+            "content": "second",
+        },
+    )
+
+    replay = dispatcher.dispatch(
+        call_id="write-1",
+        name="workspace_apply",
+        arguments=first_arguments,
+    )
+
+    assert replay.replayed is False
+    assert replay.result["error_type"] == "call_id_conflict"
+    assert backend.workspace_apply({
+        "operation": "read", "path": "report.txt"
+    })["data"]["content"] == "second"
+
+
+def test_fixture_package_resolution_is_pure_until_activation(tmp_path):
+    backend = AgenticV2FixtureBackend(
+        root=tmp_path,
+        profile=AgenticV2Profile.from_mapping({
+            "tool_contract_version": "2.0",
+            "policy_profile_id": "package-broker-v1",
+            "foundation_only": True,
+        }),
+    )
+    dispatcher = AgenticV2ToolDispatcher(
+        backend, AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    )
+    before = backend.state_sha256()
+    workspace_before = backend.workspace_state_sha256()
+
+    resolved = dispatcher.dispatch(
+        call_id="resolve-1",
+        name="environment_resolve",
+        arguments={"ecosystem": "python", "requirements": ["demo-pkg==1.0.0"]},
+    )
+
+    assert resolved.result["ok"] is True
+    assert backend.state_sha256() == before
+    lock_digest = resolved.result["data"]["lock_digest"]
+
+    activated = dispatcher.dispatch(
+        call_id="activate-1",
+        name="environment_activate",
+        arguments={"lock_digest": lock_digest},
+    )
+
+    assert activated.result["ok"] is True
+    assert backend.workspace_state_sha256() == workspace_before
+    assert activated.result["state_after_sha256"] != resolved.result[
+        "state_after_sha256"
+    ]
+
+
+def test_fixture_package_lock_is_revalidated_at_activation(tmp_path):
+    backend = AgenticV2FixtureBackend(
+        root=tmp_path,
+        profile=AgenticV2Profile.from_mapping({
+            "tool_contract_version": "2.0",
+            "policy_profile_id": "package-broker-v1",
+            "foundation_only": True,
+        }),
+    )
+    resolved = backend.environment_resolve({
+        "ecosystem": "python", "requirements": ["demo-pkg==1.0.0"]
+    })
+    digest = resolved["data"]["lock_digest"]
+    backend._locks[digest] = b'{"ecosystem":"python","requirements":[],"blobs":[]}'
+
+    assert backend.environment_activate({"lock_digest": digest}) == {
+        "ok": False,
+        "error_type": "unapproved_lock",
+    }
+    with pytest.raises(TypeError):
+        backend.package_catalog["python:other==1.0"] = "a" * 64
+
+
+def test_offline_profile_rejects_package_resolution(tmp_path):
+    backend = _backend(tmp_path)
+    dispatcher = AgenticV2ToolDispatcher(
+        backend, AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    )
+
+    result = dispatcher.dispatch(
+        call_id="resolve-1",
+        name="environment_resolve",
+        arguments={"ecosystem": "python", "requirements": ["demo-pkg==1.0.0"]},
+    )
+
+    assert result.result["ok"] is False
+    assert result.result["error_type"] == "capability_unavailable"
+
+
+def test_offline_fixture_browser_rejects_web_operations(tmp_path):
+    backend = _backend(tmp_path)
+    dispatcher = AgenticV2ToolDispatcher(
+        backend, AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    )
+
+    result = dispatcher.dispatch(
+        call_id="web-1",
+        name="browser_run",
+        arguments={"operation": "search", "query": "benchmark answer"},
+    )
+
+    assert result.result["ok"] is False
+    assert result.result["error_type"] == "capability_unavailable"
+
+
+def test_fixture_rejects_symlink_and_hardlink_deliverables(tmp_path):
+    backend = _backend(tmp_path)
+    (backend.work / "real.txt").write_text("content", encoding="utf-8")
+    (backend.work / "link.txt").symlink_to("real.txt")
+    os.link(backend.work / "real.txt", backend.work / "hard.txt")
+
+    for path in ("link.txt", "real.txt", "hard.txt"):
+        result = backend.verify_public({"deliverables": [path]})
+        assert result == {"ok": False, "error_type": "artifact_not_openable"}
+
+
+@pytest.mark.parametrize("operation", ["read", "write", "copy", "exec", "browser"])
+def test_fixture_rejects_hardlinks_across_all_io_paths(tmp_path, operation):
+    backend = _backend(tmp_path)
+    external = tmp_path / "external.txt"
+    external.write_text("outside", encoding="utf-8")
+    linked = backend.work / "linked.txt"
+    os.link(external, linked)
+
+    with pytest.raises(ValueError, match="single-link regular|unsafe entry"):
+        if operation == "read":
+            backend.workspace_apply({"operation": "read", "path": "linked.txt"})
+        elif operation == "write":
+            backend.workspace_apply({
+                "operation": "write", "path": "linked.txt", "content": "changed"
+            })
+        elif operation == "copy":
+            backend.workspace_apply({
+                "operation": "copy",
+                "source": "linked.txt",
+                "destination": "copy.txt",
+            })
+        elif operation == "exec":
+            backend.exec_run({
+                "argv": ["fixture-upper", "linked.txt", "copy.txt"],
+                "cwd": ".",
+                "timeout_seconds": 30,
+            })
+        else:
+            backend.browser_run({"operation": "open_local", "path": "linked.txt"})
+
+    assert external.read_text(encoding="utf-8") == "outside"
+
+
+def test_fixture_rejects_fifo_without_blocking(tmp_path):
+    backend = _backend(tmp_path)
+    fifo = backend.work / "pipe"
+    os.mkfifo(fifo)
+
+    with pytest.raises(ValueError, match="single-link regular"):
+        backend.workspace_apply({"operation": "read", "path": "pipe"})
+
+
+def test_fixture_rejects_socket_without_blocking(tmp_path):
+    backend = _backend(tmp_path)
+    socket_path = backend.work / "fixture.sock"
+    fixture_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    fixture_socket.bind(str(socket_path))
+    try:
+        with pytest.raises((OSError, ValueError)):
+            backend.workspace_apply({
+                "operation": "read", "path": "fixture.sock"
+            })
+        with pytest.raises(ValueError, match="unsafe entry"):
+            backend.state_sha256()
+    finally:
+        fixture_socket.close()
+
+
+def test_fixture_parent_swap_cannot_redirect_read_outside_root(tmp_path):
+    backend = _backend(tmp_path)
+    inside = backend.work / "safe"
+    inside.mkdir()
+    (inside / "report.txt").write_text("inside", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "report.txt").write_text("outside", encoding="utf-8")
+    original = backend._open_parent
+    swapped = False
+
+    def swap_after_open(relative, *, create=False):
+        nonlocal swapped
+        descriptor, name = original(relative, create=create)
+        if not swapped:
+            inside.rename(backend.work / "safe-detached")
+            inside.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return descriptor, name
+
+    backend._open_parent = swap_after_open
+
+    assert backend.workspace_apply({
+        "operation": "read", "path": "safe/report.txt"
+    })["data"]["content"] == "inside"
+
+
+def test_fixture_parent_move_outside_work_is_rejected_before_write(
+    tmp_path, monkeypatch
+):
+    backend = _backend(tmp_path)
+    parent = backend.work / "safe"
+    parent.mkdir()
+    (parent / "existing.txt").write_text("private", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    moved = outside / "moved-safe"
+    original = backend._open_parent
+
+    def move_after_open(relative, *, create=False):
+        descriptor, name = original(relative, create=create)
+        parent.rename(moved)
+        return descriptor, name
+
+    monkeypatch.setattr(backend, "_open_parent", move_after_open)
+
+    with pytest.raises(ValueError, match="moved outside"):
+        backend.workspace_apply({
+            "operation": "write",
+            "path": "safe/report.txt",
+            "content": "must-not-escape",
+        })
+
+    assert list(moved.iterdir()) == []
+
+
+def test_fixture_nested_ancestor_move_purges_siblings(tmp_path, monkeypatch):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    backend.workspace_apply({
+        "operation": "write",
+        "path": "outer/inner/report.txt",
+        "content": "report",
+    })
+    backend.workspace_apply({
+        "operation": "write",
+        "path": "outer/sibling.txt",
+        "content": "private",
+    })
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    moved = outside / "moved-outer"
+    original_open = fixture_backend.os.open
+    raced = False
+
+    def racing_open(path, flags, *args, **kwargs):
+        nonlocal raced
+        descriptor = original_open(path, flags, *args, **kwargs)
+        if path == "inner" and not raced:
+            (backend.work / "outer").rename(moved)
+            raced = True
+        return descriptor
+
+    monkeypatch.setattr(fixture_backend.os, "open", racing_open)
+
+    with pytest.raises(ValueError, match="moved outside"):
+        backend.workspace_apply({
+            "operation": "read", "path": "outer/inner/report.txt"
+        })
+
+    assert list(moved.iterdir()) == []
+
+
+def test_fixture_snapshot_nested_move_purges_detached_ancestor(
+    tmp_path, monkeypatch
+):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    backend.workspace_apply({
+        "operation": "write",
+        "path": "outer/inner/report.txt",
+        "content": "report",
+    })
+    backend.workspace_apply({
+        "operation": "write",
+        "path": "outer/sibling.txt",
+        "content": "private",
+    })
+    outside = tmp_path / "outside-snapshot"
+    outside.mkdir()
+    moved = outside / "moved-outer"
+    original_open = fixture_backend.os.open
+    raced = False
+
+    def racing_open(path, flags, *args, **kwargs):
+        nonlocal raced
+        descriptor = original_open(path, flags, *args, **kwargs)
+        if path == "inner" and not raced:
+            (backend.work / "outer").rename(moved)
+            raced = True
+        return descriptor
+
+    monkeypatch.setattr(fixture_backend.os, "open", racing_open)
+
+    with pytest.raises(ValueError, match="moved outside"):
+        backend.state_sha256()
+
+    assert list(moved.iterdir()) == []
+    backend.close()
+    assert list(moved.iterdir()) == []
+
+
+def test_fixture_close_purges_pinned_root_after_lexical_move(tmp_path):
+    backend = _backend(tmp_path)
+    backend.workspace_apply({
+        "operation": "write", "path": "report.txt", "content": "private"
+    })
+    moved = tmp_path / "moved-work"
+    backend.work.rename(moved)
+
+    backend.close()
+
+    assert backend.closed is True
+    assert moved.is_dir()
+    assert list(moved.iterdir()) == []
+
+
+def test_fixture_workspace_byte_limit_is_fail_closed(tmp_path, monkeypatch):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    monkeypatch.setattr(fixture_backend, "_MAX_WORKSPACE_BYTES", 4)
+
+    with pytest.raises(ValueError, match="byte limit"):
+        backend.workspace_apply({
+            "operation": "write",
+            "path": "report.txt",
+            "content": "12345",
+        })
+
+
+def test_fixture_overwrite_reserves_peak_temporary_bytes(tmp_path, monkeypatch):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    monkeypatch.setattr(fixture_backend, "_MAX_WORKSPACE_BYTES", 6)
+    backend.workspace_apply({
+        "operation": "write", "path": "report.txt", "content": "1234"
+    })
+    backend.workspace_apply({
+        "operation": "write", "path": "report.txt", "content": "12"
+    })
+    backend.workspace_apply({
+        "operation": "write", "path": "report.txt", "content": "1234"
+    })
+    before = backend.state_sha256()
+
+    with pytest.raises(ValueError, match="byte limit"):
+        backend.workspace_apply({
+            "operation": "write", "path": "report.txt", "content": "123"
+        })
+
+    assert backend.state_sha256() == before
+    assert backend.workspace_apply({
+        "operation": "read", "path": "report.txt"
+    })["data"]["content"] == "1234"
+    assert not any(path.name.endswith(".tmp") for path in backend.work.iterdir())
+
+
+def test_fixture_individual_file_limit_rejects_without_mutation(
+    tmp_path, monkeypatch
+):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    monkeypatch.setattr(fixture_backend, "_MAX_FILE_BYTES", 4)
+    before = backend.state_sha256()
+
+    with pytest.raises(ValueError, match="write exceeds byte limit"):
+        backend.workspace_apply({
+            "operation": "write", "path": "report.txt", "content": "12345"
+        })
+
+    assert backend.state_sha256() == before
+    assert list(backend.work.iterdir()) == []
+
+
+def test_fixture_final_byte_limit_rejects_without_terminal_mutation(
+    tmp_path, monkeypatch
+):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    backend.workspace_apply({
+        "operation": "write", "path": "one.txt", "content": "12"
+    })
+    backend.workspace_apply({
+        "operation": "write", "path": "two.txt", "content": "34"
+    })
+    monkeypatch.setattr(fixture_backend, "_MAX_FINAL_BYTES", 3)
+    before = backend.state_sha256()
+
+    result = backend.finalize({
+        "deliverables": ["one.txt", "two.txt"], "summary": "done"
+    })
+
+    assert result == {"ok": False, "error_type": "artifact_not_openable"}
+    assert backend.best_result() is None
+    assert backend.state_sha256() == before
+
+
+def test_fixture_workspace_entry_limit_rejects_n_plus_one_without_mutation(
+    tmp_path, monkeypatch
+):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    monkeypatch.setattr(fixture_backend, "_MAX_WORKSPACE_ENTRIES", 1)
+    backend.workspace_apply({
+        "operation": "write", "path": "first.txt", "content": "1"
+    })
+    before = backend.state_sha256()
+
+    with pytest.raises(ValueError, match="entry limit"):
+        backend.workspace_apply({
+            "operation": "write", "path": "second.txt", "content": "2"
+        })
+
+    assert backend.state_sha256() == before
+    assert sorted(path.name for path in backend.work.iterdir()) == ["first.txt"]
+
+
+def test_fixture_temporary_collision_retries_without_deleting_existing_file(
+    tmp_path, monkeypatch
+):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    collision = backend.work / ".agentic-v2-aaaaaaaaaaaaaaaa.tmp"
+    collision.write_text("preserve", encoding="utf-8")
+    tokens = iter(["a" * 16, "b" * 16])
+    monkeypatch.setattr(
+        fixture_backend.secrets,
+        "token_hex",
+        lambda _size: next(tokens),
+    )
+
+    backend.workspace_apply({
+        "operation": "write", "path": "report.txt", "content": "done"
+    })
+
+    assert collision.read_text(encoding="utf-8") == "preserve"
+    assert (backend.work / "report.txt").read_text(encoding="utf-8") == "done"
+
+
+def test_fixture_temporary_collision_failure_preserves_state(
+    tmp_path, monkeypatch
+):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    collision = backend.work / ".agentic-v2-aaaaaaaaaaaaaaaa.tmp"
+    collision.write_text("preserve", encoding="utf-8")
+    monkeypatch.setattr(
+        fixture_backend.secrets,
+        "token_hex",
+        lambda _size: "a" * 16,
+    )
+    before = backend.state_sha256()
+
+    with pytest.raises(ValueError, match="temporary file allocation failed"):
+        backend.workspace_apply({
+            "operation": "write", "path": "report.txt", "content": "done"
+        })
+
+    assert backend.state_sha256() == before
+    assert collision.read_text(encoding="utf-8") == "preserve"
+    assert not (backend.work / "report.txt").exists()
+
+
+def test_virtual_root_mkdir_reservation_is_noop_at_entry_limit():
+    ledger = {
+        "directories": {".", *{f"dir-{index}" for index in range(4096)}},
+        "files": {},
+    }
+
+    assert agentic_v2_provenance._virtual_reserve_entries(
+        ledger, ".", temporary_leaf=False
+    ) is None
+
+
+def test_fixture_directory_entry_limit_rejects_n_plus_one_without_mutation(
+    tmp_path, monkeypatch
+):
+    import core.agentic_v2_fixture_backend as fixture_backend
+
+    backend = _backend(tmp_path)
+    monkeypatch.setattr(fixture_backend, "_MAX_DIRECTORY_ENTRIES", 1)
+    backend.workspace_apply({
+        "operation": "write", "path": "first.txt", "content": "1"
+    })
+    before = backend.state_sha256()
+
+    with pytest.raises(ValueError, match="directory entry limit"):
+        backend.workspace_apply({
+            "operation": "write", "path": "second.txt", "content": "2"
+        })
+
+    assert backend.state_sha256() == before
+
+
+def test_dispatcher_forbids_every_tool_after_finalize(tmp_path):
+    backend = _backend(tmp_path)
+    (backend.work / "report.txt").write_text("done", encoding="utf-8")
+    lifecycle = AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    dispatcher = AgenticV2ToolDispatcher(backend, lifecycle)
+
+    finalized = dispatcher.dispatch(
+        call_id="final-1",
+        name="finalize",
+        arguments={"deliverables": ["report.txt"], "summary": "done"},
+    )
+    rejected = dispatcher.dispatch(
+        call_id="read-after-final",
+        name="capabilities_query",
+        arguments={"kind": "commands"},
+    )
+
+    assert finalized.finalized is True
+    assert lifecycle.state is LifecycleState.FINALIZED
+    assert rejected.result["error_type"] == "tool_not_allowed_in_state"
+
+
+def test_dispatcher_replays_finalize_after_terminal_state(tmp_path):
+    backend = _backend(tmp_path)
+    (backend.work / "report.txt").write_text("done", encoding="utf-8")
+    dispatcher = AgenticV2ToolDispatcher(
+        backend, AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    )
+    arguments = {"deliverables": ["report.txt"], "summary": "done"}
+
+    finalized = dispatcher.dispatch(
+        call_id="final-1", name="finalize", arguments=arguments
+    )
+    replay = dispatcher.dispatch(
+        call_id="final-1", name="finalize", arguments=arguments
+    )
+
+    assert finalized.finalized is True
+    assert replay.finalized is True
+    assert replay.replayed is True
+    assert replay.result == finalized.result
+    assert dispatcher.total_calls == 1
+
+
+def test_finalize_envelope_failure_transitions_to_failed(tmp_path):
+    backend = _backend(tmp_path)
+    (backend.work / "report.txt").write_text("done", encoding="utf-8")
+    lifecycle = AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    dispatcher = AgenticV2ToolDispatcher(
+        backend, lifecycle, max_result_bytes=64
+    )
+
+    result = dispatcher.dispatch(
+        call_id="final-1",
+        name="finalize",
+        arguments={"deliverables": ["report.txt"], "summary": "done"},
+    )
+
+    assert result.finalized is False
+    assert result.result["error_type"] == "tool_result_too_large"
+    assert result.result["request_sha256"] is not None
+    assert result.result["usage_delta"]["tool_calls"] == 1
+    assert result.result["usage_delta"]["output_bytes"] == 2
+    assert result.result["state_before_sha256"] is not None
+    assert result.result["state_after_sha256"] is not None
+    assert lifecycle.state is LifecycleState.FAILED
+
+
+def test_large_read_produces_verifiable_oversized_failure_trace(tmp_path):
+    content = "x" * 70000
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "large.txt",
+                    "content": content,
+                },
+            },
+            {
+                "call_id": "read-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "read",
+                    "path": "large.txt",
+                    "limit": len(content),
+                },
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    envelope = result["agentic_v2"]["private_audit"]["events"][2][
+        "payload"
+    ]["result"]
+
+    assert result["success"] is False
+    assert result["error"] == "tool_result_too_large"
+    assert envelope["error_type"] == "tool_result_too_large"
+    assert envelope["data"] == {}
+    assert envelope["usage_delta"]["tool_calls"] == 1
+    assert envelope["usage_delta"]["output_bytes"] == 2
+    verify_agentic_v2_failure_result(result)
+
+
+def test_trace_pair_rejects_oversized_wrapper_rewritten_as_success(tmp_path):
+    content = "x" * 70000
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "large.txt",
+                    "content": content,
+                },
+            },
+            {
+                "call_id": "read-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "read",
+                    "path": "large.txt",
+                    "limit": len(content),
+                },
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    metadata = deepcopy(result["agentic_v2"])
+    data = {
+        "content": content,
+        "content_sha256": __import__("hashlib").sha256(
+            content.encode("utf-8")
+        ).hexdigest(),
+    }
+    _forge_success_event(
+        metadata,
+        2,
+        call_id="read-1",
+        tool_name="workspace_apply",
+        arguments={
+            "operation": "read",
+            "path": "large.txt",
+            "limit": len(content),
+        },
+        data=data,
+    )
+    _sync_failure_event(
+        metadata,
+        error_type="finalize_not_called",
+        lifecycle_state="failed",
+    )
+
+    with pytest.raises(ValueError, match="fixture tool result mismatch"):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+def test_trace_pair_rejects_first_call_false_budget_exhaustion(tmp_path):
+    result = _single_capability_run(tmp_path)
+    metadata = deepcopy(result["agentic_v2"])
+    envelope = metadata["private_audit"]["events"][1]["payload"]["result"]
+    metadata["private_audit"]["events"][1]["payload"]["replayed"] = False
+    metadata["private_audit"]["events"][1]["payload"]["result"] = (
+        _unexecuted_error_from(envelope, "tool_budget_exhausted")
+    )
+    _sync_trace_pair_event(metadata, 1)
+    _sync_failure_event(
+        metadata,
+        error_type="tool_budget_exhausted",
+        lifecycle_state="failed",
+    )
+
+    with pytest.raises(ValueError, match="tool budget state mismatch"):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+def test_trace_pair_rejects_tool_after_exact_error(tmp_path):
+    result = _successful_result(tmp_path)
+    metadata = deepcopy(result["agentic_v2"])
+    event = metadata["private_audit"]["events"][1]
+    event["payload"]["request"] = {
+        "call_id": "write-1",
+        "name": "browser_run",
+        "arguments": {"operation": "search", "query": "offline"},
+    }
+    envelope = event["payload"]["result"]
+    envelope.update({
+        "tool_name": "browser_run",
+        "request_sha256": canonical_sha256({
+            "tool_contract_version": "2.0",
+            "call_id": "write-1",
+            "name": "browser_run",
+            "arguments": {"operation": "search", "query": "offline"},
+        }),
+        "ok": False,
+        "error_type": "capability_unavailable",
+        "data": {},
+        "usage_delta": {"tool_calls": 1, "wall_ms": 0, "output_bytes": 2},
+    })
+    envelope["state_after_sha256"] = envelope["state_before_sha256"]
+    event["state_sha256"] = envelope["state_after_sha256"]
+    _rehash_result(envelope)
+    _sync_trace_pair_event(metadata, 1)
+
+    with pytest.raises(ValueError, match="tool event follows terminal result"):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+def test_trace_pair_rejects_tool_after_successful_finalize(tmp_path):
+    result = _successful_result(tmp_path)
+    metadata = deepcopy(result["agentic_v2"])
+    final_state = metadata["private_audit"]["events"][-1]["state_sha256"]
+    request = {
+        "call_id": "after-final",
+        "name": "capabilities_query",
+        "arguments": {"kind": "commands"},
+    }
+    data = {"kind": "commands", "items": ["fixture-upper"]}
+    envelope = _forged_result_envelope(
+        request,
+        data,
+        state_before=final_state,
+        state_after=final_state,
+    )
+    _append_trace_pair_tool_event(metadata, request, envelope)
+
+    with pytest.raises(ValueError, match="tool event follows terminal result"):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+def test_trace_pair_rejects_failure_lifecycle_mismatch(tmp_path):
+    result = _single_capability_run(tmp_path)
+    metadata = deepcopy(result["agentic_v2"])
+    _sync_failure_event(
+        metadata,
+        error_type="cancelled",
+        lifecycle_state="failed",
+        stage="control",
+    )
+
+    with pytest.raises(ValueError, match="failure lifecycle mismatch"):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+def test_failed_finalize_returns_to_active_before_retry(tmp_path):
+    backend = _backend(tmp_path)
+    lifecycle = AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    dispatcher = AgenticV2ToolDispatcher(backend, lifecycle)
+
+    failed = dispatcher.dispatch(
+        call_id="final-missing",
+        name="finalize",
+        arguments={"deliverables": ["report.txt"], "summary": "done"},
+    )
+
+    assert failed.result["error_type"] == "artifact_not_openable"
+    assert lifecycle.state is LifecycleState.ACTIVE
+    written = dispatcher.dispatch(
+        call_id="write-1",
+        name="workspace_apply",
+        arguments={
+            "operation": "write",
+            "path": "report.txt",
+            "content": "done",
+        },
+    )
+    finalized = dispatcher.dispatch(
+        call_id="final-valid",
+        name="finalize",
+        arguments={"deliverables": ["report.txt"], "summary": "done"},
+    )
+    assert written.result["ok"] is True
+    assert finalized.finalized is True
+    assert lifecycle.state is LifecycleState.FINALIZED
+
+
+def test_finalize_rejects_terminal_bytes_that_do_not_match_artifacts(tmp_path):
+    class MismatchedTerminalBackend(AgenticV2FixtureBackend):
+        def best_result(self):
+            result = dict(super().best_result())
+            result["files"] = [{"filename": "report.txt", "content": b"tampered"}]
+            return result
+
+    backend = MismatchedTerminalBackend(
+        root=tmp_path,
+        profile=AgenticV2Profile.from_mapping(PROFILE),
+    )
+    backend.workspace_apply({
+        "operation": "write", "path": "report.txt", "content": "done"
+    })
+    lifecycle = AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    result = AgenticV2ToolDispatcher(backend, lifecycle).dispatch(
+        call_id="final-1",
+        name="finalize",
+        arguments={"deliverables": ["report.txt"], "summary": "done"},
+    )
+
+    assert result.finalized is False
+    assert result.terminal_result is None
+    assert result.result["error_type"] == "finalize_result_mismatch"
+    assert lifecycle.state is LifecycleState.FAILED
+
+
+def test_finalize_commit_followed_by_deadline_failure_is_terminal(tmp_path):
+    clock = _ManualClock()
+
+    class SlowFinalizeBackend(AgenticV2FixtureBackend):
+        def finalize(self, arguments):
+            result = super().finalize(arguments)
+            clock.advance(2)
+            return result
+
+    backend = SlowFinalizeBackend(
+        root=tmp_path,
+        profile=AgenticV2Profile.from_mapping(PROFILE),
+    )
+    backend.workspace_apply({
+        "operation": "write", "path": "report.txt", "content": "done"
+    })
+    lifecycle = AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    result = AgenticV2ToolDispatcher(
+        backend,
+        lifecycle,
+        deadline=1,
+        clock=clock,
+    ).dispatch(
+        call_id="final-1",
+        name="finalize",
+        arguments={"deliverables": ["report.txt"], "summary": "done"},
+    )
+
+    assert result.finalized is False
+    assert result.terminal_result is None
+    assert result.result["error_type"] == "task_wall_time_exhausted"
+    assert lifecycle.state is LifecycleState.FAILED
+
+
+def test_scripted_runner_completes_deterministically(tmp_path):
+    calls = [
+        {
+            "call_id": "write-1",
+            "name": "workspace_apply",
+            "arguments": {
+                "operation": "write",
+                "path": "draft.txt",
+                "content": "hello",
+            },
+        },
+        {
+            "call_id": "exec-1",
+            "name": "exec_run",
+            "arguments": {
+                "argv": ["fixture-upper", "draft.txt", "report.txt"],
+                "cwd": ".",
+                "timeout_seconds": 30,
+            },
+        },
+        {
+            "call_id": "verify-1",
+            "name": "verify_public",
+            "arguments": {"deliverables": ["report.txt"]},
+        },
+        {
+            "call_id": "final-1",
+            "name": "finalize",
+            "arguments": {"deliverables": ["report.txt"], "summary": "done"},
+        },
+    ]
+    backends = []
+
+    def factory(**kwargs):
+        backend = AgenticV2FixtureBackend(root=tmp_path, **kwargs)
+        backends.append(backend)
+        return backend
+
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=factory,
+        scripted_calls=calls,
+        profile=PROFILE,
+    )
+
+    result = runner.run("Create report", task_id="task-1")
+
+    assert result["success"] is True
+    assert result["files"][0]["content"] == b"HELLO"
+    assert result["agentic_v2"]["schema_version"] == "2.0"
+    assert result["agentic_v2"]["foundation_only"] is True
+    for classification, key in (
+        ("private", "private_audit"),
+        ("public_redacted", "public_trace"),
+    ):
+        trace = result["agentic_v2"][key]
+        assert trace["classification"] == classification
+        assert len(trace["events"]) == 5
+        assert all(
+            not list(Draft202012Validator(EVENT_SCHEMA).iter_errors(event))
+            for event in trace["events"]
+        )
+        verify_event_chain(
+            trace["events"], trace["event_chain_head_sha256"]
+        )
+    verify_trace_pair(
+        result["agentic_v2"]["private_audit"],
+        result["agentic_v2"]["public_trace"],
+        result["agentic_v2"]["trace_pair_sha256"],
+    )
+    assert backends[0].closed is True
+
+
+def test_scripted_runner_public_trace_redacts_request_and_result_content(tmp_path):
+    secret = "private-workspace-content"
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": secret,
+                },
+            },
+            {
+                "call_id": "read-1",
+                "name": "workspace_apply",
+                "arguments": {"operation": "read", "path": "report.txt"},
+            },
+            {
+                "call_id": "final-1",
+                "name": "finalize",
+                "arguments": {
+                    "deliverables": ["report.txt"],
+                    "summary": "done",
+                },
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+
+    assert secret not in str(result["agentic_v2"]["public_trace"])
+    assert secret in str(result["agentic_v2"]["private_audit"])
+
+
+def test_scripted_runner_rejects_advertised_capability_mismatch(tmp_path):
+    class CapabilityMismatchBackend(AgenticV2FixtureBackend):
+        def start(self, timeout_seconds):
+            result = dict(super().start(timeout_seconds))
+            result["data"] = deepcopy(result["data"])
+            result["data"]["capabilities"]["commands"] = ["unexpected"]
+            return result
+
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: CapabilityMismatchBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "compute_start_failed"
+
+
+def test_runtime_identity_is_sensitive_to_backend_and_capabilities():
+    implementation = foundation_implementation_fingerprint()
+    common = {
+        "policy_profile_id": "offline-full-v1",
+        "substrate_manifest_sha256": "1" * 64,
+        "package_snapshot_sha256": "2" * 64,
+        "browser_build_sha256": "3" * 64,
+        "budget_caps": {"tool_calls": 32, "wall_seconds": 1200},
+    }
+    first = runtime_fingerprint(
+        **common,
+        backend_implementation_sha256=implementation,
+        capabilities_sha256="4" * 64,
+    )
+    changed_backend = runtime_fingerprint(
+        **common,
+        backend_implementation_sha256="5" * 64,
+        capabilities_sha256="4" * 64,
+    )
+    changed_capabilities = runtime_fingerprint(
+        **common,
+        backend_implementation_sha256=implementation,
+        capabilities_sha256="6" * 64,
+    )
+
+    assert len({first, changed_backend, changed_capabilities}) == 3
+
+
+def test_scripted_runner_two_cold_runs_have_same_public_identity(tmp_path):
+    calls = [
+        {
+            "call_id": "write-1",
+            "name": "workspace_apply",
+            "arguments": {
+                "operation": "write",
+                "path": "report.txt",
+                "content": "deterministic",
+            },
+        },
+        {
+            "call_id": "final-1",
+            "name": "finalize",
+            "arguments": {"deliverables": ["report.txt"], "summary": "done"},
+        },
+    ]
+
+    def run(root):
+        runner = AgenticV2ScriptedRunner(
+            backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+                root=root, **kwargs
+            ),
+            scripted_calls=calls,
+            profile=PROFILE,
+            clock=lambda: 0.0,
+        )
+        return runner.run("Create report", task_id="task-1")
+
+    first = run(tmp_path / "first")
+    second = run(tmp_path / "second")
+
+    assert first["agentic_v2"]["runtime_fingerprint"] == second["agentic_v2"]["runtime_fingerprint"]
+    assert first["agentic_v2"]["private_audit"][
+        "event_chain_head_sha256"
+    ] == second["agentic_v2"]["private_audit"]["event_chain_head_sha256"]
+    assert first["agentic_v2"]["public_trace"][
+        "event_chain_head_sha256"
+    ] == second["agentic_v2"]["public_trace"]["event_chain_head_sha256"]
+    assert first["files"] == second["files"]
+
+
+def test_event_chain_detects_tool_result_tampering(tmp_path):
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "done",
+                },
+            },
+            {
+                "call_id": "final-1",
+                "name": "finalize",
+                "arguments": {"deliverables": ["report.txt"], "summary": "done"},
+            },
+        ],
+        profile=PROFILE,
+    )
+    result = runner.run("task", task_id="task-1")
+    trace = result["agentic_v2"]["private_audit"]
+    events = deepcopy(trace["events"])
+    events[1]["payload"]["result"]["usage_delta"]["wall_ms"] += 1
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="tool result hash mismatch"):
+        verify_event_chain(events, head)
+
+
+def test_event_chain_detects_tool_request_tampering(tmp_path):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "original",
+                },
+            },
+            {
+                "call_id": "final-1",
+                "name": "finalize",
+                "arguments": {
+                    "deliverables": ["report.txt"],
+                    "summary": "done",
+                },
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    events[1]["payload"]["request"]["arguments"]["content"] = "tampered"
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="tool request hash mismatch"):
+        verify_event_chain(events, head)
+
+
+def test_trace_pair_detects_rehashed_public_commitment_tampering(tmp_path):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "done",
+                },
+            },
+            {
+                "call_id": "final-1",
+                "name": "finalize",
+                "arguments": {
+                    "deliverables": ["report.txt"],
+                    "summary": "done",
+                },
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    private_trace = result["agentic_v2"]["private_audit"]
+    public_trace = deepcopy(result["agentic_v2"]["public_trace"])
+    public_trace["events"][1]["payload"]["result_commitment"]["ok"] = False
+    public_trace["event_chain_head_sha256"] = _rehash_events(
+        public_trace["events"]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="trace pair commitment mismatch|tool event follows terminal result",
+    ):
+        verify_trace_pair(
+            private_trace,
+            public_trace,
+            result["agentic_v2"]["trace_pair_sha256"],
+        )
+
+
+def test_event_chain_rejects_unknown_rehashed_kind(tmp_path):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "cap-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "commands"},
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    events[1]["kind"] = "unknown"
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="event kind is invalid"):
+        verify_event_chain(events, head)
+
+
+def test_event_chain_rejects_first_call_replay_after_rehash(tmp_path):
+    result = _single_capability_run(tmp_path)
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    events[1]["payload"]["replayed"] = True
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="replay history mismatch"):
+        verify_event_chain(events, head)
+
+
+def test_event_chain_rejects_cleared_replay_bit_after_rehash(tmp_path):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "cap-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "commands"},
+            },
+            {
+                "call_id": "cap-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "commands"},
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    events[2]["payload"]["replayed"] = False
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="replay history mismatch"):
+        verify_event_chain(events, head)
+
+
+def test_event_chain_rejects_forged_conflict_for_exact_replay(tmp_path):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "cap-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "commands"},
+            },
+            {
+                "call_id": "cap-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "commands"},
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    replay = events[2]["payload"]
+    replay["replayed"] = False
+    replay["result"] = _unexecuted_error_from(
+        replay["result"], "call_id_conflict"
+    )
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="replay history mismatch"):
+        verify_event_chain(events, head)
+
+
+def test_event_chain_rejects_wrong_conflict_for_changed_request(tmp_path):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "cap-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "commands"},
+            },
+            {
+                "call_id": "cap-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "runtimes"},
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    conflict = events[2]["payload"]["result"]
+    conflict["error_type"] = "invalid_result_envelope"
+    conflict.pop("result_sha256")
+    conflict["result_sha256"] = canonical_sha256(conflict)
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="replay history mismatch"):
+        verify_event_chain(events, head)
+
+
+def test_duplicate_call_state_drift_is_exact_conflict_and_verifies(tmp_path):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "cap-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "commands"},
+            },
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "changed",
+                },
+            },
+            {
+                "call_id": "cap-1",
+                "name": "capabilities_query",
+                "arguments": {"kind": "commands"},
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    trace = result["agentic_v2"]["private_audit"]
+
+    assert trace["events"][3]["payload"]["result"]["error_type"] == (
+        "call_id_conflict"
+    )
+    verify_event_chain(trace["events"], trace["event_chain_head_sha256"])
+
+
+def test_event_chain_rejects_invalid_request_success_after_rehash(tmp_path):
+    result = _single_capability_run(tmp_path)
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    event = events[1]
+    event["payload"]["request"]["arguments"] = {"kind": "invalid"}
+    envelope = event["payload"]["result"]
+    envelope["request_sha256"] = None
+    envelope.pop("result_sha256")
+    envelope["result_sha256"] = canonical_sha256(envelope)
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="invalid request result mismatch"):
+        verify_event_chain(events, head)
+
+
+@pytest.mark.parametrize(
+    "tool_request",
+    [
+        {
+            "call_id": "bad call",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        },
+        {"call_id": "call-1", "name": "unknown", "arguments": {}},
+        {
+            "call_id": "call-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "invalid"},
+        },
+    ],
+)
+def test_event_chain_rejects_wrong_invalid_request_error_class(
+    tmp_path, tool_request
+):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[tool_request],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    envelope = events[1]["payload"]["result"]
+    envelope["error_type"] = "tool_budget_exhausted"
+    envelope.pop("result_sha256")
+    envelope["result_sha256"] = canonical_sha256(envelope)
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="invalid request result mismatch"):
+        verify_event_chain(events, head)
+
+
+@pytest.mark.parametrize("mutation", ["backend", "profile", "capability"])
+def test_event_chain_rejects_started_identity_tampering(tmp_path, mutation):
+    result = _single_capability_run(tmp_path)
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    started = events[0]["payload"]
+    if mutation == "backend":
+        started["backend_identity"]["backend_id"] = "alternate"
+    elif mutation == "profile":
+        started["policy_profile_id"] = "unknown"
+    else:
+        started["capabilities"]["commands"] = ["unexpected"]
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="started event is invalid"):
+        verify_event_chain(events, head)
+
+
+def test_success_metadata_recomputes_runtime_identity(tmp_path):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "done",
+                },
+            },
+            {
+                "call_id": "final-1",
+                "name": "finalize",
+                "arguments": {
+                    "deliverables": ["report.txt"],
+                    "summary": "done",
+                },
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    metadata = result["agentic_v2"]
+
+    verify_agentic_v2_metadata(metadata)
+    verify_agentic_v2_result(result)
+    tampered = deepcopy(metadata)
+    tampered["runtime_fingerprint"] = "f" * 64
+    with pytest.raises(ValueError, match="runtime fingerprint mismatch"):
+        verify_agentic_v2_metadata(tampered)
+
+
+@pytest.mark.parametrize("mutation", ["substrate", "package_snapshot", "packages"])
+def test_metadata_rejects_fully_rehashed_fixture_identity_tampering(
+    tmp_path, mutation
+):
+    result = _successful_result(tmp_path)
+    metadata = deepcopy(result["agentic_v2"])
+    for trace_name in ("private_audit", "public_trace"):
+        started = metadata[trace_name]["events"][0]["payload"]
+        if mutation == "substrate":
+            started["runtime"]["substrate_manifest_sha256"] = "f" * 64
+        elif mutation == "package_snapshot":
+            started["runtime"]["package_snapshot_sha256"] = "e" * 64
+        else:
+            started["capabilities"]["packages"] = ["python:other==1.0"]
+        metadata[trace_name]["event_chain_head_sha256"] = _rehash_events(
+            metadata[trace_name]["events"]
+        )
+    started = metadata["private_audit"]["events"][0]["payload"]
+    metadata["capabilities_sha256"] = canonical_sha256(
+        started["capabilities"]
+    )
+    runtime = started["runtime"]
+    metadata["runtime_fingerprint"] = runtime_fingerprint(
+        policy_profile_id=started["policy_profile_id"],
+        substrate_manifest_sha256=runtime["substrate_manifest_sha256"],
+        package_snapshot_sha256=runtime["package_snapshot_sha256"],
+        browser_build_sha256=runtime["browser_build_sha256"],
+        backend_implementation_sha256=started["backend_identity"][
+            "implementation_sha256"
+        ],
+        capabilities_sha256=metadata["capabilities_sha256"],
+        budget_caps=runtime["budget_caps"],
+    )
+    metadata["trace_pair_sha256"] = trace_pair_fingerprint(
+        metadata["private_audit"], metadata["public_trace"]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="started event is invalid|canonical fixture identity mismatch",
+    ):
+        verify_agentic_v2_metadata(metadata)
+
+
+def test_event_chain_rejects_forged_capability_inventory(tmp_path):
+    result = _single_capability_run(tmp_path)
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    envelope = events[1]["payload"]["result"]
+    envelope["data"]["items"] = ["unexpected"]
+    _rehash_result(envelope)
+    head = _rehash_events(events)
+
+    with pytest.raises(
+        ValueError,
+        match="capability inventory mismatch|fixture tool result mismatch",
+    ):
+        verify_event_chain(events, head)
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "data"),
+    [
+        (
+            "browser_run",
+            {"operation": "search", "query": "must remain offline"},
+            {"path": "forged.txt", "sha256": "f" * 64},
+        ),
+        (
+            "exec_run",
+            {
+                "argv": ["unadvertised-command"],
+                "cwd": ".",
+                "timeout_seconds": 30,
+            },
+            {"returncode": 0},
+        ),
+    ],
+)
+def test_trace_pair_rejects_fully_rehashed_impossible_tool_success(
+    tmp_path, tool_name, arguments, data
+):
+    result = _single_capability_run(tmp_path)
+    metadata = deepcopy(result["agentic_v2"])
+    event = metadata["private_audit"]["events"][1]
+    event["payload"]["request"] = {
+        "call_id": "cap-1",
+        "name": tool_name,
+        "arguments": arguments,
+    }
+    envelope = event["payload"]["result"]
+    envelope.update({
+        "tool_name": tool_name,
+        "request_sha256": canonical_sha256({
+            "tool_contract_version": "2.0",
+            "call_id": "cap-1",
+            "name": tool_name,
+            "arguments": arguments,
+        }),
+        "ok": True,
+        "error_type": None,
+        "data": data,
+    })
+    _rehash_result(envelope)
+    _sync_trace_pair_event(metadata, 1)
+
+    with pytest.raises(ValueError, match="fixture tool result mismatch"):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+def test_trace_pair_rejects_fully_rehashed_forged_verification_artifact(
+    tmp_path
+):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "done",
+                },
+            },
+            {
+                "call_id": "verify-1",
+                "name": "verify_public",
+                "arguments": {"deliverables": ["report.txt"]},
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    metadata = deepcopy(result["agentic_v2"])
+    envelope = metadata["private_audit"]["events"][2]["payload"]["result"]
+    envelope["data"]["artifacts"][0].update({
+        "sha256": "f" * 64,
+        "size": 999,
+    })
+    _rehash_result(envelope)
+    _sync_trace_pair_event(metadata, 2)
+
+    with pytest.raises(ValueError, match="fixture tool result mismatch"):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+@pytest.mark.parametrize(
+    ("prefix_calls", "tool_name", "arguments", "data"),
+    [
+        (
+            [],
+            "workspace_apply",
+            {"operation": "delete", "path": "."},
+            {"path": "."},
+        ),
+        (
+            [{
+                "call_id": "mkdir-1",
+                "name": "workspace_apply",
+                "arguments": {"operation": "mkdir", "path": "target"},
+            }],
+            "workspace_apply",
+            {"operation": "write", "path": "target", "content": "forged"},
+            {"path": "target"},
+        ),
+        (
+            [
+                {
+                    "call_id": "write-1",
+                    "name": "workspace_apply",
+                    "arguments": {
+                        "operation": "write",
+                        "path": "source.txt",
+                        "content": "source",
+                    },
+                },
+                {
+                    "call_id": "mkdir-1",
+                    "name": "workspace_apply",
+                    "arguments": {"operation": "mkdir", "path": "target"},
+                },
+            ],
+            "workspace_apply",
+            {
+                "operation": "copy",
+                "source": "source.txt",
+                "destination": "target",
+            },
+            {"path": "target"},
+        ),
+        (
+            [
+                {
+                    "call_id": "write-1",
+                    "name": "workspace_apply",
+                    "arguments": {
+                        "operation": "write",
+                        "path": "source.txt",
+                        "content": "source",
+                    },
+                },
+                {
+                    "call_id": "mkdir-1",
+                    "name": "workspace_apply",
+                    "arguments": {"operation": "mkdir", "path": "target"},
+                },
+            ],
+            "exec_run",
+            {
+                "argv": ["fixture-upper", "source.txt", "target"],
+                "cwd": ".",
+                "timeout_seconds": 30,
+            },
+            {"returncode": 0},
+        ),
+    ],
+)
+def test_trace_pair_rejects_fully_rehashed_impossible_workspace_success(
+    tmp_path, prefix_calls, tool_name, arguments, data
+):
+    calls = [
+        *prefix_calls,
+        {
+            "call_id": "probe-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        },
+    ]
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=calls,
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    metadata = deepcopy(result["agentic_v2"])
+    event_index = len(prefix_calls) + 1
+
+    _forge_success_event(
+        metadata,
+        event_index,
+        call_id="probe-1",
+        tool_name=tool_name,
+        arguments=arguments,
+        data=data,
+    )
+
+    with pytest.raises(ValueError, match="fixture tool result mismatch"):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+@pytest.mark.parametrize("usage_field", ["output_bytes", "wall_ms"])
+def test_trace_pair_rejects_fully_rehashed_usage_tampering(
+    tmp_path, usage_field
+):
+    result = _single_capability_run(tmp_path)
+    metadata = deepcopy(result["agentic_v2"])
+    envelope = metadata["private_audit"]["events"][1]["payload"]["result"]
+    envelope["usage_delta"][usage_field] += 1
+    _rehash_result(envelope)
+    _sync_trace_pair_event(metadata, 1)
+
+    with pytest.raises(
+        ValueError,
+        match="result usage mismatch|fixture tool result mismatch",
+    ):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+@pytest.mark.parametrize(
+    "wrapper_error",
+    [
+        "tool_result_too_large",
+        "invalid_result_envelope",
+        "finalize_result_mismatch",
+        "task_wall_time_exhausted",
+    ],
+)
+def test_trace_pair_rejects_fully_rehashed_false_wrapper_error(
+    tmp_path, wrapper_error
+):
+    result = _single_capability_run(tmp_path)
+    metadata = deepcopy(result["agentic_v2"])
+    envelope = metadata["private_audit"]["events"][1]["payload"]["result"]
+    envelope["ok"] = False
+    envelope["error_type"] = wrapper_error
+    envelope["data"] = {}
+    envelope["usage_delta"]["output_bytes"] = 2
+    _rehash_result(envelope)
+    _sync_trace_pair_event(metadata, 1)
+
+    with pytest.raises(ValueError, match="wrapper condition mismatch"):
+        verify_trace_pair(
+            metadata["private_audit"],
+            metadata["public_trace"],
+            metadata["trace_pair_sha256"],
+        )
+
+
+def test_isolated_fixture_two_cold_runs_have_same_trace_identity(tmp_path):
+    calls = [
+        {
+            "call_id": "write-1",
+            "name": "workspace_apply",
+            "arguments": {
+                "operation": "write",
+                "path": "report.txt",
+                "content": "deterministic",
+            },
+        },
+        {
+            "call_id": "final-1",
+            "name": "finalize",
+            "arguments": {"deliverables": ["report.txt"], "summary": "done"},
+        },
+    ]
+
+    def run(root):
+        return AgenticV2IsolatedFixtureRunner(
+            fixture_root=root,
+            scripted_calls=calls,
+            profile=PROFILE,
+        ).run("task", task_id="task-1")
+
+    first = run(tmp_path / "first")
+    second = run(tmp_path / "second")
+
+    assert first["success"] is True
+    assert second["success"] is True
+    assert first["files"] == second["files"]
+    assert first["agentic_v2"] == second["agentic_v2"]
+
+
+@pytest.mark.parametrize("filename", ["a" * 240, "é" * 120])
+def test_isolated_fixture_accepts_exact_utf8_path_boundary(tmp_path, filename):
+    result = AgenticV2IsolatedFixtureRunner(
+        fixture_root=tmp_path,
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": filename,
+                    "content": "done",
+                },
+            },
+            {
+                "call_id": "final-1",
+                "name": "finalize",
+                "arguments": {"deliverables": [filename], "summary": "done"},
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+
+    assert result["success"] is True
+    assert result["files"] == [{"filename": filename, "content": b"done"}]
+    verify_agentic_v2_result(result)
+
+
+@pytest.mark.parametrize(
+    "destination",
+    ["bad\x00name", "bad\u0085name", "x" * 241],
+)
+def test_isolated_fixture_rejects_noncanonical_exec_destination(
+    tmp_path, destination
+):
+    result = AgenticV2IsolatedFixtureRunner(
+        fixture_root=tmp_path,
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "source.txt",
+                    "content": "source",
+                },
+            },
+            {
+                "call_id": "exec-1",
+                "name": "exec_run",
+                "arguments": {
+                    "argv": ["fixture-upper", "source.txt", destination],
+                    "cwd": ".",
+                    "timeout_seconds": 30,
+                },
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "fixture_backend_error"
+    verify_agentic_v2_failure_result(result)
+
+
+def test_failure_verifier_rejects_rehashed_impossible_prestart_error(tmp_path):
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: (_ for _ in ()).throw(
+            RuntimeError("private construction detail")
+        ),
+        scripted_calls=[],
+        profile=PROFILE,
+    )
+    result = runner.run("task", task_id="task-1")
+    tampered = deepcopy(result)
+    tampered["error"] = "artifact_not_openable"
+    metadata = tampered["agentic_v2"]
+    _sync_failure_event(
+        metadata,
+        error_type="artifact_not_openable",
+        lifecycle_state="failed",
+        stage="runtime",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="pre-start failure stage mismatch|failure event is invalid",
+    ):
+        verify_agentic_v2_failure_result(tampered)
+
+
+def test_event_chain_rejects_forged_workspace_content_hash(tmp_path):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "original",
+                },
+            },
+            {
+                "call_id": "read-1",
+                "name": "workspace_apply",
+                "arguments": {"operation": "read", "path": "report.txt"},
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    envelope = events[2]["payload"]["result"]
+    envelope["data"]["content"] = "forged"
+    _rehash_result(envelope)
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match="result data mismatch|content hash mismatch"):
+        verify_event_chain(events, head)
+
+
+def test_event_chain_rejects_forged_package_blob(tmp_path):
+    profile = {
+        "tool_contract_version": "2.0",
+        "policy_profile_id": "package-broker-v1",
+        "foundation_only": True,
+    }
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[{
+            "call_id": "resolve-1",
+            "name": "environment_resolve",
+            "arguments": {
+                "ecosystem": "python",
+                "requirements": ["demo-pkg==1.0.0"],
+            },
+        }],
+        profile=profile,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    envelope = events[1]["payload"]["result"]
+    lock = envelope["data"]["lock"]
+    lock["blobs"] = ["f" * 64]
+    envelope["data"]["lock_digest"] = canonical_sha256(lock)
+    _rehash_result(envelope)
+    head = _rehash_events(events)
+
+    with pytest.raises(
+        ValueError,
+        match="package lock mismatch|fixture tool result mismatch",
+    ):
+        verify_event_chain(events, head)
+
+
+def test_event_chain_rejects_activation_without_prior_resolve(tmp_path):
+    profile = {
+        "tool_contract_version": "2.0",
+        "policy_profile_id": "package-broker-v1",
+        "foundation_only": True,
+    }
+    digest = canonical_sha256({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+        "blobs": ["d" * 64],
+    })
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[{
+            "call_id": "activate-1",
+            "name": "environment_activate",
+            "arguments": {"lock_digest": digest},
+        }],
+        profile=profile,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    envelope = events[1]["payload"]["result"]
+    envelope["ok"] = True
+    envelope["error_type"] = None
+    envelope["data"] = {"environment_id": digest}
+    _rehash_result(envelope)
+    head = _rehash_events(events)
+
+    with pytest.raises(
+        ValueError,
+        match="package activation mismatch|fixture tool result mismatch",
+    ):
+        verify_event_chain(events, head)
+
+
+def test_success_verifier_rejects_removed_finalize_pair(tmp_path):
+    result = _successful_result(tmp_path)
+    tampered = deepcopy(result)
+    metadata = tampered["agentic_v2"]
+    for trace_name in ("private_audit", "public_trace"):
+        metadata[trace_name]["events"].pop()
+        metadata[trace_name]["event_chain_head_sha256"] = _rehash_events(
+            metadata[trace_name]["events"]
+        )
+    metadata["trace_pair_sha256"] = trace_pair_fingerprint(
+        metadata["private_audit"], metadata["public_trace"]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="terminal finalize is missing|trace terminal state is invalid",
+    ):
+        verify_agentic_v2_result(tampered)
+
+
+def test_success_verifier_rejects_terminal_file_byte_tampering(tmp_path):
+    result = _successful_result(tmp_path)
+    tampered = deepcopy(result)
+    tampered["files"][0]["content"] = b"forged"
+
+    with pytest.raises(ValueError, match="artifact bytes mismatch"):
+        verify_agentic_v2_result(tampered)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("call_identity", "call identity mismatch"),
+        ("status", "result status mismatch"),
+        ("data", "result data mismatch"),
+        ("state", "state continuity mismatch"),
+    ],
+)
+def test_event_chain_rejects_rehashed_semantic_mismatch(
+    tmp_path, mutation, message
+):
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "done",
+                },
+            },
+            {
+                "call_id": "final-1",
+                "name": "finalize",
+                "arguments": {
+                    "deliverables": ["report.txt"],
+                    "summary": "done",
+                },
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    events = deepcopy(result["agentic_v2"]["private_audit"]["events"])
+    tool_event = events[1]
+    envelope = tool_event["payload"]["result"]
+    if mutation == "call_identity":
+        envelope["call_id"] = "other-call"
+    elif mutation == "status":
+        envelope["error_type"] = "invalid_arguments"
+    elif mutation == "data":
+        envelope["data"]["path"] = "other.txt"
+    else:
+        tool_event["state_sha256"] = "f" * 64
+    if mutation != "state":
+        envelope.pop("result_sha256")
+        envelope["result_sha256"] = canonical_sha256(envelope)
+    head = _rehash_events(events)
+
+    with pytest.raises(ValueError, match=message):
+        verify_event_chain(events, head)
+
+
+def test_backend_construction_and_startup_failures_have_verifiable_traces(
+    tmp_path
+):
+    class StartFailureBackend(AgenticV2FixtureBackend):
+        def start(self, timeout_seconds):
+            del timeout_seconds
+            raise RuntimeError("private startup detail")
+
+    runners = [
+        AgenticV2ScriptedRunner(
+            backend_factory=lambda **kwargs: (_ for _ in ()).throw(
+                RuntimeError("private construction detail")
+            ),
+            scripted_calls=[],
+            profile=PROFILE,
+        ),
+        AgenticV2ScriptedRunner(
+            backend_factory=lambda **kwargs: StartFailureBackend(
+                root=tmp_path, **kwargs
+            ),
+            scripted_calls=[],
+            profile=PROFILE,
+        ),
+    ]
+
+    for runner in runners:
+        result = runner.run("task", task_id="task-1")
+        verify_trace_pair(
+            result["agentic_v2"]["private_audit"],
+            result["agentic_v2"]["public_trace"],
+            result["agentic_v2"]["trace_pair_sha256"],
+        )
+        assert result["agentic_v2"]["private_audit"]["events"][-1][
+            "kind"
+        ] == "failure"
+
+
+def test_startup_backend_error_is_normalized_to_canonical_stage(tmp_path):
+    class RejectedStartBackend(AgenticV2FixtureBackend):
+        def start(self, timeout_seconds):
+            del timeout_seconds
+            return {"ok": False, "error_type": "artifact_not_openable"}
+
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: RejectedStartBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+    failure = result["agentic_v2"]["private_audit"]["events"][-1]
+
+    assert result["error"] == "compute_start_failed"
+    assert failure["payload"] == {
+        "error_type": "compute_start_failed",
+        "lifecycle_state": "failed",
+        "stage": "startup",
+    }
+    verify_agentic_v2_failure_result(result)
+
+
+def test_failure_stage_error_map_is_disjoint_and_complete():
+    stage_errors = agentic_v2_provenance._FAILURE_STAGE_ERRORS
+    all_errors = set()
+    for errors in stage_errors.values():
+        assert all_errors.isdisjoint(errors)
+        all_errors.update(errors)
+    assert all_errors == set(agentic_v2_provenance.ERROR_TYPES)
+
+
+def test_failure_verifier_rejects_backend_error_reclassified_as_control():
+    result = agentic_v2_runner._failure(
+        "compute_backend_error",
+        AgenticV2Lifecycle(LifecycleState.FAILED),
+        agentic_v2_provenance.AgenticV2EventChain(),
+        agentic_v2_provenance.AgenticV2EventChain(),
+        stage="backend",
+    )
+    tampered = deepcopy(result)
+    _sync_failure_event(
+        tampered["agentic_v2"],
+        error_type="compute_backend_error",
+        lifecycle_state="failed",
+        stage="control",
+    )
+
+    with pytest.raises(ValueError, match="failure event is invalid"):
+        verify_agentic_v2_failure_result(tampered)
+
+
+def test_failure_verifier_rejects_cleanup_error_reclassified_as_runtime():
+    result = agentic_v2_runner._failure(
+        "compute_cleanup_failed",
+        AgenticV2Lifecycle(LifecycleState.FAILED),
+        agentic_v2_provenance.AgenticV2EventChain(),
+        agentic_v2_provenance.AgenticV2EventChain(),
+        stage="cleanup",
+    )
+    tampered = deepcopy(result)
+    _sync_failure_event(
+        tampered["agentic_v2"],
+        error_type="compute_cleanup_failed",
+        lifecycle_state="failed",
+        stage="runtime",
+    )
+
+    with pytest.raises(ValueError, match="failure event is invalid"):
+        verify_agentic_v2_failure_result(tampered)
+
+
+def test_v2_config_requires_exact_profile_and_stays_nonpublishing():
+    config = ExperimentConfig.from_dict({
+        "experiment": {"id": "exp032_agentic_sandbox_v2_fixture", "name": "V2 fixture"},
+        "data": {"source": "fixture/gdpval", "filter": {"task_ids": ["task-1"]}},
+        "condition_a": {
+            "name": "Fixture",
+            "model": {"provider": "anthropic", "deployment": "unused-model"},
+            "prompt": {"system": "system"},
+        },
+        "output": {"publish_to_hf": False, "submit_to_evals": False},
+        "execution": {
+            "mode": "agentic_sandbox_v2",
+            "agentic_v2": PROFILE,
+        },
+    })
+
+    assert config.validate() == []
+    assert config.to_dict()["execution"]["agentic_v2"] == PROFILE
+
+    config.execution.agentic_v2 = {"tool_contract_version": "1.0"}
+    assert any("tool_contract_version" in error for error in config.validate())
+
+    config.execution.mode = "subprocess"
+    assert any("only valid" in error for error in config.validate())
+
+
+def test_v2_executor_is_explicitly_model_free_and_dispatches_fixture(tmp_path):
+    calls = [
+        {
+            "call_id": "write-1",
+            "name": "workspace_apply",
+            "arguments": {
+                "operation": "write",
+                "path": "report.txt",
+                "content": "fixture",
+            },
+        },
+        {
+            "call_id": "final-1",
+            "name": "finalize",
+            "arguments": {"deliverables": ["report.txt"], "summary": "done"},
+        },
+    ]
+
+    executor = TaskExecutor(
+        mode="agentic_sandbox_v2",
+        non_paid_test_mode=True,
+        agentic_v2_options=PROFILE,
+        agentic_v2_fixture_root=tmp_path,
+        agentic_v2_scripted_calls=calls,
+    )
+
+    result = executor.execute(
+        task_prompt="Create report",
+        model="",
+        run_id="fixture-run",
+        condition_name="condition_a",
+        task_id="task-1",
+    )
+
+    assert result["success"] is True
+    assert result["files"][0]["content"] == b"fixture"
+
+    rejected = executor.execute(
+        task_prompt="Create report",
+        model="real-model-name",
+        task_id="task-1",
+    )
+    assert rejected["success"] is False
+    assert "refuses model input" in rejected["error"]
+
+    with pytest.raises(ValueError, match="model-free only"):
+        TaskExecutor(
+            mode="agentic_sandbox_v2",
+            agentic_v2_options=PROFILE,
+            agentic_v2_fixture_root=tmp_path,
+            agentic_v2_scripted_calls=calls,
+        )
+    with pytest.raises(ValueError, match="rejects custom backend"):
+        TaskExecutor(
+            mode="agentic_sandbox_v2",
+            non_paid_test_mode=True,
+            agentic_v2_options=PROFILE,
+            agentic_v2_fixture_root=tmp_path,
+            agentic_v2_backend_factory=lambda **kwargs: object(),
+            agentic_v2_scripted_calls=calls,
+        )
+    with pytest.raises(ValueError, match="refuses credential inputs"):
+        TaskExecutor(
+            mode="agentic_sandbox_v2",
+            non_paid_test_mode=True,
+            api_key="must-not-be-consumed",
+            agentic_v2_options=PROFILE,
+            agentic_v2_fixture_root=tmp_path,
+            agentic_v2_scripted_calls=calls,
+        )
+    with pytest.raises(ValueError, match="refuses model inputs"):
+        TaskExecutor(
+            mode="agentic_sandbox_v2",
+            non_paid_test_mode=True,
+            model_name="must-not-be-consumed",
+            agentic_v2_options=PROFILE,
+            agentic_v2_fixture_root=tmp_path,
+            agentic_v2_scripted_calls=calls,
+        )
+
+
+def test_step1_preserves_v2_public_profile(tmp_path, monkeypatch):
+    config = ExperimentConfig.from_dict({
+        "experiment": {"id": "exp032_agentic_sandbox_v2_fixture", "name": "V2 fixture"},
+        "data": {"source": "fixture/gdpval", "filter": {"task_ids": ["task-1"]}},
+        "condition_a": {
+            "name": "Fixture",
+            "model": {"provider": "azure", "deployment": "test-model"},
+            "prompt": {"system": "system"},
+        },
+        "execution": {"mode": "agentic_sandbox_v2", "agentic_v2": PROFILE},
+    })
+    task = SimpleNamespace(
+        task_id="task-1",
+        sector="test",
+        occupation="Analyst",
+        prompt="Create report",
+        rubric_pretty="rubric",
+        rubric_json="{}",
+        reference_files=[],
+        reference_file_urls=[],
+        reference_file_hf_uris=[],
+    )
+    projection = source_task_projection_sha256(
+        task_id=task.task_id,
+        sector=task.sector,
+        occupation=task.occupation,
+        prompt=task.prompt,
+        rubric_pretty=task.rubric_pretty,
+        rubric_json=task.rubric_json,
+        reference_files=[],
+        reference_file_urls=[],
+        reference_file_hf_uris=[],
+    )
+
+    class Manifest:
+        def require_schema(self, version):
+            assert version == 4
+
+        def source_projection_sha256(self, task_id):
+            assert task_id == "task-1"
+            return projection
+
+        def reference_records(self, task_id, reference_files):
+            return []
+
+        def needs_files(self, task_id):
+            return False
+
+    monkeypatch.setattr(step1, "WORKSPACE_DIR", tmp_path)
+    monkeypatch.setattr(step1.ExperimentConfig, "from_yaml", lambda path: config)
+    monkeypatch.setattr(
+        step1, "GDPValDataLoader", lambda auto_download=False: SimpleNamespace(
+            load=lambda: [task]
+        )
+    )
+    monkeypatch.setattr(
+        step1.NeedsFilesManifest,
+        "load",
+        classmethod(lambda cls: Manifest()),
+    )
+
+    prepared = step1.prepare_tasks("fixture.yaml")
+
+    assert prepared["execution"]["mode"] == "agentic_sandbox_v2"
+    assert prepared["execution"]["agentic_v2"] == PROFILE
+
+
+def test_step2_rejects_v2_before_provider_construction():
+    with pytest.raises(ValueError, match="model-free.*scripted fixture"):
+        step2._require_runnable_execution_mode("agentic_sandbox_v2")
+    with pytest.raises(ValueError, match="model-free.*scripted fixture"):
+        step2._resolve_runnable_execution_mode(
+            "agentic_sandbox_v2", "subprocess"
+        )
+    with pytest.raises(ValueError, match="model-free.*scripted fixture"):
+        step2._resolve_runnable_execution_mode(
+            "subprocess", "agentic_sandbox_v2"
+        )
+
+    step2._require_runnable_execution_mode("agentic_sandbox")
+    assert step2._resolve_runnable_execution_mode(
+        "agentic_sandbox", None
+    ) == "agentic_sandbox"
+
+    source = inspect.getsource(step2._run_inference_impl)
+    assert source.index("_resolve_runnable_execution_mode(") < (
+        source.index("# 2. Create LLM client")
+    )
+
+
+def test_step2_configured_v2_override_constructs_no_provider_or_executor(
+    tmp_path, monkeypatch
+):
+    task = {
+        "task_id": "task-1",
+        "reference_files": [],
+        "reference_file_records": [],
+        "needs_files": False,
+        "source_projection_sha256": "a" * 64,
+    }
+    prepared = {
+        "experiment_id": "exp-v2-fixture",
+        "publication_generation": "generation-v2-fixture",
+        "source": "fixture/gdpval",
+        "execution": {"mode": "agentic_sandbox_v2"},
+        "condition_a": {
+            "name": "fixture",
+            "model": {"provider": "azure", "deployment": "unused"},
+            "prompt": {"system": "unused"},
+        },
+        "condition_b": None,
+        "tasks": [task],
+    }
+    prepared["prepared_fingerprint"] = prepared_fingerprint(prepared)
+    (tmp_path / "step1_tasks_prepared.json").write_text(
+        json.dumps(prepared), encoding="utf-8"
+    )
+
+    class Manifest:
+        def require_schema(self, version):
+            assert version == 4
+
+        def __contains__(self, task_id):
+            return task_id == "task-1"
+
+        def reference_records(self, task_id, reference_files):
+            return []
+
+        def needs_files(self, task_id):
+            return False
+
+        def source_projection_sha256(self, task_id):
+            return "a" * 64
+
+    provider = Mock()
+    typed_factory = Mock()
+    executor = Mock()
+    monkeypatch.setattr(step2, "WORKSPACE_DIR", tmp_path)
+    monkeypatch.setattr(
+        step2.NeedsFilesManifest,
+        "load",
+        classmethod(lambda cls: Manifest()),
+    )
+    monkeypatch.setattr(step2, "resolve_verified_reference_paths", Mock())
+    monkeypatch.setattr(step2, "create_provider_client", provider)
+    monkeypatch.setattr(step2, "AzureAIClientFactory", typed_factory)
+    monkeypatch.setattr(step2, "TaskExecutor", executor)
+
+    with pytest.raises(SystemExit):
+        step2._run_inference_impl(
+            execution_mode="subprocess",
+            runtime_resources=step2._Step2RuntimeResources(),
+        )
+
+    provider.assert_not_called()
+    typed_factory.assert_not_called()
+    executor.assert_not_called()
+
+
+def test_dispatch_result_matches_strict_envelope(tmp_path):
+    backend = _backend(tmp_path)
+    dispatcher = AgenticV2ToolDispatcher(
+        backend, AgenticV2Lifecycle(LifecycleState.ACTIVE)
+    )
+
+    dispatch = dispatcher.dispatch(
+        call_id="cap-1",
+        name="capabilities_query",
+        arguments={"kind": "commands"},
+    )
+
+    assert not list(
+        Draft202012Validator(TOOL_RESULT_SCHEMA).iter_errors(dispatch.result)
+    )
+    assert dispatch.result["result_sha256"]
+
+
+def test_result_hash_commits_backend_data_even_when_state_is_equal(tmp_path):
+    class AlternateCapabilitiesBackend(AgenticV2FixtureBackend):
+        def capabilities_query(self, arguments):
+            return {
+                "ok": True,
+                "data": {"kind": arguments["kind"], "items": ["alternate"]},
+            }
+
+    def dispatch(backend):
+        return AgenticV2ToolDispatcher(
+            backend, AgenticV2Lifecycle(LifecycleState.ACTIVE)
+        ).dispatch(
+            call_id="cap-1",
+            name="capabilities_query",
+            arguments={"kind": "commands"},
+        )
+
+    standard = dispatch(_backend(tmp_path / "standard"))
+    alternate = dispatch(AlternateCapabilitiesBackend(
+        root=tmp_path / "alternate",
+        profile=AgenticV2Profile.from_mapping(PROFILE),
+    ))
+
+    assert standard.result["state_before_sha256"] == alternate.result[
+        "state_before_sha256"
+    ]
+    assert standard.result["state_after_sha256"] == alternate.result[
+        "state_after_sha256"
+    ]
+    assert standard.result["result_sha256"] != alternate.result["result_sha256"]
+
+
+def test_scripted_runner_honors_control_plane_cancellation(tmp_path):
+    backend = []
+
+    def factory(**kwargs):
+        value = AgenticV2FixtureBackend(root=tmp_path, **kwargs)
+        backend.append(value)
+        return value
+
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=factory,
+        scripted_calls=[{
+            "call_id": "cap-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        }],
+        profile=PROFILE,
+        cancel_requested=lambda: True,
+    )
+
+    result = runner.run("task", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "cancelled"
+    assert result["agentic_v2"]["lifecycle_state"] == "cancelled"
+    assert backend[0].closed is True
+
+
+def test_scripted_runner_honors_wall_time_before_tool_dispatch(tmp_path):
+    ticks = iter([0.0, 2.0])
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[{
+            "call_id": "cap-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        }],
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 1},
+        clock=lambda: next(ticks),
+    )
+
+    result = runner.run("task", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "task_wall_time_exhausted"
+    assert result["agentic_v2"]["lifecycle_state"] == "failed"
+
+
+def test_scripted_runner_wall_expires_after_start_before_tool(tmp_path):
+    ticks = iter([0.0, 0.0, 0.0, 2.0])
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[{
+            "call_id": "cap-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        }],
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 1},
+        clock=lambda: next(ticks),
+    )
+
+    result = runner.run("task", task_id="task-1")
+    events = result["agentic_v2"]["private_audit"]["events"]
+
+    assert result["error"] == "task_wall_time_exhausted"
+    assert [event["kind"] for event in events] == ["started", "failure"]
+    assert events[-1]["payload"]["stage"] == "control"
+    verify_agentic_v2_failure_result(result)
+
+
+def test_scripted_runner_wall_expires_inside_dispatch_boundary(tmp_path):
+    ticks = iter([0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0])
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[{
+            "call_id": "cap-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        }],
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 1},
+        clock=lambda: next(ticks),
+    )
+
+    result = runner.run("task", task_id="task-1")
+    events = result["agentic_v2"]["private_audit"]["events"]
+    envelope = events[1]["payload"]["result"]
+
+    assert result["error"] == "task_wall_time_exhausted"
+    assert envelope["ok"] is True
+    assert envelope["error_type"] is None
+    assert events[-1]["payload"]["stage"] == "control"
+    verify_agentic_v2_failure_result(result)
+
+
+def test_dispatcher_records_real_wall_usage_for_executed_error(tmp_path):
+    clock = _ManualClock()
+
+    class TimedFailureBackend(AgenticV2FixtureBackend):
+        def capabilities_query(self, arguments):
+            del arguments
+            clock.advance(0.125)
+            raise RuntimeError("private backend detail")
+
+    backend = TimedFailureBackend(
+        root=tmp_path,
+        profile=AgenticV2Profile.from_mapping(PROFILE),
+    )
+    result = AgenticV2ToolDispatcher(
+        backend,
+        AgenticV2Lifecycle(LifecycleState.ACTIVE),
+        clock=clock,
+    ).dispatch(
+        call_id="cap-1",
+        name="capabilities_query",
+        arguments={"kind": "commands"},
+    ).result
+
+    assert result["error_type"] == "fixture_backend_error"
+    assert result["usage_delta"] == {
+        "tool_calls": 1,
+        "wall_ms": 125,
+        "output_bytes": 2,
+    }
+    assert result["request_sha256"] is not None
+    assert result["state_before_sha256"] is not None
+    assert result["state_after_sha256"] is not None
+
+
+def test_scripted_runner_enforces_startup_deadline(tmp_path):
+    clock = _ManualClock()
+    backends = []
+
+    class SlowStartBackend(AgenticV2FixtureBackend):
+        def start(self, timeout_seconds):
+            assert timeout_seconds == 1
+            clock.advance(2)
+            return super().start(timeout_seconds)
+
+    def factory(**kwargs):
+        backend = SlowStartBackend(root=tmp_path, **kwargs)
+        backends.append(backend)
+        return backend
+
+    result = AgenticV2ScriptedRunner(
+        backend_factory=factory,
+        scripted_calls=[],
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 1},
+        clock=clock,
+    ).run("task", task_id="task-1")
+
+    assert result["error"] == "task_wall_time_exhausted"
+    assert result["agentic_v2"]["lifecycle_state"] == "failed"
+    assert backends[0].closed is True
+
+
+def test_scripted_runner_enforces_tool_deadline_after_execution(tmp_path):
+    clock = _ManualClock()
+
+    class SlowToolBackend(AgenticV2FixtureBackend):
+        def capabilities_query(self, arguments):
+            clock.advance(2)
+            return super().capabilities_query(arguments)
+
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: SlowToolBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[{
+            "call_id": "cap-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        }],
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 1},
+        clock=clock,
+    ).run("task", task_id="task-1")
+
+    envelope = result["agentic_v2"]["private_audit"]["events"][1][
+        "payload"
+    ]["result"]
+    assert result["error"] == "task_wall_time_exhausted"
+    assert result["agentic_v2"]["lifecycle_state"] == "failed"
+    assert envelope["ok"] is True
+    assert envelope["error_type"] is None
+    assert envelope["usage_delta"]["wall_ms"] == 0
+    assert envelope["usage_delta"]["tool_calls"] == 1
+    verify_agentic_v2_failure_result(result)
+
+
+@pytest.mark.parametrize("blocked_stage", ["start", "tool"])
+def test_isolated_fixture_hard_deadline_kills_blocked_worker(
+    tmp_path, monkeypatch, blocked_stage
+):
+    if blocked_stage == "start":
+        monkeypatch.setattr(AgenticV2FixtureBackend, "start", _block_forever)
+        calls = []
+    else:
+        monkeypatch.setattr(
+            AgenticV2FixtureBackend, "capabilities_query", _block_forever
+        )
+        calls = [{
+            "call_id": "cap-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        }]
+    runner = AgenticV2IsolatedFixtureRunner(
+        fixture_root=tmp_path,
+        scripted_calls=calls,
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 1},
+    )
+
+    result = runner.run("task", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "task_wall_time_exhausted"
+    assert runner._last_process.exitcode is not None
+    assert runner._last_process.is_alive() is False
+    assert list(tmp_path.glob(".agentic-v2-run-*")) == []
+    verify_trace_pair(
+        result["agentic_v2"]["private_audit"],
+        result["agentic_v2"]["public_trace"],
+        result["agentic_v2"]["trace_pair_sha256"],
+    )
+
+
+def test_isolated_fixture_hard_deadline_kills_ignoring_descendant(
+    tmp_path, monkeypatch
+):
+    global _DESCENDANT_PID_PATH
+    _DESCENDANT_PID_PATH = tmp_path / "descendant.pid"
+    monkeypatch.setattr(
+        AgenticV2FixtureBackend,
+        "capabilities_query",
+        _spawn_ignoring_descendant_and_block,
+    )
+    runner = AgenticV2IsolatedFixtureRunner(
+        fixture_root=tmp_path,
+        scripted_calls=[{
+            "call_id": "cap-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        }],
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 1},
+    )
+
+    result = runner.run("task", task_id="task-1")
+    descendant_pid = int(Path(_DESCENDANT_PID_PATH).read_text(encoding="utf-8"))
+
+    assert result["error"] == "task_wall_time_exhausted"
+    assert runner._last_process.is_alive() is False
+    try:
+        descendant = psutil.Process(descendant_pid)
+    except psutil.NoSuchProcess:
+        descendant = None
+    if descendant is not None:
+        gone, alive = psutil.wait_procs([descendant], timeout=1)
+        assert gone
+        assert alive == []
+    assert list(tmp_path.glob(".agentic-v2-run-*")) == []
+
+
+@pytest.mark.parametrize(
+    ("backend_method", "expected_error"),
+    [
+        (_spawn_ignoring_descendant_and_return, "finalize_not_called"),
+        (_spawn_ignoring_descendant_and_crash, "compute_backend_error"),
+    ],
+)
+def test_isolated_fixture_always_kills_descendant_after_worker_exit(
+    tmp_path, monkeypatch, backend_method, expected_error
+):
+    global _DESCENDANT_PID_PATH
+    _DESCENDANT_PID_PATH = tmp_path / "descendant.pid"
+    monkeypatch.setattr(
+        AgenticV2FixtureBackend,
+        "capabilities_query",
+        backend_method,
+    )
+    runner = AgenticV2IsolatedFixtureRunner(
+        fixture_root=tmp_path,
+        scripted_calls=[{
+            "call_id": "cap-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        }],
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 3},
+    )
+
+    result = runner.run("task", task_id="task-1")
+    descendant_pid = int(Path(_DESCENDANT_PID_PATH).read_text(encoding="utf-8"))
+
+    assert result["error"] == expected_error
+    assert runner._last_process.is_alive() is False
+    try:
+        descendant = psutil.Process(descendant_pid)
+    except psutil.NoSuchProcess:
+        descendant = None
+    if descendant is not None:
+        gone, alive = psutil.wait_procs([descendant], timeout=1)
+        assert gone
+        assert alive == []
+    assert list(tmp_path.glob(".agentic-v2-run-*")) == []
+
+
+def test_isolated_fixture_discards_success_when_parent_verifier_type_errors(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        agentic_v2_runner,
+        "_run_fixture_worker",
+        _send_forged_success_and_wait,
+    )
+    monkeypatch.setattr(
+        agentic_v2_runner,
+        "verify_agentic_v2_result",
+        lambda _value: (_ for _ in ()).throw(TypeError("forged bytes")),
+    )
+    runner = AgenticV2IsolatedFixtureRunner(
+        fixture_root=tmp_path,
+        scripted_calls=[],
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 3},
+    )
+
+    result = runner.run("task", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "compute_backend_error"
+    assert runner._last_process.is_alive() is False
+    verify_agentic_v2_failure_result(result)
+
+
+def test_isolated_fixture_discards_malformed_failure_after_worker_exit(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        agentic_v2_runner,
+        "_run_fixture_worker",
+        _send_malformed_failure_and_exit,
+    )
+    runner = AgenticV2IsolatedFixtureRunner(
+        fixture_root=tmp_path,
+        scripted_calls=[],
+        profile=PROFILE,
+        budget_caps={"tool_calls": 32, "wall_seconds": 3},
+    )
+
+    result = runner.run("task", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "compute_backend_error"
+    assert runner._last_process.is_alive() is False
+    verify_agentic_v2_failure_result(result)
+
+
+def test_scripted_runner_cleanup_failure_overrides_success(tmp_path):
+    class CleanupFailureBackend(AgenticV2FixtureBackend):
+        def close(self):
+            raise RuntimeError("sensitive cleanup detail")
+
+    runner = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: CleanupFailureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "done",
+                },
+            },
+            {
+                "call_id": "final-1",
+                "name": "finalize",
+                "arguments": {"deliverables": ["report.txt"], "summary": "done"},
+            },
+        ],
+        profile=PROFILE,
+    )
+
+    result = runner.run("task", task_id="task-1")
+
+    assert result["success"] is False
+    assert result["error"] == "compute_cleanup_failed"
+    assert "sensitive" not in str(result)
+
+
+def test_scripted_runner_cleanup_failure_preserves_prior_error(tmp_path):
+    class CleanupFailureBackend(AgenticV2FixtureBackend):
+        def close(self):
+            raise RuntimeError("sensitive cleanup detail")
+
+    result = AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: CleanupFailureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[{
+            "call_id": "resolve-1",
+            "name": "environment_resolve",
+            "arguments": {
+                "ecosystem": "python",
+                "requirements": ["demo-pkg==1.0.0"],
+            },
+        }],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+
+    assert result["error"] == "capability_unavailable"
+    assert "cleanup" not in str(result)
+
+
+@pytest.mark.parametrize(
+    "budget_caps",
+    [
+        {"tool_calls": 0},
+        {"wall_seconds": 0},
+        {"tool_calls": True},
+        {"unknown": 1},
+    ],
+)
+def test_scripted_runner_rejects_invalid_budget_caps(tmp_path, budget_caps):
+    with pytest.raises(ValueError, match="budget cap|tool_calls|wall_seconds"):
+        AgenticV2ScriptedRunner(
+            backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+                root=tmp_path, **kwargs
+            ),
+            scripted_calls=[],
+            profile=PROFILE,
+            budget_caps=budget_caps,
+        )
+
+
+@pytest.mark.parametrize(
+    ("profile_id", "package_ok", "web_ok"),
+    [
+        ("offline-full-v1", False, False),
+        ("package-broker-v1", True, False),
+        ("web-augmented-v1", True, False),
+    ],
+)
+def test_fixture_profile_matrix(tmp_path, profile_id, package_ok, web_ok):
+    backend = AgenticV2FixtureBackend(
+        root=tmp_path / profile_id,
+        profile=AgenticV2Profile.from_mapping({
+            "tool_contract_version": "2.0",
+            "policy_profile_id": profile_id,
+            "foundation_only": True,
+        }),
+    )
+    package = backend.environment_resolve({
+        "ecosystem": "python", "requirements": ["demo-pkg==1.0.0"]
+    })
+    web = backend.browser_run({"operation": "search", "query": "query"})
+
+    assert package["ok"] is package_ok
+    assert web["ok"] is web_ok
+
+
+class _ManualClock:
+    def __init__(self):
+        self.value = 0.0
+
+    def __call__(self):
+        return self.value
+
+    def advance(self, seconds):
+        self.value += seconds
+
+
+def _rehash_events(events):
+    previous = "0" * 64
+    for sequence, event in enumerate(events):
+        event["sequence"] = sequence
+        event["previous_sha256"] = previous
+        event.pop("event_sha256", None)
+        event["event_sha256"] = canonical_sha256(event)
+        previous = event["event_sha256"]
+    return previous
+
+
+def _single_capability_run(tmp_path):
+    return AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[{
+            "call_id": "cap-1",
+            "name": "capabilities_query",
+            "arguments": {"kind": "commands"},
+        }],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+
+
+def _successful_result(tmp_path):
+    return AgenticV2ScriptedRunner(
+        backend_factory=lambda **kwargs: AgenticV2FixtureBackend(
+            root=tmp_path, **kwargs
+        ),
+        scripted_calls=[
+            {
+                "call_id": "write-1",
+                "name": "workspace_apply",
+                "arguments": {
+                    "operation": "write",
+                    "path": "report.txt",
+                    "content": "done",
+                },
+            },
+            {
+                "call_id": "final-1",
+                "name": "finalize",
+                "arguments": {
+                    "deliverables": ["report.txt"],
+                    "summary": "done",
+                },
+            },
+        ],
+        profile=PROFILE,
+    ).run("task", task_id="task-1")
+
+
+def _rehash_result(envelope):
+    envelope.pop("result_sha256", None)
+    envelope["result_sha256"] = canonical_sha256(envelope)
+
+
+def _unexecuted_error_from(envelope, error_type):
+    value = {
+        "schema_version": envelope["schema_version"],
+        "call_id": envelope["call_id"],
+        "tool_name": envelope["tool_name"],
+        "request_sha256": None,
+        "ok": False,
+        "error_type": error_type,
+        "data": {},
+        "usage_delta": {"tool_calls": 0, "wall_ms": 0, "output_bytes": 0},
+        "state_before_sha256": None,
+        "state_after_sha256": None,
+    }
+    value["result_sha256"] = canonical_sha256(value)
+    return value
+
+
+def _sync_trace_pair_event(metadata, event_index):
+    private_event = metadata["private_audit"]["events"][event_index]
+    public_event = metadata["public_trace"]["events"][event_index]
+    envelope = private_event["payload"]["result"]
+    public_event["payload"] = {
+        "result_commitment": {
+            field: deepcopy(envelope.get(field))
+            for field in (
+                "call_id",
+                "tool_name",
+                "request_sha256",
+                "result_sha256",
+                "ok",
+                "error_type",
+                "usage_delta",
+                "state_before_sha256",
+                "state_after_sha256",
+            )
+        },
+        "replayed": private_event["payload"]["replayed"],
+    }
+    public_event["state_sha256"] = private_event["state_sha256"]
+    metadata["private_audit"]["event_chain_head_sha256"] = _rehash_events(
+        metadata["private_audit"]["events"]
+    )
+    metadata["public_trace"]["event_chain_head_sha256"] = _rehash_events(
+        metadata["public_trace"]["events"]
+    )
+    metadata["trace_pair_sha256"] = trace_pair_fingerprint(
+        metadata["private_audit"], metadata["public_trace"]
+    )
+
+
+def _forge_success_event(
+    metadata,
+    event_index,
+    *,
+    call_id,
+    tool_name,
+    arguments,
+    data,
+):
+    event = metadata["private_audit"]["events"][event_index]
+    event["payload"]["request"] = {
+        "call_id": call_id,
+        "name": tool_name,
+        "arguments": arguments,
+    }
+    envelope = event["payload"]["result"]
+    envelope.update({
+        "call_id": call_id,
+        "tool_name": tool_name,
+        "request_sha256": canonical_sha256({
+            "tool_contract_version": "2.0",
+            "call_id": call_id,
+            "name": tool_name,
+            "arguments": arguments,
+        }),
+        "ok": True,
+        "error_type": None,
+        "data": data,
+    })
+    envelope["usage_delta"] = {
+        "tool_calls": 1,
+        "wall_ms": 0,
+        "output_bytes": len(json.dumps(
+            data,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")),
+    }
+    _rehash_result(envelope)
+    _sync_trace_pair_event(metadata, event_index)
+
+
+def _sync_failure_event(
+    metadata,
+    *,
+    error_type,
+    lifecycle_state,
+    stage="runtime",
+):
+    payload = {
+        "error_type": error_type,
+        "lifecycle_state": lifecycle_state,
+        "stage": stage,
+    }
+    state = canonical_sha256({"schema_version": "2.0", **payload})
+    for trace_name in ("private_audit", "public_trace"):
+        event = metadata[trace_name]["events"][-1]
+        assert event["kind"] == "failure"
+        event["payload"] = deepcopy(payload)
+        event["state_sha256"] = state
+        metadata[trace_name]["event_chain_head_sha256"] = _rehash_events(
+            metadata[trace_name]["events"]
+        )
+    metadata["trace_pair_sha256"] = trace_pair_fingerprint(
+        metadata["private_audit"], metadata["public_trace"]
+    )
+
+
+def _forged_result_envelope(request, data, *, state_before, state_after):
+    value = {
+        "schema_version": "2.0",
+        "call_id": request["call_id"],
+        "tool_name": request["name"],
+        "request_sha256": canonical_sha256({
+            "tool_contract_version": "2.0",
+            "call_id": request["call_id"],
+            "name": request["name"],
+            "arguments": request["arguments"],
+        }),
+        "ok": True,
+        "error_type": None,
+        "data": deepcopy(data),
+        "usage_delta": {
+            "tool_calls": 1,
+            "wall_ms": 0,
+            "output_bytes": len(json.dumps(
+                data,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")),
+        },
+        "state_before_sha256": state_before,
+        "state_after_sha256": state_after,
+    }
+    value["result_sha256"] = canonical_sha256(value)
+    return value
+
+
+def _append_trace_pair_tool_event(metadata, request, envelope):
+    private_events = metadata["private_audit"]["events"]
+    public_events = metadata["public_trace"]["events"]
+    private_events.append({
+        "schema_version": "2.0",
+        "sequence": len(private_events),
+        "kind": "tool_result",
+        "payload": {
+            "request": deepcopy(request),
+            "result": deepcopy(envelope),
+            "replayed": False,
+        },
+        "state_sha256": envelope["state_after_sha256"],
+        "previous_sha256": private_events[-1]["event_sha256"],
+        "event_sha256": "0" * 64,
+    })
+    public_events.append({
+        "schema_version": "2.0",
+        "sequence": len(public_events),
+        "kind": "tool_result_public",
+        "payload": {
+            "result_commitment": {
+                field: deepcopy(envelope.get(field))
+                for field in (
+                    "call_id",
+                    "tool_name",
+                    "request_sha256",
+                    "result_sha256",
+                    "ok",
+                    "error_type",
+                    "usage_delta",
+                    "state_before_sha256",
+                    "state_after_sha256",
+                )
+            },
+            "replayed": False,
+        },
+        "state_sha256": envelope["state_after_sha256"],
+        "previous_sha256": public_events[-1]["event_sha256"],
+        "event_sha256": "0" * 64,
+    })
+    metadata["private_audit"]["event_chain_head_sha256"] = _rehash_events(
+        private_events
+    )
+    metadata["public_trace"]["event_chain_head_sha256"] = _rehash_events(
+        public_events
+    )
+    metadata["trace_pair_sha256"] = trace_pair_fingerprint(
+        metadata["private_audit"], metadata["public_trace"]
+    )

--- a/batch-runner/tests/test_agentic_workflows.py
+++ b/batch-runner/tests/test_agentic_workflows.py
@@ -53,7 +53,9 @@ def test_general_batch_blocks_agentic_before_any_credential_step():
     )
     assert inspect_checkout["with"]["persist-credentials"] is False
     assert "YAML.safe_load" in inspect_job["steps"][-1]["run"]
-    assert "mode'] == 'agentic_sandbox'" in inspect_job["steps"][-1]["run"]
+    inspect_script = inspect_job["steps"][-1]["run"]
+    assert "'agentic_sandbox'" in inspect_script
+    assert "'agentic_sandbox_v2'" in inspect_script
     assert reject_job["if"] == (
         "needs.inspect-mode.outputs.uses_agentic == 'true'"
     )
@@ -68,9 +70,9 @@ def test_general_batch_blocks_agentic_before_any_credential_step():
     assert steps[block_index]["if"] == (
         "steps.read_config.outputs.uses_agentic == 'true'"
     )
-    assert "mode == 'agentic_sandbox' or hardened" in steps[
-        names.index("Read experiment config flags")
-    ]["run"]
+    read_config_script = steps[names.index("Read experiment config flags")]["run"]
+    assert '"agentic_sandbox"' in read_config_script
+    assert '"agentic_sandbox_v2"' in read_config_script
     credential_indices = [
         index
         for index, step in enumerate(steps)

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -3,109 +3,88 @@
 This is the canonical rolling record of the most recently completed repository
 task. It must be refreshed before a task is reported complete.
 
-- Updated: 2026-07-26
-- Status: GPT-5.6 Sol Max narrative and grading policy shipped through PR #144;
-  protected `grading` Environment configured; automatic PR validation,
-  post-merge validation, and Pages deployment passed
+- Updated: 2026-07-27
+- Status: Agentic Sandbox V2 Phase 1A foundation implemented, fully validated,
+  and independently approved; shipment pending
 
 ## Task
 
-- Set dashboard narrative and production grading to GPT-5.6 Sol 1M Max.
-- Apply the policy through runtime code, grading config, publication identity,
-  workflow guardrails, schemas, types, tests, and current operator manuals.
-- Find and correct current 5.4/5.4 Pro narrative or grading claims without
-  rewriting historical configs, results, measurements, or provenance.
-- Validate end to end, then commit, push, open a PR, pass checks, and merge.
+- Begin the full Agentic Sandbox redesign with a model-free Phase 1A foundation
+  that can be tested without cloud credentials, model calls, or paid workflows.
+- Define versioned tools, lifecycle, profiles, provenance, replay behavior,
+  runtime identity, deterministic fixtures, and fail-closed execution gates.
+- Preserve every public V1 Agentic Sandbox identity and keep V2 visibly
+  non-production until real compute, package, web, and model planes are proven.
+- Complete security review, full credential-free validation, documentation,
+  commit, push, PR checks, and merge without touching the primary dirty checkout.
 
 ## Result
 
-- Narrative analysis now defaults to `gpt-5.6-sol` with `max` reasoning over
-  direct-v1. Step 6 persists model, effort, and runtime fingerprint; route or
-  model failure remains a model-free report and never falls back to the
-  experiment model.
-- Publication independently recomputes and verifies the expected narrative
-  identity. Model-backed publication also requires all four narrative fields
-  to be nonempty strings; model-free publication requires all three identity
-  keys to exist as `null` and all four narrative fields to be empty strings.
-- Added `grading_configs/default_v2_sol_max.yaml` as the workflow default:
-  `gpt-5.6-sol` Max for main judge, visual perception, and finalization;
-  `gpt-audio-1.5` remains the dedicated audio deployment. The 1.05M context is
-  documented as deployment-owned rather than a synthetic request field.
-- Main, visual, and finalization effort values share one fail-closed enum
-  contract. Explicit null or unknown values are rejected before API calls.
-- Semantic-invalid final JSON receives one no-tools retry with its own bounded
-  budget, including when the normal tool-loop iteration budget is exhausted.
-- Grade schema 1.2 costs remain explicitly unpriced: `estimated_cost_usd=null`,
-  `pricing_complete=false`, and a nonempty unique model set exactly matching
-  the persisted main and perception identities. Prior 1.0/1.1 lifecycle
-  payloads retain their numeric-cost compatibility.
-- Split the grading workflow into request validation, credential-free dry-run,
-  protected paid approval, and paid grading jobs. Dry-run has read-only contents
-  permission, does not retain checkout credentials, cannot mint OIDC tokens,
-  and receives no repository secret. Paid grading requires both explicit input
-  authorization and Environment approval; the Azure login job has no
-  Environment, preserving the `refs/heads/main` OIDC subject. Resume chunks
-  inherit exact config, resolved inference revision, task limit, and approval
-  input; each newly dispatched chunk requires a fresh Environment approval.
-- Created the remote `grading` Environment with required owner review,
-  `can_admins_bypass=false`, and one exact `main` custom branch policy.
-  `prevent_self_review=false` is explicit because the repository has no
-  independent collaborator; enabling it would make approval impossible.
-  Existing `copilot` Environment metadata, secrets, and variables were not
-  changed.
-- Updated English/Korean READMEs, first-experiment manuals, config guide,
-  authoritative grading specs, analysis semantics, and frontend types. Current
-  policy now consistently names Sol Max; 5.4 references are clearly historical
-  comparison, benchmark, or provenance identities.
+- Added strict V2 contracts for `capabilities_query`, `workspace_apply`,
+  `exec_run`, `environment_resolve`, `environment_activate`, `browser_run`,
+  `verify_public`, and `finalize`, plus exact lifecycle and typed result/event
+  envelopes.
+- Added `offline-full-v1`, `package-broker-v1`, and `web-augmented-v1` profiles.
+  All profiles require `foundation_only=true`; the fixture still rejects live
+  web operations and no model loop exists.
+- Added a built-in deterministic fixture backend and isolated runner. The
+  executor rejects production use, custom backend factories, model/client/
+  credential/provider/prompt inputs, publication, grading, QA, and preprocessors.
+- Worker startup performs a process-group handshake. Normal return, timeout,
+  cancellation, EOF, and crash all terminate and join the full process group,
+  including SIGTERM-ignoring descendants.
+- Workspace I/O walks every component from a pinned root descriptor, rejects
+  symlinks, hardlinks, FIFO/socket/special files, verifies ancestry before and
+  after operations, purges detached subtrees, and reserves directory, entry,
+  individual-file, peak-temporary, workspace, and final-artifact limits before
+  mutation.
+- Canonical source-byte identity binds the tool contract, semantic validators,
+  fixture backend, exact capability inventory, package snapshot, browser build,
+  substrate, profile, and budget caps. Immutable package locks are revalidated
+  against the snapshot before activation.
+- Private audit and public-redacted traces independently hash requests, full
+  results, state transitions, failures, and replay history. Offline verification
+  rejects rehashed call/tool/status/data/state, capability, content-hash,
+  package, runtime, replay, terminal-finalize, and returned-file tampering.
+- General `batch-run.yml` classifies V2 in its credential-free inspection and
+  prevents the credentialed job from starting. Step 2 rejects both configured
+  V2 and CLI override V2 before any provider factory or executor construction.
+- V1 prompt/tool hashes, default limits, progress checkpoint bytes, final result
+  fingerprint, restore/resave behavior, imports, defaults, and recommendations
+  are frozen by compatibility tests.
 
 ## Verification
 
-- Full credential-free backend: **2,358 passed, 6 skipped, 44 deselected** in
-  130.59 seconds after all review fixes.
-- Frontend/data/onboarding contracts: **94 passed** using real Ruby 3.3 for the
-  embedded workflow syntax checks.
-- Grade analysis tests: **9 passed**.
-- Both changed workflows passed actionlint 1.7.7 and Ruby Psych 3.3 parsing.
-- TypeScript compilation and Vite production build passed after aggregation of
-  1 experiment, 23 reports, 17 grades, 28 prompt architectures, and 4 field
-  notes. Only the existing large-chunk and stale Browserslist-data warnings
-  remain.
-- Runtime, integrity, perception, and success browser suites passed in real
-  Chromium from Playwright 1.61.1: **4 passed, 0 failed**, with no console or
-  page errors.
-- Four independent review passes found publication-content, finalization-budget,
-  reasoning-effort, cost-identity, dry-run-permission, and dated-document
-  boundaries. Every finding was fixed and covered by focused tests before the
-  final full validation.
-- Remote GET verification confirms `grading` has one required owner reviewer,
-  administrator bypass disabled, custom branch policies enabled, and exactly
-  one `main` branch policy. `copilot` remains unprotected with no Environment
-  secrets or variables, matching its prior state.
-- No paid workflow, Azure login/token acquisition, model call, grading run,
-  Hugging Face read/write, or deployment was executed. The only remote mutation
-  was the explicitly requested GitHub `grading` Environment configuration.
+- V2 contract, foundation, V1 compatibility, and workflow suite: **196 passed,
+  0 skipped, 0 warnings** in 6.07 seconds.
+- Complete credential-free backend after all review fixes: **2,551 passed, 6
+  skipped, 44 integration tests deselected, 0 warnings** in 112.67 seconds.
+- Static diagnostics report zero errors across all touched Python and test files;
+  `py_compile` and `git diff --check` pass.
+- `batch-run.yml` parses with PyYAML and static workflow tests prove both mode
+  inspections recognize V2 before credentials. `actionlint` and Ruby/Psych are
+  unavailable in this local environment and remain shipment evidence gaps.
+- Seven high-stakes security/release reviews and an iterative full-diff review
+  progressed from `REJECT`/`CHANGES_REQUESTED` to final `APPROVE`. Every
+  process, filesystem, identity, provenance, replay, terminal, workflow, and
+  V1-compatibility finding was fixed and covered by a focused regression before
+  the complete backend run.
+- No model, credential, token, Azure, Hugging Face, grading, deployment,
+  workflow dispatch, network write, remote mutation, or paid action occurred.
 
 ## Shipment
 
-- Reviewed implementation head:
-  `148c1838b185c01e97ccfd5286f08b8403a7c97b`.
-- PR [#144](https://github.com/hyeonsangjeon/gdpval-realworks/pull/144)
-  passed automatic validation and was squash-merged as
-  `bc27f882446a5c2c93ecd97e75b4c7cf8d9576f4` on 2026-07-25 UTC.
-- Automatic PR run
-  [30175334019](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/30175334019)
-  passed `validate` in 1 minute 52 seconds; `deploy` was skipped as required for
-  pull requests.
-- Automatic `main` push run
-  [30175424979](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/30175424979)
-  passed `validate` in 107 seconds and Pages `deploy` in 11 seconds.
-- The feature branch was deleted after merge. Both automatic runs were free
-  repository validation/deployment paths; neither dispatched paid grading,
-  Azure login, model calls, or Hugging Face operations.
+- Clean worktree: `/tmp/gdpval-agentic-sandbox-v2`.
+- Branch: `feat/agentic-sandbox-v2-foundation`.
+- Base: `origin/main@8ba02a40255a55c69075d8ba30bded1c874b4f8c`.
+- Commit, push, PR checks, merge, and post-merge completion record are pending.
+- The local planning Bolt remains intentionally ignored/private and is not part
+  of the public repository change.
 
 ## Remaining Work
 
-- No repository implementation or delivery work remains for the Sol Max policy
-  migration.
-- A live paid Sol Max canary remains intentionally outside this task and still
-  requires explicit owner input plus protected Environment approval.
+- Ship the reviewed implementation, verify automatic checks, and update this
+  rolling record with the reviewed head, PR, merge commit, and check runs.
+- Phase 1B and later must separately prove real microVM/container compute,
+  package-broker supply chain, browser/web egress, model-loop budgeting,
+  publication, and production authorization. None is approved by Phase 1A.


### PR DESCRIPTION
## Summary
- add a versioned, model-free Agentic Sandbox V2 contract with eight strict tools, lifecycle, profiles, provenance, and deterministic fixture execution
- isolate fixture runs in killable process groups with descriptor-anchored filesystem and package/runtime identity enforcement
- keep V2 non-production and fail closed before credentials/providers in Step 2 and the general batch workflow
- freeze V1 prompt, tool, limits, checkpoint, result, restore, import, and mode identities

## Verification
- focused V2/V1/workflow: 196 passed, 0 skipped, 0 warnings
- full credential-free backend: 2551 passed, 6 skipped, 44 integration deselected, 0 warnings
- static diagnostics: 0 errors
- git diff --check: clean
- independent security and full-diff reviews: APPROVE

## Safety
- no model, Azure, Hugging Face, grading, deployment, workflow dispatch, network-write, remote project mutation, or paid execution occurred
- real compute, package broker, live web, model loop, publication, and production authorization remain deferred