### PR TITLE
fix(grading): 오디오 콘텐츠 파트를 Responses API 형식으로 보낸다

### DIFF
--- a/batch-runner/core/perception/audio.py
+++ b/batch-runner/core/perception/audio.py
@@ -50,6 +50,13 @@ AUDIO_CALL_CAP = 3
 #: than keeping a second copy.
 AUDIO_TRIM_SECONDS = 30
 
+#: The only container formats the Responses API accepts on an ``input_audio``
+#: content part (``openai.types.responses.response_input_audio_param.InputAudio``
+#: types ``format`` as ``Literal["mp3", "wav"]``). Anything else is rejected
+#: with a 400 before the model is reached, so a clip that cannot be presented
+#: as one of these is refused here rather than paid for and bounced.
+SUPPORTED_AUDIO_FORMATS = ("mp3", "wav")
+
 
 @dataclass(frozen=True)
 class AudioVerdict:
@@ -110,12 +117,23 @@ def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS
 
     Uses PyAV (wheel bundles ffmpeg per env audit). Falls back to
     sending the raw file if PyAV cannot decode (e.g. exotic codec).
+
+    The file is only handed over untouched when it is *known* to be short
+    enough and already carries a format the API accepts. A clip whose
+    duration the container does not report is re-encoded rather than sent
+    whole: "no duration" is not "short", and a studio stem that declines to
+    say how long it is would otherwise go out at its full size.
     """
+    fmt = _guess_format(path)
+
+    def raw() -> Tuple[bytes, str]:
+        with open(path, "rb") as fh:
+            return fh.read(), fmt
+
     try:
         import av  # type: ignore
     except ImportError:
-        with open(path, "rb") as fh:
-            return fh.read(), _guess_format(path)
+        return raw()
 
     try:
         container = av.open(path)
@@ -123,9 +141,12 @@ def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS
             stream = container.streams.audio[0]
             duration_s = (float(container.duration) / 1_000_000.0
                           if container.duration else None)
-            if duration_s is None or duration_s <= max_seconds:
-                with open(path, "rb") as fh:
-                    return fh.read(), _guess_format(path)
+            if (
+                duration_s is not None
+                and duration_s <= max_seconds
+                and fmt in SUPPORTED_AUDIO_FORMATS
+            ):
+                return raw()
             # Re-encode head slice to WAV in memory.
             import io
             buf = io.BytesIO()
@@ -145,8 +166,7 @@ def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS
         finally:
             container.close()
     except Exception:
-        with open(path, "rb") as fh:
-            return fh.read(), _guess_format(path)
+        return raw()
 
 
 def _guess_format(path: str) -> str:
@@ -196,6 +216,19 @@ class AudioPerception:
                 reasoning=f"audio preparation failed: {type(exc).__name__}",
                 judge_error=public_task_error_text(exc),
             )
+        if fmt not in SUPPORTED_AUDIO_FORMATS:
+            # Refused before the call, not after it. The API rejects an
+            # unsupported container outright, so sending it spends a slot from
+            # ``call_cap`` and buys a 400. No call goes out, so nothing is
+            # billed and the usage this verdict reports — zero — is complete.
+            return AudioVerdict(
+                verdict="judge_error",
+                partial_score=0.0,
+                evidence="",
+                confidence=0.0,
+                reasoning=f"unsupported audio format: {fmt}",
+                judge_error="unsupported_audio_format",
+            )
         b64 = base64.b64encode(data).decode("ascii")
         self._calls_used += 1
         call_started = time.perf_counter()
@@ -213,7 +246,7 @@ class AudioPerception:
                             {"type": "input_text",
                              "text": f"{_AUDIO_PROMPT_HEADER}\n\nCriterion:\n{criterion}"},
                             {"type": "input_audio",
-                             "audio": {"data": b64, "format": fmt}},
+                             "input_audio": {"data": b64, "format": fmt}},
                         ],
                     }
                 ],

--- a/batch-runner/tests/test_audio_rejection_stops_a_track2_shard.py
+++ b/batch-runner/tests/test_audio_rejection_stops_a_track2_shard.py
@@ -1,0 +1,339 @@
+"""One rejected audio call ended a 17-task shard. This is that chain, offline.
+
+Stage 3 shard 1 of 11 died twice at the same place — run 33239138322 and its
+re-run 33241377185, both at task 2 of 17, both with ``rc=6`` and the same
+message::
+
+    ERROR: Track 2 grading stopped after runtime failure for
+    38889c3b-e3d4-49c8-816a-3cc8e5313aba: usage_incomplete
+
+The task had already been graded (40.9 of 62). What stopped the run was not
+the grade but an integrity check, and what tripped that check was three audio
+sub-judge calls that the provider refused. The cause was a malformed request:
+the content part put its payload under ``audio`` where the Responses API
+requires ``input_audio``, so every audio call ever made by this pipeline was
+rejected with a 400 before it reached a model. The suite did not catch it
+because the audio test asserted the key by hand, and asserted it wrong.
+
+The shape itself is pinned in ``test_perception_audio``. What this module
+pins is the *consequence* — the chain that turned one refused call into a
+dead shard — because that is the part that made the failure expensive rather
+than merely wrong:
+
+    a rejected call reports usage_complete=False
+        -> the visual prepass ANDs it into the item
+            -> the task ANDs every item
+                -> _track2_task_runtime_error returned "usage_incomplete"
+                    -> step8_grade returned GRADE_EXIT_RUNTIME_FAILURE
+
+Each hop was a deliberate design decision and none was wrong on its own.
+Together they meant an unproven perception path could end a paid run over
+fifteen tasks that were never attempted.
+
+The chain is now cut in three places, by three changes that only work as a
+set, and this module is where the set is held together — each of the three
+has its own tests, but none of them can see what the other two do to the
+same failure:
+
+* the request carries ``input_audio``, so the call is not refused at all;
+* an item the listening model never answered is a ``judge_error`` and leaves
+  the score, instead of being marked as a fault in the deliverable;
+* an unknown token count no longer stops the run, because it says nothing
+  about whether the marking was right — only about what it cost.
+
+So the first two hops still hold, deliberately: a call that really does fail
+still reports its usage as unknown, and that flag still propagates. What no
+longer follows is the shard's death. If someone reconnects those last two
+hops, this module says which property they gave back.
+
+Nothing here calls a model. It builds verdicts and task dictionaries in
+memory and asks the real functions what they make of them.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import step8_grade as s8  # noqa: E402
+from core.perception.audio import AudioPerception, AudioVerdict  # noqa: E402
+from core.tool_calling_judge import (  # noqa: E402
+    ToolCallingJudge,
+    VisualPrepassResult,
+)
+
+
+class _RejectingResponses:
+    """A provider that refuses the request, the way a 400 arrives in-process."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        raise BadRequestError("invalid content part")
+
+
+class BadRequestError(Exception):
+    """Stands in for ``openai.BadRequestError``.
+
+    Only the class *name* travels: ``public_provider_error_text`` publishes
+    ``provider_error:<TypeName>`` and deliberately drops the message, so the
+    grade file records the type and nothing that could carry a prompt or an
+    endpoint. Naming the local double the same thing is what makes the
+    evidence string below identical to the one in the failed run.
+    """
+
+
+class _Client:
+    def __init__(self, responses) -> None:
+        self.responses = responses
+
+
+@pytest.fixture
+def wav_file(tmp_path: Path) -> Path:
+    import struct
+    import wave
+
+    p = tmp_path / "stem.wav"
+    with wave.open(str(p), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(8000)
+        w.writeframes(b"".join(struct.pack("<h", (i % 50) * 300)
+                               for i in range(8000)))
+    return p
+
+
+def _task(*, items: list[dict], usage_complete: bool, error=None) -> dict:
+    return {"task_id": "38889c3b", "error": error, "items": items,
+            "usage_complete": usage_complete}
+
+
+def _item(*, usage_complete: bool, verdict: str = "fail") -> dict:
+    return {"verdict": verdict, "score_excluded": False,
+            "usage_complete": usage_complete, "routing_modality": "audio"}
+
+
+# ── hop 1: the refused call ──────────────────────────────────────────
+
+
+def test_a_refused_audio_call_reports_its_usage_as_incomplete(wav_file):
+    """The verdict that came back from all three real calls.
+
+    ``usage_complete`` is initialised ``False`` and only becomes ``True``
+    once a reply has been read, so a call that raises reports ``False`` — it
+    was sent, and this process cannot say what it cost.
+
+    That is the honest reading for a timeout. For a 400 it overstates the
+    doubt, since a rejected request is not billed; the distinction is noted
+    here rather than acted on, because with the request shape corrected this
+    path stops being reached and narrowing it would weaken the same check for
+    the failures where the doubt is real.
+    """
+    client = _Client(_RejectingResponses())
+    verdict = AudioPerception(client=client).judge(
+        criterion="the mix is free of clipping", audio_path=str(wav_file)
+    )
+
+    assert isinstance(verdict, AudioVerdict)
+    assert verdict.verdict == "judge_error"
+    assert verdict.judge_error == "provider_error:BadRequestError"
+    assert verdict.reasoning == "audio call failed: BadRequestError"
+    assert verdict.api_call_count == 1
+    assert (verdict.input_tokens, verdict.output_tokens) == (0, 0)
+    assert verdict.usage_complete is False
+
+
+# ── hop 2: the prepass ───────────────────────────────────────────────
+
+
+def test_the_prepass_takes_the_incomplete_flag_from_any_one_tool_result(
+    wav_file,
+):
+    """One bad perception result is enough; the rest cannot repair it.
+
+    The accumulator ANDs, so ordering does not matter and a later good call
+    never restores the flag. This is why the real task reported three audio
+    calls with zero tokens against 111 grading calls that all reported usage.
+    """
+    client = _Client(_RejectingResponses())
+    refused = AudioPerception(client=client).judge(
+        criterion="x", audio_path=str(wav_file)
+    ).to_dict()
+    good = AudioVerdict(verdict="pass", partial_score=1.0, evidence="",
+                        confidence=1.0, reasoning="", api_call_count=1,
+                        input_tokens=900, output_tokens=40).to_dict()
+
+    prepass = VisualPrepassResult()
+    assert prepass.usage_complete is True
+    ToolCallingJudge._accumulate_perception_result(prepass, {"data": refused})
+    assert prepass.usage_complete is False
+    ToolCallingJudge._accumulate_perception_result(prepass, {"data": good})
+    assert prepass.usage_complete is False, "a good call must not repair it"
+
+    assert prepass.perception_call_count == 2
+    assert prepass.perception_input_tokens == 900
+
+
+# ── hops 3 and 4: the gate and the exit code ─────────────────────────
+
+
+def test_an_unknown_token_count_no_longer_stops_the_whole_run():
+    """The hop that cost sixteen unattempted tasks, cut.
+
+    The flag still travels — hops 1 and 2 above are unchanged — but the gate
+    no longer reads it as a reason to stop. It never described the marking:
+    an item whose tokens went uncounted was graded exactly as carefully as
+    one whose tokens arrived. What is genuinely unknown is the bill, and that
+    is carried by the task's own ``usage_complete`` into ``summary.cost``, so
+    the run still refuses to publish a cost it cannot stand behind.
+
+    Both shapes are checked because they can differ: the task-level roll-up
+    and any single item's flag were separate reasons to abort, and leaving
+    either one connected would leave the shard just as killable.
+    """
+    assert s8._track2_task_runtime_error(
+        _task(items=[_item(usage_complete=True)], usage_complete=True)
+    ) is None
+
+    assert s8._track2_task_runtime_error(
+        _task(items=[_item(usage_complete=True)], usage_complete=False)
+    ) is None
+
+    assert s8._track2_task_runtime_error(
+        _task(
+            items=[_item(usage_complete=True), _item(usage_complete=False)],
+            usage_complete=True,
+        )
+    ) is None
+
+
+def test_marks_nobody_can_read_still_stop_the_run():
+    """What the gate is still for, so that cutting one hop did not cut them all.
+
+    A number no reader can interpret is worse than no number, so a task the
+    grader gave up on, items that are not a list, and a judge error left
+    inside the score it should have been excluded from all still end the
+    shard. Naming them here keeps the previous test honest: it asserts a
+    specific hop was removed, not that the gate was emptied.
+    """
+    assert s8._track2_task_runtime_error(
+        _task(items=[_item(usage_complete=True)], usage_complete=True,
+              error="judge_transport_failure")
+    ) == "judge_transport_failure"
+
+    assert s8._track2_task_runtime_error(
+        {"task_id": "t", "error": None, "items": "not-a-list"}
+    ) is not None
+
+    assert s8._track2_task_runtime_error(
+        _task(items=[{"verdict": "judge_error", "score_excluded": False,
+                      "usage_complete": True}], usage_complete=True)
+    ) == "invalid_score_exclusion"
+
+
+def test_the_repaired_chain_end_to_end_on_the_item_that_killed_shard_one():
+    """The join the three changes only satisfy together.
+
+    Each change is tested where it lives, but none of those tests can see the
+    other two: the listening fix does not know what the gate does with its
+    verdict, and the gate does not know how the verdict was reached. This is
+    the handover — the exact item dictionary the judge now emits for a call
+    that was never answered, handed to the exact gate that decides whether
+    the shard lives.
+
+    ``verdict="judge_error"`` with ``score_excluded=True`` is what the item
+    became; ``usage_complete=False`` is what the failed call still costs the
+    run. A gate that objected to either field would put the shard's death
+    back, one change short of the set.
+    """
+    item_the_judge_now_emits = {
+        "verdict": "judge_error",
+        "judge_error": "audio_perception_failed:provider_error:BadRequestError",
+        "score_excluded": True,
+        "usage_complete": False,
+        "routing_modality": "audio",
+    }
+
+    assert s8._track2_task_runtime_error(
+        _task(items=[item_the_judge_now_emits, _item(usage_complete=True,
+                                                     verdict="pass")],
+              usage_complete=False)
+    ) is None
+
+
+def test_the_three_tolerated_errors_stay_tolerated():
+    """Selection outcomes are findings about the deliverable, not faults.
+
+    A task with nothing to mark is a result the corpus is allowed to contain.
+    Were these to start aborting the run, a gold corpus with one empty
+    submission could never be graded at all.
+    """
+    for tolerated in ("all_items_score_excluded", "no_deliverables",
+                      "selection_error"):
+        assert s8._track2_task_runtime_error(
+            _task(items=[_item(usage_complete=True)], usage_complete=True,
+                  error=tolerated)
+        ) is None
+
+    assert s8._track2_task_runtime_error(
+        _task(items=[_item(usage_complete=True)], usage_complete=True,
+              error="usage_incomplete")
+    ) == "usage_incomplete"
+
+
+def test_a_judge_error_item_must_be_excluded_from_the_score():
+    """The other half of the same gate, and the reason the ceiling held.
+
+    An item the judge could not decide has no score, so counting it as zero
+    would depress a ceiling measurement for an infrastructure reason. The gate
+    refuses a run where one is scored anyway.
+
+    Worth reading beside the real failure: the three refused audio items came
+    back ``fail``, not ``judge_error``, because the main judge was told its
+    tool had failed and then decided for itself. So this check passed and the
+    usage check is what caught them — but their zeros were counted, which is
+    why 65.97% for that task is not a ceiling and must not be read as one.
+    """
+    assert s8._track2_task_runtime_error(
+        _task(items=[{"verdict": "judge_error", "score_excluded": True,
+                      "usage_complete": True}], usage_complete=True)
+    ) is None
+
+    assert s8._track2_task_runtime_error(
+        _task(items=[{"verdict": "judge_error", "score_excluded": False,
+                      "usage_complete": True}], usage_complete=True)
+    ) == "invalid_score_exclusion"
+
+
+def test_a_runtime_failure_leaves_its_partial_result_uncommitted():
+    """Why this failure cost two runs and left nothing behind in git.
+
+    ``step8_grade`` does write a diagnostic partial before returning — the
+    grade for the task that failed, and for the one before it, was computed
+    and saved. But the workflow commits a grade file only when the step exits
+    0 or 7, and a runtime failure exits 6, so that partial survived only as a
+    30-day artifact. Nothing in the repository records that the work happened.
+
+    The exit-code constants are local to ``main``, so the contract is
+    read from the workflow instead: this asserts which return codes reach the
+    commit, which is the half that decides whether paid work is preserved.
+    """
+    workflow = (Path(__file__).resolve().parents[2]
+                / ".github/workflows/grade-run.yml").read_text(encoding="utf-8")
+    step = workflow.index("- name: Commit grade result")
+    condition = workflow[step:workflow.index("\n        env:", step)]
+
+    accepted = set(re.findall(r"steps\.grade\.outputs\.rc == '(\d+)'",
+                              condition))
+    assert accepted == {"0", "7"}, (
+        "the commit gate changed; a run that now reaches it, or no longer "
+        "does, changes whether paid grades survive as commits"
+    )
+    assert "6" not in accepted

--- a/batch-runner/tests/test_perception_audio.py
+++ b/batch-runner/tests/test_perception_audio.py
@@ -3,14 +3,39 @@
 from __future__ import annotations
 
 import struct
+import typing
 import wave
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import typing_extensions
+from openai.types.responses.response_input_audio_param import (
+    InputAudio,
+    ResponseInputAudioParam,
+)
 
 from core.perception import AUDIO_CALL_CAP, AudioPerception, AudioVerdict
+from core.perception.audio import SUPPORTED_AUDIO_FORMATS
+
+
+def _sdk_keys(typed_dict: type) -> set[str]:
+    """The keys an ``openai`` request TypedDict declares.
+
+    Read through ``typing_extensions`` rather than ``__required_keys__``: the
+    SDK writes its annotations as strings and marks them with
+    ``typing_extensions.Required``, which the 3.10 stdlib does not resolve — it
+    reports every key as optional and ``__required_keys__`` comes back empty,
+    so a check built on it would pass against anything.
+    """
+    return set(typing_extensions.get_type_hints(typed_dict))
+
+
+def _sdk_audio_formats() -> set[str]:
+    """The container formats the SDK's ``InputAudio.format`` literal admits."""
+    hints = typing_extensions.get_type_hints(InputAudio)
+    return set(typing.get_args(hints["format"]))
 
 
 # ── Fakes ────────────────────────────────────────────────────────────
@@ -128,7 +153,21 @@ def test_a_reply_that_reports_no_tokens_at_all_is_not_counted(wav_file):
     assert v.usage_complete is False
 
 
-def test_request_shape_includes_audio_block(wav_file):
+def test_request_shape_matches_the_sdk_audio_content_part(wav_file):
+    """The audio block is checked against the SDK type, not against belief.
+
+    This assertion used to be written by hand, and it was wrong twice: it
+    accepted the payload under the key ``audio`` (the API requires
+    ``input_audio``) and it accepted ``flac``/``ogg``/``m4a``/``aac`` as
+    formats (the API takes ``mp3`` and ``wav``). Both mistakes are invisible
+    to a fake client, which accepts any keyword argument, so the suite stayed
+    green while every real audio call was rejected with a 400 before reaching
+    the model.
+
+    So the shape is read off ``ResponseInputAudioParam`` — the same generated
+    type the SDK serialises against — and a future change to the wire format
+    fails here instead of failing in a paid run.
+    """
     client = FakeClient(FakeResponses())
     ap = AudioPerception(client=client, deployment="gpt-audio-1.5")
     ap.judge(criterion="x", audio_path=str(wav_file))
@@ -139,9 +178,56 @@ def test_request_shape_includes_audio_block(wav_file):
     content = sent["input"][0]["content"]
     kinds = {b["type"] for b in content}
     assert {"input_text", "input_audio"}.issubset(kinds)
-    audio_block = next(b for b in content if b["type"] == "input_audio")
-    assert audio_block["audio"]["format"] in ("wav", "mp3", "flac", "ogg", "m4a", "aac")
-    assert audio_block["audio"]["data"]  # base64 non-empty
+
+    block = next(b for b in content if b["type"] == "input_audio")
+    assert set(block) == _sdk_keys(ResponseInputAudioParam), (
+        f"audio content part carries {sorted(block)}, but the SDK declares "
+        f"{sorted(_sdk_keys(ResponseInputAudioParam))}"
+    )
+    payload = block["input_audio"]
+    assert set(payload) == _sdk_keys(InputAudio)
+    assert payload["format"] in _sdk_audio_formats()
+    assert payload["data"]  # base64 non-empty
+
+
+def test_the_module_offers_exactly_the_formats_the_sdk_accepts():
+    """``SUPPORTED_AUDIO_FORMATS`` is the SDK's list, not a second opinion.
+
+    The refusal in ``judge`` is only as good as this tuple. If the API grows a
+    third format and this is not updated, clips it would have accepted get
+    turned away for free; if it shrinks and this is not updated, we go back to
+    paying for 400s.
+    """
+    assert set(SUPPORTED_AUDIO_FORMATS) == _sdk_audio_formats()
+
+
+def test_an_unsupported_container_is_refused_without_spending_a_call(tmp_path):
+    """A format the API will reject never becomes a request.
+
+    The call cap is three per task. Spending one of them on a container the
+    API refuses outright costs money and buys nothing, and — because the
+    rejection arrives as an exception from a call that *was* sent — it also
+    marks the item's usage incomplete, which is what aborts a Track 2 run.
+
+    Refusing here keeps all three properties right at once: no charge, the cap
+    intact, and usage that is complete at zero because nothing was sent.
+    """
+    clip = tmp_path / "stem.aiff"
+    clip.write_bytes(b"FORM\x00\x00\x00\x04AIFF")  # not decodable; ext is what matters
+    client = FakeClient(FakeResponses())
+    ap = AudioPerception(client=client)
+
+    verdict = ap.judge(criterion="x", audio_path=str(clip))
+
+    assert client.responses.calls == []
+    assert verdict.verdict == "judge_error"
+    assert verdict.judge_error == "unsupported_audio_format"
+    assert "aiff" in verdict.reasoning
+    assert ap.calls_used == 0
+    assert verdict.api_call_count == 0
+    assert verdict.usage_complete is True
+
+
 
 
 def test_call_cap_short_circuits(wav_file):


### PR DESCRIPTION
> **DRAFT — 병합 금지.** Stage 3 shard 10개가 아직 `a5f6e40`에서 실행 중입니다.
> 이 PR은 `grader_source_hash`를 바꾸므로, 병합 시점이 결과 보존을 좌우합니다. 아래 "병합 조건" 참조.

## 무슨 일이 있었나

Stage 3 shard 1/11이 두 번 같은 자리에서 죽었습니다.

| run | shard | 중단 지점 | rc | 결과 |
|---|---|---|---|---|
| [33239138322](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/33239138322) | 1/11 | task 2/17 `38889c3b` | 6 | `Commit grade result` **skipped** |
| [33241377185](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/33241377185) | 1/11 | 동일 | 6 | 동일 |

재시도로 같은 자리에서 죽었으니 일시적 장애가 아닙니다.

## 원인

`input_audio` 콘텐츠 파트는 페이로드를 **`input_audio`** 키에 담아야 합니다.
`openai.types.responses.response_input_audio_param`:

```python
class InputAudio(TypedDict, total=False):
    data: Required[str]
    format: Required[Literal["mp3", "wav"]]

class ResponseInputAudioParam(TypedDict, total=False):
    input_audio: Required[InputAudio]      # <- 여기
    type: Required[Literal["input_audio"]]
```

코드는 `{"type": "input_audio", "audio": {...}}`를 보내고 있었습니다.
모델에 닿기 전에 400으로 거절됩니다 — 조건 없이, 매번.

### 400 하나가 shard를 죽이는 경로

```
audio 호출 → 400 BadRequestError
  → audio.py except 경로가 usage_complete=False, api_call_count=1 반환
    → _accumulate_perception_result 가 prepass에 AND
      → item → task (grader.py:802 all(...))
        → _track2_task_runtime_error → "usage_incomplete"
          → rc=6 → 남은 15개 과제 중단
```

과제 자체는 이미 채점을 마친 상태였습니다(40.9/62, 65.97%). 채점이 아니라
**무결성 게이트**가 run을 세운 것입니다. 게이트는 제 역할을 했습니다.

### 왜 아무도 몰랐나

- 커밋된 전체 채점 기록에서 **오디오 라우팅 item 116개가 전부 `perception_called=False`**.
  이 코드는 프로덕션에서 한 번도 성공한 적이 없고, Stage 3이 첫 실전 실행이었습니다.
- 기존 테스트 `test_request_shape_includes_audio_block`은 **두 번 틀렸습니다** —
  키 이름(`audio`)도, 허용 포맷 집합(`flac`/`ogg`/`m4a`/`aac`)도. `FakeResponses.create(**kwargs)`가
  아무 키워드 인자나 받으므로 스위트는 초록인 채로 실전 호출은 전부 400을 맞았습니다.

## 무엇을 고쳤나

**1. 키 이름** (`core/perception/audio.py`) — `"audio"` → `"input_audio"`.

**2. 컨테이너 포맷 보장.** API는 mp3/wav만 받는데 `GRADER_AUDIO_EXTENSIONS`는
flac/ogg/m4a/aac도 오디오로 분류합니다.
- `_trim_audio_bytes`: 길이를 **알고** 짧고 **동시에** 지원 포맷일 때만 원본을 그대로 넘깁니다.
  기존에는 `duration_s is None`이면 원본을 통째로 보냈습니다 — "길이 불명"은 "짧다"가 아니고,
  길이를 보고하지 않는 스튜디오 스템은 전체 크기로 나갔습니다.
- `judge`: 그래도 지원 포맷이 아니면 **호출 전에** 거절합니다. 보내봐야 400이고 과제당 3회
  한도만 깎입니다. 호출이 나가지 않으므로 과금이 없고, 이 verdict가 보고하는 사용량 0은
  완전합니다(`usage_complete=True`) — 즉 게이트를 오염시키지 않습니다.

**건드리지 않은 것:** `usage_complete` 의미론과 Track 2 게이트. 불을 끄면 게이트는 저절로
조용해집니다. 게이트를 무르게 하면 gold ceiling 측정치가 인프라 이유로 조용히 낮아집니다.

## 테스트

`tests/test_perception_audio.py` — 손으로 적은 믿음 대신 SDK 타입에서 형식을 읽어 검증합니다.
`tests/test_audio_rejection_stops_a_track2_shard.py` — 400 → shard 중단까지 4단계를 모델 호출
없이 고정합니다.

되돌려서 확인했습니다:

| 되돌린 결함 | 실패하는 테스트 |
|---|---|
| `"input_audio"` → `"audio"` | `test_request_shape_matches_the_sdk_audio_content_part`<br>`audio content part carries ['audio', 'type'], but the SDK declares ['input_audio', 'type']` |
| 포맷 가드 2곳 제거 | `test_an_unsupported_container_is_refused_without_spending_a_call`<br>`format: 'aiff'` 페이로드가 실제로 전송됨 |

전체 백엔드 스위트: **수집 5650개, 실패 0** (`origin/main` 5642 → 5650, 추가한 8개와 정확히 일치).

두 번 돌렸고 통과/건너뜀 배분이 달랐습니다 — `5641 passed / 9 skipped`와 `5644 passed / 6 skipped`. 건너뛰는 것은 환경 의존 테스트뿐입니다: `main` 모듈 부재(2), seccomp TSYNC 미노출(1), LibreOffice 부재(3). 수집 수와 실패 0은 두 번 다 같습니다.

## 코퍼스 노출도 (모델 호출 없이 로컬 계산)

185개 gold 과제의 rubric에 `classify_criterion`을 돌린 결과:

- AUDIO로 라우팅되는 criterion을 가진 과제: **21개** (item 96개), **11개 shard 전부**에 분포
- 그중 실제로 오디오 파일이 있어 호출이 도달 가능한 과제: **3개**

| gold | shard | pos | task_id | 파일 | 상태 |
|---|---|---|---|---|---|
| 12 | 1/11 | 2 | `38889c3b` | `.zip` (내부 `.wav`, 179 MB) | 두 번 사망 |
| 46 | 2/11 | 5 | `e222075d` | `.mp4` | 통과한 것으로 보임 |
| 47 | 3/11 | 5 | `75401f7c` | `.mp4` | 통과한 것으로 보임 |

shard 2·3은 06:50에 채점을 시작해 2시간 45분 넘게 `in_progress`입니다. shard 1은
position 2에서 31분 만에 죽었으므로, 이들이 position 5에서 같은 결함을 만났다면 이미
죽었어야 합니다. `.mp4`는 `_EXT_KIND`에서 `video`로 분류되어 판정자가 `audio_judge`에
넘기지 않은 것으로 보입니다. **추정이며, 종료 시 확인이 필요합니다.**

## 병합 조건 — 읽어주세요

`core/perception/audio.py`는 `compute_grader_source_hash`의 대상입니다
(`step8_grade.py:157` `core_root.rglob("*")` + `.suffix == ".py"`). `tests/**`는 대상이 아닙니다.

`gold_ceiling_185_v2_sol_max.yaml` 기준 실측:

| | grader_source_hash |
|---|---|
| `a5f6e40` (현재 실행 중) | `ce7d4978bce9effc113708caca10a705d215eaf0cd8a759aa3bcc759799f0338` |
| 이 PR 적용 후 | `a116661d5f02002c30656f751cb9b4adce787886d2c14de08e8d23b3761b9368` |

`grader_source_hash`는 `step9_merge_shards.CONTRACT_IDENTITY_FIELDS`의 항목이고,
`_check_identity_fields(..., contract=True)`는 불일치 시 `ShardMergeError`를 던집니다.
**탈출구가 없습니다.** 그래서:

1. **shard 10개가 끝나기 전에 병합하면 안 됩니다.** rc=7 chunk-resume가 새 main을 체크아웃하면
   `_validate_grade_resume_identity`가 거부하고, 비용을 다 쓴 뒤에 실패합니다.
2. 병합 후 shard 1만 재실행하면 그 shard만 `a116661d…`가 되어 **11개 병합이 실패합니다.**
3. 한편 `ce7d4978…` 아래에서 과제 `38889c3b`는 **원리적으로 채점 불가능**합니다. 오디오 호출이
   무조건 400이고 게이트가 무조건 중단시키므로, 몇 번을 재실행해도 185/185에 도달할 수 없습니다.

세 사실을 합치면 결론은 하나입니다: **이 수정을 병합한 뒤 11개 shard 전부를 새 해시로
재실행해야 합니다.** 현재 실행 중인 10개는 182개 과제에 대한 유효한 측정으로 커밋되어
보존되지만, 185개 병합 결과로는 쓸 수 없습니다.

## 부수 발견 (이 PR 범위 밖)

1. `grader.py:1557`의 `AudioPerception`에는 `before_upstream_call`이 없습니다.
   `VisionPerception`(`:1546`)과 메인 판정자(`:1587`)는 둘 다 `self._apply_tpm_delay`를 받습니다.
   오디오 호출만 TPM 가드를 우회합니다.
2. 실패한 과제의 오디오 item 3개는 `judge_error`가 아니라 **`verdict: "fail"`,
   `score_excluded: false`** 로 채점됐습니다. 메인 판정자가 도구 실패를 통보받고 스스로 판단한
   결과입니다. gold ceiling 측정에서 인프라 이유로 0점이 계산에 들어갔다는 뜻이므로,
   65.97%는 천장으로 읽으면 안 됩니다.

