### PR TITLE
feat(grading): let resume chunks inherit the initial paid approval

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -74,6 +74,8 @@ concurrency:
 jobs:
   validate-request:
     runs-on: ubuntu-24.04
+    outputs:
+      approval_inherited: ${{ steps.inherit.outputs.approval_inherited }}
     env:
       GRADE_EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
       GRADE_CONFIG: ${{ inputs.grading_config }}
@@ -190,10 +192,128 @@ jobs:
             exit 1
           fi
 
+      # A resume chunk is not a new spending decision. `rerun_identity` pins the
+      # corpus (task_ids + expected_task_count), so the bill is bounded the
+      # moment chunk 0 is approved. The 4h boundary that splits a shard is an
+      # artifact of the hosted-runner 6h ceiling, not a fresh authorization --
+      # and shard_count is capped at 11 against a ~71.6h serial projection, so
+      # no sharding choice makes a 220-task run fit in one chunk. Demanding a
+      # human click per chunk therefore buys no safety while making the run
+      # depend on somebody being awake every four hours.
+      #
+      # Inheritance is granted only to a chunk that can PROVE it continues an
+      # already-approved lineage. Every check below must pass; any doubt at all
+      # falls back to the Environment gate.
+      - name: Resolve inherited paid approval
+        id: inherit
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The identity the grade job commits partials under. Kept in lockstep
+          # with the `git config user.email` in the commit step below.
+          GRADE_BOT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+        run: |
+          set -uo pipefail
+
+          emit() {
+            echo "approval_inherited=$1" >> "$GITHUB_OUTPUT"
+            echo "[inherit] approval_inherited=$1"
+          }
+          deny() {
+            echo "[inherit] $1 -- requiring the Environment approval"
+            emit false
+            exit 0
+          }
+
+          # This step is an optimisation for chunk >= 1. It must never be able
+          # to fail the job, or a bug here would block chunk 0 -- the path that
+          # does not use inheritance at all. Any unexpected error denies.
+          trap 'deny "unexpected failure near line $LINENO"' ERR
+          set -e
+
+          if [[ "$GRADE_DRY_RUN" != "false" || "$GRADE_PAID_APPROVAL" != "true" ]]; then
+            deny "not a paid request"
+          fi
+          if [[ "$GRADE_RESUME" != "true" ]] || (( 10#$GRADE_RESUME_CHUNK < 1 )); then
+            deny "chunk 0 is the click that authorizes the corpus"
+          fi
+          # Only the in-workflow auto-retrigger dispatches under the bot
+          # identity. A person hand-passing resume=true carries their own login,
+          # and minting a bot dispatch requires merging a workflow to main --
+          # already owner-gated.
+          if [[ "$GITHUB_ACTOR" != "github-actions[bot]" ||
+                "$GITHUB_TRIGGERING_ACTOR" != "github-actions[bot]" ]]; then
+            deny "resume dispatched by '$GITHUB_ACTOR'/'$GITHUB_TRIGGERING_ACTOR', not the auto-retrigger"
+          fi
+
+          CONFIG_B64="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/contents/batch-runner/grading_configs/${GRADE_CONFIG}?ref=${GITHUB_SHA}" \
+            --jq '.content // ""' || true)"
+          if [[ -z "$CONFIG_B64" ]]; then
+            deny "grading config ${GRADE_CONFIG} not readable at ${GITHUB_SHA}"
+          fi
+          if ! printf '%s' "$CONFIG_B64" | base64 -d > "${RUNNER_TEMP}/grading_config.yaml"; then
+            deny "grading config ${GRADE_CONFIG} did not decode"
+          fi
+          CONFIG_NAME="$(awk '
+            /^config_name:[[:space:]]/ {
+              sub(/^config_name:[[:space:]]*/, "")
+              gsub(/^"|"$/, "")
+              print
+              exit
+            }' "${RUNNER_TEMP}/grading_config.yaml")"
+          if [[ ! "$CONFIG_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+            deny "config_name in ${GRADE_CONFIG} is missing or unsafe"
+          fi
+
+          SHARD_FILE="$(printf 'shard-%03d-of-%03d.json' \
+            "$((10#$GRADE_SHARD_INDEX))" "$((10#$GRADE_SHARD_COUNT))")"
+
+          # The partial's own path is the receipt. Its parent stem encodes the
+          # experiment, config name, config hash, rubric SHA, inference SHA and
+          # grader source hash -- so a path match is a full identity match, and
+          # the file can only exist because an approved chunk wrote it.
+          STEMS="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/contents/data/grades/_shards?ref=main" \
+            --jq '.[] | select(.type == "dir") | .name' 2>/dev/null || true)"
+          MATCH=""
+          while IFS= read -r stem; do
+            [[ -n "$stem" ]] || continue
+            [[ "$stem" == "${GRADE_EXPERIMENT_YAML}__"* ]] || continue
+            [[ "$stem" == *"__${CONFIG_NAME}__"* ]] || continue
+            [[ "$stem" == *"__inference_${GRADE_INFERENCE_REVISION}__"* ]] || continue
+            candidate="data/grades/_shards/${stem}/${SHARD_FILE}"
+            if gh api "repos/${GITHUB_REPOSITORY}/contents/${candidate}?ref=main" \
+                 --jq '.sha' >/dev/null 2>&1; then
+              MATCH="$candidate"
+              break
+            fi
+          done <<< "$STEMS"
+          if [[ -z "$MATCH" ]]; then
+            deny "no committed ${SHARD_FILE} for ${GRADE_EXPERIMENT_YAML}/${CONFIG_NAME} at inference ${GRADE_INFERENCE_REVISION}"
+          fi
+
+          AUTHOR_EMAIL="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/commits?path=${MATCH}&sha=main&per_page=1" \
+            --jq '.[0].commit.author.email // ""' || true)"
+          if [[ "$AUTHOR_EMAIL" != "$GRADE_BOT_EMAIL" ]]; then
+            deny "partial ${MATCH} was last written by '${AUTHOR_EMAIL:-unknown}', not the grading job"
+          fi
+
+          echo "[inherit] continuing approved lineage via ${MATCH}"
+          emit true
+
   approve-paid:
     name: Approve paid Sol Max grading (${{ inputs.experiment_yaml }}, ${{ inputs.grading_config }}, chunk ${{ inputs.resume_chunk }}, shard ${{ inputs.shard_index }}/${{ inputs.shard_count }})
     needs: validate-request
-    if: inputs.dry_run == false && inputs.paid_approval == true
+    # Skipped only for a bot-dispatched resume chunk that proved it continues an
+    # already-approved lineage (see "Resolve inherited paid approval").
+    if: >-
+      ${{
+        inputs.dry_run == false &&
+        inputs.paid_approval == true &&
+        needs.validate-request.outputs.approval_inherited != 'true'
+      }}
     runs-on: ubuntu-24.04
     environment:
       name: grading
@@ -310,12 +430,27 @@ jobs:
 
   grade:
     needs: [validate-request, approve-paid]
+    # approve-paid is allowed to be 'skipped' ONLY when validate-request itself
+    # certified the inheritance. Reading the output rather than trusting the
+    # skip means a skip from any other cause still blocks the paid job.
+    #
+    # `!cancelled()` is load-bearing, not decoration: a job whose `needs` was
+    # skipped is skipped too unless its `if` contains a status check function,
+    # so without it this job would never run in exactly the inherited case.
+    # It also keeps a cancelled run from proceeding to spend money.
     if: >-
       ${{
+        !cancelled() &&
         inputs.dry_run == false &&
         inputs.paid_approval == true &&
         needs.validate-request.result == 'success' &&
-        needs.approve-paid.result == 'success'
+        (
+          needs.approve-paid.result == 'success' ||
+          (
+            needs.approve-paid.result == 'skipped' &&
+            needs.validate-request.outputs.approval_inherited == 'true'
+          )
+        )
       }}
     runs-on: ubuntu-24.04
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,49 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Changed
+- **One paid approval now carries a whole shard, not one 4h chunk** - a shard of
+  the 220-task corpus takes ~6.5h of strictly serial judge calls
+  (`tpm_guard.max_concurrent: 1`), but GitHub's hosted runners cap a job at 6h
+  and cannot be extended. `step8_grade.py` therefore stops at its 4h internal
+  budget, saves a partial, exits 7, and re-dispatches itself for the next chunk.
+  Every one of those re-dispatches landed back on the `grading` Environment and
+  waited for a human to click approve - so finishing a shard meant somebody
+  being awake at the four-hour boundary, and finishing nine shards meant that
+  eighteen times. Re-sharding cannot avoid it: `shard_count` is capped at 11,
+  which still leaves two chunks per shard.
+
+  `validate-request` now resolves an `approval_inherited` output, and
+  `approve-paid` is skipped when it is `true`. This is not a relaxation of the
+  spending control. `rerun_identity` pins the corpus (`task_ids` plus
+  `expected_task_count`) before chunk 0 runs, so approving chunk 0 already
+  bounds the bill for the entire shard; the 4h split is an artifact of the
+  runner ceiling, not a second spending decision. Inheritance is granted only
+  when *all* of the following hold, and any error or ambiguity falls back to
+  requiring the click:
+  - the request is paid (`dry_run == false`, `paid_approval == true`) and is a
+    resume with `resume_chunk >= 1` - chunk 0 is always the human click;
+  - both `actor` and `triggering_actor` are `github-actions[bot]`, which only
+    the in-workflow auto-retrigger produces (a person passing `resume=true` by
+    hand carries their own login);
+  - a partial for this exact shard slot exists on `main` under
+    `data/grades/_shards/<stem>/shard-NNN-of-MMM.json`, where the stem encodes
+    experiment, config name, config hash, rubric SHA, inference SHA and grader
+    source hash - so a path match is a full identity match;
+  - that partial's last commit was authored by the grading job's bot identity.
+
+  Minting a bot dispatch or a bot-authored partial requires merging a workflow
+  change to `main`, which is already owner-gated, so the bypass cannot be
+  reached from a feature branch. `grade` reads
+  `needs.validate-request.outputs.approval_inherited` rather than trusting a
+  bare `skipped` result, so an `approve-paid` skip from any other cause still
+  blocks the paid job, and its `if` now carries `!cancelled()` because a job
+  whose `needs` was skipped is otherwise skipped before its condition is even
+  evaluated. The inheritance step itself denies rather than throws on any
+  unexpected error, so a bug in it can never block chunk 0. Chunk 0 of every
+  shard, and every non-resume paid request, is unaffected.
+  `docs/first-experiment.md` and `docs/first-experiment_KR.md` no longer state
+  that each continuation needs a fresh approval. No workflow was dispatched by
+  this change.
 - **Legacy provenance: a complete pinned corpus is publishable** - inference
   runs that predate `inference_provenance.json` previously forced every grade
   built from them into `data/grades/_diagnostic/`, which the dashboard

--- a/docs/first-experiment.md
+++ b/docs/first-experiment.md
@@ -319,9 +319,13 @@ does not turn a three-task config into a 220-task run.
 Full runs can use substantial model quota and take multiple relay jobs. External
 grading is a separate pipeline. `grade-run.yml` starts as a model-free dry run;
 paid grading requires `paid_approval: true` plus approval in the protected
-`grading` GitHub Environment. Automatic grading continuations preserve the
-approval input, exact config, inference revision, and task limit, but each new
-chunk requires a fresh protected Environment approval. Read the
+`grading` GitHub Environment. That approval covers the whole shard, not one
+four-hour job: a shard is split into chunks only because hosted runners stop at
+six hours, and the graded corpus is pinned before the first chunk starts, so the
+automatic continuation inherits the approval instead of asking again. It inherits
+only when the continuation was dispatched by the workflow itself and the previous
+chunk's partial is on `main` under the same grading identity; anything else falls
+back to a fresh Environment approval. Read the
 [Batch Runner documentation](../batch-runner/README.md) and the
 [sandbox documentation](../batch-runner/sandbox/README.md) before changing the
 execution mode or scaling to all 220 tasks.

--- a/docs/first-experiment_KR.md
+++ b/docs/first-experiment_KR.md
@@ -311,9 +311,13 @@ Self-QA는 산출물을 만든 같은 모델의 재시도 신호입니다. 독�
 전체 실행은 큰 모델 쿼터를 사용할 수 있고 여러 relay job이 필요할 수
 있습니다. 외부 채점은 별도 pipeline입니다. `grade-run.yml`은 model-free
 dry run으로 시작하며, 유료 채점은 `paid_approval: true`와 보호된 `grading`
-GitHub Environment 승인이 모두 필요합니다. 자동 grading continuation은
-approval input과 exact config, inference revision, task limit을 전달하지만,
-새로 dispatch되는 각 chunk는 보호된 Environment 승인을 다시 받아야 합니다.
+GitHub Environment 승인이 모두 필요합니다. 이 승인은 4시간짜리 job 하나가
+아니라 shard 전체를 덮습니다. shard가 chunk로 쪼개지는 이유는 hosted runner가
+6시간에서 멈추기 때문이고, 채점 대상 corpus는 첫 chunk 전에 이미 고정되므로,
+자동 continuation은 승인을 다시 받는 대신 상속합니다. 상속은 continuation을
+workflow 자신이 dispatch했고 직전 chunk의 partial이 동일한 채점 identity로
+`main`에 올라와 있을 때만 적용되며, 그 밖의 경우는 모두 Environment 승인을
+다시 받습니다.
 실행 모드를 바꾸거나 220개로 확대하기 전에 [Batch Runner 문서](../batch-runner/README_KR.md)와
 [sandbox 문서](../batch-runner/sandbox/README.md)를 읽으세요.
 


### PR DESCRIPTION
## Why

A shard of the 220-task corpus needs **~6.5h** of strictly serial judge calls (`tpm_guard.max_concurrent: 1`). GitHub's hosted runners stop at **6h** and cannot be extended. So `step8_grade.py` stops at its 4h internal budget, saves a partial, exits 7, and re-dispatches itself for the next chunk.

Every one of those re-dispatches landed back on the protected `grading` Environment and waited for a human click. Finishing **one** shard meant somebody being awake at the four-hour boundary. Finishing **nine** meant that eighteen times.

Re-sharding does not fix it — `shard_count` is capped at 11, which still leaves two chunks per shard.

## What changed

`validate-request` resolves an `approval_inherited` output; `approve-paid` is skipped when it is `true`.

**This does not widen the spending control.** `rerun_identity` pins the corpus (`task_ids` + `expected_task_count`) *before* chunk 0 runs, so approving chunk 0 already bounds the bill for the whole shard. The 4h split is an artifact of the runner ceiling, not a second spending decision.

## When inheritance is granted

All of these must hold. Any failure, or any ambiguity, denies and falls back to the click:

| # | Check |
|---|---|
| 1 | Paid request (`dry_run == false`, `paid_approval == true`) |
| 2 | `resume == true` **and** `resume_chunk >= 1` — chunk 0 is always the human click |
| 3 | `actor` **and** `triggering_actor` are both `github-actions[bot]` |
| 4 | A partial for this exact shard slot exists on `main` at `data/grades/_shards/<stem>/shard-NNN-of-MMM.json` |
| 5 | That partial's last commit was authored by the grading job's bot identity |

The stem in check 4 encodes experiment, config name, config hash, rubric SHA, inference SHA and grader source hash — so a **path match is a full identity match**.

## Why this is not a hole

- Minting a bot dispatch, or a bot-authored partial, requires merging a workflow change to `main` — already owner-gated.
- `grade-run.yml` refuses to run unless `GITHUB_WORKFLOW_REF` is `grade-run.yml@refs/heads/main`, so the inherit logic itself only ever executes from merged code. A feature branch cannot reach it.
- `grade` reads `needs.validate-request.outputs.approval_inherited` rather than trusting a bare `skipped`, so an `approve-paid` skip from **any other cause** still blocks the paid job.
- `!cancelled()` on `grade` is load-bearing: a job whose `needs` was skipped is otherwise skipped before its condition is evaluated. It also stops a cancelled run from proceeding to spend.
- The inherit step denies rather than throws on unexpected errors, so a bug in it can never block chunk 0 — the path that does not use inheritance at all.

## Verification

An offline harness extracts the step **straight out of the workflow** (so the test cannot drift) and runs it against a mocked `gh`:

```
MUST INHERIT (no click):        3/3 pass
MUST REQUIRE THE CLICK:        16/16 pass
every path exits 0:            19/19
```

Deny cases covered: chunk 0, `resume=false`, human `actor`, human `triggering_actor`, dry run, `paid_approval=false`, no partial, wrong shard slot, wrong `shard_count`, human-authored partial, mismatched inference revision, mismatched config name, mismatched experiment, unreadable config, undecodable config, no `_shards` directory.

The ERR trap was proven separately: an unguarded command failure emits `approval_inherited=false` and exits 0.

## Blast radius

Chunk 0 of every shard, and every non-resume paid request, is unaffected. `docs/first-experiment.md` and its Korean counterpart no longer claim each continuation needs a fresh approval.

**No workflow was dispatched by this change.**