### PR TITLE
fix(grading): grade several same-format outputs instead of declining to choose

### DIFF
--- a/batch-runner/core/deliverable_selector.py
+++ b/batch-runner/core/deliverable_selector.py
@@ -251,7 +251,7 @@ def select_deliverables(
             selection_rule="set_diff_then_primary_support_split",
         )
 
-    if task_class == "separate_equivalent":
+    if task_class in ("separate_equivalent", "uniform_primaries"):
         primary_paths = _choose_separate_primaries(generated, items, required_exts)
         if not primary_paths:
             return _selection_error(
@@ -263,17 +263,28 @@ def select_deliverables(
                 "separate_equivalent_no_primary",
             )
         support = [p for p in generated if p not in primary_paths]
+        # The emitted task_class is the same either way, because downstream
+        # routing should not care how the classification was reached. The rule
+        # is not: "separate_primaries" means the instruction said so, and
+        # "uniform_primaries" means it did not and the selector inferred it
+        # from several same-format outputs. That is a weaker inference and an
+        # audit should be able to see which tasks rest on it.
+        rule = (
+            "set_diff_then_separate_primaries"
+            if task_class == "separate_equivalent"
+            else "set_diff_then_uniform_primaries"
+        )
         return DeliverableSelection(
             selection_status="ok",
             task_id=task_id,
-            task_class=task_class,
+            task_class="separate_equivalent",
             primary_targets=[
                 _target_for_path(path, "separate_primary", target_id=None)
                 for path in primary_paths
             ],
             support_artifacts=support,
             reference_files_excluded=reference_echo,
-            selection_rule="set_diff_then_separate_primaries",
+            selection_rule=rule,
         )
 
     return _selection_error(
@@ -468,7 +479,39 @@ def _classify_task(
         if _multiple_file_types_requested(text) or len(doc_ext_groups) > 1:
             return "separate_equivalent"
 
+    # Everything above needs positive evidence -- "two separate files", two
+    # requested formats, a single named primary. What is left is the case with
+    # no such evidence: several document-like outputs sharing one format, and
+    # an instruction that never says how many files it wants. Five school
+    # reports. A plan and a deck. A guide, an application, a template.
+    #
+    # Declining to choose used to be the answer here, and it is the wrong one,
+    # because declining is not neutral: every rubric item on the task becomes a
+    # judge error and the task scores zero even though the model delivered. On
+    # the sol-220 run that was 243 of 333 judge errors from 5 tasks -- more
+    # than every other cause combined.
+    #
+    # Treating them as equal primaries is safe in a way choosing one is not.
+    # No file is demoted, and nothing downstream has to be told which one
+    # mattered: a criterion whose text matches a filename routes to that file,
+    # and every other criterion routes to the bundle, where the judge sees all
+    # of them and resolves "the fax cover sheet ..." from the criterion itself.
+    # Most land in the bundle, which is the case this relies on. So the
+    # selector no longer has to answer a question it cannot answer -- which of
+    # these is THE deliverable -- to let grading proceed.
+    if len(_document_like(generated)) >= 2:
+        return "uniform_primaries"
+
     return "ambiguous"
+
+
+def _document_like(generated: list[str]) -> list[str]:
+    return [
+        p
+        for p in generated
+        if _extension(p) in DOCUMENT_EXTENSIONS
+        and _extension(p) not in IMAGE_EXTENSIONS
+    ]
 
 
 def _has_single_primary_with_support(

--- a/batch-runner/tests/test_deliverable_selector.py
+++ b/batch-runner/tests/test_deliverable_selector.py
@@ -458,3 +458,129 @@ def test_selection_object_and_audit_schema_are_structured_not_bare_paths():
         "selected_paths",
         "support_paths_visible",
     }
+
+
+# The four tests below cover the fall-through that used to return
+# "ambiguous_candidates": several same-format outputs and an instruction that
+# never says how many files it wants. On the sol-220 run that fall-through was
+# 243 of 333 judge errors across 5 tasks, every one of which scored zero with
+# the judge never called, on tasks where the model had in fact delivered.
+#
+# The shapes here are taken from those tasks: a checklist plus a fax cover
+# sheet, five parallel school reports, a guide plus its application form.
+
+
+def _uniform_selection(names: list[str], criteria: list[str], instruction: str = ""):
+    return select_deliverables(
+        task_id="uniform",
+        deliverable_files=[_path("uniform", name) for name in names],
+        instruction=instruction,
+        rubric_items=[{"criterion": c, "score": 1} for c in criteria],
+    )
+
+
+def test_uniform_same_format_outputs_are_recovered_as_separate_primaries():
+    selection = _uniform_selection(
+        ["Fax_Cover_Sheet.docx", "Admission_Pre_Screening_Checklist.docx"],
+        [
+            "Includes a title at the top of the fax cover sheet.",
+            "Includes a labeled, writable field for the sender's name.",
+            "Lists the required pre-admission documents.",
+        ],
+    )
+
+    assert selection.selection_status == "ok"
+    assert selection.task_class == "separate_equivalent"
+    # A distinct rule, not the one explicit language earns. Both reach the same
+    # routing, but an audit has to be able to tell which tasks rest on the
+    # weaker inference.
+    assert selection.selection_rule == "set_diff_then_uniform_primaries"
+    assert _selected_names(selection) == {
+        "Fax_Cover_Sheet.docx",
+        "Admission_Pre_Screening_Checklist.docx",
+    }
+
+
+def test_uniform_recovery_scales_past_two_equivalent_outputs():
+    names = [
+        "Floral_Park_Bellerose_School_Report.pdf",
+        "Garden_City_Park_School_Report.pdf",
+        "Hillside_Grade_School_Report.pdf",
+        "John_Lewis_Childs_School_Report.pdf",
+        "Manor_Oaks_School_Report.pdf",
+    ]
+    selection = _uniform_selection(
+        names,
+        [
+            "The report includes the overall Niche.com grade for Hillside Grade School.",
+            "The report includes the overall Niche.com grade for Manor Oaks School.",
+        ],
+    )
+
+    assert selection.selection_status == "ok"
+    assert selection.selection_rule == "set_diff_then_uniform_primaries"
+    assert _selected_names(selection) == set(names)
+
+
+def test_uniform_recovery_shows_the_judge_every_file_by_default():
+    # This is what makes equal primaries safe where choosing one would not be.
+    # "fax cover sheet" does not match the filename Fax_Cover_Sheet, so the
+    # criterion routes to the bundle rather than to one file -- and that is the
+    # common case, not the exception. The judge gets both files plus the
+    # criterion text and resolves which one it is about. Nothing is demoted and
+    # nothing is hidden, which is exactly what picking a single primary here
+    # would have done.
+    selection = _uniform_selection(
+        ["Fax_Cover_Sheet.docx", "Admission_Pre_Screening_Checklist.docx"],
+        ["Limits the fax cover sheet length to one page."],
+    )
+
+    plan = plan_targets_for_criterion(
+        selection, "Limits the fax cover sheet length to one page."
+    )
+
+    assert plan.target_scope == "primary_bundle"
+    assert plan.selected_paths == [
+        _path("uniform", "Fax_Cover_Sheet.docx"),
+        _path("uniform", "Admission_Pre_Screening_Checklist.docx"),
+    ]
+
+
+def test_uniform_recovery_still_narrows_when_a_criterion_names_the_file():
+    selection = _uniform_selection(
+        ["Fax_Cover_Sheet.docx", "Admission_Pre_Screening_Checklist.docx"],
+        ["Limits Fax_Cover_Sheet to one page."],
+    )
+
+    plan = plan_targets_for_criterion(selection, "Limits Fax_Cover_Sheet to one page.")
+
+    assert plan.target_scope == "file_target"
+    assert plan.selected_paths == [_path("uniform", "Fax_Cover_Sheet.docx")]
+
+
+def test_explicit_separate_language_keeps_its_own_stronger_rule():
+    # The recovery is a fall-through and must stay one: a task whose
+    # instruction does say how many files it wants is still classified by that
+    # statement, not by counting outputs.
+    selection = _uniform_selection(
+        ["Session_13.pptx", "Session_14.pptx"],
+        ["Provides two separate presentations, one per session."],
+    )
+
+    assert selection.selection_status == "ok"
+    assert selection.selection_rule == "set_diff_then_separate_primaries"
+
+
+def test_candidates_with_no_document_still_decline_to_choose():
+    # The point of the change is not that the selector now always answers. With
+    # nothing document-like to grade there is still no defensible choice, and
+    # saying so remains better than inventing one.
+    selection = _uniform_selection(
+        ["convergence_binomial.png", "pricing_comparison.png"],
+        ["The chart is readable."],
+    )
+
+    assert selection.selection_status == "selection_error"
+    assert selection.task_class == "ambiguous"
+    assert selection.selection_rule == "ambiguous_candidates"
+    assert selection.primary_targets == []

--- a/batch-runner/tests/test_track2_visual_inventory.py
+++ b/batch-runner/tests/test_track2_visual_inventory.py
@@ -24,6 +24,15 @@ INVENTORY_SOURCE = Path(
 # format moves them, which is the point: it forces a fresh look at the cap.
 # .docx took the total from 466 to 574 and left the per-task max at 68,
 # because the task holding the max carries no document deliverable.
+#
+# One limit worth stating, because the number looks more complete than it is:
+# the projection reads the selected_paths this run recorded, so the 5 tasks it
+# recorded as selection_error contribute nothing -- they have no paths. The
+# selector now resolves those (set_diff_then_uniform_primaries), and a fresh
+# run would plan roughly 18 more calls than the figure below, peaking at 5 on
+# any one of them. That does not move the max or threaten the cap, which is
+# why this stays a fixed expectation rather than a re-derived one: deriving it
+# would need the task instructions, which this file deliberately does not read.
 EXPECTED_SUPPORTED_CALL_TOTAL = 574
 EXPECTED_SUPPORTED_CALL_MAX = 68
 CONFIGURED_TASK_CAP = 72


### PR DESCRIPTION
## What this changes

The deliverable selector had one last resort: decline. If a task produced several document-like files, the instruction never said how many files it wanted, and no single file could be named the primary, the selector returned `selection_error`.

Declining reads as the cautious option. It isn't. A `selection_error` means every rubric item on that task is recorded as a judge error, the judge is never called, and the task scores 0.0 — on work the model did in fact deliver.

On the completed 220-task run that single fall-through produced **243 of 333 judge errors, across 5 tasks** — more than every other cause combined:

| task | what the model produced |
|---|---|
| `94925f49` | 5 parallel school-report PDFs |
| `cecac8f9` | an 8-week plan PDF + a team launch deck PDF |
| `1aecc095` | 3 telehealth .docx (email, roadmap, workflow) |
| `c9bf9801` | a mentorship guide + application form + roadmap template, all .docx |
| `7151c60a` | a pre-screening checklist + a fax cover sheet, both .docx |

Every one of them is gradable. None of them was graded.

## The approach

Treat them as **equal primaries** rather than picking one. That is safe in a way picking one is not: no file is demoted, and no criterion has to be told which file it meant.

- A criterion whose text contains a filename routes to that file (`file_target`).
- Every other criterion routes to the bundle (`primary_bundle`), where the judge sees *all* the files plus the criterion text and resolves "the fax cover sheet …" itself.

Most criteria land in the bundle — `_match_file_specific_target` matches filename substrings, not natural language, so "the fax cover sheet" does **not** match `Fax_Cover_Sheet.docx`. That is the case this design relies on, and the tests assert it directly rather than assuming the friendlier routing.

The emitted `task_class` stays `separate_equivalent`, so no downstream router learns a new case. The **audit rule** does distinguish them: `set_diff_then_uniform_primaries` records that the classification was inferred from output shape, versus `set_diff_then_separate_primaries` when the instruction stated it. The inferred one is the weaker claim and an audit should be able to see which tasks rest on it.

## Safety, measured rather than asserted

Replayed the selector over all 220 tasks of the completed run, reconstructing inputs from the recorded selections:

| | before | after |
|---|---|---|
| `ok` | 188 | **197** |
| `selection_error` | 9 | **0** |
| `wrong_format_primary` | 22 | 22 |
| `no_generated_candidate` | 1 | 1 |
| `set_diff_single` | 131 | 131 |
| `set_diff_then_separate_primaries` | 31 | 31 |
| `set_diff_then_primary_support_split` | 24 | 24 |
| `set_diff_then_format_variant` | 2 | 2 |
| `set_diff_then_uniform_primaries` | 0 | **9** |

**Zero tasks moved out of `ok`.** The change touches only the fall-through, i.e. exactly the tasks that hard-error today.

The harness reproduces 214/220 recorded outcomes exactly; the 6 that differ all fail *pessimistically* (it drops `instruction`, which only ever adds signal), so it is a conservative lower bound and cannot invent a broken task. All 5 real ambiguous tasks are inside the repro's 9.

## Cost

These 5 tasks previously made 0 judge calls and 0 vision calls, because they hard-errored before the judge.

| task | files | items | judge calls | vision calls | cap-blocked |
|---|---|---|---|---|---|
| `1aecc095` | 3 | 52 | 54 | 4 | 0 |
| `cecac8f9` | 2 | 55 | 56 | 2 | 0 |
| `c9bf9801` | 3 | 47 | 47 | 3 | 0 |
| `94925f49` | 5 | 56 | 60 | 5 | **1** |
| `7151c60a` | 2 | 33 | 33 | 4 | 0 |
| **total** | | | **250** | **18** | **1** |

~1 judge call per item, nothing near the 72-per-task visual cap. 242 of the 243 items recover; the last trades `selection_error` for `required_visual_file_cap_exceeded` on the 5-PDF task (5 > `_VISUAL_FILE_CAP = 3`).

## Does not touch the completed run

No recorded score changes, no `grader_source_hash` change, no threshold moved, nothing excluded. Applying this to the sol-220 run would require re-grading those 5 tasks — a new dispatch, and an owner decision, not part of this PR.

Projected `judge_error_rate` on a *fresh* run, combining this with #189: 333 − 65 (docx) − 242 (selector) = **26 → 0.249%**, under the 2% gate. That is a projection under the replay harness, not a measurement.

## Tests

6 new regression tests in `test_deliverable_selector.py`, built from the shapes of the 5 real tasks:

- recovery on two same-format outputs, asserting the distinct `uniform_primaries` audit rule
- recovery scaling past two (the 5 school reports)
- the judge sees **every** file by default — asserts `primary_bundle`, which is the common case
- narrowing still works when a criterion contains the literal filename
- explicit "two separate presentations" language still earns the *stronger* rule, so the recovery stays a fall-through
- candidates with no document-like file **still decline** — the point is not that the selector always answers

`test_track2_visual_inventory.py` gains a comment stating the limit of its own projection: it reads recorded `selected_paths`, so those 5 tasks contribute 0, and a fresh run would plan ~18 more calls than the number it asserts. Re-deriving it would need the task instructions the file deliberately does not read.

Full backend suite: **3300 passed, 3 failed, 6 skipped**. The 3 are pre-existing environment failures that also fail on pristine `main` (pinned SDK versions, missing `pdfplumber`); baseline was 3294 passed, and +6 is exactly the new tests. `mypy core/deliverable_selector.py` clean.
