### PR TITLE
fix(grading): read the content that was always in the deliverable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,13 @@ tasks/0822_saturday/*
 !tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md
 !tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
 !tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+# The grading-rebuild specs and reports here predate the `tasks/**` rule, so
+# they stay tracked without an entry. A *new* file among them does not -- git
+# will not un-ignore a path inside an ignored directory, which is why the
+# directory has to be re-opened before the file can be named.
+!tasks/rebuilding_grading_task/
+tasks/rebuilding_grading_task/*
+!tasks/rebuilding_grading_task/PR3_GOLD_CEILING.md
 
 *.parquet
 .huggingface/

--- a/batch-runner/core/tools/read_deliverable.py
+++ b/batch-runner/core/tools/read_deliverable.py
@@ -34,6 +34,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -58,6 +59,23 @@ READ_DELIVERABLE_OPS: Tuple[str, ...] = (
 MAX_CONTENT_CHARS = 200_000   # ``read_content`` text payload cap
 MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5MB before/after downsample
 MAX_CELLS_FORMATTING = 5_000  # inspect_formatting iterates capped cells
+
+#: Archive limits. A deliverable submitted as a ``.zip`` is a container of
+#: files the other ops already handle, so the archive is listed and single
+#: members can be opened through ``scope={"member": ...}``. Both numbers bound
+#: what one call can cost: entries bound the listing sent to a judge, bytes
+#: bound what is written to temp before an op reads it.
+MAX_ZIP_ENTRIES = 2_000
+MAX_ZIP_MEMBER_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB extracted per member
+
+#: Archive members macOS writes alongside the real files. These are resource
+#: forks, not deliverables, and listing them buries the actual content -- the
+#: one gold answer in the stage-1 corpus that ships as an archive has five
+#: real stems and five of these. Hidden from the default listing, still
+#: openable by exact name so nothing is unreachable.
+_ZIP_NOISE = ("__MACOSX/",)
+_ZIP_NOISE_BASENAMES = ("._",)
+
 MAX_PAGES_DEFAULT = 200       # PDF page-iteration safety cap
 MAX_SHEETS = 100              # workbook safety cap
 RENDERER_VERSION_TIMEOUT_SEC = 10
@@ -211,6 +229,7 @@ _EXT_KIND = {
     **{extension: "audio" for extension in GRADER_AUDIO_EXTENSIONS},
     ".mp4": "video", ".mov": "video", ".webm": "video",
     ".mkv": "video", ".avi": "video",
+    ".zip": "zip",
 }
 
 
@@ -269,6 +288,135 @@ def _inspect_pptx(p: Path) -> Dict[str, Any]:
     return {"kind": "pptx", "slide_count": len(pres.slides), "slides": slides}
 
 
+# ── Archives ─────────────────────────────────────────────────────────
+#
+# A ``.zip`` deliverable is not an unreadable binary. It is a container of
+# files every other op here already handles, and refusing it refuses them all:
+# one stage-1 gold answer is five WAV stems in an archive, and it scored 2 of
+# 62 because thirty-four rubric items -- sample rate, bit depth, duration, key,
+# tempo -- were answered "binary or unsupported for text read" about a file
+# nothing ever opened. The single item it did pass was "exactly one top-level
+# ZIP archive is submitted".
+
+
+def _is_zip_noise(name: str) -> bool:
+    """AppleDouble resource forks, which are not part of the deliverable."""
+    return name.startswith(_ZIP_NOISE) or Path(name).name.startswith(
+        _ZIP_NOISE_BASENAMES
+    )
+
+
+def _zip_entries(p: Path) -> Tuple[List[Dict[str, Any]], int, bool]:
+    """Real members, count of hidden noise, and whether the list was cut."""
+    import zipfile
+
+    entries: List[Dict[str, Any]] = []
+    hidden = 0
+    truncated = False
+    with zipfile.ZipFile(p) as archive:
+        for info in archive.infolist():
+            if info.is_dir():
+                continue
+            if _is_zip_noise(info.filename):
+                hidden += 1
+                continue
+            if len(entries) >= MAX_ZIP_ENTRIES:
+                truncated = True
+                break
+            entries.append({
+                "name": info.filename,
+                "size": info.file_size,
+                "compressed_size": info.compress_size,
+                "kind": _EXT_KIND.get(Path(info.filename).suffix.lower(), "unknown"),
+            })
+    return entries, hidden, truncated
+
+
+def _inspect_zip(p: Path) -> Dict[str, Any]:
+    entries, hidden, truncated = _zip_entries(p)
+    return {
+        "kind": "zip",
+        "entry_count": len(entries),
+        "entries": entries,
+        "hidden_resource_fork_count": hidden,
+        "truncated": truncated,
+        "note": (
+            "open a member with scope={\"member\": \"<name>\"} on any op, "
+            "e.g. probe_audio for a .wav or read_content for a .docx"
+        ),
+    }
+
+
+def _read_zip_text(p: Path, _scope: Dict[str, Any]) -> str:
+    """The manifest, as text.
+
+    A judge that never learns about the member scope still has to be able to
+    answer "does the archive contain a Bass stem in WAV format", so the listing
+    itself is the content of an archive.
+    """
+    entries, hidden, truncated = _zip_entries(p)
+    lines = [f"[Archive: {len(entries)} file(s)]"]
+    lines += [
+        f"{entry['name']} | {entry['kind']} | {entry['size']} bytes"
+        for entry in entries
+    ]
+    if truncated:
+        lines.append(f"... listing truncated at {MAX_ZIP_ENTRIES} entries")
+    if hidden:
+        lines.append(f"({hidden} macOS resource-fork entries hidden)")
+    return "\n".join(lines)
+
+
+@contextmanager
+def _extracted_zip_member(p: Path, member: str) -> Any:
+    """One member on disk, under its own suffix, for the length of one op.
+
+    The name has to already be in the archive, so there is no path a caller can
+    name that is not a member -- traversal is refused by lookup rather than by
+    sanitising. The extract is streamed to a temp file so a member is bounded
+    by disk rather than held in memory, and the declared size is checked first
+    so an archive cannot ask for more than the cap by lying cheaply.
+    """
+    import zipfile
+
+    with zipfile.ZipFile(p) as archive:
+        try:
+            info = archive.getinfo(member)
+        except KeyError:
+            names = [
+                entry["name"]
+                for entry in _zip_entries(p)[0][:20]
+            ]
+            raise InvalidScope(
+                f"no member {member!r} in archive; members: {names}"
+            ) from None
+        if info.is_dir():
+            raise InvalidScope(f"member {member!r} is a directory, not a file")
+        if info.file_size > MAX_ZIP_MEMBER_BYTES:
+            raise ReadDeliverableError(
+                f"member {member!r} is {info.file_size} bytes, over the "
+                f"{MAX_ZIP_MEMBER_BYTES}-byte extraction cap"
+            )
+
+        temp_dir = tempfile.mkdtemp(prefix="gdpval-zip-")
+        try:
+            target = Path(temp_dir) / Path(member).name
+            written = 0
+            with archive.open(info) as source, open(target, "wb") as sink:
+                while chunk := source.read(1024 * 1024):
+                    written += len(chunk)
+                    if written > MAX_ZIP_MEMBER_BYTES:
+                        raise ReadDeliverableError(
+                            f"member {member!r} exceeded the "
+                            f"{MAX_ZIP_MEMBER_BYTES}-byte extraction cap while "
+                            "being read; its declared size was understated"
+                        )
+                    sink.write(chunk)
+            yield target
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
 def _inspect_pdf(p: Path) -> Dict[str, Any]:
     try:
         import fitz  # type: ignore
@@ -312,6 +460,8 @@ def _op_inspect_structure(p: Path, _scope: Dict[str, Any]) -> Dict[str, Any]:
             base["audio"] = _inspect_audio(p)
         elif kind == "video":
             base["video"] = _inspect_video(p)
+        elif kind == "zip":
+            base.update(_inspect_zip(p))
         # txt/csv/image: size + kind only
     except Exception as exc:  # noqa: BLE001
         base["inspection_error"] = f"{type(exc).__name__}: {exc}"
@@ -371,6 +521,131 @@ def _read_docx_text(p: Path, _scope: Dict[str, Any]) -> str:
     return "\n\n".join(parts)
 
 
+#: Namespace of the DrawingML chart part. Used to read cached category and
+#: value points straight out of the XML when python-pptx will not model the
+#: plot type -- see ``_pptx_chart_xml_text``.
+_CHART_NS = {"c": "http://schemas.openxmlformats.org/drawingml/2006/chart"}
+
+
+def _pptx_chart_xml_text(chart: Any) -> List[str]:
+    """Categories and values read from the chart part itself.
+
+    python-pptx models a subset of plot types and raises ``ValueError:
+    unsupported plot type`` on the rest -- ``pie3DChart`` among them, which is
+    what four of the five charts in one stage-1 gold answer are. For those, the
+    modelled accessors give nothing at all: not the values, not the categories,
+    not even the type name.
+
+    The cached points are in the XML regardless, because that is what lets a
+    deck render without the workbook it was built from. Reading them there is
+    uniform across every plot type, which is the point: the set of chart types
+    a judge might meet is not the set python-pptx happens to model.
+    """
+    lines: List[str] = []
+    plot_types = [
+        etree_tag.split("}")[-1]
+        for plot in chart.findall(".//c:plotArea/*", _CHART_NS)
+        for etree_tag in [str(plot.tag)]
+        if etree_tag.endswith("Chart")
+    ]
+    lines.append(f"[Chart: {', '.join(plot_types)}]" if plot_types else "[Chart]")
+
+    for series in chart.findall(".//c:ser", _CHART_NS):
+        name = next(
+            (v.text for v in series.findall("./c:tx//c:v", _CHART_NS) if v.text),
+            "series",
+        )
+        categories = [
+            v.text or "" for v in series.findall("./c:cat//c:pt/c:v", _CHART_NS)
+        ]
+        values = [
+            v.text or "" for v in series.findall("./c:val//c:pt/c:v", _CHART_NS)
+        ]
+        if categories:
+            lines.append("categories: " + ", ".join(categories))
+        if values:
+            lines.append(f"{name}: " + ", ".join(values))
+    return lines
+
+
+def _pptx_chart_text(shape: Any) -> List[str]:
+    """Category and series values behind a chart, when they can be read.
+
+    Rubrics ask things like "no categories outside the specified 12 appear in
+    the table or chart", which is unanswerable from a picture of a pie. The
+    numbers are in the embedded workbook and in the chart part, and this tries
+    the modelled accessors first -- they name the chart type and hand back
+    typed values -- then falls back to the raw XML for the plot types
+    python-pptx declines to model.
+
+    Every step is guarded. This runs against arbitrary gold answers, so a chart
+    that will not describe itself has to cost its own text and nothing else:
+    one bad chart must not take the slides behind it down with it.
+    """
+    try:
+        chart = shape.chart
+    except Exception:
+        return []
+
+    lines: List[str] = []
+    try:
+        lines.append(f"[Chart: {chart.chart_type}]")
+    except Exception:
+        lines = []
+    if lines:
+        try:
+            categories = [str(c) for c in chart.plots[0].categories]
+            if categories:
+                lines.append("categories: " + ", ".join(categories))
+        except Exception:
+            pass
+        try:
+            for series in chart.series:
+                values = ", ".join("" if v is None else str(v) for v in series.values)
+                lines.append(f"{series.name}: {values}")
+        except Exception:
+            pass
+
+    if len(lines) < 2:
+        try:
+            lines = _pptx_chart_xml_text(chart._chartSpace)
+        except Exception:
+            return []
+    return ["\n".join(lines)] if len(lines) > 1 else []
+
+
+def _pptx_shape_text(shape: Any, depth: int = 0) -> List[str]:
+    """Everything on one shape a judge should be able to read.
+
+    ``shape.has_text_frame`` on its own misses most of what a real deck carries.
+    A table is a graphic frame with no text frame, so every cell of it is
+    invisible; a group is a single shape whose children are never visited. Both
+    were silently dropped, which is how a five-slide deck read as 186 characters
+    of slide titles while the table holding the twelve categories a rubric item
+    asked about sat unread.
+    """
+    out: List[str] = []
+    if getattr(shape, "has_text_frame", False):
+        text = shape.text_frame.text.strip()
+        if text:
+            out.append(text)
+    if getattr(shape, "has_table", False):
+        rows = [
+            " | ".join(cell.text.strip() for cell in row.cells)
+            for row in shape.table.rows
+        ]
+        out.append("[Table]\n" + "\n".join(rows))
+    if getattr(shape, "has_chart", False):
+        out.extend(_pptx_chart_text(shape))
+    # Groups nest, and a table one level down is as unreadable as one at the
+    # top. The depth cap is only a guard against a malformed file describing a
+    # cycle -- real decks do not nest anywhere near this deep.
+    if depth < 8 and hasattr(shape, "shapes"):
+        for child in shape.shapes:
+            out.extend(_pptx_shape_text(child, depth + 1))
+    return out
+
+
 def _read_pptx_text(p: Path, _scope: Dict[str, Any]) -> str:
     from pptx import Presentation  # type: ignore
 
@@ -379,10 +654,7 @@ def _read_pptx_text(p: Path, _scope: Dict[str, Any]) -> str:
     for i, slide in enumerate(pres.slides, 1):
         chunks = [f"[Slide {i}]"]
         for shape in slide.shapes:
-            if shape.has_text_frame:
-                t = shape.text_frame.text.strip()
-                if t:
-                    chunks.append(t)
+            chunks.extend(_pptx_shape_text(shape))
         parts.append("\n".join(chunks))
         if sum(len(x) for x in parts) > MAX_CONTENT_CHARS:
             break
@@ -401,6 +673,8 @@ def _op_read_content(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
         text = _read_pptx_text(p, scope)
     elif kind in ("txt", "csv"):
         text = p.read_text(encoding="utf-8", errors="replace")
+    elif kind == "zip":
+        text = _read_zip_text(p, scope)
     else:
         return {"kind": kind, "text": "", "note": "binary or unsupported for text read"}
     truncated = len(text) > MAX_CONTENT_CHARS
@@ -1146,6 +1420,9 @@ def read_deliverable(
               outside the base is rejected.
         base_dir: Trusted base directory (required keyword).
         scope: Op-specific scope dict (sheet name, page range, …).
+               On a ``.zip``, ``{"member": "<name>"}`` runs the op against
+               that member of the archive instead of the archive itself; the
+               rest of the scope is passed through to it unchanged.
 
     Returns:
         Envelope dict — see module docstring.
@@ -1165,7 +1442,22 @@ def read_deliverable(
         )
     fn = _OP_TABLE[op]
     try:
-        data = fn(resolved, scope or {})
+        scope = dict(scope or {})
+        # A member is addressed by the same op as a loose file, so the
+        # extraction happens here rather than inside each op: `probe_audio` on
+        # a WAV inside an archive is `probe_audio` on a WAV.
+        if "member" in scope:
+            if _kind_of(resolved) != "zip":
+                raise InvalidScope(
+                    f"scope key 'member' is only valid on a zip archive, "
+                    f"not on a {_kind_of(resolved)} file"
+                )
+            member = scope.pop("member")
+            if not isinstance(member, str) or not member:
+                raise InvalidScope("scope key 'member' must be a non-empty string")
+            with _extracted_zip_member(resolved, member) as member_path:
+                return _envelope_ok(fn(member_path, scope))
+        data = fn(resolved, scope)
         return _envelope_ok(data)
     except RendererDependencyError as exc:
         return _envelope_error(str(exc), kind="dependency_missing")

--- a/batch-runner/scripts/analyze_gold_ceiling.py
+++ b/batch-runner/scripts/analyze_gold_ceiling.py
@@ -21,11 +21,12 @@ Two of the six need work the payload does not do for you:
   evidence the judge recorded, sorted so the largest losses come first, which
   is the input a person needs to classify them.
 
-It also refuses a payload that is not the run the specification pinned. A
-number read out of the wrong file is worse than no number, and the three
-identity fields it checks -- task count, ordered-id fingerprint, and run
-status -- are exactly the ones that would differ if somebody pointed this at a
-shard, a repeat, or a different corpus.
+It also refuses a payload that is not stage 1's corpus, fully graded. A number
+read out of the wrong file is worse than no number, and the four things it
+checks -- task count, ordered-id fingerprint, graded count and run status --
+are the ones that differ when somebody points this at a shard or at a
+different corpus. A stage 2 repeat passes them, and should: it is the same
+thirty tasks graded again, which is exactly what stage 2 needs to read.
 
 Usage
 -----
@@ -61,6 +62,18 @@ EXPECTED_ORDERED_TASK_IDS_SHA256 = (
     "09ce924576b6822a7f96d651b40c18add5fceb6e216653c8bdb9c5a194c9dfdc"
 )
 
+# What a finished run is allowed to call itself. Both spellings mean the same
+# thing here -- every task was graded -- and which one a gold run gets is
+# decided by whether it was sharded, not by anything about its completeness.
+# `step8_grade.py` marks a gold-corpus run `diagnostic` so it forks away from
+# the dashboard, but `step9_merge_shards.py` writes a flat `final` when it
+# joins shards back together. Insisting on `final` would therefore refuse a
+# perfectly complete single-shard repeat, which is precisely the run stage 2
+# needs to read. `partial` is the one that must never be accepted: a shard
+# declares the whole corpus in its identity fields while holding only its own
+# slice, so its aggregates read exactly like the full run's.
+COMPLETE_RUN_STATUSES = frozenset({"final", "diagnostic"})
+
 
 class NotTheRunThatWasPinned(SystemExit):
     """The payload is readable but is not stage 1's run."""
@@ -70,10 +83,11 @@ def _identity_problems(payload: dict[str, Any]) -> list[str]:
     problems: list[str] = []
 
     status = payload.get("run_status")
-    if status != "final":
+    if status not in COMPLETE_RUN_STATUSES:
         problems.append(
-            f"run_status is {status!r}, not 'final' -- this is a shard or an "
-            "unfinished run, and its aggregates cover only part of the corpus"
+            f"run_status is {status!r}, which is not a finished run "
+            f"({', '.join(sorted(COMPLETE_RUN_STATUSES))}) -- a shard covers "
+            "only its own slice while declaring the whole corpus"
         )
 
     count = payload.get("expected_task_count")
@@ -448,8 +462,9 @@ def main(argv: list[str] | None = None) -> int:
         "--allow-any-run",
         action="store_true",
         help=(
-            "skip the check that this payload is the run the specification "
-            "pinned. Use for a repeat or a shard, never for stage 1's own number"
+            "skip the check that this payload is stage 1's corpus, fully "
+            "graded. Use to look inside a single shard or another corpus, "
+            "never for a number a report will quote"
         ),
     )
     args = parser.parse_args(argv)

--- a/batch-runner/scripts/analyze_gold_ceiling.py
+++ b/batch-runner/scripts/analyze_gold_ceiling.py
@@ -58,8 +58,25 @@ JUDGE_ERROR_RATE_CEILING = 0.02
 # other run, and reading stage 1's numbers out of it would be a mistake no
 # reader could detect afterwards.
 EXPECTED_TASK_COUNT = 30
+
+# The 30 pinned task ids, fingerprinted the way the grader fingerprints them.
+#
+# This is compared against `expected_ordered_task_ids_sha256` in the payload,
+# and that field is written by `step8_grade._ordered_task_ids_sha256`, which
+# hashes `json.dumps(ids, ensure_ascii=False, separators=(",", ":"))` -- a
+# compact JSON array. So this constant has to be the compact-JSON digest of
+# the same ids in the same order; any other encoding of the identical list
+# produces a different digest and refuses the very run it was written for.
+#
+# That is not hypothetical. An earlier pass pinned the newline-joined digest
+# of these exact ids, `09ce9245...`, and it refused stage 1's own run. Both
+# digests cover the same thirty ids in the same order -- only the separator
+# differs -- so the mismatch says nothing whatsoever about the corpus, which
+# is what made it slow to read. `test_the_pinned_corpus_matches_the_grading_
+# config` now recomputes this through the grader's own function rather than
+# restating the formula, so the two can no longer drift apart in silence.
 EXPECTED_ORDERED_TASK_IDS_SHA256 = (
-    "09ce924576b6822a7f96d651b40c18add5fceb6e216653c8bdb9c5a194c9dfdc"
+    "82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b"
 )
 
 # What a finished run is allowed to call itself. Both spellings mean the same

--- a/batch-runner/tests/test_gold_ceiling_analysis.py
+++ b/batch-runner/tests/test_gold_ceiling_analysis.py
@@ -152,10 +152,18 @@ def test_the_thresholds_are_the_ones_the_spec_states():
 
 
 def test_the_pinned_corpus_matches_the_grading_config():
-    """The 30 the tool insists on are the 30 the run was told to grade."""
-    import hashlib
+    """The 30 the tool insists on are the 30 the run was told to grade.
 
+    Recomputed through ``step8_grade``'s own function rather than by restating
+    its formula here. The constant is compared against a field that function
+    writes, so a second spelling of "hash these ids" is a second thing that can
+    drift -- and it did: a newline-joined digest of these very ids sat in the
+    constant and refused stage 1's own run, saying nothing about the corpus
+    while looking exactly like a corpus mismatch.
+    """
     import yaml
+
+    from step8_grade import _ordered_task_ids_sha256
 
     config = yaml.safe_load(
         (
@@ -165,8 +173,7 @@ def test_the_pinned_corpus_matches_the_grading_config():
     pinned = config["rerun_identity"]["task_ids"]
 
     assert len(pinned) == analysis.EXPECTED_TASK_COUNT
-    digest = hashlib.sha256("\n".join(pinned).encode("utf-8")).hexdigest()
-    assert digest == analysis.EXPECTED_ORDERED_TASK_IDS_SHA256
+    assert _ordered_task_ids_sha256(pinned) == analysis.EXPECTED_ORDERED_TASK_IDS_SHA256
 
 
 # ── Only stage 1's own run may be read as stage 1's number ─────────────────

--- a/batch-runner/tests/test_gold_ceiling_analysis.py
+++ b/batch-runner/tests/test_gold_ceiling_analysis.py
@@ -183,6 +183,30 @@ def test_a_shard_is_refused():
     assert any("run_status" in problem for problem in problems)
 
 
+def test_a_complete_run_is_accepted_under_either_spelling():
+    """Sharding, not completeness, decides which word a gold run gets.
+
+    `step8_grade.py` calls a gold-corpus run `diagnostic` so that it forks away
+    from the dashboard, but `step9_merge_shards.py` writes a flat `final` when
+    it joins shards back up. So the same thirty tasks, fully graded, land under
+    one name or the other purely on whether the run was split. Refusing
+    `diagnostic` would refuse a complete single-shard repeat -- and stage 2 is
+    made of repeats.
+    """
+    for status in ("final", "diagnostic"):
+        assert analysis._identity_problems(_payload(run_status=status)) == [], status
+
+
+def test_a_run_with_no_status_at_all_is_refused():
+    """Absent is not complete. A payload that never says must not be assumed."""
+    payload = _payload()
+    payload.pop("run_status")
+
+    problems = analysis._identity_problems(payload)
+
+    assert any("run_status" in problem for problem in problems)
+
+
 def test_a_different_corpus_is_refused():
     problems = analysis._identity_problems(
         _payload(expected_ordered_task_ids_sha256="b" * 64)
@@ -216,7 +240,11 @@ def test_the_command_line_refuses_rather_than_reporting(tmp_path):
 
 
 def test_the_refusal_can_be_overridden_on_purpose(tmp_path, capsys):
-    """Stage 2 reads repeats with this tool, and they are legitimately not run 1."""
+    """Looking inside one shard is a legitimate thing to want to do.
+
+    Not for a number any report quotes -- a shard's mean is the mean of its
+    slice -- but for working out which shard a bad task landed in.
+    """
     grade_file = tmp_path / "repeat.json"
     grade_file.write_text(json.dumps(_payload(run_status="partial")))
 

--- a/batch-runner/tests/test_gold_ceiling_contract.py
+++ b/batch-runner/tests/test_gold_ceiling_contract.py
@@ -390,11 +390,22 @@ def test_spec_records_the_input_fingerprints_that_re_derive():
     and settles nothing. Both of these come from the manifest and the config
     alone, so the 623 MB of gold files are not needed to check the claim, and
     a sample that shifted by one task changes both.
+
+    The task-id digest is recomputed by calling the grader's own function
+    rather than by restating its formula here. Restating it is how the spec
+    came to carry ``09ce9245…`` -- the same thirty ids in the same order,
+    newline-joined instead of encoded as a compact JSON array. The list was
+    right, the order was right, and the number matched nothing the pipeline
+    ever writes: a run's own payload failed the check that was supposed to
+    confirm it. A test that re-implements the thing it is testing can agree
+    with itself all the way to the wrong answer.
     """
+    from step8_grade import _ordered_task_ids_sha256
+
     spec = SPEC_PATH.read_text(encoding="utf-8")
     pinned = _load_yaml(GOLD_CONFIG_PATH)["rerun_identity"]["task_ids"]
 
-    ordered_ids = hashlib.sha256("\n".join(pinned).encode("utf-8")).hexdigest()
+    ordered_ids = _ordered_task_ids_sha256(pinned)
     file_set = hashlib.sha256(
         "\n".join(
             f"{file['graded_path']}\t{file['sha256']}\t{file['size']}"

--- a/batch-runner/tests/test_gold_ceiling_contract.py
+++ b/batch-runner/tests/test_gold_ceiling_contract.py
@@ -463,14 +463,30 @@ def test_spec_names_the_container_and_renderer_the_run_will_use():
     assert preflight.EXPECTED_LIBREOFFICE_VERSION in spec
 
 
-def test_spec_discloses_the_unreadable_deliverable_before_the_run():
-    """One pinned task's only answer is a zip the read tool cannot open.
+def test_spec_accounts_for_the_archive_answer_the_run_could_not_read():
+    """One pinned task's only answer is a zip, and that cost it the task.
 
     Predicting a weak score is evidence; explaining one afterwards is not. The
     task stays in the sample -- dropping it would flatter the ceiling -- so the
-    limitation is written down in advance, and this keeps the disclosure honest
-    by checking the tool really does refuse the format.
+    limitation went into the spec in advance, and the first paid run confirmed
+    it exactly: 2.00 of 62, and the one item that passed was "exactly one
+    top-level ZIP archive is submitted", which passed *because* it is a zip.
+
+    What the disclosure got wrong was the reason. It called this a format the
+    reading tool does not support. Every format inside the archive is
+    supported -- they are WAV stems, and ``probe_audio`` has read WAV since
+    PR2. What was unsupported was the container: nothing ever opened it, so
+    thirty-four items about sample rate, bit depth and duration were answered
+    from a file the judge never saw inside of.
+
+    So this now checks the container is readable and that the spec still says
+    which items remain out of reach, since the remaining gap is real and is a
+    different one: routing and selection still treat the archive as a single
+    opaque file, so no listening model is dispatched for it.
     """
+    import zipfile
+    import wave
+
     from core.tools import read_deliverable
 
     spec = SPEC_PATH.read_text(encoding="utf-8")
@@ -484,17 +500,38 @@ def test_spec_discloses_the_unreadable_deliverable_before_the_run():
     assert ".zip" in spec
 
     with tempfile.TemporaryDirectory() as workdir:
-        name = Path(zipped[0]["graded_path"]).name
-        (Path(workdir) / name).write_bytes(b"PK\x03\x04not really a zip")
-        envelope = read_deliverable("read_content", name, base_dir=workdir)
+        stem = Path(workdir) / "STEM.wav"
+        with wave.open(str(stem), "wb") as sound:
+            sound.setnchannels(2)
+            sound.setsampwidth(3)  # 24-bit, as the rubric asks about
+            sound.setframerate(48_000)
+            sound.writeframes(b"\x00" * 3 * 2 * 4_800)
 
-    # Not an error -- that is the point. The judge is handed an empty reading
-    # with a note, so the shortfall looks like a weak answer rather than a
-    # tool that failed, which is exactly why it has to be disclosed up front.
-    assert envelope["ok"] is True
-    assert envelope["data"]["kind"] == "unknown"
-    assert envelope["data"]["text"] == ""
-    assert envelope["data"]["note"] == "binary or unsupported for text read"
+        name = Path(zipped[0]["graded_path"]).name
+        archive = Path(workdir) / name
+        with zipfile.ZipFile(archive, "w") as writing:
+            writing.write(stem, "STEMS/MASTER.wav")
+            # macOS ships one of these beside every real file. The gold answer
+            # carries five, and listing them would bury the five that matter.
+            writing.writestr("__MACOSX/STEMS/._MASTER.wav", b"\x00\x05\x16\x07")
+        stem.unlink()
+
+        listing = read_deliverable("read_content", name, base_dir=workdir)
+        probe = read_deliverable(
+            "probe_audio", name, base_dir=workdir,
+            scope={"member": "STEMS/MASTER.wav"},
+        )
+
+    assert listing["ok"] is True
+    assert listing["data"]["kind"] == "zip"
+    assert "STEMS/MASTER.wav" in listing["data"]["text"]
+    assert "__MACOSX" not in listing["data"]["text"]
+
+    # The three rubric items this recovers, on the real answer: WAV format,
+    # 48 kHz exactly, and 24-bit PCM.
+    assert probe["ok"] is True, probe
+    assert probe["data"]["sample_rate"] == 48_000
+    assert probe["data"]["codec"] == "pcm_s24le"
 
 
 # --------------------------------------------------------------------------

--- a/batch-runner/tests/test_read_deliverable.py
+++ b/batch-runner/tests/test_read_deliverable.py
@@ -261,6 +261,232 @@ def test_read_content_docx(base_dir, docx_file):
     assert "First paragraph" in r["data"]["text"]
 
 
+# ── read_content: a deck is more than its text frames ────────────────
+#
+# `_read_pptx_text` used to take `shape.has_text_frame` and nothing else, so a
+# table was a graphic frame it walked straight past and a group was one shape
+# whose children it never entered. Both are where real decks keep their
+# content: a gold answer in the stage-1 corpus, `WorkStudy.pptx`, read as 186
+# characters of slide titles while the fifteen-row table holding every activity
+# category and percentage -- which a rubric item then asked about, and scored
+# 0/1 -- was never shown to the judge at all.
+#
+# Each fixture below puts its content *only* in the shape under test, so a
+# reader that regresses to text frames alone fails rather than passing on the
+# title it can still see.
+
+
+@pytest.fixture
+def pptx_with_table(base_dir: Path) -> Path:
+    pytest.importorskip("pptx")
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[5])
+    slide.shapes.title.text = "Activity Analysis"
+    table = slide.shapes.add_table(
+        3, 2, Inches(1), Inches(2), Inches(6), Inches(2)
+    ).table
+    table.cell(0, 0).text = "Activity"
+    table.cell(0, 1).text = "Share"
+    table.cell(1, 0).text = "Material handling"
+    table.cell(1, 1).text = "31.4%"
+    table.cell(2, 0).text = "Machine setup"
+    table.cell(2, 1).text = "12.7%"
+    p = base_dir / "study.pptx"
+    presentation.save(p)
+    return p
+
+
+@pytest.fixture
+def pptx_with_group(base_dir: Path) -> Path:
+    pytest.importorskip("pptx")
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[5])
+    slide.shapes.title.text = "Findings"
+    group = slide.shapes.add_group_shape()
+    box = group.shapes.add_textbox(
+        Inches(1), Inches(2), Inches(4), Inches(1)
+    )
+    box.text_frame.text = "Grouped callout text"
+    p = base_dir / "grouped.pptx"
+    presentation.save(p)
+    return p
+
+
+@pytest.fixture
+def pptx_with_chart(base_dir: Path) -> Path:
+    pytest.importorskip("pptx")
+    from pptx import Presentation
+    from pptx.chart.data import CategoryChartData
+    from pptx.enum.chart import XL_CHART_TYPE
+    from pptx.util import Inches
+
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[5])
+    slide.shapes.title.text = "Distribution"
+    chart_data = CategoryChartData()
+    chart_data.categories = ["Inspection", "Rework"]
+    chart_data.add_series("Share", (0.62, 0.38))
+    slide.shapes.add_chart(
+        XL_CHART_TYPE.PIE, Inches(1), Inches(2), Inches(6), Inches(4), chart_data
+    )
+    p = base_dir / "chart.pptx"
+    presentation.save(p)
+    return p
+
+
+def test_read_content_pptx_reads_text_frames(base_dir, pptx_file):
+    """The behaviour that already worked has to keep working."""
+    r = read_deliverable("read_content", pptx_file.name, base_dir=str(base_dir))
+    assert r["ok"] is True
+    assert "Overview" in r["data"]["text"]
+    assert "Details" in r["data"]["text"]
+
+
+def test_read_content_pptx_reads_table_cells(base_dir, pptx_with_table):
+    """The defect this fixes: cells live on a shape with no text frame."""
+    r = read_deliverable(
+        "read_content", pptx_with_table.name, base_dir=str(base_dir)
+    )
+
+    assert r["ok"] is True
+    text = r["data"]["text"]
+    assert "Material handling" in text
+    assert "31.4%" in text
+    assert "Machine setup" in text
+
+
+def test_read_content_pptx_keeps_table_rows_together(base_dir, pptx_with_table):
+    """A row read cell-by-cell loses which share belongs to which activity.
+
+    Marked and joined the same way ``_read_docx_text`` already marks tables, so
+    a judge meets one shape of table across both formats.
+    """
+    r = read_deliverable(
+        "read_content", pptx_with_table.name, base_dir=str(base_dir)
+    )
+
+    text = r["data"]["text"]
+    assert "[Table]" in text
+    assert "Material handling | 31.4%" in text
+
+
+def test_read_content_pptx_reads_inside_a_group(base_dir, pptx_with_group):
+    """A group is one shape; its children were never visited."""
+    r = read_deliverable(
+        "read_content", pptx_with_group.name, base_dir=str(base_dir)
+    )
+
+    assert r["ok"] is True
+    assert "Grouped callout text" in r["data"]["text"]
+
+
+def test_read_content_pptx_reads_chart_categories(base_dir, pptx_with_chart):
+    """Rubrics ask which categories a chart shows, which a picture cannot say."""
+    r = read_deliverable(
+        "read_content", pptx_with_chart.name, base_dir=str(base_dir)
+    )
+
+    assert r["ok"] is True
+    text = r["data"]["text"]
+    assert "Inspection" in text
+    assert "Rework" in text
+
+
+@pytest.fixture
+def pptx_with_unmodelled_chart(base_dir: Path, pptx_with_chart: Path) -> Path:
+    """A plot type python-pptx will not model, built from one it will.
+
+    ``pie3DChart`` is not exotic -- four of the five charts in one stage-1 gold
+    answer are that -- but python-pptx raises ``unsupported plot type`` on it,
+    and there is no way to author one through the library. Retagging the plot
+    element of a chart it *can* write produces the same file Excel would, and
+    reproduces the failure exactly: chart_type, categories and series all raise.
+    """
+    pytest.importorskip("pptx")
+    from pptx import Presentation
+
+    namespace = {"c": "http://schemas.openxmlformats.org/drawingml/2006/chart"}
+    presentation = Presentation(str(pptx_with_chart))
+    shape = next(
+        s
+        for s in presentation.slides[0].shapes
+        if getattr(s, "has_chart", False)
+    )
+    plot = shape.chart._chartSpace.find(".//c:plotArea/c:pieChart", namespace)
+    plot.tag = "{%s}pie3DChart" % namespace["c"]
+    p = base_dir / "pie3d.pptx"
+    presentation.save(p)
+    return p
+
+
+def test_the_modelled_chart_accessors_really_do_refuse(pptx_with_unmodelled_chart):
+    """The fixture is only worth anything if it reproduces the real failure.
+
+    Without this, a python-pptx release that starts modelling 3-D pies would
+    leave the fallback untested and the next test passing down the easy path.
+    """
+    from pptx import Presentation
+
+    shape = next(
+        s
+        for s in Presentation(str(pptx_with_unmodelled_chart)).slides[0].shapes
+        if getattr(s, "has_chart", False)
+    )
+
+    with pytest.raises(ValueError, match="unsupported plot type"):
+        shape.chart.chart_type
+
+
+def test_read_content_pptx_reads_a_chart_python_pptx_cannot_model(
+    base_dir, pptx_with_unmodelled_chart
+):
+    """The cached points are in the XML whatever the plot type is."""
+    r = read_deliverable(
+        "read_content", pptx_with_unmodelled_chart.name, base_dir=str(base_dir)
+    )
+
+    assert r["ok"] is True
+    text = r["data"]["text"]
+    assert "pie3DChart" in text, "the chart type is itself a rubric fact"
+    assert "Inspection" in text
+    assert "Rework" in text
+    assert "0.62" in text
+
+
+def test_a_chart_that_cannot_describe_itself_does_not_break_the_read(
+    base_dir, pptx_with_table, monkeypatch
+):
+    """One unreadable chart must cost its own text, not the whole deck's.
+
+    python-pptx raises on chart types with no category axis, and this reader
+    runs against arbitrary gold answers -- so the guard is the difference
+    between losing a chart and losing every slide behind it.
+    """
+    class Exploding:
+        has_text_frame = False
+        has_table = False
+        has_chart = True
+
+        @property
+        def chart(self):
+            raise ValueError("no category axis on this chart type")
+
+    assert read_deliverable_module._pptx_shape_text(Exploding()) == []
+
+    # And the surrounding deck still reads.
+    r = read_deliverable(
+        "read_content", pptx_with_table.name, base_dir=str(base_dir)
+    )
+    assert r["ok"] is True
+    assert "Material handling" in r["data"]["text"]
+
+
 def test_read_content_truncation_flag(base_dir):
     big = base_dir / "big.txt"
     big.write_text("x" * (300_000))
@@ -990,3 +1216,259 @@ def test_probe_video_note_for_non_video(base_dir, txt_file):
     r = read_deliverable("probe_video", txt_file.name, base_dir=str(base_dir))
     assert r["ok"] is True
     assert "note" in r["data"]
+
+
+# ── Archives: a container of readable files is not an unreadable file ─
+#
+# A `.zip` used to fall through to `kind: "unknown"`, and `read_content`
+# answered every question about it with an empty string and the note "binary or
+# unsupported for text read". One stage-1 gold answer is five WAV stems in an
+# archive; it scored 2.00 of 62, and the single item it passed was "exactly one
+# top-level ZIP archive is submitted" -- which passed *because* it is a zip.
+# Everything else -- five "in WAV format", five "48,000 Hz exactly", five
+# "24-bit PCM or IEEE float", the master's running time -- was asked about a
+# file nothing had opened.
+#
+# The formats inside were never the problem. `probe_audio` has read WAV since
+# PR2. What was missing was a way in.
+
+
+@pytest.fixture
+def wav_bytes() -> bytes:
+    """A 24-bit 48 kHz stereo WAV, which is what the rubric asks about."""
+    import io as _io
+    import wave
+
+    buffer = _io.BytesIO()
+    with wave.open(buffer, "wb") as sound:
+        sound.setnchannels(2)
+        sound.setsampwidth(3)
+        sound.setframerate(48_000)
+        sound.writeframes(b"\x00" * 3 * 2 * 24_000)  # half a second
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def zip_file(base_dir: Path, wav_bytes: bytes) -> Path:
+    """One real stem and the resource fork macOS files beside it."""
+    import zipfile
+
+    p = base_dir / "STEMS.zip"
+    with zipfile.ZipFile(p, "w") as writing:
+        writing.writestr("STEMS/MASTER.wav", wav_bytes)
+        writing.writestr("STEMS/notes.txt", "mixed at 48k, 24-bit\n")
+        writing.writestr("__MACOSX/STEMS/._MASTER.wav", b"\x00\x05\x16\x07")
+        writing.writestr("STEMS/._notes.txt", b"\x00\x05\x16\x07")
+    return p
+
+
+def test_inspect_structure_lists_an_archive(base_dir, zip_file):
+    r = read_deliverable("inspect_structure", zip_file.name, base_dir=str(base_dir))
+
+    assert r["ok"] is True
+    data = r["data"]
+    assert data["kind"] == "zip"
+    assert data["entry_count"] == 2
+    assert [entry["name"] for entry in data["entries"]] == [
+        "STEMS/MASTER.wav",
+        "STEMS/notes.txt",
+    ]
+    # The kind of each member is what tells a judge which op to reach for.
+    assert [entry["kind"] for entry in data["entries"]] == ["audio", "txt"]
+
+
+def test_an_archive_reads_as_its_own_listing(base_dir, zip_file):
+    """"Does it contain a Bass stem in WAV format" is answerable from names.
+
+    A judge that never learns about the member scope still has to be able to
+    answer that, so the listing is the text of an archive.
+    """
+    r = read_deliverable("read_content", zip_file.name, base_dir=str(base_dir))
+
+    assert r["ok"] is True
+    assert r["data"]["kind"] == "zip"
+    assert "STEMS/MASTER.wav" in r["data"]["text"]
+    assert "audio" in r["data"]["text"]
+
+
+def test_resource_forks_are_hidden_but_counted(base_dir, zip_file):
+    """Five real stems and five ``._`` twins reads as ten files of nothing.
+
+    Hiding them is not the same as dropping them: the count says how many were
+    withheld, so a listing that looks short can be checked rather than trusted.
+    """
+    listing = read_deliverable(
+        "inspect_structure", zip_file.name, base_dir=str(base_dir)
+    )["data"]
+
+    assert "__MACOSX" not in str(listing["entries"])
+    assert "._notes.txt" not in str(listing["entries"])
+    assert listing["hidden_resource_fork_count"] == 2
+
+
+def test_a_hidden_member_is_still_reachable_by_name(base_dir, zip_file):
+    """Hidden from the listing, not removed from the archive.
+
+    Something has to be able to look at a resource fork to establish that it is
+    one, and a reader that can only report what it chose to show cannot be
+    argued with.
+    """
+    r = read_deliverable(
+        "read_content", zip_file.name, base_dir=str(base_dir),
+        scope={"member": "__MACOSX/STEMS/._MASTER.wav"},
+    )
+
+    assert r["ok"] is True
+
+
+def test_probe_audio_reaches_a_stem_inside_an_archive(base_dir, zip_file):
+    """The three rubric items the archive gap cost, on one member.
+
+    Format, sample rate and bit depth are each five items on the real answer --
+    thirty of the sixty points it lost -- and all three come off a WAV header
+    that was always readable, once something opens the container.
+    """
+    pytest.importorskip("av")
+
+    r = read_deliverable(
+        "probe_audio", zip_file.name, base_dir=str(base_dir),
+        scope={"member": "STEMS/MASTER.wav"},
+    )
+
+    assert r["ok"] is True, r
+    data = r["data"]
+    assert data["sample_rate"] == 48_000
+    assert data["channels"] == 2
+    assert data["codec"] == "pcm_s24le"  # 24-bit PCM, little-endian
+    assert 0.4 < data["duration_s"] < 0.6
+
+
+def test_read_content_reaches_a_text_member(base_dir, zip_file):
+    """Any op, not just the audio one: a member is addressed like a file."""
+    r = read_deliverable(
+        "read_content", zip_file.name, base_dir=str(base_dir),
+        scope={"member": "STEMS/notes.txt"},
+    )
+
+    assert r["ok"] is True
+    assert r["data"]["kind"] == "txt"
+    assert "24-bit" in r["data"]["text"]
+
+
+def test_a_member_keeps_its_extension_while_being_read(base_dir, zip_file):
+    """Extraction under a random temp name would make every member unknown.
+
+    Every op here dispatches on suffix, so a member written to disk as
+    ``tmpXXXX`` is a member no op can identify -- the container would be open
+    and its contents still unreadable.
+    """
+    with read_deliverable_module._extracted_zip_member(
+        zip_file, "STEMS/MASTER.wav"
+    ) as extracted:
+        assert extracted.suffix == ".wav"
+        assert read_deliverable_module._kind_of(extracted) == "audio"
+        assert extracted.is_file()
+
+    # And it does not outlive the op that asked for it.
+    assert not extracted.exists()
+
+
+def test_an_unknown_member_is_refused_with_the_names_that_exist(
+    base_dir, zip_file
+):
+    r = read_deliverable(
+        "probe_audio", zip_file.name, base_dir=str(base_dir),
+        scope={"member": "STEMS/BASS.wav"},
+    )
+
+    assert r["ok"] is False
+    assert r["error_type"] == "bad_scope"
+    assert "STEMS/MASTER.wav" in r["error"]
+
+
+def test_a_member_name_cannot_escape_the_archive(base_dir, zip_file):
+    """Traversal is refused by lookup, not by sanitising.
+
+    ``getinfo`` matches names exactly, so a member that is not in the archive
+    cannot be named -- there is no rule to get wrong and no encoding to slip
+    past. This checks the property rather than a blocklist.
+    """
+    for attempt in ("../../etc/passwd", "/etc/passwd", "STEMS/../../../secret"):
+        r = read_deliverable(
+            "read_content", zip_file.name, base_dir=str(base_dir),
+            scope={"member": attempt},
+        )
+        assert r["ok"] is False, attempt
+        assert r["error_type"] == "bad_scope", attempt
+
+
+def test_the_member_scope_is_refused_on_a_file_that_is_not_an_archive(
+    base_dir, txt_file
+):
+    """A scope key that silently does nothing is worse than one that errors."""
+    r = read_deliverable(
+        "read_content", txt_file.name, base_dir=str(base_dir),
+        scope={"member": "anything"},
+    )
+
+    assert r["ok"] is False
+    assert r["error_type"] == "bad_scope"
+    assert "zip" in r["error"]
+
+
+def test_an_oversized_member_is_refused_before_it_is_written(
+    base_dir, zip_file, monkeypatch
+):
+    """The cap bounds temp disk, so it has to be checked before extracting.
+
+    The real archive is 179.7 MB compressed; a hostile or merely broken one is
+    the reason this is a number rather than a hope.
+    """
+    monkeypatch.setattr(read_deliverable_module, "MAX_ZIP_MEMBER_BYTES", 16)
+
+    r = read_deliverable(
+        "read_content", zip_file.name, base_dir=str(base_dir),
+        scope={"member": "STEMS/notes.txt"},
+    )
+
+    assert r["ok"] is False
+    assert r["error_type"] == "op_error"
+    assert "cap" in r["error"]
+
+
+def test_a_long_listing_is_cut_and_says_so(base_dir, monkeypatch):
+    """A truncated listing that looks complete is a wrong answer, not a short one."""
+    import zipfile
+
+    monkeypatch.setattr(read_deliverable_module, "MAX_ZIP_ENTRIES", 3)
+    p = base_dir / "many.zip"
+    with zipfile.ZipFile(p, "w") as writing:
+        for i in range(10):
+            writing.writestr(f"file{i}.txt", "x")
+
+    listing = read_deliverable("inspect_structure", p.name, base_dir=str(base_dir))
+    text = read_deliverable("read_content", p.name, base_dir=str(base_dir))
+
+    assert listing["data"]["entry_count"] == 3
+    assert listing["data"]["truncated"] is True
+    assert "truncated" in text["data"]["text"]
+
+
+def test_a_corrupt_archive_reports_the_failure_instead_of_reading_empty(
+    base_dir
+):
+    """The old behaviour was an empty read with a note, which reads as a weak
+    answer rather than a broken file. An archive that will not open should look
+    like what it is.
+    """
+    p = base_dir / "broken.zip"
+    p.write_bytes(b"PK\x03\x04not really a zip")
+
+    r = read_deliverable("read_content", p.name, base_dir=str(base_dir))
+    structure = read_deliverable("inspect_structure", p.name, base_dir=str(base_dir))
+
+    assert r["ok"] is False
+    assert r["error_type"] == "exception"
+    # inspect_structure keeps its own contract: it never raises, it annotates.
+    assert structure["ok"] is True
+    assert "inspection_error" in structure["data"]

--- a/tasks/rebuilding_grading_task/300-gold-ceiling.md
+++ b/tasks/rebuilding_grading_task/300-gold-ceiling.md
@@ -59,11 +59,25 @@
 
 | 지문 | 값 |
 |---|---|
-| `ordered_task_ids_sha256` | `09ce924576b6822a7f96d651b40c18add5fceb6e216653c8bdb9c5a194c9dfdc` |
+| `ordered_task_ids_sha256` | `82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b` |
 | `gold_file_set_sha256` | `cd4448b4a25b12aa3ae95616a60fdccc47707298d86a9aa2f7cd2ace9c15a7c8` |
 
-- `ordered_task_ids_sha256` = 30개 task id를 순서대로 개행으로 이어 붙인 문자열의 SHA-256
-- `gold_file_set_sha256` = 각 파일의 `graded_path\tsha256\tsize`를 task 순서대로 개행으로 이어 붙인 문자열의 SHA-256
+- `ordered_task_ids_sha256` = 30개 task id를 순서대로 담은 compact JSON 배열
+  (`json.dumps(ids, ensure_ascii=False, separators=(",", ":"))`)의 SHA-256.
+  이건 **채점기가 직접 쓰는 값**이다. `step8_grade._ordered_task_ids_sha256`가
+  계산해서 모든 grade JSON의 `expected_ordered_task_ids_sha256`에 넣고,
+  출력 디렉터리 이름도 이 값이 된다. 그래서 2단계 반복 실행은 이 값을
+  payload 필드와 그대로 맞대볼 수 있다.
+- `gold_file_set_sha256` = 각 파일의 `graded_path\tsha256\tsize`를 task 순서대로
+  개행으로 이어 붙인 문자열의 SHA-256. 이건 **이 문서가 정의한 값**이다.
+  파이프라인 어디에도 정답 파일 묶음을 지문화하는 코드가 없어서, payload에는
+  대응하는 필드가 없다. 자기 자신끼리만 비교한다.
+
+> 같은 30개를 다른 방식으로 인코딩하면 당연히 다른 지문이 나온다. 예전 판의 이
+> 표에는 같은 id 목록을 개행으로 이어 붙인 `09ce9245…`가 적혀 있었고, 그 값이
+> 분석 도구에 그대로 옮겨져 **1단계 자기 실행을 거부했다**. 목록도 순서도 옳았고
+> 구분자만 달랐다. 그래서 지금은 도구가 이 값을 문자열로 베끼지 않고
+> `step8_grade`의 함수로 다시 계산해 맞춘다.
 
 두 값 모두 매니페스트와 grading config만으로 다시 계산된다 — 623MB짜리 원본 파일 없이도 검증 가능하다.
 

--- a/tasks/rebuilding_grading_task/300-gold-ceiling.md
+++ b/tasks/rebuilding_grading_task/300-gold-ceiling.md
@@ -83,11 +83,17 @@
 
 **표본 구성**: 파일 40개 / 184,099,078 바이트. 확장자는 docx 13, pdf 12, xlsx 11, pptx 3, zip 1. sector는 Government 13, Professional·Scientific·Technical 9, Manufacturing 5, Information 3. 직업은 Accountants and Auditors 5, Administrative Services Managers 5, Buyers and Purchasing Agents 5, Compliance Officers 5, Computer and Information Systems Managers 4, Audio and Video Technicians 3, Child·Family·School Social Workers 3.
 
-### 알려진 입력 한계 (사전 공개)
+### 알려진 입력 한계 (사전 공개 → 1차 실행이 확인 → 고침)
 
-task `38889c3b-e3d4-49c8-816a-3cc8e5313aba`의 gold 답안은 179.7MB `.zip` 한 개다. `core/tools/read_deliverable.py`는 zip을 다루지 못한다 — `kind`가 `unknown`으로 떨어지고 `read_content`는 빈 텍스트에 "binary or unsupported for text read" 주석을 붙여 돌려준다.
+task `38889c3b-e3d4-49c8-816a-3cc8e5313aba`의 gold 답안은 179.7MB `.zip` 한 개다. 실행 전에 이 표본에서 빼지 않겠다고 적어두었다 — 빼면 천장이 실제보다 좋아 보이기 때문이다. 미리 적어두는 이유는, 실행 후에 이유를 만들어내는 것과 미리 예측해두는 것은 증거로서 값이 다르기 때문이다.
 
-그래도 표본에서 빼지 않는다. 빼면 천장이 실제보다 좋아 보이기 때문이다. 이 task가 낮게 나오면 그건 grader 결함이 아니라 **읽기 도구의 형식 미지원**이며, 결과 분석에서 그렇게 분류해야 한다. 미리 적어두는 이유는, 실행 후에 이유를 만들어내는 것과 미리 예측해두는 것은 증거로서 값이 다르기 때문이다.
+1차 유료 실행이 예측을 그대로 확인했다: **62점 만점에 2.00점**. 통과한 항목은 "최상위 zip 압축 파일 정확히 한 개를 제출한다" 하나뿐이고, 그건 zip이라서 통과한 것이다. 나머지 34개 항목은 전부 "binary or unsupported for text read" 또는 "not an audio file"이라는 증거를 달고 떨어졌다.
+
+**다만 예측의 이유가 틀렸다.** 예전 판은 이걸 "읽기 도구의 형식 미지원"이라고 적었다. 압축 파일 **안**의 형식은 전부 지원된다 — 5개 WAV stem이고, `probe_audio`는 PR2부터 WAV를 읽는다. 지원되지 않은 것은 형식이 아니라 **컨테이너**였다. 아무도 열어보지 않은 파일을 놓고 표본율·비트 심도·길이를 물은 것이다.
+
+그래서 고쳤다. `core/tools/read_deliverable.py`가 이제 압축 파일의 목록을 내용으로 돌려주고, `scope={"member": "<이름>"}`으로 개별 구성원에 아무 op이나 걸 수 있다. 실제 답안에 걸어 확인한 결과: 5개 stem 전부 48,000Hz / `pcm_s24le`(24비트) / 스테레오, MASTER 137.14초(2분 17초). 이걸로 32점어치 항목(WAV 형식 5, 표본율 5, 비트 심도 5, 길이 1)이 증거를 갖게 된다.
+
+**아직 닿지 않는 것**은 남은 28점이다. `grader_routing.py`와 `deliverable_selector.py`에게 이 답안은 여전히 확장자가 `.zip`인 파일 한 개라서, 듣기 모델이 배정되지 않는다. 조성(G장조 → A♭장조 → G장조), 템포 140, 보컬 없음, 브리지 1:22–1:49, 시간계 이펙트, 신스 계열, `DRUM REFERENCE TRACK.wav`와의 동기 — 전부 실제로 들어야 답할 수 있고, 이번 수정 범위 밖이다. 후속 항목으로 분리해 점수 영향까지 적어 둔다.
 
 ### 결과가 발표되지 않는 이유
 


### PR DESCRIPTION
## 왜 이 변경이 필요한가

1단계 gold-ceiling 실행은 벤치마크가 스스로 정답이라 내놓은 결과물을 채점한 것이다. 정답이니 만점 근처가 나와야 하는데 **평균 78.24%** 가 나왔다. 그러면 잘못은 정답이 아니라 채점기 쪽에 있다.

원인을 셋으로 나눠 봤고 — 채점기 결함 / 입력 결함 / 도구 결함 — 그중 **도구 결함 두 개**를 여기서 고친다. 둘 다 같은 모양이다: **파일 안에 있던 내용을 판정자에게 한 번도 보여주지 않았다.**

## 무엇이 안 보였나

**발표 자료의 표·차트·묶음 도형.** `_read_pptx_text`가 `shape.has_text_frame`만 보고 멈췄다. 표는 텍스트 프레임이 없는 도형이라 셀 하나하나를 그냥 지나쳤고, 묶음 도형은 안에 든 자식을 아예 들어가 보지 않았다. `WorkStudy.pptx`는 슬라이드 제목 **186자**로 읽혔다 — 그 아래 15행짜리 표에 모든 활동 분류와 비율이 들어 있었는데도. 채점 항목이 바로 그 분류를 물었고 0/1을 받았다. 지금은 **3,041자**로 읽힌다.

**차트는 길이 하나 더 필요했다.** python-pptx는 일부 차트 종류만 다루고 나머지엔 `unsupported plot type`을 던진다. 같은 자료의 차트 5개 중 4개가 그 나머지(`pie3DChart`)다. 게다가 종류·분류·계열 셋 다 똑같이 던져서, 모델링된 경로로는 아무것도 못 얻는다. 캐시된 값은 차트 XML에 항상 들어 있다 — 원본 워크시트 없이도 자료가 그려지는 이유가 그거다. 그래서 거기서 직접 읽는다. 차트 종류와 무관하게 동작하는 게 핵심이다.

**압축 파일.** 확장자 표에 `.zip`이 없어서 `read_content`가 빈 문자열과 "binary or unsupported for text read"만 돌려줬다. 어떤 정답은 WAV 스템 5개가 담긴 압축 파일 하나인데, **62점 만점에 2.00점** 을 받았다. 통과한 항목은 "최상위 zip 압축 파일 정확히 한 개를 제출한다" 하나뿐 — zip이라서 통과한 것이다.

안에 든 형식은 처음부터 문제가 아니었다. WAV는 PR2부터 읽을 수 있었다. **없었던 건 들어가는 길이다.**

## 무엇이 달라지나

압축 파일은 이제 자기 목록을 내용으로 돌려주고, `scope={"member": "<이름>"}`으로 개별 구성원에 아무 op이나 걸 수 있다. 압축 파일 안 WAV에 대한 `probe_audio`는 그냥 WAV에 대한 `probe_audio`다.

실제 179.7MB 정답에 걸어 확인:

```
[Archive: 5 file(s)]
DEJA VU  STEMS /BRIDGE.wav | audio | 60965258 bytes
...
BRIDGE.wav  -> 48000 Hz 2 ch pcm_s24le 211.68 s
MASTER.wav  -> 48000 Hz 2 ch pcm_s24le 137.14 s
```

스템 5개 전부 48,000Hz / 24비트 / 스테레오, 마스터 2분 17초. **32점어치 채점 항목**(WAV 형식 5, 표본율 5, 비트 심도 5, 길이 1)이 이제 증거를 갖는다 — 전에는 아무도 열어보지 않은 파일을 놓고 답하던 것들이다.

## 안전 처리

구성원은 이름 조회로만 접근한다. 압축 파일에 없는 이름은 존재하는 이름 목록과 함께 거부되므로, 경로 탈출을 걸러낼 게 아니라 애초에 없다. 추출은 바이트 상한을 **쓰기 전과 쓰는 중 양쪽에서** 확인하며 흘려보낸다 — 선언된 크기는 줄여 적을 수 있기 때문이다. macOS 리소스 포크는 목록에서 감추되 이름으로는 여전히 열린다(여기 압축 파일엔 진짜 스템 5개 옆에 포크 5개가 들어 있다).

## 아직 못 고친 것

`grader_routing.py`와 `deliverable_selector.py`에게 이 정답은 여전히 확장자가 `.zip`인 파일 한 개다. 그래서 듣기 모델이 배정되지 않는다. 조성·템포·보컬 유무·브리지 구간 — **같은 과제에서 약 28점** — 은 실제로 들어야 답할 수 있고, 별개 변경이다. 나중에 다시 발견하게 두는 대신 명세에 적어 뒀다.

## 지문이 바뀐다

`core/`를 건드렸으므로 `grader_source_hash`가 `8513975c188f31a6` → `c33d9d55703fbf5d`로 바뀐다. 1단계는 고친 채점기로 다시 돌려야 하고, 결과 파일은 이름이 달라 기존 실행을 덮지 않는다.

`grade-run.yml`은 `HEAD == main`과 `HEAD == GITHUB_SHA`를 둘 다 검사한다. 즉 **유료 채점은 병합된 코드로만 돌 수 있다.** 그래서 이 PR이 먼저 들어가야 하고, 1단계 보고서(`PR3_GOLD_CEILING.md`)와 그 검사 시험은 실행 결과가 나온 뒤 별도 PR로 따라온다.

## 검증

- 전체 시험 **5071 통과 / 0 실패** (integration 45개 제외)
- `read_deliverable` 시험 78개, gold-ceiling 계약·분석 시험 62개 포함
- mypy: `read_deliverable.py` 7건, 저장소 전체 170건 — main과 **완전히 동일**. 새로 추가된 것 없음