### PR TITLE
chore(grading): explain summary.wow drift on two retired 2026-06 runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/select_agentic_tasks.py
 !batch-runner/scripts/sweep_stalled_shard_relays.py
 !batch-runner/scripts/judge_error_breakdown.py
+!batch-runner/scripts/summary_wow_drift.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Added
+- **Two retired 2026-06 grade runs no longer recompute, and now we can say
+  why.** `judge_gpt-5_4__rubric_v2_tools` publishes
+  `rubric_item_coverage_avg` 0.4232 and `critical_item_pass_rate` 0.501 where
+  today's summariser makes 0.4338 and 0.485; the `_mini` run drifts the same
+  way (0.4533 → 0.4646, 0.528 → 0.5128). **One cause, not two:** `6ad789a`
+  (#69) taught `_compute_summary` to skip items carrying `score_excluded`, and
+  both files were graded before it. Deleting that gate — changing nothing else
+  — reproduces all five published rates exactly in both files. The gate removes
+  255 items, every one a `judge_error` the judge never managed to score (243
+  `selection_error`, 12 `wrong_format_primary`, spread over 17 of 220 tasks).
+  Coverage rises because it keeps its whole numerator — a judge error is never
+  a `pass` — while critical falls because all 15 of its excluded items are
+  flagged `model_did_right`. The other three rates reproduce unchanged, which
+  reflects the gate being a no-op for them on this corpus rather than those
+  paths being untouched. **Nothing official moved:** both runs were retired as
+  comparators in Phase 5, and the sol-220 R1 result and its comparator
+  recompute to the digit. Across all 37 published payloads: 31 reproduce, 2 are
+  this gate, 4 are the already-known pre-sign-aware `__v1.json` files, and 0
+  are unexplained. `scripts/summary_wow_drift.py` recomputes every payload with
+  the production summariser and exits nonzero only for drift that matches no
+  rule we have shipped; `tests/test_summary_wow_drift.py` pins the finding, and
+  `data/grades/_validation/SUMMARY_WOW_DRIFT.md` records the full history and
+  the options. **Diagnosis only — no payload was edited and no rate was
+  republished**, so every number already cited stays citable.
+
 ### Removed
 - **Task 207 — the legacy grader code is gone.** `core/grader_batch.py`
   (508 lines) is deleted, and with it every batch / tier-routing / text-extract

--- a/batch-runner/scripts/summary_wow_drift.py
+++ b/batch-runner/scripts/summary_wow_drift.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Recompute every published ``summary.wow`` rate and account for what differs.
+
+A grade file carries two things that are supposed to agree: the rubric items
+the judge produced, and the five headline rates in ``summary.wow`` computed
+from them. The rates are written once, by whatever the summariser was on the
+day the run finished, and are never revisited afterwards -- ``#188`` backfilled
+the by-sector, histogram and severity blocks into the older files deliberately
+*without* republishing the rates, so that no number anyone had already cited
+moved underneath them.
+
+That is the right call, and it has a consequence: a grade file stops being
+self-consistent the moment the summariser's counting rule changes. The stored
+rate and a fresh recompute of the same frozen items then disagree, and neither
+is wrong on its own terms -- one is what we published, the other is what the
+rule says today. What is not acceptable is not knowing which rule produced a
+given number, because then a rate cannot be compared with any other rate.
+
+So this does not "fix" anything and never writes to a payload. It recomputes
+each file with the production summariser, and where that disagrees with what
+is stored it tries to reproduce the stored value with each summariser rule we
+have actually shipped. A file that matches one of them is explained. A file
+that matches none is the only interesting output here, and the only thing that
+sets a nonzero exit code.
+
+The two rules that are not the current one:
+
+``pre-#69``
+    Before ``6ad789a`` the item loop had no ``score_excluded`` gate at all.
+    Judge errors -- items the judge never managed to score -- were counted in
+    every denominator as though the model had failed them. ``#69`` added the
+    gate, which shrinks ``all_items`` and ``critical_items`` and therefore
+    moves ``rubric_item_coverage_avg`` *up* and, because the numerator loses
+    items too, ``critical_item_pass_rate`` *down*.
+
+``pre-#100``
+    Before ``240b860`` there was no ``model_did_right`` on an item at all, so
+    ``critical_item_pass_rate`` was taken from the raw verdict. Those files are
+    the four ``__v1.json`` payloads and their drift is a separate story from
+    the one above; they are reported under their own cause so the two never get
+    added together.
+
+Imports the real ``step8_grade._compute_summary`` rather than reimplementing
+it. The question being asked is whether the *production* summariser reproduces
+a published file, and a reimplementation would quietly answer a different
+question -- it would agree with itself.
+
+Run it from ``batch-runner/``::
+
+    python3 scripts/summary_wow_drift.py                  # whole corpus
+    python3 scripts/summary_wow_drift.py ../data/grades/<one file>.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parent.parent
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.grader import _is_critical_item  # noqa: E402
+from step8_grade import _compute_summary  # noqa: E402
+
+DEFAULT_ROOT = BATCH_RUNNER_ROOT.parent / "data" / "grades"
+
+WOW_RATES = (
+    "rubric_item_coverage_avg",
+    "critical_item_pass_rate",
+    "precheck_pass_rate",
+    "judge_pass_rate",
+    "judge_error_rate",
+)
+
+CAUSE_MATCH = "reproduces"
+CAUSE_PRE_69 = "pre-#69 summariser (no score_excluded gate)"
+CAUSE_PRE_100 = "pre-#100 payload (no model_did_right on items)"
+CAUSE_UNKNOWN = "UNEXPLAINED"
+
+
+def iter_items(tasks: list[dict]):
+    for task in tasks:
+        for item in task.get("items", []):
+            if isinstance(item, dict):
+                yield item
+
+
+def pre_69_wow(tasks: list[dict]) -> dict[str, float]:
+    """``_compute_summary``'s item loop as it stood before ``6ad789a`` (#69).
+
+    Transcribed from that revision rather than derived: no ``score_excluded``
+    anywhere, and ``round(x, 4)`` on every rate including ``judge_error_rate``,
+    which only later moved to the half-up ``canonical_rate``.
+    """
+    all_items = all_pass = 0
+    pre_items = pre_pass = 0
+    judge_items = judge_pass = judge_errors = 0
+    critical_items = critical_pass = 0
+
+    for item in iter_items(tasks):
+        verdict = item.get("verdict")
+        all_items += 1
+        if verdict == "pass":
+            all_pass += 1
+        if item.get("decided_by") == "precheck":
+            pre_items += 1
+            if verdict == "pass":
+                pre_pass += 1
+        if item.get("decided_by") == "judge":
+            judge_items += 1
+            if verdict == "pass":
+                judge_pass += 1
+            if verdict == "judge_error":
+                judge_errors += 1
+        if _is_critical_item(item.get("max_score")):
+            critical_items += 1
+            if bool(item.get("model_did_right", False)):
+                critical_pass += 1
+
+    def rate(numerator: int, denominator: int) -> float:
+        return round((numerator / denominator) if denominator else 0.0, 4)
+
+    return {
+        "rubric_item_coverage_avg": rate(all_pass, all_items),
+        "critical_item_pass_rate": rate(critical_pass, critical_items),
+        "precheck_pass_rate": rate(pre_pass, pre_items),
+        "judge_pass_rate": rate(judge_pass, judge_items),
+        "judge_error_rate": rate(judge_errors, judge_items),
+    }
+
+
+@dataclass
+class Finding:
+    path: Path
+    task_count: int
+    drift: tuple[str, ...]
+    cause: str
+    notes: tuple[str, ...] = ()
+
+    @property
+    def explained(self) -> bool:
+        return self.cause != CAUSE_UNKNOWN
+
+
+def gate_delta(tasks: list[dict]) -> tuple[str, ...]:
+    """Per-counter effect of the ``score_excluded`` gate, for the report.
+
+    This is the minimal diff: which items the two rules disagree about, and
+    what that does to each numerator and denominator.
+    """
+    excluded = [i for i in iter_items(tasks) if i.get("score_excluded")]
+    if not excluded:
+        return ()
+    passing = sum(1 for i in excluded if i.get("verdict") == "pass")
+    critical = [i for i in excluded if _is_critical_item(i.get("max_score"))]
+    right = sum(1 for i in critical if bool(i.get("model_did_right", False)))
+    verdicts = sorted({str(i.get("verdict")) for i in excluded})
+    return (
+        f"{len(excluded)} score_excluded item(s), verdict(s)={','.join(verdicts)}",
+        f"coverage: denominator -{len(excluded)}, numerator -{passing}",
+        f"critical: denominator -{len(critical)}, numerator -{right}",
+    )
+
+
+def classify(path: Path, payload: dict) -> Finding | None:
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        return None
+    published = summary.get("wow")
+    if not isinstance(published, dict) or not any(k in published for k in WOW_RATES):
+        return None
+    tasks = payload.get("tasks")
+    if not isinstance(tasks, list):
+        return None
+
+    current = _compute_summary(tasks)["wow"]
+    drift = tuple(k for k in WOW_RATES if published.get(k) != current.get(k))
+    if not drift:
+        return Finding(path, len(tasks), (), CAUSE_MATCH)
+
+    if all(published.get(k) == pre_69_wow(tasks).get(k) for k in WOW_RATES):
+        return Finding(path, len(tasks), drift, CAUSE_PRE_69, gate_delta(tasks))
+
+    # Deliberately not reconstructed. These predate `model_did_right`, so the
+    # metric that reads it is the only one that can move, and reproducing
+    # their arithmetic would invite adding their drift to the gate's.
+    has_flag = any("model_did_right" in i for i in iter_items(tasks))
+    if not has_flag and drift == ("critical_item_pass_rate",):
+        return Finding(path, len(tasks), drift, CAUSE_PRE_100)
+
+    return Finding(
+        path,
+        len(tasks),
+        drift,
+        CAUSE_UNKNOWN,
+        tuple(
+            f"{k}: published={published.get(k)} recomputed={current.get(k)}"
+            for k in drift
+        ),
+    )
+
+
+def collect(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files += [
+                p
+                for p in sorted(path.rglob("*.json"))
+                if "_validation" not in p.parts
+            ]
+        elif path.is_file():
+            files.append(path)
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_ROOT],
+        help="grade files or directories to scan (default: data/grades)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="print only files whose drift is unexplained",
+    )
+    args = parser.parse_args()
+
+    findings: list[Finding] = []
+    for path in collect(args.paths):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        finding = classify(path, payload)
+        if finding is not None:
+            findings.append(finding)
+
+    if not findings:
+        print("no grade payloads with summary.wow rates found")
+        return 0
+
+    unexplained = [f for f in findings if not f.explained]
+    order = [CAUSE_UNKNOWN, CAUSE_PRE_69, CAUSE_PRE_100, CAUSE_MATCH]
+    lines: list[str] = []
+    for cause in order:
+        group = [f for f in findings if f.cause == cause]
+        if not group:
+            continue
+        if args.quiet and cause != CAUSE_UNKNOWN:
+            continue
+        lines.append(f"{cause}: {len(group)} payload(s)")
+        for finding in group:
+            lines.append(f"  {finding.path.name}  ({finding.task_count} tasks)")
+            if finding.drift:
+                lines.append(f"    drifting: {', '.join(finding.drift)}")
+            for note in finding.notes:
+                lines.append(f"    {note}")
+        lines.append("")
+
+    lines.append(
+        f"{len(findings)} payload(s) checked, "
+        f"{len(unexplained)} with unexplained drift"
+    )
+    if unexplained:
+        lines.append(
+            "  An unexplained rate cannot be compared with any other rate. "
+            "Find the summariser change before citing these."
+        )
+    print("\n".join(lines))
+    return 1 if unexplained else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/batch-runner/tests/test_summary_wow_drift.py
+++ b/batch-runner/tests/test_summary_wow_drift.py
@@ -1,0 +1,205 @@
+"""Tests for the ``summary.wow`` drift diagnosis.
+
+The finding these pin down is narrow and worth stating plainly: two grade files
+published in 2026-06 no longer recompute, and the whole difference is one
+counting rule. ``#69`` taught the summariser to skip items the judge never
+managed to score. Both files were graded before that, so their stored rates
+count 255 judge errors as though the model had failed them.
+
+``test_deleting_the_gate_reproduces_both_published_files`` is the load-bearing
+one. It does not merely observe a difference; it reconstructs the pre-``#69``
+loop and shows it lands on all five published rates exactly, which is what
+turns "these numbers disagree" into "these numbers were produced by a rule we
+can name". A companion test proves that reconstruction is not vacuous by
+showing it disagrees with the current summariser on the same input.
+
+``test_the_official_sol_220_run_still_reproduces`` is the one that decides
+whether any of this matters to a reader of the dashboard. It does not: the
+badged run was graded after the change and recomputes to the digit.
+
+The corpus-wide guard is ``test_no_published_payload_has_unexplained_drift``.
+Two known causes, four payloads under the second, nothing left over. If a
+future summariser change lands without a note, that test is where it surfaces.
+"""
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import summary_wow_drift as swd
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GRADES = REPO_ROOT / "data" / "grades"
+
+# Graded 2026-06-10 and 2026-06-04 respectively, both before `6ad789a` (#69).
+TOOLS = (
+    "exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools.json"
+)
+MINI = (
+    "exp003_GPT52Chat_baseline_runner_exec"
+    "__judge_gpt-5_4-mini__rubric_v2_tools_mini.json"
+)
+
+# The sol-220 run badged OFFICIAL, matched by its source-hash segment because
+# the full stem also carries config, rubric and inference hashes.
+OFFICIAL_SRC = "src_1c967673eb8081a6"
+
+# Left column is what the file says; right column is what today's summariser
+# makes of the same items. Transcribed, not computed, so that a change to
+# either side has to be argued for rather than absorbed.
+DRIFT = {
+    TOOLS: {
+        "rubric_item_coverage_avg": (0.4232, 0.4338),
+        "critical_item_pass_rate": (0.501, 0.485),
+    },
+    MINI: {
+        "rubric_item_coverage_avg": (0.4533, 0.4646),
+        "critical_item_pass_rate": (0.528, 0.5128),
+    },
+}
+
+# Both files were graded against the same rubric by two different judges, so
+# the items the gate removes are identical in each: 255 judge errors, of which
+# 15 are critical. None of the 255 is a `pass`, which is why the coverage
+# numerator does not move and only its denominator does.
+EXCLUDED_ITEMS = 255
+EXCLUDED_CRITICAL = 15
+
+
+def _load(name: str) -> dict:
+    return json.loads((GRADES / name).read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def payloads() -> dict[str, dict]:
+    return {name: _load(name) for name in DRIFT}
+
+
+@pytest.mark.parametrize("name", sorted(DRIFT))
+def test_the_two_2026_06_runs_drift_in_exactly_two_rates(payloads, name):
+    published = payloads[name]["summary"]["wow"]
+    current = swd._compute_summary(payloads[name]["tasks"])["wow"]
+
+    drifting = {
+        key: (published[key], current[key])
+        for key in swd.WOW_RATES
+        if published[key] != current[key]
+    }
+    assert drifting == DRIFT[name]
+
+    # The other three are untouched, and say so explicitly: a reader should
+    # not have to infer which rates are safe to quote from a list of which
+    # are not.
+    for key in set(swd.WOW_RATES) - set(DRIFT[name]):
+        assert published[key] == current[key], key
+
+
+@pytest.mark.parametrize("name", sorted(DRIFT))
+def test_deleting_the_gate_reproduces_both_published_files(payloads, name):
+    legacy = swd.pre_69_wow(payloads[name]["tasks"])
+    published = payloads[name]["summary"]["wow"]
+
+    assert {key: legacy[key] for key in swd.WOW_RATES} == {
+        key: published[key] for key in swd.WOW_RATES
+    }
+
+
+@pytest.mark.parametrize("name", sorted(DRIFT))
+def test_the_reconstructed_rule_is_not_the_current_one(payloads, name):
+    """Guard against `pre_69_wow` quietly becoming a copy of the summariser.
+
+    If it ever did, the test above would still pass on files that reproduce
+    and would stop meaning anything on files that do not.
+    """
+    legacy = swd.pre_69_wow(payloads[name]["tasks"])
+    current = swd._compute_summary(payloads[name]["tasks"])["wow"]
+
+    assert {key for key in swd.WOW_RATES if legacy[key] != current[key]} == set(
+        DRIFT[name]
+    )
+
+
+@pytest.mark.parametrize("name", sorted(DRIFT))
+def test_the_gate_moves_the_two_rates_in_opposite_directions(payloads, name):
+    """Coverage rises, critical falls, and the counters say why.
+
+    Both denominators shrink. Coverage keeps its whole numerator, because a
+    judge error is never a `pass`, so the rate goes up. The critical numerator
+    loses every item the denominator does -- all 15 excluded critical items
+    are flagged `model_did_right` -- so that rate goes down instead.
+    """
+    published = payloads[name]["summary"]["wow"]
+    current = swd._compute_summary(payloads[name]["tasks"])["wow"]
+
+    assert current["rubric_item_coverage_avg"] > published["rubric_item_coverage_avg"]
+    assert current["critical_item_pass_rate"] < published["critical_item_pass_rate"]
+
+    excluded = [
+        item
+        for item in swd.iter_items(payloads[name]["tasks"])
+        if item.get("score_excluded")
+    ]
+    assert len(excluded) == EXCLUDED_ITEMS
+    assert {item["verdict"] for item in excluded} == {"judge_error"}
+    assert not [item for item in excluded if item["verdict"] == "pass"]
+
+    critical = [
+        item for item in excluded if swd._is_critical_item(item.get("max_score"))
+    ]
+    assert len(critical) == EXCLUDED_CRITICAL
+    assert all(item["model_did_right"] for item in critical)
+
+
+def test_the_official_sol_220_run_still_reproduces():
+    matches = [p for p in GRADES.glob(f"*{OFFICIAL_SRC}*.json")]
+    assert matches, f"no payload matching {OFFICIAL_SRC}"
+
+    for path in matches:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        published = payload["summary"]["wow"]
+        current = swd._compute_summary(payload["tasks"])["wow"]
+        assert {key: published[key] for key in swd.WOW_RATES} == {
+            key: current[key] for key in swd.WOW_RATES
+        }, path.name
+
+
+def test_no_published_payload_has_unexplained_drift():
+    findings = [
+        swd.classify(path, json.loads(path.read_text(encoding="utf-8")))
+        for path in swd.collect([GRADES])
+    ]
+    findings = [f for f in findings if f is not None]
+    assert findings, "no grade payloads found"
+
+    unexplained = [f.path.name for f in findings if not f.explained]
+    assert unexplained == []
+
+    by_cause = {}
+    for finding in findings:
+        by_cause.setdefault(finding.cause, []).append(finding.path.name)
+    assert sorted(by_cause[swd.CAUSE_PRE_69]) == sorted(DRIFT)
+    # The four pre-sign-aware `__v1.json` files. Counted separately on purpose:
+    # their drift has a different cause and must not be added to the gate's.
+    assert len(by_cause[swd.CAUSE_PRE_100]) == 4
+
+
+def test_an_unexplained_drift_is_reported_rather_than_absorbed(payloads, tmp_path):
+    payload = copy.deepcopy(payloads[TOOLS])
+    payload["summary"]["wow"]["judge_pass_rate"] = 0.1234
+
+    finding = swd.classify(tmp_path / "made_up.json", payload)
+
+    assert finding.cause == swd.CAUSE_UNKNOWN
+    assert "judge_pass_rate" in finding.drift
+
+
+def test_diagnosing_never_edits_the_payload(payloads):
+    """The whole exercise is read-only; nothing here may touch a grade file."""
+    for name, payload in payloads.items():
+        before = json.dumps(payload, sort_keys=True)
+        swd.classify(GRADES / name, payload)
+        swd.pre_69_wow(payload["tasks"])
+        assert json.dumps(payload, sort_keys=True) == before, name

--- a/data/grades/_validation/SUMMARY_WOW_DRIFT.md
+++ b/data/grades/_validation/SUMMARY_WOW_DRIFT.md
@@ -1,0 +1,148 @@
+# `summary.wow` Drift — Two Retired 2026-06 Runs
+
+**Diagnosis only.** No payload was edited, no rate was republished, and no
+grading was dispatched. Everything below was derived from files already in the
+repository plus `git`.
+
+Subjects:
+
+- `exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools.json`
+  (graded 2026-06-10)
+- `exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__rubric_v2_tools_mini.json`
+  (graded 2026-06-04)
+
+## TL;DR
+
+1. **One cause, not two.** `6ad789a` (#69, 2026-07-15) taught the summariser's
+   item loop to skip items carrying `score_excluded`. Both files were graded
+   before that commit, so their stored rates count 255 judge errors as though
+   the model had failed them. Removing the gate — and changing nothing else —
+   reproduces **all five** published rates exactly, in **both** files.
+
+2. **The two rates move in opposite directions for one reason.** The gate
+   shrinks both denominators. Coverage keeps its entire numerator, because a
+   judge error is never a `pass`, so it rises. The critical numerator loses
+   every item its denominator does, and loses proportionally more, so it falls.
+
+3. **No OFFICIAL number is affected.** Both runs were retired as comparators in
+   Phase 5 (`scripts/__tests__/official-filter.test.mjs`); the two ids the
+   dashboard still treats as official are the sol-220 R1 result and its
+   single sol-vs-sol predecessor, and both recompute to the digit.
+
+4. **Nothing is left over.** 37 published payloads carry `summary.wow` rates.
+   31 reproduce, 2 are the gate, 4 are the already-known pre-sign-aware
+   `__v1.json` files, 0 are unexplained.
+
+## The numbers
+
+`n/d` is the counter pair behind each rate.
+
+| file | rate | published | as `n/d` | recomputed | as `n/d` |
+|---|---|--:|---|--:|---|
+| tools | `rubric_item_coverage_avg` | 0.4232 | 4424 / 10453 | 0.4338 | 4424 / 10198 |
+| tools | `critical_item_pass_rate` | 0.501 | 242 / 483 | 0.485 | 227 / 468 |
+| mini | `rubric_item_coverage_avg` | 0.4533 | 4738 / 10453 | 0.4646 | 4738 / 10198 |
+| mini | `critical_item_pass_rate` | 0.528 | 255 / 483 | 0.5128 | 240 / 468 |
+
+`precheck_pass_rate` (0.5832), `judge_pass_rate` and `judge_error_rate`
+reproduce unchanged in both files. That is **not** evidence that their code
+paths were left alone — it is evidence that the gate is a no-op for them on
+this corpus. All 255 excluded items are `decided_by: judge`, so none reaches
+the precheck counters; none is a `pass`, so none reaches `judge_pass`; and
+`judge_items` has never been gated.
+
+## What the gate removes
+
+All 255 are the same shape, in both files, because the two runs share a rubric
+and differ only by judge:
+
+| field | value |
+|---|---|
+| `verdict` | `judge_error` (255/255) |
+| `decided_by` | `judge` (255/255) |
+| `awarded_score` | `0.0` (255/255) |
+| `model_did_right` | `true` (255/255 — see below) |
+| `selection_status` | `selection_error` (243), `wrong_format_primary` (12) |
+| `max_score` | 1 (149), 2 (86), 5 (15), 3 (5) |
+| spread | 17 of 220 tasks |
+
+These are items the judge never managed to score. #69's position — the one the
+code still holds — is that charging them to the model measures the harness, not
+the model.
+
+The minimal diff, per file:
+
+```
+coverage: denominator -255, numerator   -0
+critical: denominator  -15, numerator  -15
+```
+
+The 15 are exactly the excluded items with `|max_score| >= 4`; all 15 carry
+`max_score: 5`, and all 15 carry `model_did_right: true`.
+
+## Change history
+
+| commit | date | PR | effect |
+|---|---|---|---|
+| `240b860` | 2026-05-29 | — | introduces `model_did_right`; `judge_error` → `False` |
+| `2cf4171` | 2026-06-03 | — | introduces `score_excluded`, and tests it **before** the `judge_error` branch, so judge errors get `model_did_right = True` |
+| **`6ad789a`** | **2026-07-15** | **#69** | **adds the `score_excluded` gate to `_compute_summary` — this is the drift** |
+| `6cdfb98` | 2026-08-10 | #168 | swaps those two branches back, so `judge_error` → `False` again; adds the `invalid_score_exclusion` guard; moves `judge_error_rate` to `canonical_rate` |
+| `bc14a91` | 2026-08-21 | #180 | refactors the loop into `_tally_item`; semantics unchanged |
+| `0e4a844` | 2026-08-21 | #188 | backfills `by_sector` / histogram / severity into the old files, deliberately **without** republishing the rates |
+
+Both grading commits are descendants of `2cf4171` and ancestors of `6ad789a`,
+which is the whole story: the files were written in the window where
+`score_excluded` existed on items but the summariser did not read it.
+
+`#188` is not a defect here. Leaving the rates alone is why a number anyone had
+already cited did not move underneath them — and why the drift is legible at
+all, instead of having been quietly overwritten.
+
+## Two differences that do not show up in this recompute
+
+**`model_did_right` on judge errors.** `2cf4171` ordered the branches so that
+`if it.score_excluded` won before `elif it.verdict == "judge_error"`, and
+`score_excluded` was already set upstream for judge errors. Every judge error
+in these files therefore claims the model did right. #168 restored the intended
+order. This does not change the recompute — the recompute reads the stored
+flag, and today's gate discards those items anyway — but it does mean the
+published `critical_item_pass_rate` of 0.501 credits the model for 15 items the
+judge failed to score. Applying both later fixes to these frozen verdicts lands
+on 227/468 either way: the flag fix and the gate remove the same 15 items.
+
+**Rounding.** `judge_error_rate` moved from `round()` (half-even) to
+`canonical_rate()` (half-up) in #168. Inert on this corpus — it reproduces
+everywhere — but it is a third rule change, and it would bite on an exact
+`.00005` tie.
+
+## Reproduce
+
+From `batch-runner/`:
+
+```bash
+# whole corpus, with the per-counter diff for anything that drifts
+python3 scripts/summary_wow_drift.py
+
+# the guard, as CI runs it
+python -m pytest tests/test_summary_wow_drift.py
+```
+
+The script exits nonzero only when a file's drift matches no summariser rule we
+have shipped. It never writes to a payload.
+
+## Options, not taken
+
+Listed for a decision; none of these is done, because each changes a published
+number or a schema.
+
+| | option | cost | consequence |
+|---|---|---|---|
+| A | **Leave both files as published** (recommended) | none | The rates stay comparable with the analysis docs and CHANGELOG entries that already quote them. `summary_wow_drift.py` plus its test keep the divergence named rather than rediscovered. Both runs are retired, so nothing on the dashboard reads them. |
+| B | Recompute the two rates in place from the frozen items | no model calls; a script run | Makes the files self-consistent, but silently changes 0.501 and 0.528 — both of which are quoted in the committed `.analysis.md` next to each payload. Those docs would have to move in the same commit, and any external citation would go stale. |
+| C | Stamp payloads with the summariser rule that produced them | schema field + migration | Removes the need to bisect next time. Worth doing only if the summariser is expected to keep changing; it does not help the files already written. |
+
+Option A is the recommendation. The published rates are not wrong — they are
+what the rule of the day produced over honestly-recorded items, on two runs
+that no longer back any live claim. What was missing was a way to tell that
+from an actual accounting error, and that is now checked on every CI run.


### PR DESCRIPTION
## What this is

Two published grade files stopped reproducing. This finds out why, and **changes no published number**.

| file | rate | published | recomputed |
|---|---|--:|--:|
| `judge_gpt-5_4__rubric_v2_tools` | `rubric_item_coverage_avg` | 0.4232 | 0.4338 |
| | `critical_item_pass_rate` | 0.501 | 0.485 |
| `judge_gpt-5_4-mini__rubric_v2_tools_mini` | `rubric_item_coverage_avg` | 0.4533 | 0.4646 |
| | `critical_item_pass_rate` | 0.528 | 0.5128 |

## Cause — one, not two

`6ad789a` (#69, 2026-07-15) taught `_compute_summary`'s item loop to skip items carrying `score_excluded`. Both files were graded before it — `9d9fd79` on 2026-06-10 and `cd085ea` on 2026-06-04, each a descendant of the commit that introduced the field and an ancestor of the commit that started reading it.

Deleting that gate and changing nothing else reproduces **all five** published rates exactly, in **both** files. The minimal per-counter diff:

```
coverage: denominator -255, numerator   -0
critical: denominator  -15, numerator  -15
```

The 255 are all `verdict: judge_error` — items the judge never managed to score (243 `selection_error`, 12 `wrong_format_primary`, across 17 of 220 tasks). Coverage keeps its entire numerator, because a judge error is never a `pass`, so the rate rises. The critical numerator loses every item its denominator does, so that rate falls instead. That is why the two move in opposite directions.

The other three rates reproduce unchanged. That is **not** evidence their code paths were untouched — it is evidence the gate is a no-op for them on this corpus, and the doc says so explicitly.

## Blast radius

37 published payloads carry `summary.wow` rates: **31 reproduce, 2 are this gate, 4 are the already-known pre-sign-aware `__v1.json` files, 0 are unexplained.** Those four are classified under their own cause on purpose, so their drift never gets added to this one's.

Nothing OFFICIAL is affected. Both subjects were retired as comparators in Phase 5; the sol-220 R1 result and its single surviving predecessor recompute to the digit, and there is a test for that.

## What's in the diff

- `batch-runner/scripts/summary_wow_drift.py` — recomputes every payload with the **real** `_compute_summary` (a reimplementation would only agree with itself), reproduces drift against each summariser rule we have actually shipped, and exits nonzero only when a file matches none. Never writes to a payload.
- `batch-runner/tests/test_summary_wow_drift.py` — 12 tests. The load-bearing one reconstructs the pre-#69 loop and lands on all five published rates; a companion proves that reconstruction is not just a copy of today's summariser. Both directions were mutation-checked before shipping.
- `data/grades/_validation/SUMMARY_WOW_DRIFT.md` — numbers, change history, two further rule changes that are inert on this corpus, repro commands, and options A/B/C.
- `.gitignore` — the new script needs an allowlist entry, same as its ten siblings.

## Recommendation

**Option A: leave both files as published.** The rates are not wrong — they are what the rule of the day produced over honestly-recorded items, on two runs that no longer back any live claim. `0.501` and `0.528` are quoted in the committed `.analysis.md` next to each payload; republishing would desync those and any external citation. What was missing was a way to tell this apart from a real accounting error, and that is now checked on every CI run.

## Verification

- `pytest -m "not integration"` — 3518 passed, 9 skipped (+12 collected, no regressions)
- `npm run test:aggregate` — 146 passed, 1 skipped
- `mypy scripts/summary_wow_drift.py --ignore-missing-imports` — clean
- `python3 scripts/summary_wow_drift.py` — `37 payload(s) checked, 0 with unexplained drift`, exit 0

No model call, no grading dispatch, no payload edit.

**Note:** merging touches `data/grades/**`, so this fires a Pages redeploy. It is a no-op — `aggregate-grades.mjs` reads that directory non-recursively and filters on `.json`, so a `.md` under `_validation/` is invisible to it.
