### PR TITLE
fix(grading): retry the grade pushes a shard race rejects

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -891,24 +891,44 @@ jobs:
             MSG="$MSG [shard $GRADE_SHARD_INDEX of $GRADE_SHARD_COUNT]"
           fi
           git commit -m "$MSG"
-          git pull --rebase origin "${GITHUB_REF_NAME}"
-          if [[ ! -f "$GRADE_FILE" ]]; then
-            echo "::error::grade file disappeared after rebase: $GRADE_FILE"
-            exit 1
-          fi
-          POST_REBASE_GRADE_BLOB_SHA="$(python - "$GRADE_FILE" <<'PY'
+          # N shards push to one branch on purpose, so losing a push race is
+          # the expected case rather than a fault. Today the first rejection
+          # ends the job -- after the grading is already paid for -- and takes
+          # the auto-resume chain with it, since that step gates on
+          # committed=true. So a few seconds of contention can cost a slice.
+          #
+          # Every guard sits inside the loop, not ahead of it. Each rebase is
+          # another chance for the tree to move, and checking once and then
+          # pushing six times would be checking a tree we are no longer the
+          # one pushing. The rebase itself is deliberately not retried: `set
+          # -e` still ends the step if it conflicts, because two shards
+          # writing different bytes into one grade file is a real fault and
+          # not contention.
+          #
+          # Any push failure retries, unclassified. A permissions or network
+          # error will not recover, but it costs ~90s to establish that and
+          # the final attempt still prints git's own message. Pattern-matching
+          # git's rejection wording would be one more thing to get wrong.
+          PUSHED=false
+          for attempt in 1 2 3 4 5 6; do
+            git pull --rebase origin "${GITHUB_REF_NAME}"
+            if [[ ! -f "$GRADE_FILE" ]]; then
+              echo "::error::grade file disappeared after rebase: $GRADE_FILE"
+              exit 1
+            fi
+            POST_REBASE_GRADE_BLOB_SHA="$(python - "$GRADE_FILE" <<'PY'
           import hashlib
           import sys
           from pathlib import Path
 
           print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
           PY
-          )"
-          if [[ "$POST_REBASE_GRADE_BLOB_SHA" != "$GRADE_BLOB_SHA" ]]; then
-            echo "::error::grade file changed during rebase"
-            exit 1
-          fi
-          python - "$GRADE_FILE" <<'PY'
+            )"
+            if [[ "$POST_REBASE_GRADE_BLOB_SHA" != "$GRADE_BLOB_SHA" ]]; then
+              echo "::error::grade file changed during rebase"
+              exit 1
+            fi
+            python - "$GRADE_FILE" <<'PY'
           import json
           import os
           import sys
@@ -927,7 +947,23 @@ jobs:
           if payload.get("run_status") != os.environ["EXPECTED_GRADE_STATUS"]:
               raise SystemExit("post-rebase grade run_status does not match exit code")
           PY
-          git push
+            if git push; then
+              PUSHED=true
+              break
+            fi
+            if [[ "$attempt" -eq 6 ]]; then
+              break
+            fi
+            # Jittered, or nine shards that collided once line up to collide
+            # again on the same schedule.
+            BACKOFF=$(( attempt * 5 + RANDOM % 5 ))
+            echo "::warning::push attempt $attempt rejected; rebasing and retrying in ${BACKOFF}s"
+            sleep "$BACKOFF"
+          done
+          if [[ "$PUSHED" != "true" ]]; then
+            echo "::error::could not push the grade file to ${GITHUB_REF_NAME} after 6 attempts"
+            exit 1
+          fi
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
       - name: Auto-retrigger next chunk (time budget hit)
@@ -1080,8 +1116,27 @@ jobs:
             # pull above and this push. That is safe at the git level too: the
             # rebase drops our commit by patch-id, and even if it did not, an
             # add/add of byte-identical content resolves without conflict.
-            git pull --rebase origin "${GITHUB_REF_NAME}"
-            git push
+            # Safe, but not automatic -- the push is still rejected as
+            # non-fast-forward, and a rejection here fails the one shard that
+            # completed the corpus. So rebase and try again.
+            MERGE_PUSHED=false
+            for attempt in 1 2 3 4 5 6; do
+              git pull --rebase origin "${GITHUB_REF_NAME}"
+              if git push; then
+                MERGE_PUSHED=true
+                break
+              fi
+              if [[ "$attempt" -eq 6 ]]; then
+                break
+              fi
+              BACKOFF=$(( attempt * 5 + RANDOM % 5 ))
+              echo "::warning::merge push attempt $attempt rejected; rebasing and retrying in ${BACKOFF}s"
+              sleep "$BACKOFF"
+            done
+            if [[ "$MERGE_PUSHED" != "true" ]]; then
+              echo "::error::could not push the merged grade to ${GITHUB_REF_NAME} after 6 attempts"
+              exit 1
+            fi
           fi
           echo "merged=true" >> "$GITHUB_OUTPUT"
           echo "grade_file=$FINAL_FILE" >> "$GITHUB_OUTPUT"
@@ -1138,8 +1193,26 @@ jobs:
             exit 0
           fi
           git commit -m "docs(grading): auto-analysis for $GRADE_EXPERIMENT_YAML ($GRADE_CONFIG)"
-          git pull --rebase origin "${GITHUB_REF_NAME}"
-          git push
+          # Same race as the grade and merge pushes above. This one runs last,
+          # so it is the most likely to find the branch moved under it.
+          ANALYSIS_PUSHED=false
+          for attempt in 1 2 3 4 5 6; do
+            git pull --rebase origin "${GITHUB_REF_NAME}"
+            if git push; then
+              ANALYSIS_PUSHED=true
+              break
+            fi
+            if [[ "$attempt" -eq 6 ]]; then
+              break
+            fi
+            BACKOFF=$(( attempt * 5 + RANDOM % 5 ))
+            echo "::warning::analysis push attempt $attempt rejected; rebasing and retrying in ${BACKOFF}s"
+            sleep "$BACKOFF"
+          done
+          if [[ "$ANALYSIS_PUSHED" != "true" ]]; then
+            echo "::error::could not push the analysis to ${GITHUB_REF_NAME} after 6 attempts"
+            exit 1
+          fi
 
       - name: Upload grade artifact
         if: always() && inputs.dry_run == false && steps.grade.outputs.grade_file != ''

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -3255,6 +3255,99 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
     assert '--revision "${{ inputs.inference_revision }}"' not in workflow
 
 
+def _retry_loop_body(script: str) -> str:
+    """Return the text between ``for attempt ...; do`` and its matching ``done``.
+
+    Slicing on the loop rather than searching the whole script is the point:
+    a guard that sits above the loop runs once and then the job pushes up to
+    six times against trees it never looked at.
+    """
+    header = "for attempt in 1 2 3 4 5 6; do"
+    start = script.index(header)
+    indent = " " * (start - script.rindex("\n", 0, start) - 1)
+    return script[start : script.index(f"\n{indent}done\n", start)]
+
+
+def test_every_grade_push_retries_instead_of_dying_on_a_shard_race():
+    """Nine shards push to one branch on purpose, so a rejection is traffic.
+
+    Before the loop, the first rejection ended the job -- after the grading
+    was already paid for -- and the auto-resume step gates on committed=true,
+    so a multi-chunk shard stopped handing off as well. A few seconds of
+    contention could cost a slice.
+
+    What the loop must not do is turn a genuine disagreement into a retry.
+    Two shards writing different bytes into one grade file conflict on
+    rebase, and that stays fatal: only the push is retried, and the rebase
+    runs bare so ``set -e`` still ends the step.
+    """
+    text = Path("../.github/workflows/grade-run.yml").read_text(encoding="utf-8")
+    steps = {
+        step["name"]: step
+        for step in yaml.safe_load(text)["jobs"]["grade"]["steps"]
+        if step.get("name")
+    }
+    pull = 'git pull --rebase origin "${GITHUB_REF_NAME}"'
+    sites = {
+        "Commit grade result": "could not push the grade file",
+        "Merge shards into the final grade": "could not push the merged grade",
+        "Commit analysis": "could not push the analysis",
+    }
+
+    for name, exhausted in sites.items():
+        script = steps[name]["run"]
+        body = _retry_loop_body(script)
+
+        # Rebase then push, both inside the loop. A pull left outside it
+        # would retry the same rejected push six times.
+        assert pull in body, name
+        assert "if git push; then" in body, name
+        assert body.index(pull) < body.index("if git push; then"), name
+
+        # Bare, so a conflicting rebase still ends the step.
+        assert f"{pull} ||" not in script, name
+        assert "rebase --abort" not in script, name
+
+        # Nine shards that collide once will collide again on the same
+        # schedule unless the wait is jittered.
+        assert "RANDOM" in body, name
+        assert "::warning::" in body, name
+
+        # Exhausting the attempts is a failure, not a quiet success.
+        assert f"::error::{exhausted}" in script, name
+        assert script.index("done\n") < script.index(f"::error::{exhausted}"), name
+
+    # The grade file is the one that carries paid work, so its post-rebase
+    # guards -- the blob it committed is still the blob it is pushing, and
+    # that blob still satisfies the schema -- belong to each attempt.
+    commit = _retry_loop_body(steps["Commit grade result"]["run"])
+    assert '[[ "$POST_REBASE_GRADE_BLOB_SHA" != "$GRADE_BLOB_SHA" ]]' in commit
+    assert "validate_grade_payload(payload, schema)" in commit
+    assert commit.index(pull) < commit.index("$POST_REBASE_GRADE_BLOB_SHA")
+    assert commit.index("validate_grade_payload(payload, schema)") < commit.index(
+        "if git push; then"
+    )
+
+    # committed=true drives the auto-resume dispatch. Emitting it on a push
+    # that never landed would hand the next chunk a branch without its
+    # predecessor's partial on it.
+    grade_script = steps["Commit grade result"]["run"]
+    assert grade_script.index('if [[ "$PUSHED" != "true" ]]') < grade_script.index(
+        'echo "committed=true"'
+    )
+
+    # Nothing here may overwrite a sibling's work to get its own push through.
+    # Scoped to the push lines: bare --force is step8_grade.py's own CLI flag
+    # and appears legitimately elsewhere in this file.
+    push_lines = [line.strip() for line in text.splitlines() if "git push" in line]
+    assert len(push_lines) == len(sites)
+    for line in push_lines:
+        assert "--force" not in line, line
+        assert " -f " not in line, line
+    for forbidden in ("--force-with-lease", "--no-verify"):
+        assert forbidden not in text, forbidden
+
+
 def test_grade_checkout_stays_on_the_major_that_writes_extraheader_to_git_config():
     """The credentialed checkout and the extraheader guard have to move together.
 


### PR DESCRIPTION
## The race

Nine shards push grade files to one branch on purpose — the concurrency key
includes `shard_index` but not `shard_count`, so siblings run at the same time
by design. A sibling landing between `git pull --rebase` and `git push` is
ordinary traffic.

Until now the first rejection ended the job — **after the grading had already
been paid for**. It also killed the auto-resume chain, which gates on
`steps.commit_grade.outputs.committed == 'true'`, so a multi-chunk shard
stopped handing off as well. Seconds of contention could cost a slice.

## The change

All three pushes in the `grade` job — `Commit grade result`,
`Merge shards into the final grade`, and `Commit analysis` — now rebase and
retry up to six times with a jittered backoff (`attempt * 5 + RANDOM % 5`
seconds). Without the jitter, shards that collide once line up to collide
again on the same schedule. Exhausting the attempts is a loud failure, not a
quiet success.

Two things the loop deliberately does **not** do:

- **It does not retry the rebase.** `set -e` still ends the step when the
  rebase conflicts, because two shards writing different bytes into one grade
  file is a real disagreement, not contention.
- **It does not classify the failure.** A permissions or network error will
  not recover, but it costs ~90s to establish that and the final attempt still
  prints git's own message. Pattern-matching git's rejection wording would be
  one more thing to get wrong.

Every guard moved *inside* the loop rather than staying above it — the
post-rebase blob check and the schema revalidation both re-run on each
attempt, since each rebase is another chance for the tree to move — and
`committed=true` is emitted only after a push that actually landed.

## `grader_source_hash` is unaffected

`compute_grader_source_hash()` hashes `step8_grade.py`, `core/**/*.py`, the
grade schema, `requirements.txt`, the HF download script, the prompt templates
and the config file. `grade-run.yml` is not in that set, and neither are
`tests/`. Grades from before and after this change stay directly comparable —
no regrade is implied.

## Verification

The workflow's `run:` scripts were extracted and driven against real git
remotes using a real 2 MB shard partial (`shard-001-of-009.json`,
`run_status: partial`, 25 tasks):

| scenario | result |
|---|---|
| push loses twice, lands on attempt 3 | rc=0, 21s, `committed=true`, file on origin **byte-identical** to the source shard |
| sibling writes different bytes to the same grade file | rc=1 on attempt 1, `CONFLICT (add/add)`, no `committed=true`, nothing pushed |
| every push loses | 6 attempts, 89s, backoffs 5/11/18/22/29s, `::error::could not push the grade file …`, rc=1, no `committed=true` |

Also:

- YAML parses; **every** `run:` script in the workflow passes `bash -n` with
  empty stderr — this is what proves the heredoc-inside-a-loop indentation is
  right, since YAML strips the block's common indent and a terminator that
  drifts two spaces silently breaks the heredoc.
- Four mutations of the new test each fail it: hoisting the rebase out of the
  loop, adding `push --force`, dropping one site's exhaustion `::error::`, and
  appending `|| true` to the rebase.
- Full local backend suite: **3513 passed, 6 skipped, 45 deselected** — the
  3512 baseline plus the one new test.

## Not in scope

No paid model call, no grading dispatch, no regrade. No grading shards were in
flight when this branch was cut (`gh run list` — nothing non-completed).
