### PR TITLE
Agentic Sandbox V2 1단계 — 모델 반복 대화 기반 구현 (실제 모델 연결은 여전히 거부)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,43 @@ entries land under a fresh dated heading the day they merge to `main`.
   reporting quietly if one is passed, so the worked-out amount is a limit and
   not a hope. Nothing is approved, nothing is switched on, and all three safety
   blocks stay shut: `scripts/check_agentic_stage_one_ceiling.py` prints the
-  table and refuses, reporting first that the model conversation stage one is
-  about does not exist yet — established by looking at what the runner accepts,
-  so the answer changes by itself when it is built. 52 new tests.
+  table and refuses, reporting first that nothing here can reach a real model —
+  established by running the refusing seam and the loop's own refusal, so the
+  answer changes by itself when that stops being true. 52 new tests.
+
+### Added
+- **The repeated conversation Agentic Sandbox V2 stage one is about now
+  exists.** Step two of
+  `tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md`. Until now the
+  runner replayed a list of tool calls written down in advance; a run therefore
+  proved that the tools worked, not that a model could choose them.
+  `batch-runner/core/agentic_v2_conversation.py` adds the loop itself: ask,
+  run the tool it asked for, show it what came back, ask again — with every
+  state and every way of stopping named rather than implied. It reaches no real
+  model and cannot be made to: `real_model_voice` refuses, and the loop refuses
+  any model that says it would be charged for **before** asking it anything, so
+  an unapproved paid run cannot start by accident. A test reads the module's
+  own imports and fails if it ever gains a route to a paid client or to another
+  way of running a task.
+
+  Three things it holds to, each fixed by tests. **A loop with no limit is not
+  a loop, it is a leak** — five ceilings (turns, tokens written in one turn,
+  wall-clock seconds, cost, and how often one request may be repeated) are
+  checked *before* the next call, and a run whose limits are not all set is
+  refused rather than run unlimited. **A failure the model is shown is not a
+  failure of the loop** — a refused tool call, including one for a capability
+  that is not available, goes back to the model to react to; only a limit
+  reached, a cancellation, or a broken tool desk ends the run. **What the model
+  reasons is not kept** — the model is shown real tool results, but what is
+  stored per turn is fingerprints, sizes, token counts and a short stated
+  reason, never the reasoning itself.
+
+  Nothing is switched on. All three safety blocks stay shut, and the free check
+  now reports the smaller remaining blocker — no way to reach a real model —
+  instead of the loop being missing. 97 new tests, covering normal completion,
+  every ceiling, cancellation before and mid-turn, timeout, repeated requests,
+  corrupted replies, broken desks, unsupported capabilities, and six runs
+  against the real dispatcher.
 
 ### Changed
 - **The Codex question is now half answered, and narrower.**

--- a/batch-runner/core/agentic_v2_conversation.py
+++ b/batch-runner/core/agentic_v2_conversation.py
@@ -1,0 +1,883 @@
+"""The repeated conversation with a model that Agentic Sandbox V2 stage one is.
+
+Every other run place in the comparison asks the model once. It writes one
+block of Python, somebody runs it, and whatever that block produced is the
+answer. If a library is missing or a file is not shaped the way the model
+guessed, the task simply fails.
+
+Stage one is the other thing: the model asks for one tool, is shown what came
+back, and chooses again with that in front of it. This module is that loop, and
+only that loop. It does not run commands, it does not pick a model, and it
+cannot be reached from the paid pipeline.
+
+Three properties are worth stating plainly, because they are the reason the
+module is shaped the way it is.
+
+**A loop with no limit is not a loop, it is a leak.** Four separate ceilings
+bound it: how many times the model may be asked, how much one reply may run to,
+how long the whole thing may take, and how much it may cost. A ceiling that is
+*missing* is treated exactly like one that has been *passed* — the loop refuses
+to start rather than run without it. The alternative, defaulting to something
+sensible, means the one run where somebody forgot is the run with no limit at
+all.
+
+**A failure the model is shown is not a failure of the loop.** Being told
+"that did not work" and choosing something else is the entire behaviour being
+measured. So an ordinary tool refusal is handed back to the model and the loop
+carries on. Only failures that make carrying on meaningless — a limit reached,
+the tool desk itself broken — end the run.
+
+**What the model reasons is not kept.** The record holds what was asked for,
+the short stated grounds for asking, and what came back. It has no field for a
+chain of thought, and the fields it does have are bounded, so there is nowhere
+for one to be smuggled through.
+
+What is deliberately *not* here: any way to reach a real model.
+:func:`real_model_voice` refuses, because reaching one costs money that has not
+been approved and the run place is still shut in three separate places. The
+loop is proven against deterministic stand-ins instead, which is enough to show
+the control flow is right and spends nothing doing it.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Mapping, Optional, Protocol, Sequence
+
+from core.agentic_v2_contract import TOOL_NAMES
+from core.agentic_v2_provenance import canonical_sha256
+from core.agentic_v2_stage_one_budget import StageOneBudget, StageOneBudgetExceeded
+from core.agentic_v2_tools import AgenticV2ToolDispatcher
+
+
+MOST_CHARACTERS_IN_A_STATED_REASON = 200
+"""How much of the model's stated grounds for a tool call is kept.
+
+Short on purpose. A sentence saying why a tool was chosen is useful when
+reading back what happened. A field with no ceiling is somewhere a whole chain
+of thought ends up, one paragraph at a time, and nobody notices until the
+records are large and full of things that were never meant to be stored.
+"""
+
+
+# ---------------------------------------------------------------------------
+# What the model may say back
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AskForTool:
+    """The model wants one tool run, and says briefly why."""
+
+    call_id: str
+    tool_name: str
+    arguments: Mapping[str, Any]
+    why: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+@dataclass(frozen=True)
+class GaveUp:
+    """The model stopped without committing anything.
+
+    Distinct from finishing. Finishing means the model called ``finalize`` and
+    the tool desk accepted it, which is the only way a task produces an answer.
+    This is the model walking away, and it is recorded as such rather than
+    being dressed up as a quiet success.
+    """
+
+    note: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+ModelReply = AskForTool | GaveUp
+
+
+@dataclass(frozen=True)
+class ToolExchange:
+    """One tool call and its answer, as the model is shown it.
+
+    Separate from :class:`TurnRecord` on purpose. The model has to see what
+    actually came back or it cannot react to it, which is the whole point. The
+    record that is kept afterwards holds fingerprints instead, so the two
+    cannot be confused for each other.
+    """
+
+    call_id: str
+    tool_name: str
+    arguments: Mapping[str, Any]
+    ok: bool
+    error_type: Optional[str]
+    data: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ModelRequest:
+    """Everything the model is given before it chooses its next action."""
+
+    turn: int
+    task_prompt: str
+    tools_available: tuple[str, ...]
+    history: tuple[ToolExchange, ...]
+    turns_left: int
+
+
+class ModelVoice(Protocol):
+    """Anything that can answer :class:`ModelRequest` with a next action.
+
+    ``makes_paid_calls`` is asked for rather than assumed. The loop refuses any
+    voice that says yes, so wiring a real client in cannot be done by accident
+    — it has to be done alongside removing that refusal, which is a change a
+    reviewer will see.
+    """
+
+    makes_paid_calls: bool
+
+    def next_turn(self, request: ModelRequest) -> ModelReply: ...
+
+
+@dataclass
+class ScriptedVoice:
+    """A stand-in model that says the same thing every time it is run.
+
+    This is what proves the loop works without spending anything. Each reply is
+    written down in advance and handed back in order; running past the end is
+    the model going quiet, which the loop must survive rather than hang on.
+    """
+
+    replies: Sequence[ModelReply]
+    makes_paid_calls: bool = False
+    requests_seen: list[ModelRequest] = field(default_factory=list)
+
+    def next_turn(self, request: ModelRequest) -> ModelReply:
+        self.requests_seen.append(request)
+        index = len(self.requests_seen) - 1
+        if index >= len(self.replies):
+            return GaveUp(note="the stand-in model ran out of written replies")
+        return self.replies[index]
+
+
+class NoModelVoiceAvailable(RuntimeError):
+    """Raised where a real model would be reached, because none can be."""
+
+
+def real_model_voice(*_args: Any, **_kwargs: Any) -> ModelVoice:
+    """The seam a real model would be plugged into, which refuses.
+
+    Kept as a function that raises rather than left absent, so the refusal can
+    be *run* by the free check instead of inferred from a file not existing.
+    When somebody does build this, that check fails and says what has to be
+    reviewed before a paid run is allowed.
+    """
+    raise NoModelVoiceAvailable(
+        "Agentic Sandbox V2 stage one has no way to reach a real model. "
+        "Building one costs money in a loop, and no amount has been approved "
+        "for it: experiments/execution_envelope/agentic_stage_one_plan.yaml "
+        "leaves the amount empty on purpose. The run place is also still "
+        "refused in three separate places. Use ScriptedVoice to exercise the "
+        "loop, which spends nothing."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Where tool calls go
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolOutcome:
+    """What one tool call produced."""
+
+    ok: bool
+    error_type: Optional[str] = None
+    data: Mapping[str, Any] = field(default_factory=dict)
+    request_sha256: Optional[str] = None
+    result_sha256: Optional[str] = None
+    result_bytes: int = 0
+    finished: bool = False
+    final_result: Optional[Mapping[str, Any]] = None
+    replayed: bool = False
+
+    @classmethod
+    def worked(cls, **data: Any) -> "ToolOutcome":
+        return cls(ok=True, data=dict(data))
+
+    @classmethod
+    def refused(cls, error_type: str) -> "ToolOutcome":
+        return cls(ok=False, error_type=error_type)
+
+    @classmethod
+    def committed(cls, final_result: Mapping[str, Any]) -> "ToolOutcome":
+        return cls(ok=True, finished=True, final_result=dict(final_result))
+
+
+class ToolDesk(Protocol):
+    """Anything that can run one tool call and report what happened."""
+
+    def run_one(
+        self,
+        *,
+        call_id: str,
+        tool_name: str,
+        arguments: Mapping[str, Any],
+    ) -> ToolOutcome: ...
+
+
+@dataclass
+class DispatcherToolDesk:
+    """Send tool calls to the real Agentic Sandbox V2 dispatcher.
+
+    Nothing is loosened on the way through. The dispatcher checks the arguments
+    against the published contract, counts the call against its own ceiling,
+    and refuses ``exec_run`` exactly as it does today. This adapter only
+    reshapes what comes back into the form the loop reads.
+    """
+
+    dispatcher: AgenticV2ToolDispatcher
+
+    def run_one(
+        self,
+        *,
+        call_id: str,
+        tool_name: str,
+        arguments: Mapping[str, Any],
+    ) -> ToolOutcome:
+        dispatch = self.dispatcher.dispatch(
+            call_id=call_id, name=tool_name, arguments=arguments
+        )
+        result = dispatch.result
+        usage = result.get("usage_delta") or {}
+        return ToolOutcome(
+            ok=result.get("ok") is True,
+            error_type=result.get("error_type"),
+            data=dict(result.get("data") or {}),
+            request_sha256=result.get("request_sha256"),
+            result_sha256=result.get("result_sha256"),
+            result_bytes=int(usage.get("output_bytes") or 0),
+            finished=dispatch.finalized,
+            final_result=dispatch.terminal_result,
+            replayed=dispatch.replayed,
+        )
+
+
+@dataclass
+class ScriptedToolDesk:
+    """A stand-in tool desk that answers from a list written in advance.
+
+    Running past the end answers ``capability_unavailable`` rather than
+    raising, because that is what a real desk does when asked for something it
+    cannot do, and a loop that keeps asking should be stopped by one of its own
+    ceilings rather than by the stand-in falling over.
+    """
+
+    answers: Sequence[ToolOutcome] = ()
+    calls: list[tuple[str, str, Mapping[str, Any]]] = field(default_factory=list)
+
+    def run_one(
+        self,
+        *,
+        call_id: str,
+        tool_name: str,
+        arguments: Mapping[str, Any],
+    ) -> ToolOutcome:
+        index = len(self.calls)
+        self.calls.append((call_id, tool_name, dict(arguments)))
+        if index >= len(self.answers):
+            return ToolOutcome.refused("capability_unavailable")
+        return self.answers[index]
+
+
+# ---------------------------------------------------------------------------
+# The ceilings
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LoopLimits:
+    """The four ceilings a run may not pass, plus a guard against going in
+    circles.
+
+    Each may be ``None``, which means nobody has said what it should be. The
+    loop treats that as a reason to refuse rather than filling in a default,
+    because a default is only ever consulted on the one run where somebody
+    forgot, and that is precisely the run that should not be allowed to go
+    unbounded.
+    """
+
+    max_model_turns: Optional[int] = None
+    max_written_tokens_per_turn: Optional[int] = None
+    max_seconds: Optional[float] = None
+    budget: Optional[StageOneBudget] = None
+    max_repeats_of_one_request: Optional[int] = None
+
+    def whats_missing(self) -> list[str]:
+        """Every ceiling nobody has set, said in full rather than one at a
+        time."""
+        missing: list[str] = []
+        if not _is_a_positive_whole_number(self.max_model_turns):
+            missing.append(
+                "nobody has said how many times the model may be asked, so "
+                "the loop could run until something else stopped it"
+            )
+        if not _is_a_positive_whole_number(self.max_written_tokens_per_turn):
+            missing.append(
+                "nobody has said how much one reply may run to, so a single "
+                "turn could be charged for any length at all"
+            )
+        if self.max_seconds is None or isinstance(self.max_seconds, bool) or (
+            not isinstance(self.max_seconds, (int, float))
+        ) or self.max_seconds <= 0:
+            missing.append(
+                "nobody has said how long the whole run may take, so a slow "
+                "or stuck turn could hold the run open indefinitely"
+            )
+        if not isinstance(self.budget, StageOneBudget):
+            missing.append(
+                "nobody has said what this run may cost, so it could spend "
+                "past whatever was approved without anything noticing"
+            )
+        if not _is_a_positive_whole_number(self.max_repeats_of_one_request):
+            missing.append(
+                "nobody has said how often the same request may be repeated, "
+                "so a model asking the same thing over and over would spend "
+                "the whole budget making no progress"
+            )
+        return missing
+
+
+def _is_a_positive_whole_number(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+# ---------------------------------------------------------------------------
+# What state the loop is in, and why it stopped
+# ---------------------------------------------------------------------------
+
+
+class LoopStep(Enum):
+    """The named points a run passes through, in order.
+
+    Written down as states rather than left implicit in log lines, so that
+    reading back a run means reading a sequence rather than reconstructing one.
+    """
+
+    MODEL_ASKED = "model_asked"
+    MODEL_REPLIED = "model_replied"
+    TOOL_REQUESTED = "tool_requested"
+    TOOL_ANSWERED = "tool_answered"
+    NEXT_TURN = "next_turn"
+    STOPPED = "stopped"
+
+
+class StopReason(Enum):
+    """Every way a run can end. There is no unlabelled ending."""
+
+    FINISHED_NORMALLY = "finished_normally"
+    MODEL_STOPPED_WITHOUT_FINISHING = "model_stopped_without_finishing"
+    TURN_LIMIT_REACHED = "turn_limit_reached"
+    WRITING_LIMIT_REACHED = "writing_limit_reached"
+    TIME_LIMIT_REACHED = "time_limit_reached"
+    COST_LIMIT_REACHED = "cost_limit_reached"
+    TOOL_CALL_LIMIT_REACHED = "tool_call_limit_reached"
+    REPEATED_REQUEST = "repeated_request"
+    LIMIT_MISSING = "limit_missing"
+    CANCELLED = "cancelled"
+    MODEL_REPLY_UNUSABLE = "model_reply_unusable"
+    TOOL_DESK_BROKE = "tool_desk_broke"
+    PAID_CALL_REFUSED = "paid_call_refused"
+
+    @property
+    def produced_an_answer(self) -> bool:
+        """Only one ending produces a deliverable, and it is named."""
+        return self is StopReason.FINISHED_NORMALLY
+
+    @property
+    def is_a_limit(self) -> bool:
+        """Whether the run was stopped by a ceiling rather than by going
+        wrong."""
+        return self in _LIMIT_REASONS
+
+
+_LIMIT_REASONS = frozenset({
+    StopReason.TURN_LIMIT_REACHED,
+    StopReason.WRITING_LIMIT_REACHED,
+    StopReason.TIME_LIMIT_REACHED,
+    StopReason.COST_LIMIT_REACHED,
+    StopReason.TOOL_CALL_LIMIT_REACHED,
+    StopReason.REPEATED_REQUEST,
+    StopReason.LIMIT_MISSING,
+})
+
+
+_ENDS_THE_RUN: Mapping[str, StopReason] = {
+    # Ceilings the tool desk enforces for itself.
+    "cancelled": StopReason.CANCELLED,
+    "task_wall_time_exhausted": StopReason.TIME_LIMIT_REACHED,
+    "tool_budget_exhausted": StopReason.TOOL_CALL_LIMIT_REACHED,
+    # The desk itself is not working. Asking the model to react to this would
+    # be asking it to work around a broken tool, which is not the behaviour
+    # being measured and is not safe to encourage.
+    "compute_backend_error": StopReason.TOOL_DESK_BROKE,
+    "compute_cleanup_failed": StopReason.TOOL_DESK_BROKE,
+    "compute_start_failed": StopReason.TOOL_DESK_BROKE,
+    "fixture_backend_error": StopReason.TOOL_DESK_BROKE,
+    "invalid_backend_result": StopReason.TOOL_DESK_BROKE,
+    "invalid_backend_state": StopReason.TOOL_DESK_BROKE,
+    "invalid_lifecycle_transition": StopReason.TOOL_DESK_BROKE,
+    "invalid_result_envelope": StopReason.TOOL_DESK_BROKE,
+    "runner_internal_error": StopReason.TOOL_DESK_BROKE,
+    "substrate_manifest_missing": StopReason.TOOL_DESK_BROKE,
+}
+"""Tool failures that end the run, and the ending each one gets.
+
+Everything absent from this table — including ``capability_unavailable``, which
+is what asking to run a command gets today — is handed back to the model
+instead. That is not leniency. Reading a refusal and choosing something else is
+the one behaviour stage one exists to measure, so a loop that gave up at the
+first refusal would measure nothing.
+"""
+
+
+# ---------------------------------------------------------------------------
+# What is kept afterwards
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TurnRecord:
+    """One turn, in the form that is kept.
+
+    Built field by field from a fixed list rather than by copying whatever the
+    model handed over. That is what makes the no-reasoning-kept property hold:
+    a voice can attach anything it likes to its reply and none of it reaches
+    here, because nothing here is copied wholesale.
+    """
+
+    turn: int
+    call_id: str
+    tool_name: str
+    argument_names: tuple[str, ...]
+    stated_reason: str
+    ok: bool
+    error_type: Optional[str]
+    request_sha256: Optional[str]
+    result_sha256: Optional[str]
+    result_bytes: int
+    input_tokens: int
+    output_tokens: int
+    replayed: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "turn": self.turn,
+            "call_id": self.call_id,
+            "tool_name": self.tool_name,
+            "argument_names": list(self.argument_names),
+            "stated_reason": self.stated_reason,
+            "ok": self.ok,
+            "error_type": self.error_type,
+            "request_sha256": self.request_sha256,
+            "result_sha256": self.result_sha256,
+            "result_bytes": self.result_bytes,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "replayed": self.replayed,
+        }
+
+
+@dataclass(frozen=True)
+class LoopEvent:
+    """One point the run passed through."""
+
+    step: LoopStep
+    turn: int
+    detail: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "step": self.step.value,
+            "turn": self.turn,
+            "detail": dict(self.detail),
+        }
+
+
+@dataclass(frozen=True)
+class ConversationOutcome:
+    """How a run ended, and everything kept from it."""
+
+    stop_reason: StopReason
+    detail: str
+    turns: tuple[TurnRecord, ...]
+    events: tuple[LoopEvent, ...]
+    final_result: Optional[Mapping[str, Any]] = None
+    budget_after: Optional[Mapping[str, Any]] = None
+
+    @property
+    def produced_an_answer(self) -> bool:
+        return self.stop_reason.produced_an_answer
+
+    @property
+    def model_turns_used(self) -> int:
+        return sum(
+            1 for event in self.events if event.step is LoopStep.MODEL_ASKED
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "stop_reason": self.stop_reason.value,
+            "detail": self.detail,
+            "produced_an_answer": self.produced_an_answer,
+            "model_turns_used": self.model_turns_used,
+            "turns": [record.as_dict() for record in self.turns],
+            "events": [event.as_dict() for event in self.events],
+            "budget_after": (
+                dict(self.budget_after) if self.budget_after is not None else None
+            ),
+        }
+
+
+# ---------------------------------------------------------------------------
+# The loop
+# ---------------------------------------------------------------------------
+
+
+def run_model_conversation(
+    *,
+    task_prompt: str,
+    voice: ModelVoice,
+    desk: ToolDesk,
+    limits: LoopLimits,
+    tools_available: Sequence[str] = TOOL_NAMES,
+    cancel_requested: Optional[Callable[[], bool]] = None,
+    clock: Callable[[], float] = time.monotonic,
+) -> ConversationOutcome:
+    """Ask the model, run what it asked for, show it the answer, repeat.
+
+    Ends the moment any ceiling is reached, the model commits an answer, or the
+    model walks away. It never reaches for a different tool, a different model,
+    or a different run place on the model's behalf: a run that could not finish
+    is reported as one, because a quiet substitution produces a result nobody
+    can attribute to anything.
+    """
+    asked_to_stop = cancel_requested or (lambda: False)
+    events: list[LoopEvent] = []
+    turns: list[TurnRecord] = []
+    history: list[ToolExchange] = []
+    repeats: dict[str, int] = {}
+    started_at = clock()
+    turn = 0
+
+    def finish(reason: StopReason, detail: str, **extra: Any) -> ConversationOutcome:
+        events.append(LoopEvent(
+            step=LoopStep.STOPPED,
+            turn=turn,
+            detail={"stop_reason": reason.value, "why": detail},
+        ))
+        return ConversationOutcome(
+            stop_reason=reason,
+            detail=detail,
+            turns=tuple(turns),
+            events=tuple(events),
+            budget_after=(
+                limits.budget.as_dict()
+                if isinstance(limits.budget, StageOneBudget)
+                else None
+            ),
+            **extra,
+        )
+
+    # Asked before anything else, and defaulting to "yes it is paid" when the
+    # voice does not say. A voice that forgot to declare itself is refused
+    # rather than assumed free.
+    if getattr(voice, "makes_paid_calls", True):
+        return finish(
+            StopReason.PAID_CALL_REFUSED,
+            "this model would be charged for, and no amount has been approved "
+            "for an Agentic Sandbox V2 stage-one run. Nothing was asked",
+        )
+
+    missing = limits.whats_missing()
+    if missing:
+        return finish(
+            StopReason.LIMIT_MISSING,
+            "this run has no ceiling on something it needs one for, so it was "
+            "refused before the model was asked anything: " + "; ".join(missing),
+        )
+    # Every ceiling is present from here on, so the loop may read them without
+    # guarding each use.
+    max_turns = int(limits.max_model_turns or 0)
+    max_written = int(limits.max_written_tokens_per_turn or 0)
+    max_seconds = float(limits.max_seconds or 0.0)
+    max_repeats = int(limits.max_repeats_of_one_request or 0)
+    budget: StageOneBudget = limits.budget  # type: ignore[assignment]
+
+    while True:
+        if asked_to_stop():
+            return finish(
+                StopReason.CANCELLED,
+                "the run was asked to stop before the model was asked again",
+            )
+        if turn >= max_turns:
+            return finish(
+                StopReason.TURN_LIMIT_REACHED,
+                f"the model has been asked {turn} times, which is all the "
+                f"{max_turns} this run was allowed",
+            )
+        elapsed = clock() - started_at
+        if elapsed >= max_seconds:
+            return finish(
+                StopReason.TIME_LIMIT_REACHED,
+                f"this run has taken {elapsed:.3f} seconds, which is all the "
+                f"{max_seconds:.3f} it was allowed",
+            )
+        refusal = budget.refusal_before_next_call()
+        if refusal is not None:
+            return finish(StopReason.COST_LIMIT_REACHED, refusal)
+
+        turn += 1
+        events.append(LoopEvent(
+            step=LoopStep.MODEL_ASKED,
+            turn=turn,
+            detail={
+                "tool_results_so_far": len(history),
+                "turns_left": max_turns - turn,
+            },
+        ))
+        request = ModelRequest(
+            turn=turn,
+            task_prompt=task_prompt,
+            tools_available=tuple(str(name) for name in tools_available),
+            history=tuple(history),
+            turns_left=max_turns - turn,
+        )
+        try:
+            reply = voice.next_turn(request)
+        except Exception as error:  # noqa: BLE001 - any failure ends the run
+            return finish(
+                StopReason.MODEL_REPLY_UNUSABLE,
+                f"asking the model failed: {type(error).__name__}",
+            )
+
+        usage = _usage_of(reply)
+        if usage is None:
+            return finish(
+                StopReason.MODEL_REPLY_UNUSABLE,
+                "the model's reply did not say how much it used, or said "
+                "something that is not a count, so it cannot be charged for "
+                "and the run cannot be allowed to continue",
+            )
+        input_tokens, output_tokens = usage
+        # Recorded as having happened before the run decides what to do about
+        # it, so that a trace read back afterwards shows the reply arriving
+        # rather than seeming to vanish between the asking and the stopping.
+        events.append(LoopEvent(
+            step=LoopStep.MODEL_REPLIED,
+            turn=turn,
+            detail={
+                "kind": type(reply).__name__,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+        ))
+        try:
+            budget.record(input_tokens=input_tokens, output_tokens=output_tokens)
+        except StageOneBudgetExceeded as error:
+            return finish(StopReason.COST_LIMIT_REACHED, str(error))
+        except ValueError as error:
+            return finish(
+                StopReason.MODEL_REPLY_UNUSABLE,
+                f"the model's reply could not be charged for: {error}",
+            )
+
+        if output_tokens > max_written:
+            return finish(
+                StopReason.WRITING_LIMIT_REACHED,
+                f"the model wrote {output_tokens} tokens in one turn, past the "
+                f"{max_written} this run allows in one turn",
+            )
+
+        if isinstance(reply, GaveUp):
+            return finish(
+                StopReason.MODEL_STOPPED_WITHOUT_FINISHING,
+                "the model stopped without committing an answer"
+                + _appended_note(reply.note),
+            )
+
+        asked = _readable_request(reply)
+        if asked is None:
+            return finish(
+                StopReason.MODEL_REPLY_UNUSABLE,
+                "the model's reply was not a usable tool request, so there is "
+                "nothing to run and nothing to show it next",
+            )
+        call_id, tool_name, arguments, why = asked
+
+        fingerprint = canonical_sha256({"name": tool_name, "arguments": arguments})
+        repeats[fingerprint] = repeats.get(fingerprint, 0) + 1
+        if repeats[fingerprint] > max_repeats:
+            return finish(
+                StopReason.REPEATED_REQUEST,
+                f"the model asked for {tool_name} with the same arguments "
+                f"{repeats[fingerprint]} times, past the {max_repeats} this "
+                "run allows. It is going in circles rather than making "
+                "progress, and every further turn would be charged for",
+            )
+
+        if asked_to_stop():
+            return finish(
+                StopReason.CANCELLED,
+                "the run was asked to stop before the tool was run",
+            )
+        elapsed = clock() - started_at
+        if elapsed >= max_seconds:
+            return finish(
+                StopReason.TIME_LIMIT_REACHED,
+                f"this run has taken {elapsed:.3f} seconds, which is all the "
+                f"{max_seconds:.3f} it was allowed",
+            )
+
+        events.append(LoopEvent(
+            step=LoopStep.TOOL_REQUESTED,
+            turn=turn,
+            detail={
+                "call_id": call_id,
+                "tool_name": tool_name,
+                "argument_names": sorted(arguments),
+            },
+        ))
+        try:
+            outcome = desk.run_one(
+                call_id=call_id, tool_name=tool_name, arguments=arguments
+            )
+        except Exception as error:  # noqa: BLE001 - any failure ends the run
+            return finish(
+                StopReason.TOOL_DESK_BROKE,
+                f"running the tool failed: {type(error).__name__}",
+            )
+        if not isinstance(outcome, ToolOutcome):
+            return finish(
+                StopReason.TOOL_DESK_BROKE,
+                "the tool desk answered with something that is not a tool "
+                "outcome, so what happened to the task environment is unknown",
+            )
+
+        turns.append(TurnRecord(
+            turn=turn,
+            call_id=call_id,
+            tool_name=tool_name,
+            argument_names=tuple(sorted(arguments)),
+            stated_reason=why,
+            ok=outcome.ok,
+            error_type=outcome.error_type,
+            request_sha256=outcome.request_sha256,
+            result_sha256=outcome.result_sha256,
+            result_bytes=outcome.result_bytes,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            replayed=outcome.replayed,
+        ))
+        history.append(ToolExchange(
+            call_id=call_id,
+            tool_name=tool_name,
+            arguments=dict(arguments),
+            ok=outcome.ok,
+            error_type=outcome.error_type,
+            data=dict(outcome.data),
+        ))
+        events.append(LoopEvent(
+            step=LoopStep.TOOL_ANSWERED,
+            turn=turn,
+            detail={
+                "call_id": call_id,
+                "tool_name": tool_name,
+                "ok": outcome.ok,
+                "error_type": outcome.error_type,
+                "replayed": outcome.replayed,
+                "finished": outcome.finished,
+            },
+        ))
+
+        if outcome.finished:
+            if not isinstance(outcome.final_result, Mapping):
+                return finish(
+                    StopReason.TOOL_DESK_BROKE,
+                    "the tool desk said the task was committed but handed back "
+                    "no answer, so there is nothing to report as the result",
+                )
+            return finish(
+                StopReason.FINISHED_NORMALLY,
+                f"the model committed an answer on turn {turn}",
+                final_result=dict(outcome.final_result),
+            )
+
+        ends_it = _ENDS_THE_RUN.get(str(outcome.error_type or ""))
+        if ends_it is not None:
+            return finish(
+                ends_it,
+                f"{tool_name} answered {outcome.error_type}, which the model "
+                "cannot usefully be asked to work around",
+            )
+
+        events.append(LoopEvent(
+            step=LoopStep.NEXT_TURN,
+            turn=turn,
+            detail={
+                "showing_the_model": (
+                    "a result" if outcome.ok else f"a refusal: {outcome.error_type}"
+                ),
+            },
+        ))
+
+
+def _usage_of(reply: Any) -> Optional[tuple[int, int]]:
+    """How much a reply cost, or ``None`` if it did not say in plain counts."""
+    if not isinstance(reply, (AskForTool, GaveUp)):
+        return None
+    values: list[int] = []
+    for name in ("input_tokens", "output_tokens"):
+        value = getattr(reply, name, None)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            return None
+        values.append(value)
+    return values[0], values[1]
+
+
+def _readable_request(
+    reply: AskForTool,
+) -> Optional[tuple[str, str, dict[str, Any], str]]:
+    """Pull the four things a tool call needs out of a reply, or refuse it.
+
+    Only these four are read. Anything else attached to the reply is left where
+    it is, which is what keeps a chain of thought out of the record even when
+    the thing answering is trying to hand one over.
+    """
+    call_id = getattr(reply, "call_id", None)
+    tool_name = getattr(reply, "tool_name", None)
+    arguments = getattr(reply, "arguments", None)
+    why = getattr(reply, "why", "")
+    if not isinstance(call_id, str) or not call_id:
+        return None
+    if not isinstance(tool_name, str) or not tool_name:
+        return None
+    if not isinstance(arguments, Mapping):
+        return None
+    if any(not isinstance(key, str) for key in arguments):
+        return None
+    if not isinstance(why, str):
+        why = ""
+    return (
+        call_id,
+        tool_name,
+        dict(arguments),
+        why[:MOST_CHARACTERS_IN_A_STATED_REASON],
+    )
+
+
+def _appended_note(note: Any) -> str:
+    if not isinstance(note, str) or not note.strip():
+        return ""
+    return ": " + note.strip()[:MOST_CHARACTERS_IN_A_STATED_REASON]

--- a/batch-runner/core/agentic_v2_stage_one_budget.py
+++ b/batch-runner/core/agentic_v2_stage_one_budget.py
@@ -548,48 +548,116 @@ def load_stage_one_plan(path: Any = None) -> dict:
     return raw
 
 
-def check_the_model_conversation_does_not_exist_yet() -> list[str]:
-    """Confirm the runner still replays a written-down list rather than asking.
+def check_stage_one_cannot_reach_a_model() -> list[str]:
+    """Confirm nothing here can put a real model into the stage-one loop.
 
-    Stage one is defined as the step that replaces the replayed list with a
-    real conversation. Until that exists, stage one cannot start however much
-    money is approved, and saying so plainly is more useful than letting the
-    money question stand in for it.
+    The loop stage one is about now exists:
+    :func:`core.agentic_v2_conversation.run_model_conversation` asks something,
+    runs the tool it asked for, shows it what came back, and asks again. What
+    does not exist is any way to reach a *real* model with it. The seam a real
+    client would be plugged into refuses, because reaching one costs money in a
+    loop and no amount has been approved for that.
 
-    Checked by looking at what the runner accepts, not by reading a comment, so
-    the answer changes by itself when the conversation is built.
+    So stage one still cannot start, but for a different and much smaller
+    reason than before, and the difference is worth stating rather than
+    flattening into "not built yet".
+
+    Everything below is established by running the code, not by reading it:
+    the refusing seam is called and required to refuse, and the loop is run
+    with a stand-in that declares itself paid and required to stop before
+    asking it anything. A comment could say either of those and be wrong.
     """
     import inspect
 
     try:
-        from core.agentic_v2_runner import AgenticV2ScriptedRunner
+        from core.agentic_v2_conversation import (
+            GaveUp,
+            LoopLimits,
+            NoModelVoiceAvailable,
+            ScriptedToolDesk,
+            ScriptedVoice,
+            StopReason,
+            real_model_voice,
+            run_model_conversation,
+        )
     except ImportError as error:  # pragma: no cover - defensive
         return [
-            "the Agentic Sandbox V2 runner could not be loaded, so whether "
-            f"the model conversation exists cannot be established: {error}"
+            "the Agentic Sandbox V2 model conversation could not be loaded, so "
+            "whether a real model can be reached cannot be established: "
+            f"{error}"
         ]
-    accepted = set(
-        inspect.signature(AgenticV2ScriptedRunner.__init__).parameters
+
+    problems: list[str] = []
+
+    try:
+        real_model_voice()
+    except NoModelVoiceAvailable:
+        pass
+    except Exception as error:  # pragma: no cover - defensive
+        problems.append(
+            "asking for a real model failed in an unexpected way, so what "
+            "would happen on a paid run is unknown: "
+            f"{type(error).__name__}: {error}"
+        )
+    else:
+        problems.append(
+            "core.agentic_v2_conversation.real_model_voice now hands back a "
+            "way to reach a real model. Stage one may be about to spend money "
+            "in a loop, so before any paid run is allowed somebody must "
+            "confirm the amount is approved here and that the loop still "
+            "stops at the dispatcher's own tool-call ceiling"
+        )
+
+    would_be_charged_for = ScriptedVoice(
+        replies=[GaveUp(note="never asked")], makes_paid_calls=True
     )
-    if "scripted_calls" not in accepted:
-        return [
-            "the Agentic Sandbox V2 runner no longer takes a list of calls "
-            "written down in advance. If the model conversation has been "
-            "built, this check needs updating to say so; until then stage one "
-            "cannot be graded"
-        ]
-    if accepted & {"model_client", "llm_client", "client"}:
-        return [
-            "the Agentic Sandbox V2 runner now accepts a model client. Stage "
-            "one may have been built, and this check must be updated to "
-            "confirm the loop stops at the dispatcher's ceiling before any "
-            "paid run is allowed"
-        ]
+    refused = run_model_conversation(
+        task_prompt="a check that spends nothing",
+        voice=would_be_charged_for,
+        desk=ScriptedToolDesk(),
+        limits=LoopLimits(),
+    )
+    if refused.stop_reason is not StopReason.PAID_CALL_REFUSED:
+        problems.append(
+            "the stage-one loop no longer refuses a model that would be "
+            "charged for: it stopped with "
+            f"{refused.stop_reason.value!r} instead. That refusal is what "
+            "keeps an unapproved paid run from starting by accident"
+        )
+    if would_be_charged_for.requests_seen:
+        problems.append(
+            "the stage-one loop asked a model that declares itself paid "
+            "before refusing it, so the money would already have been spent "
+            "by the time anything noticed"
+        )
+
+    try:
+        from core.agentic_v2_runner import AgenticV2ScriptedRunner
+    except ImportError as error:  # pragma: no cover - defensive
+        problems.append(
+            "the Agentic Sandbox V2 runner could not be loaded, so whether it "
+            f"holds a model client cannot be established: {error}"
+        )
+    else:
+        accepted = set(
+            inspect.signature(AgenticV2ScriptedRunner.__init__).parameters
+        )
+        if accepted & {"model_client", "llm_client", "client"}:
+            problems.append(
+                "the Agentic Sandbox V2 runner now accepts a model client "
+                "directly. That is a second route to a paid call which this "
+                "check does not cover, and it must be reviewed before any "
+                "stage-one run is allowed"
+            )
+
+    if problems:
+        return problems
     return [
-        "the model conversation stage one is about does not exist yet: "
-        "core.agentic_v2_runner.AgenticV2ScriptedRunner replays a list of "
-        "calls written down in advance and holds no model client, so no model "
-        "ever sees a tool result and chooses what to do next"
+        "stage one cannot start because nothing here can reach a real model: "
+        "the loop exists at core.agentic_v2_conversation.run_model_conversation "
+        "and is proven against stand-ins that spend nothing, but "
+        "real_model_voice refuses and the loop refuses any model that would be "
+        "charged for. Approving an amount below is what removes this"
     ]
 
 
@@ -621,7 +689,7 @@ def run_stage_one_preflight(
             "stay true"
         )
     problems.extend(check_agentic_sandbox_v2_blocks_are_intact())
-    problems.extend(check_the_model_conversation_does_not_exist_yet())
+    problems.extend(check_stage_one_cannot_reach_a_model())
 
     fixed = dict(plan.get("fixed_settings") or {})
     if fixed.get("exec_run_open") is not False:

--- a/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
+++ b/batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml
@@ -19,9 +19,12 @@
 # Beyond the money, two things still block stage one even if the money is
 # approved, and neither is removed here:
 #
-#   - the model conversation itself does not exist. core/agentic_v2_runner.py
-#     replays a list of calls written down in advance and holds no model client
-#     at all.
+#   - nothing here can reach a real model. The repeated conversation stage one
+#     is about does now exist, at
+#     core/agentic_v2_conversation.run_model_conversation, and it is proven
+#     against stand-ins that spend nothing. But real_model_voice refuses to
+#     hand back a way to reach a real model, and the loop itself refuses any
+#     model that says it would be charged for, before asking it anything.
 #   - two separate guards refuse the mode: the check in
 #     step2_run_inference._require_runnable_execution_mode, and the refusal in
 #     core/executor.py to build a runner unless the caller states the run makes

--- a/batch-runner/scripts/check_agentic_stage_one_ceiling.py
+++ b/batch-runner/scripts/check_agentic_stage_one_ceiling.py
@@ -14,9 +14,8 @@ Usage:
     python scripts/check_agentic_stage_one_ceiling.py --plan other.yaml
 
 The exit code is 0 only when nothing is left to fix, which today it never is:
-the model conversation stage one is about has not been built, and no amount has
-been approved for it. Anything else exits 1, so this is safe to wire into an
-automated check.
+nothing here can reach a real model, and no amount has been approved for one.
+Anything else exits 1, so this is safe to wire into an automated check.
 """
 
 from __future__ import annotations

--- a/batch-runner/tests/test_agentic_stage_one_budget.py
+++ b/batch-runner/tests/test_agentic_stage_one_budget.py
@@ -37,7 +37,7 @@ from core.agentic_v2_stage_one_budget import (  # noqa: E402
     StageOneBudgetExceeded,
     StageOneConditions,
     budget_for_one_task,
-    check_the_model_conversation_does_not_exist_yet,
+    check_stage_one_cannot_reach_a_model,
     load_stage_one_plan,
     price_the_options,
     read_dispatcher_limits,
@@ -595,29 +595,99 @@ def _preflight(plan, catalog, assumptions):
     )
 
 
-def test_stage_one_is_refused_today_and_says_the_conversation_is_missing(
+def test_stage_one_is_refused_today_and_says_no_model_can_be_reached(
     stage_one_plan, catalog, assumptions
 ):
-    """The honest first answer is not about money.
+    """The honest first answer is still not about money.
 
-    Even with an amount approved, stage one could not start: the thing it is
-    about — the model being asked again with a tool result in front of it —
-    has not been built. Saying that plainly is more useful than letting the
-    money question stand in for it.
+    The loop stage one is about now exists and is proven against stand-ins.
+    What does not exist is any way to put a real model into it, so stage one
+    could not start even with an amount approved — and saying which of the two
+    is missing is more useful than letting the money question stand in for it.
     """
     result = _preflight(stage_one_plan, catalog, assumptions)
 
     assert result.may_start is False
     assert any(
-        "does not exist yet" in note for note in result.problems
+        "nothing here can reach a real model" in note
+        for note in result.problems
     )
 
 
-def test_the_missing_conversation_is_established_by_looking_at_the_code():
-    """Read from what the runner accepts, so the answer changes by itself."""
-    problems = check_the_model_conversation_does_not_exist_yet()
+def test_the_missing_model_is_established_by_running_the_code():
+    """Established by calling the refusing seam, not by reading a comment."""
+    problems = check_stage_one_cannot_reach_a_model()
     assert len(problems) == 1
-    assert "replays a list of calls written down in advance" in problems[0]
+    assert "real_model_voice refuses" in problems[0]
+    assert "core.agentic_v2_conversation.run_model_conversation" in problems[0]
+
+
+def test_the_check_reports_it_if_a_way_to_reach_a_model_appears(monkeypatch):
+    """The answer must change by itself the day somebody builds one."""
+    import core.agentic_v2_conversation as conversation
+
+    monkeypatch.setattr(
+        conversation,
+        "real_model_voice",
+        lambda *args, **kwargs: conversation.ScriptedVoice(replies=[]),
+    )
+
+    problems = check_stage_one_cannot_reach_a_model()
+
+    assert any("now hands back a way to reach a real model" in note
+               for note in problems)
+    assert any("dispatcher's own tool-call ceiling" in note
+               for note in problems)
+
+
+def test_the_check_reports_it_if_the_loop_stops_refusing_paid_models(
+    monkeypatch,
+):
+    """The refusal is what keeps an unapproved paid run from starting."""
+    import core.agentic_v2_conversation as conversation
+
+    def a_loop_that_asks_anyway(*, voice, **_kwargs):
+        voice.next_turn(
+            conversation.ModelRequest(
+                turn=1,
+                task_prompt="",
+                tools_available=(),
+                history=(),
+                turns_left=0,
+            )
+        )
+        return conversation.ConversationOutcome(
+            stop_reason=conversation.StopReason.MODEL_STOPPED_WITHOUT_FINISHING,
+            detail="",
+            turns=(),
+            events=(),
+        )
+
+    monkeypatch.setattr(
+        conversation, "run_model_conversation", a_loop_that_asks_anyway
+    )
+
+    problems = check_stage_one_cannot_reach_a_model()
+
+    assert any(
+        "no longer refuses a model that would be charged for" in note
+        for note in problems
+    )
+    assert any("before refusing it" in note for note in problems)
+
+
+def test_the_check_reports_it_if_the_runner_gains_a_model_client(monkeypatch):
+    """A second route to a paid call this check does not otherwise cover."""
+    from core.agentic_v2_runner import AgenticV2ScriptedRunner
+
+    def __init__(self, *, model_client=None, **kwargs):  # pragma: no cover
+        raise AssertionError("only the signature is read")
+
+    monkeypatch.setattr(AgenticV2ScriptedRunner, "__init__", __init__)
+
+    problems = check_stage_one_cannot_reach_a_model()
+
+    assert any("now accepts a model client" in note for note in problems)
 
 
 def test_the_committed_stage_one_plan_approves_nothing(stage_one_plan):
@@ -663,10 +733,12 @@ def test_choosing_a_row_reports_the_limit_each_task_would_be_stopped_by(
         assert budget.refusal_before_next_call() is None
 
     # The money is settled and the settings are chosen, so the only thing left
-    # standing between here and a run is that the conversation does not exist.
+    # standing between here and a run is that no real model can be reached.
     assert result.may_start is False
     assert [
-        note for note in result.problems if "does not exist yet" in note
+        note
+        for note in result.problems
+        if "nothing here can reach a real model" in note
     ] == result.problems
 
 
@@ -893,7 +965,7 @@ def test_running_the_tool_refuses_and_prints_the_table():
 
     assert finished.returncode == 1, finished.stdout + finished.stderr
     assert "What each candidate setting could cost at most" in finished.stdout
-    assert "does not exist yet" in finished.stdout
+    assert "nothing here can reach a real model" in finished.stdout
     # The dispatcher's real ceiling, read from code, must reach the report.
     assert str(read_dispatcher_limits().max_total_calls) in finished.stdout
 

--- a/batch-runner/tests/test_agentic_v2_conversation.py
+++ b/batch-runner/tests/test_agentic_v2_conversation.py
@@ -161,7 +161,13 @@ def test_a_refusal_the_model_could_work_around_does_not_end_the_run():
 
 
 def test_asking_to_run_a_command_is_refused_and_the_command_never_runs():
-    """The unsupported capability, end to end, against the real dispatcher."""
+    """The unsupported capability seen from the loop's side.
+
+    The refusal itself, against the real dispatcher, is
+    :func:`test_the_real_dispatcher_still_refuses_to_run_a_command` below. What
+    this fixes is what the loop does with it: records it, shows it, and lets
+    the model decide, rather than treating it as the run failing.
+    """
     voice = ScriptedVoice(replies=[run_a_command(), GaveUp(note="nothing left")])
     desk = ScriptedToolDesk(answers=[ToolOutcome.refused("capability_unavailable")])
 

--- a/batch-runner/tests/test_agentic_v2_conversation.py
+++ b/batch-runner/tests/test_agentic_v2_conversation.py
@@ -1,0 +1,1067 @@
+"""Every way the Agentic Sandbox V2 model conversation can end, fixed in place.
+
+The loop is worth having only if it stops when it should. These tests spend
+nothing: the model is a stand-in that says what it was told to say, and the
+tool desk is either a stand-in or the real dispatcher with commands still shut.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import pathlib
+
+import pytest
+
+from core.agentic_v2_contract import (
+    TOOL_NAMES,
+    AgenticV2Lifecycle,
+    AgenticV2Profile,
+    LifecycleState,
+)
+from core.agentic_v2_conversation import (
+    MOST_CHARACTERS_IN_A_STATED_REASON,
+    AskForTool,
+    ConversationOutcome,
+    DispatcherToolDesk,
+    GaveUp,
+    LoopLimits,
+    LoopStep,
+    ModelRequest,
+    NoModelVoiceAvailable,
+    ScriptedToolDesk,
+    ScriptedVoice,
+    StopReason,
+    ToolOutcome,
+    real_model_voice,
+    run_model_conversation,
+)
+from core.agentic_v2_fixture_backend import AgenticV2FixtureBackend
+from core.agentic_v2_stage_one_budget import StageOneBudget
+from core.agentic_v2_tools import AgenticV2ToolDispatcher
+
+
+PROFILE = {
+    "tool_contract_version": "2.0",
+    "policy_profile_id": "offline-full-v1",
+    "foundation_only": True,
+}
+
+
+def a_budget(**changes) -> StageOneBudget:
+    settings = {
+        "max_model_calls": 16,
+        "max_input_tokens": 1_000_000,
+        "max_output_tokens": 200_000,
+    }
+    settings.update(changes)
+    return StageOneBudget(**settings)
+
+
+def limits(**changes) -> LoopLimits:
+    settings = {
+        "max_model_turns": 6,
+        "max_written_tokens_per_turn": 2048,
+        "max_seconds": 60.0,
+        "max_repeats_of_one_request": 2,
+        "budget": a_budget(),
+    }
+    settings.update(changes)
+    return LoopLimits(**settings)
+
+
+def ask(call_id: str, tool_name: str, /, **arguments) -> AskForTool:
+    return AskForTool(
+        call_id=call_id,
+        tool_name=tool_name,
+        arguments=arguments,
+        why=f"stand-in model asked for {tool_name}",
+        input_tokens=100,
+        output_tokens=20,
+    )
+
+
+def look_around(call_id: str = "call-1") -> AskForTool:
+    return ask(call_id, "capabilities_query", kind="commands")
+
+
+def run_a_command(call_id: str = "call-1") -> AskForTool:
+    return ask(
+        call_id,
+        "exec_run",
+        argv=["python", "-c", "print(1)"],
+        cwd=".",
+        timeout_seconds=60,
+    )
+
+
+def write_a_file(call_id: str = "call-2", path: str = "report.txt") -> AskForTool:
+    return ask(
+        call_id, "workspace_apply", operation="write", path=path, content="hello"
+    )
+
+
+def commit(call_id: str = "call-3", path: str = "report.txt") -> AskForTool:
+    return ask(call_id, "finalize", deliverables=[path], summary="done")
+
+
+def a_run(voice, desk, **limit_changes) -> ConversationOutcome:
+    return run_model_conversation(
+        task_prompt="write a short report",
+        voice=voice,
+        desk=desk,
+        limits=limits(**limit_changes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The behaviour stage one exists to measure
+# ---------------------------------------------------------------------------
+
+
+def test_the_model_is_asked_again_with_the_failure_in_front_of_it():
+    """The one thing stage one is for: react to a refusal, do not stop at it."""
+    voice = ScriptedVoice(replies=[
+        run_a_command("call-1"),
+        write_a_file("call-2"),
+        commit("call-3"),
+    ])
+    desk = ScriptedToolDesk(answers=[
+        ToolOutcome.refused("capability_unavailable"),
+        ToolOutcome.worked(bytes_written=5),
+        ToolOutcome.committed({"success": True, "text": "done", "files": []}),
+    ])
+
+    outcome = a_run(voice, desk)
+
+    assert outcome.stop_reason is StopReason.FINISHED_NORMALLY
+    assert outcome.produced_an_answer is True
+    second_request = voice.requests_seen[1]
+    assert second_request.history[0].error_type == "capability_unavailable"
+    assert second_request.history[0].ok is False
+    assert second_request.turn == 2
+
+
+def test_a_refusal_the_model_could_work_around_does_not_end_the_run():
+    voice = ScriptedVoice(replies=[
+        write_a_file("call-1", path="nowhere/report.txt"),
+        write_a_file("call-2"),
+        commit("call-3"),
+    ])
+    desk = ScriptedToolDesk(answers=[
+        ToolOutcome.refused("path_not_directory"),
+        ToolOutcome.worked(bytes_written=5),
+        ToolOutcome.committed({"success": True, "text": "done", "files": []}),
+    ])
+
+    outcome = a_run(voice, desk)
+
+    assert outcome.stop_reason is StopReason.FINISHED_NORMALLY
+    assert len(outcome.turns) == 3
+
+
+def test_asking_to_run_a_command_is_refused_and_the_command_never_runs():
+    """The unsupported capability, end to end, against the real dispatcher."""
+    voice = ScriptedVoice(replies=[run_a_command(), GaveUp(note="nothing left")])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.refused("capability_unavailable")])
+
+    outcome = a_run(voice, desk)
+
+    assert outcome.turns[0].tool_name == "exec_run"
+    assert outcome.turns[0].ok is False
+    assert outcome.turns[0].error_type == "capability_unavailable"
+    assert outcome.stop_reason is StopReason.MODEL_STOPPED_WITHOUT_FINISHING
+    assert outcome.produced_an_answer is False
+    assert outcome.final_result is None
+
+
+# ---------------------------------------------------------------------------
+# The ceilings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "absent, expected_phrase",
+    [
+        ("max_model_turns", "how many times the model may be asked"),
+        ("max_written_tokens_per_turn", "how much one reply may run to"),
+        ("max_seconds", "how long the whole run may take"),
+        ("budget", "what this run may cost"),
+        ("max_repeats_of_one_request", "how often the same request"),
+    ],
+)
+def test_a_missing_ceiling_refuses_the_run_before_anything_is_asked(
+    absent, expected_phrase
+):
+    """Missing is treated as exceeded. A default would only ever be consulted
+    on the run where somebody forgot, which is the run that must not go
+    unbounded."""
+    voice = ScriptedVoice(replies=[look_around()])
+    desk = ScriptedToolDesk()
+
+    outcome = a_run(voice, desk, **{absent: None})
+
+    assert outcome.stop_reason is StopReason.LIMIT_MISSING
+    assert expected_phrase in outcome.detail
+    assert voice.requests_seen == []
+    assert desk.calls == []
+
+
+def test_every_missing_ceiling_is_named_at_once():
+    outcome = run_model_conversation(
+        task_prompt="anything",
+        voice=ScriptedVoice(replies=[look_around()]),
+        desk=ScriptedToolDesk(),
+        limits=LoopLimits(),
+    )
+
+    assert outcome.stop_reason is StopReason.LIMIT_MISSING
+    assert outcome.detail.count(";") == 4
+
+
+@pytest.mark.parametrize("bad", [0, -1, True, "8", 8.5])
+def test_a_ceiling_that_is_not_a_positive_whole_number_is_missing(bad):
+    outcome = a_run(
+        ScriptedVoice(replies=[look_around()]),
+        ScriptedToolDesk(),
+        max_model_turns=bad,
+    )
+
+    assert outcome.stop_reason is StopReason.LIMIT_MISSING
+
+
+@pytest.mark.parametrize("bad", [0, -1.0, True, "60"])
+def test_a_time_ceiling_that_is_not_a_positive_number_is_missing(bad):
+    outcome = a_run(
+        ScriptedVoice(replies=[look_around()]),
+        ScriptedToolDesk(),
+        max_seconds=bad,
+    )
+
+    assert outcome.stop_reason is StopReason.LIMIT_MISSING
+
+
+def test_a_budget_that_is_not_a_budget_is_missing():
+    outcome = a_run(
+        ScriptedVoice(replies=[look_around()]),
+        ScriptedToolDesk(),
+        budget={"max_model_calls": 4},
+    )
+
+    assert outcome.stop_reason is StopReason.LIMIT_MISSING
+    assert "what this run may cost" in outcome.detail
+
+
+def test_the_run_stops_when_the_model_has_been_asked_all_the_times_allowed():
+    voice = ScriptedVoice(replies=[look_around(f"call-{n}") for n in range(10)])
+    desk = ScriptedToolDesk(
+        answers=[ToolOutcome.worked(kinds=[str(n)]) for n in range(10)]
+    )
+
+    outcome = a_run(voice, desk, max_model_turns=3, max_repeats_of_one_request=99)
+
+    assert outcome.stop_reason is StopReason.TURN_LIMIT_REACHED
+    assert outcome.stop_reason.is_a_limit is True
+    assert outcome.model_turns_used == 3
+    assert len(voice.requests_seen) == 3
+    assert "3 times, which is all the 3" in outcome.detail
+
+
+def test_a_reply_longer_than_one_turn_allows_stops_the_run():
+    voice = ScriptedVoice(replies=[
+        AskForTool(
+            call_id="call-1",
+            tool_name="capabilities_query",
+            arguments={"kind": "commands"},
+            input_tokens=100,
+            output_tokens=9000,
+        )
+    ])
+    desk = ScriptedToolDesk()
+
+    outcome = a_run(voice, desk, max_written_tokens_per_turn=2048)
+
+    assert outcome.stop_reason is StopReason.WRITING_LIMIT_REACHED
+    assert "9000 tokens in one turn" in outcome.detail
+    assert desk.calls == []
+
+
+def test_the_overlong_reply_is_still_charged_for_because_it_was_written():
+    budget = a_budget()
+    voice = ScriptedVoice(replies=[
+        AskForTool(
+            call_id="call-1",
+            tool_name="capabilities_query",
+            arguments={"kind": "commands"},
+            input_tokens=700,
+            output_tokens=9000,
+        )
+    ])
+
+    outcome = a_run(
+        voice, ScriptedToolDesk(), budget=budget, max_written_tokens_per_turn=2048
+    )
+
+    assert outcome.stop_reason is StopReason.WRITING_LIMIT_REACHED
+    assert budget.output_tokens_used == 9000
+    assert budget.input_tokens_used == 700
+
+
+def test_the_run_stops_when_it_has_taken_all_the_time_it_was_allowed():
+    ticks = iter([0.0, 0.0, 0.5, 9.0])
+    voice = ScriptedVoice(replies=[look_around("call-1"), look_around("call-2")])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(kinds=["a"])])
+
+    outcome = run_model_conversation(
+        task_prompt="anything",
+        voice=voice,
+        desk=desk,
+        limits=limits(max_seconds=5.0),
+        clock=lambda: next(ticks),
+    )
+
+    assert outcome.stop_reason is StopReason.TIME_LIMIT_REACHED
+    assert "which is all the 5.000 it was allowed" in outcome.detail
+    assert len(voice.requests_seen) == 1
+    assert len(desk.calls) == 1
+
+
+def test_running_out_of_time_between_the_reply_and_the_tool_stops_the_run():
+    """The tool is not run once the clock has gone, even though it was asked
+    for."""
+    ticks = iter([0.0, 0.0, 9.0])
+    voice = ScriptedVoice(replies=[look_around("call-1")])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(kinds=["a"])])
+
+    outcome = run_model_conversation(
+        task_prompt="anything",
+        voice=voice,
+        desk=desk,
+        limits=limits(max_seconds=5.0),
+        clock=lambda: next(ticks),
+    )
+
+    assert outcome.stop_reason is StopReason.TIME_LIMIT_REACHED
+    assert len(voice.requests_seen) == 1
+    assert desk.calls == []
+
+
+def test_the_run_stops_before_a_call_it_can_no_longer_afford():
+    budget = a_budget(max_model_calls=2)
+    voice = ScriptedVoice(replies=[look_around(f"call-{n}") for n in range(5)])
+    desk = ScriptedToolDesk(
+        answers=[ToolOutcome.worked(kinds=[str(n)]) for n in range(5)]
+    )
+
+    outcome = a_run(voice, desk, budget=budget, max_repeats_of_one_request=99)
+
+    assert outcome.stop_reason is StopReason.COST_LIMIT_REACHED
+    assert len(voice.requests_seen) == 2
+    assert "all the 2 it was allowed" in outcome.detail
+
+
+def test_a_single_reply_that_overspends_stops_the_run_rather_than_reporting_it():
+    budget = a_budget(max_output_tokens=100)
+    voice = ScriptedVoice(replies=[
+        AskForTool(
+            call_id="call-1",
+            tool_name="capabilities_query",
+            arguments={"kind": "commands"},
+            input_tokens=10,
+            output_tokens=90,
+        ),
+        AskForTool(
+            call_id="call-2",
+            tool_name="capabilities_query",
+            arguments={"kind": "runtimes"},
+            input_tokens=10,
+            output_tokens=90,
+        ),
+    ])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(kinds=["a"])])
+
+    outcome = a_run(voice, desk, budget=budget)
+
+    assert outcome.stop_reason is StopReason.COST_LIMIT_REACHED
+    assert "180 tokens received against a limit of 100" in outcome.detail
+    assert len(desk.calls) == 1
+
+
+def test_the_cost_ceiling_is_checked_before_the_call_not_after_it():
+    budget = a_budget(max_input_tokens=100)
+    voice = ScriptedVoice(replies=[look_around("call-1"), look_around("call-2")])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(kinds=["a"])])
+
+    outcome = a_run(voice, desk, budget=budget)
+
+    assert outcome.stop_reason is StopReason.COST_LIMIT_REACHED
+    assert budget.model_calls_made == 1
+    assert "already sent 100 tokens" in outcome.detail
+
+
+# ---------------------------------------------------------------------------
+# Going in circles
+# ---------------------------------------------------------------------------
+
+
+def test_asking_for_the_same_thing_over_and_over_stops_the_run():
+    voice = ScriptedVoice(replies=[
+        ask("call-1", "capabilities_query", kind="commands"),
+        ask("call-2", "capabilities_query", kind="commands"),
+        ask("call-3", "capabilities_query", kind="commands"),
+    ])
+    desk = ScriptedToolDesk(
+        answers=[ToolOutcome.worked(kinds=["a"]) for _ in range(3)]
+    )
+
+    outcome = a_run(voice, desk, max_repeats_of_one_request=2)
+
+    assert outcome.stop_reason is StopReason.REPEATED_REQUEST
+    assert "going in circles" in outcome.detail
+    assert len(desk.calls) == 2
+
+
+def test_a_fresh_call_identifier_does_not_disguise_the_same_request():
+    """Counted on what was asked, not on the label attached to it."""
+    voice = ScriptedVoice(replies=[
+        ask("first", "capabilities_query", kind="commands"),
+        ask("second", "capabilities_query", kind="commands"),
+    ])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(kinds=["a"])])
+
+    outcome = a_run(voice, desk, max_repeats_of_one_request=1)
+
+    assert outcome.stop_reason is StopReason.REPEATED_REQUEST
+    assert len(desk.calls) == 1
+
+
+def test_different_arguments_are_not_a_repeat():
+    voice = ScriptedVoice(replies=[
+        ask("call-1", "capabilities_query", kind="commands"),
+        ask("call-2", "capabilities_query", kind="runtimes"),
+        commit("call-3"),
+    ])
+    desk = ScriptedToolDesk(answers=[
+        ToolOutcome.worked(kinds=["a"]),
+        ToolOutcome.worked(kinds=["b"]),
+        ToolOutcome.committed({"success": True, "text": "done", "files": []}),
+    ])
+
+    outcome = a_run(voice, desk, max_repeats_of_one_request=1)
+
+    assert outcome.stop_reason is StopReason.FINISHED_NORMALLY
+
+
+def test_a_repeat_the_dispatcher_replayed_is_recorded_as_replayed():
+    voice = ScriptedVoice(replies=[
+        ask("call-1", "capabilities_query", kind="commands"),
+        ask("call-1", "capabilities_query", kind="commands"),
+        GaveUp(note="stuck"),
+    ])
+    desk = ScriptedToolDesk(answers=[
+        ToolOutcome.worked(kinds=["a"]),
+        ToolOutcome(ok=True, data={"kinds": ["a"]}, replayed=True),
+    ])
+
+    outcome = a_run(voice, desk, max_repeats_of_one_request=2)
+
+    assert [record.replayed for record in outcome.turns] == [False, True]
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+
+def test_a_run_asked_to_stop_never_asks_the_model():
+    voice = ScriptedVoice(replies=[look_around()])
+    desk = ScriptedToolDesk()
+
+    outcome = run_model_conversation(
+        task_prompt="anything",
+        voice=voice,
+        desk=desk,
+        limits=limits(),
+        cancel_requested=lambda: True,
+    )
+
+    assert outcome.stop_reason is StopReason.CANCELLED
+    assert voice.requests_seen == []
+    assert outcome.turns == ()
+
+
+def test_a_run_asked_to_stop_mid_turn_does_not_run_the_tool():
+    answers = iter([False, True])
+    voice = ScriptedVoice(replies=[look_around()])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(kinds=["a"])])
+
+    outcome = run_model_conversation(
+        task_prompt="anything",
+        voice=voice,
+        desk=desk,
+        limits=limits(),
+        cancel_requested=lambda: next(answers),
+    )
+
+    assert outcome.stop_reason is StopReason.CANCELLED
+    assert len(voice.requests_seen) == 1
+    assert desk.calls == []
+    assert "before the tool was run" in outcome.detail
+
+
+def test_a_tool_desk_reporting_cancellation_ends_the_run():
+    voice = ScriptedVoice(replies=[look_around(), look_around("call-2")])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.refused("cancelled")])
+
+    outcome = a_run(voice, desk)
+
+    assert outcome.stop_reason is StopReason.CANCELLED
+    assert len(voice.requests_seen) == 1
+
+
+# ---------------------------------------------------------------------------
+# Replies that cannot be used
+# ---------------------------------------------------------------------------
+
+
+class BrokenVoice:
+    makes_paid_calls = False
+
+    def __init__(self, reply):
+        self.reply = reply
+        self.times_asked = 0
+
+    def next_turn(self, request: ModelRequest):
+        self.times_asked += 1
+        return self.reply
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        None,
+        "capabilities_query",
+        {"tool_name": "capabilities_query"},
+        42,
+        [],
+    ],
+)
+def test_a_reply_that_is_not_a_reply_at_all_stops_the_run(reply):
+    voice = BrokenVoice(reply)
+    desk = ScriptedToolDesk()
+
+    outcome = a_run(voice, desk)
+
+    assert outcome.stop_reason is StopReason.MODEL_REPLY_UNUSABLE
+    assert desk.calls == []
+
+
+@pytest.mark.parametrize(
+    "usage",
+    [
+        {"input_tokens": -1, "output_tokens": 10},
+        {"input_tokens": 10, "output_tokens": -5},
+        {"input_tokens": True, "output_tokens": 10},
+        {"input_tokens": 1.5, "output_tokens": 10},
+        {"input_tokens": "100", "output_tokens": 10},
+    ],
+)
+def test_a_reply_that_does_not_say_what_it_used_stops_the_run(usage):
+    voice = BrokenVoice(AskForTool(
+        call_id="call-1",
+        tool_name="capabilities_query",
+        arguments={"kind": "commands"},
+        **usage,
+    ))
+
+    outcome = a_run(voice, ScriptedToolDesk())
+
+    assert outcome.stop_reason is StopReason.MODEL_REPLY_UNUSABLE
+    assert "cannot be charged for" in outcome.detail
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"call_id": ""},
+        {"call_id": None},
+        {"call_id": 7},
+        {"tool_name": ""},
+        {"tool_name": None},
+        {"tool_name": ["capabilities_query"]},
+        {"arguments": None},
+        {"arguments": "kind=commands"},
+        {"arguments": [("kind", "commands")]},
+        {"arguments": {1: "commands"}},
+    ],
+)
+def test_a_tool_request_missing_what_it_needs_stops_the_run(changes):
+    settings = {
+        "call_id": "call-1",
+        "tool_name": "capabilities_query",
+        "arguments": {"kind": "commands"},
+        "input_tokens": 10,
+        "output_tokens": 10,
+    }
+    settings.update(changes)
+
+    outcome = a_run(BrokenVoice(AskForTool(**settings)), ScriptedToolDesk())
+
+    assert outcome.stop_reason is StopReason.MODEL_REPLY_UNUSABLE
+    assert "not a usable tool request" in outcome.detail
+
+
+def test_a_model_that_raises_stops_the_run_rather_than_the_process():
+    class ExplodingVoice:
+        makes_paid_calls = False
+
+        def next_turn(self, request):
+            raise TimeoutError("the model never answered")
+
+    outcome = a_run(ExplodingVoice(), ScriptedToolDesk())
+
+    assert outcome.stop_reason is StopReason.MODEL_REPLY_UNUSABLE
+    assert "TimeoutError" in outcome.detail
+
+
+def test_a_model_that_walks_away_is_not_recorded_as_a_success():
+    voice = ScriptedVoice(replies=[GaveUp(note="I cannot do this")])
+
+    outcome = a_run(voice, ScriptedToolDesk())
+
+    assert outcome.stop_reason is StopReason.MODEL_STOPPED_WITHOUT_FINISHING
+    assert outcome.produced_an_answer is False
+    assert "I cannot do this" in outcome.detail
+
+
+def test_a_model_that_runs_out_of_things_to_say_ends_the_run():
+    voice = ScriptedVoice(replies=[])
+
+    outcome = a_run(voice, ScriptedToolDesk())
+
+    assert outcome.stop_reason is StopReason.MODEL_STOPPED_WITHOUT_FINISHING
+    assert "ran out of written replies" in outcome.detail
+
+
+# ---------------------------------------------------------------------------
+# A tool desk that is not working
+# ---------------------------------------------------------------------------
+
+
+class BrokenDesk:
+    def __init__(self, answer=None, raises=None):
+        self.answer = answer
+        self.raises = raises
+        self.calls: list = []
+
+    def run_one(self, *, call_id, tool_name, arguments):
+        self.calls.append((call_id, tool_name, dict(arguments)))
+        if self.raises is not None:
+            raise self.raises
+        return self.answer
+
+
+def test_a_tool_desk_that_raises_stops_the_run():
+    desk = BrokenDesk(raises=OSError("the workspace disappeared"))
+
+    outcome = a_run(ScriptedVoice(replies=[look_around()]), desk)
+
+    assert outcome.stop_reason is StopReason.TOOL_DESK_BROKE
+    assert "OSError" in outcome.detail
+
+
+@pytest.mark.parametrize("answer", [None, {"ok": True}, "ok", 1])
+def test_a_tool_desk_answering_with_something_else_stops_the_run(answer):
+    outcome = a_run(ScriptedVoice(replies=[look_around()]), BrokenDesk(answer))
+
+    assert outcome.stop_reason is StopReason.TOOL_DESK_BROKE
+    assert "not a tool outcome" in outcome.detail
+
+
+@pytest.mark.parametrize(
+    "error_type",
+    [
+        "compute_backend_error",
+        "compute_cleanup_failed",
+        "compute_start_failed",
+        "fixture_backend_error",
+        "invalid_backend_result",
+        "invalid_backend_state",
+        "invalid_lifecycle_transition",
+        "invalid_result_envelope",
+        "runner_internal_error",
+        "substrate_manifest_missing",
+    ],
+)
+def test_a_broken_desk_is_not_something_the_model_is_asked_to_work_around(
+    error_type,
+):
+    voice = ScriptedVoice(replies=[look_around(), look_around("call-2")])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.refused(error_type)])
+
+    outcome = a_run(voice, desk)
+
+    assert outcome.stop_reason is StopReason.TOOL_DESK_BROKE
+    assert len(voice.requests_seen) == 1
+
+
+def test_a_committed_answer_with_nothing_in_it_is_refused():
+    voice = ScriptedVoice(replies=[commit("call-1")])
+    desk = ScriptedToolDesk(answers=[ToolOutcome(ok=True, finished=True)])
+
+    outcome = a_run(voice, desk)
+
+    assert outcome.stop_reason is StopReason.TOOL_DESK_BROKE
+    assert "no answer" in outcome.detail
+    assert outcome.final_result is None
+
+
+def test_the_desk_running_out_of_its_own_call_budget_ends_the_run():
+    voice = ScriptedVoice(replies=[look_around(), look_around("call-2")])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.refused("tool_budget_exhausted")])
+
+    outcome = a_run(voice, desk)
+
+    assert outcome.stop_reason is StopReason.TOOL_CALL_LIMIT_REACHED
+    assert outcome.stop_reason.is_a_limit is True
+
+
+# ---------------------------------------------------------------------------
+# Nothing paid, nothing switched on, nothing swapped out
+# ---------------------------------------------------------------------------
+
+
+def test_there_is_no_way_to_reach_a_real_model():
+    with pytest.raises(NoModelVoiceAvailable) as raised:
+        real_model_voice()
+
+    assert "no amount has been approved" in str(raised.value)
+
+
+def test_a_model_that_would_be_charged_for_is_refused_before_being_asked():
+    voice = ScriptedVoice(replies=[look_around()], makes_paid_calls=True)
+
+    outcome = a_run(voice, ScriptedToolDesk())
+
+    assert outcome.stop_reason is StopReason.PAID_CALL_REFUSED
+    assert voice.requests_seen == []
+
+
+def test_a_model_that_does_not_say_whether_it_is_paid_is_refused():
+    """Fail shut. A voice that forgot to declare itself is treated as paid."""
+
+    class SilentVoice:
+        def next_turn(self, request):  # pragma: no cover - never reached
+            raise AssertionError("the loop must not ask an undeclared model")
+
+    outcome = a_run(SilentVoice(), ScriptedToolDesk())
+
+    assert outcome.stop_reason is StopReason.PAID_CALL_REFUSED
+
+
+def test_the_paid_refusal_comes_before_anything_else_is_checked():
+    voice = ScriptedVoice(replies=[look_around()], makes_paid_calls=True)
+
+    outcome = run_model_conversation(
+        task_prompt="anything",
+        voice=voice,
+        desk=ScriptedToolDesk(),
+        limits=LoopLimits(),
+    )
+
+    assert outcome.stop_reason is StopReason.PAID_CALL_REFUSED
+
+
+def test_the_loop_cannot_reach_any_other_way_of_running_a_task():
+    """No quiet substitution: the module cannot name another run place, so it
+    cannot fall back to one when a task fails."""
+    import core.agentic_v2_conversation as loop_module
+
+    source = pathlib.Path(loop_module.__file__).read_text(encoding="utf-8")
+    imported: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+
+    forbidden = {
+        "core.executor",
+        "core.subprocess_runner",
+        "core.code_interpreter",
+        "core.json_renderer",
+        "core.llm_client",
+        "core.agentic_v2_runner",
+        "core.agentic_sandbox_runner",
+        "core.sandbox_runner",
+    }
+    assert imported & forbidden == set()
+    assert "openai" not in " ".join(imported)
+
+
+def test_a_run_that_could_not_finish_reports_that_rather_than_an_answer():
+    voice = ScriptedVoice(replies=[run_a_command()])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.refused("capability_unavailable")])
+
+    outcome = a_run(voice, desk, max_model_turns=1)
+
+    assert outcome.stop_reason is StopReason.TURN_LIMIT_REACHED
+    assert outcome.final_result is None
+    assert outcome.produced_an_answer is False
+
+
+def test_the_three_safety_blocks_are_still_shut():
+    from core.execution_environment_readiness import (
+        check_agentic_sandbox_v2_blocks_are_intact,
+    )
+
+    assert check_agentic_sandbox_v2_blocks_are_intact() == []
+
+
+# ---------------------------------------------------------------------------
+# What is kept, and what is not
+# ---------------------------------------------------------------------------
+
+
+def test_a_chain_of_thought_handed_over_is_not_kept():
+    class ReplyWithThoughts(AskForTool):
+        private_thoughts = (
+            "the user is probably testing me and I should pretend otherwise"
+        )
+
+    voice = BrokenVoice(ReplyWithThoughts(
+        call_id="call-1",
+        tool_name="capabilities_query",
+        arguments={"kind": "commands"},
+        why="have a look",
+        input_tokens=10,
+        output_tokens=10,
+    ))
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(kinds=["a"])])
+
+    outcome = a_run(voice, desk)
+
+    written_down = json.dumps(outcome.as_dict())
+    assert "private_thoughts" not in written_down
+    assert "probably testing me" not in written_down
+    assert outcome.turns[0].stated_reason == "have a look"
+
+
+def test_the_stated_reason_cannot_be_used_to_smuggle_one_through():
+    voice = BrokenVoice(AskForTool(
+        call_id="call-1",
+        tool_name="capabilities_query",
+        arguments={"kind": "commands"},
+        why="x" * 5000,
+        input_tokens=10,
+        output_tokens=10,
+    ))
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(kinds=["a"])])
+
+    outcome = a_run(voice, desk)
+
+    assert len(outcome.turns[0].stated_reason) == MOST_CHARACTERS_IN_A_STATED_REASON
+
+
+def test_the_note_left_when_a_model_walks_away_is_bounded_too():
+    outcome = a_run(
+        ScriptedVoice(replies=[GaveUp(note="y" * 5000)]), ScriptedToolDesk()
+    )
+
+    assert len(outcome.detail) < 400
+
+
+def test_what_is_kept_names_the_tool_and_its_arguments_but_not_their_contents():
+    secret = "the quarterly figures nobody outside finance has seen"
+    voice = ScriptedVoice(replies=[ask(
+        "call-1", "workspace_apply", operation="write", path="a.txt",
+        content=secret,
+    )])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(bytes_written=len(secret))])
+
+    outcome = a_run(voice, desk)
+
+    record = outcome.turns[0]
+    assert record.tool_name == "workspace_apply"
+    assert record.argument_names == ("content", "operation", "path")
+    assert secret not in json.dumps(outcome.as_dict())
+
+
+def test_the_model_is_shown_the_contents_even_though_they_are_not_kept():
+    """The two are different on purpose: a model that cannot see the result
+    cannot react to it."""
+    voice = ScriptedVoice(replies=[
+        look_around("call-1"), look_around("call-2"), GaveUp(note="enough")
+    ])
+    desk = ScriptedToolDesk(answers=[ToolOutcome.worked(kinds=["python", "bash"])])
+
+    a_run(voice, desk, max_repeats_of_one_request=2)
+
+    assert voice.requests_seen[1].history[0].data == {"kinds": ["python", "bash"]}
+
+
+def test_every_point_the_run_passed_through_is_written_down_in_order():
+    voice = ScriptedVoice(replies=[
+        run_a_command("call-1"), write_a_file("call-2"), commit("call-3")
+    ])
+    desk = ScriptedToolDesk(answers=[
+        ToolOutcome.refused("capability_unavailable"),
+        ToolOutcome.worked(bytes_written=5),
+        ToolOutcome.committed({"success": True, "text": "done", "files": []}),
+    ])
+
+    outcome = a_run(voice, desk)
+
+    steps = [event.step for event in outcome.events]
+    assert steps[:5] == [
+        LoopStep.MODEL_ASKED,
+        LoopStep.MODEL_REPLIED,
+        LoopStep.TOOL_REQUESTED,
+        LoopStep.TOOL_ANSWERED,
+        LoopStep.NEXT_TURN,
+    ]
+    assert steps[-1] is LoopStep.STOPPED
+    assert steps.count(LoopStep.NEXT_TURN) == 2
+    assert outcome.events[-1].detail["stop_reason"] == "finished_normally"
+
+
+def test_a_reply_that_arrived_is_written_down_even_when_it_ends_the_run():
+    budget = a_budget(max_output_tokens=5)
+    voice = ScriptedVoice(replies=[look_around()])
+
+    outcome = a_run(voice, ScriptedToolDesk(), budget=budget)
+
+    assert outcome.stop_reason is StopReason.COST_LIMIT_REACHED
+    steps = [event.step for event in outcome.events]
+    assert steps == [
+        LoopStep.MODEL_ASKED, LoopStep.MODEL_REPLIED, LoopStep.STOPPED
+    ]
+
+
+def test_every_ending_is_named_and_only_one_of_them_is_an_answer():
+    answers = [
+        reason for reason in StopReason if reason.produced_an_answer
+    ]
+    assert answers == [StopReason.FINISHED_NORMALLY]
+    assert StopReason.FINISHED_NORMALLY.is_a_limit is False
+    assert StopReason.TOOL_DESK_BROKE.is_a_limit is False
+
+
+def test_what_is_kept_can_be_written_out_as_it_stands():
+    voice = ScriptedVoice(replies=[look_around(), commit("call-2")])
+    desk = ScriptedToolDesk(answers=[
+        ToolOutcome.worked(kinds=["a"]),
+        ToolOutcome.committed({"success": True, "text": "done", "files": []}),
+    ])
+
+    outcome = a_run(voice, desk)
+    written = json.loads(json.dumps(outcome.as_dict()))
+
+    assert written["stop_reason"] == "finished_normally"
+    assert written["model_turns_used"] == 2
+    assert len(written["turns"]) == 2
+    assert written["budget_after"]["model_calls_made"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Against the real dispatcher, with commands still shut
+# ---------------------------------------------------------------------------
+
+
+def a_real_desk(tmp_path, **changes) -> DispatcherToolDesk:
+    backend = AgenticV2FixtureBackend(
+        root=tmp_path, profile=AgenticV2Profile.from_mapping(PROFILE)
+    )
+    settings = {"max_total_calls": 8}
+    settings.update(changes)
+    return DispatcherToolDesk(AgenticV2ToolDispatcher(
+        backend, AgenticV2Lifecycle(LifecycleState.ACTIVE), **settings
+    ))
+
+
+def test_the_real_dispatcher_still_refuses_to_run_a_command(tmp_path):
+    voice = ScriptedVoice(replies=[run_a_command(), GaveUp(note="nothing else")])
+
+    outcome = a_run(voice, a_real_desk(tmp_path))
+
+    assert outcome.turns[0].error_type == "capability_unavailable"
+    assert outcome.stop_reason is StopReason.MODEL_STOPPED_WITHOUT_FINISHING
+
+
+def test_the_real_dispatcher_checks_the_arguments_it_is_given(tmp_path):
+    voice = ScriptedVoice(replies=[
+        ask("call-1", "capabilities_query", kind="nonsense"),
+        GaveUp(note="that was wrong"),
+    ])
+
+    outcome = a_run(voice, a_real_desk(tmp_path))
+
+    assert outcome.turns[0].error_type == "invalid_arguments"
+
+
+def test_a_tool_the_contract_does_not_have_is_refused(tmp_path):
+    voice = ScriptedVoice(replies=[
+        ask("call-1", "delete_everything", path="/"),
+        GaveUp(note="not allowed then"),
+    ])
+
+    outcome = a_run(voice, a_real_desk(tmp_path))
+
+    assert outcome.turns[0].error_type == "unknown_tool"
+    assert outcome.turns[0].ok is False
+
+
+def test_the_run_stops_at_the_dispatchers_own_call_ceiling(tmp_path):
+    """The second test section 9 of the specification asks for."""
+    voice = ScriptedVoice(replies=[
+        ask(f"call-{n}", "capabilities_query", kind=kind)
+        for n, kind in enumerate(
+            ["commands", "runtimes", "packages", "formats", "budgets"]
+        )
+    ])
+
+    outcome = a_run(voice, a_real_desk(tmp_path, max_total_calls=2))
+
+    assert outcome.stop_reason is StopReason.TOOL_CALL_LIMIT_REACHED
+    assert len(outcome.turns) == 3
+    assert [record.ok for record in outcome.turns] == [True, True, False]
+
+
+def test_a_real_run_writes_a_file_and_commits_it(tmp_path):
+    voice = ScriptedVoice(replies=[
+        run_a_command("call-1"),
+        write_a_file("call-2"),
+        commit("call-3"),
+    ])
+
+    outcome = a_run(voice, a_real_desk(tmp_path))
+
+    assert outcome.stop_reason is StopReason.FINISHED_NORMALLY
+    assert outcome.final_result is not None
+    assert outcome.final_result["success"] is True
+    assert outcome.final_result["deliverable_text"] == "done"
+    assert [file["filename"] for file in outcome.final_result["files"]] == [
+        "report.txt"
+    ]
+    assert all(record.result_sha256 for record in outcome.turns)
+
+
+def test_a_real_repeat_is_replayed_rather_than_run_twice(tmp_path):
+    voice = ScriptedVoice(replies=[
+        write_a_file("call-1"),
+        write_a_file("call-1"),
+        GaveUp(note="done poking"),
+    ])
+
+    outcome = a_run(voice, a_real_desk(tmp_path), max_repeats_of_one_request=2)
+
+    assert [record.replayed for record in outcome.turns] == [False, True]
+    assert outcome.turns[0].result_sha256 == outcome.turns[1].result_sha256
+
+
+def test_the_tools_offered_are_the_ones_the_contract_publishes():
+    voice = ScriptedVoice(replies=[GaveUp(note="just looking")])
+
+    a_run(voice, ScriptedToolDesk())
+
+    assert voice.requests_seen[0].tools_available == tuple(TOOL_NAMES)

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
@@ -45,11 +45,15 @@ isolated virtual machine and refuses to validate without that policy.
    test case that copies a file and converts it to capital letters. Nothing real
    can be run.
 
-2. **The model is never asked anything.** `core/agentic_v2_runner.py` replays a
-   list of calls written down in advance. It has a `scripted_calls` input and no
-   model client at all. The state machine can be exercised, but no model ever
-   sees a result and chooses what to do next, which is the entire point of this
-   run place.
+2. **No real model can be asked anything.** The loop now exists:
+   `core/agentic_v2_conversation.py` asks a model, runs the tool it asked for,
+   shows it the result, and asks again, under five ceilings checked before each
+   call. It is proven against stand-in models that spend nothing. What it
+   cannot do is reach a real model: `real_model_voice()` refuses, and the loop
+   refuses any model that declares itself paid before asking it anything.
+   `core/agentic_v2_runner.py` is untouched and still replays a list of calls
+   written down in advance, with no model client at all — the loop was added
+   beside it rather than inside it, so nothing that runs today changed.
 
 3. **Two separate guards refuse the mode outright.**
    `step2_run_inference._require_runnable_execution_mode` rejects it, and
@@ -92,6 +96,9 @@ while leaving `exec_run` shut. The model can look at the workspace, resolve
 packages, and finish, but it cannot run a command. This proves the loop works —
 the model reads a result and picks a next action — without the risky capability.
 It is enough to answer "does asking the model repeatedly help at all?"
+*The loop is built (`core/agentic_v2_conversation.py`) and proven against
+stand-ins. Asking a real model needs an approved amount and the removal of a
+deliberate refusal; neither has happened.*
 
 **Stage two — write down the containment, and prove it separately.**
 Before any command runs, state what the command may touch: which directory,
@@ -118,7 +125,8 @@ the loop is worth having.
 
 | File | Role |
 |---|---|
-| `batch-runner/core/agentic_v2_runner.py` | Stage one: gains a real conversation with the model in place of the replayed list. |
+| `batch-runner/core/agentic_v2_conversation.py` | Stage one, **built**: the loop that asks the model, runs the tool it chose, shows it the result, and asks again. Reaches no real model. |
+| `batch-runner/core/agentic_v2_runner.py` | Unchanged. Still replays the written-down list; the loop was added beside it, not inside it. |
 | `batch-runner/core/agentic_v2_tools.py` | Unchanged surface; the ceilings it already applies become the loop's limits. |
 | `batch-runner/core/agentic_v2_fixture_backend.py` | Stays shut through stages one and two. |
 | `batch-runner/core/agentic_v2_substrate.py` | Stage two: the containment rules are stated and checked here. |
@@ -231,21 +239,32 @@ loop that has already overspent has lost track of what it is doing.
 
 ### What is still missing before stage one could run
 
-The money is the smaller of the two blockers, and saying so plainly matters more
-than the numbers above.
+The money is now the larger of the two blockers, which is a change from where
+this section started.
 
-`core/agentic_v2_runner.py` still replays a list of calls written down in
-advance and holds no model client at all. The thing stage one is *about* — the
-model being asked again with a tool result in front of it — does not exist. The
-free check reports this first, before it reports anything about money, and it
-establishes it by looking at what the runner accepts rather than by reading a
-comment, so the answer will change by itself when the conversation is built.
+The loop itself is built. `core/agentic_v2_conversation.py` asks a model, runs
+the tool it asked for, shows it what came back, and asks again, with every
+ceiling checked before the next call and every way of stopping named. What is
+missing is narrower: nothing here can reach a *real* model.
+`real_model_voice()` refuses, and the loop refuses any model that declares
+itself paid before asking it anything. The free check still reports this first,
+before it reports anything about money, and it now establishes it by *running*
+both refusals rather than by reading what the runner accepts — so the answer
+will change by itself the day somebody wires a real client in.
+
+`core/agentic_v2_runner.py` is unchanged and still replays a written-down list.
+That was left alone on purpose: the loop is a separate module, so nothing that
+runs today changed behaviour, and the existing runner's tests still hold.
 
 ## 8. Order the work would be done in
 
-1. Work out and get approval for the cost ceiling of a small stage-one run.
-2. Build the model conversation with `exec_run` still shut.
-3. Measure whether choosing tools helps, on the same five tasks.
+1. ~~Work out and get approval for the cost ceiling of a small stage-one run.~~
+   Worked out (section 7a). **Approval still outstanding.**
+2. ~~Build the model conversation with `exec_run` still shut.~~ Built:
+   `core/agentic_v2_conversation.py`, proven against stand-ins that spend
+   nothing. `exec_run` is still shut, and the loop cannot reach a real model.
+3. Measure whether choosing tools helps, on the same five tasks. **Needs an
+   approved amount and a way to reach a real model.**
 4. Write the containment rules and the tests that try to break them.
 5. Seek approval for command execution, presenting those test results.
 6. Only then, open `exec_run`.
@@ -256,29 +275,38 @@ comment, so the answer will change by itself when the conversation is built.
 
 - Stage one: a test that gives the model a task whose first attempt must fail,
   and requires that the model be asked again with the failure in front of it.
+  **Done:**
+  `tests/test_agentic_v2_conversation.py::test_the_model_is_asked_again_with_the_failure_in_front_of_it`.
 - Stage one: a test that the run stops at the dispatcher's call ceiling rather
-  than continuing indefinitely.
+  than continuing indefinitely. **Done:**
+  `tests/test_agentic_v2_conversation.py::test_the_run_stops_at_the_dispatchers_own_call_ceiling`.
 - Stage two: one test per containment rule, each attempting to exceed it and
   requiring failure.
 - All stages: the existing test that opens all three guards and requires them
-  shut must keep passing until the stage that deliberately changes one.
+  shut must keep passing until the stage that deliberately changes one. **Still
+  passing**, and the loop's own test suite runs all three blocks as well.
 
 ## 10. Done when
 
-- [ ] The model chooses its own next action, and a test proves it reacts to a
-      failure it was shown.
+- [x] The model chooses its own next action, and a test proves it reacts to a
+      failure it was shown. (Against a stand-in model. A real one is still out
+      of reach and needs an approved amount.)
 - [ ] Every containment rule has a test that tries to exceed it and fails.
 - [ ] Command execution is opened only after a separate written approval.
 - [ ] The free check reports this run place as able to run only when it is.
 
 ## 11. Known blockers and the next decision
 
-- **Blocked on the model conversation, which does not exist.** This is the
-  larger blocker and it is free to remove: `core/agentic_v2_runner.py` replays a
-  written-down list and holds no model client. Until that changes, no amount of
-  approved money lets stage one start.
-- **Blocked on approval to call a model in a loop.** The ceiling has now been
-  worked out (section 7a) and nothing has been approved against it.
+- **Blocked on there being no way to reach a real model.** This is now the
+  smaller blocker. The loop exists at
+  `core/agentic_v2_conversation.run_model_conversation` and is proven against
+  stand-ins that spend nothing, but `real_model_voice` refuses and the loop
+  refuses any model that would be charged for. That refusal is deliberate: it
+  means a paid run cannot start until somebody removes it in a change a
+  reviewer will see, alongside approving the amount.
+- **Blocked on approval to call a model in a loop.** This is now the larger
+  blocker. The ceiling has been worked out (section 7a) and nothing has been
+  approved against it.
   `experiments/execution_envelope/agentic_stage_one_plan.yaml` leaves the amount
   empty on purpose, and the free check refuses while it is empty. The 32.23
   United States dollars approved on 2026-08-25 was for the three-place
@@ -294,5 +322,6 @@ could still answer the question is four tool calls with a 2,048-token cap per
 turn, at most 3.24 to run and 5.85 to mark, so 9.09 in total. The dispatcher's
 own defaults are 492.67 to run.
 
-Choosing a row does not start anything. The model conversation still has to be
-built first, and that is the next piece of work either way.
+Choosing a row does not start anything, and neither figure above is an approved
+amount. Approving one, and removing the refusal that keeps a real model out of
+the loop, are two separate steps and both are the owner's to take.


### PR DESCRIPTION
## 한 줄 요약

**모델에게 반복해서 물어보는 기능을 만들었습니다.** 지금까지는 미리 적어둔 도구 호출 목록을 그대로 재생할 뿐이었고, 모델이 스스로 다음 행동을 고르는 부분이 아예 없었습니다. 그 부분을 만들었습니다. **돈은 한 푼도 쓰지 않았고, 실제 모델에 연결할 방법은 일부러 막아 두었습니다.**

## 무엇이 달라졌나

### 전에는

`core/agentic_v2_runner.py`가 **미리 적어둔 도구 호출 목록을 순서대로 재생**했습니다. 이걸 돌리면 "도구가 잘 작동한다"는 것은 알 수 있지만, "모델이 도구를 고를 줄 안다"는 것은 알 수 없었습니다. Agentic Sandbox V2 1단계가 답하려던 질문이 바로 그 두 번째 것이었는데, 그 기능 자체가 없었습니다.

### 지금은

`batch-runner/core/agentic_v2_conversation.py`가 그 반복을 합니다.

> 모델에게 묻는다 → 모델이 고른 도구를 실행한다 → 결과를 모델에게 보여준다 → 다시 묻는다

각 단계와 **끝나는 모든 방식**에 이름을 붙였습니다. "어쩌다 보니 끝났다"가 없습니다.

## 이 기능이 지키는 세 가지

각각을 자동 테스트로 고정했습니다.

### 1. 한도 없는 반복은 반복이 아니라 새는 구멍이다

다섯 가지 한도를 **다음 호출을 하기 전에** 확인합니다.

| 한도 | 무엇을 막나 |
|---|---|
| 반복 횟수 | 끝나지 않는 대화 |
| 한 번에 쓸 수 있는 길이 | 한 턴에 폭주하는 응답 |
| 전체 걸린 시간 | 멈추지 않는 실행 |
| 비용 | 승인 금액 초과 |
| 같은 요청 반복 횟수 | 제자리를 도는 대화 |

다섯 중 **하나라도 정해지지 않았으면 실행을 거부**합니다. 한도가 없다고 무제한으로 돌지 않습니다.

마지막 항목은 지시에 있던 "중복 도구 호출"에 해당합니다. 모델이 같은 것을 계속 요청하면 진전 없이 요금만 쌓이므로, 정해진 횟수를 넘으면 멈춥니다. 호출 번호를 새로 붙여도 요청 내용이 같으면 같은 것으로 셉니다.

### 2. 모델에게 보여준 실패는 반복 기능의 실패가 아니다

도구가 거절한 결과는 **모델에게 돌려주고 계속 진행**합니다. "이 기능은 여기서 쓸 수 없다"는 응답도 마찬가지입니다 — 그것을 보고 모델이 다른 방법을 고르는 것이 이 기능의 요점이기 때문입니다.

실행을 끝내는 것은 세 가지뿐입니다: **한도 도달, 취소 요청, 도구 실행 창구 자체의 고장.**

### 3. 모델이 무슨 생각을 했는지는 저장하지 않는다

모델에게는 **진짜 도구 결과**를 그대로 보여줍니다. 그래야 반응할 수 있습니다.

하지만 **기록으로 남기는 것**은 지문값, 크기, 토큰 수, 그리고 200자로 자른 짧은 사유뿐입니다. 원시 추론 과정은 남기지 않습니다. 모델 응답에 생각이 딸려 와도 **정해진 네 개 항목만 읽기 때문에** 기록에 들어갈 수 없습니다. 이것도 테스트로 고정했습니다.

## 안전 — 무엇이 여전히 막혀 있나

### 실제 모델에 연결할 수 없습니다

두 겹입니다.

1. `real_model_voice()`는 **항상 거부**합니다. 실제 모델로 가는 길이 코드에 없습니다.
2. 반복 기능 자체가, 요금이 부과되는 모델이라고 밝힌 상대는 **아무것도 묻기 전에** 거부합니다.

두 번째가 중요합니다. **묻고 나서 거부하면 이미 돈이 나간 뒤**입니다. 그래서 묻기 전에 막습니다.

이 거부를 없애려면 코드를 고쳐야 하고, 그것은 검토자가 반드시 보게 되는 변경입니다. 실수로 유료 실행이 시작될 수 없습니다.

### 다른 실행 환경으로 몰래 갈아타지 않습니다

테스트가 이 모듈이 무엇을 가져다 쓰는지 직접 읽어서, 유료 모델 연결이나 다른 실행 방식(`executor`, `subprocess_runner`, `code_interpreter`, `json_renderer`, 기존 runner들)으로 가는 길이 생기면 **실패합니다**.

### 기존 세 가지 안전 차단은 그대로입니다

| 차단 | 상태 |
|---|---|
| `exec_run`이 명령 실행을 거부 | 그대로 닫힘 |
| `step2_run_inference`가 이 실행 방식을 거부 | 그대로 |
| `core/executor.py`가 유료 호출 없음을 확인하기 전에는 거부 | 그대로 |

세 가지를 **실제로 실행해서** 확인하는 기존 검사가 계속 통과합니다.

### 기존 runner는 건드리지 않았습니다

새 모듈을 **옆에 만들었습니다**. `core/agentic_v2_runner.py`는 한 줄도 바뀌지 않았으므로, 지금 돌아가는 것의 동작이 달라지지 않았고 기존 테스트도 그대로입니다.

## 무료 검사가 보고하는 내용이 바뀌었습니다

전: "1단계가 말하는 기능이 존재하지 않는다"
후: **"실제 모델에 연결할 방법이 없다"**

이 판단을 주석을 읽어서가 아니라, 거부하는 함수를 **실제로 호출해 보고** 반복 기능에 유료 모델을 넣어 **실제로 거부당하는지 확인해서** 내립니다. 누군가 실제 연결을 만들면 답이 저절로 바뀝니다.

막는 것의 크기도 뒤집혔습니다. **이제 돈이 더 큰 차단 조건입니다.**

## 승인 금액에 대하여

**이 pull request는 어떤 금액도 승인하지 않습니다.**

- 3자 비교 최대 비용 **43.77 달러** — 승인되지 않음
- Agentic Sandbox V2 1단계 최소 비용 **9.09 달러** — 승인되지 않음

두 숫자 모두 계산 결과일 뿐이며, 승인 금액으로 기록하지 않았습니다. 실행 승인은 저장소 소유자가 별도로 내리는 결정입니다.

## 검사 결과

| 항목 | 결과 |
|---|---|
| 저장소 전체 테스트 | **3,885 통과 / 0 실패** |
| 신규 테스트 | 반복 기능 97개, 무료 검사 3개 순증 |
| `mypy core/` | **170개 오류 / 32개 파일 — `origin/main`과 동일.** 새 모듈이 만든 오류 0개 |

### 지시받은 실패 상황을 모두 테스트로 고정했습니다

정상 종료 · 반복 횟수 한도 · 길이 한도 · 시간 초과 · 비용 한도 · 도구 호출 한도 · 같은 요청 반복 · 취소(묻기 전 / 도중) · 손상된 모델 응답 · 고장 난 도구 창구 · 지원되지 않는 기능 · 그리고 실제 dispatcher를 상대로 한 6개 통합 테스트.

## 함께 갱신한 문서

- `tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md` — 2·5·6·7·8·9·10·11절을 실제 코드 상태에 맞췄습니다
- `batch-runner/experiments/execution_envelope/agentic_stage_one_plan.yaml`
- `batch-runner/scripts/check_agentic_stage_one_ceiling.py`
- `CHANGELOG.md`

## 다음에 남은 것

1. **실제 모델에 연결하는 방법** — 금액 승인과 함께, 별도 검토가 필요한 변경
2. **금액 승인** — 소유자 결정
3. 명령 실행(`exec_run`) 개방은 2·3단계이며 각각 별도 승인이 필요합니다. 기반이 생겼다는 이유로 앞당기지 않았습니다
