### PR TITLE
fix(grading): render .docx deliverables for visual judging

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -650,6 +650,7 @@ jobs:
               libreoffice-core \
               libreoffice-calc \
               libreoffice-impress \
+              libreoffice-writer \
               fonts-dejavu-core \
               fonts-liberation2 \
               fontconfig || return 1

--- a/.github/workflows/grading-renderer-preflight.yml
+++ b/.github/workflows/grading-renderer-preflight.yml
@@ -50,6 +50,7 @@ jobs:
               libreoffice-core \
               libreoffice-calc \
               libreoffice-impress \
+              libreoffice-writer \
               fonts-dejavu-core \
               fonts-liberation2 \
               fontconfig || return 1

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -101,6 +101,10 @@ _VISUAL_RENDER_SCOPES: Dict[str, Dict[str, int]] = {
     ".xlsx": {"workbook_page": 1},
     ".xlsm": {"workbook_page": 1},
     ".pptx": {"slide": 1},
+    # A .docx stores no pagination, so "page 1" is page 1 of the LibreOffice
+    # conversion rather than a property of the file. That is fine at the only
+    # index used here -- the first page is the first page under any engine.
+    ".docx": {"page": 1},
     ".png": {},
     ".jpg": {},
     ".jpeg": {},

--- a/batch-runner/core/tools/read_deliverable.py
+++ b/batch-runner/core/tools/read_deliverable.py
@@ -944,6 +944,42 @@ def _op_render_to_image(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
             "base64": base64.b64encode(png).decode("ascii"),
             "byte_size": len(png),
         }
+    if kind == "docx":
+        # Unlike the two branches above there is no pre-conversion count to
+        # validate `page` against: a .docx stores no pagination, so its page
+        # count does not exist until a layout engine computes one. Nothing
+        # here opens the file with python-docx for that reason -- it could
+        # only add a way to fail on a document LibreOffice would still
+        # render. `_render_pdf_page` range-checks against the converted PDF,
+        # which is the only authoritative page count there is.
+        #
+        # The corollary, which the returned key name is careful about: page N
+        # is page N *of this conversion*. LibreOffice's line breaking is not
+        # guaranteed to match Word's, so a page index is only as stable as
+        # the converter. Page 1 -- the only page the judge asks for -- is
+        # stable under any engine.
+        _validate_scope_keys(scope, allowed={"page"}, source_kind="docx")
+        page = _positive_int(scope.get("page", 1), "page")
+        renderer_fingerprint = get_renderer_fingerprint()
+        with tempfile.TemporaryDirectory(prefix="gdpval-grade-render-") as temp:
+            out_dir = Path(temp)
+            converted = _convert_office_to_pdf(p, out_dir)
+            png, converted_page_count = _render_pdf_page(converted, page)
+        png = _downsample_to_cap(png)
+        return {
+            "kind": "image_png_base64",
+            "source_kind": "docx",
+            "scope": {"page": page},
+            "converted_page_count": converted_page_count,
+            "renderer": {
+                "converter": "libreoffice",
+                "rasterizer": "pymupdf",
+                "dpi": 150,
+                **renderer_fingerprint,
+            },
+            "base64": base64.b64encode(png).decode("ascii"),
+            "byte_size": len(png),
+        }
     if kind == "image":
         _validate_scope_keys(scope, allowed=set(), source_kind="image")
         png = _downsample_to_cap(_render_image(p))
@@ -957,7 +993,7 @@ def _op_render_to_image(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
         }
     raise UnsupportedScope(
         f"render_to_image not supported for kind={kind}; "
-        "supported: pdf, xlsx, pptx, image. "
+        "supported: pdf, xlsx, pptx, docx, image. "
         "Use inspect_structure/read_content instead."
     )
 

--- a/batch-runner/requirements-renderer.txt
+++ b/batch-runner/requirements-renderer.txt
@@ -1,5 +1,9 @@
 # Shared by grade-run.yml and grading-renderer-preflight.yml.
 openpyxl>=3.1.0
 python-pptx>=0.6.0
+# Writes the preflight's .docx fixture. The renderer itself never opens a
+# document with it -- LibreOffice does the conversion -- but the preflight has
+# to produce one to prove Writer is installed.
+python-docx>=1.0.0
 Pillow>=10.0.0
 PyMuPDF>=1.21.0

--- a/batch-runner/scripts/preflight_grading_renderer.py
+++ b/batch-runner/scripts/preflight_grading_renderer.py
@@ -121,6 +121,28 @@ def _write_pptx_fixture(path: Path) -> None:
     presentation.save(path)
 
 
+def _write_docx_fixture(path: Path) -> None:
+    from docx import Document  # type: ignore
+    from docx.shared import Pt  # type: ignore
+
+    document = Document()
+    # A plain bold run rather than add_heading(): heading styles come from the
+    # template and a missing one raises, which would report a python-docx
+    # template gap as a LibreOffice failure.
+    title = document.add_paragraph()
+    title_run = title.add_run("GDPVal grading renderer preflight")
+    title_run.font.name = FONT_FAMILY
+    title_run.font.size = Pt(20)
+    title_run.font.bold = True
+    body = document.add_paragraph()
+    body_run = body.add_run(
+        "Document body paragraph rendered through LibreOffice Writer."
+    )
+    body_run.font.name = FONT_FAMILY
+    body_run.font.size = Pt(12)
+    document.save(path)
+
+
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -237,11 +259,18 @@ def run_preflight() -> dict[str, Any]:
 
         xlsx_path = work_dir / "renderer_preflight.xlsx"
         pptx_path = work_dir / "renderer_preflight.pptx"
+        docx_path = work_dir / "renderer_preflight.docx"
         _write_xlsx_fixture(xlsx_path)
         _write_pptx_fixture(pptx_path)
+        _write_docx_fixture(docx_path)
+        # docx is here because it is the format this preflight was blind to:
+        # the grading runners installed libreoffice-core/-calc/-impress and no
+        # -writer, so a Writer-shaped gap could not fail anything. xlsx and
+        # pptx render through Calc and Impress and would keep passing.
         fixtures = (
             (xlsx_path, "xlsx", {"workbook_page": 1}),
             (pptx_path, "pptx", {"slide": 1}),
+            (docx_path, "docx", {"page": 1}),
         )
         before_hashes = {path.name: _sha256_file(path) for path, _, _ in fixtures}
         renders: list[dict[str, Any]] = []

--- a/batch-runner/tests/test_grader_preflight.py
+++ b/batch-runner/tests/test_grader_preflight.py
@@ -203,7 +203,9 @@ def test_plan_enforces_runtime_visual_file_cap(monkeypatch, tmp_path: Path):
 def test_plan_filters_unsupported_paths_from_visual_bundle(
     monkeypatch, tmp_path: Path
 ):
-    paths = ["Brief.docx", "Chart.pdf", "Report.xlsx"]
+    # Brief.docx is here to prove the opposite of what it used to prove: a
+    # document is now a render target, so only Notes.csv is filtered out.
+    paths = ["Brief.docx", "Chart.pdf", "Notes.csv"]
     for path in paths:
         (tmp_path / path).write_bytes(path.encode("utf-8"))
     selection = DeliverableSelection(
@@ -233,10 +235,10 @@ def test_plan_filters_unsupported_paths_from_visual_bundle(
     assert plan["planned_render_calls"] == 2
     assert plan["planned_perception_calls"] == 2
     assert plan["items"][0]["planned_visual_paths"] == [
+        "Brief.docx",
         "Chart.pdf",
-        "Report.xlsx",
     ]
-    assert plan["unsupported_visual_paths"] == ["Brief.docx"]
+    assert plan["unsupported_visual_paths"] == ["Notes.csv"]
     assert plan["errors"] == []
 
 

--- a/batch-runner/tests/test_grader_selector_integration.py
+++ b/batch-runner/tests/test_grader_selector_integration.py
@@ -767,9 +767,15 @@ def test_split_preflight_failure_records_prior_perception_call(
     assert style.perception_called is True
 
 
-def test_explicit_visual_docx_remains_fail_closed_without_render_target(
+def test_explicit_visual_item_fails_closed_without_render_target(
     monkeypatch, tmp_path
 ):
+    """A visual item with nothing renderable must error, not text-judge.
+
+    This used to be spelled with a .docx deliverable. Documents render now, so
+    the unrenderable case needs a format that genuinely has no render target;
+    the property under test -- fail closed, touch no model -- is unchanged.
+    """
     from core.rubric_loader import RubricItem, TaskRubric
     import core.tool_calling_judge as tool_judge_mod
 
@@ -780,8 +786,79 @@ def test_explicit_visual_docx_remains_fail_closed_without_render_target(
     monkeypatch.setattr(
         tool_judge_mod,
         "read_deliverable",
-        lambda *args, **kwargs: pytest.fail("unsupported DOCX must fail before render"),
+        lambda *args, **kwargs: pytest.fail("unrenderable file must fail before render"),
     )
+    deliverable_dir = tmp_path / "task"
+    deliverable_dir.mkdir()
+    (deliverable_dir / "Summary.csv").write_bytes(b"header_a,header_b\n1,2\n")
+    task = TaskRubric(
+        task_id="t-csv-visual",
+        sector="Information",
+        occupation="Analyst",
+        prompt="Create a CSV export of the summary table.",
+        rubric_items=[RubricItem(
+            "visual", "Document color and page layout are visually polished", 4, None
+        )],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+    grade = grader.grade_task(task, str(deliverable_dir))
+    item = grade.items[0]
+
+    assert item.routing_modality == "visual"
+    assert item.verdict == "judge_error"
+    assert item.score_excluded is True
+    assert item.evidence == "required_visual_render_target_unavailable"
+    assert item.render_call_count == 0
+    assert vision.calls == []
+    assert responses.calls == []
+
+
+def test_explicit_visual_docx_renders_instead_of_failing_closed(
+    monkeypatch, tmp_path
+):
+    """The inverse of the test above, on the same criterion and deliverable.
+
+    This exact shape -- a visual rubric item whose only deliverable is a
+    document -- is what produced 73 `required_visual_render_target_unavailable`
+    items across 24 tasks in the sol-220 run, none of which reached a model.
+    """
+    from core.rubric_loader import RubricItem, TaskRubric
+    import core.tool_calling_judge as tool_judge_mod
+
+    responses = ScriptedResponses([
+        _response(output=[_final(_payload("pass", 1.0, "page layout is polished"))]),
+    ])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision()
+    grader._tool_judge.vision_perception = vision
+    rendered = []
+
+    def fake_render(op, path, **kwargs):
+        rendered.append((path, kwargs.get("scope")))
+        return {
+            "ok": True,
+            "data": {
+                "kind": "image_png_base64",
+                "base64": "aW1hZ2U=",
+                "byte_size": 5,
+                "scope": {"page": 1},
+                "source_kind": "docx",
+                "converted_page_count": 3,
+                "renderer": {
+                    "converter": "libreoffice",
+                    "rasterizer": "pymupdf",
+                    "libreoffice_binary": "soffice",
+                    "libreoffice_version": "LibreOffice 24.2.7.2",
+                    "pymupdf_version": "1.26.3",
+                    "dpi": 150,
+                },
+            },
+        }
+
+    monkeypatch.setattr(tool_judge_mod, "read_deliverable", fake_render)
     deliverable_dir = tmp_path / "task"
     deliverable_dir.mkdir()
     (deliverable_dir / "Brief.docx").write_bytes(b"docx")
@@ -802,12 +879,16 @@ def test_explicit_visual_docx_remains_fail_closed_without_render_target(
     item = grade.items[0]
 
     assert item.routing_modality == "visual"
-    assert item.verdict == "judge_error"
-    assert item.score_excluded is True
-    assert item.evidence == "required_visual_render_target_unavailable"
-    assert item.render_call_count == 0
-    assert vision.calls == []
-    assert responses.calls == []
+    assert item.verdict == "pass"
+    assert item.score_excluded is False
+    assert item.evidence != "required_visual_render_target_unavailable"
+    assert rendered == [("Brief.docx", {"page": 1})]
+    assert item.render_call_count == 1
+    assert len(vision.calls) == 1
+    assert item.visual_provenance[0]["path"] == "Brief.docx"
+    assert (
+        item.visual_provenance[0]["renderer_metadata"]["source_kind"] == "docx"
+    )
 
 
 def test_split_visual_child_validation_precedes_task_budget_and_render(

--- a/batch-runner/tests/test_grading_renderer_preflight_workflow.py
+++ b/batch-runner/tests/test_grading_renderer_preflight_workflow.py
@@ -64,6 +64,9 @@ def test_workflow_installs_only_renderer_surface_and_validates_json():
         "libreoffice-core",
         "libreoffice-calc",
         "libreoffice-impress",
+        # Writer is what renders .docx. Its absence is why the preflight could
+        # pass while the judge could not render a document deliverable.
+        "libreoffice-writer",
         "fonts-dejavu-core",
         "fonts-liberation2",
         "fontconfig",

--- a/batch-runner/tests/test_preflight_grading_renderer.py
+++ b/batch-runner/tests/test_preflight_grading_renderer.py
@@ -94,7 +94,7 @@ def _mock_boundaries(monkeypatch, *, mutate_source=False):
             finally:
                 workbook.close()
             source_kind = "xlsx"
-        else:
+        elif path.endswith(".pptx"):
             from pptx import Presentation
 
             presentation = Presentation(str(source_path))
@@ -111,6 +111,19 @@ def _mock_boundaries(monkeypatch, *, mutate_source=False):
                     run.font.name == preflight.FONT_FAMILY for run in runs
                 )
             source_kind = "pptx"
+        else:
+            from docx import Document
+
+            document = Document(str(source_path))
+            runs = [
+                run
+                for paragraph in document.paragraphs
+                for run in paragraph.runs
+            ]
+            assert runs and all(
+                run.font.name == preflight.FONT_FAMILY for run in runs
+            )
+            source_kind = "docx"
         if mutate_source:
             source_path.write_bytes(source_path.read_bytes() + b"mutated")
         return _successful_render(source_kind, scope)
@@ -131,10 +144,10 @@ def test_run_preflight_mocks_version_conversion_and_fc_match_boundaries(
     assert result["renderer_fingerprint"] == FINGERPRINT
     assert result["font_family"] == "Liberation Sans"
     assert [render["source_kind"] for render in result["renders"]] == [
-        "xlsx", "pptx"
+        "xlsx", "pptx", "docx"
     ]
     assert [call[3] for call in observed["renders"]] == [
-        {"workbook_page": 1}, {"slide": 1}
+        {"workbook_page": 1}, {"slide": 1}, {"page": 1}
     ]
     assert len(observed["fc_match"]) == 1
     command, kwargs = observed["fc_match"][0]

--- a/batch-runner/tests/test_read_deliverable.py
+++ b/batch-runner/tests/test_read_deliverable.py
@@ -611,13 +611,128 @@ def test_render_to_image_still_rejects_unsupported_text(base_dir, txt_file):
     assert "not supported for kind=txt" in r["error"]
 
 
-def test_render_to_image_still_rejects_docx(base_dir, docx_file):
+def test_render_to_image_docx_page(base_dir, docx_file, monkeypatch):
+    """docx renders through the same LibreOffice->PDF->PyMuPDF path.
+
+    This used to assert the opposite. The judge's visual route could not
+    render a document deliverable at all, so every visual rubric item on a
+    docx-only task failed the run with
+    `required_visual_render_target_unavailable` -- 73 items across 24 tasks of
+    the sol-220 grading run, none of which ever reached a model.
+    """
+    source_before = docx_file.read_bytes()
+    observed = {}
+
+    def fake_convert(source: Path, out_dir: Path) -> Path:
+        observed["source"] = source
+        observed["bytes"] = source.read_bytes()
+        return _fake_convert_to_pdf(source, out_dir, pages=2)
+
+    monkeypatch.setattr(
+        read_deliverable_module, "_convert_office_to_pdf", fake_convert
+    )
+    monkeypatch.setattr(
+        read_deliverable_module,
+        "get_renderer_fingerprint",
+        lambda: {
+            "libreoffice_binary": "soffice",
+            "libreoffice_version": "LibreOffice 24.2.7.2",
+            "pymupdf_version": "1.26.3",
+        },
+    )
+    r = read_deliverable(
+        "render_to_image", docx_file.name,
+        base_dir=str(base_dir), scope={"page": 2},
+    )
+    assert r["ok"] is True
+    payload = r["data"]
+    assert payload["source_kind"] == "docx"
+    assert payload["scope"] == {"page": 2}
+    assert payload["converted_page_count"] == 2
+    # A .docx carries no pagination of its own, so there is no source page
+    # count to report -- only what the conversion produced.
+    assert "source_page_count" not in payload
+    assert payload["renderer"]["converter"] == "libreoffice"
+    assert payload["renderer"]["rasterizer"] == "pymupdf"
+    assert payload["renderer"]["libreoffice_binary"] == "soffice"
+    assert payload["renderer"]["libreoffice_version"] == "LibreOffice 24.2.7.2"
+    assert payload["renderer"]["pymupdf_version"] == "1.26.3"
+    assert base64.b64decode(payload["base64"]).startswith(b"\x89PNG")
+    # The original is handed to the converter untouched, as for xlsx.
+    assert observed["source"] == docx_file
+    assert observed["bytes"] == source_before
+    assert docx_file.read_bytes() == source_before
+
+
+def test_render_to_image_docx_defaults_to_first_page(
+    base_dir, docx_file, monkeypatch
+):
+    monkeypatch.setattr(
+        read_deliverable_module, "_convert_office_to_pdf", _fake_convert_to_pdf
+    )
+    monkeypatch.setattr(
+        read_deliverable_module,
+        "get_renderer_fingerprint",
+        lambda: {
+            "libreoffice_binary": "soffice",
+            "libreoffice_version": "LibreOffice 24.2.7.2",
+            "pymupdf_version": "1.26.3",
+        },
+    )
     r = read_deliverable(
         "render_to_image", docx_file.name, base_dir=str(base_dir),
     )
+    assert r["ok"] is True
+    assert r["data"]["scope"] == {"page": 1}
+
+
+def test_render_docx_out_of_range_page_is_invalid_scope(
+    base_dir, docx_file, monkeypatch
+):
+    """Range is checked against the conversion, the only page count there is."""
+    monkeypatch.setattr(
+        read_deliverable_module, "_convert_office_to_pdf", _fake_convert_to_pdf
+    )
+    monkeypatch.setattr(
+        read_deliverable_module,
+        "get_renderer_fingerprint",
+        lambda: {
+            "libreoffice_binary": "soffice",
+            "libreoffice_version": "LibreOffice 24.2.7.2",
+            "pymupdf_version": "1.26.3",
+        },
+    )
+    r = read_deliverable(
+        "render_to_image", docx_file.name,
+        base_dir=str(base_dir), scope={"page": 9},
+    )
     assert r["ok"] is False
-    assert r["error_type"] == "unsupported_scope"
-    assert "not supported for kind=docx" in r["error"]
+    assert r["error_type"] == "bad_scope"
+    assert "page 9 out of range 1..2" in r["error"]
+
+
+def test_render_docx_rejects_unknown_scope_keys(base_dir, docx_file):
+    r = read_deliverable(
+        "render_to_image", docx_file.name,
+        base_dir=str(base_dir), scope={"slide": 1},
+    )
+    assert r["ok"] is False
+    assert r["error_type"] == "bad_scope"
+    assert "unknown scope keys for docx" in r["error"]
+
+
+def test_render_docx_missing_libreoffice_is_actionable(
+    base_dir, docx_file, monkeypatch
+):
+    """The exact shape of the gap this fix closes: no Writer, clear error."""
+    monkeypatch.setattr(read_deliverable_module, "_find_soffice", lambda: None)
+    r = read_deliverable(
+        "render_to_image", docx_file.name,
+        base_dir=str(base_dir), scope={"page": 1},
+    )
+    assert r["ok"] is False
+    assert r["error_type"] == "dependency_missing"
+    assert "LibreOffice" in r["error"]
 
 
 def test_libreoffice_conversion_uses_isolated_profile_and_allowlisted_env(

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -1544,7 +1544,9 @@ def test_visual_preflight_filters_unsupported_bundle_paths(
         score=4,
         required=None,
     )
-    (deliverable_dir / "Brief.docx").write_bytes(b"docx")
+    # .csv, not .docx: documents render now, so a docx here would no longer
+    # be the unsupported case this test exists to cover.
+    (deliverable_dir / "Notes.csv").write_bytes(b"header_a,header_b\n1,2\n")
     (deliverable_dir / "Chart.pdf").write_bytes(b"pdf")
 
     pytest.importorskip("PIL")
@@ -1602,7 +1604,7 @@ def test_visual_preflight_filters_unsupported_bundle_paths(
         task=task,
         item=visual_item,
         deliverable_dir=str(deliverable_dir),
-        file_names=["Brief.docx", "Chart.pdf", "report.xlsx"],
+        file_names=["Notes.csv", "Chart.pdf", "report.xlsx"],
     )
 
     assert result.verdict == "pass"
@@ -1612,7 +1614,8 @@ def test_visual_preflight_filters_unsupported_bundle_paths(
         "Chart.pdf",
         "report.xlsx",
     ]
-    assert "Brief.docx" in client.responses.calls[0]["input"][0]["content"]
+    # Unrenderable, but still named to the model so it knows what was there.
+    assert "Notes.csv" in client.responses.calls[0]["input"][0]["content"]
 
 
 def test_visual_file_cap_fails_before_render_vision_or_main(

--- a/batch-runner/tests/test_track2_visual_inventory.py
+++ b/batch-runner/tests/test_track2_visual_inventory.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from core.grader_routing import Modality, resolve_runtime_routing
+from core.tool_calling_judge import ToolCallingJudge
 
 
 INVENTORY_SOURCE = Path(
@@ -13,19 +14,17 @@ INVENTORY_SOURCE = Path(
     "exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini"
     "__rubric_v2_tools_mini.json"
 )
-SUPPORTED_VISUAL_EXTENSIONS = {
-    ".pdf",
-    ".xlsx",
-    ".xlsm",
-    ".pptx",
-    ".png",
-    ".jpg",
-    ".jpeg",
-    ".gif",
-    ".bmp",
-    ".webp",
-}
-EXPECTED_SUPPORTED_CALL_TOTAL = 466
+# Derived from the runtime, never restated. This file used to keep its own
+# copy of the supported-extension set, and the copy is how a drift hides: when
+# .docx rendering was added, a hardcoded list here would have kept reporting
+# the old call volume against the cap and nothing would have said so.
+#
+# The totals below are a forward projection -- what a run over these 220 tasks
+# would plan today -- not a record of what the checked-in run did. Adding a
+# format moves them, which is the point: it forces a fresh look at the cap.
+# .docx took the total from 466 to 574 and left the per-task max at 68,
+# because the task holding the max carries no document deliverable.
+EXPECTED_SUPPORTED_CALL_TOTAL = 574
 EXPECTED_SUPPORTED_CALL_MAX = 68
 CONFIGURED_TASK_CAP = 72
 
@@ -34,13 +33,7 @@ def _supported_calls(criterion: str, selected_paths: list[str]) -> int:
     decision = resolve_runtime_routing(criterion, selected_paths)
     if decision.modality is not Modality.VISUAL:
         return 0
-    stable_paths = sorted(
-        dict.fromkeys(selected_paths), key=lambda path: (path.casefold(), path)
-    )
-    return sum(
-        Path(path).suffix.lower() in SUPPORTED_VISUAL_EXTENSIONS
-        for path in stable_paths
-    )
+    return len(ToolCallingJudge.planned_supported_visual_names(selected_paths))
 
 
 def _item_supported_calls(item: dict) -> int:


### PR DESCRIPTION
## What this fixes

The grading judge could not render a document. `_op_render_to_image` in
`core/tools/read_deliverable.py` handled `pdf`, `xlsx`, `pptx` and `image`, and
raised `UnsupportedScope` on everything else. A visual rubric item whose
deliverable was a `.docx` therefore failed with
`required_visual_render_target_unavailable` **before any model was called**.

In the completed sol-220 run, `required_visual_render_target_unavailable` fired
on **73 items across 24 tasks**. Of those, **65 items across 21 tasks** name a
`.docx` and are what this PR recovers. The other 8 items (3 tasks) are `.txt`
targets, including one `failed_to_generate.txt`; a text file has no render
target under any renderer, so those stay fail-closed and are tracked separately.

## Why this is a defect, not a scope limit

Four independent pieces of evidence:

1. `tasks/rebuilding_grading_task/201-tool-interface.md:41` names a 2-page docx
   fixture in its acceptance criteria.
2. This repo comments its deliberate omissions; there is no such comment here.
3. `.github/workflows/batch-run.yml:481` installs `libreoffice-writer` for the
   **inference**-side renderer (`core/artifact_renderer.py`, which *does*
   support docx). All three grading-path package lists omitted it.
4. The CI renderer preflight rendered only xlsx and pptx, so a Writer-shaped
   gap could not fail anything.

The gap was consistent end to end — no render branch, no `libreoffice-writer`,
no docx fixture — which is precisely why it stayed invisible.

## The change

**Renderer** — a docx branch mirroring the existing pptx/xlsx pattern:
LibreOffice → PDF, PyMuPDF → PNG. Unlike a workbook or a deck there is no
pre-conversion page count to validate `page` against, because a `.docx` stores
no pagination; the branch deliberately does not open the file with python-docx,
which could only add a way to fail on a document LibreOffice would still
render. `_render_pdf_page` range-checks against the conversion instead.

**Workflows** — `libreoffice-writer` added to `grade-run.yml` and
`grading-renderer-preflight.yml`. Neither half of this fix works alone.

**Preflight** — now renders a docx fixture. Without it the preflight would keep
passing on a runner with no Writer: Calc and Impress render xlsx and pptx fine.
`python-docx` was also missing from `requirements-renderer.txt` and is added.

**Tests** — three tests asserted the old behaviour. The fail-closed test keeps
its property (a visual item with no render target must error and touch no
model) and moves to `.csv`, which genuinely has no render target; a companion
test covers the docx path end to end.
`test_track2_visual_inventory.py` now derives the supported set from the
runtime instead of keeping a private copy — a private copy is how this drift
hid in the first place.

## Call-volume impact

Measured against the checked-in 220-task inventory before writing any code:

| | total planned vision calls | max per task | over cap |
|---|---|---|---|
| before | 466 | 68 | 0 |
| after | 574 (+108, +23%) | 68 (unchanged) | 0 |

The per-task max is unchanged because the task holding it carries no document
deliverable, so `call_cap_per_task: 72` is not breached. The +108 is a real
delta on any *future* run and is flagged for the owner.

## What this does not do

This changes **no recorded score**. The sol-220 `judge_error_rate` of 3.19%
(333/10453) is a property of a finished run; no code change moves it. And on a
re-run, recovering all 65 docx items would leave 268/10453 = **2.56%, still
above the 2% gate** — the residual is dominated by 243 `selection_error` items
from 5 multi-deliverable tasks, which is a separate defect.

## Verification

- Full backend suite: **3294 passed, 3 failed, 6 skipped, 45 deselected**. All
  3 failures reproduce identically on pristine `main`
  (`test_azure_ai_clients.py::test_pinned_real_project_sdk_constructs_offline_without_credential_use`,
  `test_file_preview.py::TestPdfPreview::test_basic_preview`,
  `test_read_deliverable.py::test_read_content_pdf`).
- mypy on the two changed core modules: 25 findings, **identical to `main`** —
  zero new.
- The new renderer tests use the existing fake-converter fixture, so they do
  not require a real LibreOffice.

**Real Writer verification must follow the merge.** `Grading Renderer
Preflight` is `workflow_dispatch:` only and gated on
`if: github.ref == 'refs/heads/main'`, so it cannot run on this PR. It is
model-free. I will dispatch it once this lands.

