### PR TITLE
chore(azure-ai): rename endpoint secret to FOUNDRY_PROJECT_ENDPOINT

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -425,7 +425,7 @@ jobs:
       - name: Validate Azure AI routes before remote writes
         env:
           AZURE_AI_ROUTE_PROFILE: ${{ steps.read_config.outputs.uses_code_interpreter == 'true' && 'project-ci' || 'direct-v1' }}
-          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
           AZURE_AI_EXPECTED_PROJECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_PROJECT_ACCOUNT }}
@@ -539,7 +539,7 @@ jobs:
         env:
           GDPVAL_RELAY_LINEAGE_ID: ${{ inputs.relay_lineage_id }}
           AZURE_AI_ROUTE_PROFILE: ${{ steps.read_config.outputs.uses_code_interpreter == 'true' && 'project-ci' || 'direct-v1' }}
-          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
           AZURE_AI_EXPECTED_PROJECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_PROJECT_ACCOUNT }}
@@ -632,7 +632,7 @@ jobs:
       - name: Verify Azure AI token before model calls
         env:
           AZURE_AI_ROUTE_PROFILE: ${{ steps.read_config.outputs.uses_code_interpreter == 'true' && 'project-ci' || 'direct-v1' }}
-          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
           AZURE_AI_EXPECTED_PROJECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_PROJECT_ACCOUNT }}
@@ -655,7 +655,7 @@ jobs:
           OPENAI_API_KEY: ${{ steps.read_config.outputs.requires_openai_key == 'true' && secrets.OPENAI_API_KEY || '' }}
           ANTHROPIC_API_KEY: ${{ steps.read_config.outputs.requires_anthropic_key == 'true' && secrets.ANTHROPIC_API_KEY || '' }}
           AZURE_AI_ROUTE_PROFILE: ${{ steps.read_config.outputs.uses_code_interpreter == 'true' && 'project-ci' || 'direct-v1' }}
-          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
           AZURE_AI_EXPECTED_PROJECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_PROJECT_ACCOUNT }}
@@ -802,7 +802,7 @@ jobs:
         if: steps.check_relay.outputs.needs_relay != 'true' && steps.step2a.outcome == 'success'
         env:
           AZURE_AI_ROUTE_PROFILE: direct-v1
-          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
         run: |
@@ -937,7 +937,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           EXPECTED_TARGET_HEAD: ${{ steps.step0.outputs.target_head }}
           AZURE_AI_ROUTE_PROFILE: direct-v1
-          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
         run: |
@@ -968,7 +968,7 @@ jobs:
           SOURCE_REPO: ${{ steps.read_config.outputs.source_repo }}
           EXPECTED_GENERATION: ${{ inputs.relay_run > 0 && steps.restore_checkpoint.outputs.generation || '' }}
           AZURE_AI_ROUTE_PROFILE: direct-v1
-          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
         run: |

--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -395,7 +395,7 @@ jobs:
         if: inputs.dry_run != true
         env:
           AZURE_AI_ROUTE_PROFILE: direct-v1
-          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
           AZURE_AI_WORKLOADS_JSON: ${{ steps.renderer.outputs.azure_ai_workloads_json }}
@@ -457,7 +457,7 @@ jobs:
         if: inputs.dry_run != true
         env:
           AZURE_AI_ROUTE_PROFILE: direct-v1
-          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
           AZURE_AI_WORKLOADS_JSON: ${{ steps.renderer.outputs.azure_ai_workloads_json }}
@@ -497,7 +497,7 @@ jobs:
         id: grade
         env:
           AZURE_AI_ROUTE_PROFILE: ${{ !inputs.dry_run && 'direct-v1' || '' }}
-          FOUNDRY_PROJECT_ENDPOINT: ${{ !inputs.dry_run && secrets.AZURE_OPENAI_ENDPOINT || '' }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ !inputs.dry_run && secrets.FOUNDRY_PROJECT_ENDPOINT || '' }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: ${{ !inputs.dry_run && '1' || '0' }}
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ !inputs.dry_run && vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT || '' }}
           # Force unbuffered Python stdout so per-task progress prints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Changed
+- **Foundry endpoint secret rename** - read the Foundry project endpoint from a
+  `FOUNDRY_PROJECT_ENDPOINT` repository secret instead of the legacy
+  `AZURE_OPENAI_ENDPOINT` name across all ten workflow sites, seven in
+  `batch-run.yml` and three in `grade-run.yml`. Every site already assigned the
+  value to a runtime variable of the same new name, so the mapping is now
+  one-to-one and the surrounding route profile, expected-identity, workload,
+  and `dry_run` gating expressions are untouched. `AZURE_OPENAI_ENDPOINT`
+  remains a rejected runtime environment variable: the deprecation error and
+  check in `core/azure_ai_clients.py`, the forbidden-name list in
+  `scripts/azure_ai_route_preflight.py`, the legacy native path in
+  `step2_run_inference.py`, and the two contract assertions requiring that name
+  to be absent from step environments are all unchanged. Both onboarding guides
+  and both Batch Runner references now list the new secret, state that the
+  deprecated runtime variable is still never injected, and tell operators of a
+  fork created before this rename to add the new secret. The onboarding contract
+  test pins the new name in the required-secret list and matches the rewritten
+  mapping sentence in the English and Korean guides independently. A missing
+  value fails the route preflight before any model call, so the failure mode
+  stays fail-closed. This change is deliberately name-only: no Python source,
+  grading config, schema, archived config, or historical task record moved.
+  Validation passes 12 onboarding contract tests and 733 workflow and Azure
+  route Python tests; both workflow files parse as YAML, and
+  `secrets.AZURE_OPENAI_ENDPOINT` no longer appears under `.github/workflows`.
+  The five root aggregate note suites fail three cases each on unmodified
+  `origin/main` and after this change alike, because they need the generated
+  `public/generated/reports-index.json`. `actionlint` is unavailable on the
+  validation host, so GitHub Actions expression schema remains unverified. No
+  workflow dispatch, model call, paid operation, or secret deletion occurred.
 - **Sol Max anchor4 and revision-scoped legacy provenance wiring** - keep the
   four source-ordered diagnostic/perception tasks and modality-normalized
   projection while allowing their fixed inference revision to use the parquet

--- a/batch-runner/README.md
+++ b/batch-runner/README.md
@@ -113,10 +113,10 @@ dated Azure OpenAI client and its required
 `https://cognitiveservices.azure.com/.default` audience; token preflight checks
 the audience selected by each typed route.
 
-GitHub Actions retains the old repository secret name
-`AZURE_OPENAI_ENDPOINT` only as an onboarding input and maps it to the typed
-runtime variable `FOUNDRY_PROJECT_ENDPOINT`; it never injects the old runtime
-environment variable.
+GitHub Actions supplies the endpoint through the `FOUNDRY_PROJECT_ENDPOINT`
+repository secret and maps it to the identically named typed runtime variable;
+it never injects the deprecated `AZURE_OPENAI_ENDPOINT` runtime environment
+variable.
 
 CI always requires `AZURE_AI_EXPECTED_CLIENT_ID`,
 `AZURE_AI_EXPECTED_TENANT_ID`, `AZURE_AI_EXPECTED_SUBSCRIPTION_ID`, and

--- a/batch-runner/README_KR.md
+++ b/batch-runner/README_KR.md
@@ -107,10 +107,9 @@ v1 route를 사용하고 `project-ci`에서도 Code Interpreter만 project route
 client와 필수 audience인 `https://cognitiveservices.azure.com/.default`를
 사용하며 token preflight는 typed route가 선택한 audience를 검증합니다.
 
-GitHub Actions는 기존 repository secret 이름 `AZURE_OPENAI_ENDPOINT`를
-onboarding 입력으로만 유지하고 typed runtime 변수
-`FOUNDRY_PROJECT_ENDPOINT`로 매핑합니다. 기존 runtime 환경 변수는 주입하지
-않습니다.
+GitHub Actions는 `FOUNDRY_PROJECT_ENDPOINT` repository secret으로 endpoint를
+받아 동일한 이름의 typed runtime 변수로 매핑합니다. deprecated runtime 환경
+변수 `AZURE_OPENAI_ENDPOINT`는 주입하지 않습니다.
 
 CI에는 `AZURE_AI_EXPECTED_CLIENT_ID`, `AZURE_AI_EXPECTED_TENANT_ID`,
 `AZURE_AI_EXPECTED_SUBSCRIPTION_ID`, `AZURE_AI_EXPECTED_DIRECT_ACCOUNT`가 항상

--- a/docs/first-experiment.md
+++ b/docs/first-experiment.md
@@ -164,7 +164,7 @@ repository secret** and add:
 | `AZURE_CLIENT_ID` | Entra application client ID |
 | `AZURE_TENANT_ID` | Entra directory tenant ID |
 | `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
-| `AZURE_OPENAI_ENDPOINT` | Foundry project endpoint ending in `/api/projects/<project-name>`; retained as the GitHub secret name during migration |
+| `FOUNDRY_PROJECT_ENDPOINT` | Foundry project endpoint ending in `/api/projects/<project-name>` |
 | `HF_TOKEN` | Dedicated Hugging Face write token |
 
 Under **Settings > Secrets and variables > Actions > Variables**, add the
@@ -189,11 +189,14 @@ tenant/client claims to those independent variables. The supported workflows
 do not select `legacy-rollback`; an explicit local strict rollback requires the
 legacy account variable instead of direct/project account variables.
 
-The workflow maps the `AZURE_OPENAI_ENDPOINT` secret into the typed
-`FOUNDRY_PROJECT_ENDPOINT` runtime variable; Python never receives the
-deprecated name. Do not add `AZURE_OPENAI_API_KEY`, `AZURE_API_KEY`,
-`AZURE_OPENAI_AD_TOKEN`, or `AZURE_CLIENT_SECRET`. `GITHUB_TOKEN` is supplied by
-GitHub automatically.
+The workflow maps the `FOUNDRY_PROJECT_ENDPOINT` secret into the identically
+named typed runtime variable; Python never receives the deprecated
+`AZURE_OPENAI_ENDPOINT` name. A fork created before this rename must add
+`FOUNDRY_PROJECT_ENDPOINT`, because the workflows no longer read the former
+`AZURE_OPENAI_ENDPOINT` secret and a missing value fails the route preflight
+before any model call. Do not add `AZURE_OPENAI_API_KEY`, `AZURE_API_KEY`,
+`AZURE_OPENAI_AD_TOKEN`, or `AZURE_CLIENT_SECRET`. `GITHUB_TOKEN` is supplied
+by GitHub automatically.
 
 The route fingerprint binds endpoint kind, endpoint hash, deployment name, SDK
 version, and workload. It does **not** prove the Azure deployment SKU, PTU

--- a/docs/first-experiment_KR.md
+++ b/docs/first-experiment_KR.md
@@ -161,7 +161,7 @@ secret**에서 다음을 추가합니다.
 | `AZURE_CLIENT_ID` | Entra 앱의 client ID |
 | `AZURE_TENANT_ID` | Entra directory tenant ID |
 | `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
-| `AZURE_OPENAI_ENDPOINT` | `/api/projects/<project-name>` Foundry project endpoint. migration 동안 GitHub secret 이름만 유지 |
+| `FOUNDRY_PROJECT_ENDPOINT` | `/api/projects/<project-name>` Foundry project endpoint |
 | `HF_TOKEN` | Hugging Face 전용 write token |
 
 **Settings > Secrets and variables > Actions > Variables**에는 fail-closed
@@ -185,9 +185,12 @@ route preflight가 사용할 identity를 등록합니다.
 지원 workflow는 `legacy-rollback`을 선택하지 않으며, 명시적인 local strict
 rollback에서는 direct/project account 변수 대신 legacy account 변수가 필요합니다.
 
-workflow는 `AZURE_OPENAI_ENDPOINT` secret을 typed runtime 변수
-`FOUNDRY_PROJECT_ENDPOINT`로 mapping하며 Python에는 deprecated 이름을 전달하지
-않습니다. `AZURE_OPENAI_API_KEY`, `AZURE_API_KEY`, `AZURE_OPENAI_AD_TOKEN`,
+workflow는 `FOUNDRY_PROJECT_ENDPOINT` secret을 동일한 이름의 typed runtime
+변수로 mapping하며 deprecated 이름 `AZURE_OPENAI_ENDPOINT`는 Python에 전달하지
+않습니다. 이 rename 이전에 만든 fork는 `FOUNDRY_PROJECT_ENDPOINT`를 추가해야
+합니다. workflow가 기존 `AZURE_OPENAI_ENDPOINT` secret을 더 이상 읽지 않으며,
+값이 없으면 모델 호출 전에 route preflight가 실패합니다.
+`AZURE_OPENAI_API_KEY`, `AZURE_API_KEY`, `AZURE_OPENAI_AD_TOKEN`,
 `AZURE_CLIENT_SECRET`은 추가하지 마세요. `GITHUB_TOKEN`은 GitHub가 자동으로
 제공합니다.
 

--- a/scripts/__tests__/onboarding-contract.test.mjs
+++ b/scripts/__tests__/onboarding-contract.test.mjs
@@ -589,7 +589,7 @@ test('documented authentication uses typed Foundry routes and OIDC-only credenti
     'AZURE_CLIENT_ID',
     'AZURE_TENANT_ID',
     'AZURE_SUBSCRIPTION_ID',
-    'AZURE_OPENAI_ENDPOINT',
+    'FOUNDRY_PROJECT_ENDPOINT',
     'HF_TOKEN',
   ]
   const expectedVariables = [
@@ -613,7 +613,7 @@ test('documented authentication uses typed Foundry routes and OIDC-only credenti
     assert.deepEqual(dataRows(variableTable).map((row) => cleanCode(row[0])), expectedVariables)
     assert.match(guide, /`\/openai\/v1\/`/)
     assert.match(guide, /`\/api\/projects\/<project-name>`/)
-    assert.match(guide, /maps the `AZURE_OPENAI_ENDPOINT` secret|secret을 typed runtime 변수/)
+    assert.match(guide, /maps the `FOUNDRY_PROJECT_ENDPOINT` secret|secret을 동일한 이름의 typed runtime/)
     assert.match(guide, /`https:\/\/ai\.azure\.com\/\.default`|`ai\.azure\.com` token/)
   }
 

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,10 +1,109 @@
 # Latest Task Result
 
-- Updated: 2026-08-11
+- Updated: 2026-08-12
+- Status: the Foundry endpoint secret rename is implemented and reviewed; no
+  workflow was dispatched and the legacy secret still exists
+
+## Current Task: Foundry Endpoint Secret Rename
+
+### Task
+
+- Read the Foundry project endpoint from a `FOUNDRY_PROJECT_ENDPOINT`
+  repository secret instead of the legacy `AZURE_OPENAI_ENDPOINT` name, so the
+  secret matches the typed runtime variable it feeds.
+- Keep `AZURE_OPENAI_ENDPOINT` rejected as a runtime environment variable; the
+  deprecation guard, forbidden-name list, and absence assertions must survive.
+- Update both onboarding guides, both Batch Runner references, and the contract
+  test that pins the required secret list.
+- Do not dispatch a workflow, delete the legacy secret, or touch grading
+  configs, historical grades, archived configs, or Azure resources.
+
+### Result
+
+- `.github/workflows/batch-run.yml` reads `secrets.FOUNDRY_PROJECT_ENDPOINT` at
+  seven sites and `.github/workflows/grade-run.yml` at three. Each site already
+  assigned the value to a `FOUNDRY_PROJECT_ENDPOINT` runtime variable, so the
+  mapping is now one-to-one.
+- The route profile, `AZURE_AI_REQUIRE_EXPECTED_IDENTITIES`,
+  `AZURE_AI_EXPECTED_*`, and `AZURE_AI_WORKLOADS_JSON` lines around each site
+  are unchanged, including the `${{ !inputs.dry_run && ... || '' }}` gating in
+  `grade-run.yml` and the conditional `project-ci`/`direct-v1` expression in
+  `batch-run.yml`. Step order is unchanged.
+- `docs/first-experiment.md`, `docs/first-experiment_KR.md`,
+  `batch-runner/README.md`, and `batch-runner/README_KR.md` list the new secret,
+  state that the deprecated runtime variable is still never injected, and tell
+  operators of a fork created before this rename to add the new secret.
+- `scripts/__tests__/onboarding-contract.test.mjs` pins
+  `FOUNDRY_PROJECT_ENDPOINT` in the required-secret list at the same table
+  position used by both guides, and its mapping-sentence assertion matches the
+  English and Korean prose independently on a single line each.
+- Every remaining `AZURE_OPENAI_ENDPOINT` occurrence is environment-variable
+  scoped: `core/azure_ai_clients.py` lines 265, 274, and 299; the forbidden-name
+  list in `scripts/azure_ai_route_preflight.py`; the legacy native path in
+  `step2_run_inference.py`; the `llm_client.py` docstring; the two contract
+  assertions requiring absence from step environments; and the "rejects"
+  sentences in both Batch Runner references.
+- No Python source, grading config, schema, archived config, or historical task
+  record changed.
+
+### Cutover Order
+
+1. The owner created secret `FOUNDRY_PROJECT_ENDPOINT` and set
+   `AZURE_OPENAI_ENDPOINT` to the same Foundry project endpoint, so both names
+   resolve identically while this change is in review.
+2. This change switches every workflow reference to the new name.
+3. Only after it reaches exact `main` and a run confirms the new name resolves
+   may the owner delete `AZURE_OPENAI_ENDPOINT`.
+
+Deleting the legacy secret before step 3 breaks any ref that still reads it,
+because a workflow run resolves secrets against its own ref. A fork that never
+adds the new secret fails the route preflight before any model call, so the
+failure mode stays fail-closed rather than silently misrouting.
+
+### Verification
+
+- `scripts/__tests__/onboarding-contract.test.mjs`: 12 passed, 0 failed.
+- Workflow and Azure route Python suites: 733 passed across
+  `test_agentic_runtime_identity`, `test_agentic_v2_package_broker`,
+  `test_grading_config`, `test_grading_renderer_preflight_workflow`,
+  `test_relay_checkpoint`, `test_step8_grade`, `test_track2_preflight_workflow`,
+  `test_azure_ai_clients`, `test_azure_ai_route_preflight`, and
+  `test_azure_ai_step2_wiring`.
+- Both workflow files parse under `yaml.safe_load`.
+- `secrets.AZURE_OPENAI_ENDPOINT` occurrences under `.github/workflows`: 0.
+- The five root aggregate note suites fail three cases each both on unmodified
+  `origin/main` and after this change; they require the generated
+  `public/generated/reports-index.json`. Counts are identical, so this change
+  introduces no regression.
+
+### Unmeasured
+
+- `actionlint` is not installed on the validation host, so GitHub Actions
+  expression and `if:` schema validity is unverified. The change alters only
+  `secrets.*` identifiers and leaves every expression structure intact.
+
+### Review Evidence
+
+- Independent `first-reviewer` verdict: `APPROVE`, no blocking findings; the
+  env-var invariant table was confirmed intact at every listed site.
+- The reviewer's fork-migration observation was adopted in both onboarding
+  guides before this record was written.
+
+### Remaining Work
+
+- The owner decides whether and when to merge.
+- After merge, confirm a run resolves the new secret, then delete
+  `AZURE_OPENAI_ENDPOINT`.
+- The paid four-task Sol Max anchor remains unrun and separately approved.
+- Do not create a documentation-only PR to record this change's eventual merge
+  metadata.
+
+---
+
+## Preserved Prior Result: Sol Max Anchor Legacy Provenance Wiring (2026-08-11)
+
 - Status: exact-revision legacy provenance wiring is reviewed and validated;
   no paid grading was dispatched
-
-## Current Task: Sol Max Anchor Legacy Provenance Wiring
 
 ### Task
 


### PR DESCRIPTION
## Summary

Read the Foundry project endpoint from a `FOUNDRY_PROJECT_ENDPOINT` repository
secret instead of the legacy `AZURE_OPENAI_ENDPOINT` name at all ten workflow
sites — seven in `batch-run.yml`, three in `grade-run.yml`. Each site already
assigned the value to a runtime variable of that same name, so the mapping is
now one-to-one.

PR #140 deferred this deliberately; the guide said the old name was "retained as
the GitHub secret name during migration". This completes that step.

## The invariant this change preserves

`AZURE_OPENAI_ENDPOINT` is simultaneously a **forbidden runtime environment
variable**. Every env-var-scoped reference is untouched:

- `core/azure_ai_clients.py` 265, 274, 299 — deprecation error and check
- `scripts/azure_ai_route_preflight.py` 31 — forbidden-name list
- `step2_run_inference.py` 3104, 3106 — legacy native path
- `core/llm_client.py` 305 — docstring
- `onboarding-contract.test.mjs` 474, 482 — absence assertions
- the "rejects" sentences in both Batch Runner references

No Python source, grading config, schema, archived config, or historical task
record changed.

## Operator impact

⚠️ A fork created before this rename must add `FOUNDRY_PROJECT_ENDPOINT`. The
workflows no longer read the former secret. A missing value fails the route
preflight **before any model call**, so the failure mode is fail-closed rather
than a silent misroute. Both onboarding guides now say this.

## Cutover order

1. ✅ Owner created `FOUNDRY_PROJECT_ENDPOINT` and set `AZURE_OPENAI_ENDPOINT`
   to the same Foundry project endpoint, so both names resolve identically.
2. ⬅️ This PR switches every workflow reference.
3. ⏳ Only after this reaches exact `main` and a run confirms the new name
   resolves may the owner delete `AZURE_OPENAI_ENDPOINT`.

Deleting the legacy secret before step 3 breaks any ref that still reads it,
because a workflow run resolves secrets against its own ref.

## Validation

- `scripts/__tests__/onboarding-contract.test.mjs`: **12 passed, 0 failed**
- Workflow and Azure route Python suites: **733 passed** across
  `test_agentic_runtime_identity`, `test_agentic_v2_package_broker`,
  `test_grading_config`, `test_grading_renderer_preflight_workflow`,
  `test_relay_checkpoint`, `test_step8_grade`, `test_track2_preflight_workflow`,
  `test_azure_ai_clients`, `test_azure_ai_route_preflight`,
  `test_azure_ai_step2_wiring`
- Both workflow files parse under `yaml.safe_load`
- `secrets.AZURE_OPENAI_ENDPOINT` under `.github/workflows`: **0**
- `git diff --check`: clean
- Independent `first-reviewer`: **APPROVE**, no blocking findings; env-var
  invariant confirmed intact at every site. Its fork-migration observation was
  adopted before this PR was opened.

### Not measured

- The five root aggregate note suites fail three cases each **both** on
  unmodified `origin/main` and after this change; they need the generated
  `public/generated/reports-index.json`. Counts are identical, so no regression.
- `actionlint` is not installed on the validation host, so GitHub Actions
  expression and `if:` schema validity is unverified. This change alters only
  `secrets.*` identifiers and leaves every expression structure intact.

## Remote execution boundary

No workflow dispatch, Azure credential or token acquisition, model call, grading
run, Hugging Face write, deployment, paid execution, or secret deletion was
performed.