### PR TITLE
Agentic Sandbox V2 — 3단계를 막던 격리 질문에 실제로 답함 (가능한 머신 없음, 차단은 그대로)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/check_execution_environment_readiness.py
 !batch-runner/scripts/check_execution_envelope_advance_check.py
 !batch-runner/scripts/check_agentic_stage_one_ceiling.py
+!batch-runner/scripts/check_agentic_containment.py
 !batch-runner/scripts/build_gdpval_task_catalog.py
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,49 @@ entries land under a fresh dated heading the day they merge to `main`.
   place: leaving it out stops the count rather than quietly standing in a zero.
 
 ### Added
+- **The containment question that blocked Agentic Sandbox V2 stage three is
+  answered, and the answer is no machine.** The specification said whether the
+  small isolated virtual machine it requires "is available on the machines this
+  would run on has not been established". It is now established by reading
+  machines rather than by asserting prose, and it cost nothing: no model was
+  called, no command was run, no account was signed in to, nothing was
+  installed. `batch-runner/core/agentic_v2_containment_readiness.py` reports,
+  per requirement, whether a machine meets it and **why** in a full sentence.
+  Three machines are in play and each is a different kind of no. This box has a
+  processor that could do it, but sits inside a container with no virtualisation
+  device passed through, runs kernel 3.10.102 against the 5.10 that is the
+  oldest Firecracker validates, and has neither `firecracker` nor `jailer`
+  installed. GitHub-hosted runners are a documented no: GitHub says running a
+  virtual machine inside one is "technically possible" but "not officially
+  supported", with no guarantee of stability, performance or compatibility —
+  **a containment boundary offered with no guarantee is not a containment
+  boundary.** The self-hosted `agentic-sandbox` runner is not a no at all: no
+  such machine is registered, so the question has no subject, and that is the
+  only one of the three a decision could change.
+
+  Four things it deliberately does. It reads the five required settings from
+  `core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY` instead of restating them,
+  so the check and the rule it enforces cannot drift apart. It **never runs a
+  command** to find any of this out — a test reads its own source and fails if
+  it ever gains a way to start a process, because a containment check that
+  starts processes to decide whether starting processes is safe has the problem
+  backwards. It counts "cannot be established" against availability rather than
+  for it, so an unanswered question can never be mistaken for a cleared one. And
+  it reads `runs-on:` out of every workflow file and fails if a machine is being
+  asked for that has no recorded finding, so adding a runner without answering
+  the containment question for it is caught by a test rather than by somebody
+  remembering. It also distinguishes "not validated" from "forbidden": Firecracker
+  does not ban older kernels, it declines to test them, and the report says so.
+
+  Nothing is switched on and no refusal is removed. `exec_run` still answers
+  `capability_unavailable`, both guards still reject the mode, and
+  `refuse_command_execution` returns a refusal that would clear only once the
+  containment genuinely exists somewhere. `scripts/check_agentic_containment.py`
+  prints the whole report for free and exits 1. 61 new tests, one of which pins
+  a trap this change fell into: a line added above `canonical_sha256` in
+  `core/agentic_v2_substrate.py` silently breaks 91 licence tests, because that
+  function's starting line is part of a frozen identity, and the error names the
+  licence evaluator and never mentions the file that moved.
 - **What Agentic Sandbox V2 stage one would cost, worked out for free.** Step
   one of `tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md`. A loop's
   bill does not rise in step with the number of turns — it rises roughly with

--- a/batch-runner/core/agentic_v2_containment_readiness.py
+++ b/batch-runner/core/agentic_v2_containment_readiness.py
@@ -1,0 +1,749 @@
+"""Whether the containment Agentic Sandbox V2 requires exists on any machine here.
+
+The specification for Agentic Sandbox V2 has carried one open question since it
+was written: the substrate manifest insists that commands run inside a small
+isolated virtual machine, and nobody had established whether such a thing is
+available on the machines this repository actually runs on. Stage three — the
+stage that lets a model's chosen commands really run — cannot be designed while
+that is unknown, because the containment is the whole of its safety.
+
+This module answers that question, and answers it by reading the machine rather
+than by asserting something in prose. Nothing here calls a model, signs in to an
+account, runs a command, installs anything, or spends money. Every reading is a
+file this process may already open or a lookup on the program search path.
+
+**A readiness report already existed and was not enough.**
+:func:`core.agentic_v2_microvm.inspect_microvm_readiness` checks four things:
+the two Firecracker programs, ``/dev/kvm``, and whether a kernel image and a
+root filesystem image were handed to it. Those facts are reused here rather than
+read a second time. But two readings decide the answer on every real machine and
+that report takes neither of them:
+
+* **the version of the kernel this machine is running**, which is what rules out
+  an older host outright, and
+* **whether the processor offers hardware virtualisation at all**, which is what
+  separates "this machine could do it once configured" from "this machine never
+  can".
+
+It also reports only ``ready_for_boot_test`` or ``not_run``, which tells a reader
+that something is missing without telling them what or whether it is fixable.
+
+**Three machines are in play, and only one can be read from here.** The other
+two are recorded in :data:`RECORDED_FINDINGS` with the source and the date they
+were established, kept deliberately separate from anything probed, so a reader
+is never left guessing which kind of evidence they are looking at.
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from core.agentic_v2_microvm import inspect_microvm_readiness
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
+
+# ── What Firecracker itself says it needs ─────────────────────────────────
+
+OLDEST_HOST_KERNEL_FIRECRACKER_VALIDATES = (5, 10)
+"""The oldest host kernel Firecracker's own kernel policy lists.
+
+Read on 2026-08-26 from Firecracker's ``docs/kernel-policy.md``, which gives
+v5.10, v6.1 and v6.18 as the host kernels it validates against and says of
+anything else that it "might work" but is "not periodically validated in our
+test suite".
+
+That wording matters for how this is used below. A kernel older than this is not
+reported as *forbidden*, because Firecracker does not forbid it; it is reported
+as *outside what its own project tests*, which for a containment boundary is
+reason enough not to rely on it. The distinction is kept because overstating a
+requirement is its own kind of wrong answer.
+"""
+
+FIRECRACKER_KERNEL_POLICY_URL = (
+    "https://github.com/firecracker-microvm/firecracker/blob/main/docs/"
+    "kernel-policy.md"
+)
+
+PROCESSOR_VIRTUALISATION_FLAGS = ("vmx", "svm")
+"""The processor flags that mean hardware virtualisation exists — Intel, AMD."""
+
+
+# ── The four readings that can be taken here ──────────────────────────────
+#
+# Written as statements that are either true or false about a machine, so a
+# report reads as a list of plain claims rather than a list of setting names.
+
+NEEDS_A_PROCESSOR_THAT_CAN = "the processor offers hardware virtualisation"
+NEEDS_TO_REACH_THE_HARDWARE = "this machine can reach hardware virtualisation"
+NEEDS_A_KERNEL_FIRECRACKER_TESTS = (
+    "the kernel is one Firecracker validates against"
+)
+NEEDS_THE_PROGRAMS_INSTALLED = "the Firecracker programs are installed"
+
+READINGS_TAKEN_HERE = (
+    NEEDS_A_PROCESSOR_THAT_CAN,
+    NEEDS_TO_REACH_THE_HARDWARE,
+    NEEDS_A_KERNEL_FIRECRACKER_TESTS,
+    NEEDS_THE_PROGRAMS_INSTALLED,
+)
+
+# How each setting in the manifest's containment policy reads as a claim about a
+# running virtual machine. These cannot be checked without one, and saying so is
+# the honest report; quietly leaving them out would read as though the manifest
+# asked for less than it does.
+_POLICY_SETTING_AS_A_CLAIM = {
+    "runtime": "the small isolated virtual machine is run by {value}",
+    "network": "the small isolated virtual machine's network is {value}",
+    "rootfs": "the small isolated virtual machine's root filesystem is {value}",
+    "workdir": "the small isolated virtual machine's working directory is "
+    "{value}",
+}
+
+
+@dataclass(frozen=True)
+class MachineFacts:
+    """What was read off one machine. Nothing here is a judgement."""
+
+    kernel_release: str
+    processor_flags: tuple[str, ...]
+    processor_flags_were_readable: bool
+    hardware_virtualisation_reachable: bool
+    firecracker_programs_found: tuple[str, ...]
+    firecracker_programs_missing: tuple[str, ...]
+    inside_a_container: bool
+    container_evidence: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "kernel_release": self.kernel_release,
+            "processor_flags": list(self.processor_flags),
+            "processor_flags_were_readable": self.processor_flags_were_readable,
+            "hardware_virtualisation_reachable": (
+                self.hardware_virtualisation_reachable
+            ),
+            "firecracker_programs_found": list(self.firecracker_programs_found),
+            "firecracker_programs_missing": list(
+                self.firecracker_programs_missing
+            ),
+            "inside_a_container": self.inside_a_container,
+            "container_evidence": self.container_evidence,
+        }
+
+
+@dataclass(frozen=True)
+class Requirement:
+    """One claim about containment, judged, with what was read beside it."""
+
+    claim: str
+    met: bool | None
+    """``True`` yes, ``False`` no, ``None`` it could not be established here."""
+
+    because: str
+
+    @property
+    def verdict(self) -> str:
+        if self.met is True:
+            return "met"
+        if self.met is False:
+            return "not met"
+        return "cannot be established here"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"claim": self.claim, "verdict": self.verdict, "because": self.because}
+
+
+@dataclass(frozen=True)
+class RecordedFinding:
+    """An answer for a machine that cannot be read from this one."""
+
+    machine: str
+    containment_available: bool | None
+    finding: str
+    established_by: str
+    on_date: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "machine": self.machine,
+            "containment_available": self.containment_available,
+            "finding": self.finding,
+            "established_by": self.established_by,
+            "on_date": self.on_date,
+        }
+
+
+@dataclass
+class ContainmentAnswer:
+    """What one machine can and cannot provide, and what follows from it."""
+
+    machine: str
+    requirements: list[Requirement] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def required_containment_available(self) -> bool:
+        """True only when every claim was established and every one holds.
+
+        A claim that could not be established counts against availability. The
+        rule the specification already sets for the container run place applies
+        here too: when the intended isolation cannot be shown to be present, the
+        answer is no, not "probably".
+        """
+        return bool(self.requirements) and all(
+            requirement.met is True for requirement in self.requirements
+        )
+
+    def whats_missing(self) -> list[str]:
+        """Every claim that does not hold, said as a sentence with its reason."""
+        return [
+            f"{requirement.claim} — {requirement.verdict}: {requirement.because}"
+            for requirement in self.requirements
+            if requirement.met is not True
+        ]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "machine": self.machine,
+            "required_containment_available": self.required_containment_available,
+            "requirements": [item.as_dict() for item in self.requirements],
+            "whats_missing": self.whats_missing(),
+            "notes": list(self.notes),
+        }
+
+
+# ── Reading one machine ───────────────────────────────────────────────────
+
+
+def read_this_machine(
+    *,
+    cpuinfo_path: str | Path = "/proc/cpuinfo",
+    docker_marker_path: str | Path = "/.dockerenv",
+    cgroup_path: str | Path = "/proc/1/cgroup",
+    kernel_release: str | None = None,
+    microvm_report: Mapping[str, Any] | None = None,
+) -> MachineFacts:
+    """Read the machine this process is on. Free, read-only, and offline.
+
+    The Firecracker programs and the hardware-virtualisation device are not read
+    again here: :func:`core.agentic_v2_microvm.inspect_microvm_readiness`
+    already does that, and reading them a second way is how two answers to one
+    question start to disagree. Pass ``microvm_report`` to supply that reading
+    instead of taking it, which is what the tests do.
+    """
+    report = (
+        inspect_microvm_readiness(asset_paths={})
+        if microvm_report is None
+        else microvm_report
+    )
+    tools = report.get("tools", {})
+    found = tuple(
+        sorted(
+            name
+            for name, item in tools.items()
+            if isinstance(item, Mapping) and item.get("status") == "present"
+        )
+    )
+    missing = tuple(sorted(set(tools) - set(found)))
+
+    flags, flags_readable = _read_processor_flags(Path(cpuinfo_path))
+    inside, evidence = _read_container_markers(
+        Path(docker_marker_path), Path(cgroup_path)
+    )
+    return MachineFacts(
+        kernel_release=(
+            platform.release() if kernel_release is None else kernel_release
+        ),
+        processor_flags=flags,
+        processor_flags_were_readable=flags_readable,
+        hardware_virtualisation_reachable=bool(
+            report.get("checks", {}).get("kvm")
+        ),
+        firecracker_programs_found=found,
+        firecracker_programs_missing=missing,
+        inside_a_container=inside,
+        container_evidence=evidence,
+    )
+
+
+def _read_processor_flags(cpuinfo_path: Path) -> tuple[tuple[str, ...], bool]:
+    try:
+        text = cpuinfo_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return (), False
+    for line in text.splitlines():
+        name, separator, value = line.partition(":")
+        if separator and name.strip().lower() in {"flags", "features"}:
+            return tuple(value.split()), True
+    return (), False
+
+
+def _read_container_markers(
+    docker_marker_path: Path, cgroup_path: Path
+) -> tuple[bool, str]:
+    if docker_marker_path.exists():
+        return True, f"{docker_marker_path} exists"
+    try:
+        text = cgroup_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False, ""
+    for marker in ("/docker/", "/kubepods", "/lxc/", "/containerd"):
+        if marker in text:
+            return True, f"{cgroup_path} mentions {marker}"
+    return False, ""
+
+
+# ── Judging what was read ─────────────────────────────────────────────────
+
+
+def judge_containment(
+    facts: MachineFacts, *, machine: str = "this machine"
+) -> ContainmentAnswer:
+    """Turn readings into claims that hold or do not, each with its reason."""
+    answer = ContainmentAnswer(machine=machine)
+
+    answer.requirements.append(_judge_processor(facts))
+    answer.requirements.append(_judge_reach(facts))
+    answer.requirements.append(_judge_kernel(facts))
+    answer.requirements.append(_judge_programs(facts))
+    answer.requirements.extend(_judge_policy_settings(answer.requirements))
+
+    if facts.inside_a_container:
+        answer.notes.append(
+            "this is running inside a container "
+            f"({facts.container_evidence}), which is why the hardware "
+            "virtualisation device is not reachable. That is not disqualifying "
+            "by itself — Firecracker can run inside a container when the "
+            "device is passed through to it — but nothing here passes it "
+            "through, and the machine outside would still have to meet the "
+            "other claims"
+        )
+    return answer
+
+
+def _judge_processor(facts: MachineFacts) -> Requirement:
+    if not facts.processor_flags_were_readable:
+        return Requirement(
+            claim=NEEDS_A_PROCESSOR_THAT_CAN,
+            met=None,
+            because=(
+                "the processor's capability list could not be read on this "
+                "machine, so whether the hardware can do it at all is unknown"
+            ),
+        )
+    present = sorted(
+        set(facts.processor_flags) & set(PROCESSOR_VIRTUALISATION_FLAGS)
+    )
+    if present:
+        return Requirement(
+            claim=NEEDS_A_PROCESSOR_THAT_CAN,
+            met=True,
+            because=(
+                "the processor reports "
+                + ", ".join(present)
+                + ", so the hardware itself can do it"
+            ),
+        )
+    return Requirement(
+        claim=NEEDS_A_PROCESSOR_THAT_CAN,
+        met=False,
+        because=(
+            "the processor reports neither "
+            + " nor ".join(PROCESSOR_VIRTUALISATION_FLAGS)
+            + ", so no amount of configuration would make this work here"
+        ),
+    )
+
+
+def _judge_reach(facts: MachineFacts) -> Requirement:
+    if facts.hardware_virtualisation_reachable:
+        return Requirement(
+            claim=NEEDS_TO_REACH_THE_HARDWARE,
+            met=True,
+            because=(
+                "core.agentic_v2_microvm.inspect_microvm_readiness found the "
+                "hardware virtualisation device present and usable by this user"
+            ),
+        )
+    return Requirement(
+        claim=NEEDS_TO_REACH_THE_HARDWARE,
+        met=False,
+        because=(
+            "core.agentic_v2_microvm.inspect_microvm_readiness found no usable "
+            "hardware virtualisation device, so nothing here can start a small "
+            "isolated virtual machine even if everything else were in place"
+        ),
+    )
+
+
+def _judge_kernel(facts: MachineFacts) -> Requirement:
+    version = _kernel_version(facts.kernel_release)
+    oldest = ".".join(str(part) for part in OLDEST_HOST_KERNEL_FIRECRACKER_VALIDATES)
+    if version is None:
+        return Requirement(
+            claim=NEEDS_A_KERNEL_FIRECRACKER_TESTS,
+            met=None,
+            because=(
+                f"the kernel reports itself as {facts.kernel_release!r}, which "
+                "this check could not read a version number out of"
+            ),
+        )
+    if version >= OLDEST_HOST_KERNEL_FIRECRACKER_VALIDATES:
+        return Requirement(
+            claim=NEEDS_A_KERNEL_FIRECRACKER_TESTS,
+            met=True,
+            because=(
+                f"the kernel is {facts.kernel_release}, at or above the {oldest} "
+                f"that Firecracker's own kernel policy lists "
+                f"({FIRECRACKER_KERNEL_POLICY_URL})"
+            ),
+        )
+    return Requirement(
+        claim=NEEDS_A_KERNEL_FIRECRACKER_TESTS,
+        met=False,
+        because=(
+            f"the kernel is {facts.kernel_release}, below the {oldest} that "
+            "Firecracker's own kernel policy lists. Firecracker does not forbid "
+            "an older one, but says untabled versions are not validated in its "
+            "test suite, and an unvalidated containment boundary is not one to "
+            f"rely on ({FIRECRACKER_KERNEL_POLICY_URL})"
+        ),
+    )
+
+
+def _judge_programs(facts: MachineFacts) -> Requirement:
+    if facts.firecracker_programs_missing:
+        return Requirement(
+            claim=NEEDS_THE_PROGRAMS_INSTALLED,
+            met=False,
+            because=(
+                "not on the program search path: "
+                + ", ".join(facts.firecracker_programs_missing)
+            ),
+        )
+    if not facts.firecracker_programs_found:
+        return Requirement(
+            claim=NEEDS_THE_PROGRAMS_INSTALLED,
+            met=None,
+            because=(
+                "nothing looked for the Firecracker programs, so whether they "
+                "are installed is unknown"
+            ),
+        )
+    return Requirement(
+        claim=NEEDS_THE_PROGRAMS_INSTALLED,
+        met=True,
+        because=(
+            "found on the program search path: "
+            + ", ".join(facts.firecracker_programs_found)
+        ),
+    )
+
+
+def _judge_policy_settings(
+    already_judged: Sequence[Requirement],
+) -> list[Requirement]:
+    """The manifest's own containment settings, which need a machine to check.
+
+    Read from :data:`core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY` rather
+    than listed again here, so that a setting added to the manifest turns into a
+    line in this report instead of being silently left out of it.
+    """
+    can_start_one = all(item.met is True for item in already_judged)
+    settings: list[Requirement] = []
+
+    # The premise first: the manifest does not merely prefer containment, it
+    # refuses to validate without it. Everything below is a detail of a thing
+    # that is mandatory.
+    mandatory = REQUIRED_MICROVM_POLICY.get("required")
+    settings.append(
+        Requirement(
+            claim=(
+                "containment is mandatory rather than optional, so a machine "
+                "without it must refuse rather than run"
+            ),
+            met=mandatory is True,
+            because=(
+                "core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY sets "
+                f"required to {mandatory!r}, and a manifest that says "
+                "otherwise fails to validate"
+            ),
+        )
+    )
+
+    for name, value in sorted(REQUIRED_MICROVM_POLICY.items()):
+        if name == "required":
+            continue
+        wording = _POLICY_SETTING_AS_A_CLAIM.get(name)
+        if wording is None:
+            settings.append(
+                Requirement(
+                    claim=(
+                        f"the manifest's containment setting {name!r} "
+                        f"({value!r}) holds"
+                    ),
+                    met=None,
+                    because=(
+                        "the manifest has gained a containment setting this "
+                        "report does not know how to describe or check. Add it "
+                        "to core.agentic_v2_containment_readiness before "
+                        "relying on this answer"
+                    ),
+                )
+            )
+            continue
+        settings.append(
+            Requirement(
+                claim=wording.format(value=value),
+                met=True if can_start_one else None,
+                because=(
+                    "this is a setting applied when the virtual machine is "
+                    "started rather than a capability the host must already "
+                    "have, and this machine can start one"
+                    if can_start_one
+                    else "there is no small isolated virtual machine on this "
+                    "machine to apply this to. It becomes answerable only once "
+                    "the four claims above hold"
+                ),
+            )
+        )
+    return settings
+
+
+def _kernel_version(release: str) -> tuple[int, int] | None:
+    match = re.match(r"\s*(\d+)\.(\d+)", release or "")
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+# ── The machines that cannot be read from here ────────────────────────────
+
+RECORDED_FINDINGS: tuple[RecordedFinding, ...] = (
+    RecordedFinding(
+        machine="github-hosted runner (ubuntu-latest, ubuntu-24.04)",
+        containment_available=False,
+        finding=(
+            "GitHub's own documentation says that running a virtual machine "
+            "inside one of its runners, which is what this containment would "
+            "require, is \"technically possible\" but \"not officially "
+            "supported\": experimental, at the user's own risk, with no "
+            "guarantee of stability, performance or compatibility. A "
+            "containment boundary offered with no guarantee is not a "
+            "containment boundary, so this is a no rather than an unknown"
+        ),
+        established_by=(
+            "https://docs.github.com/en/actions/using-github-hosted-runners/"
+            "using-github-hosted-runners/about-github-hosted-runners"
+        ),
+        on_date="2026-08-26",
+    ),
+    RecordedFinding(
+        machine="self-hosted runner labelled agentic-sandbox",
+        containment_available=None,
+        finding=(
+            "there is no such machine. No self-hosted runner is registered to "
+            "this repository, and .github/workflows/agentic-sandbox-preflight."
+            "yml, the one workflow that asks for this label, has never run. So "
+            "the question cannot be answered for it: a machine that does not "
+            "exist has no containment either way, and whether a future one "
+            "would have it is a decision nobody has taken yet"
+        ),
+        established_by=(
+            "gh api repos/hyeonsangjeon/gdpval-realworks/actions/runners "
+            "returned total_count 0, and gh run list --workflow "
+            "agentic-sandbox-preflight.yml returned nothing"
+        ),
+        on_date="2026-08-26",
+    ),
+)
+
+_LABELS_COVERED_BY_A_FINDING = {
+    "ubuntu-latest": RECORDED_FINDINGS[0],
+    "ubuntu-24.04": RECORDED_FINDINGS[0],
+    "ubuntu-22.04": RECORDED_FINDINGS[0],
+    "ubuntu-20.04": RECORDED_FINDINGS[0],
+    "agentic-sandbox": RECORDED_FINDINGS[1],
+}
+
+_IGNORED_RUNNER_LABELS = frozenset({"self-hosted", "linux", "x64", "x86_64"})
+
+
+def runner_labels_used_by_workflows(
+    workflows_directory: str | Path,
+) -> tuple[str, ...]:
+    """Every machine label the workflows ask for. Read from the files, offline.
+
+    Reading these rather than listing them means that adding a workflow which
+    runs somewhere new makes :func:`check_every_machine_has_a_containment_finding`
+    report a gap, instead of the new machine quietly inheriting an answer that
+    was established about a different one.
+    """
+    directory = Path(workflows_directory)
+    labels: set[str] = set()
+    for path in sorted(directory.glob("*.yml")) + sorted(directory.glob("*.yaml")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:  # pragma: no cover - defensive
+            continue
+        for match in re.finditer(r"^\s*runs-on:\s*(.+?)\s*$", text, re.MULTILINE):
+            labels.update(_split_runner_labels(match.group(1)))
+    return tuple(sorted(labels - _IGNORED_RUNNER_LABELS))
+
+
+def _split_runner_labels(raw: str) -> Iterable[str]:
+    stripped = raw.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        stripped = stripped[1:-1]
+    for part in stripped.split(","):
+        label = part.strip().strip("\"'")
+        # A label written as ${{ ... }} is chosen when the workflow runs, so
+        # there is nothing to look up here.
+        if label and not label.startswith("${{"):
+            yield label
+
+
+def check_every_machine_has_a_containment_finding(
+    workflows_directory: str | Path,
+) -> list[str]:
+    """Report any machine the workflows use that no finding covers."""
+    problems: list[str] = []
+    for label in runner_labels_used_by_workflows(workflows_directory):
+        if label not in _LABELS_COVERED_BY_A_FINDING:
+            problems.append(
+                f"a workflow now runs on {label!r}, and no finding records "
+                "whether the containment Agentic Sandbox V2 requires is "
+                "available there. Establish it before that machine is counted "
+                "as a place stage three could run"
+            )
+    return problems
+
+
+# ── The answer, and the refusal that follows from it ──────────────────────
+
+
+def containment_answer_everywhere(
+    *,
+    facts: MachineFacts | None = None,
+    workflows_directory: str | Path | None = None,
+) -> dict[str, Any]:
+    """The whole answer: this machine read live, the others from record.
+
+    ``every_machine_in_play_has_an_answer`` is ``None`` rather than ``True``
+    when no workflows directory was given, because in that case nothing looked.
+    A check that treats "nobody asked" as "the answer is yes" is the failure
+    this whole module exists to avoid making.
+    """
+    here = judge_containment(
+        facts if facts is not None else read_this_machine(),
+        machine="the machine this check is running on",
+    )
+    available_anywhere = here.required_containment_available or any(
+        finding.containment_available is True for finding in RECORDED_FINDINGS
+    )
+    gaps = (
+        check_every_machine_has_a_containment_finding(workflows_directory)
+        if workflows_directory is not None
+        else []
+    )
+    return {
+        "required_containment": dict(REQUIRED_MICROVM_POLICY),
+        "this_machine": here.as_dict(),
+        "recorded_findings": [finding.as_dict() for finding in RECORDED_FINDINGS],
+        "machines_without_a_finding": gaps,
+        "every_machine_in_play_has_an_answer": (
+            None if workflows_directory is None else not gaps
+        ),
+        "available_on_any_machine_in_play": available_anywhere,
+    }
+
+
+def refuse_command_execution(
+    answer: Mapping[str, Any] | None = None,
+) -> str | None:
+    """The sentence explaining why a model's chosen commands may not run here.
+
+    Returns ``None`` only if the required containment is genuinely available
+    somewhere, which today it is not. This exists so that the reason is one
+    value a caller can act on rather than something a reader has to infer from a
+    report, and so that the day it changes, it changes here.
+
+    It does not switch anything on or off by itself. The three refusals that
+    keep command execution shut are unchanged and stay where they are; this is
+    the containment answer they were waiting on, not a replacement for them.
+    """
+    report = answer if answer is not None else containment_answer_everywhere()
+    if report.get("available_on_any_machine_in_play"):
+        return None
+    return (
+        "a model's chosen commands must not run: the containment the substrate "
+        "manifest requires — a small isolated virtual machine run by "
+        f"{REQUIRED_MICROVM_POLICY['runtime']}, with "
+        f"network {REQUIRED_MICROVM_POLICY['network']} and a "
+        f"{REQUIRED_MICROVM_POLICY['rootfs']} root filesystem — is not "
+        "available on any machine in play. Running them somewhere weaker "
+        "instead is the substitution the specification forbids, so the answer "
+        "is to leave the capability shut"
+    )
+
+
+def describe_containment(report: Mapping[str, Any]) -> list[str]:
+    """The report as lines to print. No colour, no symbols, no abbreviations."""
+    lines: list[str] = []
+    required = report["required_containment"]
+    lines.append("What the substrate manifest requires before a command may run")
+    lines.append("-" * 74)
+    lines.append("  a small isolated virtual machine, with these settings:")
+    for name, value in sorted(required.items()):
+        lines.append(f"      {name}: {value}")
+    lines.append("")
+
+    here = report["this_machine"]
+    lines.append(f"On {here['machine']}")
+    lines.append("-" * 74)
+    for requirement in here["requirements"]:
+        lines.append(f"  {requirement['claim']}")
+        lines.append(f"      {requirement['verdict']}: {requirement['because']}")
+    for note in here["notes"]:
+        lines.append("")
+        lines.append(f"  Worth knowing: {note}")
+    lines.append("")
+
+    lines.append("On the machines that cannot be read from here")
+    lines.append("-" * 74)
+    for finding in report["recorded_findings"]:
+        available = finding["containment_available"]
+        verdict = (
+            "available"
+            if available is True
+            else "not available"
+            if available is False
+            else "cannot be answered"
+        )
+        lines.append(f"  {finding['machine']}: {verdict}")
+        lines.append(f"      {finding['finding']}")
+        lines.append(
+            f"      established {finding['on_date']} from "
+            f"{finding['established_by']}"
+        )
+    lines.append("")
+
+    for gap in report["machines_without_a_finding"]:
+        lines.append(f"  Gap: {gap}")
+    if report["machines_without_a_finding"]:
+        lines.append("")
+
+    lines.append("The answer")
+    lines.append("-" * 74)
+    refusal = refuse_command_execution(report)
+    if refusal is None:
+        lines.append(
+            "  The required containment is available. That removes the "
+            "specification's open question, and nothing else: opening command "
+            "execution is a separate decision with its own approval."
+        )
+    else:
+        lines.append(f"  {refusal}")
+    return lines

--- a/batch-runner/core/agentic_v2_substrate.py
+++ b/batch-runner/core/agentic_v2_substrate.py
@@ -128,6 +128,29 @@ def canonical_sha256(value: Any) -> str:
     ).hexdigest()
 
 
+# NOTHING MAY BE INSERTED ABOVE THIS POINT WITHOUT REPINNING THE LICENCE
+# EVALUATOR. core/agentic_v2_license.py freezes the exact bytecode identity of
+# canonical_sha256 above, and that identity includes the line it starts on. Add
+# a line anywhere before it and every licence report stops validating, with an
+# error that names the licence evaluator and never mentions this file. New
+# constants for this module therefore go here, below it, not up with the others.
+
+# The containment a substrate manifest must promise before it will validate.
+#
+# Named rather than written inline in the check below, so that anything asking
+# "what containment is actually required here?" reads the answer from the same
+# place the check enforces it. Two copies of these five settings could disagree
+# with each other; one cannot. core/agentic_v2_containment_readiness.py reads it
+# to report which of them a given machine can actually meet.
+REQUIRED_MICROVM_POLICY: dict[str, Any] = {
+    "required": True,
+    "runtime": "firecracker",
+    "network": "none",
+    "rootfs": "read-only",
+    "workdir": "ephemeral-quota",
+}
+
+
 @dataclass(frozen=True)
 class AgenticV2SubstrateManifest:
     document: dict[str, Any]
@@ -289,13 +312,10 @@ def _validate_manifest(value: Any) -> dict[str, Any]:
         "license_policy_id": "agentic-v2-license-v2",
     }:
         raise ValueError("agentic v2 substrate supply-chain policy is invalid")
-    if document["microvm"] != {
-        "required": True,
-        "runtime": "firecracker",
-        "network": "none",
-        "rootfs": "read-only",
-        "workdir": "ephemeral-quota",
-    } or document["microvm"].get("required") is not True:
+    if (
+        document["microvm"] != REQUIRED_MICROVM_POLICY
+        or document["microvm"].get("required") is not True
+    ):
         raise ValueError("agentic v2 substrate microvm policy is invalid")
     return document
 

--- a/batch-runner/scripts/check_agentic_containment.py
+++ b/batch-runner/scripts/check_agentic_containment.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""The free check for whether Agentic Sandbox V2's containment exists anywhere.
+
+Nothing here calls a model, signs in to a cloud account, runs a command,
+installs anything, or spends money. It reads the machine it is running on, the
+repository's own workflow files, and two findings recorded about machines that
+cannot be read from here, and prints whether the containment the substrate
+manifest requires is available on any of them.
+
+Usage:
+
+    cd batch-runner
+    python scripts/check_agentic_containment.py
+    python scripts/check_agentic_containment.py --json
+
+The exit code is 0 only when the required containment is available on some
+machine in play *and* every machine the workflows ask for has an answer
+recorded. Today neither holds for the first reason: this machine cannot reach
+hardware virtualisation and runs a kernel below the oldest Firecracker
+validates, GitHub-hosted runners do not officially support running a virtual
+machine inside them, and the self-hosted machine the one workflow asks for has
+never been registered. Anything else exits 1, so this is safe to wire into an
+automated check — including the case where somebody adds a workflow that runs
+somewhere nobody has answered the question for.
+
+Stage three of the specification — letting a model's chosen commands really run
+— is what this answers a question for. It switches nothing on and removes no
+refusal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_v2_containment_readiness import (  # noqa: E402
+    containment_answer_everywhere,
+    describe_containment,
+)
+
+DEFAULT_WORKFLOWS_DIRECTORY = BATCH_RUNNER_ROOT.parent / ".github" / "workflows"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check for free whether the containment Agentic Sandbox V2 "
+            "requires is available on any machine this repository runs on."
+        )
+    )
+    parser.add_argument(
+        "--workflows",
+        type=Path,
+        default=DEFAULT_WORKFLOWS_DIRECTORY,
+        help="Where the workflow files are, to see which machines are asked for.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Print the report as JSON instead of readable text.",
+    )
+    args = parser.parse_args()
+
+    report = containment_answer_everywhere(workflows_directory=args.workflows)
+
+    if args.as_json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            "Agentic Sandbox V2 — is the containment it requires available "
+            "anywhere?\n"
+            "(nothing was called, nothing was run, nothing was spent)"
+        )
+        print("=" * 74)
+        print()
+        for line in describe_containment(report):
+            print(line)
+
+    return (
+        0
+        if report["available_on_any_machine_in_play"]
+        and report["every_machine_in_play_has_an_answer"]
+        else 1
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/tests/test_agentic_v2_containment_readiness.py
+++ b/batch-runner/tests/test_agentic_v2_containment_readiness.py
@@ -1,0 +1,770 @@
+"""What containment this repository can actually get, and what follows from it.
+
+These tests pin the answer to the question the Agentic Sandbox V2 specification
+left open: is the small isolated virtual machine its substrate manifest requires
+available on any machine this repository runs on?
+
+Nothing here calls a model, runs a command, signs in to anything, or spends
+money. Every machine below is either described to the code as a set of readings
+or is this machine, read the same read-only way the check itself reads it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_containment_readiness import (
+    FIRECRACKER_KERNEL_POLICY_URL,
+    NEEDS_A_KERNEL_FIRECRACKER_TESTS,
+    NEEDS_A_PROCESSOR_THAT_CAN,
+    NEEDS_THE_PROGRAMS_INSTALLED,
+    NEEDS_TO_REACH_THE_HARDWARE,
+    OLDEST_HOST_KERNEL_FIRECRACKER_VALIDATES,
+    RECORDED_FINDINGS,
+    MachineFacts,
+    check_every_machine_has_a_containment_finding,
+    containment_answer_everywhere,
+    describe_containment,
+    judge_containment,
+    read_this_machine,
+    refuse_command_execution,
+    runner_labels_used_by_workflows,
+)
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
+
+WORKFLOWS_DIRECTORY = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+
+# ── Describing a machine to the code ──────────────────────────────────────
+
+
+def a_machine(**changes) -> MachineFacts:
+    """A machine that meets every requirement, unless a test takes one away."""
+    settings = {
+        "kernel_release": "6.1.0-generic",
+        "processor_flags": ("fpu", "vmx", "aes"),
+        "processor_flags_were_readable": True,
+        "hardware_virtualisation_reachable": True,
+        "firecracker_programs_found": ("firecracker", "jailer"),
+        "firecracker_programs_missing": (),
+        "inside_a_container": False,
+        "container_evidence": "",
+    }
+    settings.update(changes)
+    return MachineFacts(**settings)
+
+
+def claim(answer, wanted: str):
+    """The one judged claim whose wording starts with ``wanted``."""
+    matches = [item for item in answer.requirements if item.claim.startswith(wanted)]
+    assert matches, f"no claim starting {wanted!r} in {[i.claim for i in answer.requirements]}"
+    return matches[0]
+
+
+def a_microvm_report(*, kvm: bool = False, programs: tuple[str, ...] = ()) -> dict:
+    """The shape core.agentic_v2_microvm.inspect_microvm_readiness hands back."""
+    return {
+        "checks": {"kvm": kvm},
+        "tools": {
+            name: {
+                "status": "present" if name in programs else "missing",
+                "sha256": None,
+                "size": None,
+            }
+            for name in ("firecracker", "jailer")
+        },
+    }
+
+
+# ── A machine that has everything ─────────────────────────────────────────
+
+
+def test_a_machine_with_everything_can_provide_the_required_containment():
+    answer = judge_containment(a_machine())
+
+    assert answer.required_containment_available is True
+    assert answer.whats_missing() == []
+
+
+def test_every_setting_the_manifest_asks_for_appears_in_the_answer():
+    """The report covers the whole policy, not the part that is easy to check.
+
+    Three of the manifest's settings — no network, a read-only root filesystem,
+    a temporary working directory — are things you configure on a virtual
+    machine rather than things a host has or lacks. Leaving them out of the
+    report would make it read as though the manifest asked for less than it
+    does, so each one gets a line either way.
+    """
+    answer = judge_containment(a_machine())
+    wording = " ".join(item.claim for item in answer.requirements)
+
+    for value in REQUIRED_MICROVM_POLICY.values():
+        if value is True:
+            continue
+        assert str(value) in wording, f"the answer never mentions {value!r}"
+
+
+def test_the_configured_settings_are_not_claimed_to_have_been_checked():
+    """Nothing boots a virtual machine here, and the wording must not imply it."""
+    answer = judge_containment(a_machine())
+    network = claim(answer, "the small isolated virtual machine's network")
+
+    assert network.met is True
+    assert "setting applied when the virtual machine is started" in network.because
+    assert "rather than a capability the host must already have" in network.because
+
+
+# ── Each requirement, taken away one at a time ────────────────────────────
+
+
+def test_a_processor_that_cannot_do_it_is_a_permanent_no():
+    answer = judge_containment(a_machine(processor_flags=("fpu", "aes")))
+    judged = claim(answer, NEEDS_A_PROCESSOR_THAT_CAN)
+
+    assert answer.required_containment_available is False
+    assert judged.met is False
+    assert "no amount of configuration would make this work here" in judged.because
+
+
+def test_a_processor_whose_capabilities_could_not_be_read_is_not_called_a_no():
+    """An unread fact and a fact that came back negative are different answers.
+
+    Reporting "the processor cannot do it" when the truth is "nobody managed to
+    look" would send somebody to buy hardware they may already own.
+    """
+    answer = judge_containment(
+        a_machine(processor_flags=(), processor_flags_were_readable=False)
+    )
+    judged = claim(answer, NEEDS_A_PROCESSOR_THAT_CAN)
+
+    assert judged.met is None
+    assert judged.verdict == "cannot be established here"
+    assert answer.required_containment_available is False
+
+
+def test_an_amd_processor_counts_as_well_as_an_intel_one():
+    answer = judge_containment(a_machine(processor_flags=("fpu", "svm")))
+
+    assert claim(answer, NEEDS_A_PROCESSOR_THAT_CAN).met is True
+
+
+def test_hardware_the_machine_cannot_reach_is_a_no():
+    answer = judge_containment(a_machine(hardware_virtualisation_reachable=False))
+    judged = claim(answer, NEEDS_TO_REACH_THE_HARDWARE)
+
+    assert answer.required_containment_available is False
+    assert judged.met is False
+    assert "core.agentic_v2_microvm.inspect_microvm_readiness" in judged.because
+
+
+def test_the_programs_being_absent_names_which_ones():
+    answer = judge_containment(
+        a_machine(
+            firecracker_programs_found=("firecracker",),
+            firecracker_programs_missing=("jailer",),
+        )
+    )
+    judged = claim(answer, NEEDS_THE_PROGRAMS_INSTALLED)
+
+    assert judged.met is False
+    assert "jailer" in judged.because
+
+
+def test_not_having_looked_for_the_programs_is_not_the_same_as_their_being_absent():
+    answer = judge_containment(
+        a_machine(firecracker_programs_found=(), firecracker_programs_missing=())
+    )
+    judged = claim(answer, NEEDS_THE_PROGRAMS_INSTALLED)
+
+    assert judged.met is None
+    assert "unknown" in judged.because
+
+
+# ── The kernel, which is the reading the existing report never took ───────
+
+
+@pytest.mark.parametrize(
+    "release",
+    ["5.10", "5.10.0-generic", "5.15.0-91-generic", "6.1.0", "6.18.2-aws"],
+)
+def test_a_kernel_at_or_above_what_firecracker_validates_is_accepted(release):
+    answer = judge_containment(a_machine(kernel_release=release))
+
+    assert claim(answer, NEEDS_A_KERNEL_FIRECRACKER_TESTS).met is True
+
+
+@pytest.mark.parametrize("release", ["3.10.102", "4.14.0", "4.19.2", "5.9.16"])
+def test_a_kernel_below_what_firecracker_validates_is_refused(release):
+    answer = judge_containment(a_machine(kernel_release=release))
+    judged = claim(answer, NEEDS_A_KERNEL_FIRECRACKER_TESTS)
+
+    assert answer.required_containment_available is False
+    assert judged.met is False
+    assert release in judged.because
+
+
+def test_the_kernel_requirement_says_where_it_came_from_and_does_not_overstate_it():
+    """Firecracker does not forbid an older kernel, and neither does this.
+
+    Its kernel policy says untabled versions "might work" but are not validated
+    in its test suite. Reporting that as a prohibition would be a different
+    claim from the one the source makes, so the reason says which it is.
+    """
+    answer = judge_containment(a_machine(kernel_release="4.19.2"))
+    judged = claim(answer, NEEDS_A_KERNEL_FIRECRACKER_TESTS)
+
+    assert FIRECRACKER_KERNEL_POLICY_URL in judged.because
+    assert "does not forbid" in judged.because
+    assert "not validated in its test suite" in judged.because
+
+
+def test_a_kernel_that_reports_no_version_number_is_an_unknown_not_a_no():
+    answer = judge_containment(a_machine(kernel_release="unknown"))
+    judged = claim(answer, NEEDS_A_KERNEL_FIRECRACKER_TESTS)
+
+    assert judged.met is None
+    assert "'unknown'" in judged.because
+
+
+def test_the_kernel_floor_is_the_one_firecracker_publishes():
+    assert OLDEST_HOST_KERNEL_FIRECRACKER_VALIDATES == (5, 10)
+
+
+# ── What the report says when it cannot answer ────────────────────────────
+
+
+def test_a_claim_that_could_not_be_established_counts_against_availability():
+    """The rule the container run place already follows, applied here.
+
+    When the intended isolation cannot be shown to be present, the answer is
+    no. Treating "could not tell" as "probably fine" is how a task ends up
+    running somewhere weaker than anybody agreed to.
+    """
+    answer = judge_containment(a_machine(kernel_release="unknown"))
+
+    assert answer.required_containment_available is False
+
+
+def test_the_settings_are_unanswerable_while_no_virtual_machine_can_start():
+    answer = judge_containment(a_machine(hardware_virtualisation_reachable=False))
+    rootfs = claim(answer, "the small isolated virtual machine's root filesystem")
+
+    assert rootfs.met is None
+    assert "It becomes answerable only once the four claims above hold" in rootfs.because
+
+
+def test_whats_missing_lists_only_what_is_wrong_and_why():
+    answer = judge_containment(
+        a_machine(
+            kernel_release="3.10.102",
+            hardware_virtualisation_reachable=False,
+            firecracker_programs_found=(),
+            firecracker_programs_missing=("firecracker", "jailer"),
+        )
+    )
+    missing = answer.whats_missing()
+
+    assert any("3.10.102" in line for line in missing)
+    assert any("firecracker, jailer" in line for line in missing)
+    assert not any(NEEDS_A_PROCESSOR_THAT_CAN in line for line in missing)
+    assert all(" — " in line and ": " in line for line in missing)
+
+
+def test_an_answer_with_no_requirements_in_it_is_not_treated_as_available():
+    """An empty report is the absence of evidence, not evidence of readiness."""
+    from core.agentic_v2_containment_readiness import ContainmentAnswer
+
+    assert ContainmentAnswer(machine="nowhere").required_containment_available is False
+
+
+# ── The manifest is read, not copied ──────────────────────────────────────
+
+
+def test_a_new_setting_in_the_manifest_is_reported_rather_than_ignored(monkeypatch):
+    """The drift guard. A requirement nobody checks is worse than none at all.
+
+    If the manifest starts demanding something this report does not understand,
+    the honest output is to say so. The alternative — quietly reporting on the
+    settings it happens to know about — would let the answer stay green while
+    the requirement it answers about had changed underneath it.
+    """
+    monkeypatch.setitem(REQUIRED_MICROVM_POLICY, "memory", "512MiB-hard-cap")
+    try:
+        answer = judge_containment(a_machine())
+    finally:
+        REQUIRED_MICROVM_POLICY.pop("memory", None)
+
+    unknown = claim(answer, "the manifest's containment setting 'memory'")
+    assert unknown.met is None
+    assert "does not know how to describe or check" in unknown.because
+    assert answer.required_containment_available is False
+
+
+def test_the_report_says_containment_is_mandatory_and_reads_that_from_the_manifest():
+    answer = judge_containment(a_machine())
+    premise = claim(answer, "containment is mandatory")
+
+    assert premise.met is True
+    assert "REQUIRED_MICROVM_POLICY" in premise.because
+
+
+def test_a_manifest_that_stopped_requiring_containment_would_show_up(monkeypatch):
+    monkeypatch.setitem(REQUIRED_MICROVM_POLICY, "required", False)
+    try:
+        answer = judge_containment(a_machine())
+    finally:
+        REQUIRED_MICROVM_POLICY["required"] = True
+
+    assert claim(answer, "containment is mandatory").met is False
+    assert answer.required_containment_available is False
+
+
+def test_the_premise_is_stated_before_the_details_of_it():
+    answer = judge_containment(a_machine())
+    claims = [item.claim for item in answer.requirements]
+    premise = next(
+        index for index, item in enumerate(claims)
+        if item.startswith("containment is mandatory")
+    )
+    detail = next(
+        index for index, item in enumerate(claims) if "root filesystem" in item
+    )
+
+    assert premise < detail
+
+
+def test_nothing_was_added_above_the_frozen_function_in_the_substrate_module():
+    """A trap this change walked into, left pinned so nobody walks into it twice.
+
+    core/agentic_v2_license.py freezes the exact bytecode identity of
+    core.agentic_v2_substrate.canonical_sha256, and that identity includes the
+    line the function starts on. A single blank line added anywhere above it
+    breaks ninety-one licence tests, none of which mention the substrate module
+    in their failure message. Reading REQUIRED_MICROVM_POLICY from that module
+    meant putting a constant in it, which is exactly how one arrives here.
+
+    This test fails on its own, with a message that names the cause.
+    """
+    from core.agentic_v2_license import license_evaluator_runtime_identity
+    from core.agentic_v2_substrate import canonical_sha256
+
+    try:
+        license_evaluator_runtime_identity()
+    except RuntimeError as error:
+        pytest.fail(
+            "the licence evaluator no longer recognises its own frozen "
+            "identity. If core/agentic_v2_substrate.py was edited, check "
+            "whether a line was added above canonical_sha256, which now starts "
+            f"on line {canonical_sha256.__code__.co_firstlineno}. Its starting "
+            "line is part of the frozen identity, so moving it down by even "
+            "one blank line breaks every licence report. New constants in that "
+            f"module go below it, not above. Underlying error: {error}"
+        )
+
+
+# ── Reading a machine ─────────────────────────────────────────────────────
+
+
+def test_reading_a_machine_takes_the_program_and_hardware_facts_from_one_place():
+    """Two ways of reading one fact is how two answers start to disagree."""
+    facts = read_this_machine(
+        kernel_release="6.1.0",
+        microvm_report=a_microvm_report(kvm=True, programs=("firecracker",)),
+    )
+
+    assert facts.hardware_virtualisation_reachable is True
+    assert facts.firecracker_programs_found == ("firecracker",)
+    assert facts.firecracker_programs_missing == ("jailer",)
+
+
+def test_reading_a_machine_finds_the_processor_capabilities(tmp_path):
+    cpuinfo = tmp_path / "cpuinfo"
+    cpuinfo.write_text(
+        "processor\t: 0\nvendor_id\t: AuthenticAMD\nflags\t\t: fpu vme svm aes\n",
+        encoding="utf-8",
+    )
+    facts = read_this_machine(
+        cpuinfo_path=cpuinfo,
+        docker_marker_path=tmp_path / "absent",
+        cgroup_path=tmp_path / "absent",
+        kernel_release="6.1.0",
+        microvm_report=a_microvm_report(),
+    )
+
+    assert facts.processor_flags_were_readable is True
+    assert "svm" in facts.processor_flags
+
+
+def test_a_processor_capability_list_that_cannot_be_read_is_reported_as_such(tmp_path):
+    facts = read_this_machine(
+        cpuinfo_path=tmp_path / "there-is-no-such-file",
+        docker_marker_path=tmp_path / "absent",
+        cgroup_path=tmp_path / "absent",
+        kernel_release="6.1.0",
+        microvm_report=a_microvm_report(),
+    )
+
+    assert facts.processor_flags_were_readable is False
+    assert facts.processor_flags == ()
+
+
+def test_a_processor_capability_list_written_the_other_way_round_is_read(tmp_path):
+    """Some machines label the same list Features rather than flags."""
+    cpuinfo = tmp_path / "cpuinfo"
+    cpuinfo.write_text("Features\t: fp asimd vmx\n", encoding="utf-8")
+    facts = read_this_machine(
+        cpuinfo_path=cpuinfo,
+        docker_marker_path=tmp_path / "absent",
+        cgroup_path=tmp_path / "absent",
+        kernel_release="6.1.0",
+        microvm_report=a_microvm_report(),
+    )
+
+    assert "vmx" in facts.processor_flags
+
+
+def test_being_inside_a_container_is_noticed_from_the_marker_file(tmp_path):
+    marker = tmp_path / ".dockerenv"
+    marker.write_text("", encoding="utf-8")
+    facts = read_this_machine(
+        cpuinfo_path=tmp_path / "absent",
+        docker_marker_path=marker,
+        cgroup_path=tmp_path / "absent",
+        kernel_release="6.1.0",
+        microvm_report=a_microvm_report(),
+    )
+
+    assert facts.inside_a_container is True
+    assert str(marker) in facts.container_evidence
+
+
+def test_being_inside_a_container_is_noticed_from_the_process_groups(tmp_path):
+    cgroup = tmp_path / "cgroup"
+    cgroup.write_text("7:memory:/docker/f1e2da85\n", encoding="utf-8")
+    facts = read_this_machine(
+        cpuinfo_path=tmp_path / "absent",
+        docker_marker_path=tmp_path / "absent",
+        cgroup_path=cgroup,
+        kernel_release="6.1.0",
+        microvm_report=a_microvm_report(),
+    )
+
+    assert facts.inside_a_container is True
+    assert "/docker/" in facts.container_evidence
+
+
+def test_a_machine_that_is_not_in_a_container_says_so(tmp_path):
+    cgroup = tmp_path / "cgroup"
+    cgroup.write_text("0::/init.scope\n", encoding="utf-8")
+    facts = read_this_machine(
+        cpuinfo_path=tmp_path / "absent",
+        docker_marker_path=tmp_path / "absent",
+        cgroup_path=cgroup,
+        kernel_release="6.1.0",
+        microvm_report=a_microvm_report(),
+    )
+
+    assert facts.inside_a_container is False
+    assert facts.container_evidence == ""
+
+
+def test_being_inside_a_container_is_explained_rather_than_held_against_the_machine():
+    """Firecracker can run inside a container. The note must not say otherwise.
+
+    Being in a container explains why the hardware is out of reach here; it is
+    not itself a reason the containment could never work.
+    """
+    answer = judge_containment(
+        a_machine(
+            hardware_virtualisation_reachable=False,
+            inside_a_container=True,
+            container_evidence="/.dockerenv exists",
+        )
+    )
+
+    assert any("not disqualifying by itself" in note for note in answer.notes)
+    assert not any(item.claim.startswith("this is not a container") for item in answer.requirements)
+
+
+# ── This machine, read for real ───────────────────────────────────────────
+
+
+def test_reading_this_machine_costs_nothing_and_answers():
+    """The live reading. It opens files this process may already open."""
+    facts = read_this_machine()
+    answer = judge_containment(facts)
+
+    assert isinstance(facts.kernel_release, str) and facts.kernel_release
+    assert [item.claim for item in answer.requirements]
+    assert isinstance(answer.required_containment_available, bool)
+
+
+def test_the_check_never_runs_a_command_to_find_any_of_this_out():
+    """Reading a machine must not become running things on it.
+
+    A readiness check that shells out is a readiness check that can have side
+    effects, and this one is meant to be safe to run anywhere, including on a
+    machine where running things is exactly what is not allowed.
+    """
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "core"
+        / "agentic_v2_containment_readiness.py"
+    ).read_text(encoding="utf-8")
+
+    assert "import subprocess" not in source
+    assert "subprocess." not in source
+    assert "os.system" not in source
+
+
+# ── The machines that cannot be read from here ────────────────────────────
+
+
+def test_every_recorded_finding_says_where_it_came_from_and_when():
+    assert RECORDED_FINDINGS
+    for finding in RECORDED_FINDINGS:
+        assert finding.machine
+        assert finding.established_by
+        assert finding.on_date == "2026-08-26"
+        assert len(finding.finding) > 80, "a finding with no reasoning in it"
+
+
+def test_no_recorded_finding_claims_the_containment_is_available():
+    """The answer as it stands. This test changes on the day the answer does."""
+    assert all(
+        finding.containment_available is not True for finding in RECORDED_FINDINGS
+    )
+
+
+def test_the_github_runner_finding_rests_on_githubs_own_documentation():
+    github = next(
+        finding for finding in RECORDED_FINDINGS if "github-hosted" in finding.machine
+    )
+
+    assert github.containment_available is False
+    assert "docs.github.com" in github.established_by
+    assert "not officially supported" in github.finding
+
+
+def test_the_self_hosted_machine_is_an_unknown_because_it_does_not_exist():
+    """A machine nobody has registered has no containment answer either way.
+
+    Recording this as "not available" would be wrong in a way that matters: it
+    would read as though somebody had looked at a machine and found it wanting,
+    when the truth is that the machine has never been built.
+    """
+    self_hosted = next(
+        finding for finding in RECORDED_FINDINGS if "self-hosted" in finding.machine
+    )
+
+    assert self_hosted.containment_available is None
+    assert "there is no such machine" in self_hosted.finding
+    assert "total_count 0" in self_hosted.established_by
+
+
+# ── Which machines the workflows actually ask for ─────────────────────────
+
+
+def test_the_machines_the_workflows_ask_for_are_read_from_the_workflow_files(tmp_path):
+    (tmp_path / "one.yml").write_text(
+        "jobs:\n  build:\n    runs-on: ubuntu-latest\n", encoding="utf-8"
+    )
+    (tmp_path / "two.yaml").write_text(
+        "jobs:\n  test:\n    runs-on: [self-hosted, linux, x64, agentic-sandbox]\n",
+        encoding="utf-8",
+    )
+
+    assert runner_labels_used_by_workflows(tmp_path) == (
+        "agentic-sandbox",
+        "ubuntu-latest",
+    )
+
+
+def test_a_machine_chosen_while_the_workflow_runs_is_not_guessed_at(tmp_path):
+    (tmp_path / "one.yml").write_text(
+        "jobs:\n  build:\n    runs-on: ${{ inputs.runner }}\n", encoding="utf-8"
+    )
+
+    assert runner_labels_used_by_workflows(tmp_path) == ()
+
+
+def test_a_workflow_running_somewhere_new_is_reported_as_a_gap(tmp_path):
+    (tmp_path / "one.yml").write_text(
+        "jobs:\n  build:\n    runs-on: macos-14\n", encoding="utf-8"
+    )
+    problems = check_every_machine_has_a_containment_finding(tmp_path)
+
+    assert len(problems) == 1
+    assert "macos-14" in problems[0]
+    assert "Establish it before that machine is counted" in problems[0]
+
+
+def test_every_machine_this_repository_uses_today_has_an_answer_recorded():
+    """The live guard against the answer going stale.
+
+    This reads the real workflow files. Adding one that runs somewhere new
+    fails here rather than letting the new machine quietly inherit a finding
+    that was established about a different one.
+    """
+    assert check_every_machine_has_a_containment_finding(WORKFLOWS_DIRECTORY) == []
+
+
+# ── The whole answer, and the refusal that follows ────────────────────────
+
+
+def test_the_whole_answer_covers_this_machine_and_the_recorded_ones():
+    report = containment_answer_everywhere(
+        facts=a_machine(hardware_virtualisation_reachable=False),
+        workflows_directory=WORKFLOWS_DIRECTORY,
+    )
+
+    assert report["required_containment"] == dict(REQUIRED_MICROVM_POLICY)
+    assert report["this_machine"]["required_containment_available"] is False
+    assert len(report["recorded_findings"]) == len(RECORDED_FINDINGS)
+    assert report["machines_without_a_finding"] == []
+    assert report["available_on_any_machine_in_play"] is False
+
+
+def test_the_whole_answer_can_be_written_down_as_it_stands():
+    report = containment_answer_everywhere(workflows_directory=WORKFLOWS_DIRECTORY)
+
+    assert json.loads(json.dumps(report)) == report
+
+
+def test_a_machine_here_that_could_do_it_would_change_the_answer():
+    report = containment_answer_everywhere(facts=a_machine())
+
+    assert report["available_on_any_machine_in_play"] is True
+    assert refuse_command_execution(report) is None
+
+
+def test_an_unanswered_machine_is_reported_beside_the_answer_not_folded_into_it(
+    tmp_path,
+):
+    """A gap and a no are different things, and the report keeps them apart.
+
+    ``scripts/check_agentic_containment.py`` passes only when both hold, so a
+    workflow that starts running somewhere nobody has answered for fails the
+    check even on a machine that could itself provide the containment. The two
+    are separate keys rather than one, because folding them together would
+    report an unanswered machine as though it had been answered no.
+    """
+    (tmp_path / "somewhere-new.yml").write_text(
+        "jobs:\n  build:\n    runs-on: macos-15\n", encoding="utf-8"
+    )
+
+    report = containment_answer_everywhere(
+        facts=a_machine(), workflows_directory=tmp_path
+    )
+
+    assert report["available_on_any_machine_in_play"] is True
+    assert report["every_machine_in_play_has_an_answer"] is False
+    assert len(report["machines_without_a_finding"]) == 1
+    assert "macos-15" in report["machines_without_a_finding"][0]
+
+
+def test_every_machine_this_repository_uses_today_is_answered_in_the_report():
+    report = containment_answer_everywhere(
+        facts=a_machine(), workflows_directory=WORKFLOWS_DIRECTORY
+    )
+
+    assert report["every_machine_in_play_has_an_answer"] is True
+
+
+def test_not_looking_at_the_workflows_is_reported_as_not_looked_not_as_yes():
+    """The distinction the script's exit code depends on.
+
+    With no workflows directory, nothing inspected which machines are in play.
+    Saying "every machine has an answer" then would be a claim nobody checked,
+    and it is exactly the sort of unasked question this module refuses to let
+    pass as a cleared one.
+    """
+    report = containment_answer_everywhere(facts=a_machine())
+
+    assert report["every_machine_in_play_has_an_answer"] is None
+    assert report["machines_without_a_finding"] == []
+
+
+def test_commands_a_model_chose_are_refused_today_and_the_reason_is_the_containment():
+    report = containment_answer_everywhere(
+        facts=a_machine(hardware_virtualisation_reachable=False)
+    )
+    refusal = refuse_command_execution(report)
+
+    assert refusal is not None
+    assert "must not run" in refusal
+    assert REQUIRED_MICROVM_POLICY["runtime"] in refusal
+    assert "the substitution the specification forbids" in refusal
+
+
+def test_the_refusal_reads_this_machine_when_it_is_given_nothing():
+    refusal = refuse_command_execution()
+
+    assert refusal is not None, (
+        "this machine cannot provide the containment, so the refusal must stand"
+    )
+
+
+def test_answering_the_containment_question_opens_none_of_the_three_blocks():
+    """The point of instruction six, checked rather than promised.
+
+    Establishing that containment is unavailable is not permission to run
+    anything, and it must not have loosened the refusals that were already
+    holding command execution shut. Those three are run, not read.
+    """
+    from core.execution_environment_readiness import (
+        check_agentic_sandbox_v2_blocks_are_intact,
+    )
+
+    assert check_agentic_sandbox_v2_blocks_are_intact() == []
+
+
+# ── The printed report ────────────────────────────────────────────────────
+
+
+def test_the_printed_report_states_the_requirement_the_verdict_and_the_sources():
+    report = containment_answer_everywhere(
+        facts=a_machine(kernel_release="3.10.102", hardware_virtualisation_reachable=False),
+        workflows_directory=WORKFLOWS_DIRECTORY,
+    )
+    printed = "\n".join(describe_containment(report))
+
+    assert "What the substrate manifest requires" in printed
+    assert "runtime: firecracker" in printed
+    assert "3.10.102" in printed
+    assert "docs.github.com" in printed
+    assert "there is no such machine" in printed
+    assert "must not run" in printed
+
+
+def test_the_printed_report_says_so_plainly_if_the_containment_becomes_available():
+    report = containment_answer_everywhere(facts=a_machine())
+    printed = "\n".join(describe_containment(report))
+
+    assert "The required containment is available" in printed
+    assert "opening command execution is a separate decision" in printed
+
+
+def test_the_printed_report_shows_a_machine_nobody_has_an_answer_for(tmp_path):
+    (tmp_path / "one.yml").write_text(
+        "jobs:\n  build:\n    runs-on: windows-2022\n", encoding="utf-8"
+    )
+    report = containment_answer_everywhere(
+        facts=a_machine(hardware_virtualisation_reachable=False),
+        workflows_directory=tmp_path,
+    )
+    printed = "\n".join(describe_containment(report))
+
+    assert "Gap: a workflow now runs on 'windows-2022'" in printed
+
+
+def test_the_printed_report_uses_no_symbols_or_shorthand():
+    """It is read by somebody deciding whether to build a machine, not by a tool."""
+    report = containment_answer_everywhere(workflows_directory=WORKFLOWS_DIRECTORY)
+
+    for line in describe_containment(report):
+        assert "✓" not in line and "✗" not in line and "❌" not in line
+        assert "N/A" not in line and "TBD" not in line

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
@@ -2,8 +2,10 @@
 
 - Written: 2026-08-25
 - Updated: 2026-08-26 — step one of section 8 is done. The cost of a stage-one
-  run has been worked out and is in section 7a. Nothing was spent doing it and
-  nothing was switched on.
+  run has been worked out and is in section 7a. The containment question that
+  blocked stage three has been answered, and the answer is in section 7b: the
+  containment is available on no machine currently in play. Nothing was spent
+  finding either out and nothing was switched on.
 - Status: **specification only. Nothing here is built, and nothing in it may be
   built without a separate, explicit approval to open command execution.**
 - Related GitHub Project: hyeonsangjeon/projects/5 — card
@@ -35,7 +37,11 @@ result, and a deadline.
 **There is a large amount of supporting machinery.** Alongside the tools sit
 modules for the contract, provenance, supply chain, licence evaluation, the
 image format, and the substrate. The substrate manifest requires a small
-isolated virtual machine and refuses to validate without that policy.
+isolated virtual machine and refuses to validate without that policy. Whether
+any machine can actually provide that virtual machine is now answered rather
+than assumed — `core/agentic_v2_containment_readiness.py` reads the machine it
+is on and reports which parts of the policy it can meet. Section 7b has the
+answer: none of the machines in play can meet it.
 
 **Three things stand between this and a real run:**
 
@@ -106,6 +112,11 @@ whether the network is reachable, how much memory and time, which user it runs
 as, and what happens when it exceeds any of those. Prove each one with a test
 that tries to exceed it and requires the attempt to fail. This is a test-only
 stage; nothing is switched on.
+*Half of this is now done, and it is the half that turned out to matter.
+Section 7b establishes **where** the containment could run, by reading machines
+rather than by asserting it, and the answer is: nowhere currently in play.
+Writing rules and testing them can proceed regardless, but they would be rules
+for a machine that does not yet exist.*
 
 **Stage three — open command execution behind its own approval.**
 Only after stage two passes. `exec_run` starts running real commands inside the
@@ -129,7 +140,9 @@ the loop is worth having.
 | `batch-runner/core/agentic_v2_runner.py` | Unchanged. Still replays the written-down list; the loop was added beside it, not inside it. |
 | `batch-runner/core/agentic_v2_tools.py` | Unchanged surface; the ceilings it already applies become the loop's limits. |
 | `batch-runner/core/agentic_v2_fixture_backend.py` | Stays shut through stages one and two. |
-| `batch-runner/core/agentic_v2_substrate.py` | Stage two: the containment rules are stated and checked here. |
+| `batch-runner/core/agentic_v2_substrate.py` | Stage two: the containment rules are stated and checked here. `REQUIRED_MICROVM_POLICY` is the one written-down copy of them. |
+| `batch-runner/core/agentic_v2_containment_readiness.py` | Stage two, **built**: reads a machine and reports which of those rules it can actually meet, and why. Reads the policy above rather than restating it. |
+| `batch-runner/core/agentic_v2_microvm.py` | Unchanged. Reports whether a boot test could be attempted; does not judge the host kernel or the processor, which is why the module above exists. |
 | `batch-runner/step2_run_inference.py` | Stage three: the guard is revisited, not before. |
 | `batch-runner/core/executor.py` | Stage three: the paid-run refusal is revisited, not before. |
 
@@ -256,6 +269,113 @@ will change by itself the day somebody wires a real client in.
 That was left alone on purpose: the loop is a separate module, so nothing that
 runs today changed behaviour, and the existing runner's tests still hold.
 
+## 7b. Where the containment could actually run, established on 2026-08-26
+
+Section 11 used to say the containment question "has not been established". It
+has now. Like section 7a, this cost nothing: no model was called, no command was
+run, no account was signed in to, and nothing was installed. It reads machines
+and published policies.
+
+### What was actually required, and where that is written
+
+The substrate manifest will not validate unless it promises a small isolated
+virtual machine, run by Firecracker, with no network, a read-only root
+filesystem, and a working directory that is wiped and size-limited. Those five
+settings now have exactly one written-down copy,
+`core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY`, which the manifest check
+enforces and the readiness report reads. Two copies could disagree with each
+other about what is required; one cannot.
+
+### The answer, in one line
+
+**The containment is available on no machine currently in play.** Three machines
+are in play, and each is a different kind of no.
+
+| machine | can it provide the containment? | how that was established |
+|---|---|---|
+| the box this repository is worked on from | no | read from the machine itself |
+| GitHub-hosted runners | no | GitHub's own published documentation |
+| the self-hosted `agentic-sandbox` runner | the question cannot be answered | there is no such machine |
+
+### This box
+
+Its processor can do the job — it reports `svm`, so the hardware itself supports
+running a virtual machine. Everything above the hardware fails:
+
+- It cannot reach the hardware. This is running inside a container
+  (`/.dockerenv` exists) with no virtualisation device passed through. Running
+  inside a container is not disqualifying on its own — Firecracker supports it
+  when the device is passed through — but nothing here passes it through.
+- Its kernel is 3.10.102. The oldest host kernel Firecracker validates against
+  is 5.10. Firecracker does not *forbid* older ones; its kernel policy says
+  untabled versions "might work" but are not validated in its test suite. An
+  unvalidated containment boundary is not one to rely on, so this is treated as
+  not met rather than as forbidden, and the report says which of the two it
+  means.
+- Neither `firecracker` nor `jailer` is installed.
+
+### GitHub-hosted runners
+
+This is a documented no, not an unknown. GitHub's own documentation says running
+a virtual machine inside one of its runners is "technically possible" but "not
+officially supported" — experimental, at the user's own risk, with no guarantee
+of stability, performance or compatibility. **A containment boundary offered
+with no guarantee is not a containment boundary.** The whole point of stage
+three's containment is that it holds when a model asks for something unexpected,
+and "no guarantee of compatibility" is the opposite of that.
+
+### The self-hosted runner
+
+`.github/workflows/agentic-sandbox-preflight.yml` asks for a machine labelled
+`agentic-sandbox`. No self-hosted runner is registered to this repository, and
+that workflow has never run. So this is not a no — it is a question with no
+subject. A machine that does not exist has no containment either way, and
+whether a future one would have it is a decision nobody has taken yet.
+
+This is worth stating separately from the other two, because it is the only one
+of the three that a decision could change.
+
+### How to see this for yourself, for free
+
+```
+cd batch-runner
+python scripts/check_agentic_containment.py
+```
+
+It prints every requirement, whether this machine meets it, and *why* in a full
+sentence; then the findings recorded about the two machines that cannot be read
+from here, each with its source; then the answer. It exits 0 only if the
+containment is available somewhere, so it is safe to wire into an automated
+check — today it exits 1.
+
+Three properties of that check are worth knowing:
+
+- **It never runs a command to find any of this out.** It reads files and
+  inspects the program search path. A test asserts the module's own source
+  contains no way of starting a process, because a containment check that
+  starts processes to decide whether starting processes is safe has the problem
+  backwards.
+- **It notices when a new machine appears.** It reads `runs-on:` out of every
+  workflow file and fails if any machine is being asked for that has no recorded
+  finding. Adding a runner to a workflow without answering the containment
+  question for it is caught by a test rather than by a person remembering.
+- **It distinguishes "no" from "cannot be answered".** A requirement whose
+  answer is unknown counts against availability rather than for it, so an
+  unanswered question can never be mistaken for a cleared one.
+
+### What this changes, and what it deliberately does not
+
+It answers the question that blocked stage three from being *designed*. It does
+not unblock stage three, and it removes no refusal: `exec_run` still answers
+`capability_unavailable`, and the two guards still reject the mode. The
+readiness module has its own function for this,
+`refuse_command_execution`, which returns a refusal today and would return
+nothing only once the containment genuinely exists somewhere.
+
+It also changes what stage three's first step is. It was "write the containment
+rules". It is now "obtain a machine that can hold them" — which is a request for
+hardware, not a code change, and is the owner's to make.
+
 ## 8. Order the work would be done in
 
 1. ~~Work out and get approval for the cost ceiling of a small stage-one run.~~
@@ -266,6 +386,11 @@ runs today changed behaviour, and the existing runner's tests still hold.
 3. Measure whether choosing tools helps, on the same five tasks. **Needs an
    approved amount and a way to reach a real model.**
 4. Write the containment rules and the tests that try to break them.
+   **Where those rules could run is now established (section 7b): nowhere in
+   play.** So this step now begins with obtaining a machine that can hold them,
+   which is a request for hardware rather than a code change. The rules can be
+   written and tested before that machine exists; they simply would not apply to
+   anything yet.
 5. Seek approval for command execution, presenting those test results.
 6. Only then, open `exec_run`.
 7. Revisit the two guards, each in its own change.
@@ -282,9 +407,16 @@ runs today changed behaviour, and the existing runner's tests still hold.
   `tests/test_agentic_v2_conversation.py::test_the_run_stops_at_the_dispatchers_own_call_ceiling`.
 - Stage two: one test per containment rule, each attempting to exceed it and
   requiring failure.
+- Stage two: a check that reports, per machine, which containment rules that
+  machine can meet and why. **Done:**
+  `tests/test_agentic_v2_containment_readiness.py`, 61 tests, including one that
+  requires the check itself to be incapable of starting a process and one that
+  fails if a workflow starts asking for a machine nobody has answered the
+  containment question for.
 - All stages: the existing test that opens all three guards and requires them
   shut must keep passing until the stage that deliberately changes one. **Still
-  passing**, and the loop's own test suite runs all three blocks as well.
+  passing**, and both the loop's and the containment check's own test suites run
+  all three blocks as well.
 
 ## 10. Done when
 
@@ -292,8 +424,13 @@ runs today changed behaviour, and the existing runner's tests still hold.
       failure it was shown. (Against a stand-in model. A real one is still out
       of reach and needs an approved amount.)
 - [ ] Every containment rule has a test that tries to exceed it and fails.
+      (Which machine could satisfy those rules is now established — none of the
+      three in play. See section 7b.)
 - [ ] Command execution is opened only after a separate written approval.
 - [ ] The free check reports this run place as able to run only when it is.
+      (Two of the three questions behind that report are now answered from real
+      readings rather than assumed: whether a real model can be reached, and
+      whether the containment exists anywhere. Both answers are no.)
 
 ## 11. Known blockers and the next decision
 
@@ -311,10 +448,17 @@ runs today changed behaviour, and the existing runner's tests still hold.
   empty on purpose, and the free check refuses while it is empty. The 32.23
   United States dollars approved on 2026-08-25 was for the three-place
   comparison and does not extend here.
-- **Blocked on a decision about containment.** The substrate manifest requires a
-  small isolated virtual machine. Whether that is available on the machines this
-  would run on has not been established, and stage three cannot be designed
-  concretely until it is. This blocks stage three only, not stage one.
+- **Blocked on there being no machine that can hold the containment.** This was
+  previously "blocked on a decision about containment", with the note that
+  whether it was available "has not been established". It has now been
+  established, by reading machines rather than by asserting it, and the answer
+  is in section 7b: **no machine currently in play can provide it.** This box
+  cannot reach hardware virtualisation and runs a kernel below the oldest
+  Firecracker validates; GitHub-hosted runners offer the capability only as
+  unsupported and unguaranteed, which is not a containment boundary; and the
+  self-hosted machine one workflow asks for has never been registered, so its
+  question has no subject. This blocks stage three only, not stage one. It is
+  also the only blocker on this list that code cannot clear: it needs a machine.
 
 The next decision is now a specific one with a price beside it: **which row of
 the table in section 7a is stage one worth running at?** The cheapest row that
@@ -325,3 +469,11 @@ own defaults are 492.67 to run.
 Choosing a row does not start anything, and neither figure above is an approved
 amount. Approving one, and removing the refusal that keeps a real model out of
 the loop, are two separate steps and both are the owner's to take.
+
+There is now a second decision, for stage three rather than stage one, and it
+does not compete with the first: **is a machine that can run a Firecracker
+virtual machine worth obtaining?** Section 7b establishes that none exists
+today. Stage one does not need one — it never runs a command. Stage three
+cannot happen without one. Deciding not to obtain one is a legitimate answer,
+and it would mean stage three is closed rather than pending, which is worth
+knowing either way.


### PR DESCRIPTION
## 무엇을 했나

명세서 `tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md`가 계속 열어두고 있던 질문 하나에 답합니다.

> **Blocked on a decision about containment.** ... Whether that is available on the machines this would run on **has not been established**

이제 확인되었습니다. **답은 "지금 쓰는 어떤 머신에서도 불가능"입니다.**

비용 0입니다. 모델 호출 없음, 명령 실행 없음, Azure 로그인 없음, 키 생성 없음, 설치 없음. 파일을 읽고 프로그램 경로를 조회한 것이 전부입니다.

## 세 머신, 세 가지 다른 "아니오"

| 머신 | 격리 제공 가능? | 근거 |
|---|---|---|
| 이 저장소를 작업하는 이 머신 | 불가 | 머신에서 직접 읽음 |
| GitHub 호스트 러너 | 불가 | GitHub 자체 공식 문서 |
| self-hosted `agentic-sandbox` | **답할 수 없음** | 그런 머신이 존재하지 않음 |

**이 머신** — 프로세서는 `svm`을 보고하므로 하드웨어 자체는 가능합니다. 그 위가 전부 막혀 있습니다. 컨테이너 안(`/.dockerenv`)이고 가상화 장치가 전달되지 않았으며, 커널이 3.10.102로 Firecracker가 검증하는 가장 낮은 5.10보다 낮고, `firecracker`·`jailer`가 없습니다.

**GitHub 호스트 러너** — 모름이 아니라 문서화된 불가입니다. GitHub은 러너 안에서 가상 머신을 돌리는 것이 "technically possible"이지만 "not officially supported"이며 안정성·성능·호환성을 보장하지 않는다고 명시합니다. **보장이 없는 격리 경계는 격리 경계가 아닙니다.** 3단계 격리의 존재 이유는 모델이 예상 밖의 것을 요청했을 때 버티는 것인데, "호환성 보장 없음"은 그 반대입니다.

**self-hosted 러너** — 이것만은 "아니오"가 아니라 주어 없는 질문입니다. `.github/workflows/agentic-sandbox-preflight.yml`이 `agentic-sandbox` 라벨을 요구하지만 등록된 러너가 없고 그 워크플로는 실행된 적이 없습니다. 셋 중 결정으로 바뀔 수 있는 유일한 항목이라 따로 적었습니다.

## 설계상 지키는 것 네 가지

- **요구 설정을 다시 적지 않습니다.** 다섯 설정을 `core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY`에서 읽습니다(이번에 상수로 추출). 사본이 둘이면 서로 어긋날 수 있고, 하나면 그럴 수 없습니다.
- **명령을 절대 실행하지 않습니다.** 자기 소스를 읽어 프로세스 시작 경로가 생기면 실패하는 테스트가 있습니다. 프로세스를 시작해도 되는지 판단하려고 프로세스를 시작하는 검사는 문제를 거꾸로 잡은 것입니다.
- **"확인 불가"를 가용으로 세지 않습니다.** 답이 없는 요구는 가용에 반대로 셉니다. 묻지 않은 질문이 통과한 질문으로 오인될 수 없습니다.
- **새 머신이 생기면 알아챕니다.** 모든 워크플로 파일의 `runs-on:`을 읽어, 답이 기록되지 않은 머신을 쓰기 시작하면 테스트가 실패합니다. 사람이 기억하는 대신 테스트가 잡습니다.

"검증 안 됨"과 "금지됨"도 구분합니다. Firecracker는 낮은 커널을 금지하지 않고 테스트하지 않을 뿐이며, 보고서가 그렇게 말합니다. 요구를 과장하는 것도 틀린 답의 일종입니다.

## 무엇을 켜지 않았나

아무것도 켜지 않았고 어떤 거부도 제거하지 않았습니다.

- `exec_run`은 여전히 `capability_unavailable`을 답합니다.
- `step2_run_inference._require_runnable_execution_mode`와 `core/executor.py`는 여전히 모드를 거부합니다.
- `check_agentic_sandbox_v2_blocks_are_intact()`를 실제로 **실행하는** 테스트가 이 변경에 포함되어 있고 통과합니다.
- `refuse_command_execution`은 오늘 거부를 반환하며, 격리가 실제로 어딘가 존재해야만 통과합니다.

3단계는 여전히 막혀 있습니다. 다만 막힌 이유가 "모른다"에서 "머신이 없다"로 바뀌었고, 이것은 코드로 풀 수 없는 유일한 차단 항목입니다.

## 직접 확인하는 법 (무료)

```
cd batch-runner
python scripts/check_agentic_containment.py
```

요구마다 충족 여부와 **그 이유**를 완전한 문장으로 출력하고, 여기서 읽을 수 없는 두 머신의 기록을 출처와 함께 출력한 뒤 답을 말합니다. 격리가 어딘가 가능하고 **또한** 워크플로가 쓰는 모든 머신에 답이 기록되어 있을 때만 종료 코드 0입니다. 오늘은 1입니다.

## 검증

- 새 테스트 61개, 전부 통과
- 전체 스위트 **3,946 통과 / 0 실패** (6 skipped, 45 deselected)
- `mypy core/ --ignore-missing-imports` — 170 errors in 32 files, 기준선과 동일. 새 모듈 기여분 0
- 라이선스·supply chain·contract·verifier·readiness 관련 스위트 530 통과

## 함정 하나를 테스트로 박아둠

`core/agentic_v2_substrate.py`의 `canonical_sha256` **위에** 줄을 추가하면 — 빈 줄 하나라도 — 라이선스 테스트 91개가 깨집니다. `core/agentic_v2_license.py`가 그 함수의 바이트코드 신원을 고정하는데 거기에 `co_firstlineno`가 포함되기 때문입니다. 에러 메시지는 라이선스 평가기를 가리킬 뿐 움직인 파일을 언급하지 않습니다. 이 변경이 실제로 이 함정에 빠졌고, 원인을 이름으로 말해주는 테스트를 남겨 다음 사람이 같은 곳에 빠지지 않게 했습니다.

## 승인이 필요한 것

없습니다. 이 PR은 아무것도 승인 요청하지 않고 아무 금액도 승인된 것으로 기록하지 않습니다.

다만 명세서에 **결정 하나가 새로 생겼고**, 1단계 결정과 경쟁하지 않습니다: **Firecracker 가상 머신을 돌릴 수 있는 머신을 확보할 가치가 있는가?** 1단계는 명령을 실행하지 않으므로 그 머신이 필요 없습니다. 3단계는 그것 없이는 불가능합니다. "확보하지 않는다"도 정당한 답이며, 그 경우 3단계는 보류가 아니라 종료입니다 — 어느 쪽이든 알아둘 가치가 있습니다.