### PR TITLE
fix(grading): 채점기가 코드·설정·노트북 산출물을 읽게 만든다

### DIFF
--- a/batch-runner/core/deliverable_selector.py
+++ b/batch-runner/core/deliverable_selector.py
@@ -34,6 +34,27 @@ DOCUMENT_EXTENSIONS = {
     ".txt",
     ".md",
     ".csv",
+    # Source and configuration files. A task that asks for a script, a query,
+    # or a specification is answered with one, and the corpus does exactly
+    # that: ``.py``, ``.overpassql`` and ``.yaml`` each ship as a gold
+    # deliverable on the pinned revision, and each was previously left out of
+    # this set, so ``_classify_task`` found fewer than two document-like files
+    # and declined the task -- 154 rubric items, 224 points, judged as nothing.
+    #
+    # This is a named list rather than "anything unrecognised", because
+    # ``grader._list_files`` walks the whole deliverable tree with no junk
+    # filter: a permissive rule would promote a stray ``.DS_Store``, ``.log``
+    # or ``.pyc`` to a primary deliverable on a model run.
+    ".py",
+    ".overpassql",
+    ".yaml",
+    # ``.yml`` is not in the corpus as a file, but 2c249e0f's own rubric names
+    # it beside .yaml -- "A YAML file with extension .yaml or .yml exists in
+    # the deliverable root" -- so the benchmark treats the two as one format.
+    ".yml",
+    # ``.json`` is already read as text by ``read_deliverable``; its absence
+    # here was the same inconsistency ``.ipynb`` had in the other direction.
+    ".json",
 }
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".tif", ".tiff"}
 SPREADSHEET_EXTENSIONS = {".xls", ".xlsx", ".xlsm", ".csv"}

--- a/batch-runner/core/tools/read_deliverable.py
+++ b/batch-runner/core/tools/read_deliverable.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import base64
 import io
+import json
 import os
 import shutil
 import subprocess
@@ -78,6 +79,12 @@ _ZIP_NOISE_BASENAMES = ("._",)
 
 MAX_PAGES_DEFAULT = 200       # PDF page-iteration safety cap
 MAX_SHEETS = 100              # workbook safety cap
+
+#: How much of a file is examined before deciding it is text. The question is
+#: whether the bytes are text, and 64 KiB answers it -- a binary format puts
+#: its magic number and its first NUL byte far inside this. Bounding the read
+#: keeps the decision cheap on a large file.
+TEXT_SNIFF_BYTES = 64 * 1024
 
 #: Page geometry. A rubric asks "is it landscape", "is it letter size", "does
 #: it fit on one page" -- questions about the page, which a page count alone
@@ -257,6 +264,7 @@ _EXT_KIND = {
     ".csv": "csv",
     ".txt": "txt", ".md": "txt",
     ".json": "txt",
+    ".ipynb": "notebook",
     ".png": "image", ".jpg": "image", ".jpeg": "image",
     ".gif": "image", ".bmp": "image", ".webp": "image",
     **{extension: "audio" for extension in GRADER_AUDIO_EXTENSIONS},
@@ -266,8 +274,55 @@ _EXT_KIND = {
 }
 
 
+def _reads_as_text(path: Path) -> bool:
+    """Does this file hold text? Answered by opening it, not by its name.
+
+    Only ever asked about an extension ``_EXT_KIND`` does not map, so it
+    cannot reinterpret a format the map already names.
+    """
+    try:
+        with path.open("rb") as handle:
+            head = handle.read(TEXT_SNIFF_BYTES)
+    except OSError:
+        # Unreadable is not the same as binary, but nothing downstream can
+        # read it either, so the honest answer is the conservative one.
+        return False
+    if b"\x00" in head:
+        return False
+    if not head:
+        # No bytes, so no byte that is not text. A zero-byte deliverable is a
+        # real defect and reads better as an empty file the judge is told is
+        # empty than as a file nothing here claims to understand.
+        return True
+    try:
+        head.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        # A multi-byte character can straddle the cap. That is a fact about
+        # where the read stopped, not about the file -- but only when the read
+        # actually stopped there, and only within one character of the end.
+        if len(head) < TEXT_SNIFF_BYTES or exc.start < len(head) - 4:
+            return False
+    return True
+
+
 def _kind_of(path: Path) -> str:
-    return _EXT_KIND.get(path.suffix.lower(), "unknown")
+    """Map a file to the kind the ops dispatch on.
+
+    The extension answers first and its answer is final: an ``.xlsx`` is a
+    workbook whatever its bytes look like, and letting content override that
+    would only invent ways to misread a format already named correctly.
+
+    An unmapped extension is where the name has stopped saying anything, and
+    the corpus ships several -- ``.py``, ``.yaml``, ``.overpassql`` are all
+    gold deliverables, all plainly readable, and all previously ``unknown``,
+    which routes zero rubric items. So the file is opened and looked at, on
+    the same reasoning ``has_audio_content`` already uses for containers: the
+    extension is a fact about naming, not about whether the bytes are text.
+    """
+    mapped = _EXT_KIND.get(path.suffix.lower())
+    if mapped is not None:
+        return mapped
+    return "txt" if _reads_as_text(path) else "unknown"
 
 
 # ── inspect_structure ────────────────────────────────────────────────
@@ -647,10 +702,131 @@ def _op_inspect_structure(p: Path, _scope: Dict[str, Any]) -> Dict[str, Any]:
             base["video"] = _inspect_video(p)
         elif kind == "zip":
             base.update(_inspect_zip(p))
+        elif kind == "notebook":
+            base.update(_inspect_notebook(p))
         # txt/csv/image: size + kind only
     except Exception as exc:  # noqa: BLE001
         base["inspection_error"] = f"{type(exc).__name__}: {exc}"
     return base
+
+
+# ── Notebooks ────────────────────────────────────────────────────────
+
+#: An ``.ipynb`` is JSON, so the sniff above would call it text and a judge
+#: would be handed the raw file. That reads badly in a specific way: the
+#: corpus notebook is 2,285,938 characters of which 39,478 -- 1.7 per cent --
+#: are source, the rest being base64 image payload. A raw read is cut at
+#: MAX_CONTENT_CHARS, so 91 per cent of the file never arrives and most of
+#: what does is base64. Flattening to source plus text output puts the whole
+#: notebook, all 69 cells, inside the window at 48,933 characters.
+#:
+#: Parsed with ``json`` rather than ``nbformat``: the grading container is
+#: pinned by digest, so this cannot add a package to it.
+
+_NOTEBOOK_TEXT_MIMES = ("text/plain", "text/markdown", "application/json")
+
+
+def _notebook_document(p: Path) -> Optional[Dict[str, Any]]:
+    """The parsed notebook, or ``None`` if it is not one.
+
+    A file that does not parse is not an error to report -- it is still text,
+    and the caller falls back to reading it as text, which is what a broken
+    notebook is.
+    """
+    try:
+        document = json.loads(p.read_text(encoding="utf-8", errors="replace"))
+    except ValueError:
+        return None
+    if not isinstance(document, dict) or not isinstance(document.get("cells"), list):
+        return None
+    return document
+
+
+def _joined(value: Any) -> str:
+    """Notebook string fields are either a string or a list of lines."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "".join(part for part in value if isinstance(part, str))
+    return ""
+
+
+def _notebook_output_lines(output: Dict[str, Any]) -> List[str]:
+    kind = output.get("output_type")
+    if kind == "stream":
+        return [f"    [{output.get('name', 'stdout')}] {_joined(output.get('text'))}"]
+    if kind == "error":
+        traceback = "\n".join(
+            line for line in output.get("traceback", []) if isinstance(line, str)
+        )
+        return [f"    [error] {output.get('ename', '')}: "
+                f"{output.get('evalue', '')}\n{traceback}"]
+    if kind in ("execute_result", "display_data"):
+        data = output.get("data")
+        if not isinstance(data, dict):
+            return []
+        for mime in _NOTEBOOK_TEXT_MIMES:
+            if mime in data:
+                return [f"    [{mime}] {_joined(data[mime])}"]
+        # An image output is named rather than dropped. A rubric asking
+        # whether the notebook plots something is answered by the fact that a
+        # figure exists here, and the bytes themselves would not help a text
+        # read.
+        return [f"    [{mime} output, not text]" for mime in sorted(data)]
+    return []
+
+
+def _read_notebook_text(p: Path, _scope: Dict[str, Any]) -> str:
+    document = _notebook_document(p)
+    if document is None:
+        return p.read_text(encoding="utf-8", errors="replace")
+    language = (
+        (document.get("metadata") or {}).get("language_info", {}).get("name")
+        or (document.get("metadata") or {}).get("kernelspec", {}).get("language")
+        or "unknown"
+    )
+    cells = document["cells"]
+    lines = [f"[Notebook: {len(cells)} cell(s), language {language}]"]
+    length = len(lines[0])
+    for index, cell in enumerate(cells, start=1):
+        if not isinstance(cell, dict):
+            continue
+        block = [f"--- cell {index} ({cell.get('cell_type', 'unknown')}) ---",
+                 _joined(cell.get("source"))]
+        for output in cell.get("outputs") or []:
+            if isinstance(output, dict):
+                block.extend(_notebook_output_lines(output))
+        lines.extend(block)
+        length += sum(len(line) + 1 for line in block)
+        if length > MAX_CONTENT_CHARS:
+            # ``_op_read_content`` truncates and says so; stopping here only
+            # avoids building text nobody will see.
+            break
+    return "\n".join(lines)
+
+
+def _inspect_notebook(p: Path) -> Dict[str, Any]:
+    document = _notebook_document(p)
+    if document is None:
+        return {"kind": "notebook", "note": "not valid notebook JSON; read_content "
+                                            "returns the raw file as text"}
+    cells = [cell for cell in document["cells"] if isinstance(cell, dict)]
+    metadata = document.get("metadata") or {}
+    counts: Dict[str, int] = {}
+    outputs = 0
+    for cell in cells:
+        kind = str(cell.get("cell_type", "unknown"))
+        counts[kind] = counts.get(kind, 0) + 1
+        outputs += len(cell.get("outputs") or [])
+    return {
+        "kind": "notebook",
+        "cell_count": len(cells),
+        "cell_types": dict(sorted(counts.items())),
+        "output_count": outputs,
+        "language": (metadata.get("language_info", {}).get("name")
+                     or metadata.get("kernelspec", {}).get("language")),
+        "nbformat": document.get("nbformat"),
+    }
 
 
 # ── read_content ─────────────────────────────────────────────────────
@@ -999,6 +1175,8 @@ def has_extractable_text(path: Union[str, Path]) -> Optional[bool]:
             return bool(_read_xlsx_text(p, {}).strip())
         if kind in ("txt", "csv"):
             return bool(p.read_text(encoding="utf-8", errors="replace").strip())
+        if kind == "notebook":
+            return bool(_read_notebook_text(p, {}).strip())
     except Exception:  # noqa: BLE001
         return None
     # audio, video, zip, unknown: text is not the medium, and "this file has
@@ -1051,6 +1229,8 @@ def _op_read_content(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
         text = _read_pptx_text(p, scope)
     elif kind in ("txt", "csv"):
         text = p.read_text(encoding="utf-8", errors="replace")
+    elif kind == "notebook":
+        text = _read_notebook_text(p, scope)
     elif kind == "zip":
         text = _read_zip_text(p, scope)
     else:

--- a/batch-runner/tests/test_judge_can_read_a_text_deliverable.py
+++ b/batch-runner/tests/test_judge_can_read_a_text_deliverable.py
@@ -1,0 +1,434 @@
+"""A source file, a config file and a notebook are things a judge can read.
+
+Two modules had to agree before that was true, and neither did.
+
+``read_deliverable._kind_of`` decided what a file is from its extension alone,
+and its map names no source or config format. A ``.py``, a ``.yaml``, an
+``.overpassql`` were all ``unknown``, which routes ``read_content`` to "this
+file holds no text" -- a sentence that is false about every one of them.
+
+``deliverable_selector.DOCUMENT_EXTENSIONS`` decides what counts as a
+document-like candidate, and left the same formats out. ``_classify_task``
+needs two document-like files before it will call a multi-file task
+``uniform_primaries``; each of the three affected gold tasks has exactly one
+once its source file is discounted, so all three fell through to ``ambiguous``
+and the whole task was declined.
+
+Measured on the 185 gold-bearing tasks of the pinned revision, before this
+change:
+
+* ``46fc494e`` (Mechanical Engineers) -- ``HeatConduction.py`` -- 0 of 81
+  rubric items, 117 points
+* ``854f3814`` (Software Developers) -- ``abq okc query.overpassql`` -- 0 of
+  23 items, 33 points
+* ``2c249e0f`` (Software Developers) -- ``robot_data_upload_api_v2.yaml`` --
+  0 of 50 items, 74 points
+* ``c7d83f01`` (Financial and Investment Analysts) --
+  ``AmericanOptionPricing.ipynb`` -- no selection error at all, all 43 items
+  judged, every read returning ``char_count=0``. The worst of the four,
+  because nothing reported it.
+
+Nothing here calls a model, marks anything, or spends anything.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.deliverable_selector import (  # noqa: E402
+    DOCUMENT_EXTENSIONS,
+    select_deliverables,
+)
+from core.tools import has_extractable_text  # noqa: E402
+from core.tools.read_deliverable import (  # noqa: E402
+    MAX_CONTENT_CHARS,
+    TEXT_SNIFF_BYTES,
+    _kind_of,
+    _reads_as_text,
+    read_deliverable,
+)
+
+
+@pytest.fixture()
+def base_dir(tmp_path: Path) -> Path:
+    root = tmp_path / "deliverables"
+    root.mkdir()
+    return root
+
+
+# ── The file is opened, not guessed at from its name ──────────────────────
+
+# Every one of these ships as a gold deliverable on the pinned revision except
+# the last two, which the corpus names in prose. Sizes are the real ones.
+SOURCE_FILES_THE_CORPUS_SHIPS = [
+    pytest.param("HeatConduction.py", b"import numpy as np\n", id="py-46fc494e"),
+    pytest.param(
+        "abq okc query.overpassql",
+        b'[out:json][timeout:180];\nway["ref"="US:I 40"];\n',
+        id="overpassql-854f3814",
+    ),
+    pytest.param(
+        "robot_data_upload_api_v2.yaml",
+        b"openapi: 3.0.3\ninfo:\n  title: Robot Data Upload API\n",
+        id="yaml-2c249e0f",
+    ),
+    pytest.param("config.yml", b"retries: 3\n", id="yml-named-beside-yaml"),
+    pytest.param("manifest.json", b'{"ok": true}\n', id="json"),
+]
+
+
+@pytest.mark.parametrize("name,content", SOURCE_FILES_THE_CORPUS_SHIPS)
+def test_a_source_or_config_file_is_read_as_text(
+    base_dir: Path, name: str, content: bytes
+) -> None:
+    written = base_dir / name
+    written.write_bytes(content)
+
+    assert _kind_of(written) in ("txt", "notebook")
+    result = read_deliverable(op="read_content", path=name, base_dir=str(base_dir))
+    assert result["ok"], result
+    assert result["data"]["text"].strip() == content.decode().strip()
+    assert result["data"]["char_count"] > 0
+
+
+def test_a_file_whose_bytes_are_not_text_stays_unknown(base_dir: Path) -> None:
+    """The sniff answers no as readily as yes, or it is not an answer."""
+    drawing = base_dir / "assembly.dwg"
+    drawing.write_bytes(b"AC1032\x00\x00\x00\x00" + b"\xff" * 200)
+
+    assert _kind_of(drawing) == "unknown"
+    data = read_deliverable(
+        op="read_content", path="assembly.dwg", base_dir=str(base_dir)
+    )["data"]
+    assert data["char_count"] == 0
+    assert "holds no text" in data["note"]
+
+
+def test_a_mapped_extension_is_never_reinterpreted_by_its_bytes(
+    base_dir: Path,
+) -> None:
+    """The name wins where the map has an entry, and the map is not a guess.
+
+    A workbook that happens to start with printable bytes is still a workbook,
+    and letting content override the map could only invent ways to misread a
+    format that was named correctly.
+    """
+    fake_workbook = base_dir / "figures.xlsx"
+    fake_workbook.write_bytes(b"this is not really a workbook")
+    fake_image = base_dir / "chart.png"
+    fake_image.write_bytes(b"nor is this a png")
+
+    assert _kind_of(fake_workbook) == "xlsx"
+    assert _kind_of(fake_image) == "image"
+
+
+def test_an_empty_file_of_an_unmapped_extension_is_an_empty_text_file(
+    base_dir: Path,
+) -> None:
+    """No bytes means no byte that is not text.
+
+    A zero-byte deliverable is a real defect, and it reads better as an empty
+    file the judge is told is empty than as a file nothing here understands.
+    """
+    empty = base_dir / "pipeline.py"
+    empty.write_bytes(b"")
+
+    assert _kind_of(empty) == "txt"
+    data = read_deliverable(
+        op="read_content", path="pipeline.py", base_dir=str(base_dir)
+    )["data"]
+    assert data["char_count"] == 0
+    assert data["has_text_layer"] is False
+    assert "no extractable text" in data["note"]
+
+
+def test_a_character_split_by_the_cap_is_not_evidence_of_binary(
+    base_dir: Path,
+) -> None:
+    """Where the read stopped is a fact about the read, not about the file."""
+    filler = b"a" * (TEXT_SNIFF_BYTES - 1)
+    straddling = base_dir / "notes.overpassql"
+    straddling.write_bytes(filler + "€".encode() + b"more text after")
+
+    assert _reads_as_text(straddling) is True
+    assert _kind_of(straddling) == "txt"
+
+
+def test_a_broken_byte_inside_the_window_is_evidence_of_binary(
+    base_dir: Path,
+) -> None:
+    """The tolerance is one character at the boundary, not a blanket pardon."""
+    broken = base_dir / "notes.overpassql"
+    broken.write_bytes(b"query text " + b"\xff\xfe" + b"a" * 4096)
+
+    assert _reads_as_text(broken) is False
+    assert _kind_of(broken) == "unknown"
+
+
+def test_a_file_that_cannot_be_opened_is_not_called_text(base_dir: Path) -> None:
+    """Unreadable is not binary, but nothing downstream can read it either."""
+    assert _reads_as_text(base_dir / "was_never_written.py") is False
+
+
+# ── A notebook is read as a notebook, not as its own JSON ──────────────────
+
+
+def _notebook(cells: list[dict], **metadata: object) -> str:
+    return json.dumps(
+        {
+            "cells": cells,
+            "metadata": {"language_info": {"name": "python"}, **metadata},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+    )
+
+
+def test_a_notebook_is_flattened_to_its_cells(base_dir: Path) -> None:
+    """The raw file is JSON, so the sniff alone would hand over the JSON.
+
+    That reads badly in a measurable way. The corpus notebook,
+    ``AmericanOptionPricing.ipynb``, is 2,285,938 characters of which 39,478 --
+    1.7 per cent -- are source; the rest is base64 image payload. A raw read
+    is cut at MAX_CONTENT_CHARS, so 91 per cent of the file never reaches the
+    judge and most of what does is base64. Flattened, the whole notebook is
+    48,933 characters and nothing is cut.
+    """
+    notebook = base_dir / "analysis.ipynb"
+    notebook.write_text(
+        _notebook(
+            [
+                {"cell_type": "markdown", "source": ["# Pricing\n"], "metadata": {}},
+                {
+                    "cell_type": "code",
+                    "source": ["print(binomial(100))\n"],
+                    "metadata": {},
+                    "outputs": [
+                        {
+                            "output_type": "stream",
+                            "name": "stdout",
+                            "text": ["10.4501\n"],
+                        }
+                    ],
+                },
+            ]
+        )
+    )
+
+    assert _kind_of(notebook) == "notebook"
+    data = read_deliverable(
+        op="read_content", path="analysis.ipynb", base_dir=str(base_dir)
+    )["data"]
+    assert data["kind"] == "notebook"
+    assert "# Pricing" in data["text"]
+    assert "print(binomial(100))" in data["text"]
+    assert "10.4501" in data["text"]
+    # The JSON scaffolding the judge would otherwise have paid its window for.
+    assert "nbformat_minor" not in data["text"]
+    assert has_extractable_text(notebook) is True
+
+
+def test_a_figure_in_a_notebook_is_named_rather_than_dumped(
+    base_dir: Path,
+) -> None:
+    """A rubric asks whether the notebook plots something.
+
+    The answer is that a figure exists, which is the one thing base64 bytes
+    could not tell a text read.
+    """
+    notebook = base_dir / "analysis.ipynb"
+    payload = "iVBORw0KGgo" * 5_000
+    notebook.write_text(
+        _notebook(
+            [
+                {
+                    "cell_type": "code",
+                    "source": ["plt.plot(prices)\n"],
+                    "metadata": {},
+                    "outputs": [
+                        {
+                            "output_type": "display_data",
+                            "data": {"image/png": payload},
+                            "metadata": {},
+                        }
+                    ],
+                }
+            ]
+        )
+    )
+
+    text = read_deliverable(
+        op="read_content", path="analysis.ipynb", base_dir=str(base_dir)
+    )["data"]["text"]
+    assert "image/png output, not text" in text
+    assert payload[:64] not in text
+
+
+def test_a_notebook_that_does_not_parse_is_still_read_as_text(
+    base_dir: Path,
+) -> None:
+    """A broken notebook is a text file, and saying so beats raising."""
+    notebook = base_dir / "half_written.ipynb"
+    notebook.write_text('{"cells": [{"cell_type": "code",')
+
+    data = read_deliverable(
+        op="read_content", path="half_written.ipynb", base_dir=str(base_dir)
+    )["data"]
+    assert data["char_count"] > 0
+    assert '"cells"' in data["text"]
+
+
+def test_notebook_structure_reports_what_a_notebook_has(base_dir: Path) -> None:
+    notebook = base_dir / "analysis.ipynb"
+    notebook.write_text(
+        _notebook(
+            [
+                {"cell_type": "markdown", "source": ["# Title\n"], "metadata": {}},
+                {
+                    "cell_type": "code",
+                    "source": ["x = 1\n"],
+                    "metadata": {},
+                    "outputs": [
+                        {"output_type": "stream", "name": "stdout", "text": ["1\n"]}
+                    ],
+                },
+            ]
+        )
+    )
+
+    data = read_deliverable(
+        op="inspect_structure", path="analysis.ipynb", base_dir=str(base_dir)
+    )["data"]
+    assert data["kind"] == "notebook"
+    assert data["cell_count"] == 2
+    assert data["cell_types"] == {"code": 1, "markdown": 1}
+    assert data["output_count"] == 1
+    assert data["language"] == "python"
+
+
+def test_a_notebook_larger_than_the_window_still_says_it_was_truncated(
+    base_dir: Path,
+) -> None:
+    notebook = base_dir / "huge.ipynb"
+    cell = {"cell_type": "code", "source": ["x = 1  # padding\n" * 400], "metadata": {}}
+    notebook.write_text(_notebook([dict(cell) for _ in range(60)]))
+
+    data = read_deliverable(
+        op="read_content", path="huge.ipynb", base_dir=str(base_dir)
+    )["data"]
+    assert data["truncated"] is True
+    assert data["char_count"] == MAX_CONTENT_CHARS
+
+
+# ── The other ops keep their footing on the new kinds ──────────────────────
+
+
+def test_the_listening_and_watching_probes_name_the_kind_they_were_given(
+    base_dir: Path,
+) -> None:
+    script = base_dir / "solver.py"
+    script.write_bytes(b"print(1)\n")
+
+    for op, note in (("probe_audio", "not an audio file"),
+                     ("probe_video", "not a video file")):
+        data = read_deliverable(op=op, path="solver.py", base_dir=str(base_dir))["data"]
+        assert data["kind"] == "txt"
+        assert data["note"] == note
+
+
+def test_rendering_a_script_is_refused_by_name(base_dir: Path) -> None:
+    """Refusal is fine here; a silent misread would not be."""
+    script = base_dir / "solver.py"
+    script.write_bytes(b"print(1)\n")
+
+    result = read_deliverable(
+        op="render_to_image", path="solver.py", base_dir=str(base_dir)
+    )
+    assert result["ok"] is False
+    assert "txt" in result["error"]
+
+
+# ── The selector can now choose one of these as the deliverable ────────────
+
+# task id, the files it ships, and the file that used to be discounted.
+GOLD_TASKS_THAT_WERE_DECLINED = [
+    pytest.param(
+        "46fc494e",
+        [
+            "HeatConduction.py",
+            "Material analysis Report.pdf",
+            "isotherms_20min.png",
+            "profiles_by_time.png",
+            "time_traces.png",
+        ],
+        "HeatConduction.py",
+        "Provides a node temperature profile vs node index at t ≈ 0.5 minutes "
+        "(time stamp within ±0.1 min of 0.5 min).",
+        id="46fc494e-a-python-solver-and-a-report",
+    ),
+    pytest.param(
+        "854f3814",
+        ["abq okc query instructions.md", "abq okc query.overpassql"],
+        "abq okc query.overpassql",
+        "Includes the full OverpassQL query as a single, contiguous snippet, "
+        "either in its own file or embedded within another file.",
+        id="854f3814-a-query-and-its-instructions",
+    ),
+    pytest.param(
+        "2c249e0f",
+        ["data_flow_updated_v2.txt", "robot_data_upload_api_v2.yaml"],
+        "robot_data_upload_api_v2.yaml",
+        "A YAML file with extension .yaml or .yml exists in the deliverable "
+        "root and serves as the OpenAPI specification",
+        id="2c249e0f-a-spec-and-a-data-flow",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "task,files,discounted,criterion", GOLD_TASKS_THAT_WERE_DECLINED
+)
+def test_the_expert_answer_is_no_longer_declined_as_ambiguous(
+    task: str, files: list[str], discounted: str, criterion: str
+) -> None:
+    """A gold answer is what the task wanted. It cannot be unrecognisable."""
+    selection = select_deliverables(
+        task_id=task,
+        deliverable_files=[f"deliverable_files/{task}/{name}" for name in files],
+        instruction="Produce the deliverable described below.",
+        rubric_items=[{"criterion": criterion, "score": 2}],
+    )
+
+    assert selection.selection_status == "ok", selection.selection_error
+    chosen = {
+        path.rsplit("/", 1)[-1]
+        for target in selection.primary_targets
+        for path in target.paths
+    }
+    assert discounted in chosen
+
+
+def test_the_yml_spelling_is_here_because_a_rubric_names_it() -> None:
+    """2c249e0f writes both spellings in one line, so the pair is one format."""
+    assert {".yaml", ".yml"} <= DOCUMENT_EXTENSIONS
+
+
+def test_junk_a_run_leaves_behind_is_still_not_a_deliverable() -> None:
+    """Why this is a named list rather than "anything unrecognised".
+
+    ``grader._list_files`` walks the whole deliverable tree and appends every
+    file it finds, with no junk filter. A rule that promoted any unmapped
+    extension would make a stray editor or interpreter artefact a candidate
+    primary on a model run, which is a worse failure than the one being fixed
+    -- it would be graded, and silently.
+    """
+    for junk in (".ds_store", ".log", ".pyc", ".swp", ".tmp", ".bak"):
+        assert junk not in DOCUMENT_EXTENSIONS

--- a/batch-runner/tests/test_read_deliverable.py
+++ b/batch-runner/tests/test_read_deliverable.py
@@ -1873,17 +1873,30 @@ def test_has_extractable_text_is_false_for_an_image(png_file):
 
 
 def test_has_extractable_text_is_none_for_a_file_it_cannot_speak_for(base_dir):
-    # A missing file, a medium text is not carried in, and a kind the tool has
-    # no reader for. None of the three is evidence that a file has no text.
+    # A missing file, a medium text is not carried in, and a file whose bytes
+    # are not text. None of the three is evidence that a file has no text.
     missing = base_dir / "nothing_here.pdf"
     audio = base_dir / "stems.wav"
     audio.write_bytes(b"\x00")
-    unknown = base_dir / "notes.rtf"
-    unknown.write_bytes(b"{\\rtf1}")
+    unknown = base_dir / "model.dwg"
+    unknown.write_bytes(b"AC1032\x00\x00\x00\x00binary drawing")
 
     assert has_extractable_text(missing) is None
     assert has_extractable_text(audio) is None
     assert has_extractable_text(unknown) is None
+
+
+def test_an_unmapped_extension_holding_text_is_spoken_for(base_dir):
+    """``.rtf`` is markup, and markup is text.
+
+    It used to answer ``None`` here, on the reasoning that the tool has no
+    reader for it. But ``None`` and ``True`` route identically -- only a
+    measured ``False`` escalates -- so the whole difference is what
+    ``read_content`` returns, and the file plainly holds the prose.
+    """
+    rtf = base_dir / "notes.rtf"
+    rtf.write_bytes(rb"{\rtf1\ansi Quarterly summary follows.\par}")
+    assert has_extractable_text(rtf) is True
 
 
 def test_has_extractable_text_is_none_when_it_could_not_reach_every_page(


### PR DESCRIPTION
## What this is

Three of the benchmark's own expert answers are files the judge has no way to
open, and a fourth is opened and comes back empty. The deliverable is a Python
script, an OverpassQL query, a YAML specification, and a Jupyter notebook.

This teaches the grader to read them. Nothing here calls a model, marks
anything, or spends anything. It changes the grader fingerprint — see **What
this invalidates** at the bottom.

## The defect, in two modules that had to agree

`read_deliverable._kind_of` decided what a file is from its extension alone,
against a fixed map. That map names no source or configuration format, so a
`.py`, a `.yaml`, an `.overpassql`, an `.ipynb` were all `unknown` — and
`unknown` routes `read_content` to `char_count: 0` and the note *"this file
holds no text"*, which is false about every one of them.

`deliverable_selector.DOCUMENT_EXTENSIONS` decides what counts as a
document-like candidate, and left the same formats out. `_classify_task`
requires two document-like files before it will call a multi-file task
`uniform_primaries`. Each of the three affected tasks has exactly one once its
source file is discounted, so each fell through to `ambiguous` and the whole
task was declined.

Either module alone would have been enough to lose the task. Both had the same
gap, in the same direction, for the same reason.

## The cost, measured rather than argued

**Four of the 185 gold-bearing tasks. 197 rubric items. 277 points.**

| task | occupation | the deliverable | what happened |
|---|---|---|---|
| `46fc494e` | Mechanical Engineers | `HeatConduction.py` + a PDF report + 3 PNGs | declined — **0 of 81 items, 117 points** |
| `854f3814` | Software Developers | `abq okc query.overpassql` + its `.md` instructions | declined — **0 of 23 items, 33 points** |
| `2c249e0f` | Software Developers | `robot_data_upload_api_v2.yaml` + a `.txt` data flow | declined — **0 of 50 items, 74 points** |
| `c7d83f01` | Financial and Investment Analysts | `AmericanOptionPricing.ipynb` | **all 43 items judged**, every read returning `char_count: 0` |

The first three at least reported themselves, as
`selection_error: generated candidates exist but selector could not choose
deterministically`. `c7d83f01` is the worse failure: no error anywhere, 43
items marked normally, each one against an empty read. A silent wrong answer
costs more than a loud refusal.

After this change all four select and all four read.

## The notebook needed more than the sniff

Making `_kind_of` open an unmapped file and look at its bytes is enough for the
script, the query and the specification. It is not enough for the notebook,
because a notebook *is* JSON — the sniff would call it text and hand over the
raw file.

Measured on the corpus file:

| | characters | cut at `MAX_CONTENT_CHARS`? |
|---|---|---|
| the file on disk | 2,285,938 | — |
| of which actual source | 39,478 (**1.7 %**) | — |
| what a raw read delivers | 200,000 (**8.7 % of the file**) | yes, and mostly base64 |
| flattened to cells | **48,933**, all 69 cells | **no** |

So `.ipynb` gets a real reader: cell source, stream and error output, and text
`execute_result`/`display_data`. An image output is **named** rather than
dumped — `[image/png output, not text]` — because a rubric asking whether the
notebook plots something is answered by the fact that a figure exists, and the
base64 bytes could not have told a text read anything else.

Parsed with stdlib `json`, not `nbformat`: the grading container is pinned by
digest (`ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c0…`), so this
cannot add a package to it.

`inspect_structure` now reports the real shape — `cell_count 69`,
`cell_types {code: 44, markdown: 25}`, `output_count 25`, `language python`,
`nbformat 4`.

## Why a named list and not "anything unrecognised"

The selector change adds exactly five extensions — `.py`, `.overpassql`,
`.yaml`, `.yml`, `.json` — each with a reason written next to it.

A permissive rule was the obvious alternative and was rejected on evidence:
`grader._list_files` walks the whole deliverable tree and appends every file it
finds, **with no junk filter**. "Any unmapped extension is document-like" would
promote a stray `.DS_Store`, `.log` or `.pyc` to a candidate primary
deliverable on a model run. That failure is worse than the one being fixed,
because it would be graded, and silently.

Each addition is grounded in the corpus census of all 248 gold files on the
pinned revision:

```
.pdf 85 · .xlsx 65 · .docx 64 · .pptx 17 · .zip 5 · .png 3 · .mp4 2
.ipynb 1 · .py 1 · .jpg 1 · .overpassql 1 · .md 1 · .txt 1 · .yaml 1
```

`.yml` ships in no gold file, and is here because `2c249e0f`'s own rubric
writes both spellings in one line — *"A YAML file with extension .yaml or .yml
exists in the deliverable root and serves as the OpenAPI specification"* — so
the benchmark treats the pair as one format. `.json` is here because
`read_deliverable` already read it as text; its absence from the selector was
the same inconsistency `.ipynb` had in the other direction.

**`.tsx` was rejected.** Task `0e386e32` names it in prose but ships
`PrivateCrypMixV2.zip`; `c2e8f271` names `.ts` and `.spec.tsx` and ships
`Coding Standards.docx`. Neither is evidence that the format arrives as a file,
and adding it on prose alone would widen the candidate set for nothing.

## The precedent this follows

`has_audio_content`, landed in #260, already opens a container instead of
trusting its name, on the reasoning *"the container extension is a fact about
packaging, not about the medium."* The same sentence is now written into
`_kind_of`: **the extension is a fact about naming, not about whether the bytes
are text.**

The map stays authoritative where it has an entry, so the sniff can never
reinterpret a named format — an `.xlsx` is a workbook whatever its first bytes
look like. The sniff only speaks where the name has stopped saying anything.

## One existing test changed, and why that is safe

`test_has_extractable_text_is_none_for_a_file_it_cannot_speak_for` used `.rtf`
as its example of a file the tool cannot speak for. `.rtf` is markup, and
markup is text, so it now answers `True`.

That was checked rather than patched around. `core/grader_routing.py:180`
states the routing contract in its own words: *"`None` means unknown and
changes nothing — only a measured `False` escalates."* `None` and `True` route
**identically**. The entire behavioural difference is that `read_content` now
returns the RTF prose instead of claiming the file holds no text, which is
strictly better.

So the fixture moved to a genuinely binary file (a `.dwg` with a NUL byte), and
a new test records the RTF answer explicitly rather than leaving it implied.

## Blast radius

Both changes are **additive**. The sniff runs only where `_EXT_KIND` has no
entry — every currently-mapped format behaves exactly as before. The selector
gains five extensions and loses none, so no file that is document-like today
stops being one.

## What it does to a run

`plan_task_runtime` re-run over all 185 gold-bearing tasks, against a clean
`origin/main` worktree at `1f4082e`:

| | main | this branch |
|---|---|---|
| tasks selecting cleanly | 182 | **185** |
| `selection_error` | 3 | **0** |
| tasks routing **zero** rubric items | 3 — 154 items, **224 points** | **0** |
| planned main judgments | 8,649 | **8,804** (+155) |
| planner errors | 15, on 8 tasks | **12, on 5 tasks** |
| routes: text / formatting / visual / audio / mixed | 7,777 / 366 / 501 / 10 / 8 | 7,925 / 370 / 503 / 10 / 8 |
| planned render / audio calls | 578 / 10 | 580 / 10 |

**No error was added.** The three removed are exactly the three tasks above.
The remaining 12 on 5 tasks are pre-existing and unrelated: `38889c3b` (10
audio criteria against `AUDIO_CALL_CAP = 3`), `a73fbc98` (102 renders against a
cap of 72), and `required_visual_render_target_unavailable` on `e222075d`,
`75401f7c`, `7de33b48`.

Per-task, the three declined tasks move from
`ambiguous` / `ambiguous_candidates` to `separate_equivalent` /
`set_diff_then_separate_primaries`, and each names its real deliverables as
primary. On `46fc494e` the three `.png` figures correctly stay support
artifacts rather than becoming primaries.

## Tests

`tests/test_judge_can_read_a_text_deliverable.py`, 23 tests, all offline. The
rubric lines are **verbatim from the pinned revision**, so the file fails if
the corpus stops looking like this.

They cover: each corpus source format reads as text end-to-end; a file whose
bytes are not text stays `unknown`; a mapped extension is never reinterpreted
by its bytes; a zero-byte unmapped file is an empty text file, not an
unreadable one; a multi-byte character split by the 64 KiB sniff cap is not
evidence of binary but a broken byte well inside the window is; an unopenable
path is not called text; a notebook is flattened to its cells with its JSON
scaffolding gone; a figure is named not dumped; a notebook that does not parse
falls back to raw text rather than raising; `inspect_structure` reports cell
counts; an oversized notebook still reports itself truncated; `probe_audio`,
`probe_video` and `render_to_image` all name the new kind rather than
mishandling it; the three real gold tasks select end-to-end; and editor and
interpreter junk is still not document-like.

- 173 tests pass across the four directly affected files.
- Full offline suite: **5,526 passed, 9 skipped**, 45 deselected, 829 s.
- `mypy core/tools/read_deliverable.py core/deliverable_selector.py
  --ignore-missing-imports` — the same 7 pre-existing errors as `origin/main`,
  shifted by the added lines. **None new.**

## What is deliberately left

`.doc`, `.xls`, `.ppt` are in `DOCUMENT_EXTENSIONS` but have no reader, so the
selector can choose one and then nothing can open it. They are binary OLE
formats — the byte sniff correctly refuses them, and giving them a reader means
a converter, not a sniff.

The corpus does not trip this: on the pinned revision **zero gold files and
zero reference files** use any of the three. They appear only in prose — 14
tasks write `.doc`, 6 write `.xls`, 4 write `.ppt` — so the exposure is on
model runs, where a model could emit one and have it selected and then unread.
That is a Stage 4 concern and is out of scope here.

## What this invalidates

`grader_source_hash` changes, because both edited modules are inside what it
fingerprints:

```
gold_ceiling_30_v2_sol_max.yaml
  5cdf044eb9509cc0f7f5757963816e3dd6e1847a194ada662d1bed8aa45113b0  (main, 1f4082e)
  0e8ba6702d1d56d5c5449c9e977903e76d85a1835a1b9fbb0cdeb586c6fb44b9  (this branch)

default_v2.yaml
  1b195b2d377b66645247f8d052ef6626b4182791dd2ba5a7896abf3037c28366  (main, 1f4082e)
  ad99d45d4e948cf3e7e95287a791563cb0bea6a66227db0a84a4705c6d4d5b79  (this branch)
```

One correction to the record while quoting these. #261's body predicted its
post-merge values as `d774ecfb…` and `07c5bcd6…`. Those were measured on a
branch cut before #257, which landed on main **67 seconds earlier** and added
`core/cost_metering.py`, `core/cost_receipts.py` and changes to `core/grader.py`
— all inside the fingerprint. The prediction was superseded by merge order, not
wrong when made. The four values above were all measured today, on `1f4082e`
and on this branch, so the pair is a real before and after.

Grades produced after this merge land under a new `src_` fingerprint and are
**not item-level comparable** to the Stage 1 and Stage 2 records. Those records
stay exactly as they are — they are the measurement of the grader that produced
them, and no source file or test pins any of these values.

The corpus fingerprints are untouched: `gold_file_set_sha256` (`cd4448b4…`) and
`_ordered_task_ids_sha256` (`82d14ac9…`) are unchanged, so the same tasks and
the same files are still the contract.

## Why this lands before Stage 3

Same reason as #260 and #261. Stage 3 grades all 185 gold-bearing tasks at
roughly 19.4 minutes each. Dispatching it with a known-recoverable input defect
would re-lose these 277 points at full corpus scale and pay for the privilege.
Four expert answers the grader cannot read is not a finding about any model,
and measuring it again would not make it one.
