### PR TITLE
feat(dashboard): promote the rebuilt-harness 220 regrade to OFFICIAL

### DIFF
--- a/scripts/__tests__/official-filter.test.mjs
+++ b/scripts/__tests__/official-filter.test.mjs
@@ -147,28 +147,61 @@ test('unknown coverage is never treated as partial', () => {
   assert.equal(isPartialCorpusGrade(undefined), false)
 })
 
-// ── Phase 4: curated baselines ──────────────────────────────────────────────
+// ── Phase 4/5: curated baselines ────────────────────────────────────────────
+// Phase 4 established the shape — one current result plus one A/B comparator.
+// Phase 5 recurated which two runs fill those slots after the harness rebuild.
 
-const SOL_220 =
+const SOL_220_R1 =
+  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_595c7254caf8fbd7__v2.2'
+const SOL_220_LEGACY =
   'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_1c967673eb8081a6__v2.2'
 const GPT54_220 = 'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools'
 const GPT54_MINI_220 =
   'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini'
 
-test('the sol 220 regrade is the current official result', () => {
-  assert.equal(isOfficialGradeId(SOL_220), true)
+test('the rebuilt-harness sol 220 regrade is the current official result', () => {
+  assert.equal(isOfficialGradeId(SOL_220_R1), true)
 })
 
 test('exactly one older run is retained as an A/B comparator', () => {
-  assert.equal(isOfficialGradeId(GPT54_220), true)
-  assert.equal(isSupersededGradeId(GPT54_220), false)
+  assert.equal(isOfficialGradeId(SOL_220_LEGACY), true)
+  assert.equal(isSupersededGradeId(SOL_220_LEGACY), false)
   // Two official ids total: the current result and its single comparator.
   assert.equal(OFFICIAL_GRADE_IDS.size, 2)
+})
+
+test('the retained comparator differs from the result in one variable only', () => {
+  // The point of keeping this particular predecessor: same judge, same rubric,
+  // same inference corpus, different `grader_source_hash`. If a future
+  // recuration picks a comparator that also swaps the judge, the gap stops
+  // being attributable to the harness and the pairing silently stops meaning
+  // what the dashboard says it means.
+  const strip = (id) => id.replace(/__src_[0-9a-f]+__/, '__src__')
+  assert.equal(strip(SOL_220_R1), strip(SOL_220_LEGACY))
+  assert.notEqual(SOL_220_R1, SOL_220_LEGACY)
 })
 
 test('the mini-judge run is retired, not deleted', () => {
   assert.equal(isSupersededGradeId(GPT54_MINI_220), true)
   assert.equal(isOfficialGradeId(GPT54_MINI_220), false)
+})
+
+test('the full-size gpt-5.4 run is retired once a same-judge predecessor exists', () => {
+  // It held the comparator slot only because nothing closer was available. A
+  // sol-vs-sol pair isolates the harness change; sol-vs-5.4 cannot.
+  assert.equal(isSupersededGradeId(GPT54_220), true)
+  assert.equal(isOfficialGradeId(GPT54_220), false)
+})
+
+test('promotion does not disturb the measured hide rules', () => {
+  // Both official ids carry the `__src_<hex>__v2.2` suffix, which is close
+  // enough to the legacy `__<7hex>__v<n>` shape to be worth pinning: if
+  // `isLegacyExp003` ever widened to match them, the official allowlist would
+  // be the only thing keeping the current result on screen.
+  for (const id of [SOL_220_R1, SOL_220_LEGACY]) {
+    assert.equal(/__[0-9a-f]{7}__v\d/i.test(id), false)
+    assert.equal(id.endsWith('_tight'), false)
+  }
 })
 
 test('no id can be both official and superseded', () => {

--- a/src/lib/officialExperimentScope.js
+++ b/src/lib/officialExperimentScope.js
@@ -49,23 +49,31 @@ export function isPartialCorpusGrade(grade) {
  * rule. Add an id here when a run is promoted.
  */
 export const OFFICIAL_GRADE_IDS = new Set([
-  // gpt-5.6-sol judge, 220 tasks — current primary result
+  // gpt-5.6-sol judge, 220 tasks, grader src_595c7254caf8fbd7 — current primary
+  // result. Same judge and same rubric as the run below; what changed is the
+  // harness that decides what the judge is shown, which took judge_error from
+  // 3.19% to 0.31% (311 harness-caused failures down to 8).
+  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_595c7254caf8fbd7__v2.2',
+  // gpt-5.6-sol judge, 220 tasks, grader src_1c967673eb8081a6 — retained A/B
+  // comparator for the run above
   'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_1c967673eb8081a6__v2.2',
-  // gpt-5.4 judge, 220 tasks — retained A/B comparator for the run above
-  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools',
 ])
 
 /**
- * Full-corpus runs retired in favour of a newer judge. Their numbers are
- * sound — this is not the partial-corpus rule — but a results page that keeps
- * every generation of judge becomes a changelog, and readers compare whatever
- * is on screen. The dashboard therefore shows the current result plus exactly
- * one older run as an A/B comparator, and retires the rest.
+ * Full-corpus runs retired in favour of a newer one. Their numbers are sound —
+ * this is not the partial-corpus rule — but a results page that keeps every
+ * generation becomes a changelog, and readers compare whatever is on screen.
+ * The dashboard therefore shows the current result plus exactly one older run
+ * as an A/B comparator, and retires the rest.
  *
- * `gpt-5.4-mini` is the one retired: against a `gpt-5.6-sol` judge it varies
- * in both judge size and judge version at once, so a gap measured across it
- * cannot be attributed to either. The full-size `gpt-5.4` run is the
- * like-for-like comparator and stays.
+ * Which older run earns that slot is decided by how many things it varies at
+ * once. The two `gpt-5.6-sol` runs share a judge, a rubric, and an inference
+ * corpus, and differ only in `grader_source_hash` — so the gap between them is
+ * attributable to the harness and to nothing else. Both `gpt-5.4` runs vary the
+ * judge as well, which makes them a worse comparator for the same question:
+ * `gpt-5.4-mini` varies judge size and version together, and full-size
+ * `gpt-5.4` varies judge version on top of the harness change. Neither can
+ * isolate anything the sol-vs-sol pair does not isolate better.
  *
  * Retirement is display-only. The grade JSON is untouched, the card is one
  * `?debug=1` away, and its own page still resolves by direct URL.
@@ -73,6 +81,9 @@ export const OFFICIAL_GRADE_IDS = new Set([
 export const SUPERSEDED_GRADE_IDS = new Set([
   // gpt-5.4-mini judge, 220 tasks — superseded; see above for why this one
   'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini',
+  // gpt-5.4 judge, 220 tasks — was the A/B comparator until a same-judge
+  // predecessor existed to take the slot
+  'exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools',
 ])
 
 /** Curated official baseline: badged, and exempt from every hide rule. */

--- a/src/lib/officialFilter.ts
+++ b/src/lib/officialFilter.ts
@@ -22,6 +22,13 @@
  * to OFFICIAL as the current result, and the older full-corpus runs are retired
  * down to a single A/B comparator — every rule up to here removes things that
  * are not results, this one decides which results still earn screen space.
+ *
+ * Phase 5 recurates that pair after the harness rebuild. The rebuilt run takes
+ * the primary slot and its own predecessor — same judge, same rubric, differing
+ * only in `grader_source_hash` — takes the comparator slot, so the two cards on
+ * screen differ in exactly one variable. The `gpt-5.4` run it displaces joins
+ * `gpt-5.4-mini` in retirement; it held the slot only while no same-judge
+ * predecessor existed.
  */
 import type { GradeResult } from '../hooks/useGrades'
 import type { ExperimentEntry } from '../types/report'


### PR DESCRIPTION
The nine-shard regrade published a complete 220-task `final` (`run_status: final`, 220/220 graded, 0 error tasks). It is now the result the benchmark page should be showing.

Paired against its own predecessor on all 220 shared tasks:

| | before | after |
|---|---|---|
| judge_error rate | 3.19% | **0.31%** |
| harness-caused | 311 | **8** |
| judge-side | 4 | 6 |
| model-caused | 18 | 18 |
| unclassified | — | 0 |

The unmoved model-caused column is the integrity check: the improvement came from fixing what the judge is shown, not from changing what the model scored. Aggregate score moves 54.98% → 54.82% pooled (57.49% → 57.3% by per-task average), and task coverage goes 215/220 → **220/220**.

## What changes

`OFFICIAL_GRADE_IDS` — the rebuilt run takes the primary slot; its predecessor takes the comparator slot.

`SUPERSEDED_GRADE_IDS` — the full-size `gpt-5.4` run is retired, joining `gpt-5.4-mini`.

The pair is deliberate. Both official runs use the `gpt-5.6-sol` judge, the same rubric, and the same inference corpus, and differ only in `grader_source_hash` — so the gap between the two cards on screen is attributable to the harness and to nothing else. The `gpt-5.4` run that held the comparator slot until now varies the judge as well and could never isolate that; it held the slot only while no same-judge predecessor existed.

Retirement is display-only: the grade JSON is untouched, the card is one `?debug=1` away, and its own page still resolves by direct URL. Set size stays at two, per the policy already written into the curated-baselines block — which also records that this is a hand-written publication decision, not something inferred from a pattern.

## Tests

`scripts/__tests__/official-filter.test.mjs`, 20 tests (was 16). Three are new and pin what a future recuration could quietly break:

- the comparator differs from the result in exactly one variable (strip the `__src_<hex>__` segment and the two ids are identical)
- the displaced `gpt-5.4` run is retired, not merely absent
- neither official id is matchable by `isLegacyExp003`, whose `__<7hex>__v<n>` pattern sits close to the `__src_<hex>__v2.2` naming both official ids use

Mutation-checked: restoring `gpt-5.4` as the comparator fails 3 of the 20.

## Verification

- `npm run test:aggregate:prepared` — 147 tests, 146 pass, 1 skipped, 0 fail
- `npx tsc --noEmit` — clean
- `npm run aggregate` — both official runs resolve; the promoted one reports 220/220 tasks

No `grader_source_hash` input is touched (`step8_grade.py`, `batch-runner/core/**.py`, `schemas/grade.schema.json`, `requirements.txt`, prompt templates) and neither is `grade-run.yml`. Nothing is in flight in any case — all nine shards merged.