### PR TITLE
fix(ci): gate the grading image publish on an environment, not ref_protected

### DIFF
--- a/.github/workflows/build-grading-image.yml
+++ b/.github/workflows/build-grading-image.yml
@@ -13,6 +13,19 @@
 #   sandbox/grading.Dockerfile asserts the renderer version, font resolution,
 #   git, and az in its own RUN steps, so a build that succeeds has already
 #   proven the acceptance criteria. The steps below only surface the evidence.
+#
+# WHAT GATES THE PUBLISH
+#   The grading-image-publish environment: required reviewer, and a deployment
+#   branch policy that names main and nothing else. Both are enforced by
+#   GitHub before the job starts, so a dispatch from any other ref cannot
+#   reach a runner at all.
+#
+#   This job used to gate on github.ref_protected instead. That read as a
+#   stronger control than it was: main carries no branch protection here on
+#   purpose, because grade-run.yml pushes grade files straight to it from up
+#   to nine concurrent shards. So the condition was never true and the job
+#   silently skipped every time. An environment gates this one publish
+#   without touching how anything else merges or pushes.
 name: Build Grading Image
 
 on:
@@ -104,14 +117,18 @@ jobs:
       ${{
         github.event_name == 'workflow_dispatch' &&
         inputs.publish == true &&
-        github.ref == 'refs/heads/main' &&
-        github.ref_protected == true
+        github.ref == 'refs/heads/main'
       }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
       contents: read
       packages: write
+    # Holds the run until a reviewer approves it, and refuses to start at all
+    # on any ref but main. packages: write lives only on this job, so the
+    # approval and the credential that can write to GHCR are the same gate.
+    environment:
+      name: grading-image-publish
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -119,11 +136,10 @@ jobs:
           persist-credentials: false
           ref: ${{ github.sha }}
 
-      - name: Verify protected main checkout
+      - name: Verify main checkout
         run: |
           set -euo pipefail
           test "$GITHUB_REF" = "refs/heads/main"
-          test "$GITHUB_REF_PROTECTED" = "true"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - name: Set up Docker Buildx

--- a/batch-runner/tests/test_grading_image.py
+++ b/batch-runner/tests/test_grading_image.py
@@ -172,7 +172,6 @@ def test_publish_is_gated_and_pinned_by_digest_not_by_tag():
     for guard in (
         "inputs.publish == true",
         "github.ref == 'refs/heads/main'",
-        "github.ref_protected == true",
     ):
         assert guard in publish["if"]
 
@@ -186,6 +185,56 @@ def test_publish_is_gated_and_pinned_by_digest_not_by_tag():
     # never changed, which is the whole failure this image exists to remove.
     assert ":latest" not in tags
     assert "${{ github.sha }}" in tags
+
+
+def test_publish_is_gated_by_an_environment_that_only_main_can_reach():
+    """The approval gate is the environment, so the wiring has to hold.
+
+    This job used to gate on ``github.ref_protected``. main carries no branch
+    protection here on purpose -- grade-run.yml pushes grade files straight to
+    it from up to nine concurrent shards -- so that condition was never true
+    and the job skipped silently on every dispatch. Silently is the problem:
+    the run went green having published nothing.
+
+    grading-image-publish replaces it with a required reviewer and a
+    deployment branch policy naming main and nothing else, both enforced
+    before a runner is handed out. That is a repository setting this file
+    cannot read, so what it locks instead is the half that lives in the repo:
+    the job still asks for the environment, still refuses any ref but main,
+    and is still the only job holding the credential that can write to GHCR.
+    """
+    workflow = _workflow(BUILD_WORKFLOW_PATH)
+    publish = workflow["jobs"]["publish-grading-image"]
+
+    assert publish["environment"] == {"name": "grading-image-publish"}
+
+    # Dropping the environment while keeping the conditions would publish on
+    # dispatch with no human in the loop, which is exactly what the owner
+    # declined when they declined relaxing the guard outright.
+    condition = " ".join(publish["if"].split())
+    assert "github.event_name == 'workflow_dispatch'" in condition
+    assert "inputs.publish == true" in condition
+    assert "github.ref == 'refs/heads/main'" in condition
+
+    # The environment's branch policy enforces main, and so does the job. Both
+    # only because a branch policy is edited in a settings page nobody reviews
+    # in a diff; the condition is the copy that travels with the code.
+    assert "github.ref_protected" not in condition
+    verify_checkout = next(
+        step for step in publish["steps"] if step.get("name") == "Verify main checkout"
+    )
+    assert 'test "$GITHUB_REF" = "refs/heads/main"' in verify_checkout["run"]
+    assert "GITHUB_REF_PROTECTED" not in verify_checkout["run"]
+
+    # packages: write belongs to the approved job alone. Granting it at the
+    # top level, or to the unapproved verify job, would hand the token that
+    # can push to a public registry to a run nobody approved.
+    assert workflow["permissions"] == {"contents": "read"}
+    for name, job in workflow["jobs"].items():
+        has_packages = "packages" in (job.get("permissions") or {})
+        assert has_packages == (name == "publish-grading-image"), name
+        if name != "publish-grading-image":
+            assert "environment" not in job, name
 
 
 def test_every_action_in_the_build_workflow_is_sha_pinned():


### PR DESCRIPTION
## What was broken

`publish-grading-image` required `github.ref_protected == true`. **`main` carries
no branch protection in this repository on purpose** — `grade-run.yml` pushes
grade files straight to it from up to nine concurrent shards. So the condition
was never true.

A dispatch with `publish: true` (run `32662637685`) completed in 12 seconds
with **both jobs skipped and nothing published** — and reported success while
doing it. That is the worst property here: the gate did not hold the run back,
it made the run a no-op that looked fine.

## Why not the two obvious repairs

- **Enable branch protection on `main`** — changes how every future PR merges,
  for a property only this one job wanted, and would sit directly on top of the
  nine-shard push path.
- **Delete the condition** — leaves a publish to a *public* registry behind
  nothing but a dispatch, and deletes the exact control that distinguishes this
  credential-carrying image from the sandbox image.

## What this does instead

The gate moves rather than disappearing. A new **`grading-image-publish`**
environment carries a required reviewer and a deployment branch policy naming
`main` and nothing else. Both are enforced by GitHub *before a runner is handed
out*, so a dispatch from any other ref cannot reach a runner at all.

`workflow_dispatch`, `inputs.publish == true` and `refs/heads/main` are
unchanged. Nothing about how anything else merges or pushes changes.

This follows the existing house pattern: the paid `grade-run.yml` job is gated
by the `grading` environment with the same shape.

### Environment settings, read back from the API after creation

| setting | value |
|---|---|
| required reviewer | `hyeonsangjeon` (User) |
| self-review | allowed (`prevent_self_review: false`) |
| deployment branch policy | custom, single entry: `main` (branch) |
| secrets | 0 |
| variables | 0 |
| `main` branch protection | still `false` — unchanged |

### One removal worth naming

The job's own `test "$GITHUB_REF_PROTECTED" = "true"` line also goes. It is the
same retired condition restated at a second site; leaving it would let the job
clear the environment approval and then fail on a property the repository
deliberately does not have. The `GITHUB_REF` and `HEAD == GITHUB_SHA`
assertions stay.

## What the tests lock

The environment's own settings live in repository configuration and cannot be
read from a test. What `test_grading_image.py` locks is the half that lives in
the repo:

- the job asks for `grading-image-publish` by name
- it still refuses any ref but `main`, in the `if` *and* at runtime
- it no longer mentions `ref_protected`
- `packages: write` exists on this job and nowhere else — not at the top level,
  not on the unapproved `verify-grading-image` job

Six mutations each fail the test: dropping the environment, dropping either
condition, hoisting `packages: write` to the top level, granting it to the
verify job, and restoring the dead runtime check.

Local suite: **3514 passed, 6 skipped, 45 deselected**.

## Out of scope, but found while here

Two sibling workflows gate on `ref_protected` and are dead in exactly the same
way:

- `build-sandbox-image.yml` — its publish job has **never fired**; every run in
  its history is the `pull_request` verify job.
- `agentic-sandbox-preflight.yml` — **zero runs, ever**. Dispatch-only and
  gated the same way, so any dispatch would have skipped.

Neither is touched here. Flagged for a separate decision.

## Not in scope

No paid model call, no grading dispatch, no regrade. `grade-run.yml` is
untouched, so `grader_source_hash` does not move and published grades stay
comparable.
