### PR TITLE
fix(grading): pin the renderer version the published corpus was graded on

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -630,10 +630,24 @@ jobs:
       #
       # This does not make apt succeed while a mirror is down; nothing here
       # can. It converts a silent five-hour hang into either a recovery or a
-      # fast, legible failure. Removing the apt dependency altogether means
-      # running this job in ghcr.io/hyeonsangjeon/gdpval-sandbox, which already
-      # ships LibreOffice -- tracked separately, deliberately not on the
-      # critical path for finishing the current run.
+      # fast, legible failure.
+      #
+      # What apt cannot give is a *fixed* renderer: these packages carry no
+      # version, so whichever LibreOffice the mirror serves that day becomes
+      # the judge's eyes, and on formatting criteria the renderer is the
+      # evidence. Two runs a generation apart are not comparable however
+      # identical their model, prompt, and grader_source_hash. The preflight
+      # below closes that by asserting the installed version against
+      # EXPECTED_LIBREOFFICE_VERSION before Azure login, so drift costs a free
+      # step rather than a paid corpus run.
+      #
+      # Pinning a version here instead was considered and rejected: Ubuntu
+      # drops superseded builds from the pocket, so the pin would fail as an
+      # opaque apt error some months from now rather than as a statement about
+      # comparability. A purpose-built image is the durable answer -- and it
+      # must be ubuntu:24.04-based, since ghcr.io/hyeonsangjeon/gdpval-sandbox
+      # ships LibreOffice 7.4.7.2 against this runner's 24.2.7.2 and would
+      # move the very scores it was meant to stabilise.
       - name: Install grading render dependencies
         if: steps.renderer.outputs.required == 'true'
         run: |

--- a/batch-runner/scripts/preflight_grading_renderer.py
+++ b/batch-runner/scripts/preflight_grading_renderer.py
@@ -34,6 +34,40 @@ FONT_FAMILY = "Liberation Sans"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 SUBPROCESS_TIMEOUT_SEC = 10
 
+#: The LibreOffice build every published grade file was rendered by, verbatim
+#: as ``renderer_fingerprint.libreoffice_version`` records it.
+#:
+#: The renderer is not a detail of how a grade is produced -- on formatting
+#: criteria it *is* the evidence. ``PR3_EXP003_REVALIDATION.md`` measured the
+#: v2 judge awarding 61.8% of available formatting points against v1's 87.7%,
+#: and traced the whole gap to what each judge could see. A grader that reads
+#: a rendered page inherits that renderer's layout decisions, so two runs on
+#: two LibreOffice generations are not comparable no matter how identical the
+#: model, prompt, and ``grader_source_hash`` are.
+#:
+#: Nothing pinned it. The workflow asks apt for ``libreoffice-core`` and
+#: friends with no version, printed the result, and checked nothing; whatever
+#: the mirror served that day became the judge's eyes. This constant closes
+#: that: a mismatch fails here, before Azure login, so drift costs a free
+#: preflight instead of a paid corpus run that lands incomparable numbers in
+#: ``data/grades/``.
+#:
+#: Deliberately the full version line rather than the ``24.2.7.2`` prefix. The
+#: distribution build suffix moves only when the binary does, and the binary
+#: is the thing under test.
+EXPECTED_LIBREOFFICE_VERSION = "LibreOffice 24.2.7.2 420(Build:2)"
+
+#: Repoint the pin without editing this file -- for a deliberate, announced
+#: renderer upgrade, where the new value is chosen rather than discovered.
+EXPECTED_VERSION_ENV = "GDPVAL_EXPECTED_LIBREOFFICE_VERSION"
+
+#: Escape hatch for the case the pin exists to catch: the run must go out
+#: today and the operator accepts that its scores stand alone. Set to ``1``
+#: and the mismatch degrades to a warning. It cannot hide the drift -- the
+#: actual version still lands in ``renderer_fingerprint`` in every grade file
+#: and in ``renderer_version_drift_accepted`` in this preflight's own output.
+ALLOW_VERSION_DRIFT_ENV = "GDPVAL_ALLOW_RENDERER_VERSION_DRIFT"
+
 
 class RendererPreflightError(RuntimeError):
     """Raised when a renderer preflight invariant is not satisfied."""
@@ -176,6 +210,31 @@ def _validate_fingerprint(fingerprint: Any) -> dict[str, str]:
     return normalized
 
 
+def _expected_libreoffice_version() -> str:
+    override = os.environ.get(EXPECTED_VERSION_ENV, "").strip()
+    return override or EXPECTED_LIBREOFFICE_VERSION
+
+
+def _validate_pinned_version(fingerprint: Mapping[str, str]) -> bool:
+    """Return whether an accepted drift occurred; raise on an unaccepted one."""
+    expected = _expected_libreoffice_version()
+    actual = fingerprint["libreoffice_version"]
+    if actual == expected:
+        return False
+    detail = (
+        f"grading renderer is {actual!r} but this repository is pinned to "
+        f"{expected!r}. Formatting verdicts are read off LibreOffice renders, "
+        "so grades produced here would not be comparable with the published "
+        "corpus. Upgrade deliberately by setting "
+        f"{EXPECTED_VERSION_ENV} to the new version, or accept a one-off "
+        f"incomparable run with {ALLOW_VERSION_DRIFT_ENV}=1."
+    )
+    if os.environ.get(ALLOW_VERSION_DRIFT_ENV, "").strip() != "1":
+        raise RendererPreflightError(detail)
+    print(f"::warning::{detail}", file=sys.stderr)
+    return True
+
+
 def _validate_render_result(
     result: Any,
     *,
@@ -256,6 +315,7 @@ def run_preflight() -> dict[str, Any]:
         work_dir = Path(temp)
         font_match = _validate_liberation_sans(work_dir)
         fingerprint = _validate_fingerprint(get_renderer_fingerprint())
+        version_drift_accepted = _validate_pinned_version(fingerprint)
 
         xlsx_path = work_dir / "renderer_preflight.xlsx"
         pptx_path = work_dir / "renderer_preflight.pptx"
@@ -297,6 +357,8 @@ def run_preflight() -> dict[str, Any]:
         "ok": True,
         "font_family": font_match,
         "renderer_fingerprint": fingerprint,
+        "expected_libreoffice_version": _expected_libreoffice_version(),
+        "renderer_version_drift_accepted": version_drift_accepted,
         "renders": renders,
     }
 

--- a/batch-runner/tests/test_preflight_grading_renderer.py
+++ b/batch-runner/tests/test_preflight_grading_renderer.py
@@ -13,7 +13,11 @@ from scripts import preflight_grading_renderer as preflight
 
 FINGERPRINT = {
     "libreoffice_binary": "soffice",
-    "libreoffice_version": "LibreOffice 24.2.7.2",
+    # The full line the probe actually returns, build suffix included, and the
+    # value every published grade file carries. A fixture trimmed to the bare
+    # version number would silently satisfy a prefix check and stop testing
+    # the pin the moment the pin got stricter.
+    "libreoffice_version": preflight.EXPECTED_LIBREOFFICE_VERSION,
     "pymupdf_version": "1.26.3",
 }
 PNG = preflight.PNG_SIGNATURE + b"mock-rendered-png"
@@ -165,6 +169,108 @@ def test_run_preflight_rejects_source_mutation(monkeypatch):
 
     with pytest.raises(preflight.RendererPreflightError, match="mutated"):
         preflight.run_preflight()
+
+
+def test_pin_matches_every_published_grade_file():
+    """The pin is only meaningful if it is the corpus's actual renderer.
+
+    Read from the published artifacts rather than restated, because a pin
+    typed by hand can drift from the thing it claims to pin and nothing
+    would say so.
+    """
+    grades_dir = Path(__file__).resolve().parents[2] / "data" / "grades"
+    observed = set()
+    for path in sorted(grades_dir.glob("*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        fingerprint = payload.get("renderer_fingerprint")
+        if isinstance(fingerprint, dict) and fingerprint.get(
+            "libreoffice_version"
+        ):
+            observed.add(fingerprint["libreoffice_version"])
+
+    assert observed, "no published grade file records a renderer fingerprint"
+    assert observed == {preflight.EXPECTED_LIBREOFFICE_VERSION}
+
+
+def test_version_drift_fails_closed_before_any_paid_work(monkeypatch):
+    monkeypatch.delenv(preflight.ALLOW_VERSION_DRIFT_ENV, raising=False)
+    monkeypatch.delenv(preflight.EXPECTED_VERSION_ENV, raising=False)
+
+    with pytest.raises(
+        preflight.RendererPreflightError, match="not be comparable"
+    ):
+        preflight._validate_pinned_version(
+            {**FINGERPRINT, "libreoffice_version": "LibreOffice 7.4.7.2 40"}
+        )
+
+
+def test_version_drift_is_not_satisfied_by_a_prefix(monkeypatch):
+    """``24.2.7.2`` alone is a different build, not a looser spelling."""
+    monkeypatch.delenv(preflight.ALLOW_VERSION_DRIFT_ENV, raising=False)
+    monkeypatch.delenv(preflight.EXPECTED_VERSION_ENV, raising=False)
+
+    with pytest.raises(preflight.RendererPreflightError):
+        preflight._validate_pinned_version(
+            {**FINGERPRINT, "libreoffice_version": "LibreOffice 24.2.7.2"}
+        )
+
+
+def test_expected_version_env_repoints_the_pin(monkeypatch):
+    monkeypatch.delenv(preflight.ALLOW_VERSION_DRIFT_ENV, raising=False)
+    monkeypatch.setenv(preflight.EXPECTED_VERSION_ENV, "LibreOffice 25.8.1.2")
+
+    assert (
+        preflight._validate_pinned_version(
+            {**FINGERPRINT, "libreoffice_version": "LibreOffice 25.8.1.2"}
+        )
+        is False
+    )
+
+
+def test_accepted_drift_warns_and_is_recorded_rather_than_hidden(
+    monkeypatch, capsys
+):
+    monkeypatch.delenv(preflight.EXPECTED_VERSION_ENV, raising=False)
+    monkeypatch.setenv(preflight.ALLOW_VERSION_DRIFT_ENV, "1")
+
+    accepted = preflight._validate_pinned_version(
+        {**FINGERPRINT, "libreoffice_version": "LibreOffice 7.4.7.2 40"}
+    )
+
+    assert accepted is True
+    assert "::warning::" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("value", ["", "0", "true", "yes", " 1 x"])
+def test_only_exactly_1_accepts_drift(monkeypatch, value):
+    monkeypatch.delenv(preflight.EXPECTED_VERSION_ENV, raising=False)
+    monkeypatch.setenv(preflight.ALLOW_VERSION_DRIFT_ENV, value)
+
+    with pytest.raises(preflight.RendererPreflightError):
+        preflight._validate_pinned_version(
+            {**FINGERPRINT, "libreoffice_version": "LibreOffice 7.4.7.2 40"}
+        )
+
+
+def test_matching_version_reports_no_drift(monkeypatch):
+    monkeypatch.delenv(preflight.ALLOW_VERSION_DRIFT_ENV, raising=False)
+    monkeypatch.delenv(preflight.EXPECTED_VERSION_ENV, raising=False)
+
+    assert preflight._validate_pinned_version(FINGERPRINT) is False
+
+
+def test_successful_preflight_publishes_the_pin_it_enforced(monkeypatch):
+    monkeypatch.delenv(preflight.ALLOW_VERSION_DRIFT_ENV, raising=False)
+    monkeypatch.delenv(preflight.EXPECTED_VERSION_ENV, raising=False)
+    _mock_boundaries(monkeypatch)
+
+    result = preflight.run_preflight()
+
+    assert (
+        result["expected_libreoffice_version"]
+        == preflight.EXPECTED_LIBREOFFICE_VERSION
+    )
+    assert result["renderer_version_drift_accepted"] is False
 
 
 @pytest.mark.parametrize("family", ["DejaVu Sans", "Liberation Sans Narrow"])

--- a/tasks/rebuilding_grading_task/000-OVERVIEW.md
+++ b/tasks/rebuilding_grading_task/000-OVERVIEW.md
@@ -55,28 +55,43 @@ PR3의 남은 항목(300 · 302 · 303)은 전부 유료 dispatch나 비용 결�
 그래서 순서를 "무료로 먼저 확정할 수 있는 것 → 유료 중 가장 값어치 있는 것"으로
 잡는다. 아래 두 건이 그 순서다.
 
-### C1 — grade job을 prebuilt container로 이전 (무료, 선행)
+### C1 — 렌더러 버전 고정 (무료, 선행) ✅ **DONE — `#193`**
 
-`ghcr.io/hyeonsangjeon/gdpval-sandbox`는 이미 `libreoffice` 메타패키지를 담고
-있다 (`batch-runner/sandbox/Dockerfile:39`). grade job은 아직 shard마다 apt로
-설치한다.
+**원래 계획은 틀렸다.** 이 항목은 "grade job을 `ghcr.io/hyeonsangjeon/gdpval-sandbox`로
+옮긴다"였다. Dockerfile이 아니라 실제 이미지를 받아서 열어보니 성립하지 않는다.
 
-**이건 더 이상 장애 수정이 아니다.** shard 5개를 죽였던 apt 정지는 `#26`에서
-retry·timeout·dpkg lock timeout으로 이미 처리됐다 (`grade-run.yml:637-668`).
-지금 남은 이유는 다르고, 중요한 순서대로:
+| | sandbox 이미지 | 지금 grade 러너 | 발행된 grade 파일 |
+|---|---|---|---|
+| LibreOffice | **7.4.7.2** | **24.2.7.2** | **24.2.7.2** (4개 전부) |
+| `git` | 없음 | 있음 | — |
+| `az` | 없음 | 있음 | — |
 
-1. **렌더러가 버전 고정이 안 돼 있는데, 렌더러가 점수를 움직인다.** 설치는
-   `libreoffice-core` / `-calc` / `-impress` / `-writer`를 버전 없이 요청한다.
-   그날 미러가 주는 게 곧 judge가 보는 이미지를 만든다. 301은 v2의 formatting
-   판정이 "본 것"에서 나온다는 걸 확인했다 — 즉 렌더러가 고정 안 되면 점수도
-   고정이 안 된다. grader source hash가 같아도 한 달 차이 나는 두 run은 엄밀히
-   비교 대상이 아니다. **baseline으로 발행할 run을 만들기 *전에* 해야 하는
-   이유가 이것이다.**
-2. retry는 미러 장애를 복구 가능하게 만들 뿐 없애지 못한다. container는 미러가
-   필요 없다.
-3. 같은 패키지를 shard 수만큼 반복 설치한다.
-4. `#189`의 .docx 렌더링은 Writer 존재에 의존한다. container에서는 빌드 시점의
-   사실이고, apt에서는 런타임의 기대다.
+즉 그 이미지로 옮기면 (1) 채점기의 눈을 17세대 낡은 렌더러로 **바꿔서 점수를
+움직이고** — 이 항목이 막으려던 바로 그 일이다 — (2) `git`이 없어
+`actions/checkout`이 `.git` 없는 tarball로 떨어져 shard merge의 commit·push가
+깨지고 (3) `az`가 없어 `azure/login` + `DefaultAzureCredential`이 인증하지
+못한다. sandbox 이미지에 `az`를 넣는 선택지는 보안상 기각했다 — 그 이미지는 LLM이
+쓴 코드를 실행한다.
+
+**목적은 다른 방법으로 달성했다.** 진짜 문제는 컨테이너 유무가 아니라 apt가
+`libreoffice-core`/`-calc`/`-impress`/`-writer`를 버전 없이 요청하고, 결과를
+출력만 하고 **아무것도 검증하지 않는다**는 것이었다. 그날 미러가 주는 게 곧
+judge의 눈이 된다. 301은 formatting 판정이 "본 것"에서 나온다는 걸 확인했으므로
+(v2 61.8% vs v1 87.7%) 렌더러 세대가 다른 두 run은 model·prompt·
+`grader_source_hash`가 같아도 비교 대상이 아니다.
+
+`#193`은 `scripts/preflight_grading_renderer.py`가 설치된 버전을 발행 corpus의
+값(`LibreOffice 24.2.7.2 420(Build:2)`)과 대조하게 했다. shard마다,
+`azure/login` **앞에서** 돈다 — drift는 무료 스텝에서 실패한다.
+
+여기에 더 날카로운 구멍 하나가 같이 막혔다. `step9_merge_shards.py:124`는
+`renderer_fingerprint`를 contract identity 필드로 요구한다. 즉 shard 9개가 같은
+버전을 기록해야 병합된다. 며칠에 걸쳐 resume하는 9-shard run이 중간에 미러 bump를
+맞으면 **돈을 다 쓴 뒤에** 병합이 거부된다.
+
+남은 일(무료, P2): `FROM ubuntu:24.04` 기반 전용 grading 이미지. 버전이 구조적으로
+일치하고, 미러 의존과 shard당 중복 설치가 사라지고, Ubuntu가 패키지를 올릴 때
+사람이 pin을 고칠 필요가 없어진다. board 카드 참조.
 
 ### R1 — 220 task 전체 재채점 (유료, owner gate) ⭐
 
@@ -111,8 +126,15 @@ run 안에 서로 다른 두 채점 파이프라인이 섞인다. "새로운 기
 `.py`를 해싱하므로 `#189`·`#190` 둘 다 포함된다). 새 run은 새 파일로 떨어지고
 **아무것도 덮어쓰지 않는다. 따라서 `force`는 반드시 `false`.**
 
-**선행 조건: C1.** 이 run의 formatting 판정은 LibreOffice 렌더에서 나오는데 지금
-설치는 버전을 고정하지 않는다.
+**선행 조건: 해소됨.** 이 run의 formatting 판정은 LibreOffice 렌더에서 나오는데,
+`#193`이 그 버전을 발행 corpus와 동일하게 고정하고 shard 9개가 같은 버전을
+기록하도록 보장한다.
+
+**한 가지 운영 리스크가 남아 있다.** 직전 시도 3건은 apt도 렌더러도 아닌 이유로
+죽었다: `union has 214 task(s) but expected_task_count is 220 (6 missing).
+Refusing to promote an incomplete merge to run_status='final'.` 완결성 가드가
+제대로 작동한 것이지만, R1도 같은 자리에서 멈출 수 있다는 뜻이다. dispatch 전에
+shard 0 canary로 확인한다.
 
 **푸는 것:** `< 2%` 게이트를 처음으로 정당하게 통과 · 303의 3회 중 1회를 겸함
 (303의 추가 비용이 2회로 감소) · 300에 corpus 전체 비교 대상 제공.


### PR DESCRIPTION
## What this changes

The grade job installs LibreOffice with no version pin, prints the result, and asserts nothing. The preflight now asserts it against the version every published grade file was actually rendered by.

## Why it matters

`PR3_EXP003_REVALIDATION.md` traced the whole formatting gap — v2 awarding **61.8%** of available formatting points against v1's **87.7%** — to what each judge could *see*. On formatting criteria the renderer is not an implementation detail, it is the evidence. Two runs a LibreOffice generation apart are not comparable however identical their model, prompt, and `grader_source_hash`.

Every grade file in `data/grades/` records `LibreOffice 24.2.7.2 420(Build:2)`. Nothing was holding it there.

There is a second, sharper failure mode. `step9_merge_shards.py:124` lists `renderer_fingerprint` among the contract identity fields, so all nine shards must record the same version or the merge refuses. A 9-shard run that resumes across days would hit a mirror bump *after* the money was spent. The preflight runs per shard and before `azure/login`, so that now fails free.

## Escapes

Both explicit, both leave a trace:

| env | effect |
|---|---|
| `GDPVAL_EXPECTED_LIBREOFFICE_VERSION` | repoints the pin for a deliberate, chosen upgrade |
| `GDPVAL_ALLOW_RENDERER_VERSION_DRIFT=1` | accepts one incomparable run; warns; sets `renderer_version_drift_accepted` |

The real version still lands in `renderer_fingerprint` regardless, so an accepted drift cannot hide.

## Correcting a stale note

The comment above the apt block said the durable fix was to run this job in `ghcr.io/hyeonsangjeon/gdpval-sandbox`. Verified against the actual image rather than the Dockerfile:

| | image | this runner |
|---|---|---|
| LibreOffice | **7.4.7.2** | **24.2.7.2** |
| `git` | absent | present |
| `az` | absent | present |

So that migration would break `actions/checkout` and the shard `git push`, break `azure/login` + `DefaultAzureCredential`, and move the very scores it was meant to stabilise. A purpose-built `ubuntu:24.04` image is the durable answer; the comment now says so.

Pinning apt package versions was also considered and rejected — Ubuntu drops superseded builds from the pocket, so the pin would fail as an opaque apt error some months out rather than as a statement about comparability.

## Tests

`tests/test_preflight_grading_renderer.py` — 22 passed, 9 new. The pin is verified by reading `data/grades/*.json` rather than restating the constant, so a hand-typed value cannot drift from the corpus it claims to describe. Prefix matches are rejected; only `=1` accepts drift.

Full suite: **3312 passed**, 3 pre-existing failures unrelated to this change (local SDK version pins, `pdfplumber` absent locally) that also fail on `main`.

## Not in scope

No score changes, no grade file touched, no dispatch. `grader_source_hash` is unaffected — `scripts/` is not hashed.