### PR TITLE
fix(grading): pin the paid-gate workflow test to its current conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,17 @@ entries land under a fresh dated heading the day they merge to `main`.
   and grade data are unchanged.
 
 ### Fixed
+- **Paid-gate workflow test pinned to the post-inheritance conditions** - the
+  approval-inheritance change left `test_grade_workflow_rc7_requires_valid_
+  committed_partial` comparing `approve-paid`'s `if:` against the old literal
+  `inputs.dry_run == false && inputs.paid_approval == true`, so `main` has been
+  red since that merge. Nothing caught it because no workflow runs the
+  batch-runner pytest suite on pull requests. The assertions now normalize the
+  YAML block scalar through a `_gh_expr` helper and pin both the `approve-paid`
+  and `grade` conditions exactly, replacing four substring probes that would
+  have passed against a gate weakened to `!= 'failure'` or one that dropped the
+  `approval_inherited` conjunct. Verified by mutation: removing the inheritance
+  conjunct from the workflow makes the test fail.
 - **First Sol Max anchor result and bounded analysis filenames** - run the
   owner-approved four-task anchor once as Actions run `31582293672` from main
   SHA `c9492645496e176c8e6a3510809585f9542a5bf1` with grader source hash

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -2798,6 +2798,17 @@ def test_atomic_save_supports_stage_b_output_basename(tmp_path):
     assert list(tmp_path.glob(".grade-*.tmp")) == []
 
 
+def _gh_expr(raw):
+    """Collapse a GitHub Actions `if:` to one comparable line.
+
+    The conditions guarding paid grading are written as multi-line YAML block
+    scalars for readability, so an exact string compare would break on a
+    reflow that changed nothing. Normalizing whitespace keeps these assertions
+    strict about the condition itself and indifferent to its formatting.
+    """
+    return " ".join(str(raw).strip().removeprefix("${{").removesuffix("}}").split())
+
+
 def test_grade_workflow_rc7_requires_valid_committed_partial():
     workflow_path = Path("../.github/workflows/grade-run.yml")
     workflow = workflow_path.read_text(
@@ -2817,8 +2828,12 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
     dry_run_job = parsed["jobs"]["grade-dry-run"]
     grade_job = parsed["jobs"]["grade"]
     assert approval_job["needs"] == "validate-request"
-    assert approval_job["if"] == (
-        "inputs.dry_run == false && inputs.paid_approval == true"
+    # A paid request goes to the protected environment unless validate-request
+    # proved the run inherits the approval already given for this shard.
+    assert _gh_expr(approval_job["if"]) == (
+        "inputs.dry_run == false && "
+        "inputs.paid_approval == true && "
+        "needs.validate-request.outputs.approval_inherited != 'true'"
     )
     assert approval_job["environment"] == {"name": "grading"}
     assert "permissions" not in approval_job
@@ -2843,10 +2858,20 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
     assert "id-token" not in yaml.safe_dump(dry_run_job)
     assert "actions" not in dry_run_job["permissions"]
     assert grade_job["needs"] == ["validate-request", "approve-paid"]
-    assert "inputs.dry_run == false" in grade_job["if"]
-    assert "inputs.paid_approval == true" in grade_job["if"]
-    assert "needs.validate-request.result == 'success'" in grade_job["if"]
-    assert "needs.approve-paid.result == 'success'" in grade_job["if"]
+    # Paid grading runs on a successful approval, or on a *skipped* approval
+    # only when validate-request certified the inheritance. Pinned exactly:
+    # any looser condition here (a bare `!= 'failure'`, dropping the
+    # approval_inherited conjunct) would let a paid run start with neither a
+    # click nor a proof, which is the whole thing this gate exists to prevent.
+    assert _gh_expr(grade_job["if"]) == (
+        "!cancelled() && "
+        "inputs.dry_run == false && "
+        "inputs.paid_approval == true && "
+        "needs.validate-request.result == 'success' && "
+        "( needs.approve-paid.result == 'success' || "
+        "( needs.approve-paid.result == 'skipped' && "
+        "needs.validate-request.outputs.approval_inherited == 'true' ) )"
+    )
     assert "environment" not in grade_job
     assert grade_job["permissions"] == {
         "contents": "write",


### PR DESCRIPTION
## Why

`main` has been red since #179. That PR added the `approval_inherited` conjunct to `approve-paid` and the skipped-approval escape to `grade`, and rewrote both `if:` blocks as YAML block scalars. `test_grade_workflow_rc7_requires_valid_committed_partial` kept comparing against the old one-line literal:

```python
assert approval_job["if"] == (
    "inputs.dry_run == false && inputs.paid_approval == true"
)
```

Nothing reported it because **no workflow runs the batch-runner pytest suite on pull requests.** That gap is the reason a red test merged; it is filed separately rather than bundled here.

## What

- `_gh_expr` normalizes a multi-line block scalar to one comparable line, so the assertions stay strict about the condition and indifferent to formatting.
- Both `approve-paid` and `grade` conditions are now pinned exactly.
- Four substring probes on `grade_job["if"]` are gone. They would have passed against a gate weakened to a bare `!= 'failure'`, or one that dropped `approval_inherited` — exactly what this gate exists to prevent.

Mutation-verified: deleting the inheritance conjunct from `grade-run.yml` makes the test fail. The assertion is load-bearing, not curve-fitted to the current text.

## Merge safety during the live paid run

This branch touches **only** `batch-runner/tests/` and `CHANGELOG.md`. Neither is in the `compute_grader_source_hash` file set (`step8_grade.py`, `core/**/*.py`, `schemas/grade.schema.json`, `requirements.txt`, `scripts/download_inference_from_hf.py`, prompt template, grading config).

Recomputed on this branch:

```
1c967673eb8081a61505919476fc8509372876ab71259b8d5456532ccbf2d413
```

That is byte-identical to the hash pinned in the in-flight `shard-000-of-009.json`. The 220-task relay is unaffected by this merge.

The remaining half of #180 — the `summary.wow` analytics in `step8_grade.py` — computes `2eff25db6649b9ca...` and stays held until all nine shards are merged.

## Verification

`251 passed` across `test_step8_grade.py` and `test_grade_schema.py`.