### PR TITLE
fix(grading): 한 과제의 토큰 집계 불명이 샤드 전체를 죽이지 않게 한다

### DIFF
--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -1095,8 +1095,20 @@ def _validate_grade_task_set(
         raise ValueError(
             f"existing grade contains runtime failures: {runtime_errors}"
         )
-    if existing["summary"]["cost"].get("usage_complete") is not True:
-        raise ValueError("existing grade has incomplete aggregate usage")
+    # A resumed chunk has to be able to load a payload whose cost total is
+    # legitimately incomplete, because an earlier chunk may have graded a task
+    # whose token counts never arrived. Those grades are still good; only the
+    # bill is unknown. What is still refused is a payload that will not say
+    # either way — the flag must be present and must be a boolean, so the fold
+    # that produces the run's total can never be handed a missing or
+    # truthy-ish value. `step9_merge_shards` demands exactly this of every
+    # shard it merges.
+    aggregate_usage = existing["summary"]["cost"].get("usage_complete")
+    if type(aggregate_usage) is not bool:
+        raise ValueError(
+            "existing grade aggregate usage flag is missing or not a boolean: "
+            f"{aggregate_usage!r}"
+        )
     return set(existing_ids)
 
 
@@ -1200,6 +1212,22 @@ def filter_tasks_for_config(
 
 
 def _track2_task_runtime_error(task: dict) -> str | None:
+    """Why this task's marks cannot be read, or ``None`` if they can.
+
+    Everything named here leaves the *score* unreadable: a task that already
+    carries a foreign error, items that are not a list, an item that is not an
+    object, or a judge error left sitting inside the score it should have been
+    excluded from. Any one of them stops the shard, because a number nobody
+    can read is worse than no number at all.
+
+    An incomplete token count is deliberately not on that list. It says
+    nothing about whether the marking was right — only that what the marking
+    cost is unknown. That is carried instead by the task's own
+    ``usage_complete``, which the aggregate folds into
+    ``summary.cost.usage_complete``, so the run still refuses to publish a
+    cost figure it cannot stand behind while the grades it *can* stand behind
+    survive.
+    """
     existing_error = task.get("error")
     if existing_error and existing_error not in {
         "all_items_score_excluded",
@@ -1220,10 +1248,6 @@ def _track2_task_runtime_error(task: dict) -> str | None:
         ):
             return "invalid_score_exclusion"
 
-    if task.get("usage_complete") is not True:
-        return "usage_incomplete"
-    if any(item.get("usage_complete") is not True for item in items):
-        return "usage_incomplete"
     return None
 
 
@@ -2331,6 +2355,21 @@ def main() -> int:
             runtime_error = _track2_task_runtime_error(row)
             if runtime_error is not None and not row.get("error"):
                 row["error"] = runtime_error
+            if runtime_error is None and row.get("usage_complete") is not True:
+                # Not an error, and deliberately not stamped as one: this
+                # task's marking is as good as every other task's, so it keeps
+                # its score and stays in the sector breakdown and the item
+                # rates. Only the bill is unknown, and this row's own
+                # `usage_complete: false` already says so — `summary.cost`
+                # folds it in, and the receipt for the task is filed partial.
+                # Said out loud here because a run that quietly stops being
+                # priceable is the thing worth noticing.
+                print(
+                    f"WARNING: {row['task_id']} reported incomplete token "
+                    "usage; its grades stand, but this run's cost total is "
+                    "no longer complete.",
+                    file=sys.stderr,
+                )
         task_payloads.append(row)
 
         print(

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -784,9 +784,16 @@ def test_track2_limit_three_mock_smoke(monkeypatch, tmp_path):
     assert payload["renderer_fingerprint"] == _RENDERER_FINGERPRINT
 
 
-def test_track2_incomplete_judge_error_stops_and_persists_diagnostic(
+def test_track2_runtime_failure_stops_and_persists_diagnostic(
     monkeypatch, tmp_path, capsys
 ):
+    """A task the grader itself gave up on halts the run, and says why.
+
+    This is the failure the halt exists for: the grader reported a transport
+    failure, so this task has no marks at all and the shard's total would be
+    a number no reader can interpret. The run stops, writes what it has as a
+    diagnostic, and keeps the details of a failed cleanup out of the log.
+    """
     _setup_workspace(tmp_path)
     _configure_track2(tmp_path)
     config_path = tmp_path / "grading_configs" / "default.yaml"
@@ -813,14 +820,13 @@ def test_track2_incomplete_judge_error_stops_and_persists_diagnostic(
             item.evidence = "BadRequestError: invalid prompt_cache_key"
             item.score_excluded = True
             item.judge_call_count = 1
-            item.usage_complete = False
             grade.total_awarded = 0.0
             grade.total_max = 0
             grade.pct = 0.0
             grade.pct_raw = 0.0
             grade.judge_call_count = 1
             grade.precheck_count = 0
-            grade.usage_complete = False
+            grade.error = "judge_transport_failure"
             return grade
 
         def close(self):
@@ -846,17 +852,89 @@ def test_track2_incomplete_judge_error_stops_and_persists_diagnostic(
         )
     )
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert payload["tasks"][0]["error"] == "usage_incomplete"
+    assert payload["run_status"] == "diagnostic"
+    assert payload["tasks"][0]["error"] == "judge_transport_failure"
     assert payload["summary"]["graded_tasks"] == 0
     assert payload["summary"]["error_tasks"] == 1
     assert payload["summary"]["openai_compat"]["avg_score_pct"] is None
     assert payload["summary"]["openai_compat"]["ci_pct"] is None
     assert payload["summary"]["openai_compat"]["perfect_count"] == 0
     assert payload["summary"]["wow"]["judge_error_rate"] == 1.0
-    assert payload["summary"]["cost"]["usage_complete"] is False
     stderr = capsys.readouterr().err
     assert "provider_error:OSError" in stderr
     assert _SENSITIVE_CLEANUP_DETAIL not in stderr
+
+
+def test_track2_incomplete_usage_keeps_the_grades_and_finishes(
+    monkeypatch, tmp_path, capsys
+):
+    """An unknown bill is not a wrong mark, and must not throw the marks away.
+
+    The listening model answers without a prompt-cache breakdown, which used
+    to be read as unknown usage. One such item set ``usage_complete`` false on
+    its task, the task tripped the halt, and a 17-task shard exited on rc=6
+    with every one of its API calls already paid for — including the calls for
+    the sixteen tasks that had nothing wrong with them.
+
+    So the run now finishes. The task keeps its score and stays in every rate
+    the report quotes, and the one thing that really is unknown — what it cost
+    — is what the run refuses to publish, through ``summary.cost``.
+    """
+    _setup_workspace(tmp_path)
+    _configure_track2(tmp_path)
+    config_path = tmp_path / "grading_configs" / "default.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["output"]["filename_template"] = (
+        "{exp_id}__{judge_slug}__{rubric_sha}__{prompt_v}.json"
+    )
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+
+    class _UnpriceableGrader(_FakeGrader):
+        def grade_task(self, task, deliverable_dir):
+            grade = super().grade_task(task, deliverable_dir)
+            grade.items[0].usage_complete = False
+            grade.usage_complete = False
+            return grade
+
+    monkeypatch.setattr(s8, "Grader", _UnpriceableGrader)
+    monkeypatch.setattr(
+        s8, "get_renderer_fingerprint", lambda: dict(_RENDERER_FINGERPRINT)
+    )
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py", "exp998_smoke_baseline_sample",
+        "--config", "grading_configs/default.yaml", "--force",
+    ])
+
+    assert s8.main() == 0
+    out = (
+        tmp_path
+        / "data/grades"
+        / (
+            "exp998_smoke_baseline_sample__gpt-5_4-pro__"
+            f"{_FakeLoader().rubric_sha}__v1.json"
+        )
+    )
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    task = payload["tasks"][0]
+
+    assert payload["run_status"] == "final"
+    assert task.get("error") in (None, "")
+    assert task["usage_complete"] is False
+    assert task["pct"] == 100.0
+    assert payload["summary"]["graded_tasks"] == len(payload["tasks"])
+    assert payload["summary"]["error_tasks"] == 0
+    # The mark survives everywhere a reader looks for it, including the
+    # breakdown that a stamped `error` used to drop the task out of.
+    assert payload["summary"]["openai_compat"]["avg_score_pct"] == 100.0
+    assert sum(
+        sector["task_count"]
+        for sector in payload["summary"]["wow"]["by_sector"].values()
+    ) == len(payload["tasks"])
+    # And the one thing that is genuinely unknown stays unpublished.
+    assert payload["summary"]["cost"]["usage_complete"] is False
+    assert "reported incomplete token usage" in capsys.readouterr().err
 
 
 def test_track2_runtime_error_allows_call_free_unscorable_selection():
@@ -1319,7 +1397,13 @@ def test_all_unscored_main_completes_without_formatting_null(
     assert "avg_pct=unscored" in capsys.readouterr().out
 
 
-def test_track2_incomplete_usage_is_runtime_failure():
+def test_track2_incomplete_usage_is_not_a_runtime_failure():
+    """The guard is about unreadable marks, not about an unknown bill.
+
+    Every field here that decides a score is sound: the item passed, it was
+    decided, it carries evidence. Only the token counts are missing. That
+    belongs to the cost claim, which ``usage_complete`` carries on its own.
+    """
     task = {
         "task_id": "task-001",
         "error": None,
@@ -1334,7 +1418,24 @@ def test_track2_incomplete_usage_is_runtime_failure():
         }],
     }
 
-    assert s8._track2_task_runtime_error(task) == "usage_incomplete"
+    assert s8._track2_task_runtime_error(task) is None
+
+
+def test_track2_unreadable_marks_still_stop_the_run():
+    """The other half of the split: what the guard is still for."""
+    unreadable = [
+        {"task_id": "t", "error": "judge_transport_failure", "items": []},
+        {"task_id": "t", "error": None, "items": "not-a-list"},
+        {"task_id": "t", "error": None, "items": ["not-an-object"]},
+        {
+            "task_id": "t",
+            "error": None,
+            "items": [{"verdict": "judge_error", "score_excluded": False}],
+        },
+    ]
+
+    for task in unreadable:
+        assert s8._track2_task_runtime_error(task) is not None, task
 
 
 def test_tasks_filter(monkeypatch, tmp_path):
@@ -2492,7 +2593,6 @@ def test_track2_resume_rejects_runtime_failure_before_grader(
     )
     payload = json.loads(out.read_text(encoding="utf-8"))
     payload["tasks"][0]["error"] = "judge_error"
-    payload["tasks"][0]["usage_complete"] = False
     payload["summary"] = s8._compute_summary(
         payload["tasks"],
         unpriced_models=["gpt-5.4-pro"],
@@ -2505,6 +2605,91 @@ def test_track2_resume_rejects_runtime_failure_before_grader(
 
     assert s8.main() != 0
     assert "runtime failures" in capsys.readouterr().err
+
+
+def test_track2_resume_accepts_a_chunk_whose_cost_is_unknown(
+    monkeypatch, tmp_path
+):
+    """The other end of the same fix: chunk two must be able to load chunk one.
+
+    A long shard grades in chunks, and each chunk reloads what the last one
+    wrote. If chunk one graded a task whose token counts never arrived, its
+    aggregate cost flag is legitimately false — and refusing to load that
+    payload would move the shard's death from the task to the next chunk
+    boundary, which is the same death with extra steps.
+    """
+    _setup_workspace(tmp_path)
+    _configure_track2(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(
+        s8, "get_renderer_fingerprint", lambda: dict(_RENDERER_FINGERPRINT)
+    )
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+    out = _seed_partial_grade(
+        tmp_path, ["task-001", "task-002"], dict(_RENDERER_FINGERPRINT)
+    )
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    payload["tasks"][0]["usage_complete"] = False
+    payload["summary"] = s8._compute_summary(
+        payload["tasks"],
+        unpriced_models=["gpt-5.4-pro"],
+    )
+    assert payload["summary"]["cost"]["usage_complete"] is False
+    out.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py", "exp998_smoke_baseline_sample",
+        "--config", "grading_configs/default.yaml", "--resume",
+    ])
+
+    assert s8.main() == 0
+    resumed = json.loads(out.read_text(encoding="utf-8"))
+    # The unknown cost is carried forward, not quietly healed by the resume.
+    assert resumed["summary"]["cost"]["usage_complete"] is False
+    assert len(resumed["tasks"]) == 3
+
+
+@pytest.mark.parametrize(
+    "flag", [None, "true", 1], ids=["missing", "string", "int"]
+)
+def test_track2_resume_rejects_a_chunk_that_will_not_say(
+    monkeypatch, tmp_path, capsys, flag
+):
+    """Loading a false flag is fine; loading no answer at all is not.
+
+    The merged total is a fold over every chunk's flag, so a value that is
+    absent, or that merely looks true, would silently become whatever `bool`
+    made of it. ``step9_merge_shards`` refuses the same three shapes.
+    """
+    _setup_workspace(tmp_path)
+    _configure_track2(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(
+        s8, "get_renderer_fingerprint", lambda: dict(_RENDERER_FINGERPRINT)
+    )
+
+    class _NeverConstruct:
+        def __init__(self, *args, **kwargs):
+            pytest.fail("Grader must not resume an unreadable cost flag")
+
+    monkeypatch.setattr(s8, "Grader", _NeverConstruct)
+    out = _seed_partial_grade(
+        tmp_path, ["task-001"], dict(_RENDERER_FINGERPRINT)
+    )
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    if flag is None:
+        payload["summary"]["cost"].pop("usage_complete", None)
+    else:
+        payload["summary"]["cost"]["usage_complete"] = flag
+    out.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py", "exp998_smoke_baseline_sample",
+        "--config", "grading_configs/default.yaml", "--resume",
+    ])
+
+    assert s8.main() != 0
+    assert "aggregate usage flag" in capsys.readouterr().err
 
 
 def test_track2_valid_cache_hit_checks_fingerprint_and_skips(


### PR DESCRIPTION
## 무엇이 잘못됐는가

한 과제의 **토큰 집계가 불완전하다**는 이유로, 그 과제의 채점 결과가 멀쩡한데도
샤드 전체가 죽는다.

`step8_grade.py` 의 `_track2_task_runtime_error` 는 "이 과제의 점수를 읽을 수
없는 이유"를 돌려주는 함수다. 여기에 `usage_incomplete` 가 섞여 있었다. 하지만
토큰 집계가 불완전하다는 것은 **채점이 틀렸다**는 말이 아니라 **그 채점에 든
비용을 모른다**는 말이다. 성질이 다른 두 가지가 한 목록에 있었다.

그 결과가 이것이다. 이미 채점이 **끝난** 과제 하나 때문에, 아직 채점하지 않은
나머지 과제까지 전부 버려진다. 그것도 샤드 값을 **이미 다 치른 뒤에**.

## 증거 — 샤드 1 이 같은 자리에서 두 번 죽었다

185 과제 금표준 코퍼스(Stage 3)를 11 샤드로 나눠 돌렸다. 샤드 1 은 두 번
디스패치됐고(`33239138322`, `33241377185`) 두 번 다 같은 자리에서 같은 이유로
죽었다.

```
SHARD 2/11: grading 17 of 185 tasks
[1/17] 7b08cd4d -> 92.1% (82.0/89)
[2/17] 38889c3b -> 72.3% (44.8/62)
ERROR: Track 2 grading stopped after runtime failure for
       38889c3b-e3d4-49c8-816a-3cc8e5313aba: usage_incomplete
[grade-step] step8_grade.py exited with rc=6
```

두 과제 모두 **점수가 나왔다**. 92.1% 와 72.3% 다. 그런데도 rc=6 으로 끝났고
17 과제 중 15 개는 시작조차 못 했다.

`38889c3b` 는 179 MB 짜리 `DEJA VU  STEMS .zip`(`.wav` 10 개)을 제출물로 갖는
185 과제 중 **유일한** 오디오 과제이고, 이 실행의 작업 목록에 `gpt-audio-1.5`
가 올라와 있다
(`AZURE_AI_WORKLOADS_JSON: ["grader=gpt-5.6-sol","grader=gpt-5.6-sol","grader=gpt-audio-1.5"]`).

### 근본 원인을 정정한다

이 PR 을 처음 열 때 나는 근본 원인이 "듣는 모델이 `input_tokens_details` 를
보내지 않는 것"이고 #266 이 그것을 고친다고 적었다. **그 설명은 틀렸다.**
실행 산출물을 내려받아 확인한 뒤 정정한다.

죽은 샤드의 진단 산출물에는 `38889c3b` 의 세 항목이 전부 이렇게 적혀 있다.

```
"evidence": "audio call failed: BadRequestError"
```

`BadRequestError` 는 HTTP 400 이다. 요청이 **모델에 닿기도 전에** 거절됐다.
원인은 콘텐츠 파트의 키를 `audio` 로 보낸 것이고, 설치된 SDK 타입
(`openai.types.responses.response_input_audio_param.ResponseInputAudioParam`)
은 `input_audio` 를 **필수**로 선언한다. 즉 이 호출은 조건에 상관없이 **매번**
거절됐다. 이것을 고치는 것은 **#267** 이다.

`#266` 은 이 경로를 구하지 못한다. #266 이 다루는 것은 **응답이 성공했는데
캐시 내역만 빠진** 경우다. 400 은 응답 자체가 없어서 토큰 블록이 아예 존재
하지 않는, #266 이 **의도적으로 `usage_complete=False` 로 남겨 두는** 바로 그
경우다. #266 은 그 자체로는 여전히 옳지만, 이 샤드를 살렸을 PR 은 아니다.

정정하고 나면 이 PR 의 자리는 오히려 더 분명해진다. 이것은 근본 원인 수정이
아니라 **마지막 방어선**이다. 어떤 모델이 어떤 이유로든 토큰 수를 알려주지
못하는 날이 와도, 그것 하나가 이미 채점된 과제들을 데리고 죽지는 못하게 한다.

### #267 과 겹치는 시험 하나

#267 이 `tests/test_audio_rejection_stops_a_track2_shard.py` 를 새로 넣는데,
그 안의 `test_an_item_with_incomplete_usage_stops_the_whole_run` 은 이 PR 이
**의도적으로 없애는** 동작(`usage_incomplete` → rc=6)을 고정한다. 두 PR 이
각자 자기 자리에서 옳고, 겹치는 것은 시험 하나뿐이다.

#267 은 실패 사슬 네 마디를 문서로 고정하는 시험이고, 이 PR 은 그 사슬의
**마지막 마디**를 끊는다. 따라서 병합 순서는 **#267 먼저, 이 PR 나중**이고,
이 PR 이 리베이스하면서 그 시험의 3·4 번째 마디를 새 동작으로 고쳐 쓴다.
없애지 않고 고쳐 쓴다 — 사슬이 어디까지 이어졌는지는 남길 값어치가 있다.

## 무엇을 바꾸는가

| 위치 | 전 | 후 |
|---|---|---|
| `_track2_task_runtime_error` | `usage_incomplete` 를 치명적 오류로 돌려줌 (2 곳) | 돌려주지 않음. 점수를 읽을 수 없게 만드는 것만 남김 |
| 재개 검증 (`_validate_grade_resume_identity` 경로) | 이전 청크의 `summary.cost.usage_complete` 가 `True` 가 아니면 거부 | **불리언이면** 통과. 없거나 문자열이면 여전히 거부 |
| 본 루프 호출부 | 없음 | 집계가 불완전한 과제를 만나면 stderr 에 `WARNING:` 한 줄 |

치명적 목록에 **남은** 것: 다른 오류를 이미 달고 있는 과제, `items` 가 리스트가
아닌 경우, 항목이 객체가 아닌 경우, 채점기 오류가 점수에서 제외되지 않은 채
들어앉은 경우. 넷 다 "점수를 읽을 수 없다"는 한 가지 말을 한다.

## 이것은 fail-closed 를 약화시킨다 — 왜 그래도 옳은가

숨기지 않고 적는다. 이 PR 은 닫혀 있던 문을 연다. 근거는 셋이다.

**1. 약화가 점수가 아니라 비용 주장에만 닿는다.** 지금까지 이 가드는 "비용을
모르겠다"는 신호를 받아 **점수**를 버렸다. 두 가지는 독립이다. 바뀐 뒤에도
`core/grader.py:802` 에서 과제의 `usage_complete` 는 항목들의 AND 이고,
`step8_grade.py` 에서 `summary.cost.usage_complete` 는 과제들의 AND 다. 모르는
것은 모른다고 계속 말한다. 다만 그것 때문에 아는 것까지 버리지는 않는다.

**2. 소비자 쪽은 이미 이 모양을 받도록 쓰여 있었다.**
`step9_merge_shards.py:950-967` 은 병합 대상 샤드의 집계 플래그가 `False` 여도
실패하지 않는다. `type(value) is bool` 만 요구하고, 경고를 한 번 내고, 값을
그대로 접어 올린다 — `"merged summary.cost.usage_complete is false; at least one
shard reported incomplete aggregate usage."` 즉 파이프라인의 뒷단은 이 payload 를
이미 기다리고 있었고, 앞단인 `step8_grade.py` 혼자 만들기를 거부하고 있었다.
이 PR 은 계약을 느슨하게 하는 게 아니라 **양쪽을 일치시킨다**.

**3. 더 엄격한 계약은 그대로 둔다.** 앵커(anchor) 쪽 계약은 의도적으로 더
엄격하며 건드리지 않았다. `scripts/analyze_grade_run.py:1276-1290` 의
`anchor_usage_incomplete` · `anchor_item_usage_incomplete` ·
`anchor_summary_usage_incomplete` 는 전부 그대로다.

재개 검증을 `is not True` 대신 **불리언 타입 검사**로 바꾼 것도 같은 이유다.
`is None` 만 막는 더 약한 형태로 다시 쓰는 것을 막기 위해, 문자열과 정수를 각각
거부하는 시험을 함께 넣었다.

## 조용히 넘어가지 않는다

집계가 불완전한 과제를 만나면 stderr 에 한 줄을 남긴다.

```
WARNING: <task_id> reported incomplete token usage; its grades stand,
         but this run's cost total is no longer complete.
```

값을 매길 수 없게 된 실행이 **아무 말 없이** 그렇게 되는 것이 실제로 위험한
쪽이기 때문이다.

## 시험

`tests/test_step8_grade.py` 에 넷을 새로 넣고 둘을 고쳐 썼다.

- `test_track2_incomplete_usage_keeps_the_grades_and_finishes` — 죽은 샤드를 그대로
  재현한다. rc=0, `run_status == "final"`, 과제에 `error` 없음,
  `usage_complete is False`, `pct == 100.0`, `graded_tasks == len(tasks)`,
  섹터 분해의 과제 수 합이 전체 과제 수와 같음(오류로 찍혔다면 섹터에서
  빠졌을 것이다), `summary.cost.usage_complete is False`, 경고 문구가 stderr 에 있음.
- `test_track2_unreadable_marks_still_stop_the_run` — 남겨 둔 네 가지 모양이 여전히
  실행을 세우는지.
- `test_track2_resume_accepts_a_chunk_whose_cost_is_unknown` — 비용이 불명인 이전
  청크에서 재개되는지, 재개 뒤에도 플래그가 `False` 로 남는지.
- `test_track2_resume_rejects_a_chunk_that_will_not_say` — 없음 / 문자열 / 정수를
  각각 거부하는지.
- `test_track2_incomplete_usage_is_not_a_runtime_failure` (이름 변경) 과
  `test_track2_runtime_failure_stops_and_persists_diagnostic` (이름 변경).

두 번째 것의 이름을 바꾸면서 하나를 알게 됐다. 원래 이 시험은
`score_excluded = False` 로 `invalid_score_exclusion` 을 노렸는데 rc=6 이 아니라
rc=5 가 나왔다. 스키마가 그 모양 자체를 금지하기 때문이다
(`judge_error` 가지 아래 `score_excluded: {"const": true}`). 즉
`invalid_score_exclusion` 은 끝에서 끝까지로는 **도달할 수 없는** 경로이고
스키마가 먼저 잡는다. 가드는 이중 방어로 남겨 뒀다.

**이 시험들에 이가 있는지 확인했다.** 옛 규칙을 되돌려 놓고 다시 돌리자 정확히
**6 개**가 깨졌다. 되돌린 뒤 `test_step8_grade.py` + `test_step9_merge_shards.py`
373 개 통과.

`mypy step8_grade.py --ignore-missing-imports`: 변경 전후 모두 41 errors — 동일.

## 병합 순서 주의

이 PR 은 `step8_grade.py` 를 건드리고, 그 파일은 `compute_grader_source_hash`
가 해시하는 대상에 들어 있다(`step8_grade.py:168`). 따라서 병합되는 순간
`grader_source_hash` 가 바뀐다. `step9_merge_shards.py` 는 `grader_source_hash`
를 `CONTRACT_IDENTITY_FIELDS` 로 두고 샤드 간 불일치를 `ShardMergeError` 로
**하드 실패** 처리한다. **채점 샤드가 하나라도 떠 있는 동안 병합하지 말 것.**
