### PR TITLE
fix(dashboard): 가격표에 없는 모델로 채점한 실행을 "미채점"으로 지우지 않는다

### DIFF
--- a/scripts/__tests__/cost-receipt.test.mjs
+++ b/scripts/__tests__/cost-receipt.test.mjs
@@ -354,6 +354,65 @@ test('unavailable receipts are counted but never priced', () => {
   assert.equal(summary.known_cost_usd, 0);
 });
 
+test('a run against a model with no published price stays partial, not not_run', () => {
+  // The shape Stage 3 actually produced. `azure:gpt-5.6-sol` is absent from
+  // experiments/execution_envelope/model_price_table.json, so every judge call
+  // settles `price_missing` and the receipt's known floor is $0 — the contract
+  // working, since the calls and their tokens are kept and only the USD is
+  // refused. `measuredAmount` then nulls that floor so no reader takes it for
+  // "so far it has cost nothing", which leaves the run with nothing measured.
+  //
+  // Nothing measured is not nothing done. Deciding the run's state from the
+  // amounts sent this past `partial` to `not_run`, which renders as 미채점
+  // beside 17 graded tasks and 1784 calls.
+  const unpriced = projectCostReceipt(unmeasured('partial', {
+    model_calls: 114,
+    usage: { input_tokens: 3142728, output_tokens: 46245 },
+    missing_reasons: ['price_missing'],
+    components: [
+      component({
+        name: 'grading',
+        stage: 'grading',
+        status: 'partial',
+        known_cost_usd: 0,
+        model_calls: 113,
+        missing_reasons: ['price_missing'],
+      }),
+    ],
+  }));
+
+  const summary = summarizeCostReceipts([row(unpriced), row(unpriced)]);
+
+  assert.equal(summary.status, 'partial');
+  assert.equal(summary.partial_tasks, 2);
+  assert.equal(summary.not_run_tasks, 0);
+  assert.equal(summary.measured_tasks, 0);
+  // No figure was measured, so none is offered. The run is still not erased.
+  assert.equal(summary.estimated_cost_usd, null);
+  assert.deepEqual(summary.missing_reasons, ['price_missing']);
+});
+
+test('work that never ran does not stop the rest being a total', () => {
+  // cost_receipts.py drops not_run receipts before deciding the summary's
+  // status, so a run where one task was skipped and the rest priced cleanly is
+  // complete. Agreeing with it matters more than either answer alone: the
+  // dashboard reads this summariser and the report reads that one, off the
+  // same file.
+  const summary = summarizeCostReceipts(
+    [
+      row(projectCostReceipt(receipt())),
+      row(projectCostReceipt(unmeasured('not_run'))),
+    ],
+    { successfulDeliverables: 1 },
+  );
+
+  assert.equal(summary.status, 'complete');
+  assert.equal(summary.not_run_tasks, 1);
+  assert.equal(summary.known_cost_usd, 0.25);
+  assert.equal(summary.estimated_cost_usd, 0.25);
+  assert.equal(summary.cost_per_successful_deliverable_usd, 0.25);
+});
+
 test('failed-task cost is reported beside the total, not removed from it', () => {
   const summary = summarizeCostReceipts(
     [

--- a/scripts/cost-receipt.mjs
+++ b/scripts/cost-receipt.mjs
@@ -424,15 +424,30 @@ export function summarizeCostReceipts(rows, { successfulDeliverables = null } = 
     ? round(amounts.reduce((sum, amount) => sum + amount, 0), MONEY_DIGITS)
     : 0;
 
-  // The run total is only a total when every receipt is complete. One partial
-  // or unavailable receipt makes it a floor, and it is labelled as one rather
-  // than quietly rounded up into a headline number.
-  const completeRun = counts.complete === receipts.length;
+  // The run's state comes from the receipts' own states, not from whether a
+  // number fell out of them. `amounts` is empty whenever every measurable
+  // receipt has a $0 floor — which `measuredAmount` nulls on purpose, and which
+  // is the ordinary case when the model that was called is absent from the
+  // price table, as the Stage 3 judge is. Reading the state off `amounts` made
+  // such a run fall past `partial` all the way to `not_run`, telling the reader
+  // that a run of 17 graded tasks and 1784 calls had never happened.
+  //
+  // Work that genuinely never ran is not a hole in the run: it contributed
+  // nothing, so it neither drags the state down nor stops a total being a
+  // total. This mirrors `_summary_status` in
+  // batch-runner/core/cost_receipts.py, so the two summarisers cannot give
+  // different answers about the same receipts.
+  const ran = receipts.filter((entry) => entry.status !== 'not_run');
   let status;
-  if (completeRun) status = 'complete';
-  else if (amounts.length) status = 'partial';
-  else if (counts.unavailable) status = 'unavailable';
-  else status = 'not_run';
+  if (!ran.length) status = 'not_run';
+  else if (ran.every((entry) => entry.status === 'complete')) status = 'complete';
+  else if (ran.every((entry) => entry.status === 'unavailable')) status = 'unavailable';
+  else status = 'partial';
+
+  // The run total is only a total when everything that ran is complete. One
+  // partial or unavailable receipt makes it a floor, and it is labelled as one
+  // rather than quietly rounded up into a headline number.
+  const completeRun = status === 'complete';
 
   const reasons = [...new Set(receipts.flatMap((r) => r.missing_reasons))].sort();
   const priceTables = [...new Set(


### PR DESCRIPTION
## 무엇이 잘못되어 있었나

`scripts/cost-receipt.mjs`의 `summarizeCostReceipts`는 실행 상태를 영수증의
상태가 아니라 **"금액이 하나라도 나왔는가"** 에서 유도하고 있었습니다.
두 값은 같지 않습니다.

`measuredAmount`는 `complete`가 아닌 영수증의 $0을 의도적으로 `null`로
만듭니다. "아직 확인된 것이 없다"는 뜻의 0이 화면에 `$0.0000`으로 나가지
않게 하려는 것이고, 이건 올바른 동작입니다. 그런데 그 결과로, 호출한 모델이
가격표에 없으면 모든 영수증이 `price_missing` + $0 바닥값으로 정착하고
`amounts` 배열이 **비게** 됩니다.

Stage 3 판정 모델 `gpt-5.6-sol`이 정확히 그 경우입니다
(`experiments/execution_envelope/model_price_table.json`에 항목이 없음).

**측정된 것이 없다는 것은 한 일이 없다는 뜻이 아닙니다.** 비어 있는
`amounts`로 상태를 정하면 실행이 `partial`을 지나 `not_run`까지 떨어지고,
대시보드는 유료로 끝난 채점 실행을 이렇게 표시합니다:

> 미채점 — 해당 작업이 수행되지 않아 비용이 없습니다.

네 가지 상태를 나눠 둔 이유가 막으려던 가짜 `$0`의, 정확한 거울상입니다.

## 실제 데이터 근거

이미 완료된 유료 Stage 3 shard 두 개를 그대로 통과시켜 수정 전/후를
비교했습니다. 새로 dispatch한 유료 실행은 없습니다.

| shard | 과제 | 판정 호출 | 수정 전 | 수정 후 |
|---|---|---|---|---|
| `shard-000-of-011` | 17 | 1,728 | `not_run` | `partial` |
| `shard-008-of-011` | 17 | 1,918 | `not_run` | `partial` |

두 실행 모두 정상 완료(`run_status` 성공, `judge_error` 0건)이며, 대시보드에는
"수행되지 않았다"로 나가고 있었습니다.

## 함께 고친 두 번째 결함

같은 자리에서 `completeRun`이 `counts.complete === receipts.length`였습니다.
과제 하나가 실행되지 않고 나머지가 모두 정상적으로 가격이 매겨진 실행을
`partial`로 분류해 `estimated_cost_usd`와 산출물당 단가를 숨깁니다.

실행되지 않은 일은 실행의 구멍이 아니라 기여가 없는 것입니다. Python 쪽
`batch-runner/core/cost_receipts.py`의 `_summary_status`는 이 경우를
`complete`로 부릅니다. 이제 두 요약기가 같은 규칙을 씁니다 — 대시보드와
보고서가 **같은 파일**을 읽으므로, 같은 영수증에 대해 다른 답을 내놓아서는
안 됩니다.

## 검증

| 항목 | 결과 |
|---|---|
| `node --test scripts/__tests__/cost-receipt.test.mjs` | 23/23 |
| `npm run test:cost-data` | 62/62 |
| `node scripts/__tests__/cost-receipts.browser.mjs` | pass (3 시나리오, 실제 chromium) |
| `tsc && vite build` | clean |

회귀 테스트가 실제로 이 결함을 잡는지 역방향으로 확인했습니다. 소스만
stash하고 테스트는 남긴 채 재실행하면 새 테스트 2개가 각각 다른 증상으로
실패합니다.

- `expected: 'partial' / actual: 'not_run'`
- `expected: 'complete' / actual: 'partial'`

브라우저 하네스는 성공 시 아무것도 출력하지 않으므로, 조용한 exit 0이
진짜 통과인지도 확인했습니다. 기대 문자열 하나를 일부러 어긋나게 하면
실제 DOM 텍스트 `미채점`을 읽어 와 `AssertionError`로 실패합니다.

## 채점 소스 해시 동결

`step8_grade.py`의 `grader_source_hash` 입력은 모두 `batch-runner/` 아래에
열거되어 있습니다(`step8_grade.py`, `core/**.py`, `schemas/grade.schema.json`,
`requirements.txt`, `scripts/download_inference_from_hf.py`, prompt template).

이 PR은 저장소 **최상위** `scripts/`만 건드립니다 — `batch-runner/scripts/`와는
다른 디렉터리입니다. 해시 대상이 아니므로 진행 중인 shard에 영향이 없습니다.
