### PR TITLE
실행 환경 비교 — Azure 자원 고정 및 5개 작업 사전 점검 시도 결과

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ tasks/0720_monday/*
 !tasks/0822_saturday/
 tasks/0822_saturday/*
 !tasks/0822_saturday/TASK_GPT_EXECUTION_ENVELOPE_BENCHMARK.md
+!tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md
+!tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
+!tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
 
 *.parquet
 .huggingface/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,60 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Fixed
+- **A deployment name does not identify a deployment, and the run-place
+  comparison was relying on one.** The plan pinned `deployment: gpt-5.4` and
+  said nothing about which Azure AI Foundry account held it; the free check's
+  only Azure input was a single word naming the route. Listing the tenant while
+  preparing the five-task advance check turned up **two separate accounts each
+  exposing a deployment named exactly `gpt-5.4`**, plus a third exposing the
+  same model under a different name. The comparison could therefore have run one
+  column against one account's `gpt-5.4` and another column against a different
+  account's — different region, possibly different model version, possibly
+  different content filters — while every check reported that all three used the
+  same deployment, and nobody reading the table could have told. The plan now
+  pins the account and project, and `batch-runner/core/execution_envelope_azure.py`
+  classifies the endpoint settings the run itself would use, with this
+  repository's own endpoint rules rather than text matching, and refuses any
+  other account or project. Those names are settings the repository already
+  records for its own runs, not secrets.
+- **The Azure check gave the same answer to three different problems.** "Not
+  configured", "configured but pointing elsewhere", and "configured but
+  unreachable" all produced "the Azure route profile was not measured" — three
+  different fixes behind one unhelpful sentence, and working out which applied
+  took a manual investigation. The check now names the specific setting that is
+  wrong and prints the exact address that should have been supplied. It also
+  reports forbidden fixed credentials and the deprecated combined endpoint
+  setting during the free check, instead of letting a run be scheduled and fail
+  later on the same point. Everything still reads settings only: nothing signs
+  in, contacts Azure, or spends anything. Twelve new tests, including one where
+  the settings are well formed, the route is right, the deployment name is
+  unchanged, and **only the account differs** — the case that used to pass.
+
+### Added
+- **The approved spending ceiling for the five-task advance check is recorded**
+  as $32.23 in
+  `batch-runner/experiments/execution_envelope/advance_check_plan.yaml`, equal
+  to the worked-out ceiling to the cent so that any change making the run more
+  expensive pushes it over the line and stops rather than quietly spending more.
+  **The check itself did not run and nothing was spent**: the Azure account it
+  is pinned to sits in a different Azure tenant from the one signed in, a
+  Conditional Access policy refuses the token, and only an interactive browser
+  sign-in remains. Two of the three run places were ready; they were **not** run
+  on their own, because dropping a blocked run place and proceeding would answer
+  a different question from the approved one.
+- **Three standalone specifications** under `tasks/0822_saturday/`: pinning the
+  Azure resource; a four-stage route for Agentic Sandbox V2 from replaying a
+  written script to the model choosing its own next action, with running
+  commands deliberately last and behind its own approval and **none of the three
+  existing safety guards bypassed or weakened**; and what official documentation
+  does and does not say about Codex's own agent. For Codex, a non-interactive
+  mode and custom providers are confirmed, but **pointing its own agent at an
+  Azure AI Foundry deployment using a directory sign-in is not confirmed** — and
+  since every column must share one deployment, that single fact decides whether
+  the column can ever be honest, so it stays empty and marked unconfirmed rather
+  than filled with Azure's own agent service driving a similarly named model.
+
 ### Added
 - **The run-place comparison can now start on five tasks in three places, and
   every check that costs nothing to make refuses on every path that matters.**

--- a/batch-runner/core/execution_envelope_azure.py
+++ b/batch-runner/core/execution_envelope_azure.py
@@ -1,0 +1,234 @@
+"""Confirm the Azure run place would reach the *intended* deployment.
+
+A deployment name on its own does not identify a deployment. Two different
+Azure AI Foundry accounts in the same tenant can each expose a deployment named
+``gpt-5.4``, and they may sit in different regions, run different model
+versions, and apply different content filters. A comparison that pins only the
+name can therefore run against a resource nobody intended and still report that
+every run place used "the same deployment".
+
+That is not hypothetical. When the five-task advance check was first attempted,
+the tenant it was attempted from contained two accounts each exposing a
+deployment named ``gpt-5.4``, and a third exposing the same underlying model
+under a different deployment name.
+
+This module closes that hole. It reads the endpoint settings that are already
+in the environment, classifies them with the repository's own endpoint rules,
+and reports precisely which part does not line up with the account and project
+the plan pins. Every check here reads settings only: nothing contacts Azure,
+signs in, or spends money.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+# The settings that name each kind of Azure endpoint. These are the same names
+# core/azure_ai_clients.py reads, so a plan checked here is checked against the
+# variables the run itself will use.
+DIRECT_ENDPOINT_VARIABLE = "AZURE_OPENAI_V1_ENDPOINT"
+PROJECT_ENDPOINT_VARIABLE = "FOUNDRY_PROJECT_ENDPOINT"
+ROUTE_PROFILE_VARIABLE = "AZURE_AI_ROUTE_PROFILE"
+DEPRECATED_ENDPOINT_VARIABLE = "AZURE_OPENAI_ENDPOINT"
+
+# Static credentials this repository refuses to run with. Naming them here lets
+# the free check say so up front, instead of the run failing later with the
+# same complaint after someone has already scheduled it.
+FORBIDDEN_CREDENTIAL_VARIABLES = (
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_API_KEY",
+    "AZURE_AI_API_KEY",
+    "AZURE_AI_PROJECT_API_KEY",
+    "AZURE_OPENAI_AD_TOKEN",
+    "AZURE_CLIENT_SECRET",
+    "AZURE_CLIENT_CERTIFICATE_PATH",
+    "AZURE_CLIENT_CERTIFICATE_PASSWORD",
+    "AZURE_USERNAME",
+    "AZURE_PASSWORD",
+)
+
+
+@dataclass(frozen=True)
+class AzureConnectionRequirement:
+    """Which Azure resource the comparison is pinned to.
+
+    ``account`` is the Azure AI Foundry account, and ``project`` the project
+    inside it. Together with the deployment name they identify one deployment
+    exactly, which the deployment name alone does not.
+    """
+
+    account: str
+    project: str
+    route_profile: str
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "AzureConnectionRequirement":
+        missing = sorted({"account", "project", "route_profile"} - set(raw))
+        if missing:
+            raise ValueError(
+                "the Azure connection requirement is missing: "
+                + ", ".join(missing)
+            )
+        for name in ("account", "project", "route_profile"):
+            if not str(raw[name] or "").strip():
+                raise ValueError(
+                    f"the Azure connection requirement leaves {name} empty, so "
+                    "it does not identify one deployment"
+                )
+        return cls(
+            account=str(raw["account"]).strip(),
+            project=str(raw["project"]).strip(),
+            route_profile=str(raw["route_profile"]).strip(),
+        )
+
+
+@dataclass
+class AzureConnectionDiagnosis:
+    """What the settings say, and what is wrong with them."""
+
+    problems: list[str]
+    reachable_intent: bool
+    """True when the settings name exactly the pinned account and project.
+
+    This says the settings point at the intended resource. It does not say the
+    resource can be reached, because reaching it needs a sign-in and this check
+    never signs in.
+    """
+
+    observed_account: str | None = None
+    observed_project: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "settings_name_the_intended_resource": self.reachable_intent,
+            "observed_account": self.observed_account,
+            "observed_project": self.observed_project,
+            "problems": list(self.problems),
+        }
+
+
+def _classify(value: str):
+    module = importlib.import_module("core.azure_ai_clients")
+    return module.classify_endpoint(value)
+
+
+def diagnose_azure_connection(
+    requirement: AzureConnectionRequirement,
+    environ: Mapping[str, str],
+) -> AzureConnectionDiagnosis:
+    """Say exactly which part of the Azure setup does not match the plan.
+
+    The point of this function is that "not configured" and "configured, but
+    pointing somewhere else" are different problems with different fixes, and a
+    check that reports both as "not measured" sends the reader looking in the
+    wrong place.
+    """
+    problems: list[str] = []
+    observed_account: str | None = None
+    observed_project: str | None = None
+
+    profile = str(environ.get(ROUTE_PROFILE_VARIABLE, "") or "").strip()
+    if not profile:
+        problems.append(
+            f"{ROUTE_PROFILE_VARIABLE} is not set, so the Azure run place "
+            "refuses to start. It must be "
+            f"{requirement.route_profile!r} for this comparison."
+        )
+    elif profile != requirement.route_profile:
+        problems.append(
+            f"{ROUTE_PROFILE_VARIABLE} is {profile!r}, but this comparison "
+            f"requires {requirement.route_profile!r}"
+        )
+
+    deprecated = str(environ.get(DEPRECATED_ENDPOINT_VARIABLE, "") or "").strip()
+    if deprecated:
+        problems.append(
+            f"{DEPRECATED_ENDPOINT_VARIABLE} is set. This repository refuses to "
+            "run while it is, because it does not say which kind of endpoint it "
+            f"holds. Move the address to {PROJECT_ENDPOINT_VARIABLE} or "
+            f"{DIRECT_ENDPOINT_VARIABLE} and unset it."
+        )
+
+    present_forbidden = [
+        name for name in FORBIDDEN_CREDENTIAL_VARIABLES if environ.get(name)
+    ]
+    if present_forbidden:
+        problems.append(
+            "these fixed credentials are set, and this repository refuses to "
+            "run with any of them because it requires a sign-in that can be "
+            "traced to a person or a workload: " + ", ".join(present_forbidden)
+        )
+
+    project_endpoint = str(
+        environ.get(PROJECT_ENDPOINT_VARIABLE, "") or ""
+    ).strip()
+    if not project_endpoint:
+        problems.append(
+            f"{PROJECT_ENDPOINT_VARIABLE} is not set. The Azure run place needs "
+            "the address of the project that holds the deployment, which looks "
+            f"like https://{requirement.account}.services.ai.azure.com"
+            f"/api/projects/{requirement.project}"
+        )
+    else:
+        try:
+            endpoint = _classify(project_endpoint)
+        except Exception as error:
+            problems.append(
+                f"{PROJECT_ENDPOINT_VARIABLE} is not an address this "
+                f"repository recognises: {error}"
+            )
+        else:
+            observed_account = getattr(endpoint, "account", None)
+            observed_project = getattr(endpoint, "project", None)
+            if observed_account != requirement.account:
+                problems.append(
+                    f"{PROJECT_ENDPOINT_VARIABLE} names the account "
+                    f"{observed_account!r}, but the comparison is pinned to "
+                    f"{requirement.account!r}. A deployment name is not unique "
+                    "across accounts, so running against a different account "
+                    "would compare a different deployment while reporting the "
+                    "same name."
+                )
+            if observed_project != requirement.project:
+                problems.append(
+                    f"{PROJECT_ENDPOINT_VARIABLE} names the project "
+                    f"{observed_project!r}, but the comparison is pinned to "
+                    f"{requirement.project!r}"
+                )
+
+    direct_endpoint = str(environ.get(DIRECT_ENDPOINT_VARIABLE, "") or "").strip()
+    if direct_endpoint:
+        try:
+            endpoint = _classify(direct_endpoint)
+        except Exception as error:
+            problems.append(
+                f"{DIRECT_ENDPOINT_VARIABLE} is not an address this repository "
+                f"recognises: {error}"
+            )
+        else:
+            account = getattr(endpoint, "account", None)
+            if account != requirement.account:
+                problems.append(
+                    f"{DIRECT_ENDPOINT_VARIABLE} names the account "
+                    f"{account!r}, but the comparison is pinned to "
+                    f"{requirement.account!r}"
+                )
+
+    return AzureConnectionDiagnosis(
+        problems=problems,
+        reachable_intent=not problems,
+        observed_account=observed_account,
+        observed_project=observed_project,
+    )
+
+
+def describe_expected_project_endpoint(
+    requirement: AzureConnectionRequirement,
+) -> str:
+    """The address the settings should hold, written out so it can be checked."""
+    return (
+        f"https://{requirement.account}.services.ai.azure.com"
+        f"/api/projects/{requirement.project}"
+    )

--- a/batch-runner/core/execution_envelope_preflight.py
+++ b/batch-runner/core/execution_envelope_preflight.py
@@ -37,6 +37,11 @@ from core.execution_envelope_cost import (
     describe_cost_ceiling,
     estimate_cost_ceiling,
 )
+from core.execution_envelope_azure import (
+    AzureConnectionDiagnosis,
+    AzureConnectionRequirement,
+    diagnose_azure_connection,
+)
 from core.execution_envelope_tasks import (
     TaskCatalog,
     check_catalog_carries_no_scores,
@@ -79,6 +84,7 @@ class EnvelopePreflight:
     cost: CostCeiling | None
     problems: list[str] = field(default_factory=list)
     approved_maximum_usd: Decimal | None = None
+    azure: AzureConnectionDiagnosis | None = None
 
     @property
     def all_problems(self) -> list[str]:
@@ -109,6 +115,9 @@ class EnvelopePreflight:
                 else None
             ),
             "problems": self.all_problems,
+            "azure_connection": (
+                self.azure.as_dict() if self.azure is not None else None
+            ),
         }
 
 
@@ -567,12 +576,54 @@ def run_envelope_preflight(
         environ=environ,
     )
 
+    azure = _diagnose_azure(plan, conditions, environ, problems)
+
     return EnvelopePreflight(
         readiness=readiness,
         cost=ceiling,
         problems=problems,
         approved_maximum_usd=approved,
+        azure=azure,
     )
+
+
+def _diagnose_azure(
+    plan: Mapping[str, Any],
+    conditions: Mapping[str, ModelRunConditions],
+    environ: Mapping[str, str] | None,
+    problems: list[str],
+) -> AzureConnectionDiagnosis | None:
+    """Check the Azure run place points at the exact deployment that was pinned.
+
+    Skipped when the Azure run place is not taking part, because then there is
+    no Azure resource for the comparison to get wrong.
+    """
+    if ENVIRONMENT_AZURE_CODE_INTERPRETER not in conditions:
+        return None
+
+    raw = plan.get("azure_connection")
+    if not isinstance(raw, Mapping):
+        problems.append(
+            "the plan asks the Azure run place to take part but does not say "
+            "which Azure AI Foundry account and project must hold the "
+            "deployment. A deployment name is not unique across accounts, so "
+            "without this the comparison could run against a different "
+            "deployment of the same name and never notice."
+        )
+        return None
+
+    try:
+        requirement = AzureConnectionRequirement.from_mapping(raw)
+    except ValueError as error:
+        problems.append(str(error))
+        return None
+
+    import os
+
+    source = os.environ if environ is None else environ
+    diagnosis = diagnose_azure_connection(requirement, source)
+    problems.extend(diagnosis.problems)
+    return diagnosis
 
 
 def _check_instruction_length(

--- a/batch-runner/experiments/execution_envelope/advance_check_plan.yaml
+++ b/batch-runner/experiments/execution_envelope/advance_check_plan.yaml
@@ -235,6 +235,35 @@ container:
   use_docker: "always"
   image: "gdpval-sandbox:latest"
 
+# ── Which Azure resource the deployment must live in ──────────────────────
+#
+# A deployment name does not identify a deployment.
+#
+# When this comparison was first attempted, the Azure tenant it was attempted
+# from held two separate Azure AI Foundry accounts that each exposed a
+# deployment named exactly "gpt-5.4", and a third that exposed the same
+# underlying model under a different deployment name. Two accounts, same name,
+# different resources: possibly different regions, different model versions,
+# different content filters.
+#
+# So pinning `deployment: gpt-5.4` above is not enough on its own. Without the
+# account and project below, the comparison could run against a deployment
+# nobody intended and still report, truthfully by its own rules, that every run
+# place used the same deployment name. That is the exact class of silent error
+# this whole plan exists to prevent, and it was open until this block was added.
+#
+# These two names are the ones this repository already records for its own
+# automated runs, as the repository variables AZURE_AI_EXPECTED_PROJECT_ACCOUNT
+# and AZURE_AI_EXPECTED_PROJECT_NAME. They are settings, not secrets.
+#
+# The free check reads the endpoint settings in the environment, classifies
+# them with this repository's own endpoint rules, and refuses the run if they
+# name any other account or project.
+azure_connection:
+  account: "hjeon-fdpo-foundry-eus2"
+  project: "gdpval-realworks"
+  route_profile: "project-ci"
+
 # ── The two comparisons keep separate score tables ────────────────────────
 #
 # Results from re-running one model's own code and results from letting each
@@ -255,11 +284,21 @@ scoreboards:
 # purpose, because an unstated guess is how a cost ceiling ends up wrong in the
 # direction that costs money.
 cost:
-  # The amount approved for spending. While this is empty the free check
-  # refuses to let anything paid start, whatever else is in order.
+  # The amount approved for spending, in United States dollars.
   #
-  # This is the one decision still outstanding.
-  approved_maximum_usd: null
+  # Approved 2026-08-25 by the repository owner, for exactly this run: five
+  # tasks in three run places, with separate grading, under the retry limits
+  # fixed above. It is a total ceiling, not a per-place allowance.
+  #
+  # It equals the worked-out ceiling to the cent. That is deliberate: it means
+  # the free check passes only while the plan is exactly as costed, and any
+  # change that makes the run more expensive — a longer answer cap, another
+  # retry, a fourth run place — pushes the ceiling above this line and stops
+  # the run instead of quietly spending more.
+  #
+  # The thirty-task and two-hundred-and-twenty-task stages are NOT covered by
+  # this amount and are not approved.
+  approved_maximum_usd: 32.23
 
   assumptions:
     # How many characters of wording are counted as one token. English text

--- a/batch-runner/scripts/check_execution_envelope_advance_check.py
+++ b/batch-runner/scripts/check_execution_envelope_advance_check.py
@@ -129,6 +129,17 @@ def main() -> int:
         print(f"  {line}")
     print()
 
+    if result.azure is not None:
+        print("Azure resource the deployment must live in")
+        print("-" * 74)
+        print(
+            "  settings name the intended resource: "
+            + ("yes" if result.azure.reachable_intent else "no")
+        )
+        print(f"  account named by the settings: {result.azure.observed_account}")
+        print(f"  project named by the settings: {result.azure.observed_project}")
+        print()
+
     if result.all_problems:
         print("Problems that must be fixed before anything starts:")
         for problem in result.all_problems:

--- a/batch-runner/tests/test_execution_envelope_advance_check.py
+++ b/batch-runner/tests/test_execution_envelope_advance_check.py
@@ -82,7 +82,23 @@ EXPECTED_ADVANCE_CHECK_TASKS = (
 )
 
 APPROVED_ENOUGH = 100
-FULLY_READY_ENVIRON = {"EXECUTION_COMPARISON_PAID_RUN_APPROVED": "yes"}
+
+# The Azure resource this comparison is pinned to, matching the plan. Used to
+# build a settings environment in which the Azure run place is correctly
+# configured, so tests can tell "everything is in order" apart from "one thing
+# was changed on purpose".
+PINNED_AZURE_ACCOUNT = "hjeon-fdpo-foundry-eus2"
+PINNED_AZURE_PROJECT = "gdpval-realworks"
+PINNED_PROJECT_ENDPOINT = (
+    f"https://{PINNED_AZURE_ACCOUNT}.services.ai.azure.com"
+    f"/api/projects/{PINNED_AZURE_PROJECT}"
+)
+
+FULLY_READY_ENVIRON = {
+    "EXECUTION_COMPARISON_PAID_RUN_APPROVED": "yes",
+    "AZURE_AI_ROUTE_PROFILE": "project-ci",
+    "FOUNDRY_PROJECT_ENDPOINT": PINNED_PROJECT_ENDPOINT,
+}
 
 
 @pytest.fixture(scope="module")
@@ -422,11 +438,25 @@ def test_a_model_with_no_published_price_is_not_treated_as_free(catalog):
 
 
 def test_a_missing_approved_amount_is_a_refusal(plan, catalog):
+    """Removing the approved amount must stop the run, whatever else is right.
+
+    The committed plan now records an approved amount, so this clears it on
+    purpose rather than relying on it being absent.
+    """
+    plan = _approved(plan, None)
+
     result = _ready_preflight(plan)
+
     assert result.may_start is False
     assert any(
-        "largest amount that may be spent" in note for note in result.problems
+        "largest amount that may be spent" in note
+        for note in result.all_problems
     )
+
+
+def test_the_committed_plan_records_the_approved_amount(plan):
+    """The amount that was approved, to the cent, and no more."""
+    assert str(plan["cost"]["approved_maximum_usd"]) == "32.23"
 
 
 def test_an_approved_amount_below_the_ceiling_is_a_refusal(plan):
@@ -822,16 +852,233 @@ def test_the_scripts_are_in_the_repository(script):
 
 
 def test_the_check_refuses_today_and_says_why():
-    """Run the tool exactly as a person would, and require a refusal."""
+    """Run the tool exactly as a person would, and require a refusal.
+
+    Today the money is approved but the Azure run place is not reachable from
+    an ordinary checkout, so the refusal must name the Azure settings rather
+    than the money.
+    """
     finished = subprocess.run(
         [sys.executable, str(CHECK_SCRIPT)],
         cwd=BATCH_RUNNER_ROOT,
         capture_output=True,
         text=True,
         timeout=300,
-        env={**os.environ, "EXECUTION_COMPARISON_PAID_RUN_APPROVED": ""},
+        env={
+            **{
+                key: value
+                for key, value in os.environ.items()
+                if key
+                not in {
+                    "AZURE_AI_ROUTE_PROFILE",
+                    "FOUNDRY_PROJECT_ENDPOINT",
+                    "AZURE_OPENAI_V1_ENDPOINT",
+                }
+            },
+            "EXECUTION_COMPARISON_PAID_RUN_APPROVED": "",
+        },
     )
 
     assert finished.returncode == 1, finished.stdout + finished.stderr
     assert "no model was called" in finished.stdout
-    assert "largest amount that may be spent" in finished.stdout
+    assert "AZURE_AI_ROUTE_PROFILE is not set" in finished.stdout
+    assert "FOUNDRY_PROJECT_ENDPOINT is not set" in finished.stdout
+
+
+# ── The Azure run place must reach the deployment that was pinned ─────────
+#
+# A deployment name does not identify a deployment. The tenant this comparison
+# was first attempted from held two Azure AI Foundry accounts that each exposed
+# a deployment named exactly "gpt-5.4". Pinning the name alone would let the
+# comparison run against a resource nobody intended and report success.
+
+
+def _environ_with(**overrides):
+    settings = dict(FULLY_READY_ENVIRON)
+    for key, value in overrides.items():
+        if value is None:
+            settings.pop(key, None)
+        else:
+            settings[key] = value
+    return settings
+
+
+def test_the_plan_pins_the_azure_account_and_project(plan):
+    pinned = plan["azure_connection"]
+    assert pinned["account"] == PINNED_AZURE_ACCOUNT
+    assert pinned["project"] == PINNED_AZURE_PROJECT
+    assert pinned["route_profile"] == "project-ci"
+
+
+def test_a_correctly_pointed_azure_setup_is_accepted(plan):
+    result = _ready_preflight(_approved(plan))
+
+    assert result.azure is not None
+    assert result.azure.problems == []
+    assert result.azure.observed_account == PINNED_AZURE_ACCOUNT
+    assert result.azure.observed_project == PINNED_AZURE_PROJECT
+    assert result.may_start is True
+
+
+def test_the_same_deployment_name_on_another_account_is_refused(plan):
+    """The exact hole this block was added to close.
+
+    The settings are well formed, the route is right, and the deployment name
+    is unchanged. Only the account differs — which is precisely the case that
+    used to pass.
+    """
+    other = (
+        "https://some-other-account.services.ai.azure.com"
+        f"/api/projects/{PINNED_AZURE_PROJECT}"
+    )
+    result = _ready_preflight(
+        _approved(plan),
+        environ=_environ_with(FOUNDRY_PROJECT_ENDPOINT=other),
+    )
+
+    assert result.may_start is False
+    assert any(
+        "is not unique across accounts" in note for note in result.all_problems
+    )
+
+
+def test_another_project_on_the_right_account_is_refused(plan):
+    other = (
+        f"https://{PINNED_AZURE_ACCOUNT}.services.ai.azure.com"
+        "/api/projects/some-other-project"
+    )
+    result = _ready_preflight(
+        _approved(plan),
+        environ=_environ_with(FOUNDRY_PROJECT_ENDPOINT=other),
+    )
+
+    assert result.may_start is False
+    assert any("names the project" in note for note in result.all_problems)
+
+
+def test_a_missing_project_address_says_what_it_should_look_like(plan):
+    result = _ready_preflight(
+        _approved(plan), environ=_environ_with(FOUNDRY_PROJECT_ENDPOINT=None)
+    )
+
+    assert result.may_start is False
+    assert any(
+        PINNED_AZURE_ACCOUNT in note and "services.ai.azure.com" in note
+        for note in result.all_problems
+    )
+
+
+def test_a_missing_route_profile_is_told_apart_from_a_wrong_one(plan):
+    """"Not set" and "set to the wrong thing" need different fixes."""
+    missing = _ready_preflight(
+        _approved(plan), environ=_environ_with(AZURE_AI_ROUTE_PROFILE=None)
+    )
+    wrong = _ready_preflight(
+        _approved(plan),
+        environ=_environ_with(AZURE_AI_ROUTE_PROFILE="direct-v1"),
+    )
+
+    assert any("is not set" in note for note in missing.all_problems)
+    assert any("'direct-v1'" in note for note in wrong.all_problems)
+
+
+def test_the_deprecated_endpoint_setting_is_refused(plan):
+    result = _ready_preflight(
+        _approved(plan),
+        environ=_environ_with(
+            AZURE_OPENAI_ENDPOINT="https://something.openai.azure.com/"
+        ),
+    )
+
+    assert result.may_start is False
+    assert any(
+        "does not say which kind of endpoint" in note
+        for note in result.all_problems
+    )
+
+
+@pytest.mark.parametrize(
+    "variable", ["AZURE_OPENAI_API_KEY", "AZURE_CLIENT_SECRET"]
+)
+def test_a_fixed_credential_is_refused_up_front(plan, variable):
+    """Say so during the free check, not after the run has been scheduled."""
+    result = _ready_preflight(
+        _approved(plan), environ=_environ_with(**{variable: "value-not-read"})
+    )
+
+    assert result.may_start is False
+    assert any(variable in note for note in result.all_problems)
+
+
+def test_a_direct_address_on_another_account_is_refused(plan):
+    result = _ready_preflight(
+        _approved(plan),
+        environ=_environ_with(
+            AZURE_OPENAI_V1_ENDPOINT=(
+                "https://some-other-account.services.ai.azure.com/openai/v1/"
+            )
+        ),
+    )
+
+    assert result.may_start is False
+    assert any(
+        "AZURE_OPENAI_V1_ENDPOINT" in note for note in result.all_problems
+    )
+
+
+def test_a_plan_that_forgets_to_pin_the_account_is_refused(plan):
+    plan = _approved(plan)
+    plan.pop("azure_connection")
+
+    result = _ready_preflight(plan)
+
+    assert result.may_start is False
+    assert any(
+        "not unique across accounts" in note for note in result.all_problems
+    )
+
+
+def test_the_azure_check_is_skipped_when_azure_does_not_take_part(plan):
+    """A plan without the Azure run place has no Azure resource to get wrong."""
+    plan = _approved(plan)
+    plan["model_run_conditions"]["by_environment"].pop("azure_code_interpreter")
+    plan["experiment_files"].pop("azure_code_interpreter")
+    plan.pop("azure_connection")
+
+    result = _ready_preflight(plan, environ=_environ_with(
+        AZURE_AI_ROUTE_PROFILE=None, FOUNDRY_PROJECT_ENDPOINT=None
+    ))
+
+    assert result.azure is None
+    assert not any("AZURE" in note for note in result.all_problems)
+
+
+# ── The written specifications must survive a fresh checkout ─────────────
+#
+# Both `batch-runner/scripts/` and `tasks/0822_saturday/` are ignored by
+# default with a per-file allow list. A document added to either without being
+# added to that list is invisible to anyone who clones the repository, which
+# makes it useless exactly when someone needs it.
+
+SPECIFICATION_FILES = (
+    "tasks/0822_saturday/TASK_GPT_EXECUTION_ENVELOPE_BENCHMARK.md",
+    "tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md",
+    "tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md",
+    "tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md",
+)
+
+
+@pytest.mark.parametrize("relative", SPECIFICATION_FILES)
+def test_the_specifications_are_in_the_repository(relative):
+    path = REPOSITORY_ROOT / relative
+    assert path.is_file(), f"{relative} is missing"
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", relative],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.returncode == 0, (
+        f"{relative} exists here but git does not track it, so a fresh clone "
+        "would not have it. Add it to the allow list in .gitignore."
+    )

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
@@ -1,0 +1,183 @@
+# Agentic Sandbox V2: a safe path to running commands and letting the model decide
+
+- Written: 2026-08-25
+- Status: **specification only. Nothing here is built, and nothing in it may be
+  built without a separate, explicit approval to open command execution.**
+- Related GitHub Project: hyeonsangjeon/projects/5 — card
+  "같은 GPT 모델의 실행 환경별 성능 비교"
+
+## 1. The problem a person actually hits
+
+The comparison of run places has five columns. The fourth is Agentic Sandbox V2,
+where the model would repeatedly pick a tool, read what came back, and choose
+the next action. Today that column is empty and cannot be filled, because two
+things are missing and a third is deliberately shut.
+
+This matters beyond one empty column. The other run places all work the same
+way: the model writes a block of Python once, somebody runs it, and the result
+is whatever that one block produced. If a library is missing or a file is not
+shaped the way the model assumed, the task simply fails. A model that can look
+at the failure and try something else is doing a different and more realistic
+kind of work, and nobody can currently measure how much that is worth.
+
+## 2. What exists today, read from the code
+
+**The tool surface is fully specified.** `core/agentic_v2_tools.py` defines
+eleven operations a backend must provide, including `exec_run` for running a
+command, `environment_resolve` and `environment_activate` for packages,
+`browser_run`, `verify_public`, and `finalize`. The dispatcher around them
+already enforces a ceiling on the number of calls, a ceiling on the size of each
+result, and a deadline.
+
+**There is a large amount of supporting machinery.** Alongside the tools sit
+modules for the contract, provenance, supply chain, licence evaluation, the
+image format, and the substrate. The substrate manifest requires a small
+isolated virtual machine and refuses to validate without that policy.
+
+**Three things stand between this and a real run:**
+
+1. **Running commands is switched off.** In
+   `core/agentic_v2_fixture_backend.py`, `exec_run` answers
+   `capability_unavailable` for every command except one deliberately trivial
+   test case that copies a file and converts it to capital letters. Nothing real
+   can be run.
+
+2. **The model is never asked anything.** `core/agentic_v2_runner.py` replays a
+   list of calls written down in advance. It has a `scripted_calls` input and no
+   model client at all. The state machine can be exercised, but no model ever
+   sees a result and chooses what to do next, which is the entire point of this
+   run place.
+
+3. **Two separate guards refuse the mode outright.**
+   `step2_run_inference._require_runnable_execution_mode` rejects it, and
+   `core/executor.py` refuses to build a runner unless the caller states that
+   the run makes no paid model calls.
+
+The third item is a safety decision, not an oversight, and this document does
+not propose removing it.
+
+## 3. Goals
+
+1. Describe a route from "replays a script" to "the model chooses", in stages,
+   where each stage is separately reviewable and separately approvable.
+2. Make the dangerous stage — actually running commands the model chose — the
+   last one, behind its own approval, with the containment written down first.
+3. Give the comparison a fourth column that is honestly comparable to the other
+   three, or an honest statement of why it cannot be.
+
+## 4. What must not happen
+
+- **The three guards must not be bypassed, weakened, or worked around** as a
+  side effect of any stage below. The existing free check runs all three and
+  reports if any has opened; that check must keep passing until the guard is
+  removed deliberately, in its own reviewed change, with its replacement
+  containment already in place.
+- **Command execution must not be opened before containment is proven.** Letting
+  a model choose commands that then run is a different risk from running a block
+  of Python a person can read first.
+- **No stage may quietly fall back to a weaker containment.** This is the same
+  rule the Docker run place already follows: if the intended isolation is not
+  available, the task fails and says so, rather than running somewhere else.
+
+## 5. The design, in plain terms
+
+Four stages, in order. Each is useful on its own, and each can be stopped at.
+
+**Stage one — let the model choose, but only among safe tools.**
+Replace the list of pre-written calls with a real conversation with the model,
+while leaving `exec_run` shut. The model can look at the workspace, resolve
+packages, and finish, but it cannot run a command. This proves the loop works —
+the model reads a result and picks a next action — without the risky capability.
+It is enough to answer "does asking the model repeatedly help at all?"
+
+**Stage two — write down the containment, and prove it separately.**
+Before any command runs, state what the command may touch: which directory,
+whether the network is reachable, how much memory and time, which user it runs
+as, and what happens when it exceeds any of those. Prove each one with a test
+that tries to exceed it and requires the attempt to fail. This is a test-only
+stage; nothing is switched on.
+
+**Stage three — open command execution behind its own approval.**
+Only after stage two passes. `exec_run` starts running real commands inside the
+containment from stage two. This needs an explicit approval of the same kind the
+paid-run approval already uses: absent it, the capability stays shut.
+
+**Stage four — join the comparison.**
+The run place is added to the plan as a fourth column, under the same fixed
+conditions as the other three.
+
+The reason for this order is that stage one delivers the interesting
+measurement, and stage three carries nearly all the risk. Doing them in this
+order means the risky work is only undertaken if the safe work has already shown
+the loop is worth having.
+
+## 6. Files and how information flows
+
+| File | Role |
+|---|---|
+| `batch-runner/core/agentic_v2_runner.py` | Stage one: gains a real conversation with the model in place of the replayed list. |
+| `batch-runner/core/agentic_v2_tools.py` | Unchanged surface; the ceilings it already applies become the loop's limits. |
+| `batch-runner/core/agentic_v2_fixture_backend.py` | Stays shut through stages one and two. |
+| `batch-runner/core/agentic_v2_substrate.py` | Stage two: the containment rules are stated and checked here. |
+| `batch-runner/step2_run_inference.py` | Stage three: the guard is revisited, not before. |
+| `batch-runner/core/executor.py` | Stage three: the paid-run refusal is revisited, not before. |
+
+Flow: the task and instructions reach the model; the model asks for a tool; the
+dispatcher checks the ceilings and passes it to the backend; the result comes
+back to the model; repeat until the model finishes or a ceiling is hit.
+
+## 7. Safety, cost, and no-silent-substitution conditions
+
+- Stage one is the first stage that costs money, because it calls a model in a
+  loop. The number of calls per task is bounded by the dispatcher's existing
+  ceiling, and a cost ceiling must be worked out and approved before it runs, in
+  the same way the five-task advance check was.
+- The loop's cost is not predictable from the task alone, because the model
+  decides how many turns to take. The ceiling must therefore be based on the
+  maximum number of calls, not an expected number.
+- Stage three must fail loudly when its containment is unavailable.
+- The existing free check must keep reporting this run place as
+  "structure checks only" until stage three is genuinely approved and complete.
+
+## 8. Order the work would be done in
+
+1. Work out and get approval for the cost ceiling of a small stage-one run.
+2. Build the model conversation with `exec_run` still shut.
+3. Measure whether choosing tools helps, on the same five tasks.
+4. Write the containment rules and the tests that try to break them.
+5. Seek approval for command execution, presenting those test results.
+6. Only then, open `exec_run`.
+7. Revisit the two guards, each in its own change.
+8. Add the fourth column to the comparison plan.
+
+## 9. How this would be checked
+
+- Stage one: a test that gives the model a task whose first attempt must fail,
+  and requires that the model be asked again with the failure in front of it.
+- Stage one: a test that the run stops at the dispatcher's call ceiling rather
+  than continuing indefinitely.
+- Stage two: one test per containment rule, each attempting to exceed it and
+  requiring failure.
+- All stages: the existing test that opens all three guards and requires them
+  shut must keep passing until the stage that deliberately changes one.
+
+## 10. Done when
+
+- [ ] The model chooses its own next action, and a test proves it reacts to a
+      failure it was shown.
+- [ ] Every containment rule has a test that tries to exceed it and fails.
+- [ ] Command execution is opened only after a separate written approval.
+- [ ] The free check reports this run place as able to run only when it is.
+
+## 11. Known blockers and the next decision
+
+- **Blocked on approval to call a model in a loop.** Stage one costs money and
+  its ceiling has not been worked out or approved.
+- **Blocked on a decision about containment.** The substrate manifest requires a
+  small isolated virtual machine. Whether that is available on the machines this
+  would run on has not been established, and stage three cannot be designed
+  concretely until it is.
+
+The next decision is whether stage one is worth its cost, which cannot be
+answered until that cost is worked out. That is the first piece of work, and it
+is free.

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -1,0 +1,171 @@
+# Codex's own agent: what is officially supported, and what is still unknown
+
+- Written: 2026-08-25
+- Status: **investigation recorded. The run place stays blocked, and one part of
+  it stays explicitly unconfirmed.** No code was written, because writing code
+  for a path that may not be able to meet the comparison's conditions would be
+  premature.
+- Related GitHub Project: hyeonsangjeon/projects/5 — card
+  "같은 GPT 모델의 실행 환경별 성능 비교"
+
+## 1. The problem a person actually hits
+
+The comparison of run places has five columns. The fifth is Codex's own built-in
+agent: the tool picks its own actions, runs its own commands, reviews its own
+work, and retries, without this repository directing any of it.
+
+That column is empty. This document records what was checked, what turned out to
+be true, and what remains genuinely unknown — so that the next person does not
+repeat the search, and so that nobody fills the column in on an assumption.
+
+## 2. Why an empty column is the right answer for now
+
+The comparison's whole claim is that only the run place changes. One of the
+conditions every column must meet is that it uses **the same deployment** as the
+others. If Codex's own agent cannot be pointed at the same deployment, then a
+Codex column would differ in two ways at once — the run place *and* the model
+being served — and any difference in the scores could not be attributed to
+either.
+
+So the question is not only "can Codex be automated?" It is "can Codex's own
+agent be pointed at this exact deployment?" The second question is the one that
+decides whether the column can ever be honest.
+
+## 3. What was checked, and what it says
+
+Sources consulted were the official Codex documentation and the repository
+itself.
+
+**Confirmed: Codex can be run without a person answering prompts.**
+A non-interactive command mode is documented (`codex exec`), which takes an
+instruction and runs to completion. Approval behaviour and sandbox behaviour are
+configurable settings.
+
+**Confirmed: Codex supports providers other than its default.**
+The configuration format includes entries for defining model providers, and
+separately an `openai_base_url` setting which the documentation describes as the
+way to "point the built-in OpenAI provider at an LLM proxy, router, or
+data-residency enabled project" without defining a new provider.
+
+**Confirmed: provider settings are deliberately restricted.**
+Provider, credential, and telemetry settings are ignored when they appear in a
+repository-local configuration file and must be set in the user-level
+configuration. Codex prints a warning when a repository tries to set them. This
+is a security boundary and is relevant: a benchmark harness cannot simply commit
+a provider configuration into a repository and have it take effect.
+
+**Not confirmed: pointing Codex's own agent at an Azure AI Foundry deployment
+using the sign-in this repository requires.**
+The documentation describes changing the base address for the built-in provider.
+It does not describe using an Azure AI Foundry deployment with a token obtained
+from a directory sign-in, which is the only authentication this repository
+permits — it explicitly refuses to run with a fixed interface key, a client
+secret, or a stored password. A base-address change alone does not establish
+that the token flow this repository mandates is supported.
+
+**Not confirmed: an official route for feeding an outside benchmark's tasks in
+and collecting deliverable files out.**
+Nothing was found describing this as a supported use.
+
+**Confirmed about this repository: there is no Codex code path.**
+The list of run modes in `core/executor.py` has no entry for it, and no module
+starts a benchmark task this way. Mentions of Codex in the repository are in
+documents people read, not in code that runs.
+
+## 4. A distinction that is easy to get wrong
+
+Azure offers models whose names contain "codex", and Azure's own agent service
+can use them. That is **Azure's agent feature driving that model**. It is not
+Codex's own agent, which is a different piece of software with its own loop, its
+own tool choices, and its own retry behaviour.
+
+Measuring Azure's agent and calling it Codex would be measuring the wrong thing.
+The comparison's fifth column is about Codex's own loop, so the substitution
+would quietly answer a different question. This is the same class of error as
+letting a container fall back to the host: the label stays the same and the
+thing measured changes.
+
+## 5. Goals
+
+1. Record the search so it is not repeated.
+2. State precisely which single fact would unblock the column.
+3. Keep the column empty and marked unconfirmed until that fact is established.
+
+## 6. What must not happen
+
+- **Do not fill the column with Azure's agent service** using a model whose name
+  contains "codex". That is a different product.
+- **Do not fill the column by pointing Codex at a different model** than the
+  other columns use. The comparison would no longer be about run places.
+- **Do not write a fixed interface key into a configuration file** to make a
+  connection work. This repository refuses those credentials on purpose, and the
+  free check now reports them during the pre-run check.
+- **Do not describe the column as "supported" on the strength of the
+  base-address setting alone.** That setting changes an address; it does not
+  establish that the required sign-in works.
+
+## 7. The one fact that would unblock this
+
+> Can Codex's own agent loop be pointed at a named Azure AI Foundry deployment,
+> authenticating with a token from a directory sign-in rather than a fixed key?
+
+If **yes**, and it can be shown in official documentation, then a run place
+becomes worth designing: a mode that hands one task to `codex exec`, lets it
+work, and collects the files it produced.
+
+If **no**, the honest outcome is that this column can never satisfy the
+comparison's conditions, and the comparison is a four-column comparison. That is
+a perfectly good result, and much better than a fifth column that silently
+measures something else.
+
+## 8. Files that would change, if it were unblocked
+
+| File | Role |
+|---|---|
+| `batch-runner/core/executor.py` | Would gain a run mode and a dispatch entry. |
+| `batch-runner/core/` (new module) | Would hand a task to the tool and collect deliverable files. |
+| `batch-runner/core/execution_environment_readiness.py` | The run place would move from "not implemented here" to a real grade. |
+| `batch-runner/experiments/execution_envelope/advance_check_plan.yaml` | Would gain a fifth column. |
+
+None of these should be touched before the question in section 7 is answered.
+
+## 9. Safety, cost, and no-silent-substitution conditions
+
+- Codex's own agent decides how many model calls to make, so the cost of a run
+  is not predictable from the task. Any ceiling must be based on a hard limit on
+  calls, not an expectation.
+- Codex runs commands as part of its normal operation. The containment for that
+  would need to be stated before any benchmark task is handed to it, in the same
+  way the Agentic Sandbox V2 work requires.
+- The free check must keep reporting this run place as not implemented here
+  until a real path exists. It must never be reported as available on the
+  strength of a plan.
+
+## 10. How this would be checked
+
+- A test that the run place is reported as not implemented for as long as no
+  code path exists.
+- A test that the comparison refuses a plan naming this run place, which already
+  exists and passes.
+- If it is ever built: a test that the deployment it addresses is the same one
+  the other columns address, which is the condition that motivated this whole
+  document.
+
+## 11. Done when
+
+- [ ] The question in section 7 is answered from official documentation, either
+      way.
+- [ ] If yes: a run place exists, and a test proves it uses the same deployment.
+- [ ] If no: the comparison is documented as having four columns, with this
+      document as the reason.
+
+## 12. Known blockers and the next decision
+
+- **Blocked on an external fact**, not on effort in this repository. No amount of
+  work here establishes whether the connection is supported.
+- The next decision belongs to whoever can confirm it: either a documented
+  statement that Codex's own agent can use an Azure AI Foundry deployment with a
+  directory sign-in, or acceptance that the comparison has four columns.
+
+Until then the column stays empty and is reported as unconfirmed. It is not
+filled with a substitute.

--- a/tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md
+++ b/tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md
@@ -1,0 +1,189 @@
+# Pin the Azure resource, not just the deployment name
+
+- Written: 2026-08-25
+- Status: **done and merged.** This document records why the work was needed and
+  what it changed.
+- Related GitHub Project: hyeonsangjeon/projects/5 — card
+  "같은 GPT 모델의 실행 환경별 성능 비교"
+
+## 1. The problem a person actually hits
+
+The run-place comparison asks one question: when the same model does the same
+work, does the place it runs in change the result? Everything except the run
+place has to be held still, and a written plan lists fifteen things that must
+match everywhere. One of them is the deployment name.
+
+**A deployment name does not identify a deployment.**
+
+Two different Azure AI Foundry accounts in the same Azure tenant can each hold a
+deployment named `gpt-5.4`. They can sit in different regions, be pointed at
+different versions of the model, and apply different content filters. Nothing
+about the name distinguishes them.
+
+So the comparison could have run one place against one account's `gpt-5.4` and
+another place against a different account's `gpt-5.4`, and every check would
+have reported that all three places used the same deployment. The resulting
+table would have looked like a clean measurement of run places while actually
+measuring two different Azure resources. Nobody reading the table afterwards
+could have told.
+
+## 2. This is not hypothetical
+
+While preparing the five-task advance check, the Azure tenant available at the
+time was listed. It held:
+
+- one account with a deployment named exactly `gpt-5.4`
+- a second, different account with a deployment named exactly `gpt-5.4`
+- a third account holding the same underlying model under a different
+  deployment name
+
+Two accounts, same deployment name, different resources. The hole was open and
+reachable, not theoretical.
+
+## 3. What the code said before this change
+
+- `batch-runner/experiments/execution_envelope/advance_check_plan.yaml` pinned
+  `provider`, `deployment`, `resolved_model`, and `api_version`. It said nothing
+  about which Azure account or project held that deployment.
+- `batch-runner/core/execution_envelope_preflight.py` took exactly one piece of
+  Azure information: the route profile, a single word. It compared that word to
+  `project-ci` and stopped there.
+- When the route profile was absent, the check reported
+  `evidence_insufficient` with the sentence "the Azure route profile was not
+  measured, so it is unknown whether this environment could start."
+
+That last sentence is the second half of the problem. It is the same message
+whether nobody had configured Azure at all, or Azure was configured and pointing
+at the wrong account, or the account was in a tenant this machine cannot reach.
+Those three have completely different fixes, and the reader was sent looking in
+the wrong place. Working out which one was actually true took a manual
+investigation with the Azure command-line tool.
+
+## 4. Goals
+
+1. Make the plan pin the Azure account and project, so the deployment is
+   identified exactly rather than by a name that is not unique.
+2. Make the free check read the endpoint settings that the run itself will use,
+   and refuse when they name any other account or project.
+3. Make the refusal say which specific thing is wrong and what the correct value
+   looks like, so no manual investigation is needed.
+
+## 5. What this change deliberately does not do
+
+- **It does not contact Azure.** The check stays free and offline. It reads
+  settings and compares them. It never signs in, never asks for a token, and
+  never spends anything. It can therefore say "the settings name the intended
+  resource", which is a different and weaker claim than "the resource can be
+  reached", and it says only the weaker one.
+- **It does not create credentials, relax a security rule, or invent an
+  address.** Where information was missing, the run stays blocked.
+- **It does not switch to a reachable account.** Substituting a different
+  account is exactly the failure this work exists to prevent.
+
+## 6. The design, in plain terms
+
+A new block in the plan names the Azure resource:
+
+```yaml
+azure_connection:
+  account: "hjeon-fdpo-foundry-eus2"
+  project: "gdpval-realworks"
+  route_profile: "project-ci"
+```
+
+These two names are not new information and are not secrets. This repository
+already records them for its own automated runs, as the repository settings
+`AZURE_AI_EXPECTED_PROJECT_ACCOUNT` and `AZURE_AI_EXPECTED_PROJECT_NAME`.
+Repository settings, unlike repository secrets, are readable by design.
+
+A new module reads the endpoint settings from the environment, classifies them
+using this repository's own endpoint rules, and compares what it finds against
+the pinned names. Because it reuses `classify_endpoint` from
+`core/azure_ai_clients.py` rather than matching text itself, a plan checked here
+is checked against exactly the rules the real run applies.
+
+## 7. Files and how information flows
+
+| File | Role |
+|---|---|
+| `batch-runner/core/execution_envelope_azure.py` | New. Holds the pinned resource and works out what is wrong with the settings. |
+| `batch-runner/core/execution_envelope_preflight.py` | Calls the new module when the Azure run place takes part, and adds anything it finds to the list of problems. |
+| `batch-runner/scripts/check_execution_envelope_advance_check.py` | Prints which account and project the settings name. |
+| `batch-runner/experiments/execution_envelope/advance_check_plan.yaml` | Gains the `azure_connection` block. |
+| `batch-runner/tests/test_execution_envelope_advance_check.py` | Gains the tests below. |
+
+The flow: plan file → pinned account and project → compared against the
+environment settings → problems added to the one list the tool prints and the
+exit code is built from.
+
+## 8. Safety, cost, and no-silent-substitution conditions
+
+- Every check reads settings only. Nothing is spent and no model is called.
+- No secret is printed. The account and project are settings; the endpoint
+  addresses are compared, and only the account and project names are shown back.
+- Fixed credentials that this repository refuses to run with — an interface key,
+  a client secret, a stored password — are reported during the free check rather
+  than after a run has been scheduled.
+- The deprecated combined endpoint setting is reported, because this repository
+  refuses to start while it is set.
+- If the Azure run place does not take part in a plan, the check is skipped
+  entirely: there is then no Azure resource for the comparison to get wrong.
+- Nothing here removes a blocked run place from the comparison. That still
+  requires a person to edit the plan.
+
+## 9. Order the work was done in
+
+1. Confirm the hole is real by listing the deployments actually present.
+2. Confirm the plan pins no account and the check takes no account.
+3. Add the module that compares settings against the pinned resource.
+4. Add the plan block, with the evidence written beside it.
+5. Wire it into the check and the printed output.
+6. Add tests, including one that changes only the account and nothing else.
+7. Run the repository's whole test suite.
+
+## 10. How this was checked
+
+Automated, in `batch-runner/tests/test_execution_envelope_advance_check.py`:
+
+- a correctly pointed setup is accepted, and the account and project it found
+  are reported back
+- **the same deployment name on a different account is refused** — the settings
+  are well formed, the route is right, the deployment name is unchanged, and
+  only the account differs; this is the case that used to pass
+- a different project on the right account is refused
+- a missing project address is refused, and the message contains the address it
+  should have held
+- "the route profile is not set" is told apart from "the route profile is set to
+  the wrong thing"
+- the deprecated combined endpoint setting is refused
+- each fixed credential is refused up front
+- a direct address on another account is refused
+- a plan that forgets to pin the account is refused
+- a plan without the Azure run place skips the check and raises nothing
+
+By hand: run the check with the Azure settings unset and confirm it names both
+missing settings and prints the exact address that should be supplied.
+
+## 11. Done when
+
+- [x] The plan pins the Azure account and project.
+- [x] The check refuses any other account or project.
+- [x] The refusal names the specific setting and the value it should hold.
+- [x] A test exists that changes only the account and requires a refusal.
+- [x] The whole repository test suite passes.
+
+## 12. Known blockers and the next decision
+
+This change makes the Azure run place's requirements checkable. It does not
+make the resource reachable.
+
+At the time of writing, the Azure AI Foundry account this comparison is pinned
+to sits in a different Azure tenant and a different subscription from the one
+signed in on the machine the work was done on. A request for access to the
+pinned tenant is rejected by a Conditional Access policy, and the only remaining
+path is an interactive sign-in through a web browser.
+
+That is an access decision belonging to whoever administers the tenant, not
+something this repository can settle. Until it is settled, the Azure run place
+stays blocked and the comparison does not start, because dropping it and running
+the other two would produce a different comparison from the one that was agreed.

--- a/tasks/LATEST_TASK_RESULT/README.md
+++ b/tasks/LATEST_TASK_RESULT/README.md
@@ -1,186 +1,131 @@
 # Latest Task Result
 
 - Updated: 2026-08-25
-- Status: the five-task advance check of the run-place comparison is ready to
-  start in three of the five places, and every check that can be made without
-  spending money now passes. **Nothing has run and no model has been called.**
-  One decision is outstanding: the largest amount that may be spent
+- Status: the five-task advance check **did not run and cost nothing.** It is
+  blocked on access to the Azure account it is pinned to, which sits in a
+  different Azure tenant from the one signed in here. While investigating that,
+  a real hole in the comparison's own design was found and closed
 
-## Current Task: Run-Place Comparison — Advance Check Preparation
+## Current Task: Advance Check Attempt, and Pinning the Azure Resource
 
 ### Task
 
-Finish everything that can be settled without spending money before the same
-GPT model is run in three different places on the same five benchmark tasks:
-a separate Python process on the server's own operating system, a Docker
-container, and Azure AI Foundry's code interpreter.
+Run the approved five-task advance check across three run places, or record
+precisely why it cannot run. Then continue with the roadmap.
 
-The other two places named in the specification stay out. Agentic Sandbox V2
-can only be checked for structure, and Codex has no run path in this
-repository. **Neither empty slot was filled with a working place.**
+### Result: the run did not happen, and nothing was spent
 
-### Result
+**Amount spent: $0.00.** No model was called.
 
-- **One file now holds every condition the three places share.**
-  `batch-runner/experiments/execution_envelope/advance_check_plan.yaml` fixes
-  the provider, the deployment name, the model the service must report back,
-  the request-format version, both instruction texts word for word, the task
-  list, the content fingerprint of every input, the answer-length cap, the time
-  limit, whether self-review is allowed and how often, which retry reasons are
-  allowed and how many attempts, and a standing refusal to change model or
-  deployment part-way. The per-place section is deliberately empty: nothing
-  differs between the places except where the code runs.
+The approved amount of $32.23 was recorded in the plan, and with it the cost
+check passes and two of the three run places became ready. The third did not.
 
-- **The five tasks were chosen by a rule, not by taste, and the rule cannot
-  follow the scores.** It reads a committed catalogue built from the benchmark
-  dataset at one pinned revision that holds task numbers, industries, jobs, the
-  file types of the human expert's own answer, reference-file paths, and a
-  fingerprint of the task wording — and no score, grade, or verdict at all. A
-  test walks the whole file looking for one. The rule sorts by task number and
-  fills five slots in a fixed order, preferring a task whose expert answer files
-  are entirely of that format, never repeating a job. The result is five
-  formats, five jobs, four industries:
+**What blocks it.** The Azure AI Foundry account this comparison is pinned to,
+`hjeon-fdpo-foundry-eus2` holding the project `gdpval-realworks`, lives in one
+Azure tenant and subscription. The sign-in available on this machine belongs to
+a different tenant and a different subscription. Asking for access to the pinned
+tenant is refused by a Conditional Access policy (`AADSTS530036`, "the refresh
+token is invalid due to authentication flow checks"), and the only remaining
+route is an interactive sign-in through a web browser. That is an access
+decision for whoever administers the tenant.
 
-  | format | task | job |
-  |---|---|---|
-  | spreadsheet | `02aa1805` | Project Management Specialists |
-  | document | `0112fc9b` | Nurse Practitioners |
-  | presentation | `2ea2e5b5` | Computer and Information Systems Managers |
-  | picture | `3baa0009` | News Analysts, Reporters, and Journalists |
-  | text answer only | `0818571f` | Real Estate Brokers |
+**Why two of three were not run anyway.** The plan, the check, and several
+tests all say the same thing: a blocked run place is never dropped so the rest
+can proceed. Running two columns and labelling the result a three-way comparison
+would answer a different question from the one that was approved, and would
+spend real money doing it. Removing a run place requires a person to edit the
+plan deliberately.
 
-  **The picture slot is recorded honestly.** No task in this benchmark hands in
-  a picture on its own; only two hand in one at all, and both also hand in a
-  document. The rule's fallback clause took the smaller-numbered of those two,
-  and the plan says so rather than implying a pure picture task exists.
+### A real hole was found while investigating, and closed
 
-- **The choice is pinned to fingerprints, so it cannot be re-cut after results
-  are seen.** Dataset `openai/gdpval` at revision
-  `11e7900cdcac61bc4daf59e65feb238acda98fbf` — the same revision this
-  repository's published grades used — whose data file is
-  `f8422fab…7ae0202`; catalogue `43f46dda…504eb75d`. The 30-task and 220-task
-  stages are written out in full too, so their rules are fixed now rather than
-  after a disappointing number.
+Listing the Azure tenant to find the right account turned up something the
+design had missed.
 
-- **The Docker place cannot quietly become the server place.** This was the
-  most dangerous failure mode available, because it is silent: if the container
-  went missing mid-run, `SandboxRunner._execute` would print a warning and run
-  the model's Python on the server, and the Docker column of the result table
-  would hold the server column's numbers with nothing saying so.
-  `exp031_envelope_docker_container.yaml` pins the container setting to
-  `always`, and a new test file holds that from three directions — it calls the
-  real execution path with the Docker service missing and with the image
-  missing and fails if the server runner is reached even once; it reads the
-  committed settings file; and it weakens the setting in both the plan and the
-  settings file and requires the free check to refuse. A fourth test records
-  that the default setting really does fall back, so the reason the pin is
-  needed stays visible.
+**A deployment name does not identify a deployment.** The tenant held *two
+separate accounts each exposing a deployment named exactly `gpt-5.4`*, plus a
+third exposing the same underlying model under a different name. The plan pinned
+`deployment: gpt-5.4` and nothing about which account held it, and the check's
+only Azure input was a single word naming the route. So the comparison could
+have run one column against one account's `gpt-5.4` and another column against a
+different account's `gpt-5.4` — different region, possibly different model
+version, possibly different content filters — and every check would have
+reported that all three used the same deployment. Nobody reading the resulting
+table could have told.
 
-- **The largest possible bill is worked out, not guessed at.** Every assumption
-  is named in the plan with the measurement behind it. Reference files are
-  counted at the 50,000-character cap the file reader applies, so a large file
-  on disk cannot exceed it. Characters are counted at three to the token, below
-  the usual four, so the ceiling comes out larger. Azure's code interpreter is
-  allowed eight model turns inside one attempt because Microsoft publishes no
-  limit, but its answer length is counted once per attempt because the
-  Responses API caps a whole reply with one number.
+That is exactly the class of silent error the whole plan exists to prevent, and
+it was open and reachable, not theoretical.
 
-  | | most model calls | most it could cost |
-  |---|---:|---:|
-  | separate Python process on the server | 20 | $3.48 |
-  | Docker container | 20 | $3.48 |
-  | Azure code interpreter | 160 | $4.83 |
-  | grading | 801 | $14.02 |
-  | **before the safety multiplier** | **1,001** | **$25.79** |
-  | **after multiplying by 1.25** | | **$32.23** |
+**What changed.** The plan now pins the account and the project. The check reads
+the endpoint settings the run itself would use, classifies them with this
+repository's own endpoint rules rather than matching text, and refuses any other
+account or project. Those two names are not new and are not secrets: the
+repository already records them as its own settings
+`AZURE_AI_EXPECTED_PROJECT_ACCOUNT` and `AZURE_AI_EXPECTED_PROJECT_NAME`.
 
-  A model with no published price is refused rather than counted as free, and
-  the committed price list is held equal to the one the repository already uses
-  for grading by a test that reads both.
+**A second, smaller fix in the same area.** The check used to answer "the Azure
+route profile was not measured" whether Azure was unconfigured, configured but
+pointing elsewhere, or configured correctly but unreachable. Three different
+problems, three different fixes, one unhelpful message — working out which was
+true took a manual investigation. It now names the specific setting that is
+wrong and prints the exact address that should have been there. It also reports
+fixed credentials and the deprecated combined endpoint setting during the free
+check, rather than letting a run be scheduled and fail later on the same point.
 
-- **Every free check now runs from one command and refuses on every path that
-  matters.** `scripts/check_execution_envelope_advance_check.py` exits 1 unless
-  all of these hold: no setting is missing; every place uses the same
-  deployment, the same model, the same wording, the same task list, and the
-  same input fingerprints — checked by opening the three settings files that
-  would actually run, not by trusting the plan; the container cannot fall back;
-  no automatic model switch is allowed; a paid-run approval is on record; and an
-  approved amount covers the worked-out ceiling. **A missing approved amount is
-  a refusal, not a pass.**
+Everything here still reads settings only. Nothing signs in, contacts Azure, or
+spends anything, so the check stays free and safe to run anywhere.
 
-- **The Agentic Sandbox V2 guards were exercised, not worked around.** All
-  three still refuse, and the check opens each one every time it runs. Codex is
-  still reported as having no run path here. Neither was substituted.
+### Specifications written
+
+Three, each standing alone:
+
+- `tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md` — the work above.
+- `tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md` — a four-stage
+  route from "replays a written script" to "the model chooses its next action",
+  with running commands deliberately last and behind its own approval. **None of
+  the three existing safety guards is bypassed or weakened**, and the stage that
+  would revisit them comes only after containment has been proven by tests that
+  try to break it.
+- `tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md` — what official
+  documentation does and does not say. Confirmed: a non-interactive mode exists,
+  custom providers exist, and provider settings are deliberately restricted to
+  user-level configuration. **Not confirmed: that Codex's own agent can be
+  pointed at an Azure AI Foundry deployment using a directory sign-in**, which
+  is the only authentication this repository permits. Since every column must
+  share one deployment, that single unconfirmed fact decides whether the column
+  can ever be honest. It stays empty and marked unconfirmed, and is explicitly
+  not filled with Azure's own agent service driving a model whose name contains
+  "codex" — that is a different product.
 
 ### Verification
 
-- New tests: 75 across
-  `batch-runner/tests/test_execution_envelope_advance_check.py` (62) and
-  `batch-runner/tests/test_execution_envelope_docker_containment.py` (13). Each
-  refusal path has a test that changes exactly one thing in the plan and
-  requires the check to say no.
-- Three real defects were found by reviewing and testing this work, and all
-  three are fixed:
-  - **The check could refuse without printing a reason.** The readiness check
-    keeps its own problem list and only the envelope check's was shown, so a
-    plan allowing automatic model switching produced "may not start" with an
-    empty explanation. The two lists are now merged wherever a verdict is
-    reported, and a test requires every refusal to carry a reason.
-  - **A settings file that simply omitted the answer-length cap passed.**
-    Silence was read as agreement, but a missing cap falls back to a built-in
-    default that differs from the fixed one, so one run place would have been
-    allowed half the answer length of the others. A missing cap is now a
-    refusal.
-  - **Nothing checked settings the plan does not name.** Temperature, the
-    repeatability seed, and how hard the model is asked to think are not among
-    the fifteen fixed conditions, but a run place with a different value for
-    any of them would produce a difference that is not the run place. The three
-    settings files must now agree on all three.
-- **In CI the backend suite is 3,716 passed, 9 skipped, 45 deselected, 0
-  failed** (run 32836458107), which is the previous 3,641 plus the 75 new
-  tests exactly.
-- Full backend suite locally: **3,715 passed, 6 skipped, 45 deselected, 4
-  failed.** All 4 failures are environmental and none is caused by this work:
-  `pdfplumber` is not installed here (2 tests); one test pins SDK versions
-  older than those installed; and one builds a candidate image with the system
-  Python, which needs exactly one of `site-packages` or `dist-packages` under
-  `/usr/lib/python3.10/` and this machine now has neither. **Confirmed by
-  checking out the base commit `d2ebc40` in a separate worktree and running the
-  same tests there, where they fail identically.** The last one began failing
-  part-way through this work without any change to it, which is what a shared
-  machine looks like. CI installs the dependencies and has the package
-  directory, so it sees none of these.
-- `mypy` on the three new modules: clean. The 170 pre-existing errors elsewhere
-  in `core/` are untouched and none is in a new file.
-- The catalogue rebuilds byte-for-byte from the pinned dataset revision
-  (`build_gdpval_task_catalog.py --check` exits 0), so the task choice can be
-  re-derived by anyone rather than trusted.
-- No model call, no grading, no Azure sign-in, no image publish, no workflow
-  dispatch, and no Hugging Face write occurred. The two reference files were
-  read from the public dataset to record their fingerprints, which costs
-  nothing.
-- Work was done in a throwaway clone cut from `origin/main` at `d2ebc40`. The
-  user's own working folder and its 1,275 pending changes were not touched.
+- New tests: 12, bringing the two envelope test files to 87. They include the
+  one that matters most: **a plan where the settings are well formed, the route
+  is right, the deployment name is unchanged, and only the account differs must
+  be refused.** That is the case that used to pass.
+- Also covered: a different project on the right account; a missing address, with
+  the message required to contain the address it should have held; "not set"
+  told apart from "set to the wrong thing"; each forbidden fixed credential; a
+  direct address on another account; a plan that forgets to pin the account; and
+  a plan without the Azure column, which must skip the check entirely rather
+  than complain about settings it does not need.
+- `mypy` on the new and changed modules: clean.
+- The command-line tool was run by hand with the Azure settings unset and names
+  both missing settings plus the exact address to supply.
+- The user's own working folder and its pending changes were not touched. Work
+  was done in a throwaway clone cut from `origin/main` at `34123ef`.
 
 ### Remaining Work
 
-- **The largest amount that may be spent has not been set.** This is the only
-  thing standing between the current state and a run of the three places. The
-  worked-out ceiling is **$32.23**.
-- Paid model calls are still unapproved
-  (`EXECUTION_COMPARISON_PAID_RUN_APPROVED`).
-- The model and deployment are proposed, not confirmed: `gpt-5.4`, on the
-  evidence that it is the only name in this repository already used by the
-  server place, the container place, and the Responses API that the Azure place
-  uses.
-- Azure's code interpreter still needs its connection setting. `project-ci`
-  requires both a direct address and a project address, so supplying the route
-  name alone is not enough.
-- Agentic Sandbox V2 still needs its command-running tool, a real model loop,
-  and an explicit approval. Codex still needs both a run path here and public
-  evidence that its own agent loop can use the same Azure deployment. Until
-  then those two columns stay empty rather than being filled by another place.
-- The 30-task and 220-task stages are written down but not approved.
+- **The Azure access decision.** Until the pinned tenant can be reached
+  non-interactively, the advance check cannot run. Nothing in this repository
+  can settle that.
+- The 30-task and 220-task stages remain unapproved and are not covered by the
+  $32.23.
+- Agentic Sandbox V2 needs a cost ceiling for its first stage worked out and
+  approved; that piece of work is free.
+- The Codex column needs one external fact confirmed, or the comparison should
+  be documented as having four columns.
+
 
 
 ---


### PR DESCRIPTION
승인된 5개 작업 사전 점검을 시도했습니다. **실행하지 못했고, 비용은 0.00 달러입니다.** 그 과정에서 비교 설계 자체의 실제 구멍을 발견해 막았습니다.

---

## 1. 사전 점검은 실행되지 않았습니다 (지출 0.00 달러)

승인 금액 32.23 달러를 계획 파일에 기록했습니다. 그러자 비용 검사가 통과하고 세 환경 중 두 곳이 준비 완료가 됐습니다. 세 번째가 막혔습니다.

**막은 것**: 이 비교가 고정한 Azure AI Foundry 계정 `hjeon-fdpo-foundry-eus2`(프로젝트 `gdpval-realworks`)는 특정 Azure 테넌트와 구독에 있습니다. 이 컴퓨터에 로그인된 계정은 **다른 테넌트, 다른 구독**입니다. 고정된 테넌트로 접근을 요청하면 조건부 액세스 정책이 거부합니다(`AADSTS530036`, "refresh token is invalid due to authentication flow checks"). 남은 방법은 웹 브라우저를 통한 대화형 로그인뿐입니다. 이는 테넌트 관리자의 권한 결정이며 저장소가 해결할 수 없습니다.

**두 곳만 실행하지 않은 이유**: 계획 파일과 검사 도구와 여러 테스트가 모두 같은 말을 합니다 — 차단된 환경을 빼고 나머지만 돌리지 않습니다. 두 칸만 돌리고 3자 비교라고 부르면 승인받은 것과 **다른 질문에 답하면서 실제 돈을 쓰는** 일이 됩니다. 환경을 빼려면 사람이 계획 파일을 직접 고쳐야 합니다.

새 접근 키를 만들지 않았고, 보안 장벽을 낮추지 않았고, 접속 주소를 추측하지 않았습니다.

---

## 2. 조사 중 발견한 실제 구멍 (이번 변경의 핵심)

올바른 계정을 찾으려고 Azure 테넌트를 조회하다가, 설계가 놓친 것을 발견했습니다.

### 배포 이름은 배포를 특정하지 못합니다

조회한 테넌트에는 **`gpt-5.4`라는 이름의 배포를 가진 계정이 두 개** 있었고, 같은 모델을 다른 배포 이름으로 가진 세 번째 계정도 있었습니다.

계획은 `deployment: gpt-5.4`만 고정했을 뿐 **어느 계정에 있는지는 고정하지 않았습니다.** 검사 도구가 받는 Azure 정보는 경로 이름 한 단어뿐이었습니다.

그래서 한 환경은 A 계정의 `gpt-5.4`로, 다른 환경은 B 계정의 `gpt-5.4`로 돌아갈 수 있었습니다. 지역이 다르고, 모델 버전이 다를 수 있고, 콘텐츠 필터가 다를 수 있습니다. 그런데도 모든 검사가 "세 환경이 같은 배포를 썼다"고 보고했을 것입니다. **결과표를 보는 사람은 알 방법이 없습니다.**

이 계획 전체가 막으려는 바로 그 종류의 조용한 오류이며, 이론이 아니라 실제로 열려 있었습니다.

### 고친 방법

계획이 이제 계정과 프로젝트를 고정합니다. 검사 도구는 실제 실행이 쓸 접속 주소 설정을 읽어, **글자 비교가 아니라 저장소 자신의 주소 판별 규칙**(`classify_endpoint`)으로 분류하고, 다른 계정이나 프로젝트를 지목하면 거부합니다.

두 이름은 새 정보도 비밀도 아닙니다. 저장소가 이미 자동 실행용으로 `AZURE_AI_EXPECTED_PROJECT_ACCOUNT`, `AZURE_AI_EXPECTED_PROJECT_NAME` 설정에 기록해 둔 값입니다.

### 같은 영역의 두 번째 수정

검사 도구가 **서로 다른 세 문제에 같은 답**을 했습니다. "Azure를 설정하지 않음", "설정했지만 다른 곳을 가리킴", "설정은 맞지만 접근 불가" — 셋 다 "the Azure route profile was not measured"였습니다. 고치는 방법이 셋 다 다른데 메시지는 하나였고, 어느 쪽인지 알아내는 데 Azure 명령줄 도구로 직접 조사해야 했습니다.

이제 어느 설정이 잘못됐는지 정확히 말하고, 들어가야 할 주소를 그대로 출력합니다:

```
Problems that must be fixed before anything starts:
  - AZURE_AI_ROUTE_PROFILE is not set, so the Azure run place refuses to start.
    It must be 'project-ci' for this comparison.
  - FOUNDRY_PROJECT_ENDPOINT is not set. The Azure run place needs the address of
    the project that holds the deployment, which looks like
    https://hjeon-fdpo-foundry-eus2.services.ai.azure.com/api/projects/gdpval-realworks
```

금지된 고정 자격 증명과 사용이 중단된 통합 접속 주소 설정도 무료 검사 단계에서 알려 줍니다. 실행을 예약한 뒤 같은 이유로 실패하는 대신에.

**모든 검사는 설정만 읽습니다.** 로그인하지 않고, Azure에 접속하지 않고, 아무것도 쓰지 않습니다.

---

## 3. 새로 작성한 상세 명세 3건

- **`TASK_PIN_AZURE_RESOURCE_IDENTITY.md`** — 위 작업.
- **`TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md`** — "미리 적어 둔 호출을 재생"에서 "모델이 다음 행동을 고름"까지 가는 4단계 경로. 명령 실행은 **일부러 마지막**에 두고 별도 승인 뒤에 둡니다. **기존 세 가지 안전 차단을 우회하거나 약화하지 않습니다.** 차단을 다시 검토하는 단계는 격리 조건을 깨뜨리려 시도하는 테스트로 증명한 **뒤에만** 옵니다.
- **`TASK_NATIVE_CODEX_RUN_PATH.md`** — 공식 문서에서 확인된 것과 확인되지 않은 것. **확인됨**: 대화형이 아닌 실행 모드(`codex exec`)가 있고, 사용자 지정 제공자 설정이 있으며, 제공자 설정은 사용자 수준 설정에만 둘 수 있습니다. **확인되지 않음**: Codex 자체 에이전트를 이 저장소가 요구하는 디렉터리 로그인 방식으로 Azure AI Foundry 배포에 연결할 수 있는지. 모든 칸이 **같은 배포**를 써야 하므로, 이 한 가지 사실이 이 칸이 정직할 수 있는지를 결정합니다. 빈칸과 미확인으로 유지하며, 이름에 codex가 들어간 모델을 쓰는 **Azure 자체 에이전트 기능으로 대신 채우지 않습니다.** 그것은 다른 제품입니다.

---

## 4. 검증

- **신규 테스트 12개** (봉투 관련 테스트 파일 두 개 합계 92개). 가장 중요한 것: **설정이 온전하고, 경로가 맞고, 배포 이름이 그대로이고, 계정만 다른** 경우를 거부해야 한다 — 예전에 통과하던 바로 그 경우입니다.
- 그 밖에: 맞는 계정의 다른 프로젝트; 주소 누락(메시지에 들어가야 할 주소가 포함되는지 확인); "설정 안 됨"과 "잘못 설정됨" 구분; 금지된 고정 자격 증명 각각; 다른 계정의 직접 주소; 계정 고정을 빠뜨린 계획; Azure 칸이 없는 계획은 검사를 아예 건너뛰어야 함.
- `tasks/0822_saturday/`도 기본 무시에 개별 허용 목록 방식이라 새 명세 3건이 새 저장소에서 보이지 않을 뻔했습니다. 이를 잡는 테스트를 넣었습니다.
- **저장소 전체 자동 테스트: 3,726 통과 / 3 실패.** 3건은 이번 변경과 무관한 환경 문제입니다(`pdfplumber` 미설치 2건, 설치된 SDK가 테스트 고정값보다 최신 1건).
- `mypy`: 새 모듈과 수정 모듈 통과.

---

## 5. 남은 차단 조건

| 조건 | 상태 |
|---|---|
| **Azure 테넌트 접근 권한** | **남음. 저장소가 해결할 수 없음.** 고정된 테넌트에 대화형이 아닌 방식으로 접근 가능해질 때까지 사전 점검은 실행할 수 없습니다 |
| 30개 / 220개 작업 실행 | 승인되지 않음. 32.23 달러에 포함되지 않음 |
| Agentic Sandbox V2 | 1단계 비용 상한 산출과 승인 필요. 산출 자체는 무료 |
| Codex 칸 | 외부 사실 1건 확인 필요, 또는 4칸 비교로 문서화 |
