### PR TITLE
docs(task): record README containment merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,16 @@ entries land under a fresh dated heading the day they merge to `main`.
   passes and one expected Ruby skip, the production build with 2,783 modules,
   diagnostics, and diff checks. No model, grading, cloud credential, workflow
   dispatch, Hugging Face write, or paid operation ran; aggregation made only
-  unauthenticated read-only public report requests.
+  unauthenticated read-only public report requests. Independent
+  `first-reviewer` review returned `APPROVE` with no blocking findings. PR #165
+  reached `MERGED` at `2026-08-07T17:04:12Z` from reviewed head
+  `c3b2a0b4e814d8bb2c830b01162d627f1277739b` as squash merge
+  `2d82691ffb5d1911f19f996be0807d4ca037ae81`. GitHub reported the PR
+  `MERGEABLE` and `CLEAN`; automatic PR validation passed with deployment
+  skipped. Automatic post-merge main run
+  [`31200577265`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/31200577265)
+  then passed validation and Pages deployment; no workflow was manually
+  dispatched.
 - **Field Notes rescue reconciliation and onboarding truth labels** - preserve a
   physical copy of the full three-week primary worktree before Git mutation,
   then reconcile the seven requested Field Notes paths against

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -3,7 +3,7 @@
 - Updated: 2026-08-08
 - Status: Root English/Korean containment documentation now separates the
   unexecuted self-hosted preflight from verified hosted Docker controls;
-  `exec_run` and the aggregate gate remain blocked
+  merged through PR #165 while `exec_run` and the aggregate gate remain blocked
 
 ## Current Task: Root README Containment Evidence
 
@@ -45,18 +45,20 @@
 
 ### Shipment
 
-- Working branch: `docs/hosted-containment-readme`.
-- Base: `origin/main@ec8503334ca1725b3b60db9b65cb878a020cfd14`.
+- Reviewed branch head:
+  `c3b2a0b4e814d8bb2c830b01162d627f1277739b`.
 - Independent `first-reviewer` verdict: `APPROVE`, with no blocking finding.
-- Follow-up PR
-  [#165](https://github.com/hyeonsangjeon/gdpval-realworks/pull/165) contains
-  the bilingual README update, regression contract, changelog entry, and this
-  completion record and remains open for the owner's decision.
+- PR [#165](https://github.com/hyeonsangjeon/gdpval-realworks/pull/165) reached
+  `MERGED` at `2026-08-07T17:04:12Z` as squash commit
+  `2d82691ffb5d1911f19f996be0807d4ca037ae81`.
+- GitHub reported the PR `MERGEABLE` and `CLEAN`; automatic PR validation passed
+  with deployment skipped. Automatic post-merge main run
+  [`31200577265`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/31200577265)
+  passed validation and Pages deployment. No workflow was manually dispatched.
 
 ### Remaining Work
 
-- The owner decides whether and when to merge PR #165. Do not push directly to
-  `main` or dispatch a workflow.
+- No remaining shipment work is carried by this README correction record.
 
 ---
 


### PR DESCRIPTION
## Summary

- record PR #165 as squash-merged at `2d82691ffb5d1911f19f996be0807d4ca037ae81`
- replace the stale OPEN/owner-decision wording in the latest-task record
- record successful automatic PR validation and post-merge main validation/Pages deployment

## Evidence

- PR #165: https://github.com/hyeonsangjeon/gdpval-realworks/pull/165
- reviewed head: `c3b2a0b4e814d8bb2c830b01162d627f1277739b`
- PR validation: https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/31199384772 (`validate` success, `deploy` skipped)
- post-merge main run: https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/31200577265 (`validate` success, `deploy` success)

## Validation

- `git diff --check`: passed
- VS Code diagnostics: clean
- independent `first-reviewer`: APPROVE, no blocking findings

No workflow was manually dispatched. This completion-record PR is left open for the owner merge decision.