### PR TITLE
fix(grading): 채점기 도구가 못 보던 네 가지를 보게 만든다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,87 @@ entries land under a fresh dated heading the day they merge to `main`.
   because none of them can run.
 
 ### Fixed
+- **A task made entirely of music was graded without anything ever listening to
+  it.** Stage-1 task `38889c3b` delivers its whole answer as one 180 MB `.zip`
+  of audio stems and is marked on tempo, key, vocals, effects and mix. It
+  recorded `perception_call_count: 0` and scored 41.8 of 62. The cause is one
+  line of routing: an audio criterion whose files carry no audio is demoted to
+  the reading path, and the test for "carries audio" was the file extension.
+  `.zip` is not an audio extension, so every listening criterion on that task
+  was demoted and answered by reading an archive listing. A container is a fact
+  about packaging, not about the medium. New `has_audio_content()` opens the
+  archive and looks, and routing now keeps the listening model on a criterion
+  whose files really do hold audio. **Measured against that run's own recorded
+  routing, across all 1,428 items of the 30-task cohort: exactly 10 items move,
+  all of them on this one task, all of them to the listening path** (7 from the
+  reading path, 3 from the formatting path). Together they hold 18 points — 9.5
+  the task lost and 8.5 it already earned, which the change must not undo.
+  About 5.5 of the 9.5 are reachable; the
+  rest need more than the first 30 seconds, which `trim_seconds` in the frozen
+  grading config fixes, or need signal measurements no listening model performs.
+  The probe is used **defensively only** — it can stop a demotion, it can never
+  route a criterion on its own — so "the file is named correctly" on a music
+  task stays on the reading path instead of spending one of the three listening
+  calls a task is allowed.
+- **`audio_judge` could only be handed a whole file, so a stem inside an archive
+  was unreachable even once routing pointed at it.** The tool now takes an
+  optional `member`, extracts that one entry for the duration of the call, and
+  cleans it up afterwards; naming an entry that is not there returns the
+  archive's real contents so the next call can succeed, which is the same answer
+  `read_deliverable` gives for the same mistake.
+- **The blast radius is one file.** Across all 248 gold deliverable files the
+  new probe answers *yes* exactly once — the stems archive above. Every one of
+  the 146 Office deliverables answers *no*, because an `.xlsx` is a zip
+  container but not an archive of media, so the defect PR #93 fixed ("Sound
+  Technician fees" on a tour budget routing to audio) stays fixed and is now
+  pinned end-to-end rather than at the routing call alone. One gold `.zip` will
+  not open at all; the probe reports *unknown* rather than *no*, which leaves
+  the existing extension rule in charge instead of promoting towards a file
+  nothing can extract.
+- **An empty read was treated as proof the content was absent.** On stage-1
+  task `43dc9778` the judge read a two-page scan that has no text layer,
+  `read_content` returned `"text": "", "char_count": 0`, and **ten rubric items
+  about that document's contents were failed on that alone — 13 points** — for
+  a document that says all ten things, on pages the harness had already
+  rendered for the same task's other items. Reads that come back empty now say
+  *why* (no text layer, an unsupported kind, a genuinely empty file) and name
+  the op that can still answer, and the judge's standing instructions now say
+  that "I could not read it" is not "it is not there". A second, narrower net
+  routes an item whose files *all* fail to read to the path that looks at them
+  instead: only a *measured* "no text" counts, only text and formatting items
+  escalate, and every selected file must be renderable, so it can only fire
+  where the run currently produces `required_visual_render_target_unavailable`
+  anyway. **Measured across all 1,428 items of the 30-task gold cohort, that
+  escalation fires on none of them** — the one text-less file in the corpus is
+  always selected alongside a readable companion — so on this cohort the repair
+  is the honest empty result and the instruction that goes with it, and the
+  added vision cost is zero.
+- **"Does it fit on one page" was answered from a character count.** A `.docx`
+  stores no pagination — the number does not exist until something lays the
+  document out — so six stage-1 items asking about length were answered from
+  `paragraph_count` or `char_count`, and five were marked down against gold
+  answers that were the right length. `inspect_structure` now converts with the
+  same LibreOffice the render path uses and reports `converted_page_count`; a
+  missing converter costs that one number and nothing else. Separately, a gold
+  answer lost an orientation item because the only geometry a judge could see
+  was `page_count: 1` — the page was 432×288, landscape, exactly as asked — so
+  both PDF ops now report page sizes, orientation and whether the pages are
+  uniform.
+- **The judge's standing instructions got longer, so the marking cost envelope
+  was re-measured instead of left quoting the old length.** Telling the judge
+  what an empty read means, and which op can still answer, took the committed
+  `prompts/grader_judge_v2.md` from **6,263 to 6,772 characters**. That length
+  is not decoration: the file is read from disk and sent on every single
+  marking call, so it is counted into what one call can carry. The opening
+  every call carries rises from **2,656 to 2,825 tokens** and the demanded
+  input per call from **535,990 to 536,159**. Running the free check on this
+  branch and on `main` shows those figures are the *only* difference in its 98
+  lines of output — the same 14 problems, the same ceiling, the same approved
+  maximum, the same non-zero exit. The figures quoted in the earlier entries in
+  this section were correct when they were measured and are superseded by
+  these. Five cost tests failed on the old number and were corrected to the new
+  measurement rather than loosened: a length that has stopped matching the file
+  is precisely what those tests exist to catch.
 - **Every request was charged 1,068 characters for wording that renders to
   between 3,533 and 5,020, and 345 of the 1,068 were for wording no model ever
   reads.** `instruction_character_count` pays for everything a request carries

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -13,7 +13,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Callable, Iterable, Literal, Optional
 
 from core.azure_ai_clients import (
     AzureAIClientFactory,
@@ -37,6 +37,7 @@ from core.grader_routing import (
     resolve_runtime_routing,
 )
 from core.rubric_loader import RubricItem, TaskRubric
+from core.tools import has_audio_content, has_extractable_text
 
 logger = logging.getLogger(__name__)
 
@@ -279,6 +280,14 @@ class Grader:
                 / 1000.0
             )
             self._last_judge_call_at: float | None = None
+            #: Per-task memos for the two routing probes, reset at the top of
+            #: every ``grade_task``. ``grader_preflight`` builds a Grader
+            #: through ``object.__new__`` and never runs this method, so it
+            #: sets its own; there is no lazy default on purpose, because a
+            #: missing memo should surface as an error rather than as a probe
+            #: silently repeated once per rubric item.
+            self._text_layer_cache: dict[str, bool | None] = {}
+            self._audio_content_cache: dict[str, bool | None] = {}
 
             # Task 207 — the tool-calling judge is the only grading path.
             # The legacy text-extract / batch / tier-routing paths are gone,
@@ -334,6 +343,11 @@ class Grader:
         # PR3 (0531) — reset per-task perception call caps before each task.
         # __init__ guarantees _tool_judge exists, so this is the only path.
         self._tool_judge.reset_perception()
+        # Every rubric item of a task asks about the same files, so the
+        # routing probes are answered once per file per task rather than
+        # once per item. Cleared here for the same reason the caps are.
+        self._text_layer_cache = {}
+        self._audio_content_cache = {}
         return self._grade_task_with_selector(task, deliverable_path, files)
 
 
@@ -353,6 +367,7 @@ class Grader:
                 selection,
                 item,
                 plan_targets_for_criterion(selection, item.criterion),
+                deliverable_path,
             )
             for item in task.rubric_items
         ]
@@ -557,14 +572,72 @@ class Grader:
             grade.error = "no_deliverables"
         return grade
 
+    def _any_selected_path(
+        self,
+        deliverable_path: Path,
+        paths: Iterable[str],
+        probe: Callable[[Path], "bool | None"],
+        memo: dict[str, bool | None],
+    ) -> bool | None:
+        """Ask one yes/no question of a set of files, once per file per task.
+
+        ``True`` as soon as one file answers yes, ``False`` only if every one
+        was examined and none did, and ``None`` the moment a file cannot be
+        answered for. Routing acts on the definite answers alone, so a file
+        the probe cannot speak for must not be allowed to look like a no.
+
+        The probes are I/O, which is why they live here and not in
+        ``grader_routing``: that module is pure and stays that way.
+        """
+        seen_unknown = False
+        seen_any = False
+        for name in paths:
+            if not isinstance(name, str) or not name:
+                continue
+            seen_any = True
+            if name not in memo:
+                memo[name] = probe(deliverable_path / name)
+            answer = memo[name]
+            if answer:
+                return True
+            if answer is None:
+                seen_unknown = True
+        if not seen_any or seen_unknown:
+            return None
+        return False
+
+    def _selected_paths_have_text(
+        self, deliverable_path: Path, paths: Iterable[str]
+    ) -> bool | None:
+        """Does any of these files yield a single character of text?"""
+        return self._any_selected_path(
+            deliverable_path, paths, has_extractable_text, self._text_layer_cache
+        )
+
+    def _selected_paths_have_audio(
+        self, deliverable_path: Path, paths: Iterable[str]
+    ) -> bool | None:
+        """Is any of these files audio, or an archive that holds audio?"""
+        return self._any_selected_path(
+            deliverable_path, paths, has_audio_content, self._audio_content_cache
+        )
+
     def _runtime_criterion_plan(
         self,
         selection: DeliverableSelection,
         item: RubricItem,
         plan: CriterionTargetPlan,
+        deliverable_path: Path,
     ) -> _RuntimeCriterionPlan:
         item_decision = resolve_runtime_routing(
-            item.criterion, plan.selected_paths
+            item.criterion,
+            plan.selected_paths,
+            selected_paths_have_text=self._selected_paths_have_text(
+                deliverable_path, plan.selected_paths
+            ),
+            selected_paths_have_audio=self._selected_paths_have_audio(
+                deliverable_path, plan.selected_paths
+            ),
         )
         target_decisions: dict[str, RoutingDecision] = {}
         raw_visual_paths: list[str] = []
@@ -582,7 +655,16 @@ class Grader:
                 target = target_by_id.get(target_id)
                 if target is None:
                     continue
-                decision = resolve_runtime_routing(item.criterion, target.paths)
+                decision = resolve_runtime_routing(
+                    item.criterion,
+                    target.paths,
+                    selected_paths_have_text=self._selected_paths_have_text(
+                        deliverable_path, target.paths
+                    ),
+                    selected_paths_have_audio=self._selected_paths_have_audio(
+                        deliverable_path, target.paths
+                    ),
+                )
                 target_decisions[target_id] = decision
                 if decision.modality is Modality.VISUAL:
                     raw_visual_paths.extend(target.paths)

--- a/batch-runner/core/grader_preflight.py
+++ b/batch-runner/core/grader_preflight.py
@@ -17,6 +17,11 @@ def _planner(config: dict) -> Grader:
     """Build only the local precheck surface; never initialize an API client."""
     grader = object.__new__(Grader)
     grader.config = config
+    # ``__init__`` never runs here, so the per-task memos the routing probes
+    # write through have to be created by hand. A preflight plans one task,
+    # so one memo for its lifetime is the same scope ``grade_task`` gives it.
+    grader._text_layer_cache = {}
+    grader._audio_content_cache = {}
     return grader
 
 
@@ -88,7 +93,16 @@ def plan_task_runtime(
                     if visual_error is None:
                         visual_error = f"{target_id}: missing target"
                     continue
-                decision = resolve_runtime_routing(item.criterion, target.paths)
+                decision = resolve_runtime_routing(
+                    item.criterion,
+                    target.paths,
+                    selected_paths_have_text=grader._selected_paths_have_text(
+                        deliverable_path, target.paths
+                    ),
+                    selected_paths_have_audio=grader._selected_paths_have_audio(
+                        deliverable_path, target.paths
+                    ),
+                )
                 child_routes.append(decision.modality.value)
                 if decision.modality is Modality.VISUAL:
                     planned_names, child_visual_error = (
@@ -181,8 +195,24 @@ def plan_task_runtime(
                 continue
             precheck_fallbacks += 1
 
+        # The probes are passed here for the same reason this module exists: a
+        # preflight that predicts a route the run will not take is not a check.
+        # It matters in one direction specifically. An item escalated to VISUAL
+        # at run time is the item whose paths must pass
+        # ``validate_planned_visual_names``, and skipping that check here would
+        # let a path the run cannot render reach the run unflagged -- a gate
+        # that fails open on exactly the case it was added to catch. The audio
+        # probe is what keeps ``planned_audio_calls`` and the budget check
+        # below counting the calls the run will really make.
         decision = resolve_runtime_routing(
-            item.criterion, target_plan.selected_paths
+            item.criterion,
+            target_plan.selected_paths,
+            selected_paths_have_text=grader._selected_paths_have_text(
+                deliverable_path, target_plan.selected_paths
+            ),
+            selected_paths_have_audio=grader._selected_paths_have_audio(
+                deliverable_path, target_plan.selected_paths
+            ),
         )
         routes[decision.modality.value] += 1
         supported: list[str] = []

--- a/batch-runner/core/grader_routing.py
+++ b/batch-runner/core/grader_routing.py
@@ -69,6 +69,22 @@ _AUDIO_KEYWORDS: tuple[str, ...] = (
     "audio", "sound", "music", "musical", "voice", "vocal", "mix", "mixing",
     "loudness", "loud", "silence", "silent", "clipping", "noise",
     "instrumentation",
+    # Added on stage-1 evidence, not on taste. Task 38889c3b delivers a
+    # 180 MB archive of music stems and is graded on tempo, key, vocals and
+    # effects; it scored 41.8/62 with ``perception_call_count: 0``. Every
+    # criterion below matched nothing above and was judged by reading a zip.
+    #
+    # The bar for adding one is that it names a property of sound and would
+    # be odd in a rubric about a report. "instrumental", "stem" and "track"
+    # were considered and rejected: "was instrumental in", "the delay stems
+    # from" and "on track" are ordinary business English. "key" was rejected
+    # outright. A word that slips through anyway is cheap -- a criterion that
+    # routes AUDIO against files holding no audio is demoted back to TEXT by
+    # ``resolve_runtime_routing`` before any model sees it.
+    "vocals", "tempo", "bpm", "harmonic", "harmony", "harmonies",
+    "melody", "melodic", "timbre", "audible", "audibly", "reverb",
+    "synth", "synths", "synthesizer", "synthesizers",
+    "waveform", "octave", "chord", "chords",
 )
 _FORMATTING_KEYWORDS: tuple[str, ...] = (
     "format", "formatted", "formatting", "style", "styles", "styling",
@@ -151,9 +167,24 @@ def classify_criterion(criterion_text: str) -> RoutingDecision:
 
 
 def resolve_runtime_routing(
-    criterion_text: str, selected_paths: Iterable[str]
+    criterion_text: str,
+    selected_paths: Iterable[str],
+    *,
+    selected_paths_have_text: bool | None = None,
+    selected_paths_have_audio: bool | None = None,
 ) -> RoutingDecision:
-    """Apply target-aware policy without changing criterion classification."""
+    """Apply target-aware policy without changing criterion classification.
+
+    ``selected_paths_have_text`` is the caller's answer to "does any selected
+    file yield a single character of text". The caller reads the files; this
+    module stays pure. ``None`` means unknown and changes nothing -- only a
+    measured ``False`` escalates.
+
+    ``selected_paths_have_audio`` is the same shape of answer to "is there
+    anything here to listen to", and is used only defensively: a measured
+    ``True`` stops the demotion below from stripping the listening model off a
+    criterion about sound. It can never promote a criterion on its own.
+    """
     decision = classify_criterion(criterion_text)
     suffixes = {
         suffix
@@ -166,17 +197,29 @@ def resolve_runtime_routing(
         and suffixes
         and suffixes.issubset({".doc", ".docx"})
     ):
-        return RoutingDecision(
+        decision = RoutingDecision(
             modality=Modality.FORMATTING,
             preferred_op="inspect_formatting",
             matched_keywords=decision.matched_keywords,
         )
-    if (
+    # A criterion about a mix has no meaning against a spreadsheet, so an
+    # AUDIO classification whose files carry no audio is demoted to the path
+    # that can actually answer it.
+    #
+    # Until now that test was the file extension alone, which reads a
+    # container as if it were a medium. A folder of stems delivered as one
+    # ``.zip`` is audio; ``.zip`` is disjoint from the audio extensions; and
+    # so every listening criterion on stage-1 task 38889c3b was demoted to
+    # TEXT and answered by reading an archive. The measured probe is what the
+    # extension was standing in for, so where it speaks it wins, and where it
+    # says nothing the extension test is unchanged.
+    elif (
         decision.modality is Modality.AUDIO
+        and selected_paths_have_audio is not True
         and suffixes
         and suffixes.isdisjoint(GRADER_AUDIO_EXTENSIONS)
     ):
-        return RoutingDecision(
+        decision = RoutingDecision(
             modality=Modality.TEXT,
             preferred_op="read_content",
             matched_keywords=decision.matched_keywords,
@@ -208,15 +251,43 @@ def resolve_runtime_routing(
     # selected file is renderable, which is exactly the set that currently
     # errors out. Nor can it answer from a partial view the way raising the
     # file cap would -- the text is handed over whole.
-    if (
+    elif (
         decision.modality is Modality.VISUAL
         and is_overall_style_criterion(criterion_text)
         and suffixes
         and suffixes.isdisjoint(GRADER_VISUAL_RENDER_EXTENSIONS)
     ):
-        return RoutingDecision(
+        decision = RoutingDecision(
             modality=Modality.TEXT,
             preferred_op="read_content",
+            matched_keywords=decision.matched_keywords,
+        )
+
+    # The mirror image of the demotions above, and the last rule because it
+    # judges the outcome of all of them: a file with no text in it answers
+    # nothing from its text.
+    #
+    # One stage-1 gold answer is a two-page scan. Ten rubric items about its
+    # contents routed TEXT, read zero characters, and were failed as "that
+    # content is absent" -- from a document that says all ten things, on pages
+    # the harness had already rendered for the task's other items. Reading is
+    # not the only way to see a page, so an item whose only files cannot be
+    # read goes to the path that looks at them.
+    #
+    # Three conditions keep this narrow. Only a measured ``False`` counts, so
+    # an unreadable or unsupported file cannot escalate on a guess. Only TEXT
+    # and FORMATTING escalate, because AUDIO and VISUAL already name what they
+    # need. And every selected file must be renderable, so escalating never
+    # trades a readable file for one nothing can look at.
+    if (
+        selected_paths_have_text is False
+        and decision.modality in (Modality.TEXT, Modality.FORMATTING)
+        and suffixes
+        and suffixes.issubset(GRADER_VISUAL_RENDER_EXTENSIONS)
+    ):
+        return RoutingDecision(
+            modality=Modality.VISUAL,
+            preferred_op="render_to_image",
             matched_keywords=decision.matched_keywords,
         )
     return decision

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -49,6 +49,7 @@ import math
 import re
 import time
 from collections.abc import Mapping
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -63,7 +64,9 @@ from core.rubric_loader import RubricItem, TaskRubric
 from core.tools import (
     MODEL_READ_DELIVERABLE_OPS,
     MODEL_READ_DELIVERABLE_TOOL_SCHEMA,
+    open_archive_member,
     read_deliverable,
+    ReadDeliverableError,
 )
 
 logger = logging.getLogger(__name__)
@@ -990,6 +993,17 @@ class ToolCallingJudge:
                 "properties": {
                     "criterion": {"type": "string"},
                     "audio_path": {"type": "string"},
+                    "member": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "Optional. When audio_path is a .zip, the exact "
+                            "name of the audio member to listen to, taken "
+                            "from a read_deliverable inspect_structure "
+                            "listing. An archive of stems is audio that was "
+                            "delivered zipped; name the member and it is "
+                            "heard like any other file."
+                        ),
+                    },
                 },
                 "required": ["criterion", "audio_path"],
                 "additionalProperties": False,
@@ -1069,12 +1083,41 @@ class ToolCallingJudge:
                     "error": "audio_path does not resolve to a file",
                     "error_type": "bad_path",
                 }
+            # A stem inside an archive is audio the same way a page inside a
+            # PDF is a page. Without this the listening model could be handed
+            # nothing but a ``.zip``, which is not a thing it can hear, and
+            # the one stage-1 task made entirely of music had its whole
+            # deliverable packaged that way.
+            member = args.get("member")
+            if member is not None and not isinstance(member, str):
+                return {
+                    "ok": False,
+                    "error": "member must be a string",
+                    "error_type": "bad_args",
+                }
             try:
-                v = self.audio_perception.judge(
-                    criterion=args.get("criterion", ""),
-                    audio_path=str(resolved_audio_path),
+                source = (
+                    open_archive_member(resolved_audio_path, member)
+                    if member
+                    else nullcontext(resolved_audio_path)
                 )
+                with source as audio_file:
+                    v = self.audio_perception.judge(
+                        criterion=args.get("criterion", ""),
+                        audio_path=str(audio_file),
+                    )
                 return {"ok": v.judge_error is None, "data": v.to_dict()}
+            except ReadDeliverableError as exc:
+                # Naming a member that is not in the archive is the judge's
+                # own mistake to correct, so it gets the message -- which
+                # lists what the archive does hold. This is the same envelope
+                # ``read_deliverable`` returns for the same mistake made
+                # through ``scope={"member": ...}``.
+                return {
+                    "ok": False,
+                    "error": str(exc),
+                    "error_type": "bad_scope",
+                }
             except Exception as exc:  # noqa: BLE001
                 return {
                     "ok": False,

--- a/batch-runner/core/tools/__init__.py
+++ b/batch-runner/core/tools/__init__.py
@@ -7,6 +7,9 @@ or any file under the trusted base directory.
 
 from .read_deliverable import (
     get_renderer_fingerprint,
+    has_audio_content,
+    has_extractable_text,
+    open_archive_member,
     read_deliverable,
     ReadDeliverableError,
     RendererDependencyError,
@@ -18,6 +21,9 @@ from .read_deliverable import (
 
 __all__ = [
     "get_renderer_fingerprint",
+    "has_audio_content",
+    "has_extractable_text",
+    "open_archive_member",
     "read_deliverable",
     "ReadDeliverableError",
     "RendererDependencyError",

--- a/batch-runner/core/tools/read_deliverable.py
+++ b/batch-runner/core/tools/read_deliverable.py
@@ -37,7 +37,7 @@ import tempfile
 from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from core.media_types import GRADER_AUDIO_EXTENSIONS
 
@@ -78,6 +78,15 @@ _ZIP_NOISE_BASENAMES = ("._",)
 
 MAX_PAGES_DEFAULT = 200       # PDF page-iteration safety cap
 MAX_SHEETS = 100              # workbook safety cap
+
+#: Page geometry. A rubric asks "is it landscape", "is it letter size", "does
+#: it fit on one page" -- questions about the page, which a page count alone
+#: cannot answer. Measured pages are reported as one row per distinct size, so
+#: a uniform 200-page report costs one row and a document that turns landscape
+#: halfway costs two. Points are the PDF unit; inches are carried alongside
+#: because that is the unit rubrics are written in.
+MAX_PDF_PAGE_SIZE_GROUPS = 20
+PDF_POINTS_PER_INCH = 72.0
 RENDERER_VERSION_TIMEOUT_SEC = 10
 RENDERER_VERSION_MAX_CHARS = 200
 
@@ -100,9 +109,11 @@ READ_DELIVERABLE_TOOL_SCHEMA: Dict[str, Any] = {
                 "enum": list(READ_DELIVERABLE_OPS),
                 "description": (
                     "Operation to perform. "
-                    "inspect_structure: file type + sheets/pages/slides summary. "
+                    "inspect_structure: file type, sheets/slides, page count "
+                    "and page size. "
                     "read_content: textual content (no truncation up to cap). "
-                    "inspect_formatting: cell fills/fonts/borders/charts/styles. "
+                    "inspect_formatting: cell fills/fonts/borders/charts/styles, "
+                    "plus page count and page size. "
                     "render_to_image: PNG (base64) of an allowed first/page surface. "
                     "probe_audio: sample-rate/channels/duration/peak/silence. "
                     "probe_video: codec/duration/resolution/fps."
@@ -146,6 +157,21 @@ MODEL_READ_DELIVERABLE_TOOL_SCHEMA: Dict[str, Any] = {
             "op": {
                 "type": "string",
                 "enum": list(MODEL_READ_DELIVERABLE_OPS),
+                "description": (
+                    "inspect_structure: kind, size, sheets/slides, and for a "
+                    "document or PDF the page count "
+                    "(page_count, or converted_page_count for a .docx, which "
+                    "stores no pagination of its own) and the page size "
+                    "(width_pt/height_pt, width_in/height_in, orientation). "
+                    "How long a document is and which way its pages face are "
+                    "answerable ONLY from these fields: paragraph_count and "
+                    "char_count are lengths, not page counts, and must never "
+                    "be used as one. "
+                    "read_content: text. "
+                    "inspect_formatting: styles, fills, fonts, borders, and "
+                    "the same page count and page size. "
+                    "probe_audio / probe_video: media metadata."
+                ),
             },
             "path": {
                 "type": "string",
@@ -153,7 +179,14 @@ MODEL_READ_DELIVERABLE_TOOL_SCHEMA: Dict[str, Any] = {
             },
             "scope": {
                 "type": ["object", "null"],
-                "description": "Optional op-specific content/formatting scope.",
+                "description": (
+                    "Optional op-specific content/formatting scope. To reach "
+                    "a file inside a .zip deliverable, pass "
+                    "{\"member\": \"<exact name from the listing>\"} to any "
+                    "op -- probe_audio for a stem, read_content for a "
+                    "document. An archive is a container of files this tool "
+                    "already reads, not an unreadable binary."
+                ),
                 "additionalProperties": True,
             },
         },
@@ -260,12 +293,62 @@ def _inspect_xlsx(p: Path) -> Dict[str, Any]:
     }
 
 
+@lru_cache(maxsize=64)
+def _cached_docx_page_count(identity: Tuple[str, int, int]) -> int:
+    """Lay a .docx out once per ``(path, size, mtime_ns)``.
+
+    Structure inspection and formatting inspection both want this number, a
+    judge asks for each more than once per file, and every Writer conversion
+    costs seconds. The key moves whenever the file does, so a cached count can
+    never outlive the bytes it was measured from.
+    """
+    source = Path(identity[0])
+    with tempfile.TemporaryDirectory(prefix="gdpval-grade-pagecount-") as temp:
+        return _pdf_page_count(_convert_office_to_pdf(source, Path(temp)))
+
+
+def _docx_converted_page_count(p: Path) -> Dict[str, Any]:
+    """How many pages this .docx lays out to, or why that is not knowable.
+
+    A .docx stores no pagination -- the count does not exist until a layout
+    engine computes one -- so this converts with the same LibreOffice the
+    render path uses and counts what came out. Reported under the render
+    path's name for the same reason it is the same number.
+
+    Six stage-1 rubric items asked "does it fit on one page" and were answered
+    from ``paragraph_count`` or ``char_count``, neither of which is a page
+    count. Five were marked down and the gold answers were the right length.
+
+    Never raises. A missing or failing converter costs the page count and
+    nothing else: the paragraph, table and style counts around it stay, and
+    the judge is told the number is unknown rather than handed a proxy.
+    """
+    try:
+        stat = p.stat()
+        return {
+            "converted_page_count": _cached_docx_page_count(
+                (str(p), stat.st_size, stat.st_mtime_ns)
+            )
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "converted_page_count": None,
+            "page_count_error": f"{type(exc).__name__}: {exc}",
+            "page_count_note": (
+                "page count unavailable for this document; paragraph_count "
+                "and char_count are lengths, not page counts, and cannot "
+                "stand in for one"
+            ),
+        }
+
+
 def _inspect_docx(p: Path) -> Dict[str, Any]:
     from docx import Document  # type: ignore
 
     doc = Document(str(p))
     return {
         "kind": "docx",
+        **_docx_converted_page_count(p),
         "paragraph_count": len(doc.paragraphs),
         "table_count": len(doc.tables),
         "section_count": len(doc.sections),
@@ -332,6 +415,15 @@ def _zip_entries(p: Path) -> Tuple[List[Dict[str, Any]], int, bool]:
     return entries, hidden, truncated
 
 
+#: Said in all three places a judge can meet an archive -- the tool schema it
+#: is given, the structure listing, and the text read -- because a judge that
+#: does not know a member can be opened reports the archive as unreadable.
+_ZIP_MEMBER_HINT = (
+    "open a member with scope={\"member\": \"<name>\"} on any op, "
+    "e.g. probe_audio for a .wav or read_content for a .docx"
+)
+
+
 def _inspect_zip(p: Path) -> Dict[str, Any]:
     entries, hidden, truncated = _zip_entries(p)
     return {
@@ -340,10 +432,7 @@ def _inspect_zip(p: Path) -> Dict[str, Any]:
         "entries": entries,
         "hidden_resource_fork_count": hidden,
         "truncated": truncated,
-        "note": (
-            "open a member with scope={\"member\": \"<name>\"} on any op, "
-            "e.g. probe_audio for a .wav or read_content for a .docx"
-        ),
+        "note": _ZIP_MEMBER_HINT,
     }
 
 
@@ -352,7 +441,10 @@ def _read_zip_text(p: Path, _scope: Dict[str, Any]) -> str:
 
     A judge that never learns about the member scope still has to be able to
     answer "does the archive contain a Bass stem in WAV format", so the listing
-    itself is the content of an archive.
+    itself is the content of an archive. The hint is repeated here rather than
+    left to ``inspect_structure`` alone because a judge that came straight to
+    ``read_content`` would otherwise see a list of names it has no stated way
+    to open, and conclude the files behind them are unreadable.
     """
     entries, hidden, truncated = _zip_entries(p)
     lines = [f"[Archive: {len(entries)} file(s)]"]
@@ -364,11 +456,12 @@ def _read_zip_text(p: Path, _scope: Dict[str, Any]) -> str:
         lines.append(f"... listing truncated at {MAX_ZIP_ENTRIES} entries")
     if hidden:
         lines.append(f"({hidden} macOS resource-fork entries hidden)")
+    lines.append(_ZIP_MEMBER_HINT)
     return "\n".join(lines)
 
 
 @contextmanager
-def _extracted_zip_member(p: Path, member: str) -> Any:
+def open_archive_member(p: Path, member: str) -> Any:
     """One member on disk, under its own suffix, for the length of one op.
 
     The name has to already be in the archive, so there is no path a caller can
@@ -417,18 +510,110 @@ def _extracted_zip_member(p: Path, member: str) -> Any:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
 
+def _orientation(width_pt: float, height_pt: float) -> str:
+    if width_pt > height_pt:
+        return "landscape"
+    if height_pt > width_pt:
+        return "portrait"
+    return "square"
+
+
+def _summarize_page_sizes(
+    rects: List[Tuple[float, float]],
+) -> Tuple[List[Dict[str, Any]], bool]:
+    """Group measured page rectangles into one row per distinct size."""
+    grouped: Dict[Tuple[float, float], Dict[str, Any]] = {}
+    order: List[Tuple[float, float]] = []
+    for page_number, (width, height) in enumerate(rects, 1):
+        key = (round(float(width), 2), round(float(height), 2))
+        entry = grouped.get(key)
+        if entry is None:
+            grouped[key] = {
+                "width_pt": key[0],
+                "height_pt": key[1],
+                "width_in": round(key[0] / PDF_POINTS_PER_INCH, 2),
+                "height_in": round(key[1] / PDF_POINTS_PER_INCH, 2),
+                "orientation": _orientation(*key),
+                "page_count": 1,
+                "first_page": page_number,
+            }
+            order.append(key)
+        else:
+            entry["page_count"] += 1
+    kept = order[:MAX_PDF_PAGE_SIZE_GROUPS]
+    return [grouped[key] for key in kept], len(order) > len(kept)
+
+
+def _pdf_geometry(
+    rects: List[Tuple[float, float]], page_count: int
+) -> Dict[str, Any]:
+    """The page-geometry block both PDF ops report.
+
+    One stage-1 gold answer lost an orientation item because the only geometry
+    a judge could see was ``page_count: 1``. The page was 432x288 -- landscape,
+    exactly as the rubric asked -- and the answer was marked wrong for it.
+    """
+    sizes, truncated = _summarize_page_sizes(rects)
+    uniform = len(sizes) == 1 and not truncated
+    geometry: Dict[str, Any] = {
+        "pages_measured": len(rects),
+        "page_sizes": sizes,
+        "page_size_uniform": uniform,
+    }
+    if uniform:
+        geometry["orientation"] = sizes[0]["orientation"]
+    if truncated:
+        geometry["page_sizes_truncated"] = True
+    if len(rects) < page_count:
+        # Only the measured prefix is described. Say so rather than let
+        # "uniform" be read as a claim about pages nothing looked at.
+        geometry["pages_measured_capped"] = True
+    return geometry
+
+
+def _fitz_page_rects(doc: Any) -> List[Tuple[float, float]]:
+    rects: List[Tuple[float, float]] = []
+    for index in range(min(doc.page_count, MAX_PAGES_DEFAULT)):
+        rect = doc.load_page(index).rect
+        rects.append((float(rect.width), float(rect.height)))
+    return rects
+
+
+def _pdf_page_count(p: Path) -> int:
+    try:
+        import fitz  # type: ignore
+    except ImportError:
+        import pdfplumber  # type: ignore
+        with pdfplumber.open(p) as pdf:
+            return len(pdf.pages)
+    doc = fitz.open(str(p))
+    try:
+        return doc.page_count
+    finally:
+        doc.close()
+
+
 def _inspect_pdf(p: Path) -> Dict[str, Any]:
     try:
         import fitz  # type: ignore
     except ImportError:
         import pdfplumber  # type: ignore
         with pdfplumber.open(p) as pdf:
-            return {"kind": "pdf", "page_count": len(pdf.pages)}
+            rects = [
+                (float(page.width), float(page.height))
+                for page in pdf.pages[:MAX_PAGES_DEFAULT]
+            ]
+            return {
+                "kind": "pdf",
+                "page_count": len(pdf.pages),
+                **_pdf_geometry(rects, len(pdf.pages)),
+            }
     doc = fitz.open(str(p))
     try:
         return {
             "kind": "pdf",
             "page_count": doc.page_count,
+            **_pdf_geometry(_fitz_page_rects(doc), doc.page_count),
             "metadata": dict(doc.metadata or {}),
         }
     finally:
@@ -661,6 +846,199 @@ def _read_pptx_text(p: Path, _scope: Dict[str, Any]) -> str:
     return "\n\n".join(parts)
 
 
+# ── an empty read is a fact about the file, not about its content ────
+#
+# One stage-1 gold answer is a two-page scan. Its text layer is empty, so
+# ``read_content`` returned ``char_count: 0`` and ten rubric items were graded
+# "that content is absent" -- about a document that contains all ten things,
+# in ink, on pages the harness had already rendered twice. Nothing lied: the
+# tool said the text was empty and the judge read empty text as an empty
+# document. So the tool now says which of the two it means.
+
+
+#: Attached to every empty read. The distinction it draws is the whole of
+#: this section: "I could not read it here" and "it is not there" are
+#: different findings, and only one of them is a reason to fail an item.
+_EMPTY_READ_DISCLAIMER = (
+    "an empty text read means this file carries no extractable text, NOT "
+    "that the content is absent; grade absence only from a file that was "
+    "actually read"
+)
+
+#: For the kinds that hold no text at all, the op that does read them. A
+#: judge told only "unsupported" has been told the file is a dead end.
+_NON_TEXT_READ_ROUTES: Dict[str, str] = {
+    "audio": (
+        "call probe_audio for sample rate, channels, duration, peak level "
+        "and silence"
+    ),
+    "video": (
+        "call probe_video for codec, duration, resolution and frame rate"
+    ),
+    "image": (
+        "call inspect_structure for kind and size; an image is judged from "
+        "the rendered visual evidence the harness supplies, not from text"
+    ),
+}
+
+
+def _pdf_text_layer_facts(p: Path) -> Dict[str, Any]:
+    """Pages and embedded images of a PDF that yielded no text.
+
+    A scan and an empty file both read as zero characters. These two numbers
+    tell them apart: two pages carrying two images is a scan whose content is
+    in the images, and zero pages is a file with nothing in it.
+
+    Never raises -- this runs on the failure path of a read that already
+    returned nothing, and losing the read as well would leave the judge with
+    strictly less than it has today.
+    """
+    try:
+        import fitz  # type: ignore
+    except ImportError:
+        try:
+            import pdfplumber  # type: ignore
+
+            with pdfplumber.open(p) as pdf:
+                return {"page_count": len(pdf.pages)}
+        except Exception:  # noqa: BLE001
+            return {}
+    try:
+        doc = fitz.open(str(p))
+    except Exception:  # noqa: BLE001
+        return {}
+    try:
+        images = 0
+        for index in range(min(doc.page_count, MAX_PAGES_DEFAULT)):
+            images += len(doc.load_page(index).get_images(full=True))
+        return {"page_count": doc.page_count, "embedded_image_count": images}
+    except Exception:  # noqa: BLE001
+        return {}
+    finally:
+        doc.close()
+
+
+def _empty_read_report(p: Path, kind: str) -> Tuple[Dict[str, Any], str]:
+    """Structured facts and a note describing what an unreadable file is."""
+    if kind != "pdf":
+        return {"has_text_layer": False}, f"no extractable text -- {_EMPTY_READ_DISCLAIMER}"
+
+    facts: Dict[str, Any] = {"has_text_layer": False}
+    facts.update(_pdf_text_layer_facts(p))
+    images = facts.get("embedded_image_count")
+    pages = facts.get("page_count")
+    if images:
+        what = (
+            f"this PDF has no text layer: its {pages} page(s) carry {images} "
+            f"embedded image(s), so the content is in the page images -- it "
+            f"is a scan or an exported graphic, not an empty document"
+        )
+    elif pages == 0:
+        what = "this PDF has no pages"
+    else:
+        what = "this PDF has no text layer"
+    return facts, f"{what} -- {_EMPTY_READ_DISCLAIMER}"
+
+
+def _pdf_has_text(p: Path) -> Optional[bool]:
+    """Whether any page of a PDF yields a character. ``None`` if unknowable.
+
+    Returns on the first character found, so an ordinary document costs one
+    page. A scan costs every page, which is the only way to be sure of a
+    negative, and is cheap on pages whose content stream is one image draw.
+    """
+    try:
+        import fitz  # type: ignore
+    except ImportError:
+        import pdfplumber  # type: ignore
+
+        with pdfplumber.open(p) as pdf:
+            for page in pdf.pages[:MAX_PAGES_DEFAULT]:
+                if (page.extract_text() or "").strip():
+                    return True
+            return None if len(pdf.pages) > MAX_PAGES_DEFAULT else False
+
+    doc = fitz.open(str(p))
+    try:
+        for index in range(min(doc.page_count, MAX_PAGES_DEFAULT)):
+            if doc.load_page(index).get_text().strip():
+                return True
+        return None if doc.page_count > MAX_PAGES_DEFAULT else False
+    finally:
+        doc.close()
+
+
+def has_extractable_text(path: Union[str, Path]) -> Optional[bool]:
+    """Whether this file yields any text at all. ``None`` means unknowable.
+
+    Routing asks this, not the judge. A file with no text layer answers no
+    criterion from its text -- every question about its content is a question
+    about its pages -- and the grader uses that to hand the item to the render
+    and vision path instead of letting an empty read stand as an answer.
+
+    ``False`` is a positive claim and is only returned when the whole file was
+    examined. Anything unexamined, unsupported, or broken is ``None``: routing
+    must not escalate on a guess, and the caller treats the two differently.
+    """
+    p = Path(path)
+    if not p.is_file():
+        return None
+    kind = _kind_of(p)
+    if kind == "image":
+        # Not a failure to read. An image has no text layer by construction,
+        # which is exactly the fact routing wants.
+        return False
+    try:
+        if kind == "pdf":
+            return _pdf_has_text(p)
+        if kind == "docx":
+            return bool(_read_docx_text(p, {}).strip())
+        if kind == "pptx":
+            return bool(_read_pptx_text(p, {}).strip())
+        if kind == "xlsx":
+            return bool(_read_xlsx_text(p, {}).strip())
+        if kind in ("txt", "csv"):
+            return bool(p.read_text(encoding="utf-8", errors="replace").strip())
+    except Exception:  # noqa: BLE001
+        return None
+    # audio, video, zip, unknown: text is not the medium, and "this file has
+    # no text" would be read as a finding about a file nothing can read here.
+    return None
+
+
+def has_audio_content(path: Union[str, Path]) -> Optional[bool]:
+    """Whether there is anything here for the listening model to hear.
+
+    Routing asks this, and the interesting answer is the archive. A folder of
+    stems delivered as one ``.zip`` is an audio deliverable; the container
+    extension is a fact about packaging, not about the medium. Reading it as
+    a statement about the medium is how a stage-1 task made entirely of music
+    -- tempo, key, vocals, mix -- was graded end to end without a single
+    listening call.
+
+    ``True`` for an audio file or an archive holding one. ``False`` is a
+    positive claim and means the file was examined and carries no audio.
+    ``None`` is an admission -- missing file, unreadable archive, or a member
+    list that was cut short and may have stopped one entry before the audio --
+    so that routing never promotes on a guess.
+    """
+    p = Path(path)
+    if not p.is_file():
+        return None
+    kind = _kind_of(p)
+    if kind == "audio":
+        return True
+    if kind != "zip":
+        return False
+    try:
+        entries, _hidden, truncated = _zip_entries(p)
+    except Exception:  # noqa: BLE001
+        return None
+    if any(entry["kind"] == "audio" for entry in entries):
+        return True
+    return None if truncated else False
+
+
 def _op_read_content(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
     kind = _kind_of(p)
     if kind == "xlsx":
@@ -676,11 +1054,34 @@ def _op_read_content(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
     elif kind == "zip":
         text = _read_zip_text(p, scope)
     else:
-        return {"kind": kind, "text": "", "note": "binary or unsupported for text read"}
+        route = _NON_TEXT_READ_ROUTES.get(kind)
+        note = "this file holds no text"
+        if route:
+            note = f"{note}; {route}"
+        return {"kind": kind, "text": "", "char_count": 0, "truncated": False,
+                "has_text_layer": False,
+                "note": f"{note} -- {_EMPTY_READ_DISCLAIMER}"}
     truncated = len(text) > MAX_CONTENT_CHARS
     if truncated:
         text = text[:MAX_CONTENT_CHARS]
-    return {"kind": kind, "text": text, "char_count": len(text), "truncated": truncated}
+    result: Dict[str, Any] = {"kind": kind, "text": text,
+                              "char_count": len(text), "truncated": truncated}
+    notes: List[str] = []
+    if kind == "docx":
+        # The one required item stage 1 failed was failed here: 6,532
+        # characters were read as "longer than one page". Length is not
+        # layout, and the op that does lay the document out is named.
+        notes.append(
+            "char_count is a length, not a page count; call inspect_structure "
+            "for converted_page_count"
+        )
+    if not text.strip():
+        facts, empty_note = _empty_read_report(p, kind)
+        result.update(facts)
+        notes.append(empty_note)
+    if notes:
+        result["note"] = " | ".join(notes)
+    return result
 
 
 # ── inspect_formatting ───────────────────────────────────────────────
@@ -815,6 +1216,7 @@ def _format_docx(p: Path, _scope: Dict[str, Any]) -> Dict[str, Any]:
         styles[para.style.name] = styles.get(para.style.name, 0) + 1
     return {
         "kind": "docx",
+        **_docx_converted_page_count(p),
         "paragraph_count": len(doc.paragraphs),
         "table_count": len(doc.tables),
         "section_count": len(doc.sections),
@@ -859,6 +1261,7 @@ def _op_inspect_formatting(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
                     for f in page.get_fonts(full=False):
                         fonts.add(f[3])
                 return {"kind": "pdf", "page_count": doc.page_count,
+                        **_pdf_geometry(_fitz_page_rects(doc), doc.page_count),
                         "fonts": sorted(fonts)[:50]}
             finally:
                 doc.close()
@@ -1455,7 +1858,7 @@ def read_deliverable(
             member = scope.pop("member")
             if not isinstance(member, str) or not member:
                 raise InvalidScope("scope key 'member' must be a non-empty string")
-            with _extracted_zip_member(resolved, member) as member_path:
+            with open_archive_member(resolved, member) as member_path:
                 return _envelope_ok(fn(member_path, scope))
         data = fn(resolved, scope)
         return _envelope_ok(data)

--- a/batch-runner/prompts/grader_judge_v2.md
+++ b/batch-runner/prompts/grader_judge_v2.md
@@ -29,9 +29,16 @@ image bytes and cannot invoke rendering or vision yourself.
 4. **PII redaction.** Replace personal names, emails, phone numbers, etc.
    in the `evidence` quote with `[REDACTED]`.
 
-5. **No hallucination.** If a tool call returns nothing useful, say so in
-   `reasoning` and return `fail` with evidence describing what is
-   missing. Never assume facts not observed via a tool.
+5. **No hallucination, and no absence you did not observe.** Never assume
+   facts not observed via a tool. Equally, "I could not read it" is not
+   "it is not there": a result carrying `has_text_layer: false` means the
+   file holds no extractable text, not that it holds no content. Before
+   failing an item on an empty result, try the op that suits the file
+   (`inspect_structure`/`inspect_formatting` for page count, size and
+   layout; `probe_audio`/`probe_video` for media; `scope={"member": "..."}`
+   for a file inside an archive) and use the trusted visual evidence block
+   if one is present. If nothing can ground a verdict, return `fail` and
+   say in `reasoning` which of the two you mean.
 
 6. **No comparison to gold.** A reference/gold deliverable is NOT
    provided. Judge only against the rubric criterion text.

--- a/batch-runner/tests/test_envelope_preflight_prices_the_marking_tool_results.py
+++ b/batch-runner/tests/test_envelope_preflight_prices_the_marking_tool_results.py
@@ -329,9 +329,9 @@ def test_the_real_check_measures_the_scoring_line_instead_of_being_told():
     assert widest > 0, "a width of zero would price the scoring line at nothing"
 
 
-@pytest.mark.parametrize("raised_to", [535_990, 1_000_000])
+@pytest.mark.parametrize("raised_to", [536_159, 1_000_000])
 def test_raising_the_number_to_the_limit_settles_this_rule(raised_to):
-    """535990 is the whole demand: 533334 of tool results, 2656 of opening."""
+    """536159 is the whole demand: 533334 of tool results, 2825 of opening."""
     plan = load_plan(PLAN_PATH)
     plan["cost"]["assumptions"]["grading_input_tokens_per_call"] = raised_to
     result = run_envelope_preflight(plan, root=BATCH_RUNNER_ROOT)

--- a/batch-runner/tests/test_grader_archive_audio_routing.py
+++ b/batch-runner/tests/test_grader_archive_audio_routing.py
@@ -1,0 +1,304 @@
+"""The grader half of "an archive of stems is audio".
+
+``core/grader_routing.py`` decides where an item is judged and is deliberately
+pure, so the question it now asks -- *is any selected file audio, or an archive
+that holds audio* -- has to be answered by whoever is allowed to touch the
+disk. That is ``Grader._selected_paths_have_audio``, and this file covers it
+plus the two places that call it: the paid run and the model-free preflight
+that is supposed to predict the paid run exactly.
+
+The defect being fixed: stage 1 graded a task made entirely of music -- tempo,
+key, vocals, mix -- whose whole deliverable is one 180 MB ``.zip`` of stems.
+``.zip`` is not an audio extension, so every listening criterion was demoted to
+TEXT and answered by reading an archive listing. The task recorded
+``perception_call_count: 0`` and scored 41.8 of 62.
+
+The companion file ``test_grader_empty_read_routing.py`` does the same job for
+the text probe; the two share one engine, ``Grader._any_selected_path``.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from core.grader import Grader
+from core.grader_preflight import _planner, plan_task_runtime
+from core.rubric_loader import RubricItem, TaskRubric
+
+
+def _probe_surface() -> Grader:
+    """A Grader with nothing on it but what the probe needs.
+
+    ``__init__`` opens an Azure client. The probe reads files and a dict, so
+    it is built the same way ``grader_preflight`` builds one.
+    """
+    grader = object.__new__(Grader)
+    grader._audio_content_cache = {}
+    return grader
+
+
+@pytest.fixture
+def stems(tmp_path: Path) -> Path:
+    """The shape of the real deliverable: audio, packaged."""
+    archive = tmp_path / "DEJA VU  STEMS .zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("Master.wav", b"RIFF....WAVEfmt master")
+        zf.writestr("Bass.wav", b"RIFF....WAVEfmt bass")
+        zf.writestr("session notes.txt", b"140 bpm, G major")
+    return archive
+
+
+@pytest.fixture
+def documents(tmp_path: Path) -> Path:
+    """The control: the same container, nothing to listen to."""
+    archive = tmp_path / "DEJA VU  STEMS .zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("report.docx", b"not really a docx")
+        zf.writestr("session notes.txt", b"140 bpm, G major")
+    return archive
+
+
+# ── The probe: True is the interesting answer, None is an admission ──
+
+
+def test_an_archive_of_stems_is_audio(tmp_path, stems):
+    assert _probe_surface()._selected_paths_have_audio(
+        tmp_path, ["DEJA VU  STEMS .zip"]
+    ) is True
+
+
+def test_an_archive_of_documents_is_examined_and_found_silent(
+    tmp_path, documents
+):
+    assert _probe_surface()._selected_paths_have_audio(
+        tmp_path, ["DEJA VU  STEMS .zip"]
+    ) is False
+
+
+def test_one_audio_file_answers_for_the_whole_set(tmp_path, documents):
+    (tmp_path / "master.wav").write_bytes(b"RIFF")
+
+    assert _probe_surface()._selected_paths_have_audio(
+        tmp_path, ["DEJA VU  STEMS .zip", "master.wav"]
+    ) is True
+
+
+def test_a_zip_that_will_not_open_never_reads_as_silent(tmp_path):
+    """Not hypothetical: one gold deliverable is a ``.zip`` that is not one.
+
+    ``PrivateCrypMixV2.zip`` raises ``BadZipFile`` on open. ``None`` keeps the
+    existing extension test in charge there rather than promoting an item
+    towards a file nothing can extract.
+    """
+    (tmp_path / "broken.zip").write_bytes(b"not an archive at all")
+
+    assert _probe_surface()._selected_paths_have_audio(
+        tmp_path, ["broken.zip"]
+    ) is None
+
+
+def test_a_missing_file_never_reads_as_silent(tmp_path):
+    assert _probe_surface()._selected_paths_have_audio(
+        tmp_path, ["was_never_delivered.zip"]
+    ) is None
+
+
+def test_no_selected_paths_is_not_a_finding_either(tmp_path):
+    assert _probe_surface()._selected_paths_have_audio(tmp_path, []) is None
+    assert _probe_surface()._selected_paths_have_audio(
+        tmp_path, ["", None]
+    ) is None
+
+
+def test_each_archive_is_opened_once_per_task_not_once_per_rubric_item(
+    tmp_path, monkeypatch
+):
+    """Thirty-five items asking about one 180 MB archive.
+
+    Without the memo this task alone would walk that archive's directory 35
+    times. The reset that bounds the memo to one task is covered by
+    ``test_the_preflight_starts_each_task_with_an_empty_memo``.
+    """
+    (tmp_path / "stems.zip").write_bytes(b"")
+    opened: list[Path] = []
+
+    def _counting(path):
+        opened.append(Path(path))
+        return True
+
+    monkeypatch.setattr("core.grader.has_audio_content", _counting)
+    grader = _probe_surface()
+
+    for _ in range(5):
+        grader._selected_paths_have_audio(tmp_path, ["stems.zip"])
+
+    assert len(opened) == 1
+
+
+def test_the_two_probes_do_not_share_a_memo(tmp_path, stems):
+    """Same key, different question. One dict would answer both with one."""
+    grader = object.__new__(Grader)
+    grader._audio_content_cache = {}
+    grader._text_layer_cache = {}
+    name = "DEJA VU  STEMS .zip"
+
+    grader._selected_paths_have_audio(tmp_path, [name])
+
+    assert grader._audio_content_cache[name] is True
+    assert name not in grader._text_layer_cache
+
+
+def test_the_preflight_starts_each_task_with_an_empty_memo():
+    # The memo is keyed on a relative name, so carrying one across tasks would
+    # answer for `stems.zip` in task B with what was read in task A.
+    assert _planner({})._audio_content_cache == {}
+
+
+# ── The paid run and its free rehearsal must agree ───────────────────
+
+
+def _task(prompt: str, items: list[RubricItem]) -> TaskRubric:
+    return TaskRubric(
+        task_id="task-1",
+        sector="test",
+        occupation="test",
+        prompt=prompt,
+        rubric_items=items,
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+
+_MIX_ITEM = RubricItem(
+    "vocals", "The Master track contains no vocals (instrumental-only).", 2, None
+)
+_NAMING_ITEM = RubricItem(
+    "naming", "The deliverable is named DEJA VU STEMS.", 1, None
+)
+
+
+def test_the_preflight_sends_a_mix_criterion_to_the_listening_model(
+    tmp_path, stems
+):
+    """The ten-item failure, reproduced at the level that predicts it.
+
+    ``plan_task_runtime`` is the model-free rehearsal of a paid run: same
+    selection, same routing, no API calls. Before this change it planned TEXT
+    here, which is exactly what the paid run then did.
+    """
+    plan = plan_task_runtime(
+        {}, _task("Deliver the stems archive.", [_MIX_ITEM]), tmp_path
+    )
+
+    assert plan["judge_routes"] == {"audio": 1}
+    assert plan["planned_audio_calls"] == 1
+
+
+def test_the_preflight_still_demotes_a_mix_criterion_over_documents(
+    tmp_path, documents
+):
+    """The control. Nothing about the criterion differs from the test above --
+    only whether the archive it points at has anything to listen to."""
+    plan = plan_task_runtime(
+        {}, _task("Deliver the stems archive.", [_MIX_ITEM]), tmp_path
+    )
+
+    assert plan["judge_routes"] == {"text": 1}
+    assert plan["planned_audio_calls"] == 0
+    assert plan["errors"] == []
+
+
+def test_finding_audio_does_not_route_the_rest_of_the_task_to_it(
+    tmp_path, stems
+):
+    """Why the probe is defensive only, priced.
+
+    The real task has 35 items against this one archive and a cap of 3
+    listening calls. Promoting on the file rather than on the criterion would
+    spend all three on whichever items came first -- here, on checking a
+    filename.
+    """
+    plan = plan_task_runtime(
+        {}, _task("Deliver the stems archive.", [_NAMING_ITEM, _MIX_ITEM]),
+        tmp_path,
+    )
+
+    assert plan["judge_routes"] == {"audio": 1, "text": 1}
+    assert plan["planned_audio_calls"] == 1
+
+
+def test_the_preflight_says_out_loud_that_audio_needs_configuring(
+    tmp_path, stems
+):
+    """An audio route on a config with no audio model is a preflight finding.
+
+    This is the check that would have caught the defect from the other side:
+    a cohort that plans zero audio calls on a music task never trips it, which
+    is why it stayed quiet through stage 1.
+    """
+    plan = plan_task_runtime(
+        {}, _task("Deliver the stems archive.", [_MIX_ITEM]), tmp_path
+    )
+
+    assert any("require configured audio perception" in e for e in plan["errors"])
+    assert any("routes=1" in e for e in plan["errors"])
+
+
+def test_a_configured_cohort_plans_the_call_within_its_cap(tmp_path, stems):
+    config = {"judge": {"perception": {"audio": {
+        "model": "gpt-4o-audio-preview", "call_cap_per_task": 3,
+    }}}}
+
+    plan = plan_task_runtime(
+        config, _task("Deliver the stems archive.", [_MIX_ITEM]), tmp_path
+    )
+
+    assert plan["planned_audio_calls"] == 1
+    assert plan["audio_call_cap"] == 3
+    assert not any("budget exceeded" in e for e in plan["errors"])
+    assert not any("require configured" in e for e in plan["errors"])
+
+
+# ── The defect PR #93 fixed must stay fixed ──────────────────────────
+
+
+def test_sound_technician_fees_on_a_budget_are_still_not_audio(tmp_path):
+    """The criterion PR #93 was written for, through the whole grader path.
+
+    An ``.xlsx`` is a zip container, so "does this archive hold audio" is a
+    question that could plausibly have been asked of it -- and answering yes
+    would send a line item about contractor fees to a listening model. It does
+    not: ``_kind_of`` gives an Office file its own kind rather than ``zip``, so
+    the probe short-circuits to ``False`` and the extension demotion PR #93
+    added is left in charge. Checked against all 146 Office deliverables in the
+    gold corpus, every one of which probes ``False``.
+
+    ``test_audio_keyword_with_xlsx_target_downgrades_to_text`` covers the pure
+    routing call. This covers the paid path, where the probe actually runs.
+    """
+    import openpyxl
+
+    book = openpyxl.Workbook()
+    book.active["A1"] = "Sound Technician"
+    book.save(tmp_path / "tour_budget.xlsx")
+    item = RubricItem(
+        "fees",
+        "Band and Crew includes Sound Technician fees attributed to the "
+        "tour manager.",
+        2,
+        None,
+    )
+
+    plan = plan_task_runtime(
+        {}, _task("Produce tour_budget.xlsx.", [item]), tmp_path
+    )
+
+    assert plan["judge_routes"] == {"text": 1}
+    assert plan["planned_audio_calls"] == 0
+    assert _probe_surface()._selected_paths_have_audio(
+        tmp_path, ["tour_budget.xlsx"]
+    ) is False

--- a/batch-runner/tests/test_grader_empty_read_routing.py
+++ b/batch-runner/tests/test_grader_empty_read_routing.py
@@ -1,0 +1,200 @@
+"""The grader half of "an empty read is not an absent document".
+
+``core/grader_routing.py`` decides where an item is judged and is deliberately
+pure, so the question it now asks -- *does any selected file yield a single
+character of text* -- has to be answered by whoever is allowed to touch the
+disk. That is ``Grader._selected_paths_have_text``, and this file covers it
+plus the two places that call it: the paid run and the model-free preflight
+that is supposed to predict the paid run exactly.
+
+The defect being fixed: stage 1 graded a gold deliverable that is a two-page
+scan. Ten rubric items about its contents routed TEXT, read zero characters,
+and were failed as "that content is absent" -- about a document that says all
+ten things, on pages the harness had already rendered for the same task's
+other items.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.grader import Grader
+from core.grader_preflight import _planner, plan_task_runtime
+from core.rubric_loader import RubricItem, TaskRubric
+
+
+def _probe_surface() -> Grader:
+    """A Grader with nothing on it but what the probe needs.
+
+    ``__init__`` opens an Azure client. The probe reads files and a dict, so
+    it is built the same way ``grader_preflight`` builds one.
+    """
+    grader = object.__new__(Grader)
+    grader._text_layer_cache = {}
+    return grader
+
+
+@pytest.fixture
+def scan(tmp_path: Path) -> Path:
+    """Two pages of image and not one character of text."""
+    pytest.importorskip("reportlab")
+    pytest.importorskip("fitz")
+    pytest.importorskip("PIL")
+    from PIL import Image
+    from reportlab.lib.utils import ImageReader
+    from reportlab.pdfgen import canvas
+
+    photo = tmp_path / "_page.png"
+    Image.new("RGB", (64, 64), color="white").save(photo)
+    p = tmp_path / "Scan.pdf"
+    document = canvas.Canvas(str(p))
+    for _ in range(2):
+        document.drawImage(ImageReader(str(photo)), 40, 40, width=200, height=200)
+        document.showPage()
+    document.save()
+    photo.unlink()
+    return p
+
+
+@pytest.fixture
+def typed(tmp_path: Path) -> Path:
+    """The control: the same shape of file, with a text layer."""
+    pytest.importorskip("reportlab")
+    from reportlab.pdfgen import canvas
+
+    p = tmp_path / "Scan.pdf"
+    document = canvas.Canvas(str(p))
+    document.drawString(100, 750, "The total contract value is 4,200 USD.")
+    document.showPage()
+    document.save()
+    return p
+
+
+# ── The probe: False is a claim, None is an admission ────────────────
+
+
+def test_one_readable_file_answers_for_the_whole_set(tmp_path, scan):
+    (tmp_path / "notes.txt").write_text("readable", encoding="utf-8")
+
+    answer = _probe_surface()._selected_paths_have_text(
+        tmp_path, ["Scan.pdf", "notes.txt"]
+    )
+
+    assert answer is True
+
+
+def test_every_file_examined_and_none_had_text_is_a_finding(tmp_path, scan):
+    (tmp_path / "blank.txt").write_text("  \n", encoding="utf-8")
+
+    answer = _probe_surface()._selected_paths_have_text(
+        tmp_path, ["Scan.pdf", "blank.txt"]
+    )
+
+    assert answer is False
+
+
+def test_one_file_it_cannot_speak_for_poisons_the_answer(tmp_path, scan):
+    # ``.wav`` is not a kind text is carried in, so "this file has no text" is
+    # not a finding about it. Escalation reads ``False`` as "look at the pages
+    # instead", and half a set is not grounds for that.
+    (tmp_path / "stems.wav").write_bytes(b"\x00")
+
+    answer = _probe_surface()._selected_paths_have_text(
+        tmp_path, ["Scan.pdf", "stems.wav"]
+    )
+
+    assert answer is None
+
+
+def test_no_selected_paths_is_not_a_finding_either(tmp_path):
+    assert _probe_surface()._selected_paths_have_text(tmp_path, []) is None
+    assert _probe_surface()._selected_paths_have_text(tmp_path, ["", None]) is None
+
+
+def test_a_missing_file_never_reads_as_empty(tmp_path):
+    answer = _probe_surface()._selected_paths_have_text(
+        tmp_path, ["was_never_written.pdf"]
+    )
+
+    assert answer is None
+
+
+def test_each_file_is_opened_once_per_task_not_once_per_rubric_item(
+    tmp_path, monkeypatch
+):
+    """A task's items all ask about the same files.
+
+    Without the memo a 20-item task re-reads every page of every scan 20
+    times. The reset that bounds the memo to one task is covered by
+    ``test_the_preflight_starts_each_task_with_an_empty_memo``.
+    """
+    (tmp_path / "notes.txt").write_text("readable", encoding="utf-8")
+    opened: list[Path] = []
+
+    def _counting(path):
+        opened.append(Path(path))
+        return True
+
+    monkeypatch.setattr("core.grader.has_extractable_text", _counting)
+    grader = _probe_surface()
+
+    for _ in range(5):
+        grader._selected_paths_have_text(tmp_path, ["notes.txt"])
+
+    assert len(opened) == 1
+
+
+def test_the_preflight_starts_each_task_with_an_empty_memo():
+    # The memo is keyed on a relative name, so carrying one across tasks would
+    # answer for `report.pdf` in task B with what was read in task A.
+    assert _planner({})._text_layer_cache == {}
+
+
+# ── The paid run and its free rehearsal must agree ───────────────────
+
+
+def _task(prompt: str, items: list[RubricItem]) -> TaskRubric:
+    return TaskRubric(
+        task_id="task-1",
+        sector="test",
+        occupation="test",
+        prompt=prompt,
+        rubric_items=items,
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+
+_CONTENT_ITEM = RubricItem(
+    "value", "The document states the total contract value.", 2, None
+)
+
+
+def test_the_preflight_escalates_a_scan_to_the_render_path(tmp_path, scan):
+    """The ten-item failure, reproduced at the level that predicts it.
+
+    ``plan_task_runtime`` is the model-free rehearsal of a paid run: same
+    selection, same routing, no API calls. Before this change it planned TEXT
+    here, which is exactly what the paid run then did.
+    """
+    plan = plan_task_runtime({}, _task("Produce Scan.pdf.", [_CONTENT_ITEM]), tmp_path)
+
+    assert plan["judge_routes"] == {"visual": 1}
+    assert plan["planned_render_calls"] == 1
+    assert plan["errors"] == []
+
+
+def test_the_preflight_leaves_a_readable_document_on_the_text_path(tmp_path, typed):
+    """The control. Escalating this one would be a regression and a cost.
+
+    Nothing about the criterion changed between this test and the one above --
+    only whether the file it points at can be read.
+    """
+    plan = plan_task_runtime({}, _task("Produce Scan.pdf.", [_CONTENT_ITEM]), tmp_path)
+
+    assert plan["judge_routes"] == {"text": 1}
+    assert plan["planned_render_calls"] == 0
+    assert plan["errors"] == []

--- a/batch-runner/tests/test_marking_cost_counts_the_conversation_opening.py
+++ b/batch-runner/tests/test_marking_cost_counts_the_conversation_opening.py
@@ -12,7 +12,7 @@ the sentence that denied it.
 
 * The standing instructions are a committed file. ``prompt.tool_template``
   names it in all nine settings files, the judge splits it and sends both
-  halves on every single call, and it is 6,263 characters long today.
+  halves on every single call, and it is 6,772 characters long today.
 * The task preview is cut to ``ToolCallingJudge.task_prompt_truncate``
   characters, which is 500, and every task in the committed catalogue is longer
   than that — so the cut is always taken in full.
@@ -387,21 +387,25 @@ def test_forgetting_the_opening_lowers_the_demand():
         characters_of_widest_scoring_line=1,
     ).input_tokens_one_call_must_cover(THREE)
     assert without < with_opening
-    assert with_opening - without == 2_655
+    assert with_opening - without == 2_824
 
 
 def test_leaving_the_scoring_line_out_of_the_opening_lowers_the_demand():
     """The piece this task added, priced on its own.
 
-    401 tokens a call does not sound like the finding. Multiplied by the calls
+    400 tokens a call does not sound like the finding. Multiplied by the calls
     the settings allow across 10,453 scoring lines it is the difference between
     a figure that is a ceiling and a figure that was printed as one.
+
+    The 1,202 characters removed here are 400.67 tokens at three characters a
+    token, so the figure the subtraction leaves behind is 400 or 401 depending
+    on where the whole sum's rounding-up lands. Both are the same finding.
     """
     whole = caps().input_tokens_one_call_must_cover(THREE)
     almost_without = caps(
         characters_of_widest_scoring_line=1
     ).input_tokens_one_call_must_cover(THREE)
-    assert whole - almost_without == 401
+    assert whole - almost_without == 400
 
 
 def test_a_longer_instruction_file_raises_the_demand_by_itself():
@@ -584,7 +588,7 @@ def test_the_committed_plan_still_records_the_bigger_number():
 
     matching = [p for p in result.cost_findings if "input per marking call" in p]
     assert len(matching) == 1
-    assert "535990" in matching[0]
+    assert "536159" in matching[0]
     assert "533334" in matching[0]
     assert matching[0] not in result.problems
 
@@ -656,7 +660,7 @@ def test_the_description_says_what_every_call_opens_with():
     opening = [line for line in lines if "opens with" in line]
     assert len(opening) == 1
     assert "prompts/grader_judge_v2.md" in opening[0]
-    assert "6263" in opening[0]
+    assert "6772" in opening[0]
 
 
 def test_the_description_says_the_figure_is_a_ceiling_once_the_width_is_known():
@@ -720,7 +724,7 @@ def test_the_written_out_form_carries_the_new_measurements():
     assert written_out["standing_instructions_read_from"] == (
         "prompts/grader_judge_v2.md"
     )
-    assert written_out["characters_of_standing_instructions"] == 6263
+    assert written_out["characters_of_standing_instructions"] == 6772
     assert written_out["characters_of_task_wording_shown"] == 500
     assert written_out["task_wording_width_named_by_the_settings"] == 500
     assert written_out["the_settings_width_is_ignored"] is False

--- a/batch-runner/tests/test_perception_routing.py
+++ b/batch-runner/tests/test_perception_routing.py
@@ -321,3 +321,252 @@ def test_inventory_counts():
     counts = inventory([c for c, _ in CASES])
     # 5 visual, 3 audio, 1 formatting, 3 text per the CASES table
     assert counts == {"visual": 5, "audio": 3, "formatting": 1, "text": 3}
+
+
+# ── A file with no text answers nothing from its text ────────────────
+#
+# Stage 1 graded one gold answer that is a two-page scan. Ten rubric items
+# about its contents routed TEXT, read zero characters, and were failed as
+# "that content is absent" -- about a document that says all ten things, on
+# pages the harness had already rendered for the same task's other items.
+#
+# The escalation below is the fix, and these tests pin the three conditions
+# that keep it from doing harm: it fires only on a measured ``False``, only
+# from the two modalities that were asking for text, and only when every
+# selected file can actually be rendered.
+
+
+def test_a_text_criterion_escalates_when_no_selected_file_has_text():
+    decision = resolve_runtime_routing(
+        "The memo states the total contract value",
+        ["scan.pdf"],
+        selected_paths_have_text=False,
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.preferred_op == "render_to_image"
+
+
+def test_a_formatting_criterion_escalates_on_the_same_evidence():
+    # FORMATTING escalates for the same reason TEXT does: `inspect_formatting`
+    # on a scan reports the page box and nothing about the layout drawn on it.
+    decision = resolve_runtime_routing(
+        "The document structure follows the required template",
+        ["scan.pdf"],
+        selected_paths_have_text=False,
+    )
+
+    assert decision.modality is Modality.VISUAL
+
+
+def test_an_unknown_text_layer_escalates_nothing():
+    # ``None`` is what the probe returns for a file it could not examine in
+    # full -- unsupported kind, read error, page cap. Escalating on it would
+    # trade a readable file for a render on a guess.
+    decision = resolve_runtime_routing(
+        "The memo states the total contract value",
+        ["report.pdf"],
+        selected_paths_have_text=None,
+    )
+
+    assert decision.modality is Modality.TEXT
+    assert decision.preferred_op == "read_content"
+
+
+def test_a_file_that_has_text_is_never_escalated():
+    decision = resolve_runtime_routing(
+        "The memo states the total contract value",
+        ["report.pdf"],
+        selected_paths_have_text=True,
+    )
+
+    assert decision.modality is Modality.TEXT
+
+
+def test_escalation_needs_every_selected_file_to_be_renderable():
+    # ``.txt`` has no renderer. Escalating a set containing one would promise
+    # a render the prepass refuses, which is a guaranteed harness error --
+    # strictly worse than the empty read this rule exists to replace.
+    decision = resolve_runtime_routing(
+        "The memo states the total contract value",
+        ["scan.pdf", "appendix.txt"],
+        selected_paths_have_text=False,
+    )
+
+    assert decision.modality is Modality.TEXT
+
+
+def test_escalation_needs_a_selected_file_at_all():
+    decision = resolve_runtime_routing(
+        "The memo states the total contract value",
+        [],
+        selected_paths_have_text=False,
+    )
+
+    assert decision.modality is Modality.TEXT
+
+
+def test_an_audio_criterion_on_its_own_medium_is_not_escalated():
+    # ``.wav`` is not renderable, so the escalation cannot reach an item that
+    # is already pointed at the sense that answers it.
+    decision = resolve_runtime_routing(
+        "The mix has no clipping",
+        ["stems.wav"],
+        selected_paths_have_text=False,
+    )
+
+    assert decision.modality is Modality.AUDIO
+    assert decision.preferred_op == "probe_audio"
+
+
+def test_an_escalated_decision_keeps_its_matched_keywords():
+    # Mirrors ``test_downgraded_visual_keeps_its_matched_keywords``: moving an
+    # item changes where the judge looks, not what the criterion was found to
+    # be asking for.
+    criterion = "The document structure follows the required template"
+    decision = resolve_runtime_routing(
+        criterion, ["scan.pdf"], selected_paths_have_text=False
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.matched_keywords == classify_criterion(criterion).matched_keywords
+    assert decision.matched_keywords != ()
+
+
+@pytest.mark.parametrize("criterion,_expected", CASES)
+@pytest.mark.parametrize(
+    "paths",
+    [[], ["deliverable"], ["notes.txt"], ["report.pdf"], ["mix.wav"],
+     ["book.xlsx", "slides.pptx"]],
+)
+def test_omitting_the_probe_is_identical_to_not_knowing(criterion, _expected, paths):
+    """The new argument's default must be inert.
+
+    The three pre-existing rules were rewritten from separate ``return``
+    statements into one ``if``/``elif`` chain to make room for the escalation.
+    That is only safe if no two of them could ever have fired together, which
+    is an argument about code rather than a fact about it -- so it is asserted
+    here across every criterion and target shape the module is tested with.
+    """
+    assert resolve_runtime_routing(criterion, paths) == resolve_runtime_routing(
+        criterion, paths, selected_paths_have_text=None
+    )
+
+
+# ── An archive of stems is audio ─────────────────────────────────────
+#
+# ``resolve_runtime_routing`` demotes an AUDIO criterion whose files carry no
+# audio, because a question about a mix has no meaning against a spreadsheet.
+# The test for that was the file extension, which reads a container as if it
+# were a medium: the stage-1 music task ships one ``.zip``, ``.zip`` is not an
+# audio extension, and so all ten of its listening criteria were demoted to
+# TEXT and answered by reading an archive. ``selected_paths_have_audio`` is the
+# measured fact the extension was standing in for.
+
+_STEMS = ["DEJA VU  STEMS .zip"]
+_MIX_CRITERION = "The Master track contains no vocals (instrumental-only)."
+
+
+def test_an_archive_that_holds_audio_keeps_its_listening_route():
+    decision = resolve_runtime_routing(
+        _MIX_CRITERION, _STEMS, selected_paths_have_audio=True
+    )
+
+    assert decision.modality is Modality.AUDIO
+    assert decision.preferred_op == "probe_audio"
+
+
+def test_an_archive_with_no_audio_in_it_is_still_demoted():
+    decision = resolve_runtime_routing(
+        _MIX_CRITERION, _STEMS, selected_paths_have_audio=False
+    )
+
+    assert decision.modality is Modality.TEXT
+
+
+def test_an_archive_it_could_not_open_is_still_demoted():
+    """``None`` is an admission and must not be read as a yes.
+
+    One gold deliverable is a ``.zip`` that will not open. Promoting on that
+    would hand the listening model a file nothing can extract.
+    """
+    decision = resolve_runtime_routing(
+        _MIX_CRITERION, _STEMS, selected_paths_have_audio=None
+    )
+
+    assert decision.modality is Modality.TEXT
+
+
+def test_a_wav_never_needed_the_probe_and_still_does_not():
+    for probe in (True, False, None):
+        decision = resolve_runtime_routing(
+            _MIX_CRITERION, ["master.wav"], selected_paths_have_audio=probe
+        )
+        assert decision.modality is Modality.AUDIO
+
+
+def test_finding_audio_cannot_promote_a_criterion_that_is_not_about_sound():
+    """The probe is defensive only. It stops a demotion; it never routes.
+
+    Otherwise every item on a music task -- including "the filename is
+    correct" -- would be sent to a listening model.
+    """
+    decision = resolve_runtime_routing(
+        "The deliverable is named DEJA VU STEMS.",
+        _STEMS,
+        selected_paths_have_audio=True,
+    )
+
+    assert decision.modality is Modality.TEXT
+
+
+def test_finding_audio_does_not_disturb_a_visual_criterion():
+    decision = resolve_runtime_routing(
+        "The chart colors are legible.",
+        ["deck.pptx", "master.wav"],
+        selected_paths_have_audio=True,
+    )
+
+    assert decision.modality is Modality.VISUAL
+
+
+@pytest.mark.parametrize("criterion", [
+    "The Master track contains no vocals (instrumental-only).",
+    "The Master track tempo is 140 BPM (± 1 BPM).",
+    "From the beginning through 1:22, the harmonic key centers on G major.",
+    "At least one time-based effect is audibly evident in the tails.",
+    "The Bass sound is created using one of the referenced synth families.",
+])
+def test_the_music_criteria_that_matched_nothing_now_classify_audio(criterion):
+    """Verbatim from the stage-1 rubric that scored 0 on every one of them."""
+    assert classify_criterion(criterion).modality is Modality.AUDIO
+
+
+@pytest.mark.parametrize("criterion", [
+    "The delay stems from a supplier issue.",
+    "She was instrumental in closing the deal.",
+    "Revenue is on track for Q3.",
+    "The report lists the key findings.",
+    "The chord of the argument is consistent",
+])
+def test_ordinary_business_english_is_not_mistaken_for_music(criterion):
+    """The words rejected while choosing the additions, kept as a guard.
+
+    The last one is deliberate: "chord" IS an audio keyword, and this shows
+    what happens when one slips through. It classifies AUDIO and is then
+    demoted by the file it points at, which is why a stray hit costs nothing.
+    """
+    assert resolve_runtime_routing(
+        criterion, ["report.docx"], selected_paths_have_audio=False
+    ).modality is not Modality.AUDIO
+
+
+@pytest.mark.parametrize("criterion,_expected", CASES)
+@pytest.mark.parametrize("paths", [[], ["deliverable"], ["stems.zip"],
+                                   ["master.wav"], ["report.pdf"]])
+def test_omitting_the_audio_probe_is_identical_to_not_knowing(
+    criterion, _expected, paths
+):
+    assert resolve_runtime_routing(criterion, paths) == resolve_runtime_routing(
+        criterion, paths, selected_paths_have_audio=None
+    )

--- a/batch-runner/tests/test_read_deliverable.py
+++ b/batch-runner/tests/test_read_deliverable.py
@@ -18,6 +18,8 @@ from core.tools import (
     READ_DELIVERABLE_OPS,
     READ_DELIVERABLE_TOOL_SCHEMA,
     RendererDependencyError,
+    has_audio_content,
+    has_extractable_text,
     read_deliverable,
 )
 
@@ -220,6 +222,236 @@ def test_inspect_structure_pdf(base_dir, pdf_file):
     assert r["ok"] is True
     assert r["data"]["kind"] == "pdf"
     assert r["data"]["page_count"] == 1
+
+
+# ── page count and page size ─────────────────────────────────────────
+#
+# Six stage-1 rubric items asked how long a document was and one asked which
+# way its pages faced. Every one of them was answered from a number that is
+# not the answer -- paragraph_count, char_count, or a bare page_count with no
+# geometry beside it -- and five of the seven were marked down against gold
+# answers that were the right length and the right orientation.
+
+
+def _sized_pdf(path: Path, sizes) -> Path:
+    """A PDF whose pages have exactly the given (width_pt, height_pt)."""
+    pytest.importorskip("reportlab")
+    from reportlab.pdfgen import canvas
+
+    document = canvas.Canvas(str(path))
+    for width, height in sizes:
+        document.setPageSize((width, height))
+        document.drawString(20, 20, "page")
+        document.showPage()
+    document.save()
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _clear_page_count_cache():
+    """The layout cache is keyed on a real path, and tmp_path is per-test."""
+    read_deliverable_module._cached_docx_page_count.cache_clear()
+    yield
+    read_deliverable_module._cached_docx_page_count.cache_clear()
+
+
+def test_inspect_structure_docx_reports_the_laid_out_page_count(
+    base_dir, docx_file, monkeypatch
+):
+    """The number already existed on the render path; now the judge sees it."""
+    monkeypatch.setattr(
+        read_deliverable_module,
+        "_convert_office_to_pdf",
+        lambda source, out_dir: _fake_convert_to_pdf(source, out_dir, pages=3),
+    )
+    r = read_deliverable("inspect_structure", docx_file.name, base_dir=str(base_dir))
+    assert r["ok"] is True
+    assert r["data"]["converted_page_count"] == 3
+    # It is reported under the render path's name because it is the same
+    # number: a .docx stores no pagination, so both come from a conversion.
+    assert "page_count_error" not in r["data"]
+    # and it is an addition, not a replacement
+    assert r["data"]["paragraph_count"] >= 2
+    assert r["data"]["table_count"] == 0
+
+
+def test_inspect_formatting_docx_reports_the_laid_out_page_count(
+    base_dir, docx_file, monkeypatch
+):
+    monkeypatch.setattr(
+        read_deliverable_module,
+        "_convert_office_to_pdf",
+        lambda source, out_dir: _fake_convert_to_pdf(source, out_dir, pages=2),
+    )
+    r = read_deliverable("inspect_formatting", docx_file.name, base_dir=str(base_dir))
+    assert r["ok"] is True
+    assert r["data"]["converted_page_count"] == 2
+    assert "style_histogram" in r["data"]
+
+
+def test_docx_page_count_says_unknown_rather_than_failing_the_inspection(
+    base_dir, docx_file, monkeypatch
+):
+    """No Writer costs the page count and nothing else.
+
+    The alternative -- letting the conversion raise through
+    ``inspect_structure`` -- would trade six mis-answered items for a whole
+    op that reports nothing about any document.
+    """
+    monkeypatch.setattr(read_deliverable_module, "_find_soffice", lambda: None)
+    r = read_deliverable("inspect_structure", docx_file.name, base_dir=str(base_dir))
+    assert r["ok"] is True
+    assert r["data"]["converted_page_count"] is None
+    assert "LibreOffice" in r["data"]["page_count_error"]
+    assert "not page counts" in r["data"]["page_count_note"]
+    assert "inspection_error" not in r["data"]
+    assert r["data"]["paragraph_count"] >= 2
+
+
+def test_docx_page_count_is_laid_out_once_per_file(
+    base_dir, docx_file, monkeypatch
+):
+    """A judge asks twice; LibreOffice is charged once."""
+    conversions = []
+
+    def counting_convert(source: Path, out_dir: Path) -> Path:
+        conversions.append(source)
+        return _fake_convert_to_pdf(source, out_dir, pages=2)
+
+    monkeypatch.setattr(
+        read_deliverable_module, "_convert_office_to_pdf", counting_convert
+    )
+    for op in ("inspect_structure", "inspect_formatting", "inspect_structure"):
+        assert read_deliverable(
+            op, docx_file.name, base_dir=str(base_dir)
+        )["data"]["converted_page_count"] == 2
+    assert len(conversions) == 1
+
+
+def test_docx_page_count_is_laid_out_again_when_the_file_changes(
+    base_dir, docx_file, monkeypatch
+):
+    """The cache key is the bytes, not the name."""
+    pages = [2]
+
+    def counting_convert(source: Path, out_dir: Path) -> Path:
+        return _fake_convert_to_pdf(source, out_dir, pages=pages[0])
+
+    monkeypatch.setattr(
+        read_deliverable_module, "_convert_office_to_pdf", counting_convert
+    )
+    first = read_deliverable(
+        "inspect_structure", docx_file.name, base_dir=str(base_dir)
+    )
+    assert first["data"]["converted_page_count"] == 2
+
+    from docx import Document
+    document = Document(str(docx_file))
+    document.add_paragraph("A third page's worth of new body text.")
+    document.save(docx_file)
+    os.utime(docx_file, (0, 0))  # force a distinct mtime, not a faster clock
+    pages[0] = 5
+
+    second = read_deliverable(
+        "inspect_structure", docx_file.name, base_dir=str(base_dir)
+    )
+    assert second["data"]["converted_page_count"] == 5
+
+
+def test_read_content_docx_refuses_to_be_read_as_a_page_count(
+    base_dir, docx_file
+):
+    """The one required item stage 1 failed was failed on this surface."""
+    r = read_deliverable("read_content", docx_file.name, base_dir=str(base_dir))
+    assert r["ok"] is True
+    assert r["data"]["char_count"] > 0
+    assert "not a page count" in r["data"]["note"]
+    assert "converted_page_count" in r["data"]["note"]
+
+
+def test_inspect_structure_pdf_reports_page_size_and_orientation(base_dir):
+    """432x288 is landscape. The gold answer said so and was marked wrong."""
+    pytest.importorskip("fitz")
+    path = _sized_pdf(base_dir / "landscape.pdf", [(432, 288)])
+    r = read_deliverable("inspect_structure", path.name, base_dir=str(base_dir))
+    assert r["ok"] is True
+    data = r["data"]
+    assert data["page_count"] == 1
+    assert data["pages_measured"] == 1
+    assert data["page_size_uniform"] is True
+    assert data["orientation"] == "landscape"
+    assert data["page_sizes"] == [{
+        "width_pt": 432.0,
+        "height_pt": 288.0,
+        "width_in": 6.0,
+        "height_in": 4.0,
+        "orientation": "landscape",
+        "page_count": 1,
+        "first_page": 1,
+    }]
+
+
+def test_inspect_formatting_pdf_reports_page_size(base_dir):
+    pytest.importorskip("fitz")
+    path = _sized_pdf(base_dir / "portrait.pdf", [(612, 792)])
+    r = read_deliverable("inspect_formatting", path.name, base_dir=str(base_dir))
+    assert r["ok"] is True
+    assert r["data"]["orientation"] == "portrait"
+    assert r["data"]["page_sizes"][0]["width_in"] == 8.5
+    assert r["data"]["page_sizes"][0]["height_in"] == 11.0
+    assert "fonts" in r["data"]
+
+
+def test_pdf_page_sizes_group_by_size_not_by_page(base_dir):
+    """A uniform report costs one row; a document that turns costs two."""
+    pytest.importorskip("fitz")
+    path = _sized_pdf(
+        base_dir / "mixed.pdf",
+        [(612, 792), (612, 792), (792, 612), (612, 792)],
+    )
+    r = read_deliverable("inspect_structure", path.name, base_dir=str(base_dir))
+    assert r["ok"] is True
+    data = r["data"]
+    assert data["page_count"] == 4
+    assert data["page_size_uniform"] is False
+    # No single orientation is claimed when there is not one.
+    assert "orientation" not in data
+    assert [(row["orientation"], row["page_count"], row["first_page"])
+            for row in data["page_sizes"]] == [
+        ("portrait", 3, 1), ("landscape", 1, 3)]
+
+
+def test_pdf_geometry_never_claims_uniform_beyond_what_it_measured():
+    """A capped scan describes its prefix and says that it did."""
+    geometry = read_deliverable_module._pdf_geometry(
+        [(612.0, 792.0)] * read_deliverable_module.MAX_PAGES_DEFAULT,
+        page_count=900,
+    )
+    assert geometry["pages_measured"] == read_deliverable_module.MAX_PAGES_DEFAULT
+    assert geometry["pages_measured_capped"] is True
+    assert geometry["page_sizes"][0]["page_count"] == (
+        read_deliverable_module.MAX_PAGES_DEFAULT
+    )
+
+
+def test_pdf_geometry_flags_a_truncated_size_list_instead_of_claiming_uniform():
+    limit = read_deliverable_module.MAX_PDF_PAGE_SIZE_GROUPS
+    geometry = read_deliverable_module._pdf_geometry(
+        [(600.0 + n, 800.0) for n in range(limit + 3)], page_count=limit + 3
+    )
+    assert len(geometry["page_sizes"]) == limit
+    assert geometry["page_sizes_truncated"] is True
+    assert geometry["page_size_uniform"] is False
+
+
+def test_model_schema_tells_the_judge_where_a_page_count_comes_from():
+    """The full schema's descriptions never reach the model; this one does."""
+    description = MODEL_READ_DELIVERABLE_TOOL_SCHEMA[
+        "parameters"
+    ]["properties"]["op"]["description"]
+    assert "converted_page_count" in description
+    assert "orientation" in description
+    assert "char_count" in description and "not page counts" in description
 
 
 # ── read_content ─────────────────────────────────────────────────────
@@ -1291,6 +1523,39 @@ def test_an_archive_reads_as_its_own_listing(base_dir, zip_file):
     assert "audio" in r["data"]["text"]
 
 
+def test_every_place_a_judge_meets_an_archive_says_a_member_can_be_opened(
+    base_dir, zip_file
+):
+    """The listing was reachable; the way to open what it lists was not.
+
+    A stage-1 gold answer of five WAV stems scored 2 of 62 because thirty-four
+    items were answered "binary or unsupported" about files nothing opened.
+    The member scope existed by then -- it was just never said anywhere the
+    judge reads, so all three of those places say it now.
+    """
+    hint = "scope={\"member\""
+
+    structure = read_deliverable(
+        "inspect_structure", zip_file.name, base_dir=str(base_dir)
+    )
+    assert hint in structure["data"]["note"]
+
+    content = read_deliverable(
+        "read_content", zip_file.name, base_dir=str(base_dir)
+    )
+    assert hint in content["data"]["text"]
+    # and it comes after the listing, not instead of it
+    assert content["data"]["text"].index("STEMS/MASTER.wav") < content[
+        "data"
+    ]["text"].index(hint)
+
+    scope_description = MODEL_READ_DELIVERABLE_TOOL_SCHEMA[
+        "parameters"
+    ]["properties"]["scope"]["description"]
+    assert "member" in scope_description
+    assert ".zip" in scope_description
+
+
 def test_resource_forks_are_hidden_but_counted(base_dir, zip_file):
     """Five real stems and five ``._`` twins reads as ten files of nothing.
 
@@ -1362,7 +1627,7 @@ def test_a_member_keeps_its_extension_while_being_read(base_dir, zip_file):
     ``tmpXXXX`` is a member no op can identify -- the container would be open
     and its contents still unreadable.
     """
-    with read_deliverable_module._extracted_zip_member(
+    with read_deliverable_module.open_archive_member(
         zip_file, "STEMS/MASTER.wav"
     ) as extracted:
         assert extracted.suffix == ".wav"
@@ -1472,3 +1737,290 @@ def test_a_corrupt_archive_reports_the_failure_instead_of_reading_empty(
     # inspect_structure keeps its own contract: it never raises, it annotates.
     assert structure["ok"] is True
     assert "inspection_error" in structure["data"]
+
+
+# ── "I could not read it" is not "it is not there" ───────────────────
+#
+# Stage 1 graded a two-page scan. ``read_content`` returned ``char_count: 0``,
+# and ten rubric items were failed as "that content is absent" -- about a
+# document that says all ten things, in ink. Nothing lied: the tool said the
+# text was empty and the judge read empty text as an empty document. So the
+# tool now says which of the two it means, and routing (tested separately in
+# ``test_perception_routing.py``) hands the item to the path that looks at the
+# page instead of the one that reads it.
+
+
+@pytest.fixture
+def scanned_pdf(base_dir: Path) -> Path:
+    """Two pages of image and not one character of text."""
+    pytest.importorskip("reportlab")
+    pytest.importorskip("PIL")
+    from PIL import Image
+    from reportlab.lib.utils import ImageReader
+    from reportlab.pdfgen import canvas
+
+    photo = base_dir / "page_image.png"
+    Image.new("RGB", (64, 64), color="white").save(photo)
+    p = base_dir / "scan.pdf"
+    document = canvas.Canvas(str(p))
+    for _ in range(2):
+        document.drawImage(ImageReader(str(photo)), 40, 40, width=200, height=200)
+        document.showPage()
+    document.save()
+    return p
+
+
+def test_read_content_of_a_scan_reports_a_missing_text_layer(base_dir, scanned_pdf):
+    pytest.importorskip("fitz")
+    r = read_deliverable("read_content", scanned_pdf.name, base_dir=str(base_dir))
+
+    assert r["ok"] is True
+    data = r["data"]
+    assert data["char_count"] == 0
+    assert data["has_text_layer"] is False
+    # The two numbers that tell a scan apart from an empty file.
+    assert data["page_count"] == 2
+    assert data["embedded_image_count"] >= 2
+    assert read_deliverable_module._EMPTY_READ_DISCLAIMER in data["note"]
+    assert "scan" in data["note"]
+
+
+def test_an_empty_text_file_is_reported_as_unreadable_not_as_absent(base_dir):
+    empty = base_dir / "blank.txt"
+    empty.write_text("   \n", encoding="utf-8")
+
+    r = read_deliverable("read_content", empty.name, base_dir=str(base_dir))
+
+    assert r["ok"] is True
+    assert r["data"]["has_text_layer"] is False
+    assert read_deliverable_module._EMPTY_READ_DISCLAIMER in r["data"]["note"]
+
+
+def test_a_file_that_holds_no_text_names_the_op_that_does_read_it(base_dir):
+    # Previously: "binary or unsupported for text read" -- which tells a judge
+    # the file is a dead end, when in fact one call away is every fact the
+    # criterion is asking about.
+    for name, expected_op in (
+        ("clip.wav", "probe_audio"),
+        ("clip.mp4", "probe_video"),
+    ):
+        (base_dir / name).write_bytes(b"\x00\x01\x02")
+        r = read_deliverable("read_content", name, base_dir=str(base_dir))
+        assert r["ok"] is True
+        assert r["data"]["char_count"] == 0
+        assert r["data"]["has_text_layer"] is False
+        assert expected_op in r["data"]["note"]
+        assert read_deliverable_module._EMPTY_READ_DISCLAIMER in r["data"]["note"]
+
+
+def test_an_image_read_points_at_the_visual_evidence_instead(base_dir, png_file):
+    r = read_deliverable("read_content", png_file.name, base_dir=str(base_dir))
+
+    assert r["ok"] is True
+    assert r["data"]["has_text_layer"] is False
+    assert "rendered visual evidence" in r["data"]["note"]
+
+
+def test_an_empty_docx_carries_both_notes(base_dir):
+    """The length note and the empty note answer different wrong readings."""
+    pytest.importorskip("docx")
+    from docx import Document
+
+    p = base_dir / "blank.docx"
+    Document().save(p)
+
+    r = read_deliverable("read_content", p.name, base_dir=str(base_dir))
+
+    note = r["data"]["note"]
+    assert "not a page count" in note
+    assert read_deliverable_module._EMPTY_READ_DISCLAIMER in note
+
+
+def test_the_empty_read_report_survives_a_broken_pdf(base_dir):
+    """It runs on the failure path of a read that already returned nothing.
+
+    Raising here would lose the read as well, leaving the judge with strictly
+    less than it had before this section existed.
+    """
+    broken = base_dir / "truncated.pdf"
+    broken.write_bytes(b"%PDF-1.4\nnot actually a pdf")
+
+    facts, note = read_deliverable_module._empty_read_report(broken, "pdf")
+
+    assert facts == {"has_text_layer": False}
+    assert read_deliverable_module._EMPTY_READ_DISCLAIMER in note
+
+
+# ── has_extractable_text: False is a claim, None is an admission ─────
+
+
+def test_has_extractable_text_is_true_for_a_document_with_words(
+    base_dir, docx_file, txt_file, pdf_file
+):
+    for path in (docx_file, txt_file, pdf_file):
+        assert has_extractable_text(path) is True, path.name
+
+
+def test_has_extractable_text_is_false_for_a_scan(base_dir, scanned_pdf):
+    pytest.importorskip("fitz")
+    assert has_extractable_text(scanned_pdf) is False
+
+
+def test_has_extractable_text_is_false_for_an_image(png_file):
+    # Not a failure to read. An image has no text layer by construction, and
+    # that is exactly the fact routing wants.
+    assert has_extractable_text(png_file) is False
+
+
+def test_has_extractable_text_is_none_for_a_file_it_cannot_speak_for(base_dir):
+    # A missing file, a medium text is not carried in, and a kind the tool has
+    # no reader for. None of the three is evidence that a file has no text.
+    missing = base_dir / "nothing_here.pdf"
+    audio = base_dir / "stems.wav"
+    audio.write_bytes(b"\x00")
+    unknown = base_dir / "notes.rtf"
+    unknown.write_bytes(b"{\\rtf1}")
+
+    assert has_extractable_text(missing) is None
+    assert has_extractable_text(audio) is None
+    assert has_extractable_text(unknown) is None
+
+
+def test_has_extractable_text_is_none_when_it_could_not_reach_every_page(
+    base_dir, scanned_pdf, monkeypatch
+):
+    """A partial look is not a finding.
+
+    ``False`` escalates an item to the render path, so it may only be returned
+    when the whole file was examined. The page cap is monkeypatched rather than
+    building a 201-page fixture: the cap's value is not what is under test, the
+    behaviour at it is.
+    """
+    pytest.importorskip("fitz")
+    monkeypatch.setattr(read_deliverable_module, "MAX_PAGES_DEFAULT", 1)
+
+    assert has_extractable_text(scanned_pdf) is None
+
+
+def test_has_extractable_text_stops_at_the_first_page_that_has_text(
+    base_dir, monkeypatch
+):
+    """An ordinary document costs one page, not all of them."""
+    pytest.importorskip("reportlab")
+    pytest.importorskip("fitz")
+    from reportlab.pdfgen import canvas
+
+    p = base_dir / "long.pdf"
+    document = canvas.Canvas(str(p))
+    for page in range(5):
+        document.drawString(100, 750, f"page {page}")
+        document.showPage()
+    document.save()
+
+    monkeypatch.setattr(read_deliverable_module, "MAX_PAGES_DEFAULT", 1)
+
+    # Capped at one page and still True: the answer came from page one.
+    assert has_extractable_text(p) is True
+
+
+# ── has_audio_content: a container is not a medium ───────────────────
+#
+# The stage-1 music task delivers its whole answer as one 180 MB ``.zip`` of
+# stems. Routing decided there was no audio because the extension said ``.zip``,
+# so the task was graded on tempo, key and vocals without the listening model
+# being invoked once. This probe is what routing asks instead.
+
+
+def _archive(base_dir, name, members):
+    import zipfile
+
+    p = base_dir / name
+    with zipfile.ZipFile(p, "w") as archive:
+        for member, payload in members.items():
+            archive.writestr(member, payload)
+    return p
+
+
+def test_has_audio_content_is_true_for_an_audio_file(base_dir):
+    p = base_dir / "master.wav"
+    p.write_bytes(b"\x00")
+
+    assert has_audio_content(p) is True
+
+
+def test_has_audio_content_is_true_for_an_archive_of_stems(base_dir):
+    p = _archive(base_dir, "stems.zip", {
+        "STEMS/README.txt": "five stems",
+        "STEMS/SYNTHS .wav": b"\x00",
+    })
+
+    assert has_audio_content(p) is True
+
+
+def test_has_audio_content_is_false_for_an_archive_of_documents(base_dir):
+    """A claim, not an admission. Nothing in here is for listening to."""
+    p = _archive(base_dir, "code.zip", {
+        "src/main.py": "print(1)",
+        "README.md": "# notes",
+    })
+
+    assert has_audio_content(p) is False
+
+
+def test_has_audio_content_ignores_the_resource_forks_macos_leaves(base_dir):
+    """``__MACOSX/._SYNTHS .wav`` is a few hundred bytes of metadata.
+
+    It is filtered out of every listing the tool produces, so treating it as
+    audio would promote a criterion to a model that has nothing to hear.
+    """
+    p = _archive(base_dir, "forks.zip", {
+        "STEMS/notes.txt": "no audio here",
+        "__MACOSX/STEMS/._SYNTHS .wav": b"\x00",
+    })
+
+    assert has_audio_content(p) is False
+
+
+def test_has_audio_content_is_false_for_a_document(base_dir):
+    p = base_dir / "report.pdf"
+    p.write_bytes(b"%PDF-1.4\n")
+
+    assert has_audio_content(p) is False
+
+
+def test_has_audio_content_is_none_for_a_file_that_is_not_there(base_dir):
+    assert has_audio_content(base_dir / "never_written.zip") is None
+
+
+def test_has_audio_content_is_none_for_an_archive_it_cannot_open(base_dir):
+    """One gold deliverable really is this: a ``.zip`` that is not one."""
+    p = base_dir / "broken.zip"
+    p.write_bytes(b"not actually a zip file")
+
+    assert has_audio_content(p) is None
+
+
+def test_has_audio_content_is_none_when_the_listing_was_cut_short(
+    base_dir, monkeypatch
+):
+    """A list that stopped early may have stopped one entry before the audio.
+
+    ``False`` would be a claim about members nobody looked at, and the caller
+    reads ``False`` and ``None`` differently on purpose.
+    """
+    p = _archive(base_dir, "many.zip", {f"f{i}.txt": "x" for i in range(5)})
+    monkeypatch.setattr(read_deliverable_module, "MAX_ZIP_ENTRIES", 2)
+
+    assert has_audio_content(p) is None
+
+
+def test_has_audio_content_answers_before_the_cut_when_it_can(
+    base_dir, monkeypatch
+):
+    """Truncation only matters if the audio was not already found."""
+    p = _archive(base_dir, "front.zip", {
+        "a.wav": b"\x00", "b.txt": "x", "c.txt": "x", "d.txt": "x",
+    })
+    monkeypatch.setattr(read_deliverable_module, "MAX_ZIP_ENTRIES", 2)
+
+    assert has_audio_content(p) is True

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -2076,3 +2076,205 @@ def test_unknown_tool_name_returns_envelope_error(deliverable_dir, task_and_item
     outputs = [m for m in second_input if isinstance(m, dict)
                and m.get("type") == "function_call_output"]
     assert outputs and "bad_function" in outputs[0]["output"]
+
+
+# ── audio_judge can reach a stem inside an archive ───────────────────
+#
+# The one stage-1 task made entirely of music ships its whole deliverable as a
+# single ``.zip`` of stems. Without ``member`` the listening model can only be
+# handed the archive itself, which is not a thing it can hear, so every
+# listening criterion on that task had to be answered some other way.
+
+class _RecordingAudio:
+    """Remembers the path it was handed and whether it still exists."""
+
+    def __init__(self):
+        self.paths: list[str] = []
+        self.existed: list[bool] = []
+        self.bytes_seen: list[bytes] = []
+
+    def judge(self, *, criterion: str, audio_path: str):
+        self.paths.append(audio_path)
+        self.existed.append(Path(audio_path).is_file())
+        self.bytes_seen.append(Path(audio_path).read_bytes())
+        return SimpleNamespace(
+            judge_error=None,
+            to_dict=lambda: {"verdict": "pass", "partial_score": 1.0},
+        )
+
+
+def _stems_archive(base_dir: Path, name: str = "stems.zip") -> Path:
+    import zipfile
+
+    archive = base_dir / name
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("Master.wav", b"RIFF....WAVEfmt master")
+        zf.writestr("Bass.wav", b"RIFF....WAVEfmt bass")
+        zf.writestr("notes.txt", b"session notes")
+    return archive
+
+
+def _audio_judge(judge, deliverable_dir, **kwargs):
+    return judge._dispatch_tool(
+        _fc("a1", "audio_judge", **kwargs),
+        deliverable_dir=str(deliverable_dir),
+        allowed_paths={kwargs["audio_path"]},
+    )
+
+
+def test_naming_a_member_hands_over_the_stem_and_not_the_archive(
+    deliverable_dir, task_and_item
+):
+    _stems_archive(deliverable_dir)
+    audio = _RecordingAudio()
+    judge = ToolCallingJudge(
+        client=FakeClient(ScriptedResponses([])), model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=audio,
+    )
+
+    result = _audio_judge(
+        judge, deliverable_dir,
+        criterion="The Master track contains no vocals.",
+        audio_path="stems.zip", member="Master.wav",
+    )
+
+    assert result["ok"] is True
+    assert audio.bytes_seen == [b"RIFF....WAVEfmt master"]
+    # It got a real file on disk, not a handle or a buffer.
+    assert audio.existed == [True]
+    assert audio.paths[0].endswith(".wav")
+
+
+def test_the_extracted_stem_does_not_outlive_the_call(
+    deliverable_dir, task_and_item
+):
+    """Two 180 MB archives per task is why this is a context manager."""
+    _stems_archive(deliverable_dir)
+    audio = _RecordingAudio()
+    judge = ToolCallingJudge(
+        client=FakeClient(ScriptedResponses([])), model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=audio,
+    )
+
+    _audio_judge(
+        judge, deliverable_dir, criterion="c",
+        audio_path="stems.zip", member="Bass.wav",
+    )
+
+    assert not Path(audio.paths[0]).exists()
+
+
+def test_omitting_member_still_hands_over_the_file_itself(
+    deliverable_dir, task_and_item
+):
+    (deliverable_dir / "clip.wav").write_bytes(b"RIFF....WAVEfmt clip")
+    audio = _RecordingAudio()
+    judge = ToolCallingJudge(
+        client=FakeClient(ScriptedResponses([])), model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=audio,
+    )
+
+    result = _audio_judge(
+        judge, deliverable_dir, criterion="c", audio_path="clip.wav",
+    )
+
+    assert result["ok"] is True
+    assert audio.paths == [str(deliverable_dir / "clip.wav")]
+
+
+def test_a_null_member_is_the_same_as_none_at_all(
+    deliverable_dir, task_and_item
+):
+    """The schema types ``member`` nullable, so a model may send ``null``."""
+    (deliverable_dir / "clip.wav").write_bytes(b"RIFF....WAVEfmt clip")
+    audio = _RecordingAudio()
+    judge = ToolCallingJudge(
+        client=FakeClient(ScriptedResponses([])), model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=audio,
+    )
+
+    result = _audio_judge(
+        judge, deliverable_dir, criterion="c",
+        audio_path="clip.wav", member=None,
+    )
+
+    assert result["ok"] is True
+    assert audio.paths == [str(deliverable_dir / "clip.wav")]
+
+
+def test_an_unknown_member_is_told_what_the_archive_holds(
+    deliverable_dir, task_and_item
+):
+    """The judge's own mistake to correct, so it gets a usable message.
+
+    ``public_task_error_text`` would return ``code:type`` and strip exactly
+    the member list that lets the next call succeed. ``read_deliverable``
+    surfaces ``str(exc)`` for the identical mistake made through ``scope``.
+    """
+    _stems_archive(deliverable_dir)
+    judge = ToolCallingJudge(
+        client=FakeClient(ScriptedResponses([])), model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=_RecordingAudio(),
+    )
+
+    result = _audio_judge(
+        judge, deliverable_dir, criterion="c",
+        audio_path="stems.zip", member="Vocals.wav",
+    )
+
+    assert result["ok"] is False
+    assert result["error_type"] == "bad_scope"
+    assert "Master.wav" in result["error"]
+
+
+def test_a_member_that_is_not_a_string_is_a_bad_argument(
+    deliverable_dir, task_and_item
+):
+    _stems_archive(deliverable_dir)
+    audio = _RecordingAudio()
+    judge = ToolCallingJudge(
+        client=FakeClient(ScriptedResponses([])), model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=audio,
+    )
+
+    result = _audio_judge(
+        judge, deliverable_dir, criterion="c",
+        audio_path="stems.zip", member=17,
+    )
+
+    assert result["ok"] is False
+    assert result["error_type"] == "bad_args"
+    assert audio.paths == []
+
+
+def test_member_cannot_be_used_to_reach_outside_the_allowlist(
+    deliverable_dir, task_and_item
+):
+    """The archive is still checked against the allowlist before extraction."""
+    _stems_archive(deliverable_dir)
+    audio = _RecordingAudio()
+    judge = ToolCallingJudge(
+        client=FakeClient(ScriptedResponses([])), model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=audio,
+    )
+
+    result = judge._dispatch_tool(
+        _fc("a1", "audio_judge", criterion="c",
+            audio_path="stems.zip", member="Master.wav"),
+        deliverable_dir=str(deliverable_dir),
+        allowed_paths={"other.wav"},
+    )
+
+    assert result["ok"] is False
+    assert audio.paths == []
+
+
+def test_the_schema_offers_member_without_demanding_it():
+    schema = ToolCallingJudge._audio_tool_schema()
+    params = schema["parameters"]
+
+    assert "member" in params["properties"]
+    assert params["required"] == ["criterion", "audio_path"]
+    # Nullable, because ``additionalProperties: False`` plus a non-nullable
+    # optional is how a model ends up unable to say "the whole file".
+    assert params["properties"]["member"]["type"] == ["string", "null"]


### PR DESCRIPTION
## What this is

Stage 1 graded 30 gold deliverables — the benchmark's own reference answers —
and they scored **82.87%** against a ≥90% threshold. Stage 1's conclusion was
that the shortfall is not about the answers: it is about what the judge's tools
let it see. This pull request fixes the four tool defects that report named,
before any of that is paid for again at 220-task scale.

Nothing here calls a model, marks anything, or spends anything. It changes what
the judge is able to observe, and therefore changes the grader fingerprint —
see **What this invalidates** at the bottom.

## The four defects

### 1. A task made entirely of music was graded without anything ever listening

Stage-1 task `38889c3b` delivers its whole answer as one 180 MB `.zip` of audio
stems and is marked on tempo, key, vocals, effects and mix. It recorded
`perception_call_count: 0` and scored 41.8 of 62.

One line of routing caused it. An audio criterion whose files carry no audio is
demoted to the reading path, and the test for "carries audio" was the file
extension. `.zip` is not an audio extension, so every listening criterion on
that task was demoted and answered by reading an archive listing. A container is
a fact about packaging, not about the medium.

New `has_audio_content()` opens the archive and looks. Routing now keeps the
listening model on a criterion whose files really do hold audio.

**Measured against that run's own recorded `routing_modality`, replayed across
all 1,428 items of the 30-task cohort: exactly 10 items move, all on this one
task, all to the listening path** (7 from `text`, 3 from `formatting`). Those 10
hold **18 points — 9.5 the task lost and 8.5 it already earned**. The earned
ones are the WAV-header items that `probe_audio` answers either way, and they
must not regress.

Of the 9.5 lost, about **5.5 are reachable** and about **4.0 are not**, because
`AUDIO_TRIM_SECONDS = 30` sends only the first thirty seconds. That constant is
read from the grading config, so raising it would change `config_hash` on the
frozen `gold_ceiling_30_v2_sol_max.yaml` contract that stages 1, 2 and 3 all
have to share. It is left alone and reported as a measured limit rather than
quietly changed. Stage 1's "~20 points" estimate for this item is not
supportable — the remainder sits on signal measurements no listening model
performs.

The probe is **defensive only**. It can stop a demotion; it can never route a
criterion on its own. Promoting on the file rather than on the criterion would
have sent all 35 items of that task to the listening path — including "the file
is named correctly" — and spent the three-call-per-task cap on the first three.

### 2. `audio_judge` could only be handed a whole file

Once routing points at an archive, the listening tool still could not reach the
stem inside it. `audio_judge` now takes an optional `member`, extracts that one
entry for the duration of the call and cleans it up afterwards. Naming an entry
that is not there returns the archive's real contents so the next call can
succeed — the same answer `read_deliverable` already gives for the same mistake.

### 3. An empty read was treated as proof the content was absent

On stage-1 task `43dc9778` the judge read a two-page scan that has no text
layer. `read_content` returned `"text": "", "char_count": 0, "truncated":
false` — and **ten rubric items about that document's contents were failed on
that alone, losing 13 points**. The document says all ten things, on pages the
harness had already rendered for the same task's other items.

Reads that come back empty now say *why* (no text layer, an unsupported kind, a
genuinely empty file) and name the op that can still answer. Rule 5 of the
judge's standing instructions now says the same thing in words: "I could not
read it" is not "it is not there".

A second, narrower net routes an item whose files *all* fail to read to the path
that looks at them instead. Only a *measured* "no text" counts (an unknown never
escalates), only text and formatting items escalate, and every selected file
must be renderable, so it can only fire where the run currently produces
`required_visual_render_target_unavailable` anyway.

**Measured across all 1,428 items: that escalation fires on none of them.** The
only text-less file in the whole gold corpus is always selected alongside a
readable companion, so on this cohort the repair is entirely the honest empty
result and the instruction that goes with it — and the added vision cost is
**zero**. The escalation is a safety net for the case this cohort does not
contain, not the thing that fixes these ten items.

### 4. "Does it fit on one page" was answered from a character count

A `.docx` stores no pagination — the number does not exist until something lays
the document out. Six stage-1 items asking about length were answered from
`paragraph_count` or `char_count`; five were marked down against gold answers
that were the right length. The one *required* item stage 1 failed was failed
here, on 6,532 characters read as "longer than one page".

`inspect_structure` now converts with the same LibreOffice the render path uses
and reports `converted_page_count`. A missing converter costs that one number
and nothing else.

Separately, a gold answer lost an orientation item because the only geometry a
judge could see was `page_count: 1`. The page was 432×288 — landscape, exactly
as the rubric asked. Both PDF ops now report page sizes, orientation and whether
the pages are uniform.

## Blast radius, measured rather than argued

`has_audio_content` was run against **all 248 gold deliverable files**:

| answer | count | meaning |
|---|---|---|
| `True` | **1** | `DEJA VU  STEMS .zip` — the task above |
| `False` | 246 | cannot change routing |
| `None` | 1 | `PrivateCrypMixV2.zip`, which raises `BadZipFile` |

Only the single `True` can change routing at all. `None` deliberately leaves the
existing extension rule in charge rather than promoting towards a file nothing
can extract.

**The defect PR #93 fixed stays fixed.** An `.xlsx` *is* a zip container, so
"does this hold audio" is a question that could plausibly have been asked of one
— and answering yes would send a line item about contractor fees ("Band and Crew
includes Sound Technician fees") to a listening model. It does not:
`_kind_of` gives an Office file its own kind rather than `zip`, so the probe
short-circuits to `False`. Verified against **all 146 Office deliverables in the
gold corpus, every one of which probes `False`**, and now pinned end-to-end
through `plan_task_runtime` rather than at the pure routing call alone.

## Cost

Cost does not block this branch — PR #252 records the owner's standing approval
— but it is recorded.

* **Defect 3 adds no vision calls on this cohort.** An item escalated from the
  reading path to the render path would be a vision call that did not happen
  before, bounded by the existing `visual_file_cap` and
  `_remaining_vision_calls()`. Replayed over all 1,428 items of the 30-task
  cohort, **no item escalates**, so the added vision spend here is zero. On a
  cohort that does contain an all-unreadable item the bound still applies; no
  new budget is introduced.
* **Defect 1 adds paid listening calls**, bounded by the existing
  `AUDIO_CALL_CAP = 3` per task. Ten items move to the listening path, all on
  one task, so the cohort gains **at most three** audio calls.
* **The judge prompt grew, so the marking cost envelope moved.** Telling the
  judge what an empty read means took `prompts/grader_judge_v2.md` from **6,263
  to 6,772 characters**. That file is sent on every marking call and is priced,
  so the opening every call carries rises **2,656 → 2,825 tokens** and the
  demanded input per call **535,990 → 536,159**. Running the free envelope check
  on this branch and on `main` shows that is the **only** difference in its 98
  lines of output: same 14 problems, same ceiling, same approved maximum, same
  non-zero exit.

Five cost-envelope tests failed on the old length. They were corrected to the
new measurement, **not loosened** — a pinned length that has stopped matching
the file is exactly what those tests exist to catch.

## Why `prompt_version` is not bumped

`step8_grade.py:1815` shows the recorded version comes from the grading config,
not from the template footer, and `grader_source_hash` already fingerprints the
template byte-for-byte into every grade filename. Bumping the footer would
change the hash a second time for no added distinguishing power and would make
existing configs disagree with the file they name.

## Tests

84 new tests, all offline:

| file | new |
|---|---|
| `tests/test_read_deliverable.py` | +34 |
| `tests/test_perception_routing.py` | +18 |
| `tests/test_grader_archive_audio_routing.py` | 15 (new file) |
| `tests/test_grader_empty_read_routing.py` | 9 (new file) |
| `tests/test_tool_calling_judge.py` | +8 |

Both new files test the paid path *and* the model-free preflight that is
supposed to predict it exactly, because a preflight that disagrees with the run
is how this defect stayed invisible through stage 1: a cohort that plans zero
audio calls on a music task never trips the "audio routes require configured
audio perception" check.

LibreOffice is not installed on the machine these tests run on, so the
conversion tests monkeypatch `_convert_office_to_pdf` / `_find_soffice` rather
than silently skipping.

`mypy core/ --ignore-missing-imports` is a verified **zero-regression** against
`main`, compared by building a clean baseline worktree and diffing with line
numbers stripped.

## What this invalidates

`grader_source_hash` on the frozen gold-ceiling config changes:

```
c33d9d55703fbf5de5f988d427e34efd44d7a73306412caac88a753bad16ff4e   (main)
2cf2f97157773651019a328c79b84e2ac144fc52fb4138494ee30a27eea14298   (this branch)
```

This is correct — the grader really did change — but it means grades produced
after this merge land under a new `src_` fingerprint and are **not item-level
comparable** to the stage 1 and stage 2 records. Those records stay as they are;
they are the measurement of the grader that produced them.

The corpus fingerprints are untouched: `gold_file_set_sha256` and
`_ordered_task_ids_sha256` are unchanged, so the same 30 tasks and the same 40
files are still the contract.
