### PR TITLE
fix(grading): stop filing judge flakiness under the model under test

### DIFF
--- a/batch-runner/scripts/judge_error_breakdown.py
+++ b/batch-runner/scripts/judge_error_breakdown.py
@@ -4,21 +4,25 @@
 ``judge_error_rate`` is already published in every grade file's
 ``summary.wow``, and every downstream card carries a ``< 2%`` gate on it. The
 rate alone is not enough to decide anything, because the errors it counts come
-from two unlike places:
+from three unlike places:
 
 * the harness could not put the deliverable in front of the judge -- the
   selector refused to choose between same-format files (``#190``), or a
   document had no render target (``#189``). These are our defects, and fixing
   them is what makes the number move.
-* the model did not submit gradeable work -- wrong format, or nothing at all.
-  These are findings about the model under test. They are supposed to be
-  there, and driving them to zero would mean grading something the model never
-  produced.
+* the judge was shown the work and did not answer -- empty final text, output
+  that would not parse, an envelope that would not validate. That is the
+  grading model misbehaving, usually against a token cap. It is noise: it
+  varies run to run over identical input, so a change in it is not a result.
+* the model under test did not submit gradeable work -- wrong format. This is
+  a finding about the model. It is supposed to be there, and driving it to
+  zero would mean grading something the model never produced.
 
 A run whose rate falls because we fixed the first kind has genuinely improved.
-A run whose rate falls because the corpus happened to contain fewer of the
-second kind has not. Reading only the headline rate cannot tell those apart,
-so this prints the split.
+A run whose rate moves because the judge flaked a different number of times,
+or because the corpus happened to contain fewer of the third kind, has not.
+Reading only the headline rate cannot tell those apart, so this prints the
+split.
 
 The second reason to have this is that **a shard's rate is not the run's
 rate**, and they differ by a lot. On the published sol-220 run the whole-run
@@ -55,17 +59,19 @@ from pathlib import Path
 from typing import Iterable, Sequence
 
 
-# Ordered worst-first for display. The two ``harness`` buckets are ours to fix;
-# the two ``model`` ones are results, not defects.
+# Ordered worst-first for display. The ``harness`` buckets are ours to fix; the
+# ``judge`` one is the grading LLM failing to answer; the ``model`` one is a
+# result, not a defect.
 HARNESS_BUCKETS = ("selector_ambiguous", "render_target_missing")
-MODEL_BUCKETS = ("wrong_format", "empty_output")
-BUCKETS = HARNESS_BUCKETS + MODEL_BUCKETS + ("unclassified",)
+JUDGE_BUCKETS = ("judge_no_verdict",)
+MODEL_BUCKETS = ("wrong_format",)
+BUCKETS = HARNESS_BUCKETS + JUDGE_BUCKETS + MODEL_BUCKETS + ("unclassified",)
 
 BUCKET_HELP = {
     "selector_ambiguous": "harness: selector could not choose between candidates",
     "render_target_missing": "harness: nothing could be rendered for the judge to see",
+    "judge_no_verdict": "judge: the grading model returned no usable verdict",
     "wrong_format": "model: submitted files, none in a requested format",
-    "empty_output": "model: submitted no gradeable text",
     "unclassified": "UNKNOWN -- a failure shape this tool does not recognise",
 }
 
@@ -117,7 +123,15 @@ def classify_error(item: dict) -> str:
     if modality in ("visual", "mixed") and not rendered:
         return "render_target_missing"
     if modality == "text":
-        return "empty_output"
+        # Selection succeeded and the text was put in front of the judge, so
+        # what failed is the judge's own answer: it returned empty text, or
+        # text that would not parse, or an envelope that did not validate
+        # (``core.tool_calling_judge._finalization_retry_reason``). Every
+        # instance in both the published run and the rerun is one of those.
+        # This was originally called ``empty_output`` and filed under the
+        # model, which read as a finding about the submission when it is
+        # really grading-side flakiness -- mostly a token cap.
+        return "judge_no_verdict"
     return "unclassified"
 
 
@@ -144,6 +158,10 @@ class Breakdown:
     @property
     def harness_errors(self) -> int:
         return sum(self.buckets[name] for name in HARNESS_BUCKETS)
+
+    @property
+    def judge_side_errors(self) -> int:
+        return sum(self.buckets[name] for name in JUDGE_BUCKETS)
 
     @property
     def model_errors(self) -> int:
@@ -300,6 +318,8 @@ def compare(new: Breakdown, old: Breakdown) -> list[str]:
         f"  rate              {old.rate * 100:>6.2f}% -> {new.rate * 100:>6.2f}%",
         f"  harness-caused    {old.harness_errors:>7} -> {new.harness_errors:>7}"
         f"   <- ours to fix; this is the number a fix should move",
+        f"  judge-side        {old.judge_side_errors:>7} -> {new.judge_side_errors:>7}"
+        f"   <- the grading model not answering; noise, not signal",
         f"  model-caused      {old.model_errors:>7} -> {new.model_errors:>7}"
         f"   <- a property of the submissions, not a defect",
     ]

--- a/batch-runner/tests/test_judge_error_breakdown.py
+++ b/batch-runner/tests/test_judge_error_breakdown.py
@@ -48,7 +48,7 @@ PUBLISHED_TOTALS = {
     "selector_ambiguous": 243,
     "render_target_missing": 74,
     "wrong_format": 12,
-    "empty_output": 4,
+    "judge_no_verdict": 4,
     "unclassified": 0,
 }
 
@@ -172,7 +172,11 @@ def test_the_tool_reproduces_the_published_run_exactly():
     assert total.rate == 0.0319
     assert sum(total.buckets.values()) == total.errors
     assert total.harness_errors == 243 + 74
-    assert total.model_errors == 12 + 4
+    assert total.judge_side_errors == 4
+    assert total.model_errors == 12
+    # 317 of the 333 are ours. The published run's headline 3.19% is very
+    # nearly a measure of this harness, not of the model under test.
+    assert total.harness_errors + total.judge_side_errors + total.model_errors == 333
 
 
 @pytest.mark.skipif(
@@ -212,6 +216,51 @@ def test_every_published_shard_rate_recomputes():
     assert rates[0] < 0.01 < 0.09 < rates[-1]
 
 
+@pytest.mark.skipif(
+    _published_corpus() is None,
+    reason=(
+        f"the published sol-220 shards (data/grades/_shards/*{PUBLISHED_SRC}*) "
+        "are not in this checkout"
+    ),
+)
+def test_the_judge_bucket_holds_only_judge_side_failures():
+    """Cross-check the structural rule against the prose it refuses to read.
+
+    ``classify_error`` decides from structured fields on purpose, so nothing
+    rebuckets when a message is reworded. The cost of that is no feedback if
+    the rule is aimed at the wrong thing -- which it was: this bucket was
+    called ``empty_output`` and filed under the model under test, and the
+    rerun showed ``final_json_parse_failed`` in it. That string comes from
+    ``core.tool_calling_judge._finalization_retry_reason``, and it describes
+    the *judge's* answer failing to parse, not a submission.
+
+    So read the evidence here and nowhere else, as an assertion rather than as
+    a classifier: everything the structural rule puts in this bucket must be
+    one of the reasons that function emits. A new shape appearing here means
+    the rule is catching something it was not aimed at, and the bucket name is
+    lying about the cause.
+    """
+    judge_side = ("empty_final_text", "final_json_parse_failed", "invalid_final_envelope")
+    found = set()
+    for part_path in sorted(_published_corpus().glob("shard-*.json")):
+        payload = json.loads(part_path.read_text(encoding="utf-8"))
+        for task in payload["tasks"]:
+            for item in task.get("items") or []:
+                if item.get("decided_by") != "judge":
+                    continue
+                if item.get("verdict") != "judge_error":
+                    continue
+                if jeb.classify_error(item) != "judge_no_verdict":
+                    continue
+                evidence = str(item.get("evidence") or "")
+                # ``empty_final_text`` carries a ``:finish_reason`` suffix.
+                assert evidence.startswith(judge_side), evidence
+                found.add(evidence.split(":")[0])
+
+    # If the corpus ever stops containing any, this test would pass vacuously.
+    assert found == {"empty_final_text"}
+
+
 # --------------------------------------------------------------------------
 # classification
 # --------------------------------------------------------------------------
@@ -246,9 +295,10 @@ def test_every_published_shard_rate_recomputes():
             {"selection_status": "ok", "routing_modality": "mixed"},
             "render_target_missing",
         ),
-        # Selection was fine and the route was text, so the deliverable held
-        # no gradeable text.
-        ({"selection_status": "ok", "routing_modality": "text"}, "empty_output"),
+        # Selection was fine and the route was text, so the work reached the
+        # judge and the judge is what failed -- empty final text, unparseable
+        # output, or an envelope that would not validate.
+        ({"selection_status": "ok", "routing_modality": "text"}, "judge_no_verdict"),
     ],
 )
 def test_each_failure_shape_lands_in_its_own_bucket(item, expected):
@@ -416,32 +466,43 @@ def test_the_gate_passes_and_fails_on_the_threshold(tmp_path, capsys):
     assert jeb.main([str(path)]) == 0
 
 
-def test_a_paired_comparison_keeps_the_two_causes_apart(tmp_path, capsys):
-    """A fix should be read off the harness line, not the headline rate."""
+def test_a_paired_comparison_keeps_the_three_causes_apart(tmp_path, capsys):
+    """A fix should be read off the harness line, not the headline rate.
+
+    The other two lines are what makes that reading safe. Here the harness
+    errors go away while a judge flake and a model failure stay exactly where
+    they were, so the rate move is attributable to the fix and to nothing
+    else. Collapsing judge-side into the model line -- which this tool did
+    until the rerun showed ``final_json_parse_failed`` sitting in it -- would
+    report grading flakiness as a finding about the submissions.
+    """
     old = _write(
         tmp_path / "old",
         "grade.json",
         _payload(
             [_item(selection_status="selection_error")] * 6
             + [_item(selection_status="wrong_format_primary")] * 2
-            + [_item(verdict="pass")] * 92
+            + [_item(selection_status="ok", routing_modality="text")] * 1
+            + [_item(verdict="pass")] * 91
         ),
     )
-    # Same denominator, harness errors fixed, model errors untouched.
+    # Same denominator, harness errors fixed, the other two untouched.
     new = _write(
         tmp_path / "new",
         "grade.json",
         _payload(
             [_item(selection_status="wrong_format_primary")] * 2
-            + [_item(verdict="pass")] * 98
+            + [_item(selection_status="ok", routing_modality="text")] * 1
+            + [_item(verdict="pass")] * 97
         ),
     )
 
     assert jeb.main([str(new), "--baseline", str(old)]) == 0
     out = capsys.readouterr().out
     assert "harness-caused          6 ->       0" in out
+    assert "judge-side              1 ->       1" in out
     assert "model-caused            2 ->       2" in out
-    assert "rate                8.00% ->   2.00%" in out
+    assert "rate                9.00% ->   3.00%" in out
     assert "NOTE" not in out
 
 


### PR DESCRIPTION
Follow-up to #199 / #200. Found by the first complete shard of the rerun.

## The bug

The `empty_output` bucket was described as *"model: submitted no gradeable text"* and counted toward `model_errors`. It is neither.

Its two evidence strings both come from `core/tool_calling_judge.py:_finalization_retry_reason`, where `final_text` is the **judge's** response:

```python
if not final_text.strip():
    return f"empty_final_text:{finish_reason}"
parsed = _safe_json_loads(final_text)
if parsed is None:
    return "final_json_parse_failed"
```

They mean the grading model returned nothing, or returned something that would not parse — usually against a token cap. That is grading-side flakiness. It says nothing about the submission, and it varies run to run over identical input.

## How it surfaced

Shard 0 of the rerun finished (25/25 tasks) and came back with model-caused apparently **up 3 → 5** against the published run, on the same 25 tasks and the same 1081 items. Item by item, the two "new" failures were `empty_final_text` on a task that already had one, and `final_json_parse_failed` on a previously clean task — the judge declining to answer, on submissions that had not changed.

Reported as "model-caused", that reads as the model under test having got worse between two runs it did not participate in.

## The change

Three-way split: **harness** (ours to fix) / **judge-side** (noise) / **model** (a result). The bucket is `judge_no_verdict`, and `compare()` prints its own line.

Shard 0, corrected:

```
  harness-caused         13 ->       6   <- ours to fix; this is the number a fix should move
  judge-side              1 ->       3   <- the grading model not answering; noise, not signal
  model-caused            2 ->       2   <- a property of the submissions, not a defect
  rate                1.48% ->   1.02%
```

The `#189` render fix halving our defects, the model line flat where it should be, and the flake visible as flake.

The published run's split is unchanged in substance, re-labelled: of 333 errors, **317 harness, 4 judge-side, 12 model**.

## Why a test didn't catch it

Classification is deliberately structural — decided from `selection_status` / `routing_modality` / `visual_provenance`, never from evidence prose, so nothing rebuckets when a message is reworded. The cost is no feedback when the rule is aimed at the wrong thing.

`test_the_judge_bucket_holds_only_judge_side_failures` reads the prose exactly once, as an assertion rather than as a classifier: everything the structural rule puts in this bucket must be a reason `_finalization_retry_reason` emits, and a new shape appearing there means the bucket name is lying about the cause. Mutating `wrong_format_primary` into this bucket fails it.

31 tests.

## Freeze

Neither touched path feeds `grader_source_hash` — re-verified `595c7254caf8fbd7`, unchanged. Eight shards are still in flight; nothing in `core/`, `step8_grade.py`, the schema, `requirements.txt`, prompts or `grade-run.yml` is modified. `core/tool_calling_judge.py` was read only.