### PR TITLE
test(cost): 강화 실행이 비용을 기록하지 않는다는 것을 고정한다

### DIFF
--- a/batch-runner/tests/test_hardened_execution_keeps_no_priced_record.py
+++ b/batch-runner/tests/test_hardened_execution_keeps_no_priced_record.py
@@ -1,0 +1,295 @@
+"""A hardened run keeps no priced record, and says so rather than saying $0.
+
+Most execution modes are metered: the client is wrapped, every call is
+reserved before it leaves and settled when it returns, and the task ends with
+a receipt that names what it cost. Two modes are not. ``agentic_sandbox``, and
+``sandbox`` with ``hardened_substrate`` on, run the model behind an attested
+substrate this process does not wrap. There is no honest number to write, so
+``step2_run_inference`` does not open a ledger for them at all and marks the
+receipt ``unavailable`` with ``stage_unsupported``.
+
+That policy is three lines, and until now nothing held it in place. The gap
+was recorded when the metering work merged (#257) and this module closes it.
+
+Two different mistakes could be made here, in opposite directions, and both
+are silent:
+
+* **Metering the attested path.** Turning the ledger on for a hardened run —
+  by narrowing the flag, or by moving the ``open_cost_recorder`` call out from
+  under its guard — produces a receipt that looks priced and is not, because
+  the calls this process can see are not the calls that were billed. An
+  understated bill that presents as a complete one is the worst shape a cost
+  record takes; it is the failure the four statuses exist to prevent.
+* **Letting "unrecorded" read as "free".** ``unavailable`` and ``$0.00`` look
+  the same in a total. They are opposites: one is an absence of knowledge, the
+  other a measurement. A hardened run that summarised to zero would quietly
+  subtract real spend from a report.
+
+The flag governing both is ``hardened_requested``, and it covers *two* modes,
+not one. Narrowing it to ``agentic_sandbox`` alone would leave the hardened
+sandbox metered while still reading as deliberate.
+
+Why part of this is read from the source rather than run. The policy lives
+inside ``main()`` in ``step2_run_inference`` — a long function that reaches the
+branch only after argument parsing, workspace setup, dataset load and client
+construction. There is no hardened end-to-end harness in this suite to drive
+it: ``hardened=True`` is a defined parameter with no exercised path, and
+building one needs the signature-approval gate, which means a real run. So the
+structural half of this module asks the module's own syntax tree the three
+questions a harness would have asked, and the behavioural half runs the
+receipt semantics that branch produces, which *are* reachable. Between them
+the branch is pinned at both ends: which calls happen, and what they report.
+
+Nothing here calls a model, runs a sandbox, marks anything, or spends
+anything. It parses one file and builds receipts in memory.
+"""
+
+from __future__ import annotations
+
+import ast
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from core.cost_receipts import (
+    REASON_LEDGER_ABSENT,
+    REASON_STAGE_UNSUPPORTED,
+    STATUS_COMPLETE,
+    STATUS_UNAVAILABLE,
+    CostReceipt,
+    summarise_receipts,
+)
+
+STEP2 = Path(__file__).resolve().parents[1] / "step2_run_inference.py"
+FLAG = "hardened_requested"
+
+
+@pytest.fixture(scope="module")
+def step2_tree() -> ast.Module:
+    """``step2_run_inference`` as syntax, not text.
+
+    Parsed rather than grepped so the assertions survive reformatting, moved
+    lines and rewritten comments, and fail only when the *structure* changes —
+    which is the thing being held still.
+    """
+    return ast.parse(STEP2.read_text(encoding="utf-8"))
+
+
+def _calls_to(node: ast.AST, name: str) -> list[ast.Call]:
+    """Every call to *name*, whether plain or reached through an attribute."""
+    calls = []
+    for inner in ast.walk(node):
+        if not isinstance(inner, ast.Call):
+            continue
+        func = inner.func
+        if isinstance(func, ast.Name) and func.id == name:
+            calls.append(inner)
+        elif isinstance(func, ast.Attribute) and func.attr == name:
+            calls.append(inner)
+    return calls
+
+
+def _is_not_flag(test: ast.expr) -> bool:
+    """True for the expression ``not hardened_requested``."""
+    return (
+        isinstance(test, ast.UnaryOp)
+        and isinstance(test.op, ast.Not)
+        and isinstance(test.operand, ast.Name)
+        and test.operand.id == FLAG
+    )
+
+
+def test_a_hardened_run_opens_no_cost_ledger(step2_tree: ast.Module) -> None:
+    """The ledger is opened under ``if not hardened_requested:``, or not at all.
+
+    This is the keystone. Metering starts at ``open_cost_recorder`` — it
+    returns the recorder that then wraps every client — so a hardened run
+    stays unmetered exactly as long as that one call stays behind the guard.
+    Moving it out, or adding a second unguarded call beside it, would wrap the
+    attested path and start writing prices for calls this process never saw.
+
+    Stated as "every call is guarded" rather than "the call on line N is
+    guarded" so that a *new* unguarded call fails this too.
+    """
+    every = {call.lineno for call in _calls_to(step2_tree, "open_cost_recorder")}
+    assert every, "step2 no longer opens a cost ledger anywhere; this guard moved"
+
+    guarded = {
+        call.lineno
+        for node in ast.walk(step2_tree)
+        if isinstance(node, ast.If) and _is_not_flag(node.test)
+        for stmt in node.body
+        for call in _calls_to(stmt, "open_cost_recorder")
+    }
+    assert every == guarded, (
+        f"open_cost_recorder is reached outside `if not {FLAG}:` at lines "
+        f"{sorted(every - guarded)}; a hardened run would be metered"
+    )
+
+
+def test_hardened_covers_the_agentic_mode_and_the_sandbox_flag(
+    step2_tree: ast.Module,
+) -> None:
+    """Both unmetered modes set the flag — not just the obvious one.
+
+    ``agentic_sandbox`` is a mode; the hardened substrate is an option *on*
+    the ordinary sandbox mode. Reading the flag quickly suggests the first
+    covers it. It does not, and dropping the second would leave hardened
+    sandbox runs metered while the code still looked deliberate.
+    """
+    assigned = [
+        node
+        for node in ast.walk(step2_tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == FLAG
+            for target in node.targets
+        )
+    ]
+    assert len(assigned) == 1, f"expected exactly one place to define {FLAG}"
+
+    literals = {
+        inner.value
+        for inner in ast.walk(assigned[0].value)
+        if isinstance(inner, ast.Constant) and isinstance(inner.value, str)
+    }
+    assert {"agentic_sandbox", "sandbox", "hardened_substrate"} <= literals, (
+        f"{FLAG} no longer names both unmetered modes; it reads {sorted(literals)}"
+    )
+
+
+def test_an_unmetered_hardened_task_blames_the_stage_not_a_lost_ledger(
+    step2_tree: ast.Module,
+) -> None:
+    """The two ways to have no ledger are told apart in the receipt.
+
+    A hardened run has no ledger *by design*; an ordinary run without one has
+    lost something. Both produce ``unavailable``, and the reason code is the
+    only thing that distinguishes "this mode is not priceable" from "the
+    ledger did not open, go and find out why". Collapsing them to one reason
+    would turn a real fault into something that looks intended.
+    """
+    selections = [
+        call.keywords[0].value
+        for call in _calls_to(step2_tree, "unavailable")
+        if len(call.keywords) == 1
+        and call.keywords[0].arg == "reasons"
+        and isinstance(call.keywords[0].value, ast.IfExp)
+    ]
+    assert len(selections) == 1, (
+        "expected one receipt that picks its reason from " + FLAG
+    )
+
+    chosen = selections[0]
+    assert isinstance(chosen.test, ast.Name) and chosen.test.id == FLAG
+
+    def named(branch: ast.expr) -> set[str]:
+        return {
+            inner.id for inner in ast.walk(branch) if isinstance(inner, ast.Name)
+        }
+
+    assert named(chosen.body) == {"REASON_STAGE_UNSUPPORTED"}
+    assert named(chosen.orelse) == {"REASON_LEDGER_ABSENT"}
+
+
+def test_a_hardened_task_reports_unavailable_rather_than_zero() -> None:
+    """What that branch hands back, run rather than read.
+
+    ``estimated_cost_usd`` is the only field that claims to be a total, and it
+    stays ``None`` here. ``known_cost_usd`` is ``0.0``, which is honest — zero
+    was confirmed, because nothing was — and is not a total, because the
+    status says it is not one.
+    """
+    receipt = CostReceipt.unavailable(reasons=(REASON_STAGE_UNSUPPORTED,))
+    payload = receipt.as_dict()
+
+    assert payload["status"] == STATUS_UNAVAILABLE
+    assert payload["estimated_cost_usd"] is None
+    assert payload["missing_reasons"] == [REASON_STAGE_UNSUPPORTED]
+    assert payload["model_calls"] == 0
+    assert payload["components"] == []
+
+
+def test_an_ordinary_run_without_a_ledger_says_something_else() -> None:
+    """The other side of the same branch, so the two cannot converge.
+
+    If a refactor ever made both paths produce the same reason, the assertion
+    above would still pass on its own. This one fails.
+    """
+    assert CostReceipt.unavailable().missing_reasons == (REASON_LEDGER_ABSENT,)
+    assert (
+        CostReceipt.unavailable(reasons=(REASON_STAGE_UNSUPPORTED,)).missing_reasons
+        != CostReceipt.unavailable().missing_reasons
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [{}, "not a mapping at all", {"schema_version": "1.3", "known_cost_usd": 9.0}],
+    ids=["empty", "not-a-mapping", "superseded-schema"],
+)
+def test_every_way_of_arriving_at_unavailable_carries_a_reason(payload) -> None:
+    """``unavailable`` and nothing else is not a state this produces.
+
+    A reader shown "unavailable" with no reason cannot act on it, and one that
+    rejects reason-less receipts drops the row — so the run loses a task from
+    its report rather than showing it as unpriced.
+
+    The paths that reach ``unavailable`` without anyone choosing a reason are
+    the fail-closed ones: reading back a row that is missing, malformed, or
+    written to a superseded schema. A receipt from an older build carrying a
+    real amount is refused rather than trusted, since the fields behind that
+    number have since changed meaning.
+
+    (``CostReceipt.unavailable`` will pass an empty tuple through if handed
+    one explicitly. No caller does — every site takes the default or names its
+    own reason — so that is a latent trap rather than a defect, and left
+    alone here rather than fixed on a branch scoped to a test gap.)
+    """
+    receipt = CostReceipt.from_dict(payload)
+
+    assert receipt.status == STATUS_UNAVAILABLE
+    assert receipt.missing_reasons == (REASON_LEDGER_ABSENT,)
+    assert receipt.as_dict()["estimated_cost_usd"] is None
+    assert summarise_receipts([receipt]).missing_reasons == (REASON_LEDGER_ABSENT,)
+
+
+def test_a_whole_hardened_run_never_summarises_to_zero_dollars() -> None:
+    """Every task unpriced keeps the run unpriced.
+
+    A summary is where the misreading would do damage: one number, on a
+    report, next to runs that do have totals. It stays ``unavailable`` and
+    keeps the reason, so the run reads as unmeasured rather than as free.
+    """
+    receipts = [CostReceipt.unavailable(reasons=(REASON_STAGE_UNSUPPORTED,))] * 3
+    summary = summarise_receipts(receipts).as_dict()
+
+    assert summary["status"] == STATUS_UNAVAILABLE
+    assert summary["estimated_cost_usd"] is None
+    assert summary["missing_reasons"] == [REASON_STAGE_UNSUPPORTED]
+
+
+def test_one_unmetered_task_stops_the_run_claiming_a_total() -> None:
+    """A mixed run is a floor, never a total.
+
+    Only some pipelines are hardened, so a run can hold priced tasks beside
+    unpriceable ones. The priced amount is still worth reporting — but as
+    ``partial``, where it reads as "at least this much". Were it to summarise
+    ``complete``, the report would state a total that is missing every
+    hardened task's spend and give no sign of it.
+    """
+    priced = CostReceipt(
+        status=STATUS_COMPLETE,
+        known_cost_usd=Decimal("1.25"),
+        model_cost_usd=Decimal("1.25"),
+        model_calls=1,
+    )
+    summary = summarise_receipts(
+        [priced, CostReceipt.unavailable(reasons=(REASON_STAGE_UNSUPPORTED,))]
+    ).as_dict()
+
+    assert summary["status"] == "partial"
+    assert summary["estimated_cost_usd"] is None
+    assert summary["known_cost_usd"] == pytest.approx(1.25)
+    assert REASON_STAGE_UNSUPPORTED in summary["missing_reasons"]


### PR DESCRIPTION
#257을 병합하면서 **회귀 테스트 없이 남겨 둔 분기 하나**를 닫는다. 카드에도 "남아 있는 구멍"으로 적어 뒀던 그 항목이다.

## 무엇이 비어 있었나

`agentic_sandbox`, 그리고 `hardened_substrate`를 켠 `sandbox` — 이 두 모드는 증명된 substrate 뒤에서 모델을 돌린다. 이 프로세스가 클라이언트를 감싸지 못하므로 정직하게 적을 숫자가 없다. 그래서 `step2_run_inference`는 **원장을 아예 열지 않고** 영수증을 `unavailable`(`stage_unsupported`)로 둔다.

정책은 세 줄인데, 그 세 줄을 붙잡는 게 아무것도 없었다.

## 왜 위험한가 — 양방향이고, 둘 다 조용하다

**증명된 경로를 계측하면.** 플래그를 좁히거나 `open_cost_recorder`를 가드 밖으로 옮기면, **완결된 것처럼 보이지만 실제로는 아닌** 영수증이 나온다. 이 프로세스가 본 호출은 실제로 청구된 호출이 아니기 때문이다. 청구액을 적게 적으면서 완결된 모습으로 나타나는 것 — 비용 기록이 취할 수 있는 최악의 형태고, 네 가지 상태가 존재하는 이유가 바로 이걸 막기 위해서다.

**"기록 없음"이 "공짜"로 읽히면.** 총액에서 `unavailable`과 `$0.00`은 똑같이 생겼다. 그런데 정반대다. 하나는 지식의 부재이고 하나는 측정값이다. 강화 실행이 0원으로 합산되면 실제 지출이 보고서에서 조용히 빠진다.

그리고 플래그는 **모드 두 개**를 덮는다. `agentic_sandbox` 하나로 좁히면 hardened sandbox는 계측되는데 코드는 여전히 의도적으로 보인다.

## 왜 일부는 실행이 아니라 소스를 읽는가

정책이 `step2_run_inference`의 `main()` 안에 있다. 인자 파싱·워크스페이스 준비·데이터셋 로드·클라이언트 생성을 다 지나야 그 분기에 닿는다. 이 스위트에는 hardened end-to-end 하네스가 **없다** — `hardened=True`는 파라미터로 정의만 되어 있고 실제 경로가 없으며, 만들려면 서명 승인 게이트가 필요하고 그건 실제 실행을 뜻한다.

그래서 절반은 **모듈의 구문 트리에 직접 묻는다.** 하네스가 물었을 세 가지를 AST로 묻는다(정규식이 아니라 AST라서 재포맷·줄 이동·주석 수정에는 안 깨지고 *구조*가 바뀔 때만 깨진다). 나머지 절반은 그 분기가 만들어내는 **영수증 의미를 실제로 만들어** 확인한다. 양쪽 끝이 다 고정된다 — 어떤 호출이 일어나는가, 그리고 무엇을 보고하는가.

## 테스트가 진짜 잡는지 확인했다

통과하는 테스트는 증거가 아니다. 그래서 구현을 **세 가지로 망가뜨려** 봤다.

| 변형 | 결과 |
|---|---|
| `open_cost_recorder`를 가드 밖으로 옮김 | **잡힘** |
| 플래그를 `agentic_sandbox`로만 좁힘 | **잡힘** |
| 두 사유 코드를 하나로 합침 | **잡힘** |

세 번 다 원본으로 복구했고 워킹트리는 깨끗하다.

## 구현은 안 고쳤다

**버그가 확인되지 않았다.** 읽고 돌려서 확인한 결과 분기는 정확하게 동작한다. 플래그는 두 모드를 다 덮고, 원장은 안 열리고, 영수증은 `unavailable`/`stage_unsupported`이고, 요약은 `$0`으로 무너지지 않는다. 섞인 실행은 `partial`로 내려가면서 확인된 금액을 하한으로 유지한다. **구멍은 순전히 테스트 커버리지였다.**

작업 중에 인접한 사실 하나를 관찰해서 테스트 docstring에 적어 뒀다. `CostReceipt.unavailable`은 빈 튜플을 명시적으로 넘기면 그대로 통과시킨다. 다만 **그렇게 부르는 호출자가 없다** — 모든 사이트가 기본값을 쓰거나 자기 사유를 지정한다. 잠재적 함정이지 결함이 아니라서, 테스트 구멍을 닫는 브랜치에서 프로덕션 코드를 건드리지 않고 기록만 남겼다.

## 범위

| | |
|---|---|
| 변경 파일 | **1개** (테스트 신규 1개) |
| 프로덕션 코드 변경 | **없음** |
| 세션 B 소유 파일 | **0건** — `src/**`, `scripts/**` 전부 미접촉 |
| 로컬 전체 스위트 | **5536 passed, 9 skipped, 45 deselected** (exit 0) |
| mypy | clean |

모델 호출, Azure 로그인, 채점·재채점, 샌드박스 실행 — **하나도 없다.** 파일 하나를 파싱하고 메모리에서 영수증을 만든다.
