### PR TITLE
feat(grading): split judge errors into harness and model causes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/compare_agentic_conditions.py
 !batch-runner/scripts/select_agentic_tasks.py
 !batch-runner/scripts/sweep_stalled_shard_relays.py
+!batch-runner/scripts/judge_error_breakdown.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/batch-runner/scripts/judge_error_breakdown.py
+++ b/batch-runner/scripts/judge_error_breakdown.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Break a grade run's judge errors down by cause, and compare two runs.
+
+``judge_error_rate`` is already published in every grade file's
+``summary.wow``, and every downstream card carries a ``< 2%`` gate on it. The
+rate alone is not enough to decide anything, because the errors it counts come
+from two unlike places:
+
+* the harness could not put the deliverable in front of the judge -- the
+  selector refused to choose between same-format files (``#190``), or a
+  document had no render target (``#189``). These are our defects, and fixing
+  them is what makes the number move.
+* the model did not submit gradeable work -- wrong format, or nothing at all.
+  These are findings about the model under test. They are supposed to be
+  there, and driving them to zero would mean grading something the model never
+  produced.
+
+A run whose rate falls because we fixed the first kind has genuinely improved.
+A run whose rate falls because the corpus happened to contain fewer of the
+second kind has not. Reading only the headline rate cannot tell those apart,
+so this prints the split.
+
+The second reason to have this is that **a shard's rate is not the run's
+rate**, and they differ by a lot. On the published sol-220 run the whole-run
+rate is 3.19%, while its nine shards range from 0.40% to 9.71% -- the 243
+selector failures sit almost entirely in four of them, and shard 0 has none at
+all. Comparing a canary shard against a whole-run baseline would therefore
+flatter or damn a fix for reasons that have nothing to do with the fix. Pass
+``--baseline`` and the comparison is paired: shard 0 against shard 0, over the
+same tasks.
+
+Stdlib only, deliberately, as with ``sweep_stalled_shard_relays.py``: a tool
+for reading how a paid run went should not need the stack that ran it.
+
+Run it from ``batch-runner/``::
+
+    # one run, or one shard directory
+    python3 scripts/judge_error_breakdown.py ../data/grades/_shards/<stem>
+
+    # paired against the published baseline, gated at 2%
+    python3 scripts/judge_error_breakdown.py ../data/grades/_shards/<new> \\
+        --baseline ../data/grades/_shards/<old> --max-rate 0.02
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+# Ordered worst-first for display. The two ``harness`` buckets are ours to fix;
+# the two ``model`` ones are results, not defects.
+HARNESS_BUCKETS = ("selector_ambiguous", "render_target_missing")
+MODEL_BUCKETS = ("wrong_format", "empty_output")
+BUCKETS = HARNESS_BUCKETS + MODEL_BUCKETS + ("unclassified",)
+
+BUCKET_HELP = {
+    "selector_ambiguous": "harness: selector could not choose between candidates",
+    "render_target_missing": "harness: nothing could be rendered for the judge to see",
+    "wrong_format": "model: submitted files, none in a requested format",
+    "empty_output": "model: submitted no gradeable text",
+    "unclassified": "UNKNOWN -- a failure shape this tool does not recognise",
+}
+
+
+def canonical_rate(numerator: int, denominator: int) -> float:
+    """Return a nonnegative ratio rounded half-up to four decimal places.
+
+    Copied from ``core.grade_payload.canonical_rate`` rather than imported, to
+    keep this script free of the grading stack. Held to the original by
+    ``test_the_borrowed_rate_still_matches_grade_payload``. The copy matters
+    because the rounding is half-up integer arithmetic, not Python's
+    round-half-to-even -- a reimplementation using ``round()`` would disagree
+    with the published field on exact ties and look like a data error.
+    """
+    if denominator <= 0:
+        return 0.0
+    scaled = (2 * numerator * 10_000 + denominator) // (2 * denominator)
+    return scaled / 10_000
+
+
+def classify_error(item: dict) -> str:
+    """Return which bucket one ``judge_error`` item belongs to.
+
+    Decided from the structured fields the grader already writes, not from the
+    ``evidence`` prose. Prose was the obvious route -- the reason usually
+    appears as the first token of the evidence string -- and it is wrong twice
+    over: it scatters one cause across several spellings (the published run
+    files the same render failure under three different prefixes), and it
+    silently rebuckets everything the day someone rewords a message.
+
+    Anything that matches no known shape returns ``unclassified`` rather than
+    being folded into the nearest bucket. A new failure mode should be visible
+    as a new failure mode, not absorbed into an existing count -- absorbing it
+    is how a regression gets reported as an improvement.
+    """
+    status = item.get("selection_status")
+    if status == "selection_error":
+        return "selector_ambiguous"
+    if status == "wrong_format_primary":
+        return "wrong_format"
+    if status != "ok":
+        return "unclassified"
+
+    # Selection succeeded, so the failure is downstream of it. What separates
+    # the two remaining causes is what the judge was routed to look at.
+    modality = item.get("routing_modality")
+    provenance = item.get("visual_provenance")
+    rendered = bool(provenance) if isinstance(provenance, list) else provenance is not None
+    if modality in ("visual", "mixed") and not rendered:
+        return "render_target_missing"
+    if modality == "text":
+        return "empty_output"
+    return "unclassified"
+
+
+@dataclass
+class Breakdown:
+    """Judge-error accounting for one grade file, or a set of them."""
+
+    label: str
+    judge_items: int = 0
+    errors: int = 0
+    buckets: dict = field(default_factory=lambda: {name: 0 for name in BUCKETS})
+    tasks: int = 0
+    # Rate as the file itself published it, where there is one to compare with.
+    published_rate: float | None = None
+
+    @property
+    def rate(self) -> float:
+        return canonical_rate(self.errors, self.judge_items)
+
+    @property
+    def harness_errors(self) -> int:
+        return sum(self.buckets[name] for name in HARNESS_BUCKETS)
+
+    @property
+    def model_errors(self) -> int:
+        return sum(self.buckets[name] for name in MODEL_BUCKETS)
+
+    def merge(self, other: "Breakdown") -> None:
+        self.judge_items += other.judge_items
+        self.errors += other.errors
+        self.tasks += other.tasks
+        for name in BUCKETS:
+            self.buckets[name] += other.buckets[name]
+
+
+def breakdown_payload(payload: dict, label: str) -> Breakdown:
+    """Account for one grade payload.
+
+    ``judge_items`` counts items decided by the judge, matching the definition
+    ``core.grade_payload`` validates the published rate against. Precheck-
+    decided items are excluded there and are excluded here, so the denominator
+    is the same one.
+    """
+    result = Breakdown(label=label)
+    tasks = payload.get("tasks")
+    if not isinstance(tasks, list):
+        raise ValueError(f"{label} has no tasks array")
+    result.tasks = len(tasks)
+    for task in tasks:
+        if not isinstance(task, dict):
+            raise ValueError(f"{label} has a task that is not an object")
+        for item in task.get("items") or []:
+            if not isinstance(item, dict) or item.get("decided_by") != "judge":
+                continue
+            result.judge_items += 1
+            if item.get("verdict") != "judge_error":
+                continue
+            result.errors += 1
+            result.buckets[classify_error(item)] += 1
+
+    summary = payload.get("summary")
+    if isinstance(summary, dict):
+        wow = summary.get("wow")
+        if isinstance(wow, dict) and isinstance(
+            wow.get("judge_error_rate"), (int, float)
+        ):
+            result.published_rate = float(wow["judge_error_rate"])
+    return result
+
+
+def grade_files(path: Path) -> list[Path]:
+    """Return the grade files under ``path``, newest-format first.
+
+    A directory is read as a shard stem: every ``shard-*.json`` in it, in shard
+    order, plus any final merged file. A file is read as itself.
+    """
+    if path.is_file():
+        return [path]
+    if not path.is_dir():
+        raise ValueError(f"not a grade file or directory: {path}")
+    shards = sorted(path.glob("shard-*.json"))
+    finals = sorted(p for p in path.glob("*.json") if not p.name.startswith("shard-"))
+    found = shards + finals
+    if not found:
+        raise ValueError(f"no grade files under {path}")
+    return found
+
+
+def read_breakdowns(paths: Sequence[Path]) -> list[Breakdown]:
+    out: list[Breakdown] = []
+    for path in paths:
+        for file_path in grade_files(path):
+            payload = json.loads(file_path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                raise ValueError(f"{file_path} top-level JSON must be an object")
+            out.append(breakdown_payload(payload, file_path.name))
+    return out
+
+
+def total_of(parts: Iterable[Breakdown], label: str = "ALL") -> Breakdown:
+    total = Breakdown(label=label)
+    for part in parts:
+        total.merge(part)
+    return total
+
+
+def _row(entry: Breakdown, width: int) -> str:
+    return (
+        f"{entry.label[:width]:<{width}} {entry.tasks:>5} {entry.judge_items:>7} "
+        f"{entry.errors:>5} {entry.rate * 100:>6.2f}%"
+        + "".join(f" {entry.buckets[name]:>5}" for name in BUCKETS)
+    )
+
+
+def render(parts: list[Breakdown], total: Breakdown, width: int) -> list[str]:
+    header = (
+        f"{'file':<{width}} {'tasks':>5} {'judged':>7} {'errs':>5} {'rate':>7}"
+        + "".join(f" {name[:5]:>5}" for name in BUCKETS)
+    )
+    lines = [header, "-" * len(header)]
+    lines += [_row(part, width) for part in parts]
+    if len(parts) > 1:
+        lines += ["-" * len(header), _row(total, width)]
+    lines.append("")
+    lines.append("buckets:")
+    for name in BUCKETS:
+        lines.append(f"  {name[:5]:<5}  {name:<22}  {BUCKET_HELP[name]}")
+    return lines
+
+
+def compare(new: Breakdown, old: Breakdown) -> list[str]:
+    """Render a paired before/after, keeping the two causes apart."""
+    lines = [
+        "",
+        f"paired comparison  ({old.label} -> {new.label})",
+        "-" * 58,
+        f"  judged items      {old.judge_items:>7} -> {new.judge_items:>7}",
+        f"  judge errors      {old.errors:>7} -> {new.errors:>7}",
+        f"  rate              {old.rate * 100:>6.2f}% -> {new.rate * 100:>6.2f}%",
+        f"  harness-caused    {old.harness_errors:>7} -> {new.harness_errors:>7}"
+        f"   <- ours to fix; this is the number a fix should move",
+        f"  model-caused      {old.model_errors:>7} -> {new.model_errors:>7}"
+        f"   <- a property of the submissions, not a defect",
+    ]
+    if old.judge_items != new.judge_items:
+        lines.append(
+            f"  NOTE: the denominators differ ({old.judge_items} vs "
+            f"{new.judge_items}), so these are not the same items. Check that "
+            "you are comparing the same shard index of the same corpus."
+        )
+    return lines
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Break a grade run's judge errors down by cause."
+    )
+    parser.add_argument(
+        "paths", nargs="+", type=Path, help="grade file(s) or shard directory"
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help="a second run to compare against, paired by totals",
+    )
+    parser.add_argument(
+        "--max-rate",
+        type=float,
+        default=None,
+        help="fail if the overall judge_error rate is above this (e.g. 0.02)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        parts = read_breakdowns(args.paths)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    width = max([len(part.label) for part in parts] + [20])
+    width = min(width, 46)
+    total = total_of(parts)
+    lines = render(parts, total, width)
+
+    # A published rate that disagrees with the recomputed one means this tool
+    # and the grader do not count the same things. Say so rather than quietly
+    # reporting a number nobody else would get.
+    for part in parts:
+        if part.published_rate is not None and part.published_rate != part.rate:
+            lines.append(
+                f"  WARNING: {part.label} publishes judge_error_rate="
+                f"{part.published_rate} but recomputes to {part.rate}"
+            )
+
+    exit_code = 0
+    if args.baseline is not None:
+        try:
+            baseline = total_of(read_breakdowns([args.baseline]), label="baseline")
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"error reading baseline: {exc}", file=sys.stderr)
+            return 2
+        lines += compare(total, baseline)
+
+    if total.buckets["unclassified"]:
+        lines.append("")
+        lines.append(
+            f"  {total.buckets['unclassified']} item(s) matched no known failure "
+            "shape. Do not read the split as complete until they are explained."
+        )
+        exit_code = 1
+
+    if args.max_rate is not None:
+        verdict = "OK" if total.rate <= args.max_rate else "OVER"
+        lines.append("")
+        lines.append(
+            f"  gate: {total.rate * 100:.2f}% vs {args.max_rate * 100:.2f}% -> {verdict}"
+        )
+        if total.rate > args.max_rate:
+            exit_code = 1
+
+    print("\n".join(lines))
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/batch-runner/tests/test_judge_error_breakdown.py
+++ b/batch-runner/tests/test_judge_error_breakdown.py
@@ -1,0 +1,497 @@
+"""Tests for the judge-error breakdown tool.
+
+Two things here are worth more than the rest.
+
+The first is ``test_the_tool_reproduces_the_published_run_exactly``. The whole
+value of the tool is that its split adds up: 243 + 74 + 12 + 4 = 333, the
+number the sol-220 run already published, with nothing left over. A split that
+loses or invents an error is worse than no split, because it would be read as
+evidence about which fixes worked. The corpus is checked in, so this is a real
+regression test rather than a mock.
+
+The second is ``test_the_borrowed_rate_still_matches_grade_payload``. The
+script copies ``canonical_rate`` instead of importing it, to stay free of the
+grading stack, and a copy can drift. It is held to the original over a grid
+that includes exact ties -- and a companion test proves the grid actually has
+teeth by showing a ``round()``-based rate disagrees on some of them.
+
+The rest are constructed cases, one per branch of ``classify_error``, plus the
+properties that make the output trustworthy: an unrecognised failure shape is
+reported rather than absorbed, precheck items stay out of the denominator, and
+a paired comparison says so when the two sides are not the same items.
+"""
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import judge_error_breakdown as jeb
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The sol-220 run that is badged OFFICIAL on the dashboard. Matched by its
+# source-hash segment rather than the full stem, which also carries the config,
+# rubric and inference hashes and is 200 characters long.
+PUBLISHED_SRC = "src_1c967673eb8081a6"
+
+# What that run's 333 judge errors are, once split by cause. Transcribed on
+# purpose: unlike the rate, there is no published field to check the split
+# against, so these numbers are the record of what the corpus contained when
+# the classifier was written.
+PUBLISHED_TOTALS = {
+    "tasks": 220,
+    "judge_items": 10453,
+    "errors": 333,
+    "selector_ambiguous": 243,
+    "render_target_missing": 74,
+    "wrong_format": 12,
+    "empty_output": 4,
+    "unclassified": 0,
+}
+
+
+def _published_corpus():
+    """Return the published shard directory, or ``None`` if it is not here."""
+    root = REPO_ROOT / "data" / "grades" / "_shards"
+    if not root.is_dir():
+        return None
+    matches = [p for p in root.iterdir() if p.is_dir() and PUBLISHED_SRC in p.name]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _item(verdict="judge_error", decided_by="judge", **fields):
+    item = {"decided_by": decided_by, "verdict": verdict}
+    item.update(fields)
+    return item
+
+
+def _payload(items, *, published_rate=None, task_count=1):
+    """One grade payload holding ``items``, spread over ``task_count`` tasks."""
+    tasks = [{"task_id": f"t-{index}", "items": []} for index in range(task_count)]
+    for offset, item in enumerate(items):
+        tasks[offset % task_count]["items"].append(item)
+    payload = {"tasks": tasks}
+    if published_rate is not None:
+        payload["summary"] = {"wow": {"judge_error_rate": published_rate}}
+    return payload
+
+
+def _write(directory: Path, name: str, payload) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------
+# the borrowed arithmetic
+# --------------------------------------------------------------------------
+
+
+RATE_GRID = [
+    (num, den)
+    for den in (1, 3, 6, 7, 16, 1081, 10453, 20000, 40000)
+    for num in range(0, min(den, 60) + 1)
+]
+
+
+def test_the_borrowed_rate_still_matches_grade_payload():
+    """The copy must agree with the function the grader publishes with.
+
+    Checked against the real implementation rather than a table of expected
+    values, so that a change to how the grader rounds fails here instead of
+    letting this tool quietly report a rate nobody else would get.
+    """
+    from core.grade_payload import canonical_rate as original
+
+    mismatches = [
+        (num, den, jeb.canonical_rate(num, den), original(num, den))
+        for num, den in RATE_GRID
+        if jeb.canonical_rate(num, den) != original(num, den)
+    ]
+    assert mismatches == []
+
+    # Degenerate denominators are defined, not crashes: a shard with no
+    # judge-decided items has a rate of zero, not a ZeroDivisionError.
+    for den in (0, -1):
+        assert jeb.canonical_rate(5, den) == original(5, den) == 0.0
+
+
+def test_a_round_based_rate_would_disagree_on_ties():
+    """Proof that the grid above is not vacuous.
+
+    ``canonical_rate`` rounds half-*up* with integer arithmetic. The obvious
+    reimplementation, ``round(num / den, 4)``, rounds half-to-even, and the
+    difference only shows on exact ties. If the grid contained no ties, the
+    equivalence test would pass for a wrong copy, so this pins down that it
+    does contain them.
+    """
+    disagreements = [
+        (num, den)
+        for num, den in RATE_GRID
+        if jeb.canonical_rate(num, den) != round(num / den, 4) if den > 0
+    ]
+    assert disagreements, "the rate grid no longer exercises half-up rounding"
+
+
+# --------------------------------------------------------------------------
+# the published corpus
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    _published_corpus() is None,
+    reason=(
+        f"the published sol-220 shards (data/grades/_shards/*{PUBLISHED_SRC}*) "
+        "are not in this checkout"
+    ),
+)
+def test_the_tool_reproduces_the_published_run_exactly():
+    """The split must account for all 333 errors and invent none.
+
+    ``unclassified == 0`` is the assertion that carries the weight. The
+    headline rate has been quoted in the roadmap and on the dashboard, and the
+    reason to split it was to say which part of it we caused. A split with
+    leftovers cannot answer that.
+    """
+    total = jeb.total_of(jeb.read_breakdowns([_published_corpus()]))
+
+    got = {
+        "tasks": total.tasks,
+        "judge_items": total.judge_items,
+        "errors": total.errors,
+        **{name: total.buckets[name] for name in jeb.BUCKETS},
+    }
+    assert got == PUBLISHED_TOTALS
+    assert total.rate == 0.0319
+    assert sum(total.buckets.values()) == total.errors
+    assert total.harness_errors == 243 + 74
+    assert total.model_errors == 12 + 4
+
+
+@pytest.mark.skipif(
+    _published_corpus() is None,
+    reason=(
+        f"the published sol-220 shards (data/grades/_shards/*{PUBLISHED_SRC}*) "
+        "are not in this checkout"
+    ),
+)
+def test_every_published_shard_rate_recomputes():
+    """Per shard, this tool's numerator must be the grader's numerator.
+
+    Recomputing each of the nine shards and getting the published number back
+    is stronger than checking the totals, which could match by two errors
+    cancelling.
+
+    It does *not* check the denominator filter. Every one of the 10453 items
+    in this corpus is ``decided_by == "judge"``, so dropping the filter
+    entirely would not move a single shard's rate. That branch is only
+    exercised by ``test_precheck_items_are_not_in_the_denominator``, and if
+    this corpus is ever replaced by one containing precheck decisions, this
+    test gets stronger rather than weaker.
+    """
+    parts = jeb.read_breakdowns([_published_corpus()])
+    assert len(parts) == 9
+
+    disagreements = [
+        (part.label, part.published_rate, part.rate)
+        for part in parts
+        if part.published_rate is None or part.published_rate != part.rate
+    ]
+    assert disagreements == []
+
+    # And the spread is the reason ``--baseline`` exists at all: judging a fix
+    # by comparing one shard against the whole-run rate would be meaningless.
+    rates = sorted(part.rate for part in parts)
+    assert rates[0] < 0.01 < 0.09 < rates[-1]
+
+
+# --------------------------------------------------------------------------
+# classification
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "item, expected",
+    [
+        # The selector declined to choose between same-format candidates.
+        ({"selection_status": "selection_error"}, "selector_ambiguous"),
+        # It chose, but nothing it could choose was in a requested format.
+        ({"selection_status": "wrong_format_primary"}, "wrong_format"),
+        # Selection was fine; the judge was routed to look at something and
+        # there was nothing rendered to look at.
+        (
+            {
+                "selection_status": "ok",
+                "routing_modality": "visual",
+                "visual_provenance": [],
+            },
+            "render_target_missing",
+        ),
+        (
+            {
+                "selection_status": "ok",
+                "routing_modality": "mixed",
+                "visual_provenance": None,
+            },
+            "render_target_missing",
+        ),
+        (
+            {"selection_status": "ok", "routing_modality": "mixed"},
+            "render_target_missing",
+        ),
+        # Selection was fine and the route was text, so the deliverable held
+        # no gradeable text.
+        ({"selection_status": "ok", "routing_modality": "text"}, "empty_output"),
+    ],
+)
+def test_each_failure_shape_lands_in_its_own_bucket(item, expected):
+    assert jeb.classify_error(item) == expected
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        # A status the grader does not currently emit.
+        {"selection_status": "quarantined"},
+        # No status at all.
+        {},
+        # Selection fine, but a routing modality nobody has seen.
+        {"selection_status": "ok", "routing_modality": "haptic"},
+        # The subtle one: routed to a visual judge, something *was* rendered,
+        # and it still failed. That is not a render-target miss, and calling
+        # it one would credit `#189` with a fix it did not make.
+        {
+            "selection_status": "ok",
+            "routing_modality": "visual",
+            "visual_provenance": [{"page": 1}],
+        },
+    ],
+)
+def test_an_unknown_shape_is_reported_not_absorbed(item):
+    """Unrecognised failures must surface, not join the nearest bucket.
+
+    Absorbing them is how a regression gets published as an improvement: a new
+    harness defect would land in ``model:`` and read as the model getting
+    worse while we got better.
+    """
+    assert jeb.classify_error(item) == "unclassified"
+
+
+def test_unclassified_items_fail_the_run_and_say_so(tmp_path, capsys):
+    payload = _payload([_item(selection_status="quarantined")] * 2)
+    path = _write(tmp_path, "grade.json", payload)
+
+    assert jeb.main([str(path)]) == 1
+    out = capsys.readouterr().out
+    assert "2 item(s) matched no known failure shape" in out
+    assert "Do not read the split as complete" in out
+
+
+# --------------------------------------------------------------------------
+# the denominator
+# --------------------------------------------------------------------------
+
+
+def test_precheck_items_are_not_in_the_denominator():
+    """Only judge-decided items count, on both sides of the fraction.
+
+    A deterministic precheck can fail an item without a judge ever seeing it.
+    Counting those would inflate the denominator and make every fix look
+    smaller than it was.
+    """
+    items = [
+        _item(selection_status="selection_error"),
+        _item(verdict="pass"),
+        _item(verdict="pass"),
+        # Precheck-decided, including one that carries the same verdict string.
+        _item(decided_by="precheck", selection_status="selection_error"),
+        _item(decided_by="precheck", verdict="fail"),
+    ]
+    result = jeb.breakdown_payload(_payload(items), "L")
+
+    assert (result.judge_items, result.errors) == (3, 1)
+    assert result.rate == jeb.canonical_rate(1, 3)
+    assert result.buckets["selector_ambiguous"] == 1
+
+
+def test_a_payload_without_a_tasks_array_is_rejected():
+    with pytest.raises(ValueError, match="no tasks array"):
+        jeb.breakdown_payload({"summary": {}}, "L")
+    with pytest.raises(ValueError, match="task that is not an object"):
+        jeb.breakdown_payload({"tasks": ["t-1"]}, "L")
+
+
+# --------------------------------------------------------------------------
+# reading input
+# --------------------------------------------------------------------------
+
+
+def test_a_directory_reads_shards_in_order_then_finals(tmp_path):
+    stem = tmp_path / "stem"
+    for name in ("shard-002-of-003.json", "shard-000-of-003.json"):
+        _write(stem, name, _payload([]))
+    _write(stem, "shard-001-of-003.json", _payload([]))
+    _write(stem, "final.json", _payload([]))
+
+    assert [p.name for p in jeb.grade_files(stem)] == [
+        "shard-000-of-003.json",
+        "shard-001-of-003.json",
+        "shard-002-of-003.json",
+        "final.json",
+    ]
+    assert jeb.grade_files(stem / "final.json") == [stem / "final.json"]
+
+
+def test_an_empty_or_missing_directory_is_an_error(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(ValueError, match="no grade files"):
+        jeb.grade_files(empty)
+    with pytest.raises(ValueError, match="not a grade file or directory"):
+        jeb.grade_files(tmp_path / "nope")
+
+
+def test_unreadable_input_exits_two_not_one(tmp_path, capsys):
+    """A read failure and a gate failure must not share an exit code.
+
+    Anything wiring this into CI has to be able to tell "the rate is too high"
+    from "I could not read the run", because only one of those is a finding.
+    """
+    (tmp_path / "broken.json").write_text("{[", encoding="utf-8")
+    assert jeb.main([str(tmp_path / "broken.json")]) == 2
+    assert "error:" in capsys.readouterr().err
+
+    assert jeb.main([str(tmp_path / "absent.json")]) == 2
+
+    good = _write(tmp_path / "ok", "grade.json", _payload([]))
+    assert jeb.main([str(good), "--baseline", str(tmp_path / "absent")]) == 2
+    assert "error reading baseline:" in capsys.readouterr().err
+
+
+def test_a_published_rate_that_disagrees_is_flagged(tmp_path, capsys):
+    """If the file and the tool count differently, say so rather than pick one."""
+    payload = _payload(
+        [_item(selection_status="selection_error")] + [_item(verdict="pass")] * 9,
+        published_rate=0.5,
+    )
+    path = _write(tmp_path, "grade.json", payload)
+
+    jeb.main([str(path)])
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "publishes judge_error_rate=0.5 but recomputes to 0.1" in out
+
+
+# --------------------------------------------------------------------------
+# the gate and the pairing
+# --------------------------------------------------------------------------
+
+
+def _hundred_items(errors: int):
+    return [_item(selection_status="selection_error")] * errors + [
+        _item(verdict="pass")
+    ] * (100 - errors)
+
+
+def test_the_gate_passes_and_fails_on_the_threshold(tmp_path, capsys):
+    path = _write(tmp_path, "grade.json", _payload(_hundred_items(3)))
+
+    assert jeb.main([str(path), "--max-rate", "0.02"]) == 1
+    assert "gate: 3.00% vs 2.00% -> OVER" in capsys.readouterr().out
+
+    assert jeb.main([str(path), "--max-rate", "0.05"]) == 0
+    assert "gate: 3.00% vs 5.00% -> OK" in capsys.readouterr().out
+
+    # Exactly on the threshold passes; the gate is documented as "above this".
+    assert jeb.main([str(path), "--max-rate", "0.03"]) == 0
+
+    # And with no gate asked for, a high rate is reported, not enforced.
+    assert jeb.main([str(path)]) == 0
+
+
+def test_a_paired_comparison_keeps_the_two_causes_apart(tmp_path, capsys):
+    """A fix should be read off the harness line, not the headline rate."""
+    old = _write(
+        tmp_path / "old",
+        "grade.json",
+        _payload(
+            [_item(selection_status="selection_error")] * 6
+            + [_item(selection_status="wrong_format_primary")] * 2
+            + [_item(verdict="pass")] * 92
+        ),
+    )
+    # Same denominator, harness errors fixed, model errors untouched.
+    new = _write(
+        tmp_path / "new",
+        "grade.json",
+        _payload(
+            [_item(selection_status="wrong_format_primary")] * 2
+            + [_item(verdict="pass")] * 98
+        ),
+    )
+
+    assert jeb.main([str(new), "--baseline", str(old)]) == 0
+    out = capsys.readouterr().out
+    assert "harness-caused          6 ->       0" in out
+    assert "model-caused            2 ->       2" in out
+    assert "rate                8.00% ->   2.00%" in out
+    assert "NOTE" not in out
+
+
+def test_a_denominator_change_is_called_out_in_the_pairing(tmp_path, capsys):
+    """Different item counts mean it is not the same comparison.
+
+    This is the mistake the tool exists to prevent: reading a 25-task canary
+    shard against a 220-task baseline and calling the difference a result.
+    """
+    old = _write(tmp_path / "old", "grade.json", _payload(_hundred_items(3)))
+    new = _write(
+        tmp_path / "new",
+        "grade.json",
+        _payload([_item(selection_status="selection_error")] + [_item(verdict="pass")] * 9),
+    )
+
+    jeb.main([str(new), "--baseline", str(old)])
+    out = capsys.readouterr().out
+    assert "NOTE: the denominators differ (100 vs 10)" in out
+    assert "same shard index of the same corpus" in out
+
+
+# --------------------------------------------------------------------------
+# independence from the grading stack
+# --------------------------------------------------------------------------
+
+
+def test_the_tool_imports_without_the_grading_stack():
+    """The breakdown must run wherever a grade file can be copied to.
+
+    Same guarantee the relay sweep has, for the same reason: reading how a
+    paid run went should not require the stack that ran it -- azure, openai
+    and jsonschema, none of which a laptop or a minimal runner will have.
+
+    Parsed rather than prefix-matched, because this module's own docstring
+    contains a line beginning "from two unlike places:" and a string check
+    would call that an import.
+    """
+    tree = ast.parse(Path(jeb.__file__).read_text(encoding="utf-8"))
+
+    imported = []
+    for node in tree.body:  # module scope only
+        if isinstance(node, ast.Import):
+            imported += [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(node.module or "")
+
+    forbidden = ("step8_grade", "step9_merge_shards", "core", "jsonschema")
+    offenders = [
+        name
+        for name in imported
+        if name.split(".")[0] in forbidden
+    ]
+    assert offenders == [], (
+        f"the breakdown must not import the grading stack: {offenders}"
+    )


### PR DESCRIPTION
## Why

`judge_error_rate` is published in every grade file's `summary.wow` and gated at 2% on every downstream card, but the errors it counts come from two unlike places:

- **ours** — the selector refused to choose between same-format candidates (`#190`), or a document had no render target (`#189`)
- **the model's** — wrong format, or nothing gradeable submitted at all

Only the first kind is a defect. The headline rate cannot tell them apart, so a corpus that happens to contain fewer bad submissions reads as a harness improvement.

## What it prints

Against the published sol-220 run, the split accounts for all 333 errors with nothing left over:

```
file                  tasks  judged  errs    rate selec rende wrong empty uncla
-------------------------------------------------------------------------------
shard-000-of-009.json    25    1081    16   1.48%     0    13     2     1     0
shard-001-of-009.json    25    1043    72   6.90%    56    15     0     1     0
shard-002-of-009.json    25    1146    55   4.80%    47     4     3     1     0
shard-003-of-009.json    25    1385    53   3.83%    33    19     1     0     0
shard-004-of-009.json    24    1123   109   9.71%   107     1     1     0     0
shard-005-of-009.json    24    1067     5   0.47%     0     2     3     0     0
shard-006-of-009.json    24    1262     5   0.40%     0     4     1     0     0
shard-007-of-009.json    24    1189     9   0.76%     0     9     0     0     0
shard-008-of-009.json    24    1157     9   0.78%     0     7     1     1     0
-------------------------------------------------------------------------------
ALL                     220   10453   333   3.19%   243    74    12     4     0
```

243 + 74 harness, 12 + 4 model, **0 unclassified**.

## Why `--baseline` is paired

That table is also the argument for it. A shard's rate is not the run's rate: these nine range from **0.40% to 9.71%** around the 3.19% whole-run figure, and all 243 selector failures sit in four of them — shard 0 has none at all. Reading a canary shard against a whole-run baseline would credit or damn a fix for reasons unrelated to the fix. `--baseline` compares like against like.

## Design notes

- **Structured fields, not prose.** Classification reads `selection_status` and `routing_modality`. Parsing the `evidence` string was the obvious route and is wrong twice over: the published run spells one render failure under three different prefixes, and any reworded message silently rebuckets history.
- **Unknown shapes are reported, not absorbed.** Anything matching no known shape becomes `unclassified` and exits non-zero. Folding it into the nearest bucket is how a new harness defect would get published as the model getting worse.
- **Stdlib only**, like the relay sweep and for the same reason — reading how a paid run went should not require the stack that ran it. An `ast`-based import guard keeps that true.

## Tests — 25, all passing

The two that carry the weight:

- `test_the_tool_reproduces_the_published_run_exactly` — regression against the checked-in sol-220 shards. This is what makes `unclassified == 0` a fact rather than a claim.
- `test_the_borrowed_rate_still_matches_grade_payload` — holds the copied `canonical_rate` to `core.grade_payload`'s half-up rounding over a grid of exact ties, with a companion test proving the grid has teeth (a `round()`-based copy agrees everywhere else).

Three mutations were run against the suite to confirm it fails when the tool is wrong. One of them was informative: widening the denominator to all items is **not** caught by the corpus tests, because all 10453 of that corpus's items are `decided_by == "judge"`. That limitation is now recorded on the test that would otherwise appear to cover it.

## Safe to merge during the R1 freeze

Touches `batch-runner/scripts/`, `batch-runner/tests/`, and `.gitignore` — none of which feed `grader_source_hash`. Verified on this branch: `regrade_exp003_v2_sol_max_score_excluded.yaml` still hashes to `595c7254caf8fbd7`, unchanged from the value the nine in-flight shards are running under.

Full local suite: 3389 passed. The 3 failures are pre-existing and local-only (openai version pin, no `pdfplumber` installed here); none occur on CI.