### PR TITLE
fix(agentic-v2): derive the readiness blockers instead of restating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,61 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **Two free checks printed contradicting answers about the same fact, to the
+  same reader, in the same session.** `scripts/check_agentic_stage_one_ceiling.py`
+  said the model conversation loop exists, is proven against stand-ins that spend
+  nothing, and that what is missing is a way to reach a real model.
+  `scripts/check_execution_envelope_advance_check.py` said "the model never sees
+  a tool result and never chooses a next action". Only one of them had looked:
+  the first establishes its answer by running the loop, the second was a sentence
+  in `core/execution_environment_readiness.py` written before the loop existed
+  and never re-read after it was built. A sentence is not checked against
+  anything.
+
+  This was not untidiness. **The stale half pointed at work that was already
+  finished**, so a reader taking it at its word would have gone off to write a
+  loop that exists, instead of at the two things stage one actually waits on.
+
+  `core/execution_environment_readiness.py` no longer decides this. It asks
+  `core.agentic_v2_stage_one_budget.check_stage_one_cannot_reach_a_model`, the
+  one place that settles it by running the loop against a stand-in that declares
+  itself paid and requiring the loop to stop before asking it anything, and
+  prints back exactly what that returns. Two copies of one piece of reasoning is
+  what caused the defect, so the fix is one copy and one caller. The lookup uses
+  this module's existing by-name import helper, so a module that has moved is
+  reported as *a real model has to be treated as reachable until somebody
+  checks* — never as silence, which reads as a question that was asked and came
+  back clear.
+
+- **One blocker sentence was making three claims with three different ways
+  out.** "the command-running tool exec_run is closed, the model never sees a
+  tool result and never chooses a next action, and no approval exists to use this
+  environment in a real experiment" bundles opening the command tool, reaching a
+  real model, and obtaining an approval. While they shared a sentence, finishing
+  one of the three changed nothing in the report — which is how the finished one
+  went on being listed as outstanding. They are now three blockers. The command
+  tool is **called** and the blocker reports what came back, so a tool that
+  opened reaches the report instead of the reassuring sentence; the approval
+  stays a plain statement, because an approval is a decision, not a fact about a
+  module.
+
+- **`experiments/execution_envelope/advance_check_plan.yaml`** carried the same
+  stale claim in a comment. Corrected, with a note naming which of the two copies
+  is the one checked against the code.
+
+### Added
+- `batch-runner/tests/test_free_checks_agree_on_the_loop.py` — nine tests. The
+  load-bearing one requires the sentence the readiness report prints about
+  reaching a real model to be, character for character, the sentence the other
+  check produced; matching on substance instead would let the two drift apart
+  again, which is the failure being fixed. Five of the nine fail against the code
+  as it stood before this change.
+
+  Nothing was switched on. The report gained a blocker and lost none, the three
+  guards are as shut as they were, the environment is still
+  `structure_check_only`, and all three free checks still exit 1.
+
+### Fixed
 - **Four of the six things a containment has to say were never written down,
   and the two that were had three copies that nothing compared.** A set of
   settings is a containment only if it answers where a command may write,

--- a/batch-runner/core/execution_environment_readiness.py
+++ b/batch-runner/core/execution_environment_readiness.py
@@ -535,6 +535,79 @@ def _check_exec_run_stays_unavailable(backend_class: Any) -> list[str]:
     return []
 
 
+def _why_a_real_model_is_out_of_reach() -> list[str]:
+    """Ask the one place that establishes this instead of restating it.
+
+    ``core.agentic_v2_stage_one_budget.check_stage_one_cannot_reach_a_model``
+    settles this by running the loop with a stand-in that declares itself paid
+    and requiring it to stop before asking the stand-in anything. Saying the
+    same thing again here in a sentence is exactly what let the two free checks
+    print contradicting answers in the same run, so this asks rather than says.
+
+    Looked up by name, in this module's usual way, so a missing module is
+    reported as an unanswered question rather than crashing the whole report.
+    """
+    try:
+        establish = _import_attribute(
+            "core.agentic_v2_stage_one_budget",
+            "check_stage_one_cannot_reach_a_model",
+        )
+    except (ImportError, AttributeError) as error:
+        return [
+            "whether a real model can be reached could not be established, so "
+            f"it has to be treated as reachable until somebody checks: {error}"
+        ]
+    try:
+        return list(establish())
+    except Exception as error:  # pragma: no cover - defensive
+        return [
+            "establishing whether a real model can be reached failed, so it "
+            "has to be treated as reachable until somebody checks: "
+            f"{type(error).__name__}: {error}"
+        ]
+
+
+def _agentic_sandbox_v2_blockers() -> list[str]:
+    """Work out what stops this run place by running it, not by describing it.
+
+    Until 2026-08-26 this was one hand-written sentence that said three things
+    at once: that the command-running tool was closed, that the model never saw
+    a tool result and never chose a next action, and that nobody had approved
+    using this environment for real work.
+
+    The middle one stopped being true when the loop was built.
+    ``core.agentic_v2_conversation.run_model_conversation`` shows the model what
+    a tool returned and asks it again, and is proven doing so against stand-ins
+    that spend nothing. The sentence carried on being printed, because a
+    sentence is not checked against anything, while the other free check
+    established the opposite by running the code and printed that in the same
+    session. A reader had two answers and no way to tell which one had been
+    looked up.
+
+    They are also three separate blockers with three different ways out —
+    opening the command tool, reaching a real model, and an approval — so
+    bundling them meant that when one of the three moved, nothing in the report
+    changed shape.
+    """
+    blockers: list[str] = []
+
+    blocks_that_opened = check_agentic_sandbox_v2_blocks_are_intact()
+    if blocks_that_opened:
+        blockers.extend(blocks_that_opened)
+    else:
+        blockers.append(
+            "the command-running tool exec_run is closed: called here with an "
+            "ordinary command, it answers that the capability is unavailable"
+        )
+
+    blockers.extend(_why_a_real_model_is_out_of_reach())
+
+    blockers.append(
+        "no approval exists to use this environment in a real experiment"
+    )
+    return blockers
+
+
 def inspect_environment_support(
     *,
     docker_daemon_available: bool | None = None,
@@ -606,20 +679,19 @@ def inspect_environment_support(
 
         if environment == ENVIRONMENT_AGENTIC_SANDBOX_V2:
             evidence.append(
-                "core.executor.TaskExecutor refuses this mode unless the run is "
-                "declared free of paid model calls, and "
-                "step2_run_inference._require_runnable_execution_mode refuses it "
-                "in the paid inference pipeline"
+                "the three safety blocks were run rather than read: "
+                "step2_run_inference._require_runnable_execution_mode, "
+                "core.executor.TaskExecutor's refusal of a paid run, and "
+                "core.agentic_v2_fixture_backend.AgenticV2FixtureBackend."
+                "exec_run on an ordinary command"
             )
             evidence.append(
-                "core.agentic_v2_fixture_backend.AgenticV2FixtureBackend.exec_run "
-                "answers capability_unavailable for ordinary commands"
+                "whether a real model can be reached was settled by "
+                "core.agentic_v2_stage_one_budget."
+                "check_stage_one_cannot_reach_a_model, which runs the loop "
+                "with a stand-in instead of describing what it would do"
             )
-            blockers.append(
-                "the command-running tool exec_run is closed, the model never "
-                "sees a tool result and never chooses a next action, and no "
-                "approval exists to use this environment in a real experiment"
-            )
+            blockers.extend(_agentic_sandbox_v2_blockers())
             results.append(
                 EnvironmentReadiness(
                     environment=environment,

--- a/batch-runner/experiments/execution_envelope/advance_check_plan.yaml
+++ b/batch-runner/experiments/execution_envelope/advance_check_plan.yaml
@@ -37,9 +37,14 @@ comparison: "same_generated_code_rerun"
 # other two are left out on purpose and are NOT replaced by anything:
 #
 #   Agentic Sandbox V2 — its command-running tool answers that the capability
-#     is unavailable, no loop lets the model read a tool result and pick a next
-#     action, and two separate guards refuse the mode. Only structure checks
-#     are possible, so it cannot take part in a scored comparison.
+#     is unavailable, two separate guards refuse the mode, and nothing here can
+#     reach a real model to drive it. The loop itself does exist, at
+#     core/agentic_v2_conversation.py, and is proven against stand-ins that
+#     spend nothing; this comment said otherwise until 2026-08-26, which is
+#     what a written-down claim does when nobody re-reads it. Only structure
+#     checks are possible, so it cannot take part in a scored comparison.
+#     core/execution_environment_readiness.py is the copy that is checked
+#     against the code; if the two ever disagree, believe that one.
 #
 #   Codex built-in agent — this repository holds no code that runs a benchmark
 #     task through it, and no official documentation was found describing

--- a/batch-runner/tests/test_free_checks_agree_on_the_loop.py
+++ b/batch-runner/tests/test_free_checks_agree_on_the_loop.py
@@ -1,0 +1,194 @@
+"""The two free checks must not give different answers to the same question.
+
+Both of these are printed to whoever is deciding what to do next:
+
+  scripts/check_agentic_stage_one_ceiling.py said the loop exists, that it is
+  proven against stand-ins, and that what is missing is a way to reach a real
+  model.
+
+  scripts/check_execution_envelope_advance_check.py said "the model never sees
+  a tool result and never chooses a next action".
+
+Both ran in the same repository on the same day and only one of them had looked.
+The first establishes its answer by running the loop; the second carried a
+sentence written before the loop existed, and a sentence is not checked against
+anything. A reader had two answers and no way to tell which had been looked up
+— and the wrong one pointed at work that was already finished.
+
+These tests hold the two together: they require the answer printed by the
+readiness report to be the answer the other check produced, rather than a
+second telling of it.
+
+Nothing here calls a model, runs a command, or spends money. The blocks that
+keep Agentic Sandbox V2 shut are asserted to still be shut rather than
+loosened for the convenience of a test.
+"""
+
+from __future__ import annotations
+
+from core.agentic_v2_stage_one_budget import check_stage_one_cannot_reach_a_model
+from core.execution_environment_readiness import (
+    ENVIRONMENT_AGENTIC_SANDBOX_V2,
+    STATUS_STRUCTURE_CHECK_ONLY,
+    check_agentic_sandbox_v2_blocks_are_intact,
+    inspect_environment_support,
+)
+import core.execution_environment_readiness as readiness
+
+
+def _agentic_entry():
+    return next(
+        entry
+        for entry in inspect_environment_support()
+        if entry.environment == ENVIRONMENT_AGENTIC_SANDBOX_V2
+    )
+
+
+# ── The two checks agree ──────────────────────────────────────────────────
+
+
+def test_the_two_free_checks_give_the_same_answer_about_reaching_a_model():
+    """Not "agree in substance" — the same words, because it is one answer.
+
+    Matching on the sentence itself is deliberate. Two checks that reach the
+    same conclusion by separate routes can drift apart the moment one of the
+    routes changes, which is what happened here. One of them now asks the
+    other, and this is what says so.
+    """
+    settled = check_stage_one_cannot_reach_a_model()
+    blockers = _agentic_entry().blockers
+
+    assert settled, "the other check stopped saying anything about a real model"
+    for sentence in settled:
+        assert sentence in blockers, (
+            "the readiness report no longer prints what the stage-one check "
+            f"established; it is missing {sentence!r}"
+        )
+
+
+def test_the_report_does_not_say_the_loop_is_missing_while_the_loop_exists():
+    """The exact claim that went stale, named so a return of it fails here."""
+    from core.agentic_v2_conversation import run_model_conversation
+
+    assert callable(run_model_conversation)
+
+    entry = _agentic_entry()
+    for note in list(entry.blockers) + list(entry.evidence):
+        assert "never sees a tool result" not in note, (
+            f"the report says the loop does not exist: {note!r}"
+        )
+        assert "never chooses a next action" not in note, (
+            f"the report says the loop does not exist: {note!r}"
+        )
+
+
+# ── Three claims, three blockers ──────────────────────────────────────────
+
+
+def test_the_three_claims_are_three_blockers_rather_than_one_sentence():
+    """One sentence holding three claims hides which of the three moved.
+
+    Opening the command tool, reaching a real model and obtaining an approval
+    are three different pieces of work with three different people behind them.
+    While they shared a sentence, finishing one of them changed nothing in the
+    report — which is how the finished one went on being listed as outstanding.
+    """
+    blockers = _agentic_entry().blockers
+
+    holding_the_command_tool = [note for note in blockers if "exec_run" in note]
+    holding_the_model = [note for note in blockers if "real model" in note]
+    holding_the_approval = [note for note in blockers if "no approval exists" in note]
+
+    assert len(holding_the_command_tool) == 1
+    assert len(holding_the_model) == 1
+    assert len(holding_the_approval) == 1
+    assert (
+        len(
+            set(holding_the_command_tool + holding_the_model + holding_the_approval)
+        )
+        == 3
+    ), "two of the three claims are sharing one sentence again"
+
+
+def test_the_command_tool_blocker_says_it_was_called_rather_than_described():
+    blocker = next(note for note in _agentic_entry().blockers if "exec_run" in note)
+
+    assert "called here" in blocker
+    assert "capability is unavailable" in blocker
+
+
+# ── What happens when an observation comes back wrong ─────────────────────
+
+
+def test_a_block_that_opened_is_reported_instead_of_the_reassuring_sentence(
+    monkeypatch,
+):
+    """The point of observing rather than asserting, stated as a test.
+
+    A sentence would have gone on saying the tool was closed. What is there now
+    reports what it found, so a block that opened reaches the report.
+    """
+    monkeypatch.setattr(
+        readiness,
+        "check_agentic_sandbox_v2_blocks_are_intact",
+        lambda: ["the exec_run command tool accepted an ordinary command"],
+    )
+    blockers = _agentic_entry().blockers
+
+    assert "the exec_run command tool accepted an ordinary command" in blockers
+    assert not any("exec_run is closed" in note for note in blockers)
+
+
+def test_an_unanswerable_question_is_reported_rather_than_passed_over(monkeypatch):
+    """Not being able to check is not the same as there being nothing to find.
+
+    If the module that settles this cannot be loaded, the honest report is that
+    a real model has to be treated as reachable until somebody looks — not
+    silence, which reads as though the question was asked and came back clear.
+    """
+
+    def cannot_load(module_name, attribute):
+        raise ImportError(f"no module named {module_name}")
+
+    monkeypatch.setattr(readiness, "_import_attribute", cannot_load)
+    problems = readiness._why_a_real_model_is_out_of_reach()
+
+    assert len(problems) == 1
+    assert "has to be treated as reachable until somebody checks" in problems[0]
+
+
+def test_a_determination_that_raises_is_reported_rather_than_passed_over(
+    monkeypatch,
+):
+    def explodes():
+        raise RuntimeError("something changed underneath")
+
+    monkeypatch.setattr(
+        readiness,
+        "_import_attribute",
+        lambda module_name, attribute: explodes,
+    )
+    problems = readiness._why_a_real_model_is_out_of_reach()
+
+    assert len(problems) == 1
+    assert "has to be treated as reachable until somebody checks" in problems[0]
+    assert "RuntimeError" in problems[0]
+
+
+# ── Nothing was opened to make any of the above true ──────────────────────
+
+
+def test_this_run_place_is_still_structure_check_only_and_still_shut():
+    """Reporting a blocker more accurately must not remove one."""
+    assert check_agentic_sandbox_v2_blocks_are_intact() == []
+    assert _agentic_entry().status == STATUS_STRUCTURE_CHECK_ONLY
+
+
+def test_the_evidence_says_the_blocks_were_run_rather_than_read():
+    evidence = _agentic_entry().evidence
+
+    assert any("run rather than read" in note for note in evidence)
+    assert any("exec_run" in note for note in evidence)
+    assert any(
+        "check_stage_one_cannot_reach_a_model" in note for note in evidence
+    )

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
@@ -514,6 +514,88 @@ that a reader can tell whether to go and find a machine or go and write code.
 containment would be is not the same as having one, and the three guards are
 exactly as shut as they were.
 
+## 7d. Two free checks that answered the same question differently, fixed 2026-08-26
+
+### What a reader saw
+
+Both of these are printed to whoever is deciding what to do next, and on
+2026-08-26 both were run in the same session:
+
+| Check | What it said about the loop |
+|---|---|
+| `scripts/check_agentic_stage_one_ceiling.py` | the loop exists at `core.agentic_v2_conversation.run_model_conversation`, is proven against stand-ins that spend nothing, and what is missing is a way to reach a real model |
+| `scripts/check_execution_envelope_advance_check.py` | "the model never sees a tool result and never chooses a next action" |
+
+Only one of them had looked. The first settles the question by running the loop
+against a stand-in that declares itself paid and requiring the loop to stop
+before asking it anything. The second was a sentence in
+`core/execution_environment_readiness.py`, written before the loop existed and
+correct when it was written. Building the loop (section 5, pull request #228) did
+not change it, because a sentence is not checked against anything.
+
+This is the same fault as sections 7b and 7c and as the two pull requests before
+them: **a claim written in prose, relied on, and never compared with the code.**
+The only new part is that this time the repository was already contradicting
+itself out loud and nobody had put the two outputs side by side.
+
+### Why it mattered rather than being untidy
+
+The stale half pointed at work that was already finished. A reader taking the
+advance check at its word would have concluded that stage one still needed its
+loop written, when what stage one needs is an amount approved and a way to reach
+a real model — a different job, for a different person.
+
+### One sentence that was three claims
+
+The blocker read: *the command-running tool exec_run is closed, the model never
+sees a tool result and never chooses a next action, and no approval exists to use
+this environment in a real experiment.*
+
+Those are three separate blockers with three different ways out — opening the
+command tool, reaching a real model, and an approval. Bundled into one sentence,
+finishing any one of them changed nothing in the report, which is precisely how
+the finished one went on being listed as outstanding.
+
+### What it does now
+
+They are three blockers, and none of them is asserted:
+
+- **The command tool** is called, here, with an ordinary command, and the
+  blocker reports what came back. If it ever answers instead of refusing, the
+  report says so rather than repeating the reassuring sentence.
+- **Reaching a real model** is not decided here at all. The readiness report asks
+  `core.agentic_v2_stage_one_budget.check_stage_one_cannot_reach_a_model`, which
+  is the one place that establishes it by running the loop, and prints back
+  exactly what it returns. Writing a second copy of that reasoning is what caused
+  this defect; the fix is to have one copy and one caller.
+- **The approval** stays a plain statement, because there is nothing in the code
+  to observe: an approval is a decision, not a fact about a module.
+
+The lookup goes through this module's existing by-name import helper, so a module
+that has moved is reported as an unanswered question rather than crashing the
+whole report — and an unanswered question is reported as *a real model has to be
+treated as reachable until somebody checks*, never as silence.
+
+`experiments/execution_envelope/advance_check_plan.yaml` carried the same stale
+claim in a comment and was corrected in the same change, with a note saying which
+of the two copies is the one checked against the code.
+
+### The test that stops it happening again
+
+Nine tests in `tests/test_free_checks_agree_on_the_loop.py`. The load-bearing one
+requires the sentence the readiness report prints about reaching a real model to
+be, character for character, the sentence the other check produced. Matching on
+substance rather than on the text would let the two drift apart again, which is
+the whole failure being fixed. Five of the nine fail against the code as it stood
+before this change.
+
+### What was switched on — nothing
+
+The report gained a blocker and lost none. The three guards are as shut as they
+were, `check_agentic_sandbox_v2_blocks_are_intact()` still returns no problems,
+the environment is still `structure_check_only`, and all three free checks still
+exit 1.
+
 ## 8. Order the work would be done in
 
 1. ~~Work out and get approval for the cost ceiling of a small stage-one run.~~


### PR DESCRIPTION
## What a reader saw

Two free checks were run in the same session, on the same day, and printed contradicting answers about the same fact.

| Check | What it said about the loop |
|---|---|
| `scripts/check_agentic_stage_one_ceiling.py` | the loop exists at `core.agentic_v2_conversation.run_model_conversation`, is proven against stand-ins that spend nothing, and what is missing is a way to reach a real model |
| `scripts/check_execution_envelope_advance_check.py` | *"the model never sees a tool result and never chooses a next action"* |

Only one of them had looked.

The first settles the question **by running the loop** against a stand-in that declares itself paid, and requiring the loop to stop before asking it anything. The second was a sentence in `core/execution_environment_readiness.py`, written before the loop existed and correct when it was written. #228 built the loop; the sentence did not change, because **a sentence is not checked against anything**.

## Why it mattered

The stale half **pointed at work that was already finished.** A reader taking the advance check at its word would have concluded that stage one still needed its loop written — when what stage one needs is an amount approved and a way to reach a real model. Different job, different person.

This is the same defect class as #226, #227, #230/#231 and #232: a claim written in prose, relied on, and never compared with the code. The new part is that the repository was already contradicting itself out loud and nobody had put the two outputs side by side.

## One sentence that was three claims

> the command-running tool exec_run is closed, the model never sees a tool result and never chooses a next action, and no approval exists to use this environment in a real experiment

Three separate blockers with three different ways out — opening the command tool, reaching a real model, and an approval. Bundled into one sentence, **finishing any one of them changed nothing in the report**, which is exactly how the finished one went on being listed as outstanding.

## What it does now

Three blockers, and none of them asserted:

- **The command tool** is *called*, here, with an ordinary command, and the blocker reports what came back. If it ever answers instead of refusing, the report says so rather than repeating the reassuring sentence.
- **Reaching a real model** is not decided here at all. Readiness asks `core.agentic_v2_stage_one_budget.check_stage_one_cannot_reach_a_model` and prints back exactly what it returns. Two copies of one piece of reasoning is what caused this; the fix is one copy and one caller.
- **The approval** stays a plain statement, because there is nothing in the code to observe. An approval is a decision, not a fact about a module.

The lookup goes through this module's existing by-name import helper, so a module that has moved is reported as *"a real model has to be treated as reachable until somebody checks"* — never as silence, which reads as a question that was asked and came back clear.

`experiments/execution_envelope/advance_check_plan.yaml` carried the same stale claim in a comment. Corrected, with a note naming which of the two copies is the one checked against the code.

## Before and after

```
- blocked by: the command-running tool exec_run is closed, the model never sees a
              tool result and never chooses a next action, and no approval exists
              to use this environment in a real experiment

+ blocked by: the command-running tool exec_run is closed: called here with an
              ordinary command, it answers that the capability is unavailable
+ blocked by: stage one cannot start because nothing here can reach a real model:
              the loop exists at core.agentic_v2_conversation.run_model_conversation
              and is proven against stand-ins that spend nothing, but
              real_model_voice refuses and the loop refuses any model that would be
              charged for. Approving an amount below is what removes this
+ blocked by: no approval exists to use this environment in a real experiment
```

The middle line is now **character for character** what the ceiling check prints.

## The test that stops it happening again

Nine tests in `tests/test_free_checks_agree_on_the_loop.py`. The load-bearing one requires the sentence readiness prints about reaching a real model to be, character for character, the sentence the other check produced. Matching on substance rather than on the text would let the two drift apart again, which is the whole failure being fixed.

**Five of the nine fail against the code as it stood before this change** — verified by restoring the old blocker and re-running.

## What was switched on — nothing

The report **gained** a blocker and lost none.

- `check_agentic_sandbox_v2_blocks_are_intact()` still returns no problems
- the environment is still `structure_check_only`
- all three free checks still exit `1`
- no amount was approved; no model was called; no command was run

## Checks

- new tests: **9**, all passing
- full suite: **4,065 passed / 6 skipped / 0 failed** (collection confirms the delta is exactly +9: 4,060 → 4,069)
- `mypy core/`: **170 errors in 32 files** — identical to baseline; **0** in the changed module
