### PR TITLE
fix(grading): stop counting a blank submission as a render defect

### DIFF
--- a/batch-runner/scripts/judge_error_breakdown.py
+++ b/batch-runner/scripts/judge_error_breakdown.py
@@ -14,9 +14,12 @@ from three unlike places:
   that would not parse, an envelope that would not validate. That is the
   grading model misbehaving, usually against a token cap. It is noise: it
   varies run to run over identical input, so a change in it is not a result.
-* the model under test did not submit gradeable work -- wrong format. This is
-  a finding about the model. It is supposed to be there, and driving it to
-  zero would mean grading something the model never produced.
+* the model under test did not submit gradeable work -- it wrote files but
+  none in a requested format, or it produced nothing at all and the pipeline
+  left a ``failed_to_generate.txt`` placeholder where the deliverable should
+  have been. This is a finding about the model. It is supposed to be there,
+  and driving it to zero would mean grading something the model never
+  produced.
 
 A run whose rate falls because we fixed the first kind has genuinely improved.
 A run whose rate moves because the judge flaked a different number of times,
@@ -64,7 +67,7 @@ from typing import Iterable, Sequence
 # result, not a defect.
 HARNESS_BUCKETS = ("selector_ambiguous", "render_target_missing")
 JUDGE_BUCKETS = ("judge_no_verdict",)
-MODEL_BUCKETS = ("wrong_format",)
+MODEL_BUCKETS = ("wrong_format", "nothing_submitted")
 BUCKETS = HARNESS_BUCKETS + JUDGE_BUCKETS + MODEL_BUCKETS + ("unclassified",)
 
 BUCKET_HELP = {
@@ -72,8 +75,14 @@ BUCKET_HELP = {
     "render_target_missing": "harness: nothing could be rendered for the judge to see",
     "judge_no_verdict": "judge: the grading model returned no usable verdict",
     "wrong_format": "model: submitted files, none in a requested format",
+    "nothing_submitted": "model: produced nothing; a placeholder stands in",
     "unclassified": "UNKNOWN -- a failure shape this tool does not recognise",
 }
+
+# What the pipeline writes in place of a deliverable when inference produced no
+# file at all. Named here rather than matched loosely, because the string also
+# appears as a ``target_id`` and both spellings have to mean the same thing.
+PLACEHOLDER_TARGET = "failed_to_generate"
 
 
 def canonical_rate(numerator: int, denominator: int) -> float:
@@ -90,6 +99,23 @@ def canonical_rate(numerator: int, denominator: int) -> float:
         return 0.0
     scaled = (2 * numerator * 10_000 + denominator) // (2 * denominator)
     return scaled / 10_000
+
+
+def _submitted_nothing(item: dict) -> bool:
+    """True when what was selected for grading is the no-output placeholder.
+
+    Checked on both ``target_ids`` and ``selected_paths``: the selector names
+    the target ``failed_to_generate`` and the path ``failed_to_generate.txt``,
+    and a file list without a target list (or the reverse) still has to be
+    recognised.
+    """
+    targets = item.get("target_ids")
+    if isinstance(targets, list) and PLACEHOLDER_TARGET in targets:
+        return True
+    paths = item.get("selected_paths")
+    if isinstance(paths, list):
+        return any(PLACEHOLDER_TARGET in str(path) for path in paths)
+    return False
 
 
 def classify_error(item: dict) -> str:
@@ -114,6 +140,18 @@ def classify_error(item: dict) -> str:
         return "wrong_format"
     if status != "ok":
         return "unclassified"
+
+    # Before asking what the judge was shown, ask whether there was anything to
+    # show. When inference produces no file, the pipeline leaves a
+    # ``failed_to_generate.txt`` placeholder, and the selector passes some of
+    # those through as ``ok`` -- 8 of the published 220 tasks are placeholders,
+    # 2 of them selected cleanly. A visual rubric item then finds a text stub
+    # where a document should be and reports no render target, which reads as a
+    # renderer defect. It is not: nothing was submitted. Blaming the harness for
+    # a file the model never wrote is the same mistake as the old
+    # ``empty_output`` bucket, one step earlier in the pipeline.
+    if _submitted_nothing(item):
+        return "nothing_submitted"
 
     # Selection succeeded, so the failure is downstream of it. What separates
     # the two remaining causes is what the judge was routed to look at.

--- a/batch-runner/tests/test_judge_error_breakdown.py
+++ b/batch-runner/tests/test_judge_error_breakdown.py
@@ -46,8 +46,9 @@ PUBLISHED_TOTALS = {
     "judge_items": 10453,
     "errors": 333,
     "selector_ambiguous": 243,
-    "render_target_missing": 74,
+    "render_target_missing": 68,
     "wrong_format": 12,
+    "nothing_submitted": 6,
     "judge_no_verdict": 4,
     "unclassified": 0,
 }
@@ -171,10 +172,10 @@ def test_the_tool_reproduces_the_published_run_exactly():
     assert got == PUBLISHED_TOTALS
     assert total.rate == 0.0319
     assert sum(total.buckets.values()) == total.errors
-    assert total.harness_errors == 243 + 74
+    assert total.harness_errors == 243 + 68
     assert total.judge_side_errors == 4
-    assert total.model_errors == 12
-    # 317 of the 333 are ours. The published run's headline 3.19% is very
+    assert total.model_errors == 12 + 6
+    # 311 of the 333 are ours. The published run's headline 3.19% is very
     # nearly a measure of this harness, not of the model under test.
     assert total.harness_errors + total.judge_side_errors + total.model_errors == 333
 
@@ -261,6 +262,59 @@ def test_the_judge_bucket_holds_only_judge_side_failures():
     assert found == {"empty_final_text"}
 
 
+@pytest.mark.skipif(
+    _published_corpus() is None,
+    reason=(
+        f"the published sol-220 shards (data/grades/_shards/*{PUBLISHED_SRC}*) "
+        "are not in this checkout"
+    ),
+)
+def test_the_placeholder_bucket_is_drawn_from_the_render_failures():
+    """Show that this bucket took its members from the harness, not the judge.
+
+    Asserting that these items carry the placeholder would be circular -- that
+    is the rule. What is worth asserting is where they came from, so read the
+    evidence prose here, as an assertion and not as a classifier: every one of
+    them reports a missing render target. That is what makes the split a
+    correction rather than a new category. Before this, all six counted as
+    ``render_target_missing`` and were reported as our defect, which put the
+    remaining harness residue at seven when it is one.
+
+    The task-level check is the other half: a placeholder means inference
+    produced no file, so the task cannot have scored. If one of these ever sits
+    on a task that scored, the rule is catching something other than a blank.
+    """
+    tasks_seen = {}
+    evidence_shapes = set()
+    for part_path in sorted(_published_corpus().glob("shard-*.json")):
+        payload = json.loads(part_path.read_text(encoding="utf-8"))
+        for task in payload["tasks"]:
+            for item in task.get("items") or []:
+                if item.get("decided_by") != "judge":
+                    continue
+                if item.get("verdict") != "judge_error":
+                    continue
+                if jeb.classify_error(item) != "nothing_submitted":
+                    continue
+                evidence = str(item.get("evidence") or "")
+                assert "render_target_unavailable" in evidence, evidence
+                evidence_shapes.add(evidence)
+                tasks_seen[task["task_id"]] = task
+
+    # Non-vacuous, and the whole bucket is one blank submission.
+    assert len(tasks_seen) == 1
+    assert evidence_shapes == {"required_visual_render_target_unavailable"}
+    task = next(iter(tasks_seen.values()))
+    assert task["total_awarded"] == 0.0
+    assert task["total_max"] > 0
+
+    # And the counts move as a correction: what left the harness is exactly
+    # what arrived at the model.
+    total = jeb.total_of(jeb.read_breakdowns([_published_corpus()]))
+    assert total.buckets["nothing_submitted"] == 6
+    assert total.buckets["render_target_missing"] == 74 - 6
+
+
 # --------------------------------------------------------------------------
 # classification
 # --------------------------------------------------------------------------
@@ -299,9 +353,86 @@ def test_the_judge_bucket_holds_only_judge_side_failures():
         # judge and the judge is what failed -- empty final text, unparseable
         # output, or an envelope that would not validate.
         ({"selection_status": "ok", "routing_modality": "text"}, "judge_no_verdict"),
+        # Nothing was submitted. Named by target, by path, and by both --
+        # whichever the grader wrote, the answer is the same. Each of these
+        # would otherwise have been read as a render-target miss, blaming the
+        # renderer for a file that was never produced.
+        (
+            {
+                "selection_status": "ok",
+                "routing_modality": "visual",
+                "visual_provenance": [],
+                "target_ids": ["failed_to_generate"],
+            },
+            "nothing_submitted",
+        ),
+        (
+            {
+                "selection_status": "ok",
+                "routing_modality": "visual",
+                "visual_provenance": [],
+                "selected_paths": ["failed_to_generate.txt"],
+            },
+            "nothing_submitted",
+        ),
+        (
+            {
+                "selection_status": "ok",
+                "routing_modality": "visual",
+                "visual_provenance": [],
+                "target_ids": ["failed_to_generate"],
+                "selected_paths": ["failed_to_generate.txt"],
+            },
+            "nothing_submitted",
+        ),
+        # And it outranks the text route too: a placeholder graded as text is
+        # still nothing submitted, not the judge declining to answer.
+        (
+            {
+                "selection_status": "ok",
+                "routing_modality": "text",
+                "target_ids": ["failed_to_generate"],
+            },
+            "nothing_submitted",
+        ),
     ],
 )
 def test_each_failure_shape_lands_in_its_own_bucket(item, expected):
+    assert jeb.classify_error(item) == expected
+
+
+@pytest.mark.parametrize(
+    "item, expected",
+    [
+        # The selector's own failures are decided before anything is looked at,
+        # so they keep their bucket even when a placeholder is what it landed
+        # on. Which of the two is reported matters: `#190` is measured by the
+        # selector count, and letting a placeholder silently drain it would
+        # make an unfixed selector look fixed.
+        (
+            {
+                "selection_status": "selection_error",
+                "target_ids": ["failed_to_generate"],
+            },
+            "selector_ambiguous",
+        ),
+        (
+            {
+                "selection_status": "wrong_format_primary",
+                "selected_paths": ["failed_to_generate.txt"],
+            },
+            "wrong_format",
+        ),
+    ],
+)
+def test_a_placeholder_does_not_override_a_selection_failure(item, expected):
+    """Ordering is a decision, not an accident, so pin it.
+
+    Neither combination occurs in either run -- every placeholder-carrying
+    error in both the published corpus and the rerun is ``(ok, visual)``. That
+    is exactly why it is worth a test: nothing in the data would catch it if
+    the check moved above the status guards.
+    """
     assert jeb.classify_error(item) == expected
 
 


### PR DESCRIPTION
## What

`judge_error_breakdown.py` filed a blank submission under the harness.

Six of the seven harness errors remaining in the R1 rerun sit on a single task whose selected deliverable is `failed_to_generate.txt` — the placeholder written when inference produced no file. The selector passes some of those through as `selection_status: ok`, so a visual rubric item finds a text stub where a document should be and reports `required_visual_render_target_unavailable`.

`classify_error` read that string's *shape* as `render_target_missing` and counted it as our defect. It is not a renderer defect. Nothing was submitted, and no renderer change could ever move it.

This is the same mistake the old `empty_output` bucket made (#201), one step earlier in the pipeline: a model outcome charged to the harness.

## Why it matters now

R1 is being read to decide whether #189 and #190 worked. Across the 125 tasks published so far, the paired split was reporting:

```
harness-caused        193 ->       7
model-caused            7 ->       7
```

The true split is:

```
harness-caused        187 ->       1
model-caused           13 ->      13
```

The residual harness defect is **one task**, not seven — and the count is identical on both sides of the comparison, because a blank submission is a property of the submission, not of the grader.

## Ordering

The placeholder check sits **after** the selection-status guards, so a selector failure still reports as a selector failure. Draining `selector_ambiguous` into a placeholder bucket would make an unfixed selector look fixed, and #190 is measured by that count.

That ordering is not observable in the data — every placeholder-carrying error in both the published corpus and the rerun is `(ok, visual)` — so it gets an explicit test rather than relying on a corpus that cannot catch its regression.

## Verification

- 38 tests pass (was 31; +7).
- Corpus test updated: the published run's 333 errors now split 243 / 68 / 4 / 12 / 6, `unclassified == 0`.
- New corpus cross-check reads the evidence prose (which the classifier refuses to read) to prove these six came *from* the render bucket, and asserts the task scored 0.
- Mutation-tested: hoisting the placeholder check above the status guards fails exactly the two ordering tests and nothing else; restore is clean.

## Freeze safety

Touches only `batch-runner/scripts/` and `batch-runner/tests/`, neither an input to `grader_source_hash`. Re-verified at `595c7254caf8fbd7`, matching the stem of the nine shards currently in flight.