### PR TITLE
ci(grading): build a purpose-built ubuntu:24.04 grading image

### DIFF
--- a/.github/workflows/build-grading-image.yml
+++ b/.github/workflows/build-grading-image.yml
@@ -1,0 +1,169 @@
+# Build & publish the GDPVal grading image to GitHub Container Registry.
+#
+# WHY THIS IS NOT A THIRD TARGET IN build-sandbox-image.yml
+#   That workflow's build-sandbox-image job fires on *any* workflow_dispatch
+#   against main, so adding a publish_grading input there would rebuild and
+#   republish the 8.46 GB sandbox image every time someone wanted a grading
+#   image. The two also have different trust stories: the sandbox executes
+#   LLM-generated code and deliberately carries no credentials tooling, while
+#   this image carries the Azure CLI precisely so the grade job can log in.
+#   Keeping them apart keeps that distinction legible.
+#
+# WHAT THE VERIFICATION IS
+#   sandbox/grading.Dockerfile asserts the renderer version, font resolution,
+#   git, and az in its own RUN steps, so a build that succeeds has already
+#   proven the acceptance criteria. The steps below only surface the evidence.
+name: Build Grading Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Push to GHCR (false builds and verifies without pushing)
+        required: true
+        default: false
+        type: boolean
+  pull_request:
+    paths:
+      - ".github/workflows/build-grading-image.yml"
+      - "batch-runner/sandbox/grading.Dockerfile"
+      - "batch-runner/tests/test_grading_image.py"
+
+concurrency:
+  group: build-grading-image-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Build without pushing. This is the acceptance run: if the renderer moved,
+  # the Dockerfile's assertion fails here, for free, on a pull request.
+  verify-grading-image:
+    if: >-
+      ${{
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish != true)
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
+      - name: Build grading image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: batch-runner/sandbox
+          file: batch-runner/sandbox/grading.Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: gdpval-grading:verify-${{ github.run_id }}
+
+      - name: Collect renderer evidence
+        env:
+          IMAGE: gdpval-grading:verify-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/grading-image"
+          docker run --rm --entrypoint cat "$IMAGE" \
+            /opt/gdpval/renderer-version.txt \
+            | tee "$RUNNER_TEMP/grading-image/renderer-version.txt"
+          docker run --rm --entrypoint cat "$IMAGE" \
+            /opt/gdpval/grading-packages.txt \
+            > "$RUNNER_TEMP/grading-image/grading-packages.txt"
+          {
+            echo "### Grading image"
+            echo '```'
+            cat "$RUNNER_TEMP/grading-image/renderer-version.txt"
+            echo '```'
+            echo "- packages installed: $(wc -l < "$RUNNER_TEMP/grading-image/grading-packages.txt")"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload grading image evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: grading-image-evidence-${{ github.run_id }}
+          path: ${{ runner.temp }}/grading-image
+          if-no-files-found: error
+          retention-days: 14
+
+  # Publish. The digest printed to the step summary is what grade-run.yml
+  # pins; a tag would let the renderer move under a job that never changed.
+  publish-grading-image:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' &&
+        inputs.publish == true &&
+        github.ref == 'refs/heads/main' &&
+        github.ref_protected == true
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Verify protected main checkout
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_REF_PROTECTED" = "true"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push grading image
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: batch-runner/sandbox
+          file: batch-runner/sandbox/grading.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/hyeonsangjeon/gdpval-grading:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-grading:buildcache
+          cache-to: type=registry,ref=ghcr.io/hyeonsangjeon/gdpval-grading:buildcache,mode=max
+
+      - name: Verify the published digest
+        env:
+          IMAGE: ghcr.io/hyeonsangjeon/gdpval-grading@${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker pull "$IMAGE"
+          ACTUAL_REVISION=$(docker image inspect \
+            --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$IMAGE")
+          test "$ACTUAL_REVISION" = "$GITHUB_SHA"
+          RENDERER=$(docker run --rm --entrypoint cat "$IMAGE" /opt/gdpval/renderer-version.txt)
+          {
+            echo "### Grading image published"
+            echo "- Image: \`$IMAGE\`"
+            echo "- Renderer: \`$RENDERER\`"
+            echo ""
+            echo "Pin this digest in \`grade-run.yml\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/batch-runner/sandbox/grading.Dockerfile
+++ b/batch-runner/sandbox/grading.Dockerfile
@@ -1,0 +1,121 @@
+# GDPVal grading image — the judge's eyes, frozen into a layer.
+#
+# WHY THIS EXISTS
+#   On formatting criteria the renderer is not a detail of how a grade is
+#   produced; it *is* the evidence. grade-run.yml asks apt for
+#   libreoffice-core and friends with no version, so whichever build the
+#   mirror serves that morning becomes what the judge sees, and two runs a
+#   generation apart are not comparable however identical their model,
+#   prompt, and grader_source_hash.
+#
+#   That install is also a live outage surface. On 2026-08-19 the Ubuntu
+#   mirror stalled mid-transfer for ~25 minutes; apt imposes no wall-clock
+#   ceiling on itself, five grade jobs sat in that step for 5h18m, and 63 of
+#   the 220 tasks died with them.
+#
+#   scripts/preflight_grading_renderer.py closed the comparability half by
+#   asserting the installed build before Azure login, so drift costs a free
+#   step instead of a paid corpus run. This image closes the other half: the
+#   renderer stops being installed at run time at all.
+#
+# WHY ubuntu:24.04 AND NOT THE EXISTING SANDBOX IMAGE
+#   ghcr.io/hyeonsangjeon/gdpval-sandbox ships LibreOffice 7.4.7.2 (it is
+#   built FROM python:3.11-slim-bookworm). Every published grade file records
+#   24.2.7.2. Reusing it would move the very scores this exists to stabilise,
+#   and it carries neither git nor az, both of which the grade job needs.
+#
+# BUILD (from batch-runner/)
+#   docker build -f sandbox/grading.Dockerfile -t gdpval-grading:dev sandbox
+#
+#   The RUN steps below are the acceptance test: a build that succeeds has
+#   proven the renderer version, the font resolution, git, and az. There is
+#   nothing to assert afterwards.
+
+# Digest-pinned so a rebuild reproduces this renderer rather than today's.
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+
+LABEL org.opencontainers.image.title="gdpval-grading" \
+      org.opencontainers.image.description="Frozen LibreOffice renderer and Actions runtime for GDPVal grading" \
+      org.opencontainers.image.source="https://github.com/hyeonsangjeon/gdpval-realworks"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# ── The renderer, and exactly the packages grade-run.yml installs ───────────
+# tests/test_grading_image.py holds this list against that step, so the image
+# cannot silently drop a package the runner has.
+RUN apt-get update -qq \
+ && apt-get install -y --no-install-recommends \
+      libreoffice-core \
+      libreoffice-calc \
+      libreoffice-impress \
+      libreoffice-writer \
+      fonts-dejavu-core \
+      fonts-liberation2 \
+      fontconfig \
+ && rm -rf /var/lib/apt/lists/*
+
+# ── Actions runtime ────────────────────────────────────────────────────────
+# Without git, actions/checkout silently falls back to a REST tarball with no
+# .git, and the grade job's own verification (`git rev-parse`, upstream check,
+# extraheader check) and the shard commit/push all fail.
+RUN apt-get update -qq \
+ && apt-get install -y --no-install-recommends \
+      git \
+      curl \
+      ca-certificates \
+      gnupg \
+ && rm -rf /var/lib/apt/lists/*
+
+# ── Azure CLI ──────────────────────────────────────────────────────────────
+# azure/login shells out to `az`, so OIDC login needs it present.
+#
+# Installed from packages.microsoft.com rather than the aka.ms install script,
+# which is a pipe from a redirect into a root shell. The key is verified by
+# fingerprint before it is trusted, and the source line is signed-by that one
+# keyring, so this repository cannot sign anything outside azure-cli.
+ARG MICROSOFT_GPG_FINGERPRINT="BC528686B50D79E339D3721CEB3E94ADBE1229CF"
+RUN set -eux; \
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc -o /tmp/microsoft.asc; \
+    actual="$(gpg --show-keys --with-colons --with-fingerprint /tmp/microsoft.asc \
+              | awk -F: '/^fpr:/ { print $10; exit }')"; \
+    if [ "$actual" != "$MICROSOFT_GPG_FINGERPRINT" ]; then \
+      echo "microsoft signing key fingerprint mismatch"; \
+      echo "  expected: $MICROSOFT_GPG_FINGERPRINT"; \
+      echo "  actual:   $actual"; \
+      exit 1; \
+    fi; \
+    gpg --dearmor < /tmp/microsoft.asc > /usr/share/keyrings/microsoft.gpg; \
+    rm -f /tmp/microsoft.asc; \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ noble main" \
+      > /etc/apt/sources.list.d/azure-cli.list; \
+    apt-get update -qq; \
+    apt-get install -y --no-install-recommends azure-cli; \
+    rm -rf /var/lib/apt/lists/*
+
+# ── Acceptance, enforced at build time ─────────────────────────────────────
+# The version string is the whole point of the image, so a mismatch has to
+# fail the build rather than be discovered by a grade run. It is deliberately
+# the full line rather than a 24.2.7 prefix: the distribution build suffix
+# moves only when the binary does, and the binary is the thing under test.
+ARG EXPECTED_LIBREOFFICE_VERSION="LibreOffice 24.2.7.2 420(Build:2)"
+RUN set -eux; \
+    mkdir -p /opt/gdpval; \
+    actual="$(soffice --headless --version)"; \
+    if [ "$actual" != "$EXPECTED_LIBREOFFICE_VERSION" ]; then \
+      echo "renderer version mismatch"; \
+      echo "  expected: $EXPECTED_LIBREOFFICE_VERSION"; \
+      echo "  actual:   $actual"; \
+      exit 1; \
+    fi; \
+    printf '%s\n' "$actual" > /opt/gdpval/renderer-version.txt; \
+    fc-match --format '%{family}\n' 'Liberation Sans' \
+      | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+      | grep -qx 'Liberation Sans'; \
+    git --version; \
+    az version --output none; \
+    dpkg-query -W -f='${Package}=${Version}\n' | sort > /opt/gdpval/grading-packages.txt
+
+WORKDIR /work

--- a/batch-runner/tests/test_grading_image.py
+++ b/batch-runner/tests/test_grading_image.py
@@ -1,0 +1,202 @@
+"""Static contract for the purpose-built grading image and its build workflow.
+
+The image exists to stop the renderer moving under the judge, so the things
+worth testing without Docker are the ones that would let it move anyway: a
+version restated instead of derived, a package the runner installs and the
+image does not, a floating base, a floating published tag, or a package
+source trusted without checking who signed it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from scripts import preflight_grading_renderer as preflight
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE_PATH = REPO_ROOT / "batch-runner/sandbox/grading.Dockerfile"
+BUILD_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/build-grading-image.yml"
+GRADE_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/grade-run.yml"
+
+RENDERER_INSTALL_STEP = "Install grading render dependencies"
+PINNED_ACTION = re.compile(r"^[\w.-]+/[\w./-]+@[0-9a-f]{40}$")
+
+
+def _dockerfile() -> str:
+    return DOCKERFILE_PATH.read_text(encoding="utf-8")
+
+
+def _dockerfile_instructions() -> str:
+    """The Dockerfile with comments dropped — what actually runs."""
+    return "\n".join(
+        line
+        for line in _dockerfile().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+def _workflow(path: Path) -> dict:
+    parsed = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def _apt_packages(shell_text: str) -> set[str]:
+    """Collect package names from every ``apt-get install`` in a snippet."""
+    joined = " ".join(
+        line.strip().rstrip("\\").strip() for line in shell_text.splitlines()
+    )
+    packages: set[str] = set()
+    for segment in re.split(r"(?:&&|\|\||;)", joined):
+        tokens = segment.split()
+        if "install" not in tokens:
+            continue
+        if not any(token.endswith("apt-get") for token in tokens):
+            continue
+        for token in tokens[tokens.index("install") + 1:]:
+            if token.startswith("-"):
+                continue
+            if re.fullmatch(r"[a-z0-9][a-z0-9+.-]*", token):
+                packages.add(token)
+    return packages
+
+
+def _renderer_install_step() -> str:
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+    for step in grade["jobs"]["grade"]["steps"]:
+        if step.get("name") == RENDERER_INSTALL_STEP:
+            return step["run"]
+    raise AssertionError(f"{RENDERER_INSTALL_STEP!r} step not found in grade-run.yml")
+
+
+def test_expected_renderer_version_is_derived_from_the_preflight_pin():
+    # One source of truth. A second copy is how a renderer upgrade lands in
+    # the image while the preflight still asserts the old build, which is a
+    # failure that only shows up after a paid run has already been graded.
+    match = re.search(
+        r'^ARG EXPECTED_LIBREOFFICE_VERSION="(?P<value>[^"]+)"$',
+        _dockerfile(),
+        re.MULTILINE,
+    )
+    assert match is not None
+    assert match.group("value") == preflight.EXPECTED_LIBREOFFICE_VERSION
+
+
+def test_image_carries_every_package_the_runner_installs():
+    image_packages = _apt_packages(_dockerfile_instructions())
+    runner_packages = _apt_packages(_renderer_install_step())
+
+    assert runner_packages, "renderer install step parsed to no packages"
+    # Guards the parser as much as the image: if the extraction ever degrades
+    # to a handful of tokens, the superset check below would pass vacuously.
+    assert {"libreoffice-core", "fontconfig"} <= runner_packages
+    assert runner_packages <= image_packages, sorted(runner_packages - image_packages)
+
+
+def test_image_carries_the_actions_runtime_the_grade_job_needs():
+    # Without git, actions/checkout falls back to a REST tarball with no .git
+    # and the grade job's own checkout verification fails; without az,
+    # azure/login cannot complete the OIDC exchange.
+    image_packages = _apt_packages(_dockerfile_instructions())
+
+    assert {"git", "curl", "ca-certificates", "azure-cli"} <= image_packages
+
+
+def test_base_image_is_digest_pinned_to_ubuntu_2404():
+    # ubuntu:24.04 is where the 24.2.7.2 renderer comes from; the digest is
+    # what stops a rebuild picking up a later one.
+    from_lines = [
+        line.strip()
+        for line in _dockerfile().splitlines()
+        if line.startswith("FROM ")
+    ]
+
+    assert len(from_lines) == 1
+    assert re.fullmatch(r"FROM ubuntu:24\.04@sha256:[0-9a-f]{64}", from_lines[0])
+
+
+def test_build_asserts_the_renderer_rather_than_reporting_it():
+    text = _dockerfile()
+
+    assert 'actual="$(soffice --headless --version)"' in text
+    assert 'if [ "$actual" != "$EXPECTED_LIBREOFFICE_VERSION" ]; then' in text
+    assert "/opt/gdpval/renderer-version.txt" in text
+    assert "grep -qx 'Liberation Sans'" in text
+
+
+def test_azure_cli_source_is_verified_before_it_is_trusted():
+    text = _dockerfile()
+    fingerprint = re.search(
+        r'^ARG MICROSOFT_GPG_FINGERPRINT="(?P<value>[^"]+)"$', text, re.MULTILINE
+    )
+
+    assert fingerprint is not None
+    assert re.fullmatch(r"[0-9A-F]{40}", fingerprint.group("value"))
+    assert 'if [ "$actual" != "$MICROSOFT_GPG_FINGERPRINT" ]; then' in text
+    assert "signed-by=/usr/share/keyrings/microsoft.gpg" in text
+    # The documented install path for azure-cli is a redirect piped into a
+    # root shell. Nothing that *runs* here may reintroduce it — the prose
+    # above the RUN step is allowed to name it, which is why this reads the
+    # instructions rather than the file.
+    instructions = _dockerfile_instructions()
+    assert "aka.ms" not in instructions
+    assert not re.search(r"\|\s*(ba)?sh\b", instructions)
+
+
+def test_build_workflow_verifies_on_pull_request_without_pushing():
+    workflow = _workflow(BUILD_WORKFLOW_PATH)
+    triggers = workflow["on"]
+
+    assert set(triggers) == {"workflow_dispatch", "pull_request"}
+    assert "batch-runner/sandbox/grading.Dockerfile" in triggers["pull_request"]["paths"]
+    assert workflow["permissions"] == {"contents": "read"}
+
+    verify = workflow["jobs"]["verify-grading-image"]
+    assert verify["permissions"] == {"contents": "read"}
+    build = next(
+        step for step in verify["steps"] if step.get("name") == "Build grading image"
+    )
+    assert build["with"]["push"] == "false"
+    assert build["with"]["file"] == "batch-runner/sandbox/grading.Dockerfile"
+
+
+def test_publish_is_gated_and_pinned_by_digest_not_by_tag():
+    workflow = _workflow(BUILD_WORKFLOW_PATH)
+    publish = workflow["jobs"]["publish-grading-image"]
+
+    assert publish["permissions"] == {"contents": "read", "packages": "write"}
+    for guard in (
+        "inputs.publish == true",
+        "github.ref == 'refs/heads/main'",
+        "github.ref_protected == true",
+    ):
+        assert guard in publish["if"]
+
+    build = next(
+        step
+        for step in publish["steps"]
+        if step.get("name") == "Build and push grading image"
+    )
+    tags = build["with"]["tags"]
+    # A moving :latest would let the renderer change under a grade job that
+    # never changed, which is the whole failure this image exists to remove.
+    assert ":latest" not in tags
+    assert "${{ github.sha }}" in tags
+
+
+def test_every_action_in_the_build_workflow_is_sha_pinned():
+    workflow = _workflow(BUILD_WORKFLOW_PATH)
+    uses = [
+        step["uses"]
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if "uses" in step
+    ]
+
+    assert uses
+    unpinned = [reference for reference in uses if not PINNED_ACTION.fullmatch(reference)]
+    assert not unpinned, unpinned


### PR DESCRIPTION
## Why

On formatting criteria the renderer is not a detail of how a grade is produced; it *is* the evidence. `grade-run.yml` asks apt for `libreoffice-core` and friends with no version, so whichever build the mirror serves that morning becomes what the judge sees — and two runs a generation apart are not comparable however identical their model, prompt, and `grader_source_hash`.

That install is also a live outage surface. On 2026-08-19 the Ubuntu mirror stalled mid-transfer for ~25 minutes; apt imposes no wall-clock ceiling on itself, five grade jobs sat in that step for 5h18m, and 63 of the 220 tasks died with them. #191 hardened that step with timeouts and retries; #193 asserted the installed build before Azure login so drift costs a free step instead of a paid corpus run.

Both are mitigations of a run-time install. This removes the run-time install.

## What lands here

- `batch-runner/sandbox/grading.Dockerfile` — `ubuntu:24.04` (digest-pinned), the same seven render packages `grade-run.yml` installs, plus the Actions runtime the grade job needs (`git`, `curl`, `ca-certificates`) and the Azure CLI.
- `.github/workflows/build-grading-image.yml` — builds and verifies on every PR that touches the image; publishes to GHCR only on an explicit dispatch against protected `main`.
- `batch-runner/tests/test_grading_image.py` — the static contract, 9 tests, no Docker required.

`grade-run.yml` is **not** touched, so the paid pipeline is unchanged by this PR.

## The version claim, verified

`ubuntu:24.04` + `libreoffice-core/-calc/-impress/-writer` resolves to `4:24.2.7-0ubuntu0.24.04.6`, which reports:

```
LibreOffice 24.2.7.2 420(Build:2)
```

That is an exact match for all **559** `libreoffice_version` values recorded across the three published grade files. Adopting this image therefore reproduces the renderer the existing corpus was graded with rather than moving it.

This is also why the image is not `ghcr.io/hyeonsangjeon/gdpval-sandbox`: that one is built `FROM python:3.11-slim-bookworm` and ships LibreOffice 7.4.7.2. Reusing it would move the very scores this exists to stabilise, and it carries neither `git` nor `az`.

## The Dockerfile is its own acceptance test

The final `RUN` asserts, and fails the build on mismatch:

| Check | Why it has to be a build failure |
|---|---|
| `soffice --headless --version` equals the pinned string | The version is the whole point; discovering a mismatch during a grade run is discovering it too late |
| `fc-match 'Liberation Sans'` resolves to Liberation Sans | A missing font silently changes every rendered page |
| `git --version` | Without git, `actions/checkout` falls back to a REST tarball with no `.git`, and the grade job's own checkout verification and the shard push both fail |
| `az version` | `azure/login` shells out to `az` for the OIDC exchange |

A green build *is* the evidence, so the workflow only surfaces it: `/opt/gdpval/renderer-version.txt` and a full `dpkg-query` package manifest are uploaded as an artifact and written to the step summary.

## Two things worth reviewing closely

**1. This is a new workflow file, not a third target in `build-sandbox-image.yml`** — a deliberate deviation from how the roadmap card described it. That workflow's `build-sandbox-image` job is gated on `github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.ref_protected == true`, with no per-target input in the condition, so it fires on *any* dispatch. Adding a `publish_grading` input there would rebuild and republish the 8.46 GB sandbox image every time someone wanted a grading image. The two also have opposite trust stories: the sandbox executes model-generated code and deliberately carries no credential tooling, while this image carries `az` precisely so the grade job can log in. Keeping them apart keeps that distinction legible.

**2. The Azure CLI comes from `packages.microsoft.com`, not the documented one-liner.** The published install path is a redirect piped into a root shell. Here the signing key is fetched, its fingerprint compared against a build arg *before* it is dearmored and trusted, and the source line is `signed-by=` that single keyring — so the Microsoft repository cannot sign anything outside `azure-cli`. A test asserts no `aka.ms` and no pipe-to-shell survives in the instructions.

## What the tests hold

`test_grading_image.py` targets the ways this could rot without anyone noticing:

- the expected renderer version is **derived from** `scripts/preflight_grading_renderer.EXPECTED_LIBREOFFICE_VERSION`, never restated — a second copy is how an upgrade lands in the image while the preflight still asserts the old build
- the image's apt package set must be a **superset** of the packages `grade-run.yml` installs, parsed out of the workflow itself, so the image cannot silently drop one
- the base is digest-pinned to `ubuntu:24.04`
- the published tag carries `${{ github.sha }}` and never `:latest` — a moving tag would let the renderer change under a job that never changed
- `verify-grading-image` has no `packages: write`; `publish-grading-image` is gated on `inputs.publish == true` **and** `refs/heads/main` **and** `github.ref_protected == true`
- every action is pinned to a 40-hex SHA

Local suite: `3478 passed, 6 skipped, 45 deselected` (baseline `3469` + the 9 added here, no regressions).

## Verified locally vs. proven in CI

The renderer version and the package resolution were confirmed in a local container. The `fc-match` assertion could **not** be exercised locally — the local Docker is 20.10.3 and its seccomp profile aborts `fontconfig` against glibc 2.39 (`cannot get entropy for arc4random`). That is an artifact of the old daemon, not of Ubuntu, and modern CI Docker is unaffected — but it means the font check is first proven by the `verify-grading-image` job on this PR. If that job is green, the check ran.

## Not in scope

Pinning the published digest in `grade-run.yml` and deleting the apt step is a follow-up. It cannot happen in this PR (the digest does not exist until this merges and publishes), and moving the grade job into a container also needs `actions/setup-python`'s `ImageOS` handling plus a free `dry_run=true` rehearsal before any paid run touches it.
