### PR TITLE
feat(cost): record what each task actually cost to solve and to grade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ tasks/0822_saturday/*
 !tasks/0822_saturday/TASK_PIN_AZURE_RESOURCE_IDENTITY.md
 !tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md
 !tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+!tasks/0828_friday/
+tasks/0828_friday/*
+!tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md
 # The grading-rebuild specs and reports here predate the `tasks/**` rule, so
 # they stay tracked without an entry. A *new* file among them does not -- git
 # will not un-ignore a path inside an ignored directory, which is why the

--- a/batch-runner/core/cost_metering.py
+++ b/batch-runner/core/cost_metering.py
@@ -1,0 +1,539 @@
+"""Turning a provider client into one that keeps its own receipts.
+
+The pipeline calls models from a dozen places — a subprocess runner, a
+container, a self-check, four judges, two perception readers. Threading a
+ledger through every one of those signatures would touch most of the codebase
+and would still miss whichever path was added last.
+
+So the ledger is attached to the *client* instead. :meth:`CostRecorder.meter`
+wraps whatever the provider factory returned, and from then on every
+``chat.completions.create`` and ``responses.create`` that goes through it
+reserves a row before the request and settles it after the reply, without the
+calling code knowing. What the calling code does supply is *whose* call it is —
+:meth:`CostRecorder.attributed` marks a block as belonging to one task at one
+stage, and calls made inside it are filed there.
+
+Metering is opt-in, one client at a time. A path nobody wrapped records
+nothing, and its receipt says ``stage_unsupported`` rather than quietly
+reporting a smaller bill. That is the intended behaviour for execution paths
+that have no confirmed model call to meter: silence is reported as silence.
+
+Nothing here contacts a provider. It sits between code that does and the
+ledger.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+from core.cost_receipts import (
+    BUCKETS,
+    RETRY_NONE,
+    RETRY_KINDS,
+    STAGES,
+    STAGE_BUCKET,
+    CallUsage,
+    CostReceipt,
+    CostReceiptLedger,
+    load_receipt_price_table,
+    make_call_id,
+)
+
+__all__ = [
+    "Attribution",
+    "CostRecorder",
+    "MeteredClient",
+    "extract_usage",
+    "open_cost_recorder",
+    "resolved_model_of",
+]
+
+
+@dataclass(frozen=True)
+class Attribution:
+    """Whose call this is: one task, one stage, one kind of retry."""
+
+    task_id: str
+    stage: str
+    retry_kind: str = RETRY_NONE
+    attempt_index: int = 0
+
+    def __post_init__(self) -> None:
+        if self.stage not in STAGES:
+            raise ValueError(f"unknown stage {self.stage!r}")
+        if self.retry_kind not in RETRY_KINDS:
+            raise ValueError(f"unknown retry kind {self.retry_kind!r}")
+        if not self.task_id:
+            raise ValueError("a metered call must belong to a task")
+
+    @property
+    def bucket(self) -> str:
+        return STAGE_BUCKET[self.stage]
+
+
+_CURRENT: ContextVar[Attribution | None] = ContextVar(
+    "cost_attribution", default=None
+)
+
+
+# ── Reading usage off whatever the provider returned ─────────────────────
+
+
+def _as_int(value: Any) -> int | None:
+    """Accept a token count only if it is really one.
+
+    ``bool`` is excluded on purpose — ``True`` is an ``int`` in Python and a
+    truthy flag arriving where a count belongs should not silently become one
+    token.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    return None
+
+
+def _get(container: Any, name: str) -> Any:
+    if container is None:
+        return None
+    if isinstance(container, Mapping):
+        return container.get(name)
+    return getattr(container, name, None)
+
+
+def _first_int(container: Any, *names: str) -> int | None:
+    for name in names:
+        found = _as_int(_get(container, name))
+        if found is not None:
+            return found
+    return None
+
+
+def extract_usage(response: Any) -> CallUsage:
+    """Read one reply's token counts, whatever API shape it arrived in.
+
+    Three shapes reach this function: the Chat Completions object with
+    ``prompt_tokens``/``completion_tokens``, the Responses object with
+    ``input_tokens``/``output_tokens``, and the normalised wrapper this
+    repository puts around non-OpenAI providers. All three are read here so
+    that no call site has to know which one it is holding.
+
+    A field that is absent stays ``None``. It is not defaulted to zero — a
+    provider that reported nothing has not told us the call was free.
+    """
+    usage = _get(response, "usage")
+    if usage is None:
+        return CallUsage()
+
+    input_tokens = _first_int(usage, "input_tokens", "prompt_tokens")
+    output_tokens = _first_int(usage, "output_tokens", "completion_tokens")
+
+    cached = _first_int(usage, "cached_tokens", "cache_read_input_tokens")
+    if cached is None:
+        for details_name in ("prompt_tokens_details", "input_tokens_details"):
+            cached = _first_int(_get(usage, details_name), "cached_tokens")
+            if cached is not None:
+                break
+
+    reasoning = _first_int(usage, "reasoning_tokens")
+    if reasoning is None:
+        for details_name in (
+            "completion_tokens_details",
+            "output_tokens_details",
+        ):
+            reasoning = _first_int(_get(usage, details_name), "reasoning_tokens")
+            if reasoning is not None:
+                break
+
+    return CallUsage(
+        input_tokens=input_tokens,
+        cached_input_tokens=cached,
+        output_tokens=output_tokens,
+        reasoning_tokens=reasoning,
+    )
+
+
+def resolved_model_of(response: Any, fallback: str) -> str:
+    """The model the *reply* names, falling back to the one we asked for.
+
+    A deployment alias and the model behind it can differ, and it is the model
+    behind it that appears on the bill. Where the reply says nothing, the
+    request's name is used and the price lookup either matches exactly or
+    reports itself missing.
+    """
+    named = _get(response, "model")
+    if isinstance(named, str) and named.strip():
+        return named.strip()
+    return fallback
+
+
+# ── The recorder ─────────────────────────────────────────────────────────
+
+
+class CostRecorder:
+    """Files metered calls into a ledger under whichever task is in scope.
+
+    ``round_index`` keeps a resumed run from colliding with the round before
+    it. Call identifiers are derived from position rather than content, so the
+    second round's first generation call would otherwise be named exactly like
+    the first round's — and settling an already-settled identifier with
+    different numbers is, correctly, an error. Numbering the round separates
+    them, and the earlier round's costs survive alongside the new ones.
+    """
+
+    def __init__(
+        self,
+        ledger: CostReceiptLedger,
+        *,
+        run_id: str | None = None,
+        round_index: int = 0,
+    ):
+        self.ledger = ledger
+        self.run_id = str(run_id or ledger.run_id)
+        self.round_index = int(round_index)
+        self._sequences: dict[tuple[str, str, str, int], int] = {}
+
+    # -- attribution -----------------------------------------------------
+
+    @contextmanager
+    def attributed(
+        self,
+        *,
+        task_id: str,
+        stage: str,
+        retry_kind: str = RETRY_NONE,
+        attempt_index: int | None = None,
+    ) -> Iterator[Attribution]:
+        """Mark a block of work as one task's, at one stage.
+
+        Nests: a perception read taken during grading can open its own scope
+        and the outer one is restored on the way out, so the two land in
+        different components of the same receipt.
+        """
+        attribution = Attribution(
+            task_id=str(task_id),
+            stage=stage,
+            retry_kind=retry_kind,
+            attempt_index=(
+                self.round_index if attempt_index is None else int(attempt_index)
+            ),
+        )
+        token = _CURRENT.set(attribution)
+        try:
+            yield attribution
+        finally:
+            _CURRENT.reset(token)
+
+    @staticmethod
+    def current() -> Attribution | None:
+        return _CURRENT.get()
+
+    def _next_call_id(self, attribution: Attribution) -> str:
+        key = (
+            attribution.task_id,
+            attribution.stage,
+            attribution.retry_kind,
+            attribution.attempt_index,
+        )
+        sequence = self._sequences.get(key, 0)
+        self._sequences[key] = sequence + 1
+        # The round is folded into the hashed run identity rather than left to
+        # ``attempt_index``, because callers that know their own attempt number
+        # — a Self-QA loop, say — pass one and would otherwise reuse the
+        # previous round's identifiers exactly.
+        return make_call_id(
+            run_id=f"{self.run_id}|round{self.round_index}",
+            task_id=attribution.task_id,
+            stage=attribution.stage,
+            retry_kind=attribution.retry_kind,
+            attempt_index=attribution.attempt_index,
+            sequence=sequence,
+        )
+
+    # -- metering --------------------------------------------------------
+
+    def meter(
+        self,
+        client: Any,
+        *,
+        provider: str,
+        model: str | None = None,
+        stage: str | None = None,
+    ) -> "MeteredClient":
+        """Wrap a provider client so its calls record themselves.
+
+        ``stage`` pins every call made through this wrapper to one stage,
+        overriding whatever scope it happens to run inside. That is how a
+        perception reader sharing the judge's client still lands in its own
+        component: the two get two wrappers around one connection, and the
+        task in scope is taken from the enclosing block either way.
+        """
+        if stage is not None and stage not in STAGES:
+            raise ValueError(f"unknown stage {stage!r}")
+        return MeteredClient(
+            client,
+            recorder=self,
+            provider=str(provider),
+            default_model=model,
+            stage=stage,
+        )
+
+    def record_call(
+        self,
+        *,
+        provider: str,
+        requested_model: str,
+        response: Any,
+        attribution: Attribution | None = None,
+    ) -> str | None:
+        """File a call that has already happened.
+
+        For the handful of paths that own their own transport and cannot be
+        wrapped. Reserves and settles in one go, which means it cannot show a
+        request that left and never came back — use :meth:`meter` where the
+        call can be intercepted.
+        """
+        target = attribution or self.current()
+        if target is None:
+            return None
+        call_id = self._next_call_id(target)
+        self.ledger.reserve(
+            call_id=call_id,
+            task_id=target.task_id,
+            stage=target.stage,
+            retry_kind=target.retry_kind,
+            provider=provider,
+            requested_model=requested_model,
+        )
+        self.ledger.settle(
+            call_id,
+            usage=extract_usage(response),
+            resolved_model=resolved_model_of(response, requested_model),
+        )
+        return call_id
+
+    def abandon_call(self, call_id: str, *, note: str | None = None) -> None:
+        """Record that a reserved call never went out, so it cost nothing."""
+        self.ledger.abandon(call_id, note=note)
+
+    # -- reading ---------------------------------------------------------
+
+    def receipt_for(
+        self, task_id: str, bucket: str, **kwargs: Any
+    ) -> CostReceipt:
+        if bucket not in BUCKETS:
+            raise ValueError(f"unknown bucket {bucket!r}")
+        return self.ledger.receipt_for(task_id, bucket, **kwargs)
+
+
+# ── The wrapper ──────────────────────────────────────────────────────────
+
+
+class _MeteredCreate:
+    """Stands in for one ``…create`` method and records around it."""
+
+    def __init__(self, inner: Any, wrapper: "MeteredClient"):
+        self._inner = inner
+        self._wrapper = wrapper
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._wrapper._around(self._inner.create, kwargs)
+
+
+class _MeteredChat:
+    def __init__(self, inner: Any, wrapper: "MeteredClient"):
+        self._inner = inner
+        self._wrapper = wrapper
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "completions":
+            return _MeteredCreate(self._inner.completions, self._wrapper)
+        return getattr(self._inner, name)
+
+
+class MeteredClient:
+    """A provider client that writes a ledger row for every call it makes.
+
+    Everything not intercepted is passed straight through, so this can stand in
+    anywhere the unwrapped client stood. Only the two request methods are
+    replaced.
+
+    ``stage`` pins calls to one stage regardless of the scope they run in,
+    which lets two wrappers around one connection file into two different
+    components — the judge's own calls and the perception reads it shares its
+    client with.
+
+    When a call raises, the reservation is deliberately *left standing* rather
+    than cleaned up. A request that timed out may well have been served and
+    billed, and the honest record of that is an unsettled reservation, which
+    turns the task's receipt ``partial`` with ``call_reachability_unknown``. A
+    caller that knows the failure happened before anything left the process can
+    say so with :meth:`CostRecorder.abandon_call`.
+    """
+
+    #: Lets code that must know a client's real provider type look through the
+    #: wrapper. ``isinstance`` cannot see past a forwarding proxy, so the one
+    #: place in the pipeline that dispatches on client type reads this instead.
+    _is_cost_metered = True
+
+    def __init__(
+        self,
+        inner: Any,
+        *,
+        recorder: CostRecorder,
+        provider: str,
+        default_model: str | None = None,
+        stage: str | None = None,
+    ):
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_recorder", recorder)
+        object.__setattr__(self, "_provider", provider)
+        object.__setattr__(self, "_default_model", default_model)
+        object.__setattr__(self, "_stage", stage)
+        object.__setattr__(self, "last_call_id", None)
+
+    # -- the two request surfaces ----------------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        inner = object.__getattribute__(self, "_inner")
+        if name == "responses":
+            return _MeteredCreate(inner.responses, self)
+        if name == "chat":
+            return _MeteredChat(inner.chat, self)
+        return getattr(inner, name)
+
+    def chat_complete(self, **kwargs: Any) -> Any:
+        """The normalised entry point non-OpenAI providers expose."""
+        inner = object.__getattribute__(self, "_inner")
+        return self._around(inner.chat_complete, kwargs)
+
+    # -- passthrough for the parts callers rely on -----------------------
+
+    @property
+    def inner(self) -> Any:
+        return object.__getattribute__(self, "_inner")
+
+    @property
+    def provider(self) -> str:
+        return object.__getattribute__(self, "_provider")
+
+    def close(self) -> None:
+        inner = object.__getattribute__(self, "_inner")
+        close = getattr(inner, "close", None)
+        if callable(close):
+            close()
+
+    def __enter__(self) -> "MeteredClient":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.close()
+
+    # -- internals -------------------------------------------------------
+
+    def _around(self, call: Any, kwargs: dict[str, Any]) -> Any:
+        recorder: CostRecorder = object.__getattribute__(self, "_recorder")
+        attribution = recorder.current()
+        if attribution is None:
+            # Outside any task's scope. Report generation and other
+            # out-of-band work belongs to neither pipeline, and inventing a
+            # home for it would corrupt both totals.
+            return call(**kwargs)
+
+        pinned = object.__getattribute__(self, "_stage")
+        if pinned is not None and pinned != attribution.stage:
+            attribution = Attribution(
+                task_id=attribution.task_id,
+                stage=pinned,
+                retry_kind=attribution.retry_kind,
+                attempt_index=attribution.attempt_index,
+            )
+
+        requested = str(
+            kwargs.get("model")
+            or object.__getattribute__(self, "_default_model")
+            or ""
+        )
+        call_id = recorder._next_call_id(attribution)
+        recorder.ledger.reserve(
+            call_id=call_id,
+            task_id=attribution.task_id,
+            stage=attribution.stage,
+            retry_kind=attribution.retry_kind,
+            provider=object.__getattribute__(self, "_provider"),
+            requested_model=requested,
+        )
+        object.__setattr__(self, "last_call_id", call_id)
+        response = call(**kwargs)
+        recorder.ledger.settle(
+            call_id,
+            usage=extract_usage(response),
+            resolved_model=resolved_model_of(response, requested),
+        )
+        return response
+
+
+# ── Opening a recorder for a run ─────────────────────────────────────────
+
+
+def open_cost_recorder(
+    path: Path | str,
+    *,
+    run_id: str,
+    round_index: int = 0,
+    continue_rounds: bool = False,
+    price_table_path: Path | str | None = None,
+    logger: Any = None,
+) -> tuple[CostRecorder | None, str | None]:
+    """Open the ledger for one run, or explain why there is none.
+
+    Returns ``(recorder, note)``. A failure here does not stop the run: a
+    pipeline that cannot open a bookkeeping file should still do the work it
+    was started for. What it must not do is pretend the work was free, so the
+    failure returns ``None`` and every receipt built afterwards says
+    ``ledger_absent`` instead of showing a total.
+
+    A missing or malformed price table is treated the same way but less
+    severely — the ledger still records what was *sent*, and the receipts come
+    out ``partial`` with ``price_missing`` rather than showing nothing at all.
+
+    ``continue_rounds`` is for callers that resume without counting their own
+    rounds. Where a run knows it is on round *n* it says so; where it only
+    knows it is picking up a ledger somebody else left behind, this reads the
+    round number off the ledger's own size. See
+    :meth:`CostReceiptLedger.call_count`.
+    """
+    from pathlib import Path as _Path
+
+    price_table = None
+    note = None
+    try:
+        price_table = load_receipt_price_table(price_table_path)
+    except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+        note = (
+            f"price table unreadable ({type(exc).__name__}); "
+            "calls recorded unpriced"
+        )
+        if logger is not None:
+            logger.warning("cost receipts: %s", note)
+
+    try:
+        ledger = CostReceiptLedger(
+            _Path(path), run_id=run_id, price_table=price_table
+        )
+    except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+        failure = f"cost ledger could not be opened ({type(exc).__name__})"
+        if logger is not None:
+            logger.warning("cost receipts: %s", failure)
+        return None, failure
+
+    if continue_rounds:
+        round_index = max(int(round_index), ledger.call_count())
+    return CostRecorder(ledger, round_index=round_index), note

--- a/batch-runner/core/cost_receipts.py
+++ b/batch-runner/core/cost_receipts.py
@@ -90,6 +90,23 @@ BUCKET_GRADING = "grading_cost"
 
 BUCKETS = (BUCKET_PROBLEM_SOLVING, BUCKET_GRADING)
 
+#: The label a receipt line carries when the work was a second attempt. It is
+#: not a stage — retrying is something a stage does — but a reader showing one
+#: row per line needs a word for it, and "what did retrying cost" is a question
+#: worth being able to answer at a glance.
+COMPONENT_RETRY = "retry"
+
+#: Every value :attr:`ReceiptComponent.name` can take. Published so that a
+#: reader can build its display from the producer's own vocabulary instead of
+#: guessing at one; a name absent from here is a bug on this side, not a slug
+#: the reader has to defend against.
+#:
+#: There is deliberately no ``runtime`` entry. Runtime fees are not model
+#: calls, they are reported separately as ``runtime_cost_usd``, and a component
+#: line carrying them would be added twice by any reader that sums the lines
+#: and then adds the runtime total.
+COMPONENT_NAMES = (*STAGES, COMPONENT_RETRY)
+
 #: The one place that decides which pipeline a stage belongs to. Every caller
 #: that needs the split reads it from here, so the two totals cannot drift into
 #: each other through a second, disagreeing copy.
@@ -565,8 +582,23 @@ class ReceiptComponent:
     usage: dict[str, int | None]
     missing_reasons: tuple[str, ...] = ()
 
+    @property
+    def name(self) -> str:
+        """A single word for this line, for readers that show one label.
+
+        The pair ``(stage, retry_kind)`` is the honest shape — a retry belongs
+        to the stage that retried — but a breakdown with a column per line
+        needs one name, and deriving it here means every reader derives the
+        same one. First work carries its stage's name; anything that had to be
+        done again is :data:`COMPONENT_RETRY`, because "how much did retrying
+        cost" is the question a reader actually asks. Which stage a retry
+        belonged to is not lost: both fields travel beside this one.
+        """
+        return self.stage if self.retry_kind == RETRY_NONE else COMPONENT_RETRY
+
     def as_dict(self) -> dict[str, Any]:
         return {
+            "name": self.name,
             "stage": self.stage,
             "retry_kind": self.retry_kind,
             "status": self.status,

--- a/batch-runner/core/cost_receipts.py
+++ b/batch-runner/core/cost_receipts.py
@@ -1,0 +1,1540 @@
+"""What each task actually cost, kept as two receipts that never add up.
+
+The pre-run ceiling in :mod:`core.execution_envelope_cost` answers *how large
+could the bill be*. This module answers a different question — *what did this
+one task actually cost* — and it answers it twice per task, because solving a
+problem and marking the answer are two separate pipelines with two separate
+approvals, and a number that mixes them is worse than no number at all.
+
+Three rules run through everything here.
+
+**Zero is a measurement, not a default.** A missing usage block does not mean a
+call was free; it means nobody can say what it cost. The honest output is
+``partial`` with the confirmed part in ``known_cost_usd``, and
+``estimated_cost_usd`` left as ``None``. The only real ``$0`` is a path that
+never contacted a provider at all.
+
+**A price has to match exactly.** A model is priced when the committed table
+holds its ``provider:resolved_model`` key and not otherwise. No prefix match, no
+nearest neighbour, no falling back to the family's flagship. An unpriced call is
+recorded as unpriced.
+
+**Nothing is ever removed.** A call that happened stays in the ledger even after
+its output is thrown away and regenerated, even after a resumed round replaces
+the answer, even after shards are merged. The cost of a run is what was spent,
+not what survived.
+
+Nothing in this module contacts a provider or spends anything.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+RECEIPT_SCHEMA_VERSION = "cost-receipt-v1"
+PRICE_TABLE_SCHEMA_VERSION = "cost-receipt-price-table-v1"
+
+PRICE_TABLE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "experiments"
+    / "execution_envelope"
+    / "model_price_table.json"
+)
+
+TOKENS_PER_MILLION = Decimal(1_000_000)
+
+#: Published amounts are rounded here. Eight places matches the precision the
+#: rest of the pipeline already persists for conservative cost figures, and is
+#: far below the smallest amount any single call can cost.
+MONEY_PLACES = Decimal("0.00000001")
+
+
+# ── The vocabulary the two sessions share ────────────────────────────────
+
+STAGE_PREPROCESSING = "preprocessing"
+STAGE_GENERATION = "generation"
+STAGE_SELF_QA = "self_qa"
+STAGE_GRADING = "grading"
+STAGE_PERCEPTION = "perception"
+
+STAGES = (
+    STAGE_PREPROCESSING,
+    STAGE_GENERATION,
+    STAGE_SELF_QA,
+    STAGE_GRADING,
+    STAGE_PERCEPTION,
+)
+
+RETRY_NONE = "none"
+RETRY_SEMANTIC = "semantic"
+RETRY_INFRASTRUCTURE = "infrastructure"
+RETRY_RESUME = "resume"
+RETRY_INTERNAL_RECOVERY = "internal_recovery"
+
+RETRY_KINDS = (
+    RETRY_NONE,
+    RETRY_SEMANTIC,
+    RETRY_INFRASTRUCTURE,
+    RETRY_RESUME,
+    RETRY_INTERNAL_RECOVERY,
+)
+
+BUCKET_PROBLEM_SOLVING = "problem_solving_cost"
+BUCKET_GRADING = "grading_cost"
+
+BUCKETS = (BUCKET_PROBLEM_SOLVING, BUCKET_GRADING)
+
+#: The one place that decides which pipeline a stage belongs to. Every caller
+#: that needs the split reads it from here, so the two totals cannot drift into
+#: each other through a second, disagreeing copy.
+STAGE_BUCKET: dict[str, str] = {
+    STAGE_PREPROCESSING: BUCKET_PROBLEM_SOLVING,
+    STAGE_GENERATION: BUCKET_PROBLEM_SOLVING,
+    STAGE_SELF_QA: BUCKET_PROBLEM_SOLVING,
+    STAGE_GRADING: BUCKET_GRADING,
+    STAGE_PERCEPTION: BUCKET_GRADING,
+}
+
+STATUS_COMPLETE = "complete"
+STATUS_PARTIAL = "partial"
+STATUS_UNAVAILABLE = "unavailable"
+STATUS_NOT_RUN = "not_run"
+
+STATUSES = (
+    STATUS_COMPLETE,
+    STATUS_PARTIAL,
+    STATUS_UNAVAILABLE,
+    STATUS_NOT_RUN,
+)
+
+REASON_USAGE_ABSENT = "usage_absent"
+REASON_USAGE_PARTIAL = "usage_partial"
+REASON_PRICE_MISSING = "price_missing"
+REASON_CALL_REACHABILITY_UNKNOWN = "call_reachability_unknown"
+REASON_RUNTIME_UNATTRIBUTABLE = "runtime_cost_unattributable"
+REASON_RUNTIME_UNPRICED = "runtime_cost_unpriced"
+REASON_LEDGER_ABSENT = "ledger_absent"
+REASON_STAGE_UNSUPPORTED = "stage_unsupported"
+
+MISSING_REASONS = (
+    REASON_USAGE_ABSENT,
+    REASON_USAGE_PARTIAL,
+    REASON_PRICE_MISSING,
+    REASON_CALL_REACHABILITY_UNKNOWN,
+    REASON_RUNTIME_UNATTRIBUTABLE,
+    REASON_RUNTIME_UNPRICED,
+    REASON_LEDGER_ABSENT,
+    REASON_STAGE_UNSUPPORTED,
+)
+
+STATE_RESERVED = "reserved"
+STATE_SETTLED = "settled"
+STATE_ABANDONED = "abandoned"
+
+ATTRIBUTION_PER_TASK = "per_task"
+ATTRIBUTION_SHARED = "shared"
+
+REASONING_BILLED_AS_OUTPUT = "output"
+REASONING_BILLED_SEPARATELY = "separate"
+REASONING_BILLED_UNKNOWN = "unknown"
+
+
+class LedgerIntegrityError(RuntimeError):
+    """The ledger was asked to contradict something it already recorded.
+
+    Raised rather than resolved. A second settlement that disagrees with the
+    first is not a race to be smoothed over — it means two different beliefs
+    exist about what one call cost, and only a person can say which is right.
+    """
+
+
+# ── The committed price list ─────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ModelReceiptPrice:
+    """What one provider's one model costs, per million tokens.
+
+    ``reasoning_billed_as`` is the field that stops the same tokens being
+    charged twice. Where a provider counts its own reasoning inside the output
+    it reports, those tokens are already paid for by ``output_usd_per_million``
+    and must not be multiplied again; where it bills them separately they must.
+    Where nobody has established which, the call cannot be priced.
+    """
+
+    provider: str
+    model: str
+    input_usd_per_million: Decimal
+    cached_input_usd_per_million: Decimal
+    output_usd_per_million: Decimal
+    reasoning_billed_as: str
+    reasoning_usd_per_million: Decimal | None
+    source: str
+    last_reviewed: str
+    currency: str
+    unit: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.provider}:{self.model}"
+
+
+@dataclass(frozen=True)
+class RuntimePrice:
+    """What a paid execution environment costs, and whether it can be attributed.
+
+    ``attribution`` is the whole point. A container started for one task can be
+    billed to that task. A pool shared by many cannot be divided among them
+    without inventing a division, so it is not divided — see
+    :meth:`CostReceiptLedger.record_runtime_cost`.
+    """
+
+    kind: str
+    usd_per_hour: Decimal
+    attribution: str
+    source: str
+    last_reviewed: str
+    currency: str
+
+
+@dataclass(frozen=True)
+class ReceiptPriceTable:
+    """The committed prices, plus the fingerprint of the file they came from."""
+
+    models: Mapping[str, ModelReceiptPrice]
+    runtimes: Mapping[str, RuntimePrice]
+    sha256: str
+    currency: str
+
+    def lookup(self, provider: str, model: str) -> ModelReceiptPrice | None:
+        """Find a price by exact ``provider:model``, or return ``None``.
+
+        Deliberately not forgiving. ``None`` here becomes ``price_missing`` in
+        the receipt, which is a smaller problem than a number computed from the
+        wrong model's rates.
+        """
+        if not provider or not model:
+            return None
+        return self.models.get(f"{provider}:{model}")
+
+    def runtime(self, kind: str) -> RuntimePrice | None:
+        if not kind:
+            return None
+        return self.runtimes.get(kind)
+
+
+def _decimal(value: Any, *, field_name: str) -> Decimal:
+    try:
+        parsed = Decimal(str(value))
+    except Exception as exc:  # noqa: BLE001 - re-raised with a readable message
+        raise ValueError(f"{field_name} is not a number: {value!r}") from exc
+    if not parsed.is_finite() or parsed < 0:
+        raise ValueError(f"{field_name} must be a finite amount of at least zero")
+    return parsed
+
+
+def load_receipt_price_table(
+    path: str | Path | None = None,
+) -> ReceiptPriceTable:
+    """Read the committed receipt prices and fingerprint the file they are in.
+
+    The fingerprint covers the whole file, not just the block read here, so a
+    receipt that records it can be checked against the exact bytes that priced
+    it. The pre-run ceiling's own ``models`` block lives in the same file and is
+    left untouched; this reader ignores it.
+    """
+    target = Path(path) if path is not None else PRICE_TABLE_PATH
+    if not target.is_file():
+        raise ValueError(f"the price list is missing at {target}")
+    raw_bytes = target.read_bytes()
+    digest = hashlib.sha256(raw_bytes).hexdigest()
+    try:
+        document = json.loads(raw_bytes)
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"the price list at {target} is not valid JSON") from exc
+    if not isinstance(document, Mapping):
+        raise ValueError("the price list must be a block of settings")
+    version = document.get("cost_receipt_schema_version")
+    if version != PRICE_TABLE_SCHEMA_VERSION:
+        raise ValueError(
+            "the receipt price list was written for "
+            f"{version!r}, but this code reads {PRICE_TABLE_SCHEMA_VERSION!r}"
+        )
+
+    models: dict[str, ModelReceiptPrice] = {}
+    for key, entry in dict(document.get("providers") or {}).items():
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"the price entry for {key} is not a block")
+        if ":" not in str(key):
+            raise ValueError(
+                f"the price key {key!r} must name a provider and a model, "
+                "written as provider:model"
+            )
+        provider, _, model = str(key).partition(":")
+        if not provider or not model:
+            raise ValueError(
+                f"the price key {key!r} must name both a provider and a model"
+            )
+        for required in ("source", "last_reviewed"):
+            if not str(entry.get(required) or "").strip():
+                raise ValueError(
+                    f"the price entry for {key} has no {required}; a price "
+                    "nobody can trace is not a price"
+                )
+        if entry.get("currency") != "USD":
+            raise ValueError(f"the price entry for {key} must be in USD")
+        billed_as = str(entry.get("reasoning_billed_as") or "")
+        if billed_as not in (
+            REASONING_BILLED_AS_OUTPUT,
+            REASONING_BILLED_SEPARATELY,
+            REASONING_BILLED_UNKNOWN,
+        ):
+            raise ValueError(
+                f"the price entry for {key} does not say how reasoning tokens "
+                "are billed; it must be one of output, separate, unknown"
+            )
+        reasoning_rate: Decimal | None = None
+        if billed_as == REASONING_BILLED_SEPARATELY:
+            if "reasoning_usd_per_million" not in entry:
+                raise ValueError(
+                    f"the price entry for {key} bills reasoning separately but "
+                    "states no rate for it"
+                )
+            reasoning_rate = _decimal(
+                entry["reasoning_usd_per_million"],
+                field_name=f"{key}.reasoning_usd_per_million",
+            )
+        models[str(key)] = ModelReceiptPrice(
+            provider=provider,
+            model=model,
+            input_usd_per_million=_decimal(
+                entry["input_usd_per_million"],
+                field_name=f"{key}.input_usd_per_million",
+            ),
+            cached_input_usd_per_million=_decimal(
+                entry["cached_input_usd_per_million"],
+                field_name=f"{key}.cached_input_usd_per_million",
+            ),
+            output_usd_per_million=_decimal(
+                entry["output_usd_per_million"],
+                field_name=f"{key}.output_usd_per_million",
+            ),
+            reasoning_billed_as=billed_as,
+            reasoning_usd_per_million=reasoning_rate,
+            source=str(entry["source"]),
+            last_reviewed=str(entry["last_reviewed"]),
+            currency="USD",
+            unit=str(entry.get("unit") or "per 1,000,000 tokens"),
+        )
+
+    runtimes: dict[str, RuntimePrice] = {}
+    for kind, entry in dict(document.get("runtime") or {}).items():
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"the runtime price entry for {kind} is not a block")
+        attribution = str(entry.get("attribution") or "")
+        if attribution not in (ATTRIBUTION_PER_TASK, ATTRIBUTION_SHARED):
+            raise ValueError(
+                f"the runtime price entry for {kind} must say whether it is "
+                "per_task or shared"
+            )
+        for required in ("source", "last_reviewed"):
+            if not str(entry.get(required) or "").strip():
+                raise ValueError(
+                    f"the runtime price entry for {kind} has no {required}"
+                )
+        if entry.get("currency") != "USD":
+            raise ValueError(f"the runtime price entry for {kind} must be in USD")
+        runtimes[str(kind)] = RuntimePrice(
+            kind=str(kind),
+            usd_per_hour=_decimal(
+                entry["usd_per_hour"], field_name=f"{kind}.usd_per_hour"
+            ),
+            attribution=attribution,
+            source=str(entry["source"]),
+            last_reviewed=str(entry["last_reviewed"]),
+            currency="USD",
+        )
+
+    return ReceiptPriceTable(
+        models=models, runtimes=runtimes, sha256=digest, currency="USD"
+    )
+
+
+# ── What one call reports back ───────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CallUsage:
+    """How much one call sent and wrote back, as the provider reported it.
+
+    Every field may be ``None``, and ``None`` never becomes ``0``. A provider
+    that returns no usage block has told us nothing, and nothing is not zero.
+
+    ``cached_input_tokens`` is understood the way providers report it: as a
+    part of ``input_tokens``, not an addition to it. The billable input is
+    therefore the difference, which is what :func:`price_call` charges.
+    """
+
+    input_tokens: int | None = None
+    cached_input_tokens: int | None = None
+    output_tokens: int | None = None
+    reasoning_tokens: int | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        return (
+            self.input_tokens is None
+            and self.output_tokens is None
+            and self.cached_input_tokens is None
+            and self.reasoning_tokens is None
+        )
+
+    def as_dict(self) -> dict[str, int | None]:
+        return {
+            "input_tokens": self.input_tokens,
+            "cached_input_tokens": self.cached_input_tokens,
+            "output_tokens": self.output_tokens,
+            "reasoning_tokens": self.reasoning_tokens,
+        }
+
+
+@dataclass(frozen=True)
+class PricedCall:
+    """The result of trying to put a number on one call."""
+
+    cost_usd: Decimal | None
+    missing_reasons: tuple[str, ...]
+
+    @property
+    def is_priced(self) -> bool:
+        return self.cost_usd is not None and not self.missing_reasons
+
+
+def price_call(
+    price: ModelReceiptPrice | None, usage: CallUsage
+) -> PricedCall:
+    """Charge one call, or say why it cannot be charged.
+
+    The two traps this exists to avoid:
+
+    *Cached input counted twice.* Providers report ``input_tokens`` inclusive of
+    whatever they served from cache. Charging the full input at the full rate
+    and then charging the cached part again at the cache rate bills the same
+    tokens twice. Only the difference is charged at full rate.
+
+    *Reasoning counted twice.* Where reasoning tokens are already inside the
+    reported output, charging them again on top double-bills the model's
+    thinking. The price entry says which it is, and where it says ``unknown``
+    and reasoning actually happened, the call is left unpriced rather than
+    guessed.
+    """
+    reasons: list[str] = []
+    if usage.is_empty:
+        reasons.append(REASON_USAGE_ABSENT)
+    elif usage.input_tokens is None or usage.output_tokens is None:
+        reasons.append(REASON_USAGE_PARTIAL)
+
+    cached = usage.cached_input_tokens or 0
+    if usage.input_tokens is not None and cached > usage.input_tokens:
+        # More was served from cache than was sent. One of the two numbers is
+        # wrong and there is no way to tell which, so neither is trusted.
+        if REASON_USAGE_PARTIAL not in reasons:
+            reasons.append(REASON_USAGE_PARTIAL)
+
+    if price is None:
+        reasons.append(REASON_PRICE_MISSING)
+
+    reasoning = usage.reasoning_tokens or 0
+    if (
+        price is not None
+        and reasoning > 0
+        and price.reasoning_billed_as == REASONING_BILLED_UNKNOWN
+    ):
+        if REASON_USAGE_PARTIAL not in reasons:
+            reasons.append(REASON_USAGE_PARTIAL)
+
+    if reasons:
+        return PricedCall(cost_usd=None, missing_reasons=tuple(reasons))
+
+    assert price is not None  # narrowed by the checks above
+    billable_input = Decimal(max((usage.input_tokens or 0) - cached, 0))
+    cost = (
+        billable_input * price.input_usd_per_million
+        + Decimal(cached) * price.cached_input_usd_per_million
+        + Decimal(usage.output_tokens or 0) * price.output_usd_per_million
+    )
+    if (
+        price.reasoning_billed_as == REASONING_BILLED_SEPARATELY
+        and price.reasoning_usd_per_million is not None
+    ):
+        cost += Decimal(reasoning) * price.reasoning_usd_per_million
+    return PricedCall(cost_usd=cost / TOKENS_PER_MILLION, missing_reasons=())
+
+
+def make_call_id(
+    *,
+    run_id: str,
+    task_id: str,
+    stage: str,
+    retry_kind: str,
+    attempt_index: int,
+    sequence: int,
+) -> str:
+    """A name for one call that two processes will agree on without talking.
+
+    Derived only from where the call sits in the run, never from what it says.
+    That keeps prompts out of the ledger and makes a merged shard's rows line up
+    with the originals, so the same call cannot be counted twice under two
+    different names.
+    """
+    material = "|".join(
+        (
+            str(run_id),
+            str(task_id),
+            str(stage),
+            str(retry_kind),
+            str(int(attempt_index)),
+            str(int(sequence)),
+        )
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+# ── The receipt ──────────────────────────────────────────────────────────
+
+
+def _money(value: Decimal) -> float:
+    return float(value.quantize(MONEY_PLACES, rounding=ROUND_HALF_UP))
+
+
+def _read_count(value: Any) -> int:
+    """A call count read back off a published receipt; nonsense reads as zero.
+
+    Unlike an amount, a bad count cannot make a receipt overstate what is
+    known — the money fields are checked separately — so this one degrades
+    quietly rather than voiding the receipt.
+    """
+    if value is None or isinstance(value, bool):
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return parsed if parsed >= 0 else 0
+
+
+def _read_money(value: Any) -> Decimal | None:
+    """Take an amount back off a published receipt, or say it is not one.
+
+    The round trip goes through JSON, so what comes back is a float. It is
+    turned into a :class:`~decimal.Decimal` by way of its shortest decimal
+    spelling rather than its binary expansion, so that ``0.1`` written out
+    reads back as ``0.1`` and a column of them still adds up.
+
+    An absent amount reads as zero; an amount that is present but is not a
+    number returns ``None``, and the caller turns that into an unavailable
+    receipt. The distinction matters: a corrupt figure quietly read as ``0``
+    would leave a ``complete`` receipt claiming the work was free.
+    """
+    if value is None:
+        return Decimal(0)
+    try:
+        parsed = Decimal(str(value))
+    except Exception:  # noqa: BLE001 - a corrupt amount is not a real amount
+        return None
+    if not parsed.is_finite() or parsed < 0:
+        return None
+    return parsed
+
+
+@dataclass(frozen=True)
+class ReceiptComponent:
+    """One line of a receipt: what one stage, at one retry kind, cost."""
+
+    stage: str
+    retry_kind: str
+    status: str
+    model_calls: int
+    known_cost_usd: Decimal
+    usage: dict[str, int | None]
+    missing_reasons: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage,
+            "retry_kind": self.retry_kind,
+            "status": self.status,
+            "model_calls": self.model_calls,
+            "known_cost_usd": _money(self.known_cost_usd),
+            "usage": dict(self.usage),
+            "missing_reasons": list(self.missing_reasons),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ReceiptComponent":
+        known = _read_money(payload.get("known_cost_usd"))
+        return cls(
+            stage=str(payload.get("stage") or ""),
+            retry_kind=str(payload.get("retry_kind") or RETRY_NONE),
+            status=(
+                str(payload.get("status") or STATUS_UNAVAILABLE)
+                if known is not None
+                else STATUS_UNAVAILABLE
+            ),
+            model_calls=_read_count(payload.get("model_calls")),
+            known_cost_usd=known if known is not None else Decimal(0),
+            usage=dict(payload.get("usage") or {}),
+            missing_reasons=tuple(sorted(_decode_reasons(
+                payload.get("missing_reasons")
+            ))),
+        )
+
+
+@dataclass(frozen=True)
+class CostReceipt:
+    """What one pipeline cost for one task — or why that cannot be said.
+
+    ``estimated_cost_usd`` is the only field that claims to be a total, and it
+    is populated only when :data:`STATUS_COMPLETE` holds. ``known_cost_usd`` is
+    always the sum of what was confirmed, which on a partial receipt is a floor
+    and must never be displayed as a total.
+    """
+
+    status: str
+    currency: str = "USD"
+    known_cost_usd: Decimal = Decimal(0)
+    model_cost_usd: Decimal = Decimal(0)
+    runtime_cost_usd: Decimal = Decimal(0)
+    model_calls: int = 0
+    usage: dict[str, int | None] = field(default_factory=dict)
+    components: tuple[ReceiptComponent, ...] = ()
+    price_table_sha256: str | None = None
+    missing_reasons: tuple[str, ...] = ()
+
+    @property
+    def estimated_cost_usd(self) -> Decimal | None:
+        if self.status != STATUS_COMPLETE:
+            return None
+        return self.known_cost_usd
+
+    def as_dict(self) -> dict[str, Any]:
+        estimated = self.estimated_cost_usd
+        return {
+            "schema_version": RECEIPT_SCHEMA_VERSION,
+            "status": self.status,
+            "currency": self.currency,
+            "estimated_cost_usd": None if estimated is None else _money(estimated),
+            "known_cost_usd": _money(self.known_cost_usd),
+            "model_cost_usd": _money(self.model_cost_usd),
+            "runtime_cost_usd": _money(self.runtime_cost_usd),
+            "model_calls": self.model_calls,
+            "usage": dict(self.usage),
+            "components": [entry.as_dict() for entry in self.components],
+            "price_table_sha256": self.price_table_sha256,
+            "missing_reasons": list(self.missing_reasons),
+        }
+
+    @classmethod
+    def not_run(cls) -> "CostReceipt":
+        """This pipeline did not run. Not free — it did not happen."""
+        return cls(status=STATUS_NOT_RUN)
+
+    @classmethod
+    def unavailable(
+        cls, *, reasons: Sequence[str] = (REASON_LEDGER_ABSENT,)
+    ) -> "CostReceipt":
+        """It ran, but this run kept no record that could price it."""
+        return cls(status=STATUS_UNAVAILABLE, missing_reasons=tuple(reasons))
+
+    @classmethod
+    def free(cls, *, price_table_sha256: str | None = None) -> "CostReceipt":
+        """It ran, made no model call at all, and therefore really cost nothing.
+
+        The one honest ``$0``. Reserved for paths that reach a verdict by rule
+        rather than by asking a model.
+        """
+        return cls(
+            status=STATUS_COMPLETE,
+            price_table_sha256=price_table_sha256,
+        )
+
+    @classmethod
+    def from_dict(cls, payload: Any) -> "CostReceipt":
+        """Read a published receipt back, for summing rows that are already out.
+
+        Needed wherever the totals must come from what was *published* rather
+        than from a live ledger: a resumed grading run whose earlier tasks were
+        written by an earlier process, and shard merging, where the shards' own
+        ledgers may be long gone. Reading the rows keeps the summary equal to
+        the sum of the receipts a reader can actually see.
+
+        ``estimated_cost_usd`` is recomputed from ``status`` rather than
+        trusted, so a file that had been edited to show a total on an
+        incomplete receipt does not get to keep it. Anything that is not a
+        readable receipt of this version comes back
+        :meth:`unavailable` — a row we cannot price is not a row that cost
+        nothing.
+        """
+        if not isinstance(payload, Mapping):
+            return cls.unavailable()
+        if payload.get("schema_version") != RECEIPT_SCHEMA_VERSION:
+            return cls.unavailable()
+        status = str(payload.get("status") or "")
+        if status not in STATUSES:
+            return cls.unavailable()
+        if status == STATUS_NOT_RUN:
+            return cls.not_run()
+        known = _read_money(payload.get("known_cost_usd"))
+        model_cost = _read_money(payload.get("model_cost_usd"))
+        runtime_cost = _read_money(payload.get("runtime_cost_usd"))
+        if known is None or model_cost is None or runtime_cost is None:
+            return cls.unavailable()
+        return cls(
+            status=status,
+            currency=str(payload.get("currency") or "USD"),
+            known_cost_usd=known,
+            model_cost_usd=model_cost,
+            runtime_cost_usd=runtime_cost,
+            model_calls=_read_count(payload.get("model_calls")),
+            usage=dict(payload.get("usage") or {}),
+            components=tuple(
+                ReceiptComponent.from_dict(entry)
+                for entry in (payload.get("components") or [])
+                if isinstance(entry, Mapping)
+            ),
+            price_table_sha256=payload.get("price_table_sha256") or None,
+            missing_reasons=tuple(sorted(_decode_reasons(
+                payload.get("missing_reasons")
+            ))),
+        )
+
+
+def empty_usage() -> dict[str, int | None]:
+    return {
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "reasoning_tokens": 0,
+    }
+
+
+# ── The ledger ───────────────────────────────────────────────────────────
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS cost_calls (
+    call_id             TEXT PRIMARY KEY,
+    run_id              TEXT NOT NULL,
+    task_id             TEXT NOT NULL,
+    stage               TEXT NOT NULL,
+    retry_kind          TEXT NOT NULL,
+    provider            TEXT NOT NULL,
+    requested_model     TEXT NOT NULL,
+    resolved_model      TEXT,
+    state               TEXT NOT NULL,
+    input_tokens        INTEGER,
+    cached_input_tokens INTEGER,
+    output_tokens       INTEGER,
+    reasoning_tokens    INTEGER,
+    model_cost_usd      TEXT,
+    missing_reasons     TEXT NOT NULL DEFAULT '[]',
+    price_table_sha256  TEXT,
+    request_sha256      TEXT,
+    note                TEXT
+);
+
+CREATE TABLE IF NOT EXISTS cost_runtime (
+    entry_id            TEXT PRIMARY KEY,
+    run_id              TEXT NOT NULL,
+    task_id             TEXT NOT NULL,
+    bucket              TEXT NOT NULL,
+    runtime_kind        TEXT NOT NULL,
+    attribution         TEXT NOT NULL,
+    runtime_cost_usd    TEXT,
+    missing_reasons     TEXT NOT NULL DEFAULT '[]'
+);
+
+CREATE INDEX IF NOT EXISTS cost_calls_task ON cost_calls (task_id, stage);
+CREATE INDEX IF NOT EXISTS cost_runtime_task ON cost_runtime (task_id, bucket);
+"""
+
+_CALL_COLUMNS = (
+    "call_id",
+    "run_id",
+    "task_id",
+    "stage",
+    "retry_kind",
+    "provider",
+    "requested_model",
+    "resolved_model",
+    "state",
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_tokens",
+    "model_cost_usd",
+    "missing_reasons",
+    "price_table_sha256",
+    "request_sha256",
+    "note",
+)
+
+_RUNTIME_COLUMNS = (
+    "entry_id",
+    "run_id",
+    "task_id",
+    "bucket",
+    "runtime_kind",
+    "attribution",
+    "runtime_cost_usd",
+    "missing_reasons",
+)
+
+
+class CostReceiptLedger:
+    """An append-only record of every call that was paid for.
+
+    Two writes per call. :meth:`reserve` happens *before* the request goes out,
+    :meth:`settle` after the reply comes back. The gap between them is not
+    bookkeeping pedantry — it is the only way to notice a call that left and
+    never returned. A reservation that is never settled stays in the ledger as
+    exactly that, and turns its task's receipt ``partial`` with
+    ``call_reachability_unknown``, because a request that may have been served
+    may also have been billed.
+
+    Rows are never deleted and never silently rewritten. Settling the same call
+    twice with the same numbers is a no-op, which makes retried writes and
+    re-imported shards safe. Settling it twice with *different* numbers raises
+    :class:`LedgerIntegrityError`.
+
+    Concurrency is left to SQLite. Shards run as separate processes against the
+    same file, and a primary key on ``call_id`` is what stops the same call
+    being counted once per process.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        run_id: str,
+        price_table: ReceiptPriceTable | None = None,
+    ):
+        self.path = Path(path)
+        self.run_id = str(run_id)
+        self._price_table = price_table
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(str(self.path), timeout=30.0)
+        self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA journal_mode=WAL")
+        self._connection.execute("PRAGMA synchronous=FULL")
+        self._connection.executescript(_SCHEMA)
+        self._connection.commit()
+
+    # -- lifecycle -------------------------------------------------------
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def __enter__(self) -> "CostReceiptLedger":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.close()
+
+    @property
+    def price_table(self) -> ReceiptPriceTable | None:
+        return self._price_table
+
+    # -- writing ---------------------------------------------------------
+
+    def reserve(
+        self,
+        *,
+        call_id: str,
+        task_id: str,
+        stage: str,
+        retry_kind: str,
+        provider: str,
+        requested_model: str,
+        request_sha256: str | None = None,
+        note: str | None = None,
+    ) -> str:
+        """Record that a call is about to go out.
+
+        Written before the request, so that a crash between here and the reply
+        leaves evidence rather than silence.
+        """
+        _require(stage in STAGES, f"unknown stage {stage!r}")
+        _require(retry_kind in RETRY_KINDS, f"unknown retry kind {retry_kind!r}")
+        _require(bool(task_id), "a call must belong to a task")
+        if request_sha256 is not None:
+            _require(
+                _is_sha256(request_sha256),
+                "a request identifier may only be recorded as a SHA-256 digest",
+            )
+        existing = self._row(call_id)
+        if existing is not None:
+            # A resumed round re-reserving a call it already recorded. Keep the
+            # original row; re-reserving must never reset a settled one.
+            return call_id
+        self._connection.execute(
+            "INSERT INTO cost_calls (call_id, run_id, task_id, stage, "
+            "retry_kind, provider, requested_model, state, missing_reasons, "
+            "request_sha256, note) VALUES (?, ?, ?, ?, ?, ?, ?, ?, '[]', ?, ?)",
+            (
+                call_id,
+                self.run_id,
+                str(task_id),
+                stage,
+                retry_kind,
+                str(provider),
+                str(requested_model),
+                STATE_RESERVED,
+                request_sha256,
+                note,
+            ),
+        )
+        self._connection.commit()
+        return call_id
+
+    def settle(
+        self,
+        call_id: str,
+        *,
+        usage: CallUsage,
+        resolved_model: str | None = None,
+        extra_reasons: Sequence[str] = (),
+    ) -> PricedCall:
+        """Record what the call actually reported, and price it.
+
+        ``resolved_model`` is the model the *reply* names. Where a provider
+        answers a deployment alias with a different underlying model, the reply
+        is what gets priced, because the reply is what was billed.
+        """
+        row = self._row(call_id)
+        if row is None:
+            raise LedgerIntegrityError(
+                f"call {call_id} was settled without ever being reserved"
+            )
+        if row["state"] == STATE_ABANDONED:
+            raise LedgerIntegrityError(
+                f"call {call_id} was recorded as never sent, and cannot now "
+                "report usage"
+            )
+
+        model = str(resolved_model or row["requested_model"] or "")
+        price = None
+        table = self._price_table
+        if table is not None:
+            price = table.lookup(str(row["provider"]), model)
+        priced = price_call(price, usage)
+        reasons = list(priced.missing_reasons)
+        for reason in extra_reasons:
+            _require(reason in MISSING_REASONS, f"unknown reason {reason!r}")
+            if reason not in reasons:
+                reasons.append(reason)
+        if table is None and REASON_PRICE_MISSING not in reasons:
+            reasons.append(REASON_PRICE_MISSING)
+        cost = None if reasons else priced.cost_usd
+
+        if row["state"] == STATE_SETTLED:
+            self._require_same_settlement(row, usage, model, cost, reasons)
+            return PricedCall(cost_usd=cost, missing_reasons=tuple(reasons))
+
+        self._connection.execute(
+            "UPDATE cost_calls SET state = ?, resolved_model = ?, "
+            "input_tokens = ?, cached_input_tokens = ?, output_tokens = ?, "
+            "reasoning_tokens = ?, model_cost_usd = ?, missing_reasons = ?, "
+            "price_table_sha256 = ? WHERE call_id = ?",
+            (
+                STATE_SETTLED,
+                model,
+                usage.input_tokens,
+                usage.cached_input_tokens,
+                usage.output_tokens,
+                usage.reasoning_tokens,
+                None if cost is None else str(cost),
+                json.dumps(sorted(reasons)),
+                None if table is None else table.sha256,
+                call_id,
+            ),
+        )
+        self._connection.commit()
+        return PricedCall(cost_usd=cost, missing_reasons=tuple(reasons))
+
+    def abandon(self, call_id: str, *, note: str | None = None) -> None:
+        """Record that the call never left — so it never cost anything.
+
+        Only correct where the failure is known to precede the request: a
+        prompt that could not be assembled, a client that could not be built.
+        A timeout is *not* this; a timeout leaves the reservation standing,
+        because the request may well have been served and billed.
+        """
+        row = self._row(call_id)
+        if row is None:
+            raise LedgerIntegrityError(
+                f"call {call_id} was abandoned without ever being reserved"
+            )
+        if row["state"] == STATE_SETTLED:
+            raise LedgerIntegrityError(
+                f"call {call_id} already reported usage and cannot now be "
+                "recorded as never sent"
+            )
+        self._connection.execute(
+            "UPDATE cost_calls SET state = ?, note = COALESCE(?, note) "
+            "WHERE call_id = ?",
+            (STATE_ABANDONED, note, call_id),
+        )
+        self._connection.commit()
+
+    def record_runtime_cost(
+        self,
+        *,
+        entry_id: str,
+        task_id: str,
+        bucket: str,
+        runtime_kind: str,
+        seconds: float | None = None,
+        usd: Decimal | None = None,
+    ) -> None:
+        """Record a paid execution environment against one task, if it can be.
+
+        A shared environment is recorded but **not** costed. Splitting a pool's
+        bill across the tasks that happened to use it produces a number that
+        looks like measurement and is not one, so the entry carries
+        ``runtime_cost_unattributable`` instead and holds the task's receipt at
+        ``partial``. Under-claiming is recoverable; a fabricated split is not.
+        """
+        _require(bucket in BUCKETS, f"unknown bucket {bucket!r}")
+        reasons: list[str] = []
+        amount: Decimal | None = None
+        price = (
+            self._price_table.runtime(runtime_kind)
+            if self._price_table is not None
+            else None
+        )
+        if usd is not None:
+            amount = Decimal(str(usd))
+        elif price is None:
+            reasons.append(REASON_RUNTIME_UNPRICED)
+        elif price.attribution == ATTRIBUTION_SHARED:
+            reasons.append(REASON_RUNTIME_UNATTRIBUTABLE)
+        elif seconds is None:
+            reasons.append(REASON_RUNTIME_UNPRICED)
+        else:
+            amount = (
+                price.usd_per_hour * Decimal(str(seconds)) / Decimal(3600)
+            )
+        if price is not None and price.attribution == ATTRIBUTION_SHARED:
+            amount = None
+            if REASON_RUNTIME_UNATTRIBUTABLE not in reasons:
+                reasons.append(REASON_RUNTIME_UNATTRIBUTABLE)
+        self._connection.execute(
+            "INSERT OR REPLACE INTO cost_runtime (entry_id, run_id, task_id, "
+            "bucket, runtime_kind, attribution, runtime_cost_usd, "
+            "missing_reasons) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(entry_id),
+                self.run_id,
+                str(task_id),
+                bucket,
+                str(runtime_kind),
+                price.attribution if price is not None else "unknown",
+                None if amount is None else str(amount),
+                json.dumps(sorted(reasons)),
+            ),
+        )
+        self._connection.commit()
+
+    # -- reading ---------------------------------------------------------
+
+    def call_count(self) -> int:
+        """How many calls this ledger already holds.
+
+        A resumed run reads this to number its round. Identifiers are derived
+        from position, so a task that was being graded when the previous
+        process died would otherwise be re-graded under exactly the same
+        identifiers — and settling one of those a second time, with the second
+        attempt's token counts, is a contradiction the ledger refuses. Starting
+        the new round at the current row count separates them, and it is
+        monotonic for the only reason that matters: a round can only repeat a
+        count it has already written past.
+        """
+        row = self._connection.execute(
+            "SELECT COUNT(*) AS n FROM cost_calls"
+        ).fetchone()
+        return int(row["n"]) if row is not None else 0
+
+    def task_ids(self) -> list[str]:
+        rows = self._connection.execute(
+            "SELECT DISTINCT task_id FROM cost_calls "
+            "UNION SELECT DISTINCT task_id FROM cost_runtime"
+        ).fetchall()
+        return sorted(str(row["task_id"]) for row in rows)
+
+    def calls_for(self, task_id: str, *, bucket: str | None = None) -> list[dict]:
+        rows = self._connection.execute(
+            "SELECT * FROM cost_calls WHERE task_id = ? ORDER BY call_id",
+            (str(task_id),),
+        ).fetchall()
+        out = []
+        for row in rows:
+            if bucket is not None and STAGE_BUCKET.get(row["stage"]) != bucket:
+                continue
+            out.append(_row_to_dict(row, _CALL_COLUMNS))
+        return out
+
+    def receipt_for(
+        self,
+        task_id: str,
+        bucket: str,
+        *,
+        when_empty: str = STATUS_NOT_RUN,
+    ) -> CostReceipt:
+        """Build one task's receipt for one pipeline.
+
+        ``when_empty`` settles what silence means, because the ledger cannot
+        tell on its own. No rows may mean the pipeline never ran
+        (:data:`STATUS_NOT_RUN`), or ran by rule without calling a model
+        (:data:`STATUS_COMPLETE`, a real ``$0``), or ran on a build that kept no
+        record (:data:`STATUS_UNAVAILABLE`). Those are three different sentences
+        and the caller knows which one applies.
+        """
+        _require(bucket in BUCKETS, f"unknown bucket {bucket!r}")
+        _require(
+            when_empty in (STATUS_NOT_RUN, STATUS_COMPLETE, STATUS_UNAVAILABLE),
+            f"unknown empty meaning {when_empty!r}",
+        )
+        calls = self.calls_for(task_id, bucket=bucket)
+        runtime_rows = [
+            _row_to_dict(row, _RUNTIME_COLUMNS)
+            for row in self._connection.execute(
+                "SELECT * FROM cost_runtime WHERE task_id = ? AND bucket = ? "
+                "ORDER BY entry_id",
+                (str(task_id), bucket),
+            ).fetchall()
+        ]
+        if not calls and not runtime_rows:
+            if when_empty == STATUS_NOT_RUN:
+                return CostReceipt.not_run()
+            if when_empty == STATUS_UNAVAILABLE:
+                return CostReceipt.unavailable()
+            return CostReceipt.free(
+                price_table_sha256=(
+                    self._price_table.sha256
+                    if self._price_table is not None
+                    else None
+                )
+            )
+        return build_receipt(
+            calls,
+            runtime_rows,
+            price_table_sha256=(
+                self._price_table.sha256 if self._price_table is not None else None
+            ),
+        )
+
+    # -- exchange --------------------------------------------------------
+
+    def export_jsonl(self, path: str | Path) -> str:
+        """Write the ledger out as one line per record, and return its digest.
+
+        Deterministic: fixed key order, rows sorted by identifier. Two exports
+        of the same ledger produce byte-identical files, which is what lets the
+        digest published beside a result mean anything.
+        """
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        lines: list[str] = []
+        for row in self._connection.execute(
+            "SELECT * FROM cost_calls ORDER BY call_id"
+        ).fetchall():
+            record = _row_to_dict(row, _CALL_COLUMNS)
+            record["record_type"] = "call"
+            lines.append(_canonical_json(record))
+        for row in self._connection.execute(
+            "SELECT * FROM cost_runtime ORDER BY entry_id"
+        ).fetchall():
+            record = _row_to_dict(row, _RUNTIME_COLUMNS)
+            record["record_type"] = "runtime"
+            lines.append(_canonical_json(record))
+        payload = "".join(line + "\n" for line in lines)
+        target.write_text(payload, encoding="utf-8")
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def import_jsonl(self, path: str | Path) -> int:
+        """Fold another ledger's records in, and return how many were new.
+
+        Used by a resumed round reading its predecessor and by shard merging.
+        Identifiers are derived from position rather than content, so a record
+        that arrives twice is recognised as the same record and counted once.
+        A record that arrives twice with different numbers is a contradiction
+        and raises rather than overwriting.
+        """
+        target = Path(path)
+        if not target.is_file():
+            raise ValueError(f"there is no ledger export at {target}")
+        added = 0
+        for line in target.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            kind = record.pop("record_type", "call")
+            if kind == "runtime":
+                added += self._import_runtime(record)
+            else:
+                added += self._import_call(record)
+        self._connection.commit()
+        return added
+
+    def _import_call(self, record: Mapping[str, Any]) -> int:
+        call_id = str(record.get("call_id") or "")
+        _require(bool(call_id), "an imported call has no identifier")
+        existing = self._row(call_id)
+        if existing is not None:
+            _require_agreement(existing, record)
+            if existing["state"] == STATE_RESERVED and str(
+                record.get("state") or ""
+            ) in (STATE_SETTLED, STATE_ABANDONED):
+                # We only knew the request had gone out; the arriving export
+                # knows how it ended. Taking the outcome resolves a doubt
+                # rather than overwriting a figure, and it is the difference
+                # between a receipt that stays partial forever and one that
+                # closes. The reverse direction is not allowed: a settled row
+                # is never demoted back to an open question.
+                self._connection.execute(
+                    "UPDATE cost_calls SET {assignments} WHERE call_id = ?".format(
+                        assignments=", ".join(
+                            f"{column} = ?"
+                            for column in _CALL_COLUMNS
+                            if column != "call_id"
+                        )
+                    ),
+                    tuple(
+                        _import_value(record, column)
+                        for column in _CALL_COLUMNS
+                        if column != "call_id"
+                    )
+                    + (call_id,),
+                )
+            return 0
+        self._connection.execute(
+            "INSERT INTO cost_calls ({columns}) VALUES ({slots})".format(
+                columns=", ".join(_CALL_COLUMNS),
+                slots=", ".join("?" for _ in _CALL_COLUMNS),
+            ),
+            tuple(_import_value(record, column) for column in _CALL_COLUMNS),
+        )
+        return 1
+
+    def _import_runtime(self, record: Mapping[str, Any]) -> int:
+        entry_id = str(record.get("entry_id") or "")
+        _require(bool(entry_id), "an imported runtime entry has no identifier")
+        existing = self._connection.execute(
+            "SELECT * FROM cost_runtime WHERE entry_id = ?", (entry_id,)
+        ).fetchone()
+        if existing is not None:
+            return 0
+        self._connection.execute(
+            "INSERT INTO cost_runtime ({columns}) VALUES ({slots})".format(
+                columns=", ".join(_RUNTIME_COLUMNS),
+                slots=", ".join("?" for _ in _RUNTIME_COLUMNS),
+            ),
+            tuple(_import_value(record, column) for column in _RUNTIME_COLUMNS),
+        )
+        return 1
+
+    # -- internals -------------------------------------------------------
+
+    def _row(self, call_id: str) -> sqlite3.Row | None:
+        return self._connection.execute(
+            "SELECT * FROM cost_calls WHERE call_id = ?", (str(call_id),)
+        ).fetchone()
+
+    @staticmethod
+    def _require_same_settlement(
+        row: sqlite3.Row,
+        usage: CallUsage,
+        model: str,
+        cost: Decimal | None,
+        reasons: Sequence[str],
+    ) -> None:
+        recorded = (
+            row["input_tokens"],
+            row["cached_input_tokens"],
+            row["output_tokens"],
+            row["reasoning_tokens"],
+            str(row["resolved_model"] or ""),
+            row["model_cost_usd"],
+            row["missing_reasons"],
+        )
+        incoming = (
+            usage.input_tokens,
+            usage.cached_input_tokens,
+            usage.output_tokens,
+            usage.reasoning_tokens,
+            model,
+            None if cost is None else str(cost),
+            json.dumps(sorted(reasons)),
+        )
+        if recorded != incoming:
+            raise LedgerIntegrityError(
+                f"call {row['call_id']} was already settled with different "
+                "usage; the ledger will not overwrite a recorded cost"
+            )
+
+
+def verify_export(path: str | Path, expected_sha256: str) -> bool:
+    """Check an exported ledger against the digest published beside it."""
+    target = Path(path)
+    if not target.is_file():
+        return False
+    actual = hashlib.sha256(target.read_bytes()).hexdigest()
+    return actual == str(expected_sha256).lower()
+
+
+# ── Building receipts out of rows ────────────────────────────────────────
+
+
+def build_receipt(
+    calls: Iterable[Mapping[str, Any]],
+    runtime_rows: Iterable[Mapping[str, Any]] = (),
+    *,
+    price_table_sha256: str | None = None,
+) -> CostReceipt:
+    """Add up rows into one receipt, keeping every doubt visible.
+
+    Abandoned calls contribute nothing and cost nothing — they never went out.
+    Reserved-but-unsettled calls contribute nothing but *do* cost the receipt
+    its ``complete`` status, because whether they were billed is unknown.
+    """
+    per_component: dict[tuple[str, str], dict[str, Any]] = {}
+    reasons: set[str] = set()
+    model_cost = Decimal(0)
+    model_calls = 0
+    totals = empty_usage()
+
+    for call in calls:
+        state = str(call.get("state") or "")
+        if state == STATE_ABANDONED:
+            continue
+        stage = str(call.get("stage") or "")
+        retry_kind = str(call.get("retry_kind") or RETRY_NONE)
+        key = (stage, retry_kind)
+        bucket = per_component.setdefault(
+            key,
+            {
+                "model_calls": 0,
+                "known_cost_usd": Decimal(0),
+                "usage": empty_usage(),
+                "reasons": set(),
+            },
+        )
+        model_calls += 1
+        bucket["model_calls"] += 1
+
+        if state == STATE_RESERVED:
+            reasons.add(REASON_CALL_REACHABILITY_UNKNOWN)
+            bucket["reasons"].add(REASON_CALL_REACHABILITY_UNKNOWN)
+            continue
+
+        row_reasons = _decode_reasons(call.get("missing_reasons"))
+        reasons.update(row_reasons)
+        bucket["reasons"].update(row_reasons)
+
+        raw_cost = call.get("model_cost_usd")
+        if raw_cost is not None:
+            amount = Decimal(str(raw_cost))
+            model_cost += amount
+            bucket["known_cost_usd"] += amount
+
+        for name in totals:
+            value = call.get(name)
+            if value is None:
+                # Absent is not zero, but it is also not automatically a gap.
+                # Whether this call could be priced was already settled by
+                # :func:`price_call`, which knows that a model reporting no
+                # cached or reasoning tokens simply had none. Re-deciding it
+                # here would mark every ordinary call partial.
+                continue
+            totals[name] = (totals[name] or 0) + int(value)
+            bucket["usage"][name] = (bucket["usage"][name] or 0) + int(value)
+
+    runtime_cost = Decimal(0)
+    for entry in runtime_rows:
+        entry_reasons = _decode_reasons(entry.get("missing_reasons"))
+        reasons.update(entry_reasons)
+        raw = entry.get("runtime_cost_usd")
+        if raw is not None:
+            runtime_cost += Decimal(str(raw))
+
+    status = STATUS_PARTIAL if reasons else STATUS_COMPLETE
+    components = tuple(
+        ReceiptComponent(
+            stage=stage,
+            retry_kind=retry_kind,
+            status=STATUS_PARTIAL if data["reasons"] else STATUS_COMPLETE,
+            model_calls=data["model_calls"],
+            known_cost_usd=data["known_cost_usd"],
+            usage=data["usage"],
+            missing_reasons=tuple(sorted(data["reasons"])),
+        )
+        for (stage, retry_kind), data in sorted(per_component.items())
+    )
+    return CostReceipt(
+        status=status,
+        known_cost_usd=model_cost + runtime_cost,
+        model_cost_usd=model_cost,
+        runtime_cost_usd=runtime_cost,
+        model_calls=model_calls,
+        usage=totals,
+        components=components,
+        price_table_sha256=price_table_sha256,
+        missing_reasons=tuple(sorted(reasons)),
+    )
+
+
+def summarise_receipts(receipts: Sequence[CostReceipt]) -> CostReceipt:
+    """Roll per-task receipts into one experiment-level receipt.
+
+    A summary is ``complete`` only when every task it covers is. One task whose
+    usage went missing is enough to stop the experiment total being presented as
+    a total — which is the point, since a headline figure that quietly omits a
+    task is read as if it did not.
+
+    Where *nothing* under the summary could be priced the answer is
+    ``unavailable``, not ``partial``. The two are not the same claim: partial
+    says part of this is known and the rest is not, and its ``known_cost_usd``
+    is a real floor. A run with no record at all has no floor, and reporting one
+    of ``$0`` invites exactly the reading — "so far it has cost nothing" — that
+    the four statuses exist to prevent.
+    """
+    contributing = [
+        receipt
+        for receipt in receipts
+        if receipt.status not in (STATUS_NOT_RUN,)
+    ]
+    if not contributing:
+        return CostReceipt.not_run()
+
+    reasons: set[str] = set()
+    known = Decimal(0)
+    model_cost = Decimal(0)
+    runtime_cost = Decimal(0)
+    model_calls = 0
+    totals = empty_usage()
+    sha = None
+    for receipt in contributing:
+        reasons.update(receipt.missing_reasons)
+        known += receipt.known_cost_usd
+        model_cost += receipt.model_cost_usd
+        runtime_cost += receipt.runtime_cost_usd
+        model_calls += receipt.model_calls
+        sha = sha or receipt.price_table_sha256
+        for name in totals:
+            value = receipt.usage.get(name)
+            if value is None:
+                continue
+            totals[name] = (totals[name] or 0) + int(value)
+    return CostReceipt(
+        status=_summary_status(contributing),
+        known_cost_usd=known,
+        model_cost_usd=model_cost,
+        runtime_cost_usd=runtime_cost,
+        model_calls=model_calls,
+        usage=totals,
+        price_table_sha256=sha,
+        missing_reasons=tuple(sorted(reasons)),
+    )
+
+
+def _summary_status(contributing: Sequence[CostReceipt]) -> str:
+    if all(receipt.status == STATUS_COMPLETE for receipt in contributing):
+        return STATUS_COMPLETE
+    if all(receipt.status == STATUS_UNAVAILABLE for receipt in contributing):
+        return STATUS_UNAVAILABLE
+    return STATUS_PARTIAL
+
+
+def ledger_reference(path: str | Path, sha256: str) -> dict[str, str]:
+    """The pointer a published result carries to its own audit trail."""
+    return {"path": str(path), "sha256": str(sha256)}
+
+
+# ── Small helpers ────────────────────────────────────────────────────────
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _is_sha256(value: str) -> bool:
+    text = str(value)
+    return len(text) == 64 and all(char in "0123456789abcdef" for char in text)
+
+
+def _decode_reasons(raw: Any) -> set[str]:
+    if raw is None:
+        return set()
+    if isinstance(raw, (list, tuple)):
+        return {str(item) for item in raw}
+    try:
+        parsed = json.loads(str(raw))
+    except Exception:  # noqa: BLE001 - a corrupt cell is a partial receipt
+        return {REASON_USAGE_PARTIAL}
+    if isinstance(parsed, list):
+        return {str(item) for item in parsed}
+    return set()
+
+
+def _row_to_dict(row: sqlite3.Row, columns: Sequence[str]) -> dict[str, Any]:
+    record: dict[str, Any] = {}
+    for column in columns:
+        value = row[column]
+        if column == "missing_reasons":
+            record[column] = sorted(_decode_reasons(value))
+        else:
+            record[column] = value
+    return record
+
+
+def _canonical_json(record: Mapping[str, Any]) -> str:
+    return json.dumps(
+        dict(sorted(record.items())),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _import_value(record: Mapping[str, Any], column: str) -> Any:
+    value = record.get(column)
+    if column == "missing_reasons":
+        return json.dumps(sorted(_decode_reasons(value)))
+    return value
+
+
+def _require_agreement(
+    existing: sqlite3.Row, record: Mapping[str, Any]
+) -> None:
+    """An imported call that clashes with a recorded one is not merged away."""
+    if existing["state"] == STATE_RESERVED:
+        # The local row knows less than the arriving one. Fill it in rather
+        # than treat the arrival as a contradiction.
+        return
+    for column in ("input_tokens", "output_tokens", "model_cost_usd"):
+        incoming = record.get(column)
+        recorded = existing[column]
+        if incoming is None or recorded is None:
+            continue
+        if str(incoming) != str(recorded):
+            raise LedgerIntegrityError(
+                f"imported call {existing['call_id']} disagrees with the "
+                f"recorded {column}; the ledger will not overwrite it"
+            )

--- a/batch-runner/core/grade_payload.py
+++ b/batch-runner/core/grade_payload.py
@@ -24,7 +24,7 @@ def validate_grade_payload(payload: Any, schema: dict) -> None:
     validate(instance=payload, schema=schema)
     if not isinstance(payload, dict):
         return
-    current_schema = payload.get("schema_version") in {"1.2", "1.3"}
+    current_schema = payload.get("schema_version") in {"1.2", "1.3", "1.4"}
     if current_schema and "run_status" not in payload:
         raise ValueError("current grade lifecycle identity is missing")
     if "run_status" not in payload:
@@ -66,7 +66,7 @@ def validate_grade_payload(payload: Any, schema: dict) -> None:
         raise ValueError("primary grader route fingerprint mismatch")
     if not current_schema:
         return
-    if payload.get("schema_version") == "1.3":
+    if payload.get("schema_version") in {"1.3", "1.4"}:
         tasks = payload.get("tasks")
         if not isinstance(tasks, list):
             raise ValueError("current grade tasks are missing")
@@ -173,4 +173,45 @@ def validate_grade_payload(payload: Any, schema: dict) -> None:
     ):
         raise ValueError(
             "current grade unpriced models do not match persisted model identity"
+        )
+    if payload.get("schema_version") == "1.4":
+        _validate_grading_cost_receipts(payload)
+
+
+def _validate_grading_cost_receipts(payload: dict) -> None:
+    """Check that the run total does not claim more certainty than its parts.
+
+    The receipts' shape is the schema's business. The one thing the schema
+    cannot say is how the summary relates to the rows it was summed from, and
+    that relation is the whole guarantee: a total is only a total when every
+    part behind it is known. A run holding one task whose usage never arrived
+    may still report what it confirmed, but it reports it as a floor, not as
+    the bill.
+
+    Tasks that were never run are not parts of the total and do not count
+    against it — a shard that graded ten of two hundred tasks has a complete
+    bill for ten.
+    """
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise ValueError("grade summary is missing")
+    run_receipt = summary.get("grading_cost")
+    if not isinstance(run_receipt, dict):
+        raise ValueError("schema 1.4 grade summary is missing its cost receipt")
+    tasks = payload.get("tasks")
+    if not isinstance(tasks, list):
+        raise ValueError("grade tasks are missing")
+
+    task_statuses = []
+    for task in tasks:
+        receipt = task.get("grading_cost") if isinstance(task, dict) else None
+        if not isinstance(receipt, dict):
+            raise ValueError("schema 1.4 grade task is missing its cost receipt")
+        task_statuses.append(receipt.get("status"))
+
+    if run_receipt.get("status") == "complete" and any(
+        status not in {"complete", "not_run"} for status in task_statuses
+    ):
+        raise ValueError(
+            "grade summary claims a complete cost over an incomplete task"
         )

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -21,6 +21,7 @@ from core.azure_ai_clients import (
     canonical_deployment,
     grader_route_workloads,
 )
+from core.cost_receipts import STAGE_GRADING, STAGE_PERCEPTION
 from core.llm_client import ManagedAzureAIClient, create_typed_azure_client
 from core.public_error import public_provider_error_text
 from core.deliverable_selector import (
@@ -236,6 +237,7 @@ class Grader:
         *,
         client=None,
         client_factory: AzureAIClientFactory | None = None,
+        cost_recorder=None,
     ):
         self.config = config
         self.rubric_loader = rubric_loader
@@ -265,6 +267,26 @@ class Grader:
             )
             client = self._managed_client.client
         self.client = client
+
+        # Per-task cost receipts (task 0828). Metering is opt-in: with no
+        # recorder the two attributes below are the bare client and nothing
+        # is written, which is what keeps an unmetered run reporting an
+        # absent ledger rather than a smaller bill.
+        #
+        # Two wrappers, one connection. The judge's own calls follow whatever
+        # stage is in scope; the perception readers share this client but are
+        # pinned to their own stage, so a visual read taken mid-grading lands
+        # in its own component of the marking receipt instead of disappearing
+        # into the judge's.
+        self._cost_recorder = cost_recorder
+        self._perception_client = client
+        if cost_recorder is not None:
+            self.client = cost_recorder.meter(
+                client, provider="azure", model=deployment
+            )
+            self._perception_client = cost_recorder.meter(
+                client, provider="azure", stage=STAGE_PERCEPTION
+            )
 
         try:
             self.prompt_template = self._read_prompt_template(
@@ -325,6 +347,7 @@ class Grader:
         finally:
             self._managed_client = None
             self.client = None
+            self._perception_client = None
 
     def __enter__(self) -> "Grader":
         return self
@@ -348,8 +371,16 @@ class Grader:
         # once per item. Cleared here for the same reason the caps are.
         self._text_layer_cache = {}
         self._audio_content_cache = {}
-        return self._grade_task_with_selector(task, deliverable_path, files)
+        if self._cost_recorder is None:
+            return self._grade_task_with_selector(task, deliverable_path, files)
 
+        # Everything this call spends — judge turns, retries inside the
+        # judge, and the perception reads it delegates — belongs to one
+        # task's marking bill.
+        with self._cost_recorder.attributed(
+            task_id=task.task_id, stage=STAGE_GRADING
+        ):
+            return self._grade_task_with_selector(task, deliverable_path, files)
 
     def _grade_task_with_selector(
         self, task: TaskRubric, deliverable_path: Path, files: list[Path]
@@ -1503,7 +1534,7 @@ class Grader:
                 vis_cfg, "judge.perception.visual"
             )
             vision_perception = VisionPerception(
-                client=self.client,
+                client=self._perception_client,
                 deployment=vision_deployment,
                 call_cap=int(
                     vis_cfg.get("call_cap_per_task", VISION_CALL_CAP)
@@ -1524,7 +1555,7 @@ class Grader:
                 aud_cfg, "judge.perception.audio"
             )
             audio_perception = AudioPerception(
-                client=self.client,
+                client=self._perception_client,
                 deployment=audio_deployment,
                 call_cap=int(
                     aud_cfg.get("call_cap_per_task", AUDIO_CALL_CAP)

--- a/batch-runner/core/llm_client.py
+++ b/batch-runner/core/llm_client.py
@@ -372,7 +372,13 @@ def complete(
     """
     start = time.time()
 
-    if isinstance(client, AnthropicClient):
+    # A client may be wrapped by core.cost_metering so that each call records
+    # what it cost. The wrapper forwards every attribute but not its type, so
+    # the provider test below looks *through* it while the call itself still
+    # goes *through* it — the request has to stay metered.
+    probe = client.inner if getattr(client, "_is_cost_metered", False) else client
+
+    if isinstance(probe, AnthropicClient):
         response = client.chat_complete(
             model=model,
             messages=messages,

--- a/batch-runner/experiments/execution_envelope/model_price_table.json
+++ b/batch-runner/experiments/execution_envelope/model_price_table.json
@@ -23,5 +23,56 @@
       "input_usd_per_million": "5.00",
       "output_usd_per_million": "15.00"
     }
-  }
+  },
+  "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+  "cost_receipt_note": "The block above prices a plan before it runs. The two blocks below price calls after they have run, and are read by core/cost_receipts.py. They are kept apart because a ceiling and a receipt are answers to different questions and must not be edited as if they were one list. Keys here are provider:resolved_model, where resolved_model is the model the response reports — not the deployment name in the request. A provider or model with no entry here is recorded as price_missing; it is never priced from a similar entry.",
+  "providers": {
+    "azure:gpt-5.4": {
+      "input_usd_per_million": "1.25",
+      "cached_input_usd_per_million": "1.25",
+      "output_usd_per_million": "5.00",
+      "reasoning_billed_as": "output",
+      "source": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
+      "last_reviewed": "2026-05-28",
+      "currency": "USD",
+      "unit": "per 1,000,000 tokens"
+    },
+    "azure:gpt-5.4-mini": {
+      "input_usd_per_million": "0.25",
+      "cached_input_usd_per_million": "0.25",
+      "output_usd_per_million": "1.00",
+      "reasoning_billed_as": "output",
+      "source": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
+      "last_reviewed": "2026-05-28",
+      "currency": "USD",
+      "unit": "per 1,000,000 tokens"
+    },
+    "azure:gpt-5.4-nano": {
+      "input_usd_per_million": "0.075",
+      "cached_input_usd_per_million": "0.075",
+      "output_usd_per_million": "0.30",
+      "reasoning_billed_as": "output",
+      "source": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
+      "last_reviewed": "2026-05-28",
+      "currency": "USD",
+      "unit": "per 1,000,000 tokens"
+    },
+    "azure:gpt-5.4-pro": {
+      "input_usd_per_million": "5.00",
+      "cached_input_usd_per_million": "5.00",
+      "output_usd_per_million": "15.00",
+      "reasoning_billed_as": "output",
+      "source": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
+      "last_reviewed": "2026-05-28",
+      "currency": "USD",
+      "unit": "per 1,000,000 tokens"
+    }
+  },
+  "cost_receipt_caveats": {
+    "cached_input": "No discounted cache rate has been sourced for this tenant, so cached input is priced at the full input rate. That over-states the bill rather than under-stating it, which is the only direction this repository is willing to be wrong in. Replace these with a sourced rate before treating a receipt as a quote.",
+    "reasoning_tokens": "reasoning_billed_as is 'output' because these deployments report reasoning tokens inside the completion token count, so charging them again on top would bill the same tokens twice. A provider that bills reasoning separately needs 'separate' and its own rate; where nobody has established which it is, 'unknown' leaves the call unpriced.",
+    "other_providers": "Only the provider covered by the source above is listed. Calls to any other provider are recorded as price_missing and hold their receipt at partial until someone sources the rates and adds them here.",
+    "runtime": "No execution-environment rate has been sourced, so the runtime block is empty and directly attributable runtime fees are recorded as runtime_cost_unpriced. An empty list is a smaller error than an invented hourly rate."
+  },
+  "runtime": {}
 }

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -2,6 +2,132 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GDPVal Grade Result",
   "$defs": {
+    "costUsage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "input_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "cached_input_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "output_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "reasoning_tokens": {"type": ["integer", "null"], "minimum": 0}
+      }
+    },
+    "costMissingReason": {
+      "enum": [
+        "usage_absent",
+        "usage_partial",
+        "price_missing",
+        "call_reachability_unknown",
+        "runtime_cost_unattributable",
+        "runtime_cost_unpriced",
+        "ledger_absent",
+        "stage_unsupported"
+      ]
+    },
+    "costComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stage",
+        "retry_kind",
+        "status",
+        "model_calls",
+        "known_cost_usd",
+        "usage",
+        "missing_reasons"
+      ],
+      "properties": {
+        "stage": {
+          "enum": [
+            "preprocessing",
+            "generation",
+            "self_qa",
+            "grading",
+            "perception"
+          ]
+        },
+        "retry_kind": {
+          "enum": [
+            "none",
+            "semantic",
+            "infrastructure",
+            "resume",
+            "internal_recovery"
+          ]
+        },
+        "status": {"enum": ["complete", "partial", "unavailable", "not_run"]},
+        "model_calls": {"type": "integer", "minimum": 0},
+        "known_cost_usd": {"type": "number", "minimum": 0},
+        "usage": {"$ref": "#/$defs/costUsage"},
+        "missing_reasons": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/costMissingReason"}
+        }
+      }
+    },
+    "costReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "status",
+        "currency",
+        "estimated_cost_usd",
+        "known_cost_usd",
+        "model_cost_usd",
+        "runtime_cost_usd",
+        "model_calls",
+        "usage",
+        "components",
+        "price_table_sha256",
+        "missing_reasons"
+      ],
+      "properties": {
+        "schema_version": {"const": "cost-receipt-v1"},
+        "status": {"enum": ["complete", "partial", "unavailable", "not_run"]},
+        "currency": {"const": "USD"},
+        "estimated_cost_usd": {"type": ["number", "null"], "minimum": 0},
+        "known_cost_usd": {"type": "number", "minimum": 0},
+        "model_cost_usd": {"type": "number", "minimum": 0},
+        "runtime_cost_usd": {"type": "number", "minimum": 0},
+        "model_calls": {"type": "integer", "minimum": 0},
+        "usage": {"$ref": "#/$defs/costUsage"},
+        "components": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/costComponent"}
+        },
+        "price_table_sha256": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "missing_reasons": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/costMissingReason"}
+        }
+      },
+      "allOf": [
+        {
+          "$comment": "estimated_cost_usd is a number only where every cost behind it is confirmed. Anywhere else the confirmed part stays in known_cost_usd and the total stays null, so a floor is never read as a total.",
+          "if": {
+            "required": ["status"],
+            "properties": {"status": {"const": "complete"}}
+          },
+          "then": {"properties": {"estimated_cost_usd": {"type": "number"}}},
+          "else": {"properties": {"estimated_cost_usd": {"type": "null"}}}
+        }
+      ]
+    },
+    "costLedgerReference": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
     "visualScope": {
       "type": "object",
       "properties": {
@@ -102,7 +228,7 @@
     {
       "if": {
         "required": ["schema_version"],
-        "properties": {"schema_version": {"enum": ["1.2", "1.3"]}}
+        "properties": {"schema_version": {"enum": ["1.2", "1.3", "1.4"]}}
       },
       "then": {
         "required": [
@@ -136,7 +262,7 @@
     {
       "if": {
         "required": ["schema_version"],
-        "properties": {"schema_version": {"const": "1.3"}}
+        "properties": {"schema_version": {"enum": ["1.3", "1.4"]}}
       },
       "then": {
         "properties": {
@@ -186,6 +312,28 @@
       }
     },
     {
+      "$comment": "1.4 puts money beside the token counters that were already there. A grade that calls itself 1.4 carries a receipt on every task and on the summary, and points at the ledger those receipts were read from. A pointer of null is allowed and means no ledger was kept for this run; a missing key is not allowed, because it would be indistinguishable from a reader that simply did not look.",
+      "if": {
+        "required": ["schema_version"],
+        "properties": {"schema_version": {"const": "1.4"}}
+      },
+      "then": {
+        "required": ["cost_ledger"],
+        "properties": {
+          "tasks": {
+            "items": {
+              "required": ["grading_cost"],
+              "properties": {"grading_cost": {"$ref": "#/$defs/costReceipt"}}
+            }
+          },
+          "summary": {
+            "required": ["grading_cost"],
+            "properties": {"grading_cost": {"$ref": "#/$defs/costReceipt"}}
+          }
+        }
+      }
+    },
+    {
       "if": {
         "required": ["schema_version"],
         "properties": {"schema_version": {"enum": ["1.0", "1.1", "1.2"]}}
@@ -219,7 +367,7 @@
     "summary"
   ],
   "properties": {
-    "schema_version": {"enum": ["1.0", "1.1", "1.2", "1.3"], "description": "1.0 = legacy item-level grade JSON. 1.1 = sign-aware backfill. 1.2 = lifecycle and explicit unpriced-cost provenance. 1.3 = judge_error is score-excluded and judge_error_rate remains required; headline scores are not directly comparable with 1.0-1.2."},
+    "schema_version": {"enum": ["1.0", "1.1", "1.2", "1.3", "1.4"], "description": "1.0 = legacy item-level grade JSON. 1.1 = sign-aware backfill. 1.2 = lifecycle and explicit unpriced-cost provenance. 1.3 = judge_error is score-excluded and judge_error_rate remains required; headline scores are not directly comparable with 1.0-1.2. 1.4 = every task carries a grading_cost receipt and the run points at the ledger those receipts came from; scores are unchanged from 1.3 and stay comparable with it."},
     "run_status": {"enum": ["partial", "final", "diagnostic"]},
     "expected_task_count": {"type": "integer", "minimum": 1},
     "expected_ordered_task_ids_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
@@ -391,6 +539,7 @@
     "graded_at": {"type": "string"},
     "graded_by": {"type": "string"},
     "graded_by_version": {"type": "string"},
+    "cost_ledger": {"$ref": "#/$defs/costLedgerReference"},
     "tasks": {
       "type": "array",
       "items": {
@@ -498,6 +647,7 @@
           "render_call_count": {"type": "integer", "minimum": 0},
           "render_total_latency_ms": {"type": "number", "minimum": 0},
           "usage_complete": {"type": "boolean"},
+          "grading_cost": {"$ref": "#/$defs/costReceipt"},
           "selected_deliverables": {"type": ["object", "null"]},
           "reference_files_excluded": {"type": "array", "items": {"type": "string"}},
           "selection_rule": {"type": ["string", "null"]},
@@ -530,7 +680,8 @@
           "additionalProperties": true
         },
         "wow": {"type": "object"},
-        "cost": {"type": "object"}
+        "cost": {"type": "object"},
+        "grading_cost": {"$ref": "#/$defs/costReceipt"}
       },
       "additionalProperties": true
     }

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -28,6 +28,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "name",
         "stage",
         "retry_kind",
         "status",
@@ -37,6 +38,16 @@
         "missing_reasons"
       ],
       "properties": {
+        "name": {
+          "enum": [
+            "preprocessing",
+            "generation",
+            "self_qa",
+            "grading",
+            "perception",
+            "retry"
+          ]
+        },
         "stage": {
           "enum": [
             "preprocessing",

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -23,6 +23,7 @@ Usage:
 """
 
 import argparse
+import contextlib
 import copy
 import gc
 import hashlib
@@ -59,6 +60,22 @@ from core.execution_metrics import (
     add_durations_ms,
     bounded_count,
     bounded_duration_ms,
+)
+from core.cost_metering import open_cost_recorder
+from core.cost_receipts import (
+    BUCKET_PROBLEM_SOLVING,
+    REASON_LEDGER_ABSENT,
+    REASON_STAGE_UNSUPPORTED,
+    RETRY_NONE,
+    RETRY_RESUME,
+    RETRY_SEMANTIC,
+    STAGE_GENERATION,
+    STAGE_PREPROCESSING,
+    STAGE_SELF_QA,
+    STATUS_NOT_RUN,
+    CostReceipt,
+    ledger_reference,
+    summarise_receipts,
 )
 from core.file_preview import generate_all_previews
 from core.inference_manifest import (
@@ -205,6 +222,7 @@ class _Step2RuntimeResources:
         self.managed_clients: list[ManagedAzureAIClient] = []
         self.provider_clients: list[object] = []
         self.factory: Optional[AzureAIClientFactory] = None
+        self.cost_ledger: Optional[object] = None
         self._closed = False
 
     def own_executor(self, executor: TaskExecutor) -> None:
@@ -215,6 +233,9 @@ class _Step2RuntimeResources:
 
     def own_provider_client(self, client: object) -> None:
         self.provider_clients.append(client)
+
+    def own_cost_ledger(self, ledger: object) -> None:
+        self.cost_ledger = ledger
 
     def own_factory(self, factory: AzureAIClientFactory) -> None:
         if self.factory is not None and self.factory is not factory:
@@ -239,6 +260,10 @@ class _Step2RuntimeResources:
                 for client in reversed(self.provider_clients)
             ),
             ("factory", self.factory),
+            # Last: the ledger outlives the clients whose calls it recorded,
+            # so a settle issued during their teardown still has somewhere
+            # to go.
+            ("cost ledger", self.cost_ledger),
         ]
         for role, resource in resources:
             if resource is None or id(resource) in seen:
@@ -258,7 +283,11 @@ class _Step2RuntimeResources:
             if executor_error is not None:
                 close_error = executor_error
             elif typed_error_type is not None:
-                prefix = "typed Azure AI " if role != "provider client" else ""
+                prefix = (
+                    ""
+                    if role in {"provider client", "cost ledger"}
+                    else "typed Azure AI "
+                )
                 close_error = RuntimeError(
                     f"{prefix}{role} cleanup failed ({typed_error_type})"
                 )
@@ -586,6 +615,7 @@ def _run_preprocessors(
     azure_ai_route_plan: Optional[
         list[tuple[AzureAIWorkload, str, dict]]
     ] = None,
+    cost_recorder=None,
 ) -> str:
     """Run preprocessors defined in condition YAML (e.g. audio_analyzer).
 
@@ -596,6 +626,23 @@ def _run_preprocessors(
     preprocessors = condition.get("preprocessors", [])
     if not preprocessors:
         return ""
+
+    def _metered(raw_client, provider_name: str, deployment: str):
+        """Bill a preprocessor's reads to the task, under their own stage.
+
+        These clients are built here and thrown away here, so they cannot be
+        wrapped once at the top of the run like the main one. The stage is
+        pinned because this work happens inside the generation scope: without
+        the pin, listening to an audio file would be filed as generation.
+        """
+        if cost_recorder is None:
+            return raw_client
+        return cost_recorder.meter(
+            raw_client,
+            provider=("azure" if provider_name == "azure_openai" else provider_name),
+            model=deployment,
+            stage=STAGE_PREPROCESSING,
+        )
 
     results: list[str] = []
 
@@ -667,7 +714,9 @@ def _run_preprocessors(
                             pp_deployment,
                             azure_ai_route_plan or [],
                         )
-                        pp_client = managed_pp_client
+                        pp_client = _metered(
+                            managed_pp_client, pp_provider, pp_deployment
+                        )
                         observation["runtime_fingerprint"] = verified_route[
                             "runtime_fingerprint"
                         ]
@@ -684,7 +733,11 @@ def _run_preprocessors(
                     finally:
                         managed_pp_client.close()
                 else:
-                    pp_client = create_provider_client(pp_provider)
+                    pp_client = _metered(
+                        create_provider_client(pp_provider),
+                        pp_provider,
+                        pp_deployment,
+                    )
                     try:
                         analysis = analyze_audio_files(
                             client=pp_client,
@@ -784,7 +837,9 @@ def _run_preprocessors(
                             pp_deployment,
                             azure_ai_route_plan or [],
                         )
-                        pp_client = managed_pp_client
+                        pp_client = _metered(
+                            managed_pp_client, pp_provider, pp_deployment
+                        )
                         observation["runtime_fingerprint"] = verified_route[
                             "runtime_fingerprint"
                         ]
@@ -805,7 +860,11 @@ def _run_preprocessors(
                     finally:
                         managed_pp_client.close()
                 else:
-                    pp_client = create_provider_client(pp_provider)
+                    pp_client = _metered(
+                        create_provider_client(pp_provider),
+                        pp_provider,
+                        pp_deployment,
+                    )
                     try:
                         analysis = analyze_video_files(
                             client=pp_client,
@@ -1972,6 +2031,7 @@ def _execute_single_task(
     azure_ai_route_plan: Optional[
         list[tuple[AzureAIWorkload, str, dict]]
     ] = None,
+    cost_recorder=None,
 ) -> dict:
     """Execute a single task and return result dict."""
     task_id = task_info["task_id"]
@@ -2074,6 +2134,7 @@ def _execute_single_task(
             observations=preprocessor_observations,
             azure_ai_factory=azure_ai_factory,
             azure_ai_route_plan=azure_ai_route_plan,
+            cost_recorder=cost_recorder,
         )
         perception_text = None
         if preprocessor_prefix:
@@ -3187,6 +3248,59 @@ def _run_inference_impl(
             )
             sys.exit(1)
 
+    # ── Per-task cost receipts (task 0828) ──
+    #
+    # One ledger per condition, opened before the executor so that every
+    # client the run will use is already metered when the first task starts.
+    # The ledger is append-only and keyed by call, so a relay restart reopens
+    # this same file and adds to it rather than starting a fresh bill.
+    #
+    # Two paths are deliberately left unmetered. The hardened and agentic
+    # substrates build their clients behind a signed approval gate and account
+    # for their own spend against a separate budget ledger; wrapping that
+    # factory here would put a second, unattested layer inside an attested
+    # path. Their receipts therefore report `stage_unsupported` — an explicit
+    # "this build kept no priced record", which is the honest reading, rather
+    # than a total that silently omits them.
+    cost_ledger_path = WORKSPACE_DIR / f"cost_ledger_{condition_key}.sqlite3"
+    cost_recorder = None
+    cost_ledger_note = "unsupported for this execution mode"
+    if not hardened_requested:
+        cost_recorder, cost_ledger_note = open_cost_recorder(
+            cost_ledger_path,
+            run_id=run_identity,
+            round_index=int(
+                (prevalidated_progress or {}).get("resume_round", 0) or 0
+            ),
+        )
+    if cost_recorder is not None:
+        runtime_resources.own_cost_ledger(cost_recorder.ledger)
+
+        metered_provider = "azure" if provider == "azure_openai" else provider
+        # Self-QA usually shares the main client. Wrapping the same object
+        # twice would open two reservations for one request and bill it twice,
+        # so the shared case reuses the one wrapper.
+        qa_shares_main_client = qa_client is client
+        if client is not None:
+            client = cost_recorder.meter(
+                client, provider=metered_provider, model=model
+            )
+        if qa_shares_main_client:
+            qa_client = client
+        elif qa_client is not None:
+            qa_client = cost_recorder.meter(
+                qa_client, provider=metered_provider, model=qa_deployment
+            )
+        if code_interpreter_client is not None:
+            code_interpreter_client = cost_recorder.meter(
+                code_interpreter_client, provider=metered_provider, model=model
+            )
+        print(f"   Cost ledger:        {cost_ledger_path.name}")
+        if cost_ledger_note:
+            print(f"                       {cost_ledger_note}")
+    else:
+        print(f"   Cost ledger:        not kept ({cost_ledger_note})")
+
     # 3. Initialize executor (no silent fallback — fail loudly)
     reasoning_effort = condition.get("model", {}).get("reasoning_effort")
     agentic_task_requests = None
@@ -3291,7 +3405,9 @@ def _run_inference_impl(
 
     # ── Helper: execute one task with QA loop ──
 
-    def _run_task_with_qa(task: dict, error_context: str = None) -> dict:
+    def _run_task_with_qa(
+        task: dict, error_context: str = None, resume_round: int = 0
+    ) -> dict:
         """Execute one task with infra retries + Self-QA retry loop.
 
         QA status handling:
@@ -3326,6 +3442,24 @@ def _run_inference_impl(
         qa_attempts = 0
         last_qa_feedback = error_context
         reflection_history = []
+
+        # Which bill each call lands on. A resume round's calls are marked as
+        # such and kept beside the round before them: the earlier attempt was
+        # paid for whether or not its output survived.
+        solving_retry_kind = RETRY_RESUME if resume_round else RETRY_NONE
+
+        def _solving_scope(stage: str, attempt: int):
+            """Attribute the calls made inside to this task, at one stage."""
+            if cost_recorder is None:
+                return contextlib.nullcontext()
+            return cost_recorder.attributed(
+                task_id=task_id,
+                stage=stage,
+                retry_kind=(
+                    solving_retry_kind if attempt == 0 else RETRY_SEMANTIC
+                ),
+                attempt_index=attempt,
+            )
 
         # ── best-swap state ──
         best_result = None
@@ -3498,19 +3632,21 @@ def _run_inference_impl(
                     # 파일을 생성했을 때 구/신 파일이 공존하게 됨
                     _clear_task_files()
 
-                result = _execute_single_task(
-                    task, condition, executor, execution_mode,
-                    client, model, manifest,
-                    error_context=last_qa_feedback,
-                    verbose=verbose,
-                    run_id=run_identity,
-                    condition_name=execution_condition,
-                    strict_inputs=hardened_requested,
-                    experiment_id=experiment_id,
-                    upload_root=condition_upload_root,
-                    azure_ai_factory=azure_ai_factory,
-                    azure_ai_route_plan=azure_ai_route_plan,
-                )
+                with _solving_scope(STAGE_GENERATION, qa_attempts):
+                    result = _execute_single_task(
+                        task, condition, executor, execution_mode,
+                        client, model, manifest,
+                        error_context=last_qa_feedback,
+                        verbose=verbose,
+                        run_id=run_identity,
+                        condition_name=execution_condition,
+                        strict_inputs=hardened_requested,
+                        experiment_id=experiment_id,
+                        upload_root=condition_upload_root,
+                        azure_ai_factory=azure_ai_factory,
+                        azure_ai_route_plan=azure_ai_route_plan,
+                        cost_recorder=cost_recorder,
+                    )
                 if metrics_enabled:
                     _record_execution_metrics(result)
 
@@ -3530,22 +3666,23 @@ def _run_inference_impl(
 
                 # Run Self-QA (파일이 workspace에 저장된 상태 → file_preview로 실제 내용 확인)
                 qa_started = time.perf_counter()
-                qa_result_info = _run_self_qa(
-                    task, condition,
-                    result.get("deliverable_text", ""),
-                    result.get("deliverable_files", []),
-                    qa_client,
-                    qa_max_tokens=qa_max_tokens,
-                    upload_root=condition_upload_root,
-                    **(
-                        {"redact_provider_errors": True}
-                        if (
-                            typed_azure_active
-                            and provider in {"azure", "azure_openai"}
-                        )
-                        else {}
-                    ),
-                )
+                with _solving_scope(STAGE_SELF_QA, qa_attempts):
+                    qa_result_info = _run_self_qa(
+                        task, condition,
+                        result.get("deliverable_text", ""),
+                        result.get("deliverable_files", []),
+                        qa_client,
+                        qa_max_tokens=qa_max_tokens,
+                        upload_root=condition_upload_root,
+                        **(
+                            {"redact_provider_errors": True}
+                            if (
+                                typed_azure_active
+                                and provider in {"azure", "azure_openai"}
+                            )
+                            else {}
+                        ),
+                    )
                 if metrics_enabled:
                     self_qa_call_count += 1
                     self_qa_time_ms += (time.perf_counter() - qa_started) * 1000
@@ -3644,12 +3781,42 @@ def _run_inference_impl(
             best_result["reflection_attempts"] = len(reflection_history)
             if len(reflection_history) > 0:
                 best_result["reflection_final_score"] = best_score
-            return _attach_job_metrics(best_result)
+            return _attach_solving_cost(_attach_job_metrics(best_result))
         result["reflection_history"] = reflection_history
         result["reflection_attempts"] = len(reflection_history)
         if len(reflection_history) > 0 and result.get("status") == "success":
             result["reflection_final_score"] = best_score if best_score >= 0 else None
-        return _attach_job_metrics(result)
+        return _attach_solving_cost(_attach_job_metrics(result))
+
+    # ── Helper: what this task cost to solve ──
+
+    def _solving_receipt(task_id: str) -> CostReceipt:
+        """This task's problem-solving bill, read from the ledger.
+
+        Read rather than accumulated in memory, so a task picked up by a
+        resume round carries the earlier round's calls too — the discarded
+        attempt was still paid for.
+
+        A run with no ledger reports ``unavailable``. It does not report
+        ``$0``: a reader who cannot tell "free" from "unrecorded" will read
+        the first.
+        """
+        if cost_recorder is None:
+            return CostReceipt.unavailable(
+                reasons=(
+                    (REASON_STAGE_UNSUPPORTED,)
+                    if hardened_requested
+                    else (REASON_LEDGER_ABSENT,)
+                )
+            )
+        return cost_recorder.receipt_for(task_id, BUCKET_PROBLEM_SOLVING)
+
+    def _attach_solving_cost(result: dict) -> dict:
+        """Stamp the task's problem-solving bill onto its result."""
+        task_id = result.get("task_id")
+        if task_id:
+            result[BUCKET_PROBLEM_SOLVING] = _solving_receipt(task_id).as_dict()
+        return result
 
     # ── Helper: print result status ──
 
@@ -3848,7 +4015,11 @@ def _run_inference_impl(
                   f"(prev: {fail_info['status']})...",
                   end=" ", flush=True)
 
-            result = _run_task_with_qa(task, error_context=fail_info.get("error"))
+            result = _run_task_with_qa(
+                task,
+                error_context=fail_info.get("error"),
+                resume_round=round_num,
+            )
             result["resume_round"] = round_num
 
             # progress.json에서 해당 task_id 오브젝트를 직접 교체
@@ -3885,6 +4056,23 @@ def _run_inference_impl(
     )
     results = bind_deliverable_file_records(results, condition_upload_root)
     results = _public_persisted_results(results)
+
+    # ── Per-task cost receipts: settle up ──
+    #
+    # Re-read every task's bill now that the last round is over. A task that
+    # succeeded in round 0 and was never touched again still gets a fresh read,
+    # which costs nothing and removes the class of bug where a result carries a
+    # receipt from before the ledger was complete.
+    solving_receipts = []
+    for result in results:
+        task_id = result.get("task_id")
+        if not task_id:
+            continue
+        receipt = _solving_receipt(task_id)
+        result[BUCKET_PROBLEM_SOLVING] = receipt.as_dict()
+        solving_receipts.append(receipt)
+    solving_summary = summarise_receipts(solving_receipts)
+
     success = sum(1 for r in results if r["status"] == "success")
     errors = sum(1 for r in results if r["status"] == "error")
     qa_failed = sum(1 for r in results if r.get("status") == "qa_failed")
@@ -3909,11 +4097,28 @@ def _run_inference_impl(
             "success": success,
             "error": errors,
             "qa_failed": qa_failed,
+            BUCKET_PROBLEM_SOLVING: solving_summary.as_dict(),
         },
         "results": results,
     }
     if azure_ai_routes is not None:
         final_output["azure_ai_routes"] = azure_ai_routes
+
+    # The audit trail the receipts above are derived from. Exported as JSONL
+    # next to the results so a later step — a resume, a shard merge, a reader
+    # who wants to recheck the arithmetic — can reimport it, and so the digest
+    # makes silent edits detectable.
+    if cost_recorder is not None:
+        cost_export_path = WORKSPACE_DIR / f"cost_ledger_{condition_key}.jsonl"
+        try:
+            digest = cost_recorder.ledger.export_jsonl(cost_export_path)
+        except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+            print(f"   ⚠️  cost ledger export failed ({type(exc).__name__})")
+        else:
+            final_output["cost_ledger"] = ledger_reference(
+                cost_export_path.name, digest
+            )
+
     final_output["result_fingerprint"] = inference_result_fingerprint(final_output)
 
     with open(output_path, "w", encoding="utf-8") as f:
@@ -3936,6 +4141,24 @@ def _run_inference_impl(
     if qa_failed:
         print(f"   QA failed:          {qa_failed}/{len(results)}")
     print(f"   Resume rounds used: {progress.get('resume_round', 0)}/{resume_max_rounds}")
+    solving_estimate = solving_summary.as_dict()["estimated_cost_usd"]
+    if solving_estimate is not None:
+        solving_line = (
+            f"${solving_estimate:.4f} ({solving_summary.model_calls} calls)"
+        )
+    elif solving_summary.status == STATUS_NOT_RUN:
+        # Not "$0.00 so far". Nothing was metered here at all, which is a
+        # different statement from a run that recorded calls it could not
+        # price, and printing a figure would blur the two.
+        solving_line = "not recorded (no metered calls)"
+    else:
+        solving_line = (
+            f"{solving_summary.status} — "
+            f"${float(solving_summary.known_cost_usd):.4f} confirmed so far, "
+            "not a total ("
+            f"{', '.join(solving_summary.missing_reasons) or 'reason unrecorded'})"
+        )
+    print(f"   Problem-solving:    {solving_line}")
     print(f"{'='*60}")
 
 

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -32,6 +32,14 @@ from core.azure_ai_clients import (
     grader_route_workloads,
     preflight_routes,
 )
+from core.cost_metering import open_cost_recorder
+from core.cost_receipts import (
+    BUCKET_GRADING,
+    STATUS_COMPLETE,
+    CostReceipt,
+    ledger_reference,
+    summarise_receipts,
+)
 from core.experiment_config import ExperimentConfig
 from core.grader import (
     Grader,
@@ -52,7 +60,7 @@ from core.rubric_loader import RubricLoader
 from core.tool_calling_judge import resolve_visual_file_cap
 from core.tools import ReadDeliverableError, get_renderer_fingerprint
 
-SCHEMA_VERSION = "1.3"
+SCHEMA_VERSION = "1.4"
 GRADED_BY_VERSION = "0.1.0"
 FULL_HF_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 FULL_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -1599,6 +1607,15 @@ def _compute_summary(
             "total_render_latency_sec": round(render_latency_ms / 1000.0, 2),
             "usage_complete": usage_complete,
         },
+        # The priced counterpart to the token counters above. Read back off
+        # the task rows rather than off the live ledger, so that the total a
+        # reader sees is the sum of the receipts a reader can see: a resumed
+        # run's earlier tasks were written by an earlier process, and a merged
+        # shard's ledger may be long gone, but their rows are right here.
+        BUCKET_GRADING: summarise_receipts([
+            CostReceipt.from_dict(task.get(BUCKET_GRADING))
+            for task in task_dicts
+        ]).as_dict(),
     }
 
 
@@ -1661,6 +1678,7 @@ def _build_grade_payload(
     exp_config: ExperimentConfig | None = None,
     source_experiment_id: str | None = None,
     renderer_fingerprint: dict[str, str] | None = None,
+    cost_ledger: dict[str, str] | None = None,
 ) -> dict:
     if run_status not in {"partial", "final", "diagnostic"}:
         raise ValueError("grade run_status is invalid")
@@ -1732,6 +1750,10 @@ def _build_grade_payload(
         "graded_at": _now_iso(),
         "graded_by": "step8_grade.py",
         "graded_by_version": GRADED_BY_VERSION,
+        # Where the per-call audit trail for this run's grading costs was
+        # written, and its digest. ``None`` where no ledger was kept, which is
+        # a different claim from a ledger showing nothing.
+        "cost_ledger": cost_ledger,
         "tasks": task_dicts,
         "summary": _compute_summary(
             task_dicts,
@@ -2082,19 +2104,79 @@ def main() -> int:
             file=sys.stderr,
         )
 
+    # ── Per-task grading cost receipts (task 0828) ──
+    #
+    # One ledger per grade file, opened before the judge so that the judge's
+    # client and its perception readers are already metered on the first task.
+    # It lives beside the grade file and is append-only: a resumed chunk, and
+    # the next chunk after that, reopen this same ledger and add to it. What an
+    # abandoned attempt cost stays in it, because it was still spent.
+    #
+    # `continue_rounds` is how a resume avoids colliding with the chunk before
+    # it. Step 8 keeps no round counter of its own — a resumed run only knows
+    # which tasks are already done — so the round is read off the ledger's size.
+    cost_ledger_path = out_path.with_name(out_path.stem + ".cost_ledger.sqlite3")
+    cost_export_path = out_path.with_name(out_path.stem + ".cost_ledger.jsonl")
+    cost_recorder, cost_ledger_note = open_cost_recorder(
+        cost_ledger_path,
+        run_id=f"{args.experiment_yaml_name}|{config_hash}|{grader_source_hash}",
+        continue_rounds=True,
+    )
+    if cost_ledger_note:
+        print(f"[cost] {cost_ledger_note}", file=sys.stderr)
+
+    def cost_ledger_pointer() -> dict[str, str] | None:
+        """Export the ledger and return the pointer a saved grade carries.
+
+        Called at each save rather than once at the end, because a partial is a
+        published result too and its pointer has to match the ledger as it
+        stood when that partial was written. A failed export returns ``None``:
+        a grade that cannot point at its own audit trail says so, instead of
+        carrying a digest of something else.
+        """
+        if cost_recorder is None:
+            return None
+        try:
+            digest = cost_recorder.ledger.export_jsonl(cost_export_path)
+        except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+            print(
+                f"[cost] ledger export failed ({type(exc).__name__})",
+                file=sys.stderr,
+            )
+            return None
+        return ledger_reference(cost_export_path.name, digest)
+
+    def grading_receipt(task_id: str) -> dict:
+        """This task's grading receipt, or an explicit reason there is none.
+
+        ``when_empty`` is ``complete`` on purpose. Reaching this line means the
+        task *was* graded; a task graded entirely by rule, with no judge call
+        at all, really did cost nothing, and that is the one honest ``$0``. A
+        run with no ledger is the other case and reports ``unavailable``.
+        """
+        if cost_recorder is None:
+            return CostReceipt.unavailable().as_dict()
+        return cost_recorder.receipt_for(
+            task_id, BUCKET_GRADING, when_empty=STATUS_COMPLETE
+        ).as_dict()
+
     try:
         config["_runtime"] = {
             "experiment_id": args.experiment_yaml_name,
             "rubric_sha": loader.rubric_sha,
             "azure_ai_runtime_fingerprint": primary_runtime_fingerprint,
         }
-        grader = Grader(config=config, rubric_loader=loader)
+        grader = Grader(
+            config=config, rubric_loader=loader, cost_recorder=cost_recorder
+        )
     except BaseException as exc:
         print(
             "ERROR: judge initialization failed: "
             f"{public_provider_error_text(exc)}",
             file=sys.stderr,
         )
+        if cost_recorder is not None:
+            cost_recorder.ledger.close()
         return 4
 
     def close_grader() -> None:
@@ -2111,6 +2193,16 @@ def main() -> int:
                 f"{public_provider_error_text(exc)}",
                 file=sys.stderr,
             )
+        # After the judge, never before: closing the ledger first would leave
+        # a client that is still being shut down writing to a closed database.
+        if cost_recorder is not None:
+            try:
+                cost_recorder.ledger.close()
+            except BaseException as exc:
+                print(
+                    f"ERROR: cost ledger cleanup failed: {type(exc).__name__}",
+                    file=sys.stderr,
+                )
 
     grader_exit_cleanup = atexit.register(close_grader)
 
@@ -2204,6 +2296,7 @@ def main() -> int:
                     exp_config=exp_config,
                     source_experiment_id=args.source_experiment_id,
                     renderer_fingerprint=renderer_fingerprint,
+                    cost_ledger=cost_ledger_pointer(),
                 )
                 _validate_schema(partial)
                 _save_json(out_path, partial)
@@ -2228,6 +2321,11 @@ def main() -> int:
             grade,
             grading_wall_time_ms=grading_wall_time_ms,
         )
+        # Stamped here, once, while this task's calls are the newest in the
+        # ledger — not recomputed at save time. A resumed chunk loads the
+        # earlier chunk's rows verbatim, so what an earlier process recorded
+        # for an earlier task stays exactly as that process recorded it.
+        row[BUCKET_GRADING] = grading_receipt(row["task_id"])
         runtime_error = None
         if config.get("schema_version") == "2.0":
             runtime_error = _track2_task_runtime_error(row)
@@ -2260,6 +2358,7 @@ def main() -> int:
                     exp_config=exp_config,
                     source_experiment_id=args.source_experiment_id,
                     renderer_fingerprint=renderer_fingerprint,
+                    cost_ledger=cost_ledger_pointer(),
                 )
                 _validate_schema(diagnostic)
                 _save_json(out_path, diagnostic)
@@ -2300,6 +2399,7 @@ def main() -> int:
                     exp_config=exp_config,
                     source_experiment_id=args.source_experiment_id,
                     renderer_fingerprint=renderer_fingerprint,
+                    cost_ledger=cost_ledger_pointer(),
                 )
                 _validate_schema(partial)
                 _save_json(out_path, partial)
@@ -2334,6 +2434,7 @@ def main() -> int:
         exp_config=exp_config,
         source_experiment_id=args.source_experiment_id,
         renderer_fingerprint=renderer_fingerprint,
+        cost_ledger=cost_ledger_pointer(),
     )
     _validate_schema(final)
     _save_json(out_path, final)

--- a/batch-runner/step9_merge_shards.py
+++ b/batch-runner/step9_merge_shards.py
@@ -89,6 +89,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
 
+from core.cost_receipts import (
+    BUCKET_GRADING,
+    CostReceiptLedger,
+    ledger_reference,
+    verify_export,
+)
 from core.grade_payload import canonical_rate, validate_grade_payload
 from step8_grade import (
     SCHEMA_VERSION,
@@ -487,6 +493,52 @@ def _check_cost_sums(
             )
 
 
+def _check_grading_call_sums(
+    shards: Sequence[dict],
+    labels: Sequence[str],
+    merged_summary: dict,
+) -> None:
+    """Prove no shard's grading receipts were dropped on the way in.
+
+    The merged receipt is recomputed from the merged task rows, so the money
+    in it is only as complete as the rows that survived the merge. Comparing
+    amounts would mean comparing rounded decimals; the call *count* behind
+    them is an integer and sums exactly, which catches the failure that
+    actually matters — a shard whose receipts silently did not arrive.
+
+    A shard that carries no receipt at all is a merge that cannot be checked,
+    and an unchecked merge of a priced run is refused rather than published.
+    """
+    merged_receipt = merged_summary.get(BUCKET_GRADING)
+    if not isinstance(merged_receipt, dict):
+        raise ShardMergeError(
+            "merged summary is missing its grading cost receipt: "
+            f"{_describe(merged_receipt)}"
+        )
+    total = 0
+    for shard, label in zip(shards, labels):
+        receipt = _get_path(shard, ("summary", BUCKET_GRADING))
+        if not isinstance(receipt, dict):
+            raise ShardMergeError(
+                f"{label} summary.{BUCKET_GRADING} is missing: "
+                f"{_describe(receipt)}"
+            )
+        calls = receipt.get("model_calls")
+        if type(calls) is not int:
+            raise ShardMergeError(
+                f"{label} summary.{BUCKET_GRADING}.model_calls must be an "
+                f"integer, got {_describe(calls)}"
+            )
+        total += calls
+    if merged_receipt.get("model_calls") != total:
+        raise ShardMergeError(
+            f"merged summary.{BUCKET_GRADING}.model_calls does not equal the "
+            f"shard sum: recomputed="
+            f"{_describe(merged_receipt.get('model_calls'))}, "
+            f"shard_sum={total}"
+        )
+
+
 def _check_latency_sums(
     shards: Sequence[dict],
     labels: Sequence[str],
@@ -727,6 +779,7 @@ def merge_shard_payloads(
     source_digests: Sequence[str] | None = None,
     expected_task_ids: Sequence[str] | None = None,
     strict_routes: bool = False,
+    cost_ledger: dict[str, str] | None = None,
     warn: Callable[[str], None] | None = None,
 ) -> dict:
     """Merge N partial shard payloads into one final grade payload.
@@ -892,6 +945,7 @@ def merge_shard_payloads(
     summary = _compute_summary(merged_tasks, unpriced_models=unpriced_models)
     _check_cost_sums(shards, labels, summary["cost"])
     _check_latency_sums(shards, labels, summary["cost"])
+    _check_grading_call_sums(shards, labels, summary)
 
     shard_usage_complete = True
     for shard, label in zip(shards, labels):
@@ -963,6 +1017,12 @@ def merge_shard_payloads(
     merged["azure_ai_routes"] = merged_routes
     merged["azure_ai_runtime_fingerprint"] = primary_fingerprint
     merged["graded_at"] = merged_graded_at
+    # Deliberately not adopted from shard 0: each shard pointed at its own
+    # ledger, and the merged result may only point at a ledger that actually
+    # holds every shard's rows. The caller builds that file; ``None`` here
+    # means it could not be built, which is a different claim from a ledger
+    # showing nothing.
+    merged["cost_ledger"] = cost_ledger
     merged["tasks"] = merged_tasks
     merged["summary"] = summary
     merged["shard_provenance"] = [
@@ -1099,6 +1159,77 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def merge_shard_cost_ledgers(
+    shard_paths: Sequence[Path],
+    payloads: Sequence[dict],
+    out_path: Path,
+    *,
+    warn: Callable[[str], None] | None = None,
+) -> dict[str, str] | None:
+    """Fold every shard's grading ledger into one beside the merged grade.
+
+    Each shard pointed at its own audit trail; the merged grade may only point
+    at a file that holds all of them. Records are keyed by identifier, so a
+    file folded in twice adds nothing, and a record arriving with figures that
+    contradict one already held raises rather than overwriting.
+
+    Returns ``None`` — and says why — whenever the merged ledger would be
+    partial: a shard with no pointer, a pointer whose file is gone, or a file
+    that no longer matches the digest its shard published. A merged trail that
+    quietly omits a shard reads as though that shard had spent nothing, which
+    is exactly the reading this whole mechanism exists to prevent. The per-task
+    receipts are unaffected; they travel in the rows.
+    """
+    emit = warn if warn is not None else (
+        lambda message: print(f"WARNING: {message}", file=sys.stderr)
+    )
+
+    exports: list[Path] = []
+    for shard_path, payload in zip(shard_paths, payloads):
+        pointer = payload.get("cost_ledger")
+        if not isinstance(pointer, dict):
+            emit(
+                f"{shard_path} carries no cost ledger pointer; the merged "
+                "grade will not claim one."
+            )
+            return None
+        export = shard_path.with_name(str(pointer.get("path") or ""))
+        if not export.is_file():
+            emit(
+                f"{shard_path} points at a cost ledger that is not beside it "
+                f"({export.name}); the merged grade will not claim one."
+            )
+            return None
+        if not verify_export(export, str(pointer.get("sha256") or "")):
+            emit(
+                f"{export.name} does not match the digest {shard_path} "
+                "published for it; the merged grade will not claim one."
+            )
+            return None
+        exports.append(export)
+
+    if not exports:
+        return None
+
+    merged_db = out_path.with_name(out_path.stem + ".cost_ledger.sqlite3")
+    merged_export = out_path.with_name(out_path.stem + ".cost_ledger.jsonl")
+    try:
+        ledger = CostReceiptLedger(merged_db, run_id=out_path.stem)
+    except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+        emit(f"merged cost ledger could not be opened ({type(exc).__name__})")
+        return None
+    try:
+        for export in exports:
+            ledger.import_jsonl(export)
+        digest = ledger.export_jsonl(merged_export)
+    except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+        emit(f"merged cost ledger could not be written ({type(exc).__name__})")
+        return None
+    finally:
+        ledger.close()
+    return ledger_reference(merged_export.name, digest)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
 
@@ -1145,6 +1276,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_digests=[digest for _, digest in loaded],
             expected_task_ids=explicit_ids,
             strict_routes=args.strict_routes,
+            cost_ledger=merge_shard_cost_ledgers(
+                shard_paths,
+                [payload for payload, _ in loaded],
+                out_path,
+            ),
         )
     except ShardMergeIncomplete as exc:
         if args.defer_if_incomplete:

--- a/batch-runner/tests/test_azure_ai_step2_wiring.py
+++ b/batch-runner/tests/test_azure_ai_step2_wiring.py
@@ -56,6 +56,21 @@ def _planned_fingerprint(workload, deployment):
     ).hexdigest()
 
 
+def _unmetered(client):
+    """Look through the cost-metering wrapper at the client it stands for.
+
+    Step 2 hands out every provider client already wrapped, so that each call
+    records what it cost. The wrapper forwards everything and changes nothing
+    about *which* client is *which* — which is what the assertions below are
+    for. So they check the wrapper is present, then look through it, and the
+    routing claim they always made is unchanged.
+    """
+    assert getattr(client, "_is_cost_metered", False), (
+        "Step 2 must hand out metered clients"
+    )
+    return client.inner
+
+
 def _checkpoint_success(task_id="task-1"):
     return {
         "task_id": task_id,
@@ -469,7 +484,7 @@ def test_profile_absent_keeps_legacy_client_and_output_shape(monkeypatch, tmp_pa
         "azure",
         {"endpoint": "https://legacy.invalid/"},
     )]
-    assert created["executors"][0].kwargs["llm_client"] is raw_client
+    assert _unmetered(created["executors"][0].kwargs["llm_client"]) is raw_client
     assert "redact_provider_errors" not in created["executors"][0].kwargs
     assert "azure_ai_routes" not in output
     assert "azure_ai_routes" not in json.loads(
@@ -661,7 +676,7 @@ def test_requested_profile_with_native_only_workload_uses_no_typed_resources(
     assert provider_calls == ["openai"]
     assert created["managed"] == []
     assert created["factories"] == []
-    assert created["executors"][0].kwargs["llm_client"] is native
+    assert _unmetered(created["executors"][0].kwargs["llm_client"]) is native
     assert events == [
         "preflight:workloads",
         "create:executor",
@@ -694,8 +709,9 @@ def test_typed_clients_share_factory_and_reach_exact_executor_slots(
     executor = created["executors"][0]
     main = created["managed"][0]
     assert created["factories"][0].settings is settings
-    assert isinstance(executor.kwargs["llm_client"], step2._RedactedAzureAIClient)
-    assert executor.kwargs["llm_client"]._target is main
+    main_proxy = _unmetered(executor.kwargs["llm_client"])
+    assert isinstance(main_proxy, step2._RedactedAzureAIClient)
+    assert main_proxy._target is main
     assert all(
         managed.factory is created["factories"][0]
         for managed in created["managed"]
@@ -703,7 +719,7 @@ def test_typed_clients_share_factory_and_reach_exact_executor_slots(
     if mode == "code_interpreter":
         assert executor.kwargs["redact_provider_errors"] is True
         ci_client = created["managed"][1]
-        assert executor.kwargs["code_interpreter_client"] is ci_client
+        assert _unmetered(executor.kwargs["code_interpreter_client"]) is ci_client
         assert [event for event in events if event.startswith("close:")] == [
             "close:executor",
             "close:code-interpreter:main-model",
@@ -832,10 +848,10 @@ def test_typed_self_qa_uses_distinct_verified_wrapper_and_closes_in_order(
 
     main_client, qa_client = created["managed"]
     assert qa_client is not main_client
-    main_proxy = created["executors"][0].kwargs["llm_client"]
+    main_proxy = _unmetered(created["executors"][0].kwargs["llm_client"])
     assert isinstance(main_proxy, step2._RedactedAzureAIClient)
     assert main_proxy._target is main_client
-    assert qa_clients == [qa_client]
+    assert [_unmetered(seen) for seen in qa_clients] == [qa_client]
     assert main_client.runtime_fingerprint == qa_client.runtime_fingerprint
     assert [event for event in events if event.startswith("close:")] == [
         "close:executor",
@@ -1023,7 +1039,7 @@ def test_native_main_with_azure_preprocessor_executor_init_error_preserves_detai
 
     def _fail_executor(**kwargs):
         events.append("create:executor")
-        assert kwargs["llm_client"] is native_client
+        assert _unmetered(kwargs["llm_client"]) is native_client
         raise RuntimeError(detail)
 
     monkeypatch.setattr(step2, "TaskExecutor", _fail_executor)
@@ -1403,7 +1419,7 @@ def test_native_main_with_azure_preprocessor_uses_both_paths(
     _run()
 
     assert provider_calls == ["openai"]
-    assert created["executors"][0].kwargs["llm_client"] is native
+    assert _unmetered(created["executors"][0].kwargs["llm_client"]) is native
     assert created["executors"][0].execute_calls[0]["model"] == "  native-main  "
     assert [client.name for client in created["managed"]] == [
         "inference:probe-model"
@@ -1466,7 +1482,7 @@ def test_native_main_with_azure_preprocessor_preserves_local_failure_detail(
     final = json.loads(
         (workspace / "step2_inference_results_condition_a.json").read_text()
     )
-    assert created["executors"][0].kwargs["llm_client"] is native
+    assert _unmetered(created["executors"][0].kwargs["llm_client"]) is native
     assert "redact_provider_errors" not in created["executors"][0].kwargs
     expected = "task_execution_error:TaskExecutionError"
     assert progress["results"][0]["error"] == expected
@@ -1611,7 +1627,7 @@ def test_typed_whitespace_deployments_use_exact_canonical_runtime_strings(
     qa_calls = []
 
     def _complete(client, model, messages, **kwargs):
-        qa_calls.append((client, model, kwargs))
+        qa_calls.append((_unmetered(client), model, kwargs))
         return (
             SimpleNamespace(
                 choices=[SimpleNamespace(

--- a/batch-runner/tests/test_cost_metering_records_what_the_client_sent.py
+++ b/batch-runner/tests/test_cost_metering_records_what_the_client_sent.py
@@ -1,0 +1,442 @@
+"""The wrapper: what the client actually sent is what gets recorded.
+
+Instrumentation that reads its numbers from anywhere but the provider's own
+reply is guessing. These tests drive the wrapper with stand-in clients of each
+API shape the pipeline meets, and check that the row written afterwards says
+what the reply said — including when the reply says nothing.
+
+No provider is contacted. Every client here is local and returns a fixed
+object.
+"""
+
+import json
+from decimal import Decimal
+
+import pytest
+
+from core.cost_metering import (
+    Attribution,
+    CostRecorder,
+    extract_usage,
+    resolved_model_of,
+)
+from core.cost_receipts import (
+    BUCKET_GRADING,
+    BUCKET_PROBLEM_SOLVING,
+    REASON_CALL_REACHABILITY_UNKNOWN,
+    RETRY_SEMANTIC,
+    STAGE_GENERATION,
+    STAGE_GRADING,
+    STAGE_PERCEPTION,
+    STAGE_SELF_QA,
+    STATUS_COMPLETE,
+    STATUS_PARTIAL,
+    CostReceiptLedger,
+    load_receipt_price_table,
+)
+
+PRICE_TABLE = {
+    "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+    "providers": {
+        "azure:test-model": {
+            "input_usd_per_million": "10",
+            "cached_input_usd_per_million": "1",
+            "output_usd_per_million": "20",
+            "reasoning_billed_as": "output",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        }
+    },
+    "runtime": {},
+}
+
+
+@pytest.fixture
+def price_table(tmp_path):
+    path = tmp_path / "prices.json"
+    path.write_text(json.dumps(PRICE_TABLE), encoding="utf-8")
+    return load_receipt_price_table(path)
+
+
+@pytest.fixture
+def recorder(tmp_path, price_table):
+    with CostReceiptLedger(
+        tmp_path / "cost.sqlite3", run_id="run-1", price_table=price_table
+    ) as ledger:
+        yield CostRecorder(ledger)
+
+
+# ── stand-in clients ─────────────────────────────────────────────────────
+
+
+class _Bag:
+    """An object whose attributes are whatever it was handed."""
+
+    def __init__(self, **fields):
+        for name, value in fields.items():
+            setattr(self, name, value)
+
+
+def _chat_reply(prompt=100_000, completion=10_000, cached=None, reasoning=None):
+    """The Chat Completions shape."""
+    usage = _Bag(prompt_tokens=prompt, completion_tokens=completion)
+    if cached is not None:
+        usage.prompt_tokens_details = _Bag(cached_tokens=cached)
+    if reasoning is not None:
+        usage.completion_tokens_details = _Bag(reasoning_tokens=reasoning)
+    return _Bag(model="test-model", usage=usage)
+
+
+def _responses_reply(input_tokens=100_000, output_tokens=10_000, cached=None):
+    """The Responses shape."""
+    usage = _Bag(input_tokens=input_tokens, output_tokens=output_tokens)
+    if cached is not None:
+        usage.input_tokens_details = _Bag(cached_tokens=cached)
+    return _Bag(model="test-model", usage=usage)
+
+
+class FakeClient:
+    """Answers on all three surfaces the pipeline uses."""
+
+    def __init__(self, reply=None, *, raises=None):
+        self._reply = reply if reply is not None else _chat_reply()
+        self._raises = raises
+        self.seen: list[dict] = []
+        self.chat = _Bag(completions=_Bag(create=self._create))
+        self.responses = _Bag(create=self._create)
+        self.api_version = "2026-01-01"
+
+    def _create(self, **kwargs):
+        self.seen.append(kwargs)
+        if self._raises is not None:
+            raise self._raises
+        return self._reply
+
+    def chat_complete(self, **kwargs):
+        return self._create(**kwargs)
+
+    def close(self):
+        self.closed = True
+
+
+# ── the three surfaces ───────────────────────────────────────────────────
+
+
+def test_a_chat_completion_writes_the_row_the_reply_supports(recorder):
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(model="a-deployment", messages=[])
+
+    receipt = recorder.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_COMPLETE
+    assert receipt.model_calls == 1
+    assert receipt.estimated_cost_usd == Decimal("1.20")
+
+
+def test_a_responses_call_writes_the_same_kind_of_row(recorder):
+    client = recorder.meter(
+        FakeClient(reply=_responses_reply()), provider="azure"
+    )
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.responses.create(model="a-deployment", input="hello")
+
+    receipt = recorder.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.estimated_cost_usd == Decimal("1.20")
+
+
+def test_the_normalised_entry_point_is_metered_too(recorder):
+    """Non-OpenAI providers reach the model through ``chat_complete``."""
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat_complete(model="a-deployment", messages=[])
+
+    assert recorder.receipt_for(
+        "task-a", BUCKET_PROBLEM_SOLVING
+    ).model_calls == 1
+
+
+def test_the_wrapper_passes_the_request_through_unchanged(recorder):
+    """Metering must not alter what the provider is asked."""
+    inner = FakeClient()
+    client = recorder.meter(inner, provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(
+            model="a-deployment", messages=[{"role": "user"}], temperature=0.2
+        )
+
+    assert inner.seen == [
+        {
+            "model": "a-deployment",
+            "messages": [{"role": "user"}],
+            "temperature": 0.2,
+        }
+    ]
+
+
+def test_everything_else_on_the_client_still_works(recorder):
+    """The wrapper has to stand in wherever the real client stood."""
+    inner = FakeClient()
+    client = recorder.meter(inner, provider="azure")
+
+    client.close()
+
+    assert client.api_version == "2026-01-01"
+    assert client.inner is inner
+    assert client.provider == "azure"
+    assert inner.closed is True
+
+
+# ── attribution ──────────────────────────────────────────────────────────
+
+
+def test_a_call_outside_any_task_scope_is_not_filed_under_one(recorder):
+    """Report writing belongs to neither pipeline; it gets no home."""
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    reply = client.chat.completions.create(model="a-deployment", messages=[])
+
+    assert reply is not None
+    assert recorder.ledger.task_ids() == []
+
+
+def test_calls_land_in_the_stage_that_was_in_scope(recorder):
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(model="a-deployment", messages=[])
+    with recorder.attributed(
+        task_id="task-a", stage=STAGE_SELF_QA, retry_kind=RETRY_SEMANTIC
+    ):
+        client.chat.completions.create(model="a-deployment", messages=[])
+
+    receipt = recorder.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert {component.stage for component in receipt.components} == {
+        STAGE_GENERATION,
+        STAGE_SELF_QA,
+    }
+    assert receipt.estimated_cost_usd == Decimal("2.40")
+
+
+def test_a_nested_scope_returns_to_the_one_around_it(recorder):
+    """A perception read during marking is its own component, not a takeover."""
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GRADING):
+        client.chat.completions.create(model="a-deployment", messages=[])
+        with recorder.attributed(task_id="task-a", stage=STAGE_PERCEPTION):
+            client.chat.completions.create(model="a-deployment", messages=[])
+        client.chat.completions.create(model="a-deployment", messages=[])
+
+    receipt = recorder.receipt_for("task-a", BUCKET_GRADING)
+    by_stage = {
+        component.stage: component.model_calls for component in receipt.components
+    }
+
+    assert by_stage == {STAGE_GRADING: 2, STAGE_PERCEPTION: 1}
+    assert recorder.receipt_for("task-a", BUCKET_PROBLEM_SOLVING).model_calls == 0
+
+
+def test_two_calls_in_one_scope_are_two_rows_not_one(recorder):
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(model="a-deployment", messages=[])
+        client.chat.completions.create(model="a-deployment", messages=[])
+
+    rows = recorder.ledger.calls_for("task-a")
+
+    assert len({row["call_id"] for row in rows}) == 2
+
+
+def test_a_stage_nobody_defined_is_refused_at_the_boundary(recorder):
+    with pytest.raises(ValueError):
+        Attribution(task_id="task-a", stage="invoicing")
+
+
+def test_a_call_that_belongs_to_no_task_is_refused(recorder):
+    with pytest.raises(ValueError):
+        Attribution(task_id="", stage=STAGE_GENERATION)
+
+
+# ── failure ──────────────────────────────────────────────────────────────
+
+
+def test_a_call_that_raised_leaves_the_receipt_open(recorder):
+    """A timeout may have been served and billed. It is not written off."""
+    client = recorder.meter(
+        FakeClient(raises=TimeoutError("no reply")), provider="azure"
+    )
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        with pytest.raises(TimeoutError):
+            client.chat.completions.create(model="a-deployment", messages=[])
+
+    receipt = recorder.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_PARTIAL
+    assert REASON_CALL_REACHABILITY_UNKNOWN in receipt.missing_reasons
+    assert receipt.estimated_cost_usd is None
+    assert receipt.model_calls == 1
+
+
+def test_a_failure_known_to_predate_the_request_is_written_off(recorder):
+    """Only a caller that knows nothing left the process may say so."""
+    client = recorder.meter(
+        FakeClient(raises=ValueError("prompt too long to build")),
+        provider="azure",
+    )
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        with pytest.raises(ValueError):
+            client.chat.completions.create(model="a-deployment", messages=[])
+        recorder.abandon_call(client.last_call_id, note="request never built")
+
+    receipt = recorder.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_COMPLETE
+    assert receipt.model_calls == 0
+    assert receipt.estimated_cost_usd == Decimal(0)
+
+
+# ── reading the reply ────────────────────────────────────────────────────
+
+
+def test_usage_is_read_from_the_chat_shape():
+    usage = extract_usage(
+        _chat_reply(prompt=500, completion=60, cached=100, reasoning=40)
+    )
+
+    assert usage.input_tokens == 500
+    assert usage.output_tokens == 60
+    assert usage.cached_input_tokens == 100
+    assert usage.reasoning_tokens == 40
+
+
+def test_usage_is_read_from_the_responses_shape():
+    usage = extract_usage(_responses_reply(500, 60, cached=100))
+
+    assert usage.input_tokens == 500
+    assert usage.output_tokens == 60
+    assert usage.cached_input_tokens == 100
+
+
+def test_usage_is_read_from_a_plain_dictionary():
+    """Some providers are normalised into dicts before they get here."""
+    usage = extract_usage(
+        {
+            "usage": {
+                "prompt_tokens": 500,
+                "completion_tokens": 60,
+                "cached_tokens": 100,
+            }
+        }
+    )
+
+    assert usage.input_tokens == 500
+    assert usage.cached_input_tokens == 100
+
+
+def test_a_reply_with_no_usage_reports_nothing_rather_than_zero():
+    usage = extract_usage(_Bag(model="test-model"))
+
+    assert usage.is_empty
+    assert usage.input_tokens is None
+    assert usage.output_tokens is None
+
+
+def test_a_field_the_provider_omitted_stays_absent():
+    """Absent is not zero, and the difference decides the receipt's status."""
+    usage = extract_usage(_chat_reply(prompt=500, completion=60))
+
+    assert usage.input_tokens == 500
+    assert usage.cached_input_tokens is None
+    assert usage.reasoning_tokens is None
+
+
+def test_a_flag_arriving_where_a_count_belongs_is_not_read_as_one():
+    """``True`` is an ``int`` in Python. It is not one token."""
+    usage = extract_usage({"usage": {"prompt_tokens": True, "completion_tokens": 5}})
+
+    assert usage.input_tokens is None
+    assert usage.output_tokens == 5
+
+
+def test_a_negative_count_is_not_believed():
+    usage = extract_usage({"usage": {"prompt_tokens": -5, "completion_tokens": 5}})
+
+    assert usage.input_tokens is None
+
+
+def test_the_reply_names_the_model_that_is_priced():
+    assert resolved_model_of(_Bag(model="what-answered"), "what-was-asked") == (
+        "what-answered"
+    )
+
+
+def test_a_reply_that_names_no_model_falls_back_to_the_request():
+    assert resolved_model_of(_Bag(), "what-was-asked") == "what-was-asked"
+    assert resolved_model_of(_Bag(model="   "), "what-was-asked") == (
+        "what-was-asked"
+    )
+
+
+def test_the_deployment_alias_is_kept_beside_the_model_that_answered(recorder):
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(model="a-deployment", messages=[])
+
+    row = recorder.ledger.calls_for("task-a")[0]
+
+    assert row["requested_model"] == "a-deployment"
+    assert row["resolved_model"] == "test-model"
+
+
+# ── paths that own their transport ───────────────────────────────────────
+
+
+def test_a_call_made_elsewhere_can_still_be_filed(recorder):
+    """For the paths that cannot be wrapped, but do hold a reply."""
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        call_id = recorder.record_call(
+            provider="azure",
+            requested_model="a-deployment",
+            response=_chat_reply(),
+        )
+
+    receipt = recorder.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert call_id is not None
+    assert receipt.estimated_cost_usd == Decimal("1.20")
+
+
+def test_filing_a_call_with_no_task_in_scope_files_nothing(recorder):
+    call_id = recorder.record_call(
+        provider="azure", requested_model="a-deployment", response=_chat_reply()
+    )
+
+    assert call_id is None
+    assert recorder.ledger.task_ids() == []
+
+
+def test_a_default_model_covers_a_request_that_names_none(recorder):
+    """Some call sites set the deployment on the client, not the request."""
+    client = recorder.meter(
+        FakeClient(), provider="azure", model="a-default-deployment"
+    )
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(messages=[])
+
+    assert recorder.ledger.calls_for("task-a")[0]["requested_model"] == (
+        "a-default-deployment"
+    )

--- a/batch-runner/tests/test_cost_receipts_keep_every_call_that_happened.py
+++ b/batch-runner/tests/test_cost_receipts_keep_every_call_that_happened.py
@@ -15,12 +15,15 @@ import pytest
 from core.cost_receipts import (
     BUCKET_GRADING,
     BUCKET_PROBLEM_SOLVING,
+    COMPONENT_NAMES,
+    COMPONENT_RETRY,
     REASON_CALL_REACHABILITY_UNKNOWN,
     RETRY_INFRASTRUCTURE,
     RETRY_NONE,
     RETRY_SEMANTIC,
     STAGE_GENERATION,
     STAGE_GRADING,
+    STAGE_SELF_QA,
     STATUS_COMPLETE,
     STATUS_PARTIAL,
     CallUsage,
@@ -143,6 +146,133 @@ def test_a_regenerated_answer_does_not_erase_what_the_first_one_cost(ledger):
         RETRY_NONE,
         RETRY_SEMANTIC,
     }
+
+
+# ── the name a reader shows for each line ────────────────────────────────
+#
+# ``(stage, retry_kind)`` is the honest shape, but a breakdown with one row per
+# line needs one word. Deriving it here rather than leaving each reader to
+# invent its own is what keeps two displays of the same receipt from disagreeing
+# about what a line is called.
+
+
+def test_every_line_is_named_from_the_published_vocabulary(ledger):
+    for sequence, (stage, retry_kind) in enumerate((
+        (STAGE_GENERATION, RETRY_NONE),
+        (STAGE_GENERATION, RETRY_SEMANTIC),
+        (STAGE_SELF_QA, RETRY_NONE),
+    )):
+        _spend(
+            ledger,
+            "task-a",
+            stage=stage,
+            retry_kind=retry_kind,
+            sequence=sequence,
+            usage=_usage(),
+        )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.components
+    assert all(
+        component.name in COMPONENT_NAMES for component in receipt.components
+    )
+    assert all(
+        entry["name"] in COMPONENT_NAMES
+        for entry in receipt.as_dict()["components"]
+    )
+
+
+def test_first_work_is_named_for_its_stage_and_a_repeat_is_named_retry(ledger):
+    """"What did retrying cost" is the question, so retries share a name.
+
+    Which stage a retry belonged to is not lost — ``stage`` sits on the same
+    line — but a reader that shows one row per name gets the answer without
+    having to sum across rows itself.
+    """
+    for sequence, (stage, retry_kind) in enumerate((
+        (STAGE_GENERATION, RETRY_NONE),
+        (STAGE_GENERATION, RETRY_SEMANTIC),
+        (STAGE_SELF_QA, RETRY_INFRASTRUCTURE),
+    )):
+        _spend(
+            ledger,
+            "task-a",
+            stage=stage,
+            retry_kind=retry_kind,
+            sequence=sequence,
+            usage=_usage(),
+        )
+
+    by_name: dict[str, list] = {}
+    for component in ledger.receipt_for(
+        "task-a", BUCKET_PROBLEM_SOLVING
+    ).components:
+        by_name.setdefault(component.name, []).append(component)
+
+    assert set(by_name) == {STAGE_GENERATION, COMPONENT_RETRY}
+    # Both retries land on the one name, and each still says which stage it
+    # was a retry of.
+    assert {
+        component.stage for component in by_name[COMPONENT_RETRY]
+    } == {STAGE_GENERATION, STAGE_SELF_QA}
+
+
+def test_a_runtime_fee_does_not_become_a_line_that_gets_counted_twice(tmp_path):
+    """Runtime is reported once, as its own field, and never as a line.
+
+    A reader that sums the lines and then adds ``runtime_cost_usd`` — the
+    obvious way to show a breakdown and a total together — would charge the
+    container twice if it appeared in both.
+
+    This one builds its own ledger: the price list shared by the rest of the
+    file prices no runtime at all, which would leave the fee unpriced and prove
+    nothing about where a priced fee lands.
+    """
+    path = tmp_path / "with-runtime.json"
+    path.write_text(
+        json.dumps({
+            **PRICE_TABLE,
+            "runtime": {
+                "own-container": {
+                    "usd_per_hour": "3.60",
+                    "attribution": "per_task",
+                    "source": "fixture",
+                    "last_reviewed": "2026-08-28",
+                    "currency": "USD",
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+    with CostReceiptLedger(
+        tmp_path / "runtime.sqlite3",
+        run_id="run-1",
+        price_table=load_receipt_price_table(path),
+    ) as ledger:
+        _spend(
+            ledger,
+            "task-a",
+            stage=STAGE_GENERATION,
+            retry_kind=RETRY_NONE,
+            sequence=0,
+            usage=_usage(),
+        )
+        ledger.record_runtime_cost(
+            entry_id="task-a:own",
+            task_id="task-a",
+            bucket=BUCKET_PROBLEM_SOLVING,
+            runtime_kind="own-container",
+            seconds=3600,
+        )
+        receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.runtime_cost_usd == Decimal("3.60")
+    assert "runtime" not in {component.name for component in receipt.components}
+    assert sum(
+        (component.known_cost_usd for component in receipt.components),
+        Decimal(0),
+    ) == receipt.model_cost_usd
 
 
 def test_settling_the_same_call_twice_bills_it_once(ledger):

--- a/batch-runner/tests/test_cost_receipts_keep_every_call_that_happened.py
+++ b/batch-runner/tests/test_cost_receipts_keep_every_call_that_happened.py
@@ -1,0 +1,416 @@
+"""The ledger's promise: a call that happened stays recorded.
+
+Costs are not the record of what worked. A task that failed after four
+attempts was billed for four attempts, and a run that threw its first answer
+away and generated a second one paid for both. These tests hold the ledger to
+that — and to the other half of the promise, that a call which never left the
+process is not charged for.
+"""
+
+import json
+from decimal import Decimal
+
+import pytest
+
+from core.cost_receipts import (
+    BUCKET_GRADING,
+    BUCKET_PROBLEM_SOLVING,
+    REASON_CALL_REACHABILITY_UNKNOWN,
+    RETRY_INFRASTRUCTURE,
+    RETRY_NONE,
+    RETRY_SEMANTIC,
+    STAGE_GENERATION,
+    STAGE_GRADING,
+    STATUS_COMPLETE,
+    STATUS_PARTIAL,
+    CallUsage,
+    CostReceiptLedger,
+    LedgerIntegrityError,
+    load_receipt_price_table,
+    make_call_id,
+    verify_export,
+)
+
+PRICE_TABLE = {
+    "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+    "providers": {
+        "azure:test-model": {
+            "input_usd_per_million": "10",
+            "cached_input_usd_per_million": "1",
+            "output_usd_per_million": "20",
+            "reasoning_billed_as": "output",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        }
+    },
+    "runtime": {},
+}
+
+
+@pytest.fixture
+def price_table(tmp_path):
+    path = tmp_path / "prices.json"
+    path.write_text(json.dumps(PRICE_TABLE), encoding="utf-8")
+    return load_receipt_price_table(path)
+
+
+@pytest.fixture
+def ledger(tmp_path, price_table):
+    with CostReceiptLedger(
+        tmp_path / "cost.sqlite3", run_id="run-1", price_table=price_table
+    ) as opened:
+        yield opened
+
+
+def _spend(ledger, task_id, *, stage, retry_kind, sequence, usage=None):
+    call_id = make_call_id(
+        run_id=ledger.run_id,
+        task_id=task_id,
+        stage=stage,
+        retry_kind=retry_kind,
+        attempt_index=0,
+        sequence=sequence,
+    )
+    ledger.reserve(
+        call_id=call_id,
+        task_id=task_id,
+        stage=stage,
+        retry_kind=retry_kind,
+        provider="azure",
+        requested_model="test-deployment",
+    )
+    if usage is not None:
+        ledger.settle(call_id, usage=usage, resolved_model="test-model")
+    return call_id
+
+
+def _usage(input_tokens=100_000, output_tokens=10_000, cached=0):
+    return CallUsage(
+        input_tokens=input_tokens,
+        cached_input_tokens=cached,
+        output_tokens=output_tokens,
+        reasoning_tokens=0,
+    )
+
+
+def test_a_task_that_failed_still_shows_what_it_cost(ledger):
+    """Four attempts, no usable answer, and a bill for all four."""
+    for sequence in range(4):
+        _spend(
+            ledger,
+            "task-a",
+            stage=STAGE_GENERATION,
+            retry_kind=RETRY_NONE if sequence == 0 else RETRY_INFRASTRUCTURE,
+            sequence=sequence,
+            usage=_usage(),
+        )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_COMPLETE
+    assert receipt.model_calls == 4
+    # 100k in at $10/M plus 10k out at $20/M is $1.20 a call.
+    assert receipt.estimated_cost_usd == Decimal("4.80")
+
+
+def test_a_regenerated_answer_does_not_erase_what_the_first_one_cost(ledger):
+    """The discarded attempt is still on the bill."""
+    _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(),
+    )
+    first = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_SEMANTIC,
+        sequence=0,
+        usage=_usage(),
+    )
+    second = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert second.known_cost_usd == first.known_cost_usd * 2
+    assert second.model_calls == 2
+    assert {component.retry_kind for component in second.components} == {
+        RETRY_NONE,
+        RETRY_SEMANTIC,
+    }
+
+
+def test_settling_the_same_call_twice_bills_it_once(ledger):
+    """A retried write must not double the bill."""
+    call_id = _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(),
+    )
+    ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.model_calls == 1
+    assert receipt.estimated_cost_usd == Decimal("1.20")
+
+
+def test_settling_the_same_call_with_different_numbers_is_refused(ledger):
+    """Two beliefs about one call's cost is a fault, not a merge."""
+    call_id = _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(),
+    )
+
+    with pytest.raises(LedgerIntegrityError):
+        ledger.settle(
+            call_id, usage=_usage(input_tokens=999), resolved_model="test-model"
+        )
+
+
+def test_a_call_that_never_left_the_process_costs_nothing(ledger):
+    """Failing to build a request is not spending money."""
+    call_id = _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+    )
+    ledger.abandon(call_id, note="prompt could not be assembled")
+    _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_INFRASTRUCTURE,
+        sequence=0,
+        usage=_usage(),
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_COMPLETE
+    assert receipt.model_calls == 1
+    assert receipt.estimated_cost_usd == Decimal("1.20")
+
+
+def test_an_abandoned_call_cannot_later_report_usage(ledger):
+    """Recording a call as never sent is a claim, and it has to stay true."""
+    call_id = _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+    )
+    ledger.abandon(call_id)
+
+    with pytest.raises(LedgerIntegrityError):
+        ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+
+
+def test_a_settled_call_cannot_later_be_called_unsent(ledger):
+    call_id = _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(),
+    )
+
+    with pytest.raises(LedgerIntegrityError):
+        ledger.abandon(call_id)
+
+
+def test_a_call_that_was_never_reserved_cannot_be_settled(ledger):
+    """Settlement without a reservation means a call went out unrecorded."""
+    with pytest.raises(LedgerIntegrityError):
+        ledger.settle("0" * 64, usage=_usage(), resolved_model="test-model")
+
+
+def test_a_request_that_never_came_back_holds_the_receipt_open(ledger):
+    """A timeout may still have been billed, so it is not written off."""
+    _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(),
+    )
+    _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_INFRASTRUCTURE,
+        sequence=0,
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_PARTIAL
+    assert receipt.estimated_cost_usd is None
+    assert REASON_CALL_REACHABILITY_UNKNOWN in receipt.missing_reasons
+    # What is known is still reported — as a floor, not a total.
+    assert receipt.known_cost_usd == Decimal("1.20")
+
+
+def test_the_ledger_records_no_prompt_text(ledger):
+    """The ledger is written to be publishable."""
+    ledger.reserve(
+        call_id="a" * 64,
+        task_id="task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        provider="azure",
+        requested_model="test-deployment",
+        request_sha256="b" * 64,
+    )
+
+    stored = ledger.calls_for("task-a")[0]
+
+    assert stored["request_sha256"] == "b" * 64
+    assert not any(
+        "prompt" in str(key) and key != "request_sha256" for key in stored
+    )
+
+
+def test_a_request_identifier_is_only_accepted_as_a_digest(ledger):
+    with pytest.raises(ValueError):
+        ledger.reserve(
+            call_id="a" * 64,
+            task_id="task-a",
+            stage=STAGE_GENERATION,
+            retry_kind=RETRY_NONE,
+            provider="azure",
+            requested_model="test-deployment",
+            request_sha256="write the prompt here",
+        )
+
+
+def test_an_export_can_be_checked_against_its_published_digest(ledger, tmp_path):
+    _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(),
+    )
+    _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GRADING,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(),
+    )
+
+    export = tmp_path / "cost_ledger.jsonl"
+    digest = ledger.export_jsonl(export)
+
+    assert verify_export(export, digest)
+    assert not verify_export(export, "0" * 64)
+    assert len(export.read_text(encoding="utf-8").strip().splitlines()) == 2
+
+
+def test_two_exports_of_one_ledger_are_byte_identical(ledger, tmp_path):
+    """A digest beside a result only means something if it is reproducible."""
+    for sequence in range(3):
+        _spend(
+            ledger,
+            f"task-{sequence}",
+            stage=STAGE_GENERATION,
+            retry_kind=RETRY_NONE,
+            sequence=sequence,
+            usage=_usage(),
+        )
+
+    first = ledger.export_jsonl(tmp_path / "one.jsonl")
+    second = ledger.export_jsonl(tmp_path / "two.jsonl")
+
+    assert first == second
+
+
+def test_reopening_the_ledger_finds_everything_still_there(tmp_path, price_table):
+    """A crash between rounds must not lose what was already spent."""
+    path = tmp_path / "cost.sqlite3"
+    with CostReceiptLedger(path, run_id="run-1", price_table=price_table) as first:
+        _spend(
+            first,
+            "task-a",
+            stage=STAGE_GENERATION,
+            retry_kind=RETRY_NONE,
+            sequence=0,
+            usage=_usage(),
+        )
+
+    with CostReceiptLedger(path, run_id="run-1", price_table=price_table) as second:
+        receipt = second.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.estimated_cost_usd == Decimal("1.20")
+
+
+def test_reserving_a_call_twice_does_not_reset_what_it_reported(ledger):
+    """A resumed round re-walking its own history must not erase it."""
+    call_id = _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(),
+    )
+    ledger.reserve(
+        call_id=call_id,
+        task_id="task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        provider="azure",
+        requested_model="test-deployment",
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_COMPLETE
+    assert receipt.estimated_cost_usd == Decimal("1.20")
+
+
+def test_grading_calls_do_not_appear_on_the_solving_receipt(ledger):
+    _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(),
+    )
+    _spend(
+        ledger,
+        "task-a",
+        stage=STAGE_GRADING,
+        retry_kind=RETRY_NONE,
+        sequence=0,
+        usage=_usage(input_tokens=200_000),
+    )
+
+    solving = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+    grading = ledger.receipt_for("task-a", BUCKET_GRADING)
+
+    assert solving.model_calls == 1
+    assert grading.model_calls == 1
+    assert solving.estimated_cost_usd == Decimal("1.20")
+    assert grading.estimated_cost_usd == Decimal("2.20")

--- a/batch-runner/tests/test_cost_receipts_never_invent_a_number.py
+++ b/batch-runner/tests/test_cost_receipts_never_invent_a_number.py
@@ -1,0 +1,506 @@
+"""The refusals: where a number cannot be established, none is produced.
+
+Every test here is about the difference between ``0`` and *unknown*. A run
+whose provider returned no usage block, a model nobody has published a price
+for, a container shared by fifty tasks — each of these is a place where a
+plausible number could be produced and where producing one would be a lie
+dressed as a measurement.
+
+The one real ``$0`` also lives here: a marking path that reaches a verdict by
+rule and never calls a model at all.
+"""
+
+import json
+from decimal import Decimal
+
+import pytest
+
+from core.cost_receipts import (
+    BUCKET_GRADING,
+    BUCKET_PROBLEM_SOLVING,
+    REASON_LEDGER_ABSENT,
+    REASON_PRICE_MISSING,
+    REASON_RUNTIME_UNATTRIBUTABLE,
+    REASON_RUNTIME_UNPRICED,
+    REASON_USAGE_ABSENT,
+    REASON_USAGE_PARTIAL,
+    RETRY_NONE,
+    STAGE_GENERATION,
+    STAGE_GRADING,
+    STATUS_COMPLETE,
+    STATUS_NOT_RUN,
+    STATUS_PARTIAL,
+    STATUS_UNAVAILABLE,
+    CallUsage,
+    CostReceipt,
+    CostReceiptLedger,
+    load_receipt_price_table,
+    make_call_id,
+    price_call,
+    summarise_receipts,
+)
+
+PRICE_TABLE = {
+    "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+    "providers": {
+        "azure:cheap-cache": {
+            "input_usd_per_million": "10",
+            "cached_input_usd_per_million": "1",
+            "output_usd_per_million": "20",
+            "reasoning_billed_as": "output",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        },
+        "azure:thinks-on-the-side": {
+            "input_usd_per_million": "10",
+            "cached_input_usd_per_million": "10",
+            "output_usd_per_million": "20",
+            "reasoning_billed_as": "separate",
+            "reasoning_usd_per_million": "40",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        },
+        "azure:unclear-thinker": {
+            "input_usd_per_million": "10",
+            "cached_input_usd_per_million": "10",
+            "output_usd_per_million": "20",
+            "reasoning_billed_as": "unknown",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        },
+    },
+    "runtime": {
+        "own-container": {
+            "usd_per_hour": "3.60",
+            "attribution": "per_task",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+        },
+        "shared-pool": {
+            "usd_per_hour": "7.20",
+            "attribution": "shared",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+        },
+    },
+}
+
+
+@pytest.fixture
+def price_table(tmp_path):
+    path = tmp_path / "prices.json"
+    path.write_text(json.dumps(PRICE_TABLE), encoding="utf-8")
+    return load_receipt_price_table(path)
+
+
+@pytest.fixture
+def ledger(tmp_path, price_table):
+    with CostReceiptLedger(
+        tmp_path / "cost.sqlite3", run_id="run-1", price_table=price_table
+    ) as opened:
+        yield opened
+
+
+def _call(ledger, task_id, *, stage=STAGE_GENERATION, sequence=0):
+    call_id = make_call_id(
+        run_id=ledger.run_id,
+        task_id=task_id,
+        stage=stage,
+        retry_kind=RETRY_NONE,
+        attempt_index=0,
+        sequence=sequence,
+    )
+    ledger.reserve(
+        call_id=call_id,
+        task_id=task_id,
+        stage=stage,
+        retry_kind=RETRY_NONE,
+        provider="azure",
+        requested_model="a-deployment-name",
+    )
+    return call_id
+
+
+# ── missing usage ────────────────────────────────────────────────────────
+
+
+def test_a_reply_with_no_usage_block_is_not_treated_as_free(ledger):
+    call_id = _call(ledger, "task-a")
+    ledger.settle(call_id, usage=CallUsage(), resolved_model="cheap-cache")
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_PARTIAL
+    assert receipt.estimated_cost_usd is None
+    assert REASON_USAGE_ABSENT in receipt.missing_reasons
+    assert receipt.known_cost_usd == Decimal(0)
+    assert receipt.model_calls == 1
+
+
+def test_a_reply_missing_only_its_output_count_is_still_incomplete(ledger):
+    call_id = _call(ledger, "task-a")
+    ledger.settle(
+        call_id,
+        usage=CallUsage(input_tokens=1000, output_tokens=None),
+        resolved_model="cheap-cache",
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_PARTIAL
+    assert REASON_USAGE_PARTIAL in receipt.missing_reasons
+
+
+# ── missing price ────────────────────────────────────────────────────────
+
+
+def test_a_model_with_no_published_price_is_not_priced_from_a_similar_one(ledger):
+    """``cheap-cache-v2`` is not ``cheap-cache``, and is not billed as it."""
+    call_id = _call(ledger, "task-a")
+    ledger.settle(
+        call_id,
+        usage=CallUsage(input_tokens=100_000, output_tokens=10_000),
+        resolved_model="cheap-cache-v2",
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_PARTIAL
+    assert receipt.missing_reasons == (REASON_PRICE_MISSING,)
+    assert receipt.known_cost_usd == Decimal(0)
+    # The usage is still reported. Only the money is withheld.
+    assert receipt.usage["input_tokens"] == 100_000
+
+
+def test_the_model_that_answered_is_priced_not_the_one_that_was_asked_for(ledger):
+    """A deployment alias is a routing detail; the bill names the model."""
+    call_id = _call(ledger, "task-a")
+    ledger.settle(
+        call_id,
+        usage=CallUsage(input_tokens=100_000, output_tokens=10_000, cached_input_tokens=0),
+        resolved_model="cheap-cache",
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_COMPLETE
+    assert ledger.calls_for("task-a")[0]["resolved_model"] == "cheap-cache"
+    assert ledger.calls_for("task-a")[0]["requested_model"] == "a-deployment-name"
+
+
+def test_a_ledger_with_no_price_list_at_all_prices_nothing(tmp_path):
+    with CostReceiptLedger(
+        tmp_path / "cost.sqlite3", run_id="run-1", price_table=None
+    ) as ledger:
+        call_id = _call(ledger, "task-a")
+        ledger.settle(
+            call_id,
+            usage=CallUsage(input_tokens=100, output_tokens=10),
+            resolved_model="cheap-cache",
+        )
+        receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_PARTIAL
+    assert REASON_PRICE_MISSING in receipt.missing_reasons
+
+
+# ── double billing ───────────────────────────────────────────────────────
+
+
+def test_cached_input_is_charged_once_not_twice(price_table):
+    """The provider counts cache hits inside the input it reports."""
+    price = price_table.lookup("azure", "cheap-cache")
+    priced = price_call(
+        price,
+        CallUsage(
+            input_tokens=1_000_000,
+            cached_input_tokens=900_000,
+            output_tokens=0,
+        ),
+    )
+
+    # 100k fresh at $10/M plus 900k cached at $1/M.
+    assert priced.cost_usd == Decimal("1.90")
+    # Not the $10.90 that charging the full input and the cache again gives.
+    assert priced.cost_usd != Decimal("10.90")
+
+
+def test_more_cache_than_input_is_a_contradiction_not_a_bargain(price_table):
+    price = price_table.lookup("azure", "cheap-cache")
+    priced = price_call(
+        price,
+        CallUsage(input_tokens=1000, cached_input_tokens=5000, output_tokens=10),
+    )
+
+    assert priced.cost_usd is None
+    assert REASON_USAGE_PARTIAL in priced.missing_reasons
+
+
+def test_reasoning_inside_the_output_count_is_not_charged_again(price_table):
+    """These tokens are already inside ``output_tokens``."""
+    price = price_table.lookup("azure", "cheap-cache")
+    priced = price_call(
+        price,
+        CallUsage(
+            input_tokens=0,
+            cached_input_tokens=0,
+            output_tokens=100_000,
+            reasoning_tokens=80_000,
+        ),
+    )
+
+    assert priced.cost_usd == Decimal("2.00")
+
+
+def test_reasoning_billed_separately_is_charged_at_its_own_rate(price_table):
+    price = price_table.lookup("azure", "thinks-on-the-side")
+    priced = price_call(
+        price,
+        CallUsage(
+            input_tokens=0,
+            cached_input_tokens=0,
+            output_tokens=100_000,
+            reasoning_tokens=100_000,
+        ),
+    )
+
+    # $2 of output plus $4 of reasoning.
+    assert priced.cost_usd == Decimal("6.00")
+
+
+def test_reasoning_nobody_has_pinned_down_leaves_the_call_unpriced(price_table):
+    price = price_table.lookup("azure", "unclear-thinker")
+    priced = price_call(
+        price,
+        CallUsage(
+            input_tokens=1000,
+            cached_input_tokens=0,
+            output_tokens=1000,
+            reasoning_tokens=500,
+        ),
+    )
+
+    assert priced.cost_usd is None
+    assert REASON_USAGE_PARTIAL in priced.missing_reasons
+
+
+def test_a_model_that_did_no_reasoning_is_unaffected_by_the_unknown_rule(price_table):
+    """Only reasoning that actually happened can be mis-billed."""
+    price = price_table.lookup("azure", "unclear-thinker")
+    priced = price_call(
+        price,
+        CallUsage(
+            input_tokens=1_000_000,
+            cached_input_tokens=0,
+            output_tokens=0,
+            reasoning_tokens=0,
+        ),
+    )
+
+    assert priced.cost_usd == Decimal("10")
+
+
+# ── runtime fees ─────────────────────────────────────────────────────────
+
+
+def test_a_container_started_for_one_task_is_billed_to_that_task(ledger):
+    call_id = _call(ledger, "task-a")
+    ledger.settle(
+        call_id,
+        usage=CallUsage(input_tokens=0, cached_input_tokens=0, output_tokens=0, reasoning_tokens=0),
+        resolved_model="cheap-cache",
+    )
+    ledger.record_runtime_cost(
+        entry_id="task-a:own",
+        task_id="task-a",
+        bucket=BUCKET_PROBLEM_SOLVING,
+        runtime_kind="own-container",
+        seconds=600,
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_COMPLETE
+    # Ten minutes of a $3.60/hour container.
+    assert receipt.runtime_cost_usd == Decimal("0.60")
+    assert receipt.known_cost_usd == receipt.model_cost_usd + receipt.runtime_cost_usd
+
+
+def test_a_shared_pool_is_not_divided_between_the_tasks_that_used_it(ledger):
+    """An invented split reads exactly like a measurement, so none is made."""
+    ledger.record_runtime_cost(
+        entry_id="task-a:pool",
+        task_id="task-a",
+        bucket=BUCKET_PROBLEM_SOLVING,
+        runtime_kind="shared-pool",
+        seconds=3600,
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_PARTIAL
+    assert receipt.runtime_cost_usd == Decimal(0)
+    assert REASON_RUNTIME_UNATTRIBUTABLE in receipt.missing_reasons
+    assert receipt.estimated_cost_usd is None
+
+
+def test_a_runtime_nobody_has_priced_is_recorded_as_unpriced(ledger):
+    ledger.record_runtime_cost(
+        entry_id="task-a:mystery",
+        task_id="task-a",
+        bucket=BUCKET_PROBLEM_SOLVING,
+        runtime_kind="a-runtime-with-no-rate",
+        seconds=3600,
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.status == STATUS_PARTIAL
+    assert REASON_RUNTIME_UNPRICED in receipt.missing_reasons
+
+
+# ── nothing happened ─────────────────────────────────────────────────────
+
+
+def test_marking_that_never_ran_is_not_marking_that_was_free(ledger):
+    receipt = ledger.receipt_for("task-a", BUCKET_GRADING)
+
+    assert receipt.status == STATUS_NOT_RUN
+    assert receipt.estimated_cost_usd is None
+    assert receipt.as_dict()["estimated_cost_usd"] is None
+
+
+def test_marking_by_rule_alone_really_did_cost_nothing(ledger):
+    """The single honest zero: a verdict reached without asking a model."""
+    receipt = ledger.receipt_for(
+        "task-a", BUCKET_GRADING, when_empty=STATUS_COMPLETE
+    )
+
+    assert receipt.status == STATUS_COMPLETE
+    assert receipt.estimated_cost_usd == Decimal(0)
+    assert receipt.model_calls == 0
+
+
+def test_a_run_that_kept_no_record_says_so_rather_than_reporting_zero(ledger):
+    receipt = ledger.receipt_for(
+        "task-a", BUCKET_PROBLEM_SOLVING, when_empty=STATUS_UNAVAILABLE
+    )
+
+    assert receipt.status == STATUS_UNAVAILABLE
+    assert receipt.missing_reasons == (REASON_LEDGER_ABSENT,)
+    assert receipt.estimated_cost_usd is None
+
+
+def test_the_three_kinds_of_silence_do_not_look_alike(ledger):
+    """Never ran, ran free, ran unrecorded — three different sentences."""
+    statuses = {
+        ledger.receipt_for("t", BUCKET_GRADING).status,
+        ledger.receipt_for("t", BUCKET_GRADING, when_empty=STATUS_COMPLETE).status,
+        ledger.receipt_for(
+            "t", BUCKET_GRADING, when_empty=STATUS_UNAVAILABLE
+        ).status,
+    }
+
+    assert statuses == {STATUS_NOT_RUN, STATUS_COMPLETE, STATUS_UNAVAILABLE}
+
+
+def test_a_summary_over_nothing_knowable_stays_unknowable():
+    """Rolling up silence must not turn it into a floor of ``$0``.
+
+    ``partial`` carries a real claim — part of this is known, and
+    ``known_cost_usd`` is a genuine lower bound. A run where no task could be
+    priced has no lower bound, and publishing one of zero is how a summary comes
+    to be read as "so far it has cost nothing".
+    """
+    summary = summarise_receipts(
+        [CostReceipt.unavailable(), CostReceipt.unavailable()]
+    )
+
+    assert summary.status == STATUS_UNAVAILABLE
+    assert summary.estimated_cost_usd is None
+    assert summary.missing_reasons == (REASON_LEDGER_ABSENT,)
+
+
+def test_one_priced_task_among_unpriceable_ones_gives_a_real_floor(ledger):
+    """The moment any part is known, the summary has something to bound."""
+    priced = CostReceipt(
+        status=STATUS_COMPLETE,
+        known_cost_usd=Decimal("1.50"),
+        model_cost_usd=Decimal("1.50"),
+        model_calls=1,
+    )
+
+    summary = summarise_receipts([priced, CostReceipt.unavailable()])
+
+    assert summary.status == STATUS_PARTIAL
+    assert summary.estimated_cost_usd is None
+    assert summary.known_cost_usd == Decimal("1.50")
+
+
+def test_an_execution_path_with_no_metering_is_reported_as_unsupported():
+    """No confirmed model call means no invented cost."""
+    receipt = CostReceipt.unavailable(reasons=("stage_unsupported",))
+
+    assert receipt.status == STATUS_UNAVAILABLE
+    assert receipt.as_dict()["missing_reasons"] == ["stage_unsupported"]
+    assert receipt.as_dict()["estimated_cost_usd"] is None
+
+
+# ── the contract's own arithmetic ────────────────────────────────────────
+
+
+def test_a_partial_receipt_never_publishes_a_total(ledger):
+    _call(ledger, "task-a")  # reserved and never settled
+    settled = _call(ledger, "task-a", sequence=1)
+    ledger.settle(
+        settled,
+        usage=CallUsage(
+            input_tokens=100_000, cached_input_tokens=0, output_tokens=0, reasoning_tokens=0
+        ),
+        resolved_model="cheap-cache",
+    )
+
+    payload = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING).as_dict()
+
+    assert payload["status"] == STATUS_PARTIAL
+    assert payload["estimated_cost_usd"] is None
+    assert payload["known_cost_usd"] == 1.0
+    assert payload["schema_version"] == "cost-receipt-v1"
+
+
+def test_the_parts_of_a_receipt_add_up_to_its_known_cost(ledger):
+    for sequence, stage in enumerate((STAGE_GRADING, STAGE_GRADING)):
+        call_id = _call(ledger, "task-a", stage=stage, sequence=sequence)
+        ledger.settle(
+            call_id,
+            usage=CallUsage(
+                input_tokens=100_000,
+                cached_input_tokens=0,
+                output_tokens=10_000,
+                reasoning_tokens=0,
+            ),
+            resolved_model="cheap-cache",
+        )
+    ledger.record_runtime_cost(
+        entry_id="task-a:own",
+        task_id="task-a",
+        bucket=BUCKET_GRADING,
+        runtime_kind="own-container",
+        seconds=60,
+    )
+
+    receipt = ledger.receipt_for("task-a", BUCKET_GRADING)
+
+    assert receipt.model_cost_usd + receipt.runtime_cost_usd == receipt.known_cost_usd
+    assert sum(
+        (component.known_cost_usd for component in receipt.components),
+        Decimal(0),
+    ) == receipt.model_cost_usd

--- a/batch-runner/tests/test_cost_receipts_reach_the_pipeline_boundaries.py
+++ b/batch-runner/tests/test_cost_receipts_reach_the_pipeline_boundaries.py
@@ -1,0 +1,568 @@
+"""The receipts have to survive the two places a run stops being one run.
+
+The ledger tests elsewhere in this directory prove the bookkeeping is sound in
+isolation. This file is about the seams: the point where step 8 turns rows into
+a published grade, and the point where step 9 turns eight of those grades back
+into one. Both seams rewrite the artifact, and a seam that rewrites money is
+where money goes missing.
+
+Nothing here calls a provider. Every figure comes from a fixture price list and
+a synthetic usage block.
+"""
+
+import hashlib
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+import step8_grade as s8
+import step9_merge_shards as s9
+from core.cost_receipts import (
+    BUCKET_GRADING,
+    REASON_USAGE_ABSENT,
+    RETRY_NONE,
+    STAGE_GRADING,
+    STATUS_COMPLETE,
+    STATUS_PARTIAL,
+    STATUS_UNAVAILABLE,
+    CallUsage,
+    CostReceipt,
+    CostReceiptLedger,
+    load_receipt_price_table,
+    make_call_id,
+    verify_export,
+)
+from core.grade_payload import validate_grade_payload
+
+
+PRICE_TABLE = {
+    "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+    "providers": {
+        "azure:test-model": {
+            "input_usd_per_million": "10",
+            "cached_input_usd_per_million": "10",
+            "output_usd_per_million": "20",
+            "reasoning_billed_as": "output",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        }
+    },
+    "runtime": {},
+}
+
+
+@pytest.fixture
+def price_table(tmp_path):
+    path = tmp_path / "prices.json"
+    path.write_text(json.dumps(PRICE_TABLE), encoding="utf-8")
+    return load_receipt_price_table(path)
+
+
+def _ledger(tmp_path, name, price_table, run_id="run-1"):
+    return CostReceiptLedger(
+        tmp_path / name, run_id=run_id, price_table=price_table
+    )
+
+
+def _grade_one(ledger, task_id, *, sequence=0, settle=True):
+    """Record one judge call for ``task_id`` and return its identifier."""
+    call_id = make_call_id(
+        run_id=ledger.run_id,
+        task_id=task_id,
+        stage=STAGE_GRADING,
+        retry_kind=RETRY_NONE,
+        attempt_index=0,
+        sequence=sequence,
+    )
+    ledger.reserve(
+        call_id=call_id,
+        task_id=task_id,
+        stage=STAGE_GRADING,
+        retry_kind=RETRY_NONE,
+        provider="azure",
+        requested_model="a-deployment",
+    )
+    if settle:
+        ledger.settle(
+            call_id,
+            usage=CallUsage(
+                input_tokens=100_000,
+                cached_input_tokens=0,
+                output_tokens=10_000,
+                reasoning_tokens=0,
+            ),
+            resolved_model="test-model",
+        )
+    return call_id
+
+
+# ── step 9: folding many audit trails into one ───────────────────────────
+#
+# Each shard published a grade file and, beside it, the ledger that grade was
+# read from. The merged grade may only point at a trail that holds all of them.
+
+
+def _shard_on_disk(tmp_path, price_table, index, task_ids):
+    """Write one shard grade file plus the ledger export it points at."""
+    directory = tmp_path / f"shard{index}"
+    directory.mkdir()
+    ledger = _ledger(directory, "ledger.sqlite3", price_table, run_id=f"run-{index}")
+    try:
+        for sequence, task_id in enumerate(task_ids):
+            _grade_one(ledger, task_id, sequence=sequence)
+        digest = ledger.export_jsonl(directory / "grade.cost_ledger.jsonl")
+    finally:
+        ledger.close()
+    payload = {"cost_ledger": {"path": "grade.cost_ledger.jsonl", "sha256": digest}}
+    shard_path = directory / "grade.json"
+    shard_path.write_text(json.dumps(payload), encoding="utf-8")
+    return shard_path, payload
+
+
+def _merged_rows(export: Path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in export.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_the_merged_trail_holds_every_shards_calls(tmp_path, price_table):
+    first = _shard_on_disk(tmp_path, price_table, 0, ["task-a", "task-b"])
+    second = _shard_on_disk(tmp_path, price_table, 1, ["task-c"])
+    out = tmp_path / "merged.json"
+
+    warnings: list[str] = []
+    pointer = s9.merge_shard_cost_ledgers(
+        [first[0], second[0]],
+        [first[1], second[1]],
+        out,
+        warn=warnings.append,
+    )
+
+    assert warnings == []
+    assert pointer is not None
+    export = out.with_name(pointer["path"])
+    calls = [row for row in _merged_rows(export) if row.get("call_id")]
+    assert {row["task_id"] for row in calls} == {"task-a", "task-b", "task-c"}
+
+
+def test_the_merged_pointer_can_be_checked_against_the_file_it_names(
+    tmp_path, price_table
+):
+    first = _shard_on_disk(tmp_path, price_table, 0, ["task-a"])
+    second = _shard_on_disk(tmp_path, price_table, 1, ["task-b"])
+    out = tmp_path / "merged.json"
+
+    pointer = s9.merge_shard_cost_ledgers(
+        [first[0], second[0]], [first[1], second[1]], out, warn=lambda _m: None
+    )
+
+    assert pointer is not None
+    assert verify_export(out.with_name(pointer["path"]), pointer["sha256"])
+
+
+def test_the_same_shard_folded_in_twice_is_still_one_bill(tmp_path, price_table):
+    """A retried merge must not double what the shard actually spent."""
+    shard = _shard_on_disk(tmp_path, price_table, 0, ["task-a", "task-b"])
+    out = tmp_path / "merged.json"
+
+    once = s9.merge_shard_cost_ledgers(
+        [shard[0]], [shard[1]], out, warn=lambda _m: None
+    )
+    twice = s9.merge_shard_cost_ledgers(
+        [shard[0], shard[0]],
+        [shard[1], shard[1]],
+        tmp_path / "merged2.json",
+        warn=lambda _m: None,
+    )
+
+    assert once is not None and twice is not None
+    assert once["sha256"] == twice["sha256"]
+
+
+def test_a_shard_with_no_pointer_stops_the_merged_trail(tmp_path, price_table):
+    """Silence about one shard must not be published as a complete trail."""
+    good = _shard_on_disk(tmp_path, price_table, 0, ["task-a"])
+    blind = tmp_path / "shard-blind.json"
+    blind.write_text(json.dumps({"cost_ledger": None}), encoding="utf-8")
+
+    warnings: list[str] = []
+    pointer = s9.merge_shard_cost_ledgers(
+        [good[0], blind],
+        [good[1], {"cost_ledger": None}],
+        tmp_path / "merged.json",
+        warn=warnings.append,
+    )
+
+    assert pointer is None
+    assert any("shard-blind.json" in message for message in warnings)
+
+
+def test_a_pointer_to_a_file_that_is_gone_stops_the_merged_trail(
+    tmp_path, price_table
+):
+    shard_path, payload = _shard_on_disk(tmp_path, price_table, 0, ["task-a"])
+    shard_path.with_name(payload["cost_ledger"]["path"]).unlink()
+
+    warnings: list[str] = []
+    pointer = s9.merge_shard_cost_ledgers(
+        [shard_path], [payload], tmp_path / "merged.json", warn=warnings.append
+    )
+
+    assert pointer is None
+    assert any("not beside it" in message for message in warnings)
+
+
+def test_a_trail_that_no_longer_matches_its_digest_stops_the_merge(
+    tmp_path, price_table
+):
+    """An edited audit trail is worth less than no audit trail at all."""
+    shard_path, payload = _shard_on_disk(tmp_path, price_table, 0, ["task-a"])
+    export = shard_path.with_name(payload["cost_ledger"]["path"])
+    rows = _merged_rows(export)
+    for row in rows:
+        if row.get("call_id"):
+            row["model_cost_usd"] = 0.0
+    export.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    warnings: list[str] = []
+    pointer = s9.merge_shard_cost_ledgers(
+        [shard_path], [payload], tmp_path / "merged.json", warn=warnings.append
+    )
+
+    assert pointer is None
+    assert any("does not match the digest" in message for message in warnings)
+
+
+def test_two_shards_that_disagree_about_one_call_stop_the_merged_trail(
+    tmp_path, price_table
+):
+    """Same identifier, different money: one of the two is wrong, so stop.
+
+    Deduplication by identifier is what makes an overlapping merge safe. It is
+    only safe while the identifier means the same call; a collision carrying a
+    different figure is a contradiction, and picking either number would be
+    publishing a guess. The grade itself still publishes — the per-task receipts
+    travel in the rows — but it publishes without claiming an audit trail.
+    """
+    first_path, first = _shard_on_disk(tmp_path, price_table, 0, ["task-a"])
+    second_path, second = _shard_on_disk(tmp_path, price_table, 1, ["task-a"])
+    # Same run identity on both sides, so the call identifiers collide.
+    forged = second_path.with_name(second["cost_ledger"]["path"])
+    rows = _merged_rows(first_path.with_name(first["cost_ledger"]["path"]))
+    for row in rows:
+        if row.get("call_id"):
+            row["output_tokens"] = 999_999
+    forged.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    second["cost_ledger"]["sha256"] = hashlib.sha256(
+        forged.read_bytes()
+    ).hexdigest()
+
+    warnings: list[str] = []
+    pointer = s9.merge_shard_cost_ledgers(
+        [first_path, second_path],
+        [first, second],
+        tmp_path / "merged.json",
+        warn=warnings.append,
+    )
+
+    assert pointer is None
+    assert any("LedgerIntegrityError" in message for message in warnings)
+
+
+# ── step 9: the arithmetic-free cross-check ──────────────────────────────
+
+
+def _summary(calls):
+    return {BUCKET_GRADING: {"model_calls": calls}}
+
+
+def test_shard_call_counts_must_add_up_to_the_merged_count():
+    s9._check_grading_call_sums(
+        [{"summary": _summary(3)}, {"summary": _summary(4)}],
+        ["shard-0", "shard-1"],
+        _summary(7),
+    )
+
+
+def test_a_shard_whose_receipts_did_not_arrive_is_caught():
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        s9._check_grading_call_sums(
+            [{"summary": _summary(3)}, {"summary": _summary(4)}],
+            ["shard-0", "shard-1"],
+            _summary(3),
+        )
+    assert "shard_sum=7" in str(excinfo.value)
+
+
+def test_a_shard_that_carries_no_receipt_cannot_be_checked_and_is_refused():
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        s9._check_grading_call_sums(
+            [{"summary": _summary(3)}, {"summary": {}}],
+            ["shard-0", "shard-1"],
+            _summary(3),
+        )
+    assert "shard-1" in str(excinfo.value)
+
+
+def test_a_call_count_that_is_not_a_count_is_refused():
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        s9._check_grading_call_sums(
+            [{"summary": _summary(3.0)}],
+            ["shard-0"],
+            _summary(3),
+        )
+    assert "must be an integer" in str(excinfo.value)
+
+
+# ── the ledger seam: an import that closes an open question ──────────────
+
+
+def test_an_open_reservation_is_closed_by_the_settlement_that_arrives(
+    tmp_path, price_table
+):
+    """One process saw the request go out; another saw how it ended.
+
+    Before the merge the local row can only say ``call_reachability_unknown``,
+    which holds the whole task's receipt at ``partial`` forever. Taking the
+    outcome from the arriving export resolves a doubt rather than overwriting a
+    figure.
+    """
+    sender = _ledger(tmp_path, "sender.sqlite3", price_table)
+    try:
+        _grade_one(sender, "task-a")
+        digest = sender.export_jsonl(tmp_path / "settled.jsonl")
+    finally:
+        sender.close()
+    assert digest
+
+    local = _ledger(tmp_path, "local.sqlite3", price_table)
+    try:
+        _grade_one(local, "task-a", settle=False)
+        assert local.receipt_for("task-a", bucket=BUCKET_GRADING).status == (
+            STATUS_PARTIAL
+        )
+
+        local.import_jsonl(tmp_path / "settled.jsonl")
+
+        receipt = local.receipt_for("task-a", bucket=BUCKET_GRADING)
+        assert receipt.status == STATUS_COMPLETE
+        assert receipt.model_calls == 1
+        assert receipt.estimated_cost_usd == Decimal("1.2")
+    finally:
+        local.close()
+
+
+def test_a_settled_call_is_not_reopened_by_a_reservation_that_arrives(
+    tmp_path, price_table
+):
+    """The reverse direction is a demotion, and a bill does not become a doubt."""
+    opener = _ledger(tmp_path, "opener.sqlite3", price_table)
+    try:
+        _grade_one(opener, "task-a", settle=False)
+        opener.export_jsonl(tmp_path / "reserved.jsonl")
+    finally:
+        opener.close()
+
+    local = _ledger(tmp_path, "local.sqlite3", price_table)
+    try:
+        _grade_one(local, "task-a")
+        local.import_jsonl(tmp_path / "reserved.jsonl")
+
+        receipt = local.receipt_for("task-a", bucket=BUCKET_GRADING)
+        assert receipt.status == STATUS_COMPLETE
+        assert receipt.estimated_cost_usd == Decimal("1.2")
+    finally:
+        local.close()
+
+
+# ── step 8: the published rows are what the run total is made of ─────────
+
+
+def _graded_row(task_id, receipt, *, pct=100.0):
+    return {
+        "task_id": task_id,
+        "pct": pct,
+        "total_awarded": 1,
+        "total_max": 1,
+        "items": [{"target_id": "c1", "verdict": "pass", "decided_by": "rule"}],
+        BUCKET_GRADING: receipt.as_dict(),
+    }
+
+
+def _receipt(status, **overrides):
+    """A one-call receipt, built through the real type rather than by hand.
+
+    Going through :class:`CostReceipt` means the row these tests publish is
+    exactly the shape ``from_dict`` will read back — a literal dict here would
+    drift from the type the moment either side gained a field.
+    """
+    fields = {
+        "status": status,
+        "known_cost_usd": Decimal("1.2"),
+        "model_cost_usd": Decimal("1.2"),
+        "model_calls": 1,
+        "usage": {
+            "input_tokens": 100_000,
+            "cached_input_tokens": 0,
+            "output_tokens": 10_000,
+            "reasoning_tokens": 0,
+        },
+        "missing_reasons": (
+            () if status == STATUS_COMPLETE else (REASON_USAGE_ABSENT,)
+        ),
+    }
+    fields.update(overrides)
+    return CostReceipt(**fields)
+
+
+def test_a_run_total_is_summed_from_the_rows_that_were_published():
+    summary = s8._compute_summary(
+        [
+            _graded_row("task-a", _receipt(STATUS_COMPLETE)),
+            _graded_row("task-b", _receipt(STATUS_COMPLETE)),
+        ],
+        unpriced_models=["gpt-5.4"],
+    )
+
+    assert summary[BUCKET_GRADING]["status"] == STATUS_COMPLETE
+    assert summary[BUCKET_GRADING]["model_calls"] == 2
+    assert summary[BUCKET_GRADING]["estimated_cost_usd"] == pytest.approx(2.4)
+
+
+def test_one_unknown_row_turns_the_run_total_into_a_floor():
+    """A total is only a total when every part behind it is known."""
+    summary = s8._compute_summary(
+        [
+            _graded_row("task-a", _receipt(STATUS_COMPLETE)),
+            _graded_row("task-b", _receipt(STATUS_PARTIAL)),
+        ],
+        unpriced_models=["gpt-5.4"],
+    )
+
+    receipt = summary[BUCKET_GRADING]
+    assert receipt["status"] == STATUS_PARTIAL
+    assert receipt["estimated_cost_usd"] is None
+    assert receipt["known_cost_usd"] == pytest.approx(2.4)
+
+
+def test_rows_from_before_receipts_existed_do_not_read_as_free():
+    summary = s8._compute_summary(
+        [_graded_row("task-a", CostReceipt.unavailable())],
+        unpriced_models=["gpt-5.4"],
+    )
+
+    receipt = summary[BUCKET_GRADING]
+    assert receipt["status"] == STATUS_UNAVAILABLE
+    assert receipt["estimated_cost_usd"] is None
+    assert receipt["known_cost_usd"] == 0.0
+
+
+def test_a_row_marked_entirely_by_rule_really_did_cost_nothing():
+    """The one honest zero: no judge was asked, so there is nothing to pay."""
+    summary = s8._compute_summary(
+        [_graded_row("task-a", CostReceipt.free())],
+        unpriced_models=["gpt-5.4"],
+    )
+
+    receipt = summary[BUCKET_GRADING]
+    assert receipt["status"] == STATUS_COMPLETE
+    assert receipt["estimated_cost_usd"] == 0.0
+    assert receipt["model_calls"] == 0
+
+
+# ── the published invariant: a summary cannot outrun its rows ────────────
+
+
+def _grade_payload(rows, run_receipt, schema_version="1.4"):
+    """A minimal 1.4 payload that carries the receipt fields under test."""
+    task_ids = [row["task_id"] for row in rows]
+    fingerprint = "a" * 64
+    return {
+        "schema_version": schema_version,
+        "run_status": "final",
+        "expected_task_count": len(rows),
+        "expected_ordered_task_ids_sha256": s8._ordered_task_ids_sha256(task_ids),
+        "azure_ai_routes": [
+            {
+                "endpoint_kind": "direct-v1",
+                "profile": "direct-v1",
+                "runtime_fingerprint": fingerprint,
+                "workload": "grader",
+            }
+        ],
+        "azure_ai_runtime_fingerprint": fingerprint,
+        "judge": {"model": "gpt-5.4"},
+        "cost_ledger": None,
+        "tasks": rows,
+        "summary": {
+            "total_tasks": len(rows),
+            "graded_tasks": len(rows),
+            "error_tasks": 0,
+            "openai_compat": {"avg_score_pct": 100.0},
+            "wow": {"judge_error_rate": 0.0},
+            "cost": {
+                "estimated_cost_usd": None,
+                "pricing_complete": False,
+                "unpriced_models": ["gpt-5.4"],
+            },
+            BUCKET_GRADING: run_receipt.as_dict(),
+        },
+    }
+
+
+def test_a_summary_claiming_a_complete_bill_over_an_unknown_row_is_refused():
+    payload = _grade_payload(
+        [
+            _graded_row("task-a", _receipt(STATUS_COMPLETE)),
+            _graded_row("task-b", _receipt(STATUS_PARTIAL)),
+        ],
+        _receipt(STATUS_COMPLETE),
+    )
+
+    with pytest.raises(ValueError, match="complete cost over an incomplete task"):
+        validate_grade_payload(payload, {})
+
+
+def test_a_row_that_was_never_graded_does_not_spoil_the_shards_bill():
+    """A shard that graded ten of two hundred has a complete bill for ten."""
+    payload = _grade_payload(
+        [
+            _graded_row("task-a", _receipt(STATUS_COMPLETE)),
+            _graded_row("task-b", CostReceipt.not_run()),
+        ],
+        _receipt(STATUS_COMPLETE),
+    )
+
+    validate_grade_payload(payload, {})
+
+
+def test_a_1_4_row_without_a_receipt_at_all_is_refused():
+    rows = [_graded_row("task-a", _receipt(STATUS_COMPLETE))]
+    rows[0].pop(BUCKET_GRADING)
+    payload = _grade_payload(rows, _receipt(STATUS_COMPLETE))
+
+    with pytest.raises(ValueError, match="task is missing its cost receipt"):
+        validate_grade_payload(payload, {})
+
+
+def test_a_1_3_grade_is_not_asked_for_receipts_it_never_had():
+    """Read compatibility: older grades stay valid and stay readable."""
+    rows = [_graded_row("task-a", _receipt(STATUS_COMPLETE))]
+    rows[0].pop(BUCKET_GRADING)
+    payload = _grade_payload(rows, _receipt(STATUS_COMPLETE), schema_version="1.3")
+    payload["summary"].pop(BUCKET_GRADING)
+    payload.pop("cost_ledger")
+
+    validate_grade_payload(payload, {})

--- a/batch-runner/tests/test_cost_receipts_survive_resume_and_shard_merge.py
+++ b/batch-runner/tests/test_cost_receipts_survive_resume_and_shard_merge.py
@@ -1,0 +1,343 @@
+"""Costs survive the things that replace results: resuming and merging.
+
+A run that stops halfway and starts again produces one set of deliverables and
+two sets of bills. A grading job split across eight shards produces eight
+ledgers for one experiment. Both cases end with the earlier record being
+folded into the later one, and in both the temptation is to let the newest
+write win — which would quietly discard money that was really spent.
+
+These tests fix the opposite behaviour: the union, deduplicated by an
+identifier that two processes can compute without talking to each other.
+"""
+
+import json
+from decimal import Decimal
+
+import pytest
+
+from core.cost_metering import CostRecorder
+from core.cost_receipts import (
+    BUCKET_GRADING,
+    BUCKET_PROBLEM_SOLVING,
+    RETRY_NONE,
+    RETRY_RESUME,
+    STAGE_GENERATION,
+    STAGE_GRADING,
+    STAGE_PERCEPTION,
+    STAGE_PREPROCESSING,
+    STAGE_SELF_QA,
+    STATUS_COMPLETE,
+    CallUsage,
+    CostReceiptLedger,
+    LedgerIntegrityError,
+    load_receipt_price_table,
+    make_call_id,
+    summarise_receipts,
+)
+
+PRICE_TABLE = {
+    "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+    "providers": {
+        "azure:test-model": {
+            "input_usd_per_million": "10",
+            "cached_input_usd_per_million": "10",
+            "output_usd_per_million": "20",
+            "reasoning_billed_as": "output",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        }
+    },
+    "runtime": {},
+}
+
+
+@pytest.fixture
+def price_table(tmp_path):
+    path = tmp_path / "prices.json"
+    path.write_text(json.dumps(PRICE_TABLE), encoding="utf-8")
+    return load_receipt_price_table(path)
+
+
+def _open(tmp_path, name, price_table, run_id="run-1"):
+    return CostReceiptLedger(
+        tmp_path / name, run_id=run_id, price_table=price_table
+    )
+
+
+def _usage(input_tokens=100_000, output_tokens=10_000):
+    return CallUsage(
+        input_tokens=input_tokens,
+        cached_input_tokens=0,
+        output_tokens=output_tokens,
+        reasoning_tokens=0,
+    )
+
+
+def _spend(ledger, task_id, *, stage, retry_kind=RETRY_NONE, attempt=0, sequence=0):
+    call_id = make_call_id(
+        run_id=ledger.run_id,
+        task_id=task_id,
+        stage=stage,
+        retry_kind=retry_kind,
+        attempt_index=attempt,
+        sequence=sequence,
+    )
+    ledger.reserve(
+        call_id=call_id,
+        task_id=task_id,
+        stage=stage,
+        retry_kind=retry_kind,
+        provider="azure",
+        requested_model="a-deployment",
+    )
+    ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+    return call_id
+
+
+# ── resume ───────────────────────────────────────────────────────────────
+
+
+def test_a_resumed_round_adds_to_the_earlier_bill_instead_of_replacing_it(
+    tmp_path, price_table
+):
+    with _open(tmp_path, "round1.sqlite3", price_table) as first:
+        _spend(first, "task-a", stage=STAGE_GENERATION)
+        export = tmp_path / "round1.jsonl"
+        first.export_jsonl(export)
+        before = first.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    with _open(tmp_path, "round2.sqlite3", price_table) as second:
+        assert second.import_jsonl(export) == 1
+        _spend(
+            second,
+            "task-a",
+            stage=STAGE_GENERATION,
+            retry_kind=RETRY_RESUME,
+            attempt=1,
+        )
+        after = second.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert before.model_calls == 1
+    assert after.model_calls == 2
+    assert after.known_cost_usd == before.known_cost_usd * 2
+    assert after.status == STATUS_COMPLETE
+
+
+def test_a_second_round_does_not_collide_with_the_first_rounds_identifiers(
+    tmp_path, price_table
+):
+    """Numbering the round is what keeps two first-calls apart."""
+    with _open(tmp_path, "cost.sqlite3", price_table) as ledger:
+        first_round = CostRecorder(ledger, round_index=0)
+        second_round = CostRecorder(ledger, round_index=1)
+
+        with first_round.attributed(task_id="task-a", stage=STAGE_GENERATION) as one:
+            first_id = first_round._next_call_id(one)
+        with second_round.attributed(task_id="task-a", stage=STAGE_GENERATION) as two:
+            second_id = second_round._next_call_id(two)
+
+    assert first_id != second_id
+
+
+def test_importing_the_same_round_twice_does_not_double_the_bill(
+    tmp_path, price_table
+):
+    """Re-running a merge step must be safe."""
+    with _open(tmp_path, "round1.sqlite3", price_table) as first:
+        _spend(first, "task-a", stage=STAGE_GENERATION)
+        export = tmp_path / "round1.jsonl"
+        first.export_jsonl(export)
+
+    with _open(tmp_path, "round2.sqlite3", price_table) as second:
+        assert second.import_jsonl(export) == 1
+        assert second.import_jsonl(export) == 0
+        receipt = second.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    assert receipt.model_calls == 1
+    assert receipt.estimated_cost_usd == Decimal("1.20")
+
+
+def test_an_import_that_contradicts_a_recorded_cost_is_refused(
+    tmp_path, price_table
+):
+    with _open(tmp_path, "one.sqlite3", price_table) as first:
+        call_id = _spend(first, "task-a", stage=STAGE_GENERATION)
+        export = tmp_path / "one.jsonl"
+        first.export_jsonl(export)
+
+    tampered = tmp_path / "tampered.jsonl"
+    record = json.loads(export.read_text(encoding="utf-8").splitlines()[0])
+    record["input_tokens"] = 1
+    record["model_cost_usd"] = "0.00001"
+    tampered.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    with _open(tmp_path, "two.sqlite3", price_table) as second:
+        second.import_jsonl(export)
+        with pytest.raises(LedgerIntegrityError):
+            second.import_jsonl(tampered)
+        assert second.calls_for("task-a")[0]["call_id"] == call_id
+
+
+# ── shard merge ──────────────────────────────────────────────────────────
+
+
+def test_shards_merge_into_the_union_of_what_they_each_spent(
+    tmp_path, price_table
+):
+    exports = []
+    for shard in range(3):
+        with _open(tmp_path, f"shard{shard}.sqlite3", price_table) as ledger:
+            _spend(ledger, f"task-{shard}", stage=STAGE_GRADING)
+            _spend(ledger, f"task-{shard}", stage=STAGE_PERCEPTION)
+            export = tmp_path / f"shard{shard}.jsonl"
+            ledger.export_jsonl(export)
+            exports.append(export)
+
+    with _open(tmp_path, "merged.sqlite3", price_table) as merged:
+        added = sum(merged.import_jsonl(export) for export in exports)
+        receipts = [
+            merged.receipt_for(task_id, BUCKET_GRADING)
+            for task_id in merged.task_ids()
+        ]
+        summary = summarise_receipts(receipts)
+
+    assert added == 6
+    assert len(receipts) == 3
+    assert summary.model_calls == 6
+    assert summary.status == STATUS_COMPLETE
+    assert summary.estimated_cost_usd == Decimal("7.20")
+
+
+def test_overlapping_shards_count_a_shared_call_once(tmp_path, price_table):
+    """Two shards that both handled a task must not bill it twice."""
+    exports = []
+    for shard in range(2):
+        with _open(tmp_path, f"shard{shard}.sqlite3", price_table) as ledger:
+            _spend(ledger, "task-a", stage=STAGE_GRADING)
+            export = tmp_path / f"shard{shard}.jsonl"
+            ledger.export_jsonl(export)
+            exports.append(export)
+
+    with _open(tmp_path, "merged.sqlite3", price_table) as merged:
+        for export in exports:
+            merged.import_jsonl(export)
+        receipt = merged.receipt_for("task-a", BUCKET_GRADING)
+
+    assert receipt.model_calls == 1
+    assert receipt.estimated_cost_usd == Decimal("1.20")
+
+
+def test_a_merged_ledger_exports_a_digest_a_reader_can_check(
+    tmp_path, price_table
+):
+    with _open(tmp_path, "shard.sqlite3", price_table) as shard:
+        _spend(shard, "task-a", stage=STAGE_GRADING)
+        shard_export = tmp_path / "shard.jsonl"
+        shard.export_jsonl(shard_export)
+
+    with _open(tmp_path, "merged.sqlite3", price_table) as merged:
+        merged.import_jsonl(shard_export)
+        digest = merged.export_jsonl(tmp_path / "merged.jsonl")
+
+    assert len(digest) == 64
+    assert int(digest, 16) >= 0
+
+
+# ── the two pipelines stay apart ─────────────────────────────────────────
+
+
+def test_the_two_totals_are_built_from_disjoint_sets_of_calls(
+    tmp_path, price_table
+):
+    with _open(tmp_path, "cost.sqlite3", price_table) as ledger:
+        for stage in (STAGE_PREPROCESSING, STAGE_GENERATION, STAGE_SELF_QA):
+            _spend(ledger, "task-a", stage=stage)
+        for stage in (STAGE_GRADING, STAGE_PERCEPTION):
+            _spend(ledger, "task-a", stage=stage)
+
+        solving = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+        grading = ledger.receipt_for("task-a", BUCKET_GRADING)
+        every_call = ledger.calls_for("task-a")
+
+    assert solving.model_calls == 3
+    assert grading.model_calls == 2
+    assert solving.model_calls + grading.model_calls == len(every_call)
+    assert {component.stage for component in solving.components}.isdisjoint(
+        {component.stage for component in grading.components}
+    )
+
+
+def test_the_solving_total_is_the_sum_of_its_stages_and_retries(
+    tmp_path, price_table
+):
+    """The arithmetic the contract promises, to the last cent."""
+    with _open(tmp_path, "cost.sqlite3", price_table) as ledger:
+        _spend(ledger, "task-a", stage=STAGE_PREPROCESSING)
+        _spend(ledger, "task-a", stage=STAGE_GENERATION)
+        _spend(ledger, "task-a", stage=STAGE_SELF_QA, sequence=0)
+        _spend(ledger, "task-a", stage=STAGE_SELF_QA, sequence=1)
+        _spend(
+            ledger,
+            "task-a",
+            stage=STAGE_GENERATION,
+            retry_kind=RETRY_RESUME,
+            attempt=1,
+        )
+        receipt = ledger.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    parts = sum(
+        (component.known_cost_usd for component in receipt.components), Decimal(0)
+    )
+
+    assert receipt.model_calls == 5
+    assert parts == receipt.known_cost_usd == Decimal("6.00")
+    assert receipt.estimated_cost_usd == Decimal("6.00")
+
+
+def test_an_experiment_summary_is_not_complete_if_one_task_is_not(
+    tmp_path, price_table
+):
+    """A headline that silently drops a task reads as if it had not."""
+    with _open(tmp_path, "cost.sqlite3", price_table) as ledger:
+        _spend(ledger, "task-a", stage=STAGE_GENERATION)
+        unfinished = make_call_id(
+            run_id=ledger.run_id,
+            task_id="task-b",
+            stage=STAGE_GENERATION,
+            retry_kind=RETRY_NONE,
+            attempt_index=0,
+            sequence=0,
+        )
+        ledger.reserve(
+            call_id=unfinished,
+            task_id="task-b",
+            stage=STAGE_GENERATION,
+            retry_kind=RETRY_NONE,
+            provider="azure",
+            requested_model="a-deployment",
+        )
+        summary = summarise_receipts(
+            [
+                ledger.receipt_for(task_id, BUCKET_PROBLEM_SOLVING)
+                for task_id in ledger.task_ids()
+            ]
+        )
+
+    assert summary.status == "partial"
+    assert summary.estimated_cost_usd is None
+    assert summary.known_cost_usd == Decimal("1.20")
+
+
+def test_a_summary_over_tasks_that_never_ran_says_so(tmp_path, price_table):
+    with _open(tmp_path, "cost.sqlite3", price_table) as ledger:
+        summary = summarise_receipts(
+            [
+                ledger.receipt_for("task-a", BUCKET_GRADING),
+                ledger.receipt_for("task-b", BUCKET_GRADING),
+            ]
+        )
+
+    assert summary.status == "not_run"
+    assert summary.as_dict()["estimated_cost_usd"] is None

--- a/batch-runner/tests/test_shard_merge_roundtrip.py
+++ b/batch-runner/tests/test_shard_merge_roundtrip.py
@@ -26,6 +26,7 @@ import pytest
 
 import step8_grade as s8
 import step9_merge_shards as s9
+from core.cost_receipts import verify_export
 from core.grade_payload import validate_grade_payload
 from tests.test_step8_grade import (  # noqa: F401 -- _typed_azure_ai_route is an autouse fixture
     _FakeGrader,
@@ -72,7 +73,16 @@ def _grade_path(root: Path, index: int, count: int) -> Path:
 #     moments by construction, and even this harness drifts by a second when a
 #     run straddles a second boundary. Its merge rule is asserted directly in
 #     test_merge_takes_the_last_shard_completion_time rather than diffed here.
-_EXPECTED_DIVERGENCE = {"shard_provenance", "grading_wall_time_ms", "graded_at"}
+#   cost_ledger -- a pointer to the audit file sitting beside *this* grade, so a
+#     serial run and a merged run necessarily spell the path differently. What
+#     has to hold is asserted directly below: the merged grade points at a real
+#     trail that matches the digest it publishes for it.
+_EXPECTED_DIVERGENCE = {
+    "shard_provenance",
+    "grading_wall_time_ms",
+    "graded_at",
+    "cost_ledger",
+}
 
 
 def _run_grade(
@@ -136,6 +146,14 @@ def test_sharded_run_merges_into_a_serial_identical_payload(
     assert merged["run_status"] == "final"
     assert [task["task_id"] for task in merged["tasks"]] == _CORPUS
     assert _strip(merged) == _strip(serial)
+
+    # Stripped from the diff above, so pin it here instead: the merged grade
+    # must name an audit trail that actually sits beside it and still matches
+    # the digest it published. A pointer to a file nobody can check is the same
+    # as no pointer, and worse, because it reads like one.
+    trail = merged_path.with_name(merged["cost_ledger"]["path"])
+    assert trail.is_file()
+    assert verify_export(trail, merged["cost_ledger"]["sha256"])
 
     # The exact gate the workflow's merge step applies before it will publish a
     # merged file to data/grades/. Pinning it here means a drift in either step8

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 import step8_grade as s8
+from core.cost_receipts import CostReceipt
 
 
 INFERENCE_SHA = "a" * 40
@@ -59,8 +60,9 @@ class _FakeLoader:
 class _FakeGrader:
     prompt_version = "v1"
 
-    def __init__(self, config, rubric_loader):
+    def __init__(self, config, rubric_loader, cost_recorder=None):
         self.calls = 0
+        self.cost_recorder = cost_recorder
         self.runtime_fingerprint = config["_runtime"][
             "azure_ai_runtime_fingerprint"
         ]
@@ -473,7 +475,7 @@ def test_force_overwrites(monkeypatch, tmp_path):
     code = s8.main()
     assert code == 0
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == "1.3"
+    assert payload["schema_version"] == "1.4"
     assert all(
         isinstance(task["grading_wall_time_ms"], (int, float))
         and task["grading_wall_time_ms"] >= 0
@@ -534,7 +536,7 @@ def test_main_rejects_missing_or_secondary_grader_fingerprint(
     closed = []
 
     class UnboundGrader:
-        def __init__(self, config, rubric_loader):
+        def __init__(self, config, rubric_loader, cost_recorder=None):
             self.runtime_fingerprint = runtime_fingerprint
 
         def close(self):
@@ -1771,6 +1773,10 @@ def _seed_partial_grade(
             "judge_input_tokens": 0,
             "judge_output_tokens": 0,
             "usage_complete": True,
+            # Decided entirely by precheck above, so no judge call was made and
+            # the receipt is the one honest zero. A fixture partial keeps no
+            # ledger, hence the null pointer on the payload below.
+            "grading_cost": CostReceipt.free().as_dict(),
             "graded_at": "2026-05-27T00:00:00Z",
             "error": None,
         }
@@ -1824,6 +1830,7 @@ def _seed_partial_grade(
         "prompt": {"template": "prompts/grader_judge.md", "version": "v1"},
         "graded_at": "2026-05-27T00:00:00Z",
         "graded_by": "step8_grade.py",
+        "cost_ledger": None,
         "tasks": task_rows,
         "summary": s8._compute_summary(
             task_rows,
@@ -1875,7 +1882,7 @@ def _validate_resume_anchor_projection(
 
 def _matching_resume_identity() -> dict:
     return {
-        "schema_version": "1.3",
+        "schema_version": "1.4",
         "experiment_id": "exp003",
         "rubric": {"commit_sha": "a" * 40},
         "prompt": {"version": "v2.2"},
@@ -2957,7 +2964,7 @@ def test_time_budget_exit_7_writes_partial(monkeypatch, tmp_path, capsys):
     out = tmp_path / "data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1.json"
     assert out.exists()
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == "1.3"
+    assert payload["schema_version"] == "1.4"
     assert [task["task_id"] for task in payload["tasks"]] == ["task-001"]
     stderr = capsys.readouterr().err
     assert "provider_error:OSError" in stderr

--- a/batch-runner/tests/test_step9_merge_shards.py
+++ b/batch-runner/tests/test_step9_merge_shards.py
@@ -56,6 +56,7 @@ from pathlib import Path
 import pytest
 
 import step9_merge_shards as s9
+from core.cost_receipts import CostReceipt
 from core.grade_payload import canonical_rate, validate_grade_payload
 from step8_grade import (
     SCHEMA_VERSION,
@@ -125,7 +126,7 @@ def anchor_provenance() -> dict:
 
 
 def _normalised_tasks(raw_corpus: dict, limit: int | None = None) -> list[dict]:
-    """Deep-copied corpus tasks migrated to the schema-1.3 item contract."""
+    """Deep-copied corpus tasks migrated to the schema-1.4 item contract."""
     tasks = copy.deepcopy(raw_corpus["tasks"])
     if limit is not None:
         tasks = tasks[:limit]
@@ -133,6 +134,11 @@ def _normalised_tasks(raw_corpus: dict, limit: int | None = None) -> list[dict]:
         for item in task["items"]:
             if item.get("verdict") == "judge_error":
                 item["score_excluded"] = True
+        # The corpus these rows come from was graded before receipts existed,
+        # so nothing is known about what it cost. That is the honest reading,
+        # and it is the one the merge has to keep: an old row must not merge
+        # into a total as though it were free.
+        task["grading_cost"] = CostReceipt.unavailable().as_dict()
     return tasks
 
 
@@ -181,6 +187,7 @@ def _build_reference(
         "graded_at": raw_corpus["graded_at"],
         "graded_by": raw_corpus["graded_by"],
         "graded_by_version": raw_corpus["graded_by_version"],
+        "cost_ledger": None,
         "tasks": tasks,
         "summary": _compute_summary(tasks, unpriced_models=UNPRICED_MODELS),
     }

--- a/tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md
+++ b/tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md
@@ -1,0 +1,396 @@
+# SPEC: Per-Task Cost Receipts — 문제 풀이 비용과 채점 비용의 분리 원장
+
+## 0. 메타
+
+- **Status**: Session A (ledger + instrumentation) in progress
+- **Owner**: hyeonsangjeon
+- **Repo**: `hyeonsangjeon/gdpval-realworks`
+- **Project card**: Project #5 — `문제별 문제 풀이 비용과 채점 비용 기록`
+- **계약 버전**: `cost-receipt-v1`
+- **통화**: USD (표시 통화는 `currency` 필드가 결정하며 코드에 상수로 박지 않는다)
+
+이 명세는 **모델·제공 서비스에 중립적**이다. 본문에 특정 배포 이름, 특정 사업자
+이름, 특정 단가를 적지 않는다. 그런 값은 전부 커밋된 가격표 파일과 실험 설정에만
+존재하며, 코드와 이 문서는 그 파일을 읽는 방법만 정의한다.
+
+### 0.1 병렬 소유권
+
+| 세션 | 범위 |
+|------|------|
+| A | 가격표, `CostReceiptLedger`, 호출 계측, grade schema 1.4, 재개·병합 보존, Python 테스트 |
+| B | `self_report.json` 투영, 보고서, HF 게시, 집계 스크립트, React 대시보드, 프런트 테스트 |
+
+세션 A는 React/TypeScript/보고서 화면을 수정하지 않는다. 세션 B는 원장 계산 로직과
+grade schema를 수정하지 않는다. 계약 변경이 필요하면 Project 카드에 먼저 기록한다.
+
+---
+
+## 1. 문제 정의
+
+지금 저장소는 비용에 대해 두 가지만 안다.
+
+1. **실행 전 상한** — `core/execution_envelope_cost.py`가 "최악의 경우 얼마까지
+   나올 수 있는가"를 계산한다. 예측이 아니라 천장이고, 승인 게이트용이다.
+2. **흩어진 사용량** — `step2_run_inference.py`의 `_bounded_agentic_metrics`,
+   `core/grader.py`의 `judge_*_tokens` / `perception_*_tokens`,
+   `step8_grade.py`의 `summary.cost`가 토큰 수를 모은다. 그러나
+   `summary.cost.estimated_cost_usd`는 **항상 `null`**이고
+   `pricing_complete`는 **항상 `false`**다. 즉 사용량은 있는데 값이 붙은 적이 없다.
+
+없는 것은 세 가지다.
+
+- **작업 단위 귀속**: 어떤 호출이 어느 task의 어느 단계에 속하는지 남지 않는다.
+- **문제 풀이와 채점의 분리**: 두 비용이 서로 다른 파이프라인에서 발생하는데,
+  이를 합산 불가능하게 분리해 보관하는 자리가 없다.
+- **감사 가능성**: 재시도·재개·폐기된 호출은 집계에서 사라진다. 실제로 돈이 나간
+  호출인데 결과물이 교체되면 기록도 함께 사라진다.
+
+## 2. 설계 원칙
+
+### P1. 0달러는 측정 결과일 때만 쓴다
+
+`0`은 "무료였다"는 **주장**이다. 모르는 것은 `null`이고 상태는 `partial`이다.
+사용량이 없거나, 가격이 없거나, 호출이 실제로 나갔는지 불분명하면 금액을
+`estimated_cost_usd`에 넣지 않는다. 확인된 부분만 `known_cost_usd`에 남긴다.
+
+진짜 `$0`은 하나뿐이다: **모델을 한 번도 부르지 않은 규칙 기반 경로**. 이때만
+`complete` + `estimated_cost_usd: 0`이다.
+
+### P2. 가격은 정확히 일치할 때만 적용한다 (fail closed)
+
+`(provider, resolved_model)` 쌍이 가격표에 **정확히** 있어야 값을 매긴다. 비슷한
+이름, 접두사 일치, 상위 모델 대체는 전부 금지한다. 없으면 `price_missing` 사유와
+함께 `partial`이다. 실행을 다른 모델로 바꾸지 않는다.
+
+### P3. 원장은 추가 전용이다
+
+호출은 지워지지 않는다. 결과물이 교체되어도, 재개로 다시 돌려도, shard가 병합돼도
+이전 호출 기록은 남는다. 비용은 "마지막 시도"가 아니라 "실제로 나간 모든 호출"의
+합이다.
+
+### P4. 원장에 비밀이 들어가지 않는다
+
+프롬프트 원문, API 키, 응답 전문, 내부 추론(raw chain-of-thought)은 저장하지
+않는다. 요청 식별자가 필요하면 SHA-256 해시만 남긴다. 원장은 공개 산출물로
+게시될 수 있다는 전제로 작성한다.
+
+### P5. 공유 사용료는 임의 배분하지 않는다
+
+한 작업에 직접 귀속되는 실행 환경 사용료만 그 작업의 영수증에 넣는다. 여러 작업이
+공유한 컨테이너·풀 사용료는 나누어 배분하지 않고, 해당 작업 영수증을 `partial`로
+유지하며 사유를 남긴다. 근사 배분은 측정이 아니라 창작이다.
+
+---
+
+## 3. 공유 계약 (`cost-receipt-v1`)
+
+세션 B가 소비하는 형태다. 필드 이름과 의미는 고정이다.
+
+### 3.1 상태
+
+| 상태 | 뜻 |
+|------|-----|
+| `complete` | 모든 구성 호출의 사용량과 가격이 확인됨. `estimated_cost_usd`가 숫자다. |
+| `partial` | 일부만 확인됨. `known_cost_usd`만 있고 `estimated_cost_usd`는 `null`이다. |
+| `unavailable` | 이 실행에는 원본 사용량 기록 자체가 없다 (예: 계측 이전 실험). |
+| `not_run` | 이 단계가 실행되지 않았다 (예: 미채점). 비용이 0인 것이 아니라 사건이 없다. |
+
+`unavailable`과 `not_run`은 둘 다 금액이 없지만 **다른 이야기**다. 전자는 "썼는데
+기록이 없다", 후자는 "쓰지 않았다"이다. 화면에서 같게 보이면 안 된다.
+
+### 3.2 영수증 (receipt)
+
+```json
+{
+  "schema_version": "cost-receipt-v1",
+  "status": "complete | partial | unavailable | not_run",
+  "currency": "USD",
+  "estimated_cost_usd": 0.0421,
+  "known_cost_usd": 0.0421,
+  "model_cost_usd": 0.0400,
+  "runtime_cost_usd": 0.0021,
+  "model_calls": 7,
+  "usage": {
+    "input_tokens": 120340,
+    "cached_input_tokens": 41000,
+    "output_tokens": 8800,
+    "reasoning_tokens": 5200
+  },
+  "components": [
+    {
+      "stage": "generation",
+      "retry_kind": "none",
+      "status": "complete",
+      "model_calls": 1,
+      "known_cost_usd": 0.0180,
+      "usage": { "...": 0 }
+    }
+  ],
+  "price_table_sha256": "…64 hex…",
+  "missing_reasons": []
+}
+```
+
+규칙:
+
+- `estimated_cost_usd`는 `status == "complete"`일 때만 숫자다. 그 외에는 `null`.
+- `known_cost_usd`는 상태와 무관하게 **확인된 금액의 합**이다. 총액이 아니다.
+- `model_cost_usd + runtime_cost_usd == known_cost_usd`.
+- `usage.reasoning_tokens`는 **참고 표시**다. 사업자가 추론 토큰을 출력 토큰에
+  포함해 청구하면 `output_tokens`에 이미 들어 있으므로 다시 곱하지 않는다.
+  §5.3 참조.
+- `missing_reasons`는 §3.4의 열거값만 담는다.
+
+### 3.3 작업·실험 필드
+
+작업(task) 레코드와 실험 요약 모두 같은 두 필드를 가진다.
+
+- `problem_solving_cost` — 전처리 + 생성 + Self-QA + 모든 재시도 + 직접 귀속
+  실행 환경 사용료
+- `grading_cost` — 주 채점 + 판독(시각·소리) + 채점 재시도 + 직접 귀속 채점 실행
+  환경 사용료
+
+두 값은 **절대 합산되지 않는다**. 서로 다른 파이프라인, 서로 다른 승인, 서로 다른
+모델이다. 실험 요약의 값은 작업별 값의 합이며, 하나라도 `complete`가 아니면
+요약도 `complete`가 아니다.
+
+감사 원장 참조:
+
+```json
+"cost_ledger": { "path": "…/cost_ledger.jsonl", "sha256": "…64 hex…" }
+```
+
+### 3.4 `missing_reasons` 열거값
+
+| 값 | 언제 |
+|----|------|
+| `usage_absent` | 응답에 사용량이 없다 |
+| `usage_partial` | 사용량 일부 필드가 없다 |
+| `price_missing` | `(provider, model)`이 가격표에 없다 |
+| `call_reachability_unknown` | 요청이 사업자에 도달했는지 불명 (타임아웃 등) |
+| `runtime_cost_unattributable` | 공유 실행 환경이라 작업 귀속 불가 |
+| `runtime_cost_unpriced` | 실행 환경 사용료 단가가 없다 |
+| `ledger_absent` | 이 실행에 원장이 없다 |
+| `stage_unsupported` | 해당 실행 경로에 모델 호출 계측이 없다 |
+
+---
+
+## 4. 가격표
+
+파일: `batch-runner/experiments/execution_envelope/model_price_table.json`
+
+기존 `models` 블록(실행 전 상한 계산용)은 **그대로 둔다**. 영수증용으로 형제 키를
+추가한다.
+
+```json
+{
+  "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+  "providers": {
+    "<provider>:<resolved_model>": {
+      "input_usd_per_million": "…",
+      "cached_input_usd_per_million": "…",
+      "output_usd_per_million": "…",
+      "reasoning_billed_as": "output | separate | unknown",
+      "reasoning_usd_per_million": "…",
+      "source": "<가격 고지 URL>",
+      "last_reviewed": "YYYY-MM-DD",
+      "currency": "USD",
+      "unit": "per 1,000,000 tokens"
+    }
+  },
+  "runtime": {
+    "<runtime_kind>": {
+      "usd_per_hour": "…",
+      "attribution": "per_task | shared",
+      "source": "…", "last_reviewed": "…", "currency": "USD"
+    }
+  }
+}
+```
+
+- 키는 `provider:resolved_model`이다. `resolved_model`은 **응답이 실제로 보고한
+  모델**이지 요청에 적은 배포 이름이 아니다. 둘이 다르면 응답 값을 쓴다.
+- `price_table_sha256`은 **파일 전체 바이트**의 SHA-256이다. 영수증마다 기록해
+  나중에 어느 가격표로 계산했는지 재현할 수 있게 한다.
+- `attribution: "shared"`인 실행 환경은 작업에 배분하지 않는다 (P5).
+- 항목 추가·수정은 `source`와 `last_reviewed` 없이 허용하지 않는다.
+
+## 5. 계측
+
+### 5.1 단계 (`stage`)
+
+| 값 | 대상 |
+|----|------|
+| `preprocessing` | 입력 파일 전처리 — 소리·영상 분석 등 |
+| `generation` | 결과물 생성 본 호출 |
+| `self_qa` | 자체 점검과 그로 인한 재생성 |
+| `grading` | 주 채점 |
+| `perception` | 채점 중 시각·소리 판독 |
+
+`preprocessing`·`generation`·`self_qa`는 `problem_solving_cost`로,
+`grading`·`perception`은 `grading_cost`로 흐른다. 이 매핑은 코드에 한 곳에만
+존재해야 한다.
+
+### 5.2 재시도 종류 (`retry_kind`)
+
+| 값 | 뜻 |
+|----|-----|
+| `none` | 첫 시도 |
+| `semantic` | 결과 품질 때문에 다시 함 (Self-QA 지적 등) |
+| `infrastructure` | 오류·타임아웃·속도 제한 때문에 다시 함 |
+| `resume` | 이전 실행이 끊겨 재개하며 다시 함 |
+| `internal_recovery` | 실행 경로 내부의 도구 오류 복구 |
+
+전부 실제로 돈이 나간 호출이므로 전부 합산 대상이다. 구분하는 이유는 비용의
+출처를 읽을 수 있게 하기 위해서다.
+
+### 5.3 이중 과금 방지
+
+두 가지를 반드시 지킨다.
+
+1. **캐시된 입력 토큰**: 사업자가 보고하는 `input_tokens`는 보통 캐시 적중분을
+   **포함한** 총량이다. 따라서 과금 대상 입력은
+   `input_tokens - cached_input_tokens`이고, 캐시분은 별도 단가로 한 번만 곱한다.
+   `cached > input`이면 데이터가 모순이므로 `usage_partial`로 처리한다.
+2. **추론 토큰**: `reasoning_billed_as`가 `output`이면 이미 `output_tokens`에
+   포함되어 있으므로 **다시 곱하지 않는다**. `separate`일 때만 별도 단가를
+   적용한다. `unknown`이면 값을 매기지 않고 `usage_partial`이다.
+
+### 5.4 연결 지점
+
+| 경로 | 파일 | 단계 |
+|------|------|------|
+| 서버 별도 Python 프로세스 | `core/subprocess_runner.py` | `generation` |
+| Azure Code Interpreter | `core/code_interpreter.py` | `generation` |
+| 기존 Sandbox | `core/hardened_sandbox_runner.py` | `generation` |
+| Agentic Sandbox | `core/agentic_sandbox_runner.py` | `generation` |
+| Self-QA | `core/output_qa.py`, `step2_run_inference.py` | `self_qa` |
+| 소리·영상 전처리 | `core/audio_analyzer.py`, `core/video_analyzer.py` | `preprocessing` |
+| 주 채점 | `core/tool_calling_judge.py`, `core/grader.py` | `grading` |
+| 판독 | `core/perception/vision.py`, `core/perception/audio.py` | `perception` |
+| 채점 재시도 | `core/grader.py` | `grading` (`retry_kind` 구분) |
+
+**미지원 경로**: Agentic Sandbox V2와 Native Codex처럼 실제 모델 실행 경로가
+없거나 확인되지 않은 곳은 비용을 만들어내지 않는다. `stage_unsupported`를 달고
+`partial`, 실행되지 않았으면 `not_run`이다.
+
+## 6. 원장 (`CostReceiptLedger`)
+
+파일: `batch-runner/core/cost_receipts.py`. 저장소는 SQLite.
+
+### 6.1 왜 SQLite인가
+
+동시에 도는 shard 여러 개가 같은 파일에 쓴다. JSONL 추가 쓰기는 프로세스 경계를
+넘으면 줄이 섞일 수 있고, 중복 정산을 막을 유일성 제약을 걸 수 없다. SQLite는
+둘 다 해결한다. 교환·게시용으로는 JSONL로 내보낸다.
+
+### 6.2 수명주기: 예약 → 정산
+
+```
+reserve(call_id, task_id, stage, retry_kind, provider, model, …)
+  → 호출 전에 행을 만든다. 상태 reserved.
+settle(call_id, usage=…, resolved_model=…)
+  → 응답 후 사용량을 채우고 가격을 적용한다. 상태 settled.
+abandon(call_id, reason=…)
+  → 호출이 나가지 않았음이 확실할 때. 상태 abandoned, 비용 0.
+```
+
+예약을 먼저 하는 이유: **호출은 나갔는데 응답을 못 받은 경우**를 잃지 않기 위해서다.
+정산되지 않은 예약 행은 사라지지 않고 `call_reachability_unknown`으로 남아 그 작업
+영수증을 `partial`로 만든다. 이것이 "API 도달 여부 불명확"의 처리다.
+
+"호출 전 실패"(요청을 만들다 실패)는 `abandon`이며 비용에 영향이 없다.
+
+### 6.3 중복 정산 방지
+
+`call_id`는 기본 키다. 같은 `call_id`를 두 번 정산하면:
+
+- 사용량이 **같으면** 조용히 무시한다 (재시도된 쓰기).
+- 사용량이 **다르면** 오류다. 원장 손상 신호이며 조용히 덮어쓰지 않는다.
+
+`call_id`는 호출 지점에서 결정적으로 만든다:
+`sha256(run_id | task_id | stage | retry_kind | attempt_index | sequence)`.
+프롬프트 내용은 넣지 않는다 (P4).
+
+### 6.4 내보내기·가져오기·검증
+
+- `export_jsonl(path)` — 한 줄에 한 호출, 결정적 키 순서, 정렬된 순서.
+- `import_jsonl(path)` — 재개·병합용. 이미 있는 `call_id`는 §6.3 규칙을 따른다.
+- `verify(path)` — 내보낸 파일의 SHA-256과 행별 무결성을 확인한다.
+
+### 6.5 재개와 shard 병합
+
+- **재개**: 이전 라운드의 원장을 가져와 이어 쓴다. 이전 라운드의 실패·폐기 호출
+  비용은 그대로 남는다. 결과물만 교체되고 비용은 누적된다.
+- **shard 병합**: 각 shard가 자기 원장 JSONL을 사이드카로 남긴다. `step9`가
+  이를 합집합으로 가져온다. `call_id`가 결정적이므로 중복은 자동으로 한 번만
+  집계된다.
+
+## 7. Grade schema 1.4
+
+`batch-runner/schemas/grade.schema.json`에 `1.4`를 추가한다.
+
+- 1.4는 작업별 `grading_cost` 영수증과 요약 `grading_cost`, `cost_ledger` 참조를
+  요구한다.
+- **1.0~1.3은 계속 읽힌다.** 기존 조건절은 손대지 않고 1.4 전용 조건절을 더한다.
+- 기존 `summary.cost` 블록은 유지한다 (사용량 집계). 1.4에서
+  `summary.grading_cost`가 값이 붙은 영수증을 담당한다.
+- exp003처럼 비용 필드가 없는 기존 결과와 구형 보고서는 계속 열려야 한다.
+
+## 8. 검증
+
+### 8.1 산술
+
+`problem_solving_cost.known_cost_usd` ==
+최초 생성 + Self-QA + 의미 재시도 + 실행 오류 재시도 + 재개 + 직접 귀속 실행
+사용료의 합. 소수점 오차 없이 `Decimal`로 계산한다.
+
+`grading_cost`는 주 채점 + 판독 + 채점 재시도의 합이며, 두 값이 섞이는 경로가
+코드에 존재하지 않아야 한다.
+
+### 8.2 테스트 목록
+
+각각 독립 테스트로 존재한다.
+
+1. 실패한 작업 — 비용은 남고 결과는 실패
+2. 응답 사용량 누락 — `usage_absent`, `partial`
+3. 미등록 가격 — `price_missing`, `partial`, 대체 금지
+4. API 도달 불명확 — 미정산 예약이 `partial`을 만든다
+5. 호출 전 실패 — `abandon`, 비용 영향 없음
+6. 규칙 기반 무호출 채점 — `complete`, `$0`
+7. 미채점 — `not_run`
+8. 같은 호출 두 번 정산 — 한 번만 집계
+9. 캐시 토큰 이중 과금 없음
+10. 추론 토큰 이중 과금 없음
+11. 재개 후 이전 비용 보존
+12. shard 병합 후 이전 비용 보존
+13. 결과물 교체 후 이전 비용 보존
+14. 문제 풀이·채점 비용 미혼합
+15. exp003 및 구형 보고서 읽기 호환
+16. 공유 실행 환경 — 배분 금지, `partial` 유지
+
+### 8.3 유료 실행 금지
+
+이 명세의 모든 테스트는 **모의 응답**으로 돈다. 실제 사업자 호출, 로그인, 실제
+채점·재채점, Smoke/Pilot/Full 실행은 세션 A·B 어느 쪽도 하지 않는다. 통합 담당
+세션이 두 PR 병합 후 한 번만 실제 Smoke를 돌린다.
+
+## 9. 중단 규칙
+
+다음이 발견되면 유료 실행 전에 멈춘다.
+
+- 원장 손상 (같은 `call_id`에 다른 사용량)
+- 중복 정산이 집계에 반영됨
+- 문제 풀이 비용과 채점 비용의 혼합
+- 원장에 프롬프트 원문·키·응답 전문 저장
+- 가격표 정확 일치 실패를 대체로 넘김
+
+## 10. 통합 순서
+
+1. 세션 A PR — 계약·가격표·원장·계측·schema 1.4·테스트
+2. 세션 B PR — 투영·보고서·게시·집계·대시보드
+3. A 먼저 병합
+4. B를 최신 main에 rebase, 전체 CI
+5. 모델 없는 end-to-end fixture로 작업별·실험별 합계 검증
+6. 통합 담당 세션에서만 실제 Smoke 1회
+7. Smoke가 완전하면 Pilot, 이후 Full


### PR DESCRIPTION
Records what each task actually cost — once to solve, once to grade — as a
receipt written at the moment the money was spent, rather than a number
reconstructed afterwards from whatever survived.

This is Session A of a two-session split. Session B (#256) consumes what this
produces; the contract between them is frozen on the Project #5 card. Session A
merges first.

---

## ⚠️ Do not merge while a grading run is in flight

At the time of writing, `exp_gold_baseline` is mid-flight: shards 0 and 2 of 3
have committed to `main`, and shard 1 (run `33187134567`) is still running.
**Merging this PR before that run's merge step completes will destroy it, after
the money has already been spent.** Two independent reasons:

1. **Schema version.** Step9 pins each shard's `schema_version` against the
   current contract constant, not just against its siblings. This PR takes that
   constant from `1.3` to `1.4`. Verified directly against the two real shard
   files now on `main`:

   ```
   ShardMergeError: shard merge identity mismatch for schema_version:
   s0='1.3', current contract='1.4'
   ```

2. **`grader_source_hash`.** `compute_grader_source_hash` digests
   `step8_grade.py`, **every** `core/**/*.py`, and `schemas/grade.schema.json`.
   This PR adds two core modules and edits four more, plus step8 and the schema.
   Shard 1 running against a post-merge checkout would record a different hash
   from its two already-committed siblings, and step9 would refuse the merge —
   again only after the spend.

Neither is a defect introduced here; both are the existing guards doing their
job. They just make merge timing load-bearing. **Wait for `data/grades/` to hold
the merged `exp_gold_baseline` final, then merge.**

## What gets recorded

A receipt is written per `(task, bucket)`, where bucket is `problem_solving` or
`grading`. Every model call is **reserved before it goes out** and **settled when
the response comes back**, so a call that was billed but whose answer was thrown
away still appears — and a call that failed before it ever left the process does
not.

The ledger is append-only SQLite with `synchronous=FULL`, keyed by a
deterministic `call_id` = `sha256(run_id|task_id|stage|retry_kind|attempt_index|
sequence)`. That primary key is the whole concurrency story: two processes
racing to settle the same call cannot double-bill it, and a resumed round
re-walking its own history re-reserves rows it already has instead of resetting
them.

Stages are `preprocessing`, `generation`, `self_qa`, `grading`, `perception`.
Retry kinds are `none`, `semantic`, `infrastructure`, `resume`,
`internal_recovery`.

## Refusing to invent a number

`estimated_cost_usd` is a number **only** when status is `complete` — every call
settled, every model priced. Otherwise it is `null`, and whatever *is* known
goes to `known_cost_usd` as a floor. The distinction that matters: a task with
an unpriced model is not a task that cost `$0`.

Specifically:

- **No near-miss pricing.** A price is matched on the exact
  `(provider, resolved_model)` the *response* reported, never the deployment
  name that was requested. No fallback to a similar model — `price_missing`,
  `partial`.
- **No double-billing of cached input.** Billable input is
  `input_tokens − cached_input_tokens`.
- **No double-billing of reasoning.** `reasoning_billed_as` is
  `output | separate | unknown`; `unknown` refuses to guess.
- **A request that never came back holds the receipt open.** A timeout may well
  have been billed, so the reservation stays unsettled and the receipt is
  `partial` with `call_reachability_unknown` — not written off as free.
- **Shared runtime is never allocated.** A container billed per-hour across many
  tasks is not divided by task count to produce a plausible-looking number. The
  task receipt stays `partial`. Only directly attributable runtime is priced,
  and it is reported as `runtime_cost_usd`, separately from model cost.

## The paths that are not metered, and what they say instead

Meter coverage is not universal, and the uncovered paths say so rather than
reporting zero:

| Path | Receipt | Reason |
|---|---|---|
| Hardened / agentic substrate | `unavailable` | `stage_unsupported`, plus an explicit console line |
| `agentic_sandbox_v2` | `not_run` | Its executor raises on model clients, credentials, model names, prompts and custom backend factories — it is structurally incapable of spending money |
| Native Codex | — | No execution mode exists |

**Known gap, stated rather than papered over:** there is no regression test on
the `hardened_requested` branch itself. No hardened end-to-end harness exists in
the suite (`hardened=True` is a defined parameter that is never exercised), and
building one needs the signed approval gate. The branch is three lines and is
readable at `step2_run_inference.py:3251-3302`, but it is not pinned by a test,
and a future edit could silently start metering — or silently stop.

## Contract answer for Session B: `components[].name`

Session B asked on the card for the exact slug vocabulary, having assumed
`{generation, self_qa, retry, runtime, grading, perception}` with aliases and an
unknown-slug fallback. The producer previously emitted **no `name` key at all**.
Resolved additively — nothing renamed, nothing removed, no Session B file
touched:

```
COMPONENT_NAMES = (preprocessing, generation, self_qa, grading, perception, retry)
```

`name` is derived: first work carries its stage's name, and anything that had to
be done again is `retry`, because "what did retrying cost" is the question a
reader asks. Neither underlying field is lost — `stage` and `retry_kind` still
travel on the same line.

Five of Session B's six match exactly. `preprocessing` is extra, which their
fallback already handles. **`runtime` is deliberately not emitted**: runtime fees
are not model calls, they are reported as `runtime_cost_usd`, and a component
line carrying them would be counted twice by any reader that sums the lines and
then adds the runtime total. A test pins that absence.

## Published rows, not the live ledger

Step8's `summary.grading_cost` is summed from the task rows via
`CostReceipt.from_dict` — not from the ledger it just wrote. That one choice is
what makes shard merging correct for free: step9 recomputes the merged summary
from merged rows, and the arithmetic agrees by construction. Step9's
cross-shard check compares integer `model_calls`, never rounded decimal money,
so it catches a shard whose receipts silently failed to arrive without
manufacturing a float-comparison flake.

## Nothing sensitive reaches the ledger

No prompt text, no response bodies, no keys, no reasoning traces. Request
identifiers are accepted **only** as SHA-256 digests — passing anything that
isn't one raises. The export is byte-reproducible, so the digest published
beside a grade can actually be checked, and `verify_export` does check it.

## Tests

`5171 passed, 6 skipped, 45 deselected` on this head — full suite, exit 0. 512
of those cover the cost surface directly, across five new files:

- `test_cost_receipts_keep_every_call_that_happened.py` — a call that happened stays recorded
- `test_cost_receipts_never_invent_a_number.py` — the refusals above
- `test_cost_receipts_reach_the_pipeline_boundaries.py` — real step2/step8 wiring
- `test_cost_receipts_survive_resume_and_shard_merge.py` — preservation across rounds and merges
- `test_cost_metering_records_what_the_client_sent.py` — the client wrapper

All 16 scenarios required by `tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md`
§8.2 have a test. `test_azure_ai_step2_wiring.py` now looks *through* the
metering wrapper, which pins every executor client slot as metered — a future
unwrapped client fails a test instead of silently going unbilled.

**Every test runs on mocked responses.** No paid model call, no Azure login, no
grading or regrade, no Smoke/Pilot/Full run was performed in this work.

## Also in this PR

`tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md` — the written spec, which the
card referenced but which existed in no checkout. It is written to be
independent of any particular model or provider.
