### PR TITLE
ci: move pinned actions off the Node 20 runtime

### DIFF
--- a/.github/workflows/agentic-sandbox-preflight.yml
+++ b/.github/workflows/agentic-sandbox-preflight.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout exact implementation
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
           ref: ${{ github.sha }}

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -40,7 +40,7 @@ jobs:
       # shipment") through `git cat-file`, which exits 128 when that object is
       # not in the clone. The pack is ~41 MiB, so full history is cheap here.
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -55,7 +55,7 @@ jobs:
       # ever stops shipping a 3.10.12 build for the runner image, re-pin the
       # constant and this together -- not this alone.
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10.12"
           cache: pip

--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -98,7 +98,7 @@ jobs:
           fi
 
       - name: Checkout config only
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -168,7 +168,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -178,7 +178,7 @@ jobs:
           [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]]
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -658,7 +658,7 @@ jobs:
 
       # ── Step 2a: Run Inference (condition_a) ──
       - name: 'Azure Login (OIDC)'
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -903,7 +903,7 @@ jobs:
       - name: Create Pull Request with results
         id: cpr
         if: inputs.dry_run != true && steps.check_relay.outputs.needs_relay == 'false' && steps.step2a.outcome == 'success'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "experiment: ${{ env.experiment_name }}"
@@ -1098,7 +1098,7 @@ jobs:
       # ── Upload artifacts ──
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: batch-results-${{ github.run_id }}
           path: |

--- a/.github/workflows/build-grading-image.yml
+++ b/.github/workflows/build-grading-image.yml
@@ -51,15 +51,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build grading image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: batch-runner/sandbox
           file: batch-runner/sandbox/grading.Dockerfile
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload grading image evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grading-image-evidence-${{ github.run_id }}
           path: ${{ runner.temp }}/grading-image
@@ -114,7 +114,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
           ref: ${{ github.sha }}
@@ -127,10 +127,10 @@ jobs:
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Build and push grading image
         id: build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: batch-runner/sandbox
           file: batch-runner/sandbox/grading.Dockerfile

--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
           ref: ${{ github.sha }}
@@ -139,10 +139,10 @@ jobs:
           PY
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -150,7 +150,7 @@ jobs:
 
       - name: Build and push sandbox image
         id: base_build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: batch-runner
           file: batch-runner/sandbox/Dockerfile
@@ -168,7 +168,7 @@ jobs:
       - name: Build agentic sandbox audit candidate
         if: ${{ inputs.publish_agentic == true }}
         id: agentic_candidate
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: batch-runner
           file: batch-runner/sandbox/agentic.Dockerfile
@@ -203,7 +203,7 @@ jobs:
       - name: Build and push audited agentic sandbox image
         if: ${{ inputs.publish_agentic == true }}
         id: agentic_build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: batch-runner
           file: batch-runner/sandbox/agentic.Dockerfile
@@ -298,7 +298,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout exact pull request head
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
@@ -313,7 +313,7 @@ jobs:
           test -z "$(git status --porcelain --untracked-files=all)"
 
       - name: Set up exact Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11.9"
 
@@ -370,7 +370,7 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload hosted containment evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agentic-v2-hosted-containment-${{ github.run_id }}
           path: ${{ runner.temp }}/agentic-v2-hosted-containment

--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -353,7 +353,7 @@ jobs:
       GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
     steps:
       - name: Checkout exact main revision (read-only)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: main
           persist-credentials: false
@@ -390,7 +390,7 @@ jobs:
           done
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -477,8 +477,15 @@ jobs:
 
     steps:
 
+      # Held on the v5 line on purpose. checkout v6 moved persisted
+      # credentials out of .git/config into a separate file referenced by an
+      # includeIf entry, and `git config --local` does not expand includes.
+      # The extraheader check in the next step would stop finding the
+      # credential and abort this job -- on the paid path, after dispatch.
+      # tests/test_step8_grade.py holds the two together; bump both or
+      # neither.
       - name: Checkout exact main revision
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: main
           persist-credentials: true
@@ -519,7 +526,7 @@ jobs:
           done
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -701,7 +708,7 @@ jobs:
 
       - name: Azure Login (OIDC)
         if: inputs.dry_run != true
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -1136,7 +1143,7 @@ jobs:
 
       - name: Upload grade artifact
         if: always() && inputs.dry_run == false && steps.grade.outputs.grade_file != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Shards are separate workflow runs, so the names cannot collide --
           # but a downloaded bundle is unreadable without knowing which slice it

--- a/.github/workflows/grading-renderer-preflight.yml
+++ b/.github/workflows/grading-renderer-preflight.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: pip
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload renderer evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grading-renderer-preflight-${{ github.run_id }}
           path: ${{ runner.temp }}/grading-renderer-preflight.json

--- a/.github/workflows/preflight-track2-cohort.yml
+++ b/.github/workflows/preflight-track2-cohort.yml
@@ -135,7 +135,7 @@ jobs:
           PY
 
       - name: Checkout exact repository commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.expected_repository_commit }}
           persist-credentials: false
@@ -154,7 +154,7 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11.9"
           cache: "pip"
@@ -350,7 +350,7 @@ jobs:
 
       - name: Upload exact cohort plan
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: track2-preflight-${{ github.run_id }}
           path: |

--- a/.github/workflows/shard-relay-sweep.yml
+++ b/.github/workflows/shard-relay-sweep.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
           # Full history, not the default shallow clone. Liveness is read from
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 

--- a/batch-runner/tests/test_agentic_workflows.py
+++ b/batch-runner/tests/test_agentic_workflows.py
@@ -228,7 +228,7 @@ def test_hosted_containment_measurement_is_read_only_and_exact():
     assert "GITHUB_STEP_SUMMARY" in measure["run"]
     upload = job["steps"][names.index("Upload hosted containment evidence")]
     assert upload["uses"] == (
-        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     )
     assert upload["with"]["if-no-files-found"] == "error"
     assert upload["with"]["retention-days"] == 14

--- a/batch-runner/tests/test_grading_renderer_preflight_workflow.py
+++ b/batch-runner/tests/test_grading_renderer_preflight_workflow.py
@@ -9,9 +9,9 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/grading-renderer-preflight.yml"
-CHECKOUT = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
-SETUP_PYTHON = "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
-UPLOAD_ARTIFACT = "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+CHECKOUT = "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
+SETUP_PYTHON = "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
+UPLOAD_ARTIFACT = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 
 
 def _workflow() -> tuple[str, dict]:

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 
 import pytest
@@ -3117,20 +3118,20 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
     assert "inference_revision:" in workflow
     assert 'default: ""' in workflow
     assert checkout["uses"] == (
-        "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
     )
     assert checkout["with"] == {
         "ref": "main",
         "persist-credentials": True,
     }
     assert setup_python["uses"] == (
-        "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
+        "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
     )
     assert azure_login["uses"] == (
-        "azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5"
+        "azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca"
     )
     assert upload["uses"] == (
-        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     )
     assert "GITHUB_WORKFLOW_SHA" in validate_inputs["run"]
     assert "refs/heads/main" in validate_inputs["run"]
@@ -3209,6 +3210,51 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
     assert '-f experiment_yaml="$GRADE_EXPERIMENT_YAML"' in retrigger["run"]
     assert '-f grading_config="$GRADE_CONFIG"' in retrigger["run"]
     assert '--revision "${{ inputs.inference_revision }}"' not in workflow
+
+
+def test_grade_checkout_stays_on_the_major_that_writes_extraheader_to_git_config():
+    """The credentialed checkout and the extraheader guard have to move together.
+
+    checkout v6 persists credentials to a separate file that .git/config only
+    references through an includeIf entry, and ``git config --local`` does not
+    expand includes. The guard below would stop finding the credential and
+    abort the grade job -- on the paid path, after dispatch, for a reason that
+    looks nothing like an action bump. Nothing else in the repository couples
+    a pin to a shell assertion, so nothing else would catch it.
+    """
+    text = Path("../.github/workflows/grade-run.yml").read_text(encoding="utf-8")
+    parsed = yaml.safe_load(text)
+    steps = {
+        step["name"]: step
+        for step in parsed["jobs"]["grade"]["steps"]
+        if step.get("name")
+    }
+    name = "Checkout exact main revision"
+    checkout = steps[name]
+    guard = steps["Verify checked out main and input files"]["run"]
+
+    assert checkout["with"]["persist-credentials"] is True
+
+    # grade-run.yml checks out twice on the same pin, and only this one keeps
+    # credentials, so the version comment has to be read from this step's own
+    # block rather than from the first match in the file. The trailing newline
+    # is load-bearing: the other step is named "<this> (read-only)", so an
+    # unterminated anchor matches it first and reads the wrong pin.
+    start = text.index(f"- name: {name}\n")
+    block = text[start:text.index("- name:", start + 1)]
+    pinned = re.search(
+        rf"uses:\s*{re.escape(checkout['uses'])}\s*#\s*v(?P<major>\d+)\.\d+\.\d+",
+        block,
+    )
+    assert pinned is not None, "the credentialed checkout pin needs a # vX.Y.Z comment"
+    assert pinned.group("major") == "5"
+
+    # The guard reads one file with includes off. If it ever gains --includes,
+    # or reads the credentials config directly, this test has done its job and
+    # the major above is free to move with it.
+    assert "git config --local --name-only --get-regexp" in guard
+    assert "extraheader" in guard
+    assert "--includes" not in guard
 
 
 def _run_grade_workflow_input_preflight(**overrides):

--- a/batch-runner/tests/test_track2_preflight_workflow.py
+++ b/batch-runner/tests/test_track2_preflight_workflow.py
@@ -93,7 +93,7 @@ def test_track2_preflight_workflow_is_model_free_and_fail_closed():
     assert upload["if"] == "always()"
     assert upload["uses"] == (
         "actions/upload-artifact@"
-        "ea165f8d65b6e75b540449e92b4886f43607fa02"
+        "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     )
     assert upload["with"]["if-no-files-found"] == "warn"
     assert "batch-runner/workspace/track2_cohort_plan.json" in upload["with"]["path"]
@@ -120,8 +120,8 @@ def test_track2_preflight_workflow_requires_strict_identity_inputs():
     assert 'if len(task_ids) != limit:' in workflow
     assert 'if len(set(task_ids)) != len(task_ids):' in workflow
     assert 'ref: ${{ inputs.expected_repository_commit }}' in workflow
-    assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
-    assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" in workflow
+    assert "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09" in workflow
+    assert "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" in workflow
     assert "--require-hashes" in workflow
     assert "--only-binary=:all:" in workflow
     assert workflow.index("Verify source and local planner identities") < workflow.index(


### PR DESCRIPTION
## What

GitHub is sunsetting the Node 20 action runtime. Every pinned action in this repository was still on it — twelve call sites across nine workflows, not the four the roadmap card assumed. All of them move to majors that ship on Node 24, keeping SHA pins and restating each version in the trailing comment.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4.2.2 / v4.3.1 | **v5.1.0** (held — see below) |
| `actions/setup-python` | v5.6.0 | v7.0.0 |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 |
| `docker/build-push-action` | v6.18.0 | v7.3.0 |
| `docker/setup-buildx-action` | v3.11.1 | v4.3.0 |
| `docker/login-action` | v3.3.0 | v4.6.0 |
| `azure/login` | v2.3.0 | v3.0.1 |
| `peter-evans/create-pull-request` | v6.1.0 | v8.1.1 |

## Two findings that changed the plan

**`upload-artifact@v5` is still a Node 20 action.** Only v6 moved to Node 24. The obvious "+1 major" pass would have left every artifact upload here exactly where it started, still on the sunsetting runtime, while looking like it had been handled.

**`checkout` is held at v5.1.0 on purpose — v6 would break `grade-run.yml` on the paid path.** In v5 the auth helper writes `http.<origin>/.extraheader` straight into `.git/config`. In v6 it writes a separate credentials file that `.git/config` only references through an `includeIf` entry, and `git config --local` does not expand includes. `grade-run.yml` asserts that credential is present before the job is allowed to publish results:

```bash
if ! git config --local --name-only --get-regexp '^http\..*\.extraheader$' >/dev/null; then
  echo "::error::checkout credentials required for result publication are missing"
  exit 1
fi
```

Under v6 that guard stops finding the credential and aborts the job — after dispatch, for a reason that looks nothing like an action bump. v5.1.0 is already Node 24, so holding there costs nothing against the sunset.

That constraint lives half in a workflow pin and half in a shell assertion, which a comment alone would not protect. `test_step8_grade.py` now reads the version comment out of the credentialed checkout's own step block and fails if the major moves while the guard still reads a single file with includes off. Negative-checked: patching the pin comment to `# v6.0.3` fails the test with `assert '6' == '5'`; restoring it passes. The block anchor is newline-terminated because the other checkout in that file is named `Checkout exact main revision (read-only)` — an unterminated anchor matches it first and reads the wrong pin.

## What is not in here

`deploy.yml` and its four remaining Node 20 pins. Merging any edit to that file triggers a live Pages deployment, and `actions/deploy-pages` only ever runs on `main`, so the bump cannot be proven by a pull request. It needs its own change and its own decision.

## Verification

Read `action.yml` at every target tag rather than trusting release notes. The inputs and environment variables removed across these majors — `pip-install`, `git-token`, `PULL_REQUEST_NUMBER`, `DOCKER_BUILD_NO_SUMMARY`, `DOCKER_BUILD_EXPORT_RETENTION_DAYS` — are unused here; `package.json` declares no `packageManager`; `azure/login@v3.0.1` has the same input surface as v2.3.0. The `azure/login` pin is the **peeled** commit — it tags annotatively, so the tag object SHA the API returns is not a commit and would not resolve.

The PR-triggered `build-grading-image` verify job exercises checkout v5.1.0, the three docker actions and upload-artifact v7.0.1 for free.

Local: `3480 passed, 6 skipped, 45 deselected`.

Tests only touch `tests/`, so `grader_source_hash` does not move.
