### PR TITLE
chore(grades): backfill summary.wow analytics without republishing rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,45 @@ entries land under a fresh dated heading the day they merge to `main`.
   the in-flight 220-task relay, so it waits for the shard merge.
 
 ### Changed
+- **Existing grade payloads backfilled with the `summary.wow` analytics** - the
+  entry above taught `_compute_summary` to emit the four analytic fields, but
+  only for runs graded after it merged. All 17 real grade payloads already on
+  disk still carried `by_sector: {}`, `score_density_histogram: []` and
+  `rubric_severity_curve: []`, including the newest sol-220 run, so the sector
+  heatmap, the score histogram and the severity curve rendered empty states
+  across the whole dashboard. Nothing needed re-grading and nothing was
+  dispatched: each field is a pure function of the `tasks` array already in the
+  file, and `scripts/backfill_summary_wow.py` recomputes it from that array.
+
+  What the script does *not* do is the reason it exists in this form. Six of the
+  seventeen payloads were graded under semantics the current summariser no
+  longer reproduces — the four pre-sign-aware `__v1.json` files carry no
+  `model_did_right`, so their `critical_item_pass_rate` recomputes to `0.0`
+  against a published `0.42`/`0.52`/`1.0`, and the two `rubric_v2_tools` files
+  drift by about a point (`0.501 → 0.485`, `0.4232 → 0.4338`). Republishing
+  those would let a later grading standard rewrite the record of an earlier
+  experiment, which is exactly the thing a benchmark must not do. So the rule is
+  per-file rather than global: a payload's semantics-dependent breakdowns
+  (`by_sector`, `rubric_severity_curve`) are written only when the current
+  summariser reproduces that payload's five published scalar rates exactly, and
+  that agreement is the evidence the same code understands the same file. It
+  holds for 11 of 17. The remaining 6 get `score_density_histogram` only — a
+  bucket count over the per-task `pct` values already published in the file,
+  carrying no semantic assumption that a change in grading criteria could move.
+
+  `by_rubric_category` stays `{}` everywhere for the reason given above: there
+  is no category taxonomy in a GDPVal rubric to build it from.
+
+  The script is dry-run by default and refuses to write a file if anything
+  outside `summary.wow`, or any of the five published rates inside it, would
+  change. That guard is not decoration — the first cut of this change lacked the
+  inside-`wow` half of it and would have republished four payloads'
+  `critical_item_pass_rate` as `0.0`. Verified after applying by re-parsing every
+  payload against `git show HEAD:` and confirming that the only values that moved
+  anywhere are the three analytic fields, that no `_v2sm_*` key was dropped, and
+  that every histogram and sector breakdown sums to that file's own
+  `graded_tasks` (the shortfall against `total_tasks` is exactly `error_tasks`,
+  which carry no `pct`).
 - **One paid approval now carries a whole shard, not one 4h chunk** - a shard of
   the 220-task corpus takes ~6.5h of strictly serial judge calls
   (`tpm_guard.max_concurrent: 1`), but GitHub's hosted runners cap a job at 6h

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-hybrid__11e7900__v1.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-hybrid__11e7900__v1.json
@@ -150576,7 +150576,48 @@
       "judge_error_rate": 0.006,
       "by_sector": {},
       "by_rubric_category": {},
-      "score_density_histogram": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 11
+        },
+        {
+          "bucket": "10-20%",
+          "count": 14
+        },
+        {
+          "bucket": "20-30%",
+          "count": 18
+        },
+        {
+          "bucket": "30-40%",
+          "count": 29
+        },
+        {
+          "bucket": "40-50%",
+          "count": 41
+        },
+        {
+          "bucket": "50-60%",
+          "count": 28
+        },
+        {
+          "bucket": "60-70%",
+          "count": 37
+        },
+        {
+          "bucket": "70-80%",
+          "count": 18
+        },
+        {
+          "bucket": "80-90%",
+          "count": 17
+        },
+        {
+          "bucket": "90-100%",
+          "count": 6
+        }
+      ],
       "rubric_severity_curve": []
     },
     "cost": {

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-hybrid__11e7900__v1__v2sm.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-hybrid__11e7900__v1__v2sm.json
@@ -161247,10 +161247,226 @@
       "precheck_pass_rate": 0.8384,
       "judge_pass_rate": 0.3329,
       "judge_error_rate": 0.006,
-      "by_sector": {},
+      "by_sector": {
+        "Finance and Insurance": {
+          "task_count": 24,
+          "avg_pct": 45.86,
+          "critical_item_pass_rate": 0.3478,
+          "precheck_pass_rate": 0.9524,
+          "judge_pass_rate": 0.2912
+        },
+        "Government": {
+          "task_count": 25,
+          "avg_pct": 52.32,
+          "critical_item_pass_rate": 0.5161,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.3575
+        },
+        "Health Care and Social Assistance": {
+          "task_count": 25,
+          "avg_pct": 52.56,
+          "critical_item_pass_rate": 0.3056,
+          "precheck_pass_rate": 0.9231,
+          "judge_pass_rate": 0.35
+        },
+        "Information": {
+          "task_count": 25,
+          "avg_pct": 40.56,
+          "critical_item_pass_rate": 0.4235,
+          "precheck_pass_rate": 0.5373,
+          "judge_pass_rate": 0.2812
+        },
+        "Manufacturing": {
+          "task_count": 25,
+          "avg_pct": 46.59,
+          "critical_item_pass_rate": 0.6078,
+          "precheck_pass_rate": 0.7639,
+          "judge_pass_rate": 0.3174
+        },
+        "Professional, Scientific, and Technical Services": {
+          "task_count": 25,
+          "avg_pct": 34.24,
+          "critical_item_pass_rate": 0.3208,
+          "precheck_pass_rate": 0.86,
+          "judge_pass_rate": 0.2225
+        },
+        "Real Estate and Rental and Leasing": {
+          "task_count": 25,
+          "avg_pct": 53.19,
+          "critical_item_pass_rate": 0.4957,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.4534
+        },
+        "Retail Trade": {
+          "task_count": 20,
+          "avg_pct": 59.99,
+          "critical_item_pass_rate": 0.8182,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.4489
+        },
+        "Wholesale Trade": {
+          "task_count": 25,
+          "avg_pct": 50.56,
+          "critical_item_pass_rate": 0.4118,
+          "precheck_pass_rate": 0.7727,
+          "judge_pass_rate": 0.3755
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 13
+        },
+        {
+          "bucket": "10-20%",
+          "count": 13
+        },
+        {
+          "bucket": "20-30%",
+          "count": 18
+        },
+        {
+          "bucket": "30-40%",
+          "count": 30
+        },
+        {
+          "bucket": "40-50%",
+          "count": 41
+        },
+        {
+          "bucket": "50-60%",
+          "count": 30
+        },
+        {
+          "bucket": "60-70%",
+          "count": 37
+        },
+        {
+          "bucket": "70-80%",
+          "count": 20
+        },
+        {
+          "bucket": "80-90%",
+          "count": 15
+        },
+        {
+          "bucket": "90-100%",
+          "count": 2
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": -85,
+          "n_items": 1,
+          "pass_rate": 0.0
+        },
+        {
+          "weight": -60,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -20,
+          "n_items": 2,
+          "pass_rate": 0.0
+        },
+        {
+          "weight": -10,
+          "n_items": 64,
+          "pass_rate": 0.5625
+        },
+        {
+          "weight": -6,
+          "n_items": 1,
+          "pass_rate": 0.0
+        },
+        {
+          "weight": -5,
+          "n_items": 15,
+          "pass_rate": 0.6
+        },
+        {
+          "weight": -4,
+          "n_items": 2,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -2,
+          "n_items": 6,
+          "pass_rate": 0.6667
+        },
+        {
+          "weight": -1,
+          "n_items": 2,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 1,
+          "n_items": 5369,
+          "pass_rate": 0.3366
+        },
+        {
+          "weight": 2,
+          "n_items": 4341,
+          "pass_rate": 0.3711
+        },
+        {
+          "weight": 3,
+          "n_items": 252,
+          "pass_rate": 0.381
+        },
+        {
+          "weight": 4,
+          "n_items": 61,
+          "pass_rate": 0.2787
+        },
+        {
+          "weight": 5,
+          "n_items": 274,
+          "pass_rate": 0.4818
+        },
+        {
+          "weight": 6,
+          "n_items": 26,
+          "pass_rate": 0.3846
+        },
+        {
+          "weight": 7,
+          "n_items": 6,
+          "pass_rate": 0.1667
+        },
+        {
+          "weight": 8,
+          "n_items": 7,
+          "pass_rate": 0.2857
+        },
+        {
+          "weight": 10,
+          "n_items": 19,
+          "pass_rate": 0.6316
+        },
+        {
+          "weight": 12,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 15,
+          "n_items": 1,
+          "pass_rate": 0.0
+        },
+        {
+          "weight": 16,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 20,
+          "n_items": 1,
+          "pass_rate": 1.0
+        }
+      ],
       "_v2sm_critical_items": 483,
       "_v2sm_critical_right": 225
     },

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-mini__11e7900__v1.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-mini__11e7900__v1.json
@@ -150576,7 +150576,48 @@
       "judge_error_rate": 0.0036,
       "by_sector": {},
       "by_rubric_category": {},
-      "score_density_histogram": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 12
+        },
+        {
+          "bucket": "10-20%",
+          "count": 11
+        },
+        {
+          "bucket": "20-30%",
+          "count": 14
+        },
+        {
+          "bucket": "30-40%",
+          "count": 30
+        },
+        {
+          "bucket": "40-50%",
+          "count": 32
+        },
+        {
+          "bucket": "50-60%",
+          "count": 37
+        },
+        {
+          "bucket": "60-70%",
+          "count": 39
+        },
+        {
+          "bucket": "70-80%",
+          "count": 18
+        },
+        {
+          "bucket": "80-90%",
+          "count": 19
+        },
+        {
+          "bucket": "90-100%",
+          "count": 7
+        }
+      ],
       "rubric_severity_curve": []
     },
     "cost": {

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-mini__11e7900__v1__v2sm.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-mini__11e7900__v1__v2sm.json
@@ -161247,10 +161247,226 @@
       "precheck_pass_rate": 0.8384,
       "judge_pass_rate": 0.383,
       "judge_error_rate": 0.0036,
-      "by_sector": {},
+      "by_sector": {
+        "Finance and Insurance": {
+          "task_count": 24,
+          "avg_pct": 47.96,
+          "critical_item_pass_rate": 0.5652,
+          "precheck_pass_rate": 0.9524,
+          "judge_pass_rate": 0.3361
+        },
+        "Government": {
+          "task_count": 25,
+          "avg_pct": 54.77,
+          "critical_item_pass_rate": 0.5968,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.4158
+        },
+        "Health Care and Social Assistance": {
+          "task_count": 25,
+          "avg_pct": 55.08,
+          "critical_item_pass_rate": 0.5556,
+          "precheck_pass_rate": 0.9231,
+          "judge_pass_rate": 0.4028
+        },
+        "Information": {
+          "task_count": 25,
+          "avg_pct": 49.45,
+          "critical_item_pass_rate": 0.5412,
+          "precheck_pass_rate": 0.5373,
+          "judge_pass_rate": 0.3691
+        },
+        "Manufacturing": {
+          "task_count": 25,
+          "avg_pct": 48.41,
+          "critical_item_pass_rate": 0.7255,
+          "precheck_pass_rate": 0.7639,
+          "judge_pass_rate": 0.3582
+        },
+        "Professional, Scientific, and Technical Services": {
+          "task_count": 25,
+          "avg_pct": 35.34,
+          "critical_item_pass_rate": 0.3774,
+          "precheck_pass_rate": 0.86,
+          "judge_pass_rate": 0.2515
+        },
+        "Real Estate and Rental and Leasing": {
+          "task_count": 25,
+          "avg_pct": 53.89,
+          "critical_item_pass_rate": 0.6496,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.4915
+        },
+        "Retail Trade": {
+          "task_count": 20,
+          "avg_pct": 61.81,
+          "critical_item_pass_rate": 0.8182,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.4799
+        },
+        "Wholesale Trade": {
+          "task_count": 25,
+          "avg_pct": 54.04,
+          "critical_item_pass_rate": 0.6176,
+          "precheck_pass_rate": 0.7727,
+          "judge_pass_rate": 0.4511
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 12
+        },
+        {
+          "bucket": "10-20%",
+          "count": 10
+        },
+        {
+          "bucket": "20-30%",
+          "count": 14
+        },
+        {
+          "bucket": "30-40%",
+          "count": 32
+        },
+        {
+          "bucket": "40-50%",
+          "count": 32
+        },
+        {
+          "bucket": "50-60%",
+          "count": 38
+        },
+        {
+          "bucket": "60-70%",
+          "count": 39
+        },
+        {
+          "bucket": "70-80%",
+          "count": 20
+        },
+        {
+          "bucket": "80-90%",
+          "count": 20
+        },
+        {
+          "bucket": "90-100%",
+          "count": 2
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": -85,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -60,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -20,
+          "n_items": 2,
+          "pass_rate": 0.0
+        },
+        {
+          "weight": -10,
+          "n_items": 64,
+          "pass_rate": 0.7188
+        },
+        {
+          "weight": -6,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -5,
+          "n_items": 15,
+          "pass_rate": 0.6
+        },
+        {
+          "weight": -4,
+          "n_items": 2,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -2,
+          "n_items": 6,
+          "pass_rate": 0.6667
+        },
+        {
+          "weight": -1,
+          "n_items": 2,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 1,
+          "n_items": 5369,
+          "pass_rate": 0.3777
+        },
+        {
+          "weight": 2,
+          "n_items": 4341,
+          "pass_rate": 0.4232
+        },
+        {
+          "weight": 3,
+          "n_items": 252,
+          "pass_rate": 0.4286
+        },
+        {
+          "weight": 4,
+          "n_items": 61,
+          "pass_rate": 0.377
+        },
+        {
+          "weight": 5,
+          "n_items": 274,
+          "pass_rate": 0.6314
+        },
+        {
+          "weight": 6,
+          "n_items": 26,
+          "pass_rate": 0.4615
+        },
+        {
+          "weight": 7,
+          "n_items": 6,
+          "pass_rate": 0.1667
+        },
+        {
+          "weight": 8,
+          "n_items": 7,
+          "pass_rate": 0.5714
+        },
+        {
+          "weight": 10,
+          "n_items": 19,
+          "pass_rate": 0.6316
+        },
+        {
+          "weight": 12,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 15,
+          "n_items": 1,
+          "pass_rate": 0.0
+        },
+        {
+          "weight": 16,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 20,
+          "n_items": 1,
+          "pass_rate": 1.0
+        }
+      ],
       "_v2sm_critical_items": 483,
       "_v2sm_critical_right": 288
     },

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__default_v2_mini__cfg_f4baac0b08378549__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_fd58885f62867b3b__v2.2.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__default_v2_mini__cfg_f4baac0b08378549__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_fd58885f62867b3b__v2.2.json
@@ -1966,10 +1966,75 @@
       "precheck_pass_rate": 1.0,
       "judge_pass_rate": 0.4167,
       "judge_error_rate": 0.0,
-      "by_sector": {},
+      "by_sector": {
+        "Professional, Scientific, and Technical Services": {
+          "task_count": 1,
+          "avg_pct": 50.63,
+          "critical_item_pass_rate": 0.0,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.4167
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": []
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 0
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 0
+        },
+        {
+          "bucket": "40-50%",
+          "count": 0
+        },
+        {
+          "bucket": "50-60%",
+          "count": 1
+        },
+        {
+          "bucket": "60-70%",
+          "count": 0
+        },
+        {
+          "bucket": "70-80%",
+          "count": 0
+        },
+        {
+          "bucket": "80-90%",
+          "count": 0
+        },
+        {
+          "bucket": "90-100%",
+          "count": 0
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": 1,
+          "n_items": 16,
+          "pass_rate": 0.375
+        },
+        {
+          "weight": 2,
+          "n_items": 21,
+          "pass_rate": 0.5238
+        },
+        {
+          "weight": 5,
+          "n_items": 1,
+          "pass_rate": 0.0
+        }
+      ]
     },
     "cost": {
       "total_judge_calls": 128,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini.json
@@ -360785,7 +360785,48 @@
       "judge_error_rate": 0.0356,
       "by_sector": {},
       "by_rubric_category": {},
-      "score_density_histogram": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 25
+        },
+        {
+          "bucket": "10-20%",
+          "count": 7
+        },
+        {
+          "bucket": "20-30%",
+          "count": 2
+        },
+        {
+          "bucket": "30-40%",
+          "count": 12
+        },
+        {
+          "bucket": "40-50%",
+          "count": 26
+        },
+        {
+          "bucket": "50-60%",
+          "count": 38
+        },
+        {
+          "bucket": "60-70%",
+          "count": 32
+        },
+        {
+          "bucket": "70-80%",
+          "count": 32
+        },
+        {
+          "bucket": "80-90%",
+          "count": 29
+        },
+        {
+          "bucket": "90-100%",
+          "count": 12
+        }
+      ],
       "rubric_severity_curve": []
     },
     "cost": {

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort10__cfg_b11acba425087d85__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_011ef05cf7f7a951__v2.2.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort10__cfg_b11acba425087d85__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_011ef05cf7f7a951__v2.2.json
@@ -22490,10 +22490,102 @@
       "precheck_pass_rate": 0.0,
       "judge_pass_rate": 0.4391,
       "judge_error_rate": 0.0,
-      "by_sector": {},
+      "by_sector": {
+        "Government": {
+          "task_count": 5,
+          "avg_pct": 79.26,
+          "critical_item_pass_rate": 0.4706,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.6667
+        },
+        "Professional, Scientific, and Technical Services": {
+          "task_count": 5,
+          "avg_pct": 36.22,
+          "critical_item_pass_rate": 0.2,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.2917
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": []
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 2
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 1
+        },
+        {
+          "bucket": "40-50%",
+          "count": 0
+        },
+        {
+          "bucket": "50-60%",
+          "count": 2
+        },
+        {
+          "bucket": "60-70%",
+          "count": 1
+        },
+        {
+          "bucket": "70-80%",
+          "count": 0
+        },
+        {
+          "bucket": "80-90%",
+          "count": 4
+        },
+        {
+          "bucket": "90-100%",
+          "count": 0
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": -2,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 1,
+          "n_items": 202,
+          "pass_rate": 0.495
+        },
+        {
+          "weight": 2,
+          "n_items": 199,
+          "pass_rate": 0.3869
+        },
+        {
+          "weight": 3,
+          "n_items": 11,
+          "pass_rate": 0.4545
+        },
+        {
+          "weight": 4,
+          "n_items": 3,
+          "pass_rate": 0.3333
+        },
+        {
+          "weight": 5,
+          "n_items": 18,
+          "pass_rate": 0.4444
+        },
+        {
+          "weight": 10,
+          "n_items": 1,
+          "pass_rate": 0.0
+        }
+      ]
     },
     "cost": {
       "total_judge_calls": 1359,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort3__cfg_0a8e1f421ad46dc2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_9b8a9ae3288ec3e9__v2.2.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort3__cfg_0a8e1f421ad46dc2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_9b8a9ae3288ec3e9__v2.2.json
@@ -7661,10 +7661,75 @@
       "precheck_pass_rate": 0.0,
       "judge_pass_rate": 0.281,
       "judge_error_rate": 0.0,
-      "by_sector": {},
+      "by_sector": {
+        "Professional, Scientific, and Technical Services": {
+          "task_count": 3,
+          "avg_pct": 36.14,
+          "critical_item_pass_rate": 0.0,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.281
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": []
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 1
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 1
+        },
+        {
+          "bucket": "40-50%",
+          "count": 0
+        },
+        {
+          "bucket": "50-60%",
+          "count": 0
+        },
+        {
+          "bucket": "60-70%",
+          "count": 1
+        },
+        {
+          "bucket": "70-80%",
+          "count": 0
+        },
+        {
+          "bucket": "80-90%",
+          "count": 0
+        },
+        {
+          "bucket": "90-100%",
+          "count": 0
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": 1,
+          "n_items": 68,
+          "pass_rate": 0.2647
+        },
+        {
+          "weight": 2,
+          "n_items": 82,
+          "pass_rate": 0.3049
+        },
+        {
+          "weight": 5,
+          "n_items": 3,
+          "pass_rate": 0.0
+        }
+      ]
     },
     "cost": {
       "total_judge_calls": 536,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools.json
@@ -357097,7 +357097,48 @@
       "judge_error_rate": 0.0276,
       "by_sector": {},
       "by_rubric_category": {},
-      "score_density_histogram": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 26
+        },
+        {
+          "bucket": "10-20%",
+          "count": 7
+        },
+        {
+          "bucket": "20-30%",
+          "count": 5
+        },
+        {
+          "bucket": "30-40%",
+          "count": 14
+        },
+        {
+          "bucket": "40-50%",
+          "count": 21
+        },
+        {
+          "bucket": "50-60%",
+          "count": 39
+        },
+        {
+          "bucket": "60-70%",
+          "count": 30
+        },
+        {
+          "bucket": "70-80%",
+          "count": 35
+        },
+        {
+          "bucket": "80-90%",
+          "count": 28
+        },
+        {
+          "bucket": "90-100%",
+          "count": 10
+        }
+      ],
       "rubric_severity_curve": []
     },
     "cost": {

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools_tight.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools_tight.json
@@ -6777,10 +6777,102 @@
       "precheck_pass_rate": 1.0,
       "judge_pass_rate": 0.3744,
       "judge_error_rate": 0.0338,
-      "by_sector": {},
+      "by_sector": {
+        "Government": {
+          "task_count": 5,
+          "avg_pct": 80.36,
+          "critical_item_pass_rate": 0.5294,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.6564
+        },
+        "Professional, Scientific, and Technical Services": {
+          "task_count": 5,
+          "avg_pct": 29.19,
+          "critical_item_pass_rate": 0.0,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.1912
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": []
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 2
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 1
+        },
+        {
+          "bucket": "40-50%",
+          "count": 2
+        },
+        {
+          "bucket": "50-60%",
+          "count": 1
+        },
+        {
+          "bucket": "60-70%",
+          "count": 0
+        },
+        {
+          "bucket": "70-80%",
+          "count": 0
+        },
+        {
+          "bucket": "80-90%",
+          "count": 4
+        },
+        {
+          "bucket": "90-100%",
+          "count": 0
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": -2,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 1,
+          "n_items": 202,
+          "pass_rate": 0.4653
+        },
+        {
+          "weight": 2,
+          "n_items": 199,
+          "pass_rate": 0.3467
+        },
+        {
+          "weight": 3,
+          "n_items": 11,
+          "pass_rate": 0.3636
+        },
+        {
+          "weight": 4,
+          "n_items": 3,
+          "pass_rate": 0.3333
+        },
+        {
+          "weight": 5,
+          "n_items": 18,
+          "pass_rate": 0.3889
+        },
+        {
+          "weight": 10,
+          "n_items": 1,
+          "pass_rate": 1.0
+        }
+      ]
     },
     "cost": {
       "total_judge_calls": 414,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_1c967673eb8081a6__v2.2.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_1c967673eb8081a6__v2.2.json
@@ -514014,10 +514014,226 @@
       "precheck_pass_rate": 0.0,
       "judge_pass_rate": 0.4502,
       "judge_error_rate": 0.0319,
-      "by_sector": {},
+      "by_sector": {
+        "Finance and Insurance": {
+          "task_count": 25,
+          "avg_pct": 55.59,
+          "critical_item_pass_rate": 0.2609,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.4146
+        },
+        "Government": {
+          "task_count": 25,
+          "avg_pct": 69.53,
+          "critical_item_pass_rate": 0.5738,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.5734
+        },
+        "Health Care and Social Assistance": {
+          "task_count": 22,
+          "avg_pct": 60.93,
+          "critical_item_pass_rate": 0.2727,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.4677
+        },
+        "Information": {
+          "task_count": 25,
+          "avg_pct": 49.74,
+          "critical_item_pass_rate": 0.494,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.399
+        },
+        "Manufacturing": {
+          "task_count": 25,
+          "avg_pct": 50.7,
+          "critical_item_pass_rate": 0.7083,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.3865
+        },
+        "Professional, Scientific, and Technical Services": {
+          "task_count": 25,
+          "avg_pct": 46.77,
+          "critical_item_pass_rate": 0.1837,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.3601
+        },
+        "Real Estate and Rental and Leasing": {
+          "task_count": 24,
+          "avg_pct": 59.75,
+          "critical_item_pass_rate": 0.6316,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.5292
+        },
+        "Retail Trade": {
+          "task_count": 19,
+          "avg_pct": 71.01,
+          "critical_item_pass_rate": 0.619,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.6146
+        },
+        "Wholesale Trade": {
+          "task_count": 25,
+          "avg_pct": 57.1,
+          "critical_item_pass_rate": 0.1667,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.5004
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": []
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 28
+        },
+        {
+          "bucket": "10-20%",
+          "count": 7
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 9
+        },
+        {
+          "bucket": "40-50%",
+          "count": 20
+        },
+        {
+          "bucket": "50-60%",
+          "count": 33
+        },
+        {
+          "bucket": "60-70%",
+          "count": 32
+        },
+        {
+          "bucket": "70-80%",
+          "count": 36
+        },
+        {
+          "bucket": "80-90%",
+          "count": 29
+        },
+        {
+          "bucket": "90-100%",
+          "count": 21
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": -85,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -60,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -20,
+          "n_items": 2,
+          "pass_rate": 0.5
+        },
+        {
+          "weight": -10,
+          "n_items": 64,
+          "pass_rate": 0.9844
+        },
+        {
+          "weight": -6,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -5,
+          "n_items": 15,
+          "pass_rate": 0.8
+        },
+        {
+          "weight": -4,
+          "n_items": 2,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": -2,
+          "n_items": 6,
+          "pass_rate": 0.8333
+        },
+        {
+          "weight": -1,
+          "n_items": 2,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 1,
+          "n_items": 5184,
+          "pass_rate": 0.4653
+        },
+        {
+          "weight": 2,
+          "n_items": 4224,
+          "pass_rate": 0.4768
+        },
+        {
+          "weight": 3,
+          "n_items": 242,
+          "pass_rate": 0.5413
+        },
+        {
+          "weight": 4,
+          "n_items": 60,
+          "pass_rate": 0.4167
+        },
+        {
+          "weight": 5,
+          "n_items": 254,
+          "pass_rate": 0.3858
+        },
+        {
+          "weight": 6,
+          "n_items": 26,
+          "pass_rate": 0.2692
+        },
+        {
+          "weight": 7,
+          "n_items": 6,
+          "pass_rate": 0.0
+        },
+        {
+          "weight": 8,
+          "n_items": 7,
+          "pass_rate": 0.5714
+        },
+        {
+          "weight": 10,
+          "n_items": 19,
+          "pass_rate": 0.4211
+        },
+        {
+          "weight": 12,
+          "n_items": 1,
+          "pass_rate": 1.0
+        },
+        {
+          "weight": 15,
+          "n_items": 1,
+          "pass_rate": 0.0
+        },
+        {
+          "weight": 16,
+          "n_items": 1,
+          "pass_rate": 0.0
+        },
+        {
+          "weight": 20,
+          "n_items": 1,
+          "pass_rate": 0.0
+        }
+      ]
     },
     "cost": {
       "total_judge_calls": 23250,

--- a/data/grades/exp998_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1.json
+++ b/data/grades/exp998_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1.json
@@ -1427,7 +1427,48 @@
       "judge_error_rate": 0.0,
       "by_sector": {},
       "by_rubric_category": {},
-      "score_density_histogram": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 0
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 0
+        },
+        {
+          "bucket": "40-50%",
+          "count": 0
+        },
+        {
+          "bucket": "50-60%",
+          "count": 0
+        },
+        {
+          "bucket": "60-70%",
+          "count": 1
+        },
+        {
+          "bucket": "70-80%",
+          "count": 0
+        },
+        {
+          "bucket": "80-90%",
+          "count": 2
+        },
+        {
+          "bucket": "90-100%",
+          "count": 0
+        }
+      ],
       "rubric_severity_curve": []
     },
     "cost": {

--- a/data/grades/exp998_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1__v2sm.json
+++ b/data/grades/exp998_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1__v2sm.json
@@ -1522,10 +1522,82 @@
       "precheck_pass_rate": 0.8,
       "judge_pass_rate": 0.5952,
       "judge_error_rate": 0.0,
-      "by_sector": {},
+      "by_sector": {
+        "Government": {
+          "task_count": 2,
+          "avg_pct": 83.6,
+          "critical_item_pass_rate": 0.0,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.7429
+        },
+        "Real Estate and Rental and Leasing": {
+          "task_count": 1,
+          "avg_pct": 66.88,
+          "critical_item_pass_rate": 1.0,
+          "precheck_pass_rate": 0.3333,
+          "judge_pass_rate": 0.4898
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 0
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 0
+        },
+        {
+          "bucket": "40-50%",
+          "count": 0
+        },
+        {
+          "bucket": "50-60%",
+          "count": 0
+        },
+        {
+          "bucket": "60-70%",
+          "count": 1
+        },
+        {
+          "bucket": "70-80%",
+          "count": 0
+        },
+        {
+          "bucket": "80-90%",
+          "count": 2
+        },
+        {
+          "bucket": "90-100%",
+          "count": 0
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": 1,
+          "n_items": 39,
+          "pass_rate": 0.5128
+        },
+        {
+          "weight": 2,
+          "n_items": 54,
+          "pass_rate": 0.6852
+        },
+        {
+          "weight": 5,
+          "n_items": 1,
+          "pass_rate": 1.0
+        }
+      ],
       "_v2sm_critical_items": 1,
       "_v2sm_critical_right": 1
     },

--- a/data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json
+++ b/data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json
@@ -1426,7 +1426,48 @@
       "judge_error_rate": 0.0595,
       "by_sector": {},
       "by_rubric_category": {},
-      "score_density_histogram": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 0
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 0
+        },
+        {
+          "bucket": "40-50%",
+          "count": 0
+        },
+        {
+          "bucket": "50-60%",
+          "count": 0
+        },
+        {
+          "bucket": "60-70%",
+          "count": 1
+        },
+        {
+          "bucket": "70-80%",
+          "count": 1
+        },
+        {
+          "bucket": "80-90%",
+          "count": 1
+        },
+        {
+          "bucket": "90-100%",
+          "count": 0
+        }
+      ],
       "rubric_severity_curve": []
     },
     "cost": {

--- a/data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1__v2sm.json
+++ b/data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1__v2sm.json
@@ -1521,10 +1521,82 @@
       "precheck_pass_rate": 0.8,
       "judge_pass_rate": 0.5952,
       "judge_error_rate": 0.0595,
-      "by_sector": {},
+      "by_sector": {
+        "Government": {
+          "task_count": 2,
+          "avg_pct": 77.88,
+          "critical_item_pass_rate": 0.0,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.6286
+        },
+        "Real Estate and Rental and Leasing": {
+          "task_count": 1,
+          "avg_pct": 77.72,
+          "critical_item_pass_rate": 1.0,
+          "precheck_pass_rate": 0.3333,
+          "judge_pass_rate": 0.5714
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": [],
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 0
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 0
+        },
+        {
+          "bucket": "40-50%",
+          "count": 0
+        },
+        {
+          "bucket": "50-60%",
+          "count": 0
+        },
+        {
+          "bucket": "60-70%",
+          "count": 1
+        },
+        {
+          "bucket": "70-80%",
+          "count": 1
+        },
+        {
+          "bucket": "80-90%",
+          "count": 1
+        },
+        {
+          "bucket": "90-100%",
+          "count": 0
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": 1,
+          "n_items": 39,
+          "pass_rate": 0.5128
+        },
+        {
+          "weight": 2,
+          "n_items": 54,
+          "pass_rate": 0.6852
+        },
+        {
+          "weight": 5,
+          "n_items": 1,
+          "pass_rate": 1.0
+        }
+      ],
       "_v2sm_critical_items": 1,
       "_v2sm_critical_right": 1
     },

--- a/data/grades/exp998_smoke_baseline_sample__judge_gpt-5_4__rubric_v2_tools.json
+++ b/data/grades/exp998_smoke_baseline_sample__judge_gpt-5_4__rubric_v2_tools.json
@@ -1525,10 +1525,82 @@
       "precheck_pass_rate": 0.8,
       "judge_pass_rate": 0.631,
       "judge_error_rate": 0.0119,
-      "by_sector": {},
+      "by_sector": {
+        "Government": {
+          "task_count": 2,
+          "avg_pct": 90.72,
+          "critical_item_pass_rate": 0.0,
+          "precheck_pass_rate": 1.0,
+          "judge_pass_rate": 0.7714
+        },
+        "Real Estate and Rental and Leasing": {
+          "task_count": 1,
+          "avg_pct": 75.06,
+          "critical_item_pass_rate": 0.0,
+          "precheck_pass_rate": 0.3333,
+          "judge_pass_rate": 0.5306
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": []
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 0
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 0
+        },
+        {
+          "bucket": "40-50%",
+          "count": 0
+        },
+        {
+          "bucket": "50-60%",
+          "count": 0
+        },
+        {
+          "bucket": "60-70%",
+          "count": 0
+        },
+        {
+          "bucket": "70-80%",
+          "count": 1
+        },
+        {
+          "bucket": "80-90%",
+          "count": 1
+        },
+        {
+          "bucket": "90-100%",
+          "count": 1
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": 1,
+          "n_items": 39,
+          "pass_rate": 0.5385
+        },
+        {
+          "weight": 2,
+          "n_items": 54,
+          "pass_rate": 0.7407
+        },
+        {
+          "weight": 5,
+          "n_items": 1,
+          "pass_rate": 0.0
+        }
+      ]
     },
     "cost": {
       "total_judge_calls": 84,

--- a/data/grades/exp999_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1.json
+++ b/data/grades/exp999_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1.json
@@ -731,10 +731,70 @@
       "precheck_pass_rate": 0.0,
       "judge_pass_rate": 0.8125,
       "judge_error_rate": 0.0,
-      "by_sector": {},
+      "by_sector": {
+        "Government": {
+          "task_count": 1,
+          "avg_pct": 89.17,
+          "critical_item_pass_rate": 0.0,
+          "precheck_pass_rate": 0.0,
+          "judge_pass_rate": 0.8125
+        }
+      },
       "by_rubric_category": {},
-      "score_density_histogram": [],
-      "rubric_severity_curve": []
+      "score_density_histogram": [
+        {
+          "bucket": "0-10%",
+          "count": 0
+        },
+        {
+          "bucket": "10-20%",
+          "count": 0
+        },
+        {
+          "bucket": "20-30%",
+          "count": 0
+        },
+        {
+          "bucket": "30-40%",
+          "count": 0
+        },
+        {
+          "bucket": "40-50%",
+          "count": 0
+        },
+        {
+          "bucket": "50-60%",
+          "count": 0
+        },
+        {
+          "bucket": "60-70%",
+          "count": 0
+        },
+        {
+          "bucket": "70-80%",
+          "count": 0
+        },
+        {
+          "bucket": "80-90%",
+          "count": 1
+        },
+        {
+          "bucket": "90-100%",
+          "count": 0
+        }
+      ],
+      "rubric_severity_curve": [
+        {
+          "weight": 1,
+          "n_items": 8,
+          "pass_rate": 0.875
+        },
+        {
+          "weight": 2,
+          "n_items": 8,
+          "pass_rate": 0.75
+        }
+      ]
     },
     "cost": {
       "total_judge_calls": 16,

--- a/scripts/backfill_summary_wow.py
+++ b/scripts/backfill_summary_wow.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Recompute ``summary.wow`` for grade JSONs written before it was emitted.
+
+Every grade file on disk carries a ``summary.wow`` block whose four analytic
+fields -- ``by_sector``, ``by_rubric_category``, ``score_density_histogram``
+and ``rubric_severity_curve`` -- are empty, so the dashboard's sector heatmap,
+severity curve and score histogram have nothing to draw. The five scalar rates
+next to them are populated, which is why the gap is easy to miss.
+
+Nothing needs re-grading. Each field is a pure function of the ``tasks`` array
+already in the file, and ``step8_grade._compute_summary`` is that function.
+This script calls it on the file's own tasks and copies the recomputed ``wow``
+block back in.
+
+Two fields will still come back empty, and that is correct:
+
+``by_rubric_category``
+    GDPVal rubric items have an id, a criterion string and a weight, and
+    nothing that groups them into categories. ``step8_grade`` leaves this
+    empty on purpose rather than inventing a taxonomy and presenting it as
+    measurement. ``SectorHeatmap.tsx`` already falls back to the per-sector
+    rates.
+
+``rubric_severity_curve`` on pre-sign-aware files
+    The curve counts ``model_did_right``, which grades written before PR1
+    task 100 do not carry. Without it every point reads 0.0 and the chart
+    asserts a total failure that never happened. A scalar rate can absorb a
+    missing field; a curve cannot, because its shape is the claim.
+
+The safety property this script enforces: **no published number changes.**
+
+That is not automatic, and the first cut of this script got it wrong. Six of
+the seventeen files on disk were graded under semantics the current
+summariser no longer reproduces. Recomputing their whole ``wow`` block moves
+published rates:
+
+* the four pre-sign-aware ``__v1.json`` files carry no ``model_did_right``,
+  so ``critical_item_pass_rate`` recomputes to ``0.0`` against a published
+  ``0.42`` / ``0.52`` / ``1.0`` -- a total-failure claim that never happened;
+* the two ``rubric_v2_tools`` files drift by roughly a point
+  (``0.501 -> 0.485``, ``0.4232 -> 0.4338``).
+
+So the rule is per-file, not global: **a file's semantics-dependent
+breakdowns are written only when the current summariser reproduces that
+file's five published scalar rates exactly.** Agreement is the evidence that
+the same code understands the same file. Where it disagrees, only
+``score_density_histogram`` is written -- it is a bucket count over the
+per-task ``pct`` values already published in the file, so it carries no
+semantic assumption at all.
+
+Everything outside ``summary.wow``, and the five scalar rates inside it, are
+compared before and after; the file is left untouched if any of it would
+move. Keys already present in ``wow`` that ``_compute_summary`` does not
+produce (``_v2sm_*``, written by ``backfill_sign_aware.py``) are preserved.
+
+Dry-run by default. Pass ``--apply`` to write.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "batch-runner"))
+
+from step8_grade import _compute_summary  # noqa: E402
+
+# Legacy demo data, not a real grading run. 103-backfill-existing-grades.md
+# excludes it by name, and it carries no `wow` block at all to bring forward.
+EXCLUDED = {"dummy_gpt5_baseline.json"}
+
+ANALYTIC_FIELDS = (
+    "by_sector",
+    "by_rubric_category",
+    "score_density_histogram",
+    "rubric_severity_curve",
+)
+
+#: Published rates. These must be byte-identical before and after, always.
+SCALAR_RATES = (
+    "rubric_item_coverage_avg",
+    "critical_item_pass_rate",
+    "precheck_pass_rate",
+    "judge_pass_rate",
+    "judge_error_rate",
+)
+
+#: A bucket count over the per-task ``pct`` values already published in the
+#: file. No sign-awareness, no item semantics, nothing that a change in
+#: grading criteria could move. Safe to write even where the summariser and
+#: the file disagree about everything else.
+SEMANTICS_FREE_FIELDS = ("score_density_histogram",)
+
+
+def _is_empty(value: object) -> bool:
+    return value is None or (
+        isinstance(value, (list, dict, str)) and len(value) == 0
+    )
+
+
+def _filled(wow: dict) -> int:
+    return sum(1 for f in ANALYTIC_FIELDS if not _is_empty(wow.get(f)))
+
+
+def backfill_one(path: Path, apply: bool) -> dict:
+    """Return a report for one file; write it only when ``apply`` is set."""
+    original_text = path.read_text()
+    doc = json.loads(original_text)
+
+    tasks = doc.get("tasks")
+    summary = doc.get("summary")
+    if not isinstance(tasks, list) or not isinstance(summary, dict):
+        return {"path": path.name, "status": "skipped", "reason": "no tasks/summary"}
+    old_wow = summary.get("wow")
+    if not isinstance(old_wow, dict):
+        return {"path": path.name, "status": "skipped", "reason": "no summary.wow"}
+
+    before_filled = _filled(old_wow)
+
+    # Recompute from the file's own tasks. `unpriced_models` only affects the
+    # `cost` block, which this script never reads.
+    recomputed = _compute_summary(copy.deepcopy(tasks))["wow"]
+
+    # Does the current summariser still reproduce this file's published rates?
+    # That agreement is the whole licence for writing its derived breakdowns:
+    # by_sector and rubric_severity_curve are built from the same counters as
+    # these scalars, so if the scalars disagree the breakdowns are describing
+    # a grading semantics this file was never graded under.
+    diverged = [k for k in SCALAR_RATES if old_wow.get(k) != recomputed.get(k)]
+    writable = SEMANTICS_FREE_FIELDS if diverged else ANALYTIC_FIELDS
+
+    new_wow = dict(old_wow)  # keep _v2sm_* and anything else non-standard
+    for field in writable:
+        new_wow[field] = recomputed[field]
+
+    if new_wow == old_wow:
+        return {
+            "path": path.name,
+            "status": "unchanged",
+            "before_filled": before_filled,
+            "after_filled": before_filled,
+            "diverged": diverged,
+        }
+
+    candidate = copy.deepcopy(doc)
+    candidate["summary"]["wow"] = new_wow
+
+    # Guard 1: nothing outside summary.wow moved. Compared on the parsed
+    # documents with `wow` excised from both, so key order and formatting can
+    # neither mask a real change nor invent a false one.
+    a, b = copy.deepcopy(doc), copy.deepcopy(candidate)
+    a["summary"].pop("wow", None)
+    b["summary"].pop("wow", None)
+    if a != b:
+        return {
+            "path": path.name,
+            "status": "ABORTED",
+            "reason": "a field outside summary.wow would change",
+        }
+
+    # Guard 2: no published rate inside wow moved. The first cut of this
+    # script lacked exactly this check and would have republished four files'
+    # critical_item_pass_rate as 0.0.
+    moved = [k for k in SCALAR_RATES if old_wow.get(k) != new_wow.get(k)]
+    if moved:
+        return {
+            "path": path.name,
+            "status": "ABORTED",
+            "reason": f"published rate would change: {moved}",
+        }
+
+    changed = sorted(
+        f for f in ANALYTIC_FIELDS if old_wow.get(f) != new_wow.get(f)
+    )
+    still_empty = sorted(f for f in ANALYTIC_FIELDS if _is_empty(new_wow.get(f)))
+
+    if apply:
+        # Match the trailing-newline convention of the file as found.
+        text = json.dumps(candidate, indent=2, ensure_ascii=False)
+        if original_text.endswith("\n"):
+            text += "\n"
+        path.write_text(text)
+
+    return {
+        "path": path.name,
+        "status": "written" if apply else "would-write",
+        "before_filled": before_filled,
+        "after_filled": _filled(new_wow),
+        "changed": changed,
+        "still_empty": still_empty,
+        "diverged": diverged,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "grades_dir",
+        nargs="?",
+        type=Path,
+        default=REPO_ROOT / "data" / "grades",
+    )
+    ap.add_argument("--apply", action="store_true", help="write files (default: dry run)")
+    args = ap.parse_args()
+
+    files = sorted(p for p in args.grades_dir.glob("*.json") if p.name not in EXCLUDED)
+    if not files:
+        print(f"no grade JSONs under {args.grades_dir}", file=sys.stderr)
+        return 1
+
+    reports = [backfill_one(p, args.apply) for p in files]
+    aborted = [r for r in reports if r["status"] == "ABORTED"]
+    touched = [r for r in reports if r["status"] in ("written", "would-write")]
+
+    for r in reports:
+        if r["status"] in ("skipped", "unchanged"):
+            print(f"  {r['status']:<12} {r['path'][:70]}"
+                  f"{'  (' + r['reason'] + ')' if r.get('reason') else ''}")
+            continue
+        if r["status"] == "ABORTED":
+            print(f"  ABORTED      {r['path'][:70]}  {r['reason']}")
+            continue
+        print(f"  {r['status']:<12} {r['path'][:70]}")
+        print(f"      analytic fields filled: {r['before_filled']}/4 -> {r['after_filled']}/4")
+        print(f"      changed: {r['changed']}")
+        if r.get("diverged"):
+            print(f"      SEMANTICS DIVERGED on {r['diverged']} -- "
+                  f"restricted to {list(SEMANTICS_FREE_FIELDS)}")
+        if r["still_empty"]:
+            print(f"      still empty: {r['still_empty']}")
+
+    print()
+    diverged = [r for r in reports if r.get("diverged")]
+    print(f"{len(files)} files considered, {len(EXCLUDED)} excluded by name")
+    print(f"{len(touched)} {'written' if args.apply else 'would be written'}, "
+          f"{len(aborted)} aborted")
+    print(f"{len(diverged)} files where the current summariser no longer reproduces "
+          f"the published rates (semantics-free fields only)")
+    if not args.apply and touched:
+        print("\ndry run -- re-run with --apply to write")
+    return 1 if aborted else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Three of the four `summary.wow` analytic fields are now populated in all 17 real grade payloads on disk. Before this, every one of them carried `by_sector: {}`, `score_density_histogram: []` and `rubric_severity_curve: []` — including the newest sol-220 run — so `SectorHeatmap`, `ScoreDensityHistogram` and `RubricSeverityCurve` rendered empty states across the whole dashboard.

`_compute_summary` learned to emit these fields earlier, but only for runs graded after that merged. This backfills the ones already written. Each field is a pure function of the `tasks` array already in the file, so **nothing was re-graded and no run was dispatched.**

## The constraint that shapes it

Six of the seventeen payloads were graded under semantics the current summariser no longer reproduces:

| payload | field | published | recomputed |
|---|---|---|---|
| `gpt-5_4-hybrid__11e7900__v1` | `critical_item_pass_rate` | `0.4206` | `0.0` |
| `gpt-5_4-mini__11e7900__v1` | `critical_item_pass_rate` | `0.5177` | `0.0` |
| `exp998 ..._4-mini__v1` | `critical_item_pass_rate` | `1.0` | `0.0` |
| `exp998 ..._4-pro__v1` | `critical_item_pass_rate` | `1.0` | `0.0` |
| `judge_gpt-5_4-mini__rubric_v2_tools_mini` | `rubric_item_coverage_avg` / `critical_item_pass_rate` | `0.4533` / `0.528` | `0.4646` / `0.5128` |
| `judge_gpt-5_4__rubric_v2_tools` | `rubric_item_coverage_avg` / `critical_item_pass_rate` | `0.4232` / `0.501` | `0.4338` / `0.485` |

The four `__v1.json` files carry no `model_did_right`, so the sign-aware counter finds zero right and reports a total failure that never happened. Recomputing their whole `wow` block would let a later grading standard rewrite the record of an earlier experiment.

So the rule is **per-file, not global**: a payload's semantics-dependent breakdowns (`by_sector`, `rubric_severity_curve`) are written only where the current summariser reproduces that payload's five published scalar rates exactly. That agreement is the evidence that the same code understands the same file, and it holds for 11 of 17. The other 6 get `score_density_histogram` alone — a bucket count over the per-task `pct` values already published in the file, so it carries no semantic assumption that a change in grading criteria could move.

`by_rubric_category` stays `{}` everywhere. GDPVal rubric items have an id, a criterion string and a weight and nothing that groups them, so there is no source for it; populating it would mean inventing a taxonomy and presenting it as measurement.

## Guards

`scripts/backfill_summary_wow.py` is dry-run by default and refuses to write a file if anything outside `summary.wow`, **or any of the five published rates inside it**, would change. The second half of that guard is not decoration — the first cut of this change lacked it and would have republished four payloads' `critical_item_pass_rate` as `0.0`.

## Verification

- Re-parsed every payload against `git show HEAD:` after applying: the only values that moved anywhere are the three analytic fields, no `_v2sm_*` key was dropped, and no field outside `summary.wow` changed.
- Every histogram and sector breakdown sums to that file's own `graded_tasks`; the shortfall against `total_tasks` is exactly `error_tasks`, which carry no `pct`.
- Per-sector rates bracket the run-wide rate in all 11 files that got them.
- Written shapes match `SectorWowMetric`, `ScoreDensityBucket` and `RubricSeverityPoint` in `src/types/grade.ts`.
- `pytest tests/test_grade_schema.py tests/test_step8_grade.py` — 266 passed.
- `npm run aggregate` — all 18 files aggregate, average scores unchanged.

## Follow-up worth carding separately

The current summariser no longer reproduces the published `rubric_item_coverage_avg` / `critical_item_pass_rate` for the two `rubric_v2_tools` payloads. That drift is not caused by this PR and is not fixed by it — this PR only declines to paper over it. It is worth understanding on its own.