### PR TITLE
fix(grading): exclude judge errors from scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Changed
+- **Judge errors excluded from score denominators** - make `judge_error` a
+  visible unscored outcome rather than a model failure. Runtime aggregation now
+  overrides stale producer flags, excludes judge failures from task numerators,
+  denominators, coverage, and critical metrics, and marks fully excluded tasks
+  unscored with null headline score and confidence interval. Track 2 continues
+  past complete score-excluded errors while malformed items, incomplete usage,
+  and unexcluded errors remain fatal. Output schema `1.3`, its Python validator,
+  resume identity, and the dashboard parser enforce the same cross-field
+  contract; schemas `1.0`-`1.2` remain readable with numeric historical
+  headlines. The dashboard always exposes canonical four-decimal
+  `judge_error_rate`, discloses denominator exclusion, rejects malformed 1.3
+  payloads, and renders unscored headlines as an em dash. Read-only analysis of
+  tracked payload SHA-256
+  `b5cbb6a80c776b458f99f007841a946c1c5f9ec8bf60be052500713dd6f13570`
+  found 355 judge errors; 100 score-included zeros affected 53 tasks and split
+  into 61 final-JSON parse failures, 31 empty final responses, five rate limits,
+  and three content-policy errors. A dedicated future full-run config pins all
+  220 tasks, config hash `55a7dc5cfb8023fe`, rubric commit
+  `11e7900cdcac61bc4daf59e65feb238acda98fbf`, and inference revision
+  `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`; Step 8 checks that identity
+  before its route preflight and model construction. Headline scores across the
+  schema 1.2/1.3 boundary are explicitly non-comparable without a complete
+  rerun under one identity. Validation completed 3,033 backend passes with six
+  skips and 45 integration deselections; three host-dependency failures passed
+  under exact temporary Python 3.10 dependencies. Aggregate contracts passed
+  105 with one expected Ruby skip, the production build transformed 2,783
+  modules, and Ruff, `py_compile`, diagnostics, and diff checks passed. No grade
+  payload was modified, no partial or paid regrade ran, and no credential or
+  workflow dispatch was used. Independent grading and code reviews approved
+  substantive head `3c8ab817916129dff7a33291520a1f4f2db7d048` with no
+  blocking findings.
 - **Non-recursive repository completion records** - clarify that the latest-task
   result and changelog entry stop at facts available before merge: task scope,
   concrete outcome, verification evidence, the reviewed head SHA when a review

--- a/batch-runner/core/grade_payload.py
+++ b/batch-runner/core/grade_payload.py
@@ -11,12 +11,20 @@ from jsonschema import validate
 FULL_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
+def canonical_rate(numerator: int, denominator: int) -> float:
+    """Return a nonnegative ratio rounded half-up to four decimal places."""
+    if denominator <= 0:
+        return 0.0
+    scaled = (2 * numerator * 10_000 + denominator) // (2 * denominator)
+    return scaled / 10_000
+
+
 def validate_grade_payload(payload: Any, schema: dict) -> None:
     """Validate one legacy or current grade payload before persistence."""
     validate(instance=payload, schema=schema)
     if not isinstance(payload, dict):
         return
-    current_schema = payload.get("schema_version") == "1.2"
+    current_schema = payload.get("schema_version") in {"1.2", "1.3"}
     if current_schema and "run_status" not in payload:
         raise ValueError("current grade lifecycle identity is missing")
     if "run_status" not in payload:
@@ -58,6 +66,69 @@ def validate_grade_payload(payload: Any, schema: dict) -> None:
         raise ValueError("primary grader route fingerprint mismatch")
     if not current_schema:
         return
+    if payload.get("schema_version") == "1.3":
+        tasks = payload.get("tasks")
+        if not isinstance(tasks, list):
+            raise ValueError("current grade tasks are missing")
+        judge_items = 0
+        judge_errors = 0
+        for task in tasks:
+            if not isinstance(task, dict):
+                raise ValueError("current grade task is invalid")
+            items = task.get("items")
+            if not isinstance(items, list):
+                raise ValueError("current grade task items are invalid")
+            for item in items:
+                if not isinstance(item, dict):
+                    raise ValueError("current grade item is invalid")
+                if item.get("decided_by") == "judge":
+                    judge_items += 1
+                    if item.get("verdict") == "judge_error":
+                        judge_errors += 1
+                if (
+                    item.get("verdict") == "judge_error"
+                    and item.get("score_excluded") is not True
+                ):
+                    raise ValueError(
+                        "schema 1.3 judge_error must be score_excluded"
+                    )
+            if items and all(
+                item.get("score_excluded") is True for item in items
+            ) and not task.get("error"):
+                raise ValueError("all-excluded task must be unscored")
+
+        summary = payload.get("summary")
+        if not isinstance(summary, dict):
+            raise ValueError("current grade summary is missing")
+        graded_tasks = sum(1 for task in tasks if not task.get("error"))
+        error_tasks = len(tasks) - graded_tasks
+        if (
+            summary.get("total_tasks") != len(tasks)
+            or summary.get("graded_tasks") != graded_tasks
+            or summary.get("error_tasks") != error_tasks
+        ):
+            raise ValueError("current grade task counts are inconsistent")
+        openai_compat = summary.get("openai_compat")
+        if not isinstance(openai_compat, dict):
+            raise ValueError("current grade headline summary is missing")
+        if graded_tasks == 0:
+            if (
+                openai_compat.get("avg_score_pct") is not None
+                or openai_compat.get("ci_pct") is not None
+                or openai_compat.get("perfect_count") != 0
+                or openai_compat.get("zero_count") != 0
+                or openai_compat.get("partial_count") != 0
+                or openai_compat.get("inconsistent_count") != 0
+            ):
+                raise ValueError("unscored grade must not report headline scores")
+        elif not isinstance(openai_compat.get("avg_score_pct"), (int, float)):
+            raise ValueError("scored grade headline score is missing")
+        wow = summary.get("wow")
+        if not isinstance(wow, dict):
+            raise ValueError("current grade health summary is missing")
+        expected_error_rate = canonical_rate(judge_errors, judge_items)
+        if wow.get("judge_error_rate") != expected_error_rate:
+            raise ValueError("current grade judge_error_rate is inconsistent")
     cost = summary.get("cost") if isinstance(summary, dict) else None
     if not isinstance(cost, dict):
         raise ValueError("grade cost provenance is missing")

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -1696,10 +1696,11 @@ class Grader:
         # 'did right' flag so downstream metrics (critical_item_pass_rate
         # in PR1 task 101) treat positive and negative items consistently.
         for it in items:
-            if it.score_excluded:
-                it.model_did_right = True
-            elif it.verdict == "judge_error":
+            if it.verdict == "judge_error":
+                it.score_excluded = True
                 it.model_did_right = False
+            elif it.score_excluded:
+                it.model_did_right = True
             elif (it.max_score or 0) < 0:
                 it.model_did_right = (it.verdict != "pass")
             else:
@@ -1761,6 +1762,7 @@ class Grader:
             judge_total_latency_ms=0.0,
             judge_input_tokens=0,
             judge_output_tokens=0,
+            error=("all_items_score_excluded" if items and not scored_items else None),
             pct_raw=round(pct_raw, 2),
         )
 

--- a/batch-runner/grading_configs/README.md
+++ b/batch-runner/grading_configs/README.md
@@ -6,6 +6,7 @@
 |---|---|---|---|
 | `default_v2_sol_max.yaml` | tool-calling judge | v2 (`ToolCallingJudge` via `judge.tools.read_deliverable`) | **Production default.** GPT-5.6 Sol 1M Max for main, visual, and bounded finalization; gpt-audio-1.5 for audio perception. |
 | `default_v2.yaml` | tool-calling judge | v2 | Historical gpt-5.4 medium comparison identity. Pass explicitly when reproducing that condition. |
+| `regrade_exp003_v2_mini_score_excluded.yaml` | tool-calling judge | v2 | Full-220 exp003 rerun only. Pins score-excluded semantics, the historical mini judge condition, rubric commit, inference revision, and exact task count. |
 | `default_gpt5pro.yaml` | text-extract judge | v1 (`Judge` / `BatchJudge`) | Historical mini/text-extract comparison identity. Pass explicitly only for provenance-compatible analysis. |
 
 `grade-run.yml` defaults to `default_v2_sol_max.yaml`. The 1.05M context window
@@ -33,6 +34,42 @@ saved with `run_status: diagnostic` under
 subset from sharing a cache/resume path with a complete run, and the dashboard
 aggregator only discovers root-level grade JSON. A verified complete run keeps
 the root output path and `run_status: final`.
+
+## Judge-error score boundary
+
+New grade payloads use output schema `1.3`: every `judge_error` item is excluded
+from task score numerators and denominators, while `summary.wow.judge_error_rate`
+remains required and visible in the dashboard. If every item in a task is
+excluded, the task is unscored rather than silently contributing a zero.
+
+Headline scores from schema `1.3` are not directly comparable with schemas
+`1.0`-`1.2`, where some judge failures could contribute score-included zeros.
+Historical payloads remain readable and unchanged; do not backfill or combine
+partial results across this boundary. Compare conditions only after a complete
+rerun under one grader source and one schema identity.
+
+The read-only baseline analysis used tracked payload
+`data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini.json`
+(SHA-256
+`b5cbb6a80c776b458f99f007841a946c1c5f9ec8bf60be052500713dd6f13570`).
+It contains 355 `judge_error` items. Of those, 100 were score-included zeros
+across 53 tasks: 61 `final_json_parse_failed`, 31 `empty_final_text`, five
+`RateLimitError`, and three content-policy `BadRequestError` items. The other
+255 errors were already score-excluded selection failures. This analysis did
+not mutate or partially regrade the payload.
+
+The approved future exp003 full rerun is fixed to:
+
+- config: `regrade_exp003_v2_mini_score_excluded.yaml`
+- config hash: `55a7dc5cfb8023fe`
+- rubric commit: `11e7900cdcac61bc4daf59e65feb238acda98fbf`
+- inference revision: `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`
+- expected task count: `220`
+
+Inside Step 8, the config's `rerun_identity` block is checked before its Azure
+route preflight and before model-client construction, so a partial task set or
+identity drift cannot start model grading. The workflow may authenticate and
+perform its own route checks earlier.
 
 ## Archived (no longer recommended)
 

--- a/batch-runner/grading_configs/regrade_exp003_v2_mini_score_excluded.yaml
+++ b/batch-runner/grading_configs/regrade_exp003_v2_mini_score_excluded.yaml
@@ -1,0 +1,92 @@
+schema_version: "2.0"
+config_name: "regrade_exp003_v2_mini_score_excluded"
+description: |
+  Full 220-task exp003 regrade identity for schema 1.3 score semantics.
+  This preserves the historical default_v2_mini judge settings while pinning
+  the exact experiment, task count, rubric commit, and inference revision.
+  Partial or identity-drifted runs fail before Azure route preflight.
+
+rerun_identity:
+  experiment_id: "exp003_GPT52Chat_baseline_runner_exec"
+  expected_task_count: 220
+  rubric_commit_sha: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  inference_revision: "9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f"
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.4-mini"
+  deployment: "gpt-5.4-mini"
+  api_version: "2025-04-01-preview"
+  timeout_sec: 600
+  reasoning:
+    effort: "medium"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.4"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v2"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -102,7 +102,7 @@
     {
       "if": {
         "required": ["schema_version"],
-        "properties": {"schema_version": {"const": "1.2"}}
+        "properties": {"schema_version": {"enum": ["1.2", "1.3"]}}
       },
       "then": {
         "required": [
@@ -132,6 +132,78 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "required": ["schema_version"],
+        "properties": {"schema_version": {"const": "1.3"}}
+      },
+      "then": {
+        "properties": {
+          "tasks": {
+            "items": {
+              "properties": {
+                "items": {
+                  "items": {
+                    "allOf": [
+                      {
+                        "if": {
+                          "required": ["verdict"],
+                          "properties": {"verdict": {"const": "judge_error"}}
+                        },
+                        "then": {
+                          "required": ["score_excluded"],
+                          "properties": {"score_excluded": {"const": true}}
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "summary": {
+            "properties": {
+              "openai_compat": {
+                "properties": {
+                  "avg_score_pct": {"type": ["number", "null"], "minimum": 0, "maximum": 100},
+                  "ci_pct": {"type": ["number", "null"], "minimum": 0}
+                }
+              },
+              "wow": {
+                "required": ["judge_error_rate"],
+                "properties": {
+                  "judge_error_rate": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["schema_version"],
+        "properties": {"schema_version": {"enum": ["1.0", "1.1", "1.2"]}}
+      },
+      "then": {
+        "properties": {
+          "summary": {
+            "properties": {
+              "openai_compat": {
+                "properties": {
+                  "avg_score_pct": {"type": "number"},
+                  "ci_pct": {"type": "number"}
+                }
+              }
+            }
+          }
+        }
+      }
     }
   ],
   "required": [
@@ -147,7 +219,7 @@
     "summary"
   ],
   "properties": {
-    "schema_version": {"enum": ["1.0", "1.1", "1.2"], "description": "1.0 = legacy item-level grade JSON. 1.1 = sign-aware backfill. 1.2 = current lifecycle and explicit unpriced-cost provenance."},
+    "schema_version": {"enum": ["1.0", "1.1", "1.2", "1.3"], "description": "1.0 = legacy item-level grade JSON. 1.1 = sign-aware backfill. 1.2 = lifecycle and explicit unpriced-cost provenance. 1.3 = judge_error is score-excluded and judge_error_rate remains required; headline scores are not directly comparable with 1.0-1.2."},
     "run_status": {"enum": ["partial", "final", "diagnostic"]},
     "expected_task_count": {"type": "integer", "minimum": 1},
     "expected_ordered_task_ids_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
@@ -392,8 +464,8 @@
           "type": "object",
           "required": ["avg_score_pct", "ci_pct", "perfect_count", "zero_count", "partial_count", "inconsistent_count"],
           "properties": {
-            "avg_score_pct": {"type": "number", "minimum": 0, "maximum": 100},
-            "ci_pct": {"type": "number", "minimum": 0},
+            "avg_score_pct": {"type": ["number", "null"], "minimum": 0, "maximum": 100},
+            "ci_pct": {"type": ["number", "null"], "minimum": 0},
             "perfect_count": {"type": "integer", "minimum": 0},
             "zero_count": {"type": "integer", "minimum": 0},
             "partial_count": {"type": "integer", "minimum": 0},

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -39,7 +39,7 @@ from core.grader import (
     grader_transport_options,
     resolve_tool_prompt_path,
 )
-from core.grade_payload import validate_grade_payload
+from core.grade_payload import canonical_rate, validate_grade_payload
 from core.inference_manifest import (
     canonical_task_id,
     canonicalize_inference_payload,
@@ -50,7 +50,7 @@ from core.public_error import public_provider_error_text
 from core.rubric_loader import RubricLoader
 from core.tools import ReadDeliverableError, get_renderer_fingerprint
 
-SCHEMA_VERSION = "1.2"
+SCHEMA_VERSION = "1.3"
 GRADED_BY_VERSION = "0.1.0"
 FULL_HF_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 FULL_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -469,6 +469,42 @@ def validate_grading_config(config: dict) -> None:
     if int(config.get("tpm_guard", {}).get("max_concurrent", 1)) < 1:
         raise ValueError("tpm_guard.max_concurrent must be >= 1")
 
+    rerun_identity = config.get("rerun_identity")
+    if rerun_identity is not None:
+        if schema_version != "2.0" or not isinstance(rerun_identity, dict):
+            raise ValueError("rerun_identity requires a schema 2.0 object")
+        required_identity_fields = {
+            "experiment_id",
+            "expected_task_count",
+            "rubric_commit_sha",
+            "inference_revision",
+        }
+        if set(rerun_identity) != required_identity_fields:
+            raise ValueError(
+                "rerun_identity must contain exactly experiment_id, "
+                "expected_task_count, rubric_commit_sha, and inference_revision"
+            )
+        experiment_id = rerun_identity["experiment_id"]
+        if not isinstance(experiment_id, str) or not re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", experiment_id
+        ):
+            raise ValueError("rerun_identity.experiment_id is invalid")
+        expected_task_count = rerun_identity["expected_task_count"]
+        if (
+            type(expected_task_count) is not int
+            or expected_task_count < 1
+            or expected_task_count > 220
+        ):
+            raise ValueError("rerun_identity.expected_task_count is invalid")
+        for field_name in ("rubric_commit_sha", "inference_revision"):
+            value = rerun_identity[field_name]
+            if not isinstance(value, str) or not FULL_HF_SHA_RE.fullmatch(value):
+                raise ValueError(f"rerun_identity.{field_name} is invalid")
+        if rubric["revision"] != rerun_identity["rubric_commit_sha"]:
+            raise ValueError(
+                "rubric.revision must match rerun_identity.rubric_commit_sha"
+            )
+
 
 def requires_track2_office_renderer(config: dict) -> bool:
     if config.get("schema_version") != "2.0":
@@ -545,6 +581,7 @@ def _validate_grade_resume_identity(
     renderer_fingerprint: dict[str, str] | None,
 ) -> None:
     checks = (
+        ("schema_version", existing.get("schema_version"), SCHEMA_VERSION),
         ("experiment_id", existing.get("experiment_id"), experiment_id),
         (
             "rubric.commit_sha",
@@ -592,6 +629,39 @@ def _validate_grade_resume_identity(
             raise ValueError(
                 f"Grade resume identity {state} for {field_name}: "
                 f"existing={actual!r}, current={expected!r}"
+            )
+
+
+def _validate_pinned_rerun_identity(
+    config: dict,
+    *,
+    experiment_id: str,
+    task_count: int,
+    rubric_commit_sha: str,
+    inference_revision: str | None,
+) -> None:
+    identity = config.get("rerun_identity")
+    if identity is None:
+        return
+    checks = (
+        ("experiment_id", experiment_id, identity["experiment_id"]),
+        ("task_count", task_count, identity["expected_task_count"]),
+        (
+            "rubric_commit_sha",
+            rubric_commit_sha,
+            identity["rubric_commit_sha"],
+        ),
+        (
+            "inference_revision",
+            inference_revision,
+            identity["inference_revision"],
+        ),
+    )
+    for field_name, actual, expected in checks:
+        if actual != expected:
+            raise ValueError(
+                f"pinned rerun identity mismatch for {field_name}: "
+                f"actual={actual!r}, expected={expected!r}"
             )
 
 
@@ -752,6 +822,7 @@ def filter_tasks(inference_results: dict, tasks_csv: str | None, limit: int) -> 
 def _track2_task_runtime_error(task: dict) -> str | None:
     existing_error = task.get("error")
     if existing_error and existing_error not in {
+        "all_items_score_excluded",
         "no_deliverables",
         "selection_error",
     }:
@@ -763,22 +834,11 @@ def _track2_task_runtime_error(task: dict) -> str | None:
     for item in items:
         if not isinstance(item, dict):
             return "invalid_item"
-        if item.get("verdict") != "judge_error":
-            continue
-        call_count = sum(
-            int(item.get(field, 0) or 0)
-            for field in (
-                "judge_call_count",
-                "perception_call_count",
-                "render_call_count",
-            )
-        )
-        evidence = str(item.get("evidence") or "")
-        if call_count > 0 or evidence.startswith((
-            "required_visual_",
-            "task_visual_budget_exceeded",
-        )):
-            return "judge_error"
+        if (
+            item.get("verdict") == "judge_error"
+            and item.get("score_excluded") is not True
+        ):
+            return "invalid_score_exclusion"
 
     if task.get("usage_complete") is not True:
         return "usage_incomplete"
@@ -867,7 +927,7 @@ def _compute_summary(
     graded_tasks = len(scored_tasks)
     error_tasks = total - graded_tasks
     pcts = [float(task["pct"]) for task in scored_tasks]
-    avg_pct = (sum(pcts) / len(pcts)) if pcts else 0.0
+    avg_pct = (sum(pcts) / len(pcts)) if pcts else None
 
     perfect = sum(1 for x in pcts if x >= 99.0)
     zero = sum(1 for x in pcts if x <= 1.0)
@@ -956,8 +1016,8 @@ def _compute_summary(
         "graded_tasks": graded_tasks,
         "error_tasks": error_tasks,
         "openai_compat": {
-            "avg_score_pct": round(avg_pct, 2),
-            "ci_pct": round(_ci_pct(pcts), 2),
+            "avg_score_pct": round(avg_pct, 2) if avg_pct is not None else None,
+            "ci_pct": round(_ci_pct(pcts), 2) if pcts else None,
             "perfect_count": perfect,
             "zero_count": zero,
             "partial_count": partial,
@@ -968,7 +1028,7 @@ def _compute_summary(
             "critical_item_pass_rate": round((critical_pass / critical_items) if critical_items else 0.0, 4),
             "precheck_pass_rate": round((pre_pass / pre_items) if pre_items else 0.0, 4),
             "judge_pass_rate": round((judge_pass / judge_items) if judge_items else 0.0, 4),
-            "judge_error_rate": round((judge_errors / judge_items) if judge_items else 0.0, 4),
+            "judge_error_rate": canonical_rate(judge_errors, judge_items),
             "by_sector": {},
             "by_rubric_category": {},
             "score_density_histogram": [],
@@ -1215,6 +1275,18 @@ def main() -> int:
         tasks = filter_tasks(inf_results, args.tasks, args.limit)
     except ValueError as exc:
         print(f"ERROR: invalid grading task selection: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        _validate_pinned_rerun_identity(
+            config,
+            experiment_id=args.experiment_yaml_name,
+            task_count=len(tasks),
+            rubric_commit_sha=rubric_sha,
+            inference_revision=inference_revision,
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
     expected_task_ids = [task["task_id"] for task in tasks]
@@ -1630,7 +1702,11 @@ def main() -> int:
     _save_json(out_path, final)
 
     avg = final["summary"]["openai_compat"]["avg_score_pct"]
-    print(f"Completed grading: tasks={len(task_payloads)}, avg_pct={avg:.2f}, out={out_path}")
+    avg_text = "unscored" if avg is None else f"{avg:.2f}"
+    print(
+        f"Completed grading: tasks={len(task_payloads)}, "
+        f"avg_pct={avg_text}, out={out_path}"
+    )
     return finish(0)
 
 

--- a/batch-runner/tests/test_grade_schema.py
+++ b/batch-runner/tests/test_grade_schema.py
@@ -152,10 +152,13 @@ def test_minimal_valid_grade_passes_schema():
     validate(instance=_minimal_payload(), schema=_load_schema())
 
 
-def test_current_grade_requires_explicit_unpriced_cost_provenance():
+@pytest.mark.parametrize("schema_version", ["1.2", "1.3"])
+def test_current_grade_requires_explicit_unpriced_cost_provenance(
+    schema_version
+):
     payload = _minimal_payload()
     payload.update({
-        "schema_version": "1.2",
+        "schema_version": schema_version,
         "run_status": "final",
         "expected_task_count": 1,
         "expected_ordered_task_ids_sha256": "a" * 64,
@@ -275,10 +278,10 @@ def test_present_grader_runtime_fingerprint_must_not_be_null():
         validate(instance=payload, schema=_load_schema())
 
 
-def _current_grade_payload() -> dict:
+def _current_grade_payload(schema_version: str = "1.2") -> dict:
     payload = _minimal_payload()
     payload.update({
-        "schema_version": "1.2",
+        "schema_version": schema_version,
         "run_status": "partial",
         "expected_task_count": 1,
         "expected_ordered_task_ids_sha256": "a" * 64,
@@ -304,6 +307,104 @@ def _current_grade_payload() -> dict:
         "unpriced_models": ["gpt-5.4-pro"],
     })
     return payload
+
+
+def test_schema_1_3_requires_judge_errors_to_be_score_excluded():
+    payload = _current_grade_payload("1.3")
+    item = payload["tasks"][0]["items"][0]
+    scored_item = deepcopy(item)
+    scored_item["rubric_item_id"] = "ri-scored"
+    payload["tasks"][0]["items"].append(scored_item)
+    item.update({
+        "verdict": "judge_error",
+        "decided_by": "judge",
+        "awarded_score": 0,
+        "score_excluded": True,
+    })
+    payload["summary"]["wow"]["judge_error_rate"] = 1.0
+
+    validate_grade_payload(payload, _load_schema())
+
+    for invalid_value in (False, None):
+        invalid = deepcopy(payload)
+        if invalid_value is None:
+            del invalid["tasks"][0]["items"][0]["score_excluded"]
+        else:
+            invalid["tasks"][0]["items"][0]["score_excluded"] = invalid_value
+        with pytest.raises(ValidationError):
+            validate_grade_payload(invalid, _load_schema())
+
+
+@pytest.mark.parametrize("schema_version", ["1.0", "1.1", "1.2"])
+def test_previous_schemas_keep_historical_judge_error_compatibility(
+    schema_version
+):
+    payload = _current_grade_payload(schema_version)
+    payload["tasks"][0]["items"][0].update({
+        "verdict": "judge_error",
+        "decided_by": "judge",
+        "awarded_score": 0,
+        "score_excluded": False,
+    })
+
+    validate_grade_payload(payload, _load_schema())
+
+    payload["summary"]["openai_compat"]["avg_score_pct"] = None
+    payload["summary"]["openai_compat"]["ci_pct"] = None
+    with pytest.raises(ValidationError):
+        validate_grade_payload(payload, _load_schema())
+
+
+def test_schema_1_3_requires_visible_judge_error_rate():
+    payload = _current_grade_payload("1.3")
+    del payload["summary"]["wow"]["judge_error_rate"]
+
+    with pytest.raises(ValidationError):
+        validate_grade_payload(payload, _load_schema())
+
+    previous = deepcopy(payload)
+    previous["schema_version"] = "1.2"
+    validate_grade_payload(previous, _load_schema())
+
+
+def test_schema_1_3_rejects_all_excluded_task_as_zero_score():
+    payload = _current_grade_payload("1.3")
+    item = payload["tasks"][0]["items"][0]
+    item.update({
+        "verdict": "judge_error",
+        "decided_by": "judge",
+        "awarded_score": 0,
+        "score_excluded": True,
+    })
+    payload["summary"].update({"graded_tasks": 0, "error_tasks": 1})
+    payload["summary"]["wow"]["judge_error_rate"] = 1.0
+    payload["summary"]["openai_compat"].update({
+        "avg_score_pct": None,
+        "ci_pct": None,
+        "perfect_count": 0,
+        "zero_count": 0,
+        "partial_count": 0,
+    })
+
+    invalid = deepcopy(payload)
+    invalid["tasks"][0]["error"] = None
+    invalid["summary"]["openai_compat"]["avg_score_pct"] = 0.0
+    invalid["summary"]["openai_compat"]["ci_pct"] = 0.0
+    invalid["summary"]["openai_compat"]["zero_count"] = 1
+    with pytest.raises((ValidationError, ValueError)):
+        validate_grade_payload(invalid, _load_schema())
+
+    payload["tasks"][0]["error"] = "all_items_score_excluded"
+    validate_grade_payload(payload, _load_schema())
+
+    payload["summary"]["total_tasks"] = 999
+    with pytest.raises(ValueError, match="task counts"):
+        validate_grade_payload(payload, _load_schema())
+
+    payload["summary"]["total_tasks"] = 1
+    payload["summary"]["openai_compat"]["inconsistent_count"] = 7
+    with pytest.raises(ValueError, match="headline scores"):
+        validate_grade_payload(payload, _load_schema())
 
 
 @pytest.mark.parametrize(

--- a/batch-runner/tests/test_grader.py
+++ b/batch-runner/tests/test_grader.py
@@ -592,6 +592,77 @@ def test_model_did_right_judge_error_is_conservative(monkeypatch, tmp_path):
     assert neg.model_did_right is False
 
 
+def test_aggregate_excludes_judge_error_from_runtime_score_denominator(
+    monkeypatch, tmp_path
+):
+    """A producer flag omission cannot turn judge failure into model score."""
+    from core.grader import ItemGrade
+
+    grader = _make_grader(monkeypatch, tmp_path)
+    task = _task(RubricItem("pass", "correct", 10, None))
+    grade = grader._aggregate(
+        [
+            ItemGrade(
+                rubric_item_id="pass",
+                criterion="correct",
+                max_score=10,
+                awarded_score=10,
+                verdict="pass",
+                decided_by="judge",
+                required=None,
+                evidence="verified",
+            ),
+            ItemGrade(
+                rubric_item_id="error",
+                criterion="unresolved",
+                max_score=90,
+                awarded_score=0,
+                verdict="judge_error",
+                decided_by="judge",
+                required=None,
+                evidence="final_json_parse_failed",
+                score_excluded=False,
+            ),
+        ],
+        task,
+    )
+
+    error_item = grade.items[1]
+    assert error_item.score_excluded is True
+    assert error_item.model_did_right is False
+    assert grade.total_awarded == 10
+    assert grade.total_max == 10
+    assert grade.pct == 100
+    assert grade.critical_fail is False
+
+
+def test_aggregate_marks_all_judge_error_task_unscored(monkeypatch, tmp_path):
+    from core.grader import ItemGrade
+
+    grader = _make_grader(monkeypatch, tmp_path)
+    task = _task(RubricItem("error", "unresolved", 10, None))
+    grade = grader._aggregate(
+        [
+            ItemGrade(
+                rubric_item_id="error",
+                criterion="unresolved",
+                max_score=10,
+                awarded_score=0,
+                verdict="judge_error",
+                decided_by="judge",
+                required=None,
+                evidence="empty_final_text",
+            )
+        ],
+        task,
+    )
+
+    assert grade.error == "all_items_score_excluded"
+    assert grade.items[0].score_excluded is True
+    assert grade.total_max == 0
+    assert grade.pct == 0
+
+
 def test_model_did_right_persisted_in_json(monkeypatch, tmp_path):
     """asdict() in step8_grade._task_to_dict should emit the new field."""
     from dataclasses import asdict

--- a/batch-runner/tests/test_grading_config.py
+++ b/batch-runner/tests/test_grading_config.py
@@ -174,6 +174,7 @@ def test_grade_workflow_defaults_to_v2_sol_max():
         "default_v2_sol_max.yaml",
         "default_v2_mini.yaml",
         "default_v2_tight.yaml",
+        "regrade_exp003_v2_mini_score_excluded.yaml",
         "validation_v2_mini_cohort3.yaml",
         "validation_v2_mini_cohort10.yaml",
     ],
@@ -231,6 +232,34 @@ def test_cohort_configs_only_change_baseline_identity(
         baseline.pop(key)
         candidate.pop(key)
     assert candidate == baseline
+
+
+def test_exp003_score_excluded_rerun_identity_is_pinned():
+    baseline_path = Path("grading_configs/default_v2_mini.yaml")
+    rerun_path = Path(
+        "grading_configs/regrade_exp003_v2_mini_score_excluded.yaml"
+    )
+    baseline = yaml.safe_load(baseline_path.read_text(encoding="utf-8"))
+    rerun = yaml.safe_load(rerun_path.read_text(encoding="utf-8"))
+
+    validate_grading_config(rerun)
+
+    identity = rerun["rerun_identity"]
+    assert identity == {
+        "experiment_id": "exp003_GPT52Chat_baseline_runner_exec",
+        "expected_task_count": 220,
+        "rubric_commit_sha": "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+        "inference_revision": "9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f",
+    }
+    assert rerun["rubric"]["revision"] == identity["rubric_commit_sha"]
+    assert hash_config(str(rerun_path)) == "55a7dc5cfb8023fe"
+
+    for key in ("config_name", "description"):
+        baseline.pop(key)
+        rerun.pop(key)
+    rerun.pop("rerun_identity")
+    baseline["rubric"]["revision"] = identity["rubric_commit_sha"]
+    assert rerun == baseline
 
 
 def test_v2_tools_block_requires_ops_list(tmp_path):

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -461,7 +461,7 @@ def test_force_overwrites(monkeypatch, tmp_path):
     code = s8.main()
     assert code == 0
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == "1.2"
+    assert payload["schema_version"] == "1.3"
 
 
 def test_main_preflight_matches_grader_transport_before_calls(
@@ -711,7 +711,7 @@ def test_track2_limit_three_mock_smoke(monkeypatch, tmp_path):
     assert payload["renderer_fingerprint"] == _RENDERER_FINGERPRINT
 
 
-def test_track2_runtime_judge_error_stops_and_persists_diagnostic(
+def test_track2_incomplete_judge_error_stops_and_persists_diagnostic(
     monkeypatch, tmp_path, capsys
 ):
     _setup_workspace(tmp_path)
@@ -773,10 +773,11 @@ def test_track2_runtime_judge_error_stops_and_persists_diagnostic(
         )
     )
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert payload["tasks"][0]["error"] == "judge_error"
+    assert payload["tasks"][0]["error"] == "usage_incomplete"
     assert payload["summary"]["graded_tasks"] == 0
     assert payload["summary"]["error_tasks"] == 1
-    assert payload["summary"]["openai_compat"]["avg_score_pct"] == 0.0
+    assert payload["summary"]["openai_compat"]["avg_score_pct"] is None
+    assert payload["summary"]["openai_compat"]["ci_pct"] is None
     assert payload["summary"]["openai_compat"]["perfect_count"] == 0
     assert payload["summary"]["wow"]["judge_error_rate"] == 1.0
     assert payload["summary"]["cost"]["usage_complete"] is False
@@ -792,6 +793,7 @@ def test_track2_runtime_error_allows_call_free_unscorable_selection():
         "usage_complete": True,
         "items": [{
             "verdict": "judge_error",
+            "score_excluded": True,
             "evidence": "wrong_format_primary: expected PDF",
             "judge_call_count": 0,
             "perception_call_count": 0,
@@ -801,6 +803,231 @@ def test_track2_runtime_error_allows_call_free_unscorable_selection():
     }
 
     assert s8._track2_task_runtime_error(task) is None
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        {
+            "task_id": "task-mixed",
+            "error": None,
+            "usage_complete": True,
+            "items": [
+                {
+                    "verdict": "pass",
+                    "score_excluded": False,
+                    "usage_complete": True,
+                },
+                {
+                    "verdict": "judge_error",
+                    "score_excluded": True,
+                    "judge_call_count": 1,
+                    "usage_complete": True,
+                },
+            ],
+        },
+        {
+            "task_id": "task-unscored",
+            "error": "all_items_score_excluded",
+            "usage_complete": True,
+            "items": [{
+                "verdict": "judge_error",
+                "score_excluded": True,
+                "judge_call_count": 1,
+                "usage_complete": True,
+            }],
+        },
+    ],
+)
+def test_track2_allows_score_excluded_judge_errors(task):
+    assert s8._track2_task_runtime_error(task) is None
+
+
+def test_track2_rejects_unexcluded_judge_error():
+    task = {
+        "task_id": "task-invalid",
+        "error": None,
+        "usage_complete": True,
+        "items": [{
+            "verdict": "judge_error",
+            "score_excluded": False,
+            "usage_complete": True,
+        }],
+    }
+
+    assert s8._track2_task_runtime_error(task) == "invalid_score_exclusion"
+
+
+def test_runtime_score_exclusion_keeps_judge_error_rate_visible():
+    from core.grader import Grader, ItemGrade
+    from core.rubric_loader import TaskRubric
+
+    task = TaskRubric(
+        task_id="task-001",
+        sector="s",
+        occupation="o",
+        prompt="p",
+        rubric_items=[],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+    grade = Grader._aggregate(
+        [
+            ItemGrade(
+                rubric_item_id="pass",
+                criterion="correct",
+                max_score=10,
+                awarded_score=10,
+                verdict="pass",
+                decided_by="judge",
+                required=None,
+                evidence="verified",
+            ),
+            ItemGrade(
+                rubric_item_id="error",
+                criterion="unresolved",
+                max_score=90,
+                awarded_score=0,
+                verdict="judge_error",
+                decided_by="judge",
+                required=None,
+                evidence="final_json_parse_failed",
+                score_excluded=False,
+            ),
+        ],
+        task,
+    )
+
+    summary = s8._compute_summary([s8._task_to_dict(grade)])
+
+    assert grade.pct == 100
+    assert grade.items[1].score_excluded is True
+    assert summary["openai_compat"]["avg_score_pct"] == 100
+    assert summary["wow"]["rubric_item_coverage_avg"] == 1.0
+    assert summary["wow"]["judge_error_rate"] == 0.5
+
+
+def test_judge_error_rate_uses_canonical_half_up_rounding():
+    items = [
+        {
+            "verdict": "judge_error" if index == 0 else "pass",
+            "decided_by": "judge",
+            "score_excluded": index == 0,
+            "model_did_right": index != 0,
+            "max_score": 1,
+        }
+        for index in range(32)
+    ]
+    task = {
+        "pct": 100.0,
+        "error": None,
+        "items": items,
+        "usage_complete": True,
+    }
+
+    summary = s8._compute_summary([task])
+
+    assert summary["wow"]["judge_error_rate"] == 0.0313
+
+
+def test_all_score_excluded_task_has_no_headline_score():
+    from core.grader import Grader, ItemGrade
+    from core.rubric_loader import TaskRubric
+
+    task = TaskRubric(
+        task_id="task-001",
+        sector="s",
+        occupation="o",
+        prompt="p",
+        rubric_items=[],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+    grade = Grader._aggregate(
+        [
+            ItemGrade(
+                rubric_item_id="error",
+                criterion="unresolved",
+                max_score=10,
+                awarded_score=0,
+                verdict="judge_error",
+                decided_by="judge",
+                required=None,
+                evidence="empty_final_text",
+            )
+        ],
+        task,
+    )
+
+    summary = s8._compute_summary([s8._task_to_dict(grade)])
+
+    assert summary["graded_tasks"] == 0
+    assert summary["error_tasks"] == 1
+    assert summary["openai_compat"]["avg_score_pct"] is None
+    assert summary["openai_compat"]["ci_pct"] is None
+    assert summary["openai_compat"]["zero_count"] == 0
+    assert summary["wow"]["judge_error_rate"] == 1.0
+
+
+def test_all_unscored_main_completes_without_formatting_null(
+    monkeypatch, tmp_path, capsys
+):
+    _setup_workspace(tmp_path)
+    _configure_track2(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(
+        s8,
+        "get_renderer_fingerprint",
+        lambda: dict(_RENDERER_FINGERPRINT),
+    )
+
+    class _AllUnscoredGrader(_FakeGrader):
+        def grade_task(self, task, deliverable_dir):
+            from core.grader import ItemGrade, TaskGrade
+
+            self.calls += 1
+            return TaskGrade(
+                task_id=task.task_id,
+                sector=task.sector,
+                occupation=task.occupation,
+                items=[ItemGrade(
+                    rubric_item_id="ri-1",
+                    criterion="unresolved",
+                    max_score=2,
+                    awarded_score=0,
+                    verdict="judge_error",
+                    decided_by="judge",
+                    required=None,
+                    evidence="empty_final_text",
+                    score_excluded=True,
+                )],
+                total_awarded=0,
+                total_max=0,
+                pct=0,
+                critical_fail=False,
+                gold_referenced=False,
+                judge_call_count=0,
+                precheck_count=0,
+                judge_total_latency_ms=0,
+                judge_input_tokens=0,
+                judge_output_tokens=0,
+                error="all_items_score_excluded",
+            )
+
+    monkeypatch.setattr(s8, "Grader", _AllUnscoredGrader)
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py",
+        "exp998_smoke_baseline_sample",
+        "--config",
+        "grading_configs/default.yaml",
+        "--force",
+    ])
+
+    assert s8.main() == 0
+    assert "avg_pct=unscored" in capsys.readouterr().out
 
 
 def test_track2_incomplete_usage_is_runtime_failure():
@@ -1217,7 +1444,7 @@ def _seed_partial_grade(
         )
     )
     payload = {
-        "schema_version": "1.2",
+        "schema_version": s8.SCHEMA_VERSION,
         "run_status": run_status,
         "expected_task_count": 3,
         "expected_ordered_task_ids_sha256": s8._ordered_task_ids_sha256(
@@ -1272,6 +1499,106 @@ def _seed_partial_grade(
         payload["renderer_fingerprint"] = renderer_fingerprint
     out.write_text(json.dumps(payload), encoding="utf-8")
     return out
+
+
+def test_resume_rejects_previous_score_semantics():
+    with pytest.raises(ValueError, match="schema_version"):
+        s8._validate_grade_resume_identity(
+            {"schema_version": "1.2"},
+            experiment_id="exp003",
+            rubric_commit_sha="a" * 40,
+            prompt_version="v2.2",
+            config_hash="0123456789abcdef",
+            source_inference_repo_id="owner/repo",
+            source_inference_revision="b" * 40,
+            grader_source_hash="c" * 64,
+            renderer_fingerprint=None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("experiment_id", "other-exp"),
+        ("task_count", 53),
+        ("rubric_commit_sha", "d" * 40),
+        ("inference_revision", "e" * 40),
+    ],
+)
+def test_pinned_rerun_identity_rejects_drift(field, value):
+    config = {
+        "rerun_identity": {
+            "experiment_id": "exp003",
+            "expected_task_count": 220,
+            "rubric_commit_sha": "a" * 40,
+            "inference_revision": "b" * 40,
+        }
+    }
+    actual = {
+        "experiment_id": "exp003",
+        "task_count": 220,
+        "rubric_commit_sha": "a" * 40,
+        "inference_revision": "b" * 40,
+    }
+    actual[field] = value
+
+    with pytest.raises(ValueError, match="pinned rerun identity"):
+        s8._validate_pinned_rerun_identity(config, **actual)
+
+
+def test_pinned_rerun_identity_accepts_exact_full_run():
+    config = {
+        "rerun_identity": {
+            "experiment_id": "exp003",
+            "expected_task_count": 220,
+            "rubric_commit_sha": "a" * 40,
+            "inference_revision": "b" * 40,
+        }
+    }
+
+    s8._validate_pinned_rerun_identity(
+        config,
+        experiment_id="exp003",
+        task_count=220,
+        rubric_commit_sha="a" * 40,
+        inference_revision="b" * 40,
+    )
+
+
+def test_pinned_rerun_identity_fails_before_route_preflight(
+    monkeypatch, tmp_path
+):
+    _setup_workspace(tmp_path)
+    _configure_track2(tmp_path)
+    config_path = tmp_path / "grading_configs" / "default.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["rubric"]["revision"] = _FakeLoader().rubric_sha
+    config["rerun_identity"] = {
+        "experiment_id": "exp998_smoke_baseline_sample",
+        "expected_task_count": 220,
+        "rubric_commit_sha": _FakeLoader().rubric_sha,
+        "inference_revision": INFERENCE_SHA,
+    }
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    route_calls = []
+
+    def unexpected_preflight(*args, **kwargs):
+        route_calls.append((args, kwargs))
+        raise AssertionError("route preflight must not run")
+
+    monkeypatch.setattr(s8, "preflight_routes", unexpected_preflight)
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py",
+        "exp998_smoke_baseline_sample",
+        "--config",
+        "grading_configs/default.yaml",
+        "--dry-run",
+    ])
+
+    assert s8.main() == 1
+    assert route_calls == []
 
 
 def test_github_output_helper_writes_exact_repo_relative_grade_path(
@@ -2035,7 +2362,7 @@ def test_time_budget_exit_7_writes_partial(monkeypatch, tmp_path, capsys):
     out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
     assert out.exists()
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == "1.2"
+    assert payload["schema_version"] == "1.3"
     assert [task["task_id"] for task in payload["tasks"]] == ["task-001"]
     stderr = capsys.readouterr().err
     assert "provider_error:OSError" in stderr

--- a/scripts/__tests__/aggregate-grades.test.mjs
+++ b/scripts/__tests__/aggregate-grades.test.mjs
@@ -10,6 +10,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { isPublishableGrade, processGradesFile } from '../aggregate-grades.mjs';
 import { gradeIdentityFromRaw } from '../grade-identity.mjs';
 
@@ -83,6 +84,265 @@ test('processGradesFile routes current schema 1.2 through item-level grading', (
   assert.equal(out.grade_status, 'graded_v1');
   assert.equal(out.schema_version, '1.2');
   assert.equal(out.judge_model, 'gpt-5.6-sol');
+});
+
+test('processGradesFile preserves visible zero judge-error rate for schema 1.3', () => {
+  const raw = {
+    schema_version: '1.3',
+    experiment_id: 'exp-score-excluded',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4-mini' },
+    summary: {
+      total_tasks: 1,
+      graded_tasks: 1,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 100,
+        ci_pct: 0,
+        perfect_count: 1,
+        partial_count: 0,
+        zero_count: 0,
+        inconsistent_count: 0,
+      },
+      wow: { judge_error_rate: 0 },
+    },
+    tasks: [{ task_id: 'task-1', pct: 100, error: null, items: [] }],
+  };
+
+  const out = processGradesFile('score-excluded.json', raw);
+
+  assert.equal(out.grade_status, 'graded_v1');
+  assert.equal(out.schema_version, '1.3');
+  assert.equal(out.summary_v1.wow.judge_error_rate, 0);
+});
+
+test('processGradesFile rejects malformed schema 1.3 required shapes', () => {
+  const valid = {
+    schema_version: '1.3',
+    experiment_id: 'exp-shape',
+    summary: {
+      total_tasks: 1,
+      graded_tasks: 1,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 100,
+        ci_pct: 0,
+        perfect_count: 1,
+        partial_count: 0,
+        zero_count: 0,
+        inconsistent_count: 0,
+      },
+      wow: { judge_error_rate: 0 },
+    },
+    tasks: [{ task_id: 'task-1', pct: 100, error: null, items: [] }],
+  };
+
+  for (const mutate of [
+    (raw) => { delete raw.tasks; },
+    (raw) => { delete raw.tasks[0].items; },
+    (raw) => { delete raw.summary.openai_compat.ci_pct; },
+    (raw) => { delete raw.summary.openai_compat.zero_count; },
+  ]) {
+    const invalid = structuredClone(valid);
+    mutate(invalid);
+    assert.throws(
+      () => processGradesFile('invalid-shape.json', invalid),
+      /schema 1.3 .*missing|schema 1.3 .*invalid/,
+    );
+  }
+});
+
+test('processGradesFile rejects nullable headline before schema 1.3', () => {
+  const raw = {
+    schema_version: '1.2',
+    experiment_id: 'exp-old-null',
+    summary: {
+      total_tasks: 0,
+      graded_tasks: 0,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: null,
+        ci_pct: null,
+        perfect_count: 0,
+        partial_count: 0,
+        zero_count: 0,
+        inconsistent_count: 0,
+      },
+      wow: {},
+    },
+    tasks: [],
+  };
+
+  assert.throws(
+    () => processGradesFile('old-null.json', raw),
+    /schema 1.0-1.2 headline must remain numeric/,
+  );
+});
+
+test('processGradesFile rejects hidden or score-included schema 1.3 judge errors', () => {
+  const raw = {
+    schema_version: '1.3',
+    experiment_id: 'exp-invalid-score-policy',
+    summary: {
+      total_tasks: 1,
+      graded_tasks: 1,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 0,
+        ci_pct: 0,
+        perfect_count: 0,
+        partial_count: 1,
+        zero_count: 0,
+        inconsistent_count: 0,
+      },
+      wow: { judge_error_rate: 1 },
+    },
+    tasks: [{
+      task_id: 'task-1',
+      pct: 0,
+      error: null,
+      items: [{
+        verdict: 'judge_error',
+        decided_by: 'judge',
+        score_excluded: false,
+      }],
+    }],
+  };
+
+  assert.throws(
+    () => processGradesFile('invalid.json', raw),
+    /judge_error must be score_excluded/,
+  );
+
+  raw.tasks[0].items[0].score_excluded = true;
+  raw.tasks[0].items.push({
+    verdict: 'pass',
+    decided_by: 'precheck',
+    score_excluded: false,
+  });
+  delete raw.summary.wow.judge_error_rate;
+  assert.throws(
+    () => processGradesFile('invalid.json', raw),
+    /judge_error_rate is missing or inconsistent/,
+  );
+
+  raw.summary.wow.judge_error_rate = 0.99999;
+  assert.throws(
+    () => processGradesFile('invalid.json', raw),
+    /judge_error_rate is missing or inconsistent/,
+  );
+});
+
+test('processGradesFile renders an all-excluded schema 1.3 run as unscored', () => {
+  const raw = {
+    schema_version: '1.3',
+    experiment_id: 'exp-unscored',
+    summary: {
+      total_tasks: 1,
+      graded_tasks: 0,
+      error_tasks: 1,
+      openai_compat: {
+        avg_score_pct: null,
+        ci_pct: null,
+        perfect_count: 0,
+        partial_count: 0,
+        zero_count: 0,
+        inconsistent_count: 0,
+      },
+      wow: { judge_error_rate: 1 },
+    },
+    tasks: [{
+      task_id: 'task-1',
+      pct: 0,
+      error: 'all_items_score_excluded',
+      items: [{
+        verdict: 'judge_error',
+        decided_by: 'judge',
+        score_excluded: true,
+      }],
+    }],
+  };
+
+  const out = processGradesFile('unscored.json', raw);
+
+  assert.equal(out.summary.avg_score_pct, null);
+  assert.equal(out.summary.zero_score, 0);
+  assert.equal(out.tasks[0].error, true);
+
+  raw.summary.total_tasks = 999;
+  assert.throws(
+    () => processGradesFile('invalid-count.json', raw),
+    /task counts are inconsistent/,
+  );
+  raw.summary.total_tasks = 1;
+
+  raw.summary.openai_compat.inconsistent_count = 7;
+  assert.throws(
+    () => processGradesFile('invalid-inconsistent.json', raw),
+    /unscored grade must not report headline scores/,
+  );
+  raw.summary.openai_compat.inconsistent_count = 0;
+
+  raw.tasks[0].error = null;
+  raw.summary.openai_compat.avg_score_pct = 0;
+  raw.summary.openai_compat.ci_pct = 0;
+  raw.summary.openai_compat.zero_count = 1;
+  assert.throws(
+    () => processGradesFile('invalid-unscored.json', raw),
+    /all-excluded task must be unscored/,
+  );
+});
+
+test('schema 1.3 judge-error rate uses the backend half-up tie rule', () => {
+  const items = Array.from({ length: 32 }, (_, index) => ({
+    verdict: index === 0 ? 'judge_error' : 'pass',
+    decided_by: 'judge',
+    score_excluded: index === 0,
+  }));
+  const raw = {
+    schema_version: '1.3',
+    experiment_id: 'exp-rate-tie',
+    summary: {
+      total_tasks: 1,
+      graded_tasks: 1,
+      error_tasks: 0,
+      openai_compat: {
+        avg_score_pct: 100,
+        ci_pct: 0,
+        perfect_count: 1,
+        partial_count: 0,
+        zero_count: 0,
+        inconsistent_count: 0,
+      },
+      wow: { judge_error_rate: 0.0313 },
+    },
+    tasks: [{ task_id: 'task-1', pct: 100, error: null, items }],
+  };
+
+  assert.equal(
+    processGradesFile('rate-tie.json', raw).summary_v1.wow.judge_error_rate,
+    0.0313,
+  );
+  raw.summary.wow.judge_error_rate = 0.0312;
+  assert.throws(
+    () => processGradesFile('rate-tie-invalid.json', raw),
+    /judge_error_rate is missing or inconsistent/,
+  );
+});
+
+test('dashboard always renders judge-error rate and discloses score exclusion', async () => {
+  const healthStrip = await readFile(
+    new URL('../../src/components/wow/HealthStrip.tsx', import.meta.url),
+    'utf8',
+  );
+  const tooltips = await readFile(
+    new URL('../../src/data/tooltipTexts.ts', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(healthStrip, /label="err"[\s\S]*value=\{fmtPct\(errRate\)\}/);
+  assert.doesNotMatch(healthStrip, /errRate\s*&&\s*<Pill/);
+  assert.match(tooltips, /excluded from score denominators but remain visible here/);
 });
 
 // ── Fixture A — minimal v1 grade with empty `inference_model` ───────────────

--- a/scripts/aggregate-grades.mjs
+++ b/scripts/aggregate-grades.mjs
@@ -164,7 +164,141 @@ function processLegacyGradesFile(filePath, raw, taskQaByExperiment = new Map()) 
 // Maps raw item-level grade JSON onto the dashboard's existing legacy shape
 // while preserving the full v1 payload in summary_v1 / tasks_v1 so WOW
 // components can consume rich item-level data.
+function validateScoreExcludedGrade(raw) {
+  if (raw?.schema_version !== '1.3') return;
+
+  if (!Array.isArray(raw.tasks)) {
+    throw new Error('schema 1.3 tasks are missing or invalid');
+  }
+  if (!raw.summary || typeof raw.summary !== 'object' || Array.isArray(raw.summary)) {
+    throw new Error('schema 1.3 summary is missing or invalid');
+  }
+  if (
+    !raw.summary.openai_compat
+    || typeof raw.summary.openai_compat !== 'object'
+    || Array.isArray(raw.summary.openai_compat)
+  ) {
+    throw new Error('schema 1.3 headline summary is missing or invalid');
+  }
+  if (
+    !raw.summary.wow
+    || typeof raw.summary.wow !== 'object'
+    || Array.isArray(raw.summary.wow)
+  ) {
+    throw new Error('schema 1.3 health summary is missing or invalid');
+  }
+
+  const tasks = raw.tasks;
+  let judgeItems = 0;
+  let judgeErrors = 0;
+  let gradedTasks = 0;
+  for (const task of tasks) {
+    if (!task || typeof task !== 'object' || Array.isArray(task)) {
+      throw new Error('schema 1.3 task is missing or invalid');
+    }
+    if (!Array.isArray(task.items)) {
+      throw new Error('schema 1.3 task items are missing or invalid');
+    }
+    const items = task.items;
+    const allExcluded = items.length > 0
+      && items.every((item) => item?.score_excluded === true);
+    if (allExcluded && !task?.error) {
+      throw new Error('schema 1.3 all-excluded task must be unscored');
+    }
+    if (!task?.error) gradedTasks += 1;
+    for (const item of items) {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) {
+        throw new Error('schema 1.3 item is missing or invalid');
+      }
+      if (item?.decided_by === 'judge') {
+        judgeItems += 1;
+        if (item.verdict === 'judge_error') judgeErrors += 1;
+      }
+      if (item?.verdict === 'judge_error' && item.score_excluded !== true) {
+        throw new Error('schema 1.3 judge_error must be score_excluded');
+      }
+    }
+  }
+
+  const summary = raw?.summary;
+  const errorTasks = tasks.length - gradedTasks;
+  for (const field of ['total_tasks', 'graded_tasks', 'error_tasks']) {
+    if (!Number.isInteger(summary[field]) || summary[field] < 0) {
+      throw new Error(`schema 1.3 ${field} is missing or invalid`);
+    }
+  }
+  if (
+    summary?.total_tasks !== tasks.length
+    || summary?.graded_tasks !== gradedTasks
+    || summary?.error_tasks !== errorTasks
+  ) {
+    throw new Error('schema 1.3 task counts are inconsistent');
+  }
+  const openaiCompat = summary?.openai_compat;
+  for (const field of [
+    'perfect_count',
+    'zero_count',
+    'partial_count',
+    'inconsistent_count',
+  ]) {
+    if (!Number.isInteger(openaiCompat[field]) || openaiCompat[field] < 0) {
+      throw new Error(`schema 1.3 ${field} is missing or invalid`);
+    }
+  }
+  if (
+    openaiCompat.perfect_count
+      + openaiCompat.zero_count
+      + openaiCompat.partial_count
+    !== gradedTasks
+  ) {
+    throw new Error('schema 1.3 headline counts are inconsistent');
+  }
+  if (gradedTasks === 0) {
+    if (
+      openaiCompat?.avg_score_pct !== null
+      || openaiCompat?.ci_pct !== null
+      || openaiCompat?.perfect_count !== 0
+      || openaiCompat?.zero_count !== 0
+      || openaiCompat?.partial_count !== 0
+      || openaiCompat?.inconsistent_count !== 0
+    ) {
+      throw new Error('schema 1.3 unscored grade must not report headline scores');
+    }
+  } else if (
+    !Number.isFinite(openaiCompat?.avg_score_pct)
+    || openaiCompat.avg_score_pct < 0
+    || openaiCompat.avg_score_pct > 100
+    || !Number.isFinite(openaiCompat?.ci_pct)
+    || openaiCompat.ci_pct < 0
+  ) {
+    throw new Error('schema 1.3 scored headline is missing or invalid');
+  }
+
+  const rate = raw?.summary?.wow?.judge_error_rate;
+  const canonicalRate = judgeItems > 0
+    ? Math.floor((2 * judgeErrors * 10_000 + judgeItems) / (2 * judgeItems)) / 10_000
+    : 0;
+  if (
+    !Number.isFinite(rate)
+    || rate < 0
+    || rate > 1
+    || rate !== canonicalRate
+  ) {
+    throw new Error('schema 1.3 judge_error_rate is missing or inconsistent');
+  }
+}
+
+function validateHistoricalHeadline(raw) {
+  if (!['1.0', '1.1', '1.2'].includes(raw?.schema_version)) return;
+  const openaiCompat = raw?.summary?.openai_compat;
+  if (openaiCompat?.avg_score_pct === null || openaiCompat?.ci_pct === null) {
+    throw new Error('schema 1.0-1.2 headline must remain numeric');
+  }
+}
+
 function processV1GradesFile(filePath, raw, taskQaByExperiment = new Map()) {
+  validateScoreExcludedGrade(raw);
+  validateHistoricalHeadline(raw);
   const filename = basename(filePath, '.json');
   const rawTasks = Array.isArray(raw.tasks) ? raw.tasks : [];
   const summary = raw.summary || {};
@@ -265,9 +399,11 @@ function processV1GradesFile(filePath, raw, taskQaByExperiment = new Map()) {
       total_tasks: totalTasks,
       graded_tasks: gradedTasks,
       error_tasks: errorTasks,
-      avg_score_pct: typeof openaiCompat.avg_score_pct === 'number'
-        ? openaiCompat.avg_score_pct
-        : 0,
+      avg_score_pct: openaiCompat.avg_score_pct === null
+        ? null
+        : typeof openaiCompat.avg_score_pct === 'number'
+          ? openaiCompat.avg_score_pct
+          : 0,
       ci_pct: typeof openaiCompat.ci_pct === 'number' ? openaiCompat.ci_pct : null,
       perfect_score: openaiCompat.perfect_count ?? 0,
       partial_score: openaiCompat.partial_count ?? 0,
@@ -290,7 +426,7 @@ function processV1GradesFile(filePath, raw, taskQaByExperiment = new Map()) {
 export function processGradesFile(filePath, raw, taskQaByExperiment = new Map()) {
   // All item-level 1.x payloads share the rich grade projection. Later minor
   // versions add provenance contracts without changing dashboard score shape.
-  if (raw && ['1.0', '1.1', '1.2'].includes(raw.schema_version)) {
+  if (raw && ['1.0', '1.1', '1.2', '1.3'].includes(raw.schema_version)) {
     return processV1GradesFile(filePath, raw, taskQaByExperiment);
   }
   return processLegacyGradesFile(filePath, raw, taskQaByExperiment);
@@ -389,7 +525,10 @@ async function main() {
   for (const r of results) {
     const dummy = r.is_dummy ? ' [DUMMY]' : '';
     const v1 = r.schema_version ? ` [v${r.schema_version}]` : '';
-    console.log(`   ${r.id}: ${r.summary.avg_score_pct}% avg (${r.summary.graded_tasks}/${r.summary.total_tasks} tasks)${dummy}${v1}`);
+    const headline = r.summary.avg_score_pct == null
+      ? 'unscored'
+      : `${r.summary.avg_score_pct}% avg`;
+    console.log(`   ${r.id}: ${headline} (${r.summary.graded_tasks}/${r.summary.total_tasks} tasks)${dummy}${v1}`);
   }
 }
 

--- a/src/components/GradesSummary.tsx
+++ b/src/components/GradesSummary.tsx
@@ -176,7 +176,7 @@ function GradeCard({ grade, index }: { grade: GradeResult; index: number }) {
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ duration: 0.5, delay: 0.3 }}
               >
-                {s.avg_score_pct}%
+                {s.avg_score_pct == null ? '—' : `${s.avg_score_pct}%`}
               </motion.p>
               {s.ci_pct && (
                 <p className="text-xs text-muted-foreground">± {s.ci_pct}% (95% CI)</p>

--- a/src/components/dashboard/GradingAnalysisView.tsx
+++ b/src/components/dashboard/GradingAnalysisView.tsx
@@ -403,7 +403,9 @@ function GradeOverviewCard({ grade, color, onNavigate }: { grade: GradeResult; c
             </div>
           </div>
           <div className="text-right">
-            <p className="text-2xl font-bold text-dash-heading font-mono">{s.avg_score_pct}%</p>
+            <p className="text-2xl font-bold text-dash-heading font-mono">
+              {s.avg_score_pct == null ? '—' : `${s.avg_score_pct}%`}
+            </p>
             {s.ci_pct && <p className="text-[10px] text-dash-text-faint flex items-center gap-0.5 justify-end">± {s.ci_pct}% CI <InfoTooltip content={tooltipTexts.grading.ci} position="left" /></p>}
           </div>
         </div>

--- a/src/data/tooltipTexts.ts
+++ b/src/data/tooltipTexts.ts
@@ -54,7 +54,7 @@ export const tooltipTexts = {
     row:
       'Run-quality diagnostics: judge call success rate, pass rates by decision type, and cost/latency totals. Distinct from the score itself.',
     judgeErrorRate:
-      'Percentage of judge calls that failed (timeout, parse error, or hit token limit). Alert threshold > 5% — unreliable run.',
+      'Percentage of judge-decided rubric items that failed (timeout, parse error, or token limit). These items are excluded from score denominators but remain visible here. Alert threshold > 5% — unreliable run.',
     judgePassRate:
       'Pass rate among LLM-judge-decided rubric items (content-quality criteria). Distinct from precheck (deterministic structural checks).',
     precheckPassRate:

--- a/src/hooks/useGrades.ts
+++ b/src/hooks/useGrades.ts
@@ -23,7 +23,7 @@ export interface GradeSummary {
   total_tasks: number
   graded_tasks: number
   error_tasks: number
-  avg_score_pct: number
+  avg_score_pct: number | null
   ci_pct: number | null
   perfect_score: number
   partial_score: number
@@ -68,7 +68,7 @@ export interface GradeResult {
   tasks: TaskGrade[]
 
   // ── Item-level grade schema additions ──
-  schema_version?: '1.0' | '1.1' | '1.2' | null
+  schema_version?: '1.0' | '1.1' | '1.2' | '1.3' | null
   judge?: JudgeProvenance
   rubric?: RubricProvenance
   prompt?: GradePromptInfo

--- a/src/pages/GradeDetail.tsx
+++ b/src/pages/GradeDetail.tsx
@@ -348,7 +348,7 @@ function GradeDetail() {
               icon={Target}
               label="Average Score"
               tooltip="Mean score across all graded tasks (excluding errors), expressed as a percentage."
-              value={`${s.avg_score_pct}%`}
+              value={s.avg_score_pct == null ? '—' : `${s.avg_score_pct}%`}
               sub={s.ci_pct ? `± ${s.ci_pct}%` : undefined}
               color="text-blue-500"
               bg="bg-blue-500/10"
@@ -581,8 +581,10 @@ function GradeDetail() {
                 {s.error_tasks > 0 && (
                   <> <strong className="text-orange-500">{s.error_tasks}</strong> task{s.error_tasks > 1 ? 's' : ''} could not be evaluated.</>
                 )}
-                {' '}The average score was <strong>{s.avg_score_pct}%</strong>
-                {s.ci_pct && <> (±{s.ci_pct}% at 95% confidence)</>}.
+                {s.avg_score_pct == null
+                  ? <> No headline score is available.</>
+                  : <> The average score was <strong>{s.avg_score_pct}%</strong>
+                    {s.ci_pct && <> (±{s.ci_pct}% at 95% confidence)</>}.</>}
                 {s.inconsistent_grades > 0 && (
                   <> Graders disagreed on <strong className="text-purple-500">{s.inconsistent_grades}</strong> task{s.inconsistent_grades > 1 ? 's' : ''}.</>
                 )}

--- a/src/types/grade.ts
+++ b/src/types/grade.ts
@@ -51,8 +51,8 @@ export interface CalibrationCounts {
 }
 
 export interface OpenAICompatSummary {
-  avg_score_pct: number
-  ci_pct: number
+  avg_score_pct: number | null
+  ci_pct: number | null
   perfect_count: number
   zero_count: number
   partial_count: number
@@ -88,7 +88,7 @@ export interface WowSummary {
   critical_item_pass_rate: number
   precheck_pass_rate: number
   judge_pass_rate: number
-  judge_error_rate?: number
+  judge_error_rate: number
   by_sector?: Record<string, SectorWowMetric>
   by_rubric_category?: Record<string, RubricCategoryMetric>
   score_density_histogram?: ScoreDensityBucket[]

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,10 +1,99 @@
 # Latest Task Result
 
 - Updated: 2026-08-08
+- Status: `judge_error` is score-excluded at runtime and remains visible in
+  schema 1.3 summaries and the dashboard; no paid regrade was run
+
+## Current Task: Judge Error Score Exclusion
+
+### Task
+
+- Analyze the 100 known score-included `judge_error` zeros without a model call
+  or mutation of the checked-in grade payload.
+- Exclude every judge failure from score numerators and denominators at runtime,
+  including stale or missing producer flags, while keeping the error rate
+  visible.
+- Increment the grade output schema, document the comparison boundary, and pin
+  the exact identity for a later complete 220-task rerun.
+- Do not partially regrade the 53 affected tasks or perform any paid grading in
+  this policy task.
+
+### Result
+
+- `Grader._aggregate` now forces every `judge_error` to
+  `score_excluded=true`, keeps `model_did_right=false`, and excludes the item
+  from score, coverage, and critical metrics.
+- A task whose items are all excluded is unscored rather than zero-scored. Its
+  headline score and confidence interval are null, all headline counts are
+  zero, and dashboard score surfaces render an em dash.
+- Complete score-excluded judge errors no longer abort Track 2. Malformed
+  items, incomplete usage, and any unexcluded judge error still stop the run.
+- Output schema `1.3`, shared Python validation, resume identity, and strict
+  dashboard ingestion enforce the same task-count, exclusion, headline, and
+  canonical four-decimal error-rate invariants. Historical schemas `1.0`-`1.2`
+  remain readable and retain numeric headline requirements.
+- `judge_error_rate` remains visible even at zero in run health and analysis
+  cards; its tooltip explicitly states that errors are excluded from score
+  denominators but not hidden.
+- Headline scores from schema `1.3` are not directly comparable with schemas
+  `1.0`-`1.2`. Resume rejects the old score semantics rather than mixing them.
+
+### Historical Analysis
+
+- Read-only source:
+  `data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini.json`.
+- Payload SHA-256:
+  `b5cbb6a80c776b458f99f007841a946c1c5f9ec8bf60be052500713dd6f13570`.
+- Observed 355 `judge_error` items. Of those, 100 score-included zeros affected
+  53 tasks: 61 `final_json_parse_failed`, 31 `empty_final_text`, five
+  `RateLimitError`, and three content-policy `BadRequestError` items.
+- The other 255 errors were already score-excluded selection failures. The
+  source payload was not edited or partially regraded.
+
+### Fixed Rerun Identity
+
+- Config: `regrade_exp003_v2_mini_score_excluded.yaml`.
+- Config hash: `55a7dc5cfb8023fe`.
+- Rubric commit: `11e7900cdcac61bc4daf59e65feb238acda98fbf`.
+- Inference revision: `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`.
+- Expected task count: 220. Step 8 rejects experiment, task-count, rubric, or
+  inference drift before its Azure route preflight and model construction.
+
+### Verification
+
+- Runtime/schema/config/selector matrix: 382 passed before the final invariant
+  fixes; the complete backend suite then passed 3,033 tests with six skips and
+  45 integration tests deselected.
+- The three unchanged host-environment failures were stale Azure SDK versions
+  and missing `pdfplumber`; all three passed under exact temporary Python 3.10
+  dependencies.
+- Self-preparing aggregate suite: 105 passed, 1 expected Ruby skip.
+- `npm run build`: passed with 2,783 transformed modules.
+- Ruff, `py_compile`, VS Code diagnostics, and `git diff --check`: passed.
+- No grade payload, workflow, or production configuration was rewritten. No
+  partial/full grading run, credential use, workflow dispatch, or paid model
+  operation occurred.
+
+### Review Evidence
+
+- Reviewed substantive head:
+  `3c8ab817916129dff7a33291520a1f4f2db7d048`.
+- Independent `grading-engineer` and `first-reviewer` verdicts: `APPROVE`, with
+  no blocking findings.
+
+### Remaining Work
+
+- The owner decides whether and when to merge the reviewed change.
+- A later paid task may run the complete 220-task pinned config after separate
+  approval. Do not merge a 53-task partial rerun, and do not create a
+  documentation-only PR to record this change's eventual merge metadata.
+
+---
+
+## Preserved Prior Result: Non-Recursive Completion Records (2026-08-08)
+
 - Status: Completion records retain verified task evidence without forcing
   documentation-only PRs that restate their carrying PR's merge status
-
-## Current Task: Non-Recursive Completion Records
 
 ### Task
 


### PR DESCRIPTION
## Summary

- force every `judge_error` to be score-excluded at the runtime aggregation boundary, including stale producer flags, while retaining it in `judge_error_rate`
- represent fully excluded tasks as unscored rather than zero-scored; complete excluded errors continue Track 2 while malformed, unexcluded, or usage-incomplete rows remain fatal
- introduce output schema 1.3 with strict Python and dashboard cross-field validation, 1.2 resume rejection, nullable unscored headlines, and canonical four-decimal half-up error rates
- keep `judge_error_rate` visible in dashboard health surfaces, disclose denominator exclusion, and reject malformed 1.3 payloads
- pin the later full-220 exp003 rerun to config hash `55a7dc5cfb8023fe`, rubric `11e7900cdcac61bc4daf59e65feb238acda98fbf`, and inference `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`

## Historical evidence

Read-only payload SHA-256: `b5cbb6a80c776b458f99f007841a946c1c5f9ec8bf60be052500713dd6f13570`. It contains 355 judge errors; 100 score-included zeros affected 53 tasks: 61 final-JSON parse failures, 31 empty final responses, five rate limits, and three content-policy errors. The payload is unchanged.

Schema 1.3 headline scores are not directly comparable with schemas 1.0-1.2 without a complete rerun under one grader identity.

## Validation

- full backend: 3,033 passed, 6 skipped, 45 integration deselected
- three host-dependency failures separately passed under exact temporary Python 3.10 dependencies
- aggregate contracts: 105 passed, 1 expected Ruby skip
- production build: 2,783 modules transformed
- Ruff, `py_compile`, diagnostics, and `git diff --check`: passed
- `grading-engineer` and `first-reviewer`: APPROVE, no blocking findings
- reviewed substantive head: `3c8ab817916129dff7a33291520a1f4f2db7d048`

## Safety

No grade payload or workflow was modified. No partial or full grading run, credential use, workflow dispatch, or paid model operation occurred. The 53 affected tasks must not be partially rerun or merged; any later paid execution uses the pinned full-220 config under separate owner approval. The owner controls this PR merge decision.