### PR TITLE
fix(grading): 파일 이름에 붙은 확장자를 형식 요구로 읽지 않는다

### DIFF
--- a/batch-runner/core/deliverable_selector.py
+++ b/batch-runner/core/deliverable_selector.py
@@ -418,18 +418,29 @@ def _reference_basenames(reference_files: list[str], reference_file_urls: list[s
     return names
 
 
+# An extension only asks for a format when it is written on its own -- "as a
+# single .pdf", "deliver one .xlsx". Written against a name it is naming a file
+# instead: "pm duties final.pdf", "territory_fit_report_ref_(3).xlsx". The
+# patterns below reach across the whole task with ``.*``, and _norm has already
+# folded the prompt and every rubric line into one line, so without this the
+# ``.pdf`` of a reference input the task was told to read against satisfies
+# ``final.*\.pdf`` from a trigger word several sentences away. Requiring a space
+# in front is what separates the two readings.
+_STANDALONE = r"(?<!\S)"
+
+
 def _required_primary_extensions(text: str) -> set[str]:
     low = _norm(text)
     exts: set[str] = set()
     strong_patterns = [
-        (r"(single|exactly one|final|primary|deliverable).*\.pdf|single pdf|exactly one .*pdf", {".pdf"}),
-        (r"(single|exactly one|final|primary|deliverable).*\.docx|single microsoft word|single word file", WORD_EXTENSIONS),
-        (r"(single|exactly one|final|primary|deliverable).*\.xlsx|single excel workbook|single workbook", SPREADSHEET_EXTENSIONS),
-        (r"(single|exactly one|final|primary|deliverable).*\.pptx|single powerpoint|single presentation", PRESENTATION_EXTENSIONS),
-        (r"(single|all content|deliverable).*\.zip|single \.zip|single zip", {".zip"}),
+        (rf"(single|exactly one|final|primary|deliverable).*{_STANDALONE}\.pdf|single pdf|exactly one .*pdf", {".pdf"}),
+        (rf"(single|exactly one|final|primary|deliverable).*{_STANDALONE}\.docx|single microsoft word|single word file", WORD_EXTENSIONS),
+        (rf"(single|exactly one|final|primary|deliverable).*{_STANDALONE}\.xlsx|single excel workbook|single workbook", SPREADSHEET_EXTENSIONS),
+        (rf"(single|exactly one|final|primary|deliverable).*{_STANDALONE}\.pptx|single powerpoint|single presentation", PRESENTATION_EXTENSIONS),
+        (rf"(single|all content|deliverable).*{_STANDALONE}\.zip|single \.zip|single zip", {".zip"}),
         (r"(audio file|wav file|delivered audio|deliverable audio)", AUDIO_EXTENSIONS),
-        (r"(final deliverable).*\.mp4|final .*mp4|mp4 video|final composited video|final video", VIDEO_EXTENSIONS),
-        (r"python notebook|\.ipynb|notebook file", {".ipynb"}),
+        (rf"(final deliverable).*{_STANDALONE}\.mp4|final .*mp4|mp4 video|final composited video|final video", VIDEO_EXTENSIONS),
+        (rf"python notebook|{_STANDALONE}\.ipynb|notebook file", {".ipynb"}),
     ]
     for pattern, matched in strong_patterns:
         if re.search(pattern, low):

--- a/batch-runner/tests/test_selector_reads_a_filename_as_a_filename.py
+++ b/batch-runner/tests/test_selector_reads_a_filename_as_a_filename.py
@@ -1,0 +1,315 @@
+"""An extension against a name is naming a file, not demanding a format.
+
+``_required_primary_extensions`` decides what format a task is asking for, and
+``select_deliverables`` refuses the whole task -- ``wrong_format_primary``,
+every rubric item a judge error, a score of zero -- when nothing delivered
+matches. Its patterns reach across the task with ``.*``, and ``_norm`` has
+already folded the prompt and every rubric line into a single line, so the
+``.*`` crosses sentences that have nothing to do with each other.
+
+What it crosses into is usually a *reference input*: the file the task told the
+model to read. Measured on the pinned revision, the widest of these matches ran
+6,847 characters and ended on ``pm duties final.pdf`` -- a PDF the task supplies
+-- on a task whose own first rubric line reads "Deliverable is a Word document".
+
+The cost, measured rather than argued:
+
+* On the 185 gold-bearing tasks, **six** had the benchmark's own expert answer
+  called the wrong format. A gold answer is the format the task wanted by
+  definition, so all six were the inference being wrong, and each lost its
+  whole task: 268 rubric items, 427 points, 3.01 per cent of the corpus.
+* On the committed paid 220-task run ``exp003_GPT52Chat_baseline_runner_exec``
+  the same guard fired 12 times, every one scoring 0.0 or 0.01. Comparing each
+  against that task's own first rubric line: **six agreed and six did not**.
+
+The rule that separates the two readings is that a format demand writes the
+extension on its own -- "as a single .pdf", "in .pptx format" -- and a filename
+writes it against a name: ``pm duties final.pdf``,
+``territory_fit_report_ref_(3).xlsx``. Requiring whitespace in front is the
+whole change. It cannot widen an inference, so it cannot make the guard fire
+anywhere it does not fire today.
+
+Nothing here calls a model, marks anything, or spends anything.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.deliverable_selector import (  # noqa: E402
+    _required_primary_extensions,
+    select_deliverables,
+)
+
+
+def _path(task: str, name: str) -> str:
+    return f"deliverable_files/{task}/{name}"
+
+
+def _ref_url(name: str) -> str:
+    encoded = name.replace(" ", "%20")
+    return (
+        "https://huggingface.co/datasets/openai/gdpval/resolve/main/"
+        f"reference_files/hash/{encoded}"
+    )
+
+
+# ── The rule itself ───────────────────────────────────────────────────────
+
+# Verbatim from the pinned revision. Each is one rubric line from a task whose
+# gold answer is a different format from the one this line used to imply, and
+# each names a reference input the task supplies.
+FILENAMES_IN_REAL_RUBRIC_LINES = [
+    pytest.param(
+        "Includes any details that materially contradicts what is found in "
+        "PM Duties FINAL.pdf",
+        ".pdf",
+        id="1e5a1d7f-a-supplied-pdf-on-a-task-answered-in-word",
+    ),
+    pytest.param(
+        "All figures (counts, durations) are derived from the provided "
+        "'Inventory Incident Report FINAL.xlsx'",
+        ".xlsx",
+        id="552b7dd0-a-supplied-workbook-on-a-task-answered-in-powerpoint",
+    ),
+    pytest.param(
+        "Includes a brief assumptions/notes section indicating sources "
+        "(e.g., “Pricing Email.docx”)",
+        ".docx",
+        id="15d37511-a-supplied-letter-on-a-task-answered-in-a-workbook",
+    ),
+    pytest.param(
+        "Each flyer contains one of the eligible homes listed in "
+        "Massabama Active Listings.xlsx",
+        ".xlsx",
+        id="11593a50-a-supplied-workbook-on-a-task-answered-in-pdf",
+    ),
+    pytest.param(
+        "No numeric values or rankings in the presentation contradict the "
+        "aggregations computed from territory_fit_report_ref_(3).xlsx",
+        ".xlsx",
+        id="a69be28f-a-bracket-before-the-dot-is-still-a-filename",
+    ),
+]
+
+
+@pytest.mark.parametrize("line,extension", FILENAMES_IN_REAL_RUBRIC_LINES)
+def test_an_extension_written_against_a_name_is_not_a_format_demand(
+    line: str, extension: str
+) -> None:
+    """The trigger word is present; the extension belongs to a filename."""
+    text = f"Produce the final deliverable for the client. {line}"
+    assert extension not in _required_primary_extensions(text)
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("The deliverable must be a single .pdf", ".pdf"),
+        ("Deliver exactly one .xlsx workbook", ".xlsx"),
+        ("The final file is a .docx", ".docx"),
+        ("Delivers the deliverable as a file in .pptx format", ".pptx"),
+        ("Package all content as a single .zip", ".zip"),
+    ],
+)
+def test_an_extension_standing_on_its_own_is_still_a_format_demand(
+    text: str, expected: str
+) -> None:
+    assert expected in _required_primary_extensions(text)
+
+
+def test_the_extension_at_the_very_start_of_a_line_still_counts():
+    """There is no character in front of it at all, which is not a name."""
+    assert ".ipynb" in _required_primary_extensions(".ipynb is required")
+
+
+# ── What the ``.*`` was reaching across ───────────────────────────────────
+
+
+def test_a_trigger_word_cannot_reach_a_filename_in_a_different_sentence():
+    """The measured failure: 6,847 characters between the two.
+
+    ``_norm`` makes the prompt and every rubric line one line, so nothing in
+    the pattern stops ``final`` here from meeting ``.pdf`` there. Both halves
+    are innocent; the join is the defect.
+    """
+    text = (
+        "Build the final schedule chart for the maintenance team. "
+        + "Cover every asset class and note the intervals. " * 40
+        + "Includes any details that materially contradicts what is found in "
+        "PM Duties FINAL.pdf"
+    )
+    assert _required_primary_extensions(text) == set()
+
+
+def test_the_same_sentence_with_the_extension_freed_still_demands_the_format():
+    """The join is the defect, not the distance. Distance alone is allowed."""
+    text = (
+        "Build the final schedule chart for the maintenance team. "
+        + "Cover every asset class and note the intervals. " * 40
+        + "The deliverable must be a single .pdf"
+    )
+    assert _required_primary_extensions(text) == {".pdf"}
+
+
+# ── End to end, on the six gold answers that were refused ─────────────────
+
+# task id, what the task supplies, what the expert answer is, the rubric line
+# that used to decide the format, and that task's own first rubric line.
+GOLD_ANSWERS_THAT_WERE_CALLED_THE_WRONG_FORMAT = [
+    pytest.param(
+        "1e5a1d7f",
+        "PM Duties (1).pdf",
+        "PM Schedule Chart.docx",
+        "Includes any details that materially contradicts what is found in "
+        "PM Duties FINAL.pdf",
+        "Deliverable is a Word document",
+        id="1e5a1d7f-word",
+    ),
+    pytest.param(
+        "552b7dd0",
+        "Inventory Incident Report FINAL.xlsx",
+        "Inventory Incident Reports FINAL.pptx",
+        "All figures (counts, durations) are derived from the provided "
+        "'Inventory Incident Report FINAL.xlsx'",
+        "Delivers a PowerPoint presentation file in .pptx format that opens "
+        "without errors",
+        id="552b7dd0-powerpoint",
+    ),
+    pytest.param(
+        "15d37511",
+        "Pricing Email.docx",
+        "GloNGroRealEstate Marketplace Pro Forma.xlsx",
+        "Includes a brief assumptions/notes section indicating sources "
+        "(e.g., “Pricing Email.docx”)",
+        "The deliverable is provided in a spreadsheet format (e.g., Excel, "
+        "CSV, or equivalent).",
+        id="15d37511-spreadsheet",
+    ),
+    pytest.param(
+        "11593a50",
+        "Massabama Active Listings.xlsx",
+        "Massabama Home Flyers.pdf",
+        "Each flyer contains one of the eligible homes listed in "
+        "Massabama Active Listings.xlsx",
+        "Creates a pdf document",
+        id="11593a50-pdf",
+    ),
+    pytest.param(
+        "a69be28f",
+        "Territory Fit Report REF (3).xlsx",
+        "Territory Fit Deck.pdf",
+        "No numeric values or rankings in the presentation contradict the "
+        "aggregations computed from territory_fit_report_ref_(3).xlsx",
+        "The deliverable is a multi-slide presentation exported to PDF "
+        "format.",
+        id="a69be28f-pdf",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "task,reference,gold,filename_line,first_line",
+    GOLD_ANSWERS_THAT_WERE_CALLED_THE_WRONG_FORMAT,
+)
+def test_the_expert_answer_is_no_longer_refused_for_its_format(
+    task: str, reference: str, gold: str, filename_line: str, first_line: str
+) -> None:
+    """A gold answer is the format the task wanted. It cannot be the wrong one."""
+    selection = select_deliverables(
+        task_id=task,
+        deliverable_files=[_path(task, gold), _path(task, reference)],
+        reference_file_urls=[_ref_url(reference)],
+        instruction="Produce the final deliverable described below.",
+        rubric_items=[
+            {"criterion": first_line, "score": 3},
+            {"criterion": filename_line, "score": 2},
+        ],
+    )
+
+    assert selection.selection_status != "wrong_format_primary", (
+        selection.selection_error
+    )
+    assert selection.primary_targets, "the task must have something to grade"
+    assert {
+        path.rsplit("/", 1)[-1]
+        for target in selection.primary_targets
+        for path in target.paths
+    } == {gold}
+
+
+def test_the_supplied_file_is_still_kept_out_of_what_gets_graded():
+    """Not refusing must not turn a reference input into a deliverable."""
+    task, reference, gold = (
+        "11593a50",
+        "Massabama Active Listings.xlsx",
+        "Massabama Home Flyers.pdf",
+    )
+    selection = select_deliverables(
+        task_id=task,
+        deliverable_files=[_path(task, gold), _path(task, reference)],
+        reference_file_urls=[_ref_url(reference)],
+        instruction="Produce the final deliverable described below.",
+        rubric_items=[
+            {"criterion": "Creates a pdf document", "score": 3},
+            {
+                "criterion": "Each flyer contains one of the eligible homes "
+                "listed in Massabama Active Listings.xlsx",
+                "score": 2,
+            },
+        ],
+    )
+    assert _path(task, reference) in selection.reference_files_excluded
+    assert _path(task, reference) not in [
+        path for target in selection.primary_targets for path in target.paths
+    ]
+
+
+# ── The guard keeps its teeth ─────────────────────────────────────────────
+
+
+def test_a_task_that_really_asks_for_one_format_still_refuses_another():
+    """The six the guard was right about must stay refused.
+
+    Otherwise this trades one silent loss for another.
+    """
+    selection = select_deliverables(
+        task_id="really-wants-a-workbook",
+        deliverable_files=[_path("really-wants-a-workbook", "Summary.docx")],
+        instruction="Deliver a single Excel workbook of the quarter's figures.",
+        rubric_items=[
+            {"criterion": "Provides a single Excel workbook.", "score": 3}
+        ],
+    )
+    assert selection.selection_status == "wrong_format_primary"
+    assert selection.primary_targets == []
+
+
+def test_the_change_can_only_narrow_an_inference_never_widen_one():
+    """Whitespace in front is a restriction, so no text can gain a format.
+
+    This is what bounds the blast radius: a run cannot start refusing a task it
+    accepts today. Measured across all 220 tasks of the pinned revision, no
+    task gained a format and none was newly refused.
+    """
+    permissive_alternatives = [
+        "single pdf",
+        "single word file",
+        "single excel workbook",
+        "single powerpoint",
+        "single zip",
+        "wav file",
+        "mp4 video",
+        "python notebook",
+    ]
+    for text in permissive_alternatives:
+        assert _required_primary_extensions(text), (
+            f"{text!r} names a format in words and must keep working"
+        )


### PR DESCRIPTION
## What this is

The judge decides what format a task asked for by reading the task. When
nothing delivered matches that format, `select_deliverables` refuses the whole
task — `wrong_format_primary`, every rubric item becomes a judge error, and the
task scores zero.

This changes one thing about how that format is inferred: an extension only
counts as a format demand when it is written on its own. Written against a name
it is naming a file.

Nothing here calls a model, marks anything, or spends anything. It changes the
grader fingerprint — see **What this invalidates** at the bottom.

## The defect

`_required_primary_extensions` reaches across the whole task with `.*`, and
`_norm` has already folded the prompt and every rubric line into a single line.
So the `.*` crosses sentences that have nothing to do with each other, and what
it crosses into is usually a **reference input** — the file the task told the
model to read.

Measured on the pinned revision, the widest of these matches ran **6,847
characters** and ended on `pm duties final.pdf`, a PDF the task supplies, on a
task whose own first rubric line reads *"Deliverable is a Word document"*. The
trigger word `final` was several sentences away from the `.pdf` it matched.
Matches up to **14,968 characters** occur across the corpus.

Both halves are innocent. The join is the defect.

## The cost, measured rather than argued

**On the 185 gold-bearing tasks, six had the benchmark's own expert answer
called the wrong format.** A gold answer is by definition the format the task
wanted, so every one of these is the inference being wrong — and each one lost
its whole task.

| task | format inferred | what the expert answer actually is | the extension that decided it |
|---|---|---|---|
| `1e5a1d7f` | PDF | `PM Schedule Chart.docx` | `PM Duties FINAL.pdf` |
| `6074bba3` | Word | a PDF | a supplied `.docx` |
| `11593a50` | spreadsheet | `Massabama Home Flyers.pdf` | `Massabama Active Listings.xlsx` |
| `a69be28f` | spreadsheet | `Territory Fit Deck.pdf` | `territory_fit_report_ref_(3).xlsx` |
| `15d37511` | Word | `…Pro Forma.xlsx` | `Pricing Email.docx` |
| `552b7dd0` | spreadsheet | `Inventory Incident Reports FINAL.pptx` | `Inventory Incident Report FINAL.xlsx` |

That is **268 rubric items, 427 points, 3.01 per cent of the corpus**, lost
before a judge read a word. After this change: **0 of 185**.

**On the committed paid 220-task run `exp003_GPT52Chat_baseline_runner_exec`
the same guard fired 12 times**, every one scoring 0.0 or 0.01. Comparing each
against that task's own first rubric line — the line that says in plain words
what the deliverable is — **six agreed and six did not**.

## Why one regex token and not the three-part fix I built first

The first version masked reference filenames out of the text, matched one
rubric line at a time, and required the trigger word within 80 characters. It
reached 0 wrongly-zeroed gold tasks. It also made the guard go blind on 35 gold
tasks where the format really is being asked for.

So all 48 combinations were ablated and scored on two axes — gold answers
wrongly refused, and gold tasks where the guard stops seeing a real demand:

| rule for the extension | gold answers wrongly refused | tasks the guard stops covering |
|---|---|---|
| as today | 6 | 0 |
| + mask reference filenames | 2 | 6 |
| not glued to a letter or digit | 1 | 9 |
| + mask + one rubric line at a time | 0 | 29 |
| **standalone token `(?<!\S)`, alone** | **0** | **35** |

Coverage is not the thing to maximise, though — being *right* is. So every
variant was also scored against the only real evidence that exists: the 12
tasks the paid run actually zeroed, split six right / six wrong by each task's
own first rubric line.

| variant | right refusals kept | wrong refusals dropped |
|---|---|---|
| as today | 6/6 | 1/6 |
| not glued to a letter or digit | 6/6 | 5/6 |
| mask + sentence + gap (3 changes) | 6/6 | **6/6** |
| **standalone token (1 change)** | **6/6** | **6/6** |

The one-token change scores identically to the three-part change on real
evidence. It won on that, not on taste.

Masking reference filenames cannot work here in any case, and the corpus says
why: the rubric spells the supplied files differently from disk —
`pm duties final.pdf` against `PM Duties (1).pdf`,
`territory_fit_report_ref_(3).xlsx` against `Territory Fit Report REF (3).xlsx`.
A mask built from disk names misses the names the rubric actually writes. The
standalone-token rule needs no such list.

## The 35 tasks where the guard narrows

This is recorded rather than buried. On 35 gold tasks the guard now infers
fewer formats than before, so it will not refuse a wrong-format answer it
would previously have caught. That was accepted for two reasons.

The first is that it costs nothing measurable: on the only evidence available —
the 12 real refusals — all six correct ones survive.

The second is the repo's own precedent, written into `_classify_task` in this
same file: *"Declining to choose used to be the answer here, and it is the wrong
one, because declining is not neutral: every rubric item on the task becomes a
judge error and the task scores zero even though the model delivered. On the
sol-220 run that was 243 of 333 judge errors from 5 tasks — more than every
other cause combined."* Refusing a task is the expensive failure. Grading a
wrong-format answer at least produces a score.

## Blast radius

The change is a **restriction**: requiring whitespace in front can only make a
pattern match less often. It cannot make the guard fire where it does not fire
today, so **no task can be newly refused**.

Across all 220 tasks of the pinned revision:

| | tasks |
|---|---|
| gain a format | **0** |
| lose every inferred format | 46 |
| keep some, lose others | 16 |
| unchanged | 158 |

## What it does to a run

The model-free planner (`plan_task_runtime`) was re-run over all 185
gold-bearing tasks, before and after:

| | before | after |
|---|---|---|
| planner errors | 21, on 14 tasks | 15, on 8 tasks |
| tasks routing **zero** rubric items | 9 — **651 points** | 3 — **224 points** |
| planned main judgments | 8,377 | **8,649** (+272) |
| judge routes | text 7,559 · visual 472 · formatting 347 · audio 10 · mixed 6 | text 7,777 · visual 501 · formatting 366 · audio 10 · mixed 8 |
| planned perception calls | 548 | 588 (578 render, 10 audio) |

The eight remaining error tasks are unrelated to this change: `38889c3b`
(10 audio criteria against `AUDIO_CALL_CAP = 3`, the measured limit already
recorded on card 300), `a73fbc98` (102 renders against a cap of 72), three
`required_visual_render_target_unavailable`, and three whose deliverable is a
`.py` / `.overpassql` / `.yaml` file the judge has no reader for — tracked
separately, to land before Stage 3 is dispatched.

## Tests

`tests/test_selector_reads_a_filename_as_a_filename.py`, 21 tests, all offline.

The filename cases are **verbatim rubric lines from the pinned revision**, not
invented strings, so the test fails if the corpus stops looking like this. They
cover: an extension against a name is not a demand; an extension on its own
still is; an extension at the very start of a line still is; a trigger word
cannot reach across sentences; the same sentence with the extension freed still
demands the format; each of the six gold answers is now accepted end-to-end
through `select_deliverables`; the supplied reference file is still excluded
from what gets graded; a task that really asks for one format still refuses
another; and the change can only narrow, never widen.

Two of these failed on first run and both were **my test assumptions being
wrong, not the code**. `"Delivers a presentation file in .pptx format"` infers
nothing because `Delivers` is not one of the trigger words — pre-existing
behaviour this change does not touch. And `reference_files_excluded` holds full
paths, not basenames. Both were corrected to what the code actually does.

- 64 selector tests pass (21 new, 43 existing).
- Full offline suite: **5,402 passed, 9 skipped**, 45 deselected.
- `mypy core/deliverable_selector.py --ignore-missing-imports` — clean.

## What this invalidates

`grader_source_hash` changes, because `core/deliverable_selector.py` is inside
what it fingerprints:

```
gold_ceiling_30_v2_sol_max.yaml
  2cf2f97157773651019a328c79b84e2ac144fc52fb4138494ee30a27eea14298  (main)
  d774ecfb085dd9a5f1184f3846fbac3ff5879952769e6a84b2b4eb9440f58947  (this branch)

default_v2.yaml
  057203929bd0ecd493ff4301f82f55ef926896d930546b9a41ed3f8ae36f722f  (main)
  07c5bcd674ff8d93feaec4885f6a9ff8311314f0df08ec6e85a7bb42438c994f  (this branch)
```

This is correct — the grader really did change — but grades produced after this
merge land under a new `src_` fingerprint and are **not item-level comparable**
to the Stage 1 and Stage 2 records. Those records stay exactly as they are;
they are the measurement of the grader that produced them. No source file or
test pins either old value.

The corpus fingerprints are untouched: `gold_file_set_sha256`
(`cd4448b4…`) and `_ordered_task_ids_sha256` (`82d14ac9…`) are unchanged, so
the same tasks and the same files are still the contract.

## Why this lands before Stage 3

Same reason as #260, stated the same way: running the corpus paid with a
known-recoverable input defect re-loses those points at 220-task scale. 427
points of gold answers refused for their format is not a finding about any
model, and paying to measure it again would not make it one.
