### PR TITLE
docs(policy): stop recursive completion PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,11 +5,24 @@ CI/CD, or remote project state (including PR merges, deployments, and workflow
 runs), complete all of the following before reporting the task as done:
 
 1. Update `tasks/LATEST_TASK_RESULT/README.md` so it describes the latest task's
-   current result. Replace stale status rather than accumulating an unbounded
-   history. Include the task scope, concrete outcome, verification evidence,
-   and any remaining work.
+   current result. Replace stale task status rather than accumulating an
+   unbounded history. Include the task scope, concrete outcome, verification
+   evidence, the reviewed head SHA when a review gate applies, and any
+   remaining work.
 2. Add or update the corresponding `CHANGELOG.md` entry under `[Unreleased]`
    using the repository's Keep a Changelog categories. Preserve unrelated
-   entries and user changes.
-3. Perform these documentation updates after validation and before the final
-   response. Do not declare completion while either record is stale.
+   entries and user changes. Apply the same evidence boundary described below
+   to the changelog entry.
+3. Stop both completion records at pre-merge facts. Do not record the carrying
+   PR's own merge SHA, merge time, or `OPEN` / `MERGED` state in either record.
+   Git history already holds those facts, and a record describing its own merge
+   cannot be written before that merge, so requiring it forces an unnecessary
+   follow-up PR.
+4. If an earlier entry genuinely needs a status correction, fold it into the
+   next substantive work PR. Do not open a documentation-only PR solely to
+   record that an earlier PR merged.
+5. Perform these documentation updates after validation and before the final
+   response. Do not declare completion while the task scope, outcome,
+   verification evidence, reviewed head SHA when applicable, or remaining work
+   is stale. This clarifies the evidence boundary; it does not relax the
+   completion requirements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ entries land under a fresh dated heading the day they merge to `main`.
   three-record preservation check, diagnostics, and diff checks pass. No
   application model/API call, credential, workflow dispatch, or paid operation
   ran; shipment is limited to authenticated Git and GitHub branch/PR writes.
+  Independent `first-reviewer` review approved substantive head
+  `e800734576dbcc314e5646af80281114672e05dc` with no blocking findings.
 - **Root README containment evidence split** - update the English and Korean
   operational-control tables after PR #163 without conflating two separate
   evidence states. The dedicated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Changed
+- **Non-recursive repository completion records** - clarify that the latest-task
+  result and changelog entry stop at facts available before merge: task scope,
+  concrete outcome, verification evidence, the reviewed head SHA when a review
+  gate applies, and remaining work. Neither record duplicates the carrying PR's
+  own merge SHA, merge time, or `OPEN` / `MERGED` state. Git history already
+  holds those facts, and a record describing its own merge cannot be written
+  before that merge, so requiring it forces an unnecessary follow-up PR. A
+  genuine correction to an earlier entry must ride with the next substantive
+  work PR instead of creating a documentation-only merge-status PR. Existing
+  bounded-history, `[Unreleased]`, unrelated-entry preservation, validation,
+  and pre-response update requirements remain mandatory; the existing
+  historical merge records below are intentionally unchanged. The exact policy
+  contract, exact three-file scope, six-marker historical-preservation check,
+  three-record preservation check, diagnostics, and diff checks pass. No
+  application model/API call, credential, workflow dispatch, or paid operation
+  ran; shipment is limited to authenticated Git and GitHub branch/PR writes.
 - **Root README containment evidence split** - update the English and Korean
   operational-control tables after PR #163 without conflating two separate
   evidence states. The dedicated

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,11 +1,60 @@
 # Latest Task Result
 
 - Updated: 2026-08-08
+- Status: Completion records retain verified task evidence without forcing
+  documentation-only PRs that restate their carrying PR's merge status
+
+## Current Task: Non-Recursive Completion Records
+
+### Task
+
+- Clarify the repository completion requirements so the latest-task result and
+  changelog remain complete without describing the carrying PR's own merge.
+- Preserve task scope, concrete outcome, verification evidence, reviewed head
+  SHA, remaining work, bounded history, `[Unreleased]`, and unrelated entries.
+- Preserve every existing historical merge record and require genuine earlier
+  corrections to ride with the next substantive work PR.
+
+### Result
+
+- Both completion records now stop at pre-merge facts and exclude their
+  carrying PR's own merge SHA, merge time, and `OPEN` / `MERGED` state.
+- The policy states the reason directly: Git history already holds those facts,
+  while a record describing its own merge cannot be written before that merge
+  and therefore forces an unnecessary follow-up PR.
+- Earlier status corrections remain supported, but they must be folded into the
+  next substantive work PR instead of opening a documentation-only PR solely
+  for merge status.
+- Existing rigor is unchanged: scope, outcome, verification, reviewed head,
+  remaining work, bounded history, changelog category, unrelated-entry
+  preservation, and post-validation/pre-response timing all remain required.
+- The previous README containment, Hosted Tier 1, and Field Notes records are
+  preserved below, and no historical merge metadata was rewritten.
+
+### Verification
+
+- Exact-phrase completion-policy contract: passed.
+- Scope and preservation contract: exactly three changed files, all six prior
+  changelog merge markers unchanged, all three prior latest-task records
+  preserved, and no carrying-PR identity in the new completion entries.
+- VS Code diagnostics and `git diff --check`: passed.
+- No application model/API call, credential, workflow dispatch, or paid
+  operation ran; shipment is limited to authenticated Git and GitHub branch/PR
+  writes.
+
+### Remaining Work
+
+- Obtain independent `first-reviewer` approval and create the substantive PR
+  for the owner's merge decision. Do not create a later documentation-only PR
+  to record that PR's merge metadata.
+
+---
+
+## Preserved Prior Result: Root README Containment Evidence (2026-08-08)
+
 - Status: Root English/Korean containment documentation now separates the
   unexecuted self-hosted preflight from verified hosted Docker controls;
   merged through PR #165 while `exec_run` and the aggregate gate remain blocked
-
-## Current Task: Root README Containment Evidence
 
 ### Task
 

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -42,11 +42,16 @@
   operation ran; shipment is limited to authenticated Git and GitHub branch/PR
   writes.
 
+### Review Evidence
+
+- Reviewed substantive head:
+  `e800734576dbcc314e5646af80281114672e05dc`.
+- Independent `first-reviewer` verdict: `APPROVE`, with no blocking findings.
+
 ### Remaining Work
 
-- Obtain independent `first-reviewer` approval and create the substantive PR
-  for the owner's merge decision. Do not create a later documentation-only PR
-  to record that PR's merge metadata.
+- The owner decides whether and when to merge the reviewed change. Do not create
+  a later documentation-only PR to record the carrying PR's merge metadata.
 
 ---
 


### PR DESCRIPTION
## Summary

- stop `LATEST_TASK_RESULT` and `[Unreleased]` records at pre-merge evidence: scope, outcome, verification, reviewed substantive head, and remaining work
- exclude the carrying PR own merge SHA, merge time, and `OPEN` / `MERGED` state because Git history already owns those facts and self-merge records force recursive follow-up PRs
- require genuine prior-entry corrections to ride with the next substantive work PR while preserving all existing completion rigor

## Preservation

- all six existing CHANGELOG merge markers remain unchanged
- Root README containment, Hosted Tier 1, and Field Notes latest-task records remain intact
- no historical merge metadata was removed or rewritten

## Validation

- exact-phrase completion-policy contract: passed
- exact changed-file scope: 3 files
- historical marker and preserved-record contracts: passed
- current completion entries contain only reviewed substantive head `e800734576dbcc314e5646af80281114672e05dc`, with no carrying-PR identity
- VS Code diagnostics and `git diff --check`: passed
- independent `first-reviewer`: APPROVE on the substantive head and final metadata delta, no blocking findings

No application model/API call, credential, workflow dispatch, or paid operation ran. The owner controls the merge decision. After merge, the new policy intentionally forbids a documentation-only PR that merely records this PR own merge metadata.