### PR TITLE
fix(grading): name the half-rendered bundle instead of dropping it

### DIFF
--- a/batch-runner/scripts/judge_error_breakdown.py
+++ b/batch-runner/scripts/judge_error_breakdown.py
@@ -65,14 +65,32 @@ from typing import Iterable, Sequence
 # Ordered worst-first for display. The ``harness`` buckets are ours to fix; the
 # ``judge`` one is the grading LLM failing to answer; the ``model`` one is a
 # result, not a defect.
-HARNESS_BUCKETS = ("selector_ambiguous", "render_target_missing")
+HARNESS_BUCKETS = (
+    "selector_ambiguous",
+    "render_target_missing",
+    "render_target_partial",
+)
 JUDGE_BUCKETS = ("judge_no_verdict",)
 MODEL_BUCKETS = ("wrong_format", "nothing_submitted")
 BUCKETS = HARNESS_BUCKETS + JUDGE_BUCKETS + MODEL_BUCKETS + ("unclassified",)
 
+# Column headings for the table. Taking the first five characters collides
+# once ``render_target_missing`` and ``render_target_partial`` are both
+# present, and two columns headed ``rende`` are worse than no heading at all.
+BUCKET_ABBREV = {
+    "selector_ambiguous": "selec",
+    "render_target_missing": "rmiss",
+    "render_target_partial": "rpart",
+    "judge_no_verdict": "judge",
+    "wrong_format": "wrong",
+    "nothing_submitted": "nothi",
+    "unclassified": "uncla",
+}
+
 BUCKET_HELP = {
     "selector_ambiguous": "harness: selector could not choose between candidates",
     "render_target_missing": "harness: nothing could be rendered for the judge to see",
+    "render_target_partial": "harness: only some of the selected files reached the judge",
     "judge_no_verdict": "judge: the grading model returned no usable verdict",
     "wrong_format": "model: submitted files, none in a requested format",
     "nothing_submitted": "model: produced nothing; a placeholder stands in",
@@ -134,6 +152,36 @@ def _submitted_nothing(item: dict) -> bool:
     return bool(names) and all(_is_placeholder_name(name) for name in names)
 
 
+def _render_is_partial(item: dict) -> bool:
+    """True when some, but not all, of the selected files reached the judge.
+
+    Only meaningful for an item that already failed. Partial rendering on its
+    own is ordinary and harmless -- across the two runs, 42 items rendered a
+    subset of what they selected and the judge answered them all without
+    complaint, because the rubric line only needed the file it got. So this is
+    never a defect by itself; it is only the explanation for an item that has
+    already been recorded as a ``judge_error``.
+
+    Judged on path coverage rather than on the evidence prose, which for these
+    reads ``required_visual_perception_failed:<file>:invalid_vision_envelope``.
+    An item that selected two files and has provenance for one of them was
+    shown half of what the rubric asked about, and a rubric line phrased "in
+    both the spreadsheet and the layout" cannot be answered from half.
+    """
+    selected = item.get("selected_paths")
+    provenance = item.get("visual_provenance")
+    if not isinstance(selected, list) or not isinstance(provenance, list):
+        return False
+    covered = {
+        str(entry.get("path"))
+        for entry in provenance
+        if isinstance(entry, dict) and entry.get("path")
+    }
+    if not covered:
+        return False
+    return any(str(path) not in covered for path in selected)
+
+
 def classify_error(item: dict) -> str:
     """Return which bucket one ``judge_error`` item belongs to.
 
@@ -176,6 +224,8 @@ def classify_error(item: dict) -> str:
     rendered = bool(provenance) if isinstance(provenance, list) else provenance is not None
     if modality in ("visual", "mixed") and not rendered:
         return "render_target_missing"
+    if modality in ("visual", "mixed") and _render_is_partial(item):
+        return "render_target_partial"
     if modality == "text":
         # Selection succeeded and the text was put in front of the judge, so
         # what failed is the judge's own answer: it returned empty text, or
@@ -347,7 +397,7 @@ def _row(entry: Breakdown, width: int) -> str:
 def render(parts: list[Breakdown], total: Breakdown, width: int) -> list[str]:
     header = (
         f"{'file':<{width}} {'tasks':>5} {'judged':>7} {'errs':>5} {'rate':>7}"
-        + "".join(f" {name[:5]:>5}" for name in BUCKETS)
+        + "".join(f" {BUCKET_ABBREV[name]:>5}" for name in BUCKETS)
     )
     lines = [header, "-" * len(header)]
     lines += [_row(part, width) for part in parts]
@@ -356,7 +406,7 @@ def render(parts: list[Breakdown], total: Breakdown, width: int) -> list[str]:
     lines.append("")
     lines.append("buckets:")
     for name in BUCKETS:
-        lines.append(f"  {name[:5]:<5}  {name:<22}  {BUCKET_HELP[name]}")
+        lines.append(f"  {BUCKET_ABBREV[name]:<5}  {name:<22}  {BUCKET_HELP[name]}")
     return lines
 
 

--- a/batch-runner/tests/test_judge_error_breakdown.py
+++ b/batch-runner/tests/test_judge_error_breakdown.py
@@ -47,6 +47,12 @@ PUBLISHED_TOTALS = {
     "errors": 333,
     "selector_ambiguous": 243,
     "render_target_missing": 68,
+    # Zero, and that is the point: `render_target_partial` was added while
+    # reading the rerun, where it named 2 errors this classifier had been
+    # returning as `unclassified`. A new bucket that reached back and moved
+    # counts in the published run would silently restate a finished experiment,
+    # so this pins that it does not.
+    "render_target_partial": 0,
     "wrong_format": 12,
     "nothing_submitted": 6,
     "judge_no_verdict": 4,
@@ -459,6 +465,67 @@ def test_an_item_naming_no_target_at_all_is_not_a_blank_submission():
             "selected_paths": [],
         }
     ) == "render_target_missing"
+
+
+def _visual(selected, covered, modality="visual"):
+    return {
+        "selection_status": "ok",
+        "routing_modality": modality,
+        "selected_paths": list(selected),
+        "visual_provenance": [{"path": path} for path in covered],
+    }
+
+
+@pytest.mark.parametrize("modality", ["visual", "mixed"])
+def test_half_a_bundle_reaching_the_judge_is_a_harness_failure(modality):
+    """The shape that was coming back `unclassified` from the rerun.
+
+    Task a73fbc98 selected a PDF and an XLSX under `target_scope:
+    primary_bundle`. The PDF rendered; the XLSX did not, and the rubric line
+    asks about *both* ("in both the spreadsheet deliverable and the arena
+    layout deliverable"). Provenance is non-empty, so the existing
+    `render_target_missing` check -- which requires it to be empty -- did not
+    fire, and the item fell off the end of the classifier.
+    """
+    item = _visual(
+        ["Spring_Bazaar_2025_Table_Assignment_Summary.pdf", "Spring_Bazaar_2025_Vendor_Assignments.xlsx"],
+        ["Spring_Bazaar_2025_Table_Assignment_Summary.pdf"],
+        modality=modality,
+    )
+    assert jeb.classify_error(item) == "render_target_partial"
+    assert "render_target_partial" in jeb.HARNESS_BUCKETS
+
+
+def test_a_fully_rendered_bundle_is_not_a_partial_render():
+    """Everything selected reached the judge, so whatever failed is not this."""
+    item = _visual(["a.pdf", "b.xlsx"], ["a.pdf", "b.xlsx"])
+    assert jeb.classify_error(item) != "render_target_partial"
+
+
+def test_nothing_rendered_is_still_reported_as_missing_not_partial():
+    """Empty provenance keeps its own bucket. Folding "none" into "some" would
+    hide the difference between a renderer that produced nothing and one that
+    produced half, which are different bugs with different fixes."""
+    assert jeb.classify_error(_visual(["a.pdf", "b.xlsx"], [])) == "render_target_missing"
+
+
+def test_a_blank_submission_still_outranks_a_partial_render():
+    """Ordering: nothing submitted is the deeper cause, so it wins. A
+    placeholder-only item can also look partially rendered, and reporting that
+    as a renderer defect is the exact mistake `nothing_submitted` exists to
+    prevent."""
+    item = _visual(["failed_to_generate.txt", "failed_to_generate.txt"], ["failed_to_generate.txt"])
+    assert jeb.classify_error(item) == "nothing_submitted"
+
+
+def test_every_bucket_has_a_column_heading_and_they_are_distinct():
+    """Two buckets abbreviated to the same five characters once
+    `render_target_partial` arrived, which put two columns headed `rende` in
+    the table."""
+    assert set(jeb.BUCKET_ABBREV) == set(jeb.BUCKETS)
+    assert set(jeb.BUCKET_HELP) == set(jeb.BUCKETS)
+    assert len(set(jeb.BUCKET_ABBREV.values())) == len(jeb.BUCKETS)
+    assert all(len(short) == 5 for short in jeb.BUCKET_ABBREV.values())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Two judge errors in the R1 rerun were coming back `unclassified`, and the tool prints *"do not read the split as complete until they are explained"* when that happens. They are explained now — and they are **ours**.

Task `a73fbc98` selected a PDF and an XLSX under `target_scope: primary_bundle`. The PDF rendered; the XLSX failed with `invalid_vision_envelope`. The rubric line asks about **both** (*"in both the spreadsheet deliverable and the arena layout deliverable"*), so half a bundle cannot answer it. `render_target_missing` requires provenance to be *empty*, so a partially-rendered bundle matched nothing and fell off the end of the classifier.

### What this adds
`render_target_partial`, under the harness buckets, decided **structurally** on path coverage — provenance covering fewer of `selected_paths` than were selected — rather than on the evidence prose `required_visual_perception_failed:<file>:invalid_vision_envelope`. That keeps the classifier's no-prose rule.

### Partial rendering is not, by itself, a defect
**42 items** across the two runs rendered a subset of what they selected and the judge answered every one, because the rubric line only needed the file it got. So the bucket only ever applies to an item already recorded as a `judge_error`. Getting this backwards would have invented 42 defects.

### The published run is unmoved
`render_target_partial` is **0** in the published corpus, now pinned in `PUBLISHED_TOTALS`. A new bucket that reached back and restated a finished experiment's counts would be a worse bug than the one it fixes — all of `selector_ambiguous: 243`, `render_target_missing: 68`, `wrong_format: 12`, `nothing_submitted: 6`, `judge_no_verdict: 4` are byte-identical.

Also gives each bucket an explicit 5-character column heading: `render_target_missing` and `render_target_partial` both truncated to `rende`, putting two identically-headed columns in the table.

### Effect on the R1 read
On the 180 tasks published so far, harness-caused goes from a reported **4 with 2 unexplained** to **6 with none**. Tests **42 → 48**.

### Source-hash freeze
Diff is confined to `batch-runner/scripts/judge_error_breakdown.py` and `batch-runner/tests/`, neither a hash input. `grader_source_hash` recomputed after the change: **`595c7254caf8fbd7`**, matching the in-flight shard stem.