### PR TITLE
ci(grading): run both grade jobs in the pinned grading image

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -337,10 +337,48 @@ jobs:
             "  resume_chunk=$GRADE_RESUME_CHUNK" \
             "  shard=$GRADE_SHARD_INDEX/$GRADE_SHARD_COUNT"
 
+  # ---------------------------------------------------------------------------
+  # Both grading jobs run inside the purpose-built grading image rather than on
+  # the bare hosted runner. On formatting criteria the renderer *is* the
+  # evidence, so whichever LibreOffice an Ubuntu mirror happened to serve that
+  # morning used to decide what a score meant. The image fixes it at the build
+  # the published corpus was graded on, and is pinned by digest rather than tag
+  # because a tag can be repointed at a rebuild without this file changing.
+  #
+  #   ghcr.io/hyeonsangjeon/gdpval-grading
+  #   revision  59432d4d04dbb2fad049939444bbb8cd8cc4912a
+  #   renderer  LibreOffice 24.2.7.2 420(Build:2)
+  #
+  # No `credentials:` -- the package is public, and adding any would hand a
+  # registry token to a job that has no use for one.
+  #
+  # ImageOS is how actions/setup-python identifies the runner image. The runner
+  # exports it for its own image and not for a container, so setting it keeps
+  # the action on the same tool-cache selection path it takes on the host. LANG
+  # matches what the hosted runner exports; read_deliverable forces
+  # LC_ALL=C.UTF-8 for the renderer either way, so this only keeps Python's
+  # default encoding identical to what the corpus was graded under.
+  #
+  # What the image deliberately does not carry, and why that is safe:
+  #   gh      -- one call site, the auto-resume dispatch below. It now POSTs to
+  #              the REST endpoint that `gh workflow run` wraps, using curl,
+  #              which the image does carry.
+  #   ffprobe -- core/file_reader.py enriches .wav/.mp3/.mp4 *deliverables*
+  #              with a duration/codec line and falls back to name and size
+  #              when ffprobe is absent. Every deliverable recorded in
+  #              data/grades is .pdf/.xlsx/.pptx/.docx/.png -- 2,273 file
+  #              entries, zero media -- so nothing in the published corpus
+  #              reaches it. It is named here because that fallback is silent
+  #              and would change prompt text without moving grader_source_hash
+  #              or renderer_fingerprint. test_grading_image.py fails if any
+  #              new external binary joins the grading path.
+  # ---------------------------------------------------------------------------
   grade-dry-run:
     needs: validate-request
     if: inputs.dry_run == true
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c056e31e1ea1d693fc2f8f873da160b232926fa1b6cde75c24e5344a04
     permissions:
       contents: read
     env:
@@ -351,7 +389,19 @@ jobs:
       HF_HUB_DISABLE_IMPLICIT_TOKEN: '1'
       GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
       GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
+      ImageOS: ubuntu24
+      LANG: C.UTF-8
     steps:
+      - name: Verify grading container
+        run: |
+          set -euo pipefail
+          test -f /opt/gdpval/renderer-version.txt
+          cat /opt/gdpval/renderer-version.txt
+          for binary in soffice fc-match git curl; do
+            command -v "$binary" >/dev/null \
+              || { echo "::error::$binary is missing from the grading image"; exit 1; }
+          done
+
       - name: Checkout exact main revision (read-only)
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -399,6 +449,16 @@ jobs:
         run: |
           cd batch-runner
           pip install -r requirements.txt
+
+      # The paid job runs this only when the config needs the Office renderer.
+      # Here it is unconditional and deliberately so: a free dry run is the
+      # only place the container's renderer gets exercised before money is
+      # committed, and it costs one step to learn that the pinned digest still
+      # renders xlsx/pptx/docx to the bytes the judge expects.
+      - name: Preflight grading renderer
+        run: |
+          cd batch-runner
+          python scripts/preflight_grading_renderer.py
 
       - name: Download inference results anonymously
         run: |
@@ -453,10 +513,15 @@ jobs:
         )
       }}
     runs-on: ubuntu-24.04
+    # Same pinned grading image as grade-dry-run, for the same reason; see the
+    # block above that job. The two digests must stay identical -- a dry run
+    # against a different renderer than the paid run proves nothing.
+    container:
+      image: ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c056e31e1ea1d693fc2f8f873da160b232926fa1b6cde75c24e5344a04
     permissions:
       contents: write
       id-token: write
-      actions: write  # required for self-retrigger via gh workflow run
+      actions: write  # required for the auto-resume workflow dispatch
     env:
       GRADE_EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
       GRADE_CONFIG: ${{ inputs.grading_config }}
@@ -469,6 +534,8 @@ jobs:
       GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
       GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
       GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
+      ImageOS: ubuntu24
+      LANG: C.UTF-8
     # GH Actions hosted runners have a HARD 6h (360min) timeout that cannot be
     # extended. We set 320min so step8_grade.py's internal 4h time guard (env
     # GRADER_TIME_BUDGET_SEC=14400) trips first, partial-saves, and exits 7,
@@ -476,6 +543,19 @@ jobs:
     timeout-minutes: 320
 
     steps:
+
+      # First, so a wrong or missing image costs seconds rather than a
+      # checkout, a dependency install, and an Azure login. az is on this list
+      # and not on the dry run's because only this job logs in.
+      - name: Verify grading container
+        run: |
+          set -euo pipefail
+          test -f /opt/gdpval/renderer-version.txt
+          cat /opt/gdpval/renderer-version.txt
+          for binary in soffice fc-match git curl az; do
+            command -v "$binary" >/dev/null \
+              || { echo "::error::$binary is missing from the grading image"; exit 1; }
+          done
 
       # Held on the v5 line on purpose. checkout v6 moved persisted
       # credentials out of .git/config into a separate file referenced by an
@@ -605,101 +685,35 @@ jobs:
 
       # The renderer is a host binary, not a library: core/artifact_renderer.py
       # and core/tools/read_deliverable.py both shell out to `soffice`, so it
-      # has to exist on the runner before grading starts.
+      # has to exist before grading starts. It arrives with the container now,
+      # asserted at build time and again by Verify grading container above.
       #
-      # On 2026-08-19 that made this step the single point of failure for the
-      # 220-task run. Between 08:11 and 08:35 UTC azure.archive.ubuntu.com
-      # returned Ign: for every index, apt fell back to archive.ubuntu.com, and
-      # that connection stalled mid-transfer. apt imposes no wall-clock ceiling
-      # on itself, so five grade jobs sat here for 5h18m until timeout-minutes
-      # killed them -- taking 63 of the 220 tasks with them and reporting
-      # nothing until the job died. The same 25-minute window cost nothing to
-      # the shards that reached this step at 08:41 and 08:44, where apt
-      # completed in under two and a half minutes.
+      # It used to arrive by apt, and on 2026-08-19 that made the install step
+      # the single point of failure for the 220-task run: azure.archive.ubuntu
+      # .com returned Ign: for every index between 08:11 and 08:35 UTC, apt
+      # fell back to archive.ubuntu.com, and that connection stalled
+      # mid-transfer. apt imposes no wall-clock ceiling on itself, so five
+      # grade jobs sat there for 5h18m until timeout-minutes killed them --
+      # taking 63 of the 220 tasks with them and reporting nothing until the
+      # job died. Timeouts and a retry loop were added afterwards; they turned
+      # a silent five-hour hang into a legible failure but could not make apt
+      # succeed while a mirror was down.
       #
-      # Three guards, in order of what they catch:
-      #   Acquire::*::Timeout  -- a stalled socket errors out instead of
-      #                           blocking forever, which is what actually
-      #                           happened here.
-      #   sudo timeout         -- a hard ceiling on apt regardless of why it is
-      #                           stuck. Run under sudo, not around it, so the
-      #                           signal reaches apt rather than sudo.
-      #   DPkg::Lock::Timeout  -- after a TERM'd attempt, the next one waits for
-      #                           the dpkg lock instead of failing on contact
-      #                           with a lock the dying process still holds.
-      #   the retry loop       -- a transient mirror outage becomes recoverable
-      #                           inside the job. Worst case is 36 minutes
-      #                           (3 x 11min ceiling + 60s and 120s backoff),
-      #                           which outlasts the ~25-minute outage actually
-      #                           observed and still leaves the 240-minute
-      #                           grading budget inside the 320-minute job
-      #                           timeout.
+      # The deeper problem was that apt could not give a *fixed* renderer at
+      # all. Those packages carried no version, so whichever LibreOffice the
+      # mirror served that day became the judge's eyes, and two runs a
+      # generation apart were not comparable however identical their model,
+      # prompt, and grader_source_hash. Pinning a version in apt was rejected
+      # because Ubuntu drops superseded builds from the pocket, so the pin
+      # would eventually fail as an opaque apt error rather than as a
+      # statement about comparability. The digest-pinned image is the durable
+      # answer, and it had to be ubuntu:24.04-based: gdpval-sandbox ships
+      # LibreOffice 7.4.7.2 against this corpus's 24.2.7.2 and would move the
+      # very scores it was meant to stabilise.
       #
-      # This does not make apt succeed while a mirror is down; nothing here
-      # can. It converts a silent five-hour hang into either a recovery or a
-      # fast, legible failure.
-      #
-      # What apt cannot give is a *fixed* renderer: these packages carry no
-      # version, so whichever LibreOffice the mirror serves that day becomes
-      # the judge's eyes, and on formatting criteria the renderer is the
-      # evidence. Two runs a generation apart are not comparable however
-      # identical their model, prompt, and grader_source_hash. The preflight
-      # below closes that by asserting the installed version against
-      # EXPECTED_LIBREOFFICE_VERSION before Azure login, so drift costs a free
-      # step rather than a paid corpus run.
-      #
-      # Pinning a version here instead was considered and rejected: Ubuntu
-      # drops superseded builds from the pocket, so the pin would fail as an
-      # opaque apt error some months from now rather than as a statement about
-      # comparability. A purpose-built image is the durable answer -- and it
-      # must be ubuntu:24.04-based, since ghcr.io/hyeonsangjeon/gdpval-sandbox
-      # ships LibreOffice 7.4.7.2 against this runner's 24.2.7.2 and would
-      # move the very scores it was meant to stabilise.
-      - name: Install grading render dependencies
-        if: steps.renderer.outputs.required == 'true'
-        run: |
-          APT_OPTS=(
-            -o Acquire::Retries=3
-            -o Acquire::http::Timeout=30
-            -o Acquire::https::Timeout=30
-            -o DPkg::Lock::Timeout=60
-          )
-          install_render_deps() {
-            sudo timeout 240 apt-get "${APT_OPTS[@]}" update || return 1
-            sudo timeout 420 apt-get "${APT_OPTS[@]}" install \
-              --yes --no-install-recommends \
-              libreoffice-core \
-              libreoffice-calc \
-              libreoffice-impress \
-              libreoffice-writer \
-              fonts-dejavu-core \
-              fonts-liberation2 \
-              fontconfig || return 1
-          }
-          for attempt in 1 2 3; do
-            if install_render_deps; then
-              break
-            fi
-            if [[ "$attempt" -eq 3 ]]; then
-              echo "::error::apt could not install the grading renderer after 3 attempts"
-              exit 1
-            fi
-            echo "::warning::apt attempt $attempt failed; retrying in $((attempt * 60))s"
-            sleep "$((attempt * 60))"
-          done
-          libreoffice --headless --version
-          FONT_FAMILIES="$(fc-match --format '%{family}\n' 'Liberation Sans')"
-          if ! printf '%s\n' "$FONT_FAMILIES" | tr ',' '\n' | awk '
-            {
-              gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
-              if ($0 == "Liberation Sans") found = 1
-            }
-            END { exit(found ? 0 : 1) }
-          '; then
-            echo "::error::fc-match did not resolve exact family token Liberation Sans"
-            exit 1
-          fi
-
+      # The preflight below stays gated on the config actually needing the
+      # renderer, and still asserts the version before Azure login, so drift
+      # in a future rebuild costs a free step rather than a paid corpus run.
       - name: Preflight grading renderer
         if: steps.renderer.outputs.required == 'true'
         run: |
@@ -972,25 +986,51 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RESOLVED_INFERENCE_REVISION: ${{ steps.inference.outputs.revision }}
         run: |
+          set -euo pipefail
           NEXT_CHUNK=$(( GRADE_RESUME_CHUNK + 1 ))
           if [[ $NEXT_CHUNK -gt 10 ]]; then
             echo "::error::resume_chunk=$NEXT_CHUNK exceeds safety cap (10). Aborting auto-resume; investigate manually."
             exit 1
           fi
           echo "[auto-resume] triggering chunk $NEXT_CHUNK for $GRADE_EXPERIMENT_YAML / $GRADE_CONFIG (shard $GRADE_SHARD_INDEX/$GRADE_SHARD_COUNT)"
-          gh workflow run grade-run.yml \
-            --ref "${GITHUB_REF_NAME}" \
-            -f experiment_yaml="$GRADE_EXPERIMENT_YAML" \
-            -f grading_config="$GRADE_CONFIG" \
-            -f inference_revision="$RESOLVED_INFERENCE_REVISION" \
-            -f force=false \
-            -f tasks_limit="$GRADE_TASKS_LIMIT" \
-            -f dry_run=false \
-            -f paid_approval="$GRADE_PAID_APPROVAL" \
-            -f resume=true \
-            -f resume_chunk=$NEXT_CHUNK \
-            -f shard_count="$GRADE_SHARD_COUNT" \
-            -f shard_index="$GRADE_SHARD_INDEX"
+          # This used to be `gh workflow run`, which is a thin wrapper over the
+          # endpoint below; gh is not in the grading image. Every input is a
+          # JSON string, including the booleans, because that is what gh sent
+          # and what the dispatch API accepts. Building the body in Python
+          # rather than by string concatenation keeps a value containing a
+          # quote from silently producing a different dispatch.
+          export NEXT_CHUNK
+          python - <<'PY' > "$RUNNER_TEMP/auto-resume.json"
+          import json
+          import os
+
+          print(json.dumps({
+              "ref": os.environ["GITHUB_REF_NAME"],
+              "inputs": {
+                  "experiment_yaml": os.environ["GRADE_EXPERIMENT_YAML"],
+                  "grading_config": os.environ["GRADE_CONFIG"],
+                  "inference_revision": os.environ["RESOLVED_INFERENCE_REVISION"],
+                  "force": "false",
+                  "tasks_limit": os.environ["GRADE_TASKS_LIMIT"],
+                  "dry_run": "false",
+                  "paid_approval": os.environ["GRADE_PAID_APPROVAL"],
+                  "resume": "true",
+                  "resume_chunk": os.environ["NEXT_CHUNK"],
+                  "shard_count": os.environ["GRADE_SHARD_COUNT"],
+                  "shard_index": os.environ["GRADE_SHARD_INDEX"],
+              },
+          }))
+          PY
+          # --fail-with-body, not --fail: a dispatch rejected for a bad input
+          # explains itself in the response body, and a silent 422 here strands
+          # the run with its budget already spent.
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --data "@$RUNNER_TEMP/auto-resume.json" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/workflows/grade-run.yml/dispatches"
           echo "[auto-resume] chunk $NEXT_CHUNK dispatched"
 
       - name: Merge shards into the final grade

--- a/batch-runner/sandbox/grading.Dockerfile
+++ b/batch-runner/sandbox/grading.Dockerfile
@@ -2,21 +2,22 @@
 #
 # WHY THIS EXISTS
 #   On formatting criteria the renderer is not a detail of how a grade is
-#   produced; it *is* the evidence. grade-run.yml asks apt for
+#   produced; it *is* the evidence. grade-run.yml used to ask apt for
 #   libreoffice-core and friends with no version, so whichever build the
-#   mirror serves that morning becomes what the judge sees, and two runs a
-#   generation apart are not comparable however identical their model,
+#   mirror served that morning became what the judge saw, and two runs a
+#   generation apart were not comparable however identical their model,
 #   prompt, and grader_source_hash.
 #
-#   That install is also a live outage surface. On 2026-08-19 the Ubuntu
+#   That install was also a live outage surface. On 2026-08-19 the Ubuntu
 #   mirror stalled mid-transfer for ~25 minutes; apt imposes no wall-clock
 #   ceiling on itself, five grade jobs sat in that step for 5h18m, and 63 of
 #   the 220 tasks died with them.
 #
 #   scripts/preflight_grading_renderer.py closed the comparability half by
 #   asserting the installed build before Azure login, so drift costs a free
-#   step instead of a paid corpus run. This image closes the other half: the
-#   renderer stops being installed at run time at all.
+#   step instead of a paid corpus run. This image closes the other half: both
+#   grading jobs now run inside it, pinned by digest, and the renderer is not
+#   installed at run time at all.
 #
 # WHY ubuntu:24.04 AND NOT THE EXISTING SANDBOX IMAGE
 #   ghcr.io/hyeonsangjeon/gdpval-sandbox ships LibreOffice 7.4.7.2 (it is
@@ -43,9 +44,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \
     PYTHONDONTWRITEBYTECODE=1
 
-# ── The renderer, and exactly the packages grade-run.yml installs ───────────
-# tests/test_grading_image.py holds this list against that step, so the image
-# cannot silently drop a package the runner has.
+# ── The renderer, and the packages grade-run.yml used to install ───────────
+# grade-run.yml no longer installs them: both grading jobs run in this image,
+# pinned by digest. tests/test_grading_image.py holds this list under
+# RENDERER_PACKAGES, so the image cannot silently drop one that the runner
+# used to guarantee.
 RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
       libreoffice-core \

--- a/batch-runner/tests/test_grading_image.py
+++ b/batch-runner/tests/test_grading_image.py
@@ -2,13 +2,14 @@
 
 The image exists to stop the renderer moving under the judge, so the things
 worth testing without Docker are the ones that would let it move anyway: a
-version restated instead of derived, a package the runner installs and the
-image does not, a floating base, a floating published tag, or a package
-source trusted without checking who signed it.
+version restated instead of derived, a floating base, a floating published
+tag, a package source trusted without checking who signed it -- or a grading
+job that reaches for something the image does not carry.
 """
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -18,12 +19,48 @@ from scripts import preflight_grading_renderer as preflight
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+BATCH_RUNNER = REPO_ROOT / "batch-runner"
 DOCKERFILE_PATH = REPO_ROOT / "batch-runner/sandbox/grading.Dockerfile"
 BUILD_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/build-grading-image.yml"
 GRADE_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/grade-run.yml"
 
-RENDERER_INSTALL_STEP = "Install grading render dependencies"
+GRADING_JOBS = ("grade", "grade-dry-run")
+
+# The renderer packages the grade job used to apt-install on every run. They
+# moved into the image; this is the list that moved, kept here so the image
+# losing one of them is a test failure rather than a rendering difference
+# discovered halfway through a paid corpus.
+RENDERER_PACKAGES = frozenset({
+    "libreoffice-core",
+    "libreoffice-calc",
+    "libreoffice-impress",
+    "libreoffice-writer",
+    "fonts-dejavu-core",
+    "fonts-liberation2",
+    "fontconfig",
+})
+
+# Every external binary the grading path may shell out to, and what makes it
+# safe. Discovered by walking step8_grade.py's import closure; see
+# test_grading_path_shells_out_only_to_known_binaries for how it is enforced.
+ALLOWED_SHELL_OUTS = {
+    "soffice": "libreoffice-core; asserted by the image build and the preflight",
+    "libreoffice": "same package -- _find_soffice tries this name second",
+    "ffprobe": (
+        "NOT in the image. core/file_reader.py uses it to add a duration and "
+        "codec line for .wav/.mp3/.mp4 deliverables and falls back to name "
+        "and size without it. Every deliverable recorded in data/grades is "
+        ".pdf/.xlsx/.pptx/.docx/.png, so the published corpus never reaches "
+        "it -- but the fallback is silent and moves neither "
+        "grader_source_hash nor renderer_fingerprint, so it is named here "
+        "rather than left to be noticed."
+    ),
+}
+
 PINNED_ACTION = re.compile(r"^[\w.-]+/[\w./-]+@[0-9a-f]{40}$")
+PINNED_IMAGE = re.compile(
+    r"^ghcr\.io/hyeonsangjeon/gdpval-grading@sha256:[0-9a-f]{64}$"
+)
 
 
 def _dockerfile() -> str:
@@ -65,12 +102,13 @@ def _apt_packages(shell_text: str) -> set[str]:
     return packages
 
 
-def _renderer_install_step() -> str:
-    grade = _workflow(GRADE_WORKFLOW_PATH)
-    for step in grade["jobs"]["grade"]["steps"]:
-        if step.get("name") == RENDERER_INSTALL_STEP:
-            return step["run"]
-    raise AssertionError(f"{RENDERER_INSTALL_STEP!r} step not found in grade-run.yml")
+def _run_scripts(job: dict) -> list[tuple[str, str]]:
+    return [
+        (step.get("name", "<unnamed>"), step["run"])
+        for step in job["steps"]
+        if "run" in step
+    ]
+
 
 
 def test_expected_renderer_version_is_derived_from_the_preflight_pin():
@@ -86,15 +124,261 @@ def test_expected_renderer_version_is_derived_from_the_preflight_pin():
     assert match.group("value") == preflight.EXPECTED_LIBREOFFICE_VERSION
 
 
-def test_image_carries_every_package_the_runner_installs():
+def test_image_carries_the_renderer_packages_the_jobs_stopped_installing():
+    # The grade job used to apt-install these on every run, which is how a
+    # mirror outage cost 63 tasks and five hours on 2026-08-19, and how the
+    # renderer could differ between two runs with identical inputs. Dropping
+    # one from the image now would reintroduce the second failure quietly:
+    # LibreOffice converts a .pptx without libreoffice-impress installed, just
+    # not the same way.
     image_packages = _apt_packages(_dockerfile_instructions())
-    runner_packages = _apt_packages(_renderer_install_step())
 
-    assert runner_packages, "renderer install step parsed to no packages"
-    # Guards the parser as much as the image: if the extraction ever degrades
-    # to a handful of tokens, the superset check below would pass vacuously.
-    assert {"libreoffice-core", "fontconfig"} <= runner_packages
-    assert runner_packages <= image_packages, sorted(runner_packages - image_packages)
+    assert RENDERER_PACKAGES <= image_packages, sorted(
+        RENDERER_PACKAGES - image_packages
+    )
+
+
+def test_grading_jobs_run_in_the_published_image_by_digest():
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+    images = set()
+
+    for name in GRADING_JOBS:
+        job = grade["jobs"][name]
+        container = job.get("container")
+        assert container is not None, f"{name} is not containerised"
+        # A tag would let a rebuild change the renderer under a job whose file
+        # never changed, which is the whole failure the image exists to close.
+        assert PINNED_IMAGE.fullmatch(container["image"]), container["image"]
+        # The package is public. A credentials block would hand a registry
+        # token to a job with no use for one.
+        assert "credentials" not in container, name
+        images.add(container["image"])
+
+    # A dry run against a different renderer than the paid run proves nothing
+    # about the paid run.
+    assert len(images) == 1, sorted(images)
+
+
+def test_grading_jobs_declare_the_image_os_setup_python_reads():
+    # The runner exports ImageOS for its own image and not for a container, so
+    # without this actions/setup-python cannot tell which prebuilt CPython
+    # applies. LANG matches what the hosted runner exports, keeping Python's
+    # default encoding identical to what the published corpus was graded under.
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+
+    for name in GRADING_JOBS:
+        env = grade["jobs"][name]["env"]
+        assert env.get("ImageOS") == "ubuntu24", name
+        assert env.get("LANG") == "C.UTF-8", name
+
+
+def test_grading_jobs_verify_the_image_before_spending_anything():
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+    asserted = {}
+
+    for name in GRADING_JOBS:
+        steps = grade["jobs"][name]["steps"]
+        # First step, so a wrong image costs seconds rather than a checkout, a
+        # dependency install and an Azure login.
+        assert steps[0]["name"] == "Verify grading container", name
+        script = steps[0]["run"]
+        assert "/opt/gdpval/renderer-version.txt" in script
+        binaries = re.search(r"for binary in ([^;\n]+); do", script)
+        assert binaries is not None, name
+        asserted[name] = set(binaries.group(1).split())
+        assert {"soffice", "fc-match", "git", "curl"} <= asserted[name], name
+
+    # Only the paid job logs in to Azure, so only it needs to prove az exists.
+    assert "az" in asserted["grade"]
+    assert "az" not in asserted["grade-dry-run"]
+
+
+def test_no_grading_job_installs_the_renderer_at_runtime():
+    # apt in the grade job was both the outage and the drift: these packages
+    # carry no version, so whichever LibreOffice the mirror served that day
+    # became the judge's eyes. Reintroducing an install here would silently
+    # reintroduce both.
+    text = GRADE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+
+    for name in GRADING_JOBS:
+        for step_name, script in _run_scripts(grade["jobs"][name]):
+            assert "apt-get" not in script, (name, step_name)
+            assert "sudo" not in script, (name, step_name)
+
+    # Belt and braces: the prose above the jobs is allowed to describe the
+    # history, but nothing anywhere in the file may run apt.
+    assert "apt-get install" not in text
+
+
+def test_the_dry_run_exercises_the_renderer_it_is_rehearsing():
+    # dry_run == true and dry_run == false select different jobs, so the paid
+    # job's preflight never runs on a free rehearsal. Without an unconditional
+    # copy here, no free run touches the container's renderer at all and the
+    # rehearsal certifies nothing about the thing that changed.
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+    dry_run = grade["jobs"]["grade-dry-run"]
+
+    preflight_step = next(
+        step
+        for step in dry_run["steps"]
+        if step.get("name") == "Preflight grading renderer"
+    )
+    assert "if" not in preflight_step
+    assert "preflight_grading_renderer.py" in preflight_step["run"]
+
+    # On the paid path it stays gated on the config actually needing the
+    # renderer -- containerising must not change what the paid run does.
+    paid_preflight = next(
+        step
+        for step in grade["jobs"]["grade"]["steps"]
+        if step.get("name") == "Preflight grading renderer"
+    )
+    assert paid_preflight["if"] == "steps.renderer.outputs.required == 'true'"
+
+
+def test_no_containerised_job_reaches_for_gh():
+    # gh is not in the image, and a `gh` call that only runs on the rc=7
+    # handoff would fail after the chunk's budget was already spent. The
+    # auto-resume step posts to the REST endpoint gh wraps, with curl.
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+
+    for name in GRADING_JOBS:
+        for step_name, script in _run_scripts(grade["jobs"][name]):
+            # Whole-line comments are dropped first: the auto-resume step
+            # explains in prose why it no longer calls gh, and a checker that
+            # cannot tell an explanation from an invocation would force that
+            # explanation to be deleted to stay green.
+            body = "\n".join(
+                line
+                for line in script.splitlines()
+                if not line.lstrip().startswith("#")
+            )
+            commands = re.findall(r"(?:^|[|&;(]|\$\()\s*(gh)\b", body, re.M)
+            assert not commands, (name, step_name)
+
+    retrigger = next(
+        step
+        for step in grade["jobs"]["grade"]["steps"]
+        if step.get("name") == "Auto-retrigger next chunk (time budget hit)"
+    )
+    assert "actions/workflows/grade-run.yml/dispatches" in retrigger["run"]
+    # --fail-with-body, not --fail: a 422 that explains itself is the
+    # difference between a fixable dispatch and a stranded paid run.
+    assert "--fail-with-body" in retrigger["run"]
+
+
+def test_grading_path_shells_out_only_to_known_binaries():
+    """Walk step8_grade.py's imports and check nothing new needs the host.
+
+    Containerising moved the grading path onto a filesystem chosen on purpose,
+    which is worth much more than the runner's -- and also much smaller. A new
+    ``subprocess.run(["pdftotext", ...])`` on this path would not fail loudly;
+    most of these call sites fall back, so it would change what the judge is
+    shown while grader_source_hash and renderer_fingerprint both stay put.
+    """
+    reachable: set[Path] = set()
+    queue = ["step8_grade"]
+    seen: set[str] = set()
+
+    def resolve(module: str) -> Path | None:
+        relative = module.replace(".", "/")
+        for candidate in (
+            BATCH_RUNNER / f"{relative}.py",
+            BATCH_RUNNER / relative / "__init__.py",
+        ):
+            if candidate.is_file():
+                return candidate
+        return None
+
+    def absolute(module: str, node: ast.ImportFrom) -> str | None:
+        """Turn a possibly-relative ImportFrom into a dotted module name.
+
+        core/tools/__init__.py reaches read_deliverable with `from
+        .read_deliverable import ...`, so a walker that only understood
+        absolute imports would stop one file short of the renderer.
+        """
+        if not node.level:
+            return node.module
+        package = module if resolve(module).name == "__init__.py" else module.rsplit(".", 1)[0]
+        parts = package.split(".")
+        if node.level > 1:
+            parts = parts[: -(node.level - 1)]
+        if not parts:
+            return node.module
+        return ".".join(parts + ([node.module] if node.module else []))
+
+    while queue:
+        module = queue.pop()
+        if module in seen:
+            continue
+        seen.add(module)
+        path = resolve(module)
+        if path is None:
+            continue
+        reachable.add(path)
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                queue.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                target = absolute(module, node)
+                if not target:
+                    continue
+                queue.append(target)
+                # `from core.tools import read_deliverable` names a module,
+                # not an attribute, and that module is where soffice is
+                # resolved. Following only the package would walk past the
+                # single most important file on this path.
+                queue.extend(f"{target}.{alias.name}" for alias in node.names)
+
+    assert len(reachable) > 10, "import walk collapsed; the check would be vacuous"
+
+    found: dict[str, Path] = {}
+    for path in sorted(reachable):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            names: list[ast.expr] = []
+            target = node.func
+            if isinstance(target, ast.Attribute) and target.attr == "which":
+                names.extend(node.args[:1])
+            elif isinstance(target, ast.Attribute) and target.attr in {
+                "run",
+                "Popen",
+                "check_output",
+                "check_call",
+                "call",
+            }:
+                if node.args and isinstance(node.args[0], (ast.List, ast.Tuple)):
+                    names.extend(node.args[0].elts[:1])
+            for name in names:
+                if isinstance(name, ast.Constant) and isinstance(name.value, str):
+                    found.setdefault(name.value, path)
+
+    # _find_soffice resolves its binary through a loop variable, so the walk
+    # above cannot see the name. It is the reason the image exists, so assert
+    # it directly rather than widening the scanner for one call site.
+    soffice = BATCH_RUNNER / "core/tools/read_deliverable.py"
+    assert soffice in reachable
+    assert 'for executable in ("soffice", "libreoffice"):' in soffice.read_text(
+        encoding="utf-8"
+    )
+
+    unexpected = {
+        name: str(path.relative_to(REPO_ROOT))
+        for name, path in found.items()
+        if name not in ALLOWED_SHELL_OUTS
+    }
+    assert not unexpected, (
+        "new external binary on the grading path; confirm the image carries it "
+        f"and add it to ALLOWED_SHELL_OUTS: {unexpected}"
+    )
+    assert "ffprobe" in found, (
+        "ffprobe left the grading path -- drop it from ALLOWED_SHELL_OUTS and "
+        "from the container note in grade-run.yml"
+    )
 
 
 def test_image_carries_the_actions_runtime_the_grade_job_needs():

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import re
 import subprocess
+import sys
 
 import pytest
 import yaml
@@ -3240,9 +3241,19 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
     assert "${{ steps.analysis.outputs.analysis_file }}" in upload["with"]["path"]
 
     assert "steps.commit_grade.outputs.committed == 'true'" in retrigger["if"]
-    assert '-f inference_revision="$RESOLVED_INFERENCE_REVISION"' in retrigger["run"]
-    assert '-f tasks_limit="$GRADE_TASKS_LIMIT"' in retrigger["run"]
-    assert '-f paid_approval="$GRADE_PAID_APPROVAL"' in retrigger["run"]
+    assert "NEXT_CHUNK=$(( GRADE_RESUME_CHUNK + 1 ))" in retrigger["run"]
+    assert "$NEXT_CHUNK -gt 10" in retrigger["run"]
+    dispatch = _auto_resume_dispatch(retrigger["run"])
+    assert dispatch["ref"] == "main"
+    assert dispatch["inputs"]["inference_revision"] == "resolved-revision"
+    assert dispatch["inputs"]["tasks_limit"] == "17"
+    assert dispatch["inputs"]["paid_approval"] == "true"
+    # A handoff that resumed as a fresh dry run would report success having
+    # graded nothing, and one that did not resume would regrade from zero.
+    assert dispatch["inputs"]["dry_run"] == "false"
+    assert dispatch["inputs"]["force"] == "false"
+    assert dispatch["inputs"]["resume"] == "true"
+    assert dispatch["inputs"]["resume_chunk"] == "4"
 
     assert workflow.index("- name: Validate workflow context and inputs") < workflow.index(
         "- name: Checkout exact main revision"
@@ -3250,9 +3261,46 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
     assert "resume_chunk must be between 0 and 10" in workflow
     assert "resume requires the pinned inference_revision" in workflow
     assert "force and resume are mutually exclusive" in workflow
-    assert '-f experiment_yaml="$GRADE_EXPERIMENT_YAML"' in retrigger["run"]
-    assert '-f grading_config="$GRADE_CONFIG"' in retrigger["run"]
+    assert dispatch["inputs"]["experiment_yaml"] == "exp-under-test"
+    assert dispatch["inputs"]["grading_config"] == "config-under-test.yaml"
     assert '--revision "${{ inputs.inference_revision }}"' not in workflow
+
+
+def _auto_resume_dispatch(script: str) -> dict:
+    """Return the body the auto-resume step would POST, by running its builder.
+
+    This used to be a ``gh workflow run`` invocation whose ``-f`` flags could
+    be read straight out of the YAML. gh is not in the grading image, so it is
+    a curl POST now and the readable artefact is the JSON rather than the
+    command line. Executing the builder instead of grepping it is the point:
+    grep cannot tell a misspelled environment variable from a correct one, and
+    that misspelling would strand an rc=7 chunk with its budget already spent.
+    """
+    match = re.search(r"python - <<'PY'[^\n]*\n(.*?)\nPY\n", script, re.DOTALL)
+    assert match is not None, "auto-resume payload builder not found"
+
+    completed = subprocess.run(
+        [sys.executable, "-c", match.group(1)],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GITHUB_REF_NAME": "main",
+            "GRADE_EXPERIMENT_YAML": "exp-under-test",
+            "GRADE_CONFIG": "config-under-test.yaml",
+            "RESOLVED_INFERENCE_REVISION": "resolved-revision",
+            "GRADE_TASKS_LIMIT": "17",
+            "GRADE_PAID_APPROVAL": "true",
+            "NEXT_CHUNK": "4",
+            "GRADE_SHARD_COUNT": "9",
+            "GRADE_SHARD_INDEX": "6",
+        },
+    )
+    payload = json.loads(completed.stdout)
+    # The dispatch API takes booleans as strings, which is what gh sent. A
+    # real bool here is a 422 on the paid path.
+    assert all(isinstance(value, str) for value in payload["inputs"].values())
+    return payload
 
 
 def _retry_loop_body(script: str) -> str:
@@ -4123,8 +4171,9 @@ def test_grade_workflow_wires_shards_end_to_end():
     # An rc=7 chunk hands off to the next chunk OF THE SAME SHARD. Losing the
     # shard flags here would resume the remainder as an unsharded run.
     retrigger = by_name["Auto-retrigger next chunk (time budget hit)"]
-    assert '-f shard_count="$GRADE_SHARD_COUNT"' in retrigger["run"]
-    assert '-f shard_index="$GRADE_SHARD_INDEX"' in retrigger["run"]
+    resume_inputs = _auto_resume_dispatch(retrigger["run"])["inputs"]
+    assert resume_inputs["shard_count"] == "9"
+    assert resume_inputs["shard_index"] == "6"
 
     merge = by_name["Merge shards into the final grade"]
     assert merge["id"] == "merge_shards"


### PR DESCRIPTION
Phase B of the grading-image work. Task #65; follows #216, which published
`ghcr.io/hyeonsangjeon/gdpval-grading` through the `grading-image-publish`
Environment gate.

## What changes

Both `grade` and `grade-dry-run` now run inside that image, pinned by digest:

```
ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c056e31e1ea1d693fc2f8f873da160b232926fa1b6cde75c24e5344a04
revision  59432d4d04dbb2fad049939444bbb8cd8cc4912a
renderer  LibreOffice 24.2.7.2 420(Build:2)
```

By digest and not by tag, because a tag can be repointed at a rebuild without
this file changing — which is exactly the drift the image exists to close. No
`credentials:`: the package is public, and adding one would hand a registry
token to a job that has no use for it.

The `Install grading render dependencies` apt step is deleted. It was both the
comparability hole (unversioned packages, so the mirror picked the judge's
eyes) and the outage surface of 2026-08-19. That incident record, and why
pinning a version *in apt* was rejected, stay in the file as the comment above
the preflight.

`grade-dry-run` gains an unconditional renderer preflight. The paid job runs
its copy only when the config needs the renderer; a free dry run is the only
place the container's renderer is exercised before money is committed, so
gating it there would leave the rehearsal certifying nothing about what
actually changed.

## Two deviations, both deliberate

**`gh` is not in the image.** One call site — the rc=7 auto-resume dispatch.
It is now a `curl` POST to the REST endpoint `gh workflow run` wraps, with the
body built in Python so a value containing a quote cannot silently produce a
different dispatch, and `--fail-with-body` so a 422 explains itself instead of
stranding a run whose budget is already spent. Verified to emit the same
eleven string inputs `gh` sent. The alternative — republishing the image with
`gh` — needs a second Environment approval and buys nothing here.

**`ffprobe` is not in the image.** `core/file_reader.py` uses it to add a
duration and codec line for `.wav`/`.mp3`/`.mp4` *deliverables*, and falls
back to name and size without it. All 2,273 file entries across `data/grades`
are `.pdf`/`.xlsx`/`.pptx`/`.docx`/`.png` — zero media — so the published
corpus never reaches it. It is named in the workflow comment and locked by a
test anyway, because that fallback is silent and would change judge prompt
text while moving neither `grader_source_hash` nor `renderer_fingerprint`.
Adding `ffmpeg` via a republish is available if media deliverables ever land;
that is an owner call, not a side effect of this PR.

## What the tests now hold

Seven new contracts in `test_grading_image.py`:

- both jobs pinned to the *same* digest, matching the published-image pattern,
  with no `credentials:` — a dry run against a different renderer than the paid
  run proves nothing
- `ImageOS` and `LANG` on both jobs, so `actions/setup-python` takes the same
  tool-cache path it takes on the host
- `Verify grading container` is step 0 on both, so a wrong image costs seconds
  rather than a checkout, an install and an Azure login; `az` asserted only on
  the job that logs in
- no `apt-get` and no `sudo` anywhere in the workflow
- the dry run's preflight is ungated, and the paid one stays gated
- no containerised job reaches for `gh` (whole-line comments excluded, so the
  step may keep explaining why it no longer does)
- an AST walk of `step8_grade.py`'s import closure — 23 files — that fails if a
  new external binary joins the grading path. It finds exactly `ffprobe`, and
  asserts `read_deliverable.py` is reachable so the check cannot pass vacuously

`test_step8_grade.py` now *executes* the auto-resume payload builder rather
than grepping `gh -f` flags. Grep cannot tell a misspelled environment variable
from a correct one, and that misspelling would strand an rc=7 chunk with its
budget already spent.

Also corrects two comments in `grading.Dockerfile` that described the apt step
this PR deletes.

## Verification

- `3521 passed, 6 skipped, 45 deselected` locally (baseline `3514 / 6 / 45`);
  +7 is exactly the new tests
- noble-updates still serves `4:24.2.7-0ubuntu0.24.04.6`, so the digest-pinned
  base still reproduces this renderer — the Dockerfile touch re-runs
  `verify-grading-image` on this PR to confirm that end to end
- The free `dry_run=true` rehearsal can only run after merge: `validate-request`
  hard-fails any dispatch whose `GITHUB_WORKFLOW_REF` is not
  `grade-run.yml@refs/heads/main`. It runs immediately on merge.

## Residual risk

A free rehearsal exercises the container's read-side git (`config`,
`rev-parse`, `symbolic-ref`), the renderer, `setup-python`, `pip install` and
the HF download. It does not exercise `git commit`/`push`, because no free job
pushes. The container-specific failure mode there is workspace ownership,
which the read-side commands already prove, and CA certificates, which the
image asserts at build time.

No paid model call, paid grading, or regrade is part of this PR.
