### PR TITLE
fix(ci): bound apt installs so a stalled mirror cannot hang a job

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -184,15 +184,38 @@ jobs:
           cache: pip
 
       # ── System deps for native Python packages (pycairo/pygraphviz, etc.) ──
+      # Stall-guarded: see grade-run.yml's renderer install for the 2026-08-19
+      # mirror outage that hung five jobs for 5h18m apiece. Same defect lives
+      # in every bare apt-get call in this repo, so it gets the same guard.
       - name: Install system dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            pkg-config \
-            libcairo2-dev \
-            libffi-dev \
-            graphviz \
-            libgraphviz-dev
+          APT_OPTS=(
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=30
+            -o Acquire::https::Timeout=30
+            -o DPkg::Lock::Timeout=60
+          )
+          install_system_deps() {
+            sudo timeout 240 apt-get "${APT_OPTS[@]}" update -qq || return 1
+            sudo timeout 420 apt-get "${APT_OPTS[@]}" install -y \
+              --no-install-recommends \
+              pkg-config \
+              libcairo2-dev \
+              libffi-dev \
+              graphviz \
+              libgraphviz-dev || return 1
+          }
+          for attempt in 1 2 3; do
+            if install_system_deps; then
+              break
+            fi
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "::error::apt could not install system dependencies after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::apt attempt $attempt failed; retrying in $((attempt * 60))s"
+            sleep "$((attempt * 60))"
+          done
 
       - name: Install dependencies
         run: |
@@ -436,29 +459,51 @@ jobs:
           cd batch-runner
           python3 scripts/azure_ai_route_preflight.py
 
+      # Stall-guarded like the other apt calls here. This one installs the
+      # largest package set in the repo, so it gets a longer install ceiling.
       - name: Install LibreOffice & Noto Sans fonts
         if: steps.read_config.outputs.install_libreoffice == 'True'
         run: |
           echo "📦 Installing LibreOffice (headless) + Noto Sans fonts + system deps..."
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            libreoffice-core \
-            libreoffice-calc \
-            libreoffice-impress \
-            libreoffice-writer \
-            fonts-noto-core \
-            fonts-noto-cjk \
-            ffmpeg \
-            libsndfile1 \
-            tesseract-ocr \
-            poppler-utils \
-            wkhtmltopdf \
-            ghostscript \
-            graphviz libgraphviz-dev \
-            libzbar0 \
-            libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
-            libgdk-pixbuf-2.0-0 libffi-dev \
-            libgl1 libglib2.0-0
+          APT_OPTS=(
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=30
+            -o Acquire::https::Timeout=30
+            -o DPkg::Lock::Timeout=60
+          )
+          install_office_deps() {
+            sudo timeout 240 apt-get "${APT_OPTS[@]}" update -qq || return 1
+            sudo timeout 900 apt-get "${APT_OPTS[@]}" install -y \
+              --no-install-recommends \
+              libreoffice-core \
+              libreoffice-calc \
+              libreoffice-impress \
+              libreoffice-writer \
+              fonts-noto-core \
+              fonts-noto-cjk \
+              ffmpeg \
+              libsndfile1 \
+              tesseract-ocr \
+              poppler-utils \
+              wkhtmltopdf \
+              ghostscript \
+              graphviz libgraphviz-dev \
+              libzbar0 \
+              libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
+              libgdk-pixbuf-2.0-0 libffi-dev \
+              libgl1 libglib2.0-0 || return 1
+          }
+          for attempt in 1 2 3; do
+            if install_office_deps; then
+              break
+            fi
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "::error::apt could not install LibreOffice after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::apt attempt $attempt failed; retrying in $((attempt * 60))s"
+            sleep "$((attempt * 60))"
+          done
           fc-cache -fv
           echo "✅ LibreOffice version:"
           libreoffice --version

--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -596,17 +596,75 @@ jobs:
           cd batch-runner
           python scripts/azure_ai_route_preflight.py
 
+      # The renderer is a host binary, not a library: core/artifact_renderer.py
+      # and core/tools/read_deliverable.py both shell out to `soffice`, so it
+      # has to exist on the runner before grading starts.
+      #
+      # On 2026-08-19 that made this step the single point of failure for the
+      # 220-task run. Between 08:11 and 08:35 UTC azure.archive.ubuntu.com
+      # returned Ign: for every index, apt fell back to archive.ubuntu.com, and
+      # that connection stalled mid-transfer. apt imposes no wall-clock ceiling
+      # on itself, so five grade jobs sat here for 5h18m until timeout-minutes
+      # killed them -- taking 63 of the 220 tasks with them and reporting
+      # nothing until the job died. The same 25-minute window cost nothing to
+      # the shards that reached this step at 08:41 and 08:44, where apt
+      # completed in under two and a half minutes.
+      #
+      # Three guards, in order of what they catch:
+      #   Acquire::*::Timeout  -- a stalled socket errors out instead of
+      #                           blocking forever, which is what actually
+      #                           happened here.
+      #   sudo timeout         -- a hard ceiling on apt regardless of why it is
+      #                           stuck. Run under sudo, not around it, so the
+      #                           signal reaches apt rather than sudo.
+      #   DPkg::Lock::Timeout  -- after a TERM'd attempt, the next one waits for
+      #                           the dpkg lock instead of failing on contact
+      #                           with a lock the dying process still holds.
+      #   the retry loop       -- a transient mirror outage becomes recoverable
+      #                           inside the job. Worst case is 36 minutes
+      #                           (3 x 11min ceiling + 60s and 120s backoff),
+      #                           which outlasts the ~25-minute outage actually
+      #                           observed and still leaves the 240-minute
+      #                           grading budget inside the 320-minute job
+      #                           timeout.
+      #
+      # This does not make apt succeed while a mirror is down; nothing here
+      # can. It converts a silent five-hour hang into either a recovery or a
+      # fast, legible failure. Removing the apt dependency altogether means
+      # running this job in ghcr.io/hyeonsangjeon/gdpval-sandbox, which already
+      # ships LibreOffice -- tracked separately, deliberately not on the
+      # critical path for finishing the current run.
       - name: Install grading render dependencies
         if: steps.renderer.outputs.required == 'true'
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            libreoffice-core \
-            libreoffice-calc \
-            libreoffice-impress \
-            fonts-dejavu-core \
-            fonts-liberation2 \
-            fontconfig
+          APT_OPTS=(
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=30
+            -o Acquire::https::Timeout=30
+            -o DPkg::Lock::Timeout=60
+          )
+          install_render_deps() {
+            sudo timeout 240 apt-get "${APT_OPTS[@]}" update || return 1
+            sudo timeout 420 apt-get "${APT_OPTS[@]}" install \
+              --yes --no-install-recommends \
+              libreoffice-core \
+              libreoffice-calc \
+              libreoffice-impress \
+              fonts-dejavu-core \
+              fonts-liberation2 \
+              fontconfig || return 1
+          }
+          for attempt in 1 2 3; do
+            if install_render_deps; then
+              break
+            fi
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "::error::apt could not install the grading renderer after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::apt attempt $attempt failed; retrying in $((attempt * 60))s"
+            sleep "$((attempt * 60))"
+          done
           libreoffice --headless --version
           FONT_FAMILIES="$(fc-match --format '%{family}\n' 'Liberation Sans')"
           if ! printf '%s\n' "$FONT_FAMILIES" | tr ',' '\n' | awk '

--- a/.github/workflows/grading-renderer-preflight.yml
+++ b/.github/workflows/grading-renderer-preflight.yml
@@ -31,16 +31,40 @@ jobs:
           cache: pip
           cache-dependency-path: batch-runner/requirements-renderer.txt
 
+      # Same stall guard as grade-run.yml's renderer install -- see the comment
+      # there for the 2026-08-19 mirror outage this exists to survive. A
+      # preflight that hangs for five hours is worse than one that fails in
+      # ten minutes, because nobody reads a job that is still "running".
       - name: Install document renderer
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            libreoffice-core \
-            libreoffice-calc \
-            libreoffice-impress \
-            fonts-dejavu-core \
-            fonts-liberation2 \
-            fontconfig
+          APT_OPTS=(
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=30
+            -o Acquire::https::Timeout=30
+            -o DPkg::Lock::Timeout=60
+          )
+          install_render_deps() {
+            sudo timeout 240 apt-get "${APT_OPTS[@]}" update || return 1
+            sudo timeout 420 apt-get "${APT_OPTS[@]}" install \
+              --yes --no-install-recommends \
+              libreoffice-core \
+              libreoffice-calc \
+              libreoffice-impress \
+              fonts-dejavu-core \
+              fonts-liberation2 \
+              fontconfig || return 1
+          }
+          for attempt in 1 2 3; do
+            if install_render_deps; then
+              break
+            fi
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "::error::apt could not install the document renderer after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::apt attempt $attempt failed; retrying in $((attempt * 60))s"
+            sleep "$((attempt * 60))"
+          done
           libreoffice --headless --version
           FONT_FAMILIES="$(fc-match --format '%{family}\n' 'Liberation Sans')"
           if ! printf '%s\n' "$FONT_FAMILIES" | tr ',' '\n' | awk '


### PR DESCRIPTION
Five grade jobs for the 220-task run died on 2026-08-19 after hanging 5h18m each in `Install grading render dependencies` — step 9 of 24, before any judge call. 63 of 220 tasks went with them, and nothing was reported until `timeout-minutes: 320` killed the jobs.

## What happened

```
08:29:16 Ign:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages
08:29:17 Get:5  https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
13:47:30 ##[error]The operation was canceled.
```

The Azure Ubuntu mirror returned `Ign:` for every index between roughly 08:11 and 08:35 UTC. apt fell back to `archive.ubuntu.com` and that connection stalled mid-transfer. apt imposes no wall-clock ceiling on itself, so the step simply never returned.

The outage was about 25 minutes. Shards that reached the same step at 08:41 and 08:44 installed in 1m49s and 2m21s. Sharding did not cause this — it multiplied the exposure, because nine jobs each buy a separate ticket in the same lottery.

## What changed

Every bare `apt-get` call in the repo has the same defect, so all four sites get the same guard — `grade-run.yml`, `grading-renderer-preflight.yml`, and `batch-run.yml` (×2).

| guard | catches |
|---|---|
| `Acquire::*::Timeout=30` | a stalled socket errors out instead of blocking — what actually happened here |
| `sudo timeout` | a hard ceiling regardless of why apt is stuck. Run *under* sudo, not around it, so the signal reaches apt rather than sudo |
| `DPkg::Lock::Timeout=60` | the retry waits for the lock a TERM’d attempt may still hold, instead of failing on contact |
| bounded retry loop | a transient outage becomes recoverable inside the job |

Worst case is 36 minutes (3 × 11-minute ceiling, plus 60s and 120s backoff). That outlasts the outage actually observed and still leaves the 240-minute grading budget inside the 320-minute job timeout.

## What this does not do

It does not make apt succeed while a mirror is down. Nothing here can. It converts a silent five-hour hang into either a recovery or a fast, legible failure.

Removing the apt dependency altogether means running these jobs in `ghcr.io/hyeonsangjeon/gdpval-sandbox`, which already ships LibreOffice. That is tracked separately and deliberately kept off the critical path for the run currently in flight.

## Reproducibility

No effect on `grader_source_hash`. `.github/workflows/**` is outside the hashed set; verified at `1c967673eb8081a6` before and after, which also matches the `src_1c967673eb8081a6` segment in the committed shard paths.

## Verification

- All three workflow files parse as YAML with their job sets unchanged.
- The retry loop was exercised under `bash -e` against a stub failing 0, 1, 2, and 3 times: rc=0 for 0–2 failures with correct warning annotations and 60s/120s backoff; rc=1 at 3 failures with the error annotation. Post-loop code is reached in every success case.