### PR TITLE
fix(grading): mount the toolcache where its shebangs already point

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -379,6 +379,22 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c056e31e1ea1d693fc2f8f873da160b232926fa1b6cde75c24e5344a04
+      # The runner already mounts its tool cache, but at /__t, and the prebuilt
+      # CPython in there was installed on the runner image with
+      # RUNNER_TOOL_CACHE=/opt/hostedtoolcache. Nothing rewrites paths on the
+      # way in (actions/python-versions' setup.sh only copies and symlinks), so
+      # bin/pip still starts `#!/opt/hostedtoolcache/.../python3.11` -- a path
+      # that does not exist under this mount name. actions/setup-python found
+      # 3.11.16, reported "Successfully set up CPython", then failed to launch
+      # its own pip: `spawn /__t/Python/3.11.16/x64/bin/pip ENOENT`.
+      #
+      # Mounting the same host directory a second time under the name its
+      # shebangs already expect fixes it without a download. The alternative,
+      # pointing RUNNER_TOOL_CACHE somewhere container-local, makes setup-python
+      # fetch CPython fresh on every job -- a new network dependency in front of
+      # a paid run, which is the shape of the 2026-08-19 apt outage.
+      volumes:
+        - /opt/hostedtoolcache:/opt/hostedtoolcache
     # A container job defaults `run:` to `sh -e {0}`, not to the runner's
     # `bash -e {0}` -- the runner will not assume an arbitrary image has bash.
     # The free 2026-08-24 rehearsal found it on the first step (`set: Illegal
@@ -545,6 +561,9 @@ jobs:
     # against a different renderer than the paid run proves nothing.
     container:
       image: ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c056e31e1ea1d693fc2f8f873da160b232926fa1b6cde75c24e5344a04
+      # Same reason as grade-dry-run; see the note there.
+      volumes:
+        - /opt/hostedtoolcache:/opt/hostedtoolcache
     # Same reason as grade-dry-run; see the note there. What makes it matter
     # more here is where the bash syntax sits: Run grading, Commit grade
     # result, Merge shards, Auto-analyze and Commit analysis all use [[ ]] or

--- a/batch-runner/tests/test_grading_image.py
+++ b/batch-runner/tests/test_grading_image.py
@@ -159,6 +159,39 @@ def test_grading_jobs_run_in_the_published_image_by_digest():
     assert len(images) == 1, sorted(images)
 
 
+def test_grading_jobs_mount_the_toolcache_where_its_shebangs_point():
+    """The runner's prebuilt CPython only works under its build-time path.
+
+    The runner mounts its tool cache at /__t, but the CPython inside it was
+    installed on the runner image with RUNNER_TOOL_CACHE=/opt/hostedtoolcache
+    and nothing rewrites paths on the way in, so ``bin/pip`` still starts
+    ``#!/opt/hostedtoolcache/.../python3.11``. The free 2026-08-24 rehearsal
+    got "Successfully set up CPython (3.11.16)" and then ``spawn
+    /__t/Python/3.11.16/x64/bin/pip ENOENT`` from setup-python's own pip.
+
+    Mounting the same host directory again under the name the shebangs expect
+    costs nothing at run time. Pointing RUNNER_TOOL_CACHE at a container-local
+    path instead would work too, but only by downloading CPython before every
+    paid job.
+    """
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+    mount = "/opt/hostedtoolcache:/opt/hostedtoolcache"
+
+    for name in GRADING_JOBS:
+        job = grade["jobs"][name]
+        volumes = job["container"].get("volumes") or []
+        assert mount in volumes, (name, volumes)
+
+        # The mount only matters because these jobs take their interpreter
+        # from the tool cache rather than from the image, which carries none.
+        setup = [
+            step for step in job["steps"]
+            if str(step.get("uses", "")).startswith("actions/setup-python@")
+        ]
+        assert len(setup) == 1, name
+        assert str(setup[0]["with"]["python-version"]).startswith("3.11"), name
+
+
 def test_grading_jobs_run_their_steps_under_bash():
     """A container job defaults `run:` to sh, and these steps are bash.
 


### PR DESCRIPTION
## What broke

The free `dry_run=true` rehearsal on merged `main` (run 32700945259) got past every fix so far and then died at **Setup Python**, one line after succeeding:

```
Successfully set up CPython (3.11.16)
Error: spawn /__t/Python/3.11.16/x64/bin/pip ENOENT
```

`pip` was present at that path. So was the interpreter. What was missing is the path baked into pip's **shebang**.

## Why

The runner bind-mounts its host tool cache into the container as `/__t` (visible in the `docker create` line: `-v "/opt/hostedtoolcache":"/__t"`). But the CPython in that cache was installed when the *runner image* was built, with `RUNNER_TOOL_CACHE=/opt/hostedtoolcache`. The setup script `actions/python-versions` ships inside each build only copies files and creates symlinks — it rewrites no paths (confirmed by reading `installers/nix-setup-template.sh` upstream). So `bin/pip` still starts:

```
#!/opt/hostedtoolcache/Python/3.11.16/x64/bin/python3.11
```

Under the `/__t` mount name that file does not exist. `ENOENT` names `pip` because `pip` is what was spawned; the thing actually not found is its interpreter.

Outside a container this never appears — there, the tool cache *is* at `/opt/hostedtoolcache`.

## Fix

Mount the same host directory a second time, under the name the shebangs already expect:

```yaml
volumes:
  - /opt/hostedtoolcache:/opt/hostedtoolcache
```

Nothing is downloaded and nothing is copied; it is one extra bind of a directory the runner is already binding.

### The alternative, and why not

Pointing `RUNNER_TOOL_CACHE` at a container-local path also works — `setup-python` would then install 3.11 fresh inside the container, with correct shebangs. But that means **fetching CPython over the network before every job**, including every paid one. That is a new network dependency in front of paid work, structurally the same as the 2026-08-19 apt mirror stall that held five grade jobs for 5h18m and killed 63 of 220 tasks. The whole point of moving to a pinned image was removing that class of dependency, not relocating it.

## Test

`test_grading_jobs_mount_the_toolcache_where_its_shebangs_point` asserts the mount on both `grade-dry-run` and `grade`, and asserts alongside it that each job still takes its interpreter from `actions/setup-python` at 3.11.

That second half is deliberate. The mount is load-bearing *only because* the grading image carries no `python3` of its own. If that ever changes, the mount should be reconsidered rather than left behind as cargo — and the test will point at it.

Mutation-checked: removing the `volumes:` block from either job fails; dropping `setup-python` fails.

## Context

Third container-vs-runner defect found by a **free** rehearsal since the grading jobs moved into the pinned image:

| # | Defect | PR |
|---|--------|-----|
| 1 | `container:` defaults `run:` to `sh -e {0}`, not bash | #218 |
| 2 | git `dubious ownership` — root in the container vs. runner-owned `/__w` | #219 |
| 3 | toolcache shebangs point at a path absent under `/__t` | this PR |

Each would have aborted a paid run. Finding all three cost nothing.

## Verification

- Full local suite: **3524 passed, 6 skipped, 45 deselected** (`596a0e42` was 3523; the delta is this test)
- Targeted: `test_grading_image.py tests/test_step8_grade.py tests/test_agentic_workflows.py` → 257 passed
- No behaviour change outside the two `container:` blocks; grading logic, prompts, configs, and `grader_source_hash` inputs are untouched

Next after merge: re-dispatch the free `dry_run=true` rehearsal from `main`.