### PR TITLE
feat(sandbox): add offline wheel broker candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,32 @@ entries land under a fresh dated heading the day they merge to `main`.
   credential, publication, or paid API call was used for this fix.
 
 ### Added
+- **Agentic Sandbox V2 Phase 1D-A offline wheel broker candidate** - add a
+  disconnected, model-free local candidate for stateless resolution and atomic
+  activation of at most eight exact dependency-free `py3-none-any` wheels from
+  one approved Linux/amd64/current-Python snapshot. Admission verifies exact
+  artifact bytes, ZIP/RECORD/METADATA/WHEEL identity, compatibility, bounded
+  paths and resources, and rejects dependency, startup-hook, executable-mode,
+  collision, link, FIFO, and mutable-coordinate surfaces. Activation uses a
+  deterministic stdlib extractor rather than pip or a subprocess; canonical
+  receipts bind independently derived file inventories to the lock, snapshot,
+  policy, implementation, and Python identity. Descriptor-relative staging,
+  bounded replay and cleanup, process-shared nonblocking leases, global root
+  state, and 8-environment/512 MiB quotas fail closed on drift and preserve
+  shared environments until the last lease closes. The implementation is
+  outside existing image/core-tree and Phase 1B/1C allowlist inputs, while
+  tracked Dockerignore rules exclude all Phase 1D-A artifacts from existing
+  publication build contexts. The 75 focused adversarial contracts and 644
+  Agentic V2/Phase 1B/1C regressions pass; independent
+  security and code reviews returned `APPROVE`. The credential-free backend
+  completed 3,001 passes and 6 skips with 45 integration tests deselected, and
+  three unchanged environment failures caused by stale local Azure SDK versions
+  and missing `pdfplumber`. No package
+  index, network, model, credential, workflow, grading, upload, publication, or
+  paid operation ran. `exec_run`, npm, Debian/apt, URLs/VCS/sdists/editables,
+  production wiring, and admission claims for SBOM/license/CVE/provenance/
+  signature remain disabled or `not_run`; OS containment and crash durability
+  remain unproven.
 - **Self-preparing dashboard validation** - make `npm run test:aggregate`
   generate its required dashboard/report fixtures before running while exposing
   a prepared-only entry point for CI reuse; isolate the Ruby-backed workflow

--- a/batch-runner/.dockerignore
+++ b/batch-runner/.dockerignore
@@ -1,6 +1,12 @@
 # Docker build context ignore list for the sandbox image.
 # Build context is batch-runner/; keep it small and reproducible.
 
+# Disconnected Agentic V2 package broker candidate
+sandbox/v2/agentic_v2_package_broker.py
+sandbox/v2/README.md
+schemas/agentic-v2-package-snapshot.schema.json
+security/agentic-v2-package-broker-policy.json
+
 # VCS / tooling
 .git
 .gitignore

--- a/batch-runner/sandbox/v2/README.md
+++ b/batch-runner/sandbox/v2/README.md
@@ -1,4 +1,4 @@
-# Agentic Sandbox V2 Phase 1B/1C Candidate
+# Agentic Sandbox V2 Phase 1B/1C/1D-A Candidates
 
 This directory defines a **model-free, local-only professional-work substrate
 candidate**. It does not activate `agentic_sandbox_v2`, publish an image, or
@@ -47,7 +47,59 @@ stays `blocked`.
 - `professional-work.Dockerfile` has no default parent and no registry output.
 - `disabled_entrypoint.py` exits 78 for every default invocation.
 
-## Local Candidate Build
+## Phase 1D-A Offline Python Wheel Broker
+
+Phase 1D-A adds a separate **model-free, local-only package activation
+candidate**. It is not imported by `TaskExecutor`, Step 2, the Agentic V2
+runner, an experiment, a workflow, grading, upload, or publication code. Its
+dispatcher candidate exposes package resolve and activation while returning
+`capability_unavailable` for workspace mutation, command execution, browser,
+verification, and finalization.
+
+The implementation remains under `sandbox/v2/`, outside the existing agentic
+image's `COPY core` input and core-tree identity. The tracked
+`batch-runner/.dockerignore` also excludes the implementation, this README,
+the snapshot schema, broker policy, and tests from existing Docker publication
+contexts. Phase 1B/1C explicit build allowlists and embedded-image manifests do
+not include the broker.
+
+The checked-in snapshot contract accepts at most eight canonical exact Python
+coordinates for the current Linux amd64 Python major/minor. Each artifact must
+be a dependency-free `py3-none-any` wheel without a build tag. Admission
+reopens exact local bytes, verifies size and SHA-256, validates every bounded
+ZIP path and RECORD member, matches METADATA name/version and
+`Requires-Python`, rejects `Requires-Dist`, file/directory collisions,
+executable-mode entries, `.data`, `.pth`, `.egg-link`, `.pyc`, and all
+`sitecustomize`/`usercustomize` forms, and requires one strict WHEEL identity.
+The snapshot and runtime policy are both identity-bound.
+
+`environment_resolve` is stateless: it returns the existing V2 lock shape and
+does not change backend state. Activation reconstructs an approved lock from
+the snapshot, then uses a deterministic stdlib wheel extractor. It does not
+invoke pip, a package index, a package installer subprocess, or network code.
+Content is staged beneath the already-open private environment-root descriptor,
+verified against an independently derived expected inventory, mode-sealed,
+and atomically renamed. Canonical receipt bytes bind the exact lock, snapshot,
+policy, installer implementation, Python version, file modes, sizes, and
+hashes.
+
+Linux `flock` leases serialize processes and preserve shared environments until
+the last broker closes. Global state and quota checks validate every live
+digest/lease pair, reject unaccounted root entries, and bind all receipt hashes
+and payload bytes. Limits include 256 MiB and 4,096 entries per environment,
+eight environments and 512 MiB per root, 4,104 cleanup entries, and cleanup
+depth 128. Replay uses bounded descriptor-relative traversal and exact-length
+reads; FIFO, symlink, hardlink, growth, mode, content, receipt, lease, and root
+identity drift fail closed.
+
+This slice does not authorize arbitrary Linux execution. The local Bubblewrap
+probe could not create the required user namespace, so `exec_run` remains
+`capability_unavailable`. npm, Debian/apt, live indexes, URLs, VCS, sdists,
+editable installs, model execution, and production wiring remain disabled.
+SBOM, license, CVE, provenance, signature, OS network containment, and crash
+durability are explicitly `not_run` or `not_claimed` for package admission.
+
+## Phase 1B/1C Local Candidate Build
 
 From a **clean committed worktree**:
 
@@ -160,5 +212,6 @@ microVM isolation.
 - MicroVM readiness is not a boot/escape/cleanup proof and does not authorize
   task execution.
 - No GHCR image is pushed, promoted, signed, or tagged `latest`.
-- Phase 1A remains fixture-only. Real package broker, web, model, grading, and
-  publication paths remain disabled.
+- Phase 1A remains fixture-only. Phase 1D-A proves only exact local wheel
+  activation through a disconnected candidate; production package, web,
+  command execution, model, grading, and publication paths remain disabled.

--- a/batch-runner/sandbox/v2/agentic_v2_package_broker.py
+++ b/batch-runner/sandbox/v2/agentic_v2_package_broker.py
@@ -1,0 +1,2101 @@
+"""Offline Python wheel broker candidate for Agentic Sandbox V2 Phase 1D-A.
+
+This module is deliberately not connected to the model loop, ``TaskExecutor``,
+Step 2, workflows, or publication. It proves that an exact local package
+snapshot can be resolved without mutation and activated atomically without any
+package-index or network access.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import base64
+import csv
+import fcntl
+import io
+import itertools
+import json
+import os
+import platform
+import re
+import stat
+import sys
+import tempfile
+import threading
+import zipfile
+from dataclasses import dataclass
+from contextlib import contextmanager
+from email.parser import BytesParser
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import canonicalize_name, parse_wheel_filename
+from packaging.version import Version
+
+from core.agentic_v2_contract import AgenticV2Profile
+from core.agentic_v2_provenance import canonical_sha256
+
+
+PACKAGE_SNAPSHOT_SCHEMA_VERSION = "1.0"
+PACKAGE_BROKER_ID = "agentic-v2-offline-python-wheel-broker-v1"
+PACKAGE_POLICY_ID = "agentic-v2-package-broker-candidate-v1"
+MAX_REQUESTED_PACKAGES = 8
+MAX_ARTIFACT_BYTES = 64 * 1024 * 1024
+MAX_SNAPSHOT_ARTIFACT_BYTES = 64 * 1024 * 1024
+MAX_ENVIRONMENT_BYTES = 256 * 1024 * 1024
+MAX_ENVIRONMENT_ENTRIES = 4096
+MAX_ACTIVE_ENVIRONMENTS = 8
+MAX_ACTIVE_ENVIRONMENT_BYTES = 512 * 1024 * 1024
+MAX_WHEEL_ENTRIES = 4096
+MAX_WHEEL_PATH_BYTES = 240
+MAX_WHEEL_METADATA_BYTES = 1024 * 1024
+MAX_WHEEL_CONTROL_BYTES = 64 * 1024
+MAX_WHEEL_RECORD_BYTES = 2 * 1024 * 1024
+MAX_MANIFEST_BYTES = 1024 * 1024
+MAX_RECEIPT_BYTES = 2 * 1024 * 1024
+MAX_CLEANUP_ENTRIES = MAX_ENVIRONMENT_ENTRIES + 8
+MAX_CLEANUP_DEPTH = 128
+INSTALLER_OVERHEAD_BYTES_PER_WHEEL = 4096
+INSTALLER_OVERHEAD_ENTRIES_PER_WHEEL = 4
+STAGING_PREFIX = ".agentic-v2-staging-"
+LEASE_PREFIX = ".agentic-v2-lease-"
+
+_DIGEST = re.compile(r"[0-9a-f]{64}")
+_EXACT_REQUIREMENT = re.compile(
+    r"([a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?)"
+    r"==([A-Za-z0-9](?:[A-Za-z0-9.!+_-]{0,126}[A-Za-z0-9])?)"
+)
+
+
+@dataclass(frozen=True)
+class PackageArtifact:
+    coordinate: str
+    filename: str
+    sha256: str
+    size: int
+    unpacked_size: int
+    entry_count: int
+    files: frozenset[str]
+    directories: frozenset[str]
+
+
+@dataclass(frozen=True)
+class WheelInspection:
+    unpacked_size: int
+    entry_count: int
+    files: frozenset[str]
+    directories: frozenset[str]
+
+
+@dataclass(frozen=True)
+class PackageSnapshot:
+    artifact_root: Path
+    document: Mapping[str, Any]
+    sha256: str
+    artifacts: Mapping[str, PackageArtifact]
+
+    @classmethod
+    def load(
+        cls,
+        manifest_path: str | Path,
+        *,
+        artifact_root: str | Path,
+    ) -> "PackageSnapshot":
+        root = _directory_path(artifact_root, label="package artifact root")
+        try:
+            raw = _read_regular_bytes(
+                manifest_path,
+                label="package snapshot manifest",
+                max_bytes=MAX_MANIFEST_BYTES,
+            ).decode("utf-8")
+            value = json.loads(raw)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("package snapshot manifest is invalid") from exc
+        document, records = _validate_snapshot(value, root)
+        return cls(
+            artifact_root=root,
+            document=_freeze_json(document),
+            sha256=canonical_sha256(document),
+            artifacts=MappingProxyType(records),
+        )
+
+    def artifact_path(self, coordinate: str) -> Path:
+        artifact = self.artifacts.get(coordinate)
+        if artifact is None:
+            raise KeyError(coordinate)
+        return self.artifact_root / artifact.filename
+
+    def verify_artifact(self, coordinate: str) -> PackageArtifact:
+        artifact = self.artifacts.get(coordinate)
+        if artifact is None:
+            raise ValueError("package is not in the approved snapshot")
+        inspection = _verify_artifact(self.artifact_root, artifact)
+        if inspection != WheelInspection(
+            unpacked_size=artifact.unpacked_size,
+            entry_count=artifact.entry_count,
+            files=artifact.files,
+            directories=artifact.directories,
+        ):
+            raise ValueError("package artifact inventory drifted")
+        return artifact
+
+    def verified_artifact_content(
+        self,
+        coordinate: str,
+    ) -> tuple[PackageArtifact, bytes]:
+        artifact = self.artifacts.get(coordinate)
+        if artifact is None:
+            raise ValueError("package is not in the approved snapshot")
+        content, inspection = _verified_artifact_content(
+            self.artifact_root, artifact
+        )
+        if inspection != WheelInspection(
+            unpacked_size=artifact.unpacked_size,
+            entry_count=artifact.entry_count,
+            files=artifact.files,
+            directories=artifact.directories,
+        ):
+            raise ValueError("package artifact inventory drifted")
+        return artifact, content
+
+
+class OfflinePythonWheelBroker:
+    """Resolve and atomically activate approved local pure-Python wheels."""
+
+    def __init__(
+        self,
+        *,
+        snapshot: PackageSnapshot,
+        environment_root: str | Path,
+    ):
+        self.snapshot = snapshot
+        root = Path(environment_root)
+        if root.is_symlink():
+            raise ValueError("package environment root symlink is forbidden")
+        root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.environment_root = root.resolve()
+        root_metadata = self.environment_root.stat()
+        if (
+            root_metadata.st_uid != os.getuid()
+            or stat.S_IMODE(root_metadata.st_mode) != 0o700
+        ):
+            raise ValueError("package environment root must be private and owned")
+        self._root_fd: int | None = os.open(
+            self.environment_root,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+        )
+        opened_root = os.fstat(self._root_fd)
+        if (
+            opened_root.st_dev != root_metadata.st_dev
+            or opened_root.st_ino != root_metadata.st_ino
+        ):
+            os.close(self._root_fd)
+            self._root_fd = None
+            raise ValueError("package environment root identity changed")
+        self.installer_identity = MappingProxyType(
+            _deterministic_installer_identity()
+        )
+        self.policy_sha256 = _load_package_policy()
+        self._active: dict[str, str] = {}
+        self._leases: dict[str, int] = {}
+        self._activation_lock = threading.RLock()
+        self._closed = False
+
+    def state_sha256(self) -> str:
+        with self._activation_lock:
+            root_fd = self._root_fd
+            if root_fd is not None:
+                fcntl.flock(root_fd, fcntl.LOCK_SH)
+            try:
+                environments: list[tuple[str, str]] = []
+                payload_bytes = 0
+                if root_fd is not None:
+                    self._verify_root_identity(root_fd)
+                    try:
+                        environments, payload_bytes = self._global_root_state(
+                            root_fd
+                        )
+                    except Exception as exc:
+                        raise ValueError(
+                            "package environment state drifted"
+                        ) from exc
+                return canonical_sha256({
+                    "broker_id": PACKAGE_BROKER_ID,
+                    "policy_sha256": self.policy_sha256,
+                    "snapshot_sha256": self.snapshot.sha256,
+                    "installer": dict(self.installer_identity),
+                    "active_environments": environments,
+                    "active_environment_payload_bytes": payload_bytes,
+                })
+            finally:
+                if root_fd is not None:
+                    fcntl.flock(root_fd, fcntl.LOCK_UN)
+
+    def resolve(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        with self._activation_lock:
+            if self._closed:
+                return _error("compute_backend_error")
+        ecosystem = arguments.get("ecosystem")
+        if ecosystem != "python":
+            return _error("capability_unavailable")
+        raw_requirements = arguments.get("requirements")
+        if (
+            not isinstance(raw_requirements, list)
+            or not 1 <= len(raw_requirements) <= MAX_REQUESTED_PACKAGES
+            or any(not isinstance(value, str) for value in raw_requirements)
+            or len(set(raw_requirements)) != len(raw_requirements)
+        ):
+            return _error("invalid_arguments")
+        requirements = sorted(raw_requirements)
+        try:
+            coordinates = [
+                _coordinate_from_requirement(requirement)
+                for requirement in requirements
+            ]
+        except ValueError:
+            return _error("invalid_arguments")
+        if any(coordinate not in self.snapshot.artifacts for coordinate in coordinates):
+            return _error("package_not_in_snapshot")
+        lock = _package_lock(
+            [self.snapshot.artifacts[coordinate] for coordinate in coordinates]
+        )
+        digest = canonical_sha256(lock)
+        return {
+            "ok": True,
+            "data": {"lock_digest": digest, "lock": lock},
+        }
+
+    def activate(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        digest = arguments.get("lock_digest")
+        if not isinstance(digest, str) or _DIGEST.fullmatch(digest) is None:
+            return _error("invalid_arguments")
+        try:
+            lock = self._validated_lock(digest)
+            for requirement in lock["requirements"]:
+                self.snapshot.verify_artifact(
+                    _coordinate_from_requirement(requirement)
+                )
+        except ValueError:
+            return _error("unapproved_lock")
+
+        with self._exclusive_root() as root_fd:
+            if root_fd is None:
+                return _error("compute_backend_error")
+            try:
+                self._remove_stale_entries(root_fd, preserve_digest=digest)
+            except (OSError, ValueError):
+                return _error("compute_backend_error")
+            target = _root_entry_path(root_fd, digest)
+            if _entry_exists(root_fd, digest):
+                try:
+                    receipt_sha256 = self._verify_environment(target, digest, lock)
+                except ValueError:
+                    return _error("unapproved_lock")
+                if (
+                    digest in self._active
+                    and self._active[digest] != receipt_sha256
+                ):
+                    return _error("unapproved_lock")
+                try:
+                    self._acquire_environment_lease(root_fd, digest)
+                except (OSError, ValueError):
+                    return _error("compute_backend_error")
+                self._active[digest] = receipt_sha256
+                return _success_environment(digest)
+
+            try:
+                self._verify_root_quota(root_fd, lock)
+            except ValueError:
+                return _error("compute_backend_error")
+
+            try:
+                self._acquire_environment_lease(root_fd, digest)
+            except (OSError, ValueError):
+                return _error("compute_backend_error")
+
+            staging: Path | None = None
+            published = False
+            try:
+                staging = Path(tempfile.mkdtemp(
+                    prefix=STAGING_PREFIX,
+                    dir=_root_entry_path(root_fd, ""),
+                ))
+                site_packages = staging / "site-packages"
+                site_packages.mkdir(mode=0o700)
+                for requirement in lock["requirements"]:
+                    coordinate = _coordinate_from_requirement(requirement)
+                    artifact, content = self.snapshot.verified_artifact_content(
+                        coordinate
+                    )
+                    _install_verified_wheel(content, site_packages, artifact)
+                _make_tree_read_only(site_packages)
+                receipt = _expected_environment_receipt(
+                    self.snapshot,
+                    lock,
+                    lock_digest=digest,
+                    snapshot_sha256=self.snapshot.sha256,
+                    policy_sha256=self.policy_sha256,
+                    installer_identity=self.installer_identity,
+                    requirements=lock["requirements"],
+                )
+                receipt_path = staging / "environment.json"
+                receipt_raw = json.dumps(
+                    receipt,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                ).encode("utf-8")
+                if len(receipt_raw) > MAX_RECEIPT_BYTES:
+                    raise ValueError("package environment receipt exceeds limit")
+                _write_regular_exclusive(receipt_path, receipt_raw, mode=0o444)
+                staging.chmod(0o555)
+                receipt_sha256 = self._verify_environment(staging, digest, lock)
+                os.replace(
+                    staging.name,
+                    digest,
+                    src_dir_fd=root_fd,
+                    dst_dir_fd=root_fd,
+                )
+                published = True
+                _best_effort_fsync(root_fd)
+                self._active[digest] = receipt_sha256
+            except (OSError, ValueError, zipfile.BadZipFile):
+                try:
+                    self._release_environment_lease(root_fd, digest)
+                except (OSError, ValueError):
+                    if published:
+                        try:
+                            _remove_entry_at(root_fd, digest)
+                        except (OSError, ValueError):
+                            pass
+                return _error("compute_backend_error")
+            finally:
+                if staging is not None and _entry_exists(root_fd, staging.name):
+                    _remove_entry_at(root_fd, staging.name)
+        return _success_environment(digest)
+
+    def environment_path(self, lock_digest: str) -> Path:
+        if not isinstance(lock_digest, str) or _DIGEST.fullmatch(lock_digest) is None:
+            raise ValueError("package environment digest is invalid")
+        return self.environment_root / lock_digest
+
+    def close(self) -> None:
+        with self._activation_lock:
+            root_fd = self._root_fd
+            if self._closed or root_fd is None:
+                return
+            fcntl.flock(root_fd, fcntl.LOCK_EX)
+            close_error: Exception | None = None
+            try:
+                for digest in tuple(self._leases):
+                    try:
+                        self._release_environment_lease(
+                            root_fd,
+                            digest,
+                            budget={"entries": 0},
+                        )
+                    except (OSError, ValueError) as exc:
+                        if close_error is None:
+                            close_error = exc
+                try:
+                    self._remove_stale_entries(root_fd)
+                except (OSError, ValueError) as exc:
+                    if close_error is None:
+                        close_error = exc
+            finally:
+                for lease_fd in self._leases.values():
+                    try:
+                        fcntl.flock(lease_fd, fcntl.LOCK_UN)
+                    finally:
+                        os.close(lease_fd)
+                self._leases.clear()
+                self._active.clear()
+                self._closed = True
+                self._root_fd = None
+                fcntl.flock(root_fd, fcntl.LOCK_UN)
+                os.close(root_fd)
+            if close_error is not None:
+                raise ValueError("package environment cleanup failed") from close_error
+
+    def _validated_lock(self, digest: str) -> dict[str, Any]:
+        artifacts = tuple(self.snapshot.artifacts.values())
+        for count in range(1, len(artifacts) + 1):
+            for selected in itertools.combinations(artifacts, count):
+                lock = _package_lock(selected)
+                if canonical_sha256(lock) == digest:
+                    return lock
+        raise ValueError("package lock is not in the approved snapshot")
+
+    def _verify_environment(
+        self,
+        target: Path,
+        digest: str,
+        lock: Mapping[str, Any],
+    ) -> str:
+        try:
+            target_metadata = target.lstat()
+        except OSError as exc:
+            raise ValueError("package environment is unavailable") from exc
+        if (
+            target.is_symlink()
+            or not stat.S_ISDIR(target_metadata.st_mode)
+            or stat.S_IMODE(target_metadata.st_mode) != 0o555
+            or target_metadata.st_uid != os.getuid()
+        ):
+            raise ValueError("package environment is unsafe")
+        try:
+            target_fd = os.open(
+                target,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_CLOEXEC", 0),
+            )
+            try:
+                opened = os.fstat(target_fd)
+                children = set()
+                for entry in os.scandir(target_fd):
+                    children.add(entry.name)
+                    if len(children) > 2:
+                        raise ValueError(
+                            "package environment has unexpected entries"
+                        )
+                if (
+                    opened.st_dev != target_metadata.st_dev
+                    or opened.st_ino != target_metadata.st_ino
+                    or children != {"environment.json", "site-packages"}
+                ):
+                    raise ValueError("package environment identity is unsafe")
+                receipt_raw = _read_regular_at(
+                    "environment.json",
+                    dir_fd=target_fd,
+                    label="package environment receipt",
+                    max_bytes=MAX_RECEIPT_BYTES,
+                    required_mode=0o444,
+                    required_uid=os.getuid(),
+                )
+                site_packages_fd = _open_directory_at(
+                    target_fd,
+                    "site-packages",
+                    label="package environment site-packages",
+                    required_mode=0o555,
+                )
+                try:
+                    actual = _environment_receipt_from_fd(
+                        site_packages_fd,
+                        lock_digest=digest,
+                        snapshot_sha256=self.snapshot.sha256,
+                        policy_sha256=self.policy_sha256,
+                        installer_identity=self.installer_identity,
+                        requirements=lock["requirements"],
+                    )
+                finally:
+                    os.close(site_packages_fd)
+            finally:
+                os.close(target_fd)
+        except OSError as exc:
+            raise ValueError("package environment identity changed") from exc
+        expected = _expected_environment_receipt(
+            self.snapshot,
+            lock,
+            lock_digest=digest,
+            snapshot_sha256=self.snapshot.sha256,
+            policy_sha256=self.policy_sha256,
+            installer_identity=self.installer_identity,
+            requirements=lock["requirements"],
+        )
+        expected_raw = _canonical_json_bytes(expected)
+        if receipt_raw != expected_raw or actual != expected:
+            raise ValueError("package environment receipt drifted")
+        return hashlib.sha256(receipt_raw).hexdigest()
+
+    def _verify_root_quota(
+        self,
+        root_fd: int,
+        prospective_lock: Mapping[str, Any],
+    ) -> None:
+        environments, active_bytes = self._global_root_state(root_fd)
+        prospective_bytes = _lock_unpacked_bytes(
+            self.snapshot, prospective_lock
+        )
+        if (
+            len(environments) + 1 > MAX_ACTIVE_ENVIRONMENTS
+            or active_bytes + prospective_bytes
+            > MAX_ACTIVE_ENVIRONMENT_BYTES
+        ):
+            raise ValueError("package environment root quota exceeded")
+
+    def _global_root_state(
+        self,
+        root_fd: int,
+    ) -> tuple[list[tuple[str, str]], int]:
+        environment_digests: set[str] = set()
+        lease_digests: set[str] = set()
+        seen = 0
+        for entry in os.scandir(root_fd):
+            seen += 1
+            if seen > MAX_ACTIVE_ENVIRONMENTS * 2:
+                raise ValueError("package environment root entry limit exceeded")
+            if _DIGEST.fullmatch(entry.name) is not None:
+                environment_digests.add(entry.name)
+                continue
+            if entry.name.startswith(LEASE_PREFIX):
+                digest = entry.name.removeprefix(LEASE_PREFIX)
+                if _DIGEST.fullmatch(digest) is not None:
+                    lease_digests.add(digest)
+                    continue
+            raise ValueError("package environment root entry is unaccounted")
+        if (
+            environment_digests != lease_digests
+            or len(environment_digests) > MAX_ACTIVE_ENVIRONMENTS
+            or set(self._active) != set(self._leases)
+            or not set(self._active).issubset(environment_digests)
+        ):
+            raise ValueError("package environment root inventory is invalid")
+
+        environments: list[tuple[str, str]] = []
+        payload_bytes = 0
+        for digest in sorted(environment_digests):
+            _validate_live_lease(
+                root_fd,
+                digest,
+                held_fd=self._leases.get(digest),
+            )
+            lock = self._validated_lock(digest)
+            receipt_sha256 = self._verify_environment(
+                _root_entry_path(root_fd, digest),
+                digest,
+                lock,
+            )
+            if (
+                digest in self._active
+                and receipt_sha256 != self._active[digest]
+            ):
+                raise ValueError(
+                    "package environment receipt baseline drifted"
+                )
+            environments.append((digest, receipt_sha256))
+            payload_bytes += _lock_unpacked_bytes(self.snapshot, lock)
+        if payload_bytes > MAX_ACTIVE_ENVIRONMENT_BYTES:
+            raise ValueError("package environment root byte limit exceeded")
+        return environments, payload_bytes
+
+    @contextmanager
+    def _exclusive_root(self):
+        with self._activation_lock:
+            root_fd = self._root_fd
+            if self._closed or root_fd is None:
+                yield None
+                return
+            fcntl.flock(root_fd, fcntl.LOCK_EX)
+            try:
+                try:
+                    self._verify_root_identity(root_fd)
+                except ValueError:
+                    yield None
+                else:
+                    yield root_fd
+            finally:
+                fcntl.flock(root_fd, fcntl.LOCK_UN)
+
+    def _verify_root_identity(self, root_fd: int) -> None:
+        try:
+            path_metadata = self.environment_root.lstat()
+            opened_metadata = os.fstat(root_fd)
+        except OSError as exc:
+            raise ValueError("package environment root is unavailable") from exc
+        if (
+            self.environment_root.is_symlink()
+            or not stat.S_ISDIR(path_metadata.st_mode)
+            or path_metadata.st_dev != opened_metadata.st_dev
+            or path_metadata.st_ino != opened_metadata.st_ino
+            or path_metadata.st_uid != os.getuid()
+            or stat.S_IMODE(path_metadata.st_mode) != 0o700
+        ):
+            raise ValueError("package environment root identity changed")
+
+    def _acquire_environment_lease(self, root_fd: int, digest: str) -> None:
+        if digest in self._leases:
+            _validate_held_lease(
+                root_fd,
+                digest,
+                self._leases[digest],
+            )
+            return
+        lease_fd = os.open(
+            _lease_name(digest),
+            os.O_RDWR
+            | os.O_CREAT
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+            dir_fd=root_fd,
+        )
+        try:
+            _validate_held_lease(root_fd, digest, lease_fd)
+        except Exception:
+            os.close(lease_fd)
+            raise
+        self._leases[digest] = lease_fd
+
+    def _release_environment_lease(
+        self,
+        root_fd: int,
+        digest: str,
+        *,
+        budget: dict[str, int] | None = None,
+    ) -> None:
+        lease_fd = self._leases.pop(digest, None)
+        if lease_fd is not None:
+            fcntl.flock(lease_fd, fcntl.LOCK_UN)
+            os.close(lease_fd)
+        _cleanup_unleased_environment(root_fd, digest, budget=budget)
+
+    def _remove_stale_entries(
+        self,
+        root_fd: int,
+        *,
+        preserve_digest: str | None = None,
+    ) -> None:
+        cleanup_budget = {"entries": 0}
+        for entry in os.scandir(root_fd):
+            _consume_cleanup_budget(cleanup_budget)
+            if entry.name.startswith(LEASE_PREFIX):
+                digest = entry.name.removeprefix(LEASE_PREFIX)
+                if _DIGEST.fullmatch(digest) is None:
+                    _remove_entry_at(
+                        root_fd,
+                        entry.name,
+                        budget=cleanup_budget,
+                    )
+                elif not _entry_exists(root_fd, digest):
+                    if digest in self._leases:
+                        self._release_environment_lease(
+                            root_fd,
+                            digest,
+                            budget=cleanup_budget,
+                        )
+                    else:
+                        _cleanup_unleased_environment(
+                            root_fd,
+                            digest,
+                            budget=cleanup_budget,
+                        )
+                elif digest in self._leases:
+                    _validate_held_lease(
+                        root_fd,
+                        digest,
+                        self._leases[digest],
+                    )
+                elif digest != preserve_digest and digest not in self._leases:
+                    _cleanup_unleased_environment(
+                        root_fd,
+                        digest,
+                        budget=cleanup_budget,
+                    )
+            elif entry.name.startswith(".agentic-v2-"):
+                _remove_entry_at(
+                    root_fd,
+                    entry.name,
+                    budget=cleanup_budget,
+                )
+            elif _DIGEST.fullmatch(entry.name) is not None:
+                if entry.name == preserve_digest:
+                    continue
+                lease_name = _lease_name(entry.name)
+                if not _entry_exists(root_fd, lease_name):
+                    _remove_entry_at(
+                        root_fd,
+                        entry.name,
+                        budget=cleanup_budget,
+                    )
+                elif entry.name not in self._leases:
+                    _cleanup_unleased_environment(
+                        root_fd,
+                        entry.name,
+                        budget=cleanup_budget,
+                    )
+            else:
+                raise ValueError("package environment root entry is unaccounted")
+
+
+class AgenticV2PackageBrokerCandidateBackend:
+    """Tool-dispatch candidate with package activation and no execution plane."""
+
+    def __init__(
+        self,
+        *,
+        root: str | Path,
+        profile: AgenticV2Profile,
+        snapshot: PackageSnapshot,
+        budget_caps: Mapping[str, Any] | None = None,
+        **_: Any,
+    ):
+        if (
+            profile.policy_profile_id != "package-broker-v1"
+            or profile.foundation_only is not True
+        ):
+            raise ValueError("package broker candidate requires package-broker-v1")
+        candidate_root = Path(root)
+        if candidate_root.is_symlink():
+            raise ValueError("package broker candidate root symlink is forbidden")
+        candidate_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.root = candidate_root.resolve()
+        self.profile = profile
+        self.snapshot = snapshot
+        self.budget_caps = dict(
+            budget_caps or {"tool_calls": 32, "wall_seconds": 1200}
+        )
+        self.broker = OfflinePythonWheelBroker(
+            snapshot=snapshot,
+            environment_root=self.root / "environments",
+        )
+        self._closed = False
+
+    def start(self, timeout_seconds: float) -> Mapping[str, Any]:
+        del timeout_seconds
+        capabilities = self.expected_capabilities()
+        implementation_sha256 = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+        return {
+            "ok": True,
+            "data": {
+                "substrate_manifest": {
+                    "schema_version": "1.0-candidate",
+                    "sha256": canonical_sha256({
+                        "broker_id": PACKAGE_BROKER_ID,
+                        "exec_run": "blocked_pending_containment",
+                        "policy_sha256": self.broker.policy_sha256,
+                        "snapshot_sha256": self.snapshot.sha256,
+                    }),
+                },
+                "backend_identity": {
+                    "backend_id": PACKAGE_BROKER_ID,
+                    "foundation_only": True,
+                    "implementation_sha256": implementation_sha256,
+                },
+                "package_snapshot_sha256": self.snapshot.sha256,
+                "package_policy_sha256": self.broker.policy_sha256,
+                "browser_build_sha256": canonical_sha256({
+                    "browser": "disabled"
+                }),
+                "capabilities": capabilities,
+            },
+        }
+
+    def expected_capabilities(self) -> Mapping[str, Any]:
+        return {
+            "commands": [],
+            "runtimes": [],
+            "packages": sorted(self.snapshot.artifacts),
+            "formats": [],
+            "budgets": [
+                f"tool_calls={self.budget_caps['tool_calls']}",
+                f"wall_seconds={self.budget_caps['wall_seconds']}",
+            ],
+        }
+
+    def state_sha256(self) -> str:
+        return self.broker.state_sha256()
+
+    def capabilities_query(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        kind = str(arguments["kind"])
+        return {
+            "ok": True,
+            "data": {"kind": kind, "items": self.expected_capabilities()[kind]},
+        }
+
+    def workspace_apply(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        del arguments
+        return _error("capability_unavailable")
+
+    def exec_run(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        del arguments
+        return _error("capability_unavailable")
+
+    def environment_resolve(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self.broker.resolve(arguments)
+
+    def environment_activate(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self.broker.activate(arguments)
+
+    def browser_run(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        del arguments
+        return _error("capability_unavailable")
+
+    def verify_public(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        del arguments
+        return _error("capability_unavailable")
+
+    def finalize(self, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        del arguments
+        return _error("capability_unavailable")
+
+    def best_result(self) -> Mapping[str, Any] | None:
+        return None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self.broker.close()
+        self._closed = True
+
+
+def _validate_snapshot(
+    value: Any,
+    artifact_root: Path,
+) -> tuple[dict[str, Any], dict[str, PackageArtifact]]:
+    if not isinstance(value, dict) or set(value) != {
+        "schema_version",
+        "policy_id",
+        "foundation_only",
+        "production_activation",
+        "platform",
+        "artifacts",
+    }:
+        raise ValueError("package snapshot fields are invalid")
+    if (
+        value.get("schema_version") != PACKAGE_SNAPSHOT_SCHEMA_VERSION
+        or value.get("policy_id") != PACKAGE_POLICY_ID
+        or value.get("foundation_only") is not True
+        or value.get("production_activation") != "disabled"
+        or value.get("platform") != {
+            "os": "linux",
+            "architecture": "amd64",
+            "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+        }
+        or sys.platform != "linux"
+        or platform.machine().lower() not in {"x86_64", "amd64"}
+        or not isinstance(value.get("artifacts"), list)
+        or not value["artifacts"]
+        or len(value["artifacts"]) > MAX_REQUESTED_PACKAGES
+    ):
+        raise ValueError("package snapshot policy is invalid")
+    document = json.loads(json.dumps(value, allow_nan=False))
+    records: dict[str, PackageArtifact] = {}
+    package_names: set[str] = set()
+    filenames: set[str] = set()
+    digests: set[str] = set()
+    installed_files: set[str] = set()
+    installed_directories: set[str] = set()
+    total_artifact_bytes = 0
+    total_unpacked_bytes = 0
+    total_entries = 0
+    for item in document["artifacts"]:
+        if not isinstance(item, dict) or set(item) != {
+            "coordinate",
+            "filename",
+            "sha256",
+            "size",
+            "dependencies",
+        }:
+            raise ValueError("package artifact fields are invalid")
+        coordinate = item.get("coordinate")
+        filename = item.get("filename")
+        digest = item.get("sha256")
+        size = item.get("size")
+        if (
+            not isinstance(coordinate, str)
+            or not coordinate.startswith("python:")
+            or not isinstance(filename, str)
+            or filename != Path(filename).name
+            or "/" in filename
+            or "\\" in filename
+            or not filename.endswith(".whl")
+            or not isinstance(digest, str)
+            or _DIGEST.fullmatch(digest) is None
+            or type(size) is not int
+            or not 0 < size <= MAX_ARTIFACT_BYTES
+            or item.get("dependencies") != []
+            or coordinate in records
+            or filename in filenames
+            or digest in digests
+        ):
+            raise ValueError("package artifact policy is invalid")
+        requirement = coordinate.removeprefix("python:")
+        name, version = _split_exact_requirement(requirement)
+        if name in package_names:
+            raise ValueError("package snapshot contains conflicting versions")
+        wheel_name, wheel_version, wheel_build, wheel_tags = parse_wheel_filename(
+            filename
+        )
+        if (
+            canonicalize_name(str(wheel_name)) != name
+            or str(wheel_version) != version
+            or wheel_build != ()
+            or {str(tag) for tag in wheel_tags} != {"py3-none-any"}
+        ):
+            raise ValueError("package wheel identity is invalid")
+        provisional = PackageArtifact(
+            coordinate=coordinate,
+            filename=filename,
+            sha256=digest,
+            size=size,
+            unpacked_size=0,
+            entry_count=0,
+            files=frozenset(),
+            directories=frozenset(),
+        )
+        inspection = _verify_artifact(artifact_root, provisional)
+        if (
+            installed_files.intersection(inspection.files)
+            or installed_files.intersection(inspection.directories)
+            or installed_directories.intersection(inspection.files)
+        ):
+            raise ValueError("package wheel file collision is forbidden")
+        artifact = PackageArtifact(
+            coordinate=coordinate,
+            filename=filename,
+            sha256=digest,
+            size=size,
+            unpacked_size=inspection.unpacked_size,
+            entry_count=inspection.entry_count,
+            files=inspection.files,
+            directories=inspection.directories,
+        )
+        records[coordinate] = artifact
+        package_names.add(name)
+        filenames.add(filename)
+        digests.add(digest)
+        installed_files.update(inspection.files)
+        installed_directories.update(inspection.directories)
+        total_artifact_bytes += size
+        total_unpacked_bytes += (
+            inspection.unpacked_size + INSTALLER_OVERHEAD_BYTES_PER_WHEEL
+        )
+        total_entries += (
+            inspection.entry_count + INSTALLER_OVERHEAD_ENTRIES_PER_WHEEL
+        )
+        if (
+            total_artifact_bytes > MAX_SNAPSHOT_ARTIFACT_BYTES
+            or total_unpacked_bytes > MAX_ENVIRONMENT_BYTES
+            or total_entries > MAX_ENVIRONMENT_ENTRIES
+        ):
+            raise ValueError("package snapshot aggregate limits exceeded")
+    if document["artifacts"] != sorted(
+        document["artifacts"], key=lambda item: item["coordinate"]
+    ):
+        raise ValueError("package artifacts must be canonically ordered")
+    return document, records
+
+
+def _coordinate_from_requirement(requirement: str) -> str:
+    name, version = _split_exact_requirement(requirement)
+    return f"python:{name}=={version}"
+
+
+def _package_lock(artifacts: Iterable[PackageArtifact]) -> dict[str, Any]:
+    ordered = sorted(
+        artifacts,
+        key=lambda artifact: artifact.coordinate,
+    )
+    requirements = [
+        artifact.coordinate.removeprefix("python:") for artifact in ordered
+    ]
+    names = [_split_exact_requirement(requirement)[0] for requirement in requirements]
+    if len(names) != len(set(names)):
+        raise ValueError("package lock contains conflicting versions")
+    return {
+        "ecosystem": "python",
+        "requirements": requirements,
+        "blobs": [artifact.sha256 for artifact in ordered],
+    }
+
+
+def _lock_unpacked_bytes(
+    snapshot: PackageSnapshot,
+    lock: Mapping[str, Any],
+) -> int:
+    return sum(
+        snapshot.artifacts[_coordinate_from_requirement(requirement)].unpacked_size
+        for requirement in lock["requirements"]
+    )
+
+
+def _split_exact_requirement(requirement: str) -> tuple[str, str]:
+    match = _EXACT_REQUIREMENT.fullmatch(requirement)
+    if match is None:
+        raise ValueError("package requirement must be exact name==version")
+    name, version = match.groups()
+    if canonicalize_name(name) != name:
+        raise ValueError("package requirement name must be canonical")
+    return name, version
+
+
+def _verify_artifact(root: Path, artifact: PackageArtifact) -> WheelInspection:
+    _, inspection = _verified_artifact_content(root, artifact)
+    return inspection
+
+
+def _verified_artifact_content(
+    root: Path,
+    artifact: PackageArtifact,
+) -> tuple[bytes, WheelInspection]:
+    root_fd = os.open(
+        root,
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0),
+    )
+    try:
+        descriptor = os.open(
+            artifact.filename,
+            os.O_RDONLY
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=root_fd,
+        )
+        try:
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or metadata.st_size != artifact.size
+                or metadata.st_size > MAX_ARTIFACT_BYTES
+            ):
+                raise ValueError("package artifact size or type drifted")
+            chunks = []
+            remaining = artifact.size
+            while remaining:
+                chunk = os.read(descriptor, min(1024 * 1024, remaining))
+                if not chunk:
+                    raise ValueError("package artifact was truncated")
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            if os.read(descriptor, 1):
+                raise ValueError("package artifact grew during verification")
+            final_metadata = os.fstat(descriptor)
+            if (
+                final_metadata.st_dev != metadata.st_dev
+                or final_metadata.st_ino != metadata.st_ino
+                or final_metadata.st_size != metadata.st_size
+                or final_metadata.st_mtime_ns != metadata.st_mtime_ns
+                or final_metadata.st_ctime_ns != metadata.st_ctime_ns
+            ):
+                raise ValueError("package artifact changed during verification")
+        finally:
+            os.close(descriptor)
+    except OSError as exc:
+        raise ValueError("package artifact is unavailable or unsafe") from exc
+    finally:
+        os.close(root_fd)
+    content = b"".join(chunks)
+    if hashlib.sha256(content).hexdigest() != artifact.sha256:
+        raise ValueError("package artifact digest drifted")
+    return content, _validate_wheel_archive(content, artifact)
+
+
+def _validate_wheel_archive(
+    content: bytes,
+    artifact: PackageArtifact,
+) -> WheelInspection:
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(content))
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise ValueError("package wheel archive is invalid") from exc
+    with archive:
+        infos = archive.infolist()
+        names = [info.filename for info in infos]
+        unpacked_size = sum(info.file_size for info in infos)
+        if (
+            not infos
+            or len(infos) > MAX_WHEEL_ENTRIES
+            or len(names) != len(set(names))
+            or unpacked_size + INSTALLER_OVERHEAD_BYTES_PER_WHEEL
+            > MAX_ENVIRONMENT_BYTES
+        ):
+            raise ValueError("package wheel archive limits are invalid")
+        expanded_entries: set[str] = set()
+        directory_entries: set[str] = set()
+        file_entries: set[str] = set()
+        for info in infos:
+            path = info.filename
+            normalized = path[:-1] if path.endswith("/") else path
+            parts = normalized.split("/")
+            lowered_parts = [part.casefold() for part in parts]
+            mode = info.external_attr >> 16
+            file_type = stat.S_IFMT(mode)
+            try:
+                path_bytes = path.encode("ascii")
+            except UnicodeEncodeError:
+                path_bytes = b""
+            if (
+                not normalized
+                or not path_bytes
+                or len(path_bytes) > MAX_WHEEL_PATH_BYTES
+                or any(value < 0x20 or value == 0x7F for value in path_bytes)
+                or path.startswith("/")
+                or "\\" in path
+                or any(part in {"", ".", ".."} for part in parts)
+                or info.flag_bits & 0x1
+                or (not info.is_dir() and mode & 0o111)
+                or lowered_parts[0].endswith(".data")
+                or any(
+                    part.split(".", 1)[0]
+                    in {"sitecustomize", "usercustomize"}
+                    for part in lowered_parts
+                )
+                or any(
+                    part.endswith((".pyc", ".pth", ".egg-link"))
+                    for part in lowered_parts
+                )
+                or (
+                    file_type
+                    and file_type not in {stat.S_IFREG, stat.S_IFDIR}
+                )
+            ):
+                raise ValueError("package wheel archive entry is unsafe")
+            for depth in range(1, len(parts)):
+                directory_entries.add("/".join(parts[:depth]))
+            if info.is_dir():
+                directory_entries.add(normalized)
+            else:
+                file_entries.add(normalized)
+            expanded_entries.update(directory_entries)
+            expanded_entries.update(file_entries)
+        if file_entries.intersection(directory_entries):
+            raise ValueError("package wheel path kind collision is forbidden")
+        if (
+            len(expanded_entries) + INSTALLER_OVERHEAD_ENTRIES_PER_WHEEL
+            > MAX_ENVIRONMENT_ENTRIES
+        ):
+            raise ValueError("package wheel archive limits are invalid")
+        metadata_names = [name for name in names if name.endswith(".dist-info/METADATA")]
+        wheel_names = [name for name in names if name.endswith(".dist-info/WHEEL")]
+        record_names = [name for name in names if name.endswith(".dist-info/RECORD")]
+        expected_dist_info = (
+            artifact.filename[:-4].rsplit("-", 3)[0] + ".dist-info"
+        )
+        if (
+            metadata_names != [f"{expected_dist_info}/METADATA"]
+            or wheel_names != [f"{expected_dist_info}/WHEEL"]
+            or record_names != [f"{expected_dist_info}/RECORD"]
+        ):
+            raise ValueError("package wheel metadata set is invalid")
+        metadata = BytesParser().parsebytes(_read_wheel_member(
+            archive,
+            metadata_names[0],
+            max_bytes=MAX_WHEEL_METADATA_BYTES,
+            label="METADATA",
+        ))
+        requirement = artifact.coordinate.removeprefix("python:")
+        expected_name, expected_version = _split_exact_requirement(requirement)
+        requires_python = metadata.get_all("Requires-Python", [])
+        try:
+            python_compatible = (
+                not requires_python
+                or (
+                    len(requires_python) == 1
+                    and Version(platform.python_version())
+                    in SpecifierSet(requires_python[0])
+                )
+            )
+        except InvalidSpecifier as exc:
+            raise ValueError("package wheel Python requirement is invalid") from exc
+        if (
+            len(metadata.get_all("Name", [])) != 1
+            or len(metadata.get_all("Version", [])) != 1
+            or canonicalize_name(str(metadata.get("Name", ""))) != expected_name
+            or str(metadata.get("Version", "")) != expected_version
+            or metadata.get_all("Requires-Dist")
+            or not python_compatible
+        ):
+            raise ValueError("package wheel metadata identity is invalid")
+        _validate_wheel_headers(_read_wheel_member(
+            archive,
+            wheel_names[0],
+            max_bytes=MAX_WHEEL_CONTROL_BYTES,
+            label="WHEEL",
+        ))
+        _validate_wheel_record(archive, record_names[0])
+        files = frozenset(file_entries)
+        return WheelInspection(
+            unpacked_size=unpacked_size,
+            entry_count=len(expanded_entries),
+            files=files,
+            directories=frozenset(directory_entries),
+        )
+
+
+def _install_verified_wheel(
+    content: bytes,
+    site_packages: Path,
+    artifact: PackageArtifact,
+) -> None:
+    inspection = _validate_wheel_archive(content, artifact)
+    if inspection != WheelInspection(
+        unpacked_size=artifact.unpacked_size,
+        entry_count=artifact.entry_count,
+        files=artifact.files,
+        directories=artifact.directories,
+    ):
+        raise ValueError("package wheel inventory drifted")
+    with zipfile.ZipFile(io.BytesIO(content)) as archive:
+        for directory in sorted(
+            inspection.directories,
+            key=lambda value: (value.count("/"), value),
+        ):
+            (site_packages / directory).mkdir(mode=0o755, exist_ok=True)
+        for name in sorted(inspection.files):
+            _write_regular_exclusive(
+                site_packages / name,
+                archive.read(name),
+                mode=0o644,
+            )
+
+
+def _validate_wheel_record(archive: zipfile.ZipFile, record_name: str) -> None:
+    try:
+        rows = list(csv.reader(io.StringIO(
+            _read_wheel_member(
+                archive,
+                record_name,
+                max_bytes=MAX_WHEEL_RECORD_BYTES,
+                label="RECORD",
+            ).decode("utf-8")
+        )))
+    except (UnicodeDecodeError, csv.Error, KeyError) as exc:
+        raise ValueError("package wheel RECORD is invalid") from exc
+    records: dict[str, tuple[str, str]] = {}
+    for row in rows:
+        if len(row) != 3 or row[0] in records:
+            raise ValueError("package wheel RECORD is invalid")
+        records[row[0]] = (row[1], row[2])
+    file_names = {
+        info.filename for info in archive.infolist() if not info.is_dir()
+    }
+    if set(records) != file_names or records.get(record_name) != ("", ""):
+        raise ValueError("package wheel RECORD inventory mismatch")
+    for name in sorted(file_names - {record_name}):
+        encoded_hash, encoded_size = records[name]
+        content = archive.read(name)
+        expected_hash = "sha256=" + base64.urlsafe_b64encode(
+            hashlib.sha256(content).digest()
+        ).decode("ascii").rstrip("=")
+        if encoded_hash != expected_hash or encoded_size != str(len(content)):
+            raise ValueError("package wheel RECORD identity mismatch")
+
+
+def _validate_wheel_headers(content: bytes) -> None:
+    normalized = content.replace(b"\r\n", b"\n")
+    if b"\r" in normalized or any(
+        value < 0x20 and value != 0x0A or value == 0x7F
+        for value in normalized
+    ):
+        raise ValueError("package wheel WHEEL is invalid")
+    try:
+        lines = normalized.decode("ascii").split("\n")
+    except UnicodeDecodeError as exc:
+        raise ValueError("package wheel WHEEL is invalid") from exc
+    if lines and lines[-1] == "":
+        lines.pop()
+    if lines and lines[-1] == "":
+        lines.pop()
+    if not lines or any(not line for line in lines):
+        raise ValueError("package wheel WHEEL is invalid")
+    headers: dict[str, list[str]] = {}
+    allowed = {"Wheel-Version", "Generator", "Root-Is-Purelib", "Tag"}
+    for line in lines:
+        if (
+            not line
+            or line[0].isspace()
+            or ":" not in line
+        ):
+            raise ValueError("package wheel WHEEL is invalid")
+        name, raw_value = line.split(":", 1)
+        value = raw_value.strip()
+        if (
+            name not in allowed
+            or not value
+            or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+        ):
+            raise ValueError("package wheel WHEEL is invalid")
+        headers.setdefault(name, []).append(value)
+    if (
+        headers.get("Wheel-Version") != ["1.0"]
+        or headers.get("Root-Is-Purelib") != ["true"]
+        or headers.get("Tag") != ["py3-none-any"]
+        or len(headers.get("Generator", [])) > 1
+        or any(len(value.encode("ascii")) > 256 for value in headers.get("Generator", []))
+    ):
+        raise ValueError("package wheel compatibility is invalid")
+
+
+def _read_wheel_member(
+    archive: zipfile.ZipFile,
+    name: str,
+    *,
+    max_bytes: int,
+    label: str,
+) -> bytes:
+    try:
+        info = archive.getinfo(name)
+        if info.file_size < 0 or info.file_size > max_bytes:
+            raise ValueError(f"package wheel {label} exceeds its limit")
+        content = archive.read(info)
+    except (KeyError, OSError, zipfile.BadZipFile) as exc:
+        raise ValueError(f"package wheel {label} is invalid") from exc
+    if len(content) != info.file_size or len(content) > max_bytes:
+        raise ValueError(f"package wheel {label} size drifted")
+    return content
+
+
+def _environment_receipt(
+    site_packages: Path,
+    *,
+    lock_digest: str,
+    snapshot_sha256: str,
+    policy_sha256: str,
+    installer_identity: Mapping[str, Any],
+    requirements: list[str],
+) -> dict[str, Any]:
+    root_fd = _open_directory_path(
+        site_packages,
+        label="package environment site-packages",
+        required_mode=0o555,
+    )
+    try:
+        return _environment_receipt_from_fd(
+            root_fd,
+            lock_digest=lock_digest,
+            snapshot_sha256=snapshot_sha256,
+            policy_sha256=policy_sha256,
+            installer_identity=installer_identity,
+            requirements=requirements,
+        )
+    finally:
+        os.close(root_fd)
+
+
+def _environment_receipt_from_fd(
+    root_fd: int,
+    *,
+    lock_digest: str,
+    snapshot_sha256: str,
+    policy_sha256: str,
+    installer_identity: Mapping[str, Any],
+    requirements: list[str],
+) -> dict[str, Any]:
+    entries: list[dict[str, Any]] = []
+    limits = {"entries": 0, "bytes": 0}
+    _walk_environment_directory(root_fd, "", entries, limits)
+    if not entries:
+        raise ValueError("package environment is empty")
+    entries.sort(key=lambda item: item["path"])
+    return _receipt_document(
+        entries,
+        total_bytes=limits["bytes"],
+        lock_digest=lock_digest,
+        snapshot_sha256=snapshot_sha256,
+        policy_sha256=policy_sha256,
+        installer_identity=installer_identity,
+        requirements=requirements,
+    )
+
+
+def _walk_environment_directory(
+    directory_fd: int,
+    prefix: str,
+    entries: list[dict[str, Any]],
+    limits: dict[str, int],
+) -> None:
+    for entry in os.scandir(directory_fd):
+        limits["entries"] += 1
+        if limits["entries"] > MAX_ENVIRONMENT_ENTRIES:
+            raise ValueError("package environment entry limit exceeded")
+        relative = f"{prefix}/{entry.name}" if prefix else entry.name
+        try:
+            encoded = relative.encode("ascii")
+        except UnicodeEncodeError as exc:
+            raise ValueError("package environment path is invalid") from exc
+        if (
+            not encoded
+            or len(encoded) > MAX_WHEEL_PATH_BYTES
+            or any(value < 0x20 or value == 0x7F for value in encoded)
+            or entry.name in {"", ".", ".."}
+            or "/" in entry.name
+            or "\\" in entry.name
+        ):
+            raise ValueError("package environment path is invalid")
+        metadata = entry.stat(follow_symlinks=False)
+        if stat.S_ISDIR(metadata.st_mode):
+            child_fd = _open_directory_at(
+                directory_fd,
+                entry.name,
+                label="package environment directory",
+                required_mode=0o555,
+                expected=metadata,
+            )
+            try:
+                entries.append({
+                    "path": relative,
+                    "kind": "directory",
+                    "mode": 0o555,
+                })
+                _walk_environment_directory(
+                    child_fd,
+                    relative,
+                    entries,
+                    limits,
+                )
+            finally:
+                os.close(child_fd)
+        elif stat.S_ISREG(metadata.st_mode):
+            if metadata.st_size < 0:
+                raise ValueError("package environment file size is invalid")
+            projected = limits["bytes"] + metadata.st_size
+            if projected > MAX_ENVIRONMENT_BYTES:
+                raise ValueError("package environment byte limit exceeded")
+            content = _read_regular_at(
+                entry.name,
+                dir_fd=directory_fd,
+                label="package environment file",
+                max_bytes=MAX_ENVIRONMENT_BYTES - limits["bytes"],
+                required_mode=0o444,
+                required_uid=os.getuid(),
+                expected=metadata,
+            )
+            limits["bytes"] += len(content)
+            entries.append({
+                "path": relative,
+                "kind": "file",
+                "mode": 0o444,
+                "size": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            })
+        else:
+            raise ValueError("package environment entry type is forbidden")
+
+
+def _expected_environment_receipt(
+    snapshot: PackageSnapshot,
+    lock: Mapping[str, Any],
+    *,
+    lock_digest: str,
+    snapshot_sha256: str,
+    policy_sha256: str,
+    installer_identity: Mapping[str, Any],
+    requirements: list[str],
+) -> dict[str, Any]:
+    entries_by_path: dict[str, dict[str, Any]] = {}
+    total_bytes = 0
+    for requirement in lock["requirements"]:
+        artifact, content = snapshot.verified_artifact_content(
+            _coordinate_from_requirement(requirement)
+        )
+        with zipfile.ZipFile(io.BytesIO(content)) as archive:
+            for directory in artifact.directories:
+                entries_by_path[directory] = {
+                    "path": directory,
+                    "kind": "directory",
+                    "mode": 0o555,
+                }
+            for name in artifact.files:
+                file_content = archive.read(name)
+                total_bytes += len(file_content)
+                entries_by_path[name] = {
+                    "path": name,
+                    "kind": "file",
+                    "mode": 0o444,
+                    "size": len(file_content),
+                    "sha256": hashlib.sha256(file_content).hexdigest(),
+                }
+    entries = [entries_by_path[path] for path in sorted(entries_by_path)]
+    return _receipt_document(
+        entries,
+        total_bytes=total_bytes,
+        lock_digest=lock_digest,
+        snapshot_sha256=snapshot_sha256,
+        policy_sha256=policy_sha256,
+        installer_identity=installer_identity,
+        requirements=requirements,
+    )
+
+
+def _receipt_document(
+    entries: list[dict[str, Any]],
+    *,
+    total_bytes: int,
+    lock_digest: str,
+    snapshot_sha256: str,
+    policy_sha256: str,
+    installer_identity: Mapping[str, Any],
+    requirements: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "broker_id": PACKAGE_BROKER_ID,
+        "foundation_only": True,
+        "production_activation": "disabled",
+        "lock_digest": lock_digest,
+        "snapshot_sha256": snapshot_sha256,
+        "policy_sha256": policy_sha256,
+        "installer": dict(installer_identity),
+        "requirements": list(requirements),
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "entries": entries,
+        "entries_sha256": canonical_sha256(entries),
+        "total_bytes": total_bytes,
+    }
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _read_regular_bytes(
+    value: str | Path,
+    *,
+    label: str,
+    max_bytes: int,
+    required_mode: int | None = None,
+) -> bytes:
+    return _read_regular_at(
+        value,
+        dir_fd=None,
+        label=label,
+        max_bytes=max_bytes,
+        required_mode=required_mode,
+    )
+
+
+def _read_regular_at(
+    value: str | Path,
+    *,
+    dir_fd: int | None,
+    label: str,
+    max_bytes: int,
+    required_mode: int | None = None,
+    required_uid: int | None = None,
+    expected: os.stat_result | None = None,
+) -> bytes:
+    try:
+        descriptor = os.open(
+            value,
+            os.O_RDONLY
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=dir_fd,
+        )
+        try:
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or metadata.st_size < 0
+                or metadata.st_size > max_bytes
+                or (
+                    required_mode is not None
+                    and stat.S_IMODE(metadata.st_mode) != required_mode
+                )
+                or (
+                    required_uid is not None
+                    and metadata.st_uid != required_uid
+                )
+                or (
+                    expected is not None
+                    and (
+                        metadata.st_dev != expected.st_dev
+                        or metadata.st_ino != expected.st_ino
+                        or metadata.st_size != expected.st_size
+                        or metadata.st_mtime_ns != expected.st_mtime_ns
+                        or metadata.st_ctime_ns != expected.st_ctime_ns
+                    )
+                )
+            ):
+                raise ValueError(f"{label} must be a bounded single-link file")
+            chunks = []
+            remaining = metadata.st_size
+            while remaining:
+                chunk = os.read(descriptor, min(1024 * 1024, remaining))
+                if not chunk:
+                    raise ValueError(f"{label} was truncated while reading")
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            if os.read(descriptor, 1):
+                raise ValueError(f"{label} grew while reading")
+            final_metadata = os.fstat(descriptor)
+            if (
+                final_metadata.st_dev != metadata.st_dev
+                or final_metadata.st_ino != metadata.st_ino
+                or final_metadata.st_size != metadata.st_size
+                or final_metadata.st_mode != metadata.st_mode
+                or final_metadata.st_nlink != metadata.st_nlink
+                or final_metadata.st_mtime_ns != metadata.st_mtime_ns
+                or final_metadata.st_ctime_ns != metadata.st_ctime_ns
+            ):
+                raise ValueError(f"{label} changed while reading")
+        finally:
+            os.close(descriptor)
+    except OSError as exc:
+        raise ValueError(f"{label} is unavailable") from exc
+    return b"".join(chunks)
+
+
+def _open_directory_path(
+    value: str | Path,
+    *,
+    label: str,
+    required_mode: int | None = None,
+) -> int:
+    path = Path(value)
+    try:
+        expected = path.lstat()
+        if path.is_symlink() or not stat.S_ISDIR(expected.st_mode):
+            raise ValueError(f"{label} must be a directory")
+        descriptor = os.open(
+            path,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+        )
+        metadata = os.fstat(descriptor)
+        if (
+            metadata.st_dev != expected.st_dev
+            or metadata.st_ino != expected.st_ino
+            or metadata.st_uid != os.getuid()
+            or (
+                required_mode is not None
+                and stat.S_IMODE(metadata.st_mode) != required_mode
+            )
+        ):
+            os.close(descriptor)
+            raise ValueError(f"{label} identity is unsafe")
+        return descriptor
+    except OSError as exc:
+        raise ValueError(f"{label} is unavailable") from exc
+
+
+def _open_directory_at(
+    parent_fd: int,
+    name: str,
+    *,
+    label: str,
+    required_mode: int | None = None,
+    expected: os.stat_result | None = None,
+) -> int:
+    try:
+        descriptor = os.open(
+            name,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=parent_fd,
+        )
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or (
+                required_mode is not None
+                and stat.S_IMODE(metadata.st_mode) != required_mode
+            )
+            or (
+                expected is not None
+                and (
+                    metadata.st_dev != expected.st_dev
+                    or metadata.st_ino != expected.st_ino
+                    or metadata.st_mtime_ns != expected.st_mtime_ns
+                    or metadata.st_ctime_ns != expected.st_ctime_ns
+                )
+            )
+        ):
+            os.close(descriptor)
+            raise ValueError(f"{label} identity is unsafe")
+        return descriptor
+    except OSError as exc:
+        raise ValueError(f"{label} is unavailable") from exc
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({
+            key: _freeze_json(item) for key, item in value.items()
+        })
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _write_regular_exclusive(path: Path, content: bytes, *, mode: int) -> None:
+    descriptor = os.open(
+        path,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0),
+        0o600,
+    )
+    try:
+        offset = 0
+        while offset < len(content):
+            offset += os.write(descriptor, content[offset:])
+        os.fchmod(descriptor, mode)
+    finally:
+        os.close(descriptor)
+
+
+def _directory_path(value: str | Path, *, label: str) -> Path:
+    path = Path(value)
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"{label} is unavailable") from exc
+    if path.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError(f"{label} must be a directory")
+    return path.resolve()
+
+
+def _best_effort_fsync(descriptor: int) -> None:
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+
+
+def _deterministic_installer_identity() -> dict[str, str]:
+    return {
+        "installer_id": "agentic-v2-deterministic-wheel-extractor-v1",
+        "implementation_sha256": hashlib.sha256(
+            Path(__file__).read_bytes()
+        ).hexdigest(),
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+    }
+
+
+def _load_package_policy() -> str:
+    policy_path = (
+        Path(__file__).resolve().parents[2]
+        / "security"
+        / "agentic-v2-package-broker-policy.json"
+    )
+    try:
+        document = json.loads(_read_regular_bytes(
+            policy_path,
+            label="package broker policy",
+            max_bytes=MAX_MANIFEST_BYTES,
+        ))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("package broker policy is invalid") from exc
+    if document != _expected_package_policy():
+        raise ValueError("package broker policy does not match implementation")
+    return canonical_sha256(document)
+
+
+def _expected_package_policy() -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "policy_id": PACKAGE_POLICY_ID,
+        "foundation_only": True,
+        "production_activation": "disabled",
+        "network": {
+            "package_index": "disabled",
+            "os_containment": "not_run",
+        },
+        "supported_ecosystems": ["python-wheel"],
+        "exec_run": "blocked_pending_containment",
+        "limits": {
+            "requested_packages": MAX_REQUESTED_PACKAGES,
+            "artifact_bytes": MAX_ARTIFACT_BYTES,
+            "snapshot_artifact_bytes": MAX_SNAPSHOT_ARTIFACT_BYTES,
+            "environment_bytes": MAX_ENVIRONMENT_BYTES,
+            "environment_entries": MAX_ENVIRONMENT_ENTRIES,
+            "active_environments": MAX_ACTIVE_ENVIRONMENTS,
+            "active_environment_payload_bytes": MAX_ACTIVE_ENVIRONMENT_BYTES,
+            "wheel_path_bytes": MAX_WHEEL_PATH_BYTES,
+            "wheel_metadata_bytes": MAX_WHEEL_METADATA_BYTES,
+            "wheel_control_bytes": MAX_WHEEL_CONTROL_BYTES,
+            "wheel_record_bytes": MAX_WHEEL_RECORD_BYTES,
+            "cleanup_entries": MAX_CLEANUP_ENTRIES,
+            "cleanup_depth": MAX_CLEANUP_DEPTH,
+        },
+        "activation": {
+            "concurrency": "linux-flock",
+            "seal": "read-only-modes-with-drift-verification",
+            "crash_durability": "not_claimed",
+        },
+        "admission_evidence": {
+            "sbom": "not_run",
+            "license": "not_run",
+            "cve": "not_run",
+            "provenance": "not_run",
+            "signature": "not_run",
+        },
+        "python": {
+            "requirements": "exact-name-version-only",
+            "wheel_tags": ["py3-none-any"],
+            "dependencies": "preclosed-none-only",
+            "installer": "deterministic-stdlib-wheel-extractor-v1",
+        },
+        "denied": [
+            "live-index",
+            "url-requirement",
+            "vcs-requirement",
+            "sdist",
+            "editable",
+            "npm",
+            "debian-apt",
+            "shell-exec",
+            "model-loop",
+            "workflow",
+            "publication",
+        ],
+    }
+
+
+def _make_tree_read_only(root: Path) -> None:
+    for path in sorted(root.rglob("*"), key=lambda item: len(item.parts), reverse=True):
+        if path.is_symlink():
+            raise ValueError("package environment symlink is forbidden")
+        path.chmod(0o555 if path.is_dir() else 0o444)
+    root.chmod(0o555)
+
+
+def _lease_name(digest: str) -> str:
+    if _DIGEST.fullmatch(digest) is None:
+        raise ValueError("package environment lease digest is invalid")
+    return f"{LEASE_PREFIX}{digest}"
+
+
+def _validate_held_lease(root_fd: int, digest: str, lease_fd: int) -> None:
+    lease_name = _lease_name(digest)
+    try:
+        path_metadata = os.stat(
+            lease_name,
+            dir_fd=root_fd,
+            follow_symlinks=False,
+        )
+        opened_metadata = os.fstat(lease_fd)
+    except OSError as exc:
+        raise ValueError("package environment lease is unavailable") from exc
+    if (
+        not stat.S_ISREG(path_metadata.st_mode)
+        or path_metadata.st_dev != opened_metadata.st_dev
+        or path_metadata.st_ino != opened_metadata.st_ino
+        or opened_metadata.st_nlink != 1
+        or opened_metadata.st_uid != os.getuid()
+        or stat.S_IMODE(opened_metadata.st_mode) != 0o600
+        or opened_metadata.st_size != 0
+    ):
+        raise ValueError("package environment lease is unsafe")
+    fcntl.flock(lease_fd, fcntl.LOCK_SH | fcntl.LOCK_NB)
+
+
+def _validate_live_lease(
+    root_fd: int,
+    digest: str,
+    *,
+    held_fd: int | None,
+) -> None:
+    if held_fd is not None:
+        _validate_held_lease(root_fd, digest, held_fd)
+    lease_fd = os.open(
+        _lease_name(digest),
+        os.O_RDWR
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0),
+        dir_fd=root_fd,
+    )
+    try:
+        _validate_held_lease(root_fd, digest, lease_fd)
+        if held_fd is None:
+            fcntl.flock(lease_fd, fcntl.LOCK_UN)
+        try:
+            fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return
+        fcntl.flock(lease_fd, fcntl.LOCK_UN)
+        raise ValueError("package environment lease is not held")
+    finally:
+        os.close(lease_fd)
+
+
+def _root_entry_path(root_fd: int, name: str) -> Path:
+    if name and (
+        name in {".", ".."}
+        or "/" in name
+        or "\\" in name
+    ):
+        raise ValueError("package root entry name is invalid")
+    return Path("/proc/self/fd") / str(root_fd) / name
+
+
+def _cleanup_unleased_environment(
+    root_fd: int,
+    digest: str,
+    *,
+    budget: dict[str, int] | None = None,
+) -> bool:
+    lease_name = _lease_name(digest)
+    try:
+        lease_fd = os.open(
+            lease_name,
+            os.O_RDWR
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=root_fd,
+        )
+    except FileNotFoundError:
+        _remove_entry_at(root_fd, digest, budget=budget)
+        return True
+    try:
+        metadata = os.fstat(lease_fd)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_uid != os.getuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+            or metadata.st_size != 0
+        ):
+            raise ValueError("package environment lease is unsafe")
+        try:
+            fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return False
+        _remove_entry_at(root_fd, digest, budget=budget)
+        _remove_entry_at(root_fd, lease_name, budget=budget)
+        return True
+    finally:
+        try:
+            fcntl.flock(lease_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(lease_fd)
+
+
+def _remove_entry_at(
+    parent_fd: int,
+    name: str,
+    *,
+    budget: dict[str, int] | None = None,
+) -> None:
+    cleanup_budget = budget if budget is not None else {"entries": 0}
+    _consume_cleanup_budget(cleanup_budget)
+    try:
+        metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    if not stat.S_ISDIR(metadata.st_mode):
+        os.unlink(name, dir_fd=parent_fd)
+        return
+    descriptor = _open_cleanup_directory(parent_fd, name, metadata)
+    try:
+        root_iterator = os.scandir(descriptor)
+    except Exception:
+        os.close(descriptor)
+        raise
+    stack: list[tuple[int, str, int, Any, int]] = [
+        (parent_fd, name, descriptor, root_iterator, 0)
+    ]
+    try:
+        while stack:
+            entry_parent_fd, entry_name, directory_fd, iterator, depth = stack[-1]
+            try:
+                entry = next(iterator)
+            except StopIteration:
+                iterator.close()
+                os.close(directory_fd)
+                os.rmdir(entry_name, dir_fd=entry_parent_fd)
+                stack.pop()
+                continue
+            _consume_cleanup_budget(cleanup_budget)
+            child_metadata = entry.stat(follow_symlinks=False)
+            if not stat.S_ISDIR(child_metadata.st_mode):
+                os.unlink(entry.name, dir_fd=directory_fd)
+                continue
+            child_depth = depth + 1
+            if child_depth > MAX_CLEANUP_DEPTH:
+                raise ValueError("package cleanup depth limit exceeded")
+            child_fd = _open_cleanup_directory(
+                directory_fd,
+                entry.name,
+                child_metadata,
+            )
+            try:
+                child_iterator = os.scandir(child_fd)
+            except Exception:
+                os.close(child_fd)
+                raise
+            stack.append((
+                directory_fd,
+                entry.name,
+                child_fd,
+                child_iterator,
+                child_depth,
+            ))
+    finally:
+        for _, _, open_fd, iterator, _ in reversed(stack):
+            iterator.close()
+            try:
+                os.close(open_fd)
+            except OSError:
+                pass
+
+
+def _open_cleanup_directory(
+    parent_fd: int,
+    name: str,
+    expected: os.stat_result,
+) -> int:
+    descriptor = os.open(
+        name,
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0),
+        dir_fd=parent_fd,
+    )
+    metadata = os.fstat(descriptor)
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_dev != expected.st_dev
+        or metadata.st_ino != expected.st_ino
+        or metadata.st_uid != os.getuid()
+    ):
+        os.close(descriptor)
+        raise ValueError("package cleanup directory identity is unsafe")
+    try:
+        os.fchmod(descriptor, 0o700)
+    except Exception:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def _consume_cleanup_budget(budget: dict[str, int]) -> None:
+    budget["entries"] += 1
+    if budget["entries"] > MAX_CLEANUP_ENTRIES:
+        raise ValueError("package cleanup entry limit exceeded")
+
+
+def _entry_exists(parent_fd: int, name: str) -> bool:
+    try:
+        os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _success_environment(digest: str) -> dict[str, Any]:
+    return {"ok": True, "data": {"environment_id": digest}}
+
+
+def _error(error_type: str) -> dict[str, Any]:
+    return {"ok": False, "error_type": error_type}

--- a/batch-runner/schemas/agentic-v2-package-snapshot.schema.json
+++ b/batch-runner/schemas/agentic-v2-package-snapshot.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hyeonsangjeon/gdpval-realworks/schemas/agentic-v2-package-snapshot.schema.json",
+  "title": "Agentic Sandbox V2 Offline Python Package Snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "policy_id",
+    "foundation_only",
+    "production_activation",
+    "platform",
+    "artifacts"
+  ],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "policy_id": {"const": "agentic-v2-package-broker-candidate-v1"},
+    "foundation_only": {"const": true},
+    "production_activation": {"const": "disabled"},
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "architecture", "python"],
+      "properties": {
+        "os": {"const": "linux"},
+        "architecture": {"const": "amd64"},
+        "python": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+$"}
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "coordinate",
+          "filename",
+          "sha256",
+          "size",
+          "dependencies"
+        ],
+        "properties": {
+          "coordinate": {
+            "type": "string",
+            "pattern": "^python:[a-z0-9]+(?:-[a-z0-9]+)*==[A-Za-z0-9](?:[A-Za-z0-9.!+_-]{0,126}[A-Za-z0-9])?$"
+          },
+          "filename": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_.+-]+-py3-none-any\\.whl$"
+          },
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+          "size": {"type": "integer", "minimum": 1, "maximum": 67108864},
+          "dependencies": {"type": "array", "maxItems": 0}
+        }
+      }
+    }
+  }
+}

--- a/batch-runner/security/agentic-v2-package-broker-policy.json
+++ b/batch-runner/security/agentic-v2-package-broker-policy.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "1.0",
+  "policy_id": "agentic-v2-package-broker-candidate-v1",
+  "foundation_only": true,
+  "production_activation": "disabled",
+  "network": {
+    "package_index": "disabled",
+    "os_containment": "not_run"
+  },
+  "supported_ecosystems": ["python-wheel"],
+  "exec_run": "blocked_pending_containment",
+  "limits": {
+    "requested_packages": 8,
+    "artifact_bytes": 67108864,
+    "snapshot_artifact_bytes": 67108864,
+    "environment_bytes": 268435456,
+    "environment_entries": 4096,
+    "active_environments": 8,
+    "active_environment_payload_bytes": 536870912,
+    "wheel_path_bytes": 240,
+    "wheel_metadata_bytes": 1048576,
+    "wheel_control_bytes": 65536,
+    "wheel_record_bytes": 2097152,
+    "cleanup_entries": 4104,
+    "cleanup_depth": 128
+  },
+  "activation": {
+    "concurrency": "linux-flock",
+    "seal": "read-only-modes-with-drift-verification",
+    "crash_durability": "not_claimed"
+  },
+  "admission_evidence": {
+    "sbom": "not_run",
+    "license": "not_run",
+    "cve": "not_run",
+    "provenance": "not_run",
+    "signature": "not_run"
+  },
+  "python": {
+    "requirements": "exact-name-version-only",
+    "wheel_tags": ["py3-none-any"],
+    "dependencies": "preclosed-none-only",
+    "installer": "deterministic-stdlib-wheel-extractor-v1"
+  },
+  "denied": [
+    "live-index",
+    "url-requirement",
+    "vcs-requirement",
+    "sdist",
+    "editable",
+    "npm",
+    "debian-apt",
+    "shell-exec",
+    "model-loop",
+    "workflow",
+    "publication"
+  ]
+}

--- a/batch-runner/tests/test_agentic_v2_package_broker.py
+++ b/batch-runner/tests/test_agentic_v2_package_broker.py
@@ -1,0 +1,1907 @@
+from __future__ import annotations
+
+import base64
+import csv
+import fcntl
+import hashlib
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+import zipfile
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+import sandbox.v2.agentic_v2_package_broker as package_broker_module
+from core.agentic_v2_contract import AgenticV2Lifecycle, AgenticV2Profile, LifecycleState
+from sandbox.v2.agentic_v2_package_broker import (
+    AgenticV2PackageBrokerCandidateBackend,
+    OfflinePythonWheelBroker,
+    PackageSnapshot,
+)
+from core.agentic_v2_tools import AgenticV2ToolDispatcher
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _record_hash(content: bytes) -> str:
+    digest = hashlib.sha256(content).digest()
+    return "sha256=" + base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _write_fixture_wheel(
+    root: Path,
+    *,
+    distribution: str = "demo-pkg",
+    version: str = "1.0.0",
+    module_name: str | None = None,
+    requires_dist: str | None = None,
+    requires_python: str | None = None,
+    corrupt_record: bool = False,
+    dist_info: str | None = None,
+    extra_files: dict[str, bytes] | None = None,
+) -> Path:
+    wheel_distribution = distribution.replace("-", "_")
+    module_name = module_name or wheel_distribution
+    dist_info = dist_info or f"{wheel_distribution}-{version}.dist-info"
+    wheel = root / f"{wheel_distribution}-{version}-py3-none-any.whl"
+    files = {
+        f"{module_name}/__init__.py": (
+            b'def message():\n    return "offline-package-ok"\n'
+        ),
+        f"{dist_info}/METADATA": (
+            b"Metadata-Version: 2.1\n"
+            + f"Name: {distribution}\n".encode("utf-8")
+            + f"Version: {version}\n".encode("utf-8")
+            + b"License-Expression: MIT\n"
+            + (
+                f"Requires-Dist: {requires_dist}\n".encode("utf-8")
+                if requires_dist is not None
+                else b""
+            )
+            + (
+                f"Requires-Python: {requires_python}\n".encode("utf-8")
+                if requires_python is not None
+                else b""
+            )
+        ),
+        f"{dist_info}/WHEEL": (
+            b"Wheel-Version: 1.0\n"
+            b"Generator: gdpval-tests\n"
+            b"Root-Is-Purelib: true\n"
+            b"Tag: py3-none-any\n"
+        ),
+    }
+    files.update(extra_files or {})
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\n")
+    for path, content in sorted(files.items()):
+        writer.writerow((
+            path,
+            "sha256=" + "A" * 43 if corrupt_record and path.endswith("METADATA") else _record_hash(content),
+            len(content),
+        ))
+    writer.writerow((f"{dist_info}/RECORD", "", ""))
+    files[f"{dist_info}/RECORD"] = output.getvalue().encode("utf-8")
+    with zipfile.ZipFile(wheel, "w", compression=zipfile.ZIP_STORED) as archive:
+        for path, content in sorted(files.items()):
+            info = zipfile.ZipInfo(path, date_time=(2020, 1, 1, 0, 0, 0))
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, content)
+    return wheel
+
+
+def _write_snapshot(root: Path, wheel: Path) -> Path:
+    path = root / "snapshot.json"
+    path.write_text(
+        json.dumps(
+            _snapshot_document(wheel),
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _snapshot_document(wheel: Path) -> dict:
+    return {
+        "schema_version": "1.0",
+        "policy_id": "agentic-v2-package-broker-candidate-v1",
+        "foundation_only": True,
+        "production_activation": "disabled",
+        "platform": {
+            "os": "linux",
+            "architecture": "amd64",
+            "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+        },
+        "artifacts": [_artifact_document(wheel, "python:demo-pkg==1.0.0")],
+    }
+
+
+def _artifact_document(wheel: Path, coordinate: str) -> dict:
+    return {
+        "coordinate": coordinate,
+        "filename": wheel.name,
+        "sha256": _sha256(wheel),
+        "size": wheel.stat().st_size,
+        "dependencies": [],
+    }
+
+
+def _write_two_package_snapshot(root: Path, artifact_root: Path) -> Path:
+    alpha = _write_fixture_wheel(
+        artifact_root,
+        distribution="alpha-pkg",
+    )
+    beta = _write_fixture_wheel(
+        artifact_root,
+        distribution="beta-pkg",
+    )
+    document = _snapshot_document(alpha)
+    document["artifacts"] = [
+        _artifact_document(alpha, "python:alpha-pkg==1.0.0"),
+        _artifact_document(beta, "python:beta-pkg==1.0.0"),
+    ]
+    path = root / "two-package-snapshot.json"
+    path.write_text(
+        json.dumps(document, sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_local_snapshot_installs_python_wheel_then_imports_it(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    snapshot_path = _write_snapshot(tmp_path, wheel)
+    snapshot = PackageSnapshot.load(snapshot_path, artifact_root=artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=snapshot,
+        environment_root=tmp_path / "environments",
+    )
+    before = broker.state_sha256()
+
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+
+    assert resolved["ok"] is True
+    assert broker.state_sha256() == before
+    lock_digest = resolved["data"]["lock_digest"]
+
+    activated = broker.activate({"lock_digest": lock_digest})
+
+    assert activated == {
+        "ok": True,
+        "data": {"environment_id": lock_digest},
+    }
+    assert broker.state_sha256() != before
+    environment = broker.environment_path(lock_digest)
+    assert {path.name for path in environment.iterdir()} == {
+        "environment.json",
+        "site-packages",
+    }
+    site_packages = environment / "site-packages"
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            (
+                "import sys;"
+                f"sys.path.insert(0,{str(site_packages)!r});"
+                "import demo_pkg;"
+                "print(demo_pkg.message())"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "LANG": "C.UTF-8"},
+    )
+    assert probe.stdout.strip() == "offline-package-ok"
+    assert not list(environment.parent.glob(".agentic-v2-staging-*"))
+
+    repeated = broker.activate({"lock_digest": lock_digest})
+
+    assert repeated == activated
+    broker.close()
+    assert not environment.exists()
+    assert not list(environment.parent.iterdir())
+    assert wheel.exists()
+
+
+def test_resolved_digest_activates_after_broker_restart(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    snapshot = PackageSnapshot.load(
+        _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+    )
+    environment_root = tmp_path / "environments"
+    resolver = OfflinePythonWheelBroker(
+        snapshot=snapshot,
+        environment_root=environment_root,
+    )
+    resolved = resolver.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+
+    restarted = OfflinePythonWheelBroker(
+        snapshot=snapshot,
+        environment_root=environment_root,
+    )
+    activated = restarted.activate({"lock_digest": digest})
+
+    assert activated == {
+        "ok": True,
+        "data": {"environment_id": digest},
+    }
+    restarted.close()
+    resolver.close()
+
+
+@pytest.mark.parametrize(
+    ("ecosystem", "requirements", "error_type"),
+    [
+        ("npm", ["demo-pkg==1.0.0"], "capability_unavailable"),
+        ("debian", ["demo-pkg==1.0.0"], "capability_unavailable"),
+        ("python", ["demo-pkg"], "invalid_arguments"),
+        ("python", ["demo-pkg @ https://example.test/pkg.whl"], "invalid_arguments"),
+        ("python", ["missing-pkg==1.0.0"], "package_not_in_snapshot"),
+    ],
+)
+def test_broker_rejects_live_or_unapproved_package_requests(
+    tmp_path, ecosystem, requirements, error_type
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+
+    result = broker.resolve({
+        "ecosystem": ecosystem,
+        "requirements": requirements,
+    })
+
+    assert result == {"ok": False, "error_type": error_type}
+
+
+def test_activation_revalidates_artifact_bytes(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    wheel.write_bytes(wheel.read_bytes() + b"drift")
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "unapproved_lock"}
+    assert not list((tmp_path / "environments").iterdir())
+
+
+def test_activation_bounds_artifact_read_during_concurrent_growth(
+    tmp_path, monkeypatch
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    original_read = os.read
+    mutated = False
+
+    def read_then_grow(descriptor, size):
+        nonlocal mutated
+        content = original_read(descriptor, size)
+        if content and not mutated:
+            mutated = True
+            wheel.write_bytes(wheel.read_bytes() + b"growth")
+        return content
+
+    monkeypatch.setattr(os, "read", read_then_grow)
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "unapproved_lock"}
+    assert not list((tmp_path / "environments").iterdir())
+
+
+def test_source_drift_during_install_prevents_publish(tmp_path, monkeypatch):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    snapshot = PackageSnapshot.load(
+        _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+    )
+    broker = OfflinePythonWheelBroker(
+        snapshot=snapshot,
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    original_install = package_broker_module._install_verified_wheel
+
+    def mutate_source_after_verified_read(content, site_packages, artifact):
+        assert hashlib.sha256(content).hexdigest() == artifact.sha256
+        wheel.write_bytes(wheel.read_bytes() + b"source-drift")
+        original_install(content, site_packages, artifact)
+
+    monkeypatch.setattr(
+        package_broker_module,
+        "_install_verified_wheel",
+        mutate_source_after_verified_read,
+    )
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert not list((tmp_path / "environments").iterdir())
+    broker.close()
+
+
+def test_post_lease_artifact_drift_rolls_back_lease_and_staging(
+    tmp_path, monkeypatch
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    original_acquire = broker._acquire_environment_lease
+
+    def acquire_then_drift(root_fd, selected_digest):
+        original_acquire(root_fd, selected_digest)
+        wheel.write_bytes(wheel.read_bytes() + b"post-lease-drift")
+
+    monkeypatch.setattr(broker, "_acquire_environment_lease", acquire_then_drift)
+
+    result = broker.activate({"lock_digest": digest})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert not broker.environment_path(digest).exists()
+    assert not list(environment_root.iterdir())
+    broker.close()
+
+
+def test_snapshot_rejects_symlinked_artifact(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(tmp_path)
+    linked = artifact_root / wheel.name
+    linked.symlink_to(wheel)
+    snapshot = _snapshot_document(wheel)
+    snapshot["artifacts"][0]["size"] = wheel.stat().st_size
+    path = tmp_path / "snapshot.json"
+    path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unavailable or unsafe"):
+        PackageSnapshot.load(path, artifact_root=artifact_root)
+
+
+@pytest.mark.timeout(2)
+def test_snapshot_manifest_fifo_fails_without_blocking(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    manifest_fifo = tmp_path / "snapshot.fifo"
+    os.mkfifo(manifest_fifo)
+
+    with pytest.raises(ValueError, match="bounded single-link file"):
+        PackageSnapshot.load(manifest_fifo, artifact_root=artifact_root)
+
+
+@pytest.mark.timeout(2)
+def test_snapshot_artifact_fifo_fails_without_blocking(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    artifact_fifo = artifact_root / "demo_pkg-1.0.0-py3-none-any.whl"
+    os.mkfifo(artifact_fifo)
+    fixture_root = tmp_path / "fixture"
+    fixture_root.mkdir()
+    fixture = _write_fixture_wheel(fixture_root)
+    document = _snapshot_document(fixture)
+    document["artifacts"][0]["filename"] = artifact_fifo.name
+    document["artifacts"][0]["sha256"] = "a" * 64
+    document["artifacts"][0]["size"] = 1
+    manifest = tmp_path / "snapshot.json"
+    manifest.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="size or type drifted"):
+        PackageSnapshot.load(manifest, artifact_root=artifact_root)
+
+
+@pytest.mark.parametrize(
+    ("wheel_kwargs", "message"),
+    [
+        ({"requires_dist": "other-pkg==1.0.0"}, "metadata identity"),
+        ({"corrupt_record": True}, "RECORD identity"),
+    ],
+)
+def test_snapshot_rejects_hidden_dependency_or_record_drift(
+    tmp_path, wheel_kwargs, message
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root, **wheel_kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        )
+
+
+@pytest.mark.parametrize("requires_python", ["<3", "not-a-specifier"])
+def test_snapshot_rejects_incompatible_or_invalid_python_requirement(
+    tmp_path, requires_python
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(
+        artifact_root, requires_python=requires_python
+    )
+
+    with pytest.raises(ValueError, match="Python requirement|metadata identity"):
+        PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        )
+
+
+@pytest.mark.parametrize(
+    "wheel_kwargs",
+    [
+        {"dist_info": "other-1.0.0.dist-info"},
+        {"extra_files": {"../escape.py": b"unsafe\n"}},
+        {"extra_files": {"startup.pth": b"import os\n"}},
+        {"extra_files": {"sitecustomize/__init__.py": b"value = 1\n"}},
+        {"extra_files": {"sitecustomize.pyc": b"bytecode"}},
+        {"extra_files": {"pkg/usercustomize.py": b"value = 1\n"}},
+        {"extra_files": {"shared": b"file", "shared/module.py": b"nested"}},
+        {"extra_files": {"a" * 241: b"oversized"}},
+    ],
+)
+def test_snapshot_rejects_mismatched_or_unsafe_wheel_entries(
+    tmp_path, wheel_kwargs
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root, **wheel_kwargs)
+
+    with pytest.raises(
+        ValueError,
+        match="metadata set|entry is unsafe|path kind collision",
+    ):
+        PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        )
+
+
+def test_snapshot_rejects_cross_wheel_file_directory_collision(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    alpha = _write_fixture_wheel(
+        artifact_root,
+        distribution="alpha-pkg",
+        extra_files={"shared": b"file"},
+    )
+    beta = _write_fixture_wheel(
+        artifact_root,
+        distribution="beta-pkg",
+        extra_files={"shared/module.py": b"value = 1\n"},
+    )
+    document = _snapshot_document(alpha)
+    document["artifacts"] = [
+        _artifact_document(alpha, "python:alpha-pkg==1.0.0"),
+        _artifact_document(beta, "python:beta-pkg==1.0.0"),
+    ]
+    snapshot_path = tmp_path / "snapshot.json"
+    snapshot_path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="collision"):
+        PackageSnapshot.load(snapshot_path, artifact_root=artifact_root)
+
+
+def test_snapshot_rejects_wheel_before_extraction_when_unpacked_limit_exceeds(
+    tmp_path, monkeypatch
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    monkeypatch.setattr(package_broker_module, "MAX_ENVIRONMENT_BYTES", 128)
+
+    with pytest.raises(ValueError, match="archive limits"):
+        PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        )
+
+
+def test_snapshot_bounds_wheel_control_metadata_before_parsing(
+    tmp_path, monkeypatch
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    monkeypatch.setattr(package_broker_module, "MAX_WHEEL_METADATA_BYTES", 32)
+
+    with pytest.raises(ValueError, match="METADATA exceeds"):
+        PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        )
+
+
+@pytest.mark.parametrize(
+    "wheel_control",
+    [
+        (
+            b"Wheel-Version: 1.0\n"
+            b"Wheel-Version: 2.0\n"
+            b"Root-Is-Purelib: true\n"
+            b"Tag: py3-none-any\n"
+        ),
+        (
+            b"Wheel-Version: 1.0\n"
+            b"Root-Is-Purelib: true\n"
+            b"Root-Is-Purelib: false\n"
+            b"Tag: py3-none-any\n"
+        ),
+        (
+            b"Wheel-Version: 1.0\n"
+            b"Root-Is-Purelib: true\n"
+            b"Tag: py3-none-any\n"
+            b"Tag: cp310-none-any\n"
+        ),
+        (
+            b"wheel-version: 1.0\n"
+            b"Root-Is-Purelib: true\n"
+            b"Tag: py3-none-any\n"
+        ),
+        (
+            b"Wheel-Version: 1.0\n"
+            b"Root-Is-Purelib: true\n"
+            b"Tag: py3-none-any\n"
+            b"Unexpected: value\n"
+        ),
+    ],
+)
+def test_snapshot_rejects_duplicate_conflicting_or_unknown_wheel_headers(
+    tmp_path, wheel_control
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(
+        artifact_root,
+        extra_files={"demo_pkg-1.0.0.dist-info/WHEEL": wheel_control},
+    )
+
+    with pytest.raises(ValueError, match="WHEEL|compatibility"):
+        PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        )
+
+
+def test_snapshot_accepts_standard_wheel_header_terminator(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(
+        artifact_root,
+        extra_files={
+            "demo_pkg-1.0.0.dist-info/WHEEL": (
+                b"Wheel-Version: 1.0\r\n"
+                b"Generator: gdpval-tests\r\n"
+                b"Root-Is-Purelib: true\r\n"
+                b"Tag: py3-none-any\r\n"
+                b"\r\n"
+            ),
+        },
+    )
+
+    snapshot = PackageSnapshot.load(
+        _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+    )
+
+    assert sorted(snapshot.artifacts) == ["python:demo-pkg==1.0.0"]
+
+
+@pytest.mark.parametrize("separator", [b"\v", b"\f", b"\r"])
+def test_snapshot_rejects_nonstandard_wheel_line_separators(
+    tmp_path, separator
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(
+        artifact_root,
+        extra_files={
+            "demo_pkg-1.0.0.dist-info/WHEEL": (
+                b"Wheel-Version: 1.0"
+                + separator
+                + b"Root-Is-Purelib: true\n"
+                + b"Tag: py3-none-any\n"
+            ),
+        },
+    )
+
+    with pytest.raises(ValueError, match="WHEEL is invalid"):
+        PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        )
+
+
+def test_failed_installation_leaves_no_partial_environment(tmp_path, monkeypatch):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    monkeypatch.setattr(
+        package_broker_module,
+        "_install_verified_wheel",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("failed")),
+    )
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert not list((tmp_path / "environments").iterdir())
+
+
+def test_unexpected_staging_entry_is_rejected_before_publish(tmp_path, monkeypatch):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    original_install = package_broker_module._install_verified_wheel
+
+    def install_with_extra_entry(content, site_packages, artifact):
+        original_install(content, site_packages, artifact)
+        (site_packages.parent / "unexpected.txt").write_text(
+            "unexpected", encoding="utf-8"
+        )
+
+    monkeypatch.setattr(
+        package_broker_module,
+        "_install_verified_wheel",
+        install_with_extra_entry,
+    )
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert not list((tmp_path / "environments").iterdir())
+
+
+def test_oversized_receipt_is_rejected_before_publish(tmp_path, monkeypatch):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    monkeypatch.setattr(package_broker_module, "MAX_RECEIPT_BYTES", 128)
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert not list((tmp_path / "environments").iterdir())
+
+
+def test_malformed_lease_blocks_before_environment_publish(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    malformed_lease = environment_root / f".agentic-v2-lease-{digest}"
+    malformed_lease.write_text("not-empty", encoding="utf-8")
+
+    result = broker.activate({"lock_digest": digest})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert not broker.environment_path(digest).exists()
+    assert not list(environment_root.glob(".agentic-v2-staging-*"))
+    malformed_lease.unlink()
+    broker.close()
+
+
+def test_concurrent_activation_reuses_one_mode_sealed_environment(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    results = []
+
+    def activate():
+        results.append(broker.activate({"lock_digest": digest}))
+
+    workers = [threading.Thread(target=activate) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert results == [
+        {"ok": True, "data": {"environment_id": digest}},
+        {"ok": True, "data": {"environment_id": digest}},
+    ]
+    assert [
+        path.name
+        for path in (tmp_path / "environments").iterdir()
+        if len(path.name) == 64
+    ] == [digest]
+
+
+def test_distinct_brokers_serialize_activation_with_root_flock(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    snapshot = PackageSnapshot.load(
+        _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+    )
+    environment_root = tmp_path / "environments"
+    brokers = [
+        OfflinePythonWheelBroker(
+            snapshot=snapshot,
+            environment_root=environment_root,
+        )
+        for _ in range(2)
+    ]
+    resolved = brokers[0].resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    results = []
+
+    workers = [
+        threading.Thread(
+            target=lambda broker=broker: results.append(
+                broker.activate({"lock_digest": digest})
+            )
+        )
+        for broker in brokers
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert results == [
+        {"ok": True, "data": {"environment_id": digest}},
+        {"ok": True, "data": {"environment_id": digest}},
+    ]
+    assert [
+        path.name for path in environment_root.iterdir() if len(path.name) == 64
+    ] == [digest]
+    brokers[0].close()
+    assert brokers[1].environment_path(digest).is_dir()
+    assert brokers[1].activate({"lock_digest": digest})["ok"] is True
+    brokers[1].close()
+    assert not list(environment_root.iterdir())
+
+
+def test_concurrent_close_cannot_remove_another_brokers_lease(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    snapshot = PackageSnapshot.load(
+        _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+    )
+    environment_root = tmp_path / "environments"
+    brokers = [
+        OfflinePythonWheelBroker(
+            snapshot=snapshot,
+            environment_root=environment_root,
+        )
+        for _ in range(2)
+    ]
+    resolved = brokers[0].resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    assert brokers[0].activate({"lock_digest": digest})["ok"] is True
+    assert brokers[1].activate({"lock_digest": digest})["ok"] is True
+    results = []
+    workers = [
+        threading.Thread(target=brokers[0].close),
+        threading.Thread(
+            target=lambda: results.append(
+                brokers[1].activate({"lock_digest": digest})
+            )
+        ),
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert results == [{"ok": True, "data": {"environment_id": digest}}]
+    assert brokers[1].environment_path(digest).is_dir()
+    brokers[1].close()
+    assert not list(environment_root.iterdir())
+
+
+def test_separate_processes_serialize_activation_with_root_flock(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    snapshot_path = _write_snapshot(tmp_path, wheel)
+    snapshot = PackageSnapshot.load(snapshot_path, artifact_root=artifact_root)
+    environment_root = tmp_path / "environments"
+    resolver = OfflinePythonWheelBroker(
+        snapshot=snapshot,
+        environment_root=environment_root,
+    )
+    resolved = resolver.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    script = (
+        "import json;"
+        "from sandbox.v2.agentic_v2_package_broker import "
+        "OfflinePythonWheelBroker,PackageSnapshot;"
+        f"snapshot=PackageSnapshot.load({str(snapshot_path)!r},"
+        f"artifact_root={str(artifact_root)!r});"
+        "broker=OfflinePythonWheelBroker(snapshot=snapshot,"
+        f"environment_root={str(environment_root)!r});"
+        f"print(json.dumps(broker.activate({{'lock_digest':{digest!r}}})))"
+    )
+    batch_root = Path(__file__).resolve().parents[1]
+    workers = [
+        subprocess.Popen(
+            [sys.executable, "-c", script],
+            cwd=batch_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for _ in range(2)
+    ]
+    results = []
+    for worker in workers:
+        stdout, stderr = worker.communicate(timeout=30)
+        assert worker.returncode == 0, stderr
+        results.append(json.loads(stdout))
+
+    assert results == [
+        {"ok": True, "data": {"environment_id": digest}},
+        {"ok": True, "data": {"environment_id": digest}},
+    ]
+    assert [
+        path.name for path in environment_root.iterdir() if len(path.name) == 64
+    ] == [digest]
+    resolver.close()
+
+
+def test_root_environment_count_quota_rejects_second_digest(
+    tmp_path, monkeypatch
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    snapshot = PackageSnapshot.load(
+        _write_two_package_snapshot(tmp_path, artifact_root),
+        artifact_root=artifact_root,
+    )
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=snapshot,
+        environment_root=environment_root,
+    )
+    alpha = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["alpha-pkg==1.0.0"],
+    })
+    beta = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["beta-pkg==1.0.0"],
+    })
+    assert broker.activate({"lock_digest": alpha["data"]["lock_digest"]})[
+        "ok"
+    ] is True
+    monkeypatch.setattr(package_broker_module, "MAX_ACTIVE_ENVIRONMENTS", 1)
+
+    result = broker.activate({"lock_digest": beta["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert broker.environment_path(alpha["data"]["lock_digest"]).is_dir()
+    assert not broker.environment_path(beta["data"]["lock_digest"]).exists()
+    broker.close()
+
+
+def test_root_environment_byte_quota_rejects_second_digest(
+    tmp_path, monkeypatch
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    snapshot = PackageSnapshot.load(
+        _write_two_package_snapshot(tmp_path, artifact_root),
+        artifact_root=artifact_root,
+    )
+    broker = OfflinePythonWheelBroker(
+        snapshot=snapshot,
+        environment_root=tmp_path / "environments",
+    )
+    alpha = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["alpha-pkg==1.0.0"],
+    })
+    beta = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["beta-pkg==1.0.0"],
+    })
+    assert broker.activate({"lock_digest": alpha["data"]["lock_digest"]})[
+        "ok"
+    ] is True
+    alpha_bytes = snapshot.artifacts[
+        "python:alpha-pkg==1.0.0"
+    ].unpacked_size
+    beta_bytes = snapshot.artifacts[
+        "python:beta-pkg==1.0.0"
+    ].unpacked_size
+    monkeypatch.setattr(
+        package_broker_module,
+        "MAX_ACTIVE_ENVIRONMENT_BYTES",
+        alpha_bytes + beta_bytes - 1,
+    )
+
+    result = broker.activate({"lock_digest": beta["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert broker.environment_path(alpha["data"]["lock_digest"]).is_dir()
+    assert not broker.environment_path(beta["data"]["lock_digest"]).exists()
+    broker.close()
+
+
+def test_close_cleans_multiple_valid_environments_with_independent_budgets(
+    tmp_path, monkeypatch
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    snapshot = PackageSnapshot.load(
+        _write_two_package_snapshot(tmp_path, artifact_root),
+        artifact_root=artifact_root,
+    )
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=snapshot,
+        environment_root=environment_root,
+    )
+    digests = []
+    for requirement in ("alpha-pkg==1.0.0", "beta-pkg==1.0.0"):
+        resolved = broker.resolve({
+            "ecosystem": "python",
+            "requirements": [requirement],
+        })
+        digest = resolved["data"]["lock_digest"]
+        assert broker.activate({"lock_digest": digest})["ok"] is True
+        digests.append(digest)
+    cleanup_costs = [
+        2 + sum(1 for _ in broker.environment_path(digest).rglob("*"))
+        for digest in digests
+    ]
+    per_environment_limit = max(cleanup_costs)
+    assert sum(cleanup_costs) > per_environment_limit
+    monkeypatch.setattr(
+        package_broker_module,
+        "MAX_CLEANUP_ENTRIES",
+        per_environment_limit,
+    )
+
+    broker.close()
+
+    assert not list(environment_root.iterdir())
+
+
+def test_shared_root_changes_are_visible_in_every_broker_state(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    snapshot = PackageSnapshot.load(
+        _write_two_package_snapshot(tmp_path, artifact_root),
+        artifact_root=artifact_root,
+    )
+    environment_root = tmp_path / "environments"
+    brokers = [
+        OfflinePythonWheelBroker(
+            snapshot=snapshot,
+            environment_root=environment_root,
+        )
+        for _ in range(2)
+    ]
+    initial = brokers[0].state_sha256()
+    assert brokers[1].state_sha256() == initial
+    alpha = brokers[0].resolve({
+        "ecosystem": "python",
+        "requirements": ["alpha-pkg==1.0.0"],
+    })
+    beta = brokers[1].resolve({
+        "ecosystem": "python",
+        "requirements": ["beta-pkg==1.0.0"],
+    })
+
+    assert brokers[0].activate({"lock_digest": alpha["data"]["lock_digest"]})[
+        "ok"
+    ] is True
+    after_alpha = brokers[1].state_sha256()
+    assert after_alpha == brokers[0].state_sha256()
+    assert after_alpha != initial
+    assert brokers[1].activate({"lock_digest": beta["data"]["lock_digest"]})[
+        "ok"
+    ] is True
+    after_beta = brokers[0].state_sha256()
+    assert after_beta == brokers[1].state_sha256()
+    assert after_beta != after_alpha
+
+    brokers[0].close()
+    brokers[1].close()
+
+
+def test_unaccounted_root_entry_invalidates_global_state(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    unaccounted = environment_root / "unexpected.txt"
+    unaccounted.write_text("unexpected", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="state drifted"):
+        broker.state_sha256()
+
+    unaccounted.unlink()
+    broker.close()
+
+
+def test_mode_or_content_drift_invalidates_state_and_reactivation(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    assert broker.activate({"lock_digest": digest})["ok"] is True
+    environment = broker.environment_path(digest)
+    for path in [environment, *environment.rglob("*")]:
+        expected = 0o555 if path.is_dir() else 0o444
+        assert path.stat().st_mode & 0o777 == expected
+    assert len(broker.state_sha256()) == 64
+    package_file = environment / "site-packages/demo_pkg/__init__.py"
+    package_file.chmod(0o644)
+    package_file.write_text("drifted = True\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="state drifted"):
+        broker.state_sha256()
+    repeated = broker.activate({"lock_digest": digest})
+
+    assert repeated == {"ok": False, "error_type": "unapproved_lock"}
+    broker.close()
+
+
+def test_environment_growth_during_replay_fails_closed(tmp_path, monkeypatch):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    assert broker.activate({"lock_digest": digest})["ok"] is True
+    package_file = broker.environment_path(
+        digest
+    ) / "site-packages/demo_pkg/__init__.py"
+    original_read = os.read
+    mutated = False
+
+    def read_then_grow(descriptor, size):
+        nonlocal mutated
+        content = original_read(descriptor, size)
+        try:
+            opened_path = os.readlink(f"/proc/self/fd/{descriptor}")
+        except OSError:
+            opened_path = ""
+        if content and not mutated and opened_path == str(package_file):
+            mutated = True
+            package_file.chmod(0o644)
+            with package_file.open("ab") as stream:
+                stream.write(b"growth")
+        return content
+
+    monkeypatch.setattr(os, "read", read_then_grow)
+
+    with pytest.raises(ValueError, match="state drifted"):
+        broker.state_sha256()
+    assert mutated is True
+    broker.close()
+
+
+def test_environment_entry_flood_is_bounded_during_replay(tmp_path, monkeypatch):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    assert broker.activate({"lock_digest": digest})["ok"] is True
+    site_packages = broker.environment_path(digest) / "site-packages"
+    site_packages.chmod(0o755)
+    for index in range(16):
+        extra = site_packages / f"extra-{index}.txt"
+        extra.write_text("x", encoding="utf-8")
+        extra.chmod(0o444)
+    site_packages.chmod(0o555)
+    monkeypatch.setattr(package_broker_module, "MAX_ENVIRONMENT_ENTRIES", 8)
+
+    with pytest.raises(ValueError, match="state drifted"):
+        broker.state_sha256()
+    broker.close()
+
+
+def test_forged_receipt_cannot_approve_content_drift(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    assert broker.activate({"lock_digest": digest})["ok"] is True
+    environment = broker.environment_path(digest)
+    package_file = environment / "site-packages/demo_pkg/__init__.py"
+    package_file.chmod(0o644)
+    package_file.write_text("drifted = True\n", encoding="utf-8")
+    package_file.chmod(0o444)
+    lock = broker._validated_lock(digest)
+    forged = package_broker_module._environment_receipt(
+        environment / "site-packages",
+        lock_digest=digest,
+        snapshot_sha256=broker.snapshot.sha256,
+        policy_sha256=broker.policy_sha256,
+        installer_identity=broker.installer_identity,
+        requirements=lock["requirements"],
+    )
+    receipt = environment / "environment.json"
+    receipt.chmod(0o644)
+    receipt.write_text(
+        json.dumps(forged, sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    receipt.chmod(0o444)
+
+    repeated = broker.activate({"lock_digest": digest})
+
+    assert repeated == {"ok": False, "error_type": "unapproved_lock"}
+    broker.close()
+
+
+@pytest.mark.parametrize("mutation", ["reformat", "duplicate", "boolean-as-int"])
+def test_receipt_requires_exact_canonical_bytes(tmp_path, mutation):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    assert broker.activate({"lock_digest": digest})["ok"] is True
+    receipt = broker.environment_path(digest) / "environment.json"
+    original = receipt.read_bytes()
+    if mutation == "reformat":
+        changed = json.dumps(json.loads(original), indent=2).encode("utf-8")
+    elif mutation == "duplicate":
+        changed = b'{"schema_version":"1.0",' + original[1:]
+    else:
+        changed = original.replace(b'"foundation_only":true', b'"foundation_only":1')
+    receipt.chmod(0o644)
+    receipt.write_bytes(changed)
+    receipt.chmod(0o444)
+
+    assert broker.activate({"lock_digest": digest}) == {
+        "ok": False,
+        "error_type": "unapproved_lock",
+    }
+    with pytest.raises(ValueError, match="state drifted"):
+        broker.state_sha256()
+    broker.close()
+
+
+def test_receipt_baseline_hash_cannot_be_replaced_in_memory(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    assert broker.activate({"lock_digest": digest})["ok"] is True
+    broker._active[digest] = "0" * 64
+
+    with pytest.raises(ValueError, match="state drifted"):
+        broker.state_sha256()
+    assert broker.activate({"lock_digest": digest}) == {
+        "ok": False,
+        "error_type": "unapproved_lock",
+    }
+    broker.close()
+
+
+def test_active_lease_metadata_drift_invalidates_state(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    assert broker.activate({"lock_digest": digest})["ok"] is True
+    lease = environment_root / f".agentic-v2-lease-{digest}"
+    lease.write_text("drift", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="state drifted"):
+        broker.state_sha256()
+    assert broker.activate({"lock_digest": digest}) == {
+        "ok": False,
+        "error_type": "compute_backend_error",
+    }
+    lease.write_text("", encoding="utf-8")
+    broker.close()
+
+
+def test_unlocked_local_lease_is_reestablished_before_state_acceptance(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    assert broker.activate({"lock_digest": digest})["ok"] is True
+    fcntl.flock(broker._leases[digest], fcntl.LOCK_UN)
+
+    assert len(broker.state_sha256()) == 64
+    probe = os.open(
+        environment_root / f".agentic-v2-lease-{digest}",
+        os.O_RDWR | os.O_NONBLOCK,
+    )
+    try:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        os.close(probe)
+    broker.close()
+
+
+def test_abrupt_exit_orphan_lease_is_recovered_on_retry(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    lease = environment_root / f".agentic-v2-lease-{digest}"
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import fcntl,os;"
+                f"fd=os.open({str(lease)!r},os.O_RDWR|os.O_CREAT,0o600);"
+                "fcntl.flock(fd,fcntl.LOCK_SH)"
+            ),
+        ],
+        check=True,
+    )
+    assert lease.is_file()
+    assert not broker.environment_path(digest).exists()
+
+    result = broker.activate({"lock_digest": digest})
+
+    assert result == {"ok": True, "data": {"environment_id": digest}}
+    assert broker.environment_path(digest).is_dir()
+    broker.close()
+
+
+def test_live_prepublish_lease_blocks_publish_until_holder_exits(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    lease = environment_root / f".agentic-v2-lease-{digest}"
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import fcntl,os,sys;"
+                f"fd=os.open({str(lease)!r},os.O_RDWR|os.O_CREAT,0o600);"
+                "fcntl.flock(fd,fcntl.LOCK_SH);"
+                "print('ready',flush=True);"
+                "sys.stdin.readline()"
+            ),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert holder.stdout is not None
+    assert holder.stdout.readline().strip() == "ready"
+
+    blocked = broker.activate({"lock_digest": digest})
+
+    assert blocked == {"ok": False, "error_type": "compute_backend_error"}
+    assert not broker.environment_path(digest).exists()
+    assert not list(environment_root.glob(".agentic-v2-staging-*"))
+    assert holder.stdin is not None
+    holder.stdin.write("release\n")
+    holder.stdin.flush()
+    stdout, stderr = holder.communicate(timeout=10)
+    assert holder.returncode == 0, stdout + stderr
+
+    recovered = broker.activate({"lock_digest": digest})
+
+    assert recovered == {"ok": True, "data": {"environment_id": digest}}
+    assert broker.environment_path(digest).is_dir()
+    broker.close()
+
+
+def test_digest_symlink_is_rejected_without_touching_external_target(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    digest = resolved["data"]["lock_digest"]
+    external = tmp_path / "external-environment"
+    external.mkdir(mode=0o755)
+    canary = external / "keep.txt"
+    canary.write_text("keep", encoding="utf-8")
+    (environment_root / digest).symlink_to(external, target_is_directory=True)
+
+    result = broker.activate({"lock_digest": digest})
+
+    assert result == {"ok": False, "error_type": "unapproved_lock"}
+    assert canary.read_text(encoding="utf-8") == "keep"
+    assert external.stat().st_mode & 0o777 == 0o755
+    broker.close()
+    assert canary.exists()
+
+
+def test_stale_staging_symlink_cleanup_never_touches_external_target(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    canary = tmp_path / "external-canary"
+    canary.mkdir(mode=0o755)
+    canary_file = canary / "keep.txt"
+    canary_file.write_text("keep", encoding="utf-8")
+    stale = environment_root / ".agentic-v2-stale"
+    stale.symlink_to(canary, target_is_directory=True)
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result["ok"] is True
+    assert not stale.exists()
+    assert canary_file.read_text(encoding="utf-8") == "keep"
+    assert canary.stat().st_mode & 0o777 == 0o755
+    broker.close()
+
+
+def test_stale_staging_hardlink_cleanup_preserves_external_inode(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    external = tmp_path / "external.txt"
+    external.write_text("keep", encoding="utf-8")
+    external.chmod(0o640)
+    stale = environment_root / ".agentic-v2-stale"
+    stale.mkdir()
+    os.link(external, stale / "linked.txt")
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result["ok"] is True
+    assert external.read_text(encoding="utf-8") == "keep"
+    assert external.stat().st_mode & 0o777 == 0o640
+    broker.close()
+
+
+@pytest.mark.parametrize("shape", ["flood", "deep"])
+def test_stale_cleanup_is_bounded_without_recursion(tmp_path, monkeypatch, shape):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    stale = environment_root / ".agentic-v2-stale"
+    stale.mkdir()
+    if shape == "flood":
+        for index in range(16):
+            (stale / f"entry-{index}.txt").write_text("x", encoding="utf-8")
+        monkeypatch.setattr(package_broker_module, "MAX_CLEANUP_ENTRIES", 8)
+    else:
+        cursor = stale
+        for index in range(12):
+            cursor = cursor / f"d{index}"
+            cursor.mkdir()
+        monkeypatch.setattr(package_broker_module, "MAX_CLEANUP_DEPTH", 4)
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert not broker.environment_path(resolved["data"]["lock_digest"]).exists()
+
+
+def test_multiple_stale_trees_share_one_cleanup_budget(tmp_path, monkeypatch):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    for tree_index in range(2):
+        stale = environment_root / f".agentic-v2-stale-{tree_index}"
+        stale.mkdir()
+        for entry_index in range(4):
+            (stale / f"entry-{entry_index}.txt").write_text(
+                "x", encoding="utf-8"
+            )
+    monkeypatch.setattr(package_broker_module, "MAX_CLEANUP_ENTRIES", 10)
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert list(environment_root.glob(".agentic-v2-stale-*"))
+
+
+def test_environment_root_path_replacement_cannot_redirect_activation(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    environment_root = tmp_path / "environments"
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=environment_root,
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    moved_root = tmp_path / "moved-environments"
+    environment_root.rename(moved_root)
+    environment_root.mkdir(mode=0o700)
+    canary = environment_root / "keep.txt"
+    canary.write_text("keep", encoding="utf-8")
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result == {"ok": False, "error_type": "compute_backend_error"}
+    assert canary.read_text(encoding="utf-8") == "keep"
+    assert not list(moved_root.iterdir())
+    broker.close()
+
+
+def test_parent_fsync_failure_does_not_misreport_atomic_commit(
+    tmp_path, monkeypatch
+):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    broker = OfflinePythonWheelBroker(
+        snapshot=PackageSnapshot.load(
+            _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+        ),
+        environment_root=tmp_path / "environments",
+    )
+    resolved = broker.resolve({
+        "ecosystem": "python",
+        "requirements": ["demo-pkg==1.0.0"],
+    })
+    monkeypatch.setattr(os, "fsync", lambda _descriptor: (_ for _ in ()).throw(
+        OSError("unsupported")
+    ))
+
+    result = broker.activate({"lock_digest": resolved["data"]["lock_digest"]})
+
+    assert result["ok"] is True
+    assert broker.environment_path(resolved["data"]["lock_digest"]).is_dir()
+    broker.close()
+
+
+def test_candidate_backend_dispatches_broker_but_blocks_exec(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    snapshot = PackageSnapshot.load(
+        _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+    )
+    backend = AgenticV2PackageBrokerCandidateBackend(
+        root=tmp_path / "candidate",
+        profile=AgenticV2Profile.from_mapping({
+            "tool_contract_version": "2.0",
+            "policy_profile_id": "package-broker-v1",
+            "foundation_only": True,
+        }),
+        snapshot=snapshot,
+    )
+    dispatcher = AgenticV2ToolDispatcher(
+        backend,
+        AgenticV2Lifecycle(LifecycleState.ACTIVE),
+    )
+    before = backend.state_sha256()
+    started = backend.start(timeout_seconds=30)
+
+    assert started["ok"] is True
+    assert started["data"]["package_snapshot_sha256"] == snapshot.sha256
+    assert started["data"]["package_policy_sha256"] == backend.broker.policy_sha256
+    assert len(started["data"]["package_policy_sha256"]) == 64
+
+    resolved = dispatcher.dispatch(
+        call_id="resolve-1",
+        name="environment_resolve",
+        arguments={
+            "ecosystem": "python",
+            "requirements": ["demo-pkg==1.0.0"],
+        },
+    )
+
+    assert resolved.result["ok"] is True
+    assert resolved.result["state_after_sha256"] == before
+    activated = dispatcher.dispatch(
+        call_id="activate-1",
+        name="environment_activate",
+        arguments={"lock_digest": resolved.result["data"]["lock_digest"]},
+    )
+    assert activated.result["ok"] is True
+    assert activated.result["state_after_sha256"] != before
+
+    blocked = dispatcher.dispatch(
+        call_id="exec-1",
+        name="exec_run",
+        arguments={"argv": ["python", "--version"], "cwd": ".", "timeout_seconds": 30},
+    )
+
+    assert blocked.result["ok"] is False
+    assert blocked.result["error_type"] == "capability_unavailable"
+    backend.close()
+
+
+def test_candidate_backend_close_preserves_replacement_environment_path(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    snapshot = PackageSnapshot.load(
+        _write_snapshot(tmp_path, wheel), artifact_root=artifact_root
+    )
+    backend = AgenticV2PackageBrokerCandidateBackend(
+        root=tmp_path / "candidate",
+        profile=AgenticV2Profile.from_mapping({
+            "tool_contract_version": "2.0",
+            "policy_profile_id": "package-broker-v1",
+            "foundation_only": True,
+        }),
+        snapshot=snapshot,
+    )
+    environment_root = backend.broker.environment_root
+    moved_root = tmp_path / "moved-environments"
+    environment_root.rename(moved_root)
+    environment_root.mkdir(mode=0o700)
+    canary = environment_root / "keep.txt"
+    canary.write_text("keep", encoding="utf-8")
+
+    backend.close()
+
+    assert canary.read_text(encoding="utf-8") == "keep"
+    assert moved_root.is_dir()
+
+
+def test_checked_in_snapshot_schema_and_policy_accept_candidate_fixture(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    wheel = _write_fixture_wheel(artifact_root)
+    snapshot = _snapshot_document(wheel)
+    batch_root = Path(__file__).resolve().parents[1]
+    schema = json.loads(
+        (batch_root / "schemas/agentic-v2-package-snapshot.schema.json")
+        .read_text(encoding="utf-8")
+    )
+    policy = json.loads(
+        (batch_root / "security/agentic-v2-package-broker-policy.json")
+        .read_text(encoding="utf-8")
+    )
+
+    assert not list(Draft202012Validator(schema).iter_errors(snapshot))
+    noncanonical = json.loads(json.dumps(snapshot))
+    noncanonical["artifacts"][0]["coordinate"] = "python:demo_pkg==1.0.0"
+    assert list(Draft202012Validator(schema).iter_errors(noncanonical))
+    assert policy["foundation_only"] is True
+    assert policy["production_activation"] == "disabled"
+    assert policy["network"] == {
+        "package_index": "disabled",
+        "os_containment": "not_run",
+    }
+    assert set(policy["admission_evidence"].values()) == {"not_run"}
+    assert policy["supported_ecosystems"] == ["python-wheel"]
+    assert policy["exec_run"] == "blocked_pending_containment"
+    assert policy["limits"]["active_environments"] == 8
+    assert policy["limits"]["active_environment_payload_bytes"] == 536870912
+    assert policy["limits"]["cleanup_entries"] == 4104
+    assert policy["limits"]["cleanup_depth"] == 128
+    assert policy["activation"] == {
+        "concurrency": "linux-flock",
+        "seal": "read-only-modes-with-drift-verification",
+        "crash_durability": "not_claimed",
+    }
+
+
+def test_candidate_is_not_wired_into_paid_or_production_paths():
+    batch_root = Path(__file__).resolve().parents[1]
+    candidate_relative = "sandbox/v2/agentic_v2_package_broker.py"
+    forbidden = [
+        batch_root / "core/executor.py",
+        batch_root / "core/llm_client.py",
+        batch_root / "core/agentic_v2_runner.py",
+        batch_root / "step2_run_inference.py",
+        batch_root / "step7_upload_hf.sh",
+        batch_root / "step8_grade.py",
+        *sorted((batch_root.parent / ".github/workflows").glob("*.yml")),
+        *sorted((batch_root / "experiments").glob("*.yaml")),
+    ]
+
+    for path in forbidden:
+        assert "agentic_v2_package_broker" not in path.read_text(encoding="utf-8")
+
+    candidate = batch_root / candidate_relative
+    assert candidate.is_file()
+    assert not (batch_root / "core/agentic_v2_package_broker.py").exists()
+    build_surfaces = [
+        batch_root / "sandbox/agentic.Dockerfile",
+        batch_root / "sandbox/v2/professional-work.Dockerfile",
+        batch_root / "sandbox/v2/build_candidate.py",
+        batch_root / "sandbox/v2/verify_candidate.py",
+        batch_root.parent / ".github/workflows/build-sandbox-image.yml",
+    ]
+    for path in build_surfaces:
+        content = path.read_text(encoding="utf-8")
+        assert candidate_relative not in content
+        assert "agentic_v2_package_broker.py" not in content
+
+    docker_context_exclusions = {
+        line.strip()
+        for line in (batch_root / ".dockerignore").read_text(
+            encoding="utf-8"
+        ).splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    assert {
+        candidate_relative,
+        "sandbox/v2/README.md",
+        "schemas/agentic-v2-package-snapshot.schema.json",
+        "security/agentic-v2-package-broker-policy.json",
+    } <= docker_context_exclusions
+    assert "tests/" in docker_context_exclusions
+    workflow = (
+        batch_root.parent / ".github/workflows/build-sandbox-image.yml"
+    ).read_text(encoding="utf-8")
+    assert "context: batch-runner" in workflow

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,74 +1,82 @@
 # Latest Task Result
 
-- Updated: 2026-08-05
-- Status: Completed 220-task mini regrade history restored on `main` through
-  PR #158
+- Updated: 2026-08-06
+- Status: Phase 1D-A offline Python wheel broker candidate implemented,
+  validated, and still disconnected from production
 
 ## Task
 
-- Recover the useful completed-run content from the preserved dirty checkout
-  without merging its stale code, UI regressions, generated artifacts, or
-  unrelated local work.
-- Replace the checked-in `BLOCKED` pre-run note with a reproducible historical
-  record of the completed `default_v2_mini.yaml` 220-task grading relay.
-- Correct stale provenance and incorporate later experiments that resolved the
-  original future-work hypotheses.
+- Continue Agentic Sandbox V2 toward installable external packages and Linux
+  execution without weakening containment, reproducibility, or fail-closed
+  behavior.
+- Deliver the smallest model-free package slice that can be proved on this
+  host, while deferring command execution that lacks enforceable isolation.
+- Preserve the intentional dirty primary checkout byte-for-byte by working from
+  clean `origin/main@fa76d24973e6` in a separate worktree.
 
 ## Result
 
-- Replaced the pre-run note with the four successful GitHub Actions runs,
-  workflow input heads, preserved output commits, and cumulative task counts.
-- Corrected the chunk-2 output identity to
-  `110f3bf604f62029fe12e5737b777687439e4b15`.
-- Recomputed from the checked-in final grade JSON:
-  - selection status: 194 ok, 20 wrong-format primary, 1 no generated
-    candidate, and 5 selection errors;
-  - 113 tasks with excluded reference files and no reference fallback;
-  - 8,904 judge calls, 130,092,056 input tokens, and 5,523,697 output tokens;
-  - 10,453 item audit coverage with no missing required audit fields;
-  - 355 judge errors, including 100 score-included zeros across 53 tasks with
-    max-score weight 164.
-- Rejoined owner gold 20 by exact task and criterion. Overall Style bias is
-  -0.1625/5 and MAE is 1.2125/5.
-- Clarified that the baseline is selector-clean, not error-free, and that
-  `perception_called=false` does not imply the judge had no tool observation.
-- Replaced obsolete future work with the checked-in follow-up findings:
-  broad rendering was effectively null at equal model, the GPT-5.4 full run was
-  completed, and production grading now defaults to GPT-5.6 Sol Max.
-- No source code, grading output, grade score, workflow, model configuration,
-  current production policy, or published artifact was changed.
+- Added a foundation-only snapshot schema and runtime policy for at most eight
+  exact, canonical, dependency-free `py3-none-any` wheels on Linux amd64 and the
+  active Python major/minor.
+- Added strict artifact admission for size/hash, archive paths and controls,
+  RECORD inventory and hashes, METADATA identity and `Requires-Python`, exact
+  WHEEL headers, aggregate limits, collisions, links, executable-mode entries,
+  `.data`, `.pth`, `.egg-link`, `.pyc`, and startup hooks.
+- Added stateless lock resolution. A returned digest can be activated after a
+  broker restart without hidden resolver state.
+- Added deterministic stdlib wheel extraction with no pip, installer
+  subprocess, package index, or network path. Activation uses private
+  descriptor-anchored staging, independent expected inventory, canonical
+  receipt bytes, mode sealing, and atomic rename.
+- Added process-shared nonblocking leases, shared-root global state and quota
+  validation, canonical receipt baselines, bounded descriptor replay and
+  cleanup, orphan recovery, last-lease cleanup, and fail-closed root/lease/
+  content/mode/size drift handling.
+- Added a dispatcher candidate that permits only capabilities query, package
+  resolve, and package activation. Command execution, workspace mutation,
+  browser, public verification, and finalization return
+  `capability_unavailable`.
+- Confirmed the candidate is not wired into executor, Step 2, the Agentic V2
+  runner, experiments, workflows, grading, upload, or publication.
+- Kept the implementation under `sandbox/v2/`, outside the existing
+  `COPY core` image input, core-tree identity, Phase 1B/1C build allowlist, and
+  embedded-image manifest. Tracked Dockerignore rules also exclude every
+  Phase 1D-A artifact from existing publication build contexts.
 
 ## Verification
 
-- Recomputed selector, reference, token, judge-error, audit, population score,
-  and gold metrics directly from the final 220-task mini grade JSON.
-- Verified all four GitHub Actions runs are complete and successful.
-- Reopened each preserved output commit and verified the cumulative progression:
-  46 -> 112 -> 162 -> 220 tasks.
-- Verified final grade and auto-analysis commits and all linked evidence paths.
-- Verified the follow-up GPT-5.4 JSON reproduces the same selector distribution
-  and the checked-in vision report records the null broad-render result.
-- Executable historical-report contract and `git diff --check` passed.
-- Independent grading review returned `APPROVE` with no findings.
-- No model call, grading run, workflow dispatch, cloud credential, publication,
-  or paid API call was used for this documentation recovery.
+- Focused Phase 1D-A adversarial suite: 75 passed.
+- Agentic V2 contract, foundation, compatibility, candidate verifier, Phase 1B
+  static/contract/OCI/supply-chain, and Phase 1C license regressions: 644
+  passed.
+- Ruff, `py_compile`, VS Code diagnostics, and `git diff --check`: passed.
+- Credential-free backend: 3,001 passed, 6 skipped, and 45 integration tests
+  deselected. Three unrelated environment failures remain: installed
+  `openai==2.45.0`, `azure-core==1.39.0`, and `azure-ai-projects==1.0.0` do not
+  match repository pins 2.46.0/1.41.0/2.3.0, and `pdfplumber` is absent. The
+  failing tests and requirements are unchanged from `origin/main`.
+- Independent security and code reviews returned `APPROVE` with no blocking
+  findings for this foundation-only candidate.
+- No model call, package index, external network, credential, workflow,
+  grading, upload, publication, or paid operation was used.
 
 ## Shipment
 
-- Reviewed branch head:
-  `3a303590ca08484e3bd9c83303500d44d0a9b31e`.
-- PR [#158](https://github.com/hyeonsangjeon/gdpval-realworks/pull/158)
-  reached `MERGED` at `2026-08-05T09:35:56Z` as commit
-  `d610c717696b4e6589cf28fb8a122c7b3b9aa2d8`.
-- The changed documentation paths are outside the active automatic workflow
-  filters, so GitHub created no PR or post-merge workflow run. The executable
-  evidence contract and two independent reviews supplied acceptance evidence.
+- Working branch: `feat/agentic-v2-package-broker`.
+- Base: `origin/main@fa76d24973e660f4e93b26fe7ef7d87dc5ba3223`.
+- This record describes the reviewed local candidate before remote shipment.
 
 ## Remaining Work
 
-- The historical mini headline includes score-included judge errors and must not
-  be cited as an error-free judge-quality estimate.
-- Historical grade artifacts are preserved as recorded; this task does not
-  rewrite their scores or remove old error evidence.
-- Reproduction requires explicitly selecting the historical
-  `default_v2_mini.yaml` identity because it is no longer the production default.
+- Production activation remains disabled. The candidate is not connected to a
+  model loop, experiment, workflow, grader, uploader, or public artifact path.
+- `exec_run` remains blocked. The local Bubblewrap probe cannot create the
+  required user namespace, so arbitrary Linux execution has no enforceable
+  containment proof on this host.
+- npm, Debian/apt, live indexes, URL/VCS requirements, sdists, and editable
+  installs remain unsupported.
+- Package admission SBOM, license, CVE, provenance, signature, OS-level network
+  containment, and crash durability remain `not_run` or `not_claimed`.
+- A later production phase must add approved supply-chain evidence and a proven
+  containment substrate before connecting package environments to execution.


### PR DESCRIPTION
## Summary
- add a disconnected Agentic Sandbox V2 Phase 1D-A broker for stateless resolution and deterministic activation of exact dependency-free local `py3-none-any` wheels
- validate wheel bytes, metadata, RECORD, compatibility, paths, resource limits, canonical receipts, leases, replay, cleanup, and shared-root quotas without pip, installer subprocesses, or network access
- keep the candidate outside existing image/core-tree and Phase 1B/1C build inputs, with tracked Docker context exclusions

## Validation
- focused Phase 1D-A adversarial suite: 75 passed
- Agentic V2 and Phase 1B/1C regression suite: 644 passed
- credential-free backend: 3,001 passed, 6 skipped, 3 unchanged local dependency failures, 45 integration tests deselected
- Ruff, `py_compile`, VS Code diagnostics, and `git diff --check`: passed
- independent security, code, and architecture reviews: APPROVE

## Safety boundaries
- no package index, external network, model, credential, workflow, grading, upload, publication, or paid operation
- `exec_run`, npm, Debian/apt, URL/VCS requirements, sdists, editables, and production wiring remain disabled
- package SBOM/license/CVE/provenance/signature evidence, OS containment, and crash durability remain `not_run` or `not_claimed`