### PR TITLE
feat(cost): 영수증 단가를 공표된 Azure meter에서 다시 세운다

### DIFF
--- a/batch-runner/experiments/execution_envelope/model_price_table.json
+++ b/batch-runner/experiments/execution_envelope/model_price_table.json
@@ -5,7 +5,7 @@
   "source": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
   "mirrors": "scripts/analyze_grade_run.py PRICING_USD_PER_M_TOKENS",
   "last_reviewed": "2026-05-28",
-  "note": "These are list prices recorded in this repository, not a quote from a bill. A tenant with negotiated rates must replace them before any number here is treated as a commitment. tests/test_execution_envelope_cost.py fails if these stop matching scripts/analyze_grade_run.py.",
+  "note": "These are list prices recorded in this repository, not a quote from a bill. A tenant with negotiated rates must replace them before any number here is treated as a commitment. tests/test_execution_envelope_cost.py fails if these stop matching scripts/analyze_grade_run.py. KNOWN DEFECT, not fixed here: on 2026-08-29 every figure in this planning block was checked against the Azure Retail Prices API and none of them matched a published meter — see cost_receipt_caveats.planning_block_is_also_wrong. It is left alone in this change because it is a pre-run ceiling mirrored in another file under its own test, and correcting it is a separate change with a separate blast radius.",
   "models": {
     "gpt-5.4": {
       "input_usd_per_million": "1.25",
@@ -25,54 +25,184 @@
     }
   },
   "cost_receipt_schema_version": "cost-receipt-price-table-v1",
-  "cost_receipt_note": "The block above prices a plan before it runs. The two blocks below price calls after they have run, and are read by core/cost_receipts.py. They are kept apart because a ceiling and a receipt are answers to different questions and must not be edited as if they were one list. Keys here are provider:resolved_model, where resolved_model is the model the response reports — not the deployment name in the request. A provider or model with no entry here is recorded as price_missing; it is never priced from a similar entry.",
+  "cost_receipt_note": "The block above prices a plan before it runs. The blocks below price calls after they have run, and are read by core/cost_receipts.py. They are kept apart because a ceiling and a receipt are answers to different questions and must not be edited as if they were one list. Keys here are provider:resolved_model, where resolved_model is the model the response reports — not the deployment name in the request. A provider or model with no entry here is recorded as price_missing; it is never priced from a similar entry. Every rate in `providers` names the exact published meter it came from, so it can be re-checked without trusting this file. `azure_published_meters` records the full official matrix including the rates NOT used, so that a reader can see what was chosen and what was rejected. `pricing_axes` records, per model, which billing axes were settled by evidence and which are still open.",
+  "cost_receipt_last_reviewed": "2026-08-29",
+  "cost_receipt_source": {
+    "authority": "Azure Retail Prices API (unauthenticated, public)",
+    "query": "https://prices.azure.com/api/retail/prices?currencyCode='USD'&$filter=contains(meterName,'<meter fragment>')",
+    "published_page": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
+    "product_name": "Azure OpenAI GPT5",
+    "service_name": "Foundry Models",
+    "price_type": "Consumption",
+    "retrieved": "2026-08-29",
+    "currency": "USD",
+    "unit": "per 1,000,000 tokens",
+    "why_the_api_and_not_the_page": "The pricing page renders every figure from a region and currency selector, so fetching the page returns rows whose price cells are all '$-'. The Retail Prices API returns the same list prices as data. That is why every number below can be re-checked by re-running one query, instead of by trusting a screenshot or a person's memory.",
+    "meter_name_key": "Inp = input, Opt = output, Cd Inp = cached input, Cd Wr = cache write. Gl = Global deployment, Dz = Data Zone deployment. Std = standard, PP = Priority Processing, Batch = Batch API. ShortCo / LongCo (and, on the 5.4 meters, the absence or presence of 'longco') = the context-length tier."
+  },
   "providers": {
     "azure:gpt-5.4": {
-      "input_usd_per_million": "1.25",
-      "cached_input_usd_per_million": "1.25",
-      "output_usd_per_million": "5.00",
-      "reasoning_billed_as": "output",
-      "source": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
-      "last_reviewed": "2026-05-28",
-      "currency": "USD",
-      "unit": "per 1,000,000 tokens"
-    },
-    "azure:gpt-5.4-mini": {
-      "input_usd_per_million": "0.25",
+      "input_usd_per_million": "2.50",
       "cached_input_usd_per_million": "0.25",
-      "output_usd_per_million": "1.00",
-      "reasoning_billed_as": "output",
-      "source": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
-      "last_reviewed": "2026-05-28",
-      "currency": "USD",
-      "unit": "per 1,000,000 tokens"
-    },
-    "azure:gpt-5.4-nano": {
-      "input_usd_per_million": "0.075",
-      "cached_input_usd_per_million": "0.075",
-      "output_usd_per_million": "0.30",
-      "reasoning_billed_as": "output",
-      "source": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
-      "last_reviewed": "2026-05-28",
-      "currency": "USD",
-      "unit": "per 1,000,000 tokens"
-    },
-    "azure:gpt-5.4-pro": {
-      "input_usd_per_million": "5.00",
-      "cached_input_usd_per_million": "5.00",
       "output_usd_per_million": "15.00",
       "reasoning_billed_as": "output",
-      "source": "https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/",
-      "last_reviewed": "2026-05-28",
+      "source": "https://prices.azure.com/api/retail/prices — meters '5.4 inp Gl 1M Tokens', '5.4 cd inp Gl 1M Tokens', '5.4 opt Gl 1M Tokens'; productName 'Azure OpenAI GPT5', type Consumption",
+      "last_reviewed": "2026-08-29",
       "currency": "USD",
-      "unit": "per 1,000,000 tokens"
+      "unit": "per 1,000,000 tokens",
+      "meters": {
+        "input": "5.4 inp Gl 1M Tokens",
+        "cached_input": "5.4 cd inp Gl 1M Tokens",
+        "output": "5.4 opt Gl 1M Tokens"
+      },
+      "tier": "standard",
+      "zone": "global",
+      "context_tier": "under 272k",
+      "premises": [
+        "The deployment is a Global one, not a Data Zone one. Nothing in this repository or in any published artifact records the deployment's zone, so this is stated rather than proven. If it is a Data Zone deployment the correct meters are 3.00 input, 0.30 cached input, 16.50 output.",
+        "No single request sends more than 272,000 input tokens. Azure prices 5.4 in two context tiers split at that figure, and the receipt records tokens per task rather than per call, so this cannot be read off the receipt. It CAN be read off the per-call cost ledger, which the inference workflow does publish. If a request crosses 272k the correct meters are 5.00 input, 0.50 cached input, 22.50 output."
+      ]
+    },
+    "azure:gpt-5.4-mini": {
+      "input_usd_per_million": "0.75",
+      "cached_input_usd_per_million": "0.075",
+      "output_usd_per_million": "4.50",
+      "reasoning_billed_as": "output",
+      "source": "https://prices.azure.com/api/retail/prices — meters '5.4 mini Inp Gl 1M Tokens', '5.4 mini cd Inp Gl 1M Tokens', '5.4 mini Opt Gl 1M Tokens'; productName 'Azure OpenAI GPT5', type Consumption",
+      "last_reviewed": "2026-08-29",
+      "currency": "USD",
+      "unit": "per 1,000,000 tokens",
+      "meters": {
+        "input": "5.4 mini Inp Gl 1M Tokens",
+        "cached_input": "5.4 mini cd Inp Gl 1M Tokens",
+        "output": "5.4 mini Opt Gl 1M Tokens"
+      },
+      "tier": "standard",
+      "zone": "global",
+      "premises": [
+        "The deployment is a Global one, not a Data Zone one. See azure:gpt-5.4."
+      ]
+    },
+    "azure:gpt-5.4-nano": {
+      "input_usd_per_million": "0.20",
+      "cached_input_usd_per_million": "0.02",
+      "output_usd_per_million": "1.25",
+      "reasoning_billed_as": "output",
+      "source": "https://prices.azure.com/api/retail/prices — meters '5.4 nano Inp Gl 1M Tokens', '5.4 nano cd Inp Gl 1M Tokens', '5.4 nano Opt Gl 1M Tokens'; productName 'Azure OpenAI GPT5', type Consumption",
+      "last_reviewed": "2026-08-29",
+      "currency": "USD",
+      "unit": "per 1,000,000 tokens",
+      "meters": {
+        "input": "5.4 nano Inp Gl 1M Tokens",
+        "cached_input": "5.4 nano cd Inp Gl 1M Tokens",
+        "output": "5.4 nano Opt Gl 1M Tokens"
+      },
+      "tier": "standard",
+      "zone": "global",
+      "premises": [
+        "The deployment is a Global one, not a Data Zone one. See azure:gpt-5.4."
+      ]
+    }
+  },
+  "pricing_axes": {
+    "why_this_block_exists": "Azure does not publish one price per model. It publishes one price per (model x context tier x zone x tier x rate kind). A key in `providers` is flat — one provider:model maps to one set of rates — so adding an entry means asserting where the call sat on every one of those axes. This block records how each axis was settled, so that a rate here is either evidence or a stated premise, never an unmarked choice.",
+    "axes_settled_for_every_azure_call_in_this_pipeline": {
+      "batch_api": "Excluded by evidence, not by preference. The Batch API is a separate endpoint with its own meters ('5.4 Batch inp Gl' and friends, roughly half the standard rate for a 24-hour turnaround). This pipeline never calls it: core/ contains no reference to a batches endpoint, and every call site is a synchronous responses.create or chat.completions.create. Batch meters are therefore not applicable.",
+      "priority_processing": "Excluded by evidence. Priority Processing has its own meters ('5.4 pp inp Gl' and friends, exactly 2x standard) and has to be asked for. Nothing in core/ or step*.py ever sets service_tier or any priority flag, so calls land on the standard meters."
+    },
+    "axes_open": {
+      "zone": {
+        "status": "unresolved",
+        "spread": "Data Zone is 1.1x to 1.2x Global depending on the rate kind.",
+        "why_it_cannot_be_read": "Global versus Data Zone is a property of the deployment, chosen when the deployment was created. It is not in the response, not in the config, and not in any published artifact. azure_ai_routes.endpoint_kind ('direct-v1') describes the shape of the API surface, not the zone. core/config.py holds no region or zone token at all.",
+        "what_would_settle_it": "One statement from whoever owns the deployment, or recording the deployment's SKU alongside the resolved model at call time.",
+        "handling": "Stated as a premise on each entry rather than left silent, because a receipt that is 10% wrong AND says which way is a smaller problem than one that is 10% wrong and says nothing."
+      },
+      "context_tier": {
+        "status": "resolved for 5.4, unresolved for 5.6-sol",
+        "gpt_5_4": "The split is published as 272k, so the premise is checkable against the per-call cost ledger that the inference workflow publishes.",
+        "gpt_5_6_sol": "Azure labels the two tiers only 'short context' and 'long context' and publishes no threshold anywhere. Even with per-call tokens in hand there would be nothing to compare them against.",
+        "what_would_settle_it": "Azure publishing the 5.6-sol threshold, plus per-call input tokens surviving into a published artifact on the grading side."
+      }
+    }
+  },
+  "models_deliberately_not_priced": {
+    "azure:gpt-5.6-sol": {
+      "used_for": "the Track 2 grading judge and its visual perception calls",
+      "official_price_exists": true,
+      "why_unpriced": "Not because Azure is silent — Azure publishes 24 meters for this model. Because nothing available says which of them applies. Two axes are open at once: the zone, as for every model here, and the context tier, and for 5.6-sol the context tier is the worse of the two. Azure names those tiers only 'short context' and 'long context' and publishes no threshold for either, so no token measurement can settle the question — there is nothing to compare a measurement against. Nor would one blanket answer serve: across the 86 graded tasks whose receipts were read on 2026-08-29, per-task input ranged from 76,600 tokens over 32 calls to 6,150,162 tokens over 177 calls, an eighty-fold spread, and a tool-calling judge's conversation grows with every turn within a task. Picking a tier would move the answer by 2x on input and 1.5x on output. That is the guess this table exists to refuse.",
+      "what_would_settle_it": "Publish the grading-side per-call cost ledger (it is written next to the grade file and then dies with the runner), and establish the 5.6-sol context threshold. With both, the tier becomes arithmetic instead of a choice.",
+      "consequence": "Every grading receipt stays partial with missing_reason price_missing. Call counts and token counts are all preserved; only the rate is absent."
+    },
+    "azure:gpt-audio-1.5": {
+      "used_for": "audio perception during grading, and the audio branch of inference",
+      "official_price_exists": false,
+      "why_unpriced": "No meter for it exists. The Azure Retail Prices API was searched for every meter containing 'audio' and every meter containing 'Audio'; the model does not appear under any of them, and it is absent from the pricing page as well. The audio meters that do exist belong to other products entirely — gpt4o realtime audio, Azure Speech, Azure Video Indexer, Azure Content Understanding. Pricing this model from any of those would be pricing it from a different service.",
+      "what_would_settle_it": "Azure publishing a meter, or the tenant's own negotiated rate.",
+      "consequence": "Audio perception calls stay unpriced, and any receipt containing one stays partial."
+    },
+    "azure:gpt-5.4-pro": {
+      "used_for": "nothing in this pipeline at present",
+      "official_price_exists": "partly",
+      "why_unpriced": "Azure publishes input (30.00) and output (180.00) for 5.4 pro but publishes no cached-input meter for it at all. The receipt schema requires a cached-input rate, and every call this pipeline makes reports cached tokens. Filling that field would mean inventing the one rate Azure declines to state. The entry that used to be here claimed 5.00 / 5.00 / 15.00, which was wrong on all three counts and would have under-charged output by a factor of twelve.",
+      "what_would_settle_it": "Azure publishing a cached-input meter for 5.4 pro.",
+      "consequence": "A 5.4-pro call would be recorded as price_missing. Nothing in this pipeline makes one."
+    }
+  },
+  "azure_published_meters": {
+    "why_this_block_exists": "The rates actually in use are a small selection out of a large published matrix. Recording the whole matrix means a reviewer can check not only that a chosen rate is real, but that the right one was chosen — and it means the alternatives are already here when a premise turns out to be wrong.",
+    "retrieved": "2026-08-29",
+    "currency": "USD",
+    "unit": "per 1,000,000 tokens unless stated otherwise",
+    "gpt-5.4": {
+      "standard_global": {"input": "2.50", "cached_input": "0.25", "output": "15.00"},
+      "standard_data_zone": {"input": "3.00", "cached_input": "0.30", "output": "16.50"},
+      "standard_global_long_context": {"input": "5.00", "cached_input": "0.50", "output": "22.50"},
+      "standard_data_zone_long_context": {"input": "6.00", "cached_input": "0.60", "output": "24.75"},
+      "priority_global": {"input": "5.00", "cached_input": "0.50", "output": "30.00"},
+      "priority_data_zone": {"input": "5.50", "cached_input": "0.55", "output": "33.00"},
+      "batch_global": {"input": "1.25", "cached_input": "0.13", "output": "7.50"},
+      "batch_data_zone": {"input": "1.375", "cached_input": "0.143", "output": "8.25"}
+    },
+    "gpt-5.4-mini": {
+      "standard_global": {"input": "0.75", "cached_input": "0.075", "output": "4.50"}
+    },
+    "gpt-5.4-nano": {
+      "standard_global": {"input": "0.20", "cached_input": "0.02", "output": "1.25"}
+    },
+    "gpt-5.4-pro": {
+      "standard_global": {"input": "30.00", "cached_input": null, "output": "180.00"},
+      "standard_data_zone": {"input": "33.00", "cached_input": null, "output": "198.00"},
+      "standard_global_long_context": {"input": "60.00", "cached_input": null, "output": "270.00"},
+      "note": "No cached-input meter is published for any 5.4 pro variant."
+    },
+    "gpt-5.6-sol": {
+      "short_context_standard_global": {"input": "5.00", "cached_input": "0.50", "cache_write": "6.25", "output": "30.00"},
+      "short_context_standard_data_zone": {"input": "5.50", "cached_input": "0.55", "cache_write": "6.875", "output": "33.00"},
+      "short_context_priority_global": {"input": "10.00", "cached_input": "1.00", "cache_write": "12.50", "output": "60.00"},
+      "short_context_priority_data_zone": {"input": "11.00", "cached_input": "1.10", "cache_write": "13.75", "output": "66.00"},
+      "long_context_standard_global": {"input": "10.00", "cached_input": "1.00", "cache_write": "12.50", "output": "45.00"},
+      "long_context_standard_data_zone": {"input": "11.00", "cached_input": "1.10", "cache_write": "13.75", "output": "49.50"},
+      "note": "Long context has no Priority Processing variant. 5.6-sol also bills cache WRITES, which 5.4 does not; the receipt records cached-input tokens but no cache-write count, so even with the tier settled that meter could not be applied from what is recorded."
+    },
+    "execution_environment": {
+      "code_interpreter_session_global": {"price": "0.03", "unit": "per session", "meter": "Code-Interpreter-global Session", "product": "Azure OpenAI"},
+      "code_interpreter_session_regional": {"price": "0.0363", "unit": "per session", "meter": "Code-Interpreter-regnl EP Session", "product": "Azure OpenAI"},
+      "note": "Recorded here as evidence; see cost_receipt_caveats.runtime for why it cannot yet be loaded into the runtime block."
+    },
+    "audio": {
+      "gpt-audio-1.5": null,
+      "note": "Searched exhaustively; no meter exists for this model under any product. See models_deliberately_not_priced."
     }
   },
   "cost_receipt_caveats": {
-    "cached_input": "No discounted cache rate has been sourced for this tenant, so cached input is priced at the full input rate. That over-states the bill rather than under-stating it, which is the only direction this repository is willing to be wrong in. Replace these with a sourced rate before treating a receipt as a quote.",
-    "reasoning_tokens": "reasoning_billed_as is 'output' because these deployments report reasoning tokens inside the completion token count, so charging them again on top would bill the same tokens twice. A provider that bills reasoning separately needs 'separate' and its own rate; where nobody has established which it is, 'unknown' leaves the call unpriced.",
+    "cached_input": "Cached input is now priced from its own published meter, one per model, named on each entry. This replaces an earlier rule that charged cached input at the full input rate on the stated grounds that no cache rate had been sourced. A cache rate had in fact been published all along — 0.25 against 2.50 for 5.4 — so that rule was over-charging cached tokens roughly tenfold, and cached tokens are the majority of input on a grading run.",
+    "reasoning_tokens": "reasoning_billed_as is 'output' because these deployments report reasoning tokens inside the completion token count, so charging them again on top would bill the same tokens twice. core/cost_receipts.py price_call enforces this: it charges output_tokens once and adds a separate reasoning charge only where an entry says 'separate' and supplies its own rate. A provider that bills reasoning separately needs 'separate'; where nobody has established which it is, 'unknown' leaves the call unpriced rather than guessed.",
+    "double_counting_of_cached_input": "Providers report input_tokens inclusive of the part served from cache. price_call charges (input - cached) at the input rate and cached at the cache rate, so no token is charged twice. With the cache rate now correct rather than equal to the input rate, that split finally changes the answer.",
     "other_providers": "Only the provider covered by the source above is listed. Calls to any other provider are recorded as price_missing and hold their receipt at partial until someone sources the rates and adds them here.",
-    "runtime": "No execution-environment rate has been sourced, so the runtime block is empty and directly attributable runtime fees are recorded as runtime_cost_unpriced. An empty list is a smaller error than an invented hourly rate."
+    "runtime": "The runtime block is still empty, but the reason has changed and is worth stating precisely. A rate HAS now been sourced: Azure publishes the code interpreter container at 0.03 per session (Global) and 0.0363 per session (regional endpoint), recorded under azure_published_meters.execution_environment. It cannot be loaded here because core/cost_receipts.py's runtime entry accepts only usd_per_hour, and turning a per-session charge into an hourly one would require inventing a session length. Directly attributable runtime fees therefore remain runtime_cost_unpriced. Expressing a per-session rate needs a schema change in a file that is inside the grader source-hash freeze, so it is a separate change.",
+    "planning_block_is_also_wrong": "The `models` block at the top of this file, which prices a plan before it runs rather than a call after it, was checked against the same API on 2026-08-29 and none of its figures match a published meter either — it records 1.25/5.00 for 5.4 where the meters say 2.50/15.00, and 5.00/15.00 for 5.4 pro where they say 30.00/180.00. That block understates a pre-run ceiling by between two and twelve times depending on the model. It is deliberately NOT corrected in this change: it is mirrored in scripts/analyze_grade_run.py under a test that compares the two, so correcting it touches a different file and a different gate, and bundling that into a receipts change would put a budget guard and a receipt in the same blast radius.",
+    "what_these_rates_are_not": "List prices retrieved from a public catalogue. Not a bill, not a quote, and not this tenant's negotiated rate. A receipt priced from them says what the published rate would have cost, which is the most this repository can honestly claim without access to the account's actual invoices."
   },
   "runtime": {}
 }

--- a/batch-runner/tests/test_receipt_prices_match_the_published_meters.py
+++ b/batch-runner/tests/test_receipt_prices_match_the_published_meters.py
@@ -1,0 +1,415 @@
+"""Price real grading usage without calling a model.
+
+Every token count below was read out of a Stage 3 shard artifact — the same
+files the grading workflow published — and is named with the shard and task it
+came from. Nothing here is invented, and nothing here calls a provider.
+
+Two halves, and the difference between them matters:
+
+* The first half prices those tasks under the model that actually graded them,
+  ``gpt-5.6-sol``, which this repository deliberately does not price. It asserts
+  that the receipt says so: partial, ``price_missing``, no dollar figure, and
+  every call and every token still there. That is what today's published grading
+  payloads really contain.
+* The second half re-labels the same token counts to ``gpt-5.4``, which the
+  table does cover, and asserts the arithmetic to the cent. **Those dollar
+  figures are not what the grading run cost.** They are what these tokens would
+  have cost had they gone to a model with published rates, and they exist to
+  prove the pricing path is right, not to price a run that was never priced.
+
+One structural note on aggregation. Each row below carries a stage's whole
+token count rather than its individual calls, because the per-call breakdown
+lives in the cost ledger and the grading workflow never publishes it. Charging
+a stage's tokens in one row gives the identical figure only because pricing is
+linear in tokens. The single thing that would break that linearity is a
+context-length tier, where a large call crosses onto a different rate — which
+is precisely the axis ``model_price_table.json`` records as an open premise for
+``gpt-5.4`` and as the reason ``gpt-5.6-sol`` stays unpriced. So this test is
+exact under the table's own stated assumption, and no more exact than that.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from core.cost_receipts import (
+    REASON_PRICE_MISSING,
+    STAGE_GRADING,
+    STAGE_PERCEPTION,
+    STATE_SETTLED,
+    STATUS_COMPLETE,
+    STATUS_PARTIAL,
+    CallUsage,
+    build_receipt,
+    load_receipt_price_table,
+    price_call,
+)
+
+PRICE_TABLE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "experiments"
+    / "execution_envelope"
+    / "model_price_table.json"
+)
+
+# The published meters, restated here so the table cannot be edited and this
+# file still pass. Retrieved 2026-08-29 from the Azure Retail Prices API,
+# productName "Azure OpenAI GPT5", type Consumption, Standard Global
+# deployments at the short-context tier. USD per 1,000,000 tokens.
+PUBLISHED_METERS = {
+    "azure:gpt-5.4": {
+        "input": Decimal("2.50"),
+        "cached_input": Decimal("0.25"),
+        "output": Decimal("15.00"),
+    },
+    "azure:gpt-5.4-mini": {
+        "input": Decimal("0.75"),
+        "cached_input": Decimal("0.075"),
+        "output": Decimal("4.50"),
+    },
+    "azure:gpt-5.4-nano": {
+        "input": Decimal("0.20"),
+        "cached_input": Decimal("0.02"),
+        "output": Decimal("1.25"),
+    },
+}
+
+# Models this repository is not willing to guess at. Each is absent for its own
+# reason, recorded in the table under models_deliberately_not_priced.
+UNPRICED = ("gpt-5.6-sol", "gpt-audio-1.5", "gpt-5.4-pro")
+
+MILLION = Decimal(1_000_000)
+
+
+class RealTask:
+    """One task's real published usage, split by the stage that spent it."""
+
+    def __init__(self, label, shard, task_id, calls, stages):
+        self.label = label
+        self.shard = shard
+        self.task_id = task_id
+        self.calls = calls
+        self.stages = stages  # ((stage, input, cached, output, reasoning), ...)
+
+    @property
+    def totals(self):
+        return {
+            "input_tokens": sum(s[1] for s in self.stages),
+            "cached_input_tokens": sum(s[2] for s in self.stages),
+            "output_tokens": sum(s[3] for s in self.stages),
+            "reasoning_tokens": sum(s[4] for s in self.stages),
+        }
+
+    def __repr__(self):  # keeps pytest ids readable
+        return self.label
+
+
+# Five real tasks spanning the whole observed range: the smallest by input, the
+# largest, and three in between. Two of them ran perception calls as well as
+# judge calls, which is what gives this file a genuine multi-component case.
+REAL_TASKS = (
+    RealTask(
+        "smallest-a328feea",
+        "shard-006-of-011",
+        "a328feea-47db-4856-b4be-2bdc63dd88fb",
+        32,
+        ((STAGE_GRADING, 76_600, 58_831, 6_138, 4_058),),
+    ),
+    RealTask(
+        "judge-only-f84ea6ac",
+        "shard-005-of-011",
+        "f84ea6ac-8f9f-428c-b96c-d0884e30f7c7",
+        75,
+        ((STAGE_GRADING, 225_011, 160_679, 28_631, 23_878),),
+    ),
+    RealTask(
+        "two-stage-83d10b06",
+        "shard-000-of-011",
+        "83d10b06-26d1-4636-a32c-23f92c57f30b",
+        114,
+        (
+            (STAGE_GRADING, 3_139_951, 1_096_158, 45_791, 39_050),
+            (STAGE_PERCEPTION, 2_777, 0, 454, 0),
+        ),
+    ),
+    RealTask(
+        "two-stage-b5d2e6f1",
+        "shard-010-of-011",
+        "b5d2e6f1-62a2-433a-bcdd-95b260cdd860",
+        98,
+        (
+            (STAGE_GRADING, 4_087_698, 1_931_251, 56_575, 50_359),
+            (STAGE_PERCEPTION, 2_777, 0, 300, 0),
+        ),
+    ),
+    RealTask(
+        "largest-19403010",
+        "shard-010-of-011",
+        "19403010-3e5c-494e-a6d3-13594e99f6af",
+        177,
+        (
+            (STAGE_GRADING, 6_144_751, 1_392_720, 68_010, 55_122),
+            (STAGE_PERCEPTION, 5_411, 0, 608, 0),
+        ),
+    ),
+)
+
+# What each task's tokens come to under azure:gpt-5.4, worked from the meters
+# above. Hard-coded rather than recomputed so that a change to the formula which
+# is merely self-consistent still fails. Worked for judge-only-f84ea6ac:
+#   billable input = 225,011 - 160,679       = 64,332
+#   64,332 x 2.50 + 160,679 x 0.25 + 28,631 x 15.00
+#     = 160,830.00 + 40,169.75 + 429,465.00 = 630,464.75 per million
+#     = $0.63046475
+EXPECTED_UNDER_GPT_5_4 = {
+    "smallest-a328feea": Decimal("0.15120025"),
+    "judge-only-f84ea6ac": Decimal("0.63046475"),
+    "two-stage-83d10b06": Decimal("6.0841395"),
+    "two-stage-b5d2e6f1": Decimal("6.73399775"),
+    "largest-19403010": Decimal("13.271055"),
+}
+
+
+@pytest.fixture(scope="module")
+def table():
+    return load_receipt_price_table(PRICE_TABLE_PATH)
+
+
+def _row(stage, usage, priced):
+    """One settled ledger row, shaped the way build_receipt reads them."""
+    return {
+        "state": STATE_SETTLED,
+        "stage": stage,
+        "retry_kind": "none",
+        "model_cost_usd": None if priced is None else str(priced.cost_usd),
+        "missing_reasons": json.dumps(
+            list(priced.missing_reasons) if priced else [REASON_PRICE_MISSING]
+        ),
+        "input_tokens": usage.input_tokens,
+        "cached_input_tokens": usage.cached_input_tokens,
+        "output_tokens": usage.output_tokens,
+        "reasoning_tokens": usage.reasoning_tokens,
+    }
+
+
+def _receipt_for(task, model, tbl):
+    price = tbl.lookup("azure", model)
+    rows = []
+    for stage, inp, cached, out, reasoning in task.stages:
+        usage = CallUsage(
+            input_tokens=inp,
+            cached_input_tokens=cached,
+            output_tokens=out,
+            reasoning_tokens=reasoning,
+        )
+        rows.append(_row(stage, usage, price_call(price, usage) if price else None))
+    return build_receipt(rows, price_table_sha256=tbl.sha256)
+
+
+# ── What the table says ──────────────────────────────────────────────────
+
+
+def test_every_rate_is_the_meter_it_claims_to_be(table):
+    """A rate that drifts off its published meter fails here, loudly."""
+    assert set(table.models) == set(PUBLISHED_METERS)
+    for key, meters in PUBLISHED_METERS.items():
+        entry = table.models[key]
+        assert entry.input_usd_per_million == meters["input"], key
+        assert entry.cached_input_usd_per_million == meters["cached_input"], key
+        assert entry.output_usd_per_million == meters["output"], key
+        # Reasoning is inside the completion count on these deployments, so it
+        # must not carry a rate of its own. See the double-charge test below.
+        assert entry.reasoning_billed_as == "output", key
+
+
+def test_a_rate_nobody_can_trace_is_not_a_rate():
+    """Every entry has to say where it came from and when that was checked."""
+    raw = json.loads(PRICE_TABLE_PATH.read_text(encoding="utf-8"))
+    for key, entry in raw["providers"].items():
+        assert entry["currency"] == "USD", key
+        assert entry["last_reviewed"], key
+        assert "prices.azure.com" in entry["source"], key
+        # The meter name is what makes the number checkable by someone who does
+        # not trust this file. A rate without one is just a number.
+        assert set(entry["meters"]) == {"input", "cached_input", "output"}, key
+        for kind, meter in entry["meters"].items():
+            assert meter.strip(), f"{key}:{kind}"
+
+
+@pytest.mark.parametrize("model", UNPRICED)
+def test_the_models_we_refuse_to_guess_at_stay_absent(table, model):
+    """Absence here is the feature. Exact-match lookup, no nearest neighbour."""
+    assert table.lookup("azure", model) is None
+    raw = json.loads(PRICE_TABLE_PATH.read_text(encoding="utf-8"))
+    entry = raw["models_deliberately_not_priced"][f"azure:{model}"]
+    assert entry["why_unpriced"].strip()
+    assert entry["what_would_settle_it"].strip()
+
+
+def test_the_runtime_block_is_empty_and_says_why():
+    """A sourced rate we cannot express is still not a rate we may invent."""
+    raw = json.loads(PRICE_TABLE_PATH.read_text(encoding="utf-8"))
+    assert raw["runtime"] == {}
+    assert "per session" in raw["cost_receipt_caveats"]["runtime"]
+
+
+# ── The half that reflects what really happened ──────────────────────────
+
+
+@pytest.mark.parametrize("task", REAL_TASKS, ids=repr)
+def test_real_grading_usage_is_recorded_but_not_priced(table, task):
+    """The judge model has no published rate here, and the receipt admits it.
+
+    This is the state every published Stage 3 payload is actually in. The point
+    of checking it is that "we do not know" has to survive as a distinct answer
+    from "it cost nothing".
+    """
+    receipt = _receipt_for(task, "gpt-5.6-sol", table)
+
+    assert receipt.status == STATUS_PARTIAL
+    assert REASON_PRICE_MISSING in receipt.missing_reasons
+    assert receipt.known_cost_usd == Decimal(0)
+    assert receipt.model_cost_usd == Decimal(0)
+
+    # Nothing that happened may go missing just because it could not be priced.
+    assert receipt.usage == task.totals
+    assert receipt.model_calls == len(task.stages)
+    assert {c.stage for c in receipt.components} == {s[0] for s in task.stages}
+    for component in receipt.components:
+        assert component.status == STATUS_PARTIAL
+        assert REASON_PRICE_MISSING in component.missing_reasons
+
+
+# ── The half that proves the arithmetic ──────────────────────────────────
+
+
+@pytest.mark.parametrize("task", REAL_TASKS, ids=repr)
+def test_the_same_tokens_price_exactly_under_a_model_we_do_cover(table, task):
+    """Re-label to gpt-5.4 and the receipt has to land on the cent.
+
+    Again: this figure is not what grading cost. It is proof that when a model
+    IS covered, the number the receipt produces is the number the meters imply.
+    """
+    receipt = _receipt_for(task, "gpt-5.4", table)
+
+    assert receipt.status == STATUS_COMPLETE
+    assert receipt.missing_reasons == ()
+    assert receipt.model_cost_usd == EXPECTED_UNDER_GPT_5_4[task.label]
+
+    # Independently of the hard-coded figure, the meters have to reproduce it.
+    meters = PUBLISHED_METERS["azure:gpt-5.4"]
+    by_hand = sum(
+        (
+            Decimal(inp - cached) * meters["input"]
+            + Decimal(cached) * meters["cached_input"]
+            + Decimal(out) * meters["output"]
+        )
+        for _stage, inp, cached, out, _reasoning in task.stages
+    ) / MILLION
+    assert receipt.model_cost_usd == by_hand
+
+    assert receipt.usage == task.totals
+
+
+@pytest.mark.parametrize("task", REAL_TASKS, ids=repr)
+def test_the_parts_add_up_to_the_whole(table, task):
+    """Components sum to the model cost; model plus runtime is the known cost.
+
+    A receipt whose parts do not add up invites a reader to trust whichever
+    number suits them.
+    """
+    receipt = _receipt_for(task, "gpt-5.4", table)
+
+    assert sum(
+        (c.known_cost_usd for c in receipt.components), Decimal(0)
+    ) == receipt.model_cost_usd
+    assert receipt.known_cost_usd == receipt.model_cost_usd + receipt.runtime_cost_usd
+    assert sum(c.model_calls for c in receipt.components) == receipt.model_calls
+    for field in task.totals:
+        assert (
+            sum(c.usage[field] for c in receipt.components) == receipt.usage[field]
+        ), field
+
+
+# ── The two ways a token gets charged twice ──────────────────────────────
+
+
+def test_cached_input_is_charged_once_and_at_the_cache_rate(table):
+    """Cached tokens are part of the input count, not an addition to it.
+
+    Uses judge-only-f84ea6ac's real numbers: 225,011 input of which 160,679 came
+    from cache. If those 160,679 were charged at both rates the answer would be
+    higher by exactly their cache rate, and if the split were ignored entirely
+    it would be higher by the difference between the two rates.
+    """
+    meters = PUBLISHED_METERS["azure:gpt-5.4"]
+    price = table.lookup("azure", "gpt-5.4")
+    total, cached, out = 225_011, 160_679, 28_631
+
+    with_cache = price_call(
+        price,
+        CallUsage(
+            input_tokens=total, cached_input_tokens=cached, output_tokens=out
+        ),
+    ).cost_usd
+    without_cache = price_call(
+        price,
+        CallUsage(input_tokens=total, cached_input_tokens=0, output_tokens=out),
+    ).cost_usd
+
+    # The saving is the whole cached block moving from the input rate to the
+    # cache rate — no more, which would mean double-charging, and no less,
+    # which would mean the cache rate was never applied.
+    saving = Decimal(cached) * (meters["input"] - meters["cached_input"]) / MILLION
+    assert without_cache - with_cache == saving
+    assert with_cache < without_cache
+
+    charged_twice = with_cache + Decimal(cached) * meters["cached_input"] / MILLION
+    assert with_cache != charged_twice
+
+
+def test_reasoning_tokens_do_not_add_a_second_charge(table):
+    """These deployments count reasoning inside the completion tokens.
+
+    So the cost has to be blind to the reasoning field. If it moves, the same
+    tokens are being billed as output and then again as reasoning.
+    """
+    price = table.lookup("azure", "gpt-5.4")
+    base = dict(input_tokens=225_011, cached_input_tokens=160_679, output_tokens=28_631)
+
+    none_reported = price_call(price, CallUsage(**base, reasoning_tokens=None)).cost_usd
+    real = price_call(price, CallUsage(**base, reasoning_tokens=23_878)).cost_usd
+    absurd = price_call(price, CallUsage(**base, reasoning_tokens=10_000_000)).cost_usd
+
+    assert none_reported == real == absurd
+    assert real == EXPECTED_UNDER_GPT_5_4["judge-only-f84ea6ac"]
+
+
+# ── The receipt has to name the table it used ────────────────────────────
+
+
+def test_the_receipt_fingerprints_the_table_that_priced_it(table):
+    """The fingerprint has to be the bytes on disk, or it traces to nothing."""
+    on_disk = hashlib.sha256(PRICE_TABLE_PATH.read_bytes()).hexdigest()
+    assert table.sha256 == on_disk
+
+    receipt = _receipt_for(REAL_TASKS[1], "gpt-5.4", table)
+    assert receipt.price_table_sha256 == on_disk
+    assert receipt.as_dict()["price_table_sha256"] == on_disk
+
+
+def test_changing_a_rate_changes_the_fingerprint(table, tmp_path):
+    """Otherwise a receipt could name a table whose numbers had since moved."""
+    raw = json.loads(PRICE_TABLE_PATH.read_text(encoding="utf-8"))
+    raw["providers"]["azure:gpt-5.4"]["output_usd_per_million"] = "16.50"
+    altered = tmp_path / "model_price_table.json"
+    altered.write_text(json.dumps(raw, indent=2), encoding="utf-8")
+
+    other = load_receipt_price_table(altered)
+    assert other.sha256 != table.sha256
+    assert other.models["azure:gpt-5.4"].output_usd_per_million == Decimal("16.50")


### PR DESCRIPTION
## 무엇이 문제였나

영수증에 박혀 있던 단가가 **어떤 공표 meter와도 맞지 않았다.** 2026-08-29 Azure Retail Prices API(`productName: Azure OpenAI GPT5`, `type: Consumption`)로 한 줄씩 대조한 결과다.

| 기존 값 | 실제로 그 숫자의 정체 |
|---|---|
| 입력 `1.25` | 이 코드가 호출하지 않는 **Batch API**의 입력 단가 |
| 출력 `5.00` | 실제로는 **입력** 단가인데 출력 자리에 들어가 있었다 |
| 캐시 입력 = 입력 | 캐시 토큰을 약 **10배 과다 청구**. 실제 과제 다섯 건에서 캐시 토큰은 입력의 23~77%(합계 34%)를 차지한다 |
| `gpt-5.4-pro` 출력 `15.00` | 공표 meter는 `180.00`. **12배 과소 청구** |

Standard Global 배포의 실제 `gpt-5.4`는 입력 `2.50` / 캐시 `0.25` / 출력 `15.00`이다.

## 무엇을 했나

**세 모델만 값을 매긴다** — `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`. 단가마다 meter 이름, 조회 출처, 검토일, 통화, 과금 단위를 붙였다. meter 이름을 적는 이유는 이 파일을 믿지 않는 사람도 숫자를 직접 확인할 수 있게 하기 위해서다. 출처 없는 숫자는 그냥 숫자다.

**배포 이름을 비슷한 모델로 자동 대체하지 않는다.** 조회는 정확히 일치할 때만 성공한다.

**확정할 수 없는 축은 침묵하지 않고 전제로 적었다.** 배포 zone(Global vs Data Zone)은 저장소 어떤 산출물로도 확정되지 않는다. 두 후보 사이 차이가 10~20%이므로, 각 항목에 "Global로 가정했고 Data Zone이면 얼마가 된다"를 명시했다.

**값을 세울 수 없는 모델은 숫자를 지어내지 않고 뺐다.** 왜 뺐는지와 무엇이 있어야 채울 수 있는지를 같이 적었다.

| 뺀 모델 | 이유 |
|---|---|
| `gpt-5.6-sol` | meter는 24개 공표돼 있으나 **배포 zone과 컨텍스트 구간이 둘 다 미해결**. 후보 meter 간 격차가 입력 2배·출력 1.5배다. Azure가 구간을 "short/long context"로만 부르고 임계값을 공표하지 않아, **토큰을 재도 비교할 대상이 없다** |
| `gpt-audio-1.5` | 어떤 이름으로도 **meter가 존재하지 않는다** |
| `gpt-5.4-pro` | **캐시 입력 meter가 공표돼 있지 않다** |

**실행 환경 단가는 출처를 찾았으나 표현할 수 없다.** `Code-Interpreter-global Session`은 **세션당** 과금인데 로더는 시간당 단가만 받는다. 스키마 변경은 지금 동결 구간 안이므로 `runtime`은 빈 채로 두고 파일에 이 이유를 적었다. 기존 파일이 적어 둔 이유("출처를 찾지 못했다")는 사실이 아니었다.

## 지금 영수증이 왜 전부 `partial`인가

디스크에 있는 Stage 3 shard 여섯 개(000·001·005·006·008·010)를 그대로 읽었다. **86개 과제, 10,035회 호출, 148개 구성요소. 전부 `partial`, `complete`는 0건.**

실제로 호출된 모델은 둘뿐이다.

| 어디서 | provider | deployment | requested | **resolved** | API | api_version | 호출 |
|---|---|---|---|---|---|---|---|
| 판정 | `azure_openai` | `gpt-5.6-sol` | `gpt-5.6-sol` | **기록 없음** | `responses` | `2025-04-01-preview` | 9,701 |
| 시각 판독 | `azure_openai` | `gpt-5.6-sol` | `gpt-5.6-sol` | **기록 없음** | `responses` | `2025-04-01-preview` | ↴ |
| 청각 판독 | `azure_openai` | `gpt-audio-1.5` | `gpt-audio-1.5` | **기록 없음** | 기록 없음 | 기록 없음 | 합계 334 |

판정 신원은 shard 여섯 개 전부 동일하다. 청각 판독은 설정만 된 게 아니라 **실제로 돌았다** — shard 001에 `perception_called: true`와 `tools_used: [..., "audio_judge"]`가 6건 있다.

이유는 네 가지이고, 서로 다른 이유다.

1. `gpt-5.6-sol`은 meter가 있으나 축 두 개가 열려 있다 (위 표).
2. `gpt-audio-1.5`는 meter 자체가 없다.
3. **영수증은 자기가 값매김하지 못한 모델이 무엇인지 기록하지 않는다.** 구성요소 148개 전부 모델 필드가 없다.
4. **`perception` 구성요소가 서로 다른 두 모델을 한 줄에 합쳐 놓았다.** 그래서 `gpt-5.6-sol`을 값매김한 뒤에도 그 줄은 여전히 정확히 값매김되지 않는다.

그리고 **조회 키를 발행된 산출물로는 검증할 수 없다.** `core/cost_receipts.py:962`는 `resolved_model or requested_model`로 값을 찾는데, `resolved_model`은 원장에만 있고 원장은 발행되지 않으며(#84) 영수증은 그 필드를 버린다. shard 산출물에는 **설정된** 배포 이름만 남는다. 응답이 날짜 붙은 이름을 돌려줬다면 그게 조회 키였을 텐데, 그걸 말해 주는 파일이 없다. 1과제 스모크가 읽어서가 아니라 **돌려서** 확정해야 하는 이유가 이것이다.

**이 영수증들에 금액이 없는 건 결함이 아니다.** 호출 수도 토큰 수도 전부 남아 있다. 없는 건 단가뿐이고, 없는 게 맞다. 여기에 `$0`을 쓰는 게 결함이다.

## 일부러 안 한 것

계획용 `models` 블록은 **건드리지 않았다.** 그 값들도 전부 공표 meter와 맞지 않는다는 것을 확인해 파일에 결함으로 적어 뒀다(실행 전 상한을 3~12배 낮게 잡고 있다). 다만 이 블록은 자체 테스트를 가진 다른 파일에 미러돼 있어 **별도 변경으로 다뤄야 한다.** 한 PR에서 두 개의 폭발 반경을 섞지 않는다.

## 기존 실험에 영향 없음

네 가지로 확인했다.

1. 발행된 payload의 `price_table_sha256`을 디스크 파일과 대조하는 코드가 `.py`/`.mjs`/`.ts`/`.tsx`/`.yml` 어디에도 없다. 옛 지문을 달고 발행된 payload는 그대로 통과한다.
2. `core/agentic_pricing.py`는 최상위 키 집합이 정확히 일치해야 하는 **구조가 다른 별도 표**를 쓴다. 이 파일이 그 자리에 들어갈 수 없다.
3. 실제 shard 여섯 개의 영수증 86건은 **이미 전부 `partial`**이다. `complete`에서 바뀌는 것이 하나도 없다.
4. **채점 소스 해시가 이 브랜치에서 바뀌지 않는다 — 주장이 아니라 측정값이다.**

4번이 지금 가장 중요하다. 진행 중인 Stage 3는 11개 shard 중 **9개가 이미 main에 들어와 있고**(0·2·3·5·6·7·8·9·10), 남은 것은 shard 1과 4다. 아홉 개 전부 소스 해시 `ce7d4978bce9effc` 아래 있다. 이 브랜치에서 같은 config로 `compute_grader_source_hash`를 직접 돌린 결과:

```
ce7d4978bce9effc113708caca10a705d215eaf0cd8a759aa3bcc759799f0338
```

**이미 들어온 shard 아홉 개와 같은 해시다.** 그러므로 이 PR이 병합된 뒤 shard 1·4를 돌려도 앞의 아홉 개와 같은 디렉터리에 들어간다. 코퍼스가 둘로 갈라지지 않는다.

이유는 단순하다. `step8_grade.py:167-173`의 `source_paths`는 `step8_grade.py`, `core/**/*.py`, `schemas/grade.schema.json`, `requirements.txt`, `scripts/download_inference_from_hf.py`, 프롬프트 템플릿, config뿐이다. 이 PR의 두 파일은 `experiments/`와 `tests/` 아래에 있어 **어느 항목에도 해당하지 않는다.** 옛 sha256을 고정한 테스트도 없다.

## 검증

- **새 테스트 25개** — 모델을 부르지 않는다. 실제 shard에서 읽은 과제 다섯 건(최소·최대 포함, 두 건은 판독 단계까지 있는 다단계)의 토큰 수를 넣어 확인한다. 판정 모델이 가격표에 없을 때 영수증이 `partial`로 남고 **호출·토큰이 하나도 사라지지 않는지**, 같은 토큰을 값매김 가능한 모델로 바꿔 달면 **센트 단위까지 맞는지**, **캐시·추론 토큰이 두 번 청구되지 않는지**, 구성요소 합이 전체와 맞는지, 영수증이 자기를 값매김한 표의 **지문**을 남기는지.
- **테스트가 초록인 것만으로는 부족해서 두 번 망가뜨려 봤다.** 출력 단가를 옛 값으로 되돌리면 7건 실패, 추론 토큰에 별도 단가를 붙이면 7건 실패. 표는 두 번 다 바이트 단위로 복원했다.
- **전체 스위트: 5666 passed, 6 skipped, 0 failed** (10분 51초).

## 병합 조건

**지금 병합하면 안 된다.** 유료 채점 run이 아직 shard를 밀어 넣고 있다(`origin/main`이 방금 shard 2 결과로 움직였다). 이 PR은 채점 소스 해시 대상이 아니지만, 진행 중인 run이 끝난 뒤 병합한다.

## 세션 A 의존 없음

PR #266~#269가 건드리는 파일 11개와 이 PR의 파일 2개는 **겹치는 것이 하나도 없다.** 따라서 의존 PR을 만들 필요가 없고, 순서 제약도 없다.

<details>
<summary>대조 결과</summary>

- #266 → `core/cost_metering.py`, `core/perception/audio.py`, `core/perception/vision.py`, `core/tool_calling_judge.py` + 테스트 4
- #267 → `core/perception/audio.py` + 테스트 2
- #268 → `step8_grade.py` + 테스트 1
- #269 → `core/tool_calling_judge.py` + 테스트 1
- 이 PR → `experiments/execution_envelope/model_price_table.json`, `tests/test_receipt_prices_match_the_published_meters.py`

</details>
