### PR TITLE
chore(dashboard): publish the sol 220 result and retire the spare baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,32 @@ entries land under a fresh dated heading the day they merge to `main`.
   that had been showing up as a grading outcome. Two of those the selector
   passed through with `selection_status: 'ok'`.
 
+- **Curated the published baseline set down to a result and one comparator
+  (`src/lib/officialExperimentScope.js`)** - the 220-task `gpt-5.6-sol` regrade,
+  the run this month of work existed to produce, was rendering without the
+  OFFICIAL badge beside two older badged runs. A reader scanning the page would
+  take the badged, older, lower numbers as the benchmark's answer. It is now
+  promoted, and the older runs are cut to a single A/B comparator.
+
+  `gpt-5.4-mini` is the one retired. Against a `gpt-5.6-sol` judge it differs in
+  judge size and judge version simultaneously, so a gap measured across it
+  cannot be attributed to either; the full-size `gpt-5.4` run is the
+  like-for-like comparator and stays. Every other rule in the module decides
+  from a measured property, but which finished run represents the benchmark is
+  a publication decision, so both lists are hand-written and sit together with
+  the reasoning attached.
+
+  Retirement is not the partial-corpus rule and does not imply the numbers are
+  wrong - the retired run graded all 220 tasks and its figures stand. It is
+  display-only: no grade JSON changes, the card is one `?debug=1` away, and its
+  own page still resolves by direct URL. Visible cards go from 3 to 2, both
+  badged OFFICIAL.
+
+  `OFFICIAL_GRADE_IDS` moved from `officialFilter.ts` into
+  `officialExperimentScope.js` so the curation is covered by the node test
+  suite, including a guard that the official and retired sets can never
+  overlap.
+
 - **Partial-corpus grading runs hidden from the default dashboard view
   (`scripts/aggregate-grades.mjs`, `src/lib/officialExperimentScope.js`)** - the
   Grading Analysis tab listed six cards for the same experiment, three of which

--- a/scripts/__tests__/official-filter.test.mjs
+++ b/scripts/__tests__/official-filter.test.mjs
@@ -8,8 +8,12 @@ import {
   HIDDEN_DIAGNOSTIC_EXPERIMENT_IDS,
   isHiddenDiagnosticExperimentId,
   isHiddenOfficialExperiment,
+  isOfficialGradeId,
   isPartialCorpusGrade,
+  isSupersededGradeId,
+  OFFICIAL_GRADE_IDS,
   OFFICIAL_TASK_COUNT,
+  SUPERSEDED_GRADE_IDS,
 } from '../../src/lib/officialExperimentScope.js'
 
 test('official 220-task experiments remain visible', () => {
@@ -141,4 +145,50 @@ test('unknown coverage is never treated as partial', () => {
   assert.equal(isPartialCorpusGrade({ coverage: null }), false)
   assert.equal(isPartialCorpusGrade(null), false)
   assert.equal(isPartialCorpusGrade(undefined), false)
+})
+
+// ── Phase 4: curated baselines ──────────────────────────────────────────────
+
+const SOL_220 =
+  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_1c967673eb8081a6__v2.2'
+const GPT54_220 = 'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools'
+const GPT54_MINI_220 =
+  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini'
+
+test('the sol 220 regrade is the current official result', () => {
+  assert.equal(isOfficialGradeId(SOL_220), true)
+})
+
+test('exactly one older run is retained as an A/B comparator', () => {
+  assert.equal(isOfficialGradeId(GPT54_220), true)
+  assert.equal(isSupersededGradeId(GPT54_220), false)
+  // Two official ids total: the current result and its single comparator.
+  assert.equal(OFFICIAL_GRADE_IDS.size, 2)
+})
+
+test('the mini-judge run is retired, not deleted', () => {
+  assert.equal(isSupersededGradeId(GPT54_MINI_220), true)
+  assert.equal(isOfficialGradeId(GPT54_MINI_220), false)
+})
+
+test('no id can be both official and superseded', () => {
+  // The official guard runs first in isHiddenGrade, so an id in both sets would
+  // stay visible while reading as retired — a silent contradiction. Assert the
+  // sets are disjoint rather than relying on evaluation order.
+  const overlap = [...OFFICIAL_GRADE_IDS].filter((id) => SUPERSEDED_GRADE_IDS.has(id))
+  assert.deepEqual(overlap, [])
+})
+
+test('curation predicates reject non-string input', () => {
+  for (const bad of [null, undefined, 0, {}, []]) {
+    assert.equal(isOfficialGradeId(bad), false)
+    assert.equal(isSupersededGradeId(bad), false)
+  }
+})
+
+test('retirement is curated, never inferred from the judge name', () => {
+  // A future gpt-5.4 run must not be swept up by a pattern match on the model
+  // name; retirement is a hand-written decision about one specific run.
+  assert.equal(isSupersededGradeId('exp042_something__judge_gpt-5_4-mini__rubric_v3'), false)
+  assert.equal(isSupersededGradeId('exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini'), false)
 })

--- a/src/lib/officialExperimentScope.d.ts
+++ b/src/lib/officialExperimentScope.d.ts
@@ -13,6 +13,11 @@ interface GradeCoverageScope {
 
 export function isPartialCorpusGrade(grade: GradeCoverageScope | null | undefined): boolean
 
+export const OFFICIAL_GRADE_IDS: ReadonlySet<string>
+export const SUPERSEDED_GRADE_IDS: ReadonlySet<string>
+export function isOfficialGradeId(id: string | null | undefined): boolean
+export function isSupersededGradeId(id: string | null | undefined): boolean
+
 interface DashboardExperimentScope {
 	short_id: string
 	experiment_name: string

--- a/src/lib/officialExperimentScope.js
+++ b/src/lib/officialExperimentScope.js
@@ -39,6 +39,53 @@ export function isPartialCorpusGrade(grade) {
   return grade?.coverage?.is_partial_corpus === true
 }
 
+// ── curated baselines ───────────────────────────────────────────────────────
+// The two sets below are hand-picked, not patterns. Every other rule in this
+// file decides from measured properties; which finished run represents the
+// benchmark is a publication decision and has to be written down by a person.
+
+/**
+ * Grade ids published as official baselines — badged, and never hidden by any
+ * rule. Add an id here when a run is promoted.
+ */
+export const OFFICIAL_GRADE_IDS = new Set([
+  // gpt-5.6-sol judge, 220 tasks — current primary result
+  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_1c967673eb8081a6__v2.2',
+  // gpt-5.4 judge, 220 tasks — retained A/B comparator for the run above
+  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools',
+])
+
+/**
+ * Full-corpus runs retired in favour of a newer judge. Their numbers are
+ * sound — this is not the partial-corpus rule — but a results page that keeps
+ * every generation of judge becomes a changelog, and readers compare whatever
+ * is on screen. The dashboard therefore shows the current result plus exactly
+ * one older run as an A/B comparator, and retires the rest.
+ *
+ * `gpt-5.4-mini` is the one retired: against a `gpt-5.6-sol` judge it varies
+ * in both judge size and judge version at once, so a gap measured across it
+ * cannot be attributed to either. The full-size `gpt-5.4` run is the
+ * like-for-like comparator and stays.
+ *
+ * Retirement is display-only. The grade JSON is untouched, the card is one
+ * `?debug=1` away, and its own page still resolves by direct URL.
+ */
+export const SUPERSEDED_GRADE_IDS = new Set([
+  // gpt-5.4-mini judge, 220 tasks — superseded; see above for why this one
+  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini',
+])
+
+/** Curated official baseline: badged, and exempt from every hide rule. */
+export function isOfficialGradeId(id) {
+  return typeof id === 'string' && OFFICIAL_GRADE_IDS.has(id)
+}
+
+/** Curated retirement: a complete run kept out of the default comparison set. */
+export function isSupersededGradeId(id) {
+  return typeof id === 'string' && SUPERSEDED_GRADE_IDS.has(id)
+}
+
+
 /** Default dashboard exclusion rule for inference reports. */
 export function isHiddenOfficialExperiment(experiment) {
   return (

--- a/src/lib/officialFilter.ts
+++ b/src/lib/officialFilter.ts
@@ -17,18 +17,32 @@
  * grade covering fewer tasks than the inference run it graded is a preflight
  * and is hidden. `_tight` was always an instance of this rule written by hand;
  * the pattern stays as a fallback for grades whose experiment has no report.
+ *
+ * Phase 4 curates what survives. The 220-task `gpt-5.6-sol` regrade is promoted
+ * to OFFICIAL as the current result, and the older full-corpus runs are retired
+ * down to a single A/B comparator — every rule up to here removes things that
+ * are not results, this one decides which results still earn screen space.
  */
 import type { GradeResult } from '../hooks/useGrades'
 import type { ExperimentEntry } from '../types/report'
 import {
   isHiddenDiagnosticExperimentId,
   isHiddenOfficialExperiment,
+  isOfficialGradeId,
   isPartialCorpusGrade,
   isSmokeExperimentId,
+  isSupersededGradeId,
+  OFFICIAL_GRADE_IDS,
   OFFICIAL_TASK_COUNT,
+  SUPERSEDED_GRADE_IDS,
 } from './officialExperimentScope.js'
 
-export { OFFICIAL_TASK_COUNT, isPartialCorpusGrade }
+export {
+  OFFICIAL_GRADE_IDS,
+  OFFICIAL_TASK_COUNT,
+  SUPERSEDED_GRADE_IDS,
+  isPartialCorpusGrade,
+}
 
 /**
  * Smoke / test identifier. `exp99x` is the reserved smoke namespace
@@ -47,20 +61,25 @@ export function isDemoGrade(
 }
 
 /**
- * Curated OFFICIAL grade ids (phase 2). "Official" is a hand-picked status,
- * NOT a pattern — when a new official run is promoted, add its id here.
+ * Curated OFFICIAL grade ids (phase 2, recurated in phase 4). "Official" is a
+ * hand-picked status, NOT a pattern — when a new official run is promoted, add
+ * its id to `OFFICIAL_GRADE_IDS` in `officialExperimentScope.js`, where it sits
+ * next to the retirement list and is covered by the node test suite.
  * These are pinned visible (badged) and never hidden by any rule.
  */
-export const OFFICIAL_GRADE_IDS: ReadonlySet<string> = new Set([
-  // clean gpt-5.4 judge, 220 tasks — final baseline
-  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools',
-  // clean gpt-5.4-mini judge, 220 tasks — comparison baseline
-  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini',
-])
 
 /** Curated official baseline (gets the OFFICIAL badge; never hidden). */
 export function isOfficialGrade(g: Pick<GradeResult, 'id'>): boolean {
-  return OFFICIAL_GRADE_IDS.has(g.id)
+  return isOfficialGradeId(g.id)
+}
+
+/**
+ * A complete run retired in favour of a newer judge (phase 4). Distinct from
+ * `isPartialCorpusGrade`: nothing is wrong with these numbers, they are simply
+ * no longer the comparison the page is making.
+ */
+export function isSupersededGrade(g: Pick<GradeResult, 'id'>): boolean {
+  return isSupersededGradeId(g.id)
 }
 
 /**
@@ -76,8 +95,9 @@ export function isLegacyExp003(g: Pick<GradeResult, 'id'>): boolean {
 
 /**
  * True when a grade card should be hidden from the default (non-debug) view:
- * legacy demo, smoke/test run, a superseded/partial exp003 card, or a grading
- * run that covered only part of its inference corpus.
+ * legacy demo, smoke/test run, a superseded/partial exp003 card, a grading run
+ * that covered only part of its inference corpus, or a complete run retired in
+ * favour of a newer judge.
  * Curated OFFICIAL ids are never hidden (reverse protection).
  */
 export function isHiddenGrade(g: GradeResult): boolean {
@@ -88,6 +108,7 @@ export function isHiddenGrade(g: GradeResult): boolean {
     isSmokeId(g.id) ||
     isHiddenDiagnosticExperimentId(g.experiment_id) ||
     isHiddenDiagnosticExperimentId(g.id) ||
+    isSupersededGrade(g) ||
     isPartialCorpusGrade(g) ||
     isLegacyExp003(g)
   )


### PR DESCRIPTION
Owner decisions, implemented:

1. **Badge the newest result.** The 220-task `gpt-5.6-sol` regrade (57.49%) is promoted to OFFICIAL.
2. **Keep one A/B comparator, retire the rest.** The older gradings stay in the data but only one remains on screen.

## Why it mattered

The run this month of work existed to produce was rendering **without** the OFFICIAL badge, beside two older runs that had it. Anyone scanning the page would take the badged, older, lower numbers as the benchmark's answer.

## Which older run stays, and why

| judge | avg | verdict |
|---|---|---|
| `gpt-5.6-sol` | **57.49%** | promoted — current result |
| `gpt-5.4` | 53.30% | **retained** as the A/B comparator |
| `gpt-5.4-mini` | 54.10% | retired |

`gpt-5.4-mini` differs from `gpt-5.6-sol` in **judge size and judge version at once**, so a gap measured across it cannot be attributed to either. The full-size `gpt-5.4` run varies one thing and is the like-for-like comparison.

## Retirement ≠ the partial-corpus rule

This carries no claim that the retired numbers are wrong. That run graded all 220 tasks and its figures stand — it is simply no longer the comparison the page is making. Concretely:

- no file under `data/grades/` changes
- the card is one `?debug=1` away
- its own grade page still resolves by direct URL

Every other rule in the module decides from a measured property. Which finished run *represents* the benchmark is a publication decision, so both lists are hand-written with the reasoning attached rather than inferred from a judge-name pattern — there is a test asserting a future `gpt-5.4-mini` run is **not** swept up by this.

## Structural change

`OFFICIAL_GRADE_IDS` moves from `officialFilter.ts` into `officialExperimentScope.js`, joining `SUPERSEDED_GRADE_IDS`. The `.ts` file can't be imported by `node --test`, so the curation was previously untested; it now is — including a guard that the two sets can never overlap. That guard matters because the official check short-circuits `isHiddenGrade`, so an id in both sets would stay visible while reading as retired.

## Result

Visible cards **3 → 2**, both badged OFFICIAL, both full 220-corpus runs.

## Verification

- `node --test official-filter.test.mjs` — 17/17 pass (6 new)
- `npm run test:aggregate:prepared` — **144 tests, 143 pass, 1 skip** (pre-existing: Ruby not installed locally), 0 fail
- `npx tsc --noEmit` clean, `npm run build` clean
- Simulated against the built index: 18 grades → 2 visible, both OFFICIAL, `gpt-5.4-mini` correctly retired