### PR TITLE
fix(grading): run containerised grade steps under bash, not sh

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -379,6 +379,16 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c056e31e1ea1d693fc2f8f873da160b232926fa1b6cde75c24e5344a04
+    # A container job defaults `run:` to `sh -e {0}`, not to the runner's
+    # `bash -e {0}` -- the runner will not assume an arbitrary image has bash.
+    # The free 2026-08-24 rehearsal found it on the first step (`set: Illegal
+    # option -o pipefail` under dash), but every step here is written in bash:
+    # [[ ]], arrays, ${VAR%.json}. Restated as the runner's exact default
+    # rather than the `shell: bash` shorthand, which would also add pipefail
+    # to steps that were graded without it.
+    defaults:
+      run:
+        shell: bash -e {0}
     permissions:
       contents: read
     env:
@@ -518,6 +528,14 @@ jobs:
     # against a different renderer than the paid run proves nothing.
     container:
       image: ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c056e31e1ea1d693fc2f8f873da160b232926fa1b6cde75c24e5344a04
+    # Same reason as grade-dry-run; see the note there. What makes it matter
+    # more here is where the bash syntax sits: Run grading, Commit grade
+    # result, Merge shards, Auto-analyze and Commit analysis all use [[ ]] or
+    # arrays, and all of them run after the corpus has been judged and paid
+    # for. Only the two steps that already carried `shell: bash` were safe.
+    defaults:
+      run:
+        shell: bash -e {0}
     permissions:
       contents: write
       id-token: write

--- a/batch-runner/tests/test_grading_image.py
+++ b/batch-runner/tests/test_grading_image.py
@@ -159,6 +159,34 @@ def test_grading_jobs_run_in_the_published_image_by_digest():
     assert len(images) == 1, sorted(images)
 
 
+def test_grading_jobs_run_their_steps_under_bash():
+    """A container job defaults `run:` to sh, and these steps are bash.
+
+    Found by the free 2026-08-24 rehearsal, which died on the first step with
+    ``set: Illegal option -o pipefail``. The dry run fails cheaply; the paid
+    job would not have, because Run grading, Commit grade result, Merge shards
+    and both analysis steps use ``[[ ]]`` or arrays and all run after the
+    corpus has been judged and paid for.
+
+    ``bash -e {0}`` and not the ``shell: bash`` shorthand: the shorthand
+    expands to ``bash --noprofile --norc -eo pipefail {0}``, which would add
+    pipefail to steps that were graded without it.
+    """
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+
+    for name in GRADING_JOBS:
+        job = grade["jobs"][name]
+        assert job.get("defaults", {}).get("run", {}).get("shell") == "bash -e {0}", name
+
+        # And the default has to actually cover the steps that need it: a
+        # per-step `shell:` that is not bash would slip past the job default.
+        for step in job["steps"]:
+            if "run" not in step:
+                continue
+            shell = step.get("shell")
+            assert shell is None or shell.startswith("bash"), (name, step.get("name"))
+
+
 def test_grading_jobs_declare_the_image_os_setup_python_reads():
     # The runner exports ImageOS for its own image and not for a container, so
     # without this actions/setup-python cannot tell which prebuilt CPython


### PR DESCRIPTION
Follow-up to #217, found by the free `dry_run=true` rehearsal it enabled.

## What happened

Run [32697925517](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/32697925517)
failed on the very first step of `grade-dry-run`:

```
/__w/_temp/....sh: 1: set: Illegal option -o pipefail
##[error]Process completed with exit code 2.
```

The log shows `shell: sh -e {0}`. A container job defaults `run:` to `sh`, not
to the runner's `bash -e {0}` — the runner will not assume an arbitrary image
carries bash. Only two steps across the two grading jobs declared
`shell: bash`; every other one was written in bash and was being handed to
dash.

## Why this is worth a separate PR rather than a note

In `grade-dry-run` the failure is free and immediate. In `grade` it is not.
Scanning both jobs for bash-only syntax:

| step | syntax | runs after payment |
|---|---|---|
| Verify grading container | `set -o pipefail` | no |
| Verify checked out main and input files | `[[ ]]`, `local` | no — already `shell: bash` |
| Validate Azure OIDC identity / AI route | `set -o pipefail` | no |
| Verify Azure OIDC session / AI token | `set -o pipefail` | no |
| **Run grading** | `[[ ]]`, arrays | — |
| **Commit grade result** | `[[ ]]`, `=~` | **yes** |
| **Merge shards into the final grade** | `[[ ]]`, arrays, `${x%...}` | **yes** |
| **Auto-analyze / Commit analysis** | `[[ ]]` | **yes** |

The `Verify grading container` step happens to fail first, so in practice the
blast radius would have been contained — but only by accident of step order,
and that step is itself new in #217.

## The fix

A job-level `defaults.run.shell` on both containerised jobs:

```yaml
defaults:
  run:
    shell: bash -e {0}
```

Not the `shell: bash` shorthand. That expands to
`bash --noprofile --norc -eo pipefail {0}`, which would add `pipefail` to
steps the published corpus was graded without. `bash -e {0}` is the runner's
own default, so containerising changes nothing about how these steps run —
which is the point.

## Test

`test_grading_jobs_run_their_steps_under_bash` asserts the job default on both
jobs and, separately, that no individual step opts back out to a non-bash
shell — a per-step `shell:` would slip past the job default otherwise.

`336 passed, 6 skipped` locally for the grading test files; full suite below.

The rehearsal re-runs on merge.
