### PR TITLE
fix(grading): require every selected target to be a placeholder

### DIFF
--- a/batch-runner/scripts/judge_error_breakdown.py
+++ b/batch-runner/scripts/judge_error_breakdown.py
@@ -58,7 +58,7 @@ import argparse
 import json
 import sys
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterable, Sequence
 
 
@@ -101,21 +101,37 @@ def canonical_rate(numerator: int, denominator: int) -> float:
     return scaled / 10_000
 
 
-def _submitted_nothing(item: dict) -> bool:
-    """True when what was selected for grading is the no-output placeholder.
+def _is_placeholder_name(name: str) -> bool:
+    """True for a target or path that names the no-output placeholder.
 
-    Checked on both ``target_ids`` and ``selected_paths``: the selector names
-    the target ``failed_to_generate`` and the path ``failed_to_generate.txt``,
-    and a file list without a target list (or the reverse) still has to be
-    recognised.
+    One predicate covers both spellings: the selector names the target
+    ``failed_to_generate`` and the path ``.../failed_to_generate.txt``.
     """
-    targets = item.get("target_ids")
-    if isinstance(targets, list) and PLACEHOLDER_TARGET in targets:
-        return True
-    paths = item.get("selected_paths")
-    if isinstance(paths, list):
-        return any(PLACEHOLDER_TARGET in str(path) for path in paths)
-    return False
+    return PurePosixPath(str(name)).name.lower().startswith(PLACEHOLDER_TARGET)
+
+
+def _submitted_nothing(item: dict) -> bool:
+    """True when *everything* selected for grading is the no-output placeholder.
+
+    Every name has to be a placeholder, not merely one of them. A task graded
+    with ``target_scope: split_children`` puts each child in this list, so a
+    two-child task that produced one real file and one placeholder would, under
+    an any-match rule, be reported as having submitted nothing -- when in fact
+    half of it arrived and deserves to be judged. ``scripts/selection-outcome.mjs``
+    settled on the same all-match rule for the dashboard's task-level split; the
+    two answers to "was anything submitted?" should not be allowed to disagree.
+
+    Read across ``target_ids`` and ``selected_paths`` together, since an item
+    may carry either list alone. No names at all is not a blank submission --
+    it is an item we cannot speak for, and it falls through to the other rules.
+    """
+    names = [
+        name
+        for key in ("target_ids", "selected_paths")
+        if isinstance(item.get(key), list)
+        for name in item[key]
+    ]
+    return bool(names) and all(_is_placeholder_name(name) for name in names)
 
 
 def classify_error(item: dict) -> str:

--- a/batch-runner/tests/test_judge_error_breakdown.py
+++ b/batch-runner/tests/test_judge_error_breakdown.py
@@ -402,6 +402,66 @@ def test_each_failure_shape_lands_in_its_own_bucket(item, expected):
 
 
 @pytest.mark.parametrize(
+    "item",
+    [
+        # A `split_children` task grades each child as its own target. One child
+        # produced a real workbook and the other did not: something was
+        # submitted, so "nothing submitted" is the wrong answer, and what is
+        # left -- a visual item with no render target -- is the honest one.
+        {
+            "selection_status": "ok",
+            "routing_modality": "visual",
+            "visual_provenance": [],
+            "target_ids": ["mig_welding_catch_up_plan", "failed_to_generate"],
+        },
+        {
+            "selection_status": "ok",
+            "routing_modality": "visual",
+            "visual_provenance": [],
+            "selected_paths": ["out/plan.xlsx", "out/failed_to_generate.txt"],
+        },
+        # Split across the two lists, which is how the grader writes an item
+        # that carries both a target list and the paths they resolved to.
+        {
+            "selection_status": "ok",
+            "routing_modality": "visual",
+            "visual_provenance": [],
+            "target_ids": ["mig_welding_catch_up_plan"],
+            "selected_paths": ["out/failed_to_generate.txt"],
+        },
+    ],
+)
+def test_one_real_file_among_placeholders_is_not_a_blank_submission(item):
+    """The rule is all-match, not any-match.
+
+    ``scripts/selection-outcome.mjs`` reached the same conclusion for the
+    dashboard's task-level split, where ``isInferencePlaceholder`` requires
+    every file to be a placeholder. Two modules answering "was anything
+    submitted?" differently would put two different numbers in front of a
+    reader, so the item-level rule here is held to the same standard.
+
+    No mixed item exists in either run today -- all 6 placeholder-carrying
+    errors in each are placeholder-only. This pins the behaviour before a run
+    produces one.
+    """
+    assert jeb.classify_error(item) == "render_target_missing"
+
+
+def test_an_item_naming_no_target_at_all_is_not_a_blank_submission():
+    """Absent lists mean we cannot speak for the item, which is not the same
+    as knowing it was blank. It falls through to the other rules."""
+    assert jeb.classify_error(
+        {
+            "selection_status": "ok",
+            "routing_modality": "visual",
+            "visual_provenance": [],
+            "target_ids": [],
+            "selected_paths": [],
+        }
+    ) == "render_target_missing"
+
+
+@pytest.mark.parametrize(
     "item, expected",
     [
         # The selector's own failures are decided before anything is looked at,


### PR DESCRIPTION
`_submitted_nothing` in `judge_error_breakdown.py` matched on **any** placeholder among an item's targets. A `split_children` item lists each child separately, so a task that produced one real workbook and one placeholder would have been reported as having submitted nothing — when half of it arrived and deserves to be judged.

`scripts/selection-outcome.mjs` already settled this question for the dashboard's task-level split: `isInferencePlaceholder` requires *every* file to match. Two modules answering "was anything submitted?" differently would put two different numbers in front of a reader, so the item-level rule is now held to the same standard. Both spellings the grader emits (`failed_to_generate` as a target, `failed_to_generate.txt` as a path) now go through one basename-prefix predicate.

### No counts move
All 6 placeholder-carrying errors in the published corpus and all 6 in the rerun are placeholder-**only**, so any-match and all-match agree on today's data — verified directly against both shard sets. This pins the behaviour before a run produces a mixed item. An item naming no targets at all is likewise no longer claimable as blank; it falls through to the other rules.

### Verification
- `tests/test_judge_error_breakdown.py`: **38 → 42 passed**. The corpus-backed assertions (`PUBLISHED_TOTALS`, and the render-failure cross-check) read the real grade files and are unchanged.
- Mutation test: reverting `all` → `any` fails exactly the three new mixed-item cases (3 failed, 39 passed).

### Source-hash freeze
Diff is confined to `batch-runner/scripts/judge_error_breakdown.py` and `batch-runner/tests/`, neither of which is a hash input. `grader_source_hash` recomputed after the change: **`595c7254caf8fbd7`**, matching the in-flight shard stem. Safe to merge with shards running.