### PR TITLE
feat(gold-ceiling): 실행 결과를 stage 1이 묻는 여섯 가지 숫자로 읽어낸다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/check_agentic_containment.py
 !batch-runner/scripts/build_gdpval_task_catalog.py
 !batch-runner/scripts/build_gold_deliverable_manifest.py
+!batch-runner/scripts/analyze_gold_ceiling.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/batch-runner/scripts/analyze_gold_ceiling.py
+++ b/batch-runner/scripts/analyze_gold_ceiling.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Read a gold-ceiling grade payload and answer the questions stage 1 asks.
+
+Why this exists
+---------------
+``tasks/rebuilding_grading_task/300-gold-ceiling.md`` asks for six things: the
+mean score, the required-item pass rate, the grader error rate, the evidence
+behind every item that fell short of full marks, the usage split by model, and
+the actual bill. Every one of those is already in the grade payload. Copying
+them into a report by hand is where a report stops matching its run -- so this
+reads them out, and the report quotes this.
+
+Two of the six need work the payload does not do for you:
+
+* **Image and audio call counts separately.** ``summary.cost`` carries one
+  ``total_perception_calls``. Which of those looked at a picture and which
+  listened to a recording is only recoverable per rubric item, from
+  ``routing_modality``, so this regroups them.
+* **Which shortfalls are the grader's fault.** Nothing can decide that
+  automatically. What this does is surface every below-maximum item with the
+  evidence the judge recorded, sorted so the largest losses come first, which
+  is the input a person needs to classify them.
+
+It also refuses a payload that is not the run the specification pinned. A
+number read out of the wrong file is worse than no number, and the three
+identity fields it checks -- task count, ordered-id fingerprint, and run
+status -- are exactly the ones that would differ if somebody pointed this at a
+shard, a repeat, or a different corpus.
+
+Usage
+-----
+    python batch-runner/scripts/analyze_gold_ceiling.py <grade.json>
+    python batch-runner/scripts/analyze_gold_ceiling.py <grade.json> --json
+
+Exit status is 0 when every threshold is met and 1 when any is missed, so a
+run that quietly fell below the ceiling cannot be reported as passing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# The three numbers stage 1 is accepted or rejected on, from
+# `tasks/rebuilding_grading_task/300-gold-ceiling.md` lines 17-19 and 24-26.
+# `test_gold_ceiling_analysis.py` checks these against the specification text,
+# so a threshold edited in one place and not the other fails rather than drifts.
+MEAN_SCORE_PCT_FLOOR = 90.0
+CRITICAL_ITEM_PASS_FLOOR = 0.95
+JUDGE_ERROR_RATE_CEILING = 0.02
+
+# What the specification pinned. A payload disagreeing with either is some
+# other run, and reading stage 1's numbers out of it would be a mistake no
+# reader could detect afterwards.
+EXPECTED_TASK_COUNT = 30
+EXPECTED_ORDERED_TASK_IDS_SHA256 = (
+    "09ce924576b6822a7f96d651b40c18add5fceb6e216653c8bdb9c5a194c9dfdc"
+)
+
+
+class NotTheRunThatWasPinned(SystemExit):
+    """The payload is readable but is not stage 1's run."""
+
+
+def _identity_problems(payload: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+
+    status = payload.get("run_status")
+    if status != "final":
+        problems.append(
+            f"run_status is {status!r}, not 'final' -- this is a shard or an "
+            "unfinished run, and its aggregates cover only part of the corpus"
+        )
+
+    count = payload.get("expected_task_count")
+    if count != EXPECTED_TASK_COUNT:
+        problems.append(
+            f"expected_task_count is {count!r}, not {EXPECTED_TASK_COUNT}"
+        )
+
+    ordered = payload.get("expected_ordered_task_ids_sha256")
+    if ordered != EXPECTED_ORDERED_TASK_IDS_SHA256:
+        problems.append(
+            "expected_ordered_task_ids_sha256 is "
+            f"{ordered!r}, not the pinned {EXPECTED_ORDERED_TASK_IDS_SHA256}"
+        )
+
+    graded = (payload.get("summary") or {}).get("graded_tasks")
+    if graded != EXPECTED_TASK_COUNT:
+        problems.append(
+            f"summary.graded_tasks is {graded!r}, so {EXPECTED_TASK_COUNT} "
+            "tasks were pinned but a different number was graded"
+        )
+
+    return problems
+
+
+def perception_calls_by_modality(payload: dict[str, Any]) -> dict[str, int]:
+    """How many perception calls each routing modality accounted for.
+
+    ``summary.cost.total_perception_calls`` is one number. The specification
+    asks for the image and audio counts separately, and only the rubric items
+    know which was which.
+    """
+    by_modality: dict[str, int] = defaultdict(int)
+    for task in payload.get("tasks") or []:
+        for item in task.get("items") or []:
+            calls = item.get("perception_call_count") or 0
+            if calls:
+                by_modality[item.get("routing_modality") or "unrecorded"] += calls
+    return dict(sorted(by_modality.items()))
+
+
+def items_below_full_marks(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every rubric item that did not score its maximum, biggest loss first.
+
+    This is the raw material for the specification's "library limit or genuine
+    shortfall" call. It deliberately keeps items whose award is *above* the
+    maximum out of the list but reports them separately as a fault, because a
+    score over the maximum is a grader bug rather than a shortfall.
+    """
+    shortfalls: list[dict[str, Any]] = []
+    for task in payload.get("tasks") or []:
+        for item in task.get("items") or []:
+            awarded = item.get("awarded_score")
+            maximum = item.get("max_score")
+            if awarded is None or maximum is None:
+                continue
+            if item.get("score_excluded"):
+                continue
+            if awarded >= maximum:
+                continue
+            shortfalls.append(
+                {
+                    "task_id": task.get("task_id"),
+                    "sector": task.get("sector"),
+                    "occupation": task.get("occupation"),
+                    "rubric_item_id": item.get("rubric_item_id"),
+                    "criterion": item.get("criterion"),
+                    "awarded_score": awarded,
+                    "max_score": maximum,
+                    "lost": round(float(maximum) - float(awarded), 4),
+                    "verdict": item.get("verdict"),
+                    "required": item.get("required"),
+                    "decided_by": item.get("decided_by"),
+                    "routing_modality": item.get("routing_modality"),
+                    "perception_called": item.get("perception_called"),
+                    "selection_status": item.get("selection_status"),
+                    "selection_error": item.get("selection_error"),
+                    "selected_paths": item.get("selected_paths"),
+                    "judge_confidence": item.get("judge_confidence"),
+                    "evidence": item.get("evidence"),
+                }
+            )
+    shortfalls.sort(key=lambda row: (-row["lost"], str(row["task_id"])))
+    return shortfalls
+
+
+def _tasks_with_errors(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {"task_id": task.get("task_id"), "error": task.get("error")}
+        for task in payload.get("tasks") or []
+        if task.get("error")
+    ]
+
+
+def _tasks_failing_a_required_item(payload: dict[str, Any]) -> list[str]:
+    return [
+        str(task.get("task_id"))
+        for task in payload.get("tasks") or []
+        if task.get("critical_fail")
+    ]
+
+
+def analyze(payload: dict[str, Any]) -> dict[str, Any]:
+    summary = payload.get("summary") or {}
+    compat = summary.get("openai_compat") or {}
+    wow = summary.get("wow") or {}
+    cost = summary.get("cost") or {}
+
+    mean_pct = compat.get("avg_score_pct")
+    critical_pass = wow.get("critical_item_pass_rate")
+    error_rate = wow.get("judge_error_rate")
+
+    gates = {
+        "mean_score_pct": {
+            "value": mean_pct,
+            "floor": MEAN_SCORE_PCT_FLOOR,
+            "met": mean_pct is not None and mean_pct >= MEAN_SCORE_PCT_FLOOR,
+        },
+        "critical_item_pass_rate": {
+            "value": critical_pass,
+            "floor": CRITICAL_ITEM_PASS_FLOOR,
+            "met": (
+                critical_pass is not None
+                and critical_pass >= CRITICAL_ITEM_PASS_FLOOR
+            ),
+        },
+        "judge_error_rate": {
+            "value": error_rate,
+            "ceiling": JUDGE_ERROR_RATE_CEILING,
+            "met": error_rate is not None and error_rate < JUDGE_ERROR_RATE_CEILING,
+        },
+    }
+
+    shortfalls = items_below_full_marks(payload)
+    graded_items = sum(len(task.get("items") or []) for task in payload.get("tasks") or [])
+
+    return {
+        "identity": {
+            "experiment_id": payload.get("experiment_id"),
+            "run_status": payload.get("run_status"),
+            "graded_at": payload.get("graded_at"),
+            "judge": payload.get("judge"),
+            "grader_source_hash": payload.get("grader_source_hash"),
+            "renderer_fingerprint": payload.get("renderer_fingerprint"),
+            "source_inference_revision": payload.get("source_inference_revision"),
+            "source_azure_ai_provenance_status": payload.get(
+                "source_azure_ai_provenance_status"
+            ),
+            "expected_task_count": payload.get("expected_task_count"),
+            "expected_ordered_task_ids_sha256": payload.get(
+                "expected_ordered_task_ids_sha256"
+            ),
+            "shard_provenance": payload.get("shard_provenance"),
+        },
+        "gates": gates,
+        "all_gates_met": all(gate["met"] for gate in gates.values()),
+        "scores": {
+            "graded_tasks": summary.get("graded_tasks"),
+            "error_tasks": summary.get("error_tasks"),
+            "perfect_count": compat.get("perfect_count"),
+            "zero_count": compat.get("zero_count"),
+            "partial_count": compat.get("partial_count"),
+            "ci_pct": compat.get("ci_pct"),
+            "rubric_item_coverage_avg": wow.get("rubric_item_coverage_avg"),
+            "judge_pass_rate": wow.get("judge_pass_rate"),
+            "precheck_pass_rate": wow.get("precheck_pass_rate"),
+            "by_sector": wow.get("by_sector"),
+            "score_density_histogram": wow.get("score_density_histogram"),
+        },
+        "usage": {
+            "total_judge_calls": cost.get("total_judge_calls"),
+            "total_main_judge_calls": cost.get("total_main_judge_calls"),
+            "total_perception_calls": cost.get("total_perception_calls"),
+            "total_render_calls": cost.get("total_render_calls"),
+            "main_input_tokens": cost.get("main_input_tokens"),
+            "main_output_tokens": cost.get("main_output_tokens"),
+            "main_cached_tokens": cost.get("main_cached_tokens"),
+            "perception_input_tokens": cost.get("perception_input_tokens"),
+            "perception_output_tokens": cost.get("perception_output_tokens"),
+            "perception_cached_tokens": cost.get("perception_cached_tokens"),
+            "total_judge_latency_sec": cost.get("total_judge_latency_sec"),
+            "usage_complete": cost.get("usage_complete"),
+            "perception_calls_by_modality": perception_calls_by_modality(payload),
+        },
+        "bill": {
+            "estimated_cost_usd": cost.get("estimated_cost_usd"),
+            "pricing_complete": cost.get("pricing_complete"),
+            "unpriced_models": cost.get("unpriced_models"),
+        },
+        "shortfalls": {
+            "graded_items": graded_items,
+            "below_full_marks": len(shortfalls),
+            "total_points_lost": round(sum(row["lost"] for row in shortfalls), 4),
+            "tasks_failing_a_required_item": _tasks_failing_a_required_item(payload),
+            "tasks_with_errors": _tasks_with_errors(payload),
+            "items": shortfalls,
+        },
+    }
+
+
+def _mark(met: bool) -> str:
+    return "PASS" if met else "MISS"
+
+
+def _describe_renderer(fingerprint: Any) -> str:
+    """The renderer line, with the LibreOffice version where a reader looks.
+
+    Stage 1 freezes the LibreOffice version by name, so it should not be
+    something you find by reading a dictionary printed sideways.
+    """
+    if not isinstance(fingerprint, dict):
+        return str(fingerprint)
+    parts = [
+        str(fingerprint.get("libreoffice_version") or "libreoffice version unrecorded")
+    ]
+    pymupdf = fingerprint.get("pymupdf_version")
+    if pymupdf:
+        parts.append(f"pymupdf {pymupdf}")
+    return ", ".join(parts)
+
+
+def _wrapped_ids(task_ids: list[str], *, per_line: int = 3, indent: str = " " * 6) -> list[str]:
+    """Identifiers down the page rather than off the side of it."""
+    return [
+        indent + ", ".join(task_ids[start : start + per_line])
+        for start in range(0, len(task_ids), per_line)
+    ]
+
+
+def _render(report: dict[str, Any], *, shortfall_limit: int) -> str:
+    lines: list[str] = []
+    identity = report["identity"]
+    lines.append("Gold ceiling — stage 1")
+    lines.append("=" * 60)
+    lines.append(f"  experiment      {identity['experiment_id']}")
+    lines.append(f"  graded at       {identity['graded_at']}")
+    lines.append(f"  run status      {identity['run_status']}")
+    lines.append(f"  grader source   {identity['grader_source_hash']}")
+    lines.append(f"  renderer        {_describe_renderer(identity['renderer_fingerprint'])}")
+    lines.append(f"  provenance      {identity['source_azure_ai_provenance_status']}")
+    lines.append("")
+
+    lines.append("Thresholds")
+    lines.append("-" * 60)
+    gates = report["gates"]
+    mean = gates["mean_score_pct"]
+    crit = gates["critical_item_pass_rate"]
+    err = gates["judge_error_rate"]
+    lines.append(
+        f"  mean score              {mean['value']}%   "
+        f"(needs >= {mean['floor']}%)   {_mark(mean['met'])}"
+    )
+    lines.append(
+        f"  required-item pass      {crit['value']}   "
+        f"(needs >= {crit['floor']})   {_mark(crit['met'])}"
+    )
+    lines.append(
+        f"  grader error rate       {err['value']}   "
+        f"(needs < {err['ceiling']})   {_mark(err['met'])}"
+    )
+    lines.append("")
+
+    scores = report["scores"]
+    lines.append("Scores")
+    lines.append("-" * 60)
+    lines.append(
+        f"  graded {scores['graded_tasks']} task(s), "
+        f"{scores['error_tasks']} in error; "
+        f"{scores['perfect_count']} perfect, "
+        f"{scores['partial_count']} partial, {scores['zero_count']} zero"
+    )
+    lines.append(f"  rubric item coverage    {scores['rubric_item_coverage_avg']}")
+    lines.append(f"  judge pass rate         {scores['judge_pass_rate']}")
+    for sector, block in (scores["by_sector"] or {}).items():
+        lines.append(
+            f"    {sector:<52} {block.get('avg_pct')}%  "
+            f"n={block.get('task_count')}"
+        )
+    lines.append("")
+
+    usage = report["usage"]
+    lines.append("Usage")
+    lines.append("-" * 60)
+    lines.append(
+        f"  judge calls             {usage['total_judge_calls']} "
+        f"({usage['total_main_judge_calls']} main, "
+        f"{usage['total_perception_calls']} perception)"
+    )
+    for modality, calls in (usage["perception_calls_by_modality"] or {}).items():
+        lines.append(f"    {modality:<20} {calls}")
+    if not usage["perception_calls_by_modality"]:
+        lines.append("    (no perception call was made)")
+    lines.append(
+        f"  main tokens             in {usage['main_input_tokens']}, "
+        f"out {usage['main_output_tokens']}, "
+        f"cached {usage['main_cached_tokens']}"
+    )
+    lines.append(
+        f"  perception tokens       in {usage['perception_input_tokens']}, "
+        f"out {usage['perception_output_tokens']}"
+    )
+    lines.append(f"  judge latency (total)   {usage['total_judge_latency_sec']}s")
+    lines.append(f"  usage complete          {usage['usage_complete']}")
+    lines.append("")
+
+    bill = report["bill"]
+    lines.append("Bill")
+    lines.append("-" * 60)
+    if bill["pricing_complete"]:
+        lines.append(f"  estimated cost          ${bill['estimated_cost_usd']}")
+    else:
+        # Never render an unpriced run as zero. A model with no published price
+        # makes the total unknown, and unknown is not free.
+        lines.append(
+            "  estimated cost          UNKNOWN — not every model used has a "
+            "published price"
+        )
+        lines.append(f"  unpriced models         {bill['unpriced_models']}")
+    lines.append("")
+
+    short = report["shortfalls"]
+    lines.append("Shortfalls")
+    lines.append("-" * 60)
+    lines.append(
+        f"  {short['below_full_marks']} of {short['graded_items']} rubric item(s) "
+        f"scored below their maximum, losing {short['total_points_lost']} point(s)"
+    )
+    if short["tasks_failing_a_required_item"]:
+        failed = short["tasks_failing_a_required_item"]
+        lines.append(f"  required item failed in {len(failed)} task(s):")
+        lines.extend(_wrapped_ids(failed))
+    if short["tasks_with_errors"]:
+        lines.append(f"  tasks in error: {len(short['tasks_with_errors'])}")
+        for row in short["tasks_with_errors"]:
+            lines.append(f"      {row['task_id']}  {row['error']}")
+    lines.append("")
+
+    for row in short["items"][:shortfall_limit]:
+        lines.append(
+            f"  -{row['lost']} of {row['max_score']}  "
+            f"[{row['verdict']}, {row['routing_modality']}, "
+            f"decided by {row['decided_by']}]  {row['task_id']}"
+        )
+        lines.append(f"      criterion  {(row['criterion'] or '')[:150]}")
+        lines.append(f"      evidence   {(row['evidence'] or '')[:220]}")
+        if row["selection_status"] != "ok":
+            lines.append(
+                f"      selection  {row['selection_status']}: {row['selection_error']}"
+            )
+    remaining = len(short["items"]) - shortfall_limit
+    if remaining > 0:
+        lines.append(f"  ... and {remaining} more (use --json for all of them)")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("grade_file", type=Path, help="merged grade payload JSON")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the whole analysis as JSON instead of a readable report",
+    )
+    parser.add_argument(
+        "--shortfall-limit",
+        type=int,
+        default=40,
+        help="how many below-maximum items to print in the readable report",
+    )
+    parser.add_argument(
+        "--allow-any-run",
+        action="store_true",
+        help=(
+            "skip the check that this payload is the run the specification "
+            "pinned. Use for a repeat or a shard, never for stage 1's own number"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    payload = json.loads(args.grade_file.read_text(encoding="utf-8"))
+
+    if not args.allow_any_run:
+        problems = _identity_problems(payload)
+        if problems:
+            raise NotTheRunThatWasPinned(
+                f"{args.grade_file} is not the run stage 1 pinned:\n  - "
+                + "\n  - ".join(problems)
+                + "\nPass --allow-any-run to read it anyway."
+            )
+
+    report = analyze(payload)
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(_render(report, shortfall_limit=args.shortfall_limit))
+
+    return 0 if report["all_gates_met"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/batch-runner/tests/test_gold_ceiling_analysis.py
+++ b/batch-runner/tests/test_gold_ceiling_analysis.py
@@ -1,0 +1,527 @@
+"""Tests for the gold-ceiling analysis tool.
+
+The tool exists so that stage 1's report quotes a run rather than restating
+one. That only holds if three things are true, and each has a test here.
+
+The thresholds have to be the specification's thresholds. They are written as
+constants in the script, so ``test_the_thresholds_are_the_ones_the_spec_states``
+holds them against the specification text: an acceptance bar loosened in the
+code and not in the document fails rather than passes quietly.
+
+The payload has to be the run that was pinned. Stage 2 will produce repeats and
+every run produces shards, all of them structurally identical and all of them
+wrong to read stage 1's number out of. The identity check refuses each, and
+refuses a payload whose graded count does not match the count it declares.
+
+And the tool has to survive a fresh clone. ``batch-runner/scripts/`` is ignored
+with a per-file allow list, so a script added there works for whoever wrote it
+and is absent for everyone else -- which is exactly how the manifest builder
+reached CI red on an earlier pass of this same work.
+"""
+
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from scripts import analyze_gold_ceiling as analysis
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC_PATH = REPO_ROOT / "tasks/rebuilding_grading_task/300-gold-ceiling.md"
+TOOL_PATH = "batch-runner/scripts/analyze_gold_ceiling.py"
+
+
+def _item(**overrides):
+    item = {
+        "rubric_item_id": "item-1",
+        "criterion": "The workbook opens.",
+        "max_score": 2,
+        "awarded_score": 2.0,
+        "verdict": "pass",
+        "decided_by": "judge",
+        "required": None,
+        "evidence": "opened cleanly",
+        "judge_confidence": 1.0,
+        "routing_modality": "text",
+        "perception_called": False,
+        "perception_call_count": 0,
+        "selection_status": "ok",
+        "selection_error": None,
+        "selected_paths": ["Sample.xlsx"],
+        "score_excluded": False,
+    }
+    item.update(overrides)
+    return item
+
+
+def _task(task_id="task-1", items=None, **overrides):
+    task = {
+        "task_id": task_id,
+        "sector": "Government",
+        "occupation": "Auditor",
+        "critical_fail": False,
+        "error": None,
+        "items": items if items is not None else [_item()],
+    }
+    task.update(overrides)
+    return task
+
+
+def _payload(tasks=None, **overrides):
+    """A payload shaped like a real one and passing every identity check."""
+    payload = {
+        "experiment_id": "exp_gold_baseline",
+        "run_status": "final",
+        "graded_at": "2026-08-28T15:00:00Z",
+        "judge": {"model": "gpt-5.6-sol"},
+        "grader_source_hash": "a" * 64,
+        "renderer_fingerprint": "libreoffice-24.2.7.2",
+        "source_inference_revision": "1" * 40,
+        "source_azure_ai_provenance_status": "gold-corpus",
+        "expected_task_count": analysis.EXPECTED_TASK_COUNT,
+        "expected_ordered_task_ids_sha256": (
+            analysis.EXPECTED_ORDERED_TASK_IDS_SHA256
+        ),
+        "shard_provenance": None,
+        "tasks": tasks if tasks is not None else [_task()],
+        "summary": {
+            "total_tasks": analysis.EXPECTED_TASK_COUNT,
+            "graded_tasks": analysis.EXPECTED_TASK_COUNT,
+            "error_tasks": 0,
+            "openai_compat": {
+                "avg_score_pct": 96.4,
+                "ci_pct": 2.1,
+                "perfect_count": 20,
+                "zero_count": 0,
+                "partial_count": 10,
+            },
+            "wow": {
+                "critical_item_pass_rate": 0.98,
+                "judge_error_rate": 0.004,
+                "judge_pass_rate": 0.95,
+                "precheck_pass_rate": 0.0,
+                "rubric_item_coverage_avg": 0.97,
+                "by_sector": {"Government": {"task_count": 30, "avg_pct": 96.4}},
+                "score_density_histogram": [],
+            },
+            "cost": {
+                "total_judge_calls": 1433,
+                "total_main_judge_calls": 1400,
+                "total_perception_calls": 33,
+                "total_render_calls": 33,
+                "main_input_tokens": 3_900_000,
+                "main_output_tokens": 340_000,
+                "main_cached_tokens": 1_000_000,
+                "perception_input_tokens": 50_000,
+                "perception_output_tokens": 6_000,
+                "perception_cached_tokens": 0,
+                "total_judge_latency_sec": 34567.8,
+                "estimated_cost_usd": None,
+                "pricing_complete": False,
+                "unpriced_models": ["gpt-5.6-sol", "gpt-audio-1.5"],
+                "usage_complete": True,
+            },
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ── The thresholds are the specification's ─────────────────────────────────
+
+
+def test_the_thresholds_are_the_ones_the_spec_states():
+    """A bar moved in the code and not in the document must fail here.
+
+    The specification writes them once as a list of expectations and again as
+    the acceptance criteria, so both spellings are checked -- loosening either
+    alone would leave the document self-contradictory and this green.
+    """
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+
+    assert f"≥ {analysis.MEAN_SCORE_PCT_FLOOR:.0f}%" in spec
+    assert f"≥ {analysis.CRITICAL_ITEM_PASS_FLOOR}" in spec
+    assert f"< {analysis.JUDGE_ERROR_RATE_CEILING:.0%}" in spec
+    assert (
+        f"{analysis.MEAN_SCORE_PCT_FLOOR:.0f}% / "
+        f"{analysis.CRITICAL_ITEM_PASS_FLOOR} / "
+        f"{analysis.JUDGE_ERROR_RATE_CEILING:.0%}"
+    ) in spec
+
+
+def test_the_pinned_corpus_matches_the_grading_config():
+    """The 30 the tool insists on are the 30 the run was told to grade."""
+    import hashlib
+
+    import yaml
+
+    config = yaml.safe_load(
+        (
+            REPO_ROOT / "batch-runner/grading_configs/gold_ceiling_30_v2_sol_max.yaml"
+        ).read_text(encoding="utf-8")
+    )
+    pinned = config["rerun_identity"]["task_ids"]
+
+    assert len(pinned) == analysis.EXPECTED_TASK_COUNT
+    digest = hashlib.sha256("\n".join(pinned).encode("utf-8")).hexdigest()
+    assert digest == analysis.EXPECTED_ORDERED_TASK_IDS_SHA256
+
+
+# ── Only stage 1's own run may be read as stage 1's number ─────────────────
+
+
+def test_a_complete_pinned_run_is_accepted():
+    assert analysis._identity_problems(_payload()) == []
+
+
+def test_a_shard_is_refused():
+    """A shard's aggregates cover its slice, and read like the whole run's."""
+    problems = analysis._identity_problems(_payload(run_status="partial"))
+
+    assert any("run_status" in problem for problem in problems)
+
+
+def test_a_different_corpus_is_refused():
+    problems = analysis._identity_problems(
+        _payload(expected_ordered_task_ids_sha256="b" * 64)
+    )
+
+    assert any("ordered_task_ids" in problem for problem in problems)
+
+
+def test_a_run_that_graded_fewer_tasks_than_it_declared_is_refused():
+    """The declared count and the graded count disagreeing is the whole point.
+
+    A payload can claim 30 while holding 12 -- that is what a merge failure
+    looks like -- and its mean would be the mean of 12.
+    """
+    payload = _payload()
+    payload["summary"]["graded_tasks"] = 12
+
+    problems = analysis._identity_problems(payload)
+
+    assert any("graded_tasks" in problem for problem in problems)
+
+
+def test_the_command_line_refuses_rather_than_reporting(tmp_path):
+    grade_file = tmp_path / "shard.json"
+    grade_file.write_text(json.dumps(_payload(run_status="partial")))
+
+    with pytest.raises(SystemExit) as refused:
+        analysis.main([str(grade_file)])
+
+    assert "not the run stage 1 pinned" in str(refused.value)
+
+
+def test_the_refusal_can_be_overridden_on_purpose(tmp_path, capsys):
+    """Stage 2 reads repeats with this tool, and they are legitimately not run 1."""
+    grade_file = tmp_path / "repeat.json"
+    grade_file.write_text(json.dumps(_payload(run_status="partial")))
+
+    exit_code = analysis.main([str(grade_file), "--allow-any-run", "--json"])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["gates"]["mean_score_pct"]["met"]
+
+
+# ── The three gates ────────────────────────────────────────────────────────
+
+
+def test_every_gate_met_reports_success():
+    report = analysis.analyze(_payload())
+
+    assert report["all_gates_met"]
+    assert report["gates"]["mean_score_pct"]["met"]
+    assert report["gates"]["critical_item_pass_rate"]["met"]
+    assert report["gates"]["judge_error_rate"]["met"]
+
+
+@pytest.mark.parametrize(
+    "block, field, value, gate",
+    [
+        ("openai_compat", "avg_score_pct", 89.9, "mean_score_pct"),
+        ("wow", "critical_item_pass_rate", 0.94, "critical_item_pass_rate"),
+        ("wow", "judge_error_rate", 0.02, "judge_error_rate"),
+    ],
+)
+def test_a_missed_gate_is_reported_and_exits_nonzero(
+    block, field, value, gate, tmp_path
+):
+    """Just under each bar, including the error rate's exact boundary.
+
+    The error rate is specified as strictly under 2%, so 0.02 itself misses.
+    """
+    payload = _payload()
+    payload["summary"][block][field] = value
+    grade_file = tmp_path / "grade.json"
+    grade_file.write_text(json.dumps(payload))
+
+    report = analysis.analyze(payload)
+    assert not report["gates"][gate]["met"]
+    assert not report["all_gates_met"]
+
+    assert analysis.main([str(grade_file)]) == 1
+
+
+def test_the_bars_themselves_are_met():
+    """Exactly at each bar passes, so the comparison is not off by one side."""
+    payload = _payload()
+    payload["summary"]["openai_compat"]["avg_score_pct"] = 90.0
+    payload["summary"]["wow"]["critical_item_pass_rate"] = 0.95
+    payload["summary"]["wow"]["judge_error_rate"] = 0.0199
+
+    assert analysis.analyze(payload)["all_gates_met"]
+
+
+def test_a_missing_number_is_a_miss_rather_than_a_pass():
+    """A payload with no mean must not read as clearing the bar."""
+    payload = _payload()
+    payload["summary"]["openai_compat"].pop("avg_score_pct")
+
+    report = analysis.analyze(payload)
+
+    assert not report["gates"]["mean_score_pct"]["met"]
+    assert not report["all_gates_met"]
+
+
+# ── Image and audio, counted apart ─────────────────────────────────────────
+
+
+def test_perception_calls_are_split_by_modality():
+    """The specification asks for the image and audio counts separately.
+
+    ``summary.cost`` only carries their sum, so the split has to come from the
+    rubric items.
+    """
+    payload = _payload(
+        tasks=[
+            _task(
+                "task-1",
+                items=[
+                    _item(routing_modality="visual", perception_call_count=3),
+                    _item(routing_modality="audio", perception_call_count=2),
+                    _item(routing_modality="text", perception_call_count=0),
+                ],
+            ),
+            _task(
+                "task-2",
+                items=[_item(routing_modality="visual", perception_call_count=1)],
+            ),
+        ]
+    )
+
+    assert analysis.perception_calls_by_modality(payload) == {
+        "audio": 2,
+        "visual": 4,
+    }
+
+
+def test_a_perception_call_with_no_recorded_modality_is_still_counted():
+    """Dropping it would make the parts silently smaller than the whole."""
+    payload = _payload(
+        tasks=[
+            _task(
+                items=[_item(routing_modality=None, perception_call_count=5)],
+            )
+        ]
+    )
+
+    assert analysis.perception_calls_by_modality(payload) == {"unrecorded": 5}
+
+
+# ── The shortfalls a person has to classify ────────────────────────────────
+
+
+def test_only_items_below_their_maximum_are_listed():
+    payload = _payload(
+        tasks=[
+            _task(
+                items=[
+                    _item(rubric_item_id="full", awarded_score=2.0, max_score=2),
+                    _item(rubric_item_id="short", awarded_score=0.5, max_score=2),
+                ]
+            )
+        ]
+    )
+
+    listed = analysis.items_below_full_marks(payload)
+
+    assert [row["rubric_item_id"] for row in listed] == ["short"]
+    assert listed[0]["lost"] == 1.5
+
+
+def test_an_excluded_item_is_not_counted_as_a_shortfall():
+    """A score the config excludes did not fall short; it was not in play."""
+    payload = _payload(
+        tasks=[
+            _task(
+                items=[
+                    _item(awarded_score=0.0, max_score=3, score_excluded=True),
+                ]
+            )
+        ]
+    )
+
+    assert analysis.items_below_full_marks(payload) == []
+
+
+def test_the_biggest_losses_come_first():
+    """The readable report truncates, so order decides what a reader sees."""
+    payload = _payload(
+        tasks=[
+            _task(
+                items=[
+                    _item(rubric_item_id="small", awarded_score=1.0, max_score=2),
+                    _item(rubric_item_id="large", awarded_score=0.0, max_score=5),
+                    _item(rubric_item_id="middle", awarded_score=1.0, max_score=4),
+                ]
+            )
+        ]
+    )
+
+    assert [row["rubric_item_id"] for row in analysis.items_below_full_marks(payload)] == [
+        "large",
+        "middle",
+        "small",
+    ]
+
+
+def test_the_evidence_a_classification_needs_travels_with_the_shortfall():
+    """Library limit or genuine miss is decided from these fields."""
+    payload = _payload(
+        tasks=[
+            _task(
+                items=[
+                    _item(
+                        awarded_score=0.0,
+                        max_score=2,
+                        verdict="fail",
+                        evidence="the renderer produced no page for slide 4",
+                        routing_modality="visual",
+                        selection_status="ok",
+                    )
+                ]
+            )
+        ]
+    )
+
+    row = analysis.items_below_full_marks(payload)[0]
+
+    assert row["evidence"] == "the renderer produced no page for slide 4"
+    assert row["routing_modality"] == "visual"
+    assert row["verdict"] == "fail"
+    assert row["criterion"]
+    assert row["task_id"] == "task-1"
+
+
+def test_a_task_that_failed_a_required_item_is_named():
+    payload = _payload(
+        tasks=[_task("task-1"), _task("task-2", critical_fail=True)]
+    )
+
+    report = analysis.analyze(payload)
+
+    assert report["shortfalls"]["tasks_failing_a_required_item"] == ["task-2"]
+
+
+def test_a_task_that_errored_is_named_with_its_error():
+    payload = _payload(tasks=[_task("task-1", error="judge timed out")])
+
+    report = analysis.analyze(payload)
+
+    assert report["shortfalls"]["tasks_with_errors"] == [
+        {"task_id": "task-1", "error": "judge timed out"}
+    ]
+
+
+# ── An unpriced run is never reported as free ──────────────────────────────
+
+
+def test_an_unpriced_run_is_reported_as_unknown_rather_than_zero(tmp_path, capsys):
+    """`gpt-5.6-sol` and `gpt-audio-1.5` have no published price.
+
+    Rendering that as $0 would be the one wrong answer, because it reads as
+    "this cost nothing" rather than "nobody can say what this cost".
+    """
+    grade_file = tmp_path / "grade.json"
+    grade_file.write_text(json.dumps(_payload()))
+
+    analysis.main([str(grade_file)])
+    printed = capsys.readouterr().out
+
+    assert "UNKNOWN" in printed
+    assert "gpt-5.6-sol" in printed
+    assert "$0" not in printed
+
+
+def test_a_priced_run_shows_its_total(tmp_path, capsys):
+    payload = _payload()
+    payload["summary"]["cost"]["pricing_complete"] = True
+    payload["summary"]["cost"]["estimated_cost_usd"] = 412.75
+    payload["summary"]["cost"]["unpriced_models"] = []
+    grade_file = tmp_path / "grade.json"
+    grade_file.write_text(json.dumps(payload))
+
+    analysis.main([str(grade_file)])
+
+    assert "$412.75" in capsys.readouterr().out
+
+
+# ── The readable report stays readable ─────────────────────────────────────
+
+
+def test_the_libreoffice_version_is_named_on_its_own_line(tmp_path, capsys):
+    """It is one of the frozen things, so it should not need digging out."""
+    payload = _payload(
+        renderer_fingerprint={
+            "libreoffice_binary": "soffice",
+            "libreoffice_version": "LibreOffice 24.2.7.2 420(Build:2)",
+            "pymupdf_version": "1.28.2",
+        }
+    )
+    grade_file = tmp_path / "grade.json"
+    grade_file.write_text(json.dumps(payload))
+
+    analysis.main([str(grade_file)])
+    printed = capsys.readouterr().out
+
+    assert "renderer        LibreOffice 24.2.7.2 420(Build:2), pymupdf 1.28.2" in printed
+
+
+def test_many_failing_tasks_are_listed_down_the_page(tmp_path, capsys):
+    """One line of a hundred identifiers is a line nobody reads."""
+    tasks = [_task(f"task-{n:02d}", critical_fail=True) for n in range(12)]
+    grade_file = tmp_path / "grade.json"
+    grade_file.write_text(json.dumps(_payload(tasks=tasks)))
+
+    analysis.main([str(grade_file)])
+    printed = capsys.readouterr().out
+
+    assert "required item failed in 12 task(s):" in printed
+    assert max(len(line) for line in printed.splitlines()) < 120
+    for task in tasks:
+        assert task["task_id"] in printed
+
+
+# ── The contract must survive a fresh clone ────────────────────────────────
+
+
+def test_the_tool_is_in_the_repository():
+    """``batch-runner/scripts/`` is ignored except by an explicit allow list.
+
+    A script written here and left out of that list runs for its author and is
+    missing for CI, which is how an earlier pass of this work reached red.
+    """
+    assert (REPO_ROOT / TOOL_PATH).is_file()
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", TOOL_PATH],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.returncode == 0, (
+        f"{TOOL_PATH} exists here but git does not track it, so a fresh clone "
+        "would not have it. Add it to the allow list in .gitignore."
+    )


### PR DESCRIPTION
## 무엇을

`300-gold-ceiling.md`의 "기록할 것"이 요구하는 여섯 가지를 grade payload에서 읽어내는 도구와 그 테스트.

| 명세가 묻는 것 | 어디서 읽는가 |
|---|---|
| 평균 점수 | `summary.openai_compat.avg_score_pct` |
| 필수 항목 통과율 | `summary.wow.critical_item_pass_rate` |
| grader 오류율 | `summary.wow.judge_error_rate` |
| task별 증거 | `tasks[].items[]` — 만점 미달 항목 전부, 잃은 점수 순 |
| 모델별 사용량 | `summary.cost.main_*` / `perception_*` |
| 이미지·오디오 호출 수 | `items[].perception_call_count`를 `routing_modality`로 재집계 |
| 실제 청구액 | `summary.cost.estimated_cost_usd` / `pricing_complete` |

## 왜 손으로 안 적나

보고서가 숫자를 옮겨 적으면 그 순간부터 실행과 어긋날 수 있고, 나중에 읽는 사람은 어긋났다는 걸 알 방법이 없다. 도구가 읽고 보고서가 인용한다.

## 거부하는 것

고정 목록이 아닌 payload는 읽지 않는다. 검사하는 값은 넷 — task 수, 순서 지문, `run_status`, 그리고 선언한 수와 실제 채점한 수의 일치. shard·반복 실행·다른 corpus에 이 도구를 겨눴을 때 달라지는 값이 정확히 이 넷이다.

Stage 2는 반복 실행을 읽어야 하므로 `--allow-any-run`으로 의도적으로 넘길 수 있다. 기본값은 거부다.

## 청구액을 `$0`으로 안 쓰는 이유

`gpt-5.6-sol`과 `gpt-audio-1.5`는 공개 가격이 없다. `pricing_complete: false`면 `UNKNOWN`으로 찍고 미가격 모델을 나열한다. 값을 모르는 것은 공짜가 아니다.

## 임계값

`90% / 0.95 / 2%`를 코드 상수로 두되, 테스트가 명세 본문과 대조한다. 한쪽만 느슨해지면 조용히 흘러가는 대신 실패한다. 임계값 미달이면 종료 코드 1.

## 지금 도는 실행에 영향 없음

`compute_grader_source_hash`가 `scripts/`에서 해싱하는 건 `download_inference_from_hf.py` 하나뿐이고 테스트 파일은 전혀 포함하지 않는다. 이 PR은 `core/`·`schemas/`·`prompts/`·`grading_configs/`·`grade-run.yml`을 건드리지 않으므로, 진행 중인 3 shard의 grader 소스 지문이 바뀌지 않는다.

## 검증

- 신규 테스트 27개 통과
- 전체 로컬 스위트 `5048 passed, 6 skipped, 45 deselected` (10분 3초)
- 실제 220-task payload에 대해 end-to-end 실행 확인 — 임계값 미달이므로 종료 코드 1