### PR TITLE
ci(deploy): move the Pages workflow off Node 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,7 +110,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -122,9 +122,9 @@ jobs:
           [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]]
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -187,7 +187,7 @@ jobs:
           && (github.event_name == 'push'
               || (github.event_name == 'workflow_dispatch'
                   && inputs.deploy_pages == true))
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./dist
 
@@ -208,4 +208,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## What

`deploy.yml` was the last workflow still pinned to the Node 20 action majors. #58 bumped the other eleven call sites; this one was held back because merging it republishes the live dashboard, and that needed its own decision. That decision is made, so this closes the gap.

| action | before | after | runtime |
|---|---|---|---|
| `actions/checkout` | v4 | **v5.1.0** | node24 |
| `actions/setup-node` | v4 | **v7.0.0** | node24 |
| `actions/upload-pages-artifact` | v3 | **v5.0.0** | composite |
| `actions/deploy-pages` | v4 | **v5.0.0** | node24 |

Plus `node-version: 20` → `24`.

The checkout SHA is the one the other eleven call sites already use, so this aligns `deploy.yml` with the repo rather than adding a new pin. `upload-pages-artifact@v5.0.0` is a composite that pins its nested `actions/upload-artifact` at v7.0.0 (node24) by SHA, which closes the one floating `@v4` reference that was left in the Pages path.

## Why 24 and not 22

Nothing in the build constrains the version: there is no `.nvmrc`, `.node-version`, `.tool-versions`, or `engines` field. Both pinned toolchain packages accept it — vite 5.4.21 wants `^18.0.0 || >=20.0.0`, playwright 1.61.1 wants `>=18`. 24 is active LTS and matches what the four actions run on, so the action runtime and the build runtime stay the same number.

## The one breaking change that could have reached us

`upload-pages-artifact` v4.0.0 stopped including hidden files in the tarball by default. Checked before assuming it was harmless:

- `find public -name ".*"` → nothing
- `vite.config.ts` sets only `base`; no `manifest`, no custom `outDir`
- a local `npm ci && npm run build` produced `dist/` = `404.html assets/ generated/ index.html social-preview.png`, and `find dist -name ".*"` → nothing

So `include-hidden-files` stays at its default `false`.

## What is deliberately not in this PR

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` (L85) stays. Removing it would be the opposite of removing Node 20 — it is the flag that has been forcing these actions *off* Node 20 while they were still on the old majors. `batch-run.yml` sets it too, and dropping it from only one of the two would leave the pair inconsistent for no gain.

## Verification

Validation-only dispatch on this branch, before opening the PR — [run 32663153695](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/32663153695):

```
✓ validate in 1m46s
  ✓ Verify non-PR event contract      ✓ Verify aggregate contracts and pinned history
  ✓ Checkout                          ✓ Install Chromium headless shell
  ✓ Verify exact checkout             ✓ Verify Field Notes in browser
  ✓ Setup Node                        ✓ Verify dashboard build provenance in browser
  ✓ Install dependencies              ✓ Verify clean working tree
  ✓ Aggregate test data               - Upload Pages artifact   (correctly skipped)
  ✓ Verify generated files          - deploy                    (correctly skipped)
  ✓ Build
```

`Setup Node` resolved `node: v24.19.0`, and the whole aggregate → build → Playwright chain passed on it. The artifact upload and the `deploy` job skipped as they should for `deploy_pages=false`.

## Merge effect

`.github/workflows/deploy.yml` is in `deploy.yml`'s own `push: main` path list, so merging this triggers a real deploy and republishes the public dashboard. That is expected and approved. The site will be checked after the deploy run finishes.
