### PR TITLE
fix(grading): pin multimodal Sol Max anchor4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,40 +12,32 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Changed
-- **Sol Max regrade preparation and anchor instrumentation** - preserve schema
-  `1.3` nullable headlines across grading analysis: the sign-aware backfill now
-  rejects non-`1.0` inputs instead of downgrading them, pairwise comparison
-  renders aggregate and task-level null/error scores as `unscored` without a
-  delta, and run analysis keeps null in JSON and Markdown. Add pinned exp003 Sol
-  Max configs for the planned full 220-task rerun and a bounded three-task paid
-  anchor. Their hashes are `14fc577ea39d98c5` and `25653df2d5841c97`;
-  both bind rubric commit `11e7900cdcac61bc4daf59e65feb238acda98fbf`
-  and inference revision `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`.
-  The production audio block remains byte-equivalent in semantics
-  (`gpt-audio-1.5`, three calls, 30-second trim), the visual cap remains 72,
-  and all existing comparison configs remain unchanged. Step 8 now records
-  measured per-task grading wall time. The analyzer emits task-level wall,
-  main/visual/audio/unknown calls, tokens, cache, latency, render usage, and
-  public judge-error subtypes, treats unknown perception token attribution as
-  unpriced, and projects serial 220-task wall time against the 44-hour resume
-  envelope without inventing USD cost. The three-task anchor is deliberately
-  smaller than ten because Sol Max has no prior payload; matching mini baselines
-  already have zero judge errors. Cohort 3 records 532 main and four visual
-  calls with 41.2 minutes summed latency; cohort 10 records 1,333 main and 26
-  visual calls with 88.8 minutes. Neither has an audio call or judge error, so
-  the first Sol Max anchor can establish operational volume and detect a
-  regression or match, but cannot prove improvement below the mini zero floor.
-  Validation passes 28 analysis tests, 312 grading/config/schema/perception
-  tests, 3,038 backend tests with nine skips and 45 integration deselections,
-  plus the three host-dependency cases under exact temporary Python 3.10
-  dependencies. Aggregate contracts pass 105 with one expected Ruby skip, the
-  production build transforms 2,783 modules, and `py_compile`, diagnostics,
-  and diff checks pass. No workflow, credential, paid model call, grade payload,
-  or existing config was changed or executed. Independent grading and code
-  reviews approved substantive head
-  `eee62b8e3fc6cff0ed447781251cde37f10e6b4f`. The paid anchor remains pending
-  because its config must first reach exact `main`; it requires a separate
-  owner-approved protected grading dispatch.
+- **Sol Max anchor4 task selection and modality-normalized projection** -
+  replace the three-task anchor with a four-task diagnostic/perception anchor
+  pinned to canonical inference-source order. The selected mini rows contain
+  13 `final_json_parse_failed` and nine `empty_final_text` outcomes, 234 main
+  calls, 2,449.19944 seconds of main latency, 43 visual criteria, and 13 audio
+  criteria. The tracked schema `1.0` baseline has no active perception, so it is
+  explicitly a main-judge-only reference rather than a Sol Max multiplier.
+  Step 8 now binds exact task IDs and an `anchor_projection` contract into the
+  config and grade payload, rejects CLI/limit conflicts, persists the subset as
+  diagnostic, and requires cache/resume contracts to match exactly. The
+  analyzer validates the current grade schema and repository config identity,
+  then projects main by `220/4`, visual by `337/43`, and audio by `58/13`.
+  Partial, reordered, malformed, identity-drifted, usage-incomplete, or
+  task-error payloads cannot emit a numeric projection. Non-targetable judge
+  errors, dead audio wiring, visual-budget overflow, unknown perception, no
+  finalization improvement, and a projected duration at or above 44 hours all
+  block the full-run gate; a clean result is only eligible for owner review.
+  The anchor config hash is `6dcff620fbe8dbf3`; the unchanged full-220 config
+  remains `14fc577ea39d98c5`. Validation passes 3,069 backend tests with six
+  skips and 45 integration deselections, 42 analyzer/baseline tests, 267
+  config/Step 8/schema tests, and 105 aggregate tests with one expected skip.
+  The production build transforms 2,783 modules, and `py_compile`, focused
+  Ruff, diagnostics, and diff checks pass. No workflow, historical grade,
+  protected comparison config, credential, model call, or paid dispatch was
+  changed or executed. Independent grading and code reviews approved
+  substantive head `ba7b1661fa7aadaa77192ec7b547826e123de5a7`.
 - **Judge errors excluded from score denominators** - make `judge_error` a
   visible unscored outcome rather than a model failure. Runtime aggregation now
   overrides stale producer flags, excludes judge failures from task numerators,

--- a/batch-runner/grading_configs/README.md
+++ b/batch-runner/grading_configs/README.md
@@ -8,7 +8,7 @@
 | `default_v2.yaml` | tool-calling judge | v2 | Historical gpt-5.4 medium comparison identity. Pass explicitly when reproducing that condition. |
 | `regrade_exp003_v2_mini_score_excluded.yaml` | tool-calling judge | v2 | Full-220 exp003 rerun only. Pins score-excluded semantics, the historical mini judge condition, rubric commit, inference revision, and exact task count. |
 | `regrade_exp003_v2_sol_max_score_excluded.yaml` | tool-calling judge | v2 | Planned full-220 exp003 Sol Max rerun. Pins score-excluded semantics, production judge/perception settings, rubric commit, inference revision, and exact task count. |
-| `validation_exp003_v2_sol_max_anchor3.yaml` | tool-calling judge | v2 | Paid three-task Sol Max anchor with the same runtime semantics and pinned source identities as the planned full rerun. |
+| `validation_exp003_v2_sol_max_anchor4.yaml` | tool-calling judge | v2 | Paid four-task Sol Max anchor with pinned diagnostic-error and visual/audio coverage, plus the same runtime semantics and source identities as the planned full rerun. |
 | `default_gpt5pro.yaml` | text-extract judge | v1 (`Judge` / `BatchJudge`) | Historical mini/text-extract comparison identity. Pass explicitly only for provenance-compatible analysis. |
 
 `grade-run.yml` defaults to `default_v2_sol_max.yaml`. The 1.05M context window
@@ -78,31 +78,107 @@ The pinned Sol Max identities are:
 | purpose | config | config hash | tasks |
 |---|---|---|---:|
 | full rerun | `regrade_exp003_v2_sol_max_score_excluded.yaml` | `14fc577ea39d98c5` | 220 |
-| paid anchor | `validation_exp003_v2_sol_max_anchor3.yaml` | `25653df2d5841c97` | 3 |
+| paid anchor | `validation_exp003_v2_sol_max_anchor4.yaml` | `6dcff620fbe8dbf3` | 4 |
 
 Both pin rubric commit `11e7900cdcac61bc4daf59e65feb238acda98fbf`
 and inference revision `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`.
 Their audio block remains the production `gpt-audio-1.5` configuration with a
 three-call task cap and 30-second trim, and their visual task cap remains 72.
 
-The first paid anchor is deliberately three tasks, not ten. There is no prior
-Sol Max grade payload, while the matching mini cohorts already report zero
-judge errors at both sizes. Three tasks bound the first exposure while still
-covering 536 mini baseline calls and four visual-perception calls. Consequently,
-the anchor can establish token/latency volume and detect an error-rate
-regression, but it cannot prove an error-rate reduction below the mini floor of
-zero. The ten-task mini baseline remains available for a later owner-approved
-expansion if the three-task anchor is operationally acceptable.
+The mini reference below is not like-for-like. Its tracked payload uses schema
+`1.0`, has no top-level `config_name` or `grader_source_hash`, and all 220 tasks
+have `perception_call_count=0`. Although its items are labelled with 337 visual
+and 58 audio routing decisions, those criteria predate perception wiring and
+were silently handled by the text judge. Therefore its calls and latency are a
+main-judge-only historical reference, not a "Sol Max multiplier" and not a
+basis for scaling newly active visual or audio work.
 
-| mini baseline | main calls | visual calls | audio calls | main tokens (in/out/cached) | visual tokens (in/out/cached) | audio tokens | summed judge latency | judge errors |
-|---|---:|---:|---:|---|---|---|---:|---:|
-| cohort3 | 532 | 4 | 0 | 4,540,399 / 176,531 / 1,955,328 | 4,751 / 1,032 / 0 | 0 / 0 / 0 | 41.2 min | 0 |
-| cohort10 | 1,333 | 26 | 0 | 6,833,450 / 369,014 / 3,389,440 | 30,282 / 6,836 / 0 | 0 / 0 / 0 | 88.8 min | 0 |
+### Pinned anchor tasks and selection rules
 
-These historical payloads predate task-level `grading_wall_time_ms`, so their
-true task wall-clock values cannot be reconstructed. The Sol Max anchor records
-that field prospectively and the analyzer projects serial 220-task wall time
-against the 44-hour resume envelope without inventing a USD estimate.
+The paid anchor pins these tasks in canonical inference-source order (the
+tracked payload array indices are authoritative):
+
+1. index 10 — `99ac6944-4ec6-4848-959c-a460ac705c6f`
+2. index 29 — `4c18ebae-dfaa-4b76-b10c-61fcdf26734c`
+3. index 78 — `40a8c4b1-b169-4f92-a38b-7f79685037ec`
+4. index 179 — `a73fbc98-90d4-4134-a54f-2b1d0c838791`
+
+The tasks were selected by targetable score-included mini errors, not by score.
+The baseline payload is
+`data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini.json`
+(SHA-256
+`b5cbb6a80c776b458f99f007841a946c1c5f9ec8bf60be052500713dd6f13570`).
+
+| task | final JSON parse | empty final text | targetable | visual | audio | main calls | main latency |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `99ac6944-4ec6-4848-959c-a460ac705c6f` | 2 | 1 | 3 | 10 | 13 | 52 | 679.03787 s |
+| `4c18ebae-dfaa-4b76-b10c-61fcdf26734c` | 5 | 1 | 6 | 1 | 0 | 50 | 387.76369 s |
+| `40a8c4b1-b169-4f92-a38b-7f79685037ec` | 3 | 5 | 8 | 0 | 0 | 72 | 635.26040 s |
+| `a73fbc98-90d4-4134-a54f-2b1d0c838791` | 3 | 2 | 5 | 32 | 0 | 60 | 747.13748 s |
+| **Total** | **13** | **9** | **22** | **43** | **13** | **234** | **2,449.19944 s** |
+
+These 22 errors are all `final_json_parse_failed` or `empty_final_text`; none is
+wrong-format, rate-limit, content-policy, or selection failure. They cover 22%
+of the 100 historical score-included judge errors while adding 43 visual and 13
+audio criteria. Every latency value and the
+2,449.19944-second total above are derived from raw `judge_total_latency_ms`;
+display precision is decimal formatting, not per-task truncation.
+
+When config `rerun_identity.task_ids` is present, Step 8 resolves it through the
+existing `filter_tasks` validation path. Canonical source order is authoritative.
+CLI `--tasks` is accepted only when it resolves to the same ordered task set;
+otherwise the run fails. `--limit` must be either `0` or the pinned count (`4`),
+so the protected workflow may continue to pass `tasks_limit=4` without adding a
+new workflow input. Any pinned subset is emitted as a diagnostic grade.
+
+### Preregistered anchor decision
+
+The paid result is judged against the same four mini task rows above:
+
+1. **Diagnostic outcome.** Count `final_json_parse_failed` and
+   `empty_final_text` by task. Fewer than the mini baseline total of 22 is an
+   improvement; zero is elimination. A total of 22 or more is **no improvement**
+   and means the model-switch rationale has no diagnostic support. Other judge
+   errors make the diagnostic inconclusive and block the full run; they cannot
+   be credited as finalization improvement. The
+   baseline is the four selected rows in the 220-task payload above, not a
+   different cohort payload.
+2. **Operational reference.** Report observed main calls and main latency
+   against 234 calls and 2,449.19944 seconds. Label those ratios
+   **main-judge-only references**, never Sol Max multipliers, because the mini
+   baseline had no active perception. Also report main, visual, audio, and
+   unknown token/cache/call/latency planes. No USD amount is inferred.
+3. **Modality-normalized projection.** Never extrapolate the whole anchor by
+   task count alone. Project and sum these components independently:
+   - main plane: scale the measured non-perception wall/main component by
+     `220 / 4 = 55`;
+   - visual: scale measured visual latency by `337 / 43 ≈ 7.837209`;
+   - audio: scale measured audio latency by `58 / 13 ≈ 4.461538`.
+   Unknown perception makes the projection incomplete. Compare the known
+   component total with the 44-hour envelope.
+4. **Wiring and cap gates.** `audio.call_count` must be greater than zero;
+   otherwise report dead audio wiring and stop before 220. The count of
+   `task_visual_budget_exceeded` must be zero; any occurrence means visual work
+   was silently excluded at cap 72 and blocks the full run.
+
+   At or above 44 hours, stop before a full run and return to the owner with the
+   existing choices: expand the chunk range, reduce the visual cap, or approve
+   an explicit split/resume plan. This preparation authorizes none of them.
+
+The analyzer only projects a JSON-Schema-valid `1.3` diagnostic payload whose
+current repository config file matches the persisted config name and hash, and
+whose judge/perception, rubric, inference, prompt, and four source-ordered task
+identities match that preregistered config. Partial/resume payloads, missing,
+duplicate, or reordered tasks, incomplete task/item/summary usage, and any
+task-level error make the projection incomplete and block owner review.
+For an anchor config identity, a missing or `null` `anchor_projection` is also
+blocked rather than falling back to task-count extrapolation. Step 8 requires
+the persisted projection contract to exactly match the current config before
+accepting either a completed cache entry or a partial `--resume` payload.
+
+All diagnostic, operational, modality, audio, visual-budget, and envelope
+results must be reported numerically. Improvement alone does not justify the
+full run if any wiring, cap, unknown-attribution, or time gate fails.
 
 ## Archived (no longer recommended)
 

--- a/batch-runner/grading_configs/validation_exp003_v2_sol_max_anchor4.yaml
+++ b/batch-runner/grading_configs/validation_exp003_v2_sol_max_anchor4.yaml
@@ -1,14 +1,39 @@
 schema_version: "2.0"
-config_name: "validation_exp003_v2_sol_max_anchor3"
+config_name: "validation_exp003_v2_sol_max_anchor4"
 description: |
-  Paid three-task Sol Max anchor for exp003. Runtime grading semantics match
-  the pinned full rerun; only the config identity and expected task count differ.
+  Paid four-task Sol Max anchor for exp003. Runtime grading semantics match
+  the pinned full rerun; only the config identity and anchored task set differ.
 
 rerun_identity:
   experiment_id: "exp003_GPT52Chat_baseline_runner_exec"
-  expected_task_count: 3
+  expected_task_count: 4
   rubric_commit_sha: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
   inference_revision: "9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f"
+  task_ids:
+    - "99ac6944-4ec6-4848-959c-a460ac705c6f"
+    - "4c18ebae-dfaa-4b76-b10c-61fcdf26734c"
+    - "40a8c4b1-b169-4f92-a38b-7f79685037ec"
+    - "a73fbc98-90d4-4134-a54f-2b1d0c838791"
+
+anchor_projection:
+  method: "modality_normalized_v1"
+  anchor_config_name: "validation_exp003_v2_sol_max_anchor4"
+  anchor_task_count: 4
+  anchor_ordered_task_ids_sha256: "29d5623a5cec85eb38f21fb73a2f3b06c66ed6a5fd6fd95948b979cd70a70bc9"
+  anchor_source_inference_repo_id: "HyeonSang/exp003_GPT52Chat_baseline_runner_exec"
+  baseline_payload_sha256: "b5cbb6a80c776b458f99f007841a946c1c5f9ec8bf60be052500713dd6f13570"
+  baseline_schema_version: "1.0"
+  baseline_perception_wired: false
+  baseline_main_calls: 234
+  baseline_main_latency_ms: 2449199.44
+  baseline_final_json_parse_failed: 13
+  baseline_empty_final_text: 9
+  anchor_visual_criteria: 43
+  anchor_audio_criteria: 13
+  full_task_count: 220
+  full_visual_criteria: 337
+  full_audio_criteria: 58
+  chunk_envelope_hours: 44
 
 judge:
   provider: "azure_openai"

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -235,6 +235,50 @@
       "type": ["string", "null"],
       "pattern": "^[0-9a-f]{40}$"
     },
+    "anchor_projection": {
+      "type": ["object", "null"],
+      "required": [
+        "method",
+        "anchor_config_name",
+        "anchor_task_count",
+        "anchor_ordered_task_ids_sha256",
+        "anchor_source_inference_repo_id",
+        "baseline_payload_sha256",
+        "baseline_schema_version",
+        "baseline_perception_wired",
+        "baseline_main_calls",
+        "baseline_main_latency_ms",
+        "baseline_final_json_parse_failed",
+        "baseline_empty_final_text",
+        "anchor_visual_criteria",
+        "anchor_audio_criteria",
+        "full_task_count",
+        "full_visual_criteria",
+        "full_audio_criteria",
+        "chunk_envelope_hours"
+      ],
+      "properties": {
+        "method": {"const": "modality_normalized_v1"},
+        "anchor_config_name": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+        "anchor_task_count": {"type": "integer", "minimum": 1},
+        "anchor_ordered_task_ids_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "anchor_source_inference_repo_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$"},
+        "baseline_payload_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "baseline_schema_version": {"const": "1.0"},
+        "baseline_perception_wired": {"const": false},
+        "baseline_main_calls": {"type": "integer", "minimum": 1},
+        "baseline_main_latency_ms": {"type": "number", "exclusiveMinimum": 0},
+        "baseline_final_json_parse_failed": {"type": "integer", "minimum": 1},
+        "baseline_empty_final_text": {"type": "integer", "minimum": 1},
+        "anchor_visual_criteria": {"type": "integer", "minimum": 1},
+        "anchor_audio_criteria": {"type": "integer", "minimum": 1},
+        "full_task_count": {"type": "integer", "minimum": 1},
+        "full_visual_criteria": {"type": "integer", "minimum": 1},
+        "full_audio_criteria": {"type": "integer", "minimum": 1},
+        "chunk_envelope_hours": {"type": "integer", "minimum": 1}
+      },
+      "additionalProperties": false
+    },
     "source_azure_ai_routes": {
       "type": "array",
       "items": {

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -479,10 +479,16 @@ def validate_grading_config(config: dict) -> None:
             "rubric_commit_sha",
             "inference_revision",
         }
-        if set(rerun_identity) != required_identity_fields:
+        allowed_identity_fields = required_identity_fields | {"task_ids"}
+        identity_fields = set(rerun_identity)
+        if (
+            not required_identity_fields.issubset(identity_fields)
+            or not identity_fields.issubset(allowed_identity_fields)
+        ):
             raise ValueError(
-                "rerun_identity must contain exactly experiment_id, "
-                "expected_task_count, rubric_commit_sha, and inference_revision"
+                "rerun_identity must contain experiment_id, "
+                "expected_task_count, rubric_commit_sha, and inference_revision; "
+                "task_ids is the only optional field"
             )
         experiment_id = rerun_identity["experiment_id"]
         if not isinstance(experiment_id, str) or not re.fullmatch(
@@ -503,6 +509,150 @@ def validate_grading_config(config: dict) -> None:
         if rubric["revision"] != rerun_identity["rubric_commit_sha"]:
             raise ValueError(
                 "rubric.revision must match rerun_identity.rubric_commit_sha"
+            )
+        task_ids = rerun_identity.get("task_ids")
+        if task_ids is not None:
+            if not isinstance(task_ids, list) or not task_ids:
+                raise ValueError("rerun_identity.task_ids must be a non-empty list")
+            if any(
+                not isinstance(task_id, str)
+                or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", task_id)
+                for task_id in task_ids
+            ):
+                raise ValueError("rerun_identity.task_ids contains an invalid task ID")
+            if len(task_ids) != len(set(task_ids)):
+                raise ValueError("rerun_identity.task_ids contains duplicate task IDs")
+            if len(task_ids) != expected_task_count:
+                raise ValueError(
+                    "rerun_identity.task_ids count must match expected_task_count"
+                )
+
+    anchor_projection = config.get("anchor_projection")
+    if anchor_projection is not None:
+        if not isinstance(anchor_projection, dict):
+            raise ValueError("anchor_projection must be an object")
+        if not isinstance(rerun_identity, dict) or not rerun_identity.get("task_ids"):
+            raise ValueError("anchor_projection requires pinned rerun task_ids")
+        required_projection_fields = {
+            "method",
+            "anchor_config_name",
+            "anchor_task_count",
+            "anchor_ordered_task_ids_sha256",
+            "anchor_source_inference_repo_id",
+            "baseline_payload_sha256",
+            "baseline_schema_version",
+            "baseline_perception_wired",
+            "baseline_main_calls",
+            "baseline_main_latency_ms",
+            "baseline_final_json_parse_failed",
+            "baseline_empty_final_text",
+            "anchor_visual_criteria",
+            "anchor_audio_criteria",
+            "full_task_count",
+            "full_visual_criteria",
+            "full_audio_criteria",
+            "chunk_envelope_hours",
+        }
+        if set(anchor_projection) != required_projection_fields:
+            raise ValueError(
+                "anchor_projection fields must match the versioned contract"
+            )
+        if anchor_projection["method"] != "modality_normalized_v1":
+            raise ValueError("anchor_projection.method is invalid")
+        if anchor_projection["anchor_config_name"] != config["config_name"]:
+            raise ValueError(
+                "anchor_projection config name must match config_name"
+            )
+        if not FULL_SHA256_RE.fullmatch(
+            str(anchor_projection["anchor_ordered_task_ids_sha256"])
+        ):
+            raise ValueError("anchor_projection task identity SHA is invalid")
+        if not re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*",
+            str(anchor_projection["anchor_source_inference_repo_id"]),
+        ):
+            raise ValueError(
+                "anchor_projection source inference repo is invalid"
+            )
+        experiment_path = (
+            _batch_runner_root()
+            / "experiments"
+            / f"{rerun_identity['experiment_id']}.yaml"
+        )
+        try:
+            experiment = yaml.safe_load(
+                experiment_path.read_text(encoding="utf-8")
+            )
+        except (OSError, yaml.YAMLError) as exc:
+            raise ValueError(
+                "anchor_projection experiment source is unavailable"
+            ) from exc
+        experiment_source = str(
+            (experiment or {}).get("data", {}).get("source", "")
+        ).strip()
+        if (
+            anchor_projection["anchor_source_inference_repo_id"]
+            != experiment_source
+        ):
+            raise ValueError(
+                "anchor_projection source repo must match experiment source"
+            )
+        if not FULL_SHA256_RE.fullmatch(
+            str(anchor_projection["baseline_payload_sha256"])
+        ):
+            raise ValueError("anchor_projection baseline payload SHA is invalid")
+        if anchor_projection["baseline_schema_version"] != "1.0":
+            raise ValueError("anchor_projection baseline schema must be 1.0")
+        if anchor_projection["baseline_perception_wired"] is not False:
+            raise ValueError(
+                "anchor_projection baseline perception must remain unwired"
+            )
+        positive_integer_fields = (
+            "anchor_task_count",
+            "baseline_main_calls",
+            "baseline_final_json_parse_failed",
+            "baseline_empty_final_text",
+            "anchor_visual_criteria",
+            "anchor_audio_criteria",
+            "full_task_count",
+            "full_visual_criteria",
+            "full_audio_criteria",
+            "chunk_envelope_hours",
+        )
+        if any(
+            type(anchor_projection[field_name]) is not int
+            or anchor_projection[field_name] <= 0
+            for field_name in positive_integer_fields
+        ):
+            raise ValueError(
+                "anchor_projection count and envelope fields must be positive integers"
+            )
+        baseline_latency = anchor_projection["baseline_main_latency_ms"]
+        if (
+            not isinstance(baseline_latency, (int, float))
+            or not math.isfinite(baseline_latency)
+            or baseline_latency <= 0
+        ):
+            raise ValueError(
+                "anchor_projection baseline main latency must be positive"
+            )
+        if anchor_projection["full_task_count"] < len(
+            rerun_identity["task_ids"]
+        ):
+            raise ValueError(
+                "anchor_projection full task count is smaller than anchor"
+            )
+        if anchor_projection["anchor_task_count"] != len(
+            rerun_identity["task_ids"]
+        ):
+            raise ValueError(
+                "anchor_projection task count must match pinned task_ids"
+            )
+        if anchor_projection["anchor_ordered_task_ids_sha256"] != (
+            _ordered_task_ids_sha256(rerun_identity["task_ids"])
+        ):
+            raise ValueError(
+                "anchor_projection task identity must match pinned task_ids"
             )
 
 
@@ -579,6 +729,7 @@ def _validate_grade_resume_identity(
     source_inference_revision: str,
     grader_source_hash: str,
     renderer_fingerprint: dict[str, str] | None,
+    anchor_projection: dict | None,
 ) -> None:
     checks = (
         ("schema_version", existing.get("schema_version"), SCHEMA_VERSION),
@@ -616,6 +767,11 @@ def _validate_grade_resume_identity(
             existing.get("grader_source_hash"),
             grader_source_hash,
         ),
+        (
+            "anchor_projection",
+            existing.get("anchor_projection"),
+            anchor_projection,
+        ),
     )
     if renderer_fingerprint is not None:
         checks += ((
@@ -636,16 +792,18 @@ def _validate_pinned_rerun_identity(
     config: dict,
     *,
     experiment_id: str,
-    task_count: int,
+    task_ids: list[str] | None = None,
+    task_count: int | None = None,
     rubric_commit_sha: str,
     inference_revision: str | None,
 ) -> None:
     identity = config.get("rerun_identity")
     if identity is None:
         return
+    actual_task_count = len(task_ids) if task_ids is not None else task_count
     checks = (
         ("experiment_id", experiment_id, identity["experiment_id"]),
-        ("task_count", task_count, identity["expected_task_count"]),
+        ("task_count", actual_task_count, identity["expected_task_count"]),
         (
             "rubric_commit_sha",
             rubric_commit_sha,
@@ -663,6 +821,12 @@ def _validate_pinned_rerun_identity(
                 f"pinned rerun identity mismatch for {field_name}: "
                 f"actual={actual!r}, expected={expected!r}"
             )
+    expected_task_ids = identity.get("task_ids")
+    if expected_task_ids is not None and task_ids != expected_task_ids:
+        raise ValueError(
+            "pinned rerun identity mismatch for task_ids: "
+            f"actual={task_ids!r}, expected={expected_task_ids!r}"
+        )
 
 
 def _validate_azure_ai_resume_identity(
@@ -817,6 +981,45 @@ def filter_tasks(inference_results: dict, tasks_csv: str | None, limit: int) -> 
     if limit > 0:
         tasks = tasks[:limit]
     return tasks
+
+
+def filter_tasks_for_config(
+    inference_results: dict,
+    config: dict,
+    *,
+    tasks_csv: str | None,
+    limit: int,
+) -> tuple[list[dict], bool]:
+    identity = config.get("rerun_identity")
+    pinned_ids = identity.get("task_ids") if isinstance(identity, dict) else None
+    if pinned_ids is None:
+        return filter_tasks(inference_results, tasks_csv, limit), False
+
+    pinned_tasks = filter_tasks(
+        inference_results,
+        ",".join(pinned_ids),
+        0,
+    )
+    canonical_pinned_ids = [task["task_id"] for task in pinned_tasks]
+    if canonical_pinned_ids != pinned_ids:
+        raise ValueError(
+            "config pinned task selection must follow canonical source order"
+        )
+
+    if tasks_csv is not None:
+        cli_tasks = filter_tasks(inference_results, tasks_csv, 0)
+        cli_ids = [task["task_id"] for task in cli_tasks]
+        if cli_ids != canonical_pinned_ids:
+            raise ValueError(
+                "CLI --tasks conflicts with config pinned task selection"
+            )
+
+    if limit not in {0, len(canonical_pinned_ids)}:
+        raise ValueError(
+            "--limit conflicts with config pinned task selection: "
+            f"expected 0 or {len(canonical_pinned_ids)}, got {limit}"
+        )
+    return pinned_tasks, True
 
 
 def _track2_task_runtime_error(task: dict) -> str | None:
@@ -1169,6 +1372,7 @@ def _build_grade_payload(
         "azure_ai_runtime_fingerprint": azure_ai_runtime_fingerprint,
         "grader_source_hash": grader_source_hash,
         "renderer_fingerprint": renderer_fingerprint,
+        "anchor_projection": config.get("anchor_projection"),
         "inference_model": _resolve_inference_model(inf_results, exp_config),
         "inference_completed_at": inf_results.get("completed_at"),
         "judge": {
@@ -1280,7 +1484,12 @@ def main() -> int:
     judge_slug = _judge_slug(config["judge"]["model"])
     prompt_v = config["prompt"]["version"]
     try:
-        tasks = filter_tasks(inf_results, args.tasks, args.limit)
+        tasks, config_pinned_task_selection = filter_tasks_for_config(
+            inf_results,
+            config,
+            tasks_csv=args.tasks,
+            limit=args.limit,
+        )
     except ValueError as exc:
         print(f"ERROR: invalid grading task selection: {exc}", file=sys.stderr)
         return 1
@@ -1289,7 +1498,7 @@ def main() -> int:
         _validate_pinned_rerun_identity(
             config,
             experiment_id=args.experiment_yaml_name,
-            task_count=len(tasks),
+            task_ids=[task["task_id"] for task in tasks],
             rubric_commit_sha=rubric_sha,
             inference_revision=inference_revision,
         )
@@ -1302,7 +1511,8 @@ def main() -> int:
         "azure_ai_provenance_status", "local-runtime"
     )
     diagnostic_run = (
-        args.tasks is not None
+        config_pinned_task_selection
+        or args.tasks is not None
         or args.limit > 0
         or source_provenance_status == "legacy-missing"
     )
@@ -1386,6 +1596,7 @@ def main() -> int:
                 renderer_fingerprint=(
                     renderer_fingerprint if renderer_required else None
                 ),
+                anchor_projection=config.get("anchor_projection"),
             )
             _validate_grade_task_set(
                 existing,
@@ -1443,6 +1654,7 @@ def main() -> int:
                 renderer_fingerprint=(
                     renderer_fingerprint if renderer_required else None
                 ),
+                anchor_projection=config.get("anchor_projection"),
             )
             completed_task_ids = _validate_grade_task_set(
                 existing, tasks, require_complete=False

--- a/batch-runner/tests/test_grading_config.py
+++ b/batch-runner/tests/test_grading_config.py
@@ -176,7 +176,7 @@ def test_grade_workflow_defaults_to_v2_sol_max():
         "default_v2_tight.yaml",
         "regrade_exp003_v2_mini_score_excluded.yaml",
         "regrade_exp003_v2_sol_max_score_excluded.yaml",
-        "validation_exp003_v2_sol_max_anchor3.yaml",
+        "validation_exp003_v2_sol_max_anchor4.yaml",
         "validation_v2_mini_cohort3.yaml",
         "validation_v2_mini_cohort10.yaml",
     ],
@@ -273,9 +273,9 @@ def test_exp003_score_excluded_rerun_identity_is_pinned():
             "14fc577ea39d98c5",
         ),
         (
-            "validation_exp003_v2_sol_max_anchor3.yaml",
-            3,
-            "25653df2d5841c97",
+            "validation_exp003_v2_sol_max_anchor4.yaml",
+            4,
+            "6dcff620fbe8dbf3",
         ),
     ],
 )
@@ -292,23 +292,62 @@ def test_exp003_sol_max_configs_are_pinned_and_preserve_modalities(
     validate_grading_config(candidate)
 
     identity = candidate["rerun_identity"]
-    assert identity == {
+    expected_identity = {
         "experiment_id": "exp003_GPT52Chat_baseline_runner_exec",
         "expected_task_count": expected_task_count,
         "rubric_commit_sha": "11e7900cdcac61bc4daf59e65feb238acda98fbf",
         "inference_revision": "9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f",
     }
+    if expected_task_count == 4:
+        expected_identity["task_ids"] = [
+            "99ac6944-4ec6-4848-959c-a460ac705c6f",
+            "4c18ebae-dfaa-4b76-b10c-61fcdf26734c",
+            "40a8c4b1-b169-4f92-a38b-7f79685037ec",
+            "a73fbc98-90d4-4134-a54f-2b1d0c838791",
+        ]
+    assert identity == expected_identity
     assert candidate["rubric"]["revision"] == identity["rubric_commit_sha"]
     assert hash_config(str(candidate_path)) == expected_hash
     assert candidate["judge"]["perception"]["audio"] == (
         baseline["judge"]["perception"]["audio"]
     )
     assert candidate["judge"]["perception"]["visual"]["call_cap_per_task"] == 72
+    if expected_task_count == 220:
+        assert "task_ids" not in identity
+        assert "anchor_projection" not in candidate
+    else:
+        assert candidate["anchor_projection"] == {
+            "method": "modality_normalized_v1",
+            "anchor_config_name": "validation_exp003_v2_sol_max_anchor4",
+            "anchor_task_count": 4,
+            "anchor_ordered_task_ids_sha256": (
+                "29d5623a5cec85eb38f21fb73a2f3b06c66ed6a5fd6fd95948b979cd70a70bc9"
+            ),
+            "anchor_source_inference_repo_id": (
+                "HyeonSang/exp003_GPT52Chat_baseline_runner_exec"
+            ),
+            "baseline_payload_sha256": (
+                "b5cbb6a80c776b458f99f007841a946c1c5f9ec8bf60be052500713dd6f13570"
+            ),
+            "baseline_schema_version": "1.0",
+            "baseline_perception_wired": False,
+            "baseline_main_calls": 234,
+            "baseline_main_latency_ms": 2449199.44,
+            "baseline_final_json_parse_failed": 13,
+            "baseline_empty_final_text": 9,
+            "anchor_visual_criteria": 43,
+            "anchor_audio_criteria": 13,
+            "full_task_count": 220,
+            "full_visual_criteria": 337,
+            "full_audio_criteria": 58,
+            "chunk_envelope_hours": 44,
+        }
 
     for key in ("config_name", "description"):
         baseline.pop(key)
         candidate.pop(key)
     candidate.pop("rerun_identity")
+    candidate.pop("anchor_projection", None)
     baseline["rubric"]["revision"] = identity["rubric_commit_sha"]
     assert candidate == baseline
 
@@ -329,6 +368,130 @@ def test_sol_max_rerun_identity_rejects_invalid_values(
     path = Path("grading_configs/regrade_exp003_v2_sol_max_score_excluded.yaml")
     config = yaml.safe_load(path.read_text(encoding="utf-8"))
     config["rerun_identity"][field] = value
+
+    with pytest.raises(ValueError, match=message):
+        validate_grading_config(config)
+
+
+def test_sol_max_anchor_acceptance_is_preregistered():
+    readme = Path("grading_configs/README.md").read_text(encoding="utf-8")
+
+    for task_id in (
+        "99ac6944-4ec6-4848-959c-a460ac705c6f",
+        "40a8c4b1-b169-4f92-a38b-7f79685037ec",
+        "4c18ebae-dfaa-4b76-b10c-61fcdf26734c",
+        "a73fbc98-90d4-4134-a54f-2b1d0c838791",
+    ):
+        assert task_id in readme
+    for expected in (
+        "final_json_parse_failed",
+        "empty_final_text",
+        "2,449.19944",
+        "6dcff620fbe8dbf3",
+        "337 / 43",
+        "58 / 13",
+        "44-hour",
+        "main-judge-only reference",
+        "task_visual_budget_exceeded",
+    ):
+        assert expected in readme
+
+
+def test_anchor_task_ids_are_unique_and_match_expected_count():
+    path = Path("grading_configs/validation_exp003_v2_sol_max_anchor4.yaml")
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    identity = config["rerun_identity"]
+
+    assert identity["task_ids"] == [
+        "99ac6944-4ec6-4848-959c-a460ac705c6f",
+        "4c18ebae-dfaa-4b76-b10c-61fcdf26734c",
+        "40a8c4b1-b169-4f92-a38b-7f79685037ec",
+        "a73fbc98-90d4-4134-a54f-2b1d0c838791",
+    ]
+    assert len(identity["task_ids"]) == identity["expected_task_count"] == 4
+    assert len(set(identity["task_ids"])) == 4
+
+
+@pytest.mark.parametrize(
+    ("task_ids", "expected_task_count", "message"),
+    [
+        (["task-a", "task-a"], 2, "duplicate"),
+        (["task-a", "task-b"], 3, "expected_task_count"),
+        (["task-a,b", "task-c"], 2, "task_ids"),
+    ],
+)
+def test_rerun_identity_rejects_invalid_task_ids(
+    task_ids: list[str],
+    expected_task_count: int,
+    message: str,
+):
+    path = Path("grading_configs/validation_exp003_v2_sol_max_anchor4.yaml")
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    config["rerun_identity"]["task_ids"] = task_ids
+    config["rerun_identity"]["expected_task_count"] = expected_task_count
+
+    with pytest.raises(ValueError, match=message):
+        validate_grading_config(config)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda config: config.pop("rerun_identity"), "requires pinned"),
+        (
+            lambda config: config["anchor_projection"].__setitem__(
+                "baseline_perception_wired",
+                True,
+            ),
+            "perception",
+        ),
+        (
+            lambda config: config["anchor_projection"].__setitem__(
+                "anchor_audio_criteria",
+                0,
+            ),
+            "positive integers",
+        ),
+        (
+            lambda config: config["anchor_projection"].__setitem__(
+                "anchor_task_count",
+                3,
+            ),
+            "must match pinned task_ids",
+        ),
+        (
+            lambda config: config["anchor_projection"].__setitem__(
+                "anchor_config_name",
+                "wrong_config",
+            ),
+            "must match config_name",
+        ),
+        (
+            lambda config: config["anchor_projection"].__setitem__(
+                "anchor_ordered_task_ids_sha256",
+                "0" * 64,
+            ),
+            "must match pinned task_ids",
+        ),
+        (
+            lambda config: config["anchor_projection"].__setitem__(
+                "anchor_source_inference_repo_id",
+                "other/repo",
+            ),
+            "must match experiment source",
+        ),
+        (
+            lambda config: config["anchor_projection"].pop(
+                "full_visual_criteria"
+            ),
+            "versioned contract",
+        ),
+    ],
+)
+def test_anchor_projection_rejects_invalid_contract(mutation, message):
+    path = Path("grading_configs/validation_exp003_v2_sol_max_anchor4.yaml")
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    mutation(config)
 
     with pytest.raises(ValueError, match=message):
         validate_grading_config(config)

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -1528,7 +1528,58 @@ def test_resume_rejects_previous_score_semantics():
             source_inference_revision="b" * 40,
             grader_source_hash="c" * 64,
             renderer_fingerprint=None,
+            anchor_projection=None,
         )
+
+
+def _validate_resume_anchor_projection(
+    existing: dict,
+    expected: dict | None,
+) -> None:
+    s8._validate_grade_resume_identity(
+        existing,
+        experiment_id="exp003",
+        rubric_commit_sha="a" * 40,
+        prompt_version="v2.2",
+        config_hash="0123456789abcdef",
+        source_inference_repo_id="owner/repo",
+        source_inference_revision="b" * 40,
+        grader_source_hash="c" * 64,
+        renderer_fingerprint=None,
+        anchor_projection=expected,
+    )
+
+
+def _matching_resume_identity() -> dict:
+    return {
+        "schema_version": "1.3",
+        "experiment_id": "exp003",
+        "rubric": {"commit_sha": "a" * 40},
+        "prompt": {"version": "v2.2"},
+        "judge": {"config_hash": "0123456789abcdef"},
+        "source_inference_repo_id": "owner/repo",
+        "source_inference_revision": "b" * 40,
+        "grader_source_hash": "c" * 64,
+    }
+
+
+def test_resume_accepts_exact_anchor_projection_contract():
+    contract = {"method": "modality_normalized_v1"}
+    existing = _matching_resume_identity()
+    existing["anchor_projection"] = contract
+
+    _validate_resume_anchor_projection(existing, contract)
+
+
+@pytest.mark.parametrize("persisted", ["missing", None, {"method": "other"}])
+def test_resume_rejects_anchor_projection_contract_drift(persisted):
+    contract = {"method": "modality_normalized_v1"}
+    existing = _matching_resume_identity()
+    if persisted != "missing":
+        existing["anchor_projection"] = persisted
+
+    with pytest.raises(ValueError, match="anchor_projection"):
+        _validate_resume_anchor_projection(existing, contract)
 
 
 @pytest.mark.parametrize(
@@ -1578,6 +1629,179 @@ def test_pinned_rerun_identity_accepts_exact_full_run():
         rubric_commit_sha="a" * 40,
         inference_revision="b" * 40,
     )
+
+
+def _pinned_task_config() -> dict:
+    return {
+        "rerun_identity": {
+            "experiment_id": "exp003",
+            "expected_task_count": 2,
+            "rubric_commit_sha": "a" * 40,
+            "inference_revision": "b" * 40,
+            "task_ids": ["task-002", "task-003"],
+        }
+    }
+
+
+def _selection_inference() -> dict:
+    return {
+        "results": [
+            {"task_id": "task-001"},
+            {"task_id": "task-002"},
+            {"task_id": "task-003"},
+        ]
+    }
+
+
+def test_config_pinned_tasks_apply_without_cli_selection():
+    selected, pinned = s8.filter_tasks_for_config(
+        _selection_inference(),
+        _pinned_task_config(),
+        tasks_csv=None,
+        limit=0,
+    )
+
+    assert [task["task_id"] for task in selected] == ["task-002", "task-003"]
+    assert pinned is True
+
+
+def test_matching_cli_tasks_are_accepted_in_canonical_source_order():
+    selected, pinned = s8.filter_tasks_for_config(
+        _selection_inference(),
+        _pinned_task_config(),
+        tasks_csv="task-003,task-002",
+        limit=2,
+    )
+
+    assert [task["task_id"] for task in selected] == ["task-002", "task-003"]
+    assert pinned is True
+
+
+@pytest.mark.parametrize(
+    ("tasks_csv", "limit"),
+    [
+        ("task-001,task-002", 2),
+        (None, 1),
+        (None, 3),
+    ],
+)
+def test_pinned_selection_rejects_cli_or_limit_mismatch(tasks_csv, limit):
+    with pytest.raises(ValueError, match="pinned task selection"):
+        s8.filter_tasks_for_config(
+            _selection_inference(),
+            _pinned_task_config(),
+            tasks_csv=tasks_csv,
+            limit=limit,
+        )
+
+
+def test_pinned_runtime_identity_requires_exact_ordered_task_ids():
+    config = _pinned_task_config()
+
+    s8._validate_pinned_rerun_identity(
+        config,
+        experiment_id="exp003",
+        task_ids=["task-002", "task-003"],
+        rubric_commit_sha="a" * 40,
+        inference_revision="b" * 40,
+    )
+    with pytest.raises(ValueError, match="task_ids"):
+        s8._validate_pinned_rerun_identity(
+            config,
+            experiment_id="exp003",
+            task_ids=["task-003", "task-002"],
+            rubric_commit_sha="a" * 40,
+            inference_revision="b" * 40,
+        )
+
+
+def test_main_applies_config_pinned_tasks_as_diagnostic_without_cli(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    _setup_workspace(tmp_path)
+    config_path = tmp_path / "grading_configs" / "default.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["schema_version"] = "2.0"
+    config["rubric"]["revision"] = _FakeLoader().rubric_sha
+    config["rerun_identity"] = {
+        "experiment_id": "exp998_smoke_baseline_sample",
+        "expected_task_count": 2,
+        "rubric_commit_sha": _FakeLoader().rubric_sha,
+        "inference_revision": INFERENCE_SHA,
+        "task_ids": ["task-002", "task-003"],
+    }
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    github_output = tmp_path / "github-output.txt"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py",
+        "exp998_smoke_baseline_sample",
+        "--config",
+        "grading_configs/default.yaml",
+        "--dry-run",
+    ])
+
+    assert s8.main() == 0
+    assert "Dry-run tasks=2" in capsys.readouterr().out
+    output = github_output.read_text(encoding="utf-8")
+    assert "grade_status=diagnostic" in output
+
+
+def test_grade_payload_binds_anchor_projection_contract(monkeypatch, tmp_path):
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "grading_configs" / "default.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["anchor_projection"] = {
+        "method": "modality_normalized_v1",
+        "anchor_config_name": config["config_name"],
+        "anchor_task_count": 2,
+        "anchor_ordered_task_ids_sha256": s8._ordered_task_ids_sha256(
+            ["task-002", "task-003"]
+        ),
+        "anchor_source_inference_repo_id": "owner/repo",
+        "baseline_payload_sha256": "b" * 64,
+        "baseline_schema_version": "1.0",
+        "baseline_perception_wired": False,
+        "baseline_main_calls": 234,
+        "baseline_main_latency_ms": 2_449_199.44,
+        "baseline_final_json_parse_failed": 13,
+        "baseline_empty_final_text": 9,
+        "anchor_visual_criteria": 43,
+        "anchor_audio_criteria": 13,
+        "full_task_count": 220,
+        "full_visual_criteria": 337,
+        "full_audio_criteria": 58,
+        "chunk_envelope_hours": 44,
+    }
+    routes = s8.preflight_routes(
+        s8.grader_route_workloads(config),
+        **s8.grader_transport_options(config),
+    )
+
+    payload = s8._build_grade_payload(
+        "exp998_smoke_baseline_sample",
+        {},
+        config,
+        "0123456789abcdef",
+        _FakeLoader(),
+        "v2.2",
+        [],
+        "c" * 64,
+        "owner/repo",
+        INFERENCE_SHA,
+        azure_ai_runtime_fingerprint=routes[0]["runtime_fingerprint"],
+        azure_ai_routes=routes,
+        run_status="diagnostic",
+        expected_task_ids=["task-002", "task-003"],
+    )
+
+    assert payload["anchor_projection"] == config["anchor_projection"]
+    s8._validate_schema(payload)
 
 
 def test_pinned_rerun_identity_fails_before_route_preflight(

--- a/scripts/__tests__/test_analyze_grade_run.py
+++ b/scripts/__tests__/test_analyze_grade_run.py
@@ -8,10 +8,14 @@ top-5-slowest selection.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "analyze_grade_run.py"
@@ -401,6 +405,560 @@ def test_task_anchor_separates_main_visual_audio_and_error_types(tmp_path: Path)
     assert "20.0s" in markdown
     assert "10.0s" in markdown
     assert "projected_220_wall_hours: 7.52" in markdown
+
+
+def _anchor4_projection_grade() -> dict:
+    config_path = (
+        REPO_ROOT
+        / "batch-runner/grading_configs/validation_exp003_v2_sol_max_anchor4.yaml"
+    )
+    config_bytes = config_path.read_bytes()
+    config = yaml.safe_load(config_bytes)
+    identity = config["rerun_identity"]
+    task_ids = identity["task_ids"]
+    source_judge = config["judge"]
+    grade = _grade_json(model="gpt-5.6-sol", n_tasks=4)
+    for task, task_id in zip(grade["tasks"], task_ids, strict=True):
+        task.update({
+            "task_id": task_id,
+            "sector": "test-sector",
+            "occupation": "test-occupation",
+            "total_awarded": 1,
+            "total_max": 1,
+            "pct": 100,
+            "critical_fail": False,
+            "gold_referenced": False,
+            "grading_wall_time_ms": 100_000,
+            "judge_call_count": 5,
+            "precheck_count": 0,
+            "judge_total_latency_ms": 50_000,
+            "perception_call_count": 0,
+            "perception_input_tokens": 0,
+            "perception_output_tokens": 0,
+            "perception_cached_tokens": 0,
+            "perception_total_latency_ms": 0,
+            "usage_complete": True,
+            "error": None,
+            "items": [],
+        })
+    task_hash = hashlib.sha256(
+        json.dumps(task_ids, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    route_fingerprint = "f" * 64
+    grade.update({
+        "schema_version": "1.3",
+        "run_status": "diagnostic",
+        "expected_task_count": 4,
+        "expected_ordered_task_ids_sha256": task_hash,
+        "experiment_id": identity["experiment_id"],
+        "experiment_yaml_name": identity["experiment_id"],
+        "source_inference_experiment_id": identity["experiment_id"],
+        "source_inference_repo_id": config["anchor_projection"][
+            "anchor_source_inference_repo_id"
+        ],
+        "source_inference_revision": identity["inference_revision"],
+        "azure_ai_routes": [{
+            "endpoint_kind": "direct-v1",
+            "profile": "direct-v1",
+            "runtime_fingerprint": route_fingerprint,
+            "workload": "grader",
+        }],
+        "azure_ai_runtime_fingerprint": route_fingerprint,
+        "grader_source_hash": "e" * 64,
+        "anchor_projection": config["anchor_projection"],
+        "rubric": {
+            "source": config["rubric"]["source"],
+            "repo_id": config["rubric"]["repo_id"],
+            "revision": config["rubric"]["revision"],
+            "commit_sha": identity["rubric_commit_sha"],
+            "short_sha": identity["rubric_commit_sha"][:7],
+        },
+        "prompt": {
+            "template": config["prompt"]["template"],
+            "version": config["prompt"]["version"],
+        },
+        "graded_at": "2026-05-27T00:04:00Z",
+        "graded_by": "step8_grade.py",
+    })
+    grade["judge"] = {
+        "provider": source_judge["provider"],
+        "api": source_judge["api"],
+        "model": source_judge["model"],
+        "deployment": source_judge["deployment"],
+        "api_version": source_judge["api_version"],
+        "reasoning_effort": source_judge["reasoning"]["effort"],
+        "temperature": source_judge["generation"]["temperature"],
+        "seed": source_judge["generation"]["seed"],
+        "perception": source_judge["perception"],
+        "config_name": config["config_name"],
+        "config_hash": hashlib.sha256(config_bytes).hexdigest()[:16],
+    }
+    first = grade["tasks"][0]
+    first.update({
+        "perception_call_count": 3,
+        "perception_input_tokens": 1_500,
+        "perception_output_tokens": 150,
+        "perception_cached_tokens": 30,
+        "perception_total_latency_ms": 150_000,
+    })
+    first["items"] = [
+        {
+            "rubric_item_id": "visual-1",
+            "criterion": "visual",
+            "max_score": 1,
+            "awarded_score": 1,
+            "routing_modality": "visual",
+            "verdict": "pass",
+            "decided_by": "judge",
+            "required": None,
+            "evidence": "verified",
+            "precheck_pattern_id": None,
+            "perception_call_count": 2,
+            "perception_input_tokens": 1_000,
+            "perception_output_tokens": 100,
+            "perception_cached_tokens": 20,
+            "perception_total_latency_ms": 100_000,
+            "usage_complete": True,
+        },
+        {
+            "rubric_item_id": "audio-1",
+            "criterion": "audio",
+            "max_score": 1,
+            "awarded_score": 1,
+            "routing_modality": "audio",
+            "verdict": "pass",
+            "decided_by": "judge",
+            "required": None,
+            "evidence": "verified",
+            "precheck_pattern_id": None,
+            "perception_call_count": 1,
+            "perception_input_tokens": 500,
+            "perception_output_tokens": 50,
+            "perception_cached_tokens": 10,
+            "perception_total_latency_ms": 50_000,
+            "usage_complete": True,
+        },
+        {
+            "rubric_item_id": "text-1",
+            "criterion": "text",
+            "max_score": 1,
+            "awarded_score": 0,
+            "routing_modality": "text",
+            "verdict": "judge_error",
+            "decided_by": "judge",
+            "required": None,
+            "evidence": "final_json_parse_failed",
+            "precheck_pattern_id": None,
+            "score_excluded": True,
+            "usage_complete": True,
+        },
+    ]
+    grade["summary"] = {
+        "total_tasks": 4,
+        "graded_tasks": 4,
+        "error_tasks": 0,
+        "openai_compat": {
+            "avg_score_pct": 100,
+            "ci_pct": 0,
+            "perfect_count": 4,
+            "zero_count": 0,
+            "partial_count": 0,
+            "inconsistent_count": 0,
+        },
+        "wow": {
+            "critical_item_pass_rate": 1.0,
+            "judge_pass_rate": 0.6667,
+            "judge_error_rate": 0.3333,
+            "precheck_pass_rate": 0.0,
+        },
+        "cost": {
+            "estimated_cost_usd": None,
+            "pricing_complete": False,
+            "unpriced_models": ["gpt-5.6-sol", "gpt-audio-1.5"],
+            "usage_complete": True,
+        },
+    }
+    return grade
+
+
+def test_anchor4_projection_separates_modalities_and_preregistered_gates(
+    tmp_path: Path,
+):
+    analyzed = _run(tmp_path, _anchor4_projection_grade())["this"]
+    markdown = _run(tmp_path, _anchor4_projection_grade(), as_json=False)
+    projection = analyzed["modality_projection"]
+
+    assert analyzed["projection_method"] == "modality_normalized_v1"
+    assert projection["baseline_is_like_for_like"] is False
+    assert "main-judge-only reference" in projection["baseline_caveat"]
+    assert projection["components"]["main"] == {
+        "anchor_latency_sec": 250.0,
+        "scale": 55.0,
+        "projected_hours": 3.8194,
+        "normalization": "task_count",
+        "measurement": "max(main_latency, measured_wall_minus_perception)",
+    }
+    assert projection["components"]["visual"]["scale"] == pytest.approx(
+        337 / 43,
+        abs=1e-6,
+    )
+    assert projection["components"]["visual"]["projected_hours"] == 0.2177
+    assert projection["components"]["audio"]["scale"] == pytest.approx(
+        58 / 13,
+        abs=1e-6,
+    )
+    assert projection["components"]["audio"]["projected_hours"] == 0.062
+    assert projection["projected_220_hours"] == 4.0991
+    assert projection["envelope_status"] == "below_44h_envelope"
+    assert projection["audio_wiring"] == {"call_count": 1, "status": "passed"}
+    assert projection["visual_budget"] == {
+        "task_visual_budget_exceeded": 0,
+        "status": "passed",
+    }
+    assert projection["diagnostic"] == {
+        "baseline_targetable_errors": 22,
+        "observed_targetable_errors": 1,
+        "targetable_status": "improved",
+        "non_targetable_errors": {},
+        "status": "improved",
+    }
+    assert projection["full_run_gate"] == {
+        "status": "eligible_for_owner_review",
+        "blockers": [],
+    }
+    assert "not a Sol Max multiplier" in markdown
+    assert "| visual | 100.0 |" in markdown
+    assert "| audio | 50.0 |" in markdown
+
+
+def test_anchor4_projection_blocks_dead_audio_and_visual_budget_error(
+    tmp_path: Path,
+):
+    grade = _anchor4_projection_grade()
+    first = grade["tasks"][0]
+    first["perception_call_count"] = 2
+    first["perception_input_tokens"] = 1_000
+    first["perception_output_tokens"] = 100
+    first["perception_cached_tokens"] = 20
+    first["perception_total_latency_ms"] = 100_000
+    first["items"] = [
+        item for item in first["items"]
+        if item.get("routing_modality") != "audio"
+    ]
+    first["items"].append({
+        "rubric_item_id": "visual-budget-1",
+        "criterion": "visual budget",
+        "max_score": 1,
+        "awarded_score": 0,
+        "routing_modality": "visual",
+        "verdict": "judge_error",
+        "decided_by": "judge",
+        "required": None,
+        "evidence": "task_visual_budget_exceeded:required=73,cap=72",
+        "precheck_pattern_id": None,
+        "score_excluded": True,
+        "usage_complete": True,
+    })
+
+    projection = _run(tmp_path, grade)["this"]["modality_projection"]
+
+    assert projection["audio_wiring"] == {
+        "call_count": 0,
+        "status": "failed_no_audio_calls",
+    }
+    assert projection["visual_budget"] == {
+        "task_visual_budget_exceeded": 1,
+        "status": "failed",
+    }
+    assert projection["full_run_gate"] == {
+        "status": "blocked",
+        "blockers": [
+            "non_targetable_judge_errors_present",
+            "audio_wiring_not_exercised",
+            "visual_budget_exceeded",
+        ],
+    }
+
+
+def test_anchor4_projection_blocks_44h_or_unknown_perception(tmp_path: Path):
+    over_time = _anchor4_projection_grade()
+    for task in over_time["tasks"]:
+        task["grading_wall_time_ms"] = 1_000_000
+    projection = _run(tmp_path, over_time)["this"]["modality_projection"]
+    assert projection["envelope_status"] == "at_or_above_44h_envelope"
+    assert "at_or_above_44h_envelope" in projection["full_run_gate"]["blockers"]
+
+    unknown = _anchor4_projection_grade()
+    unknown_task = unknown["tasks"][1]
+    unknown_task.update({
+        "perception_call_count": 1,
+        "perception_input_tokens": 100,
+        "perception_output_tokens": 10,
+        "perception_cached_tokens": 0,
+        "perception_total_latency_ms": 5_000,
+    })
+    projection = _run(tmp_path, unknown)["this"]["modality_projection"]
+    assert projection["envelope_status"] == "incomplete_unknown_perception"
+    assert projection["full_run_gate"]["status"] == "blocked"
+    assert "incomplete_unknown_perception" in projection["full_run_gate"]["blockers"]
+
+
+@pytest.mark.parametrize(
+    ("mutation", "blocker"),
+    [
+        (
+            lambda grade: (
+                grade.__setitem__("run_status", "partial"),
+                grade.__setitem__("tasks", grade["tasks"][:2]),
+            ),
+            "anchor_run_not_complete_diagnostic",
+        ),
+        (
+            lambda grade: grade.__setitem__(
+                "expected_ordered_task_ids_sha256", "0" * 64
+            ),
+            "anchor_ordered_task_identity_mismatch",
+        ),
+        (
+            lambda grade: grade["tasks"][1].__setitem__(
+                "usage_complete", False
+            ),
+            "anchor_usage_incomplete",
+        ),
+        (
+            lambda grade: grade["tasks"][1].__setitem__(
+                "error", "provider_error"
+            ),
+            "anchor_task_errors",
+        ),
+        (
+            lambda grade: grade["tasks"][0]["items"][0].__setitem__(
+                "usage_complete", False
+            ),
+            "anchor_item_usage_incomplete",
+        ),
+        (
+            lambda grade: grade["summary"]["cost"].__setitem__(
+                "usage_complete", False
+            ),
+            "anchor_summary_usage_incomplete",
+        ),
+        (
+            lambda grade: grade.pop("rubric"),
+            "anchor_schema_invalid",
+        ),
+        (
+            lambda grade: grade["anchor_projection"].__setitem__(
+                "anchor_task_count", "4"
+            ),
+            "anchor_schema_invalid",
+        ),
+        (
+            lambda grade: grade["anchor_projection"].__setitem__(
+                "anchor_visual_criteria", 0
+            ),
+            "anchor_schema_invalid",
+        ),
+        (
+            lambda grade: grade["anchor_projection"].pop(
+                "anchor_task_count"
+            ),
+            "anchor_schema_invalid",
+        ),
+        (
+            lambda grade: grade["judge"].__setitem__(
+                "model", "gpt-5.4-mini"
+            ),
+            "anchor_runtime_identity_mismatch",
+        ),
+        (
+            lambda grade: grade["judge"].__setitem__(
+                "config_hash", "0" * 16
+            ),
+            "anchor_config_identity_mismatch",
+        ),
+        (
+            lambda grade: grade["rubric"].__setitem__(
+                "source", "local"
+            ),
+            "anchor_source_identity_mismatch",
+        ),
+        (
+            lambda grade: grade["rubric"].__setitem__(
+                "repo_id", "other/rubric"
+            ),
+            "anchor_source_identity_mismatch",
+        ),
+        (
+            lambda grade: grade.__setitem__(
+                "source_inference_experiment_id", "other_experiment"
+            ),
+            "anchor_source_identity_mismatch",
+        ),
+        (
+            lambda grade: grade.__setitem__(
+                "source_inference_repo_id", "other/repo"
+            ),
+            "anchor_source_identity_mismatch",
+        ),
+    ],
+)
+def test_anchor4_projection_requires_complete_clean_identity(
+    tmp_path: Path,
+    mutation,
+    blocker: str,
+):
+    grade = _anchor4_projection_grade()
+    mutation(grade)
+
+    projection = _run(tmp_path, grade)["this"]["modality_projection"]
+
+    assert projection["projected_220_hours"] is None
+    assert projection["envelope_status"] == "incomplete_anchor_payload"
+    assert projection["anchor_integrity"]["status"] == "failed"
+    assert blocker in projection["full_run_gate"]["blockers"]
+    assert projection["full_run_gate"]["status"] == "blocked"
+    assert projection["diagnostic"]["targetable_status"] == (
+        "inconclusive_invalid_anchor_payload"
+    )
+    assert projection["diagnostic"]["status"] == (
+        "inconclusive_invalid_anchor_payload"
+    )
+
+
+def test_anchor4_projection_blocks_non_object_contract(tmp_path: Path):
+    grade = _anchor4_projection_grade()
+    grade["anchor_projection"] = "malformed"
+
+    analyzed = _run(tmp_path, grade)["this"]
+    projection = analyzed["modality_projection"]
+
+    assert analyzed["projected_220_wall_hours"] is None
+    assert analyzed["projection_status"] == "incomplete_anchor_payload"
+    assert analyzed["projection_method"] is None
+    assert projection["anchor_integrity"] == {
+        "status": "failed",
+        "blockers": ["anchor_schema_invalid"],
+    }
+    assert projection["diagnostic"]["status"] == (
+        "inconclusive_invalid_anchor_payload"
+    )
+    assert projection["full_run_gate"] == {
+        "status": "blocked",
+        "blockers": ["anchor_schema_invalid"],
+    }
+
+
+@pytest.mark.parametrize("contract_state", ["missing", "null"])
+def test_anchor4_projection_blocks_missing_or_null_contract(
+    tmp_path: Path,
+    contract_state: str,
+):
+    grade = _anchor4_projection_grade()
+    if contract_state == "missing":
+        grade.pop("anchor_projection")
+    else:
+        grade["anchor_projection"] = None
+
+    analyzed = _run(tmp_path, grade)["this"]
+    projection = analyzed["modality_projection"]
+
+    assert analyzed["projected_220_wall_hours"] is None
+    assert analyzed["projection_status"] == "incomplete_anchor_payload"
+    assert analyzed["projection_method"] == "modality_normalized_v1"
+    assert projection["diagnostic"]["status"] == (
+        "inconclusive_invalid_anchor_payload"
+    )
+    assert "anchor_projection_missing_or_null" in (
+        projection["full_run_gate"]["blockers"]
+    )
+    assert projection["full_run_gate"]["status"] == "blocked"
+
+
+def test_anchor4_projection_hash_identity_blocks_missing_contract(
+    tmp_path: Path,
+):
+    grade = _anchor4_projection_grade()
+    grade.pop("anchor_projection")
+    grade["judge"]["config_name"] = "renamed_anchor"
+
+    projection = _run(tmp_path, grade)["this"]["modality_projection"]
+
+    assert projection["projected_220_hours"] is None
+    assert "anchor_projection_missing_or_null" in (
+        projection["full_run_gate"]["blockers"]
+    )
+    assert "anchor_config_identity_mismatch" in (
+        projection["full_run_gate"]["blockers"]
+    )
+
+
+@pytest.mark.parametrize("contract_state", ["missing", "null"])
+def test_non_anchor_payload_keeps_task_count_fallback(
+    tmp_path: Path,
+    contract_state: str,
+):
+    grade = _grade_json(n_tasks=1)
+    grade["tasks"][0]["grading_wall_time_ms"] = 1_000
+    if contract_state == "null":
+        grade["anchor_projection"] = None
+
+    analyzed = _run(tmp_path, grade)["this"]
+
+    assert analyzed["modality_projection"] is None
+    assert analyzed["projection_method"] == "task_count_fallback"
+    assert analyzed["projected_220_wall_hours"] is not None
+
+
+@pytest.mark.parametrize("error_type", ["RateLimitError", "BadRequestError", "unknown"])
+def test_anchor4_projection_blocks_non_targetable_judge_errors(
+    tmp_path: Path,
+    error_type: str,
+):
+    grade = _anchor4_projection_grade()
+    grade["tasks"][0]["items"][2]["evidence"] = error_type
+
+    projection = _run(tmp_path, grade)["this"]["modality_projection"]
+    markdown = _run(tmp_path, grade, as_json=False)
+
+    assert projection["diagnostic"]["observed_targetable_errors"] == 0
+    assert projection["diagnostic"]["targetable_status"] == (
+        "inconclusive_other_judge_errors"
+    )
+    assert projection["diagnostic"]["status"] == (
+        "inconclusive_other_judge_errors"
+    )
+    assert projection["diagnostic"]["non_targetable_errors"] == {
+        error_type: 1
+    }
+    assert "non_targetable_judge_errors_present" in (
+        projection["full_run_gate"]["blockers"]
+    )
+    assert projection["full_run_gate"]["status"] == "blocked"
+    assert "targetable_status=inconclusive_other_judge_errors" in markdown
+    assert "targetable_status=eliminated" not in markdown
+
+
+def test_anchor4_projection_rejects_reordered_tasks_with_recomputed_hash(
+    tmp_path: Path,
+):
+    grade = _anchor4_projection_grade()
+    grade["tasks"].reverse()
+    grade["expected_ordered_task_ids_sha256"] = hashlib.sha256(
+        json.dumps(
+            [task["task_id"] for task in grade["tasks"]],
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+    projection = _run(tmp_path, grade)["this"]["modality_projection"]
+
+    assert projection["projected_220_hours"] is None
+    assert projection["anchor_integrity"]["status"] == "failed"
+    assert "anchor_ordered_task_identity_mismatch" in (
+        projection["full_run_gate"]["blockers"]
+    )
+    assert projection["full_run_gate"]["status"] == "blocked"
 
 
 def test_markdown_contains_key_sections(tmp_path: Path):

--- a/scripts/__tests__/test_sol_max_anchor_selection.py
+++ b/scripts/__tests__/test_sol_max_anchor_selection.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PAYLOAD = (
+    REPO_ROOT
+    / "data/grades"
+    / "exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini.json"
+)
+CONFIG = (
+    REPO_ROOT
+    / "batch-runner/grading_configs/validation_exp003_v2_sol_max_anchor4.yaml"
+)
+PAYLOAD_SHA256 = "b5cbb6a80c776b458f99f007841a946c1c5f9ec8bf60be052500713dd6f13570"
+
+
+def _error_type(item: dict) -> str:
+    evidence = str(item.get("evidence") or "")
+    for error_type in ("final_json_parse_failed", "empty_final_text"):
+        if evidence.startswith(error_type):
+            return error_type
+    return "other"
+
+
+def test_anchor_tasks_maximize_targetable_mini_errors():
+    payload_bytes = PAYLOAD.read_bytes()
+    assert hashlib.sha256(payload_bytes).hexdigest() == PAYLOAD_SHA256
+    payload = json.loads(payload_bytes)
+    config = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    task_ids = config["rerun_identity"]["task_ids"]
+
+    assert payload["schema_version"] == "1.0"
+    assert payload.get("config_name") is None
+    assert "grader_source_hash" not in payload
+    assert all(
+        (task.get("perception_call_count") or 0) == 0
+        for task in payload["tasks"]
+    )
+    assert sum(
+        item.get("routing_modality") == "visual"
+        for task in payload["tasks"]
+        for item in task.get("items", [])
+    ) == 337
+    assert sum(
+        item.get("routing_modality") == "audio"
+        for task in payload["tasks"]
+        for item in task.get("items", [])
+    ) == 58
+
+    assert task_ids == [
+        "99ac6944-4ec6-4848-959c-a460ac705c6f",
+        "4c18ebae-dfaa-4b76-b10c-61fcdf26734c",
+        "40a8c4b1-b169-4f92-a38b-7f79685037ec",
+        "a73fbc98-90d4-4134-a54f-2b1d0c838791",
+    ]
+    source_indices = {
+        task["task_id"]: index
+        for index, task in enumerate(payload["tasks"])
+    }
+    assert [source_indices[task_id] for task_id in task_ids] == [10, 29, 78, 179]
+    selected = [task for task in payload["tasks"] if task["task_id"] in task_ids]
+    assert [task["task_id"] for task in selected] == task_ids
+
+    expected_types = {
+        "99ac6944-4ec6-4848-959c-a460ac705c6f": Counter({
+            "final_json_parse_failed": 2,
+            "empty_final_text": 1,
+        }),
+        "4c18ebae-dfaa-4b76-b10c-61fcdf26734c": Counter({
+            "final_json_parse_failed": 5,
+            "empty_final_text": 1,
+        }),
+        "40a8c4b1-b169-4f92-a38b-7f79685037ec": Counter({
+            "empty_final_text": 5,
+            "final_json_parse_failed": 3,
+        }),
+        "a73fbc98-90d4-4134-a54f-2b1d0c838791": Counter({
+            "final_json_parse_failed": 3,
+            "empty_final_text": 2,
+        }),
+    }
+    observed_types = {}
+    for task in selected:
+        score_included_errors = [
+            item
+            for item in task["items"]
+            if item.get("verdict") == "judge_error"
+            and item.get("score_excluded") is not True
+        ]
+        types = Counter(_error_type(item) for item in score_included_errors)
+        assert "other" not in types
+        observed_types[task["task_id"]] = types
+
+    assert observed_types == expected_types
+    assert sum(sum(types.values()) for types in observed_types.values()) == 22
+    assert sum(types["final_json_parse_failed"] for types in observed_types.values()) == 13
+    assert sum(types["empty_final_text"] for types in observed_types.values()) == 9
+    assert sum(
+        item.get("routing_modality") == "visual"
+        for task in selected
+        for item in task.get("items", [])
+    ) == 43
+    assert sum(
+        item.get("routing_modality") == "audio"
+        for task in selected
+        for item in task.get("items", [])
+    ) == 13
+    assert sum(task["judge_call_count"] for task in selected) == 234
+    assert sum(task["judge_total_latency_ms"] for task in selected) / 1000 == (
+        pytest.approx(2449.19944)
+    )
+
+    projection = config["anchor_projection"]
+    assert projection["anchor_config_name"] == config["config_name"]
+    assert projection["anchor_task_count"] == 4
+    assert projection["anchor_ordered_task_ids_sha256"] == (
+        "29d5623a5cec85eb38f21fb73a2f3b06c66ed6a5fd6fd95948b979cd70a70bc9"
+    )
+    assert projection["anchor_source_inference_repo_id"] == (
+        "HyeonSang/exp003_GPT52Chat_baseline_runner_exec"
+    )
+    assert projection["baseline_main_calls"] == 234
+    assert projection["baseline_main_latency_ms"] == pytest.approx(2449199.44)
+    assert projection["baseline_final_json_parse_failed"] == 13
+    assert projection["baseline_empty_final_text"] == 9
+    assert projection["anchor_visual_criteria"] == 43
+    assert projection["anchor_audio_criteria"] == 13
+    assert projection["full_task_count"] == 220
+    assert projection["full_visual_criteria"] == 337
+    assert projection["full_audio_criteria"] == 58
+    assert sum(
+        task.get("judge_total_latency_ms", 0) or 0
+        for task in payload["tasks"]
+    ) == pytest.approx(56_473_083.72)

--- a/scripts/analyze_grade_run.py
+++ b/scripts/analyze_grade_run.py
@@ -13,12 +13,17 @@ for models present in its reviewed price table.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import re
 import statistics
 import sys
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
 
 # input, output per 1M tokens (USD). Edit to keep current. These are
 # Azure OpenAI list prices as of 2025-Q2 (best-effort). For internal/external
@@ -36,6 +41,163 @@ PRICING_USD_PER_M_TOKENS = {
 # (Azure Responses API automatic prompt caching, parity with OpenAI public
 # pricing). Confirm against billing for negotiated tenant rates.
 CACHED_INPUT_DISCOUNT = 0.50
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GRADE_SCHEMA_PATH = REPO_ROOT / "batch-runner/schemas/grade.schema.json"
+ANCHOR_CONFIG_DIR = REPO_ROOT / "batch-runner/grading_configs"
+
+
+def _ordered_task_ids_sha256(task_ids: list[str]) -> str:
+    encoded = json.dumps(
+        task_ids,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _anchor_schema_blockers(grade: dict) -> list[str]:
+    try:
+        schema = json.loads(GRADE_SCHEMA_PATH.read_text(encoding="utf-8"))
+        schema_errors = list(Draft202012Validator(schema).iter_errors(grade))
+    except (OSError, json.JSONDecodeError):
+        schema_errors = ["schema unavailable"]
+    return ["anchor_schema_invalid"] if schema_errors else []
+
+
+def _repository_anchor_contract(grade: dict) -> dict | None:
+    judge = grade.get("judge") if isinstance(grade.get("judge"), dict) else {}
+    config_name = judge.get("config_name")
+    config_hash = judge.get("config_hash")
+    candidate_paths = []
+    if isinstance(config_name, str) and re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", config_name
+    ):
+        candidate_paths.append(ANCHOR_CONFIG_DIR / f"{config_name}.yaml")
+    if isinstance(config_hash, str) and re.fullmatch(r"[0-9a-f]{16}", config_hash):
+        candidate_paths.extend(ANCHOR_CONFIG_DIR.glob("*.yaml"))
+
+    seen = set()
+    for config_path in candidate_paths:
+        if config_path in seen or not config_path.is_file():
+            continue
+        seen.add(config_path)
+        try:
+            config_bytes = config_path.read_bytes()
+            source_config = yaml.safe_load(config_bytes)
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(source_config, dict):
+            continue
+        source_contract = source_config.get("anchor_projection")
+        if not isinstance(source_contract, dict):
+            continue
+        source_name = source_config.get("config_name")
+        source_hash = hashlib.sha256(config_bytes).hexdigest()[:16]
+        if config_name == source_name or config_hash == source_hash:
+            return source_contract
+    return None
+
+
+def _anchor_config_identity_blockers(
+    grade: dict,
+    contract: dict,
+    task_ids: list[str],
+) -> list[str]:
+    blockers = []
+    config_name = contract.get("anchor_config_name")
+    if not isinstance(config_name, str) or not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", config_name
+    ):
+        blockers.append("anchor_source_config_unavailable")
+        return blockers
+    config_path = ANCHOR_CONFIG_DIR / f"{config_name}.yaml"
+    try:
+        config_bytes = config_path.read_bytes()
+        source_config = yaml.safe_load(config_bytes)
+    except (OSError, yaml.YAMLError):
+        blockers.append("anchor_source_config_unavailable")
+        return blockers
+    if not isinstance(source_config, dict):
+        blockers.append("anchor_source_config_unavailable")
+        return blockers
+
+    if source_config.get("anchor_projection") != contract:
+        blockers.append("anchor_projection_contract_mismatch")
+    source_identity = source_config.get("rerun_identity")
+    source_task_ids = (
+        source_identity.get("task_ids")
+        if isinstance(source_identity, dict) else None
+    )
+    contract_task_hash = contract.get("anchor_ordered_task_ids_sha256")
+    if (
+        not isinstance(source_task_ids, list)
+        or _ordered_task_ids_sha256(source_task_ids) != contract_task_hash
+        or _ordered_task_ids_sha256(task_ids) != contract_task_hash
+    ):
+        blockers.append("anchor_ordered_task_identity_mismatch")
+
+    judge = grade.get("judge") if isinstance(grade.get("judge"), dict) else {}
+    expected_config_hash = hashlib.sha256(config_bytes).hexdigest()[:16]
+    if (
+        judge.get("config_name") != config_name
+        or judge.get("config_hash") != expected_config_hash
+    ):
+        blockers.append("anchor_config_identity_mismatch")
+
+    source_judge = (
+        source_config.get("judge")
+        if isinstance(source_config.get("judge"), dict) else {}
+    )
+    expected_judge = {
+        "provider": source_judge.get("provider"),
+        "api": source_judge.get("api"),
+        "model": source_judge.get("model"),
+        "deployment": source_judge.get("deployment"),
+        "api_version": source_judge.get("api_version", ""),
+        "reasoning_effort": (
+            source_judge.get("reasoning", {}).get("effort", "high")
+        ),
+        "temperature": (
+            source_judge.get("generation", {}).get("temperature", 0)
+        ),
+        "seed": source_judge.get("generation", {}).get("seed", 42),
+        "perception": source_judge.get("perception", {}),
+    }
+    if any(judge.get(key) != value for key, value in expected_judge.items()):
+        blockers.append("anchor_runtime_identity_mismatch")
+
+    rubric = grade.get("rubric") if isinstance(grade.get("rubric"), dict) else {}
+    prompt = grade.get("prompt") if isinstance(grade.get("prompt"), dict) else {}
+    source_rubric = source_config.get("rubric", {})
+    source_prompt = source_config.get("prompt", {})
+    expected_experiment = (
+        source_identity.get("experiment_id")
+        if isinstance(source_identity, dict) else None
+    )
+    expected_rubric = (
+        source_identity.get("rubric_commit_sha")
+        if isinstance(source_identity, dict) else None
+    )
+    expected_inference = (
+        source_identity.get("inference_revision")
+        if isinstance(source_identity, dict) else None
+    )
+    if (
+        grade.get("experiment_id") != expected_experiment
+        or grade.get("experiment_yaml_name") != expected_experiment
+        or grade.get("source_inference_experiment_id") != expected_experiment
+        or grade.get("source_inference_repo_id")
+        != contract.get("anchor_source_inference_repo_id")
+        or grade.get("source_inference_revision") != expected_inference
+        or rubric.get("source") != source_rubric.get("source")
+        or rubric.get("repo_id") != source_rubric.get("repo_id")
+        or rubric.get("revision") != source_rubric.get("revision")
+        or rubric.get("commit_sha") != expected_rubric
+        or prompt.get("template") != source_prompt.get("template")
+        or prompt.get("version") != source_prompt.get("version")
+    ):
+        blockers.append("anchor_source_identity_mismatch")
+    return blockers
 
 
 def _parse_iso(s: str | None) -> datetime | None:
@@ -336,6 +498,125 @@ def _anchor_usage(values: dict[str, int | float] | None) -> dict:
     }
 
 
+def _blocked_modality_projection(
+    contract: dict,
+    task_anchors: list[dict],
+    perception_usage: dict[str, dict[str, int | float]],
+    total_main_latency_sec: float,
+    judge_error_types: Counter,
+    blockers: list[str],
+) -> dict:
+    visual_usage = perception_usage.get("visual") or {}
+    audio_usage = perception_usage.get("audio") or {}
+    unknown_usage = perception_usage.get("unknown") or {}
+    visual_latency_sec = float(visual_usage.get("latency_ms", 0) or 0) / 1000
+    audio_latency_sec = float(audio_usage.get("latency_ms", 0) or 0) / 1000
+    unknown_latency_sec = float(unknown_usage.get("latency_ms", 0) or 0) / 1000
+    unknown_volume = {
+        "call_count": int(unknown_usage.get("call_count", 0) or 0),
+        "input_tokens": int(unknown_usage.get("input_tokens", 0) or 0),
+        "output_tokens": int(unknown_usage.get("output_tokens", 0) or 0),
+        "cached_tokens": int(unknown_usage.get("cached_tokens", 0) or 0),
+        "latency_sec": round(unknown_latency_sec, 5),
+    }
+    observed_targetable_errors = (
+        judge_error_types.get("final_json_parse_failed", 0)
+        + judge_error_types.get("empty_final_text", 0)
+    )
+    non_targetable_errors = {
+        error_type: count
+        for error_type, count in sorted(judge_error_types.items())
+        if error_type not in {"final_json_parse_failed", "empty_final_text"}
+        and count > 0
+    }
+    baseline_parse = contract.get("baseline_final_json_parse_failed")
+    baseline_empty = contract.get("baseline_empty_final_text")
+    baseline_targetable_errors = (
+        baseline_parse + baseline_empty
+        if type(baseline_parse) is int and type(baseline_empty) is int
+        else None
+    )
+    baseline_latency = contract.get("baseline_main_latency_ms")
+    baseline_latency_sec = (
+        round(float(baseline_latency) / 1000, 5)
+        if isinstance(baseline_latency, (int, float)) else None
+    )
+    audio_call_count = int(audio_usage.get("call_count", 0) or 0)
+    visual_budget_errors = judge_error_types.get(
+        "task_visual_budget_exceeded",
+        0,
+    )
+    unique_blockers = list(dict.fromkeys(blockers))
+    return {
+        "method": contract.get("method"),
+        "baseline_is_like_for_like": False,
+        "baseline_caveat": (
+            "schema 1.0 pre-perception payload; mini metrics are a "
+            "main-judge-only reference, not a Sol Max multiplier"
+        ),
+        "anchor_task_count": len(task_anchors),
+        "measured_anchor_wall_sec": None,
+        "anchor_integrity": {
+            "status": "failed",
+            "blockers": unique_blockers,
+        },
+        "components": {
+            "main": {
+                "anchor_latency_sec": round(total_main_latency_sec, 5),
+                "scale": None,
+                "projected_hours": None,
+                "normalization": "task_count",
+                "measurement": "blocked_invalid_anchor_payload",
+            },
+            "visual": {
+                "anchor_latency_sec": round(visual_latency_sec, 5),
+                "scale": None,
+                "projected_hours": None,
+                "normalization": "visual_criteria",
+            },
+            "audio": {
+                "anchor_latency_sec": round(audio_latency_sec, 5),
+                "scale": None,
+                "projected_hours": None,
+                "normalization": "audio_criteria",
+            },
+        },
+        "projected_220_hours": None,
+        "chunk_envelope_hours": contract.get("chunk_envelope_hours"),
+        "envelope_status": "incomplete_anchor_payload",
+        "unknown_perception": unknown_volume,
+        "diagnostic": {
+            "baseline_targetable_errors": baseline_targetable_errors,
+            "observed_targetable_errors": observed_targetable_errors,
+            "targetable_status": "inconclusive_invalid_anchor_payload",
+            "non_targetable_errors": non_targetable_errors,
+            "status": "inconclusive_invalid_anchor_payload",
+        },
+        "audio_wiring": {
+            "call_count": audio_call_count,
+            "status": "passed" if audio_call_count > 0 else "failed_no_audio_calls",
+        },
+        "visual_budget": {
+            "task_visual_budget_exceeded": visual_budget_errors,
+            "status": "passed" if visual_budget_errors == 0 else "failed",
+        },
+        "full_run_gate": {
+            "status": "blocked",
+            "blockers": unique_blockers,
+        },
+        "main_reference": {
+            "calls": contract.get("baseline_main_calls"),
+            "latency_sec": baseline_latency_sec,
+            "observed_calls": sum(
+                anchor["main"]["call_count"] for anchor in task_anchors
+            ),
+            "observed_latency_sec": round(total_main_latency_sec, 5),
+            "calls_ratio": None,
+            "latency_ratio": None,
+        },
+    }
+
+
 def _task_anchor(task: dict) -> dict:
     modality_usage = _perception_usage_by_modality({"tasks": [task]})
     error_types = Counter(
@@ -374,6 +655,319 @@ def _task_anchor(task: dict) -> dict:
         "judge_error_types": dict(sorted(error_types.items())),
         "usage_complete": bool(task.get("usage_complete", True)),
         "error": task.get("error"),
+    }
+
+
+def _modality_normalized_projection(
+    grade: dict,
+    task_anchors: list[dict],
+    perception_usage: dict[str, dict[str, int | float]],
+    total_main_latency_sec: float,
+    judge_error_types: Counter,
+) -> dict | None:
+    contract = grade.get("anchor_projection")
+    if contract is None:
+        expected_contract = _repository_anchor_contract(grade)
+        if expected_contract is None:
+            return None
+        task_ids = [anchor["task_id"] for anchor in task_anchors]
+        blockers = ["anchor_projection_missing_or_null"]
+        blockers.extend(
+            _anchor_config_identity_blockers(
+                grade,
+                expected_contract,
+                task_ids,
+            )
+        )
+        return _blocked_modality_projection(
+            expected_contract,
+            task_anchors,
+            perception_usage,
+            total_main_latency_sec,
+            judge_error_types,
+            blockers,
+        )
+    if not isinstance(contract, dict):
+        return _blocked_modality_projection(
+            {},
+            task_anchors,
+            perception_usage,
+            total_main_latency_sec,
+            judge_error_types,
+            ["anchor_schema_invalid"],
+        )
+
+    schema_blockers = _anchor_schema_blockers(grade)
+    if schema_blockers:
+        return _blocked_modality_projection(
+            contract,
+            task_anchors,
+            perception_usage,
+            total_main_latency_sec,
+            judge_error_types,
+            schema_blockers,
+        )
+
+    task_count = len(task_anchors)
+    anchor_task_count = contract["anchor_task_count"]
+    task_ids = [anchor["task_id"] for anchor in task_anchors]
+    anchor_integrity_blockers = []
+    if grade.get("schema_version") != "1.3":
+        anchor_integrity_blockers.append("anchor_schema_not_1_3")
+    if grade.get("run_status") != "diagnostic":
+        anchor_integrity_blockers.append("anchor_run_not_complete_diagnostic")
+    if grade.get("expected_task_count") != anchor_task_count:
+        anchor_integrity_blockers.append("anchor_expected_task_count_mismatch")
+    if task_count != anchor_task_count:
+        anchor_integrity_blockers.append("anchor_task_count_incomplete")
+    valid_task_ids = (
+        all(isinstance(task_id, str) and task_id for task_id in task_ids)
+        and len(task_ids) == len(set(task_ids))
+    )
+    expected_task_hash = grade.get("expected_ordered_task_ids_sha256")
+    contract_task_hash = contract.get("anchor_ordered_task_ids_sha256")
+    if (
+        not valid_task_ids
+        or not isinstance(expected_task_hash, str)
+        or expected_task_hash != contract_task_hash
+        or _ordered_task_ids_sha256(task_ids) != contract_task_hash
+    ):
+        anchor_integrity_blockers.append("anchor_ordered_task_identity_mismatch")
+    tasks = grade.get("tasks") if isinstance(grade.get("tasks"), list) else []
+    if any(task.get("usage_complete") is not True for task in tasks):
+        anchor_integrity_blockers.append("anchor_usage_incomplete")
+    if any(
+        item.get("usage_complete") is not True
+        for task in tasks
+        for item in task.get("items", [])
+        if isinstance(item, dict)
+    ):
+        anchor_integrity_blockers.append("anchor_item_usage_incomplete")
+    summary = grade.get("summary") if isinstance(grade.get("summary"), dict) else {}
+    summary_cost = (
+        summary.get("cost") if isinstance(summary.get("cost"), dict) else {}
+    )
+    if summary_cost.get("usage_complete") is not True:
+        anchor_integrity_blockers.append("anchor_summary_usage_incomplete")
+    if any(task.get("error") for task in tasks):
+        anchor_integrity_blockers.append("anchor_task_errors")
+    if (
+        summary.get("total_tasks") != anchor_task_count
+        or summary.get("graded_tasks") != anchor_task_count
+        or summary.get("error_tasks") != 0
+    ):
+        anchor_integrity_blockers.append("anchor_summary_task_counts_mismatch")
+    anchor_integrity_blockers.extend(
+        _anchor_config_identity_blockers(grade, contract, task_ids)
+    )
+    anchor_integrity_blockers = list(dict.fromkeys(anchor_integrity_blockers))
+
+    measured_walls = [
+        anchor["wall_clock_sec"]
+        for anchor in task_anchors
+        if anchor["wall_clock_sec"] is not None
+    ]
+    visual_usage = perception_usage.get("visual") or {}
+    audio_usage = perception_usage.get("audio") or {}
+    unknown_usage = perception_usage.get("unknown") or {}
+    visual_latency_sec = float(visual_usage.get("latency_ms", 0) or 0) / 1000
+    audio_latency_sec = float(audio_usage.get("latency_ms", 0) or 0) / 1000
+    unknown_latency_sec = float(unknown_usage.get("latency_ms", 0) or 0) / 1000
+    total_perception_latency_sec = (
+        visual_latency_sec + audio_latency_sec + unknown_latency_sec
+    )
+
+    if len(measured_walls) == task_count and task_count > 0:
+        measured_wall_sec = sum(measured_walls)
+        main_anchor_sec = max(
+            total_main_latency_sec,
+            measured_wall_sec - total_perception_latency_sec,
+        )
+        main_measurement = "max(main_latency, measured_wall_minus_perception)"
+    else:
+        measured_wall_sec = None
+        main_anchor_sec = total_main_latency_sec
+        main_measurement = "main_latency_fallback_missing_task_wall"
+
+    main_scale = contract["full_task_count"] / anchor_task_count
+    visual_scale = (
+        contract["full_visual_criteria"]
+        / contract["anchor_visual_criteria"]
+    )
+    audio_scale = (
+        contract["full_audio_criteria"]
+        / contract["anchor_audio_criteria"]
+    )
+    projection_ready = not anchor_integrity_blockers and measured_wall_sec is not None
+    components = {
+        "main": {
+            "anchor_latency_sec": round(main_anchor_sec, 5),
+            "scale": round(main_scale, 6),
+            "projected_hours": (
+                round(main_anchor_sec * main_scale / 3600, 4)
+                if projection_ready else None
+            ),
+            "normalization": "task_count",
+            "measurement": main_measurement,
+        },
+        "visual": {
+            "anchor_latency_sec": round(visual_latency_sec, 5),
+            "scale": round(visual_scale, 6),
+            "projected_hours": (
+                round(visual_latency_sec * visual_scale / 3600, 4)
+                if projection_ready else None
+            ),
+            "normalization": "visual_criteria",
+        },
+        "audio": {
+            "anchor_latency_sec": round(audio_latency_sec, 5),
+            "scale": round(audio_scale, 6),
+            "projected_hours": (
+                round(audio_latency_sec * audio_scale / 3600, 4)
+                if projection_ready else None
+            ),
+            "normalization": "audio_criteria",
+        },
+    }
+    projected_hours = (
+        round(
+            sum(
+                component["projected_hours"]
+                for component in components.values()
+            ),
+            4,
+        )
+        if projection_ready else None
+    )
+
+    unknown_volume = {
+        "call_count": int(unknown_usage.get("call_count", 0) or 0),
+        "input_tokens": int(unknown_usage.get("input_tokens", 0) or 0),
+        "output_tokens": int(unknown_usage.get("output_tokens", 0) or 0),
+        "cached_tokens": int(unknown_usage.get("cached_tokens", 0) or 0),
+        "latency_sec": round(unknown_latency_sec, 5),
+    }
+    has_unknown = any(unknown_volume.values())
+    envelope_hours = contract["chunk_envelope_hours"]
+    if anchor_integrity_blockers:
+        envelope_status = "incomplete_anchor_payload"
+    elif has_unknown:
+        envelope_status = "incomplete_unknown_perception"
+    elif measured_wall_sec is None:
+        envelope_status = "incomplete_missing_task_wall"
+    elif projected_hours >= envelope_hours:
+        envelope_status = "at_or_above_44h_envelope"
+    else:
+        envelope_status = "below_44h_envelope"
+
+    targetable_errors = (
+        judge_error_types.get("final_json_parse_failed", 0)
+        + judge_error_types.get("empty_final_text", 0)
+    )
+    baseline_targetable_errors = (
+        contract["baseline_final_json_parse_failed"]
+        + contract["baseline_empty_final_text"]
+    )
+    non_targetable_errors = {
+        error_type: count
+        for error_type, count in sorted(judge_error_types.items())
+        if error_type not in {"final_json_parse_failed", "empty_final_text"}
+        and count > 0
+    }
+    if targetable_errors == 0:
+        targetable_status = "eliminated"
+    elif targetable_errors < baseline_targetable_errors:
+        targetable_status = "improved"
+    else:
+        targetable_status = "no_improvement"
+    if anchor_integrity_blockers:
+        targetable_status = "inconclusive_invalid_anchor_payload"
+    elif non_targetable_errors:
+        targetable_status = "inconclusive_other_judge_errors"
+    diagnostic_status = targetable_status
+
+    audio_call_count = int(audio_usage.get("call_count", 0) or 0)
+    visual_budget_errors = judge_error_types.get(
+        "task_visual_budget_exceeded",
+        0,
+    )
+    gate_blockers = list(anchor_integrity_blockers)
+    if targetable_errors >= baseline_targetable_errors:
+        gate_blockers.append("no_finalization_improvement")
+    if non_targetable_errors:
+        gate_blockers.append("non_targetable_judge_errors_present")
+    if audio_call_count == 0:
+        gate_blockers.append("audio_wiring_not_exercised")
+    if visual_budget_errors > 0:
+        gate_blockers.append("visual_budget_exceeded")
+    if (
+        envelope_status != "below_44h_envelope"
+        and envelope_status != "incomplete_anchor_payload"
+    ):
+        gate_blockers.append(envelope_status)
+    return {
+        "method": contract["method"],
+        "baseline_is_like_for_like": False,
+        "baseline_caveat": (
+            "schema 1.0 pre-perception payload; mini metrics are a "
+            "main-judge-only reference, not a Sol Max multiplier"
+        ),
+        "anchor_task_count": task_count,
+        "measured_anchor_wall_sec": (
+            round(measured_wall_sec, 5)
+            if measured_wall_sec is not None else None
+        ),
+        "anchor_integrity": {
+            "status": "passed" if not anchor_integrity_blockers else "failed",
+            "blockers": anchor_integrity_blockers,
+        },
+        "components": components,
+        "projected_220_hours": projected_hours,
+        "chunk_envelope_hours": envelope_hours,
+        "envelope_status": envelope_status,
+        "unknown_perception": unknown_volume,
+        "diagnostic": {
+            "baseline_targetable_errors": baseline_targetable_errors,
+            "observed_targetable_errors": targetable_errors,
+            "targetable_status": targetable_status,
+            "non_targetable_errors": non_targetable_errors,
+            "status": diagnostic_status,
+        },
+        "audio_wiring": {
+            "call_count": audio_call_count,
+            "status": "passed" if audio_call_count > 0 else "failed_no_audio_calls",
+        },
+        "visual_budget": {
+            "task_visual_budget_exceeded": visual_budget_errors,
+            "status": "passed" if visual_budget_errors == 0 else "failed",
+        },
+        "full_run_gate": {
+            "status": (
+                "blocked" if gate_blockers else "eligible_for_owner_review"
+            ),
+            "blockers": gate_blockers,
+        },
+        "main_reference": {
+            "calls": contract["baseline_main_calls"],
+            "latency_sec": round(
+                contract["baseline_main_latency_ms"] / 1000,
+                5,
+            ),
+            "observed_calls": sum(
+                anchor["main"]["call_count"] for anchor in task_anchors
+            ),
+            "observed_latency_sec": round(total_main_latency_sec, 5),
+            "calls_ratio": round(
+                sum(anchor["main"]["call_count"] for anchor in task_anchors)
+                / contract["baseline_main_calls"],
+                6,
+            ),
+            "latency_ratio": round(
+                total_main_latency_sec
+                / (contract["baseline_main_latency_ms"] / 1000),
+                6,
+            ),
+        },
     }
 
 
@@ -582,21 +1176,34 @@ def analyze(path: Path) -> dict:
     judge_error_types = Counter()
     for anchor in task_anchors:
         judge_error_types.update(anchor["judge_error_types"])
-    measured_task_wall_times = [
-        anchor["wall_clock_sec"]
-        for anchor in task_anchors
-        if anchor["wall_clock_sec"] is not None
-    ]
-    projected_220_wall_hours = (
-        round(statistics.mean(measured_task_wall_times) * 220 / 3600, 2)
-        if measured_task_wall_times else None
+    modality_projection = _modality_normalized_projection(
+        grade,
+        task_anchors,
+        perception_usage,
+        total_main_latency_sec,
+        judge_error_types,
     )
-    if projected_220_wall_hours is None:
-        projection_status = "unmeasured"
-    elif projected_220_wall_hours >= 44:
-        projection_status = "at_or_above_44h_envelope"
+    if modality_projection is not None:
+        projected_220_wall_hours = modality_projection["projected_220_hours"]
+        projection_status = modality_projection["envelope_status"]
+        projection_method = modality_projection["method"]
     else:
-        projection_status = "below_44h_envelope"
+        measured_task_wall_times = [
+            anchor["wall_clock_sec"]
+            for anchor in task_anchors
+            if anchor["wall_clock_sec"] is not None
+        ]
+        projected_220_wall_hours = (
+            round(statistics.mean(measured_task_wall_times) * 220 / 3600, 2)
+            if measured_task_wall_times else None
+        )
+        if projected_220_wall_hours is None:
+            projection_status = "unmeasured"
+        elif projected_220_wall_hours >= 44:
+            projection_status = "at_or_above_44h_envelope"
+        else:
+            projection_status = "below_44h_envelope"
+        projection_method = "task_count_fallback"
 
     # PR3 Step 0 — effective (cache-discounted) cost. Skipped if the run
     # used the legacy v1 path (no cached_tokens captured).
@@ -707,6 +1314,8 @@ def analyze(path: Path) -> dict:
         "judge_error_types": dict(sorted(judge_error_types.items())),
         "projected_220_wall_hours": projected_220_wall_hours,
         "projection_status": projection_status,
+        "projection_method": projection_method,
+        "modality_projection": modality_projection,
     }
 
 
@@ -826,8 +1435,68 @@ def render_markdown(a: dict, base: dict | None = None) -> str:
     )
     lines.append(
         "- projected_220_wall_hours: "
-        f"{a['projected_220_wall_hours']} ({a['projection_status']})"
+        f"{a['projected_220_wall_hours']} ({a['projection_status']}; "
+        f"method={a['projection_method']})"
     )
+    projection = a.get("modality_projection")
+    if projection is not None:
+        lines.append("")
+        lines.append("## Preregistered anchor decision")
+        lines.append(f"- baseline caveat: {projection['baseline_caveat']}")
+        lines.append(
+            "- anchor integrity: "
+            f"{projection['anchor_integrity']['status']} "
+            f"(blockers={projection['anchor_integrity']['blockers']})"
+        )
+        diagnostic = projection["diagnostic"]
+        lines.append(
+            "- targetable finalization errors: "
+            f"baseline={diagnostic['baseline_targetable_errors']}, "
+            f"observed={diagnostic['observed_targetable_errors']}, "
+            f"targetable_status={diagnostic['targetable_status']}, "
+            f"other={diagnostic['non_targetable_errors']}, "
+            f"status={diagnostic['status']}"
+        )
+        lines.append(
+            "- audio wiring: "
+            f"calls={projection['audio_wiring']['call_count']}, "
+            f"status={projection['audio_wiring']['status']}"
+        )
+        lines.append(
+            "- visual budget: "
+            f"task_visual_budget_exceeded="
+            f"{projection['visual_budget']['task_visual_budget_exceeded']}, "
+            f"status={projection['visual_budget']['status']}"
+        )
+        lines.append(
+            "- full-run gate: "
+            f"{projection['full_run_gate']['status']} "
+            f"(blockers={projection['full_run_gate']['blockers']})"
+        )
+        main_reference = projection["main_reference"]
+        lines.append(
+            "- mini main-judge-only reference: "
+            f"calls={main_reference['calls']} → "
+            f"{main_reference['observed_calls']} "
+            f"(ratio={main_reference['calls_ratio']}), latency="
+            f"{main_reference['latency_sec']}s → "
+            f"{main_reference['observed_latency_sec']}s "
+            f"(ratio={main_reference['latency_ratio']}); not a Sol Max multiplier"
+        )
+        lines.append("")
+        lines.append("| component | anchor latency (s) | scale | projected hours | normalization |")
+        lines.append("|---|--:|--:|--:|---|")
+        for component_name in ("main", "visual", "audio"):
+            component = projection["components"][component_name]
+            lines.append(
+                f"| {component_name} | {component['anchor_latency_sec']} | "
+                f"{component['scale']} | {component['projected_hours']} | "
+                f"{component['normalization']} |"
+            )
+        lines.append(
+            f"- component total: {projection['projected_220_hours']}h; "
+            f"44h gate={projection['envelope_status']}"
+        )
     lines.append("")
     lines.append("## Cost estimate")
     lines.append(f"- raw: {_fmt_cost(a['cost_estimate'])}")

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,90 +1,89 @@
 # Latest Task Result
 
-- Updated: 2026-08-10
-- Status: Sol Max full-rerun and three-task anchor preparation is reviewed and
-  validated; paid anchor dispatch awaits main integration and separate approval
+- Updated: 2026-08-11
+- Status: Sol Max anchor4 selection and modality-normalized projection are
+  reviewed and validated; no paid grading was dispatched
 
-## Current Task: Sol Max Regrade Preparation
+## Current Task: Sol Max Anchor4 Finalization
 
 ### Task
 
-- Make schema `1.3` nullable headline scores safe in every analysis script that
-  will consume the future rerun.
-- Add a new pinned Sol Max full-220 config without modifying existing comparison
-  identities, and preserve dedicated audio perception and the visual task cap.
-- Prepare a small paid anchor that records task-level main, visual, and audio
-  volume, wall time, errors, and a serial 220-task time projection.
-- Do not run the full 220 tasks, modify historical grades, or dispatch paid work
-  before the new config reaches exact `main` and receives separate approval.
+- Replace the targetable-error-heavy three-task anchor with four source-ordered
+  tasks that also exercise visual and audio perception.
+- Pin exact task selection and projection identity without changing the grading
+  workflow, historical grades, or the full-220 Sol Max config.
+- Extrapolate main, visual, and audio latency independently and fail closed on
+  incomplete identity, usage, perception attribution, or acceptance gates.
+- Do not dispatch the paid anchor or full 220-task run.
 
 ### Result
 
-- `backfill_sign_aware.py` now accepts only schema `1.0`; it refuses schema
-  `1.3` rather than silently replacing a null headline with zero and emitting
-  schema `1.1`.
-- `compare_grades.py` renders null or errored aggregate/task scores as
-  `unscored` and emits no score delta. `analyze_grade_run.py` preserves null in
-  JSON and renders `unscored` in Markdown.
-- Added `regrade_exp003_v2_sol_max_score_excluded.yaml` for the planned full
-  rerun and `validation_exp003_v2_sol_max_anchor3.yaml` for the first paid
-  anchor. Both retain production Sol Max main/visual/finalization settings,
-  exact `gpt-audio-1.5` audio settings, and visual cap 72.
-- Step 8 measures `grading_wall_time_ms` around each `grade_task` call. The
-  analyzer now reports task-level wall time; main, visual, audio, and unknown
-  perception calls/tokens/cache/latency; render volume; usage completeness; and
-  public provider or split-child judge-error subtypes.
-- Unknown perception tokens are explicitly unpriced instead of being attributed
-  to the main model. Zero-token residual calls remain visible in task anchors
-  but do not create a false cost component.
-- The analyzer projects serial 220-task wall time from measured anchor task wall
-  times and labels whether it is below or at/above the 44-hour resume envelope.
-  It does not claim USD cost for unpriced models.
+- Replaced `validation_exp003_v2_sol_max_anchor3.yaml` with
+  `validation_exp003_v2_sol_max_anchor4.yaml`, preserving production Sol Max
+  main/visual/finalization settings, `gpt-audio-1.5` with call cap 3 and
+  30-second trim, and visual task cap 72.
+- `rerun_identity.task_ids` pins four IDs in canonical source order. Step 8
+  reuses the existing task filter, rejects config/CLI/limit conflicts, emits a
+  diagnostic grade, and requires an exact projection-contract match for cached
+  or resumed payloads.
+- The versioned `anchor_projection` binds the config name/hash, ordered-task
+  digest, source repository, baseline payload, counts, and 44-hour envelope
+  into both config validation and the grade payload schema.
+- The analyzer reloads the exact repository config and verifies schema,
+  config/runtime, rubric, prompt, inference, task-order, usage, and task-error
+  identity before producing a numeric projection.
+- Main latency scales by `220/4 = 55`, visual by `337/43`, and audio by `58/13`.
+  Unknown perception attribution makes the projection incomplete.
+- The full-run gate blocks non-targetable judge errors, no finalization
+  improvement, zero audio calls, `task_visual_budget_exceeded`, incomplete
+  identity/usage, and projected duration at or above 44 hours. A clean anchor
+  is only `eligible_for_owner_review`; it never authorizes a full run.
 
 ### Fixed Identities
 
 | Purpose | Config hash | Tasks |
 |---|---|---:|
 | Full rerun | `14fc577ea39d98c5` | 220 |
-| Paid anchor | `25653df2d5841c97` | 3 |
+| Paid anchor | `6dcff620fbe8dbf3` | 4 |
 
 - Experiment: `exp003_GPT52Chat_baseline_runner_exec`.
 - Rubric commit: `11e7900cdcac61bc4daf59e65feb238acda98fbf`.
 - Inference revision: `9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f`.
-- Audio remains `gpt-audio-1.5`, call cap 3, trim 30 seconds. Visual cap remains
-  72. Tests reduce each new config to its baseline plus identity-only changes.
+- Ordered-task digest:
+  `29d5623a5cec85eb38f21fb73a2f3b06c66ed6a5fd6fd95948b979cd70a70bc9`.
+- Baseline payload SHA-256:
+  `b5cbb6a80c776b458f99f007841a946c1c5f9ec8bf60be052500713dd6f13570`.
 
 ### Anchor Decision
 
-- Chosen size: 3 tasks. Sol Max has no prior grade payload, so the first paid
-  exposure is bounded before considering the 10-task expansion.
-- Mini cohort 3: 532 main calls, 4 visual calls, 0 audio calls; main tokens
-  4,540,399 input / 176,531 output / 1,955,328 cached; visual tokens 4,751 /
-  1,032 / 0; summed judge latency 41.2 minutes; zero judge errors.
-- Mini cohort 10: 1,333 main calls, 26 visual calls, 0 audio calls; main tokens
-  6,833,450 / 369,014 / 3,389,440; visual tokens 30,282 / 6,836 / 0; summed
-  judge latency 88.8 minutes; zero judge errors.
-- Because both mini anchors are already at `judge_error_rate=0`, the Sol Max
-  anchor cannot establish a reduction below that floor. It can establish
-  call/token/time volume and detect a match or regression. Historical mini
-  payloads lack task wall time, so only the new anchor supports wall projection.
+- Source indices: `10`, `29`, `78`, and `179`.
+- Task IDs: `99ac6944-4ec6-4848-959c-a460ac705c6f`,
+  `4c18ebae-dfaa-4b76-b10c-61fcdf26734c`,
+  `40a8c4b1-b169-4f92-a38b-7f79685037ec`, and
+  `a73fbc98-90d4-4134-a54f-2b1d0c838791`.
+- Baseline totals: 13 final-JSON parse failures, nine empty finals, 43 visual
+  criteria, 13 audio criteria, 234 main calls, and 2,449.19944 seconds of main
+  latency. The full baseline contains 337 visual and 58 audio criteria.
+- The schema `1.0` mini baseline has zero perception calls across all 220 tasks;
+  it is a main-judge-only reference, not a Sol Max multiplier.
 
 ### Verification
 
-- Nullable and analyzer scripts: 28 passed.
-- Config, Step 8, schema, tool-calling, audio, and perception: 312 passed.
-- Complete backend: 3,038 passed, 9 skipped, 45 integration tests deselected.
-- The three unchanged host dependency failures passed under exact temporary
-  Python 3.10 dependencies.
+- Analyzer and tracked baseline contracts: 42 passed.
+- Config, Step 8, and grade schema: 267 passed.
+- Complete backend: 3,069 passed, 6 skipped, 45 integration tests deselected.
 - Self-preparing aggregate suite: 105 passed, 1 expected Ruby skip.
 - `npm run build`: passed with 2,783 transformed modules.
-- `py_compile`, VS Code diagnostics, and `git diff --check`: passed.
-- Existing Sol Max/mini configs, workflows, and `data/grades` are unchanged.
-  No credential, workflow dispatch, model call, or paid operation ran.
+- `py_compile`, focused Ruff, VS Code diagnostics, and `git diff --check`:
+  passed.
+- The full Sol Max and mini comparison configs, workflows, and `data/grades`
+  are unchanged. No credential, workflow dispatch, model call, or paid
+  operation ran.
 
 ### Review Evidence
 
 - Reviewed substantive head:
-  `eee62b8e3fc6cff0ed447781251cde37f10e6b4f`.
+  `ba7b1661fa7aadaa77192ec7b547826e123de5a7`.
 - Independent `grading-engineer` and `first-reviewer` verdicts: `APPROVE`, with
   no blocking findings.
 
@@ -92,9 +91,10 @@
 
 - The owner decides whether and when to merge the reviewed preparation change.
 - After the configs reach exact `main`, a separate owner-approved protected
-  grading dispatch may run the three-task anchor. The result must be inspected
-  for task-level volume, error types, and projected 220-task wall time before
-  any full run or 10-task expansion decision.
+  grading dispatch may run the four-task anchor. Its artifact must pass every
+  preregistered diagnostic, identity, usage, audio, visual-budget, attribution,
+  and 44-hour gate before the owner considers a full run.
+- This preparation neither dispatches nor authorizes the full 220-task run.
 - Do not create a documentation-only PR to record this change's eventual merge
   metadata.
 


### PR DESCRIPTION
## Summary

- replace the three-task Sol Max anchor with four source-ordered tasks covering 22 targetable finalization errors, 43 visual criteria, and 13 audio criteria
- bind exact task, config, baseline, runtime, source, schema, cache, and resume identities into the diagnostic payload
- project main, visual, and audio latency separately and fail closed before any full run when diagnostic, wiring, budget, attribution, identity, usage, or 44-hour gates fail

## Fixed identities

- anchor config: `validation_exp003_v2_sol_max_anchor4.yaml`
- anchor config hash: `6dcff620fbe8dbf3`
- full config hash, unchanged: `14fc577ea39d98c5`
- reviewed substantive head: `ba7b1661fa7aadaa77192ec7b547826e123de5a7`

## Validation

- backend: 3,069 passed, 6 skipped, 45 integration tests deselected
- analyzer and baseline contracts: 42 passed
- config, Step 8, and grade schema: 267 passed
- aggregate contracts: 105 passed, 1 expected skip
- production build: 2,783 modules transformed
- `py_compile`, focused Ruff, diagnostics, and `git diff --check`: passed
- independent `grading-engineer` and `first-reviewer`: APPROVE

## Guardrails

- no workflow, historical grade, full Sol Max, or mini comparison config changes
- no credential use beyond repository publication, model call, grading dispatch, or paid execution
- a clean anchor result is only `eligible_for_owner_review`; this PR does not authorize the anchor or full 220-task run