### PR TITLE
실행 환경 비교 — 반복 호출 비용 계산 수정과 Agentic Sandbox V2 1단계 비용 상한

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/summary_wow_drift.py
 !batch-runner/scripts/check_execution_environment_readiness.py
 !batch-runner/scripts/check_execution_envelope_advance_check.py
+!batch-runner/scripts/check_agentic_stage_one_ceiling.py
 !batch-runner/scripts/build_gdpval_task_catalog.py
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,65 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **The cost ceiling charged a looping request as though it never grew, and the
+  approved amount was worked out with that mistake in it.** The shared
+  arithmetic multiplied one turn's input by the number of model calls. That is
+  right when each attempt is a fresh request, and wrong for any request where
+  the model is asked again after each tool result: every later turn re-reads the
+  whole conversation before it, so what was written on turn one is charged again
+  on turns two, three and onwards. Counting a conversation as it grows raises
+  the Azure code interpreter column from 4.83 to 14.06 United States dollars and
+  the whole five-task, three-place run from 32.23 to 43.77 — **above the 32.23
+  approved for it on 2026-08-25**. So the run could have been allowed to start
+  and then billed more than was approved, with every check reporting it as
+  within budget. Nothing was spent under the wrong figure, because the Azure run
+  place has never been reachable from the machine it was attempted from. The
+  free check now refuses, which is the safety mechanism working; the plan file
+  records the three ways out and leaves the choice to the owner. The two
+  single-turn run places are unchanged to the token, and a test holds that in
+  place. `max_tool_result_tokens_per_turn` is now a required assumption per run
+  place: leaving it out stops the count rather than quietly standing in a zero.
+
+### Added
+- **What Agentic Sandbox V2 stage one would cost, worked out for free.** Step
+  one of `tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md`. A loop's
+  bill does not rise in step with the number of turns — it rises roughly with
+  the square of it, because the earlier turns are re-read by every later one.
+  `batch-runner/core/agentic_v2_stage_one_budget.py` prices the candidate
+  settings over the same five tasks, taking the tool-call ceiling and the
+  tool-result size from the dispatcher's own code rather than from numbers
+  copied into a document. The finding that motivates the table: **the
+  dispatcher's own defaults are the most expensive setting available**, at most
+  492.67 dollars to run five tasks, against 3.24 for the cheapest setting that
+  could still answer the question — over fifty times, from two settings a
+  reasonable person would have left alone. `StageOneBudget` then holds a run to
+  the figure, refusing the next call at each ceiling and raising rather than
+  reporting quietly if one is passed, so the worked-out amount is a limit and
+  not a hope. Nothing is approved, nothing is switched on, and all three safety
+  blocks stay shut: `scripts/check_agentic_stage_one_ceiling.py` prints the
+  table and refuses, reporting first that the model conversation stage one is
+  about does not exist yet — established by looking at what the runner accepts,
+  so the answer changes by itself when it is built. 52 new tests.
+
+### Changed
+- **The Codex question is now half answered, and narrower.**
+  `tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md` asked whether Codex's own
+  agent could be pointed at an Azure AI Foundry deployment using a directory
+  sign-in. The authentication half turns out to be documented in general: a
+  `model_providers.<id>.auth` table runs a command that prints a token to
+  standard output and refreshes it, which is the shape a directory sign-in
+  needs. The Azure half is still unconfirmed, and the evidence now leans
+  against: `wire_api` documents `responses` as its only supported value with no
+  statement that Azure's Responses API accepts that format, Azure appears
+  nowhere in the configuration reference, and Amazon Bedrock — which does have a
+  built-in provider, its own settings, its own page, and a statement of format
+  compatibility — shows that the documentation covers a competing cloud in depth
+  when it means to. The column stays empty and is not filled with Azure's own
+  agent service, which is a different product. The remaining unknown is written
+  down as one checkable question, with the configuration it would use, marked
+  clearly as untested.
+
+### Fixed
 - **A deployment name does not identify a deployment, and the run-place
   comparison was relying on one.** The plan pinned `deployment: gpt-5.4` and
   said nothing about which Azure AI Foundry account held it; the free check's

--- a/batch-runner/core/agentic_v2_stage_one_budget.py
+++ b/batch-runner/core/agentic_v2_stage_one_budget.py
@@ -1,0 +1,853 @@
+"""What stage one of Agentic Sandbox V2 could cost, and how it is held to it.
+
+Stage one is the first step described in
+``tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md``: let the model
+choose its own next action from the safe tools, with the command-running tool
+``exec_run`` still shut. It is also the first step in that document that costs
+money, because it calls the model again after every tool result instead of
+once per task.
+
+That changes the shape of the bill completely, and the difference is not small.
+When the model is asked once, the cost of a task is roughly fixed by how long
+the task is. When the model is asked again after each tool result, three things
+happen at once:
+
+* the number of calls rises to the number of tool calls allowed;
+* every call may write a full-length answer, so the writing is charged once per
+  turn rather than once per task;
+* every turn re-reads the whole conversation so far, so what was written on the
+  first turn is charged again on every turn after it.
+
+The third is the one that catches people out. It means the bill does not grow
+in step with the number of turns; it grows roughly with the square of it.
+Doubling how many times the model may be asked roughly quadruples what the
+earlier turns cost to re-read.
+
+So this module does two separate jobs.
+
+**Before anything runs**, :func:`stage_one_ceiling` works out the largest bill a
+stage-one run could produce, using the same arithmetic as the rest of the
+comparison. It takes the limits it needs from the dispatcher's own code rather
+than from numbers copied into a document, so the figure cannot drift away from
+what the code would actually allow.
+
+**While something runs**, :class:`StageOneBudget` counts what has been spent and
+refuses the next call once a ceiling is reached. Without it the worked-out
+figure would be a hope rather than a limit.
+
+Nothing in this module calls a model, opens ``exec_run``, or changes any of the
+three blocks that keep Agentic Sandbox V2 out of the paid pipeline. It does
+arithmetic and it counts.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from decimal import Decimal, ROUND_CEILING
+from pathlib import Path
+from typing import Any, Mapping
+
+from core.agentic_v2_tools import AgenticV2ToolDispatcher
+from core.execution_envelope_cost import (
+    CostAssumptions,
+    CostCeiling,
+    ModelPrice,
+    estimate_cost_ceiling,
+)
+from core.execution_envelope_tasks import CatalogTask
+from core.execution_environment_readiness import (
+    ENVIRONMENT_AGENTIC_SANDBOX_V2,
+    ModelRunConditions,
+)
+
+
+@dataclass(frozen=True)
+class DispatcherLimits:
+    """The ceilings the tool dispatcher applies, read from its own code.
+
+    These are not restated here as numbers. They are read from
+    :class:`core.agentic_v2_tools.AgenticV2ToolDispatcher` so that lowering or
+    raising a limit in the dispatcher moves the worked-out bill with it, and a
+    document cannot quietly disagree with the code.
+    """
+
+    max_total_calls: int
+    """The most tool calls one run may make before the dispatcher refuses."""
+
+    max_result_bytes: int
+    """The most one tool result may weigh once written out."""
+
+
+def read_dispatcher_limits() -> DispatcherLimits:
+    """Read the two ceilings the dispatcher applies to every run."""
+    defaults = {
+        entry.name: entry.default
+        for entry in dataclasses.fields(AgenticV2ToolDispatcher)
+    }
+    readable: dict[str, int] = {}
+    missing: list[str] = []
+    for name in ("max_total_calls", "max_result_bytes"):
+        value = defaults.get(name)
+        if isinstance(value, bool) or not isinstance(value, int):
+            missing.append(name)
+        else:
+            readable[name] = value
+    if missing:
+        raise ValueError(
+            "the tool dispatcher no longer states a plain number for: "
+            + ", ".join(sorted(missing))
+            + ". The stage-one bill is worked out from those numbers, so it "
+            "cannot be worked out until they are readable again."
+        )
+    return DispatcherLimits(
+        max_total_calls=readable["max_total_calls"],
+        max_result_bytes=readable["max_result_bytes"],
+    )
+
+
+def tool_result_tokens_ceiling(
+    limits: DispatcherLimits, *, characters_per_token: Decimal
+) -> int:
+    """The most one tool result could weigh, in tokens rather than bytes.
+
+    The dispatcher measures a result in bytes, and a bill is measured in
+    tokens, so the two have to be brought together somewhere. Dividing by the
+    same characters-per-token figure the rest of the comparison uses keeps that
+    conversion in one place and visible.
+    """
+    if characters_per_token <= 0:
+        raise ValueError("characters_per_token must be greater than zero")
+    tokens = Decimal(limits.max_result_bytes) / characters_per_token
+    return int(tokens.to_integral_value(rounding=ROUND_CEILING))
+
+
+@dataclass(frozen=True)
+class StageOneConditions:
+    """The settings a stage-one run would use.
+
+    Deliberately smaller than the full comparison's conditions: stage one is
+    not a scored comparison and does not need to match the other run places on
+    every point. It needs to answer one question — does asking the model
+    repeatedly help at all — for the least money that can answer it.
+    """
+
+    deployment: str
+    resolved_model: str
+    task_ids: tuple[str, ...]
+    tool_calls_per_attempt: int
+    """How many times the model may be asked again inside one attempt.
+
+    Never more than the dispatcher's own ceiling: the dispatcher refuses
+    further tool calls beyond it, so allowing more here would price turns that
+    could never happen.
+    """
+
+    max_output_tokens_per_turn: int
+    """The most the model may write in reply to one turn.
+
+    This is a separate number from the one the three-place comparison uses.
+    There, one answer is written per task, so a generous cap costs little.
+    Here an answer may be written on every turn, so the same generous cap is
+    multiplied by the number of turns. A turn that only picks a tool needs very
+    little room.
+    """
+
+    retry_max_attempts: int
+    per_task_timeout_seconds: int
+
+    def validated(self, limits: DispatcherLimits) -> "StageOneConditions":
+        """Refuse settings the dispatcher would not honour anyway."""
+        if self.tool_calls_per_attempt < 1:
+            raise ValueError(
+                "a stage-one attempt asks the model at least once"
+            )
+        if self.tool_calls_per_attempt > limits.max_total_calls:
+            raise ValueError(
+                f"the settings allow {self.tool_calls_per_attempt} tool calls "
+                f"in one attempt, but the dispatcher refuses anything past "
+                f"{limits.max_total_calls}, so the extra turns would be priced "
+                "but could never happen"
+            )
+        if self.max_output_tokens_per_turn < 1:
+            raise ValueError(
+                "a turn that may write nothing cannot produce an answer"
+            )
+        if self.retry_max_attempts < 0:
+            raise ValueError("a task cannot be attempted a negative number of times")
+        return self
+
+    def as_run_conditions(self) -> ModelRunConditions:
+        """Express these settings the way the shared cost arithmetic reads them.
+
+        Reusing the comparison's own arithmetic rather than writing a second
+        copy means a correction made in one place cannot be missed in the
+        other.
+        """
+        return ModelRunConditions.from_mapping(
+            {
+                "provider": "azure",
+                "deployment": self.deployment,
+                "resolved_model": self.resolved_model,
+                "api_version": "2025-04-01-preview",
+                "system_instruction": "",
+                "task_instruction": "",
+                "task_ids": list(self.task_ids),
+                "input_file_versions": {},
+                "max_output_tokens": self.max_output_tokens_per_turn,
+                "per_task_timeout_seconds": self.per_task_timeout_seconds,
+                # Stage one answers whether choosing tools helps. A second look
+                # at the finished answer is a different question and would make
+                # the result impossible to attribute, so it stays off.
+                "self_review_enabled": False,
+                "self_review_max_attempts": 0,
+                "retry_reasons_allowed": ["infrastructure_error"],
+                "retry_max_attempts": self.retry_max_attempts,
+                "automatic_model_switch_allowed": False,
+            }
+        )
+
+
+def stage_one_ceiling(
+    *,
+    conditions: StageOneConditions,
+    tasks_by_id: Mapping[str, CatalogTask],
+    assumptions: CostAssumptions,
+    limits: DispatcherLimits | None = None,
+    prices: Mapping[str, ModelPrice] | None = None,
+) -> CostCeiling:
+    """The largest bill a stage-one run could produce.
+
+    The tool-result size is not taken from the caller. It is read from the
+    dispatcher, because that is the number that will actually be enforced when
+    something runs.
+    """
+    dispatcher_limits = limits if limits is not None else read_dispatcher_limits()
+    conditions = conditions.validated(dispatcher_limits)
+    place = ENVIRONMENT_AGENTIC_SANDBOX_V2
+    stage_one_assumptions = dataclasses.replace(
+        assumptions,
+        tool_loop_max_model_turns={
+            place: conditions.tool_calls_per_attempt,
+        },
+        # Each turn is its own request with its own cap on how much may be
+        # written, unlike the Azure code interpreter where one cap covers the
+        # whole reply. So a full-length answer is possible on every turn.
+        output_tokens_capped_per_attempt={place: False},
+        max_tool_result_tokens_per_turn={
+            place: tool_result_tokens_ceiling(
+                dispatcher_limits,
+                characters_per_token=assumptions.characters_per_token,
+            ),
+        },
+    )
+    return estimate_cost_ceiling(
+        conditions_by_environment={place: conditions.as_run_conditions()},
+        tasks_by_id=tasks_by_id,
+        assumptions=stage_one_assumptions,
+        prices=prices,
+    )
+
+
+class StageOneBudgetExceeded(RuntimeError):
+    """Raised when a run has already spent more than it was allowed to."""
+
+
+@dataclass
+class StageOneBudget:
+    """Counts what a stage-one run has spent and refuses to let it spend more.
+
+    A worked-out ceiling that nothing enforces is a hope. This is the part that
+    makes it a limit: a loop asks :meth:`refusal_before_next_call` before every
+    call and stops when it gets an answer, and reports what each call actually
+    used with :meth:`record`.
+
+    Reporting more than was allowed raises rather than returning quietly. The
+    reason is that a loop which has already overspent has lost the thread of
+    what it is doing, and the only safe thing left is to stop loudly. Silently
+    carrying on and reporting the overspend afterwards is how a small mistake
+    becomes a large bill.
+    """
+
+    max_model_calls: int
+    max_input_tokens: int
+    max_output_tokens: int
+    model_calls_made: int = 0
+    input_tokens_used: int = 0
+    output_tokens_used: int = 0
+
+    def __post_init__(self) -> None:
+        for name in ("max_model_calls", "max_input_tokens", "max_output_tokens"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"{name} must be a plain whole number")
+            if value < 0:
+                raise ValueError(f"{name} cannot be below zero")
+
+    def refusal_before_next_call(self) -> str | None:
+        """Why the next call must not be made, or ``None`` if it may be.
+
+        Checked before the call rather than after it, because after it the
+        money is already spent.
+        """
+        if self.model_calls_made >= self.max_model_calls:
+            return (
+                f"this run has already made {self.model_calls_made} model "
+                f"calls, which is all the {self.max_model_calls} it was allowed"
+            )
+        if self.input_tokens_used >= self.max_input_tokens:
+            return (
+                f"this run has already sent {self.input_tokens_used} tokens, "
+                f"which is all the {self.max_input_tokens} it was allowed"
+            )
+        if self.output_tokens_used >= self.max_output_tokens:
+            return (
+                f"this run has already been sent back "
+                f"{self.output_tokens_used} tokens, which is all the "
+                f"{self.max_output_tokens} it was allowed"
+            )
+        return None
+
+    def record(self, *, input_tokens: int, output_tokens: int) -> None:
+        """Add what one call used, and refuse to go past any ceiling."""
+        for name, value in (
+            ("input_tokens", input_tokens),
+            ("output_tokens", output_tokens),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"{name} must be a plain whole number")
+            if value < 0:
+                raise ValueError(f"{name} cannot be below zero")
+        self.model_calls_made += 1
+        self.input_tokens_used += input_tokens
+        self.output_tokens_used += output_tokens
+        passed = []
+        if self.model_calls_made > self.max_model_calls:
+            passed.append(
+                f"{self.model_calls_made} model calls against a limit of "
+                f"{self.max_model_calls}"
+            )
+        if self.input_tokens_used > self.max_input_tokens:
+            passed.append(
+                f"{self.input_tokens_used} tokens sent against a limit of "
+                f"{self.max_input_tokens}"
+            )
+        if self.output_tokens_used > self.max_output_tokens:
+            passed.append(
+                f"{self.output_tokens_used} tokens received against a limit of "
+                f"{self.max_output_tokens}"
+            )
+        if passed:
+            raise StageOneBudgetExceeded(
+                "a stage-one run has spent more than it was allowed: "
+                + "; ".join(passed)
+            )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "model_calls_allowed": self.max_model_calls,
+            "model_calls_made": self.model_calls_made,
+            "input_tokens_allowed": self.max_input_tokens,
+            "input_tokens_used": self.input_tokens_used,
+            "output_tokens_allowed": self.max_output_tokens,
+            "output_tokens_used": self.output_tokens_used,
+        }
+
+
+def budget_for_one_task(ceiling: CostCeiling, task_id: str) -> StageOneBudget:
+    """Build the running limit for one task from the worked-out ceiling.
+
+    Taking the limit from the same figure that was approved, rather than from a
+    number typed in beside it, means the two cannot drift apart. If the ceiling
+    is recomputed the limit moves with it.
+    """
+    for environment in ceiling.environments:
+        for task in environment.tasks:
+            if task.task_id == task_id:
+                return StageOneBudget(
+                    max_model_calls=task.model_calls,
+                    max_input_tokens=task.total_input_tokens,
+                    max_output_tokens=task.total_output_tokens,
+                )
+    raise ValueError(
+        f"the worked-out ceiling says nothing about task {task_id}, so there "
+        "is no limit to hold it to"
+    )
+
+
+@dataclass(frozen=True)
+class StageOneOption:
+    """One candidate setting, with what it would cost at most.
+
+    Running and marking are kept apart because they move for different
+    reasons. Running the tasks is what these settings change; marking the
+    answers costs the same whatever the settings are, and at the smaller
+    settings it is most of the bill. Adding them into one figure would hide
+    that, and would make a change to the settings look less effective than it
+    is.
+    """
+
+    tool_calls_per_attempt: int
+    max_output_tokens_per_turn: int
+    most_running_model_calls: int
+    most_grading_model_calls: int
+    most_running_could_cost_usd: Decimal
+    most_grading_could_cost_usd: Decimal
+    most_it_could_cost_usd: Decimal
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "tool_calls_per_attempt": self.tool_calls_per_attempt,
+            "max_output_tokens_per_turn": self.max_output_tokens_per_turn,
+            "most_running_model_calls": self.most_running_model_calls,
+            "most_grading_model_calls": self.most_grading_model_calls,
+            "most_running_could_cost_usd": _money(
+                self.most_running_could_cost_usd
+            ),
+            "most_grading_could_cost_usd": _money(
+                self.most_grading_could_cost_usd
+            ),
+            "most_it_could_cost_usd": _money(self.most_it_could_cost_usd),
+        }
+
+
+def _money(value: Decimal) -> str:
+    return str(value.quantize(Decimal("0.01"), rounding=ROUND_CEILING))
+
+
+def price_the_options(
+    *,
+    base: StageOneConditions,
+    tasks_by_id: Mapping[str, CatalogTask],
+    assumptions: CostAssumptions,
+    tool_call_choices: tuple[int, ...],
+    output_token_choices: tuple[int, ...],
+    limits: DispatcherLimits | None = None,
+    prices: Mapping[str, ModelPrice] | None = None,
+) -> list[StageOneOption]:
+    """Work out what each candidate setting would cost at most.
+
+    Presented as a list rather than a single figure on purpose. The decision
+    stage one needs is not "may we spend the worked-out amount"; it is "which
+    settings buy an answer worth having, for a price worth paying". That is a
+    judgement, and a judgement needs the alternatives beside each other.
+
+    Settings the dispatcher would refuse are left out rather than priced, so a
+    reader is never offered a choice that could not be taken.
+    """
+    dispatcher_limits = limits if limits is not None else read_dispatcher_limits()
+    options: list[StageOneOption] = []
+    for tool_calls in sorted(set(tool_call_choices)):
+        for output_tokens in sorted(set(output_token_choices)):
+            candidate = dataclasses.replace(
+                base,
+                tool_calls_per_attempt=tool_calls,
+                max_output_tokens_per_turn=output_tokens,
+            )
+            try:
+                candidate.validated(dispatcher_limits)
+            except ValueError:
+                continue
+            ceiling = stage_one_ceiling(
+                conditions=candidate,
+                tasks_by_id=tasks_by_id,
+                assumptions=assumptions,
+                limits=dispatcher_limits,
+                prices=prices,
+            )
+            options.append(
+                StageOneOption(
+                    tool_calls_per_attempt=tool_calls,
+                    max_output_tokens_per_turn=output_tokens,
+                    most_running_model_calls=sum(
+                        entry.model_calls for entry in ceiling.environments
+                    ),
+                    most_grading_model_calls=ceiling.grading_model_calls,
+                    most_running_could_cost_usd=(
+                        ceiling.running_usd * ceiling.safety_multiplier
+                    ),
+                    most_grading_could_cost_usd=(
+                        ceiling.grading_usd * ceiling.safety_multiplier
+                    ),
+                    most_it_could_cost_usd=ceiling.total_usd,
+                )
+            )
+    return options
+
+
+# ── The free check that must pass before stage one spends anything ─────────
+
+STAGE_ONE_PLAN_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "experiments"
+    / "execution_envelope"
+    / "agentic_stage_one_plan.yaml"
+)
+
+STAGE_ONE_PLAN_VERSION = "agentic-stage-one-v1"
+
+
+@dataclass
+class StageOnePreflight:
+    """Whether stage one may start, and every reason it may not."""
+
+    may_start: bool
+    problems: list[str] = field(default_factory=list)
+    options: list[StageOneOption] = field(default_factory=list)
+    chosen: StageOneOption | None = None
+    chosen_budget: dict[str, StageOneBudget] = field(default_factory=dict)
+    """The limit each task would be held to, once a row has been chosen.
+
+    Empty until a row is chosen, because until then there is no figure to hold
+    anything to. Reported so that whoever approves an amount can see the limit
+    that would actually stop a run, rather than only the amount.
+    """
+
+    approved_maximum_usd: Decimal | None = None
+    dispatcher_limits: DispatcherLimits | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "may_start": self.may_start,
+            "problems": list(self.problems),
+            "options": [entry.as_dict() for entry in self.options],
+            "chosen": self.chosen.as_dict() if self.chosen else None,
+            "chosen_budget": {
+                task_id: budget.as_dict()
+                for task_id, budget in self.chosen_budget.items()
+            },
+            "approved_maximum_usd": (
+                _money(self.approved_maximum_usd)
+                if self.approved_maximum_usd is not None
+                else None
+            ),
+            "dispatcher_limits": (
+                dataclasses.asdict(self.dispatcher_limits)
+                if self.dispatcher_limits
+                else None
+            ),
+        }
+
+
+def load_stage_one_plan(path: Any = None) -> dict:
+    """Read the stage-one plan file."""
+    import yaml
+
+    target = Path(path) if path is not None else STAGE_ONE_PLAN_PATH
+    if not target.is_file():
+        raise ValueError(f"the stage-one plan is missing at {target}")
+    raw = yaml.safe_load(target.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"the stage-one plan at {target} is not a mapping")
+    if raw.get("plan_version") != STAGE_ONE_PLAN_VERSION:
+        raise ValueError(
+            "the stage-one plan was written for "
+            f"{raw.get('plan_version')!r}, but this code reads "
+            f"{STAGE_ONE_PLAN_VERSION!r}"
+        )
+    return raw
+
+
+def check_the_model_conversation_does_not_exist_yet() -> list[str]:
+    """Confirm the runner still replays a written-down list rather than asking.
+
+    Stage one is defined as the step that replaces the replayed list with a
+    real conversation. Until that exists, stage one cannot start however much
+    money is approved, and saying so plainly is more useful than letting the
+    money question stand in for it.
+
+    Checked by looking at what the runner accepts, not by reading a comment, so
+    the answer changes by itself when the conversation is built.
+    """
+    import inspect
+
+    try:
+        from core.agentic_v2_runner import AgenticV2ScriptedRunner
+    except ImportError as error:  # pragma: no cover - defensive
+        return [
+            "the Agentic Sandbox V2 runner could not be loaded, so whether "
+            f"the model conversation exists cannot be established: {error}"
+        ]
+    accepted = set(
+        inspect.signature(AgenticV2ScriptedRunner.__init__).parameters
+    )
+    if "scripted_calls" not in accepted:
+        return [
+            "the Agentic Sandbox V2 runner no longer takes a list of calls "
+            "written down in advance. If the model conversation has been "
+            "built, this check needs updating to say so; until then stage one "
+            "cannot be graded"
+        ]
+    if accepted & {"model_client", "llm_client", "client"}:
+        return [
+            "the Agentic Sandbox V2 runner now accepts a model client. Stage "
+            "one may have been built, and this check must be updated to "
+            "confirm the loop stops at the dispatcher's ceiling before any "
+            "paid run is allowed"
+        ]
+    return [
+        "the model conversation stage one is about does not exist yet: "
+        "core.agentic_v2_runner.AgenticV2ScriptedRunner replays a list of "
+        "calls written down in advance and holds no model client, so no model "
+        "ever sees a tool result and chooses what to do next"
+    ]
+
+
+def run_stage_one_preflight(
+    plan: Mapping[str, Any],
+    *,
+    tasks_by_id: Mapping[str, CatalogTask],
+    assumptions: CostAssumptions,
+    limits: DispatcherLimits | None = None,
+    prices: Mapping[str, ModelPrice] | None = None,
+) -> StageOnePreflight:
+    """Work out what stage one could cost, and refuse to let it start.
+
+    Every refusal is collected rather than the first one being returned, so a
+    reader sees the whole list of what is missing instead of fixing one thing
+    at a time.
+    """
+    from core.execution_environment_readiness import (
+        check_agentic_sandbox_v2_blocks_are_intact,
+    )
+
+    problems: list[str] = []
+    dispatcher_limits = limits if limits is not None else read_dispatcher_limits()
+
+    if plan.get("safety_blocks_must_stay_closed") is not True:
+        problems.append(
+            "the stage-one plan no longer requires the three safety blocks to "
+            "stay closed. Stage one does not open any of them, so this must "
+            "stay true"
+        )
+    problems.extend(check_agentic_sandbox_v2_blocks_are_intact())
+    problems.extend(check_the_model_conversation_does_not_exist_yet())
+
+    fixed = dict(plan.get("fixed_settings") or {})
+    if fixed.get("exec_run_open") is not False:
+        problems.append(
+            "the stage-one plan does not state that the command-running tool "
+            "exec_run stays shut. Opening it is stage three and needs its own "
+            "separate written approval"
+        )
+    if fixed.get("self_review_enabled") is not False:
+        problems.append(
+            "the stage-one plan switches self-review on. Stage one asks "
+            "whether choosing tools helps; a second look at the finished "
+            "answer is a different question and would make the result "
+            "impossible to attribute to either"
+        )
+    if fixed.get("automatic_model_switch_allowed") is not False:
+        problems.append(
+            "the stage-one plan allows the run to change model or deployment "
+            "on its own, which would leave a result no single model produced"
+        )
+
+    task_ids = tuple(str(value) for value in (plan.get("task_ids") or []))
+    if not task_ids:
+        problems.append("the stage-one plan names no task to run")
+
+    model = dict(plan.get("model") or {})
+    candidates = dict(plan.get("candidate_settings") or {})
+    tool_call_choices = tuple(
+        int(value) for value in (candidates.get("tool_calls_per_attempt") or [])
+    )
+    output_token_choices = tuple(
+        int(value)
+        for value in (candidates.get("max_output_tokens_per_turn") or [])
+    )
+    if not tool_call_choices or not output_token_choices:
+        problems.append(
+            "the stage-one plan offers no candidate settings to price, so "
+            "there is nothing to choose between"
+        )
+
+    options: list[StageOneOption] = []
+    if task_ids and tool_call_choices and output_token_choices:
+        base = StageOneConditions(
+            deployment=str(model.get("deployment") or ""),
+            resolved_model=str(model.get("resolved_model") or ""),
+            task_ids=task_ids,
+            tool_calls_per_attempt=min(tool_call_choices),
+            max_output_tokens_per_turn=min(output_token_choices),
+            retry_max_attempts=int(fixed.get("retry_max_attempts", 0)),
+            per_task_timeout_seconds=int(
+                fixed.get("per_task_timeout_seconds", 1200)
+            ),
+        )
+        options = price_the_options(
+            base=base,
+            tasks_by_id=tasks_by_id,
+            assumptions=assumptions,
+            tool_call_choices=tool_call_choices,
+            output_token_choices=output_token_choices,
+            limits=dispatcher_limits,
+            prices=prices,
+        )
+        if not options:
+            problems.append(
+                "every candidate setting was refused by the dispatcher's own "
+                f"ceiling of {dispatcher_limits.max_total_calls} tool calls, "
+                "so there is nothing that could be run"
+            )
+
+    cost = dict(plan.get("cost") or {})
+    chosen_raw = dict(cost.get("chosen_settings") or {})
+    chosen_calls = chosen_raw.get("tool_calls_per_attempt")
+    chosen_output = chosen_raw.get("max_output_tokens_per_turn")
+    chosen: StageOneOption | None = None
+    chosen_budget: dict[str, StageOneBudget] = {}
+    if chosen_calls is None or chosen_output is None:
+        problems.append(
+            "no settings have been chosen for stage one. Pick one row from "
+            "the table above and write its two numbers into "
+            "cost.chosen_settings"
+        )
+    else:
+        for option in options:
+            if (
+                option.tool_calls_per_attempt == int(chosen_calls)
+                and option.max_output_tokens_per_turn == int(chosen_output)
+            ):
+                chosen = option
+                break
+        if chosen is None:
+            problems.append(
+                f"the chosen settings — {chosen_calls} tool calls and "
+                f"{chosen_output} tokens per turn — are not one of the "
+                "candidates that was priced, so nobody has seen what they "
+                "would cost"
+            )
+        else:
+            # Work out the limit each task would actually be stopped by, from
+            # the same figures the price came from. Reported rather than only
+            # computed, so an approver sees the limit and not just the amount.
+            chosen_ceiling = stage_one_ceiling(
+                conditions=StageOneConditions(
+                    deployment=str(model.get("deployment") or ""),
+                    resolved_model=str(model.get("resolved_model") or ""),
+                    task_ids=task_ids,
+                    tool_calls_per_attempt=chosen.tool_calls_per_attempt,
+                    max_output_tokens_per_turn=(
+                        chosen.max_output_tokens_per_turn
+                    ),
+                    retry_max_attempts=int(fixed.get("retry_max_attempts", 0)),
+                    per_task_timeout_seconds=int(
+                        fixed.get("per_task_timeout_seconds", 1200)
+                    ),
+                ),
+                tasks_by_id=tasks_by_id,
+                assumptions=assumptions,
+                limits=dispatcher_limits,
+                prices=prices,
+            )
+            chosen_budget = {
+                task_id: budget_for_one_task(chosen_ceiling, task_id)
+                for task_id in task_ids
+            }
+
+    approved_raw = cost.get("approved_maximum_usd")
+    approved: Decimal | None = None
+    if approved_raw is None:
+        problems.append(
+            "nobody has written down the largest amount that may be spent on "
+            "stage one. The 32.23 United States dollars approved for the "
+            "three-place comparison was for that comparison and does not "
+            "extend here"
+        )
+    else:
+        try:
+            approved = Decimal(str(approved_raw))
+        except Exception:
+            problems.append(
+                f"the largest amount that may be spent, {approved_raw!r}, is "
+                "not a number"
+            )
+        else:
+            if approved <= 0:
+                problems.append(
+                    "the largest amount that may be spent must be greater "
+                    "than zero"
+                )
+            elif chosen is not None and chosen.most_it_could_cost_usd > approved:
+                problems.append(
+                    "the most the chosen settings could cost, "
+                    f"{_money(chosen.most_it_could_cost_usd)} United States "
+                    f"dollars, is above the {_money(approved)} that was "
+                    "approved"
+                )
+
+    return StageOnePreflight(
+        may_start=not problems,
+        problems=problems,
+        options=options,
+        chosen=chosen,
+        chosen_budget=chosen_budget,
+        approved_maximum_usd=approved,
+        dispatcher_limits=dispatcher_limits,
+    )
+
+
+def describe_stage_one_preflight(result: StageOnePreflight) -> list[str]:
+    """The report a person reads, with the table the decision needs."""
+    lines: list[str] = []
+    if result.dispatcher_limits is not None:
+        lines.append(
+            "The tool dispatcher refuses more than "
+            f"{result.dispatcher_limits.max_total_calls} tool calls in one "
+            "run, and cuts any single tool result off at "
+            f"{result.dispatcher_limits.max_result_bytes} bytes. Both figures "
+            "are read from core/agentic_v2_tools.py, not copied into a "
+            "document."
+        )
+        lines.append("")
+    if result.options:
+        lines.append("What each candidate setting could cost at most")
+        lines.append("-" * 74)
+        lines.append(
+            f"{'tool calls':>10}  {'write cap':>10}  {'running':>10}  "
+            f"{'marking':>10}  {'total':>10}"
+        )
+        for option in result.options:
+            written = option.as_dict()
+            lines.append(
+                f"{option.tool_calls_per_attempt:>10}  "
+                f"{option.max_output_tokens_per_turn:>10}  "
+                f"{'$' + written['most_running_could_cost_usd']:>10}  "
+                f"{'$' + written['most_grading_could_cost_usd']:>10}  "
+                f"{'$' + written['most_it_could_cost_usd']:>10}"
+            )
+        lines.append("")
+        lines.append(
+            "Marking costs the same whatever the settings are. Only the "
+            "running column moves when the settings change."
+        )
+        lines.append("")
+    if result.chosen is not None:
+        written = result.chosen.as_dict()
+        lines.append(
+            f"Chosen: {result.chosen.tool_calls_per_attempt} tool calls, "
+            f"{result.chosen.max_output_tokens_per_turn} tokens per turn, at "
+            f"most ${written['most_it_could_cost_usd']} in total"
+        )
+        if result.chosen_budget:
+            lines.append("")
+            lines.append(
+                "Each task would be stopped by these limits, whatever it is "
+                "doing at the time:"
+            )
+            for task_id in sorted(result.chosen_budget):
+                budget = result.chosen_budget[task_id]
+                lines.append(
+                    f"  {task_id}: at most {budget.max_model_calls} model "
+                    f"calls, {budget.max_input_tokens} tokens sent, "
+                    f"{budget.max_output_tokens} tokens received"
+                )
+        lines.append("")
+    if result.problems:
+        lines.append("Stage one must not start yet, because:")
+        for note in result.problems:
+            lines.append(f"  - {note}")
+    else:
+        lines.append("Every stage-one condition is met.")
+    return lines

--- a/batch-runner/core/execution_envelope_cost.py
+++ b/batch-runner/core/execution_envelope_cost.py
@@ -118,6 +118,15 @@ class CostAssumptions:
     number, so its answer length is counted once per attempt. A place that
     sends a fresh request per turn is counted once per turn."""
 
+    max_tool_result_tokens_per_turn: Mapping[str, int]
+    """For each run place, the most one tool result may add to the conversation.
+
+    This only matters where the model is asked more than once inside an
+    attempt. Each turn re-reads every tool result that came before it, so this
+    number is charged again on every later turn of the same attempt. A place
+    that asks the model once per attempt carries nothing forward and may state
+    0."""
+
     safety_multiplier: Decimal
     """A final multiplier applied to the whole ceiling, to leave room for
     counting that turns out to be optimistic."""
@@ -135,6 +144,7 @@ class CostAssumptions:
             "instruction_character_count",
             "tool_loop_max_model_turns",
             "output_tokens_capped_per_attempt",
+            "max_tool_result_tokens_per_turn",
             "safety_multiplier",
             "grading_required",
             "grading_model",
@@ -166,6 +176,18 @@ class CostAssumptions:
                     f"{place} allows {value} model turns inside one attempt; "
                     "every attempt asks the model at least once"
                 )
+        tool_result_tokens = {
+            str(key): int(value)
+            for key, value in dict(
+                raw["max_tool_result_tokens_per_turn"]
+            ).items()
+        }
+        for place, value in tool_result_tokens.items():
+            if value < 0:
+                raise ValueError(
+                    f"{place} states {value} tokens per tool result; a tool "
+                    "result cannot be shorter than nothing"
+                )
         return cls(
             characters_per_token=characters_per_token,
             instruction_character_count=int(raw["instruction_character_count"]),
@@ -176,6 +198,7 @@ class CostAssumptions:
                     raw["output_tokens_capped_per_attempt"]
                 ).items()
             },
+            max_tool_result_tokens_per_turn=tool_result_tokens,
             safety_multiplier=safety_multiplier,
             grading_required=bool(raw["grading_required"]),
             grading_model=str(raw["grading_model"]),
@@ -193,15 +216,23 @@ class CostAssumptions:
 class AttemptCounts:
     """How many times one task could be billed, split by what is billed.
 
-    ``model_calls`` is how many times the model is asked, which is what the
-    input side is billed for. ``answer_lengths`` is how many times a full
-    answer of the maximum permitted length could be produced, which is what the
-    output side is billed for. The two differ wherever one request may loop
-    through several tool turns under a single cap on answer length.
+    ``model_calls`` is how many times the model is asked in total.
+    ``answer_lengths`` is how many times a full answer of the maximum permitted
+    length could be produced, which is what the output side is billed for. The
+    two differ wherever one request may loop through several tool turns under a
+    single cap on answer length.
+
+    The input side needs a third and fourth number, because a request that
+    loops does not send the same thing every time. ``looping_attempts`` counts
+    the attempts that run the whole tool loop, and ``single_turn_calls`` counts
+    the calls that ask the model exactly once and carry nothing forward — today
+    that is the call each self-review makes to look at a finished answer.
     """
 
     model_calls: int
     answer_lengths: int
+    looping_attempts: int
+    single_turn_calls: int
 
 
 def max_attempt_counts(
@@ -242,7 +273,67 @@ def max_attempt_counts(
     # produce a replacement, and the replacement may loop like any attempt.
     model_calls += reviews * (1 + tool_loop_max_model_turns)
     answer_lengths += reviews * (1 + answers_per_attempt)
-    return AttemptCounts(model_calls=model_calls, answer_lengths=answer_lengths)
+    return AttemptCounts(
+        model_calls=model_calls,
+        answer_lengths=answer_lengths,
+        looping_attempts=attempts + reviews,
+        single_turn_calls=reviews,
+    )
+
+
+def max_input_tokens_per_attempt(
+    *,
+    base_input_tokens: int,
+    tool_loop_max_model_turns: int,
+    max_output_tokens: int,
+    output_tokens_capped_per_attempt: bool,
+    max_tool_result_tokens_per_turn: int,
+) -> int:
+    """The most one attempt could send, counting the conversation as it grows.
+
+    A place that asks the model once per attempt sends the same thing every
+    time, so its input is just what the task and the standing instructions
+    weigh. A place that asks the model again after each tool result does not:
+    every later turn re-reads the whole conversation so far, so what was
+    written on turn one is paid for again on turns two, three, and onwards.
+
+    Multiplying one turn's input by the number of turns therefore undercounts
+    any loop. The count below adds, for each turn, everything that could
+    already be in front of the model when that turn starts:
+
+    * the task and the standing instructions, once per turn;
+    * everything the model has written so far. Where one cap covers the whole
+      attempt, the largest that can be is the whole cap, and the worst case for
+      the bill is that it was all written early, so every later turn re-reads
+      all of it. Where the cap applies to each turn separately, turn *k* can
+      have at most *k* full-length answers behind it;
+    * every tool result so far, at the largest a single result may be.
+
+    The last two both grow with the turn number, which is why a loop's input
+    rises faster than the number of turns. Doubling the turns roughly
+    quadruples what the tool results cost.
+
+    At one turn per attempt every added term is zero, so this returns exactly
+    the base input and nothing about the two single-turn run places changes.
+    """
+    if tool_loop_max_model_turns < 1:
+        raise ValueError("every attempt asks the model at least once")
+    if max_tool_result_tokens_per_turn < 0:
+        raise ValueError("a tool result cannot be shorter than nothing")
+    turns = tool_loop_max_model_turns
+    output = max(max_output_tokens, 0)
+    # 0 + 1 + ... + (turns - 1): how many earlier turns each turn re-reads,
+    # summed over the whole attempt.
+    earlier_turn_pairs = turns * (turns - 1) // 2
+    if output_tokens_capped_per_attempt:
+        # One cap covers the attempt. Worst case for the bill: it is spent on
+        # the first turn, so each of the remaining turns re-reads all of it.
+        written_so_far = (turns - 1) * output
+    else:
+        # A fresh cap per turn, so turn k can have k full answers behind it.
+        written_so_far = earlier_turn_pairs * output
+    tool_results_so_far = earlier_turn_pairs * max_tool_result_tokens_per_turn
+    return turns * base_input_tokens + written_so_far + tool_results_so_far
 
 
 def max_input_tokens_per_call(
@@ -272,6 +363,7 @@ class TaskCostCeiling:
     model_calls: int
     answer_lengths: int
     input_tokens_per_call: int
+    input_tokens_per_attempt: int
     output_tokens_per_call: int
     total_input_tokens: int
     total_output_tokens: int
@@ -282,7 +374,10 @@ class TaskCostCeiling:
             "task_id": self.task_id,
             "most_model_calls": self.model_calls,
             "most_full_length_answers": self.answer_lengths,
-            "most_input_tokens_per_call": self.input_tokens_per_call,
+            "most_input_tokens_in_the_first_turn": self.input_tokens_per_call,
+            "most_input_tokens_across_one_attempt": (
+                self.input_tokens_per_attempt
+            ),
             "most_output_tokens_per_answer": self.output_tokens_per_call,
             "most_input_tokens_in_total": self.total_input_tokens,
             "most_output_tokens_in_total": self.total_output_tokens,
@@ -395,6 +490,15 @@ def estimate_cost_ceiling(
         capped = bool(
             assumptions.output_tokens_capped_per_attempt.get(environment, False)
         )
+        tool_result_tokens = assumptions.max_tool_result_tokens_per_turn.get(
+            environment
+        )
+        if tool_result_tokens is None:
+            raise ValueError(
+                f"{environment} has no written limit on how much one tool "
+                "result may add to the conversation, so the input a looping "
+                "attempt re-reads cannot be counted"
+            )
         counts = max_attempt_counts(
             conditions,
             tool_loop_max_model_turns=turns,
@@ -416,7 +520,20 @@ def estimate_cost_ceiling(
                 )
             input_tokens = max_input_tokens_per_call(task, assumptions)
             output_tokens = max(conditions.max_output_tokens, 0)
-            total_input = input_tokens * counts.model_calls
+            attempt_input = max_input_tokens_per_attempt(
+                base_input_tokens=input_tokens,
+                tool_loop_max_model_turns=turns,
+                max_output_tokens=output_tokens,
+                output_tokens_capped_per_attempt=capped,
+                max_tool_result_tokens_per_turn=tool_result_tokens,
+            )
+            # Attempts that run the whole loop are charged the growing
+            # conversation. The calls that ask the model once and carry nothing
+            # forward are charged the base input on its own.
+            total_input = (
+                attempt_input * counts.looping_attempts
+                + input_tokens * counts.single_turn_calls
+            )
             total_output = output_tokens * counts.answer_lengths
             cost = (
                 price.cost_of(
@@ -431,6 +548,7 @@ def estimate_cost_ceiling(
                     model_calls=counts.model_calls,
                     answer_lengths=counts.answer_lengths,
                     input_tokens_per_call=input_tokens,
+                    input_tokens_per_attempt=attempt_input,
                     output_tokens_per_call=output_tokens,
                     total_input_tokens=total_input,
                     total_output_tokens=total_output,

--- a/batch-runner/experiments/execution_envelope/advance_check_plan.yaml
+++ b/batch-runner/experiments/execution_envelope/advance_check_plan.yaml
@@ -290,14 +290,36 @@ cost:
   # tasks in three run places, with separate grading, under the retry limits
   # fixed above. It is a total ceiling, not a per-place allowance.
   #
-  # It equals the worked-out ceiling to the cent. That is deliberate: it means
-  # the free check passes only while the plan is exactly as costed, and any
-  # change that makes the run more expensive — a longer answer cap, another
-  # retry, a fourth run place — pushes the ceiling above this line and stops
-  # the run instead of quietly spending more.
-  #
   # The thirty-task and two-hundred-and-twenty-task stages are NOT covered by
   # this amount and are not approved.
+  #
+  # IMPORTANT — this amount no longer covers the worked-out ceiling, and the
+  # free check refuses the run because of it. That is the safety mechanism
+  # working, not a fault.
+  #
+  # When the amount was approved, the ceiling came to exactly 32.23. That
+  # figure was too low, because of a counting mistake in how a looping request
+  # was charged. The Azure code interpreter asks the model again after each
+  # piece of code it runs, and every one of those later turns re-reads the
+  # whole conversation so far. The old count charged the first turn's input
+  # eight times over instead, which leaves out everything the model wrote and
+  # every result it was shown in between. Counting the conversation as it grows
+  # raises the Azure place from 4.83 to 14.06 and the whole run from 32.23 to
+  # 43.77.
+  #
+  # Nothing was spent under the wrong figure: the Azure run place has never
+  # been reachable from the machine this was attempted from. But had it been,
+  # the run could have been allowed to start and then billed more than was
+  # approved, with every check reporting it as within budget.
+  #
+  # Three ways out, and the choice belongs to the owner:
+  #   1. approve 43.77 instead;
+  #   2. lower azure_code_interpreter in tool_loop_max_model_turns, which is a
+  #      chosen limit rather than a published one — the free check prints the
+  #      resulting figure;
+  #   3. leave it, and the run stays refused.
+  # The answer-length cap is not one of the ways out: the note at
+  # max_output_tokens records that a lower value truncated this model's code.
   approved_maximum_usd: 32.23
 
   assumptions:
@@ -335,6 +357,28 @@ cost:
       host_python_process: false
       docker_container: false
       azure_code_interpreter: true
+
+    # The most one tool result may add to the conversation, in tokens.
+    #
+    # This only has an effect where the model is asked more than once inside
+    # one attempt. Every later turn re-reads the results of the earlier ones,
+    # so a result written on turn one is paid for again on turns two, three and
+    # onwards. That is why a loop's input rises faster than its number of
+    # turns.
+    #
+    #   A separate Python process on the server, and a Docker container: the
+    #   model is asked once and nothing is carried forward, so 0.
+    #
+    #   Azure code interpreter: the service feeds the output of the code it ran
+    #   back to the model. Microsoft's documentation does not publish a limit on
+    #   how large that may be, so a limit is chosen here rather than left open,
+    #   the same way the turn limit above is. 5000 tokens is roughly fifteen
+    #   thousand characters, which is a great deal of program output for one
+    #   step and well above what the tasks in this comparison produce.
+    max_tool_result_tokens_per_turn:
+      host_python_process: 0
+      docker_container: 0
+      azure_code_interpreter: 5000
 
     # Applied to the whole ceiling at the end, to leave room for counting that
     # turns out to be optimistic.

--- a/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
+++ b/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
@@ -1,0 +1,194 @@
+# Agentic Sandbox V2, stage one: the settings and what they could cost
+# ====================================================================
+#
+# Stage one is the first step in
+# tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md: let the model
+# choose its own next action from the safe tools, with the command-running tool
+# exec_run still shut. It answers one question — does asking the model again
+# after each tool result help at all? — and nothing else.
+#
+# NOTHING HERE IS APPROVED AND NOTHING HERE RUNS.
+#
+# The amount that may be spent is deliberately left empty below. The free check
+# at batch-runner/scripts/check_agentic_stage_one_ceiling.py reads this file,
+# works out what each candidate setting could cost, and refuses to let anything
+# start while that amount is empty. Filling it in is a decision for the owner
+# of the repository, and this file exists to put the numbers in front of that
+# decision rather than to make it.
+#
+# Beyond the money, two things still block stage one even if the money is
+# approved, and neither is removed here:
+#
+#   - the model conversation itself does not exist. core/agentic_v2_runner.py
+#     replays a list of calls written down in advance and holds no model client
+#     at all.
+#   - two separate guards refuse the mode: the check in
+#     step2_run_inference._require_runnable_execution_mode, and the refusal in
+#     core/executor.py to build a runner unless the caller states the run makes
+#     no paid model calls. Both stay exactly as they are.
+#
+# Read this file with:
+#     cd batch-runner
+#     python scripts/check_agentic_stage_one_ceiling.py
+#
+# Written: 2026-08-26.
+
+plan_version: "agentic-stage-one-v1"
+
+# ── The model, which must be the same one the comparison uses ─────────────
+#
+# Stage one is not itself a scored comparison against the other run places, but
+# its result is only worth anything if it can later be set beside them. That
+# needs the same deployment, in the same Azure account, so the same rules apply
+# here as in advance_check_plan.yaml.
+model:
+  deployment: "gpt-5.4"
+  resolved_model: "gpt-5.4"
+
+azure_connection:
+  account: "hjeon-fdpo-foundry-eus2"
+  project: "gdpval-realworks"
+  route_profile: "project-ci"
+
+# ── The tasks ─────────────────────────────────────────────────────────────
+#
+# The same five tasks the three-place comparison fixed, chosen by the rule in
+# core/execution_envelope_tasks.py from a catalogue that holds no score. Using
+# the same five means a stage-one result can be set beside the other three run
+# places on the same work, rather than on work chosen afterwards.
+task_ids:
+  - "02aa1805-c658-4069-8a6a-02dec146063a"
+  - "0112fc9b-c3b2-4084-8993-5a4abb1f54f1"
+  - "2ea2e5b5-257f-42e6-a7dc-93763f28b19d"
+  - "3baa0009-5a60-4ae8-ae99-4955cb328ff3"
+  - "0818571f-5ff7-4d39-9d2c-ced5ae44299e"
+
+# ── The settings whose price is being asked about ─────────────────────────
+#
+# Two settings decide almost all of the cost, and they are the two the owner
+# has to choose between. They are listed here as candidates rather than fixed,
+# because the point of this file is to price the choice.
+#
+#   tool_calls_per_attempt — how many times the model may be asked again inside
+#     one attempt. The dispatcher in core/agentic_v2_tools.py refuses anything
+#     past its own ceiling, and the free check reads that ceiling from the code
+#     rather than from a number written here, so a candidate above it is left
+#     out instead of being priced.
+#
+#     This is the setting that matters most, and not in the way people expect.
+#     Every turn re-reads the whole conversation before it, so what was written
+#     early is charged again on every later turn. Doubling this number roughly
+#     quadruples what the earlier turns cost to re-read.
+#
+#   max_output_tokens_per_turn — the most the model may write in one turn.
+#
+#     The three-place comparison uses 32768, and there that is nearly free
+#     because one answer is written per task. Here an answer may be written on
+#     every turn, so the same number is multiplied by the number of turns. A
+#     turn that only picks a tool needs very little room, so the smaller
+#     candidates are not a compromise; they match what a turn actually does.
+candidate_settings:
+  tool_calls_per_attempt: [4, 6, 8, 12, 16, 32]
+  max_output_tokens_per_turn: [2048, 4096, 8192, 32768]
+
+# The settings that are fixed whatever is chosen above.
+fixed_settings:
+  # One retry, and only after a network failure, a server error, or a timeout.
+  # The model's own judgement never triggers one.
+  retry_max_attempts: 1
+  retry_reasons_allowed:
+    - "infrastructure_error"
+
+  # Off. Stage one asks whether choosing tools helps. Letting the model take a
+  # second look at its finished answer is a different question, and running
+  # both at once would make it impossible to say which one produced the
+  # difference.
+  self_review_enabled: false
+  self_review_max_attempts: 0
+
+  per_task_timeout_seconds: 1200
+
+  # Never allowed. If a call fails, the run stops rather than quietly asking a
+  # different model or a different deployment.
+  automatic_model_switch_allowed: false
+
+  # exec_run stays shut. Stage one proves the loop works — the model reads a
+  # result and picks a next action — without the capability that carries the
+  # risk. Opening it is stage three and needs its own separate approval.
+  exec_run_open: false
+
+# ── The command-running tool stays shut ───────────────────────────────────
+#
+# Listed separately so it cannot be lost among the settings above. All three
+# blocks described in the specification stay exactly as they are through stage
+# one, and the free check confirms each of them by running it, not by reading
+# text:
+#
+#   1. step2_run_inference._require_runnable_execution_mode refuses the mode.
+#   2. core/executor.py refuses to build a runner for a paid run.
+#   3. exec_run answers that the capability is unavailable for any ordinary
+#      command.
+#
+# If any of the three has opened, the free check refuses regardless of money.
+safety_blocks_must_stay_closed: true
+
+# ── What may be spent ─────────────────────────────────────────────────────
+cost:
+  # Empty on purpose. Nothing has been approved for stage one.
+  #
+  # The 32.23 United States dollars approved on 2026-08-25 was for the
+  # three-place comparison of five tasks and nothing else. It does not extend
+  # here, and stage one must not be started under it.
+  #
+  # To approve stage one, choose one row from the table the free check prints,
+  # write the two settings into chosen_settings below, and write the amount
+  # from that row here.
+  approved_maximum_usd: null
+
+  # Empty until a row is chosen. The free check refuses while either is empty,
+  # and refuses if the pair is not one of the candidates above.
+  chosen_settings:
+    tool_calls_per_attempt: null
+    max_output_tokens_per_turn: null
+
+  # The written guesses the figures rest on. These are the same ones the
+  # three-place comparison uses, taken from
+  # experiments/execution_envelope/advance_check_plan.yaml so the two cannot
+  # drift apart. The free check reads them from that file rather than from a
+  # second copy here.
+  #
+  # One of those guesses is borrowed rather than measured: the length of the
+  # standing instructions. Stage one will have its own wording, which does not
+  # exist yet, so the three-place comparison's 1068 characters stands in for it.
+  # That wording is sent on every turn, so if stage one's instructions turn out
+  # much longer, this must be measured again before the figures are trusted.
+  assumptions_come_from: "experiments/execution_envelope/advance_check_plan.yaml"
+
+  # One thing is NOT taken from that file: how much a single tool result may
+  # add to the conversation. That number is read from the dispatcher's own code
+  # in core/agentic_v2_tools.py, because the dispatcher is what will actually
+  # enforce it when something runs. A number written down here could disagree
+  # with the code; a number read from the code cannot.
+  tool_result_size_comes_from: "core/agentic_v2_tools.py AgenticV2ToolDispatcher"
+
+# ── What happens after stage one ──────────────────────────────────────────
+#
+# Written down now so that a disappointing result cannot lead to the rules
+# being loosened afterwards.
+after_stage_one:
+  success_criteria: >-
+    All five tasks finish without an error, and a test shows the model was
+    asked again with a tool result in front of it and changed what it did
+    because of it. Whether the answers scored well is a separate question and
+    is not part of finishing stage one.
+  stop_conditions: >-
+    Stop at once if the model name or deployment name reported back differs
+    from the one fixed above; if a run switches model or deployment on its own;
+    if any of the three safety blocks shows signs of having been opened; if a
+    paid call is about to happen without an approved amount on record; or if
+    real spending passes the amount approved above.
+  next_stage: >-
+    Stage two writes down what a command may touch and proves each limit with a
+    test that tries to exceed it. It is test-only and switches nothing on.
+    Opening exec_run is stage three and needs its own separate written
+    approval, presented with those test results.

--- a/batch-runner/scripts/check_agentic_stage_one_ceiling.py
+++ b/batch-runner/scripts/check_agentic_stage_one_ceiling.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""The free check that must pass before Agentic Sandbox V2 stage one spends anything.
+
+Nothing here calls a model, signs in to a cloud account, runs a command, or
+spends money. It reads this repository's own code and the stage-one plan file,
+works out what each candidate setting could cost at most, and prints every
+reason stage one may not start yet.
+
+Usage:
+
+    cd batch-runner
+    python scripts/check_agentic_stage_one_ceiling.py
+    python scripts/check_agentic_stage_one_ceiling.py --json
+    python scripts/check_agentic_stage_one_ceiling.py --plan other.yaml
+
+The exit code is 0 only when nothing is left to fix, which today it never is:
+the model conversation stage one is about has not been built, and no amount has
+been approved for it. Anything else exits 1, so this is safe to wire into an
+automated check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_stage_one_budget import (  # noqa: E402
+    STAGE_ONE_PLAN_PATH,
+    describe_stage_one_preflight,
+    load_stage_one_plan,
+    run_stage_one_preflight,
+)
+from core.execution_envelope_cost import CostAssumptions  # noqa: E402
+from core.execution_envelope_preflight import load_plan  # noqa: E402
+from core.execution_envelope_tasks import load_task_catalog  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check for free what Agentic Sandbox V2 stage one could cost, and "
+            "whether it may start."
+        )
+    )
+    parser.add_argument("--plan", type=Path, default=STAGE_ONE_PLAN_PATH)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Print the report as JSON instead of readable text.",
+    )
+    args = parser.parse_args()
+
+    plan = load_stage_one_plan(args.plan)
+
+    # The written guesses come from the three-place comparison's plan rather
+    # than a second copy here, so the two cannot drift apart. Only the
+    # tool-result size is different, and that is read from the dispatcher's own
+    # code.
+    shared_plan_path = BATCH_RUNNER_ROOT / str(
+        plan.get("cost", {}).get("assumptions_come_from")
+        or "experiments/execution_envelope/advance_check_plan.yaml"
+    )
+    shared_plan = load_plan(shared_plan_path)
+    assumptions = CostAssumptions.from_mapping(
+        shared_plan["cost"]["assumptions"]
+    )
+
+    result = run_stage_one_preflight(
+        plan,
+        tasks_by_id=load_task_catalog().by_task_id(),
+        assumptions=assumptions,
+    )
+
+    if args.as_json:
+        print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+    else:
+        print(
+            "Agentic Sandbox V2, stage one — free readiness and cost check\n"
+            "(no model was called, no command was run, nothing was spent)"
+        )
+        print("=" * 74)
+        print(
+            "Stage one is the step where the model chooses its own next action "
+            "from\nthe safe tools, with the command-running tool exec_run "
+            "still shut.\n"
+        )
+        for line in describe_stage_one_preflight(result):
+            print(line)
+
+    return 0 if result.may_start else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/tests/test_agentic_stage_one_budget.py
+++ b/batch-runner/tests/test_agentic_stage_one_budget.py
@@ -1,0 +1,920 @@
+"""Tests for the stage-one cost ceiling and the limit that enforces it.
+
+Two separate things are being held in place here.
+
+The first is a correction. The shared cost arithmetic used to charge one turn's
+input once per model call, which is right when each attempt is a fresh request
+and wrong when the model is asked again after each tool result. These tests
+require the corrected count to leave the single-turn run places untouched, and
+to charge a loop more than the old count did.
+
+The second is the stage-one work itself: what a run where the model chooses its
+own next action could cost, where the limits it is priced against come from,
+and the refusals that keep it from starting.
+"""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import subprocess
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+import yaml
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = BATCH_RUNNER_ROOT.parent
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_stage_one_budget import (  # noqa: E402
+    STAGE_ONE_PLAN_PATH,
+    DispatcherLimits,
+    StageOneBudget,
+    StageOneBudgetExceeded,
+    StageOneConditions,
+    budget_for_one_task,
+    check_the_model_conversation_does_not_exist_yet,
+    load_stage_one_plan,
+    price_the_options,
+    read_dispatcher_limits,
+    run_stage_one_preflight,
+    stage_one_ceiling,
+    tool_result_tokens_ceiling,
+)
+from core.agentic_v2_tools import AgenticV2ToolDispatcher  # noqa: E402
+from core.execution_envelope_cost import (  # noqa: E402
+    CostAssumptions,
+    ModelPrice,
+    estimate_cost_ceiling,
+    max_attempt_counts,
+    max_input_tokens_per_attempt,
+)
+from core.execution_envelope_preflight import load_plan  # noqa: E402
+from core.execution_envelope_tasks import load_task_catalog  # noqa: E402
+from core.execution_environment_readiness import ModelRunConditions  # noqa: E402
+
+SHARED_PLAN_PATH = (
+    BATCH_RUNNER_ROOT
+    / "experiments"
+    / "execution_envelope"
+    / "advance_check_plan.yaml"
+)
+STAGE_ONE_SCRIPT = (
+    BATCH_RUNNER_ROOT / "scripts" / "check_agentic_stage_one_ceiling.py"
+)
+
+ONLY_TASK = "02aa1805-c658-4069-8a6a-02dec146063a"
+
+
+@pytest.fixture(scope="module")
+def catalog():
+    return load_task_catalog()
+
+
+@pytest.fixture(scope="module")
+def shared_plan():
+    return load_plan(SHARED_PLAN_PATH)
+
+
+@pytest.fixture(scope="module")
+def assumptions(shared_plan):
+    return CostAssumptions.from_mapping(shared_plan["cost"]["assumptions"])
+
+
+@pytest.fixture
+def stage_one_plan():
+    return load_stage_one_plan(STAGE_ONE_PLAN_PATH)
+
+
+def _assumptions(**overrides) -> CostAssumptions:
+    base = {
+        "characters_per_token": 3,
+        "instruction_character_count": 0,
+        "tool_loop_max_model_turns": {"a_place": 1},
+        "output_tokens_capped_per_attempt": {"a_place": False},
+        "max_tool_result_tokens_per_turn": {"a_place": 0},
+        "safety_multiplier": 1,
+        "grading_required": False,
+        "grading_model": "gpt-5.4",
+        "grading_calls_per_rubric_item": 1,
+        "grading_input_tokens_per_call": 1,
+        "grading_output_tokens_per_call": 1,
+    }
+    base.update(overrides)
+    return CostAssumptions.from_mapping(base)
+
+
+def _conditions(**overrides) -> ModelRunConditions:
+    base = {
+        "provider": "azure",
+        "deployment": "gpt-5.4",
+        "resolved_model": "gpt-5.4",
+        "api_version": "2025-04-01-preview",
+        "system_instruction": "a",
+        "task_instruction": "b",
+        "task_ids": [ONLY_TASK],
+        "input_file_versions": {},
+        "max_output_tokens": 1000,
+        "per_task_timeout_seconds": 60,
+        "self_review_enabled": False,
+        "self_review_max_attempts": 0,
+        "retry_reasons_allowed": ["infrastructure_error"],
+        "retry_max_attempts": 0,
+        "automatic_model_switch_allowed": False,
+    }
+    base.update(overrides)
+    return ModelRunConditions.from_mapping(base)
+
+
+# ── The correction: a conversation that grows is charged as one ────────────
+
+
+def test_one_turn_per_attempt_still_sends_only_the_base_input():
+    """The correction must not move the two single-turn run places at all.
+
+    They send the same thing every time they are asked, so every term the
+    correction adds has to come out as nothing. If this ever fails, a change
+    meant for loops has leaked into places that do not loop.
+    """
+    for capped in (True, False):
+        for tool_result_tokens in (0, 21846):
+            assert (
+                max_input_tokens_per_attempt(
+                    base_input_tokens=17_000,
+                    tool_loop_max_model_turns=1,
+                    max_output_tokens=32_768,
+                    output_tokens_capped_per_attempt=capped,
+                    max_tool_result_tokens_per_turn=tool_result_tokens,
+                )
+                == 17_000
+            )
+
+
+def test_a_loop_is_charged_more_than_one_turn_times_the_number_of_turns():
+    """The old count multiplied a constant. The new one must exceed it.
+
+    This is the whole correction in one line: eight turns of a conversation
+    cost more than eight copies of its first turn, because the later turns
+    re-read what the earlier ones produced.
+    """
+    base = 17_000
+    turns = 8
+    old_count = base * turns
+
+    new_count = max_input_tokens_per_attempt(
+        base_input_tokens=base,
+        tool_loop_max_model_turns=turns,
+        max_output_tokens=32_768,
+        output_tokens_capped_per_attempt=True,
+        max_tool_result_tokens_per_turn=5_000,
+    )
+
+    assert new_count > old_count
+    # Seven later turns re-read the whole answer, and the tool results build up
+    # over twenty-eight turn pairs.
+    assert new_count == old_count + 7 * 32_768 + 28 * 5_000
+
+
+def test_doubling_the_turns_more_than_doubles_what_tool_results_cost():
+    """Tool results build up, so their cost grows faster than the turn count.
+
+    This is the property that makes a long loop expensive in a way people do
+    not expect, and the reason the stage-one table exists.
+    """
+
+    def tool_result_part(turns: int) -> int:
+        with_results = max_input_tokens_per_attempt(
+            base_input_tokens=1_000,
+            tool_loop_max_model_turns=turns,
+            max_output_tokens=0,
+            output_tokens_capped_per_attempt=True,
+            max_tool_result_tokens_per_turn=5_000,
+        )
+        without = max_input_tokens_per_attempt(
+            base_input_tokens=1_000,
+            tool_loop_max_model_turns=turns,
+            max_output_tokens=0,
+            output_tokens_capped_per_attempt=True,
+            max_tool_result_tokens_per_turn=0,
+        )
+        return with_results - without
+
+    assert tool_result_part(16) > 2 * tool_result_part(8)
+    assert tool_result_part(16) == pytest.approx(
+        4 * tool_result_part(8), rel=0.2
+    )
+
+
+def test_a_fresh_cap_each_turn_costs_more_than_one_cap_for_the_attempt():
+    """Where each turn may write a full answer, each turn's answer is re-read."""
+    per_attempt = max_input_tokens_per_attempt(
+        base_input_tokens=1_000,
+        tool_loop_max_model_turns=8,
+        max_output_tokens=4_096,
+        output_tokens_capped_per_attempt=True,
+        max_tool_result_tokens_per_turn=0,
+    )
+    per_turn = max_input_tokens_per_attempt(
+        base_input_tokens=1_000,
+        tool_loop_max_model_turns=8,
+        max_output_tokens=4_096,
+        output_tokens_capped_per_attempt=False,
+        max_tool_result_tokens_per_turn=0,
+    )
+    assert per_turn > per_attempt
+
+
+def test_a_turn_count_below_one_is_refused():
+    with pytest.raises(ValueError, match="at least once"):
+        max_input_tokens_per_attempt(
+            base_input_tokens=1,
+            tool_loop_max_model_turns=0,
+            max_output_tokens=1,
+            output_tokens_capped_per_attempt=True,
+            max_tool_result_tokens_per_turn=0,
+        )
+
+
+def test_a_negative_tool_result_size_is_refused():
+    with pytest.raises(ValueError, match="shorter than nothing"):
+        max_input_tokens_per_attempt(
+            base_input_tokens=1,
+            tool_loop_max_model_turns=2,
+            max_output_tokens=1,
+            output_tokens_capped_per_attempt=True,
+            max_tool_result_tokens_per_turn=-1,
+        )
+    with pytest.raises(ValueError, match="shorter than nothing"):
+        _assumptions(max_tool_result_tokens_per_turn={"a_place": -1})
+
+
+def test_a_run_place_with_no_written_tool_result_size_is_refused(catalog):
+    """An unstated guess is how a ceiling ends up wrong in the costly direction.
+
+    Leaving the number out must stop the count rather than quietly standing in
+    a zero, which would price a loop as though nothing were carried forward.
+    """
+    assumptions = _assumptions(
+        tool_loop_max_model_turns={"a_place": 4},
+        output_tokens_capped_per_attempt={"a_place": True},
+        max_tool_result_tokens_per_turn={"a_different_place": 0},
+    )
+    with pytest.raises(ValueError, match="how much one tool result may add"):
+        estimate_cost_ceiling(
+            conditions_by_environment={"a_place": _conditions()},
+            tasks_by_id=catalog.by_task_id(),
+            assumptions=assumptions,
+        )
+
+
+def test_the_attempt_count_separates_looping_attempts_from_single_calls():
+    """The input side needs to know which calls carry a conversation forward.
+
+    A self-review's first call looks at a finished answer and starts nothing,
+    so it must not be charged as though it were a whole loop.
+    """
+    counts = max_attempt_counts(
+        _conditions(
+            retry_max_attempts=3,
+            self_review_enabled=True,
+            self_review_max_attempts=2,
+        ),
+        tool_loop_max_model_turns=8,
+        output_tokens_capped_per_attempt=True,
+    )
+    assert counts.looping_attempts == 4 + 2
+    assert counts.single_turn_calls == 2
+    assert counts.model_calls == 4 * 8 + 2 * (1 + 8)
+
+
+def test_the_single_turn_places_in_the_committed_plan_are_unchanged(
+    shared_plan, assumptions, catalog
+):
+    """The two places that ask once must cost exactly what they always did.
+
+    Guarded against the committed plan rather than a made-up one, because the
+    committed plan is what would actually be billed.
+    """
+    shared = shared_plan["model_run_conditions"]["shared"]
+    conditions = ModelRunConditions.from_mapping(shared)
+    ceiling = estimate_cost_ceiling(
+        conditions_by_environment={"host_python_process": conditions},
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=assumptions,
+    )
+    entry = ceiling.environments[0]
+    for task in entry.tasks:
+        # One turn per attempt, so what one attempt sends is what one call
+        # sends, and the total is simply that once per call.
+        assert task.input_tokens_per_attempt == task.input_tokens_per_call
+        assert task.total_input_tokens == (
+            task.input_tokens_per_call * task.model_calls
+        )
+
+
+def test_the_committed_plan_no_longer_fits_inside_the_approved_amount(
+    shared_plan, assumptions, catalog
+):
+    """The approved amount was worked out with the mistake in place.
+
+    32.23 United States dollars was approved on 2026-08-25, when the Azure run
+    place was priced by charging its first turn's input eight times. Counting
+    the conversation as it grows raises the whole run above that line, so the
+    free check must now refuse.
+
+    Nothing was spent under the wrong figure — the Azure run place has never
+    been reachable — but the run could have been allowed to start and then
+    billed more than was approved.
+
+    This test exists so that the correction cannot be undone quietly. If the
+    ceiling ever drops back below the approved amount, either the arithmetic
+    was reverted or the plan was changed, and both deserve to be noticed.
+    """
+    from core.execution_envelope_cost import check_cost_ceiling
+
+    conditions = ModelRunConditions.from_mapping(
+        shared_plan["model_run_conditions"]["shared"]
+    )
+    ceiling = estimate_cost_ceiling(
+        conditions_by_environment={
+            place: conditions
+            for place in (
+                "host_python_process",
+                "docker_container",
+                "azure_code_interpreter",
+            )
+        },
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=assumptions,
+    )
+
+    approved = Decimal(str(shared_plan["cost"]["approved_maximum_usd"]))
+    assert approved == Decimal("32.23")
+    assert ceiling.total_usd > approved
+
+    problems = check_cost_ceiling(ceiling, approved_maximum_usd=approved)
+    assert any("is above the" in note for note in problems)
+
+
+def test_the_plan_says_the_approved_amount_no_longer_covers_the_ceiling():
+    """A reader of the plan must be told, not left to work it out."""
+    text = SHARED_PLAN_PATH.read_text(encoding="utf-8")
+    assert "no longer covers the worked-out ceiling" in text
+
+
+# ── Where the stage-one limits come from ───────────────────────────────────
+
+
+def test_the_dispatcher_limits_are_read_from_the_dispatcher():
+    """Read from the code, not restated, so the two cannot disagree."""
+    limits = read_dispatcher_limits()
+    defaults = {
+        entry.name: entry.default
+        for entry in dataclasses.fields(AgenticV2ToolDispatcher)
+    }
+    assert limits.max_total_calls == defaults["max_total_calls"]
+    assert limits.max_result_bytes == defaults["max_result_bytes"]
+
+
+def test_a_tool_result_is_priced_at_the_size_the_dispatcher_allows():
+    limits = DispatcherLimits(max_total_calls=32, max_result_bytes=65_536)
+    assert (
+        tool_result_tokens_ceiling(limits, characters_per_token=Decimal(3))
+        == 21_846
+    )
+
+
+def test_a_lower_dispatcher_ceiling_lowers_the_bill(catalog, assumptions):
+    """Tightening the dispatcher must show up in the price without an edit here."""
+
+    def cost_with(max_result_bytes: int) -> Decimal:
+        return stage_one_ceiling(
+            conditions=_stage_one_conditions(),
+            tasks_by_id=catalog.by_task_id(),
+            assumptions=assumptions,
+            limits=DispatcherLimits(
+                max_total_calls=32, max_result_bytes=max_result_bytes
+            ),
+        ).total_usd
+
+    assert cost_with(8_192) < cost_with(65_536)
+
+
+def _stage_one_conditions(**overrides) -> StageOneConditions:
+    base = {
+        "deployment": "gpt-5.4",
+        "resolved_model": "gpt-5.4",
+        "task_ids": (ONLY_TASK,),
+        "tool_calls_per_attempt": 8,
+        "max_output_tokens_per_turn": 4_096,
+        "retry_max_attempts": 1,
+        "per_task_timeout_seconds": 1_200,
+    }
+    base.update(overrides)
+    return StageOneConditions(**base)
+
+
+def test_more_tool_calls_than_the_dispatcher_allows_is_refused():
+    limits = DispatcherLimits(max_total_calls=32, max_result_bytes=65_536)
+    with pytest.raises(ValueError, match="could never happen"):
+        _stage_one_conditions(tool_calls_per_attempt=33).validated(limits)
+
+
+def test_a_turn_that_may_write_nothing_is_refused():
+    limits = DispatcherLimits(max_total_calls=32, max_result_bytes=65_536)
+    with pytest.raises(ValueError, match="cannot produce an answer"):
+        _stage_one_conditions(max_output_tokens_per_turn=0).validated(limits)
+
+
+def test_stage_one_never_switches_self_review_on():
+    """Stage one asks one question, so nothing else may be running beside it."""
+    conditions = _stage_one_conditions().as_run_conditions()
+    assert conditions.self_review_enabled is False
+    assert conditions.self_review_max_attempts == 0
+    assert conditions.automatic_model_switch_allowed is False
+
+
+def test_candidates_the_dispatcher_would_refuse_are_left_out(
+    catalog, assumptions
+):
+    """A reader must never be offered a setting that could not be taken."""
+    options = price_the_options(
+        base=_stage_one_conditions(),
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=assumptions,
+        tool_call_choices=(4, 64),
+        output_token_choices=(2_048,),
+        limits=DispatcherLimits(max_total_calls=32, max_result_bytes=65_536),
+    )
+    assert [entry.tool_calls_per_attempt for entry in options] == [4]
+
+
+def test_more_turns_cost_more_and_marking_stays_the_same(catalog, assumptions):
+    """Only the running column may move when the settings change."""
+    options = price_the_options(
+        base=_stage_one_conditions(),
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=dataclasses.replace(assumptions, grading_required=True),
+        tool_call_choices=(4, 8),
+        output_token_choices=(2_048,),
+    )
+    cheap, dear = options
+    assert dear.most_running_could_cost_usd > cheap.most_running_could_cost_usd
+    assert (
+        dear.most_grading_could_cost_usd == cheap.most_grading_could_cost_usd
+    )
+
+
+def test_the_dispatcher_default_settings_are_far_dearer_than_a_small_run(
+    catalog, assumptions
+):
+    """The finding that makes the table worth printing.
+
+    Running stage one at the dispatcher's own default of thirty-two tool calls,
+    with the answer-length cap the three-place comparison uses, costs many
+    times what a short loop with a small cap costs. Somebody who did not look
+    would reasonably assume the defaults were a sensible starting point.
+    """
+    options = price_the_options(
+        base=_stage_one_conditions(),
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=assumptions,
+        tool_call_choices=(4, 32),
+        output_token_choices=(2_048, 32_768),
+    )
+    by_setting = {
+        (entry.tool_calls_per_attempt, entry.max_output_tokens_per_turn): entry
+        for entry in options
+    }
+    small = by_setting[(4, 2_048)].most_running_could_cost_usd
+    defaults = by_setting[(32, 32_768)].most_running_could_cost_usd
+    assert defaults > small * 20
+
+
+# ── The limit that is enforced while something runs ────────────────────────
+
+
+def test_a_budget_permits_a_call_while_it_has_room():
+    budget = StageOneBudget(
+        max_model_calls=2, max_input_tokens=100, max_output_tokens=100
+    )
+    assert budget.refusal_before_next_call() is None
+    budget.record(input_tokens=10, output_tokens=10)
+    assert budget.refusal_before_next_call() is None
+
+
+@pytest.mark.parametrize(
+    "limits,used,expected",
+    [
+        ({"max_model_calls": 1}, {}, "model calls"),
+        ({"max_input_tokens": 10}, {"input_tokens": 10}, "already sent"),
+        ({"max_output_tokens": 10}, {"output_tokens": 10}, "already been sent back"),
+    ],
+)
+def test_a_budget_refuses_the_next_call_at_each_ceiling(limits, used, expected):
+    """Refused before the call, because after it the money is gone."""
+    settings = {
+        "max_model_calls": 100,
+        "max_input_tokens": 1_000,
+        "max_output_tokens": 1_000,
+    }
+    settings.update(limits)
+    budget = StageOneBudget(**settings)
+    budget.record(
+        input_tokens=used.get("input_tokens", 0),
+        output_tokens=used.get("output_tokens", 0),
+    )
+
+    refusal = budget.refusal_before_next_call()
+
+    assert refusal is not None
+    assert expected in refusal
+
+
+def test_spending_more_than_allowed_raises_rather_than_reporting_quietly():
+    """A loop that has overspent has lost the thread; the safe move is to stop."""
+    budget = StageOneBudget(
+        max_model_calls=10, max_input_tokens=100, max_output_tokens=100
+    )
+    with pytest.raises(StageOneBudgetExceeded, match="tokens sent against"):
+        budget.record(input_tokens=101, output_tokens=0)
+
+
+def test_a_budget_refuses_settings_that_are_not_whole_numbers():
+    with pytest.raises(ValueError, match="whole number"):
+        StageOneBudget(
+            max_model_calls=True, max_input_tokens=1, max_output_tokens=1
+        )
+    budget = StageOneBudget(
+        max_model_calls=1, max_input_tokens=1, max_output_tokens=1
+    )
+    with pytest.raises(ValueError, match="whole number"):
+        budget.record(input_tokens=1.5, output_tokens=0)
+
+
+def test_the_running_limit_comes_from_the_worked_out_ceiling(
+    catalog, assumptions
+):
+    """The limit and the approved figure must not be able to drift apart."""
+    ceiling = stage_one_ceiling(
+        conditions=_stage_one_conditions(),
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=assumptions,
+    )
+    priced = ceiling.environments[0].tasks[0]
+
+    budget = budget_for_one_task(ceiling, ONLY_TASK)
+
+    assert budget.max_model_calls == priced.model_calls
+    assert budget.max_input_tokens == priced.total_input_tokens
+    assert budget.max_output_tokens == priced.total_output_tokens
+
+
+def test_a_task_the_ceiling_says_nothing_about_has_no_limit(
+    catalog, assumptions
+):
+    ceiling = stage_one_ceiling(
+        conditions=_stage_one_conditions(),
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=assumptions,
+    )
+    with pytest.raises(ValueError, match="no limit to hold it to"):
+        budget_for_one_task(ceiling, "a-task-that-was-never-priced")
+
+
+# ── The refusals that keep stage one from starting ─────────────────────────
+
+
+def _preflight(plan, catalog, assumptions):
+    return run_stage_one_preflight(
+        plan, tasks_by_id=catalog.by_task_id(), assumptions=assumptions
+    )
+
+
+def test_stage_one_is_refused_today_and_says_the_conversation_is_missing(
+    stage_one_plan, catalog, assumptions
+):
+    """The honest first answer is not about money.
+
+    Even with an amount approved, stage one could not start: the thing it is
+    about — the model being asked again with a tool result in front of it —
+    has not been built. Saying that plainly is more useful than letting the
+    money question stand in for it.
+    """
+    result = _preflight(stage_one_plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any(
+        "does not exist yet" in note for note in result.problems
+    )
+
+
+def test_the_missing_conversation_is_established_by_looking_at_the_code():
+    """Read from what the runner accepts, so the answer changes by itself."""
+    problems = check_the_model_conversation_does_not_exist_yet()
+    assert len(problems) == 1
+    assert "replays a list of calls written down in advance" in problems[0]
+
+
+def test_the_committed_stage_one_plan_approves_nothing(stage_one_plan):
+    """Nothing has been approved for stage one, and the file must say so."""
+    cost = stage_one_plan["cost"]
+    assert cost["approved_maximum_usd"] is None
+    assert cost["chosen_settings"]["tool_calls_per_attempt"] is None
+    assert cost["chosen_settings"]["max_output_tokens_per_turn"] is None
+
+
+def test_the_three_place_approval_does_not_extend_to_stage_one(
+    stage_one_plan, catalog, assumptions
+):
+    result = _preflight(stage_one_plan, catalog, assumptions)
+    assert any(
+        "does not\nextend here" in note.replace(" ", " ")
+        or "does not extend here" in note
+        for note in result.problems
+    )
+
+
+def test_choosing_a_row_reports_the_limit_each_task_would_be_stopped_by(
+    stage_one_plan, catalog, assumptions
+):
+    """An approver must see the limit, not only the amount.
+
+    The amount says what could be spent. The limit says what would actually
+    stop a run, and it is built from the same figures the amount came from, so
+    the two cannot drift apart.
+    """
+    plan = copy.deepcopy(stage_one_plan)
+    plan["cost"]["chosen_settings"] = {
+        "tool_calls_per_attempt": 4,
+        "max_output_tokens_per_turn": 2_048,
+    }
+    plan["cost"]["approved_maximum_usd"] = 1_000
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert set(result.chosen_budget) == set(plan["task_ids"])
+    for budget in result.chosen_budget.values():
+        # Four turns across a first attempt and one retry.
+        assert budget.max_model_calls == 4 * 2
+        assert budget.max_output_tokens == 2_048 * 4 * 2
+        assert budget.max_input_tokens > 0
+        assert budget.refusal_before_next_call() is None
+
+    # The money is settled and the settings are chosen, so the only thing left
+    # standing between here and a run is that the conversation does not exist.
+    assert result.may_start is False
+    assert [
+        note for note in result.problems if "does not exist yet" in note
+    ] == result.problems
+
+
+def test_nothing_is_chosen_so_no_limit_is_reported(
+    stage_one_plan, catalog, assumptions
+):
+    result = _preflight(stage_one_plan, catalog, assumptions)
+    assert result.chosen_budget == {}
+
+
+def test_the_reported_limit_stops_a_run_that_reaches_it(
+    stage_one_plan, catalog, assumptions
+):
+    """Follow the reported limit to the point where it refuses."""
+    plan = copy.deepcopy(stage_one_plan)
+    plan["cost"]["chosen_settings"] = {
+        "tool_calls_per_attempt": 4,
+        "max_output_tokens_per_turn": 2_048,
+    }
+    plan["cost"]["approved_maximum_usd"] = 1_000
+
+    result = _preflight(plan, catalog, assumptions)
+    budget = result.chosen_budget[plan["task_ids"][0]]
+
+    for _ in range(budget.max_model_calls):
+        assert budget.refusal_before_next_call() is None
+        budget.record(input_tokens=0, output_tokens=0)
+
+    assert budget.refusal_before_next_call() is not None
+
+
+def test_choosing_settings_nobody_priced_is_refused(
+    stage_one_plan, catalog, assumptions
+):
+    plan = copy.deepcopy(stage_one_plan)
+    plan["cost"]["chosen_settings"] = {
+        "tool_calls_per_attempt": 5,
+        "max_output_tokens_per_turn": 3_000,
+    }
+    plan["cost"]["approved_maximum_usd"] = 1_000
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any("not one of the candidates" in note for note in result.problems)
+
+
+def test_an_approved_amount_below_the_chosen_setting_is_refused(
+    stage_one_plan, catalog, assumptions
+):
+    plan = copy.deepcopy(stage_one_plan)
+    plan["cost"]["chosen_settings"] = {
+        "tool_calls_per_attempt": 32,
+        "max_output_tokens_per_turn": 32_768,
+    }
+    plan["cost"]["approved_maximum_usd"] = "1.00"
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any("is above the" in note for note in result.problems)
+    assert result.chosen is not None
+
+
+def test_letting_the_safety_blocks_open_is_refused(
+    stage_one_plan, catalog, assumptions
+):
+    plan = copy.deepcopy(stage_one_plan)
+    plan["safety_blocks_must_stay_closed"] = False
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any("stay closed" in note for note in result.problems)
+
+
+def test_opening_the_command_tool_in_stage_one_is_refused(
+    stage_one_plan, catalog, assumptions
+):
+    """Opening exec_run is stage three and needs its own written approval."""
+    plan = copy.deepcopy(stage_one_plan)
+    plan["fixed_settings"]["exec_run_open"] = True
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any("stage three" in note for note in result.problems)
+
+
+def test_switching_self_review_on_in_stage_one_is_refused(
+    stage_one_plan, catalog, assumptions
+):
+    plan = copy.deepcopy(stage_one_plan)
+    plan["fixed_settings"]["self_review_enabled"] = True
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any("impossible to attribute" in note for note in result.problems)
+
+
+def test_allowing_the_run_to_change_model_on_its_own_is_refused(
+    stage_one_plan, catalog, assumptions
+):
+    plan = copy.deepcopy(stage_one_plan)
+    plan["fixed_settings"]["automatic_model_switch_allowed"] = True
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any("no single model produced" in note for note in result.problems)
+
+
+def test_a_plan_that_names_no_task_is_refused(
+    stage_one_plan, catalog, assumptions
+):
+    plan = copy.deepcopy(stage_one_plan)
+    plan["task_ids"] = []
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any("names no task" in note for note in result.problems)
+
+
+def test_a_plan_offering_no_candidates_is_refused(
+    stage_one_plan, catalog, assumptions
+):
+    plan = copy.deepcopy(stage_one_plan)
+    plan["candidate_settings"]["tool_calls_per_attempt"] = []
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any("nothing to choose between" in note for note in result.problems)
+
+
+def test_every_candidate_being_impossible_is_refused(
+    stage_one_plan, catalog, assumptions
+):
+    plan = copy.deepcopy(stage_one_plan)
+    plan["candidate_settings"]["tool_calls_per_attempt"] = [1_000]
+
+    result = _preflight(plan, catalog, assumptions)
+
+    assert result.may_start is False
+    assert any(
+        "refused by the dispatcher's own ceiling" in note
+        for note in result.problems
+    )
+
+
+def test_a_plan_written_for_another_version_is_refused(tmp_path):
+    target = tmp_path / "plan.yaml"
+    target.write_text(
+        yaml.safe_dump({"plan_version": "something-else"}), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="was written for"):
+        load_stage_one_plan(target)
+
+
+def test_the_stage_one_plan_pins_the_same_azure_resource(stage_one_plan):
+    """A stage-one result is only worth having beside the other run places.
+
+    That needs the same deployment in the same account, so the same pinning
+    applies here as in the three-place plan.
+    """
+    shared = load_plan(SHARED_PLAN_PATH)
+    assert stage_one_plan["azure_connection"] == shared["azure_connection"]
+    assert (
+        stage_one_plan["model"]["deployment"]
+        == shared["model_run_conditions"]["shared"]["deployment"]
+    )
+
+
+def test_the_stage_one_plan_uses_the_same_five_tasks(stage_one_plan):
+    shared = load_plan(SHARED_PLAN_PATH)
+    assert (
+        stage_one_plan["task_ids"]
+        == shared["model_run_conditions"]["shared"]["task_ids"]
+    )
+
+
+# ── The tool a person actually runs ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "batch-runner/scripts/check_agentic_stage_one_ceiling.py",
+        "batch-runner/core/agentic_v2_stage_one_budget.py",
+        "batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml",
+    ],
+)
+def test_the_new_files_are_in_the_repository(relative):
+    """This directory hides new files unless they are allowed in by name.
+
+    Without this, everything here would pass on the machine it was written on
+    and be missing from a fresh clone.
+    """
+    path = REPOSITORY_ROOT / relative
+    assert path.is_file(), f"{relative} is missing"
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", relative],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.returncode == 0, (
+        f"{relative} exists here but git does not track it, so a fresh clone "
+        "would not have it. Add it to the allow list in .gitignore."
+    )
+
+
+def test_running_the_tool_refuses_and_prints_the_table():
+    """Run it exactly as a person would, and require a refusal with the numbers."""
+    finished = subprocess.run(
+        [sys.executable, str(STAGE_ONE_SCRIPT)],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+    assert finished.returncode == 1, finished.stdout + finished.stderr
+    assert "What each candidate setting could cost at most" in finished.stdout
+    assert "does not exist yet" in finished.stdout
+    # The dispatcher's real ceiling, read from code, must reach the report.
+    assert str(read_dispatcher_limits().max_total_calls) in finished.stdout
+
+
+def test_the_tool_can_report_itself_as_json():
+    finished = subprocess.run(
+        [sys.executable, str(STAGE_ONE_SCRIPT), "--json"],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+    assert finished.returncode == 1
+    import json
+
+    written = json.loads(finished.stdout)
+    assert written["may_start"] is False
+    assert written["approved_maximum_usd"] is None
+    assert written["chosen"] is None
+    assert len(written["options"]) > 0

--- a/batch-runner/tests/test_agentic_stage_one_budget.py
+++ b/batch-runner/tests/test_agentic_stage_one_budget.py
@@ -631,12 +631,9 @@ def test_the_committed_stage_one_plan_approves_nothing(stage_one_plan):
 def test_the_three_place_approval_does_not_extend_to_stage_one(
     stage_one_plan, catalog, assumptions
 ):
+    """The 32.23 approved on 2026-08-25 was for that comparison and no other."""
     result = _preflight(stage_one_plan, catalog, assumptions)
-    assert any(
-        "does not\nextend here" in note.replace(" ", " ")
-        or "does not extend here" in note
-        for note in result.problems
-    )
+    assert any("does not extend here" in note for note in result.problems)
 
 
 def test_choosing_a_row_reports_the_limit_each_task_would_be_stopped_by(

--- a/batch-runner/tests/test_execution_envelope_advance_check.py
+++ b/batch-runner/tests/test_execution_envelope_advance_check.py
@@ -391,6 +391,7 @@ def test_a_reference_file_is_counted_at_the_cap_the_reader_applies(catalog):
             "instruction_character_count": 0,
             "tool_loop_max_model_turns": {"host_python_process": 1},
             "output_tokens_capped_per_attempt": {"host_python_process": False},
+            "max_tool_result_tokens_per_turn": {"host_python_process": 0},
             "safety_multiplier": 1,
             "grading_required": False,
             "grading_model": "gpt-5.4",
@@ -416,6 +417,7 @@ def test_a_model_with_no_published_price_is_not_treated_as_free(catalog):
             "instruction_character_count": 0,
             "tool_loop_max_model_turns": {"host_python_process": 1},
             "output_tokens_capped_per_attempt": {"host_python_process": False},
+            "max_tool_result_tokens_per_turn": {"host_python_process": 0},
             "safety_multiplier": 1,
             "grading_required": False,
             "grading_model": "gpt-5.4",
@@ -854,9 +856,10 @@ def test_the_scripts_are_in_the_repository(script):
 def test_the_check_refuses_today_and_says_why():
     """Run the tool exactly as a person would, and require a refusal.
 
-    Today the money is approved but the Azure run place is not reachable from
-    an ordinary checkout, so the refusal must name the Azure settings rather
-    than the money.
+    Two separate things are wrong today and the report must name both. The
+    Azure run place is not reachable from an ordinary checkout, and the amount
+    approved on 2026-08-25 no longer covers the worked-out ceiling, because it
+    was agreed while a looping request was undercounted.
     """
     finished = subprocess.run(
         [sys.executable, str(CHECK_SCRIPT)],
@@ -883,6 +886,7 @@ def test_the_check_refuses_today_and_says_why():
     assert "no model was called" in finished.stdout
     assert "AZURE_AI_ROUTE_PROFILE is not set" in finished.stdout
     assert "FOUNDRY_PROJECT_ENDPOINT is not set" in finished.stdout
+    assert "is above the" in finished.stdout
 
 
 # ── The Azure run place must reach the deployment that was pinned ─────────

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
@@ -1,6 +1,9 @@
 # Agentic Sandbox V2: a safe path to running commands and letting the model decide
 
 - Written: 2026-08-25
+- Updated: 2026-08-26 — step one of section 8 is done. The cost of a stage-one
+  run has been worked out and is in section 7a. Nothing was spent doing it and
+  nothing was switched on.
 - Status: **specification only. Nothing here is built, and nothing in it may be
   built without a separate, explicit approval to open command execution.**
 - Related GitHub Project: hyeonsangjeon/projects/5 — card
@@ -139,6 +142,105 @@ back to the model; repeat until the model finishes or a ceiling is hit.
 - The existing free check must keep reporting this run place as
   "structure checks only" until stage three is genuinely approved and complete.
 
+## 7a. What stage one would cost, worked out on 2026-08-26
+
+This is step one of section 8, done. It cost nothing: no model was called, no
+command was run, and no account was signed in to.
+
+### Why a loop is not priced the way a single request is
+
+The three run places already in the comparison ask the model once per task.
+Their cost is close to fixed: the task is however long it is, the answer may be
+up to the length the settings permit, and that is the bill.
+
+A loop is different in three ways at once, and only the first is obvious.
+
+1. The model is asked once per tool call rather than once per task.
+2. Every one of those turns may write a full-length answer, so the writing is
+   charged per turn instead of per task.
+3. **Every turn re-reads the whole conversation before it.** What the model
+   wrote on turn one, and every tool result it was shown, is sent again on turn
+   two, and again on turn three, and so on.
+
+The third is the one that catches people out, because it means the bill does not
+rise in step with the number of turns. It rises roughly with the square of it.
+Doubling how many times the model may be asked roughly quadruples what the
+earlier turns cost to re-read.
+
+That property was worth finding for a second reason: the same mistake was
+already in the shared arithmetic, where it was undercounting the Azure code
+interpreter — which also loops. Correcting it raised the three-place
+comparison's ceiling from 32.23 to 43.77 United States dollars, above the amount
+that had been approved for it. That is recorded in
+`batch-runner/experiments/execution_envelope/advance_check_plan.yaml`.
+
+### The numbers
+
+Worked out by `batch-runner/core/agentic_v2_stage_one_budget.py` over the same
+five tasks the three-place comparison uses. Print the table with:
+
+```
+cd batch-runner
+python scripts/check_agentic_stage_one_ceiling.py
+```
+
+Two settings decide almost the whole bill. Running costs, in United States
+dollars, at most:
+
+| tool calls per attempt | most a turn may write | most it could cost to run |
+|---|---|---|
+| 4 | 2,048 | 3.24 |
+| 4 | 32,768 | 13.80 |
+| 8 | 2,048 | 12.45 |
+| 8 | 32,768 | 41.25 |
+| 16 | 2,048 | 48.79 |
+| 32 | 2,048 | 193.15 |
+| 32 | 32,768 | 492.67 |
+
+Marking the answers adds 5.85 whichever row is chosen, so a total is the running
+figure plus 5.85.
+
+### What the table says
+
+**The dispatcher's own defaults are the most expensive row on it.** The
+dispatcher allows 32 tool calls, and the three-place comparison lets an answer
+run to 32,768 tokens. Someone starting from both defaults, reasonably assuming
+they were sensible starting points, would be committing to at most 492.67
+dollars for five tasks — over fifty times the cheapest row that could still
+answer the question.
+
+**The answer-length cap is the cheaper of the two levers, and costs nothing to
+turn down.** In the three-place comparison a generous cap is nearly free,
+because one answer is written per task; the note there records that lowering it
+truncated the model's code. Here it is multiplied by the number of turns, and a
+turn that only picks a tool needs very little room. It is not a compromise to
+lower it; it matches what a turn actually does.
+
+**Marking dominates at the small end.** At four tool calls, marking is 5.85
+against 3.24 for running. Anyone trying to make stage one cheaper by shortening
+the loop further will find there is little left to save.
+
+### The figure is enforced, not just written down
+
+A worked-out ceiling that nothing enforces is a hope. `StageOneBudget` in the
+same module counts what a run has spent and refuses the next call once any of
+the three ceilings is reached, and it is built from the same worked-out figure
+rather than from a number typed in beside it, so the two cannot drift apart.
+Spending past a ceiling raises rather than being reported quietly, because a
+loop that has already overspent has lost track of what it is doing.
+
+### What is still missing before stage one could run
+
+The money is the smaller of the two blockers, and saying so plainly matters more
+than the numbers above.
+
+`core/agentic_v2_runner.py` still replays a list of calls written down in
+advance and holds no model client at all. The thing stage one is *about* — the
+model being asked again with a tool result in front of it — does not exist. The
+free check reports this first, before it reports anything about money, and it
+establishes it by looking at what the runner accepts rather than by reading a
+comment, so the answer will change by itself when the conversation is built.
+
 ## 8. Order the work would be done in
 
 1. Work out and get approval for the cost ceiling of a small stage-one run.
@@ -171,13 +273,26 @@ back to the model; repeat until the model finishes or a ceiling is hit.
 
 ## 11. Known blockers and the next decision
 
-- **Blocked on approval to call a model in a loop.** Stage one costs money and
-  its ceiling has not been worked out or approved.
+- **Blocked on the model conversation, which does not exist.** This is the
+  larger blocker and it is free to remove: `core/agentic_v2_runner.py` replays a
+  written-down list and holds no model client. Until that changes, no amount of
+  approved money lets stage one start.
+- **Blocked on approval to call a model in a loop.** The ceiling has now been
+  worked out (section 7a) and nothing has been approved against it.
+  `experiments/execution_envelope/agentic_stage_one_plan.yaml` leaves the amount
+  empty on purpose, and the free check refuses while it is empty. The 32.23
+  United States dollars approved on 2026-08-25 was for the three-place
+  comparison and does not extend here.
 - **Blocked on a decision about containment.** The substrate manifest requires a
   small isolated virtual machine. Whether that is available on the machines this
   would run on has not been established, and stage three cannot be designed
-  concretely until it is.
+  concretely until it is. This blocks stage three only, not stage one.
 
-The next decision is whether stage one is worth its cost, which cannot be
-answered until that cost is worked out. That is the first piece of work, and it
-is free.
+The next decision is now a specific one with a price beside it: **which row of
+the table in section 7a is stage one worth running at?** The cheapest row that
+could still answer the question is four tool calls with a 2,048-token cap per
+turn, at most 3.24 to run and 5.85 to mark, so 9.09 in total. The dispatcher's
+own defaults are 492.67 to run.
+
+Choosing a row does not start anything. The model conversation still has to be
+built first, and that is the next piece of work either way.

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -1,6 +1,8 @@
 # Codex's own agent: what is officially supported, and what is still unknown
 
 - Written: 2026-08-25
+- Updated: 2026-08-26 — the documentation was searched again and half of the
+  open question is now answered. See section 3a.
 - Status: **investigation recorded. The run place stays blocked, and one part of
   it stays explicitly unconfirmed.** No code was written, because writing code
   for a path that may not be able to meet the comparison's conditions would be
@@ -72,6 +74,59 @@ The list of run modes in `core/executor.py` has no entry for it, and no module
 starts a benchmark task this way. Mentions of Codex in the repository are in
 documents people read, not in code that runs.
 
+## 3a. Searched again on 2026-08-26: half the question is now answered
+
+The question in section 7 has two halves, and it turns out they have different
+answers. Separating them is the main result of the second search.
+
+**Half one — getting a token from a directory sign-in. Confirmed supported, in
+general.** The configuration reference documents a table
+`model_providers.<id>.auth`, described as command-backed bearer token
+configuration for a custom provider. Its `auth.command` setting runs a command
+which "must print the token to stdout", with `auth.args`, `auth.cwd`,
+`auth.timeout_ms`, and `auth.refresh_interval_ms` alongside it. It is documented
+as mutually exclusive with `env_key`, `experimental_bearer_token`, and
+`requires_openai_auth`.
+
+That is exactly the shape a directory sign-in needs: a command runs, it prints a
+short-lived token, and the token is refreshed when it expires. The earlier
+version of this document said the documentation "does not describe using an
+Azure AI Foundry deployment with a token obtained from a directory sign-in".
+That was right about Azure and wrong about tokens: a general mechanism for
+tokens from a command is documented. This repository's rule is that
+authentication comes from a directory sign-in rather than a fixed key, and that
+rule could be satisfied by this setting.
+
+**Half two — addressing an Azure AI Foundry deployment. Still not confirmed,
+and the evidence now leans against it.** Three things were found:
+
+1. `model_providers.<id>.wire_api` documents `responses` as "the only supported
+   value". Azure AI Foundry serves a Responses API of its own, but nothing
+   states that the format Codex sends is accepted by it. A shared name is not a
+   shared format.
+2. Azure OpenAI and Azure AI Foundry do not appear in the configuration
+   reference at all. The only Azure entry anywhere in the documentation
+   navigation is a workload identity federation page, which is about using an
+   Azure identity to authenticate **to OpenAI** — the opposite direction from
+   what this run place would need.
+3. Amazon Bedrock, by contrast, has a built-in provider selected with
+   `model_provider = "amazon-bedrock"`, its own settings
+   (`model_providers.amazon-bedrock.aws.profile` and `.aws.region`), its own
+   documentation page, and its own authentication path covering federated
+   identity. It is documented as providing "an OpenAI-compatible Responses API
+   implementation for supported OpenAI models".
+
+Point 3 is what changes the weight of the evidence. Before it, Azure's absence
+could be read as documentation simply not covering every case. After it, the
+documentation demonstrably does cover a competing cloud in depth, with a
+purpose-built provider and a statement of format compatibility. Azure has none
+of those. That is not proof of impossibility, but it is no longer neutral, and
+it should not be read as "probably fine, nobody wrote it down".
+
+**What this means for the column.** It stays empty. What changes is that the
+remaining unknown is now one specific, checkable thing rather than a general
+doubt, and it is written in section 7 below.
+
 ## 4. A distinction that is easy to get wrong
 
 Azure offers models whose names contain "codex", and Azure's own agent service
@@ -106,17 +161,54 @@ thing measured changes.
 
 ## 7. The one fact that would unblock this
 
+The original question was:
+
 > Can Codex's own agent loop be pointed at a named Azure AI Foundry deployment,
 > authenticating with a token from a directory sign-in rather than a fixed key?
 
-If **yes**, and it can be shown in official documentation, then a run place
-becomes worth designing: a mode that hands one task to `codex exec`, lets it
-work, and collects the files it produced.
+After the second search, the authentication half is answered yes, so what is
+left is narrower and more specific:
 
-If **no**, the honest outcome is that this column can never satisfy the
-comparison's conditions, and the comparison is a four-column comparison. That is
-a perfectly good result, and much better than a fifth column that silently
-measures something else.
+> Does Codex's `responses` request format work against an Azure AI Foundry
+> deployment's own Responses API endpoint, and is that stated in official
+> documentation?
+
+This is now a single checkable thing rather than a general doubt. If it is
+answered **yes** in official documentation, a run place becomes worth designing,
+and the settings it would use are already known:
+
+```toml
+# In the user-level configuration, not a repository-local one: provider and
+# credential settings are ignored when a repository tries to set them.
+[model_providers.azure-foundry]
+name = "Azure AI Foundry"
+base_url = "<the project endpoint>"
+wire_api = "responses"
+
+# A directory sign-in rather than a fixed key, which is the only kind of
+# credential this repository permits.
+[model_providers.azure-foundry.auth]
+command = "<a command that prints a directory token to stdout>"
+refresh_interval_ms = <shorter than the token's lifetime>
+```
+
+This block is written here so that the next person starts from the documented
+settings rather than searching again. **It is not a working configuration and
+must not be treated as one.** It rests on the unanswered question above, and if
+that answer is no, none of it works.
+
+If the answer is **no**, the honest outcome is that this column can never
+satisfy the comparison's conditions, and the comparison is a four-column
+comparison. That is a perfectly good result, and much better than a fifth column
+that silently measures something else.
+
+A third possibility is worth naming because it is the most likely trap: the
+settings above might partly work — a connection is made, answers come back —
+while some part of the format is quietly handled differently. That would produce
+a column that looks filled in and is not comparable. So "it seemed to work when
+somebody tried it" is not the standard here; the standard is a documented
+statement, which is why this stays blocked on documentation rather than on an
+experiment.
 
 ## 8. Files that would change, if it were unblocked
 
@@ -163,9 +255,14 @@ None of these should be touched before the question in section 7 is answered.
 
 - **Blocked on an external fact**, not on effort in this repository. No amount of
   work here establishes whether the connection is supported.
+- As of 2026-08-26 the fact is narrower than it was: the authentication half is
+  answered, and what remains is whether Codex's `responses` request format is
+  documented as working against an Azure AI Foundry deployment.
 - The next decision belongs to whoever can confirm it: either a documented
-  statement that Codex's own agent can use an Azure AI Foundry deployment with a
-  directory sign-in, or acceptance that the comparison has four columns.
+  statement that it does, or acceptance that the comparison has four columns.
+  Given that a competing cloud is documented in depth and Azure is not mentioned
+  at all, four columns is the more likely outcome, and planning around it would
+  not be premature.
 
 Until then the column stays empty and is reported as unconfirmed. It is not
 filled with a substitute.


### PR DESCRIPTION
## What this changes

Two things, and the first one matters more than the second.

### 1. A looping request was being charged as though the conversation never grew

`core/execution_envelope_cost.py` worked out the input side by multiplying one
turn's input by the number of model calls. That is correct for the two run
places that ask the model once per task. It is wrong for any request where the
model is asked again after each tool result, because **every later turn re-reads
the whole conversation before it** — what the model wrote on turn one, and every
tool result it was shown, is sent again on turn two, and again on turn three.

The Azure code interpreter is exactly such a request, and the plan already
prices it at eight turns. The old count charged its first turn's input eight
times and left out everything generated in between.

Counting the conversation as it grows:

| | before | after |
|---|---|---|
| Azure code interpreter | $4.83 | **$14.06** |
| separate Python process on the server | $3.48 | $3.48 |
| Docker container | $3.48 | $3.48 |
| marking | $14.02 | $14.02 |
| **whole run, after the safety multiplier** | **$32.23** | **$43.77** |

**The approved amount is $32.23**, agreed on 2026-08-25 while the mistake was in
place. So the run could have been allowed to start and then billed more than was
approved, with every check reporting it as within budget, and nobody would have
found out until the bill arrived.

Nothing was spent under the wrong figure — the Azure run place has never been
reachable from the machine this was attempted from — but the exposure was real
and reachable, not theoretical.

**The free check now refuses the run.** That is the safety mechanism working as
designed; the plan file itself said any change that made the run more expensive
should stop it rather than quietly spend more. I have left the approved amount
exactly as the owner set it. Raising it is not this change's decision to make.
The plan records the three ways out and who they belong to.

The two single-turn run places are unchanged to the token, and a test holds that
in place — a correction meant for loops leaking into places that do not loop is
the obvious way to get this wrong.

`max_tool_result_tokens_per_turn` becomes a required assumption per run place.
Leaving it out stops the count rather than quietly standing in a zero, which
would price a loop as though nothing were carried forward.

### 2. What Agentic Sandbox V2 stage one would cost

Step one of `tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md`, which
that document says is the first piece of work and is free. It is the same
arithmetic applied to a loop that may run 32 turns instead of 8.

A loop's bill does not rise in step with its turns. It rises roughly with the
square of them. The table this prints has one finding worth the trouble:

| tool calls | most a turn may write | most it could cost to run |
|---|---|---|
| 4 | 2,048 | **$3.24** |
| 8 | 2,048 | $12.45 |
| 32 | 2,048 | $193.15 |
| 32 | 32,768 | **$492.67** |

**The dispatcher's own defaults are the most expensive row on the table.** The
dispatcher allows 32 tool calls; the three-place comparison lets an answer run
to 32,768 tokens. Someone starting from both — reasonably, since both are the
existing defaults — would be committing to at most $492.67 for five tasks,
against $3.24 for the cheapest setting that could still answer the question.
Fifty times apart, from two settings a careful person would have left alone.

The ceiling numbers come from the dispatcher's own code, not from figures copied
into a document, so tightening a limit in the code moves the price with it.

`StageOneBudget` then holds a run to the figure: it refuses the next call at each
ceiling, and raises rather than reporting quietly if one is passed. A worked-out
ceiling that nothing enforces is a hope, not a limit.

### 3. The Codex question is half answered, and narrower

The authentication half turns out to be documented in general — a
`model_providers.<id>.auth` table runs a command that prints a token to standard
output and refreshes it, which is the shape a directory sign-in needs. The Azure
half is still unconfirmed and the evidence now leans against it: `wire_api`
documents `responses` as its only supported value with no statement that Azure's
Responses API accepts that format, Azure appears nowhere in the configuration
reference, and Amazon Bedrock does have a built-in provider, its own settings,
its own page and a statement of format compatibility. The documentation covers a
competing cloud in depth when it means to.

The column stays empty. It is not filled with Azure's own agent service, which
is a different product with a different loop.

## What this does not do

- **Nothing was spent. No model was called. $0.00.**
- Does not raise the approved amount, or lower any setting to fit under it.
- Does not open `exec_run`, build the model conversation, or touch either of the
  two guards. All three blocks stay shut, and the check confirms each by running
  it.
- Does not approve stage one. `agentic_stage_one_plan.yaml` leaves the amount
  empty and the check refuses while it is.
- Does not report stage one as able to run. The check says first that the model
  conversation it is about does not exist yet, established by looking at what
  the runner accepts, so the answer changes by itself when it is built.

## Tests

52 new. The ones that carry weight:

- one turn per attempt sends exactly the base input, for every combination of
  the added terms — the backwards-compatibility guard
- the committed plan no longer fits inside the approved amount, so the
  correction cannot be undone quietly
- doubling the turns more than doubles what the tool results cost
- leaving out the tool-result size stops the count instead of assuming zero
- a lower dispatcher ceiling lowers the bill without an edit to the test
- candidates the dispatcher would refuse are left out rather than priced
- with the money settled and a row chosen, the only remaining refusal is that
  the conversation does not exist
- the three new files are tracked by git, so a fresh clone has them

Full backend suite: **3,782 passed, 9 skipped, 0 failed** (3,733 at `2082301`
plus 49; three more were added during review). `mypy` clean on both changed
modules.

## The decision this leaves

Two, and both belong to the owner:

1. The five-task three-place run now costs at most **$43.77**, not $32.23.
   Approve $43.77, lower the Azure turn limit, or leave the run refused.
2. Stage one is priced but not approved. The cheapest row that could still
   answer its question is **$3.24 to run and $5.85 to mark, so $9.09**.

Neither can start anyway until the Azure tenant block clears, which is not
something this repository can fix.