### PR TITLE
fix(analysis): 분석 도구에 185과제 코퍼스와 채점기 자신의 필수항목 규칙을 가르친다

### DIFF
--- a/batch-runner/scripts/analyze_gold_ceiling.py
+++ b/batch-runner/scripts/analyze_gold_ceiling.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Read a gold-ceiling grade payload and answer the questions stage 1 asks.
+"""Read a gold-ceiling grade payload and answer the questions the specs ask.
 
 Why this exists
 ---------------
@@ -10,7 +10,14 @@ the actual bill. Every one of those is already in the grade payload. Copying
 them into a report by hand is where a report stops matching its run -- so this
 reads them out, and the report quotes this.
 
-Two of the six need work the payload does not do for you:
+``304-full-gold-corpus.md`` asks the same six of a corpus six times the size,
+and three more that only make sense once there is a bigger corpus to ask them
+of: the mean per occupation, the mean of the same thirty tasks stage 1 graded
+so the two runs can be compared like for like, and the mean with the five
+known-limit tasks held out. Those three are the ``by_occupation`` and
+``subsets`` blocks.
+
+Two of the original six need work the payload does not do for you:
 
 * **Image and audio call counts separately.** ``summary.cost`` carries one
   ``total_perception_calls``. Which of those looked at a picture and which
@@ -21,12 +28,15 @@ Two of the six need work the payload does not do for you:
   evidence the judge recorded, sorted so the largest losses come first, which
   is the input a person needs to classify them.
 
-It also refuses a payload that is not stage 1's corpus, fully graded. A number
-read out of the wrong file is worse than no number, and the four things it
-checks -- task count, ordered-id fingerprint, graded count and run status --
-are the ones that differ when somebody points this at a shard or at a
-different corpus. A stage 2 repeat passes them, and should: it is the same
-thirty tasks graded again, which is exactly what stage 2 needs to read.
+It also refuses a payload that is not one of the corpora pinned below, fully
+graded. A number read out of the wrong file is worse than no number, and the
+things it checks -- the ordered-id fingerprint, the task count, the graded
+count and the run status -- are the ones that differ when somebody points this
+at a single shard or at a corpus nobody pinned. The fingerprint decides *which*
+corpus a payload is, so stage 1's thirty and stage 3's hundred and eighty-five
+are both read without a flag, and neither can be mistaken for the other. A
+stage 2 repeat passes too, and should: it is the same thirty tasks graded
+again, which is exactly what stage 2 needs to read.
 
 Usage
 -----
@@ -42,9 +52,10 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import textwrap
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 # The three numbers stage 1 is accepted or rejected on, from
 # `tasks/rebuilding_grading_task/300-gold-ceiling.md` lines 17-19 and 24-26.
@@ -66,30 +77,81 @@ JUDGE_ERROR_RATE_CEILING = 0.02
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.grader import MAGNITUDE_THRESHOLD as REQUIRED_ITEM_MIN_ABS_SCORE  # noqa: E402
+from step8_grade import _ordered_task_ids_sha256  # noqa: E402
 
-# What the specification pinned. A payload disagreeing with either is some
-# other run, and reading stage 1's numbers out of it would be a mistake no
+# What the specification pinned. A payload disagreeing with a known corpus is
+# some other run, and reading a stage's numbers out of it would be a mistake no
 # reader could detect afterwards.
-EXPECTED_TASK_COUNT = 30
-
-# The 30 pinned task ids, fingerprinted the way the grader fingerprints them.
 #
-# This is compared against `expected_ordered_task_ids_sha256` in the payload,
-# and that field is written by `step8_grade._ordered_task_ids_sha256`, which
-# hashes `json.dumps(ids, ensure_ascii=False, separators=(",", ":"))` -- a
-# compact JSON array. So this constant has to be the compact-JSON digest of
-# the same ids in the same order; any other encoding of the identical list
+# The digest is compared against `expected_ordered_task_ids_sha256` in the
+# payload, and that field is written by `step8_grade._ordered_task_ids_sha256`,
+# which hashes `json.dumps(ids, ensure_ascii=False, separators=(",", ":"))` --
+# a compact JSON array. So each digest here has to be the compact-JSON digest
+# of the same ids in the same order; any other encoding of the identical list
 # produces a different digest and refuses the very run it was written for.
 #
 # That is not hypothetical. An earlier pass pinned the newline-joined digest
-# of these exact ids, `09ce9245...`, and it refused stage 1's own run. Both
+# of stage 1's exact ids, `09ce9245...`, and it refused stage 1's own run. Both
 # digests cover the same thirty ids in the same order -- only the separator
 # differs -- so the mismatch says nothing whatsoever about the corpus, which
-# is what made it slow to read. `test_the_pinned_corpus_matches_the_grading_
-# config` now recomputes this through the grader's own function rather than
-# restating the formula, so the two can no longer drift apart in silence.
-EXPECTED_ORDERED_TASK_IDS_SHA256 = (
-    "82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b"
+# is what made it slow to read. `test_the_pinned_corpora_match_the_grading_
+# configs` now recomputes both through the grader's own function rather than
+# restating the formula, so they can no longer drift apart in silence.
+
+
+class PinnedCorpus(NamedTuple):
+    """A corpus this tool is allowed to report numbers for."""
+
+    key: str
+    label: str
+    config_name: str
+    task_count: int
+    ordered_task_ids_sha256: str
+
+
+STAGE_ONE_CORPUS = PinnedCorpus(
+    key="stage1-30",
+    label="stage 1 -- the 30-task sample",
+    config_name="gold_ceiling_30_v2_sol_max",
+    task_count=30,
+    ordered_task_ids_sha256=(
+        "82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b"
+    ),
+)
+
+STAGE_THREE_CORPUS = PinnedCorpus(
+    key="stage3-185",
+    label="stage 3 -- the whole 185-task gold population",
+    config_name="gold_ceiling_185_v2_sol_max",
+    task_count=185,
+    ordered_task_ids_sha256=(
+        "cef3a5b9f1305f19437d6ee337936a065965f979325b95a41d1001747e6bfa18"
+    ),
+)
+
+#: Every corpus this tool will report on. Stage 3 is listed here rather than
+#: read through `--allow-any-run` on purpose: that flag's own help says it is
+#: never for a number a report will quote, so reaching for it to produce the
+#: stage 3 report would have made the report's provenance exactly as weak as
+#: the flag warns. A corpus a report quotes belongs in this tuple, where the
+#: identity check still applies to it.
+PINNED_CORPORA: tuple[PinnedCorpus, ...] = (STAGE_ONE_CORPUS, STAGE_THREE_CORPUS)
+
+# Kept as module-level names because the payload identity check, the report's
+# generated blocks and the tests all grew up around stage 1 being *the* corpus.
+EXPECTED_TASK_COUNT = STAGE_ONE_CORPUS.task_count
+EXPECTED_ORDERED_TASK_IDS_SHA256 = STAGE_ONE_CORPUS.ordered_task_ids_sha256
+
+#: The five tasks `304-full-gold-corpus.md` declared as known input limits
+#: *before* the paid run, so their effect on the mean is separated rather than
+#: argued about afterwards. Four of them arrive with stage 3's widening; only
+#: `38889c3b` was inside stage 1's sample.
+KNOWN_LIMIT_TASK_IDS: tuple[str, ...] = (
+    "38889c3b",
+    "a73fbc98",
+    "e222075d",
+    "75401f7c",
+    "7de33b48",
 )
 
 # What a finished run is allowed to call itself. Both spellings mean the same
@@ -106,7 +168,27 @@ COMPLETE_RUN_STATUSES = frozenset({"final", "diagnostic"})
 
 
 class NotTheRunThatWasPinned(SystemExit):
-    """The payload is readable but is not stage 1's run."""
+    """The payload is readable but is not one of the pinned runs."""
+
+
+def identify_corpus(payload: dict[str, Any]) -> PinnedCorpus | None:
+    """Which pinned corpus this payload claims to be, or ``None``.
+
+    Matched on the ordered-id digest rather than on the task count, because
+    the digest names the exact ids in the exact order while the count is
+    satisfied by any corpus of the same size. Stage 3 dropping one task and
+    gaining another would keep 185 and change the digest, and it is the digest
+    that has to refuse it.
+
+    The count is then checked *against the matched corpus* rather than used to
+    find it, so a payload carrying stage 3's digest and stage 1's count is a
+    contradiction this reports instead of resolving.
+    """
+    digest = payload.get("expected_ordered_task_ids_sha256")
+    for corpus in PINNED_CORPORA:
+        if digest == corpus.ordered_task_ids_sha256:
+            return corpus
+    return None
 
 
 def _identity_problems(payload: dict[str, Any]) -> list[str]:
@@ -120,24 +202,33 @@ def _identity_problems(payload: dict[str, Any]) -> list[str]:
             "only its own slice while declaring the whole corpus"
         )
 
-    count = payload.get("expected_task_count")
-    if count != EXPECTED_TASK_COUNT:
-        problems.append(
-            f"expected_task_count is {count!r}, not {EXPECTED_TASK_COUNT}"
+    corpus = identify_corpus(payload)
+    if corpus is None:
+        known = ", ".join(
+            f"{item.key} ({item.task_count} tasks, "
+            f"{item.ordered_task_ids_sha256[:12]}...)"
+            for item in PINNED_CORPORA
         )
-
-    ordered = payload.get("expected_ordered_task_ids_sha256")
-    if ordered != EXPECTED_ORDERED_TASK_IDS_SHA256:
         problems.append(
             "expected_ordered_task_ids_sha256 is "
-            f"{ordered!r}, not the pinned {EXPECTED_ORDERED_TASK_IDS_SHA256}"
+            f"{payload.get('expected_ordered_task_ids_sha256')!r}, which is "
+            f"not a pinned corpus -- known: {known}"
+        )
+        return problems
+
+    count = payload.get("expected_task_count")
+    if count != corpus.task_count:
+        problems.append(
+            f"expected_task_count is {count!r}, but the ordered-id digest is "
+            f"{corpus.key}'s, which pins {corpus.task_count}"
         )
 
     graded = (payload.get("summary") or {}).get("graded_tasks")
-    if graded != EXPECTED_TASK_COUNT:
+    if graded != corpus.task_count:
         problems.append(
-            f"summary.graded_tasks is {graded!r}, so {EXPECTED_TASK_COUNT} "
-            "tasks were pinned but a different number was graded"
+            f"summary.graded_tasks is {graded!r}, so {corpus.task_count} "
+            f"tasks were pinned by {corpus.key} but a different number was "
+            "graded"
         )
 
     return problems
@@ -271,20 +362,51 @@ def per_task(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
+def _counts_toward_required_rate(item: dict[str, Any]) -> bool:
+    """The run's own test for an item the second threshold counts.
+
+    Both halves are `step8_grade.py`'s, at the line that fills
+    ``critical_item_pass_rate``::
+
+        if not score_excluded and _is_critical_item(item.get("max_score")):
+
+    An excluded item is one the grader decided not to score at all, so counting
+    it would put an item in the denominator that no answer could have moved.
+    """
+    if item.get("score_excluded"):
+        return False
+    maximum = item.get("max_score")
+    return maximum is not None and abs(maximum) >= REQUIRED_ITEM_MIN_ABS_SCORE
+
+
 def required_items(payload: dict[str, Any]) -> dict[str, Any]:
     """What the second threshold is actually counting.
 
-    `core/grader.py` calls an item required when ``|max_score| >= 4`` and marks
-    it passed only on a ``pass`` verdict, so partial credit counts against the
-    rate exactly as hard as a flat failure does. Whether 0.95 is a reachable
-    bar therefore depends entirely on which items clear that width and how
-    subjective they are -- neither of which the rate itself shows.
+    An item is required when ``|max_score| >= 4`` and the grader did not
+    exclude it from scoring, and it passes when ``model_did_right`` is true --
+    **not** when the verdict is ``pass``. That distinction is the whole reason
+    this function was rewritten, and `step8_grade.py` states it at the point of
+    use: the legacy spelling was *"both wrong-threshold and wrong-sign"*, and
+    the sign is what bites here.
 
-    So this reports the denominator: how many items, split by verdict, and the
-    criteria that recur across tasks. A criterion appearing in most of the
-    thirty rubrics is a criterion whose wording sets the threshold, and a
-    reader deciding whether a missed gate is a grader defect or a metric
-    artefact needs to see it rather than take the claim on trust.
+    A penalty item carries a negative maximum -- "reviews articles behind a
+    paywall", "uses footage with identifiable faces". Its verdict answers *did
+    the deliverable do this thing*, so a verdict of ``pass`` on a penalty means
+    the penalty **fired** and the answer was marked down. Reading ``pass`` as
+    success therefore inverts every penalty item: the answers that avoided the
+    trap are counted as failures and the ones that fell in are counted as
+    successes.
+
+    Stage 1's thirty tasks contained no negative required items at all, so the
+    two spellings returned the same 0.5714 and the defect was invisible. The
+    185-task corpus contains 54 of them across 8 tasks -- 15% of the
+    denominator -- and 38 sit in one task. So this reports both rates and the
+    items they disagree on, rather than quietly swapping one number for the
+    other in a report whose earlier edition quoted the old one.
+
+    ``rate`` is the run's definition, because it is the number the gate is
+    judged on and a report must not print a second opinion beside it under the
+    same name.
     """
     rows: list[dict[str, Any]] = []
     for task in payload.get("tasks") or []:
@@ -299,16 +421,43 @@ def required_items(payload: dict[str, Any]) -> dict[str, Any]:
                     "max_score": maximum,
                     "awarded_score": item.get("awarded_score"),
                     "verdict": item.get("verdict"),
+                    "score_excluded": bool(item.get("score_excluded")),
+                    "model_did_right": item.get("model_did_right"),
+                    "counted": _counts_toward_required_rate(item),
                 }
             )
 
-    by_verdict = Counter(str(row["verdict"]) for row in rows)
-    by_criterion = Counter(row["criterion"] for row in rows)
-    passed = by_verdict.get("pass", 0)
+    counted = [row for row in rows if row["counted"]]
+    passed = sum(1 for row in counted if bool(row["model_did_right"]))
+
+    # The retired definition, over the denominator it used: no exclusion filter.
+    legacy_passed = sum(1 for row in rows if row["verdict"] == "pass")
+
+    disagreements = [
+        row
+        for row in counted
+        if bool(row["model_did_right"]) != (row["verdict"] == "pass")
+    ]
+
+    # An item with no `model_did_right` cannot be scored by the run's rule, and
+    # defaulting it to False the way the grader does would read a payload too
+    # old to carry the field as a total failure. Counted and reported instead.
+    unscorable = [row for row in counted if row["model_did_right"] is None]
+
+    penalties = [row for row in counted if row["max_score"] < 0]
+
+    by_verdict = Counter(str(row["verdict"]) for row in counted)
+    by_criterion = Counter(row["criterion"] for row in counted)
+
+    payload_rate = ((payload.get("summary") or {}).get("wow") or {}).get(
+        "critical_item_pass_rate"
+    )
+    rate = None if not counted else round(passed / len(counted), 4)
+
     return {
-        "total": len(rows),
+        "total": len(counted),
         "passed": passed,
-        "rate": None if not rows else round(passed / len(rows), 4),
+        "rate": rate,
         "by_verdict": dict(by_verdict.most_common()),
         "recurring_criteria": [
             {
@@ -316,14 +465,238 @@ def required_items(payload: dict[str, Any]) -> dict[str, Any]:
                 "tasks": count,
                 "passed": sum(
                     1
-                    for row in rows
-                    if row["criterion"] == criterion and row["verdict"] == "pass"
+                    for row in counted
+                    if row["criterion"] == criterion
+                    and bool(row["model_did_right"])
                 ),
             }
             for criterion, count in by_criterion.most_common()
             if count > 1
         ],
+        "score_excluded": len(rows) - len(counted),
+        "unscorable": len(unscorable),
+        "penalty_items": len(penalties),
+        "penalty_items_fired": sum(
+            1 for row in penalties if not bool(row["model_did_right"])
+        ),
+        "legacy_verdict_pass": {
+            "total": len(rows),
+            "passed": legacy_passed,
+            "rate": None if not rows else round(legacy_passed / len(rows), 4),
+            "disagreements": len(disagreements),
+            "disagreeing_items": sorted(
+                (
+                    {
+                        "task_id": row["task_id"],
+                        "criterion": row["criterion"],
+                        "max_score": row["max_score"],
+                        "verdict": row["verdict"],
+                        "model_did_right": row["model_did_right"],
+                    }
+                    for row in disagreements
+                ),
+                key=lambda row: (str(row["task_id"]), str(row["criterion"])),
+            ),
+        },
+        # The rate the gate is judged on is written by the grader, not by this
+        # tool. If the two disagree, one of them is wrong and the report must
+        # not pick a side silently.
+        "payload_rate": payload_rate,
+        "agrees_with_payload": (
+            payload_rate is not None
+            and rate is not None
+            and abs(rate - float(payload_rate)) <= 0.0001
+        ),
     }
+
+
+def _aggregate(tasks: list[dict[str, Any]]) -> dict[str, Any]:
+    """Score a group of tasks the way the run scores the whole corpus.
+
+    The two headline numbers are aggregated differently and a recomputation
+    that picks one style for both is wrong twice:
+
+    * ``avg_pct`` is a **macro** mean -- the mean of each task's ``pct``, over
+      tasks that did not error. Every task weighs the same regardless of how
+      many rubric items it carries. `step8_grade.py` computes it as
+      ``sum(pcts) / len(pcts)`` over ``[t for t in tasks if not t["error"]]``.
+    * ``critical_item_pass_rate`` is a **micro** rate -- required items passed
+      over required items counted, pooled across tasks, so a task with forty
+      required items pulls forty times as hard as a task with one.
+
+    ``avg_pct_raw`` is the same macro mean over ``pct_raw``, which the grader
+    writes before clamping ``pct`` into [0, 100]. The two differ only where
+    penalties drove a task below zero, and there the clamped mean cannot tell a
+    fired penalty from an answer that simply scored nothing. One task in the
+    185 carries -380 points of penalties against a 50-point maximum, so this is
+    a real distinction on this corpus rather than a defensive one.
+    """
+    scored = [task for task in tasks if not task.get("error")]
+
+    pcts = [
+        float(task["pct"]) for task in scored if task.get("pct") is not None
+    ]
+    raws = [
+        float(task["pct_raw"])
+        for task in scored
+        if task.get("pct_raw") is not None
+    ]
+
+    counted = [
+        item
+        for task in tasks
+        for item in (task.get("items") or [])
+        if _counts_toward_required_rate(item)
+    ]
+    passed = sum(1 for item in counted if bool(item.get("model_did_right")))
+
+    clamped = [
+        str(task.get("task_id"))
+        for task in scored
+        if task.get("pct") is not None
+        and task.get("pct_raw") is not None
+        and abs(float(task["pct_raw"]) - float(task["pct"])) > 1e-9
+    ]
+
+    return {
+        "task_count": len(tasks),
+        "graded_tasks": len(scored),
+        "error_tasks": len(tasks) - len(scored),
+        "avg_pct": round(sum(pcts) / len(pcts), 2) if pcts else None,
+        "avg_pct_raw": round(sum(raws) / len(raws), 2) if raws else None,
+        "required_items": len(counted),
+        "required_passed": passed,
+        "critical_item_pass_rate": (
+            round(passed / len(counted), 4) if counted else None
+        ),
+        "tasks_clamped_at_zero": clamped,
+    }
+
+
+def by_occupation(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Per-occupation means, the breakdown `304` asks for and the payload lacks.
+
+    The payload carries ``wow.by_sector`` and nothing by occupation, yet
+    occupation is where stage 3's widening actually happened: stage 1 reached 7
+    of 44 occupations against all 9 sectors' worth of 4. A sector average over
+    nine buckets cannot show which of the 37 newly-covered occupations moved
+    the ceiling.
+    """
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for task in payload.get("tasks") or []:
+        groups[str(task.get("occupation") or "unrecorded")].append(task)
+    return {name: _aggregate(tasks) for name, tasks in sorted(groups.items())}
+
+
+def _match_task_ids(
+    payload: dict[str, Any], wanted: tuple[str, ...] | list[str]
+) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    """Resolve id prefixes against the payload, refusing ambiguity.
+
+    The specification names tasks by their first eight characters while the
+    payload carries full UUIDs, so these have to be matched by prefix. A prefix
+    that matches two tasks would silently double-count one and a prefix that
+    matches none would silently shrink the subset, and either would move a mean
+    the report quotes -- so both are returned rather than absorbed.
+    """
+    tasks = payload.get("tasks") or []
+    matched: list[dict[str, Any]] = []
+    missing: list[str] = []
+    ambiguous: list[str] = []
+    for prefix in wanted:
+        hits = [
+            task for task in tasks if str(task.get("task_id")).startswith(prefix)
+        ]
+        if not hits:
+            missing.append(prefix)
+        elif len(hits) > 1:
+            ambiguous.append(prefix)
+        else:
+            matched.append(hits[0])
+    return matched, missing, ambiguous
+
+
+def subset_scores(
+    payload: dict[str, Any],
+    task_ids: tuple[str, ...] | list[str],
+    *,
+    exclude: bool = False,
+) -> dict[str, Any]:
+    """Re-score the corpus over a subset, or over everything but a subset.
+
+    `304-full-gold-corpus.md` promises the mean *with and without* the five
+    declared input limits, so that their share is separated rather than argued
+    about after the fact. Recomputing it needs the run's own two aggregation
+    styles, which is why this goes through `_aggregate` rather than averaging
+    the per-task percentages a second way.
+    """
+    matched, missing, ambiguous = _match_task_ids(payload, task_ids)
+    matched_ids = {id(task) for task in matched}
+
+    if exclude:
+        selected = [
+            task
+            for task in (payload.get("tasks") or [])
+            if id(task) not in matched_ids
+        ]
+    else:
+        selected = matched
+
+    block = _aggregate(selected)
+    block["requested"] = list(task_ids)
+    block["matched"] = [str(task.get("task_id")) for task in matched]
+    block["missing"] = missing
+    block["ambiguous"] = ambiguous
+    block["excluded"] = exclude
+    return block
+
+
+def stage_one_subset(payload: dict[str, Any]) -> dict[str, Any]:
+    """How stage 1's thirty tasks scored inside this run.
+
+    Stage 1's corpus is the first thirty of stage 3's in the same order, and
+    `step9_merge_shards.py` normalises shards back into canonical corpus order
+    before writing, so the first thirty entries of a merged payload *are* those
+    tasks. That is an inference about ordering, though, and a report should not
+    rest a comparison on one -- so it is checked: the thirty ids are hashed
+    with the grader's own function and the digest has to be stage 1's pinned
+    `82d14ac9...`.
+
+    If it is not, ``verified`` is false and the numbers are withheld. A
+    same-30 comparison drawn from the wrong thirty tasks is worse than no
+    comparison, because nothing downstream could tell.
+    """
+    tasks = payload.get("tasks") or []
+    corpus = STAGE_ONE_CORPUS
+
+    if len(tasks) < corpus.task_count:
+        return {
+            "verified": False,
+            "reason": (
+                f"payload holds {len(tasks)} tasks, fewer than the "
+                f"{corpus.task_count} stage 1 pinned"
+            ),
+        }
+
+    first = tasks[: corpus.task_count]
+    digest = _ordered_task_ids_sha256(
+        [str(task.get("task_id")) for task in first]
+    )
+    if digest != corpus.ordered_task_ids_sha256:
+        return {
+            "verified": False,
+            "reason": (
+                f"the first {corpus.task_count} tasks hash to {digest}, not "
+                f"stage 1's {corpus.ordered_task_ids_sha256} -- so they are "
+                "not stage 1's corpus in stage 1's order"
+            ),
+            "ordered_task_ids_sha256": digest,
+        }
+
+    block = _aggregate(first)
+    block["verified"] = True
+    block["ordered_task_ids_sha256"] = digest
+    return block
 
 
 def _tasks_with_errors(payload: dict[str, Any]) -> list[dict[str, Any]]:
@@ -375,9 +748,12 @@ def analyze(payload: dict[str, Any]) -> dict[str, Any]:
 
     shortfalls = items_below_full_marks(payload)
     graded_items = sum(len(task.get("items") or []) for task in payload.get("tasks") or [])
+    corpus = identify_corpus(payload)
 
     return {
         "identity": {
+            "corpus": None if corpus is None else corpus.key,
+            "corpus_label": None if corpus is None else corpus.label,
             "experiment_id": payload.get("experiment_id"),
             "run_status": payload.get("run_status"),
             "graded_at": payload.get("graded_at"),
@@ -407,6 +783,7 @@ def analyze(payload: dict[str, Any]) -> dict[str, Any]:
             "judge_pass_rate": wow.get("judge_pass_rate"),
             "precheck_pass_rate": wow.get("precheck_pass_rate"),
             "by_sector": wow.get("by_sector"),
+            "by_occupation": by_occupation(payload),
             "score_density_histogram": wow.get("score_density_histogram"),
         },
         "usage": {
@@ -439,6 +816,17 @@ def analyze(payload: dict[str, Any]) -> dict[str, Any]:
         },
         "per_task": per_task(payload),
         "required_items": required_items(payload),
+        "subsets": {
+            # `304` asks for the mean with and without the five declared input
+            # limits, and for the same thirty tasks stage 1 measured. All three
+            # go through the run's own aggregation so they can sit in one table
+            # beside the headline number without a footnote about arithmetic.
+            "stage_one_same_thirty": stage_one_subset(payload),
+            "known_limits_only": subset_scores(payload, KNOWN_LIMIT_TASK_IDS),
+            "without_known_limits": subset_scores(
+                payload, KNOWN_LIMIT_TASK_IDS, exclude=True
+            ),
+        },
     }
 
 
@@ -471,10 +859,83 @@ def _wrapped_ids(task_ids: list[str], *, per_line: int = 3, indent: str = " " * 
     ]
 
 
+def _wrapped_prose(
+    text: str,
+    *,
+    indent: str,
+    width: int = 110,
+    first_indent: str | None = None,
+) -> list[str]:
+    """A sentence down the page rather than off the side of it.
+
+    The readable report is checked line by line for width, because a report
+    somebody has to scroll sideways to read is one they stop reading.
+    """
+    return textwrap.wrap(
+        text,
+        width=width,
+        initial_indent=indent if first_indent is None else first_indent,
+        subsequent_indent=indent,
+    ) or [(indent if first_indent is None else first_indent) + text]
+
+
+def _labelled_prose(label: str, text: str | None, *, budget: int) -> list[str]:
+    """A labelled sentence, wrapped under a hanging indent.
+
+    The criterion and the judge's evidence are free text written by other
+    people, so they arrive at any length and with newlines in them. They used
+    to be cut with a bare slice, which both ran off the side of the page and
+    stopped mid-word; this collapses the whitespace, cuts on a word boundary
+    if it must cut at all, and lets the rest wrap underneath the label.
+    """
+    body = " ".join((text or "").split())
+    if not body:
+        return []
+    if len(body) > budget:
+        body = textwrap.shorten(body, width=budget, placeholder=" ...")
+    return _wrapped_prose(
+        body, indent=" " * 17, first_indent=f"      {label:<9}  "
+    )
+
+
+def _render_subset(label: str, block: dict[str, Any]) -> list[str]:
+    """One subset's line, or the reason there isn't one.
+
+    A withheld subset prints why it was withheld. Printing nothing would read
+    the same as a subset that scored nothing. The reason carries two 64-character
+    fingerprints, so it is wrapped rather than run off the side of the page.
+    """
+    if block.get("verified") is False:
+        return [f"  {label}"] + _wrapped_prose(
+            f"withheld — {block.get('reason')}", indent=" " * 6
+        )
+
+    pct = "n/a" if block["avg_pct"] is None else f"{block['avg_pct']}%"
+    out = [
+        f"  {pct:<8} n={block['task_count']:<4d} "
+        f"required {block['required_passed']}/{block['required_items']}"
+        f"  ·  {label}"
+    ]
+
+    if block.get("avg_pct_raw") is not None and block["avg_pct_raw"] != block["avg_pct"]:
+        out.append(
+            f"      before the floor at zero: {block['avg_pct_raw']}% "
+            f"({len(block['tasks_clamped_at_zero'])} task(s) clamped)"
+        )
+    for field, note in (
+        ("missing", "named but not in this payload"),
+        ("ambiguous", "matched more than one task, so left out"),
+    ):
+        if block.get(field):
+            out.append(f"      {note}:")
+            out.extend(_wrapped_ids(block[field]))
+    return out
+
+
 def _render(report: dict[str, Any], *, shortfall_limit: int) -> str:
     lines: list[str] = []
     identity = report["identity"]
-    lines.append("Gold ceiling — stage 1")
+    lines.append(f"Gold ceiling — {identity['corpus_label'] or 'unpinned corpus'}")
     lines.append("=" * 60)
     lines.append(f"  experiment      {identity['experiment_id']}")
     lines.append(f"  graded at       {identity['graded_at']}")
@@ -513,6 +974,36 @@ def _render(report: dict[str, Any], *, shortfall_limit: int) -> str:
         f"  {req['passed']} of {req['total']} passed"
         + ("" if req["rate"] is None else f"  ({req['rate']})")
     )
+    if not req["agrees_with_payload"]:
+        # Recomputed here and written by the grader there. If they part company
+        # the report has two answers to one question, and saying so is the only
+        # honest thing to print.
+        lines.append(
+            f"  !! recount disagrees with the run's own "
+            f"{req['payload_rate']} — do not quote either until it is settled"
+        )
+    if req["score_excluded"]:
+        lines.append(
+            f"  not scored              {req['score_excluded']} item(s) the "
+            "grader excluded, kept out of the denominator"
+        )
+    if req["unscorable"]:
+        lines.append(
+            f"  unscorable              {req['unscorable']} counted item(s) "
+            "carry no model_did_right"
+        )
+    if req["penalty_items"]:
+        lines.append(
+            f"  penalties               {req['penalty_items']} item(s) with a "
+            f"negative maximum, {req['penalty_items_fired']} of them fired"
+        )
+    legacy = req["legacy_verdict_pass"]
+    if legacy["disagreements"]:
+        lines.append(
+            f"  retired 'verdict == pass' spelling would say "
+            f"{legacy['passed']} of {legacy['total']} ({legacy['rate']}), "
+            f"differing on {legacy['disagreements']} item(s)"
+        )
     if req["by_verdict"]:
         verdicts = ", ".join(f"{n} {v}" for v, n in req["by_verdict"].items())
         lines.append(f"  verdicts                {verdicts}")
@@ -539,6 +1030,34 @@ def _render(report: dict[str, Any], *, shortfall_limit: int) -> str:
             f"    {sector:<52} {block.get('avg_pct')}%  "
             f"n={block.get('task_count')}"
         )
+    lines.append("")
+
+    occupations = scores["by_occupation"] or {}
+    if occupations:
+        lines.append(f"By occupation ({len(occupations)})")
+        lines.append("-" * 60)
+        for name, block in sorted(
+            occupations.items(),
+            key=lambda pair: (
+                pair[1]["avg_pct"] is None,
+                pair[1]["avg_pct"],
+                pair[0],
+            ),
+        ):
+            pct = "  n/a" if block["avg_pct"] is None else f"{block['avg_pct']:6.2f}"
+            lines.append(
+                f"  {pct}%  n={block['task_count']:<3d}  "
+                f"required {block['required_passed']}/{block['required_items']}"
+                f"  ·  {name[:44]}"
+            )
+        lines.append("")
+
+    subsets = report["subsets"]
+    lines.append("Subsets")
+    lines.append("-" * 60)
+    lines.extend(_render_subset("the same thirty stage 1 graded", subsets["stage_one_same_thirty"]))
+    lines.extend(_render_subset("the five declared input limits", subsets["known_limits_only"]))
+    lines.extend(_render_subset("everything but those five", subsets["without_known_limits"]))
     lines.append("")
 
     usage = report["usage"]
@@ -629,11 +1148,15 @@ def _render(report: dict[str, Any], *, shortfall_limit: int) -> str:
             f"[{row['verdict']}, {row['routing_modality']}, "
             f"decided by {row['decided_by']}]  {row['task_id']}"
         )
-        lines.append(f"      criterion  {(row['criterion'] or '')[:150]}")
-        lines.append(f"      evidence   {(row['evidence'] or '')[:220]}")
+        lines.extend(_labelled_prose("criterion", row["criterion"], budget=300))
+        lines.extend(_labelled_prose("evidence", row["evidence"], budget=400))
         if row["selection_status"] != "ok":
-            lines.append(
-                f"      selection  {row['selection_status']}: {row['selection_error']}"
+            lines.extend(
+                _labelled_prose(
+                    "selection",
+                    f"{row['selection_status']}: {row['selection_error']}",
+                    budget=300,
+                )
             )
     remaining = len(short["items"]) - shortfall_limit
     if remaining > 0:
@@ -660,9 +1183,9 @@ def main(argv: list[str] | None = None) -> int:
         "--allow-any-run",
         action="store_true",
         help=(
-            "skip the check that this payload is stage 1's corpus, fully "
-            "graded. Use to look inside a single shard or another corpus, "
-            "never for a number a report will quote"
+            "skip the check that this payload is one of the pinned corpora, "
+            "fully graded. Use to look inside a single shard, never for a "
+            "number a report will quote"
         ),
     )
     args = parser.parse_args(argv)
@@ -673,7 +1196,7 @@ def main(argv: list[str] | None = None) -> int:
         problems = _identity_problems(payload)
         if problems:
             raise NotTheRunThatWasPinned(
-                f"{args.grade_file} is not the run stage 1 pinned:\n  - "
+                f"{args.grade_file} is not a pinned corpus, fully graded:\n  - "
                 + "\n  - ".join(problems)
                 + "\nPass --allow-any-run to read it anyway."
             )

--- a/batch-runner/scripts/analyze_gold_ceiling.py
+++ b/batch-runner/scripts/analyze_gold_ceiling.py
@@ -922,9 +922,18 @@ def _render_subset(label: str, block: dict[str, Any]) -> list[str]:
             f"      before the floor at zero: {block['avg_pct_raw']}% "
             f"({len(block['tasks_clamped_at_zero'])} task(s) clamped)"
         )
+    # An ambiguous prefix is dropped from `matched`, so which side of the
+    # subset it lands on flips with the subset's own sense. Naming it "left
+    # out" of an exclusion would say the opposite of what happened: those
+    # tasks are still counted in the mean printed on this very line.
+    ambiguous_note = (
+        "matched more than one task, so left in rather than taken out"
+        if block.get("excluded")
+        else "matched more than one task, so left out"
+    )
     for field, note in (
         ("missing", "named but not in this payload"),
-        ("ambiguous", "matched more than one task, so left out"),
+        ("ambiguous", ambiguous_note),
     ):
         if block.get(field):
             out.append(f"      {note}:")
@@ -988,10 +997,23 @@ def _render(report: dict[str, Any], *, shortfall_limit: int) -> str:
         f"  {req['passed']} of {req['total']} passed"
         + ("" if req["rate"] is None else f"  ({req['rate']})")
     )
-    if not req["agrees_with_payload"]:
-        # Recomputed here and written by the grader there. If they part company
-        # the report has two answers to one question, and saying so is the only
-        # honest thing to print.
+    # Recomputed here and written by the grader there. If they part company the
+    # report has two answers to one question, and saying so is the only honest
+    # thing to print. But `agrees_with_payload` is false in three different
+    # situations and only one of them is a conflict: a missing rate on either
+    # side leaves nothing to compare, and calling that a disagreement invents
+    # one out of an absent field.
+    if req["payload_rate"] is None:
+        lines.append(
+            "  !! the run states no critical-item rate of its own, so this "
+            "recount is unchecked"
+        )
+    elif req["rate"] is None:
+        lines.append(
+            f"  !! no required items here to recount, so the run's own "
+            f"{req['payload_rate']} is unchecked"
+        )
+    elif not req["agrees_with_payload"]:
         lines.append(
             f"  !! recount disagrees with the run's own "
             f"{req['payload_rate']} — do not quote either until it is settled"

--- a/batch-runner/scripts/analyze_gold_ceiling.py
+++ b/batch-runner/scripts/analyze_gold_ceiling.py
@@ -951,18 +951,32 @@ def _render(report: dict[str, Any], *, shortfall_limit: int) -> str:
     mean = gates["mean_score_pct"]
     crit = gates["critical_item_pass_rate"]
     err = gates["judge_error_rate"]
-    lines.append(
-        f"  mean score              {mean['value']}%   "
-        f"(needs >= {mean['floor']}%)   {_mark(mean['met'])}"
-    )
-    lines.append(
-        f"  required-item pass      {crit['value']}   "
-        f"(needs >= {crit['floor']})   {_mark(crit['met'])}"
-    )
-    lines.append(
-        f"  grader error rate       {err['value']}   "
-        f"(needs < {err['ceiling']})   {_mark(err['met'])}"
-    )
+    # Three gates decide the stage, so the eye should be able to run straight
+    # down the PASS/MISS column. The bars are different lengths -- "needs >=
+    # 90.0%" against "needs < 0.02" -- so the column only lines up if every
+    # field is padded to the widest of the three rather than written by hand.
+    gate_rows = [
+        ("mean score", f"{mean['value']}%", f"needs >= {mean['floor']}%", mean["met"]),
+        (
+            "required-item pass",
+            f"{crit['value']}",
+            f"needs >= {crit['floor']}",
+            crit["met"],
+        ),
+        (
+            "grader error rate",
+            f"{err['value']}",
+            f"needs < {err['ceiling']}",
+            err["met"],
+        ),
+    ]
+    value_width = max(len(value) for _, value, _, _ in gate_rows)
+    bar_width = max(len(bar) for _, _, bar, _ in gate_rows) + 2
+    for label, value, bar, met in gate_rows:
+        lines.append(
+            f"  {label:<24}{value:>{value_width}}   "
+            f"{f'({bar})':<{bar_width}}   {_mark(met)}"
+        )
     lines.append("")
 
     req = report["required_items"]

--- a/batch-runner/tests/test_gold_ceiling_analysis.py
+++ b/batch-runner/tests/test_gold_ceiling_analysis.py
@@ -819,6 +819,30 @@ def test_a_long_occupation_does_not_run_off_the_page():
     assert max(len(line) for line in rendered.splitlines()) < 120
 
 
+def test_the_three_verdicts_line_up_in_one_column():
+    """Three gates decide the stage, so the eye should run down one column.
+
+    The bars are different lengths -- 'needs >= 90.0%' against 'needs < 0.02'
+    -- so writing the three lines by hand left PASS and MISS stepping across
+    the page. This is worth a test because it is the block every reader looks
+    at first, and because the padding is computed from the widest row, so a
+    fourth gate or a re-worded bar would silently break the alignment again.
+    """
+    rendered = analysis._render(
+        analysis.analyze(_payload(tasks=[_task("task-1")])), shortfall_limit=0
+    )
+
+    verdicts = [
+        line for line in rendered.splitlines() if line.endswith(("  PASS", "  MISS"))
+    ]
+    assert len(verdicts) == 3, verdicts
+
+    columns = {line.index("(") for line in verdicts}
+    assert len(columns) == 1, f"the bars start in different columns: {verdicts}"
+    columns = {len(line) for line in verdicts}
+    assert len(columns) == 1, f"the verdicts end in different columns: {verdicts}"
+
+
 def test_a_long_criterion_wraps_instead_of_stopping_mid_word():
     """The criterion and the evidence are other people's prose, at any length.
 

--- a/batch-runner/tests/test_gold_ceiling_analysis.py
+++ b/batch-runner/tests/test_gold_ceiling_analysis.py
@@ -1215,6 +1215,38 @@ def test_a_run_with_no_required_items_does_not_divide_by_zero():
     analysis._render(analysis.analyze(payload), shortfall_limit=0)
 
 
+def test_a_rate_that_cannot_be_compared_is_not_reported_as_a_conflict():
+    """"Nothing to compare" and "the two disagree" are different findings.
+
+    `agrees_with_payload` is false in three situations and only one of them is
+    a conflict. Printing the conflict wording for the other two would put a
+    disagreement in the report that no two numbers ever had -- and in the case
+    where the run states no rate at all, would print the word `None` as if it
+    were the run's answer.
+    """
+    # A rate on the payload, nothing here to recount it against.
+    no_required = analysis._render(
+        analysis.analyze(_payload(tasks=[_task("task-1", items=[_item(max_score=1)])])),
+        shortfall_limit=0,
+    )
+    assert "disagrees" not in no_required
+    assert "no required items here to recount, so the run's own 0.98" in no_required
+
+    # A recount here, no rate on the payload to check it against.
+    no_payload_rate = analysis._render(
+        analysis.analyze(
+            _payload(
+                tasks=[_task("task-1", items=[_item(max_score=5, verdict="pass")])],
+                summary={**_payload()["summary"], "wow": {}},
+            )
+        ),
+        shortfall_limit=0,
+    )
+    assert "disagrees" not in no_payload_rate
+    assert "the run's own None" not in no_payload_rate
+    assert "states no critical-item rate of its own" in no_payload_rate
+
+
 # ── The breakdowns 304 asks for and the payload does not carry ─────────────
 
 
@@ -1358,6 +1390,34 @@ def test_a_prefix_matching_two_tasks_is_refused_rather_than_guessed():
 
     assert block["ambiguous"] == ["aaaaaaaa"]
     assert block["matched"] == []
+
+
+def test_an_ambiguous_prefix_in_an_exclusion_is_not_called_left_out():
+    """Refusing to match puts a task on opposite sides of the two subsets.
+
+    "everything but those five" is built by dropping what `matched` holds, and
+    an ambiguous prefix never reaches `matched` -- so those tasks stay in the
+    mean this line prints. Labelling them "left out" would tell the reader the
+    five were taken out when two of them were not.
+    """
+    payload = _payload(
+        tasks=[
+            _task("aaaaaaaa-1111", pct=20.0),
+            _task("aaaaaaaa-2222", pct=90.0),
+            _task("bbbbbbbb-3333", pct=50.0),
+        ]
+    )
+
+    block = analysis.subset_scores(payload, ["aaaaaaaa"], exclude=True)
+
+    assert block["ambiguous"] == ["aaaaaaaa"]
+    assert block["matched"] == []
+    # Nothing was taken out, so the mean still spans all three.
+    assert block["task_count"] == 3
+
+    rendered = "\n".join(analysis._render_subset("everything but those five", block))
+    assert "left in rather than taken out" in rendered
+    assert "so left out" not in rendered
 
 
 def test_the_known_limit_ids_are_eight_characters_of_a_real_task():

--- a/batch-runner/tests/test_gold_ceiling_analysis.py
+++ b/batch-runner/tests/test_gold_ceiling_analysis.py
@@ -1,17 +1,27 @@
 """Tests for the gold-ceiling analysis tool.
 
-The tool exists so that stage 1's report quotes a run rather than restating
-one. That only holds if three things are true, and each has a test here.
+The tool exists so that a stage's report quotes a run rather than restating
+one. That only holds if four things are true, and each has a test here.
 
 The thresholds have to be the specification's thresholds. They are written as
 constants in the script, so ``test_the_thresholds_are_the_ones_the_spec_states``
 holds them against the specification text: an acceptance bar loosened in the
 code and not in the document fails rather than passes quietly.
 
-The payload has to be the run that was pinned. Stage 2 will produce repeats and
+The payload has to be one of the pinned corpora. Stage 2 produces repeats and
 every run produces shards, all of them structurally identical and all of them
-wrong to read stage 1's number out of. The identity check refuses each, and
-refuses a payload whose graded count does not match the count it declares.
+wrong to read a stage's number out of. The identity check refuses each, refuses
+a payload whose graded count does not match the count it declares, and decides
+*which* corpus a payload is from its ordered-id fingerprint rather than from
+its size -- so stage 1's thirty and stage 3's hundred and eighty-five are both
+read, and neither can be mistaken for the other.
+
+The counting rules have to be the grader's counting rules. The second threshold
+counts ``model_did_right`` over unexcluded items whose score magnitude reaches
+the grader's own ``MAGNITUDE_THRESHOLD``, and for a penalty item that is the
+*opposite* of a ``pass`` verdict. `_model_did_right` restates that rule for the
+fixtures and ``test_the_helper_agrees_with_the_grader`` runs the real
+`core.grader._aggregate` over the same cases to keep the restatement honest.
 
 And the tool has to survive a fresh clone. ``batch-runner/scripts/`` is ignored
 with a per-file allow list, so a script added there works for whoever wrote it
@@ -31,6 +41,23 @@ from scripts import analyze_gold_ceiling as analysis
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SPEC_PATH = REPO_ROOT / "tasks/rebuilding_grading_task/300-gold-ceiling.md"
 TOOL_PATH = "batch-runner/scripts/analyze_gold_ceiling.py"
+
+
+def _model_did_right(verdict, max_score, score_excluded):
+    """The grader's own rule, from `core.grader._aggregate` lines 1352-1361.
+
+    Restated here rather than imported because the grader computes it while
+    building `ItemGrade` objects, not as a function a test can call. Restating
+    it is only safe because `test_the_helper_agrees_with_the_grader` runs the
+    real `_aggregate` over the same four cases and compares.
+    """
+    if verdict == "judge_error":
+        return False
+    if score_excluded:
+        return True
+    if (max_score or 0) < 0:
+        return verdict != "pass"
+    return verdict == "pass"
 
 
 def _item(**overrides):
@@ -53,6 +80,13 @@ def _item(**overrides):
         "score_excluded": False,
     }
     item.update(overrides)
+    # A real payload never carries a verdict without this flag beside it, and
+    # the analysis counts the flag. A fixture that omitted it would let a test
+    # assert a rate no run could produce.
+    if "model_did_right" not in overrides:
+        item["model_did_right"] = _model_did_right(
+            item["verdict"], item["max_score"], item["score_excluded"]
+        )
     return item
 
 
@@ -151,8 +185,8 @@ def test_the_thresholds_are_the_ones_the_spec_states():
     ) in spec
 
 
-def test_the_pinned_corpus_matches_the_grading_config():
-    """The 30 the tool insists on are the 30 the run was told to grade.
+def test_the_pinned_corpora_match_the_grading_configs():
+    """The tasks each corpus insists on are the tasks its run was told to grade.
 
     Recomputed through ``step8_grade``'s own function rather than by restating
     its formula here. The constant is compared against a field that function
@@ -160,23 +194,71 @@ def test_the_pinned_corpus_matches_the_grading_config():
     drift -- and it did: a newline-joined digest of these very ids sat in the
     constant and refused stage 1's own run, saying nothing about the corpus
     while looking exactly like a corpus mismatch.
+
+    Both corpora are checked, because the second was added by hand from a
+    measurement and a mistyped digit would refuse stage 3's own run the same
+    way.
     """
     import yaml
 
     from step8_grade import _ordered_task_ids_sha256
 
-    config = yaml.safe_load(
-        (
-            REPO_ROOT / "batch-runner/grading_configs/gold_ceiling_30_v2_sol_max.yaml"
-        ).read_text(encoding="utf-8")
+    for corpus in analysis.PINNED_CORPORA:
+        config = yaml.safe_load(
+            (
+                REPO_ROOT
+                / f"batch-runner/grading_configs/{corpus.config_name}.yaml"
+            ).read_text(encoding="utf-8")
+        )
+        pinned = config["rerun_identity"]["task_ids"]
+
+        assert len(pinned) == corpus.task_count, corpus.key
+        assert (
+            _ordered_task_ids_sha256(pinned) == corpus.ordered_task_ids_sha256
+        ), corpus.key
+
+
+def test_the_back_compatible_names_still_point_at_stage_one():
+    """Six call sites and the report's own blocks grew up around these."""
+    assert analysis.EXPECTED_TASK_COUNT == analysis.STAGE_ONE_CORPUS.task_count
+    assert (
+        analysis.EXPECTED_ORDERED_TASK_IDS_SHA256
+        == analysis.STAGE_ONE_CORPUS.ordered_task_ids_sha256
     )
-    pinned = config["rerun_identity"]["task_ids"]
-
-    assert len(pinned) == analysis.EXPECTED_TASK_COUNT
-    assert _ordered_task_ids_sha256(pinned) == analysis.EXPECTED_ORDERED_TASK_IDS_SHA256
 
 
-# ── Only stage 1's own run may be read as stage 1's number ─────────────────
+def test_stage_ones_thirty_are_the_first_thirty_of_stage_threes():
+    """The same-30 comparison rests on this, so it is checked rather than assumed.
+
+    `step9_merge_shards.py` normalises shards back into canonical corpus order
+    before writing, so a merged 185-task payload's first thirty entries are
+    stage 1's corpus -- *if* stage 1's config was itself cut from the front of
+    the same canonical order. That is a property of two YAML files, and this is
+    where it is established.
+    """
+    import yaml
+
+    from step8_grade import _ordered_task_ids_sha256
+
+    def ids(corpus):
+        return yaml.safe_load(
+            (
+                REPO_ROOT
+                / f"batch-runner/grading_configs/{corpus.config_name}.yaml"
+            ).read_text(encoding="utf-8")
+        )["rerun_identity"]["task_ids"]
+
+    thirty = ids(analysis.STAGE_ONE_CORPUS)
+    hundred_and_eighty_five = ids(analysis.STAGE_THREE_CORPUS)
+
+    assert hundred_and_eighty_five[:30] == thirty
+    assert (
+        _ordered_task_ids_sha256(hundred_and_eighty_five[:30])
+        == analysis.STAGE_ONE_CORPUS.ordered_task_ids_sha256
+    )
+
+
+# ── Only a pinned corpus's own run may be read as its number ───────────────
 
 
 def test_a_complete_pinned_run_is_accepted():
@@ -220,6 +302,60 @@ def test_a_different_corpus_is_refused():
     )
 
     assert any("ordered_task_ids" in problem for problem in problems)
+    assert any("stage1-30" in problem for problem in problems)
+    assert any("stage3-185" in problem for problem in problems)
+
+
+def test_the_185_task_corpus_is_read_without_a_flag():
+    """Stage 3's run is a first-class corpus, not something read past a warning.
+
+    ``--allow-any-run``'s own help says it is *never* for a number a report
+    will quote, and stage 3's report quotes every number in its payload. So the
+    corpus is pinned rather than waved through.
+    """
+    corpus = analysis.STAGE_THREE_CORPUS
+    payload = _payload(
+        expected_task_count=corpus.task_count,
+        expected_ordered_task_ids_sha256=corpus.ordered_task_ids_sha256,
+    )
+    payload["summary"]["graded_tasks"] = corpus.task_count
+
+    assert analysis._identity_problems(payload) == []
+    assert analysis.identify_corpus(payload) is corpus
+    assert analysis.analyze(payload)["identity"]["corpus"] == "stage3-185"
+
+
+def test_the_digest_decides_which_corpus_it_is_not_the_count():
+    """A 185-task digest carrying stage 1's count is a merge that lost tasks.
+
+    Matching on the count first would let this pass as stage 1 while holding
+    stage 3's fingerprint. Matching on the digest first names it: this is
+    stage 3's corpus, and 155 of it is missing.
+    """
+    corpus = analysis.STAGE_THREE_CORPUS
+    payload = _payload(
+        expected_task_count=30,
+        expected_ordered_task_ids_sha256=corpus.ordered_task_ids_sha256,
+    )
+
+    problems = analysis._identity_problems(payload)
+
+    assert any(
+        "expected_task_count is 30" in problem and "stage3-185" in problem
+        for problem in problems
+    ), problems
+
+
+def test_an_unpinned_payload_read_with_the_flag_says_it_is_unpinned(tmp_path, capsys):
+    """The readable report must not imply a corpus it could not identify."""
+    grade_file = tmp_path / "shard.json"
+    grade_file.write_text(
+        json.dumps(_payload(expected_ordered_task_ids_sha256="c" * 64))
+    )
+
+    analysis.main([str(grade_file), "--allow-any-run", "--shortfall-limit", "0"])
+
+    assert "unpinned corpus" in capsys.readouterr().out
 
 
 def test_a_run_that_graded_fewer_tasks_than_it_declared_is_refused():
@@ -243,7 +379,7 @@ def test_the_command_line_refuses_rather_than_reporting(tmp_path):
     with pytest.raises(SystemExit) as refused:
         analysis.main([str(grade_file)])
 
-    assert "not the run stage 1 pinned" in str(refused.value)
+    assert "is not a pinned corpus, fully graded" in str(refused.value)
 
 
 def test_the_refusal_can_be_overridden_on_purpose(tmp_path, capsys):
@@ -683,22 +819,162 @@ def test_a_long_occupation_does_not_run_off_the_page():
     assert max(len(line) for line in rendered.splitlines()) < 120
 
 
+def test_a_long_criterion_wraps_instead_of_stopping_mid_word():
+    """The criterion and the evidence are other people's prose, at any length.
+
+    The real corpus carries criteria past 300 characters and judge evidence
+    past 400. These used to be cut with a bare slice, which both ran off the
+    side of the page and stopped mid-word -- one real line ended at
+    'for YTD amor'. Wrapping keeps the sentence and keeps the width.
+    """
+    criterion = (
+        "Prepaid Summary totals are linked by formulas to the detailed tabs "
+        "(not hard-coded values), directly referencing the 1250 and 1251 "
+        "sheets for YTD amortization and April ending balances."
+    )
+    evidence = "Row header: " + ", ".join(f"Debit Adds {n}" for n in range(40))
+    task = _task(
+        "task-prose",
+        items=[
+            _item(
+                verdict="fail",
+                max_score=2,
+                awarded_score=0.0,
+                criterion=criterion,
+                evidence=evidence,
+            )
+        ],
+    )
+
+    rendered = analysis._render(
+        analysis.analyze(_payload(tasks=[task])), shortfall_limit=5
+    )
+
+    assert max(len(line) for line in rendered.splitlines()) < 120
+    # The sentence survives the wrap: joining the wrapped lines back up
+    # reproduces it, so nothing was dropped to make it fit.
+    flattened = " ".join(rendered.split())
+    assert criterion in flattened
+    assert "for YTD amortization and April ending balances." in flattened
+
+
+def test_prose_too_long_even_to_wrap_is_cut_on_a_word():
+    """A budget still applies -- but it ends on a word, not inside one."""
+    criterion = " ".join(f"clause{n}" for n in range(200))
+    task = _task(
+        "task-endless",
+        items=[_item(verdict="fail", max_score=2, awarded_score=0.0, criterion=criterion)],
+    )
+
+    rendered = analysis._render(
+        analysis.analyze(_payload(tasks=[task])), shortfall_limit=5
+    )
+
+    assert max(len(line) for line in rendered.splitlines()) < 120
+    assert "..." in rendered
+    # Cut between words, so no half-word is left behind.
+    assert "clause" in rendered
+    for line in rendered.splitlines():
+        for fragment in line.split():
+            if fragment.startswith("clause") and fragment != "clause":
+                assert fragment.removeprefix("clause").isdigit(), fragment
+
+
+def test_newlines_in_evidence_cannot_break_the_width_guarantee():
+    """Judge evidence arrives with newlines in it; they must not pass through.
+
+    A raw newline would split one logical line into two that the width check
+    never sees as over-long, so the collapse happens before the wrap.
+    """
+    evidence = "first line\n" + "x" * 300 + "\nlast line"
+    task = _task(
+        "task-newline",
+        items=[_item(verdict="fail", max_score=2, awarded_score=0.0, evidence=evidence)],
+    )
+
+    rendered = analysis._render(
+        analysis.analyze(_payload(tasks=[task])), shortfall_limit=5
+    )
+
+    assert max(len(line) for line in rendered.splitlines()) < 120
+    assert "first line" in rendered
+
+
 # ── What the second threshold is counting ─────────────────────────────────
+
+
+def test_the_helper_agrees_with_the_grader():
+    """The fixture's rule and the grader's rule, over every branch.
+
+    `_model_did_right` restates `core.grader._aggregate`. A restatement can
+    drift, and drift here would be invisible: every test in this file would
+    still pass, against a payload no run could produce. So the real thing is
+    run over the same cases and compared.
+    """
+    from core.grader import Grader, ItemGrade
+    from core.rubric_loader import TaskRubric
+
+    cases = [
+        ("pass", 5, False),
+        ("partial", 5, False),
+        ("fail", 5, False),
+        ("pass", -4, False),      # the penalty fired
+        ("fail", -4, False),      # the penalty was avoided
+        ("judge_error", 5, False),
+        ("pass", 5, True),
+    ]
+    graded = [
+        ItemGrade(
+            rubric_item_id="i",
+            criterion="c",
+            max_score=max_score,
+            awarded_score=0.0,
+            verdict=verdict,
+            decided_by="judge",
+            required=None,
+            evidence="",
+            score_excluded=excluded,
+        )
+        for verdict, max_score, excluded in cases
+    ]
+    Grader._aggregate(
+        graded,
+        TaskRubric(
+            task_id="t",
+            sector="s",
+            occupation="o",
+            prompt="p",
+            rubric_items=[],
+            rubric_pretty="",
+            reference_files=[],
+            gold_deliverable_files=[],
+        ),
+    )
+
+    for item, (verdict, max_score, excluded) in zip(graded, cases):
+        assert item.model_did_right == _model_did_right(
+            verdict, max_score, excluded
+        ), f"{verdict} at max_score={max_score}, excluded={excluded}"
 
 
 def test_required_items_counts_what_the_grader_counts():
     """Partial credit is a miss, and a negative maximum still qualifies.
 
     Both come from `core.grader`: an item is required iff its score magnitude
-    reaches ``MAGNITUDE_THRESHOLD``, and it is marked done right only on a
-    ``pass`` verdict.
+    reaches ``MAGNITUDE_THRESHOLD``, and it is marked done right on
+    ``model_did_right`` -- which for a penalty item is the *opposite* of a
+    ``pass`` verdict, because a penalty's verdict answers "did the deliverable
+    do this prohibited thing".
+
+    So the ``fail`` on the penalty below is a **pass** for this rate: the
+    deliverable avoided the trap. The retired spelling counted it as a miss.
     """
     task = _task(
         "task-1",
         items=[
             _item(criterion="required, passed", max_score=5, verdict="pass"),
             _item(criterion="required, partial", max_score=5, verdict="partial"),
-            _item(criterion="required penalty", max_score=-4, verdict="fail"),
+            _item(criterion="required penalty avoided", max_score=-4, verdict="fail"),
             _item(criterion="not required", max_score=3, verdict="partial"),
         ],
     )
@@ -706,9 +982,133 @@ def test_required_items_counts_what_the_grader_counts():
     required = analysis.required_items(_payload(tasks=[task]))
 
     assert required["total"] == 3
-    assert required["passed"] == 1
-    assert required["rate"] == pytest.approx(1 / 3, abs=1e-4)
+    assert required["passed"] == 2
+    assert required["rate"] == pytest.approx(2 / 3, abs=1e-4)
     assert required["by_verdict"] == {"pass": 1, "partial": 1, "fail": 1}
+
+    assert required["penalty_items"] == 1
+    assert required["penalty_items_fired"] == 0
+
+    # And the retired spelling is reported beside it rather than erased, so a
+    # report whose earlier edition quoted the old number can see the move.
+    legacy = required["legacy_verdict_pass"]
+    assert legacy["passed"] == 1
+    assert legacy["rate"] == pytest.approx(1 / 3, abs=1e-4)
+    assert legacy["disagreements"] == 1
+    assert legacy["disagreeing_items"][0]["criterion"] == "required penalty avoided"
+
+
+def test_a_fired_penalty_is_a_miss_under_both_counts():
+    """The other half of the inversion, so the fix is not one-directional."""
+    task = _task(
+        "task-1",
+        items=[_item(criterion="penalty fired", max_score=-4, verdict="pass")],
+    )
+
+    required = analysis.required_items(_payload(tasks=[task]))
+
+    assert required["total"] == 1
+    assert required["passed"] == 0
+    assert required["penalty_items_fired"] == 1
+    # The retired spelling called this a success: `verdict == "pass"`.
+    assert required["legacy_verdict_pass"]["passed"] == 1
+    assert required["legacy_verdict_pass"]["disagreements"] == 1
+
+
+def test_an_excluded_item_leaves_the_denominator():
+    """`step8_grade.py:1386` counts only `not score_excluded`.
+
+    An excluded item is one the grader declined to score, so leaving it in the
+    denominator would put an item there that no deliverable could have moved.
+    The count is still reported, because a denominator that silently shrank is
+    how a rate improves without anything improving.
+    """
+    task = _task(
+        "task-1",
+        items=[
+            _item(criterion="scored", max_score=5, verdict="pass"),
+            _item(
+                criterion="the judge errored",
+                max_score=5,
+                verdict="judge_error",
+                score_excluded=True,
+            ),
+        ],
+    )
+
+    required = analysis.required_items(_payload(tasks=[task]))
+
+    assert required["total"] == 1
+    assert required["passed"] == 1
+    assert required["rate"] == 1.0
+    assert required["score_excluded"] == 1
+
+
+def test_an_item_with_no_flag_is_counted_and_named():
+    """A payload too old to carry the field must not read as total failure.
+
+    The grader defaults a missing flag to False, and this matches it so the
+    rate agrees -- but it says how many items it did that to, because a rate
+    computed over absent data should not look like a rate computed over data.
+    """
+    task = _task(
+        "task-1",
+        items=[_item(max_score=5, verdict="pass", model_did_right=None)],
+    )
+
+    required = analysis.required_items(_payload(tasks=[task]))
+
+    assert required["total"] == 1
+    assert required["passed"] == 0
+    assert required["unscorable"] == 1
+
+
+def test_a_recount_that_parts_from_the_run_says_so():
+    """Two answers to one question is a finding, not something to average.
+
+    The rate the gate is judged on is written by the grader. This tool
+    recomputes it from the same items, so agreement is the expected case and
+    disagreement means one of them is wrong.
+    """
+    agreeing = _payload(
+        tasks=[_task("task-1", items=[_item(max_score=5, verdict="pass")])],
+        summary={
+            **_payload()["summary"],
+            "wow": {**_payload()["summary"]["wow"], "critical_item_pass_rate": 1.0},
+        },
+    )
+    assert analysis.required_items(agreeing)["agrees_with_payload"] is True
+
+    # The payload claims 0.98; the items say 1.0.
+    assert analysis.required_items(
+        _payload(tasks=[_task("task-1", items=[_item(max_score=5, verdict="pass")])])
+    )["agrees_with_payload"] is False
+
+
+def test_the_disagreement_reaches_the_readable_report(tmp_path, capsys):
+    """A recount that parted from the run cannot be findable only in --json."""
+    grade_file = tmp_path / "grade.json"
+    grade_file.write_text(
+        json.dumps(
+            _payload(
+                tasks=[
+                    _task(
+                        "task-1",
+                        items=[_item(max_score=5, verdict="pass")],
+                        pct=100.0,
+                        total_awarded=5.0,
+                        total_max=5,
+                    )
+                ]
+            )
+        )
+    )
+
+    analysis.main([str(grade_file), "--shortfall-limit", "0"])
+    printed = capsys.readouterr().out
+
+    assert "recount disagrees with the run's own 0.98" in printed
+    assert max(len(line) for line in printed.splitlines()) < 120
 
 
 def test_the_threshold_is_the_graders_own():
@@ -740,6 +1140,9 @@ def test_a_criterion_repeated_across_tasks_is_surfaced():
 
     required = analysis.required_items(_payload(tasks=tasks))
 
+    # Two of the three passed: `n=0` drew partial credit, `n=1` and `n=2`
+    # passed. Counted on `model_did_right`, which for these positive items is
+    # the same thing the verdict says.
     assert required["recurring_criteria"] == [
         {"criterion": shared, "tasks": 3, "passed": 2}
     ]
@@ -776,11 +1179,260 @@ def test_a_run_with_no_required_items_does_not_divide_by_zero():
 
     required = analysis.required_items(payload)
 
-    assert required == {
-        "total": 0,
-        "passed": 0,
-        "rate": None,
-        "by_verdict": {},
-        "recurring_criteria": [],
-    }
+    assert required["total"] == 0
+    assert required["passed"] == 0
+    assert required["rate"] is None
+    assert required["by_verdict"] == {}
+    assert required["recurring_criteria"] == []
+    assert required["penalty_items"] == 0
+    assert required["legacy_verdict_pass"]["rate"] is None
+    # No rate to compare, so no claim of agreement either.
+    assert required["agrees_with_payload"] is False
     analysis._render(analysis.analyze(payload), shortfall_limit=0)
+
+
+# ── The breakdowns 304 asks for and the payload does not carry ─────────────
+
+
+def test_occupations_are_grouped_and_scored():
+    """Stage 1 reached 7 occupations of 44; stage 3 reaches all of them.
+
+    A sector average over nine buckets cannot show which of the newly-covered
+    occupations moved the ceiling, and the payload carries no occupation
+    breakdown at all -- so this computes one.
+    """
+    tasks = [
+        _task("task-1", occupation="Auditor", pct=90.0),
+        _task("task-2", occupation="Auditor", pct=70.0),
+        _task("task-3", occupation="Film Editor", pct=50.0),
+    ]
+
+    grouped = analysis.by_occupation(_payload(tasks=tasks))
+
+    assert set(grouped) == {"Auditor", "Film Editor"}
+    assert grouped["Auditor"]["task_count"] == 2
+    assert grouped["Auditor"]["avg_pct"] == pytest.approx(80.0)
+    assert grouped["Film Editor"]["avg_pct"] == pytest.approx(50.0)
+
+
+def test_an_unrecorded_occupation_gets_a_bucket_rather_than_vanishing():
+    """Dropping it would make the buckets sum to less than the corpus."""
+    grouped = analysis.by_occupation(
+        _payload(tasks=[_task("task-1", occupation=None, pct=40.0)])
+    )
+
+    assert grouped["unrecorded"]["task_count"] == 1
+
+
+def test_the_mean_is_macro_and_the_required_rate_is_micro():
+    """The two headline numbers aggregate differently, and both are recomputed.
+
+    `step8_grade.py` averages per-task percentages for the mean -- every task
+    weighs the same -- and pools required items for the rate, so a task with
+    four required items pulls four times as hard. A recomputation that picked
+    one style for both would be wrong twice, and would be wrong *quietly*: the
+    numbers would still look like numbers.
+    """
+    tasks = [
+        _task(
+            "task-1",
+            pct=100.0,
+            items=[_item(max_score=5, verdict="pass") for _ in range(4)],
+        ),
+        _task(
+            "task-2",
+            pct=0.0,
+            items=[_item(max_score=5, verdict="fail")],
+        ),
+    ]
+
+    block = analysis.subset_scores(_payload(tasks=tasks), ["task-1", "task-2"])
+
+    # Macro: the two tasks weigh the same.
+    assert block["avg_pct"] == pytest.approx(50.0)
+    # Micro: four passing items against one failing one.
+    assert block["required_items"] == 5
+    assert block["required_passed"] == 4
+    assert block["critical_item_pass_rate"] == pytest.approx(0.8)
+
+
+def test_a_task_in_error_is_out_of_the_mean_but_in_the_count():
+    """The grader averages over `[t for t in tasks if not t["error"]]`."""
+    tasks = [
+        _task("task-1", pct=80.0),
+        _task("task-2", pct=None, error="judge unreachable"),
+    ]
+
+    block = analysis.subset_scores(_payload(tasks=tasks), ["task-1", "task-2"])
+
+    assert block["task_count"] == 2
+    assert block["graded_tasks"] == 1
+    assert block["error_tasks"] == 1
+    assert block["avg_pct"] == pytest.approx(80.0)
+
+
+def test_the_unclamped_mean_is_reported_beside_the_clamped_one():
+    """One task in the 185 carries -380 points against a 50-point maximum.
+
+    `core.grader` floors `pct` at zero and keeps the real value in `pct_raw`.
+    Averaging only the clamped value cannot tell a fired penalty from an answer
+    that simply scored nothing, and the difference is the whole finding.
+    """
+    tasks = [
+        _task("task-1", pct=100.0, pct_raw=100.0),
+        _task("task-2", pct=0.0, pct_raw=-660.0),
+    ]
+
+    block = analysis.subset_scores(_payload(tasks=tasks), ["task-1", "task-2"])
+
+    assert block["avg_pct"] == pytest.approx(50.0)
+    assert block["avg_pct_raw"] == pytest.approx(-280.0)
+    assert block["tasks_clamped_at_zero"] == ["task-2"]
+
+
+def test_a_subset_can_be_taken_or_left():
+    """`304` promises the mean *with and without* the five declared limits."""
+    tasks = [
+        _task("aaaaaaaa-1111", pct=20.0),
+        _task("bbbbbbbb-2222", pct=80.0),
+        _task("cccccccc-3333", pct=90.0),
+    ]
+    payload = _payload(tasks=tasks)
+
+    only = analysis.subset_scores(payload, ["aaaaaaaa"])
+    without = analysis.subset_scores(payload, ["aaaaaaaa"], exclude=True)
+
+    assert only["matched"] == ["aaaaaaaa-1111"]
+    assert only["avg_pct"] == pytest.approx(20.0)
+    assert without["task_count"] == 2
+    assert without["avg_pct"] == pytest.approx(85.0)
+    assert without["excluded"] is True
+
+
+def test_a_prefix_matching_nothing_is_named_rather_than_absorbed():
+    """A subset that silently shrank would move a mean the report quotes."""
+    block = analysis.subset_scores(
+        _payload(tasks=[_task("aaaaaaaa-1111", pct=20.0)]), ["zzzzzzzz"]
+    )
+
+    assert block["missing"] == ["zzzzzzzz"]
+    assert block["matched"] == []
+    assert block["avg_pct"] is None
+
+
+def test_a_prefix_matching_two_tasks_is_refused_rather_than_guessed():
+    """The spec names tasks by eight characters; the payload holds UUIDs.
+
+    Eight hex characters over 185 tasks is not obviously collision-free, and a
+    prefix that matched two would double-count one of them into a mean.
+    """
+    payload = _payload(
+        tasks=[_task("aaaaaaaa-1111", pct=20.0), _task("aaaaaaaa-2222", pct=90.0)]
+    )
+
+    block = analysis.subset_scores(payload, ["aaaaaaaa"])
+
+    assert block["ambiguous"] == ["aaaaaaaa"]
+    assert block["matched"] == []
+
+
+def test_the_known_limit_ids_are_eight_characters_of_a_real_task():
+    """A typo in the pinned five would silently produce an empty subset.
+
+    The five are quoted from `300-gold-ceiling.md`'s declared input limits, and
+    each has to name a task the 185-corpus config actually grades.
+    """
+    import yaml
+
+    config = yaml.safe_load(
+        (
+            REPO_ROOT
+            / "batch-runner/grading_configs"
+            / f"{analysis.STAGE_THREE_CORPUS.config_name}.yaml"
+        ).read_text(encoding="utf-8")
+    )
+    graded = config["rerun_identity"]["task_ids"]
+
+    for prefix in analysis.KNOWN_LIMIT_TASK_IDS:
+        hits = [task_id for task_id in graded if task_id.startswith(prefix)]
+        assert len(hits) == 1, f"{prefix} matched {len(hits)} of the 185"
+
+
+# ── The same thirty, compared like for like ────────────────────────────────
+
+
+def test_the_same_thirty_are_verified_before_they_are_reported():
+    """Withheld rather than wrong, if the first thirty are not stage 1's.
+
+    The comparison rests on `step9_merge_shards.py` normalising into canonical
+    order. That is an inference, so the thirty ids are hashed and the digest
+    has to be stage 1's -- otherwise nothing downstream could tell that the
+    "same 30" were a different 30.
+    """
+    block = analysis.stage_one_subset(
+        _payload(tasks=[_task(f"task-{n}", pct=50.0) for n in range(30)])
+    )
+
+    assert block["verified"] is False
+    assert "not stage 1's corpus" in block["reason"]
+    assert "avg_pct" not in block
+
+
+def test_the_same_thirty_are_scored_when_the_digest_matches():
+    """The real thirty, read from stage 1's own config."""
+    import yaml
+
+    thirty = yaml.safe_load(
+        (
+            REPO_ROOT
+            / "batch-runner/grading_configs"
+            / f"{analysis.STAGE_ONE_CORPUS.config_name}.yaml"
+        ).read_text(encoding="utf-8")
+    )["rerun_identity"]["task_ids"]
+
+    tasks = [_task(task_id, pct=80.0) for task_id in thirty]
+    tasks.append(_task("a-thirty-first-task", pct=10.0))
+
+    block = analysis.stage_one_subset(_payload(tasks=tasks))
+
+    assert block["verified"] is True
+    assert block["task_count"] == 30
+    # The thirty-first is outside the comparison, so it cannot move it.
+    assert block["avg_pct"] == pytest.approx(80.0)
+    assert (
+        block["ordered_task_ids_sha256"]
+        == analysis.STAGE_ONE_CORPUS.ordered_task_ids_sha256
+    )
+
+
+def test_a_payload_too_small_for_the_comparison_says_so():
+    block = analysis.stage_one_subset(_payload(tasks=[_task("task-1")]))
+
+    assert block["verified"] is False
+    assert "fewer than the 30" in block["reason"]
+
+
+def test_the_subsets_reach_the_readable_report(tmp_path, capsys):
+    grade_file = tmp_path / "grade.json"
+    grade_file.write_text(
+        json.dumps(
+            _payload(
+                tasks=[
+                    _task(f"task-{n:02d}", pct=float(n), occupation=f"Job {n % 3}")
+                    for n in range(30)
+                ]
+            )
+        )
+    )
+
+    analysis.main([str(grade_file), "--shortfall-limit", "0"])
+    printed = capsys.readouterr().out
+
+    assert "By occupation (3)" in printed
+    assert "Subsets" in printed
+    assert "the same thirty stage 1 graded" in printed
+    assert "the five declared input limits" in printed
+    assert "everything but those five" in printed
+    # The withheld reason carries two 64-character fingerprints.
+    assert "withheld" in printed
+    assert max(len(line) for line in printed.splitlines()) < 120

--- a/tasks/rebuilding_grading_task/PR3_GOLD_CEILING.md
+++ b/tasks/rebuilding_grading_task/PR3_GOLD_CEILING.md
@@ -202,7 +202,7 @@
 
 <!-- generated: python batch-runner/scripts/analyze_gold_ceiling.py data/grades/_diagnostic/82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b/exp_gold_baseline__judge_gpt-5_6-sol__gold_ceiling_30_v2_sol_max__cfg_d1bfc8217c9981d2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_c33d9d55703fbf5d__v2.2.json --shortfall-limit 12 -->
 ```text
-Gold ceiling — stage 1
+Gold ceiling — stage 1 -- the 30-task sample
 ============================================================
   experiment      exp_gold_baseline
   graded at       2026-08-28T18:41:32Z
@@ -214,8 +214,8 @@ Gold ceiling — stage 1
 Thresholds
 ------------------------------------------------------------
   mean score              82.87%   (needs >= 90.0%)   MISS
-  required-item pass      0.5714   (needs >= 0.95)   MISS
-  grader error rate       0.0014   (needs < 0.02)   PASS
+  required-item pass      0.5714   (needs >= 0.95)    MISS
+  grader error rate       0.0014   (needs < 0.02)     PASS
 
 Required items (|max score| >= 4)
 ------------------------------------------------------------
@@ -232,6 +232,28 @@ Scores
     Information                                          77.87%  n=3
     Manufacturing                                        84.27%  n=5
     Professional, Scientific, and Technical Services     80.46%  n=9
+
+By occupation (7)
+------------------------------------------------------------
+   77.87%  n=3    required 1/2  ·  Audio and Video Technicians
+   79.34%  n=4    required 0/2  ·  Computer and Information Systems Managers
+   81.36%  n=5    required 3/5  ·  Accountants and Auditors
+   83.98%  n=5    required 1/2  ·  Compliance Officers
+   84.27%  n=5    required 0/4  ·  Buyers and Purchasing Agents
+   84.64%  n=5    required 12/17  ·  Administrative Services Managers
+   87.99%  n=3    required 3/3  ·  Child, Family, and School Social Workers
+
+Subsets
+------------------------------------------------------------
+  82.87%   n=30   required 20/35  ·  the same thirty stage 1 graded
+  67.42%   n=1    required 0/0  ·  the five declared input limits
+      named but not in this payload:
+      a73fbc98, e222075d, 75401f7c
+      7de33b48
+  83.41%   n=29   required 20/35  ·  everything but those five
+      named but not in this payload:
+      a73fbc98, e222075d, 75401f7c
+      7de33b48
 
 Usage
 ------------------------------------------------------------
@@ -326,40 +348,48 @@ Shortfalls
       evidence   "char_count": 6532, "truncated": false
   -3.25 of 5  [partial, visual, decided by judge]  83d10b06-26d1-4636-a32c-23f92c57f30b
       criterion  Overall formatting and style of the deliverable
-      evidence   Bold headers and consistent font are visible, but entries run together across columns (e.g., “Corporate BanCorporate Loans” and “Cayman IslanWillett Bank Cayman”).
+      evidence   Bold headers and consistent font are visible, but entries run together across columns (e.g.,
+                 “Corporate BanCorporate Loans” and “Cayman IslanWillett Bank Cayman”).
   -2.75 of 5  [partial, visual, decided by judge]  c44e9b62-7cd8-4f72-8ad9-f8fbddb94083
       criterion  Highlights reductions consistently on the org chart with a legend or notation.
-      evidence   Several role boxes use blue outlines, but no visible legend or text explains that these outlines denote reductions.
+      evidence   Several role boxes use blue outlines, but no visible legend or text explains that these
+                 outlines denote reductions.
   -2.25 of 5  [partial, visual, decided by judge]  7bbfcfe9-132d-4194-82bb-d6f29d001b01
       criterion  Overall formatting and style of the deliverable
-      evidence   Bold headers and clear gridlines provide basic readability, but the excessive blank area, awkward scale, and uneven row spacing make the sheet look unfinished and poorly balanced.
+      evidence   Bold headers and clear gridlines provide basic readability, but the excessive blank area,
+                 awkward scale, and uneven row spacing make the sheet look unfinished and poorly balanced.
   -2.1 of 5  [partial, visual, decided by judge]  24d1e93f-9018-45d4-b522-ad89dfd78079
       criterion  Overall formatting and style of the deliverable
-      evidence   Clear blue title and a bordered 3-column table, but long assumption lines end abruptly at the right, all body text is italic, and most of the page is unused white space.
+      evidence   Clear blue title and a bordered 3-column table, but long assumption lines end abruptly at the
+                 right, all body text is italic, and most of the page is unused white space.
   -2.0 of 2  [fail, text, decided by judge]  15ddd28d-8445-4baa-ac7f-f41372e1344e
       criterion  The document length is between 2 and 3 pages (inclusive).
       evidence   "kind": "docx", "paragraph_count": 63, "table_count": 1, "section_count": 1
   -2.0 of 2  [fail, text, decided by judge]  17111c03-aac7-45c2-857d-c06d8223d6ad
-      criterion  The memo identifies the sender’s role as Administrative Services Manager (wording can vary but must clearly convey this role).
+      criterion  The memo identifies the sender’s role as Administrative Services Manager (wording can vary
+                 but must clearly convey this role).
       evidence   From: Your Name
   -2.0 of 2  [fail, text, decided by judge]  17111c03-aac7-45c2-857d-c06d8223d6ad
       criterion  No section/area appears in the Excel schedule that is not Section 1, 2, 3, or 4 (no extras).
-      evidence   SECTION 3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-,SECTION ,
+      evidence   SECTION 3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,, ,SECTION ,
   -2.0 of 2  [fail, text, decided by judge]  17111c03-aac7-45c2-857d-c06d8223d6ad
-      criterion  All dates or week ranges from 'TENTATIVE CLEANUP SCHEDULE.pdf' are represented in the Excel schedule (no omissions).
+      criterion  All dates or week ranges from 'TENTATIVE CLEANUP SCHEDULE.pdf' are represented in the Excel
+                 schedule (no omissions).
       evidence   2025-04-01 00:00:00
   -2.0 of 2  [fail, formatting, decided by judge]  2696757c-1f8a-4959-8f0d-f5597b9e70fc
-      criterion  Immediately after the 9.08(c)(3) test question, a regulatory citation appears identifying VA Servicer Handbook M26-4, Chapter 9, paragraph 9.08(c)(3),
+      criterion  Immediately after the 9.08(c)(3) test question, a regulatory citation appears identifying VA
+                 Servicer Handbook M26-4, Chapter 9, paragraph 9.08(c)(3), and the Chapter 9 publication date
+                 (August 12, 2024) (punctuation/formatting may vary).
       evidence   Regulatory Cita.on: VA Servicer Handbook M26-4, Chapter 9: VA Purchase, 9.08(c)(3), August
-12, 2024
-When the borrower has discharged
+                 12, 2024 When the borrower has discharged
   -2.0 of 2  [fail, text, decided by judge]  27e8912c-8bd5-44ba-ad87-64066ea05264
-      criterion  The checklist explicitly cites a foundation checklist from a credible source by naming the organization and the document title (accept phrasing like '
-      evidence   ~End of Assessment~
-Workstation Ergonomics Checklist 5
+      criterion  The checklist explicitly cites a foundation checklist from a credible source by naming the
+                 organization and the document title (accept phrasing like 'Based on' or 'Adapted from';
+                 including a source link is acceptable but not required).
+      evidence   ~End of Assessment~ Workstation Ergonomics Checklist 5
   -2.0 of 2  [fail, text, decided by judge]  36d567ba-e205-4313-9756-931c6e4691fe
-      criterion  The document visibly includes the exact title text: "Federal Applicant - Risk Assessment Tool"
+      criterion  The document visibly includes the exact title text: "Federal Applicant - Risk Assessment
+                 Tool"
       evidence   Federal Applicant – Risk Assessment Tool
   ... and 358 more (use --json for all of them)
 ```
@@ -373,7 +403,7 @@ Workstation Ergonomics Checklist 5
 
 <!-- generated: python batch-runner/scripts/analyze_gold_ceiling.py data/grades/_diagnostic/82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b/_superseded/exp_gold_baseline__judge_gpt-5_6-sol__gold_ceiling_30_v2_sol_max__cfg_d1bfc8217c9981d2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_8513975c188f31a6__v2.2.json --shortfall-limit 0 -->
 ```text
-Gold ceiling — stage 1
+Gold ceiling — stage 1 -- the 30-task sample
 ============================================================
   experiment      exp_gold_baseline
   graded at       2026-08-28T14:11:53Z
@@ -385,8 +415,8 @@ Gold ceiling — stage 1
 Thresholds
 ------------------------------------------------------------
   mean score              78.24%   (needs >= 90.0%)   MISS
-  required-item pass      0.5429   (needs >= 0.95)   MISS
-  grader error rate       0.0   (needs < 0.02)   PASS
+  required-item pass      0.5429   (needs >= 0.95)    MISS
+  grader error rate          0.0   (needs < 0.02)     PASS
 
 Required items (|max score| >= 4)
 ------------------------------------------------------------
@@ -403,6 +433,28 @@ Scores
     Information                                          56.21%  n=3
     Manufacturing                                        83.94%  n=5
     Professional, Scientific, and Technical Services     71.39%  n=9
+
+By occupation (7)
+------------------------------------------------------------
+   56.21%  n=3    required 1/2  ·  Audio and Video Technicians
+   59.53%  n=4    required 0/2  ·  Computer and Information Systems Managers
+   80.87%  n=5    required 3/5  ·  Accountants and Auditors
+   83.94%  n=5    required 0/4  ·  Buyers and Purchasing Agents
+   84.43%  n=5    required 1/2  ·  Compliance Officers
+   86.14%  n=5    required 12/17  ·  Administrative Services Managers
+   87.82%  n=3    required 2/3  ·  Child, Family, and School Social Workers
+
+Subsets
+------------------------------------------------------------
+  78.24%   n=30   required 19/35  ·  the same thirty stage 1 graded
+  3.23%    n=1    required 0/0  ·  the five declared input limits
+      named but not in this payload:
+      a73fbc98, e222075d, 75401f7c
+      7de33b48
+  80.82%   n=29   required 19/35  ·  everything but those five
+      named but not in this payload:
+      a73fbc98, e222075d, 75401f7c
+      7de33b48
 
 Usage
 ------------------------------------------------------------


### PR DESCRIPTION
## Why

The gold-ceiling analysis tool is what turns a grading run into a stage report. Stage 3 grades **185 tasks**, and the tool could not read that run at all — it pinned exactly one corpus, stage 1's thirty, and refused everything else. Two things had to change before it could be pointed at the stage 3 payload, and the second one is a correctness bug rather than a gap.

### 1. It knew one corpus

`identify_corpus()` recognised a single pinned run. A 185-task payload was refused as "not the run stage 1 pinned" — correct behaviour for an unknown payload, wrong answer for the run the tool exists to read.

### 2. It counted required items by a retired rule

The tool counted a required item as passed when `verdict == "pass"`. The grader does not do that. From `core/grader.py:1344-1361`:

```
verdict == "judge_error"  ->  score_excluded = True, model_did_right = False
score_excluded            ->  model_did_right = True
max_score < 0             ->  model_did_right = (verdict != "pass")
otherwise                 ->  model_did_right = (verdict == "pass")
```

For a **penalty item — one with a negative maximum — a `pass` verdict means the penalty fired**, which is a miss, not a pass. The retired spelling inverts every one of them.

That is not hypothetical on this corpus. Counted from the rubric parquet over the 185 tasks:

| | count |
|---|---|
| required items (`\|score\| >= 4`) | 357 |
| negative-score items | 61, across 13 tasks |
| **negative *and* required** | **54, across 8 tasks** |

So **15% of the required-item denominator** would have been counted with its sign flipped — in the run whose required-item rate is one of three acceptance gates.

## What changed

**`batch-runner/scripts/analyze_gold_ceiling.py`**

- Two pinned corpora. Which one a payload is comes from its **ordered-task-id fingerprint, not its size**, so stage 1's thirty and stage 3's hundred and eighty-five are both read and neither can be mistaken for the other. Repeats and shards are still refused.
- Required items are counted by the grader's own rule. The block now also reports items the grader excluded, counted items carrying no `model_did_right`, and penalty items with how many fired.
- **The recount is checked against the run's own number.** When they disagree the report says so and tells the reader to quote neither until it is settled, rather than quietly printing a second opinion beside the gate.
- New **per-occupation** block, and three **subsets**: the same thirty stage 1 graded, the five declared input limits, and everything but those five. A subset whose fingerprint cannot be verified is withheld with its reason rather than reported.
- The unclamped mean (`pct_raw`) is reported beside the clamped one when they differ, with the count of tasks that hit the floor at zero. `pct` is clamped to `[0, 100]` at `core/grader.py:1393`, and one task in this corpus (`6074bba3`) has a worst case of **-660%** before that clamp — so the clamp is load-bearing and worth showing.
- Criterion and evidence text wraps instead of being cut with a bare slice. One real line ended mid-word at `for YTD amor`.

**`batch-runner/tests/test_gold_ceiling_analysis.py`** — 40 → 68 tests.

**`tasks/rebuilding_grading_task/PR3_GOLD_CEILING.md`** — stage 1's report quotes the tool's output inside `<!-- generated: ... -->` fences, and `test_every_generated_block_still_matches_its_command` re-runs the command and demands the block still match. Changing the tool made those quotes stale and that test caught it. Both blocks were regenerated **by the tool**, not retyped. **Stage 1's conclusion is unchanged — 82.87% / 0.5714 / 0.0014 are the same numbers**; what moved is the layout, plus the new per-occupation and subset sections.

Two small presentation fixes went with it: the three gate lines now pad to the widest bar so `PASS`/`MISS` forms one column (`needs >= 90.0%` and `needs < 0.02` are different lengths, so hand-written lines stepped across the page), and criterion/evidence prose wraps under a hanging indent instead of being cut with a bare slice — one real line ended mid-word at `for YTD amor`. Max report width on real data went from **204 to 118**.

## Evidence

Stage 1's 185-task sibling does not exist yet, so the tool was verified end-to-end against stage 1's **real payload**. It identifies the corpus by digest and reproduces all three published numbers:

```
Gold ceiling — stage 1 -- the 30-task sample
  mean score          82.87%   (needs >= 90.0%)   MISS
  required-item pass  0.5714   (needs >= 0.95)    MISS
  grader error rate   0.0014   (needs < 0.02)     PASS

Subsets
  82.87%  n=30  required 20/35  ·  the same thirty stage 1 graded
  67.42%  n=1   required 0/0    ·  the five declared input limits
  83.41%  n=29  required 20/35  ·  everything but those five
```

The same-thirty subset returning **82.87%**, identical to the headline, is the self-consistency check: the tool's macro mean reproduces `step8_grade`'s arithmetic independently.

Two tests keep the new counting honest rather than merely consistent with itself:

- `test_the_helper_agrees_with_the_grader` builds real `ItemGrade`/`TaskRubric` objects and runs the **actual `Grader._aggregate`** over seven cases, so the rule restated in the fixtures cannot drift from the grader in silence.
- `test_stage_ones_thirty_are_the_first_thirty_of_stage_threes` proves stage 3's config's `task_ids[:30]` are exactly stage 1's thirty, **in order**, and hash to `82d14ac9…`. That is what licenses the same-thirty comparison against a merged 185-task payload.

## Checks

- 68/68 in `tests/test_gold_ceiling_analysis.py`; full backend suite **5664 passed, 6 skipped, 0 failed**.
- mypy: **0 errors in the edited file**. The 41 it reports come from `core/` and `step8_grade.py`, which this branch does not touch, and CI does not gate on mypy (`.github/workflows/backend-tests.yml:8`).
- No production module is touched — `scripts/` is not imported by the pipeline, so **`grader_source_hash` is unchanged**.

## Do not merge yet

The stage 3 shards are grading right now against `main` at `a5f6e40`. `step8_grade._validate_grade_resume_identity` is fail-closed on `grader_source_hash` at chunk-2 resume, and `step9_merge_shards.py` requires every shard to agree on it. This PR does not change that hash — but the freeze is on merging to `main` at all while shards are in flight, so this waits for them to land.
