### PR TITLE
fix(grading): give pip a cache directory root actually owns

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -359,6 +359,19 @@ jobs:
   # LC_ALL=C.UTF-8 for the renderer either way, so this only keeps Python's
   # default encoding identical to what the corpus was graded under.
   #
+  # PIP_CACHE_DIR moves pip's cache off $HOME. Steps here run as root, and the
+  # runner bind-mounts $HOME=/github/home from its own work directory, so it
+  # stays owned by the runner user. For root, pip does not ask whether it can
+  # write the cache -- it asks who owns it, and takes anything else as the
+  # sudo-without-H mistake it is guarding against (utils/filesystem.py:
+  # `if os.geteuid() == 0: return path_uid == 0`). It then disables the cache,
+  # and `pip cache dir` -- the first thing `cache: "pip"` runs -- exits 1
+  # because there is no cache to report. The free 2026-08-24 rehearsal died
+  # there. chmod does not help; only ownership does. A container-local path
+  # under /root is owned by root, so the cache stays on, which matters:
+  # dropping `cache: "pip"` instead would put a full PyPI download in front of
+  # every paid run.
+  #
   # What the image deliberately does not carry, and why that is safe:
   #   gh      -- one call site, the auto-resume dispatch below. It now POSTs to
   #              the REST endpoint that `gh workflow run` wraps, using curl,
@@ -417,6 +430,7 @@ jobs:
       GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
       ImageOS: ubuntu24
       LANG: C.UTF-8
+      PIP_CACHE_DIR: /root/.cache/pip
     steps:
       - name: Verify grading container
         run: |
@@ -590,6 +604,7 @@ jobs:
       GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
       ImageOS: ubuntu24
       LANG: C.UTF-8
+      PIP_CACHE_DIR: /root/.cache/pip
     # GH Actions hosted runners have a HARD 6h (360min) timeout that cannot be
     # extended. We set 320min so step8_grade.py's internal 4h time guard (env
     # GRADER_TIME_BUDGET_SEC=14400) trips first, partial-saves, and exits 7,

--- a/batch-runner/tests/test_grading_image.py
+++ b/batch-runner/tests/test_grading_image.py
@@ -192,6 +192,50 @@ def test_grading_jobs_mount_the_toolcache_where_its_shebangs_point():
         assert str(setup[0]["with"]["python-version"]).startswith("3.11"), name
 
 
+def test_grading_jobs_give_pip_a_cache_dir_root_actually_owns():
+    """As root, pip checks who owns its cache, not whether it can write there.
+
+    Container steps run as root, and $HOME is /github/home, bind-mounted from
+    the runner user's own work directory -- so root can write it but does not
+    own it. pip reads that as the sudo-without-H mistake and disables the
+    cache outright (utils/filesystem.py: ``if os.geteuid() == 0: return
+    path_uid == 0``). ``pip cache dir``, which is the first thing
+    ``cache: "pip"`` runs, then exits 1 with "pip cache commands can not
+    function since cache is disabled". The free 2026-08-24 rehearsal died
+    there, one step after setup-python reported success.
+
+    Reproduced as root against a uid-1001 $HOME: chmod 777 does not help, and
+    a container-local PIP_CACHE_DIR does -- the HTTP cache fills and a second
+    install reports "Using cached".
+
+    So the cache is kept rather than dropped, and the assertion is the pair:
+    ``cache: "pip"`` is only safe here while PIP_CACHE_DIR points somewhere
+    root owns. Dropping the cache would work too, at the price of a full PyPI
+    download in front of every paid run.
+    """
+    grade = _workflow(GRADE_WORKFLOW_PATH)
+
+    # Bind-mounted from the runner and left in the runner user's ownership:
+    # the two roots pip will refuse for exactly the reason above.
+    runner_owned = ("/github/home", "/__w", "/home/runner")
+
+    for name in GRADING_JOBS:
+        job = grade["jobs"][name]
+
+        cached = [
+            step for step in job["steps"]
+            if str(step.get("uses", "")).startswith("actions/setup-python@")
+            and (step.get("with") or {}).get("cache")
+        ]
+        if not cached:
+            continue
+
+        cache_dir = (job.get("env") or {}).get("PIP_CACHE_DIR")
+        assert cache_dir, f"{name} caches pip without steering PIP_CACHE_DIR"
+        assert cache_dir.startswith("/"), (name, cache_dir)
+        assert not cache_dir.startswith(runner_owned), (name, cache_dir)
+
+
 def test_grading_jobs_run_their_steps_under_bash():
     """A container job defaults `run:` to sh, and these steps are bash.
 


### PR DESCRIPTION
## What happened

The rehearsal after #220 (run 32703736955) got one step further and stopped in the same action:

```
Successfully set up CPython (3.11.16)
[command]/__t/Python/3.11.16/x64/bin/pip cache dir
WARNING: The directory '/github/home/.cache/pip' or its parent directory is not owned
or is not writable by the current user. The cache has been disabled. ...
ERROR: pip cache commands can not function since cache is disabled.
##[error]The process '/__t/Python/3.11.16/x64/bin/pip' failed with exit code 1
```

First, the good news buried in that: **#220 worked.** `pip` *ran* — those are pip's own diagnostics. The previous failure was `spawn ... ENOENT`, meaning it could not be launched at all.

## Why the error message is misleading

"or is not writable by the current user" invites a `chmod`. That is not the problem, and `chmod` does not touch it.

Container steps run as **root**, and pip treats root as a special case. It stops asking whether it *can* write the cache and asks *who owns* it:

```python
# pip/_internal/utils/filesystem.py
if os.geteuid() == 0:
    # Special handling for root user in order to handle properly
    # cases where users use sudo without -H flag.
    return path_uid == 0
```

`$HOME` is `/github/home`, bind-mounted from the runner's own work directory, so it keeps the runner user's ownership no matter how root the process is. pip reads that as the sudo-without-`-H` mistake it guards against, disables the cache, and `pip cache dir` — the first thing `cache: "pip"` runs — exits 1 because there is no longer a cache to report.

Outside a container this never fires: the job is not root, so pip takes the `os.access(path, W_OK)` branch instead.

## Reproduced

As root against a uid-1001 `$HOME` (`python:3.12-slim`, no rendering involved, so this box could actually run it):

| | result |
|---|---|
| default `$HOME=/github/home` owned by uid 1001 | both log lines, **verbatim** |
| same, plus `chmod 777` | **still fails** → ownership, not permissions |
| `PIP_CACHE_DIR=/root/.cache/pip` | `pip cache dir` → `/root/.cache/pip`, exit 0 |
| …after one install | HTTP cache 193 kB, 8 files; second install reports `Using cached` |

## Fix

```yaml
env:
  PIP_CACHE_DIR: /root/.cache/pip
```

on both grading jobs. `/root` is inside the image and owned by root, so pip's check passes and the cache stays **on**.

### Why not just drop `cache: "pip"`

It would also make the error go away — by putting a full PyPI download in front of every paid run. That is the dependency shape this whole migration exists to remove (cf. the 2026-08-19 apt mirror stall: 5h18m, 63 of 220 tasks lost). Not a trade worth making to avoid one env var.

### Why not change `HOME`

`git` and `az` key off `HOME` too, and `azure/login` writes `$HOME/.azure` for later steps to read. Much larger blast radius, to fix one tool. The narrow variable is the right lever.

## Test

`test_grading_jobs_give_pip_a_cache_dir_root_actually_owns` asserts the pairing rather than the value: **if** a grading job enables `cache` on `setup-python`, **then** `PIP_CACHE_DIR` must be set, absolute, and outside `/github/home`, `/__w`, `/home/runner`.

Stated that way it stays true if the cache is ever dropped deliberately, and fails if someone re-adds it without the variable, or points the variable back into the bind mount.

Mutation-checked — both caught:
- remove `PIP_CACHE_DIR` from `grade-dry-run` → fails
- point it at `/github/home/.cache/pip` → fails

## Scorecard so far

| # | Defect | Found by | PR |
|---|--------|----------|-----|
| 1 | `container:` defaults `run:` to `sh`, not bash | free rehearsal | #218 |
| 2 | git `dubious ownership` — root vs. runner-owned `/__w` | free rehearsal | #219 |
| 3 | toolcache shebangs point outside `/__t` | free rehearsal | #220 |
| 4 | pip-as-root demands cache ownership | free rehearsal | this PR |

Four defects, four free runs, no money spent finding any of them. Each would have aborted a paid dispatch.

## One thing worth recording

The failing run reached `Setup Python`, which means everything before it now passes in-container: `Verify grading container` printed `LibreOffice 24.2.7.2 420(Build:2)`, and the `safe.directory` step from #219 ran under `bash -e {0}`.

It also means the step after this one — `Preflight grading renderer` — is now the next thing to execute, and that step is not a smoke test: it writes real `.xlsx`/`.pptx`/`.docx` fixtures, drives each through LibreOffice → PyMuPDF, and checks the PNG signature, byte size, scope and the whole renderer fingerprint. So the **free** dry run exercises the actual render path end to end, as root, in the pinned image. What remains exercised only on the paid path is narrower than previously assumed: `azure/login`, and the three git pushes in `Commit grade result` / `Merge shards` / `Commit analysis`.

## Verification

- Full local suite: **3525 passed**, 6 skipped, 45 deselected (`d70485f2` was 3524)
- Targeted: 258 passed
- No change outside the two `env:` blocks — grading logic, prompts, configs and `grader_source_hash` inputs untouched