### PR TITLE
feat: close Phase 1C license evidence deterministically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **Agentic Sandbox V2 Phase 1C deterministic license evidence closure** - add
+  model-free, exact-image Debian, Python, R, and npm license collection with
+  same-descriptor bytes and hashes; host-owned SPDX normalization; honest
+  `missing_metadata`, `ambiguous`, and `unverifiable` outcomes; denied-first
+  decisions; and package/version/purl/evidence-digest/expression/reviewer-bound
+  exceptions. The evaluator is staged from pinned Git and packaging source,
+  runs under `python -I -S -B`, and binds its transformed parser, frozen SPDX
+  tables, normalization/classification/report surface, semantic dependencies,
+  and import-order-independent callable identity. Exact-image integration also
+  aligns static R receipt/SBOM inventory, rejects image volumes and
+  healthchecks, binds probe-loaded source to Git, treats hybrid and
+  noncanonical Debian metadata as unresolved, represents blocked symlink paths
+  without following them, and rehashes 1,720 physical evidence files through
+  safe host copies or bounded non-extracted archives. Checkpoint
+  `1397f92b5257747ca3faf99e00a74269d4b14875` produced image
+  `sha256:e47537b8f7ac7c595b3a055dea4d16283efaa9c9a67c0f8a3e0fc2d65e834e29`
+  and OCI manifest
+  `sha256:0064ce70a26d6df58353a2e305a69d1d03e1db4525eee9870841fe10c6b3d02a`.
+  Its 1,423 packages classify as 186 resolved, 898 ambiguous, 1 missing
+  metadata, 338 unverifiable, and zero denied/exceptions; all 1,237 unresolved
+  packages remain visible, license status stays failed, and production remains
+  disabled and blocked on containment, CVE, license, microVM, provenance, and
+  signature evidence. Validation passes 372 focused contracts, one exact
+  Docker/OCI integration, 923 agentic/sandbox/executor regressions with one
+  host-dependent skip, and the complete credential-free backend with 2,927
+  passed, 6 skipped, and 45 integration tests deselected. Independent
+  adversarial review finished with zero mandatory or optional findings. No
+  model, Azure, grading, Hugging Face write, registry push, publication,
+  workflow dispatch, or paid operation ran.
 - **Agentic Sandbox V2 Phase 1B professional-work candidate** - add a separate,
   local-only image substrate without activating the Phase 1A executor, Step 2,
   workflows, models, grading, publication, or a registry path. An exact GHCR

--- a/batch-runner/core/agentic_v2_license.py
+++ b/batch-runner/core/agentic_v2_license.py
@@ -2,30 +2,37 @@
 
 from __future__ import annotations
 
+import ast
+import builtins
 import hashlib
 import json
-import marshal
 import os
-import re
 import stat
 import sys
 import types
 import packaging
 import packaging.licenses as packaging_licenses
-from copy import deepcopy
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
 from urllib.parse import quote
 
-from packaging.licenses import InvalidLicenseExpression, canonicalize_license_expression
+from packaging.licenses import InvalidLicenseExpression
+from packaging.licenses import (
+    canonicalize_license_expression as _packaging_canonicalize_license_expression,
+)
 from packaging.licenses import _spdx
 
 from core.agentic_v2_substrate import canonical_sha256
 
 
-CLASSIFICATIONS = frozenset({
+_INTERPRETER_FROZENSET_TYPE = (
+    lambda value: value in {"a", "b"}
+).__code__.co_consts[1].__class__
+
+
+CLASSIFICATIONS = _INTERPRETER_FROZENSET_TYPE({
     "resolved",
     "missing_metadata",
     "ambiguous",
@@ -51,58 +58,18 @@ LICENSE_EVALUATOR_RUNTIME_GRAPH_SHA256 = (
 )
 LICENSE_EVALUATOR_PYTHON_VERSION = "3.10.12"
 LICENSE_EVALUATOR_CALLABLE_SHA256 = (
-    "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"
+    "825f97f04b9b94c048326625a7e56b6a0960b196964dabcf4ba7ad3e8e9b3056"
 )
-UNRESOLVED_CLASSIFICATIONS = frozenset({
+UNRESOLVED_CLASSIFICATIONS = _INTERPRETER_FROZENSET_TYPE({
     "missing_metadata", "ambiguous", "unverifiable",
 })
-_HEX_DIGEST = re.compile(r"[0-9a-f]{64}")
-_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
-_SOURCE_SHA = re.compile(r"[0-9a-f]{40}")
-_EXPRESSION_TOKEN = re.compile(
-    r"(?<![A-Za-z0-9.+-])"
-    r"([A-Za-z0-9](?:[A-Za-z0-9.+-]{0,126}[A-Za-z0-9+])?)"
-    r"(?![A-Za-z0-9+-])",
-    re.ASCII,
-)
 _PYTHON_PURELIB_PATH = PurePosixPath("/usr/local/lib/python3.11/site-packages")
 _MAX_LICENSE_EXPRESSION_LENGTH = 4096
 _MAX_LICENSE_EXPRESSION_DEPTH = 64
 _MAX_LICENSE_EXPRESSION_TOKENS = 512
-_R_LICENSE_REFERENCE = re.compile(
-    r"file ([A-Za-z0-9][A-Za-z0-9._+-]*)\Z", re.ASCII
-)
-_NPM_LICENSE_REFERENCE = re.compile(
-    r"SEE LICENSE IN ([A-Za-z0-9][A-Za-z0-9._+-]*)\Z", re.ASCII
-)
-_R_REFERENCE_LIKE = re.compile(r"\bfile\b", re.IGNORECASE | re.ASCII)
-_R_RUNTIME_REFERENCE_LIKE = re.compile(
-    r"(?<![A-Za-z0-9])Part[^A-Za-z0-9]+of[^A-Za-z0-9]+R(?![A-Za-z0-9])",
-    re.IGNORECASE,
-)
-_NPM_REFERENCE_LIKE = re.compile(
-    r"(?<![A-Za-z0-9])SEE[^A-Za-z0-9]+LICENSE[^A-Za-z0-9]+IN"
-    r"(?![A-Za-z0-9])",
-    re.IGNORECASE,
-)
-_LICENSE_FILE_TOKEN_TEXT = re.compile(
-    r"[A-Za-z0-9](?:[A-Za-z0-9.+-]{0,126}[A-Za-z0-9+])?\Z",
-    re.ASCII,
-)
 _DEP5_FORMAT_URI = (
     "https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/"
 )
-_REGISTERED_SPDX_IDENTIFIERS = frozenset(
-    value["id"]
-    for collection in (_spdx.LICENSES, _spdx.EXCEPTIONS)
-    for value in collection.values()
-)
-
-
-def _matches(pattern: re.Pattern, value: Any) -> bool:
-    return isinstance(value, str) and pattern.fullmatch(value) is not None
-
-
 _EXACT_ALIASES = {
     "2-clause BSD": "BSD-2-Clause",
     "Apache 2.0": "Apache-2.0",
@@ -163,11 +130,10 @@ _PYTHON_EXACT_ALIASES = {
     "LGPLv3+": "LGPL-3.0-or-later",
 }
 
-_DEBIAN_OPERATORS = re.compile(
-    r"(\(|\)|,\s+and\s+|,\s+or\s+|\s+and\s+|\s+or\s+|\s+with\s+)",
-    re.IGNORECASE,
-)
-
+_EXACT_ALIASES = types.MappingProxyType(dict(_EXACT_ALIASES))
+_DEBIAN_EXACT_ALIASES = types.MappingProxyType(dict(_DEBIAN_EXACT_ALIASES))
+_PYTHON_CLASSIFIERS = types.MappingProxyType(dict(_PYTHON_CLASSIFIERS))
+_PYTHON_EXACT_ALIASES = types.MappingProxyType(dict(_PYTHON_EXACT_ALIASES))
 
 @dataclass(frozen=True)
 class _Outcome:
@@ -175,6 +141,724 @@ class _Outcome:
     issue: str | None
     reason: str
     identifiers: frozenset[str]
+
+
+_FROZEN_OUTCOME_TYPE = _Outcome
+_FROZEN_OUTCOME_INIT = _Outcome.__init__
+_FROZEN_OUTCOME_INIT_CODE = _Outcome.__init__.__code__
+_FROZEN_OUTCOME_INIT_DEFAULTS = _Outcome.__init__.__defaults__
+_FROZEN_DATE_TYPE = date
+_FROZEN_CANONICAL_SHA256 = canonical_sha256
+_FROZEN_CANONICAL_SHA256_CODE = canonical_sha256.__code__
+_FROZEN_CANONICAL_SHA256_DEFAULTS = canonical_sha256.__defaults__
+_FROZEN_ALIAS_BINDINGS = (
+    ("debian", _DEBIAN_EXACT_ALIASES),
+    ("exact", _EXACT_ALIASES),
+    ("python-classifiers", _PYTHON_CLASSIFIERS),
+    ("python-exact", _PYTHON_EXACT_ALIASES),
+)
+
+
+def _callable_constant_identity(value):
+    if value is None:
+        return {"type": "none"}
+    if value is Ellipsis:
+        return {"type": "ellipsis"}
+    if type(value) is bool:
+        return {"type": "bool", "value": value}
+    if type(value) is int:
+        return {"type": "int", "value": str(value)}
+    if type(value) is float:
+        return {"type": "float", "value": value.hex()}
+    if type(value) is complex:
+        return {
+            "type": "complex",
+            "real": value.real.hex(),
+            "imag": value.imag.hex(),
+        }
+    if type(value) is str:
+        return {"type": "str", "value": value}
+    if type(value) is bytes:
+        return {"type": "bytes", "value": value.hex()}
+    if type(value) is tuple:
+        return {
+            "type": "tuple",
+            "items": [_callable_constant_identity(item) for item in value],
+        }
+    if type(value) is frozenset:
+        items = [_callable_constant_identity(item) for item in value]
+        return {
+            "type": "frozenset",
+            "items": sorted(
+                items,
+                key=lambda item: json.dumps(
+                    item,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=True,
+                    allow_nan=False,
+                ),
+            ),
+        }
+    if type(value) is _FROZEN_CODE_TYPE:
+        return {"type": "code", "value": _callable_code_identity(value)}
+    raise RuntimeError("agentic v2 license evaluator code constant is invalid")
+
+
+def _callable_code_identity(code: types.CodeType) -> dict[str, Any]:
+    return {
+        "argcount": code.co_argcount,
+        "posonlyargcount": code.co_posonlyargcount,
+        "kwonlyargcount": code.co_kwonlyargcount,
+        "nlocals": code.co_nlocals,
+        "stacksize": code.co_stacksize,
+        "flags": code.co_flags,
+        "code": code.co_code.hex(),
+        "constants": [
+            _callable_constant_identity(value) for value in code.co_consts
+        ],
+        "names": list(code.co_names),
+        "varnames": list(code.co_varnames),
+        "freevars": list(code.co_freevars),
+        "cellvars": list(code.co_cellvars),
+        "filename": "packaging/licenses/__init__.py",
+        "name": code.co_name,
+        "qualname": getattr(code, "co_qualname", code.co_name),
+        "firstlineno": code.co_firstlineno,
+        "line_table": getattr(code, "co_linetable", code.co_lnotab).hex(),
+        "exception_table": getattr(code, "co_exceptiontable", b"").hex(),
+    }
+
+
+_FROZEN_FUNCTION_TYPE = (lambda: None).__class__
+_FROZEN_CODE_TYPE = (lambda: None).__code__.__class__
+_FROZEN_MAPPING_PROXY_TYPE = _FROZEN_FUNCTION_TYPE.__dict__.__class__
+_FROZEN_BUILTIN_FUNCTION_TYPE = {}.get.__class__
+_FROZEN_STR_TYPE = "".__class__
+_FROZEN_BOOL_TYPE = (1 == 1).__class__
+_FROZEN_DICT_TYPE = {}.__class__
+_FROZEN_FLOAT_TYPE = (0.0).__class__
+_FROZEN_INT_TYPE = (0).__class__
+_FROZEN_LIST_TYPE = [].__class__
+_FROZEN_SET_TYPE = {None}.__class__
+_FROZEN_TUPLE_TYPE = ().__class__
+_FROZEN_TYPE_TYPE = _FROZEN_STR_TYPE.__class__
+_FROZEN_FROZENSET_TYPE = _INTERPRETER_FROZENSET_TYPE
+
+
+def _capture_value_error_type():
+    try:
+        "".index("missing")
+    except:  # noqa: E722
+        return sys.exc_info()[0]
+    raise RuntimeError("agentic v2 ValueError identity is unavailable")
+
+
+_FROZEN_VALUE_ERROR = _capture_value_error_type()
+_FROZEN_EXCEPTION = _FROZEN_VALUE_ERROR.__base__
+_FROZEN_BASE_EXCEPTION = _FROZEN_EXCEPTION.__base__
+
+
+def _capture_recursion_error_type():
+    def recurse():
+        return recurse()
+
+    try:
+        recurse()
+    except _FROZEN_BASE_EXCEPTION:
+        value = sys.exc_info()[0]
+        if value.__module__ == "builtins" and value.__qualname__ == "RecursionError":
+            return value
+    raise RuntimeError("agentic v2 RecursionError identity is unavailable")
+
+
+_FROZEN_RECURSION_ERROR = _capture_recursion_error_type()
+_FROZEN_RUNTIME_ERROR = _FROZEN_RECURSION_ERROR.__base__
+
+
+def _is_ascii_alphanumeric(value: str) -> bool:
+    return (
+        "0" <= value <= "9"
+        or "A" <= value <= "Z"
+        or "a" <= value <= "z"
+    )
+
+
+_FROZEN_ASCII_ALPHANUMERIC = _is_ascii_alphanumeric
+_FROZEN_ASCII_ALPHANUMERIC_CODE = _is_ascii_alphanumeric.__code__
+
+
+def _expression_tokens(
+    value: str,
+    str_type=_FROZEN_STR_TYPE,
+    ascii_alphanumeric=_FROZEN_ASCII_ALPHANUMERIC,
+) -> tuple[str, ...]:
+    if value.__class__ is not str_type:
+        return ()
+    tokens = []
+    start = None
+    index = 0
+    for character in value:
+        allowed = ascii_alphanumeric(character) or character in ".+-"
+        if allowed and start is None:
+            start = index
+        if not allowed and start is not None:
+            candidate = value[start:index]
+            start = None
+            while candidate and candidate[-1] in ".-":
+                candidate = candidate[:-1]
+            if candidate and ascii_alphanumeric(candidate[0]):
+                tokens.append(candidate)
+        index += 1
+    if start is not None:
+        candidate = value[start:]
+        while candidate and candidate[-1] in ".-":
+            candidate = candidate[:-1]
+        if candidate and ascii_alphanumeric(candidate[0]):
+            tokens.append(candidate)
+    return (*tokens,)
+
+
+_FROZEN_EXPRESSION_TOKENS = _expression_tokens
+_FROZEN_EXPRESSION_TOKENS_CODE = _expression_tokens.__code__
+_FROZEN_EXPRESSION_TOKENS_DEFAULTS = _expression_tokens.__defaults__
+
+
+def _license_ref_allowed(
+    value: str,
+    str_type=_FROZEN_STR_TYPE,
+    ascii_alphanumeric=_FROZEN_ASCII_ALPHANUMERIC,
+) -> bool:
+    if value.__class__ is not str_type:
+        return False
+    for character in value:
+        if not ascii_alphanumeric(character) and character not in ".-":
+            return False
+    return True
+
+
+_FROZEN_LICENSE_REF_ALLOWED = _license_ref_allowed
+_FROZEN_LICENSE_REF_ALLOWED_CODE = _license_ref_allowed.__code__
+_FROZEN_LICENSE_REF_ALLOWED_DEFAULTS = _license_ref_allowed.__defaults__
+
+
+def _clone_json(
+    value,
+    bool_type=_FROZEN_BOOL_TYPE,
+    int_type=_FROZEN_INT_TYPE,
+    float_type=_FROZEN_FLOAT_TYPE,
+    str_type=_FROZEN_STR_TYPE,
+    list_type=_FROZEN_LIST_TYPE,
+    dict_type=_FROZEN_DICT_TYPE,
+):
+    scalar_types = {bool_type, int_type, float_type, str_type}
+    def clone(item):
+        if item is None or item.__class__ in scalar_types:
+            return item
+        if item.__class__ is list_type:
+            return [clone(child) for child in item]
+        if item.__class__ is dict_type:
+            return {key: clone(child) for key, child in item.items()}
+        raise RuntimeError("agentic v2 license JSON value type is invalid")
+
+    return clone(value)
+
+
+def _is_lower_hex(
+    value,
+    length: int,
+    str_type=_FROZEN_STR_TYPE,
+) -> bool:
+    if value.__class__ is not str_type or value.__len__() != length:
+        return False
+    for character in value:
+        if not ("0" <= character <= "9" or "a" <= character <= "f"):
+            return False
+    return True
+
+
+def _is_license_file_token(
+    value,
+    str_type=_FROZEN_STR_TYPE,
+    ascii_alphanumeric=_FROZEN_ASCII_ALPHANUMERIC,
+) -> bool:
+    if (
+        value.__class__ is not str_type
+        or not value
+        or value.__len__() > 128
+        or not ascii_alphanumeric(value[0])
+    ):
+        return False
+    if value.__len__() > 1 and not (
+        ascii_alphanumeric(value[-1]) or value[-1] == "+"
+    ):
+        return False
+    for character in value:
+        if not ascii_alphanumeric(character) and character not in ".+-":
+            return False
+    return True
+
+
+def _ascii_words(
+    value,
+    str_type=_FROZEN_STR_TYPE,
+    ascii_alphanumeric=_FROZEN_ASCII_ALPHANUMERIC,
+) -> tuple[str, ...]:
+    if value.__class__ is not str_type:
+        return ()
+    words = []
+    start = None
+    index = 0
+    for character in value:
+        if ascii_alphanumeric(character):
+            if start is None:
+                start = index
+        elif start is not None:
+            words.append(value[start:index].casefold())
+            start = None
+        index += 1
+    if start is not None:
+        words.append(value[start:].casefold())
+    return (*words,)
+
+
+def _contains_words(
+    value,
+    expected: tuple[str, ...],
+    word_parser=_ascii_words,
+) -> bool:
+    words = word_parser(value)
+    width = expected.__len__()
+    if width == 0 or words.__len__() < width:
+        return False
+    index = 0
+    while index <= words.__len__() - width:
+        if words[index:index + width] == expected:
+            return True
+        index += 1
+    return False
+
+
+def _reference_filename(
+    value,
+    prefix: str,
+    str_type=_FROZEN_STR_TYPE,
+    ascii_alphanumeric=_FROZEN_ASCII_ALPHANUMERIC,
+) -> str | None:
+    if value.__class__ is not str_type or not value.startswith(prefix):
+        return None
+    filename = value[prefix.__len__():]
+    if not filename or not ascii_alphanumeric(filename[0]):
+        return None
+    for character in filename:
+        if not ascii_alphanumeric(character) and character not in "._+-":
+            return None
+    return filename
+
+
+def _split_debian_operators(
+    value: str,
+    str_type=_FROZEN_STR_TYPE,
+) -> list[str]:
+    if value.__class__ is not str_type:
+        return []
+    tokens = []
+    start = 0
+    index = 0
+    length = value.__len__()
+    while index < length:
+        if value[index] in "()":
+            if start < index:
+                tokens.append(value[start:index])
+            tokens.append(value[index])
+            index += 1
+            start = index
+            continue
+        candidate_start = index
+        if value[index] == ",":
+            index += 1
+            whitespace_start = index
+            while index < length and value[index].isspace():
+                index += 1
+            if index == whitespace_start:
+                index = candidate_start + 1
+                continue
+        elif value[index].isspace():
+            while index < length and value[index].isspace():
+                index += 1
+        else:
+            index += 1
+            continue
+        for operator in ("and", "or", "with"):
+            end = index + operator.__len__()
+            if (
+                value[index:end].casefold() == operator
+                and end < length
+                and value[end].isspace()
+            ):
+                while end < length and value[end].isspace():
+                    end += 1
+                if start < candidate_start:
+                    tokens.append(value[start:candidate_start])
+                tokens.append(operator)
+                index = end
+                start = end
+                break
+        else:
+            index = candidate_start + 1
+    if start < length:
+        tokens.append(value[start:])
+    return tokens
+
+
+def _freeze_spdx_collection(value, label: str):
+    if type(value) is not dict:
+        raise RuntimeError(f"agentic v2 {label} SPDX table is invalid")
+    frozen = {}
+    for key, item in value.items():
+        if (
+            type(key) is not str
+            or type(item) is not dict
+            or type(item.get("id")) is not str
+            or not item["id"]
+        ):
+            raise RuntimeError(f"agentic v2 {label} SPDX table is invalid")
+        frozen[key] = _FROZEN_MAPPING_PROXY_TYPE({"id": item["id"]})
+    return _FROZEN_MAPPING_PROXY_TYPE(frozen)
+
+
+_FROZEN_LICENSES = _freeze_spdx_collection(_spdx.LICENSES, "license")
+_FROZEN_EXCEPTIONS = _freeze_spdx_collection(_spdx.EXCEPTIONS, "exception")
+_REGISTERED_SPDX_IDENTIFIERS = _FROZEN_FROZENSET_TYPE(
+    value["id"]
+    for collection in (_FROZEN_LICENSES, _FROZEN_EXCEPTIONS)
+    for value in collection.values()
+)
+_TRUSTED_COMPILE = builtins.compile
+_TRUSTED_LEN = builtins.len
+_TRUSTED_ALL = builtins.all
+_TRUSTED_ANY = builtins.any
+_TRUSTED_BOOL = builtins.bool
+_TRUSTED_DICT = builtins.dict
+_TRUSTED_FROZENSET = builtins.frozenset
+_TRUSTED_GETATTR = builtins.getattr
+_TRUSTED_HASATTR = builtins.hasattr
+_TRUSTED_ISINSTANCE = builtins.isinstance
+_TRUSTED_LIST = builtins.list
+_TRUSTED_MAX = builtins.max
+_TRUSTED_MIN = builtins.min
+_TRUSTED_NEXT = builtins.next
+_TRUSTED_SET = builtins.set
+_TRUSTED_SORTED = builtins.sorted
+_TRUSTED_STR = builtins.str
+_TRUSTED_SUM = builtins.sum
+_TRUSTED_TUPLE = builtins.tuple
+_TRUSTED_TYPE = builtins.type
+_FROZEN_UPSTREAM_PARSER_CODE = (
+    _packaging_canonicalize_license_expression.__code__
+)
+
+
+def _capture_syntax_error_type():
+    try:
+        _TRUSTED_COMPILE("(", "", "eval")
+    except _FROZEN_BASE_EXCEPTION:
+        return sys.exc_info()[0]
+    raise RuntimeError("agentic v2 SyntaxError identity is unavailable")
+
+
+_TRUSTED_SYNTAX_ERROR = _capture_syntax_error_type()
+
+
+class _TransformLicenseParser(ast.NodeTransformer):
+    def __init__(self) -> None:
+        self.cast_replacements = 0
+        self.license_ref_replacements = 0
+
+    def visit_Call(self, node):
+        node = self.generic_visit(node)
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "cast"
+            and len(node.args) == 2
+            and not node.keywords
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "NormalizedLicenseExpression"
+        ):
+            self.cast_replacements += 1
+            return ast.copy_location(node.args[1], node)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "match"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "license_ref_allowed"
+            and len(node.args) == 1
+            and not node.keywords
+        ):
+            self.license_ref_replacements += 1
+            return ast.copy_location(
+                ast.Call(
+                    func=ast.Name(id="_license_ref_allowed", ctx=ast.Load()),
+                    args=node.args,
+                    keywords=[],
+                ),
+                node,
+            )
+        return node
+
+
+def _read_frozen_parser_source() -> bytes:
+    path = Path(str(packaging_licenses.__file__))
+    descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC)
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size < 0
+            or before.st_size > 1024 * 1024
+        ):
+            raise RuntimeError("agentic v2 license parser source is invalid")
+        chunks = []
+        while True:
+            chunk = os.read(descriptor, 64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    source = b"".join(chunks)
+    def identity(value):
+        return (
+            value.st_dev, value.st_ino, value.st_mode, value.st_nlink,
+            value.st_size, value.st_mtime_ns,
+        )
+
+    if (
+        identity(before) != identity(after)
+        or len(source) != before.st_size
+        or hashlib.sha256(source).hexdigest() != LICENSE_EVALUATOR_PARSER_SHA256
+    ):
+        raise RuntimeError("agentic v2 license parser source identity differs")
+    return source
+
+
+def _build_frozen_parser_code() -> types.CodeType:
+    tree = ast.parse(
+        _read_frozen_parser_source(),
+        filename="packaging/licenses/__init__.py",
+        mode="exec",
+    )
+    functions = [
+        node for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "canonicalize_license_expression"
+    ]
+    if len(functions) != 1 or not isinstance(functions[0], ast.FunctionDef):
+        raise RuntimeError("agentic v2 license parser function is invalid")
+    function = functions[0]
+    function.decorator_list = []
+    function.returns = None
+    for argument in (
+        *function.args.posonlyargs,
+        *function.args.args,
+        *function.args.kwonlyargs,
+    ):
+        argument.annotation = None
+    transformer = _TransformLicenseParser()
+    function = transformer.visit(function)
+    if (
+        transformer.cast_replacements != 1
+        or transformer.license_ref_replacements != 1
+    ):
+        raise RuntimeError("agentic v2 license parser transform shape is invalid")
+    module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+    namespace = {"__builtins__": {}}
+    exec(
+        _TRUSTED_COMPILE(
+            module,
+            "packaging/licenses/__init__.py",
+            "exec",
+            dont_inherit=True,
+            optimize=2,
+        ),
+        namespace,
+    )
+    parser = namespace.get("canonicalize_license_expression")
+    if type(parser) is not _FROZEN_FUNCTION_TYPE:
+        raise RuntimeError("agentic v2 frozen license parser is invalid")
+    return parser.__code__
+
+
+_FROZEN_PARSER_CODE = _build_frozen_parser_code()
+
+
+def _license_parser_binding_identity() -> dict[str, Any]:
+    if (
+        builtins.compile is not _TRUSTED_COMPILE
+        or builtins.len is not _TRUSTED_LEN
+        or builtins.all is not _TRUSTED_ALL
+        or builtins.any is not _TRUSTED_ANY
+        or builtins.bool is not _TRUSTED_BOOL
+        or builtins.dict is not _TRUSTED_DICT
+        or builtins.frozenset is not _TRUSTED_FROZENSET
+        or builtins.getattr is not _TRUSTED_GETATTR
+        or builtins.hasattr is not _TRUSTED_HASATTR
+        or builtins.isinstance is not _TRUSTED_ISINSTANCE
+        or builtins.list is not _TRUSTED_LIST
+        or builtins.max is not _TRUSTED_MAX
+        or builtins.min is not _TRUSTED_MIN
+        or builtins.next is not _TRUSTED_NEXT
+        or builtins.set is not _TRUSTED_SET
+        or builtins.sorted is not _TRUSTED_SORTED
+        or builtins.str is not _TRUSTED_STR
+        or builtins.sum is not _TRUSTED_SUM
+        or builtins.tuple is not _TRUSTED_TUPLE
+        or builtins.type is not _TRUSTED_TYPE
+        or builtins.SyntaxError is not _TRUSTED_SYNTAX_ERROR
+        or _TRUSTED_SYNTAX_ERROR.__module__ != "builtins"
+        or _TRUSTED_SYNTAX_ERROR.__qualname__ != "SyntaxError"
+        or _TRUSTED_SYNTAX_ERROR.__mro__[1:] != (
+            _FROZEN_EXCEPTION,
+            _FROZEN_BASE_EXCEPTION,
+            object,
+        )
+        or _FROZEN_VALUE_ERROR.__module__ != "builtins"
+        or _FROZEN_VALUE_ERROR.__qualname__ != "ValueError"
+        or _FROZEN_VALUE_ERROR.__mro__[1:] != (
+            _FROZEN_EXCEPTION,
+            _FROZEN_BASE_EXCEPTION,
+            object,
+        )
+        or builtins.RecursionError is not _FROZEN_RECURSION_ERROR
+        or _FROZEN_RECURSION_ERROR.__mro__[1:] != (
+            _FROZEN_RUNTIME_ERROR,
+            _FROZEN_EXCEPTION,
+            _FROZEN_BASE_EXCEPTION,
+            object,
+        )
+        or InvalidLicenseExpression is not packaging_licenses.InvalidLicenseExpression
+        or InvalidLicenseExpression.__module__ != "packaging.licenses"
+        or InvalidLicenseExpression.__qualname__ != "InvalidLicenseExpression"
+        or InvalidLicenseExpression.__bases__ != (_FROZEN_VALUE_ERROR,)
+        or _packaging_canonicalize_license_expression.__defaults__ is not None
+        or _packaging_canonicalize_license_expression.__kwdefaults__ is not None
+        or _packaging_canonicalize_license_expression.__closure__ is not None
+    ):
+        raise RuntimeError("agentic v2 license evaluator binding identity differs")
+    try:
+        _TRUSTED_COMPILE("(", "", "eval")
+    except _FROZEN_BASE_EXCEPTION:
+        if sys.exc_info()[0] is not _TRUSTED_SYNTAX_ERROR:
+            raise RuntimeError(
+                "agentic v2 license evaluator builtin behavior differs"
+            )
+    else:
+        raise RuntimeError("agentic v2 license evaluator builtin behavior differs")
+    return {
+        "builtins": [
+            _trusted_builtin_identity(_TRUSTED_ALL, "all"),
+            _trusted_builtin_identity(_TRUSTED_ANY, "any"),
+            _trusted_builtin_identity(_TRUSTED_COMPILE, "compile"),
+            _trusted_builtin_identity(_TRUSTED_GETATTR, "getattr"),
+            _trusted_builtin_identity(_TRUSTED_HASATTR, "hasattr"),
+            _trusted_builtin_identity(_TRUSTED_ISINSTANCE, "isinstance"),
+            _trusted_builtin_identity(_TRUSTED_LEN, "len"),
+            _trusted_builtin_identity(_TRUSTED_MAX, "max"),
+            _trusted_builtin_identity(_TRUSTED_MIN, "min"),
+            _trusted_builtin_identity(_TRUSTED_NEXT, "next"),
+            _trusted_builtin_identity(_TRUSTED_SORTED, "sorted"),
+            _trusted_builtin_identity(_TRUSTED_SUM, "sum"),
+            _trusted_type_identity(_TRUSTED_BOOL, _FROZEN_BOOL_TYPE, "bool"),
+            _trusted_type_identity(_TRUSTED_DICT, _FROZEN_DICT_TYPE, "dict"),
+            _trusted_type_identity(
+                _TRUSTED_FROZENSET,
+                _FROZEN_FROZENSET_TYPE,
+                "frozenset",
+            ),
+            _trusted_type_identity(_TRUSTED_LIST, _FROZEN_LIST_TYPE, "list"),
+            _trusted_type_identity(_TRUSTED_SET, _FROZEN_SET_TYPE, "set"),
+            _trusted_type_identity(_TRUSTED_STR, _FROZEN_STR_TYPE, "str"),
+            _trusted_type_identity(_TRUSTED_TUPLE, _FROZEN_TUPLE_TYPE, "tuple"),
+            _trusted_type_identity(_TRUSTED_TYPE, _FROZEN_TYPE_TYPE, "type"),
+            {"module": "builtins", "qualname": "SyntaxError"},
+            {"module": "builtins", "qualname": "ValueError"},
+            {"module": "builtins", "qualname": "RecursionError"},
+        ],
+        "exceptions": sorted(
+            (key, value["id"]) for key, value in _FROZEN_EXCEPTIONS.items()
+        ),
+        "invalid_expression": {
+            "module": "builtins",
+            "qualname": "ValueError",
+        },
+        "licenses": sorted(
+            (key, value["id"]) for key, value in _FROZEN_LICENSES.items()
+        ),
+        "transform": "remove-cast-and-license-ref-regex-v2",
+        "function_type": {"module": "builtins", "qualname": "function"},
+    }
+
+
+def _execute_frozen_license_parser(
+    value: str,
+    _code=_FROZEN_PARSER_CODE,
+    _function_type=_FROZEN_FUNCTION_TYPE,
+    _compile=_TRUSTED_COMPILE,
+    _length=_TRUSTED_LEN,
+    _syntax_error=_TRUSTED_SYNTAX_ERROR,
+    _licenses=_FROZEN_LICENSES,
+    _exceptions=_FROZEN_EXCEPTIONS,
+    _license_ref_allowed=_FROZEN_LICENSE_REF_ALLOWED,
+    _invalid_expression=_FROZEN_VALUE_ERROR,
+):
+    parser_globals = {
+        "__builtins__": {
+            "compile": _compile,
+            "len": _length,
+            "SyntaxError": _syntax_error,
+        },
+        "EXCEPTIONS": _exceptions,
+        "InvalidLicenseExpression": _invalid_expression,
+        "LICENSES": _licenses,
+        "_license_ref_allowed": _license_ref_allowed,
+    }
+    parser = _function_type(
+        _code,
+        parser_globals,
+        "canonicalize_license_expression",
+    )
+    return parser(value)
+
+
+_FROZEN_PARSER_EXECUTOR = _execute_frozen_license_parser
+_FROZEN_PARSER_EXECUTOR_CODE = _execute_frozen_license_parser.__code__
+_FROZEN_PARSER_EXECUTOR_DEFAULTS = _execute_frozen_license_parser.__defaults__
+
+
+def _trusted_builtin_identity(value, name: str) -> dict[str, str]:
+    if (
+        value.__class__ is not _FROZEN_BUILTIN_FUNCTION_TYPE
+        or value.__module__ != "builtins"
+        or value.__name__ != name
+        or value.__qualname__ != name
+        or value.__self__ is not builtins
+    ):
+        raise RuntimeError("agentic v2 license evaluator builtin identity differs")
+    return {"module": "builtins", "qualname": name}
+
+
+def _trusted_type_identity(value, expected, name: str) -> dict[str, str]:
+    if (
+        value is not expected
+        or value.__class__ is not _FROZEN_TYPE_TYPE
+        or value.__module__ != "builtins"
+        or value.__name__ != name
+        or value.__qualname__ != name
+    ):
+        raise RuntimeError("agentic v2 license evaluator type identity differs")
+    return {"module": "builtins", "qualname": name}
 
 
 def license_evaluator_runtime_identity() -> dict[str, str]:
@@ -191,15 +875,62 @@ def license_evaluator_runtime_identity() -> dict[str, str]:
         packaging_path != expected_paths["packaging/__init__.py"]
         or parser_path != expected_paths["packaging/licenses/__init__.py"]
         or spdx_path != expected_paths["packaging/licenses/_spdx.py"]
-        or canonicalize_license_expression
+        or _packaging_canonicalize_license_expression
         is not packaging_licenses.canonicalize_license_expression
-        or canonicalize_license_expression.__module__ != "packaging.licenses"
-        or canonicalize_license_expression.__qualname__
+        or _packaging_canonicalize_license_expression.__module__
+        != "packaging.licenses"
+        or _packaging_canonicalize_license_expression.__qualname__
         != "canonicalize_license_expression"
-        or not hasattr(canonicalize_license_expression, "__code__")
-        or Path(canonicalize_license_expression.__code__.co_filename) != parser_path
-        or canonicalize_license_expression.__globals__
+        or not hasattr(_packaging_canonicalize_license_expression, "__code__")
+        or Path(
+            _packaging_canonicalize_license_expression.__code__.co_filename
+        ) != parser_path
+        or _packaging_canonicalize_license_expression.__code__
+        is not _FROZEN_UPSTREAM_PARSER_CODE
+        or _packaging_canonicalize_license_expression.__globals__
         is not packaging_licenses.__dict__
+        or _execute_frozen_license_parser is not _FROZEN_PARSER_EXECUTOR
+        or _execute_frozen_license_parser.__code__
+        is not _FROZEN_PARSER_EXECUTOR_CODE
+        or _execute_frozen_license_parser.__defaults__
+        is not _FROZEN_PARSER_EXECUTOR_DEFAULTS
+        or _is_ascii_alphanumeric is not _FROZEN_ASCII_ALPHANUMERIC
+        or _is_ascii_alphanumeric.__code__
+        is not _FROZEN_ASCII_ALPHANUMERIC_CODE
+        or _expression_tokens is not _FROZEN_EXPRESSION_TOKENS
+        or _expression_tokens.__code__ is not _FROZEN_EXPRESSION_TOKENS_CODE
+        or _expression_tokens.__defaults__
+        is not _FROZEN_EXPRESSION_TOKENS_DEFAULTS
+        or _license_ref_allowed is not _FROZEN_LICENSE_REF_ALLOWED
+        or _license_ref_allowed.__code__ is not _FROZEN_LICENSE_REF_ALLOWED_CODE
+        or _license_ref_allowed.__defaults__
+        is not _FROZEN_LICENSE_REF_ALLOWED_DEFAULTS
+        or _identifiers is not _FROZEN_IDENTIFIERS
+        or _identifiers.__code__ is not _FROZEN_IDENTIFIERS_CODE
+        or _identifiers.__defaults__ is not _FROZEN_IDENTIFIERS_DEFAULTS
+        or _valid_expression_shape is not _FROZEN_VALID_EXPRESSION_SHAPE
+        or _valid_expression_shape.__code__
+        is not _FROZEN_VALID_EXPRESSION_SHAPE_CODE
+        or _valid_expression_shape.__defaults__
+        is not _FROZEN_VALID_EXPRESSION_SHAPE_DEFAULTS
+        or _canonical is not _FROZEN_CANONICAL
+        or _canonical.__code__ is not _FROZEN_CANONICAL_CODE
+        or _canonical.__defaults__ is not _FROZEN_CANONICAL_DEFAULTS
+        or _classification_surface_identity
+        is not _FROZEN_CLASSIFICATION_IDENTITY
+        or _classification_surface_identity.__code__
+        is not _FROZEN_CLASSIFICATION_IDENTITY_CODE
+        or _classification_surface_identity.__defaults__
+        is not _FROZEN_CLASSIFICATION_IDENTITY_DEFAULTS
+        or _Outcome is not _FROZEN_OUTCOME_TYPE
+        or _Outcome.__init__ is not _FROZEN_OUTCOME_INIT
+        or _Outcome.__init__.__code__ is not _FROZEN_OUTCOME_INIT_CODE
+        or _Outcome.__init__.__defaults__ is not _FROZEN_OUTCOME_INIT_DEFAULTS
+        or date is not _FROZEN_DATE_TYPE
+        or canonical_sha256 is not _FROZEN_CANONICAL_SHA256
+        or canonical_sha256.__code__ is not _FROZEN_CANONICAL_SHA256_CODE
+        or canonical_sha256.__defaults__ is not _FROZEN_CANONICAL_SHA256_DEFAULTS
+        or types.FunctionType is not _FROZEN_FUNCTION_TYPE
         or packaging_licenses.LICENSES is not _spdx.LICENSES
         or packaging_licenses.EXCEPTIONS is not _spdx.EXCEPTIONS
         or InvalidLicenseExpression
@@ -260,19 +991,119 @@ def license_evaluator_runtime_identity() -> dict[str, str]:
             "sha256": hashlib.sha256(source_bytes).hexdigest(),
             "size": len(source_bytes),
         })
-    def normalize_code(code):
-        constants = tuple(
-            normalize_code(value) if isinstance(value, types.CodeType) else value
-            for value in code.co_consts
+    current_licenses = _freeze_spdx_collection(_spdx.LICENSES, "license")
+    current_exceptions = _freeze_spdx_collection(_spdx.EXCEPTIONS, "exception")
+    if (
+        dict(current_licenses) != dict(_FROZEN_LICENSES)
+        or dict(current_exceptions) != dict(_FROZEN_EXCEPTIONS)
+    ):
+        raise RuntimeError("agentic v2 license evaluator SPDX bindings differ")
+    alias_globals = {
+        "debian": _DEBIAN_EXACT_ALIASES,
+        "exact": _EXACT_ALIASES,
+        "python-classifiers": _PYTHON_CLASSIFIERS,
+        "python-exact": _PYTHON_EXACT_ALIASES,
+    }
+    for name, mapping in _FROZEN_ALIAS_BINDINGS:
+        if (
+            alias_globals.get(name) is not mapping
+            or mapping.__class__ is not _FROZEN_MAPPING_PROXY_TYPE
+            or any(
+                key.__class__ is not _FROZEN_STR_TYPE
+                or value.__class__ is not _FROZEN_STR_TYPE
+                for key, value in mapping.items()
+            )
+        ):
+            raise RuntimeError("agentic v2 license alias bindings differ")
+    policy_date = _FROZEN_DATE_TYPE.fromisoformat("2026-07-31")
+    later_date = _FROZEN_DATE_TYPE.fromisoformat("2027-07-31")
+    if (
+        policy_date.__class__ is not _FROZEN_DATE_TYPE
+        or policy_date.isoformat() != "2026-07-31"
+        or later_date.__class__ is not _FROZEN_DATE_TYPE
+        or not policy_date < later_date
+        or _FROZEN_DATE_TYPE.__module__ != "datetime"
+        or _FROZEN_DATE_TYPE.__qualname__ != "date"
+    ):
+        raise RuntimeError("agentic v2 license date binding differs")
+    if (
+        _FROZEN_IDENTIFIERS_DEFAULTS != (
+            _FROZEN_EXPRESSION_TOKENS,
+            _FROZEN_FROZENSET_TYPE,
         )
-        return code.replace(
-            co_consts=constants,
-            co_filename="packaging/licenses/__init__.py",
+        or _FROZEN_EXPRESSION_TOKENS_DEFAULTS != (
+            _FROZEN_STR_TYPE,
+            _FROZEN_ASCII_ALPHANUMERIC,
         )
-
-    callable_sha256 = hashlib.sha256(marshal.dumps(normalize_code(
-        canonicalize_license_expression.__code__
-    ))).hexdigest()
+        or _FROZEN_LICENSE_REF_ALLOWED_DEFAULTS != (
+            _FROZEN_STR_TYPE,
+            _FROZEN_ASCII_ALPHANUMERIC,
+        )
+        or _FROZEN_VALID_EXPRESSION_SHAPE_DEFAULTS != (
+            _FROZEN_STR_TYPE,
+            _TRUSTED_LEN,
+            _MAX_LICENSE_EXPRESSION_LENGTH,
+            _MAX_LICENSE_EXPRESSION_DEPTH,
+            _MAX_LICENSE_EXPRESSION_TOKENS,
+        )
+        or _FROZEN_CANONICAL_DEFAULTS != (
+            _FROZEN_PARSER_EXECUTOR,
+            _FROZEN_VALID_EXPRESSION_SHAPE,
+            _FROZEN_IDENTIFIERS,
+            _REGISTERED_SPDX_IDENTIFIERS,
+            (_FROZEN_VALUE_ERROR, _FROZEN_RECURSION_ERROR),
+            _FROZEN_STR_TYPE,
+        )
+    ):
+        raise RuntimeError("agentic v2 canonicalizer bindings differ")
+    callable_sha256 = canonical_sha256({
+        "aliases": {
+            name: sorted(mapping.items())
+            for name, mapping in _FROZEN_ALIAS_BINDINGS
+        },
+        "bindings": _license_parser_binding_identity(),
+        "canonical": _callable_code_identity(_FROZEN_CANONICAL_CODE),
+        "canonical_sha256": _callable_code_identity(
+            _FROZEN_CANONICAL_SHA256_CODE
+        ),
+        "classification_checker": _callable_code_identity(
+            _FROZEN_CLASSIFICATION_IDENTITY_CODE
+        ),
+        "classification_surface": _classification_surface_identity(),
+        "canonical_bindings": {
+            "errors": ["builtins.RecursionError", "builtins.ValueError"],
+            "expression_tokenizer": "ascii-alnum-dot-plus-hyphen-v1",
+            "limits": {
+                "depth": _MAX_LICENSE_EXPRESSION_DEPTH,
+                "length": _MAX_LICENSE_EXPRESSION_LENGTH,
+                "tokens": _MAX_LICENSE_EXPRESSION_TOKENS,
+            },
+            "registered": sorted(_REGISTERED_SPDX_IDENTIFIERS),
+            "return_type": "builtins.str",
+        },
+        "executor": _callable_code_identity(_FROZEN_PARSER_EXECUTOR_CODE),
+        "expression_tokens": _callable_code_identity(
+            _FROZEN_EXPRESSION_TOKENS_CODE
+        ),
+        "identifiers": _callable_code_identity(_FROZEN_IDENTIFIERS_CODE),
+        "license_ref_allowed": _callable_code_identity(
+            _FROZEN_LICENSE_REF_ALLOWED_CODE
+        ),
+        "outcome": {
+            "init": _callable_code_identity(_FROZEN_OUTCOME_INIT_CODE),
+            "module": _FROZEN_OUTCOME_TYPE.__module__,
+            "qualname": _FROZEN_OUTCOME_TYPE.__qualname__,
+        },
+        "parser": _callable_code_identity(_FROZEN_PARSER_CODE),
+        "shape": _callable_code_identity(
+            _FROZEN_VALID_EXPRESSION_SHAPE_CODE
+        ),
+        "date": {
+            "module": "datetime",
+            "qualname": "date",
+            "ordering": "2026-07-31<2027-07-31",
+        },
+    })
     payload = {
         "packaging_version": packaging.__version__,
         "spdx_version": _spdx.VERSION,
@@ -303,16 +1134,30 @@ def license_evaluator_runtime_identity() -> dict[str, str]:
     return identity
 
 
-def _identifiers(expression: str) -> frozenset[str]:
-    return frozenset(
+def _identifiers(
+    expression: str,
+    tokenizer=_FROZEN_EXPRESSION_TOKENS,
+    frozen_type=_FROZEN_FROZENSET_TYPE,
+) -> frozenset[str]:
+    return frozen_type(
         token
-        for token in _EXPRESSION_TOKEN.findall(expression)
+        for token in tokenizer(expression)
         if token not in {"AND", "OR", "WITH"}
     )
 
 
-def _valid_expression_shape(expression: Any) -> bool:
-    if not isinstance(expression, str) or len(expression) > _MAX_LICENSE_EXPRESSION_LENGTH:
+def _valid_expression_shape(
+    expression: Any,
+    str_type=_FROZEN_STR_TYPE,
+    length=_TRUSTED_LEN,
+    max_length=_MAX_LICENSE_EXPRESSION_LENGTH,
+    max_depth=_MAX_LICENSE_EXPRESSION_DEPTH,
+    max_tokens=_MAX_LICENSE_EXPRESSION_TOKENS,
+) -> bool:
+    if (
+        expression.__class__ is not str_type
+        or length(expression) > max_length
+    ):
         return False
     depth = 0
     maximum_depth = 0
@@ -321,7 +1166,8 @@ def _valid_expression_shape(expression: Any) -> bool:
     for character in expression:
         if character == "(":
             depth += 1
-            maximum_depth = max(maximum_depth, depth)
+            if depth > maximum_depth:
+                maximum_depth = depth
             tokens += 1
             in_token = False
         elif character == ")":
@@ -339,23 +1185,44 @@ def _valid_expression_shape(expression: Any) -> bool:
             tokens += 1
             in_token = True
         if (
-            maximum_depth > _MAX_LICENSE_EXPRESSION_DEPTH
-            or tokens > _MAX_LICENSE_EXPRESSION_TOKENS
+            maximum_depth > max_depth
+            or tokens > max_tokens
         ):
             return False
     return depth == 0
 
 
-def _canonical(expression: Any) -> str | None:
-    if not _valid_expression_shape(expression):
+def _canonical(
+    expression: Any,
+    parser=_FROZEN_PARSER_EXECUTOR,
+    valid_shape=_valid_expression_shape,
+    identifiers=_identifiers,
+    registered=_REGISTERED_SPDX_IDENTIFIERS,
+    errors=(_FROZEN_VALUE_ERROR, _FROZEN_RECURSION_ERROR),
+    str_type=_FROZEN_STR_TYPE,
+) -> str | None:
+    if not valid_shape(expression):
         return None
     try:
-        canonical = str(canonicalize_license_expression(expression))
-    except (InvalidLicenseExpression, RecursionError):
+        canonical = parser(expression)
+    except errors:
         return None
-    if not _identifiers(canonical).issubset(_REGISTERED_SPDX_IDENTIFIERS):
+    if canonical.__class__ is not str_type:
+        return None
+    if not identifiers(canonical).issubset(registered):
         return None
     return canonical
+
+
+_FROZEN_IDENTIFIERS = _identifiers
+_FROZEN_IDENTIFIERS_CODE = _identifiers.__code__
+_FROZEN_IDENTIFIERS_DEFAULTS = _identifiers.__defaults__
+_FROZEN_VALID_EXPRESSION_SHAPE = _valid_expression_shape
+_FROZEN_VALID_EXPRESSION_SHAPE_CODE = _valid_expression_shape.__code__
+_FROZEN_VALID_EXPRESSION_SHAPE_DEFAULTS = _valid_expression_shape.__defaults__
+_FROZEN_CANONICAL = _canonical
+_FROZEN_CANONICAL_CODE = _canonical.__code__
+_FROZEN_CANONICAL_DEFAULTS = _canonical.__defaults__
 
 
 def _atom(value: str, aliases: Mapping[str, str]) -> _Outcome:
@@ -378,12 +1245,14 @@ def _atom(value: str, aliases: Mapping[str, str]) -> _Outcome:
         None,
         "ambiguous" if ambiguous else "unverifiable",
         "ambiguous-license-label" if ambiguous else "unmapped-exact-license-label",
-        frozenset(),
+        _FROZEN_FROZENSET_TYPE(),
     )
 
 
 def _combine(operator: str, outcomes: list[_Outcome], reason: str) -> _Outcome:
-    identifiers = frozenset().union(*(item.identifiers for item in outcomes))
+    identifiers = _FROZEN_FROZENSET_TYPE().union(
+        *(item.identifiers for item in outcomes)
+    )
     issues = [item.issue for item in outcomes if item.issue]
     if issues:
         issue = "ambiguous" if "ambiguous" in issues else "unverifiable"
@@ -406,12 +1275,15 @@ def _debian_expression(raw: str) -> _Outcome:
             None,
             "unverifiable",
             "invalid-debian-license-expression-shape",
-            frozenset(),
+            _FROZEN_FROZENSET_TYPE(),
         )
     direct = _atom(raw, {**_EXACT_ALIASES, **_DEBIAN_EXACT_ALIASES})
     if direct.expression is not None:
         return direct
-    tokens = [token for token in _DEBIAN_OPERATORS.split(raw) if token and token.strip()]
+    tokens = [
+        token for token in _split_debian_operators(raw)
+        if token and token.strip()
+    ]
     if len(tokens) == 1:
         return direct
 
@@ -517,7 +1389,7 @@ def _python_outcome(record: Mapping[str, Any]) -> _Outcome:
             ambiguous_classifier = True
         else:
             unknown_classifier = True
-    all_identifiers = frozenset().union(*(
+    all_identifiers = _FROZEN_FROZENSET_TYPE().union(*(
         item.identifiers for item in outcomes + classifier_values
     ))
     if unknown_classifier:
@@ -579,7 +1451,9 @@ def _python_outcome(record: Mapping[str, Any]) -> _Outcome:
     if len(resolved) > 1:
         return _Outcome(
             None, "ambiguous", "conflicting-python-license-metadata",
-            frozenset().union(*(item.identifiers for item in outcomes + classifier_values)),
+            _FROZEN_FROZENSET_TYPE().union(*(
+                item.identifiers for item in outcomes + classifier_values
+            )),
         )
     if resolved:
         return _Outcome(
@@ -588,8 +1462,18 @@ def _python_outcome(record: Mapping[str, Any]) -> _Outcome:
             _identifiers(resolved[0]),
         )
     if not record["raw_values"]:
-        return _Outcome(None, "missing_metadata", "python-license-metadata-missing", frozenset())
-    return _Outcome(None, "unverifiable", "python-license-metadata-unverifiable", frozenset())
+        return _Outcome(
+            None,
+            "missing_metadata",
+            "python-license-metadata-missing",
+            _FROZEN_FROZENSET_TYPE(),
+        )
+    return _Outcome(
+        None,
+        "unverifiable",
+        "python-license-metadata-unverifiable",
+        _FROZEN_FROZENSET_TYPE(),
+    )
 
 
 def _r_outcome(record: Mapping[str, Any]) -> _Outcome:
@@ -602,7 +1486,7 @@ def _r_outcome(record: Mapping[str, Any]) -> _Outcome:
             None,
             "unverifiable",
             "invalid-r-license-expression-shape",
-            frozenset(),
+            _FROZEN_FROZENSET_TYPE(),
         )
     if (
         isinstance(declared, str)
@@ -618,22 +1502,27 @@ def _r_outcome(record: Mapping[str, Any]) -> _Outcome:
                 None,
                 "unverifiable",
                 "r-runtime-copyright-unstructured",
-                frozenset(),
+                _FROZEN_FROZENSET_TYPE(),
             )
         if not isinstance(runtime, str) or not runtime:
-            return _Outcome(None, "missing_metadata", "r-runtime-license-missing", frozenset())
+            return _Outcome(
+                None,
+                "missing_metadata",
+                "r-runtime-license-missing",
+                _FROZEN_FROZENSET_TYPE(),
+            )
         if not _valid_expression_shape(runtime):
             return _Outcome(
                 None,
                 "unverifiable",
                 "invalid-r-license-expression-shape",
-                frozenset(),
+                _FROZEN_FROZENSET_TYPE(),
             )
         parts = [part.strip() for part in runtime.split("|")]
         if not parts or any(not part for part in parts):
             return _Outcome(
                 None, "unverifiable", "invalid-r-license-alternatives",
-                frozenset(),
+                _FROZEN_FROZENSET_TYPE(),
             )
         outcomes = [_atom(part, _DEBIAN_EXACT_ALIASES) for part in parts]
         return _combine("OR", outcomes, "r-base-runtime-license")
@@ -642,18 +1531,23 @@ def _r_outcome(record: Mapping[str, Any]) -> _Outcome:
             None,
             "unverifiable",
             "invalid-r-runtime-license-reference",
-            frozenset(),
+            _FROZEN_FROZENSET_TYPE(),
         )
     if isinstance(declared, str) and declared:
         parts = [part.strip() for part in declared.split("|")]
         if not parts or any(not part for part in parts):
             return _Outcome(
                 None, "unverifiable", "invalid-r-license-alternatives",
-                frozenset(),
+                _FROZEN_FROZENSET_TYPE(),
             )
         outcomes = [_atom(part, _DEBIAN_EXACT_ALIASES) for part in parts]
         return _combine("OR", outcomes, "r-description-license")
-    return _Outcome(None, "missing_metadata", "r-license-metadata-missing", frozenset())
+    return _Outcome(
+        None,
+        "missing_metadata",
+        "r-license-metadata-missing",
+        _FROZEN_FROZENSET_TYPE(),
+    )
 
 
 def _normalize(record: Mapping[str, Any]) -> _Outcome:
@@ -669,7 +1563,7 @@ def _normalize(record: Mapping[str, Any]) -> _Outcome:
                     None,
                     "unverifiable",
                     "debian-copyright-path-unverifiable",
-                    frozenset(),
+                    _FROZEN_FROZENSET_TYPE(),
                 )
             if not any(
                 item["source"] == "debian-copyright"
@@ -679,11 +1573,11 @@ def _normalize(record: Mapping[str, Any]) -> _Outcome:
                     None,
                     "missing_metadata",
                     "debian-copyright-metadata-missing",
-                    frozenset(),
+                    _FROZEN_FROZENSET_TYPE(),
                 )
             return _Outcome(
                 None, "unverifiable", "debian-copyright-has-no-dep5-license-fields",
-                frozenset(),
+                _FROZEN_FROZENSET_TYPE(),
             )
         outcomes = [_debian_expression(value) for value in raw_values]
         return _combine("AND", outcomes, "debian-file-stanza-license-conjunction")
@@ -693,13 +1587,18 @@ def _normalize(record: Mapping[str, Any]) -> _Outcome:
         return _r_outcome(record)
     if ecosystem == "npm":
         if not record["raw_values"]:
-            return _Outcome(None, "missing_metadata", "npm-license-missing", frozenset())
+            return _Outcome(
+                None,
+                "missing_metadata",
+                "npm-license-missing",
+                _FROZEN_FROZENSET_TYPE(),
+            )
         return _atom(record["raw_values"][0], _EXACT_ALIASES)
     raise ValueError("unsupported license evidence ecosystem")
 
 
 def _validate_evidence_item(value: Any) -> dict[str, Any]:
-    if not isinstance(value, Mapping) or set(value) != {
+    if not isinstance(value, Mapping) or {item for item in value} != {
         "source", "path", "resolved_path", "sha256", "size",
     }:
         raise ValueError("agentic v2 license evidence item fields are invalid")
@@ -707,7 +1606,7 @@ def _validate_evidence_item(value: Any) -> dict[str, Any]:
     if (
         not isinstance(item["source"], str)
         or not item["source"]
-        or not _matches(_HEX_DIGEST, item["sha256"])
+        or not _is_lower_hex(item["sha256"], 64)
         or type(item["size"]) is not int
         or item["size"] < 0
     ):
@@ -759,11 +1658,11 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
     def valid_file_tokens(value: Any) -> bool:
         return (
             isinstance(value, list)
-            and value == sorted(set(value))
+            and value == sorted({item for item in value})
             and len(value) <= 4096
             and all(
                 isinstance(item, str)
-                and _LICENSE_FILE_TOKEN_TEXT.fullmatch(item) is not None
+                and _is_license_file_token(item)
                 and "-" in item
                 for item in value
             )
@@ -779,7 +1678,7 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
             if item["source"] == "debian-copyright-path-unverifiable"
         ]
         if (
-            set(metadata) != {"architecture", "copyright_format"}
+            {item for item in metadata} != {"architecture", "copyright_format"}
             or not isinstance(metadata["architecture"], str)
             or not metadata["architecture"]
             or metadata["architecture"] != metadata["architecture"].strip()
@@ -791,7 +1690,7 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
                 or metadata["copyright_format"]
                 != metadata["copyright_format"].strip()
             )
-            or raw_values != sorted(set(raw_values))
+            or raw_values != sorted({item for item in raw_values})
             or any(
                 not isinstance(item, str)
                 or not item
@@ -853,7 +1752,7 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
         return
     if ecosystem == "python":
         if (
-            set(metadata) != {
+            {item for item in metadata} != {
                 "license_expression", "license", "classifiers",
                 "license_file_tokens", "license_files",
             }
@@ -862,7 +1761,9 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
                 for key in ("license_expression", "license")
             )
             or not isinstance(metadata["classifiers"], list)
-            or metadata["classifiers"] != sorted(set(metadata["classifiers"]))
+            or metadata["classifiers"] != sorted({
+                item for item in metadata["classifiers"]
+            })
             or any(not isinstance(item, str) for item in metadata["classifiers"])
             or not valid_file_tokens(metadata["license_file_tokens"])
             or not isinstance(metadata["license_files"], list)
@@ -896,11 +1797,11 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
             raise ValueError("agentic v2 Python METADATA path is invalid")
         distribution_root = metadata_file.parent
         expected_paths = []
-        declared = set()
+        declared = {item for item in ()}
         for selection in metadata["license_files"]:
             if (
                 not isinstance(selection, Mapping)
-                or set(selection) != {"declared", "path"}
+                or {item for item in selection} != {"declared", "path"}
                 or not isinstance(selection["declared"], str)
                 or not selection["declared"]
                 or PurePosixPath(selection["declared"]).is_absolute()
@@ -931,7 +1832,7 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
         return
     if ecosystem == "r":
         if (
-            set(metadata) != {
+            {item for item in metadata} != {
                 "declared_license", "priority", "runtime_license",
                 "runtime_license_fields", "runtime_copyright_format",
                 "runtime_version",
@@ -959,9 +1860,9 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
                 or metadata["priority"] != metadata["priority"].strip()
             )
             or not isinstance(metadata["runtime_license_fields"], list)
-            or metadata["runtime_license_fields"] != sorted(
-                set(metadata["runtime_license_fields"])
-            )
+            or metadata["runtime_license_fields"] != sorted({
+                item for item in metadata["runtime_license_fields"]
+            })
             or any(
                 not isinstance(item, str)
                 or not item
@@ -983,7 +1884,7 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
             if value
         ]
         sources = [item["source"] for item in evidence]
-        reference = _R_LICENSE_REFERENCE.fullmatch(metadata["declared_license"])
+        reference = _reference_filename(metadata["declared_license"], "file ")
         reference_items = [item for item in evidence if item["source"] == "r-license-file"]
         if (
             raw_values != expected_raw
@@ -1047,7 +1948,7 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
                 _require_resolved_under(item, "/usr/share/R/share/licenses")
         if reference is not None:
             referenced_path = (
-                f"/usr/lib/R/library/{record['package']}/{reference.group(1)}"
+            f"/usr/lib/R/library/{record['package']}/{reference}"
             )
             _require_exact_path(reference_items[0], referenced_path)
             _require_resolved_under(
@@ -1055,7 +1956,10 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
             )
         return
     if ecosystem == "npm":
-        reference = _NPM_LICENSE_REFERENCE.fullmatch(metadata.get("license", ""))
+        reference = _reference_filename(
+            metadata.get("license", ""),
+            "SEE LICENSE IN ",
+        )
         package_items = [
             item for item in evidence if item["source"] == "npm-package-json"
         ]
@@ -1063,7 +1967,7 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
             item for item in evidence if item["source"] == "npm-license-file"
         ]
         if (
-            set(metadata) != {"license", "license_file_tokens"}
+            {item for item in metadata} != {"license", "license_file_tokens"}
             or not isinstance(metadata["license"], str)
             or not metadata["license"]
             or metadata["license"] != metadata["license"].strip()
@@ -1079,7 +1983,7 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
         _require_resolved_under(package_items[0], "/usr/share/nodejs/npm")
         if reference is not None:
             _require_exact_path(
-                reference_items[0], f"/usr/share/nodejs/npm/{reference.group(1)}"
+                reference_items[0], f"/usr/share/nodejs/npm/{reference}"
             )
             _require_resolved_under(reference_items[0], "/usr/share/nodejs/npm")
         return
@@ -1090,11 +1994,11 @@ def validate_license_evidence(
     value: Any,
     sbom: Mapping[str, Any],
 ) -> dict[str, Any]:
-    if not isinstance(value, Mapping) or set(value) != {
+    if not isinstance(value, Mapping) or {item for item in value} != {
         "schema_version", "collector", "records", "records_sha256",
     }:
         raise ValueError("agentic v2 license evidence fields are invalid")
-    document = deepcopy(dict(value))
+    document = _clone_json({key: item for key, item in value.items()})
     if (
         document["schema_version"] != "1.0"
         or document["collector"] != "gdpval-agentic-v2-license-evidence-v1"
@@ -1122,7 +2026,7 @@ def validate_license_evidence(
         "npm": "pkg:npm/",
     }
     for raw_record in document["records"]:
-        if not isinstance(raw_record, Mapping) or set(raw_record) != {
+        if not isinstance(raw_record, Mapping) or {item for item in raw_record} != {
             "ecosystem", "package", "version", "purl", "raw_values",
             "metadata", "evidence",
         }:
@@ -1190,8 +2094,11 @@ def validate_license_evidence(
     }
     if len(debian_status_identities) > 1:
         raise ValueError("agentic v2 Debian status evidence identity is inconsistent")
-    if set(records) != set(packages) or document["records"] != sorted(
+    if (
+        {item for item in records} != {item for item in packages}
+        or document["records"] != sorted(
         document["records"], key=lambda item: item["purl"]
+        )
     ):
         raise ValueError("agentic v2 license evidence package inventory mismatch")
     return document
@@ -1212,14 +2119,16 @@ def validate_license_exceptions(policy: Mapping[str, Any]) -> list[dict[str, Any
     if not isinstance(exceptions, list):
         raise ValueError("agentic v2 license exceptions are invalid")
     validated = []
-    identities = set()
+    identities = {item for item in ()}
     expected_fields = {
         "ecosystem", "package", "version", "purl", "normalized_expression",
         "evidence_sha256", "reason", "approver", "expires_at",
     }
-    denied_identifiers = set(license_policy.get("denied_identifiers", []))
+    denied_identifiers = {
+        item for item in license_policy.get("denied_identifiers", [])
+    }
     for raw in exceptions:
-        if not isinstance(raw, Mapping) or set(raw) != expected_fields:
+        if not isinstance(raw, Mapping) or {item for item in raw} != expected_fields:
             raise ValueError("agentic v2 license exception fields are invalid")
         item = dict(raw)
         normalized = _canonical(item["normalized_expression"])
@@ -1235,7 +2144,7 @@ def validate_license_exceptions(policy: Mapping[str, Any]) -> list[dict[str, Any
                     "reason", "approver", "expires_at",
                 )
             )
-            or not _matches(_HEX_DIGEST, item["evidence_sha256"])
+            or not _is_lower_hex(item["evidence_sha256"], 64)
             or normalized != item["normalized_expression"]
             or bool(denied_identifiers.intersection(
                 _identifiers(item["normalized_expression"])
@@ -1264,25 +2173,27 @@ def _decision(
     exceptions: Mapping[tuple[str, str], Mapping[str, Any]],
 ) -> dict[str, Any]:
     outcome = _normalize(record)
-    evidence = deepcopy(record["evidence"])
+    evidence = _clone_json(record["evidence"])
     evidence_sha256 = canonical_sha256(evidence)
     policy_by_casefold = {
         identifier.casefold(): identifier for identifier in denied_identifiers
     }
-    raw_identifiers = set()
+    raw_identifiers = {item for item in ()}
     for raw in record["raw_values"]:
-        for token in _EXPRESSION_TOKEN.findall(raw):
+        for token in _FROZEN_EXPRESSION_TOKENS(raw):
             if token.upper() in {"AND", "OR", "WITH"}:
                 continue
-            spdx = _spdx.LICENSES.get(token.casefold()) or _spdx.EXCEPTIONS.get(
+            spdx = _FROZEN_LICENSES.get(
                 token.casefold()
-            )
+            ) or _FROZEN_EXCEPTIONS.get(token.casefold())
             if spdx is not None:
                 raw_identifiers.add(spdx["id"])
             elif token.casefold() in policy_by_casefold:
                 raw_identifiers.add(policy_by_casefold[token.casefold()])
     denied = sorted(
-        denied_identifiers.intersection(outcome.identifiers | frozenset(raw_identifiers))
+        denied_identifiers.intersection(
+            outcome.identifiers | _FROZEN_FROZENSET_TYPE(raw_identifiers)
+        )
     )
     if denied:
         classification = "denied"
@@ -1308,7 +2219,7 @@ def _decision(
         runtime_version = record["metadata"].get("runtime_version")
         if (
             isinstance(declared, str)
-            and _R_RUNTIME_REFERENCE_LIKE.search(declared)
+            and _contains_words(declared, ("part", "of", "r"))
         ):
             reference_evidence_complete = (
                 declared == f"Part of R {runtime_version}"
@@ -1320,9 +2231,9 @@ def _decision(
                     for item in record["evidence"]
                 ) == 1
             )
-        elif isinstance(declared, str) and _R_REFERENCE_LIKE.search(declared):
+        elif isinstance(declared, str) and _contains_words(declared, ("file",)):
             reference_evidence_complete = (
-                _R_LICENSE_REFERENCE.fullmatch(declared) is not None
+            _reference_filename(declared, "file ") is not None
                 and sum(
                     item["source"] == "r-license-file"
                     for item in record["evidence"]
@@ -1330,9 +2241,12 @@ def _decision(
             )
     elif record["ecosystem"] == "npm":
         declared = record["metadata"].get("license", "")
-        if isinstance(declared, str) and _NPM_REFERENCE_LIKE.search(declared):
+        if (
+            isinstance(declared, str)
+            and _contains_words(declared, ("see", "license", "in"))
+        ):
             reference_evidence_complete = (
-                _NPM_LICENSE_REFERENCE.fullmatch(declared) is not None
+                _reference_filename(declared, "SEE LICENSE IN ") is not None
                 and sum(
                     item["source"] == "npm-license-file"
                     for item in record["evidence"]
@@ -1352,7 +2266,9 @@ def _decision(
         classification = "exception"
         normalized_expression = exception["normalized_expression"]
         reason = "package-version-specific-policy-exception"
-        exception_applied = deepcopy(dict(exception))
+        exception_applied = _clone_json({
+            key: item for key, item in exception.items()
+        })
     return {
         "ecosystem": record["ecosystem"],
         "package": record["package"],
@@ -1360,7 +2276,7 @@ def _decision(
         "purl": record["purl"],
         "classification": classification,
         "normalized_expression": normalized_expression,
-        "raw_values": deepcopy(record["raw_values"]),
+        "raw_values": _clone_json(record["raw_values"]),
         "normalization_reason": reason,
         "denied_identifiers": denied,
         "evidence": evidence,
@@ -1406,7 +2322,9 @@ def build_license_report(
         (item["purl"], item["evidence_sha256"]): item
         for item in exceptions
     }
-    denied_identifiers = set(policy["license"]["denied_identifiers"])
+    denied_identifiers = {
+        item for item in policy["license"]["denied_identifiers"]
+    }
     records_by_purl = {item["purl"]: item for item in evidence["records"]}
     decisions = [
         _decision(records_by_purl[purl], denied_identifiers, exception_map)
@@ -1417,7 +2335,7 @@ def build_license_report(
         for decision in decisions
         if decision["exception"] is not None
     }
-    if applied_exceptions != set(exception_map):
+    if applied_exceptions != {item for item in exception_map}:
         raise ValueError("agentic v2 license exception is stale or unmatched")
     counts = {name: 0 for name in sorted(CLASSIFICATIONS)}
     ecosystem_counts = {
@@ -1469,6 +2387,73 @@ def build_license_report(
     return report
 
 
+_CLASSIFICATION_SURFACE_NAMES = (
+    "_clone_json",
+    "_is_lower_hex",
+    "_is_license_file_token",
+    "_ascii_words",
+    "_contains_words",
+    "_reference_filename",
+    "_split_debian_operators",
+    "_identifiers",
+    "_valid_expression_shape",
+    "_canonical",
+    "_atom",
+    "_combine",
+    "_debian_expression",
+    "_python_outcome",
+    "_r_outcome",
+    "_normalize",
+    "_validate_evidence_item",
+    "_validate_record_metadata",
+    "validate_license_evidence",
+    "validate_license_exceptions",
+    "_decision",
+    "build_license_report",
+)
+_MODULE_GLOBALS = globals()
+_FROZEN_CLASSIFICATION_SURFACE = _FROZEN_MAPPING_PROXY_TYPE({
+    name: (
+        _MODULE_GLOBALS[name],
+        _MODULE_GLOBALS[name].__code__,
+        _MODULE_GLOBALS[name].__defaults__,
+        _MODULE_GLOBALS[name].__kwdefaults__,
+    )
+    for name in _CLASSIFICATION_SURFACE_NAMES
+})
+
+
+def _classification_surface_identity(
+    _module_globals=_MODULE_GLOBALS,
+    _surface=_FROZEN_CLASSIFICATION_SURFACE,
+    _names=_CLASSIFICATION_SURFACE_NAMES,
+) -> dict[str, Any]:
+    identity = {}
+    for name in _names:
+        expected_function, expected_code, expected_defaults, expected_kwdefaults = (
+            _surface[name]
+        )
+        current = _module_globals.get(name)
+        if (
+            current is not expected_function
+            or current.__code__ is not expected_code
+            or current.__defaults__ is not expected_defaults
+            or current.__kwdefaults__ is not expected_kwdefaults
+        ):
+            raise RuntimeError(
+                "agentic v2 license classification surface differs"
+            )
+        identity[name] = _callable_code_identity(expected_code)
+    return identity
+
+
+_FROZEN_CLASSIFICATION_IDENTITY = _classification_surface_identity
+_FROZEN_CLASSIFICATION_IDENTITY_CODE = _classification_surface_identity.__code__
+_FROZEN_CLASSIFICATION_IDENTITY_DEFAULTS = (
+    _classification_surface_identity.__defaults__
+)
+
+
 def validate_license_report(
     value: Any,
     *,
@@ -1489,12 +2474,12 @@ def validate_license_report(
     )
     if not isinstance(value, Mapping):
         raise ValueError("agentic v2 license report identity is invalid")
-    supplied = deepcopy(dict(value))
+    supplied = _clone_json({key: item for key, item in value.items()})
     claimed = supplied.pop("report_sha256", None)
     if (
-        not _matches(_HEX_DIGEST, claimed)
+        not _is_lower_hex(claimed, 64)
         or claimed != canonical_sha256(supplied)
         or canonical_sha256(value) != canonical_sha256(expected)
     ):
         raise ValueError("agentic v2 license report identity is invalid")
-    return deepcopy(expected)
+    return _clone_json(expected)

--- a/batch-runner/core/agentic_v2_license.py
+++ b/batch-runner/core/agentic_v2_license.py
@@ -76,8 +76,14 @@ _NPM_LICENSE_REFERENCE = re.compile(
     r"SEE LICENSE IN ([A-Za-z0-9][A-Za-z0-9._+-]*)\Z", re.ASCII
 )
 _R_REFERENCE_LIKE = re.compile(r"\bfile\b", re.IGNORECASE | re.ASCII)
+_R_RUNTIME_REFERENCE_LIKE = re.compile(
+    r"(?<![A-Za-z0-9])Part[^A-Za-z0-9]+of[^A-Za-z0-9]+R(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
 _NPM_REFERENCE_LIKE = re.compile(
-    r"\bSEE\s+LICENSE\s+IN\b", re.IGNORECASE | re.ASCII
+    r"(?<![A-Za-z0-9])SEE[^A-Za-z0-9]+LICENSE[^A-Za-z0-9]+IN"
+    r"(?![A-Za-z0-9])",
+    re.IGNORECASE,
 )
 _LICENSE_FILE_TOKEN_TEXT = re.compile(
     r"[A-Za-z0-9](?:[A-Za-z0-9.+-]{0,126}[A-Za-z0-9+])?\Z",
@@ -607,6 +613,13 @@ def _r_outcome(record: Mapping[str, Any]) -> _Outcome:
         if isinstance(runtime_fields, list) and runtime_fields:
             outcomes = [_debian_expression(value) for value in runtime_fields]
             return _combine("AND", outcomes, "r-runtime-copyright-license")
+        if metadata.get("runtime_copyright_format") != _DEP5_FORMAT_URI:
+            return _Outcome(
+                None,
+                "unverifiable",
+                "r-runtime-copyright-unstructured",
+                frozenset(),
+            )
         if not isinstance(runtime, str) or not runtime:
             return _Outcome(None, "missing_metadata", "r-runtime-license-missing", frozenset())
         if not _valid_expression_shape(runtime):
@@ -648,6 +661,16 @@ def _normalize(record: Mapping[str, Any]) -> _Outcome:
     if ecosystem == "debian":
         raw_values = record["raw_values"]
         if not raw_values:
+            if any(
+                item["source"] == "debian-copyright-path-unverifiable"
+                for item in record["evidence"]
+            ):
+                return _Outcome(
+                    None,
+                    "unverifiable",
+                    "debian-copyright-path-unverifiable",
+                    frozenset(),
+                )
             if not any(
                 item["source"] == "debian-copyright"
                 for item in record["evidence"]
@@ -697,9 +720,18 @@ def _validate_evidence_item(value: Any) -> dict[str, Any]:
             or ".." in PurePosixPath(path).parts
         ):
             raise ValueError("agentic v2 license evidence path is invalid")
-    if (item["path"] is None) != (item["resolved_path"] is None):
+    if item["path"] is None and item["resolved_path"] is not None:
         raise ValueError("agentic v2 virtual license evidence paths are invalid")
-    if item["path"] is not None and item["path"] != item["resolved_path"]:
+    if (
+        item["path"] is not None
+        and item["resolved_path"] is None
+        and item["source"] != "debian-copyright-path-unverifiable"
+    ):
+        raise ValueError("agentic v2 unresolved license evidence source is invalid")
+    if (
+        item["resolved_path"] is not None
+        and item["path"] != item["resolved_path"]
+    ):
         raise ValueError("agentic v2 license evidence path did not remain lexical")
     return item
 
@@ -742,6 +774,10 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
         copyright_items = [
             item for item in evidence if item["source"] == "debian-copyright"
         ]
+        unverifiable_path_items = [
+            item for item in evidence
+            if item["source"] == "debian-copyright-path-unverifiable"
+        ]
         if (
             set(metadata) != {"architecture", "copyright_format"}
             or not isinstance(metadata["architecture"], str)
@@ -764,7 +800,10 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
             )
             or len(status_items) != 1
             or len(copyright_items) > 1
-            or len(status_items) + len(copyright_items) != len(evidence)
+            or len(unverifiable_path_items) > 1
+            or copyright_items and unverifiable_path_items
+            or len(status_items) + len(copyright_items)
+            + len(unverifiable_path_items) != len(evidence)
             or record["purl"] != (
                 f"pkg:deb/debian/{quote(record['package'], safe='')}@"
                 f"{quote(record['version'], safe='')}?arch="
@@ -788,6 +827,27 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
                 raise ValueError("agentic v2 Debian copyright format is invalid")
             if raw_values and metadata["copyright_format"] is None:
                 raise ValueError("agentic v2 Debian license fields lack DEP-5 format")
+        elif unverifiable_path_items:
+            item = unverifiable_path_items[0]
+            path = f"/usr/share/doc/{record['package']}/copyright"
+            _require_exact_path(item, path)
+            observation = json.dumps(
+                {"path": path, "reason": "symlink-or-nondirectory"},
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            ).encode("utf-8")
+            if (
+                item["resolved_path"] is not None
+                or item["sha256"] != hashlib.sha256(observation).hexdigest()
+                or item["size"] != len(observation)
+                or metadata["copyright_format"] is not None
+                or raw_values
+            ):
+                raise ValueError(
+                    "agentic v2 Debian unverifiable path evidence is invalid"
+                )
         elif metadata["copyright_format"] is not None or raw_values:
             raise ValueError("agentic v2 Debian license fields lack evidence")
         return
@@ -889,7 +949,8 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
             != metadata["declared_license"].strip()
             or metadata["runtime_version"] != metadata["runtime_version"].strip()
             or metadata["runtime_license"] != ""
-            or metadata["runtime_copyright_format"] != _DEP5_FORMAT_URI
+            or metadata["runtime_copyright_format"] is not None
+            and metadata["runtime_copyright_format"] != _DEP5_FORMAT_URI
             or metadata["priority"] is not None
             and not isinstance(metadata["priority"], str)
             or isinstance(metadata["priority"], str)
@@ -907,6 +968,8 @@ def _validate_record_metadata(record: dict[str, Any]) -> None:
                 or item != item.strip()
                 for item in metadata["runtime_license_fields"]
             )
+            or metadata["runtime_license_fields"]
+            and metadata["runtime_copyright_format"] != _DEP5_FORMAT_URI
             or not valid_file_tokens(metadata["license_file_tokens"])
         ):
             raise ValueError("agentic v2 R license metadata is invalid")
@@ -1242,7 +1305,22 @@ def _decision(
         )
     elif record["ecosystem"] == "r":
         declared = record["metadata"].get("declared_license", "")
-        if isinstance(declared, str) and _R_REFERENCE_LIKE.search(declared):
+        runtime_version = record["metadata"].get("runtime_version")
+        if (
+            isinstance(declared, str)
+            and _R_RUNTIME_REFERENCE_LIKE.search(declared)
+        ):
+            reference_evidence_complete = (
+                declared == f"Part of R {runtime_version}"
+                and record["metadata"].get("priority") == "base"
+                and record["metadata"].get("runtime_copyright_format")
+                == _DEP5_FORMAT_URI
+                and sum(
+                    item["source"] == "r-runtime-copyright"
+                    for item in record["evidence"]
+                ) == 1
+            )
+        elif isinstance(declared, str) and _R_REFERENCE_LIKE.search(declared):
             reference_evidence_complete = (
                 _R_LICENSE_REFERENCE.fullmatch(declared) is not None
                 and sum(

--- a/batch-runner/core/agentic_v2_license.py
+++ b/batch-runner/core/agentic_v2_license.py
@@ -1,0 +1,1422 @@
+"""Deterministic Phase 1C package-license evidence and decision contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import marshal
+import os
+import re
+import stat
+import sys
+import types
+import packaging
+import packaging.licenses as packaging_licenses
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+from urllib.parse import quote
+
+from packaging.licenses import InvalidLicenseExpression, canonicalize_license_expression
+from packaging.licenses import _spdx
+
+from core.agentic_v2_substrate import canonical_sha256
+
+
+CLASSIFICATIONS = frozenset({
+    "resolved",
+    "missing_metadata",
+    "ambiguous",
+    "unverifiable",
+    "denied",
+    "exception",
+})
+DENIED_LICENSE_IDENTIFIERS = (
+    "BUSL-1.1",
+    "Commons-Clause",
+    "SSPL-1.0",
+)
+LICENSE_EVALUATOR_PACKAGING_VERSION = "26.2"
+LICENSE_EVALUATOR_SPDX_VERSION = "3.27.0"
+LICENSE_EVALUATOR_SPDX_SHA256 = (
+    "ecc082fdc1fcdcae47b2f56c4ce2cdc2c9d6d54ca555a09814abd78dece7a230"
+)
+LICENSE_EVALUATOR_PARSER_SHA256 = (
+    "fc9c745d1883ff9f296a5b169f22eb2ee879f59a4608f20f5cb29d668f4e26f4"
+)
+LICENSE_EVALUATOR_RUNTIME_GRAPH_SHA256 = (
+    "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"
+)
+LICENSE_EVALUATOR_PYTHON_VERSION = "3.10.12"
+LICENSE_EVALUATOR_CALLABLE_SHA256 = (
+    "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"
+)
+UNRESOLVED_CLASSIFICATIONS = frozenset({
+    "missing_metadata", "ambiguous", "unverifiable",
+})
+_HEX_DIGEST = re.compile(r"[0-9a-f]{64}")
+_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+_SOURCE_SHA = re.compile(r"[0-9a-f]{40}")
+_EXPRESSION_TOKEN = re.compile(
+    r"(?<![A-Za-z0-9.+-])"
+    r"([A-Za-z0-9](?:[A-Za-z0-9.+-]{0,126}[A-Za-z0-9+])?)"
+    r"(?![A-Za-z0-9+-])",
+    re.ASCII,
+)
+_PYTHON_PURELIB_PATH = PurePosixPath("/usr/local/lib/python3.11/site-packages")
+_MAX_LICENSE_EXPRESSION_LENGTH = 4096
+_MAX_LICENSE_EXPRESSION_DEPTH = 64
+_MAX_LICENSE_EXPRESSION_TOKENS = 512
+_R_LICENSE_REFERENCE = re.compile(
+    r"file ([A-Za-z0-9][A-Za-z0-9._+-]*)\Z", re.ASCII
+)
+_NPM_LICENSE_REFERENCE = re.compile(
+    r"SEE LICENSE IN ([A-Za-z0-9][A-Za-z0-9._+-]*)\Z", re.ASCII
+)
+_R_REFERENCE_LIKE = re.compile(r"\bfile\b", re.IGNORECASE | re.ASCII)
+_NPM_REFERENCE_LIKE = re.compile(
+    r"\bSEE\s+LICENSE\s+IN\b", re.IGNORECASE | re.ASCII
+)
+_LICENSE_FILE_TOKEN_TEXT = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9.+-]{0,126}[A-Za-z0-9+])?\Z",
+    re.ASCII,
+)
+_DEP5_FORMAT_URI = (
+    "https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/"
+)
+_REGISTERED_SPDX_IDENTIFIERS = frozenset(
+    value["id"]
+    for collection in (_spdx.LICENSES, _spdx.EXCEPTIONS)
+    for value in collection.values()
+)
+
+
+def _matches(pattern: re.Pattern, value: Any) -> bool:
+    return isinstance(value, str) and pattern.fullmatch(value) is not None
+
+
+_EXACT_ALIASES = {
+    "2-clause BSD": "BSD-2-Clause",
+    "Apache 2.0": "Apache-2.0",
+    "Apache License 2.0": "Apache-2.0",
+    "Apache License, Version 2.0": "Apache-2.0",
+    "BSD 2-Clause": "BSD-2-Clause",
+    "BSD 2-Clause License": "BSD-2-Clause",
+    "BSD 3-Clause": "BSD-3-Clause",
+    "BSD 3-Clause License": "BSD-3-Clause",
+    "MIT License": "MIT",
+    "New BSD": "BSD-3-Clause",
+    "PSFL": "PSF-2.0",
+    "The MIT License (MIT)": "MIT",
+    "new BSD License": "BSD-3-Clause",
+}
+
+_DEBIAN_EXACT_ALIASES = {
+    "Apache-2": "Apache-2.0",
+    "Artistic-2": "Artistic-2.0",
+    "BOOST-1.0": "BSL-1.0",
+    "BSL-1": "BSL-1.0",
+    "Expat": "MIT",
+    "GPL-1": "GPL-1.0-only",
+    "GPL-1+": "GPL-1.0-or-later",
+    "GPL-2": "GPL-2.0-only",
+    "GPL-2+": "GPL-2.0-or-later",
+    "GPL-3": "GPL-3.0-only",
+    "GPL-3+": "GPL-3.0-or-later",
+    "LGPL-2": "LGPL-2.0-only",
+    "LGPL-2+": "LGPL-2.0-or-later",
+    "LGPL-2.1": "LGPL-2.1-only",
+    "LGPL-2.1+": "LGPL-2.1-or-later",
+    "LGPL-3": "LGPL-3.0-only",
+    "LGPL-3+": "LGPL-3.0-or-later",
+    "MPL2.0": "MPL-2.0",
+    "SIL-1.1": "OFL-1.1",
+    "expat": "MIT",
+}
+
+_PYTHON_CLASSIFIERS = {
+    "License :: OSI Approved :: Apache Software License": "Apache-2.0",
+    "License :: OSI Approved :: GNU Affero General Public License v3": "AGPL-3.0-only",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)": "GPL-2.0-only",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)": "GPL-3.0-only",
+    "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)": "LGPL-2.0-only",
+    "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)": "LGPL-2.0-or-later",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)": "LGPL-3.0-only",
+    "License :: OSI Approved :: ISC License (ISCL)": "ISC",
+    "License :: OSI Approved :: MIT License": "MIT",
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)": "MPL-2.0",
+    "License :: OSI Approved :: Python Software Foundation License": "PSF-2.0",
+    "License :: OSI Approved :: The Unlicense (Unlicense)": "Unlicense",
+}
+
+_PYTHON_EXACT_ALIASES = {
+    **_EXACT_ALIASES,
+    "GPLv2": "GPL-2.0-only",
+    "LGPLv3+": "LGPL-3.0-or-later",
+}
+
+_DEBIAN_OPERATORS = re.compile(
+    r"(\(|\)|,\s+and\s+|,\s+or\s+|\s+and\s+|\s+or\s+|\s+with\s+)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class _Outcome:
+    expression: str | None
+    issue: str | None
+    reason: str
+    identifiers: frozenset[str]
+
+
+def license_evaluator_runtime_identity() -> dict[str, str]:
+    packaging_path = Path(str(packaging.__file__))
+    package_root = packaging_path.parent
+    parser_path = Path(str(packaging_licenses.__file__))
+    spdx_path = Path(str(_spdx.__file__))
+    expected_paths = {
+        "packaging/__init__.py": package_root / "__init__.py",
+        "packaging/licenses/__init__.py": package_root / "licenses" / "__init__.py",
+        "packaging/licenses/_spdx.py": package_root / "licenses" / "_spdx.py",
+    }
+    if (
+        packaging_path != expected_paths["packaging/__init__.py"]
+        or parser_path != expected_paths["packaging/licenses/__init__.py"]
+        or spdx_path != expected_paths["packaging/licenses/_spdx.py"]
+        or canonicalize_license_expression
+        is not packaging_licenses.canonicalize_license_expression
+        or canonicalize_license_expression.__module__ != "packaging.licenses"
+        or canonicalize_license_expression.__qualname__
+        != "canonicalize_license_expression"
+        or not hasattr(canonicalize_license_expression, "__code__")
+        or Path(canonicalize_license_expression.__code__.co_filename) != parser_path
+        or canonicalize_license_expression.__globals__
+        is not packaging_licenses.__dict__
+        or packaging_licenses.LICENSES is not _spdx.LICENSES
+        or packaging_licenses.EXCEPTIONS is not _spdx.EXCEPTIONS
+        or InvalidLicenseExpression
+        is not packaging_licenses.InvalidLicenseExpression
+        or any(not path.is_absolute() for path in expected_paths.values())
+        or not all(
+            isinstance(getattr(os, name, None), int)
+            for name in ("O_NOFOLLOW", "O_CLOEXEC")
+        )
+    ):
+        raise RuntimeError("agentic v2 license evaluator parser identity differs")
+    def parser_identity(value):
+        return (
+            value.st_dev,
+            value.st_ino,
+            value.st_mode,
+            value.st_size,
+            value.st_mtime_ns,
+        )
+
+    graph = []
+    sources = {}
+    for relative_path, path in sorted(expected_paths.items()):
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        )
+        try:
+            before = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or before.st_nlink != 1
+                or before.st_size > 1024 * 1024
+            ):
+                raise RuntimeError(
+                    "agentic v2 license evaluator source file is invalid"
+                )
+            chunks = []
+            while True:
+                chunk = os.read(descriptor, 64 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+        source_bytes = b"".join(chunks)
+        if (
+            parser_identity(before) != parser_identity(after)
+            or len(source_bytes) != before.st_size
+        ):
+            raise RuntimeError(
+                "agentic v2 license evaluator source changed while reading"
+            )
+        sources[relative_path] = source_bytes
+        graph.append({
+            "path": relative_path,
+            "sha256": hashlib.sha256(source_bytes).hexdigest(),
+            "size": len(source_bytes),
+        })
+    def normalize_code(code):
+        constants = tuple(
+            normalize_code(value) if isinstance(value, types.CodeType) else value
+            for value in code.co_consts
+        )
+        return code.replace(
+            co_consts=constants,
+            co_filename="packaging/licenses/__init__.py",
+        )
+
+    callable_sha256 = hashlib.sha256(marshal.dumps(normalize_code(
+        canonicalize_license_expression.__code__
+    ))).hexdigest()
+    payload = {
+        "packaging_version": packaging.__version__,
+        "spdx_version": _spdx.VERSION,
+        "licenses": sorted(_spdx.LICENSES.items()),
+        "exceptions": sorted(_spdx.EXCEPTIONS.items()),
+    }
+    identity = {
+        "packaging_version": packaging.__version__,
+        "spdx_version": _spdx.VERSION,
+        "spdx_sha256": canonical_sha256(payload),
+        "parser_sha256": hashlib.sha256(
+            sources["packaging/licenses/__init__.py"]
+        ).hexdigest(),
+        "runtime_graph_sha256": canonical_sha256(graph),
+        "python_version": ".".join(str(item) for item in sys.version_info[:3]),
+        "callable_sha256": callable_sha256,
+    }
+    if identity != {
+        "packaging_version": LICENSE_EVALUATOR_PACKAGING_VERSION,
+        "spdx_version": LICENSE_EVALUATOR_SPDX_VERSION,
+        "spdx_sha256": LICENSE_EVALUATOR_SPDX_SHA256,
+        "parser_sha256": LICENSE_EVALUATOR_PARSER_SHA256,
+        "runtime_graph_sha256": LICENSE_EVALUATOR_RUNTIME_GRAPH_SHA256,
+        "python_version": LICENSE_EVALUATOR_PYTHON_VERSION,
+        "callable_sha256": LICENSE_EVALUATOR_CALLABLE_SHA256,
+    }:
+        raise RuntimeError("agentic v2 license evaluator runtime identity differs")
+    return identity
+
+
+def _identifiers(expression: str) -> frozenset[str]:
+    return frozenset(
+        token
+        for token in _EXPRESSION_TOKEN.findall(expression)
+        if token not in {"AND", "OR", "WITH"}
+    )
+
+
+def _valid_expression_shape(expression: Any) -> bool:
+    if not isinstance(expression, str) or len(expression) > _MAX_LICENSE_EXPRESSION_LENGTH:
+        return False
+    depth = 0
+    maximum_depth = 0
+    tokens = 0
+    in_token = False
+    for character in expression:
+        if character == "(":
+            depth += 1
+            maximum_depth = max(maximum_depth, depth)
+            tokens += 1
+            in_token = False
+        elif character == ")":
+            depth -= 1
+            if depth < 0:
+                return None
+            tokens += 1
+            in_token = False
+        elif character == "|":
+            tokens += 1
+            in_token = False
+        elif character.isspace():
+            in_token = False
+        elif not in_token:
+            tokens += 1
+            in_token = True
+        if (
+            maximum_depth > _MAX_LICENSE_EXPRESSION_DEPTH
+            or tokens > _MAX_LICENSE_EXPRESSION_TOKENS
+        ):
+            return False
+    return depth == 0
+
+
+def _canonical(expression: Any) -> str | None:
+    if not _valid_expression_shape(expression):
+        return None
+    try:
+        canonical = str(canonicalize_license_expression(expression))
+    except (InvalidLicenseExpression, RecursionError):
+        return None
+    if not _identifiers(canonical).issubset(_REGISTERED_SPDX_IDENTIFIERS):
+        return None
+    return canonical
+
+
+def _atom(value: str, aliases: Mapping[str, str]) -> _Outcome:
+    stripped = value.strip()
+    canonical = _canonical(stripped)
+    if canonical is not None:
+        return _Outcome(canonical, None, "direct-spdx-expression", _identifiers(canonical))
+    mapped = aliases.get(stripped)
+    if mapped is not None:
+        canonical = _canonical(mapped)
+        if canonical is None:
+            raise RuntimeError(f"invalid internal SPDX alias: {stripped}")
+        return _Outcome(canonical, None, f"exact-alias:{stripped}", _identifiers(canonical))
+    ambiguous = (
+        stripped in {"Artistic", "BSD", "BSD License", "Dual License", "GPL", "MPL"}
+        or "and/or" in stripped.lower()
+        or stripped.lower().startswith("dual licens")
+    )
+    return _Outcome(
+        None,
+        "ambiguous" if ambiguous else "unverifiable",
+        "ambiguous-license-label" if ambiguous else "unmapped-exact-license-label",
+        frozenset(),
+    )
+
+
+def _combine(operator: str, outcomes: list[_Outcome], reason: str) -> _Outcome:
+    identifiers = frozenset().union(*(item.identifiers for item in outcomes))
+    issues = [item.issue for item in outcomes if item.issue]
+    if issues:
+        issue = "ambiguous" if "ambiguous" in issues else "unverifiable"
+        return _Outcome(None, issue, reason, identifiers)
+    expressions = sorted({item.expression for item in outcomes if item.expression})
+    if not expressions:
+        return _Outcome(None, "missing_metadata", reason, identifiers)
+    if len(expressions) == 1:
+        return _Outcome(expressions[0], None, reason, identifiers)
+    candidate = f" {operator} ".join(f"({value})" for value in expressions)
+    canonical = _canonical(candidate)
+    if canonical is None:
+        return _Outcome(None, "unverifiable", reason, identifiers)
+    return _Outcome(canonical, None, reason, _identifiers(canonical))
+
+
+def _debian_expression(raw: str) -> _Outcome:
+    if not _valid_expression_shape(raw):
+        return _Outcome(
+            None,
+            "unverifiable",
+            "invalid-debian-license-expression-shape",
+            frozenset(),
+        )
+    direct = _atom(raw, {**_EXACT_ALIASES, **_DEBIAN_EXACT_ALIASES})
+    if direct.expression is not None:
+        return direct
+    tokens = [token for token in _DEBIAN_OPERATORS.split(raw) if token and token.strip()]
+    if len(tokens) == 1:
+        return direct
+
+    def parse_range(start: int, end: int) -> _Outcome:
+        def encloses_range() -> bool:
+            if end - start < 2 or tokens[start] != "(" or tokens[end - 1] != ")":
+                return False
+            depth = 0
+            for index in range(start, end):
+                if tokens[index] == "(":
+                    depth += 1
+                elif tokens[index] == ")":
+                    depth -= 1
+                    if depth == 0 and index != end - 1:
+                        return False
+                    if depth < 0:
+                        return False
+            return depth == 0
+
+        while encloses_range():
+            start += 1
+            end -= 1
+        depth = 0
+        for operator, label in (("or", "OR"), ("and", "AND")):
+            parts = []
+            last = start
+            depth = 0
+            for index in range(start, end):
+                token = tokens[index].strip().lower().replace(",", "")
+                if tokens[index] == "(":
+                    depth += 1
+                elif tokens[index] == ")":
+                    depth -= 1
+                elif depth == 0 and token == operator:
+                    parts.append(parse_range(last, index))
+                    last = index + 1
+            if parts:
+                parts.append(parse_range(last, end))
+                return _combine(label, parts, f"debian-{operator}-expression")
+        depth = 0
+        for index in range(start, end):
+            if tokens[index] == "(":
+                depth += 1
+            elif tokens[index] == ")":
+                depth -= 1
+            elif depth == 0 and tokens[index].strip().lower() == "with":
+                left = parse_range(start, index)
+                exception = " ".join(tokens[index + 1:end]).strip()
+                exception_aliases = {
+                    "Autoconf exception 3.0": "Autoconf-exception-3.0",
+                    "Bison exception": "Bison-exception-2.2",
+                    "Classpath exception 2.0": "Classpath-exception-2.0",
+                    "Libtool exception": "Libtool-exception",
+                }
+                mapped = exception_aliases.get(exception, exception)
+                if left.expression is None:
+                    return left
+                candidate = f"{left.expression} WITH {mapped}"
+                canonical = _canonical(candidate)
+                if canonical is None:
+                    return _Outcome(
+                        None, "unverifiable", "unmapped-license-exception",
+                        left.identifiers,
+                    )
+                return _Outcome(
+                    canonical, None, "debian-with-expression", _identifiers(canonical)
+                )
+        return _atom(" ".join(tokens[start:end]), {**_EXACT_ALIASES, **_DEBIAN_EXACT_ALIASES})
+
+    return parse_range(0, len(tokens))
+
+
+def _python_outcome(record: Mapping[str, Any]) -> _Outcome:
+    metadata = record["metadata"]
+    outcomes = []
+    expression_outcome = None
+    expression_issue = None
+    expression = metadata.get("license_expression")
+    if isinstance(expression, str) and expression.strip():
+        result = _atom(expression, {})
+        if result.expression is None:
+            expression_issue = result
+        else:
+            expression_outcome = result
+        outcomes.append(result)
+
+    license_outcome = None
+    license_issue = None
+    license_value = metadata.get("license")
+    if isinstance(license_value, str) and license_value.strip() not in {"UNKNOWN", "NOASSERTION"}:
+        license_outcome = _atom(license_value, _PYTHON_EXACT_ALIASES)
+        outcomes.append(license_outcome)
+        if license_outcome.expression is None:
+            license_issue = license_outcome
+    classifier_values = []
+    ambiguous_classifier = False
+    unknown_classifier = False
+    for classifier in metadata.get("classifiers", []):
+        mapped = _PYTHON_CLASSIFIERS.get(classifier)
+        if mapped:
+            classifier_values.append(_atom(mapped, {}))
+        elif classifier == "License :: OSI Approved :: BSD License":
+            ambiguous_classifier = True
+        else:
+            unknown_classifier = True
+    all_identifiers = frozenset().union(*(
+        item.identifiers for item in outcomes + classifier_values
+    ))
+    if unknown_classifier:
+        return _Outcome(
+            None, "unverifiable", "unmapped-python-license-classifier",
+            all_identifiers,
+        )
+    if expression_issue is not None:
+        return _Outcome(
+            None,
+            expression_issue.issue or "unverifiable",
+            "invalid-python-license-expression",
+            all_identifiers,
+        )
+    if license_issue is not None:
+        return _Outcome(
+            None,
+            license_issue.issue or "unverifiable",
+            "unresolved-explicit-python-license-field",
+            all_identifiers,
+        )
+    if ambiguous_classifier:
+        return _Outcome(
+            None, "ambiguous", "generic-bsd-classifier",
+            all_identifiers,
+        )
+    if expression_outcome is not None:
+        if (
+            license_outcome is not None
+            and license_outcome.expression != expression_outcome.expression
+        ) or any(
+            item.expression is not None
+            and not item.identifiers.issubset(expression_outcome.identifiers)
+            for item in classifier_values
+        ):
+            return _Outcome(
+                None, "ambiguous", "conflicting-python-license-metadata",
+                all_identifiers,
+            )
+        return _Outcome(
+            expression_outcome.expression,
+            None,
+            "python-license-expression-with-compatible-metadata",
+            expression_outcome.identifiers,
+        )
+    resolved = sorted({item.expression for item in outcomes + classifier_values if item.expression})
+    if license_outcome is not None and license_outcome.expression is not None:
+        if all(
+            item.expression is None
+            or item.identifiers.issubset(license_outcome.identifiers)
+            for item in classifier_values
+        ):
+            return _Outcome(
+                license_outcome.expression,
+                None,
+                "python-license-field-with-compatible-classifiers",
+                license_outcome.identifiers,
+            )
+    if len(resolved) > 1:
+        return _Outcome(
+            None, "ambiguous", "conflicting-python-license-metadata",
+            frozenset().union(*(item.identifiers for item in outcomes + classifier_values)),
+        )
+    if resolved:
+        return _Outcome(
+            resolved[0], None,
+            "python-license-field-or-classifier",
+            _identifiers(resolved[0]),
+        )
+    if not record["raw_values"]:
+        return _Outcome(None, "missing_metadata", "python-license-metadata-missing", frozenset())
+    return _Outcome(None, "unverifiable", "python-license-metadata-unverifiable", frozenset())
+
+
+def _r_outcome(record: Mapping[str, Any]) -> _Outcome:
+    metadata = record["metadata"]
+    declared = metadata.get("declared_license")
+    runtime = metadata.get("runtime_license")
+    runtime_version = metadata.get("runtime_version")
+    if isinstance(declared, str) and not _valid_expression_shape(declared):
+        return _Outcome(
+            None,
+            "unverifiable",
+            "invalid-r-license-expression-shape",
+            frozenset(),
+        )
+    if (
+        isinstance(declared, str)
+        and declared == f"Part of R {runtime_version}"
+        and metadata.get("priority") == "base"
+    ):
+        runtime_fields = metadata.get("runtime_license_fields")
+        if isinstance(runtime_fields, list) and runtime_fields:
+            outcomes = [_debian_expression(value) for value in runtime_fields]
+            return _combine("AND", outcomes, "r-runtime-copyright-license")
+        if not isinstance(runtime, str) or not runtime:
+            return _Outcome(None, "missing_metadata", "r-runtime-license-missing", frozenset())
+        if not _valid_expression_shape(runtime):
+            return _Outcome(
+                None,
+                "unverifiable",
+                "invalid-r-license-expression-shape",
+                frozenset(),
+            )
+        parts = [part.strip() for part in runtime.split("|")]
+        if not parts or any(not part for part in parts):
+            return _Outcome(
+                None, "unverifiable", "invalid-r-license-alternatives",
+                frozenset(),
+            )
+        outcomes = [_atom(part, _DEBIAN_EXACT_ALIASES) for part in parts]
+        return _combine("OR", outcomes, "r-base-runtime-license")
+    if isinstance(declared, str) and declared.startswith("Part of R"):
+        return _Outcome(
+            None,
+            "unverifiable",
+            "invalid-r-runtime-license-reference",
+            frozenset(),
+        )
+    if isinstance(declared, str) and declared:
+        parts = [part.strip() for part in declared.split("|")]
+        if not parts or any(not part for part in parts):
+            return _Outcome(
+                None, "unverifiable", "invalid-r-license-alternatives",
+                frozenset(),
+            )
+        outcomes = [_atom(part, _DEBIAN_EXACT_ALIASES) for part in parts]
+        return _combine("OR", outcomes, "r-description-license")
+    return _Outcome(None, "missing_metadata", "r-license-metadata-missing", frozenset())
+
+
+def _normalize(record: Mapping[str, Any]) -> _Outcome:
+    ecosystem = record["ecosystem"]
+    if ecosystem == "debian":
+        raw_values = record["raw_values"]
+        if not raw_values:
+            if not any(
+                item["source"] == "debian-copyright"
+                for item in record["evidence"]
+            ):
+                return _Outcome(
+                    None,
+                    "missing_metadata",
+                    "debian-copyright-metadata-missing",
+                    frozenset(),
+                )
+            return _Outcome(
+                None, "unverifiable", "debian-copyright-has-no-dep5-license-fields",
+                frozenset(),
+            )
+        outcomes = [_debian_expression(value) for value in raw_values]
+        return _combine("AND", outcomes, "debian-file-stanza-license-conjunction")
+    if ecosystem == "python":
+        return _python_outcome(record)
+    if ecosystem == "r":
+        return _r_outcome(record)
+    if ecosystem == "npm":
+        if not record["raw_values"]:
+            return _Outcome(None, "missing_metadata", "npm-license-missing", frozenset())
+        return _atom(record["raw_values"][0], _EXACT_ALIASES)
+    raise ValueError("unsupported license evidence ecosystem")
+
+
+def _validate_evidence_item(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != {
+        "source", "path", "resolved_path", "sha256", "size",
+    }:
+        raise ValueError("agentic v2 license evidence item fields are invalid")
+    item = dict(value)
+    if (
+        not isinstance(item["source"], str)
+        or not item["source"]
+        or not _matches(_HEX_DIGEST, item["sha256"])
+        or type(item["size"]) is not int
+        or item["size"] < 0
+    ):
+        raise ValueError("agentic v2 license evidence item identity is invalid")
+    for key in ("path", "resolved_path"):
+        path = item[key]
+        if path is not None and (
+            not isinstance(path, str)
+            or not path.startswith("/")
+            or ".." in PurePosixPath(path).parts
+        ):
+            raise ValueError("agentic v2 license evidence path is invalid")
+    if (item["path"] is None) != (item["resolved_path"] is None):
+        raise ValueError("agentic v2 virtual license evidence paths are invalid")
+    if item["path"] is not None and item["path"] != item["resolved_path"]:
+        raise ValueError("agentic v2 license evidence path did not remain lexical")
+    return item
+
+
+def _require_exact_path(item: Mapping[str, Any], path: str) -> None:
+    if item["path"] != path:
+        raise ValueError("agentic v2 license evidence source path is invalid")
+
+
+def _require_resolved_under(item: Mapping[str, Any], root: str) -> None:
+    resolved = item["resolved_path"]
+    if resolved is None:
+        raise ValueError("agentic v2 license evidence resolved path is missing")
+    resolved_path = PurePosixPath(resolved)
+    root_path = PurePosixPath(root)
+    if root_path not in (resolved_path, *resolved_path.parents):
+        raise ValueError("agentic v2 license evidence resolved path is invalid")
+
+
+def _validate_record_metadata(record: dict[str, Any]) -> None:
+    ecosystem = record["ecosystem"]
+    metadata = record["metadata"]
+    evidence = record["evidence"]
+    raw_values = record["raw_values"]
+    def valid_file_tokens(value: Any) -> bool:
+        return (
+            isinstance(value, list)
+            and value == sorted(set(value))
+            and len(value) <= 4096
+            and all(
+                isinstance(item, str)
+                and _LICENSE_FILE_TOKEN_TEXT.fullmatch(item) is not None
+                and "-" in item
+                for item in value
+            )
+        )
+
+    if ecosystem == "debian":
+        status_items = [item for item in evidence if item["source"] == "debian-status"]
+        copyright_items = [
+            item for item in evidence if item["source"] == "debian-copyright"
+        ]
+        if (
+            set(metadata) != {"architecture", "copyright_format"}
+            or not isinstance(metadata["architecture"], str)
+            or not metadata["architecture"]
+            or metadata["architecture"] != metadata["architecture"].strip()
+            or metadata["copyright_format"] is not None
+            and not isinstance(metadata["copyright_format"], str)
+            or isinstance(metadata["copyright_format"], str)
+            and (
+                not metadata["copyright_format"]
+                or metadata["copyright_format"]
+                != metadata["copyright_format"].strip()
+            )
+            or raw_values != sorted(set(raw_values))
+            or any(
+                not isinstance(item, str)
+                or not item
+                or item != item.strip()
+                for item in raw_values
+            )
+            or len(status_items) != 1
+            or len(copyright_items) > 1
+            or len(status_items) + len(copyright_items) != len(evidence)
+            or record["purl"] != (
+                f"pkg:deb/debian/{quote(record['package'], safe='')}@"
+                f"{quote(record['version'], safe='')}?arch="
+                f"{quote(metadata['architecture'], safe='')}"
+            )
+        ):
+            raise ValueError("agentic v2 Debian license metadata is invalid")
+        _require_exact_path(status_items[0], "/var/lib/dpkg/status")
+        _require_resolved_under(status_items[0], "/var/lib/dpkg")
+        if copyright_items:
+            _require_exact_path(
+                copyright_items[0], f"/usr/share/doc/{record['package']}/copyright"
+            )
+            _require_resolved_under(copyright_items[0], "/usr/share/doc")
+            if metadata["copyright_format"] == "":
+                raise ValueError("agentic v2 Debian copyright format is invalid")
+            if (
+                metadata["copyright_format"] is not None
+                and metadata["copyright_format"] != _DEP5_FORMAT_URI
+            ):
+                raise ValueError("agentic v2 Debian copyright format is invalid")
+            if raw_values and metadata["copyright_format"] is None:
+                raise ValueError("agentic v2 Debian license fields lack DEP-5 format")
+        elif metadata["copyright_format"] is not None or raw_values:
+            raise ValueError("agentic v2 Debian license fields lack evidence")
+        return
+    if ecosystem == "python":
+        if (
+            set(metadata) != {
+                "license_expression", "license", "classifiers",
+                "license_file_tokens", "license_files",
+            }
+            or any(
+                metadata[key] is not None and not isinstance(metadata[key], str)
+                for key in ("license_expression", "license")
+            )
+            or not isinstance(metadata["classifiers"], list)
+            or metadata["classifiers"] != sorted(set(metadata["classifiers"]))
+            or any(not isinstance(item, str) for item in metadata["classifiers"])
+            or not valid_file_tokens(metadata["license_file_tokens"])
+            or not isinstance(metadata["license_files"], list)
+        ):
+            raise ValueError("agentic v2 Python license metadata is invalid")
+        expected_raw = []
+        for key in ("license_expression", "license"):
+            value = metadata[key]
+            if isinstance(value, str) and value.strip():
+                expected_raw.append(value.strip())
+        expected_raw.extend(metadata["classifiers"])
+        expected_raw.extend(metadata["license_file_tokens"])
+        metadata_items = [item for item in evidence if item["source"] == "python-metadata"]
+        license_items = [item for item in evidence if item["source"] == "python-license-file"]
+        if (
+            raw_values != expected_raw
+            or len(metadata_items) != 1
+            or len(metadata_items) + len(license_items) != len(evidence)
+        ):
+            raise ValueError("agentic v2 Python license evidence is invalid")
+        metadata_path = metadata_items[0]["resolved_path"]
+        if metadata_path is None:
+            raise ValueError("agentic v2 Python METADATA path is missing")
+        metadata_file = PurePosixPath(metadata_path)
+        if (
+            metadata_file.name not in {"METADATA", "PKG-INFO"}
+            or not metadata_file.parent.name.endswith((".dist-info", ".egg-info"))
+            or _PYTHON_PURELIB_PATH not in metadata_file.parents
+            or metadata_file.parent.parent != _PYTHON_PURELIB_PATH
+        ):
+            raise ValueError("agentic v2 Python METADATA path is invalid")
+        distribution_root = metadata_file.parent
+        expected_paths = []
+        declared = set()
+        for selection in metadata["license_files"]:
+            if (
+                not isinstance(selection, Mapping)
+                or set(selection) != {"declared", "path"}
+                or not isinstance(selection["declared"], str)
+                or not selection["declared"]
+                or PurePosixPath(selection["declared"]).is_absolute()
+                or ".." in PurePosixPath(selection["declared"]).parts
+                or selection["declared"] in declared
+                or not isinstance(selection["path"], str)
+            ):
+                raise ValueError("agentic v2 Python License-File declaration is invalid")
+            declared.add(selection["declared"])
+            allowed_paths = {
+                str(distribution_root / "licenses" / selection["declared"]),
+                str(distribution_root / selection["declared"]),
+            }
+            if selection["path"] not in allowed_paths:
+                raise ValueError("agentic v2 Python license file path is invalid")
+            expected_paths.append(selection["path"])
+        if (
+            metadata["license_files"]
+            != sorted(
+                metadata["license_files"],
+                key=lambda item: (item["declared"], item["path"]),
+            )
+            or sorted(item["path"] for item in license_items)
+            != sorted(expected_paths)
+            or len(expected_paths) != len(license_items)
+        ):
+            raise ValueError("agentic v2 Python license file evidence is invalid")
+        return
+    if ecosystem == "r":
+        if (
+            set(metadata) != {
+                "declared_license", "priority", "runtime_license",
+                "runtime_license_fields", "runtime_copyright_format",
+                "runtime_version",
+                "license_file_tokens",
+            }
+            or any(
+                not isinstance(metadata[key], str)
+                for key in (
+                    "declared_license", "runtime_license", "runtime_version",
+                )
+            )
+            or not metadata["declared_license"]
+            or not metadata["runtime_version"]
+            or metadata["declared_license"]
+            != metadata["declared_license"].strip()
+            or metadata["runtime_version"] != metadata["runtime_version"].strip()
+            or metadata["runtime_license"] != ""
+            or metadata["runtime_copyright_format"] != _DEP5_FORMAT_URI
+            or metadata["priority"] is not None
+            and not isinstance(metadata["priority"], str)
+            or isinstance(metadata["priority"], str)
+            and (
+                not metadata["priority"]
+                or metadata["priority"] != metadata["priority"].strip()
+            )
+            or not isinstance(metadata["runtime_license_fields"], list)
+            or metadata["runtime_license_fields"] != sorted(
+                set(metadata["runtime_license_fields"])
+            )
+            or any(
+                not isinstance(item, str)
+                or not item
+                or item != item.strip()
+                for item in metadata["runtime_license_fields"]
+            )
+            or not valid_file_tokens(metadata["license_file_tokens"])
+        ):
+            raise ValueError("agentic v2 R license metadata is invalid")
+        expected_raw = [
+            value
+            for value in (
+                metadata["declared_license"], metadata["runtime_license"],
+                *metadata["runtime_license_fields"],
+                *metadata["license_file_tokens"],
+            )
+            if value
+        ]
+        sources = [item["source"] for item in evidence]
+        reference = _R_LICENSE_REFERENCE.fullmatch(metadata["declared_license"])
+        reference_items = [item for item in evidence if item["source"] == "r-license-file"]
+        if (
+            raw_values != expected_raw
+            or sources.count("r-description") != 1
+            or sources.count("r-runtime-description") != 1
+            or sources.count("r-runtime-license") != 1
+            or sources.count("r-runtime-copyright") != 1
+            or any(
+                source not in {
+                    "r-description", "r-runtime-description", "r-runtime-license",
+                    "r-runtime-copyright", "r-shared-license", "r-license-file",
+                }
+                for source in sources
+            )
+            or (reference is None and reference_items)
+            or (reference is not None and len(reference_items) != 1)
+        ):
+            raise ValueError("agentic v2 R license evidence is invalid")
+        description = next(item for item in evidence if item["source"] == "r-description")
+        _require_exact_path(
+            description, f"/usr/lib/R/library/{record['package']}/DESCRIPTION"
+        )
+        _require_resolved_under(description, "/usr/lib/R/library")
+        runtime_description = next(
+            item for item in evidence if item["source"] == "r-runtime-description"
+        )
+        _require_exact_path(
+            runtime_description, "/usr/lib/R/library/base/DESCRIPTION"
+        )
+        _require_resolved_under(runtime_description, "/usr/lib/R/library/base")
+        runtime = next(item for item in evidence if item["source"] == "r-runtime-license")
+        runtime_value = {
+            "version": metadata["runtime_version"],
+            "license": "",
+        }
+        runtime_bytes = json.dumps(
+            runtime_value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+        if (
+            runtime["path"] is not None
+            or runtime["resolved_path"] is not None
+            or runtime["sha256"] != hashlib.sha256(runtime_bytes).hexdigest()
+            or runtime["size"] != len(runtime_bytes)
+        ):
+            raise ValueError("agentic v2 R runtime evidence is invalid")
+        copyright_item = next(
+            item for item in evidence if item["source"] == "r-runtime-copyright"
+        )
+        _require_exact_path(copyright_item, "/usr/share/doc/r-base-core/copyright")
+        _require_resolved_under(copyright_item, "/usr/share/doc/r-base-core")
+        for item in evidence:
+            if item["source"] == "r-shared-license" and not str(item["path"]).startswith(
+                "/usr/share/R/share/licenses/"
+            ):
+                raise ValueError("agentic v2 R shared license path is invalid")
+            if item["source"] == "r-shared-license":
+                _require_resolved_under(item, "/usr/share/R/share/licenses")
+        if reference is not None:
+            referenced_path = (
+                f"/usr/lib/R/library/{record['package']}/{reference.group(1)}"
+            )
+            _require_exact_path(reference_items[0], referenced_path)
+            _require_resolved_under(
+                reference_items[0], f"/usr/lib/R/library/{record['package']}"
+            )
+        return
+    if ecosystem == "npm":
+        reference = _NPM_LICENSE_REFERENCE.fullmatch(metadata.get("license", ""))
+        package_items = [
+            item for item in evidence if item["source"] == "npm-package-json"
+        ]
+        reference_items = [
+            item for item in evidence if item["source"] == "npm-license-file"
+        ]
+        if (
+            set(metadata) != {"license", "license_file_tokens"}
+            or not isinstance(metadata["license"], str)
+            or not metadata["license"]
+            or metadata["license"] != metadata["license"].strip()
+            or not valid_file_tokens(metadata["license_file_tokens"])
+            or raw_values != [metadata["license"], *metadata["license_file_tokens"]]
+            or len(package_items) != 1
+            or len(package_items) + len(reference_items) != len(evidence)
+            or (reference is None and reference_items)
+            or (reference is not None and len(reference_items) != 1)
+        ):
+            raise ValueError("agentic v2 npm license metadata is invalid")
+        _require_exact_path(package_items[0], "/usr/share/nodejs/npm/package.json")
+        _require_resolved_under(package_items[0], "/usr/share/nodejs/npm")
+        if reference is not None:
+            _require_exact_path(
+                reference_items[0], f"/usr/share/nodejs/npm/{reference.group(1)}"
+            )
+            _require_resolved_under(reference_items[0], "/usr/share/nodejs/npm")
+        return
+    raise ValueError("unsupported license evidence ecosystem")
+
+
+def validate_license_evidence(
+    value: Any,
+    sbom: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != {
+        "schema_version", "collector", "records", "records_sha256",
+    }:
+        raise ValueError("agentic v2 license evidence fields are invalid")
+    document = deepcopy(dict(value))
+    if (
+        document["schema_version"] != "1.0"
+        or document["collector"] != "gdpval-agentic-v2-license-evidence-v1"
+        or not isinstance(document["records"], list)
+        or not document["records"]
+        or document["records_sha256"] != canonical_sha256(document["records"])
+    ):
+        raise ValueError("agentic v2 license evidence identity is invalid")
+    if (
+        not isinstance(sbom.get("packages"), list)
+        or not sbom["packages"]
+    ):
+        raise ValueError("agentic v2 SBOM package inventory is empty")
+    packages = {
+        package["externalRefs"][0]["referenceLocator"]: package
+        for package in sbom["packages"]
+    }
+    if len(packages) != len(sbom["packages"]):
+        raise ValueError("agentic v2 SBOM purl identity is invalid")
+    records = {}
+    ecosystem_prefixes = {
+        "debian": "pkg:deb/debian/",
+        "python": "pkg:pypi/",
+        "r": "pkg:cran/",
+        "npm": "pkg:npm/",
+    }
+    for raw_record in document["records"]:
+        if not isinstance(raw_record, Mapping) or set(raw_record) != {
+            "ecosystem", "package", "version", "purl", "raw_values",
+            "metadata", "evidence",
+        }:
+            raise ValueError("agentic v2 license evidence record fields are invalid")
+        record = dict(raw_record)
+        if (
+            record["ecosystem"] not in {"debian", "python", "r", "npm"}
+            or not all(
+                isinstance(record[key], str) and record[key]
+                for key in ("package", "version", "purl")
+            )
+            or not record["purl"].startswith(
+                ecosystem_prefixes.get(record["ecosystem"], "invalid:")
+            )
+            or not isinstance(record["raw_values"], list)
+            or any(not isinstance(item, str) or len(item) > 1024 * 1024 for item in record["raw_values"])
+            or not isinstance(record["metadata"], dict)
+            or not isinstance(record["evidence"], list)
+            or not record["evidence"]
+            or record["purl"] in records
+        ):
+            raise ValueError("agentic v2 license evidence record identity is invalid")
+        package = packages.get(record["purl"])
+        if (
+            package is None
+            or package["name"] != record["package"]
+            or package["versionInfo"] != record["version"]
+        ):
+            raise ValueError("agentic v2 license evidence differs from SBOM")
+        record["evidence"] = [_validate_evidence_item(item) for item in record["evidence"]]
+        _validate_record_metadata(record)
+        records[record["purl"]] = record
+    r_runtime_identities = {
+        canonical_sha256({
+            "runtime_version": record["metadata"]["runtime_version"],
+            "runtime_license": record["metadata"]["runtime_license"],
+            "runtime_license_fields": record["metadata"]["runtime_license_fields"],
+            "runtime_copyright_format": record["metadata"][
+                "runtime_copyright_format"
+            ],
+            "evidence": [
+                item
+                for item in record["evidence"]
+                if item["source"] in {
+                    "r-runtime-description",
+                    "r-runtime-license",
+                    "r-runtime-copyright",
+                    "r-shared-license",
+                }
+            ],
+        })
+        for record in records.values()
+        if record["ecosystem"] == "r"
+    }
+    if len(r_runtime_identities) > 1:
+        raise ValueError("agentic v2 R runtime evidence identity is inconsistent")
+    debian_status_identities = {
+        canonical_sha256(next(
+            item
+            for item in record["evidence"]
+            if item["source"] == "debian-status"
+        ))
+        for record in records.values()
+        if record["ecosystem"] == "debian"
+    }
+    if len(debian_status_identities) > 1:
+        raise ValueError("agentic v2 Debian status evidence identity is inconsistent")
+    if set(records) != set(packages) or document["records"] != sorted(
+        document["records"], key=lambda item: item["purl"]
+    ):
+        raise ValueError("agentic v2 license evidence package inventory mismatch")
+    return document
+
+
+def validate_license_exceptions(policy: Mapping[str, Any]) -> list[dict[str, Any]]:
+    license_policy = policy.get("license")
+    if not isinstance(license_policy, Mapping):
+        raise ValueError("agentic v2 license policy is missing")
+    as_of_date = license_policy.get("as_of_date")
+    exceptions = license_policy.get("exceptions")
+    if license_policy.get("denied_identifiers") != list(DENIED_LICENSE_IDENTIFIERS):
+        raise ValueError("agentic v2 denied license identifiers are invalid")
+    try:
+        policy_date = date.fromisoformat(as_of_date)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("agentic v2 license policy date is invalid") from exc
+    if not isinstance(exceptions, list):
+        raise ValueError("agentic v2 license exceptions are invalid")
+    validated = []
+    identities = set()
+    expected_fields = {
+        "ecosystem", "package", "version", "purl", "normalized_expression",
+        "evidence_sha256", "reason", "approver", "expires_at",
+    }
+    denied_identifiers = set(license_policy.get("denied_identifiers", []))
+    for raw in exceptions:
+        if not isinstance(raw, Mapping) or set(raw) != expected_fields:
+            raise ValueError("agentic v2 license exception fields are invalid")
+        item = dict(raw)
+        normalized = _canonical(item["normalized_expression"])
+        if (
+            item["ecosystem"] not in {"debian", "python", "r", "npm"}
+            or any(
+                not isinstance(item[key], str)
+                or not item[key]
+                or item[key] != item[key].strip()
+                or "*" in item[key]
+                for key in (
+                    "package", "version", "purl", "normalized_expression",
+                    "reason", "approver", "expires_at",
+                )
+            )
+            or not _matches(_HEX_DIGEST, item["evidence_sha256"])
+            or normalized != item["normalized_expression"]
+            or bool(denied_identifiers.intersection(
+                _identifiers(item["normalized_expression"])
+            ))
+        ):
+            raise ValueError("agentic v2 license exception identity is invalid")
+        try:
+            expires = date.fromisoformat(item["expires_at"])
+        except ValueError as exc:
+            raise ValueError("agentic v2 license exception expiry is invalid") from exc
+        if item["expires_at"] != expires.isoformat():
+            raise ValueError("agentic v2 license exception expiry is not canonical")
+        if expires < policy_date:
+            raise ValueError("agentic v2 license exception is expired")
+        identity = (item["purl"], item["evidence_sha256"])
+        if identity in identities:
+            raise ValueError("agentic v2 license exception is duplicated")
+        identities.add(identity)
+        validated.append(item)
+    return sorted(validated, key=lambda item: (item["purl"], item["evidence_sha256"]))
+
+
+def _decision(
+    record: Mapping[str, Any],
+    denied_identifiers: set[str],
+    exceptions: Mapping[tuple[str, str], Mapping[str, Any]],
+) -> dict[str, Any]:
+    outcome = _normalize(record)
+    evidence = deepcopy(record["evidence"])
+    evidence_sha256 = canonical_sha256(evidence)
+    policy_by_casefold = {
+        identifier.casefold(): identifier for identifier in denied_identifiers
+    }
+    raw_identifiers = set()
+    for raw in record["raw_values"]:
+        for token in _EXPRESSION_TOKEN.findall(raw):
+            if token.upper() in {"AND", "OR", "WITH"}:
+                continue
+            spdx = _spdx.LICENSES.get(token.casefold()) or _spdx.EXCEPTIONS.get(
+                token.casefold()
+            )
+            if spdx is not None:
+                raw_identifiers.add(spdx["id"])
+            elif token.casefold() in policy_by_casefold:
+                raw_identifiers.add(policy_by_casefold[token.casefold()])
+    denied = sorted(
+        denied_identifiers.intersection(outcome.identifiers | frozenset(raw_identifiers))
+    )
+    if denied:
+        classification = "denied"
+    elif outcome.expression is not None:
+        classification = "resolved"
+    else:
+        classification = outcome.issue or "unverifiable"
+    exception = exceptions.get((record["purl"], evidence_sha256))
+    exception_applied = None
+    normalized_expression = outcome.expression
+    reason = outcome.reason
+    reference_evidence_complete = True
+    if record["ecosystem"] == "debian":
+        reference_evidence_complete = (
+            record["metadata"].get("copyright_format") == _DEP5_FORMAT_URI
+            and sum(
+                item["source"] == "debian-copyright"
+                for item in record["evidence"]
+            ) == 1
+        )
+    elif record["ecosystem"] == "r":
+        declared = record["metadata"].get("declared_license", "")
+        if isinstance(declared, str) and _R_REFERENCE_LIKE.search(declared):
+            reference_evidence_complete = (
+                _R_LICENSE_REFERENCE.fullmatch(declared) is not None
+                and sum(
+                    item["source"] == "r-license-file"
+                    for item in record["evidence"]
+                ) == 1
+            )
+    elif record["ecosystem"] == "npm":
+        declared = record["metadata"].get("license", "")
+        if isinstance(declared, str) and _NPM_REFERENCE_LIKE.search(declared):
+            reference_evidence_complete = (
+                _NPM_LICENSE_REFERENCE.fullmatch(declared) is not None
+                and sum(
+                    item["source"] == "npm-license-file"
+                    for item in record["evidence"]
+                ) == 1
+            )
+    if (
+        exception is not None
+        and classification in UNRESOLVED_CLASSIFICATIONS
+        and reference_evidence_complete
+    ):
+        if (
+            exception["ecosystem"] != record["ecosystem"]
+            or exception["package"] != record["package"]
+            or exception["version"] != record["version"]
+        ):
+            raise ValueError("agentic v2 license exception package identity mismatch")
+        classification = "exception"
+        normalized_expression = exception["normalized_expression"]
+        reason = "package-version-specific-policy-exception"
+        exception_applied = deepcopy(dict(exception))
+    return {
+        "ecosystem": record["ecosystem"],
+        "package": record["package"],
+        "version": record["version"],
+        "purl": record["purl"],
+        "classification": classification,
+        "normalized_expression": normalized_expression,
+        "raw_values": deepcopy(record["raw_values"]),
+        "normalization_reason": reason,
+        "denied_identifiers": denied,
+        "evidence": evidence,
+        "evidence_sha256": evidence_sha256,
+        "exception": exception_applied,
+    }
+
+
+def build_license_report(
+    *,
+    subject: Mapping[str, Any],
+    subject_sha256: str,
+    sbom: Mapping[str, Any],
+    license_evidence: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    policy_sha256: str,
+) -> dict[str, Any]:
+    if subject_sha256 != canonical_sha256(subject):
+        raise ValueError("agentic v2 license report subject hash differs")
+    if policy_sha256 != canonical_sha256(policy):
+        raise ValueError("agentic v2 license report policy hash differs")
+    from core.agentic_v2_supply_chain import CandidateSubject, SupplyChainPolicy
+
+    CandidateSubject.from_mapping(subject)
+    SupplyChainPolicy.from_mapping(policy)
+    runtime_identity = license_evaluator_runtime_identity()
+    if any(
+        subject.get(subject_key) != runtime_identity[runtime_key]
+        for subject_key, runtime_key in (
+            ("license_evaluator_packaging_version", "packaging_version"),
+            ("license_evaluator_spdx_version", "spdx_version"),
+            ("license_evaluator_spdx_sha256", "spdx_sha256"),
+            ("license_evaluator_parser_sha256", "parser_sha256"),
+            ("license_evaluator_runtime_graph_sha256", "runtime_graph_sha256"),
+            ("license_evaluator_python_version", "python_version"),
+            ("license_evaluator_callable_sha256", "callable_sha256"),
+        )
+    ):
+        raise ValueError("agentic v2 license evaluator runtime binding differs")
+    evidence = validate_license_evidence(license_evidence, sbom)
+    exceptions = validate_license_exceptions(policy)
+    exception_map = {
+        (item["purl"], item["evidence_sha256"]): item
+        for item in exceptions
+    }
+    denied_identifiers = set(policy["license"]["denied_identifiers"])
+    records_by_purl = {item["purl"]: item for item in evidence["records"]}
+    decisions = [
+        _decision(records_by_purl[purl], denied_identifiers, exception_map)
+        for purl in sorted(records_by_purl)
+    ]
+    applied_exceptions = {
+        (decision["purl"], decision["evidence_sha256"])
+        for decision in decisions
+        if decision["exception"] is not None
+    }
+    if applied_exceptions != set(exception_map):
+        raise ValueError("agentic v2 license exception is stale or unmatched")
+    counts = {name: 0 for name in sorted(CLASSIFICATIONS)}
+    ecosystem_counts = {
+        ecosystem: {name: 0 for name in sorted(CLASSIFICATIONS)}
+        for ecosystem in ("debian", "python", "r", "npm")
+    }
+    for decision in decisions:
+        counts[decision["classification"]] += 1
+        ecosystem_counts[decision["ecosystem"]][decision["classification"]] += 1
+    unresolved_count = sum(counts[name] for name in UNRESOLVED_CLASSIFICATIONS)
+    status = "failed" if counts["denied"] or unresolved_count else "verified"
+    binding = {
+        "subject_sha256": subject_sha256,
+        "image_id": subject["image_id"],
+        "config_digest": subject["image_id"],
+        "oci_manifest_digest": subject["oci_manifest_digest"],
+        "source_revision": subject["source_revision"],
+        "effective_sbom_sha256": canonical_sha256(sbom),
+        "license_evidence_sha256": canonical_sha256(evidence),
+        "license_collector_sha256": subject["license_collector_sha256"],
+        "license_evaluator_sha256": subject["license_evaluator_sha256"],
+        "license_evaluator_packaging_version": runtime_identity["packaging_version"],
+        "license_evaluator_spdx_version": runtime_identity["spdx_version"],
+        "license_evaluator_spdx_sha256": runtime_identity["spdx_sha256"],
+        "license_evaluator_parser_sha256": runtime_identity["parser_sha256"],
+        "license_evaluator_runtime_graph_sha256": runtime_identity[
+            "runtime_graph_sha256"
+        ],
+        "license_evaluator_python_version": runtime_identity["python_version"],
+        "license_evaluator_callable_sha256": runtime_identity["callable_sha256"],
+        "policy_sha256": policy_sha256,
+    }
+    report = {
+        "schema_version": "2.0",
+        "policy_id": policy["license"]["policy_id"],
+        "foundation_only": True,
+        "production_activation": "disabled",
+        "status": status,
+        "binding": binding,
+        "package_count": len(decisions),
+        "counts": counts,
+        "unresolved_count": unresolved_count,
+        "ecosystem_counts": ecosystem_counts,
+        "exceptions": exceptions,
+        "decisions": decisions,
+        "decisions_sha256": canonical_sha256(decisions),
+    }
+    report["report_sha256"] = canonical_sha256(report)
+    return report
+
+
+def validate_license_report(
+    value: Any,
+    *,
+    subject: Mapping[str, Any],
+    subject_sha256: str,
+    sbom: Mapping[str, Any],
+    license_evidence: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    policy_sha256: str,
+) -> dict[str, Any]:
+    expected = build_license_report(
+        subject=subject,
+        subject_sha256=subject_sha256,
+        sbom=sbom,
+        license_evidence=license_evidence,
+        policy=policy,
+        policy_sha256=policy_sha256,
+    )
+    if not isinstance(value, Mapping):
+        raise ValueError("agentic v2 license report identity is invalid")
+    supplied = deepcopy(dict(value))
+    claimed = supplied.pop("report_sha256", None)
+    if (
+        not _matches(_HEX_DIGEST, claimed)
+        or claimed != canonical_sha256(supplied)
+        or canonical_sha256(value) != canonical_sha256(expected)
+    ):
+        raise ValueError("agentic v2 license report identity is invalid")
+    return deepcopy(expected)

--- a/batch-runner/core/agentic_v2_oci.py
+++ b/batch-runner/core/agentic_v2_oci.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import posixpath
 import shutil
@@ -168,7 +169,7 @@ def verify_oci_layout(
     index = _json_loads(index_bytes)
     if not isinstance(index, dict) or set(index) != {
         "schemaVersion", "mediaType", "manifests"
-    } or index["schemaVersion"] != 2 or index["mediaType"] != (
+    } or type(index["schemaVersion"]) is not int or index["schemaVersion"] != 2 or index["mediaType"] != (
         "application/vnd.oci.image.index.v1+json"
     ):
         raise ValueError("OCI index identity is invalid")
@@ -188,10 +189,17 @@ def verify_oci_layout(
     manifest = _json_loads(manifest_bytes)
     if not isinstance(manifest, dict) or set(manifest) != {
         "schemaVersion", "mediaType", "config", "layers"
-    } or manifest["schemaVersion"] != 2 or manifest["mediaType"] != OCI_MANIFEST_MEDIA_TYPE:
+    } or type(manifest["schemaVersion"]) is not int or manifest["schemaVersion"] != 2 or manifest["mediaType"] != OCI_MANIFEST_MEDIA_TYPE:
         raise ValueError("OCI image manifest is invalid")
+    config_descriptor = manifest["config"]
+    if (
+        not isinstance(config_descriptor, dict)
+        or set(config_descriptor) != {"mediaType", "digest", "size"}
+        or config_descriptor["mediaType"] != OCI_CONFIG_MEDIA_TYPE
+    ):
+        raise ValueError("OCI config descriptor is invalid")
     config_bytes = _read_verified_blob(
-        root, manifest["config"], maximum=64 * 1024 * 1024
+        root, config_descriptor, maximum=64 * 1024 * 1024
     )
     config = _json_loads(config_bytes)
     layers = manifest["layers"]
@@ -211,7 +219,7 @@ def verify_oci_layout(
     total_layer_bytes = 0
     referenced_digests = {
         descriptor["digest"].removeprefix("sha256:"),
-        manifest["config"]["digest"].removeprefix("sha256:"),
+        config_descriptor["digest"].removeprefix("sha256:"),
     }
     for layer in layers:
         if not isinstance(layer, dict) or layer.get("mediaType") != OCI_LAYER_MEDIA_TYPE:
@@ -473,7 +481,44 @@ def _json_loads(value: bytes):
             result[key] = item
         return result
 
+    def bounded_int(raw):
+        if len(raw.lstrip("-")) > 100:
+            raise ValueError("JSON integer is too large")
+        return int(raw)
+
+    def reject_constant(raw):
+        raise ValueError(f"JSON constant is invalid: {raw}")
+
+    def bounded_float(raw):
+        if len(raw) > 100:
+            raise ValueError("JSON float is too large")
+        value = float(raw)
+        if not math.isfinite(value):
+            raise ValueError("JSON float is not finite")
+        return value
+
     try:
-        return json.loads(value, object_pairs_hook=reject_duplicates)
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        document = json.loads(
+            value,
+            object_pairs_hook=reject_duplicates,
+            parse_int=bounded_int,
+            parse_float=bounded_float,
+            parse_constant=reject_constant,
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError) as exc:
         raise ValueError("JSON document is invalid") from exc
+    stack = [(document, 1)]
+    nodes = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > 500_000 or depth > 64:
+            raise ValueError("JSON document structure exceeds limits")
+        if isinstance(item, str) and len(item) > 1024 * 1024:
+            raise ValueError("JSON string exceeds size limit")
+        if isinstance(item, dict):
+            stack.extend((key, depth + 1) for key in item)
+            stack.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, list):
+            stack.extend((child, depth + 1) for child in item)
+    return document

--- a/batch-runner/core/agentic_v2_substrate.py
+++ b/batch-runner/core/agentic_v2_substrate.py
@@ -12,6 +12,36 @@ from typing import Any, Mapping
 
 SUBSTRATE_SCHEMA_VERSION = "1.0"
 SUBSTRATE_ID = "professional-work-v1"
+AGENTIC_V2_IMAGE_PROBE_COUNT = 3
+AGENTIC_V2_IMAGE_PROBE_TIMEOUT_SECONDS = 900
+AGENTIC_V2_SHORT_DOCKER_COMMAND_LIMIT = 64
+AGENTIC_V2_SHORT_DOCKER_TIMEOUT_SECONDS = 60
+AGENTIC_V2_GIT_COMMAND_LIMIT = 64
+AGENTIC_V2_GIT_TIMEOUT_SECONDS = 30
+AGENTIC_V2_EVIDENCE_ROOT_COPY_LIMIT = 6
+AGENTIC_V2_EVIDENCE_ROOT_COPY_TIMEOUT_SECONDS = 900
+AGENTIC_V2_VERIFICATION_SESSION_MAX_CONTAINERS = 16
+AGENTIC_V2_VERIFICATION_SESSION_SWEEP_LIMIT = 3
+AGENTIC_V2_VERIFICATION_SESSION_INVENTORY_TIMEOUT_SECONDS = 60
+AGENTIC_V2_VERIFICATION_SESSION_REMOVE_TIMEOUT_SECONDS = 30
+AGENTIC_V2_HOST_VALIDATION_BUDGET_SECONDS = 1800
+AGENTIC_V2_VERIFIER_OVERHEAD_SECONDS = (
+    AGENTIC_V2_SHORT_DOCKER_COMMAND_LIMIT
+    * AGENTIC_V2_SHORT_DOCKER_TIMEOUT_SECONDS
+    + AGENTIC_V2_GIT_COMMAND_LIMIT * AGENTIC_V2_GIT_TIMEOUT_SECONDS
+    + AGENTIC_V2_EVIDENCE_ROOT_COPY_LIMIT
+    * AGENTIC_V2_EVIDENCE_ROOT_COPY_TIMEOUT_SECONDS
+    + (AGENTIC_V2_VERIFICATION_SESSION_SWEEP_LIMIT + 1)
+    * AGENTIC_V2_VERIFICATION_SESSION_INVENTORY_TIMEOUT_SECONDS
+    + AGENTIC_V2_VERIFICATION_SESSION_MAX_CONTAINERS
+    * AGENTIC_V2_VERIFICATION_SESSION_SWEEP_LIMIT
+    * AGENTIC_V2_VERIFICATION_SESSION_REMOVE_TIMEOUT_SECONDS
+    + AGENTIC_V2_HOST_VALIDATION_BUDGET_SECONDS
+)
+AGENTIC_V2_VERIFIER_TIMEOUT_SECONDS = (
+    AGENTIC_V2_IMAGE_PROBE_COUNT * AGENTIC_V2_IMAGE_PROBE_TIMEOUT_SECONDS
+    + AGENTIC_V2_VERIFIER_OVERHEAD_SECONDS
+)
 REQUIRED_CAPABILITY_FAMILIES = frozenset({
     "browser-local",
     "cad-dxf",
@@ -162,7 +192,8 @@ def validate_capability_receipt(
         or any(
             set(item) != {"id", "status", "artifact_sha256"}
             or item.get("status") != "pass"
-            or _DIGEST.fullmatch(str(item.get("artifact_sha256", ""))) is None
+            or not isinstance(item.get("artifact_sha256"), str)
+            or _DIGEST.fullmatch(item["artifact_sha256"]) is None
             for item in smokes
             if isinstance(item, Mapping)
         )
@@ -178,7 +209,8 @@ def validate_capability_receipt(
             or set(item) != {"count", "sha256", "records"}
             or type(item.get("count")) is not int
             or item["count"] <= 0
-            or _DIGEST.fullmatch(str(item.get("sha256", ""))) is None
+            or not isinstance(item.get("sha256"), str)
+            or _DIGEST.fullmatch(item["sha256"]) is None
             or not isinstance(item.get("records"), list)
             or item["records"] != sorted(set(item["records"]))
             or len(item["records"]) != item["count"]
@@ -254,7 +286,7 @@ def _validate_manifest(value: Any) -> dict[str, Any]:
         "provenance_profile": "buildkit-max-v1",
         "signature_profile": "cosign-offline-v1",
         "cve_policy_id": "agentic-v2-cve-v1",
-        "license_policy_id": "agentic-v2-license-v1",
+        "license_policy_id": "agentic-v2-license-v2",
     }:
         raise ValueError("agentic v2 substrate supply-chain policy is invalid")
     if document["microvm"] != {
@@ -263,7 +295,7 @@ def _validate_manifest(value: Any) -> dict[str, Any]:
         "network": "none",
         "rootfs": "read-only",
         "workdir": "ephemeral-quota",
-    }:
+    } or document["microvm"].get("required") is not True:
         raise ValueError("agentic v2 substrate microvm policy is invalid")
     return document
 
@@ -310,7 +342,8 @@ def _receipt_records(value: Any, label: str) -> dict[str, dict[str, Any]]:
             or not isinstance(item.get("name"), str)
             or not isinstance(item.get("version"), str)
             or not item["version"]
-            or _DIGEST.fullmatch(str(item.get("sha256", ""))) is None
+            or not isinstance(item.get("sha256"), str)
+            or _DIGEST.fullmatch(item["sha256"]) is None
             or item["name"] in records
         ):
             raise ValueError(f"agentic v2 capability receipt {label} is invalid")

--- a/batch-runner/core/agentic_v2_supply_chain.py
+++ b/batch-runner/core/agentic_v2_supply_chain.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import hashlib
+import math
 import os
 import re
 import stat
@@ -22,6 +23,19 @@ from core.agentic_v2_substrate import (
     AgenticV2SubstrateManifest,
     canonical_sha256,
     validate_capability_receipt,
+)
+from core.agentic_v2_license import (
+    DENIED_LICENSE_IDENTIFIERS,
+    LICENSE_EVALUATOR_CALLABLE_SHA256,
+    LICENSE_EVALUATOR_PACKAGING_VERSION,
+    LICENSE_EVALUATOR_PARSER_SHA256,
+    LICENSE_EVALUATOR_PYTHON_VERSION,
+    LICENSE_EVALUATOR_RUNTIME_GRAPH_SHA256,
+    LICENSE_EVALUATOR_SPDX_SHA256,
+    LICENSE_EVALUATOR_SPDX_VERSION,
+    validate_license_evidence,
+    validate_license_exceptions,
+    validate_license_report,
 )
 
 
@@ -59,6 +73,10 @@ EVIDENCE_COLLECTION_CHECKS = frozenset({
 _DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
 _HEX_DIGEST = re.compile(r"[0-9a-f]{64}")
 _SOURCE_SHA = re.compile(r"[0-9a-f]{40}")
+
+
+def _matches(pattern: re.Pattern, value: Any) -> bool:
+    return isinstance(value, str) and pattern.fullmatch(value) is not None
 
 
 @dataclass(frozen=True)
@@ -151,9 +169,9 @@ def build_blocked_evidence_report(
     capability_receipt_sha256: str,
     oci_layout_report_sha256: str,
 ) -> dict[str, Any]:
-    if _HEX_DIGEST.fullmatch(capability_receipt_sha256) is None:
+    if not _matches(_HEX_DIGEST, capability_receipt_sha256):
         raise ValueError("capability receipt evidence digest is invalid")
-    if _HEX_DIGEST.fullmatch(oci_layout_report_sha256) is None:
+    if not _matches(_HEX_DIGEST, oci_layout_report_sha256):
         raise ValueError("OCI evidence digest is invalid")
     evidence = {
         name: _not_run_evidence(subject.sha256)
@@ -585,7 +603,10 @@ def validate_evidence_directory(
         oci_layout,
         expected_manifest_digest=subject.document["oci_manifest_digest"],
     )
-    if oci_report != verified_oci:
+    if (
+        canonical_sha256(oci_report) != canonical_sha256(verified_oci)
+        or verified_oci.get("config_digest") != subject.document["image_id"]
+    ):
         raise ValueError("agentic v2 OCI evidence report mismatch")
     _match_report_evidence(gate, "oci_layout", oci_report)
 
@@ -606,6 +627,7 @@ def validate_evidence_directory(
 
     receipt_path = root / "candidate-receipt.json"
     sbom_path = root / "effective-sbom.spdx.json"
+    license_evidence_path = root / "license-evidence.json"
     license_path = root / "license-report.json"
     capability_status = gate["evidence"]["capability_receipt"]["status"]
     expected_files = {
@@ -619,6 +641,7 @@ def validate_evidence_directory(
         expected_files.update({
             "candidate-receipt.json",
             "effective-sbom.spdx.json",
+            "license-evidence.json",
             "license-report.json",
         })
     if _regular_directory_files(root) != expected_files:
@@ -668,17 +691,25 @@ def validate_evidence_directory(
             tool_name="gdpval-agentic-v2-effective-sbom",
             tool_sha256=subject.document["sbom_generator_sha256"],
         )
-        license_report = _read_json(license_path, 4 * 1024 * 1024)
-        expected_license = evaluate_license_policy(sbom, policy)
-        if license_report != expected_license:
-            raise ValueError("agentic v2 license evidence report mismatch")
+        license_evidence = validate_license_evidence(
+            _read_json(license_evidence_path, 256 * 1024 * 1024), sbom
+        )
+        license_report = validate_license_report(
+            _read_json(license_path, 256 * 1024 * 1024),
+            subject=subject.document,
+            subject_sha256=subject.sha256,
+            sbom=sbom,
+            license_evidence=license_evidence,
+            policy=policy.document,
+            policy_sha256=policy.sha256,
+        )
         _match_report_evidence(gate, "license", license_report)
         _require_evidence_binding(
             gate,
             "license",
             status=license_report["status"],
-            tool_name="gdpval-agentic-v2-license-policy",
-            tool_sha256=policy.sha256,
+            tool_name="gdpval-agentic-v2-license-evaluator",
+            tool_sha256=subject.document["license_evaluator_sha256"],
         )
     elif (
         evidence_collection_allowed(containment)
@@ -764,6 +795,15 @@ def _validate_subject(value: Any) -> dict[str, Any]:
         "verifier_sha256",
         "oci_exporter_sha256",
         "sbom_generator_sha256",
+        "license_collector_sha256",
+        "license_evaluator_sha256",
+        "license_evaluator_packaging_version",
+        "license_evaluator_parser_sha256",
+        "license_evaluator_python_version",
+        "license_evaluator_callable_sha256",
+        "license_evaluator_runtime_graph_sha256",
+        "license_evaluator_spdx_version",
+        "license_evaluator_spdx_sha256",
         "lock_set_sha256",
     }:
         raise ValueError("agentic v2 candidate subject fields are invalid")
@@ -772,11 +812,11 @@ def _validate_subject(value: Any) -> dict[str, Any]:
         document["schema_version"] != "1.0"
         or document["substrate_id"] != "professional-work-v1"
         or any(
-            _DIGEST.fullmatch(str(document[name])) is None
+            not _matches(_DIGEST, document[name])
             for name in ("image_id", "oci_manifest_digest", "parent_manifest_digest")
         )
         or any(
-            _HEX_DIGEST.fullmatch(str(document[name])) is None
+            not _matches(_HEX_DIGEST, document[name])
             for name in (
                 "dockerfile_sha256",
                 "manifest_sha256",
@@ -785,11 +825,31 @@ def _validate_subject(value: Any) -> dict[str, Any]:
                 "verifier_sha256",
                 "oci_exporter_sha256",
                 "sbom_generator_sha256",
+                "license_collector_sha256",
+                "license_evaluator_sha256",
+                "license_evaluator_parser_sha256",
+                "license_evaluator_callable_sha256",
+                "license_evaluator_runtime_graph_sha256",
+                "license_evaluator_spdx_sha256",
                 "lock_set_sha256",
             )
         )
+        or document["license_evaluator_packaging_version"]
+        != LICENSE_EVALUATOR_PACKAGING_VERSION
+        or document["license_evaluator_spdx_version"]
+        != LICENSE_EVALUATOR_SPDX_VERSION
+        or document["license_evaluator_spdx_sha256"]
+        != LICENSE_EVALUATOR_SPDX_SHA256
+        or document["license_evaluator_parser_sha256"]
+        != LICENSE_EVALUATOR_PARSER_SHA256
+        or document["license_evaluator_python_version"]
+        != LICENSE_EVALUATOR_PYTHON_VERSION
+        or document["license_evaluator_callable_sha256"]
+        != LICENSE_EVALUATOR_CALLABLE_SHA256
+        or document["license_evaluator_runtime_graph_sha256"]
+        != LICENSE_EVALUATOR_RUNTIME_GRAPH_SHA256
         or document["platform"] != "linux/amd64"
-        or _SOURCE_SHA.fullmatch(str(document["source_revision"])) is None
+        or not _matches(_SOURCE_SHA, document["source_revision"])
     ):
         raise ValueError("agentic v2 candidate subject identity is invalid")
     return document
@@ -813,18 +873,59 @@ def _validate_policy(value: Any) -> dict[str, Any]:
     if set(value) != expected:
         raise ValueError("agentic v2 supply-chain policy fields are invalid")
     document = deepcopy(dict(value))
+    license_policy = document.get("license")
+    cve = document.get("cve")
+    signature = document.get("signature")
+    microvm = document.get("microvm")
     if (
         document["schema_version"] != "1.0"
-        or document["policy_id"] != "agentic-v2-phase1b-candidate-v1"
+        or document["policy_id"] != "agentic-v2-phase1c-candidate-v1"
         or document["foundation_only"] is not True
         or document["production_activation"] != "disabled"
         or document["required_evidence"] != sorted(EVIDENCE_NAMES)
-        or document["cve"]["policy_id"] != "agentic-v2-cve-v1"
-        or document["license"]["policy_id"] != "agentic-v2-license-v1"
+        or not isinstance(cve, dict)
+        or type(cve.get("scanner_db_max_age_days")) is not int
+        or document["cve"] != {
+            "policy_id": "agentic-v2-cve-v1",
+            "scanner_db_max_age_days": 7,
+            "denied_severities": ["CRITICAL", "HIGH"],
+            "exceptions_require": [
+                "cve", "purl", "reason", "approver", "expires_at",
+            ],
+        }
+        or document["license"]["policy_id"] != "agentic-v2-license-v2"
+        or not isinstance(license_policy, dict)
+        or set(license_policy) != {
+            "policy_id", "as_of_date", "unknown_is_failure",
+            "unknown_classifications", "denied_identifiers",
+            "exceptions_require", "exceptions",
+        }
+        or license_policy["unknown_is_failure"] is not True
+        or license_policy["denied_identifiers"]
+        != list(DENIED_LICENSE_IDENTIFIERS)
+        or document["license"].get("as_of_date") != "2026-07-31"
+        or document["license"].get("unknown_classifications") != [
+            "ambiguous", "missing_metadata", "unverifiable"
+        ]
+        or document["license"].get("exceptions_require") != [
+            "ecosystem", "package", "version", "purl",
+            "normalized_expression", "evidence_sha256", "reason", "approver",
+            "expires_at",
+        ]
         or document["signature"] != {
             "profile": "cosign-offline-v1",
             "trusted_key_required": True,
             "bundle_required": True,
+        }
+        or not isinstance(signature, dict)
+        or signature.get("trusted_key_required") is not True
+        or signature.get("bundle_required") is not True
+        or document["provenance"] != {
+            "profile": "buildkit-max-v1",
+            "required_subjects": [
+                "candidate", "parent", "dockerfile", "locks", "manifest",
+                "probe", "sbom", "policy",
+            ],
         }
         or document["microvm"] != {
             "runtime": "firecracker",
@@ -834,8 +935,14 @@ def _validate_policy(value: Any) -> dict[str, Any]:
             "read_only_rootfs": True,
             "ephemeral_work_disk": True,
         }
+        or not isinstance(microvm, dict)
+        or microvm.get("jailer_required") is not True
+        or microvm.get("kvm_required") is not True
+        or microvm.get("read_only_rootfs") is not True
+        or microvm.get("ephemeral_work_disk") is not True
     ):
         raise ValueError("agentic v2 supply-chain policy is invalid")
+    validate_license_exceptions(document)
     return document
 
 
@@ -886,8 +993,8 @@ def _validate_evidence_item(name: str, value: Any, subject_sha256: str) -> None:
         not isinstance(tool, dict)
         or set(tool) != {"name", "version", "sha256"}
         or not all(isinstance(tool[key], str) and tool[key] for key in ("name", "version"))
-        or _HEX_DIGEST.fullmatch(str(tool.get("sha256", ""))) is None
-        or _HEX_DIGEST.fullmatch(str(value.get("report_sha256", ""))) is None
+        or not _matches(_HEX_DIGEST, tool.get("sha256"))
+        or not _matches(_HEX_DIGEST, value.get("report_sha256"))
     ):
         raise ValueError(f"agentic v2 {name} evidence tool identity is invalid")
 
@@ -975,10 +1082,47 @@ def _read_json(path: Path, maximum: int):
             result[key] = item
         return result
 
+    def bounded_int(raw):
+        if len(raw.lstrip("-")) > 100:
+            raise ValueError("agentic v2 evidence JSON integer is too large")
+        return int(raw)
+
+    def bounded_float(raw):
+        if len(raw) > 100:
+            raise ValueError("agentic v2 evidence JSON float is too large")
+        result = float(raw)
+        if not math.isfinite(result):
+            raise ValueError("agentic v2 evidence JSON float is not finite")
+        return result
+
+    def reject_constant(raw):
+        raise ValueError(f"agentic v2 evidence JSON constant is invalid: {raw}")
+
     try:
-        return json.loads(value, object_pairs_hook=reject_duplicates)
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        document = json.loads(
+            value,
+            object_pairs_hook=reject_duplicates,
+            parse_int=bounded_int,
+            parse_float=bounded_float,
+            parse_constant=reject_constant,
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError) as exc:
         raise ValueError("agentic v2 evidence JSON is invalid") from exc
+    stack = [(document, 1)]
+    nodes = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > 500_000 or depth > 64:
+            raise ValueError("agentic v2 evidence JSON structure exceeds limits")
+        if isinstance(item, str) and len(item) > 1024 * 1024:
+            raise ValueError("agentic v2 evidence JSON string exceeds size limit")
+        if isinstance(item, dict):
+            stack.extend((key, depth + 1) for key in item)
+            stack.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, list):
+            stack.extend((child, depth + 1) for child in item)
+    return document
 
 
 def _secure_read_flags() -> int:

--- a/batch-runner/requirements.txt
+++ b/batch-runner/requirements.txt
@@ -14,7 +14,7 @@ azure-ai-projects==2.3.0
 jsonschema>=4.21.0
 cryptography>=42.0.0
 ijson>=3.3.0
-packaging>=24.2
+packaging==26.2
 
 # Reference file readers
 pdfplumber>=0.10.0

--- a/batch-runner/sandbox/agentic_v2_capabilities.json
+++ b/batch-runner/sandbox/agentic_v2_capabilities.json
@@ -83,7 +83,7 @@
     "provenance_profile": "buildkit-max-v1",
     "signature_profile": "cosign-offline-v1",
     "cve_policy_id": "agentic-v2-cve-v1",
-    "license_policy_id": "agentic-v2-license-v1"
+    "license_policy_id": "agentic-v2-license-v2"
   },
   "microvm": {
     "required": true,

--- a/batch-runner/sandbox/v2/README.md
+++ b/batch-runner/sandbox/v2/README.md
@@ -1,4 +1,4 @@
-# Agentic Sandbox V2 Phase 1B Candidate
+# Agentic Sandbox V2 Phase 1B/1C Candidate
 
 This directory defines a **model-free, local-only professional-work substrate
 candidate**. It does not activate `agentic_sandbox_v2`, publish an image, or
@@ -53,8 +53,8 @@ From a **clean committed worktree**:
 
 ```bash
 cd batch-runner
-python sandbox/v2/build_candidate.py \
-  --output-root /tmp/gdpval-agentic-v2-phase1b-evidence
+python -I -S -B sandbox/v2/build_candidate.py \
+  --output-root /tmp/gdpval-agentic-v2-phase1c-evidence
 ```
 
 The builder:
@@ -88,38 +88,66 @@ experiment, or publication path in this directory.
 | Capability receipt | `not_run` until collection isolation is verified; then bound to one exact local image/config/OCI digest |
 | OCI layout | Host-generated and every blob rehashed |
 | Effective SBOM | `not_run` until collection isolation is verified; then generated from exact installed Debian, Python, R, and npm records |
-| License | `not_run` with no SBOM; otherwise unknown or denied SPDX expressions fail |
+| License | `not_run` with no SBOM; otherwise exact Debian, Python, R, and npm evidence is classified as resolved, missing, ambiguous, unverifiable, denied, or exact exception; every unresolved class fails |
 | CVE | `not_run` until a pinned scanner and DB snapshot are supplied |
 | Signature | `not_run` until an approved offline trust root and bundle exist |
 | Provenance | `not_run` until source/locks/build/SBOM policy subjects are attested |
 | MicroVM | `not_run` unless Firecracker, jailer, KVM, kernel, and rootfs exist |
 
+## Deterministic License Closure
+
+Phase 1C adds a stdlib-only in-image collector and a separately staged host
+evaluator. The collector reads exact files from fixed Debian, Python, R, and
+npm roots with descriptor-relative no-follow opens. The host validates the
+SBOM inventory, reopens 1,720 physical evidence files from the exact image,
+normalizes only exact SPDX evidence, and records honest unresolved outcomes.
+Package exceptions require exact ecosystem, package, version, purl, evidence
+digest, normalized expression, reviewer, reason, and expiry. Denied identifiers
+win before exceptions, and unstructured or incomplete referenced evidence is
+never exception-eligible.
+
+The evaluator runs under `python -I -S -B` from staged Git and packaging source
+bytes. Its callable identity binds the transformed parser, frozen SPDX tables,
+normalization/classification/report surface, semantic dependencies, and
+import-order-independent runtime behavior. Image-declared volumes and
+healthchecks are forbidden; every probe disables healthchecks. R inventory is
+shared between the receipt and SPDX generator, including the installed
+`translations` package. Symlink-heavy npm and Debian documentation roots are
+verified through bounded, non-extracted canonical tar members.
+
 ## Validated Checkpoint
 
-Commit `133df3f0aa5e4361c6c6cb7fd142ef5bdff8c1b5` produced one local-only
+Commit `1397f92b5257747ca3faf99e00a74269d4b14875` produced one local-only
 candidate:
 
 - image ID:
-  `sha256:dea418e4964c2e73bf77496633d0e16e5fc4fb66dddbb743d91d0020b672a77a`;
+  `sha256:e47537b8f7ac7c595b3a055dea4d16283efaa9c9a67c0f8a3e0fc2d65e834e29`;
 - OCI manifest:
-  `sha256:e55817b206dfc4fed855742b327bf6a7c7bdd3b08bc391c2470f9b16efa7f525`;
-- OCI status: `verified`, 22 layers, `linux/amd64`;
+  `sha256:0064ce70a26d6df58353a2e305a69d1d03e1db4525eee9870841fe10c6b3d02a`;
+- OCI status: `verified`, 23 layers, `linux/amd64`;
 - collection isolation: `verified` for network, read-only root, non-root
   identity, dropped capabilities, no-new-privileges, and memory;
 - production containment: `failed` only because this host cannot enforce CPU
   quota or PID limits;
 - capability receipt: `verified` for 20 commands, 13 Python modules, three font
   families, and all nine artifact smokes;
-- effective SPDX SBOM: `verified` for 1,422 packages across Debian, Python, R,
-  and npm inventories;
-- license: `failed` on 1,255 unknown declarations with zero denied packages;
+- effective SPDX SBOM: `verified` for 1,423 packages: Debian 1,152, Python 255,
+  R 15, and npm 1;
+- license evidence: 1,423 records and 1,720 exact physical files, deterministic
+  raw SHA-256
+  `bee961e424cdd356eae5db67600829eeeaf28ac423cd14ee04bd702d89980043`;
+- license decisions: 186 resolved, 898 ambiguous, 1 missing metadata, 338
+  unverifiable, 0 denied, and 0 exceptions; 1,237 unresolved packages keep the
+  license evidence status `failed`;
 - CVE, signature, provenance, and microVM: `not_run`;
 - aggregate gate: `blocked`, with production activation still `disabled`.
 
 This result proves the exact candidate's observed professional-work capability
-matrix and SBOM while keeping production execution fail-closed. It does not
-prove a complete dependency lock, license compliance, vulnerability status,
-signature, provenance, or microVM isolation.
+matrix, SBOM, and deterministic license-evidence classifications while keeping
+production execution fail-closed. It deliberately does not claim license
+compliance because 1,237 packages remain unresolved. It also does not prove a
+complete dependency lock, vulnerability status, signature, provenance, or
+microVM isolation.
 
 ## Anti-Claims
 

--- a/batch-runner/sandbox/v2/build_candidate.py
+++ b/batch-runner/sandbox/v2/build_candidate.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import signal
 import shutil
 import stat
 import subprocess
@@ -17,13 +18,434 @@ import uuid
 from pathlib import Path
 
 
+_STAGED_ROOT_ENV = "GDPVAL_AGENTIC_V2_STAGED_BUILDER_ROOT"
+_REPOSITORY_ROOT_ENV = "GDPVAL_AGENTIC_V2_REPOSITORY_ROOT"
+_SOURCE_REVISION_ENV = "GDPVAL_AGENTIC_V2_SOURCE_REVISION"
+_RUNTIME_ROOT_ENV = "GDPVAL_AGENTIC_V2_LICENSE_RUNTIME_ROOT"
+_TRUSTED_PATH = "/usr/bin:/bin"
+_TRUSTED_GIT = "/usr/bin/git"
+_TRUSTED_DOCKER = "/usr/bin/docker"
+_BOOTSTRAP_FORBIDDEN_ENV = (
+    "AZURE_CLIENT_SECRET",
+    "AZURE_OPENAI_API_KEY",
+    "DOCKER_AUTH_CONFIG",
+    "GITHUB_TOKEN",
+    "HF_TOKEN",
+    "OPENAI_API_KEY",
+)
+_BUILDER_SOURCE_PATHS = (
+    "batch-runner/core/agentic_v2_license.py",
+    "batch-runner/core/agentic_v2_oci.py",
+    "batch-runner/core/agentic_v2_substrate.py",
+    "batch-runner/sandbox/v2/build_candidate.py",
+)
 BATCH_ROOT = Path(__file__).resolve().parents[2]
-REPOSITORY_ROOT = BATCH_ROOT.parent
-if str(BATCH_ROOT) not in sys.path:
+REPOSITORY_ROOT = (
+    Path(os.environ[_REPOSITORY_ROOT_ENV]).resolve(strict=True)
+    if __name__ == "__main__" and os.getenv(_STAGED_ROOT_ENV)
+    else BATCH_ROOT.parent
+)
+_BOOTSTRAP_RUNTIME_FILES = {
+    "packaging/__init__.py": (
+        494,
+        "42130474fbb65e882b2735774b42964bab7b97423d93c11e0d1265e1f9f0f3bb",
+    ),
+    "packaging/licenses/__init__.py": (
+        7293,
+        "fc9c745d1883ff9f296a5b169f22eb2ee879f59a4608f20f5cb29d668f4e26f4",
+    ),
+    "packaging/licenses/_spdx.py": (
+        51122,
+        "596ec35e2ca0ebcba9fd8343ff0a51625af548786257815f24b41f7e08613314",
+    ),
+}
+
+
+def _bootstrap_file_identity(item) -> tuple[int, ...]:
+    return (
+        item.st_dev,
+        item.st_ino,
+        item.st_mode,
+        item.st_nlink,
+        item.st_size,
+        item.st_mtime_ns,
+    )
+
+
+def _require_trusted_executable(path: str) -> None:
+    executable = Path(path)
+    if executable not in {Path(_TRUSTED_GIT), Path(_TRUSTED_DOCKER)}:
+        raise RuntimeError("candidate builder executable is not allowlisted")
+    for directory in (Path("/usr"), Path("/usr/bin")):
+        metadata = directory.lstat()
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != 0
+            or metadata.st_mode & 0o022
+        ):
+            raise RuntimeError("candidate builder trusted tool directory is invalid")
+    metadata = executable.lstat()
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != 0
+        or metadata.st_mode & 0o022
+        or not metadata.st_mode & 0o111
+    ):
+        raise RuntimeError("candidate builder trusted executable is invalid")
+
+
+def _bootstrap_runtime_matches(root: Path) -> bool:
+    try:
+        for directory in (root, root / "packaging", root / "packaging" / "licenses"):
+            metadata = directory.lstat()
+            if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+                return False
+        for relative_path, (expected_size, expected_sha256) in (
+            _BOOTSTRAP_RUNTIME_FILES.items()
+        ):
+            descriptor = os.open(
+                root / relative_path,
+                os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            )
+            try:
+                before = os.fstat(descriptor)
+                if (
+                    not stat.S_ISREG(before.st_mode)
+                    or before.st_nlink != 1
+                    or before.st_size != expected_size
+                ):
+                    return False
+                chunks = []
+                while True:
+                    chunk = os.read(descriptor, 64 * 1024)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                after = os.fstat(descriptor)
+            finally:
+                os.close(descriptor)
+            value = b"".join(chunks)
+            if (
+                _bootstrap_file_identity(before) != _bootstrap_file_identity(after)
+                or len(value) != expected_size
+                or hashlib.sha256(value).hexdigest() != expected_sha256
+            ):
+                return False
+    except OSError:
+        return False
+    return True
+
+
+def _bootstrap_staged_runtime_matches(root: Path) -> bool:
+    if not _bootstrap_runtime_matches(root):
+        return False
+    expected_files = set(_BOOTSTRAP_RUNTIME_FILES)
+    actual_files = set()
+    try:
+        for path in root.rglob("*"):
+            if path.is_symlink():
+                return False
+            if path.is_file():
+                actual_files.add(str(path.relative_to(root)))
+    except OSError:
+        return False
+    return actual_files == expected_files
+
+
+def _bootstrap_git_environment() -> dict[str, str]:
+    return {
+        "PATH": _TRUSTED_PATH,
+        "HOME": "/nonexistent",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+
+
+def _bootstrap_git(repository_root: Path, *arguments: str) -> bytes:
+    _require_trusted_executable(_TRUSTED_GIT)
+    return subprocess.run(
+        [
+            _TRUSTED_GIT, "--no-replace-objects",
+            "-c", "core.fsmonitor=false",
+            "-c", "core.hooksPath=/dev/null",
+            "-C", str(repository_root),
+            *arguments,
+        ],
+        env=_bootstrap_git_environment(),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+        check=True,
+    ).stdout
+
+
+def _bootstrap_git_blob(
+    repository_root: Path,
+    source_revision: str,
+    repository_path: str,
+) -> bytes:
+    return _bootstrap_git(
+        repository_root,
+        "show",
+        f"{source_revision}:{repository_path}",
+    )
+
+
+def _bootstrap_stage_sources(
+    repository_root: Path,
+    source_revision: str,
+    root: Path,
+) -> None:
+    for repository_path in _BUILDER_SOURCE_PATHS:
+        destination = root / repository_path.removeprefix("batch-runner/")
+        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        destination.write_bytes(_bootstrap_git_blob(
+            repository_root,
+            source_revision,
+            repository_path,
+        ))
+
+
+def _bootstrap_copy_runtime(source_root: Path, destination_root: Path) -> None:
+    if not _bootstrap_runtime_matches(source_root):
+        raise RuntimeError("candidate builder packaging runtime differs")
+    for relative_path, (expected_size, expected_sha256) in (
+        _BOOTSTRAP_RUNTIME_FILES.items()
+    ):
+        source = source_root / relative_path
+        descriptor = os.open(
+            source,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        )
+        try:
+            before = os.fstat(descriptor)
+            chunks = []
+            while True:
+                chunk = os.read(descriptor, 64 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+        value = b"".join(chunks)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or _bootstrap_file_identity(before) != _bootstrap_file_identity(after)
+            or len(value) != expected_size
+            or hashlib.sha256(value).hexdigest() != expected_sha256
+        ):
+            raise RuntimeError("candidate builder runtime changed while staging")
+        destination = destination_root / relative_path
+        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        destination.write_bytes(value)
+    if not _bootstrap_staged_runtime_matches(destination_root):
+        raise RuntimeError("staged candidate builder packaging runtime differs")
+
+
+def _bootstrap_runtime_root() -> Path:
+    executable = Path(sys.executable)
+    if not executable.is_absolute() or ".." in executable.parts:
+        raise RuntimeError("candidate builder Python executable path is invalid")
+    executable_prefix = executable.parent.parent
+    python_directory = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    candidates = [
+        executable_prefix / "lib" / python_directory / name
+        for name in ("site-packages", "dist-packages")
+    ]
+    runtime_roots = [path for path in candidates if _bootstrap_runtime_matches(path)]
+    if len(runtime_roots) != 1:
+        raise RuntimeError("candidate builder packaging runtime root is ambiguous")
+    return runtime_roots[0]
+
+
+def _bootstrap_validate_staged_sources(
+    staged_root: Path,
+    repository_root: Path,
+    source_revision: str,
+) -> None:
+    if Path(__file__).resolve(strict=True) != (
+        staged_root / "sandbox" / "v2" / "build_candidate.py"
+    ):
+        raise RuntimeError("candidate builder staged entrypoint identity differs")
+    expected_files = {
+        repository_path.removeprefix("batch-runner/")
+        for repository_path in _BUILDER_SOURCE_PATHS
+    }
+    actual_files = set()
+    for path in staged_root.rglob("*"):
+        if path.is_symlink():
+            raise RuntimeError("candidate builder staged source contains a symlink")
+        if path.is_file():
+            actual_files.add(str(path.relative_to(staged_root)))
+    if actual_files != expected_files:
+        raise RuntimeError("candidate builder staged source inventory differs")
+    for repository_path in _BUILDER_SOURCE_PATHS:
+        staged_path = staged_root / repository_path.removeprefix("batch-runner/")
+        expected = _bootstrap_git_blob(
+            repository_root,
+            source_revision,
+            repository_path,
+        )
+        descriptor = os.open(
+            staged_path,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        )
+        try:
+            before = os.fstat(descriptor)
+            chunks = []
+            while True:
+                chunk = os.read(descriptor, 64 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+        value = b"".join(chunks)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or _bootstrap_file_identity(before) != _bootstrap_file_identity(after)
+            or len(value) != before.st_size
+            or value != expected
+        ):
+            raise RuntimeError("candidate builder staged source differs from Git")
+
+
+def _bootstrap_builder_imports() -> Path:
+    if (
+        sys.flags.isolated != 1
+        or sys.flags.no_site != 1
+        or not sys.dont_write_bytecode
+    ):
+        raise RuntimeError(
+            "candidate builder requires isolated no-site no-bytecode startup"
+        )
+    staged_root = Path(os.environ[_STAGED_ROOT_ENV]).resolve(strict=True)
+    runtime_root = Path(os.environ[_RUNTIME_ROOT_ENV]).resolve(strict=True)
+    source_revision = os.environ[_SOURCE_REVISION_ENV]
+    if not re.fullmatch(r"[0-9a-f]{40}", source_revision):
+        raise RuntimeError("candidate builder staged revision is invalid")
+    if not _bootstrap_staged_runtime_matches(runtime_root):
+        raise RuntimeError("candidate builder staged runtime differs")
+    _bootstrap_validate_staged_sources(
+        staged_root,
+        REPOSITORY_ROOT,
+        source_revision,
+    )
+    existing = [
+        item
+        for item in sys.path
+        if item and Path(item).resolve() not in {Path.cwd().resolve(), BATCH_ROOT}
+    ]
+    sys.path[:] = [str(runtime_root), str(staged_root), *existing]
+    return runtime_root
+
+
+def _launch_staged_builder() -> int:
+    if any(os.getenv(name) for name in _BOOTSTRAP_FORBIDDEN_ENV):
+        raise RuntimeError("candidate builder refuses credential-bearing environment")
+    repository_root = BATCH_ROOT.parent.resolve(strict=True)
+    source_revision = _bootstrap_git(
+        repository_root,
+        "rev-parse",
+        "HEAD",
+    ).decode("ascii").strip()
+    if re.fullmatch(r"[0-9a-f]{40}", source_revision) is None:
+        raise RuntimeError("candidate builder source revision is invalid")
+    if _bootstrap_git(
+        repository_root,
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+    ):
+        raise RuntimeError("candidate builder requires a clean source tree")
+    runtime_source = _bootstrap_runtime_root()
+    with tempfile.TemporaryDirectory(
+        prefix="agentic-v2-staged-builder-"
+    ) as temporary:
+        temporary_root = Path(temporary)
+        staged_root = temporary_root / "batch-runner"
+        runtime_root = temporary_root / "license-runtime"
+        _bootstrap_stage_sources(repository_root, source_revision, staged_root)
+        _bootstrap_copy_runtime(runtime_source, runtime_root)
+        environment = {
+            "PATH": _TRUSTED_PATH,
+            "HOME": "/nonexistent",
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONHASHSEED": "0",
+            _STAGED_ROOT_ENV: str(staged_root),
+            _RUNTIME_ROOT_ENV: str(runtime_root),
+            _REPOSITORY_ROOT_ENV: str(repository_root),
+            _SOURCE_REVISION_ENV: source_revision,
+        }
+        if os.getenv("DOCKER_HOST"):
+            environment["DOCKER_HOST"] = os.environ["DOCKER_HOST"]
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-S",
+                "-B",
+                str(staged_root / "sandbox" / "v2" / "build_candidate.py"),
+                *sys.argv[1:],
+            ],
+            cwd=staged_root,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            check=False,
+        )
+        return completed.returncode
+
+
+if __name__ == "__main__" and not os.getenv(_STAGED_ROOT_ENV):
+    if (
+        sys.flags.isolated != 1
+        or sys.flags.no_site != 1
+        or not sys.dont_write_bytecode
+    ):
+        raise RuntimeError(
+            "candidate builder requires isolated no-site no-bytecode startup"
+        )
+    raise SystemExit(_launch_staged_builder())
+
+_BOOTSTRAPPED_RUNTIME_ROOT = (
+    _bootstrap_builder_imports() if __name__ == "__main__" else None
+)
+if _BOOTSTRAPPED_RUNTIME_ROOT is None and str(BATCH_ROOT) not in sys.path:
     sys.path.insert(0, str(BATCH_ROOT))
 
+import packaging  # noqa: E402
+
 from core.agentic_v2_oci import export_docker_archive_to_oci  # noqa: E402
+from core.agentic_v2_license import (  # noqa: E402
+    LICENSE_EVALUATOR_RUNTIME_GRAPH_SHA256,
+    license_evaluator_runtime_identity,
+)
 from core.agentic_v2_substrate import AgenticV2SubstrateManifest  # noqa: E402
+from core.agentic_v2_substrate import (  # noqa: E402
+    AGENTIC_V2_IMAGE_PROBE_COUNT,
+    AGENTIC_V2_IMAGE_PROBE_TIMEOUT_SECONDS,
+    AGENTIC_V2_VERIFICATION_SESSION_INVENTORY_TIMEOUT_SECONDS,
+    AGENTIC_V2_VERIFICATION_SESSION_MAX_CONTAINERS,
+    AGENTIC_V2_VERIFICATION_SESSION_REMOVE_TIMEOUT_SECONDS,
+    AGENTIC_V2_VERIFICATION_SESSION_SWEEP_LIMIT,
+    AGENTIC_V2_VERIFIER_OVERHEAD_SECONDS,
+)
+AGENTIC_V2_VERIFIER_TIMEOUT_SECONDS = (
+    AGENTIC_V2_IMAGE_PROBE_COUNT * AGENTIC_V2_IMAGE_PROBE_TIMEOUT_SECONDS
+    + AGENTIC_V2_VERIFIER_OVERHEAD_SECONDS
+)
 
 
 _SOURCE_SHA = re.compile(r"[0-9a-f]{40}")
@@ -43,21 +465,50 @@ _BUILD_CONTEXT_PATHS = (
     "batch-runner/sandbox/v2/disabled_entrypoint.py",
     "batch-runner/sandbox/v2/effective_sbom.py",
     "batch-runner/sandbox/v2/image_probe.py",
+    "batch-runner/sandbox/v2/license_evidence.py",
     "batch-runner/sandbox/v2/professional-work.Dockerfile",
     "batch-runner/sandbox/v2/python-extra.lock",
 )
 _VERIFIER_PATHS = (
+    "batch-runner/core/agentic_v2_license.py",
     "batch-runner/core/agentic_v2_microvm.py",
     "batch-runner/core/agentic_v2_oci.py",
     "batch-runner/core/agentic_v2_substrate.py",
     "batch-runner/core/agentic_v2_supply_chain.py",
     "batch-runner/sandbox/v2/verify_candidate.py",
 )
+_LICENSE_RUNTIME_PATHS = (
+    "packaging/__init__.py",
+    "packaging/licenses/__init__.py",
+    "packaging/licenses/_spdx.py",
+)
+_VERIFIER_BOOTSTRAP = (
+    "import runpy,sys;"
+    "runtime_root=sys.argv[1];verifier=sys.argv[2];"
+    "sys.path.insert(0,runtime_root);sys.argv=sys.argv[2:];"
+    "runpy.run_path(verifier,run_name='__main__')"
+)
+_VERIFICATION_SESSION_LABEL = "io.gdpval.agentic-v2.verification-session"
+_SESSION_ID = re.compile(r"[0-9a-f]{32}")
+_CONTAINER_ID = re.compile(r"[0-9a-f]{64}")
 
 
-def build_candidate(output_root: Path) -> dict:
+class VerificationLifecycleError(RuntimeError):
+    def __init__(self, message: str, failures: list[BaseException]):
+        self.failures = tuple(failures)
+        super().__init__(
+            f"{message}: "
+            + "; ".join(
+                f"{type(item).__name__}: {item}" for item in self.failures
+            )
+        )
+
+
+def build_candidate(output_root: Path, *, source_revision: str) -> dict:
     _require_no_credentials()
-    _require_tools()
+    license_evaluator_runtime_identity()
+    if _SOURCE_SHA.fullmatch(source_revision) is None:
+        raise RuntimeError("source revision is invalid")
     output_root = output_root.resolve()
     output_root.parent.mkdir(parents=True, exist_ok=True)
     if output_root.exists() or output_root.is_symlink():
@@ -65,11 +516,11 @@ def build_candidate(output_root: Path) -> dict:
     lock_path = Path("/tmp/.gdpval-agentic-v2-phase1b-build.lock")
     with _open_build_lock(lock_path) as lock_stream:
         fcntl.flock(lock_stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        source_revision = _git("rev-parse", "HEAD")
-        if _SOURCE_SHA.fullmatch(source_revision) is None:
-            raise RuntimeError("source revision is invalid")
+        if _git("rev-parse", "HEAD") != source_revision:
+            raise RuntimeError("candidate builder HEAD moved after source staging")
         if _git("status", "--porcelain"):
             raise RuntimeError("candidate build requires a clean source tree")
+        _require_tools()
         parent_lock = _load_parent_lock_from_git(source_revision)
         if _git_blob_sha256(source_revision, "batch-runner/sandbox/Dockerfile") != (
             parent_lock["v1_dockerfile_sha256"]
@@ -79,7 +530,7 @@ def build_candidate(output_root: Path) -> dict:
             _git_blob(source_revision, "batch-runner/sandbox/agentic_v2_capabilities.json")
         ))
         parent_inspect = _docker_json([
-            "docker", "image", "inspect", parent_lock["reference"]
+            _TRUSTED_DOCKER, "image", "inspect", parent_lock["reference"]
         ])
         if (
             not isinstance(parent_inspect, list)
@@ -118,7 +569,7 @@ def _build_locked(
         docker_config = Path(config_temporary)
         (docker_config / "config.json").write_text("{}\n", encoding="utf-8")
         build_command = [
-            "docker", "build", "--pull=false", "--network=default",
+            _TRUSTED_DOCKER, "build", "--pull=false", "--network=default",
             "--build-arg", f"BASE_IMAGE={parent_lock['reference']}",
             "--build-arg", f"SOURCE_REVISION={source_revision}",
             "--build-arg", f"CAPABILITY_MANIFEST_SHA256={manifest.sha256}",
@@ -132,12 +583,13 @@ def _build_locked(
             env=_docker_environment(docker_config),
             check=True,
         )
-    image_id = _docker_json(["docker", "image", "inspect", image])[0]["Id"]
+    image_id = _docker_json([_TRUSTED_DOCKER, "image", "inspect", image])[0]["Id"]
     temporary = Path(tempfile.mkdtemp(prefix=".phase1b-output-", dir=output_root.parent))
     archive = temporary / "candidate.docker.tar"
     try:
         subprocess.run(
-            ["docker", "image", "save", "--output", str(archive), image_id],
+            [_TRUSTED_DOCKER, "image", "save", "--output", str(archive), image_id],
+            env=_docker_cli_environment(),
             stdin=subprocess.DEVNULL,
             check=True,
         )
@@ -150,6 +602,8 @@ def _build_locked(
             staged_batch_root = Path(verifier_temporary) / "batch-runner"
             _stage_git_files(source_revision, staged_batch_root, _VERIFIER_PATHS)
             verifier = staged_batch_root / "sandbox" / "v2" / "verify_candidate.py"
+            runtime_root = Path(verifier_temporary) / "license-runtime"
+            _stage_license_evaluator_runtime(runtime_root)
             docker_config = Path(config_temporary)
             (docker_config / "config.json").write_text("{}\n", encoding="utf-8")
             verifier_environment = _docker_environment(docker_config)
@@ -158,24 +612,20 @@ def _build_locked(
                 "PYTHONHASHSEED": "0",
                 "PYTHONNOUSERSITE": "1",
             })
-            completed = subprocess.run(
-                [
-                    sys.executable,
-                    "-I",
-                    str(verifier),
-                    "--image", image_id,
-                    "--source-revision", source_revision,
-                    "--repository-root", str(REPOSITORY_ROOT),
-                    "--oci-layout", str(temporary / "oci"),
-                    "--output-directory", str(temporary / "evidence"),
-                ],
+            verification_session = uuid.uuid4().hex
+            completed = _run_verifier(
+                _verifier_command(
+                    runtime_root=runtime_root,
+                    verifier=verifier,
+                    image_id=image_id,
+                    source_revision=source_revision,
+                    oci_layout=temporary / "oci",
+                    output_directory=temporary / "evidence",
+                    session_id=verification_session,
+                ),
                 cwd=staged_batch_root,
-                env=verifier_environment,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                timeout=1800,
-                check=False,
+                environment=verifier_environment,
+                session_id=verification_session,
             )
         if completed.returncode != 0:
             raise RuntimeError(
@@ -208,11 +658,11 @@ def _build_locked(
 
 
 def _require_tools() -> None:
-    for name in ("docker", "git"):
-        if shutil.which(name) is None:
-            raise RuntimeError(f"required local tool is missing: {name}")
+    _require_trusted_executable(_TRUSTED_GIT)
+    _require_trusted_executable(_TRUSTED_DOCKER)
     subprocess.run(
-        ["docker", "info"],
+        [_TRUSTED_DOCKER, "info"],
+        env=_docker_cli_environment(),
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -220,7 +670,8 @@ def _require_tools() -> None:
         check=True,
     )
     endpoint = subprocess.run(
-        ["docker", "context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"],
+        [_TRUSTED_DOCKER, "context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"],
+        env=_docker_cli_environment(),
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -254,19 +705,23 @@ def _load_parent_lock_from_git(source_revision: str) -> dict:
         or value.get("reference") != (
             "ghcr.io/hyeonsangjeon/gdpval-sandbox@" + str(value.get("manifest_digest"))
         )
-        or _DIGEST.fullmatch(str(value.get("manifest_digest", ""))) is None
-        or _DIGEST.fullmatch(str(value.get("observed_local_image_id", ""))) is None
+        or not isinstance(value.get("manifest_digest"), str)
+        or _DIGEST.fullmatch(value["manifest_digest"]) is None
+        or not isinstance(value.get("observed_local_image_id"), str)
+        or _DIGEST.fullmatch(value["observed_local_image_id"]) is None
         or value.get("platform") != "linux/amd64"
-        or _SOURCE_SHA.fullmatch(str(value.get("source_revision", ""))) is None
+        or not isinstance(value.get("source_revision"), str)
+        or _SOURCE_SHA.fullmatch(value["source_revision"]) is None
     ):
         raise RuntimeError("candidate parent lock is invalid")
     return value
 
 
 def _git(*arguments: str) -> str:
+    _require_trusted_executable(_TRUSTED_GIT)
     return subprocess.run(
         [
-            "git", "--no-replace-objects",
+            _TRUSTED_GIT, "--no-replace-objects",
             "-c", "core.fsmonitor=false",
             "-c", "core.hooksPath=/dev/null",
             "-C", str(REPOSITORY_ROOT), *arguments,
@@ -284,6 +739,7 @@ def _git(*arguments: str) -> str:
 def _docker_json(command: list[str]):
     return json.loads(subprocess.run(
         command,
+        env=_docker_cli_environment(),
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -308,10 +764,260 @@ def _stage_git_files(
         destination.write_bytes(_git_blob(source_revision, repository_path))
 
 
+def _stage_license_evaluator_runtime(root: Path) -> dict[str, str]:
+    identity = license_evaluator_runtime_identity()
+    package_root = Path(str(packaging.__file__)).parent
+    graph = []
+    for relative_path in _LICENSE_RUNTIME_PATHS:
+        source = package_root.parent / relative_path
+        descriptor = os.open(
+            source,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        )
+        try:
+            before = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or before.st_nlink != 1
+                or before.st_size > 1024 * 1024
+            ):
+                raise RuntimeError("license evaluator runtime source is invalid")
+            chunks = []
+            while True:
+                chunk = os.read(descriptor, 64 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+        finally:
+            os.close(descriptor)
+        value = b"".join(chunks)
+        def file_identity(metadata):
+            return (
+                metadata.st_dev,
+                metadata.st_ino,
+                metadata.st_mode,
+                metadata.st_nlink,
+                metadata.st_size,
+                metadata.st_mtime_ns,
+            )
+        if file_identity(before) != file_identity(after) or len(value) != before.st_size:
+            raise RuntimeError("license evaluator runtime source changed while reading")
+        graph.append({
+            "path": relative_path,
+            "sha256": hashlib.sha256(value).hexdigest(),
+            "size": len(value),
+        })
+        destination = root / relative_path
+        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        destination.write_bytes(value)
+    if _canonical_sha256(graph) != LICENSE_EVALUATOR_RUNTIME_GRAPH_SHA256:
+        raise RuntimeError("license evaluator runtime graph differs")
+    return identity
+
+
+def _verifier_command(
+    *,
+    runtime_root: Path,
+    verifier: Path,
+    image_id: str,
+    source_revision: str,
+    oci_layout: Path,
+    output_directory: Path,
+    session_id: str,
+) -> list[str]:
+    return [
+        sys.executable,
+        "-I",
+        "-S",
+        "-B",
+        "-c",
+        _VERIFIER_BOOTSTRAP,
+        str(runtime_root),
+        str(verifier),
+        "--image", image_id,
+        "--source-revision", source_revision,
+        "--repository-root", str(REPOSITORY_ROOT),
+        "--oci-layout", str(oci_layout),
+        "--output-directory", str(output_directory),
+        "--session-id", session_id,
+    ]
+
+
+def _run_verifier(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    session_id: str,
+) -> subprocess.CompletedProcess:
+    if _SESSION_ID.fullmatch(session_id) is None:
+        raise ValueError("candidate verification session identity is invalid")
+    process = None
+    result = None
+    failures = []
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        stdout, stderr = process.communicate(
+            timeout=AGENTIC_V2_VERIFIER_TIMEOUT_SECONDS
+        )
+        result = subprocess.CompletedProcess(
+            command,
+            process.returncode,
+            stdout,
+            stderr,
+        )
+    except BaseException as exc:
+        failures.append(exc)
+    finally:
+        if process is not None:
+            try:
+                _terminate_verifier_process_group(process)
+            except BaseException as exc:
+                failures.append(exc)
+        try:
+            _cleanup_verification_session(session_id)
+        except BaseException as exc:
+            failures.append(exc)
+    if failures:
+        if len(failures) == 1:
+            raise failures[0]
+        raise VerificationLifecycleError(
+            "candidate verifier lifecycle failed",
+            failures,
+        )
+    if result is None:
+        raise RuntimeError("candidate verifier produced no result")
+    return result
+
+
+def _terminate_verifier_process_group(process: subprocess.Popen) -> None:
+    failures = []
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    except BaseException as exc:
+        failures.append(exc)
+    if process.poll() is None:
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
+        except BaseException as exc:
+            failures.append(exc)
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    except BaseException as exc:
+        failures.append(exc)
+    if process.poll() is None:
+        try:
+            process.wait(timeout=10)
+        except BaseException as exc:
+            failures.append(exc)
+    if failures:
+        raise VerificationLifecycleError(
+            "candidate verifier process-group termination failed",
+            failures,
+        )
+
+
+def _verification_session_containers(session_id: str) -> list[str]:
+    if _SESSION_ID.fullmatch(session_id) is None:
+        raise ValueError("candidate verification session identity is invalid")
+    completed = subprocess.run(
+        [
+            _TRUSTED_DOCKER,
+            "container",
+            "ls",
+            "--all",
+            "--quiet",
+            "--no-trunc",
+            "--filter",
+            f"label={_VERIFICATION_SESSION_LABEL}={session_id}",
+        ],
+        env=_docker_cli_environment(),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=AGENTIC_V2_VERIFICATION_SESSION_INVENTORY_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if (
+        completed.returncode != 0
+        or completed.stderr
+        or len(completed.stdout) > 64 * 1024
+    ):
+        raise RuntimeError("candidate verification session inventory failed")
+    identifiers = completed.stdout.decode("ascii", errors="strict").splitlines()
+    if (
+        len(identifiers) > AGENTIC_V2_VERIFICATION_SESSION_MAX_CONTAINERS
+        or len(identifiers) != len(set(identifiers))
+        or any(_CONTAINER_ID.fullmatch(item) is None for item in identifiers)
+    ):
+        raise RuntimeError("candidate verification session inventory is invalid")
+    return identifiers
+
+
+def _cleanup_verification_session(session_id: str) -> None:
+    failures = []
+    for _attempt in range(AGENTIC_V2_VERIFICATION_SESSION_SWEEP_LIMIT):
+        try:
+            identifiers = _verification_session_containers(session_id)
+        except BaseException as exc:
+            failures.append(exc)
+            continue
+        if not identifiers:
+            continue
+        for identifier in identifiers:
+            try:
+                completed = subprocess.run(
+                    [_TRUSTED_DOCKER, "container", "rm", "--force", identifier],
+                    env=_docker_cli_environment(),
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    timeout=AGENTIC_V2_VERIFICATION_SESSION_REMOVE_TIMEOUT_SECONDS,
+                    check=False,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                failures.append(exc)
+                continue
+            if (
+                completed.returncode != 0
+                or len(completed.stdout) > 4096
+                or len(completed.stderr) > 64 * 1024
+            ):
+                failures.append(RuntimeError(
+                    "candidate verification session container removal failed"
+                ))
+    try:
+        remaining = _verification_session_containers(session_id)
+    except BaseException as exc:
+        failures.append(exc)
+        remaining = ["inventory-unavailable"]
+    if failures or remaining:
+        raise VerificationLifecycleError(
+            "candidate verification session cleanup is incomplete",
+            failures or [RuntimeError("candidate verification containers remain")],
+        )
+
+
 def _git_blob(source_revision: str, repository_path: str) -> bytes:
+    _require_trusted_executable(_TRUSTED_GIT)
     return subprocess.run(
         [
-            "git", "--no-replace-objects",
+            _TRUSTED_GIT, "--no-replace-objects",
             "-c", "core.fsmonitor=false",
             "-c", "core.hooksPath=/dev/null",
             "-C", str(REPOSITORY_ROOT),
@@ -332,20 +1038,36 @@ def _git_blob_sha256(source_revision: str, repository_path: str) -> str:
 
 def _docker_environment(config_directory: Path) -> dict[str, str]:
     environment = {
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "PATH": _TRUSTED_PATH,
         "HOME": str(config_directory.parent),
         "DOCKER_CONFIG": str(config_directory),
         "LANG": "C.UTF-8",
         "LC_ALL": "C.UTF-8",
     }
     if os.getenv("DOCKER_HOST"):
+        if not os.environ["DOCKER_HOST"].startswith("unix://"):
+            raise RuntimeError("candidate build requires a local Unix Docker daemon")
+        environment["DOCKER_HOST"] = os.environ["DOCKER_HOST"]
+    return environment
+
+
+def _docker_cli_environment() -> dict[str, str]:
+    environment = {
+        "PATH": _TRUSTED_PATH,
+        "HOME": "/nonexistent",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+    }
+    if os.getenv("DOCKER_HOST"):
+        if not os.environ["DOCKER_HOST"].startswith("unix://"):
+            raise RuntimeError("candidate build requires a local Unix Docker daemon")
         environment["DOCKER_HOST"] = os.environ["DOCKER_HOST"]
     return environment
 
 
 def _git_environment() -> dict[str, str]:
     return {
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "PATH": _TRUSTED_PATH,
         "HOME": "/nonexistent",
         "LANG": "C.UTF-8",
         "LC_ALL": "C.UTF-8",
@@ -396,10 +1118,18 @@ def _canonical_sha256(value) -> str:
 
 
 def main() -> None:
+    if _BOOTSTRAPPED_RUNTIME_ROOT is None:
+        raise RuntimeError("candidate builder entrypoint was not isolated")
     parser = argparse.ArgumentParser()
     parser.add_argument("--output-root", required=True, type=Path)
     arguments = parser.parse_args()
-    report = build_candidate(arguments.output_root)
+    source_revision = os.environ.get(_SOURCE_REVISION_ENV)
+    if source_revision is None:
+        raise RuntimeError("candidate builder staged revision is missing")
+    report = build_candidate(
+        arguments.output_root,
+        source_revision=source_revision,
+    )
     print(json.dumps(report, sort_keys=True, separators=(",", ":")))
 
 

--- a/batch-runner/sandbox/v2/debian-extra.lock
+++ b/batch-runner/sandbox/v2/debian-extra.lock
@@ -1,4 +1,4 @@
-chromium=150.0.7871.181-1~deb12u1
+chromium=151.0.7922.71-1~deb12u1
 cmake=3.25.1-1
 fonts-noto-color-emoji=2.042-0+deb12u1
 fonts-noto-core=20201225-1

--- a/batch-runner/sandbox/v2/effective_sbom.py
+++ b/batch-runner/sandbox/v2/effective_sbom.py
@@ -5,9 +5,46 @@ from __future__ import annotations
 import hashlib
 import importlib.metadata
 import json
+import re
 import subprocess
 from pathlib import Path
 from urllib.parse import quote
+
+
+DEBIAN_STATUS_PATH = Path("/var/lib/dpkg/status")
+_DEBIAN_FIELD_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9-]*\Z", re.ASCII)
+MAX_DEBIAN_FIELD_CHARS = 1024 * 1024
+
+
+def _split_debian_stanzas(value: str) -> list[str]:
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n")
+    return re.split(r"\n[ \t]*\n+", normalized)
+
+
+def _debian_fields(stanza: str) -> dict[str, str]:
+    fields = {}
+    current = None
+    for line in stanza.splitlines():
+        if line[:1].isspace():
+            if current is None:
+                raise RuntimeError("Debian status metadata is malformed")
+            fields[current] += "\n" + line.strip()
+            if len(fields[current]) > MAX_DEBIAN_FIELD_CHARS:
+                raise RuntimeError("Debian status field is too large")
+            continue
+        if ":" not in line:
+            if line:
+                raise RuntimeError("Debian status metadata is malformed")
+            continue
+        key, value = line.split(":", 1)
+        normalized = key.casefold()
+        if _DEBIAN_FIELD_NAME.fullmatch(key) is None or normalized in fields:
+            raise RuntimeError("Debian status field is invalid")
+        fields[normalized] = value.strip()
+        if len(fields[normalized]) > MAX_DEBIAN_FIELD_CHARS:
+            raise RuntimeError("Debian status field is too large")
+        current = normalized
+    return fields
 
 
 def _spdx_id(ecosystem: str, name: str, version: str) -> str:
@@ -42,21 +79,19 @@ def _package(
 
 
 def _debian_packages() -> list[dict]:
-    status = Path("/var/lib/dpkg/status").read_text(
-        encoding="utf-8", errors="replace"
+    status = DEBIAN_STATUS_PATH.read_text(
+        encoding="utf-8", errors="strict"
     )
     packages = []
-    for stanza in status.split("\n\n"):
-        fields = {}
-        for line in stanza.splitlines():
-            if ": " in line:
-                key, value = line.split(": ", 1)
-                fields[key] = value
-        if fields.get("Status") != "install ok installed" or not fields.get("Package"):
+    for stanza in _split_debian_stanzas(status):
+        fields = _debian_fields(stanza)
+        if fields.get("status") != "install ok installed" or not fields.get("package"):
             continue
-        name = fields["Package"]
-        version = fields.get("Version", "NOASSERTION")
-        architecture = fields.get("Architecture", "amd64")
+        name = fields["package"]
+        version = fields.get("version")
+        architecture = fields.get("architecture")
+        if not version or not architecture:
+            raise RuntimeError(f"Debian package identity is incomplete: {name}")
         purl = (
             f"pkg:deb/debian/{quote(name, safe='')}@{quote(version, safe='')}"
             f"?arch={quote(architecture, safe='')}"

--- a/batch-runner/sandbox/v2/effective_sbom.py
+++ b/batch-runner/sandbox/v2/effective_sbom.py
@@ -6,14 +6,17 @@ import hashlib
 import importlib.metadata
 import json
 import re
-import subprocess
 from pathlib import Path
 from urllib.parse import quote
 
 
 DEBIAN_STATUS_PATH = Path("/var/lib/dpkg/status")
+R_LIBRARY_ROOT = Path("/usr/lib/R/library")
 _DEBIAN_FIELD_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9-]*\Z", re.ASCII)
+_R_FIELD_NAME = re.compile(r"[A-Za-z][A-Za-z0-9._-]*\Z", re.ASCII)
 MAX_DEBIAN_FIELD_CHARS = 1024 * 1024
+MAX_R_FIELD_CHARS = 1024 * 1024
+MAX_R_DESCRIPTION_BYTES = 64 * 1024 * 1024
 
 
 def _split_debian_stanzas(value: str) -> list[str]:
@@ -125,26 +128,69 @@ def _python_packages() -> list[dict]:
     return packages
 
 
+def _parse_r_dcf(value: bytes) -> dict[str, str]:
+    fields = {}
+    identities = set()
+    key = None
+    record_ended = False
+    for line in value.decode("utf-8", errors="strict").splitlines():
+        if not line:
+            record_ended = True
+            key = None
+            continue
+        if record_ended:
+            raise RuntimeError("R DESCRIPTION contains multiple records")
+        if line[:1].isspace() and key is not None:
+            fields[key] += "\n" + line.strip()
+            if len(fields[key]) > MAX_R_FIELD_CHARS:
+                raise RuntimeError("R DESCRIPTION field is too large")
+        elif line[:1].isspace():
+            raise RuntimeError("R DESCRIPTION metadata is malformed")
+        elif ":" in line:
+            raw_key, raw_value = line.split(":", 1)
+            if _R_FIELD_NAME.fullmatch(raw_key) is None:
+                raise RuntimeError("R DESCRIPTION field name is malformed")
+            identity = raw_key.casefold()
+            if identity in identities:
+                raise RuntimeError("R DESCRIPTION field is duplicated")
+            identities.add(identity)
+            key = identity
+            fields[key] = raw_value.strip()
+            if len(fields[key]) > MAX_R_FIELD_CHARS:
+                raise RuntimeError("R DESCRIPTION field is too large")
+        else:
+            raise RuntimeError("R DESCRIPTION metadata is malformed")
+    return fields
+
+
 def _r_packages() -> list[dict]:
-    expression = (
-        "p<-installed.packages();"
-        "cat(apply(p[,c('Package','Version','License'),drop=FALSE],1,"
-        "function(x) paste(x,collapse='\\t')),sep='\\n')"
-    )
-    completed = subprocess.run(
-        ["Rscript", "--vanilla", "-e", expression],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        timeout=60,
-        check=True,
-    )
+    library_root = R_LIBRARY_ROOT
+    if not library_root.is_dir() or library_root.is_symlink():
+        raise RuntimeError("R library root is missing")
     packages = []
-    for line in completed.stdout.decode("utf-8").splitlines():
-        parts = line.split("\t", 2)
-        if len(parts) != 3:
-            raise RuntimeError("R package inventory is malformed")
-        name, version, license_value = parts
+    for package_root in sorted(library_root.iterdir(), key=lambda value: value.name):
+        if package_root.is_symlink():
+            raise RuntimeError("R package root is symlinked")
+        description_path = package_root / "DESCRIPTION"
+        if not description_path.exists():
+            continue
+        if not description_path.is_file() or description_path.is_symlink():
+            raise RuntimeError("R DESCRIPTION is not a regular file")
+        metadata = description_path.stat()
+        if metadata.st_size < 0 or metadata.st_size > MAX_R_DESCRIPTION_BYTES:
+            raise RuntimeError("R DESCRIPTION file is too large")
+        description_bytes = description_path.read_bytes()
+        if len(description_bytes) != metadata.st_size:
+            raise RuntimeError("R DESCRIPTION changed while reading")
+        fields = _parse_r_dcf(description_bytes)
+        name = fields.get("package")
+        version = fields.get("version")
+        license_value = fields.get("license")
+        if not all(
+            isinstance(item, str) and item
+            for item in (name, version, license_value)
+        ):
+            raise RuntimeError("R package inventory is incomplete")
         packages.append(_package(
             "cran",
             name,

--- a/batch-runner/sandbox/v2/effective_sbom.py
+++ b/batch-runner/sandbox/v2/effective_sbom.py
@@ -163,11 +163,11 @@ def _parse_r_dcf(value: bytes) -> dict[str, str]:
     return fields
 
 
-def _r_packages() -> list[dict]:
+def r_inventory_records() -> list[dict[str, str]]:
     library_root = R_LIBRARY_ROOT
     if not library_root.is_dir() or library_root.is_symlink():
         raise RuntimeError("R library root is missing")
-    packages = []
+    records = []
     for package_root in sorted(library_root.iterdir(), key=lambda value: value.name):
         if package_root.is_symlink():
             raise RuntimeError("R package root is symlinked")
@@ -191,14 +191,29 @@ def _r_packages() -> list[dict]:
             for item in (name, version, license_value)
         ):
             raise RuntimeError("R package inventory is incomplete")
-        packages.append(_package(
+        records.append({
+            "name": name,
+            "version": version,
+            "license": license_value,
+        })
+    identities = [(item["name"].casefold(), item["version"]) for item in records]
+    if len(identities) != len(set(identities)):
+        raise RuntimeError("R package inventory is duplicated")
+    return records
+
+
+def _r_packages() -> list[dict]:
+    return [
+        _package(
             "cran",
-            name,
-            version,
-            license_value or "NOASSERTION",
-            f"pkg:cran/{quote(name, safe='')}@{quote(version, safe='')}",
-        ))
-    return packages
+            item["name"],
+            item["version"],
+            item["license"],
+            f"pkg:cran/{quote(item['name'], safe='')}@"
+            f"{quote(item['version'], safe='')}",
+        )
+        for item in r_inventory_records()
+    ]
 
 
 def _npm_packages() -> list[dict]:

--- a/batch-runner/sandbox/v2/image_probe.py
+++ b/batch-runner/sandbox/v2/image_probe.py
@@ -49,6 +49,9 @@ def _run(
     cwd: Path,
     timeout: int = COMMAND_TIMEOUT_SECONDS,
 ) -> subprocess.CompletedProcess:
+    command = list(argv)
+    if Path(command[0]).name in {"python", "python3", "python3.11"}:
+        command[1:1] = ["-I", "-S", "-B"]
     environment = {
         "HOME": str(cwd / ".home"),
         "TMPDIR": str(cwd / ".tmp"),
@@ -62,7 +65,7 @@ def _run(
     for name in (".home", ".tmp", ".cache", ".config"):
         (cwd / name).mkdir(mode=0o700, parents=True, exist_ok=True)
     completed = subprocess.run(
-        argv,
+        command,
         cwd=cwd,
         env=environment,
         stdin=subprocess.DEVNULL,

--- a/batch-runner/sandbox/v2/image_probe.py
+++ b/batch-runner/sandbox/v2/image_probe.py
@@ -7,8 +7,11 @@ import importlib.metadata
 import importlib.util
 import json
 import os
+import re
 import shutil
+import stat
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Callable
@@ -17,6 +20,7 @@ from typing import Callable
 MANIFEST_PATH = Path("/opt/gdpval/v2/capabilities.json")
 MAX_OUTPUT_BYTES = 65536
 COMMAND_TIMEOUT_SECONDS = 45
+_HEX_SHA256 = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
 
 
 def _canonical_sha256(value) -> str:
@@ -165,7 +169,66 @@ def _font_observation(name: str, work: Path) -> dict:
     }
 
 
-def _inventory(work: Path) -> dict:
+def _effective_sbom_namespace(expected_sha256: str) -> dict:
+    if _HEX_SHA256.fullmatch(expected_sha256) is None:
+        raise RuntimeError("effective SBOM inventory digest is invalid")
+    path = Path(__file__).with_name("effective_sbom.py")
+    required_flags = ("O_NOFOLLOW", "O_CLOEXEC")
+    if any(not isinstance(getattr(os, name, None), int) for name in required_flags):
+        raise RuntimeError("secure Unix open flags are required for image inventory")
+    descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC)
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size < 0
+            or before.st_size > 1024 * 1024
+        ):
+            raise RuntimeError("effective SBOM inventory module is invalid")
+        chunks = []
+        while True:
+            chunk = os.read(descriptor, 64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    source = b"".join(chunks)
+    def identity(value):
+        return (
+            value.st_dev, value.st_ino, value.st_mode, value.st_nlink,
+            value.st_size, value.st_mtime_ns,
+        )
+
+    if identity(before) != identity(after) or len(source) != before.st_size:
+        raise RuntimeError("effective SBOM inventory module changed while reading")
+    if hashlib.sha256(source).hexdigest() != expected_sha256:
+        raise RuntimeError("effective SBOM inventory module digest differs")
+    namespace = {
+        "__builtins__": __builtins__,
+        "__file__": str(path),
+        "__name__": "_gdpval_agentic_v2_effective_sbom",
+        "__package__": None,
+    }
+    exec(compile(source, "effective_sbom.py", "exec"), namespace)
+    if not callable(namespace.get("r_inventory_records")):
+        raise RuntimeError("effective SBOM R inventory is unavailable")
+    return namespace
+
+
+def _r_inventory_records(expected_sbom_sha256: str) -> list[str]:
+    records = _effective_sbom_namespace(expected_sbom_sha256)[
+        "r_inventory_records"
+    ]()
+    values = sorted(f"{item['name']}={item['version']}" for item in records)
+    if len(values) != len(set(values)):
+        raise RuntimeError("R package observation is duplicated")
+    return values
+
+
+def _inventory(work: Path, expected_sbom_sha256: str) -> dict:
     debian = _run(
         ["dpkg-query", "-W", "-f=${Package}:${Architecture}=${Version}\\n"], cwd=work
     ).stdout.decode("utf-8").splitlines()
@@ -173,13 +236,7 @@ def _inventory(work: Path) -> dict:
         f"{distribution.metadata.get('Name') or distribution.name}={distribution.version}"
         for distribution in importlib.metadata.distributions()
     })
-    r_output = _run([
-        "Rscript",
-        "--vanilla",
-        "-e",
-        "p<-installed.packages();cat(paste(p[,1],p[,3],sep='=',collapse='\\n'))",
-    ], cwd=work).stdout.decode("utf-8")
-    r_packages = sorted(filter(None, r_output.splitlines()))
+    r_packages = _r_inventory_records(expected_sbom_sha256)
     npm_output = _run(["npm", "--version"], cwd=work).stdout.decode("utf-8").strip()
     records = {
         "debian": sorted(debian),
@@ -452,7 +509,7 @@ SMOKES: dict[str, Callable[[Path], str]] = {
 }
 
 
-def collect() -> dict:
+def collect(expected_sbom_sha256: str) -> dict:
     if os.geteuid() != 65532 or os.getegid() != 65532:
         raise RuntimeError("Phase 1B probe must run as UID/GID 65532")
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
@@ -480,7 +537,7 @@ def collect() -> dict:
                 "status": "pass",
                 "artifact_sha256": SMOKES[item["id"]](smoke_root),
             })
-        inventory = _inventory(root)
+        inventory = _inventory(root, expected_sbom_sha256)
     return {
         "schema_version": "1.0",
         "substrate_id": "professional-work-v1",
@@ -494,7 +551,9 @@ def collect() -> dict:
 
 
 def main() -> None:
-    print(json.dumps(collect(), sort_keys=True, separators=(",", ":")))
+    if len(sys.argv) != 2:
+        raise RuntimeError("effective SBOM inventory digest argument is required")
+    print(json.dumps(collect(sys.argv[1]), sort_keys=True, separators=(",", ":")))
 
 
 if __name__ == "__main__":

--- a/batch-runner/sandbox/v2/license_evidence.py
+++ b/batch-runner/sandbox/v2/license_evidence.py
@@ -1,0 +1,655 @@
+"""Collect deterministic package-license evidence from the candidate image."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+from email.parser import BytesParser
+from email.policy import compat32
+import json
+import os
+import re
+import stat
+import sysconfig
+from pathlib import Path
+from urllib.parse import quote
+
+
+MAX_EVIDENCE_FILE_BYTES = 64 * 1024 * 1024
+PYTHON_PURELIB_PATH = "/usr/local/lib/python3.11/site-packages"
+DEBIAN_STATUS_PATH = Path("/var/lib/dpkg/status")
+DEBIAN_DOCUMENTATION_ROOT = Path("/usr/share/doc")
+R_LIBRARY_ROOT = Path("/usr/lib/R/library")
+R_RUNTIME_COPYRIGHT_PATH = Path("/usr/share/doc/r-base-core/copyright")
+R_SHARED_LICENSE_ROOT = Path("/usr/share/R/share/licenses")
+NPM_PACKAGE_PATH = Path("/usr/share/nodejs/npm/package.json")
+DEP5_FORMAT_URI = (
+    "https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/"
+)
+_DEBIAN_FIELD_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9-]*\Z", re.ASCII)
+_DEBIAN_COPYRIGHT_FIELD_LIKE = re.compile(
+    r"^\s*(?:Format|Upstream-Name|Upstream-Contact|Source|Disclaimer|Comment|"
+    r"License|Copyright|Files|Files-Excluded(?:-[A-Za-z0-9.+-]+)?)\s*:",
+    re.IGNORECASE | re.ASCII,
+)
+_R_FIELD_NAME = re.compile(r"[A-Za-z][A-Za-z0-9._-]*\Z", re.ASCII)
+_R_LICENSE_REFERENCE = re.compile(
+    r"file ([A-Za-z0-9][A-Za-z0-9._+-]*)\Z", re.ASCII
+)
+_NPM_LICENSE_REFERENCE = re.compile(
+    r"SEE LICENSE IN ([A-Za-z0-9][A-Za-z0-9._+-]*)\Z", re.ASCII
+)
+_LICENSE_FILE_TOKEN = re.compile(
+    rb"(?<![A-Za-z0-9.+-])"
+    rb"([A-Za-z0-9](?:[A-Za-z0-9.+-]{0,126}[A-Za-z0-9+])?)"
+    rb"(?![A-Za-z0-9+-])"
+)
+_LICENSE_FILE_TOKEN_TEXT = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9.+-]{0,126}[A-Za-z0-9+])?\Z",
+    re.ASCII,
+)
+MAX_LICENSE_FILE_TOKENS = 4096
+MAX_DEBIAN_FIELD_CHARS = 1024 * 1024
+
+
+class _UnavailableEvidencePath(RuntimeError):
+    def __init__(self, path: Path, error_number: int):
+        super().__init__(f"license evidence path is not symlink-free: {path}")
+        self.error_number = error_number
+
+
+def _split_debian_stanzas(value: str) -> list[str]:
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n")
+    return re.split(r"\n[ \t]*\n+", normalized)
+
+
+def _canonical_json(value) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _canonical_sha256(value) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _read_regular_file(
+    source: str,
+    path: Path,
+    *,
+    allowed_roots: tuple[Path, ...],
+) -> tuple[dict, bytes]:
+    lexical = Path(path)
+    roots = [Path(root) for root in allowed_roots]
+    if (
+        not lexical.is_absolute()
+        or ".." in lexical.parts
+        or any(not root.is_absolute() or ".." in root.parts for root in roots)
+    ):
+        raise RuntimeError(f"license evidence path is not absolute: {lexical}")
+    if not any(root in (lexical, *lexical.parents) for root in roots):
+        raise RuntimeError(f"license evidence escapes allowlisted root: {lexical}")
+    required_flags = ("O_NOFOLLOW", "O_CLOEXEC", "O_NONBLOCK", "O_DIRECTORY")
+    if any(not isinstance(getattr(os, name, None), int) for name in required_flags):
+        raise RuntimeError("secure Unix open flags are required for license evidence")
+    directory_flags = (
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK
+    )
+    file_flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK
+    directory_descriptor = None
+    descriptor = None
+    try:
+        directory_descriptor = os.open("/", directory_flags)
+        for component in lexical.parts[1:-1]:
+            next_descriptor = os.open(
+                component,
+                directory_flags,
+                dir_fd=directory_descriptor,
+            )
+            os.close(directory_descriptor)
+            directory_descriptor = next_descriptor
+        descriptor = os.open(
+            lexical.name,
+            file_flags,
+            dir_fd=directory_descriptor,
+        )
+    except OSError as exc:
+        if exc.errno in {errno.ENOENT, errno.ELOOP, errno.ENOTDIR}:
+            raise _UnavailableEvidencePath(lexical, exc.errno) from exc
+        raise RuntimeError(f"license evidence path cannot be opened: {lexical}") from exc
+    finally:
+        if directory_descriptor is not None:
+            os.close(directory_descriptor)
+    if descriptor is None:
+        raise RuntimeError(f"license evidence path cannot be opened: {lexical}")
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size < 0
+            or before.st_size > MAX_EVIDENCE_FILE_BYTES
+        ):
+            raise RuntimeError(f"license evidence file is invalid: {lexical}")
+        chunks = []
+        total = 0
+        while True:
+            chunk = os.read(descriptor, min(1024 * 1024, MAX_EVIDENCE_FILE_BYTES + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > MAX_EVIDENCE_FILE_BYTES:
+                raise RuntimeError(f"license evidence file is too large: {lexical}")
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    def identity(value):
+        return (
+            value.st_dev, value.st_ino, value.st_mode, value.st_nlink,
+            value.st_size, value.st_mtime_ns,
+        )
+    if identity(before) != identity(after) or total != before.st_size:
+        raise RuntimeError(f"license evidence file changed while reading: {lexical}")
+    value = b"".join(chunks)
+    evidence = {
+        "source": source,
+        "path": str(lexical),
+        "resolved_path": str(lexical),
+        "sha256": hashlib.sha256(value).hexdigest(),
+        "size": total,
+    }
+    return evidence, value
+
+
+def _regular_file_evidence(
+    source: str,
+    path: Path,
+    *,
+    allowed_roots: tuple[Path, ...] | None = None,
+) -> dict:
+    evidence, _value = _read_regular_file(
+        source,
+        path,
+        allowed_roots=allowed_roots or (path.parent,),
+    )
+    return evidence
+
+
+def _virtual_evidence(source: str, value: dict) -> dict:
+    encoded = _canonical_json(value)
+    return {
+        "source": source,
+        "path": None,
+        "resolved_path": None,
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+        "size": len(encoded),
+    }
+
+
+def _license_file_tokens(value: bytes) -> list[str]:
+    tokens = sorted({
+        match.group(1).decode("ascii")
+        for match in _LICENSE_FILE_TOKEN.finditer(value)
+        if b"-" in match.group(1)
+    })
+    if len(tokens) > MAX_LICENSE_FILE_TOKENS:
+        raise RuntimeError("license evidence file has too many identifier tokens")
+    return tokens
+
+
+def _debian_fields(stanza: str, source: str) -> dict[str, str]:
+    fields = {}
+    current = None
+    for line in stanza.splitlines():
+        if line[:1].isspace():
+            if current is None:
+                raise RuntimeError(f"Debian {source} metadata is malformed")
+            fields[current] += "\n" + line.strip()
+            if len(fields[current]) > MAX_DEBIAN_FIELD_CHARS:
+                raise RuntimeError(f"Debian {source} field is too large")
+            continue
+        if ":" not in line:
+            if line:
+                raise RuntimeError(f"Debian {source} metadata is malformed")
+            continue
+        key, value = line.split(":", 1)
+        normalized = key.casefold()
+        if _DEBIAN_FIELD_NAME.fullmatch(key) is None:
+            raise RuntimeError(f"Debian {source} field name is malformed")
+        if normalized in fields:
+            raise RuntimeError(f"Debian {source} field is duplicated")
+        fields[normalized] = value.strip()
+        if len(fields[normalized]) > MAX_DEBIAN_FIELD_CHARS:
+            raise RuntimeError(f"Debian {source} field is too large")
+        current = normalized
+    return fields
+
+
+def _debian_license_values(value: bytes, source: str) -> list[str]:
+    text = value.decode("utf-8", errors="strict")
+    return sorted({
+        fields["license"]
+        for stanza in _split_debian_stanzas(text)
+        for fields in [_debian_fields(stanza, source)]
+        if fields.get("license")
+    })
+
+
+def _debian_copyright_metadata(value: bytes) -> tuple[str | None, list[str]]:
+    text = value.decode("utf-8", errors="strict")
+    if not any(
+        _DEBIAN_COPYRIGHT_FIELD_LIKE.match(line)
+        for line in text.splitlines()
+    ):
+        return None, []
+    stanzas = _split_debian_stanzas(text)
+    first_fields = _debian_fields(stanzas[0], "copyright")
+    format_value = first_fields.get("format")
+    if format_value != DEP5_FORMAT_URI:
+        raise RuntimeError("Debian copyright DEP-5 Format header is invalid")
+    license_fields = []
+    for index, stanza in enumerate(stanzas):
+        fields = _debian_fields(stanza, "copyright")
+        if "format" in fields:
+            if index != 0 or fields["format"] != format_value:
+                raise RuntimeError("Debian copyright Format field is duplicated")
+        if fields.get("license"):
+            license_fields.append(fields["license"])
+    return format_value, sorted(set(license_fields))
+
+
+def _debian_records() -> list[dict]:
+    status_path = DEBIAN_STATUS_PATH
+    status_evidence, status_bytes = _read_regular_file(
+        "debian-status", status_path, allowed_roots=(status_path.parent,)
+    )
+    status = status_bytes.decode("utf-8", errors="strict")
+    records = []
+    for stanza in _split_debian_stanzas(status):
+        fields = _debian_fields(stanza, "status")
+        if fields.get("status") != "install ok installed" or not fields.get("package"):
+            continue
+        name = fields["package"]
+        version = fields.get("version")
+        architecture = fields.get("architecture")
+        if not version or not architecture:
+            raise RuntimeError(f"Debian package identity is incomplete: {name}")
+        copyright_path = DEBIAN_DOCUMENTATION_ROOT / name / "copyright"
+        evidence = []
+        license_fields = []
+        format_value = None
+        try:
+            copyright_evidence, copyright_bytes = _read_regular_file(
+                "debian-copyright",
+                copyright_path,
+                allowed_roots=(DEBIAN_DOCUMENTATION_ROOT,),
+            )
+        except _UnavailableEvidencePath as exc:
+            if exc.error_number != errno.ENOENT:
+                raise
+        else:
+            evidence.append(copyright_evidence)
+            format_value, license_fields = _debian_copyright_metadata(
+                copyright_bytes
+            )
+        records.append({
+            "ecosystem": "debian",
+            "package": name,
+            "version": version,
+            "purl": (
+                f"pkg:deb/debian/{quote(name, safe='')}@{quote(version, safe='')}"
+                f"?arch={quote(architecture, safe='')}"
+            ),
+            "raw_values": license_fields,
+            "metadata": {
+                "architecture": architecture,
+                "copyright_format": format_value,
+            },
+            "evidence": evidence,
+        })
+        records[-1]["evidence"].insert(0, status_evidence)
+    return records
+
+
+def _python_license_files(
+    distribution_root: Path,
+    declared_files: list[str],
+    site_root: Path,
+) -> tuple[list[dict], list[str], list[dict]]:
+    if (
+        not distribution_root.is_absolute()
+        or ".." in distribution_root.parts
+        or site_root not in (distribution_root, *distribution_root.parents)
+    ):
+        raise RuntimeError("Python distribution metadata root is invalid")
+    records = []
+    tokens = set()
+    selections = []
+    seen = set()
+    for raw_path in declared_files:
+        if not isinstance(raw_path, str) or not raw_path or Path(raw_path).is_absolute():
+            raise RuntimeError("Python License-File metadata is invalid")
+        for candidate in (
+            distribution_root / "licenses" / raw_path,
+            distribution_root / raw_path,
+        ):
+            if ".." in candidate.parts:
+                raise RuntimeError("Python license evidence escapes distribution metadata")
+            if str(candidate) in seen:
+                continue
+            try:
+                evidence, file_bytes = _read_regular_file(
+                    "python-license-file", candidate, allowed_roots=(distribution_root,)
+                )
+            except _UnavailableEvidencePath as exc:
+                if exc.error_number == errno.ENOENT:
+                    continue
+                raise
+            seen.add(str(candidate))
+            records.append(evidence)
+            tokens.update(_license_file_tokens(file_bytes))
+            selections.append({
+                "declared": raw_path,
+                "path": str(candidate),
+            })
+            break
+        else:
+            raise RuntimeError(f"Python License-File is missing: {raw_path}")
+    return (
+        sorted(records, key=lambda item: (item["path"], item["sha256"])),
+        sorted(tokens),
+        sorted(selections, key=lambda item: (item["declared"], item["path"])),
+    )
+
+
+def _python_records() -> list[dict]:
+    records = []
+    seen = set()
+    if sysconfig.get_path("purelib") != PYTHON_PURELIB_PATH:
+        raise RuntimeError("Python purelib root differs from candidate contract")
+    site_root = Path(PYTHON_PURELIB_PATH)
+    if not site_root.is_dir() or site_root.is_symlink():
+        raise RuntimeError("Python site-packages root is missing")
+    metadata_paths = []
+    for child in sorted(site_root.iterdir(), key=lambda value: value.name):
+        if child.name.endswith(".dist-info"):
+            metadata_paths.append(child / "METADATA")
+        elif child.name.endswith(".egg-info"):
+            metadata_paths.append(child / "PKG-INFO")
+    for metadata_path in metadata_paths:
+        metadata_evidence, metadata_bytes = _read_regular_file(
+            "python-metadata", metadata_path, allowed_roots=(site_root,)
+        )
+        metadata_bytes.decode("utf-8", errors="strict")
+        metadata = BytesParser(policy=compat32).parsebytes(metadata_bytes, headersonly=True)
+        if metadata.defects or any(
+            _DEBIAN_FIELD_NAME.fullmatch(key) is None for key in metadata.keys()
+        ):
+            raise RuntimeError(f"Python package metadata is malformed: {metadata_path}")
+        names = metadata.get_all("Name", [])
+        versions = metadata.get_all("Version", [])
+        licenses = metadata.get_all("License", [])
+        expressions = metadata.get_all("License-Expression", [])
+        if (
+            len(names) != 1
+            or len(versions) != 1
+            or len(licenses) > 1
+            or len(expressions) > 1
+        ):
+            raise RuntimeError(f"Python single-use metadata is duplicated: {metadata_path}")
+        name = names[0].strip()
+        version = versions[0].strip()
+        if not name or not version:
+            raise RuntimeError(f"Python package identity is missing: {metadata_path}")
+        identity = (name.lower(), version)
+        if identity in seen:
+            raise RuntimeError(f"Python distribution identity is duplicated: {name}=={version}")
+        seen.add(identity)
+        license_expression = expressions[0] if expressions else None
+        license_value = licenses[0] if licenses else None
+        classifiers = sorted({
+            value
+            for value in metadata.get_all("Classifier", [])
+            if value.startswith("License ::")
+        })
+        declared_files = metadata.get_all("License-File", [])
+        raw_values = []
+        if isinstance(license_expression, str) and license_expression.strip():
+            raw_values.append(license_expression.strip())
+        if isinstance(license_value, str) and license_value.strip():
+            raw_values.append(license_value.strip())
+        raw_values.extend(classifiers)
+        evidence = [metadata_evidence]
+        license_evidence, license_file_tokens, license_file_selections = (
+            _python_license_files(
+            metadata_path.parent, declared_files, site_root
+            )
+        )
+        evidence.extend(license_evidence)
+        raw_values.extend(license_file_tokens)
+        records.append({
+            "ecosystem": "python",
+            "package": name,
+            "version": version,
+            "purl": f"pkg:pypi/{quote(name, safe='')}@{quote(version, safe='')}",
+            "raw_values": raw_values,
+            "metadata": {
+                "license_expression": license_expression,
+                "license": license_value,
+                "classifiers": classifiers,
+                "license_file_tokens": license_file_tokens,
+                "license_files": license_file_selections,
+            },
+            "evidence": evidence,
+        })
+    return records
+
+
+def _parse_r_dcf(value: bytes) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    identities = set()
+    known_fields = {
+        "license": "License",
+        "package": "Package",
+        "priority": "Priority",
+        "version": "Version",
+    }
+    key = None
+    record_ended = False
+    for line in value.decode("utf-8", errors="strict").splitlines():
+        if not line:
+            record_ended = True
+            key = None
+            continue
+        if record_ended:
+            raise RuntimeError("R DESCRIPTION contains multiple records")
+        if line[:1].isspace() and key is not None:
+            fields[key] += "\n" + line.strip()
+        elif line[:1].isspace():
+            raise RuntimeError("R DESCRIPTION metadata is malformed")
+        elif ":" in line:
+            raw_key, raw = line.split(":", 1)
+            if _R_FIELD_NAME.fullmatch(raw_key) is None:
+                raise RuntimeError("R DESCRIPTION field name is malformed")
+            identity = raw_key.casefold()
+            if identity in identities:
+                raise RuntimeError("R DESCRIPTION field is duplicated")
+            identities.add(identity)
+            key = known_fields.get(identity, raw_key)
+            fields[key] = raw.strip()
+        elif line:
+            raise RuntimeError("R DESCRIPTION metadata is malformed")
+    return fields
+
+
+def _r_records() -> list[dict]:
+    library_root = R_LIBRARY_ROOT
+    if not library_root.is_dir():
+        raise RuntimeError("R library root is missing")
+
+    base_description_path = library_root / "base" / "DESCRIPTION"
+    base_evidence, base_bytes = _read_regular_file(
+        "r-runtime-description", base_description_path,
+        allowed_roots=(library_root,)
+    )
+    base_fields = _parse_r_dcf(base_bytes)
+    runtime_version = base_fields.get("Version")
+    if not runtime_version:
+        raise RuntimeError("R runtime version is missing")
+    runtime_license = ""
+    runtime_value = {"version": runtime_version, "license": runtime_license}
+    runtime_copyright = R_RUNTIME_COPYRIGHT_PATH
+    runtime_copyright_evidence, runtime_copyright_bytes = _read_regular_file(
+        "r-runtime-copyright",
+        runtime_copyright,
+        allowed_roots=(runtime_copyright.parent,),
+    )
+    runtime_copyright_format, runtime_license_fields = (
+        _debian_copyright_metadata(runtime_copyright_bytes)
+    )
+    shared = []
+    shared_root = R_SHARED_LICENSE_ROOT
+    if shared_root.is_dir():
+        for path in sorted(shared_root.iterdir(), key=lambda value: value.name):
+            if path.is_file():
+                shared.append(_regular_file_evidence(
+                    "r-shared-license", path, allowed_roots=(shared_root,)
+                ))
+    records = []
+    for package_root in sorted(library_root.iterdir(), key=lambda value: value.name):
+        description_path = package_root / "DESCRIPTION"
+        if not description_path.is_file():
+            continue
+        description_evidence, description_bytes = _read_regular_file(
+            "r-description", description_path, allowed_roots=(library_root,)
+        )
+        fields = _parse_r_dcf(description_bytes)
+        name = fields.get("Package")
+        version = fields.get("Version")
+        license_value = fields.get("License")
+        priority = fields.get("Priority")
+        if not all(isinstance(item, str) and item for item in (name, version, license_value)):
+            raise RuntimeError(f"R package license metadata is incomplete: {description_path}")
+        evidence = [description_evidence, base_evidence]
+        evidence.append(_virtual_evidence("r-runtime-license", runtime_value))
+        evidence.append(runtime_copyright_evidence)
+        evidence.extend(shared)
+        license_file_tokens = []
+        reference = _R_LICENSE_REFERENCE.fullmatch(license_value)
+        if reference is not None:
+            license_file_evidence, license_file_bytes = _read_regular_file(
+                "r-license-file",
+                package_root / reference.group(1),
+                allowed_roots=(package_root,),
+            )
+            evidence.append(license_file_evidence)
+            license_file_tokens = _license_file_tokens(license_file_bytes)
+        records.append({
+            "ecosystem": "r",
+            "package": name,
+            "version": version,
+            "purl": f"pkg:cran/{quote(name, safe='')}@{quote(version, safe='')}",
+            "raw_values": [
+                value for value in [
+                    license_value,
+                    runtime_license,
+                    *runtime_license_fields,
+                    *license_file_tokens,
+                ]
+                if value
+            ],
+            "metadata": {
+                "declared_license": license_value,
+                "priority": priority or None,
+                "runtime_license": runtime_license,
+                "runtime_license_fields": runtime_license_fields,
+                "runtime_copyright_format": runtime_copyright_format,
+                "runtime_version": runtime_version,
+                "license_file_tokens": license_file_tokens,
+            },
+            "evidence": evidence,
+        })
+    return records
+
+
+def _npm_records() -> list[dict]:
+    package_path = NPM_PACKAGE_PATH
+    package_evidence, package_bytes = _read_regular_file(
+        "npm-package-json", package_path, allowed_roots=(package_path.parent,)
+    )
+    def reject_duplicates(pairs):
+        document = {}
+        for key, value in pairs:
+            if key in document:
+                raise RuntimeError("npm package metadata field is duplicated")
+            document[key] = value
+        return document
+
+    package_text = package_bytes.decode("utf-8", errors="strict")
+    document = json.loads(
+        package_text,
+        object_pairs_hook=reject_duplicates,
+        parse_constant=lambda value: (_ for _ in ()).throw(
+            RuntimeError(f"npm package metadata constant is invalid: {value}")
+        ),
+    )
+    name = document.get("name")
+    version = document.get("version")
+    license_value = document.get("license")
+    if not all(
+        isinstance(value, str) and value and value == value.strip()
+        for value in (name, version, license_value)
+    ):
+        raise RuntimeError("npm license metadata is invalid")
+    evidence = [package_evidence]
+    license_file_tokens = []
+    reference = _NPM_LICENSE_REFERENCE.fullmatch(license_value)
+    if reference is not None:
+        license_file_evidence, license_file_bytes = _read_regular_file(
+            "npm-license-file",
+            package_path.parent / reference.group(1),
+            allowed_roots=(package_path.parent,),
+        )
+        evidence.append(license_file_evidence)
+        license_file_tokens = _license_file_tokens(license_file_bytes)
+    return [{
+        "ecosystem": "npm",
+        "package": name,
+        "version": version,
+        "purl": f"pkg:npm/{quote(name, safe='')}@{quote(version, safe='')}",
+        "raw_values": [license_value, *license_file_tokens],
+        "metadata": {
+            "license": license_value,
+            "license_file_tokens": license_file_tokens,
+        },
+        "evidence": evidence,
+    }]
+
+
+def collect() -> dict:
+    if os.geteuid() != 65532 or os.getegid() != 65532:
+        raise RuntimeError("Phase 1C license evidence must run as UID/GID 65532")
+    records = sorted(
+        _debian_records() + _python_records() + _r_records() + _npm_records(),
+        key=lambda item: item["purl"],
+    )
+    document = {
+        "schema_version": "1.0",
+        "collector": "gdpval-agentic-v2-license-evidence-v1",
+        "records": records,
+    }
+    document["records_sha256"] = _canonical_sha256(records)
+    return document
+
+
+def main() -> None:
+    print(json.dumps(collect(), sort_keys=True, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-runner/sandbox/v2/license_evidence.py
+++ b/batch-runner/sandbox/v2/license_evidence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import errno
 import hashlib
+from email.header import Header
 from email.parser import BytesParser
 from email.policy import compat32
 import json
@@ -191,6 +192,20 @@ def _virtual_evidence(source: str, value: dict) -> dict:
     }
 
 
+def _unverifiable_path_evidence(source: str, path: Path) -> dict:
+    encoded = _canonical_json({
+        "path": str(path),
+        "reason": "symlink-or-nondirectory",
+    })
+    return {
+        "source": source,
+        "path": str(path),
+        "resolved_path": None,
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+        "size": len(encoded),
+    }
+
+
 def _license_file_tokens(value: bytes) -> list[str]:
     tokens = sorted({
         match.group(1).decode("ascii")
@@ -202,10 +217,17 @@ def _license_file_tokens(value: bytes) -> list[str]:
     return tokens
 
 
-def _debian_fields(stanza: str, source: str) -> dict[str, str]:
+def _debian_fields(
+    stanza: str,
+    source: str,
+    *,
+    allow_noncritical_duplicates: bool = False,
+) -> dict[str, str]:
     fields = {}
     current = None
     for line in stanza.splitlines():
+        if line.startswith("#"):
+            continue
         if line[:1].isspace():
             if current is None:
                 raise RuntimeError(f"Debian {source} metadata is malformed")
@@ -222,12 +244,15 @@ def _debian_fields(stanza: str, source: str) -> dict[str, str]:
         if _DEBIAN_FIELD_NAME.fullmatch(key) is None:
             raise RuntimeError(f"Debian {source} field name is malformed")
         if normalized in fields:
-            raise RuntimeError(f"Debian {source} field is duplicated")
-        fields[normalized] = value.strip()
+            if not allow_noncritical_duplicates or normalized in {"format", "license"}:
+                raise RuntimeError(f"Debian {source} field is duplicated")
+            fields[normalized] += "\n" + value.strip()
+        else:
+            fields[normalized] = value.strip()
         if len(fields[normalized]) > MAX_DEBIAN_FIELD_CHARS:
             raise RuntimeError(f"Debian {source} field is too large")
         current = normalized
-    return fields
+    return {key: value.strip() for key, value in fields.items()}
 
 
 def _debian_license_values(value: bytes, source: str) -> list[str]:
@@ -240,21 +265,68 @@ def _debian_license_values(value: bytes, source: str) -> list[str]:
     })
 
 
-def _debian_copyright_metadata(value: bytes) -> tuple[str | None, list[str]]:
+def _validate_unstructured_debian_field_names(text: str) -> None:
+    for line in text.splitlines():
+        if (
+            line
+            and not line[0].isspace()
+            and _DEBIAN_COPYRIGHT_FIELD_LIKE.match(line)
+            and _DEBIAN_FIELD_NAME.fullmatch(line.split(":", 1)[0]) is None
+        ):
+            raise RuntimeError("Debian copyright field name is malformed")
+
+
+def _debian_copyright_metadata(
+    value: bytes,
+    *,
+    require_canonical_format: bool = False,
+) -> tuple[str | None, list[str]]:
     text = value.decode("utf-8", errors="strict")
-    if not any(
-        _DEBIAN_COPYRIGHT_FIELD_LIKE.match(line)
-        for line in text.splitlines()
-    ):
-        return None, []
     stanzas = _split_debian_stanzas(text)
-    first_fields = _debian_fields(stanzas[0], "copyright")
+    first_lines = stanzas[0].splitlines()
+    format_lines = [
+        line for line in first_lines
+        if line.casefold().startswith("format:")
+    ]
+    if not format_lines:
+        if require_canonical_format:
+            raise RuntimeError("Debian copyright DEP-5 Format header is invalid")
+        _validate_unstructured_debian_field_names(text)
+        return None, []
+    preliminary_format = format_lines[0].split(":", 1)[1].strip()
+    if not preliminary_format:
+        raise RuntimeError("Debian copyright DEP-5 Format header is invalid")
+    if preliminary_format != DEP5_FORMAT_URI:
+        if require_canonical_format:
+            raise RuntimeError("Debian copyright DEP-5 Format header is invalid")
+        _validate_unstructured_debian_field_names(text)
+        return None, []
+    if any(
+        lines and all(line[0].isspace() for line in lines)
+        for stanza in stanzas
+        for lines in [[
+            line for line in stanza.splitlines()
+            if line and not line.startswith("#")
+        ]]
+    ):
+        if require_canonical_format:
+            raise RuntimeError("Debian copyright metadata is malformed")
+        return None, []
+    first_fields = _debian_fields(
+        stanzas[0],
+        "copyright",
+        allow_noncritical_duplicates=True,
+    )
     format_value = first_fields.get("format")
     if format_value != DEP5_FORMAT_URI:
         raise RuntimeError("Debian copyright DEP-5 Format header is invalid")
     license_fields = []
     for index, stanza in enumerate(stanzas):
-        fields = _debian_fields(stanza, "copyright")
+        fields = _debian_fields(
+            stanza,
+            "copyright",
+            allow_noncritical_duplicates=True,
+        )
         if "format" in fields:
             if index != 0 or fields["format"] != format_value:
                 raise RuntimeError("Debian copyright Format field is duplicated")
@@ -290,7 +362,12 @@ def _debian_records() -> list[dict]:
                 allowed_roots=(DEBIAN_DOCUMENTATION_ROOT,),
             )
         except _UnavailableEvidencePath as exc:
-            if exc.error_number != errno.ENOENT:
+            if exc.error_number in {errno.ELOOP, errno.ENOTDIR}:
+                evidence.append(_unverifiable_path_evidence(
+                    "debian-copyright-path-unverifiable",
+                    copyright_path,
+                ))
+            elif exc.error_number != errno.ENOENT:
                 raise
         else:
             evidence.append(copyright_evidence)
@@ -391,10 +468,18 @@ def _python_records() -> list[dict]:
             _DEBIAN_FIELD_NAME.fullmatch(key) is None for key in metadata.keys()
         ):
             raise RuntimeError(f"Python package metadata is malformed: {metadata_path}")
-        names = metadata.get_all("Name", [])
-        versions = metadata.get_all("Version", [])
-        licenses = metadata.get_all("License", [])
-        expressions = metadata.get_all("License-Expression", [])
+        def metadata_values(key):
+            values = metadata.get_all(key, [])
+            if any(not isinstance(value, (str, Header)) for value in values):
+                raise RuntimeError(
+                    f"Python package metadata value is invalid: {metadata_path}"
+                )
+            return [str(value) for value in values]
+
+        names = metadata_values("Name")
+        versions = metadata_values("Version")
+        licenses = metadata_values("License")
+        expressions = metadata_values("License-Expression")
         if (
             len(names) != 1
             or len(versions) != 1
@@ -414,10 +499,10 @@ def _python_records() -> list[dict]:
         license_value = licenses[0] if licenses else None
         classifiers = sorted({
             value
-            for value in metadata.get_all("Classifier", [])
+            for value in metadata_values("Classifier")
             if value.startswith("License ::")
         })
-        declared_files = metadata.get_all("License-File", [])
+        declared_files = metadata_values("License-File")
         raw_values = []
         if isinstance(license_expression, str) and license_expression.strip():
             raw_values.append(license_expression.strip())

--- a/batch-runner/sandbox/v2/professional-work.Dockerfile
+++ b/batch-runner/sandbox/v2/professional-work.Dockerfile
@@ -51,6 +51,7 @@ COPY core/agentic_v2_substrate.py /opt/gdpval/v2/agentic_v2_substrate.py
 COPY sandbox/agentic_v2_capabilities.json /opt/gdpval/v2/capabilities.json
 COPY sandbox/v2/image_probe.py /opt/gdpval/v2/image_probe.py
 COPY sandbox/v2/effective_sbom.py /opt/gdpval/v2/effective_sbom.py
+COPY sandbox/v2/license_evidence.py /opt/gdpval/v2/license_evidence.py
 COPY sandbox/v2/disabled_entrypoint.py /opt/gdpval/v2/disabled_entrypoint.py
 
 RUN if ! getent group 65532 >/dev/null; then \
@@ -70,4 +71,4 @@ RUN if ! getent group 65532 >/dev/null; then \
 USER 65532:65532
 WORKDIR /work
 
-ENTRYPOINT ["python", "-I", "-B", "/opt/gdpval/v2/disabled_entrypoint.py"]
+ENTRYPOINT ["python", "-I", "-S", "-B", "/opt/gdpval/v2/disabled_entrypoint.py"]

--- a/batch-runner/sandbox/v2/verify_candidate.py
+++ b/batch-runner/sandbox/v2/verify_candidate.py
@@ -5,14 +5,19 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 import re
+import selectors
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
+import time
 import uuid
-from pathlib import Path
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 
 
 BATCH_ROOT = Path(__file__).resolve().parents[2]
@@ -24,8 +29,16 @@ from core.agentic_v2_microvm import (  # noqa: E402
     inspect_microvm_readiness,
     validate_microvm_readiness_report,
 )
+from core.agentic_v2_license import (  # noqa: E402
+    build_license_report,
+    license_evaluator_runtime_identity,
+    validate_license_evidence,
+    validate_license_report,
+)
 from core.agentic_v2_oci import verify_oci_layout  # noqa: E402
 from core.agentic_v2_substrate import (  # noqa: E402
+    AGENTIC_V2_EVIDENCE_ROOT_COPY_TIMEOUT_SECONDS,
+    AGENTIC_V2_IMAGE_PROBE_TIMEOUT_SECONDS,
     AgenticV2SubstrateManifest,
     canonical_sha256,
     validate_capability_receipt,
@@ -37,7 +50,6 @@ from core.agentic_v2_supply_chain import (  # noqa: E402
     build_evidence_report,
     evidence_collection_allowed,
     evidence_item,
-    evaluate_license_policy,
     validate_effective_sbom,
     validate_evidence_directory,
 )
@@ -45,6 +57,31 @@ from core.agentic_v2_supply_chain import (  # noqa: E402
 
 _SOURCE_SHA = re.compile(r"[0-9a-f]{40}")
 _DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+_TRUSTED_PATH = "/usr/bin:/bin"
+_TRUSTED_GIT = "/usr/bin/git"
+_TRUSTED_DOCKER = "/usr/bin/docker"
+_VERIFICATION_SESSION_LABEL = "io.gdpval.agentic-v2.verification-session"
+_SESSION_ID = re.compile(r"[0-9a-f]{32}")
+_IMAGE_PURELIB_PATH = "/usr/local/lib/python3.11/site-packages"
+_LICENSE_EVIDENCE_ROOTS = (
+    "/usr/local/lib/python3.11/site-packages",
+    "/usr/share/R/share/licenses",
+    "/usr/share/nodejs/npm",
+    "/usr/share/doc",
+    "/usr/lib/R/library",
+    "/var/lib/dpkg",
+)
+_IMAGE_STDLIB_SCRIPT_BOOTSTRAP = (
+    "import runpy,sys;"
+    "script=sys.argv[1];sys.argv=sys.argv[1:];"
+    "runpy.run_path(script,run_name='__main__')"
+)
+_IMAGE_PURELIB_SCRIPT_BOOTSTRAP = (
+    "import runpy,sys;"
+    f"sys.path.append({_IMAGE_PURELIB_PATH!r});"
+    "script=sys.argv[1];sys.argv=sys.argv[1:];"
+    "runpy.run_path(script,run_name='__main__')"
+)
 _FORBIDDEN_ENV = (
     "AZURE_CLIENT_SECRET",
     "AZURE_OPENAI_API_KEY",
@@ -63,6 +100,55 @@ _CONTAINMENT_CHECKS = frozenset({
     "pids_limit",
     "read_only_rootfs",
 })
+
+
+@dataclass(frozen=True)
+class VerificationSession:
+    session_id: str
+
+    def __post_init__(self) -> None:
+        if _SESSION_ID.fullmatch(self.session_id) is None:
+            raise ValueError("candidate verification session identity is invalid")
+
+    def container_name(self, purpose: str) -> str:
+        return (
+            f"gdpval-agentic-v2-{purpose}-{self.session_id[:12]}-"
+            f"{uuid.uuid4().hex[:12]}"
+        )
+
+    def label_arguments(self) -> list[str]:
+        return [
+            "--label",
+            f"{_VERIFICATION_SESSION_LABEL}={self.session_id}",
+        ]
+
+
+def _matches(pattern: re.Pattern, value) -> bool:
+    return isinstance(value, str) and pattern.fullmatch(value) is not None
+
+
+def _require_trusted_executable(path: str) -> None:
+    executable = Path(path)
+    if executable not in {Path(_TRUSTED_GIT), Path(_TRUSTED_DOCKER)}:
+        raise RuntimeError("candidate verifier executable is not allowlisted")
+    for directory in (Path("/usr"), Path("/usr/bin")):
+        metadata = directory.lstat()
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != 0
+            or metadata.st_mode & 0o022
+        ):
+            raise RuntimeError("candidate verifier trusted tool directory is invalid")
+    metadata = executable.lstat()
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != 0
+        or metadata.st_mode & 0o022
+        or not metadata.st_mode & 0o111
+    ):
+        raise RuntimeError("candidate verifier trusted executable is invalid")
 _CONTAINMENT_PROBE = r'''
 import ctypes
 import json
@@ -165,10 +251,12 @@ def verify_candidate(
     oci_layout: Path,
     output_directory: Path,
     repository_root: Path | None = None,
+    session_id: str,
 ) -> dict:
+    session = VerificationSession(session_id)
     _require_no_credentials()
     _require_local_docker()
-    if _SOURCE_SHA.fullmatch(source_revision) is None:
+    if not _matches(_SOURCE_SHA, source_revision):
         raise ValueError("candidate source revision is invalid")
     repository_root = _require_repository_root(
         repository_root or REPOSITORY_ROOT,
@@ -195,12 +283,12 @@ def verify_candidate(
     ):
         raise ValueError("candidate parent lock differs from committed V1 Dockerfile")
     oci_report = verify_oci_layout(oci_layout)
-    inspect = _docker_json(["docker", "image", "inspect", image])
+    inspect = _docker_json([_TRUSTED_DOCKER, "image", "inspect", image])
     if not isinstance(inspect, list) or len(inspect) != 1:
         raise ValueError("candidate image inspect result is invalid")
     image_document = inspect[0]
     parent_inspect = _docker_json([
-        "docker", "image", "inspect", parent_lock["reference"]
+        _TRUSTED_DOCKER, "image", "inspect", parent_lock["reference"]
     ])
     if not isinstance(parent_inspect, list) or len(parent_inspect) != 1:
         raise ValueError("candidate parent image inspect result is invalid")
@@ -222,7 +310,7 @@ def verify_candidate(
         or labels.get("io.gdpval.agentic-v2.production-activation") != "disabled"
         or labels.get("io.gdpval.agentic-v2.capability-manifest-sha256") != manifest.sha256
         or entrypoint != [
-            "python", "-I", "-B", "/opt/gdpval/v2/disabled_entrypoint.py"
+            "python", "-I", "-S", "-B", "/opt/gdpval/v2/disabled_entrypoint.py"
         ]
         or parent_document.get("Id") != parent_lock["observed_local_image_id"]
         or parent_lock["reference"] not in (parent_document.get("RepoDigests") or [])
@@ -234,7 +322,7 @@ def verify_candidate(
     ):
         raise ValueError("candidate image identity or labels are invalid")
     embedded_source_sha256 = _verify_embedded_files(
-        image_id, source_revision, repository_root
+        image_id, source_revision, repository_root, session=session
     )
     lock_set_sha256 = canonical_sha256([
         {
@@ -247,6 +335,7 @@ def verify_candidate(
             "batch-runner/sandbox/v2/python-extra.lock",
         )
     ])
+    evaluator_runtime = license_evaluator_runtime_identity()
     subject = CandidateSubject.from_mapping({
         "schema_version": "1.0",
         "substrate_id": "professional-work-v1",
@@ -278,11 +367,32 @@ def verify_candidate(
             "batch-runner/sandbox/v2/effective_sbom.py",
             repository_root,
         ),
+        "license_collector_sha256": _git_blob_sha256(
+            source_revision,
+            "batch-runner/sandbox/v2/license_evidence.py",
+            repository_root,
+        ),
+        "license_evaluator_sha256": _git_blob_sha256(
+            source_revision,
+            "batch-runner/core/agentic_v2_license.py",
+            repository_root,
+        ),
+        "license_evaluator_packaging_version": evaluator_runtime["packaging_version"],
+        "license_evaluator_parser_sha256": evaluator_runtime["parser_sha256"],
+        "license_evaluator_python_version": evaluator_runtime["python_version"],
+        "license_evaluator_callable_sha256": evaluator_runtime["callable_sha256"],
+        "license_evaluator_runtime_graph_sha256": evaluator_runtime[
+            "runtime_graph_sha256"
+        ],
+        "license_evaluator_spdx_version": evaluator_runtime["spdx_version"],
+        "license_evaluator_spdx_sha256": evaluator_runtime["spdx_sha256"],
         "lock_set_sha256": lock_set_sha256,
     })
     microvm_report = inspect_microvm_readiness(asset_paths={})
     validate_microvm_readiness_report(microvm_report)
-    containment_report = _inspect_containment(parent_document["Id"])
+    containment_report = _inspect_containment(
+        parent_document["Id"], session=session
+    )
     tool_sha = subject.document["verifier_sha256"]
     evidence = {
         name: evidence_item(subject, name=name, status="not_run")
@@ -312,16 +422,20 @@ def verify_candidate(
     receipt = None
     sbom = None
     license_report = None
+    license_evidence = None
     if evidence_collection_allowed(containment_report):
         _verify_disabled_entrypoint(
             image_id,
             containment_checks=containment_report["checks"],
+            session=session,
         )
         observation = _run_image_json(
             image_id,
             "/opt/gdpval/v2/image_probe.py",
             8 * 1024 * 1024,
             containment_checks=containment_report["checks"],
+            include_purelib=True,
+            session=session,
         )
         validate_capability_receipt(observation, manifest)
         sbom = _run_image_json(
@@ -329,9 +443,41 @@ def verify_candidate(
             "/opt/gdpval/v2/effective_sbom.py",
             64 * 1024 * 1024,
             containment_checks=containment_report["checks"],
+            include_purelib=True,
+            session=session,
         )
         validate_effective_sbom(sbom, observation)
-        license_report = evaluate_license_policy(sbom, policy)
+        license_evidence = _run_image_json(
+            image_id,
+            "/opt/gdpval/v2/license_evidence.py",
+            16 * 1024 * 1024,
+            containment_checks=containment_report["checks"],
+            include_purelib=False,
+            session=session,
+        )
+        license_evidence = validate_license_evidence(license_evidence, sbom)
+        _verify_license_evidence_files(
+            image_id,
+            license_evidence,
+            session=session,
+        )
+        license_report = build_license_report(
+            subject=subject.document,
+            subject_sha256=subject.sha256,
+            sbom=sbom,
+            license_evidence=license_evidence,
+            policy=policy.document,
+            policy_sha256=policy.sha256,
+        )
+        validate_license_report(
+            license_report,
+            subject=subject.document,
+            subject_sha256=subject.sha256,
+            sbom=sbom,
+            license_evidence=license_evidence,
+            policy=policy.document,
+            policy_sha256=policy.sha256,
+        )
         receipt = build_candidate_receipt(subject, observation, manifest)
         evidence["capability_receipt"] = evidence_item(
             subject,
@@ -355,9 +501,9 @@ def verify_candidate(
             subject,
             name="license",
             status=license_report["status"],
-            tool_name="gdpval-agentic-v2-license-policy",
+            tool_name="gdpval-agentic-v2-license-evaluator",
             tool_version="1.0",
-            tool_sha256=policy.sha256,
+            tool_sha256=subject.document["license_evaluator_sha256"],
             report_sha256=canonical_sha256(license_report),
         )
     gate = build_evidence_report(subject, policy, evidence)
@@ -370,6 +516,7 @@ def verify_candidate(
         if sbom is not None:
             _write_json(temporary / "effective-sbom.spdx.json", sbom)
         if license_report is not None:
+            _write_json(temporary / "license-evidence.json", license_evidence)
             _write_json(temporary / "license-report.json", license_report)
         _write_json(temporary / "containment-report.json", containment_report)
         _write_json(temporary / "microvm-readiness.json", microvm_report)
@@ -394,15 +541,23 @@ def _run_image_json(
     maximum: int,
     *,
     containment_checks: dict[str, bool],
+    include_purelib: bool,
+    session: VerificationSession,
 ) -> dict:
-    container = _container_name("evidence")
+    bootstrap = (
+        _IMAGE_PURELIB_SCRIPT_BOOTSTRAP
+        if include_purelib
+        else _IMAGE_STDLIB_SCRIPT_BOOTSTRAP
+    )
+    container = session.container_name("evidence")
     optional_limits = []
     if containment_checks["pids_limit"]:
         optional_limits.extend(["--pids-limit", "512"])
     if containment_checks["cpu_quota"]:
         optional_limits.extend(["--cpus", "2"])
     command = [
-        "docker", "run", "--pull=never", "--name", container,
+        _TRUSTED_DOCKER, "run", "--pull=never", "--name", container,
+        *session.label_arguments(),
         "--network", "none", "--read-only",
         "--user", "65532:65532", "--cap-drop", "ALL",
         "--security-opt", "no-new-privileges", "--memory", "6g",
@@ -412,16 +567,14 @@ def _run_image_json(
         "--tmpfs",
         "/tmp:rw,noexec,nosuid,nodev,size=268435456,uid=65532,gid=65532,mode=0700",
         "--entrypoint", "python",
-        image, "-I", "-B", script,
+        image, "-I", "-S", "-B", "-c", bootstrap, script,
     ]
     try:
-        completed = subprocess.run(
+        completed = _run_bounded_command(
             command,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=900,
-            check=False,
+            timeout=AGENTIC_V2_IMAGE_PROBE_TIMEOUT_SECONDS,
+            stdout_limit=maximum,
+            stderr_limit=64 * 1024,
         )
     finally:
         _remove_container(container)
@@ -430,25 +583,155 @@ def _run_image_json(
             "candidate image probe failed: "
             + completed.stderr.decode("utf-8", errors="replace")[-1000:]
         )
-    if not completed.stdout or len(completed.stdout) > maximum:
+    if not completed.stdout:
         raise RuntimeError("candidate image probe output size is invalid")
-    value = json.loads(completed.stdout)
+    value = _bounded_json_loads(completed.stdout)
     if not isinstance(value, dict):
         raise RuntimeError("candidate image probe result is invalid")
     return value
 
 
-def _inspect_containment(image: str) -> dict:
-    checks, collection_checks = _docker_base_isolation_probe(image)
+def _run_bounded_command(
+    command: list[str],
+    *,
+    timeout: float,
+    stdout_limit: int,
+    stderr_limit: int,
+) -> subprocess.CompletedProcess:
+    environment = (
+        _docker_environment()
+        if command and command[0] == _TRUSTED_DOCKER
+        else None
+    )
+    process = subprocess.Popen(
+        command,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if process.stdout is None or process.stderr is None:
+        process.kill()
+        raise RuntimeError("bounded command pipes are unavailable")
+    selector = selectors.DefaultSelector()
+    streams = {
+        process.stdout: ("stdout", stdout_limit, bytearray()),
+        process.stderr: ("stderr", stderr_limit, bytearray()),
+    }
+    for stream in streams:
+        os.set_blocking(stream.fileno(), False)
+        selector.register(stream, selectors.EVENT_READ)
+    deadline = time.monotonic() + timeout
+    try:
+        while selector.get_map() or process.poll() is None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise subprocess.TimeoutExpired(command, timeout)
+            for key, _events in selector.select(min(remaining, 0.2)):
+                stream = key.fileobj
+                name, limit, buffer = streams[stream]
+                try:
+                    chunk = os.read(stream.fileno(), 64 * 1024)
+                except BlockingIOError:
+                    continue
+                if not chunk:
+                    selector.unregister(stream)
+                    continue
+                buffer.extend(chunk)
+                if len(buffer) > limit:
+                    raise RuntimeError(f"candidate {name} exceeds size limit")
+        return subprocess.CompletedProcess(
+            command,
+            process.wait(),
+            bytes(streams[process.stdout][2]),
+            bytes(streams[process.stderr][2]),
+        )
+    except Exception:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+        raise
+    finally:
+        selector.close()
+        process.stdout.close()
+        process.stderr.close()
+
+
+def _bounded_json_loads(value: bytes):
+    def reject_duplicates(pairs):
+        result = {}
+        for key, item in pairs:
+            if key in result:
+                raise ValueError("candidate JSON contains duplicate keys")
+            result[key] = item
+        return result
+
+    def bounded_int(raw):
+        if len(raw.lstrip("-")) > 100:
+            raise ValueError("candidate JSON integer is too large")
+        return int(raw)
+
+    def reject_constant(raw):
+        raise ValueError(f"candidate JSON constant is invalid: {raw}")
+
+    def bounded_float(raw):
+        if len(raw) > 100:
+            raise ValueError("candidate JSON float is too large")
+        result = float(raw)
+        if not math.isfinite(result):
+            raise ValueError("candidate JSON float is not finite")
+        return result
+
+    try:
+        document = json.loads(
+            value,
+            object_pairs_hook=reject_duplicates,
+            parse_int=bounded_int,
+            parse_float=bounded_float,
+            parse_constant=reject_constant,
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError) as exc:
+        raise RuntimeError("candidate image probe returned invalid JSON") from exc
+    stack = [(document, 1)]
+    nodes = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > 500_000 or depth > 64:
+            raise RuntimeError("candidate JSON structure exceeds limits")
+        if isinstance(item, str) and len(item) > 1024 * 1024:
+            raise RuntimeError("candidate JSON string exceeds size limit")
+        if isinstance(item, dict):
+            stack.extend((key, depth + 1) for key in item)
+            stack.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, list):
+            stack.extend((child, depth + 1) for child in item)
+    return document
+
+
+def _inspect_containment(
+    image: str,
+    *,
+    session: VerificationSession,
+) -> dict:
+    checks, collection_checks = _docker_base_isolation_probe(
+        image, session=session
+    )
     checks["pids_limit"] = _docker_resource_limit_probe(
         image,
         name="pids_limit",
         arguments=["--pids-limit", "16"],
+        session=session,
     )
     checks["cpu_quota"] = _docker_resource_limit_probe(
         image,
         name="cpu_quota",
         arguments=["--cpus", "0.25"],
+        session=session,
     )
     report = {
         "schema_version": "1.1",
@@ -467,6 +750,8 @@ def _inspect_containment(image: str) -> dict:
 
 def _docker_base_isolation_probe(
     image: str,
+    *,
+    session: VerificationSession,
 ) -> tuple[dict[str, bool], dict[str, bool]]:
     failed = {name: False for name in _CONTAINMENT_CHECKS}
     collection_failed = {
@@ -476,39 +761,38 @@ def _docker_base_isolation_probe(
             "no_new_privileges", "non_root_uid", "read_only_rootfs",
         )
     }
-    container = _container_name("isolation")
+    container = session.container_name("isolation")
     inspected = None
     try:
-        completed = subprocess.run(
+        completed = _run_bounded_command(
             [
-                "docker", "run", "--pull=never", "--name", container,
+                _TRUSTED_DOCKER, "run", "--pull=never", "--name", container,
+                *session.label_arguments(),
                 "--network", "none", "--read-only",
                 "--user", "65532:65532", "--cap-drop", "ALL",
                 "--security-opt", "no-new-privileges",
                 "--memory", "64m",
-                "--entrypoint", "python", image, "-I", "-B", "-c",
+                "--entrypoint", "python", image, "-I", "-S", "-B", "-c",
                 _CONTAINMENT_PROBE,
             ],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             timeout=30,
-            check=False,
+            stdout_limit=64 * 1024,
+            stderr_limit=64 * 1024,
         )
         if completed.returncode == 0:
-            inspected = _docker_json(["docker", "container", "inspect", container])
+            inspected = _docker_json([
+                _TRUSTED_DOCKER, "container", "inspect", container
+            ])
     finally:
         _remove_container(container)
     if (
         completed.returncode != 0
         or not completed.stdout
-        or len(completed.stdout) > 65536
-        or len(completed.stderr) > 65536
     ):
         return failed, collection_failed
     try:
-        checks = json.loads(completed.stdout)
-    except json.JSONDecodeError:
+        checks = _bounded_json_loads(completed.stdout)
+    except (RuntimeError, ValueError):
         return failed, collection_failed
     if (
         not isinstance(checks, dict)
@@ -588,37 +872,35 @@ def _docker_resource_limit_probe(
     *,
     name: str,
     arguments: list[str],
+    session: VerificationSession,
 ) -> bool:
-    container = _container_name(name)
+    container = session.container_name(name)
     try:
-        completed = subprocess.run(
+        completed = _run_bounded_command(
             [
-                "docker", "run", "--pull=never", "--name", container,
+                _TRUSTED_DOCKER, "run", "--pull=never", "--name", container,
+                *session.label_arguments(),
                 "--network", "none", "--read-only",
                 "--user", "65532:65532", "--cap-drop", "ALL",
                 "--security-opt", "no-new-privileges", "--memory", "64m",
                 *arguments,
-                "--entrypoint", "python", image, "-I", "-B", "-c",
+                "--entrypoint", "python", image, "-I", "-S", "-B", "-c",
                 _CONTAINMENT_PROBE,
             ],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             timeout=30,
-            check=False,
+            stdout_limit=64 * 1024,
+            stderr_limit=64 * 1024,
         )
     finally:
         _remove_container(container)
     if (
         completed.returncode != 0
         or not completed.stdout
-        or len(completed.stdout) > 65536
-        or len(completed.stderr) > 65536
     ):
         return False
     try:
-        checks = json.loads(completed.stdout)
-    except json.JSONDecodeError:
+        checks = _bounded_json_loads(completed.stdout)
+    except (RuntimeError, ValueError):
         return False
     if (
         not isinstance(checks, dict)
@@ -659,43 +941,43 @@ def _resource_warning_checks(stderr: bytes) -> set[str] | None:
 
 
 def _docker_json(command: list[str]):
-    completed = subprocess.run(
+    completed = _run_bounded_command(
         command,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
         timeout=60,
-        check=True,
+        stdout_limit=2 * 1024 * 1024,
+        stderr_limit=64 * 1024,
     )
-    return json.loads(completed.stdout)
+    if completed.returncode != 0 or completed.stderr:
+        raise RuntimeError("Docker inspection failed")
+    return _bounded_json_loads(completed.stdout)
 
 
 def _verify_disabled_entrypoint(
     image_id: str,
     *,
     containment_checks: dict[str, bool],
+    session: VerificationSession,
 ) -> None:
-    container = _container_name("disabled")
+    container = session.container_name("disabled")
     optional_limits = []
     if containment_checks["pids_limit"]:
         optional_limits.extend(["--pids-limit", "16"])
     if containment_checks["cpu_quota"]:
         optional_limits.extend(["--cpus", "0.25"])
     try:
-        completed = subprocess.run(
+        completed = _run_bounded_command(
             [
-                "docker", "run", "--pull=never", "--name", container,
+                _TRUSTED_DOCKER, "run", "--pull=never", "--name", container,
+                *session.label_arguments(),
                 "--network", "none", "--read-only",
                 "--user", "65532:65532", "--cap-drop", "ALL",
                 "--security-opt", "no-new-privileges", "--memory", "64m",
                 *optional_limits,
                 image_id,
             ],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             timeout=30,
-            check=False,
+            stdout_limit=64 * 1024,
+            stderr_limit=64 * 1024,
         )
     finally:
         _remove_container(container)
@@ -719,6 +1001,8 @@ def _verify_embedded_files(
     image: str,
     source_revision: str,
     repository_root: Path,
+    *,
+    session: VerificationSession,
 ) -> str:
     expected = {
         "/opt/gdpval/v2/agentic_v2_substrate.py": "batch-runner/core/agentic_v2_substrate.py",
@@ -727,38 +1011,40 @@ def _verify_embedded_files(
         "/opt/gdpval/v2/disabled_entrypoint.py": "batch-runner/sandbox/v2/disabled_entrypoint.py",
         "/opt/gdpval/v2/effective_sbom.py": "batch-runner/sandbox/v2/effective_sbom.py",
         "/opt/gdpval/v2/image_probe.py": "batch-runner/sandbox/v2/image_probe.py",
+        "/opt/gdpval/v2/license_evidence.py": "batch-runner/sandbox/v2/license_evidence.py",
         "/opt/gdpval/v2/python-extra.lock": "batch-runner/sandbox/v2/python-extra.lock",
     }
-    container = _container_name("inspect")
+    container = session.container_name("inspect")
     records = []
     try:
-        created = subprocess.run(
+        created_result = _run_bounded_command(
             [
-                "docker", "container", "create", "--name", container,
+                _TRUSTED_DOCKER, "container", "create", "--name", container,
+                *session.label_arguments(),
                 "--network", "none", "--entrypoint", "/bin/true",
                 image,
             ],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             timeout=60,
-            check=True,
-            text=True,
-        ).stdout.strip()
+            stdout_limit=4096,
+            stderr_limit=64 * 1024,
+        )
+        if created_result.returncode != 0:
+            raise RuntimeError("candidate inspection container creation failed")
+        created = created_result.stdout.decode("ascii", errors="strict").strip()
         if not re.fullmatch(r"[0-9a-f]{64}", created):
             raise RuntimeError("candidate inspection container identity is invalid")
         with tempfile.TemporaryDirectory(prefix="phase1b-embedded-") as temporary:
             root = Path(temporary)
             for index, (container_path, repository_path) in enumerate(sorted(expected.items())):
                 target = root / f"item-{index}"
-                subprocess.run(
-                    ["docker", "container", "cp", f"{container}:{container_path}", str(target)],
-                    stdin=subprocess.DEVNULL,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE,
+                copied = _run_bounded_command(
+                    [_TRUSTED_DOCKER, "container", "cp", f"{container}:{container_path}", str(target)],
                     timeout=60,
-                    check=True,
+                    stdout_limit=4096,
+                    stderr_limit=64 * 1024,
                 )
+                if copied.returncode != 0:
+                    raise RuntimeError("candidate embedded file copy failed")
                 if not target.is_file() or target.is_symlink():
                     raise RuntimeError("candidate embedded file is not regular")
                 actual_sha = _sha256(target)
@@ -779,8 +1065,153 @@ def _verify_embedded_files(
     return canonical_sha256(records)
 
 
-def _container_name(purpose: str) -> str:
-    return f"gdpval-agentic-v2-{purpose}-{uuid.uuid4().hex}"
+def _verify_license_evidence_files(
+    image: str,
+    license_evidence: dict,
+    *,
+    session: VerificationSession,
+) -> None:
+    expected: dict[str, tuple[str, int, str, str]] = {}
+    for record in license_evidence["records"]:
+        for item in record["evidence"]:
+            path = item["path"]
+            if path is None:
+                continue
+            candidate = PurePosixPath(path)
+            roots = [
+                PurePosixPath(root)
+                for root in _LICENSE_EVIDENCE_ROOTS
+                if PurePosixPath(root) in candidate.parents
+            ]
+            if not roots:
+                raise ValueError("candidate license evidence path root is invalid")
+            source_root = max(roots, key=lambda value: len(value.parts))
+            relative = candidate.relative_to(source_root)
+            identity = (
+                item["sha256"],
+                item["size"],
+                str(source_root),
+                str(relative),
+            )
+            previous = expected.setdefault(path, identity)
+            if previous != identity:
+                raise ValueError("candidate license evidence path identity conflicts")
+    grouped: dict[str, list[tuple[str, tuple[str, int, str, str]]]] = {}
+    for path, identity in expected.items():
+        grouped.setdefault(identity[2], []).append((path, identity))
+    container = session.container_name("license-files")
+    try:
+        created = _run_bounded_command(
+            [
+                _TRUSTED_DOCKER,
+                "container",
+                "create",
+                "--name",
+                container,
+                *session.label_arguments(),
+                "--network",
+                "none",
+                "--entrypoint",
+                "/bin/true",
+                image,
+            ],
+            timeout=60,
+            stdout_limit=4096,
+            stderr_limit=64 * 1024,
+        )
+        if (
+            created.returncode != 0
+            or created.stderr
+            or re.fullmatch(rb"[0-9a-f]{64}\n?", created.stdout) is None
+        ):
+            raise RuntimeError("candidate license evidence container creation failed")
+        with tempfile.TemporaryDirectory(prefix="phase1c-license-files-") as temporary:
+            temporary_root = Path(temporary)
+            for index, (source_root, records) in enumerate(sorted(grouped.items())):
+                destination = temporary_root / f"root-{index}"
+                destination.mkdir(mode=0o700)
+                copied = _run_bounded_command(
+                    [
+                        _TRUSTED_DOCKER,
+                        "container",
+                        "cp",
+                        f"{container}:{source_root}/.",
+                        str(destination),
+                    ],
+                    timeout=AGENTIC_V2_EVIDENCE_ROOT_COPY_TIMEOUT_SECONDS,
+                    stdout_limit=4096,
+                    stderr_limit=64 * 1024,
+                )
+                if copied.returncode != 0 or copied.stdout or copied.stderr:
+                    raise RuntimeError("candidate license evidence root copy failed")
+                for _path, identity in records:
+                    _verify_copied_evidence_file(
+                        destination,
+                        PurePosixPath(identity[3]),
+                        expected_sha256=identity[0],
+                        expected_size=identity[1],
+                    )
+    finally:
+        _remove_container(container)
+
+
+def _verify_copied_evidence_file(
+    root: Path,
+    relative: PurePosixPath,
+    *,
+    expected_sha256: str,
+    expected_size: int,
+) -> None:
+    current = root
+    for index, part in enumerate(relative.parts):
+        current = current / part
+        metadata = current.lstat()
+        if current.is_symlink():
+            raise ValueError("copied license evidence path is a symlink")
+        if index < len(relative.parts) - 1 and not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError("copied license evidence parent is not a directory")
+    descriptor = os.open(
+        current,
+        os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC | os.O_NONBLOCK,
+    )
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size != expected_size
+        ):
+            raise ValueError("copied license evidence file identity differs")
+        digest = hashlib.sha256()
+        total = 0
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+            total += len(chunk)
+            if total > expected_size:
+                raise ValueError("copied license evidence file size differs")
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    def identity(item):
+        return (
+            item.st_dev,
+            item.st_ino,
+            item.st_mode,
+            item.st_nlink,
+            item.st_size,
+            item.st_mtime_ns,
+        )
+    if (
+        identity(before) != identity(after)
+        or total != expected_size
+        or digest.hexdigest() != expected_sha256
+    ):
+        raise ValueError("copied license evidence file digest differs")
+
+
 
 
 def _load_parent_lock(path: Path) -> dict:
@@ -799,10 +1230,10 @@ def _load_parent_lock_bytes(raw: bytes) -> dict:
         or value["reference"] != (
             "ghcr.io/hyeonsangjeon/gdpval-sandbox@" + value["manifest_digest"]
         )
-        or _DIGEST.fullmatch(value["manifest_digest"]) is None
-        or _DIGEST.fullmatch(value["observed_local_image_id"]) is None
+        or not _matches(_DIGEST, value["manifest_digest"])
+        or not _matches(_DIGEST, value["observed_local_image_id"])
         or value["platform"] != "linux/amd64"
-        or _SOURCE_SHA.fullmatch(value["source_revision"]) is None
+        or not _matches(_SOURCE_SHA, value["source_revision"])
         or len(value["v1_dockerfile_sha256"]) != 64
     ):
         raise ValueError("candidate parent lock identity is invalid")
@@ -816,44 +1247,61 @@ def _require_no_credentials() -> None:
 
 
 def _require_local_docker() -> None:
-    completed = subprocess.run(
-        ["docker", "context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+    _require_trusted_executable(_TRUSTED_DOCKER)
+    docker_host = os.getenv("DOCKER_HOST")
+    if docker_host and not docker_host.startswith("unix://"):
+        raise RuntimeError("candidate verifier requires a local Unix Docker daemon")
+    completed = _run_bounded_command(
+        [_TRUSTED_DOCKER, "context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"],
         timeout=30,
-        check=True,
-        text=True,
+        stdout_limit=64 * 1024,
+        stderr_limit=64 * 1024,
     )
-    endpoint = json.loads(completed.stdout)
+    if completed.returncode != 0 or completed.stderr:
+        raise RuntimeError("candidate verifier could not inspect Docker context")
+    endpoint = _bounded_json_loads(completed.stdout)
     if not isinstance(endpoint, str) or not endpoint.startswith("unix://"):
         raise RuntimeError("candidate verifier requires a local Unix Docker daemon")
-    if os.getenv("DOCKER_HOST") and os.environ["DOCKER_HOST"] != endpoint:
+    if docker_host and docker_host != endpoint:
         raise RuntimeError("DOCKER_HOST differs from verified local endpoint")
+
+
+def _docker_environment() -> dict[str, str]:
+    environment = {
+        "PATH": _TRUSTED_PATH,
+        "HOME": "/nonexistent",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+    }
+    docker_host = os.getenv("DOCKER_HOST")
+    if docker_host:
+        if not docker_host.startswith("unix://"):
+            raise RuntimeError("candidate verifier requires a local Unix Docker daemon")
+        environment["DOCKER_HOST"] = docker_host
+    return environment
 
 
 def _remove_container(container: str) -> None:
     try:
-        subprocess.run(
-            ["docker", "container", "rm", "--force", container],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+        _run_bounded_command(
+            [_TRUSTED_DOCKER, "container", "rm", "--force", container],
             timeout=60,
-            check=False,
+            stdout_limit=4096,
+            stderr_limit=64 * 1024,
         )
-    except (OSError, subprocess.SubprocessError):
+    except (OSError, RuntimeError, subprocess.SubprocessError):
         pass
     try:
-        inspected = subprocess.run(
-            ["docker", "container", "inspect", container],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+        inspected = _run_bounded_command(
+            [
+                _TRUSTED_DOCKER, "container", "inspect", "--format", "{{.Id}}",
+                container,
+            ],
             timeout=60,
-            check=False,
+            stdout_limit=4096,
+            stderr_limit=64 * 1024,
         )
-    except (OSError, subprocess.SubprocessError) as exc:
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
         raise RuntimeError(
             "candidate container cleanup could not be verified"
         ) from exc
@@ -881,9 +1329,10 @@ def _git_blob(
     repository_path: str,
     repository_root: Path = REPOSITORY_ROOT,
 ) -> bytes:
+    _require_trusted_executable(_TRUSTED_GIT)
     return subprocess.run(
         [
-            "git", "--no-replace-objects",
+            _TRUSTED_GIT, "--no-replace-objects",
             "-c", "core.fsmonitor=false",
             "-c", "core.hooksPath=/dev/null",
             "-C", str(repository_root),
@@ -909,10 +1358,11 @@ def _git_blob_sha256(
 
 
 def _require_repository_root(path: Path, source_revision: str) -> Path:
+    _require_trusted_executable(_TRUSTED_GIT)
     root = path.resolve(strict=True)
     completed = subprocess.run(
         [
-            "git", "--no-replace-objects",
+            _TRUSTED_GIT, "--no-replace-objects",
             "-c", "core.fsmonitor=false",
             "-c", "core.hooksPath=/dev/null",
             "-C", str(root), "rev-parse", "--show-toplevel",
@@ -929,7 +1379,7 @@ def _require_repository_root(path: Path, source_revision: str) -> Path:
         raise RuntimeError("candidate repository root identity is invalid")
     subprocess.run(
         [
-            "git", "--no-replace-objects",
+            _TRUSTED_GIT, "--no-replace-objects",
             "-c", "core.fsmonitor=false",
             "-c", "core.hooksPath=/dev/null",
             "-C", str(root),
@@ -947,7 +1397,7 @@ def _require_repository_root(path: Path, source_revision: str) -> Path:
 
 def _git_environment() -> dict[str, str]:
     return {
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "PATH": _TRUSTED_PATH,
         "HOME": "/nonexistent",
         "LANG": "C.UTF-8",
         "LC_ALL": "C.UTF-8",
@@ -973,12 +1423,21 @@ def _write_json(path: Path, value) -> None:
 
 
 def main() -> None:
+    if (
+        sys.flags.isolated != 1
+        or sys.flags.no_site != 1
+        or not sys.dont_write_bytecode
+    ):
+        raise RuntimeError(
+            "candidate verifier requires isolated no-site no-bytecode startup"
+        )
     parser = argparse.ArgumentParser()
     parser.add_argument("--image", required=True)
     parser.add_argument("--source-revision", required=True)
     parser.add_argument("--repository-root", type=Path, default=REPOSITORY_ROOT)
     parser.add_argument("--oci-layout", required=True, type=Path)
     parser.add_argument("--output-directory", required=True, type=Path)
+    parser.add_argument("--session-id", required=True)
     arguments = parser.parse_args()
     gate = verify_candidate(
         image=arguments.image,
@@ -986,6 +1445,7 @@ def main() -> None:
         repository_root=arguments.repository_root,
         oci_layout=arguments.oci_layout,
         output_directory=arguments.output_directory,
+        session_id=arguments.session_id,
     )
     print(json.dumps(gate, sort_keys=True, separators=(",", ":")))
 

--- a/batch-runner/sandbox/v2/verify_candidate.py
+++ b/batch-runner/sandbox/v2/verify_candidate.py
@@ -127,6 +127,16 @@ def _matches(pattern: re.Pattern, value) -> bool:
     return isinstance(value, str) and pattern.fullmatch(value) is not None
 
 
+def _validate_candidate_runtime_config(value) -> dict:
+    if (
+        not isinstance(value, dict)
+        or value.get("Volumes") is not None
+        or value.get("Healthcheck") is not None
+    ):
+        raise ValueError("candidate image runtime configuration is invalid")
+    return value
+
+
 def _require_trusted_executable(path: str) -> None:
     executable = Path(path)
     if executable not in {Path(_TRUSTED_GIT), Path(_TRUSTED_DOCKER)}:
@@ -296,8 +306,9 @@ def verify_candidate(
     parent_labels = ((parent_document.get("Config") or {}).get("Labels") or {})
     parent_layers = ((parent_document.get("RootFS") or {}).get("Layers") or [])
     candidate_layers = ((image_document.get("RootFS") or {}).get("Layers") or [])
-    labels = ((image_document.get("Config") or {}).get("Labels") or {})
-    entrypoint = ((image_document.get("Config") or {}).get("Entrypoint") or [])
+    image_config = _validate_candidate_runtime_config(image_document.get("Config"))
+    labels = image_config.get("Labels") or {}
+    entrypoint = image_config.get("Entrypoint") or []
     image_id = image_document.get("Id")
     if (
         image_id != oci_report["config_digest"]
@@ -436,6 +447,7 @@ def verify_candidate(
             containment_checks=containment_report["checks"],
             include_purelib=True,
             session=session,
+            arguments=(subject.document["sbom_generator_sha256"],),
         )
         validate_capability_receipt(observation, manifest)
         sbom = _run_image_json(
@@ -543,7 +555,15 @@ def _run_image_json(
     containment_checks: dict[str, bool],
     include_purelib: bool,
     session: VerificationSession,
+    arguments: tuple[str, ...] = (),
 ) -> dict:
+    if any(
+        not isinstance(value, str)
+        or not value
+        or len(value) > 4096
+        for value in arguments
+    ):
+        raise ValueError("candidate image probe arguments are invalid")
     bootstrap = (
         _IMAGE_PURELIB_SCRIPT_BOOTSTRAP
         if include_purelib
@@ -558,7 +578,7 @@ def _run_image_json(
     command = [
         _TRUSTED_DOCKER, "run", "--pull=never", "--name", container,
         *session.label_arguments(),
-        "--network", "none", "--read-only",
+        "--network", "none", "--read-only", "--no-healthcheck",
         "--user", "65532:65532", "--cap-drop", "ALL",
         "--security-opt", "no-new-privileges", "--memory", "6g",
         *optional_limits,
@@ -567,7 +587,7 @@ def _run_image_json(
         "--tmpfs",
         "/tmp:rw,noexec,nosuid,nodev,size=268435456,uid=65532,gid=65532,mode=0700",
         "--entrypoint", "python",
-        image, "-I", "-S", "-B", "-c", bootstrap, script,
+        image, "-I", "-S", "-B", "-c", bootstrap, script, *arguments,
     ]
     try:
         completed = _run_bounded_command(

--- a/batch-runner/sandbox/v2/verify_candidate.py
+++ b/batch-runner/sandbox/v2/verify_candidate.py
@@ -1077,6 +1077,12 @@ def _verify_license_evidence_files(
             path = item["path"]
             if path is None:
                 continue
+            if item["resolved_path"] is None:
+                if item["source"] != "debian-copyright-path-unverifiable":
+                    raise ValueError(
+                        "candidate unresolved license evidence source is invalid"
+                    )
+                continue
             candidate = PurePosixPath(path)
             roots = [
                 PurePosixPath(root)

--- a/batch-runner/sandbox/v2/verify_candidate.py
+++ b/batch-runner/sandbox/v2/verify_candidate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import io
 import json
 import math
 import os
@@ -13,6 +14,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 import uuid
@@ -71,6 +73,12 @@ _LICENSE_EVIDENCE_ROOTS = (
     "/usr/lib/R/library",
     "/var/lib/dpkg",
 )
+_LICENSE_EVIDENCE_ARCHIVE_ROOTS = frozenset({
+    "/usr/share/doc",
+    "/usr/share/nodejs/npm",
+})
+_LICENSE_EVIDENCE_ARCHIVE_MAX_BYTES = 64 * 1024 * 1024
+_LICENSE_EVIDENCE_ARCHIVE_MAX_MEMBERS = 100_000
 _IMAGE_STDLIB_SCRIPT_BOOTSTRAP = (
     "import runpy,sys;"
     "script=sys.argv[1];sys.argv=sys.argv[1:];"
@@ -1154,6 +1162,35 @@ def _verify_license_evidence_files(
         with tempfile.TemporaryDirectory(prefix="phase1c-license-files-") as temporary:
             temporary_root = Path(temporary)
             for index, (source_root, records) in enumerate(sorted(grouped.items())):
+                if source_root in _LICENSE_EVIDENCE_ARCHIVE_ROOTS:
+                    copied = _run_bounded_command(
+                        [
+                            _TRUSTED_DOCKER,
+                            "container",
+                            "cp",
+                            f"{container}:{source_root}/.",
+                            "-",
+                        ],
+                        timeout=AGENTIC_V2_EVIDENCE_ROOT_COPY_TIMEOUT_SECONDS,
+                        stdout_limit=_LICENSE_EVIDENCE_ARCHIVE_MAX_BYTES,
+                        stderr_limit=64 * 1024,
+                    )
+                    if (
+                        copied.returncode != 0
+                        or not copied.stdout
+                        or copied.stderr
+                    ):
+                        raise RuntimeError(
+                            "candidate license evidence root archive failed"
+                        )
+                    _verify_evidence_archive(
+                        copied.stdout,
+                        {
+                            identity[3]: (identity[0], identity[1])
+                            for _path, identity in records
+                        },
+                    )
+                    continue
                 destination = temporary_root / f"root-{index}"
                 destination.mkdir(mode=0o700)
                 copied = _run_bounded_command(
@@ -1179,6 +1216,91 @@ def _verify_license_evidence_files(
                     )
     finally:
         _remove_container(container)
+
+
+def _verify_evidence_archive(
+    value: bytes,
+    expected: dict[str, tuple[str, int]],
+) -> None:
+    if not value or len(value) > _LICENSE_EVIDENCE_ARCHIVE_MAX_BYTES or not expected:
+        raise ValueError("candidate license evidence archive size is invalid")
+    try:
+        with tarfile.open(fileobj=io.BytesIO(value), mode="r:") as archive:
+            members = archive.getmembers()
+            if len(members) > _LICENSE_EVIDENCE_ARCHIVE_MAX_MEMBERS:
+                raise ValueError("candidate license evidence archive is too large")
+            indexed = {}
+            for member in members:
+                if member.name == ".":
+                    raw_name = "."
+                elif member.name.startswith("./"):
+                    raw_name = member.name[2:]
+                else:
+                    raw_name = member.name
+                path = PurePosixPath(raw_name)
+                canonical_name = str(path)
+                if (
+                    not raw_name
+                    or path.is_absolute()
+                    or ".." in path.parts
+                    or len(raw_name) > 4096
+                    or canonical_name != raw_name
+                    or canonical_name in indexed
+                ):
+                    raise ValueError(
+                        "candidate license evidence archive member is invalid"
+                    )
+                indexed[canonical_name] = member
+            for relative, (expected_sha256, expected_size) in expected.items():
+                path = PurePosixPath(relative)
+                if (
+                    path.is_absolute()
+                    or ".." in path.parts
+                    or str(path) != relative
+                ):
+                    raise ValueError(
+                        "candidate license evidence archive path is invalid"
+                    )
+                for parent in path.parents:
+                    if parent == PurePosixPath("."):
+                        continue
+                    parent_member = indexed.get(str(parent))
+                    if parent_member is None or not parent_member.isdir():
+                        raise ValueError(
+                            "candidate license evidence archive parent is invalid"
+                        )
+                member = indexed.get(relative)
+                if (
+                    member is None
+                    or not member.isfile()
+                    or member.size != expected_size
+                ):
+                    raise ValueError(
+                        "candidate license evidence archive file identity differs"
+                    )
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise ValueError(
+                        "candidate license evidence archive file is unavailable"
+                    )
+                digest = hashlib.sha256()
+                total = 0
+                while True:
+                    chunk = stream.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+                    total += len(chunk)
+                    if total > expected_size:
+                        raise ValueError(
+                            "candidate license evidence archive file size differs"
+                        )
+                if total != expected_size or digest.hexdigest() != expected_sha256:
+                    raise ValueError(
+                        "candidate license evidence archive file digest differs"
+                    )
+    except tarfile.TarError as exc:
+        raise ValueError("candidate license evidence archive is invalid") from exc
 
 
 def _verify_copied_evidence_file(

--- a/batch-runner/schemas/agentic-v2-license-report.schema.json
+++ b/batch-runner/schemas/agentic-v2-license-report.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GDPVal Agentic Sandbox V2 Phase 1C License Report",
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "imageDigest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "counts": {
+      "type": "object",
+      "required": ["ambiguous", "denied", "exception", "missing_metadata", "resolved", "unverifiable"],
+      "properties": {
+        "ambiguous": {"type": "integer", "minimum": 0},
+        "denied": {"type": "integer", "minimum": 0},
+        "exception": {"type": "integer", "minimum": 0},
+        "missing_metadata": {"type": "integer", "minimum": 0},
+        "resolved": {"type": "integer", "minimum": 0},
+        "unverifiable": {"type": "integer", "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["source", "path", "resolved_path", "sha256", "size"],
+      "properties": {
+        "source": {"type": "string", "minLength": 1},
+        "path": {"type": ["string", "null"]},
+        "resolved_path": {"type": ["string", "null"]},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "size": {"type": "integer", "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "exception": {
+      "type": "object",
+      "required": ["ecosystem", "package", "version", "purl", "normalized_expression", "evidence_sha256", "reason", "approver", "expires_at"],
+      "properties": {
+        "ecosystem": {"enum": ["debian", "python", "r", "npm"]},
+        "package": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "purl": {"type": "string", "pattern": "^pkg:"},
+        "normalized_expression": {"type": "string", "minLength": 1},
+        "evidence_sha256": {"$ref": "#/$defs/sha256"},
+        "reason": {"type": "string", "minLength": 1},
+        "approver": {"type": "string", "minLength": 1},
+        "expires_at": {"type": "string", "format": "date"}
+      },
+      "allOf": [
+        {"if": {"properties": {"ecosystem": {"const": "debian"}}}, "then": {"properties": {"purl": {"pattern": "^pkg:deb/debian/"}}}},
+        {"if": {"properties": {"ecosystem": {"const": "python"}}}, "then": {"properties": {"purl": {"pattern": "^pkg:pypi/"}}}},
+        {"if": {"properties": {"ecosystem": {"const": "r"}}}, "then": {"properties": {"purl": {"pattern": "^pkg:cran/"}}}},
+        {"if": {"properties": {"ecosystem": {"const": "npm"}}}, "then": {"properties": {"purl": {"pattern": "^pkg:npm/"}}}}
+      ],
+      "additionalProperties": false
+    },
+    "decision": {
+      "type": "object",
+      "required": ["ecosystem", "package", "version", "purl", "classification", "normalized_expression", "raw_values", "normalization_reason", "denied_identifiers", "evidence", "evidence_sha256", "exception"],
+      "properties": {
+        "ecosystem": {"enum": ["debian", "python", "r", "npm"]},
+        "package": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "purl": {"type": "string", "pattern": "^pkg:"},
+        "classification": {"enum": ["resolved", "missing_metadata", "ambiguous", "unverifiable", "denied", "exception"]},
+        "normalized_expression": {"type": ["string", "null"]},
+        "raw_values": {"type": "array", "items": {"type": "string"}},
+        "normalization_reason": {"type": "string", "minLength": 1},
+        "denied_identifiers": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "evidence": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/evidence"}},
+        "evidence_sha256": {"$ref": "#/$defs/sha256"},
+        "exception": {"oneOf": [{"type": "null"}, {"$ref": "#/$defs/exception"}]}
+      },
+      "allOf": [
+        {"if": {"properties": {"ecosystem": {"const": "debian"}}}, "then": {"properties": {"purl": {"pattern": "^pkg:deb/debian/"}}}},
+        {"if": {"properties": {"ecosystem": {"const": "python"}}}, "then": {"properties": {"purl": {"pattern": "^pkg:pypi/"}}}},
+        {"if": {"properties": {"ecosystem": {"const": "r"}}}, "then": {"properties": {"purl": {"pattern": "^pkg:cran/"}}}},
+        {"if": {"properties": {"ecosystem": {"const": "npm"}}}, "then": {"properties": {"purl": {"pattern": "^pkg:npm/"}}}}
+      ],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "required": ["schema_version", "policy_id", "foundation_only", "production_activation", "status", "binding", "package_count", "counts", "unresolved_count", "ecosystem_counts", "exceptions", "decisions", "decisions_sha256", "report_sha256"],
+  "properties": {
+    "schema_version": {"const": "2.0"},
+    "policy_id": {"const": "agentic-v2-license-v2"},
+    "foundation_only": {"const": true},
+    "production_activation": {"const": "disabled"},
+    "status": {"enum": ["verified", "failed"]},
+    "binding": {
+      "type": "object",
+      "required": ["subject_sha256", "image_id", "config_digest", "oci_manifest_digest", "source_revision", "effective_sbom_sha256", "license_evidence_sha256", "license_collector_sha256", "license_evaluator_sha256", "license_evaluator_packaging_version", "license_evaluator_parser_sha256", "license_evaluator_python_version", "license_evaluator_callable_sha256", "license_evaluator_runtime_graph_sha256", "license_evaluator_spdx_version", "license_evaluator_spdx_sha256", "policy_sha256"],
+      "properties": {
+        "subject_sha256": {"$ref": "#/$defs/sha256"},
+        "image_id": {"$ref": "#/$defs/imageDigest"},
+        "config_digest": {"$ref": "#/$defs/imageDigest"},
+        "oci_manifest_digest": {"$ref": "#/$defs/imageDigest"},
+        "source_revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "effective_sbom_sha256": {"$ref": "#/$defs/sha256"},
+        "license_evidence_sha256": {"$ref": "#/$defs/sha256"},
+        "license_collector_sha256": {"$ref": "#/$defs/sha256"},
+        "license_evaluator_sha256": {"$ref": "#/$defs/sha256"},
+        "license_evaluator_packaging_version": {"const": "26.2"},
+        "license_evaluator_parser_sha256": {"const": "fc9c745d1883ff9f296a5b169f22eb2ee879f59a4608f20f5cb29d668f4e26f4"},
+        "license_evaluator_python_version": {"const": "3.10.12"},
+        "license_evaluator_callable_sha256": {"const": "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"},
+        "license_evaluator_runtime_graph_sha256": {"const": "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"},
+        "license_evaluator_spdx_version": {"const": "3.27.0"},
+        "license_evaluator_spdx_sha256": {"const": "ecc082fdc1fcdcae47b2f56c4ce2cdc2c9d6d54ca555a09814abd78dece7a230"},
+        "policy_sha256": {"$ref": "#/$defs/sha256"}
+      },
+      "additionalProperties": false
+    },
+    "package_count": {"type": "integer", "minimum": 1},
+    "counts": {"$ref": "#/$defs/counts"},
+    "unresolved_count": {"type": "integer", "minimum": 0},
+    "ecosystem_counts": {
+      "type": "object",
+      "required": ["debian", "python", "r", "npm"],
+      "properties": {
+        "debian": {"$ref": "#/$defs/counts"},
+        "python": {"$ref": "#/$defs/counts"},
+        "r": {"$ref": "#/$defs/counts"},
+        "npm": {"$ref": "#/$defs/counts"}
+      },
+      "additionalProperties": false
+    },
+    "exceptions": {"type": "array", "items": {"$ref": "#/$defs/exception"}},
+    "decisions": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/decision"}},
+    "decisions_sha256": {"$ref": "#/$defs/sha256"},
+    "report_sha256": {"$ref": "#/$defs/sha256"}
+  },
+  "additionalProperties": false
+}

--- a/batch-runner/schemas/agentic-v2-license-report.schema.json
+++ b/batch-runner/schemas/agentic-v2-license-report.schema.json
@@ -101,7 +101,7 @@
         "license_evaluator_packaging_version": {"const": "26.2"},
         "license_evaluator_parser_sha256": {"const": "fc9c745d1883ff9f296a5b169f22eb2ee879f59a4608f20f5cb29d668f4e26f4"},
         "license_evaluator_python_version": {"const": "3.10.12"},
-        "license_evaluator_callable_sha256": {"const": "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"},
+        "license_evaluator_callable_sha256": {"const": "825f97f04b9b94c048326625a7e56b6a0960b196964dabcf4ba7ad3e8e9b3056"},
         "license_evaluator_runtime_graph_sha256": {"const": "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"},
         "license_evaluator_spdx_version": {"const": "3.27.0"},
         "license_evaluator_spdx_sha256": {"const": "ecc082fdc1fcdcae47b2f56c4ce2cdc2c9d6d54ca555a09814abd78dece7a230"},

--- a/batch-runner/security/agentic-v2-supply-chain-policy.json
+++ b/batch-runner/security/agentic-v2-supply-chain-policy.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "policy_id": "agentic-v2-phase1b-candidate-v1",
+  "policy_id": "agentic-v2-phase1c-candidate-v1",
   "foundation_only": true,
   "production_activation": "disabled",
   "required_evidence": [
@@ -21,10 +21,13 @@
     "exceptions_require": ["cve", "purl", "reason", "approver", "expires_at"]
   },
   "license": {
-    "policy_id": "agentic-v2-license-v1",
+    "policy_id": "agentic-v2-license-v2",
+    "as_of_date": "2026-07-31",
     "unknown_is_failure": true,
+    "unknown_classifications": ["ambiguous", "missing_metadata", "unverifiable"],
     "denied_identifiers": ["BUSL-1.1", "Commons-Clause", "SSPL-1.0"],
-    "exceptions_require": ["purl", "license", "reason", "approver", "expires_at"]
+    "exceptions_require": ["ecosystem", "package", "version", "purl", "normalized_expression", "evidence_sha256", "reason", "approver", "expires_at"],
+    "exceptions": []
   },
   "signature": {
     "profile": "cosign-offline-v1",

--- a/batch-runner/tests/fixtures/agentic_v2_phase1c_license_cases.json
+++ b/batch-runner/tests/fixtures/agentic_v2_phase1c_license_cases.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "1.0",
+  "cases": [
+    {
+      "id": "debian-or",
+      "ecosystem": "debian",
+      "raw_values": ["GPL-2+ or BSD-3-clause"],
+      "metadata": {"architecture": "amd64", "copyright_format": "fixture"},
+      "expected_classification": "resolved",
+      "expected_expression": "(BSD-3-Clause) OR (GPL-2.0-or-later)"
+    },
+    {
+      "id": "debian-with",
+      "ecosystem": "debian",
+      "raw_values": ["GPL-2+ with Bison exception"],
+      "metadata": {"architecture": "amd64", "copyright_format": "fixture"},
+      "expected_classification": "resolved",
+      "expected_expression": "GPL-2.0-or-later WITH Bison-exception-2.2"
+    },
+    {
+      "id": "python-compatible-composite",
+      "ecosystem": "python",
+      "raw_values": [
+        "MIT OR Apache-2.0",
+        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License"
+      ],
+      "metadata": {
+        "license_expression": null,
+        "license": "MIT OR Apache-2.0",
+        "classifiers": [
+          "License :: OSI Approved :: Apache Software License",
+          "License :: OSI Approved :: MIT License"
+        ]
+      },
+      "expected_classification": "resolved",
+      "expected_expression": "MIT OR Apache-2.0"
+    },
+    {
+      "id": "python-generic-bsd",
+      "ecosystem": "python",
+      "raw_values": ["License :: OSI Approved :: BSD License"],
+      "metadata": {
+        "license_expression": null,
+        "license": null,
+        "classifiers": ["License :: OSI Approved :: BSD License"]
+      },
+      "expected_classification": "ambiguous",
+      "expected_expression": null
+    },
+    {
+      "id": "python-missing",
+      "ecosystem": "python",
+      "raw_values": [],
+      "metadata": {"license_expression": null, "license": null, "classifiers": []},
+      "expected_classification": "missing_metadata",
+      "expected_expression": null
+    },
+    {
+      "id": "npm-custom",
+      "ecosystem": "npm",
+      "raw_values": ["Vendor-Custom"],
+      "metadata": {"license": "Vendor-Custom"},
+      "expected_classification": "unverifiable",
+      "expected_expression": null
+    },
+    {
+      "id": "python-denied",
+      "ecosystem": "python",
+      "raw_values": ["Commons-Clause"],
+      "metadata": {"license_expression": null, "license": "Commons-Clause", "classifiers": []},
+      "expected_classification": "denied",
+      "expected_expression": null
+    },
+    {
+      "id": "r-runtime",
+      "ecosystem": "r",
+      "raw_values": ["Part of R 4.2.2", "GPL-2"],
+      "metadata": {
+        "declared_license": "Part of R 4.2.2",
+        "priority": "base",
+        "runtime_license": "",
+        "runtime_license_fields": ["GPL-2"],
+        "runtime_version": "4.2.2"
+      },
+      "expected_classification": "resolved",
+      "expected_expression": "GPL-2.0-only"
+    },
+    {
+      "id": "python-exception",
+      "ecosystem": "python",
+      "raw_values": ["Reviewed-Custom"],
+      "metadata": {"license_expression": null, "license": "Reviewed-Custom", "classifiers": []},
+      "expected_classification": "exception",
+      "expected_expression": "MIT"
+    }
+  ]
+}

--- a/batch-runner/tests/test_agentic_v2_candidate_verifier.py
+++ b/batch-runner/tests/test_agentic_v2_candidate_verifier.py
@@ -808,6 +808,101 @@ def test_host_rejects_symlinked_copied_license_evidence(tmp_path):
         )
 
 
+def _license_archive(
+    relative: str,
+    value: bytes,
+    *,
+    parent_symlink: bool = False,
+    duplicate: bool = False,
+) -> bytes:
+    output = verifier.io.BytesIO()
+    with verifier.tarfile.open(fileobj=output, mode="w:") as archive:
+        root = verifier.tarfile.TarInfo(".")
+        root.type = verifier.tarfile.DIRTYPE
+        archive.addfile(root)
+        parents = [
+            parent
+            for parent in verifier.PurePosixPath(relative).parents
+            if parent != verifier.PurePosixPath(".")
+        ]
+        for parent in reversed(parents):
+            member = verifier.tarfile.TarInfo(f"./{parent}")
+            if parent_symlink and parent == parents[0]:
+                member.type = verifier.tarfile.SYMTYPE
+                member.linkname = "../../outside"
+            else:
+                member.type = verifier.tarfile.DIRTYPE
+            archive.addfile(member)
+        for _index in range(2 if duplicate else 1):
+            member = verifier.tarfile.TarInfo(f"./{relative}")
+            member.size = len(value)
+            archive.addfile(member, verifier.io.BytesIO(value))
+        unrelated = verifier.tarfile.TarInfo("./unrelated")
+        unrelated.type = verifier.tarfile.SYMTYPE
+        unrelated.linkname = "../../outside"
+        archive.addfile(unrelated)
+    return output.getvalue()
+
+
+def _archive_with_alias(alias: str) -> bytes:
+    output = verifier.io.BytesIO()
+    with verifier.tarfile.open(fileobj=output, mode="w:") as archive:
+        for name in (".", "./package"):
+            member = verifier.tarfile.TarInfo(name)
+            member.type = verifier.tarfile.DIRTYPE
+            archive.addfile(member)
+        for name in ("./package/LICENSE", alias):
+            value = b"MIT\n"
+            member = verifier.tarfile.TarInfo(name)
+            member.size = len(value)
+            archive.addfile(member, verifier.io.BytesIO(value))
+    return output.getvalue()
+
+
+def test_host_reopens_expected_archive_member_without_extracting_symlinks():
+    value = b"SSPL-1.0\n"
+    archive = _license_archive("package/LICENSE", value)
+    expected = {
+        "package/LICENSE": (
+            __import__("hashlib").sha256(value).hexdigest(),
+            len(value),
+        ),
+    }
+
+    verifier._verify_evidence_archive(archive, expected)
+
+    with pytest.raises(ValueError, match="digest differs"):
+        verifier._verify_evidence_archive(
+            archive,
+            {"package/LICENSE": ("0" * 64, len(value))},
+        )
+    with pytest.raises(ValueError, match="parent is invalid"):
+        verifier._verify_evidence_archive(
+            _license_archive("package/LICENSE", value, parent_symlink=True),
+            expected,
+        )
+    with pytest.raises(ValueError, match="member is invalid"):
+        verifier._verify_evidence_archive(
+            _license_archive("package/LICENSE", value, duplicate=True),
+            expected,
+        )
+    for alias in (
+        "package//LICENSE",
+        "package/./LICENSE",
+        "././package/LICENSE",
+    ):
+        with pytest.raises(ValueError, match="member is invalid"):
+            verifier._verify_evidence_archive(
+                _archive_with_alias(alias),
+                {
+                    "package/LICENSE": (
+                        __import__("hashlib").sha256(b"MIT\n").hexdigest(),
+                        4,
+                    ),
+                },
+            )
+
+
 def test_host_reopens_all_exact_image_evidence_roots(monkeypatch):
     import hashlib
 
@@ -817,6 +912,7 @@ def test_host_reopens_all_exact_image_evidence_roots(monkeypatch):
             "/usr/local/lib/python3.11/site-packages/"
             "fixture-1.0.dist-info/METADATA"
         ): b"Name: fixture\nVersion: 1.0\n",
+        "/usr/share/doc/fixture/copyright": b"License: MIT\n",
     }
     document = {
         "records": [{
@@ -844,6 +940,16 @@ def test_host_reopens_all_exact_image_evidence_roots(monkeypatch):
             )
         assert command[1:3] == ["container", "cp"]
         source = command[-2].split(":", 1)[1].removesuffix("/.")
+        if command[-1] == "-":
+            assert source == "/usr/share/doc"
+            return SimpleNamespace(
+                returncode=0,
+                stdout=_license_archive(
+                    "fixture/copyright",
+                    values["/usr/share/doc/fixture/copyright"],
+                ),
+                stderr=b"",
+            )
         destination = Path(command[-1])
         for path, value in values.items():
             if path == source or path.startswith(source + "/"):
@@ -876,6 +982,7 @@ def test_host_reopens_all_exact_image_evidence_roots(monkeypatch):
     assert copied_roots == {
         "/var/lib/dpkg",
         "/usr/local/lib/python3.11/site-packages",
+        "/usr/share/doc",
     }
     assert session.label_arguments()[1] in commands[0]
     assert len(removed) == 1

--- a/batch-runner/tests/test_agentic_v2_candidate_verifier.py
+++ b/batch-runner/tests/test_agentic_v2_candidate_verifier.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import inspect
+import os
+from pathlib import Path
+import subprocess
+import sys
 from types import SimpleNamespace
+import venv
 
 import pytest
 
@@ -14,6 +19,31 @@ _DISABLED_ENTRYPOINT_STDERR = (
     b'{"error":"agentic_v2_phase1b_candidate_not_activated",'
     b'"foundation_only":true,"production_activation":"disabled"}\n'
 )
+
+
+def _session():
+    return verifier.VerificationSession("a" * 32)
+
+
+def test_verification_sessions_are_explicit_and_independent(monkeypatch):
+    first = verifier.VerificationSession("a" * 32)
+    second = verifier.VerificationSession("b" * 32)
+    monkeypatch.setattr(verifier.uuid, "uuid4", lambda: SimpleNamespace(hex="c" * 32))
+
+    assert first.label_arguments() != second.label_arguments()
+    assert first.container_name("evidence") != second.container_name("evidence")
+    with pytest.raises(ValueError, match="session identity"):
+        verifier.VerificationSession("missing")
+
+
+def test_verify_candidate_requires_explicit_session_id(tmp_path):
+    with pytest.raises(TypeError):
+        verifier.verify_candidate(
+            image="candidate:test",
+            source_revision="a" * 40,
+            oci_layout=tmp_path / "oci",
+            output_directory=tmp_path / "evidence",
+        )
 
 
 def test_candidate_verifier_refuses_credential_environment(monkeypatch):
@@ -42,15 +72,15 @@ def test_containment_report_separates_collection_from_production(monkeypatch):
     monkeypatch.setattr(
         verifier,
         "_docker_base_isolation_probe",
-        lambda _image: (dict(checks), dict(collection)),
+        lambda _image, *, session: (dict(checks), dict(collection)),
     )
     monkeypatch.setattr(
         verifier,
         "_docker_resource_limit_probe",
-        lambda _image, *, name, arguments: False,
+        lambda _image, *, name, arguments, session: False,
     )
 
-    report = verifier._inspect_containment("candidate:test")
+    report = verifier._inspect_containment("candidate:test", session=_session())
 
     assert report["schema_version"] == "1.1"
     assert report["status"] == "failed"
@@ -99,8 +129,8 @@ def test_containment_probe_rejects_incomplete_runtime_observation(monkeypatch):
         lambda _command: [{"Config": {}, "HostConfig": {}}],
     )
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: SimpleNamespace(
             returncode=0,
             stdout=b'{"memory_limit":true}',
@@ -108,7 +138,9 @@ def test_containment_probe_rejects_incomplete_runtime_observation(monkeypatch):
         ),
     )
 
-    checks, collection = verifier._docker_base_isolation_probe("candidate:test")
+    checks, collection = verifier._docker_base_isolation_probe(
+        "candidate:test", session=_session()
+    )
 
     assert not any(checks.values())
     assert not any(collection.values())
@@ -174,8 +206,8 @@ def test_resource_warning_overrides_forged_runtime_check(monkeypatch):
     checks = {name: True for name in verifier._CONTAINMENT_CHECKS}
     monkeypatch.setattr(verifier, "_remove_container", lambda _name: None)
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: SimpleNamespace(
             returncode=0,
             stdout=__import__("json").dumps(checks).encode("utf-8"),
@@ -187,6 +219,7 @@ def test_resource_warning_overrides_forged_runtime_check(monkeypatch):
         "candidate:test",
         name="pids_limit",
         arguments=["--pids-limit", "16"],
+        session=_session(),
     ) is False
 
 
@@ -194,8 +227,8 @@ def test_unknown_docker_warning_blocks_evidence_collection(monkeypatch):
     checks = {name: True for name in verifier._CONTAINMENT_CHECKS}
     monkeypatch.setattr(verifier, "_remove_container", lambda _name: None)
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: SimpleNamespace(
             returncode=0,
             stdout=__import__("json").dumps(checks).encode("utf-8"),
@@ -207,6 +240,7 @@ def test_unknown_docker_warning_blocks_evidence_collection(monkeypatch):
         "candidate:test",
         name="pids_limit",
         arguments=["--pids-limit", "16"],
+        session=_session(),
     ) is False
 
 
@@ -214,8 +248,8 @@ def test_mixed_resource_and_unknown_warning_blocks_evidence_collection(monkeypat
     checks = {name: True for name in verifier._CONTAINMENT_CHECKS}
     monkeypatch.setattr(verifier, "_remove_container", lambda _name: None)
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: SimpleNamespace(
             returncode=0,
             stdout=__import__("json").dumps(checks).encode("utf-8"),
@@ -227,6 +261,7 @@ def test_mixed_resource_and_unknown_warning_blocks_evidence_collection(monkeypat
         "candidate:test",
         name="pids_limit",
         arguments=["--pids-limit", "16"],
+        session=_session(),
     ) is False
 
 
@@ -247,7 +282,7 @@ def test_verifier_uses_inspected_image_id_for_candidate_operations():
     source = inspect.getsource(verifier.verify_candidate)
 
     assert "_verify_embedded_files(\n        image_id" in source
-    assert source.count("_run_image_json(\n            image_id") == 2
+    assert source.count("_run_image_json(\n            image_id") == 3
 
 
 def test_container_cleanup_accepts_confirmed_absence(monkeypatch):
@@ -260,8 +295,8 @@ def test_container_cleanup_accepts_confirmed_absence(monkeypatch):
         ),
     ])
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: next(results),
     )
 
@@ -274,8 +309,8 @@ def test_container_cleanup_rejects_remaining_container(monkeypatch):
         SimpleNamespace(returncode=0, stderr=b""),
     ])
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: next(results),
     )
 
@@ -289,8 +324,8 @@ def test_container_cleanup_rejects_ambiguous_daemon_failure(monkeypatch):
         SimpleNamespace(returncode=1, stderr=b"connection refused"),
     ])
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: next(results),
     )
 
@@ -304,8 +339,8 @@ def test_container_cleanup_rejects_wrong_object_name(monkeypatch):
         SimpleNamespace(returncode=1, stderr=b"Error: No such object: other"),
     ])
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: next(results),
     )
 
@@ -362,18 +397,39 @@ def test_container_cleanup_inspects_after_remove_timeout(monkeypatch):
             stderr=f"Error: No such object: {container}".encode("utf-8"),
         )
 
-    monkeypatch.setattr(verifier.subprocess, "run", run)
+    monkeypatch.setattr(verifier, "_run_bounded_command", run)
 
     verifier._remove_container(container)
 
-    assert calls[-1][:3] == ["docker", "container", "inspect"]
+    assert calls[-1][:3] == [verifier._TRUSTED_DOCKER, "container", "inspect"]
+
+
+def test_container_cleanup_inspects_after_remove_output_overflow(monkeypatch):
+    container = "a" * 64
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        if command[2] == "rm":
+            raise RuntimeError("candidate stderr exceeds size limit")
+        return SimpleNamespace(
+            returncode=1,
+            stdout=b"",
+            stderr=f"Error: No such object: {container}".encode("utf-8"),
+        )
+
+    monkeypatch.setattr(verifier, "_run_bounded_command", run)
+
+    verifier._remove_container(container)
+
+    assert calls[-1][:3] == [verifier._TRUSTED_DOCKER, "container", "inspect"]
 
 
 def test_verifier_disabled_entrypoint_cleans_up_on_timeout(monkeypatch):
     cleaned = []
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda command, **kwargs: (_ for _ in ()).throw(
             verifier.subprocess.TimeoutExpired(command, 30)
         ),
@@ -388,6 +444,7 @@ def test_verifier_disabled_entrypoint_cleans_up_on_timeout(monkeypatch):
         verifier._verify_disabled_entrypoint(
             "sha256:" + "a" * 64,
             containment_checks={name: False for name in verifier._CONTAINMENT_CHECKS},
+            session=_session(),
         )
 
     assert len(cleaned) == 1
@@ -412,8 +469,8 @@ def test_disabled_entrypoint_rejects_non_exact_output(
 ):
     monkeypatch.setattr(verifier, "_remove_container", lambda _name: None)
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: SimpleNamespace(
             returncode=returncode,
             stdout=stdout,
@@ -425,14 +482,15 @@ def test_disabled_entrypoint_rejects_non_exact_output(
         verifier._verify_disabled_entrypoint(
             "sha256:" + "a" * 64,
             containment_checks={name: False for name in verifier._CONTAINMENT_CHECKS},
+            session=_session(),
         )
 
 
 def test_disabled_entrypoint_accepts_exact_output(monkeypatch):
     monkeypatch.setattr(verifier, "_remove_container", lambda _name: None)
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
+        verifier,
+        "_run_bounded_command",
         lambda *args, **kwargs: SimpleNamespace(
             returncode=78,
             stdout=b"",
@@ -443,6 +501,7 @@ def test_disabled_entrypoint_accepts_exact_output(monkeypatch):
     verifier._verify_disabled_entrypoint(
         "sha256:" + "a" * 64,
         containment_checks={name: False for name in verifier._CONTAINMENT_CHECKS},
+        session=_session(),
     )
 
 
@@ -456,12 +515,360 @@ def test_candidate_runs_disable_pull_fallback():
         assert '"--pull=never"' in inspect.getsource(function)
 
 
+def test_all_docker_output_uses_bounded_runner():
+    for function in (
+        verifier._docker_base_isolation_probe,
+        verifier._docker_resource_limit_probe,
+        verifier._docker_json,
+        verifier._verify_disabled_entrypoint,
+        verifier._verify_embedded_files,
+        verifier._require_local_docker,
+        verifier._remove_container,
+    ):
+        source = inspect.getsource(function)
+        assert "_run_bounded_command(" in source
+        assert "subprocess.run(" not in source
+
+
+def test_license_collector_uses_site_disabled_python(monkeypatch):
+    commands = []
+    monkeypatch.setattr(
+        verifier,
+        "_run_bounded_command",
+        lambda command, **kwargs: (
+            commands.append(command)
+            or SimpleNamespace(returncode=0, stdout=b"{}", stderr=b"")
+        ),
+    )
+    monkeypatch.setattr(verifier, "_remove_container", lambda _name: None)
+
+    verifier._run_image_json(
+        "sha256:" + "a" * 64,
+        "/opt/gdpval/v2/license_evidence.py",
+        1024,
+        containment_checks={name: False for name in verifier._CONTAINMENT_CHECKS},
+        include_purelib=False,
+        session=_session(),
+    )
+
+    assert commands[0][-7:] == [
+        "sha256:" + "a" * 64,
+        "-I",
+        "-S",
+        "-B",
+        "-c",
+        verifier._IMAGE_STDLIB_SCRIPT_BOOTSTRAP,
+        "/opt/gdpval/v2/license_evidence.py",
+    ]
+
+
+def test_all_image_json_probes_require_no_site(monkeypatch):
+    commands = []
+    monkeypatch.setattr(
+        verifier,
+        "_run_bounded_command",
+        lambda command, **kwargs: (
+            commands.append(command)
+            or SimpleNamespace(returncode=0, stdout=b"{}", stderr=b"")
+        ),
+    )
+    monkeypatch.setattr(verifier, "_remove_container", lambda _name: None)
+
+    for script, include_purelib in (
+        ("/opt/gdpval/v2/image_probe.py", True),
+        ("/opt/gdpval/v2/effective_sbom.py", True),
+        ("/opt/gdpval/v2/license_evidence.py", False),
+    ):
+        verifier._run_image_json(
+            "sha256:" + "a" * 64,
+            script,
+            1024,
+            containment_checks={
+                name: False for name in verifier._CONTAINMENT_CHECKS
+            },
+            include_purelib=include_purelib,
+            session=_session(),
+        )
+
+    assert all(command[-6:-3] == ["-I", "-S", "-B"] for command in commands)
+    assert [command[-2] for command in commands] == [
+        verifier._IMAGE_PURELIB_SCRIPT_BOOTSTRAP,
+        verifier._IMAGE_PURELIB_SCRIPT_BOOTSTRAP,
+        verifier._IMAGE_STDLIB_SCRIPT_BOOTSTRAP,
+    ]
+
+
+def test_containment_probes_use_no_site_python():
+    for function in (
+        verifier._docker_base_isolation_probe,
+        verifier._docker_resource_limit_probe,
+    ):
+        source = inspect.getsource(function)
+        assert 'image, "-I", "-S", "-B", "-c"' in source
+
+
+def test_site_disabled_python_ignores_hostile_startup(tmp_path):
+    marker = tmp_path / "startup-ran"
+    (tmp_path / "sitecustomize.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n",
+        encoding="utf-8",
+    )
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(tmp_path)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-B",
+            "-c",
+            (
+                "import sys;"
+                "assert sys.flags.isolated == 1;"
+                "assert sys.flags.no_site == 1;"
+                "assert sys.dont_write_bytecode"
+            ),
+        ],
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    assert not marker.exists()
+
+
+def test_no_site_flag_blocks_global_pth_startup(tmp_path):
+    environment_root = tmp_path / "venv"
+    venv.EnvBuilder(with_pip=False).create(environment_root)
+    python = environment_root / "bin" / "python"
+    site_packages = (
+        environment_root
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+    marker = tmp_path / "global-pth-ran"
+    (site_packages / "hostile.pth").write_text(
+        f"import pathlib; pathlib.Path({str(marker)!r}).write_text('ran')\n",
+        encoding="utf-8",
+    )
+
+    baseline = subprocess.run(
+        [str(python), "-I", "-B", "-c", "pass"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+    assert baseline.returncode == 0, baseline.stderr.decode(errors="replace")
+    assert marker.exists()
+    marker.unlink()
+
+    isolated = subprocess.run(
+        [str(python), "-I", "-S", "-B", "-c", "pass"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+    assert isolated.returncode == 0, isolated.stderr.decode(errors="replace")
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize("module_name", ["hashlib", "json", "email"])
+def test_appended_purelib_cannot_shadow_stdlib(tmp_path, module_name):
+    shadow_root = tmp_path / "site-packages"
+    shadow_root.mkdir()
+    marker = tmp_path / f"{module_name}-shadow-ran"
+    if module_name == "email":
+        module_path = shadow_root / "email" / "__init__.py"
+        module_path.parent.mkdir()
+    else:
+        module_path = shadow_root / f"{module_name}.py"
+    module_path.write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-B",
+            "-c",
+            "import importlib,sys;sys.path.append(sys.argv[1]);"
+            "module=importlib.import_module(sys.argv[2]);"
+            "assert not module.__file__.startswith(sys.argv[1])",
+            str(shadow_root),
+            module_name,
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    assert not marker.exists()
+
+
+def test_host_reopens_copied_license_evidence_bytes(tmp_path):
+    root = tmp_path / "root"
+    path = root / "package" / "LICENSE"
+    path.parent.mkdir(parents=True)
+    value = b"SSPL-1.0\n"
+    path.write_bytes(value)
+
+    verifier._verify_copied_evidence_file(
+        root,
+        verifier.PurePosixPath("package/LICENSE"),
+        expected_sha256=__import__("hashlib").sha256(value).hexdigest(),
+        expected_size=len(value),
+    )
+
+    with pytest.raises(ValueError, match="digest differs"):
+        verifier._verify_copied_evidence_file(
+            root,
+            verifier.PurePosixPath("package/LICENSE"),
+            expected_sha256="0" * 64,
+            expected_size=len(value),
+        )
+
+
+def test_host_rejects_symlinked_copied_license_evidence(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.write_text("MIT", encoding="utf-8")
+    (root / "LICENSE").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="symlink"):
+        verifier._verify_copied_evidence_file(
+            root,
+            verifier.PurePosixPath("LICENSE"),
+            expected_sha256="0" * 64,
+            expected_size=3,
+        )
+
+
+def test_host_reopens_all_exact_image_evidence_roots(monkeypatch):
+    import hashlib
+
+    values = {
+        "/var/lib/dpkg/status": b"status",
+        (
+            "/usr/local/lib/python3.11/site-packages/"
+            "fixture-1.0.dist-info/METADATA"
+        ): b"Name: fixture\nVersion: 1.0\n",
+    }
+    document = {
+        "records": [{
+            "evidence": [
+                {
+                    "source": "fixture",
+                    "path": path,
+                    "resolved_path": path,
+                    "sha256": hashlib.sha256(value).hexdigest(),
+                    "size": len(value),
+                }
+                for path, value in values.items()
+            ],
+        }],
+    }
+    commands = []
+
+    def run(command, **kwargs):
+        commands.append(command)
+        if command[1:3] == ["container", "create"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=("a" * 64 + "\n").encode(),
+                stderr=b"",
+            )
+        assert command[1:3] == ["container", "cp"]
+        source = command[-2].split(":", 1)[1].removesuffix("/.")
+        destination = Path(command[-1])
+        for path, value in values.items():
+            if path == source or path.startswith(source + "/"):
+                relative = Path(path.removeprefix(source + "/"))
+                target = destination / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(value)
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    removed = []
+    monkeypatch.setattr(verifier, "_run_bounded_command", run)
+    monkeypatch.setattr(
+        verifier,
+        "_remove_container",
+        lambda container: removed.append(container),
+    )
+    session = verifier.VerificationSession("a" * 32)
+
+    verifier._verify_license_evidence_files(
+        "sha256:" + "b" * 64,
+        document,
+        session=session,
+    )
+
+    copied_roots = {
+        command[-2].split(":", 1)[1].removesuffix("/.")
+        for command in commands
+        if command[1:3] == ["container", "cp"]
+    }
+    assert copied_roots == {
+        "/var/lib/dpkg",
+        "/usr/local/lib/python3.11/site-packages",
+    }
+    assert session.label_arguments()[1] in commands[0]
+    assert len(removed) == 1
+
+
+def test_image_json_overflow_still_removes_exact_named_container(monkeypatch):
+    removed = []
+    monkeypatch.setattr(
+        verifier,
+        "_run_bounded_command",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("candidate stdout exceeds size limit")
+        ),
+    )
+    monkeypatch.setattr(
+        verifier,
+        "_remove_container",
+        lambda container: removed.append(container),
+    )
+
+    with pytest.raises(RuntimeError, match="stdout exceeds size limit"):
+        verifier._run_image_json(
+            "sha256:" + "a" * 64,
+            "/opt/gdpval/v2/license_evidence.py",
+            1024,
+            containment_checks={name: False for name in verifier._CONTAINMENT_CHECKS},
+            include_purelib=False,
+            session=_session(),
+        )
+
+    assert len(removed) == 1
+    assert removed[0].startswith("gdpval-agentic-v2-evidence-")
+
+
 def test_embedded_inspection_cleans_up_malformed_create_output(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(
-        verifier.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(stdout="malformed"),
+        verifier,
+        "_run_bounded_command",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0, stdout=b"malformed", stderr=b""
+        ),
     )
     monkeypatch.setattr(
         verifier,
@@ -470,7 +877,12 @@ def test_embedded_inspection_cleans_up_malformed_create_output(monkeypatch, tmp_
     )
 
     with pytest.raises(RuntimeError, match="inspection container identity"):
-        verifier._verify_embedded_files("sha256:" + "a" * 64, "b" * 40, tmp_path)
+        verifier._verify_embedded_files(
+            "sha256:" + "a" * 64,
+            "b" * 40,
+            tmp_path,
+            session=_session(),
+        )
 
     assert len(calls) == 1
     assert calls[0].startswith("gdpval-agentic-v2-inspect-")
@@ -516,6 +928,7 @@ def test_builder_stages_only_requested_git_blobs(tmp_path, monkeypatch):
 
 def test_builder_verifier_allowlist_is_exact():
     assert builder._VERIFIER_PATHS == (
+        "batch-runner/core/agentic_v2_license.py",
         "batch-runner/core/agentic_v2_microvm.py",
         "batch-runner/core/agentic_v2_oci.py",
         "batch-runner/core/agentic_v2_substrate.py",
@@ -533,4 +946,129 @@ def test_git_environments_drop_caller_injection(monkeypatch):
         assert "GIT_DIR" not in environment
         assert "PYTHONPATH" not in environment
         assert "GITHUB_TOKEN" not in environment
+        assert environment["PATH"] == "/usr/bin:/bin"
         assert environment["GIT_CONFIG_NOSYSTEM"] == "1"
+
+
+def test_verifier_ignores_hostile_path_for_repository_git(tmp_path, monkeypatch):
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "fake-git-ran"
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        f"#!/bin/sh\ntouch {str(marker)!r}\nexit 99\n",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+
+    root = verifier._require_repository_root(
+        Path.cwd().parent,
+        "3ecb8ded14b1cc8ab1725ceb41fcb23696a2c0fc",
+    )
+
+    assert root == Path.cwd().parent.resolve()
+    assert not marker.exists()
+
+
+def test_verifier_uses_absolute_trusted_docker(monkeypatch):
+    commands = []
+    monkeypatch.setattr(
+        verifier,
+        "_run_bounded_command",
+        lambda command, **kwargs: (
+            commands.append(command)
+            or SimpleNamespace(
+                returncode=0,
+                stdout=b'"unix:///var/run/docker.sock"\n',
+                stderr=b"",
+            )
+        ),
+    )
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+
+    verifier._require_local_docker()
+
+    assert commands[0][0] == verifier._TRUSTED_DOCKER == "/usr/bin/docker"
+
+
+def test_docker_environments_drop_caller_configuration(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmp_path / "fake-bin"))
+    monkeypatch.setenv("HOME", str(tmp_path / "fake-home"))
+    monkeypatch.setenv("DOCKER_CONFIG", str(tmp_path / "fake-config"))
+    monkeypatch.setenv("DOCKER_CONTEXT", "remote")
+    monkeypatch.setenv("DOCKER_CERT_PATH", str(tmp_path / "certs"))
+    monkeypatch.setenv("DOCKER_TLS_VERIFY", "1")
+    monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+    config = tmp_path / "trusted-config"
+
+    assert verifier._docker_environment() == {
+        "PATH": "/usr/bin:/bin",
+        "HOME": "/nonexistent",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "DOCKER_HOST": "unix:///var/run/docker.sock",
+    }
+    assert builder._docker_cli_environment() == {
+        "PATH": "/usr/bin:/bin",
+        "HOME": "/nonexistent",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "DOCKER_HOST": "unix:///var/run/docker.sock",
+    }
+    assert builder._docker_environment(config) == {
+        "PATH": "/usr/bin:/bin",
+        "HOME": str(tmp_path),
+        "DOCKER_CONFIG": str(config),
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "DOCKER_HOST": "unix:///var/run/docker.sock",
+    }
+
+
+def test_bounded_docker_runner_injects_sanitized_environment(monkeypatch):
+    captured = {}
+
+    class Stop(RuntimeError):
+        pass
+
+    def popen(command, **kwargs):
+        captured["command"] = command
+        captured["environment"] = kwargs.get("env")
+        raise Stop("captured")
+
+    monkeypatch.setattr(verifier.subprocess, "Popen", popen)
+    monkeypatch.setenv("PATH", "/tmp/fake")
+    monkeypatch.setenv("HOME", "/tmp/fake-home")
+    monkeypatch.setenv("DOCKER_CONFIG", "/tmp/fake-config")
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+
+    with pytest.raises(Stop, match="captured"):
+        verifier._run_bounded_command(
+            [verifier._TRUSTED_DOCKER, "version"],
+            timeout=1,
+            stdout_limit=1024,
+            stderr_limit=1024,
+        )
+
+    assert captured["command"][0] == "/usr/bin/docker"
+    assert captured["environment"] == {
+        "PATH": "/usr/bin:/bin",
+        "HOME": "/nonexistent",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+    }
+
+
+def test_nonlocal_docker_host_is_rejected_before_command(monkeypatch):
+    monkeypatch.setenv("DOCKER_HOST", "tcp://remote.example:2376")
+    monkeypatch.setattr(
+        verifier,
+        "_run_bounded_command",
+        lambda *args, **kwargs: pytest.fail("Docker command should not run"),
+    )
+
+    with pytest.raises(RuntimeError, match="local Unix Docker daemon"):
+        verifier._require_local_docker()
+    with pytest.raises(RuntimeError, match="local Unix Docker daemon"):
+        builder._docker_cli_environment()

--- a/batch-runner/tests/test_agentic_v2_candidate_verifier.py
+++ b/batch-runner/tests/test_agentic_v2_candidate_verifier.py
@@ -285,6 +285,25 @@ def test_verifier_uses_inspected_image_id_for_candidate_operations():
     assert source.count("_run_image_json(\n            image_id") == 3
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"Volumes": {"/opt/gdpval/v2": {}}},
+        {"Healthcheck": {"Test": ["CMD", "false"]}},
+    ],
+)
+def test_candidate_runtime_config_rejects_declared_mutators(mutation):
+    config = {"Volumes": None, "Healthcheck": None, **mutation}
+
+    with pytest.raises(ValueError, match="runtime configuration"):
+        verifier._validate_candidate_runtime_config(config)
+
+    assert verifier._validate_candidate_runtime_config({
+        "Volumes": None,
+        "Healthcheck": None,
+    }) == {"Volumes": None, "Healthcheck": None}
+
+
 def test_container_cleanup_accepts_confirmed_absence(monkeypatch):
     container = "a" * 64
     results = iter([
@@ -560,6 +579,36 @@ def test_license_collector_uses_site_disabled_python(monkeypatch):
         verifier._IMAGE_STDLIB_SCRIPT_BOOTSTRAP,
         "/opt/gdpval/v2/license_evidence.py",
     ]
+    assert "--no-healthcheck" in commands[0]
+
+
+def test_image_probe_receives_git_bound_sbom_digest(monkeypatch):
+    commands = []
+    monkeypatch.setattr(
+        verifier,
+        "_run_bounded_command",
+        lambda command, **kwargs: (
+            commands.append(command)
+            or SimpleNamespace(returncode=0, stdout=b"{}", stderr=b"")
+        ),
+    )
+    monkeypatch.setattr(verifier, "_remove_container", lambda _name: None)
+
+    verifier._run_image_json(
+        "sha256:" + "a" * 64,
+        "/opt/gdpval/v2/image_probe.py",
+        1024,
+        containment_checks={name: False for name in verifier._CONTAINMENT_CHECKS},
+        include_purelib=True,
+        session=_session(),
+        arguments=("b" * 64,),
+    )
+
+    assert commands[0][-2:] == [
+        "/opt/gdpval/v2/image_probe.py",
+        "b" * 64,
+    ]
+    assert "--no-healthcheck" in commands[0]
 
 
 def test_all_image_json_probes_require_no_site(monkeypatch):

--- a/batch-runner/tests/test_agentic_v2_oci.py
+++ b/batch-runner/tests/test_agentic_v2_oci.py
@@ -4,7 +4,6 @@ import io
 import json
 import os
 import tarfile
-from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -54,6 +53,31 @@ def _add(archive: tarfile.TarFile, name: str, value: bytes) -> None:
     archive.addfile(info, io.BytesIO(value))
 
 
+def _reseal_manifest(output: Path, mutate) -> str:
+    import hashlib
+
+    index_path = output / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    descriptor = index["manifests"][0]
+    old_digest = descriptor["digest"].removeprefix("sha256:")
+    old_path = output / "blobs" / "sha256" / old_digest
+    manifest = json.loads(old_path.read_text(encoding="utf-8"))
+    mutate(manifest)
+    manifest_bytes = json.dumps(
+        manifest, sort_keys=True, separators=(",", ":"), allow_nan=True
+    ).encode("utf-8")
+    new_digest = hashlib.sha256(manifest_bytes).hexdigest()
+    (output / "blobs" / "sha256" / new_digest).write_bytes(manifest_bytes)
+    old_path.unlink()
+    descriptor["digest"] = f"sha256:{new_digest}"
+    descriptor["size"] = len(manifest_bytes)
+    index_path.write_text(
+        json.dumps(index, sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    return descriptor["digest"]
+
+
 def test_docker_archive_exports_to_verified_oci_layout(tmp_path):
     archive = tmp_path / "candidate.tar"
     output = tmp_path / "oci"
@@ -82,6 +106,131 @@ def test_oci_verifier_rejects_blob_tampering(tmp_path):
 
     with pytest.raises(ValueError, match="OCI blob identity mismatch"):
         verify_oci_layout(output, expected_manifest_digest=identity["manifest_digest"])
+
+
+def test_oci_verifier_rejects_resealed_wrong_config_media_type(tmp_path):
+    archive = tmp_path / "candidate.tar"
+    output = tmp_path / "oci"
+    _archive(archive)
+    export_docker_archive_to_oci(archive, output)
+    index_path = output / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    descriptor = index["manifests"][0]
+    old_manifest_digest = descriptor["digest"].removeprefix("sha256:")
+    old_manifest_path = output / "blobs" / "sha256" / old_manifest_digest
+    manifest = json.loads(old_manifest_path.read_text(encoding="utf-8"))
+    manifest["config"]["mediaType"] = "application/octet-stream"
+    manifest_bytes = json.dumps(
+        manifest, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    import hashlib
+
+    new_manifest_digest = hashlib.sha256(manifest_bytes).hexdigest()
+    (output / "blobs" / "sha256" / new_manifest_digest).write_bytes(
+        manifest_bytes
+    )
+    old_manifest_path.unlink()
+    descriptor["digest"] = f"sha256:{new_manifest_digest}"
+    descriptor["size"] = len(manifest_bytes)
+    index_path.write_text(
+        json.dumps(index, sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="OCI config descriptor is invalid"):
+        verify_oci_layout(
+            output,
+            expected_manifest_digest=descriptor["digest"],
+        )
+
+
+@pytest.mark.parametrize("target", ["index", "manifest"])
+def test_oci_verifier_rejects_float_schema_version(tmp_path, target):
+    archive = tmp_path / "candidate.tar"
+    output = tmp_path / "oci"
+    _archive(archive)
+    identity = export_docker_archive_to_oci(archive, output)
+    if target == "index":
+        index_path = output / "index.json"
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+        index["schemaVersion"] = 2.0
+        index_path.write_text(json.dumps(index), encoding="utf-8")
+        expected = identity["manifest_digest"]
+    else:
+        expected = _reseal_manifest(
+            output, lambda manifest: manifest.update({"schemaVersion": 2.0})
+        )
+
+    with pytest.raises(ValueError, match="OCI (index identity|image manifest)"):
+        verify_oci_layout(output, expected_manifest_digest=expected)
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "1e400"])
+def test_oci_verifier_rejects_nonfinite_config_json(tmp_path, constant):
+    import hashlib
+
+    archive = tmp_path / "candidate.tar"
+    output = tmp_path / "oci"
+    _archive(archive)
+    export_docker_archive_to_oci(archive, output)
+    index = json.loads((output / "index.json").read_text())
+    manifest_digest = index["manifests"][0]["digest"].removeprefix("sha256:")
+    manifest = json.loads(
+        (output / "blobs" / "sha256" / manifest_digest).read_text()
+    )
+    config_digest = manifest["config"]["digest"].removeprefix("sha256:")
+    config_path = output / "blobs" / "sha256" / config_digest
+    config_bytes = config_path.read_bytes()
+    assert config_bytes.endswith(b"}")
+    config_bytes = (
+        config_bytes[:-1]
+        + b',"invalid":'
+        + constant.encode("ascii")
+        + b"}"
+    )
+    new_config_digest = hashlib.sha256(config_bytes).hexdigest()
+    (output / "blobs" / "sha256" / new_config_digest).write_bytes(config_bytes)
+    config_path.unlink()
+    expected_manifest = _reseal_manifest(
+        output,
+        lambda value: value["config"].update({
+            "digest": f"sha256:{new_config_digest}",
+            "size": len(config_bytes),
+        }),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="JSON (constant is invalid|float is not finite)",
+    ):
+        verify_oci_layout(
+            output,
+            expected_manifest_digest=expected_manifest,
+        )
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        (b'{"value":' + b"9" * 101 + b'}', "integer is too large"),
+        (b'{"value":1e400}', "float is not finite"),
+        (("[" * 65 + "0" + "]" * 65).encode("utf-8"), "structure exceeds"),
+        (json.dumps("x" * (1024 * 1024 + 1)).encode(), "string exceeds"),
+    ],
+)
+def test_oci_json_parser_rejects_large_or_deep_values(raw, message):
+    import core.agentic_v2_oci as module
+
+    with pytest.raises(ValueError, match=message):
+        module._json_loads(raw)
+
+
+def test_oci_json_parser_rejects_node_limit():
+    import core.agentic_v2_oci as module
+
+    raw = ("[" + ",".join("0" for _ in range(500_000)) + "]").encode()
+    with pytest.raises(ValueError, match="structure exceeds"):
+        module._json_loads(raw)
 
 
 def test_oci_export_rejects_layer_diff_id_mismatch(tmp_path):

--- a/batch-runner/tests/test_agentic_v2_phase1b_contract.py
+++ b/batch-runner/tests/test_agentic_v2_phase1b_contract.py
@@ -88,6 +88,14 @@ def test_phase1b_manifest_rejects_policy_drift(mutation):
         AgenticV2SubstrateManifest.from_mapping(value)
 
 
+def test_phase1b_manifest_rejects_numeric_microvm_required():
+    value = deepcopy(_manifest().document)
+    value["microvm"]["required"] = 1
+
+    with pytest.raises(ValueError, match="microvm policy"):
+        AgenticV2SubstrateManifest.from_mapping(value)
+
+
 def test_phase1b_capability_receipt_binds_inventory_and_manifest():
     manifest = _manifest()
     receipt = _receipt(manifest)
@@ -103,3 +111,28 @@ def test_phase1b_capability_receipt_binds_inventory_and_manifest():
     missing["smokes"].pop()
     with pytest.raises(ValueError, match="smoke matrix"):
         validate_capability_receipt(missing, manifest)
+
+
+@pytest.mark.parametrize(
+    ("section", "digest_field"),
+    [
+        ("commands", "sha256"),
+        ("python_modules", "sha256"),
+        ("font_families", "sha256"),
+        ("smokes", "artifact_sha256"),
+        ("package_inventory", "sha256"),
+    ],
+)
+def test_phase1b_capability_receipt_rejects_numeric_digests(
+    section,
+    digest_field,
+):
+    manifest = _manifest()
+    receipt = _receipt(manifest)
+    if section == "package_inventory":
+        receipt[section]["debian"][digest_field] = int("1" * 64)
+    else:
+        receipt[section][0][digest_field] = int("1" * 64)
+
+    with pytest.raises(ValueError, match="capability receipt"):
+        validate_capability_receipt(receipt, manifest)

--- a/batch-runner/tests/test_agentic_v2_phase1b_integration.py
+++ b/batch-runner/tests/test_agentic_v2_phase1b_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import uuid
 
 import pytest
 
@@ -22,6 +23,7 @@ def test_agentic_v2_phase1b_local_candidate_evidence(tmp_path):
         source_revision=source_revision,
         oci_layout=oci_layout,
         output_directory=tmp_path / "evidence",
+        session_id=uuid.uuid4().hex,
     )
 
     assert gate["gate_status"] == "blocked"

--- a/batch-runner/tests/test_agentic_v2_phase1c_license.py
+++ b/batch-runner/tests/test_agentic_v2_phase1c_license.py
@@ -1282,6 +1282,24 @@ def test_phase1c_license_evidence_rejects_inventory_and_source_tampering():
     with pytest.raises(ValueError, match="remain lexical"):
         validate_license_evidence(followed, sbom)
 
+    unresolved_file = deepcopy(evidence)
+    python_record = next(
+        item for item in unresolved_file["records"]
+        if item["ecosystem"] == "python"
+    )
+    python_record["evidence"][0]["resolved_path"] = None
+    unresolved_file["records_sha256"] = canonical_sha256(
+        unresolved_file["records"]
+    )
+    with pytest.raises(ValueError, match="unresolved license evidence source"):
+        validate_license_evidence(unresolved_file, sbom)
+    with pytest.raises(ValueError, match="unresolved license evidence source"):
+        verifier._verify_license_evidence_files(
+            "fixture-image",
+            unresolved_file,
+            session=verifier.VerificationSession("a" * 32),
+        )
+
     shadow = deepcopy(evidence)
     python_record = next(
         item for item in shadow["records"] if item["ecosystem"] == "python"
@@ -1932,15 +1950,31 @@ def test_phase1c_debian_dep5_fields_are_case_insensitive_and_stanza_scoped():
         "Format: fixture\nLicense: MIT\n", "copyright"
     )
     second = collector._debian_fields("license: SSPL-1.0\n", "copyright")
+    continued = collector._debian_fields(
+        "License:\n MIT\n SSPL-1.0\n", "copyright"
+    )
 
     assert first == {"format": "fixture", "license": "MIT"}
     assert second == {"license": "SSPL-1.0"}
+    assert continued == {"license": "MIT\nSSPL-1.0"}
     with pytest.raises(RuntimeError, match="Debian copyright field is duplicated"):
         collector._debian_fields(
             "License: MIT\nlicense: SSPL-1.0\n", "copyright"
         )
     with pytest.raises(RuntimeError, match="Debian copyright field is duplicated"):
         collector._debian_fields("Format: one\nformat: two\n", "copyright")
+    merged = collector._debian_fields(
+        "# separator\nComment: one\ncomment: two\nLicense: MIT\n",
+        "copyright",
+        allow_noncritical_duplicates=True,
+    )
+    assert merged == {"comment": "one\ntwo", "license": "MIT"}
+    with pytest.raises(RuntimeError, match="Debian copyright field is duplicated"):
+        collector._debian_fields(
+            "License: MIT\nlicense: SSPL-1.0\n",
+            "copyright",
+            allow_noncritical_duplicates=True,
+        )
 
 
 def test_phase1c_debian_license_continuation_is_preserved_and_denied(
@@ -1997,29 +2031,40 @@ def test_phase1c_debian_continuation_denial_reaches_full_report():
     assert decision["denied_identifiers"] == ["SSPL-1.0"]
 
 
-def test_phase1c_debian_copyright_symlink_is_not_treated_as_missing(monkeypatch):
-    calls = 0
+def test_phase1c_debian_copyright_symlink_is_unverifiable(tmp_path, monkeypatch):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    (copyright_path.parent / "copyright.real").write_text(
+        "Format: fixture\nLicense: MIT\n",
+        encoding="utf-8",
+    )
+    copyright_path.symlink_to("copyright.real")
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
 
-    def read_file(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            return (
-                {"source": "debian-status"},
-                b"Package: fixture\nStatus: install ok installed\n"
-                b"Version: 1\nArchitecture: amd64\n",
-            )
-        raise collector._UnavailableEvidencePath(
-            Path("/usr/share/doc/fixture/copyright"), collector.errno.ELOOP
-        )
+    record = collector._debian_records()[0]
+    decision = license_module._decision(record, set(), {})
+    blocked = record["evidence"][1]
 
-    monkeypatch.setattr(collector, "_read_regular_file", read_file)
-
-    with pytest.raises(RuntimeError, match="symlink-free"):
-        collector._debian_records()
+    assert blocked["source"] == "debian-copyright-path-unverifiable"
+    assert blocked["path"] == str(copyright_path)
+    assert blocked["resolved_path"] is None
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == (
+        "debian-copyright-path-unverifiable"
+    )
 
 
-def test_phase1c_debian_copyright_enotdir_is_not_treated_as_missing(
+def test_phase1c_debian_copyright_enotdir_is_unverifiable(
     tmp_path, monkeypatch
 ):
     status = tmp_path / "status"
@@ -2035,8 +2080,16 @@ def test_phase1c_debian_copyright_enotdir_is_not_treated_as_missing(
         collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
     )
 
-    with pytest.raises(RuntimeError, match="symlink-free"):
-        collector._debian_records()
+    record = collector._debian_records()[0]
+    decision = license_module._decision(record, set(), {})
+
+    assert record["evidence"][1]["source"] == (
+        "debian-copyright-path-unverifiable"
+    )
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == (
+        "debian-copyright-path-unverifiable"
+    )
 
 
 @pytest.mark.parametrize(
@@ -2129,9 +2182,78 @@ def test_phase1c_unstructured_debian_copyright_is_unverifiable(
     )
 
 
-@pytest.mark.parametrize("copyright_present", [False, True])
+def test_phase1c_noncanonical_debian_format_is_unverifiable(
+    tmp_path, monkeypatch
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_text(
+        "Format: http://www.debian.org/doc/packaging-manuals/"
+        "copyright-format/1.0/\n"
+        "# Non-control-file comments remain untrusted.\n"
+        "License: MIT\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    record = collector._debian_records()[0]
+    decision = license_module._decision(record, set(), {})
+
+    assert record["metadata"]["copyright_format"] is None
+    assert record["raw_values"] == []
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == (
+        "debian-copyright-has-no-dep5-license-fields"
+    )
+
+
+def test_phase1c_orphan_debian_license_prose_is_unverifiable(
+    tmp_path, monkeypatch
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_text(
+        f"Format: {collector.DEP5_FORMAT_URI}\n\n"
+        "Files: *\nLicense: MIT\n\n"
+        "    Detached SSPL-1.0 prose must not be ignored.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    record = collector._debian_records()[0]
+    decision = license_module._decision(record, set(), {})
+
+    assert record["metadata"]["copyright_format"] is None
+    assert record["raw_values"] == []
+    assert decision["classification"] == "unverifiable"
+    assert decision["denied_identifiers"] == []
+
+
+@pytest.mark.parametrize(
+    "copyright_state", ["missing", "unstructured", "unverifiable_path"]
+)
 def test_phase1c_debian_without_dep5_cannot_receive_exception(
-    copyright_present,
+    copyright_state,
 ):
     _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
     record = next(
@@ -2141,8 +2263,15 @@ def test_phase1c_debian_without_dep5_cannot_receive_exception(
         item for item in record["evidence"]
         if item["source"] == "debian-copyright"
     ]
-    if not copyright_present:
+    if copyright_state == "missing":
         record["evidence"].remove(copyright_items[0])
+    elif copyright_state == "unverifiable_path":
+        record["evidence"][record["evidence"].index(copyright_items[0])] = (
+            collector._unverifiable_path_evidence(
+                "debian-copyright-path-unverifiable",
+                Path(f"/usr/share/doc/{record['package']}/copyright"),
+            )
+        )
     record["raw_values"] = []
     record["metadata"]["copyright_format"] = None
     evidence_sha256 = canonical_sha256(record["evidence"])
@@ -2180,6 +2309,36 @@ def test_phase1c_debian_without_dep5_cannot_receive_exception(
         )
 
 
+@pytest.mark.parametrize("tampering", ["digest", "resolved_path"])
+def test_phase1c_debian_unverifiable_path_observation_is_exact(tampering):
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    record = next(
+        item for item in evidence["records"] if item["ecosystem"] == "debian"
+    )
+    copyright_item = next(
+        item for item in record["evidence"]
+        if item["source"] == "debian-copyright"
+    )
+    blocked = collector._unverifiable_path_evidence(
+        "debian-copyright-path-unverifiable",
+        Path(f"/usr/share/doc/{record['package']}/copyright"),
+    )
+    record["evidence"][record["evidence"].index(copyright_item)] = blocked
+    record["raw_values"] = []
+    record["metadata"]["copyright_format"] = None
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    assert validate_license_evidence(evidence, sbom) == evidence
+
+    if tampering == "digest":
+        blocked["sha256"] = "0" * 64
+    else:
+        blocked["resolved_path"] = blocked["path"]
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+    with pytest.raises(ValueError, match="unverifiable path evidence is invalid"):
+        validate_license_evidence(evidence, sbom)
+
+
 def test_phase1c_debian_malformed_denied_field_fails_collector(
     tmp_path, monkeypatch
 ):
@@ -2209,13 +2368,12 @@ def test_phase1c_debian_malformed_denied_field_fails_collector(
     ("copyright_text", "newline"),
     [
         ("License: MIT{nl}", "\n"),
-        ("Format:   {nl}License: MIT{nl}", "\n"),
         ("License: MIT{nl}{nl}Format: fixture{nl}", "\n"),
         ("License: MIT{nl}{nl}Format: fixture{nl}", "\r\n"),
         ("License: MIT{nl}{nl}Format: fixture{nl}", "\r"),
     ],
 )
-def test_phase1c_dep5_requires_nonempty_first_stanza_format(
+def test_phase1c_formatless_dep5_like_document_is_unverifiable(
     tmp_path, monkeypatch, copyright_text, newline
 ):
     status = tmp_path / "status"
@@ -2228,6 +2386,32 @@ def test_phase1c_dep5_requires_nonempty_first_stanza_format(
     copyright_path = documentation_root / "fixture" / "copyright"
     copyright_path.parent.mkdir(parents=True)
     copyright_path.write_bytes(copyright_text.format(nl=newline).encode("utf-8"))
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    record = collector._debian_records()[0]
+    decision = license_module._decision(record, set(), {})
+
+    assert record["metadata"]["copyright_format"] is None
+    assert record["raw_values"] == []
+    assert decision["classification"] == "unverifiable"
+
+
+def test_phase1c_dep5_requires_nonempty_first_stanza_format(
+    tmp_path, monkeypatch
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_text("Format:   \nLicense: MIT\n", encoding="utf-8")
     monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
     monkeypatch.setattr(
         collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
@@ -2251,7 +2435,7 @@ def test_phase1c_dep5_requires_nonempty_first_stanza_format(
         "Files-Excluded-component: generated/*",
     ],
 )
-def test_phase1c_dep5_field_set_requires_format(
+def test_phase1c_dep5_field_set_without_format_is_unverifiable(
     tmp_path, monkeypatch, field_line
 ):
     status = tmp_path / "status"
@@ -2269,8 +2453,12 @@ def test_phase1c_dep5_field_set_requires_format(
         collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
     )
 
-    with pytest.raises(RuntimeError, match="DEP-5 Format header is invalid"):
-        collector._debian_records()
+    record = collector._debian_records()[0]
+    decision = license_module._decision(record, set(), {})
+
+    assert record["metadata"]["copyright_format"] is None
+    assert record["raw_values"] == []
+    assert decision["classification"] == "unverifiable"
 
 
 @pytest.mark.parametrize("newline", ["\n", "\r\n", "\r"])
@@ -2374,6 +2562,28 @@ def test_phase1c_python_malformed_denied_header_fails_collector(
 
     with pytest.raises(RuntimeError, match="metadata is malformed"):
         collector._python_records()
+
+
+def test_phase1c_python_utf8_multiline_license_is_serializable(
+    tmp_path, monkeypatch
+):
+    site_root = tmp_path / "python3.11" / "site-packages"
+    metadata_root = site_root / "fixture-1.0.dist-info"
+    metadata_root.mkdir(parents=True)
+    (metadata_root / "METADATA").write_bytes(
+        b"Name: fixture\nVersion: 1.0\nLicense: BSD prose\n"
+        b" Copyright Jos\xc3\xa9 Example\n\n"
+    )
+    monkeypatch.setattr(collector, "PYTHON_PURELIB_PATH", str(site_root))
+    monkeypatch.setattr(
+        collector.sysconfig, "get_path", lambda name: str(site_root)
+    )
+
+    record = collector._python_records()[0]
+
+    assert isinstance(record["metadata"]["license"], str)
+    assert "Jos" in record["metadata"]["license"]
+    json.dumps(record, sort_keys=True, allow_nan=False)
 
 
 def test_phase1c_python_invalid_utf8_fails_collector(tmp_path, monkeypatch):
@@ -2834,21 +3044,144 @@ def test_phase1c_r_records_surface_mixed_case_runtime_denied(
     assert decision["denied_identifiers"] == ["SSPL-1.0"]
 
 
+def test_phase1c_effective_sbom_r_inventory_is_static(tmp_path, monkeypatch):
+    library_root = tmp_path / "R" / "library"
+    for package, license_value in (
+        ("base", "Part of R 4.2.2"),
+        ("translations", "Part of R 4.2.2"),
+    ):
+        package_root = library_root / package
+        package_root.mkdir(parents=True)
+        (package_root / "DESCRIPTION").write_text(
+            f"Package: {package}\nVersion: 4.2.2\nLicense: {license_value}\n",
+            encoding="utf-8",
+        )
+    monkeypatch.setattr(sbom_collector, "R_LIBRARY_ROOT", library_root)
+
+    packages = sbom_collector._r_packages()
+
+    assert [
+        item["externalRefs"][0]["referenceLocator"] for item in packages
+    ] == [
+        "pkg:cran/base@4.2.2",
+        "pkg:cran/translations@4.2.2",
+    ]
+
+
+def test_phase1c_effective_sbom_r_inventory_is_bounded(tmp_path, monkeypatch):
+    library_root = tmp_path / "R" / "library"
+    package_root = library_root / "base"
+    package_root.mkdir(parents=True)
+    description_path = package_root / "DESCRIPTION"
+    description_path.write_text(
+        "Package: base\nVersion: 4.2.2\nLicense: " + "M" * 65 + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sbom_collector, "R_LIBRARY_ROOT", library_root)
+    monkeypatch.setattr(sbom_collector, "MAX_R_FIELD_CHARS", 64)
+
+    with pytest.raises(RuntimeError, match="field is too large"):
+        sbom_collector._r_packages()
+
+    monkeypatch.setattr(sbom_collector, "MAX_R_FIELD_CHARS", 1024)
+    monkeypatch.setattr(
+        sbom_collector,
+        "MAX_R_DESCRIPTION_BYTES",
+        description_path.stat().st_size - 1,
+    )
+    with pytest.raises(RuntimeError, match="file is too large"):
+        sbom_collector._r_packages()
+
+
 @pytest.mark.parametrize(
     "runtime_copyright",
     [
-        b"License: MIT\n",
+        b"Runtime prose.\n\nLicense: GPL-2\nPortions License: Artistic\n",
         b"Format: vendor-text-v1\n\nLicense: MIT\n",
-        b"Format: \n\nLicense: MIT\n",
     ],
 )
-def test_phase1c_r_runtime_requires_canonical_dep5_format(
+def test_phase1c_unstructured_r_runtime_is_unverifiable(
     tmp_path, monkeypatch, runtime_copyright
 ):
     _configure_r_tree(
         tmp_path,
         monkeypatch,
         runtime_copyright=runtime_copyright,
+    )
+
+    record = collector._r_records()[0]
+    decision = license_module._decision(record, set(), {})
+
+    assert record["metadata"]["runtime_copyright_format"] is None
+    assert record["metadata"]["runtime_license_fields"] == []
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == (
+        "r-runtime-copyright-unstructured"
+    )
+
+
+@pytest.mark.parametrize(
+    ("declared_license", "priority"),
+    [
+        ("Part of R 4.2.2", "base"),
+        ("Part of R anything", "optional"),
+        ("(Part of R anything)", "optional"),
+        ("GPL-2 | Part of R anything", "optional"),
+        ("MIT | part-of-r anything", "optional"),
+        ("Part\u00a0of\u00a0R anything", "optional"),
+        ("MIT | Part\u2011of\u2011R anything", "optional"),
+    ],
+)
+def test_phase1c_unstructured_r_runtime_cannot_receive_exception(
+    declared_license,
+    priority,
+):
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "r")
+    record["metadata"]["declared_license"] = declared_license
+    record["metadata"]["priority"] = priority
+    record["metadata"]["runtime_copyright_format"] = None
+    record["metadata"]["runtime_license_fields"] = []
+    record["raw_values"] = [record["metadata"]["declared_license"]]
+    evidence_sha256 = canonical_sha256(record["evidence"])
+    exception = {
+        "ecosystem": "r",
+        "package": record["package"],
+        "version": record["version"],
+        "purl": record["purl"],
+        "normalized_expression": "MIT",
+        "evidence_sha256": evidence_sha256,
+        "reason": "unstructured-runtime-review",
+        "approver": "reviewer",
+        "expires_at": "2027-07-31",
+    }
+    policy["license"]["exceptions"].append(exception)
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    decision = license_module._decision(
+        record,
+        set(policy["license"]["denied_identifiers"]),
+        {(record["purl"], evidence_sha256): exception},
+    )
+
+    assert decision["classification"] == "unverifiable"
+    assert decision["exception"] is None
+    with pytest.raises(ValueError, match="stale or unmatched"):
+        build_license_report(
+            subject=subject,
+            subject_sha256=canonical_sha256(subject),
+            sbom=sbom,
+            license_evidence=evidence,
+            policy=policy,
+            policy_sha256=canonical_sha256(policy),
+        )
+
+
+def test_phase1c_r_runtime_rejects_empty_dep5_format(tmp_path, monkeypatch):
+    _configure_r_tree(
+        tmp_path,
+        monkeypatch,
+        runtime_copyright=b"Format: \n\nLicense: MIT\n",
     )
 
     with pytest.raises(RuntimeError, match="DEP-5 Format header is invalid"):
@@ -3158,6 +3491,54 @@ def test_phase1c_noncanonical_reference_cannot_receive_exception(
 
     assert decision["classification"] == "unverifiable"
     assert decision["exception"] is None
+
+
+@pytest.mark.parametrize(
+    "declared",
+    [
+        "SEE\u00a0LICENSE\u00a0IN LICENSE",
+        "SEE\u2011LICENSE\u2011IN LICENSE",
+    ],
+)
+def test_phase1c_unicode_npm_reference_cannot_receive_exception(declared):
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(
+        item for item in evidence["records"] if item["ecosystem"] == "npm"
+    )
+    record["metadata"]["license"] = declared
+    record["raw_values"] = [declared]
+    evidence_sha256 = canonical_sha256(record["evidence"])
+    exception = {
+        "ecosystem": "npm",
+        "package": record["package"],
+        "version": record["version"],
+        "purl": record["purl"],
+        "normalized_expression": "MIT",
+        "evidence_sha256": evidence_sha256,
+        "reason": "unicode-reference-review",
+        "approver": "reviewer",
+        "expires_at": "2027-07-31",
+    }
+    policy["license"]["exceptions"].append(exception)
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    decision = license_module._decision(
+        record,
+        set(policy["license"]["denied_identifiers"]),
+        {(record["purl"], evidence_sha256): exception},
+    )
+
+    assert decision["classification"] == "unverifiable"
+    assert decision["exception"] is None
+    with pytest.raises(ValueError, match="stale or unmatched"):
+        build_license_report(
+            subject=subject,
+            subject_sha256=canonical_sha256(subject),
+            sbom=sbom,
+            license_evidence=evidence,
+            policy=policy,
+            policy_sha256=canonical_sha256(policy),
+        )
 
 
 def test_phase1c_license_expression_size_is_bounded():

--- a/batch-runner/tests/test_agentic_v2_phase1c_license.py
+++ b/batch-runner/tests/test_agentic_v2_phase1c_license.py
@@ -65,7 +65,7 @@ def _subject():
         ),
         "license_evaluator_python_version": "3.10.12",
         "license_evaluator_callable_sha256": (
-            "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"
+            "825f97f04b9b94c048326625a7e56b6a0960b196964dabcf4ba7ad3e8e9b3056"
         ),
         "license_evaluator_runtime_graph_sha256": (
             "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"
@@ -407,6 +407,470 @@ def test_phase1c_evaluator_callable_tamper_is_rejected(monkeypatch):
 
     with pytest.raises(RuntimeError, match="parser identity differs"):
         license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_callable_constant_subclass_is_rejected(monkeypatch):
+    original = license_module._packaging_canonicalize_license_expression
+
+    class ForgedString(str):
+        def join(self, iterable):
+            del iterable
+            return "MIT"
+
+    def replace_constant(value):
+        if type(value) is str and value == " ":
+            return ForgedString(value)
+        if type(value) is tuple:
+            return tuple(replace_constant(item) for item in value)
+        if type(value) is license_module.types.CodeType:
+            return value.replace(
+                co_consts=tuple(
+                    replace_constant(item) for item in value.co_consts
+                )
+            )
+        return value
+
+    forged_code = replace_constant(original.__code__)
+    with pytest.raises(RuntimeError, match="code constant is invalid"):
+        license_module._callable_code_identity(forged_code)
+    monkeypatch.setattr(original, "__code__", forged_code)
+
+    with pytest.raises(RuntimeError, match="parser identity differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_live_parser_global_is_not_executed(monkeypatch):
+    monkeypatch.setattr(
+        license_module.packaging_licenses,
+        "cast",
+        lambda _type, _value: "MIT",
+    )
+
+    assert license_module._canonical("BUSL-1.1") == "BUSL-1.1"
+    assert license_module.license_evaluator_runtime_identity()[
+        "callable_sha256"
+    ] == license_module.LICENSE_EVALUATOR_CALLABLE_SHA256
+
+
+def test_phase1c_evaluator_executor_code_mutation_is_rejected(monkeypatch):
+    def forged(_value):
+        return "MIT"
+
+    monkeypatch.setattr(
+        license_module._execute_frozen_license_parser,
+        "__code__",
+        forged.__code__,
+    )
+
+    with pytest.raises(RuntimeError, match="parser identity differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_function_factory_rebinding_is_rejected(monkeypatch):
+    monkeypatch.setattr(
+        license_module.types,
+        "FunctionType",
+        lambda *_args, **_kwargs: (lambda _value: "MIT"),
+    )
+
+    assert license_module._canonical("BUSL-1.1") == "BUSL-1.1"
+    with pytest.raises(RuntimeError, match="parser identity differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_spdx_subclass_poisoning_is_rejected(monkeypatch):
+    class ForgedString(str):
+        def __add__(self, _other):
+            return "MIT"
+
+    poisoned = dict(license_module._spdx.LICENSES)
+    poisoned["busl-1.1"] = dict(poisoned["busl-1.1"])
+    poisoned["busl-1.1"]["id"] = ForgedString("BUSL-1.1")
+    monkeypatch.setattr(license_module._spdx, "LICENSES", poisoned)
+
+    assert license_module._canonical("BUSL-1.1") == "BUSL-1.1"
+    with pytest.raises(RuntimeError, match="parser identity differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_preimport_builtin_poisoning_is_rejected():
+    script = (
+        "import builtins\n"
+        "original = builtins.compile\n"
+        "def forged(source, filename, mode, *args, **kwargs):\n"
+        "    if isinstance(source, str) and mode == 'eval' and source != '(':\n"
+        "        source = 'False'\n"
+        "    return original(source, filename, mode, *args, **kwargs)\n"
+        "builtins.compile = forged\n"
+        "import core.agentic_v2_license as module\n"
+        "try:\n"
+        "    module.license_evaluator_runtime_identity()\n"
+        "except RuntimeError:\n"
+        "    print('rejected')\n"
+        "else:\n"
+        "    raise SystemExit('poisoned compile was accepted')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", errors="replace"
+    )
+    assert completed.stdout == b"rejected\n"
+
+
+def test_phase1c_evaluator_preimport_regex_poisoning_has_no_effect():
+    script = (
+        "import re, runpy\n"
+        "original = re.compile\n"
+        "class ForgedPattern:\n"
+        "    def __init__(self, pattern, flags):\n"
+        "        self.pattern = pattern\n"
+        "        self.flags = flags\n"
+        "    def findall(self, _value): return []\n"
+        "    def match(self, _value): return None\n"
+        "def forged(pattern, flags=0):\n"
+        "    if isinstance(pattern, str) and (pattern == '^[A-Za-z0-9.-]*$' "
+        "or 'A-Za-z0-9.+-' in pattern):\n"
+        "        return ForgedPattern(pattern, flags)\n"
+        "    return original(pattern, flags)\n"
+        "re.compile = forged\n"
+        "namespace = runpy.run_path('tests/test_agentic_v2_phase1c_license.py')\n"
+        "report = namespace['_fixture']()[-1]\n"
+        "assert report['counts']['denied'] == 1\n"
+        "assert report['status'] == 'failed'\n"
+        "print('regex-poisoning-isolated')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", errors="replace"
+    )
+    assert completed.stdout == b"regex-poisoning-isolated\n"
+
+
+def test_phase1c_evaluator_preimport_set_poisoning_is_rejected():
+    script = (
+        "import copy, inspect, json, os, pathlib, py_compile, signal, "
+        "subprocess, sys, types, pytest, jsonschema, builtins, runpy\n"
+        "import core.agentic_v2_substrate\n"
+        "original = builtins.set\n"
+        "def forged(iterable=()):\n"
+        "    value = original(iterable)\n"
+        "    if value == {'BUSL-1.1', 'Commons-Clause', 'SSPL-1.0'}:\n"
+        "        return original()\n"
+        "    return value\n"
+        "builtins.set = forged\n"
+        "try:\n"
+        "    namespace = runpy.run_path('tests/test_agentic_v2_phase1c_license.py')\n"
+        "    namespace['_fixture']()\n"
+        "except Exception:\n"
+        "    print('set-poisoning-rejected')\n"
+        "else:\n"
+        "    raise SystemExit('poisoned set was accepted')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", errors="replace"
+    )
+    assert completed.stdout == b"set-poisoning-rejected\n"
+
+
+def test_phase1c_evaluator_preimport_enumerate_poisoning_has_no_effect():
+    script = (
+        "import copy, inspect, json, os, pathlib, py_compile, signal, "
+        "subprocess, sys, types, pytest, jsonschema, builtins, runpy\n"
+        "import core.agentic_v2_substrate\n"
+        "original = builtins.enumerate\n"
+        "def forged(iterable, start=0):\n"
+        "    if isinstance(iterable, str) and 'BUSL-1.1' in iterable:\n"
+        "        return iter(())\n"
+        "    return original(iterable, start)\n"
+        "builtins.enumerate = forged\n"
+        "namespace = runpy.run_path('tests/test_agentic_v2_phase1c_license.py')\n"
+        "report = namespace['_fixture']()[-1]\n"
+        "assert report['counts']['denied'] == 1\n"
+        "print('enumerate-poisoning-isolated')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", errors="replace"
+    )
+    assert completed.stdout == b"enumerate-poisoning-isolated\n"
+
+
+def test_phase1c_evaluator_preimport_tuple_poisoning_is_rejected():
+    script = (
+        "import copy, inspect, json, os, pathlib, py_compile, signal, "
+        "subprocess, sys, types, pytest, jsonschema, builtins, runpy\n"
+        "import core.agentic_v2_substrate\n"
+        "original = builtins.tuple\n"
+        "def forged(iterable=()): return original(iterable)\n"
+        "builtins.tuple = forged\n"
+        "try:\n"
+        "    namespace = runpy.run_path('tests/test_agentic_v2_phase1c_license.py')\n"
+        "    namespace['_fixture']()\n"
+        "except Exception:\n"
+        "    print('tuple-poisoning-rejected')\n"
+        "else:\n"
+        "    raise SystemExit('poisoned tuple was accepted')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", errors="replace"
+    )
+    assert completed.stdout == b"tuple-poisoning-rejected\n"
+
+
+def test_phase1c_evaluator_preimport_deepcopy_poisoning_has_no_effect():
+    script = (
+        "import copy, runpy\n"
+        "original = copy.deepcopy\n"
+        "def forged(value, memo=None, _nil=[]):\n"
+        "    result = original(value, memo)\n"
+        "    if isinstance(result, dict) and result.get('raw_values') "
+        "== ['SSPL-1.0']:\n"
+        "        result['raw_values'] = ['MIT']\n"
+        "    return result\n"
+        "copy.deepcopy = forged\n"
+        "namespace = runpy.run_path('tests/test_agentic_v2_phase1c_license.py')\n"
+        "report = namespace['_fixture']()[-1]\n"
+        "assert report['counts']['denied'] == 1\n"
+        "assert report['status'] == 'failed'\n"
+        "print('deepcopy-poisoning-isolated')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", errors="replace"
+    )
+    assert completed.stdout == b"deepcopy-poisoning-isolated\n"
+
+
+def test_phase1c_evaluator_preimport_reference_regex_poisoning_has_no_effect():
+    script = (
+        "import re, runpy\n"
+        "original = re.compile\n"
+        "class ForgedPattern:\n"
+        "    def __init__(self, pattern, flags):\n"
+        "        self.pattern = pattern\n"
+        "        self.flags = flags\n"
+        "    def fullmatch(self, _value): return None\n"
+        "    def search(self, _value): return None\n"
+        "def forged(pattern, flags=0):\n"
+        "    if isinstance(pattern, str) and ('SEE LICENSE IN' in pattern "
+        "or 'file (' in pattern or 'Part' in pattern):\n"
+        "        return ForgedPattern(pattern, flags)\n"
+        "    return original(pattern, flags)\n"
+        "re.compile = forged\n"
+        "namespace = runpy.run_path('tests/test_agentic_v2_phase1c_license.py')\n"
+        "namespace['test_phase1c_unicode_npm_reference_cannot_receive_exception']"
+        "('SEE\\u00a0LICENSE\\u00a0IN LICENSE')\n"
+        "namespace['test_phase1c_unstructured_r_runtime_cannot_receive_exception']"
+        "('(Part of R anything)', 'optional')\n"
+        "print('reference-regex-poisoning-isolated')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", errors="replace"
+    )
+    assert completed.stdout == b"reference-regex-poisoning-isolated\n"
+
+
+@pytest.mark.parametrize("mutation", ["canonical-code", "canonical-defaults", "shape-code"])
+def test_phase1c_evaluator_canonicalizer_mutation_is_rejected(
+    monkeypatch,
+    mutation,
+):
+    def forged(_value):
+        return "MIT"
+
+    if mutation == "canonical-code":
+        monkeypatch.setattr(license_module._canonical, "__code__", forged.__code__)
+    elif mutation == "canonical-defaults":
+        defaults = list(license_module._canonical.__defaults__)
+        defaults[0] = forged
+        monkeypatch.setattr(license_module._canonical, "__defaults__", tuple(defaults))
+    else:
+        monkeypatch.setattr(
+            license_module._valid_expression_shape,
+            "__code__",
+            forged.__code__,
+        )
+
+    with pytest.raises(RuntimeError, match="parser identity differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_decision_mutation_is_rejected(monkeypatch):
+    def forged(*_args, **_kwargs):
+        return {"classification": "resolved"}
+
+    monkeypatch.setattr(license_module._decision, "__code__", forged.__code__)
+
+    with pytest.raises(RuntimeError, match="classification surface differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_shadow_module_globals_cannot_hide_decision_rebinding(
+    monkeypatch,
+):
+    def forged(*_args, **_kwargs):
+        return {"classification": "resolved"}
+
+    monkeypatch.setattr(
+        license_module,
+        "_MODULE_GLOBALS",
+        dict(license_module._MODULE_GLOBALS),
+    )
+    monkeypatch.setattr(license_module, "_decision", forged)
+
+    with pytest.raises(RuntimeError, match="classification surface differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_alias_rebinding_is_rejected(monkeypatch):
+    aliases = dict(license_module._PYTHON_EXACT_ALIASES)
+    aliases["Proprietary"] = "MIT"
+    monkeypatch.setattr(license_module, "_PYTHON_EXACT_ALIASES", aliases)
+
+    with pytest.raises(RuntimeError, match="alias bindings differ"):
+        license_module.license_evaluator_runtime_identity()
+
+
+@pytest.mark.parametrize("dependency", ["outcome", "date", "hash"])
+def test_phase1c_evaluator_dependency_mutation_is_rejected(
+    monkeypatch,
+    dependency,
+):
+    if dependency == "outcome":
+        def forged_init(self, expression, issue, reason, identifiers):
+            del expression, issue, reason, identifiers
+            object.__setattr__(self, "expression", "MIT")
+
+        monkeypatch.setattr(
+            license_module._Outcome,
+            "__init__",
+            forged_init,
+        )
+    elif dependency == "date":
+        monkeypatch.setattr(license_module, "date", object)
+    else:
+        monkeypatch.setattr(
+            license_module,
+            "canonical_sha256",
+            lambda _value: "0" * 64,
+        )
+
+    with pytest.raises(RuntimeError, match="parser identity differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_preimport_hash_poisoning_is_rejected():
+    script = (
+        "import core.agentic_v2_substrate as substrate\n"
+        "original = substrate.canonical_sha256\n"
+        "def forged(value): return original(value)\n"
+        "substrate.canonical_sha256 = forged\n"
+        "import core.agentic_v2_license as module\n"
+        "try:\n"
+        "    module.license_evaluator_runtime_identity()\n"
+        "except RuntimeError:\n"
+        "    print('hash-poisoning-rejected')\n"
+        "else:\n"
+        "    raise SystemExit('poisoned hash was accepted')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(
+        "utf-8", errors="replace"
+    )
+    assert completed.stdout == b"hash-poisoning-rejected\n"
+
+
+def test_phase1c_evaluator_callable_identity_is_import_order_stable():
+    outputs = []
+    for prelude in ("", "import core.executor\n"):
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                prelude
+                + "import core.agentic_v2_license as module\n"
+                + "print(module.license_evaluator_runtime_identity()"
+                + "['callable_sha256'])\n",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr.decode(
+            "utf-8", errors="replace"
+        )
+        outputs.append(completed.stdout.decode("ascii").strip())
+
+    assert outputs == [license_module.LICENSE_EVALUATOR_CALLABLE_SHA256] * 2
 
 
 def test_phase1c_staged_evaluator_runtime_is_source_only(tmp_path):
@@ -1203,7 +1667,7 @@ def test_phase1c_report_binds_candidate_oci_sbom_evidence_tools_and_policy():
         ),
         "license_evaluator_python_version": "3.10.12",
         "license_evaluator_callable_sha256": (
-            "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"
+            "825f97f04b9b94c048326625a7e56b6a0960b196964dabcf4ba7ad3e8e9b3056"
         ),
         "license_evaluator_runtime_graph_sha256": (
             "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"
@@ -3628,16 +4092,13 @@ def test_phase1c_license_expression_depth_is_bounded_below_size_limit():
 )
 def test_phase1c_expression_shape_rejects_before_parser(
     expression,
-    monkeypatch,
 ):
     assert len(expression) < 4096
-    monkeypatch.setattr(
-        license_module,
-        "canonicalize_license_expression",
-        lambda _value: pytest.fail("invalid shape reached SPDX parser"),
-    )
 
-    assert license_module._canonical(expression) is None
+    assert license_module._canonical(
+        expression,
+        parser=lambda _value: pytest.fail("invalid shape reached SPDX parser"),
+    ) is None
 
 
 @pytest.mark.parametrize(
@@ -3682,14 +4143,11 @@ def test_phase1c_r_fallback_cannot_bypass_expression_shape():
     assert outcome.reason == "invalid-r-license-expression-shape"
 
 
-def test_phase1c_spdx_parser_recursion_is_normalized(monkeypatch):
-    monkeypatch.setattr(
-        license_module,
-        "canonicalize_license_expression",
-        lambda _value: (_ for _ in ()).throw(RecursionError("fixture")),
-    )
-
-    assert license_module._canonical("MIT") is None
+def test_phase1c_spdx_parser_recursion_is_normalized():
+    assert license_module._canonical(
+        "MIT",
+        parser=lambda _value: (_ for _ in ()).throw(RecursionError("fixture")),
+    ) is None
 
 
 @pytest.mark.parametrize("declared", ["MIT || Apache-2.0", "| MIT", "MIT |"])

--- a/batch-runner/tests/test_agentic_v2_phase1c_license.py
+++ b/batch-runner/tests/test_agentic_v2_phase1c_license.py
@@ -1,0 +1,3336 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import inspect
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+from jsonschema import Draft202012Validator
+
+import core.agentic_v2_license as license_module
+import core.agentic_v2_substrate as substrate_module
+from core.agentic_v2_license import (
+    build_license_report,
+    validate_license_evidence,
+    validate_license_exceptions,
+    validate_license_report,
+)
+from core.agentic_v2_substrate import canonical_sha256
+from core.agentic_v2_supply_chain import (
+    CandidateSubject,
+    SupplyChainPolicy,
+    build_evidence_report,
+    evidence_item,
+)
+import sandbox.v2.build_candidate as builder
+import sandbox.v2.effective_sbom as sbom_collector
+import sandbox.v2.image_probe as image_probe
+import sandbox.v2.license_evidence as collector
+import sandbox.v2.verify_candidate as verifier
+
+
+CASES = Path("tests/fixtures/agentic_v2_phase1c_license_cases.json")
+SCHEMA = Path("schemas/agentic-v2-license-report.schema.json")
+
+
+def _subject():
+    return {
+        "schema_version": "1.0",
+        "substrate_id": "professional-work-v1",
+        "image_id": "sha256:" + "1" * 64,
+        "oci_manifest_digest": "sha256:" + "2" * 64,
+        "parent_manifest_digest": "sha256:" + "3" * 64,
+        "platform": "linux/amd64",
+        "source_revision": "4" * 40,
+        "dockerfile_sha256": "5" * 64,
+        "manifest_sha256": "6" * 64,
+        "probe_sha256": "7" * 64,
+        "embedded_source_sha256": "8" * 64,
+        "verifier_sha256": "9" * 64,
+        "oci_exporter_sha256": "a" * 64,
+        "sbom_generator_sha256": "b" * 64,
+        "license_collector_sha256": "c" * 64,
+        "license_evaluator_sha256": "d" * 64,
+        "license_evaluator_packaging_version": "26.2",
+        "license_evaluator_parser_sha256": (
+            "fc9c745d1883ff9f296a5b169f22eb2ee879f59a4608f20f5cb29d668f4e26f4"
+        ),
+        "license_evaluator_python_version": "3.10.12",
+        "license_evaluator_callable_sha256": (
+            "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"
+        ),
+        "license_evaluator_runtime_graph_sha256": (
+            "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"
+        ),
+        "license_evaluator_spdx_version": "3.27.0",
+        "license_evaluator_spdx_sha256": (
+            "ecc082fdc1fcdcae47b2f56c4ce2cdc2c9d6d54ca555a09814abd78dece7a230"
+        ),
+        "lock_set_sha256": "e" * 64,
+    }
+
+
+def _policy():
+    return {
+        "schema_version": "1.0",
+        "policy_id": "agentic-v2-phase1c-candidate-v1",
+        "foundation_only": True,
+        "production_activation": "disabled",
+        "required_evidence": [
+            "capability_receipt",
+            "containment",
+            "cve",
+            "license",
+            "microvm",
+            "oci_layout",
+            "provenance",
+            "sbom",
+            "signature",
+        ],
+        "cve": {
+            "policy_id": "agentic-v2-cve-v1",
+            "scanner_db_max_age_days": 7,
+            "denied_severities": ["CRITICAL", "HIGH"],
+            "exceptions_require": [
+                "cve", "purl", "reason", "approver", "expires_at",
+            ],
+        },
+        "license": {
+            "policy_id": "agentic-v2-license-v2",
+            "as_of_date": "2026-07-31",
+            "unknown_is_failure": True,
+            "unknown_classifications": [
+                "ambiguous", "missing_metadata", "unverifiable",
+            ],
+            "denied_identifiers": ["BUSL-1.1", "Commons-Clause", "SSPL-1.0"],
+            "exceptions_require": [
+                "ecosystem", "package", "version", "purl",
+                "normalized_expression", "evidence_sha256", "reason",
+                "approver", "expires_at",
+            ],
+            "exceptions": [],
+        },
+        "signature": {
+            "profile": "cosign-offline-v1",
+            "trusted_key_required": True,
+            "bundle_required": True,
+        },
+        "provenance": {
+            "profile": "buildkit-max-v1",
+            "required_subjects": [
+                "candidate", "parent", "dockerfile", "locks", "manifest",
+                "probe", "sbom", "policy",
+            ],
+        },
+        "microvm": {
+            "runtime": "firecracker",
+            "jailer_required": True,
+            "kvm_required": True,
+            "network": "none",
+            "read_only_rootfs": True,
+            "ephemeral_work_disk": True,
+        },
+    }
+
+
+def _evidence(source: str, path: str | None, index: int):
+    return {
+        "source": source,
+        "path": path,
+        "resolved_path": path,
+        "sha256": f"{index + 1:064x}",
+        "size": index + 1,
+    }
+
+
+def _case_record(case, index):
+    package = case["id"]
+    version = "1.0.0"
+    ecosystem = case["ecosystem"]
+    if ecosystem == "debian":
+        purl = f"pkg:deb/debian/{package}@{version}?arch=amd64"
+        evidence = [
+            _evidence("debian-status", "/var/lib/dpkg/status", 900),
+            _evidence(
+                "debian-copyright", f"/usr/share/doc/{package}/copyright", index
+            ),
+        ]
+    elif ecosystem == "python":
+        purl = f"pkg:pypi/{package}@{version}"
+        evidence = [_evidence(
+            "python-metadata",
+            f"/usr/local/lib/python3.11/site-packages/{package}-{version}.dist-info/METADATA",
+            index,
+        )]
+    elif ecosystem == "r":
+        purl = f"pkg:cran/{package}@{version}"
+        runtime_bytes = json.dumps(
+            {"license": "", "version": "4.2.2"},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        evidence = [
+            _evidence(
+                "r-description", f"/usr/lib/R/library/{package}/DESCRIPTION", index
+            ),
+            _evidence(
+                "r-runtime-description",
+                "/usr/lib/R/library/base/DESCRIPTION",
+                index + 100,
+            ),
+            {
+                "source": "r-runtime-license",
+                "path": None,
+                "resolved_path": None,
+                "sha256": hashlib.sha256(runtime_bytes).hexdigest(),
+                "size": len(runtime_bytes),
+            },
+            _evidence(
+                "r-runtime-copyright",
+                "/usr/share/doc/r-base-core/copyright",
+                index + 200,
+            ),
+        ]
+    else:
+        purl = f"pkg:npm/{package}@{version}"
+        evidence = [_evidence(
+            "npm-package-json", "/usr/share/nodejs/npm/package.json", index
+        )]
+    metadata = deepcopy(case["metadata"])
+    if ecosystem == "debian":
+        metadata["copyright_format"] = collector.DEP5_FORMAT_URI
+    if ecosystem in {"python", "r", "npm"}:
+        metadata["license_file_tokens"] = []
+    if ecosystem == "r":
+        metadata["runtime_copyright_format"] = collector.DEP5_FORMAT_URI
+    if ecosystem == "python":
+        metadata["license_files"] = []
+    return {
+        "ecosystem": ecosystem,
+        "package": package,
+        "version": version,
+        "purl": purl,
+        "raw_values": case["raw_values"],
+        "metadata": metadata,
+        "evidence": evidence,
+    }
+
+
+def _fixture():
+    fixture = json.loads(CASES.read_text(encoding="utf-8"))
+    assert fixture["schema_version"] == "1.0"
+    records = [
+        _case_record(case, index)
+        for index, case in enumerate(fixture["cases"])
+    ]
+    records.sort(key=lambda item: item["purl"])
+    evidence = {
+        "schema_version": "1.0",
+        "collector": "gdpval-agentic-v2-license-evidence-v1",
+        "records": records,
+        "records_sha256": canonical_sha256(records),
+    }
+    sbom = {
+        "packages": [{
+            "name": record["package"],
+            "versionInfo": record["version"],
+            "externalRefs": [{"referenceLocator": record["purl"]}],
+        } for record in records],
+    }
+    policy = _policy()
+    exception_record = next(
+        record for record in records if record["package"] == "python-exception"
+    )
+    policy["license"]["exceptions"] = [{
+        "ecosystem": "python",
+        "package": exception_record["package"],
+        "version": exception_record["version"],
+        "purl": exception_record["purl"],
+        "normalized_expression": "MIT",
+        "evidence_sha256": canonical_sha256(exception_record["evidence"]),
+        "reason": "fixture-review",
+        "approver": "fixture-approver",
+        "expires_at": "2027-07-31",
+    }]
+    subject = _subject()
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    return fixture, subject, sbom, evidence, policy, report
+
+
+def test_phase1c_fixture_has_exact_classifications_and_expressions():
+    fixture, _subject_value, _sbom, _evidence_value, _policy_value, report = _fixture()
+    decisions = {item["package"]: item for item in report["decisions"]}
+
+    for case in fixture["cases"]:
+        decision = decisions[case["id"]]
+        assert decision["classification"] == case["expected_classification"]
+        assert decision["normalized_expression"] == case["expected_expression"]
+        assert decision["evidence"]
+        assert decision["evidence_sha256"] == canonical_sha256(decision["evidence"])
+
+    assert report["counts"] == {
+        "ambiguous": 1,
+        "denied": 1,
+        "exception": 1,
+        "missing_metadata": 1,
+        "resolved": 4,
+        "unverifiable": 1,
+    }
+    assert report["unresolved_count"] == 3
+    assert report["status"] == "failed"
+
+
+def test_phase1c_report_is_canonical_deterministic_and_schema_valid():
+    _fixture_value, subject, sbom, evidence, policy, report = _fixture()
+    repeated = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=deepcopy(sbom),
+        license_evidence=deepcopy(evidence),
+        policy=deepcopy(policy),
+        policy_sha256=canonical_sha256(policy),
+    )
+
+    assert repeated == report
+    assert json.dumps(report, sort_keys=True, separators=(",", ":")) == json.dumps(
+        repeated, sort_keys=True, separators=(",", ":")
+    )
+    unsigned = deepcopy(report)
+    claimed = unsigned.pop("report_sha256")
+    assert claimed == canonical_sha256(unsigned)
+    assert report["decisions_sha256"] == canonical_sha256(report["decisions"])
+
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(report)
+    mismatched = deepcopy(report)
+    mismatched["decisions"][0]["ecosystem"] = "npm"
+    assert list(Draft202012Validator(schema).iter_errors(mismatched))
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("foundation_only",), 1),
+        (("package_count",), 9.0),
+        (("counts", "resolved"), True),
+        (("decisions", 0, "evidence", 0, "size"), 1.0),
+    ],
+)
+def test_phase1c_persisted_report_rejects_type_coercion(path, value):
+    _fixture_value, subject, sbom, evidence, policy, report = _fixture()
+    tampered = deepcopy(report)
+    target = tampered
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    unsigned = deepcopy(tampered)
+    unsigned.pop("report_sha256")
+    tampered["report_sha256"] = canonical_sha256(unsigned)
+
+    with pytest.raises(ValueError, match="license report identity"):
+        validate_license_report(
+            tampered,
+            subject=subject,
+            subject_sha256=canonical_sha256(subject),
+            sbom=sbom,
+            license_evidence=evidence,
+            policy=policy,
+            policy_sha256=canonical_sha256(policy),
+        )
+
+
+def test_phase1c_empty_inventory_cannot_build_verified_report():
+    subject = _subject()
+    policy = _policy()
+    evidence = {
+        "schema_version": "1.0",
+        "collector": "gdpval-agentic-v2-license-evidence-v1",
+        "records": [],
+        "records_sha256": canonical_sha256([]),
+    }
+
+    with pytest.raises(ValueError, match="(evidence identity|inventory is empty)"):
+        build_license_report(
+            subject=subject,
+            subject_sha256=canonical_sha256(subject),
+            sbom={"packages": []},
+            license_evidence=evidence,
+            policy=policy,
+            policy_sha256=canonical_sha256(policy),
+        )
+
+
+def test_phase1c_evaluator_runtime_drift_is_rejected(monkeypatch):
+    monkeypatch.setattr(license_module.packaging, "__version__", "26.3")
+
+    with pytest.raises(RuntimeError, match="runtime identity differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_parser_source_drift_is_rejected(tmp_path, monkeypatch):
+    tampered = tmp_path / "__init__.py"
+    tampered.write_text("def canonicalize_license_expression(value): return 'MIT'\n")
+    monkeypatch.setattr(license_module.packaging_licenses, "__file__", str(tampered))
+
+    with pytest.raises(RuntimeError, match="parser identity differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_evaluator_callable_tamper_is_rejected(monkeypatch):
+    original = license_module.packaging_licenses.canonicalize_license_expression
+
+    def forged(value):
+        return original(value)
+
+    forged.__module__ = "packaging.licenses"
+    monkeypatch.setattr(
+        license_module.packaging_licenses,
+        "canonicalize_license_expression",
+        forged,
+    )
+
+    with pytest.raises(RuntimeError, match="parser identity differs"):
+        license_module.license_evaluator_runtime_identity()
+
+
+def test_phase1c_staged_evaluator_runtime_is_source_only(tmp_path):
+    identity = builder._stage_license_evaluator_runtime(tmp_path)
+
+    assert identity["runtime_graph_sha256"] == (
+        "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"
+    )
+    assert sorted(
+        str(path.relative_to(tmp_path))
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    ) == list(builder._LICENSE_RUNTIME_PATHS)
+    assert not list(tmp_path.rglob("*.pyc"))
+    assert not list(tmp_path.rglob("__pycache__"))
+
+
+def test_phase1c_verifier_command_uses_isolated_no_site_runtime(tmp_path):
+    command = builder._verifier_command(
+        runtime_root=tmp_path / "runtime",
+        verifier=tmp_path / "verify.py",
+        image_id="sha256:" + "a" * 64,
+        source_revision="b" * 40,
+        oci_layout=tmp_path / "oci",
+        output_directory=tmp_path / "evidence",
+        session_id="c" * 32,
+    )
+
+    assert command[:6] == [
+        sys.executable,
+        "-I",
+        "-S",
+        "-B",
+        "-c",
+        builder._VERIFIER_BOOTSTRAP,
+    ]
+    assert command[-2:] == ["--session-id", "c" * 32]
+
+
+def test_phase1c_verifier_command_executes_source_only_runtime(tmp_path):
+    runtime_root = tmp_path / "runtime"
+    builder._stage_license_evaluator_runtime(runtime_root)
+    verifier_path = tmp_path / "verify.py"
+    verifier_path.write_text(
+        "import sys\n"
+        "from packaging.licenses import canonicalize_license_expression\n"
+        "assert sys.flags.isolated == 1\n"
+        "assert sys.flags.no_site == 1\n"
+        "assert sys.dont_write_bytecode\n"
+        "assert canonicalize_license_expression('mit') == 'MIT'\n"
+        "print('isolated-evaluator-ok')\n",
+        encoding="utf-8",
+    )
+    marker = tmp_path / "startup-ran"
+    hostile = tmp_path / "hostile"
+    hostile.mkdir()
+    (hostile / "sitecustomize.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n",
+        encoding="utf-8",
+    )
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(hostile)
+    command = builder._verifier_command(
+        runtime_root=runtime_root,
+        verifier=verifier_path,
+        image_id="sha256:" + "a" * 64,
+        source_revision="b" * 40,
+        oci_layout=tmp_path / "oci",
+        output_directory=tmp_path / "evidence",
+        session_id="c" * 32,
+    )
+
+    completed = subprocess.run(
+        command,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    assert completed.stdout == b"isolated-evaluator-ok\n"
+    assert not marker.exists()
+    assert not list(runtime_root.rglob("*.pyc"))
+
+
+def test_phase1c_verifier_timeout_budget_exceeds_internal_probe_budget():
+    expected_overhead = (
+        substrate_module.AGENTIC_V2_SHORT_DOCKER_COMMAND_LIMIT
+        * substrate_module.AGENTIC_V2_SHORT_DOCKER_TIMEOUT_SECONDS
+        + substrate_module.AGENTIC_V2_GIT_COMMAND_LIMIT
+        * substrate_module.AGENTIC_V2_GIT_TIMEOUT_SECONDS
+        + substrate_module.AGENTIC_V2_EVIDENCE_ROOT_COPY_LIMIT
+        * substrate_module.AGENTIC_V2_EVIDENCE_ROOT_COPY_TIMEOUT_SECONDS
+        + (
+            substrate_module.AGENTIC_V2_VERIFICATION_SESSION_SWEEP_LIMIT + 1
+        )
+        * substrate_module.AGENTIC_V2_VERIFICATION_SESSION_INVENTORY_TIMEOUT_SECONDS
+        + substrate_module.AGENTIC_V2_VERIFICATION_SESSION_MAX_CONTAINERS
+        * substrate_module.AGENTIC_V2_VERIFICATION_SESSION_SWEEP_LIMIT
+        * substrate_module.AGENTIC_V2_VERIFICATION_SESSION_REMOVE_TIMEOUT_SECONDS
+        + substrate_module.AGENTIC_V2_HOST_VALIDATION_BUDGET_SECONDS
+    )
+    assert substrate_module.AGENTIC_V2_VERIFIER_OVERHEAD_SECONDS == expected_overhead
+    assert builder.AGENTIC_V2_VERIFIER_TIMEOUT_SECONDS >= (
+        builder.AGENTIC_V2_IMAGE_PROBE_COUNT
+        * builder.AGENTIC_V2_IMAGE_PROBE_TIMEOUT_SECONDS
+        + builder.AGENTIC_V2_VERIFIER_OVERHEAD_SECONDS
+    )
+
+
+def test_phase1c_verifier_timeout_always_cleans_session(monkeypatch, tmp_path):
+    session_id = "c" * 32
+    cleaned = []
+
+    class TimedOutProcess:
+        pid = 12345
+
+        def communicate(self, *, timeout):
+            raise subprocess.TimeoutExpired(["verifier"], timeout)
+
+    def popen(command, **kwargs):
+        assert kwargs["start_new_session"] is True
+        return TimedOutProcess()
+
+    monkeypatch.setattr(
+        builder.subprocess,
+        "Popen",
+        popen,
+    )
+    monkeypatch.setattr(
+        builder,
+        "_terminate_verifier_process_group",
+        lambda process: cleaned.append(("terminated", process.pid)),
+    )
+    monkeypatch.setattr(
+        builder,
+        "_cleanup_verification_session",
+        lambda value: cleaned.append(("cleaned", value)),
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        builder._run_verifier(
+            [sys.executable, "-c", "pass"],
+            cwd=tmp_path,
+            environment={},
+            session_id=session_id,
+        )
+
+    assert cleaned == [
+        ("terminated", 12345),
+        ("cleaned", session_id),
+    ]
+
+
+def test_phase1c_session_cleanup_removes_all_and_confirms_absence(monkeypatch):
+    session_id = "d" * 32
+    first = ["a" * 64, "b" * 64]
+    inventories = iter([first, [], [], []])
+    removed = []
+    monkeypatch.setattr(
+        builder,
+        "_verification_session_containers",
+        lambda value: next(inventories),
+    )
+    monkeypatch.setattr(
+        builder.subprocess,
+        "run",
+        lambda command, **kwargs: (
+            removed.append(command[-1])
+            or SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        ),
+    )
+
+    builder._cleanup_verification_session(session_id)
+
+    assert removed == first
+
+
+def test_phase1c_session_cleanup_continues_after_removal_failure(monkeypatch):
+    session_id = "e" * 32
+    first = ["a" * 64, "b" * 64]
+    inventories = iter([first, [], [], []])
+    removed = []
+    monkeypatch.setattr(
+        builder,
+        "_verification_session_containers",
+        lambda value: next(inventories),
+    )
+
+    def run(command, **kwargs):
+        removed.append(command[-1])
+        return SimpleNamespace(
+            returncode=1 if command[-1] == first[0] else 0,
+            stdout=b"",
+            stderr=b"failed" if command[-1] == first[0] else b"",
+        )
+
+    monkeypatch.setattr(builder.subprocess, "run", run)
+
+    with pytest.raises(RuntimeError, match="cleanup is incomplete"):
+        builder._cleanup_verification_session(session_id)
+
+    assert removed == first
+
+
+def test_phase1c_session_cleanup_retries_after_initial_inventory_failure(
+    monkeypatch,
+):
+    session_id = "f" * 32
+    identifier = "a" * 64
+    inventories = iter([
+        RuntimeError("initial inventory failed"),
+        [identifier],
+        [],
+        [],
+    ])
+    removed = []
+
+    def inventory(_value):
+        result = next(inventories)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr(builder, "_verification_session_containers", inventory)
+    monkeypatch.setattr(
+        builder.subprocess,
+        "run",
+        lambda command, **kwargs: (
+            removed.append(command[-1])
+            or SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        ),
+    )
+
+    with pytest.raises(builder.VerificationLifecycleError) as error:
+        builder._cleanup_verification_session(session_id)
+
+    assert removed == [identifier]
+    assert any("initial inventory failed" in str(item) for item in error.value.failures)
+
+
+def test_phase1c_lifecycle_preserves_timeout_termination_and_cleanup_failures(
+    monkeypatch,
+    tmp_path,
+):
+    session_id = "1" * 32
+
+    class TimedOutProcess:
+        pid = 12345
+
+        def communicate(self, *, timeout):
+            raise subprocess.TimeoutExpired(["verifier"], timeout)
+
+    monkeypatch.setattr(
+        builder.subprocess,
+        "Popen",
+        lambda command, **kwargs: TimedOutProcess(),
+    )
+    monkeypatch.setattr(
+        builder,
+        "_terminate_verifier_process_group",
+        lambda process: (_ for _ in ()).throw(RuntimeError("termination failed")),
+    )
+    monkeypatch.setattr(
+        builder,
+        "_cleanup_verification_session",
+        lambda value: (_ for _ in ()).throw(RuntimeError("cleanup failed")),
+    )
+
+    with pytest.raises(builder.VerificationLifecycleError) as error:
+        builder._run_verifier(
+            [sys.executable, "-c", "pass"],
+            cwd=tmp_path,
+            environment={},
+            session_id=session_id,
+        )
+
+    assert [type(item) for item in error.value.failures] == [
+        subprocess.TimeoutExpired,
+        RuntimeError,
+        RuntimeError,
+    ]
+
+
+def test_phase1c_popen_failure_still_cleans_session(monkeypatch, tmp_path):
+    session_id = "2" * 32
+    cleaned = []
+    monkeypatch.setattr(
+        builder.subprocess,
+        "Popen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("spawn failed")),
+    )
+    monkeypatch.setattr(
+        builder,
+        "_cleanup_verification_session",
+        lambda value: cleaned.append(value),
+    )
+
+    with pytest.raises(OSError, match="spawn failed"):
+        builder._run_verifier(
+            [sys.executable, "-c", "pass"],
+            cwd=tmp_path,
+            environment={},
+            session_id=session_id,
+        )
+
+    assert cleaned == [session_id]
+
+
+def test_phase1c_process_group_attempts_kill_after_term_failure(monkeypatch):
+    signals = []
+    waits = []
+
+    class Process:
+        pid = 12345
+
+        def poll(self):
+            return None
+
+        def wait(self, *, timeout):
+            waits.append(timeout)
+            if len(waits) == 1:
+                raise subprocess.TimeoutExpired(["verifier"], timeout)
+            return -9
+
+    def killpg(_pid, signal_value):
+        signals.append(signal_value)
+        if signal_value == signal.SIGTERM:
+            raise PermissionError("term failed")
+
+    monkeypatch.setattr(builder.os, "killpg", killpg)
+
+    with pytest.raises(builder.VerificationLifecycleError) as error:
+        builder._terminate_verifier_process_group(Process())
+
+    assert signals == [signal.SIGTERM, signal.SIGKILL]
+    assert waits == [10, 10]
+    assert isinstance(error.value.failures[0], PermissionError)
+
+
+def test_phase1c_all_verifier_containers_are_session_labeled():
+    for function in (
+        verifier._run_image_json,
+        verifier._docker_base_isolation_probe,
+        verifier._docker_resource_limit_probe,
+        verifier._verify_disabled_entrypoint,
+        verifier._verify_embedded_files,
+        verifier._verify_license_evidence_files,
+    ):
+        assert "session.label_arguments()" in inspect.getsource(function)
+
+
+def test_phase1c_builder_entrypoint_ignores_hostile_startup_before_clean_guard(
+    tmp_path,
+):
+    marker = tmp_path / "builder-startup-ran"
+    hostile = tmp_path / "hostile-builder"
+    hostile.mkdir()
+    (hostile / "sitecustomize.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n",
+        encoding="utf-8",
+    )
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(hostile)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    git_marker = tmp_path / "fake-git-ran"
+    docker_marker = tmp_path / "fake-docker-ran"
+    for name, tool_marker in (("git", git_marker), ("docker", docker_marker)):
+        path = fake_bin / name
+        path.write_text(
+            f"#!/bin/sh\ntouch {str(tool_marker)!r}\nexit 99\n",
+            encoding="utf-8",
+        )
+        path.chmod(0o755)
+    environment["PATH"] = f"{fake_bin}:/usr/bin:/bin"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-B",
+            str(Path(builder.__file__)),
+            "--help",
+        ],
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    expected_help = (
+        b"usage: build_candidate.py [-h] --output-root OUTPUT_ROOT\n\n"
+        b"options:\n"
+        b"  -h, --help            show this help message and exit\n"
+        b"  --output-root OUTPUT_ROOT\n"
+    )
+    if completed.returncode == 0:
+        assert completed.stdout == expected_help
+        assert completed.stderr == b""
+    else:
+        assert completed.stdout == b""
+        assert completed.stderr.endswith(
+            b"RuntimeError: candidate builder requires a clean source tree\n"
+        )
+    assert not marker.exists()
+    assert not git_marker.exists()
+    assert not docker_marker.exists()
+
+
+def test_phase1c_builder_launches_only_git_staged_sources(
+    tmp_path, monkeypatch
+):
+    fake_repository = tmp_path / "repository"
+    fake_batch_root = fake_repository / "batch-runner"
+    (fake_batch_root / "packaging").mkdir(parents=True)
+    (fake_batch_root / "packaging" / "__init__.py").write_text(
+        "raise RuntimeError('shadow packaging executed')\n",
+        encoding="utf-8",
+    )
+    (fake_batch_root / "core").mkdir()
+    (fake_batch_root / "core" / "agentic_v2_license.py").write_text(
+        "raise RuntimeError('dirty core executed')\n",
+        encoding="utf-8",
+    )
+    pycache = fake_batch_root / "core" / "__pycache__"
+    pycache.mkdir()
+    (pycache / "agentic_v2_license.cpython-310.pyc").write_bytes(b"unchecked")
+    runtime_source = tmp_path / "runtime-source"
+    builder._stage_license_evaluator_runtime(runtime_source)
+    source_revision = "a" * 40
+    blobs = {
+        path: f"exact:{path}\n".encode("ascii")
+        for path in builder._BUILDER_SOURCE_PATHS
+    }
+    commands = []
+
+    def bootstrap_git(_root, *arguments):
+        if arguments == ("rev-parse", "HEAD"):
+            return (source_revision + "\n").encode("ascii")
+        if arguments[:2] == ("status", "--porcelain"):
+            return b""
+        raise AssertionError(arguments)
+
+    def run(command, **kwargs):
+        commands.append((command, kwargs))
+        staged_root = Path(kwargs["env"][builder._STAGED_ROOT_ENV])
+        staged_runtime = Path(kwargs["env"][builder._RUNTIME_ROOT_ENV])
+        assert command[:4] == [sys.executable, "-I", "-S", "-B"]
+        assert Path(command[4]) == (
+            staged_root / "sandbox" / "v2" / "build_candidate.py"
+        )
+        for path, expected in blobs.items():
+            assert (
+                staged_root / path.removeprefix("batch-runner/")
+            ).read_bytes() == expected
+        assert not (staged_root / "packaging").exists()
+        assert not list(staged_root.rglob("*.pyc"))
+        assert builder._bootstrap_runtime_matches(staged_runtime)
+        assert "PYTHONPATH" not in kwargs["env"]
+        assert kwargs["env"]["PATH"] == builder._TRUSTED_PATH
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(builder, "BATCH_ROOT", fake_batch_root)
+    monkeypatch.setattr(builder, "_bootstrap_git", bootstrap_git)
+    monkeypatch.setattr(
+        builder,
+        "_bootstrap_git_blob",
+        lambda _root, _revision, path: blobs[path],
+    )
+    monkeypatch.setattr(builder, "_bootstrap_runtime_root", lambda: runtime_source)
+    monkeypatch.setattr(builder.subprocess, "run", run)
+    monkeypatch.setattr(
+        builder.sys,
+        "argv",
+        ["build_candidate.py", "--output-root", str(tmp_path / "output")],
+    )
+    for name in builder._BOOTSTRAP_FORBIDDEN_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+    assert builder._launch_staged_builder() == 0
+    assert len(commands) == 1
+
+
+def test_phase1c_builder_rejects_head_move_after_staging(
+    tmp_path, monkeypatch
+):
+    staged_revision = "a" * 40
+    monkeypatch.setattr(builder, "_require_no_credentials", lambda: None)
+    monkeypatch.setattr(builder, "license_evaluator_runtime_identity", lambda: {})
+    monkeypatch.setattr(
+        builder,
+        "_require_tools",
+        lambda: pytest.fail("Docker preflight ran after staged HEAD moved"),
+    )
+    monkeypatch.setattr(builder, "_open_build_lock", lambda _path: open(
+        tmp_path / "lock", "a+", encoding="utf-8"
+    ))
+    monkeypatch.setattr(builder.fcntl, "flock", lambda *args: None)
+    monkeypatch.setattr(
+        builder,
+        "_git",
+        lambda *args: "b" * 40 if args == ("rev-parse", "HEAD") else "",
+    )
+    monkeypatch.setattr(
+        builder,
+        "_load_parent_lock_from_git",
+        lambda _revision: pytest.fail("parent lock read after HEAD moved"),
+    )
+
+    with pytest.raises(RuntimeError, match="HEAD moved after source staging"):
+        builder.build_candidate(
+            tmp_path / "output",
+            source_revision=staged_revision,
+        )
+
+
+def test_phase1c_builder_uses_only_bootstrap_pinned_revision(
+    tmp_path, monkeypatch
+):
+    staged_revision = "a" * 40
+    parent_lock = {
+        "v1_dockerfile_sha256": "c" * 64,
+        "reference": "fixture",
+        "observed_local_image_id": "sha256:" + "d" * 64,
+    }
+    captured = []
+    monkeypatch.setattr(builder, "_require_no_credentials", lambda: None)
+    monkeypatch.setattr(builder, "license_evaluator_runtime_identity", lambda: {})
+    monkeypatch.setattr(builder, "_require_tools", lambda: None)
+    monkeypatch.setattr(builder, "_open_build_lock", lambda _path: open(
+        tmp_path / "lock", "a+", encoding="utf-8"
+    ))
+    monkeypatch.setattr(builder.fcntl, "flock", lambda *args: None)
+    monkeypatch.setattr(
+        builder,
+        "_git",
+        lambda *args: staged_revision if args == ("rev-parse", "HEAD") else "",
+    )
+    monkeypatch.setattr(
+        builder,
+        "_load_parent_lock_from_git",
+        lambda revision: (captured.append(("parent", revision)) or parent_lock),
+    )
+    monkeypatch.setattr(
+        builder,
+        "_git_blob_sha256",
+        lambda revision, path: (
+            captured.append((path, revision))
+            or parent_lock["v1_dockerfile_sha256"]
+        ),
+    )
+    monkeypatch.setattr(
+        builder,
+        "_git_blob",
+        lambda revision, path: (
+            captured.append((path, revision))
+            or json.dumps(
+                json.loads(
+                    Path("sandbox/agentic_v2_capabilities.json").read_text()
+                )
+            ).encode()
+        ),
+    )
+    monkeypatch.setattr(
+        builder,
+        "_docker_json",
+        lambda _command: [{
+            "Id": parent_lock["observed_local_image_id"],
+            "Architecture": "amd64",
+            "Os": "linux",
+            "RepoDigests": [parent_lock["reference"]],
+        }],
+    )
+    monkeypatch.setattr(
+        builder,
+        "_build_locked",
+        lambda output_root, **kwargs: (
+            captured.append(("build", kwargs["source_revision"])) or {"ok": True}
+        ),
+    )
+
+    assert builder.build_candidate(
+        tmp_path / "output",
+        source_revision=staged_revision,
+    ) == {"ok": True}
+    assert captured == [
+        ("parent", staged_revision),
+        ("batch-runner/sandbox/Dockerfile", staged_revision),
+        (
+            "batch-runner/sandbox/agentic_v2_capabilities.json",
+            staged_revision,
+        ),
+        ("build", staged_revision),
+    ]
+
+
+def test_phase1c_build_locked_propagates_pinned_revision_end_to_end(
+    tmp_path, monkeypatch
+):
+    staged_revision = "a" * 40
+    image_id = "sha256:" + "b" * 64
+    manifest_digest = "sha256:" + "c" * 64
+    parent_lock = {
+        "reference": "parent@sha256:" + "d" * 64,
+        "manifest_digest": "sha256:" + "d" * 64,
+    }
+    manifest = SimpleNamespace(sha256="e" * 64)
+    captured = []
+
+    def stage_context(revision, root):
+        captured.append(("context", revision))
+
+    def stage_files(revision, root, paths):
+        captured.append(("verifier-files", revision))
+
+    def run(command, **kwargs):
+        captured.append(("command", command))
+        if command[:3] == [builder._TRUSTED_DOCKER, "image", "save"]:
+            output = Path(command[command.index("--output") + 1])
+            output.write_bytes(b"archive")
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    def export(archive, output):
+        captured.append(("export", archive.read_bytes()))
+        output.mkdir()
+        return {"manifest_digest": manifest_digest}
+
+    def run_verifier(command, *, cwd, environment, session_id):
+        captured.append(("verifier-command", command))
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            json.dumps({
+                "gate_status": "blocked",
+                "blocking_evidence": ["cve"],
+            }).encode(),
+            b"",
+        )
+
+    monkeypatch.setattr(builder, "_stage_git_context", stage_context)
+    monkeypatch.setattr(builder, "_stage_git_files", stage_files)
+    monkeypatch.setattr(builder.subprocess, "run", run)
+    monkeypatch.setattr(builder, "_docker_json", lambda command: [{"Id": image_id}])
+    monkeypatch.setattr(builder, "export_docker_archive_to_oci", export)
+    monkeypatch.setattr(
+        builder,
+        "_stage_license_evaluator_runtime",
+        lambda root: root.mkdir(parents=True),
+    )
+    monkeypatch.setattr(builder, "_run_verifier", run_verifier)
+
+    output_root = tmp_path / "candidate"
+    report = builder._build_locked(
+        output_root,
+        source_revision=staged_revision,
+        parent_lock=parent_lock,
+        manifest=manifest,
+    )
+
+    build_command = next(
+        command
+        for name, command in captured
+        if name == "command" and command[1] == "build"
+    )
+    verifier_command = next(
+        command for name, command in captured if name == "verifier-command"
+    )
+    assert ("context", staged_revision) in captured
+    assert ("verifier-files", staged_revision) in captured
+    assert f"SOURCE_REVISION={staged_revision}" in build_command
+    assert verifier_command[
+        verifier_command.index("--source-revision") + 1
+    ] == staged_revision
+    assert report["source_revision"] == staged_revision
+    saved_report = json.loads(
+        (output_root / "build-report.json").read_text(encoding="utf-8")
+    )
+    assert saved_report["source_revision"] == staged_revision
+
+
+def test_phase1c_staged_builder_rejects_shadow_source_and_bytecode(
+    tmp_path, monkeypatch
+):
+    staged_root = tmp_path / "batch-runner"
+    source_revision = "a" * 40
+    blobs = {
+        path: f"exact:{path}\n".encode("ascii")
+        for path in builder._BUILDER_SOURCE_PATHS
+    }
+    monkeypatch.setattr(
+        builder,
+        "_bootstrap_git_blob",
+        lambda _root, _revision, path: blobs[path],
+    )
+    builder._bootstrap_stage_sources(tmp_path, source_revision, staged_root)
+    monkeypatch.setattr(
+        builder,
+        "__file__",
+        str(staged_root / "sandbox" / "v2" / "build_candidate.py"),
+    )
+    pycache = staged_root / "core" / "__pycache__"
+    pycache.mkdir()
+    (pycache / "agentic_v2_license.cpython-310.pyc").write_bytes(b"unchecked")
+
+    with pytest.raises(RuntimeError, match="source inventory differs"):
+        builder._bootstrap_validate_staged_sources(
+            staged_root,
+            tmp_path,
+            source_revision,
+        )
+
+
+def test_phase1c_staged_runtime_rejects_extra_module_and_bytecode(tmp_path):
+    builder._stage_license_evaluator_runtime(tmp_path)
+    assert builder._bootstrap_staged_runtime_matches(tmp_path)
+    (tmp_path / "packaging" / "shadow.py").write_text(
+        "raise RuntimeError('shadow')\n", encoding="utf-8"
+    )
+    assert not builder._bootstrap_staged_runtime_matches(tmp_path)
+    (tmp_path / "packaging" / "shadow.py").unlink()
+    pycache = tmp_path / "packaging" / "__pycache__"
+    pycache.mkdir()
+    (pycache / "__init__.cpython-310.pyc").write_bytes(b"unchecked")
+    assert not builder._bootstrap_staged_runtime_matches(tmp_path)
+
+
+def test_phase1c_isolated_evaluator_runtime_ignores_system_sitecustomize(
+    tmp_path,
+):
+    runtime_root = tmp_path / "runtime"
+    builder._stage_license_evaluator_runtime(runtime_root)
+    marker = tmp_path / "startup-ran"
+    hostile = tmp_path / "hostile"
+    hostile.mkdir()
+    (hostile / "sitecustomize.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n",
+        encoding="utf-8",
+    )
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(hostile)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-B",
+            "-c",
+            (
+                "import sys;sys.path.insert(0,sys.argv[1]);"
+                "from packaging.licenses import canonicalize_license_expression;"
+                "assert canonicalize_license_expression('mit') == 'MIT';"
+                "assert sys.flags.isolated == 1 and sys.flags.no_site == 1;"
+                "assert sys.dont_write_bytecode"
+            ),
+            str(runtime_root),
+        ],
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    assert not marker.exists()
+    assert not list(runtime_root.rglob("*.pyc"))
+
+
+def test_phase1c_report_binds_candidate_oci_sbom_evidence_tools_and_policy():
+    _fixture_value, subject, sbom, evidence, policy, report = _fixture()
+    binding = report["binding"]
+
+    assert binding == {
+        "subject_sha256": canonical_sha256(subject),
+        "image_id": subject["image_id"],
+        "config_digest": subject["image_id"],
+        "oci_manifest_digest": subject["oci_manifest_digest"],
+        "source_revision": subject["source_revision"],
+        "effective_sbom_sha256": canonical_sha256(sbom),
+        "license_evidence_sha256": canonical_sha256(evidence),
+        "license_collector_sha256": subject["license_collector_sha256"],
+        "license_evaluator_sha256": subject["license_evaluator_sha256"],
+        "license_evaluator_packaging_version": "26.2",
+        "license_evaluator_parser_sha256": (
+            "fc9c745d1883ff9f296a5b169f22eb2ee879f59a4608f20f5cb29d668f4e26f4"
+        ),
+        "license_evaluator_python_version": "3.10.12",
+        "license_evaluator_callable_sha256": (
+            "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"
+        ),
+        "license_evaluator_runtime_graph_sha256": (
+            "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"
+        ),
+        "license_evaluator_spdx_version": "3.27.0",
+        "license_evaluator_spdx_sha256": (
+            "ecc082fdc1fcdcae47b2f56c4ce2cdc2c9d6d54ca555a09814abd78dece7a230"
+        ),
+        "policy_sha256": canonical_sha256(policy),
+    }
+
+    for key in binding:
+        tampered = deepcopy(report)
+        tampered["binding"][key] = "0" * 64
+        with pytest.raises(ValueError, match="license report identity"):
+            validate_license_report(
+                tampered,
+                subject=subject,
+                subject_sha256=canonical_sha256(subject),
+                sbom=sbom,
+                license_evidence=evidence,
+                policy=policy,
+                policy_sha256=canonical_sha256(policy),
+            )
+
+
+def test_phase1c_direct_report_api_rejects_incorrect_input_hashes():
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    arguments = {
+        "subject": subject,
+        "subject_sha256": canonical_sha256(subject),
+        "sbom": sbom,
+        "license_evidence": evidence,
+        "policy": policy,
+        "policy_sha256": canonical_sha256(policy),
+    }
+    wrong_subject = dict(arguments)
+    wrong_subject["subject_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="subject hash differs"):
+        build_license_report(**wrong_subject)
+
+    wrong_policy = dict(arguments)
+    wrong_policy["policy_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="policy hash differs"):
+        build_license_report(**wrong_policy)
+
+
+def test_phase1c_license_evidence_rejects_inventory_and_source_tampering():
+    _fixture_value, _subject_value, sbom, evidence, _policy_value, _report = _fixture()
+
+    assert validate_license_evidence(evidence, sbom) == evidence
+
+    missing = deepcopy(evidence)
+    missing["records"].pop()
+    missing["records_sha256"] = canonical_sha256(missing["records"])
+    with pytest.raises(ValueError, match="package inventory mismatch"):
+        validate_license_evidence(missing, sbom)
+
+    wrong_source = deepcopy(evidence)
+    wrong_source["records"][0]["evidence"][0]["source"] = "forged"
+    wrong_source["records_sha256"] = canonical_sha256(wrong_source["records"])
+    with pytest.raises(ValueError, match="license"):
+        validate_license_evidence(wrong_source, sbom)
+
+    escaped = deepcopy(evidence)
+    escaped["records"][0]["evidence"][0]["path"] = "/tmp/../secret"
+    escaped["records"][0]["evidence"][0]["resolved_path"] = "/tmp/../secret"
+    escaped["records_sha256"] = canonical_sha256(escaped["records"])
+    with pytest.raises(ValueError, match="path"):
+        validate_license_evidence(escaped, sbom)
+
+    followed = deepcopy(evidence)
+    followed["records"][0]["evidence"][0]["resolved_path"] = (
+        "/usr/share/doc/another-package/copyright"
+    )
+    followed["records_sha256"] = canonical_sha256(followed["records"])
+    with pytest.raises(ValueError, match="remain lexical"):
+        validate_license_evidence(followed, sbom)
+
+    shadow = deepcopy(evidence)
+    python_record = next(
+        item for item in shadow["records"] if item["ecosystem"] == "python"
+    )
+    metadata_item = python_record["evidence"][0]
+    shadow_path = metadata_item["path"].replace(
+        "/python3.11/", "/python-shadow/"
+    )
+    metadata_item["path"] = shadow_path
+    metadata_item["resolved_path"] = shadow_path
+    shadow["records_sha256"] = canonical_sha256(shadow["records"])
+    with pytest.raises(ValueError, match="Python METADATA path is invalid"):
+        validate_license_evidence(shadow, sbom)
+
+
+@pytest.mark.parametrize(
+    ("ecosystem", "wrong_ecosystem"),
+    [
+        ("debian", "python"),
+        ("python", "r"),
+        ("r", "npm"),
+        ("npm", "debian"),
+    ],
+)
+def test_phase1c_evidence_ecosystem_must_match_purl_prefix(
+    ecosystem, wrong_ecosystem
+):
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    record = next(
+        item for item in evidence["records"] if item["ecosystem"] == ecosystem
+    )
+    record["ecosystem"] = wrong_ecosystem
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    with pytest.raises(ValueError, match="record identity"):
+        validate_license_evidence(evidence, sbom)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["nonempty-runtime-license", "runtime-digest", "runtime-size"],
+)
+def test_phase1c_host_rejects_impossible_r_runtime_evidence(mutation):
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "r")
+    runtime = next(
+        item for item in record["evidence"]
+        if item["source"] == "r-runtime-license"
+    )
+    if mutation == "nonempty-runtime-license":
+        record["metadata"]["runtime_license"] = "MIT"
+        record["raw_values"].insert(1, "MIT")
+    elif mutation == "runtime-digest":
+        runtime["sha256"] = "f" * 64
+    else:
+        runtime["size"] += 1
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    with pytest.raises(ValueError, match="R (license metadata|runtime evidence)"):
+        validate_license_evidence(evidence, sbom)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("declared_license", " MIT "),
+        ("runtime_version", " 4.2.2 "),
+        ("priority", " base "),
+        ("runtime_license_fields", [" GPL-2"]),
+    ],
+)
+def test_phase1c_host_rejects_padded_r_metadata(field, value):
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "r")
+    record["metadata"][field] = value
+    if field == "declared_license":
+        record["raw_values"][0] = value
+    elif field == "runtime_license_fields":
+        record["raw_values"][-1] = value[0]
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    with pytest.raises(ValueError, match="R license metadata"):
+        validate_license_evidence(evidence, sbom)
+
+
+def test_phase1c_host_rejects_inconsistent_r_runtime_across_records():
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    source = next(item for item in evidence["records"] if item["ecosystem"] == "r")
+    duplicate = deepcopy(source)
+    duplicate["package"] = "r-second"
+    duplicate["version"] = "2.0.0"
+    duplicate["purl"] = "pkg:cran/r-second@2.0.0"
+    description = next(
+        item for item in duplicate["evidence"] if item["source"] == "r-description"
+    )
+    description["path"] = "/usr/lib/R/library/r-second/DESCRIPTION"
+    description["resolved_path"] = description["path"]
+    copyright_item = next(
+        item for item in duplicate["evidence"]
+        if item["source"] == "r-runtime-copyright"
+    )
+    copyright_item["sha256"] = "f" * 64
+    evidence["records"].append(duplicate)
+    evidence["records"].sort(key=lambda item: item["purl"])
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+    sbom["packages"].append({
+        "name": "r-second",
+        "versionInfo": "2.0.0",
+        "externalRefs": [{"referenceLocator": duplicate["purl"]}],
+    })
+
+    with pytest.raises(ValueError, match="runtime evidence identity is inconsistent"):
+        validate_license_evidence(evidence, sbom)
+
+
+def test_phase1c_host_rejects_empty_npm_license():
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "npm")
+    record["metadata"]["license"] = ""
+    record["raw_values"] = [""]
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    with pytest.raises(ValueError, match="npm license metadata"):
+        validate_license_evidence(evidence, sbom)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "raw-without-format",
+        "format-without-copyright",
+        "raw-without-copyright",
+        "empty-format",
+        "architecture-purl-mismatch",
+    ],
+)
+def test_phase1c_host_rejects_impossible_debian_metadata(mutation):
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    record = next(
+        item for item in evidence["records"] if item["ecosystem"] == "debian"
+    )
+    copyright_items = [
+        item for item in record["evidence"]
+        if item["source"] == "debian-copyright"
+    ]
+    if mutation == "raw-without-format":
+        record["metadata"]["copyright_format"] = None
+    elif mutation in {"format-without-copyright", "raw-without-copyright"}:
+        record["evidence"].remove(copyright_items[0])
+        if mutation == "raw-without-copyright":
+            record["metadata"]["copyright_format"] = None
+    elif mutation == "empty-format":
+        record["metadata"]["copyright_format"] = ""
+    else:
+        record["metadata"]["architecture"] = "arm64"
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    with pytest.raises(ValueError, match="Debian"):
+        validate_license_evidence(evidence, sbom)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("architecture", " amd64 "),
+        ("copyright_format", " fixture "),
+        ("raw_values", [" MIT "]),
+    ],
+)
+def test_phase1c_host_rejects_padded_debian_metadata(field, value):
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    record = next(
+        item for item in evidence["records"] if item["ecosystem"] == "debian"
+    )
+    if field == "raw_values":
+        record["raw_values"] = value
+    else:
+        record["metadata"][field] = value
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    with pytest.raises(ValueError, match="Debian license metadata"):
+        validate_license_evidence(evidence, sbom)
+
+
+def test_phase1c_debian_status_identity_cannot_replay_exception():
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    records = [
+        item for item in evidence["records"] if item["ecosystem"] == "debian"
+    ]
+    target = records[0]
+    status = next(
+        item for item in target["evidence"] if item["source"] == "debian-status"
+    )
+    status["sha256"] = "f" * 64
+    exception = {
+        "ecosystem": "debian",
+        "package": target["package"],
+        "version": target["version"],
+        "purl": target["purl"],
+        "normalized_expression": "MIT",
+        "evidence_sha256": canonical_sha256(target["evidence"]),
+        "reason": "historical-status",
+        "approver": "reviewer",
+        "expires_at": "2027-07-31",
+    }
+    policy["license"]["exceptions"] = [exception]
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    with pytest.raises(ValueError, match="status evidence identity is inconsistent"):
+        build_license_report(
+            subject=subject,
+            subject_sha256=canonical_sha256(subject),
+            sbom=sbom,
+            license_evidence=evidence,
+            policy=policy,
+            policy_sha256=canonical_sha256(policy),
+        )
+
+
+def test_phase1c_exceptions_are_exact_versioned_reviewable_and_not_stale():
+    _fixture_value, subject, sbom, evidence, policy, report = _fixture()
+    assert report["counts"]["exception"] == 1
+    assert validate_license_exceptions(policy) == policy["license"]["exceptions"]
+
+    wildcard = deepcopy(policy)
+    wildcard["license"]["exceptions"][0]["version"] = "*"
+    with pytest.raises(ValueError, match="exception identity"):
+        validate_license_exceptions(wildcard)
+
+    expired = deepcopy(policy)
+    expired["license"]["exceptions"][0]["expires_at"] = "2026-07-30"
+    with pytest.raises(ValueError, match="expired"):
+        validate_license_exceptions(expired)
+
+    stale = deepcopy(policy)
+    stale["license"]["exceptions"][0]["evidence_sha256"] = "f" * 64
+    with pytest.raises(ValueError, match="stale or unmatched"):
+        build_license_report(
+            subject=subject,
+            subject_sha256=canonical_sha256(subject),
+            sbom=sbom,
+            license_evidence=evidence,
+            policy=stale,
+            policy_sha256=canonical_sha256(stale),
+        )
+
+    denied = deepcopy(policy)
+    denied["license"]["exceptions"][0]["normalized_expression"] = (
+        "MIT OR BUSL-1.1"
+    )
+    with pytest.raises(ValueError, match="exception identity"):
+        validate_license_exceptions(denied)
+
+    blank_reviewer = deepcopy(policy)
+    blank_reviewer["license"]["exceptions"][0]["approver"] = "   "
+    with pytest.raises(ValueError, match="exception identity"):
+        validate_license_exceptions(blank_reviewer)
+
+    numeric_digest = deepcopy(policy)
+    numeric_digest["license"]["exceptions"][0]["evidence_sha256"] = int(
+        "1" * 64
+    )
+    with pytest.raises(ValueError, match="exception identity"):
+        validate_license_exceptions(numeric_digest)
+
+
+@pytest.mark.parametrize(
+    "denied_identifiers",
+    [
+        ["BUSL-1.1", "Commons-Clause", "sspl-1.0"],
+        ["BUSL-1.1 OR SSPL-1.0", "Commons-Clause"],
+        ["BUSL-1.1", "Commons-Clause", "Vendor-Denied"],
+        ["BUSL-1.1", "Commons-Clause", "LicenseRef-Proprietary"],
+    ],
+)
+def test_phase1c_denied_policy_identifiers_are_exact_canonical_contract(
+    denied_identifiers,
+):
+    policy = _policy()
+    policy["license"]["denied_identifiers"] = denied_identifiers
+
+    with pytest.raises(ValueError, match="denied license identifiers"):
+        validate_license_exceptions(policy)
+    with pytest.raises(ValueError, match="supply-chain policy"):
+        SupplyChainPolicy.from_mapping(policy)
+
+
+def test_phase1c_canonical_sspl_is_denied_in_full_report():
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "npm")
+    record["raw_values"] = ["sspl-1.0"]
+    record["metadata"] = {"license": "sspl-1.0", "license_file_tokens": []}
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    decision = next(item for item in report["decisions"] if item["purl"] == record["purl"])
+
+    assert decision["classification"] == "denied"
+    assert decision["denied_identifiers"] == ["SSPL-1.0"]
+
+
+def test_phase1c_verified_license_does_not_enable_production_gate():
+    subject_mapping = _subject()
+    subject = CandidateSubject.from_mapping(subject_mapping)
+    policy_mapping = _policy()
+    policy = SupplyChainPolicy.from_mapping(policy_mapping)
+    evidence = {
+        name: evidence_item(subject, name=name, status="not_run")
+        for name in (
+            "capability_receipt", "containment", "cve", "license", "microvm",
+            "oci_layout", "provenance", "sbom", "signature",
+        )
+    }
+    evidence["license"] = evidence_item(
+        subject,
+        name="license",
+        status="verified",
+        tool_name="gdpval-agentic-v2-license-evaluator",
+        tool_version="1.0",
+        tool_sha256=subject_mapping["license_evaluator_sha256"],
+        report_sha256="f" * 64,
+    )
+
+    gate = build_evidence_report(subject, policy, evidence)
+
+    assert gate["gate_status"] == "blocked"
+    assert gate["production_activation"] == "disabled"
+    assert "containment" in gate["blocking_evidence"]
+    assert "cve" in gate["blocking_evidence"]
+    assert "microvm" in gate["blocking_evidence"]
+    assert "provenance" in gate["blocking_evidence"]
+    assert "signature" in gate["blocking_evidence"]
+
+
+def test_phase1c_collector_hashes_regular_files_and_virtual_evidence(tmp_path):
+    path = tmp_path / "LICENSE"
+    path.write_bytes(b"license-evidence")
+
+    item = collector._regular_file_evidence("fixture", path)
+    virtual = collector._virtual_evidence("fixture-virtual", {"b": 2, "a": 1})
+
+    assert item == {
+        "source": "fixture",
+        "path": str(path),
+        "resolved_path": str(path.resolve()),
+        "sha256": hashlib.sha256(b"license-evidence").hexdigest(),
+        "size": len(b"license-evidence"),
+    }
+    assert virtual["source"] == "fixture-virtual"
+    assert virtual["path"] is None
+    assert virtual["resolved_path"] is None
+    assert virtual["sha256"] == hashlib.sha256(b'{"a":1,"b":2}').hexdigest()
+
+
+def test_phase1c_image_probe_hardens_python_subprocess(monkeypatch, tmp_path):
+    commands = []
+    monkeypatch.setattr(
+        image_probe.subprocess,
+        "run",
+        lambda command, **kwargs: (
+            commands.append(command)
+            or SimpleNamespace(returncode=0, stdout=b"Python 3.11\n", stderr=b"")
+        ),
+    )
+
+    image_probe._run(["python", "--version"], cwd=tmp_path)
+
+    assert commands == [["python", "-I", "-S", "-B", "--version"]]
+
+
+def test_phase1c_host_rejects_numeric_evidence_digest():
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    evidence["records"][0]["evidence"][0]["sha256"] = int("1" * 64)
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    with pytest.raises(ValueError, match="evidence item identity"):
+        validate_license_evidence(evidence, sbom)
+
+
+def test_phase1c_python_license_files_cannot_escape_dist_info(tmp_path):
+    root = tmp_path / "fixture-1.0.dist-info"
+    licenses = root / "licenses"
+    licenses.mkdir(parents=True)
+    (licenses / "LICENSE").write_text("MIT", encoding="utf-8")
+
+    records, tokens, selections = collector._python_license_files(
+        root, ["LICENSE"], tmp_path
+    )
+
+    assert len(records) == 1
+    assert tokens == []
+    assert selections == [{
+        "declared": "LICENSE",
+        "path": str(licenses / "LICENSE"),
+    }]
+    assert records[0]["resolved_path"] == str((licenses / "LICENSE").resolve())
+
+    outside = tmp_path / "outside"
+    outside.write_text("secret", encoding="utf-8")
+    (licenses / "LICENSE").unlink()
+    (licenses / "LICENSE").symlink_to(outside)
+    with pytest.raises(RuntimeError, match="symlink-free"):
+        collector._python_license_files(root, ["LICENSE"], tmp_path)
+
+
+def test_phase1c_python_license_file_denied_token_precedes_exception(
+    tmp_path, monkeypatch
+):
+    site_root = tmp_path / "python3.11" / "site-packages"
+    metadata_root = site_root / "fixture-1.0.dist-info"
+    licenses = metadata_root / "licenses"
+    licenses.mkdir(parents=True)
+    (metadata_root / "METADATA").write_text(
+        "Name: fixture\nVersion: 1.0\nLicense-File: LICENSE\n\n",
+        encoding="utf-8",
+    )
+    (licenses / "LICENSE").write_text("SSPL-1.0\n", encoding="utf-8")
+    monkeypatch.setattr(collector, "PYTHON_PURELIB_PATH", str(site_root))
+    monkeypatch.setattr(
+        collector.sysconfig, "get_path", lambda name: str(site_root)
+    )
+    record = collector._python_records()[0]
+    evidence_sha256 = canonical_sha256(record["evidence"])
+    exception = {
+        "ecosystem": "python",
+        "package": "fixture",
+        "version": "1.0",
+        "purl": record["purl"],
+        "normalized_expression": "MIT",
+        "evidence_sha256": evidence_sha256,
+        "reason": "fixture",
+        "approver": "reviewer",
+        "expires_at": "2027-07-31",
+    }
+
+    decision = license_module._decision(
+        record,
+        {"SSPL-1.0"},
+        {(record["purl"], evidence_sha256): exception},
+    )
+
+    assert record["metadata"]["license_file_tokens"] == ["SSPL-1.0"]
+    assert decision["classification"] == "denied"
+    assert decision["exception"] is None
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (b"SSPL-1.0.\n", ["SSPL-1.0"]),
+        (b"BUSL-1.1, Commons-Clause;\n", ["BUSL-1.1", "Commons-Clause"]),
+        (b"SSPL-1.0.1\n", ["SSPL-1.0.1"]),
+    ],
+)
+def test_phase1c_license_file_tokens_handle_terminal_punctuation(
+    content, expected
+):
+    assert collector._license_file_tokens(content) == expected
+
+
+def test_phase1c_terminal_punctuation_denied_token_reaches_full_report(
+    tmp_path, monkeypatch
+):
+    site_root = tmp_path / "python3.11" / "site-packages"
+    metadata_root = site_root / "fixture-1.0.dist-info"
+    licenses = metadata_root / "licenses"
+    licenses.mkdir(parents=True)
+    (metadata_root / "METADATA").write_text(
+        "Name: fixture\nVersion: 1.0\nLicense-Expression: MIT\n"
+        "License-File: LICENSE\n\n",
+        encoding="utf-8",
+    )
+    (licenses / "LICENSE").write_text(
+        "Use is governed by SSPL-1.0.\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(collector, "PYTHON_PURELIB_PATH", str(site_root))
+    monkeypatch.setattr(
+        collector.sysconfig, "get_path", lambda name: str(site_root)
+    )
+    collected = collector._python_records()[0]
+    assert collected["metadata"]["license_file_tokens"] == ["SSPL-1.0"]
+
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    replaced = next(
+        item
+        for item in evidence["records"]
+        if item["ecosystem"] == "python" and item["package"] == "python-denied"
+    )
+    old_purl = replaced["purl"]
+    hosted = deepcopy(collected)
+    distribution_root = (
+        "/usr/local/lib/python3.11/site-packages/fixture-1.0.dist-info"
+    )
+    hosted["evidence"][0]["path"] = f"{distribution_root}/METADATA"
+    hosted["evidence"][0]["resolved_path"] = f"{distribution_root}/METADATA"
+    hosted["evidence"][1]["path"] = f"{distribution_root}/licenses/LICENSE"
+    hosted["evidence"][1]["resolved_path"] = (
+        f"{distribution_root}/licenses/LICENSE"
+    )
+    hosted["metadata"]["license_files"][0]["path"] = (
+        f"{distribution_root}/licenses/LICENSE"
+    )
+    replaced.clear()
+    replaced.update(hosted)
+    evidence["records"].sort(key=lambda item: item["purl"])
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+    package = next(
+        item
+        for item in sbom["packages"]
+        if item["externalRefs"][0]["referenceLocator"] == old_purl
+    )
+    package["name"] = hosted["package"]
+    package["versionInfo"] = hosted["version"]
+    package["externalRefs"][0]["referenceLocator"] = hosted["purl"]
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    decision = next(
+        item for item in report["decisions"] if item["purl"] == hosted["purl"]
+    )
+
+    assert decision["classification"] == "denied"
+    assert decision["denied_identifiers"] == ["SSPL-1.0"]
+
+
+def test_phase1c_host_rejects_undeclared_python_license_file():
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "python")
+    distribution_root = Path(record["evidence"][0]["path"]).parent
+    record["evidence"].append(
+        _evidence(
+            "python-license-file",
+            str(distribution_root / "licenses" / "LICENSE"),
+            810,
+        )
+    )
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    with pytest.raises(ValueError, match="license file evidence"):
+        validate_license_evidence(evidence, sbom)
+
+
+def test_phase1c_host_rejects_python_license_selection_and_token_forgery():
+    _fixture_value, _subject, sbom, evidence, _policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "python")
+    distribution_root = Path(record["evidence"][0]["path"]).parent
+    selected_path = str(distribution_root / "licenses" / "LICENSE")
+    record["evidence"].append(
+        _evidence("python-license-file", selected_path, 811)
+    )
+    record["metadata"]["license_files"] = [{
+        "declared": "LICENSE",
+        "path": str(distribution_root / "undeclared" / "LICENSE"),
+    }]
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+    with pytest.raises(ValueError, match="license file path"):
+        validate_license_evidence(evidence, sbom)
+
+    record["metadata"]["license_files"][0]["path"] = selected_path
+    record["metadata"]["license_file_tokens"] = ["SSPL-1.0é"]
+    record["raw_values"].append("SSPL-1.0é")
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+    with pytest.raises(ValueError, match="Python license metadata"):
+        validate_license_evidence(evidence, sbom)
+
+
+def test_phase1c_regular_file_reader_rejects_intermediate_symlink(tmp_path):
+    actual = tmp_path / "actual"
+    actual.mkdir()
+    (actual / "LICENSE").write_text("MIT", encoding="utf-8")
+    linked = tmp_path / "linked"
+    linked.symlink_to(actual, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="symlink-free"):
+        collector._regular_file_evidence(
+            "fixture", linked / "LICENSE", allowed_roots=(tmp_path,)
+        )
+
+
+def test_phase1c_npm_and_r_duplicate_fields_are_rejected(monkeypatch):
+    monkeypatch.setattr(
+        collector,
+        "_read_regular_file",
+        lambda *args, **kwargs: (
+            {"source": "fixture"},
+            b'{"name":"npm","version":"1","license":"BUSL-1.1",'
+            b'"license":"MIT"}',
+        ),
+    )
+    with pytest.raises(RuntimeError, match="npm package metadata field is duplicated"):
+        collector._npm_records()
+
+    with pytest.raises(RuntimeError, match="R DESCRIPTION field is duplicated"):
+        collector._parse_r_dcf(
+            b"Package: fixture\nVersion: 1\nLicense: BUSL-1.1\nLicense: MIT\n"
+        )
+
+
+@pytest.mark.parametrize(
+    "package_bytes",
+    [
+        '{"name":"npm","version":"1","license":"MIT"}'.encode("utf-16"),
+        '{"name":"npm","version":"1","license":"MIT"}'.encode("utf-32"),
+        b'{"name":"npm","version":"1","license":"MIT","x":"\xff"}',
+    ],
+)
+def test_phase1c_npm_metadata_requires_strict_utf8(monkeypatch, package_bytes):
+    monkeypatch.setattr(
+        collector,
+        "_read_regular_file",
+        lambda *args, **kwargs: ({"source": "fixture"}, package_bytes),
+    )
+
+    with pytest.raises(UnicodeDecodeError):
+        collector._npm_records()
+
+
+def test_phase1c_debian_duplicate_status_fields_are_rejected(monkeypatch):
+    monkeypatch.setattr(
+        collector,
+        "_read_regular_file",
+        lambda *args, **kwargs: (
+            {"source": "fixture"},
+            b"Package: fixture\npackage: hidden\nStatus: install ok installed\n"
+            b"Version: 1\nArchitecture: amd64\n",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Debian status field is duplicated"):
+        collector._debian_records()
+
+
+def test_phase1c_debian_dep5_fields_are_case_insensitive_and_stanza_scoped():
+    first = collector._debian_fields(
+        "Format: fixture\nLicense: MIT\n", "copyright"
+    )
+    second = collector._debian_fields("license: SSPL-1.0\n", "copyright")
+
+    assert first == {"format": "fixture", "license": "MIT"}
+    assert second == {"license": "SSPL-1.0"}
+    with pytest.raises(RuntimeError, match="Debian copyright field is duplicated"):
+        collector._debian_fields(
+            "License: MIT\nlicense: SSPL-1.0\n", "copyright"
+        )
+    with pytest.raises(RuntimeError, match="Debian copyright field is duplicated"):
+        collector._debian_fields("Format: one\nformat: two\n", "copyright")
+
+
+def test_phase1c_debian_license_continuation_is_preserved_and_denied(
+    tmp_path, monkeypatch
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_text(
+        f"Format: {collector.DEP5_FORMAT_URI}\n\n"
+        "Files: *\nLicense: MIT\n SSPL-1.0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    record = collector._debian_records()[0]
+    decision = license_module._decision(record, {"SSPL-1.0"}, {})
+
+    assert record["raw_values"] == ["MIT\nSSPL-1.0"]
+    assert decision["classification"] == "denied"
+    assert decision["denied_identifiers"] == ["SSPL-1.0"]
+
+
+def test_phase1c_debian_continuation_denial_reaches_full_report():
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(
+        item for item in evidence["records"] if item["ecosystem"] == "debian"
+    )
+    record["raw_values"] = ["MIT\nSSPL-1.0"]
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    decision = next(
+        item for item in report["decisions"] if item["purl"] == record["purl"]
+    )
+
+    assert decision["classification"] == "denied"
+    assert decision["denied_identifiers"] == ["SSPL-1.0"]
+
+
+def test_phase1c_debian_copyright_symlink_is_not_treated_as_missing(monkeypatch):
+    calls = 0
+
+    def read_file(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return (
+                {"source": "debian-status"},
+                b"Package: fixture\nStatus: install ok installed\n"
+                b"Version: 1\nArchitecture: amd64\n",
+            )
+        raise collector._UnavailableEvidencePath(
+            Path("/usr/share/doc/fixture/copyright"), collector.errno.ELOOP
+        )
+
+    monkeypatch.setattr(collector, "_read_regular_file", read_file)
+
+    with pytest.raises(RuntimeError, match="symlink-free"):
+        collector._debian_records()
+
+
+def test_phase1c_debian_copyright_enotdir_is_not_treated_as_missing(
+    tmp_path, monkeypatch
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "not-a-directory"
+    documentation_root.write_text("blocked", encoding="utf-8")
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    with pytest.raises(RuntimeError, match="symlink-free"):
+        collector._debian_records()
+
+
+@pytest.mark.parametrize(
+    "identity_lines",
+    ["Version: 1\n", "Architecture: amd64\n"],
+)
+def test_phase1c_debian_identity_requires_version_and_architecture(
+    tmp_path, monkeypatch, identity_lines
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n" + identity_lines,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(sbom_collector, "DEBIAN_STATUS_PATH", status)
+
+    with pytest.raises(RuntimeError, match="identity is incomplete"):
+        collector._debian_records()
+    with pytest.raises(RuntimeError, match="identity is incomplete"):
+        sbom_collector._debian_packages()
+
+
+def test_phase1c_debian_invalid_utf8_fails_collector(tmp_path, monkeypatch):
+    status = tmp_path / "status"
+    status.write_bytes(
+        b"Package: fixture\nStatus: install ok installed\n"
+        b"Version: 1\nArchitecture: amd64\n\xff"
+    )
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+
+    with pytest.raises(UnicodeDecodeError):
+        collector._debian_records()
+
+
+def test_phase1c_debian_missing_copyright_is_missing_metadata(
+    tmp_path, monkeypatch
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    documentation_root.mkdir()
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    record = collector._debian_records()[0]
+    decision = license_module._decision(record, set(), {})
+
+    assert decision["classification"] == "missing_metadata"
+    assert decision["normalization_reason"] == "debian-copyright-metadata-missing"
+
+
+def test_phase1c_unstructured_debian_copyright_is_unverifiable(
+    tmp_path, monkeypatch
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_text(
+        "This package is distributed under terms described in its sources.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    record = collector._debian_records()[0]
+    decision = license_module._decision(record, set(), {})
+
+    assert [item["source"] for item in record["evidence"]] == [
+        "debian-status",
+        "debian-copyright",
+    ]
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == (
+        "debian-copyright-has-no-dep5-license-fields"
+    )
+
+
+@pytest.mark.parametrize("copyright_present", [False, True])
+def test_phase1c_debian_without_dep5_cannot_receive_exception(
+    copyright_present,
+):
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(
+        item for item in evidence["records"] if item["ecosystem"] == "debian"
+    )
+    copyright_items = [
+        item for item in record["evidence"]
+        if item["source"] == "debian-copyright"
+    ]
+    if not copyright_present:
+        record["evidence"].remove(copyright_items[0])
+    record["raw_values"] = []
+    record["metadata"]["copyright_format"] = None
+    evidence_sha256 = canonical_sha256(record["evidence"])
+    policy["license"]["exceptions"].append({
+        "ecosystem": "debian",
+        "package": record["package"],
+        "version": record["version"],
+        "purl": record["purl"],
+        "normalized_expression": "MIT",
+        "evidence_sha256": evidence_sha256,
+        "reason": "non-dep5-review",
+        "approver": "reviewer",
+        "expires_at": "2027-07-31",
+    })
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    decision = license_module._decision(
+        record,
+        set(policy["license"]["denied_identifiers"]),
+        {
+            (item["purl"], item["evidence_sha256"]): item
+            for item in policy["license"]["exceptions"]
+        },
+    )
+    assert decision["classification"] in {"missing_metadata", "unverifiable"}
+    assert decision["exception"] is None
+    with pytest.raises(ValueError, match="stale or unmatched"):
+        build_license_report(
+            subject=subject,
+            subject_sha256=canonical_sha256(subject),
+            sbom=sbom,
+            license_evidence=evidence,
+            policy=policy,
+            policy_sha256=canonical_sha256(policy),
+        )
+
+
+def test_phase1c_debian_malformed_denied_field_fails_collector(
+    tmp_path, monkeypatch
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_text(
+        "Format: fixture\nLicense: MIT\nLicense : SSPL-1.0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    with pytest.raises(RuntimeError, match="field name is malformed"):
+        collector._debian_records()
+
+
+@pytest.mark.parametrize(
+    ("copyright_text", "newline"),
+    [
+        ("License: MIT{nl}", "\n"),
+        ("Format:   {nl}License: MIT{nl}", "\n"),
+        ("License: MIT{nl}{nl}Format: fixture{nl}", "\n"),
+        ("License: MIT{nl}{nl}Format: fixture{nl}", "\r\n"),
+        ("License: MIT{nl}{nl}Format: fixture{nl}", "\r"),
+    ],
+)
+def test_phase1c_dep5_requires_nonempty_first_stanza_format(
+    tmp_path, monkeypatch, copyright_text, newline
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_bytes(copyright_text.format(nl=newline).encode("utf-8"))
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    with pytest.raises(RuntimeError, match="DEP-5 Format header is invalid"):
+        collector._debian_records()
+
+
+@pytest.mark.parametrize(
+    "field_line",
+    [
+        "Upstream-Name: fixture",
+        "Upstream-Contact: maintainer@example.test",
+        "Source: https://example.test/source",
+        "Disclaimer: generated source",
+        "Comment: package notes",
+        "Copyright: 2026 Example",
+        "Files: *",
+        "Files-Excluded: vendor/*",
+        "Files-Excluded-component: generated/*",
+    ],
+)
+def test_phase1c_dep5_field_set_requires_format(
+    tmp_path, monkeypatch, field_line
+):
+    status = tmp_path / "status"
+    status.write_text(
+        "Package: fixture\nStatus: install ok installed\n"
+        "Version: 1\nArchitecture: amd64\n",
+        encoding="utf-8",
+    )
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_text(field_line + "\n", encoding="utf-8")
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+
+    with pytest.raises(RuntimeError, match="DEP-5 Format header is invalid"):
+        collector._debian_records()
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n", "\r"])
+def test_phase1c_debian_newlines_are_deterministic_through_full_report(
+    tmp_path, monkeypatch, newline
+):
+    status = tmp_path / "status"
+    status.write_bytes((
+        "Package: fixture{nl}Status: install ok installed{nl}"
+        "Version: 1.0{nl}Architecture: amd64{nl}"
+    ).format(nl=newline).encode("utf-8"))
+    documentation_root = tmp_path / "doc"
+    copyright_path = documentation_root / "fixture" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_bytes((
+        "Format: https://www.debian.org/doc/packaging-manuals/"
+        "copyright-format/1.0/{nl}{nl}Files: *{nl}License: Expat{nl}"
+    ).format(nl=newline).encode("utf-8"))
+    monkeypatch.setattr(collector, "DEBIAN_STATUS_PATH", status)
+    monkeypatch.setattr(
+        collector, "DEBIAN_DOCUMENTATION_ROOT", documentation_root
+    )
+    monkeypatch.setattr(sbom_collector, "DEBIAN_STATUS_PATH", status)
+
+    record = collector._debian_records()[0]
+    sbom_package = sbom_collector._debian_packages()[0]
+    record["evidence"][0]["path"] = "/var/lib/dpkg/status"
+    record["evidence"][0]["resolved_path"] = "/var/lib/dpkg/status"
+    record["evidence"][1]["path"] = "/usr/share/doc/fixture/copyright"
+    record["evidence"][1]["resolved_path"] = record["evidence"][1]["path"]
+    evidence = {
+        "schema_version": "1.0",
+        "collector": "gdpval-agentic-v2-license-evidence-v1",
+        "records": [record],
+        "records_sha256": canonical_sha256([record]),
+    }
+    sbom = {"packages": [sbom_package]}
+    policy = _policy()
+    subject = _subject()
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+
+    assert record["raw_values"] == ["Expat"]
+    assert report["decisions"][0]["classification"] == "resolved"
+    assert report["decisions"][0]["normalized_expression"] == "MIT"
+
+
+def test_phase1c_python_single_use_metadata_duplicates_are_rejected(
+    tmp_path,
+    monkeypatch,
+):
+    site_root = tmp_path / "python3.11" / "site-packages"
+    metadata_root = site_root / "fixture-1.0.dist-info"
+    metadata_root.mkdir(parents=True)
+    (metadata_root / "METADATA").write_text(
+        "Name: fixture\nVersion: 1.0\nLicense-Expression: MIT\n"
+        "License-Expression: BUSL-1.1\n\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(collector, "PYTHON_PURELIB_PATH", str(site_root))
+    monkeypatch.setattr(
+        collector.sysconfig, "get_path", lambda name: str(site_root)
+    )
+
+    with pytest.raises(RuntimeError, match="single-use metadata is duplicated"):
+        collector._python_records()
+
+
+def test_phase1c_python_purelib_runtime_drift_is_rejected(monkeypatch):
+    monkeypatch.setattr(
+        collector.sysconfig,
+        "get_path",
+        lambda name: "/usr/local/lib/python-shadow/site-packages",
+    )
+
+    with pytest.raises(RuntimeError, match="purelib root differs"):
+        collector._python_records()
+
+
+def test_phase1c_python_malformed_denied_header_fails_collector(
+    tmp_path, monkeypatch
+):
+    site_root = tmp_path / "python3.11" / "site-packages"
+    metadata_root = site_root / "fixture-1.0.dist-info"
+    metadata_root.mkdir(parents=True)
+    (metadata_root / "METADATA").write_bytes(
+        b"Name: fixture\nVersion: 1.0\nLicense: MIT\n"
+        b"License : SSPL-1.0\n\n"
+    )
+    monkeypatch.setattr(collector, "PYTHON_PURELIB_PATH", str(site_root))
+    monkeypatch.setattr(
+        collector.sysconfig, "get_path", lambda name: str(site_root)
+    )
+
+    with pytest.raises(RuntimeError, match="metadata is malformed"):
+        collector._python_records()
+
+
+def test_phase1c_python_invalid_utf8_fails_collector(tmp_path, monkeypatch):
+    site_root = tmp_path / "python3.11" / "site-packages"
+    metadata_root = site_root / "fixture-1.0.dist-info"
+    metadata_root.mkdir(parents=True)
+    (metadata_root / "METADATA").write_bytes(
+        b"Name: fixture\nVersion: 1.0\nLicense: MIT\n"
+        b"X-Denied-Looking: \xffSSPL-1.0\n\n"
+    )
+    monkeypatch.setattr(collector, "PYTHON_PURELIB_PATH", str(site_root))
+    monkeypatch.setattr(
+        collector.sysconfig, "get_path", lambda name: str(site_root)
+    )
+
+    with pytest.raises(UnicodeDecodeError):
+        collector._python_records()
+
+
+def test_phase1c_python_enumerates_only_direct_purelib_children(
+    tmp_path, monkeypatch
+):
+    site_root = tmp_path / "python3.11" / "site-packages"
+    direct = site_root / "direct-1.0.dist-info"
+    nested = site_root / "shadow" / "nested-1.0.dist-info"
+    direct.mkdir(parents=True)
+    nested.mkdir(parents=True)
+    (direct / "METADATA").write_text(
+        "Name: direct\nVersion: 1.0\nLicense: MIT\n\n", encoding="utf-8"
+    )
+    (nested / "METADATA").write_text(
+        "Name: nested\nVersion: 1.0\nLicense: SSPL-1.0\n\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(collector, "PYTHON_PURELIB_PATH", str(site_root))
+    monkeypatch.setattr(
+        collector.sysconfig, "get_path", lambda name: str(site_root)
+    )
+
+    records = collector._python_records()
+
+    assert [record["package"] for record in records] == ["direct"]
+
+
+def test_phase1c_python_metadata_enumeration_does_not_use_glob():
+    assert ".glob(" not in inspect.getsource(collector._python_records)
+
+
+def test_phase1c_atomic_file_read_rejects_identity_change(tmp_path, monkeypatch):
+    path = tmp_path / "LICENSE"
+    path.write_text("MIT", encoding="utf-8")
+    original_fstat = collector.os.fstat
+    calls = 0
+
+    def changed_fstat(descriptor):
+        nonlocal calls
+        value = original_fstat(descriptor)
+        calls += 1
+        if calls == 2:
+            class Changed:
+                st_dev = value.st_dev
+                st_ino = value.st_ino
+                st_mode = value.st_mode
+                st_nlink = value.st_nlink
+                st_size = value.st_size
+                st_mtime_ns = value.st_mtime_ns + 1
+            return Changed()
+        return value
+
+    monkeypatch.setattr(collector.os, "fstat", changed_fstat)
+
+    with pytest.raises(RuntimeError, match="changed while reading"):
+        collector._regular_file_evidence("fixture", path)
+
+
+def test_phase1c_collector_is_uid_guarded_sorted_and_deterministic(monkeypatch):
+    def record(purl):
+        return {
+            "ecosystem": "npm",
+            "package": purl,
+            "version": "1",
+            "purl": purl,
+            "raw_values": ["MIT"],
+            "metadata": {"license": "MIT", "license_file_tokens": []},
+            "evidence": [{
+                "source": "fixture",
+                "path": "/fixture",
+                "resolved_path": "/fixture",
+                "sha256": "a" * 64,
+                "size": 1,
+            }],
+        }
+
+    monkeypatch.setattr(collector.os, "geteuid", lambda: 65532)
+    monkeypatch.setattr(collector.os, "getegid", lambda: 65532)
+    monkeypatch.setattr(collector, "_debian_records", lambda: [record("pkg:z/z@1")])
+    monkeypatch.setattr(collector, "_python_records", lambda: [record("pkg:a/a@1")])
+    monkeypatch.setattr(collector, "_r_records", lambda: [])
+    monkeypatch.setattr(collector, "_npm_records", lambda: [])
+
+    first = collector.collect()
+    second = collector.collect()
+
+    assert first == second
+    assert [item["purl"] for item in first["records"]] == ["pkg:a/a@1", "pkg:z/z@1"]
+    assert first["records_sha256"] == canonical_sha256(first["records"])
+
+    monkeypatch.setattr(collector.os, "geteuid", lambda: 0)
+    with pytest.raises(RuntimeError, match="UID/GID 65532"):
+        collector.collect()
+
+
+def test_phase1c_collector_and_evaluator_are_staged_without_activation():
+    dockerfile = Path("sandbox/v2/professional-work.Dockerfile").read_text(
+        encoding="utf-8"
+    )
+    verifier_source = inspect.getsource(verifier.verify_candidate)
+
+    assert "batch-runner/sandbox/v2/license_evidence.py" in builder._BUILD_CONTEXT_PATHS
+    assert "batch-runner/core/agentic_v2_license.py" not in builder._BUILD_CONTEXT_PATHS
+    assert "batch-runner/core/agentic_v2_license.py" in builder._VERIFIER_PATHS
+    assert "COPY sandbox/v2/license_evidence.py /opt/gdpval/v2/license_evidence.py" in dockerfile
+    assert (
+        'ENTRYPOINT ["python", "-I", "-S", "-B", '
+        '"/opt/gdpval/v2/disabled_entrypoint.py"]'
+    ) in dockerfile.splitlines()
+    assert "evaluate_license_policy(" not in verifier_source
+    assert verifier_source.count("_run_image_json(\n            image_id") == 3
+    assert verifier_source.count("include_purelib=True") == 2
+    assert verifier_source.count("include_purelib=False") == 1
+
+    policy = json.loads(Path("security/agentic-v2-supply-chain-policy.json").read_text())
+    assert policy["foundation_only"] is True
+    assert policy["production_activation"] == "disabled"
+    assert policy["required_evidence"] == sorted(policy["required_evidence"])
+    for name in ("containment", "cve", "microvm", "provenance", "signature"):
+        assert name in policy["required_evidence"]
+
+
+def test_phase1c_python_unresolved_metadata_cannot_be_overridden_by_classifier():
+    fixture, subject, sbom, evidence, policy, _report = _fixture()
+    del fixture
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "python")
+    record["raw_values"] = [
+        "Vendor-Proprietary",
+        "License :: OSI Approved :: MIT License",
+    ]
+    record["metadata"] = {
+        "license_expression": None,
+        "license": "Vendor-Proprietary",
+        "classifiers": ["License :: OSI Approved :: MIT License"],
+        "license_file_tokens": [],
+        "license_files": [],
+    }
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    decision = next(item for item in report["decisions"] if item["purl"] == record["purl"])
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == "unresolved-explicit-python-license-field"
+
+
+def test_phase1c_unknown_python_classifier_blocks_resolution():
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "python")
+    record["raw_values"] = [
+        "MIT",
+        "License :: Other/Proprietary License",
+    ]
+    record["metadata"] = {
+        "license_expression": None,
+        "license": "MIT",
+        "classifiers": ["License :: Other/Proprietary License"],
+        "license_file_tokens": [],
+        "license_files": [],
+    }
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    decision = next(item for item in report["decisions"] if item["purl"] == record["purl"])
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == "unmapped-python-license-classifier"
+
+
+@pytest.mark.parametrize(
+    ("license_value", "classifiers", "classification", "reason"),
+    [
+        (
+            "Vendor-Proprietary",
+            [],
+            "unverifiable",
+            "unresolved-explicit-python-license-field",
+        ),
+        (
+            "Apache-2.0",
+            [],
+            "ambiguous",
+            "conflicting-python-license-metadata",
+        ),
+        (
+            None,
+            ["License :: Other/Proprietary License"],
+            "unverifiable",
+            "unmapped-python-license-classifier",
+        ),
+    ],
+)
+def test_phase1c_python_expression_does_not_hide_conflicting_metadata(
+    license_value,
+    classifiers,
+    classification,
+    reason,
+):
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "python")
+    record["raw_values"] = [
+        value for value in ["MIT", license_value, *classifiers] if value is not None
+    ]
+    record["metadata"] = {
+        "license_expression": "MIT",
+        "license": license_value,
+        "classifiers": classifiers,
+        "license_file_tokens": [],
+        "license_files": [],
+    }
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    decision = next(item for item in report["decisions"] if item["purl"] == record["purl"])
+    assert decision["classification"] == classification
+    assert decision["normalization_reason"] == reason
+
+
+def test_phase1c_mixed_case_denied_identifier_cannot_use_exception():
+    _fixture_value, _subject, _sbom, evidence, policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "python")
+    record["raw_values"] = ["sspl-1.0", "Reviewed-Custom"]
+    record["metadata"] = {
+        "license_expression": "sspl-1.0",
+        "license": "Reviewed-Custom",
+        "classifiers": [],
+        "license_file_tokens": [],
+        "license_files": [],
+    }
+    evidence_sha256 = canonical_sha256(record["evidence"])
+    exception = {
+        **policy["license"]["exceptions"][0],
+        "package": record["package"],
+        "version": record["version"],
+        "purl": record["purl"],
+        "evidence_sha256": evidence_sha256,
+    }
+
+    decision = license_module._decision(
+        record,
+        {"BUSL-1.1", "Commons-Clause", "SSPL-1.0"},
+        {(record["purl"], evidence_sha256): exception},
+    )
+
+    assert decision["classification"] == "denied"
+    assert decision["denied_identifiers"] == ["SSPL-1.0"]
+    assert decision["exception"] is None
+
+
+def test_phase1c_bounded_command_rejects_stdout_and_stderr_overflow():
+    with pytest.raises(RuntimeError, match="stdout exceeds size limit"):
+        verifier._run_bounded_command(
+            [sys.executable, "-c", "print('x' * 10000)"],
+            timeout=5,
+            stdout_limit=100,
+            stderr_limit=100,
+        )
+    with pytest.raises(RuntimeError, match="stderr exceeds size limit"):
+        verifier._run_bounded_command(
+            [sys.executable, "-c", "import sys;sys.stderr.write('x' * 10000)"],
+            timeout=5,
+            stdout_limit=100,
+            stderr_limit=100,
+        )
+
+
+def test_phase1c_bounded_json_rejects_duplicates_depth_and_huge_integer():
+    with pytest.raises(ValueError, match="duplicate keys"):
+        verifier._bounded_json_loads(b'{"a":1,"a":2}')
+    with pytest.raises(RuntimeError, match="structure exceeds limits"):
+        verifier._bounded_json_loads(("[" * 65 + "0" + "]" * 65).encode())
+    with pytest.raises(ValueError, match="integer is too large"):
+        verifier._bounded_json_loads(b'{"value":' + b"9" * 101 + b'}')
+    with pytest.raises(ValueError, match="constant is invalid"):
+        verifier._bounded_json_loads(b'{"value":NaN}')
+    with pytest.raises(ValueError, match="float is not finite"):
+        verifier._bounded_json_loads(b'{"value":1e400}')
+
+
+def test_phase1c_debian_parenthesized_alternatives_preserve_scope():
+    outcome = license_module._debian_expression("(GPL-2+) or (Expat)")
+    assert outcome.issue is None
+    assert outcome.expression == "(GPL-2.0-or-later) OR (MIT)"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "GPL-2+ or Expat and Apache-2",
+            "((Apache-2.0) AND (MIT)) OR (GPL-2.0-or-later)",
+        ),
+        (
+            "(GPL-2+ or Expat) and Apache-2",
+            "((GPL-2.0-or-later) OR (MIT)) AND (Apache-2.0)",
+        ),
+        (
+            "GPL-2+ with Bison exception and Expat",
+            "(GPL-2.0-or-later WITH Bison-exception-2.2) AND (MIT)",
+        ),
+        (
+            "(GPL-2+ with Bison exception) or (Expat and Apache-2)",
+            "((Apache-2.0) AND (MIT)) OR "
+            "(GPL-2.0-or-later WITH Bison-exception-2.2)",
+        ),
+    ],
+)
+def test_phase1c_debian_nested_operator_precedence(raw, expected):
+    outcome = license_module._debian_expression(raw)
+    assert outcome.issue is None
+    assert outcome.expression == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "LicenseRef-Proprietary",
+        "MIT OR LicenseRef-Proprietary",
+        "DocumentRef-vendor:LicenseRef-Proprietary",
+    ],
+)
+def test_phase1c_custom_spdx_references_are_unverifiable(value):
+    outcome = license_module._atom(value, {})
+    assert outcome.expression is None
+    assert outcome.issue == "unverifiable"
+    assert license_module._canonical(value) is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "LicenseRef-Proprietary",
+        "MIT OR LicenseRef-Proprietary",
+        "DocumentRef-vendor:LicenseRef-Proprietary",
+    ],
+)
+def test_phase1c_custom_spdx_references_cannot_be_exceptions(value):
+    _fixture_value, _subject, _sbom, _evidence_value, policy, _report = _fixture()
+    policy["license"]["exceptions"][0]["normalized_expression"] = value
+
+    with pytest.raises(ValueError, match="exception identity"):
+        validate_license_exceptions(policy)
+
+
+def test_phase1c_host_validates_npm_reference_file_path():
+    _fixture_value, _subject, sbom, evidence, _policy_value, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "npm")
+    record["raw_values"] = ["SEE LICENSE IN LICENSE"]
+    record["metadata"] = {
+        "license": "SEE LICENSE IN LICENSE",
+        "license_file_tokens": [],
+    }
+    record["evidence"].append(
+        _evidence("npm-license-file", "/usr/share/nodejs/npm/LICENSE", 500)
+    )
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    assert validate_license_evidence(evidence, sbom) == evidence
+    record["evidence"][-1]["path"] = "/usr/share/nodejs/npm/OTHER"
+    record["evidence"][-1]["resolved_path"] = "/usr/share/nodejs/npm/OTHER"
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+    with pytest.raises(ValueError, match="source path"):
+        validate_license_evidence(evidence, sbom)
+
+
+def test_phase1c_r_runtime_dep5_is_case_insensitive_and_denied_visible():
+    fields = collector._debian_license_values(
+        b"License: GPL-2\n\nlicense: SSPL-1.0\n",
+        "R runtime copyright",
+    )
+
+    assert fields == ["GPL-2", "SSPL-1.0"]
+
+
+def _configure_r_tree(
+    tmp_path,
+    monkeypatch,
+    *,
+    declared_license="Part of R 4.2.2",
+    priority="base",
+    runtime_copyright=(
+        b"Format: https://www.debian.org/doc/packaging-manuals/"
+        b"copyright-format/1.0/\n\nLicense: GPL-2\n"
+    ),
+):
+    library_root = tmp_path / "R" / "library"
+    package_root = library_root / "base"
+    package_root.mkdir(parents=True)
+    description = (
+        f"Package: base\nVersion: 4.2.2\nLicense: {declared_license}\n"
+        f"Priority: {priority}\n"
+    )
+    (package_root / "DESCRIPTION").write_text(description, encoding="utf-8")
+    copyright_path = tmp_path / "doc" / "r-base-core" / "copyright"
+    copyright_path.parent.mkdir(parents=True)
+    copyright_path.write_bytes(runtime_copyright)
+    shared_root = tmp_path / "R" / "share" / "licenses"
+    shared_root.mkdir(parents=True)
+    monkeypatch.setattr(collector, "R_LIBRARY_ROOT", library_root)
+    monkeypatch.setattr(collector, "R_RUNTIME_COPYRIGHT_PATH", copyright_path)
+    monkeypatch.setattr(collector, "R_SHARED_LICENSE_ROOT", shared_root)
+    return package_root
+
+
+def test_phase1c_r_records_surface_mixed_case_runtime_denied(
+    tmp_path, monkeypatch
+):
+    _configure_r_tree(
+        tmp_path,
+        monkeypatch,
+        runtime_copyright=(
+            b"Format: https://www.debian.org/doc/packaging-manuals/"
+            b"copyright-format/1.0/\n\nLicense: GPL-2\n\n"
+            b"license: SSPL-1.0\n"
+        ),
+    )
+
+    record = collector._r_records()[0]
+    decision = license_module._decision(record, {"SSPL-1.0"}, {})
+
+    assert record["metadata"]["runtime_license_fields"] == ["GPL-2", "SSPL-1.0"]
+    assert decision["classification"] == "denied"
+    assert decision["denied_identifiers"] == ["SSPL-1.0"]
+
+
+@pytest.mark.parametrize(
+    "runtime_copyright",
+    [
+        b"License: MIT\n",
+        b"Format: vendor-text-v1\n\nLicense: MIT\n",
+        b"Format: \n\nLicense: MIT\n",
+    ],
+)
+def test_phase1c_r_runtime_requires_canonical_dep5_format(
+    tmp_path, monkeypatch, runtime_copyright
+):
+    _configure_r_tree(
+        tmp_path,
+        monkeypatch,
+        runtime_copyright=runtime_copyright,
+    )
+
+    with pytest.raises(RuntimeError, match="DEP-5 Format header is invalid"):
+        collector._r_records()
+
+
+def test_phase1c_r_part_of_runtime_identity_must_be_exact(tmp_path, monkeypatch):
+    _configure_r_tree(
+        tmp_path,
+        monkeypatch,
+        declared_license="Part of R anything",
+        priority="optional",
+    )
+
+    decision = license_module._decision(collector._r_records()[0], set(), {})
+
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == "invalid-r-runtime-license-reference"
+
+
+def test_phase1c_r_malformed_denied_field_fails_collector(tmp_path, monkeypatch):
+    package_root = _configure_r_tree(tmp_path, monkeypatch)
+    (package_root / "DESCRIPTION").write_text(
+        "Package: base\nVersion: 4.2.2\nLicense: MIT\n"
+        "License : SSPL-1.0\nPriority: base\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="field name is malformed"):
+        collector._r_records()
+
+
+@pytest.mark.parametrize(
+    "description_bytes",
+    [
+        b" continuation\nPackage: base\nVersion: 4.2.2\nLicense: MIT\n",
+        b"Package: base\nVersion: 4.2.2\nLicense: MIT\n\n continuation\n",
+    ],
+)
+def test_phase1c_r_orphan_continuation_fails_collector(
+    tmp_path, monkeypatch, description_bytes
+):
+    package_root = _configure_r_tree(tmp_path, monkeypatch)
+    (package_root / "DESCRIPTION").write_bytes(description_bytes)
+
+    with pytest.raises(RuntimeError, match="DESCRIPTION"):
+        collector._r_records()
+
+
+def test_phase1c_r_invalid_utf8_fails_collector(tmp_path, monkeypatch):
+    package_root = _configure_r_tree(tmp_path, monkeypatch)
+    (package_root / "DESCRIPTION").write_bytes(
+        b"Package: base\nVersion: 4.2.2\nLicense: MIT\n\xff"
+    )
+
+    with pytest.raises(UnicodeDecodeError):
+        collector._r_records()
+
+
+def test_phase1c_r_reference_file_is_evidence_bound(tmp_path, monkeypatch):
+    package_root = _configure_r_tree(
+        tmp_path, monkeypatch, declared_license="file LICENSE"
+    )
+    license_path = package_root / "LICENSE"
+    license_path.write_text("first", encoding="utf-8")
+    first = collector._r_records()[0]
+    first_item = next(
+        item for item in first["evidence"] if item["source"] == "r-license-file"
+    )
+
+    license_path.write_text("second", encoding="utf-8")
+    second = collector._r_records()[0]
+    second_item = next(
+        item for item in second["evidence"] if item["source"] == "r-license-file"
+    )
+
+    assert first_item["sha256"] != second_item["sha256"]
+    license_path.unlink()
+    outside = tmp_path / "outside-license"
+    outside.write_text("hidden", encoding="utf-8")
+    license_path.symlink_to(outside)
+    with pytest.raises(RuntimeError, match="symlink-free"):
+        collector._r_records()
+
+
+def test_phase1c_r_license_file_denied_token_precedes_exception(
+    tmp_path, monkeypatch
+):
+    package_root = _configure_r_tree(
+        tmp_path, monkeypatch, declared_license="file LICENSE"
+    )
+    (package_root / "LICENSE").write_text("SSPL-1.0\n", encoding="utf-8")
+    record = collector._r_records()[0]
+    evidence_sha256 = canonical_sha256(record["evidence"])
+    exception = {
+        "ecosystem": "r",
+        "package": record["package"],
+        "version": record["version"],
+        "purl": record["purl"],
+        "normalized_expression": "MIT",
+        "evidence_sha256": evidence_sha256,
+        "reason": "fixture",
+        "approver": "reviewer",
+        "expires_at": "2027-07-31",
+    }
+
+    decision = license_module._decision(
+        record,
+        {"SSPL-1.0"},
+        {(record["purl"], evidence_sha256): exception},
+    )
+
+    assert record["metadata"]["license_file_tokens"] == ["SSPL-1.0"]
+    assert decision["classification"] == "denied"
+    assert decision["exception"] is None
+
+
+def test_phase1c_npm_reference_file_change_invalidates_exception(
+    tmp_path, monkeypatch
+):
+    package_root = tmp_path / "npm"
+    package_root.mkdir()
+    package_path = package_root / "package.json"
+    package_path.write_text(
+        '{"name":"npm","version":"1.0.0",'
+        '"license":"SEE LICENSE IN LICENSE"}',
+        encoding="utf-8",
+    )
+    license_path = package_root / "LICENSE"
+    license_path.write_text("first", encoding="utf-8")
+    monkeypatch.setattr(collector, "NPM_PACKAGE_PATH", package_path)
+    first = collector._npm_records()[0]
+    first_digest = canonical_sha256(first["evidence"])
+    exception = {
+        "ecosystem": "npm",
+        "package": "npm",
+        "version": "1.0.0",
+        "purl": "pkg:npm/npm@1.0.0",
+        "normalized_expression": "MIT",
+        "evidence_sha256": first_digest,
+        "reason": "reviewed-reference",
+        "approver": "fixture-approver",
+        "expires_at": "2027-07-31",
+    }
+    exception_map = {(first["purl"], first_digest): exception}
+    assert license_module._decision(
+        first, set(), exception_map
+    )["classification"] == "exception"
+
+    license_path.write_text("second", encoding="utf-8")
+    second = collector._npm_records()[0]
+    second_decision = license_module._decision(second, set(), exception_map)
+    assert second_decision["classification"] == "unverifiable"
+    assert second_decision["exception"] is None
+
+    license_path.unlink()
+    outside = tmp_path / "outside-npm-license"
+    outside.write_text("hidden", encoding="utf-8")
+    license_path.symlink_to(outside)
+    with pytest.raises(RuntimeError, match="symlink-free"):
+        collector._npm_records()
+
+
+def test_phase1c_referenced_file_denied_token_precedes_matching_exception(
+    tmp_path, monkeypatch
+):
+    package_root = tmp_path / "npm-denied"
+    package_root.mkdir()
+    package_path = package_root / "package.json"
+    package_path.write_text(
+        '{"name":"npm","version":"1.0.0",'
+        '"license":"SEE LICENSE IN LICENSE"}',
+        encoding="utf-8",
+    )
+    (package_root / "LICENSE").write_text("SSPL-1.0\n", encoding="utf-8")
+    monkeypatch.setattr(collector, "NPM_PACKAGE_PATH", package_path)
+    record = collector._npm_records()[0]
+    evidence_sha256 = canonical_sha256(record["evidence"])
+    exception = {
+        "ecosystem": "npm",
+        "package": "npm",
+        "version": "1.0.0",
+        "purl": record["purl"],
+        "normalized_expression": "MIT",
+        "evidence_sha256": evidence_sha256,
+        "reason": "fixture",
+        "approver": "reviewer",
+        "expires_at": "2027-07-31",
+    }
+
+    decision = license_module._decision(
+        record,
+        {"BUSL-1.1", "Commons-Clause", "SSPL-1.0"},
+        {(record["purl"], evidence_sha256): exception},
+    )
+
+    assert record["metadata"]["license_file_tokens"] == ["SSPL-1.0"]
+    assert record["raw_values"] == ["SEE LICENSE IN LICENSE", "SSPL-1.0"]
+    assert decision["classification"] == "denied"
+    assert decision["denied_identifiers"] == ["SSPL-1.0"]
+    assert decision["exception"] is None
+
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    npm_record = next(
+        item for item in evidence["records"] if item["ecosystem"] == "npm"
+    )
+    hosted_record = deepcopy(record)
+    for item in hosted_record["evidence"]:
+        path = (
+            "/usr/share/nodejs/npm/package.json"
+            if item["source"] == "npm-package-json"
+            else "/usr/share/nodejs/npm/LICENSE"
+        )
+        item["path"] = path
+        item["resolved_path"] = path
+    npm_record.update(hosted_record)
+    evidence["records"].sort(key=lambda item: item["purl"])
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+    npm_package = next(
+        item for item in sbom["packages"]
+        if item["externalRefs"][0]["referenceLocator"].startswith("pkg:npm/")
+    )
+    npm_package["name"] = record["package"]
+    npm_package["versionInfo"] = record["version"]
+    npm_package["externalRefs"][0]["referenceLocator"] = record["purl"]
+    hosted_exception = deepcopy(exception)
+    hosted_exception["evidence_sha256"] = canonical_sha256(
+        hosted_record["evidence"]
+    )
+    policy["license"]["exceptions"] = [hosted_exception]
+    with pytest.raises(ValueError, match="stale or unmatched"):
+        build_license_report(
+            subject=subject,
+            subject_sha256=canonical_sha256(subject),
+            sbom=sbom,
+            license_evidence=evidence,
+            policy=policy,
+            policy_sha256=canonical_sha256(policy),
+        )
+
+
+def test_phase1c_npm_leading_space_reference_cannot_receive_exception(
+    tmp_path, monkeypatch
+):
+    package_root = tmp_path / "npm-leading"
+    package_root.mkdir()
+    package_path = package_root / "package.json"
+    package_path.write_text(
+        '{"name":"npm","version":"1.0.0",'
+        '"license":" SEE LICENSE IN LICENSE"}',
+        encoding="utf-8",
+    )
+    (package_root / "LICENSE").write_text("not-collected", encoding="utf-8")
+    monkeypatch.setattr(collector, "NPM_PACKAGE_PATH", package_path)
+
+    with pytest.raises(RuntimeError, match="npm license metadata is invalid"):
+        collector._npm_records()
+
+
+@pytest.mark.parametrize(
+    ("ecosystem", "declared", "metadata"),
+    [
+        (
+            "r",
+            "GPL-2 + file\tLICENSE",
+            {
+                "declared_license": "GPL-2 + file\tLICENSE",
+                "priority": None,
+                "runtime_license": "",
+                "runtime_license_fields": [],
+                "runtime_version": "4.2.2",
+            },
+        ),
+        ("npm", "SEE  LICENSE IN LICENSE", {"license": "SEE  LICENSE IN LICENSE"}),
+    ],
+)
+def test_phase1c_noncanonical_reference_cannot_receive_exception(
+    ecosystem, declared, metadata
+):
+    record = {
+        "ecosystem": ecosystem,
+        "package": "fixture",
+        "version": "1",
+        "purl": f"pkg:{'cran' if ecosystem == 'r' else 'npm'}/fixture@1",
+        "raw_values": [declared],
+        "metadata": metadata,
+        "evidence": [_evidence("fixture", "/fixture", 700)],
+    }
+    evidence_sha256 = canonical_sha256(record["evidence"])
+    exception = {
+        "ecosystem": ecosystem,
+        "package": "fixture",
+        "version": "1",
+        "purl": record["purl"],
+        "normalized_expression": "MIT",
+        "evidence_sha256": evidence_sha256,
+        "reason": "fixture",
+        "approver": "reviewer",
+        "expires_at": "2027-07-31",
+    }
+
+    decision = license_module._decision(
+        record,
+        set(),
+        {(record["purl"], evidence_sha256): exception},
+    )
+
+    assert decision["classification"] == "unverifiable"
+    assert decision["exception"] is None
+
+
+def test_phase1c_license_expression_size_is_bounded():
+    assert license_module._canonical("MIT OR " * 1000 + "MIT") is None
+
+
+def test_phase1c_license_expression_depth_is_bounded_below_size_limit():
+    expression = "(" * 400 + "MIT" + ")" * 400
+
+    assert len(expression) < 4096
+    assert license_module._canonical(expression) is None
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        ")MIT",
+        "(MIT",
+        "(" * 65 + "MIT" + ")" * 65,
+        " ".join("MIT" for _ in range(513)),
+    ],
+)
+def test_phase1c_expression_shape_rejects_before_parser(
+    expression,
+    monkeypatch,
+):
+    assert len(expression) < 4096
+    monkeypatch.setattr(
+        license_module,
+        "canonicalize_license_expression",
+        lambda _value: pytest.fail("invalid shape reached SPDX parser"),
+    )
+
+    assert license_module._canonical(expression) is None
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "(" * 65 + "Expat" + ")" * 65,
+        " or ".join("MIT" for _ in range(257)),
+    ],
+)
+def test_phase1c_debian_fallback_cannot_bypass_expression_shape(
+    expression,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        license_module,
+        "_atom",
+        lambda *args, **kwargs: pytest.fail("invalid shape reached Debian fallback"),
+    )
+
+    outcome = license_module._debian_expression(expression)
+
+    assert outcome.expression is None
+    assert outcome.issue == "unverifiable"
+    assert outcome.reason == "invalid-debian-license-expression-shape"
+
+
+def test_phase1c_r_fallback_cannot_bypass_expression_shape():
+    declared = "|".join("MIT" for _ in range(513))
+    record = {
+        "metadata": {
+            "declared_license": declared,
+            "priority": "optional",
+            "runtime_license": "",
+            "runtime_version": "4.2.2",
+        }
+    }
+
+    outcome = license_module._r_outcome(record)
+
+    assert outcome.expression is None
+    assert outcome.issue == "unverifiable"
+    assert outcome.reason == "invalid-r-license-expression-shape"
+
+
+def test_phase1c_spdx_parser_recursion_is_normalized(monkeypatch):
+    monkeypatch.setattr(
+        license_module,
+        "canonicalize_license_expression",
+        lambda _value: (_ for _ in ()).throw(RecursionError("fixture")),
+    )
+
+    assert license_module._canonical("MIT") is None
+
+
+@pytest.mark.parametrize("declared", ["MIT || Apache-2.0", "| MIT", "MIT |"])
+def test_phase1c_empty_r_alternatives_are_unverifiable_in_full_report(declared):
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "r")
+    record["raw_values"] = [declared]
+    record["metadata"] = {
+        "declared_license": declared,
+        "priority": "optional",
+        "runtime_license": "",
+        "runtime_license_fields": [],
+        "runtime_copyright_format": collector.DEP5_FORMAT_URI,
+        "runtime_version": "4.2.2",
+        "license_file_tokens": [],
+    }
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    decision = next(item for item in report["decisions"] if item["purl"] == record["purl"])
+
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == "invalid-r-license-alternatives"
+
+
+def test_phase1c_debian_expression_is_bounded_before_parsing(monkeypatch):
+    raw = "(" * 4097 + "MIT" + ")" * 4097
+    monkeypatch.setattr(
+        license_module,
+        "_atom",
+        lambda *args, **kwargs: pytest.fail("oversized expression reached parser"),
+    )
+
+    outcome = license_module._debian_expression(raw)
+
+    assert outcome.expression is None
+    assert outcome.issue == "unverifiable"
+    assert outcome.reason == "invalid-debian-license-expression-shape"
+
+
+def test_phase1c_oversized_debian_expression_is_unverifiable_in_full_report():
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "debian")
+    record["raw_values"] = ["(" * 4097 + "MIT" + ")" * 4097]
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    decision = next(item for item in report["decisions"] if item["purl"] == record["purl"])
+
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == "debian-file-stanza-license-conjunction"
+
+
+def test_phase1c_deep_expression_is_unverifiable_in_full_report():
+    _fixture_value, subject, sbom, evidence, policy, _report = _fixture()
+    record = next(item for item in evidence["records"] if item["ecosystem"] == "npm")
+    expression = "(" * 400 + "MIT" + ")" * 400
+    record["raw_values"] = [expression]
+    record["metadata"] = {
+        "license": expression,
+        "license_file_tokens": [],
+    }
+    evidence["records_sha256"] = canonical_sha256(evidence["records"])
+
+    report = build_license_report(
+        subject=subject,
+        subject_sha256=canonical_sha256(subject),
+        sbom=sbom,
+        license_evidence=evidence,
+        policy=policy,
+        policy_sha256=canonical_sha256(policy),
+    )
+    decision = next(item for item in report["decisions"] if item["purl"] == record["purl"])
+
+    assert decision["classification"] == "unverifiable"
+    assert decision["normalization_reason"] == "unmapped-exact-license-label"

--- a/batch-runner/tests/test_agentic_v2_phase1c_license.py
+++ b/batch-runner/tests/test_agentic_v2_phase1c_license.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import os
 from pathlib import Path
+import py_compile
 import signal
 import subprocess
 import sys
@@ -3059,6 +3060,13 @@ def test_phase1c_effective_sbom_r_inventory_is_static(tmp_path, monkeypatch):
     monkeypatch.setattr(sbom_collector, "R_LIBRARY_ROOT", library_root)
 
     packages = sbom_collector._r_packages()
+    monkeypatch.setattr(
+        image_probe,
+        "_effective_sbom_namespace",
+        lambda _expected: {
+            "r_inventory_records": sbom_collector.r_inventory_records,
+        },
+    )
 
     assert [
         item["externalRefs"][0]["referenceLocator"] for item in packages
@@ -3066,6 +3074,63 @@ def test_phase1c_effective_sbom_r_inventory_is_static(tmp_path, monkeypatch):
         "pkg:cran/base@4.2.2",
         "pkg:cran/translations@4.2.2",
     ]
+    assert image_probe._r_inventory_records("a" * 64) == [
+        "base=4.2.2",
+        "translations=4.2.2",
+    ]
+
+
+def test_phase1c_image_probe_ignores_effective_sbom_shadow_bytecode(
+    tmp_path, monkeypatch
+):
+    probe_path = tmp_path / "image_probe.py"
+    probe_path.write_text("", encoding="utf-8")
+    source_path = tmp_path / "effective_sbom.py"
+    source_path.write_text(
+        "def r_inventory_records():\n"
+        "    return [{'name': 'bytecode', 'version': '0', 'license': 'MIT'}]\n",
+        encoding="utf-8",
+    )
+    cache_path = (
+        tmp_path / "__pycache__"
+        / f"effective_sbom.{sys.implementation.cache_tag}.pyc"
+    )
+    cache_path.parent.mkdir()
+    py_compile.compile(
+        str(source_path),
+        cfile=str(cache_path),
+        doraise=True,
+        invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH,
+    )
+    source_path.write_text(
+        "def r_inventory_records():\n"
+        "    return [{'name': 'source', 'version': '1', 'license': 'MIT'}]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(image_probe, "__file__", str(probe_path))
+    expected_sha256 = hashlib.sha256(source_path.read_bytes()).hexdigest()
+
+    records = image_probe._effective_sbom_namespace(expected_sha256)[
+        "r_inventory_records"
+    ]()
+
+    assert records == [{"name": "source", "version": "1", "license": "MIT"}]
+    with pytest.raises(RuntimeError, match="digest differs"):
+        image_probe._effective_sbom_namespace("0" * 64)
+
+
+def test_phase1c_image_probe_rejects_symlinked_effective_sbom_source(
+    tmp_path, monkeypatch
+):
+    probe_path = tmp_path / "image_probe.py"
+    probe_path.write_text("", encoding="utf-8")
+    target = tmp_path / "target.py"
+    target.write_text("def r_inventory_records(): return []\n", encoding="utf-8")
+    (tmp_path / "effective_sbom.py").symlink_to(target)
+    monkeypatch.setattr(image_probe, "__file__", str(probe_path))
+
+    with pytest.raises(OSError):
+        image_probe._effective_sbom_namespace("0" * 64)
 
 
 def test_phase1c_effective_sbom_r_inventory_is_bounded(tmp_path, monkeypatch):

--- a/batch-runner/tests/test_agentic_v2_supply_chain.py
+++ b/batch-runner/tests/test_agentic_v2_supply_chain.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import core.agentic_v2_supply_chain as supply_chain_module
 from core.agentic_v2_microvm import (
     inspect_microvm_readiness,
     validate_microvm_readiness_report,
@@ -15,6 +16,7 @@ from core.agentic_v2_substrate import (
     AgenticV2SubstrateManifest,
     canonical_sha256,
 )
+from core.agentic_v2_license import build_license_report
 from core.agentic_v2_supply_chain import (
     CandidateSubject,
     SupplyChainPolicy,
@@ -50,6 +52,23 @@ def _subject(manifest):
         "verifier_sha256": "7" * 64,
         "oci_exporter_sha256": "8" * 64,
         "sbom_generator_sha256": "a" * 64,
+        "license_collector_sha256": "b" * 64,
+        "license_evaluator_sha256": "c" * 64,
+        "license_evaluator_packaging_version": "26.2",
+        "license_evaluator_parser_sha256": (
+            "fc9c745d1883ff9f296a5b169f22eb2ee879f59a4608f20f5cb29d668f4e26f4"
+        ),
+        "license_evaluator_python_version": "3.10.12",
+        "license_evaluator_callable_sha256": (
+            "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"
+        ),
+        "license_evaluator_runtime_graph_sha256": (
+            "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"
+        ),
+        "license_evaluator_spdx_version": "3.27.0",
+        "license_evaluator_spdx_sha256": (
+            "ecc082fdc1fcdcae47b2f56c4ce2cdc2c9d6d54ca555a09814abd78dece7a230"
+        ),
         "lock_set_sha256": "9" * 64,
     })
 
@@ -169,6 +188,7 @@ def _degraded_evidence_directory(
     )
     receipt = None
     sbom = None
+    license_evidence = None
     license_report = None
     if collection_allowed:
         inventory_observation, sbom = _effective_sbom_fixture()
@@ -177,7 +197,15 @@ def _degraded_evidence_directory(
             "package_inventory"
         ]
         receipt = build_candidate_receipt(subject, observation, manifest)
-        license_report = evaluate_license_policy(sbom, policy)
+        license_evidence = _license_evidence_fixture(sbom)
+        license_report = build_license_report(
+            subject=subject.document,
+            subject_sha256=subject.sha256,
+            sbom=sbom,
+            license_evidence=license_evidence,
+            policy=policy.document,
+            policy_sha256=policy.sha256,
+        )
         evidence["capability_receipt"] = evidence_item(
             subject,
             name="capability_receipt",
@@ -200,9 +228,9 @@ def _degraded_evidence_directory(
             subject,
             name="license",
             status=license_report["status"],
-            tool_name="gdpval-agentic-v2-license-policy",
+            tool_name="gdpval-agentic-v2-license-evaluator",
             tool_version="1.0",
-            tool_sha256=policy.sha256,
+            tool_sha256=subject.document["license_evaluator_sha256"],
             report_sha256=canonical_sha256(license_report),
         )
     gate = build_evidence_report(subject, policy, evidence)
@@ -219,6 +247,7 @@ def _degraded_evidence_directory(
         documents.update({
             "candidate-receipt.json": receipt,
             "effective-sbom.spdx.json": sbom,
+            "license-evidence.json": license_evidence,
             "license-report.json": license_report,
         })
     for name, value in documents.items():
@@ -239,6 +268,32 @@ def _validate_directory(root, subject, policy, manifest):
     )
 
 
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        (b'{"value":1e400}', "float is not finite"),
+        (b'{"value":' + b"9" * 101 + b'}', "integer is too large"),
+        (("[" * 65 + "0" + "]" * 65).encode(), "structure exceeds"),
+        (json.dumps("x" * (1024 * 1024 + 1)).encode(), "string exceeds"),
+    ],
+)
+def test_persisted_evidence_json_limits(tmp_path, raw, message):
+    path = tmp_path / "evidence.json"
+    path.write_bytes(raw)
+
+    with pytest.raises(ValueError, match=message):
+        supply_chain_module._read_json(path, 2 * 1024 * 1024)
+
+
+def test_persisted_evidence_json_node_limit(tmp_path):
+    raw = ("[" + ",".join("0" for _ in range(500_000)) + "]").encode()
+    path = tmp_path / "evidence.json"
+    path.write_bytes(raw)
+
+    with pytest.raises(ValueError, match="structure exceeds"):
+        supply_chain_module._read_json(path, 2 * 1024 * 1024)
+
+
 def test_candidate_receipt_binds_subject_manifest_and_observation():
     manifest = AgenticV2SubstrateManifest.load(MANIFEST)
     subject = _subject(manifest)
@@ -251,6 +306,11 @@ def test_candidate_receipt_binds_subject_manifest_and_observation():
     with pytest.raises(ValueError, match="observation hash mismatch"):
         validate_candidate_receipt(tampered, manifest)
 
+    numeric = _observation(manifest)
+    numeric["commands"][0]["sha256"] = int("1" * 64)
+    with pytest.raises(ValueError, match="capability receipt command"):
+        build_candidate_receipt(subject, numeric, manifest)
+
 
 def test_evidence_directory_reopens_degraded_host_reports(tmp_path, monkeypatch):
     arguments = _degraded_evidence_directory(tmp_path, monkeypatch)
@@ -260,6 +320,37 @@ def test_evidence_directory_reopens_degraded_host_reports(tmp_path, monkeypatch)
     assert gate["gate_status"] == "blocked"
     assert gate["evidence"]["containment"]["status"] == "failed"
     assert gate["evidence"]["capability_receipt"]["status"] == "not_run"
+
+
+def test_evidence_directory_rejects_oci_config_subject_mismatch(
+    tmp_path, monkeypatch
+):
+    root, subject, policy, manifest = _degraded_evidence_directory(
+        tmp_path, monkeypatch
+    )
+    oci_path = root / "oci-report.json"
+    oci_report = json.loads(oci_path.read_text(encoding="utf-8"))
+    oci_report["config_digest"] = "sha256:" + "f" * 64
+    oci_path.write_text(
+        json.dumps(oci_report, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    gate_path = root / "gate-report.json"
+    gate = json.loads(gate_path.read_text(encoding="utf-8"))
+    gate["evidence"]["oci_layout"]["report_sha256"] = canonical_sha256(
+        oci_report
+    )
+    gate_path.write_text(
+        json.dumps(gate, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "core.agentic_v2_oci.verify_oci_layout",
+        lambda *_args, **_kwargs: deepcopy(oci_report),
+    )
+
+    with pytest.raises(ValueError, match="OCI evidence report mismatch"):
+        _validate_directory(root, subject, policy, manifest)
 
 
 def test_evidence_directory_accepts_resource_only_containment_degradation(
@@ -279,6 +370,61 @@ def test_evidence_directory_accepts_resource_only_containment_degradation(
     assert gate["evidence"]["capability_receipt"]["status"] == "verified"
     assert gate["evidence"]["sbom"]["status"] == "verified"
     assert gate["evidence"]["license"]["status"] == "verified"
+
+
+def test_evidence_directory_rejects_license_report_type_coercion(
+    tmp_path, monkeypatch
+):
+    root, subject, policy, manifest = _degraded_evidence_directory(
+        tmp_path,
+        monkeypatch,
+        collection_allowed=True,
+    )
+    path = root / "license-report.json"
+    report = json.loads(path.read_text(encoding="utf-8"))
+    report["foundation_only"] = 1
+    unsigned = deepcopy(report)
+    unsigned.pop("report_sha256")
+    report["report_sha256"] = canonical_sha256(unsigned)
+    path.write_text(
+        json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    gate_path = root / "gate-report.json"
+    gate = json.loads(gate_path.read_text(encoding="utf-8"))
+    gate["evidence"]["license"]["report_sha256"] = canonical_sha256(report)
+    gate_path.write_text(
+        json.dumps(gate, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="license report identity"):
+        _validate_directory(root, subject, policy, manifest)
+
+
+def test_evidence_directory_rejects_resealed_oci_report_type_coercion(
+    tmp_path, monkeypatch
+):
+    root, subject, policy, manifest = _degraded_evidence_directory(
+        tmp_path, monkeypatch
+    )
+    path = root / "oci-report.json"
+    report = json.loads(path.read_text(encoding="utf-8"))
+    report["layer_count"] = float(report["layer_count"])
+    path.write_text(
+        json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    gate_path = root / "gate-report.json"
+    gate = json.loads(gate_path.read_text(encoding="utf-8"))
+    gate["evidence"]["oci_layout"]["report_sha256"] = canonical_sha256(report)
+    gate_path.write_text(
+        json.dumps(gate, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="OCI evidence report mismatch"):
+        _validate_directory(root, subject, policy, manifest)
 
 
 @pytest.mark.parametrize(
@@ -368,6 +514,54 @@ def test_missing_supply_chain_evidence_keeps_candidate_blocked():
         validate_evidence_report(forged, subject, policy)
 
 
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    [
+        ("cve", "policy_id", None),
+        ("cve", "unexpected", True),
+        ("cve", "scanner_db_max_age_days", "7"),
+        ("cve", "denied_severities", ["LOW"]),
+        ("provenance", "profile", None),
+        ("provenance", "unexpected", True),
+        ("provenance", "required_subjects", "candidate"),
+        ("provenance", "profile", "forged"),
+    ],
+)
+def test_supply_chain_policy_rejects_incomplete_cve_and_provenance(
+    section, field, value
+):
+    document = json.loads(POLICY.read_text(encoding="utf-8"))
+    if value is None:
+        del document[section][field]
+    else:
+        document[section][field] = value
+
+    with pytest.raises(ValueError, match="supply-chain policy"):
+        SupplyChainPolicy.from_mapping(document)
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    [
+        ("cve", "scanner_db_max_age_days", 7.0),
+        ("signature", "trusted_key_required", 1),
+        ("signature", "bundle_required", 1),
+        ("microvm", "jailer_required", 1),
+        ("microvm", "kvm_required", 1),
+        ("microvm", "read_only_rootfs", 1),
+        ("microvm", "ephemeral_work_disk", 1),
+    ],
+)
+def test_supply_chain_policy_rejects_numeric_security_types(
+    section, field, value
+):
+    document = json.loads(POLICY.read_text(encoding="utf-8"))
+    document[section][field] = value
+
+    with pytest.raises(ValueError, match="supply-chain policy"):
+        SupplyChainPolicy.from_mapping(document)
+
+
 def test_evidence_subject_mismatch_is_rejected():
     manifest = AgenticV2SubstrateManifest.load(MANIFEST)
     subject = _subject(manifest)
@@ -381,6 +575,44 @@ def test_evidence_subject_mismatch_is_rejected():
     report["evidence"]["capability_receipt"]["subject_sha256"] = "f" * 64
 
     with pytest.raises(ValueError, match="evidence identity"):
+        validate_evidence_report(report, subject, policy)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_revision", int("1" * 40)),
+        ("image_id", int("1" * 64)),
+        ("license_evaluator_sha256", int("1" * 64)),
+    ],
+)
+def test_candidate_subject_rejects_numeric_identities(field, value):
+    manifest = AgenticV2SubstrateManifest.load(MANIFEST)
+    document = deepcopy(_subject(manifest).document)
+    document[field] = value
+
+    with pytest.raises(ValueError, match="candidate subject identity"):
+        CandidateSubject.from_mapping(document)
+
+
+@pytest.mark.parametrize("field", ["sha256", "report_sha256"])
+def test_evidence_report_rejects_numeric_digests(field):
+    manifest = AgenticV2SubstrateManifest.load(MANIFEST)
+    subject = _subject(manifest)
+    policy = SupplyChainPolicy.load(POLICY)
+    report = build_blocked_evidence_report(
+        subject,
+        policy,
+        capability_receipt_sha256="a" * 64,
+        oci_layout_report_sha256="b" * 64,
+    )
+    item = report["evidence"]["capability_receipt"]
+    if field == "sha256":
+        item["tool"]["sha256"] = int("1" * 64)
+    else:
+        item["report_sha256"] = int("1" * 64)
+
+    with pytest.raises(ValueError, match="evidence tool identity"):
         validate_evidence_report(report, subject, policy)
 
 
@@ -509,6 +741,123 @@ def _effective_sbom_fixture():
         } for package in packages],
     }
     return observation, sbom
+
+
+def _license_evidence_fixture(sbom):
+    records = []
+
+    def evidence(source, path, index):
+        return {
+            "source": source,
+            "path": path,
+            "resolved_path": path,
+            "sha256": f"{index + 1:064x}",
+            "size": index + 1,
+        }
+
+    for index, package in enumerate(sbom["packages"]):
+        purl = package["externalRefs"][0]["referenceLocator"]
+        if purl.startswith("pkg:deb/"):
+            ecosystem = "debian"
+            metadata = {
+                "architecture": "amd64",
+                "copyright_format": (
+                    "https://www.debian.org/doc/packaging-manuals/"
+                    "copyright-format/1.0/"
+                ),
+            }
+            raw_values = [package["licenseDeclared"]]
+            evidence_items = [
+                evidence("debian-status", "/var/lib/dpkg/status", 800),
+                evidence(
+                    "debian-copyright",
+                    f"/usr/share/doc/{package['name']}/copyright",
+                    index,
+                ),
+            ]
+        elif purl.startswith("pkg:pypi/"):
+            ecosystem = "python"
+            metadata = {
+                "license_expression": package["licenseDeclared"],
+                "license": None,
+                "classifiers": [],
+                "license_file_tokens": [],
+                "license_files": [],
+            }
+            raw_values = [package["licenseDeclared"]]
+            metadata_path = (
+                "/usr/local/lib/python3.11/site-packages/"
+                f"{package['name']}-{package['versionInfo']}.dist-info/METADATA"
+            )
+            evidence_items = [evidence("python-metadata", metadata_path, index)]
+        elif purl.startswith("pkg:cran/"):
+            ecosystem = "r"
+            runtime_value = {"version": "4.2.2", "license": ""}
+            runtime_bytes = json.dumps(
+                runtime_value,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            metadata = {
+                "declared_license": package["licenseDeclared"],
+                "priority": None,
+                "runtime_license": "",
+                "runtime_license_fields": ["GPL-2"],
+                "runtime_copyright_format": (
+                    "https://www.debian.org/doc/packaging-manuals/"
+                    "copyright-format/1.0/"
+                ),
+                "runtime_version": "4.2.2",
+                "license_file_tokens": [],
+            }
+            raw_values = [package["licenseDeclared"], "GPL-2"]
+            description_path = f"/usr/lib/R/library/{package['name']}/DESCRIPTION"
+            evidence_items = [
+                evidence("r-description", description_path, index),
+                evidence(
+                    "r-runtime-description",
+                    "/usr/lib/R/library/base/DESCRIPTION",
+                    700,
+                ),
+                {
+                    "source": "r-runtime-license",
+                    "path": None,
+                    "resolved_path": None,
+                    "sha256": hashlib.sha256(runtime_bytes).hexdigest(),
+                    "size": len(runtime_bytes),
+                },
+                evidence(
+                    "r-runtime-copyright",
+                    "/usr/share/doc/r-base-core/copyright",
+                    701,
+                ),
+            ]
+        else:
+            ecosystem = "npm"
+            metadata = {
+                "license": package["licenseDeclared"],
+                "license_file_tokens": [],
+            }
+            raw_values = [package["licenseDeclared"]]
+            evidence_items = [evidence(
+                "npm-package-json", "/usr/share/nodejs/npm/package.json", index
+            )]
+        records.append({
+            "ecosystem": ecosystem,
+            "package": package["name"],
+            "version": package["versionInfo"],
+            "purl": purl,
+            "raw_values": raw_values,
+            "metadata": metadata,
+            "evidence": evidence_items,
+        })
+    records.sort(key=lambda item: item["purl"])
+    return {
+        "schema_version": "1.0",
+        "collector": "gdpval-agentic-v2-license-evidence-v1",
+        "records": records,
+        "records_sha256": canonical_sha256(records),
+    }
 
 
 def test_effective_sbom_reconciles_ecosystem_counts():

--- a/batch-runner/tests/test_agentic_v2_supply_chain.py
+++ b/batch-runner/tests/test_agentic_v2_supply_chain.py
@@ -60,7 +60,7 @@ def _subject(manifest):
         ),
         "license_evaluator_python_version": "3.10.12",
         "license_evaluator_callable_sha256": (
-            "e27e24ff0053d4f68aca4d2ec770d83b8cd8536629c01406c7f5578f6972a78b"
+            "825f97f04b9b94c048326625a7e56b6a0960b196964dabcf4ba7ad3e8e9b3056"
         ),
         "license_evaluator_runtime_graph_sha256": (
             "8fff34b3a069995de020a123594de0254935b12ab154b272057807c8de7be459"

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,113 +1,127 @@
 # Latest Task Result
+This is the canonical rolling record of the most recently completed repository task. It must be refreshed before a task is reported complete.
 
-This is the canonical rolling record of the most recently completed repository
-task. It must be refreshed before a task is reported complete.
-
-- Updated: 2026-07-29
-- Status: Agentic Sandbox V2 evidence collection decoupled from CPU/PID
-  production limits and shipped through PR #150; exact evidence and full
-  regression validation passed
+- Updated: 2026-07-31
+- Status: Agentic Sandbox V2 Phase 1C deterministic license evidence
+  implemented and validated on one exact local candidate; production remains
+  disabled and blocked
 
 ## Task
 
-- Remove the overly strict rule that prevented capability, SBOM, and license
-  evidence whenever the host lacked CPU quota or PID controllers.
-- Preserve effective isolation for fixed CI evidence probes and keep all
-  production execution, model, Step 2, workflow, grading, publication, and
-  registry paths disabled.
-- Prove the change on one exact candidate, complete adversarial review and full
-  regression validation, update documentation, and ship through a reviewed PR.
+- Close the Phase 1B inventory's 1,255 unknown license declarations with
+  deterministic, model-free Debian, Python, R, and npm evidence.
+- Normalize only exact evidence, preserve honest unresolved outcomes, and make
+  package exceptions exact, reviewable, stale-proof, denied-proof, and
+  fail-closed.
+- Bind the result to exact Git, image, OCI, SBOM, collector, evaluator runtime,
+  policy, containment, and aggregate-gate identities without activating any
+  model, workflow, grading, publication, registry, or production path.
 
 ## Result
 
-- Added containment report schema 1.1 with separate `collection_checks` and
-  production `checks`. Collection requires effective network-none, read-only
-  root, UID/GID 65532, zero capabilities, no-new-privileges, and memory limit;
-  production still requires those six plus CPU quota and PID limit.
-- Runtime collection proof now checks capability sets, `prctl` NNP state,
-  IPv4/IPv6 routes, memory cgroups, identity, and rootfs flags. Docker inspect
-  independently binds HostConfig, the `none` network attachment, addresses and
-  gateways, security options, user, memory, and read-only root.
-- CPU and PID are probed independently, so an unsupported resource controller
-  cannot prevent the six isolation checks or fixed evidence collection.
-- Every parent and candidate operation uses a previously inspected immutable
-  local image ID and `--pull=never`. The verifier never reinterprets a mutable
-  tag or pulls during evidence collection.
-- Candidate execution occurs only after collection isolation passes. Default
-  entrypoint behavior requires exact exit code 78, empty stdout, and the exact
-  canonical stderr line. Capability and SBOM scripts are committed, Git-bound
-  inputs and run with no network, no host mounts, read-only root, non-root
-  identity, dropped capabilities, NNP, memory, tmpfs, timeout, UUID name, and
-  verified cleanup.
-- Container cleanup survives remove errors and confirms exact-name absence;
-  ambiguous daemon errors, wrong names, malformed output, unknown warnings, and
-  partial isolation all fail closed.
-- Production containment remains `failed` when CPU/PID controls are unavailable,
-  remains required by policy, and cannot make the aggregate candidate complete.
-- V1, Phase 1A, workflows, executor, Step 2, models, grading, publication, and
-  registry behavior are unchanged.
+- Added a stdlib-only in-image collector using fixed roots and
+  descriptor-relative no-follow opens. Parsed metadata and SHA-256 identities
+  derive from the same file descriptor bytes.
+- Added host-owned SPDX normalization for exact identifiers, aliases,
+  `AND`/`OR`/`WITH`, Debian expressions, Python metadata/classifiers/files, R
+  DESCRIPTION/runtime evidence, and npm metadata/files.
+- Every package records ecosystem, name, version, purl, raw values, evidence
+  source/path/digest/size, classification, normalized expression, and reason.
+- Outcomes are `resolved`, `missing_metadata`, `ambiguous`, `unverifiable`,
+  `denied`, or exact `exception`; unresolved values never become fabricated
+  certainty. Denied identifiers are checked before exceptions.
+- Exceptions require exact ecosystem, package, version, purl, evidence digest,
+  normalized expression, reason, approver, and expiry. Missing, unstructured,
+  malformed, stale, mismatched, reference-incomplete, denied, custom SPDX, and
+  Unicode-obfuscated reference cases fail closed.
+- Hybrid/noncanonical Debian copyright files remain present-unstructured;
+  canonical DEP-5 claims stay strict. Symlink/ENOTDIR copyright paths become
+  deterministic unverifiable observations without following links.
+- Python multiline Header values become deterministic strings while exact
+  METADATA remains evidence. R receipt/SBOM inventory is static and includes
+  `translations`; prose runtime copyright keeps all 15 R packages unresolved.
+- The staged evaluator runs under `python -I -S -B` from exact Git and
+  packaging source. Its identity binds the transformed parser, exact SPDX
+  snapshots, normalization/classification/report code, semantic dependencies,
+  aliases, exceptions, and import-order-independent behavior.
+- Candidate volumes and healthchecks are forbidden; every probe disables
+  healthchecks. Probe-loaded SBOM source is Git-digest-bound. Exact evidence
+  bytes are rehashed from safe root copies or bounded, canonical, non-extracted
+  Docker archives.
+- Production activation remains `disabled`. Collection isolation passes all
+  six required checks, but production containment still fails on unavailable
+  CPU and PID controllers. CVE, signature, provenance, and real microVM boot
+  remain `not_run`.
 
 ## Exact Candidate Evidence
 
-- Source checkpoint: `133df3f0aa5e4361c6c6cb7fd142ef5bdff8c1b5`.
-- Local image ID:
-  `sha256:dea418e4964c2e73bf77496633d0e16e5fc4fb66dddbb743d91d0020b672a77a`.
+- Source checkpoint: `1397f92b5257747ca3faf99e00a74269d4b14875`.
+- Local image ID/config digest:
+  `sha256:e47537b8f7ac7c595b3a055dea4d16283efaa9c9a67c0f8a3e0fc2d65e834e29`.
 - OCI manifest:
-  `sha256:e55817b206dfc4fed855742b327bf6a7c7bdd3b08bc391c2470f9b16efa7f525`.
-- OCI layout: `verified`, 22 `linux/amd64` layers.
-- Collection isolation: all six checks `true`; status `verified`.
-- Production containment: common six checks `true`, CPU quota and PID limit
-  `false`; status `failed`.
-- Capability receipt: `verified` with 20 commands, 13 Python modules, three font
-  families, and all nine artifact smokes passing.
-- Package inventories: Debian 1,152, Python 255, R 14, npm 1.
-- Effective SPDX SBOM: `verified`, 1,422 packages.
-- License policy: `failed`, 1,255 unknown declarations and zero denied packages.
-- CVE, signature, provenance, and real microVM boot: `not_run`.
-- Aggregate gate: `blocked`; production activation remains `disabled`.
-- Every evidence file is a single-link regular file; no evidence symlink or
-  candidate container remains.
+  `sha256:0064ce70a26d6df58353a2e305a69d1d03e1db4525eee9870841fe10c6b3d02a`;
+  23 `linux/amd64` layers.
+- Subject SHA-256:
+  `1973c18983231fc04bae2cae3c6ea83ac4aef3073fdd723f8361069c66e77bd5`.
+- Package inventory: Debian 1,152, Python 255, R 15, npm 1; total 1,423.
+- Effective SBOM canonical SHA-256:
+  `d255981ec7a5f31091a8d83c8e8c0e099ce312f95da052c01bc361c29551547b`.
+- License evidence: 1,423 records, 1,720 physical files, canonical SHA-256
+  `53bd61004c298ddddad065730e408228f1a795d3cb06b2b804abb70d4c1f2297`,
+  raw file SHA-256
+  `bee961e424cdd356eae5db67600829eeeaf28ac423cd14ee04bd702d89980043`.
+- Evaluator callable identity:
+  `825f97f04b9b94c048326625a7e56b6a0960b196964dabcf4ba7ad3e8e9b3056`.
+- Decisions SHA-256:
+  `cbf6946482114ec8e9948e845653ec525dcbdccedd585623a320d7c9fc8f7eff`.
+- Overall classifications: 186 resolved, 898 ambiguous, 1 missing metadata,
+  338 unverifiable, 0 denied, and 0 exceptions; unresolved total 1,237.
+- Debian: 842 ambiguous, 310 unverifiable. Python: 185 resolved, 56
+  ambiguous, 13 unverifiable, 1 missing. R: 15 unverifiable. npm: 1 resolved.
+- License status: `failed`; aggregate gate: `blocked`. Blocking evidence:
+  containment, CVE, license, microVM, provenance, and signature.
 
 ## Verification
 
-- Focused evidence, containment, cleanup, and supply-chain suite: **64 passed**.
-- Phase 1B static contracts: **93 passed**.
-- Exact local Docker integration: **1 passed** in 49.26 seconds.
-- Combined V1, Phase 1A, Phase 1B, sandbox, and executor suite: **640 passed, 1
-  skipped, and 8 integration tests deselected** in 47.01 seconds.
-- Complete credential-free backend: **2,644 passed, 6 host-dependent skipped,
-  and 45 integration tests deselected** in 103.38 seconds.
-- `py_compile`, static diagnostics, exact evidence reopening, V1 image identity,
-  and `git diff --check` pass.
-- Independent adversarial review progressed through containment, image identity,
-  Docker warning, lifecycle cleanup, route/NNP, schema, entrypoint, and test
-  findings to final **APPROVE** with no code merge blocker.
+- Phase 1B/1C focused contracts: **372 passed**, 1 integration marker
+  deselected.
+- Exact local Docker/OCI integration: **1 passed** in 161.30 seconds.
+- Agentic, sandbox, hardened-sandbox, and executor regression: **923 passed**,
+  1 host-dependent skipped, and 8 integration tests deselected.
+- Complete credential-free backend: **2,927 passed**, 6 host-dependent skipped,
+  and 45 integration tests deselected in 112.70 seconds.
+- Persisted evidence directory semantic reopening passed, including OCI blob
+  verification, receipt/SBOM reconciliation, evaluator recomputation, report
+  binding, and unsupported-evidence absence.
+- The final collector output matched the persisted evidence and a second cold
+  run byte-for-byte; all three raw SHA-256 values were `bee961e424cd...`.
+- Draft 2020-12 schema validation, Ruff, `py_compile`, `pip check`, static
+  diagnostics, and `git diff --check` passed.
+- Independent adversarial review iterated through metadata parsing, evidence
+  paths, denied/exception precedence, lifecycle cleanup, revision and source
+  binding, archive handling, import-order identity, parser globals, builtin and
+  regex poisoning, and complete classification dependencies to final
+  **APPROVE** with zero mandatory or optional findings.
 - No model, Azure, grading, Hugging Face write/upload, registry login/push,
-  workflow dispatch, publication, or paid operation ran. Docker used only the
-  local Unix daemon and public package downloads needed for the exact image.
+  publication, workflow dispatch, deployment, or paid operation ran.
 
 ## Shipment
 
-- Exact evidence code checkpoint:
-  `133df3f0aa5e4361c6c6cb7fd142ef5bdff8c1b5`.
-- Reviewed branch head: `870dfa9576e028fdf82dbcfbcd2bc61acc8e3085`.
-- PR [#150](https://github.com/hyeonsangjeon/gdpval-realworks/pull/150)
-  was squash-merged as `a4f770627aea772203d54f472f4f9d956b0e3dfd`
-  on 2026-07-29 UTC.
-- GitHub reported the PR `MERGEABLE` with no required review, status check, or
-  branch protection gate. No automatic PR or `main` workflow run was created
-  because the nine changed paths are outside every active automatic workflow
-  filter; no manual workflow was dispatched to compensate.
-- The remote feature branch was deleted after merge. No image, OCI layout, or
-  local evidence artifact was pushed or published.
+- Implementation branch: `feat/agentic-v2-phase1c-license-evidence`.
+- Current reviewed checkpoint: `1397f92b5257747ca3faf99e00a74269d4b14875`.
+- Push, pull request, remote checks, squash merge, and completion-only record PR
+  remain pending at this checkpoint.
 
 ## Remaining Work
 
-- No repository implementation or primary shipment work remains for this
-  evidence-containment correction.
-- Production activation remains blocked on CPU and PID containment, complete
+- Ship the reviewed branch through a pull request and record its squash-merge
+  identity; update this rolling record in a completion-only PR if needed.
+- Production remains blocked on enforceable CPU/PID containment, complete
   retained/transitive package artifacts, a pinned CVE scanner and database,
   approved signature trust root, provenance attestation, and a real
   Firecracker/jailer/KVM boot and cleanup proof.
+- Resolve or explicitly review the 1,237 unresolved package licenses before any
+  compliance claim. This task makes no license-compliant, vulnerability-free,
+  signed, reproducible, release-ready, or production-ready claim.
 - Package broker, web egress, model loop, grading, publication, and production
-  authorization remain later-phase work. This change approves none of them.
+  authorization remain later-phase work.


### PR DESCRIPTION
## Summary

- collect deterministic Debian, Python, R, and npm license evidence from the exact Phase 1B candidate without following evidence symlinks
- normalize only exact SPDX evidence, preserve honest missing/ambiguous/unverifiable outcomes, enforce denied-first exact exceptions, and bind every decision to package/version/purl/evidence identity
- bind the collector, evaluator, OCI layout, effective SBOM, policy, image config, runtime source, containment, and report identities while keeping production disabled
- align static R receipt/SBOM inventory, support real hybrid Debian metadata, and safely rehash 1,720 exact-image evidence files

## Exact evidence

- source checkpoint: `1397f92b5257747ca3faf99e00a74269d4b14875`
- image: `sha256:e47537b8f7ac7c595b3a055dea4d16283efaa9c9a67c0f8a3e0fc2d65e834e29`
- OCI manifest: `sha256:0064ce70a26d6df58353a2e305a69d1d03e1db4525eee9870841fe10c6b3d02a`
- inventory: 1,423 packages (Debian 1,152; Python 255; R 15; npm 1)
- decisions: 186 resolved; 898 ambiguous; 1 missing metadata; 338 unverifiable; 0 denied; 0 exceptions
- unresolved: 1,237; license status remains `failed`
- collector raw SHA-256: `bee961e424cdd356eae5db67600829eeeaf28ac423cd14ee04bd702d89980043`, byte-identical across persisted output and two fresh exact-image runs
- aggregate gate remains `blocked`; production activation remains `disabled`

## Validation

- Phase 1B/1C focused: 372 passed, 1 integration deselected
- exact Docker/OCI integration: 1 passed
- agentic/sandbox/executor: 923 passed, 1 skipped, 8 deselected
- full credential-free backend: 2,927 passed, 6 skipped, 45 deselected
- evidence directory semantic reopening, Draft 2020-12 schema, Ruff, `py_compile`, `pip check`, diagnostics, and `git diff --check` passed
- independent adversarial review: APPROVE, zero mandatory or optional findings

## Boundaries

- containment remains failed because this host cannot enforce CPU and PID limits
- CVE, signature, provenance, and real microVM evidence remain `not_run`
- no model, Azure, grading, Hugging Face write, publication, registry push, workflow dispatch, deployment, or paid operation ran
- this makes no license-compliant, vulnerability-free, signed, reproducible, release-ready, or production-ready claim
