### PR TITLE
fix(grading): pair judge-error runs on task id, not on totals

### DIFF
--- a/batch-runner/scripts/judge_error_breakdown.py
+++ b/batch-runner/scripts/judge_error_breakdown.py
@@ -25,9 +25,12 @@ rate**, and they differ by a lot. On the published sol-220 run the whole-run
 rate is 3.19%, while its nine shards range from 0.40% to 9.71% -- the 243
 selector failures sit almost entirely in four of them, and shard 0 has none at
 all. Comparing a canary shard against a whole-run baseline would therefore
-flatter or damn a fix for reasons that have nothing to do with the fix. Pass
-``--baseline`` and the comparison is paired: shard 0 against shard 0, over the
-same tasks.
+flatter or damn a fix for reasons that have nothing to do with the fix.
+
+``--baseline`` closes that off by construction: both sides are cut down to the
+task ids they share before anything is counted. That also makes it usable
+while a run is still in flight, when the new side has published thirteen tasks
+and the baseline has all two hundred and twenty.
 
 Stdlib only, deliberately, as with ``sweep_stalled_shard_relays.py``: a tool
 for reading how a paid run went should not need the stack that ran it.
@@ -129,6 +132,10 @@ class Breakdown:
     tasks: int = 0
     # Rate as the file itself published it, where there is one to compare with.
     published_rate: float | None = None
+    # The same accounting, per task, so a partial run can be paired against the
+    # same tasks in a complete one. Kept from the single parse rather than
+    # re-read, because a nine-shard corpus is tens of megabytes.
+    per_task: dict = field(default_factory=dict)
 
     @property
     def rate(self) -> float:
@@ -148,6 +155,31 @@ class Breakdown:
         self.tasks += other.tasks
         for name in BUCKETS:
             self.buckets[name] += other.buckets[name]
+        # A task claimed by two files is not a merge, it is a double count.
+        # Shard slices are disjoint by construction, so this means either the
+        # slicing broke or a merged final was read alongside the shards it was
+        # merged from -- and silently adding those together would report every
+        # number at twice its true value.
+        clashes = sorted(set(self.per_task) & set(other.per_task))
+        if clashes:
+            raise ValueError(
+                f"{other.label} repeats {len(clashes)} task(s) already counted, "
+                f"first {clashes[0]!r}. Read the shards or the merged final, "
+                "not both."
+            )
+        self.per_task.update(other.per_task)
+
+    def restrict(self, task_ids, label: str | None = None) -> "Breakdown":
+        """Return the same accounting over only ``task_ids``.
+
+        ``published_rate`` is dropped: the file published a rate for all of its
+        tasks, and it is not the rate of a subset of them.
+        """
+        out = Breakdown(label=self.label if label is None else label)
+        for task_id, part in self.per_task.items():
+            if task_id in task_ids:
+                out.merge(part)
+        return out
 
 
 def breakdown_payload(payload: dict, label: str) -> Breakdown:
@@ -162,18 +194,29 @@ def breakdown_payload(payload: dict, label: str) -> Breakdown:
     tasks = payload.get("tasks")
     if not isinstance(tasks, list):
         raise ValueError(f"{label} has no tasks array")
-    result.tasks = len(tasks)
-    for task in tasks:
+    for index, task in enumerate(tasks):
         if not isinstance(task, dict):
             raise ValueError(f"{label} has a task that is not an object")
+        task_id = task.get("task_id")
+        if not isinstance(task_id, str) or not task_id.strip():
+            # Legacy files predate the field. Give it a key that cannot
+            # collide and cannot pair, rather than refusing to read the file:
+            # an unpairable task is honest, a crash here is not.
+            task_id = f"{label}#{index}"
+
+        one = Breakdown(label=task_id, tasks=1)
         for item in task.get("items") or []:
             if not isinstance(item, dict) or item.get("decided_by") != "judge":
                 continue
-            result.judge_items += 1
+            one.judge_items += 1
             if item.get("verdict") != "judge_error":
                 continue
-            result.errors += 1
-            result.buckets[classify_error(item)] += 1
+            one.errors += 1
+            one.buckets[classify_error(item)] += 1
+        if task_id in result.per_task:
+            raise ValueError(f"{label} lists task {task_id!r} more than once")
+        result.per_task[task_id] = one
+        result.merge(one)
 
     summary = payload.get("summary")
     if isinstance(summary, dict):
@@ -251,6 +294,7 @@ def compare(new: Breakdown, old: Breakdown) -> list[str]:
         "",
         f"paired comparison  ({old.label} -> {new.label})",
         "-" * 58,
+        f"  tasks in both     {old.tasks:>7}",
         f"  judged items      {old.judge_items:>7} -> {new.judge_items:>7}",
         f"  judge errors      {old.errors:>7} -> {new.errors:>7}",
         f"  rate              {old.rate * 100:>6.2f}% -> {new.rate * 100:>6.2f}%",
@@ -262,8 +306,8 @@ def compare(new: Breakdown, old: Breakdown) -> list[str]:
     if old.judge_items != new.judge_items:
         lines.append(
             f"  NOTE: the denominators differ ({old.judge_items} vs "
-            f"{new.judge_items}), so these are not the same items. Check that "
-            "you are comparing the same shard index of the same corpus."
+            f"{new.judge_items}) across the same tasks, so the rubric itself "
+            "moved. A rate change here is not only about judge errors."
         )
     return lines
 
@@ -279,7 +323,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--baseline",
         type=Path,
         default=None,
-        help="a second run to compare against, paired by totals",
+        help="a second run to compare against, cut to the task ids both share",
     )
     parser.add_argument(
         "--max-rate",
@@ -295,14 +339,54 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
+    baseline = None
+    pairing: list[str] = []
+    if args.baseline is not None:
+        try:
+            baseline = total_of(read_breakdowns([args.baseline]), label="baseline")
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"error reading baseline: {exc}", file=sys.stderr)
+            return 2
+
+        # Pair on task_id. A run in flight has published some of its tasks and
+        # not others, and the baseline has all of them; comparing those totals
+        # measures how far along the new run is, not whether it is better.
+        # Restricting both sides to the tasks they share is the only reading
+        # that says anything about the fix.
+        new_ids = set().union(*(set(part.per_task) for part in parts)) if parts else set()
+        shared = new_ids & set(baseline.per_task)
+        only_new = len(new_ids - shared)
+        only_old = len(set(baseline.per_task) - shared)
+        if not shared:
+            print(
+                f"error: the two runs share no task ids ({len(new_ids)} here, "
+                f"{len(baseline.per_task)} in the baseline), so there is "
+                "nothing to compare. Check that both point at the same corpus.",
+                file=sys.stderr,
+            )
+            return 2
+
+        parts = [part.restrict(shared) for part in parts]
+        baseline = baseline.restrict(shared, label="baseline")
+        if only_new or only_old:
+            pairing = [
+                "",
+                f"paired on the {len(shared)} task(s) both runs have published."
+                f" Set aside: {only_new} here, {only_old} in the baseline.",
+                "The table above is restricted to those shared tasks, so it"
+                " will not match either run's own published totals.",
+            ]
+
     width = max([len(part.label) for part in parts] + [20])
     width = min(width, 46)
     total = total_of(parts)
     lines = render(parts, total, width)
+    lines += pairing
 
     # A published rate that disagrees with the recomputed one means this tool
     # and the grader do not count the same things. Say so rather than quietly
-    # reporting a number nobody else would get.
+    # reporting a number nobody else would get. Restricted parts have no
+    # published rate to check against, so this only fires on a whole file.
     for part in parts:
         if part.published_rate is not None and part.published_rate != part.rate:
             lines.append(
@@ -311,12 +395,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
 
     exit_code = 0
-    if args.baseline is not None:
-        try:
-            baseline = total_of(read_breakdowns([args.baseline]), label="baseline")
-        except (OSError, ValueError, json.JSONDecodeError) as exc:
-            print(f"error reading baseline: {exc}", file=sys.stderr)
-            return 2
+    if baseline is not None:
         lines += compare(total, baseline)
 
     if total.buckets["unclassified"]:

--- a/batch-runner/tests/test_judge_error_breakdown.py
+++ b/batch-runner/tests/test_judge_error_breakdown.py
@@ -68,9 +68,12 @@ def _item(verdict="judge_error", decided_by="judge", **fields):
     return item
 
 
-def _payload(items, *, published_rate=None, task_count=1):
+def _payload(items, *, published_rate=None, task_count=1, task_prefix="t"):
     """One grade payload holding ``items``, spread over ``task_count`` tasks."""
-    tasks = [{"task_id": f"t-{index}", "items": []} for index in range(task_count)]
+    tasks = [
+        {"task_id": f"{task_prefix}-{index}", "items": []}
+        for index in range(task_count)
+    ]
     for offset, item in enumerate(items):
         tasks[offset % task_count]["items"].append(item)
     payload = {"tasks": tasks}
@@ -443,10 +446,12 @@ def test_a_paired_comparison_keeps_the_two_causes_apart(tmp_path, capsys):
 
 
 def test_a_denominator_change_is_called_out_in_the_pairing(tmp_path, capsys):
-    """Different item counts mean it is not the same comparison.
+    """Same tasks, different item counts, means the rubric moved.
 
-    This is the mistake the tool exists to prevent: reading a 25-task canary
-    shard against a 220-task baseline and calling the difference a result.
+    Pairing on task id removes the "different tasks" explanation for a
+    denominator gap, so what is left is a real one: the rubric under which
+    those tasks were judged is not the same. A rate change then is not only
+    about judge errors, and the reader has to be told.
     """
     old = _write(tmp_path / "old", "grade.json", _payload(_hundred_items(3)))
     new = _write(
@@ -458,7 +463,102 @@ def test_a_denominator_change_is_called_out_in_the_pairing(tmp_path, capsys):
     jeb.main([str(new), "--baseline", str(old)])
     out = capsys.readouterr().out
     assert "NOTE: the denominators differ (100 vs 10)" in out
-    assert "same shard index of the same corpus" in out
+    assert "the rubric itself moved" in out
+
+
+def test_a_partial_run_is_paired_only_on_what_it_has_published(tmp_path, capsys):
+    """The case this exists for: reading a shard while the run is in flight.
+
+    The baseline holds every task; the new run has finished two of them.
+    Comparing the totals would measure how far along it is, not whether it is
+    better. Both sides are cut to the tasks they share before anything is
+    counted.
+    """
+    baseline = _write(
+        tmp_path / "old",
+        "grade.json",
+        _payload(
+            # 10 items per task; the two shared tasks carry one harness error
+            # each, the three the new run has not reached carry three more.
+            [_item(selection_status="selection_error")] * 5
+            + [_item(verdict="pass")] * 45,
+            task_count=5,
+        ),
+    )
+    # Same two tasks, now clean.
+    new = _write(
+        tmp_path / "new", "grade.json", _payload([_item(verdict="pass")] * 20, task_count=2)
+    )
+
+    assert jeb.main([str(new), "--baseline", str(baseline)]) == 0
+    out = capsys.readouterr().out
+    assert "paired on the 2 task(s) both runs have published" in out
+    assert "Set aside: 0 here, 3 in the baseline" in out
+    assert "will not match either run's own published totals" in out
+    # 2 of the 5 tasks, so 20 of the 50 items -- not the baseline's own 50.
+    assert "tasks in both           2" in out
+    assert "judged items           20 ->      20" in out
+    assert "judge errors            2 ->       0" in out
+
+
+def test_two_runs_with_no_shared_tasks_refuse_to_compare(tmp_path, capsys):
+    """An empty intersection is a mistake, not a 0.00% -> 0.00% result."""
+    old = _write(
+        tmp_path / "old", "grade.json", _payload(_hundred_items(3), task_prefix="old")
+    )
+    new = _write(
+        tmp_path / "new", "grade.json", _payload(_hundred_items(0), task_prefix="new")
+    )
+
+    assert jeb.main([str(new), "--baseline", str(old)]) == 2
+    err = capsys.readouterr().err
+    assert "share no task ids" in err
+    assert "same corpus" in err
+
+
+def test_restricting_drops_the_published_rate():
+    """A file's published rate belongs to all of its tasks, not to a subset."""
+    payload = _payload(
+        [_item(selection_status="selection_error")] + [_item(verdict="pass")] * 9,
+        published_rate=0.1,
+        task_count=2,
+    )
+    whole = jeb.breakdown_payload(payload, "L")
+    assert whole.published_rate == 0.1
+
+    part = whole.restrict({"t-0"})
+    assert part.published_rate is None
+    assert part.tasks == 1
+
+
+def test_a_task_counted_twice_is_refused_not_summed(tmp_path):
+    """Reading the shards and their merged final would double every number.
+
+    Shard slices are disjoint by construction, so an id appearing twice means
+    either the slicing broke or someone pointed this at a directory holding
+    both halves of the same data. Summing them silently would report every
+    figure at twice its true value, and the totals would still look plausible.
+    """
+    with pytest.raises(ValueError, match="more than once"):
+        jeb.breakdown_payload(
+            {"tasks": [{"task_id": "t-0", "items": []}] * 2}, "L"
+        )
+
+    stem = tmp_path / "stem"
+    _write(stem, "shard-000-of-001.json", _payload([_item(verdict="pass")]))
+    _write(stem, "final.json", _payload([_item(verdict="pass")]))
+    with pytest.raises(ValueError, match="repeats 1 task"):
+        jeb.total_of(jeb.read_breakdowns([stem]))
+
+
+def test_a_task_without_an_id_is_read_but_cannot_pair():
+    """Legacy files predate ``task_id``; refusing to read them helps nobody."""
+    payload = {"tasks": [{"items": [_item(selection_status="selection_error")]}] * 2}
+    result = jeb.breakdown_payload(payload, "legacy.json")
+
+    assert (result.tasks, result.errors) == (2, 2)
+    assert sorted(result.per_task) == ["legacy.json#0", "legacy.json#1"]
+    assert result.restrict({"t-0"}).tasks == 0
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #199.

`--baseline` compared two runs by their totals, which is only meaningful when both cover the same tasks. It rarely holds.

A shard is a stride slice, not a sample. On the published sol-220 run the nine shard rates span **0.40% to 9.71%**, because the 243 selector failures sit almost entirely in four of them and shard 0 has none at all. Comparing a canary shard against a whole-run baseline flatters or damns a fix for reasons that have nothing to do with the fix.

It bites hardest exactly where the tool is most useful — mid-run. Right now the new side has published 13 tasks and the baseline has all 220; the old output compared 600 items against 10453 and called the gap a result. That is a measure of how far along the run is.

## What changes

- Both sides are cut to the task ids they share before anything is counted. The run reports what it set aside, and that the table no longer matches either run's own published totals.
- `restrict()` drops `published_rate` — a file publishes a rate for all of its tasks, and that is not the rate of a subset of them.
- An empty intersection exits 2 rather than reporting `0.00% -> 0.00%`.
- Pairing makes double counting reachable, so a task id claimed twice now raises. Reading a shard directory alongside the final it was merged from would otherwise report every figure at twice its true value, with plausible-looking totals.
- Tasks with no `task_id` — legacy files predate the field — still parse, under a key that cannot collide and cannot pair.
- With the same tasks on both sides, a denominator gap can no longer be explained by different tasks. The NOTE now says what is left: the rubric moved.

## Verification

Against the live shard-0 slice of the run in flight:

```
shard-000-of-009.json    13     600     0   0.00%     0     0     0     0     0
paired on the 13 task(s) both runs have published. Set aside: 0 here, 207 in the baseline.
paired comparison  (baseline -> ALL)
  tasks in both          13
  judged items          600 ->     600
  judge errors            1 ->       0
  rate                0.17% ->   0.00%
  harness-caused          1 ->       0
  model-caused            0 ->       0
  gate: 0.00% vs 2.00% -> OK    exit=0
```

That reproduces exactly what an ad-hoc hand-filtered script had to do before.

30 tests, all passing. Two mutations confirmed teeth: dropping the intersection breaks `test_a_partial_run_is_paired_only_on_what_it_has_published`; dropping the clash check breaks `test_a_task_counted_twice_is_refused_not_summed`.

## Freeze

Nine shards are in flight. Neither touched path feeds `grader_source_hash` — re-verified on this branch as `595c7254caf8fbd7`, unchanged. `batch-runner/scripts/` is not globbed by the hash (only `scripts/download_inference_from_hf.py` is named), and `batch-runner/tests/` is not an input at all.