### PR TITLE
feat(gold-ceiling): 정답 답안을 채점할 수 있게 만들고, 그 실행을 통째로 고정한다

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -57,6 +57,11 @@ on:
         required: false
         type: number
         default: 0
+      run_ordinal:
+        description: "Which repeat of an identical run this is (1 = the original). Repeats above 1 commit under data/grades/**/_repeats/run-NNN/ — above the shard fork, so a repeat can still be sharded — and measure how much the score moves instead of erasing the run they repeat."
+        required: false
+        type: number
+        default: 1
 
 permissions:
   contents: read
@@ -68,6 +73,11 @@ concurrency:
   # shard_count: re-dispatching the same index under a different N still
   # serializes, which is what stops two overlapping slices from being graded
   # (and paid for) simultaneously.
+  #
+  # run_ordinal is deliberately absent for the same reason shard_count is.
+  # Repeats write to separate paths and could safely overlap, but a variance
+  # measurement gains nothing from running them at once and would bill two full
+  # corpora against one judge quota simultaneously. Queuing them is free.
   group: grade-${{ inputs.experiment_yaml }}-${{ inputs.grading_config }}-shard${{ inputs.shard_index }}
   cancel-in-progress: false
 
@@ -88,6 +98,7 @@ jobs:
       GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
       GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
       GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
+      GRADE_RUN_ORDINAL: ${{ inputs.run_ordinal }}
     steps:
       - name: Validate workflow context and inputs
         shell: bash
@@ -189,6 +200,13 @@ jobs:
           # subtree that nothing merges. Refuse the combination outright.
           if [[ "$GRADE_SHARD_COUNT" != "1" && "$GRADE_TASKS_LIMIT" != "0" ]]; then
             echo "::error::shard_count > 1 cannot be combined with tasks_limit"
+            exit 1
+          fi
+          # Ten is the same cap step8_grade.py enforces (MAX_RUN_ORDINAL). A
+          # variance measurement needs a handful of repeats; every repeat past
+          # the first is another full charge for a corpus already graded.
+          if [[ ! "$GRADE_RUN_ORDINAL" =~ ^([1-9]|10)$ ]]; then
+            echo "::error::run_ordinal must be an integer between 1 and 10"
             exit 1
           fi
 
@@ -327,6 +345,7 @@ jobs:
           GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
           GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
           GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
+          GRADE_RUN_ORDINAL: ${{ inputs.run_ordinal }}
         run: |
           printf '%s\n' \
             "Approved paid grading request:" \
@@ -428,6 +447,7 @@ jobs:
       HF_HUB_DISABLE_IMPLICIT_TOKEN: '1'
       GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
       GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
+      GRADE_RUN_ORDINAL: ${{ inputs.run_ordinal }}
       ImageOS: ubuntu24
       LANG: C.UTF-8
       PIP_CACHE_DIR: /root/.cache/pip
@@ -543,6 +563,9 @@ jobs:
           if [[ "$GRADE_SHARD_COUNT" != "1" ]]; then
             ARGS+=(--shard-count "$GRADE_SHARD_COUNT" --shard-index "$GRADE_SHARD_INDEX")
           fi
+          if [[ "$GRADE_RUN_ORDINAL" != "1" ]]; then
+            ARGS+=(--run-ordinal "$GRADE_RUN_ORDINAL")
+          fi
           python step8_grade.py "${ARGS[@]}"
 
   grade:
@@ -602,6 +625,7 @@ jobs:
       GRADE_RESUME_CHUNK: ${{ inputs.resume_chunk }}
       GRADE_SHARD_COUNT: ${{ inputs.shard_count }}
       GRADE_SHARD_INDEX: ${{ inputs.shard_index }}
+      GRADE_RUN_ORDINAL: ${{ inputs.run_ordinal }}
       ImageOS: ubuntu24
       LANG: C.UTF-8
       PIP_CACHE_DIR: /root/.cache/pip
@@ -901,6 +925,13 @@ jobs:
           if [[ "$GRADE_SHARD_COUNT" != "1" ]]; then
             ARGS+=(--shard-count "$GRADE_SHARD_COUNT" --shard-index "$GRADE_SHARD_INDEX")
           fi
+          # A repeat changes nothing about what is graded or how -- that is the
+          # entire point, since a rerun only measures movement if everything
+          # else held still. It forks the output path so the repeat sits beside
+          # the run it repeats instead of replacing it.
+          if [[ "$GRADE_RUN_ORDINAL" != "1" ]]; then
+            ARGS+=(--run-ordinal "$GRADE_RUN_ORDINAL")
+          fi
 
           set +e
           python step8_grade.py "${ARGS[@]}"
@@ -1068,7 +1099,7 @@ jobs:
             echo "::error::resume_chunk=$NEXT_CHUNK exceeds safety cap (10). Aborting auto-resume; investigate manually."
             exit 1
           fi
-          echo "[auto-resume] triggering chunk $NEXT_CHUNK for $GRADE_EXPERIMENT_YAML / $GRADE_CONFIG (shard $GRADE_SHARD_INDEX/$GRADE_SHARD_COUNT)"
+          echo "[auto-resume] triggering chunk $NEXT_CHUNK for $GRADE_EXPERIMENT_YAML / $GRADE_CONFIG (shard $GRADE_SHARD_INDEX/$GRADE_SHARD_COUNT, run $GRADE_RUN_ORDINAL)"
           # This used to be `gh workflow run`, which is a thin wrapper over the
           # endpoint below; gh is not in the grading image. Every input is a
           # JSON string, including the booleans, because that is what gh sent
@@ -1094,6 +1125,12 @@ jobs:
                   "resume_chunk": os.environ["NEXT_CHUNK"],
                   "shard_count": os.environ["GRADE_SHARD_COUNT"],
                   "shard_index": os.environ["GRADE_SHARD_INDEX"],
+                  # Load-bearing: a repeat that runs out of its four hours
+                  # resumes from a partial under _repeats/. Dropping the
+                  # ordinal here would send the next chunk to run 1's path,
+                  # where it would either be refused or overwrite the run this
+                  # one exists to be compared against.
+                  "run_ordinal": os.environ["GRADE_RUN_ORDINAL"],
               },
           }))
           PY

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/check_agentic_stage_one_ceiling.py
 !batch-runner/scripts/check_agentic_containment.py
 !batch-runner/scripts/build_gdpval_task_catalog.py
+!batch-runner/scripts/build_gold_deliverable_manifest.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/batch-runner/core/inference_manifest.py
+++ b/batch-runner/core/inference_manifest.py
@@ -30,6 +30,16 @@ STEP2_PROGRESS_SCHEMA = "step2-progress-v2"
 STEP2_RESULT_STATUSES = frozenset({
     "success", "error", "qa_failed", "pending"
 })
+#: What ``azure_ai_provenance_status`` says when the graded files are the
+#: benchmark's own expert answers rather than any model's output. It is not a
+#: missing record: no inference ran, so there is no route that could have been
+#: recorded. Grading these answers measures how high the grader can score at
+#: all, which only reads as a ceiling if it is never mistaken for a model's
+#: result -- so ``step8_grade.py`` keeps every such run out of the published
+#: path. The matching entry in ``schemas/grade.schema.json`` is what the
+#: written grade is validated against; ``tests/test_step8_grade.py`` proves the
+#: two still agree.
+GOLD_PROVENANCE_STATUS = "gold-corpus"
 _ROUTE_KEYS = {
     "endpoint_kind",
     "profile",

--- a/batch-runner/experiments/exp_gold_baseline.yaml
+++ b/batch-runner/experiments/exp_gold_baseline.yaml
@@ -1,0 +1,76 @@
+# Experiment Configuration — gold-ceiling baseline
+#
+# This is not an experiment. No model is called, no task is executed and no
+# submission repository exists. It registers the benchmark's OWN expert answers
+# as the graded corpus so the grader can be pointed at them, which answers one
+# question: how high can this grader score at all?
+#
+# That number is the ceiling every model result is read against. If the expert
+# answers do not score near the top, the shortfall is in the grader, its inputs
+# or its file-reading tools -- not in any model -- and every score already
+# published is measured against a ruler that is bent. So this file exists to be
+# graded, and its result is deliberately unpublishable: `step8_grade.py` routes
+# every `gold-corpus` run into the diagnostic path, because the dashboard has
+# no way to say "this is the ceiling, not a competitor".
+#
+# Spec: tasks/rebuilding_grading_task/300-gold-ceiling.md
+
+experiment:
+  id: "exp_gold_baseline"
+  name: "Gold Deliverable Ceiling Baseline"
+  description: >-
+    The gdpval reference answers, registered as if they were a run's output, so
+    the v2 grader can be measured against the best result it will ever see.
+  author: "Hyeonsang Jeon"
+  created_at: "2026-08-28"
+
+# Nothing varies, because nothing runs. Both lists are empty rather than
+# invented: a control block that named a changed variable would describe a
+# comparison this file does not make.
+control:
+  fixed: []
+  changed: []
+
+data:
+  # The dataset repository itself, not a submission repository. There is no
+  # `HyeonSang/exp_gold_baseline` on the Hub and there never will be.
+  source: "openai/gdpval"
+  # Read by `scripts/download_inference_from_hf.py`. Absent means `submission`,
+  # so this line is what stops the downloader looking for inference output that
+  # was never produced. Any unrecognised value is refused rather than defaulted.
+  inference_source: "gold_deliverables"
+  filter:
+    sector: null
+    occupation: null
+    # Which tasks are actually graded is pinned by `rerun_identity.task_ids` in
+    # the grading config, not here -- a sample size taken at this layer would
+    # be a different 30 tasks each time the dataset order changed.
+    sample_size: null
+
+condition_a:
+  name: "Gold Deliverable"
+  model:
+    provider: "azure"
+    # Named explicitly so no default can speak for this file. `step8_grade.py`
+    # prefers the `model` recorded in the inference payload -- which the gold
+    # builder sets to this same string -- but if that lookup ever fell through
+    # to here, the record would read "gpt-4" and claim a model produced work it
+    # did not.
+    deployment: "gold-deliverable"
+    temperature: 0.0
+    seed: null
+  prompt:
+    system: null
+    prefix: null
+    body: null
+    suffix: null
+  qa:
+    enabled: false
+
+execution:
+  # Every mode this pipeline offers describes how a model produces a
+  # deliverable. None of them applies: the deliverables already exist, written
+  # by the human experts who wrote the benchmark. Nothing here is dispatched.
+  mode: "none"
+  max_retries: 0
+  resume_max_rounds: 0

--- a/batch-runner/experiments/gold_corpus/gold_deliverable_manifest.json
+++ b/batch-runner/experiments/gold_corpus/gold_deliverable_manifest.json
@@ -1,0 +1,3229 @@
+{
+  "dataset_data_file": "data/train-00000-of-00001.parquet",
+  "dataset_file_sha256": "f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202",
+  "dataset_repo_id": "openai/gdpval",
+  "dataset_revision": "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+  "file_count": 248,
+  "gold_bearing_task_count": 185,
+  "holds_no_scores": "Only task numbers, industries, jobs, and the name, size and SHA-256 fingerprint of each expert answer file are recorded. No score, grade, verdict, or scoring line is present, and no file's contents are reproduced.",
+  "path_note": "The dataset files each expert answer under an opaque 32-character folder that is not derived from the file's contents; source_path is where the dataset keeps it and graded_path is where the grader reads it from.",
+  "schema_version": "gdpval-gold-deliverable-manifest-v1",
+  "task_count": 220,
+  "tasks": [
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/83d10b06-26d1-4636-a32c-23f92c57f30b/Sample v2.xlsx",
+          "sha256": "72b74484e2eeb6bd1a5b5391220a6dea142f3b7fbd6c218490b1aa633dbafcbb",
+          "size": 79328,
+          "source_path": "deliverable_files/2837faa0a7a6a95f40dfbe45bf66c7fb/Sample v2.xlsx"
+        }
+      ],
+      "occupation": "Accountants and Auditors",
+      "position": 0,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "83d10b06-26d1-4636-a32c-23f92c57f30b"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/7b08cd4d-df60-41ae-9102-8aaa49306ba2/Fall Music Tour Output.xlsx",
+          "sha256": "177f8ac80963256ffee1849d3e959bcd7131a6ab8722d0119f52f56eb99a4eee",
+          "size": 13370,
+          "source_path": "deliverable_files/d433821741d2c13260a67e94c56ff2df/Fall Music Tour Output.xlsx"
+        }
+      ],
+      "occupation": "Accountants and Auditors",
+      "position": 1,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "7b08cd4d-df60-41ae-9102-8aaa49306ba2"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/7d7fc9a7-21a7-4b83-906f-416dea5ad04f/Aurisic_Amortization_4-25.xlsx",
+          "sha256": "894e8b780163b00ff589075e97e1898c85a469f5503bb66bcc74208efd20a533",
+          "size": 27297,
+          "source_path": "deliverable_files/6d38d3535a408ecad05a8510a0152be4/Aurisic_Amortization_4-25.xlsx"
+        }
+      ],
+      "occupation": "Accountants and Auditors",
+      "position": 2,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "7d7fc9a7-21a7-4b83-906f-416dea5ad04f"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/43dc9778-450b-4b46-b77e-b6d82b202035/ROBERT & LISA SMITH 2024 COMPLETED 1040 PAGES 1&2.pdf",
+          "sha256": "f01713bf22b5e7c772399c1d945a3062e19f6c753985f2463acb541e5791e633",
+          "size": 184388,
+          "source_path": "deliverable_files/d2b45aedd39de350e64a8c9d1611e70f/ROBERT & LISA SMITH 2024 COMPLETED 1040 PAGES 1&2.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/43dc9778-450b-4b46-b77e-b6d82b202035/ROBERT & LISA SMITH 2024 COMPLETED TAX FORMS AND SCHEDULES REQUIRED FOR E-FILING edits.PDF",
+          "sha256": "899a0d0a4b9fc452727be713674d0dfcbb3ac781e7396ac75dced1b6847a33f5",
+          "size": 940334,
+          "source_path": "deliverable_files/5d8fa1fbe97a13aa24194489a02f74aa/ROBERT & LISA SMITH 2024 COMPLETED TAX FORMS AND SCHEDULES REQUIRED FOR E-FILING edits.PDF"
+        }
+      ],
+      "occupation": "Accountants and Auditors",
+      "position": 3,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "43dc9778-450b-4b46-b77e-b6d82b202035"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/ee09d943-5a11-430a-b7a2-971b4e9b01b5/Aurisic_Financials_4-25-1.xlsx",
+          "sha256": "5a63b873abc8244e2b72e46b5468d1706ee63656284b7e07be77ce317eadbfad",
+          "size": 93974,
+          "source_path": "deliverable_files/dc4d567b1f5c8b70374f118051b31be7/Aurisic_Financials_4-25-1.xlsx"
+        }
+      ],
+      "occupation": "Accountants and Auditors",
+      "position": 4,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "ee09d943-5a11-430a-b7a2-971b4e9b01b5"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/f84ea6ac-8f9f-428c-b96c-d0884e30f7c7/Research Scan Use AI in Government Administrative Services and Implications for Government.docx",
+          "sha256": "41f724956408fb747cc4ac859e00b740fded4e9fcc13dbbdb639c14b6cc0d01c",
+          "size": 22148,
+          "source_path": "deliverable_files/c4cf75f3d3a8acb727c291642f41f15e/Research Scan Use AI in Government Administrative Services and Implications for Government.docx"
+        }
+      ],
+      "occupation": "Administrative Services Managers",
+      "position": 5,
+      "sector": "Government",
+      "task_id": "f84ea6ac-8f9f-428c-b96c-d0884e30f7c7"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a328feea-47db-4856-b4be-2bdc63dd88fb/Regional Branches Policy Procedure Reporting of Unscheduled Absence or Lateness updated.docx",
+          "sha256": "622cac6db3ee627fe4151b7766308d9465dcfdecd6d1d77a767fa390fa9b7175",
+          "size": 18348,
+          "source_path": "deliverable_files/4d73393e6ce7023efc9f4c939cebd42c/Regional Branches Policy Procedure Reporting of Unscheduled Absence or Lateness updated.docx"
+        }
+      ],
+      "occupation": "Administrative Services Managers",
+      "position": 6,
+      "sector": "Government",
+      "task_id": "a328feea-47db-4856-b4be-2bdc63dd88fb"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/27e8912c-8bd5-44ba-ad87-64066ea05264/Organizational Action Items_Ergonomics edits.docx",
+          "sha256": "ea0d6cae0b3f4487abf75b9bf207c715aa2d16f4b4cc468168dd5fc09c279ba4",
+          "size": 54419,
+          "source_path": "deliverable_files/9ecd0c22da3f655f56425df8b8f3401a/Organizational Action Items_Ergonomics edits.docx"
+        },
+        {
+          "graded_path": "deliverable_files/27e8912c-8bd5-44ba-ad87-64066ea05264/Workstation Ergonomics Checklist edits.pdf",
+          "sha256": "b1ed090687591ce66103fbc3182f95b8cecf970c9060040a175feb1b5297ce43",
+          "size": 352765,
+          "source_path": "deliverable_files/6c5faf507d9a6dbe1bb083fa06be19b7/Workstation Ergonomics Checklist edits.pdf"
+        }
+      ],
+      "occupation": "Administrative Services Managers",
+      "position": 7,
+      "sector": "Government",
+      "task_id": "27e8912c-8bd5-44ba-ad87-64066ea05264"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/17111c03-aac7-45c2-857d-c06d8223d6ad/Cleanup Schedule.xlsx",
+          "sha256": "ec96530d5e7eb928bb8299ad67ff0f376b5c1833eefa144382081cc5f25af514",
+          "size": 32323,
+          "source_path": "deliverable_files/133bba797a2a56c10875165747a8ed57/Cleanup Schedule.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/17111c03-aac7-45c2-857d-c06d8223d6ad/Memo.pdf",
+          "sha256": "5fbd45438031d06159d0e04bde2380c27da97b6d090a042d6cca1edd1f111607",
+          "size": 68430,
+          "source_path": "deliverable_files/efa8d77baecee016b2c44f9801f94adb/Memo.pdf"
+        }
+      ],
+      "occupation": "Administrative Services Managers",
+      "position": 8,
+      "sector": "Government",
+      "task_id": "17111c03-aac7-45c2-857d-c06d8223d6ad"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/c44e9b62-7cd8-4f72-8ad9-f8fbddb94083/Budget Planning Organizational Chart Administrative Support Services Branch.pdf",
+          "sha256": "b657bd990b129d817c3daec898dfdbb9a01cc0bd74064cca29fa09c45a332e25",
+          "size": 71413,
+          "source_path": "deliverable_files/b2470a0c1f868d996f0e30ee53ea5cc3/Budget Planning Organizational Chart Administrative Support Services Branch.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/c44e9b62-7cd8-4f72-8ad9-f8fbddb94083/Fulltime Equivalent Report Administrative Support Services Planned Reductions.xlsx",
+          "sha256": "b67a9f564fedc27b2140452bc23a2100b74671d0a79d9433924e36afa7fe7674",
+          "size": 12351,
+          "source_path": "deliverable_files/e20a9da6b3037c9866f1113452060911/Fulltime Equivalent Report Administrative Support Services Planned Reductions.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/c44e9b62-7cd8-4f72-8ad9-f8fbddb94083/Budget Planning Staffing Briefing Note Administrative Support Services Branch.docx",
+          "sha256": "5efa12e5742162a8dd85086a49bc6a4e8c32372ead87c27b0e18145d79c3f9dd",
+          "size": 19605,
+          "source_path": "deliverable_files/8adabe95230a4faafddbd56f5a6b8e79/Budget Planning Staffing Briefing Note Administrative Support Services Branch.docx"
+        }
+      ],
+      "occupation": "Administrative Services Managers",
+      "position": 9,
+      "sector": "Government",
+      "task_id": "c44e9b62-7cd8-4f72-8ad9-f8fbddb94083"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/99ac6944-4ec6-4848-959c-a460ac705c6f/Summer Tour - IEM Setup_ Budget Estimate_redacted_v2 edited (1).pdf",
+          "sha256": "8d451b871e3cde18eb7353421dbc94b72dd916febf22e18a39c71b2eec44ee7f",
+          "size": 571902,
+          "source_path": "deliverable_files/ff29828d9189b0a3675061f503f8c668/Summer Tour - IEM Setup_ Budget Estimate_redacted_v2 edited (1).pdf"
+        }
+      ],
+      "occupation": "Audio and Video Technicians",
+      "position": 10,
+      "sector": "Information",
+      "task_id": "99ac6944-4ec6-4848-959c-a460ac705c6f"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/f9a1c16c-53fd-4c8f-88cc-5c325ec2f0bb/Touring Band_Stage Plot.pdf",
+          "sha256": "6381eb676d62b3e48dc7c06e540148fef3643d82c2c8b52dab46724674c16c68",
+          "size": 114547,
+          "source_path": "deliverable_files/7c2a414fb1d3dd232da6e47079ecb1d2/Touring Band_Stage Plot.pdf"
+        }
+      ],
+      "occupation": "Audio and Video Technicians",
+      "position": 11,
+      "sector": "Information",
+      "task_id": "f9a1c16c-53fd-4c8f-88cc-5c325ec2f0bb"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/38889c3b-e3d4-49c8-816a-3cc8e5313aba/DEJA VU  STEMS .zip",
+          "sha256": "9184f395a896d68f69641d0404e224ee01fd2b87af9d00b83294f06dbff5956f",
+          "size": 179653840,
+          "source_path": "deliverable_files/d4c1c929e8c81fd561438ee601109c04/DEJA VU  STEMS .zip"
+        }
+      ],
+      "occupation": "Audio and Video Technicians",
+      "position": 12,
+      "sector": "Information",
+      "task_id": "38889c3b-e3d4-49c8-816a-3cc8e5313aba"
+    },
+    {
+      "files": [],
+      "occupation": "Audio and Video Technicians",
+      "position": 13,
+      "sector": "Information",
+      "task_id": "ff85ee58-bc9f-4aa2-806d-87edeabb1b81"
+    },
+    {
+      "files": [],
+      "occupation": "Audio and Video Technicians",
+      "position": 14,
+      "sector": "Information",
+      "task_id": "4b894ae3-1f23-4560-b13d-07ed1132074e"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/1b1ade2d-f9f6-4a04-baa5-aa15012b53be/Revised Sourcing Workflow for Automotive Electronics vFinal.docx",
+          "sha256": "ccd1a615f7065d33d2087098115515bc7b1a4ac40ccf303208db0bf5e1eb91b8",
+          "size": 141957,
+          "source_path": "deliverable_files/b53e13eb94cb521d9b4be2cad571d154/Revised Sourcing Workflow for Automotive Electronics vFinal.docx"
+        }
+      ],
+      "occupation": "Buyers and Purchasing Agents",
+      "position": 15,
+      "sector": "Manufacturing",
+      "task_id": "1b1ade2d-f9f6-4a04-baa5-aa15012b53be"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/93b336f3-61f3-4287-86d2-87445e1e0f90/Proposal for a partnership for Battery Assembly in India (1).docx",
+          "sha256": "e915cba28beec4beaf2109b05fa816277474333deb9cdc0b2db365e0fed024b0",
+          "size": 20537,
+          "source_path": "deliverable_files/b094ef8b015591315a8d68b18c3d0d47/Proposal for a partnership for Battery Assembly in India (1).docx"
+        }
+      ],
+      "occupation": "Buyers and Purchasing Agents",
+      "position": 16,
+      "sector": "Manufacturing",
+      "task_id": "93b336f3-61f3-4287-86d2-87445e1e0f90"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/15ddd28d-8445-4baa-ac7f-f41372e1344e/Negotiation Strategy for Ensuring Continued Supply of Modlev Tail Lamps from LPI.docx",
+          "sha256": "d5315d6f9268283e25719bf7924bae614d6fa80c57104af8048dc2bfd794c6ec",
+          "size": 24807,
+          "source_path": "deliverable_files/94726f02d2cae4f5060f2195124bdefc/Negotiation Strategy for Ensuring Continued Supply of Modlev Tail Lamps from LPI.docx"
+        }
+      ],
+      "occupation": "Buyers and Purchasing Agents",
+      "position": 17,
+      "sector": "Manufacturing",
+      "task_id": "15ddd28d-8445-4baa-ac7f-f41372e1344e"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/24d1e93f-9018-45d4-b522-ad89dfd78079/NPV workbook Model Z headlamp.xlsx",
+          "sha256": "fa9f9e2ef496bc9a2a5864c34c0cc70cbe5096f49a3d96cb4ec65d1ea958b569",
+          "size": 18120,
+          "source_path": "deliverable_files/a0907404c5734e258aed24a637c246b9/NPV workbook Model Z headlamp.xlsx"
+        }
+      ],
+      "occupation": "Buyers and Purchasing Agents",
+      "position": 18,
+      "sector": "Manufacturing",
+      "task_id": "24d1e93f-9018-45d4-b522-ad89dfd78079"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/05389f78-589a-473c-a4ae-67c61050bfca/Escalation email for Model A headlamp_1.docx",
+          "sha256": "c629af144c76a301ee252e63355cd03a215c5a3be35302cdd029445a7a40d237",
+          "size": 19767,
+          "source_path": "deliverable_files/6598cfe62490fdd2d28ae94ba96e1be7/Escalation email for Model A headlamp_1.docx"
+        },
+        {
+          "graded_path": "deliverable_files/05389f78-589a-473c-a4ae-67c61050bfca/Alternate sourcing - Model A Headlamp_1 edits.docx",
+          "sha256": "c5caf4fd9245b540d74eb62b0749118007c83b388c5446eeb8a9281c331a0406",
+          "size": 328328,
+          "source_path": "deliverable_files/abd38f591de31af0b0076d7358b1c30d/Alternate sourcing - Model A Headlamp_1 edits.docx"
+        }
+      ],
+      "occupation": "Buyers and Purchasing Agents",
+      "position": 19,
+      "sector": "Manufacturing",
+      "task_id": "05389f78-589a-473c-a4ae-67c61050bfca"
+    },
+    {
+      "files": [],
+      "occupation": "Child, Family, and School Social Workers",
+      "position": 20,
+      "sector": "Government",
+      "task_id": "575f8679-b4c1-47a2-8e96-d570d4ed9269"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a74ead3b-f67d-4b1c-9116-f6bb81b29d4f/NP-Topic 14 Edited.pptx",
+          "sha256": "34e1639bcec2ea7e4eacafc3b269246b7458ef4c8c693f07e3ed3567cc951080",
+          "size": 115548,
+          "source_path": "deliverable_files/9ad6fcfaf9e792bf5c4141b578c0c13c/NP-Topic 14 Edited.pptx"
+        },
+        {
+          "graded_path": "deliverable_files/a74ead3b-f67d-4b1c-9116-f6bb81b29d4f/Topic 13 Edited.pptx",
+          "sha256": "df0afa2ce4633d2d352a3177ee970545a99cb4f3501816b8cc92c6c4d83a819f",
+          "size": 102160,
+          "source_path": "deliverable_files/4d9e41cecafbc172874e04573f4d2fd6/Topic 13 Edited.pptx"
+        }
+      ],
+      "occupation": "Child, Family, and School Social Workers",
+      "position": 21,
+      "sector": "Government",
+      "task_id": "a74ead3b-f67d-4b1c-9116-f6bb81b29d4f"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/bbe0a93b-ebf0-40b0-98dc-8d9243099034/Community Resource Guide.pdf",
+          "sha256": "3e85db25d37469d1622d0aca703deb27b878ebfbef6d830fced6365e8e694fc4",
+          "size": 181931,
+          "source_path": "deliverable_files/38ed8aa2da11ff5de2ee24701e974536/Community Resource Guide.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/bbe0a93b-ebf0-40b0-98dc-8d9243099034/ENGLISH Needs Assessment Template.pdf",
+          "sha256": "cae44c752791273c69f617182cff605a1f30bdba79a615b52325573b147a5dd5",
+          "size": 61078,
+          "source_path": "deliverable_files/b3dfcf253fcf2ead5b1e9cd9581fb8ed/ENGLISH Needs Assessment Template.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/bbe0a93b-ebf0-40b0-98dc-8d9243099034/SPANISH Needs Assessment Template.pdf",
+          "sha256": "40a29aece1bc98b7da7b5411b05e8817b7d00d832606db61b56655f015e70b2d",
+          "size": 61231,
+          "source_path": "deliverable_files/018c63efe9c2c436ba6a326fd310bb11/SPANISH Needs Assessment Template.pdf"
+        }
+      ],
+      "occupation": "Child, Family, and School Social Workers",
+      "position": 22,
+      "sector": "Government",
+      "task_id": "bbe0a93b-ebf0-40b0-98dc-8d9243099034"
+    },
+    {
+      "files": [],
+      "occupation": "Child, Family, and School Social Workers",
+      "position": 23,
+      "sector": "Government",
+      "task_id": "85d95ce5-b20c-41e2-834e-e788ce9622b6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/76d10872-9ffa-4ede-83ee-e0f1ec5e2b8d/New Case Creation Report for Michael Reynolds (Case PT-2025-1782).pdf",
+          "sha256": "8a379c7dc3882e6434bf210d7baa20f3f723e3064fff10f300478f4b955cb5d7",
+          "size": 159666,
+          "source_path": "deliverable_files/9aa108818874aa7b0ab6e1a88277fff8/New Case Creation Report for Michael Reynolds (Case PT-2025-1782).pdf"
+        }
+      ],
+      "occupation": "Child, Family, and School Social Workers",
+      "position": 24,
+      "sector": "Government",
+      "task_id": "76d10872-9ffa-4ede-83ee-e0f1ec5e2b8d"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/36d567ba-e205-4313-9756-931c6e4691fe/Federal Applicant Risk Assessment Tool.docx",
+          "sha256": "2b7751836b9c1324850abc7638c0bc79649f5bea72f3a00b9f66b6f148b5e95d",
+          "size": 16379,
+          "source_path": "deliverable_files/9981332f266d00b1f06ccbf4db6042a8/Federal Applicant Risk Assessment Tool.docx"
+        }
+      ],
+      "occupation": "Compliance Officers",
+      "position": 25,
+      "sector": "Government",
+      "task_id": "36d567ba-e205-4313-9756-931c6e4691fe"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/7bbfcfe9-132d-4194-82bb-d6f29d001b01/US Code 50 SCRA 3919 and 3937 Test Questions.xlsx",
+          "sha256": "868c88c869aa2c286a4972e4c52dd4244db3bf33ace81006817ca877178fbc5d",
+          "size": 11407,
+          "source_path": "deliverable_files/ac492499449c55f6956c35b25cc9898b/US Code 50 SCRA 3919 and 3937 Test Questions.xlsx"
+        }
+      ],
+      "occupation": "Compliance Officers",
+      "position": 26,
+      "sector": "Government",
+      "task_id": "7bbfcfe9-132d-4194-82bb-d6f29d001b01"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/2696757c-1f8a-4959-8f0d-f5597b9e70fc/VASP Ch7 BK Test Questions.pdf",
+          "sha256": "b5ba9c192bf768054c5ba849b6cf1b08e449ba71b8f2cf4c70ebf85f2faf9393",
+          "size": 39455,
+          "source_path": "deliverable_files/567662a9514890394715d2669ee46f86/VASP Ch7 BK Test Questions.pdf"
+        }
+      ],
+      "occupation": "Compliance Officers",
+      "position": 27,
+      "sector": "Government",
+      "task_id": "2696757c-1f8a-4959-8f0d-f5597b9e70fc"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/dfb4e0cd-a0b7-454e-b943-0dd586c2764c/Time Elapsed vs Funds Spent Analysis 2025.03.31.xlsx",
+          "sha256": "34a634d2c1eb55127aa1ad0cd6fa8b0ae7b9fbb4164220c423628f975f63f972",
+          "size": 256114,
+          "source_path": "deliverable_files/e10b080866cb5c134b1f72029074fc64/Time Elapsed vs Funds Spent Analysis 2025.03.31.xlsx"
+        }
+      ],
+      "occupation": "Compliance Officers",
+      "position": 28,
+      "sector": "Government",
+      "task_id": "dfb4e0cd-a0b7-454e-b943-0dd586c2764c"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/4c18ebae-dfaa-4b76-b10c-61fcdf26734c/Transactions Final Output.xlsx",
+          "sha256": "7d17c37a9d8114b9666ea397ff429382ad4bbaf545e2ab0b8e7a444d0c2baf1c",
+          "size": 64682,
+          "source_path": "deliverable_files/9c59b3e118091cd544918da53930a1bd/Transactions Final Output.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/4c18ebae-dfaa-4b76-b10c-61fcdf26734c/Suspicious Activity Report (SAR).docx",
+          "sha256": "3188669253e591b0aaefeedaf8c758608f4ea9b758e08a9c92558c8078bb0037",
+          "size": 23791,
+          "source_path": "deliverable_files/e52d250d0f061e4d753c0fca4514e525/Suspicious Activity Report (SAR).docx"
+        }
+      ],
+      "occupation": "Compliance Officers",
+      "position": 29,
+      "sector": "Government",
+      "task_id": "4c18ebae-dfaa-4b76-b10c-61fcdf26734c"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/cebf301e-5ea7-41ae-b117-ad8f43e7ac22/New Customer Portal.docx",
+          "sha256": "a38b2c38e0ebedfa398b328fe175e9f5fd6407c6591e7a4d65b6a7a8ad4e067f",
+          "size": 10090,
+          "source_path": "deliverable_files/6952dc49ba2274629be5608021691550/New Customer Portal.docx"
+        }
+      ],
+      "occupation": "Computer and Information Systems Managers",
+      "position": 30,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "cebf301e-5ea7-41ae-b117-ad8f43e7ac22"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/c2e8f271-7858-412f-b460-472463ad81d9/Coding Standards.docx",
+          "sha256": "49fcb70c5c2322a0ffbc6e9decd77c25ede4d59366083bc2693fe710bc653e79",
+          "size": 27830,
+          "source_path": "deliverable_files/c7595d747f1164ce7a23588c66d1a653/Coding Standards.docx"
+        }
+      ],
+      "occupation": "Computer and Information Systems Managers",
+      "position": 31,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "c2e8f271-7858-412f-b460-472463ad81d9"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/2ea2e5b5-257f-42e6-a7dc-93763f28b19d/WorkStudy.pptx",
+          "sha256": "60689a0d78724d002a4a7bdd50675b301a7e328fe5eace92107a692b42b49188",
+          "size": 65685,
+          "source_path": "deliverable_files/e9db56b584180f23e7bd4b2322a29f8e/WorkStudy.pptx"
+        }
+      ],
+      "occupation": "Computer and Information Systems Managers",
+      "position": 32,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "2ea2e5b5-257f-42e6-a7dc-93763f28b19d"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/c357f0e2-963d-4eb7-a6fa-3078fe55b3ba/UAT Plan.xlsx",
+          "sha256": "910f9b1f327643eaaa52a842c0fbe679166824e3bfdcda7659641d977e6cb74f",
+          "size": 17733,
+          "source_path": "deliverable_files/1bc0fb6fe3dd2abc591686520b556090/UAT Plan.xlsx"
+        }
+      ],
+      "occupation": "Computer and Information Systems Managers",
+      "position": 33,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "c357f0e2-963d-4eb7-a6fa-3078fe55b3ba"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a45bc83b-22f9-4def-8d89-9c5661b2b86f/Proposed_Architecture.pdf",
+          "sha256": "66d83a47e44c04800579a4448a0b4a9990a5585c83c4a303f967d7364128dc80",
+          "size": 51130,
+          "source_path": "deliverable_files/2a91cb467f53f3abe3d8964f924030d6/Proposed_Architecture.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/a45bc83b-22f9-4def-8d89-9c5661b2b86f/POC_Implementation_Guide.docx",
+          "sha256": "b8b671f6e4f463d2e5b89d478201d2bdf698fcee2274c482190b7028e67f8ba9",
+          "size": 34357,
+          "source_path": "deliverable_files/47bc2e3277d9132856ab604a3879a0e1/POC_Implementation_Guide.docx"
+        },
+        {
+          "graded_path": "deliverable_files/a45bc83b-22f9-4def-8d89-9c5661b2b86f/Proposed Architecture Summary.docx",
+          "sha256": "f7e8a7e164c323780fff15b13dbd81f323069c8dcf2e006dc0d38f83f9f9a32d",
+          "size": 16085,
+          "source_path": "deliverable_files/3465484fb6529388b3550e5bd2e6e8f3/Proposed Architecture Summary.docx"
+        }
+      ],
+      "occupation": "Computer and Information Systems Managers",
+      "position": 34,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "a45bc83b-22f9-4def-8d89-9c5661b2b86f"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a10ec48c-168e-476c-8fe3-23b2a5f616ac/Concierge Local Restaurant Recommendations (Sarasota Downtown).docx",
+          "sha256": "65d980063c0c5e6e76784c97d11199264db9b6eba100a609e1917e996acb24f7",
+          "size": 40332,
+          "source_path": "deliverable_files/e23345b712bd1fd17ec14bd10683bc0c/Concierge Local Restaurant Recommendations (Sarasota Downtown).docx"
+        }
+      ],
+      "occupation": "Concierges",
+      "position": 35,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "a10ec48c-168e-476c-8fe3-23b2a5f616ac"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/fccaa4a1-1c39-49ac-b701-55361a19966b/Early Access Statue of Liberty and Ellis Island Tour.pdf",
+          "sha256": "576daced4ddb56f8ec77131cf7fbbfb8abf0f0de97646385c4d911aa6abcbe52",
+          "size": 211598,
+          "source_path": "deliverable_files/c97a5d4dc1120a05d245fdfcfc20a6f4/Early Access Statue of Liberty and Ellis Island Tour.pdf"
+        }
+      ],
+      "occupation": "Concierges",
+      "position": 36,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "fccaa4a1-1c39-49ac-b701-55361a19966b"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/f5d428fd-b38e-41f0-8783-35423dab80f6/Bahamas 7 Day Itinerary.pdf",
+          "sha256": "69f7800268c07c5cc7ea51cc7c16512c20266ca5bf5abd440017d5b6e09bdf2b",
+          "size": 604413,
+          "source_path": "deliverable_files/c41f6861892dd3e8c96e9046908e3c9b/Bahamas 7 Day Itinerary.pdf"
+        }
+      ],
+      "occupation": "Concierges",
+      "position": 37,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "f5d428fd-b38e-41f0-8783-35423dab80f6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/2fa8e956-7b35-4c13-95dc-027f02be318b/Napa Valley Wineries 2025.08.20.docx",
+          "sha256": "fe9d343cda1c68f88444dc9a8f08b67ebcbdbaeaad9ef34c8d0ebf2a4fa6073f",
+          "size": 108790,
+          "source_path": "deliverable_files/b8c566eb4215128bca426ccc2d0bbeec/Napa Valley Wineries 2025.08.20.docx"
+        }
+      ],
+      "occupation": "Concierges",
+      "position": 38,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "2fa8e956-7b35-4c13-95dc-027f02be318b"
+    },
+    {
+      "files": [],
+      "occupation": "Concierges",
+      "position": 39,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "0e4fe8cd-16d0-4f41-8247-6385b4762582"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a0ef404e-82a6-4507-bff1-633d7c8e0004/Rental Opening Guide.docx",
+          "sha256": "6a86bf0e795ebe91261df5e1614b6df90a9edd6df38bb48b82c829bc20bc27fc",
+          "size": 18215,
+          "source_path": "deliverable_files/ee9175a1c0303fca78a095909d7379f7/Rental Opening Guide.docx"
+        }
+      ],
+      "occupation": "Counter and Rental Clerks",
+      "position": 40,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "a0ef404e-82a6-4507-bff1-633d7c8e0004"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/b7a5912e-0e63-41f5-8c22-9cdb8f46ab01/Daily Closed Operational Report June 27, 2025.xlsx",
+          "sha256": "002470f1d5188fffbdcef1405b2ad6acb9f1b3330b8aad530b63b2506a747c5f",
+          "size": 11994,
+          "source_path": "deliverable_files/89792c6994b15e8d8e9980fd2cf17edf/Daily Closed Operational Report June 27, 2025.xlsx"
+        }
+      ],
+      "occupation": "Counter and Rental Clerks",
+      "position": 41,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "b7a5912e-0e63-41f5-8c22-9cdb8f46ab01"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/aa071045-bcb0-4164-bb85-97245d56287e/Service Request Form.docx",
+          "sha256": "9c3c99c93a1e011e737e89913fc2a5ab5010c572d9afcdfcd469fbe4c4e2db90",
+          "size": 16167,
+          "source_path": "deliverable_files/a0a70db75c3807d47bd1c9425f2f6243/Service Request Form.docx"
+        },
+        {
+          "graded_path": "deliverable_files/aa071045-bcb0-4164-bb85-97245d56287e/Damage Revenue Report.xlsx",
+          "sha256": "a4194f6fff1dfaeb662b84da6c1ffe1ba7e4c72d63ea70c31aaddc56a4c96b12",
+          "size": 12425,
+          "source_path": "deliverable_files/194d83cae711d838918ea46e72dc2891/Damage Revenue Report.xlsx"
+        }
+      ],
+      "occupation": "Counter and Rental Clerks",
+      "position": 42,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "aa071045-bcb0-4164-bb85-97245d56287e"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/476db143-163a-4537-9e21-fe46adad703b/September inspections.pdf",
+          "sha256": "8feb5b306d8c42763c2ce9cde7c07f918c5110f72c01f824e2368e912ef441c2",
+          "size": 26949,
+          "source_path": "deliverable_files/e39d845cb95d5819ae3a825a0e7e61b5/September inspections.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/476db143-163a-4537-9e21-fe46adad703b/MO Email 9_23_25.pdf",
+          "sha256": "af04f8be7658e648e6a35448f4eff95370aca28fbcceea254cba540c06585e91",
+          "size": 27225,
+          "source_path": "deliverable_files/efa06e57e4eb0503db7792ad3105e3f8/MO Email 9_23_25.pdf"
+        }
+      ],
+      "occupation": "Counter and Rental Clerks",
+      "position": 43,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "476db143-163a-4537-9e21-fe46adad703b"
+    },
+    {
+      "files": [],
+      "occupation": "Counter and Rental Clerks",
+      "position": 44,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "61f546a8-c374-467f-95cc-d0d9b5656eb6"
+    },
+    {
+      "files": [],
+      "occupation": "Customer Service Representatives",
+      "position": 45,
+      "sector": "Finance and Insurance",
+      "task_id": "f3351922-dbdd-45da-85c5-e7110696bbe5"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/61717508-4df7-41be-bf97-318dfb2475c0/Elder Abuse Addendum.pdf",
+          "sha256": "00bf647e9f9ec1d02803962388832b44f8b205e9d4dca37f622373acf6ecf7c8",
+          "size": 85858,
+          "source_path": "deliverable_files/5bcaceece938f368de33ceea42c63196/Elder Abuse Addendum.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/61717508-4df7-41be-bf97-318dfb2475c0/Elder Abuse Training Deck 4 edits.pdf",
+          "sha256": "e1c4a5ad4fa9abf523ee6c9addd003ff1b2b98f39a685a63a97c89080b2d3530",
+          "size": 227549,
+          "source_path": "deliverable_files/d232faafdd473a3711eaa388527b78ae/Elder Abuse Training Deck 4 edits.pdf"
+        }
+      ],
+      "occupation": "Customer Service Representatives",
+      "position": 46,
+      "sector": "Finance and Insurance",
+      "task_id": "61717508-4df7-41be-bf97-318dfb2475c0"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/0ed38524-a4ad-405f-9dee-7b2252659aad/ECID Constituent Feedback Tracking Log Summary.pdf",
+          "sha256": "b4c2b6e9055170d5c9169771eb0e9cfb6eae5551f6c2f23e695c6bd78346835f",
+          "size": 88391,
+          "source_path": "deliverable_files/85c7e95157271cf2f993137522425327/ECID Constituent Feedback Tracking Log Summary.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/0ed38524-a4ad-405f-9dee-7b2252659aad/Talking Points for Board Meeting.pdf",
+          "sha256": "cb7e34a793f2e981299d3b8900110190d4b8d3f43e5d2b46623b1d8c02728713",
+          "size": 78799,
+          "source_path": "deliverable_files/eb0f34c33939fe1d52e358a1973e4284/Talking Points for Board Meeting.pdf"
+        }
+      ],
+      "occupation": "Customer Service Representatives",
+      "position": 47,
+      "sector": "Finance and Insurance",
+      "task_id": "0ed38524-a4ad-405f-9dee-7b2252659aad"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/87da214f-fd92-4c58-9854-f4d0d10adce0/Policy Reimbursement and Remediation Review.pptx",
+          "sha256": "32527916eb0c1367fdd6281e686380ca6ff33ebe95da252777cbe1b8701edfb3",
+          "size": 56690,
+          "source_path": "deliverable_files/384ebc517b291dbca0fe6e70aa23a596/Policy Reimbursement and Remediation Review.pptx"
+        }
+      ],
+      "occupation": "Customer Service Representatives",
+      "position": 48,
+      "sector": "Finance and Insurance",
+      "task_id": "87da214f-fd92-4c58-9854-f4d0d10adce0"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/d025a41c-c439-4ee1-bc79-dd5c94b27a2d/Case Feedback.docx",
+          "sha256": "b9245b908205a84d4361978b8cab7d38ba44925a3ea1ad5eddf9d1df89d02a10",
+          "size": 1684392,
+          "source_path": "deliverable_files/d2115f14b295e7268e0eade3e25ea7b7/Case Feedback.docx"
+        }
+      ],
+      "occupation": "Customer Service Representatives",
+      "position": 49,
+      "sector": "Finance and Insurance",
+      "task_id": "d025a41c-c439-4ee1-bc79-dd5c94b27a2d"
+    },
+    {
+      "files": [],
+      "occupation": "Editors",
+      "position": 50,
+      "sector": "Information",
+      "task_id": "401a07f1-d57e-4bb0-889b-22de8c900f0e"
+    },
+    {
+      "files": [],
+      "occupation": "Editors",
+      "position": 51,
+      "sector": "Information",
+      "task_id": "afe56d05-dac8-47d7-a233-ad1d035ca5bd"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/9a8c8e28-ce76-408b-83c3-488422892e58/Accessibility multiple choice.pdf",
+          "sha256": "07e652eab99b2267a36b7642306f47142e295bc9f966eda2da62814074c756b8",
+          "size": 80434,
+          "source_path": "deliverable_files/459d7f75be827a7cf8f853d88ecf1008/Accessibility multiple choice.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/9a8c8e28-ce76-408b-83c3-488422892e58/Accessibility editorial checklist.pdf",
+          "sha256": "9a26742a342a0b2113538c578416c9331ee2da67c2da20b55b24e337a770fde8",
+          "size": 30718,
+          "source_path": "deliverable_files/a5e655e03b0399ee1ed833f248939304/Accessibility editorial checklist.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/9a8c8e28-ce76-408b-83c3-488422892e58/New accessibility framework edits.pdf",
+          "sha256": "74a1fb72cbf230c423ee7a5dee0c77bb13d014a88a2ba550223e9b86e7a36846",
+          "size": 284883,
+          "source_path": "deliverable_files/20bbe47834a699188df32f63e9d074e4/New accessibility framework edits.pdf"
+        }
+      ],
+      "occupation": "Editors",
+      "position": 52,
+      "sector": "Information",
+      "task_id": "9a8c8e28-ce76-408b-83c3-488422892e58"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/3a4c347c-4aec-43c7-9a54-eb1f816ab1f9/Asia season proposal.docx",
+          "sha256": "e6b25fa9964d1c86ecc065239c9c694a760593e50095b850e4e5f3932fe39323",
+          "size": 3475737,
+          "source_path": "deliverable_files/515d9b98ace84ac01002bb81ce142b29/Asia season proposal.docx"
+        }
+      ],
+      "occupation": "Editors",
+      "position": 53,
+      "sector": "Information",
+      "task_id": "3a4c347c-4aec-43c7-9a54-eb1f816ab1f9"
+    },
+    {
+      "files": [],
+      "occupation": "Editors",
+      "position": 54,
+      "sector": "Information",
+      "task_id": "ec2fccc9-b7f6-4c73-bf51-896fdb433cec"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/8c8fc328-69fc-4559-a13f-82087baef0a1/Nature Doc Script.docx",
+          "sha256": "1007430d3b9a518360710d9c6604629f90b740c21bd7ffb5804f618851eea4d7",
+          "size": 9399,
+          "source_path": "deliverable_files/21d7da2643438b84a5ba9899288b9222/Nature Doc Script.docx"
+        }
+      ],
+      "occupation": "Film and Video Editors",
+      "position": 55,
+      "sector": "Information",
+      "task_id": "8c8fc328-69fc-4559-a13f-82087baef0a1"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/e222075d-5d62-4757-ae3c-e34b0846583b/GreenEnergy_v1.mp4",
+          "sha256": "89ab071ea316c153199f42a46cbc131b0041676c702b190b24d82646fe9174ac",
+          "size": 20562007,
+          "source_path": "deliverable_files/40ab98f5697683968203582f18879f9c/GreenEnergy_v1.mp4"
+        }
+      ],
+      "occupation": "Film and Video Editors",
+      "position": 56,
+      "sector": "Information",
+      "task_id": "e222075d-5d62-4757-ae3c-e34b0846583b"
+    },
+    {
+      "files": [],
+      "occupation": "Film and Video Editors",
+      "position": 57,
+      "sector": "Information",
+      "task_id": "c94452e4-39cd-4846-b73a-ab75933d1ad7"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/75401f7c-396d-406d-b08e-938874ad1045/Goodsin Studios CG Reel 2025.mp4",
+          "sha256": "13bab806b0c5a1262a051d2412e68ca587e9bf985d191497f32e130da7005b7a",
+          "size": 291593422,
+          "source_path": "deliverable_files/0c74dda7252b33de7c60052d372bf382/Goodsin Studios CG Reel 2025.mp4"
+        }
+      ],
+      "occupation": "Film and Video Editors",
+      "position": 58,
+      "sector": "Information",
+      "task_id": "75401f7c-396d-406d-b08e-938874ad1045"
+    },
+    {
+      "files": [],
+      "occupation": "Film and Video Editors",
+      "position": 59,
+      "sector": "Information",
+      "task_id": "a941b6d8-4289-4500-b45a-f8e4fc94a724"
+    },
+    {
+      "files": [],
+      "occupation": "Financial and Investment Analysts",
+      "position": 60,
+      "sector": "Finance and Insurance",
+      "task_id": "8079e27d-b6f3-4f75-a9b5-db27903c798d"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/e21cd746-404d-4602-b9d2-01d2812c5b87/5. Last Mile Logistics Private Landscape & Public Comps v2.pdf",
+          "sha256": "c0b5738cf8164b5b7cc45832559896a4e4855dc2cdd05e8d6b9522b47a34e0da",
+          "size": 579010,
+          "source_path": "deliverable_files/bb32be3caa9315856ae9e1384d4bb212/5. Last Mile Logistics Private Landscape & Public Comps v2.pdf"
+        }
+      ],
+      "occupation": "Financial and Investment Analysts",
+      "position": 61,
+      "sector": "Finance and Insurance",
+      "task_id": "e21cd746-404d-4602-b9d2-01d2812c5b87"
+    },
+    {
+      "files": [],
+      "occupation": "Financial and Investment Analysts",
+      "position": 62,
+      "sector": "Finance and Insurance",
+      "task_id": "9e8607e7-a38a-491f-ace1-e5ea7dc477cb"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/c7d83f01-2874-4876-b7fd-52582ec99e1a/AmericanOptionPricing.ipynb",
+          "sha256": "af41cc298d30df4c28c02698db0ed8c7daf2aed7f225d32df0beeca112f03b4c",
+          "size": 2285938,
+          "source_path": "deliverable_files/a83d93409a4027b051f985fc561d8b88/AmericanOptionPricing.ipynb"
+        }
+      ],
+      "occupation": "Financial and Investment Analysts",
+      "position": 63,
+      "sector": "Finance and Insurance",
+      "task_id": "c7d83f01-2874-4876-b7fd-52582ec99e1a"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/46b34f78-6c06-4416-87e2-77b6d8b20ce9/Energy Trading and Sales Strategy.docx",
+          "sha256": "9fcffa184e2c0601ef1f4b1759526f2ea413dfb802e68e7294bab3b1b97ce1b0",
+          "size": 4798210,
+          "source_path": "deliverable_files/7b508e9157f9559865da138eb5f4390e/Energy Trading and Sales Strategy.docx"
+        }
+      ],
+      "occupation": "Financial and Investment Analysts",
+      "position": 64,
+      "sector": "Finance and Insurance",
+      "task_id": "46b34f78-6c06-4416-87e2-77b6d8b20ce9"
+    },
+    {
+      "files": [],
+      "occupation": "Financial Managers",
+      "position": 65,
+      "sector": "Finance and Insurance",
+      "task_id": "a1963a68-1bea-4bb1-b7e0-145c92a57449"
+    },
+    {
+      "files": [],
+      "occupation": "Financial Managers",
+      "position": 66,
+      "sector": "Finance and Insurance",
+      "task_id": "5f6c57dd-feb6-4e70-b152-4969d92d1608"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/b39a5aa7-cd1b-47ad-b249-90afd22f8f21/Orchestra_Compensation.xlsx",
+          "sha256": "bd091a7448e27fe1a6f30df78047e4f575071cc8248bbb8b5dba488a2f2a2e51",
+          "size": 158463,
+          "source_path": "deliverable_files/0819aeea5fdeaaf2091688b357cff761/Orchestra_Compensation.xlsx"
+        }
+      ],
+      "occupation": "Financial Managers",
+      "position": 67,
+      "sector": "Finance and Insurance",
+      "task_id": "b39a5aa7-cd1b-47ad-b249-90afd22f8f21"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/b78fd844-db76-448e-a783-5e9877cb74c2/Tiny Rod Hit Inc Report.pdf",
+          "sha256": "35b6df55f51e02b8f02fdb70470d8bf25bd12ab936c0f51be61ddee343a2da75",
+          "size": 210457,
+          "source_path": "deliverable_files/67e6577509223a9f2242939226fa1a63/Tiny Rod Hit Inc Report.pdf"
+        }
+      ],
+      "occupation": "Financial Managers",
+      "position": 68,
+      "sector": "Finance and Insurance",
+      "task_id": "b78fd844-db76-448e-a783-5e9877cb74c2"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/4520f882-715a-482d-8e87-1cb3cbdfe975/Theatre CBA.xlsx",
+          "sha256": "8d9dfbd22649d0174b4cc6c4a8a067f697c69b943167c66ff21f54b3193ac905",
+          "size": 42711,
+          "source_path": "deliverable_files/9b5f97b8e386f6d87dcd42fe683d77b2/Theatre CBA.xlsx"
+        }
+      ],
+      "occupation": "Financial Managers",
+      "position": 69,
+      "sector": "Finance and Insurance",
+      "task_id": "4520f882-715a-482d-8e87-1cb3cbdfe975"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/ec591973-04d5-48c0-981c-1ab2fcec2dc1/Retail Strategy.pptx",
+          "sha256": "b9e12e73f0d87aa0de4a76718a26ff7d7432eab4fdbd880dc6922bcc116f49d3",
+          "size": 53407,
+          "source_path": "deliverable_files/e371a208bb0ebe17c9c8ab3a1a30a691/Retail Strategy.pptx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Non-Retail Sales Workers",
+      "position": 70,
+      "sector": "Wholesale Trade",
+      "task_id": "ec591973-04d5-48c0-981c-1ab2fcec2dc1"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/62f04c2f-e0f7-4710-876c-54ee9c2e8256/Gravon Shoes Exchange Program Overview.docx",
+          "sha256": "1c754c88de5025a393dda564850330acdf52a155979db72be54f25d2437b2a86",
+          "size": 16759,
+          "source_path": "deliverable_files/d82f8978263fceed6548d7d959819846/Gravon Shoes Exchange Program Overview.docx"
+        },
+        {
+          "graded_path": "deliverable_files/62f04c2f-e0f7-4710-876c-54ee9c2e8256/Gravon Exchange Authorization Form.xlsx",
+          "sha256": "10ab7ed1a375f00dfdaeb6280961aaef0e4f0a2525fe91e58bdf347b69d9c093",
+          "size": 11036,
+          "source_path": "deliverable_files/d3108223ed77d7ddc635d7a2752778f3/Gravon Exchange Authorization Form.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Non-Retail Sales Workers",
+      "position": 71,
+      "sector": "Wholesale Trade",
+      "task_id": "62f04c2f-e0f7-4710-876c-54ee9c2e8256"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/3f821c2d-ab97-46ec-a0fb-b8f73c2682bc/Sales & Stock Final.xlsx",
+          "sha256": "49d566c2197d8f8ba4174c76c3c8a878223d1762cb71aa6dc5430745179eb805",
+          "size": 16403,
+          "source_path": "deliverable_files/d2d9e704dd953d634d9b7a420ebf8bb5/Sales & Stock Final.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Non-Retail Sales Workers",
+      "position": 72,
+      "sector": "Wholesale Trade",
+      "task_id": "3f821c2d-ab97-46ec-a0fb-b8f73c2682bc"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/e996036e-8287-4e7f-8d0a-90a57cb53c45/Terms Scenario Planning New CosmoGenics.xlsx",
+          "sha256": "6d4f29f1e50a84306b58691a07f8c37abb8f3c8f94e7031c88e8c7dd8512b07e",
+          "size": 15684,
+          "source_path": "deliverable_files/3faa78107121bc755fec1794fae53597/Terms Scenario Planning New CosmoGenics.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Non-Retail Sales Workers",
+      "position": 73,
+      "sector": "Wholesale Trade",
+      "task_id": "e996036e-8287-4e7f-8d0a-90a57cb53c45"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/327fbc21-7d26-4964-bf7c-f4f41e55c54d/May Sales Plan final.xlsx",
+          "sha256": "d6bed827d09c68271ff15f33b441bb4adfb29efb84f07c7f0128627ab101ecac",
+          "size": 23253,
+          "source_path": "deliverable_files/17f68684cfb4667cf632453eee915ec2/May Sales Plan final.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Non-Retail Sales Workers",
+      "position": 74,
+      "sector": "Wholesale Trade",
+      "task_id": "327fbc21-7d26-4964-bf7c-f4f41e55c54d"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/6dcae3f5-bf1c-48e0-8b4b-23e6486a934c/Chief Key Indicators 5 Year.xlsx",
+          "sha256": "0d588f137d0fa926967a0083993b6afa561ad17df80ce3c61c71c983fc34f4ad",
+          "size": 15215,
+          "source_path": "deliverable_files/d7bf071db041a0e098350b0615c084e2/Chief Key Indicators 5 Year.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/6dcae3f5-bf1c-48e0-8b4b-23e6486a934c/Email to Dr Smith.docx",
+          "sha256": "df7c03f02c9fe7e59410e93cc8817ab5faca2a4e04c9e4022905a2dff4505752",
+          "size": 14539,
+          "source_path": "deliverable_files/8bc94de6fcfdc94b9742ac97da721192/Email to Dr Smith.docx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Office and Administrative Support Workers",
+      "position": 75,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "6dcae3f5-bf1c-48e0-8b4b-23e6486a934c"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/1aecc095-4d76-4b89-b752-1a0f870502cd/Telehealth Roadmap.docx",
+          "sha256": "984f589f348f6ca8c60f56810c598679766d49809632ee52a632555d7f25c60d",
+          "size": 40662,
+          "source_path": "deliverable_files/1cd248b62f18f12ef4f147f273c0e4b6/Telehealth Roadmap.docx"
+        },
+        {
+          "graded_path": "deliverable_files/1aecc095-4d76-4b89-b752-1a0f870502cd/Telehealth Workflow edits.docx",
+          "sha256": "3ad9447842c93a227fc861e180835b3ef143007a3a576e28b0570667bd187be8",
+          "size": 23842,
+          "source_path": "deliverable_files/8b8090b9aff67d466e678832c070337b/Telehealth Workflow edits.docx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Office and Administrative Support Workers",
+      "position": 76,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "1aecc095-4d76-4b89-b752-1a0f870502cd"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/0353ee0c-18b5-4ad3-88e8-e001d223e1d7/Deliverable Veteran PACT Act Comprehensive Guide_Updated.pdf",
+          "sha256": "7ae13791dc0e117e5cfddcd9d0ba0e399c2e6ca9f8281985e34c3c09292140f2",
+          "size": 226660,
+          "source_path": "deliverable_files/80209097200369daa4fc9b9061c2aaa7/Deliverable Veteran PACT Act Comprehensive Guide_Updated.pdf"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Office and Administrative Support Workers",
+      "position": 77,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "0353ee0c-18b5-4ad3-88e8-e001d223e1d7"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/40a8c4b1-b169-4f92-a38b-7f79685037ec/Grand Rounds 2025.xlsx",
+          "sha256": "2dc12c2738d37c79988cf81a8b87c77322dc34067df24c08994239ac678bc539",
+          "size": 18277,
+          "source_path": "deliverable_files/6dda09a9f7c0ba283717cb1cdda34b8e/Grand Rounds 2025.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Office and Administrative Support Workers",
+      "position": 78,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "40a8c4b1-b169-4f92-a38b-7f79685037ec"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/4d1a8410-e9c5-4be5-ab43-cc55563c594c/Interview Day Schedule.docx",
+          "sha256": "8c7a05fc5367b7215437afc63d184f8b9a4d3a213fc0fd506d7cf1ef596fb39b",
+          "size": 25073,
+          "source_path": "deliverable_files/efa3847cea4dbd213add6265920cf28c/Interview Day Schedule.docx"
+        },
+        {
+          "graded_path": "deliverable_files/4d1a8410-e9c5-4be5-ab43-cc55563c594c/Sample Itinerary Group A.docx",
+          "sha256": "60263f81dfbd6454fd470f2f34b9c1cbc46d905a9ba744387cbc05040738fc7b",
+          "size": 1759954,
+          "source_path": "deliverable_files/577c89488638a9ed583effff3ed2f1c7/Sample Itinerary Group A.docx"
+        },
+        {
+          "graded_path": "deliverable_files/4d1a8410-e9c5-4be5-ab43-cc55563c594c/Sample Itinerary Group B.docx",
+          "sha256": "5f738b63580fbff67d44ac8187ad96d8227d8ea3fd062a8744b6ae3b7884726b",
+          "size": 1759587,
+          "source_path": "deliverable_files/7cdcc21a5100e15fcd075c065bb00e62/Sample Itinerary Group B.docx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Office and Administrative Support Workers",
+      "position": 79,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "4d1a8410-e9c5-4be5-ab43-cc55563c594c"
+    },
+    {
+      "files": [],
+      "occupation": "First-Line Supervisors of Police and Detectives",
+      "position": 80,
+      "sector": "Government",
+      "task_id": "8c823e32-537c-42b2-84ba-635d63c2853a"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/eb54f575-93f9-408b-b9e0-f1208a0b6759/PRP.pdf",
+          "sha256": "492ff8d1cde21be220f59f8720b0cdb06702c39cfa22c69bafe6f489e9c783bb",
+          "size": 110300,
+          "source_path": "deliverable_files/d6e4e86d10e35ccc7fbd67589a532cd6/PRP.pdf"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Police and Detectives",
+      "position": 81,
+      "sector": "Government",
+      "task_id": "eb54f575-93f9-408b-b9e0-f1208a0b6759"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/11e1b169-5fb6-4d79-8a83-82ddf4987a85/Legal Definitions - Quick Reference.docx.pdf",
+          "sha256": "500c21ae1e82c93fdeaebee2a9f32c28370c2c95d1eb1a829b9c76230574fd75",
+          "size": 87525,
+          "source_path": "deliverable_files/32c2ab519b7eb91751b147da7ba1e2e7/Legal Definitions - Quick Reference.docx.pdf"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Police and Detectives",
+      "position": 82,
+      "sector": "Government",
+      "task_id": "11e1b169-5fb6-4d79-8a83-82ddf4987a85"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a95a5829-34bb-40f3-993b-558aed6dcdef/training requests final.pdf",
+          "sha256": "6cf787d6dcd3a682569866756551644c2b806f089d19e760e12c4ad2fa1f5a04",
+          "size": 141140,
+          "source_path": "deliverable_files/c487b5a45b1112538090c5a67635cb41/training requests final.pdf"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Police and Detectives",
+      "position": 83,
+      "sector": "Government",
+      "task_id": "a95a5829-34bb-40f3-993b-558aed6dcdef"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/22c0809b-f8db-489e-93b3-b4da225e3e0e/BTAM Intake Form.pdf",
+          "sha256": "d05371d18d6e38c2f31a40a331feba778f25fc0a7a838eecee382818694d73be",
+          "size": 94717,
+          "source_path": "deliverable_files/d605b36f74f5b3cdc47ec598eaef73a6/BTAM Intake Form.pdf"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Police and Detectives",
+      "position": 84,
+      "sector": "Government",
+      "task_id": "22c0809b-f8db-489e-93b3-b4da225e3e0e"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/bf68f2ad-eac5-490a-adec-d847eb45bd6f/Catch up Plan.xlsx",
+          "sha256": "3daff2dc509e6594eb9bc92ee4a01b253f7718bcda75dcbd1979f92de5865387",
+          "size": 10520,
+          "source_path": "deliverable_files/b78b0b979865901e0f43af4c87ba8543/Catch up Plan.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Production and Operating Workers",
+      "position": 85,
+      "sector": "Manufacturing",
+      "task_id": "bf68f2ad-eac5-490a-adec-d847eb45bd6f"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/efca245f-c24f-4f75-a9d5-59201330ab7a/Running Board Recovery Plan Analysis.xlsx",
+          "sha256": "41b32e55f09e9436f431f85b11f35d2d90af75f2390031dff2448278e1695471",
+          "size": 39887,
+          "source_path": "deliverable_files/ee51d59cf26e5fc42c7b2dc30f3415ee/Running Board Recovery Plan Analysis.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Production and Operating Workers",
+      "position": 86,
+      "sector": "Manufacturing",
+      "task_id": "efca245f-c24f-4f75-a9d5-59201330ab7a"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/9e39df84-ac57-4c9b-a2e3-12b8abf2c797/Dashboard Output.xlsx",
+          "sha256": "9d19da89013ed3cb027ba8908fef79f9f4d79522555a9d00a41595e63a85fee3",
+          "size": 631475,
+          "source_path": "deliverable_files/f4d775ed5afd3d1cdfbdcb488fdecb51/Dashboard Output.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Production and Operating Workers",
+      "position": 87,
+      "sector": "Manufacturing",
+      "task_id": "9e39df84-ac57-4c9b-a2e3-12b8abf2c797"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/68d8d901-dd0b-4a7e-bf9a-1074fddf1a96/Plan and Establish.xlsx",
+          "sha256": "1cbe5f548a60e051e3878c5a3641f722c3b3fa9f5546e59add258065422b3981",
+          "size": 13175,
+          "source_path": "deliverable_files/41687fbbea2b90aae14ce5f98d914ac3/Plan and Establish.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Production and Operating Workers",
+      "position": 88,
+      "sector": "Manufacturing",
+      "task_id": "68d8d901-dd0b-4a7e-bf9a-1074fddf1a96"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/1752cb53-5983-46b6-92ee-58ac85a11283/Completed Week One Test Plan.xlsx",
+          "sha256": "17d414f0073661c6d0cc0d5755b8120da7b84a994312b00e8fbe52669799bb9f",
+          "size": 13459,
+          "source_path": "deliverable_files/4568f224b1bae3cb7b15dc2211d6e64e/Completed Week One Test Plan.xlsx"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Production and Operating Workers",
+      "position": 89,
+      "sector": "Manufacturing",
+      "task_id": "1752cb53-5983-46b6-92ee-58ac85a11283"
+    },
+    {
+      "files": [],
+      "occupation": "First-Line Supervisors of Retail Sales Workers",
+      "position": 90,
+      "sector": "Retail Trade",
+      "task_id": "bd72994f-5659-4084-9fab-fc547d1efe3b"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/211d0093-2c64-4bd0-828c-0201f18924e7/Daily Task List.pdf",
+          "sha256": "edb41208a7045af65c7adc7cb4b78fa3e6105b764c28add346926648f7619024",
+          "size": 97935,
+          "source_path": "deliverable_files/b6a975e4e60151aa0dabbd77ba3dba3d/Daily Task List.pdf"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Retail Sales Workers",
+      "position": 91,
+      "sector": "Retail Trade",
+      "task_id": "211d0093-2c64-4bd0-828c-0201f18924e7"
+    },
+    {
+      "files": [],
+      "occupation": "First-Line Supervisors of Retail Sales Workers",
+      "position": 92,
+      "sector": "Retail Trade",
+      "task_id": "d4525420-a427-4ef2-b4e9-2dcc2d31b3b6"
+    },
+    {
+      "files": [],
+      "occupation": "First-Line Supervisors of Retail Sales Workers",
+      "position": 93,
+      "sector": "Retail Trade",
+      "task_id": "45c6237b-f9c9-4526-9a8d-6a5c404624ec"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/cecac8f9-8203-4ebd-ad49-54436a8c4171/Black Friday 2024  V1.3.pdf",
+          "sha256": "7f3aed74574cb84e2e7c19a1274dd8b63e802b66e9e82785158cd886b51debe6",
+          "size": 1171917,
+          "source_path": "deliverable_files/9642c2af9c7d5bc2c3ee36cff96f5834/Black Friday 2024  V1.3.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/cecac8f9-8203-4ebd-ad49-54436a8c4171/Black Friday 8 Week Plan.pdf",
+          "sha256": "04d4286c4859f91212f831279326358d8a53075f1304a473d00124591eb07b17",
+          "size": 72848,
+          "source_path": "deliverable_files/14dd7c998059140e6159fd37a12a0b1c/Black Friday 8 Week Plan.pdf"
+        }
+      ],
+      "occupation": "First-Line Supervisors of Retail Sales Workers",
+      "position": 94,
+      "sector": "Retail Trade",
+      "task_id": "cecac8f9-8203-4ebd-ad49-54436a8c4171"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/8f9e8bcd-6102-40da-ab76-23f51d8b21fa/Overcoming objections.docx",
+          "sha256": "566725b756f82f389662829e3bf0f2ac86510b0916168d3d4f5ad8e98a0c8445",
+          "size": 24349,
+          "source_path": "deliverable_files/a4328e8168601f1fb3e10cd0a25cba98/Overcoming objections.docx"
+        }
+      ],
+      "occupation": "General and Operations Managers",
+      "position": 95,
+      "sector": "Retail Trade",
+      "task_id": "8f9e8bcd-6102-40da-ab76-23f51d8b21fa"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/0fad6023-767b-42c1-a1b3-027cd4f583cb/Meat Seafood FSC POG Template.xlsx",
+          "sha256": "a333bdcbb1ebf938f6781e7ecebbc479f4ad439fb9fe1197feebebed9b9f2b28",
+          "size": 154986,
+          "source_path": "deliverable_files/9aa70fb0cee0241d9d2f556490ca2f20/Meat Seafood FSC POG Template.xlsx"
+        }
+      ],
+      "occupation": "General and Operations Managers",
+      "position": 96,
+      "sector": "Retail Trade",
+      "task_id": "0fad6023-767b-42c1-a1b3-027cd4f583cb"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/02314fc6-a24e-42f4-a8cd-362cae0f0ec1/Safety Checklist.pdf",
+          "sha256": "0ce4df73361ab3bd81e7f1228dfe0390ba8e82b187993267503ba8aa8701981e",
+          "size": 174884,
+          "source_path": "deliverable_files/a6d75782c42e853de257b253aa368f1d/Safety Checklist.pdf"
+        }
+      ],
+      "occupation": "General and Operations Managers",
+      "position": 97,
+      "sector": "Retail Trade",
+      "task_id": "02314fc6-a24e-42f4-a8cd-362cae0f0ec1"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/4d61a19a-8438-4d4c-9fc2-cf167e36dcd6/Promotion Projection Form Template.xlsx",
+          "sha256": "0fb3eabfd941a51ed86a015d2b28cb20beca92991265dee03a6b268431243747",
+          "size": 12082,
+          "source_path": "deliverable_files/fa21f2f41546a65ac1aa188cf1af08d2/Promotion Projection Form Template.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/4d61a19a-8438-4d4c-9fc2-cf167e36dcd6/Promotion Projection Form.pptx",
+          "sha256": "3f32887aef5e4903f9e3c2fdfc378718ac37bb7877781a76fa7c9ee5fe5559ab",
+          "size": 109188,
+          "source_path": "deliverable_files/65324382c425a27cab5c9cdb19992746/Promotion Projection Form.pptx"
+        }
+      ],
+      "occupation": "General and Operations Managers",
+      "position": 98,
+      "sector": "Retail Trade",
+      "task_id": "4d61a19a-8438-4d4c-9fc2-cf167e36dcd6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/6436ff9e-c5f2-47ba-9aaa-49d89b0594ab/Class Evaluation Form New Version.docx",
+          "sha256": "906a6752ff559f179b9e7779a0a8d212ccd9667d50ebd9127d5328c55f97057c",
+          "size": 19492,
+          "source_path": "deliverable_files/5bd633b1a4db19554102d1149b54e289/Class Evaluation Form New Version.docx"
+        }
+      ],
+      "occupation": "General and Operations Managers",
+      "position": 99,
+      "sector": "Retail Trade",
+      "task_id": "6436ff9e-c5f2-47ba-9aaa-49d89b0594ab"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/8a7b6fca-60cc-4ae3-b649-971753cbf8b9/Process Flow Map.pdf",
+          "sha256": "630a75856d347c1cc7fe8c3582e1d2024d72ceb1021806e0c907f6753fdcaefe",
+          "size": 106561,
+          "source_path": "deliverable_files/70fc7c97c4f41c368c2aeb0227a194e0/Process Flow Map.pdf"
+        }
+      ],
+      "occupation": "Industrial Engineers",
+      "position": 100,
+      "sector": "Manufacturing",
+      "task_id": "8a7b6fca-60cc-4ae3-b649-971753cbf8b9"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/40a99a31-42d6-4f23-b3ec-8f591afe25b6/CNC Hardware_Interface_Table.xlsx",
+          "sha256": "c1130c25bb2466ac55c162724663b30358952687493746aad436b3f16af425a2",
+          "size": 8538,
+          "source_path": "deliverable_files/62cfdd8ccb1363882d03e5041df12172/CNC Hardware_Interface_Table.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/40a99a31-42d6-4f23-b3ec-8f591afe25b6/Hardware_Selection_Report.pdf",
+          "sha256": "e0b7be8b57f88c844e86d6aa38a6e2b2e56bc10c92877fbc6b277ef2aa6530c8",
+          "size": 26259,
+          "source_path": "deliverable_files/b184ee1797d7600580f630314a806957/Hardware_Selection_Report.pdf"
+        }
+      ],
+      "occupation": "Industrial Engineers",
+      "position": 101,
+      "sector": "Manufacturing",
+      "task_id": "40a99a31-42d6-4f23-b3ec-8f591afe25b6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/b9665ca1-4da4-4ff9-86f2-40b9a8683048/Safety Circuit.pdf",
+          "sha256": "60ea04d11b122535047cc1af93e6a6bcf0b3ff5bdf1cbbc4dfab16840e5e71bf",
+          "size": 116023,
+          "source_path": "deliverable_files/d1d2ab89fb2ee7c3b6d45d8d2d5c2c20/Safety Circuit.pdf"
+        }
+      ],
+      "occupation": "Industrial Engineers",
+      "position": 102,
+      "sector": "Manufacturing",
+      "task_id": "b9665ca1-4da4-4ff9-86f2-40b9a8683048"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/c6269101-fdc8-4602-b345-eac7597c0c81/Process Capability.pptx",
+          "sha256": "0a59ed83d6c97b7d620e6987fd4a351c285f1db8c7af3d9566c88df3d0d71034",
+          "size": 1564483,
+          "source_path": "deliverable_files/f6ae00cf7fae1e9daae9fea8ca664c82/Process Capability.pptx"
+        }
+      ],
+      "occupation": "Industrial Engineers",
+      "position": 103,
+      "sector": "Manufacturing",
+      "task_id": "c6269101-fdc8-4602-b345-eac7597c0c81"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/be830ca0-b352-4658-a5bd-57139d6780ba/DMAIC - Analyze Tollgate.pptx",
+          "sha256": "58e8b8f956da00063ae7f25def60c9233864e9b70779d71628bd08de9e95b204",
+          "size": 553405,
+          "source_path": "deliverable_files/06f41d86259012529b317196226a5134/DMAIC - Analyze Tollgate.pptx"
+        }
+      ],
+      "occupation": "Industrial Engineers",
+      "position": 104,
+      "sector": "Manufacturing",
+      "task_id": "be830ca0-b352-4658-a5bd-57139d6780ba"
+    },
+    {
+      "files": [],
+      "occupation": "Lawyers",
+      "position": 105,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "cd9efc18-d14a-4f69-8531-5d178a08084d"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a97369c7-e5cf-40ca-99e8-d06f81c57d53/DRAFT Memo Refusal of Velridge Contract.docx",
+          "sha256": "d0094ab105c25741ea226880067cbeb75ee50da228edb6b3ba13696ab6242a5c",
+          "size": 37834,
+          "source_path": "deliverable_files/d0e5f2effc3ccfc122d240d9fc0c1509/DRAFT Memo Refusal of Velridge Contract.docx"
+        }
+      ],
+      "occupation": "Lawyers",
+      "position": 106,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "a97369c7-e5cf-40ca-99e8-d06f81c57d53"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/3f625cb2-f40e-4ead-8a97-6924356d5989/Legal Concerns Regarding VueVid Collection of Child Personal Information.pdf",
+          "sha256": "b789ca5ac86a58e588f8576f49572256d85d9e9377872d59c26ecfa4b913a8b1",
+          "size": 351266,
+          "source_path": "deliverable_files/4f43a27a911c6637b271d040d4d2ca61/Legal Concerns Regarding VueVid Collection of Child Personal Information.pdf"
+        }
+      ],
+      "occupation": "Lawyers",
+      "position": 107,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "3f625cb2-f40e-4ead-8a97-6924356d5989"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/aad21e4c-1d43-45fc-899a-97754a1b1b63/Share Subscription Agreement (Draft).docx",
+          "sha256": "e18c7c1be97296b7fb1d892d9c886ebe683badbf955181bbffe785faae17546e",
+          "size": 55299,
+          "source_path": "deliverable_files/93c40a98ad3dfac6ec95dfdef3b929a4/Share Subscription Agreement (Draft).docx"
+        }
+      ],
+      "occupation": "Lawyers",
+      "position": 108,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "aad21e4c-1d43-45fc-899a-97754a1b1b63"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/8314d1b1-5b0f-42a4-b5d5-91c0867b0913/DRAFT Memo re Clarivon x Luminor Transaction.docx",
+          "sha256": "b241f9b8ecdbd64669c7a970a1d02f2ff0ce9622a8d1046cc93aa30c944151cb",
+          "size": 39945,
+          "source_path": "deliverable_files/7864f3a5d7241cbed2ba372358daf7ca/DRAFT Memo re Clarivon x Luminor Transaction.docx"
+        }
+      ],
+      "occupation": "Lawyers",
+      "position": 109,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "8314d1b1-5b0f-42a4-b5d5-91c0867b0913"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/5e2b6aab-f9fb-4dd6-a1a5-874ef1743909/TOASTY_REVA_STEP_FILES.zip",
+          "sha256": "1d2fa35bacad975c5c4e117fdcd442088e298e556abbdbe6084172a02716bae9",
+          "size": 5764139,
+          "source_path": "deliverable_files/09622063ec31e102d8d3d530e3c009d4/TOASTY_REVA_STEP_FILES.zip"
+        },
+        {
+          "graded_path": "deliverable_files/5e2b6aab-f9fb-4dd6-a1a5-874ef1743909/BACK_CAP_ASSEMBLY_REVA.PDF",
+          "sha256": "eebf0c0d27c59b1eca39dd4b24883ddc838847bb327bc8c34f6cd6b193a09b46",
+          "size": 59673,
+          "source_path": "deliverable_files/ca5bb1f1db6f9c0ebd64e5b0c61cec3c/BACK_CAP_ASSEMBLY_REVA.PDF"
+        },
+        {
+          "graded_path": "deliverable_files/5e2b6aab-f9fb-4dd6-a1a5-874ef1743909/BODY_ASSEMBLY_REVA.PDF",
+          "sha256": "374c838b5ff1b21dc28d4f96400a11695a6500ca7c29955f7c7eb2d7d733ebfd",
+          "size": 95982,
+          "source_path": "deliverable_files/3fe7d48c50e2374b305ad207923b9b2b/BODY_ASSEMBLY_REVA.PDF"
+        },
+        {
+          "graded_path": "deliverable_files/5e2b6aab-f9fb-4dd6-a1a5-874ef1743909/MAIN_ASSEMBLY_REVA.PDF",
+          "sha256": "d0eb07d1f970a1c8eab2f400b75ff93ba54abc5e17803d9c5273ffd8ceebf4cf",
+          "size": 124849,
+          "source_path": "deliverable_files/04ba8d52ca69879dba3b96ad248faff7/MAIN_ASSEMBLY_REVA.PDF"
+        }
+      ],
+      "occupation": "Mechanical Engineers",
+      "position": 110,
+      "sector": "Manufacturing",
+      "task_id": "5e2b6aab-f9fb-4dd6-a1a5-874ef1743909"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/46fc494e-a24f-45ce-b099-851d5c181fd4/HeatConduction.py",
+          "sha256": "78356d1c9e456ec25cb66687787ae8c29202c6d4df17664212f65cb115da8e41",
+          "size": 5339,
+          "source_path": "deliverable_files/6cfcde5e9a28cf9b4a3ad1172cd44dc3/HeatConduction.py"
+        },
+        {
+          "graded_path": "deliverable_files/46fc494e-a24f-45ce-b099-851d5c181fd4/isotherms_20min.png",
+          "sha256": "67edd93579d3899c62e19b09f3780677c26d7f4effaa50ad705b9595477f4fff",
+          "size": 158985,
+          "source_path": "deliverable_files/402007df7912b438b018890709141f69/isotherms_20min.png"
+        },
+        {
+          "graded_path": "deliverable_files/46fc494e-a24f-45ce-b099-851d5c181fd4/profiles_by_time.png",
+          "sha256": "63056ec3fd4c027817e07877311e94ae9648d3c15291ecbf10678d694bbb4d9f",
+          "size": 195961,
+          "source_path": "deliverable_files/11aff9cb872599611b6a7c4b7822cef1/profiles_by_time.png"
+        },
+        {
+          "graded_path": "deliverable_files/46fc494e-a24f-45ce-b099-851d5c181fd4/time_traces.png",
+          "sha256": "7af42b8faf0feaf9cd722d155a4a34e37382d24af97ffae9d2b34ae60e32b496",
+          "size": 82443,
+          "source_path": "deliverable_files/d5d75c882eb5648ffb9e65b46367595b/time_traces.png"
+        },
+        {
+          "graded_path": "deliverable_files/46fc494e-a24f-45ce-b099-851d5c181fd4/Material analysis Report.pdf",
+          "sha256": "a8e39bc1f8c1bb7fb69c62f71f69f68483185e8e78929b978d373f923b1667fc",
+          "size": 570967,
+          "source_path": "deliverable_files/2a4701bcd9b43aed86f0cf05be92af2e/Material analysis Report.pdf"
+        }
+      ],
+      "occupation": "Mechanical Engineers",
+      "position": 111,
+      "sector": "Manufacturing",
+      "task_id": "46fc494e-a24f-45ce-b099-851d5c181fd4"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/3940b7e7-ec4f-4cea-8097-3ab4cfdcaaa6/X Wing Analysis Report Draft.pdf",
+          "sha256": "a9f301c1251458d04391df6259b424ed2f82d1854a96447fd65503f2cff04bb9",
+          "size": 113661,
+          "source_path": "deliverable_files/b1c51dd3b49da8791d6b86f473c717fe/X Wing Analysis Report Draft.pdf"
+        }
+      ],
+      "occupation": "Mechanical Engineers",
+      "position": 112,
+      "sector": "Manufacturing",
+      "task_id": "3940b7e7-ec4f-4cea-8097-3ab4cfdcaaa6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/8077e700-2b31-402d-bd09-df4d33c39653/Results Memo v2.pdf",
+          "sha256": "36069a50070dc57ea2511325fc40838da9847494ed1101f961657f3460e29a5d",
+          "size": 756147,
+          "source_path": "deliverable_files/8730029bcf4ef13ecc55acc3db64e878/Results Memo v2.pdf"
+        }
+      ],
+      "occupation": "Mechanical Engineers",
+      "position": 113,
+      "sector": "Manufacturing",
+      "task_id": "8077e700-2b31-402d-bd09-df4d33c39653"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/5a2d70da-0a42-4a6b-a3ca-763e03f070a5/Cover Plate Manufacturing Steps.xlsx",
+          "sha256": "f789610a8c1b7b0595fd058f2210dfc705f4e72fa61f8f5ca24576bbeeed8f5d",
+          "size": 10372,
+          "source_path": "deliverable_files/31de3a7c865a66db5258079dcaef55ba/Cover Plate Manufacturing Steps.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/5a2d70da-0a42-4a6b-a3ca-763e03f070a5/Master Tool List.xlsx",
+          "sha256": "c7d83e832e653950fc162d6baf9421123e35b06e70dbeb0212470d520ee80f3b",
+          "size": 12029,
+          "source_path": "deliverable_files/3187dc03f3f0d4771da5ac90affa2ef4/Master Tool List.xlsx"
+        }
+      ],
+      "occupation": "Mechanical Engineers",
+      "position": 114,
+      "sector": "Manufacturing",
+      "task_id": "5a2d70da-0a42-4a6b-a3ca-763e03f070a5"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/74d6e8b0-f334-4e7e-af55-c095d5d4d1a6/HT prescribing guidelines.docx",
+          "sha256": "2c2f4d086161932d2fa9c0c03e38de377035641ceb15f4899d2d1bebea25e295",
+          "size": 4148919,
+          "source_path": "deliverable_files/7828a76921eedf16b1a1a367ae9b1efe/HT prescribing guidelines.docx"
+        }
+      ],
+      "occupation": "Medical and Health Services Managers",
+      "position": 115,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "74d6e8b0-f334-4e7e-af55-c095d5d4d1a6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/81db15ff-ceea-4f63-a1cd-06dc88114709/NP vs PA Allowances by State Final-2.xlsx",
+          "sha256": "55d6eb76f03aeaae8867ab6e9d306a2e31b70dd6205104445fd1abe5e569ede8",
+          "size": 6633,
+          "source_path": "deliverable_files/e24738c64e92895fe17ffaf589c82df2/NP vs PA Allowances by State Final-2.xlsx"
+        }
+      ],
+      "occupation": "Medical and Health Services Managers",
+      "position": 116,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "81db15ff-ceea-4f63-a1cd-06dc88114709"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/61b0946a-5c1c-4bf6-8607-84d7c7e0dfe0/Collaborative Cadaver Program Proposal.docx",
+          "sha256": "99ed4e0e39b7a1ab3b34d5e525bf1e899153080ed5ad7c9f5609248d3e4163b3",
+          "size": 599398,
+          "source_path": "deliverable_files/958655d3fbec4aa795d8f0d4c7ad4725/Collaborative Cadaver Program Proposal.docx"
+        }
+      ],
+      "occupation": "Medical and Health Services Managers",
+      "position": 117,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "61b0946a-5c1c-4bf6-8607-84d7c7e0dfe0"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/61e7b9c6-0051-429f-a341-fda9b6578a84/Menopause Formulary.xlsx",
+          "sha256": "4723dc09306df798fba95a9e35cbce5929675b47b65f35492f19d6366497150f",
+          "size": 12558,
+          "source_path": "deliverable_files/12c2c91164468f32714f9a66116f1ba2/Menopause Formulary.xlsx"
+        }
+      ],
+      "occupation": "Medical and Health Services Managers",
+      "position": 118,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "61e7b9c6-0051-429f-a341-fda9b6578a84"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/c9bf9801-9640-45fa-8166-1ab01f2d98e4/OIIDP Mentor Matching Application.docx",
+          "sha256": "3ddd35948c028677786a1fa195f6c21fe46167f3abbfd162128b8fb755d35aab",
+          "size": 20369,
+          "source_path": "deliverable_files/f34eb607b3b122b191f3d203d8ef0b9d/OIIDP Mentor Matching Application.docx"
+        },
+        {
+          "graded_path": "deliverable_files/c9bf9801-9640-45fa-8166-1ab01f2d98e4/OIIDP Mentee Application.docx",
+          "sha256": "206bd1803fb962870cf6e32571530083970d5f8f589da7b31b3b1c5ded41d20b",
+          "size": 21118,
+          "source_path": "deliverable_files/5484750650ea65ee6ed0eeca7bd455d2/OIIDP Mentee Application.docx"
+        },
+        {
+          "graded_path": "deliverable_files/c9bf9801-9640-45fa-8166-1ab01f2d98e4/OIIDP MENTORSHIP PROGRAM ROADMAP_scrubbed.pdf",
+          "sha256": "e94f0899e80243a28b74ed79b78bbec9f257065f4b1c040a8f1793bd4f18c1c5",
+          "size": 669876,
+          "source_path": "deliverable_files/c05b7921ca47309c752dad30ad29453d/OIIDP MENTORSHIP PROGRAM ROADMAP_scrubbed.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/c9bf9801-9640-45fa-8166-1ab01f2d98e4/OIIDP Mentorship Program Guide_FINAL.docx",
+          "sha256": "0f67733adadf9feb214ae5b2f2cd0a034dc0cc25958115ac951290594ba1f119",
+          "size": 80508,
+          "source_path": "deliverable_files/fbdf33dc6edc3ffabeb74e7e952fa051/OIIDP Mentorship Program Guide_FINAL.docx"
+        }
+      ],
+      "occupation": "Medical and Health Services Managers",
+      "position": 119,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "c9bf9801-9640-45fa-8166-1ab01f2d98e4"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/f1be6436-ffff-4fee-9e66-d550291a1735/2026 APC IMM Estimated Costs.docx",
+          "sha256": "965b9a06d81a45e948df228b775e838873d29eb39648ab0a88501fd4eb0c0c5f",
+          "size": 1011943,
+          "source_path": "deliverable_files/d459e5e375b931dc6d877267fc409367/2026 APC IMM Estimated Costs.docx"
+        }
+      ],
+      "occupation": "Medical Secretaries and Administrative Assistants",
+      "position": 120,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "f1be6436-ffff-4fee-9e66-d550291a1735"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/41f6ef59-88c9-4b2c-bcc7-9ceb88422f48/June 2025 Declined Payments Outreach.xlsx",
+          "sha256": "ba739ec799712032e9b5150d924623c16a00e5c114b19aaa10979eda4d95efea",
+          "size": 7687,
+          "source_path": "deliverable_files/3be03420df1df1b8c70b71b995a15a62/June 2025 Declined Payments Outreach.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/41f6ef59-88c9-4b2c-bcc7-9ceb88422f48/Declined Payments Email Macro.docx",
+          "sha256": "fc948918074c2506271e393a764e5af786f84ea9f6c11a5f6d54045614f3929d",
+          "size": 7960,
+          "source_path": "deliverable_files/4dc180bb0c44ae702492685284382317/Declined Payments Email Macro.docx"
+        }
+      ],
+      "occupation": "Medical Secretaries and Administrative Assistants",
+      "position": 121,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "41f6ef59-88c9-4b2c-bcc7-9ceb88422f48"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a0552909-bc66-4a3a-8970-ee0d17b49718/Bulk Form - Arizona Pathology.xlsx",
+          "sha256": "30a491e7105233bb0cf9232f12852682d24b89d23f54b4dfe1d4a15faaf020d0",
+          "size": 57517,
+          "source_path": "deliverable_files/850ae12fcc77657116e7379e394f029f/Bulk Form - Arizona Pathology.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/a0552909-bc66-4a3a-8970-ee0d17b49718/Bulk Form - Canyon Pathology .xlsx",
+          "sha256": "adec2dc4ec711d9c317e2481738f76db4fd85e35be6d6be8c77099fb6d5cc13a",
+          "size": 57591,
+          "source_path": "deliverable_files/1289cde2fc8a6d16e8e29f15c9a5bac1/Bulk Form - Canyon Pathology .xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/a0552909-bc66-4a3a-8970-ee0d17b49718/Email Template Arizona Pathology.docx",
+          "sha256": "f19d8392f32f64f5d0e330c1e55458b9caea2abcb8b293d9d8a4d5f900113f4a",
+          "size": 7999,
+          "source_path": "deliverable_files/be6394e47b518854202cc9086ffafc3a/Email Template Arizona Pathology.docx"
+        },
+        {
+          "graded_path": "deliverable_files/a0552909-bc66-4a3a-8970-ee0d17b49718/Email Template Canyon Pathology.docx",
+          "sha256": "1f074f35b9f6ea23f655a0c0229e8a065115de166bf5caa61689ef0bb5b4a619",
+          "size": 7998,
+          "source_path": "deliverable_files/20eba705de40cfdee24852f15002c4eb/Email Template Canyon Pathology.docx"
+        },
+        {
+          "graded_path": "deliverable_files/a0552909-bc66-4a3a-8970-ee0d17b49718/Email Template Minnesota Pathology.docx",
+          "sha256": "9f03af7b74326844ec3718b61099ce267887c36a562eba202b80ffdf1e7dacf9",
+          "size": 14887,
+          "source_path": "deliverable_files/97bb5fcc33a4dd9caa7b5104c9d66be8/Email Template Minnesota Pathology.docx"
+        },
+        {
+          "graded_path": "deliverable_files/a0552909-bc66-4a3a-8970-ee0d17b49718/Bulk Form - Minnesota Pathology.xlsx",
+          "sha256": "7feb38855ecdfd7bc9a108ee350fe6629f418e186b47e44744230852d669fdc3",
+          "size": 57357,
+          "source_path": "deliverable_files/2d1e22e8f727833fd2993f8e12cb8fcc/Bulk Form - Minnesota Pathology.xlsx"
+        }
+      ],
+      "occupation": "Medical Secretaries and Administrative Assistants",
+      "position": 122,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "a0552909-bc66-4a3a-8970-ee0d17b49718"
+    },
+    {
+      "files": [],
+      "occupation": "Medical Secretaries and Administrative Assistants",
+      "position": 123,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "6d2c8e55-fe20-45c6-bdaf-93e676868503"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/4b98ccce-9e42-44e9-9115-6fc3e79de288/GENERAL CORRESPONDENCE 2025.pdf",
+          "sha256": "c016ad5469e7cfe21b3a635a1b0757a0914a6a37c4c01ffd63760a85c4fc5a4f",
+          "size": 6357044,
+          "source_path": "deliverable_files/f9fd38b1f4d32a70a75f8ca9f61aea0d/GENERAL CORRESPONDENCE 2025.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/4b98ccce-9e42-44e9-9115-6fc3e79de288/DECEASED CORRESPONDENCE 2025.pdf",
+          "sha256": "6a8b5f655ea2bd979be88fd3b0ef7e19e1ee805ad65a367297f6f16c407b6590",
+          "size": 7736387,
+          "source_path": "deliverable_files/a7c914e7812ee42a6c9a4bce02741c79/DECEASED CORRESPONDENCE 2025.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/4b98ccce-9e42-44e9-9115-6fc3e79de288/PATIENT INCIDENT 007.xlsx",
+          "sha256": "ac7d5ffacc6a4914646b03eddae586afef01a728f125a69f9316996344852dfe",
+          "size": 39114,
+          "source_path": "deliverable_files/924568d2d35cdb5436bc63782f4db02a/PATIENT INCIDENT 007.xlsx"
+        }
+      ],
+      "occupation": "Medical Secretaries and Administrative Assistants",
+      "position": 124,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "4b98ccce-9e42-44e9-9115-6fc3e79de288"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/60221cd0-686e-4a08-985e-d9bb2fa18501/The Race for Virginia_2025 Elections edits.pdf",
+          "sha256": "00304a4a0fdbcfea77540ebd835a7ab089f59f76bd6d158af27d0650788ac469",
+          "size": 182081,
+          "source_path": "deliverable_files/1ecbc34c24e906f8d12597616ad75c73/The Race for Virginia_2025 Elections edits.pdf"
+        }
+      ],
+      "occupation": "News Analysts, Reporters, and Journalists",
+      "position": 125,
+      "sector": "Information",
+      "task_id": "60221cd0-686e-4a08-985e-d9bb2fa18501"
+    },
+    {
+      "files": [],
+      "occupation": "News Analysts, Reporters, and Journalists",
+      "position": 126,
+      "sector": "Information",
+      "task_id": "ef8719da-18e5-4bfe-b986-399652d77376"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/3baa0009-5a60-4ae8-ae99-4955cb328ff3/World Bank Report Trade Wars.pdf",
+          "sha256": "bd3449db4cf8bd239c06db1d7f0eb59fd81cb0728164df6a7572aa2453d5afe1",
+          "size": 56740,
+          "source_path": "deliverable_files/8b8754856ff146e42955c926bdd592ea/World Bank Report Trade Wars.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/3baa0009-5a60-4ae8-ae99-4955cb328ff3/Global Growth chart.jpg",
+          "sha256": "262a98290698a442af25ea11a28566db0f93f0c98420a0c3c3a4d235b5db3a1a",
+          "size": 38308,
+          "source_path": "deliverable_files/ac6504e48d351374347c8fcbdc7fefed/Global Growth chart.jpg"
+        }
+      ],
+      "occupation": "News Analysts, Reporters, and Journalists",
+      "position": 127,
+      "sector": "Information",
+      "task_id": "3baa0009-5a60-4ae8-ae99-4955cb328ff3"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/5d0feb24-e8b6-4ace-b64f-d5cd1a8b563d/TRAPPIST-1 Reporter Draft AstronomyNews Edit.docx",
+          "sha256": "d92f22a2541e898300dd6f804ca0adf495bd4fc2280bdfd7d5f3268729837e76",
+          "size": 1930400,
+          "source_path": "deliverable_files/5e1121532acffdb3bee156dcf8ae66d9/TRAPPIST-1 Reporter Draft AstronomyNews Edit.docx"
+        }
+      ],
+      "occupation": "News Analysts, Reporters, and Journalists",
+      "position": 128,
+      "sector": "Information",
+      "task_id": "5d0feb24-e8b6-4ace-b64f-d5cd1a8b563d"
+    },
+    {
+      "files": [],
+      "occupation": "News Analysts, Reporters, and Journalists",
+      "position": 129,
+      "sector": "Information",
+      "task_id": "6974adea-8326-43fa-8187-2724b15d9546"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/1a78e076-445e-4c5d-b8ce-387d2fe5e715/Hypertension Adherence Lit Review.docx",
+          "sha256": "d9ad3d84cf882cb5361c5c81b3eb30b3b973aab39b430db66e351e0ea5050c8a",
+          "size": 29532,
+          "source_path": "deliverable_files/de16da28548a80fcc61eeb99c3bf0d41/Hypertension Adherence Lit Review.docx"
+        }
+      ],
+      "occupation": "Nurse Practitioners",
+      "position": 130,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "1a78e076-445e-4c5d-b8ce-387d2fe5e715"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/1b9ec237-bf9c-41f9-8fa9-0e685fcd93c6/HypertensionPPT.pptx",
+          "sha256": "9b56af79adfeba759bd6ca3f09c002244705be6e45fe42c2df087337aad1b604",
+          "size": 277717,
+          "source_path": "deliverable_files/77651e16cbced3af755097554a1efea4/HypertensionPPT.pptx"
+        }
+      ],
+      "occupation": "Nurse Practitioners",
+      "position": 131,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "1b9ec237-bf9c-41f9-8fa9-0e685fcd93c6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/0112fc9b-c3b2-4084-8993-5a4abb1f54f1/mTBI SOAP.pdf",
+          "sha256": "3730e117c5bbfb8b528ef75b72c27b6159bb2b63e414cdacc09751539c64ce44",
+          "size": 66431,
+          "source_path": "deliverable_files/3917a453dd26addb79ab9ab4b4dbb61c/mTBI SOAP.pdf"
+        }
+      ],
+      "occupation": "Nurse Practitioners",
+      "position": 132,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "0112fc9b-c3b2-4084-8993-5a4abb1f54f1"
+    },
+    {
+      "files": [],
+      "occupation": "Nurse Practitioners",
+      "position": 133,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "772e7524-174e-4c88-957e-6e510b61ea69"
+    },
+    {
+      "files": [],
+      "occupation": "Nurse Practitioners",
+      "position": 134,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "e6429658-4de1-42dd-a9e0-2d2b9b02fb10"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/b5d2e6f1-62a2-433a-bcdd-95b260cdd860/Weekly Sales Analysis.xlsx",
+          "sha256": "d8c0f1f878821963ffb484ff498e3666197173729b70824e86b6bc604cd15397",
+          "size": 184137,
+          "source_path": "deliverable_files/e46041236899c7000dcc7f5b077f3f45/Weekly Sales Analysis.xlsx"
+        }
+      ],
+      "occupation": "Order Clerks",
+      "position": 135,
+      "sector": "Wholesale Trade",
+      "task_id": "b5d2e6f1-62a2-433a-bcdd-95b260cdd860"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/f841ddcf-2a28-4f6d-bac3-61b607219d3e/PO Log June Ships.xlsx",
+          "sha256": "4c95ec1a6888511f797949f2411a8256497db6aff48720135c048372812244f4",
+          "size": 30422,
+          "source_path": "deliverable_files/c714d6cb96250c998b837456f85d3cbd/PO Log June Ships.xlsx"
+        }
+      ],
+      "occupation": "Order Clerks",
+      "position": 136,
+      "sector": "Wholesale Trade",
+      "task_id": "f841ddcf-2a28-4f6d-bac3-61b607219d3e"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/47ef842d-8eac-4b90-bda8-dd934c228c96/Inventory final.xlsx",
+          "sha256": "9bc65d11c56e3c15a38a2b162a16313a7237d4864d0e5e27e61b4aa4cf123435",
+          "size": 16185,
+          "source_path": "deliverable_files/8db57d453a6fc40a570ee3407574a166/Inventory final.xlsx"
+        }
+      ],
+      "occupation": "Order Clerks",
+      "position": 137,
+      "sector": "Wholesale Trade",
+      "task_id": "47ef842d-8eac-4b90-bda8-dd934c228c96"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/1137e2bb-bdf9-4876-b572-f29b7de5e595/Deliverable PO Entry audit.docx",
+          "sha256": "002e62a5d58aa419ce9ad4fa0688100cb5699da85a0c4e910f276cad6bd65c3e",
+          "size": 13553,
+          "source_path": "deliverable_files/623c69c77da33e6563ce0a1c9b0c3952/Deliverable PO Entry audit.docx"
+        },
+        {
+          "graded_path": "deliverable_files/1137e2bb-bdf9-4876-b572-f29b7de5e595/PO_Order_Entry_Audit.xlsx",
+          "sha256": "2239d1e20a2ba14da07f35a45950467bdd099c8ae465fdb105e44ca318df4070",
+          "size": 2677787,
+          "source_path": "deliverable_files/c6ee73c5c0f66f8d25be3dde7af03d7e/PO_Order_Entry_Audit.xlsx"
+        }
+      ],
+      "occupation": "Order Clerks",
+      "position": 138,
+      "sector": "Wholesale Trade",
+      "task_id": "1137e2bb-bdf9-4876-b572-f29b7de5e595"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/c3525d4d-2012-45df-853e-2d2a0e902991/Deliverable Holiday Floorstand Budget.xlsx",
+          "sha256": "69b5d5e5b9db1e8d7e4a7dbd9eb59c9c1c91aeee908bcd66758900c7f0dc647c",
+          "size": 34026,
+          "source_path": "deliverable_files/242d24d95a28c9597ff7ddff19d31e6a/Deliverable Holiday Floorstand Budget.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/c3525d4d-2012-45df-853e-2d2a0e902991/Final Email Deliverable.docx",
+          "sha256": "6a00a219e7ca2bdfb681d2e9b25a62059723c161551f4a2c4417dd442c10e683",
+          "size": 15031,
+          "source_path": "deliverable_files/3dcb8a9db76ff416cf0c731cd312d910/Final Email Deliverable.docx"
+        }
+      ],
+      "occupation": "Order Clerks",
+      "position": 139,
+      "sector": "Wholesale Trade",
+      "task_id": "c3525d4d-2012-45df-853e-2d2a0e902991"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/9a0d8d36-6233-4c76-9107-0d1f783c7340/Incentive and Non Qualified Stock Options.pptx",
+          "sha256": "fcf4845102506b1c63040abb2c9901e0fa3f3be3fa99972b9aa98d2614eb21d2",
+          "size": 57471,
+          "source_path": "deliverable_files/2371898511a24206139713c91ca4ab68/Incentive and Non Qualified Stock Options.pptx"
+        }
+      ],
+      "occupation": "Personal Financial Advisors",
+      "position": 140,
+      "sector": "Finance and Insurance",
+      "task_id": "9a0d8d36-6233-4c76-9107-0d1f783c7340"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/664a42e5-3240-413a-9a57-ea93c6303269/ILIT Crummey Powers Time Cycle Implementaton Considerations.pptx",
+          "sha256": "73de9cf0f7e61cb7408f4ebd3635471c8a24fcac22b94f5e7ae7e8e9ef27ef09",
+          "size": 63814,
+          "source_path": "deliverable_files/00d22c733e6d49d58f5b8e84085f3229/ILIT Crummey Powers Time Cycle Implementaton Considerations.pptx"
+        }
+      ],
+      "occupation": "Personal Financial Advisors",
+      "position": 141,
+      "sector": "Finance and Insurance",
+      "task_id": "664a42e5-3240-413a-9a57-ea93c6303269"
+    },
+    {
+      "files": [],
+      "occupation": "Personal Financial Advisors",
+      "position": 142,
+      "sector": "Finance and Insurance",
+      "task_id": "feb5eefc-39f1-4451-9ef9-bffe011b71dd"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/3600de06-3f71-4e48-9480-e4828c579924/CD vs VA Presentation.pptx",
+          "sha256": "48b8d2d93271d75867bf4e2d4943d3efcfcda75738fce5f9e8850c0c271b55b2",
+          "size": 89188,
+          "source_path": "deliverable_files/4d0e0ac481cf4f546c48e748ebe99a47/CD vs VA Presentation.pptx"
+        }
+      ],
+      "occupation": "Personal Financial Advisors",
+      "position": 143,
+      "sector": "Finance and Insurance",
+      "task_id": "3600de06-3f71-4e48-9480-e4828c579924"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/c657103b-b348-4496-a848-b2b7165d28b2/Roth Conversion Strategy.pptx",
+          "sha256": "f566577f8028dd9cb64ef5a695f724ef73cdf63c9ec1ee8bf98e80bbcb378102",
+          "size": 3169178,
+          "source_path": "deliverable_files/bb3b08ffcdf1fd3138ca472ac54c28a3/Roth Conversion Strategy.pptx"
+        },
+        {
+          "graded_path": "deliverable_files/c657103b-b348-4496-a848-b2b7165d28b2/Roth Conversion Comparison (RMD updated).xlsx",
+          "sha256": "5790bf602b8131346821875e41658c7ce3328898a399a311d3131ed4ef7eccb8",
+          "size": 22882,
+          "source_path": "deliverable_files/4a0c1b11e62b0fbebb641f02bd9f32af/Roth Conversion Comparison (RMD updated).xlsx"
+        }
+      ],
+      "occupation": "Personal Financial Advisors",
+      "position": 144,
+      "sector": "Finance and Insurance",
+      "task_id": "c657103b-b348-4496-a848-b2b7165d28b2"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/ae0c1093-5ea8-4b84-a81e-53ebf7a4321d/Undercover Observation Form.pdf",
+          "sha256": "790253d286c1e4186d3b36dda39ae7eb37bbc1e6eda8551f38e5f6abdbada2b8",
+          "size": 3911,
+          "source_path": "deliverable_files/d2e6a2197683d38be521fde9f1195aef/Undercover Observation Form.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/ae0c1093-5ea8-4b84-a81e-53ebf7a4321d/Undercover Operations Guide Employee Evaluation.pdf",
+          "sha256": "369854616cced28a661e9eb341ee1058e6e7c79d16f62fdbd1b0225826af17be",
+          "size": 6816,
+          "source_path": "deliverable_files/77ab53fbfc634a71743c8945bfd40498/Undercover Operations Guide Employee Evaluation.pdf"
+        }
+      ],
+      "occupation": "Private Detectives and Investigators",
+      "position": 145,
+      "sector": "Retail Trade",
+      "task_id": "ae0c1093-5ea8-4b84-a81e-53ebf7a4321d"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/f9f82549-fdde-4462-aff8-e70fba5b8c66/Loss Prevention Incident Flowchart.pdf",
+          "sha256": "9a112d07bc95930ccd2ed45735ad8c4d3fcb6f2a0fe80f19529246d5212ea114",
+          "size": 165011,
+          "source_path": "deliverable_files/ba6386b4f71a75b0a93baf66bdbbea85/Loss Prevention Incident Flowchart.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/f9f82549-fdde-4462-aff8-e70fba5b8c66/Missing Bank Deposits Investigation.pdf",
+          "sha256": "4898f4f23e927f44ed0a0ed96a71bfe03d825cacb43913ecc18e9134fc7e010e",
+          "size": 38835,
+          "source_path": "deliverable_files/1faa73fe07d5ea5add08a3016fda4773/Missing Bank Deposits Investigation.pdf"
+        }
+      ],
+      "occupation": "Private Detectives and Investigators",
+      "position": 146,
+      "sector": "Retail Trade",
+      "task_id": "f9f82549-fdde-4462-aff8-e70fba5b8c66"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/57b2cdf2-ad62-4591-aa91-aad489740320/Supervisor report E.pdf",
+          "sha256": "adc871b94333bb25007cf093deae6e8d928b2d741e4ad3eb42a7472c378042f5",
+          "size": 38482,
+          "source_path": "deliverable_files/c79950996299c02fd3874c73d2f1200c/Supervisor report E.pdf"
+        }
+      ],
+      "occupation": "Private Detectives and Investigators",
+      "position": 147,
+      "sector": "Retail Trade",
+      "task_id": "57b2cdf2-ad62-4591-aa91-aad489740320"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/84322284-5c2c-4873-b507-b147449d209d/Official weekly report.pdf",
+          "sha256": "13b97a5136224857b1e5795fa4b0630de162b12c0aba8712f8917c577d1778b6",
+          "size": 265411,
+          "source_path": "deliverable_files/1930843448a1b6bf56c542294bf4adb1/Official weekly report.pdf"
+        }
+      ],
+      "occupation": "Private Detectives and Investigators",
+      "position": 148,
+      "sector": "Retail Trade",
+      "task_id": "84322284-5c2c-4873-b507-b147449d209d"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a46d5cd2-55fe-48fa-a4c6-6aaf6b9991b5/Supervisor_report.pdf",
+          "sha256": "99d596a62512edbe6ae5bbef113d99f4b841bd4d10820a5ff4ea3efb5c436322",
+          "size": 500949,
+          "source_path": "deliverable_files/10a37e57e35f2108b159d5c5ddf6f89a/Supervisor_report.pdf"
+        }
+      ],
+      "occupation": "Private Detectives and Investigators",
+      "position": 149,
+      "sector": "Retail Trade",
+      "task_id": "a46d5cd2-55fe-48fa-a4c6-6aaf6b9991b5"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/6241e678-4ba3-4831-b3c7-78412697febc/Final Production Schedule.pdf",
+          "sha256": "29f006a9480d62943cd263b45a93694f48fef7cf3975558b240a6b15d3ec1844",
+          "size": 42992,
+          "source_path": "deliverable_files/a254d7ac6b7d38735dab576dcb96e37f/Final Production Schedule.pdf"
+        }
+      ],
+      "occupation": "Producers and Directors",
+      "position": 150,
+      "sector": "Information",
+      "task_id": "6241e678-4ba3-4831-b3c7-78412697febc"
+    },
+    {
+      "files": [],
+      "occupation": "Producers and Directors",
+      "position": 151,
+      "sector": "Information",
+      "task_id": "e14e32ba-d310-4d45-9b8a-6d73d0ece1ae"
+    },
+    {
+      "files": [],
+      "occupation": "Producers and Directors",
+      "position": 152,
+      "sector": "Information",
+      "task_id": "b1a79ce1-86b0-41fb-97dc-9206dfd7b044"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/e4f664ea-0e5c-4e4e-a0d3-a87a33da947a/SAINTLINESS.pdf",
+          "sha256": "5156ba763e6ca73be8150e42a2bcb0bc2d88d75e7b8e29aff3a1cb6d1c40c71d",
+          "size": 245488,
+          "source_path": "deliverable_files/08c8e6cf8a5fcb4c3921fdc0bd755209/SAINTLINESS.pdf"
+        }
+      ],
+      "occupation": "Producers and Directors",
+      "position": 153,
+      "sector": "Information",
+      "task_id": "e4f664ea-0e5c-4e4e-a0d3-a87a33da947a"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a079d38f-c529-436a-beca-3e291f9e62a3/Cost and time breakdown.xlsx",
+          "sha256": "ef8c027b924a515b89aa535b8ec0de2a1d471002618d203f3875035e28a951ba",
+          "size": 8593,
+          "source_path": "deliverable_files/2ae05eb10b1dde5ebe55fb468a2bd440/Cost and time breakdown.xlsx"
+        }
+      ],
+      "occupation": "Producers and Directors",
+      "position": 154,
+      "sector": "Information",
+      "task_id": "a079d38f-c529-436a-beca-3e291f9e62a3"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/02aa1805-c658-4069-8a6a-02dec146063a/Illinois Project Water Wells.xlsx",
+          "sha256": "e0b68b3c1c85a43efe38b35f34dd7c76e09531153395b8c23c3245edce0e3ce1",
+          "size": 15659,
+          "source_path": "deliverable_files/6164ace282d7e74a90db33e731c0c50f/Illinois Project Water Wells.xlsx"
+        }
+      ],
+      "occupation": "Project Management Specialists",
+      "position": 155,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "02aa1805-c658-4069-8a6a-02dec146063a"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/fd6129bd-f095-429b-873c-dcc3137be2c3/Change_Control_SOP.docx",
+          "sha256": "fab245e257045facb820f2642763165a8d11d7deb28e2b146562d3367aab57dd",
+          "size": 31113,
+          "source_path": "deliverable_files/5df8ead4538c81276585661205318e98/Change_Control_SOP.docx"
+        },
+        {
+          "graded_path": "deliverable_files/fd6129bd-f095-429b-873c-dcc3137be2c3/Change Control Form Filled.pdf",
+          "sha256": "0440dc00fe072e916cb1580c54ebee854c07b4e64f50cfdc8b67e38e99ca71fa",
+          "size": 141429,
+          "source_path": "deliverable_files/1bcf15d1384d8359695235619640c4f2/Change Control Form Filled.pdf"
+        }
+      ],
+      "occupation": "Project Management Specialists",
+      "position": 156,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "fd6129bd-f095-429b-873c-dcc3137be2c3"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/ce864f41-8584-49ba-b24f-9c9104b47bf0/WDT_1.xlsx",
+          "sha256": "29553a7840d28c41188ec8e4859b1892abfef38190a512a07385ce4ca655e0b0",
+          "size": 17676,
+          "source_path": "deliverable_files/16f8a6aa80957b4d5d7e50c332a7a0cd/WDT_1.xlsx"
+        }
+      ],
+      "occupation": "Project Management Specialists",
+      "position": 157,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "ce864f41-8584-49ba-b24f-9c9104b47bf0"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/58ac1cc5-5754-4580-8c9c-8c67e1a9d619/MR_Risk Assessment Summary Report.docx",
+          "sha256": "e44d27eafc62aa1fa0822a5f23a55302379399dc00ace4b0f97153677608ec9c",
+          "size": 17689,
+          "source_path": "deliverable_files/4c01fb7cc03307958ff4682e0efa09ab/MR_Risk Assessment Summary Report.docx"
+        },
+        {
+          "graded_path": "deliverable_files/58ac1cc5-5754-4580-8c9c-8c67e1a9d619/Change Control Form Filled.pdf",
+          "sha256": "0440dc00fe072e916cb1580c54ebee854c07b4e64f50cfdc8b67e38e99ca71fa",
+          "size": 141429,
+          "source_path": "deliverable_files/ba7264aa2c1cc72ecbdad75922076346/Change Control Form Filled.pdf"
+        }
+      ],
+      "occupation": "Project Management Specialists",
+      "position": 158,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "58ac1cc5-5754-4580-8c9c-8c67e1a9d619"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/3c19c6d1-672c-467a-8437-6fe21afb8eae/OUTPUT 1 BridgeMind AI POC project Common Ground Bikes POC Monthly report FINAL.pptx",
+          "sha256": "750f30d3f42ead1c66c30fedf580ae8a0dcc7277ea464c4ffa377090f4b1e87f",
+          "size": 8003353,
+          "source_path": "deliverable_files/e06950d5b909679c7c08f12a80ebecc6/OUTPUT 1 BridgeMind AI POC project Common Ground Bikes POC Monthly report FINAL.pptx"
+        }
+      ],
+      "occupation": "Project Management Specialists",
+      "position": 159,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "3c19c6d1-672c-467a-8437-6fe21afb8eae"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a99d85fc-eff8-48d2-a7d4-42a75d62f18d/Rent Offer Matrix copy.xlsx",
+          "sha256": "211e2efa37f20b0bdaeafd2143fb951e010d347ed70715056b9643d3d75961ec",
+          "size": 22697,
+          "source_path": "deliverable_files/52078902ab8948f23569a02c82f05388/Rent Offer Matrix copy.xlsx"
+        }
+      ],
+      "occupation": "Property, Real Estate, and Community Association Managers",
+      "position": 160,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "a99d85fc-eff8-48d2-a7d4-42a75d62f18d"
+    },
+    {
+      "files": [],
+      "occupation": "Property, Real Estate, and Community Association Managers",
+      "position": 161,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "55ddb773-23a4-454c-8704-d432fe1b99d9"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/1e5a1d7f-12c1-48c6-afd9-82257b3f2409/PM Schedule Chart.docx",
+          "sha256": "cb19bde924b8714a6cd694d0764c9ffc06d185aec2af11cca0bb442c9f4aa90b",
+          "size": 362501,
+          "source_path": "deliverable_files/abc71c8453556f44a237ee3410c073b6/PM Schedule Chart.docx"
+        }
+      ],
+      "occupation": "Property, Real Estate, and Community Association Managers",
+      "position": 162,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "1e5a1d7f-12c1-48c6-afd9-82257b3f2409"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/0419f1c3-d669-45d0-81cd-f4d5923b06a5/Performance Improvement Plan.docx",
+          "sha256": "93e71b38968f04304dae91f7ec4fe689dbc202c996bc349330b8e4694524dfe7",
+          "size": 19850,
+          "source_path": "deliverable_files/d89e112fbb0dc4a7754b99e3f33fbd7c/Performance Improvement Plan.docx"
+        }
+      ],
+      "occupation": "Property, Real Estate, and Community Association Managers",
+      "position": 163,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "0419f1c3-d669-45d0-81cd-f4d5923b06a5"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/ed2bc14c-99ac-4a2a-8467-482a1a5d67f3/Tenant Rentention Strategy.docx",
+          "sha256": "44b16b4a19106caf45354648ac769678c89f42aa8d582548103a7a380b8bbe84",
+          "size": 15838,
+          "source_path": "deliverable_files/7d180b0d497f670b2066800e24b57665/Tenant Rentention Strategy.docx"
+        }
+      ],
+      "occupation": "Property, Real Estate, and Community Association Managers",
+      "position": 164,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "ed2bc14c-99ac-4a2a-8467-482a1a5d67f3"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/46bc7238-3501-4839-b989-e2bd47853676/TENANT OUTREACH PLAYBOOK.pdf",
+          "sha256": "c25c51131d2f9f8f1a9976075de61cf216cb9087d7b0fa63b53662ef0d0e3675",
+          "size": 3662618,
+          "source_path": "deliverable_files/e8595757493e2bee560a7c693b29e812/TENANT OUTREACH PLAYBOOK.pdf"
+        }
+      ],
+      "occupation": "Real Estate Brokers",
+      "position": 165,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "46bc7238-3501-4839-b989-e2bd47853676"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/2d06bc0a-89c6-4e89-9417-5ffe725c1bc6/Denver Off_LOI_ 7_13_25b FIXED.docx",
+          "sha256": "67db561ff1b1b2836ee78871b465cc04416bfb96c234d49ea0d0a3a845e620d3",
+          "size": 21648,
+          "source_path": "deliverable_files/85bd3cdf7331d7194ab5e7b180fcdc5e/Denver Off_LOI_ 7_13_25b FIXED.docx"
+        }
+      ],
+      "occupation": "Real Estate Brokers",
+      "position": 166,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "2d06bc0a-89c6-4e89-9417-5ffe725c1bc6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/fd3ad420-6f7d-43b1-a990-c0c5c047d071/Broker Compensation Structure.pdf",
+          "sha256": "b69407d201975900a377fb28729cb1ee141028d80d7459bf47c4ed7215455b07",
+          "size": 132033,
+          "source_path": "deliverable_files/81460db408a9e96ecf1f8a449c61da1b/Broker Compensation Structure.pdf"
+        }
+      ],
+      "occupation": "Real Estate Brokers",
+      "position": 167,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "fd3ad420-6f7d-43b1-a990-c0c5c047d071"
+    },
+    {
+      "files": [],
+      "occupation": "Real Estate Brokers",
+      "position": 168,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "0818571f-5ff7-4d39-9d2c-ced5ae44299e"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/6074bba3-7e3a-4b1c-b8c6-a15bb6695c3b/NEW CMA  SCRUB.pdf",
+          "sha256": "066a8c9f10c2ffa559db2af60545dc3d5d9483fbd9507c145153107f023a7b5a",
+          "size": 164307,
+          "source_path": "deliverable_files/92df85ef5f3e2634d608a367bc02d416/NEW CMA  SCRUB.pdf"
+        }
+      ],
+      "occupation": "Real Estate Brokers",
+      "position": 169,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "6074bba3-7e3a-4b1c-b8c6-a15bb6695c3b"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/5ad0c554-a7a2-48cd-b41a-ebc1bff4a9de/Buyer's Agreement Brochure word.docx",
+          "sha256": "61636c29dbcec2d1e722996cdf8741c4ba607bc44fb6747fb21b69c16f05eb1f",
+          "size": 27889,
+          "source_path": "deliverable_files/2a06ce09a21623e8f4c62fba4d128069/Buyer's Agreement Brochure word.docx"
+        }
+      ],
+      "occupation": "Real Estate Sales Agents",
+      "position": 170,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "5ad0c554-a7a2-48cd-b41a-ebc1bff4a9de"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/11593a50-734d-4449-b5b4-f8986a133fd8/Massabama Home Flyers.pdf",
+          "sha256": "6cf59a61e172fea7e6b663094fbbaef074a8960a2a448c15782d2d1b37114634",
+          "size": 411461,
+          "source_path": "deliverable_files/93012be979c9c2b5bdda315112c6f88f/Massabama Home Flyers.pdf"
+        }
+      ],
+      "occupation": "Real Estate Sales Agents",
+      "position": 171,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "11593a50-734d-4449-b5b4-f8986a133fd8"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/94925f49-36bc-42da-b45b-61078d329300/School Reports.pdf",
+          "sha256": "14031861f8ee984770ffc88ec8e32ce179011da796eb07bdbe0d4aba7703bc6f",
+          "size": 911880,
+          "source_path": "deliverable_files/a87e30f0ec9f096354edd7db243514a7/School Reports.pdf"
+        }
+      ],
+      "occupation": "Real Estate Sales Agents",
+      "position": 172,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "94925f49-36bc-42da-b45b-61078d329300"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/90f37ff3-e4ed-4a0b-94bb-bed0f7def1ef/LEASE RATE ANALYSIS - FINAL.pdf",
+          "sha256": "e59138cbcaa92d833e996dd5eb9e93ff165fd2645d2d3fc266ae164f0d1ba0e6",
+          "size": 813496,
+          "source_path": "deliverable_files/cb356952ea75247497f720e94b519d99/LEASE RATE ANALYSIS - FINAL.pdf"
+        }
+      ],
+      "occupation": "Real Estate Sales Agents",
+      "position": 173,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "90f37ff3-e4ed-4a0b-94bb-bed0f7def1ef"
+    },
+    {
+      "files": [],
+      "occupation": "Real Estate Sales Agents",
+      "position": 174,
+      "sector": "Real Estate and Rental and Leasing",
+      "task_id": "d3d255b2-f5f2-4841-9f62-2083ec9ef3da"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/403b9234-6299-4b5f-a106-70c1bc11ec4c/Chamber Presentation.pptx",
+          "sha256": "ef5b3b18ffe77862efc1d131233d0dfab9ed71c705c7eb6dc836209d40865b51",
+          "size": 7791194,
+          "source_path": "deliverable_files/e367ca3f83ba413caa647774c5d123d8/Chamber Presentation.pptx"
+        }
+      ],
+      "occupation": "Recreation Workers",
+      "position": 175,
+      "sector": "Government",
+      "task_id": "403b9234-6299-4b5f-a106-70c1bc11ec4c"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/1bff4551-1d54-4e37-b2e0-d5c3f2ea4a45/JPI_Celestial_Solstice_Set_List.pdf",
+          "sha256": "56cd3b10f373c1887a9a49b8e2fdc3594884997cb2c943f3482a24bc21bed866",
+          "size": 37241,
+          "source_path": "deliverable_files/e4359d993b848ea7852bf51016d0e3ad/JPI_Celestial_Solstice_Set_List.pdf"
+        }
+      ],
+      "occupation": "Recreation Workers",
+      "position": 176,
+      "sector": "Government",
+      "task_id": "1bff4551-1d54-4e37-b2e0-d5c3f2ea4a45"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/650adcb1-ed19-4f88-8117-77640f7b94b6/Intern Schedule_Winter 2025-2026_Corrected.xlsx",
+          "sha256": "22825ac2173a019f7eebf0803e58379629152f3dec8fcc2a3a789c7cac4d128c",
+          "size": 22231,
+          "source_path": "deliverable_files/6ad1412843ce5c5c3229b4accf2d1fe7/Intern Schedule_Winter 2025-2026_Corrected.xlsx"
+        }
+      ],
+      "occupation": "Recreation Workers",
+      "position": 177,
+      "sector": "Government",
+      "task_id": "650adcb1-ed19-4f88-8117-77640f7b94b6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/01d7e53e-0513-4109-a242-8ccaf442cd21/Recreare_RecFit_Contract-5.docx",
+          "sha256": "c73c500418be14d9cb5e50b3829bda75f4d7ac78427e904a8cea5a0557dd580e",
+          "size": 47980,
+          "source_path": "deliverable_files/c1c3e1c224f8d7c467ffc32b340ad5e1/Recreare_RecFit_Contract-5.docx"
+        }
+      ],
+      "occupation": "Recreation Workers",
+      "position": 178,
+      "sector": "Government",
+      "task_id": "01d7e53e-0513-4109-a242-8ccaf442cd21"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a73fbc98-90d4-4134-a54f-2b1d0c838791/Spring Bazaar 2025 Vendors List & Table Assignments-v2.xlsx",
+          "sha256": "dc1227f85b7d45fa9afce6076d7f1c9cc1dbacd24a1ad6b5df96646a84be74bc",
+          "size": 17459,
+          "source_path": "deliverable_files/2a0eb91c53e96f2647c1605de943a559/Spring Bazaar 2025 Vendors List & Table Assignments-v2.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/a73fbc98-90d4-4134-a54f-2b1d0c838791/Meeting Room Layout with Vendor Assignment-v2.pdf",
+          "sha256": "4f978dbae855aba24e1393e67d8b41c5fa9230a61726eab3877d29a071e3d1ab",
+          "size": 102571,
+          "source_path": "deliverable_files/cf35933dd051ae008b3fad2c01b7e950/Meeting Room Layout with Vendor Assignment-v2.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/a73fbc98-90d4-4134-a54f-2b1d0c838791/Arena Layout with Vendor Assignment-v3.pdf",
+          "sha256": "4dc52b70b4b6221bfa667249b73692dedd9ecef7f8e11bcaa6212e18055590ab",
+          "size": 311689,
+          "source_path": "deliverable_files/c7a7dc17438a9a91da43b9378e08caf5/Arena Layout with Vendor Assignment-v3.pdf"
+        }
+      ],
+      "occupation": "Recreation Workers",
+      "position": 179,
+      "sector": "Government",
+      "task_id": "a73fbc98-90d4-4134-a54f-2b1d0c838791"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/0ec25916-1b5c-4bfe-93d3-4e103d860f3a/SBAR Template Emergency department (2).pdf",
+          "sha256": "7f7c05dbb5a403746d2cf5173c0cbe9422b4b33dac23836fde57a8fff4867cbc",
+          "size": 39907,
+          "source_path": "deliverable_files/ad9d3d529787f2af68f07c1f39e7eb8a/SBAR Template Emergency department (2).pdf"
+        }
+      ],
+      "occupation": "Registered Nurses",
+      "position": 180,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "0ec25916-1b5c-4bfe-93d3-4e103d860f3a"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/116e791e-890c-42b1-ba90-1db02e8bfd45/AB Care Plan.pdf",
+          "sha256": "9f35c0f01bddd9db181d027400474d178233acebff45733e261bd3800697b0be",
+          "size": 25488,
+          "source_path": "deliverable_files/89522cb126c77c30c16a94fe8a47cc9c/AB Care Plan.pdf"
+        }
+      ],
+      "occupation": "Registered Nurses",
+      "position": 181,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "116e791e-890c-42b1-ba90-1db02e8bfd45"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/dd724c67-8118-4b99-ab50-4761af705c3b/Transition of Care hosp and SNF info.xlsx",
+          "sha256": "e1f4fc658cc997536ed1c4682d51ee5cebfe54a96408159d39b7e845b9e78cf1",
+          "size": 24992,
+          "source_path": "deliverable_files/73d5bdf68a87014da755f783ed214e52/Transition of Care hosp and SNF info.xlsx"
+        }
+      ],
+      "occupation": "Registered Nurses",
+      "position": 182,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "dd724c67-8118-4b99-ab50-4761af705c3b"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/7151c60a-d4cb-4fc4-8169-3d4cb446e6b9/Fax cover sheet.docx",
+          "sha256": "5600f07dc20298839235fc1ac3ed01a8f029017148ac4fd496ea40de69c3e6a7",
+          "size": 46954,
+          "source_path": "deliverable_files/853283ef637ff2c8dbbdbd38d3858da3/Fax cover sheet.docx"
+        },
+        {
+          "graded_path": "deliverable_files/7151c60a-d4cb-4fc4-8169-3d4cb446e6b9/Facility Admission Pre _Screening Checklist.docx",
+          "sha256": "8817bc3932e205e2abf8409058b52db3aac003bfce62bd76f0d91997f19b452c",
+          "size": 55874,
+          "source_path": "deliverable_files/5c54fca99e37654bd986370e26cd032c/Facility Admission Pre _Screening Checklist.docx"
+        }
+      ],
+      "occupation": "Registered Nurses",
+      "position": 183,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "7151c60a-d4cb-4fc4-8169-3d4cb446e6b9"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/90edba97-74f0-425a-8ff6-8b93182eb7cb/Monthly Tracker Patient Lab Results Data1.xlsx",
+          "sha256": "6fca7aa05ea25eccc55149a6d47cd25dcb3ed6a81a3b6706ad6e2b96dbf2b9d5",
+          "size": 34132,
+          "source_path": "deliverable_files/d2aa42321c1cf7525d231316a5a40cff/Monthly Tracker Patient Lab Results Data1.xlsx"
+        }
+      ],
+      "occupation": "Registered Nurses",
+      "position": 184,
+      "sector": "Health Care and Social Assistance",
+      "task_id": "90edba97-74f0-425a-8ff6-8b93182eb7cb"
+    },
+    {
+      "files": [],
+      "occupation": "Pharmacists",
+      "position": 185,
+      "sector": "Retail Trade",
+      "task_id": "91060ff0-3eb5-4ddf-9edb-f6758b95499e"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/8384083a-c31b-4194-80ba-4d335a444918/DS reference revised.pdf",
+          "sha256": "e18b5f3504c4f5001a1d51e98da1e1bccdaee567ae783f50f3a369c39b9f0ab3",
+          "size": 120394,
+          "source_path": "deliverable_files/248c3e6d557319917757ece972b30154/DS reference revised.pdf"
+        }
+      ],
+      "occupation": "Pharmacists",
+      "position": 186,
+      "sector": "Retail Trade",
+      "task_id": "8384083a-c31b-4194-80ba-4d335a444918"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/045aba2e-4093-42aa-ab7f-159cc538278c/Daily.pdf",
+          "sha256": "1bf3ffc4d3ef90a1cab633d016e384a29d02afd8bc07394be8eb31c23d4ef8ac",
+          "size": 44624,
+          "source_path": "deliverable_files/281e84cc56aaaec307ebb3f224a9571d/Daily.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/045aba2e-4093-42aa-ab7f-159cc538278c/WeeklyMonthly.pdf",
+          "sha256": "ba32fdcd0290d7dc048d0bdc35dcdbb4ce0fa8a5252b22c9537e671b0be2c79b",
+          "size": 57931,
+          "source_path": "deliverable_files/1749d5457efef26e5377f4b09be1c216/WeeklyMonthly.pdf"
+        },
+        {
+          "graded_path": "deliverable_files/045aba2e-4093-42aa-ab7f-159cc538278c/QuarterAnnual.pdf",
+          "sha256": "80f09f179a7f678c858697551e067bc1e9748e8abd088bc35265461325497151",
+          "size": 58879,
+          "source_path": "deliverable_files/b88c5aaab15a85c5c593297346191c0d/QuarterAnnual.pdf"
+        }
+      ],
+      "occupation": "Pharmacists",
+      "position": 187,
+      "sector": "Retail Trade",
+      "task_id": "045aba2e-4093-42aa-ab7f-159cc538278c"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/f2986c1f-2bbf-4b83-bc93-624a9d617f45/Final- Drug list identified vFinal.xlsx",
+          "sha256": "0ac3b0a52652aa2a01e5cc09b93f07a3c79fc18b29efded7bc12f3af38d3d39d",
+          "size": 12104,
+          "source_path": "deliverable_files/27ab44f24dc5a751b0a8bdf05d75c1cd/Final- Drug list identified vFinal.xlsx"
+        }
+      ],
+      "occupation": "Pharmacists",
+      "position": 188,
+      "sector": "Retail Trade",
+      "task_id": "f2986c1f-2bbf-4b83-bc93-624a9d617f45"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/ffed32d8-d192-4e3f-8cd4-eda5a730aec3/90 vs 100 ds.pdf",
+          "sha256": "2a6aee8cd47f80b1bbee946a057dc3d59976938cfbe0c58754beba4b064457a7",
+          "size": 71877,
+          "source_path": "deliverable_files/1bb44d66dee9927e49409d21b1385649/90 vs 100 ds.pdf"
+        }
+      ],
+      "occupation": "Pharmacists",
+      "position": 189,
+      "sector": "Retail Trade",
+      "task_id": "ffed32d8-d192-4e3f-8cd4-eda5a730aec3"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/b3573f20-5d3e-4954-948f-9461fda693d2/Brand_datagathering_RR-2.pdf",
+          "sha256": "70ef93fd0ee9d90ebc0a3a483775fc657ca606cdfa1cef71d4fe90c0919c3fd6",
+          "size": 114811,
+          "source_path": "deliverable_files/75bfcf44612297c678583fcaa48f7c05/Brand_datagathering_RR-2.pdf"
+        }
+      ],
+      "occupation": "Sales Managers",
+      "position": 190,
+      "sector": "Wholesale Trade",
+      "task_id": "b3573f20-5d3e-4954-948f-9461fda693d2"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a69be28f-9a84-47c9-992e-b90446cdca9d/Territory Fit Report DELIVERABLE FINAL.pdf",
+          "sha256": "0323ebf3a1e325d07b557582fd293558b8b4d32ed58b73ffcf6a29796fdd6bb9",
+          "size": 788396,
+          "source_path": "deliverable_files/eee36f22c0b556299c6b9fc5590376a6/Territory Fit Report DELIVERABLE FINAL.pdf"
+        }
+      ],
+      "occupation": "Sales Managers",
+      "position": 191,
+      "sector": "Wholesale Trade",
+      "task_id": "a69be28f-9a84-47c9-992e-b90446cdca9d"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/788d2bc6-82df-4dc7-8467-a0f31405dc14/Advertising Agency Business Presentation.pdf",
+          "sha256": "04eaaf77fdca5128c9cbd7c051748a35602ac285f9de15bf22498864dd95071f",
+          "size": 909248,
+          "source_path": "deliverable_files/38c0175013f509fc036dd495956f285e/Advertising Agency Business Presentation.pdf"
+        }
+      ],
+      "occupation": "Sales Managers",
+      "position": 192,
+      "sector": "Wholesale Trade",
+      "task_id": "788d2bc6-82df-4dc7-8467-a0f31405dc14"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/74ed1dc7-1468-48a8-9071-58775c0d667a/Order Type Proposal edits.docx",
+          "sha256": "40e6f70b0bc92fce5f6506fc6e8976cc3961b0cb76acb4304ff81f4bde62882d",
+          "size": 221145,
+          "source_path": "deliverable_files/e76bb009e55a825bab77c91d29a8e635/Order Type Proposal edits.docx"
+        }
+      ],
+      "occupation": "Sales Managers",
+      "position": 193,
+      "sector": "Wholesale Trade",
+      "task_id": "74ed1dc7-1468-48a8-9071-58775c0d667a"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/69a8ef86-4e69-4fe2-9168-080f1e978e67/Account Return Guidelines.docx",
+          "sha256": "cd96d765981279b340f6a7d72cf8eff8cf40591592c32d67a1cfd5139697abe1",
+          "size": 16907,
+          "source_path": "deliverable_files/a684192907c4114a0c8b78c389508006/Account Return Guidelines.docx"
+        },
+        {
+          "graded_path": "deliverable_files/69a8ef86-4e69-4fe2-9168-080f1e978e67/Returns Process.docx",
+          "sha256": "f8707d51572d082761009f1d0344e30a6f591a343f4356d0d7efd375e927e8a8",
+          "size": 224453,
+          "source_path": "deliverable_files/5b7bfc5847598d23e73da73b18fbf855/Returns Process.docx"
+        }
+      ],
+      "occupation": "Sales Managers",
+      "position": 194,
+      "sector": "Wholesale Trade",
+      "task_id": "69a8ef86-4e69-4fe2-9168-080f1e978e67"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/ab81b076-e5d8-473a-9bdb-7ea7c38f6ebc/Receiving Parts Order Procedures edits.pdf",
+          "sha256": "33888c36be66b01f74b4bd0c7a07a75329d656babac661d3221963861b46f012",
+          "size": 163933,
+          "source_path": "deliverable_files/0e4c4312621b32aa45fb8351af87901d/Receiving Parts Order Procedures edits.pdf"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products",
+      "position": 195,
+      "sector": "Wholesale Trade",
+      "task_id": "ab81b076-e5d8-473a-9bdb-7ea7c38f6ebc"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/d7cfae6f-4a82-4289-955e-c799dfe1e0f4/Beutist Q124 Risks SET SELLING final_v2.xlsx",
+          "sha256": "ca707cb9731fb12fbbd3f53fad240f6a7ee2d9881d010d2d9ca0bc21d0511542",
+          "size": 22081,
+          "source_path": "deliverable_files/f47d88fd0b3002ead05057fcb6e5ad2e/Beutist Q124 Risks SET SELLING final_v2.xlsx"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products",
+      "position": 196,
+      "sector": "Wholesale Trade",
+      "task_id": "d7cfae6f-4a82-4289-955e-c799dfe1e0f4"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/19403010-3e5c-494e-a6d3-13594e99f6af/XR Retailer 2023 Sales Performance Analysis Makeup Category Final (3).xlsx",
+          "sha256": "d8fb692994bff5a68f226181a1aa848858cf46d24069f0127c5743ff0c34436b",
+          "size": 326863,
+          "source_path": "deliverable_files/1d8e4bfb74a86ef573c7efbbf9e263cd/XR Retailer 2023 Sales Performance Analysis Makeup Category Final (3).xlsx"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products",
+      "position": 197,
+      "sector": "Wholesale Trade",
+      "task_id": "19403010-3e5c-494e-a6d3-13594e99f6af"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/7ed932dd-244f-4d61-bf02-1bc3bab1af14/Additional Shipments Needed Updated - July 2025.xlsx",
+          "sha256": "be4ee0bddb8ef4bba249ea3c67b65b45a72ef25dc7d8174e7cd2168f65672bd7",
+          "size": 15402,
+          "source_path": "deliverable_files/cfd578cb5e8ae28b5d9871d903059f4a/Additional Shipments Needed Updated - July 2025.xlsx"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products",
+      "position": 198,
+      "sector": "Wholesale Trade",
+      "task_id": "7ed932dd-244f-4d61-bf02-1bc3bab1af14"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/105f8ad0-8dd2-422f-9e88-2be5fbd2b215/Competitive Pricing Strategy.xlsx",
+          "sha256": "cd4fe3733212220fdf0d271f82054160232b999c26c12c60f400e54acf1e8075",
+          "size": 29737,
+          "source_path": "deliverable_files/fa6eeebf995e05385a9ff67c462911fc/Competitive Pricing Strategy.xlsx"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products",
+      "position": 199,
+      "sector": "Wholesale Trade",
+      "task_id": "105f8ad0-8dd2-422f-9e88-2be5fbd2b215"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/b57efde3-26d6-4742-bbff-2b63c43b4baa/Aqua Nor 2025 Prospect LakeHealth DO Sensor List edits.xlsx",
+          "sha256": "7a121bac56ebdbbe3d0dcef01c71f97289d2a1921002c1e14d4d93c7691b12b0",
+          "size": 52297,
+          "source_path": "deliverable_files/fbcedaa1d478d85c98ca397b3ce8fe51/Aqua Nor 2025 Prospect LakeHealth DO Sensor List edits.xlsx"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products",
+      "position": 200,
+      "sector": "Wholesale Trade",
+      "task_id": "b57efde3-26d6-4742-bbff-2b63c43b4baa"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/15d37511-75c5-4c7f-81f1-16e00c0d95f3/GloNGroRealEstate Marketplace Pro Forma.xlsx",
+          "sha256": "6366dc1764365c6b4b7a9f2490897bed0074013b2fb7e48ef13e837704ecad06",
+          "size": 11460,
+          "source_path": "deliverable_files/ca9c00810bc7c0f8503bd3b5a9da59e9/GloNGroRealEstate Marketplace Pro Forma.xlsx"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products",
+      "position": 201,
+      "sector": "Wholesale Trade",
+      "task_id": "15d37511-75c5-4c7f-81f1-16e00c0d95f3"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/bb863dd9-31c2-4f64-911a-ce11f457143b/Quotation Q6533211 BO 757820 Inter Aid.xlsx",
+          "sha256": "e9e8415a09f27fccd0f12d6a2695306319c0b587905fd354520b5f9db3ed77c0",
+          "size": 12185,
+          "source_path": "deliverable_files/5e9868ed98a12f35fc006589e0069c39/Quotation Q6533211 BO 757820 Inter Aid.xlsx"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products",
+      "position": 202,
+      "sector": "Wholesale Trade",
+      "task_id": "bb863dd9-31c2-4f64-911a-ce11f457143b"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/fe0d3941-e32c-4bf1-a643-b566d2b4cb3c/Workflows.pptx",
+          "sha256": "c305496bbfeef362a9e69d43bfe18417ad34342d4c3f470ad48c371db7ebfc46",
+          "size": 42354,
+          "source_path": "deliverable_files/72778a36d21ced2c6965b64abf6350d5/Workflows.pptx"
+        },
+        {
+          "graded_path": "deliverable_files/fe0d3941-e32c-4bf1-a643-b566d2b4cb3c/Deliverable Survey TM.pdf",
+          "sha256": "fd33f73d73d0794057a707f16b3e67e4a1d0cf0fd547de8b5430b352566e6b14",
+          "size": 115049,
+          "source_path": "deliverable_files/242a09c20f2e9caad2de37de2f38fe43/Deliverable Survey TM.pdf"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products",
+      "position": 203,
+      "sector": "Wholesale Trade",
+      "task_id": "fe0d3941-e32c-4bf1-a643-b566d2b4cb3c"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/6a900a40-8d2b-4064-a5b1-13a60bc173d8/Q9749821-revised_including_transport.xlsx",
+          "sha256": "964e7e3fdd64987637c5f7c499fee10cd5100043291b0242da12bc4db8ea8236",
+          "size": 11363,
+          "source_path": "deliverable_files/62ad007376504310d39398f3822ed1bd/Q9749821-revised_including_transport.xlsx"
+        }
+      ],
+      "occupation": "Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products",
+      "position": 204,
+      "sector": "Wholesale Trade",
+      "task_id": "6a900a40-8d2b-4064-a5b1-13a60bc173d8"
+    },
+    {
+      "files": [],
+      "occupation": "Securities, Commodities, and Financial Services Sales Agents",
+      "position": 205,
+      "sector": "Finance and Insurance",
+      "task_id": "9efbcd35-186d-49b6-ac24-28ee2bc9a263"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/1d4672c8-b0a7-488f-905f-9ab4e25a19f7/Correlation Matrix.xlsx",
+          "sha256": "b62c38933e5e8d9a77b407a19c07fe5a7e02ebd130a4aeb4156823bf02cf66c7",
+          "size": 12589,
+          "source_path": "deliverable_files/1092ea691862e8b47f5d8cc926805316/Correlation Matrix.xlsx"
+        },
+        {
+          "graded_path": "deliverable_files/1d4672c8-b0a7-488f-905f-9ab4e25a19f7/Correlation Analysis.pdf",
+          "sha256": "7d22056f44ab22a8e4bf5f3ceac3d236d30bac719c840b014a598c1e9ce0ee99",
+          "size": 469436,
+          "source_path": "deliverable_files/4cf765f5e196ea26bcf95580c1e8c87f/Correlation Analysis.pdf"
+        }
+      ],
+      "occupation": "Securities, Commodities, and Financial Services Sales Agents",
+      "position": 206,
+      "sector": "Finance and Insurance",
+      "task_id": "1d4672c8-b0a7-488f-905f-9ab4e25a19f7"
+    },
+    {
+      "files": [],
+      "occupation": "Securities, Commodities, and Financial Services Sales Agents",
+      "position": 207,
+      "sector": "Finance and Insurance",
+      "task_id": "4de6a529-4f61-41a1-b2dc-64951ba03457"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/4c4dc603-c21c-4284-8fb1-1b827c1fddf4/Project Kenonic Teaser 3.pdf",
+          "sha256": "d912c3d09e2bfb9795a8ec86eab8508af4cff1ae986e30bb38ce5a80bf7f8744",
+          "size": 253893,
+          "source_path": "deliverable_files/60dd431920905dbea564e86fa2f40f76/Project Kenonic Teaser 3.pdf"
+        }
+      ],
+      "occupation": "Securities, Commodities, and Financial Services Sales Agents",
+      "position": 208,
+      "sector": "Finance and Insurance",
+      "task_id": "4c4dc603-c21c-4284-8fb1-1b827c1fddf4"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/bb499d9c-0263-4684-9238-75e8e86077b1/Investment Sales Department Process.docx",
+          "sha256": "d64cdffd37dc02041656b70739aee06ffc5cd731561f08b060f9a2e7775f7d62",
+          "size": 56182,
+          "source_path": "deliverable_files/682e52642dc0acbdaa0d9a30b835539b/Investment Sales Department Process.docx"
+        }
+      ],
+      "occupation": "Securities, Commodities, and Financial Services Sales Agents",
+      "position": 209,
+      "sector": "Finance and Insurance",
+      "task_id": "bb499d9c-0263-4684-9238-75e8e86077b1"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/5349dd7b-bf0a-4544-9a17-75b7013767e6/2026 Flat Rate Shipping Analysis.xlsx",
+          "sha256": "61f30d7247d8cfffe5cca2362c7efe907a53cb78e47da76281f9313da0b44f02",
+          "size": 11312,
+          "source_path": "deliverable_files/ae449d1cf1fdd433293e8e636b13deee/2026 Flat Rate Shipping Analysis.xlsx"
+        }
+      ],
+      "occupation": "Shipping, Receiving, and Inventory Clerks",
+      "position": 210,
+      "sector": "Manufacturing",
+      "task_id": "5349dd7b-bf0a-4544-9a17-75b7013767e6"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/a4a9195c-5ebe-4b8d-a0c2-4a6b7a49da8b/ESD_Handling_and_Storage_Procedure.docx",
+          "sha256": "2d1f45d930082ad3cd429a612056133740d2bd0c39821c06a218f8498cac88f8",
+          "size": 129907,
+          "source_path": "deliverable_files/8ceb3f0ad6c28deddcd1718ed7d8f785/ESD_Handling_and_Storage_Procedure.docx"
+        }
+      ],
+      "occupation": "Shipping, Receiving, and Inventory Clerks",
+      "position": 211,
+      "sector": "Manufacturing",
+      "task_id": "a4a9195c-5ebe-4b8d-a0c2-4a6b7a49da8b"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/552b7dd0-96f4-437c-a749-0691e0e4b381/Inventory Incident Reports FINAL.pptx",
+          "sha256": "1aebdd48618029cfc8bbdde86132bcb6ec189b61a5f395f934c69de4d055abd6",
+          "size": 1129834,
+          "source_path": "deliverable_files/2227f1706a019fb6a1e7a8c114089eed/Inventory Incident Reports FINAL.pptx"
+        }
+      ],
+      "occupation": "Shipping, Receiving, and Inventory Clerks",
+      "position": 212,
+      "sector": "Manufacturing",
+      "task_id": "552b7dd0-96f4-437c-a749-0691e0e4b381"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/11dcc268-cb07-4d3a-a184-c6d7a19349bc/Location Report 062425 Fix edits.xlsx",
+          "sha256": "fd257f4ebd8b2789cf8feec6a4938211cf9d458d811ab340398a38fb8a4b0a0d",
+          "size": 13903,
+          "source_path": "deliverable_files/feaf97c5e160886ae49dcb41b43ea25e/Location Report 062425 Fix edits.xlsx"
+        }
+      ],
+      "occupation": "Shipping, Receiving, and Inventory Clerks",
+      "position": 213,
+      "sector": "Manufacturing",
+      "task_id": "11dcc268-cb07-4d3a-a184-c6d7a19349bc"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/76418a2c-a3c0-4894-b89d-2493369135d9/Daily Shipment Manifest 062525.xlsx",
+          "sha256": "179aef0a5befc3636d7ffd0886a6eebddad7b18368640b74bf537ad81ecb03b2",
+          "size": 13957,
+          "source_path": "deliverable_files/51fd7afc9aecdf5650a1d6ea3498f2fd/Daily Shipment Manifest 062525.xlsx"
+        }
+      ],
+      "occupation": "Shipping, Receiving, and Inventory Clerks",
+      "position": 214,
+      "sector": "Manufacturing",
+      "task_id": "76418a2c-a3c0-4894-b89d-2493369135d9"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/0e386e32-df20-4d1f-b536-7159bc409ad5/PrivateCrypMixV2.zip",
+          "sha256": "1a89088bcc431a2baae08a197a4f1be5337ba68d2f37f6c9c8a4dd9eef1888fe",
+          "size": 33554432,
+          "source_path": "deliverable_files/226c5ad480d4f5095cba55dbc1651caf/PrivateCrypMixV2.zip"
+        }
+      ],
+      "occupation": "Software Developers",
+      "position": 215,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "0e386e32-df20-4d1f-b536-7159bc409ad5"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/7de33b48-5163-4f50-b5f3-8deea8185e57/screen_reader_status_message.zip",
+          "sha256": "da2a4b72d97c6b103b446d3c1f365aa09f4b07409e76c9c14594a8c080cf701f",
+          "size": 3504,
+          "source_path": "deliverable_files/58e3b79a2e407417a4207390182c3e29/screen_reader_status_message.zip"
+        }
+      ],
+      "occupation": "Software Developers",
+      "position": 216,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "7de33b48-5163-4f50-b5f3-8deea8185e57"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/854f3814-681c-4950-91ac-55b0db0e3781/abq okc query.overpassql",
+          "sha256": "41ab71c4e58d8905061fb7264230d4960238d9dec34417fb4aa1a2b31201e3f2",
+          "size": 227,
+          "source_path": "deliverable_files/e772e2555a44254aabcaae67d60a8bf4/abq okc query.overpassql"
+        },
+        {
+          "graded_path": "deliverable_files/854f3814-681c-4950-91ac-55b0db0e3781/abq okc query instructions.md",
+          "sha256": "4e1ba1fbb8e4735c2817a20cf171803a8fc3422ea904595683849b3a6b698837",
+          "size": 1488,
+          "source_path": "deliverable_files/413d54a95816ba8eecf400c3ee973c80/abq okc query instructions.md"
+        }
+      ],
+      "occupation": "Software Developers",
+      "position": 217,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "854f3814-681c-4950-91ac-55b0db0e3781"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/4122f866-01fa-400b-904d-fa171cdab7c7/contact form serverless backend.zip",
+          "sha256": "ebbc617dad95df68f8cfa47a75624fd81cdd9796af4a1cef4e1a8194cf01f172",
+          "size": 9107,
+          "source_path": "deliverable_files/f67c1b204fadaa659452feb3fa23b196/contact form serverless backend.zip"
+        }
+      ],
+      "occupation": "Software Developers",
+      "position": 218,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "4122f866-01fa-400b-904d-fa171cdab7c7"
+    },
+    {
+      "files": [
+        {
+          "graded_path": "deliverable_files/2c249e0f-4a8c-4f8e-b4f4-6508ba29b34f/data_flow_updated_v2.txt",
+          "sha256": "0fddd1e6e4d384b820410cec0512abb68add12ea2671aedc973349e2860e5372",
+          "size": 5621,
+          "source_path": "deliverable_files/be6dae81b6b6270e939921f6f023e297/data_flow_updated_v2.txt"
+        },
+        {
+          "graded_path": "deliverable_files/2c249e0f-4a8c-4f8e-b4f4-6508ba29b34f/robot_data_upload_api_v2.yaml",
+          "sha256": "f2eda90c0d473824b9a6afbc1dad268cb8a673a413ad92111df0aa5d368e3b81",
+          "size": 23458,
+          "source_path": "deliverable_files/7c722ef5973b28a1abfa322dd46f5664/robot_data_upload_api_v2.yaml"
+        }
+      ],
+      "occupation": "Software Developers",
+      "position": 219,
+      "sector": "Professional, Scientific, and Technical Services",
+      "task_id": "2c249e0f-4a8c-4f8e-b4f4-6508ba29b34f"
+    }
+  ],
+  "total_bytes": 623241071,
+  "written_by": "batch-runner/scripts/build_gold_deliverable_manifest.py"
+}

--- a/batch-runner/grading_configs/gold_ceiling_30_v2_sol_max.yaml
+++ b/batch-runner/grading_configs/gold_ceiling_30_v2_sol_max.yaml
@@ -1,0 +1,165 @@
+schema_version: "2.0"
+config_name: "gold_ceiling_30_v2_sol_max"
+description: |
+  The gold-ceiling measurement over a fixed 30-task sample, spec
+  tasks/rebuilding_grading_task/300-gold-ceiling.md.
+
+  Runtime semantics are byte-for-byte those of default_v2_sol_max: same judge,
+  same reasoning effort, same tool ops and caps, same perception models, same
+  critical rule, same scoring, same prompts, same rate-limit guard. Only the
+  identity differs -- the config name, the pinned corpus, and a rubric revision
+  frozen to a commit instead of following `main`. That is deliberate: a ceiling
+  measured with different settings than the runs it is the ceiling FOR would
+  not be their ceiling.
+
+  What is being graded is not a model's work. It is the benchmark's own expert
+  answers, registered by experiments/exp_gold_baseline.yaml. So the expected
+  result is near the top of the scale, and a shortfall is a finding about the
+  grader rather than about anybody's model.
+
+# Which 30, and why these. The corpus is walked in the dataset's own row order
+# and the first 30 tasks that actually carry an expert answer are taken -- 185
+# of the 220 do, so 4 tasks inside the first 34 positions are skipped for
+# having none. Taking a prefix rather than a spread is what makes the sample
+# re-derivable by anyone with the dataset: there is no seed to lose and no
+# sampling code to reimplement. tests/test_gold_ceiling_contract.py re-derives
+# this list from experiments/gold_corpus/gold_deliverable_manifest.json and
+# fails if the two ever disagree, so this block is checked, not trusted.
+#
+# The sample is narrow by construction: 4 sectors and 7 occupations, because
+# consecutive rows share an occupation. It is a grader sanity check, not a
+# representative survey -- stage 3 grades all 220.
+#
+# Order is load-bearing twice over. step8_grade.py refuses a pinned list that
+# does not follow canonical source order, and it compares the pinned list to
+# the selected list by equality, so a reordering is a refusal rather than a
+# silently different run.
+rerun_identity:
+  experiment_id: "exp_gold_baseline"
+  expected_task_count: 30
+  # The dataset commit the rubric is read from. Pinned rather than `main` so
+  # the three repeats stage 2 needs cannot drift between them.
+  rubric_commit_sha: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  # The same commit, because for a gold corpus the dataset IS the inference:
+  # no model ran, so the revision that supplied the answers is the revision
+  # that supplied the rubric.
+  inference_revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  # Deliberately absent: allow_legacy_missing_provenance. That switch forgives
+  # a submission whose Azure routes were never recorded. Here no inference ran,
+  # so there is no route that could be missing -- the payload says `gold-corpus`
+  # outright, and step8_grade.py keeps every such run out of the published path
+  # on that basis alone.
+  task_ids:
+    - "83d10b06-26d1-4636-a32c-23f92c57f30b"
+    - "7b08cd4d-df60-41ae-9102-8aaa49306ba2"
+    - "7d7fc9a7-21a7-4b83-906f-416dea5ad04f"
+    - "43dc9778-450b-4b46-b77e-b6d82b202035"
+    - "ee09d943-5a11-430a-b7a2-971b4e9b01b5"
+    - "f84ea6ac-8f9f-428c-b96c-d0884e30f7c7"
+    - "a328feea-47db-4856-b4be-2bdc63dd88fb"
+    - "27e8912c-8bd5-44ba-ad87-64066ea05264"
+    - "17111c03-aac7-45c2-857d-c06d8223d6ad"
+    - "c44e9b62-7cd8-4f72-8ad9-f8fbddb94083"
+    - "99ac6944-4ec6-4848-959c-a460ac705c6f"
+    - "f9a1c16c-53fd-4c8f-88cc-5c325ec2f0bb"
+    - "38889c3b-e3d4-49c8-816a-3cc8e5313aba"
+    - "1b1ade2d-f9f6-4a04-baa5-aa15012b53be"
+    - "93b336f3-61f3-4287-86d2-87445e1e0f90"
+    - "15ddd28d-8445-4baa-ac7f-f41372e1344e"
+    - "24d1e93f-9018-45d4-b522-ad89dfd78079"
+    - "05389f78-589a-473c-a4ae-67c61050bfca"
+    - "a74ead3b-f67d-4b1c-9116-f6bb81b29d4f"
+    - "bbe0a93b-ebf0-40b0-98dc-8d9243099034"
+    - "76d10872-9ffa-4ede-83ee-e0f1ec5e2b8d"
+    - "36d567ba-e205-4313-9756-931c6e4691fe"
+    - "7bbfcfe9-132d-4194-82bb-d6f29d001b01"
+    - "2696757c-1f8a-4959-8f0d-f5597b9e70fc"
+    - "dfb4e0cd-a0b7-454e-b943-0dd586c2764c"
+    - "4c18ebae-dfaa-4b76-b10c-61fcdf26734c"
+    - "cebf301e-5ea7-41ae-b117-ad8f43e7ac22"
+    - "c2e8f271-7858-412f-b460-472463ad81d9"
+    - "2ea2e5b5-257f-42e6-a7dc-93763f28b19d"
+    - "c357f0e2-963d-4eb7-a6fa-3078fe55b3ba"
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.6-sol"
+  deployment: "gpt-5.6-sol"
+  api_version: "2025-04-01-preview"
+  timeout_sec: 600
+  reasoning:
+    effort: "max"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+    finalization_reasoning_effort: "max"
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.6-sol"
+      deployment: "gpt-5.6-sol"
+      reasoning_effort: "max"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      deployment: "gpt-audio-1.5"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v2"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -294,7 +294,13 @@
       }
     },
     "source_azure_ai_provenance_status": {
-      "enum": ["runtime-verified", "verified-sidecar", "legacy-missing", "local-runtime"]
+      "enum": [
+        "runtime-verified",
+        "verified-sidecar",
+        "legacy-missing",
+        "local-runtime",
+        "gold-corpus"
+      ]
     },
     "azure_ai_routes": {
       "type": "array",

--- a/batch-runner/scripts/build_gold_deliverable_manifest.py
+++ b/batch-runner/scripts/build_gold_deliverable_manifest.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Write down exactly which reference answers the gold-ceiling runs are graded on.
+
+The benchmark ships one human expert answer for most of its tasks. The
+gold-ceiling check grades those answers instead of a model's, so that the score
+they earn can be read as the highest the grader is able to award. That only
+means anything if the bytes being graded are pinned: this script records, for
+every task in the benchmark, which expert answer files it ships, where the
+dataset keeps them, where the grader reads them from, how large each one is, and
+its SHA-256 fingerprint.
+
+Nothing here calls a model and nothing is spent. The dataset revision and the
+fingerprint of its data file are written into the manifest, so anyone can
+confirm which release produced it.
+
+The re-rooting rule -- the dataset files a task's expert answer under an opaque
+folder, while the grader reads it from a folder named after the task -- is not
+repeated here. It is imported from ``download_inference_from_hf`` so that the
+run and the manifest cannot drift into two different answers about where a file
+belongs.
+
+Usage:
+
+    python scripts/build_gold_deliverable_manifest.py --dataset-root DIR
+    python scripts/build_gold_deliverable_manifest.py --dataset-root DIR --check
+
+``--check`` rebuilds the manifest in memory and reports whether the committed
+file still matches, without writing anything.
+
+Getting the bytes, once and free:
+
+    huggingface-cli download openai/gdpval --repo-type dataset \\
+        --revision <sha> --include 'deliverable_files/*' --local-dir DIR
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path, PurePosixPath
+
+SCRIPTS_ROOT = Path(__file__).resolve().parent
+BATCH_RUNNER_ROOT = SCRIPTS_ROOT.parent
+for _root in (str(BATCH_RUNNER_ROOT), str(SCRIPTS_ROOT)):
+    if _root not in sys.path:
+        sys.path.insert(0, _root)
+
+from download_inference_from_hf import (  # noqa: E402
+    gold_deliverable_path,
+    gold_rows_from_parquet,
+)
+
+#: The dataset this benchmark's tasks and expert answers come from.
+DATASET_REPO_ID = "openai/gdpval"
+#: The one revision the gold-ceiling stages are frozen to. Every run in stages
+#: 1 to 3 reads this same commit, so the three of them grade identical bytes.
+DATASET_REVISION = "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+#: The one data file that revision ships its tasks in.
+DATASET_DATA_FILE = "data/train-00000-of-00001.parquet"
+
+MANIFEST_SCHEMA_VERSION = "gdpval-gold-deliverable-manifest-v1"
+MANIFEST_PATH = (
+    BATCH_RUNNER_ROOT / "experiments" / "gold_corpus" / "gold_deliverable_manifest.json"
+)
+WRITTEN_BY = "batch-runner/scripts/build_gold_deliverable_manifest.py"
+
+#: Every column read out of the dataset. Named in one place so a file that does
+#: not hold one of them can be refused up front, by name, rather than quietly
+#: becoming a task with no expert answer.
+COLUMNS_THE_MANIFEST_IS_BUILT_FROM = (
+    "task_id",
+    "sector",
+    "occupation",
+    "deliverable_files",
+)
+
+
+def sha256_of_file(path: Path) -> tuple[str, int]:
+    """The SHA-256 fingerprint and byte count of one file, read in blocks."""
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def _resolve_source_file(dataset_root: Path, source_path: str) -> Path:
+    """Locate one downloaded expert answer, refusing anything but a real file.
+
+    A symlink is refused rather than followed. The download cache keeps its
+    real bytes elsewhere and links to them, and a fingerprint taken through a
+    link records what the link pointed at today, not what the dataset ships.
+    """
+    candidate = dataset_root.joinpath(*PurePosixPath(source_path).parts)
+    if candidate.is_symlink():
+        raise SystemExit(
+            f"{source_path} is a symlink under {dataset_root}. Download with "
+            "--local-dir so the real bytes are on disk, and fingerprint those."
+        )
+    if not candidate.is_file():
+        raise SystemExit(
+            f"no copy of {source_path} under {dataset_root}. Download the "
+            f"pinned revision first: huggingface-cli download {DATASET_REPO_ID} "
+            f"--repo-type dataset --revision {DATASET_REVISION} "
+            "--include 'deliverable_files/*' --local-dir <dir>"
+        )
+    return candidate
+
+
+def build_manifest(
+    parquet_path: Path,
+    dataset_root: Path,
+    *,
+    repo_id: str,
+    revision: str,
+) -> dict:
+    """Read the pinned dataset and fingerprint every expert answer it ships.
+
+    Tasks the dataset ships no expert answer for are kept, with an empty file
+    list. Dropping them would make the benchmark look 185 tasks long, and a
+    30-task selection measured against a 185-task corpus is a different claim
+    from one measured against 220.
+    """
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(parquet_path)
+    absent = sorted(
+        set(COLUMNS_THE_MANIFEST_IS_BUILT_FROM) - set(table.column_names)
+    )
+    if absent:
+        raise SystemExit(
+            "the dataset file does not hold: "
+            + ", ".join(absent)
+            + ". It holds: "
+            + ", ".join(sorted(table.column_names))
+            + ". Building a manifest now would record no expert answer for "
+            "every task, which reads downstream as a benchmark with nothing to "
+            "grade rather than as a column nobody could find."
+        )
+
+    labels = {
+        str(row["task_id"]): (str(row["sector"]), str(row["occupation"]))
+        for row in table.select(["task_id", "sector", "occupation"]).to_pylist()
+    }
+
+    tasks: list[dict] = []
+    file_count = 0
+    total_bytes = 0
+    for position, row in enumerate(gold_rows_from_parquet(str(parquet_path))):
+        task_id = row["task_id"]
+        sector, occupation = labels[task_id]
+        files = []
+        for source_path, graded_path in zip(
+            row["gold_source_files"], row["deliverable_files"]
+        ):
+            # Re-derived rather than trusted: the pairing above only holds if
+            # the two lists were built from each other, and this says so.
+            if gold_deliverable_path(task_id, source_path) != graded_path:
+                raise SystemExit(
+                    f"{source_path} does not re-root to {graded_path} for task "
+                    f"{task_id}"
+                )
+            fingerprint, size = sha256_of_file(
+                _resolve_source_file(dataset_root, source_path)
+            )
+            files.append(
+                {
+                    "source_path": source_path,
+                    "graded_path": graded_path,
+                    "sha256": fingerprint,
+                    "size": size,
+                }
+            )
+            file_count += 1
+            total_bytes += size
+        tasks.append(
+            {
+                "position": position,
+                "task_id": task_id,
+                "sector": sector,
+                "occupation": occupation,
+                "files": files,
+            }
+        )
+
+    dataset_file_sha256, _ = sha256_of_file(parquet_path)
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "dataset_repo_id": repo_id,
+        "dataset_revision": revision,
+        "dataset_data_file": DATASET_DATA_FILE,
+        "dataset_file_sha256": dataset_file_sha256,
+        "written_by": WRITTEN_BY,
+        "holds_no_scores": (
+            "Only task numbers, industries, jobs, and the name, size and "
+            "SHA-256 fingerprint of each expert answer file are recorded. No "
+            "score, grade, verdict, or scoring line is present, and no file's "
+            "contents are reproduced."
+        ),
+        "path_note": (
+            "The dataset files each expert answer under an opaque 32-character "
+            "folder that is not derived from the file's contents; source_path "
+            "is where the dataset keeps it and graded_path is where the grader "
+            "reads it from."
+        ),
+        "task_count": len(tasks),
+        "gold_bearing_task_count": sum(1 for task in tasks if task["files"]),
+        "file_count": file_count,
+        "total_bytes": total_bytes,
+        "tasks": tasks,
+    }
+
+
+def gold_bearing_task_ids(manifest: dict) -> list[str]:
+    """Every task that ships an expert answer, in the dataset's own order."""
+    return [task["task_id"] for task in manifest["tasks"] if task["files"]]
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _serialize(manifest: dict) -> str:
+    return json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset-root",
+        required=True,
+        help="Directory holding the downloaded deliverable_files/ tree",
+    )
+    parser.add_argument(
+        "--parquet",
+        default="",
+        help=f"Path to {DATASET_DATA_FILE}; defaults to it under --dataset-root",
+    )
+    parser.add_argument("--repo-id", default=DATASET_REPO_ID)
+    parser.add_argument("--revision", default=DATASET_REVISION)
+    parser.add_argument("--output", default=str(MANIFEST_PATH))
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Rebuild in memory and report whether the committed file matches",
+    )
+    args = parser.parse_args()
+
+    dataset_root = Path(args.dataset_root).resolve()
+    parquet_path = (
+        Path(args.parquet).resolve()
+        if args.parquet
+        else dataset_root.joinpath(*PurePosixPath(DATASET_DATA_FILE).parts)
+    )
+    if not parquet_path.is_file():
+        raise SystemExit(f"no dataset file at {parquet_path}")
+
+    manifest = build_manifest(
+        parquet_path,
+        dataset_root,
+        repo_id=args.repo_id,
+        revision=args.revision,
+    )
+    rendered = _serialize(manifest)
+    output = Path(args.output)
+
+    if args.check:
+        if not output.is_file():
+            print(f"no committed manifest at {output}", file=sys.stderr)
+            return 1
+        if output.read_text(encoding="utf-8") != rendered:
+            print(
+                f"the committed manifest at {output} no longer matches the "
+                "dataset it says it was built from",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"{output} matches {args.repo_id} at {args.revision}: "
+            f"{manifest['file_count']} file(s) across "
+            f"{manifest['gold_bearing_task_count']} of "
+            f"{manifest['task_count']} task(s)"
+        )
+        return 0
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+    print(
+        f"Wrote {output}: {manifest['file_count']} file(s), "
+        f"{manifest['total_bytes']} byte(s) across "
+        f"{manifest['gold_bearing_task_count']} of {manifest['task_count']} task(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batch-runner/scripts/download_inference_from_hf.py
+++ b/batch-runner/scripts/download_inference_from_hf.py
@@ -7,6 +7,10 @@ Downloads:
 
 Usage:
   python scripts/download_inference_from_hf.py --experiment exp998_smoke_baseline_sample --output workspace/step2_inference_results.json
+
+An experiment may also declare ``data.inference_source: gold_deliverables``,
+which sources the graded corpus from the benchmark's own reference answers
+rather than from a submission repo. See ``_build_gold_inference``.
 """
 
 from __future__ import annotations
@@ -22,7 +26,7 @@ import tempfile
 import time
 import types
 import uuid
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pandas as pd
 import yaml
@@ -44,6 +48,8 @@ if "core" not in sys.modules:
     sys.modules["core"] = core_package
 
 from core.inference_manifest import (  # noqa: E402
+    GOLD_PROVENANCE_STATUS,
+    canonical_deliverable_path,
     canonicalize_inference_payload,
     validate_inference_provenance,
     validate_local_deliverables,
@@ -52,6 +58,26 @@ from core.inference_manifest import (  # noqa: E402
 
 FULL_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 FULL_LOWER_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+#: An experiment sourcing its graded corpus from a submission repo -- the
+#: default, and what every model run produces.
+SUBMISSION_INFERENCE_SOURCE = "submission"
+#: An experiment sourcing its graded corpus from the benchmark's own reference
+#: answers. No model produced these, so there is no submission repo to read and
+#: no Azure AI route provenance to verify.
+GOLD_INFERENCE_SOURCE = "gold_deliverables"
+_INFERENCE_SOURCES = frozenset({SUBMISSION_INFERENCE_SOURCE, GOLD_INFERENCE_SOURCE})
+
+#: ``openai/gdpval`` files its reference answers under a per-deliverable digest
+#: directory (``deliverable_files/<md5>/<name>``), not under the task that owns
+#: them. Nothing downstream accepts that shape -- ``canonical_deliverable_path``
+#: requires ``deliverable_files/<task_id>/`` -- so the digest segment is dropped
+#: and the file is re-rooted under its task. Matching the dataset layout exactly
+#: rather than loosely is deliberate: a path that is merely *close* to this shape
+#: is a dataset change we have not read, and re-rooting it would be a guess.
+_GOLD_SOURCE_PATH_RE = re.compile(
+    r"^deliverable_files/[A-Za-z0-9][A-Za-z0-9._-]*/[^/\\]+$"
+)
 
 
 def _hf_token() -> str | None:
@@ -258,15 +284,40 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def resolve_repo_id(experiment: str) -> str:
+def _load_experiment_data_block(experiment: str) -> dict:
     exp_path = Path("experiments") / f"{experiment}.yaml"
     data = yaml.safe_load(exp_path.read_text(encoding="utf-8"))
-    source = str((data or {}).get("data", {}).get("source", "")).strip()
+    block = (data or {}).get("data")
+    return block if isinstance(block, dict) else {}
+
+
+def resolve_repo_id(experiment: str) -> str:
+    source = str(_load_experiment_data_block(experiment).get("source", "")).strip()
     if not source:
         raise ValueError("data.source is missing in experiment yaml")
     if "/" not in source:
         raise ValueError("data.source must be owner/name")
     return source
+
+
+def resolve_inference_source(experiment: str) -> str:
+    """Read where this experiment's graded corpus comes from, fail-closed.
+
+    Absent means ``submission``, which is what every experiment written before
+    the gold-ceiling test declared implicitly. Any other unrecognised value is
+    refused rather than defaulted: silently grading a submission because a
+    typo'd source did not match is exactly the substitution this pipeline
+    exists to prevent.
+    """
+    declared = _load_experiment_data_block(experiment).get(
+        "inference_source", SUBMISSION_INFERENCE_SOURCE
+    )
+    if declared not in _INFERENCE_SOURCES:
+        raise ValueError(
+            "data.inference_source must be one of "
+            f"{sorted(_INFERENCE_SOURCES)}; got {declared!r}"
+        )
+    return declared
 
 
 def resolve_immutable_revision(repo_id: str, revision: str = "") -> str:
@@ -410,6 +461,112 @@ def _build_inference_from_parquet(parquet_path: str, experiment: str, repo_id: s
         "completed_at": None,
         "results": results,
     }
+
+
+def gold_deliverable_path(task_id: str, source_path: str) -> str:
+    """Re-root one dataset gold path under the task that owns it.
+
+    ``deliverable_files/<md5>/Report.docx`` -> ``deliverable_files/<task_id>/Report.docx``.
+    The basename is carried across untouched; only the digest directory is
+    dropped. ``canonical_deliverable_path`` then re-checks the result, so a
+    basename that would escape its task directory is refused there.
+    """
+    if not isinstance(source_path, str) or not _GOLD_SOURCE_PATH_RE.fullmatch(
+        source_path
+    ):
+        raise ValueError(
+            f"gold deliverable path is not dataset-shaped for task {task_id!r}: "
+            f"{source_path!r}"
+        )
+    name = source_path.rsplit("/", 1)[1]
+    return canonical_deliverable_path(task_id, f"deliverable_files/{task_id}/{name}")
+
+
+def gold_rows_from_parquet(parquet_path: str) -> list[dict]:
+    """Read every task's gold deliverables in canonical dataset order.
+
+    Every row is kept, including the tasks the dataset ships no reference
+    answer for. Dropping them would make a pinned 30-task selection read as the
+    *whole* corpus downstream, and a subset that calls itself complete is
+    published as a final grade instead of a diagnostic one.
+    """
+    df = pd.read_parquet(parquet_path)
+    rows: list[dict] = []
+    for record in df.to_dict("records"):
+        task_id = str(record.get("task_id") or "").strip()
+        if not task_id:
+            continue
+        source_paths = _coerce_list(record.get("deliverable_files"))
+        files: list[str] = []
+        for source_path in source_paths:
+            path = gold_deliverable_path(task_id, source_path)
+            if path in files:
+                # Two digest directories holding the same basename collapse
+                # onto one path once the digest is dropped. Refuse rather than
+                # silently grade whichever copy landed second.
+                raise ValueError(
+                    "gold deliverables collide after re-rooting for task "
+                    f"{task_id!r}: {path}"
+                )
+            files.append(path)
+        rows.append(
+            {
+                "task_id": task_id,
+                "gold_source_files": source_paths,
+                "deliverable_files": files,
+            }
+        )
+    if not rows:
+        raise ValueError("gold corpus parquet contains no tasks")
+    return rows
+
+
+def _build_gold_inference(parquet_path: str, experiment: str, repo_id: str) -> dict:
+    results = []
+    for row in gold_rows_from_parquet(parquet_path):
+        result = {
+            "task_id": row["task_id"],
+            "status": "success" if row["deliverable_files"] else "error",
+            "deliverable_text": "",
+            "deliverable_files": row["deliverable_files"],
+            "gold_source_files": row["gold_source_files"],
+        }
+        if not row["deliverable_files"]:
+            result["error"] = "no_gold_deliverable"
+        results.append(result)
+
+    return {
+        "experiment_id": experiment,
+        "source": repo_id,
+        # Named rather than blank so a grade payload records what produced the
+        # graded bytes. Nothing did: these are the benchmark's own answers.
+        "model": "gold-deliverable",
+        "completed_at": None,
+        "inference_source": GOLD_INFERENCE_SOURCE,
+        "azure_ai_routes": [],
+        # Distinct from "legacy-missing", which means a submission whose routes
+        # were never recorded. Here no inference ran at all, so there is no
+        # route to be missing.
+        "azure_ai_provenance_status": GOLD_PROVENANCE_STATUS,
+        "results": results,
+    }
+
+
+def _download_gold_inference(
+    experiment: str, repo_id: str, revision: str, out: Path
+) -> None:
+    parquet_file = _with_hub_retry(
+        "gold corpus parquet",
+        lambda: hf_hub_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            filename="data/train-00000-of-00001.parquet",
+            revision=revision,
+            token=_hf_token(),
+        ),
+    )
+    payload = _build_gold_inference(parquet_file, experiment, repo_id)
+    _atomic_write_json(out, _canonicalize_inference_payload(payload, repo_id, revision))
 
 
 def _canonicalize_inference_payload(payload: object, repo_id: str, revision: str) -> dict:
@@ -612,13 +769,145 @@ def _download_and_replace_deliverables(
         _remove_owned_path(staging_root)
 
 
+def _gold_file_plan(results: list[dict]) -> list[tuple[str, str, str]]:
+    """Pair every declared gold path with the dataset path it is copied from."""
+    plan: list[tuple[str, str, str]] = []
+    for row in results:
+        task_id = row["task_id"]
+        targets = row["deliverable_files"]
+        sources = row.get("gold_source_files")
+        if not isinstance(sources, list) or len(sources) != len(targets):
+            raise ValueError(
+                f"gold source paths do not pair with deliverables for task {task_id!r}"
+            )
+        for source_path, target in zip(sources, targets):
+            if gold_deliverable_path(task_id, source_path) != target:
+                raise ValueError(
+                    f"gold source path does not re-root to {target!r} for task {task_id!r}"
+                )
+            plan.append((task_id, str(source_path), target))
+    return plan
+
+
+def _materialize_gold_deliverables(
+    repo_id: str, revision: str, results: list[dict]
+) -> None:
+    """Copy the benchmark's own reference answers into the graded tree.
+
+    Unlike a submission repo, the dataset does not lay its files out the way the
+    grader reads them, so this stages the download and the re-rooted copy in two
+    separate directories -- both are called ``deliverable_files``, and writing
+    one into the other would nest the corpus inside itself.
+    """
+    plan = _gold_file_plan(results)
+    destination = Path("workspace") / "upload" / "deliverable_files"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging_root = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}.staging-", dir=destination.parent)
+    )
+    backup = destination.with_name(f".{destination.name}.backup-{uuid.uuid4().hex}")
+    backup_created = False
+
+    try:
+        source_root = staging_root / "source"
+        built_root = staging_root / "built"
+        built_deliverables = built_root / "deliverable_files"
+        built_deliverables.mkdir(parents=True)
+
+        if plan:
+            allow_patterns = sorted({source_path for _, source_path, _ in plan})
+            _with_hub_retry(
+                "gold deliverable_files snapshot",
+                lambda: snapshot_download(
+                    repo_id=repo_id,
+                    repo_type="dataset",
+                    local_dir=source_root,
+                    allow_patterns=allow_patterns,
+                    revision=revision,
+                    token=_hf_token(),
+                ),
+            )
+
+        for task_id, source_path, target in plan:
+            downloaded = source_root.joinpath(*PurePosixPath(source_path).parts)
+            if downloaded.is_symlink() or not downloaded.is_file():
+                raise ValueError(
+                    f"gold deliverable did not download as a regular file: {source_path}"
+                )
+            copied = built_root.joinpath(*PurePosixPath(target).parts)
+            copied.parent.mkdir(parents=True, exist_ok=True)
+            if copied.exists() or copied.is_symlink():
+                raise ValueError(f"gold deliverable target is already present: {target}")
+            shutil.copyfile(downloaded, copied, follow_symlinks=False)
+
+        validate_local_deliverables(results, built_root)
+
+        if destination.exists() or destination.is_symlink():
+            os.replace(destination, backup)
+            backup_created = True
+        try:
+            os.replace(built_deliverables, destination)
+        except BaseException:
+            if backup_created:
+                _remove_owned_path(destination)
+                os.replace(backup, destination)
+                backup_created = False
+            raise
+
+        if backup_created:
+            _remove_owned_path(backup)
+            backup_created = False
+        print(
+            f"Materialized {len(plan)} gold deliverable file(s) across "
+            f"{sum(1 for row in results if row['deliverable_files'])} task(s)"
+        )
+    finally:
+        _remove_owned_path(staging_root)
+
+
+def resolve_pinned_task_ids(config: dict) -> list[str] | None:
+    identity = config.get("rerun_identity")
+    if not isinstance(identity, dict):
+        return None
+    task_ids = identity.get("task_ids")
+    if task_ids is None:
+        return None
+    if (
+        not isinstance(task_ids, list)
+        or not task_ids
+        or any(not isinstance(task_id, str) or not task_id for task_id in task_ids)
+        or len(task_ids) != len(set(task_ids))
+    ):
+        raise ValueError("rerun_identity.task_ids must be a unique non-empty list")
+    return list(task_ids)
+
+
+def _select_gold_materialization(payload: dict, task_ids: list[str] | None) -> list[dict]:
+    """Choose which tasks' reference answers are put on disk.
+
+    The graded selection decides this, so there is no second knob to forget:
+    grading a task the config did not pin fails in ``step8_grade.py`` with a
+    missing deliverable directory rather than quietly grading nothing.
+    """
+    results = payload["results"]
+    if task_ids is None:
+        return results
+    by_task = {row["task_id"]: row for row in results}
+    missing = sorted(set(task_ids) - set(by_task))
+    if missing:
+        raise ValueError(f"pinned task_ids are absent from the gold corpus: {missing}")
+    return [by_task[task_id] for task_id in task_ids]
+
+
 def main() -> int:
     args = parse_args()
     repo_id = resolve_repo_id(args.experiment)
+    inference_source = resolve_inference_source(args.experiment)
     _stagger_shard_start()
     revision = resolve_immutable_revision(repo_id, args.revision)
     print(f"Resolved inference revision: {revision}")
 
+    grading_config: dict | None = None
     config_allowance = False
     if args.grading_config:
         grading_config = _load_repository_grading_config(args.grading_config)
@@ -631,6 +920,38 @@ def main() -> int:
 
     out = Path(args.output)
     out.parent.mkdir(parents=True, exist_ok=True)
+
+    if inference_source == GOLD_INFERENCE_SOURCE:
+        # No submission repo means no branch history to fall back on, so the
+        # dispatcher names the frozen revision rather than letting `main` drift
+        # between the three runs that have to be byte-identical.
+        if not FULL_SHA_RE.fullmatch(args.revision):
+            print(
+                "ERROR: a gold corpus requires --revision pinned to a full commit SHA",
+                file=sys.stderr,
+            )
+            return 1
+        if args.expected_leading_task_id:
+            print(
+                "ERROR: --expected-leading-task-id does not apply to a gold corpus; "
+                "pin rerun_identity.task_ids instead",
+                file=sys.stderr,
+            )
+            return 1
+        _download_gold_inference(args.experiment, repo_id, revision, out)
+        payload = _canonicalize_inference_payload(
+            json.loads(out.read_text(encoding="utf-8")), repo_id, revision
+        )
+        materialized = _select_gold_materialization(
+            payload, resolve_pinned_task_ids(grading_config or {})
+        )
+        payload["gold_materialized_task_ids"] = [
+            row["task_id"] for row in materialized
+        ]
+        _atomic_write_json(out, payload)
+        _materialize_gold_deliverables(repo_id, revision, materialized)
+        print(f"Built gold corpus from {repo_id} at {revision}")
+        return 0
 
     _download_or_reconstruct_inference(
         args.experiment,

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -41,6 +41,7 @@ from core.grader import (
 )
 from core.grade_payload import canonical_rate, validate_grade_payload
 from core.inference_manifest import (
+    GOLD_PROVENANCE_STATUS,
     canonical_task_id,
     canonicalize_inference_payload,
     task_deliverable_dir,
@@ -55,6 +56,10 @@ SCHEMA_VERSION = "1.3"
 GRADED_BY_VERSION = "0.1.0"
 FULL_HF_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 FULL_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+#: How many times one identical run may be repeated. A variance measurement
+#: needs a handful of repeats, not an open-ended budget, and every repeat past
+#: the first is a second full charge for a corpus that has already been graded.
+MAX_RUN_ORDINAL = 10
 
 
 def _now_iso() -> str:
@@ -215,6 +220,7 @@ def resolve_grade_output_path(
     diagnostic_task_scope_sha: str | None = None,
     shard_index: int = 0,
     shard_count: int = 1,
+    run_ordinal: int = 1,
 ) -> Path:
     if not FULL_HF_SHA_RE.fullmatch(rubric_sha):
         raise ValueError(
@@ -243,6 +249,10 @@ def resolve_grade_output_path(
         raise ValueError(
             "shard_index must satisfy 0 <= index < shard_count (count >= 1)"
         )
+    if not 1 <= run_ordinal <= MAX_RUN_ORDINAL:
+        raise ValueError(
+            f"run_ordinal must satisfy 1 <= ordinal <= {MAX_RUN_ORDINAL}"
+        )
     out_name = config["output"]["filename_template"].format(
         exp_id=experiment_id,
         judge_slug=judge_slug,
@@ -261,6 +271,22 @@ def resolve_grade_output_path(
     output_root = Path(config["output"]["directory"])
     if diagnostic_task_scope_sha is not None:
         output_root = output_root / "_diagnostic" / diagnostic_task_scope_sha
+    if run_ordinal > 1:
+        # Measuring how far a score drifts between reruns needs the SAME grader
+        # source, config, corpus and inputs graded more than once. Nothing that
+        # identifies the run may change, so every repeat resolves to one path,
+        # where the second would be refused as already existing and --force
+        # would erase the first.
+        #
+        # Fork above the shard fork, not below it, so the two compose: a repeat
+        # that is too large for one four-hour chunk still shards, and its shards
+        # land under this repeat's own root instead of mixing with run 1's. Run
+        # 1 keeps the canonical path, so the original of a repeat set stays an
+        # ordinary run. `scripts/aggregate-grades.mjs` globs `data/grades/*.json`
+        # without descending, so a repeat is never published to the dashboard as
+        # a second, competing result for the same config -- the repeats exist to
+        # be compared with each other, not to replace the run they repeat.
+        output_root = output_root / "_repeats" / f"run-{run_ordinal:03d}"
     if shard_count > 1:
         # Every shard of a run resolves to the same `out_name`, because their
         # identity inputs (config_hash, rubric_sha, grader_source_hash, ...) are
@@ -355,6 +381,24 @@ def parse_args() -> argparse.Namespace:
         help="0-based index of this shard; must satisfy 0 <= index < count.",
     )
     parser.add_argument(
+        "--run-ordinal",
+        type=int,
+        default=1,
+        help=(
+            "Which repeat of an otherwise identical run this is. Measuring how "
+            "much a score moves between reruns needs the SAME grader source, "
+            "config, corpus and inputs graded more than once, so nothing that "
+            "identifies the run may change -- which leaves every repeat "
+            "resolving to one output path, where the second would be refused "
+            "as already existing and --force would erase the first. Ordinals "
+            "above 1 fork the output directory the way --shard-count forks the "
+            "filename, above the shard fork so a repeat too large for one "
+            "chunk can still shard, and touch no identity input. Default 1 "
+            "keeps the canonical path, so run 1 of a repeat set is an ordinary "
+            "run and needs no flag."
+        ),
+    )
+    parser.add_argument(
         "--source-experiment-id",
         default=None,
         help=(
@@ -371,6 +415,11 @@ def parse_args() -> argparse.Namespace:
         parser.error(
             "--shard-index must satisfy 0 <= index < --shard-count "
             f"(got index={args.shard_index}, count={args.shard_count})"
+        )
+    if not 1 <= args.run_ordinal <= MAX_RUN_ORDINAL:
+        parser.error(
+            f"--run-ordinal must satisfy 1 <= ordinal <= {MAX_RUN_ORDINAL} "
+            f"(got {args.run_ordinal})"
         )
     return args
 
@@ -1802,11 +1851,20 @@ def main() -> int:
         source_provenance_status == "legacy-missing"
         and config_pinned_scope != "complete"
     )
+    # A gold corpus is the benchmark's own expert answers, graded to find out
+    # how high the grader can score at all. No model wrote it and no model
+    # could enter it in a leaderboard, so it never takes the canonical output
+    # path — `scripts/aggregate-grades.mjs` reads that path and has no way to
+    # say "this is the ceiling, not a competitor". Unlike the scope rules
+    # above, pinning the complete corpus does not lift this: what makes it
+    # unpublishable is what it is, not how much of it was graded.
+    gold_corpus_run = source_provenance_status == GOLD_PROVENANCE_STATUS
     diagnostic_run = (
         config_pinned_scope == "subset"
         or args.tasks is not None
         or args.limit > 0
         or legacy_provenance_unbounded
+        or gold_corpus_run
     )
     completed_run_status = "diagnostic" if diagnostic_run else "final"
     # Sharding deliberately does NOT feed `diagnostic_run` above. A diagnostic
@@ -1839,6 +1897,7 @@ def main() -> int:
             diagnostic_task_scope_sha=diagnostic_task_scope_sha,
             shard_index=args.shard_index,
             shard_count=args.shard_count,
+            run_ordinal=args.run_ordinal,
         )
         _write_github_output("grade_file", _repo_relative_grade_file(out_path))
         _write_github_output("grade_status", emitted_run_status)

--- a/batch-runner/tests/test_download_inference_from_hf.py
+++ b/batch-runner/tests/test_download_inference_from_hf.py
@@ -45,6 +45,20 @@ def _remote_missing(message="missing"):
     )
 
 
+def _write_submission_experiment(name="exp", source="owner/repo"):
+    """Write the experiment file ``main()`` reads, under the current directory.
+
+    ``main()`` resolves two things from it: which repository the graded corpus
+    comes from, and whether that corpus is a submission or the benchmark's own
+    reference answers. A test that chdirs into a tmp dir has to supply the file
+    for both reads -- stubbing only ``resolve_repo_id`` leaves the second one
+    looking at a path that does not exist.
+    """
+    path = Path("experiments") / f"{name}.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'data:\n  source: "{source}"\n', encoding="utf-8")
+
+
 def test_direct_script_entrypoint_resolves_core_import():
     batch_root = Path(__file__).resolve().parents[1]
     script = batch_root / "scripts" / "download_inference_from_hf.py"
@@ -776,10 +790,10 @@ def test_main_pins_all_downloads_and_removes_stale_deliverables(monkeypatch, tmp
     stale = Path("workspace/upload/deliverable_files/stale/task.txt")
     stale.parent.mkdir(parents=True)
     stale.write_text("stale", encoding="utf-8")
+    _write_submission_experiment()
     monkeypatch.setattr(module, "HfApi", FakeApi)
     monkeypatch.setattr(module, "hf_hub_download", fake_hf_hub_download)
     monkeypatch.setattr(module, "snapshot_download", fake_snapshot_download)
-    monkeypatch.setattr(module, "resolve_repo_id", lambda experiment: "owner/repo")
     monkeypatch.setattr(
         module,
         "parse_args",
@@ -831,7 +845,7 @@ def test_main_filters_manifest_and_snapshot_to_expected_leading_tasks(
     snapshot_calls = []
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(module, "resolve_repo_id", lambda experiment: "owner/repo")
+    _write_submission_experiment()
     monkeypatch.setattr(module, "resolve_immutable_revision", lambda *args: FULL_SHA)
     def fake_download(**kwargs):
         if kwargs["filename"] == "inference_provenance.json":
@@ -1293,10 +1307,10 @@ def test_main_survives_a_rate_limited_shard_fan_out(monkeypatch, tmp_path):
         return str(kwargs["local_dir"])
 
     monkeypatch.chdir(tmp_path)
+    _write_submission_experiment()
     monkeypatch.setattr(module, "HfApi", FakeApi)
     monkeypatch.setattr(module, "hf_hub_download", fake_hf_hub_download)
     monkeypatch.setattr(module, "snapshot_download", fake_snapshot_download)
-    monkeypatch.setattr(module, "resolve_repo_id", lambda experiment: "owner/repo")
     monkeypatch.setattr(
         module,
         "parse_args",

--- a/batch-runner/tests/test_gold_ceiling_contract.py
+++ b/batch-runner/tests/test_gold_ceiling_contract.py
@@ -1,0 +1,725 @@
+"""The stage-1 gold-ceiling contract.
+
+Grading the benchmark's own expert answers answers one question: how high can
+this grader score at all? Every model score already published is read against
+that ceiling, so the measurement is only worth anything if the thing measured
+cannot drift. These tests pin the parts that would drift silently -- which 30
+tasks, which settings, which dataset commit -- and the parts that would let a
+ceiling be mistaken for a competitor's result.
+
+Spec: tasks/rebuilding_grading_task/300-gold-ceiling.md
+"""
+
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import textwrap
+
+import pytest
+import yaml
+
+import step8_grade as s8
+from core.inference_manifest import GOLD_PROVENANCE_STATUS
+from scripts import preflight_grading_renderer as preflight
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BATCH_RUNNER = REPO_ROOT / "batch-runner"
+GOLD_CONFIG_PATH = BATCH_RUNNER / "grading_configs/gold_ceiling_30_v2_sol_max.yaml"
+PRODUCTION_CONFIG_PATH = BATCH_RUNNER / "grading_configs/default_v2_sol_max.yaml"
+GOLD_EXPERIMENT_PATH = BATCH_RUNNER / "experiments/exp_gold_baseline.yaml"
+GRADE_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/grade-run.yml"
+SPEC_PATH = REPO_ROOT / "tasks/rebuilding_grading_task/300-gold-ceiling.md"
+
+#: The dataset commit everything in stage 1 is frozen to. Written out rather
+#: than read from the config, so a test that checks the config against this
+#: constant is checking something.
+PINNED_DATASET_SHA = "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+SAMPLE_SIZE = 30
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _manifest_module():
+    """Import the manifest builder by path.
+
+    It lives under scripts/ with no package, and it is the only place that
+    knows how a task's row maps to its gold files -- re-deriving that rule here
+    would be re-deriving the thing under test.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_gold_manifest_builder",
+        BATCH_RUNNER / "scripts/build_gold_deliverable_manifest.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------
+# Which 30, and are they still the same 30
+# --------------------------------------------------------------------------
+
+
+def test_pinned_sample_is_the_manifest_prefix_not_a_typed_list():
+    """The config's 30 IDs must be re-derivable from the committed manifest.
+
+    A hand-kept list drifts the moment anyone edits one character, and a
+    one-character drift would be a different sample scored against the same
+    threshold. Deriving the list here means a drift is a red test rather than a
+    quietly different measurement.
+    """
+    module = _manifest_module()
+    derived = module.gold_bearing_task_ids(module.load_manifest())[:SAMPLE_SIZE]
+    pinned = _load_yaml(GOLD_CONFIG_PATH)["rerun_identity"]["task_ids"]
+
+    assert pinned == derived
+    assert len(pinned) == SAMPLE_SIZE
+    assert len(set(pinned)) == SAMPLE_SIZE
+
+
+def test_pinned_sample_is_ordered_the_way_the_grader_demands():
+    """`filter_tasks_for_config` refuses a pin that is not in source order.
+
+    That refusal is the safety net; this is the tripwire in front of it. The
+    manifest records each task's row position, so the pinned list is in source
+    order exactly when those positions ascend.
+    """
+    module = _manifest_module()
+    positions = {
+        task["task_id"]: task["position"]
+        for task in module.load_manifest()["tasks"]
+    }
+    pinned = _load_yaml(GOLD_CONFIG_PATH)["rerun_identity"]["task_ids"]
+
+    pinned_positions = [positions[task_id] for task_id in pinned]
+    assert pinned_positions == sorted(pinned_positions)
+
+
+def test_every_pinned_task_actually_has_an_expert_answer():
+    """A task with no gold file would score zero and drag the ceiling down.
+
+    That would read as a grader defect when it is really an empty input, so the
+    sample skips the 35 tasks the dataset ships without an answer. Checking it
+    here means the skip stays deliberate.
+    """
+    module = _manifest_module()
+    by_task = {task["task_id"]: task for task in module.load_manifest()["tasks"]}
+    pinned = _load_yaml(GOLD_CONFIG_PATH)["rerun_identity"]["task_ids"]
+
+    for task_id in pinned:
+        assert by_task[task_id]["files"], f"{task_id} has no gold deliverable"
+
+
+# --------------------------------------------------------------------------
+# The frozen contract: settings, rubric commit, corpus size
+# --------------------------------------------------------------------------
+
+
+def test_gold_config_grades_with_production_settings_unchanged():
+    """A ceiling measured under different settings is not their ceiling.
+
+    Every runtime block has to be what the graded runs used, byte for byte:
+    same judge and reasoning effort, same tool ops and caps, same perception
+    models, same prompts, same rate-limit guard. Only identity may differ.
+    """
+    gold = _load_yaml(GOLD_CONFIG_PATH)
+    production = _load_yaml(PRODUCTION_CONFIG_PATH)
+
+    for block in ("judge", "grader", "tpm_guard", "prompt", "output"):
+        assert gold[block] == production[block], f"{block} diverged"
+
+    # The rubric block may differ in exactly one field: the revision, pinned to
+    # a commit here where production follows `main`. Following a branch is what
+    # stage 2's three repeats cannot tolerate.
+    assert {k: v for k, v in gold["rubric"].items() if k != "revision"} == {
+        k: v for k, v in production["rubric"].items() if k != "revision"
+    }
+    assert production["rubric"]["revision"] == "main"
+    assert gold["rubric"]["revision"] == PINNED_DATASET_SHA
+
+
+def test_gold_config_pins_one_commit_for_both_rubric_and_corpus():
+    """For a gold corpus the dataset IS the inference.
+
+    No model ran, so the revision that supplied the answers has to be the
+    revision that supplied the rubric being scored against them. Two different
+    commits here would score one release's answers with another's rubric.
+    """
+    identity = _load_yaml(GOLD_CONFIG_PATH)["rerun_identity"]
+
+    assert identity["rubric_commit_sha"] == PINNED_DATASET_SHA
+    assert identity["inference_revision"] == PINNED_DATASET_SHA
+    assert identity["experiment_id"] == "exp_gold_baseline"
+    assert identity["expected_task_count"] == SAMPLE_SIZE
+
+
+def test_gold_config_does_not_forgive_missing_provenance():
+    """`allow_legacy_missing_provenance` must stay absent.
+
+    It forgives a submission whose Azure routes were never recorded. Here no
+    inference ran, so there is no route that could be missing -- setting it
+    would be claiming to excuse a gap this corpus cannot have, and would put a
+    real forgiveness switch on a config nobody would think to check.
+    """
+    identity = _load_yaml(GOLD_CONFIG_PATH)["rerun_identity"]
+
+    assert "allow_legacy_missing_provenance" not in identity
+
+
+def test_gold_config_passes_the_grader_validator():
+    s8.validate_grading_config(_load_yaml(GOLD_CONFIG_PATH))
+
+
+def test_gold_experiment_yaml_declares_the_dataset_not_a_submission():
+    """The downloader must be told to build from gold, fail-closed.
+
+    Absent, `inference_source` means `submission`, and the run would go looking
+    for output that was never produced. The declaration is also what keeps this
+    file from ever being mistaken for an experiment.
+    """
+    experiment = _load_yaml(GOLD_EXPERIMENT_PATH)
+
+    assert experiment["data"]["source"] == "openai/gdpval"
+    assert experiment["data"]["inference_source"] == "gold_deliverables"
+    # No default may speak for a run that had no model. `ExperimentConfig`
+    # fills an absent deployment with "gpt-4", which would put a model that
+    # never ran on the record.
+    assert experiment["condition_a"]["model"]["deployment"] == "gold-deliverable"
+
+
+def test_gold_experiment_yaml_loads_through_both_readers():
+    """Two independent loaders read this file, and both run before any spend.
+
+    A file that parses by eye but not by `ExperimentConfig` would fail at
+    dispatch; one the downloader cannot resolve would fail after checkout. Both
+    are cheap to catch here and expensive to catch there.
+    """
+    from core.experiment_config import ExperimentConfig
+
+    config = ExperimentConfig.from_yaml(str(GOLD_EXPERIMENT_PATH))
+    assert config.condition_a.model.deployment == "gold-deliverable"
+
+    spec = importlib.util.spec_from_file_location(
+        "_gold_downloader",
+        BATCH_RUNNER / "scripts/download_inference_from_hf.py",
+    )
+    downloader = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(downloader)
+
+    cwd = Path.cwd()
+    os.chdir(BATCH_RUNNER)
+    try:
+        assert downloader.resolve_repo_id("exp_gold_baseline") == "openai/gdpval"
+        assert (
+            downloader.resolve_inference_source("exp_gold_baseline")
+            == downloader.GOLD_INFERENCE_SOURCE
+        )
+    finally:
+        os.chdir(cwd)
+
+
+# --------------------------------------------------------------------------
+# A ceiling must never be publishable as a competitor's result
+# --------------------------------------------------------------------------
+
+
+def test_gold_provenance_status_is_a_value_the_schema_accepts():
+    """The written grade is validated against the schema before it lands.
+
+    A status the schema does not list would fail after the run has already been
+    paid for, which is the most expensive possible place to find a typo.
+    """
+    schema = json.loads(
+        (BATCH_RUNNER / "schemas/grade.schema.json").read_text(encoding="utf-8")
+    )
+    enum = schema["properties"]["source_azure_ai_provenance_status"]["enum"]
+
+    assert GOLD_PROVENANCE_STATUS in enum
+    # Distinct from every status a real submission can carry: those describe
+    # how much is known about a model's route, and this one says no model ran.
+    assert GOLD_PROVENANCE_STATUS not in {
+        "runtime-verified",
+        "verified-sidecar",
+        "legacy-missing",
+        "local-runtime",
+    }
+
+
+@pytest.fixture
+def _typed_azure_ai_route(monkeypatch):
+    """The one route step8 will accept, with every ambient credential cleared.
+
+    A run that picked up a stray key from the developer's shell would prove
+    nothing about the route the grading job actually takes, and step8 refuses
+    to start without an explicit profile -- so the refusal has to be satisfied
+    deliberately here rather than by whatever happens to be exported.
+    """
+    for name in (
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_API_KEY",
+        "AZURE_OPENAI_AD_TOKEN",
+        "AZURE_CLIENT_SECRET",
+        "OPENAI_API_KEY",
+        "FOUNDRY_PROJECT_ENDPOINT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("AZURE_AI_ROUTE_PROFILE", "direct-v1")
+    monkeypatch.setenv(
+        "AZURE_OPENAI_V1_ENDPOINT",
+        "https://test-account.services.ai.azure.com/openai/v1/",
+    )
+
+
+def test_gold_run_stays_diagnostic_even_when_the_whole_corpus_is_pinned(
+    monkeypatch, tmp_path, _typed_azure_ai_route
+):
+    """Pinning everything lifts the scope rule. It must not lift this one.
+
+    A complete pin proves nothing was dropped, which is why it publishes a
+    `legacy-missing` submission. It cannot make a ceiling publishable:
+    `scripts/aggregate-grades.mjs` reads the canonical path and has no way to
+    say "this is the ceiling, not a competitor", so a gold run landing there
+    would appear on the dashboard as a rival to the models it exists to
+    calibrate. What makes it unpublishable is what it is, not how much of it
+    was graded.
+    """
+    from tests.test_step8_grade import (
+        INFERENCE_SHA,
+        _FakeGrader,
+        _FakeLoader,
+        _setup_workspace,
+    )
+
+    _setup_workspace(tmp_path)
+    inference_path = tmp_path / "workspace/step2_inference_results.json"
+    inference = json.loads(inference_path.read_text(encoding="utf-8"))
+    inference["azure_ai_provenance_status"] = GOLD_PROVENANCE_STATUS
+    inference_path.write_text(json.dumps(inference), encoding="utf-8")
+
+    task_ids = ["task-001", "task-002", "task-003"]
+    config_path = tmp_path / "grading_configs" / "default.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["schema_version"] = "2.0"
+    config["rubric"]["revision"] = _FakeLoader().rubric_sha
+    config["rerun_identity"] = {
+        "experiment_id": "exp998_smoke_baseline_sample",
+        "expected_task_count": len(task_ids),
+        "rubric_commit_sha": _FakeLoader().rubric_sha,
+        "inference_revision": INFERENCE_SHA,
+        "task_ids": task_ids,
+    }
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "step8_grade.py",
+            "exp998_smoke_baseline_sample",
+            "--config",
+            "grading_configs/default.yaml",
+            "--force",
+        ],
+    )
+
+    assert s8.main() == 0
+
+    # Nothing on the canonical path -- that is the path the dashboard reads.
+    assert not sorted((tmp_path / "data/grades").glob("*.json"))
+    written = sorted((tmp_path / "data/grades/_diagnostic").rglob("*.json"))
+    assert len(written) == 1
+    payload = json.loads(written[0].read_text(encoding="utf-8"))
+    assert payload["run_status"] == "diagnostic"
+    assert payload["source_azure_ai_provenance_status"] == GOLD_PROVENANCE_STATUS
+
+
+def test_a_thirty_task_pin_of_the_full_corpus_is_a_subset():
+    """The gold payload carries all 220 rows; the sample pins 30 of them.
+
+    So the scope is `subset` and the output forks into `_diagnostic/` on that
+    ground too. Worth stating, because it is why stage 1 needs no special case
+    -- and why the rule above is about stage 3, where the pin gets wider.
+    """
+    inference = {
+        "results": [{"task_id": f"task-{index:03d}"} for index in range(220)]
+    }
+    config = {
+        "rerun_identity": {
+            "task_ids": [f"task-{index:03d}" for index in range(SAMPLE_SIZE)]
+        }
+    }
+
+    tasks, scope = s8.filter_tasks_for_config(
+        inference, config, tasks_csv=None, limit=0
+    )
+
+    assert len(tasks) == SAMPLE_SIZE
+    assert scope == "subset"
+
+
+# --------------------------------------------------------------------------
+# The written record has to match what was actually frozen
+# --------------------------------------------------------------------------
+
+
+def _pinned_gold_files() -> list[dict]:
+    """Every gold file behind the pinned sample, in task order then file order."""
+    module = _manifest_module()
+    by_task = {task["task_id"]: task for task in module.load_manifest()["tasks"]}
+    pinned = _load_yaml(GOLD_CONFIG_PATH)["rerun_identity"]["task_ids"]
+    return [file for task_id in pinned for file in by_task[task_id]["files"]]
+
+
+def test_spec_records_the_input_fingerprints_that_re_derive():
+    """The spec quotes two hashes. They have to be the real ones.
+
+    A fingerprint nobody can recompute is a decoration -- it looks like proof
+    and settles nothing. Both of these come from the manifest and the config
+    alone, so the 623 MB of gold files are not needed to check the claim, and
+    a sample that shifted by one task changes both.
+    """
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    pinned = _load_yaml(GOLD_CONFIG_PATH)["rerun_identity"]["task_ids"]
+
+    ordered_ids = hashlib.sha256("\n".join(pinned).encode("utf-8")).hexdigest()
+    file_set = hashlib.sha256(
+        "\n".join(
+            f"{file['graded_path']}\t{file['sha256']}\t{file['size']}"
+            for file in _pinned_gold_files()
+        ).encode("utf-8")
+    ).hexdigest()
+
+    assert f"`{ordered_ids}`" in spec
+    assert f"`{file_set}`" in spec
+    # Distinct inputs, so a copy-paste of one into the other is caught.
+    assert ordered_ids != file_set
+
+
+def test_spec_records_the_sample_size_in_bytes_and_files():
+    """The corpus is 40 files and 184 MB. Both are stated; both are derived.
+
+    File count and byte total are what a reader uses to sanity-check the run
+    time and the bill, so a stale number here is a stale expectation there.
+    """
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    files = _pinned_gold_files()
+
+    assert f"파일 {len(files)}개" in spec
+    assert f"{sum(file['size'] for file in files):,} 바이트" in spec
+
+
+def test_spec_pins_the_same_dataset_commit_as_the_config():
+    """One commit, quoted in three places, checked in one.
+
+    The spec's table, the rubric revision and the inference revision all have
+    to name the same dataset -- otherwise the answers being graded and the
+    rubric grading them come from different releases.
+    """
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    manifest = _manifest_module().load_manifest()
+
+    assert f"`{PINNED_DATASET_SHA}`" in spec
+    assert manifest["dataset_revision"] == PINNED_DATASET_SHA
+    assert f"`{manifest['dataset_file_sha256']}`" in spec
+
+
+def test_spec_names_the_container_and_renderer_the_run_will_use():
+    """A ceiling rendered by a different LibreOffice is a different ceiling.
+
+    Both are pinned in code; the spec restates them for a reader, so the
+    restatement is checked against the pins rather than trusted.
+    """
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    workflow = GRADE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    digests = set(re.findall(r"gdpval-grading@sha256:([0-9a-f]{64})", workflow))
+    assert len(digests) == 1, "grading jobs must all run the same image"
+    assert digests.pop()[:8] in spec
+
+    assert preflight.EXPECTED_LIBREOFFICE_VERSION in spec
+
+
+def test_spec_discloses_the_unreadable_deliverable_before_the_run():
+    """One pinned task's only answer is a zip the read tool cannot open.
+
+    Predicting a weak score is evidence; explaining one afterwards is not. The
+    task stays in the sample -- dropping it would flatter the ceiling -- so the
+    limitation is written down in advance, and this keeps the disclosure honest
+    by checking the tool really does refuse the format.
+    """
+    from core.tools import read_deliverable
+
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    zipped = [
+        file for file in _pinned_gold_files()
+        if file["graded_path"].lower().endswith(".zip")
+    ]
+
+    assert len(zipped) == 1
+    assert "38889c3b-e3d4-49c8-816a-3cc8e5313aba" in spec
+    assert ".zip" in spec
+
+    with tempfile.TemporaryDirectory() as workdir:
+        name = Path(zipped[0]["graded_path"]).name
+        (Path(workdir) / name).write_bytes(b"PK\x03\x04not really a zip")
+        envelope = read_deliverable("read_content", name, base_dir=workdir)
+
+    # Not an error -- that is the point. The judge is handed an empty reading
+    # with a note, so the shortfall looks like a weak answer rather than a
+    # tool that failed, which is exactly why it has to be disclosed up front.
+    assert envelope["ok"] is True
+    assert envelope["data"]["kind"] == "unknown"
+    assert envelope["data"]["text"] == ""
+    assert envelope["data"]["note"] == "binary or unsupported for text read"
+
+
+# --------------------------------------------------------------------------
+# Repeating an identical run without erasing the run it repeats
+# --------------------------------------------------------------------------
+
+
+def _output_identity(**overrides) -> dict:
+    identity = dict(
+        experiment_id="exp_gold_baseline",
+        judge_slug="gpt-5_6-sol",
+        config_hash="c" * 64,
+        rubric_sha=PINNED_DATASET_SHA,
+        rubric_short_sha=PINNED_DATASET_SHA[:7],
+        prompt_version="v2.2",
+        inference_sha=PINNED_DATASET_SHA,
+        grader_source_hash="3" * 64,
+    )
+    identity.update(overrides)
+    return identity
+
+
+_OUTPUT_CONFIG = {
+    "config_name": "gold_ceiling_30_v2_sol_max",
+    "output": {
+        "directory": "data/grades",
+        "filename_template": "{exp_id}__{config_name}__{prompt_v}.json",
+    },
+}
+
+
+def test_repeats_of_one_run_resolve_to_distinct_paths():
+    """Measuring drift needs the same run graded more than once.
+
+    Nothing that identifies the run may change, so every repeat formats the
+    same filename -- and step8 refuses to write over an existing grade, while
+    `--force` would erase the run being compared against. The ordinal forks the
+    directory instead, touching no identity input.
+    """
+    paths = [
+        s8.resolve_grade_output_path(
+            _OUTPUT_CONFIG, **_output_identity(), run_ordinal=ordinal
+        )
+        for ordinal in range(1, 4)
+    ]
+
+    assert len(set(paths)) == 3
+    # Run 1 keeps the canonical path: the original of a repeat set is an
+    # ordinary run and its dispatch needs no flag.
+    assert paths[0] == s8.resolve_grade_output_path(
+        _OUTPUT_CONFIG, **_output_identity()
+    )
+    assert paths[1].parent.name == "run-002"
+    assert paths[1].parent.parent.name == "_repeats"
+    # Same filename throughout: the identity is unchanged, which is the point.
+    assert len({path.name for path in paths}) == 1
+
+
+def test_a_repeat_can_still_be_sharded():
+    """Load-bearing. A 30-task grade runs far past the four-hour chunk budget,
+    so every stage-1 and stage-2 run has to shard -- which means a repeat has
+    to shard too. The ordinal therefore forks the directory ABOVE the shard
+    fork, so each repeat gets its own complete set of shards instead of two
+    sets landing in one directory with nothing to tell them apart.
+    """
+    first = [
+        s8.resolve_grade_output_path(
+            _OUTPUT_CONFIG,
+            **_output_identity(),
+            shard_index=index,
+            shard_count=3,
+            run_ordinal=1,
+        )
+        for index in range(3)
+    ]
+    second = [
+        s8.resolve_grade_output_path(
+            _OUTPUT_CONFIG,
+            **_output_identity(),
+            shard_index=index,
+            shard_count=3,
+            run_ordinal=2,
+        )
+        for index in range(3)
+    ]
+
+    assert len(set(first) | set(second)) == 6
+    assert len({path.parent for path in first}) == 1
+    assert len({path.parent for path in second}) == 1
+    assert first[0].parent != second[0].parent
+    assert [path.name for path in first] == [path.name for path in second]
+    # step9 reassembles by stripping `/_shards/*` and re-attaching the stem, so
+    # each repeat's shards merge back into that repeat's own final file.
+    assert second[0].parent.parent.parent.name == "run-002"
+
+
+def test_repeat_and_diagnostic_forks_compose():
+    """A gold run is always diagnostic, so a gold repeat is always both."""
+    path = s8.resolve_grade_output_path(
+        _OUTPUT_CONFIG,
+        **_output_identity(),
+        diagnostic_task_scope_sha="b" * 64,
+        shard_index=1,
+        shard_count=3,
+        run_ordinal=2,
+    )
+
+    assert path.parts[:3] == ("data", "grades", "_diagnostic")
+    assert path.parts[3] == "b" * 64
+    assert path.parts[4:6] == ("_repeats", "run-002")
+    assert path.parts[6] == "_shards"
+    assert path.name == "shard-001-of-003.json"
+
+
+def _workflow_merge_final_file(shard_grade_file, cwd):
+    """Run the workflow's own final-file derivation on one shard path.
+
+    Lifted out of `.github/workflows/grade-run.yml` rather than restated, so a
+    guard that stops accepting a repeat's path fails here instead of after
+    every shard has been graded and paid for.
+    """
+    raw = GRADE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    marker = 'SHARD_DIR="$(dirname -- "$SHARD_GRADE_FILE")"'
+    start = raw.rindex("\n", 0, raw.index(marker)) + 1
+    tail = 'FINAL_FILE="${SHARD_DIR%/_shards/*}/${STEM}.json"'
+    end = raw.index(tail, start) + len(tail)
+    block = textwrap.dedent(raw[start:end])
+
+    return subprocess.run(
+        ["bash", "-c", f'set -euo pipefail\n{block}\nprintf "%s" "$FINAL_FILE"'],
+        cwd=cwd,
+        env={"SHARD_GRADE_FILE": shard_grade_file, "PATH": os.environ["PATH"]},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_a_repeats_shards_merge_into_that_repeats_own_final_file():
+    """The workflow derives the merged file by stripping `/_shards/*` off the
+    shard's own directory and re-attaching the stem, rather than rebuilding the
+    path from the config. That is what carries the repeat fork through the
+    merge -- and a guard here that refused the deeper path would fail only
+    after all three shards had been graded.
+    """
+    shard = s8.resolve_grade_output_path(
+        _OUTPUT_CONFIG,
+        **_output_identity(),
+        diagnostic_task_scope_sha="b" * 64,
+        shard_index=1,
+        shard_count=3,
+        run_ordinal=2,
+    )
+
+    with tempfile.TemporaryDirectory() as workdir:
+        (Path(workdir) / shard.parent).mkdir(parents=True)
+        result = _workflow_merge_final_file(str(shard), cwd=workdir)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    # Beside the repeat's shards, inside the repeat's own root -- not in run
+    # 1's directory, and not in the shared diagnostic root.
+    assert Path(result.stdout) == shard.parent.parent.parent / (
+        shard.parent.name + ".json"
+    )
+
+
+@pytest.mark.parametrize("ordinal", [0, -1, 11, 100])
+def test_impossible_run_ordinals_are_refused(ordinal):
+    """Defence in depth: parse_args rejects these too, but the helper is public
+    and an out-of-range ordinal would put a paid run somewhere nobody looks."""
+    with pytest.raises(ValueError, match="run_ordinal must satisfy"):
+        s8.resolve_grade_output_path(
+            _OUTPUT_CONFIG, **_output_identity(), run_ordinal=ordinal
+        )
+
+
+def test_run_ordinal_cap_is_the_same_number_in_the_workflow():
+    """Two enforcement points, one number. The workflow rejects a bad ordinal
+    before the job starts; step8 rejects it after. If they disagreed, the gap
+    between them would be a dispatch that validates and then dies mid-run.
+    """
+    workflow = GRADE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert s8.MAX_RUN_ORDINAL == 10
+    assert "^([1-9]|10)$" in workflow
+    assert "run_ordinal must be an integer between 1 and 10" in workflow
+
+
+def test_workflow_carries_the_ordinal_through_to_the_grader():
+    """The flag has to survive four hops: input, env, argument, self-retrigger.
+
+    Dropping it at the last hop is the dangerous one -- a repeat that runs out
+    of its four hours would resume into run 1's path and overwrite the run it
+    exists to be compared against.
+    """
+    raw = GRADE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert re.search(r"^      run_ordinal:$", raw, re.MULTILINE)
+    assert raw.count("GRADE_RUN_ORDINAL: ${{ inputs.run_ordinal }}") == 4
+    assert raw.count("ARGS+=(--run-ordinal") == 2
+    assert '"run_ordinal": os.environ["GRADE_RUN_ORDINAL"]' in raw
+
+
+def test_dispatching_a_repeat_needs_no_flag():
+    """Run 1 must be the default at every layer.
+
+    An ordinary grade is run 1 and nobody should have to say so; more to the
+    point, a default of anything else would silently divert the next real
+    campaign into `_repeats/`, where the dashboard never looks.
+    """
+    raw = GRADE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    ordinal_input = raw.split("      run_ordinal:", 1)[1].split("\n\n", 1)[0]
+
+    assert "default: 1" in ordinal_input
+    assert "required: false" in ordinal_input
+
+    import inspect
+
+    signature = inspect.signature(s8.resolve_grade_output_path)
+    assert signature.parameters["run_ordinal"].default == 1
+
+
+def test_repeats_are_not_visible_to_the_dashboard_aggregator():
+    """`_repeats/` only works because the aggregator does not descend.
+
+    It lists `data/grades/` one level deep and keeps the `.json` entries -- the
+    same guarantee `_shards/` already relies on. A subdirectory has no `.json`
+    extension, so it drops out. If that listing ever became a recursive walk,
+    three repeats of one measurement would appear as three competing results.
+    """
+    aggregator = (REPO_ROOT / "scripts/aggregate-grades.mjs").read_text(
+        encoding="utf-8"
+    )
+
+    # The one enumeration of the grades directory, with no options argument:
+    # `readdir(dir, {recursive: true})` is what would break the guarantee.
+    listings = re.findall(r"readdir\((.*?)\)", aggregator)
+    assert listings == ["GRADES_DIR"]
+    assert "extname(f) === '.json'" in aggregator

--- a/batch-runner/tests/test_gold_ceiling_contract.py
+++ b/batch-runner/tests/test_gold_ceiling_contract.py
@@ -723,3 +723,41 @@ def test_repeats_are_not_visible_to_the_dashboard_aggregator():
     listings = re.findall(r"readdir\((.*?)\)", aggregator)
     assert listings == ["GRADES_DIR"]
     assert "extname(f) === '.json'" in aggregator
+
+
+# --------------------------------------------------------------------------
+# The contract must survive a fresh clone
+# --------------------------------------------------------------------------
+#
+# `batch-runner/scripts/` is ignored by default with a per-file allow list, so
+# a script added there is present for whoever wrote it and absent for everyone
+# else. That is not a hypothetical: the manifest builder below was written,
+# used to produce the committed manifest, exercised by the tests in this file,
+# and still missing from the first push -- green here, red on a fresh checkout.
+#
+# The manifest itself carries the same risk from the other direction: it is the
+# only committed record of which 30 tasks were graded and what their files
+# hashed to, and both fingerprints in the specification are re-derived from it.
+
+CONTRACT_FILES = (
+    "batch-runner/scripts/build_gold_deliverable_manifest.py",
+    "batch-runner/experiments/gold_corpus/gold_deliverable_manifest.json",
+    "batch-runner/experiments/exp_gold_baseline.yaml",
+    "batch-runner/grading_configs/gold_ceiling_30_v2_sol_max.yaml",
+)
+
+
+@pytest.mark.parametrize("relative", CONTRACT_FILES)
+def test_the_frozen_contract_is_in_the_repository(relative):
+    path = REPO_ROOT / relative
+    assert path.is_file(), f"{relative} is missing"
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", relative],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.returncode == 0, (
+        f"{relative} exists here but git does not track it, so a fresh clone "
+        "would not have it. Add it to the allow list in .gitignore."
+    )

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -3294,6 +3294,7 @@ def _auto_resume_dispatch(script: str) -> dict:
             "NEXT_CHUNK": "4",
             "GRADE_SHARD_COUNT": "9",
             "GRADE_SHARD_INDEX": "6",
+            "GRADE_RUN_ORDINAL": "3",
         },
     )
     payload = json.loads(completed.stdout)
@@ -3473,6 +3474,7 @@ def _run_grade_workflow_input_preflight(**overrides):
         "GRADE_RESUME_CHUNK": "0",
         "GRADE_SHARD_COUNT": "1",
         "GRADE_SHARD_INDEX": "0",
+        "GRADE_RUN_ORDINAL": "1",
         **overrides,
     }
     return subprocess.run(
@@ -3505,6 +3507,24 @@ def _run_grade_workflow_input_preflight(**overrides):
             "GRADE_RESUME_CHUNK": "1",
             "GRADE_SHARD_COUNT": "11",
             "GRADE_SHARD_INDEX": "10",
+        },
+        # The top repeat, dry: previewing a repeat has to be as free as
+        # previewing the run it repeats, or the only way to check the path is
+        # to pay for it.
+        {"GRADE_RUN_ORDINAL": "10"},
+        # A repeat that is also sharded and mid-relay. All three forks stack in
+        # the output path, so all three have to be dispatchable at once --
+        # otherwise a repeat too long for one four-hour chunk cannot be run at
+        # all, and stage 2 needs three of them.
+        {
+            "GRADE_INFERENCE_REVISION": "b" * 40,
+            "GRADE_DRY_RUN": "false",
+            "GRADE_PAID_APPROVAL": "true",
+            "GRADE_RESUME": "true",
+            "GRADE_RESUME_CHUNK": "2",
+            "GRADE_SHARD_COUNT": "3",
+            "GRADE_SHARD_INDEX": "2",
+            "GRADE_RUN_ORDINAL": "3",
         },
     ],
 )
@@ -3555,6 +3575,16 @@ def test_grade_workflow_input_preflight_accepts_valid_dispatch(overrides):
             {"GRADE_SHARD_COUNT": "2", "GRADE_TASKS_LIMIT": "5"},
             "cannot be combined with tasks_limit",
         ),
+        # step8 caps repeats at MAX_RUN_ORDINAL. An ordinal past it is refused
+        # here rather than after the runner has been paid for and started, and
+        # 0 is refused rather than silently meaning "the original".
+        ({"GRADE_RUN_ORDINAL": "0"}, "run_ordinal"),
+        ({"GRADE_RUN_ORDINAL": "11"}, "run_ordinal"),
+        ({"GRADE_RUN_ORDINAL": "-1"}, "run_ordinal"),
+        # "01" reads as 1 to a shell comparison and as a different directory
+        # name to the grader, which is how two runs end up in one file.
+        ({"GRADE_RUN_ORDINAL": "01"}, "run_ordinal"),
+        ({"GRADE_RUN_ORDINAL": ""}, "run_ordinal"),
     ],
 )
 def test_grade_workflow_input_preflight_rejects_invalid_dispatch(overrides, error):
@@ -4174,6 +4204,10 @@ def test_grade_workflow_wires_shards_end_to_end():
     resume_inputs = _auto_resume_dispatch(retrigger["run"])["inputs"]
     assert resume_inputs["shard_count"] == "9"
     assert resume_inputs["shard_index"] == "6"
+    # ...and OF THE SAME REPEAT. A repeat's partial lives under _repeats/, so
+    # an ordinal dropped here resumes into run 1's path and either is refused
+    # or overwrites the run this one exists to be compared against.
+    assert resume_inputs["run_ordinal"] == "3"
 
     merge = by_name["Merge shards into the final grade"]
     assert merge["id"] == "merge_shards"

--- a/tasks/rebuilding_grading_task/300-gold-ceiling.md
+++ b/tasks/rebuilding_grading_task/300-gold-ceiling.md
@@ -6,6 +6,8 @@
 
 `openai/gdpval` rubric에 포함된 gold deliverable을 v2 grader로 채점. **gold가 ceiling을 안 찍으면 grader/입력이 여전히 깨진 것** — 가장 중요한 sanity check.
 
+이미 발표된 모든 모델 점수는 이 천장을 기준으로 읽힌다. 그러니 측정 대상이 흔들리면 측정 자체가 무의미하다. 아래 "고정 계약"은 흔들릴 수 있는 것을 전부 못으로 박은 목록이다.
+
 ## 작업
 
 1. `data/gdpval-local`의 reference_files / gold_deliverable_files 위치 확인
@@ -22,3 +24,84 @@
 - gold 평균 pct ≥ 90%
 - critical_pass ≥ 0.95
 - 미달 시 grader/tool 결함 보고 (PR2로 되돌림 또는 hotfix)
+
+---
+
+## 고정 계약 (Stage 1, 30-task)
+
+한 번의 유료 실행이 무엇을 측정한 것인지 나중에도 재현·반박할 수 있도록, 움직일 수 있는 것을 전부 고정한다. 아래 값은 전부 저장소에 커밋된 파일에서 다시 계산되며, `batch-runner/tests/test_gold_ceiling_contract.py`가 어긋나면 실패한다 — 즉 신뢰가 아니라 검사 대상이다.
+
+### 무엇을 채점하는가
+
+| 항목 | 고정값 | 어디에 박혀 있나 |
+|---|---|---|
+| 데이터셋 | `openai/gdpval` | `experiments/exp_gold_baseline.yaml` |
+| 데이터셋 커밋 | `11e7900cdcac61bc4daf59e65feb238acda98fbf` | grading config `rerun_identity` |
+| rubric 커밋 | 같은 커밋 (`main` 아님) | grading config `rubric.revision` |
+| parquet 파일 지문 | `f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202` | `experiments/gold_corpus/gold_deliverable_manifest.json` |
+| 채점 대상 | 30 task | grading config `rerun_identity.task_ids` |
+| 채점 설정 | `grading_configs/gold_ceiling_30_v2_sol_max.yaml` | — |
+| grader 소스 지문 | 실행 시 계산되어 파일명과 grade JSON에 기록 | `compute_grader_source_hash` |
+| 컨테이너 이미지 | `ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c0…` (digest 고정) | `.github/workflows/grade-run.yml` |
+| LibreOffice | `LibreOffice 24.2.7.2 420(Build:2)` | `scripts/preflight_grading_renderer.py`, 이미지 빌드 시 검증 |
+
+컨테이너 digest와 LibreOffice 버전은 실행 시 `renderer_fingerprint`로 grade JSON 안에 다시 기록된다. 즉 사후에 "그때 뭘로 렌더링했나"를 문서가 아니라 결과물에서 확인할 수 있다.
+
+### 어떤 30개인가
+
+데이터셋 자기 행 순서대로 걸어가며 **실제로 gold 답안이 있는** 첫 30개. 220개 중 185개만 gold를 가지므로, 앞쪽 34행 안에서 4개가 답안 없음으로 건너뛰어진다.
+
+앞에서부터 자르는 이유는 재현성이다. seed도 없고 표본 추출 코드도 없으니, 데이터셋만 있으면 누구나 같은 30개를 다시 얻는다. 대신 표본은 좁다 — 연속된 행이 직업을 공유하므로 4개 sector, 7개 직업뿐이다. 이건 대표성 조사가 아니라 grader 온전성 검사다. 전수 220개는 Stage 3에서 한다.
+
+순서도 계약의 일부다. `step8_grade.py`는 (a) 원본 순서를 따르지 않는 목록을 거부하고, (b) 고정 목록과 선택된 목록을 순서까지 포함해 동등 비교한다. 재정렬은 조용히 다른 실행이 되는 대신 거부된다.
+
+### 입력 지문
+
+| 지문 | 값 |
+|---|---|
+| `ordered_task_ids_sha256` | `09ce924576b6822a7f96d651b40c18add5fceb6e216653c8bdb9c5a194c9dfdc` |
+| `gold_file_set_sha256` | `cd4448b4a25b12aa3ae95616a60fdccc47707298d86a9aa2f7cd2ace9c15a7c8` |
+
+- `ordered_task_ids_sha256` = 30개 task id를 순서대로 개행으로 이어 붙인 문자열의 SHA-256
+- `gold_file_set_sha256` = 각 파일의 `graded_path\tsha256\tsize`를 task 순서대로 개행으로 이어 붙인 문자열의 SHA-256
+
+두 값 모두 매니페스트와 grading config만으로 다시 계산된다 — 623MB짜리 원본 파일 없이도 검증 가능하다.
+
+**표본 구성**: 파일 40개 / 184,099,078 바이트. 확장자는 docx 13, pdf 12, xlsx 11, pptx 3, zip 1. sector는 Government 13, Professional·Scientific·Technical 9, Manufacturing 5, Information 3. 직업은 Accountants and Auditors 5, Administrative Services Managers 5, Buyers and Purchasing Agents 5, Compliance Officers 5, Computer and Information Systems Managers 4, Audio and Video Technicians 3, Child·Family·School Social Workers 3.
+
+### 알려진 입력 한계 (사전 공개)
+
+task `38889c3b-e3d4-49c8-816a-3cc8e5313aba`의 gold 답안은 179.7MB `.zip` 한 개다. `core/tools/read_deliverable.py`는 zip을 다루지 못한다 — `kind`가 `unknown`으로 떨어지고 `read_content`는 빈 텍스트에 "binary or unsupported for text read" 주석을 붙여 돌려준다.
+
+그래도 표본에서 빼지 않는다. 빼면 천장이 실제보다 좋아 보이기 때문이다. 이 task가 낮게 나오면 그건 grader 결함이 아니라 **읽기 도구의 형식 미지원**이며, 결과 분석에서 그렇게 분류해야 한다. 미리 적어두는 이유는, 실행 후에 이유를 만들어내는 것과 미리 예측해두는 것은 증거로서 값이 다르기 때문이다.
+
+### 결과가 발표되지 않는 이유
+
+`step8_grade.py`는 `gold-corpus` 출처의 모든 실행을 진단 경로(`data/grades/_diagnostic/…`)로 보낸다. 대시보드에는 "이건 천장이지 경쟁자가 아니다"라고 말할 방법이 없어서, 정규 경로에 놓이면 모델들과 나란히 순위에 오르기 때문이다. 이 규칙은 채점 범위가 얼마나 넓은지와 무관하다 — 전수를 고정해도 여전히 진단이다.
+
+### 실행 계획
+
+커밋된 220-task Sol Max 실행 기준으로 task당 평균 19.44분, 중앙값 19.29분, p90 32.7분이다. 30 task면 약 9.7시간 — 한 청크의 4시간 예산(`GRADER_TIME_BUDGET_SEC=14400`)을 넘는다.
+
+그래서 **3 shard × 10 task**로 나눈다. shard당 약 3.2시간이면 자동 재개(rc=7) 없이 한 청크 안에 끝난다. shard는 병렬로 돌고, `step9_merge_shards.py`가 하나로 합친다.
+
+유료 실행 전에 `dry_run: true`로 전 경로를 무료로 통과시킨다 — 설정 검증, 고정 목록 대조, 컨테이너·렌더러 확인까지 모델 호출 없이 끝나는 구간이 거기까지다.
+
+**shard가 도는 동안 `core/`·`schemas/`·`prompts/`·`grading_configs/`·`grade-run.yml`을 병합하지 말 것.** grader 소스 지문이 바뀌면 합치기가 실패하는데, 그 실패는 이미 돈을 다 쓴 뒤에야 드러난다.
+
+### 기록할 것
+
+실행 후 `tasks/rebuilding_grading_task/PR3_GOLD_CEILING.md`에:
+
+- 평균 점수, 필수 항목 통과율, grader 오류율 — 임계값(90% / 0.95 / 2%) 대비
+- task별 증거: 만점 미달 항목마다 라이브러리 한계인지 진짜 미흡인지 분류
+- 모델별 사용량, 이미지·오디오 채점 호출 수
+- 실제 청구액. 가격 미확정 모델(`gpt-5.6-sol`, `gpt-audio-1.5`)이 있으면 `pricing_complete: false`로 남기고 `$0`이라고 쓰지 말 것
+
+임계값 미달이면 grader 결함인지, 입력 결함인지, 도구 결함인지 분류한다. 저장소 문제면 고치고, 검증하고, 다시 돌린다.
+
+### Stage 2 준비물 (여기서 만들어 둔 것)
+
+`303-variance-and-error.md`는 같은 30개를 **세 번** 채점해야 한다. 그런데 실행을 식별하는 값은 하나도 바꿀 수 없다 — grader 소스, 설정, 대상, 입력이 전부 같아야 분산 측정이 성립한다. 그래서 세 번 모두 같은 출력 경로로 떨어지고, 두 번째는 "이미 있음"으로 거부되며 `--force`는 첫 번째를 지운다.
+
+그래서 `--run-ordinal`을 추가했다. 실행 번호만 출력 디렉터리를 가르고, 식별값은 하나도 건드리지 않는다. shard 갈림길보다 **위**에 두었으므로, 한 청크에 안 들어가는 반복도 여전히 쪼갤 수 있다. 1번은 정규 경로를 그대로 쓴다 — 반복 묶음의 원본은 평범한 실행이고 별도 플래그가 필요 없다.


### PR DESCRIPTION
## 왜 이걸 하는가

발표된 모든 모델 점수는 하나의 가정 위에 서 있다 — 채점기가 좋은 결과물을 좋다고 알아본다는 가정. 그 가정을 검사하는 방법은 하나뿐이다: 벤치마크가 스스로 정답이라고 내놓은 답안을 채점해서, 거의 만점이 나오는지 보는 것. 안 나오면 채점기나 그 입력이 깨진 것이고, 그 아래 모든 숫자를 다시 읽어야 한다.

지금까지 그럴 방법이 없었다. 채점기는 제출된 추론 결과만 읽을 수 있었고, 정답 답안은 데이터셋 안에 불투명한 이름의 폴더로만 들어 있었다.

이 PR은 **채점 준비**까지다. 실제 유료 채점은 병합 후 dispatch하며, 결과는 별도 문서로 남긴다.

## 무엇이 바뀌나

### 1. 정답 답안을 채점 대상으로 등록하는 경로

`scripts/download_inference_from_hf.py`에 `data.inference_source` 갈림길을 넣었다.

- 값이 없으면 지금까지와 **똑같이** 제출물을 받는다 (기존 실험 전부 무영향)
- `gold_deliverables` 면 데이터셋 parquet에서 정답 파일을 꺼내 `deliverable_files/<task_id>/` 로 다시 심는다
- **모르는 값은 거부한다.** 조용히 제출물로 되돌아가지 않는다

정답 경로는 40자리 리비전을 요구하고 (`main` 같은 움직이는 참조 금지), 220행을 **전부** 유지한다 — 정답이 없는 35개를 미리 빼면 고정한 30개가 전수처럼 읽히기 때문이다.

`step8_grade.py`는 이 출처를 `gold-corpus`로 기록하고, 그런 실행을 **항상** 진단 경로(`data/grades/_diagnostic/…`)로 보낸다. 대시보드에는 "이건 천장이지 경쟁자가 아니다"라고 말할 자리가 없어서, 정규 경로에 놓이면 모델들과 나란히 순위에 오른다. 이 규칙은 채점 범위와 무관하다 — 전수를 고정해도 여전히 진단이다.

### 2. `--run-ordinal` (Stage 2 준비물)

`303-variance-and-error.md`는 같은 30개를 **세 번** 채점해야 한다. 그런데 실행을 식별하는 값은 하나도 바꿀 수 없다 — grader 소스, 설정, 대상, 입력이 전부 같아야 분산 측정이 성립한다. 그래서 세 번 모두 같은 출력 경로로 떨어지고, 두 번째는 "이미 있음"으로 거부되며 `--force`는 첫 번째를 지운다.

실행 번호만 출력 디렉터리를 가른다. 식별값은 하나도 건드리지 않는다. shard 갈림길보다 **위**에 두었으므로 한 청크에 안 들어가는 반복도 여전히 쪼갤 수 있고, 1번은 정규 경로를 그대로 쓴다 — 반복 묶음의 원본은 평범한 실행이다.

## 고정한 것

| 항목 | 값 | 어디에 박혀 있나 |
|---|---|---|
| 데이터셋 커밋 | `11e7900cdcac61bc4daf59e65feb238acda98fbf` | grading config `rerun_identity` |
| rubric 커밋 | 같은 커밋 (`main` 아님) | grading config `rubric.revision` |
| parquet 지문 | `f8422fab9b21d90c…` | `gold_deliverable_manifest.json` |
| 채점 대상 | 30 task, 순서 포함 | `rerun_identity.task_ids` |
| 컨테이너 | `ghcr.io/…/gdpval-grading@sha256:0f6782c0…` | `grade-run.yml` |
| LibreOffice | `24.2.7.2 420(Build:2)` | 이미지 빌드 시 검증 |

**입력 지문**

- `ordered_task_ids_sha256` = `09ce924576b6822a7f96d651b40c18add5fceb6e216653c8bdb9c5a194c9dfdc`
- `gold_file_set_sha256` = `cd4448b4a25b12aa3ae95616a60fdccc47707298d86a9aa2f7cd2ace9c15a7c8`

둘 다 **매니페스트와 grading config만으로** 다시 계산된다 — 623MB짜리 원본 파일 없이도 검증 가능하다. `tests/test_gold_ceiling_contract.py`가 어긋나면 실패하므로, 이 값들은 신뢰 대상이 아니라 검사 대상이다.

표본은 데이터셋 자기 행 순서대로 걸어가며 실제로 정답이 있는 첫 30개다. seed도 없고 표본 추출 코드도 없으니 데이터셋만 있으면 누구나 같은 30개를 다시 얻는다. 대신 좁다 — 연속된 행이 직업을 공유하므로 4개 sector, 7개 직업뿐이다. 대표성 조사가 아니라 채점기 온전성 검사다. 전수 220개는 Stage 3에서 한다.

## 미리 적어두는 한계

task `38889c3b-e3d4-49c8-816a-3cc8e5313aba`의 정답은 179.7MB `.zip` 하나다. `core/tools/read_deliverable.py`는 zip을 다루지 못한다 — `kind`가 `unknown`으로 떨어지고 빈 텍스트를 돌려준다.

그래도 표본에서 **빼지 않는다**. 빼면 천장이 실제보다 좋아 보이기 때문이다. 이 task가 낮게 나오면 채점기 결함이 아니라 **읽기 도구의 형식 미지원**이며, 결과 분석에서 그렇게 분류한다. 실행 후에 이유를 만들어내는 것과 미리 예측해두는 것은 증거로서 값이 다르다.

## 검증

- 전체 단위 시험 **5016 passed, 6 skipped, 45 deselected, 0 failed** (594s)
- 새 시험 파일 29개 — 30개 목록과 두 지문을 매니페스트에서 **다시 계산**해 대조하고, 정답 실행이 진단 경로로 가는 것을 돌연변이로 증명하고, 반복 갈림길이 shard·진단과 합성되는 것을 확인한다
- shard 합치기는 워크플로의 **실제 bash를 잘라내 실행**한다. 반복 경로를 거부하는 가드가 생기면 여기서 실패한다 — 안 그러면 세 shard를 다 채점하고 돈을 쓴 뒤에야 드러난다
- `mypy core/ --ignore-missing-imports` 170 errors / 32 files — main 기준선과 동일
- 기존 실험 yaml에 `inference_source`가 없으므로 전부 `submission`으로 떨어진다. `test_main_resolves_anchor_config_allowance`가 실제 파일로 그것을 확인한다

## 다음

1. 이 PR 병합
2. `dry_run: true` dispatch — 모델 호출 없이 전 경로 무료 통과
3. 유료 dispatch **3 shard × 10 task** (task당 약 19.4분 → shard당 약 3.2시간, 4시간 예산 안)
4. shard 합치고 `PR3_GOLD_CEILING.md` 작성 — 평균 점수 / 필수 항목 통과율 / 채점기 오류율을 임계값 90% · 0.95 · 2% 대비로

**shard가 도는 동안 `core/`·`schemas/`·`prompts/`·`grading_configs/`·`grade-run.yml`을 병합하지 말 것.** grader 소스 지문이 바뀌면 합치기가 실패하는데, 그 실패는 이미 돈을 다 쓴 뒤에야 드러난다.

Refs #51 · spec `tasks/rebuilding_grading_task/300-gold-ceiling.md`
