### PR TITLE
feat(grading): freeze the stage 3 contract over the whole gold corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ tasks/rebuilding_grading_task/*
 !tasks/rebuilding_grading_task/PR3_GOLD_CEILING.md
 !tasks/rebuilding_grading_task/PR3_VARIANCE.md
 !tasks/rebuilding_grading_task/PR3_REPORT.md
+!tasks/rebuilding_grading_task/304-full-gold-corpus.md
 
 *.parquet
 .huggingface/

--- a/batch-runner/grading_configs/gold_ceiling_185_v2_sol_max.yaml
+++ b/batch-runner/grading_configs/gold_ceiling_185_v2_sol_max.yaml
@@ -1,0 +1,330 @@
+schema_version: "2.0"
+config_name: "gold_ceiling_185_v2_sol_max"
+description: |
+  The gold-ceiling measurement over every task that carries an expert answer,
+  spec tasks/rebuilding_grading_task/304-full-gold-corpus.md.
+
+  Runtime semantics are byte-for-byte those of gold_ceiling_30_v2_sol_max, and
+  through it those of default_v2_sol_max: same judge, same reasoning effort,
+  same tool ops and caps, same perception models, same critical rule, same
+  scoring, same prompts, same rate-limit guard. Only the identity differs --
+  the config name and the size of the pinned corpus. That is the whole point:
+  stage 1 measured a ceiling on 30 tasks, and stage 3 asks whether that number
+  survives the rest of the corpus. Changing anything else would make the two
+  incomparable and answer nothing.
+
+  What is being graded is not a model's work. It is the benchmark's own expert
+  answers, registered by experiments/exp_gold_baseline.yaml. So the expected
+  result is near the top of the scale, and a shortfall is a finding about the
+  grader rather than about anybody's model.
+
+# Which 185, and why not 220. The corpus is walked in the dataset's own row
+# order and every task that actually carries an expert answer is taken. 185 of
+# the 220 do; the other 35 ship no gold deliverable at all, and a task with no
+# answer cannot be graded against its answer. So 185 is the whole population
+# here, not a sample of it -- there is nothing left over to have excluded.
+#
+# Dropping those 35 costs no coverage. Measured on the pinned revision, the 185
+# span 9 sectors and 44 occupations, which is exactly what all 220 span. The
+# gold corpus is not a narrower slice of the benchmark; it is the same breadth
+# with the unanswerable rows removed.
+#
+# That is what makes this stage worth paying for. Stage 1's 30 tasks are the
+# first 30 gold-bearing rows in source order, and consecutive rows share an
+# occupation, so that sample covers 4 sectors and 7 occupations. It was a
+# grader sanity check and never claimed to be representative. Its 82.87% is
+# therefore a ceiling measured on 3 per cent of the occupations. Stage 3 is the
+# question stage 1 deferred: does that number hold across all 44.
+#
+# tests/test_gold_ceiling_contract.py re-derives this list from
+# experiments/gold_corpus/gold_deliverable_manifest.json and fails if the two
+# ever disagree, so this block is checked, not trusted.
+#
+# Order is load-bearing twice over. step8_grade.py refuses a pinned list that
+# does not follow canonical source order, and it compares the pinned list to
+# the selected list by equality, so a reordering is a refusal rather than a
+# silently different run.
+rerun_identity:
+  experiment_id: "exp_gold_baseline"
+  expected_task_count: 185
+  # The dataset commit the rubric is read from. The same commit stages 1 and 2
+  # were frozen to, so the two measurements are of the same corpus.
+  rubric_commit_sha: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  # The same commit, because for a gold corpus the dataset IS the inference:
+  # no model ran, so the revision that supplied the answers is the revision
+  # that supplied the rubric.
+  inference_revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  # Deliberately absent: allow_legacy_missing_provenance. That switch forgives
+  # a submission whose Azure routes were never recorded. Here no inference ran,
+  # so there is no route that could be missing -- the payload says `gold-corpus`
+  # outright, and step8_grade.py keeps every such run out of the published path
+  # on that basis alone.
+  task_ids:
+    - "83d10b06-26d1-4636-a32c-23f92c57f30b"
+    - "7b08cd4d-df60-41ae-9102-8aaa49306ba2"
+    - "7d7fc9a7-21a7-4b83-906f-416dea5ad04f"
+    - "43dc9778-450b-4b46-b77e-b6d82b202035"
+    - "ee09d943-5a11-430a-b7a2-971b4e9b01b5"
+    - "f84ea6ac-8f9f-428c-b96c-d0884e30f7c7"
+    - "a328feea-47db-4856-b4be-2bdc63dd88fb"
+    - "27e8912c-8bd5-44ba-ad87-64066ea05264"
+    - "17111c03-aac7-45c2-857d-c06d8223d6ad"
+    - "c44e9b62-7cd8-4f72-8ad9-f8fbddb94083"
+    - "99ac6944-4ec6-4848-959c-a460ac705c6f"
+    - "f9a1c16c-53fd-4c8f-88cc-5c325ec2f0bb"
+    - "38889c3b-e3d4-49c8-816a-3cc8e5313aba"
+    - "1b1ade2d-f9f6-4a04-baa5-aa15012b53be"
+    - "93b336f3-61f3-4287-86d2-87445e1e0f90"
+    - "15ddd28d-8445-4baa-ac7f-f41372e1344e"
+    - "24d1e93f-9018-45d4-b522-ad89dfd78079"
+    - "05389f78-589a-473c-a4ae-67c61050bfca"
+    - "a74ead3b-f67d-4b1c-9116-f6bb81b29d4f"
+    - "bbe0a93b-ebf0-40b0-98dc-8d9243099034"
+    - "76d10872-9ffa-4ede-83ee-e0f1ec5e2b8d"
+    - "36d567ba-e205-4313-9756-931c6e4691fe"
+    - "7bbfcfe9-132d-4194-82bb-d6f29d001b01"
+    - "2696757c-1f8a-4959-8f0d-f5597b9e70fc"
+    - "dfb4e0cd-a0b7-454e-b943-0dd586c2764c"
+    - "4c18ebae-dfaa-4b76-b10c-61fcdf26734c"
+    - "cebf301e-5ea7-41ae-b117-ad8f43e7ac22"
+    - "c2e8f271-7858-412f-b460-472463ad81d9"
+    - "2ea2e5b5-257f-42e6-a7dc-93763f28b19d"
+    - "c357f0e2-963d-4eb7-a6fa-3078fe55b3ba"
+    - "a45bc83b-22f9-4def-8d89-9c5661b2b86f"
+    - "a10ec48c-168e-476c-8fe3-23b2a5f616ac"
+    - "fccaa4a1-1c39-49ac-b701-55361a19966b"
+    - "f5d428fd-b38e-41f0-8783-35423dab80f6"
+    - "2fa8e956-7b35-4c13-95dc-027f02be318b"
+    - "a0ef404e-82a6-4507-bff1-633d7c8e0004"
+    - "b7a5912e-0e63-41f5-8c22-9cdb8f46ab01"
+    - "aa071045-bcb0-4164-bb85-97245d56287e"
+    - "476db143-163a-4537-9e21-fe46adad703b"
+    - "61717508-4df7-41be-bf97-318dfb2475c0"
+    - "0ed38524-a4ad-405f-9dee-7b2252659aad"
+    - "87da214f-fd92-4c58-9854-f4d0d10adce0"
+    - "d025a41c-c439-4ee1-bc79-dd5c94b27a2d"
+    - "9a8c8e28-ce76-408b-83c3-488422892e58"
+    - "3a4c347c-4aec-43c7-9a54-eb1f816ab1f9"
+    - "8c8fc328-69fc-4559-a13f-82087baef0a1"
+    - "e222075d-5d62-4757-ae3c-e34b0846583b"
+    - "75401f7c-396d-406d-b08e-938874ad1045"
+    - "e21cd746-404d-4602-b9d2-01d2812c5b87"
+    - "c7d83f01-2874-4876-b7fd-52582ec99e1a"
+    - "46b34f78-6c06-4416-87e2-77b6d8b20ce9"
+    - "b39a5aa7-cd1b-47ad-b249-90afd22f8f21"
+    - "b78fd844-db76-448e-a783-5e9877cb74c2"
+    - "4520f882-715a-482d-8e87-1cb3cbdfe975"
+    - "ec591973-04d5-48c0-981c-1ab2fcec2dc1"
+    - "62f04c2f-e0f7-4710-876c-54ee9c2e8256"
+    - "3f821c2d-ab97-46ec-a0fb-b8f73c2682bc"
+    - "e996036e-8287-4e7f-8d0a-90a57cb53c45"
+    - "327fbc21-7d26-4964-bf7c-f4f41e55c54d"
+    - "6dcae3f5-bf1c-48e0-8b4b-23e6486a934c"
+    - "1aecc095-4d76-4b89-b752-1a0f870502cd"
+    - "0353ee0c-18b5-4ad3-88e8-e001d223e1d7"
+    - "40a8c4b1-b169-4f92-a38b-7f79685037ec"
+    - "4d1a8410-e9c5-4be5-ab43-cc55563c594c"
+    - "eb54f575-93f9-408b-b9e0-f1208a0b6759"
+    - "11e1b169-5fb6-4d79-8a83-82ddf4987a85"
+    - "a95a5829-34bb-40f3-993b-558aed6dcdef"
+    - "22c0809b-f8db-489e-93b3-b4da225e3e0e"
+    - "bf68f2ad-eac5-490a-adec-d847eb45bd6f"
+    - "efca245f-c24f-4f75-a9d5-59201330ab7a"
+    - "9e39df84-ac57-4c9b-a2e3-12b8abf2c797"
+    - "68d8d901-dd0b-4a7e-bf9a-1074fddf1a96"
+    - "1752cb53-5983-46b6-92ee-58ac85a11283"
+    - "211d0093-2c64-4bd0-828c-0201f18924e7"
+    - "cecac8f9-8203-4ebd-ad49-54436a8c4171"
+    - "8f9e8bcd-6102-40da-ab76-23f51d8b21fa"
+    - "0fad6023-767b-42c1-a1b3-027cd4f583cb"
+    - "02314fc6-a24e-42f4-a8cd-362cae0f0ec1"
+    - "4d61a19a-8438-4d4c-9fc2-cf167e36dcd6"
+    - "6436ff9e-c5f2-47ba-9aaa-49d89b0594ab"
+    - "8a7b6fca-60cc-4ae3-b649-971753cbf8b9"
+    - "40a99a31-42d6-4f23-b3ec-8f591afe25b6"
+    - "b9665ca1-4da4-4ff9-86f2-40b9a8683048"
+    - "c6269101-fdc8-4602-b345-eac7597c0c81"
+    - "be830ca0-b352-4658-a5bd-57139d6780ba"
+    - "a97369c7-e5cf-40ca-99e8-d06f81c57d53"
+    - "3f625cb2-f40e-4ead-8a97-6924356d5989"
+    - "aad21e4c-1d43-45fc-899a-97754a1b1b63"
+    - "8314d1b1-5b0f-42a4-b5d5-91c0867b0913"
+    - "5e2b6aab-f9fb-4dd6-a1a5-874ef1743909"
+    - "46fc494e-a24f-45ce-b099-851d5c181fd4"
+    - "3940b7e7-ec4f-4cea-8097-3ab4cfdcaaa6"
+    - "8077e700-2b31-402d-bd09-df4d33c39653"
+    - "5a2d70da-0a42-4a6b-a3ca-763e03f070a5"
+    - "74d6e8b0-f334-4e7e-af55-c095d5d4d1a6"
+    - "81db15ff-ceea-4f63-a1cd-06dc88114709"
+    - "61b0946a-5c1c-4bf6-8607-84d7c7e0dfe0"
+    - "61e7b9c6-0051-429f-a341-fda9b6578a84"
+    - "c9bf9801-9640-45fa-8166-1ab01f2d98e4"
+    - "f1be6436-ffff-4fee-9e66-d550291a1735"
+    - "41f6ef59-88c9-4b2c-bcc7-9ceb88422f48"
+    - "a0552909-bc66-4a3a-8970-ee0d17b49718"
+    - "4b98ccce-9e42-44e9-9115-6fc3e79de288"
+    - "60221cd0-686e-4a08-985e-d9bb2fa18501"
+    - "3baa0009-5a60-4ae8-ae99-4955cb328ff3"
+    - "5d0feb24-e8b6-4ace-b64f-d5cd1a8b563d"
+    - "1a78e076-445e-4c5d-b8ce-387d2fe5e715"
+    - "1b9ec237-bf9c-41f9-8fa9-0e685fcd93c6"
+    - "0112fc9b-c3b2-4084-8993-5a4abb1f54f1"
+    - "b5d2e6f1-62a2-433a-bcdd-95b260cdd860"
+    - "f841ddcf-2a28-4f6d-bac3-61b607219d3e"
+    - "47ef842d-8eac-4b90-bda8-dd934c228c96"
+    - "1137e2bb-bdf9-4876-b572-f29b7de5e595"
+    - "c3525d4d-2012-45df-853e-2d2a0e902991"
+    - "9a0d8d36-6233-4c76-9107-0d1f783c7340"
+    - "664a42e5-3240-413a-9a57-ea93c6303269"
+    - "3600de06-3f71-4e48-9480-e4828c579924"
+    - "c657103b-b348-4496-a848-b2b7165d28b2"
+    - "ae0c1093-5ea8-4b84-a81e-53ebf7a4321d"
+    - "f9f82549-fdde-4462-aff8-e70fba5b8c66"
+    - "57b2cdf2-ad62-4591-aa91-aad489740320"
+    - "84322284-5c2c-4873-b507-b147449d209d"
+    - "a46d5cd2-55fe-48fa-a4c6-6aaf6b9991b5"
+    - "6241e678-4ba3-4831-b3c7-78412697febc"
+    - "e4f664ea-0e5c-4e4e-a0d3-a87a33da947a"
+    - "a079d38f-c529-436a-beca-3e291f9e62a3"
+    - "02aa1805-c658-4069-8a6a-02dec146063a"
+    - "fd6129bd-f095-429b-873c-dcc3137be2c3"
+    - "ce864f41-8584-49ba-b24f-9c9104b47bf0"
+    - "58ac1cc5-5754-4580-8c9c-8c67e1a9d619"
+    - "3c19c6d1-672c-467a-8437-6fe21afb8eae"
+    - "a99d85fc-eff8-48d2-a7d4-42a75d62f18d"
+    - "1e5a1d7f-12c1-48c6-afd9-82257b3f2409"
+    - "0419f1c3-d669-45d0-81cd-f4d5923b06a5"
+    - "ed2bc14c-99ac-4a2a-8467-482a1a5d67f3"
+    - "46bc7238-3501-4839-b989-e2bd47853676"
+    - "2d06bc0a-89c6-4e89-9417-5ffe725c1bc6"
+    - "fd3ad420-6f7d-43b1-a990-c0c5c047d071"
+    - "6074bba3-7e3a-4b1c-b8c6-a15bb6695c3b"
+    - "5ad0c554-a7a2-48cd-b41a-ebc1bff4a9de"
+    - "11593a50-734d-4449-b5b4-f8986a133fd8"
+    - "94925f49-36bc-42da-b45b-61078d329300"
+    - "90f37ff3-e4ed-4a0b-94bb-bed0f7def1ef"
+    - "403b9234-6299-4b5f-a106-70c1bc11ec4c"
+    - "1bff4551-1d54-4e37-b2e0-d5c3f2ea4a45"
+    - "650adcb1-ed19-4f88-8117-77640f7b94b6"
+    - "01d7e53e-0513-4109-a242-8ccaf442cd21"
+    - "a73fbc98-90d4-4134-a54f-2b1d0c838791"
+    - "0ec25916-1b5c-4bfe-93d3-4e103d860f3a"
+    - "116e791e-890c-42b1-ba90-1db02e8bfd45"
+    - "dd724c67-8118-4b99-ab50-4761af705c3b"
+    - "7151c60a-d4cb-4fc4-8169-3d4cb446e6b9"
+    - "90edba97-74f0-425a-8ff6-8b93182eb7cb"
+    - "8384083a-c31b-4194-80ba-4d335a444918"
+    - "045aba2e-4093-42aa-ab7f-159cc538278c"
+    - "f2986c1f-2bbf-4b83-bc93-624a9d617f45"
+    - "ffed32d8-d192-4e3f-8cd4-eda5a730aec3"
+    - "b3573f20-5d3e-4954-948f-9461fda693d2"
+    - "a69be28f-9a84-47c9-992e-b90446cdca9d"
+    - "788d2bc6-82df-4dc7-8467-a0f31405dc14"
+    - "74ed1dc7-1468-48a8-9071-58775c0d667a"
+    - "69a8ef86-4e69-4fe2-9168-080f1e978e67"
+    - "ab81b076-e5d8-473a-9bdb-7ea7c38f6ebc"
+    - "d7cfae6f-4a82-4289-955e-c799dfe1e0f4"
+    - "19403010-3e5c-494e-a6d3-13594e99f6af"
+    - "7ed932dd-244f-4d61-bf02-1bc3bab1af14"
+    - "105f8ad0-8dd2-422f-9e88-2be5fbd2b215"
+    - "b57efde3-26d6-4742-bbff-2b63c43b4baa"
+    - "15d37511-75c5-4c7f-81f1-16e00c0d95f3"
+    - "bb863dd9-31c2-4f64-911a-ce11f457143b"
+    - "fe0d3941-e32c-4bf1-a643-b566d2b4cb3c"
+    - "6a900a40-8d2b-4064-a5b1-13a60bc173d8"
+    - "1d4672c8-b0a7-488f-905f-9ab4e25a19f7"
+    - "4c4dc603-c21c-4284-8fb1-1b827c1fddf4"
+    - "bb499d9c-0263-4684-9238-75e8e86077b1"
+    - "5349dd7b-bf0a-4544-9a17-75b7013767e6"
+    - "a4a9195c-5ebe-4b8d-a0c2-4a6b7a49da8b"
+    - "552b7dd0-96f4-437c-a749-0691e0e4b381"
+    - "11dcc268-cb07-4d3a-a184-c6d7a19349bc"
+    - "76418a2c-a3c0-4894-b89d-2493369135d9"
+    - "0e386e32-df20-4d1f-b536-7159bc409ad5"
+    - "7de33b48-5163-4f50-b5f3-8deea8185e57"
+    - "854f3814-681c-4950-91ac-55b0db0e3781"
+    - "4122f866-01fa-400b-904d-fa171cdab7c7"
+    - "2c249e0f-4a8c-4f8e-b4f4-6508ba29b34f"
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.6-sol"
+  deployment: "gpt-5.6-sol"
+  api_version: "2025-04-01-preview"
+  timeout_sec: 600
+  reasoning:
+    effort: "max"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+    finalization_reasoning_effort: "max"
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.6-sol"
+      deployment: "gpt-5.6-sol"
+      reasoning_effort: "max"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      deployment: "gpt-audio-1.5"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v2"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"

--- a/batch-runner/tests/test_full_gold_corpus_contract.py
+++ b/batch-runner/tests/test_full_gold_corpus_contract.py
@@ -1,0 +1,484 @@
+"""The stage-3 contract: the gold ceiling over the whole gold corpus.
+
+Stage 1 measured a ceiling on 30 tasks and got 82.87 per cent. That sample is
+the first 30 gold-bearing rows in dataset order, and the dataset runs in sector
+blocks -- `_shard_slice` in step8_grade.py names the same property when it
+explains why shards stride rather than take contiguous blocks: "the corpus
+carries whatever ordering bias the source dataset had (sector runs, difficulty
+drift)". So stage 1's 30 cover 4 sectors and 7 occupations, and its number is a
+ceiling measured on a sixth of the sectors.
+
+Stage 3 is the question stage 1 deferred: does 82.87 survive the rest. These
+tests pin what would have to stay still for the two numbers to be comparable --
+which tasks, which settings, which dataset commit -- and the one thing that is
+allowed to change, which is how many tasks there are.
+
+Spec: tasks/rebuilding_grading_task/304-full-gold-corpus.md
+"""
+
+import importlib.util
+import math
+from pathlib import Path
+import re
+import subprocess
+
+import pytest
+import yaml
+
+import step8_grade as s8
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BATCH_RUNNER = REPO_ROOT / "batch-runner"
+FULL_CONFIG_PATH = BATCH_RUNNER / "grading_configs/gold_ceiling_185_v2_sol_max.yaml"
+SAMPLE_CONFIG_PATH = BATCH_RUNNER / "grading_configs/gold_ceiling_30_v2_sol_max.yaml"
+PRODUCTION_CONFIG_PATH = BATCH_RUNNER / "grading_configs/default_v2_sol_max.yaml"
+SPEC_PATH = REPO_ROOT / "tasks/rebuilding_grading_task/304-full-gold-corpus.md"
+
+#: The dataset commit stages 1, 2 and 3 are all frozen to. Written out rather
+#: than read from the config, so a test comparing the config to it is checking
+#: something.
+PINNED_DATASET_SHA = "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+
+#: The whole gold population, and stage 1's sample of it.
+CORPUS_SIZE = 185
+SAMPLE_SIZE = 30
+
+#: What the dataset covers at the pinned revision, measured from the committed
+#: manifest. The claim stage 3 rests on is that the first number is reached by
+#: the gold corpus and the second is not reached by stage 1's sample.
+SECTOR_COUNT = 9
+OCCUPATION_COUNT = 44
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _manifest_module():
+    """Import the manifest builder by path.
+
+    It lives under scripts/ with no package, and it is the only place that
+    knows how a task's row maps to its gold files -- re-deriving that rule here
+    would be re-deriving the thing under test.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_gold_manifest_builder",
+        BATCH_RUNNER / "scripts/build_gold_deliverable_manifest.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _manifest():
+    module = _manifest_module()
+    return module, module.load_manifest()
+
+
+def _pinned() -> list[str]:
+    return _load_yaml(FULL_CONFIG_PATH)["rerun_identity"]["task_ids"]
+
+
+# --------------------------------------------------------------------------
+# Which 185, and why not 220
+# --------------------------------------------------------------------------
+
+
+def test_the_pinned_corpus_is_every_gold_bearing_task_not_a_sample_of_them():
+    """This is a population, not a sample, so nothing may be left over.
+
+    Stage 1 pinned a prefix and had to argue for the cut. Stage 3 pins the
+    whole gold population and so has no cut to argue for -- but only if the
+    list really is everything. A single dropped task would turn stage 3 back
+    into a sample while still calling itself complete.
+    """
+    module, manifest = _manifest()
+    derived = module.gold_bearing_task_ids(manifest)
+    pinned = _pinned()
+
+    assert pinned == derived
+    assert len(pinned) == CORPUS_SIZE
+    assert len(set(pinned)) == CORPUS_SIZE
+    assert manifest["gold_bearing_task_count"] == CORPUS_SIZE
+
+
+def test_the_thirty_five_left_out_are_exactly_the_ones_with_no_expert_answer():
+    """The only ground for exclusion is having nothing to grade.
+
+    A task the dataset ships no reference answer for cannot be graded against
+    its reference answer. Any other reason for a task to be missing would be a
+    choice, and a choice would need defending.
+    """
+    module, manifest = _manifest()
+    pinned = set(_pinned())
+
+    excluded = [task for task in manifest["tasks"] if task["task_id"] not in pinned]
+    assert len(excluded) == manifest["task_count"] - CORPUS_SIZE == 35
+    for task in excluded:
+        assert not task["files"], (
+            f"{task['task_id']} has an expert answer but is not pinned"
+        )
+    for task in manifest["tasks"]:
+        if task["files"]:
+            assert task["task_id"] in pinned, (
+                f"{task['task_id']} has an expert answer and is not graded"
+            )
+
+
+def test_the_pinned_corpus_is_ordered_the_way_the_grader_demands():
+    """`filter_tasks_for_config` refuses a pin that is not in source order.
+
+    That refusal is the safety net; this is the tripwire in front of it. The
+    manifest records each task's row position, so the pinned list is in source
+    order exactly when those positions ascend.
+    """
+    module, manifest = _manifest()
+    positions = {task["task_id"]: task["position"] for task in manifest["tasks"]}
+
+    pinned_positions = [positions[task_id] for task_id in _pinned()]
+    assert pinned_positions == sorted(pinned_positions)
+
+
+def test_stage_one_graded_the_first_thirty_of_exactly_these_tasks():
+    """The two stages have to be nested, or their numbers are not comparable.
+
+    82.87 per cent came from 30 tasks. Stage 3 is only a widening of that
+    measurement if those same 30 are inside it, in the same order, scored the
+    same way. If the lists ever diverge, stage 3 stops being the continuation
+    of stage 1 and becomes a separate measurement that happens to look similar.
+    """
+    pinned = _pinned()
+    sample = _load_yaml(SAMPLE_CONFIG_PATH)["rerun_identity"]["task_ids"]
+
+    assert sample == pinned[:SAMPLE_SIZE]
+
+
+# --------------------------------------------------------------------------
+# The breadth that is the whole reason to run this
+# --------------------------------------------------------------------------
+
+
+def test_dropping_the_thirty_five_costs_no_sector_and_no_occupation():
+    """The gold corpus is the full breadth of the benchmark, not a slice of it.
+
+    This is what makes 185 an acceptable answer to a question asked about 220.
+    If the 35 unanswerable tasks had taken a sector or an occupation with them,
+    stage 3 could only speak for what was left, and the gap would have to be
+    stated every time the number was quoted. They do not: the sets are equal,
+    not merely the same size.
+    """
+    _, manifest = _manifest()
+    pinned = set(_pinned())
+
+    everything = {(t["sector"], t["occupation"]) for t in manifest["tasks"]}
+    gold = {
+        (t["sector"], t["occupation"])
+        for t in manifest["tasks"]
+        if t["task_id"] in pinned
+    }
+
+    assert gold == everything
+    assert len({sector for sector, _ in gold}) == SECTOR_COUNT
+    assert len({occupation for _, occupation in gold}) == OCCUPATION_COUNT
+
+
+def test_stage_ones_sample_reached_far_less_than_this():
+    """The gap between the two is the finding stage 3 exists to close.
+
+    Recorded as a test rather than as prose in the spec because it is the
+    entire justification for spending on stage 3. If a future edit to the
+    sample made it broad enough, this test fails and the spec's argument has to
+    be rewritten rather than quietly falsified.
+    """
+    _, manifest = _manifest()
+    by_task = {task["task_id"]: task for task in manifest["tasks"]}
+    sample = _load_yaml(SAMPLE_CONFIG_PATH)["rerun_identity"]["task_ids"]
+
+    sectors = {by_task[t]["sector"] for t in sample}
+    occupations = {by_task[t]["occupation"] for t in sample}
+
+    assert len(sectors) == 4
+    assert len(occupations) == 7
+    assert len(sectors) < SECTOR_COUNT
+    assert len(occupations) < OCCUPATION_COUNT
+
+
+# --------------------------------------------------------------------------
+# Nothing but the corpus changed
+# --------------------------------------------------------------------------
+
+
+def test_the_full_run_grades_with_the_sample_runs_settings_unchanged():
+    """Two ceilings measured under different settings cannot be compared.
+
+    Stage 3's entire output is a number placed next to 82.87 per cent. That
+    comparison is only meaningful if the judge, its reasoning effort, its tools
+    and caps, its perception models, its prompts and its rate-limit guard are
+    the ones stage 1 used. Only identity may differ, and identity is the corpus.
+    """
+    full = _load_yaml(FULL_CONFIG_PATH)
+    sample = _load_yaml(SAMPLE_CONFIG_PATH)
+
+    for block in ("judge", "grader", "tpm_guard", "prompt", "rubric", "output"):
+        assert full[block] == sample[block], f"{block} diverged"
+
+    differing = {
+        key
+        for key in set(full) | set(sample)
+        if full.get(key) != sample.get(key)
+    }
+    assert differing == {"config_name", "description", "rerun_identity"}
+
+
+def test_the_full_run_grades_with_production_settings_unchanged():
+    """A ceiling is only the ceiling of the settings that produced it.
+
+    Checked against production directly and not just transitively through the
+    sample config, so that an edit landing in both gold configs at once still
+    fails here.
+    """
+    full = _load_yaml(FULL_CONFIG_PATH)
+    production = _load_yaml(PRODUCTION_CONFIG_PATH)
+
+    for block in ("judge", "grader", "tpm_guard", "prompt", "output"):
+        assert full[block] == production[block], f"{block} diverged"
+
+    # The rubric block may differ in exactly one field: the revision, pinned to
+    # a commit here where production follows `main`. Following a branch is what
+    # a measurement meant to be repeated cannot tolerate.
+    assert {k: v for k, v in full["rubric"].items() if k != "revision"} == {
+        k: v for k, v in production["rubric"].items() if k != "revision"
+    }
+    assert production["rubric"]["revision"] == "main"
+    assert full["rubric"]["revision"] == PINNED_DATASET_SHA
+
+
+def test_the_full_run_pins_one_commit_for_both_rubric_and_corpus():
+    """For a gold corpus the dataset IS the inference.
+
+    No model ran, so the revision that supplied the answers has to be the
+    revision that supplied the rubric being scored against them. It also has to
+    be the commit stages 1 and 2 used, or stage 3 is grading a different corpus.
+    """
+    identity = _load_yaml(FULL_CONFIG_PATH)["rerun_identity"]
+
+    assert identity["rubric_commit_sha"] == PINNED_DATASET_SHA
+    assert identity["inference_revision"] == PINNED_DATASET_SHA
+    assert identity["experiment_id"] == "exp_gold_baseline"
+    assert identity["expected_task_count"] == CORPUS_SIZE
+
+
+def test_the_full_run_does_not_forgive_missing_provenance():
+    """`allow_legacy_missing_provenance` must stay absent.
+
+    It forgives a submission whose Azure routes were never recorded. Here no
+    inference ran, so there is no route that could be missing -- setting it
+    would excuse a gap this corpus cannot have, on the one config whose size
+    makes it the tempting place to loosen something.
+    """
+    identity = _load_yaml(FULL_CONFIG_PATH)["rerun_identity"]
+
+    assert "allow_legacy_missing_provenance" not in identity
+
+
+def test_the_full_run_passes_the_grader_validator():
+    """185 also has to clear the validator's own bounds, which stop at 220."""
+    s8.validate_grading_config(_load_yaml(FULL_CONFIG_PATH))
+
+
+# --------------------------------------------------------------------------
+# A ceiling must never be publishable as a competitor's result
+# --------------------------------------------------------------------------
+
+
+def test_pinning_every_gold_task_is_still_a_subset_of_the_graded_payload():
+    """185 is the whole gold population and still a subset of the payload.
+
+    That reads like a contradiction and is not. `gold_rows_from_parquet` keeps
+    all 220 rows deliberately, the 35 answerless ones carrying
+    `no_gold_deliverable`, and its docstring gives the reason: "Dropping them
+    would make a pinned 30-task selection read as the *whole* corpus
+    downstream, and a subset that calls itself complete is published as a final
+    grade instead of a diagnostic one."
+
+    So the scope stays `subset` at 185 exactly as it was at 30, and the output
+    forks into `_diagnostic/` on that ground as well as on provenance. Pinned
+    here because a later "tidy-up" that drops the empty rows would silently
+    promote this run to a publishable grade.
+    """
+    inference = {
+        "results": [{"task_id": f"task-{index:03d}"} for index in range(220)]
+    }
+    config = {
+        "rerun_identity": {
+            "task_ids": [f"task-{index:03d}" for index in range(CORPUS_SIZE)]
+        }
+    }
+
+    tasks, scope = s8.filter_tasks_for_config(
+        inference, config, tasks_csv=None, limit=0
+    )
+
+    assert len(tasks) == CORPUS_SIZE
+    assert scope == "subset"
+
+
+# --------------------------------------------------------------------------
+# The run has to fit the machinery that will carry it
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shard_count", [1, 5, 8, 10, 11])
+def test_every_allowed_shard_count_covers_the_corpus_exactly_once(shard_count):
+    """The union of the shards must be the corpus, in canonical order.
+
+    A 60-hour serial run is only survivable in shards, and the identity fields
+    keep describing the whole corpus while each shard grades a stride of it. So
+    the arithmetic that reunites them is load-bearing: a gap loses a task
+    silently, an overlap pays for one twice.
+    """
+    tasks = [{"task_id": task_id} for task_id in _pinned()]
+
+    slices = [
+        s8._shard_slice(tasks, shard_index=index, shard_count=shard_count)
+        for index in range(shard_count)
+    ]
+    seen = [task["task_id"] for shard in slices for task in shard]
+
+    assert sorted(seen) == sorted(task["task_id"] for task in tasks)
+    assert len(seen) == CORPUS_SIZE
+    for shard in slices:
+        assert s8._is_ordered_subsequence(
+            [task["task_id"] for task in shard], _pinned()
+        )
+
+
+#: Measured on the committed 220-task Sol Max run and recorded in
+#: 300-gold-ceiling.md: 19.44 minutes a task on average, 32.7 at p90.
+MEAN_TASK_MINUTES = 19.44
+P90_TASK_MINUTES = 32.7
+
+
+def _workflow_numbers() -> dict[str, int]:
+    """Read the three timing limits out of grade-run.yml.
+
+    Read rather than restated, so that changing one of them in the workflow
+    breaks this test instead of quietly invalidating the arithmetic the run
+    plan is built on.
+    """
+    text = (REPO_ROOT / ".github/workflows/grade-run.yml").read_text(encoding="utf-8")
+    budget = re.search(r'GRADER_TIME_BUDGET_SEC:\s*"(\d+)"', text)
+    timeout = re.search(r"^\s*timeout-minutes:\s*(\d+)", text, re.MULTILINE)
+    resume_cap = re.search(r"NEXT_CHUNK -gt (\d+)", text)
+    assert budget and timeout and resume_cap, "grade-run.yml no longer states its limits"
+    return {
+        "budget_min": int(budget.group(1)) // 60,
+        "timeout_min": int(timeout.group(1)),
+        "resume_cap": int(resume_cap.group(1)),
+    }
+
+
+def test_a_chunk_can_always_save_before_the_runner_kills_it():
+    """The time budget must fire far enough ahead of the job timeout.
+
+    The budget is a *pre-check*: step8_grade.py tests the clock before starting
+    a task, never during one. So a chunk can begin its last task at one second
+    under budget and then run for that task's full duration. The gap between
+    budget and timeout therefore has to be wider than a task, or a shard is
+    killed mid-judgement having saved nothing and having paid for everything.
+
+    Checked at p90 rather than at the mean, because the mean is not the case
+    that kills a job.
+    """
+    limits = _workflow_numbers()
+
+    assert limits["budget_min"] < limits["timeout_min"]
+    headroom = limits["timeout_min"] - limits["budget_min"]
+    assert headroom > P90_TASK_MINUTES, (
+        f"only {headroom} min between the {limits['budget_min']} min budget and "
+        f"the {limits['timeout_min']} min timeout; a p90 task is "
+        f"{P90_TASK_MINUTES} min"
+    )
+
+
+def test_the_widest_shard_finishes_inside_the_auto_resume_cap():
+    """A shard is expected to outlast one chunk; it must not outlast ten.
+
+    11 shards is the workflow's own cap, so the largest shard is 17 tasks, and
+    at the measured mean that is about 5.5 hours against a 4 hour chunk. Going
+    over is normal -- the auto-resume exists for it. What is not survivable is
+    needing more chunks than the resume cap allows, because the run would then
+    stop halfway with the money spent.
+    """
+    limits = _workflow_numbers()
+    largest = max(len(_pinned()[index::11]) for index in range(11))
+    assert largest == 17
+
+    minutes = largest * MEAN_TASK_MINUTES
+    chunks = math.ceil(minutes / limits["budget_min"])
+
+    assert minutes > limits["budget_min"], (
+        "a shard finishing inside one chunk would make this test vacuous"
+    )
+    assert chunks == 2
+    assert chunks <= limits["resume_cap"]
+
+
+# --------------------------------------------------------------------------
+# The written record has to match what was actually frozen
+# --------------------------------------------------------------------------
+
+
+def test_the_spec_pins_the_same_corpus_the_config_does():
+    """The spec is the document a reader trusts without opening the YAML."""
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    _, manifest = _manifest()
+
+    assert PINNED_DATASET_SHA in spec
+    assert f"`{manifest['dataset_file_sha256']}`" in spec
+    assert str(CORPUS_SIZE) in spec
+    assert s8._ordered_task_ids_sha256(_pinned()) in spec
+
+
+def test_the_spec_states_its_thresholds_before_the_run():
+    """Pass criteria written after seeing the result are not pass criteria.
+
+    Stage 1 fixed three numbers in advance and then failed two of them, which
+    is the only reason its report says anything. Stage 3 inherits the same
+    three, so they have to be in the document before the spend, in a form that
+    cannot be softened later without the diff showing it.
+    """
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+
+    for threshold in ("90", "0.95", "2%"):
+        assert threshold in spec, f"pass criterion {threshold} is not stated"
+    assert "82.87" in spec, "the number being compared against is not stated"
+
+
+# --------------------------------------------------------------------------
+# The contract must survive a fresh clone
+# --------------------------------------------------------------------------
+
+
+CONTRACT_FILES = (
+    "batch-runner/grading_configs/gold_ceiling_185_v2_sol_max.yaml",
+    "tasks/rebuilding_grading_task/304-full-gold-corpus.md",
+)
+
+
+@pytest.mark.parametrize("relative", CONTRACT_FILES)
+def test_the_stage_three_contract_is_in_the_repository(relative):
+    path = REPO_ROOT / relative
+    assert path.is_file(), f"{relative} is missing"
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", relative],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.returncode == 0, (
+        f"{relative} exists here but git does not track it, so a fresh clone "
+        "would not have it."
+    )

--- a/tasks/rebuilding_grading_task/304-full-gold-corpus.md
+++ b/tasks/rebuilding_grading_task/304-full-gold-corpus.md
@@ -1,0 +1,180 @@
+# 304 — Full Gold Corpus Ceiling
+
+> PR3 / 3 of 4. SPEC §7-1. Stage 1 = `300-gold-ceiling.md`, Stage 2 = `303-variance-and-error.md`.
+
+## 목적
+
+1단계는 30개 과제에서 천장을 쟀고 **82.87%** 가 나왔다. 3단계는 1단계가 미룬 질문 하나에 답한다: **그 숫자가 나머지 전부에서도 유지되는가.**
+
+1단계 표본은 데이터셋 행 순서 앞에서부터 잘랐다. 재현하기 쉬운 대신 좁다 — 연속된 행이 직업을 공유하기 때문이다. 저장소가 이 성질을 이미 알고 있다. `step8_grade._shard_slice`가 shard를 연속 구간이 아니라 stride로 자르는 이유를 이렇게 적어 두었다: *"the corpus carries whatever ordering bias the source dataset had (sector runs, difficulty drift)".* 같은 편향이 1단계 표본을 **9개 sector 중 4개, 44개 직업 중 7개**로 눌렀다.
+
+그러니 82.87%는 직업의 6분의 1에서 잰 천장이다. 3단계는 44개 직업 전부에서 다시 잰다.
+
+## Acceptance
+
+1단계와 **같은 세 임계값**을 쓴다. 새로 정하지 않는다 — 같은 자로 재야 두 숫자를 나란히 놓을 수 있기 때문이다.
+
+- gold 평균 pct **≥ 90%**
+- 필수 항목 통과율 **≥ 0.95**
+- grader 오류율 **< 2%**
+
+1단계 실적은 82.87% / 0.5714 / 0.14% 로 셋 중 하나만 통과했다. 3단계의 판정은 통과·미달만이 아니다. **범위를 넓혔을 때 숫자가 어느 쪽으로 움직이는가**가 실제로 알고 싶은 것이다.
+
+- 비슷하게 유지되면 → 82.87%는 grader의 실제 천장이고, 1단계의 좁은 표본이 원인이 아니었다.
+- 크게 떨어지면 → 1단계 표본이 쉬운 쪽이었다는 뜻이고, 이미 발표된 모델 점수는 더 낮은 천장 기준으로 다시 읽어야 한다.
+- 크게 오르면 → 1단계 표본에 특이하게 어려운 과제가 몰려 있었다는 뜻이다. 어느 과제인지 지목할 수 있어야 한다.
+
+미달 시 grader 결함인지, 입력 결함인지, 도구 결함인지 분류해 보고한다.
+
+---
+
+## 고정 계약 (Stage 3, 185-task)
+
+1단계와 같은 규칙이다. 움직일 수 있는 것은 전부 커밋된 파일에서 다시 계산되며, `batch-runner/tests/test_full_gold_corpus_contract.py`가 어긋나면 실패한다.
+
+### 무엇을 채점하는가
+
+| 항목 | 고정값 | 어디에 박혀 있나 |
+|---|---|---|
+| 데이터셋 | `openai/gdpval` | `experiments/exp_gold_baseline.yaml` |
+| 데이터셋 커밋 | `11e7900cdcac61bc4daf59e65feb238acda98fbf` | grading config `rerun_identity` |
+| rubric 커밋 | 같은 커밋 (`main` 아님) | grading config `rubric.revision` |
+| parquet 파일 지문 | `f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202` | `experiments/gold_corpus/gold_deliverable_manifest.json` |
+| 채점 대상 | **185 task** | grading config `rerun_identity.task_ids` |
+| 채점 설정 | `grading_configs/gold_ceiling_185_v2_sol_max.yaml` | — |
+| grader 소스 지문 | 실행 시 계산되어 파일명과 grade JSON에 기록 | `compute_grader_source_hash` |
+| 컨테이너 이미지 | `ghcr.io/hyeonsangjeon/gdpval-grading@sha256:0f6782c0…` (digest 고정) | `.github/workflows/grade-run.yml` |
+| LibreOffice | `LibreOffice 24.2.7.2 420(Build:2)` | `scripts/preflight_grading_renderer.py`, 이미지 빌드 시 검증 |
+
+1단계·2단계와 **데이터셋 커밋이 같다.** 다른 커밋이면 같은 corpus를 잰 것이 아니므로 82.87%와 비교할 수 없다.
+
+### 어떤 185개인가 — 표본이 아니라 전수
+
+데이터셋 자기 행 순서대로 걸어가며 **실제로 gold 답안이 있는 과제를 전부** 담는다. 220개 중 185개가 그렇다.
+
+빠진 35개의 유일한 사유는 **채점할 것이 없다**는 것이다. 데이터셋이 답안 파일을 하나도 싣지 않은 과제는 그 답안을 기준으로 채점할 수 없다. 다른 사유는 없고, 있다면 그건 선택이므로 변호가 필요하다. `test_the_thirty_five_left_out_are_exactly_the_ones_with_no_expert_answer`가 양방향으로 검사한다 — 답안 있는데 빠진 과제도, 답안 없는데 들어온 과제도 없어야 한다.
+
+**그래서 185는 표본이 아니라 모집단이다.** 1단계는 앞에서 잘랐으니 잘라낸 이유를 변호해야 했다. 3단계는 남는 것이 없으므로 변호할 자름이 없다.
+
+### 35개를 빼도 범위가 줄지 않는다
+
+이것이 220개를 묻는 질문에 185개로 답해도 되는 근거다.
+
+| | 과제 | sector | 직업 |
+|---|---|---|---|
+| 전체 | 220 | 9 | 44 |
+| **gold 보유 (3단계)** | **185** | **9** | **44** |
+| 1단계 표본 | 30 | 4 | 7 |
+
+**개수가 같은 게 아니라 집합이 같다.** `test_dropping_the_thirty_five_costs_no_sector_and_no_occupation`이 (sector, 직업) 쌍 집합의 동등성으로 검사한다. 빠진 35개가 어떤 sector나 직업을 데리고 나갔다면 3단계는 남은 것에 대해서만 말할 수 있고, 숫자를 인용할 때마다 그 구멍을 같이 말해야 했을 것이다. 그렇지 않다.
+
+1단계 대비 격차 — sector 4→9, 직업 7→44 — 가 3단계에 돈을 쓰는 이유 전부다. 그래서 산문이 아니라 `test_stage_ones_sample_reached_far_less_than_this`로 박아 두었다. 나중에 표본이 넓어지면 이 테스트가 빨개지고, 이 문서의 논거는 조용히 거짓이 되는 대신 다시 써야 한다.
+
+### 1단계의 30개는 이 185개의 앞 30개
+
+두 숫자가 비교 가능하려면 두 실행이 **포개져** 있어야 한다. 82.87%는 30개에서 나왔고, 3단계가 그 측정의 확장이려면 그 30개가 같은 순서로 안에 들어 있어야 한다. `test_stage_one_graded_the_first_thirty_of_exactly_these_tasks`가 검사한다.
+
+순서도 계약의 일부다. `step8_grade.py`는 (a) 원본 순서를 따르지 않는 목록을 거부하고, (b) 고정 목록과 선택된 목록을 순서까지 포함해 동등 비교한다. 재정렬은 조용히 다른 실행이 되는 대신 거부된다.
+
+### 입력 지문
+
+| 지문 | 값 |
+|---|---|
+| `ordered_task_ids_sha256` | `cef3a5b9f1305f19437d6ee337936a065965f979325b95a41d1001747e6bfa18` |
+| `gold_file_set_sha256` | `50b5e30b6a77bbaccb58a5e7c534a49258b048ba4aada79d7d9be744ab7e6983` |
+
+정의는 1단계와 같다.
+
+- `ordered_task_ids_sha256` = 185개 task id를 순서대로 담은 compact JSON 배열
+  (`json.dumps(ids, ensure_ascii=False, separators=(",", ":"))`)의 SHA-256.
+  **채점기가 직접 쓰는 값**이다 — `step8_grade._ordered_task_ids_sha256`가 계산해
+  모든 grade JSON의 `expected_ordered_task_ids_sha256`에 넣고, 출력 디렉터리
+  이름도 이 값이 된다.
+- `gold_file_set_sha256` = 각 파일의 `graded_path\tsha256\tsize`를 task 순서대로
+  개행으로 이어 붙인 문자열의 SHA-256. **이 문서가 정의한 값**이고, 파이프라인에
+  대응 필드가 없어 자기 자신끼리만 비교한다.
+
+두 값 모두 매니페스트와 grading config만으로 다시 계산된다 — 623MB짜리 원본 파일 없이도 검증 가능하다. 같은 정의를 1단계 30개에 적용하면 `82d14ac9…` / `cd4448b4…`가 그대로 재현되므로, 계산 방식이 바뀐 것이 아니라 대상이 넓어진 것임을 확인할 수 있다.
+
+### 전수 구성
+
+**파일 248개 / 623,241,071 바이트.** 1단계 표본은 40개 / 184,099,078 바이트였다.
+
+확장자: pdf 85, xlsx 65, docx 64, pptx 17, zip 5, png 3, mp4 2, ipynb 1, py 1, jpg 1, overpassql 1, md 1, txt 1, yaml 1.
+
+sector: Manufacturing 25, Wholesale Trade 25, Professional·Scientific·Technical Services 24, Government 22, Health Care and Social Assistance 22, Real Estate and Rental and Leasing 20, Finance and Insurance 17, Retail Trade 16, Information 14.
+
+rubric 규모: **항목 8,816개 / 만점 14,198점.** 1단계는 1,433개 / 2,243점이었다.
+
+### 알려진 입력 한계 (실행 전 공개)
+
+1단계의 규칙을 따른다 — **실행 후에 이유를 만들어내는 것과 미리 예측해두는 것은 증거로서 값이 다르다.** 아래는 유료 실행 전에 무료 planner(`plan_task_runtime`)를 185개 전부에 돌려 measured한 것이고, 어느 것도 이번에 빼지 않는다.
+
+planner 오류는 **5개 과제에 12건** 남아 있다. 전부 이번 단계 범위 밖의 기존 한계다.
+
+| 과제 | 무엇이 | 왜 남는가 |
+|---|---|---|
+| `38889c3b` | 듣기 기준 10개 vs `AUDIO_CALL_CAP = 3` | 179.7MB `.zip` 한 개가 답안. 압축 파일 **안**은 읽힌다(1단계에서 고침, WAV stem 5개 48kHz/24bit 확인). 그러나 `grader_routing`·`deliverable_selector`에게는 여전히 확장자 `.zip` 파일 하나라 듣기 모델이 배정되지 않는다. 1단계에서 62점 만점에 2.00점이었고, 남은 28점은 실제로 들어야 답할 수 있다. |
+| `a73fbc98` | 렌더 대상 102개 vs cap 72 | 과제 하나가 캡보다 큰 시각 자료를 요구한다. |
+| `e222075d`, `75401f7c`, `7de33b48` | `required_visual_render_target_unavailable` | 필수 시각 항목의 렌더 대상이 없다. |
+
+이 다섯은 3단계 천장을 **아래로** 끌어내린다. 1단계 표본에는 `38889c3b` 하나만 들어 있었으므로, 넓히면서 네 개가 새로 들어온다. 평균이 82.87%보다 낮게 나오면 **먼저 이 네 개를 빼고 다시 계산해** 얼마가 이들 탓인지 분리해 보고한다.
+
+### 결과가 발표되지 않는 이유
+
+`step8_grade.py`는 `gold-corpus` 출처의 모든 실행을 진단 경로(`data/grades/_diagnostic/…`)로 보낸다. 대시보드에는 "이건 천장이지 경쟁자가 아니다"라고 말할 방법이 없다.
+
+여기에 두 번째 근거가 겹친다. **185는 gold 모집단 전부이면서 동시에 채점 payload의 부분집합이다.** 모순처럼 보이지만 아니다. `gold_rows_from_parquet`은 220행을 전부 남기고 답안 없는 35행에 `no_gold_deliverable`을 달아 두는데, 그 이유를 자기 docstring에 적어 두었다: *"Dropping them would make a pinned 30-task selection read as the whole corpus downstream, and a subset that calls itself complete is published as a final grade instead of a diagnostic one."*
+
+그래서 scope는 30개일 때와 똑같이 `subset`이고, 출처와 범위 **두 가지** 이유로 진단 경로에 떨어진다. `test_pinning_every_gold_task_is_still_a_subset_of_the_graded_payload`가 이걸 박아 둔다 — 나중에 누가 빈 행을 "정리"하면 이 실행이 조용히 발표 가능한 성적으로 승격되기 때문이다.
+
+### 실행 계획
+
+커밋된 220-task Sol Max 실행 기준으로 task당 평균 19.44분이다. **185개면 약 60시간 직렬.**
+
+**11 shard**로 나눈다. `grade-run.yml`이 허용하는 최대값이고, 워크플로 자신이 그 이유를 적어 두었다: *"shard_count is capped at 11 against a ~71.6h serial projection, so no sharding choice makes a 220-task run fit in one chunk."*
+
+| | 값 |
+|---|---|
+| shard당 과제 | 16–17개 (stride `tasks[i::11]`) |
+| 가장 큰 shard | 17개 ≈ **5.5시간** |
+| 청크 예산 | `GRADER_TIME_BUDGET_SEC=14400` = **4시간** |
+| job 제한시간 | `timeout-minutes: 320` = **5.33시간** |
+| 자동 재개 상한 | 청크 **10개** |
+
+가장 큰 shard(5.5시간)가 job 제한시간(5.33시간)보다 길다. **이건 문제가 아니라 설계다** — shard 하나가 job 하나에 들어갈 필요는 없고, 그래서 청크가 있다. 17개짜리 shard는 청크 2개로 끝나고, 상한 10개에 한참 못 미친다.
+
+진짜로 지켜야 하는 부등식은 다른 것이다. 시간 예산은 **과제를 시작하기 전에만** 검사된다(`step8_grade.py`의 time-guard pre-check). 즉 청크가 예산 1초 전에 마지막 과제를 시작하면 그 과제의 전체 소요시간만큼 더 돈다. 그러므로 **예산과 제한시간 사이의 여유가 과제 하나보다 넓어야 한다.**
+
+- 여유 = 320 − 240 = **80분**
+- 과제 하나 p90 = **32.7분** → 들어간다
+
+평균이 아니라 p90으로 재는 이유는, job을 죽이는 건 평균짜리 과제가 아니기 때문이다. 여유가 부족하면 shard는 채점 도중에 살해당하고, **아무것도 저장하지 못한 채 이미 쓴 돈은 전부 날아간다.** `test_a_chunk_can_always_save_before_the_runner_kills_it`이 이 부등식을, `test_the_widest_shard_finishes_inside_the_auto_resume_cap`이 청크 개수를 검사한다. 두 테스트 모두 세 숫자를 `grade-run.yml`에서 직접 읽으므로, 워크플로에서 하나를 바꾸면 여기가 빨개진다.
+
+그러므로 shard당 **청크 2개**, 총 22개 job이다. 재개는 사람이 누르지 않는다 — 워크플로가 rc=7을 보고 `resume_chunk+1`로 자기를 다시 띄운다.
+
+shard는 병렬로 돈다. concurrency 키가 `shard_index`를 담고 `shard_count`는 담지 않아서 11개가 서로 다른 그룹이 된다. 합치기는 `step9_merge_shards.py`가 한다.
+
+유료 실행 전에 `dry_run: true`로 전 경로를 무료로 통과시킨다 — 설정 검증, 고정 목록 대조, 컨테이너·렌더러 확인까지 모델 호출 없이 끝나는 구간이 거기까지다.
+
+**shard가 도는 동안 `core/`·`schemas/`·`prompts/`·`grading_configs/`·`grade-run.yml`을 병합하지 말 것.** grader 소스 지문이 바뀌면 합치기가 실패하는데, 그 실패는 이미 돈을 다 쓴 뒤에야 드러난다.
+
+### 기록할 것
+
+실행 후 `tasks/rebuilding_grading_task/PR3_FULL_GOLD_CORPUS.md`에:
+
+- 평균 점수, 필수 항목 통과율, grader 오류율 — 임계값(90% / 0.95 / 2%) 대비
+- **1단계 30개와의 대조**: 같은 30개가 3단계 실행 안에서 몇 점을 받았는지. grader 소스 지문이 그 사이 바뀌었으므로 항목 단위로 같은 값이 나올 이유는 없지만, 크게 벌어지면 그 자체가 발견이다
+- sector별·직업별 평균 — 어디가 천장을 끌어내리는지
+- 위 다섯 개 알려진 한계를 뺀 평균, 뺀 전후를 같이
+- 만점 미달 항목마다 라이브러리 한계인지 진짜 미흡인지 분류
+- 모델별 사용량, 이미지·오디오 채점 호출 수
+- 실제 청구액. 가격 미확정 모델(`gpt-5.6-sol`, `gpt-audio-1.5`)이 있으면 `pricing_complete: false`로 남기고 `$0`이라고 쓰지 말 것
+
+---
+
+## 문서 정정
+
+1단계 문서(`300-gold-ceiling.md`)는 *"전수 220개는 Stage 3에서 한다"*라고 적었고, `gold_ceiling_30_v2_sol_max.yaml`의 주석도 *"stage 3 grades all 220"*이라고 적혀 있다. **둘 다 사실이 아니다.** 채점 가능한 전수는 185개다. 220개를 고정하면 답안 없는 35개가 전부 0점으로 들어와 천장이 실제보다 낮게 나오고, 그건 grader 결함처럼 읽힌다.
+
+같은 종류의 어긋남이 하나 더 있다. `CLAUDE.md`와 `README`가 *"220 tasks across 11 sectors, 55 occupations"*라고 적고 있는데, 고정된 커밋에서 실제로 재면 **9 sector / 44 직업**이다. 이 문서의 모든 수치는 커밋된 매니페스트에서 다시 계산된 값이다.


### PR DESCRIPTION
## What this is

Stage 3's frozen contract, written before the spend: which tasks get graded,
under which settings, against which commit, and what the run has to clear to
count.

Nothing here calls a model, marks anything, or spends anything. Unlike #260,
#261 and #262, **it also changes no fingerprint** — see *What this does not
invalidate* at the bottom.

## The question stage 3 exists to answer

Stage 1 measured the gold ceiling at **82.87 %** on 30 tasks — the first 30
gold-bearing rows in dataset order. Easy to reproduce, and narrow, because
consecutive rows share an occupation.

The repository already knew this. `step8_grade._shard_slice` explains why shards
stride rather than take contiguous blocks: *"the corpus carries whatever
ordering bias the source dataset had (sector runs, difficulty drift)."* The same
bias pressed stage 1's sample into **4 of 9 sectors and 7 of 44 occupations**.

So 82.87 % is a ceiling measured on a sixth of the occupations. Stage 3 measures
it on all of them.

## Why 185 answers a question asked about 220

The roadmap says "all 220 gold deliverables". The dataset ships an expert answer
for **185** of the 220. The other 35 have nothing to grade against — pinning
them would score 35 zeroes and drag the ceiling down for a reason that is not
about the grader.

That substitution is only legitimate if it costs no coverage, so it is measured
rather than asserted:

| | tasks | sectors | occupations |
|---|---|---|---|
| everything | 220 | 9 | 44 |
| **gold-bearing (stage 3)** | **185** | **9** | **44** |
| stage 1's sample | 30 | 4 | 7 |

**The sets are equal, not merely the same size.**
`test_dropping_the_thirty_five_costs_no_sector_and_no_occupation` compares
`(sector, occupation)` pairs directly. Had the 35 taken a sector or an
occupation with them, stage 3 could only speak for what was left, and the hole
would have to be restated every time the number was quoted.

**185 is therefore a population, not a sample.** Stage 1 pinned a prefix and had
to defend the cut; stage 3 pins everything answerable, so there is no cut to
defend. The only ground for exclusion is having no expert answer, and
`test_the_thirty_five_left_out_are_exactly_the_ones_with_no_expert_answer`
checks that in **both** directions — no answered task is missing, no answerless
task is present.

## What is frozen

`grading_configs/gold_ceiling_185_v2_sol_max.yaml`. It was built by taking the
30-task config's file text from `judge:` onward **byte for byte** and giving it
a new header, so parity is structural rather than maintained by hand.

Verified rather than claimed — the set of top-level keys whose values differ
between the two configs is exactly:

```
{config_name, description, rerun_identity}
```

`judge`, `rubric`, `grader`, `tpm_guard`, `prompt` and `output` are `==`.
`test_the_full_run_grades_with_the_sample_runs_settings_unchanged` asserts that
set equality, so adding a key to one config and not the other fails here.
Checked against production directly as well, so an edit landing in *both* gold
configs at once still fails.

| | |
|---|---|
| dataset / rubric commit | `11e7900cdcac61bc4daf59e65feb238acda98fbf` — the same commit as stages 1 and 2 |
| parquet fingerprint | `f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202` |
| `ordered_task_ids_sha256` | `cef3a5b9f1305f19437d6ee337936a065965f979325b95a41d1001747e6bfa18` |
| `gold_file_set_sha256` | `50b5e30b6a77bbaccb58a5e7c534a49258b048ba4aada79d7d9be744ab7e6983` |
| corpus | 248 files, 623,241,071 bytes, 8,816 rubric items, 14,198 points |

Both fingerprints are re-derivable from the committed manifest alone — no
623 MB download needed to check them. Applying the same two definitions to
stage 1's 30 tasks reproduces `82d14ac9…` and `cd4448b4…` exactly, so what
changed is the corpus, not the arithmetic.

Stage 1's 30 are the **first 30 of these 185**, in the same order
(`test_stage_one_graded_the_first_thirty_of_exactly_these_tasks`). Without that
nesting, stage 3 would not be a widening of stage 1's measurement but a separate
one that happens to look similar.

## Acceptance, stated before the run

The same three thresholds as stage 1, deliberately not re-set: **≥ 90 %** mean,
**≥ 0.95** required-item pass rate, **< 2 %** grader error. Stage 1 scored
82.87 % / 0.5714 / 0.14 % — one of three.

But pass/fail is not the interesting output. Which *direction* the number moves
when the corpus widens is:

- **stays near 82.87** — that is the grader's real ceiling, and stage 1's narrow
  sample was not the cause
- **drops sharply** — stage 1's sample was the easy end, and every published
  model score has to be read against a lower ceiling than the one on record
- **rises sharply** — stage 1's sample concentrated unusually hard tasks, and
  this PR's job is to be able to name which ones

## Known input limits, declared in advance

Predicting a shortfall and explaining one after the fact are worth different
amounts as evidence, so these are recorded now. All measured with the free
planner across all 185; none is excluded from the run.

**12 planner errors on 5 tasks**, all pre-existing and all outside this stage:

| task | what | why it stays |
|---|---|---|
| `38889c3b` | 10 listening criteria against `AUDIO_CALL_CAP = 3` | the answer is one 179.7 MB `.zip`. Its *inside* is now read (fixed in #260), but to `grader_routing` and `deliverable_selector` it is still one `.zip`, so no listening model is assigned. Scored 2.00 of 62 in stage 1; the remaining 28 points genuinely require listening |
| `a73fbc98` | 102 render targets against a cap of 72 | one task asks for more visual material than the cap |
| `e222075d`, `75401f7c`, `7de33b48` | `required_visual_render_target_unavailable` | a required visual item has nothing to render |

These pull the stage 3 ceiling **down**. Stage 1's sample contained only
`38889c3b`, so four arrive with the widening. If the mean lands below 82.87 %,
the report recomputes without these four first, so their share is separated
rather than argued about.

## Why the result will not be published

`step8_grade.py` routes every `gold-corpus` run to `data/grades/_diagnostic/…`.
A second, independent reason applies here too, and it looks like a
contradiction until you read the docstring.

**185 is the whole gold population and still a subset of the graded payload.**
`gold_rows_from_parquet` keeps all 220 rows on purpose, tagging the 35
answerless ones `no_gold_deliverable`, and says why: *"Dropping them would make
a pinned 30-task selection read as the whole corpus downstream, and a subset
that calls itself complete is published as a final grade instead of a diagnostic
one."*

So scope stays `subset` at 185 exactly as it was at 30.
`test_pinning_every_gold_task_is_still_a_subset_of_the_graded_payload` pins
that, because a later tidy-up dropping the empty rows would silently promote
this run to a publishable grade.

## The run plan, and the inequality that actually matters

19.44 min a task on the committed 220-task Sol Max run → **~60 h serial** for
185. Split into **11 shards**, the workflow's own cap, giving 16–17 tasks each
and about 5.5 h for the widest.

The widest shard is longer than the 5.33 h job timeout. **That is the design,
not a problem** — a shard is not required to fit one job, which is why chunking
exists. 17 tasks finish in 2 chunks against a resume cap of 10.

The load-bearing inequality is a different one. The time budget is a
**pre-check**: `step8_grade.py` tests the clock *before starting* a task, never
during one. A chunk can begin its last task one second under budget and then run
that task's full length. So the gap between budget and timeout has to exceed one
task:

- gap = 320 − 240 = **80 min**
- p90 task = **32.7 min** → fits

Measured at p90, not the mean, because the mean is not what kills a job. If the
gap were too narrow the shard would be killed mid-judgement having **saved
nothing and paid for everything**.

I originally asserted the wrong thing here — that the widest shard must fit
inside one job — and the test failed. The code was right and the assertion was
wrong. It is now two tests
(`test_a_chunk_can_always_save_before_the_runner_kills_it`,
`test_the_widest_shard_finishes_inside_the_auto_resume_cap`) that read all three
limits **out of `grade-run.yml` by regex**, so changing a limit in the workflow
turns this red instead of quietly invalidating the plan.

## Tests

`tests/test_full_gold_corpus_contract.py` — 23 tests, all offline, no network,
no model.

They pin: the corpus is derived from the manifest and not transcribed; the
exclusion rule in both directions; source ordering (the tripwire in front of
`filter_tasks_for_config`'s refusal); stage 1 nested inside stage 3; the
coverage argument as a set equality; stage 1's narrowness, so a future widening
of the sample forces this document to be rewritten rather than quietly
falsified; settings parity against both the sample and production configs; one
commit for rubric and corpus; `allow_legacy_missing_provenance` staying absent;
the validator's own bounds at 185; the subset/diagnostic property; shard
coverage exactly once at every allowed count (1, 5, 8, 10, 11); the two timing
inequalities; the spec quoting the same fingerprints and stating its thresholds;
and both contract files being tracked by git.

That last one earned its place immediately: the spec was invisible to a fresh
clone, caught by `test_the_stage_three_contract_is_in_the_repository`.
`tasks/rebuilding_grading_task/*` is gitignored with a per-file allow list, and
git will not un-ignore a path inside an ignored directory — the reason the
directory is re-opened first. `.gitignore` now names the file.

- 56 tests pass across the two gold-ceiling contract files.
- Full offline suite: green (see checks).
- `mypy core/ --ignore-missing-imports` — identical to `origin/main`; this PR
  changes no file under `core/`.

## What this does *not* invalidate

The three preceding PRs each moved `grader_source_hash`. This one does not.

`compute_grader_source_hash` fingerprints `step8_grade.py`, every
`core/**/*.py`, the schema, `requirements.txt`, the download script, both
templates, and **the config file passed in** — so a *new* config does not
disturb an existing one's hash. Measured on this branch:

```
gold_ceiling_30_v2_sol_max    0e8ba6702d1d56d5c5449c9e977903e76d85a1835a1b9fbb0cdeb586c6fb44b9
gold_ceiling_185_v2_sol_max   c3d1c821c8d78ec87f1d436dbd623ceeb9db54bffa0d8ab2fe6da6f951ccde9d
```

The first is exactly the post-merge value #262 published. Stages 1 and 2 stay
re-runnable onto the same output path, and comparable.

`gold_file_set_sha256` and `_ordered_task_ids_sha256` for the 30-task
contract (`cd4448b4…`, `82d14ac9…`) are untouched.

## Two documents corrected, and one config deliberately left alone

`300-gold-ceiling.md` says *"전수 220개는 Stage 3에서 한다"* and
`gold_ceiling_30_v2_sol_max.yaml`'s comment says *"stage 3 grades all 220"*.
Both are wrong — the gradeable population is 185.

**The config comment is left as it is on purpose.** Editing it would change that
config's `config_hash` and its `grader_source_hash`, which is precisely the
thing this PR is careful not to do. A stale comment costs a reader one
paragraph; a moved fingerprint costs the ability to re-run stage 1 onto the same
path. The correction is recorded in 304's *문서 정정* section instead.

Separately: `CLAUDE.md` and both READMEs claim *"220 tasks across 11 sectors, 55
occupations"*. Measured at the pinned commit it is **9 sectors, 44 occupations**.
Every figure in the new spec is recomputed from the committed manifest. Fixing
the READMEs is a follow-up, not this PR.
