### PR TITLE
fix(agentic-v2): state the containment rules once, with their numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,77 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **Four of the six things a containment has to say were never written down,
+  and the two that were had three copies that nothing compared.** A set of
+  settings is a containment only if it answers where a command may write,
+  whether it can reach the network, how much memory it gets, how long it may
+  run, who it runs as, and what happens when it exceeds any of those. Two were
+  answered. The working directory said `ephemeral-quota` — "there is a quota" —
+  and **never said what the quota was**, which is a rule nobody could apply even
+  if something were applying rules.
+
+  All six now have a number or a word, and every number that could be derived
+  from something already in the repository was derived rather than picked: the
+  work disk is **256 mebibytes**, twice what the tool layer already accepts, so
+  the tools can never accept a write the disk cannot hold; the clock is
+  **1,200 seconds**, the same per-task timeout the other three run places are
+  held to, so this column cannot lose a task to a stricter deadline than its
+  neighbours; the user is **`jailer-unprivileged`**, so "not root" is
+  checkable; a breach is **`stop-and-report`**, because a rule that has been
+  exceeded is a containment that is not holding. A test refuses any rule whose
+  name ends in a unit but whose value is not a positive whole number — the
+  exact shape the working directory had.
+
+  **Memory is the one number with nothing behind it, and it says so.** 4,096
+  mebibytes was picked. None of the three run places in the comparison caps
+  memory at all, so a cap here makes this column stricter on an axis the
+  comparison does not otherwise control. That is written into the rule's own
+  documentation, and a test fails if the admission is ever removed.
+
+  **Three copies became one.** The rules were stated in
+  `REQUIRED_MICROVM_POLICY`, in the signed supply-chain policy on disk, and in a
+  hand-written dictionary inside the supply-chain validator — with different
+  names in each (`read_only_rootfs: true` in one, `rootfs: "read-only"` in
+  another), which is what made a disagreement hard to see by eye. Nothing
+  compared any two of them, so a rule could be weakened in one place and left
+  standing in the others with every file still validating. The validator's copy
+  is now derived from the first, and a signed policy that disagrees is refused
+  with a message naming the rule and both places it is written down.
+
+  **Every rule is now refused when weakened** — 33 tests covering the network
+  opened to an allowlist or the host, a writable root filesystem, a persistent
+  working directory, any limit quadrupled, the user set to root, a breach rule
+  that carries on, the runtime changed to Docker, the containment marked
+  optional, and any rule deleted outright.
+
+  **What no test does is start a machine, exceed a limit and watch it stop.**
+  That test needs a machine that can host the containment — none of the three in
+  play can — and code that turns these rules into arguments for starting one,
+  which nobody has written. `tests/test_agentic_v2_containment_rules.py` says so
+  in its own opening lines rather than quietly omitting it, because a passing
+  test named after a thing that never happened is how an unenforced rule comes
+  to look enforced.
+
+- **A rule nothing applies was being reported as met.** The readiness report had
+  one field for "the containment is available", and it was answering two
+  different questions at once: *could this machine host the containment*, and
+  *is the containment actually in place*. Every policy rule now answers "cannot
+  be established here" instead of "met", and says which of the two reasons
+  applies.
+
+  They are two fields now because they are fixed by two different things. One
+  is fixed by finding or building a machine, and is read off the machine. The
+  other is fixed by writing the code that applies the rules — a fact about this
+  repository, so the answer is the same on every machine, and a better machine
+  does not change it. A reader of the refusal can now tell whether to go and
+  find a machine or go and write code.
+
+  This makes the report **strictly more cautious than before**: the refusal now
+  stands even on a machine meeting every hardware requirement. No refusal was
+  removed, nothing was switched on, and the three safety blocks are exactly as
+  shut as they were — `exec_run` still answers `capability_unavailable`, and
+  both guards still reject the mode.
+
 - **The cost arithmetic had no way to express a perception call, so marking's
   two extra models could not be counted even once they were named.** The
   previous change proved the gap existed: `grading_configs/default_v2.yaml`

--- a/batch-runner/core/agentic_v2_containment_readiness.py
+++ b/batch-runner/core/agentic_v2_containment_readiness.py
@@ -100,7 +100,35 @@ _POLICY_SETTING_AS_A_CLAIM = {
     "rootfs": "the small isolated virtual machine's root filesystem is {value}",
     "workdir": "the small isolated virtual machine's working directory is "
     "{value}",
+    "workdir_quota_mib": "the command may write at most {value} mebibytes",
+    "memory_mib": "the command is given at most {value} mebibytes of memory",
+    "wall_clock_seconds": "the command is stopped after {value} seconds",
+    "user": "the command runs as {value} rather than as a privileged user",
+    "on_breach": "exceeding any rule above results in {value}",
 }
+
+# What has to exist before any of the settings above can be reported as met.
+#
+# Nothing in this repository turns a containment rule into an argument for
+# starting a virtual machine. core/agentic_v2_microvm.py looks for the
+# Firecracker programs on the search path and stops there; no module reads
+# REQUIRED_MICROVM_POLICY and produces a start-up configuration from it.
+#
+# This matters more than it sounds. Until 2026-08-26 this report marked every
+# one of those settings as met the moment a machine could start a virtual
+# machine at all — as though being able to start one meant the rules had been
+# applied to it. On the three machines in play that never showed, because none
+# of them can start one. On the first machine that could, the report would have
+# said the containment was in place while nothing carried it there.
+#
+# A rule nobody applies is not met. It is unenforced, which is a different
+# answer, and the report now gives that one.
+NOTHING_APPLIES_THESE_RULES_YET = (
+    "no module turns core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY into "
+    "arguments for starting a virtual machine, so this rule is written down "
+    "and unenforced rather than met. core.agentic_v2_microvm only looks for "
+    "the Firecracker programs; it applies nothing"
+)
 
 
 @dataclass(frozen=True)
@@ -157,10 +185,17 @@ class Requirement:
 
 @dataclass(frozen=True)
 class RecordedFinding:
-    """An answer for a machine that cannot be read from this one."""
+    """An answer for a machine that cannot be read from this one.
+
+    What is recorded is whether the machine *could host* the containment, which
+    is the only one of the two questions below anybody has established about
+    these machines. Whether the rules would then be applied to it is not a
+    property of a machine at all — it is a property of this repository, and the
+    answer is the same everywhere.
+    """
 
     machine: str
-    containment_available: bool | None
+    could_host_the_containment: bool | None
     finding: str
     established_by: str
     on_date: str
@@ -168,7 +203,7 @@ class RecordedFinding:
     def as_dict(self) -> dict[str, Any]:
         return {
             "machine": self.machine,
-            "containment_available": self.containment_available,
+            "could_host_the_containment": self.could_host_the_containment,
             "finding": self.finding,
             "established_by": self.established_by,
             "on_date": self.on_date,
@@ -184,6 +219,30 @@ class ContainmentAnswer:
     notes: list[str] = field(default_factory=list)
 
     @property
+    def machine_could_host_it(self) -> bool:
+        """True when the four readings taken on this machine all hold.
+
+        Not the same question as :attr:`required_containment_available`, and
+        until 2026-08-26 they were one field, which is how a rule nothing
+        applies came to be reported as met. This one asks whether the machine
+        could start a small isolated virtual machine at all. That one asks
+        whether the containment is actually in place.
+
+        They are kept apart because they are fixed by different things. This one
+        is fixed by finding, configuring or building a machine. That one is
+        additionally fixed by writing the code that turns the containment rules
+        into arguments for starting the machine — which nobody has written.
+        """
+        taken_here = [
+            requirement
+            for requirement in self.requirements
+            if requirement.claim in READINGS_TAKEN_HERE
+        ]
+        return len(taken_here) == len(READINGS_TAKEN_HERE) and all(
+            requirement.met is True for requirement in taken_here
+        )
+
+    @property
     def required_containment_available(self) -> bool:
         """True only when every claim was established and every one holds.
 
@@ -191,6 +250,11 @@ class ContainmentAnswer:
         rule the specification already sets for the container run place applies
         here too: when the intended isolation cannot be shown to be present, the
         answer is no, not "probably".
+
+        This is false on every machine today, including one that has everything,
+        and it stays false until two separate things change: some machine has to
+        be able to host the containment, and something has to apply the rules to
+        it. See :data:`NOTHING_APPLIES_THESE_RULES_YET` for the second.
         """
         return bool(self.requirements) and all(
             requirement.met is True for requirement in self.requirements
@@ -207,6 +271,7 @@ class ContainmentAnswer:
     def as_dict(self) -> dict[str, Any]:
         return {
             "machine": self.machine,
+            "machine_could_host_it": self.machine_could_host_it,
             "required_containment_available": self.required_containment_available,
             "requirements": [item.as_dict() for item in self.requirements],
             "whats_missing": self.whats_missing(),
@@ -450,6 +515,13 @@ def _judge_policy_settings(
     Read from :data:`core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY` rather
     than listed again here, so that a setting added to the manifest turns into a
     line in this report instead of being silently left out of it.
+
+    None of them is ever reported as met. Two separate things would have to be
+    true for that, and only one of them is even about the machine: something
+    would have to apply the rule, and the machine would have to be able to hold
+    it. Nothing applies any of them — see
+    :data:`NOTHING_APPLIES_THESE_RULES_YET` — so the second question does not
+    arise yet.
     """
     can_start_one = all(item.met is True for item in already_judged)
     settings: list[Requirement] = []
@@ -497,15 +569,13 @@ def _judge_policy_settings(
         settings.append(
             Requirement(
                 claim=wording.format(value=value),
-                met=True if can_start_one else None,
+                met=None,
                 because=(
-                    "this is a setting applied when the virtual machine is "
-                    "started rather than a capability the host must already "
-                    "have, and this machine can start one"
+                    NOTHING_APPLIES_THESE_RULES_YET
                     if can_start_one
                     else "there is no small isolated virtual machine on this "
-                    "machine to apply this to. It becomes answerable only once "
-                    "the four claims above hold"
+                    "machine to apply this to, and "
+                    + NOTHING_APPLIES_THESE_RULES_YET
                 ),
             )
         )
@@ -524,7 +594,7 @@ def _kernel_version(release: str) -> tuple[int, int] | None:
 RECORDED_FINDINGS: tuple[RecordedFinding, ...] = (
     RecordedFinding(
         machine="github-hosted runner (ubuntu-latest, ubuntu-24.04)",
-        containment_available=False,
+        could_host_the_containment=False,
         finding=(
             "GitHub's own documentation says that running a virtual machine "
             "inside one of its runners, which is what this containment would "
@@ -542,7 +612,7 @@ RECORDED_FINDINGS: tuple[RecordedFinding, ...] = (
     ),
     RecordedFinding(
         machine="self-hosted runner labelled agentic-sandbox",
-        containment_available=None,
+        could_host_the_containment=None,
         finding=(
             "there is no such machine. No self-hosted runner is registered to "
             "this repository, and .github/workflows/agentic-sandbox-preflight."
@@ -631,6 +701,21 @@ def containment_answer_everywhere(
 ) -> dict[str, Any]:
     """The whole answer: this machine read live, the others from record.
 
+    Three answers come back rather than one, because three different things
+    would have to be done about them:
+
+    ``could_be_hosted_on_any_machine_in_play``
+        Is there a machine that could start the containment? Fixed by finding,
+        configuring or building one.
+    ``anything_applies_the_containment_rules``
+        Does any code turn the rules into arguments for starting it? Fixed by
+        writing that code. False today, on every machine, for the reason in
+        :data:`NOTHING_APPLIES_THESE_RULES_YET`.
+    ``available_on_any_machine_in_play``
+        Is the containment actually in place anywhere? Needs both of the above,
+        so it is false today and would stay false if a perfect machine appeared
+        tomorrow.
+
     ``every_machine_in_play_has_an_answer`` is ``None`` rather than ``True``
     when no workflows directory was given, because in that case nothing looked.
     A check that treats "nobody asked" as "the answer is yes" is the failure
@@ -640,9 +725,13 @@ def containment_answer_everywhere(
         facts if facts is not None else read_this_machine(),
         machine="the machine this check is running on",
     )
-    available_anywhere = here.required_containment_available or any(
-        finding.containment_available is True for finding in RECORDED_FINDINGS
+    could_be_hosted_anywhere = here.machine_could_host_it or any(
+        finding.could_host_the_containment is True for finding in RECORDED_FINDINGS
     )
+    # Not a machine fact and so not read off one. A rule is applied by code, and
+    # no code here applies these; if that changes, this changes with it and so
+    # does everything below.
+    anything_applies_the_rules = False
     gaps = (
         check_every_machine_has_a_containment_finding(workflows_directory)
         if workflows_directory is not None
@@ -656,7 +745,11 @@ def containment_answer_everywhere(
         "every_machine_in_play_has_an_answer": (
             None if workflows_directory is None else not gaps
         ),
-        "available_on_any_machine_in_play": available_anywhere,
+        "could_be_hosted_on_any_machine_in_play": could_be_hosted_anywhere,
+        "anything_applies_the_containment_rules": anything_applies_the_rules,
+        "available_on_any_machine_in_play": (
+            could_be_hosted_anywhere and anything_applies_the_rules
+        ),
     }
 
 
@@ -670,6 +763,11 @@ def refuse_command_execution(
     value a caller can act on rather than something a reader has to infer from a
     report, and so that the day it changes, it changes here.
 
+    There are two reasons it can refuse and the sentence says which, because
+    they send a reader to different work. Until 2026-08-26 there was only one,
+    and a machine that could host the containment would have cleared the refusal
+    while nothing applied a single rule to it.
+
     It does not switch anything on or off by itself. The three refusals that
     keep command execution shut are unchanged and stay where they are; this is
     the containment answer they were waiting on, not a replacement for them.
@@ -677,15 +775,25 @@ def refuse_command_execution(
     report = answer if answer is not None else containment_answer_everywhere()
     if report.get("available_on_any_machine_in_play"):
         return None
-    return (
-        "a model's chosen commands must not run: the containment the substrate "
-        "manifest requires — a small isolated virtual machine run by "
+
+    settings = (
+        "a small isolated virtual machine run by "
         f"{REQUIRED_MICROVM_POLICY['runtime']}, with "
         f"network {REQUIRED_MICROVM_POLICY['network']} and a "
-        f"{REQUIRED_MICROVM_POLICY['rootfs']} root filesystem — is not "
-        "available on any machine in play. Running them somewhere weaker "
-        "instead is the substitution the specification forbids, so the answer "
-        "is to leave the capability shut"
+        f"{REQUIRED_MICROVM_POLICY['rootfs']} root filesystem"
+    )
+    if not report.get("could_be_hosted_on_any_machine_in_play"):
+        why = f"— {settings} — is not available on any machine in play"
+    else:
+        why = (
+            f"— {settings} — could be started on a machine in play, but "
+            "nothing applies its rules: " + NOTHING_APPLIES_THESE_RULES_YET
+        )
+    return (
+        "a model's chosen commands must not run: the containment the substrate "
+        f"manifest requires {why}. Running them somewhere weaker instead is the "
+        "substitution the specification forbids, so the answer is to leave the "
+        "capability shut"
     )
 
 
@@ -714,12 +822,12 @@ def describe_containment(report: Mapping[str, Any]) -> list[str]:
     lines.append("On the machines that cannot be read from here")
     lines.append("-" * 74)
     for finding in report["recorded_findings"]:
-        available = finding["containment_available"]
+        could_host = finding["could_host_the_containment"]
         verdict = (
-            "available"
-            if available is True
-            else "not available"
-            if available is False
+            "could host it"
+            if could_host is True
+            else "could not host it"
+            if could_host is False
             else "cannot be answered"
         )
         lines.append(f"  {finding['machine']}: {verdict}")
@@ -727,6 +835,21 @@ def describe_containment(report: Mapping[str, Any]) -> list[str]:
         lines.append(
             f"      established {finding['on_date']} from "
             f"{finding['established_by']}"
+        )
+    lines.append("")
+
+    lines.append("Whether anything applies the rules, on any machine")
+    lines.append("-" * 74)
+    if report["anything_applies_the_containment_rules"]:
+        lines.append(
+            "  Something now turns the containment rules into arguments for "
+            "starting the machine."
+        )
+    else:
+        lines.append(f"  Nothing does: {NOTHING_APPLIES_THESE_RULES_YET}.")
+        lines.append(
+            "  This is the same on every machine, because it is a fact about "
+            "this repository rather than about any machine."
         )
     lines.append("")
 

--- a/batch-runner/core/agentic_v2_substrate.py
+++ b/batch-runner/core/agentic_v2_substrate.py
@@ -135,20 +135,161 @@ def canonical_sha256(value: Any) -> str:
 # error that names the licence evaluator and never mentions this file. New
 # constants for this module therefore go here, below it, not up with the others.
 
-# The containment a substrate manifest must promise before it will validate.
+# ── The containment rules ─────────────────────────────────────────────────
 #
-# Named rather than written inline in the check below, so that anything asking
-# "what containment is actually required here?" reads the answer from the same
-# place the check enforces it. Two copies of these five settings could disagree
-# with each other; one cannot. core/agentic_v2_containment_readiness.py reads it
-# to report which of them a given machine can actually meet.
+# What a command is allowed to touch when Agentic Sandbox V2 eventually runs
+# one. A substrate manifest promising anything different fails to validate.
+#
+# Six things have to be stated for this to be a containment rather than a
+# gesture: where it may write, whether it can reach the network, how much
+# memory it gets, how long it may run, who it runs as, and what happens when it
+# exceeds any of them. Until 2026-08-26 only the first two were written down,
+# and the working directory said "there is a quota" without ever saying what
+# the quota was. A limit with no number is not a limit.
+#
+# Every value here is a *chosen* limit rather than a measured one, and for a
+# containment that is the right kind of number — the point is to decide what is
+# allowed, not to record what happened. Where a value is derived from something
+# else in this repository, a test fails if the two stop agreeing; where it was
+# simply picked, it says so.
+#
+# **One other file still states these rules, and it has to.**
+# security/agentic-v2-supply-chain-policy.json is a signed artefact, so it
+# physically carries its own copy of the values in its own published wording —
+# it says ``read_only_rootfs: true`` where this file says
+# ``rootfs: "read-only"``. There was a third copy, hand-written into
+# core/agentic_v2_supply_chain.py's validator, and nothing compared any two of
+# the three; a rule could be weakened in one and left standing in the others
+# with every check still passing. The validator's copy is gone as of
+# 2026-08-26 — it derives what it requires from
+# :func:`supply_chain_microvm_block` — and :func:`containment_rules_that_disagree`
+# compares the signed file against this one, so drift is refused by name.
+#
+# core/agentic_v2_containment_readiness.py reads this to report which of these
+# a given machine could actually meet.
+
+MICROVM_WORKDIR_QUOTA_MIB = 256
+"""How much the command may write, in mebibytes.
+
+Derived, not picked. core/agentic_v2_fixture_backend.py already lets a model
+hold 64 MiB of workspace and hand back 64 MiB of finished files, so a disk
+below 128 MiB would let the tool layer accept a write the disk cannot hold —
+the failure would surface as a disk error rather than as the ceiling the tool
+layer meant to apply. This is twice that, so the disk is not the first thing to
+fail. ``test_the_disk_is_not_smaller_than_the_tools_already_allow`` fails if
+either backend ceiling is raised past it.
+"""
+
+MICROVM_MEMORY_MIB = 4096
+"""How much memory the command gets, in mebibytes.
+
+Picked, not derived, and this is the only rule here with nothing behind it to
+derive from. 4 GiB is enough to open the spreadsheets and documents these tasks
+involve with a library like pandas loaded, and small enough that a runaway
+process stops instead of taking the host down with it.
+
+**A difference between run places worth knowing about.** None of the three run
+places in the comparison caps memory at all. Applying a cap here makes this
+column stricter than the others on an axis the comparison does not otherwise
+control, so a task that fails here for memory would not have failed elsewhere
+for that reason. Recorded rather than hidden, because a comparison that is
+uneven in a way nobody wrote down is worse than one that is uneven on purpose.
+"""
+
+MICROVM_WALL_CLOCK_SECONDS = 1200
+"""How long the command may run, in seconds.
+
+Derived from ``per_task_timeout_seconds`` in
+experiments/execution_envelope/agentic_stage_one_plan.yaml, which is the same
+figure the other run places are held to. A containment that cut a task off
+earlier than the other columns do would make this run place look worse for a
+reason that had nothing to do with the model.
+``test_the_clock_matches_the_one_the_other_run_places_are_held_to`` fails if the
+plan and this stop agreeing.
+"""
+
 REQUIRED_MICROVM_POLICY: dict[str, Any] = {
     "required": True,
     "runtime": "firecracker",
     "network": "none",
     "rootfs": "read-only",
     "workdir": "ephemeral-quota",
+    "workdir_quota_mib": MICROVM_WORKDIR_QUOTA_MIB,
+    "memory_mib": MICROVM_MEMORY_MIB,
+    "wall_clock_seconds": MICROVM_WALL_CLOCK_SECONDS,
+    # Not a separate decision: Firecracker's jailer is what drops privileges,
+    # and the signed policy already requires it. Written down anyway, because
+    # "which user does the command run as" is one of the six questions, and
+    # answering it by implication elsewhere is how it went unanswered here.
+    "user": "jailer-unprivileged",
+    # What happens on breach. Stop and say so — never carry on with the rule
+    # relaxed, and never fail quietly. Section 7 of the specification asks for
+    # exactly this: stage three must fail loudly when its containment is
+    # unavailable, and a rule that has been exceeded is a containment that is
+    # not holding.
+    "on_breach": "stop-and-report",
 }
+
+# The same rules as the signed supply-chain policy states them. The key is that
+# file's name for the rule; the value is what each side has to say for the two
+# to be stating the same thing. The signed policy writes most of its rules as
+# true/false, so the pair is not a comparison of like with like and cannot be
+# left implicit.
+_SUPPLY_CHAIN_RULE_NAMES: dict[str, tuple[str, Any, Any]] = {
+    "runtime": ("runtime", "firecracker", "firecracker"),
+    "network": ("network", "none", "none"),
+    "read_only_rootfs": ("rootfs", "read-only", True),
+    "ephemeral_work_disk": ("workdir", "ephemeral-quota", True),
+}
+
+# Two rules the signed policy states that have no counterpart above, because
+# they are facts about the host rather than settings applied at start-up.
+# core/agentic_v2_containment_readiness.py reads the machine for both.
+SUPPLY_CHAIN_HOST_FACTS: dict[str, Any] = {
+    "jailer_required": True,
+    "kvm_required": True,
+}
+
+
+def supply_chain_microvm_block() -> dict[str, Any]:
+    """Exactly what the signed policy's containment block has to say.
+
+    Derived from the rules above rather than written out a third time.
+    core/agentic_v2_supply_chain.py held its own hand-written copy of this until
+    2026-08-26, which made three places stating one set of rules and no check
+    that any two of them agreed.
+    """
+    block = dict(SUPPLY_CHAIN_HOST_FACTS)
+    for their_name, (our_name, _, theirs_must_be) in _SUPPLY_CHAIN_RULE_NAMES.items():
+        block[their_name] = theirs_must_be
+    return block
+
+
+def containment_rules_that_disagree(supply_chain_microvm: Any) -> list[str]:
+    """Where the signed policy and the rules above stop saying the same thing.
+
+    Two written-down copies of one rule is two chances to weaken it and one
+    chance to notice. This is the noticing. Returns a description per rule that
+    has drifted, and an empty list when they agree.
+    """
+    if not isinstance(supply_chain_microvm, Mapping):
+        return ["the signed policy's containment block is not a set of rules"]
+
+    drifted: list[str] = []
+    for their_name, (our_name, ours_must_be, theirs_must_be) in sorted(
+        _SUPPLY_CHAIN_RULE_NAMES.items()
+    ):
+        ours = REQUIRED_MICROVM_POLICY.get(our_name)
+        theirs = supply_chain_microvm.get(their_name)
+        if ours == ours_must_be and theirs == theirs_must_be:
+            continue
+        drifted.append(
+            f"containment rule {our_name!r} disagrees between the two places "
+            f"it is written down: core.agentic_v2_substrate says {ours!r} and "
+            f"security/agentic-v2-supply-chain-policy.json says "
+            f"{their_name}={theirs!r}"
+        )
+    return drifted
 
 
 @dataclass(frozen=True)

--- a/batch-runner/core/agentic_v2_supply_chain.py
+++ b/batch-runner/core/agentic_v2_supply_chain.py
@@ -22,6 +22,8 @@ from packaging.licenses import (
 from core.agentic_v2_substrate import (
     AgenticV2SubstrateManifest,
     canonical_sha256,
+    containment_rules_that_disagree,
+    supply_chain_microvm_block,
     validate_capability_receipt,
 )
 from core.agentic_v2_license import (
@@ -877,6 +879,18 @@ def _validate_policy(value: Any) -> dict[str, Any]:
     cve = document.get("cve")
     signature = document.get("signature")
     microvm = document.get("microvm")
+    # Asked before the block below, and separately from it, because the block
+    # below can only say that this file's wording changed. It cannot say whether
+    # the wording still means the same thing as the containment rules in
+    # core/agentic_v2_substrate.py, which are the copy every other check reads.
+    # Until 2026-08-26 nothing compared the two, so a rule could be weakened in
+    # one and left standing in the other with both files still validating.
+    drifted = containment_rules_that_disagree(microvm)
+    if drifted:
+        raise ValueError(
+            "agentic v2 supply-chain policy containment drift: "
+            + "; ".join(drifted)
+        )
     if (
         document["schema_version"] != "1.0"
         or document["policy_id"] != "agentic-v2-phase1c-candidate-v1"
@@ -927,14 +941,11 @@ def _validate_policy(value: Any) -> dict[str, Any]:
                 "probe", "sbom", "policy",
             ],
         }
-        or document["microvm"] != {
-            "runtime": "firecracker",
-            "jailer_required": True,
-            "kvm_required": True,
-            "network": "none",
-            "read_only_rootfs": True,
-            "ephemeral_work_disk": True,
-        }
+        # Derived from the containment rules rather than written out here for a
+        # third time. The four rules both files state are checked against the
+        # substrate above; this pins the exact shape, so a rule added to one
+        # file and not the other is refused as well.
+        or document["microvm"] != supply_chain_microvm_block()
         or not isinstance(microvm, dict)
         or microvm.get("jailer_required") is not True
         or microvm.get("kvm_required") is not True

--- a/batch-runner/sandbox/agentic_v2_capabilities.json
+++ b/batch-runner/sandbox/agentic_v2_capabilities.json
@@ -90,6 +90,11 @@
     "runtime": "firecracker",
     "network": "none",
     "rootfs": "read-only",
-    "workdir": "ephemeral-quota"
+    "workdir": "ephemeral-quota",
+    "workdir_quota_mib": 256,
+    "memory_mib": 4096,
+    "wall_clock_seconds": 1200,
+    "user": "jailer-unprivileged",
+    "on_breach": "stop-and-report"
   }
 }

--- a/batch-runner/scripts/check_agentic_containment.py
+++ b/batch-runner/scripts/check_agentic_containment.py
@@ -15,13 +15,21 @@ Usage:
 
 The exit code is 0 only when the required containment is available on some
 machine in play *and* every machine the workflows ask for has an answer
-recorded. Today neither holds for the first reason: this machine cannot reach
-hardware virtualisation and runs a kernel below the oldest Firecracker
-validates, GitHub-hosted runners do not officially support running a virtual
-machine inside them, and the self-hosted machine the one workflow asks for has
-never been registered. Anything else exits 1, so this is safe to wire into an
-automated check — including the case where somebody adds a workflow that runs
-somewhere nobody has answered the question for.
+recorded. Today neither holds, for two separate reasons:
+
+* **No machine in play could host it.** This machine cannot reach hardware
+  virtualisation and runs a kernel below the oldest Firecracker validates,
+  GitHub-hosted runners do not officially support running a virtual machine
+  inside them, and the self-hosted machine the one workflow asks for has never
+  been registered.
+* **Nothing applies the rules.** No code in this repository turns the
+  containment rules into arguments for starting a machine, so even a machine
+  that could host it would be started with none of them applied. This one is the
+  same on every machine, and finding a better machine does not fix it.
+
+Anything else exits 1, so this is safe to wire into an automated check —
+including the case where somebody adds a workflow that runs somewhere nobody has
+answered the question for.
 
 Stage three of the specification — letting a model's chosen commands really run
 — is what this answers a question for. It switches nothing on and removes no

--- a/batch-runner/tests/test_agentic_v2_containment_readiness.py
+++ b/batch-runner/tests/test_agentic_v2_containment_readiness.py
@@ -22,6 +22,7 @@ from core.agentic_v2_containment_readiness import (
     NEEDS_A_PROCESSOR_THAT_CAN,
     NEEDS_THE_PROGRAMS_INSTALLED,
     NEEDS_TO_REACH_THE_HARDWARE,
+    NOTHING_APPLIES_THESE_RULES_YET,
     OLDEST_HOST_KERNEL_FIRECRACKER_VALIDATES,
     RECORDED_FINDINGS,
     MachineFacts,
@@ -33,7 +34,12 @@ from core.agentic_v2_containment_readiness import (
     refuse_command_execution,
     runner_labels_used_by_workflows,
 )
-from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
+from core.agentic_v2_substrate import (
+    MICROVM_MEMORY_MIB,
+    MICROVM_WALL_CLOCK_SECONDS,
+    MICROVM_WORKDIR_QUOTA_MIB,
+    REQUIRED_MICROVM_POLICY,
+)
 
 WORKFLOWS_DIRECTORY = Path(__file__).resolve().parents[2] / ".github" / "workflows"
 
@@ -82,11 +88,28 @@ def a_microvm_report(*, kvm: bool = False, programs: tuple[str, ...] = ()) -> di
 # ── A machine that has everything ─────────────────────────────────────────
 
 
-def test_a_machine_with_everything_can_provide_the_required_containment():
+def test_a_machine_with_everything_could_host_the_containment():
     answer = judge_containment(a_machine())
 
-    assert answer.required_containment_available is True
-    assert answer.whats_missing() == []
+    assert answer.machine_could_host_it is True
+
+
+def test_a_machine_with_everything_still_does_not_have_the_containment():
+    """Being able to start a machine is not the same as the rules being applied.
+
+    These were one field until 2026-08-26, and that is how a rule nothing
+    applies came to be reported as met. On the three machines in play it never
+    showed, because none of them can start a virtual machine at all. On the
+    first machine that could, the old report would have said the containment was
+    in place while nothing carried a single rule to it.
+    """
+    answer = judge_containment(a_machine())
+
+    assert answer.required_containment_available is False
+    assert answer.whats_missing(), "a rule nobody applies is not nothing missing"
+    assert all(
+        "unenforced rather than met" in line for line in answer.whats_missing()
+    )
 
 
 def test_every_setting_the_manifest_asks_for_appears_in_the_answer():
@@ -112,9 +135,24 @@ def test_the_configured_settings_are_not_claimed_to_have_been_checked():
     answer = judge_containment(a_machine())
     network = claim(answer, "the small isolated virtual machine's network")
 
-    assert network.met is True
-    assert "setting applied when the virtual machine is started" in network.because
-    assert "rather than a capability the host must already have" in network.because
+    assert network.met is None
+    assert network.verdict == "cannot be established here"
+    assert NOTHING_APPLIES_THESE_RULES_YET in network.because
+
+
+def test_the_report_names_the_module_that_would_have_to_apply_the_rules():
+    """A reader who wants to fix this has to be told where the gap is.
+
+    "Cannot be established" with no address sends somebody looking for a better
+    machine, which is the wrong work: the rules would go unapplied on the best
+    machine in the world.
+    """
+    answer = judge_containment(a_machine())
+    quota = claim(answer, "the command may write at most")
+
+    assert "core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY" in quota.because
+    assert "core.agentic_v2_microvm" in quota.because
+    assert "it applies nothing" in quota.because
 
 
 # ── Each requirement, taken away one at a time ────────────────────────────
@@ -124,7 +162,7 @@ def test_a_processor_that_cannot_do_it_is_a_permanent_no():
     answer = judge_containment(a_machine(processor_flags=("fpu", "aes")))
     judged = claim(answer, NEEDS_A_PROCESSOR_THAT_CAN)
 
-    assert answer.required_containment_available is False
+    assert answer.machine_could_host_it is False
     assert judged.met is False
     assert "no amount of configuration would make this work here" in judged.because
 
@@ -142,7 +180,7 @@ def test_a_processor_whose_capabilities_could_not_be_read_is_not_called_a_no():
 
     assert judged.met is None
     assert judged.verdict == "cannot be established here"
-    assert answer.required_containment_available is False
+    assert answer.machine_could_host_it is False
 
 
 def test_an_amd_processor_counts_as_well_as_an_intel_one():
@@ -155,7 +193,7 @@ def test_hardware_the_machine_cannot_reach_is_a_no():
     answer = judge_containment(a_machine(hardware_virtualisation_reachable=False))
     judged = claim(answer, NEEDS_TO_REACH_THE_HARDWARE)
 
-    assert answer.required_containment_available is False
+    assert answer.machine_could_host_it is False
     assert judged.met is False
     assert "core.agentic_v2_microvm.inspect_microvm_readiness" in judged.because
 
@@ -201,7 +239,7 @@ def test_a_kernel_below_what_firecracker_validates_is_refused(release):
     answer = judge_containment(a_machine(kernel_release=release))
     judged = claim(answer, NEEDS_A_KERNEL_FIRECRACKER_TESTS)
 
-    assert answer.required_containment_available is False
+    assert answer.machine_could_host_it is False
     assert judged.met is False
     assert release in judged.because
 
@@ -245,15 +283,23 @@ def test_a_claim_that_could_not_be_established_counts_against_availability():
     """
     answer = judge_containment(a_machine(kernel_release="unknown"))
 
+    assert answer.machine_could_host_it is False
     assert answer.required_containment_available is False
 
 
-def test_the_settings_are_unanswerable_while_no_virtual_machine_can_start():
+def test_the_settings_say_both_reasons_while_no_virtual_machine_can_start():
+    """Two things are wrong at once here, and the report says both.
+
+    There is no machine to apply the rule to, *and* nothing that would apply it
+    if there were. Naming only the first would send a reader to find a machine
+    and leave them surprised when the rule still went unapplied on it.
+    """
     answer = judge_containment(a_machine(hardware_virtualisation_reachable=False))
     rootfs = claim(answer, "the small isolated virtual machine's root filesystem")
 
     assert rootfs.met is None
-    assert "It becomes answerable only once the four claims above hold" in rootfs.because
+    assert "no small isolated virtual machine on this machine" in rootfs.because
+    assert NOTHING_APPLIES_THESE_RULES_YET in rootfs.because
 
 
 def test_whats_missing_lists_only_what_is_wrong_and_why():
@@ -277,7 +323,10 @@ def test_an_answer_with_no_requirements_in_it_is_not_treated_as_available():
     """An empty report is the absence of evidence, not evidence of readiness."""
     from core.agentic_v2_containment_readiness import ContainmentAnswer
 
-    assert ContainmentAnswer(machine="nowhere").required_containment_available is False
+    empty = ContainmentAnswer(machine="nowhere")
+
+    assert empty.machine_could_host_it is False
+    assert empty.required_containment_available is False
 
 
 # ── The manifest is read, not copied ──────────────────────────────────────
@@ -290,14 +339,22 @@ def test_a_new_setting_in_the_manifest_is_reported_rather_than_ignored(monkeypat
     the honest output is to say so. The alternative — quietly reporting on the
     settings it happens to know about — would let the answer stay green while
     the requirement it answers about had changed underneath it.
+
+    The setting below is invented for this test and deliberately unlike any real
+    one, so that adding it here can never be mistaken for adding it to the
+    manifest.
     """
-    monkeypatch.setitem(REQUIRED_MICROVM_POLICY, "memory", "512MiB-hard-cap")
+    monkeypatch.setitem(
+        REQUIRED_MICROVM_POLICY, "there_is_no_such_rule", "invented-for-a-test"
+    )
     try:
         answer = judge_containment(a_machine())
     finally:
-        REQUIRED_MICROVM_POLICY.pop("memory", None)
+        REQUIRED_MICROVM_POLICY.pop("there_is_no_such_rule", None)
 
-    unknown = claim(answer, "the manifest's containment setting 'memory'")
+    unknown = claim(
+        answer, "the manifest's containment setting 'there_is_no_such_rule'"
+    )
     assert unknown.met is None
     assert "does not know how to describe or check" in unknown.because
     assert answer.required_containment_available is False
@@ -319,7 +376,7 @@ def test_a_manifest_that_stopped_requiring_containment_would_show_up(monkeypatch
         REQUIRED_MICROVM_POLICY["required"] = True
 
     assert claim(answer, "containment is mandatory").met is False
-    assert answer.required_containment_available is False
+    assert any("containment is mandatory" in line for line in answer.whats_missing())
 
 
 def test_the_premise_is_stated_before_the_details_of_it():
@@ -499,6 +556,7 @@ def test_reading_this_machine_costs_nothing_and_answers():
 
     assert isinstance(facts.kernel_release, str) and facts.kernel_release
     assert [item.claim for item in answer.requirements]
+    assert isinstance(answer.machine_could_host_it, bool)
     assert isinstance(answer.required_containment_available, bool)
 
 
@@ -535,7 +593,8 @@ def test_every_recorded_finding_says_where_it_came_from_and_when():
 def test_no_recorded_finding_claims_the_containment_is_available():
     """The answer as it stands. This test changes on the day the answer does."""
     assert all(
-        finding.containment_available is not True for finding in RECORDED_FINDINGS
+        finding.could_host_the_containment is not True
+        for finding in RECORDED_FINDINGS
     )
 
 
@@ -544,7 +603,7 @@ def test_the_github_runner_finding_rests_on_githubs_own_documentation():
         finding for finding in RECORDED_FINDINGS if "github-hosted" in finding.machine
     )
 
-    assert github.containment_available is False
+    assert github.could_host_the_containment is False
     assert "docs.github.com" in github.established_by
     assert "not officially supported" in github.finding
 
@@ -560,7 +619,7 @@ def test_the_self_hosted_machine_is_an_unknown_because_it_does_not_exist():
         finding for finding in RECORDED_FINDINGS if "self-hosted" in finding.machine
     )
 
-    assert self_hosted.containment_available is None
+    assert self_hosted.could_host_the_containment is None
     assert "there is no such machine" in self_hosted.finding
     assert "total_count 0" in self_hosted.established_by
 
@@ -622,9 +681,11 @@ def test_the_whole_answer_covers_this_machine_and_the_recorded_ones():
     )
 
     assert report["required_containment"] == dict(REQUIRED_MICROVM_POLICY)
+    assert report["this_machine"]["machine_could_host_it"] is False
     assert report["this_machine"]["required_containment_available"] is False
     assert len(report["recorded_findings"]) == len(RECORDED_FINDINGS)
     assert report["machines_without_a_finding"] == []
+    assert report["could_be_hosted_on_any_machine_in_play"] is False
     assert report["available_on_any_machine_in_play"] is False
 
 
@@ -634,11 +695,35 @@ def test_the_whole_answer_can_be_written_down_as_it_stands():
     assert json.loads(json.dumps(report)) == report
 
 
-def test_a_machine_here_that_could_do_it_would_change_the_answer():
+def test_a_machine_here_that_could_do_it_changes_one_answer_and_not_the_other():
+    """The distinction the whole report now turns on.
+
+    A machine that has everything moves the hosting question and nothing else.
+    The containment still is not in place, because no code applies its rules,
+    and the refusal must stay standing on that second ground rather than lifting
+    because the first was cleared.
+    """
     report = containment_answer_everywhere(facts=a_machine())
 
-    assert report["available_on_any_machine_in_play"] is True
-    assert refuse_command_execution(report) is None
+    assert report["could_be_hosted_on_any_machine_in_play"] is True
+    assert report["anything_applies_the_containment_rules"] is False
+    assert report["available_on_any_machine_in_play"] is False
+    assert refuse_command_execution(report) is not None
+
+
+def test_the_refusal_on_a_capable_machine_names_the_rules_nobody_applies():
+    """Two grounds for refusing, and the sentence says which one it is on.
+
+    Repeating "no machine can host it" to somebody standing in front of a
+    machine that can would read as a bug in the report rather than as the real
+    remaining gap.
+    """
+    refusal = refuse_command_execution(containment_answer_everywhere(facts=a_machine()))
+
+    assert refusal is not None
+    assert "could be started on a machine in play" in refusal
+    assert NOTHING_APPLIES_THESE_RULES_YET in refusal
+    assert "is not available on any machine in play" not in refusal
 
 
 def test_an_unanswered_machine_is_reported_beside_the_answer_not_folded_into_it(
@@ -648,7 +733,7 @@ def test_an_unanswered_machine_is_reported_beside_the_answer_not_folded_into_it(
 
     ``scripts/check_agentic_containment.py`` passes only when both hold, so a
     workflow that starts running somewhere nobody has answered for fails the
-    check even on a machine that could itself provide the containment. The two
+    check even on a machine that could itself host the containment. The two
     are separate keys rather than one, because folding them together would
     report an unanswered machine as though it had been answered no.
     """
@@ -660,7 +745,7 @@ def test_an_unanswered_machine_is_reported_beside_the_answer_not_folded_into_it(
         facts=a_machine(), workflows_directory=tmp_path
     )
 
-    assert report["available_on_any_machine_in_play"] is True
+    assert report["could_be_hosted_on_any_machine_in_play"] is True
     assert report["every_machine_in_play_has_an_answer"] is False
     assert len(report["machines_without_a_finding"]) == 1
     assert "macos-15" in report["machines_without_a_finding"][0]
@@ -740,12 +825,14 @@ def test_the_printed_report_states_the_requirement_the_verdict_and_the_sources()
     assert "must not run" in printed
 
 
-def test_the_printed_report_says_so_plainly_if_the_containment_becomes_available():
+def test_the_printed_report_says_which_rules_nobody_applies():
     report = containment_answer_everywhere(facts=a_machine())
     printed = "\n".join(describe_containment(report))
 
-    assert "The required containment is available" in printed
-    assert "opening command execution is a separate decision" in printed
+    assert "Whether anything applies the rules, on any machine" in printed
+    assert "Nothing does:" in printed
+    assert "a fact about this repository rather than about any machine" in printed
+    assert "The required containment is available" not in printed
 
 
 def test_the_printed_report_shows_a_machine_nobody_has_an_answer_for(tmp_path):

--- a/batch-runner/tests/test_agentic_v2_containment_rules.py
+++ b/batch-runner/tests/test_agentic_v2_containment_rules.py
@@ -1,0 +1,354 @@
+"""The containment rules: that they are complete, numbered, and hard to weaken.
+
+Six questions have to be answered before a set of settings is a containment
+rather than a gesture — where a command may write, whether it can reach the
+network, how much memory it gets, how long it may run, who it runs as, and what
+happens when it exceeds any of them. Until 2026-08-26 only the first two were
+written down, and the working directory said "there is a quota" without ever
+saying what the quota was.
+
+These tests do three things and no more. They check that all six are answered;
+they check that the numbers which are derived from something else still agree
+with what they were derived from; and they check that weakening any one of them
+is refused rather than accepted.
+
+What they deliberately do not do is start a virtual machine, run a command,
+exceed a limit and watch it stop. That is the test these rules will eventually
+need, and it cannot be written yet: no machine in play can host the containment,
+and no code turns these rules into arguments for starting one. Writing a
+pretend version of it would be worse than leaving it out, because a passing test
+named after a thing that never happened is how an unenforced rule comes to look
+enforced. core/agentic_v2_containment_readiness.py reports the gap instead.
+
+Nothing here calls a model, runs a command, or spends money.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_fixture_backend import (
+    _MAX_FINAL_BYTES,
+    _MAX_WORKSPACE_BYTES,
+)
+from core.agentic_v2_substrate import (
+    MICROVM_MEMORY_MIB,
+    MICROVM_WALL_CLOCK_SECONDS,
+    MICROVM_WORKDIR_QUOTA_MIB,
+    REQUIRED_MICROVM_POLICY,
+    SUPPLY_CHAIN_HOST_FACTS,
+    AgenticV2SubstrateManifest,
+    _SUPPLY_CHAIN_RULE_NAMES,
+    containment_rules_that_disagree,
+    supply_chain_microvm_block,
+)
+from core.agentic_v2_supply_chain import SupplyChainPolicy
+
+MANIFEST_PATH = Path("sandbox/agentic_v2_capabilities.json")
+SIGNED_POLICY_PATH = Path("security/agentic-v2-supply-chain-policy.json")
+STAGE_ONE_PLAN_PATH = Path(
+    "experiments/execution_envelope/agentic_stage_one_plan.yaml"
+)
+
+A_MEBIBYTE = 1024 * 1024
+
+
+def _manifest_document() -> dict:
+    return deepcopy(AgenticV2SubstrateManifest.load(MANIFEST_PATH).document)
+
+
+def _signed_policy() -> dict:
+    return json.loads(SIGNED_POLICY_PATH.read_text(encoding="utf-8"))
+
+
+# ── All six questions are answered ────────────────────────────────────────
+
+
+def test_every_one_of_the_six_questions_has_an_answer():
+    """A containment that leaves one of these open is not a containment.
+
+    Named individually rather than counted, so that a failure says which
+    question stopped being answered instead of saying that a number changed.
+    """
+    assert REQUIRED_MICROVM_POLICY["workdir"] == "ephemeral-quota"
+    assert REQUIRED_MICROVM_POLICY["workdir_quota_mib"] == MICROVM_WORKDIR_QUOTA_MIB
+    assert REQUIRED_MICROVM_POLICY["network"] == "none"
+    assert REQUIRED_MICROVM_POLICY["memory_mib"] == MICROVM_MEMORY_MIB
+    assert REQUIRED_MICROVM_POLICY["wall_clock_seconds"] == MICROVM_WALL_CLOCK_SECONDS
+    assert REQUIRED_MICROVM_POLICY["user"] == "jailer-unprivileged"
+    assert REQUIRED_MICROVM_POLICY["on_breach"] == "stop-and-report"
+
+
+def test_no_limit_is_written_without_a_number():
+    """"There is a quota" is not a quota, and this is what caught that.
+
+    Every rule whose name ends in a unit has to carry a positive number. A rule
+    that names a unit and then holds a word is a rule nobody can apply.
+    """
+    for name, value in REQUIRED_MICROVM_POLICY.items():
+        if name.endswith(("_mib", "_seconds")):
+            assert isinstance(value, int) and not isinstance(value, bool), (
+                f"containment rule {name!r} names a unit but holds {value!r}"
+            )
+            assert value > 0, f"containment rule {name!r} is not a limit at {value!r}"
+
+
+def test_the_breach_rule_neither_carries_on_nor_goes_quiet():
+    """The two ways a limit fails to be one.
+
+    Section 7 of the specification asks stage three to fail loudly when its
+    containment is unavailable. A rule that has been exceeded is a containment
+    that is not holding, so the same answer applies: stop, and say so.
+    """
+    assert REQUIRED_MICROVM_POLICY["on_breach"] == "stop-and-report"
+    assert "stop" in REQUIRED_MICROVM_POLICY["on_breach"]
+    assert "report" in REQUIRED_MICROVM_POLICY["on_breach"]
+
+
+# ── The numbers that are derived still agree with their source ────────────
+
+
+def test_the_disk_is_not_smaller_than_the_tools_already_allow():
+    """The working disk has to hold what the tool layer already accepts.
+
+    core/agentic_v2_fixture_backend.py lets a model hold a workspace and hand
+    back a set of finished files, each with its own ceiling. A disk smaller than
+    those two together would let the tool layer accept a write the disk cannot
+    hold, and the failure would surface as a disk error rather than as the
+    ceiling the tool layer meant to apply.
+
+    Raising either backend ceiling past this is what this test catches.
+    """
+    what_the_tools_allow_mib = (_MAX_WORKSPACE_BYTES + _MAX_FINAL_BYTES) // A_MEBIBYTE
+
+    assert MICROVM_WORKDIR_QUOTA_MIB >= what_the_tools_allow_mib, (
+        f"the work disk is {MICROVM_WORKDIR_QUOTA_MIB} MiB but the tool layer "
+        f"already accepts {what_the_tools_allow_mib} MiB of writes"
+    )
+
+
+def test_the_clock_matches_the_one_the_other_run_places_are_held_to():
+    """A containment that cut a task off early would bias the comparison.
+
+    The three run places are compared against each other. If this one stopped a
+    task sooner than the others do, it would look worse for a reason that had
+    nothing to do with the model, and the comparison would be measuring the
+    containment instead.
+    """
+    plan = STAGE_ONE_PLAN_PATH.read_text(encoding="utf-8")
+    stated = [
+        line for line in plan.splitlines() if "per_task_timeout_seconds:" in line
+    ]
+
+    assert stated, f"{STAGE_ONE_PLAN_PATH} no longer states a per-task timeout"
+    for line in stated:
+        seconds = int(line.split(":", 1)[1].strip())
+        assert seconds == MICROVM_WALL_CLOCK_SECONDS, (
+            f"the containment stops a command after {MICROVM_WALL_CLOCK_SECONDS} "
+            f"seconds but the plan gives a task {seconds}"
+        )
+
+
+def test_the_memory_rule_says_it_was_picked_rather_than_derived():
+    """The one number with nothing behind it, and it has to admit that.
+
+    Every other limit here points at something it was derived from. This one
+    does not, and a reader deciding whether to change it needs to know which
+    kind of number they are looking at.
+    """
+    from core import agentic_v2_substrate
+
+    source = Path(agentic_v2_substrate.__file__).read_text(encoding="utf-8")
+    documentation = " ".join(
+        source.split("MICROVM_MEMORY_MIB = ")[1].split('"""')[1].split()
+    )
+
+    assert "Picked, not derived" in documentation
+    assert "None of the three run places in the comparison caps memory" in documentation
+
+
+# ── Weakening any one rule is refused ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("rule", "weakened_to"),
+    [
+        ("network", "allowlist"),
+        ("network", "host"),
+        ("rootfs", "writable"),
+        ("workdir", "persistent"),
+        ("workdir_quota_mib", MICROVM_WORKDIR_QUOTA_MIB * 4),
+        ("memory_mib", MICROVM_MEMORY_MIB * 4),
+        ("wall_clock_seconds", MICROVM_WALL_CLOCK_SECONDS * 4),
+        ("user", "root"),
+        ("on_breach", "continue"),
+        ("on_breach", "log-and-continue"),
+        ("runtime", "docker"),
+        ("required", False),
+    ],
+)
+def test_a_manifest_that_weakens_one_rule_is_refused(rule, weakened_to):
+    """One test per rule, because one rule is what gets changed at a time.
+
+    A manifest is the file that would travel with a built image, so this is the
+    check that catches a rule loosened somewhere between here and the machine
+    that runs it.
+    """
+    document = _manifest_document()
+    document["microvm"][rule] = weakened_to
+
+    with pytest.raises(ValueError, match="microvm policy"):
+        AgenticV2SubstrateManifest.from_mapping(document)
+
+
+def test_a_manifest_that_drops_a_rule_entirely_is_refused():
+    """Deleting a limit is the quietest way to remove it."""
+    for rule in sorted(REQUIRED_MICROVM_POLICY):
+        document = _manifest_document()
+        del document["microvm"][rule]
+
+        with pytest.raises(ValueError, match="microvm policy"):
+            AgenticV2SubstrateManifest.from_mapping(document)
+
+
+def test_the_manifest_on_disk_states_every_rule_and_states_them_the_same():
+    """The file that ships has to say what the code requires, exactly.
+
+    Not "contains" — equals. A manifest holding an extra containment setting
+    nobody checks is the drift this whole change is about.
+    """
+    assert _manifest_document()["microvm"] == REQUIRED_MICROVM_POLICY
+
+
+# ── The two written-down copies still agree ───────────────────────────────
+
+
+def test_the_signed_policy_and_the_rules_agree_today():
+    assert containment_rules_that_disagree(_signed_policy()["microvm"]) == []
+
+
+@pytest.mark.parametrize(
+    ("their_rule", "weakened_to"),
+    [
+        ("runtime", "docker"),
+        ("network", "allowlist"),
+        ("read_only_rootfs", False),
+        ("ephemeral_work_disk", False),
+    ],
+)
+def test_a_rule_weakened_in_the_signed_policy_alone_is_caught(their_rule, weakened_to):
+    """Two copies of a rule is two chances to weaken it and one to notice.
+
+    Before this check, the signed policy could be loosened while the substrate
+    rules stood, and both files went on validating. The names differ between the
+    two — one says ``read_only_rootfs: true`` where the other says
+    ``rootfs: "read-only"`` — which is what made the drift hard to see by eye.
+    """
+    policy = _signed_policy()
+    policy["microvm"][their_rule] = weakened_to
+    drifted = containment_rules_that_disagree(policy["microvm"])
+
+    assert len(drifted) == 1
+    assert "disagrees between the two places it is written down" in drifted[0]
+    assert repr(weakened_to) in drifted[0]
+
+    with pytest.raises(ValueError, match="containment drift"):
+        SupplyChainPolicy.from_mapping(policy)
+
+
+def test_a_signed_policy_missing_its_containment_block_is_caught():
+    assert containment_rules_that_disagree(None) == [
+        "the signed policy's containment block is not a set of rules"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("our_rule", "weakened_to"),
+    [
+        ("runtime", "docker"),
+        ("network", "allowlist"),
+        ("rootfs", "writable"),
+        ("workdir", "persistent"),
+    ],
+)
+def test_a_rule_weakened_on_our_side_alone_is_caught_too(
+    our_rule, weakened_to, monkeypatch
+):
+    """The comparison guards both copies, not just the signed one.
+
+    Easy to assume it only watches the file that arrives from outside. It does
+    not: weakening the rule here while the signed policy stands is the same
+    disagreement seen from the other side, and it is refused the same way.
+    """
+    monkeypatch.setitem(REQUIRED_MICROVM_POLICY, our_rule, weakened_to)
+    drifted = containment_rules_that_disagree(_signed_policy()["microvm"])
+
+    assert len(drifted) == 1
+    assert repr(weakened_to) in drifted[0]
+
+    with pytest.raises(ValueError, match="containment drift"):
+        SupplyChainPolicy.load(SIGNED_POLICY_PATH)
+
+
+def test_the_signed_policy_block_is_derived_rather_than_written_out_again():
+    """The third copy is gone, and this is what keeps it gone.
+
+    A rule added to the containment rules and not to the translation between the
+    two namings would leave the derived block short of it, so the signed policy
+    would be accepted without stating the new rule at all.
+    """
+    derived = supply_chain_microvm_block()
+
+    assert derived == _signed_policy()["microvm"]
+    assert set(derived) == set(_SUPPLY_CHAIN_RULE_NAMES) | set(
+        SUPPLY_CHAIN_HOST_FACTS
+    )
+    for their_name, (our_name, _, _) in _SUPPLY_CHAIN_RULE_NAMES.items():
+        assert our_name in REQUIRED_MICROVM_POLICY, (
+            f"the signed policy's {their_name!r} is translated to {our_name!r}, "
+            "which is not one of the containment rules"
+        )
+
+
+def test_the_signed_policy_as_it_stands_still_validates():
+    """The change must refuse drift without refusing the file that is correct."""
+    assert SupplyChainPolicy.load(SIGNED_POLICY_PATH).document["microvm"] == (
+        _signed_policy()["microvm"]
+    )
+
+
+# ── What is not tested here, and why ──────────────────────────────────────
+
+
+def test_no_test_in_this_file_pretends_a_rule_was_enforced():
+    """The honesty guard on the file itself.
+
+    Every rule above is checked by reading a written-down value. None of them is
+    checked by exceeding a limit and observing a stop, because nothing here can
+    start a machine to exceed it on. A test that ran something would be a test
+    that had stopped answering the question in its own name.
+
+    Read with the Python parser rather than by searching the text, so that this
+    test does not trip over its own list of the names it is looking for.
+    """
+    ways_to_run_something = {"subprocess", "os", "pty", "asyncio", "docker"}
+
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+
+    assert not imported & ways_to_run_something, (
+        f"this file now imports {sorted(imported & ways_to_run_something)}, "
+        "which is how a test that reads a value turns into one that runs a "
+        "command"
+    )
+    assert "it cannot be written yet" in __doc__

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
@@ -6,6 +6,12 @@
   blocked stage three has been answered, and the answer is in section 7b: the
   containment is available on no machine currently in play. Nothing was spent
   finding either out and nothing was switched on.
+- Updated: 2026-08-26, later the same day — the containment rules themselves are
+  now complete and stated once. Four of the six things a containment has to say
+  were never written down, and the two that were had three copies that nothing
+  compared. Section 7c. Writing down what a containment *would* be is not the
+  same as having one: the rules still apply to nothing, and this made the report
+  refuse in one more case rather than one fewer.
 - Status: **specification only. Nothing here is built, and nothing in it may be
   built without a separate, explicit approval to open command execution.**
 - Related GitHub Project: hyeonsangjeon/projects/5 — card
@@ -112,11 +118,23 @@ whether the network is reachable, how much memory and time, which user it runs
 as, and what happens when it exceeds any of those. Prove each one with a test
 that tries to exceed it and requires the attempt to fail. This is a test-only
 stage; nothing is switched on.
-*Half of this is now done, and it is the half that turned out to matter.
-Section 7b establishes **where** the containment could run, by reading machines
-rather than by asserting it, and the answer is: nowhere currently in play.
-Writing rules and testing them can proceed regardless, but they would be rules
-for a machine that does not yet exist.*
+*Where the containment could run is established — section 7b, and the answer is
+nowhere in play. The rules themselves are now written down in full: on
+2026-08-26 all six questions above got an answer, where before only two had one
+and the working directory said "there is a quota" without ever saying what the
+quota was. They are decided in one place, `REQUIRED_MICROVM_POLICY`; the signed
+policy on disk still carries its own copy because a signed artefact has to, but
+nothing hand-writes a third one any more and a disagreement between the two is
+refused by name. Every rule has a test that attempting to weaken it is refused.*
+
+*What is still missing from this stage, and cannot be supplied yet, is the other
+half of "prove it": a test that starts a machine, exceeds a limit and watches the
+limit stop it. That needs both a machine that can host the containment and code
+that turns these rules into arguments for starting one. Neither exists. A test
+written today could only assert that a value is written down, so
+`tests/test_agentic_v2_containment_rules.py` says in its own opening lines that
+this is what it does and does not do — because a passing test named after a thing
+that never happened is how an unenforced rule comes to look enforced.*
 
 **Stage three — open command execution behind its own approval.**
 Only after stage two passes. `exec_run` starts running real commands inside the
@@ -140,8 +158,10 @@ the loop is worth having.
 | `batch-runner/core/agentic_v2_runner.py` | Unchanged. Still replays the written-down list; the loop was added beside it, not inside it. |
 | `batch-runner/core/agentic_v2_tools.py` | Unchanged surface; the ceilings it already applies become the loop's limits. |
 | `batch-runner/core/agentic_v2_fixture_backend.py` | Stays shut through stages one and two. |
-| `batch-runner/core/agentic_v2_substrate.py` | Stage two: the containment rules are stated and checked here. `REQUIRED_MICROVM_POLICY` is the one written-down copy of them. |
-| `batch-runner/core/agentic_v2_containment_readiness.py` | Stage two, **built**: reads a machine and reports which of those rules it can actually meet, and why. Reads the policy above rather than restating it. |
+| `batch-runner/core/agentic_v2_substrate.py` | Stage two, **built**: the containment rules are stated and checked here. `REQUIRED_MICROVM_POLICY` is the one written-down copy of them, and the numbers in it carry documentation saying what each was derived from. `supply_chain_microvm_block()` and `containment_rules_that_disagree()` exist so the signed policy can be derived from it and compared against it rather than restating it. |
+| `batch-runner/core/agentic_v2_supply_chain.py` | Stage two: held a hand-written second copy of the containment rules until 2026-08-26. Now derives the block it requires from the file above, and refuses a signed policy whose rules have drifted from it, naming both places in the message. |
+| `batch-runner/security/agentic-v2-supply-chain-policy.json` | The signed statement of the same rules, under different names — it says `read_only_rootfs: true` where the substrate says `rootfs: "read-only"`. The mismatch in names is why the two copies could drift unnoticed; the comparison above translates between them. |
+| `batch-runner/core/agentic_v2_containment_readiness.py` | Stage two, **built**: reads a machine and reports which of those rules it can actually meet, and why. Reads the policy above rather than restating it. Reports "could this machine host the containment" and "does anything apply the rules" as two separate answers; see section 7b. |
 | `batch-runner/core/agentic_v2_microvm.py` | Unchanged. Reports whether a boot test could be attempted; does not judge the host kernel or the processor, which is why the module above exists. |
 | `batch-runner/step2_run_inference.py` | Stage three: the guard is revisited, not before. |
 | `batch-runner/core/executor.py` | Stage three: the paid-run refusal is revisited, not before. |
@@ -287,11 +307,19 @@ and published policies.
 
 The substrate manifest will not validate unless it promises a small isolated
 virtual machine, run by Firecracker, with no network, a read-only root
-filesystem, and a working directory that is wiped and size-limited. Those five
+filesystem, and a working directory that is wiped and size-limited. Those
 settings now have exactly one written-down copy,
 `core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY`, which the manifest check
 enforces and the readiness report reads. Two copies could disagree with each
 other about what is required; one cannot.
+
+*Updated 2026-08-26, later the same day: there were, in fact, three copies. The
+signed supply-chain policy stated the same rules under different names, and
+`core/agentic_v2_supply_chain.py` held a third copy hand-written into its
+validator — so a rule could be weakened in one place and left standing in the
+others with every file still validating. The signed policy's block is now
+derived from the one above, and a disagreement between the two is refused by
+name. Section 7c has the detail.*
 
 ### The answer, in one line
 
@@ -303,6 +331,11 @@ are in play, and each is a different kind of no.
 | the box this repository is worked on from | no | read from the machine itself |
 | GitHub-hosted runners | no | GitHub's own published documentation |
 | the self-hosted `agentic-sandbox` runner | the question cannot be answered | there is no such machine |
+
+*And a fourth answer, added 2026-08-26, that no machine can change: even a
+machine that could host the containment would be started with none of the rules
+applied, because no code in this repository turns them into arguments for
+starting a machine. See "Two questions that were one field" below.*
 
 ### This box
 
@@ -383,6 +416,104 @@ It also changes what stage three's first step is. It was "write the containment
 rules". It is now "obtain a machine that can hold them" — which is a request for
 hardware, not a code change, and is the owner's to make.
 
+## 7c. The containment rules themselves, finished on 2026-08-26
+
+Section 7b answered *where* the containment could run. This answers *what* it
+is. The two are separate, and the second turned out to be in worse shape than
+the first suggested.
+
+### What was actually written down, and what was missing
+
+A set of settings is a containment only if it answers six questions: where a
+command may write, whether it can reach the network, how much memory it gets,
+how long it may run, who it runs as, and what happens when it exceeds any of
+those. Only two were answered. The working directory said `ephemeral-quota` —
+"there is a quota" — and never said what the quota was. There was no memory
+limit, no time limit, no user, and no answer to what a breach does.
+
+All six are now answered, each with a number or a word rather than a promise:
+
+| question | the rule | where the number comes from |
+|---|---|---|
+| where it may write | `workdir: ephemeral-quota`, `workdir_quota_mib: 256` | twice what the tool layer already accepts — `_MAX_WORKSPACE_BYTES` and `_MAX_FINAL_BYTES` are 64 MiB each, so a smaller disk would let the tools accept a write the disk could not hold |
+| the network | `network: none` | unchanged; it was one of the two already answered |
+| memory | `memory_mib: 4096` | **picked, not derived** — the only number here with nothing behind it |
+| time | `wall_clock_seconds: 1200` | the same per-task timeout the other three run places are held to, taken from `agentic_stage_one_plan.yaml` |
+| the user | `user: jailer-unprivileged` | Firecracker's jailer drops privileges; naming it makes "not root" checkable |
+| a breach | `on_breach: stop-and-report` | section 7 already requires stage three to fail loudly when its containment is unavailable, and a rule that has been exceeded is a containment that is not holding |
+
+A test refuses any rule whose name ends in a unit but whose value is not a
+positive whole number, because that is exactly the shape the working directory
+had before.
+
+**The memory number is the honest weak spot, and is recorded as one.** None of
+the three run places in the comparison caps memory at all. Applying a cap here
+makes this column stricter than the others on an axis the comparison does not
+otherwise control, so a task that failed here for memory would not have failed
+elsewhere for that reason. That is written into the rule's own documentation
+rather than left for somebody to notice later.
+
+### Three copies of one rule, and nothing comparing them
+
+The rules were stated in three places: `REQUIRED_MICROVM_POLICY`, the signed
+supply-chain policy on disk, and a hand-written dictionary inside the
+supply-chain validator. Nothing compared any two of them, and the names differ
+between them — one says `read_only_rootfs: true` where another says
+`rootfs: "read-only"` — which is what made a disagreement hard to see by eye.
+Three copies is three chances to weaken a rule and no chance to notice.
+
+There is now one copy. The validator's dictionary is derived from it by
+`supply_chain_microvm_block()`, and a signed policy that disagrees with it is
+refused with a message naming the rule and both places it is written down.
+
+### Every rule is refused when weakened, and nothing pretends to be enforced
+
+`tests/test_agentic_v2_containment_rules.py` — 33 tests — takes each rule in
+turn, weakens it, and requires the weakened version to be rejected: the network
+opened to an allowlist or to the host, the root filesystem made writable, the
+working directory made persistent, any limit quadrupled, the user set to root,
+the breach rule changed to carry on, the runtime changed to Docker, and the
+whole containment marked optional. Deleting a rule outright is refused too,
+since that is the quietest way to remove one.
+
+What those tests deliberately do not do is start a machine, run a command,
+exceed a limit and watch it stop. That is the test these rules will eventually
+need. It cannot be written yet, and the file says so in its own opening lines
+rather than quietly omitting it, because a passing test named after a thing that
+never happened is how an unenforced rule comes to look enforced.
+
+### Two questions that were one field
+
+Writing the numbers down exposed a reporting fault. The readiness report had one
+field for "the containment is available", and it was answering two different
+questions at once: *could this machine host the containment*, and *is the
+containment actually in place*. Because they were one field, a rule that nothing
+applies was being reported as met.
+
+They are now two fields, because they are fixed by two different things:
+
+- **Could a machine host it** is fixed by finding, configuring or buying a
+  machine. It is read off the machine.
+- **Does anything apply the rules** is fixed by writing code that turns
+  `REQUIRED_MICROVM_POLICY` into arguments for starting a machine. Nobody has
+  written it. This is a fact about this repository, so the answer is the same on
+  every machine, and a better machine does not change it.
+
+Every policy setting in the report now answers "cannot be established here"
+rather than "met", and says which of the two reasons applies. The recorded
+findings for machines that cannot be read from here were renamed accordingly:
+they record whether a machine *could host* the containment, which is the only
+part of the question a machine can answer.
+
+This makes the report strictly more cautious than before: the refusal now stands
+even on a machine that meets every hardware requirement. The free check's exit
+code is 1 for either reason, and its own documentation lists them separately so
+that a reader can tell whether to go and find a machine or go and write code.
+
+**No refusal was removed and nothing was switched on.** Writing down what a
+containment would be is not the same as having one, and the three guards are
+exactly as shut as they were.
+
 ## 8. Order the work would be done in
 
 1. ~~Work out and get approval for the cost ceiling of a small stage-one run.~~
@@ -392,12 +523,14 @@ hardware, not a code change, and is the owner's to make.
    nothing. `exec_run` is still shut, and the loop cannot reach a real model.
 3. Measure whether choosing tools helps, on the same five tasks. **Needs an
    approved amount and a way to reach a real model.**
-4. Write the containment rules and the tests that try to break them.
-   **Where those rules could run is now established (section 7b): nowhere in
-   play.** So this step now begins with obtaining a machine that can hold them,
-   which is a request for hardware rather than a code change. The rules can be
-   written and tested before that machine exists; they simply would not apply to
-   anything yet.
+4. ~~Write the containment rules and the tests that try to break them.~~
+   **Rules written (section 7c):** all six questions answered with numbers, one
+   written-down copy, and a test per rule that weakening it is refused.
+   **The tests that try to break them are only half written**, and the missing
+   half needs two things that do not exist: a machine that can host the
+   containment — a request for hardware, not a code change — and code that turns
+   the rules into arguments for starting one. Until both exist, the rules are
+   written down and applied to nothing.
 5. Seek approval for command execution, presenting those test results.
 6. Only then, open `exec_run`.
 7. Revisit the two guards, each in its own change.
@@ -413,13 +546,25 @@ hardware, not a code change, and is the owner's to make.
   than continuing indefinitely. **Done:**
   `tests/test_agentic_v2_conversation.py::test_the_run_stops_at_the_dispatchers_own_call_ceiling`.
 - Stage two: one test per containment rule, each attempting to exceed it and
-  requiring failure.
+  requiring failure. **Half done, and the half that is missing is named rather
+  than skipped.** `tests/test_agentic_v2_containment_rules.py`, 33 tests, takes
+  each rule in turn, weakens it, and requires the weakened version to be
+  refused — including a rule deleted outright, and a rule weakened in the signed
+  policy alone. What no test does is start a machine, exceed a limit and watch
+  the limit stop it; that needs a machine that can host the containment and code
+  that applies the rules, and neither exists. The file's own opening lines say
+  so, and a test in it fails if the file ever gains the ability to run anything.
+- Stage two: the numbers that were derived from something else are checked
+  against their source, so the source moving is caught: the working disk against
+  the tool layer's own write ceilings, and the time limit against the per-task
+  timeout the other three run places are held to.
 - Stage two: a check that reports, per machine, which containment rules that
   machine can meet and why. **Done:**
-  `tests/test_agentic_v2_containment_readiness.py`, 61 tests, including one that
-  requires the check itself to be incapable of starting a process and one that
+  `tests/test_agentic_v2_containment_readiness.py`, 64 tests, including one that
+  requires the check itself to be incapable of starting a process, one that
   fails if a workflow starts asking for a machine nobody has answered the
-  containment question for.
+  containment question for, and one that requires no policy rule to be reported
+  as met while nothing applies the rules.
 - All stages: the existing test that opens all three guards and requires them
   shut must keep passing until the stage that deliberately changes one. **Still
   passing**, and both the loop's and the containment check's own test suites run
@@ -431,13 +576,17 @@ hardware, not a code change, and is the owner's to make.
       failure it was shown. (Against a stand-in model. A real one is still out
       of reach and needs an approved amount.)
 - [ ] Every containment rule has a test that tries to exceed it and fails.
-      (Which machine could satisfy those rules is now established — none of the
-      three in play. See section 7b.)
+      Every rule now exists and has a number (section 7c), and every rule has a
+      test that weakening it is refused. Exceeding one and watching it stop
+      needs a machine that can host the containment — none of the three in play
+      can, see section 7b — and code that applies the rules to that machine,
+      which nobody has written.
 - [ ] Command execution is opened only after a separate written approval.
 - [ ] The free check reports this run place as able to run only when it is.
-      (Two of the three questions behind that report are now answered from real
-      readings rather than assumed: whether a real model can be reached, and
-      whether the containment exists anywhere. Both answers are no.)
+      (Three of the questions behind that report are now answered from real
+      readings rather than assumed: whether a real model can be reached, whether
+      any machine could host the containment, and whether anything applies the
+      containment rules. All three answers are no.)
 
 ## 11. Known blockers and the next decision
 
@@ -466,6 +615,18 @@ hardware, not a code change, and is the owner's to make.
   self-hosted machine one workflow asks for has never been registered, so its
   question has no subject. This blocks stage three only, not stage one. It is
   also the only blocker on this list that code cannot clear: it needs a machine.
+- **Blocked on nothing applying the containment rules.** Added 2026-08-26, and
+  it is genuinely new rather than a restatement of the one above. The rules are
+  now complete and written down once (section 7c), but no code turns them into
+  arguments for starting a machine, so a machine that could hold the containment
+  would still be started with none of the rules applied. This blocker is the
+  same on every machine, because it is a fact about this repository rather than
+  about any machine — obtaining hardware does not clear it, and it does not
+  clear the hardware blocker either. Both must go before stage three can be
+  considered. Unlike the one above, this one *is* clearable by code; it was not
+  cleared here on purpose, because writing a launcher builds the risky
+  capability before there is anywhere to test it and before anyone has approved
+  opening it.
 
 The next decision is now a specific one with a price beside it: **which row of
 the table in section 7a is stage one worth running at?** The cheapest row that


### PR DESCRIPTION
## What was wrong

A set of settings is a containment only if it answers six things: **where** a command may write, whether it can reach the **network**, how much **memory** it gets, how long it may **run**, **who** it runs as, and what happens when it **exceeds** any of those.

Two were answered. The working directory said `ephemeral-quota` — *"there is a quota"* — and **never said what the quota was.** A limit with no number is not a limit; nobody could apply it even if something were applying rules.

And the two that *were* written down had **three copies** that nothing compared.

## All six now carry a number, and the derivable ones were derived

| question | rule | where the number comes from |
|---|---|---|
| where it may write | `workdir_quota_mib: 256` | twice what the tool layer already accepts — `_MAX_WORKSPACE_BYTES` and `_MAX_FINAL_BYTES` are 64 MiB each, so the tools can never accept a write the disk cannot hold |
| network | `network: none` | unchanged, already answered |
| memory | `memory_mib: 4096` | **picked, not derived** |
| time | `wall_clock_seconds: 1200` | the same `per_task_timeout_seconds` the other three run places are held to |
| the user | `user: jailer-unprivileged` | the jailer is what drops privileges; naming it makes "not root" checkable |
| a breach | `on_breach: stop-and-report` | §7 already requires stage three to fail loudly when containment is unavailable, and an exceeded rule is a containment that is not holding |

A test refuses any rule whose name ends in a unit but whose value is not a positive whole number — the exact shape the working directory had.

**Memory is the honest weak spot and says so in its own documentation.** None of the three run places in the comparison caps memory at all, so a cap here makes this column stricter on an axis the comparison does not otherwise control. A test fails if that admission is ever removed.

## Three copies became one

The rules lived in `REQUIRED_MICROVM_POLICY`, in the signed supply-chain policy on disk, and in a **hand-written dict inside the supply-chain validator** — under different names in each (`read_only_rootfs: true` in one, `rootfs: "read-only"` in another), which is what made a disagreement hard to see by eye. Nothing compared any two of the three, so a rule could be weakened in one place and left standing in the others with **every file still validating.**

The validator's copy is gone. It derives from `supply_chain_microvm_block()`, and `containment_rules_that_disagree()` refuses drift **in either direction** with a message naming the rule and both places it is written down.

## 33 tests, and one deliberate omission stated out loud

Every rule is refused when weakened: the network opened to an allowlist or the host, a writable root filesystem, a persistent working directory, any limit quadrupled, the user set to root, a breach rule that carries on, the runtime changed to Docker, the containment marked optional, and any rule deleted outright.

**What no test does is start a machine, exceed a limit and watch it stop.** That needs a machine that can host the containment — none of the three in play can, see §7b — and code that turns these rules into arguments for starting one, which nobody has written. `tests/test_agentic_v2_containment_rules.py` says this in its own opening lines rather than quietly omitting it, because a passing test named after a thing that never happened is how an unenforced rule comes to look enforced. A test in the file fails if it ever gains the ability to run anything.

## A rule nothing applies was being reported as met

Writing the numbers down exposed a reporting fault. One field was answering two different questions at once: *could this machine host the containment*, and *is the containment actually in place*.

They are two fields now, because they are fixed by two different things:

- **Could a machine host it** — fixed by finding, configuring or buying a machine. Read off the machine.
- **Does anything apply the rules** — fixed by writing that code. A fact about this repository, so the answer is the same on every machine, and a better machine does not change it.

A reader of the refusal can now tell whether to go find a machine or go write code.

## Nothing was opened

This is **strictly more cautious than before**: the refusal now stands even on a machine meeting every hardware requirement.

- `exec_run` still answers `capability_unavailable`
- `step2_run_inference._require_runnable_execution_mode` still rejects the mode
- `core/executor.py` still refuses unless the run is declared free of paid model calls
- `check_execution_environment_readiness.py` still reports `agentic_sandbox_v2` as `structure_check_only`
- `check_agentic_containment.py` still exits 1

Writing down what a containment *would* be is not the same as having one. The launcher was deliberately not built: it would create the risky capability before there is anywhere to test it and before anyone has approved opening it. §11 records that as its own blocker, separate from the hardware one, since neither clears the other.

## Verification

- **Full suite: 4051 passed, 6 skipped, 0 failed** (525 s)
- **mypy unchanged at baseline:** 170 errors in 32 files (95 source files)
- The derived supply-chain block reproduces the signed policy on disk **exactly**; that file was not modified, so its signature is intact
- Nothing calls a model, runs a command, signs in to an account, or spends money

Spec: `tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md` §5, §6, §7b, new §7c, §8, §9, §10, §11.
