### PR TITLE
fix(grading): text-judge an overall-style item with nothing renderable

### DIFF
--- a/batch-runner/core/grader_routing.py
+++ b/batch-runner/core/grader_routing.py
@@ -23,7 +23,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Iterable
 
-from core.media_types import GRADER_AUDIO_EXTENSIONS
+from core.media_types import (
+    GRADER_AUDIO_EXTENSIONS,
+    GRADER_VISUAL_RENDER_EXTENSIONS,
+)
 
 
 class Modality(str, Enum):
@@ -172,6 +175,44 @@ def resolve_runtime_routing(
         decision.modality is Modality.AUDIO
         and suffixes
         and suffixes.isdisjoint(GRADER_AUDIO_EXTENSIONS)
+    ):
+        return RoutingDecision(
+            modality=Modality.TEXT,
+            preferred_op="read_content",
+            matched_keywords=decision.matched_keywords,
+        )
+    # A narrower cousin of the audio rule above. Audio can demote wholesale
+    # because a criterion about a mix has no meaning at all against a
+    # spreadsheet. Visual cannot: the two kinds of visual criterion differ in
+    # whether text is an acceptable substitute.
+    #
+    # "Overall formatting and style of the deliverable" against a lone ``.txt``
+    # is answerable from the text -- headings, spacing, structure and line
+    # breaks *are* the formatting of a plain-text file. Today it routes VISUAL,
+    # finds no render target, and returns
+    # ``required_visual_render_target_unavailable``: a guaranteed
+    # ``judge_error`` on work the judge could have read. Three of the eight
+    # remaining harness errors on the sol-220 rerun are this, and under
+    # ``split_children`` one such child collapses every sibling with it
+    # (``grader.py`` fails the whole item on the first child error).
+    #
+    # An explicitly visual criterion must NOT demote. "Document color and page
+    # layout are visually polished" against a ``.csv`` is unanswerable from the
+    # characters in the file, and a text verdict there would be invented rather
+    # than merely absent. Failing closed is the correct outcome and
+    # ``test_explicit_visual_item_fails_closed_without_render_target`` pins it.
+    # ``is_overall_style_criterion`` is the same predicate the ``.docx`` rule
+    # above already uses to draw this line.
+    #
+    # This cannot change an item that renders today: it fires only when *no*
+    # selected file is renderable, which is exactly the set that currently
+    # errors out. Nor can it answer from a partial view the way raising the
+    # file cap would -- the text is handed over whole.
+    if (
+        decision.modality is Modality.VISUAL
+        and is_overall_style_criterion(criterion_text)
+        and suffixes
+        and suffixes.isdisjoint(GRADER_VISUAL_RENDER_EXTENSIONS)
     ):
         return RoutingDecision(
             modality=Modality.TEXT,

--- a/batch-runner/core/media_types.py
+++ b/batch-runner/core/media_types.py
@@ -11,3 +11,29 @@ GRADER_AUDIO_EXTENSIONS = frozenset({
     ".m4a",
     ".aac",
 })
+
+#: Extensions the visual prepass can actually turn into an image for the
+#: judge to look at. Kept here rather than in ``tool_calling_judge`` so the
+#: pure-functional routing module can consult it without importing the
+#: grading stack.
+#:
+#: ``tool_calling_judge._VISUAL_RENDER_SCOPES`` remains the runtime authority
+#: -- it carries the per-suffix render scope, which is not derivable from a
+#: bare set -- and its keys are held equal to this set by
+#: ``test_visual_render_extensions_match_the_renderer``. The duplication is
+#: deliberate and guarded: the failure it prevents is a suffix being added to
+#: one and not the other, which would route a renderable file to text (or
+#: promise a render that cannot happen) with no error anywhere.
+GRADER_VISUAL_RENDER_EXTENSIONS = frozenset({
+    ".pdf",
+    ".xlsx",
+    ".xlsm",
+    ".pptx",
+    ".docx",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".bmp",
+    ".webp",
+})

--- a/batch-runner/tests/test_grader_preflight.py
+++ b/batch-runner/tests/test_grader_preflight.py
@@ -354,11 +354,22 @@ def test_plan_split_children_enforces_parent_visual_file_cap(
 def test_plan_split_children_fails_when_visual_child_has_no_render_target(
     monkeypatch, tmp_path: Path
 ):
-    paths = ["Notes.txt", "Chart.pdf"]
+    """One unrenderable visual child still fails the whole split item.
+
+    The child used to be spelled ``Notes.txt``. Plain text under a generic
+    style criterion now routes to text rather than dying on a missing render
+    target, so the unrenderable case needs a target that still routes visual
+    and still has nothing to render: an extensionless file, which carries no
+    evidence of its kind either way and so is never demoted (same reasoning as
+    ``test_audio_keyword_with_extensionless_target_stays_audio``). The
+    property under test -- one child's missing render target blocks every
+    sibling -- is unchanged.
+    """
+    paths = ["Notes", "Chart.pdf"]
     for path in paths:
         (tmp_path / path).write_bytes(path.encode("utf-8"))
     targets = [
-        SelectionTarget("notes", ["Notes.txt"], "txt"),
+        SelectionTarget("notes", ["Notes"], ""),
         SelectionTarget("chart", ["Chart.pdf"], "pdf"),
     ]
     selection = DeliverableSelection(
@@ -388,7 +399,7 @@ def test_plan_split_children_fails_when_visual_child_has_no_render_target(
     assert plan["planned_main_judgments"] == 0
     assert plan["planned_render_calls"] == 0
     assert plan["planned_perception_calls"] == 0
-    assert plan["unsupported_visual_paths"] == ["Notes.txt"]
+    assert plan["unsupported_visual_paths"] == ["Notes"]
     assert plan["items"][0]["outcome"] == "preflight_error"
     assert plan["items"][0]["preflight_error"] == (
         "notes: required_visual_render_target_unavailable"
@@ -402,14 +413,73 @@ def test_plan_split_children_fails_when_visual_child_has_no_render_target(
     ]
 
 
+def test_plan_split_children_text_child_no_longer_blocks_its_siblings(
+    monkeypatch, tmp_path: Path
+):
+    """The fix for the case above, at the level it actually cost us.
+
+    Task bf68f2ad on the sol-220 rerun is exactly this shape: an ``.xlsx``
+    and a ``.txt`` under one "Overall formatting and style" item, scope
+    ``split_children``, aggregation ``blocking_min_else_mean``. The ``.txt``
+    child had no render target, and because a split item fails whole on its
+    first child error the ``.xlsx`` sibling was dragged down with it -- the
+    published item carries ``visual_provenance: []`` and scored nothing.
+
+    The text child now routes to text, contributes no visual preflight error,
+    and the spreadsheet is rendered and judged on its own merits.
+    """
+    paths = ["MIG_Welding_Catch_Up_Summary.txt", "MIG_Welding_Catch_Up_Plan.xlsx"]
+    for path in paths:
+        (tmp_path / path).write_bytes(path.encode("utf-8"))
+    targets = [
+        SelectionTarget("summary", [paths[0]], "txt"),
+        SelectionTarget("plan", [paths[1]], "xlsx"),
+    ]
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="task-1",
+        task_class="separate_equivalent",
+        primary_targets=targets,
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader_preflight.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="split_children",
+            target_ids=["summary", "plan"],
+            selected_paths=paths,
+            aggregation_rule="blocking_min_else_mean",
+        ),
+    )
+
+    plan = plan_task_runtime(
+        {"judge": {"perception": {"visual": {"call_cap_per_task": 4}}}},
+        _task([RubricItem(
+            "style", "Overall formatting and style of the deliverable", 5, None
+        )]),
+        tmp_path,
+    )
+
+    assert plan["errors"] == []
+    assert plan["items"][0]["outcome"] != "preflight_error"
+    assert plan["unsupported_visual_paths"] == []
+    # The spreadsheet still renders; only the text child was diverted.
+    assert plan["planned_render_calls"] == 1
+
+
 @pytest.mark.parametrize(
     ("second_name", "visual_cap", "expected_error"),
     [
-        (
-            "Notes.txt",
-            5,
-            "style: notes: required_visual_render_target_unavailable",
-        ),
+        # A ``Notes.txt`` case used to sit here, erroring with
+        # ``required_visual_render_target_unavailable``. It is gone rather
+        # than re-spelled because the state it described is now unreachable:
+        # under a generic style criterion a file routes visual only if its
+        # suffix is renderable, so "routes visual, cannot render" no longer
+        # exists for this kind of criterion. Removing the fix would make the
+        # case reappear -- which is what
+        # ``test_plan_split_children_text_child_no_longer_blocks_its_siblings``
+        # is for. The surviving case keeps the mixed routing (docx →
+        # formatting, pdf → visual) and the blocking property intact.
         (
             "Chart.pdf",
             0,

--- a/batch-runner/tests/test_grader_selector_integration.py
+++ b/batch-runner/tests/test_grader_selector_integration.py
@@ -894,6 +894,25 @@ def test_explicit_visual_docx_renders_instead_of_failing_closed(
 def test_split_visual_child_validation_precedes_task_budget_and_render(
     monkeypatch, tmp_path
 ):
+    """Child validation runs before the task budget check and before render.
+
+    The child used to be spelled ``Notes.txt`` and reached this path through
+    the real selector. It cannot any more: under a generic style criterion a
+    child routes visual only if its suffix is renderable, so "routes visual,
+    nothing to render" now needs an extensionless child -- and
+    ``select_deliverables`` drops extensionless files rather than making them
+    primary targets. The state is therefore constructed here instead of
+    selected, the same way ``test_grader_preflight`` constructs it for the
+    planner. The ordering under test is untouched: with the vision cap at 0
+    the *task budget* error is also armed, and the child error must still be
+    the one that surfaces, before any render call.
+    """
+    from core.deliverable_selector import (
+        CriterionTargetPlan,
+        DeliverableSelection,
+        SelectionTarget,
+    )
+    from core.grader import Grader
     from core.rubric_loader import RubricItem, TaskRubric
     import core.tool_calling_judge as tool_judge_mod
 
@@ -908,8 +927,27 @@ def test_split_visual_child_validation_precedes_task_budget_and_render(
     )
     deliverable_dir = tmp_path / "task"
     deliverable_dir.mkdir()
-    (deliverable_dir / "Notes.txt").write_bytes(b"text")
+    (deliverable_dir / "Notes").write_bytes(b"text")
     (deliverable_dir / "Chart.pdf").write_bytes(b"pdf")
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="t-split-unsupported",
+        task_class="separate_equivalent",
+        primary_targets=[
+            SelectionTarget("notes", ["Notes"], ""),
+            SelectionTarget("chart", ["Chart.pdf"], "pdf"),
+        ],
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="split_children",
+            target_ids=["notes", "chart"],
+            selected_paths=["Notes", "Chart.pdf"],
+            aggregation_rule="blocking_min_else_mean",
+        ),
+    )
     task = TaskRubric(
         task_id="t-split-unsupported",
         sector="Information",
@@ -945,14 +983,109 @@ def test_split_visual_child_validation_precedes_task_budget_and_render(
     assert responses.calls == []
 
 
+def test_split_text_child_no_longer_blocks_its_visual_sibling(
+    monkeypatch, tmp_path
+):
+    """Task bf68f2ad on the sol-220 rerun, end to end.
+
+    An ``.xlsx`` and a ``.txt`` under one "Overall formatting and style" item,
+    scope ``split_children``, aggregation ``blocking_min_else_mean``. The text
+    child had no visual render target; because a split item fails whole on its
+    first child error, the spreadsheet was dragged down with it and the
+    published item carries ``visual_provenance: []`` with nothing scored.
+
+    The text child now routes to text and the spreadsheet renders and is
+    judged. What makes this safe rather than lenient is that the judge sees
+    every child in full -- the text as text, the workbook as an image -- so
+    nothing is answered from a partial view.
+    """
+    from core.rubric_loader import RubricItem, TaskRubric
+    import core.tool_calling_judge as tool_judge_mod
+
+    responses = ScriptedResponses([
+        _response(output=[_final(_payload("pass", 1.0, "plain text is tidy"))]),
+        _response(output=[_final(_payload("pass", 1.0, "workbook is legible"))]),
+    ])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision()
+    grader._tool_judge.vision_perception = vision
+    rendered = []
+
+    def fake_render(op, path, **kwargs):
+        rendered.append((path, kwargs.get("scope")))
+        return {
+            "ok": True,
+            "data": {
+                "kind": "image_png_base64",
+                "base64": "aW1hZ2U=",
+                "byte_size": 5,
+                "scope": {"workbook_page": 1},
+                "source_kind": "xlsx",
+                "converted_page_count": 1,
+                "renderer": {
+                    "converter": "libreoffice",
+                    "rasterizer": "pymupdf",
+                    "libreoffice_binary": "soffice",
+                    "libreoffice_version": "LibreOffice 24.2.7.2",
+                    "pymupdf_version": "1.26.3",
+                    "dpi": 150,
+                },
+            },
+        }
+
+    monkeypatch.setattr(tool_judge_mod, "read_deliverable", fake_render)
+    deliverable_dir = tmp_path / "task"
+    deliverable_dir.mkdir()
+    (deliverable_dir / "MIG_Welding_Catch_Up_Plan.xlsx").write_bytes(b"xlsx")
+    (deliverable_dir / "MIG_Welding_Catch_Up_Summary.txt").write_bytes(b"summary")
+    task = TaskRubric(
+        task_id="t-split-text-sibling",
+        sector="Manufacturing",
+        occupation="Welder",
+        prompt=(
+            "Create two separate deliverables: a spreadsheet catch-up plan "
+            "and a text file summary."
+        ),
+        rubric_items=[RubricItem(
+            "style", "Overall formatting and style of the deliverable", 5, None
+        )],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+    grade = grader.grade_task(task, str(deliverable_dir))
+    item = grade.items[0]
+
+    assert item.target_scope == "split_children"
+    assert item.verdict != "judge_error"
+    assert item.score_excluded is False
+    assert "required_visual_render_target_unavailable" not in (item.evidence or "")
+    # The spreadsheet still reached the judge as an image.
+    assert rendered == [("MIG_Welding_Catch_Up_Plan.xlsx", {"workbook_page": 1})]
+    assert [entry["path"] for entry in item.visual_provenance] == [
+        "MIG_Welding_Catch_Up_Plan.xlsx"
+    ]
+    # ...and the text child was judged on the text channel, not skipped.
+    assert {child["routing_modality"] for child in item.child_grades} == {
+        "text",
+        "visual",
+    }
+    assert not any(
+        child["verdict"] == "judge_error" for child in item.child_grades
+    )
+
+
 @pytest.mark.parametrize(
     ("second_name", "vision_cap", "expected_error"),
     [
-        (
-            "Notes.txt",
-            5,
-            "notes: required_visual_render_target_unavailable",
-        ),
+        # A ``Notes.txt`` case used to sit here. It is removed rather than
+        # re-spelled: this test needs the criterion to stay generic so the
+        # docx child routes formatting and the item comes out mixed, and under
+        # a generic criterion plain text no longer routes visual at all. The
+        # blocking property is still covered by the budget case below, and the
+        # behaviour that replaced the removed one is asserted in
+        # ``test_split_text_child_no_longer_blocks_its_visual_sibling``.
         (
             "Chart.pdf",
             0,

--- a/batch-runner/tests/test_perception_routing.py
+++ b/batch-runner/tests/test_perception_routing.py
@@ -18,6 +18,7 @@ from core.grader_routing import (
     is_overall_style_criterion,
     resolve_runtime_routing,
 )
+from core.media_types import GRADER_VISUAL_RENDER_EXTENSIONS
 
 
 # Twelve representative criterion phrasings — covers all four buckets
@@ -171,6 +172,117 @@ def test_runtime_audio_resolution_is_target_specific():
 
     assert audio_child.modality is Modality.AUDIO
     assert text_child.modality is Modality.TEXT
+
+
+# ── visual with nothing renderable ──────────────────────────────────────────
+# A criterion that asks for a channel none of the selected files can supply
+# has to go somewhere. Where depends on whether text is an honest substitute,
+# which is why this is narrower than the audio rule above.
+
+
+def test_overall_style_criterion_with_only_plain_text_downgrades_to_text():
+    # The whole of task 2c249e0f on the sol-220 rerun: one ``data_flow.txt``,
+    # graded on "Overall formatting and style". There is no visual form of
+    # this file anywhere, so visual routing was unanswerable by construction —
+    # while the text in front of the judge shows its formatting directly.
+    criterion = "Overall formatting and style of the deliverable"
+
+    assert classify_criterion(criterion).modality is Modality.VISUAL
+    decision = resolve_runtime_routing(criterion, ["data_flow.txt"])
+
+    assert decision.modality is Modality.TEXT
+    assert decision.preferred_op == "read_content"
+
+
+def test_explicitly_visual_criterion_with_nothing_renderable_stays_visual():
+    # The line this rule must not cross, and the reason it is not a
+    # straight copy of the audio fallback. Colour and page layout cannot be
+    # read out of the characters in a file: demoting here would trade a
+    # missing verdict for an invented one, which is strictly worse.
+    # ``test_explicit_visual_item_fails_closed_without_render_target`` in
+    # tests/test_grader_selector_integration.py pins the same property
+    # end to end.
+    decision = resolve_runtime_routing(
+        "Document color and page layout are visually polished", ["Summary.csv"]
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.preferred_op == "render_to_image"
+
+
+def test_one_renderable_file_keeps_the_item_visual():
+    # The guard that makes this change safe. A mixed bundle still routes
+    # visual, so no item that renders today is diverted to text.
+    decision = resolve_runtime_routing(
+        "Overall formatting and style of the deliverable",
+        ["summary.txt", "plan.xlsx"],
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.preferred_op == "render_to_image"
+
+
+def test_split_children_route_the_text_child_away_from_visual():
+    # Task bf68f2ad, at the granularity ``grader.py`` actually routes at.
+    # Before this rule the ``.txt`` child errored, and because a split_children
+    # item fails whole on its first child error, the ``.xlsx`` sibling was
+    # dragged down with it — the published item has visual_provenance == [].
+    criterion = "Overall formatting and style of the deliverable"
+
+    xlsx_child = resolve_runtime_routing(criterion, ["MIG_Welding_Catch_Up_Plan.xlsx"])
+    txt_child = resolve_runtime_routing(criterion, ["MIG_Welding_Catch_Up_Summary.txt"])
+
+    assert xlsx_child.modality is Modality.VISUAL
+    assert txt_child.modality is Modality.TEXT
+
+
+def test_overall_style_with_extensionless_target_stays_visual():
+    # Mirrors ``test_audio_keyword_with_extensionless_target_stays_audio``.
+    # No suffix means no evidence either way, and demoting on absence of
+    # evidence would silently strip vision from anything oddly named.
+    decision = resolve_runtime_routing(
+        "Overall formatting and style of the deliverable", ["deliverable"]
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.preferred_op == "render_to_image"
+
+
+@pytest.mark.parametrize("suffix", sorted(GRADER_VISUAL_RENDER_EXTENSIONS))
+def test_every_renderable_suffix_still_routes_visual(suffix: str):
+    decision = resolve_runtime_routing(
+        "Chart is clearly labeled and easy to read", [f"deliverable{suffix}"]
+    )
+
+    assert decision.modality is Modality.VISUAL
+
+
+def test_visual_render_extensions_match_the_renderer():
+    """Hold the routing set equal to what the prepass can actually render.
+
+    ``GRADER_VISUAL_RENDER_EXTENSIONS`` is a copy of the keys of
+    ``tool_calling_judge._VISUAL_RENDER_SCOPES``; the original cannot be
+    imported into ``grader_routing`` without pulling the grading stack into a
+    module that is deliberately pure. A suffix added to one and not the other
+    fails in silence -- either routing sends a renderable file to text, or it
+    promises a render the prepass will refuse -- so the equality is asserted
+    rather than trusted.
+    """
+    from core.tool_calling_judge import _VISUAL_RENDER_SCOPES
+
+    assert set(_VISUAL_RENDER_SCOPES) == set(GRADER_VISUAL_RENDER_EXTENSIONS)
+
+
+def test_downgraded_visual_keeps_its_matched_keywords():
+    # The demotion changes where the judge looks, not what the criterion was
+    # found to be asking for. Losing the keywords would make a downgraded item
+    # indistinguishable from one that never matched anything.
+    criterion = "Overall formatting and style of the deliverable"
+    decision = resolve_runtime_routing(criterion, ["notes.txt"])
+
+    assert decision.modality is Modality.TEXT
+    assert decision.matched_keywords == classify_criterion(criterion).matched_keywords
+    assert decision.matched_keywords != ()
 
 
 def test_routing_decision_to_prompt_hint_keys():


### PR DESCRIPTION
## What

Three of the eight harness `judge_error`s left on the sol-220 rerun (R1) are the same shape: an **"Overall formatting and style of the deliverable"** criterion whose selected files are all plain text. The criterion classifies `VISUAL`, the visual prepass finds no render target, and the item returns `required_visual_render_target_unavailable` — a guaranteed `judge_error` on work the judge could simply have read.

Under `split_children` it is worse. `grader.py` fails the whole item on the first child error, so one `.txt` child drags its `.xlsx` sibling down with it and the published item scores nothing with `visual_provenance: []`.

| task | shape | today |
|---|---|---|
| `2c249e0f` | one `data_flow.txt`, `file_target` | `required_visual_render_target_unavailable` |
| `bf68f2ad` | `.xlsx` + `.txt`, `split_children` | text child errors, spreadsheet never rendered |
| `58ac1cc5` | `.txt` + `.pdf` + `.docx`, `split_children` | same, all four files unscored |

## How

`resolve_runtime_routing` demotes such an item to `TEXT`, mirroring the audio rule directly above it. The demotion is deliberately **narrower** than the audio one, because the two kinds of visual criterion differ in whether text is an honest substitute:

- A **generic style** criterion is answerable from the text. Headings, spacing, structure and line breaks *are* the formatting of a plain-text file.
- An **explicitly visual** criterion is not. *"Document color and page layout are visually polished"* cannot be read out of the characters in a `.csv`, and a text verdict there would be invented rather than merely absent. That case still fails closed, pinned by `test_explicit_visual_item_fails_closed_without_render_target`.

The gate is `is_overall_style_criterion`, the same predicate the `.docx → FORMATTING` rule above already uses to draw that line.

## Why this cannot touch an existing item

The rule fires only when **no** selected file is renderable — exactly the set that currently returns `judge_error` and scores nothing. Anything that renders today still renders. An extensionless target carries no evidence either way and stays `VISUAL`, as it already does for audio. And unlike raising the file cap, nothing is answered from a partial view: the text is handed to the judge whole.

Verified against the three real tasks:

```
2c249e0f (file_target, txt only)   -> text       read_content
bf68f2ad child .txt                -> text       read_content
bf68f2ad child .xlsx               -> visual     render_to_image
58ac1cc5 child .txt                -> text       read_content
58ac1cc5 child .pdf                -> visual     render_to_image
58ac1cc5 child .docx               -> formatting inspect_formatting
```

## Drift guard

`GRADER_VISUAL_RENDER_EXTENSIONS` is added to `core/media_types` so the pure-functional routing module can consult the renderable set without importing the grading stack. `tool_calling_judge._VISUAL_RENDER_SCOPES` stays the runtime authority — it carries the per-suffix render scope, which is not derivable from a bare set — and the two are held equal by `test_visual_render_extensions_match_the_renderer`. A suffix added to one and not the other would otherwise misroute in silence.

## Re-spelled tests

Two existing tests described states this makes unreachable. They were re-spelled rather than deleted:

- `test_plan_split_children_fails_when_visual_child_has_no_render_target` and `test_split_visual_child_validation_precedes_task_budget_and_render` now use an **extensionless** child, which still routes visual with nothing to render. `select_deliverables` drops extensionless files, so the latter constructs its selection instead of selecting it. The ordering property under test — child validation before the task budget check, before render — is unchanged.
- The `Notes.txt` parameter of `test_plan_mixed_split_preflight_error_blocks_all_main_calls` is removed. "Routes visual, cannot render" no longer exists for a generic style criterion; removing this fix would make the case reappear, which is what `test_plan_split_children_text_child_no_longer_blocks_its_siblings` is for.

## Scope

Does **not** change the visual file cap (still fail-closed at 3), which accounts for three more of the eight, or the `invalid_vision_envelope` on `a73fbc98`, which accounts for the remaining two. Those are tracked separately; the cap is a cost-vs-correctness call that needs a decision, not a patch.

## Verification

Full local suite: `3433 passed, 6 skipped, 45 deselected` — no failures.

This touches `core/**.py`, a `grader_source_hash` input. Safe to merge: R1 is complete and published, and no grading run is in flight.