### PR TITLE
fix(cost): 캐시 내역이 없는 응답을 사용량 불명으로 읽지 않는다

### DIFF
--- a/batch-runner/core/cost_metering.py
+++ b/batch-runner/core/cost_metering.py
@@ -47,8 +47,10 @@ __all__ = [
     "Attribution",
     "CostRecorder",
     "MeteredClient",
+    "ReportedUsage",
     "extract_usage",
     "open_cost_recorder",
+    "read_reported_usage",
     "resolved_model_of",
 ]
 
@@ -154,6 +156,72 @@ def extract_usage(response: Any) -> CallUsage:
         cached_input_tokens=cached,
         output_tokens=output_tokens,
         reasoning_tokens=reasoning,
+    )
+
+
+@dataclass(frozen=True)
+class ReportedUsage:
+    """One call's token counts, as a running tally needs them.
+
+    Separate from :class:`CallUsage` because the two answer different
+    questions. ``CallUsage`` is what the ledger stores, where an absent count
+    must stay ``None`` forever and never becomes a zero. This is what a
+    *caller keeping a running total* needs: counts it can add up, and one flag
+    saying whether the total is still worth publishing.
+
+    That flag deliberately does not depend on whether the prompt-cache
+    breakdown arrived. Cached tokens are a *part* of the input, not an
+    addition to it, so a call that comes back without a breakdown is still
+    fully counted — counted as though none of it were served from cache, which
+    is the conservative reading and can only overstate the bill, never
+    understate it. Which calls had no breakdown is not lost by flattening it
+    to zero here: the metered client records that call's
+    ``cached_input_tokens`` as ``None`` in the receipt, and ``None`` is not
+    ``0`` there.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+    usage_complete: bool = False
+
+
+def read_reported_usage(response: Any) -> ReportedUsage:
+    """Read one reply's usage the way a running tally needs it.
+
+    Three call sites keep their own token totals — the tool-calling judge and
+    the two perception sub-judges — and each used to read the usage block
+    itself. All three then treated a missing prompt-cache breakdown as
+    *unknown usage*, which is neither what a missing breakdown means nor what
+    the rest of this pipeline does with one:
+    :func:`core.cost_receipts.price_call` charges a ``None`` cached count at
+    the full uncached rate and does not call the receipt partial, and
+    ``AgenticSandboxRunner._usage`` returns a complete tuple with a cached
+    count of zero. This is the one place that decides, so the copies cannot
+    disagree with the ledger — or with each other — again.
+
+    Usage is incomplete when, and only when:
+
+    * no usage block came back at all; or
+    * the input or the output count is missing, or is not a count; or
+    * more tokens were served from cache than were sent — a contradiction that
+      makes both numbers untrustworthy, and the same check ``price_call``
+      makes before it will put a number on a call.
+    """
+    usage = extract_usage(response)
+    cached = usage.cached_input_tokens
+    complete = usage.input_tokens is not None and usage.output_tokens is not None
+    if (
+        usage.input_tokens is not None
+        and cached is not None
+        and cached > usage.input_tokens
+    ):
+        complete = False
+    return ReportedUsage(
+        input_tokens=usage.input_tokens or 0,
+        output_tokens=usage.output_tokens or 0,
+        cached_tokens=cached or 0,
+        usage_complete=complete,
     )
 
 

--- a/batch-runner/core/perception/audio.py
+++ b/batch-runner/core/perception/audio.py
@@ -34,6 +34,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
 
+from core.cost_metering import read_reported_usage
 from core.public_error import public_provider_error_text, public_task_error_text
 
 #: How many audio sub-judge calls one task gets when the marking settings
@@ -219,17 +220,11 @@ class AudioPerception:
                 temperature=0,
             )
             latency_ms = (time.perf_counter() - call_started) * 1000.0
-            usage = getattr(response, "usage", None)
-            usage_complete = usage is not None and all(
-                hasattr(usage, field_name)
-                for field_name in ("input_tokens", "output_tokens")
-            )
-            input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
-            output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
-            details = getattr(usage, "input_tokens_details", None)
-            cached_tokens = int(getattr(details, "cached_tokens", 0) or 0)
-            if details is None or not hasattr(details, "cached_tokens"):
-                usage_complete = False
+            reported = read_reported_usage(response)
+            input_tokens = reported.input_tokens
+            output_tokens = reported.output_tokens
+            cached_tokens = reported.cached_tokens
+            usage_complete = reported.usage_complete
             text = getattr(response, "output_text", "") or ""
             payload = _parse_json_envelope(text)
             return AudioVerdict(

--- a/batch-runner/core/perception/vision.py
+++ b/batch-runner/core/perception/vision.py
@@ -34,6 +34,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Dict, Optional
 
+from core.cost_metering import read_reported_usage
 from core.public_error import public_provider_error_text
 
 logger = logging.getLogger(__name__)
@@ -279,17 +280,11 @@ class VisionPerception:
                 reasoning={"effort": self.reasoning_effort},
             )
             latency_ms = (time.perf_counter() - call_started) * 1000.0
-            usage = getattr(response, "usage", None)
-            usage_complete = usage is not None and all(
-                hasattr(usage, field_name)
-                for field_name in ("input_tokens", "output_tokens")
-            )
-            input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
-            output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
-            details = getattr(usage, "input_tokens_details", None)
-            cached_tokens = int(getattr(details, "cached_tokens", 0) or 0)
-            if details is None or not hasattr(details, "cached_tokens"):
-                usage_complete = False
+            reported = read_reported_usage(response)
+            input_tokens = reported.input_tokens
+            output_tokens = reported.output_tokens
+            cached_tokens = reported.cached_tokens
+            usage_complete = reported.usage_complete
             text = getattr(response, "output_text", "") or ""
             payload = _validate_vision_envelope(text)
             verdict = VisionVerdict(

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -54,6 +54,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from core.cost_metering import read_reported_usage
 from core.grader_routing import (
     RoutingDecision,
     classify_criterion,
@@ -714,28 +715,19 @@ class ToolCallingJudge:
                 )
                 break
 
-            usage = getattr(response, "usage", None)
-            if usage is None or not all(
-                hasattr(usage, field_name)
-                for field_name in ("input_tokens", "output_tokens")
-            ):
+            # Cached input is a *part* of the reported input, so a reply that
+            # carries no prompt-cache breakdown is still fully counted -- it is
+            # counted as though nothing came from cache. Only a missing input or
+            # output count leaves the total unpublishable. The rule lives in
+            # read_reported_usage so this and the two perception readers cannot
+            # disagree with the receipt ledger, or with each other.
+            reported = read_reported_usage(response)
+            if not reported.usage_complete:
                 usage_complete = False
-            response_input_tokens = int(
-                getattr(usage, "input_tokens", 0) or 0
-            )
-            response_output_tokens = int(
-                getattr(usage, "output_tokens", 0) or 0
-            )
-            input_tok_total += response_input_tokens
+            response_output_tokens = reported.output_tokens
+            input_tok_total += reported.input_tokens
             output_tok_total += response_output_tokens
-            # PR3 Step 0 — cached_tokens (Azure Responses API automatic prompt
-            # caching). Field path: usage.input_tokens_details.cached_tokens.
-            # Older SDKs may not expose the details object; default 0.
-            details = getattr(usage, "input_tokens_details", None)
-            if details is not None:
-                cached_tok_total += int(getattr(details, "cached_tokens", 0) or 0)
-            else:
-                usage_complete = False
+            cached_tok_total += reported.cached_tokens
 
             output_items = list(getattr(response, "output", []) or [])
             function_calls = [o for o in output_items

--- a/batch-runner/tests/test_cost_metering_records_what_the_client_sent.py
+++ b/batch-runner/tests/test_cost_metering_records_what_the_client_sent.py
@@ -18,12 +18,15 @@ from core.cost_metering import (
     Attribution,
     CostRecorder,
     extract_usage,
+    read_reported_usage,
     resolved_model_of,
 )
 from core.cost_receipts import (
     BUCKET_GRADING,
     BUCKET_PROBLEM_SOLVING,
     REASON_CALL_REACHABILITY_UNKNOWN,
+    REASON_USAGE_ABSENT,
+    REASON_USAGE_PARTIAL,
     RETRY_SEMANTIC,
     STAGE_GENERATION,
     STAGE_GRADING,
@@ -33,6 +36,7 @@ from core.cost_receipts import (
     STATUS_PARTIAL,
     CostReceiptLedger,
     load_receipt_price_table,
+    price_call,
 )
 
 PRICE_TABLE = {
@@ -374,6 +378,150 @@ def test_a_negative_count_is_not_believed():
     usage = extract_usage({"usage": {"prompt_tokens": -5, "completion_tokens": 5}})
 
     assert usage.input_tokens is None
+
+
+# ── what a running tally is allowed to publish ───────────────────────────
+
+
+def _responses_bag(**usage_fields):
+    """A Responses-shaped reply whose usage block is exactly what was asked for."""
+    return _Bag(model="test-model", usage=_Bag(**usage_fields))
+
+
+def test_a_reply_without_a_cache_breakdown_is_still_a_complete_count():
+    """The bug this helper exists to fix.
+
+    ``gpt-audio-1.5`` answers without ``input_tokens_details``. Both counts
+    that decide the bill are present, so the tally is publishable — the reply
+    simply says nothing was served from cache. Reading that as *unknown usage*
+    is what failed a whole 17-task shard on rc=6 after it had already been
+    paid for.
+    """
+    reported = read_reported_usage(
+        _responses_bag(input_tokens=900, output_tokens=120)
+    )
+
+    assert reported.usage_complete is True
+    assert reported.input_tokens == 900
+    assert reported.output_tokens == 120
+    assert reported.cached_tokens == 0
+
+
+def test_a_breakdown_that_arrived_empty_is_read_the_same_way():
+    """An older SDK hands back the details object with nothing in it."""
+    reported = read_reported_usage(
+        _responses_bag(
+            input_tokens=900, output_tokens=120, input_tokens_details=_Bag()
+        )
+    )
+
+    assert reported.usage_complete is True
+    assert reported.cached_tokens == 0
+
+
+def test_a_breakdown_that_did_arrive_is_counted():
+    reported = read_reported_usage(
+        _responses_bag(
+            input_tokens=900,
+            output_tokens=120,
+            input_tokens_details=_Bag(cached_tokens=300),
+        )
+    )
+
+    assert reported.usage_complete is True
+    assert reported.cached_tokens == 300
+
+
+@pytest.mark.parametrize(
+    "usage_fields",
+    [
+        {"output_tokens": 120},                    # no input count
+        {"input_tokens": 900},                     # no output count
+        {"input_tokens": None, "output_tokens": 120},
+        {"input_tokens": True, "output_tokens": 120},   # a flag, not a count
+        {"input_tokens": -5, "output_tokens": 120},
+    ],
+    ids=["no-input", "no-output", "input-null", "input-flag", "input-negative"],
+)
+def test_a_missing_or_unbelievable_count_is_not_publishable(usage_fields):
+    assert read_reported_usage(_responses_bag(**usage_fields)).usage_complete is False
+
+
+def test_a_reply_with_no_usage_block_at_all_is_not_publishable():
+    assert read_reported_usage(_Bag(model="test-model")).usage_complete is False
+    assert read_reported_usage(_Bag(model="test-model", usage=None)).usage_complete is (
+        False
+    )
+
+
+def test_more_served_from_cache_than_was_sent_is_a_contradiction():
+    """Cached input is a part of the input, so it cannot exceed it.
+
+    One of the two numbers is wrong and there is no way to tell which, so
+    neither is trusted. ``price_call`` makes the same check before it will put
+    a number on a call.
+    """
+    reported = read_reported_usage(
+        _responses_bag(
+            input_tokens=10,
+            output_tokens=120,
+            input_tokens_details=_Bag(cached_tokens=99),
+        )
+    )
+
+    assert reported.usage_complete is False
+
+
+def test_the_helper_agrees_with_the_ledger_about_what_is_publishable(price_table):
+    """The anti-drift check, and the reason the rule lives in one place.
+
+    Three call sites keep running token totals, and each used to decide for
+    itself when a total was still worth publishing. All three invented a rule
+    stricter than the one the receipt ledger actually applies, which is how a
+    missing cache breakdown came to mean *unknown usage* in the judge while
+    meaning *nothing was cached* in the bill.
+
+    So the rule is not merely restated here — it is checked against
+    ``price_call``, the function that decides whether a call can be charged.
+    A shape the ledger is willing to price must be a shape the tally is
+    willing to publish, and the reverse. If either side moves, this fails.
+    """
+    price = price_table.lookup("azure", "test-model")
+    assert price is not None
+
+    shapes = [
+        _responses_bag(input_tokens=900, output_tokens=120),
+        _responses_bag(
+            input_tokens=900,
+            output_tokens=120,
+            input_tokens_details=_Bag(cached_tokens=300),
+        ),
+        _responses_bag(
+            input_tokens=900, output_tokens=120, input_tokens_details=_Bag()
+        ),
+        _responses_bag(input_tokens=900, output_tokens=0),
+        _responses_bag(output_tokens=120),
+        _responses_bag(input_tokens=900),
+        _responses_bag(
+            input_tokens=10,
+            output_tokens=120,
+            input_tokens_details=_Bag(cached_tokens=99),
+        ),
+        _Bag(model="test-model"),
+        _chat_reply(prompt=500, completion=60),
+    ]
+
+    for shape in shapes:
+        priced = price_call(price, extract_usage(shape))
+        ledger_is_happy = not {
+            REASON_USAGE_ABSENT,
+            REASON_USAGE_PARTIAL,
+        } & set(priced.missing_reasons)
+
+        assert read_reported_usage(shape).usage_complete is ledger_is_happy, (
+            f"the tally and the ledger disagree about {vars(shape)}: "
+            f"reasons={priced.missing_reasons}"
+        )
 
 
 def test_the_reply_names_the_model_that_is_priced():

--- a/batch-runner/tests/test_perception_audio.py
+++ b/batch-runner/tests/test_perception_audio.py
@@ -16,27 +16,35 @@ from core.perception import AUDIO_CALL_CAP, AudioPerception, AudioVerdict
 # ── Fakes ────────────────────────────────────────────────────────────
 
 
+#: Lets a test say "this reply carried no usage block at all" without that
+#: being confused with "this test did not care about the usage block".
+_UNSET = object()
+
+
+def _default_usage() -> SimpleNamespace:
+    return SimpleNamespace(
+        input_tokens=70,
+        output_tokens=12,
+        input_tokens_details=SimpleNamespace(cached_tokens=5),
+    )
+
+
 class FakeResponses:
     def __init__(self, *, text: str = '{"verdict":"pass","partial_score":1.0,'
                  '"evidence":"voice clearly audible","confidence":0.8,'
                  '"reasoning":"no clipping"}',
-                 raise_with: Exception | None = None):
+                 raise_with: Exception | None = None,
+                 usage: Any = _UNSET):
         self.text = text
         self.raise_with = raise_with
+        self.usage = _default_usage() if usage is _UNSET else usage
         self.calls: list[dict[str, Any]] = []
 
     def create(self, **kwargs: Any) -> Any:
         self.calls.append(kwargs)
         if self.raise_with is not None:
             raise self.raise_with
-        return SimpleNamespace(
-            output_text=self.text,
-            usage=SimpleNamespace(
-                input_tokens=70,
-                output_tokens=12,
-                input_tokens_details=SimpleNamespace(cached_tokens=5),
-            ),
-        )
+        return SimpleNamespace(output_text=self.text, usage=self.usage)
 
 
 class FakeClient:
@@ -77,6 +85,41 @@ def test_happy_path_parses_verdict(wav_file):
     assert v.output_tokens == 12
     assert v.cached_tokens == 5
     assert v.usage_complete is True
+
+
+def test_a_reply_with_no_cache_breakdown_is_still_counted(wav_file):
+    """What ``gpt-audio-1.5`` actually sends back, and what it used to cost.
+
+    The listening model answers without ``input_tokens_details``. Both counts
+    that decide the bill are there; the reply is simply saying that nothing
+    was served from cache. Reading the absent breakdown as *unknown usage* set
+    ``usage_complete`` false on every audio item, and the run's token guard
+    turns one such item into a failed shard -- after the whole shard has been
+    paid for.
+    """
+    client = FakeClient(
+        FakeResponses(usage=SimpleNamespace(input_tokens=70, output_tokens=12))
+    )
+    ap = AudioPerception(client=client)
+
+    v = ap.judge(criterion="voice is clear", audio_path=str(wav_file))
+
+    assert v.verdict == "pass"
+    assert v.input_tokens == 70
+    assert v.output_tokens == 12
+    assert v.cached_tokens == 0
+    assert v.usage_complete is True
+
+
+def test_a_reply_that_reports_no_tokens_at_all_is_not_counted(wav_file):
+    """The genuine unknown: a reply that says nothing about what it used."""
+    client = FakeClient(FakeResponses(usage=None))
+    ap = AudioPerception(client=client)
+
+    v = ap.judge(criterion="voice is clear", audio_path=str(wav_file))
+
+    assert v.verdict == "pass"
+    assert v.usage_complete is False
 
 
 def test_request_shape_includes_audio_block(wav_file):

--- a/batch-runner/tests/test_perception_audio.py
+++ b/batch-runner/tests/test_perception_audio.py
@@ -88,14 +88,20 @@ def test_happy_path_parses_verdict(wav_file):
 
 
 def test_a_reply_with_no_cache_breakdown_is_still_counted(wav_file):
-    """What ``gpt-audio-1.5`` actually sends back, and what it used to cost.
+    """A reply without ``input_tokens_details`` is priced, not written off.
 
-    The listening model answers without ``input_tokens_details``. Both counts
-    that decide the bill are there; the reply is simply saying that nothing
-    was served from cache. Reading the absent breakdown as *unknown usage* set
-    ``usage_complete`` false on every audio item, and the run's token guard
-    turns one such item into a failed shard -- after the whole shard has been
-    paid for.
+    Both counts that decide the bill are present; the missing breakdown only
+    declines to say how much of the input came from cache. Cached input is a
+    *part* of the input, never an addition to it, so counting the whole thing
+    at the uncached rate can only overstate the bill -- and overstating is the
+    safe direction for a number the run has to stand behind.
+
+    What this test does **not** claim is that ``gpt-audio-1.5`` behaves this
+    way. Nobody knows: until the content-part key was corrected, every audio
+    call was rejected with a 400 before it reached the model, so no reply from
+    it has ever been observed. The rule is pinned here because the three sites
+    that keep running token totals share it, and a shared rule only stays
+    shared if each site is held to it.
     """
     client = FakeClient(
         FakeResponses(usage=SimpleNamespace(input_tokens=70, output_tokens=12))

--- a/batch-runner/tests/test_perception_vision.py
+++ b/batch-runner/tests/test_perception_vision.py
@@ -27,26 +27,34 @@ def _png_b64() -> str:
     return base64.b64encode(buf.getvalue()).decode("ascii")
 
 
+#: Lets a test say "this reply carried no usage block at all" without that
+#: being confused with "this test did not care about the usage block".
+_UNSET = object()
+
+
+def _default_usage() -> SimpleNamespace:
+    return SimpleNamespace(
+        input_tokens=123,
+        output_tokens=17,
+        input_tokens_details=SimpleNamespace(cached_tokens=11),
+    )
+
+
 class FakeResponses:
     def __init__(self, *, text: str = '{"verdict":"pass","partial_score":1.0,'
                  '"evidence":"chart title visible","confidence":0.9,'
-                 '"reasoning":"clean"}', raise_with: Exception | None = None):
+                 '"reasoning":"clean"}', raise_with: Exception | None = None,
+                 usage: Any = _UNSET):
         self.text = text
         self.raise_with = raise_with
+        self.usage = _default_usage() if usage is _UNSET else usage
         self.calls: list[dict[str, Any]] = []
 
     def create(self, **kwargs: Any) -> Any:
         self.calls.append(kwargs)
         if self.raise_with is not None:
             raise self.raise_with
-        return SimpleNamespace(
-            output_text=self.text,
-            usage=SimpleNamespace(
-                input_tokens=123,
-                output_tokens=17,
-                input_tokens_details=SimpleNamespace(cached_tokens=11),
-            ),
-        )
+        return SimpleNamespace(output_text=self.text, usage=self.usage)
 
 
 class FakeClient:
@@ -91,6 +99,42 @@ def test_usage_latency_and_guard_are_recorded_exactly(monkeypatch):
     assert verdict.cached_tokens == 11
     assert verdict.latency_ms == 250.0
     assert verdict.usage_complete is True
+
+
+def test_a_reply_with_no_cache_breakdown_is_still_counted():
+    """The looking model does send the breakdown -- so this guards the rule.
+
+    Unlike the listening model, ``gpt-5.6-sol`` has always returned
+    ``input_tokens_details``, so this reading has never actually fired here.
+    It is pinned anyway: the three call sites that keep running token totals
+    now share one rule, and a rule only stays shared if each site is held to
+    it. Cached input is a part of the input, so a reply without the breakdown
+    is fully counted -- counted as though nothing came from cache, which can
+    only overstate the bill.
+    """
+    client = FakeClient(
+        FakeResponses(usage=SimpleNamespace(input_tokens=123, output_tokens=17))
+    )
+    vp = VisionPerception(client=client)
+
+    v = vp.judge(criterion="chart is labeled", image_b64=_png_b64())
+
+    assert v.verdict == "pass"
+    assert v.input_tokens == 123
+    assert v.output_tokens == 17
+    assert v.cached_tokens == 0
+    assert v.usage_complete is True
+
+
+def test_a_reply_that_reports_no_tokens_at_all_is_not_counted():
+    """The genuine unknown: a reply that says nothing about what it used."""
+    client = FakeClient(FakeResponses(usage=None))
+    vp = VisionPerception(client=client)
+
+    v = vp.judge(criterion="chart is labeled", image_b64=_png_b64())
+
+    assert v.verdict == "pass"
+    assert v.usage_complete is False
 
 
 def test_request_shape_includes_image_and_model():

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -53,18 +53,18 @@ def test_prompt_cache_key_respects_azure_length_limit():
 
 
 def _usage(
-    in_tok: int = 100, out_tok: int = 30, cached_tok: int = 7
+    in_tok: int = 100, out_tok: int = 30, cached_tok: int | None = 7
 ) -> SimpleNamespace:
-    return SimpleNamespace(
-        input_tokens=in_tok,
-        output_tokens=out_tok,
-        input_tokens_details=SimpleNamespace(cached_tokens=cached_tok),
-    )
+    """A usage block. ``cached_tok=None`` means the reply carried no breakdown."""
+    usage = SimpleNamespace(input_tokens=in_tok, output_tokens=out_tok)
+    if cached_tok is not None:
+        usage.input_tokens_details = SimpleNamespace(cached_tokens=cached_tok)
+    return usage
 
 
 def _response(*, output: list[dict] | None = None, output_text: str = "",
               in_tok: int = 100, out_tok: int = 30,
-              cached_tok: int = 7, status: str | None = None,
+              cached_tok: int | None = 7, status: str | None = None,
               incomplete_reason: str | None = None) -> SimpleNamespace:
     return SimpleNamespace(
         output=output or [],
@@ -268,6 +268,46 @@ def test_tool_round_then_final(deliverable_dir, task_and_item):
     types = [m.get("type") for m in second_input if isinstance(m, dict)]
     assert "function_call" in types
     assert "function_call_output" in types
+
+
+def test_a_turn_without_a_cache_breakdown_still_counts_toward_the_total(
+    deliverable_dir, task_and_item
+):
+    """One turn's missing breakdown must not void the whole conversation.
+
+    The marking model does send ``input_tokens_details``, so this reading has
+    never fired here -- but the judge, the looking sub-judge and the listening
+    sub-judge each kept their own copy of the rule, and the listening one's
+    copy failed a paid shard. They now share a single rule, so each is held to
+    it. Cached input is a part of the input: a turn that reports no breakdown
+    is counted in full, as though nothing came from cache.
+    """
+    task, item = task_and_item
+    asks = _response(
+        output=[_fc("c1", "read_deliverable", op="inspect_structure",
+                    path="report.xlsx")],
+        in_tok=100, out_tok=30, cached_tok=None,
+    )
+    finishes = _response(output=[_final(json.dumps({
+        "verdict": "pass", "partial_score": 1.0,
+        "evidence": "kind=xlsx, 1 sheet", "confidence": 0.95,
+        "reasoning": "ok", "tool_calls_made": 1,
+    }))], in_tok=40, out_tok=6, cached_tok=4)
+    judge = ToolCallingJudge(
+        client=FakeClient(ScriptedResponses([asks, finishes])),
+        model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE,
+    )
+
+    res = judge.judge_item(task=task, item=item,
+                           deliverable_dir=str(deliverable_dir),
+                           file_names=["report.xlsx"])
+
+    assert res.verdict == "pass"
+    assert res.input_tokens == 140
+    assert res.output_tokens == 36
+    assert res.cached_tokens == 4      # the turn that reported none counts none
+    assert res.usage_complete is True
 
 
 def test_empty_final_response_retries_once_without_tools(


### PR DESCRIPTION
## 무엇이 잘못됐는가

캐시된 입력 토큰은 입력 토큰에 **더해지는** 값이 아니라 그 **일부**다.
`CallUsage` 의 문서 문자열과 `core/cost_receipts.py:396-398` 이 그렇게
정의한다. 따라서 프롬프트 캐시 내역이 오지 않은 응답은 *사용량을 모르는*
응답이 아니라, *캐시에서 온 것이 없다*고 말하는 응답이다. 그 경우 전부
비캐시 요율로 계산되므로 청구액을 과소가 아니라 **과대** 계상할 뿐이다.

이 저장소에는 그 규칙을 이미 옳게 구현한 곳이 **둘** 있다.

| 위치 | 내역이 없을 때의 처리 |
|---|---|
| `core/cost_receipts.py:457,460` `price_call` | 영수증을 부분(partial)으로 표시하지 **않는다**. `cached = usage.cached_input_tokens or 0` |
| `core/agentic_sandbox_runner.py:736-749` `_usage` | 내역 객체가 없으면 캐시 0 으로 **완전한** 값을 돌려준다 |

그런데 자체 토큰 합계를 들고 있는 **세 곳**은 각자 자기 사본을 두고,
셋 다 자신들이 값을 넣는 영수증 원장보다 **엄격한** 규칙을 만들어 냈다.
내역이 없으면 `usage_complete` 를 내린 것이다.

- `core/perception/audio.py:229-232`
- `core/perception/vision.py:289-292`
- `core/tool_calling_judge.py:734-738`

## 무엇이 부서졌는가

듣기 모델 `gpt-audio-1.5` 는 실제로 `input_tokens_details` 를 보내지
않는다. 그래서 오디오 항목이 하나라도 있는 과제는 항상
`usage_complete=false` 가 되고, `step8_grade._track2_task_runtime_error`
(1202-1227) 의 토큰 회계 가드가 `"usage_incomplete"` 를 돌려줘
`step8_grade.py` 가 rc=6 으로 종료한다. `grade-run.yml` 은 rc=0 과 rc=7
만 성공으로 보므로, **과제 17개짜리 샤드 하나가 통째로 실패했다 — 이미
값을 치른 뒤에.**

## 무엇을 고쳤는가

규칙이 이제 `core/cost_metering.read_reported_usage` 한 곳에만 있다.
세 호출부는 모두 이 함수를 부른다. 사용량이 불완전한 경우는 정확히 셋이다.

1. 사용량 블록 자체가 오지 않았을 때
2. 입력이나 출력 수치가 없거나 수치가 아닐 때
3. 캐시에서 온 토큰이 보낸 토큰보다 많다는 모순이 있을 때 — `price_call`
   이 값을 매기기 전에 하는 검사와 같다

새 자료형 `ReportedUsage` 는 `CallUsage` 와 **의도적으로 다르다**.
`CallUsage` 는 원장이 저장하는 것으로, 없는 수치는 영원히 `None` 이어야
하고 0 이 되어서는 안 된다. `ReportedUsage` 는 *합계를 들고 있는
호출자*가 필요한 것으로, 더할 수 있는 수치와 그 합계를 아직 발표할 수
있는지를 말하는 깃발 하나다.

## 세 곳 중 하나만 실제 버그다

| 호출부 | 담당 모델 | 성격 |
|---|---|---|
| `perception/audio.py` | `gpt-audio-1.5` | **실제 버그.** 이 모델이 내역을 안 보내서 샤드가 죽었다 |
| `perception/vision.py` | `gpt-5.6-sol` | 일관성 수정. 이 모델은 내역을 보내므로 한 번도 발동한 적 없다 |
| `tool_calling_judge.py` | `gpt-5.6-sol` | 일관성 수정. 위와 같다 |

1단계(30과제) 산출물의 실제 집계로 확인했다: 항목 modality 는
`{'text': 1286, 'formatting': 69, 'visual': 77, 'mixed': 1}` — **오디오 0건**,
인지 항목 78건 전부 시각이고 전부 `usage_complete: True`, 사용량 불완전
항목 0건. 보기·심판 경로가 이 읽기로 실패한 적이 없다는 증거다.

두 곳도 각각 시험으로 고정했다. 규칙을 한 곳에 모은 이유가 세 사본이
서로 어긋난 것이었으므로, 각 호출부가 그 규칙을 지키는지 개별로 묶어야
같은 일이 반복되지 않는다.

## 의도한 엄격화 (검토 요망)

이제 `extract_usage`/`_as_int` 를 거치므로, 입력 토큰이 `None`, 불리언,
음수, 정수가 아닌 값으로 오면 사용량을 **불완전으로 표시한다**. 기존
인라인 코드 `int(getattr(usage, "input_tokens", 0) or 0)` 은 이런 값을
조용히 숫자로 만들었다. 이것은 완화가 아니라 강화이며, 실패 방향이
정직한 쪽이다. 명시적으로 밝혀 둔다.

## 내역이 없었다는 사실은 사라지지 않는다

작업 기술서는 "내역이 제공되지 않았음을 기록해 구분이 조용히 뭉개지지
않게 하라"고 요구했다. **그 요구는 이미 충족돼 있다.**
`core/grader.py:287` 이 인지 클라이언트를 계량하므로
(`cost_recorder.meter(client, provider="azure", stage=STAGE_PERCEPTION)`),
모든 인지 호출은 영수증을 남기고 거기에 `cached_input_tokens` 가 `0` 이
아니라 **`None`** 으로 들어간다. 원장에서 `None` 은 `0` 이 아니다.

그래서 새 필드를 만들지 **않았다**. 만들었다면 이 수정이 없애려는 바로
그 중복을 하나 더 만드는 셈이다. 지불면 payload 도 바뀌지 않는다 —
`visualProvenanceEntry` 는 `additionalProperties: false` 이고 그
`vision` 필드는 다섯 키만 갖는 `visualVision` 을 `$ref` 하며,
`VisualEvidenceEntry.to_provenance_dict()` (`core/tool_calling_judge.py:202-225`)
가 정확히 그 다섯 개로 투영한다.

## 검증

- `pytest -q` 전체: **5649 passed, 9 skipped, 45 deselected** (675.77s)
- 회귀 시험이 실제로 버그를 잡는지 확인: 옛 규칙을 일시 복원하니
  새 시험 6개가 세 호출부 전부에서 실패했고, 되돌리니 전부 통과했다
- 변경한 네 파일의 mypy 오류 수: **main 26개 → 이 가지 26개** (증가 없음)

## 병합 시점 — 샤드가 도는 동안은 안 된다

`compute_grader_source_hash` 는 `core/**/*.py` 전부를 해시하므로 이
변경은 `grader_source_hash` 를 바꾼다. 지금 유료 샤드 10개가 돌고 있고,
`step9_merge_shards.py:133-147` 은 모든 샤드가 같은 해시를 보고할 것을
요구한다. **돌고 있는 샤드가 다 끝난 뒤에 병합해야 한다.**

이 가지만 반영한 값 (참고용, #72 가 들어가면 또 바뀐다):

```
gold_ceiling_185_v2_sol_max   072da1e9d6764f854d0880dc42e11520a31966e45624d7d8bcbf0694168aa9ec
gold_ceiling_30_v2_sol_max    9e67d6b9cfe8c24a30b6e5b3bd4a2a74815a1679956bd83d6242521772519d66
```

재배포에 쓸 최종 값은 #72 까지 병합한 뒤 다시 계산해야 한다.
