### PR TITLE
fix(grading): preserve non-RGB Excel colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Fixed
+- **Excel formatting color observations** - stop openpyxl's inactive color
+  descriptors from leaking validation-error strings into grader evidence.
+  XLSX inspection now emits stable RGB, theme, indexed, and auto tokens,
+  preserves nonzero theme tint, and excludes the workbook's default font color
+  so plain and number-format-only cells are not misclassified as explicitly
+  styled. Defensive default-style lookup fails soft across openpyxl layout
+  changes. Validation passes 51 available `read_deliverable` contracts and 55
+  grader dispatch, perception wiring, and grading configuration contracts; one
+  unrelated PDF content test remains unexecuted locally because `pdfplumber` is
+  unavailable in the active interpreter.
+
 ### Added
 - **Self-preparing dashboard validation** - make `npm run test:aggregate`
   generate its required dashboard/report fixtures before running while exposing

--- a/batch-runner/core/tools/read_deliverable.py
+++ b/batch-runner/core/tools/read_deliverable.py
@@ -412,10 +412,69 @@ def _op_read_content(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
 # ── inspect_formatting ───────────────────────────────────────────────
 
 
+def _safe_cell_color(color: Any) -> Optional[str]:
+    """Return a stable token for an openpyxl color without reading inactive descriptors."""
+    if color is None:
+        return None
+
+    color_type = getattr(color, "type", None)
+    if color_type == "rgb":
+        value = color.rgb
+        if isinstance(value, str) and "Values must be of type" not in value:
+            return value
+    elif color_type == "theme":
+        value = color.theme
+        if isinstance(value, int) and not isinstance(value, bool):
+            token = f"theme:{value}"
+            tint = getattr(color, "tint", 0.0)
+            if isinstance(tint, (int, float)) and not isinstance(tint, bool) and tint:
+                token += f":tint:{tint:g}"
+            return token
+    elif color_type == "indexed":
+        value = color.indexed
+        if isinstance(value, int) and not isinstance(value, bool):
+            return f"indexed:{value}"
+    elif color_type == "auto" and color.auto is True:
+        return "auto"
+    return None
+
+
+def _workbook_default_font_color(workbook: Any) -> Any:
+    """Find the workbook's default font color across supported openpyxl layouts."""
+    named_styles = getattr(workbook, "_named_styles", None)
+    if named_styles is not None:
+        try:
+            normal_style = named_styles["Normal"]
+        except (KeyError, TypeError):
+            pass
+        else:
+            normal_font = getattr(normal_style, "font", None)
+            if normal_font is not None:
+                return getattr(normal_font, "color", None)
+
+    fonts = getattr(workbook, "_fonts", None)
+    if fonts:
+        return getattr(fonts[0], "color", None)
+    return None
+
+
+def _nondefault_font_color(cell: Any, default_color: Any) -> Any:
+    """Return a cell's explicit font color, omitting the workbook default."""
+    font = getattr(cell, "font", None)
+    color = getattr(font, "color", None)
+    if default_color is not None:
+        return color if color != default_color else None
+
+    style = getattr(cell, "_style", None)
+    font_id = getattr(style, "fontId", None)
+    return color if font_id not in (None, 0) else None
+
+
 def _format_xlsx(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
     import openpyxl  # type: ignore
 
     wb = openpyxl.load_workbook(p, data_only=False)
+    default_font_color = _workbook_default_font_color(wb)
     target = scope.get("sheet")
     sheets_meta = []
     for name in wb.sheetnames[:MAX_SHEETS]:
@@ -434,13 +493,13 @@ def _format_xlsx(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
                 seen += 1
                 if cell.value is None:
                     continue
-                fill_color = None
-                if cell.fill and cell.fill.fgColor and cell.fill.fgColor.rgb:
-                    fill_color = str(cell.fill.fgColor.rgb)
+                fill_color = _safe_cell_color(
+                    cell.fill.fgColor if cell.fill else None
+                )
                 font_bold = bool(cell.font and cell.font.bold)
-                font_color = (str(cell.font.color.rgb)
-                              if cell.font and cell.font.color
-                              and cell.font.color.rgb else None)
+                font_color = _safe_cell_color(
+                    _nondefault_font_color(cell, default_font_color)
+                )
                 has_border = bool(cell.border and (
                     (cell.border.top and cell.border.top.style) or
                     (cell.border.bottom and cell.border.bottom.style) or

--- a/batch-runner/tests/test_read_deliverable.py
+++ b/batch-runner/tests/test_read_deliverable.py
@@ -281,6 +281,72 @@ def test_inspect_formatting_xlsx(base_dir, xlsx_file):
     assert sheet["styled_cells_count"] >= 1
 
 
+def test_inspect_formatting_xlsx_preserves_color_types_without_descriptor_junk(
+    base_dir,
+):
+    openpyxl = pytest.importorskip("openpyxl")
+    from openpyxl.styles import Color, Font, PatternFill
+
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    colors = {
+        "A1": (Color(rgb="FF112233"), Color(rgb="FF445566")),
+        "A2": (Color(theme=4, tint=0.4), Color(theme=5, tint=-0.25)),
+        "A3": (Color(indexed=7), Color(indexed=8)),
+        "A4": (Color(auto=True), Color(auto=True)),
+    }
+    for ref, (font_color, fill_color) in colors.items():
+        sheet[ref] = ref
+        sheet[ref].font = Font(color=font_color)
+        sheet[ref].fill = PatternFill(fill_type="solid", fgColor=fill_color)
+    sheet["A5"] = "plain"
+    sheet["A6"] = 1
+    sheet["A6"].number_format = "0.00"
+
+    path = base_dir / "colors.xlsx"
+    workbook.save(path)
+
+    result = read_deliverable("inspect_formatting", path.name, base_dir=str(base_dir))
+
+    assert result["ok"] is True
+    styled = {
+        cell["ref"]: cell
+        for cell in result["data"]["sheets"][0]["styled_cells_sample"]
+    }
+    assert styled["A1"]["font_color"] == "FF112233"
+    assert styled["A1"]["fill"] == "FF445566"
+    assert styled["A2"]["font_color"] == "theme:4:tint:0.4"
+    assert styled["A2"]["fill"] == "theme:5:tint:-0.25"
+    assert styled["A3"]["font_color"] == "indexed:7"
+    assert styled["A3"]["fill"] == "indexed:8"
+    assert styled["A4"]["font_color"] == "auto"
+    assert styled["A4"]["fill"] == "auto"
+    assert set(styled) == set(colors)
+    assert result["data"]["sheets"][0]["styled_cells_count"] == len(colors)
+    assert "Values must be of type" not in str(result)
+
+
+def test_default_font_color_lookup_fails_soft_when_openpyxl_internals_change():
+    class WorkbookWithoutStyleInternals:
+        pass
+
+    class CellWithoutStyleInternals:
+        font = type("Font", (), {"color": "explicit"})()
+
+    assert (
+        read_deliverable_module._workbook_default_font_color(
+            WorkbookWithoutStyleInternals()
+        )
+        is None
+    )
+    assert (
+        read_deliverable_module._nondefault_font_color(
+            CellWithoutStyleInternals(), None
+        )
+        is None
+    )
+
+
 def test_inspect_formatting_docx(base_dir, docx_file):
     r = read_deliverable("inspect_formatting", docx_file.name, base_dir=str(base_dir))
     assert r["ok"] is True

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,75 +1,58 @@
 # Latest Task Result
 
 - Updated: 2026-08-05
-- Status: Self-preparing dashboard validation shipped to `main`; PR and
-  post-merge Pages validation passed
+- Status: Excel non-RGB formatting observation fix implemented and locally
+  validated on a clean worktree; changes are not committed or deployed
 
 ## Task
 
-- Make the documented fresh-checkout sequence work when aggregate tests run
-  before the production build.
-- Preserve the existing dashboard snapshot, experiment, workflow permission,
-  concurrency, dispatch, deployment, and Vite contracts.
-- Add a fail-closed CI check for tracked or untracked files produced by the
-  validation path.
+- Recover the useful non-RGB Excel color parser fix from historical local work
+  without merging the stale dirty checkout or its unrelated changes.
+- Prevent openpyxl descriptor validation messages from entering grader-facing
+  XLSX formatting observations.
+- Preserve explicit color information while excluding workbook defaults from
+  styled-cell counts.
 
 ## Result
 
-- `npm run test:aggregate` now invokes the full aggregate pipeline first, so
-  `public/generated/reports-index.json` and the other generated fixtures exist
-  before the test suite reads them.
-- CI can call `npm run test:aggregate:prepared` after `npm run build`, reusing
-  the exact generated snapshot instead of fetching and aggregating it again.
-- The Ruby-backed batch-workflow inspection is one independent test. It compiles
-  the Ruby heredoc and verifies the expected `condition_b` rejection when Ruby
-  is available; Ruby-less local environments report one explicit skip, while
-  CI fails if Ruby is unavailable.
-- README onboarding documents `npm ci`, `npm run test:aggregate`,
-  `npm run build`, and `git status --short`, including the public,
-  unauthenticated Hugging Face read boundary and the no-model/no-write contract.
-- Pages validation now rejects any tracked or untracked drift after browser
-  tests and before artifact upload. Ignored `node_modules`, `dist`, and
-  `public/generated` outputs remain allowed.
-- Existing deploy permissions, concurrency, path filters, dispatch validation,
-  Pages/OIDC scope, upload/deploy conditions, batch workflow, experiment/model
-  paths, and Vite base were not changed.
+- Reproduced the root cause: reading `.rgb` from theme, indexed, or auto colors
+  returns `Values must be of type <class 'str'>` in the active openpyxl runtime.
+- Added type-aware color serialization:
+  - RGB remains an aRGB string such as `FF112233`.
+  - Theme colors use `theme:N` and retain nonzero tint.
+  - Indexed colors use `indexed:N`.
+  - Automatic colors use `auto`.
+- Added defensive workbook-default font lookup using the Normal named style,
+  with font-table fallback and fail-soft handling when openpyxl internals are
+  unavailable.
+- Plain cells and cells with number formatting only no longer appear explicitly
+  styled solely because the workbook default font uses `theme:1`.
+- Unknown or malformed color types fail soft to no color token instead of
+  emitting descriptor error text.
+- No grading score, rubric, routing, workflow, model, prompt, schema, or
+  publication behavior was changed.
 
 ## Verification
 
-- Focused prepared aggregate suite: 97 tests, 96 passed, 1 intentional local
-  Ruby skip, 0 failed.
-- Documented fresh sequence: `npm ci`, `npm run test:aggregate`, and
-  `npm run build` all succeeded. The aggregate path ran with cloud credential
-  environment variables unset.
-- Production Vite build: 2,783 modules transformed successfully.
-- The cleanliness gate executable contract passes for ignored outputs and
-  fails for both tracked and untracked repository drift.
-- Static diagnostics report no errors in changed JSON, YAML, or JavaScript
-  files; `git diff --check` passes.
-- Aggregation made unauthenticated, read-only requests for 23 public Hugging
-  Face reports. The aggregate validation path used no model, cloud credential,
-  Hugging Face write, grading, or paid API call.
-
-## Shipment
-
-- Reviewed branch head:
-  `69821d3cc289fe6f1e3c7cb3352551fcbe92a9af`.
-- PR [#154](https://github.com/hyeonsangjeon/gdpval-realworks/pull/154)
-  reached `MERGED` at `2026-08-05T05:01:27Z` as commit
-  `49fc90acf8117bb1a6961f04783942c1e7bd8f75`.
-- PR validation run
-  [`30916398926`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/30916398926)
-  passed the build, 97 aggregate contracts including the Ruby path, browser
-  suites, and clean working-tree gate. Deployment was correctly skipped for
-  the pull request.
-- Post-merge main run
-  [`30976841158`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/30976841158)
-  passed validation, uploaded the exact Pages artifact, and deployed it.
+- The new public `read_deliverable("inspect_formatting", ...)` regression failed
+  before the fix on the theme color descriptor string.
+- The strengthened regression then exposed default-font overcounting before the
+  second fix and passed afterward.
+- Color compatibility tests: 2 passed.
+- Available `read_deliverable` suite: 51 passed, 1 deselected.
+- Grader dispatch, perception wiring, and grading configuration suites: 55
+  passed.
+- Python compilation, static diagnostics, and `git diff --check` passed.
+- Ruff reports the same seven pre-existing unused-import/variable findings on
+  both this branch and `origin/main`; no new Ruff category was introduced.
 
 ## Remaining Work
 
-- The public report fallback still reads mutable Hugging Face `main`; this path
-  is credential-free and read-only, but it is not offline or fully deterministic.
-- GitHub reported a non-blocking warning that pinned JavaScript actions still
-  target the deprecated Node.js 20 action runtime while the workflow forces
-  Node.js 24. Track upstream action updates without weakening the current pinning.
+- The deselected PDF content test requires `pdfplumber`, which is declared in
+  `batch-runner/requirements.txt` but unavailable in the active local Python
+  interpreter. Run the complete suite in CI or a fully provisioned environment.
+- Theme/indexed tokens identify workbook color sources rather than resolved
+  display RGB values. Resolving a theme and palette to rendered color remains a
+  separate enhancement.
+- Historical grade artifacts that already contain descriptor junk are not
+  rewritten.


### PR DESCRIPTION
## Summary
- prevent inactive openpyxl color descriptors from leaking validation-error strings into XLSX grading observations
- preserve RGB, theme/tint, indexed, and automatic color identities while excluding workbook-default font colors
- add fail-soft compatibility handling and public integration regressions for plain and number-format-only cells

## Validation
- regression failed before the fix on theme descriptor junk
- strengthened regression failed before default-font exclusion
- `tests/test_read_deliverable.py`: 51 passed, 1 local dependency deselected
- affected grader/config suites: 55 passed
- `py_compile`, diagnostics, and `git diff --check`
- grading-engineer and first-reviewer: APPROVE

The one deselected PDF content test requires `pdfplumber`, which is declared in requirements but unavailable in the active local interpreter; it is unrelated to XLSX formatting.