### PR TITLE
feat(grading): shard the 220-task grade run across N parallel relays

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -47,12 +47,28 @@ on:
         required: false
         type: number
         default: 0
+      shard_count:
+        description: "Split the corpus across N parallel dispatches (1 = serial). Each shard commits its own partial under data/grades/_shards/; the shard that finishes last merges them into the canonical final."
+        required: false
+        type: number
+        default: 1
+      shard_index:
+        description: "0-based index of this shard. Must be less than shard_count."
+        required: false
+        type: number
+        default: 0
 
 permissions:
   contents: read
 
 concurrency:
-  group: grade-${{ inputs.experiment_yaml }}-${{ inputs.grading_config }}
+  # Chunks of the SAME shard must never overlap -- they resume from one partial
+  # file and would race each other. Different shards MUST overlap or sharding
+  # buys nothing. So the key carries shard_index but deliberately NOT
+  # shard_count: re-dispatching the same index under a different N still
+  # serializes, which is what stops two overlapping slices from being graded
+  # (and paid for) simultaneously.
+  group: grade-${{ inputs.experiment_yaml }}-${{ inputs.grading_config }}-shard${{ inputs.shard_index }}
   cancel-in-progress: false
 
 jobs:
@@ -68,6 +84,8 @@ jobs:
       GRADE_PAID_APPROVAL: ${{ inputs.paid_approval }}
       GRADE_RESUME: ${{ inputs.resume }}
       GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
+      GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
+      GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
     steps:
       - name: Validate workflow context and inputs
         shell: bash
@@ -145,8 +163,35 @@ jobs:
             exit 1
           fi
 
+          # Cap at 11 concurrent shards. This is a blast-radius bound, not a
+          # derived optimum: each shard is an independent paid relay, so N is
+          # also the number of judge workloads billing at once. 11 puts the
+          # 220-task corpus at 20 tasks per shard and the ~71.6h serial
+          # projection at ~6.5h -- two 4h chunks, comfortably inside the relay
+          # envelope -- with room to dial N down if quota bites.
+          if [[ ! "$GRADE_SHARD_COUNT" =~ ^([1-9]|1[01])$ ]]; then
+            echo "::error::shard_count must be an integer between 1 and 11"
+            exit 1
+          fi
+          if [[ ! "$GRADE_SHARD_INDEX" =~ ^(0|[1-9]|10)$ ]]; then
+            echo "::error::shard_index must be an integer between 0 and 10"
+            exit 1
+          fi
+          if (( 10#$GRADE_SHARD_INDEX >= 10#$GRADE_SHARD_COUNT )); then
+            echo "::error::shard_index ($GRADE_SHARD_INDEX) must be less than shard_count ($GRADE_SHARD_COUNT)"
+            exit 1
+          fi
+          # --limit forks the output into _diagnostic/<scope_sha>/ because it
+          # narrows the graded corpus. Sharding does not narrow the corpus, and
+          # combining the two would scatter the shard set across a diagnostic
+          # subtree that nothing merges. Refuse the combination outright.
+          if [[ "$GRADE_SHARD_COUNT" != "1" && "$GRADE_TASKS_LIMIT" != "0" ]]; then
+            echo "::error::shard_count > 1 cannot be combined with tasks_limit"
+            exit 1
+          fi
+
   approve-paid:
-    name: Approve paid Sol Max grading (${{ inputs.experiment_yaml }}, ${{ inputs.grading_config }}, chunk ${{ inputs.resume_chunk }})
+    name: Approve paid Sol Max grading (${{ inputs.experiment_yaml }}, ${{ inputs.grading_config }}, chunk ${{ inputs.resume_chunk }}, shard ${{ inputs.shard_index }}/${{ inputs.shard_count }})
     needs: validate-request
     if: inputs.dry_run == false && inputs.paid_approval == true
     runs-on: ubuntu-24.04
@@ -160,6 +205,8 @@ jobs:
           GRADE_INFERENCE_REVISION: ${{ inputs.inference_revision }}
           GRADE_TASKS_LIMIT: ${{ inputs.tasks_limit }}
           GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
+          GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
+          GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
         run: |
           printf '%s\n' \
             "Approved paid grading request:" \
@@ -167,7 +214,8 @@ jobs:
             "  config=$GRADE_CONFIG" \
             "  inference_revision=${GRADE_INFERENCE_REVISION:-initial-main-resolution}" \
             "  tasks_limit=$GRADE_TASKS_LIMIT" \
-            "  resume_chunk=$GRADE_RESUME_CHUNK"
+            "  resume_chunk=$GRADE_RESUME_CHUNK" \
+            "  shard=$GRADE_SHARD_INDEX/$GRADE_SHARD_COUNT"
 
   grade-dry-run:
     needs: validate-request
@@ -181,6 +229,8 @@ jobs:
       GRADE_INFERENCE_REVISION: ${{ inputs.inference_revision }}
       GRADE_TASKS_LIMIT: ${{ inputs.tasks_limit }}
       HF_HUB_DISABLE_IMPLICIT_TOKEN: '1'
+      GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
+      GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
     steps:
       - name: Checkout exact main revision (read-only)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -251,6 +301,11 @@ jobs:
           if [[ "$GRADE_TASKS_LIMIT" != "0" ]]; then
             ARGS+=(--limit "$GRADE_TASKS_LIMIT")
           fi
+          # Preview this shard's slice, not the whole corpus -- otherwise the
+          # dry run's task count says nothing about what the paid run will do.
+          if [[ "$GRADE_SHARD_COUNT" != "1" ]]; then
+            ARGS+=(--shard-count "$GRADE_SHARD_COUNT" --shard-index "$GRADE_SHARD_INDEX")
+          fi
           python step8_grade.py "${ARGS[@]}"
 
   grade:
@@ -277,6 +332,8 @@ jobs:
       GRADE_PAID_APPROVAL: ${{ inputs.paid_approval }}
       GRADE_RESUME: ${{ inputs.resume }}
       GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
+      GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
+      GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
     # GH Actions hosted runners have a HARD 6h (360min) timeout that cannot be
     # extended. We set 320min so step8_grade.py's internal 4h time guard (env
     # GRADER_TIME_BUDGET_SEC=14400) trips first, partial-saves, and exits 7,
@@ -531,6 +588,14 @@ jobs:
           if [[ "$GRADE_TASKS_LIMIT" != "0" ]]; then
             ARGS+=(--limit "$GRADE_TASKS_LIMIT")
           fi
+          # Shard flags change WHO grades WHAT, never what is in scope: the
+          # payload still declares the full 220-task identity, so every shard
+          # shares one cache key and step9 can prove the set is complete. The
+          # slice only forks the output path (data/grades/_shards/...), which
+          # is what lets N jobs commit without contending for one file.
+          if [[ "$GRADE_SHARD_COUNT" != "1" ]]; then
+            ARGS+=(--shard-count "$GRADE_SHARD_COUNT" --shard-index "$GRADE_SHARD_INDEX")
+          fi
 
           set +e
           python step8_grade.py "${ARGS[@]}"
@@ -604,6 +669,12 @@ jobs:
           else
             MSG="chore(grades): grade $GRADE_EXPERIMENT_YAML via $GRADE_CONFIG"
           fi
+          if [[ "$GRADE_SHARD_COUNT" != "1" ]]; then
+            # Every sharded commit is a partial by construction, so say which
+            # slice it is -- the log is the only place that distinguishes N
+            # simultaneous commits touching sibling files.
+            MSG="$MSG [shard $GRADE_SHARD_INDEX of $GRADE_SHARD_COUNT]"
+          fi
           git commit -m "$MSG"
           git pull --rebase origin "${GITHUB_REF_NAME}"
           if [[ ! -f "$GRADE_FILE" ]]; then
@@ -655,7 +726,7 @@ jobs:
             echo "::error::resume_chunk=$NEXT_CHUNK exceeds safety cap (10). Aborting auto-resume; investigate manually."
             exit 1
           fi
-          echo "[auto-resume] triggering chunk $NEXT_CHUNK for $GRADE_EXPERIMENT_YAML / $GRADE_CONFIG"
+          echo "[auto-resume] triggering chunk $NEXT_CHUNK for $GRADE_EXPERIMENT_YAML / $GRADE_CONFIG (shard $GRADE_SHARD_INDEX/$GRADE_SHARD_COUNT)"
           gh workflow run grade-run.yml \
             --ref "${GITHUB_REF_NAME}" \
             -f experiment_yaml="$GRADE_EXPERIMENT_YAML" \
@@ -666,18 +737,134 @@ jobs:
             -f dry_run=false \
             -f paid_approval="$GRADE_PAID_APPROVAL" \
             -f resume=true \
-            -f resume_chunk=$NEXT_CHUNK
+            -f resume_chunk=$NEXT_CHUNK \
+            -f shard_count="$GRADE_SHARD_COUNT" \
+            -f shard_index="$GRADE_SHARD_INDEX"
           echo "[auto-resume] chunk $NEXT_CHUNK dispatched"
+
+      - name: Merge shards into the final grade
+        id: merge_shards
+        if: steps.grade.outputs.rc == '0' && inputs.dry_run == false && inputs.shard_count > 1
+        env:
+          SHARD_GRADE_FILE: ${{ steps.grade.outputs.grade_file }}
+        run: |
+          set -euo pipefail
+          # This shard has graded its whole slice. It is the LAST shard only if
+          # every sibling partial is already on main, so pull before looking.
+          #
+          # Whichever shard sees a complete set performs the merge. If two race,
+          # step9 is deterministic and order-independent, so both produce
+          # byte-identical output and the loser's `git diff --staged --quiet`
+          # turns its commit into a no-op. That is why no lock is needed. And
+          # the last shard to push its own partial is guaranteed to see all N,
+          # so at least one merger always exists.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git pull --rebase origin "${GITHUB_REF_NAME}"
+
+          SHARD_DIR="$(dirname -- "$SHARD_GRADE_FILE")"
+          # Expected shape: <output_root>/_shards/<canonical_stem>/shard-NNN-of-NNN.json
+          # Derive the final from the _shards/ parent instead of hardcoding
+          # data/grades/. A run that also forks into _diagnostic/<scope_sha>/
+          # then merges into ITS root rather than hard-failing here, after the
+          # money is already spent. Still pinned under data/grades/, still
+          # rejecting traversal, newlines and symlinked directories.
+          if [[ "$SHARD_GRADE_FILE" == *$'\n'* || "$SHARD_GRADE_FILE" == *..* ]]; then
+            echo "::error::shard grade path is not a safe relative path"
+            exit 1
+          fi
+          if [[ "$SHARD_DIR" != data/grades/* || "$SHARD_DIR" != */_shards/* ]]; then
+            echo "::error::sharded run resolved an unexpected output directory: $SHARD_DIR"
+            exit 1
+          fi
+          if [[ ! -d "$SHARD_DIR" || -L "$SHARD_DIR" ]]; then
+            echo "::error::shard directory is not a real directory: $SHARD_DIR"
+            exit 1
+          fi
+          STEM="$(basename -- "$SHARD_DIR")"
+          FINAL_FILE="${SHARD_DIR%/_shards/*}/${STEM}.json"
+          if [[ -L "$FINAL_FILE" ]]; then
+            echo "::error::refusing to merge through a symlinked output: $FINAL_FILE"
+            exit 1
+          fi
+          COUNT=$(( 10#$GRADE_SHARD_COUNT ))
+
+          SHARDS=()
+          for index in $(seq 0 $(( COUNT - 1 ))); do
+            candidate="$(printf '%s/shard-%03d-of-%03d.json' "$SHARD_DIR" "$index" "$COUNT")"
+            if [[ ! -f "$candidate" || -L "$candidate" ]]; then
+              echo "[merge] shard $index of $COUNT is not published yet; a later shard will merge"
+              echo "merged=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            SHARDS+=("$candidate")
+          done
+
+          echo "[merge] all $COUNT shards present; merging into $FINAL_FILE"
+          # --force: a shard that loses the race re-merges over a byte-identical
+          # file. step9 refuses an existing output otherwise, which would fail
+          # the loser for doing exactly the right thing.
+          python batch-runner/step9_merge_shards.py "${SHARDS[@]}" \
+            --output "$FINAL_FILE" --force
+
+          python - "$FINAL_FILE" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          sys.path.insert(0, "batch-runner")
+          from core.grade_payload import validate_grade_payload
+
+          payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          schema = json.loads(
+              Path("batch-runner/schemas/grade.schema.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          validate_grade_payload(payload, schema)
+          if payload.get("run_status") != "final":
+              raise SystemExit("merged payload must be final")
+          tasks = payload.get("tasks")
+          expected = payload.get("expected_task_count")
+          if not isinstance(tasks, list) or len(tasks) != expected:
+              raise SystemExit(
+                  f"merged payload holds {len(tasks or [])} of {expected} tasks"
+              )
+          PY
+
+          git add -- "$FINAL_FILE"
+          if git diff --staged --quiet; then
+            echo "[merge] identical merge is already on main (another shard won the race)"
+          else
+            git commit -m "chore(grades): merge $COUNT shards for $GRADE_EXPERIMENT_YAML via $GRADE_CONFIG"
+            # A sibling can still push its own merge in the window between the
+            # pull above and this push. That is safe at the git level too: the
+            # rebase drops our commit by patch-id, and even if it did not, an
+            # add/add of byte-identical content resolves without conflict.
+            git pull --rebase origin "${GITHUB_REF_NAME}"
+            git push
+          fi
+          echo "merged=true" >> "$GITHUB_OUTPUT"
+          echo "grade_file=$FINAL_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Auto-analyze (final chunk only)
         id: analysis
-        if: steps.grade.outputs.rc == '0' && inputs.dry_run == false
+        # Serial: rc=0 means the run finished. Sharded: rc=0 means only THIS
+        # slice finished, so analysing here would publish an analysis of 1/N of
+        # the corpus. Wait for the merge to declare the whole run complete.
+        if: >-
+          inputs.dry_run == false &&
+          ((inputs.shard_count == 1 && steps.grade.outputs.rc == '0') ||
+          steps.merge_shards.outputs.merged == 'true')
+        env:
+          ANALYSIS_GRADE_FILE: ${{ steps.merge_shards.outputs.grade_file || steps.grade.outputs.grade_file }}
         run: |
-          # rc=0 means step8 completed all tasks (either single-shot or last
-          # resume chunk). Analyze the exact resolved grade JSON and emit a
-          # markdown analysis (wall-clock, latency, tokens, cost estimate,
-          # top-5 slowest, quality summary).
-          GRADE_FILE="${{ steps.grade.outputs.grade_file }}"
+          # Serial: rc=0 means step8 completed every task (single-shot or last
+          # resume chunk). Sharded: the merge step above just proved the whole
+          # corpus is assembled, and hands over the merged final's path.
+          # Analyze that exact JSON and emit a markdown analysis (wall-clock,
+          # latency, tokens, cost estimate, top-5 slowest, quality summary).
+          GRADE_FILE="$ANALYSIS_GRADE_FILE"
           if [[ -z "$GRADE_FILE" || ! -f "$GRADE_FILE" ]]; then
             echo "::error::resolved grade file is missing for $GRADE_EXPERIMENT_YAML: $GRADE_FILE"
             exit 1
@@ -693,7 +880,10 @@ jobs:
           head -40 "$OUT"
 
       - name: Commit analysis
-        if: steps.grade.outputs.rc == '0' && inputs.dry_run == false
+        # Follow the analyze step exactly. Gating on rc alone would fire on a
+        # shard that produced no analysis, and the emptiness guard below would
+        # then fail the job for correctly declining to analyze 1/N of a corpus.
+        if: steps.analysis.outcome == 'success' && inputs.dry_run == false
         env:
           ANALYSIS_FILE: ${{ steps.analysis.outputs.analysis_file }}
         run: |
@@ -716,8 +906,12 @@ jobs:
         if: always() && inputs.dry_run == false && steps.grade.outputs.grade_file != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: grade-${{ env.GRADE_EXPERIMENT_YAML }}
+          # Shards are separate workflow runs, so the names cannot collide --
+          # but a downloaded bundle is unreadable without knowing which slice it
+          # holds, and the merging shard carries the final on top of its own.
+          name: grade-${{ env.GRADE_EXPERIMENT_YAML }}${{ inputs.shard_count > 1 && format('-shard{0}of{1}', inputs.shard_index, inputs.shard_count) || '' }}
           path: |
             ${{ steps.grade.outputs.grade_file }}
+            ${{ steps.merge_shards.outputs.grade_file }}
             ${{ steps.analysis.outputs.analysis_file }}
           retention-days: 30

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -212,6 +212,8 @@ def resolve_grade_output_path(
     inference_sha: str | None = None,
     grader_source_hash: str | None = None,
     diagnostic_task_scope_sha: str | None = None,
+    shard_index: int = 0,
+    shard_count: int = 1,
 ) -> Path:
     if not FULL_HF_SHA_RE.fullmatch(rubric_sha):
         raise ValueError(
@@ -236,6 +238,10 @@ def resolve_grade_output_path(
         raise ValueError(
             "diagnostic_task_scope_sha must be a full lowercase SHA-256"
         )
+    if shard_count < 1 or not 0 <= shard_index < shard_count:
+        raise ValueError(
+            "shard_index must satisfy 0 <= index < shard_count (count >= 1)"
+        )
     out_name = config["output"]["filename_template"].format(
         exp_id=experiment_id,
         judge_slug=judge_slug,
@@ -253,11 +259,26 @@ def resolve_grade_output_path(
         raise ValueError("formatted grade filename must be a single safe path component")
     output_root = Path(config["output"]["directory"])
     if diagnostic_task_scope_sha is not None:
+        output_root = output_root / "_diagnostic" / diagnostic_task_scope_sha
+    if shard_count > 1:
+        # Every shard of a run resolves to the same `out_name`, because their
+        # identity inputs (config_hash, rubric_sha, grader_source_hash, ...) are
+        # identical by construction — that sameness is the whole point, it is
+        # what lets step9 prove the shards belong together. So the *path* has to
+        # fork or N concurrent jobs would write and commit the same file.
+        #
+        # Fork it exactly the way `_diagnostic/<scope_sha>/` already does: below
+        # the canonical name, never inside it. No identity input is touched, so
+        # the cache key is unchanged and each shard's path is stable across its
+        # own rc=7 resume chunks. The `_shards/` directory also keeps these
+        # partials out of `scripts/aggregate-grades.mjs`, which globs
+        # `data/grades/*.json` non-recursively and would otherwise publish an
+        # unfinished slice to the dashboard as if it were a graded run.
         return (
             output_root
-            / "_diagnostic"
-            / diagnostic_task_scope_sha
-            / out_name
+            / "_shards"
+            / Path(out_name).stem
+            / f"shard-{shard_index:03d}-of-{shard_count:03d}.json"
         )
     return output_root / out_name
 
@@ -311,6 +332,28 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--shard-count",
+        type=int,
+        default=1,
+        help=(
+            "Split the run across N workers. Each shard grades a stride slice "
+            "(tasks[i::N]) of the SAME canonical task order, so the corpus "
+            "identity fields (expected_task_count, "
+            "expected_ordered_task_ids_sha256) still describe the full corpus "
+            "and every shard resolves to the same cache key. A shard emits "
+            "run_status 'partial'; step9_merge_shards.py reassembles the "
+            "shards into the final payload. Default 1 = serial, unsharded. "
+            "Sharding is NOT a diagnostic selection: it changes who grades "
+            "what, not which tasks are in scope."
+        ),
+    )
+    parser.add_argument(
+        "--shard-index",
+        type=int,
+        default=0,
+        help="0-based index of this shard; must satisfy 0 <= index < count.",
+    )
+    parser.add_argument(
         "--source-experiment-id",
         default=None,
         help=(
@@ -320,7 +363,15 @@ def parse_args() -> argparse.Namespace:
             "from the inference run directory (e.g. re-grading a renamed run)."
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.shard_count < 1:
+        parser.error("--shard-count must be >= 1")
+    if not 0 <= args.shard_index < args.shard_count:
+        parser.error(
+            "--shard-index must satisfy 0 <= index < --shard-count "
+            f"(got index={args.shard_index}, count={args.shard_count})"
+        )
+    return args
 
 
 def validate_grading_config(config: dict) -> None:
@@ -907,6 +958,36 @@ def _task_ids(rows: list[dict], *, label: str) -> list[str]:
     return task_ids
 
 
+def _is_ordered_subsequence(candidate: list[str], universe: list[str]) -> bool:
+    """True when ``candidate`` occurs inside ``universe`` in the same order.
+
+    A serial ``--resume`` produces a prefix of the canonical order, but a shard
+    (``--shard-count``) grades a stride slice, so its partial payload is an
+    ordered *subsequence* instead. Every prefix is a subsequence, so accepting
+    subsequences only widens what already validated.
+    """
+    remaining = iter(universe)
+    return all(task_id in remaining for task_id in candidate)
+
+
+def _shard_slice(
+    tasks: list[dict], *, shard_index: int, shard_count: int
+) -> list[dict]:
+    """Return the stride slice of ``tasks`` this shard is responsible for.
+
+    Stride (``tasks[i::n]``) rather than contiguous blocks: the corpus carries
+    whatever ordering bias the source dataset had (sector runs, difficulty
+    drift), and contiguous blocks would concentrate that bias into individual
+    shards, making per-shard cost and wall-clock wildly uneven. A stride spreads
+    it. The union of all shards is exactly ``tasks``, and each shard preserves
+    the canonical relative order, so each partial payload is an ordered
+    subsequence of the expected ids.
+    """
+    if shard_count <= 1:
+        return list(tasks)
+    return tasks[shard_index::shard_count]
+
+
 def _validate_grade_task_set(
     existing: dict,
     expected_tasks: list[dict],
@@ -939,8 +1020,10 @@ def _validate_grade_task_set(
     if require_complete:
         if existing_ids != expected_ids:
             raise ValueError("existing final grade task order is incomplete or mismatched")
-    elif existing_ids != expected_ids[: len(existing_ids)]:
-        raise ValueError("existing partial grade tasks are not an ordered prefix")
+    elif not _is_ordered_subsequence(existing_ids, expected_ids):
+        raise ValueError(
+            "existing partial grade tasks are not an ordered subsequence"
+        )
     runtime_errors = [
         (task["task_id"], error)
         for task in existing["tasks"]
@@ -1535,6 +1618,17 @@ def main() -> int:
         or source_provenance_status == "legacy-missing"
     )
     completed_run_status = "diagnostic" if diagnostic_run else "final"
+    # Sharding deliberately does NOT feed `diagnostic_run` above. A diagnostic
+    # run is one whose *scope* was narrowed (--tasks/--limit/pinned selection),
+    # which forks the output into _diagnostic/<scope_sha>/. A shard's scope is
+    # still the full corpus; only the division of labour changed. Keeping them
+    # separate is what lets every shard resolve to the same canonical
+    # out_path and merge back into one final payload.
+    sharded_run = args.shard_count > 1
+    # `completed_run_status` keeps meaning "what a COMPLETE run of this config
+    # looks like" — the cache/resume guards compare against it. What this
+    # process actually writes is a partial when it is one shard of many.
+    emitted_run_status = "partial" if sharded_run else completed_run_status
     diagnostic_task_scope_sha = (
         _ordered_task_ids_sha256(expected_task_ids)
         if diagnostic_run
@@ -1552,15 +1646,24 @@ def main() -> int:
             inference_sha=inference_revision,
             grader_source_hash=grader_source_hash,
             diagnostic_task_scope_sha=diagnostic_task_scope_sha,
+            shard_index=args.shard_index,
+            shard_count=args.shard_count,
         )
         _write_github_output("grade_file", _repo_relative_grade_file(out_path))
-        _write_github_output("grade_status", completed_run_status)
+        _write_github_output("grade_status", emitted_run_status)
     except (KeyError, ValueError) as exc:
         print(f"ERROR: grade output path resolution failed: {exc}", file=sys.stderr)
         return 1
 
     if args.dry_run:
-        _print_dry_run_stats(tasks, loader)
+        _print_dry_run_stats(
+            _shard_slice(
+                tasks,
+                shard_index=args.shard_index,
+                shard_count=args.shard_count,
+            ),
+            loader,
+        )
         return 0
 
     try:
@@ -1581,6 +1684,19 @@ def main() -> int:
     except ValueError as exc:
         print(f"ERROR: deliverable tree validation failed: {exc}", file=sys.stderr)
         return 1
+
+    # From here `tasks` is the corpus *identity* — it drives expected_task_count,
+    # expected_ordered_task_ids_sha256 and every resume/cache guard, and stays
+    # the full corpus even when this process only grades a slice of it.
+    # `shard_tasks` is this process's *workload*. Identical when unsharded.
+    shard_tasks = _shard_slice(
+        tasks, shard_index=args.shard_index, shard_count=args.shard_count
+    )
+    if sharded_run:
+        print(
+            f"SHARD {args.shard_index + 1}/{args.shard_count}: grading "
+            f"{len(shard_tasks)} of {len(tasks)} tasks"
+        )
 
     renderer_fingerprint: dict[str, str] | None = None
     renderer_required = requires_track2_office_renderer(config)
@@ -1616,12 +1732,28 @@ def main() -> int:
                 ),
                 anchor_projection=config.get("anchor_projection"),
             )
-            _validate_grade_task_set(
-                existing,
-                tasks,
-                require_complete=True,
-                complete_status=completed_run_status,
-            )
+            if sharded_run:
+                # A completed shard leaves a partial, not a final, and that
+                # partial must be THIS shard's slice — otherwise we would skip
+                # on a sibling shard's output and silently never grade our own.
+                existing_ids = _validate_grade_task_set(
+                    existing, tasks, require_complete=False
+                )
+                shard_ids = set(_task_ids(shard_tasks, label="current shard"))
+                if existing_ids != shard_ids:
+                    raise ValueError(
+                        "existing partial at this path belongs to a different "
+                        f"shard: expected {len(shard_ids)} ids for "
+                        f"--shard-index {args.shard_index}, found "
+                        f"{len(existing_ids)}"
+                    )
+            else:
+                _validate_grade_task_set(
+                    existing,
+                    tasks,
+                    require_complete=True,
+                    complete_status=completed_run_status,
+                )
         except ValueError as exc:
             print(f"ERROR: grade cache identity validation failed: {exc}", file=sys.stderr)
             return 1
@@ -1677,6 +1809,18 @@ def main() -> int:
             completed_task_ids = _validate_grade_task_set(
                 existing, tasks, require_complete=False
             )
+            if sharded_run:
+                # The partial may be short (that is what resuming means), but
+                # every id in it must belong to this shard's slice. Anything
+                # else means we picked up a sibling shard's file and would
+                # re-emit its tasks under our index, double-counting on merge.
+                shard_ids = set(_task_ids(shard_tasks, label="current shard"))
+                foreign = sorted(completed_task_ids - shard_ids)
+                if foreign:
+                    raise ValueError(
+                        "partial contains tasks outside --shard-index "
+                        f"{args.shard_index} of {args.shard_count}: {foreign}"
+                    )
         except ValueError as exc:
             print(f"ERROR: --resume {exc}", file=sys.stderr)
             return 1
@@ -1768,7 +1912,7 @@ def main() -> int:
             atexit.unregister(grader_exit_cleanup)
         return code
 
-    for idx, task_result in enumerate(tasks, start=1):
+    for idx, task_result in enumerate(shard_tasks, start=1):
         # Resume skip
         if task_result["task_id"] in completed_task_ids:
             continue
@@ -1777,7 +1921,7 @@ def main() -> int:
         elapsed_sec = time.monotonic() - grade_loop_start
         if time_budget_sec > 0 and elapsed_sec > time_budget_sec:
             graded_count = len(task_payloads)
-            remaining = len(tasks) - graded_count
+            remaining = len(shard_tasks) - graded_count
             if graded_count <= initial_completed_count:
                 print(
                     "[time-guard] no new task completed in this chunk; "
@@ -1787,7 +1931,7 @@ def main() -> int:
                 return finish(GRADE_EXIT_PERSISTENCE_FAILURE)
             print(
                 f"\n[time-guard] elapsed {elapsed_sec/60:.1f}min > budget "
-                f"{time_budget_sec/60:.0f}min; graded={graded_count}/{len(tasks)} "
+                f"{time_budget_sec/60:.0f}min; graded={graded_count}/{len(shard_tasks)} "
                 f"remaining={remaining}. Saving partial and requesting resume.",
                 file=sys.stderr,
             )
@@ -1842,7 +1986,7 @@ def main() -> int:
         task_payloads.append(row)
 
         print(
-            f"[{idx}/{len(tasks)}] {task.task_id[:8]} -> {grade.pct:.1f}% "
+            f"[{idx}/{len(shard_tasks)}] {task.task_id[:8]} -> {grade.pct:.1f}% "
             f"({grade.total_awarded:.1f}/{grade.total_max})"
         )
 
@@ -1935,7 +2079,7 @@ def main() -> int:
         inference_revision,
         azure_ai_runtime_fingerprint=azure_ai_runtime_fingerprint,
         azure_ai_routes=azure_ai_routes,
-        run_status=completed_run_status,
+        run_status=emitted_run_status,
         expected_task_ids=expected_task_ids,
         exp_config=exp_config,
         source_experiment_id=args.source_experiment_id,

--- a/batch-runner/step9_merge_shards.py
+++ b/batch-runner/step9_merge_shards.py
@@ -1,0 +1,1117 @@
+#!/usr/bin/env python3
+"""Step 9: merge N partial shard grade payloads into one final grade payload.
+
+Why this exists
+---------------
+The 220-task grade run projects to ~71.6h of judge latency while a single
+GitHub Actions relay envelope is 44h (``GRADER_TIME_BUDGET_SEC`` 4h x 10
+resume chunks). Sharding the corpus across N parallel relays is the only
+remaining lever that does not change the reproducibility contract (judge
+model / reasoning effort / prompt / rubric all stay pinned). Each shard
+produces a ``run_status: "partial"`` grade payload that declares the FULL
+corpus identity (``expected_task_count`` = 220 and
+``expected_ordered_task_ids_sha256`` = the full ordered-id hash) while
+carrying only its own slice of ``tasks``. This module folds those N
+partials back into one ``run_status: "final"`` payload.
+
+Guarantees
+----------
+* **Pure offline.** Zero LLM calls, zero Azure calls, zero network access.
+  Reads JSON, writes JSON.
+* **Deterministic.** Same inputs produce a byte-identical output (modulo
+  nothing -- the merged payload is a pure function of the shard payloads).
+  Input *order on the command line does not matter*: shards are normalised
+  into canonical corpus order before anything is computed.
+* **Serial-identical.** Every recomputed aggregate is produced by calling
+  :func:`step8_grade._compute_summary` over the merged task list, i.e. the
+  exact function a single serial run would have called over the exact same
+  list in the exact same order. Rounding is never reimplemented here:
+  ``judge_error_rate`` comes from :func:`core.grade_payload.canonical_rate`
+  (half-up at 4dp) via ``_compute_summary``, and float summation order is
+  preserved by canonical task ordering.
+* **No silent partial publication.** A merge whose task union is smaller
+  than ``expected_task_count`` is a hard failure. It never degrades to
+  emitting a partial.
+
+Latency semantics (read this before wiring a dashboard)
+-------------------------------------------------------
+``summary.cost.total_judge_latency_sec`` (and its ``main`` / ``perception``
+/ ``render`` siblings) in the merged payload is **total judge work**, not
+**elapsed wall-clock time**. N shards run concurrently, so the merged
+latency total is the sum of N parallel timelines. Displaying it as "how
+long the run took" overstates elapsed time by roughly a factor of N.
+
+The emitted value is *recomputed* from the merged task list rather than
+summed from the shard summaries, because only the recomputed value is
+identical to a serial run (each shard rounds to 2dp, so
+``sum(round(...)) != round(sum(...))``). The shard-reported latencies are
+still cross-checked against that recomputation within a rounding tolerance
+of ``0.01s x shard count`` -- see :func:`_check_latency_sums` -- so a
+hand-edited shard latency is rejected instead of being silently ignored.
+
+Route provenance
+----------------
+``azure_ai_routes`` is an order-preserving union across shards, deduplicated
+by ``runtime_fingerprint``, and ``azure_ai_runtime_fingerprint`` is taken
+from shard index 0 (the shard holding the canonically-first task). This
+follows the merge table in the shard-merge spec section D. It is a
+DELIBERATE relaxation of the sequential-resume invariant enforced by
+``step8_grade._validate_azure_ai_resume_identity``, which demands the two
+fields be byte-identical across accumulated payloads. Even a 4-task anchor
+run already observed two distinct grader fingerprints, so a 9-way run is
+expected to observe more. Pass ``--strict-routes`` to enforce the literal
+sequential invariant instead. Whichever mode is used, per-shard route
+identity is preserved in ``shard_provenance`` -- each entry records the
+fingerprint that shard actually carried, so drift is readable from the
+merged artifact alone rather than only from a stderr warning -- and every
+observed fingerprint survives in the merged ``azure_ai_routes`` list.
+
+Usage
+-----
+    python step9_merge_shards.py shard0.json shard1.json ... \
+        --output data/grades/merged.json
+
+    # explicit canonical order (e.g. from workspace/step1_tasks_prepared.json)
+    python step9_merge_shards.py shard*.json \
+        --expected-task-ids workspace/step2_inference_results.json \
+        --output merged.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+from core.grade_payload import canonical_rate, validate_grade_payload
+from step8_grade import (
+    SCHEMA_VERSION,
+    _batch_runner_root,
+    _compute_summary,
+    _ordered_task_ids_sha256,
+    _save_json,
+)
+
+FULL_SHA256_RE_TEXT = "^[0-9a-f]{64}$"
+
+#: Upper bound on stride-layout candidates explored when reconstructing the
+#: canonical corpus order without an explicit ``--expected-task-ids`` source.
+#: A 9-way stride split of 220 tasks yields 4! * 5! = 2880 candidates.
+MAX_CANDIDATE_LAYOUTS = 200_000
+
+#: Sentinel distinguishing "key absent" from "key present with value None".
+_MISSING = object()
+
+#: Shard-merge spec section C invariants 1-10: the fields
+#: ``step8_grade._validate_grade_resume_identity`` requires to be identical
+#: when two grade payloads are accumulated. Order here is the order reported.
+CONTRACT_IDENTITY_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("schema_version", ("schema_version",)),
+    ("experiment_id", ("experiment_id",)),
+    ("rubric.commit_sha", ("rubric", "commit_sha")),
+    ("prompt.version", ("prompt", "version")),
+    ("judge.config_hash", ("judge", "config_hash")),
+    ("source_inference_repo_id", ("source_inference_repo_id",)),
+    ("source_inference_revision", ("source_inference_revision",)),
+    ("grader_source_hash", ("grader_source_hash",)),
+    ("anchor_projection", ("anchor_projection",)),
+    ("renderer_fingerprint", ("renderer_fingerprint",)),
+)
+
+#: Spec section D "verify then adopt" fields that are not part of the ten
+#: sequential-resume invariants. ``summary.cost.unpriced_models`` is checked
+#: first so that a judge-model / perception-model divergence is reported
+#: against the field the kill criterion names (kill criterion 2).
+ADOPTED_IDENTITY_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("summary.cost.unpriced_models", ("summary", "cost", "unpriced_models")),
+    ("expected_task_count", ("expected_task_count",)),
+    (
+        "expected_ordered_task_ids_sha256",
+        ("expected_ordered_task_ids_sha256",),
+    ),
+    ("inference_model", ("inference_model",)),
+    ("judge", ("judge",)),
+    ("rubric", ("rubric",)),
+    ("prompt", ("prompt",)),
+    ("graded_by", ("graded_by",)),
+    ("graded_by_version", ("graded_by_version",)),
+    ("experiment_yaml_name", ("experiment_yaml_name",)),
+    ("source_inference_experiment_id", ("source_inference_experiment_id",)),
+    ("source_azure_ai_routes", ("source_azure_ai_routes",)),
+    (
+        "source_azure_ai_provenance_status",
+        ("source_azure_ai_provenance_status",),
+    ),
+    ("inference_completed_at", ("inference_completed_at",)),
+)
+
+#: Best-effort debug-only field (``step8_grade._resolve_source_inference_run_dir``
+#: probes the local filesystem, so two runners can legitimately disagree).
+#: Adopted from shard 0 without an equality requirement.
+NON_IDENTITY_ADOPTED_FIELDS: tuple[str, ...] = ("source_inference_run_dir",)
+
+#: Integer cost counters that must sum exactly. Recomputation from the merged
+#: task list is the source of truth; this check proves each shard's own
+#: summary agreed with its own tasks, i.e. that no shard was hand-edited.
+SUMMABLE_COST_FIELDS: tuple[str, ...] = (
+    "total_judge_calls",
+    "total_main_judge_calls",
+    "total_perception_calls",
+    "total_input_tokens",
+    "total_output_tokens",
+    "total_cached_tokens",
+    "main_input_tokens",
+    "main_output_tokens",
+    "main_cached_tokens",
+    "perception_input_tokens",
+    "perception_output_tokens",
+    "perception_cached_tokens",
+    "total_render_calls",
+)
+
+#: Float latency counters. Unlike :data:`SUMMABLE_COST_FIELDS` these are NOT
+#: summed into the merged payload: the merged value is recomputed from the
+#: merged task list, because only the recomputed value is identical to what a
+#: serial run over the same corpus would have emitted (spec section F kill
+#: criterion 6). Each shard rounds its own latency to 2dp, so
+#: ``sum(round(...)) != round(sum(...))`` and the shard sum is the serial value
+#: plus rounding drift.
+#:
+#: That makes each shard's own ``summary.cost.*_latency_sec`` a spectator
+#: field, which is the hole :func:`_check_latency_sums` closes.
+LATENCY_COST_FIELDS: tuple[str, ...] = (
+    "total_judge_latency_sec",
+    "total_main_judge_latency_sec",
+    "total_perception_latency_sec",
+    "total_render_latency_sec",
+)
+
+#: Per-shard tolerance, in seconds, for the latency cross-check.
+#:
+#: ``_compute_summary`` rounds every latency to 2dp, so one shard's reported
+#: value can sit at most 0.005s from its own exact value, and the merged
+#: recomputation contributes one further 0.005s. The largest legitimate gap
+#: across n shards is therefore ``0.005 * (n + 1)``, and ``0.01 * n`` bounds it
+#: for every ``n >= 1`` (``0.01n >= 0.005n + 0.005`` iff ``n >= 1``) with a
+#: factor-of-two margin. Measured worst case on the 220-task corpus is 0.01s at
+#: n=3 against a 0.03s budget. Widening this constant re-opens the tampering
+#: hole it exists to close.
+LATENCY_TOLERANCE_SEC_PER_SHARD = 0.01
+
+
+class ShardMergeError(ValueError):
+    """A shard set cannot be merged into a single final grade payload."""
+
+
+# --------------------------------------------------------------------------
+# small helpers
+# --------------------------------------------------------------------------
+
+
+def _get_path(payload: dict, path: Sequence[str]) -> Any:
+    """Return the value at ``path`` or :data:`_MISSING` when absent."""
+    node: Any = payload
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            return _MISSING
+        node = node[key]
+    return node
+
+
+def _describe(value: Any) -> str:
+    if value is _MISSING:
+        return "<missing>"
+    return repr(value)
+
+
+def _canonical_json_bytes(payload: Any) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _payload_digest(payload: dict) -> str:
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _read_grade_schema() -> dict:
+    path = _batch_runner_root() / "schemas" / "grade.schema.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ShardMergeError(f"could not read grade schema: {exc}") from exc
+
+
+def _parse_graded_at(value: Any, label: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ShardMergeError(
+            f"{label} has no usable graded_at timestamp: {_describe(value)}"
+        )
+    text = value.strip()
+    normalized = f"{text[:-1]}+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ShardMergeError(
+            f"{label} graded_at is not ISO-8601: {value!r}"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _shard_task_ids(payload: dict, label: str) -> list[str]:
+    tasks = payload.get("tasks")
+    if not isinstance(tasks, list):
+        raise ShardMergeError(f"{label} has no tasks array")
+    if not tasks:
+        raise ShardMergeError(f"{label} contains zero graded tasks")
+    task_ids: list[str] = []
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for index, row in enumerate(tasks):
+        if not isinstance(row, dict):
+            raise ShardMergeError(
+                f"{label} task at index {index} is not an object"
+            )
+        task_id = row.get("task_id")
+        if not isinstance(task_id, str) or not task_id.strip():
+            raise ShardMergeError(
+                f"{label} task at index {index} has no non-empty task_id"
+            )
+        if task_id in seen:
+            duplicates.add(task_id)
+        seen.add(task_id)
+        task_ids.append(task_id)
+    if duplicates:
+        raise ShardMergeError(
+            f"{label} contains duplicate task_ids: {sorted(duplicates)}"
+        )
+    return task_ids
+
+
+# --------------------------------------------------------------------------
+# invariant checks
+# --------------------------------------------------------------------------
+
+
+def _check_identity_fields(
+    shards: Sequence[dict],
+    labels: Sequence[str],
+    fields: Sequence[tuple[str, tuple[str, ...]]],
+    *,
+    contract: bool,
+) -> None:
+    """Fail loudly if any shard disagrees on a verify-then-adopt field."""
+    reference = shards[0]
+    reference_label = labels[0]
+    kind = "shard merge identity" if contract else "shard merge field"
+    for field_name, path in fields:
+        expected = _get_path(reference, path)
+        for shard, label in zip(shards[1:], labels[1:]):
+            actual = _get_path(shard, path)
+            if actual != expected:
+                state = "missing" if actual is _MISSING else "mismatch"
+                raise ShardMergeError(
+                    f"{kind} {state} for {field_name}: "
+                    f"{reference_label}={_describe(expected)}, "
+                    f"{label}={_describe(actual)}"
+                )
+
+
+def _check_schema_version(shards: Sequence[dict], labels: Sequence[str]) -> None:
+    for shard, label in zip(shards, labels):
+        version = shard.get("schema_version")
+        if version != SCHEMA_VERSION:
+            raise ShardMergeError(
+                "shard merge identity mismatch for schema_version: "
+                f"{label}={_describe(version)}, "
+                f"current contract={SCHEMA_VERSION!r}"
+            )
+
+
+def _check_partial_status(shards: Sequence[dict], labels: Sequence[str]) -> None:
+    for shard, label in zip(shards, labels):
+        status = shard.get("run_status")
+        if status != "partial":
+            raise ShardMergeError(
+                f"{label} run_status must be 'partial' to be merged, "
+                f"got {_describe(status)}"
+            )
+
+
+def _check_route_identity(
+    shards: Sequence[dict],
+    labels: Sequence[str],
+    *,
+    strict: bool,
+    warn: Callable[[str], None],
+) -> None:
+    """Verify section C invariants 11-12 (``azure_ai_*``) per shard.
+
+    Structural verification is unconditional: each shard must carry a
+    non-empty grader route list whose first entry matches the shard's own
+    primary ``azure_ai_runtime_fingerprint``. Cross-shard byte equality is
+    only demanded under ``strict``; otherwise drift is surfaced as a warning
+    and resolved by the section D union / shard-0 rules.
+    """
+    for shard, label in zip(shards, labels):
+        routes = shard.get("azure_ai_routes")
+        fingerprint = shard.get("azure_ai_runtime_fingerprint")
+        if not isinstance(routes, list) or not routes:
+            raise ShardMergeError(f"{label} has no azure_ai_routes")
+        for index, route in enumerate(routes):
+            if not isinstance(route, dict):
+                raise ShardMergeError(
+                    f"{label} azure_ai_routes[{index}] is not an object"
+                )
+            if route.get("workload") != "grader":
+                raise ShardMergeError(
+                    f"{label} azure_ai_routes[{index}] is not a grader "
+                    f"route: workload={_describe(route.get('workload'))}"
+                )
+        if not isinstance(fingerprint, str) or not _is_sha256(fingerprint):
+            raise ShardMergeError(
+                f"{label} azure_ai_runtime_fingerprint is invalid: "
+                f"{_describe(fingerprint)}"
+            )
+        primary = routes[0].get("runtime_fingerprint")
+        if primary != fingerprint:
+            raise ShardMergeError(
+                f"{label} primary grader route fingerprint mismatch: "
+                f"azure_ai_routes[0]={_describe(primary)}, "
+                f"azure_ai_runtime_fingerprint={fingerprint!r}"
+            )
+
+    if strict:
+        _check_identity_fields(
+            shards,
+            labels,
+            (
+                ("azure_ai_routes", ("azure_ai_routes",)),
+                (
+                    "azure_ai_runtime_fingerprint",
+                    ("azure_ai_runtime_fingerprint",),
+                ),
+            ),
+            contract=True,
+        )
+        return
+
+    fingerprints = {shard["azure_ai_runtime_fingerprint"] for shard in shards}
+    if len(fingerprints) > 1:
+        warn(
+            "azure_ai_runtime_fingerprint differs across shards "
+            f"({len(fingerprints)} distinct values); merged payload adopts "
+            "shard 0's fingerprint and unions every observed route. Re-run "
+            "with --strict-routes to reject route drift instead."
+        )
+
+
+def _is_sha256(value: str) -> bool:
+    return len(value) == 64 and all(
+        char in "0123456789abcdef" for char in value
+    )
+
+
+def _check_cost_sums(
+    shards: Sequence[dict],
+    labels: Sequence[str],
+    merged_cost: dict,
+) -> None:
+    """Prove each shard's own cost counters agreed with its own tasks.
+
+    The merged counters are recomputed from the merged task list (that is
+    what makes them serial-identical). Summing the shard-reported counters
+    must reproduce the same integers; if it does not, at least one shard
+    payload was edited after it was written and must not be merged.
+    """
+    for field in SUMMABLE_COST_FIELDS:
+        total = 0
+        for shard, label in zip(shards, labels):
+            value = _get_path(shard, ("summary", "cost", field))
+            if type(value) is not int:
+                raise ShardMergeError(
+                    f"{label} summary.cost.{field} must be an integer, "
+                    f"got {_describe(value)}"
+                )
+            total += value
+        if merged_cost.get(field) != total:
+            raise ShardMergeError(
+                f"merged summary.cost.{field} does not equal the shard sum: "
+                f"recomputed={_describe(merged_cost.get(field))}, "
+                f"shard_sum={total}"
+            )
+
+
+def _check_latency_sums(
+    shards: Sequence[dict],
+    labels: Sequence[str],
+    merged_cost: dict,
+) -> None:
+    """Bound the recomputed latency totals by the shard-reported sum.
+
+    The merged latency stays *recomputed*, never summed -- that is the whole
+    point of the field (see :data:`LATENCY_COST_FIELDS`). This check does not
+    touch the emitted value; it only refuses to merge when the recomputation
+    and the shard sum disagree by more than 2dp rounding can account for.
+
+    Without it the shards' own latency fields are read by nobody: adding
+    10000s to one shard's ``total_judge_latency_sec`` changed no output and
+    the merge succeeded silently.
+
+    Missing / non-numeric handling: a shard that omits a latency field is a
+    hard failure, matching how :func:`_check_cost_sums` already treats a
+    missing integer counter. The grade schema constrains ``summary.cost`` only
+    as ``{"type": "object"}``, so per-shard ``validate_grade_payload`` does not
+    require these fields; "absent" is therefore indistinguishable from
+    "deleted", and skipping the field would restore exactly the hole this
+    function closes.
+    """
+    tolerance = LATENCY_TOLERANCE_SEC_PER_SHARD * len(shards)
+    for field in LATENCY_COST_FIELDS:
+        values: list[float] = []
+        for shard, label in zip(shards, labels):
+            value = _get_path(shard, ("summary", "cost", field))
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ShardMergeError(
+                    f"{label} summary.cost.{field} must be a number, "
+                    f"got {_describe(value)}"
+                )
+            values.append(float(value))
+        # fsum is exactly rounded, so the verdict cannot depend on the order
+        # the shards happened to be listed in.
+        shard_sum = math.fsum(values)
+        recomputed = merged_cost.get(field, _MISSING)
+        if isinstance(recomputed, bool) or not isinstance(
+            recomputed, (int, float)
+        ):
+            raise ShardMergeError(
+                f"merged summary.cost.{field} is not a number: "
+                f"{_describe(recomputed)}"
+            )
+        difference = abs(float(recomputed) - shard_sum)
+        if difference > tolerance:
+            raise ShardMergeError(
+                f"merged summary.cost.{field} differs from the shard sum by "
+                "more than 2dp rounding can explain: "
+                f"recomputed={recomputed!r}, shard_sum={shard_sum:.6f}, "
+                f"difference={difference:.6f}, tolerance={tolerance:.6f} "
+                f"({LATENCY_TOLERANCE_SEC_PER_SHARD} x {len(shards)} shard(s))"
+                ". At least one shard's reported latency was edited after it "
+                "was written."
+            )
+
+
+# --------------------------------------------------------------------------
+# canonical corpus order
+# --------------------------------------------------------------------------
+
+
+def _stride_sizes(total: int, shard_count: int) -> list[int]:
+    """Return the task count each stride shard index must hold.
+
+    Mirrors the adopted shard design ``tasks[shard_index::shard_count]``.
+    """
+    return [len(range(index, total, shard_count)) for index in range(shard_count)]
+
+
+def _stride_layout_candidates(
+    shard_task_ids: Sequence[Sequence[str]],
+    total: int,
+) -> Iterable[tuple[int, ...]]:
+    """Yield candidate assignments of input position -> stride shard index.
+
+    Only assignments consistent with the stride size profile are produced,
+    which keeps a 9-way 220-task merge at 4! * 5! = 2880 candidates instead
+    of 9! = 362880.
+    """
+    shard_count = len(shard_task_ids)
+    required = _stride_sizes(total, shard_count)
+    actual = [len(ids) for ids in shard_task_ids]
+    if sorted(actual) != sorted(required):
+        return
+
+    indices_by_size: dict[int, list[int]] = {}
+    for shard_index, size in enumerate(required):
+        indices_by_size.setdefault(size, []).append(shard_index)
+    inputs_by_size: dict[int, list[int]] = {}
+    for input_index, size in enumerate(actual):
+        inputs_by_size.setdefault(size, []).append(input_index)
+
+    sizes = sorted(indices_by_size)
+    total_candidates = 1
+    for size in sizes:
+        group = len(indices_by_size[size])
+        for factor in range(2, group + 1):
+            total_candidates *= factor
+    if total_candidates > MAX_CANDIDATE_LAYOUTS:
+        raise ShardMergeError(
+            "canonical corpus order cannot be reconstructed: "
+            f"{total_candidates} candidate stride layouts exceeds the "
+            f"{MAX_CANDIDATE_LAYOUTS} cap. Pass --expected-task-ids with "
+            "the canonical ordered task id list."
+        )
+
+    per_size_permutations = [
+        list(itertools.permutations(inputs_by_size[size])) for size in sizes
+    ]
+    for combination in itertools.product(*per_size_permutations):
+        assignment = [-1] * shard_count
+        for size, ordered_inputs in zip(sizes, combination):
+            for shard_index, input_index in zip(
+                indices_by_size[size], ordered_inputs
+            ):
+                assignment[shard_index] = input_index
+        yield tuple(assignment)
+
+
+def _order_from_stride_assignment(
+    shard_task_ids: Sequence[Sequence[str]],
+    assignment: Sequence[int],
+    total: int,
+) -> list[str]:
+    shard_count = len(assignment)
+    order: list[str | None] = [None] * total
+    for shard_index, input_index in enumerate(assignment):
+        ids = shard_task_ids[input_index]
+        for offset, task_id in enumerate(ids):
+            position = shard_index + offset * shard_count
+            if position >= total:
+                return []
+            order[position] = task_id
+    if any(value is None for value in order):
+        return []
+    return [value for value in order if value is not None]
+
+
+def _load_expected_task_ids(source: Any, label: str) -> list[str]:
+    """Accept the several shapes that carry a canonical ordered id list."""
+    candidate: Any = source
+    if isinstance(source, dict):
+        for key in ("task_ids", "expected_ordered_task_ids"):
+            if isinstance(source.get(key), list):
+                candidate = source[key]
+                break
+        else:
+            for key in ("tasks", "results"):
+                rows = source.get(key)
+                if isinstance(rows, list):
+                    candidate = [
+                        row.get("task_id") if isinstance(row, dict) else row
+                        for row in rows
+                    ]
+                    break
+    if not isinstance(candidate, list) or not candidate:
+        raise ShardMergeError(
+            f"{label} does not contain a non-empty ordered task id list"
+        )
+    if any(not isinstance(value, str) or not value.strip() for value in candidate):
+        raise ShardMergeError(f"{label} contains a non-string task id")
+    return [str(value) for value in candidate]
+
+
+def _resolve_canonical_order(
+    shard_task_ids: Sequence[Sequence[str]],
+    *,
+    expected_count: int,
+    expected_hash: str,
+    union: set[str],
+    explicit: Sequence[str] | None,
+) -> list[str]:
+    """Return the canonical ordered corpus task id list.
+
+    The order is never guessed: whichever source supplies it, the result is
+    verified against ``expected_ordered_task_ids_sha256`` before use, so a
+    wrong reconstruction fails loudly instead of silently emitting a payload
+    whose ``tasks`` order contradicts its own declared identity.
+    """
+    if explicit is not None:
+        order = list(explicit)
+        if len(order) != expected_count:
+            raise ShardMergeError(
+                "explicit expected task ids count does not match shard "
+                f"expected_task_count: got {len(order)}, "
+                f"expected {expected_count}"
+            )
+        if len(set(order)) != len(order):
+            raise ShardMergeError(
+                "explicit expected task ids contain duplicates"
+            )
+        if set(order) != union:
+            missing = sorted(union - set(order))
+            unexpected = sorted(set(order) - union)
+            raise ShardMergeError(
+                "explicit expected task ids do not match the merged task "
+                f"set: missing_from_explicit={missing[:5]}, "
+                f"absent_from_shards={unexpected[:5]}"
+            )
+        actual_hash = _ordered_task_ids_sha256(order)
+        if actual_hash != expected_hash:
+            raise ShardMergeError(
+                "explicit expected task ids do not hash to the shard "
+                f"declared expected_ordered_task_ids_sha256: "
+                f"explicit={actual_hash}, shards={expected_hash}"
+            )
+        return order
+
+    for assignment in _stride_layout_candidates(shard_task_ids, expected_count):
+        order = _order_from_stride_assignment(
+            shard_task_ids, assignment, expected_count
+        )
+        if not order:
+            continue
+        if _ordered_task_ids_sha256(order) == expected_hash:
+            return order
+
+    raise ShardMergeError(
+        "canonical corpus order could not be reconstructed from the shard "
+        "layout (no stride assignment reproduces "
+        f"expected_ordered_task_ids_sha256={expected_hash}). Pass "
+        "--expected-task-ids with the canonical ordered task id list."
+    )
+
+
+# --------------------------------------------------------------------------
+# merge
+# --------------------------------------------------------------------------
+
+
+def merge_shard_payloads(
+    shards: Sequence[dict],
+    *,
+    source_labels: Sequence[str] | None = None,
+    source_digests: Sequence[str] | None = None,
+    expected_task_ids: Sequence[str] | None = None,
+    strict_routes: bool = False,
+    warn: Callable[[str], None] | None = None,
+) -> dict:
+    """Merge N partial shard payloads into one final grade payload.
+
+    This is a pure function: no network, no filesystem writes, no clock
+    reads. ``graded_at`` is the maximum of the shard timestamps (the moment
+    the last shard finished), never ``now()``.
+
+    Raises:
+        ShardMergeError: on any invariant violation, task-set defect, or
+            output schema failure. The message always names the field or
+            shard at fault.
+    """
+    emit_warning = warn if warn is not None else (
+        lambda message: print(f"WARNING: {message}", file=sys.stderr)
+    )
+
+    if not shards:
+        raise ShardMergeError("no shard payloads supplied")
+    labels = (
+        list(source_labels)
+        if source_labels is not None
+        else [f"shard[{index}]" for index in range(len(shards))]
+    )
+    if len(labels) != len(shards):
+        raise ShardMergeError("shard label count does not match shard count")
+    for shard, label in zip(shards, labels):
+        if not isinstance(shard, dict):
+            raise ShardMergeError(f"{label} top-level JSON must be an object")
+
+    digests = (
+        list(source_digests)
+        if source_digests is not None
+        else [_payload_digest(shard) for shard in shards]
+    )
+    if len(digests) != len(shards):
+        raise ShardMergeError("shard digest count does not match shard count")
+
+    # --- section C invariants -------------------------------------------
+    _check_schema_version(shards, labels)
+    _check_partial_status(shards, labels)
+    _check_identity_fields(
+        shards, labels, CONTRACT_IDENTITY_FIELDS, contract=True
+    )
+    _check_route_identity(
+        shards, labels, strict=strict_routes, warn=emit_warning
+    )
+    _check_identity_fields(
+        shards, labels, ADOPTED_IDENTITY_FIELDS, contract=False
+    )
+
+    reference = shards[0]
+    schema = _read_grade_schema()
+    for shard, label in zip(shards, labels):
+        try:
+            validate_grade_payload(shard, schema)
+        # Broad on purpose: the validator's exception type is not part of its
+        # contract, and every failure mode means the same thing here. Re-raised
+        # with the shard label so the message names the file at fault.
+        except Exception as exc:
+            raise ShardMergeError(
+                f"{label} is not a valid grade payload: {exc}"
+            ) from exc
+
+    expected_count = reference.get("expected_task_count")
+    if type(expected_count) is not int or expected_count < 1:
+        raise ShardMergeError(
+            f"shard expected_task_count is invalid: {_describe(expected_count)}"
+        )
+    expected_hash = reference.get("expected_ordered_task_ids_sha256")
+    if not isinstance(expected_hash, str) or not _is_sha256(expected_hash):
+        raise ShardMergeError(
+            "shard expected_ordered_task_ids_sha256 is invalid: "
+            f"{_describe(expected_hash)}"
+        )
+
+    # --- task set: disjoint, complete ------------------------------------
+    shard_task_ids = [
+        _shard_task_ids(shard, label) for shard, label in zip(shards, labels)
+    ]
+    owner: dict[str, str] = {}
+    collisions: dict[str, list[str]] = {}
+    for ids, label in zip(shard_task_ids, labels):
+        for task_id in ids:
+            if task_id in owner:
+                collisions.setdefault(task_id, [owner[task_id]]).append(label)
+            else:
+                owner[task_id] = label
+    if collisions:
+        detail = ", ".join(
+            f"{task_id} in {sorted(set(where))}"
+            for task_id, where in sorted(collisions.items())[:5]
+        )
+        raise ShardMergeError(
+            f"shards are not disjoint: {len(collisions)} duplicated task_id(s); "
+            f"{detail}"
+        )
+
+    union = set(owner)
+    if len(union) != expected_count:
+        missing = expected_count - len(union)
+        raise ShardMergeError(
+            "merged task set is incomplete: union has "
+            f"{len(union)} task(s) but expected_task_count is "
+            f"{expected_count} ({missing} missing). Refusing to promote an "
+            "incomplete merge to run_status='final'."
+        )
+
+    canonical_order = _resolve_canonical_order(
+        shard_task_ids,
+        expected_count=expected_count,
+        expected_hash=expected_hash,
+        union=union,
+        explicit=expected_task_ids,
+    )
+    position = {task_id: index for index, task_id in enumerate(canonical_order)}
+
+    # --- deterministic shard ordering (shard 0 holds canonical task 0) ---
+    shard_order = sorted(
+        range(len(shards)), key=lambda index: position[shard_task_ids[index][0]]
+    )
+
+    # --- tasks: canonical reorder-concatenate ----------------------------
+    merged_tasks: list[dict] = []
+    for shard in shards:
+        merged_tasks.extend(shard["tasks"])
+    merged_tasks.sort(key=lambda task: position[task["task_id"]])
+    if [task["task_id"] for task in merged_tasks] != canonical_order:
+        raise ShardMergeError(
+            "merged task order does not match the canonical corpus order"
+        )
+
+    # --- azure route provenance ------------------------------------------
+    merged_routes: list[dict] = []
+    seen_fingerprints: set[str] = set()
+    for index in shard_order:
+        for route in shards[index]["azure_ai_routes"]:
+            fingerprint = route.get("runtime_fingerprint")
+            if fingerprint in seen_fingerprints:
+                continue
+            seen_fingerprints.add(fingerprint)
+            merged_routes.append(dict(route))
+    primary_fingerprint = shards[shard_order[0]]["azure_ai_runtime_fingerprint"]
+    if merged_routes[0].get("runtime_fingerprint") != primary_fingerprint:
+        raise ShardMergeError(
+            "merged primary grader route does not match shard 0's "
+            f"azure_ai_runtime_fingerprint: routes[0]="
+            f"{_describe(merged_routes[0].get('runtime_fingerprint'))}, "
+            f"shard0={primary_fingerprint!r}"
+        )
+
+    # --- summary: recompute, never re-derive rounding --------------------
+    unpriced_models = _get_path(
+        reference, ("summary", "cost", "unpriced_models")
+    )
+    if not isinstance(unpriced_models, list) or not unpriced_models:
+        raise ShardMergeError(
+            "shard summary.cost.unpriced_models is missing or empty: "
+            f"{_describe(unpriced_models)}"
+        )
+    summary = _compute_summary(merged_tasks, unpriced_models=unpriced_models)
+    _check_cost_sums(shards, labels, summary["cost"])
+    _check_latency_sums(shards, labels, summary["cost"])
+
+    shard_usage_complete = True
+    for shard, label in zip(shards, labels):
+        value = _get_path(shard, ("summary", "cost", "usage_complete"))
+        if type(value) is not bool:
+            raise ShardMergeError(
+                f"{label} summary.cost.usage_complete must be a boolean, "
+                f"got {_describe(value)}"
+            )
+        shard_usage_complete = shard_usage_complete and value
+    merged_usage_complete = (
+        bool(summary["cost"]["usage_complete"]) and shard_usage_complete
+    )
+    if not merged_usage_complete:
+        emit_warning(
+            "merged summary.cost.usage_complete is false; at least one shard "
+            "reported incomplete aggregate usage."
+        )
+    summary["cost"]["usage_complete"] = merged_usage_complete
+
+    # Defensive: judge_error_rate must be canonical_rate half-up at 4dp.
+    # validate_grade_payload recomputes exactly this and rejects drift, so a
+    # mismatch here means _compute_summary and the validator disagree.
+    judge_items = 0
+    judge_errors = 0
+    for task in merged_tasks:
+        for item in task.get("items", []) or []:
+            if isinstance(item, dict) and item.get("decided_by") == "judge":
+                judge_items += 1
+                if item.get("verdict") == "judge_error":
+                    judge_errors += 1
+    expected_error_rate = canonical_rate(judge_errors, judge_items)
+    if summary["wow"]["judge_error_rate"] != expected_error_rate:
+        raise ShardMergeError(
+            "merged summary.wow.judge_error_rate does not match "
+            f"canonical_rate({judge_errors}, {judge_items}): "
+            f"computed={summary['wow']['judge_error_rate']}, "
+            f"canonical={expected_error_rate}"
+        )
+
+    # --- graded_at: completion moment of the last shard ------------------
+    graded_at_pairs = [
+        (_parse_graded_at(shard.get("graded_at"), label), str(shard["graded_at"]))
+        for shard, label in zip(shards, labels)
+    ]
+    merged_graded_at = max(graded_at_pairs)[1]
+
+    # --- assemble ---------------------------------------------------------
+    merged: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "run_status": "final",
+    }
+    for field_name, path in ADOPTED_IDENTITY_FIELDS:
+        if len(path) != 1:
+            continue
+        value = _get_path(reference, path)
+        if value is not _MISSING:
+            merged[path[0]] = value
+    for field_name, path in CONTRACT_IDENTITY_FIELDS:
+        if len(path) != 1 or path[0] in merged:
+            continue
+        value = _get_path(reference, path)
+        if value is not _MISSING:
+            merged[path[0]] = value
+    for field_name in NON_IDENTITY_ADOPTED_FIELDS:
+        if field_name in reference:
+            merged[field_name] = reference[field_name]
+
+    merged["azure_ai_routes"] = merged_routes
+    merged["azure_ai_runtime_fingerprint"] = primary_fingerprint
+    merged["graded_at"] = merged_graded_at
+    merged["tasks"] = merged_tasks
+    merged["summary"] = summary
+    merged["shard_provenance"] = [
+        {
+            "index": rank,
+            "count": len(shards),
+            "config_hash": _get_path(
+                shards[input_index], ("judge", "config_hash")
+            ),
+            "grade_file_sha256": digests[input_index],
+            "graded_at": shards[input_index].get("graded_at"),
+            # The merged payload can carry only ONE scalar
+            # azure_ai_runtime_fingerprint, because core.grade_payload
+            # structurally requires it to equal azure_ai_routes[0]
+            # .runtime_fingerprint. In the default mode shard 0's value wins
+            # and the others survive only as extra entries in
+            # azure_ai_routes, with the drift itself announced once on
+            # stderr and then gone. Recording each shard's own fingerprint
+            # here makes route drift auditable from the merged artifact
+            # alone -- who drifted, not merely that something did.
+            # _check_route_identity has already proved this value equals
+            # this shard's own azure_ai_routes[0].runtime_fingerprint, so it
+            # is a faithful record of what the shard carried.
+            "azure_ai_runtime_fingerprint": shards[input_index][
+                "azure_ai_runtime_fingerprint"
+            ],
+        }
+        for rank, input_index in enumerate(shard_order)
+    ]
+
+    # Preserve field ordering close to step8's payload for readable diffs.
+    merged = _ordered_payload(merged, reference)
+
+    if len(merged["tasks"]) != merged.get("expected_task_count"):
+        raise ShardMergeError(
+            "merged task count does not match expected_task_count; refusing "
+            "to emit a final payload"
+        )
+    try:
+        validate_grade_payload(merged, schema)
+    # Broad on purpose, as above: re-raised as a merge failure so a schema
+    # regression surfaces as "this merge is unpublishable", not a stack trace.
+    except Exception as exc:
+        raise ShardMergeError(
+            f"merged payload failed grade schema validation: {exc}"
+        ) from exc
+    return merged
+
+
+def _ordered_payload(merged: dict, reference: dict) -> dict:
+    """Return ``merged`` with keys ordered like the shard payloads."""
+    ordered: dict[str, Any] = {}
+    for key in reference:
+        if key in merged:
+            ordered[key] = merged[key]
+    for key in merged:
+        if key not in ordered:
+            ordered[key] = merged[key]
+    return ordered
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def load_shard_file(path: Path) -> tuple[dict, str]:
+    """Return ``(payload, sha256_of_file_bytes)`` for one shard file."""
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise ShardMergeError(f"could not read shard {path}: {exc}") from exc
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ShardMergeError(f"could not parse shard {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ShardMergeError(f"shard {path} top-level JSON must be an object")
+    return payload, hashlib.sha256(raw).hexdigest()
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Merge N partial shard grade payloads into one final grade "
+            "payload. Fully offline and deterministic."
+        )
+    )
+    parser.add_argument(
+        "shards",
+        nargs="+",
+        help="Partial grade JSON paths (command-line order does not matter)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Destination path for the merged final grade JSON",
+    )
+    parser.add_argument(
+        "--expected-task-ids",
+        default=None,
+        help=(
+            "Optional JSON file carrying the canonical ordered task id list "
+            "(a bare array, or an object with task_ids / tasks / results). "
+            "Required when the shard layout is not a stride split."
+        ),
+    )
+    parser.add_argument(
+        "--strict-routes",
+        action="store_true",
+        help=(
+            "Require azure_ai_routes and azure_ai_runtime_fingerprint to be "
+            "identical across all shards (the literal sequential-resume "
+            "invariant) instead of unioning routes."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite --output if it already exists",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    out_path = Path(args.output)
+    if out_path.exists() and not args.force:
+        print(
+            f"ERROR: output already exists: {out_path}. Use --force to "
+            "overwrite.",
+            file=sys.stderr,
+        )
+        return 1
+
+    shard_paths = [Path(value) for value in args.shards]
+    duplicate_paths = sorted(
+        {
+            str(path)
+            for path in shard_paths
+            if shard_paths.count(path) > 1
+        }
+    )
+    if duplicate_paths:
+        print(
+            f"ERROR: shard paths repeated on the command line: {duplicate_paths}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        loaded = [load_shard_file(path) for path in shard_paths]
+        explicit_ids: list[str] | None = None
+        if args.expected_task_ids:
+            source_path = Path(args.expected_task_ids)
+            try:
+                source = json.loads(source_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+                raise ShardMergeError(
+                    f"could not read --expected-task-ids {source_path}: {exc}"
+                ) from exc
+            explicit_ids = _load_expected_task_ids(source, str(source_path))
+
+        merged = merge_shard_payloads(
+            [payload for payload, _ in loaded],
+            source_labels=[str(path) for path in shard_paths],
+            source_digests=[digest for _, digest in loaded],
+            expected_task_ids=explicit_ids,
+            strict_routes=args.strict_routes,
+        )
+    except ShardMergeError as exc:
+        print(f"ERROR: shard merge failed: {exc}", file=sys.stderr)
+        return 1
+
+    _save_json(out_path, merged)
+    avg = merged["summary"]["openai_compat"]["avg_score_pct"]
+    avg_text = "unscored" if avg is None else f"{avg:.2f}"
+    print(
+        f"Merged {len(loaded)} shard(s): tasks={len(merged['tasks'])}, "
+        f"avg_pct={avg_text}, out={out_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/batch-runner/tests/test_shard_merge_roundtrip.py
+++ b/batch-runner/tests/test_shard_merge_roundtrip.py
@@ -1,0 +1,207 @@
+"""End-to-end proof that sharded grading reassembles into a serial-identical run.
+
+``tests/test_step8_grade.py`` pins step8's slicing and ``tests/test_step9_merge_shards.py``
+pins step9's merge algebra, but each does so against payloads the other never
+produced. This module closes that gap: it drives real ``step8_grade.main()``
+invocations with ``--shard-count``, feeds the resulting partials to real
+``step9_merge_shards.main()``, and diffs the merged payload against a serial run
+of the same corpus. Sharding is only worth doing if that diff is empty, because
+the whole premise is that splitting the 220-task corpus across N relays changes
+wall-clock only -- never a score, an aggregate, or an identity field.
+
+Layout note: each run gets its own ``<parent>/batch-runner`` directory rather
+than ``<parent>/shard0``. ``compute_grader_source_hash`` folds the
+*repository-relative* config path into the digest, so a run rooted at
+``.../shard0`` hashes ``shard0/grading_configs/default.yaml`` while one rooted at
+``.../shard1`` hashes ``shard1/...`` -- different hashes for identical bytes, and
+step9 rightly rejects the merge. Real shards all check out to the same
+``$GITHUB_WORKSPACE/batch-runner``, so the harness has to mirror that or it tests
+a layout that never ships.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import step8_grade as s8
+import step9_merge_shards as s9
+from core.grade_payload import validate_grade_payload
+from tests.test_step8_grade import (  # noqa: F401 -- _typed_azure_ai_route is an autouse fixture
+    _FakeGrader,
+    _FakeLoader,
+    _setup_workspace,
+    _typed_azure_ai_route,
+)
+
+# Absolute, because every test here chdirs into a throwaway workspace that has
+# no schemas/ of its own.
+_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schemas" / "grade.schema.json"
+
+_CORPUS = ["task-001", "task-002", "task-003"]
+_CANONICAL_STEM = "exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1"
+_CANONICAL_GRADE = f"data/grades/{_CANONICAL_STEM}.json"
+
+
+def _grade_path(root: Path, index: int, count: int) -> Path:
+    """Where step8 leaves its payload, serial or sharded.
+
+    Shards fork below the canonical name (``_shards/<stem>/shard-i-of-n.json``)
+    so that N concurrent jobs never contend for one file and so the dashboard's
+    non-recursive ``data/grades/*.json`` glob cannot mistake an unfinished slice
+    for a graded run.
+    """
+    if count <= 1:
+        return root / _CANONICAL_GRADE
+    return (
+        root
+        / "data"
+        / "grades"
+        / "_shards"
+        / _CANONICAL_STEM
+        / f"shard-{index:03d}-of-{count:03d}.json"
+    )
+
+# Fields a merged payload is *expected* to differ on. Everything else must match
+# a serial run exactly.
+#   shard_provenance -- merge-only provenance block (step9 docstring, section D)
+#   grading_wall_time_ms -- per-task elapsed measurement; N concurrent shards
+#     each keep their own timeline, so this is the one number sharding really
+#     does change. Sub-ms jitter makes it differ even under a fake grader.
+#   graded_at -- second-resolution wall clock. Shards finish at different
+#     moments by construction, and even this harness drifts by a second when a
+#     run straddles a second boundary. Its merge rule is asserted directly in
+#     test_merge_takes_the_last_shard_completion_time rather than diffed here.
+_EXPECTED_DIVERGENCE = {"shard_provenance", "grading_wall_time_ms", "graded_at"}
+
+
+def _run_grade(
+    monkeypatch, root: Path, index: int = 0, count: int = 1
+) -> tuple[dict, Path]:
+    """Run step8 to completion in a fresh workspace; return (payload, path)."""
+    root.mkdir(parents=True)
+    _setup_workspace(root)
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    shard_flags = (
+        []
+        if count <= 1
+        else ["--shard-index", str(index), "--shard-count", str(count)]
+    )
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py", "exp998_smoke_baseline_sample",
+        "--config", "grading_configs/default.yaml", "--force", *shard_flags,
+    ])
+    assert s8.main() == 0
+    path = _grade_path(root, index, count)
+    return json.loads(path.read_text(encoding="utf-8")), path
+
+
+def _strip(value):
+    """Drop the fields sharding is allowed to change, recursively."""
+    if isinstance(value, dict):
+        return {
+            key: _strip(item)
+            for key, item in value.items()
+            if key not in _EXPECTED_DIVERGENCE
+        }
+    if isinstance(value, list):
+        return [_strip(item) for item in value]
+    return value
+
+
+@pytest.mark.parametrize("shard_count", [2, 3])
+def test_sharded_run_merges_into_a_serial_identical_payload(
+    monkeypatch, tmp_path, shard_count
+):
+    shard_files = []
+    for index in range(shard_count):
+        root = tmp_path / f"shard{index}" / "batch-runner"
+        payload, path = _run_grade(monkeypatch, root, index, shard_count)
+        assert payload["run_status"] == "partial"
+        assert payload["expected_task_count"] == len(_CORPUS)
+        # A shard must never land on the canonical name; that file is reserved
+        # for the merged final and is what the dashboard aggregates.
+        assert not (root / _CANONICAL_GRADE).exists()
+        shard_files.append(str(path))
+
+    serial, _ = _run_grade(monkeypatch, tmp_path / "serial" / "batch-runner")
+    assert serial["run_status"] == "final"
+
+    merged_path = tmp_path / "merged.json"
+    assert s9.main([*shard_files, "--output", str(merged_path)]) == 0
+    merged = json.loads(merged_path.read_text(encoding="utf-8"))
+
+    assert merged["run_status"] == "final"
+    assert [task["task_id"] for task in merged["tasks"]] == _CORPUS
+    assert _strip(merged) == _strip(serial)
+
+    # The exact gate the workflow's merge step applies before it will publish a
+    # merged file to data/grades/. Pinning it here means a drift in either step8
+    # or step9 fails a test instead of a paid 220-task run's final commit.
+    validate_grade_payload(
+        merged, json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    )
+    assert len(merged["tasks"]) == merged["expected_task_count"]
+
+
+def test_merge_records_every_shard_in_provenance(monkeypatch, tmp_path):
+    """The merged artifact must be self-describing: which shards produced it,
+    and whether they agreed on config. Otherwise drift is only visible in CI
+    logs that expire."""
+    shard_files = []
+    for index in range(3):
+        root = tmp_path / f"shard{index}" / "batch-runner"
+        _, path = _run_grade(monkeypatch, root, index, 3)
+        shard_files.append(str(path))
+
+    merged_path = tmp_path / "merged.json"
+    assert s9.main([*shard_files, "--output", str(merged_path)]) == 0
+    provenance = json.loads(merged_path.read_text(encoding="utf-8"))["shard_provenance"]
+
+    assert [entry["index"] for entry in provenance] == [0, 1, 2]
+    assert {entry["count"] for entry in provenance} == {3}
+    assert len({entry["config_hash"] for entry in provenance}) == 1
+    assert len({entry["grade_file_sha256"] for entry in provenance}) == 3
+
+
+def test_merge_refuses_an_incomplete_shard_set(monkeypatch, tmp_path):
+    """Dropping a shard must fail loudly. A 220-task run that silently
+    publishes 195 graded tasks as 'final' is the worst outcome this whole
+    design has to prevent."""
+    shard_files = []
+    for index in range(3):
+        root = tmp_path / f"shard{index}" / "batch-runner"
+        _, path = _run_grade(monkeypatch, root, index, 3)
+        shard_files.append(str(path))
+
+    merged_path = tmp_path / "merged.json"
+    assert s9.main([*shard_files[:2], "--output", str(merged_path)]) != 0
+    assert not merged_path.exists()
+
+
+def test_merge_takes_the_last_shard_completion_time(monkeypatch, tmp_path):
+    """`graded_at` on the merged payload is the moment the run actually
+    finished -- i.e. the slowest shard -- not whichever file was listed first.
+    Per-task timestamps stay exactly as the grading shard recorded them."""
+    shard_files = []
+    per_task_graded_at = {}
+    for index in range(3):
+        root = tmp_path / f"shard{index}" / "batch-runner"
+        payload, path = _run_grade(monkeypatch, root, index, 3)
+        for task in payload["tasks"]:
+            per_task_graded_at[task["task_id"]] = task["graded_at"]
+        shard_files.append((payload["graded_at"], str(path)))
+
+    merged_path = tmp_path / "merged.json"
+    # Reversed on purpose: command-line order must not influence the result.
+    assert s9.main(
+        [path for _, path in reversed(shard_files)] + ["--output", str(merged_path)]
+    ) == 0
+    merged = json.loads(merged_path.read_text(encoding="utf-8"))
+
+    assert merged["graded_at"] == max(stamp for stamp, _ in shard_files)
+    assert {
+        task["task_id"]: task["graded_at"] for task in merged["tasks"]
+    } == per_task_graded_at

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -1427,9 +1427,17 @@ def _seed_partial_grade(
     task_ids: list[str],
     renderer_fingerprint: dict[str, str] | None = None,
     run_status: str = "partial",
+    out: Path | None = None,
 ) -> Path:
-    """Drop a valid partial grade JSON at the templated output path."""
-    out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
+    """Drop a valid partial grade JSON at the templated output path.
+
+    `out` overrides the destination for shard tests, whose payload lands under
+    `data/grades/_shards/<stem>/` rather than on the canonical name.
+    """
+    out = out or (
+        tmp_path
+        / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
+    )
     out.parent.mkdir(parents=True, exist_ok=True)
     task_rows = [
         {
@@ -2905,6 +2913,8 @@ def _run_grade_workflow_input_preflight(**overrides):
         "GRADE_PAID_APPROVAL": "false",
         "GRADE_RESUME": "false",
         "GRADE_RESUME_CHUNK": "0",
+        "GRADE_SHARD_COUNT": "1",
+        "GRADE_SHARD_INDEX": "0",
         **overrides,
     }
     return subprocess.run(
@@ -2926,6 +2936,17 @@ def _run_grade_workflow_input_preflight(**overrides):
             "GRADE_PAID_APPROVAL": "true",
             "GRADE_RESUME": "true",
             "GRADE_RESUME_CHUNK": "1",
+        },
+        # A shard at the top of the allowed range, mid-relay: the two features
+        # have to compose, because an 11-way split still needs rc=7 chunking.
+        {
+            "GRADE_INFERENCE_REVISION": "b" * 40,
+            "GRADE_DRY_RUN": "false",
+            "GRADE_PAID_APPROVAL": "true",
+            "GRADE_RESUME": "true",
+            "GRADE_RESUME_CHUNK": "1",
+            "GRADE_SHARD_COUNT": "11",
+            "GRADE_SHARD_INDEX": "10",
         },
     ],
 )
@@ -2961,6 +2982,21 @@ def test_grade_workflow_input_preflight_accepts_valid_dispatch(overrides):
         ),
         ({"GRADE_RESUME": "true"}, "resume requires"),
         ({"GRADE_RESUME_CHUNK": "1"}, "resume_chunk must be 0"),
+        ({"GRADE_SHARD_COUNT": "0"}, "shard_count"),
+        ({"GRADE_SHARD_COUNT": "12"}, "shard_count"),
+        ({"GRADE_SHARD_COUNT": "01"}, "shard_count"),
+        ({"GRADE_SHARD_INDEX": "11"}, "shard_index"),
+        ({"GRADE_SHARD_INDEX": "-1"}, "shard_index"),
+        # An index at or past the count would grade a slice nothing else covers,
+        # or none at all -- either way the merged set is silently incomplete.
+        ({"GRADE_SHARD_COUNT": "3", "GRADE_SHARD_INDEX": "3"}, "must be less than"),
+        ({"GRADE_SHARD_INDEX": "1"}, "must be less than"),
+        # Sharding splits the corpus; --limit narrows it into a _diagnostic/
+        # subtree nothing merges. Combining them loses tasks with no error.
+        (
+            {"GRADE_SHARD_COUNT": "2", "GRADE_TASKS_LIMIT": "5"},
+            "cannot be combined with tasks_limit",
+        ),
     ],
 )
 def test_grade_workflow_input_preflight_rejects_invalid_dispatch(overrides, error):
@@ -3007,3 +3043,582 @@ def test_time_budget_zero_disables_guard(monkeypatch, tmp_path):
     ])
     rc = s8.main()
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Sharded grading (--shard-count / --shard-index)
+#
+# The 220-task corpus projects to ~71.6h of serial judge latency against a 44h
+# relay envelope. Sharding splits the *workload* across N workers while every
+# shard keeps declaring the *full* corpus identity, so step9_merge_shards.py
+# can fold the partials back into one final payload. The tests below pin the
+# two halves of that contract: identity must never shrink to the slice, and
+# the slice must never leak into the diagnostic-isolation decision.
+# ---------------------------------------------------------------------------
+
+_CORPUS = ["task-001", "task-002", "task-003"]
+_CANONICAL_STEM = "exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1"
+_CANONICAL_GRADE = f"data/grades/{_CANONICAL_STEM}.json"
+
+
+def _shard_grade_path(root: Path, index: int, count: int) -> Path:
+    """Where a shard's partial lands.
+
+    Shards share every identity input, so they would all resolve to the same
+    canonical filename. The path -- and only the path -- forks below it, so that
+    N concurrent jobs can each commit their own file and so the dashboard's
+    non-recursive `data/grades/*.json` glob never sees an unfinished slice.
+    """
+    return (
+        root
+        / "data"
+        / "grades"
+        / "_shards"
+        / _CANONICAL_STEM
+        / f"shard-{index:03d}-of-{count:03d}.json"
+    )
+
+
+def _shard_argv(index: int, count: int, *extra: str) -> list[str]:
+    return [
+        "step8_grade.py", "exp998_smoke_baseline_sample",
+        "--config", "grading_configs/default.yaml",
+        "--shard-index", str(index),
+        "--shard-count", str(count),
+        *extra,
+    ]
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        [],                                  # nothing graded yet
+        ["task-001"],                        # prefix (serial resume)
+        ["task-001", "task-002"],            # longer prefix
+        ["task-001", "task-002", "task-003"],  # complete
+        ["task-001", "task-003"],            # stride slice, shard 0 of 2
+        ["task-002"],                        # stride slice, shard 1 of 2
+        ["task-003"],                        # suffix
+    ],
+)
+def test_is_ordered_subsequence_accepts_prefixes_and_stride_slices(candidate):
+    """Serial resume produces a prefix; a shard produces a stride slice. Both
+    are ordered subsequences, and widening prefix->subsequence must not
+    regress any prefix that already validated."""
+    assert s8._is_ordered_subsequence(candidate, _CORPUS) is True
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        ["task-002", "task-001"],            # reordered
+        ["task-003", "task-001"],            # reversed stride
+        ["task-001", "task-004"],            # foreign id
+        ["task-001", "task-001"],            # repeat beyond one occurrence
+        ["task-001", "task-002", "task-003", "task-001"],  # wraparound
+    ],
+)
+def test_is_ordered_subsequence_rejects_reordered_or_foreign(candidate):
+    assert s8._is_ordered_subsequence(candidate, _CORPUS) is False
+
+
+def test_shard_slice_partitions_the_corpus_without_loss_or_overlap():
+    """Union of all shards == corpus, shards are disjoint, and each shard
+    preserves canonical relative order (which is what makes each partial an
+    ordered subsequence)."""
+    tasks = [{"task_id": f"task-{i:03d}"} for i in range(220)]
+    for count in (1, 2, 3, 7, 9, 11, 220):
+        shards = [
+            s8._shard_slice(tasks, shard_index=i, shard_count=count)
+            for i in range(count)
+        ]
+        seen: list[dict] = []
+        for shard in shards:
+            positions = [tasks.index(task) for task in shard]
+            assert positions == sorted(positions), "shard lost canonical order"
+            seen.extend(shard)
+        ids = [task["task_id"] for task in seen]
+        assert sorted(ids) == sorted(t["task_id"] for t in tasks)
+        assert len(ids) == len(set(ids)), "shards overlap"
+        # Stride keeps sizes within one of each other; contiguous blocks would
+        # not, which is the whole reason stride was chosen.
+        sizes = [len(shard) for shard in shards]
+        assert max(sizes) - min(sizes) <= 1
+
+
+def test_shard_slice_unsharded_returns_a_copy_not_the_original():
+    tasks = [{"task_id": "task-001"}]
+    result = s8._shard_slice(tasks, shard_index=0, shard_count=1)
+    assert result == tasks
+    assert result is not tasks
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--shard-count", "0"],
+        ["--shard-count", "-1"],
+        ["--shard-index", "-1"],
+        ["--shard-index", "2", "--shard-count", "2"],
+        ["--shard-index", "9", "--shard-count", "9"],
+    ],
+)
+def test_parse_args_rejects_out_of_range_shard_flags(monkeypatch, flags):
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py", "exp998_smoke_baseline_sample",
+        "--config", "grading_configs/default.yaml", *flags,
+    ])
+    with pytest.raises(SystemExit) as excinfo:
+        s8.parse_args()
+    assert excinfo.value.code == 2
+
+
+def test_parse_args_shard_defaults_are_serial(monkeypatch):
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py", "exp998_smoke_baseline_sample",
+        "--config", "grading_configs/default.yaml",
+    ])
+    args = s8.parse_args()
+    assert args.shard_count == 1
+    assert args.shard_index == 0
+
+
+@pytest.mark.parametrize(
+    "index,expected",
+    [(0, ["task-001", "task-003"]), (1, ["task-002"])],
+)
+def test_shard_grades_only_its_stride_slice(monkeypatch, tmp_path, index, expected):
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    monkeypatch.setattr("sys.argv", _shard_argv(index, 2, "--force"))
+
+    assert s8.main() == 0
+    payload = json.loads(
+        _shard_grade_path(tmp_path, index, 2).read_text(encoding="utf-8")
+    )
+    assert [task["task_id"] for task in payload["tasks"]] == expected
+
+
+def test_shard_payload_declares_full_corpus_identity(monkeypatch, tmp_path):
+    """The identity fields describe the corpus, not the slice -- this is what
+    lets step9 verify it merged every shard, and what keeps all shards on one
+    cache key."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    monkeypatch.setattr("sys.argv", _shard_argv(0, 2, "--force"))
+
+    assert s8.main() == 0
+    payload = json.loads(
+        _shard_grade_path(tmp_path, 0, 2).read_text(encoding="utf-8")
+    )
+    assert payload["run_status"] == "partial"
+    assert payload["expected_task_count"] == len(_CORPUS)
+    assert payload["expected_ordered_task_ids_sha256"] == (
+        s8._ordered_task_ids_sha256(_CORPUS)
+    )
+    assert len(payload["tasks"]) < payload["expected_task_count"]
+
+
+def test_sharding_is_not_a_diagnostic_task_selection(monkeypatch, tmp_path):
+    """--shard-* narrows who grades what, not what is in scope. It must never
+    fork the output into _diagnostic/<scope_sha>/ the way --tasks/--limit do:
+    that directory means "this run graded a narrowed corpus and its scores are
+    not comparable", which is exactly the claim sharding must not make."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    monkeypatch.setattr("sys.argv", _shard_argv(0, 2, "--force"))
+
+    assert s8.main() == 0
+    assert _shard_grade_path(tmp_path, 0, 2).exists()
+    assert not (tmp_path / "data/grades/_diagnostic").exists()
+    assert not _diagnostic_grade_path(tmp_path, ["task-001", "task-003"]).exists()
+    # The canonical name stays free -- it belongs to the merged final, and the
+    # dashboard aggregator globs exactly that level.
+    assert not (tmp_path / _CANONICAL_GRADE).exists()
+
+
+def test_shard_path_forks_below_the_canonical_name(monkeypatch, tmp_path):
+    """The shard filename must stay derivable from the canonical one. step9's
+    output is named by the caller, but a human reading data/grades/_shards/ has
+    to be able to tell which run these partials belong to."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    github_output = tmp_path / "github-output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setattr("sys.argv", _shard_argv(2, 11, "--force"))
+
+    assert s8.main() == 0
+    out = _shard_grade_path(tmp_path, 2, 11)
+    assert out.exists()
+    assert out.parent.name == _CANONICAL_STEM
+    assert out.name == "shard-002-of-011.json"
+    # grade-run.yml commits whatever path this reports, so it has to be the
+    # shard's file and repo-relative.
+    assert (
+        f"grade_file=data/grades/_shards/{_CANONICAL_STEM}/shard-002-of-011.json"
+        in github_output.read_text(encoding="utf-8")
+    )
+
+
+def test_shard_paths_are_unique_per_index():
+    """The collision this fork exists to prevent: N jobs, one file.
+
+    Every shard shares its identity inputs by construction -- that sameness is
+    what step9 verifies before merging -- so `resolve_grade_output_path` is the
+    only place the paths can diverge.
+    """
+    config = {
+        "config_name": "default_gpt5pro",
+        "output": {
+            "directory": "data/grades",
+            "filename_template": "{exp_id}__{judge_slug}__{rubric_short_sha}__{prompt_v}.json",
+        },
+    }
+    identity = dict(
+        experiment_id="exp998_smoke_baseline_sample",
+        judge_slug="gpt-5_4-pro",
+        config_hash="c" * 64,
+        rubric_sha="1" * 40,
+        rubric_short_sha="11e7900",
+        prompt_version="v1",
+        inference_sha="2" * 40,
+        grader_source_hash="3" * 64,
+    )
+
+    paths = [
+        s8.resolve_grade_output_path(
+            config, **identity, shard_index=index, shard_count=11
+        )
+        for index in range(11)
+    ]
+    assert len(set(paths)) == 11
+    assert len({path.parent for path in paths}) == 1
+    serial = s8.resolve_grade_output_path(config, **identity)
+    assert serial not in paths
+    assert paths[0].parent.parent.name == "_shards"
+    # Zero-padded so `ls` sorts them in shard order rather than 0, 1, 10, 2.
+    assert [path.name for path in paths][:3] == [
+        "shard-000-of-011.json",
+        "shard-001-of-011.json",
+        "shard-002-of-011.json",
+    ]
+
+
+@pytest.mark.parametrize(
+    "index,count",
+    [(-1, 2), (2, 2), (5, 2), (0, 0), (0, -1)],
+)
+def test_resolve_grade_output_path_rejects_impossible_shards(index, count):
+    """Defence in depth: parse_args already rejects these, but the path helper
+    is public and a bad pair here would silently overwrite a sibling's file."""
+    config = {
+        "config_name": "default_gpt5pro",
+        "output": {
+            "directory": "data/grades",
+            "filename_template": "{exp_id}__{judge_slug}__{rubric_short_sha}__{prompt_v}.json",
+        },
+    }
+    with pytest.raises(ValueError, match="shard_index must satisfy"):
+        s8.resolve_grade_output_path(
+            config,
+            experiment_id="exp998_smoke_baseline_sample",
+            judge_slug="gpt-5_4-pro",
+            config_hash="c" * 64,
+            rubric_sha="1" * 40,
+            rubric_short_sha="11e7900",
+            prompt_version="v1",
+            inference_sha="2" * 40,
+            grader_source_hash="3" * 64,
+            shard_index=index,
+            shard_count=count,
+        )
+
+
+def test_shard_reports_partial_grade_status_to_github_output(monkeypatch, tmp_path):
+    """grade-run.yml gates the committed artifact on this value; a shard's
+    file is a partial even when the process exits 0."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    github_output = tmp_path / "github-output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    monkeypatch.setattr("sys.argv", _shard_argv(0, 2, "--force"))
+
+    assert s8.main() == 0
+    assert "grade_status=partial" in github_output.read_text(encoding="utf-8")
+
+
+def test_unsharded_run_still_emits_final(monkeypatch, tmp_path):
+    """Regression guard: the shard flags default to serial, and serial must be
+    byte-for-byte the behaviour that existed before sharding."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    github_output = tmp_path / "github-output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py", "exp998_smoke_baseline_sample",
+        "--config", "grading_configs/default.yaml", "--force",
+    ])
+
+    assert s8.main() == 0
+    payload = json.loads((tmp_path / _CANONICAL_GRADE).read_text(encoding="utf-8"))
+    assert payload["run_status"] == "final"
+    assert [task["task_id"] for task in payload["tasks"]] == _CORPUS
+    assert "grade_status=final" in github_output.read_text(encoding="utf-8")
+
+
+def test_shard_dry_run_counts_only_its_slice(monkeypatch, tmp_path, capsys):
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr("sys.argv", _shard_argv(0, 2, "--dry-run"))
+
+    assert s8.main() == 0
+    assert "Dry-run tasks=2" in capsys.readouterr().out
+
+
+def test_shard_cache_hit_skips_when_partial_is_its_own_slice(monkeypatch, tmp_path, capsys):
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    _seed_partial_grade(
+        tmp_path, ["task-001", "task-003"], out=_shard_grade_path(tmp_path, 0, 2)
+    )
+    monkeypatch.setattr("sys.argv", _shard_argv(0, 2))
+
+    assert s8.main() == 0
+    assert "SKIP - exists" in capsys.readouterr().out
+
+
+def test_shard_cache_hit_refuses_a_sibling_shards_partial(monkeypatch, tmp_path, capsys):
+    """Belt and braces. The `_shards/shard-i-of-n.json` fork should make this
+    unreachable in practice, but a stale or hand-copied file at shard 0's path
+    must never be mistaken for shard 0's own work -- that would silently drop
+    1/N of the corpus while reporting success."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    # shard 1's slice, planted at shard 0's path
+    _seed_partial_grade(
+        tmp_path, ["task-002"], out=_shard_grade_path(tmp_path, 0, 2)
+    )
+    monkeypatch.setattr("sys.argv", _shard_argv(0, 2))
+
+    assert s8.main() == 1
+    assert "belongs to a different shard" in capsys.readouterr().err
+
+
+def test_shard_resume_refuses_a_partial_holding_foreign_tasks(monkeypatch, tmp_path, capsys):
+    """A short partial is normal when resuming; one containing tasks outside
+    this shard's slice means we picked up the wrong file and would double-count
+    on merge."""
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    _seed_partial_grade(
+        tmp_path, ["task-001", "task-002"], out=_shard_grade_path(tmp_path, 0, 2)
+    )
+    monkeypatch.setattr("sys.argv", _shard_argv(0, 2, "--resume"))
+
+    assert s8.main() == 1
+    assert "outside --shard-index 0" in capsys.readouterr().err
+
+
+def test_shard_resume_continues_from_its_own_short_partial(monkeypatch, tmp_path):
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    grader_instance = {}
+
+    class _TrackGrader(_FakeGrader):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            grader_instance["g"] = self
+
+    monkeypatch.setattr(s8, "Grader", _TrackGrader)
+    _seed_partial_grade(
+        tmp_path, ["task-001"], out=_shard_grade_path(tmp_path, 0, 2)
+    )
+    monkeypatch.setattr("sys.argv", _shard_argv(0, 2, "--resume"))
+
+    assert s8.main() == 0
+    assert grader_instance["g"].calls == 1  # only task-003 remains for shard 0
+    payload = json.loads(
+        _shard_grade_path(tmp_path, 0, 2).read_text(encoding="utf-8")
+    )
+    assert [task["task_id"] for task in payload["tasks"]] == ["task-001", "task-003"]
+    assert payload["run_status"] == "partial"
+
+
+def test_all_shards_together_cover_the_corpus_exactly(monkeypatch, tmp_path):
+    """End-to-end partition check through main(): run every shard of a 3-way
+    split into its own directory and confirm the union is the whole corpus."""
+    graded: list[str] = []
+    for index in range(3):
+        shard_dir = tmp_path / f"shard{index}"
+        shard_dir.mkdir()
+        _setup_workspace(shard_dir)
+        monkeypatch.chdir(shard_dir)
+        monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+        monkeypatch.setattr(s8, "Grader", _FakeGrader)
+        monkeypatch.setattr("sys.argv", _shard_argv(index, 3, "--force"))
+
+        assert s8.main() == 0
+        payload = json.loads(
+            _shard_grade_path(shard_dir, index, 3).read_text(encoding="utf-8")
+        )
+        assert payload["run_status"] == "partial"
+        assert payload["expected_task_count"] == len(_CORPUS)
+        graded.extend(task["task_id"] for task in payload["tasks"])
+
+    assert sorted(graded) == _CORPUS
+    assert len(graded) == len(set(graded))
+
+
+def test_grade_workflow_wires_shards_end_to_end():
+    """Pin the dispatch surface that turns step8's `--shard-*` flags into N
+    parallel paid relays.
+
+    step8 can slice and step9 can merge, but neither is reachable unless the
+    workflow passes the flags through, keeps concurrent shards from serialising
+    each other, and arranges for exactly one of them to assemble the final. This
+    test guards that wiring, because every failure mode here is expensive: a
+    dropped flag double-grades the corpus, a wrong concurrency key silently
+    turns N shards back into a queue, and a mis-gated analysis publishes a
+    reading of 1/N of the corpus as if it were the whole run.
+    """
+    workflow = Path("../.github/workflows/grade-run.yml").read_text(
+        encoding="utf-8"
+    )
+    parsed = yaml.safe_load(workflow)
+    # YAML 1.1 parses a bare `on:` key as the boolean True.
+    trigger = parsed.get("on", parsed.get(True))
+    inputs = trigger["workflow_dispatch"]["inputs"]
+
+    assert inputs["shard_count"]["default"] == 1
+    assert inputs["shard_index"]["default"] == 0
+    assert inputs["shard_count"]["required"] is False
+    assert inputs["shard_index"]["required"] is False
+
+    # Chunks of the SAME shard must serialise -- they resume from one partial
+    # file. Different shards must NOT, or sharding buys nothing. Hence the key
+    # carries shard_index and deliberately not shard_count.
+    concurrency = parsed["concurrency"]["group"]
+    assert "inputs.shard_index" in concurrency
+    assert "inputs.shard_count" not in concurrency
+    assert parsed["concurrency"]["cancel-in-progress"] is False
+
+    validate = next(
+        step
+        for step in parsed["jobs"]["validate-request"]["steps"]
+        if step.get("name") == "Validate workflow context and inputs"
+    )
+    assert "shard_count must be an integer between 1 and 11" in validate["run"]
+    assert "shard_index must be an integer between 0 and 10" in validate["run"]
+    assert "must be less than shard_count" in validate["run"]
+    # --limit forks the output into _diagnostic/<scope_sha>/, where nothing
+    # merges. The two features must never combine.
+    assert "shard_count > 1 cannot be combined with tasks_limit" in (
+        validate["run"]
+    )
+
+    steps = parsed["jobs"]["grade"]["steps"]
+    by_name = {step.get("name"): step for step in steps if step.get("name")}
+    order = [step.get("name") for step in steps]
+
+    shard_args = (
+        'ARGS+=(--shard-count "$GRADE_SHARD_COUNT" '
+        '--shard-index "$GRADE_SHARD_INDEX")'
+    )
+    grade_job = parsed["jobs"]["grade"]
+    assert grade_job["env"]["GRADE_SHARD_COUNT"] == "${{ inputs.shard_count }}"
+    assert grade_job["env"]["GRADE_SHARD_INDEX"] == "${{ inputs.shard_index }}"
+    assert shard_args in by_name["Run grading"]["run"]
+    # The dry run must preview this shard's slice too, or its task count says
+    # nothing about the paid run it is meant to authorise.
+    dry_classify = next(
+        step
+        for step in parsed["jobs"]["grade-dry-run"]["steps"]
+        if step.get("name") == "Classify grading work only"
+    )
+    assert shard_args in dry_classify["run"]
+
+    # An rc=7 chunk hands off to the next chunk OF THE SAME SHARD. Losing the
+    # shard flags here would resume the remainder as an unsharded run.
+    retrigger = by_name["Auto-retrigger next chunk (time budget hit)"]
+    assert '-f shard_count="$GRADE_SHARD_COUNT"' in retrigger["run"]
+    assert '-f shard_index="$GRADE_SHARD_INDEX"' in retrigger["run"]
+
+    merge = by_name["Merge shards into the final grade"]
+    assert merge["id"] == "merge_shards"
+    assert "inputs.shard_count > 1" in merge["if"]
+    assert "steps.grade.outputs.rc == '0'" in merge["if"]
+    # Merge only after pulling, or "is every sibling published?" is answered
+    # against a stale checkout and no shard ever sees a complete set.
+    assert merge["run"].index(
+        'git pull --rebase origin "${GITHUB_REF_NAME}"'
+    ) < merge["run"].index("step9_merge_shards.py")
+    assert "data/grades/" in merge["run"]
+    assert "*/_shards/*" in merge["run"]
+    assert "shard-%03d-of-%03d.json" in merge["run"]
+    # Path guards: no traversal, no newline injection, no symlinked directory
+    # or output. The shard path comes from step8, but the merge step is what
+    # decides where a `final` grade gets written and committed.
+    assert '== *..*' in merge["run"]
+    assert "-L \"$SHARD_DIR\"" in merge["run"]
+    assert '-L "$FINAL_FILE"' in merge["run"]
+    assert '-L "$candidate"' in merge["run"]
+    assert 'echo "merged=false"' in merge["run"]
+    assert 'echo "merged=true"' in merge["run"]
+    # A partial slice must never be published as a final grade.
+    assert "from core.grade_payload import validate_grade_payload" in (
+        merge["run"]
+    )
+    assert 'payload.get("run_status") != "final"' in merge["run"]
+    assert 'payload.get("expected_task_count")' in merge["run"]
+    # Two shards can reach the merge concurrently; step9 is deterministic, so
+    # the loser rewrites an identical file and --force keeps it from erroring.
+    assert "--force" in merge["run"]
+    assert "git diff --staged --quiet" in merge["run"]
+    assert order.index("Commit grade result") < order.index(
+        "Merge shards into the final grade"
+    )
+
+    analysis = by_name["Auto-analyze (final chunk only)"]
+    assert order.index("Merge shards into the final grade") < order.index(
+        "Auto-analyze (final chunk only)"
+    )
+    assert "steps.merge_shards.outputs.merged == 'true'" in analysis["if"]
+    assert "inputs.shard_count == 1 && steps.grade.outputs.rc == '0'" in (
+        analysis["if"]
+    )
+    assert analysis["env"]["ANALYSIS_GRADE_FILE"] == (
+        "${{ steps.merge_shards.outputs.grade_file || "
+        "steps.grade.outputs.grade_file }}"
+    )
+    # Committing has to follow the analyze step exactly. Gating on rc alone
+    # would fire on a shard that produced no analysis, and the emptiness guard
+    # would then fail the job for correctly declining to analyse a fragment.
+    assert by_name["Commit analysis"]["if"] == (
+        "steps.analysis.outcome == 'success' && inputs.dry_run == false"
+    )
+
+    upload = by_name["Upload grade artifact"]
+    assert "inputs.shard_index" in upload["with"]["name"]
+    assert "${{ steps.merge_shards.outputs.grade_file }}" in (
+        upload["with"]["path"]
+    )

--- a/batch-runner/tests/test_step9_merge_shards.py
+++ b/batch-runner/tests/test_step9_merge_shards.py
@@ -1,0 +1,1519 @@
+"""Independent verification of ``step9_merge_shards.py`` against the
+field-by-field merge table in ``tasks/shard_merge_task/000-OVERVIEW.md`` §D.
+
+Scope
+-----
+These tests were written WITHOUT permission to modify the implementation.
+Every assertion below states what §C/§D require; where the implementation
+disagrees the test is left failing on purpose.
+
+Fixture provenance
+------------------
+The corpus is the real 220-task grade artifact::
+
+    data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools.json
+
+That artifact is ``schema_version: "1.0"`` and predates the lifecycle /
+provenance fields the merge contract is written against. Two deliberate,
+documented normalisations turn it into a schema-1.3 corpus:
+
+1. ``judge_error`` items are forced to ``score_excluded: true``. Schema 1.3
+   *defines* that as the only legal representation (``core.grade_payload``
+   raises "schema 1.3 judge_error must be score_excluded"), so this is the
+   unique valid migration, not a guess. 20 of 275 judge_error items in the
+   1.0 artifact needed it. It does not touch ``task["pct"]`` and therefore
+   cannot move ``avg_score_pct``.
+2. The lifecycle / provenance fields absent from 1.0 (``run_status``,
+   ``expected_task_count``, ``expected_ordered_task_ids_sha256``,
+   ``grader_source_hash``, ``anchor_projection``, ``renderer_fingerprint``,
+   ``azure_ai_routes``, ``azure_ai_runtime_fingerprint``,
+   ``source_inference_*``) are copied from the real 4-task anchor
+   diagnostic run rather than invented, so every shape is one the pipeline
+   actually emitted.
+
+What "the original" means for the round-trip assertions
+------------------------------------------------------
+The 1.0 artifact's *stored* ``summary.openai_compat.avg_score_pct`` is
+53.3, but recomputing it from those same 220 tasks with the current
+``step8_grade._compute_summary`` yields 54.54 (the stored value divided by
+the full corpus, 220, instead of by the graded corpus, 215 --
+54.54 * 215 / 220 == 53.30). That is pre-existing drift between a legacy
+artifact and current summary code; it has nothing to do with sharding.
+
+The round-trip comparator is therefore the **serial recomputation over the
+same corpus** -- literally what §F kill criterion 6 names ("동일 코퍼스
+직렬 실행"). ``serial_reference_payload`` is that payload.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import random
+from pathlib import Path
+
+import pytest
+
+import step9_merge_shards as s9
+from core.grade_payload import canonical_rate, validate_grade_payload
+from step8_grade import (
+    SCHEMA_VERSION,
+    _compute_summary,
+    _ordered_task_ids_sha256,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CORPUS_PATH = (
+    REPO_ROOT
+    / "data"
+    / "grades"
+    / "exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools.json"
+)
+ANCHOR_GLOB = "data/grades/_diagnostic/*/*sol_max_anchor4*.json"
+
+#: Both fingerprints below are real values observed in the 4-task anchor run.
+FP_PRIMARY = "4883551d5001c23b50b24d0f2290fc01a6febacf73374667fce8a0c7111de517"
+FP_SECOND = "5df8d48b6568d7a6ae41c99f61044cdab00e6cdee4cbc1ac4960efcf3881e5e7"
+
+#: The judge in the corpus artifact declares no perception sub-judges, so
+#: ``core.grade_payload`` requires exactly ``{judge.model}`` here.
+UNPRICED_MODELS = ["gpt-5.4"]
+
+#: Task count used by the invariant / task-set cases. The full 220-task
+#: corpus is reserved for the round-trip and aggregate assertions; every
+#: check exercised on this subset is task-count independent, and using a
+#: subset keeps ~30 jsonschema validations off the critical path.
+SMALL_TASK_COUNT = 24
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def grade_schema() -> dict:
+    path = REPO_ROOT / "batch-runner" / "schemas" / "grade.schema.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="session")
+def raw_corpus() -> dict:
+    """The real 13.9MB grade artifact, parsed exactly once."""
+    assert CORPUS_PATH.is_file(), f"corpus fixture missing: {CORPUS_PATH}"
+    return json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="session")
+def anchor_provenance() -> dict:
+    """Real lifecycle/provenance field values from the 4-task anchor run."""
+    matches = sorted(REPO_ROOT.glob(ANCHOR_GLOB))
+    assert matches, f"anchor diagnostic fixture missing: {ANCHOR_GLOB}"
+    anchor = json.loads(matches[0].read_text(encoding="utf-8"))
+    return {
+        "anchor_projection": anchor["anchor_projection"],
+        "renderer_fingerprint": anchor["renderer_fingerprint"],
+        "grader_source_hash": anchor["grader_source_hash"],
+        "source_inference_repo_id": anchor["source_inference_repo_id"],
+        "source_inference_revision": anchor["source_inference_revision"],
+        "source_azure_ai_provenance_status": anchor[
+            "source_azure_ai_provenance_status"
+        ],
+    }
+
+
+def _normalised_tasks(raw_corpus: dict, limit: int | None = None) -> list[dict]:
+    """Deep-copied corpus tasks migrated to the schema-1.3 item contract."""
+    tasks = copy.deepcopy(raw_corpus["tasks"])
+    if limit is not None:
+        tasks = tasks[:limit]
+    for task in tasks:
+        for item in task["items"]:
+            if item.get("verdict") == "judge_error":
+                item["score_excluded"] = True
+    return tasks
+
+
+def _build_reference(
+    raw_corpus: dict, anchor_provenance: dict, tasks: list[dict]
+) -> dict:
+    """Return the ``final`` payload a single serial run would have produced."""
+    task_ids = [task["task_id"] for task in tasks]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "experiment_id": raw_corpus["experiment_id"],
+        "experiment_yaml_name": raw_corpus["experiment_yaml_name"],
+        "source_inference_experiment_id": raw_corpus[
+            "source_inference_experiment_id"
+        ],
+        "source_inference_run_dir": raw_corpus["source_inference_run_dir"],
+        "source_inference_repo_id": anchor_provenance["source_inference_repo_id"],
+        "source_inference_revision": anchor_provenance["source_inference_revision"],
+        "source_azure_ai_provenance_status": anchor_provenance[
+            "source_azure_ai_provenance_status"
+        ],
+        "inference_model": raw_corpus["inference_model"],
+        "inference_completed_at": raw_corpus["inference_completed_at"],
+        "judge": copy.deepcopy(raw_corpus["judge"]),
+        "rubric": copy.deepcopy(raw_corpus["rubric"]),
+        "prompt": copy.deepcopy(raw_corpus["prompt"]),
+        "grader_source_hash": anchor_provenance["grader_source_hash"],
+        "anchor_projection": copy.deepcopy(
+            anchor_provenance["anchor_projection"]
+        ),
+        "renderer_fingerprint": copy.deepcopy(
+            anchor_provenance["renderer_fingerprint"]
+        ),
+        "azure_ai_routes": [
+            {
+                "endpoint_kind": "direct-v1",
+                "profile": "direct-v1",
+                "runtime_fingerprint": FP_PRIMARY,
+                "workload": "grader",
+            }
+        ],
+        "azure_ai_runtime_fingerprint": FP_PRIMARY,
+        "run_status": "final",
+        "expected_task_count": len(task_ids),
+        "expected_ordered_task_ids_sha256": _ordered_task_ids_sha256(task_ids),
+        "graded_at": raw_corpus["graded_at"],
+        "graded_by": raw_corpus["graded_by"],
+        "graded_by_version": raw_corpus["graded_by_version"],
+        "tasks": tasks,
+        "summary": _compute_summary(tasks, unpriced_models=UNPRICED_MODELS),
+    }
+
+
+@pytest.fixture(scope="session")
+def serial_reference_payload(raw_corpus: dict, anchor_provenance: dict) -> dict:
+    """220-task ``final`` payload == the serial-run comparator."""
+    return _build_reference(
+        raw_corpus, anchor_provenance, _normalised_tasks(raw_corpus)
+    )
+
+
+@pytest.fixture(scope="session")
+def small_reference_payload(raw_corpus: dict, anchor_provenance: dict) -> dict:
+    """24-task ``final`` payload for the fast invariant / task-set cases."""
+    return _build_reference(
+        raw_corpus,
+        anchor_provenance,
+        _normalised_tasks(raw_corpus, limit=SMALL_TASK_COUNT),
+    )
+
+
+def _graded_at(index: int) -> str:
+    return f"2026-06-{10 + index:02d}T00:00:{index:02d}Z"
+
+
+def make_shards(reference: dict, count: int, *, mode: str = "stride") -> list[dict]:
+    """Split ``reference`` into ``count`` deep-copied ``partial`` shards.
+
+    ``stride`` mirrors the adopted design (``tasks[shard_index::shard_count]``
+    per §C); ``block`` is a contiguous split used to probe the layout
+    reconstruction path.
+    """
+    tasks = reference["tasks"]
+    identity = {
+        key: value
+        for key, value in reference.items()
+        if key not in {"tasks", "summary"}
+    }
+    shards: list[dict] = []
+    for index in range(count):
+        if mode == "stride":
+            subset = copy.deepcopy(tasks[index::count])
+        elif mode == "block":
+            per = (len(tasks) + count - 1) // count
+            subset = copy.deepcopy(tasks[index * per : (index + 1) * per])
+        else:  # pragma: no cover - guards test authoring mistakes
+            raise AssertionError(f"unknown split mode: {mode}")
+        shard = copy.deepcopy(identity)
+        shard["run_status"] = "partial"
+        shard["tasks"] = subset
+        shard["summary"] = _compute_summary(
+            subset, unpriced_models=UNPRICED_MODELS
+        )
+        shard["graded_at"] = _graded_at(index)
+        shards.append(shard)
+    return shards
+
+
+def merge(shards: list[dict], **kwargs) -> dict:
+    """Merge with warnings captured so stderr stays clean during tests."""
+    kwargs.setdefault("warn", lambda _message: None)
+    return s9.merge_shard_payloads(shards, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# fixture-integrity guards
+#
+# If these fail, every later assertion is meaningless -- the corpus is not
+# what the merge contract assumes.
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_fixture_is_the_expected_220_task_artifact(raw_corpus: dict) -> None:
+    assert len(raw_corpus["tasks"]) == 220
+    assert len({task["task_id"] for task in raw_corpus["tasks"]}) == 220
+    assert raw_corpus["schema_version"] == "1.0"
+
+
+def test_serial_reference_is_a_valid_final_payload(
+    serial_reference_payload: dict, grade_schema: dict
+) -> None:
+    validate_grade_payload(serial_reference_payload, grade_schema)
+    assert serial_reference_payload["run_status"] == "final"
+    assert serial_reference_payload["expected_task_count"] == 220
+
+
+def test_legacy_stored_average_differs_from_serial_recomputation(
+    raw_corpus: dict, serial_reference_payload: dict
+) -> None:
+    """Pin the legacy-vs-current drift so it is never mistaken for a merge bug.
+
+    The 1.0 artifact averaged over all 220 tasks; ``_compute_summary``
+    averages over the 215 non-error tasks.
+    """
+    stored = raw_corpus["summary"]["openai_compat"]["avg_score_pct"]
+    serial = serial_reference_payload["summary"]["openai_compat"][
+        "avg_score_pct"
+    ]
+    assert stored == 53.3
+    assert serial == 54.54
+    assert round(serial * 215 / 220, 2) == stored
+
+
+# ---------------------------------------------------------------------------
+# §4 case 1 + 2 -- round-trip identity, N in {2, 3, 9}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_roundtrip_restores_canonical_task_order(
+    serial_reference_payload: dict, count: int
+) -> None:
+    merged = merge(make_shards(serial_reference_payload, count))
+    assert [task["task_id"] for task in merged["tasks"]] == [
+        task["task_id"] for task in serial_reference_payload["tasks"]
+    ]
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_roundtrip_restores_full_task_set(
+    serial_reference_payload: dict, count: int
+) -> None:
+    merged = merge(make_shards(serial_reference_payload, count))
+    assert len(merged["tasks"]) == 220
+    assert {task["task_id"] for task in merged["tasks"]} == {
+        task["task_id"] for task in serial_reference_payload["tasks"]
+    }
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_roundtrip_preserves_per_task_scores(
+    serial_reference_payload: dict, count: int
+) -> None:
+    merged = merge(make_shards(serial_reference_payload, count))
+    expected = {
+        task["task_id"]: (task["pct"], task["total_awarded"], task["total_max"])
+        for task in serial_reference_payload["tasks"]
+    }
+    actual = {
+        task["task_id"]: (task["pct"], task["total_awarded"], task["total_max"])
+        for task in merged["tasks"]
+    }
+    assert actual == expected
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_roundtrip_avg_score_pct_is_exactly_serial(
+    serial_reference_payload: dict, count: int
+) -> None:
+    """§E completion criterion: exact equality, never approximate."""
+    merged = merge(make_shards(serial_reference_payload, count))
+    assert (
+        merged["summary"]["openai_compat"]["avg_score_pct"]
+        == serial_reference_payload["summary"]["openai_compat"]["avg_score_pct"]
+    )
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_roundtrip_summary_is_identical_to_serial(
+    serial_reference_payload: dict, count: int
+) -> None:
+    """§D: every recomputed aggregate matches a serial run over the corpus."""
+    merged = merge(make_shards(serial_reference_payload, count))
+    assert merged["summary"] == serial_reference_payload["summary"]
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_merged_payload_passes_validate_grade_payload(
+    serial_reference_payload: dict, grade_schema: dict, count: int
+) -> None:
+    """§E completion criterion, asserted independently of the merge's own
+    internal validation call."""
+    merged = merge(make_shards(serial_reference_payload, count))
+    validate_grade_payload(merged, grade_schema)
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_merged_run_status_is_final(
+    serial_reference_payload: dict, count: int
+) -> None:
+    merged = merge(make_shards(serial_reference_payload, count))
+    assert merged["run_status"] == "final"
+
+
+def test_nine_way_split_is_uneven_as_the_spec_requires(
+    serial_reference_payload: dict,
+) -> None:
+    """220 % 9 == 4: four shards of 25 and five of 24."""
+    shards = make_shards(serial_reference_payload, 9)
+    sizes = sorted(len(shard["tasks"]) for shard in shards)
+    assert sizes == [24] * 5 + [25] * 4
+    assert sum(sizes) == 220
+
+
+# ---------------------------------------------------------------------------
+# §4 strong assertions -- identity, rates, cost sums, graded_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_merged_identity_fields_are_adopted_from_shards(
+    serial_reference_payload: dict, count: int
+) -> None:
+    """§D 'verify then adopt' rows survive the merge unchanged."""
+    merged = merge(make_shards(serial_reference_payload, count))
+    for field in (
+        "schema_version",
+        "experiment_id",
+        "inference_model",
+        "grader_source_hash",
+        "renderer_fingerprint",
+        "anchor_projection",
+        "source_inference_repo_id",
+        "source_inference_revision",
+        "expected_task_count",
+        "expected_ordered_task_ids_sha256",
+        "graded_by",
+        "graded_by_version",
+        "judge",
+        "rubric",
+        "prompt",
+    ):
+        assert merged[field] == serial_reference_payload[field], field
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_judge_error_rate_matches_canonical_rate(
+    serial_reference_payload: dict, count: int
+) -> None:
+    """§D: judge_error_rate == canonical_rate(judge_errors, judge_items)."""
+    merged = merge(make_shards(serial_reference_payload, count))
+    judge_items = 0
+    judge_errors = 0
+    for task in merged["tasks"]:
+        for item in task["items"]:
+            if item.get("decided_by") == "judge":
+                judge_items += 1
+                if item.get("verdict") == "judge_error":
+                    judge_errors += 1
+    assert judge_items > 0
+    assert judge_errors > 0
+    assert merged["summary"]["wow"]["judge_error_rate"] == canonical_rate(
+        judge_errors, judge_items
+    )
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_integer_cost_counters_equal_the_shard_sum(
+    serial_reference_payload: dict, count: int
+) -> None:
+    """§D: token / call counters are summed across shards."""
+    shards = make_shards(serial_reference_payload, count)
+    merged = merge(copy.deepcopy(shards))
+    for field in s9.SUMMABLE_COST_FIELDS:
+        expected = sum(shard["summary"]["cost"][field] for shard in shards)
+        assert merged["summary"]["cost"][field] == expected, field
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_cost_pricing_fields_are_pinned(
+    serial_reference_payload: dict, count: int
+) -> None:
+    """§D: estimated_cost_usd None, pricing_complete False, unpriced adopted."""
+    merged = merge(make_shards(serial_reference_payload, count))
+    cost = merged["summary"]["cost"]
+    assert cost["estimated_cost_usd"] is None
+    assert cost["pricing_complete"] is False
+    assert cost["unpriced_models"] == UNPRICED_MODELS
+
+
+@pytest.mark.parametrize("count", [2, 3, 9])
+def test_summary_task_counts_are_recomputed_from_merged_tasks(
+    serial_reference_payload: dict, count: int
+) -> None:
+    """§D: summary.total/graded/error_tasks recomputed, not summed blindly."""
+    merged = merge(make_shards(serial_reference_payload, count))
+    summary = merged["summary"]
+    graded = sum(1 for task in merged["tasks"] if not task.get("error"))
+    assert summary["total_tasks"] == len(merged["tasks"]) == 220
+    assert summary["graded_tasks"] == graded
+    assert summary["error_tasks"] == 220 - graded
+
+
+def test_graded_at_is_the_maximum_shard_timestamp(
+    small_reference_payload: dict,
+) -> None:
+    """§D: graded_at is the completion moment == max over shards.
+
+    The maximum is deliberately placed on the middle shard so that a
+    "take the first"/"take the last" implementation cannot pass.
+    """
+    shards = make_shards(small_reference_payload, 3)
+    shards[0]["graded_at"] = "2026-06-10T00:00:00Z"
+    shards[1]["graded_at"] = "2026-07-01T12:00:00Z"
+    shards[2]["graded_at"] = "2026-06-11T00:00:00Z"
+    merged = merge(shards)
+    assert merged["graded_at"] == "2026-07-01T12:00:00Z"
+
+
+def test_graded_at_max_compares_instants_not_strings(
+    small_reference_payload: dict,
+) -> None:
+    """'2026-07-01T20:00:00+09:00' sorts above 'T12:00:00Z' as a string but
+    is 11:00Z, i.e. one hour EARLIER. The instant must win."""
+    shards = make_shards(small_reference_payload, 2)
+    shards[0]["graded_at"] = "2026-07-01T12:00:00Z"
+    shards[1]["graded_at"] = "2026-07-01T20:00:00+09:00"
+    merged = merge(shards)
+    assert merged["graded_at"] == "2026-07-01T12:00:00Z"
+
+
+def test_per_task_graded_at_is_preserved(serial_reference_payload: dict) -> None:
+    """§D: task-level graded_at survives even though the top level is a max."""
+    merged = merge(make_shards(serial_reference_payload, 3))
+    expected = {
+        task["task_id"]: task["graded_at"]
+        for task in serial_reference_payload["tasks"]
+    }
+    actual = {task["task_id"]: task["graded_at"] for task in merged["tasks"]}
+    assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# §4 case 3 -- the twelve §C invariants, violated individually
+# ---------------------------------------------------------------------------
+
+
+def _set_nested(payload: dict, path: tuple[str, ...], value) -> None:
+    node = payload
+    for key in path[:-1]:
+        node = node[key]
+    node[path[-1]] = value
+
+
+#: (reported field name, dotted path, replacement value). Invariants 1-10 of
+#: §C -- the fields ``_validate_grade_resume_identity`` pins.
+CONTRACT_INVARIANT_CASES = [
+    ("schema_version", ("schema_version",), "1.2"),
+    ("experiment_id", ("experiment_id",), "exp999_other_experiment"),
+    ("rubric.commit_sha", ("rubric", "commit_sha"), "0" * 40),
+    ("prompt.version", ("prompt", "version"), "v9"),
+    ("judge.config_hash", ("judge", "config_hash"), "deadbeefdeadbeef"),
+    (
+        "source_inference_repo_id",
+        ("source_inference_repo_id",),
+        "SomeoneElse/other-run",
+    ),
+    ("source_inference_revision", ("source_inference_revision",), "b" * 40),
+    ("grader_source_hash", ("grader_source_hash",), "c" * 64),
+    ("anchor_projection", ("anchor_projection",), None),
+    ("renderer_fingerprint", ("renderer_fingerprint",), None),
+]
+
+
+@pytest.mark.parametrize(
+    "field_name,path,replacement",
+    CONTRACT_INVARIANT_CASES,
+    ids=[case[0] for case in CONTRACT_INVARIANT_CASES],
+)
+def test_contract_invariant_violation_fails_naming_the_field(
+    small_reference_payload: dict, field_name: str, path: tuple, replacement
+) -> None:
+    """§E-3: any of the ten identity invariants disagreeing must fail, with a
+    message that names the offending field.
+
+    Asserting on the field name matters: several of these replacements are
+    also schema-invalid, so a bare ``pytest.raises(ShardMergeError)`` could
+    pass because the *payload validation* fired instead of the *invariant
+    check*. The field name proves which one ran.
+    """
+    shards = make_shards(small_reference_payload, 3)
+    _set_nested(shards[1], path, replacement)
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert field_name in str(excinfo.value)
+
+
+def test_every_contract_identity_field_is_covered(small_reference_payload) -> None:
+    """Guard: the parametrised list must track ``CONTRACT_IDENTITY_FIELDS``."""
+    covered = {case[0] for case in CONTRACT_INVARIANT_CASES}
+    declared = {name for name, _path in s9.CONTRACT_IDENTITY_FIELDS}
+    assert covered == declared
+
+
+def test_invariant_11_route_drift_fails_under_strict_routes(
+    small_reference_payload: dict,
+) -> None:
+    """§C invariant 11 (``azure_ai_routes``) under the literal reading."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["azure_ai_routes"] = shards[1]["azure_ai_routes"] + [
+        {
+            "endpoint_kind": "direct-v1",
+            "profile": "direct-v1",
+            "runtime_fingerprint": FP_SECOND,
+            "workload": "grader",
+        }
+    ]
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards, strict_routes=True)
+    assert "azure_ai_routes" in str(excinfo.value)
+
+
+def test_invariant_12_fingerprint_drift_fails_under_strict_routes(
+    small_reference_payload: dict,
+) -> None:
+    """§C invariant 12 (``azure_ai_runtime_fingerprint``).
+
+    Note the structural coupling: ``azure_ai_routes[0].runtime_fingerprint``
+    must equal ``azure_ai_runtime_fingerprint`` within a shard, so a
+    fingerprint that differs across shards necessarily makes the route lists
+    differ too. Invariant 12 is therefore not independently reachable; the
+    merge reports it against ``azure_ai_routes``.
+    """
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["azure_ai_routes"] = [
+        {
+            "endpoint_kind": "direct-v1",
+            "profile": "direct-v1",
+            "runtime_fingerprint": FP_SECOND,
+            "workload": "grader",
+        }
+    ]
+    shards[1]["azure_ai_runtime_fingerprint"] = FP_SECOND
+    with pytest.raises(s9.ShardMergeError):
+        merge(shards, strict_routes=True)
+
+
+def test_fingerprint_must_match_its_own_primary_route(
+    small_reference_payload: dict,
+) -> None:
+    """Structural half of invariant 12, reachable in both modes."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["azure_ai_runtime_fingerprint"] = FP_SECOND
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "primary grader route fingerprint mismatch" in str(excinfo.value)
+
+
+def test_default_mode_unions_routes_instead_of_rejecting_drift(
+    small_reference_payload: dict,
+) -> None:
+    """§D: order-preserving union deduplicated by runtime_fingerprint, and
+    the fingerprint is taken from the canonically-first shard.
+
+    In the DEFAULT (non-strict) mode invariants 11-12 do NOT hard-fail --
+    drift is downgraded to a warning, so only 10 of the 12 §C invariants are
+    enforced by default. Per F-2 that relaxation must be *auditable*: the
+    merge is additionally required to record each shard's own fingerprint in
+    ``shard_provenance``, so "not enforced" never means "not recorded".
+    """
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["azure_ai_routes"] = [
+        {
+            "endpoint_kind": "direct-v1",
+            "profile": "direct-v1",
+            "runtime_fingerprint": FP_SECOND,
+            "workload": "grader",
+        }
+    ]
+    shards[1]["azure_ai_runtime_fingerprint"] = FP_SECOND
+    warnings: list[str] = []
+    merged = s9.merge_shard_payloads(shards, warn=warnings.append)
+    assert [
+        route["runtime_fingerprint"] for route in merged["azure_ai_routes"]
+    ] == [FP_PRIMARY, FP_SECOND]
+    assert merged["azure_ai_runtime_fingerprint"] == FP_PRIMARY
+    assert merged["azure_ai_routes"][0]["runtime_fingerprint"] == FP_PRIMARY
+    assert any("azure_ai_runtime_fingerprint" in note for note in warnings)
+    assert [
+        entry["azure_ai_runtime_fingerprint"]
+        for entry in merged["shard_provenance"]
+    ] == [FP_PRIMARY, FP_SECOND, FP_PRIMARY]
+
+
+def test_unpriced_models_mismatch_fails(small_reference_payload: dict) -> None:
+    """§F kill criterion 2 / §D: unpriced_models must agree across shards."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["summary"]["cost"]["unpriced_models"] = ["gpt-5.4", "gpt-audio-1.5"]
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "unpriced_models" in str(excinfo.value)
+
+
+def test_expected_task_count_mismatch_fails(small_reference_payload: dict) -> None:
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["expected_task_count"] = SMALL_TASK_COUNT + 1
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "expected_task_count" in str(excinfo.value)
+
+
+def test_expected_ordered_task_ids_sha256_mismatch_fails(
+    small_reference_payload: dict,
+) -> None:
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["expected_ordered_task_ids_sha256"] = "d" * 64
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "expected_ordered_task_ids_sha256" in str(excinfo.value)
+
+
+def test_non_partial_shard_is_rejected(small_reference_payload: dict) -> None:
+    """Guards against merging an already-final payload a second time."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[2]["run_status"] = "final"
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "partial" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# §4 case 4 + 5 -- task-set defects
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_task_across_shards_fails(small_reference_payload: dict) -> None:
+    """§D: shards must be disjoint."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["tasks"][0] = copy.deepcopy(shards[0]["tasks"][0])
+    shards[1]["summary"] = _compute_summary(
+        shards[1]["tasks"], unpriced_models=UNPRICED_MODELS
+    )
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    message = str(excinfo.value)
+    assert "not disjoint" in message
+    assert shards[0]["tasks"][0]["task_id"] in message
+
+
+def test_duplicate_task_within_one_shard_fails(
+    small_reference_payload: dict,
+) -> None:
+    shards = make_shards(small_reference_payload, 3)
+    shards[0]["tasks"].append(copy.deepcopy(shards[0]["tasks"][0]))
+    shards[0]["summary"] = _compute_summary(
+        shards[0]["tasks"], unpriced_models=UNPRICED_MODELS
+    )
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "duplicate task_ids" in str(excinfo.value)
+
+
+def test_missing_task_refuses_final_promotion(
+    small_reference_payload: dict,
+) -> None:
+    """§E-6: an incomplete union is a hard failure, never a quiet partial."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[2]["tasks"] = shards[2]["tasks"][:-1]
+    shards[2]["summary"] = _compute_summary(
+        shards[2]["tasks"], unpriced_models=UNPRICED_MODELS
+    )
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    message = str(excinfo.value)
+    assert "incomplete" in message
+    assert str(SMALL_TASK_COUNT - 1) in message
+
+
+def test_missing_shard_entirely_refuses_final_promotion(
+    small_reference_payload: dict,
+) -> None:
+    """A whole shard lost to a failed relay must not silently publish."""
+    shards = make_shards(small_reference_payload, 3)
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards[:2])
+    assert "incomplete" in str(excinfo.value)
+
+
+def test_extra_unknown_task_fails(small_reference_payload: dict) -> None:
+    """A task outside the declared corpus must not be absorbed."""
+    shards = make_shards(small_reference_payload, 3)
+    intruder = copy.deepcopy(shards[2]["tasks"][0])
+    intruder["task_id"] = "ffffffff-0000-0000-0000-000000000000"
+    shards[2]["tasks"].append(intruder)
+    shards[2]["summary"] = _compute_summary(
+        shards[2]["tasks"], unpriced_models=UNPRICED_MODELS
+    )
+    with pytest.raises(s9.ShardMergeError):
+        merge(shards)
+
+
+# ---------------------------------------------------------------------------
+# §4 case 6 -- input order independence
+# ---------------------------------------------------------------------------
+
+
+def test_shuffled_input_order_normalises_to_canonical_order(
+    serial_reference_payload: dict,
+) -> None:
+    shards = make_shards(serial_reference_payload, 9)
+    random.Random(20260814).shuffle(shards)
+    merged = merge(shards)
+    assert [task["task_id"] for task in merged["tasks"]] == [
+        task["task_id"] for task in serial_reference_payload["tasks"]
+    ]
+
+
+def test_shuffled_input_produces_a_byte_identical_payload(
+    serial_reference_payload: dict,
+) -> None:
+    """§E-1 determinism: command-line order must not perturb ANY field,
+    including key order and shard_provenance."""
+    ordered = merge(make_shards(serial_reference_payload, 9))
+    shuffled_input = make_shards(serial_reference_payload, 9)
+    random.Random(4242).shuffle(shuffled_input)
+    shuffled = merge(shuffled_input)
+    assert json.dumps(shuffled, sort_keys=True) == json.dumps(
+        ordered, sort_keys=True
+    )
+    assert list(shuffled.keys()) == list(ordered.keys())
+
+
+def test_merge_is_repeatable(small_reference_payload: dict) -> None:
+    first = merge(make_shards(small_reference_payload, 3))
+    second = merge(make_shards(small_reference_payload, 3))
+    assert first == second
+
+
+def test_merge_does_not_mutate_the_input_shards(
+    small_reference_payload: dict,
+) -> None:
+    shards = make_shards(small_reference_payload, 3)
+    before = json.dumps(shards, sort_keys=True)
+    merge(copy.deepcopy(shards))
+    assert json.dumps(shards, sort_keys=True) == before
+
+
+# ---------------------------------------------------------------------------
+# §4 case 7 -- usage_complete
+# ---------------------------------------------------------------------------
+
+
+def test_usage_complete_false_in_any_shard_makes_merge_false(
+    small_reference_payload: dict,
+) -> None:
+    """§D: true only when EVERY shard is true."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["summary"]["cost"]["usage_complete"] = False
+    warnings: list[str] = []
+    merged = s9.merge_shard_payloads(shards, warn=warnings.append)
+    assert merged["summary"]["cost"]["usage_complete"] is False
+    assert any("usage_complete" in note for note in warnings)
+
+
+def test_usage_complete_true_when_all_shards_true(
+    small_reference_payload: dict,
+) -> None:
+    shards = make_shards(small_reference_payload, 3)
+    assert all(
+        shard["summary"]["cost"]["usage_complete"] is True for shard in shards
+    )
+    merged = merge(shards)
+    assert merged["summary"]["cost"]["usage_complete"] is True
+
+
+def test_non_boolean_usage_complete_is_rejected(
+    small_reference_payload: dict,
+) -> None:
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["summary"]["cost"]["usage_complete"] = "yes"
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "usage_complete" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# §4 case 8 -- boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_fails(small_reference_payload: dict) -> None:
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge([])
+    assert "no shard payloads" in str(excinfo.value)
+
+
+def test_single_shard_holding_the_whole_corpus_is_promoted(
+    small_reference_payload: dict, grade_schema: dict
+) -> None:
+    """Degenerate 1-way shard: a complete partial becomes final."""
+    shards = make_shards(small_reference_payload, 1)
+    assert len(shards) == 1
+    assert len(shards[0]["tasks"]) == SMALL_TASK_COUNT
+    merged = merge(shards)
+    validate_grade_payload(merged, grade_schema)
+    assert merged["run_status"] == "final"
+    assert merged["summary"] == small_reference_payload["summary"]
+
+
+def test_shard_with_zero_tasks_fails(small_reference_payload: dict) -> None:
+    """A shard that graded nothing must not be silently absorbed.
+
+    The shard summary is recomputed alongside the emptied task list so the
+    payload stays internally consistent -- otherwise the per-shard
+    ``validate_grade_payload`` call fires first and this test would pass for
+    the wrong reason (see the companion test below).
+    """
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["tasks"] = []
+    shards[1]["summary"] = _compute_summary([], unpriced_models=UNPRICED_MODELS)
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "zero graded tasks" in str(excinfo.value)
+
+
+def test_each_shard_is_validated_before_merging(
+    small_reference_payload: dict,
+) -> None:
+    """A shard whose own summary disagrees with its tasks is rejected by
+    ``validate_grade_payload`` before any merging happens."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["tasks"] = []
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    message = str(excinfo.value)
+    assert "shard[1]" in message
+    assert "not a valid grade payload" in message
+
+
+def test_non_dict_shard_is_rejected(small_reference_payload: dict) -> None:
+    shards = make_shards(small_reference_payload, 2)
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge([shards[0], ["not", "an", "object"]])
+    assert "must be an object" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# shard_provenance (§D recommended field)
+# ---------------------------------------------------------------------------
+
+
+def test_shard_provenance_records_every_shard_in_canonical_order(
+    small_reference_payload: dict,
+) -> None:
+    shards = make_shards(small_reference_payload, 3)
+    merged = merge(copy.deepcopy(shards))
+    provenance = merged["shard_provenance"]
+    assert len(provenance) == 3
+    assert [entry["index"] for entry in provenance] == [0, 1, 2]
+    assert {entry["count"] for entry in provenance} == {3}
+    assert [entry["graded_at"] for entry in provenance] == [
+        shard["graded_at"] for shard in shards
+    ]
+    for entry in provenance:
+        assert entry["config_hash"] == small_reference_payload["judge"][
+            "config_hash"
+        ]
+        assert len(entry["grade_file_sha256"]) == 64
+
+
+def test_shard_provenance_entry_shape_is_exact(
+    small_reference_payload: dict,
+) -> None:
+    """Pin the entry key set exactly.
+
+    ``shard_provenance`` is absent from ``grade.schema.json`` and the
+    top-level ``additionalProperties`` is ``true``, so
+    ``validate_grade_payload`` neither requires nor rejects any of these
+    keys -- deleting ``azure_ai_runtime_fingerprint`` would still validate.
+    This assertion is therefore the only thing holding the F-2 record in
+    place, so it is exact rather than a containment check.
+    """
+    merged = merge(make_shards(small_reference_payload, 3))
+    for entry in merged["shard_provenance"]:
+        assert set(entry) == {
+            "index",
+            "count",
+            "config_hash",
+            "grade_file_sha256",
+            "graded_at",
+            "azure_ai_runtime_fingerprint",
+        }
+
+
+def test_shard_provenance_records_fingerprint_drift_without_failing(
+    small_reference_payload: dict, grade_schema: dict
+) -> None:
+    """F-2 core: drifting shards still merge, and BOTH observed fingerprints
+    survive in ``shard_provenance`` while the top level keeps shard 0's.
+
+    An auditor holding only the merged file must be able to see that the
+    shards disagreed. Before F-2 that fact existed solely as a stderr
+    warning and the artifact showed a single uniform fingerprint.
+    """
+    shards = make_shards(small_reference_payload, 3)
+    for index in (1, 2):
+        shards[index]["azure_ai_routes"] = [
+            {
+                "endpoint_kind": "direct-v1",
+                "profile": "direct-v1",
+                "runtime_fingerprint": FP_SECOND,
+                "workload": "grader",
+            }
+        ]
+        shards[index]["azure_ai_runtime_fingerprint"] = FP_SECOND
+    warnings: list[str] = []
+    merged = s9.merge_shard_payloads(shards, warn=warnings.append)
+
+    validate_grade_payload(merged, grade_schema)
+    assert merged["run_status"] == "final"
+    recorded = [
+        entry["azure_ai_runtime_fingerprint"]
+        for entry in merged["shard_provenance"]
+    ]
+    assert recorded == [FP_PRIMARY, FP_SECOND, FP_SECOND]
+    assert set(recorded) == {FP_PRIMARY, FP_SECOND}
+    assert merged["azure_ai_runtime_fingerprint"] == FP_PRIMARY
+    assert [
+        route["runtime_fingerprint"] for route in merged["azure_ai_routes"]
+    ] == [FP_PRIMARY, FP_SECOND]
+    assert any("azure_ai_runtime_fingerprint" in note for note in warnings)
+
+
+def test_shard_provenance_fingerprint_matches_the_shard_that_carried_it(
+    small_reference_payload: dict,
+) -> None:
+    """F-2: the recorded value is the shard's own, not shard 0's copied N
+    times. The drift is placed on the LAST shard so an implementation that
+    broadcast the primary fingerprint cannot pass."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[2]["azure_ai_routes"] = [
+        {
+            "endpoint_kind": "direct-v1",
+            "profile": "direct-v1",
+            "runtime_fingerprint": FP_SECOND,
+            "workload": "grader",
+        }
+    ]
+    shards[2]["azure_ai_runtime_fingerprint"] = FP_SECOND
+    merged = s9.merge_shard_payloads(shards, warn=lambda _message: None)
+    assert [
+        entry["azure_ai_runtime_fingerprint"]
+        for entry in merged["shard_provenance"]
+    ] == [FP_PRIMARY, FP_PRIMARY, FP_SECOND]
+
+
+def test_shard_provenance_fingerprints_are_uniform_without_drift(
+    small_reference_payload: dict,
+) -> None:
+    """F-2: with no drift every entry carries the same fingerprint, which is
+    also the merged top-level value."""
+    merged = merge(make_shards(small_reference_payload, 3))
+    assert [
+        entry["azure_ai_runtime_fingerprint"]
+        for entry in merged["shard_provenance"]
+    ] == [FP_PRIMARY] * 3
+    assert merged["azure_ai_runtime_fingerprint"] == FP_PRIMARY
+
+
+def test_shard_provenance_fingerprints_survive_the_cli_round_trip(
+    small_reference_payload: dict, tmp_path: Path
+) -> None:
+    """F-2: the record reaches disk, not just the in-memory dict."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["azure_ai_routes"] = [
+        {
+            "endpoint_kind": "direct-v1",
+            "profile": "direct-v1",
+            "runtime_fingerprint": FP_SECOND,
+            "workload": "grader",
+        }
+    ]
+    shards[1]["azure_ai_runtime_fingerprint"] = FP_SECOND
+    paths = _write_shards(tmp_path, shards)
+    out = tmp_path / "merged.json"
+    assert s9.main([*[str(p) for p in paths], "--output", str(out)]) == 0
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert [
+        entry["azure_ai_runtime_fingerprint"]
+        for entry in written["shard_provenance"]
+    ] == [FP_PRIMARY, FP_SECOND, FP_PRIMARY]
+    assert written["azure_ai_runtime_fingerprint"] == FP_PRIMARY
+
+
+def test_strict_routes_still_rejects_the_drift_that_provenance_records(
+    small_reference_payload: dict,
+) -> None:
+    """F-2 changes recording only: the same shard set that merges (and is
+    recorded) by default must still hard-fail under ``--strict-routes``."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["azure_ai_routes"] = [
+        {
+            "endpoint_kind": "direct-v1",
+            "profile": "direct-v1",
+            "runtime_fingerprint": FP_SECOND,
+            "workload": "grader",
+        }
+    ]
+    shards[1]["azure_ai_runtime_fingerprint"] = FP_SECOND
+    assert (
+        s9.merge_shard_payloads(
+            copy.deepcopy(shards), warn=lambda _message: None
+        )["shard_provenance"][1]["azure_ai_runtime_fingerprint"]
+        == FP_SECOND
+    )
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards, strict_routes=True)
+    assert "azure_ai_routes" in str(excinfo.value)
+
+
+def test_shard_provenance_uses_supplied_digests(
+    small_reference_payload: dict,
+) -> None:
+    shards = make_shards(small_reference_payload, 2)
+    merged = merge(
+        shards, source_digests=["a" * 64, "b" * 64], source_labels=["s0", "s1"]
+    )
+    assert [entry["grade_file_sha256"] for entry in merged["shard_provenance"]] == [
+        "a" * 64,
+        "b" * 64,
+    ]
+
+
+def test_shard_provenance_does_not_break_schema_validation(
+    small_reference_payload: dict, grade_schema: dict
+) -> None:
+    """§D: the schema's top-level additionalProperties:true absorbs it."""
+    merged = merge(make_shards(small_reference_payload, 3))
+    assert "shard_provenance" in merged
+    validate_grade_payload(merged, grade_schema)
+
+
+# ---------------------------------------------------------------------------
+# corpus-order reconstruction
+# ---------------------------------------------------------------------------
+
+
+def test_block_split_cannot_be_reconstructed_without_explicit_ids(
+    serial_reference_payload: dict,
+) -> None:
+    """Only the adopted stride layout is auto-reconstructible.
+
+    A contiguous-block shard layout is rejected with an actionable message
+    rather than silently reordered.
+    """
+    shards = make_shards(serial_reference_payload, 3, mode="block")
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    message = str(excinfo.value)
+    assert "canonical corpus order could not be reconstructed" in message
+    assert "--expected-task-ids" in message
+
+
+def test_block_split_merges_when_canonical_ids_are_supplied(
+    serial_reference_payload: dict,
+) -> None:
+    task_ids = [task["task_id"] for task in serial_reference_payload["tasks"]]
+    shards = make_shards(serial_reference_payload, 3, mode="block")
+    merged = merge(shards, expected_task_ids=task_ids)
+    assert [task["task_id"] for task in merged["tasks"]] == task_ids
+    assert (
+        merged["summary"]["openai_compat"]["avg_score_pct"]
+        == serial_reference_payload["summary"]["openai_compat"]["avg_score_pct"]
+    )
+
+
+def test_explicit_ids_that_disagree_with_the_declared_hash_fail(
+    small_reference_payload: dict,
+) -> None:
+    task_ids = [task["task_id"] for task in small_reference_payload["tasks"]]
+    reordered = list(reversed(task_ids))
+    shards = make_shards(small_reference_payload, 3)
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards, expected_task_ids=reordered)
+    assert "expected_ordered_task_ids_sha256" in str(excinfo.value)
+
+
+def test_explicit_ids_with_wrong_count_fail(
+    small_reference_payload: dict,
+) -> None:
+    task_ids = [task["task_id"] for task in small_reference_payload["tasks"]]
+    shards = make_shards(small_reference_payload, 3)
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards, expected_task_ids=task_ids[:-1])
+    assert "count does not match" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# latency semantics (§D 'sum' row vs the module's serial-identity guarantee)
+# ---------------------------------------------------------------------------
+
+
+def test_latency_totals_are_serial_identical(
+    serial_reference_payload: dict,
+) -> None:
+    """The merged latency equals a serial run's latency exactly."""
+    for count in (2, 3, 9):
+        merged = merge(make_shards(serial_reference_payload, count))
+        for field in (
+            "total_judge_latency_sec",
+            "total_main_judge_latency_sec",
+            "total_perception_latency_sec",
+            "total_render_latency_sec",
+        ):
+            assert (
+                merged["summary"]["cost"][field]
+                == serial_reference_payload["summary"]["cost"][field]
+            ), (count, field)
+
+
+def test_latency_total_can_differ_from_the_shard_sum(
+    serial_reference_payload: dict,
+) -> None:
+    """Characterisation of a real divergence from the §D 'sum' row.
+
+    Each shard rounds its own latency to 2dp, so summing shard-reported
+    latencies is NOT the same number as recomputing from merged tasks. At
+    N=3 the two differ by 0.01s. ``SUMMABLE_COST_FIELDS`` still covers only
+    the 13 integer counters -- the float fields are cross-checked separately
+    by ``_check_latency_sums``, within a tolerance wide enough to absorb
+    exactly this rounding drift.
+
+    The recomputed value is the serial-run value, so the OUTPUT is correct;
+    what this pins is that "summed" and "recomputed" are not interchangeable
+    for the float fields, and that the 0.01s divergence stays legal.
+    """
+    shards = make_shards(serial_reference_payload, 3)
+    merged = merge(copy.deepcopy(shards))
+    shard_sum = round(
+        sum(shard["summary"]["cost"]["total_judge_latency_sec"] for shard in shards),
+        2,
+    )
+    merged_value = merged["summary"]["cost"]["total_judge_latency_sec"]
+    assert merged_value != shard_sum
+    assert abs(merged_value - shard_sum) < 0.02
+    assert "total_judge_latency_sec" not in s9.SUMMABLE_COST_FIELDS
+
+
+def test_tampered_shard_integer_counter_is_detected(
+    small_reference_payload: dict,
+) -> None:
+    """``_check_cost_sums`` catches a hand-edited integer counter."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["summary"]["cost"]["total_input_tokens"] += 1
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "total_input_tokens" in str(excinfo.value)
+
+
+def test_tampered_shard_latency_is_detected(
+    small_reference_payload: dict,
+) -> None:
+    """F-1: +10000s on one shard's reported latency now fails the merge.
+
+    Inverted from ``test_tampered_shard_latency_is_not_detected``, which
+    documented the pre-F-1 gap: the float latency fields sit outside
+    ``SUMMABLE_COST_FIELDS``, so nothing read them and the tampering passed
+    silently. The message must name the field and show both sides plus the
+    tolerance, so an operator can tell tampering from rounding.
+    """
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["summary"]["cost"]["total_judge_latency_sec"] += 10_000.0
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    message = str(excinfo.value)
+    assert "total_judge_latency_sec" in message
+    assert "recomputed=" in message
+    assert "shard_sum=" in message
+    assert "tolerance=" in message
+
+
+def _shard_latency_sum(shards: list[dict], field: str) -> float:
+    """Shard-reported latency sum, computed the way the merge computes it."""
+    return math.fsum(shard["summary"]["cost"][field] for shard in shards)
+
+
+def _skew_shard_latency(
+    shards: list[dict], reference: dict, field: str, target_gap: float
+) -> float:
+    """Edit one shard so ``|recomputed - shard_sum|`` becomes ``target_gap``.
+
+    Returns the gap actually achieved so the caller can prove the boundary
+    was hit rather than approached.
+    """
+    recomputed = reference["summary"]["cost"][field]
+    gap = recomputed - _shard_latency_sum(shards, field)
+    shards[1]["summary"]["cost"][field] += gap - target_gap
+    return abs(recomputed - _shard_latency_sum(shards, field))
+
+
+def test_latency_gap_just_inside_the_tolerance_is_accepted(
+    small_reference_payload: dict,
+) -> None:
+    """F-1 boundary: a gap 0.001s INSIDE ``0.01 x n`` merges, and the emitted
+    latency is still the recomputed serial value, not the skewed shard sum."""
+    field = "total_judge_latency_sec"
+    count = 3
+    tolerance = s9.LATENCY_TOLERANCE_SEC_PER_SHARD * count
+    shards = make_shards(small_reference_payload, count)
+    achieved = _skew_shard_latency(
+        shards, small_reference_payload, field, tolerance - 0.001
+    )
+    assert tolerance - 0.002 < achieved < tolerance
+    merged = merge(shards)
+    assert (
+        merged["summary"]["cost"][field]
+        == small_reference_payload["summary"]["cost"][field]
+    )
+
+
+def test_latency_gap_just_outside_the_tolerance_is_rejected(
+    small_reference_payload: dict,
+) -> None:
+    """F-1 boundary: a gap 0.001s OUTSIDE ``0.01 x n`` is a hard failure."""
+    field = "total_judge_latency_sec"
+    count = 3
+    tolerance = s9.LATENCY_TOLERANCE_SEC_PER_SHARD * count
+    shards = make_shards(small_reference_payload, count)
+    achieved = _skew_shard_latency(
+        shards, small_reference_payload, field, tolerance + 0.001
+    )
+    assert tolerance < achieved < tolerance + 0.002
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert field in str(excinfo.value)
+
+
+def test_latency_tolerance_scales_with_the_shard_count(
+    small_reference_payload: dict,
+) -> None:
+    """F-1: the budget is per shard, so a gap legal at n=9 is illegal at n=2.
+
+    0.05s sits inside ``0.01 x 9`` but outside ``0.01 x 2``. This is what
+    stops the tolerance from being a flat constant that a 2-way merge would
+    treat as nine shards' worth of slack.
+    """
+    field = "total_judge_latency_sec"
+    nine = make_shards(small_reference_payload, 9)
+    assert (
+        _skew_shard_latency(nine, small_reference_payload, field, 0.05) < 0.09
+    )
+    assert merge(nine)["summary"]["cost"][field] == small_reference_payload[
+        "summary"
+    ]["cost"][field]
+
+    two = make_shards(small_reference_payload, 2)
+    _skew_shard_latency(two, small_reference_payload, field, 0.05)
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(two)
+    assert field in str(excinfo.value)
+
+
+@pytest.mark.parametrize("field", list(s9.LATENCY_COST_FIELDS))
+def test_every_latency_field_is_cross_checked(
+    small_reference_payload: dict, field: str
+) -> None:
+    """F-1 covers all four float latency fields, not just the headline total."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["summary"]["cost"][field] += 10_000.0
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert field in str(excinfo.value)
+
+
+def test_latency_field_list_matches_compute_summary_output(
+    small_reference_payload: dict,
+) -> None:
+    """Guard: ``LATENCY_COST_FIELDS`` must be exactly the float cost fields
+    ``_compute_summary`` emits, and must not overlap the integer list."""
+    cost = small_reference_payload["summary"]["cost"]
+    floats = {
+        key
+        for key, value in cost.items()
+        if isinstance(value, float) and not isinstance(value, bool)
+    }
+    assert set(s9.LATENCY_COST_FIELDS) == floats
+    assert not set(s9.LATENCY_COST_FIELDS) & set(s9.SUMMABLE_COST_FIELDS)
+
+
+def test_missing_shard_latency_field_is_rejected(
+    small_reference_payload: dict,
+) -> None:
+    """F-1: the schema types ``summary.cost`` as a bare object, so a shard may
+    legally omit a latency field. The merge refuses it rather than skipping
+    the check -- skipping would reopen the hole F-1 closes."""
+    shards = make_shards(small_reference_payload, 3)
+    del shards[1]["summary"]["cost"]["total_judge_latency_sec"]
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    message = str(excinfo.value)
+    assert "total_judge_latency_sec" in message
+    assert "<missing>" in message
+
+
+def test_non_numeric_shard_latency_is_rejected(
+    small_reference_payload: dict,
+) -> None:
+    """F-1: a string in a latency field is refused, not coerced."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["summary"]["cost"]["total_judge_latency_sec"] = "11206.15"
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "must be a number" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def _write_shards(tmp_path: Path, shards: list[dict]) -> list[Path]:
+    paths = []
+    for index, shard in enumerate(shards):
+        path = tmp_path / f"shard_{index}.json"
+        path.write_text(json.dumps(shard), encoding="utf-8")
+        paths.append(path)
+    return paths
+
+
+def test_cli_round_trip_writes_a_valid_final_payload(
+    small_reference_payload: dict, grade_schema: dict, tmp_path: Path
+) -> None:
+    paths = _write_shards(tmp_path, make_shards(small_reference_payload, 3))
+    out = tmp_path / "merged.json"
+    code = s9.main([*[str(p) for p in paths], "--output", str(out)])
+    assert code == 0
+    written = json.loads(out.read_text(encoding="utf-8"))
+    validate_grade_payload(written, grade_schema)
+    assert written["run_status"] == "final"
+    assert len(written["tasks"]) == SMALL_TASK_COUNT
+    assert (
+        written["summary"]["openai_compat"]["avg_score_pct"]
+        == small_reference_payload["summary"]["openai_compat"]["avg_score_pct"]
+    )
+
+
+def test_cli_records_file_digests_in_provenance(
+    small_reference_payload: dict, tmp_path: Path
+) -> None:
+    import hashlib
+
+    paths = _write_shards(tmp_path, make_shards(small_reference_payload, 2))
+    out = tmp_path / "merged.json"
+    assert s9.main([*[str(p) for p in paths], "--output", str(out)]) == 0
+    written = json.loads(out.read_text(encoding="utf-8"))
+    expected = {
+        hashlib.sha256(path.read_bytes()).hexdigest() for path in paths
+    }
+    assert {
+        entry["grade_file_sha256"] for entry in written["shard_provenance"]
+    } == expected
+
+
+def test_cli_refuses_to_overwrite_without_force(
+    small_reference_payload: dict, tmp_path: Path
+) -> None:
+    paths = _write_shards(tmp_path, make_shards(small_reference_payload, 2))
+    out = tmp_path / "merged.json"
+    out.write_text("{}", encoding="utf-8")
+    code = s9.main([*[str(p) for p in paths], "--output", str(out)])
+    assert code == 1
+    assert out.read_text(encoding="utf-8") == "{}"
+
+
+def test_cli_overwrites_with_force(
+    small_reference_payload: dict, tmp_path: Path
+) -> None:
+    paths = _write_shards(tmp_path, make_shards(small_reference_payload, 2))
+    out = tmp_path / "merged.json"
+    out.write_text("{}", encoding="utf-8")
+    code = s9.main([*[str(p) for p in paths], "--output", str(out), "--force"])
+    assert code == 0
+    assert json.loads(out.read_text(encoding="utf-8"))["run_status"] == "final"
+
+
+def test_cli_rejects_repeated_shard_paths(
+    small_reference_payload: dict, tmp_path: Path
+) -> None:
+    paths = _write_shards(tmp_path, make_shards(small_reference_payload, 2))
+    out = tmp_path / "merged.json"
+    code = s9.main(
+        [str(paths[0]), str(paths[0]), str(paths[1]), "--output", str(out)]
+    )
+    assert code == 1
+    assert not out.exists()
+
+
+def test_cli_returns_nonzero_and_writes_nothing_on_merge_failure(
+    small_reference_payload: dict, tmp_path: Path
+) -> None:
+    """§E-6: a failed merge must not leave a partial artifact behind."""
+    shards = make_shards(small_reference_payload, 3)
+    shards[1]["judge"]["config_hash"] = "deadbeefdeadbeef"
+    paths = _write_shards(tmp_path, shards)
+    out = tmp_path / "merged.json"
+    code = s9.main([*[str(p) for p in paths], "--output", str(out)])
+    assert code == 1
+    assert not out.exists()
+
+
+def test_cli_rejects_an_incomplete_shard_set(
+    small_reference_payload: dict, tmp_path: Path
+) -> None:
+    shards = make_shards(small_reference_payload, 3)
+    paths = _write_shards(tmp_path, shards[:2])
+    out = tmp_path / "merged.json"
+    assert s9.main([*[str(p) for p in paths], "--output", str(out)]) == 1
+    assert not out.exists()
+
+
+def test_load_shard_file_returns_payload_and_file_digest(
+    small_reference_payload: dict, tmp_path: Path
+) -> None:
+    import hashlib
+
+    shard = make_shards(small_reference_payload, 2)[0]
+    path = tmp_path / "one.json"
+    path.write_text(json.dumps(shard), encoding="utf-8")
+    payload, digest = s9.load_shard_file(path)
+    assert payload["run_status"] == "partial"
+    assert digest == hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_load_shard_file_reports_unparseable_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        s9.load_shard_file(path)
+    assert "could not parse" in str(excinfo.value)
+
+
+def test_parse_args_requires_output() -> None:
+    with pytest.raises(SystemExit):
+        s9.parse_args(["shard0.json"])
+
+
+def test_parse_args_accepts_the_documented_flags() -> None:
+    args = s9.parse_args(
+        ["a.json", "b.json", "--output", "out.json", "--strict-routes", "--force"]
+    )
+    assert args.shards == ["a.json", "b.json"]
+    assert args.output == "out.json"
+    assert args.strict_routes is True
+    assert args.force is True

--- a/data/grades/_diagnostic/29d5623a5cec85eb38f21fb73a2f3b06c66ed6a5fd6fd95948b979cd70a70bc9/grade__233124fc9c26e453b906d82429fc0f6387a14c70586639ad428685146e5b4da0.analysis.md
+++ b/data/grades/_diagnostic/29d5623a5cec85eb38f21fb73a2f3b06c66ed6a5fd6fd95948b979cd70a70bc9/grade__233124fc9c26e453b906d82429fc0f6387a14c70586639ad428685146e5b4da0.analysis.md
@@ -39,9 +39,9 @@
 - baseline caveat: schema 1.0 pre-perception payload; mini metrics are a main-judge-only reference, not a Sol Max multiplier
 - anchor integrity: passed (blockers=[])
 - targetable finalization errors: baseline=22, observed=1, targetable_status=improved, other={}, status=improved
-- audio wiring: calls=0, status=failed_no_audio_calls
+- audio wiring: calls=0, output_tokens=0, applicability=not_applicable (audio_files=0, path_bearing_items=237), status=not_applicable
 - visual budget: task_visual_budget_exceeded=0, status=passed
-- full-run gate: blocked (blockers=['audio_wiring_not_exercised', 'at_or_above_44h_envelope'])
+- full-run gate: blocked (blockers=['at_or_above_44h_envelope'])
 - mini main-judge-only reference: calls=234 → 657 (ratio=2.807692), latency=2449.19944s → 4568.33923s (ratio=1.865238); not a Sol Max multiplier
 
 | component | anchor latency (s) | scale | projected hours | normalization |

--- a/scripts/__tests__/test_analyze_grade_run.py
+++ b/scripts/__tests__/test_analyze_grade_run.py
@@ -463,6 +463,9 @@ def _anchor4_projection_grade() -> dict:
             "perception_total_latency_ms": 0,
             "usage_complete": True,
             "error": None,
+            # Audio evidence in the corpus, so applicability is "applicable"
+            # and these anchor cases keep testing wiring, not corpus content.
+            "reference_files_excluded": ["briefing-call.m4a"],
             "items": [],
         })
     task_hash = hashlib.sha256(
@@ -634,7 +637,14 @@ def test_anchor4_projection_separates_modalities_and_preregistered_gates(
     assert projection["components"]["audio"]["projected_hours"] == 0.062
     assert projection["projected_220_hours"] == 4.0991
     assert projection["envelope_status"] == "below_44h_envelope"
-    assert projection["audio_wiring"] == {"call_count": 1, "status": "passed"}
+    assert projection["audio_wiring"] == {
+        "call_count": 1,
+        "output_tokens": 50,
+        "status": "passed",
+        "applicability": "applicable",
+        "audio_file_count": 4,
+        "path_bearing_items": 0,
+    }
     assert projection["visual_budget"] == {
         "task_visual_budget_exceeded": 0,
         "status": "passed",
@@ -688,7 +698,11 @@ def test_anchor4_projection_blocks_dead_audio_and_visual_budget_error(
 
     assert projection["audio_wiring"] == {
         "call_count": 0,
+        "output_tokens": 0,
         "status": "failed_no_audio_calls",
+        "applicability": "applicable",
+        "audio_file_count": 4,
+        "path_bearing_items": 0,
     }
     assert projection["visual_budget"] == {
         "task_visual_budget_exceeded": 1,
@@ -983,6 +997,203 @@ def test_anchor4_projection_rejects_reordered_tasks_with_recomputed_hash(
         projection["full_run_gate"]["blockers"]
     )
     assert projection["full_run_gate"]["status"] == "blocked"
+
+
+def test_audio_extension_mirror_matches_core_media_types():
+    """G-A A-4: the mirrored extension set is identical to core's own set."""
+    module = _load_module()
+    batch_runner = REPO_ROOT / "batch-runner"
+    sys.path.insert(0, str(batch_runner))
+    try:
+        from core.media_types import GRADER_AUDIO_EXTENSIONS
+    finally:
+        sys.path.remove(str(batch_runner))
+
+    assert module.GRADER_AUDIO_EXTENSIONS == GRADER_AUDIO_EXTENSIONS
+
+
+def test_audio_applicability_is_unknown_without_path_fields(tmp_path: Path):
+    """G-A A-2: no path evidence stays undecided and keeps a gate blocker."""
+    grade = _anchor4_projection_grade()
+    for task in grade["tasks"]:
+        task.pop("reference_files_excluded", None)
+
+    projection = _run(tmp_path, grade)["this"]["modality_projection"]
+
+    assert projection["audio_wiring"] == {
+        "call_count": 1,
+        "output_tokens": 50,
+        "status": "indeterminate",
+        "applicability": "unknown",
+        "audio_file_count": 0,
+        "path_bearing_items": 0,
+    }
+    assert "audio_wiring_indeterminate" in projection["full_run_gate"]["blockers"]
+    assert projection["full_run_gate"]["status"] == "blocked"
+
+
+def test_audio_applicability_is_not_applicable_when_paths_carry_no_audio(
+    tmp_path: Path,
+):
+    """G-A A-2: paths present but silent means no blocker, only a note."""
+    grade = _anchor4_projection_grade()
+    for task in grade["tasks"]:
+        task.pop("reference_files_excluded", None)
+    first = grade["tasks"][0]
+    first["items"] = [
+        item for item in first["items"]
+        if item.get("routing_modality") != "audio"
+    ]
+    first["items"][0]["selected_paths"] = ["report.xlsx", "chart.png"]
+
+    projection = _run(tmp_path, grade)["this"]["modality_projection"]
+
+    assert projection["audio_wiring"]["applicability"] == "not_applicable"
+    assert projection["audio_wiring"]["audio_file_count"] == 0
+    assert projection["audio_wiring"]["path_bearing_items"] == 1
+    assert projection["audio_wiring"]["status"] == "not_applicable"
+    assert "audio_wiring_not_exercised" not in (
+        projection["full_run_gate"]["blockers"]
+    )
+    assert "audio_wiring_indeterminate" not in (
+        projection["full_run_gate"]["blockers"]
+    )
+
+
+def test_both_projection_paths_report_the_same_audio_state(tmp_path: Path):
+    """G-A A-5: normalized and blocked projections agree on audio state."""
+    normalized = _run(tmp_path, _anchor4_projection_grade())["this"]
+
+    blocked_grade = _anchor4_projection_grade()
+    blocked_grade["tasks"].reverse()
+    blocked_grade["expected_ordered_task_ids_sha256"] = hashlib.sha256(
+        json.dumps(
+            [task["task_id"] for task in blocked_grade["tasks"]],
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    blocked = _run(tmp_path, blocked_grade)["this"]
+
+    assert blocked["modality_projection"]["anchor_integrity"]["status"] == "failed"
+    assert blocked["modality_projection"]["projected_220_hours"] is None
+    assert (
+        blocked["modality_projection"]["audio_wiring"]
+        == normalized["modality_projection"]["audio_wiring"]
+    )
+    assert (
+        blocked["modality_projection"]["audio_wiring"]["applicability"]
+        == "applicable"
+    )
+
+
+def test_audio_calls_that_all_errored_are_blocked_separately(tmp_path: Path):
+    """G-B B-1/B-2: calls with zero output tokens block as audio_calls_all_failed."""
+    grade = _anchor4_projection_grade()
+    audio_item = next(
+        item for item in grade["tasks"][0]["items"]
+        if item.get("routing_modality") == "audio"
+    )
+    audio_item["perception_output_tokens"] = 0
+
+    projection = _run(tmp_path, grade)["this"]["modality_projection"]
+
+    assert projection["audio_wiring"]["applicability"] == "applicable"
+    assert projection["audio_wiring"]["call_count"] == 1
+    assert projection["audio_wiring"]["output_tokens"] == 0
+    assert projection["audio_wiring"]["status"] == "failed_all_calls_errored"
+    assert "audio_calls_all_failed" in projection["full_run_gate"]["blockers"]
+    assert "audio_wiring_not_exercised" not in (
+        projection["full_run_gate"]["blockers"]
+    )
+    assert projection["full_run_gate"]["status"] == "blocked"
+
+
+def test_envelope_status_strings_match_legacy_literals_at_44h():
+    """G-C C-2: derived envelope labels equal the pre-existing 44h literals."""
+    module = _load_module()
+    hours = module.DEFAULT_CHUNK_ENVELOPE_HOURS
+
+    assert hours == 44
+    assert module._envelope_status_at_or_above(hours) == "at_or_above_44h_envelope"
+    assert module._envelope_status_below(hours) == "below_44h_envelope"
+    assert module._envelope_status_sharded_below(hours) == (
+        "sharded_below_44h_envelope"
+    )
+
+
+def test_normalized_and_fallback_paths_share_one_envelope_value(tmp_path: Path):
+    """G-C C-1/C-3: both projection routes read the same envelope, not a literal."""
+    module = _load_module()
+    normalized = _run(tmp_path, _anchor4_projection_grade())["this"]
+
+    fallback_grade = _grade_json(n_tasks=1)
+    fallback_grade["tasks"][0]["grading_wall_time_ms"] = 3_600_000
+    fallback = _run(tmp_path, fallback_grade)["this"]
+
+    assert normalized["projection_method"] == "modality_normalized_v1"
+    assert fallback["projection_method"] == "task_count_fallback"
+    assert fallback["modality_projection"] is None
+    assert (
+        fallback["shard_projection"]["chunk_envelope_hours"]
+        == normalized["modality_projection"]["chunk_envelope_hours"]
+        == module.DEFAULT_CHUNK_ENVELOPE_HOURS
+    )
+    assert fallback["projected_220_wall_hours"] >= 44
+    assert fallback["projection_status"] == "at_or_above_44h_envelope"
+
+
+def test_shard_count_one_leaves_gate_output_unchanged(tmp_path: Path):
+    """G-D D-2: the default shard count reproduces the unsharded run exactly."""
+    grade = _anchor4_projection_grade()
+    payload = tmp_path / "default_shard.json"
+    payload.write_text(json.dumps(grade))
+
+    def _analysis(*extra: str) -> str:
+        out = tmp_path / f"out{len(extra)}.md"
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), str(payload), "--out", str(out), *extra],
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == 0, completed.stderr
+        return out.read_text(encoding="utf-8")
+
+    assert _analysis() == _analysis("--shard-count", "1")
+    assert "shard_count=" not in _analysis()
+    assert "per_shard" not in _analysis()
+
+
+def test_declared_shard_count_records_total_and_per_shard_hours(tmp_path: Path):
+    """G-D D-3/D-4/D-5: declared shards report both hours and the cost caveat."""
+    grade = _anchor4_projection_grade()
+    for task in grade["tasks"]:
+        task["grading_wall_time_ms"] = 1_000_000
+    payload = tmp_path / "sharded.json"
+    payload.write_text(json.dumps(grade))
+    out = tmp_path / "sharded.md"
+    shard_args = [sys.executable, str(SCRIPT), str(payload), "--shard-count", "9"]
+    emitted = subprocess.run([*shard_args, "--json"], capture_output=True, text=True)
+    rendered = subprocess.run(
+        [*shard_args, "--out", str(out)], capture_output=True, text=True
+    )
+    assert emitted.returncode == 0, emitted.stderr
+    assert rendered.returncode == 0, rendered.stderr
+    projection = json.loads(emitted.stdout)["this"]["modality_projection"]
+    shard = projection["shard_projection"]
+    markdown = out.read_text(encoding="utf-8")
+
+    assert shard["shard_count"] == 9
+    assert shard["max_shard_task_count"] == 25
+    assert shard["projected_total_hours"] == projection["projected_220_hours"]
+    assert shard["projected_per_shard_hours"] < shard["projected_total_hours"]
+    assert shard["per_shard_method"] == "uniform_task_cost_assumption"
+    assert "not an upper bound" in shard["per_shard_caveat"]
+    assert projection["envelope_status"] == "sharded_below_44h_envelope"
+    assert "at_or_above_44h_envelope" not in projection["full_run_gate"]["blockers"]
+    assert f"{shard['projected_total_hours']}" in markdown
+    assert f"{shard['projected_per_shard_hours']}" in markdown
+    assert "shard_count=9" in markdown
+    assert "uniform_task_cost_assumption" in markdown
 
 
 def test_markdown_contains_key_sections(tmp_path: Path):

--- a/scripts/analyze_grade_run.py
+++ b/scripts/analyze_grade_run.py
@@ -50,6 +50,30 @@ ANALYSIS_NAME_MAX_BYTES = 255
 ANALYSIS_FALLBACK_PREFIX = "grade__"
 ANALYSIS_SUFFIX = ".analysis.md"
 
+# G-C — single source for the chunk envelope. The contract value wins; this
+# constant is the fallback for payloads that carry no anchor contract, so the
+# projection path and the task-count fallback path can never disagree.
+DEFAULT_CHUNK_ENVELOPE_HOURS = 44
+FULL_RUN_TASK_COUNT = 220
+
+# G-A — Mirror core.media_types.GRADER_AUDIO_EXTENSIONS so this script stays
+# self-contained and can analyze payloads produced by a revision whose `core`
+# package is not importable here. Precedent: scripts/backfill_sign_aware.py.
+# scripts/__tests__/test_analyze_grade_run.py asserts this mirror against the
+# real constant; that test is the only guarantee against drift.
+GRADER_AUDIO_EXTENSIONS = frozenset({
+    ".wav",
+    ".mp3",
+    ".flac",
+    ".ogg",
+    ".m4a",
+    ".aac",
+})
+# Path-bearing fields. Judged and excluded files both answer "does the corpus
+# contain audio at all", so excluded reference files are scanned too.
+AUDIO_ITEM_PATH_FIELDS = ("selected_paths", "support_paths_visible")
+AUDIO_TASK_PATH_FIELDS = ("reference_files_excluded",)
+
 
 def _ordered_task_ids_sha256(task_ids: list[str]) -> str:
     encoded = json.dumps(
@@ -817,6 +841,186 @@ def _anchor_usage(values: dict[str, int | float] | None) -> dict:
     }
 
 
+def _is_audio_path(path: object) -> bool:
+    """True when `path` ends in a mirrored grader audio extension."""
+    if not isinstance(path, str):
+        return False
+    return os.path.splitext(path)[1].lower() in GRADER_AUDIO_EXTENSIONS
+
+
+def _corpus_audio_applicability(grade: dict) -> dict:
+    """G-A — decide whether the corpus can answer the audio-wiring question.
+
+    Separates "the wiring is broken" from "there is no audio to judge". The
+    three states are deliberately asymmetric: absence of path evidence yields
+    ``unknown`` (blocker kept), never ``not_applicable``, because a payload
+    that simply omits path fields tells us nothing about the corpus.
+    """
+    audio_file_count = 0
+    path_bearing_items = 0
+    scanned_path_count = 0
+    tasks = grade.get("tasks") if isinstance(grade.get("tasks"), list) else []
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        for field in AUDIO_TASK_PATH_FIELDS:
+            values = task.get(field)
+            if not isinstance(values, list):
+                continue
+            for path in values:
+                scanned_path_count += 1
+                audio_file_count += _is_audio_path(path)
+        items = task.get("items") if isinstance(task.get("items"), list) else []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            children = [
+                child for child in (item.get("child_grades") or [])
+                if isinstance(child, dict)
+            ]
+            item_has_path_field = False
+            for holder in (item, *children):
+                for field in AUDIO_ITEM_PATH_FIELDS:
+                    values = holder.get(field)
+                    if not isinstance(values, list):
+                        continue
+                    item_has_path_field = True
+                    for path in values:
+                        scanned_path_count += 1
+                        audio_file_count += _is_audio_path(path)
+            path_bearing_items += item_has_path_field
+
+    if audio_file_count > 0:
+        applicability = "applicable"
+    elif path_bearing_items == 0:
+        applicability = "unknown"
+    else:
+        applicability = "not_applicable"
+    return {
+        "audio_file_count": audio_file_count,
+        "path_bearing_items": path_bearing_items,
+        "scanned_path_count": scanned_path_count,
+        "applicability": applicability,
+    }
+
+
+def _audio_wiring_report(
+    audio_applicability: dict,
+    audio_call_count: int,
+    audio_output_tokens: int,
+) -> tuple[dict, list[str]]:
+    """G-A/G-B — map corpus applicability plus usage onto status and blockers.
+
+    ``applicable`` additionally requires ``output_tokens > 0``: a provider call
+    that raised returns ``api_call_count=1`` with ``output_tokens`` still at its
+    initial 0, so counting calls alone lets an all-failed run open the gate.
+    """
+    state = audio_applicability["applicability"]
+    if state == "applicable":
+        if audio_call_count == 0:
+            status = "failed_no_audio_calls"
+            blockers = ["audio_wiring_not_exercised"]
+        elif audio_output_tokens <= 0:
+            status = "failed_all_calls_errored"
+            blockers = ["audio_calls_all_failed"]
+        else:
+            status = "passed"
+            blockers = []
+    elif state == "unknown":
+        status = "indeterminate"
+        blockers = ["audio_wiring_indeterminate"]
+    else:
+        status = "not_applicable"
+        blockers = []
+    return (
+        {
+            "call_count": audio_call_count,
+            "output_tokens": audio_output_tokens,
+            "status": status,
+            "applicability": state,
+            "audio_file_count": audio_applicability["audio_file_count"],
+            "path_bearing_items": audio_applicability["path_bearing_items"],
+        },
+        blockers,
+    )
+
+
+def _envelope_hours(contract: object) -> int | float:
+    """G-C — the contract envelope, falling back to the module constant."""
+    if isinstance(contract, dict):
+        hours = contract.get("chunk_envelope_hours")
+        if isinstance(hours, (int, float)) and not isinstance(hours, bool):
+            return hours
+    return DEFAULT_CHUNK_ENVELOPE_HOURS
+
+
+def _envelope_status_at_or_above(envelope_hours: int | float) -> str:
+    """G-C — derive the at-or-above label from the envelope value."""
+    return f"at_or_above_{envelope_hours:g}h_envelope"
+
+
+def _envelope_status_below(envelope_hours: int | float) -> str:
+    """G-C — derive the below label from the envelope value."""
+    return f"below_{envelope_hours:g}h_envelope"
+
+
+def _envelope_status_sharded_below(envelope_hours: int | float) -> str:
+    """G-D — derive the sharded-below label from the envelope value."""
+    return f"sharded_below_{envelope_hours:g}h_envelope"
+
+
+def _shard_projection(
+    projected_total_hours: float | None,
+    shard_count: int,
+    envelope_hours: int | float,
+) -> dict:
+    """G-D — record total and per-shard hours for a declared shard count.
+
+    ``max_shard_task_count`` uses ceil because stride sharding gives the
+    leading shards the remainder, so the largest shard is what must fit.
+    """
+    max_shard_task_count = -(-FULL_RUN_TASK_COUNT // shard_count)
+    projected_per_shard_hours = (
+        round(
+            projected_total_hours * max_shard_task_count / FULL_RUN_TASK_COUNT,
+            4,
+        )
+        if projected_total_hours is not None else None
+    )
+    return {
+        "shard_count": shard_count,
+        "max_shard_task_count": max_shard_task_count,
+        "projected_total_hours": projected_total_hours,
+        "projected_per_shard_hours": projected_per_shard_hours,
+        "chunk_envelope_hours": envelope_hours,
+        "per_shard_method": (
+            "uniform_task_cost_assumption" if shard_count > 1 else "not_sharded"
+        ),
+        "per_shard_caveat": (
+            "average-based estimate, not an upper bound: per-task cost is not "
+            "uniform (that is why modality normalization exists), so one shard "
+            "can receive a costlier subset than this figure implies"
+        ),
+    }
+
+
+def _envelope_status_for(
+    projected_total_hours: float,
+    envelope_hours: int | float,
+    shard_projection: dict,
+) -> str:
+    """G-C/G-D — envelope verdict; shard-aware only when shard_count > 1."""
+    if shard_projection["shard_count"] <= 1:
+        return (
+            _envelope_status_at_or_above(envelope_hours)
+            if projected_total_hours >= envelope_hours
+            else _envelope_status_below(envelope_hours)
+        )
+    if shard_projection["projected_per_shard_hours"] >= envelope_hours:
+        return _envelope_status_at_or_above(envelope_hours)
+    return _envelope_status_sharded_below(envelope_hours)
+
+
 def _blocked_modality_projection(
     contract: dict,
     task_anchors: list[dict],
@@ -824,6 +1028,8 @@ def _blocked_modality_projection(
     total_main_latency_sec: float,
     judge_error_types: Counter,
     blockers: list[str],
+    audio_applicability: dict,
+    shard_count: int = 1,
 ) -> dict:
     visual_usage = perception_usage.get("visual") or {}
     audio_usage = perception_usage.get("audio") or {}
@@ -861,6 +1067,14 @@ def _blocked_modality_projection(
         if isinstance(baseline_latency, (int, float)) else None
     )
     audio_call_count = int(audio_usage.get("call_count", 0) or 0)
+    audio_output_tokens = int(audio_usage.get("output_tokens", 0) or 0)
+    audio_wiring, _audio_blockers = _audio_wiring_report(
+        audio_applicability,
+        audio_call_count,
+        audio_output_tokens,
+    )
+    envelope_hours = _envelope_hours(contract)
+    shard_projection = _shard_projection(None, shard_count, envelope_hours)
     visual_budget_errors = judge_error_types.get(
         "task_visual_budget_exceeded",
         0,
@@ -901,8 +1115,9 @@ def _blocked_modality_projection(
             },
         },
         "projected_220_hours": None,
-        "chunk_envelope_hours": contract.get("chunk_envelope_hours"),
+        "chunk_envelope_hours": envelope_hours,
         "envelope_status": "incomplete_anchor_payload",
+        "shard_projection": shard_projection,
         "unknown_perception": unknown_volume,
         "diagnostic": {
             "baseline_targetable_errors": baseline_targetable_errors,
@@ -911,10 +1126,7 @@ def _blocked_modality_projection(
             "non_targetable_errors": non_targetable_errors,
             "status": "inconclusive_invalid_anchor_payload",
         },
-        "audio_wiring": {
-            "call_count": audio_call_count,
-            "status": "passed" if audio_call_count > 0 else "failed_no_audio_calls",
-        },
+        "audio_wiring": audio_wiring,
         "visual_budget": {
             "task_visual_budget_exceeded": visual_budget_errors,
             "status": "passed" if visual_budget_errors == 0 else "failed",
@@ -983,6 +1195,8 @@ def _modality_normalized_projection(
     perception_usage: dict[str, dict[str, int | float]],
     total_main_latency_sec: float,
     judge_error_types: Counter,
+    audio_applicability: dict,
+    shard_count: int = 1,
 ) -> dict | None:
     contract = grade.get("anchor_projection")
     if contract is None:
@@ -1005,6 +1219,8 @@ def _modality_normalized_projection(
             total_main_latency_sec,
             judge_error_types,
             blockers,
+            audio_applicability,
+            shard_count,
         )
     if not isinstance(contract, dict):
         return _blocked_modality_projection(
@@ -1014,6 +1230,8 @@ def _modality_normalized_projection(
             total_main_latency_sec,
             judge_error_types,
             ["anchor_schema_invalid"],
+            audio_applicability,
+            shard_count,
         )
 
     schema_blockers = _anchor_schema_blockers(grade)
@@ -1025,6 +1243,8 @@ def _modality_normalized_projection(
             total_main_latency_sec,
             judge_error_types,
             schema_blockers,
+            audio_applicability,
+            shard_count,
         )
 
     task_count = len(task_anchors)
@@ -1167,17 +1387,24 @@ def _modality_normalized_projection(
         "latency_sec": round(unknown_latency_sec, 5),
     }
     has_unknown = any(unknown_volume.values())
-    envelope_hours = contract["chunk_envelope_hours"]
+    envelope_hours = _envelope_hours(contract)
+    shard_projection = _shard_projection(
+        projected_hours,
+        shard_count,
+        envelope_hours,
+    )
     if anchor_integrity_blockers:
         envelope_status = "incomplete_anchor_payload"
     elif has_unknown:
         envelope_status = "incomplete_unknown_perception"
     elif measured_wall_sec is None:
         envelope_status = "incomplete_missing_task_wall"
-    elif projected_hours >= envelope_hours:
-        envelope_status = "at_or_above_44h_envelope"
     else:
-        envelope_status = "below_44h_envelope"
+        envelope_status = _envelope_status_for(
+            projected_hours,
+            envelope_hours,
+            shard_projection,
+        )
 
     targetable_errors = (
         judge_error_types.get("final_json_parse_failed", 0)
@@ -1206,6 +1433,12 @@ def _modality_normalized_projection(
     diagnostic_status = targetable_status
 
     audio_call_count = int(audio_usage.get("call_count", 0) or 0)
+    audio_output_tokens = int(audio_usage.get("output_tokens", 0) or 0)
+    audio_wiring, audio_blockers = _audio_wiring_report(
+        audio_applicability,
+        audio_call_count,
+        audio_output_tokens,
+    )
     visual_budget_errors = judge_error_types.get(
         "task_visual_budget_exceeded",
         0,
@@ -1215,14 +1448,14 @@ def _modality_normalized_projection(
         gate_blockers.append("no_finalization_improvement")
     if non_targetable_errors:
         gate_blockers.append("non_targetable_judge_errors_present")
-    if audio_call_count == 0:
-        gate_blockers.append("audio_wiring_not_exercised")
+    gate_blockers.extend(audio_blockers)
     if visual_budget_errors > 0:
         gate_blockers.append("visual_budget_exceeded")
-    if (
-        envelope_status != "below_44h_envelope"
-        and envelope_status != "incomplete_anchor_payload"
-    ):
+    if envelope_status not in {
+        _envelope_status_below(envelope_hours),
+        _envelope_status_sharded_below(envelope_hours),
+        "incomplete_anchor_payload",
+    }:
         gate_blockers.append(envelope_status)
     return {
         "method": contract["method"],
@@ -1244,6 +1477,7 @@ def _modality_normalized_projection(
         "projected_220_hours": projected_hours,
         "chunk_envelope_hours": envelope_hours,
         "envelope_status": envelope_status,
+        "shard_projection": shard_projection,
         "unknown_perception": unknown_volume,
         "diagnostic": {
             "baseline_targetable_errors": baseline_targetable_errors,
@@ -1252,10 +1486,7 @@ def _modality_normalized_projection(
             "non_targetable_errors": non_targetable_errors,
             "status": diagnostic_status,
         },
-        "audio_wiring": {
-            "call_count": audio_call_count,
-            "status": "passed" if audio_call_count > 0 else "failed_no_audio_calls",
-        },
+        "audio_wiring": audio_wiring,
         "visual_budget": {
             "task_visual_budget_exceeded": visual_budget_errors,
             "status": "passed" if visual_budget_errors == 0 else "failed",
@@ -1382,7 +1613,7 @@ def _effective_component(
     }
 
 
-def analyze(path: Path) -> dict:
+def analyze(path: Path, shard_count: int = 1) -> dict:
     grade = json.loads(path.read_text())
     tasks = grade.get("tasks", [])
     summary = grade.get("summary", {})
@@ -1495,17 +1726,21 @@ def analyze(path: Path) -> dict:
     judge_error_types = Counter()
     for anchor in task_anchors:
         judge_error_types.update(anchor["judge_error_types"])
+    audio_applicability = _corpus_audio_applicability(grade)
     modality_projection = _modality_normalized_projection(
         grade,
         task_anchors,
         perception_usage,
         total_main_latency_sec,
         judge_error_types,
+        audio_applicability,
+        shard_count,
     )
     if modality_projection is not None:
         projected_220_wall_hours = modality_projection["projected_220_hours"]
         projection_status = modality_projection["envelope_status"]
         projection_method = modality_projection["method"]
+        shard_projection = modality_projection["shard_projection"]
     else:
         measured_task_wall_times = [
             anchor["wall_clock_sec"]
@@ -1516,12 +1751,22 @@ def analyze(path: Path) -> dict:
             round(statistics.mean(measured_task_wall_times) * 220 / 3600, 2)
             if measured_task_wall_times else None
         )
+        # G-C — same envelope source as the projection path, so changing the
+        # contract value can never leave this branch behind.
+        envelope_hours = _envelope_hours(grade.get("anchor_projection"))
+        shard_projection = _shard_projection(
+            projected_220_wall_hours,
+            shard_count,
+            envelope_hours,
+        )
         if projected_220_wall_hours is None:
             projection_status = "unmeasured"
-        elif projected_220_wall_hours >= 44:
-            projection_status = "at_or_above_44h_envelope"
         else:
-            projection_status = "below_44h_envelope"
+            projection_status = _envelope_status_for(
+                projected_220_wall_hours,
+                envelope_hours,
+                shard_projection,
+            )
         projection_method = "task_count_fallback"
 
     # PR3 Step 0 — effective (cache-discounted) cost. Skipped if the run
@@ -1634,6 +1879,8 @@ def analyze(path: Path) -> dict:
         "projected_220_wall_hours": projected_220_wall_hours,
         "projection_status": projection_status,
         "projection_method": projection_method,
+        "shard_projection": shard_projection,
+        "audio_applicability": audio_applicability,
         "modality_projection": modality_projection,
     }
 
@@ -1757,6 +2004,18 @@ def render_markdown(a: dict, base: dict | None = None) -> str:
         f"{a['projected_220_wall_hours']} ({a['projection_status']}; "
         f"method={a['projection_method']})"
     )
+    shard = a.get("shard_projection")
+    if shard is not None and shard["shard_count"] > 1:
+        lines.append(
+            "- shard-aware projection: "
+            f"shard_count={shard['shard_count']}, "
+            f"max_shard_task_count={shard['max_shard_task_count']}, "
+            f"projected_total_hours={shard['projected_total_hours']}h, "
+            f"projected_per_shard_hours="
+            f"{shard['projected_per_shard_hours']}h "
+            f"(per_shard_method={shard['per_shard_method']})"
+        )
+        lines.append(f"- per-shard caveat: {shard['per_shard_caveat']}")
     projection = a.get("modality_projection")
     if projection is not None:
         lines.append("")
@@ -1776,10 +2035,15 @@ def render_markdown(a: dict, base: dict | None = None) -> str:
             f"other={diagnostic['non_targetable_errors']}, "
             f"status={diagnostic['status']}"
         )
+        audio_wiring = projection["audio_wiring"]
         lines.append(
             "- audio wiring: "
-            f"calls={projection['audio_wiring']['call_count']}, "
-            f"status={projection['audio_wiring']['status']}"
+            f"calls={audio_wiring['call_count']}, "
+            f"output_tokens={audio_wiring['output_tokens']}, "
+            f"applicability={audio_wiring['applicability']} "
+            f"(audio_files={audio_wiring['audio_file_count']}, "
+            f"path_bearing_items={audio_wiring['path_bearing_items']}), "
+            f"status={audio_wiring['status']}"
         )
         lines.append(
             "- visual budget: "
@@ -1814,8 +2078,22 @@ def render_markdown(a: dict, base: dict | None = None) -> str:
             )
         lines.append(
             f"- component total: {projection['projected_220_hours']}h; "
-            f"44h gate={projection['envelope_status']}"
+            f"{projection['chunk_envelope_hours']:g}h gate="
+            f"{projection['envelope_status']}"
         )
+        projection_shard = projection["shard_projection"]
+        if projection_shard["shard_count"] > 1:
+            lines.append(
+                "- shard-aware envelope: "
+                f"projected_total_hours="
+                f"{projection_shard['projected_total_hours']}h, "
+                f"projected_per_shard_hours="
+                f"{projection_shard['projected_per_shard_hours']}h "
+                f"over shard_count={projection_shard['shard_count']} "
+                f"(max_shard_task_count="
+                f"{projection_shard['max_shard_task_count']}, "
+                f"per_shard_method={projection_shard['per_shard_method']})"
+            )
     lines.append("")
     lines.append("## Cost estimate")
     lines.append(f"- raw: {_fmt_cost(a['cost_estimate'])}")
@@ -1859,10 +2137,32 @@ def render_markdown(a: dict, base: dict | None = None) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _positive_shard_count(value: str) -> int:
+    """Parse --shard-count as an integer >= 1."""
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            "--shard-count must be an integer >= 1"
+        ) from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("--shard-count must be an integer >= 1")
+    return parsed
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("grade_json", type=Path)
     ap.add_argument("--compare", type=Path, default=None, help="Baseline grade JSON for Δ table")
+    ap.add_argument(
+        "--shard-count",
+        type=_positive_shard_count,
+        default=1,
+        help=(
+            "Declared shard count for the full run (default 1). Never inferred "
+            "from the payload: sharding must be declared to be recorded."
+        ),
+    )
     output_group = ap.add_mutually_exclusive_group()
     output_group.add_argument("--out", type=Path, default=None, help="Write markdown to this path (default: stdout)")
     output_group.add_argument(
@@ -1875,8 +2175,8 @@ def main() -> int:
     if args.auto_out and args.json:
         ap.error("--auto-out cannot be combined with --json")
 
-    a = analyze(args.grade_json)
-    base = analyze(args.compare) if args.compare else None
+    a = analyze(args.grade_json, args.shard_count)
+    base = analyze(args.compare, args.shard_count) if args.compare else None
 
     if args.json:
         out = {"this": a, "baseline": base}


### PR DESCRIPTION
## Why

The 220-task grade run projects to **~71.6h** of judge latency against a **44h**
relay envelope (`GRADER_TIME_BUDGET_SEC=14400` × 11 resume chunks). A serial run
cannot finish inside one dispatch chain. Sharding is the only remaining lever
that leaves the reproducibility contract untouched — judge model, reasoning
effort, prompt and rubric all stay pinned.

At `shard_count=9` the corpus splits into slices of ≤25 tasks, putting the
projection at **~8.1h per shard** — two 4h chunks, comfortably inside the relay
envelope.

## Design

**Identity vs. workload.** `tasks` stays the full corpus, because it drives
`expected_task_count`, `expected_ordered_task_ids_sha256` and every resume/cache
guard. Only the slice this process *grades* narrows. A shard emits
`run_status: "partial"` while `completed_run_status` — what a *complete* run of
this config is defined to look like, and what the guards compare against — is
unchanged. Sharding deliberately does not feed `diagnostic_run`: it changes who
grades what, not what is in scope.

**Identity vs. path.** All shards share every identity input *by construction*,
which is precisely what step9 verifies before merging. So only the path can
fork: `resolve_grade_output_path` emits
`<output_root>/_shards/<stem>/shard-NNN-of-NNN.json`, mirroring the existing
`_diagnostic/<scope_sha>/` fork. The cache key is unchanged, each shard's path is
stable across its own rc=7 chunks, and dashboard exclusion is free — `readdir()`
in `scripts/aggregate-grades.mjs:478` is non-recursive and filters on a `.json`
extension, which a `_shards/` directory entry does not have. (A second,
independent defense already exists at line 436: `grading_partial` is excluded by
status.)

**Stride split.** `tasks[i::n]` spreads corpus ordering bias evenly and keeps
shard sizes within one task of each other.

**Resume.** The partial-grade prefix check widens to an ordered *subsequence*.
A serial resume yields a prefix; a shard yields a stride subsequence; every
prefix is a subsequence, so this only loosens. Shard-aware cache/resume branches
still reject a partial belonging to a different slice.

**Merge without a lock.** Each shard, after pushing its own partial, pulls and
looks for all N siblings. The last shard to push is guaranteed to see a complete
set, so a merger always exists. If two race, step9 is deterministic and
order-independent — both produce byte-identical output, and the loser's
`git diff --staged --quiet` makes its commit a no-op. `--force` keeps step9's
existing-output refusal from failing the loser for doing the right thing.

**Path safety.** The merge step derives `FINAL_FILE` from the `_shards/` parent
rather than a hardcoded `data/grades/` prefix, so a run that *also* forks into
`_diagnostic/` merges into its own root instead of hard-failing after the money
is already spent. It rejects `..`, embedded newlines, symlinked shard
directories, symlinked candidates and a symlinked output before writing.

**Blast radius.** `shard_count` is capped at 11 — each shard is an independent
paid relay, so N is also the number of judge workloads billing at once.
Concurrency keys on `shard_index` but deliberately **not** `shard_count`, so
re-dispatching an index under a different N still serializes and two overlapping
slices are never graded — or paid for — simultaneously. `shard_count > 1` is
refused in combination with `tasks_limit`, which would scatter the set across a
`_diagnostic` subtree nothing merges.

**Auto-analyze** now waits for the merge rather than firing on one shard's rc=0,
which would have published an analysis of 1/N of a corpus.

## Verification

| Check | Result |
| --- | --- |
| Full `batch-runner` suite | **3273 passed**, 6 skipped, 45 deselected, exit 0 (baseline 3219 → +54) |
| Changed surface (step8 + step9 + roundtrip) | **332 passed** |
| Focused workflow/shard tests | **57 passed** |
| `scripts/__tests__/` | **118 passed** |
| Workflow YAML parse (all 7) | OK |
| `py_compile` (7 changed/new files) | OK |
| `git diff --check` | clean |
| ruff delta on `step8_grade.py` | 18 → 18 (no new findings) |
| `mypy core/` | untouched by this branch (179 baseline) |
| Merge-step shell smoke (stubbed git/python) | 6/6 cases |

The strongest guarantee is `test_shard_merge_roundtrip.py`: it drives **real**
`step8_grade.main()` invocations with `--shard-count`, feeds the resulting
partials to **real** `step9_merge_shards.main()`, and asserts the merged payload
is field-for-field identical to a serial run — no field missing, extra, or
divergent, save the three that sharding is *expected* to change
(`shard_provenance`, `grading_wall_time_ms`, `graded_at`).

Merge-step smoke cases: 3-shard complete merge; nested `_diagnostic` deriving
its own root; traversal rejected; absolute path rejected; symlinked shard
directory rejected; symlinked output rejected.

## Risk

- **`shard_count=1` is the default** and remains the previous serial behaviour.
  Every new code path is gated behind `shard_count > 1`.
- **`grader_source_hash` is repository-path-sensitive** — it folds the
  repo-relative config path into the digest. Real shards must all check out at
  the same `$GITHUB_WORKSPACE/batch-runner`, which GitHub Actions guarantees.
  step9 rejects the merge if they diverge, so this fails loudly rather than
  silently.
- **Route drift is tolerated by default.** `azure_ai_routes` is an
  order-preserving union and `azure_ai_runtime_fingerprint` is taken from the
  shard holding the canonically-first task. Even a 4-task anchor run already
  observed two distinct grader fingerprints, so a 9-way run will observe more.
  Each shard's own fingerprint is preserved in `shard_provenance`, so drift is
  auditable from the merged artifact alone. `--strict-routes` enforces the
  literal sequential invariant instead.
- **Latency semantics change meaning under sharding.**
  `summary.cost.total_judge_latency_sec` is total judge *work*, not elapsed
  wall-clock; N concurrent shards sum N parallel timelines. Documented at the
  top of `step9_merge_shards.py`. The value stays *recomputed* (not summed) so
  it is serial-identical, and `_check_latency_sums` cross-checks it against the
  shard-reported sum within a rounding tolerance so a hand-edited shard latency
  is rejected rather than silently ignored.
- **`_shard_projection` is an average-based estimate, not an upper bound.**
  Per-task cost is not uniform — that is why modality normalization exists — so
  one shard can draw a costlier subset than the projection implies. The caveat
  is carried in the emitted payload itself.
- **No production dispatch is included or implied by this PR.** Verification was
  performed entirely against stubs and the offline test suite.
