### PR TITLE
feat(grading): report shard relays that stop without finishing

### DIFF
--- a/.github/workflows/shard-relay-sweep.yml
+++ b/.github/workflows/shard-relay-sweep.yml
@@ -1,0 +1,90 @@
+name: Shard Relay Sweep
+
+# Watches for a sharded grade run that stopped without producing a final grade.
+#
+# `#194` let a shard that finds a short union stand down (exit 75) and leave the
+# merge to whichever sibling finishes last. That is right for the normal case,
+# and it removed a large class of false red runs. It also widened a hole: if one
+# shard never finishes, every sibling defers, nobody merges, and no final grade
+# is written. The shard that *crashes* reports itself -- its own run goes red.
+# The shard that ends green without finishing does not, and that is the case
+# this sweep exists for. It happens when the auto-resume relay's
+# `gh workflow run` dispatch fails (rate limit, expired token, a transient API
+# error) and the run still exits successfully.
+#
+# It cannot be closed inside the merge step, because shards are independent
+# `workflow_dispatch` runs rather than a matrix: no job can `needs:` all of
+# them. So this watches from outside.
+#
+# Strictly read-only. It never dispatches a shard, never merges, never commits.
+# Its whole output is a red run and a job summary.
+
+on:
+  schedule:
+    # Every three hours, off the hour. The sweep tolerates eight hours of
+    # silence before calling a relay stopped, so this cadence finds a broken
+    # relay within a working day without ever racing a healthy chunk.
+    - cron: "37 */3 * * *"
+  workflow_dispatch:
+    inputs:
+      stale_after_hours:
+        description: "Silence tolerated before a relay is called stopped"
+        required: false
+        default: "8"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shard-relay-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+          # Full history, not the default shallow clone. Liveness is read from
+          # `git log -- data/grades/_shards/<stem>`: a working shard commits its
+          # slice at the end of every chunk, so the newest commit touching a stem
+          # is a direct record of progress. A depth-1 clone has no such history
+          # and every stem would report "cannot tell".
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      # The sweep reads JSON and one YAML key. `step9_merge_shards`, which it
+      # borrows the shard loader from, is stdlib-only. Installing the full
+      # batch-runner requirements would cost minutes for nothing.
+      - name: Install PyYAML
+        run: python -m pip install --disable-pip-version-check "PyYAML>=6,<7"
+
+      - name: Sweep for stopped shard relays
+        id: sweep
+        working-directory: batch-runner
+        env:
+          STALE_AFTER_HOURS: ${{ inputs.stale_after_hours || '8' }}
+        run: |
+          set -uo pipefail
+          python3 scripts/sweep_stalled_shard_relays.py \
+            --stale-after-hours "$STALE_AFTER_HOURS" \
+            | tee "$RUNNER_TEMP/sweep.txt"
+          rc=${PIPESTATUS[0]}
+          {
+            echo "## Shard relay sweep"
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/sweep.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$rc"

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/build_agentic_input_manifest.py
 !batch-runner/scripts/compare_agentic_conditions.py
 !batch-runner/scripts/select_agentic_tasks.py
+!batch-runner/scripts/sweep_stalled_shard_relays.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/batch-runner/scripts/sweep_stalled_shard_relays.py
+++ b/batch-runner/scripts/sweep_stalled_shard_relays.py
@@ -133,6 +133,35 @@ def stride_size(shard_index: int, total: int, shard_count: int) -> int:
     return len(range(shard_index, total, shard_count))
 
 
+def parse_commit_stamp(text: str) -> datetime | None:
+    """Read the first parseable ``%cI`` timestamp out of ``git log`` output.
+
+    Two renderings have to be accepted. git through ~2.4x writes UTC as
+    ``2026-08-20T09:00:00+00:00``; git 2.55 writes the same instant as
+    ``2026-08-20T09:00:00Z``. Python 3.10's ``fromisoformat`` accepts only the
+    first, so a sweep that parsed naively would read every stem as "cannot
+    tell" on a current runner while passing on an older developer box -- silent
+    and total, since `unknown` is a quiet state by design.
+
+    Scanning lines rather than taking the whole stream keeps stray output from
+    a configured hook or signature check from masking a real answer.
+    """
+    for line in text.splitlines():
+        stamp = line.strip()
+        if not stamp:
+            continue
+        if stamp.endswith(("Z", "z")):
+            stamp = f"{stamp[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(stamp)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return None
+
+
 def last_commit_at(repo_root: Path, path: Path) -> datetime | None:
     """Return the commit time of the newest commit touching ``path``.
 
@@ -182,16 +211,7 @@ def last_commit_at(repo_root: Path, path: Path) -> datetime | None:
         return None
     if completed.returncode != 0:
         return None
-
-    for line in completed.stdout.splitlines():
-        try:
-            parsed = datetime.fromisoformat(line.strip())
-        except ValueError:
-            continue
-        if parsed.tzinfo is None:
-            return parsed.replace(tzinfo=timezone.utc)
-        return parsed.astimezone(timezone.utc)
-    return None
+    return parse_commit_stamp(completed.stdout)
 
 
 def canonical_ids_from_configs(

--- a/batch-runner/scripts/sweep_stalled_shard_relays.py
+++ b/batch-runner/scripts/sweep_stalled_shard_relays.py
@@ -140,11 +140,39 @@ def last_commit_at(repo_root: Path, path: Path) -> datetime | None:
     shallow-cloned directory. The caller treats that as "cannot tell" and
     stays quiet rather than guessing, because file mtimes after a CI checkout
     are checkout time and would make every stem look brand new.
+
+    The pathspec is made relative to the resolved work tree before it is handed
+    to git. That is not tidying: the shipped defaults are ``--repo-root ..`` and
+    ``--grades-root ../data/grades``, so passing the stem through unchanged
+    hands git a pathspec starting with ``..`` from a cwd inside the repository,
+    which it refuses as outside the work tree. Resolving both ends also makes
+    the answer independent of which side happens to carry a symlink.
     """
     try:
+        root = repo_root.resolve()
+        relative = os.path.relpath(path.resolve(), root)
+    except OSError:
+        return None
+    if relative == os.pardir or relative.startswith(os.pardir + os.sep):
+        # Genuinely outside the work tree. Nothing git can say about it.
+        return None
+
+    try:
         completed = subprocess.run(
-            ["git", "log", "-1", "--format=%cI", "--", str(path)],
-            cwd=repo_root,
+            # `log.showSignature` is a global-config footgun: with it on, every
+            # `git log` interleaves verification output, and a monitoring script
+            # that parsed the first line would read noise as "cannot tell".
+            [
+                "git",
+                "-c",
+                "log.showSignature=false",
+                "log",
+                "-1",
+                "--format=%cI",
+                "--",
+                Path(relative).as_posix(),
+            ],
+            cwd=root,
             capture_output=True,
             text=True,
             timeout=60,
@@ -154,16 +182,16 @@ def last_commit_at(repo_root: Path, path: Path) -> datetime | None:
         return None
     if completed.returncode != 0:
         return None
-    stamp = completed.stdout.strip()
-    if not stamp:
-        return None
-    try:
-        parsed = datetime.fromisoformat(stamp)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+
+    for line in completed.stdout.splitlines():
+        try:
+            parsed = datetime.fromisoformat(line.strip())
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return None
 
 
 def canonical_ids_from_configs(

--- a/batch-runner/scripts/sweep_stalled_shard_relays.py
+++ b/batch-runner/scripts/sweep_stalled_shard_relays.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Report shard relays that stopped without producing a final grade.
+
+``#194`` gave a shard that finds a short union a way to stand down politely:
+it exits ``75`` and lets whichever sibling finishes last do the merge. That is
+right for the normal case and it removed a large class of false red runs. It
+also widened a hole that was already there. If one shard never finishes, every
+surviving sibling defers, nobody merges, and no final grade is ever written.
+
+The failure is quiet in a specific way. A shard that *crashes* turns its own
+workflow run red, and after ``#194`` red means something really broke, so the
+common case reports itself. The case nothing reports is a shard that ends
+**green** without finishing -- the auto-resume relay dispatches the next chunk
+with ``gh workflow run``, and if that dispatch fails (rate limit, expired
+token, a transient API error) the run still ends successfully. The relay is
+broken and every signal is green.
+
+It cannot be closed inside the merge step, because shards are independent
+``workflow_dispatch`` runs rather than a matrix: no job can ``needs:`` all of
+them, so there is nowhere to hang "everyone is done, now merge". This sweep
+watches from outside instead. It is read-only -- it never dispatches, never
+merges, never writes. It reads what has been committed and says whether anyone
+is still making progress.
+
+Liveness comes from git rather than from the workflow API. A working shard
+commits its slice at the end of every chunk, so the newest commit touching a
+stem directory is a direct record of progress; an idle shard leaves that
+timestamp standing still. That is both cheaper and less ambiguous than matching
+dispatch inputs against ``Run GDPVal Grade Pipeline``, which is the display
+title every shard of every run shares.
+
+Run it from ``batch-runner/``, the way the other scripts here are run::
+
+    python3 scripts/sweep_stalled_shard_relays.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+import yaml
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parent.parent
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from step9_merge_shards import (  # noqa: E402  (needs the path insert above)
+    ShardMergeError,
+    _shard_task_ids,
+    load_shard_file,
+)
+
+
+#: How long a stem may go without a new commit before the relay is called
+#: stopped. A healthy chunk is capped by ``GRADER_TIME_BUDGET_SEC=14400`` (4h)
+#: in ``grade-run.yml``, after which the shard partial-saves, commits, and
+#: re-dispatches itself, so the longest legitimate silence is one chunk plus
+#: queueing and dependency install. Eight hours is roughly double that -- late
+#: enough never to interrupt a slow-but-working run, early enough that a broken
+#: relay is found the same day rather than the next time somebody looks.
+STALE_AFTER_HOURS_DEFAULT = 8.0
+
+#: ``grade-run.yml`` writes ``printf 'shard-%03d-of-%03d.json'``.
+SHARD_NAME = re.compile(r"^shard-(\d{3})-of-(\d{3})\.json$")
+
+#: States that mean a human has to do something. Everything else is either
+#: finished or still moving.
+FAILING_STATES = frozenset({"stalled", "unmerged", "malformed"})
+
+
+@dataclass(frozen=True)
+class RelayVerdict:
+    """What the sweep concluded about one ``_shards/<stem>/`` directory."""
+
+    stem: str
+    state: str
+    detail: str
+    quiet_for_hours: float | None = None
+    #: shard index -> the task ids it still owes, when the canonical order is
+    #: known. Empty when it is not; see ``shortfall_by_shard``.
+    missing_by_shard: dict[int, list[str]] = field(default_factory=dict)
+    #: shard index -> how many tasks it still owes. Always populated for a
+    #: failing verdict, because a count can be derived from the stride profile
+    #: alone even when the canonical ids cannot be recovered.
+    shortfall_by_shard: dict[int, int] = field(default_factory=dict)
+
+    @property
+    def failing(self) -> bool:
+        return self.state in FAILING_STATES
+
+
+def ordered_task_ids_sha256(task_ids: Sequence[str]) -> str:
+    """Hash an ordered id list the way ``step8_grade`` does.
+
+    Kept byte-identical to ``step8_grade._ordered_task_ids_sha256`` so a
+    grading config's pinned list can be checked against the value the shards
+    recorded. Duplicated rather than imported because importing ``step8_grade``
+    pulls in the whole judging stack for one hash.
+    """
+    encoded = json.dumps(
+        list(task_ids),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def stride_owner(position: int, shard_count: int) -> int:
+    """Return the shard index that owns canonical ``position``.
+
+    ``step8_grade._shard_slice`` splits by stride (``tasks[i::n]``), so
+    ownership is just the position modulo the shard count.
+    """
+    if shard_count <= 1:
+        return 0
+    return position % shard_count
+
+
+def stride_size(shard_index: int, total: int, shard_count: int) -> int:
+    """How many tasks shard ``shard_index`` is responsible for."""
+    if shard_count <= 1:
+        return total
+    return len(range(shard_index, total, shard_count))
+
+
+def last_commit_at(repo_root: Path, path: Path) -> datetime | None:
+    """Return the commit time of the newest commit touching ``path``.
+
+    ``None`` when git knows nothing about the path -- an uncommitted or
+    shallow-cloned directory. The caller treats that as "cannot tell" and
+    stays quiet rather than guessing, because file mtimes after a CI checkout
+    are checkout time and would make every stem look brand new.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "log", "-1", "--format=%cI", "--", str(path)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    stamp = completed.stdout.strip()
+    if not stamp:
+        return None
+    try:
+        parsed = datetime.fromisoformat(stamp)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def canonical_ids_from_configs(
+    config_dir: Path, expected_sha256: str
+) -> list[str] | None:
+    """Find the pinned canonical id list matching ``expected_sha256``.
+
+    Matching by hash rather than by parsing the stem for a config name: the
+    stem is a long underscore-joined string whose fields could be re-ordered,
+    while the hash is the same value the shards themselves agreed on. A config
+    that hashes correctly *is* the right one, so this verifies instead of
+    assuming, and simply finds nothing when no config pins that corpus.
+    """
+    if not expected_sha256 or not config_dir.is_dir():
+        return None
+    for candidate in sorted(config_dir.glob("*.yaml")):
+        try:
+            loaded = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(loaded, dict):
+            continue
+        identity = loaded.get("rerun_identity")
+        if not isinstance(identity, dict):
+            continue
+        task_ids = identity.get("task_ids")
+        if not isinstance(task_ids, list) or not task_ids:
+            continue
+        if not all(isinstance(value, str) for value in task_ids):
+            continue
+        if ordered_task_ids_sha256(task_ids) == expected_sha256:
+            return list(task_ids)
+    return None
+
+
+def _agreed(payloads: Sequence[dict], key: str):
+    """Return the value all payloads carry for ``key``, or raise on a split."""
+    values = {json.dumps(payload.get(key), sort_keys=True) for payload in payloads}
+    if len(values) != 1:
+        raise ShardMergeError(f"shards disagree on {key}")
+    return payloads[0].get(key)
+
+
+def inspect_stem(
+    stem_dir: Path,
+    *,
+    final_path: Path,
+    now: datetime,
+    stale_after: timedelta,
+    commit_time: Callable[[Path], datetime | None],
+    canonical_lookup: Callable[[str], list[str] | None],
+) -> RelayVerdict:
+    """Classify one ``_shards/<stem>/`` directory."""
+    stem = stem_dir.name
+
+    if final_path.exists():
+        return RelayVerdict(stem, "merged", "final grade is published")
+
+    shard_files: dict[int, Path] = {}
+    declared_counts: set[int] = set()
+    for candidate in sorted(stem_dir.iterdir()):
+        match = SHARD_NAME.match(candidate.name)
+        if match is None:
+            continue
+        index, count = int(match.group(1)), int(match.group(2))
+        declared_counts.add(count)
+        if index in shard_files:
+            return RelayVerdict(
+                stem, "malformed", f"shard index {index} appears more than once"
+            )
+        shard_files[index] = candidate
+
+    if not shard_files:
+        return RelayVerdict(stem, "empty", "no shard files")
+    if len(declared_counts) != 1:
+        counts = ", ".join(str(value) for value in sorted(declared_counts))
+        return RelayVerdict(
+            stem, "malformed", f"shard files disagree on the shard count: {counts}"
+        )
+
+    shard_count = declared_counts.pop()
+    absent = [index for index in range(shard_count) if index not in shard_files]
+    if absent:
+        # Not a stalled relay. A shard that has published nothing has either not
+        # been dispatched yet or is still inside its first chunk, and both are
+        # normal -- the canary-first procedure deliberately runs shard 0 alone
+        # for hours before the rest go out. Reported, never failed on.
+        listed = ", ".join(str(index) for index in absent)
+        return RelayVerdict(
+            stem,
+            "fanning-out",
+            f"{len(shard_files)}/{shard_count} shards have published; "
+            f"waiting on {listed}",
+        )
+
+    payloads: dict[int, dict] = {}
+    union: set[str] = set()
+    holdings: dict[int, int] = {}
+    for index, path in sorted(shard_files.items()):
+        try:
+            payload, _ = load_shard_file(path)
+            ids = _shard_task_ids(payload, f"{stem} shard {index}")
+        except ShardMergeError as exc:
+            return RelayVerdict(stem, "malformed", str(exc))
+        payloads[index] = payload
+        holdings[index] = len(ids)
+        union.update(ids)
+
+    ordered = [payloads[index] for index in sorted(payloads)]
+    try:
+        expected_total = _agreed(ordered, "expected_task_count")
+        expected_sha = _agreed(ordered, "expected_ordered_task_ids_sha256")
+    except ShardMergeError as exc:
+        return RelayVerdict(stem, "malformed", str(exc))
+    if not isinstance(expected_total, int) or expected_total <= 0:
+        return RelayVerdict(
+            stem, "malformed", "shards carry no usable expected_task_count"
+        )
+
+    newest = commit_time(stem_dir)
+    if newest is None:
+        return RelayVerdict(
+            stem, "unknown", "git has no commit touching this stem; cannot judge liveness"
+        )
+    quiet = now - newest
+    quiet_hours = round(quiet.total_seconds() / 3600.0, 2)
+
+    if quiet < stale_after:
+        return RelayVerdict(
+            stem,
+            "working",
+            f"{len(union)}/{expected_total} tasks in, last commit "
+            f"{quiet_hours}h ago",
+            quiet_for_hours=quiet_hours,
+        )
+
+    shortfall = {
+        index: stride_size(index, expected_total, shard_count) - holdings[index]
+        for index in range(shard_count)
+        if stride_size(index, expected_total, shard_count) > holdings[index]
+    }
+
+    missing_by_shard: dict[int, list[str]] = {}
+    canonical = canonical_lookup(expected_sha) if isinstance(expected_sha, str) else None
+    if canonical is not None and len(canonical) == expected_total:
+        for position, task_id in enumerate(canonical):
+            if task_id in union:
+                continue
+            missing_by_shard.setdefault(
+                stride_owner(position, shard_count), []
+            ).append(task_id)
+
+    if len(union) >= expected_total:
+        return RelayVerdict(
+            stem,
+            "unmerged",
+            f"all {expected_total} tasks are in and no shard has merged them "
+            f"for {quiet_hours}h",
+            quiet_for_hours=quiet_hours,
+        )
+
+    return RelayVerdict(
+        stem,
+        "stalled",
+        f"{len(union)}/{expected_total} tasks in and nothing has been "
+        f"committed for {quiet_hours}h",
+        quiet_for_hours=quiet_hours,
+        missing_by_shard=missing_by_shard,
+        shortfall_by_shard=shortfall,
+    )
+
+
+def sweep(
+    grades_root: Path,
+    *,
+    now: datetime,
+    stale_after: timedelta,
+    commit_time: Callable[[Path], datetime | None],
+    canonical_lookup: Callable[[str], list[str] | None],
+) -> list[RelayVerdict]:
+    """Classify every stem under ``<grades_root>/_shards/``."""
+    shards_root = grades_root / "_shards"
+    if not shards_root.is_dir():
+        return []
+    verdicts: list[RelayVerdict] = []
+    for stem_dir in sorted(shards_root.iterdir()):
+        if not stem_dir.is_dir():
+            continue
+        verdicts.append(
+            inspect_stem(
+                stem_dir,
+                final_path=grades_root / f"{stem_dir.name}.json",
+                now=now,
+                stale_after=stale_after,
+                commit_time=commit_time,
+                canonical_lookup=canonical_lookup,
+            )
+        )
+    return verdicts
+
+
+def render(verdicts: Iterable[RelayVerdict], *, annotate: bool) -> list[str]:
+    """Return the human-readable report lines."""
+    lines: list[str] = []
+    for verdict in verdicts:
+        lines.append(f"[{verdict.state}] {verdict.stem}")
+        lines.append(f"    {verdict.detail}")
+        for index in sorted(
+            set(verdict.shortfall_by_shard) | set(verdict.missing_by_shard)
+        ):
+            owed = verdict.shortfall_by_shard.get(index)
+            ids = verdict.missing_by_shard.get(index, [])
+            suffix = f": {', '.join(ids)}" if ids else ""
+            owed_text = "?" if owed is None else str(owed)
+            lines.append(f"    shard {index:03d} still owes {owed_text} task(s){suffix}")
+        if annotate and verdict.failing:
+            lines.append(
+                f"::error title=Shard relay {verdict.state}::"
+                f"{verdict.stem}: {verdict.detail}"
+            )
+    return lines
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Report shard relays that stopped without writing a final grade. "
+            "Read-only: never dispatches, merges, or writes."
+        )
+    )
+    parser.add_argument(
+        "--grades-root",
+        default="../data/grades",
+        help="Directory holding <stem>.json finals and the _shards/ tree",
+    )
+    parser.add_argument(
+        "--config-dir",
+        default="grading_configs",
+        help="Where to look for a config pinning the canonical task id order",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default="..",
+        help="Git working tree used to read commit times",
+    )
+    parser.add_argument(
+        "--stale-after-hours",
+        type=float,
+        default=STALE_AFTER_HOURS_DEFAULT,
+        help=(
+            "Silence tolerated before a relay is called stopped "
+            f"(default {STALE_AFTER_HOURS_DEFAULT})"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.stale_after_hours <= 0:
+        print("--stale-after-hours must be positive", file=sys.stderr)
+        return 2
+
+    repo_root = Path(args.repo_root).resolve()
+    config_dir = Path(args.config_dir)
+    verdicts = sweep(
+        Path(args.grades_root),
+        now=datetime.now(timezone.utc),
+        stale_after=timedelta(hours=args.stale_after_hours),
+        commit_time=lambda path: last_commit_at(repo_root, path),
+        canonical_lookup=lambda sha: canonical_ids_from_configs(config_dir, sha),
+    )
+
+    if not verdicts:
+        print("no shard relays to inspect")
+        return 0
+
+    annotate = bool(os.environ.get("GITHUB_ACTIONS"))
+    for line in render(verdicts, annotate=annotate):
+        print(line)
+
+    failing = [verdict for verdict in verdicts if verdict.failing]
+    if failing:
+        print(f"\n{len(failing)} shard relay(s) need attention", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/tests/test_sweep_stalled_shard_relays.py
+++ b/batch-runner/tests/test_sweep_stalled_shard_relays.py
@@ -109,34 +109,17 @@ def _git_init_with_old_commit(root: Path, *, when="2026-01-02T03:04:05+00:00"):
     # The fixture checks its own contract. Without this, a git that cannot make
     # or read a commit here surfaces later as a bare `assert None == datetime`
     # in whichever test happened to run, with nothing saying why.
-    def probe(*args):
-        return subprocess.run(
-            ["git", *args],
-            cwd=root,
-            capture_output=True,
-            text=True,
-            check=False,
-            env=env,
-        )
-
-    proof = probe("log", "-1", "--format=%cI")
+    proof = subprocess.run(
+        ["git", "log", "-1", "--format=%cI"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
     assert proof.returncode == 0 and proof.stdout.strip(), (
         "the fixture repo has no readable commit: "
         f"rc={proof.returncode} out={proof.stdout!r} err={proof.stderr!r}"
-    )
-
-    # And that the commit is reachable *through a pathspec*, which is how the
-    # sweep asks. A repo can satisfy the check above and still answer nothing
-    # here, and that difference is invisible from the failing assertion in the
-    # test body.
-    filtered = probe("log", "-1", "--format=%cI", "--", ".")
-    assert filtered.returncode == 0 and filtered.stdout.strip(), (
-        "the fixture repo has a commit but no pathspec-filtered history: "
-        f"rc={filtered.returncode} out={filtered.stdout!r} "
-        f"err={filtered.stderr!r} "
-        f"version={probe('--version').stdout.strip()!r} "
-        f"tracked={probe('ls-files').stdout.split()!r} "
-        f"status={probe('status', '--porcelain').stdout!r}"
     )
     return root
 
@@ -341,6 +324,37 @@ def test_the_shipped_config_pins_a_corpus_the_sweep_can_recover():
     )
     assert found == pinned
     assert len(found) == 220
+
+
+@pytest.mark.parametrize(
+    "rendered",
+    [
+        # git 2.55 (ubuntu-24.04 runners) renders a UTC committer date this way.
+        "2026-08-20T09:00:00Z",
+        # git 2.34 (older boxes) renders the same instant this way. Python
+        # 3.10's fromisoformat accepts only the second spelling, and
+        # `backend-tests.yml` pins 3.10.12, so parsing the first is not
+        # theoretical tidiness -- without it every stem reads as "cannot tell"
+        # on CI and in the scheduled sweep, while the tests pass locally.
+        "2026-08-20T09:00:00+00:00",
+        # Non-UTC, to prove the reader normalises rather than assuming zero.
+        "2026-08-20T18:00:00+09:00",
+    ],
+)
+def test_both_git_renderings_of_the_same_instant_parse_alike(rendered):
+    assert sweep.parse_commit_stamp(rendered) == datetime(
+        2026, 8, 20, 9, 0, tzinfo=timezone.utc
+    )
+
+
+def test_the_commit_stamp_reader_skips_noise_and_gives_up_quietly():
+    # A configured hook or signature check can prepend lines. The first
+    # *parseable* line is the answer, not the first line.
+    assert sweep.parse_commit_stamp(
+        "gpg: Signature made whenever\n2026-08-20T09:00:00Z\n"
+    ) == datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc)
+    assert sweep.parse_commit_stamp("") is None
+    assert sweep.parse_commit_stamp("not a date at all\n") is None
 
 
 def _explain_liveness(repo_root: Path, path: Path) -> str:

--- a/batch-runner/tests/test_sweep_stalled_shard_relays.py
+++ b/batch-runner/tests/test_sweep_stalled_shard_relays.py
@@ -109,17 +109,34 @@ def _git_init_with_old_commit(root: Path, *, when="2026-01-02T03:04:05+00:00"):
     # The fixture checks its own contract. Without this, a git that cannot make
     # or read a commit here surfaces later as a bare `assert None == datetime`
     # in whichever test happened to run, with nothing saying why.
-    proof = subprocess.run(
-        ["git", "log", "-1", "--format=%cI"],
-        cwd=root,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-    )
+    def probe(*args):
+        return subprocess.run(
+            ["git", *args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+    proof = probe("log", "-1", "--format=%cI")
     assert proof.returncode == 0 and proof.stdout.strip(), (
         "the fixture repo has no readable commit: "
         f"rc={proof.returncode} out={proof.stdout!r} err={proof.stderr!r}"
+    )
+
+    # And that the commit is reachable *through a pathspec*, which is how the
+    # sweep asks. A repo can satisfy the check above and still answer nothing
+    # here, and that difference is invisible from the failing assertion in the
+    # test body.
+    filtered = probe("log", "-1", "--format=%cI", "--", ".")
+    assert filtered.returncode == 0 and filtered.stdout.strip(), (
+        "the fixture repo has a commit but no pathspec-filtered history: "
+        f"rc={filtered.returncode} out={filtered.stdout!r} "
+        f"err={filtered.stderr!r} "
+        f"version={probe('--version').stdout.strip()!r} "
+        f"tracked={probe('ls-files').stdout.split()!r} "
+        f"status={probe('status', '--porcelain').stdout!r}"
     )
     return root
 

--- a/batch-runner/tests/test_sweep_stalled_shard_relays.py
+++ b/batch-runner/tests/test_sweep_stalled_shard_relays.py
@@ -1,0 +1,391 @@
+"""Tests for the stalled shard-relay sweep.
+
+The sweep re-derives two things ``step8_grade`` already knows -- which shard
+owns a canonical position, and how an ordered id list is hashed. Re-deriving
+rather than importing keeps a monitoring script from dragging in the judging
+stack, but it also means the two can drift. The tests that matter most here are
+therefore the ones that check the sweep against the real implementation instead
+of against a transcribed constant.
+"""
+
+import json
+import os
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import step8_grade
+from scripts import sweep_stalled_shard_relays as sweep
+
+
+NOW = datetime(2026, 8, 22, 12, 0, tzinfo=timezone.utc)
+FRESH = NOW - timedelta(hours=1)
+OLD = NOW - timedelta(hours=30)
+STALE_AFTER = timedelta(hours=8)
+
+
+def _ids(count: int) -> list[str]:
+    return [f"task-{index:04d}" for index in range(count)]
+
+
+def _payload(task_ids, *, total, ordered_sha):
+    return {
+        "run_status": "partial",
+        "expected_task_count": total,
+        "expected_ordered_task_ids_sha256": ordered_sha,
+        "tasks": [{"task_id": task_id} for task_id in task_ids],
+    }
+
+
+def _write_relay(
+    tmp_path: Path,
+    *,
+    stem: str = "run-stem",
+    total: int = 12,
+    shard_count: int = 3,
+    present=None,
+    drop=(),
+    final: bool = False,
+) -> Path:
+    """Lay out a ``_shards/<stem>/`` tree sliced the way step8 slices it."""
+    canonical = _ids(total)
+    ordered_sha = sweep.ordered_task_ids_sha256(canonical)
+    grades = tmp_path / "grades"
+    stem_dir = grades / "_shards" / stem
+    stem_dir.mkdir(parents=True)
+    if final:
+        (grades / f"{stem}.json").write_text("{}", encoding="utf-8")
+
+    indices = range(shard_count) if present is None else present
+    for index in indices:
+        held = [
+            task_id
+            for task_id in canonical[index::shard_count]
+            if task_id not in drop
+        ]
+        name = f"shard-{index:03d}-of-{shard_count:03d}.json"
+        (stem_dir / name).write_text(
+            json.dumps(_payload(held, total=total, ordered_sha=ordered_sha)),
+            encoding="utf-8",
+        )
+    return grades
+
+
+def _sweep(grades: Path, *, committed_at=FRESH, canonical=None):
+    return sweep.sweep(
+        grades,
+        now=NOW,
+        stale_after=STALE_AFTER,
+        commit_time=lambda path: committed_at,
+        canonical_lookup=lambda sha: canonical,
+    )
+
+
+def _git_init_with_old_commit(root: Path, *, when="2026-01-02T03:04:05+00:00"):
+    """Commit everything under ``root`` at a fixed, long-past timestamp.
+
+    ``GIT_COMMITTER_DATE`` rather than ``--date``: the sweep reads ``%cI``, the
+    committer date, and ``--date`` only moves the author date.
+    """
+    env = {**os.environ, "GIT_COMMITTER_DATE": when, "GIT_AUTHOR_DATE": when}
+
+    def git(*args):
+        subprocess.run(
+            ["git", "-c", "core.hooksPath=/dev/null", *args],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+
+    git("init", "-q")
+    git("config", "user.email", "sweep@example.invalid")
+    git("config", "user.name", "sweep")
+    git("add", "-A")
+    git("commit", "-q", "-m", "shards")
+    return root
+
+
+def test_a_published_final_is_not_the_sweeps_business(tmp_path):
+    grades = _write_relay(tmp_path, drop={"task-0004"}, final=True)
+    (verdict,) = _sweep(grades, committed_at=OLD)
+    assert verdict.state == "merged"
+    assert verdict.failing is False
+
+
+def test_shards_that_have_not_published_yet_are_reported_not_failed(tmp_path):
+    # The canary procedure runs shard 0 alone for hours before the rest go out.
+    # That is a deliberate operator choice, so it must never turn anything red.
+    grades = _write_relay(tmp_path, present=[0])
+    (verdict,) = _sweep(grades, committed_at=OLD)
+    assert verdict.state == "fanning-out"
+    assert verdict.failing is False
+    assert "waiting on 1, 2" in verdict.detail
+
+
+def test_a_short_union_that_is_still_moving_is_left_alone(tmp_path):
+    grades = _write_relay(tmp_path, drop={"task-0004"})
+    (verdict,) = _sweep(grades, committed_at=FRESH)
+    assert verdict.state == "working"
+    assert verdict.failing is False
+    assert "11/12" in verdict.detail
+
+
+def test_a_short_union_that_stopped_moving_names_the_owing_shard(tmp_path):
+    # task-0004 is canonical position 4, so with 3 shards it belongs to shard 1.
+    grades = _write_relay(tmp_path, drop={"task-0004"})
+    (verdict,) = _sweep(grades, committed_at=OLD, canonical=_ids(12))
+    assert verdict.state == "stalled"
+    assert verdict.failing is True
+    assert verdict.shortfall_by_shard == {1: 1}
+    assert verdict.missing_by_shard == {1: ["task-0004"]}
+    assert verdict.quiet_for_hours == pytest.approx(30.0)
+
+
+def test_a_stalled_relay_still_reports_counts_without_the_canonical_order(
+    tmp_path,
+):
+    # No config pins this corpus, so the ids cannot be recovered. The shard
+    # index and the size of its debt still can, and those are what a re-dispatch
+    # needs.
+    grades = _write_relay(tmp_path, drop={"task-0004", "task-0007"})
+    (verdict,) = _sweep(grades, committed_at=OLD, canonical=None)
+    assert verdict.state == "stalled"
+    assert verdict.shortfall_by_shard == {1: 2}
+    assert verdict.missing_by_shard == {}
+
+
+def test_a_complete_union_nobody_merged_is_the_hole_194_left_open(tmp_path):
+    grades = _write_relay(tmp_path)
+    (verdict,) = _sweep(grades, committed_at=OLD)
+    assert verdict.state == "unmerged"
+    assert verdict.failing is True
+    assert "all 12 tasks are in" in verdict.detail
+
+
+def test_a_complete_union_is_given_time_to_merge_before_being_called_stuck(
+    tmp_path,
+):
+    # The last shard commits its slice and merges in the same run, so a
+    # complete union with no final is normal for the minutes in between.
+    grades = _write_relay(tmp_path)
+    (verdict,) = _sweep(grades, committed_at=FRESH)
+    assert verdict.state == "working"
+    assert verdict.failing is False
+
+
+def test_shard_files_disagreeing_on_the_shard_count_are_malformed(tmp_path):
+    # A stem holding both a 3-way and a 4-way split has no single answer to
+    # "how many shards should be here", so no completeness claim can be made.
+    grades = _write_relay(tmp_path, shard_count=3)
+    stem_dir = grades / "_shards" / "run-stem"
+    (stem_dir / "shard-003-of-004.json").write_text("{}", encoding="utf-8")
+    (verdict,) = _sweep(grades)
+    assert verdict.state == "malformed"
+    assert verdict.failing is True
+    assert "disagree on the shard count" in verdict.detail
+
+
+def test_one_shard_index_published_under_two_counts_is_malformed(tmp_path):
+    # Two files can collide on an index only by declaring different counts.
+    # Reported as the collision rather than as the count split, because the
+    # collision is the more specific fact and names the shard to look at.
+    grades = _write_relay(tmp_path, shard_count=3)
+    stem_dir = grades / "_shards" / "run-stem"
+    (stem_dir / "shard-001-of-004.json").write_text("{}", encoding="utf-8")
+    (verdict,) = _sweep(grades)
+    assert verdict.state == "malformed"
+    assert verdict.failing is True
+    assert verdict.detail == "shard index 1 appears more than once"
+
+
+def test_liveness_it_cannot_read_is_never_reported_as_a_failure(tmp_path):
+    # A shallow clone has no history for the path. Guessing from file mtimes
+    # would call every stem brand new after a CI checkout, so the sweep says
+    # so and stays quiet.
+    grades = _write_relay(tmp_path, drop={"task-0004"})
+    (verdict,) = _sweep(grades, committed_at=None)
+    assert verdict.state == "unknown"
+    assert verdict.failing is False
+
+
+def test_a_relay_with_no_shard_files_is_ignored(tmp_path):
+    grades = tmp_path / "grades"
+    (grades / "_shards" / "run-stem").mkdir(parents=True)
+    (verdict,) = _sweep(grades)
+    assert verdict.state == "empty"
+    assert verdict.failing is False
+
+
+def test_a_missing_shards_tree_sweeps_nothing(tmp_path):
+    assert _sweep(tmp_path / "grades") == []
+
+
+@pytest.mark.parametrize("total,shard_count", [(220, 9), (12, 3), (7, 7), (5, 1)])
+def test_shard_ownership_agrees_with_the_slicer_that_assigns_it(
+    total, shard_count
+):
+    """The sweep's ownership maths must track ``step8_grade._shard_slice``.
+
+    Derived from the real slicer rather than from a remembered rule: if the
+    split ever stops being a stride, this fails instead of quietly blaming the
+    wrong shard in a report someone acts on.
+    """
+    tasks = [{"task_id": task_id} for task_id in _ids(total)]
+    for shard_index in range(shard_count):
+        held = step8_grade._shard_slice(
+            tasks, shard_index=shard_index, shard_count=shard_count
+        )
+        assert sweep.stride_size(shard_index, total, shard_count) == len(held)
+        for row in held:
+            position = int(row["task_id"].removeprefix("task-"))
+            assert sweep.stride_owner(position, shard_count) == shard_index
+
+
+def test_the_ordered_id_hash_matches_the_one_the_shards_recorded():
+    """Same bytes as ``step8_grade._ordered_task_ids_sha256``.
+
+    The config-to-corpus match is made by comparing this hash against the value
+    in the shard payloads. A drift here would silently stop the sweep from ever
+    naming missing ids, degrading it to counts with no error anywhere.
+    """
+    for total in (0, 1, 12, 220):
+        ids = _ids(total)
+        assert sweep.ordered_task_ids_sha256(ids) == (
+            step8_grade._ordered_task_ids_sha256(ids)
+        )
+
+
+def test_the_canonical_order_is_found_by_hash_not_by_config_name(tmp_path):
+    config_dir = tmp_path / "grading_configs"
+    config_dir.mkdir()
+    wanted = _ids(12)
+    (config_dir / "zzz-unrelated.yaml").write_text(
+        "rerun_identity:\n  task_ids: [other-a, other-b]\n", encoding="utf-8"
+    )
+    (config_dir / "aaa-match.yaml").write_text(
+        "rerun_identity:\n  task_ids:\n"
+        + "".join(f"    - {task_id}\n" for task_id in wanted),
+        encoding="utf-8",
+    )
+    found = sweep.canonical_ids_from_configs(
+        config_dir, sweep.ordered_task_ids_sha256(wanted)
+    )
+    assert found == wanted
+    assert sweep.canonical_ids_from_configs(config_dir, "0" * 64) is None
+
+
+def test_a_config_that_is_not_yaml_does_not_stop_the_search(tmp_path):
+    config_dir = tmp_path / "grading_configs"
+    config_dir.mkdir()
+    (config_dir / "aaa-broken.yaml").write_text("{[not yaml", encoding="utf-8")
+    wanted = _ids(4)
+    (config_dir / "bbb-good.yaml").write_text(
+        "rerun_identity:\n  task_ids:\n"
+        + "".join(f"    - {task_id}\n" for task_id in wanted),
+        encoding="utf-8",
+    )
+    assert sweep.canonical_ids_from_configs(
+        config_dir, sweep.ordered_task_ids_sha256(wanted)
+    ) == wanted
+
+
+def test_the_shipped_config_pins_a_corpus_the_sweep_can_recover():
+    """The 220-task re-grade is the run this sweep exists to watch."""
+    config_dir = Path(__file__).resolve().parent.parent / "grading_configs"
+    import yaml
+
+    config = yaml.safe_load(
+        (config_dir / "regrade_exp003_v2_sol_max_score_excluded.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    pinned = config["rerun_identity"]["task_ids"]
+    found = sweep.canonical_ids_from_configs(
+        config_dir, sweep.ordered_task_ids_sha256(pinned)
+    )
+    assert found == pinned
+    assert len(found) == 220
+
+
+def test_git_liveness_reads_the_newest_commit_touching_the_stem(tmp_path):
+    stem_dir = tmp_path / "grades" / "_shards" / "run-stem"
+    stem_dir.mkdir(parents=True)
+    (stem_dir / "shard-000-of-001.json").write_text("{}", encoding="utf-8")
+    _git_init_with_old_commit(tmp_path, when="2026-08-20T09:00:00+00:00")
+
+    seen = sweep.last_commit_at(tmp_path, stem_dir)
+    assert seen == datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc)
+    assert sweep.last_commit_at(tmp_path, tmp_path / "nope") is None
+
+
+def test_git_liveness_is_none_outside_a_repository(tmp_path):
+    assert sweep.last_commit_at(tmp_path, tmp_path) is None
+
+
+def test_the_report_names_the_shard_and_annotates_only_failures():
+    stalled = sweep.RelayVerdict(
+        stem="s",
+        state="stalled",
+        detail="stopped",
+        shortfall_by_shard={4: 2},
+        missing_by_shard={4: ["a", "b"]},
+    )
+    healthy = sweep.RelayVerdict(stem="h", state="working", detail="moving")
+    lines = sweep.render([stalled, healthy], annotate=True)
+    assert "    shard 004 still owes 2 task(s): a, b" in lines
+    assert sum(line.startswith("::error") for line in lines) == 1
+    assert sweep.render([stalled], annotate=False) == [
+        line for line in sweep.render([stalled], annotate=True)
+        if not line.startswith("::error")
+    ]
+
+
+def test_the_cli_exits_one_when_a_relay_needs_attention(tmp_path, capsys):
+    # End to end over a real git tree: a single-shard relay holding 3 of its 4
+    # tasks, last committed long ago, is unambiguously stopped.
+    grades = _write_relay(tmp_path, shard_count=1, total=4, drop={"task-0002"})
+    _git_init_with_old_commit(tmp_path)
+
+    rc = sweep.main(
+        [
+            "--grades-root",
+            str(grades),
+            "--config-dir",
+            str(tmp_path / "absent"),
+            "--repo-root",
+            str(tmp_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "[stalled] run-stem" in captured.out
+    assert "shard 000 still owes 1 task(s)" in captured.out
+    assert "need attention" in captured.err
+
+
+def test_the_cli_exits_zero_when_every_relay_is_accounted_for(tmp_path, capsys):
+    grades = _write_relay(tmp_path, shard_count=1, total=4)
+    _git_init_with_old_commit(tmp_path)
+
+    rc = sweep.main(
+        [
+            "--grades-root",
+            str(grades),
+            "--config-dir",
+            str(tmp_path / "absent"),
+            "--repo-root",
+            str(tmp_path),
+            "--stale-after-hours",
+            "100000",
+        ]
+    )
+    assert rc == 0
+    assert "[working] run-stem" in capsys.readouterr().out
+
+
+def test_a_non_positive_staleness_window_is_rejected(tmp_path, capsys):
+    assert sweep.main(["--stale-after-hours", "0"]) == 2
+    assert "must be positive" in capsys.readouterr().err

--- a/batch-runner/tests/test_sweep_stalled_shard_relays.py
+++ b/batch-runner/tests/test_sweep_stalled_shard_relays.py
@@ -105,6 +105,22 @@ def _git_init_with_old_commit(root: Path, *, when="2026-01-02T03:04:05+00:00"):
     git("config", "user.name", "sweep")
     git("add", "-A")
     git("commit", "-q", "-m", "shards")
+
+    # The fixture checks its own contract. Without this, a git that cannot make
+    # or read a commit here surfaces later as a bare `assert None == datetime`
+    # in whichever test happened to run, with nothing saying why.
+    proof = subprocess.run(
+        ["git", "log", "-1", "--format=%cI"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proof.returncode == 0 and proof.stdout.strip(), (
+        "the fixture repo has no readable commit: "
+        f"rc={proof.returncode} out={proof.stdout!r} err={proof.stderr!r}"
+    )
     return root
 
 
@@ -323,6 +339,32 @@ def test_git_liveness_reads_the_newest_commit_touching_the_stem(tmp_path):
 
 def test_git_liveness_is_none_outside_a_repository(tmp_path):
     assert sweep.last_commit_at(tmp_path, tmp_path) is None
+
+
+def test_liveness_survives_the_relative_roots_the_workflow_passes(
+    tmp_path, monkeypatch
+):
+    """The shipped defaults are ``--repo-root ..`` and ``--grades-root
+    ../data/grades``, both relative to ``batch-runner/``.
+
+    Handed through unchanged, the stem pathspec begins with ``..`` and git
+    refuses it as outside the work tree: every stem reports ``unknown`` and the
+    sweep is silently useless in the one workflow it exists for. No other test
+    here would catch that, and neither does running it against the real
+    repository -- a published final short-circuits before liveness is ever
+    read.
+    """
+    repo = tmp_path / "repo"
+    (repo / "batch-runner").mkdir(parents=True)
+    _write_relay(repo / "data", shard_count=1, total=4, drop={"task-0002"})
+    _git_init_with_old_commit(repo)
+    monkeypatch.chdir(repo / "batch-runner")
+
+    rc = sweep.main(
+        ["--grades-root", "../data/grades", "--repo-root", "..",
+         "--config-dir", "grading_configs"]
+    )
+    assert rc == 1
 
 
 def test_the_report_names_the_shard_and_annotates_only_failures():

--- a/batch-runner/tests/test_sweep_stalled_shard_relays.py
+++ b/batch-runner/tests/test_sweep_stalled_shard_relays.py
@@ -343,6 +343,35 @@ def test_the_shipped_config_pins_a_corpus_the_sweep_can_recover():
     assert len(found) == 220
 
 
+def _explain_liveness(repo_root: Path, path: Path) -> str:
+    """Re-run what ``last_commit_at`` runs and report all of it.
+
+    This function depends on the behaviour of an external tool, so when it
+    disagrees with the host the bare `assert None == datetime(...)` says
+    nothing about which step went wrong. Evaluated only on failure.
+    """
+    root = repo_root.resolve()
+    relative = os.path.relpath(path.resolve(), root)
+    argv = [
+        "git", "-c", "log.showSignature=false",
+        "log", "-1", "--format=%cI", "--", relative,
+    ]
+
+    def run(*args):
+        return subprocess.run(
+            list(args), cwd=root, capture_output=True, text=True, check=False
+        )
+
+    got = subprocess.run(argv, cwd=root, capture_output=True, text=True, check=False)
+    return (
+        f"argv={argv!r} cwd={str(root)!r} "
+        f"raw_root={str(repo_root)!r} raw_path={str(path)!r} relative={relative!r} "
+        f"rc={got.returncode} out={got.stdout!r} err={got.stderr!r} "
+        f"tracked={run('git', 'ls-files').stdout.split()!r} "
+        f"version={run('git', '--version').stdout.strip()!r}"
+    )
+
+
 def test_git_liveness_reads_the_newest_commit_touching_the_stem(tmp_path):
     stem_dir = tmp_path / "grades" / "_shards" / "run-stem"
     stem_dir.mkdir(parents=True)
@@ -350,7 +379,9 @@ def test_git_liveness_reads_the_newest_commit_touching_the_stem(tmp_path):
     _git_init_with_old_commit(tmp_path, when="2026-08-20T09:00:00+00:00")
 
     seen = sweep.last_commit_at(tmp_path, stem_dir)
-    assert seen == datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc)
+    assert seen == datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc), (
+        _explain_liveness(tmp_path, stem_dir)
+    )
     assert sweep.last_commit_at(tmp_path, tmp_path / "nope") is None
 
 


### PR DESCRIPTION
## What this closes

`#194` gave a shard that finds a short union a way to stand down politely: exit `75`, let whichever sibling finishes last do the merge. That is right for the normal case and it removed a large class of false red runs. It also widened a hole that was already there — if one shard never finishes, every surviving sibling defers, nobody merges, and no final grade is written.

The gap is narrow and specific:

| shard outcome | reported today? |
|---|---|
| crashes | ✅ its own run goes red |
| finishes, union short | ✅ defers on purpose, sibling merges later |
| **ends green without finishing** | ❌ **nothing anywhere** |

The third row happens when the auto-resume relay's `gh workflow run` dispatch fails — rate limit, expired token, a transient API error — and the run still exits successfully. The relay is broken and every signal is green.

It can't be closed inside the merge step. Shards are independent `workflow_dispatch` runs rather than a matrix, so no job can `needs:` all of them and there is nowhere to hang "everyone is done, now merge". This watches from outside instead, on a three-hour schedule.

## How it decides

**Liveness comes from git, not the workflow API.** A working shard commits its slice at the end of every chunk, so the newest commit touching `data/grades/_shards/<stem>/` is a direct record of progress. The API alternative would have to match dispatch inputs against the display title `Run GDPVal Grade Pipeline`, which every shard of every run shares. Eight hours of silence is the default threshold — roughly double a full chunk, late enough never to interrupt a slow-but-working run.

**Missing ids are recovered by hash, not by name.** Each grading config's pinned `rerun_identity.task_ids` is hashed and matched against the `expected_ordered_task_ids_sha256` the shards themselves recorded, so a match is verified rather than assumed. With no match it degrades to shortfall counts derived from the stride profile — still enough to name the shard to re-dispatch.

**Not-yet-published is reported, never failed on.** The canary-first procedure deliberately runs shard 0 alone for hours. Liveness git can't read (shallow clone, uncommitted tree) is reported as `unknown` rather than guessed from mtimes, which after a CI checkout would make every stem look brand new.

Sample of the failing output:

```
[stalled] <stem>
    5/6 tasks in and nothing has been committed for 514.45h
    shard 001 still owes 1 task(s)
```

## Safety

Strictly read-only — it never dispatches, merges, or writes. Its whole output is a red run and a job summary. The happy path is untouched: the last shard still merges, deferring shards still exit green.

## Tests

26 new tests. The two values the sweep re-derives from `step8_grade` — stride ownership and the ordered-id hash — are checked against the real implementations rather than transcribed constants, so drift fails a test instead of quietly blaming the wrong shard in a report someone acts on. One test asserts the shipped 220-task config is recoverable by the hash path, since that is the run this exists to watch.

Full suite on this branch: `3 failed, 3357 passed, 6 skipped` — the three failures are the known local-environment ones (pinned Azure SDK versions, absent `pdfplumber`) and are identical on `main`. Collection delta is exactly the 26 added.

## Note on the freeze

`.gitignore` needed the new script added to the `batch-runner/scripts/` allow-list. Everything here is outside `compute_grader_source_hash` and unread by `grade-run.yml`, so it is safe to land while shards are in flight.
