### PR TITLE
test(backend): run the two guards the suite was silently skipping

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -85,19 +85,14 @@ jobs:
       # even if the addopts guard above is ever relaxed. Integration tests reach
       # paid APIs; CI must never pay.
       #
-      # One deselection, and it is a real open question rather than a nuisance:
-      # test_generated_python_launcher_denies_exec_and_network asserts that both
-      # os.system() and socket.socket() raise OSError under the launcher's
-      # seccomp filter. On the runner only socket() raises. execve/execveat are
-      # still in DENIED_SYSCALLS and the filter still loads, so the sandbox is
-      # not weaker here -- what differs is whether glibc's system() surfaces the
-      # blocked exec as a Python OSError, which it does on the dev box's 3.10
-      # kernel and does not on the runner's. That makes the assertion a probe of
-      # libc error reporting, not of the filter. Deselected until the test is
-      # rewritten to check exec denial directly (os.execv, or system()'s return
-      # code); the Docker gate remains the enforcing control either way.
+      # Nothing is deselected here, and that is the point. The sandbox launcher
+      # test used to be, because it probed exec denial through os.system(): the
+      # blocked fork and exec reach Python as an OSError on the dev box's 3.10
+      # kernel and as a plain return value on the runner's, so the assertion
+      # measured libc error reporting rather than the filter. It now probes
+      # execve directly through os.execv, which raises the filter's own EPERM
+      # wherever the filter loads, so it runs on every host the suite runs on.
       - name: Run tests
         run: |
           cd batch-runner
-          python -m pytest -m "not integration" --tb=short -q \
-            --deselect "tests/test_agentic_sandbox_security.py::test_generated_python_launcher_denies_exec_and_network"
+          python -m pytest -m "not integration" --tb=short -q

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -92,7 +92,14 @@ jobs:
       # measured libc error reporting rather than the filter. It now probes
       # execve directly through os.execv, which raises the filter's own EPERM
       # wherever the filter loads, so it runs on every host the suite runs on.
+      #
+      # -rs names every skipped test and its reason. Without it, `-q` prints
+      # only a count, and a test that stops running is indistinguishable from
+      # one that passes -- which is how the launcher test above went unnoticed.
+      # Several tests here skip on a legitimately absent host capability
+      # (seccomp TSYNC, a Docker image), so the count alone cannot tell an
+      # expected skip from a newly silent one. Keep the reasons in the log.
       - name: Run tests
         run: |
           cd batch-runner
-          python -m pytest -m "not integration" --tb=short -q
+          python -m pytest -m "not integration" --tb=short -q -rs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,7 +313,33 @@ entries land under a fresh dated heading the day they merge to `main`.
   and grade data are unchanged.
 
 ### Fixed
-- **Paid-gate workflow test pinned to the post-inheritance conditions** - the
+- **Sandbox launcher test now probes exec denial rather than libc error
+  reporting** - `test_generated_python_launcher_denies_exec_and_network`
+  asserted that `os.system('/bin/true')` and `socket.socket()` both raise
+  `OSError` under the launcher's seccomp filter. Both `execve` and `fork` sit
+  in `DENIED_SYSCALLS`, so `os.system` is blocked either way, but glibc's
+  `system()` reports that block through its return value on some libc and
+  kernel pairs and as an `OSError` on others: the assertion measured error
+  reporting, not the filter. CI deselected the test for exactly that reason,
+  and the dev box skips it because its 3.10 kernel predates seccomp TSYNC, so
+  the test ran nowhere at all. It now calls `os.execv`, a thin `execve` wrapper
+  whose denial surfaces as the filter's own `SCMP_ACT_ERRNO` `EPERM` wherever
+  the filter loads, and asserts that errno rather than merely that something
+  raised. A successful `execv` replaces the process image and would exit 0 with
+  empty output, so the `blocked` marker assertion is what keeps that failure
+  visible instead of silent. The `--deselect` argument is gone from
+  `.github/workflows/backend-tests.yml`, whose comment no longer describes a
+  deselection it does not make.
+- **`@pytest.mark.timeout` restored to a working guard** - `pytest-timeout` was
+  absent from `batch-runner/requirements.txt` while
+  `test_snapshot_manifest_fifo_fails_without_blocking` and
+  `test_snapshot_artifact_fifo_fails_without_blocking` both carry
+  `@pytest.mark.timeout(2)`. pytest treats an unregistered marker as a no-op
+  with a warning, so the two tests that exist to prove `PackageSnapshot.load`
+  fails fast on a FIFO rather than blocking forever had no mechanism left to
+  detect blocking; a regression that hung the loader would have hung the job to
+  its own ceiling instead of failing the test. The dependency is now pinned and
+  both tests pass in 0.13s with the marker active.
   approval-inheritance change left `test_grade_workflow_rc7_requires_valid_
   committed_partial` comparing `approve-paid`'s `if:` against the old literal
   `inputs.dry_run == false && inputs.paid_approval == true`, so `main` has been

--- a/batch-runner/requirements.txt
+++ b/batch-runner/requirements.txt
@@ -29,6 +29,7 @@ PyPDF2>=3.0.0                 # PDF validation
 # Testing
 pytest>=8.0.0
 pytest-cov>=4.1.0
+pytest-timeout>=2.3.0         # @pytest.mark.timeout is a no-op without it
 
 # Type checking
 mypy>=1.8.0

--- a/batch-runner/tests/test_agentic_sandbox_security.py
+++ b/batch-runner/tests/test_agentic_sandbox_security.py
@@ -801,20 +801,40 @@ def test_close_removes_may_exist_resources_without_creation_flags(tmp_path):
 
 @pytest.mark.skipif(sys.platform != "linux", reason="libseccomp launcher is Linux-only")
 def test_generated_python_launcher_denies_exec_and_network():
+    """Exec and socket creation must both fail with the filter's own EPERM.
+
+    Exec is probed through os.execv rather than os.system. os.system goes
+    through glibc's system(), which reports the blocked fork and exec in its
+    return value on some libc and kernel pairs and as an OSError on others, so
+    asserting on the exception measured libc's error reporting rather than the
+    filter itself. os.execv is a thin execve wrapper, so the SCMP_ACT_ERRNO
+    deny action surfaces as PermissionError wherever the filter loads.
+
+    A successful execv replaces the process image, so a filter that failed to
+    block it would run /bin/true and exit 0 with empty output. The 'blocked'
+    marker is what makes that failure visible instead of silent.
+    """
     source = b"""
+import errno
 import os
 import socket
 
-denied = []
-for action in (
-    lambda: os.system('/bin/true'),
-    lambda: socket.socket(socket.AF_INET, socket.SOCK_STREAM),
-):
-    try:
-        action()
-    except OSError as exc:
-        denied.append(exc.errno)
-assert len(denied) == 2, denied
+denied = {}
+
+try:
+    os.execv('/bin/true', ['/bin/true'])
+except OSError as exc:
+    denied['execve'] = exc.errno
+
+try:
+    socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+except OSError as exc:
+    denied['socket'] = exc.errno
+else:
+    raise AssertionError('socket() was permitted')
+
+assert sorted(denied) == ['execve', 'socket'], denied
+assert set(denied.values()) == {errno.EPERM}, denied
 print('blocked')
 """
     harness = (
@@ -835,7 +855,11 @@ print('blocked')
     if b"seccomp TSYNC unavailable" in result.stderr:
         pytest.skip("host runtime does not expose seccomp TSYNC; Docker gate remains required")
     assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
-    assert result.stdout.strip() == b"blocked"
+    assert result.stdout.strip() == b"blocked", (
+        "launcher did not deny exec and socket; an empty stdout with a zero "
+        "exit status means execv succeeded and replaced the process. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Closes #24, closes #25.

Both of these tests already existed, already passed, and enforced nothing.

## #24 — the seccomp launcher test ran on no host at all

`test_generated_python_launcher_denies_exec_and_network` probed exec denial by
calling `os.system('/bin/true')` and asserting it raised `OSError`. Both
`execve` and `fork` are in `DENIED_SYSCALLS`, so the call really is blocked —
but glibc's `system()` reports that block through its **return value** on some
libc and kernel pairs and as an `OSError` on others. The assertion was
measuring libc's error reporting, not the filter.

That is exactly why `backend-tests.yml` carried a `--deselect` for it. And the
dev box skips it independently, because seccomp TSYNC needs kernel ≥ 3.17 and
that box runs 3.10. Deselected in CI, skipped locally: the test ran nowhere.

It now calls `os.execv`, a thin `execve` wrapper, so the launcher's own
`SCMP_ACT_ERRNO | EPERM` deny action surfaces as `PermissionError` wherever the
filter loads. The test asserts that specific errno for both `execve` and
`socket`, not merely that something raised.

A successful `execv` **replaces the process image** — a filter that failed to
block it would run `/bin/true`, exit 0, and print nothing. The `blocked` stdout
marker assertion is what keeps that failure visible instead of silent.

The `--deselect` is gone, along with the workflow comment that described a
deselection the workflow no longer makes. (The other `deselect` mentions in
that file are the unrelated integration-marker guard and are untouched.)

## #25 — `@pytest.mark.timeout` was a no-op

`pytest-timeout` was missing from `batch-runner/requirements.txt` while
`test_snapshot_manifest_fifo_fails_without_blocking` and
`test_snapshot_artifact_fifo_fails_without_blocking` both carry
`@pytest.mark.timeout(2)`. pytest treats an unregistered marker as a no-op with
a warning. The two tests that exist to prove `PackageSnapshot.load` fails fast
on a FIFO rather than blocking forever had no mechanism left to detect
blocking — a regression that hung the loader would have hung the job to its own
ceiling instead of failing the test.

## Verification

- Full local suite: **3289 passed, 3 failed, 6 skipped**. The 3 failures
  reproduce identically on clean `origin/main` (`git stash` / `git stash pop`
  confirmed) and are environmental: missing `pdfplumber`, and locally installed
  Azure SDKs older than the versions the pinned-SDK test asserts.
- Both FIFO tests pass in 0.13s with the timeout marker now active.
- **The rewritten seccomp test could not be verified on the dev box.** Its
  kernel (3.10) predates seccomp TSYNC, so `_install_filter()` raises and the
  test skips. This PR's CI run on `ubuntu-latest` is its first real execution —
  that run is the actual verification, not anything I ran locally.