### PR TITLE
test(grading): lock openpyxl colour reads behind the type guard

### DIFF
--- a/batch-runner/tests/test_read_deliverable.py
+++ b/batch-runner/tests/test_read_deliverable.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import base64
 import importlib
 import io
@@ -324,6 +325,55 @@ def test_inspect_formatting_xlsx_preserves_color_types_without_descriptor_junk(
     assert set(styled) == set(colors)
     assert result["data"]["sheets"][0]["styled_cells_count"] == len(colors)
     assert "Values must be of type" not in str(result)
+
+
+def _rgb_reads_in_core() -> list[tuple[str, str, int]]:
+    """Every ``.rgb`` attribute read under ``core/``, with its enclosing function."""
+    core_root = Path(read_deliverable_module.__file__).resolve().parents[1]
+    reads: list[tuple[str, str, int]] = []
+    for path in sorted(core_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        functions = [
+            node for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Attribute) and node.attr == "rgb"):
+                continue
+            enclosing = [
+                fn for fn in functions
+                if fn.lineno <= node.lineno <= (fn.end_lineno or fn.lineno)
+            ]
+            innermost = max(enclosing, key=lambda fn: fn.lineno).name if enclosing else "<module>"
+            reads.append(
+                (path.relative_to(core_root).as_posix(), innermost, node.lineno)
+            )
+    return reads
+
+
+def test_openpyxl_color_rgb_is_only_read_behind_the_type_guard():
+    """No module may read ``Color.rgb`` outside the type-dispatched helper.
+
+    #156 fixed the read site that put openpyxl's validation message into judge
+    evidence, but the fix is structural -- dispatch on ``color.type`` first --
+    so it holds only as long as nothing else reads the descriptor blind. The
+    behavioural test above cannot see a second offender in another module.
+    """
+    pytest.importorskip("openpyxl")
+    from openpyxl.styles import Color
+
+    # Why the rule is worth enforcing: on a non-RGB colour the descriptor
+    # returns *itself* rather than raising, and its repr is the validation
+    # message. It is not JSON-serialisable, so it only becomes visible once
+    # something stringifies the evidence -- by which point it reads like an
+    # observation. If a future openpyxl raises here instead, relax the rule.
+    leaked = Color(theme=4).rgb
+    assert not isinstance(leaked, str)
+    assert "Values must be of type" in repr(leaked)
+
+    assert [(module, function) for module, function, _ in _rgb_reads_in_core()] == [
+        ("tools/read_deliverable.py", "_safe_cell_color")
+    ], _rgb_reads_in_core()
 
 
 def test_default_font_color_lookup_fails_soft_when_openpyxl_internals_change():


### PR DESCRIPTION
Closes the "openpyxl exception string leaks into judge evidence" backlog item. The investigation found the defect **already fixed**; this PR locks the fix in without touching how a grade is produced.

## What the defect was

On a non-RGB colour, openpyxl's `rgb` descriptor returns **the descriptor object itself** rather than raising:

```
Color(theme=4).rgb   ->  <class 'openpyxl.styles.colors.RGB'>
repr(...)            ->  "Values must be of type <class 'str'>"
json.dumps(...)      ->  TypeError: Object of type RGB is not JSON serializable
```

Nothing fails. The object rides along in the evidence dict and only turns into that sentence when something stringifies it — which is why it reached the judge looking like an observation about the spreadsheet.

## It was fixed on 2026-08-05

`609992e` (#156, "fix(grading): preserve non-RGB Excel colors") replaced the blind read in `_format_xlsx` with a dispatch on `color.type`, so `.rgb` is now read only when the colour actually is RGB. It was filed as a colour-fidelity fix, so its effect on this leak was never recorded against this item.

Every payload in `data/grades/` carrying the string was graded before that commit — 2026-05-30 (2), 2026-06-04 (3), 2026-06-10 (14). Everything graded after it is clean at corpus scale, including the official 220-task run and each of its nine shards.

## What this PR adds

An AST sweep asserting `_safe_cell_color` is the only `.rgb` reader under `core/`. The behavioural test #156 added proves `read_deliverable` is clean; it cannot see a *second* unguarded read added to some other module later, which is the one way a structural fix like this regresses.

The test first asserts the descriptor still misbehaves the way the rule assumes, so if a future openpyxl raises there instead, the guard fails loudly and can be retired rather than quietly enforcing a rule that no longer protects anything.

## Why it is test-only

`compute_grader_source_hash` covers `step8_grade.py`, `core/**/*.py`, the schema, `requirements.txt`, the download script, the prompt and the config — not `tests/`. Editing `core/` to add an explicit "unreadable" marker (the item's original remedy) would move the hash for a defect that no longer manifests in any payload, and would cost a future variance replicate a clean comparison against the official run.

It would also have nothing left to disambiguate: openpyxl 3.1.5 gives every colour a type in `{rgb, theme, indexed, auto}` and `_safe_cell_color` has a token for each, so a `null` from it now means "no distinct colour", not "could not read".

## Verification

`3479 passed, 6 skipped, 45 deselected` locally — the previous 3478 plus this one, no collateral.
