### PR TITLE
docs(readme): clarify hosted containment evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Changed
+- **Root README containment evidence split** - update the English and Korean
+  operational-control tables after PR #163 without conflating two separate
+  evidence states. The dedicated
+  `[self-hosted, linux, x64, agentic-sandbox]` preflight workflow remains
+  unexecuted and `not_run` because no matching runner exists. Separately, the
+  GitHub-hosted Docker-control measurement is now identified as `verified` for
+  all eight checks, with run `31193818481`, PR #163 merge `4b1bff35`, and the
+  exact containment-report SHA-256. Both READMEs retain the
+  `not_run` / `failed` / `verified` ladder and explicitly state that this is not
+  proof of arbitrary execution isolation: `exec_run` and the aggregate gate
+  remain `blocked`, with capability, CVE, license, microVM, OCI, provenance,
+  SBOM, and signature evidence still unmeasured. Validation passes all 12
+  bilingual onboarding contracts, the self-preparing aggregate suite with 98
+  passes and one expected Ruby skip, the production build with 2,783 modules,
+  diagnostics, and diff checks. No model, grading, cloud credential, workflow
+  dispatch, Hugging Face write, or paid operation ran; aggregation made only
+  unauthenticated read-only public report requests.
 - **Field Notes rescue reconciliation and onboarding truth labels** - preserve a
   physical copy of the full three-week primary worktree before Git mutation,
   then reconcile the seven requested Field Notes paths against

--- a/README.md
+++ b/README.md
@@ -154,15 +154,19 @@ These are code-backed, path-specific controls, not a blanket security claim:
 | Configuration input | A no-credential job validates the experiment name and safely parses YAML before the credentialed job; agentic modes are rejected from the general batch path | [`batch-run.yml`](.github/workflows/batch-run.yml) |
 | Container sandbox | Sandbox runs resolve an immutable image digest across relay jobs; Docker execution disables networking and applies resource limits | [`batch-run.yml`](.github/workflows/batch-run.yml), [`sandbox_runner.py`](batch-runner/core/sandbox_runner.py) |
 | Agentic image supply chain | Manual protected-main publication requires immutable dependency locks, a digest-pinned base, runtime audit, and SBOM evidence | [`build-sandbox-image.yml`](.github/workflows/build-sandbox-image.yml) |
-| Agentic containment preflight | Defined but never run (`not_run`): the manual model-free job requires `[self-hosted, linux, x64, agentic-sandbox]`, and no matching runner exists. No containment result is established. | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
+| Agentic self-hosted preflight | Defined but never run (`not_run`): the manual model-free job requires `[self-hosted, linux, x64, agentic-sandbox]`, and no matching runner exists. This workflow itself has produced no result. | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
+| Agentic hosted containment evidence | The eight Docker controls are `verified` on GitHub-hosted `ubuntu-latest` (run [`31193818481`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/31193818481), PR #163 / merge `4b1bff35`; containment report SHA-256 `f0c4ec3cdff7d714d0db8aca58b1f5669c3958c6b6203be00095b8acb827e50e`) | [`build-sandbox-image.yml`](.github/workflows/build-sandbox-image.yml), [`sandbox/v2/README.md`](batch-runner/sandbox/v2/README.md) |
 | Dashboard publication | Pull requests aggregate, build, and run data/browser contracts; only push/manual deploy jobs receive Pages/OIDC permissions | [`deploy.yml`](.github/workflows/deploy.yml) |
 
 The default three-task smoke config uses provider-hosted `code_interpreter`.
 Docker sandbox and agentic controls apply only to their named paths. The general
 batch workflow currently rejects agentic execution before cloud credentials are
-used. The checked-in agentic workflow is a model-free preflight definition, not
-an executed proof or a paid run. Under the `not_run` / `failed` / `verified`
-evidence ladder, its containment evidence remains `not_run`.
+used. Under the `not_run` / `failed` / `verified` evidence ladder, the
+self-hosted preflight workflow remains `not_run`, while the separate hosted
+Docker-control measurement is `verified` for all eight checks. This does not
+prove arbitrary execution isolation: `exec_run` remains blocked. The aggregate
+gate also remains `blocked` because capability, CVE, license, microVM, OCI,
+provenance, SBOM, and signature evidence is still unmeasured.
 
 ---
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -134,15 +134,18 @@ Step 0-7은 실험 실행과 게시를 담당합니다. 외부 채점은 별도 
 | 설정 입력 | 인증 정보 없는 job이 실험 이름을 검사하고 YAML을 안전하게 파싱한 뒤 credential job을 시작하며, 일반 배치 경로는 agentic mode를 거부함 | [`batch-run.yml`](.github/workflows/batch-run.yml) |
 | Container sandbox | sandbox 실행은 relay 전체에 immutable image digest를 유지하며, Docker 실행은 network를 끄고 resource limit을 적용함 | [`batch-run.yml`](.github/workflows/batch-run.yml), [`sandbox_runner.py`](batch-runner/core/sandbox_runner.py) |
 | Agentic image supply chain | 수동 protected-main 게시에 immutable dependency lock, digest-pinned base, runtime audit, SBOM 근거를 요구함 | [`build-sandbox-image.yml`](.github/workflows/build-sandbox-image.yml) |
-| Agentic containment preflight | 정의돼 있으나 미실행(`not_run`): 수동 model-free job은 `[self-hosted, linux, x64, agentic-sandbox]` 러너를 요구하지만 일치하는 러너가 없어 containment 결과가 확립되지 않음 | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
+| Agentic self-hosted preflight | 정의돼 있으나 미실행(`not_run`): 수동 model-free job은 `[self-hosted, linux, x64, agentic-sandbox]` 러너를 요구하지만 일치하는 러너가 없음. 이 워크플로 자체는 결과를 만들지 못함 | [`agentic-sandbox-preflight.yml`](.github/workflows/agentic-sandbox-preflight.yml) |
+| Agentic hosted containment 근거 | GitHub-hosted `ubuntu-latest`에서 Docker 통제 8개가 모두 `verified`됨(run [`31193818481`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/31193818481), PR #163 / merge `4b1bff35`; containment report SHA-256 `f0c4ec3cdff7d714d0db8aca58b1f5669c3958c6b6203be00095b8acb827e50e`) | [`build-sandbox-image.yml`](.github/workflows/build-sandbox-image.yml), [`sandbox/v2/README.md`](batch-runner/sandbox/v2/README.md) |
 | Dashboard publication | PR에서 aggregate, build, data/browser contract를 실행하고 push/manual deploy job만 Pages/OIDC 권한을 받음 | [`deploy.yml`](.github/workflows/deploy.yml) |
 
 기본 3-task smoke는 provider-hosted `code_interpreter`를 사용합니다. Docker
 sandbox와 agentic 통제는 각각 이름이 붙은 경로에만 적용됩니다. 일반 배치
-워크플로는 cloud credential을 사용하기 전에 agentic 실행을 거부하며,
-체크인된 agentic 워크플로는 실행 근거나 유료 실행이 아니라 model-free
-preflight 정의입니다. `not_run` / `failed` / `verified` 근거 사다리에서 이
-containment 근거는 `not_run`으로 남아 있습니다.
+워크플로는 cloud credential을 사용하기 전에 agentic 실행을 거부합니다.
+`not_run` / `failed` / `verified` 근거 사다리에서 self-hosted preflight
+워크플로는 `not_run`이지만, 별도의 hosted Docker 통제 실측은 8개 항목 모두
+`verified`입니다. 이는 임의 실행 격리 증명이 아니므로 `exec_run`은 계속
+blocked입니다. capability, CVE, license, microVM, OCI, provenance, SBOM,
+signature 근거가 미측정이라 aggregate gate도 계속 `blocked`입니다.
 
 ---
 

--- a/scripts/__tests__/onboarding-contract.test.mjs
+++ b/scripts/__tests__/onboarding-contract.test.mjs
@@ -169,7 +169,7 @@ test('first-screen routes stay complete and fork-relative', async () => {
   assert.equal(runnerAction.href, rootAction.href)
 })
 
-test('root docs keep agentic preflight not_run and label model roles', async () => {
+test('root docs separate unrun preflight from verified hosted containment', async () => {
   const [rootEnglish, rootKorean, preflightText] = await Promise.all([
     readRepoFile('README.md'),
     readRepoFile('README_KR.md'),
@@ -188,8 +188,18 @@ test('root docs keep agentic preflight not_run and label model roles', async () 
   for (const section of operationalSections) {
     assert.match(section, /not_run/)
     assert.match(section, /self-hosted, linux, x64, agentic-sandbox/)
-    assert.match(section, /no matching runner exists|일치하는 러너가 없어/)
+    assert.match(section, /no matching runner exists|일치하는 러너가 없(?:어|음)/)
     assert.match(section, /not_run[^\n]*failed[^\n]*verified/)
+    assert.match(section, /31193818481/)
+    assert.match(section, /4b1bff35/)
+    assert.match(section, /f0c4ec3cdff7d714d0db8aca58b1f5669c3958c6b6203be00095b8acb827e50e/)
+    assert.match(section, /all eight checks|8개 항목 모두/)
+    assert.match(section, /exec_run[^\n]*(?:blocked|계속)/)
+    assert.match(section, /aggregate\s+gate[\s\S]{0,80}blocked/i)
+    for (const evidence of ['capability', 'CVE', 'license', 'microVM', 'OCI', 'provenance', 'SBOM', 'signature']) {
+      assert.match(section, new RegExp(evidence, 'i'))
+    }
+    assert.doesNotMatch(section, /No containment result is established|containment 근거는 `not_run`으로 남아/)
   }
 
   const cloudSections = [

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,10 +1,67 @@
 # Latest Task Result
 
 - Updated: 2026-08-08
+- Status: Root English/Korean containment documentation now separates the
+  unexecuted self-hosted preflight from verified hosted Docker controls;
+  `exec_run` and the aggregate gate remain blocked
+
+## Current Task: Root README Containment Evidence
+
+### Task
+
+- Correct the stale implication that no containment result exists after PR
+  #163, without claiming that the self-hosted preflight itself ran.
+- Keep English and Korean root README descriptions structurally parallel.
+- Preserve the evidence ladder and the blocked boundaries for arbitrary
+  execution and the aggregate gate.
+
+### Result
+
+- Split the operational-control entry into two distinct facts:
+  - the `[self-hosted, linux, x64, agentic-sandbox]` preflight remains
+    unexecuted and `not_run` because no matching runner exists;
+  - the separate GitHub-hosted Docker-control measurement is `verified` for all
+    eight checks through run `31193818481`, PR #163 / merge `4b1bff35`, and
+    containment-report SHA-256
+    `f0c4ec3cdff7d714d0db8aca58b1f5669c3958c6b6203be00095b8acb827e50e`.
+- Both READMEs state that the hosted result measures Docker control
+  effectiveness, not arbitrary execution isolation. `exec_run` remains
+  blocked.
+- Both READMEs retain aggregate gate `blocked` because capability, CVE, license,
+  microVM, OCI, provenance, SBOM, and signature evidence remains unmeasured.
+- Removed the now-false English statement that no containment result is
+  established and its Korean equivalent, while preserving the accurate
+  `not_run` status of the self-hosted workflow.
+
+### Verification
+
+- Bilingual onboarding contracts: 12 passed.
+- Self-preparing aggregate suite: 98 passed, 1 expected Ruby skip.
+- `npm run build`: passed with 2,783 transformed modules.
+- VS Code diagnostics and `git diff --check`: passed.
+- No model, grading, cloud credential, workflow dispatch, Hugging Face write,
+  or paid operation ran. Aggregation made unauthenticated read-only public
+  report requests only.
+
+### Shipment
+
+- Working branch: `docs/hosted-containment-readme`.
+- Base: `origin/main@ec8503334ca1725b3b60db9b65cb878a020cfd14`.
+- Independent `first-reviewer` verdict: `APPROVE`, with no blocking finding.
+- A single documentation follow-up PR will contain the bilingual README update,
+  regression contract, changelog entry, and this completion record.
+
+### Remaining Work
+
+- Create the follow-up PR and leave it open for the owner's merge decision; do
+  not push directly to `main` or dispatch a workflow.
+
+---
+
+## Preserved Prior Result: Hosted Containment Tier 1 (2026-08-08)
+
 - Status: GitHub-hosted Agentic Sandbox V2 containment verified 8/8; aggregate
   gate remains blocked and production execution remains disabled
-
-## Current Task: Hosted Containment Tier 1
 
 ### Task
 

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -48,13 +48,15 @@
 - Working branch: `docs/hosted-containment-readme`.
 - Base: `origin/main@ec8503334ca1725b3b60db9b65cb878a020cfd14`.
 - Independent `first-reviewer` verdict: `APPROVE`, with no blocking finding.
-- A single documentation follow-up PR will contain the bilingual README update,
-  regression contract, changelog entry, and this completion record.
+- Follow-up PR
+  [#165](https://github.com/hyeonsangjeon/gdpval-realworks/pull/165) contains
+  the bilingual README update, regression contract, changelog entry, and this
+  completion record and remains open for the owner's decision.
 
 ### Remaining Work
 
-- Create the follow-up PR and leave it open for the owner's merge decision; do
-  not push directly to `main` or dispatch a workflow.
+- The owner decides whether and when to merge PR #165. Do not push directly to
+  `main` or dispatch a workflow.
 
 ---
 


### PR DESCRIPTION
## Summary

- separate the unexecuted self-hosted preflight (`not_run`) from the GitHub-hosted Docker-control measurement (8/8 `verified`) in both root READMEs
- retain the explicit `exec_run` and aggregate-gate `blocked` boundaries and list the eight still-unmeasured evidence classes
- add bilingual regression assertions plus the required changelog and latest-task records

## Evidence

- hosted run: https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/31193818481
- implementation PR: #163 (`4b1bff35`)
- containment report SHA-256: `f0c4ec3cdff7d714d0db8aca58b1f5669c3958c6b6203be00095b8acb827e50e`

## Validation

- focused bilingual onboarding contract: 12 passed
- `npm run test:aggregate`: 98 passed, 1 expected Ruby skip
- `npm run build`: passed, 2,783 modules transformed
- VS Code diagnostics: clean
- `git diff --check`: clean
- independent `first-reviewer`: APPROVE, no blocking finding

## Boundaries

This does not claim arbitrary-execution isolation or complete Agentic Sandbox V2 readiness. `exec_run` and the aggregate gate remain blocked. No workflow was manually dispatched, and this PR is left open for the owner merge decision.