### PR TITLE
fix(grading): let the relay sweep run without the grading stack

### DIFF
--- a/.github/workflows/shard-relay-sweep.yml
+++ b/.github/workflows/shard-relay-sweep.yml
@@ -63,9 +63,13 @@ jobs:
         with:
           python-version: "3.11"
 
-      # The sweep reads JSON and one YAML key. `step9_merge_shards`, which it
-      # borrows the shard loader from, is stdlib-only. Installing the full
-      # batch-runner requirements would cost minutes for nothing.
+      # The sweep reads JSON and one YAML key, and deliberately does not import
+      # `step8_grade`/`step9_merge_shards` -- those reach azure, openai and
+      # jsonschema, and installing the full batch-runner requirements would
+      # cost minutes here for nothing. `test_the_sweep_imports_without_the_
+      # grading_stack` keeps that true, because the first version of this file
+      # did import them and the scheduled run died on ModuleNotFoundError
+      # before printing a line.
       - name: Install PyYAML
         run: python -m pip install --disable-pip-version-check "PyYAML>=6,<7"
 

--- a/batch-runner/scripts/sweep_stalled_shard_relays.py
+++ b/batch-runner/scripts/sweep_stalled_shard_relays.py
@@ -50,15 +50,69 @@ from typing import Callable, Iterable, Sequence
 
 import yaml
 
-BATCH_RUNNER_ROOT = Path(__file__).resolve().parent.parent
-if str(BATCH_RUNNER_ROOT) not in sys.path:
-    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
 
-from step9_merge_shards import (  # noqa: E402  (needs the path insert above)
-    ShardMergeError,
-    _shard_task_ids,
-    load_shard_file,
-)
+class ShardReadError(ValueError):
+    """A shard file cannot be read as a shard."""
+
+
+def load_shard_file(path: Path) -> tuple[dict, str]:
+    """Return ``(payload, sha256_of_file_bytes)`` for one shard file.
+
+    A deliberate copy of ``step9_merge_shards.load_shard_file`` rather than an
+    import of it. Importing reaches ``step9_merge_shards`` ->
+    ``core.grade_payload`` -> ``jsonschema``, and ``step9_merge_shards`` ->
+    ``step8_grade`` -> ``core.azure_ai_clients`` and the rest of the judging
+    stack. A watchdog that needs the whole grading dependency set installed
+    before it can report anything is a watchdog that stops watching every time
+    that set moves -- and this one runs on a schedule where nobody is looking.
+    The copy is held to the original by
+    ``test_the_borrowed_shard_reader_still_matches_step9``.
+    """
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise ShardReadError(f"could not read shard {path}: {exc}") from exc
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ShardReadError(f"could not parse shard {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ShardReadError(f"shard {path} top-level JSON must be an object")
+    return payload, hashlib.sha256(raw).hexdigest()
+
+
+def shard_task_ids(payload: dict, label: str) -> list[str]:
+    """Return the task ids a shard payload claims, rejecting a malformed one.
+
+    Copied from ``step9_merge_shards._shard_task_ids`` for the reason above.
+    Kept behaviourally identical, error messages included, so a stem the
+    merger would refuse reads as ``malformed`` here with the same explanation.
+    """
+    tasks = payload.get("tasks")
+    if not isinstance(tasks, list):
+        raise ShardReadError(f"{label} has no tasks array")
+    if not tasks:
+        raise ShardReadError(f"{label} contains zero graded tasks")
+    task_ids: list[str] = []
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for index, row in enumerate(tasks):
+        if not isinstance(row, dict):
+            raise ShardReadError(f"{label} task at index {index} is not an object")
+        task_id = row.get("task_id")
+        if not isinstance(task_id, str) or not task_id.strip():
+            raise ShardReadError(
+                f"{label} task at index {index} has no non-empty task_id"
+            )
+        if task_id in seen:
+            duplicates.add(task_id)
+        seen.add(task_id)
+        task_ids.append(task_id)
+    if duplicates:
+        raise ShardReadError(
+            f"{label} contains duplicate task_ids: {sorted(duplicates)}"
+        )
+    return task_ids
 
 
 #: How long a stem may go without a new commit before the relay is called
@@ -251,7 +305,7 @@ def _agreed(payloads: Sequence[dict], key: str):
     """Return the value all payloads carry for ``key``, or raise on a split."""
     values = {json.dumps(payload.get(key), sort_keys=True) for payload in payloads}
     if len(values) != 1:
-        raise ShardMergeError(f"shards disagree on {key}")
+        raise ShardReadError(f"shards disagree on {key}")
     return payloads[0].get(key)
 
 
@@ -313,8 +367,8 @@ def inspect_stem(
     for index, path in sorted(shard_files.items()):
         try:
             payload, _ = load_shard_file(path)
-            ids = _shard_task_ids(payload, f"{stem} shard {index}")
-        except ShardMergeError as exc:
+            ids = shard_task_ids(payload, f"{stem} shard {index}")
+        except ShardReadError as exc:
             return RelayVerdict(stem, "malformed", str(exc))
         payloads[index] = payload
         holdings[index] = len(ids)
@@ -324,7 +378,7 @@ def inspect_stem(
     try:
         expected_total = _agreed(ordered, "expected_task_count")
         expected_sha = _agreed(ordered, "expected_ordered_task_ids_sha256")
-    except ShardMergeError as exc:
+    except ShardReadError as exc:
         return RelayVerdict(stem, "malformed", str(exc))
     if not isinstance(expected_total, int) or expected_total <= 0:
         return RelayVerdict(

--- a/batch-runner/tests/test_sweep_stalled_shard_relays.py
+++ b/batch-runner/tests/test_sweep_stalled_shard_relays.py
@@ -357,6 +357,107 @@ def test_the_commit_stamp_reader_skips_noise_and_gives_up_quietly():
     assert sweep.parse_commit_stamp("not a date at all\n") is None
 
 
+def test_the_borrowed_shard_reader_still_matches_step9(tmp_path):
+    """The sweep copies step9's shard reader; this holds the copy to it.
+
+    The copy exists so the watchdog does not import ``step9_merge_shards`` ->
+    ``step8_grade`` -> the azure/openai/jsonschema stack just to read JSON. It
+    shipped without this guard and the scheduled run died on
+    ``ModuleNotFoundError`` before printing a line.
+
+    Every case is compared against the real implementation rather than against
+    a transcribed expectation, so a change to how the merger reads a shard
+    fails here instead of quietly letting the sweep disagree with the thing it
+    is watching -- calling a stem ``malformed`` the merger accepts, or worse,
+    accepting one the merger will reject at the end of a paid run.
+    """
+    import step9_merge_shards
+
+    cases = {
+        "valid": {"tasks": [{"task_id": "task-0001"}, {"task_id": "task-0002"}]},
+        "no tasks array": {"tasks": "nope"},
+        "missing tasks key": {"expected_task_count": 4},
+        "empty tasks": {"tasks": []},
+        "row is not an object": {"tasks": ["task-0001"]},
+        "blank task_id": {"tasks": [{"task_id": "   "}]},
+        "non-string task_id": {"tasks": [{"task_id": 7}]},
+        "duplicates": {
+            "tasks": [{"task_id": "a"}, {"task_id": "b"}, {"task_id": "a"}]
+        },
+    }
+    for name, payload in cases.items():
+        def call(fn):
+            try:
+                return ("ok", fn(payload, "L"))
+            except ValueError as exc:  # both raise a ValueError subclass
+                return ("raised", str(exc))
+
+        assert call(sweep.shard_task_ids) == call(
+            step9_merge_shards._shard_task_ids
+        ), f"shard_task_ids disagrees with step9 on: {name}"
+
+    # ...and the file reader, over the same kinds of input.
+    good = tmp_path / "shard-000-of-001.json"
+    good.write_text(json.dumps({"tasks": [{"task_id": "a"}]}), encoding="utf-8")
+    assert sweep.load_shard_file(good) == step9_merge_shards.load_shard_file(good)
+
+    for name, raw in {
+        "not json": b"{[",
+        "json but not an object": b"[1, 2]",
+        "invalid utf-8": b"\xff\xfe\x00",
+    }.items():
+        bad = tmp_path / f"bad-{abs(hash(name))}.json"
+        bad.write_bytes(raw)
+
+        def read(fn):
+            try:
+                return ("ok", fn(bad))
+            except ValueError as exc:
+                return ("raised", str(exc))
+
+        assert read(sweep.load_shard_file) == read(
+            step9_merge_shards.load_shard_file
+        ), f"load_shard_file disagrees with step9 on: {name}"
+
+    missing = tmp_path / "does-not-exist.json"
+
+    def read_missing(fn):
+        try:
+            return ("ok", fn(missing))
+        except ValueError as exc:
+            return ("raised", str(exc))
+
+    assert read_missing(sweep.load_shard_file) == read_missing(
+        step9_merge_shards.load_shard_file
+    )
+
+
+def test_the_sweep_imports_without_the_grading_stack():
+    """The watchdog must start on a runner that installed only PyYAML.
+
+    Asserted against the module's own imports rather than by installing
+    nothing, because the test process necessarily has the full requirements.
+    `step8_grade`/`step9_merge_shards` reach azure, openai and jsonschema; the
+    scheduled workflow installs none of them.
+    """
+    source = (
+        Path(sweep.__file__).read_text(encoding="utf-8")
+    )
+    imported = {
+        line.strip()
+        for line in source.splitlines()
+        if line.startswith(("import ", "from "))
+    }
+    forbidden = ("step8_grade", "step9_merge_shards", "core.", "jsonschema")
+    offenders = [
+        line for line in imported if any(name in line for name in forbidden)
+    ]
+    assert offenders == [], (
+        "the sweep must not import the grading stack at module scope: "
+        f"{offenders}"
+    )
+
+
 def _explain_liveness(repo_root: Path, path: Path) -> str:
     """Re-run what ``last_commit_at`` runs and report all of it.
 


### PR DESCRIPTION
## What went wrong

The sweep merged in #197 failed on its first real run, before printing a single line:

```
from step9_merge_shards import (...)
  -> from core.grade_payload import canonical_rate, validate_grade_payload
    -> ModuleNotFoundError: No module named 'jsonschema'
```

The workflow installs only PyYAML, and the comment justifying that said `step9_merge_shards` is stdlib-only. That was wrong. It imports `core.grade_payload` (which needs `jsonschema`) and, at line 93, `step8_grade` — which reaches `core.azure_ai_clients`, `core.grader`, `core.tools` and `core.rubric_loader`. That is the entire judging stack.

It passed locally and in CI because both have the full `requirements.txt` installed. Only a runner that installs just PyYAML shows it, which is why dispatching the merged workflow for real was what found it.

## Why not just install jsonschema

That fixes this run and leaves the actual problem. A watchdog whose ability to *start* is coupled to the grading dependency set stops watching every time that set moves — and this one runs on a schedule, where nobody is looking for its absence. Pulling in azure + openai + jsonschema also costs minutes per scheduled run to read some JSON.

So the three small pure-stdlib pieces are copied in instead, the same way `ordered_task_ids_sha256` already was and for the same reason. PyYAML is now the only third-party import, used only for one config lookup.

## Guarding the copy

Copying trades one risk for another: the sweep could drift from the merger and call a stem `malformed` that `step9` accepts — or worse, accept one `step9` will reject at the end of a paid run.

So the copy isn't trusted on inspection. `test_the_borrowed_shard_reader_still_matches_step9` imports the real `step9_merge_shards` (fine in tests, which do have the dependencies) and runs both implementations over the same inputs — the valid case and every rejection path: no tasks array, missing key, empty list, non-object row, blank/non-string `task_id`, duplicates, unparseable JSON, non-object top level, invalid UTF-8, missing file — asserting they agree, error strings included.

A second test, `test_the_sweep_imports_without_the_grading_stack`, reads the module's own import lines and fails if `step8_grade`, `step9_merge_shards`, `core.` or `jsonschema` reappear at module scope. That's the specific mistake that shipped, so it's the one worth a test.

## Verification

- 33 sweep tests pass.
- Ran the script against this repository for real with `jsonschema`, `azure`, `openai`, `core`, `step8_grade` and `step9_merge_shards` all blocked at import via `sys.meta_path` — correct verdict (`[merged] ...`), exit 0.
- After merge, the workflow will be dispatched again to confirm it runs green on a runner, since that is what caught this.

## Grading freeze

All three files are outside `compute_grader_source_hash`: `batch-runner/scripts/` is not globbed (only `scripts/download_inference_from_hf.py` is hashed, by name), `batch-runner/tests/` is not hashed, and `shard-relay-sweep.yml` is not `grade-run.yml`. Grader source hash on this branch equals `origin/main`. The in-flight canary is unaffected.