### PR TITLE
fix(notes): reconcile assets and README facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Changed
+- **Field Notes rescue reconciliation and onboarding truth labels** - preserve a
+  physical copy of the full three-week primary worktree before Git mutation,
+  then reconcile the seven requested Field Notes paths against
+  `origin/main@a6593c2`. All seven were already tracked on `main`; five primary
+  filesystem blobs were exact July 15-16 historical versions, `Journal.tsx`
+  was already identical to `main`, the missing filesystem test had a newer
+  committed successor, and the one unique `journal.ts` snapshot would remove
+  later evidence-backed articles, citations, and selectors. The rescue
+  therefore keeps the evolved canonical files instead of overwriting them with
+  stale snapshots. Current Field Notes now route every public exp026 detail
+  link through its deployed URL with safe new-tab attributes, including mobile
+  perception cards and evidence rows. English and Korean root onboarding mark
+  the unavailable self-hosted agentic preflight as `not_run`, distinguish the
+  sample `gpt-5.2-chat` value from the current production report default
+  `gpt-5.6-sol`, label every Start here path with its cost/model-call boundary,
+  and link directly to the deployed `/notes` view. Validation passes 21 focused
+  Field Notes/onboarding contracts, the self-preparing aggregate suite with 98
+  passes and one expected Ruby skip, the production build, and all four
+  containerized Chromium Field Notes suites with zero 390px overflow, runtime
+  legacy-route redirection, and exact exp026 `href`/`target`/`rel` checks. No
+  model, grading, cloud credential, workflow dispatch, Hugging Face write, or
+  paid operation ran; aggregation made only unauthenticated public report
+  reads.
+  Independent `first-reviewer` review returned `APPROVE` with no blocking
+  findings; its only note was a nonblocking future-proofing opportunity for
+  experiment IDs that are currently internal-only.
 - **Verified 220-task mini regrade history** - replace the stale pre-run
   `BLOCKED` note with an evidence-reopened record of the completed four-run
   `default_v2_mini.yaml` relay. The report now binds each successful GitHub run

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@
 
 ## Start here
 
-**[Live dashboard](https://hyeonsangjeon.github.io/gdpval-realworks/)** |
-**[Three-task sample config](batch-runner/experiments/exp998_smoke_baseline_sample.yaml)** |
-**[Run Batch workflow](../../actions/workflows/batch-run.yml)** |
-**[Results and artifacts](docs/first-experiment.md#7-know-what-success-looks-like)**
+| Path | Cost and model boundary |
+|---|---|
+| **[Live dashboard](https://hyeonsangjeon.github.io/gdpval-realworks/)** | **$0 · no model calls** |
+| **[Three-task sample config](batch-runner/experiments/exp998_smoke_baseline_sample.yaml)** | **$0 to inspect · no model calls** |
+| **[Run Batch workflow](../../actions/workflows/batch-run.yml)** | **Paid API usage · model calls and remote writes** |
+| **[Results and artifacts](docs/first-experiment.md#7-know-what-success-looks-like)** | **$0 to inspect · no model calls** |
 
 - **See the evidence:** [open the live dashboard](https://hyeonsangjeon.github.io/gdpval-realworks/).
   A browser is enough.
@@ -152,13 +154,15 @@ These are code-backed, path-specific controls, not a blanket security claim:
 | Configuration input | A no-credential job validates the experiment name and safely parses YAML before the credentialed job; agentic modes are rejected from the general batch path | [`batch-run.yml`](.github/workflows/batch-run.yml) |
 | Container sandbox | Sandbox runs resolve an immutable image digest across relay jobs; Docker execution disables networking and applies resource limits | [`batch-run.yml`](.github/workflows/batch-run.yml), [`sandbox_runner.py`](batch-runner/core/sandbox_runner.py) |
 | Agentic image supply chain | Manual protected-main publication requires immutable dependency locks, a digest-pinned base, runtime audit, and SBOM evidence | [`build-sandbox-image.yml`](.github/workflows/build-sandbox-image.yml) |
-| Agentic containment preflight | A manual model-free job rejects model/HF credentials, requires an exact preloaded image and AppArmor input, runs containment tests, and asserts cleanup | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
+| Agentic containment preflight | Defined but never run (`not_run`): the manual model-free job requires `[self-hosted, linux, x64, agentic-sandbox]`, and no matching runner exists. No containment result is established. | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
 | Dashboard publication | Pull requests aggregate, build, and run data/browser contracts; only push/manual deploy jobs receive Pages/OIDC permissions | [`deploy.yml`](.github/workflows/deploy.yml) |
 
 The default three-task smoke config uses provider-hosted `code_interpreter`.
 Docker sandbox and agentic controls apply only to their named paths. The general
 batch workflow currently rejects agentic execution before cloud credentials are
-used; the checked-in agentic workflow is a model-free preflight, not a paid run.
+used. The checked-in agentic workflow is a model-free preflight definition, not
+an executed proof or a paid run. Under the `not_run` / `failed` / `verified`
+evidence ladder, its containment evidence remains `not_run`.
 
 ---
 
@@ -188,14 +192,16 @@ Expected behavior:
   before creating and uploading a disposable Hugging Face dataset once. A
   partial target or ambiguous outcome aborts without retry or automatic deletion.
 2. Step 1 selects three tasks deterministically.
-3. Step 2 calls `gpt-5.2-chat`, creates files, and can retry same-model Self-QA.
+3. Step 2 uses `gpt-5.2-chat`, the **sample configuration value**, creates
+  files, and can retry same-model Self-QA.
 4. Steps 3-4 write formatted results and a three-row Parquet artifact.
 5. Step 5 is skipped because this is both a dry run and a three-task sample.
-6. Step 6's primary report path makes up to two sequential `gpt-5.6-sol` calls
-  with `reasoning=max`. Its 1.05M context is a deployment capability, not an
-  extra request setting. Completed calls can be billed. Any setup, call, parse,
-  or route-validation failure immediately produces a model-free report; there
-  is no second-model fallback. Report identity must pass before publication.
+6. Step 6's **current production report default** is `gpt-5.6-sol`; its primary
+  path makes up to two sequential calls with `reasoning=max`. Its 1.05M context
+  is a deployment capability, not an extra request setting. Completed calls can
+  be billed. Any setup, call, parse, or route-validation failure immediately
+  produces a model-free report; there is no second-model fallback. Report
+  identity must pass before publication.
 7. Step 7 and the result PR are skipped by `dry_run: true`.
 
 If the credentialed batch job reaches its final `always()` step, it attempts to
@@ -237,7 +243,7 @@ static React application backed by generated repository data.
 | Sector heatmap | Performance variation across 9 sectors |
 | Experiment detail | All 220 task states, files, prompts, retries, and errors |
 | Grading analysis | Evidence-linked rubric results and judge metadata |
-| RealWorks Field Notes | Chronological engineering decisions with explicit evidence caveats |
+| [RealWorks Field Notes](https://hyeonsangjeon.github.io/gdpval-realworks/notes) | Chronological engineering decisions with explicit evidence caveats |
 
 Dashboard implementation details are in [`src/README.md`](src/README.md).
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -33,10 +33,12 @@
 
 ## 여기서 시작하세요
 
-**[라이브 대시보드](https://hyeonsangjeon.github.io/gdpval-realworks/)** |
-**[3-task 샘플 config](batch-runner/experiments/exp998_smoke_baseline_sample.yaml)** |
-**[Batch workflow 실행](../../actions/workflows/batch-run.yml)** |
-**[결과와 아티팩트](docs/first-experiment_KR.md#7-성공-상태-확인)**
+| 경로 | 비용과 모델 경계 |
+|---|---|
+| **[라이브 대시보드](https://hyeonsangjeon.github.io/gdpval-realworks/)** | **$0 · 모델 호출 없음** |
+| **[3-task 샘플 config](batch-runner/experiments/exp998_smoke_baseline_sample.yaml)** | **확인 비용 $0 · 모델 호출 없음** |
+| **[Batch workflow 실행](../../actions/workflows/batch-run.yml)** | **유료 API 사용 · 모델 호출과 원격 쓰기** |
+| **[결과와 아티팩트](docs/first-experiment_KR.md#7-성공-상태-확인)** | **확인 비용 $0 · 모델 호출 없음** |
 
 - **근거 보기:** [라이브 대시보드](https://hyeonsangjeon.github.io/gdpval-realworks/)를
   엽니다. 브라우저만 있으면 됩니다.
@@ -132,13 +134,15 @@ Step 0-7은 실험 실행과 게시를 담당합니다. 외부 채점은 별도 
 | 설정 입력 | 인증 정보 없는 job이 실험 이름을 검사하고 YAML을 안전하게 파싱한 뒤 credential job을 시작하며, 일반 배치 경로는 agentic mode를 거부함 | [`batch-run.yml`](.github/workflows/batch-run.yml) |
 | Container sandbox | sandbox 실행은 relay 전체에 immutable image digest를 유지하며, Docker 실행은 network를 끄고 resource limit을 적용함 | [`batch-run.yml`](.github/workflows/batch-run.yml), [`sandbox_runner.py`](batch-runner/core/sandbox_runner.py) |
 | Agentic image supply chain | 수동 protected-main 게시에 immutable dependency lock, digest-pinned base, runtime audit, SBOM 근거를 요구함 | [`build-sandbox-image.yml`](.github/workflows/build-sandbox-image.yml) |
-| Agentic containment preflight | 수동 model-free job이 model/HF credential 부재, 정확한 preloaded image와 AppArmor 입력, containment test, 종료 후 정리를 검사함 | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
+| Agentic containment preflight | 정의돼 있으나 미실행(`not_run`): 수동 model-free job은 `[self-hosted, linux, x64, agentic-sandbox]` 러너를 요구하지만 일치하는 러너가 없어 containment 결과가 확립되지 않음 | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
 | Dashboard publication | PR에서 aggregate, build, data/browser contract를 실행하고 push/manual deploy job만 Pages/OIDC 권한을 받음 | [`deploy.yml`](.github/workflows/deploy.yml) |
 
 기본 3-task smoke는 provider-hosted `code_interpreter`를 사용합니다. Docker
 sandbox와 agentic 통제는 각각 이름이 붙은 경로에만 적용됩니다. 일반 배치
 워크플로는 cloud credential을 사용하기 전에 agentic 실행을 거부하며,
-체크인된 agentic 워크플로는 유료 실행이 아니라 model-free preflight입니다.
+체크인된 agentic 워크플로는 실행 근거나 유료 실행이 아니라 model-free
+preflight 정의입니다. `not_run` / `failed` / `verified` 근거 사다리에서 이
+containment 근거는 `not_run`으로 남아 있습니다.
 
 ---
 
@@ -168,15 +172,16 @@ sandbox와 agentic 통제는 각각 이름이 붙은 경로에만 적용됩니�
   뒤 일회성 Hugging Face dataset을 한 번 생성·업로드합니다. 기존 partial 또는
   결과가 불명확한 target은 재시도나 자동 삭제 없이 중단합니다.
 2. Step 1이 태스크 3개를 결정적으로 선택합니다.
-3. Step 2가 `gpt-5.2-chat`을 호출하고 파일을 만든 뒤 같은 모델의 Self-QA를 재시도할 수 있습니다.
+3. Step 2가 **샘플 config 예시값**인 `gpt-5.2-chat`을 호출하고 파일을 만든 뒤
+  같은 모델의 Self-QA를 재시도할 수 있습니다.
 4. Step 3-4가 포맷된 결과와 3-row Parquet artifact를 만듭니다.
 5. dry run이면서 3-task sample이므로 Step 5를 건너뜁니다.
-6. Step 6의 기본 report 경로는 `gpt-5.6-sol`을 `reasoning=max`로 순차적으로
-  최대 2회 호출합니다. 1.05M context는 별도 요청 설정이 아니라 deployment
-  capability입니다. 완료된 호출은 과금될 수 있습니다. 설정, 호출, 파싱,
-  route 검증 중 하나라도 실패하면 즉시 model-free report를 만들고 다른 모델
-  fallback은 호출하지 않습니다. 게시 전에 report identity 검증을 반드시
-  통과해야 합니다.
+6. Step 6의 **현재 프로덕션 report 기본값**은 `gpt-5.6-sol`이며,
+  `reasoning=max`로 순차적으로 최대 2회 호출합니다. 1.05M context는 별도 요청
+  설정이 아니라 deployment capability입니다. 완료된 호출은 과금될 수
+  있습니다. 설정, 호출, 파싱, route 검증 중 하나라도 실패하면 즉시
+  model-free report를 만들고 다른 모델 fallback은 호출하지 않습니다. 게시
+  전에 report identity 검증을 반드시 통과해야 합니다.
 7. `dry_run: true`이므로 Step 7과 결과 PR을 건너뜁니다.
 
 인증된 batch job이 마지막 `always()` 단계에 도달하면
@@ -218,7 +223,7 @@ threshold 아래에서 재시도합니다. inference-time reflection gate입니�
 | Sector heatmap | 9개 산업의 성능 차이 |
 | Experiment detail | 220개 태스크 상태, 파일, prompt, retry, error |
 | Grading analysis | 근거가 연결된 rubric 결과와 judge metadata |
-| RealWorks Field Notes | 근거의 한계를 명시한 시간순 엔지니어링 의사결정 |
+| [RealWorks Field Notes](https://hyeonsangjeon.github.io/gdpval-realworks/notes) | 근거의 한계를 명시한 시간순 엔지니어링 의사결정 |
 
 구현 상세는 [`src/README_KR.md`](src/README_KR.md)에 있습니다.
 

--- a/scripts/__tests__/field-notes.test.mjs
+++ b/scripts/__tests__/field-notes.test.mjs
@@ -165,7 +165,8 @@ test('journal article resolves visuals from reports and links to source details'
   assert.match(article, /useReports\(usesReportBenchmark\)/)
   assert.match(article, /<JournalArticleContent key=\{slug \?\? 'missing'\} slug=\{slug\} \/>/)
   assert.match(article, /generated\/reports-index\.json/)
-  assert.match(article, /getExperimentHref\(row\.shortId\)/)
+  assert.match(article, /const href = getExperimentHref\(experimentId\)/)
+  assert.match(article, /experimentId=\{row\.shortId\}/)
   assert.match(article, /promptBenchmark=\{readyPromptBenchmark\?\.rows\}/)
   assert.match(article, /promptBenchmark\?\.status === 'invalid'/)
   assert.match(reportsHook, /new AbortController\(\)/)
@@ -180,4 +181,25 @@ test('comparison chart preserves mobile labels and reduced-motion behavior', asy
   assert.match(chart, /interval=\{chart\.kind === 'dual' \? 0 : undefined\}/)
   assert.match(chart, /const reduceMotion = useReducedMotion\(\)/)
   assert.equal(chart.match(/isAnimationActive=\{!reduceMotion\}/g)?.length, 4)
+})
+
+test('legacy journal routes and the public exp026 detail link stay canonical', async () => {
+  const [app, article, links] = await Promise.all([
+    readSource('src/App.tsx'),
+    readSource('src/pages/JournalArticle.tsx'),
+    importTypeScriptModule('src/data/journalLinks.ts'),
+  ])
+
+  assert.match(app, /pathname: slug \? `\/notes\/\$\{slug\}` : '\/notes'/)
+  assert.match(app, /<Route path="\/journal\/:slug" element=\{<LegacyJournalRedirect \/>\} \/>/)
+  assert.equal(
+    links.getExperimentHref('exp026'),
+    'https://hyeonsangjeon.github.io/gdpval-realworks/experiments/exp026',
+  )
+  assert.equal(links.isExternalExperimentHref(links.getExperimentHref('exp026')), true)
+  assert.match(
+    article,
+    /function ExperimentDetailLink[\s\S]*target="_blank" rel="noopener noreferrer"/,
+  )
+  assert.match(article, /<ExperimentDetailLink[\s\S]*experimentId="exp026"[\s\S]*label="exp026 상세"/)
 })

--- a/scripts/__tests__/onboarding-contract.test.mjs
+++ b/scripts/__tests__/onboarding-contract.test.mjs
@@ -140,6 +140,10 @@ test('first-screen routes stay complete and fork-relative', async () => {
     assert.ok(links.some((link) => /docs\/first-experiment(?:_KR)?\.md#7-/.test(link)))
     assert.doesNotMatch(section, /github\.com\/hyeonsangjeon\/gdpval-realworks\/actions/)
   }
+  assert.match(rootSections[0], /\$0 · no model calls/)
+  assert.match(rootSections[0], /Paid API usage · model calls and remote writes/)
+  assert.match(rootSections[1], /\$0 · 모델 호출 없음/)
+  assert.match(rootSections[1], /유료 API 사용 · 모델 호출과 원격 쓰기/)
 
   const runnerSections = [
     extractSection(runnerEnglish, '## Start here'),
@@ -163,6 +167,41 @@ test('first-screen routes stay complete and fork-relative', async () => {
   )
   assert.equal(rootAction.href, 'https://github.com/fork-owner/gdpval-realworks/actions/workflows/batch-run.yml')
   assert.equal(runnerAction.href, rootAction.href)
+})
+
+test('root docs keep agentic preflight not_run and label model roles', async () => {
+  const [rootEnglish, rootKorean, preflightText] = await Promise.all([
+    readRepoFile('README.md'),
+    readRepoFile('README_KR.md'),
+    readRepoFile('.github/workflows/agentic-sandbox-preflight.yml'),
+  ])
+  const preflight = parse(preflightText)
+  assert.deepEqual(
+    preflight.jobs['model-free-preflight']['runs-on'],
+    ['self-hosted', 'linux', 'x64', 'agentic-sandbox'],
+  )
+
+  const operationalSections = [
+    extractSection(rootEnglish, '## Operational controls'),
+    extractSection(rootKorean, '## 운영 통제'),
+  ]
+  for (const section of operationalSections) {
+    assert.match(section, /not_run/)
+    assert.match(section, /self-hosted, linux, x64, agentic-sandbox/)
+    assert.match(section, /no matching runner exists|일치하는 러너가 없어/)
+    assert.match(section, /not_run[^\n]*failed[^\n]*verified/)
+  }
+
+  const cloudSections = [
+    extractSection(rootEnglish, '## First cloud experiment'),
+    extractSection(rootKorean, '## 첫 클라우드 실험'),
+  ]
+  assert.match(cloudSections[0], /gpt-5\.2-chat[^\n]*sample configuration value/)
+  assert.match(cloudSections[0], /current production report default[^\n]*gpt-5\.6-sol/)
+  assert.match(cloudSections[1], /샘플 config 예시값[^\n]*gpt-5\.2-chat/)
+  assert.match(cloudSections[1], /현재 프로덕션 report 기본값[^\n]*gpt-5\.6-sol/)
+  assert.match(rootEnglish, /\[RealWorks Field Notes\]\(https:\/\/hyeonsangjeon\.github\.io\/gdpval-realworks\/notes\)/)
+  assert.match(rootKorean, /\[RealWorks Field Notes\]\(https:\/\/hyeonsangjeon\.github\.io\/gdpval-realworks\/notes\)/)
 })
 
 test('fresh dashboard verification is self-preparing and credential-free', async () => {

--- a/scripts/__tests__/perception-note.browser.mjs
+++ b/scripts/__tests__/perception-note.browser.mjs
@@ -63,6 +63,12 @@ async function main() {
       await page.getByRole('navigation', { name: 'perception 단계별 실험 상세' }).getByRole('link').allTextContents(),
       ['exp011packages25/25QA 5.80 · 0 path', 'exp012audio*24/25QA 5.79 · 1 path', 'exp026audio+video23/25QA 6.00 · 2 path'],
     )
+    const exp026Links = page.locator('a[href="https://hyeonsangjeon.github.io/gdpval-realworks/experiments/exp026"]')
+    assert.ok(await exp026Links.count() >= 3)
+    for (const link of await exp026Links.all()) {
+      assert.equal(await link.getAttribute('target'), '_blank')
+      assert.equal(await link.getAttribute('rel'), 'noopener noreferrer')
+    }
     for (const title of chapterTitles) {
       assert.equal(await page.getByRole('heading', { name: title, exact: true }).count(), 1)
     }

--- a/scripts/__tests__/runtime-note.browser.mjs
+++ b/scripts/__tests__/runtime-note.browser.mjs
@@ -52,6 +52,12 @@ async function main() {
     const source = page.getByRole('complementary', { name: 'Runtime evidence source' })
     await source.waitFor()
     assert.equal(await source.locator('a').count(), 11)
+    const exp026Links = page.locator('a[href="https://hyeonsangjeon.github.io/gdpval-realworks/experiments/exp026"]')
+    assert.ok(await exp026Links.count() >= 2)
+    for (const link of await exp026Links.all()) {
+      assert.equal(await link.getAttribute('target'), '_blank')
+      assert.equal(await link.getAttribute('rel'), 'noopener noreferrer')
+    }
     assert.equal(await page.getByRole('heading', { name: '같은 220개, 서로 다른 시간', exact: true }).count(), 1)
     assert.equal(await page.getByRole('img', { name: /330분 step hard timeout/ }).count(), 1)
     assert.deepEqual(

--- a/scripts/__tests__/success-note.browser.mjs
+++ b/scripts/__tests__/success-note.browser.mjs
@@ -54,8 +54,9 @@ async function main() {
       await released
       await route.fulfill({ json: successNote })
     })
-    await page.goto(`${base}/notes/what-does-success-mean`)
+    await page.goto(`${base}/journal/what-does-success-mean?source=legacy`)
     await intercepted
+    await page.waitForURL('**/notes/what-does-success-mean?source=legacy')
     await page.getByRole('status').waitFor()
     await assertSuccessHidden(page)
     releaseSuccess()
@@ -64,6 +65,13 @@ async function main() {
     await page.unroute('**/generated/success-note.json*')
 
     assert.equal(await source.locator('a').count(), 7)
+    const exp026Detail = source.getByRole('link', { name: 'exp026 상세', exact: true })
+    assert.equal(
+      await exp026Detail.getAttribute('href'),
+      'https://hyeonsangjeon.github.io/gdpval-realworks/experiments/exp026',
+    )
+    assert.equal(await exp026Detail.getAttribute('target'), '_blank')
+    assert.equal(await exp026Detail.getAttribute('rel'), 'noopener noreferrer')
     for (const title of chapterTitles) {
       assert.equal(await page.getByRole('heading', { name: title, exact: true }).count(), 1)
     }

--- a/src/components/notes/NoteHeroVisual.tsx
+++ b/src/components/notes/NoteHeroVisual.tsx
@@ -1,7 +1,7 @@
 import { motion, useReducedMotion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import type { JournalHero } from '../../data/journal'
-import { getExperimentHref } from '../../data/journalLinks'
+import { getExperimentHref, isExternalExperimentHref } from '../../data/journalLinks'
 import type { PromptComplexityBenchmarkRow } from '../../lib/promptComplexityBenchmark'
 import type { RuntimeNoteBenchmarkSelection } from '../../lib/runtimeNoteBenchmark'
 import type { IntegrityNoteSelection } from '../../lib/integrityNoteBenchmark'
@@ -424,12 +424,21 @@ function MobileVisualSummary({
         <div className="font-mono text-[11px] text-dash-text-secondary mb-5">CONFIGURED PATHS · OBSERVED ROW</div>
         <nav className="grid grid-cols-3 gap-2" aria-label="perception 단계별 실험 상세">
           {perceptionBenchmark.rows.map((row, index) => (
-            <Link key={row.shortId} to={getExperimentHref(row.shortId)} className="min-w-0 border border-dash-border bg-dash-card px-2 py-4 text-center" aria-label={`${row.shortId} 실험 상세 보기`}>
-              <div className="font-mono text-xs font-semibold text-dash-heading">{row.shortId}</div>
-              <div className="mt-1 min-h-8 text-[10px]/4 text-dash-text-secondary break-words">{stageLabels[index]}</div>
-              <div className="mt-3 font-mono text-xl font-semibold text-dash-heading">{row.information.success}/{row.information.total}</div>
-              <div className="mt-2 text-[10px]/4 text-dash-text-secondary">QA {row.information.avgQaScore.toFixed(2)} · {row.perceptionPaths.length} path</div>
-            </Link>
+            isExternalExperimentHref(getExperimentHref(row.shortId)) ? (
+              <a key={row.shortId} href={getExperimentHref(row.shortId)} target="_blank" rel="noopener noreferrer" className="min-w-0 border border-dash-border bg-dash-card px-2 py-4 text-center" aria-label={`${row.shortId} 실험 상세 보기`}>
+                <div className="font-mono text-xs font-semibold text-dash-heading">{row.shortId}</div>
+                <div className="mt-1 min-h-8 text-[10px]/4 text-dash-text-secondary break-words">{stageLabels[index]}</div>
+                <div className="mt-3 font-mono text-xl font-semibold text-dash-heading">{row.information.success}/{row.information.total}</div>
+                <div className="mt-2 text-[10px]/4 text-dash-text-secondary">QA {row.information.avgQaScore.toFixed(2)} · {row.perceptionPaths.length} path</div>
+              </a>
+            ) : (
+              <Link key={row.shortId} to={getExperimentHref(row.shortId)} className="min-w-0 border border-dash-border bg-dash-card px-2 py-4 text-center" aria-label={`${row.shortId} 실험 상세 보기`}>
+                <div className="font-mono text-xs font-semibold text-dash-heading">{row.shortId}</div>
+                <div className="mt-1 min-h-8 text-[10px]/4 text-dash-text-secondary break-words">{stageLabels[index]}</div>
+                <div className="mt-3 font-mono text-xl font-semibold text-dash-heading">{row.information.success}/{row.information.total}</div>
+                <div className="mt-2 text-[10px]/4 text-dash-text-secondary">QA {row.information.avgQaScore.toFixed(2)} · {row.perceptionPaths.length} path</div>
+              </Link>
+            )
           ))}
         </nav>
         <p className="mt-5 text-center text-xs/[1.7] text-dash-text-secondary">configured path 수와 Information success는 인과 관계가 아니다.</p>

--- a/src/pages/JournalArticle.tsx
+++ b/src/pages/JournalArticle.tsx
@@ -452,6 +452,27 @@ function resolveSuccessArticle(article: JournalArticleData, benchmark: ReadySucc
   }
 }
 
+function ExperimentDetailLink({
+  experimentId,
+  label,
+  className,
+}: {
+  experimentId: string
+  label: string
+  className: string
+}) {
+  const href = getExperimentHref(experimentId)
+  return isExternalExperimentHref(href) ? (
+    <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+      {label} <ExternalLink className="h-3 w-3" />
+    </a>
+  ) : (
+    <Link to={href} className={className}>
+      {label} <ArrowRight className="h-3 w-3" />
+    </Link>
+  )
+}
+
 function BenchmarkDataSource({ rows, generated }: { rows: PromptComplexityBenchmarkRow[]; generated: string }) {
   return (
     <aside className="mb-10 border-y border-dash-border py-4 text-[11px]/[1.7] text-dash-text-secondary" aria-label="Benchmark data source">
@@ -466,13 +487,12 @@ function BenchmarkDataSource({ rows, generated }: { rows: PromptComplexityBenchm
           reports-index.json <ExternalLink className="h-3 w-3" />
         </a>
         {rows.map((row) => (
-          <Link
+          <ExperimentDetailLink
             key={row.shortId}
-            to={getExperimentHref(row.shortId)}
+            experimentId={row.shortId}
+            label={`${row.shortId} 상세`}
             className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400"
-          >
-            {row.shortId} 상세 <ArrowRight className="h-3 w-3" />
-          </Link>
+          />
         ))}
       </div>
       <div className="mt-2 text-dash-text-muted">
@@ -512,9 +532,12 @@ function RuntimeDataSource({ benchmark }: { benchmark: ReadyRuntimeBenchmark }) 
       </div>
       <div className="mt-3 flex flex-wrap gap-x-3 gap-y-2">
         {benchmark.rows.map((row) => (
-          <Link key={row.shortId} to={getExperimentHref(row.shortId)} className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400">
-            {row.shortId} · {row.executionMode} · {row.duration} <ArrowRight className="h-3 w-3" />
-          </Link>
+          <ExperimentDetailLink
+            key={row.shortId}
+            experimentId={row.shortId}
+            label={`${row.shortId} · ${row.executionMode} · ${row.duration}`}
+            className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400"
+          />
         ))}
       </div>
       <div className="mt-3 text-dash-text-muted">
@@ -552,9 +575,12 @@ function IntegrityDataSource({ benchmark }: { benchmark: ReadyIntegrityBenchmark
       </div>
       <div className="mt-3 flex flex-wrap gap-x-3 gap-y-2">
         {benchmark.rows.map((row) => (
-          <Link key={row.shortId} to={getExperimentHref(row.shortId)} className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400">
-            {row.shortId} · {row.successCount}/{row.totalTasks} · {row.successRatePct.toFixed(1)}% <ArrowRight className="h-3 w-3" />
-          </Link>
+          <ExperimentDetailLink
+            key={row.shortId}
+            experimentId={row.shortId}
+            label={`${row.shortId} · ${row.successCount}/${row.totalTasks} · ${row.successRatePct.toFixed(1)}%`}
+            className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400"
+          />
         ))}
       </div>
       <div className="mt-3 text-dash-text-muted">
@@ -591,9 +617,12 @@ function PerceptionDataSource({ benchmark }: { benchmark: ReadyPerceptionBenchma
       </div>
       <div className="mt-3 flex flex-wrap gap-x-3 gap-y-2">
         {benchmark.rows.map((row) => (
-          <Link key={row.shortId} to={getExperimentHref(row.shortId)} className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400">
-            {row.shortId} · {row.information.success}/{row.information.total} · QA {row.information.avgQaScore.toFixed(2)} <ArrowRight className="h-3 w-3" />
-          </Link>
+          <ExperimentDetailLink
+            key={row.shortId}
+            experimentId={row.shortId}
+            label={`${row.shortId} · ${row.information.success}/${row.information.total} · QA ${row.information.avgQaScore.toFixed(2)}`}
+            className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400"
+          />
         ))}
       </div>
       <div className="mt-3 text-dash-text-muted">
@@ -628,9 +657,11 @@ function SuccessDataSource({ benchmark }: { benchmark: ReadySuccessBenchmark }) 
         <a href={`${repo}/tree/main/${benchmark.sources.grades}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400">
           grade inventory <ExternalLink className="h-3 w-3" />
         </a>
-        <Link to={getExperimentHref('exp026')} className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400">
-          exp026 상세 <ArrowRight className="h-3 w-3" />
-        </Link>
+        <ExperimentDetailLink
+          experimentId="exp026"
+          label="exp026 상세"
+          className="inline-flex items-center gap-1 font-mono hover:text-emerald-600 dark:hover:text-emerald-400"
+        />
       </div>
       <div className="mt-3 text-dash-text-muted">
         report는 self-assessed pre-grading이다. artifact는 HF revision {benchmark.huggingface.revision.slice(0, 7)}와 SHA-256으로 고정했으며, 구조 검사는 외부 금융 품질 평가를 대신하지 않는다.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -3,7 +3,7 @@
 - Updated: 2026-08-07
 - Status: Field Notes rescue reconciled against current `main`; README facts and
   public experiment links corrected and validated; `first-reviewer` approved;
-  single PR pending creation
+  single PR #162 open
 
 ## Task
 
@@ -74,11 +74,11 @@
 
 - Working branch: `feat/field-notes-readme-facts`.
 - Base: `origin/main@a6593c2f0b9888a49a90fb96210b0d61b48f6332`.
-- One pull request will contain the current Field Notes link correction,
-  bilingual README update, regression contracts, changelog, and this record
-  after the required independent review approves the complete diff.
+- PR [#162](https://github.com/hyeonsangjeon/gdpval-realworks/pull/162) is open
+  with the Field Notes link correction, bilingual README update, regression
+  contracts, changelog, and this completion record in one review unit.
 
 ## Remaining Work
 
-- Create the single requested pull request. Do not merge or create a second
+- PR #162 awaits the owner's merge decision. Do not merge it or create a second
   completion PR unless the owner explicitly requests it.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -15,10 +15,9 @@
 
 ## Result
 
-- Created and checksum-verified the external physical backup at
-  `/ai-work/copilot/.gdpval-realworks-backups/20260807-field-notes-pre-s1`:
-  16,173 regular files, 27 symlinks, and 521,099,777 bytes. Its Git status
-  fingerprint is the pre-task 1,235-line SHA-256
+- Created and checksum-verified an external physical backup outside the
+  repository: 16,173 regular files, 27 symlinks, and 521,099,777 bytes. Its Git
+  status fingerprint is the pre-task 1,235-line SHA-256
   `8e96ad2cfdaceb05d61c978ad786df13c3647b8ae810771344dd3430314d91ce`.
 - Reconciled all seven requested paths and found the supplied absence premise
   was no longer true: every path is tracked on current `main`, with Field Notes
@@ -45,8 +44,8 @@
     remote-write behavior;
   - RealWorks Field Notes links to the deployed `/notes` view.
 - The primary worktree was not modified by this task. Relative to the physical
-  backup, its only new status entry is the user-created
-  `tasks/0807_friday/task.md` supplied during the session.
+  backup, its only new status entry is one user-created private task spec
+  supplied during the session.
 
 ## Verification
 

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,90 +1,85 @@
 # Latest Task Result
 
-- Updated: 2026-08-06
-- Status: Phase 1D-A offline Python wheel broker candidate implemented,
-  validated, and still disconnected from production
+- Updated: 2026-08-07
+- Status: Field Notes rescue reconciled against current `main`; README facts and
+  public experiment links corrected and validated; `first-reviewer` approved;
+  single PR pending creation
 
 ## Task
 
-- Continue Agentic Sandbox V2 toward installable external packages and Linux
-  execution without weakening containment, reproducibility, or fail-closed
-  behavior.
-- Deliver the smallest model-free package slice that can be proved on this
-  host, while deferring command execution that lacks enforceable isolation.
-- Preserve the intentional dirty primary checkout byte-for-byte by working from
-  clean `origin/main@fa76d24973e6` in a separate worktree.
+- Back up the only three-week primary worktree copy before any Git mutation.
+- Surgically rescue seven requested Field Notes assets onto
+  `origin/main@a6593c2` without importing the primary worktree's other changes.
+- Correct English and Korean root README claims about the unexecuted agentic
+  preflight, model roles, Start here cost boundaries, and Field Notes status.
 
 ## Result
 
-- Added a foundation-only snapshot schema and runtime policy for at most eight
-  exact, canonical, dependency-free `py3-none-any` wheels on Linux amd64 and the
-  active Python major/minor.
-- Added strict artifact admission for size/hash, archive paths and controls,
-  RECORD inventory and hashes, METADATA identity and `Requires-Python`, exact
-  WHEEL headers, aggregate limits, collisions, links, executable-mode entries,
-  `.data`, `.pth`, `.egg-link`, `.pyc`, and startup hooks.
-- Added stateless lock resolution. A returned digest can be activated after a
-  broker restart without hidden resolver state.
-- Added deterministic stdlib wheel extraction with no pip, installer
-  subprocess, package index, or network path. Activation uses private
-  descriptor-anchored staging, independent expected inventory, canonical
-  receipt bytes, mode sealing, and atomic rename.
-- Added process-shared nonblocking leases, shared-root global state and quota
-  validation, canonical receipt baselines, bounded descriptor replay and
-  cleanup, orphan recovery, last-lease cleanup, and fail-closed root/lease/
-  content/mode/size drift handling.
-- Added a dispatcher candidate that permits only capabilities query, package
-  resolve, and package activation. Command execution, workspace mutation,
-  browser, public verification, and finalization return
-  `capability_unavailable`.
-- Confirmed the candidate is not wired into executor, Step 2, the Agentic V2
-  runner, experiments, workflows, grading, upload, or publication.
-- Kept the implementation under `sandbox/v2/`, outside the existing
-  `COPY core` image input, core-tree identity, Phase 1B/1C build allowlist, and
-  embedded-image manifest. Tracked Dockerignore rules also exclude every
-  Phase 1D-A artifact from existing publication build contexts.
+- Created and checksum-verified the external physical backup at
+  `/ai-work/copilot/.gdpval-realworks-backups/20260807-field-notes-pre-s1`:
+  16,173 regular files, 27 symlinks, and 521,099,777 bytes. Its Git status
+  fingerprint is the pre-task 1,235-line SHA-256
+  `8e96ad2cfdaceb05d61c978ad786df13c3647b8ae810771344dd3430314d91ce`.
+- Reconciled all seven requested paths and found the supplied absence premise
+  was no longer true: every path is tracked on current `main`, with Field Notes
+  history from initial commit `8ac9c20` through later evidence-backed fixes.
+- Five primary filesystem assets were exact older Git blobs, `Journal.tsx` was
+  already identical to `main`, and the missing filesystem test had a newer
+  committed successor. The only unique `journal.ts` blob was a stale
+  intermediate that would remove the prompt-complexity note and later runtime,
+  integrity, perception, and success evidence/citation contracts. No stale blob
+  was copied over current `main`.
+- The clean branch keeps all seven canonical paths as ordinary tracked files,
+  resolving the intended final file set without changing the primary
+  index/worktree D/?? state.
+- Fixed all public exp026 detail links in Field Notes evidence and mobile cards
+  to use
+  `https://hyeonsangjeon.github.io/gdpval-realworks/experiments/exp026` with
+  `target="_blank" rel="noopener noreferrer"`.
+- Corrected both root READMEs:
+  - the self-hosted agentic preflight is defined but never run and its
+    containment evidence remains `not_run`;
+  - `gpt-5.2-chat` is labeled as the sample config value and `gpt-5.6-sol` as
+    the current production report default;
+  - every Start here route identifies $0/no-model inspection or paid model and
+    remote-write behavior;
+  - RealWorks Field Notes links to the deployed `/notes` view.
+- The primary worktree was not modified by this task. Relative to the physical
+  backup, its only new status entry is the user-created
+  `tasks/0807_friday/task.md` supplied during the session.
 
 ## Verification
 
-- Focused Phase 1D-A adversarial suite: 75 passed.
-- Agentic V2 contract, foundation, compatibility, candidate verifier, Phase 1B
-  static/contract/OCI/supply-chain, and Phase 1C license regressions: 644
-  passed.
-- Ruff, `py_compile`, VS Code diagnostics, and `git diff --check`: passed.
-- Credential-free backend: 3,001 passed, 6 skipped, and 45 integration tests
-  deselected. Three unrelated environment failures remain: installed
-  `openai==2.45.0`, `azure-core==1.39.0`, and `azure-ai-projects==1.0.0` do not
-  match repository pins 2.46.0/1.41.0/2.3.0, and `pdfplumber` is absent. The
-  failing tests and requirements are unchanged from `origin/main`.
-- Independent security and code reviews returned `APPROVE` with no blocking
-  findings for this foundation-only candidate.
-- Local implementation and executable validation used no model call, package
-  index, external network, cloud credential, workflow, grading, artifact
-  upload/publication, or paid operation.
-- Shipment used authenticated Git and GitHub PR operations only; no CI workflow
-  or artifact publication ran.
+- Focused Field Notes and bilingual onboarding contracts: 21 passed.
+- Self-preparing aggregate suite: 98 passed, 1 expected skip because Ruby is
+  unavailable locally.
+- `npm run build`: passed with 2,783 transformed modules.
+- Four Field Notes Chromium suites passed inside the pinned
+  `mcr.microsoft.com/playwright:v1.61.1-noble` image. They verify:
+  - `/journal/:slug` redirects at runtime to `/notes/:slug` while preserving
+    query parameters;
+  - all visible exp026 links use the public URL and exact safe new-tab
+    attributes;
+  - 390px and 1,280px layouts have zero horizontal overflow;
+  - reduced-motion charts remain static and evidence failure states fail closed.
+- The host Playwright binary itself could not start because `libnspr4.so` is
+  absent; the matching container supplied the browser runtime without changing
+  the host.
+- `git diff --check`: passed.
+- Independent `first-reviewer` review: `APPROVE`, with no blocking findings.
+- No model, grading, cloud credential, workflow dispatch, Hugging Face write,
+  or paid operation ran. Aggregation made unauthenticated read-only requests to
+  23 public report datasets.
 
 ## Shipment
 
-- Reviewed branch head:
-  `15138d88678dfaf08cb478855c6f395a90e32b51`.
-- PR [#160](https://github.com/hyeonsangjeon/gdpval-realworks/pull/160)
-  reached `MERGED` at `2026-08-06T14:05:35Z` as squash commit
-  `4dbb23c9abc3662db984ca8358887184eac4092f`.
-- GitHub reported the PR `MERGEABLE` and `CLEAN`. The changed paths did not
-  create an automatic PR or post-merge workflow run; local executable evidence
-  and independent reviews supplied the acceptance evidence.
+- Working branch: `feat/field-notes-readme-facts`.
+- Base: `origin/main@a6593c2f0b9888a49a90fb96210b0d61b48f6332`.
+- One pull request will contain the current Field Notes link correction,
+  bilingual README update, regression contracts, changelog, and this record
+  after the required independent review approves the complete diff.
 
 ## Remaining Work
 
-- Production activation remains disabled. The candidate is not connected to a
-  model loop, experiment, workflow, grader, uploader, or public artifact path.
-- `exec_run` remains blocked. The local Bubblewrap probe cannot create the
-  required user namespace, so arbitrary Linux execution has no enforceable
-  containment proof on this host.
-- npm, Debian/apt, live indexes, URL/VCS requirements, sdists, and editable
-  installs remain unsupported.
-- Package admission SBOM, license, CVE, provenance, signature, OS-level network
-  containment, and crash durability remain `not_run` or `not_claimed`.
-- A later production phase must add approved supply-chain evidence and a proven
-  containment substrate before connecting package environments to execution.
+- Create the single requested pull request. Do not merge or create a second
+  completion PR unless the owner explicitly requests it.


### PR DESCRIPTION
## Summary
- reconcile the seven requested Field Notes assets against current `main` after creating and checksum-verifying an external physical backup of the primary worktree
- preserve the evolved evidence-backed `main` versions instead of overwriting them with July 15-16 historical blobs or a stale intermediate `journal.ts`
- route every public exp026 Field Notes link to the deployed detail URL with `target="_blank" rel="noopener noreferrer"`
- correct EN/KR root README facts for the never-run self-hosted preflight (`not_run`), sample vs production model roles, Start here cost/model boundaries, and the deployed `/notes` view

## Forensic reconciliation
- all seven requested paths are already tracked on `origin/main@a6593c2`
- five primary filesystem assets exactly match older committed blobs
- `Journal.tsx` already matches current main
- the missing filesystem test has a newer committed successor
- the only unique primary `journal.ts` snapshot would remove later notes, citations, and evidence selectors, so it was intentionally not copied
- the primary worktree index/filesystem state, all three stashes, and `hyeonsangjeon-review-handoff-context` remain untouched

## Validation
- focused Field Notes/onboarding contracts: 21 passed
- self-preparing aggregate suite: 98 passed, 1 expected Ruby skip
- `npm run build`: passed, 2,783 modules transformed
- four Field Notes Playwright suites passed in `mcr.microsoft.com/playwright:v1.61.1-noble`
  - runtime `/journal/:slug` redirect preserves query parameters
  - 390px and 1280px horizontal overflow: zero
  - exact public exp026 `href`, `target`, and `rel`
- `git diff --check` and VS Code diagnostics: clean
- independent `first-reviewer`: APPROVE

## Cost and remote boundaries
- no model, grading, cloud credential, workflow dispatch, Hugging Face write, or paid operation
- aggregation made unauthenticated read-only public report requests only