### PR TITLE
fix(grading): raise the per-item visual file cap and record it in provenance

### DIFF
--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -753,6 +753,10 @@ class Grader:
         raw_visual_paths: list[str] = []
         supported_visual_paths: list[str] = []
         visual_preflight_error: str | None = None
+        # One read for the three checks below -- the per-child cap, the
+        # single-target cap, and the union cap are all the same bound.
+        # ``grade_task`` only routes here once the tool-calling judge exists.
+        visual_file_cap = self._tool_judge.visual_file_cap
         if plan.target_scope == "split_children":
             target_by_id = {
                 target.target_id: target for target in selection.primary_targets
@@ -767,7 +771,7 @@ class Grader:
                     raw_visual_paths.extend(target.paths)
                     planned_names, child_error = (
                         self._tool_judge.validate_planned_visual_names(
-                            target.paths
+                            target.paths, visual_file_cap
                         )
                     )
                     supported_visual_paths.extend(planned_names)
@@ -779,7 +783,7 @@ class Grader:
             raw_visual_paths.extend(plan.selected_paths)
             supported_visual_paths, visual_preflight_error = (
                 self._tool_judge.validate_planned_visual_names(
-                    plan.selected_paths
+                    plan.selected_paths, visual_file_cap
                 )
             )
 
@@ -788,9 +792,15 @@ class Grader:
             and supported_visual_paths
             and visual_preflight_error is None
         ):
+            # The union is one batched prepass: ``preflight_visual`` renders
+            # and perceives every path in it, so the cap applies to the union
+            # for the same reason it applies to a bundle. It is checked again
+            # inside that call, but not redundantly -- failing here keeps an
+            # over-cap item from booking its whole union into the task visual
+            # budget and dragging the task's other items down with it.
             supported_visual_paths, visual_preflight_error = (
                 self._tool_judge.validate_planned_visual_names(
-                    supported_visual_paths
+                    supported_visual_paths, visual_file_cap
                 )
             )
         visual_paths = tuple(supported_visual_paths)
@@ -1841,6 +1851,7 @@ class Grader:
         of the configured v1 template).
         """
         from core.tool_calling_judge import ToolCallingJudge  # local; avoid cycle
+        from core.tool_calling_judge import resolve_visual_file_cap
 
         judge_cfg = self.config.get("judge", {})
         tool_prompt_path = resolve_tool_prompt_path(self.config)
@@ -1931,6 +1942,7 @@ class Grader:
             audio_perception=audio_perception,
             prompt_cache_key=prompt_cache_key,
             before_upstream_call=self._apply_tpm_delay,
+            visual_file_cap=resolve_visual_file_cap(judge_cfg),
         )
 
     def _judge_via_tool_calling(

--- a/batch-runner/core/grader_preflight.py
+++ b/batch-runner/core/grader_preflight.py
@@ -10,7 +10,7 @@ from core.deliverable_selector import plan_targets_for_criterion
 from core.grader import Grader
 from core.grader_routing import Modality, resolve_runtime_routing
 from core.rubric_loader import TaskRubric
-from core.tool_calling_judge import ToolCallingJudge
+from core.tool_calling_judge import ToolCallingJudge, resolve_visual_file_cap
 
 
 def _planner(config: dict) -> Grader:
@@ -28,6 +28,7 @@ def plan_task_runtime(
     """Return the exact model-free routing plan for one local task."""
     grader = _planner(config)
     deliverable_path = Path(deliverable_dir)
+    visual_file_cap = resolve_visual_file_cap(config.get("judge") or {})
     files = grader._list_files(deliverable_path)
     selection = grader._select_deliverables(task, deliverable_path, files)
     file_map = grader._relative_file_map(deliverable_path, files)
@@ -92,7 +93,7 @@ def plan_task_runtime(
                 if decision.modality is Modality.VISUAL:
                     planned_names, child_visual_error = (
                         ToolCallingJudge.validate_planned_visual_names(
-                            target.paths
+                            target.paths, visual_file_cap
                         )
                     )
                     unsupported_visual_paths.extend(
@@ -120,7 +121,7 @@ def plan_task_runtime(
             if supported_visual_paths and visual_error is None:
                 planned_names, parent_visual_error = (
                     ToolCallingJudge.validate_planned_visual_names(
-                        supported_visual_paths
+                        supported_visual_paths, visual_file_cap
                     )
                 )
                 if parent_visual_error is not None:
@@ -189,7 +190,7 @@ def plan_task_runtime(
         if decision.modality is Modality.VISUAL:
             planned_names, visual_error = (
                 ToolCallingJudge.validate_planned_visual_names(
-                    target_plan.selected_paths
+                    target_plan.selected_paths, visual_file_cap
                 )
             )
             if visual_error is not None:

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -112,7 +112,35 @@ _VISUAL_RENDER_SCOPES: Dict[str, Dict[str, int]] = {
     ".bmp": {},
     ".webp": {},
 }
-_VISUAL_FILE_CAP = 3
+#: Default upper bound on how many files one visual rubric item may render
+#: and perceive. It bounds one item's evidence; ``call_cap_per_task`` bounds
+#: the whole task's visual spend, and the two are not interchangeable.
+#: Configurable per grading config via
+#: ``judge.perception.visual.file_cap_per_item`` so the value in force lands
+#: in run provenance rather than staying implicit in this file. It was 3,
+#: which was below the size of an ordinary multi-deliverable submission and
+#: failed whole items closed rather than judging them.
+_DEFAULT_VISUAL_FILE_CAP = 10
+
+
+def resolve_visual_file_cap(judge_config: Mapping[str, Any]) -> int:
+    """Return the per-item visual file cap a judge config asks for.
+
+    An absent key takes the default. So does an explicitly null one: that is
+    how YAML spells a key someone started and did not finish, and the two are
+    indistinguishable once parsed.
+    """
+    visual = ((judge_config or {}).get("perception") or {}).get("visual") or {}
+    raw = visual.get("file_cap_per_item")
+    if raw is None:
+        return _DEFAULT_VISUAL_FILE_CAP
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 1:
+        raise ValueError(
+            "judge.perception.visual.file_cap_per_item must be a positive integer"
+        )
+    return raw
+
+
 #: Where each rendered kind's surface count comes from. "Surface" is the
 #: unit the judge sampled one of -- a page, a slide, a converted workbook
 #: page -- and the count is what makes ``sampled_first_surface`` legible:
@@ -447,6 +475,10 @@ class ToolCallingJudge:
                                  fully cacheable).
         before_upstream_call:     optional zero-argument TPM guard invoked
                      before each main-judge or vision API call.
+        visual_file_cap:         most files one visual item may render.
+                     Resolved from
+                     ``judge.perception.visual.file_cap_per_item``
+                     by :func:`resolve_visual_file_cap`.
     """
 
     client: Any
@@ -465,6 +497,7 @@ class ToolCallingJudge:
     prompt_cache_key: Optional[str] = None
     compact_threshold: Optional[int] = None
     before_upstream_call: Optional[Callable[[], None]] = None
+    visual_file_cap: int = _DEFAULT_VISUAL_FILE_CAP
 
     # Cached: split prompt template into stable + variable halves once at
     # construction (or first use). The stable half is the ``instructions=``
@@ -1103,7 +1136,7 @@ class ToolCallingJudge:
             return result
 
         planned_names, planning_error = self.validate_planned_visual_names(
-            file_names
+            file_names, self.visual_file_cap
         )
         if planning_error is not None:
             result.judge_error = planning_error
@@ -1299,16 +1332,16 @@ class ToolCallingJudge:
 
     @classmethod
     def validate_planned_visual_names(
-        cls, file_names: List[str]
+        cls, file_names: List[str], cap: int
     ) -> Tuple[List[str], Optional[str]]:
         """Apply the exact runtime target, cap, and format checks."""
         planned_names = cls.planned_supported_visual_names(file_names)
         if not planned_names:
             return [], "required_visual_render_target_unavailable"
-        if len(planned_names) > _VISUAL_FILE_CAP:
+        if len(planned_names) > cap:
             return planned_names, (
                 "required_visual_file_cap_exceeded:"
-                f"planned={len(planned_names)},cap={_VISUAL_FILE_CAP}"
+                f"planned={len(planned_names)},cap={cap}"
             )
         return planned_names, None
 

--- a/batch-runner/grading_configs/README.md
+++ b/batch-runner/grading_configs/README.md
@@ -204,6 +204,74 @@ All diagnostic, operational, modality, audio, visual-budget, and envelope
 results must be reported numerically. Improvement alone does not justify the
 full run if any wiring, cap, unknown-attribution, or time gate fails.
 
+## Visual file cap per rubric item
+
+`judge.perception.visual.file_cap_per_item` bounds how many files one visual
+rubric item may render and perceive. It is a positive integer; omit it and the
+grader uses **10**. A value that is not a positive integer is rejected by
+`validate_grading_config`, so a typo fails at dispatch rather than partway
+through a paid shard.
+
+This is not the same bound as `judge.perception.visual.call_cap_per_task`,
+which is the task-wide budget (72 in the production configs). The per-item cap
+limits one item's evidence; the task cap limits what the whole task may spend.
+
+Where it applies:
+
+- `primary_bundle` / `file_target` — the item's selected files.
+- `split_children` — each child's own files, and then the union across
+  children. The union counts because the runtime hands it to a single batched
+  prepass that renders and perceives every path in it. Failing the union
+  before that call is also what keeps an over-cap item from booking its whole
+  union into the task visual budget and failing the task's other items with it.
+
+Exceeding the cap fails the item closed with
+`required_visual_file_cap_exceeded:planned=<n>,cap=<n>` — the item is scored as
+`judge_error` and excluded, and nothing is rendered. It is a deliberate refusal
+to judge breadth from a partial view rather than a truncation to the first *N*
+files.
+
+### Why the default moved from 3 to 10
+
+A hard-coded 3 was below the size of an ordinary multi-deliverable submission.
+On R1 it failed three rubric items closed on tasks where nothing was over
+budget and nothing was unrenderable — the items simply spanned four or more
+files. Truncating to the first three alphabetically was rejected: on all three
+items the un-rendered files were exactly the ones that could change the
+verdict, so a truncated pass would have been less honest than the refusal.
+
+The full fix costs +20 vision calls, 3.48% of R1's 575. The projected per-task
+maximum stays at 68 against `call_cap_per_task: 72`, so the task budget is
+still not the binding constraint.
+
+### Effect on `grader_source_hash` and comparability
+
+`compute_grader_source_hash` covers `step8_grade.py`, `core/**/*.py`,
+`schemas/grade.schema.json`, `requirements.txt`,
+`scripts/download_inference_from_hf.py`, and the configured prompt, tool
+prompt, and config file. This change edits `core/tool_calling_judge.py`,
+`core/grader.py`, `core/grader_preflight.py`, `step8_grade.py`, and the grade
+schema, so **`grader_source_hash` moves.** Grades written before it and after
+it are not the same grader identity, and a resume or shard merge across the
+boundary is refused by the existing identity checks — as intended.
+
+`config_hash` does **not** move. No shipped config sets `file_cap_per_item`;
+the raised default lives in code and the resolved value is written to
+`judge.visual_file_cap` in every new grade payload. That keeps the archived,
+regrade, and validation configs byte-identical, so runs already published under
+them keep their identity, and a reader can still tell which cap produced any
+given grade file without inferring it from a code revision.
+
+`judge.visual_file_cap` is optional in the grade schema. Payloads written
+before this change do not carry it; for those the cap was 3.
+
+Scores are comparable within one `grader_source_hash`, not across this one.
+An item that previously scored `judge_error` under the cap of 3 may now carry a
+real verdict, which changes both the numerator and the denominator of its
+task's score. Compare conditions only after a complete rerun under one grader
+source and one schema identity — the same rule as the schema `1.3` boundary
+above.
+
 ## Archived (no longer recommended)
 
 Under `_archive_v1/`. These files are provenance references, not runnable inputs
@@ -232,6 +300,7 @@ boundary.
 | `deliverable_extract_max_chars` | present | **removed** |
 | tools | none | `read_deliverable` + opt. `vision_judge` + opt. `audio_judge` |
 | perception | none | gpt-5.6-sol max vision / gpt-audio-1.5 (modality-routed) |
+| visual files per item | n/a | `file_cap_per_item`, default 10 |
 | critical rule | `weight >= 4` | `\|max_score\| >= 4` (sign-aware, includes 94 penalty items) |
 | score math | clamp-hidden negatives | sign-aware, explicit non-positive total_max handling |
 | rubric execution | one final verdict per rubric item | one final verdict per rubric item (plus bounded tool/finalization calls) |

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -352,7 +352,12 @@
         "temperature": {"type": "number"},
         "seed": {"type": "integer"},
         "config_name": {"type": "string"},
-        "config_hash": {"type": "string"}
+        "config_hash": {"type": "string"},
+        "visual_file_cap": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Resolved per-item visual file cap in force for this run. Not required: grades written before the cap became configurable do not carry it, and for those the cap was 3."
+        }
       },
       "additionalProperties": true
     },

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -48,6 +48,7 @@ from core.inference_manifest import (
 )
 from core.public_error import public_provider_error_text
 from core.rubric_loader import RubricLoader
+from core.tool_calling_judge import resolve_visual_file_cap
 from core.tools import ReadDeliverableError, get_renderer_fingerprint
 
 SCHEMA_VERSION = "1.3"
@@ -482,6 +483,10 @@ def validate_grading_config(config: dict) -> None:
             raise ValueError(
                 "judge.perception.visual.reasoning_effort is invalid"
             )
+        # resolve_visual_file_cap raises on anything that is not a positive
+        # integer. Calling it here turns a bad cap into a config error before
+        # dispatch rather than a judge_error partway through a paid shard.
+        resolve_visual_file_cap(judge)
 
     # --- v2 critical block (optional) ----------------------------------
     critical = (judge.get("critical") or {})
@@ -1656,6 +1661,11 @@ def _build_grade_payload(
             "temperature": config.get("judge", {}).get("generation", {}).get("temperature", 0),
             "seed": config.get("judge", {}).get("generation", {}).get("seed", 42),
             "perception": config.get("judge", {}).get("perception", {}),
+            # The resolved value, not the configured one. A config that omits
+            # file_cap_per_item still grades under a cap, and a grade file that
+            # only carried the perception block verbatim would leave a reader
+            # inferring it from whichever revision of the code ran.
+            "visual_file_cap": resolve_visual_file_cap(config.get("judge") or {}),
             "config_name": config.get("config_name", "unknown"),
             "config_hash": config_hash,
         },

--- a/batch-runner/tests/test_grader_preflight.py
+++ b/batch-runner/tests/test_grader_preflight.py
@@ -168,7 +168,7 @@ def test_plan_enforces_visual_call_cap(tmp_path: Path):
 
 
 def test_plan_enforces_runtime_visual_file_cap(monkeypatch, tmp_path: Path):
-    paths = [f"report-{index}.pdf" for index in range(4)]
+    paths = [f"report-{index}.pdf" for index in range(11)]
     for path in paths:
         (tmp_path / path).write_bytes(b"pdf")
     selection = DeliverableSelection(
@@ -196,8 +196,85 @@ def test_plan_enforces_runtime_visual_file_cap(monkeypatch, tmp_path: Path):
     assert plan["planned_render_calls"] == 0
     assert plan["planned_perception_calls"] == 0
     assert plan["errors"] == [
+        "visual: required_visual_file_cap_exceeded:planned=11,cap=10"
+    ]
+
+
+def test_plan_enforces_the_configured_visual_file_cap(monkeypatch, tmp_path: Path):
+    """The preflight has to plan under the run's cap, not the default one.
+
+    A cohort graded with a lowered ``file_cap_per_item`` would otherwise be
+    told its bundles fit when the grader is about to fail them closed, which
+    is the one thing a preflight exists to prevent.
+    """
+    paths = [f"report-{index}.pdf" for index in range(4)]
+    for path in paths:
+        (tmp_path / path).write_bytes(b"pdf")
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="task-1",
+        task_class="single_primary",
+        primary_targets=[SelectionTarget("bundle", paths, "pdf")],
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader_preflight.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="primary_bundle",
+            target_ids=["bundle"],
+            selected_paths=paths,
+        ),
+    )
+
+    plan = plan_task_runtime(
+        {"judge": {"perception": {"visual": {"file_cap_per_item": 3}}}},
+        _task([RubricItem("visual", "The chart layout is readable.", 1, None)]),
+        tmp_path,
+    )
+
+    assert plan["errors"] == [
         "visual: required_visual_file_cap_exceeded:planned=4,cap=3"
     ]
+
+
+def test_plan_plans_a_visual_bundle_up_to_the_default_cap(
+    monkeypatch, tmp_path: Path
+):
+    """Ten files is the default ceiling, and the tenth still renders.
+
+    The cap used to be 3, which silently dropped whole bundles of five and
+    six reports at grading time. Pinning the boundary here keeps a future
+    tightening of the default from passing quietly.
+    """
+    paths = [f"report-{index}.pdf" for index in range(10)]
+    for path in paths:
+        (tmp_path / path).write_bytes(b"pdf")
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="task-1",
+        task_class="single_primary",
+        primary_targets=[SelectionTarget("bundle", paths, "pdf")],
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader_preflight.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="primary_bundle",
+            target_ids=["bundle"],
+            selected_paths=paths,
+        ),
+    )
+
+    plan = plan_task_runtime(
+        {},
+        _task([RubricItem("visual", "The chart layout is readable.", 1, None)]),
+        tmp_path,
+    )
+
+    assert plan["errors"] == []
+    assert plan["planned_main_judgments"] == 1
+    assert plan["planned_render_calls"] == 10
+    assert plan["items"][0]["planned_visual_paths"] == sorted(paths)
 
 
 def test_plan_filters_unsupported_paths_from_visual_bundle(
@@ -313,7 +390,14 @@ def test_plan_split_children_matches_runtime_shape(tmp_path: Path):
 def test_plan_split_children_enforces_parent_visual_file_cap(
     monkeypatch, tmp_path: Path
 ):
-    paths = [f"report-{index}.pdf" for index in range(4)]
+    """The union of a split item's children is capped like a bundle is.
+
+    The runtime hands that whole union to one batched prepass, which renders
+    and perceives every path in it, so the cap has to bind there too. It is
+    also what keeps an over-cap item from booking its entire union into the
+    task visual budget and failing the task's other items with it.
+    """
+    paths = [f"report-{index}.pdf" for index in range(11)]
     targets = []
     for index, path in enumerate(paths):
         (tmp_path / path).write_bytes(b"pdf")
@@ -347,7 +431,103 @@ def test_plan_split_children_enforces_parent_visual_file_cap(
     assert plan["planned_perception_calls"] == 0
     assert plan["items"][0]["outcome"] == "preflight_error"
     assert plan["errors"] == [
-        "style: required_visual_file_cap_exceeded:planned=4,cap=3"
+        "style: required_visual_file_cap_exceeded:planned=11,cap=10"
+    ]
+
+
+def test_plan_split_children_spans_more_children_than_the_old_cap(
+    monkeypatch, tmp_path: Path
+):
+    """Four children under one item, which the old cap of three failed closed.
+
+    This is the shape that cost R1 real coverage: nothing here is over budget
+    and nothing is unrenderable, the item simply spanned more deliverables
+    than the constant allowed, so it scored nothing rather than scoring on a
+    partial view.
+    """
+    paths = [f"report-{index}.pdf" for index in range(4)]
+    targets = []
+    for index, path in enumerate(paths):
+        (tmp_path / path).write_bytes(b"pdf")
+        targets.append(SelectionTarget(f"target-{index}", [path], "pdf"))
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="task-1",
+        task_class="separate_equivalent",
+        primary_targets=targets,
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader_preflight.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="split_children",
+            target_ids=[target.target_id for target in targets],
+            selected_paths=paths,
+            aggregation_rule="blocking_min_else_mean",
+        ),
+    )
+
+    plan = plan_task_runtime(
+        {},
+        _task([RubricItem("style", "Overall Style", 1, None)]),
+        tmp_path,
+    )
+
+    assert plan["errors"] == []
+    assert plan["items"][0]["outcome"] == "judge"
+    assert plan["planned_main_judgments"] == 4
+    assert plan["planned_render_calls"] == 4
+    assert plan["planned_perception_calls"] == 4
+    assert plan["items"][0]["planned_visual_paths"] == sorted(paths)
+
+
+def test_plan_split_children_still_enforces_the_cap_on_one_child(
+    monkeypatch, tmp_path: Path
+):
+    """A single over-cap child fails before the union is ever assembled.
+
+    One failing child fails the whole item, so the error a reader sees names
+    the child rather than the union. Keeping both paths covered means a
+    future change to either one cannot quietly take the other with it.
+    """
+    paths = [f"report-{index}.pdf" for index in range(11)]
+    for path in paths:
+        (tmp_path / path).write_bytes(b"pdf")
+    targets = [
+        SelectionTarget("target-wide", paths, "pdf"),
+        SelectionTarget("target-narrow", ["summary.pdf"], "pdf"),
+    ]
+    (tmp_path / "summary.pdf").write_bytes(b"pdf")
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="task-1",
+        task_class="separate_equivalent",
+        primary_targets=targets,
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader_preflight.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="split_children",
+            target_ids=[target.target_id for target in targets],
+            selected_paths=paths + ["summary.pdf"],
+            aggregation_rule="blocking_min_else_mean",
+        ),
+    )
+
+    plan = plan_task_runtime(
+        {},
+        _task([RubricItem("style", "Overall Style", 1, None)]),
+        tmp_path,
+    )
+
+    assert plan["judge_routes"] == {"visual": 1}
+    assert plan["planned_main_judgments"] == 0
+    assert plan["planned_render_calls"] == 0
+    assert plan["planned_perception_calls"] == 0
+    assert plan["items"][0]["outcome"] == "preflight_error"
+    assert plan["errors"] == [
+        "style: target-wide: required_visual_file_cap_exceeded:planned=11,cap=10"
     ]
 
 

--- a/batch-runner/tests/test_grader_selector_integration.py
+++ b/batch-runner/tests/test_grader_selector_integration.py
@@ -1076,6 +1076,180 @@ def test_split_text_child_no_longer_blocks_its_visual_sibling(
     )
 
 
+def test_split_children_render_every_child_past_the_old_file_cap(
+    monkeypatch, tmp_path
+):
+    """Four one-file children under one item, end to end.
+
+    This is the shape the old cap of three failed closed on R1: four separate
+    reports, all renderable, none over any budget, and the item scored nothing
+    because the constant said three. The union is one batched prepass, so the
+    cap still binds on it -- it is just no longer set below the size of an
+    ordinary multi-deliverable submission.
+    """
+    from core.rubric_loader import RubricItem, TaskRubric
+    from core.deliverable_selector import (
+        CriterionTargetPlan,
+        DeliverableSelection,
+        SelectionTarget,
+    )
+    from core.grader import Grader
+    import core.tool_calling_judge as tool_judge_mod
+
+    paths = [f"report-{index}.pdf" for index in range(4)]
+    responses = ScriptedResponses([
+        _response(output=[_final(_payload("pass", 1.0, f"{path} is legible"))])
+        for path in paths
+    ])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision()
+    grader._tool_judge.vision_perception = vision
+    rendered = []
+
+    def fake_render(op, path, **kwargs):
+        rendered.append(path)
+        return {
+            "ok": True,
+            "data": {
+                "kind": "image_png_base64",
+                "base64": "aW1hZ2U=",
+                "byte_size": 5,
+                "scope": {"page": 1},
+                "source_kind": "pdf",
+                "converted_page_count": 1,
+                "renderer": {
+                    "converter": "libreoffice",
+                    "rasterizer": "pymupdf",
+                    "libreoffice_binary": "soffice",
+                    "libreoffice_version": "LibreOffice 24.2.7.2",
+                    "pymupdf_version": "1.26.3",
+                    "dpi": 150,
+                },
+            },
+        }
+
+    monkeypatch.setattr(tool_judge_mod, "read_deliverable", fake_render)
+    deliverable_dir = tmp_path / "task"
+    deliverable_dir.mkdir()
+    targets = []
+    for index, path in enumerate(paths):
+        (deliverable_dir / path).write_bytes(b"pdf")
+        targets.append(SelectionTarget(f"target-{index}", [path], "pdf"))
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="t-split-wide",
+        task_class="separate_equivalent",
+        primary_targets=targets,
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="split_children",
+            target_ids=[target.target_id for target in targets],
+            selected_paths=paths,
+            aggregation_rule="blocking_min_else_mean",
+        ),
+    )
+    task = TaskRubric(
+        task_id="t-split-wide",
+        sector="Information",
+        occupation="Analyst",
+        prompt="Create four separate PDF reports, one per region.",
+        rubric_items=[RubricItem("style", "Overall Style", 4, None)],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+    grade = grader.grade_task(task, str(deliverable_dir))
+    item = grade.items[0]
+
+    assert item.target_scope == "split_children"
+    assert item.routing_modality == "visual"
+    assert item.verdict != "judge_error"
+    assert item.score_excluded is False
+    assert sorted(rendered) == sorted(paths)
+    assert [entry["path"] for entry in item.visual_provenance] == sorted(paths)
+    assert len(item.child_grades) == 4
+    assert not any(
+        child["verdict"] == "judge_error" for child in item.child_grades
+    )
+
+
+def test_split_children_union_over_the_file_cap_fails_before_render(
+    monkeypatch, tmp_path
+):
+    """Past the cap the item still fails closed, and before any render.
+
+    The runtime and the preflight have to agree here or a cohort would be
+    told a plan the grader will not run. The preflight half of that pair
+    lives in ``tests/test_grader_preflight.py``.
+    """
+    from core.rubric_loader import RubricItem, TaskRubric
+    from core.deliverable_selector import (
+        CriterionTargetPlan,
+        DeliverableSelection,
+        SelectionTarget,
+    )
+    from core.grader import Grader
+    import core.tool_calling_judge as tool_judge_mod
+
+    paths = [f"report-{index}.pdf" for index in range(11)]
+    responses = ScriptedResponses([])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision()
+    grader._tool_judge.vision_perception = vision
+    monkeypatch.setattr(
+        tool_judge_mod,
+        "read_deliverable",
+        lambda *args, **kwargs: pytest.fail("cap must precede render"),
+    )
+    deliverable_dir = tmp_path / "task"
+    deliverable_dir.mkdir()
+    targets = []
+    for index, path in enumerate(paths):
+        (deliverable_dir / path).write_bytes(b"pdf")
+        targets.append(SelectionTarget(f"target-{index}", [path], "pdf"))
+    selection = DeliverableSelection(
+        selection_status="ok",
+        task_id="t-split-over-cap",
+        task_class="separate_equivalent",
+        primary_targets=targets,
+    )
+    monkeypatch.setattr(Grader, "_select_deliverables", lambda *args: selection)
+    monkeypatch.setattr(
+        "core.grader.plan_targets_for_criterion",
+        lambda *args: CriterionTargetPlan(
+            target_scope="split_children",
+            target_ids=[target.target_id for target in targets],
+            selected_paths=paths,
+            aggregation_rule="blocking_min_else_mean",
+        ),
+    )
+    task = TaskRubric(
+        task_id="t-split-over-cap",
+        sector="Information",
+        occupation="Analyst",
+        prompt="Create eleven separate PDF reports, one per region.",
+        rubric_items=[RubricItem("style", "Overall Style", 4, None)],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+    grade = grader.grade_task(task, str(deliverable_dir))
+    item = grade.items[0]
+
+    assert item.verdict == "judge_error"
+    assert item.score_excluded is True
+    assert item.evidence == "required_visual_file_cap_exceeded:planned=11,cap=10"
+    assert item.render_call_count == 0
+    assert item.perception_call_count == 0
+    assert vision.calls == []
+    assert responses.calls == []
+
+
 @pytest.mark.parametrize(
     ("second_name", "vision_cap", "expected_error"),
     [

--- a/batch-runner/tests/test_grading_config.py
+++ b/batch-runner/tests/test_grading_config.py
@@ -156,6 +156,51 @@ def test_reasoning_efforts_reject_null_and_unknown_values(
         validate_grading_config(cfg)
 
 
+@pytest.mark.parametrize("bad", [0, -1, 2.5, "3", True])
+def test_visual_file_cap_rejects_a_value_that_is_not_a_positive_int(
+    tmp_path, bad
+):
+    """A bad cap has to be a config error, not a mid-run judge_error.
+
+    Grading is dispatched in paid shards, so a cap that only fails once the
+    first visual item is reached would burn a run to report a typo.
+    """
+    cfg = _valid_config(tmp_path)
+    cfg["judge"]["perception"] = {
+        "visual": {"model": "gpt-5.6-sol", "file_cap_per_item": bad},
+    }
+
+    with pytest.raises(ValueError, match="file_cap_per_item"):
+        validate_grading_config(cfg)
+
+
+@pytest.mark.parametrize("good", [1, 3, 10, 25])
+def test_visual_file_cap_accepts_a_positive_int(tmp_path, good):
+    cfg = _valid_config(tmp_path)
+    cfg["judge"]["perception"] = {
+        "visual": {"model": "gpt-5.6-sol", "file_cap_per_item": good},
+    }
+
+    validate_grading_config(cfg)
+
+
+def test_shipped_configs_leave_the_visual_file_cap_at_the_default(tmp_path):
+    """No shipped config sets the cap, so none of their hashes moved.
+
+    ``config_hash`` is part of a grade's identity. Setting the cap explicitly
+    in the archived, regrade, or validation configs would have changed those
+    hashes and broken comparability with runs already published under them,
+    so the raised default lives in code and lands in provenance instead.
+    """
+    for path in sorted(Path("grading_configs").glob("*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        visual = (
+            ((data.get("judge") or {}).get("perception") or {}).get("visual")
+            or {}
+        )
+        assert "file_cap_per_item" not in visual, path.name
+
+
 def test_grade_workflow_defaults_to_v2_sol_max():
     workflow = yaml.safe_load(
         Path("../.github/workflows/grade-run.yml").read_text(encoding="utf-8")

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -1530,6 +1530,49 @@ def test_exit_2_when_no_inference_results(monkeypatch, tmp_path):
     assert s8.main() == 2
 
 
+def test_grade_file_records_the_visual_file_cap_it_graded_under(
+    monkeypatch, tmp_path
+):
+    """The resolved cap, not the configured one.
+
+    A config that omits ``file_cap_per_item`` still grades under a cap. If
+    provenance only carried the perception block verbatim, a reader comparing
+    two runs would have to infer the cap from whichever revision of the code
+    happened to produce each grade file.
+    """
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+
+    monkeypatch.setattr("sys.argv", ["step8_grade.py", "exp998_smoke_baseline_sample", "--config", "grading_configs/default.yaml", "--force"])
+    assert s8.main() == 0
+
+    out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["judge"]["visual_file_cap"] == 10
+
+
+def test_grade_file_records_a_configured_visual_file_cap(monkeypatch, tmp_path):
+    _setup_workspace(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "grading_configs" / "default.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["judge"]["perception"] = {
+        "visual": {"model": "gpt-5.4", "file_cap_per_item": 4}
+    }
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+
+    monkeypatch.setattr("sys.argv", ["step8_grade.py", "exp998_smoke_baseline_sample", "--config", "grading_configs/default.yaml", "--force"])
+    assert s8.main() == 0
+
+    out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["judge"]["visual_file_cap"] == 4
+
+
 def test_inference_model_resolved_from_inf_results_when_present(monkeypatch, tmp_path):
     """inf_results['model'] takes priority when populated."""
     _setup_workspace(tmp_path)

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -14,7 +14,11 @@ from typing import Any
 import pytest
 
 from core.rubric_loader import RubricItem, TaskRubric
-from core.tool_calling_judge import ToolCallingJudge, ToolCallingResult
+from core.tool_calling_judge import (
+    ToolCallingJudge,
+    ToolCallingResult,
+    resolve_visual_file_cap,
+)
 
 
 PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "grader_judge_v2.md"
@@ -1622,7 +1626,7 @@ def test_visual_file_cap_fails_before_render_vision_or_main(
     deliverable_dir, task_and_item, monkeypatch
 ):
     task, _ = task_and_item
-    names = ["a.png", "b.png", "c.png", "d.png"]
+    names = [f"{chr(ord('a') + index)}.png" for index in range(11)]
     for name in names:
         (deliverable_dir / name).write_bytes(b"source")
     monkeypatch.setattr(
@@ -1648,7 +1652,7 @@ def test_visual_file_cap_fails_before_render_vision_or_main(
 
     assert result.verdict == "judge_error"
     assert result.judge_error == (
-        "required_visual_file_cap_exceeded:planned=4,cap=3"
+        "required_visual_file_cap_exceeded:planned=11,cap=10"
     )
     assert result.score_excluded is True
     assert result.render_call_count == 0
@@ -1656,6 +1660,78 @@ def test_visual_file_cap_fails_before_render_vision_or_main(
     assert result.main_api_call_count == 0
     assert vision.calls == []
     assert client.responses.calls == []
+
+
+def test_visual_file_cap_comes_from_the_grading_config(
+    deliverable_dir, task_and_item, monkeypatch
+):
+    """The cap in force is a config value, and it is the one enforced.
+
+    It used to be a constant in this module, which meant a run's grade file
+    recorded no trace of the cap it graded under. A judge constructed with a
+    different cap has to actually use it, or the value in provenance is
+    decoration.
+    """
+    task, _ = task_and_item
+    names = ["a.png", "b.png", "c.png", "d.png"]
+    for name in names:
+        (deliverable_dir / name).write_bytes(b"source")
+    monkeypatch.setattr(
+        tool_calling_judge_module,
+        "read_deliverable",
+        lambda *args, **kwargs: pytest.fail("render must not start"),
+    )
+    judge = ToolCallingJudge(
+        client=FakeClient(ScriptedResponses([])),
+        model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE,
+        vision_perception=StubVision(remaining_calls=5),
+        visual_file_cap=3,
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=RubricItem("r-file-cap", "Overall Style", 4, None),
+        deliverable_dir=str(deliverable_dir),
+        file_names=names,
+    )
+
+    assert result.judge_error == (
+        "required_visual_file_cap_exceeded:planned=4,cap=3"
+    )
+
+
+@pytest.mark.parametrize(
+    "visual, expected",
+    [
+        ({}, 10),
+        ({"model": "gpt-5.4"}, 10),
+        # ``file_cap_per_item:`` with nothing after it is how YAML spells a key
+        # someone started and did not finish. It reads back as None, which is
+        # indistinguishable from the key being absent, so it takes the default
+        # rather than failing a dispatch over a blank line.
+        ({"file_cap_per_item": None}, 10),
+        ({"file_cap_per_item": 3}, 3),
+        ({"file_cap_per_item": 25}, 25),
+    ],
+)
+def test_resolve_visual_file_cap_reads_the_perception_block(visual, expected):
+    assert resolve_visual_file_cap({"perception": {"visual": visual}}) == expected
+
+
+@pytest.mark.parametrize("judge_config", [{}, {"perception": {}}, {"perception": {"visual": {}}}])
+def test_resolve_visual_file_cap_tolerates_a_missing_perception_block(judge_config):
+    assert resolve_visual_file_cap(judge_config) == 10
+
+
+@pytest.mark.parametrize("bad", [0, -1, 2.5, "3", True])
+def test_resolve_visual_file_cap_rejects_a_cap_that_is_not_a_positive_int(bad):
+    # True is here on purpose: bool is an int subclass, so an unguarded check
+    # would resolve ``file_cap_per_item: true`` to a cap of one file.
+    with pytest.raises(ValueError, match="file_cap_per_item"):
+        resolve_visual_file_cap(
+            {"perception": {"visual": {"file_cap_per_item": bad}}}
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

`_VISUAL_FILE_CAP = 3` bounded how many files one visual rubric item may
render and perceive. It is now `judge.perception.visual.file_cap_per_item`,
default **10**, and the resolved value is written to `judge.visual_file_cap`
in every new grade payload.

- A cap that is not a positive integer is rejected by
  `validate_grading_config`, so a typo fails at dispatch rather than partway
  through a paid shard.
- An absent key *and* an explicitly null one both take the default. `key:`
  with nothing after it is an unfinished YAML line, not a policy statement.
- `validate_planned_visual_names` now takes `cap` as a **required** argument,
  so a missed call site is a `TypeError` rather than a silently wrong cap.

## Why

3 was below the size of an ordinary multi-deliverable submission. On R1 it
failed three rubric items closed on tasks where nothing was over budget and
nothing was unrenderable — the items simply spanned four or more files.

Truncating to the first *N* files alphabetically was considered and rejected:
on all three of those items the un-rendered files were exactly the ones that
could change the verdict (e.g. a 3-of-5 sample passing a logo criterion whose
4th and 5th reports carry no logo). A truncated pass would have been less
honest than the refusal.

Cost: **+20 vision calls, 3.48% of R1's 575.** Projected per-task maximum
stays at 68 against `call_cap_per_task: 72`, so the task budget is still not
the binding constraint.

## The `split_children` union check is kept, not removed

The task this PR implements also asked to remove the union cap check in
`Grader._runtime_criterion_plan` as a duplicate. **That premise does not
hold, and the check is kept.** Three reasons, in order of how much they cost
if ignored:

1. **The union really is one batched operation.** `_judge_split_children`
   calls `preflight_visual(..., file_names=list(runtime_plan.visual_paths))`
   — the entire union goes into a single prepass that renders and perceives
   every path in it. The cap binds on the union for the same reason it binds
   on a bundle.
2. **Removing it is not behaviour-neutral.** `supported_visual_call_count`
   is `len(visual_paths)` only when the preflight error is `None`. Without
   the early-out, an over-cap item books its whole union into the task visual
   budget and can trip `task_visual_budget_exceeded`, failing the task's
   *other* items too.
3. **It would desync the preflight from the runtime.** `grader_preflight`
   mirrors this check; dropping it there means the model-free preflight
   promises a plan the grader will not run, which is the one thing a
   preflight exists to prevent.

Raising the cap on its own is what makes the affected R1 items grade, so the
intended outcome is delivered without the removal.

## Identity impact

- **`grader_source_hash` moves.** This edits `core/tool_calling_judge.py`,
  `core/grader.py`, `core/grader_preflight.py`, `step8_grade.py`, and
  `schemas/grade.schema.json`, all of which are hashed. Grades written before
  and after are not the same grader identity, and a resume or shard merge
  across the boundary is refused by the existing checks — as intended.
- **`config_hash` does not move.** No shipped config sets the new key, so the
  archived, regrade, and validation configs stay byte-identical and runs
  already published under them keep their identity.
  `test_shipped_configs_leave_the_visual_file_cap_at_the_default` pins that.
- `judge.visual_file_cap` is **optional** in the grade schema. Payloads
  written before this change do not carry it; for those the cap was 3.
- Scores are comparable within one `grader_source_hash`, not across this one:
  an item that scored `judge_error` under the cap of 3 may now carry a real
  verdict, which moves both the numerator and the denominator of its task.

No paid run is dispatched by this PR. Nothing was in flight when it was
opened, so the source-hash freeze does not apply.

## Tests

Full local suite: **3512 passed, 6 skipped, 45 deselected**.

New coverage:

| file | what it pins |
|---|---|
| `test_tool_calling_judge.py` | `resolve_visual_file_cap` across absent / null / valid / invalid, including `True` (bool is an int subclass); a judge built with `visual_file_cap=3` actually enforces 3 |
| `test_grading_config.py` | dispatch-time rejection of a bad cap; acceptance of valid ones; no shipped config sets the key |
| `test_grader_preflight.py` | a 10-file bundle now plans 10 renders; the configured cap is the one planned under; `split_children` across 4 children now plans instead of failing; both the union and a single over-cap child still fail closed |
| `test_grader_selector_integration.py` | end-to-end: 4 one-file children all render and all get a real verdict; an 11-file union fails before any render, vision, or main call |
| `test_step8_grade.py` | the grade file records the resolved cap, default and configured |

`grading_configs/README.md` gains a **Visual file cap per rubric item**
section covering the setting, why the default moved, where it applies, and
the `grader_source_hash` / `config_hash` split above.

## Known non-blocker

`mypy core/` gains one error, `Item "None" of "Any | None" has no attribute
"visual_file_cap"`, joining six pre-existing errors of the same family on the
same optional in the same method. The root cause is that
`_build_tool_calling_judge` has no return annotation; narrowing it is a
separate change and is not attempted inside a hashed grading path here. The
repository baseline is 182 mypy errors and mypy is not a CI gate.
