### PR TITLE
fix(grading): 듣지 못한 항목을 제출물의 실패로 채점하지 않는다

### DIFF
--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -408,6 +408,38 @@ def _validated_final_envelope(
     return verdict, partial, confidence
 
 
+#: ``audio_judge`` refusals the judge can put right by asking again. Each one
+#: is a bad argument -- a path outside the allowlist, a path that is not a
+#: file, a member that is not in the archive, a ``member`` that is not a
+#: string -- and the tool answers with the message that says so, including
+#: the archive's actual contents. The judge is meant to read that and retry,
+#: so these must not end the item.
+_CORRECTABLE_AUDIO_ERROR_TYPES = frozenset({"bad_path", "bad_args", "bad_scope"})
+
+
+def _unanswerable_audio_reason(result: Mapping[str, Any]) -> Optional[str]:
+    """Why the listening model could not answer, or ``None`` if the judge asked wrong.
+
+    The distinction this draws is who has to act. A bad path is the judge's
+    to fix and it has what it needs to fix it. A sub-judge that ran and
+    returned an error, a sub-judge that was never configured, an exception on
+    the way -- none of those get better by asking again in the same way, and
+    none of them say anything about the deliverable.
+    """
+    if result.get("ok"):
+        return None
+    error_type = result.get("error_type")
+    if isinstance(error_type, str) and error_type in _CORRECTABLE_AUDIO_ERROR_TYPES:
+        return None
+    data = result.get("data")
+    if isinstance(data, Mapping):
+        # The sub-judge itself ran and reported why it could not answer;
+        # carry its own word for it rather than inventing a second vocabulary.
+        detail = data.get("judge_error") or "unknown"
+        return f"audio_perception_failed:{detail}"
+    return f"audio_perception_failed:{error_type or 'unknown'}"
+
+
 def _finalization_retry_reason(
     final_text: str,
     response: Any,
@@ -613,6 +645,13 @@ class ToolCallingJudge:
         usage_complete = prepass.usage_complete
         final_text = ""
         judge_error: Optional[str] = None
+        # What the listening model did for this item, kept apart from the
+        # tool-call tally because the two answer different questions. The
+        # tally says how many times it was asked; these say whether it ever
+        # actually answered. An item that asked and never got an answer
+        # cannot be marked from what it heard.
+        audio_answered = False
+        audio_unanswerable: Optional[str] = None
         finalization_only = False
         finalization_retries_used = 0
 
@@ -781,6 +820,12 @@ class ToolCallingJudge:
                     )
                     if tool_name == "audio_judge":
                         self._accumulate_perception_result(prepass, result)
+                        if result.get("ok"):
+                            audio_answered = True
+                        else:
+                            reason = _unanswerable_audio_reason(result)
+                            if reason is not None and audio_unanswerable is None:
+                                audio_unanswerable = reason
                     messages.append(self._function_call_output_message(fc, result))
                 # Loop again to let the model react to the tool outputs.
                 continue
@@ -820,6 +865,20 @@ class ToolCallingJudge:
             break
         else:
             judge_error = "max_iterations_exceeded"
+
+        # The listening model was asked and never answered, and no later
+        # attempt recovered. Whatever the judge wrote about this criterion, it
+        # did not write it from having heard the audio -- so the item is a
+        # judge error and is excluded from the score, exactly as a failed
+        # visual prepass already is. Scoring it instead would take marks off a
+        # deliverable for a failure on the grader's own side, which reads as
+        # the work being wrong when nothing about the work is known.
+        #
+        # An attempt that failed and then succeeded is not an error: the run
+        # heard the audio in the end, which is the only thing the mark depends
+        # on. Only "asked, never heard" excludes.
+        if judge_error is None and audio_unanswerable is not None and not audio_answered:
+            judge_error = audio_unanswerable
 
         return self._build_result(
             item=item,

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -1177,6 +1177,202 @@ def test_audio_tool_usage_is_recorded_as_perception(tmp_path, task_and_item):
     assert result.usage_complete is True
 
 
+def _audio_item() -> RubricItem:
+    return RubricItem(
+        rubric_item_id="audio-1",
+        criterion="The Master track contains no vocals (instrumental-only).",
+        score=2,
+        required=None,
+    )
+
+
+class _DeafAudio:
+    """A listening model that is asked and never answers."""
+
+    def __init__(self, judge_error: str = "provider_error:BadRequestError"):
+        self.judge_error = judge_error
+        self.calls = 0
+
+    def judge(self, **kwargs):
+        self.calls += 1
+        return SimpleNamespace(
+            judge_error=self.judge_error,
+            to_dict=lambda: {
+                "verdict": "judge_error", "partial_score": 0.0,
+                "evidence": "", "confidence": 0.0,
+                "reasoning": "audio call failed: BadRequestError",
+                "judge_error": self.judge_error,
+                "api_call_count": 1, "input_tokens": 0,
+                "output_tokens": 0, "cached_tokens": 0,
+                "latency_ms": 267.64, "usage_complete": False,
+            },
+        )
+
+
+def test_a_listening_call_that_never_answers_is_not_scored_as_a_failure(
+    tmp_path, task_and_item,
+):
+    """Taken from a real paid run, where it cost a gold deliverable six marks.
+
+    In run ``33241377185`` the gold task ``38889c3b`` had three audio items
+    come back ``verdict: "fail"``, ``awarded_score: 0.0``,
+    ``score_excluded: false``, each carrying
+    ``evidence: "audio call failed: BadRequestError"``. The listening model
+    had been rejected with a 400 and never heard anything; the judge read a
+    broken tool as an absent quality and marked the work down for it.
+
+    Nothing about the deliverable was known at that point, so nothing about
+    the deliverable may be asserted. The item is a judge error and leaves the
+    score, which is what a failed visual prepass has always done.
+    """
+    task, _ = task_and_item
+    (tmp_path / "stems.zip").write_bytes(b"PK\x03\x04fake")
+    audio = _DeafAudio()
+
+    client = FakeClient(ScriptedResponses([
+        _response(output=[_fc(
+            "audio-call", "audio_judge",
+            criterion=_audio_item().criterion, audio_path="stems.zip",
+        )], in_tok=20, out_tok=3, cached_tok=2),
+        # The judge does exactly what it did in the real run: writes a
+        # confident `fail` whose only evidence is the tool's error text.
+        _response(output=[_final(json.dumps({
+            "verdict": "fail", "partial_score": 0.0,
+            "evidence": "audio call failed: BadRequestError",
+            "confidence": 0.78, "reasoning": "could not verify",
+        }))], in_tok=25, out_tok=4, cached_tok=3),
+    ]))
+    judge = ToolCallingJudge(
+        client=client, model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=audio,
+    )
+
+    result = judge.judge_item(
+        task=task, item=_audio_item(), deliverable_dir=str(tmp_path),
+        file_names=["stems.zip"],
+    )
+
+    assert audio.calls == 1
+    assert result.verdict == "judge_error"
+    assert result.judge_error == "audio_perception_failed:provider_error:BadRequestError"
+    assert result.score_excluded is True
+    assert result.awarded_score == 0.0
+    # Still counted and still priced -- excluded from the score is not
+    # excluded from the receipt.
+    assert result.perception_called is True
+    assert result.perception_call_count == 1
+    assert result.usage_complete is False
+
+
+def test_a_listening_call_the_judge_asked_wrong_stays_the_judge_s_to_fix(
+    tmp_path, task_and_item,
+):
+    """A bad path is not a broken model, and must not end the item.
+
+    The tool answers with the message that says what was wrong, the judge is
+    meant to read it and ask again, and an item that goes on to be marked
+    from other evidence keeps its mark.
+    """
+    task, _ = task_and_item
+    (tmp_path / "stems.zip").write_bytes(b"PK\x03\x04fake")
+
+    class _NeverReached:
+        def judge(self, **kwargs):  # pragma: no cover - must not be called
+            raise AssertionError("dispatch should have refused the path first")
+
+    client = FakeClient(ScriptedResponses([
+        _response(output=[_fc(
+            "audio-call", "audio_judge",
+            criterion=_audio_item().criterion,
+            audio_path="not-in-the-allowlist.wav",
+        )], in_tok=20, out_tok=3, cached_tok=2),
+        _response(output=[_final(json.dumps({
+            "verdict": "fail", "partial_score": 0.0,
+            "evidence": "the master track has a lead vocal throughout",
+            "confidence": 0.8, "reasoning": "heard elsewhere in the bundle",
+        }))], in_tok=25, out_tok=4, cached_tok=3),
+    ]))
+    judge = ToolCallingJudge(
+        client=client, model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=_NeverReached(),
+    )
+
+    result = judge.judge_item(
+        task=task, item=_audio_item(), deliverable_dir=str(tmp_path),
+        file_names=["stems.zip"],
+    )
+
+    assert result.verdict == "fail"
+    assert result.judge_error is None
+    assert result.score_excluded is False
+
+
+def test_a_listening_call_that_recovers_leaves_no_error(tmp_path, task_and_item):
+    """One failed attempt does not condemn an item the run went on to hear.
+
+    The mark depends on whether the audio was heard, not on how many tries it
+    took. Excluding a recovered item would throw away a reading the run
+    actually has -- and paid for.
+    """
+    task, _ = task_and_item
+    (tmp_path / "clip.wav").write_bytes(b"RIFFfake")
+
+    class _FlakyAudio:
+        def __init__(self):
+            self.calls = 0
+
+        def judge(self, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return _DeafAudio("provider_error:APITimeoutError").judge()
+            return SimpleNamespace(
+                judge_error=None,
+                to_dict=lambda: {
+                    "verdict": "pass", "partial_score": 1.0,
+                    "evidence": "no vocal content in the master",
+                    "confidence": 0.9, "reasoning": "heard",
+                    "judge_error": None, "api_call_count": 1,
+                    "input_tokens": 70, "output_tokens": 12,
+                    "cached_tokens": 5, "latency_ms": 14.0,
+                    "usage_complete": True,
+                },
+            )
+
+    audio = _FlakyAudio()
+    call = _fc("audio-call", "audio_judge",
+               criterion=_audio_item().criterion, audio_path="clip.wav")
+    client = FakeClient(ScriptedResponses([
+        _response(output=[call], in_tok=20, out_tok=3, cached_tok=2),
+        _response(output=[_fc(
+            "audio-call-2", "audio_judge",
+            criterion=_audio_item().criterion, audio_path="clip.wav",
+        )], in_tok=20, out_tok=3, cached_tok=2),
+        _response(output=[_final(json.dumps({
+            "verdict": "pass", "partial_score": 1.0,
+            "evidence": "no vocal content in the master",
+            "confidence": 0.9, "reasoning": "heard on the retry",
+        }))], in_tok=25, out_tok=4, cached_tok=3),
+    ]))
+    judge = ToolCallingJudge(
+        client=client, model="gpt-5.4",
+        prompt_template=PROMPT_TEMPLATE, audio_perception=audio,
+    )
+
+    result = judge.judge_item(
+        task=task, item=_audio_item(), deliverable_dir=str(tmp_path),
+        file_names=["clip.wav"],
+    )
+
+    assert audio.calls == 2
+    assert result.verdict == "pass"
+    assert result.judge_error is None
+    assert result.score_excluded is False
+    # The failed attempt is still on the bill and still leaves the run unable
+    # to say the token count is complete.
+    assert result.perception_call_count == 2
+    assert result.usage_complete is False
+
+
 def test_model_cannot_call_render_to_image(deliverable_dir, task_and_item):
     task, item = task_and_item
     client = FakeClient(ScriptedResponses([


### PR DESCRIPTION
## 무엇이 잘못됐는가

듣는 모델을 **부르지 못했을 때**, 그 항목이 **0점으로 채점된다.**

채점기가 소리를 못 들었다는 것은 제출물에 대해 아무것도 모른다는 뜻이다.
그런데 지금 코드는 그것을 "제출물이 기준을 만족하지 않는다"로 기록한다.
모르는 것과 틀린 것이 같은 자리에 적히고 있다.

보는 쪽(vision)은 이미 이렇게 되어 있지 않다. 시각 사전검사가 실패하면
`required_visual_perception_failed:{file}:{err}` 로 **채점기 오류**가 되고
`score_excluded=True` 가 붙어 점수 계산에서 빠진다. 듣는 쪽에는 그 승격이
없었다.

## 증거 — 실행 산출물에서 그대로 읽었다

샤드 1(`33241377185`)의 진단 산출물을 내려받아 확인했다. 과제
`38889c3b` 의 세 항목이 전부 이 모양이다.

```json
{ "verdict": "fail",
  "awarded_score": 0.0,
  "score_excluded": false,
  "routing_modality": "audio",
  "evidence": "audio call failed: BadRequestError",
  "tools_used": ["read_deliverable", "read_deliverable", "audio_judge"] }
```

`evidence` 가 제출물에 대한 관찰이 아니라 **호출 실패 기록**이다. 그런데
`score_excluded` 가 `false` 라 이 0점들이 그대로 분모에 남았다.

값으로는 이렇다. `38889c3b` 는 62점 만점에 44.8점(72.26%)을 받았다. 세
항목 6점이 애초에 알 수 없는 것이었으므로 제외됐다면 44.8/56 = **80.0%**
였다. 채점기 자신의 실패가 제출물 점수를 **7.7%p** 깎았다.

## 무엇을 바꾸는가

`core/tool_calling_judge.py` 에 "물어봤는데 끝내 못 들었다"만 골라내는
판정을 넣고, 그 경우에만 항목을 `judge_error` 로 승격한다.

| 상황 | 전 | 후 |
|---|---|---|
| 듣기 호출이 실패하고 끝남 | `fail`, 0점, 점수에 포함 | `judge_error`, **점수에서 제외** |
| 판사가 경로를 틀리게 물음 (`bad_path`·`bad_args`·`bad_scope`) | `fail`/`pass` 그대로 | **그대로** — 판사가 고쳐 다시 물을 몫 |
| 한 번 실패했다가 다시 물어 성공 | 정상 채점 | **정상 채점** — 결국 들었으므로 오류 아님 |

세 번째 줄이 이 변경의 경계다. 마지막에 들었으면 점수는 들은 것에서
나온 것이므로 오류가 아니다. **"물었고 끝내 못 들었다"만** 제외한다.

교정 가능한 오류를 남겨 둔 근거는 코드 자신에 있다. `read_deliverable`
의 주석이 "아카이브에 없는 멤버를 부르는 것은 판사가 스스로 고칠 몫"
이라고 적고 있고, 도구는 실제 아카이브 목록을 답에 담아 돌려준다.
판사는 그것을 읽고 다시 물으라고 되어 있다. 그 길을 막으면 안 된다.

## 이 변경의 실제 사정거리 — 185 과제 중 **1 개**

추측하지 않고 코퍼스를 직접 열어 셌다. 금표준 제출물 중 압축·영상
파일을 가진 과제는 일곱이고, 그 안에 **소리가 들어 있는 것은 하나뿐**
이다.

| 과제 | 파일 | 내용물 |
|---|---|---|
| `38889c3b` | `DEJA VU  STEMS .zip` (179 MB) | **`.wav` 10 개** ← 유일한 오디오 |
| `4122f866` | `contact form serverless backend.zip` | `.tf`·`.js`·`.md` |
| `7de33b48` | `screen_reader_status_message.zip` | `.json`·`.md`·`.css`·`.tsx` |
| `5e2b6aab` | `TOASTY_REVA_STEP_FILES.zip` | CAD |
| `0e386e32` | `PrivateCrypMixV2.zip` | **열 수 없음** (별건 — 아래) |
| `75401f7c`·`e222075d` | `.mp4` | 영상 |

샤드 0(완료, 17 과제)에는 오디오 항목이 **0 개**였고 실제로 이 결함에
닿은 항목도 0 개였다. 코퍼스 평균에 대한 영향은 약 **+0.04%p** 로 작다.
이 PR 의 값어치는 평균이 아니라, 채점기 실패가 제출물 점수로 **둔갑하지
않게** 하는 데 있다.

## 시험 — 셋을 넣었고, 그중 **하나만** 이 변경을 증명한다

부풀리지 않고 적는다.

- `test_a_listening_call_that_never_answers_is_not_scored_as_a_failure`
  — **이것이 증명하는 시험이다.** 죽은 실행을 그대로 재현하고
  `verdict == "judge_error"`, `score_excluded is True`,
  `awarded_score == 0.0` 을 요구한다. 가드를 빼면
  `AssertionError: assert 'fail' == 'judge_error'` 로 깨진다.
- `test_a_listening_call_the_judge_asked_wrong_stays_the_judge_s_to_fix`
- `test_a_listening_call_that_recovers_leaves_no_error`

뒤의 둘은 **과잉 승격을 막는 난간**이다. 가드를 빼도 통과한다. 즉 이
변경이 옳다는 증거가 아니라, 이 변경이 **너무 멀리 가지 않았다는**
증거다. 셋이 다 같은 무게인 것처럼 적지 않는다.

## 이것은 근본 원인 수정이 아니다

400 을 만든 원인은 요청의 콘텐츠 파트 키가 틀린 것이고 그것은 **#267**
이 고친다. 이 PR 은 그 뒤에 서는 **두 번째 방어선**이다. 앞으로 어떤
이유로든 듣기 호출이 실패했을 때, 그 실패가 제출물의 점수로 기록되지
않게 한다.

## 병합 순서 주의

`core/tool_calling_judge.py` 는 `compute_grader_source_hash` 의 해시
대상이다. 병합되는 순간 `grader_source_hash` 가 바뀌고,
`step9_merge_shards.py` 는 샤드 간 해시 불일치를 `ShardMergeError` 로
하드 실패시킨다. **채점 샤드가 하나라도 떠 있는 동안 병합하지 말 것.**
