### PR TITLE
chore(dashboard): hide grading runs that covered part of their corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,39 @@ entries land under a fresh dated heading the day they merge to `main`.
   that had been showing up as a grading outcome. Two of those the selector
   passed through with `selection_status: 'ok'`.
 
+- **Partial-corpus grading runs hidden from the default dashboard view
+  (`scripts/aggregate-grades.mjs`, `src/lib/officialExperimentScope.js`)** - the
+  Grading Analysis tab listed six cards for the same experiment, three of which
+  were preflights: a 1-task config check, a 3-task cohort trial and a 10-task
+  cohort trial. Sitting on the same axis as a finished 220-task run they read as
+  comparisons, and the numbers cannot support that - the 3-task trial scored
+  36.14% and the 10-task trial 57.74% against 53.30% for a full run, spread that
+  is mostly sampling noise. Both aggregate charts, the Score Distribution
+  Comparison and the Overall Score Breakdown, were mixing them into the same
+  totals.
+
+  The rule is measured rather than name-matched. The aggregator now records a
+  `coverage` block per grade - `grade_tasks`, `corpus_tasks`,
+  `is_partial_corpus` - where the denominator is the inference run's own
+  published `summary.total_tasks` read from `reports-index.json`. A grade that
+  covered fewer tasks than the run it graded is a preflight and is hidden.
+  This subsumes the hand-written `_tight` pattern from the previous phase,
+  which was always an instance of the same rule; the pattern stays as a
+  fallback for grades whose experiment has no report.
+
+  Two properties make the failure modes safe. Unknown coverage is never
+  partial - an experiment with no report yields `corpus_tasks: null` and the
+  grade stays visible, so ignorance leaves an early experiment alone rather
+  than silently deleting it. And a small experiment graded end to end (17 of
+  17) is complete, so the rule cannot mistake "small" for "unfinished". The
+  curated `OFFICIAL_GRADE_IDS` allowlist is still checked first and is never
+  hidden by any rule.
+
+  This is a display filter and nothing else. No file under `data/grades/` is
+  modified, `coverage` is additive metadata that changes no published figure,
+  every grade remains reachable by direct URL, and `?debug=1` restores the full
+  list. Visible cards go from 6 to 3, all three full-corpus runs.
+
 - **Backend test workflow (`backend-tests.yml`)** - the batch-runner suite had
   no pull-request gate at all, so a change could land on `main` with a red test
   and nothing would report it. That is exactly how the paid-gate assertion

--- a/scripts/__tests__/aggregate-grades.test.mjs
+++ b/scripts/__tests__/aggregate-grades.test.mjs
@@ -899,3 +899,79 @@ test('T6: v1 grade with source_inference_experiment_id resolves qa via the sourc
   assert.equal(out.source_inference_experiment_id, 'expB');
   assert.equal(out.experiment_id, 'expA', 'experiment_id field must be preserved unchanged');
 });
+
+// ── corpus coverage ───────────────────────────────────────────────────────
+// The denominator is the inference run's own published task count, taken from
+// reports-index.json. A grade never supplies its own denominator, because a
+// preflight that graded 3 tasks would then report 3/3 and look complete.
+
+test('processGradesFile measures coverage against the inference corpus', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'exp-corpus',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4-mini' },
+    summary: { total_tasks: 3, graded_tasks: 3, error_tasks: 0, openai_compat: {}, wow: {} },
+    tasks: [],
+  };
+  const corpus = new Map([['exp-corpus', 220]]);
+
+  const out = processGradesFile('preflight.json', raw, new Map(), corpus);
+
+  assert.deepEqual(out.coverage, {
+    grade_tasks: 3,
+    corpus_tasks: 220,
+    is_partial_corpus: true,
+  });
+  // The published counts are untouched — coverage explains them, never edits.
+  assert.equal(out.summary.total_tasks, 3);
+  assert.equal(out.summary.graded_tasks, 3);
+});
+
+test('processGradesFile marks a full-corpus grade complete', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'exp-corpus',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.6-sol' },
+    summary: { total_tasks: 220, graded_tasks: 215, error_tasks: 5, openai_compat: {}, wow: {} },
+    tasks: [],
+  };
+  const corpus = new Map([['exp-corpus', 220]]);
+
+  const out = processGradesFile('full.json', raw, new Map(), corpus);
+
+  assert.equal(out.coverage.is_partial_corpus, false);
+  // 5 tasks the grader could not score are still 5 tasks it was handed. An
+  // error is not a coverage gap, so graded_tasks is deliberately not the
+  // numerator here — total_tasks is.
+  assert.equal(out.coverage.grade_tasks, 220);
+});
+
+test('processGradesFile leaves coverage unknown when the experiment has no report', () => {
+  const raw = {
+    schema_version: '1.0',
+    experiment_id: 'exp-unreported',
+    inference_model: 'gpt-5.2-chat',
+    judge: { model: 'gpt-5.4' },
+    summary: { total_tasks: 10, graded_tasks: 10, error_tasks: 0, openai_compat: {}, wow: {} },
+    tasks: [],
+  };
+
+  const out = processGradesFile('unreported.json', raw, new Map(), new Map());
+
+  assert.equal(out.coverage.corpus_tasks, null);
+  assert.equal(out.coverage.is_partial_corpus, false);
+});
+
+test('processGradesFile emits coverage on legacy grades too', () => {
+  const out = processGradesFile('dummy_gpt5_baseline.json', {
+    _meta: { is_dummy: true, experiment_id: 'dummy_gpt5_baseline' },
+    tasks: [
+      { task_id: 't1', num_grades: 3, scores: [1, 1, 1], avg_score: 1.0, error: false, error_messages: [] },
+    ],
+  }, new Map(), new Map([['dummy_gpt5_baseline', 220]]));
+
+  assert.equal(out.coverage.corpus_tasks, 220);
+  assert.equal(out.coverage.is_partial_corpus, true);
+});

--- a/scripts/__tests__/official-filter.test.mjs
+++ b/scripts/__tests__/official-filter.test.mjs
@@ -8,6 +8,7 @@ import {
   HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS,
   isHiddenDiagnosticExperimentId,
   isHiddenOfficialExperiment,
+  isPartialCorpusGrade,
   OFFICIAL_TASK_COUNT,
 } from '../../src/lib/officialExperimentScope.js'
 
@@ -103,4 +104,41 @@ test('Dashboard display data keeps default and debug reports aligned', () => {
     experiments,
     reports,
   })
+})
+// ── Phase 3: partial-corpus grades ────────────────────────────────────────
+// The dashboard used to hide preflight grades by name (`_tight`), which only
+// worked for the one that happened to be named that way. Coverage is measured
+// instead: a grade over 3 of an experiment's 220 tasks is a preflight whatever
+// its config was called.
+
+test('a grade covering part of its corpus is a preflight, not a result', () => {
+  assert.equal(isPartialCorpusGrade({
+    coverage: { grade_tasks: 3, corpus_tasks: 220, is_partial_corpus: true },
+  }), true)
+})
+
+test('a grade covering the whole corpus is kept', () => {
+  assert.equal(isPartialCorpusGrade({
+    coverage: { grade_tasks: 220, corpus_tasks: 220, is_partial_corpus: false },
+  }), false)
+})
+
+test('a small experiment graded end to end is complete, not partial', () => {
+  // 17 of 17 is the entire corpus. Hiding it would confuse "small" with
+  // "unfinished" and drop a legitimate result.
+  assert.equal(isPartialCorpusGrade({
+    coverage: { grade_tasks: 17, corpus_tasks: 17, is_partial_corpus: false },
+  }), false)
+})
+
+test('unknown coverage is never treated as partial', () => {
+  // No report for the source experiment ⇒ no denominator. Staying visible on
+  // ignorance is the safer failure: the alternative silently drops real runs.
+  assert.equal(isPartialCorpusGrade({
+    coverage: { grade_tasks: 220, corpus_tasks: null, is_partial_corpus: false },
+  }), false)
+  assert.equal(isPartialCorpusGrade({}), false)
+  assert.equal(isPartialCorpusGrade({ coverage: null }), false)
+  assert.equal(isPartialCorpusGrade(null), false)
+  assert.equal(isPartialCorpusGrade(undefined), false)
 })

--- a/scripts/aggregate-grades.mjs
+++ b/scripts/aggregate-grades.mjs
@@ -57,6 +57,24 @@ function buildCalibration(tasks) {
   return { calibration_mae, calibration_counts };
 }
 
+// ── corpus coverage ───────────────────────────────────────────────────────
+// How much of an inference run a grading run actually covered.
+//
+// A grade over 3 of an experiment's 220 tasks is a preflight, not a result.
+// Put on the same axis as a full run it reads as a comparison, and the numbers
+// cannot support one. The denominator is the inference run's own published
+// total from reports-index.json, so this never guesses: an experiment with no
+// report yields corpus_tasks: null and is left alone.
+function buildCoverage(experimentId, gradeTasks, corpusByExperiment) {
+  const corpus = corpusByExperiment.get(experimentId);
+  const corpus_tasks = Number.isInteger(corpus) && corpus > 0 ? corpus : null;
+  return {
+    grade_tasks: gradeTasks,
+    corpus_tasks,
+    is_partial_corpus: corpus_tasks !== null && gradeTasks < corpus_tasks,
+  };
+}
+
 // ── qa_score resolution (strict per-experiment) ───────────────────────────
 // Returns a function (taskId) → qa_score|null for a given grade.
 // Strict rules:
@@ -84,7 +102,12 @@ function makeQaResolver(experiment_id, is_dummy, taskQaByExperiment, source_expe
 }
 
 // ── Legacy (dummy / _meta-based) format ────────────────────────────────────
-function processLegacyGradesFile(filePath, raw, taskQaByExperiment = new Map()) {
+function processLegacyGradesFile(
+  filePath,
+  raw,
+  taskQaByExperiment = new Map(),
+  corpusByExperiment = new Map(),
+) {
   const filename = basename(filePath, '.json');
   const meta = raw._meta || {};
   const rawTasks = raw.tasks || raw; // support both { _meta, tasks } and bare array
@@ -156,6 +179,7 @@ function processLegacyGradesFile(filePath, raw, taskQaByExperiment = new Map()) 
       calibration_mae,
       calibration_counts,
     },
+    coverage: buildCoverage(experiment_id, tasks.length, corpusByExperiment),
     tasks,
   };
 }
@@ -297,7 +321,12 @@ function validateHistoricalHeadline(raw) {
   }
 }
 
-function processV1GradesFile(filePath, raw, taskQaByExperiment = new Map()) {
+function processV1GradesFile(
+  filePath,
+  raw,
+  taskQaByExperiment = new Map(),
+  corpusByExperiment = new Map(),
+) {
   validateScoreExcludedGrade(raw);
   validateHistoricalHeadline(raw);
   const filename = basename(filePath, '.json');
@@ -448,6 +477,7 @@ function processV1GradesFile(filePath, raw, taskQaByExperiment = new Map()) {
       calibration_mae,
       calibration_counts,
     },
+    coverage: buildCoverage(experiment_id, totalTasks, corpusByExperiment),
     tasks,
     // v1.0 provenance + full payload (for WOW dashboard components)
     judge: raw.judge,
@@ -466,13 +496,18 @@ function processV1GradesFile(filePath, raw, taskQaByExperiment = new Map()) {
   };
 }
 
-export function processGradesFile(filePath, raw, taskQaByExperiment = new Map()) {
+export function processGradesFile(
+  filePath,
+  raw,
+  taskQaByExperiment = new Map(),
+  corpusByExperiment = new Map(),
+) {
   // All item-level 1.x payloads share the rich grade projection. Later minor
   // versions add provenance contracts without changing dashboard score shape.
   if (raw && ['1.0', '1.1', '1.2', '1.3'].includes(raw.schema_version)) {
-    return processV1GradesFile(filePath, raw, taskQaByExperiment);
+    return processV1GradesFile(filePath, raw, taskQaByExperiment, corpusByExperiment);
   }
-  return processLegacyGradesFile(filePath, raw, taskQaByExperiment);
+  return processLegacyGradesFile(filePath, raw, taskQaByExperiment, corpusByExperiment);
 }
 
 export function isPublishableGrade(result) {
@@ -481,18 +516,14 @@ export function isPublishableGrade(result) {
   );
 }
 
-// ── taskQaByExperiment lookup ─────────────────────────────────────────────
-// Build Map<experiment_id, Record<task_id, qa_score>> from reports-index.json.
-// STRICT: reports-index is the only source. No fallback to batch-runner/results/
-// — the previous global-task_id map produced incorrect cross-experiment matches
-// because GDPVal task_ids are shared across all experiments running the same
-// dataset. Missing reports-index ⇒ empty Map ⇒ all qa_score = null.
-async function buildTaskQaByExperiment() {
-  const map = new Map();
+// ── reports-index lookups ─────────────────────────────────────────────────
+// Both maps below are derived from the same file. Missing or unreadable ⇒
+// empty maps, which degrade to "no qa_score" and "coverage unknown" rather
+// than to a guess.
+async function readReportsIndex() {
   const indexPath = join(OUTPUT_DIR, 'reports-index.json');
-  let raw;
   try {
-    raw = JSON.parse(await readFile(indexPath, 'utf-8'));
+    return JSON.parse(await readFile(indexPath, 'utf-8'));
   } catch (err) {
     // ENOENT = file not yet generated (first build, fresh repo) — silent fallback.
     // Other errors (parse failure, permission, etc.) deserve a warning so they
@@ -500,12 +531,36 @@ async function buildTaskQaByExperiment() {
     if (err && err.code !== 'ENOENT') {
       console.warn(`⚠️  reports-index.json unreadable (${err.message}); all qa_score will be null.`);
     }
-    return map;
+    return null;
   }
-  for (const report of raw.reports ?? []) {
+}
+
+// Build Map<experiment_id, Record<task_id, qa_score>> from reports-index.json.
+// STRICT: reports-index is the only source. No fallback to batch-runner/results/
+// — the previous global-task_id map produced incorrect cross-experiment matches
+// because GDPVal task_ids are shared across all experiments running the same
+// dataset. Missing reports-index ⇒ empty Map ⇒ all qa_score = null.
+function buildTaskQaByExperiment(rawIndex) {
+  const map = new Map();
+  for (const report of rawIndex?.reports ?? []) {
     const expId = report?.meta?.experiment_id;
     if (expId && report.task_qa && typeof report.task_qa === 'object') {
       map.set(expId, report.task_qa);
+    }
+  }
+  return map;
+}
+
+// Build Map<experiment_id, corpus size> — the task count the inference run
+// itself published. This is the denominator a grade's coverage is measured
+// against, so it is read from the report and never inferred from the grade.
+function buildCorpusByExperiment(rawIndex) {
+  const map = new Map();
+  for (const report of rawIndex?.reports ?? []) {
+    const expId = report?.meta?.experiment_id;
+    const total = report?.summary?.total_tasks;
+    if (expId && Number.isInteger(total) && total > 0) {
+      map.set(expId, total);
     }
   }
   return map;
@@ -526,19 +581,23 @@ async function main() {
     return;
   }
 
-  // Build experiment_id → task_qa lookup once for all grade files.
-  // Strict per-experiment matching; reports-index.json is the sole source.
-  const taskQaByExperiment = await buildTaskQaByExperiment();
+  // Build experiment_id → task_qa and experiment_id → corpus size lookups once
+  // for all grade files. Strict per-experiment matching; reports-index.json is
+  // the sole source.
+  const reportsIndex = await readReportsIndex();
+  const taskQaByExperiment = buildTaskQaByExperiment(reportsIndex);
+  const corpusByExperiment = buildCorpusByExperiment(reportsIndex);
   const totalQaTasks = Array.from(taskQaByExperiment.values())
     .reduce((n, m) => n + Object.keys(m).length, 0);
   console.log(`ℹ️  task_qa lookup built: ${taskQaByExperiment.size} experiment(s), ${totalQaTasks} task(s)`);
+  console.log(`ℹ️  corpus lookup built: ${corpusByExperiment.size} experiment(s)`);
 
   const results = [];
   for (const file of jsonFiles) {
     const content = await readFile(join(GRADES_DIR, file), 'utf-8');
     try {
       const data = JSON.parse(content);
-      const processed = processGradesFile(file, data, taskQaByExperiment);
+      const processed = processGradesFile(file, data, taskQaByExperiment, corpusByExperiment);
       if (!isPublishableGrade(processed)) {
         console.warn(`⚠️  ${file} is ${processed.grade_status}; excluded from dashboard`);
         continue;
@@ -568,10 +627,15 @@ async function main() {
   for (const r of results) {
     const dummy = r.is_dummy ? ' [DUMMY]' : '';
     const v1 = r.schema_version ? ` [v${r.schema_version}]` : '';
+    // Naming a partial run in the build log is the only place the exclusion is
+    // visible to whoever ran the aggregation; the card itself just vanishes.
+    const partial = r.coverage?.is_partial_corpus
+      ? ` [PARTIAL ${r.coverage.grade_tasks}/${r.coverage.corpus_tasks} corpus]`
+      : '';
     const headline = r.summary.avg_score_pct == null
       ? 'unscored'
       : `${r.summary.avg_score_pct}% avg`;
-    console.log(`   ${r.id}: ${headline} (${r.summary.graded_tasks}/${r.summary.total_tasks} tasks)${dummy}${v1}`);
+    console.log(`   ${r.id}: ${headline} (${r.summary.graded_tasks}/${r.summary.total_tasks} tasks)${dummy}${v1}${partial}`);
   }
 }
 

--- a/src/hooks/useGrades.ts
+++ b/src/hooks/useGrades.ts
@@ -84,6 +84,17 @@ export interface GradeResult {
    *  produced before the field existed. See `src/lib/gradeProvenance.js`. */
   source_azure_ai_provenance_status?: string | null
 
+  /** How much of the inference corpus this grading run covered, measured in
+   *  aggregate-grades.mjs against the inference run's own published task count.
+   *  `corpus_tasks` is null when the source experiment has no report, in which
+   *  case coverage is unknown and `is_partial_corpus` stays false. Partial runs
+   *  are preflights and are hidden from the default dashboard view. */
+  coverage?: {
+    grade_tasks: number
+    corpus_tasks: number | null
+    is_partial_corpus: boolean
+  }
+
   // ── Item-level grade schema additions ──
   schema_version?: '1.0' | '1.1' | '1.2' | '1.3' | null
   judge?: JudgeProvenance

--- a/src/lib/officialExperimentScope.d.ts
+++ b/src/lib/officialExperimentScope.d.ts
@@ -3,6 +3,16 @@ export const HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS: ReadonlySet<string>
 export function isHiddenDiagnosticExperimentId(value: string | null | undefined): boolean
 export function isSmokeExperimentId(value: string | null | undefined): boolean
 
+interface GradeCoverageScope {
+	coverage?: {
+		grade_tasks?: number
+		corpus_tasks?: number | null
+		is_partial_corpus?: boolean
+	} | null
+}
+
+export function isPartialCorpusGrade(grade: GradeCoverageScope | null | undefined): boolean
+
 interface DashboardExperimentScope {
 	short_id: string
 	experiment_name: string

--- a/src/lib/officialExperimentScope.js
+++ b/src/lib/officialExperimentScope.js
@@ -25,6 +25,20 @@ export function isSmokeExperimentId(value) {
   return /(^|[_-])exp99\d/i.test(value) || /smoke/i.test(value)
 }
 
+/**
+ * A grading run that covered only part of the inference corpus it graded —
+ * a preflight or cohort trial, not a result. `coverage` is computed in
+ * aggregate-grades.mjs against the inference run's own published task count.
+ *
+ * Unknown coverage is never treated as partial: a grade whose experiment has
+ * no report yields `corpus_tasks: null`, and staying visible on ignorance is
+ * the safer failure. A small experiment graded end to end (17 of 17) is
+ * complete, so this rule cannot mistake "small" for "unfinished".
+ */
+export function isPartialCorpusGrade(grade) {
+  return grade?.coverage?.is_partial_corpus === true
+}
+
 /** Default dashboard exclusion rule for inference reports. */
 export function isHiddenOfficialExperiment(experiment) {
   return (

--- a/src/lib/officialFilter.ts
+++ b/src/lib/officialFilter.ts
@@ -12,17 +12,23 @@
  * Phase 2 extends this: superseded / partial exp003 cards (old `__<sha>__v*`
  * naming + the 10-task `_tight` subset) are also hidden by default, while the
  * two curated clean-220 runs are pinned OFFICIAL (allowlist) and never hidden.
+ *
+ * Phase 3 replaces the name-matching half of that with a measured one: any
+ * grade covering fewer tasks than the inference run it graded is a preflight
+ * and is hidden. `_tight` was always an instance of this rule written by hand;
+ * the pattern stays as a fallback for grades whose experiment has no report.
  */
 import type { GradeResult } from '../hooks/useGrades'
 import type { ExperimentEntry } from '../types/report'
 import {
   isHiddenDiagnosticExperimentId,
   isHiddenOfficialExperiment,
+  isPartialCorpusGrade,
   isSmokeExperimentId,
   OFFICIAL_TASK_COUNT,
 } from './officialExperimentScope.js'
 
-export { OFFICIAL_TASK_COUNT }
+export { OFFICIAL_TASK_COUNT, isPartialCorpusGrade }
 
 /**
  * Smoke / test identifier. `exp99x` is the reserved smoke namespace
@@ -70,7 +76,8 @@ export function isLegacyExp003(g: Pick<GradeResult, 'id'>): boolean {
 
 /**
  * True when a grade card should be hidden from the default (non-debug) view:
- * legacy demo, smoke/test run, or a superseded/partial exp003 card.
+ * legacy demo, smoke/test run, a superseded/partial exp003 card, or a grading
+ * run that covered only part of its inference corpus.
  * Curated OFFICIAL ids are never hidden (reverse protection).
  */
 export function isHiddenGrade(g: GradeResult): boolean {
@@ -81,6 +88,7 @@ export function isHiddenGrade(g: GradeResult): boolean {
     isSmokeId(g.id) ||
     isHiddenDiagnosticExperimentId(g.experiment_id) ||
     isHiddenDiagnosticExperimentId(g.id) ||
+    isPartialCorpusGrade(g) ||
     isLegacyExp003(g)
   )
 }


### PR DESCRIPTION
## What

The Grading Analysis tab listed **six** grade cards for the same experiment. Three were preflights, not results:

| avg | tasks graded | what it actually was |
|---|---|---|
| 50.63% | 1 / 220 | config smoke check |
| 36.14% | 3 / 220 | cohort trial |
| 57.74% | 10 / 220 | cohort trial |
| 54.77% | 10 / 220 | `_tight` subset (already hidden by a name pattern) |

Placed on the same axis as a finished 220-task run they read as comparisons, and the numbers cannot support that — a 3-task run scoring 36.14% against 53.30% for a full run is mostly sampling noise. The Score Distribution Comparison and Overall Score Breakdown charts were mixing them into the same totals.

## How

The rule is **measured**, not name-matched.

`aggregate-grades.mjs` now emits a `coverage` block per grade:

```json
"coverage": { "grade_tasks": 3, "corpus_tasks": 220, "is_partial_corpus": true }
```

The denominator is the inference run's own published `summary.total_tasks`, read from `reports-index.json` — so this never guesses at what a full run should be. `isPartialCorpusGrade` in `officialExperimentScope.js` reads that flag, and `isHiddenGrade` hides it.

This subsumes the hand-written `_tight` pattern from phase 2, which was always an instance of the same rule (it now flags as `[PARTIAL 10/220 corpus]`). The pattern is kept as a fallback for grades whose experiment has no report.

### Why the failure modes are safe

- **Unknown coverage is never partial.** An experiment with no report yields `corpus_tasks: null`, and the grade stays visible. Early experiments predating `reports-index.json` are left alone rather than silently deleted — staying visible on ignorance is the safer direction.
- **Small ≠ unfinished.** An experiment graded end to end (17 of 17) is complete and stays visible. The non-exp003 subset experiments the scope module deliberately keeps are unaffected.
- `OFFICIAL_GRADE_IDS` is checked first and is never hidden by any rule.

## What this deliberately does not do

- **No file under `data/grades/` is modified.** The audit trail is intact.
- **No published figure changes.** `coverage` is additive; `avg_score_pct`, `graded_tasks`, `error_tasks` and the rest pass straight through.
- **Every grade is still reachable by direct URL**, and `?debug=1` restores the full list.

## Result

Visible cards go from **6 to 3**, all three full-corpus (220/220) runs.

## Verification

- `npx tsc --noEmit` — clean
- `npm run test:aggregate:prepared` — **138 tests, 137 pass, 1 skip** (pre-existing: Ruby not installed locally), 0 fail
- `npm run build` — succeeds
- 8 new tests: 4 on the filter predicate (partial / full / 17-of-17 complete / unknown-coverage), 4 on the aggregator (partial flagged, full run with 5 error tasks not flagged and numerator stays 220, no-report yields null, legacy-shape grades emit coverage too)
- Ran against real data: exactly 4 grades flagged, filter simulation over the regenerated index leaves 3 visible

## Open question for the owner

The 220-task `gpt-5.6-sol` regrade (57.49%) is now one of the three visible cards but is **not** in `OFFICIAL_GRADE_IDS`, so it renders without the OFFICIAL badge next to two older badged runs. Promoting it is a curation call, not a cleanup one, so it is left out of this PR — see the review thread.