### PR TITLE
fix(envelope): make the free Azure check apply the rules the paid run applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **The free Azure check gave a clean bill of health for six settings the paid
+  run refuses to start with.** `core/execution_envelope_azure.py` decides
+  whether the three-way run-place comparison may spend anything on Azure, and
+  its own specification claimed a plan checked there was "checked against
+  exactly the rules the real run applies". Nothing measured that. Sweeping
+  seventeen Azure settings one at a time and asking both the check and
+  `AzureAIRouteSettings.from_env`, **seven disagreed and six of the seven
+  disagreed in the direction that costs money.** All six were endpoint-identity
+  settings — `AZURE_AI_EXPECTED_DIRECT_ACCOUNT`,
+  `AZURE_AI_EXPECTED_PROJECT_ACCOUNT`, `AZURE_AI_EXPECTED_PROJECT_NAME` — which
+  the run demands and compares against the endpoint it is about to use, and
+  which the check never looked at. Every workflow step in `batch-run.yml` and
+  `grade-run.yml` that can spend money hard-sets
+  `AZURE_AI_REQUIRE_EXPECTED_IDENTITIES` to `'1'`, so the run always demands
+  them, while the check that gates a 363.59 USD ceiling saw none of them. The
+  check now reads the run's own identity table and applies it, and compares the
+  plan's pinned account and project against those settings — a comparison the
+  plan file asserted in a comment and nothing performed. Sixteen of the
+  seventeen settings now agree; the seventeenth is refused here on purpose,
+  because the comparison is pinned to the `project-ci` profile.
+- **Two lists of setting names were typed out a second time inside the Azure
+  check.** The ten fixed credentials the repository refuses to run with were
+  retyped in `core/execution_envelope_azure.py`, while
+  `scripts/azure_ai_route_preflight.py` imported the same list correctly.
+  Demonstrated rather than argued: adding an eleventh name to the real list
+  left the run refusing to start and the check reporting no problems at all.
+  Four endpoint-setting names were retyped beside a comment claiming they were
+  "the same names core/azure_ai_clients.py reads" — which nothing could check,
+  because that module held them as string literals inside its functions. Those
+  names are now module-scope constants there, and the check reads them from
+  there. `core/azure_ai_clients.py` behaviour is unchanged; its 323 existing
+  tests pass untouched.
+- `tests/test_envelope_azure_applies_the_run_rules.py` is new — 41 tests, of
+  which **20 fail against the code as it was**. The core of the file is a
+  parametrised sweep that sets one Azure setting, asks the free check and the
+  paid run separately, and requires the same verdict, so this class of
+  disagreement is measured rather than reasoned about. One test opens the
+  workflow files and pins the sentence the check's own wording rests on.
+  `core/execution_envelope_azure.py` had no test file at all before this.
+- The existing `tests/test_execution_envelope_advance_check.py` carried the same
+  omission in its own fixture: the environment it called fully ready, and reused
+  across six tests, set no expected-identity names, so "nothing left to fix"
+  described a setup the paid run would have stopped. Fixed. `batch-runner`'s
+  README and `docs/first-experiment.md` had all three names listed correctly the
+  whole time — the written instructions were right and the code was wrong.
 - **The check that refuses the paid three-way comparison compared two of the
   prompt's four parts — and the two it compared were the wrong two.**
   `check_experiment_files_match_conditions` in

--- a/batch-runner/core/azure_ai_clients.py
+++ b/batch-runner/core/azure_ai_clients.py
@@ -38,6 +38,47 @@ FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV = (
 )
 FORBIDDEN_API_KEY_ENV = FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV
 
+# The environment variables that decide which route is built and which
+# resource it is allowed to reach.
+#
+# These live at module scope, rather than as string literals inside the
+# functions that read them, so that a check wanting to report the same
+# requirement up front can read the names from here instead of retyping them. A
+# retyped copy agrees until somebody edits one of the two, and then the check
+# that was meant to give early warning gives a clean answer about a setting the
+# run refuses.
+ROUTE_PROFILE_ENV = "AZURE_AI_ROUTE_PROFILE"
+DIRECT_ENDPOINT_ENV = "AZURE_OPENAI_V1_ENDPOINT"
+PROJECT_ENDPOINT_ENV = "FOUNDRY_PROJECT_ENDPOINT"
+LEGACY_ENDPOINT_ENV = "AZURE_OPENAI_LEGACY_ENDPOINT"
+DEPRECATED_ENDPOINT_ENV = "AZURE_OPENAI_ENDPOINT"
+ALLOW_LEGACY_ROLLBACK_ENV = "AZURE_AI_ALLOW_LEGACY_ROLLBACK"
+
+EXPECTED_DIRECT_ACCOUNT_ENV = "AZURE_AI_EXPECTED_DIRECT_ACCOUNT"
+EXPECTED_PROJECT_ACCOUNT_ENV = "AZURE_AI_EXPECTED_PROJECT_ACCOUNT"
+EXPECTED_PROJECT_NAME_ENV = "AZURE_AI_EXPECTED_PROJECT_NAME"
+EXPECTED_LEGACY_ACCOUNT_ENV = "AZURE_AI_EXPECTED_LEGACY_ACCOUNT"
+
+# Which endpoint identities must be named before a route is built, per profile,
+# when AZURE_AI_REQUIRE_EXPECTED_IDENTITIES is "1". Keyed by the profile's
+# written value, so a reader that only has the string can look it up without
+# importing the enumeration.
+#
+# For every profile these are also exactly the identities
+# ``_verify_expected_identities`` compares against the endpoints, so a checker
+# reading this table learns both which names must be present and which names
+# are acted on.
+REQUIRE_EXPECTED_IDENTITIES_ENV = "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES"
+REQUIRED_IDENTITY_ENV_BY_PROFILE: Mapping[str, tuple[str, ...]] = {
+    "direct-v1": (EXPECTED_DIRECT_ACCOUNT_ENV,),
+    "project-ci": (
+        EXPECTED_DIRECT_ACCOUNT_ENV,
+        EXPECTED_PROJECT_ACCOUNT_ENV,
+        EXPECTED_PROJECT_NAME_ENV,
+    ),
+    "legacy-rollback": (EXPECTED_LEGACY_ACCOUNT_ENV,),
+}
+
 _AZURE_PROVIDER_ALIASES = frozenset({"azure", "azure_openai"})
 _PREPROCESSOR_DEFAULT_DEPLOYMENTS = {
     "audio_analyzer": "gpt-audio-1.5",
@@ -262,16 +303,16 @@ def _deprecated_endpoint_error(raw: str) -> ValueError:
         kind = classify_endpoint(raw).kind
     except ValueError:
         return ValueError(
-            "AZURE_OPENAI_ENDPOINT is deprecated and must be unset; use the "
-            "typed endpoint variable for the required endpoint kind"
+            f"{DEPRECATED_ENDPOINT_ENV} is deprecated and must be unset; use "
+            "the typed endpoint variable for the required endpoint kind"
         )
     variable = {
-        EndpointKind.DIRECT_V1: "AZURE_OPENAI_V1_ENDPOINT",
-        EndpointKind.PROJECT: "FOUNDRY_PROJECT_ENDPOINT",
-        EndpointKind.LEGACY_DATED: "AZURE_OPENAI_LEGACY_ENDPOINT",
+        EndpointKind.DIRECT_V1: DIRECT_ENDPOINT_ENV,
+        EndpointKind.PROJECT: PROJECT_ENDPOINT_ENV,
+        EndpointKind.LEGACY_DATED: LEGACY_ENDPOINT_ENV,
     }[kind]
     return ValueError(
-        "AZURE_OPENAI_ENDPOINT is deprecated and must be unset; move the "
+        f"{DEPRECATED_ENDPOINT_ENV} is deprecated and must be unset; move the "
         f"{kind.value} endpoint to {variable}"
     )
 
@@ -288,31 +329,31 @@ class AzureAIRouteSettings:
         values = os.environ if env is None else env
         _reject_static_azure_credential_env(values)
 
-        raw_profile = _env_value(values, "AZURE_AI_ROUTE_PROFILE")
+        raw_profile = _env_value(values, ROUTE_PROFILE_ENV)
         if not raw_profile:
-            raise ValueError("AZURE_AI_ROUTE_PROFILE is required")
+            raise ValueError(f"{ROUTE_PROFILE_ENV} is required")
         try:
             profile = RouteProfile(raw_profile)
         except ValueError:
-            raise ValueError("AZURE_AI_ROUTE_PROFILE is unsupported") from None
+            raise ValueError(f"{ROUTE_PROFILE_ENV} is unsupported") from None
 
-        deprecated = _env_value(values, "AZURE_OPENAI_ENDPOINT")
+        deprecated = _env_value(values, DEPRECATED_ENDPOINT_ENV)
         if deprecated:
             raise _deprecated_endpoint_error(deprecated)
 
         direct = _classify_typed_endpoint(
             values,
-            "AZURE_OPENAI_V1_ENDPOINT",
+            DIRECT_ENDPOINT_ENV,
             EndpointKind.DIRECT_V1,
         )
         project = _classify_typed_endpoint(
             values,
-            "FOUNDRY_PROJECT_ENDPOINT",
+            PROJECT_ENDPOINT_ENV,
             EndpointKind.PROJECT,
         )
         legacy = _classify_typed_endpoint(
             values,
-            "AZURE_OPENAI_LEGACY_ENDPOINT",
+            LEGACY_ENDPOINT_ENV,
             EndpointKind.LEGACY_DATED,
         )
 
@@ -335,7 +376,7 @@ class AzureAIRouteSettings:
                 "project-ci profile requires direct-v1 and project endpoints"
             )
         if profile is RouteProfile.LEGACY_ROLLBACK:
-            if _env_value(values, "AZURE_AI_ALLOW_LEGACY_ROLLBACK") != "1":
+            if _env_value(values, ALLOW_LEGACY_ROLLBACK_ENV) != "1":
                 raise ValueError("legacy rollback is not explicitly authorized")
             if legacy is None:
                 raise ValueError(
@@ -353,19 +394,9 @@ class AzureAIRouteSettings:
         return settings
 
     def _require_expected_identities(self, env: Mapping[str, str]) -> None:
-        if _env_value(env, "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES") != "1":
+        if _env_value(env, REQUIRE_EXPECTED_IDENTITIES_ENV) != "1":
             return
-        required = {
-            RouteProfile.DIRECT_V1: ("AZURE_AI_EXPECTED_DIRECT_ACCOUNT",),
-            RouteProfile.PROJECT_CI: (
-                "AZURE_AI_EXPECTED_DIRECT_ACCOUNT",
-                "AZURE_AI_EXPECTED_PROJECT_ACCOUNT",
-                "AZURE_AI_EXPECTED_PROJECT_NAME",
-            ),
-            RouteProfile.LEGACY_ROLLBACK: (
-                "AZURE_AI_EXPECTED_LEGACY_ACCOUNT",
-            ),
-        }[self.profile]
+        required = REQUIRED_IDENTITY_ENV_BY_PROFILE[self.profile.value]
         missing = [name for name in required if not _env_value(env, name)]
         if missing:
             raise ValueError(
@@ -375,9 +406,7 @@ class AzureAIRouteSettings:
 
     def _verify_expected_identities(self, env: Mapping[str, str]) -> None:
         if self.profile in (RouteProfile.DIRECT_V1, RouteProfile.PROJECT_CI):
-            expected_direct = _env_value(
-                env, "AZURE_AI_EXPECTED_DIRECT_ACCOUNT"
-            )
+            expected_direct = _env_value(env, EXPECTED_DIRECT_ACCOUNT_ENV)
             if expected_direct:
                 expected_direct = _validate_account(expected_direct)
                 if (
@@ -388,7 +417,7 @@ class AzureAIRouteSettings:
 
         if self.profile is RouteProfile.PROJECT_CI:
             expected_project_account = _env_value(
-                env, "AZURE_AI_EXPECTED_PROJECT_ACCOUNT"
+                env, EXPECTED_PROJECT_ACCOUNT_ENV
             )
             if expected_project_account:
                 expected_project_account = _validate_account(
@@ -400,9 +429,7 @@ class AzureAIRouteSettings:
                 ):
                     raise ValueError("project endpoint account identity mismatch")
 
-            expected_project = _env_value(
-                env, "AZURE_AI_EXPECTED_PROJECT_NAME"
-            )
+            expected_project = _env_value(env, EXPECTED_PROJECT_NAME_ENV)
             if expected_project:
                 expected_project = _validate_project(expected_project)
                 if (
@@ -412,9 +439,7 @@ class AzureAIRouteSettings:
                     raise ValueError("Foundry project identity mismatch")
 
         if self.profile is RouteProfile.LEGACY_ROLLBACK:
-            expected_legacy = _env_value(
-                env, "AZURE_AI_EXPECTED_LEGACY_ACCOUNT"
-            )
+            expected_legacy = _env_value(env, EXPECTED_LEGACY_ACCOUNT_ENV)
             if expected_legacy:
                 expected_legacy = _validate_account(expected_legacy)
                 if (

--- a/batch-runner/core/execution_envelope_azure.py
+++ b/batch-runner/core/execution_envelope_azure.py
@@ -17,6 +17,17 @@ in the environment, classifies them with the repository's own endpoint rules,
 and reports precisely which part does not line up with the account and project
 the plan pins. Every check here reads settings only: nothing contacts Azure,
 signs in, or spends money.
+
+Every rule it applies is read from ``core/azure_ai_clients.py``, which is the
+module the paid run uses to decide whether a route may be built at all. That is
+deliberate and it was not always so. This module used to hold its own written-
+out copies of the same lists, and a copy agrees only until one of the two is
+edited: seventeen settings were swept one at a time, and seven of them got
+different answers here and there, six of the seven in the direction where this
+check hands out a clean bill of health for a setting the run refuses to start
+with. Reading the rules instead of restating them closes six of those seven;
+``tests/test_envelope_azure_applies_the_run_rules.py`` holds all seventeen in
+place and states the seventh, which is refused here on purpose.
 """
 
 from __future__ import annotations
@@ -25,29 +36,22 @@ import importlib
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-# The settings that name each kind of Azure endpoint. These are the same names
-# core/azure_ai_clients.py reads, so a plan checked here is checked against the
-# variables the run itself will use.
-DIRECT_ENDPOINT_VARIABLE = "AZURE_OPENAI_V1_ENDPOINT"
-PROJECT_ENDPOINT_VARIABLE = "FOUNDRY_PROJECT_ENDPOINT"
-ROUTE_PROFILE_VARIABLE = "AZURE_AI_ROUTE_PROFILE"
-DEPRECATED_ENDPOINT_VARIABLE = "AZURE_OPENAI_ENDPOINT"
 
-# Static credentials this repository refuses to run with. Naming them here lets
-# the free check say so up front, instead of the run failing later with the
-# same complaint after someone has already scheduled it.
-FORBIDDEN_CREDENTIAL_VARIABLES = (
-    "AZURE_OPENAI_API_KEY",
-    "AZURE_API_KEY",
-    "AZURE_AI_API_KEY",
-    "AZURE_AI_PROJECT_API_KEY",
-    "AZURE_OPENAI_AD_TOKEN",
-    "AZURE_CLIENT_SECRET",
-    "AZURE_CLIENT_CERTIFICATE_PATH",
-    "AZURE_CLIENT_CERTIFICATE_PASSWORD",
-    "AZURE_USERNAME",
-    "AZURE_PASSWORD",
-)
+def _route_rules() -> Any:
+    """The module the paid run uses to decide whether a route may be built.
+
+    Every setting name and every rule below is read from here rather than
+    written out again. The two used to be written out in both places, and a
+    copy agrees only until somebody edits one of them: adding a name to the
+    list of forbidden fixed credentials in that module left this check handing
+    out a clean bill of health for a setting the run refuses to start with.
+
+    It is imported inside the function, rather than at the top of the file, so
+    that this check keeps working in a stripped-down environment where the
+    Azure client libraries are absent until something actually needs them.
+    """
+    return importlib.import_module("core.azure_ai_clients")
+
 
 
 @dataclass(frozen=True)
@@ -110,8 +114,100 @@ class AzureConnectionDiagnosis:
 
 
 def _classify(value: str):
-    module = importlib.import_module("core.azure_ai_clients")
-    return module.classify_endpoint(value)
+    return _route_rules().classify_endpoint(value)
+
+
+def _same_identity(observed: str, expected: str, names_a_project: bool) -> bool:
+    """Compare two names the way the run place compares them.
+
+    Account names are folded to lower case on both sides before the run place
+    compares them, so a difference in capitals is not a difference. Project
+    names are not folded, so there it is.
+    """
+    if names_a_project:
+        return observed == expected
+    return observed.lower() == expected.lower()
+
+
+def _pinned_identity_problems(
+    rules: Any,
+    requirement: AzureConnectionRequirement,
+    environ: Mapping[str, str],
+) -> list[str]:
+    """Apply the run place's own identity pinning before anything is spent.
+
+    The run place refuses to build a route unless the identity settings for its
+    profile are present, and refuses again if one of them names a resource the
+    endpoints do not match. Both refusals arrive after a run has started and
+    after the money has been committed to it, which is the wrong moment to find
+    out about a setting.
+
+    Which names matter is read from the run place rather than listed here, so a
+    name added there is checked here without anyone having to remember.
+
+    This check demands the names whatever the local value of the switch that
+    turns the requirement on, because every automated run place in this
+    repository that can spend money turns it on, and the local value of that
+    switch does not change what those runs do. Refusing before the start beats
+    stopping after it.
+    """
+    problems: list[str] = []
+    required = rules.REQUIRED_IDENTITY_ENV_BY_PROFILE.get(
+        requirement.route_profile
+    )
+    if required is None:
+        # An unrecognised profile is reported by the caller, and there is no
+        # identity list to apply for one.
+        return problems
+
+    # What the plan pins each of those names to. The plan names one account and
+    # one project, and every identity setting the run place compares names one
+    # or the other.
+    pinned: Mapping[str, tuple[str, bool]] = {
+        rules.EXPECTED_DIRECT_ACCOUNT_ENV: (requirement.account, False),
+        rules.EXPECTED_PROJECT_ACCOUNT_ENV: (requirement.account, False),
+        rules.EXPECTED_LEGACY_ACCOUNT_ENV: (requirement.account, False),
+        rules.EXPECTED_PROJECT_NAME_ENV: (requirement.project, True),
+    }
+
+    for name in required:
+        value = str(environ.get(name, "") or "").strip()
+        entry = pinned.get(name)
+        if entry is None:
+            # The run place has gained an identity setting that the plan has
+            # nothing to compare against. Saying so is the whole point: an
+            # unchecked requirement is exactly what this function exists to
+            # stop, and staying quiet about one would be the old fault in a
+            # new place.
+            problems.append(
+                f"the Azure run place requires {name} before it will start, "
+                "and the plan says nothing this check can compare it against. "
+                "Either pin the value in the plan or say in writing why it "
+                "does not need pinning."
+            )
+            continue
+
+        expected, names_a_project = entry
+        subject = "project" if names_a_project else "account"
+        if not value:
+            problems.append(
+                f"{name} is not set. Every automated run place in this "
+                "repository that can spend money turns on "
+                f"{rules.REQUIRE_EXPECTED_IDENTITIES_ENV}, and the Azure run "
+                f"place then refuses to start unless this names the {subject} "
+                f"— which for this comparison is {expected!r}."
+            )
+            continue
+        if not _same_identity(value, expected, names_a_project):
+            problems.append(
+                f"{name} names the {subject} {value!r}, but the comparison is "
+                f"pinned to {expected!r}. The Azure run place compares this "
+                "setting against the endpoint it is about to use and refuses "
+                "when the two differ, so the run would stop after it had "
+                "started."
+            )
+
+    return problems
 
 
 def diagnose_azure_connection(
@@ -124,35 +220,60 @@ def diagnose_azure_connection(
     pointing somewhere else" are different problems with different fixes, and a
     check that reports both as "not measured" sends the reader looking in the
     wrong place.
+
+    Every rule applied here is read from the module the paid run uses to decide
+    whether a route may be built. A rule described here but not read from there
+    would only be a second opinion, and the opinion that stops a run is that
+    module's.
     """
+    rules = _route_rules()
     problems: list[str] = []
     observed_account: str | None = None
     observed_project: str | None = None
 
-    profile = str(environ.get(ROUTE_PROFILE_VARIABLE, "") or "").strip()
+    route_profile_variable = rules.ROUTE_PROFILE_ENV
+    project_endpoint_variable = rules.PROJECT_ENDPOINT_ENV
+    direct_endpoint_variable = rules.DIRECT_ENDPOINT_ENV
+    deprecated_endpoint_variable = rules.DEPRECATED_ENDPOINT_ENV
+
+    known_profiles = tuple(profile.value for profile in rules.RouteProfile)
+    if requirement.route_profile not in known_profiles:
+        problems.append(
+            f"the plan pins the route profile {requirement.route_profile!r}, "
+            "which the Azure run place does not recognise, so it would refuse "
+            "to start whatever the settings say. It must be one of: "
+            + ", ".join(known_profiles)
+        )
+
+    profile = str(environ.get(route_profile_variable, "") or "").strip()
     if not profile:
         problems.append(
-            f"{ROUTE_PROFILE_VARIABLE} is not set, so the Azure run place "
+            f"{route_profile_variable} is not set, so the Azure run place "
             "refuses to start. It must be "
             f"{requirement.route_profile!r} for this comparison."
         )
     elif profile != requirement.route_profile:
         problems.append(
-            f"{ROUTE_PROFILE_VARIABLE} is {profile!r}, but this comparison "
+            f"{route_profile_variable} is {profile!r}, but this comparison "
             f"requires {requirement.route_profile!r}"
         )
 
-    deprecated = str(environ.get(DEPRECATED_ENDPOINT_VARIABLE, "") or "").strip()
+    deprecated = str(
+        environ.get(deprecated_endpoint_variable, "") or ""
+    ).strip()
     if deprecated:
         problems.append(
-            f"{DEPRECATED_ENDPOINT_VARIABLE} is set. This repository refuses to "
-            "run while it is, because it does not say which kind of endpoint it "
-            f"holds. Move the address to {PROJECT_ENDPOINT_VARIABLE} or "
-            f"{DIRECT_ENDPOINT_VARIABLE} and unset it."
+            f"{deprecated_endpoint_variable} is set. This repository refuses "
+            "to run while it is, because it does not say which kind of "
+            f"endpoint it holds. Move the address to "
+            f"{project_endpoint_variable} or {direct_endpoint_variable} and "
+            "unset it."
         )
 
     present_forbidden = [
-        name for name in FORBIDDEN_CREDENTIAL_VARIABLES if environ.get(name)
+        name
+        for name in rules.FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV
+        if environ.get(name)
     ]
     if present_forbidden:
         problems.append(
@@ -162,21 +283,21 @@ def diagnose_azure_connection(
         )
 
     project_endpoint = str(
-        environ.get(PROJECT_ENDPOINT_VARIABLE, "") or ""
+        environ.get(project_endpoint_variable, "") or ""
     ).strip()
     if not project_endpoint:
         problems.append(
-            f"{PROJECT_ENDPOINT_VARIABLE} is not set. The Azure run place needs "
-            "the address of the project that holds the deployment, which looks "
-            f"like https://{requirement.account}.services.ai.azure.com"
-            f"/api/projects/{requirement.project}"
+            f"{project_endpoint_variable} is not set. The Azure run place "
+            "needs the address of the project that holds the deployment, "
+            f"which looks like https://{requirement.account}"
+            f".services.ai.azure.com/api/projects/{requirement.project}"
         )
     else:
         try:
             endpoint = _classify(project_endpoint)
         except Exception as error:
             problems.append(
-                f"{PROJECT_ENDPOINT_VARIABLE} is not an address this "
+                f"{project_endpoint_variable} is not an address this "
                 f"repository recognises: {error}"
             )
         else:
@@ -184,7 +305,7 @@ def diagnose_azure_connection(
             observed_project = getattr(endpoint, "project", None)
             if observed_account != requirement.account:
                 problems.append(
-                    f"{PROJECT_ENDPOINT_VARIABLE} names the account "
+                    f"{project_endpoint_variable} names the account "
                     f"{observed_account!r}, but the comparison is pinned to "
                     f"{requirement.account!r}. A deployment name is not unique "
                     "across accounts, so running against a different account "
@@ -193,28 +314,32 @@ def diagnose_azure_connection(
                 )
             if observed_project != requirement.project:
                 problems.append(
-                    f"{PROJECT_ENDPOINT_VARIABLE} names the project "
+                    f"{project_endpoint_variable} names the project "
                     f"{observed_project!r}, but the comparison is pinned to "
                     f"{requirement.project!r}"
                 )
 
-    direct_endpoint = str(environ.get(DIRECT_ENDPOINT_VARIABLE, "") or "").strip()
+    direct_endpoint = str(
+        environ.get(direct_endpoint_variable, "") or ""
+    ).strip()
     if direct_endpoint:
         try:
             endpoint = _classify(direct_endpoint)
         except Exception as error:
             problems.append(
-                f"{DIRECT_ENDPOINT_VARIABLE} is not an address this repository "
+                f"{direct_endpoint_variable} is not an address this repository "
                 f"recognises: {error}"
             )
         else:
             account = getattr(endpoint, "account", None)
             if account != requirement.account:
                 problems.append(
-                    f"{DIRECT_ENDPOINT_VARIABLE} names the account "
+                    f"{direct_endpoint_variable} names the account "
                     f"{account!r}, but the comparison is pinned to "
                     f"{requirement.account!r}"
                 )
+
+    problems.extend(_pinned_identity_problems(rules, requirement, environ))
 
     return AzureConnectionDiagnosis(
         problems=problems,

--- a/batch-runner/experiments/execution_envelope/advance_check_plan.yaml
+++ b/batch-runner/experiments/execution_envelope/advance_check_plan.yaml
@@ -261,9 +261,18 @@ container:
 # automated runs, as the repository variables AZURE_AI_EXPECTED_PROJECT_ACCOUNT
 # and AZURE_AI_EXPECTED_PROJECT_NAME. They are settings, not secrets.
 #
+# That sentence used to sit here on its own, with nothing comparing the two.
+# The free check now compares them: if either repository variable names another
+# account or another project, the run is refused before it starts. It also
+# demands that they be set at all, because every automated run place here that
+# can spend money turns on AZURE_AI_REQUIRE_EXPECTED_IDENTITIES, and the Azure
+# run place then refuses to start without them.
+#
 # The free check reads the endpoint settings in the environment, classifies
 # them with this repository's own endpoint rules, and refuses the run if they
-# name any other account or project.
+# name any other account or project. Every rule it applies is read from
+# core/azure_ai_clients.py, which is the module the paid run itself uses to
+# decide whether a route may be built.
 azure_connection:
   account: "hjeon-fdpo-foundry-eus2"
   project: "gdpval-realworks"

--- a/batch-runner/tests/test_envelope_azure_applies_the_run_rules.py
+++ b/batch-runner/tests/test_envelope_azure_applies_the_run_rules.py
@@ -1,0 +1,498 @@
+"""The free Azure check must apply the rules the paid run really applies.
+
+``core/execution_envelope_azure.py`` is the last gate before the run-place
+comparison spends anything: whatever it reports flows straight into whether the
+comparison may start. Its own file says a plan checked there is checked against
+the rules the real run applies, and until this file existed nothing measured
+whether that was so.
+
+It was not so. Sweeping seventeen Azure settings one at a time and comparing
+what the free check said against what ``AzureAIRouteSettings.from_env`` did,
+seven disagreed, and six of the seven disagreed in the direction that costs
+money: the free check handed out a clean bill of health for a setting the run
+refuses to start with. Three were identity settings the run demands and the
+check never looked at; three more were identity settings the run compares
+against the endpoint and the check never compared.
+
+So these tests do not read the code and agree with it. They set a setting, ask
+both sides, and require the same answer.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from core import azure_ai_clients
+from core.azure_ai_clients import AzureAIRouteSettings
+from core.execution_envelope_azure import (
+    AzureConnectionRequirement,
+    describe_expected_project_endpoint,
+    diagnose_azure_connection,
+)
+
+ACCOUNT = "hjeon-fdpo-foundry-eus2"
+PROJECT = "gdpval-realworks"
+ANOTHER_ACCOUNT = "some-other-account"
+ANOTHER_PROJECT = "some-other-project"
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture()
+def requirement() -> AzureConnectionRequirement:
+    return AzureConnectionRequirement.from_mapping(
+        {
+            "account": ACCOUNT,
+            "project": PROJECT,
+            "route_profile": "project-ci",
+        }
+    )
+
+
+def _settings(**changes: str | None) -> dict[str, str]:
+    """A correct set of Azure settings, with the named ones changed or removed.
+
+    The starting point is what the automated run place sets: the profile, the
+    two endpoints, the switch that turns identity pinning on, and the three
+    names that pinning compares.
+    """
+    values = {
+        "AZURE_AI_ROUTE_PROFILE": "project-ci",
+        "FOUNDRY_PROJECT_ENDPOINT": (
+            f"https://{ACCOUNT}.services.ai.azure.com/api/projects/{PROJECT}"
+        ),
+        "AZURE_OPENAI_V1_ENDPOINT": (
+            f"https://{ACCOUNT}.services.ai.azure.com/openai/v1/"
+        ),
+        "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES": "1",
+        "AZURE_AI_EXPECTED_DIRECT_ACCOUNT": ACCOUNT,
+        "AZURE_AI_EXPECTED_PROJECT_ACCOUNT": ACCOUNT,
+        "AZURE_AI_EXPECTED_PROJECT_NAME": PROJECT,
+    }
+    for name, value in changes.items():
+        if value is None:
+            values.pop(name, None)
+        else:
+            values[name] = value
+    return values
+
+
+def _the_run_refuses(settings: dict[str, str]) -> bool:
+    """What the paid run does with these settings, asked rather than assumed."""
+    try:
+        AzureAIRouteSettings.from_env(settings)
+    except ValueError:
+        return True
+    return False
+
+
+# ── The settings a correct run already had ────────────────────────────────
+
+
+def test_a_correct_set_of_settings_has_no_problems(requirement) -> None:
+    diagnosis = diagnose_azure_connection(requirement, _settings())
+    assert diagnosis.problems == []
+    assert diagnosis.reachable_intent is True
+    assert diagnosis.observed_account == ACCOUNT
+    assert diagnosis.observed_project == PROJECT
+
+
+def test_the_address_the_check_describes_is_the_address_it_accepts(
+    requirement,
+) -> None:
+    """The written-out address and the accepted address must be the same one.
+
+    The check tells a reader which address to set when it is missing. If that
+    sentence and the rule that accepts an address ever part company, the check
+    sends people to fix it in a way it will still refuse.
+    """
+    described = describe_expected_project_endpoint(requirement)
+    diagnosis = diagnose_azure_connection(
+        requirement, _settings(FOUNDRY_PROJECT_ENDPOINT=described)
+    )
+    assert diagnosis.problems == []
+
+
+def test_an_unset_route_profile_is_refused(requirement) -> None:
+    settings = _settings(AZURE_AI_ROUTE_PROFILE=None)
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any("AZURE_AI_ROUTE_PROFILE" in note for note in diagnosis.problems)
+    assert _the_run_refuses(settings)
+
+
+def test_the_deprecated_endpoint_setting_is_refused(requirement) -> None:
+    settings = _settings(
+        AZURE_OPENAI_ENDPOINT=f"https://{ACCOUNT}.openai.azure.com/"
+    )
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any(
+        "AZURE_OPENAI_ENDPOINT is set" in note for note in diagnosis.problems
+    )
+    assert _the_run_refuses(settings)
+
+
+def test_an_endpoint_naming_another_account_is_refused(requirement) -> None:
+    settings = _settings(
+        FOUNDRY_PROJECT_ENDPOINT=(
+            f"https://{ANOTHER_ACCOUNT}.services.ai.azure.com"
+            f"/api/projects/{PROJECT}"
+        )
+    )
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any(ANOTHER_ACCOUNT in note for note in diagnosis.problems)
+
+
+def test_an_endpoint_naming_another_project_is_refused(requirement) -> None:
+    settings = _settings(
+        FOUNDRY_PROJECT_ENDPOINT=(
+            f"https://{ACCOUNT}.services.ai.azure.com"
+            f"/api/projects/{ANOTHER_PROJECT}"
+        )
+    )
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any(ANOTHER_PROJECT in note for note in diagnosis.problems)
+
+
+# ── The lists are read from the run place, not copied from it ─────────────
+
+
+def test_a_credential_the_run_starts_refusing_is_refused_here_too(
+    requirement, monkeypatch
+) -> None:
+    """Adding a name to the run's list must not leave this check behind.
+
+    This check used to hold its own typed-out copy of the ten fixed credentials
+    the repository refuses to run with. The copy was correct on the day it was
+    typed. Adding an eleventh name to the real list left the run refusing to
+    start while this check reported no problems at all — a clean bill of health
+    for the exact setting that stops the run.
+    """
+    monkeypatch.setattr(
+        azure_ai_clients,
+        "FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV",
+        azure_ai_clients.FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV
+        + ("AZURE_TENANT_PASSWORD",),
+    )
+    settings = _settings(AZURE_TENANT_PASSWORD="a-fixed-credential")
+
+    assert _the_run_refuses(settings)
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any(
+        "AZURE_TENANT_PASSWORD" in note for note in diagnosis.problems
+    ), diagnosis.problems
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_PASSWORD",
+    ],
+)
+def test_each_fixed_credential_the_run_refuses_is_refused_here(
+    requirement, name
+) -> None:
+    settings = _settings(**{name: "a-fixed-credential"})
+    assert _the_run_refuses(settings)
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any(name in note for note in diagnosis.problems)
+
+
+def test_the_setting_names_are_read_from_the_run_place(
+    requirement, monkeypatch
+) -> None:
+    """Renaming a setting in the run place renames it here.
+
+    A name typed out again here would keep the old spelling and quietly stop
+    matching anything, which reads as "the setting is not set" for a setting
+    that is.
+    """
+    monkeypatch.setattr(
+        azure_ai_clients, "PROJECT_ENDPOINT_ENV", "FOUNDRY_PROJECT_ADDRESS"
+    )
+    settings = _settings(FOUNDRY_PROJECT_ENDPOINT=None)
+    settings["FOUNDRY_PROJECT_ADDRESS"] = (
+        f"https://{ACCOUNT}.services.ai.azure.com/api/projects/{PROJECT}"
+    )
+
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert diagnosis.problems == []
+    assert diagnosis.observed_account == ACCOUNT
+
+
+def test_a_requirement_the_plan_cannot_answer_is_reported_not_ignored(
+    requirement, monkeypatch
+) -> None:
+    """A new identity setting with nothing to compare it against must be said.
+
+    Passing quietly over a requirement nobody has pinned would be this file's
+    own fault happening again one layer along.
+    """
+    monkeypatch.setattr(
+        azure_ai_clients,
+        "REQUIRED_IDENTITY_ENV_BY_PROFILE",
+        {
+            **azure_ai_clients.REQUIRED_IDENTITY_ENV_BY_PROFILE,
+            "project-ci": (
+                *azure_ai_clients.REQUIRED_IDENTITY_ENV_BY_PROFILE[
+                    "project-ci"
+                ],
+                "AZURE_AI_EXPECTED_REGION",
+            ),
+        },
+    )
+    diagnosis = diagnose_azure_connection(
+        requirement, _settings(AZURE_AI_EXPECTED_REGION="eastus2")
+    )
+    assert any(
+        "AZURE_AI_EXPECTED_REGION" in note for note in diagnosis.problems
+    ), diagnosis.problems
+
+
+def test_every_identity_the_run_requires_has_something_to_compare_against(
+    requirement,
+) -> None:
+    """No setting in the real table falls into the "cannot answer" branch.
+
+    Written as a test rather than a comment so that adding a name to the run
+    place without pinning it in the plan is reported here as work still to do.
+    """
+    diagnosis = diagnose_azure_connection(requirement, _settings())
+    assert not any(
+        "says nothing this check can compare" in note
+        for note in diagnosis.problems
+    ), diagnosis.problems
+
+
+# ── Identity pinning is applied before the money, not after ───────────────
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "AZURE_AI_EXPECTED_DIRECT_ACCOUNT",
+        "AZURE_AI_EXPECTED_PROJECT_ACCOUNT",
+        "AZURE_AI_EXPECTED_PROJECT_NAME",
+    ],
+)
+def test_an_identity_the_run_demands_is_demanded_here(
+    requirement, missing
+) -> None:
+    """The run refuses to start without these, so this must refuse first."""
+    settings = _settings(**{missing: None})
+    assert _the_run_refuses(settings)
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any(missing in note for note in diagnosis.problems), (
+        diagnosis.problems
+    )
+
+
+@pytest.mark.parametrize(
+    "name, wrong_value",
+    [
+        ("AZURE_AI_EXPECTED_DIRECT_ACCOUNT", ANOTHER_ACCOUNT),
+        ("AZURE_AI_EXPECTED_PROJECT_ACCOUNT", ANOTHER_ACCOUNT),
+        ("AZURE_AI_EXPECTED_PROJECT_NAME", ANOTHER_PROJECT),
+    ],
+)
+def test_an_identity_naming_another_resource_is_refused(
+    requirement, name, wrong_value
+) -> None:
+    """These are the settings the plan says it agrees with, now compared.
+
+    The plan pins one account and one project and says in writing that they are
+    the two the repository already records for its automated runs. Nothing
+    compared the two until this test.
+    """
+    settings = _settings(**{name: wrong_value})
+    assert _the_run_refuses(settings)
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any(
+        name in note and wrong_value in note for note in diagnosis.problems
+    ), diagnosis.problems
+
+
+def test_the_identities_are_demanded_even_when_the_local_switch_is_off(
+    requirement,
+) -> None:
+    """On purpose stricter than one run of the run place, and never looser.
+
+    ``AzureAIRouteSettings.from_env`` demands the identity settings only when
+    the switch is on. Every automated run place in this repository that can
+    spend money turns it on, so a local switch that is off describes a rule the
+    paid run will not follow. Refusing before the start beats stopping after
+    it.
+    """
+    settings = _settings(
+        AZURE_AI_REQUIRE_EXPECTED_IDENTITIES="0",
+        AZURE_AI_EXPECTED_PROJECT_NAME=None,
+    )
+    assert not _the_run_refuses(settings)
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any(
+        "AZURE_AI_EXPECTED_PROJECT_NAME" in note
+        for note in diagnosis.problems
+    ), diagnosis.problems
+
+
+def test_an_account_written_in_capitals_is_the_same_account(
+    requirement,
+) -> None:
+    """The run folds account names to lower case, so this must not object."""
+    settings = _settings(AZURE_AI_EXPECTED_PROJECT_ACCOUNT=ACCOUNT.upper())
+    assert not _the_run_refuses(settings)
+    assert diagnose_azure_connection(requirement, settings).problems == []
+
+
+def test_a_project_written_in_capitals_is_a_different_project(
+    requirement,
+) -> None:
+    """The run does not fold project names, so a capital is a difference."""
+    settings = _settings(AZURE_AI_EXPECTED_PROJECT_NAME=PROJECT.upper())
+    assert _the_run_refuses(settings)
+    assert diagnose_azure_connection(requirement, settings).problems
+
+
+def test_a_plan_pinning_a_profile_the_run_does_not_know_is_refused() -> None:
+    """A profile the run place cannot read stops it whatever else is right."""
+    requirement = AzureConnectionRequirement.from_mapping(
+        {
+            "account": ACCOUNT,
+            "project": PROJECT,
+            "route_profile": "project-ci-v2",
+        }
+    )
+    settings = _settings(AZURE_AI_ROUTE_PROFILE="project-ci-v2")
+    assert _the_run_refuses(settings)
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any("project-ci-v2" in note for note in diagnosis.problems)
+
+
+# ── The measurement itself, kept as a test ────────────────────────────────
+
+AGREEMENT_CASES = [
+    ("everything correct", _settings()),
+    ("the profile is not set", _settings(AZURE_AI_ROUTE_PROFILE=None)),
+    ("the profile is unreadable", _settings(AZURE_AI_ROUTE_PROFILE="nonsense")),
+    (
+        "the deprecated endpoint is set",
+        _settings(AZURE_OPENAI_ENDPOINT=f"https://{ACCOUNT}.openai.azure.com/"),
+    ),
+    ("the project endpoint is not set", _settings(FOUNDRY_PROJECT_ENDPOINT=None)),
+    (
+        "the project endpoint names another account",
+        _settings(
+            FOUNDRY_PROJECT_ENDPOINT=(
+                f"https://{ANOTHER_ACCOUNT}.services.ai.azure.com"
+                f"/api/projects/{PROJECT}"
+            )
+        ),
+    ),
+    (
+        "the direct endpoint names another account",
+        _settings(
+            AZURE_OPENAI_V1_ENDPOINT=(
+                f"https://{ANOTHER_ACCOUNT}.services.ai.azure.com/openai/v1/"
+            )
+        ),
+    ),
+    ("a fixed credential is set", _settings(AZURE_OPENAI_API_KEY="x")),
+    (
+        "the expected direct account is not set",
+        _settings(AZURE_AI_EXPECTED_DIRECT_ACCOUNT=None),
+    ),
+    (
+        "the expected project account is not set",
+        _settings(AZURE_AI_EXPECTED_PROJECT_ACCOUNT=None),
+    ),
+    (
+        "the expected project name is not set",
+        _settings(AZURE_AI_EXPECTED_PROJECT_NAME=None),
+    ),
+    (
+        "the expected direct account names another account",
+        _settings(AZURE_AI_EXPECTED_DIRECT_ACCOUNT=ANOTHER_ACCOUNT),
+    ),
+    (
+        "the expected project account names another account",
+        _settings(AZURE_AI_EXPECTED_PROJECT_ACCOUNT=ANOTHER_ACCOUNT),
+    ),
+    (
+        "the expected project name names another project",
+        _settings(AZURE_AI_EXPECTED_PROJECT_NAME=ANOTHER_PROJECT),
+    ),
+    (
+        "the expected project name differs only in capitals",
+        _settings(AZURE_AI_EXPECTED_PROJECT_NAME=PROJECT.upper()),
+    ),
+    (
+        "the expected project account differs only in capitals",
+        _settings(AZURE_AI_EXPECTED_PROJECT_ACCOUNT=ACCOUNT.upper()),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label, settings",
+    AGREEMENT_CASES,
+    ids=[label for label, _ in AGREEMENT_CASES],
+)
+def test_the_free_check_and_the_paid_run_reach_the_same_verdict(
+    requirement, label, settings
+) -> None:
+    """Every setting, one at a time: both sides must say the same word.
+
+    The one setting deliberately left out of this sweep is the profile being
+    ``direct-v1``. The run place builds that route happily; the comparison
+    refuses it because the comparison is pinned to ``project-ci``. That
+    disagreement is the point of pinning, and the test below states it.
+    """
+    free_refuses = bool(
+        diagnose_azure_connection(requirement, settings).problems
+    )
+    assert free_refuses == _the_run_refuses(settings), label
+
+
+def test_the_one_place_the_check_is_stricter_on_purpose(requirement) -> None:
+    """Pinned to project-ci, so a route the run would build is still refused.
+
+    Written down rather than left as a surprise: this is the single setting
+    where the free check and the run place part company, and it parts company
+    in the direction that costs nothing.
+    """
+    settings = _settings(AZURE_AI_ROUTE_PROFILE="direct-v1")
+    assert not _the_run_refuses(settings)
+    diagnosis = diagnose_azure_connection(requirement, settings)
+    assert any("project-ci" in note for note in diagnosis.problems)
+
+
+# ── The fact the wording rests on ─────────────────────────────────────────
+
+
+def test_every_run_place_that_can_spend_turns_identity_pinning_on() -> None:
+    """The check's wording claims this, so the claim is measured here.
+
+    The message shown when an identity setting is missing says every automated
+    run place in this repository that can spend money turns the requirement on.
+    That sentence is why the check demands the names regardless of the local
+    switch. If a workflow ever stops setting it, this fails instead of the
+    sentence quietly becoming untrue.
+    """
+    name = azure_ai_clients.REQUIRE_EXPECTED_IDENTITIES_ENV
+    assignments: list[tuple[str, str]] = []
+    for workflow in sorted((REPOSITORY_ROOT / ".github" / "workflows").glob("*.yml")):
+        for line in workflow.read_text(encoding="utf-8").splitlines():
+            match = re.match(rf"\s*{re.escape(name)}\s*:\s*(.+?)\s*$", line)
+            if match:
+                assignments.append((workflow.name, match.group(1)))
+
+    assert assignments, f"no workflow sets {name}"
+    for workflow_name, value in assignments:
+        assert "'1'" in value, (
+            f"{workflow_name} sets {name} to {value}, so a run there would not "
+            "demand the endpoint identities"
+        )

--- a/batch-runner/tests/test_execution_envelope_advance_check.py
+++ b/batch-runner/tests/test_execution_envelope_advance_check.py
@@ -109,10 +109,19 @@ PINNED_PROJECT_ENDPOINT = (
     f"/api/projects/{PINNED_AZURE_PROJECT}"
 )
 
+# A settings environment in which nothing is left to fix. The three expected-
+# identity names below are here because the Azure run place refuses to start
+# without them, and every automated run place in this repository that can spend
+# money turns that requirement on. They were absent from this dictionary while
+# the free check did not look at them, which made "fully ready" describe a
+# setup the paid run would have stopped.
 FULLY_READY_ENVIRON = {
     "EXECUTION_COMPARISON_PAID_RUN_APPROVED": "yes",
     "AZURE_AI_ROUTE_PROFILE": "project-ci",
     "FOUNDRY_PROJECT_ENDPOINT": PINNED_PROJECT_ENDPOINT,
+    "AZURE_AI_EXPECTED_DIRECT_ACCOUNT": PINNED_AZURE_ACCOUNT,
+    "AZURE_AI_EXPECTED_PROJECT_ACCOUNT": PINNED_AZURE_ACCOUNT,
+    "AZURE_AI_EXPECTED_PROJECT_NAME": PINNED_AZURE_PROJECT,
 }
 
 

--- a/tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md
+++ b/tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md
@@ -98,9 +98,17 @@ Repository settings, unlike repository secrets, are readable by design.
 
 A new module reads the endpoint settings from the environment, classifies them
 using this repository's own endpoint rules, and compares what it finds against
-the pinned names. Because it reuses `classify_endpoint` from
-`core/azure_ai_clients.py` rather than matching text itself, a plan checked here
-is checked against exactly the rules the real run applies.
+the pinned names. It reuses `classify_endpoint` from `core/azure_ai_clients.py`
+rather than matching text itself, so the two agree on what an address means.
+
+> **Correction, recorded in section 13.** This section first said that
+> reusing `classify_endpoint` made a plan checked here "checked against exactly
+> the rules the real run applies". That was not true, and reusing one function
+> was never enough to make it true. Seven of seventeen settings were measured
+> to disagree, six of them in the direction that costs money. Section 13 has
+> the measurement and what was changed. The claim now holds for sixteen of the
+> seventeen, and the seventeenth is a deliberate refusal stated in writing.
+
 
 ## 7. Files and how information flows
 
@@ -187,3 +195,127 @@ That is an access decision belonging to whoever administers the tenant, not
 something this repository can settle. Until it is settled, the Azure run place
 stays blocked and the comparison does not start, because dropping it and running
 the other two would produce a different comparison from the one that was agreed.
+
+---
+
+## 13. 이 문서의 주장을 실제로 재어 봤습니다 (2026-08-26)
+
+### 13.1 무엇이 틀렸나
+
+6절에 이렇게 적혀 있었습니다.
+
+> `classify_endpoint`를 그대로 쓰기 때문에, 여기서 검사한 계획은 **실제 실행이
+> 적용하는 규칙 그대로** 검사된 것이다.
+
+주소를 해석하는 함수 하나를 같이 쓴다는 사실만으로 "규칙 그대로"라고 적은
+문장입니다. 확인한 사람은 없었습니다.
+
+Azure 설정 17개를 **한 번에 하나씩** 바꿔 놓고, 무료 검사와 실제 실행에게
+따로 물어서 답이 같은지 세어 봤습니다.
+
+| | 답이 같은 경우 | 답이 다른 경우 |
+|---|---|---|
+| 고치기 전 | 10 / 17 | **7 / 17** |
+| 고친 뒤 | **16 / 17** | 1 / 17 |
+
+다른 7개 중 **6개는 위험한 방향**이었습니다. 무료 검사는 "문제 없음"이라고
+말하고, 실제 실행은 시작을 거부하는 조합입니다.
+
+### 13.2 위험한 방향으로 어긋난 6개
+
+모두 **어느 계정·어느 프로젝트에 접속해도 되는지 못 박는 설정**입니다.
+
+| 설정 | 실제 실행 | 고치기 전 무료 검사 |
+|---|---|---|
+| `AZURE_AI_EXPECTED_DIRECT_ACCOUNT` 없음 | 거부 | 문제 없음 |
+| `AZURE_AI_EXPECTED_PROJECT_ACCOUNT` 없음 | 거부 | 문제 없음 |
+| `AZURE_AI_EXPECTED_PROJECT_NAME` 없음 | 거부 | 문제 없음 |
+| `AZURE_AI_EXPECTED_DIRECT_ACCOUNT`가 다른 계정 | 거부 | 문제 없음 |
+| `AZURE_AI_EXPECTED_PROJECT_ACCOUNT`가 다른 계정 | 거부 | 문제 없음 |
+| `AZURE_AI_EXPECTED_PROJECT_NAME`이 다른 프로젝트 | 거부 | 문제 없음 |
+
+`.github/workflows/batch-run.yml`은 돈이 나가는 모든 단계에서
+`AZURE_AI_REQUIRE_EXPECTED_IDENTITIES`를 `'1'`로 **고정해서** 넘깁니다. 즉 실제
+실행은 저 세 이름을 **항상** 요구합니다. 그런데 363.59달러를 쓸지 말지 정하는
+무료 검사는 저 세 이름을 **한 번도 쳐다보지 않았습니다.**
+
+### 13.3 손으로 다시 옮겨 적은 목록이 또 있었습니다
+
+`core/execution_envelope_azure.py`에 고정 자격증명 10개 이름이 **다시 타이핑되어**
+있었습니다. 같은 저장소의 `scripts/azure_ai_route_preflight.py`는 같은 목록을
+**가져다 쓰고** 있었는데, 이 파일만 옮겨 적었습니다.
+
+실제로 해 봤습니다. 진짜 목록에 이름을 **하나 추가**하고 그 설정을 켜 두었더니:
+
+```
+  실제 실행:  거부 (static Azure credential environment variables are forbidden)
+  무료 검사:  문제 없음 — 깨끗함
+```
+
+주소 설정 이름 4개에도 "core/azure_ai_clients.py가 읽는 이름과 같다"는 **주석이
+붙어 있었지만**, 그쪽은 함수 안에 글자로 박혀 있어서 **같은지 확인할 방법 자체가
+없었습니다.**
+
+### 13.4 지금은 어떻게 하나
+
+| 전 | 후 |
+|---|---|
+| 금지 자격증명 10개를 옮겨 적음 | 실행 쪽 목록을 **읽어 옴** |
+| 설정 이름 4개를 옮겨 적음 | 실행 쪽에서 이름을 **읽어 옴** |
+| 신원 고정 규칙 없음 | 실행 쪽 표를 **읽어서 그대로 적용** |
+| 계획에 적힌 계정·프로젝트와 저장소 설정을 비교하지 않음 | **비교함** |
+
+실행 쪽(`core/azure_ai_clients.py`)에도 손을 댔습니다. 함수 안에 글자로 박혀
+있던 설정 이름들을 **파일 맨 위 한 곳으로** 꺼냈습니다. 무료 검사가 이제 그
+한 곳을 읽습니다. 동작은 바뀌지 않았고, 기존 테스트 323개가 그대로 통과합니다.
+
+### 13.5 일부러 더 엄격하게 둔 곳 하나
+
+17개 중 마지막 하나는 여전히 답이 다릅니다.
+
+`AZURE_AI_ROUTE_PROFILE`이 `direct-v1`이면 실제 실행은 **잘 돌아갑니다.** 무료
+검사는 **거부합니다.** 이 비교는 `project-ci`로 못 박혀 있기 때문입니다.
+
+이건 결함이 아니라 못 박은 것의 목적이고, **돈이 안 드는 방향으로** 어긋납니다.
+테스트로 적어 두었습니다.
+
+신원 이름 요구도 같은 이유로 일부러 더 엄격합니다. 실제 실행은 스위치가 켜져
+있을 때만 요구하지만, 무료 검사는 스위치와 무관하게 요구합니다. **돈을 쓸 수 있는
+실행 자리는 전부 그 스위치를 켜기 때문입니다.** 그 문장이 맞는지도 테스트가
+워크플로 파일을 열어서 확인합니다 — 나중에 누가 워크플로를 바꾸면 문장이 조용히
+낡는 대신 테스트가 실패합니다.
+
+### 13.6 검사 결과
+
+- 신규 테스트 41개 (이 파일에는 테스트가 **한 개도 없었습니다**)
+- 그중 **20개는 고치기 전 코드에서 실제로 실패**합니다
+- 아무것도 켜지 않았습니다. 승인한 금액 없음, 부른 모델 없음, 로그인 없음
+- 무료 검사는 **더 많이 거부하게** 됐을 뿐, 더 허용하게 되지 않았습니다
+
+### 13.7 고치고 나서 기존 테스트 6개가 깨졌습니다
+
+전체 테스트를 돌렸더니 기존 파일
+`tests/test_execution_envelope_advance_check.py`에서 6개가 실패했습니다.
+원인은 하나였습니다. 그 파일에는 **"이제 고칠 게 하나도 없는 상태"** 라고 이름
+붙인 설정 묶음이 있고 테스트 여러 개가 그걸 같이 씁니다. 그런데 그 묶음에
+신원 이름 세 개가 **빠져 있었습니다.**
+
+즉 그 파일이 "완전히 준비됨"이라고 부르던 상태는, 실제 실행이라면 **시작을
+거부했을 상태**입니다. 무료 검사가 그 세 이름을 안 봤으니 테스트도 안 넣었고,
+아무도 몰랐습니다. 같은 결함이 테스트 쪽에도 한 번 더 있던 셈입니다. 세 이름을
+넣었고 100개 전부 통과합니다.
+
+한 가지는 짚어 둘 만합니다. `batch-runner/README.md`와
+`docs/first-experiment.md`에는 저 세 이름이 **처음부터 정확하게 적혀
+있었습니다.** 사람이 읽는 설명은 맞았고, 코드가 틀렸던 겁니다.
+
+### 13.8 바뀐 파일
+
+| 파일 | 무엇이 바뀌었나 |
+|---|---|
+| `batch-runner/core/azure_ai_clients.py` | 함수 안에 글자로 박혀 있던 설정 이름 10개를 파일 맨 위 한 곳으로 꺼냄. 동작 변화 없음 |
+| `batch-runner/core/execution_envelope_azure.py` | 옮겨 적은 목록 두 개를 지우고 실행 쪽에서 읽어 옴. 신원 고정 규칙을 적용함 |
+| `batch-runner/tests/test_envelope_azure_applies_the_run_rules.py` | 신규. 테스트 41개 |
+| `tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md` | 6절의 틀린 문장을 고치고, 이 13절을 추가 |
+| `batch-runner/experiments/execution_envelope/advance_check_plan.yaml` | 계획 옆 설명을 실제 동작에 맞게 고침 |
+| `batch-runner/tests/test_execution_envelope_advance_check.py` | "완전히 준비됨" 설정 묶음에 빠져 있던 신원 이름 세 개를 넣음 |


### PR DESCRIPTION
## What was wrong

`core/execution_envelope_azure.py` is the last gate before the run-place comparison spends anything on Azure. Its specification said a plan checked there was checked against "exactly the rules the real run applies". Nothing measured that.

I swept seventeen Azure settings one at a time, setting each and asking the free check and `AzureAIRouteSettings.from_env` separately for a verdict:

| | agree | disagree |
|---|---|---|
| before | 10 / 17 | **7 / 17** |
| after | **16 / 17** | 1 / 17 |

**Six of the seven disagreements were in the direction that costs money** — the free check reported no problems for a setting the run refuses to start with:

| setting | the run | the check, before |
|---|---|---|
| `AZURE_AI_EXPECTED_DIRECT_ACCOUNT` unset | refuses | no problems |
| `AZURE_AI_EXPECTED_PROJECT_ACCOUNT` unset | refuses | no problems |
| `AZURE_AI_EXPECTED_PROJECT_NAME` unset | refuses | no problems |
| `AZURE_AI_EXPECTED_DIRECT_ACCOUNT` names another account | refuses | no problems |
| `AZURE_AI_EXPECTED_PROJECT_ACCOUNT` names another account | refuses | no problems |
| `AZURE_AI_EXPECTED_PROJECT_NAME` names another project | refuses | no problems |

Every workflow step in `batch-run.yml` and `grade-run.yml` that can spend money hard-sets `AZURE_AI_REQUIRE_EXPECTED_IDENTITIES` to `'1'`, so the run always demands these. The check that gates a 363.59 USD ceiling looked at none of them.

## Two lists were typed out a second time

The ten fixed credentials the repository refuses to run with were retyped inside the check, while `scripts/azure_ai_route_preflight.py` imported the same list correctly. Demonstrated rather than argued — adding an eleventh name to the real list:

```
  the run:         REFUSED (static Azure credential environment variables are forbidden)
  the free check:  NO PROBLEMS - clean bill of health
```

Four endpoint setting names were retyped beside a comment claiming they were "the same names `core/azure_ai_clients.py` reads" — which nothing could check, because that module held them as string literals inside its functions.

## What changed

- the check reads the run's own `REQUIRED_IDENTITY_ENV_BY_PROFILE` table and applies it, and compares the plan's pinned account and project against those settings — a comparison the plan file asserted in a comment and nothing performed
- the forbidden-credential list and the setting names are read from the run's module instead of restated
- `core/azure_ai_clients.py` lifts those names to module scope. Behaviour identical; its 323 existing tests pass untouched
- account names are compared folded to lower case and project names are not, because that is what the run does — both pinned by a test

## The seventeenth setting

`AZURE_AI_ROUTE_PROFILE=direct-v1` builds fine in the run and is refused here, because this comparison is pinned to `project-ci`. That is the point of pinning, and it errs in the direction that costs nothing. Stated in a test rather than left as a surprise.

The identity names are likewise demanded regardless of the local value of the require switch, because every money-spending run place turns it on. A test opens the workflow files and checks that sentence, so a workflow change fails the test instead of quietly making the wording untrue.

## Tests

`tests/test_envelope_azure_applies_the_run_rules.py` is new — **41 tests, 20 of which fail against the previous code**. This module had no test file at all.

Running the full suite surfaced six failures in the existing `tests/test_execution_envelope_advance_check.py`: its shared "fully ready" environment set none of the three identity names, so what it called *nothing left to fix* described a setup the paid run would have stopped. The same defect, one layer along. Fixed. `batch-runner/README.md` and `docs/first-experiment.md` had all three listed correctly the whole time — the written instructions were right and the code was wrong.

- full suite: **4126 passed, 6 skipped** (4085 baseline + 41 new)
- mypy: unchanged at the 170-errors-in-32-files baseline, none in the changed files

## Safety

Nothing was enabled and no amount approved. No model was called, no sign-in performed, nothing contacted Azure. The free check only refuses **more** than it did.