### PR TITLE
fix(grading): trust the container checkout so git can read it

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -412,6 +412,23 @@ jobs:
               || { echo "::error::$binary is missing from the grading image"; exit 1; }
           done
 
+      # Steps in a container job run as root, while /__w is bind-mounted from
+      # the runner user's home and stays owned by that user. git therefore sees
+      # a repository owned by somebody else and refuses to read it at all:
+      # "fatal: detected dubious ownership".
+      #
+      # actions/checkout does not settle this for the steps after it. It makes
+      # the same exemption for its own run under a throwaway HOME -- the log
+      # says "Temporarily overriding HOME=... before making global git config
+      # changes" -- and drops it on the way out. The free 2026-08-24 rehearsal
+      # died on the very next step, with `git rev-parse HEAD` returning
+      # nothing and the SHA guard reporting a mismatch it had not really seen.
+      #
+      # Named exactly, never '*': this trusts the one workspace the job was
+      # handed, which is the same directory checkout trusts to clone into.
+      - name: Trust the checkout inside the container
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Checkout exact main revision (read-only)
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -574,6 +591,13 @@ jobs:
             command -v "$binary" >/dev/null \
               || { echo "::error::$binary is missing from the grading image"; exit 1; }
           done
+
+      # Same reason as grade-dry-run; see the note there. It carries further
+      # here: this job does not only read the checkout, it commits and pushes
+      # to it -- Commit grade result, Merge shards, Commit analysis -- and
+      # every one of those runs after the corpus has been judged and paid for.
+      - name: Trust the checkout inside the container
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       # Held on the v5 line on purpose. checkout v6 moved persisted
       # credentials out of .git/config into a separate file referenced by an

--- a/batch-runner/tests/test_grading_image.py
+++ b/batch-runner/tests/test_grading_image.py
@@ -221,6 +221,51 @@ def test_grading_jobs_verify_the_image_before_spending_anything():
     assert "az" not in asserted["grade-dry-run"]
 
 
+def test_grading_jobs_trust_the_workspace_before_touching_git():
+    """A container job runs as root; /__w keeps the runner user's ownership.
+
+    git then refuses the checkout outright -- "fatal: detected dubious
+    ownership" -- and actions/checkout does not settle it for the steps that
+    follow: it makes the same exemption under a throwaway HOME and drops it on
+    the way out. The free 2026-08-24 rehearsal hit this one step after
+    checkout, at ``git rev-parse HEAD``.
+
+    The ordering is the whole assertion. A trust step that lands after the
+    first git call reads as present and protects nothing.
+    """
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+
+    for name in GRADING_JOBS:
+        trusted = None
+        first_git = None
+
+        for index, step in enumerate(grade["jobs"][name]["steps"]):
+            script = step.get("run")
+            if script is None:
+                continue
+            body = "\n".join(
+                line
+                for line in script.splitlines()
+                if not line.lstrip().startswith("#")
+            )
+            if "safe.directory" in body:
+                # Exactly the workspace the job was handed, never a blanket
+                # '*' -- the grading code checks out nothing else, and a
+                # wildcard would also cover whatever it did.
+                assert '--add safe.directory "$GITHUB_WORKSPACE"' in body, name
+                if trusted is None:
+                    trusted = index
+                continue
+            if first_git is None and re.search(r"(?:^|[|&;(]|\$\()\s*git\b", body, re.M):
+                first_git = index
+
+        assert trusted is not None, f"{name} never marks the checkout safe"
+        # Without this the ordering check above would pass vacuously on a job
+        # that had stopped using git at all.
+        assert first_git is not None, f"{name} runs no git; re-read this test"
+        assert trusted < first_git, (name, trusted, first_git)
+
+
 def test_no_grading_job_installs_the_renderer_at_runtime():
     # apt in the grade job was both the outage and the drift: these packages
     # carry no version, so whichever LibreOffice the mirror served that day


### PR DESCRIPTION
## What the free rehearsal found

Run [32699062942](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/32699062942), dispatched from main after #218, cleared the `sh`-vs-`bash` bug and then died one step after checkout:

```
fatal: detected dubious ownership in repository at '/__w/gdpval-realworks/gdpval-realworks'
##[error]checked out HEAD does not match the dispatched main SHA
```

The second line is the misleading one. `git rev-parse HEAD` did not disagree with `$GITHUB_SHA`; it printed nothing at all, and the guard compared the empty string.

## Why

A container job runs its steps as **root**, while `/__w` is bind-mounted from the runner user's home and keeps that user's ownership. git sees a repository owned by somebody else and refuses to read it.

`actions/checkout` works because it grants itself the exemption — but only for itself. Straight from the run log:

```
Temporarily overriding HOME='/__w/_temp/25e45961-...' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
[command]/usr/bin/git config --global --add safe.directory /__w/gdpval-realworks/gdpval-realworks
```

That HOME is thrown away when the action returns, so nothing after it inherits the exemption. On a normal runner this never comes up: the workspace and the steps share one uid, so no exemption is needed in the first place.

## The change

One step in each containerised job, before any git command:

```yaml
- name: Trust the checkout inside the container
  run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
```

Named exactly, never `*`. `HOME=/github/home` is a mounted volume shared by every step in the job, so one write covers the rest.

## Why it matters more on the paid job

`grade-dry-run` only reads the checkout. `grade` **commits and pushes** to it — `Commit grade result`, `Merge shards`, `Commit analysis` — and each of those runs after the corpus has been judged and paid for. `git config user.name`, `git add`, `git commit`, `git pull --rebase` and `git push` all need the repository to be readable first.

A secondary effect worth naming: `grade-dry-run`'s "must not retain repository credentials" guard is written as `if git config --local ... ; then`. Under dubious ownership that git call errors out and the guard passes without reading anything. It is now actually reading the config. (`grade`'s equivalent is `if ! git config ...`, so it would have failed loudly rather than passed vacuously.)

## Test

`test_grading_jobs_trust_the_workspace_before_touching_git` asserts the step exists in both jobs, names `$GITHUB_WORKSPACE` rather than a wildcard, and **comes before the first git command** — a trust step in the wrong place reads as present and protects nothing.

Mutation-checked against three edits, all caught:

| mutation | result |
|---|---|
| step deleted | `grade never marks the checkout safe` |
| `safe.directory '*'` | assertion fails on the wildcard |
| step reordered after the first git call | `('grade', 4, 2)` |

It also asserts each job runs *some* git command, so the ordering check cannot go vacuous if a job later stops using git.

## Verification

- local: `3523 passed, 6 skipped, 45 deselected` (8m40s)
- the container itself is fine — step 0 of the failed run printed `LibreOffice 24.2.7.2 420(Build:2)` and found `soffice fc-match git curl`

Free `dry_run=true` rehearsal re-runs from main once this merges.