### PR TITLE
feat(grading): prepare Sol Max regrade anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Changed
+- **Sol Max regrade preparation and anchor instrumentation** - preserve schema
+  `1.3` nullable headlines across grading analysis: the sign-aware backfill now
+  rejects non-`1.0` inputs instead of downgrading them, pairwise comparison
+  renders aggregate and task-level null/error scores as `unscored` without a
+  delta, and run analysis keeps null in JSON and Markdown. Add pinned exp003 Sol
+  Max configs for the planned full 220-task rerun and a bounded three-task paid
+  anchor. Their hashes are `14fc577ea39d98c5` and `25653df2d5841c97`;
+  both bind rubric commit `11e7900cdcac61bc4daf59e65feb238acda98fbf`
+  and inference revision `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`.
+  The production audio block remains byte-equivalent in semantics
+  (`gpt-audio-1.5`, three calls, 30-second trim), the visual cap remains 72,
+  and all existing comparison configs remain unchanged. Step 8 now records
+  measured per-task grading wall time. The analyzer emits task-level wall,
+  main/visual/audio/unknown calls, tokens, cache, latency, render usage, and
+  public judge-error subtypes, treats unknown perception token attribution as
+  unpriced, and projects serial 220-task wall time against the 44-hour resume
+  envelope without inventing USD cost. The three-task anchor is deliberately
+  smaller than ten because Sol Max has no prior payload; matching mini baselines
+  already have zero judge errors. Cohort 3 records 532 main and four visual
+  calls with 41.2 minutes summed latency; cohort 10 records 1,333 main and 26
+  visual calls with 88.8 minutes. Neither has an audio call or judge error, so
+  the first Sol Max anchor can establish operational volume and detect a
+  regression or match, but cannot prove improvement below the mini zero floor.
+  Validation passes 28 analysis tests, 312 grading/config/schema/perception
+  tests, 3,038 backend tests with nine skips and 45 integration deselections,
+  plus the three host-dependency cases under exact temporary Python 3.10
+  dependencies. Aggregate contracts pass 105 with one expected Ruby skip, the
+  production build transforms 2,783 modules, and `py_compile`, diagnostics,
+  and diff checks pass. No workflow, credential, paid model call, grade payload,
+  or existing config was changed or executed. Independent grading and code
+  reviews approved substantive head
+  `eee62b8e3fc6cff0ed447781251cde37f10e6b4f`. The paid anchor remains pending
+  because its config must first reach exact `main`; it requires a separate
+  owner-approved protected grading dispatch.
 - **Judge errors excluded from score denominators** - make `judge_error` a
   visible unscored outcome rather than a model failure. Runtime aggregation now
   overrides stale producer flags, excludes judge failures from task numerators,

--- a/batch-runner/grading_configs/README.md
+++ b/batch-runner/grading_configs/README.md
@@ -7,6 +7,8 @@
 | `default_v2_sol_max.yaml` | tool-calling judge | v2 (`ToolCallingJudge` via `judge.tools.read_deliverable`) | **Production default.** GPT-5.6 Sol 1M Max for main, visual, and bounded finalization; gpt-audio-1.5 for audio perception. |
 | `default_v2.yaml` | tool-calling judge | v2 | Historical gpt-5.4 medium comparison identity. Pass explicitly when reproducing that condition. |
 | `regrade_exp003_v2_mini_score_excluded.yaml` | tool-calling judge | v2 | Full-220 exp003 rerun only. Pins score-excluded semantics, the historical mini judge condition, rubric commit, inference revision, and exact task count. |
+| `regrade_exp003_v2_sol_max_score_excluded.yaml` | tool-calling judge | v2 | Planned full-220 exp003 Sol Max rerun. Pins score-excluded semantics, production judge/perception settings, rubric commit, inference revision, and exact task count. |
+| `validation_exp003_v2_sol_max_anchor3.yaml` | tool-calling judge | v2 | Paid three-task Sol Max anchor with the same runtime semantics and pinned source identities as the planned full rerun. |
 | `default_gpt5pro.yaml` | text-extract judge | v1 (`Judge` / `BatchJudge`) | Historical mini/text-extract comparison identity. Pass explicitly only for provenance-compatible analysis. |
 
 `grade-run.yml` defaults to `default_v2_sol_max.yaml`. The 1.05M context window
@@ -70,6 +72,37 @@ Inside Step 8, the config's `rerun_identity` block is checked before its Azure
 route preflight and before model-client construction, so a partial task set or
 identity drift cannot start model grading. The workflow may authenticate and
 perform its own route checks earlier.
+
+The pinned Sol Max identities are:
+
+| purpose | config | config hash | tasks |
+|---|---|---|---:|
+| full rerun | `regrade_exp003_v2_sol_max_score_excluded.yaml` | `14fc577ea39d98c5` | 220 |
+| paid anchor | `validation_exp003_v2_sol_max_anchor3.yaml` | `25653df2d5841c97` | 3 |
+
+Both pin rubric commit `11e7900cdcac61bc4daf59e65feb238acda98fbf`
+and inference revision `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`.
+Their audio block remains the production `gpt-audio-1.5` configuration with a
+three-call task cap and 30-second trim, and their visual task cap remains 72.
+
+The first paid anchor is deliberately three tasks, not ten. There is no prior
+Sol Max grade payload, while the matching mini cohorts already report zero
+judge errors at both sizes. Three tasks bound the first exposure while still
+covering 536 mini baseline calls and four visual-perception calls. Consequently,
+the anchor can establish token/latency volume and detect an error-rate
+regression, but it cannot prove an error-rate reduction below the mini floor of
+zero. The ten-task mini baseline remains available for a later owner-approved
+expansion if the three-task anchor is operationally acceptable.
+
+| mini baseline | main calls | visual calls | audio calls | main tokens (in/out/cached) | visual tokens (in/out/cached) | audio tokens | summed judge latency | judge errors |
+|---|---:|---:|---:|---|---|---|---:|---:|
+| cohort3 | 532 | 4 | 0 | 4,540,399 / 176,531 / 1,955,328 | 4,751 / 1,032 / 0 | 0 / 0 / 0 | 41.2 min | 0 |
+| cohort10 | 1,333 | 26 | 0 | 6,833,450 / 369,014 / 3,389,440 | 30,282 / 6,836 / 0 | 0 / 0 / 0 | 88.8 min | 0 |
+
+These historical payloads predate task-level `grading_wall_time_ms`, so their
+true task wall-clock values cannot be reconstructed. The Sol Max anchor records
+that field prospectively and the analyzer projects serial 220-task wall time
+against the 44-hour resume envelope without inventing a USD estimate.
 
 ## Archived (no longer recommended)
 

--- a/batch-runner/grading_configs/regrade_exp003_v2_sol_max_score_excluded.yaml
+++ b/batch-runner/grading_configs/regrade_exp003_v2_sol_max_score_excluded.yaml
@@ -1,0 +1,95 @@
+schema_version: "2.0"
+config_name: "regrade_exp003_v2_sol_max_score_excluded"
+description: |
+  Full 220-task exp003 regrade identity for schema 1.3 score semantics.
+  This preserves the production Sol Max judge, visual, audio, and retry
+  settings while pinning the exact task count, rubric, and inference revision.
+
+rerun_identity:
+  experiment_id: "exp003_GPT52Chat_baseline_runner_exec"
+  expected_task_count: 220
+  rubric_commit_sha: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  inference_revision: "9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f"
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.6-sol"
+  deployment: "gpt-5.6-sol"
+  api_version: "2025-04-01-preview"
+  timeout_sec: 600
+  reasoning:
+    effort: "max"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+    finalization_reasoning_effort: "max"
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.6-sol"
+      deployment: "gpt-5.6-sol"
+      reasoning_effort: "max"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      deployment: "gpt-audio-1.5"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v2"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"

--- a/batch-runner/grading_configs/validation_exp003_v2_sol_max_anchor3.yaml
+++ b/batch-runner/grading_configs/validation_exp003_v2_sol_max_anchor3.yaml
@@ -1,0 +1,94 @@
+schema_version: "2.0"
+config_name: "validation_exp003_v2_sol_max_anchor3"
+description: |
+  Paid three-task Sol Max anchor for exp003. Runtime grading semantics match
+  the pinned full rerun; only the config identity and expected task count differ.
+
+rerun_identity:
+  experiment_id: "exp003_GPT52Chat_baseline_runner_exec"
+  expected_task_count: 3
+  rubric_commit_sha: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  inference_revision: "9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f"
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.6-sol"
+  deployment: "gpt-5.6-sol"
+  api_version: "2025-04-01-preview"
+  timeout_sec: 600
+  reasoning:
+    effort: "max"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+    finalization_reasoning_effort: "max"
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.6-sol"
+      deployment: "gpt-5.6-sol"
+      reasoning_effort: "max"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      deployment: "gpt-audio-1.5"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v2"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -431,6 +431,7 @@
           "judge_call_count": {"type": "integer", "minimum": 0},
           "precheck_count": {"type": "integer", "minimum": 0},
           "judge_total_latency_ms": {"type": "number", "minimum": 0},
+          "grading_wall_time_ms": {"type": "number", "minimum": 0},
           "judge_input_tokens": {"type": "integer", "minimum": 0},
           "judge_output_tokens": {"type": "integer", "minimum": 0},
           "judge_cached_tokens": {"type": "integer", "minimum": 0},

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -898,8 +898,16 @@ def _ci_pct(values: list[float]) -> float:
     return 1.96 * std / math.sqrt(n)
 
 
-def _task_to_dict(task_grade) -> dict:
+def _task_to_dict(
+    task_grade,
+    *,
+    grading_wall_time_ms: float | None = None,
+) -> dict:
     data = asdict(task_grade)
+    if grading_wall_time_ms is not None:
+        if not math.isfinite(grading_wall_time_ms) or grading_wall_time_ms < 0:
+            raise ValueError("grading wall time must be finite and nonnegative")
+        data["grading_wall_time_ms"] = round(grading_wall_time_ms, 2)
     data["graded_at"] = _now_iso()
     return data
 
@@ -1589,8 +1597,13 @@ def main() -> int:
 
         task = loader.load(task_result["task_id"])
         deliverable_dir = resolve_deliverable_dir(task_result)
+        task_started = time.perf_counter()
         grade = grader.grade_task(task, deliverable_dir)
-        row = _task_to_dict(grade)
+        grading_wall_time_ms = (time.perf_counter() - task_started) * 1000.0
+        row = _task_to_dict(
+            grade,
+            grading_wall_time_ms=grading_wall_time_ms,
+        )
         runtime_error = None
         if config.get("schema_version") == "2.0":
             runtime_error = _track2_task_runtime_error(row)

--- a/batch-runner/tests/test_grading_config.py
+++ b/batch-runner/tests/test_grading_config.py
@@ -175,6 +175,8 @@ def test_grade_workflow_defaults_to_v2_sol_max():
         "default_v2_mini.yaml",
         "default_v2_tight.yaml",
         "regrade_exp003_v2_mini_score_excluded.yaml",
+        "regrade_exp003_v2_sol_max_score_excluded.yaml",
+        "validation_exp003_v2_sol_max_anchor3.yaml",
         "validation_v2_mini_cohort3.yaml",
         "validation_v2_mini_cohort10.yaml",
     ],
@@ -260,6 +262,76 @@ def test_exp003_score_excluded_rerun_identity_is_pinned():
     rerun.pop("rerun_identity")
     baseline["rubric"]["revision"] = identity["rubric_commit_sha"]
     assert rerun == baseline
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_task_count", "expected_hash"),
+    [
+        (
+            "regrade_exp003_v2_sol_max_score_excluded.yaml",
+            220,
+            "14fc577ea39d98c5",
+        ),
+        (
+            "validation_exp003_v2_sol_max_anchor3.yaml",
+            3,
+            "25653df2d5841c97",
+        ),
+    ],
+)
+def test_exp003_sol_max_configs_are_pinned_and_preserve_modalities(
+    filename: str,
+    expected_task_count: int,
+    expected_hash: str,
+):
+    baseline_path = Path("grading_configs/default_v2_sol_max.yaml")
+    candidate_path = Path("grading_configs") / filename
+    baseline = yaml.safe_load(baseline_path.read_text(encoding="utf-8"))
+    candidate = yaml.safe_load(candidate_path.read_text(encoding="utf-8"))
+
+    validate_grading_config(candidate)
+
+    identity = candidate["rerun_identity"]
+    assert identity == {
+        "experiment_id": "exp003_GPT52Chat_baseline_runner_exec",
+        "expected_task_count": expected_task_count,
+        "rubric_commit_sha": "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+        "inference_revision": "9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f",
+    }
+    assert candidate["rubric"]["revision"] == identity["rubric_commit_sha"]
+    assert hash_config(str(candidate_path)) == expected_hash
+    assert candidate["judge"]["perception"]["audio"] == (
+        baseline["judge"]["perception"]["audio"]
+    )
+    assert candidate["judge"]["perception"]["visual"]["call_cap_per_task"] == 72
+
+    for key in ("config_name", "description"):
+        baseline.pop(key)
+        candidate.pop(key)
+    candidate.pop("rerun_identity")
+    baseline["rubric"]["revision"] = identity["rubric_commit_sha"]
+    assert candidate == baseline
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("expected_task_count", 0, "expected_task_count"),
+        ("expected_task_count", 221, "expected_task_count"),
+        ("inference_revision", "main", "inference_revision"),
+    ],
+)
+def test_sol_max_rerun_identity_rejects_invalid_values(
+    field: str,
+    value,
+    message: str,
+):
+    path = Path("grading_configs/regrade_exp003_v2_sol_max_score_excluded.yaml")
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    config["rerun_identity"][field] = value
+
+    with pytest.raises(ValueError, match=message):
+        validate_grading_config(config)
 
 
 def test_v2_tools_block_requires_ops_list(tmp_path):

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -98,6 +98,16 @@ class _FakeGrader:
         )
 
 
+def test_task_serialization_persists_measured_wall_time():
+    config = {"_runtime": {"azure_ai_runtime_fingerprint": "f" * 64}}
+    grader = _FakeGrader(config, rubric_loader=None)
+    grade = grader.grade_task(_FakeLoader().load("task-001"), "unused")
+
+    row = s8._task_to_dict(grade, grading_wall_time_ms=1234.5)
+
+    assert row["grading_wall_time_ms"] == 1234.5
+
+
 def test_compute_summary_includes_perception_in_total_cost_volume():
     task = {
         "pct": 50.0,
@@ -462,6 +472,11 @@ def test_force_overwrites(monkeypatch, tmp_path):
     assert code == 0
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["schema_version"] == "1.3"
+    assert all(
+        isinstance(task["grading_wall_time_ms"], (int, float))
+        and task["grading_wall_time_ms"] >= 0
+        for task in payload["tasks"]
+    )
 
 
 def test_main_preflight_matches_grader_transport_before_calls(

--- a/scripts/__tests__/test_analyze_grade_run.py
+++ b/scripts/__tests__/test_analyze_grade_run.py
@@ -163,9 +163,11 @@ def test_perception_usage_is_included_and_reported_separately(tmp_path: Path):
     assert analyzed["top5_slowest"][0]["latency_sec"] == 0.07
     assert analyzed["total_render_calls"] == 3
     assert analyzed["usage_complete"] is True
-    combined_cost = analyzed["cost_estimate"]["cost_usd"]
-    main_only = 100 / 1_000_000 * 1.25 + 20 / 1_000_000 * 5.0
-    assert combined_cost > main_only
+    assert analyzed["cost_estimate"]["cost_usd"] is None
+    assert analyzed["cost_estimate"]["pricing_complete"] is False
+    assert "unknown_perception_model" in (
+        analyzed["cost_estimate"]["unpriced_models"]
+    )
 
 
 def test_visual_perception_uses_its_own_model_price(tmp_path: Path):
@@ -231,6 +233,36 @@ def test_mixed_parent_prices_visual_child_with_visual_model(tmp_path: Path):
     assert cost["perception"][0]["input_usd"] == 1.25
 
 
+def test_unknown_perception_tokens_are_unpriced_and_visible(tmp_path: Path):
+    grade = _grade_json(model="gpt-5.4-mini", n_tasks=1)
+    task = grade["tasks"][0]
+    task.update({
+        "perception_call_count": 1,
+        "perception_input_tokens": 1_000_000,
+        "perception_output_tokens": 100,
+        "perception_cached_tokens": 10,
+        "perception_total_latency_ms": 5_000,
+    })
+    task["items"] = []
+
+    analyzed = _run(tmp_path, grade)["this"]
+    markdown = _run(tmp_path, grade, as_json=False)
+
+    assert analyzed["cost_estimate"]["pricing_complete"] is False
+    assert analyzed["cost_estimate"]["cost_usd"] is None
+    assert "unknown_perception_model" in (
+        analyzed["cost_estimate"]["unpriced_models"]
+    )
+    assert analyzed["effective_cost"]["pricing_complete"] is False
+    assert analyzed["effective_cost"]["total_usd"] is None
+    unknown = analyzed["task_anchors"][0]["unknown_perception"]
+    assert unknown["call_count"] == 1
+    assert unknown["input_tokens"] == 1_000_000
+    assert unknown["latency_sec"] == 5.0
+    assert "unknown perception calls/tokens/latency" in markdown
+    assert "1 / 1000000,100,10 / 5.0s" in markdown
+
+
 def test_routing_emits_blended_estimate(tmp_path: Path):
     routing = {
         "tier_pro": {"model": "gpt-5.4-pro"},
@@ -259,6 +291,116 @@ def test_top5_slowest_sorted_desc(tmp_path: Path):
     assert top[0]["task_id"] == "t02"
     assert top[0]["latency_sec"] == 12.0
     assert top[-1]["latency_sec"] <= top[0]["latency_sec"]
+
+
+def test_null_headline_remains_unscored_in_json_and_markdown(tmp_path: Path):
+    grade = _grade_json(n_tasks=1)
+    grade["summary"]["graded_tasks"] = 0
+    grade["summary"]["error_tasks"] = 1
+    grade["summary"]["openai_compat"]["avg_score_pct"] = None
+    grade["tasks"][0]["error"] = "all_items_score_excluded"
+
+    analyzed = _run(tmp_path, grade)["this"]
+    markdown = _run(tmp_path, grade, as_json=False)
+
+    assert analyzed["avg_score_pct"] is None
+    assert "avg_score_pct: **unscored**" in markdown
+    assert "avg_score_pct: **None**" not in markdown
+
+
+def test_task_anchor_separates_main_visual_audio_and_error_types(tmp_path: Path):
+    grade = _grade_json(model="gpt-5.6-sol", n_tasks=1)
+    grade["judge"]["perception"] = {
+        "visual": {"model": "gpt-5.6-sol"},
+        "audio": {"model": "gpt-audio-1.5"},
+    }
+    task = grade["tasks"][0]
+    task.update({
+        "grading_wall_time_ms": 123_000,
+        "judge_call_count": 2,
+        "judge_input_tokens": 1_000,
+        "judge_output_tokens": 100,
+        "judge_cached_tokens": 400,
+        "judge_total_latency_ms": 50_000,
+        "perception_call_count": 3,
+        "perception_input_tokens": 500,
+        "perception_output_tokens": 50,
+        "perception_cached_tokens": 20,
+        "perception_total_latency_ms": 30_000,
+        "render_call_count": 2,
+        "render_total_latency_ms": 2_000,
+        "usage_complete": True,
+    })
+    task["items"] = [
+        {
+            "routing_modality": "visual",
+            "verdict": "pass",
+            "perception_call_count": 2,
+            "perception_input_tokens": 300,
+            "perception_output_tokens": 30,
+            "perception_cached_tokens": 10,
+            "perception_total_latency_ms": 20_000,
+        },
+        {
+            "routing_modality": "audio",
+            "verdict": "judge_error",
+            "evidence": "provider_error:RateLimitError",
+            "score_excluded": True,
+            "perception_call_count": 1,
+            "perception_input_tokens": 200,
+            "perception_output_tokens": 20,
+            "perception_cached_tokens": 10,
+            "perception_total_latency_ms": 10_000,
+        },
+        {
+            "routing_modality": "mixed",
+            "verdict": "judge_error",
+            "evidence": "split_children: see child_grades",
+            "score_excluded": True,
+            "child_grades": [
+                {
+                    "verdict": "judge_error",
+                    "evidence": "final_json_parse_failed",
+                },
+                {"verdict": "pass", "evidence": "verified"},
+            ],
+        },
+    ]
+    grade["summary"]["wow"]["judge_error_rate"] = 0.5
+
+    analyzed = _run(tmp_path, grade)["this"]
+    markdown = _run(tmp_path, grade, as_json=False)
+    anchor = analyzed["task_anchors"][0]
+
+    assert anchor["wall_clock_sec"] == 123.0
+    assert anchor["main"] == {
+        "call_count": 2,
+        "input_tokens": 1_000,
+        "output_tokens": 100,
+        "cached_tokens": 400,
+        "latency_sec": 50.0,
+    }
+    assert anchor["visual"]["call_count"] == 2
+    assert anchor["visual"]["input_tokens"] == 300
+    assert anchor["audio"]["call_count"] == 1
+    assert anchor["audio"]["input_tokens"] == 200
+    assert anchor["judge_error_types"] == {
+        "RateLimitError": 1,
+        "final_json_parse_failed": 1,
+    }
+    assert analyzed["judge_error_types"] == {
+        "RateLimitError": 1,
+        "final_json_parse_failed": 1,
+    }
+    assert analyzed["projected_220_wall_hours"] == 7.52
+    assert analyzed["projection_status"] == "below_44h_envelope"
+    assert "## Task anchors" in markdown
+    assert "final_json_parse_failed:1" in markdown
+    assert "RateLimitError:1" in markdown
+    assert "50.0s" in markdown
+    assert "20.0s" in markdown
+    assert "10.0s" in markdown
+    assert "projected_220_wall_hours: 7.52" in markdown
 
 
 def test_markdown_contains_key_sections(tmp_path: Path):

--- a/scripts/__tests__/test_backfill_sign_aware.py
+++ b/scripts/__tests__/test_backfill_sign_aware.py
@@ -171,3 +171,31 @@ def test_backfill_preserves_input_file(tmp_path: Path):
     after = p.read_text()
     assert before == after, "input v1 file must NOT be modified"
     assert (tmp_path / "grade__v2sm.json").exists()
+
+
+def test_backfill_rejects_schema_1_3_instead_of_downgrading_null_score(
+    tmp_path: Path,
+):
+    payload = _v1_grade([
+        _task(
+            "t1",
+            [_item("r1", 4, 0, "judge_error")],
+            error="all_items_score_excluded",
+        )
+    ])
+    payload["schema_version"] = "1.3"
+    payload["summary"]["graded_tasks"] = 0
+    payload["summary"]["error_tasks"] = 1
+    payload["summary"]["openai_compat"]["avg_score_pct"] = None
+    source = tmp_path / "grade.json"
+    source.write_text(json.dumps(payload))
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(source)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "schema 1.0" in result.stderr
+    assert not (tmp_path / "grade__v2sm.json").exists()

--- a/scripts/__tests__/test_compare_grades.py
+++ b/scripts/__tests__/test_compare_grades.py
@@ -143,3 +143,35 @@ def test_handles_zero_mini_critical_pass(tmp_path: Path):
     assert rc == 0
     assert dec["decision"] == "ABORT"
     assert dec["ratio"] == 0
+
+
+@pytest.mark.parametrize("unscored_side", ["hybrid", "mini"])
+def test_null_headline_is_unscored_and_has_no_delta(
+    tmp_path: Path, unscored_side: str
+):
+    tids = ["t01"]
+    hybrid = _grade(tids, critical_pass=1.0, avg_score=80.0)
+    mini = _grade(tids, critical_pass=1.0, avg_score=80.0)
+    target = hybrid if unscored_side == "hybrid" else mini
+    target["summary"]["openai_compat"]["avg_score_pct"] = None
+
+    rc, dec, md = _run(tmp_path, hybrid, mini)
+
+    assert rc == 0
+    assert dec[f"{unscored_side}_avg"] is None
+    assert "| avg_score_pct | unscored | 80.00 | — |" in md or (
+        "| avg_score_pct | 80.00 | unscored | — |" in md
+    )
+    assert "None" not in md
+
+
+def test_unscored_task_has_no_pairwise_delta(tmp_path: Path):
+    hybrid = _grade(["t01"], critical_pass=1.0, avg_score=80.0)
+    mini = _grade(["t01"], critical_pass=1.0, avg_score=60.32)
+    hybrid["tasks"][0]["pct"] = 0
+    hybrid["tasks"][0]["error"] = "all_items_score_excluded"
+
+    _, _, md = _run(tmp_path, hybrid, mini)
+
+    assert "| `t01…` | unscored | 60.32 | — |" in md
+    assert "-60.3" not in md

--- a/scripts/analyze_grade_run.py
+++ b/scripts/analyze_grade_run.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import statistics
 import sys
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 
@@ -133,42 +134,72 @@ def _hybrid_cost_estimate(grade: dict, total_in: int, total_out: int) -> dict:
     }
 
 
-def _perception_usage_by_modality(grade: dict) -> dict[str, dict[str, int]]:
-    usage: dict[str, dict[str, int]] = {}
+def _perception_usage_by_modality(
+    grade: dict,
+) -> dict[str, dict[str, int | float]]:
+    usage: dict[str, dict[str, int | float]] = {}
 
-    def add(modality: str, in_tok: int, out_tok: int, cached_tok: int) -> None:
+    def add(
+        modality: str,
+        in_tok: int,
+        out_tok: int,
+        cached_tok: int,
+        call_count: int,
+        latency_ms: float,
+    ) -> None:
         bucket = usage.setdefault(
-            modality, {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0}
+            modality,
+            {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cached_tokens": 0,
+                "call_count": 0,
+                "latency_ms": 0.0,
+            },
         )
         bucket["input_tokens"] += in_tok
         bucket["output_tokens"] += out_tok
         bucket["cached_tokens"] += cached_tok
+        bucket["call_count"] += call_count
+        bucket["latency_ms"] += latency_ms
 
-    task_total = {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0}
-    item_total = {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0}
+    task_total = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cached_tokens": 0,
+        "call_count": 0,
+        "latency_ms": 0.0,
+    }
+    item_total = dict(task_total)
     for task in grade.get("tasks", []):
         task_total["input_tokens"] += int(task.get("perception_input_tokens", 0) or 0)
         task_total["output_tokens"] += int(task.get("perception_output_tokens", 0) or 0)
         task_total["cached_tokens"] += int(task.get("perception_cached_tokens", 0) or 0)
+        task_total["call_count"] += int(task.get("perception_call_count", 0) or 0)
+        task_total["latency_ms"] += float(
+            task.get("perception_total_latency_ms", 0) or 0
+        )
         for item in task.get("items", []):
             in_tok = int(item.get("perception_input_tokens", 0) or 0)
             out_tok = int(item.get("perception_output_tokens", 0) or 0)
             cached_tok = int(item.get("perception_cached_tokens", 0) or 0)
-            if not (in_tok or out_tok or cached_tok):
+            call_count = int(item.get("perception_call_count", 0) or 0)
+            latency_ms = float(item.get("perception_total_latency_ms", 0) or 0)
+            if not (in_tok or out_tok or cached_tok or call_count or latency_ms):
                 continue
             modality = str(item.get("routing_modality") or "unknown")
             parent_usage = {
                 "input_tokens": in_tok,
                 "output_tokens": out_tok,
                 "cached_tokens": cached_tok,
+                "call_count": call_count,
+                "latency_ms": latency_ms,
             }
             if modality == "mixed" and isinstance(item.get("child_grades"), list):
-                child_usage = {
-                    "input_tokens": 0,
-                    "output_tokens": 0,
-                    "cached_tokens": 0,
-                }
-                child_buckets: list[tuple[str, dict[str, int]]] = []
+                child_usage = {key: 0 for key in parent_usage}
+                child_buckets: list[
+                    tuple[str, dict[str, int | float]]
+                ] = []
                 for child in item["child_grades"]:
                     if not isinstance(child, dict):
                         continue
@@ -181,6 +212,12 @@ def _perception_usage_by_modality(grade: dict) -> dict[str, dict[str, int]]:
                         ),
                         "cached_tokens": int(
                             child.get("perception_cached_tokens", 0) or 0
+                        ),
+                        "call_count": int(
+                            child.get("perception_call_count", 0) or 0
+                        ),
+                        "latency_ms": float(
+                            child.get("perception_total_latency_ms", 0) or 0
                         ),
                     }
                     if not any(child_values.values()):
@@ -203,6 +240,8 @@ def _perception_usage_by_modality(grade: dict) -> dict[str, dict[str, int]]:
                             values["input_tokens"],
                             values["output_tokens"],
                             values["cached_tokens"],
+                            values["call_count"],
+                            values["latency_ms"],
                         )
                     residual = {
                         key: parent_usage[key] - child_usage[key]
@@ -214,16 +253,31 @@ def _perception_usage_by_modality(grade: dict) -> dict[str, dict[str, int]]:
                             residual["input_tokens"],
                             residual["output_tokens"],
                             residual["cached_tokens"],
+                            residual["call_count"],
+                            residual["latency_ms"],
                         )
                 else:
-                    add("unknown", in_tok, out_tok, cached_tok)
+                    add(
+                        "unknown",
+                        in_tok,
+                        out_tok,
+                        cached_tok,
+                        call_count,
+                        latency_ms,
+                    )
             else:
                 if modality not in {"visual", "audio"}:
                     modality = "unknown"
-                add(modality, in_tok, out_tok, cached_tok)
-            item_total["input_tokens"] += in_tok
-            item_total["output_tokens"] += out_tok
-            item_total["cached_tokens"] += cached_tok
+                add(
+                    modality,
+                    in_tok,
+                    out_tok,
+                    cached_tok,
+                    call_count,
+                    latency_ms,
+                )
+            for key, value in parent_usage.items():
+                item_total[key] += value
 
     remainder = {
         key: max(0, task_total[key] - item_total[key])
@@ -235,8 +289,92 @@ def _perception_usage_by_modality(grade: dict) -> dict[str, dict[str, int]]:
             remainder["input_tokens"],
             remainder["output_tokens"],
             remainder["cached_tokens"],
+            int(remainder["call_count"]),
+            float(remainder["latency_ms"]),
         )
     return usage
+
+
+def _judge_error_type(item: dict) -> str:
+    evidence = str(item.get("evidence") or "").strip()
+    for public_prefix in ("provider_error:", "task_execution_error:"):
+        if evidence.startswith(public_prefix):
+            subtype = evidence[len(public_prefix):].split(":", 1)[0].strip()
+            return subtype or public_prefix.rstrip(":")
+    for prefix in (
+        "final_json_parse_failed",
+        "empty_final_text",
+        "invalid_final_envelope",
+        "RateLimitError",
+        "BadRequestError",
+        "selection_error",
+    ):
+        if evidence.startswith(prefix):
+            return prefix
+    if evidence:
+        return evidence.split(":", 1)[0][:80]
+    return "unknown"
+
+
+def _judge_error_types(item: dict) -> list[str]:
+    child_types = [
+        _judge_error_type(child)
+        for child in (item.get("child_grades") or [])
+        if isinstance(child, dict) and child.get("verdict") == "judge_error"
+    ]
+    return child_types or [_judge_error_type(item)]
+
+
+def _anchor_usage(values: dict[str, int | float] | None) -> dict:
+    values = values or {}
+    return {
+        "call_count": int(values.get("call_count", 0) or 0),
+        "input_tokens": int(values.get("input_tokens", 0) or 0),
+        "output_tokens": int(values.get("output_tokens", 0) or 0),
+        "cached_tokens": int(values.get("cached_tokens", 0) or 0),
+        "latency_sec": round(float(values.get("latency_ms", 0) or 0) / 1000, 2),
+    }
+
+
+def _task_anchor(task: dict) -> dict:
+    modality_usage = _perception_usage_by_modality({"tasks": [task]})
+    error_types = Counter(
+        error_type
+        for item in task.get("items", [])
+        if item.get("verdict") == "judge_error"
+        for error_type in _judge_error_types(item)
+    )
+    wall_time_ms = task.get("grading_wall_time_ms")
+    return {
+        "task_id": task.get("task_id"),
+        "wall_clock_sec": (
+            round(float(wall_time_ms) / 1000, 2)
+            if isinstance(wall_time_ms, (int, float)) else None
+        ),
+        "main": {
+            "call_count": int(task.get("judge_call_count", 0) or 0),
+            "input_tokens": int(task.get("judge_input_tokens", 0) or 0),
+            "output_tokens": int(task.get("judge_output_tokens", 0) or 0),
+            "cached_tokens": int(task.get("judge_cached_tokens", 0) or 0),
+            "latency_sec": round(
+                float(task.get("judge_total_latency_ms", 0) or 0) / 1000,
+                2,
+            ),
+        },
+        "visual": _anchor_usage(modality_usage.get("visual")),
+        "audio": _anchor_usage(modality_usage.get("audio")),
+        "unknown_perception": _anchor_usage(modality_usage.get("unknown")),
+        "render": {
+            "call_count": int(task.get("render_call_count", 0) or 0),
+            "latency_sec": round(
+                float(task.get("render_total_latency_ms", 0) or 0) / 1000,
+                2,
+            ),
+        },
+        "judge_error_types": dict(sorted(error_types.items())),
+        "usage_complete": bool(task.get("usage_complete", True)),
+        "error": task.get("error"),
+    }
 
 
 def _combined_cost_estimate(
@@ -255,9 +393,14 @@ def _combined_cost_estimate(
     unpriced_models = list(main.get("unpriced_models", []))
     perception_total = 0.0
     for modality, token_usage in sorted(perception_usage.items()):
+        if not any(
+            int(token_usage.get(key, 0) or 0)
+            for key in ("input_tokens", "output_tokens", "cached_tokens")
+        ):
+            continue
         model = (
             (perception_cfg.get(modality) or {}).get("model")
-            if modality in {"visual", "audio"} else None
+            if modality in {"visual", "audio"} else "unknown_perception_model"
         ) or main_model
         priced = model in PRICING_USD_PER_M_TOKENS
         estimate = _estimate_cost(
@@ -435,6 +578,25 @@ def analyze(path: Path) -> dict:
     cost = _combined_cost_estimate(
         grade, total_main_in, total_main_out, perception_usage
     )
+    task_anchors = [_task_anchor(task) for task in tasks]
+    judge_error_types = Counter()
+    for anchor in task_anchors:
+        judge_error_types.update(anchor["judge_error_types"])
+    measured_task_wall_times = [
+        anchor["wall_clock_sec"]
+        for anchor in task_anchors
+        if anchor["wall_clock_sec"] is not None
+    ]
+    projected_220_wall_hours = (
+        round(statistics.mean(measured_task_wall_times) * 220 / 3600, 2)
+        if measured_task_wall_times else None
+    )
+    if projected_220_wall_hours is None:
+        projection_status = "unmeasured"
+    elif projected_220_wall_hours >= 44:
+        projection_status = "at_or_above_44h_envelope"
+    else:
+        projection_status = "below_44h_envelope"
 
     # PR3 Step 0 — effective (cache-discounted) cost. Skipped if the run
     # used the legacy v1 path (no cached_tokens captured).
@@ -450,9 +612,15 @@ def analyze(path: Path) -> dict:
         ]
         perception_cfg = grade.get("judge", {}).get("perception", {}) or {}
         for modality, token_usage in sorted(perception_usage.items()):
+            if not any(
+                int(token_usage.get(key, 0) or 0)
+                for key in ("input_tokens", "output_tokens", "cached_tokens")
+            ):
+                continue
             model = (
                 (perception_cfg.get(modality) or {}).get("model")
-                if modality in {"visual", "audio"} else None
+                if modality in {"visual", "audio"}
+                else "unknown_perception_model"
             ) or main_model
             components.append(_effective_component(
                 token_usage["input_tokens"],
@@ -535,6 +703,10 @@ def analyze(path: Path) -> dict:
         "effective_cost": effective_cost,    # cache-discounted, None if no cached_tokens captured
         "cache_hit_ratio": cache_hit_ratio,
         "top5_slowest": enriched[:5],
+        "task_anchors": task_anchors,
+        "judge_error_types": dict(sorted(judge_error_types.items())),
+        "projected_220_wall_hours": projected_220_wall_hours,
+        "projection_status": projection_status,
     }
 
 
@@ -562,6 +734,10 @@ def _fmt_cost(c: dict) -> str:
     return "n/a"
 
 
+def _fmt_headline_score(value) -> str:
+    return "unscored" if value is None else str(value)
+
+
 def render_markdown(a: dict, base: dict | None = None) -> str:
     lines = []
     lines.append(f"# Grade Run Analysis — {a['exp_id']}\n")
@@ -570,7 +746,9 @@ def render_markdown(a: dict, base: dict | None = None) -> str:
     lines.append(f"- tasks: {a['graded_tasks']}/{a['total_tasks']} (errors={a['error_tasks']})")
     lines.append("")
     lines.append("## Quality")
-    lines.append(f"- avg_score_pct: **{a['avg_score_pct']}**")
+    lines.append(
+        f"- avg_score_pct: **{_fmt_headline_score(a['avg_score_pct'])}**"
+    )
     lines.append(f"- critical_item_pass_rate: **{a['critical_item_pass_rate']}**")
     lines.append(f"- judge_pass_rate: {a['judge_pass_rate']}")
     lines.append(f"- judge_error_rate: {a['judge_error_rate']}")
@@ -600,6 +778,56 @@ def render_markdown(a: dict, base: dict | None = None) -> str:
         f"usage_complete={a['usage_complete']}"
     )
     lines.append(f"- per-task avg (in,out): {a['avg_tokens_per_task_io']}")
+    lines.append("")
+    lines.append("## Task anchors")
+    lines.append(
+        "| task_id | wall (s) | main calls/tokens/latency | "
+        "visual calls/tokens/latency | audio calls/tokens/latency | "
+        "unknown perception calls/tokens/latency | judge errors |"
+    )
+    lines.append("|---|--:|---|---|---|---|---|")
+    for anchor in a["task_anchors"]:
+        main = anchor["main"]
+        visual = anchor["visual"]
+        audio = anchor["audio"]
+        unknown = anchor["unknown_perception"]
+        errors = ", ".join(
+            f"{name}:{count}"
+            for name, count in anchor["judge_error_types"].items()
+        ) or "none"
+        wall = anchor["wall_clock_sec"]
+        wall_text = "unmeasured" if wall is None else str(wall)
+        lines.append(
+            f"| `{anchor['task_id']}` | {wall_text} | "
+            f"{main['call_count']} / "
+            f"{main['input_tokens']},{main['output_tokens']},"
+            f"{main['cached_tokens']} / {main['latency_sec']}s | "
+            f"{visual['call_count']} / "
+            f"{visual['input_tokens']},{visual['output_tokens']},"
+            f"{visual['cached_tokens']} / {visual['latency_sec']}s | "
+            f"{audio['call_count']} / "
+            f"{audio['input_tokens']},{audio['output_tokens']},"
+            f"{audio['cached_tokens']} / {audio['latency_sec']}s | "
+            f"{unknown['call_count']} / "
+            f"{unknown['input_tokens']},{unknown['output_tokens']},"
+            f"{unknown['cached_tokens']} / {unknown['latency_sec']}s | "
+            f"{errors} |"
+        )
+    lines.append("")
+    lines.append(
+        "- judge_error_types: "
+        + (
+            ", ".join(
+                f"{name}:{count}"
+                for name, count in a["judge_error_types"].items()
+            )
+            or "none"
+        )
+    )
+    lines.append(
+        "- projected_220_wall_hours: "
+        f"{a['projected_220_wall_hours']} ({a['projection_status']})"
+    )
     lines.append("")
     lines.append("## Cost estimate")
     lines.append(f"- raw: {_fmt_cost(a['cost_estimate'])}")
@@ -636,6 +864,9 @@ def render_markdown(a: dict, base: dict | None = None) -> str:
                 d = round(tv - bv, 3) if (isinstance(bv, (int, float)) and isinstance(tv, (int, float))) else "—"
             except Exception:
                 d = "—"
+            if k == "avg_score_pct":
+                bv = _fmt_headline_score(bv)
+                tv = _fmt_headline_score(tv)
             lines.append(f"| {k} | {bv} | {tv} | {d} |")
     return "\n".join(lines) + "\n"
 

--- a/scripts/backfill_sign_aware.py
+++ b/scripts/backfill_sign_aware.py
@@ -124,6 +124,8 @@ def _recompute_summary(payload: dict) -> dict:
 
 def backfill_file(in_path: Path) -> Path:
     raw = json.loads(in_path.read_text(encoding="utf-8"))
+    if raw.get("schema_version") != "1.0":
+        raise ValueError("backfill requires schema 1.0 input")
     out = deepcopy(raw)
     out["schema_version"] = SCHEMA_VERSION_OUT
     out["tasks"] = [_recompute_task(deepcopy(t)) for t in out.get("tasks", [])]

--- a/scripts/compare_grades.py
+++ b/scripts/compare_grades.py
@@ -60,6 +60,23 @@ def _critical_summary(task: dict) -> dict:
     }
 
 
+def _format_score(value) -> str:
+    return "unscored" if value is None else f"{value:.2f}"
+
+
+def _format_score_delta(left, right) -> str:
+    if left is None or right is None:
+        return "—"
+    return f"{left - right:+.2f}"
+
+
+def _task_score(task: dict):
+    if task.get("error"):
+        return None
+    value = task.get("pct")
+    return value if isinstance(value, (int, float)) else None
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("hybrid_json", type=Path, help="hybrid (partial or full) grade JSON")
@@ -88,13 +105,19 @@ def main() -> int:
         mt = Mb[tid]
         hc = _critical_summary(ht)
         mc = _critical_summary(mt)
+        hybrid_pct = _task_score(ht)
+        mini_pct = _task_score(mt)
         rows.append({
             "task_id": tid,
-            "hybrid_pct": ht.get("pct"),
-            "mini_pct": mt.get("pct"),
+            "hybrid_pct": hybrid_pct,
+            "mini_pct": mini_pct,
             "hybrid_crit_pass": hc["pass_rate"],
             "mini_crit_pass": mc["pass_rate"],
-            "delta_pct": (ht.get("pct") or 0) - (mt.get("pct") or 0),
+            "delta_pct": (
+                hybrid_pct - mini_pct
+                if hybrid_pct is not None and mini_pct is not None
+                else None
+            ),
             "hybrid_crit_fails": hc["fails"][:3],  # top-3 only for report size
         })
         if (mc["pass_rate"] or 0) == 1.0 and (hc["pass_rate"] or 0) < 1.0:
@@ -138,7 +161,10 @@ def main() -> int:
     md.append("| metric | hybrid | mini | Δ |")
     md.append("|---|--:|--:|--:|")
     md.append(f"| critical_item_pass_rate | {h_cp:.3f} | {m_cp:.3f} | {h_cp - m_cp:+.3f} |")
-    md.append(f"| avg_score_pct | {h_avg:.2f} | {m_avg:.2f} | {h_avg - m_avg:+.2f} |")
+    md.append(
+        f"| avg_score_pct | {_format_score(h_avg)} | "
+        f"{_format_score(m_avg)} | {_format_score_delta(h_avg, m_avg)} |"
+    )
     md.append(f"| hybrid stricter than mini on critical (tasks) | {h_strict_when_mini_pass}/{n_pairs} ({strict_overhead*100:.1f}%) |  |  |")
     md.append(f"| both flagged critical fails (agreement) | {h_agrees_on_fail}/{n_pairs} ({agreement_on_fail*100:.1f}%) |  |  |\n")
 
@@ -147,8 +173,11 @@ def main() -> int:
     md.append("|---|--:|--:|--:|--:|--:|")
     for r in rows:
         md.append(
-            f"| `{r['task_id'][:18]}…` | {r['hybrid_pct']} | {r['mini_pct']} | "
-            f"{r['delta_pct']:+.1f} | {r['hybrid_crit_pass']} | {r['mini_crit_pass']} |"
+            f"| `{r['task_id'][:18]}…` | "
+            f"{_format_score(r['hybrid_pct'])} | "
+            f"{_format_score(r['mini_pct'])} | "
+            f"{_format_score_delta(r['hybrid_pct'], r['mini_pct'])} | "
+            f"{r['hybrid_crit_pass']} | {r['mini_crit_pass']} |"
         )
 
     md.append("\n## Sample hybrid critical FAILs (top 3 per task, first 5 tasks)")

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,10 +1,109 @@
 # Latest Task Result
 
-- Updated: 2026-08-08
+- Updated: 2026-08-10
+- Status: Sol Max full-rerun and three-task anchor preparation is reviewed and
+  validated; paid anchor dispatch awaits main integration and separate approval
+
+## Current Task: Sol Max Regrade Preparation
+
+### Task
+
+- Make schema `1.3` nullable headline scores safe in every analysis script that
+  will consume the future rerun.
+- Add a new pinned Sol Max full-220 config without modifying existing comparison
+  identities, and preserve dedicated audio perception and the visual task cap.
+- Prepare a small paid anchor that records task-level main, visual, and audio
+  volume, wall time, errors, and a serial 220-task time projection.
+- Do not run the full 220 tasks, modify historical grades, or dispatch paid work
+  before the new config reaches exact `main` and receives separate approval.
+
+### Result
+
+- `backfill_sign_aware.py` now accepts only schema `1.0`; it refuses schema
+  `1.3` rather than silently replacing a null headline with zero and emitting
+  schema `1.1`.
+- `compare_grades.py` renders null or errored aggregate/task scores as
+  `unscored` and emits no score delta. `analyze_grade_run.py` preserves null in
+  JSON and renders `unscored` in Markdown.
+- Added `regrade_exp003_v2_sol_max_score_excluded.yaml` for the planned full
+  rerun and `validation_exp003_v2_sol_max_anchor3.yaml` for the first paid
+  anchor. Both retain production Sol Max main/visual/finalization settings,
+  exact `gpt-audio-1.5` audio settings, and visual cap 72.
+- Step 8 measures `grading_wall_time_ms` around each `grade_task` call. The
+  analyzer now reports task-level wall time; main, visual, audio, and unknown
+  perception calls/tokens/cache/latency; render volume; usage completeness; and
+  public provider or split-child judge-error subtypes.
+- Unknown perception tokens are explicitly unpriced instead of being attributed
+  to the main model. Zero-token residual calls remain visible in task anchors
+  but do not create a false cost component.
+- The analyzer projects serial 220-task wall time from measured anchor task wall
+  times and labels whether it is below or at/above the 44-hour resume envelope.
+  It does not claim USD cost for unpriced models.
+
+### Fixed Identities
+
+| Purpose | Config hash | Tasks |
+|---|---|---:|
+| Full rerun | `14fc577ea39d98c5` | 220 |
+| Paid anchor | `25653df2d5841c97` | 3 |
+
+- Experiment: `exp003_GPT52Chat_baseline_runner_exec`.
+- Rubric commit: `11e7900cdcac61bc4daf59e65feb238acda98fbf`.
+- Inference revision: `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`.
+- Audio remains `gpt-audio-1.5`, call cap 3, trim 30 seconds. Visual cap remains
+  72. Tests reduce each new config to its baseline plus identity-only changes.
+
+### Anchor Decision
+
+- Chosen size: 3 tasks. Sol Max has no prior grade payload, so the first paid
+  exposure is bounded before considering the 10-task expansion.
+- Mini cohort 3: 532 main calls, 4 visual calls, 0 audio calls; main tokens
+  4,540,399 input / 176,531 output / 1,955,328 cached; visual tokens 4,751 /
+  1,032 / 0; summed judge latency 41.2 minutes; zero judge errors.
+- Mini cohort 10: 1,333 main calls, 26 visual calls, 0 audio calls; main tokens
+  6,833,450 / 369,014 / 3,389,440; visual tokens 30,282 / 6,836 / 0; summed
+  judge latency 88.8 minutes; zero judge errors.
+- Because both mini anchors are already at `judge_error_rate=0`, the Sol Max
+  anchor cannot establish a reduction below that floor. It can establish
+  call/token/time volume and detect a match or regression. Historical mini
+  payloads lack task wall time, so only the new anchor supports wall projection.
+
+### Verification
+
+- Nullable and analyzer scripts: 28 passed.
+- Config, Step 8, schema, tool-calling, audio, and perception: 312 passed.
+- Complete backend: 3,038 passed, 9 skipped, 45 integration tests deselected.
+- The three unchanged host dependency failures passed under exact temporary
+  Python 3.10 dependencies.
+- Self-preparing aggregate suite: 105 passed, 1 expected Ruby skip.
+- `npm run build`: passed with 2,783 transformed modules.
+- `py_compile`, VS Code diagnostics, and `git diff --check`: passed.
+- Existing Sol Max/mini configs, workflows, and `data/grades` are unchanged.
+  No credential, workflow dispatch, model call, or paid operation ran.
+
+### Review Evidence
+
+- Reviewed substantive head:
+  `eee62b8e3fc6cff0ed447781251cde37f10e6b4f`.
+- Independent `grading-engineer` and `first-reviewer` verdicts: `APPROVE`, with
+  no blocking findings.
+
+### Remaining Work
+
+- The owner decides whether and when to merge the reviewed preparation change.
+- After the configs reach exact `main`, a separate owner-approved protected
+  grading dispatch may run the three-task anchor. The result must be inspected
+  for task-level volume, error types, and projected 220-task wall time before
+  any full run or 10-task expansion decision.
+- Do not create a documentation-only PR to record this change's eventual merge
+  metadata.
+
+---
+
+## Preserved Prior Result: Judge Error Score Exclusion (2026-08-08)
+
 - Status: `judge_error` is score-excluded at runtime and remains visible in
   schema 1.3 summaries and the dashboard; no paid regrade was run
-
-## Current Task: Judge Error Score Exclusion
 
 ### Task
 


### PR DESCRIPTION
## Summary

- make schema 1.3 nullable headlines safe across backfill, comparison, and run analysis without substituting zero
- add pinned Sol Max configs for the planned full-220 rerun (`14fc577ea39d98c5`) and a bounded three-task paid anchor (`25653df2d5841c97`)
- preserve production `gpt-audio-1.5` audio perception (cap 3, trim 30s), Sol Max visual/finalization at max, and visual cap 72
- record task grading wall time and emit task-level main/visual/audio/unknown calls, tokens, cache, latency, public error types, and serial-220 wall projection
- treat unknown perception attribution as unpriced and retain null cost provenance

## Anchor choice

The first anchor uses three tasks because Sol Max has no prior grade payload. The corresponding mini cohort has 532 main calls, four visual calls, zero audio calls, 41.2 minutes summed judge latency, and zero judge errors. The ten-task mini cohort has 1,333 main calls, 26 visual calls, zero audio calls, 88.8 minutes summed latency, and zero errors.

Because both mini baselines are already at `judge_error_rate=0`, this anchor cannot prove an error-rate reduction below that floor. It can establish operational volume and detect a match or regression. Historical mini payloads lack task wall time; the new anchor records it prospectively.

## Fixed identity

- experiment: `exp003_GPT52Chat_baseline_runner_exec`
- rubric: `11e7900cdcac61bc4daf59e65feb238acda98fbf`
- inference: `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`
- full config: `regrade_exp003_v2_sol_max_score_excluded.yaml`, 220 tasks
- anchor config: `validation_exp003_v2_sol_max_anchor3.yaml`, 3 tasks

## Validation

- analysis scripts: 28 passed
- grading/config/schema/tool/audio/perception: 312 passed
- full backend: 3,038 passed, 9 skipped, 45 integration deselected
- three host-dependency failures separately passed under exact temporary Python 3.10 dependencies
- aggregate contracts: 105 passed, 1 expected Ruby skip
- production build: 2,783 modules transformed
- `py_compile`, diagnostics, and `git diff --check`: passed
- `grading-engineer` and `first-reviewer`: APPROVE
- reviewed substantive head: `eee62b8e3fc6cff0ed447781251cde37f10e6b4f`

## Safety and next gate

Existing comparison configs, workflows, and grade payloads are unchanged. No credential, workflow dispatch, model call, USD estimate, or paid operation ran. The grade workflow checks out exact `main`, so the paid anchor is intentionally deferred until this preparation reaches main. After owner merge, a separate owner-approved protected grading dispatch is required; no full-220 run or ten-task expansion is authorized by this PR.