### PR TITLE
fix(grading): 실패한 유료 실행이 결과와 비용을 남기게 한다

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -490,17 +490,40 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]]; then
-            echo "::error::checked out HEAD does not match the dispatched main SHA"
-            exit 1
-          fi
           if [[ "$(git symbolic-ref --quiet --short HEAD)" != "main" ]]; then
             echo "::error::checkout is not on the local main branch"
             exit 1
           fi
-          if [[ "$(git rev-parse refs/remotes/origin/main)" != "$GITHUB_SHA" ]]; then
-            echo "::error::origin/main moved after dispatch; retry from the new main"
-            exit 1
+
+          # Same reasoning as the paid job's copy, which carries the full
+          # explanation: the branch tip is allowed to move, the grading inputs
+          # are not. Kept in step with it by
+          # test_a_sibling_shards_commit_cannot_kill_a_chunk.py, which reads
+          # both lists and requires them identical.
+          GRADING_INPUT_PATHS=(
+            .github/workflows/grade-run.yml
+            batch-runner/core
+            batch-runner/experiments
+            batch-runner/grading_configs
+            batch-runner/prompts
+            batch-runner/requirements.txt
+            batch-runner/schemas
+            batch-runner/scripts
+            batch-runner/step8_grade.py
+            batch-runner/step9_merge_shards.py
+          )
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [[ "$HEAD_SHA" != "$GITHUB_SHA" ]]; then
+            git fetch --no-tags --quiet --depth=1 origin "$GITHUB_SHA"
+            CHANGED="$(git diff --name-only "$GITHUB_SHA" "$HEAD_SHA" -- "${GRADING_INPUT_PATHS[@]}")"
+            if [[ -n "$CHANGED" ]]; then
+              echo "::error::grading inputs changed between the dispatched $GITHUB_SHA and the checked out $HEAD_SHA; retry from the new main"
+              while IFS= read -r changed_path; do
+                echo "::error::changed grading input: $changed_path"
+              done <<< "$CHANGED"
+              exit 1
+            fi
+            echo "[pin] main advanced $GITHUB_SHA -> $HEAD_SHA; no grading input differs"
           fi
           if git config --local --name-only --get-regexp '^http\..*\.extraheader$' >/dev/null; then
             echo "::error::dry-run checkout must not retain repository credentials"
@@ -675,10 +698,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]]; then
-            echo "::error::checked out HEAD does not match the dispatched main SHA"
-            exit 1
-          fi
           if [[ "$(git symbolic-ref --quiet --short HEAD)" != "main" ]]; then
             echo "::error::checkout is not on the local main branch"
             exit 1
@@ -687,9 +706,52 @@ jobs:
             echo "::error::local main does not track origin/main"
             exit 1
           fi
-          if [[ "$(git rev-parse refs/remotes/origin/main)" != "$GITHUB_SHA" ]]; then
-            echo "::error::origin/main moved after dispatch; retry from the new main"
-            exit 1
+
+          # main moves between dispatch and here, and that is normal: eleven
+          # shards commit their grades to the same branch, so a chunk that
+          # waits on its paid-approval gate almost always comes back to a main
+          # a sibling has already written to. Run 33248832615 was dispatched at
+          # d5c1e18 and killed 117 seconds later because shard 3 landed
+          # shard-003-of-011.json in the gap. One grade file, no code, and the
+          # chunk died with its approval already spent -- an equality check on
+          # the branch tip is false for the most ordinary reason there is.
+          #
+          # What must not move is what this job *reads*. Every path below is an
+          # input to grading; nothing the job writes appears in the list. The
+          # set is a deliberate superset of what `compute_grader_source_hash`
+          # covers -- whole directories rather than the `.py` files and the one
+          # prompt template it selects -- because erring wide can only refuse a
+          # run that would have been fine, while erring narrow lets changed
+          # code grade under an approval given for something else.
+          GRADING_INPUT_PATHS=(
+            .github/workflows/grade-run.yml
+            batch-runner/core
+            batch-runner/experiments
+            batch-runner/grading_configs
+            batch-runner/prompts
+            batch-runner/requirements.txt
+            batch-runner/schemas
+            batch-runner/scripts
+            batch-runner/step8_grade.py
+            batch-runner/step9_merge_shards.py
+          )
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [[ "$HEAD_SHA" != "$GITHUB_SHA" ]]; then
+            # Fetching one commit by SHA into the shallow clone. `git diff`
+            # needs both trees and not the history between them, so there is
+            # no reason to deepen. The repository is public, so this needs no
+            # credentials -- which matters in the read-only job, where they
+            # are deliberately absent.
+            git fetch --no-tags --quiet --depth=1 origin "$GITHUB_SHA"
+            CHANGED="$(git diff --name-only "$GITHUB_SHA" "$HEAD_SHA" -- "${GRADING_INPUT_PATHS[@]}")"
+            if [[ -n "$CHANGED" ]]; then
+              echo "::error::grading inputs changed between the dispatched $GITHUB_SHA and the checked out $HEAD_SHA; retry from the new main"
+              while IFS= read -r changed_path; do
+                echo "::error::changed grading input: $changed_path"
+              done <<< "$CHANGED"
+              exit 1
+            fi
+            echo "[pin] main advanced $GITHUB_SHA -> $HEAD_SHA; no grading input differs"
           fi
           if ! git config --local --name-only --get-regexp '^http\..*\.extraheader$' >/dev/null; then
             echo "::error::checkout credentials required for result publication are missing"
@@ -951,6 +1013,8 @@ jobs:
         if: always() && steps.grade.conclusion == 'success' && (steps.grade.outputs.rc == '0' || steps.grade.outputs.rc == '7') && inputs.dry_run == false
         env:
           EXPECTED_GRADE_STATUS: ${{ steps.grade.outputs.rc == '7' && 'partial' || steps.grade.outputs.grade_status }}
+          COST_LEDGER_FILE: ${{ steps.grade.outputs.cost_ledger_file }}
+          COST_LEDGER_SHA256: ${{ steps.grade.outputs.cost_ledger_sha256 }}
         run: |
           GRADE_FILE="${{ steps.grade.outputs.grade_file }}"
           if [[ -z "$GRADE_FILE" || ! -f "$GRADE_FILE" ]]; then
@@ -991,6 +1055,39 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -- "$GRADE_FILE"
+          # The per-call cost ledger travels with the grade it belongs to.
+          #
+          # It has to be committed, not merely uploaded: step9_merge_shards
+          # looks for each shard's ledger *beside that shard's JSON* in the
+          # checkout, and a resumed chunk rebuilds its ledger by importing the
+          # export the previous chunk left there. Both of those read from the
+          # repository, because a chunk gets a fresh runner and the workspace
+          # the ledger was written into is gone by the time anyone looks. Until
+          # this line existed the file was never committed anywhere, so the
+          # merge silently dropped every shard's ledger and each chunk counted
+          # only its own calls.
+          if [[ -n "$COST_LEDGER_FILE" ]]; then
+            if [[ "$COST_LEDGER_FILE" == /* || "$COST_LEDGER_FILE" == *$'\n'* || "$COST_LEDGER_FILE" != data/grades/*.cost_ledger.jsonl || ! -f "$COST_LEDGER_FILE" || -L "$COST_LEDGER_FILE" ]]; then
+              echo "::error::resolved cost ledger path is invalid: $COST_LEDGER_FILE"
+              exit 1
+            fi
+            LEDGER_BLOB_SHA="$(python - "$COST_LEDGER_FILE" <<'PY'
+          import hashlib
+          import sys
+          from pathlib import Path
+
+          print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
+          PY
+          )"
+            if [[ "$LEDGER_BLOB_SHA" != "$COST_LEDGER_SHA256" ]]; then
+              echo "::error::cost ledger on disk does not match the digest step8 published"
+              exit 1
+            fi
+            git add -- "$COST_LEDGER_FILE"
+            echo "[cost] committing ledger $COST_LEDGER_FILE ($LEDGER_BLOB_SHA)"
+          else
+            echo "::warning::this grade carries no cost ledger; its per-call costs will not survive the run"
+          fi
           if git diff --staged --quiet; then
             if [[ "${{ steps.grade.outputs.rc }}" == "7" ]]; then
               echo "::error::rc=7 requires a newly persisted partial grade diff"
@@ -1366,6 +1463,28 @@ jobs:
             echo "::error::could not push the analysis to ${GITHUB_REF_NAME} after 6 attempts"
             exit 1
           fi
+
+      - name: Upload cost ledger
+        # Deliberately *not* gated on steps.grade.outputs.grade_file. That
+        # output is written inside the save path, so a run that dies before its
+        # first save has none -- which is exactly the run whose costs most need
+        # preserving. Shard 4 of the first Stage 3 attempt spent five hours and
+        # left `{"total_count":0,"artifacts":[]}` behind, because this upload
+        # did not exist and the grade upload below had nothing to trigger on.
+        #
+        # Both sidecars go up. The JSONL is the portable record with a digest;
+        # the sqlite3 is what the process was writing into as it went, so it
+        # survives even a kill that never let the exporter run.
+        if: always() && inputs.dry_run == false
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cost-ledger-${{ env.GRADE_EXPERIMENT_YAML }}${{ inputs.shard_count > 1 && format('-shard{0}of{1}', inputs.shard_index, inputs.shard_count) || '' }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            data/grades/**/*.cost_ledger.jsonl
+            data/grades/**/*.cost_ledger.sqlite3
+          if-no-files-found: warn
+          retention-days: 90
 
       - name: Upload grade artifact
         if: always() && inputs.dry_run == false && steps.grade.outputs.grade_file != ''

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -46,6 +46,23 @@ DEFAULT_GRADER_TIMEOUT = 600
 DEFAULT_GRADER_API_VERSION = "2025-04-01-preview"
 
 
+class GradingDeadlineExceeded(RuntimeError):
+    """The run ran out of time part-way through a task.
+
+    Raised out of ``grade_task`` rather than returned, because a half-marked
+    task must not become a grade. Its remaining items would be missing, and a
+    task missing items scores lower than one that was never attempted — a
+    silent penalty for having been unlucky with the clock. The driver drops
+    the task, keeps everything already finished, and lets the next chunk mark
+    it from the beginning.
+
+    The alternative — no check at all — is what shard 4 of the first Stage 3
+    attempt did: one task held the loop for four hours past a four-hour
+    budget, the job hit ``timeout-minutes`` at five hours twenty, and six
+    finished tasks went down with it.
+    """
+
+
 def grader_transport_options(config: dict) -> dict[str, object]:
     """Return the exact transport fields bound into grader route identity."""
     judge = config.get("judge") or {}
@@ -238,9 +255,15 @@ class Grader:
         client=None,
         client_factory: AzureAIClientFactory | None = None,
         cost_recorder=None,
+        should_stop: Optional[Callable[[], bool]] = None,
     ):
         self.config = config
         self.rubric_loader = rubric_loader
+
+        # The driver's answer to "should I still be working?", consulted
+        # between units of work inside a task rather than only between tasks.
+        # See ``_check_should_stop``.
+        self.should_stop = should_stop
 
         provider = self.config.get("judge", {}).get("provider", "azure_openai")
         if provider != "azure_openai":
@@ -359,6 +382,26 @@ class Grader:
     def _classify(item: RubricItem) -> tuple[str, Optional[str]]:
         return "judge", None
 
+    def _check_should_stop(self, task_id: str, unit: str) -> None:
+        """Give up on this task if the driver says the run is out of time.
+
+        Called at the top of the two loops that can each run for hours: the
+        rubric items of a task, and the split children of one item. Neither is
+        bounded by anything but the deliverable — a task with forty children
+        and twenty items makes eight hundred judge conversations, and each of
+        those may retry — so a budget consulted only between tasks is a budget
+        that a single unlucky task can ignore completely.
+
+        The check sits *before* the work, so the unit that would have started
+        is never charged for. What has already been spent on this task is
+        spent; the loss is bounded at one task and the driver keeps the rest.
+        """
+        if self.should_stop is None or not self.should_stop():
+            return
+        raise GradingDeadlineExceeded(
+            f"grading deadline reached during {task_id} while starting {unit}"
+        )
+
     def grade_task(self, task: TaskRubric, deliverable_dir: str) -> TaskGrade:
         deliverable_path = Path(deliverable_dir)
         files = self._list_files(deliverable_path)
@@ -413,6 +456,7 @@ class Grader:
         judge_cached_tokens = 0
 
         for item, runtime_plan in zip(task.rubric_items, runtime_plans):
+            self._check_should_stop(task.task_id, f"item {item.rubric_item_id}")
             mode, pattern_id = self._classify(item)
             plan = runtime_plan.target_plan
 
@@ -1001,6 +1045,7 @@ class Grader:
             target = target_by_id.get(target_id)
             if target is None:
                 continue
+            self._check_should_stop(task.task_id, f"child {target_id}")
             self._last_cached_tokens = 0
             child, in_tok, out_tok = self._judge_via_tool_calling_selected(
                 task,
@@ -1297,9 +1342,14 @@ class Grader:
     def _apply_tpm_delay(self) -> None:
         """TPM guard shared by the tool judge and both perception paths.
 
-        Passed as ``before_upstream_call`` into ``ToolCallingJudge`` and
-        ``VisionPerception``, so this is live v2 infrastructure, not part
-        of the legacy text-extract path removed in task 207.
+        Passed as ``before_upstream_call`` into ``ToolCallingJudge``,
+        ``VisionPerception`` and ``AudioPerception``, so this is live v2
+        infrastructure, not part of the legacy text-extract path removed in
+        task 207.
+
+        All three share one spacer on purpose: they share one connection and
+        therefore one token-per-minute allowance, so a guard that only some
+        of them honour paces nothing.
         """
         if self._min_delay_seconds <= 0:
             return
@@ -1563,6 +1613,7 @@ class Grader:
                 trim_seconds=int(
                     aud_cfg.get("trim_seconds", AUDIO_TRIM_SECONDS)
                 ),
+                before_upstream_call=self._apply_tpm_delay,
             )
 
         return ToolCallingJudge(

--- a/batch-runner/core/perception/audio.py
+++ b/batch-runner/core/perception/audio.py
@@ -32,7 +32,7 @@ import json
 import os
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from core.cost_metering import read_reported_usage
 from core.public_error import public_provider_error_text, public_task_error_text
@@ -180,6 +180,14 @@ class AudioPerception:
     deployment: str = "gpt-audio-1.5"
     call_cap: int = AUDIO_CALL_CAP
     trim_seconds: int = AUDIO_TRIM_SECONDS
+    #: Zero-argument rate-limit guard, invoked immediately before every
+    #: request. The grader passes its own TPM spacer here, the same one the
+    #: main judge and the vision sub-judge get. Audio went without it for as
+    #: long as this class has existed, which was invisible because a mistyped
+    #: content part meant no audio request ever reached a model to be
+    #: throttled; with the shape corrected, an unguarded reader is a reader
+    #: that can spend a shard's remaining budget on 429s.
+    before_upstream_call: Optional[Callable[[], None]] = None
 
     _calls_used: int = field(default=0, init=False)
 
@@ -230,6 +238,8 @@ class AudioPerception:
                 judge_error="unsupported_audio_format",
             )
         b64 = base64.b64encode(data).decode("ascii")
+        if self.before_upstream_call is not None:
+            self.before_upstream_call()
         self._calls_used += 1
         call_started = time.perf_counter()
         input_tokens = 0

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -16,6 +16,7 @@ import json
 import math
 import os
 import re
+import signal
 import sys
 import tempfile
 import time
@@ -37,12 +38,14 @@ from core.cost_receipts import (
     BUCKET_GRADING,
     STATUS_COMPLETE,
     CostReceipt,
+    CostReceiptLedger,
     ledger_reference,
     summarise_receipts,
 )
 from core.experiment_config import ExperimentConfig
 from core.grader import (
     Grader,
+    GradingDeadlineExceeded,
     _is_critical_item,
     grader_transport_options,
     resolve_tool_prompt_path,
@@ -329,6 +332,24 @@ def _repo_relative_grade_file(out_path: Path) -> str:
     if not value or any(char in value for char in ("\r", "\n")):
         raise ValueError("grade output path is not safe for GITHUB_OUTPUT")
     return value
+
+
+def _exit_on_signal(signum: int, _frame: Any) -> None:
+    """Leave through ``SystemExit`` so the exit handlers get to run.
+
+    GitHub sends SIGTERM when a job passes its ``timeout-minutes``. Python's
+    default disposition for it kills the process where it stands, which skips
+    ``atexit`` — and the cost ledger's final export is an ``atexit`` handler,
+    because a run that is being killed is precisely the run that never reached
+    a save. Raising ``SystemExit`` instead unwinds normally and lets the export
+    happen. The code is the conventional ``128 + signal`` so that nothing
+    downstream can read a cancellation as a clean finish.
+    """
+    print(
+        f"[signal] received {signum}; unwinding so exit handlers can run",
+        file=sys.stderr,
+    )
+    sys.exit(128 + signum)
 
 
 def _write_github_output(name: str, value: str) -> None:
@@ -2141,13 +2162,55 @@ def main() -> int:
     # which tasks are already done — so the round is read off the ledger's size.
     cost_ledger_path = out_path.with_name(out_path.stem + ".cost_ledger.sqlite3")
     cost_export_path = out_path.with_name(out_path.stem + ".cost_ledger.jsonl")
+    cost_run_id = f"{args.experiment_yaml_name}|{config_hash}|{grader_source_hash}"
+
+    # The paragraph above describes a ledger that outlives its chunk, and on a
+    # developer's machine it does. In CI it did not: every chunk gets a fresh
+    # runner with an empty workspace, so the sqlite3 a previous chunk filled in
+    # was gone before the next one looked for it, and each chunk opened an
+    # empty ledger and exported only its own calls. What does survive is the
+    # JSONL, which the workflow commits beside the grade file — so that is what
+    # the ledger is rebuilt from here.
+    #
+    # This has to happen *before* the recorder is opened. ``continue_rounds``
+    # reads the round number off the ledger's size, and the round is folded
+    # into every call identifier; a ledger seeded afterwards would hand this
+    # chunk identifiers the previous one had already used, and importing those
+    # later would look like a contradiction rather than a duplicate.
+    if cost_export_path.is_file() and not cost_ledger_path.exists():
+        try:
+            seed = CostReceiptLedger(cost_ledger_path, run_id=cost_run_id)
+            try:
+                recovered = seed.import_jsonl(cost_export_path)
+            finally:
+                seed.close()
+            print(
+                f"[cost] recovered {recovered} records from "
+                f"{cost_export_path.name}",
+                file=sys.stderr,
+            )
+        except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+            print(
+                f"[cost] ledger recovery from {cost_export_path.name} failed "
+                f"({type(exc).__name__}); this chunk's receipts will cover "
+                "this chunk only",
+                file=sys.stderr,
+            )
+
     cost_recorder, cost_ledger_note = open_cost_recorder(
         cost_ledger_path,
-        run_id=f"{args.experiment_yaml_name}|{config_hash}|{grader_source_hash}",
+        run_id=cost_run_id,
         continue_rounds=True,
     )
     if cost_ledger_note:
         print(f"[cost] {cost_ledger_note}", file=sys.stderr)
+
+    # The ledger is a sqlite database, and exporting one that has been closed
+    # raises rather than returning nothing. Both facts below exist to keep the
+    # export strictly before the close on every path out of this function; see
+    # ``close_grader`` for why the ordering is not obvious.
+    ledger_closed = False
+    last_ledger_digest: str | None = None
 
     def cost_ledger_pointer() -> dict[str, str] | None:
         """Export the ledger and return the pointer a saved grade carries.
@@ -2169,6 +2232,72 @@ def main() -> int:
             )
             return None
         return ledger_reference(cost_export_path.name, digest)
+
+    def flush_cost_ledger() -> None:
+        """Put the ledger on disk wherever this run ends, including badly.
+
+        Exporting at each save is right for the pointer a saved grade carries
+        and wrong for keeping the record, because a run that never saves never
+        exports. Shard 4 of the first Stage 3 attempt is the case: it graded
+        six tasks over five hours, hit the job's own timeout inside the
+        seventh, saved nothing — ``partial_save_every_n_tasks`` is 10 — and
+        left no artifact behind, so five hours of paid calls are recorded
+        nowhere at all.
+
+        This runs on every return, on an unhandled exception, and on the
+        SIGTERM a cancelled job arrives as. It publishes the path and digest as
+        step outputs too, so the workflow can preserve them without having to
+        guess where they are.
+
+        It refuses to run once the ledger is shut. ``atexit`` unwinds in
+        reverse order of registration, so on the paths that do not go through
+        ``finish`` — the crash and the cancellation, which are the ones this
+        exists for — ``close_grader`` runs first and closes the database out
+        from under this. Exporting then raises ``ProgrammingError`` and prints
+        an export failure, which is both the wrong outcome (nothing is
+        written) and the wrong message (it reads as loss on the normal path,
+        where the ledger is already safely on disk). The flush is therefore
+        performed by ``close_grader`` immediately before it closes, and this
+        guard makes the later call a silent no-op.
+        """
+        nonlocal last_ledger_digest
+        if cost_recorder is None or ledger_closed:
+            return
+        try:
+            digest = cost_recorder.ledger.export_jsonl(cost_export_path)
+        except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+            print(
+                f"[cost] final ledger export failed ({type(exc).__name__})",
+                file=sys.stderr,
+            )
+            return
+        if digest == last_ledger_digest:
+            # Already reported, and nothing has been recorded since. Saying it
+            # twice invites the reader to look for two ledgers.
+            return
+        last_ledger_digest = digest
+        print(
+            f"[cost] ledger → {cost_export_path.name} sha256={digest}",
+            file=sys.stderr,
+        )
+        try:
+            _write_github_output(
+                "cost_ledger_file", _repo_relative_grade_file(cost_export_path)
+            )
+            _write_github_output("cost_ledger_sha256", digest)
+        except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+            print(
+                f"[cost] could not publish the ledger pointer "
+                f"({type(exc).__name__})",
+                file=sys.stderr,
+            )
+
+    atexit.register(flush_cost_ledger)
+    for _signum in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(_signum, _exit_on_signal)
+        except (ValueError, OSError):  # not the main thread, or unsupported
+            pass
 
     def grading_receipt(task_id: str) -> dict:
         """This task's grading receipt, or an explicit reason there is none.
@@ -2200,11 +2329,14 @@ def main() -> int:
             file=sys.stderr,
         )
         if cost_recorder is not None:
+            flush_cost_ledger()
+            ledger_closed = True
             cost_recorder.ledger.close()
         return 4
 
     def close_grader() -> None:
         nonlocal grader
+        nonlocal ledger_closed
         active_grader = grader
         grader = None
         try:
@@ -2220,6 +2352,20 @@ def main() -> int:
         # After the judge, never before: closing the ledger first would leave
         # a client that is still being shut down writing to a closed database.
         if cost_recorder is not None:
+            # The last chance to export, and on a crash or a cancellation the
+            # only one. This function is registered with ``atexit`` after
+            # ``flush_cost_ledger`` and so unwinds before it, which means a run
+            # that does not reach ``finish`` arrives here with the ledger still
+            # unexported. Flushing from inside the close is what makes the
+            # ordering true by construction instead of by registration order.
+            try:
+                flush_cost_ledger()
+            except BaseException as exc:
+                print(
+                    f"ERROR: cost ledger export failed: {type(exc).__name__}",
+                    file=sys.stderr,
+                )
+            ledger_closed = True
             try:
                 cost_recorder.ledger.close()
             except BaseException as exc:
@@ -2267,16 +2413,132 @@ def main() -> int:
     # for tighter chunks, or longer for self-hosted runners).
     time_budget_sec = int(os.getenv("GRADER_TIME_BUDGET_SEC", "14400"))
     grade_loop_start = time.monotonic()
+
+    # A finished task belongs on disk within this long, whatever the task
+    # count says. ``partial_save_every_n_tasks`` counts tasks, and a shard
+    # holds seventeen of them, so the first checkpoint of a default run falls
+    # after the tenth — which shard 4 of the first Stage 3 attempt never
+    # reached. It finished six, spent four more hours inside the seventh, and
+    # was killed with an empty output directory. Six tasks were graded and
+    # paid for twice.
+    partial_save_max_interval_sec = float(
+        config.get("output", {}).get("partial_save_max_interval_sec", 900)
+    )
+    last_partial_save = grade_loop_start
+    # Seeded from the loop's own start rather than a second reading of the
+    # clock. They denote the same instant, and taking it once means the
+    # budget and the checkpoint interval are measured from a common origin
+    # instead of from two points a few microseconds apart.
+
+    def out_of_time() -> bool:
+        return (
+            time_budget_sec > 0
+            and (time.monotonic() - grade_loop_start) > time_budget_sec
+        )
+
+    # Installed here rather than passed to the constructor because the budget
+    # is measured from the loop, not from the judge's setup. The grader calls
+    # this between rubric items and between split children, so the budget is
+    # reachable from inside a task instead of only between tasks.
+    grader.should_stop = out_of_time
+
     GRADE_EXIT_RESUME = 7  # contract with grade-run.yml's auto-trigger step
     GRADE_EXIT_PERSISTENCE_FAILURE = 5
     GRADE_EXIT_RUNTIME_FAILURE = 6
 
+    prompt_version = grader.prompt_version
+
+    def build_payload(run_status: str) -> dict:
+        return _build_grade_payload(
+            args.experiment_yaml_name,
+            inf_results,
+            config,
+            config_hash,
+            loader,
+            prompt_version,
+            task_payloads,
+            grader_source_hash,
+            inference_repo_id,
+            inference_revision,
+            azure_ai_runtime_fingerprint=azure_ai_runtime_fingerprint,
+            azure_ai_routes=azure_ai_routes,
+            run_status=run_status,
+            expected_task_ids=expected_task_ids,
+            exp_config=exp_config,
+            source_experiment_id=args.source_experiment_id,
+            renderer_fingerprint=renderer_fingerprint,
+            cost_ledger=cost_ledger_pointer(),
+        )
+
+    def save_checkpoint(run_status: str, *, verify: bool = True) -> None:
+        """Write the tasks finished so far, and prove the file readable.
+
+        ``verify`` re-reads and compares because the paths that end the run
+        get one chance at persistence; the periodic checkpoint skips it, since
+        another one follows shortly and a torn write there costs minutes
+        rather than the chunk.
+        """
+        nonlocal last_partial_save
+        payload = build_payload(run_status)
+        _validate_schema(payload)
+        _save_json(out_path, payload)
+        if verify:
+            persisted = _load_existing_grade(out_path)
+            _validate_schema(persisted)
+            if persisted != payload:
+                raise ValueError(f"persisted {run_status} does not match payload")
+        last_partial_save = time.monotonic()
+
     def finish(code: int) -> int:
         try:
-            close_grader()
+            flush_cost_ledger()
         finally:
-            atexit.unregister(grader_exit_cleanup)
+            try:
+                close_grader()
+            finally:
+                atexit.unregister(grader_exit_cleanup)
         return code
+
+    def out_of_time_exit(note: str) -> int:
+        """Stop, keep what is finished, and say whether resuming is worth it.
+
+        Exit 7 asks the workflow for another paid chunk, and that is only
+        honest if this chunk moved the shard forward. A chunk that finished
+        nothing would hand the next one the same first task and the same
+        result, charging for the loop each time — so it stops the shard
+        instead and leaves a human to look at the task that is eating the
+        budget.
+
+        The elapsed time is read here rather than taken from the caller so
+        that the loop asks the clock once per task, in ``out_of_time``. A
+        second read alongside it is not merely redundant: it moves the
+        decision one tick later than the number that gets reported for it.
+        """
+        elapsed_sec = time.monotonic() - grade_loop_start
+        graded_count = len(task_payloads)
+        remaining = len(shard_tasks) - graded_count
+        if graded_count <= initial_completed_count:
+            print(
+                f"[time-guard] {note}; no new task completed in this chunk; "
+                "refusing to request another paid resume",
+                file=sys.stderr,
+            )
+            return finish(GRADE_EXIT_PERSISTENCE_FAILURE)
+        print(
+            f"\n[time-guard] {note}: elapsed {elapsed_sec/60:.1f}min > budget "
+            f"{time_budget_sec/60:.0f}min; graded={graded_count}/{len(shard_tasks)} "
+            f"remaining={remaining}. Saving partial and requesting resume.",
+            file=sys.stderr,
+        )
+        try:
+            save_checkpoint("partial")
+            print(f"[time-guard] partial saved → {out_path}", file=sys.stderr)
+        except Exception as save_exc:
+            import traceback
+            print(f"[time-guard] partial save FAILED: {save_exc}", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+            return finish(GRADE_EXIT_PERSISTENCE_FAILURE)
+        return finish(GRADE_EXIT_RESUME)
 
     for idx, task_result in enumerate(shard_tasks, start=1):
         # Resume skip
@@ -2284,62 +2546,21 @@ def main() -> int:
             continue
 
         # Time-budget pre-check (before starting an expensive judge call)
-        elapsed_sec = time.monotonic() - grade_loop_start
-        if time_budget_sec > 0 and elapsed_sec > time_budget_sec:
-            graded_count = len(task_payloads)
-            remaining = len(shard_tasks) - graded_count
-            if graded_count <= initial_completed_count:
-                print(
-                    "[time-guard] no new task completed in this chunk; "
-                    "refusing to request another paid resume",
-                    file=sys.stderr,
-                )
-                return finish(GRADE_EXIT_PERSISTENCE_FAILURE)
-            print(
-                f"\n[time-guard] elapsed {elapsed_sec/60:.1f}min > budget "
-                f"{time_budget_sec/60:.0f}min; graded={graded_count}/{len(shard_tasks)} "
-                f"remaining={remaining}. Saving partial and requesting resume.",
-                file=sys.stderr,
-            )
-            try:
-                partial = _build_grade_payload(
-                    args.experiment_yaml_name,
-                    inf_results,
-                    config,
-                    config_hash,
-                    loader,
-                    grader.prompt_version,
-                    task_payloads,
-                    grader_source_hash,
-                    inference_repo_id,
-                    inference_revision,
-                    azure_ai_runtime_fingerprint=azure_ai_runtime_fingerprint,
-                    azure_ai_routes=azure_ai_routes,
-                    run_status="partial",
-                    expected_task_ids=expected_task_ids,
-                    exp_config=exp_config,
-                    source_experiment_id=args.source_experiment_id,
-                    renderer_fingerprint=renderer_fingerprint,
-                    cost_ledger=cost_ledger_pointer(),
-                )
-                _validate_schema(partial)
-                _save_json(out_path, partial)
-                persisted = _load_existing_grade(out_path)
-                _validate_schema(persisted)
-                if persisted != partial:
-                    raise ValueError("persisted partial does not match payload")
-                print(f"[time-guard] partial saved → {out_path}", file=sys.stderr)
-            except Exception as save_exc:
-                import traceback
-                print(f"[time-guard] partial save FAILED: {save_exc}", file=sys.stderr)
-                traceback.print_exc(file=sys.stderr)
-                return finish(GRADE_EXIT_PERSISTENCE_FAILURE)
-            return finish(GRADE_EXIT_RESUME)
+        if out_of_time():
+            return out_of_time_exit("between tasks")
 
         task = loader.load(task_result["task_id"])
         deliverable_dir = resolve_deliverable_dir(task_result)
         task_started = time.perf_counter()
-        grade = grader.grade_task(task, deliverable_dir)
+        try:
+            grade = grader.grade_task(task, deliverable_dir)
+        except GradingDeadlineExceeded as expired:
+            # The task is dropped whole, not saved half-marked: an unfinished
+            # task would be scored on the items it got through, and the ones
+            # it never reached would read as failures. Whatever it spent is
+            # in the ledger, and the next chunk marks it from the start.
+            print(f"[time-guard] {expired}", file=sys.stderr)
+            return out_of_time_exit(f"inside {task.task_id}")
         grading_wall_time_ms = (time.perf_counter() - task_started) * 1000.0
         row = _task_to_dict(
             grade,
@@ -2379,32 +2600,7 @@ def main() -> int:
 
         if runtime_error is not None:
             try:
-                diagnostic = _build_grade_payload(
-                    args.experiment_yaml_name,
-                    inf_results,
-                    config,
-                    config_hash,
-                    loader,
-                    grader.prompt_version,
-                    task_payloads,
-                    grader_source_hash,
-                    inference_repo_id,
-                    inference_revision,
-                    azure_ai_runtime_fingerprint=azure_ai_runtime_fingerprint,
-                    azure_ai_routes=azure_ai_routes,
-                    run_status="diagnostic",
-                    expected_task_ids=expected_task_ids,
-                    exp_config=exp_config,
-                    source_experiment_id=args.source_experiment_id,
-                    renderer_fingerprint=renderer_fingerprint,
-                    cost_ledger=cost_ledger_pointer(),
-                )
-                _validate_schema(diagnostic)
-                _save_json(out_path, diagnostic)
-                persisted = _load_existing_grade(out_path)
-                _validate_schema(persisted)
-                if persisted != diagnostic:
-                    raise ValueError("persisted diagnostic does not match payload")
+                save_checkpoint("diagnostic")
             except Exception as save_exc:
                 print(
                     f"ERROR: Track 2 runtime diagnostic save failed: {save_exc}",
@@ -2418,30 +2614,14 @@ def main() -> int:
             )
             return finish(GRADE_EXIT_RUNTIME_FAILURE)
 
-        if partial_every > 0 and idx % partial_every == 0:
+        due_by_count = partial_every > 0 and idx % partial_every == 0
+        due_by_clock = (
+            partial_save_max_interval_sec > 0
+            and (time.monotonic() - last_partial_save) > partial_save_max_interval_sec
+        )
+        if due_by_count or due_by_clock:
             try:
-                partial = _build_grade_payload(
-                    args.experiment_yaml_name,
-                    inf_results,
-                    config,
-                    config_hash,
-                    loader,
-                    grader.prompt_version,
-                    task_payloads,
-                    grader_source_hash,
-                    inference_repo_id,
-                    inference_revision,
-                    azure_ai_runtime_fingerprint=azure_ai_runtime_fingerprint,
-                    azure_ai_routes=azure_ai_routes,
-                    run_status="partial",
-                    expected_task_ids=expected_task_ids,
-                    exp_config=exp_config,
-                    source_experiment_id=args.source_experiment_id,
-                    renderer_fingerprint=renderer_fingerprint,
-                    cost_ledger=cost_ledger_pointer(),
-                )
-                _validate_schema(partial)
-                _save_json(out_path, partial)
+                save_checkpoint("partial", verify=False)
             except Exception as save_exc:
                 import traceback
                 print(
@@ -2455,26 +2635,7 @@ def main() -> int:
                 traceback.print_exc(file=sys.stderr)
                 raise
 
-    final = _build_grade_payload(
-        args.experiment_yaml_name,
-        inf_results,
-        config,
-        config_hash,
-        loader,
-        grader.prompt_version,
-        task_payloads,
-        grader_source_hash,
-        inference_repo_id,
-        inference_revision,
-        azure_ai_runtime_fingerprint=azure_ai_runtime_fingerprint,
-        azure_ai_routes=azure_ai_routes,
-        run_status=emitted_run_status,
-        expected_task_ids=expected_task_ids,
-        exp_config=exp_config,
-        source_experiment_id=args.source_experiment_id,
-        renderer_fingerprint=renderer_fingerprint,
-        cost_ledger=cost_ledger_pointer(),
-    )
+    final = build_payload(emitted_run_status)
     _validate_schema(final)
     _save_json(out_path, final)
 

--- a/batch-runner/tests/test_a_long_task_cannot_take_the_chunk_down_with_it.py
+++ b/batch-runner/tests/test_a_long_task_cannot_take_the_chunk_down_with_it.py
@@ -1,0 +1,359 @@
+"""One task must not be able to spend the whole chunk's budget in silence.
+
+Stage 3, shard 4 of 11 (run ``33239148807``) finished six tasks in seventy-one
+minutes, entered the seventh, and was still in it four hours and nine minutes
+later when ``timeout-minutes: 320`` killed the job. It committed nothing. The
+six finished tasks had to be marked again, and paid for again.
+
+Two things let that happen, and both are addressed here:
+
+* the four-hour budget was consulted only at the top of the per-task loop, so
+  a task that never returned never met it — the guard was unreachable from
+  precisely the situation it exists for;
+* the checkpoint was ``partial_save_every_n_tasks``, which is ten, and a shard
+  holds seventeen tasks, so the first save of a default run lands after the
+  tenth. Six finished tasks were never written down.
+
+So the budget is now checked between rubric items and between split children —
+the two loops inside a task that have no bound other than the deliverable —
+and a finished task is written to disk on a clock as well as on a counter.
+
+Nothing here calls a model. The grader tests drive a real ``Grader`` with a
+scripted client; the ``step8_grade`` tests read the module's syntax tree,
+because the Track 2 loop needs a graded corpus and a live endpoint to reach.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import step8_grade as s8
+from core.grader import Grader, GradingDeadlineExceeded
+from core.rubric_loader import RubricItem, TaskRubric
+
+STEP8 = Path(s8.__file__).resolve()
+
+
+# ── a grader with a scripted client ──────────────────────────────────────
+
+
+def _verdict(evidence: str) -> str:
+    return json.dumps({
+        "verdict": "pass", "partial_score": 1.0, "evidence": evidence,
+        "confidence": 0.9, "reasoning": "ok", "tool_calls_made": 0,
+    })
+
+
+def _response(text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        output=[{"type": "message",
+                 "content": [{"type": "output_text", "text": text}]}],
+        output_text="",
+        usage=SimpleNamespace(
+            input_tokens=80, output_tokens=20,
+            input_tokens_details=SimpleNamespace(cached_tokens=5),
+        ),
+        incomplete_details=None,
+        status=None,
+    )
+
+
+class ScriptedResponses:
+    """Runs out loudly, which is how a test proves an item never started."""
+
+    def __init__(self, script):
+        self.script = list(script)
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if not self.script:
+            raise AssertionError("ScriptedResponses ran out of responses")
+        return self.script.pop(0)
+
+
+def _grader(client, **kwargs) -> Grader:
+    import core.grader as grader_mod
+
+    prompt = (Path(grader_mod.__file__).resolve().parent.parent
+              / "prompts" / "grader_judge.md")
+    config = {
+        "judge": {
+            "provider": "azure_openai",
+            "api_version": "2025-04-01-preview",
+            "model": "gpt-5.4",
+            "reasoning": {"effort": "medium"},
+            "generation": {"max_output_tokens": 2400},
+            "tools": {"read_deliverable": {
+                "ops": ["inspect_structure", "read_content", "inspect_formatting"],
+                "per_item_call_cap": 8, "max_iterations": 6}},
+        },
+        "prompt": {"template": str(prompt)},
+        "grader": {"evidence_max_chars": 200},
+        "tpm_guard": {},
+    }
+    return Grader(config, rubric_loader=None, client=client, **kwargs)
+
+
+def _task(*criteria: str) -> TaskRubric:
+    return TaskRubric(
+        task_id="9e39df84-ac57-4c9b-a2e3-12b8abf2c797",
+        sector="Information",
+        occupation="Analyst",
+        prompt="Write the report.",
+        rubric_items=[
+            RubricItem(f"r{n}", criterion, 5, None)
+            for n, criterion in enumerate(criteria, start=1)
+        ],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+
+@pytest.fixture
+def deliverable(tmp_path: Path) -> Path:
+    directory = tmp_path / "task"
+    directory.mkdir()
+    (directory / "report.txt").write_text(
+        "Total revenue 42. Prepared by the analyst.", encoding="utf-8"
+    )
+    return directory
+
+
+# ── the budget, reached from inside a task ───────────────────────────────
+
+
+def test_a_task_that_outlives_the_budget_stops_at_the_next_item(deliverable):
+    """The check that was missing while shard 4 spent four hours.
+
+    One response is scripted for three items. The deadline turns true once the
+    first item is done, so if the second ever started, the scripted client
+    would raise instead — which makes "the loop stopped" an assertion about
+    behaviour rather than about a counter the test set itself.
+    """
+    responses = ScriptedResponses([_response(_verdict("revenue 42 present"))])
+    grader = _grader(SimpleNamespace(responses=responses))
+    grader.should_stop = lambda: len(responses.calls) >= 1
+
+    with pytest.raises(GradingDeadlineExceeded) as expired:
+        grader.grade_task(
+            _task("The report states total revenue of 42",
+                  "The report names the analyst",
+                  "The report gives a date"),
+            str(deliverable),
+        )
+
+    assert len(responses.calls) == 1
+    message = str(expired.value)
+    assert "9e39df84-ac57-4c9b-a2e3-12b8abf2c797" in message
+    assert "r2" in message, "the message must name the item that was refused"
+
+
+def test_a_task_is_abandoned_whole_rather_than_marked_short(deliverable):
+    """No ``TaskGrade`` comes back, and that is the point.
+
+    A task returned with two of its three items graded would be scored on
+    what it managed, and the item it never reached would read as a failure —
+    a lower mark for having been unlucky with the clock. Raising leaves the
+    driver no way to record a half-marked task by accident.
+    """
+    responses = ScriptedResponses([_response(_verdict("revenue 42 present"))])
+    grader = _grader(SimpleNamespace(responses=responses))
+    grader.should_stop = lambda: len(responses.calls) >= 1
+
+    with pytest.raises(GradingDeadlineExceeded):
+        grader.grade_task(
+            _task("The report states total revenue of 42",
+                  "The report names the analyst"),
+            str(deliverable),
+        )
+
+
+def test_a_task_that_fits_the_budget_is_graded_normally(deliverable):
+    """A deadline that never comes due changes nothing."""
+    responses = ScriptedResponses([
+        _response(_verdict("revenue 42 present")),
+        _response(_verdict("analyst named")),
+    ])
+    grader = _grader(SimpleNamespace(responses=responses))
+    grader.should_stop = lambda: False
+
+    grade = grader.grade_task(
+        _task("The report states total revenue of 42",
+              "The report names the analyst"),
+        str(deliverable),
+    )
+
+    assert len(grade.items) == 2
+    assert [item.verdict for item in grade.items] == ["pass", "pass"]
+
+
+def test_a_grader_with_no_deadline_never_consults_one(deliverable):
+    """The default is unchanged behaviour, not a deadline of zero.
+
+    Every other caller of ``Grader`` — the preflight, the analysis scripts,
+    the tests — constructs it without a driver, and none of them should start
+    raising because grading took a while.
+    """
+    responses = ScriptedResponses([_response(_verdict("revenue 42 present"))])
+    grader = _grader(SimpleNamespace(responses=responses))
+
+    assert grader.should_stop is None
+    grade = grader.grade_task(
+        _task("The report states total revenue of 42"), str(deliverable)
+    )
+    assert len(grade.items) == 1
+
+
+def test_the_deadline_can_be_supplied_at_construction():
+    """Not only assignable afterwards, so a caller can pass one in."""
+    marker = object()
+    grader = _grader(
+        SimpleNamespace(responses=ScriptedResponses([])),
+        should_stop=lambda: marker,
+    )
+    assert grader.should_stop() is marker
+
+
+def test_the_check_is_silent_until_the_driver_says_stop():
+    """The unit under both loops, on its own."""
+    grader = _grader(SimpleNamespace(responses=ScriptedResponses([])))
+    grader.should_stop = lambda: False
+    grader._check_should_stop("t", "item r1")  # no raise
+
+    grader.should_stop = lambda: True
+    with pytest.raises(GradingDeadlineExceeded):
+        grader._check_should_stop("t", "item r1")
+
+
+def test_the_split_child_loop_is_guarded_as_well():
+    """Asserted on the syntax tree, and worth saying why.
+
+    Split children are where a single item multiplies: one criterion against
+    forty sibling files is forty judge conversations, each of which may retry.
+    Reaching that loop from a test needs a deliverable that the selector
+    actually splits, so what is pinned here is narrower and more durable —
+    that the loop which calls the judge also asks whether to stop, in the same
+    body, so the two cannot be separated by a later edit.
+    """
+    import core.grader as grader_mod
+
+    tree = ast.parse(
+        Path(grader_mod.__file__).resolve().read_text(encoding="utf-8")
+    )
+    split = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_judge_split_children"
+    )
+    judging_loops = [
+        loop for loop in ast.walk(split)
+        if isinstance(loop, ast.For)
+        and "_judge_via_tool_calling_selected" in ast.unparse(loop)
+    ]
+    assert judging_loops, "the per-child judging loop moved or was renamed"
+    for loop in judging_loops:
+        assert "_check_should_stop" in ast.unparse(loop), (
+            "a child loop that judges without checking the deadline is the "
+            "shard-4 hang again, one level down"
+        )
+
+
+# ── what the driver does with it ─────────────────────────────────────────
+
+
+def _main_body() -> list[ast.stmt]:
+    tree = ast.parse(STEP8.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            return node.body
+    raise AssertionError("step8_grade has no main")
+
+
+def _local(name: str) -> ast.FunctionDef:
+    for node in _main_body():
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"main has no local function {name!r}")
+
+
+def _grade_loop() -> ast.For:
+    for node in _main_body():
+        if isinstance(node, ast.For) and "grade_task" in ast.unparse(node):
+            return node
+    raise AssertionError("main has no per-task grading loop")
+
+
+def test_the_driver_installs_its_budget_on_the_grader():
+    """Without this line the grader has a deadline it is never given."""
+    source = ast.unparse(ast.Module(body=_main_body(), type_ignores=[]))
+    assert "grader.should_stop = out_of_time" in source
+    assert "GRADER_TIME_BUDGET_SEC" in source
+
+
+def test_an_abandoned_task_is_dropped_not_recorded():
+    """The handler keeps the finished tasks and forgets the unfinished one."""
+    loop = ast.unparse(_grade_loop())
+    assert "except GradingDeadlineExceeded" in loop
+
+    handler = next(
+        h for h in ast.walk(_grade_loop())
+        if isinstance(h, ast.ExceptHandler)
+        and "GradingDeadlineExceeded" in ast.unparse(h.type or ast.Constant(None))
+    )
+    body = ast.unparse(handler)
+    assert "out_of_time_exit" in body
+    assert "task_payloads.append" not in body, (
+        "a task cut short must not be filed; its ungraded items would be "
+        "scored as failures"
+    )
+
+
+def test_a_chunk_that_finished_nothing_does_not_buy_another_one():
+    """Exit 7 asks for a paid resume, so it has to be earned.
+
+    The next chunk would start on the same task and reach the same place. The
+    guard predates this change; what is new is that a task abandoned mid-way
+    leaves through the same door, so it cannot bypass it.
+    """
+    body = ast.unparse(_local("out_of_time_exit"))
+    assert "graded_count <= initial_completed_count" in body
+    assert "GRADE_EXIT_PERSISTENCE_FAILURE" in body
+    assert "GRADE_EXIT_RESUME" in body
+    assert "save_checkpoint('partial')" in body
+
+
+def test_a_finished_task_is_written_down_on_a_clock_too():
+    """Ten tasks is not a checkpoint on a seventeen-task shard.
+
+    Both rules are kept: the counter still fires, and a slow chunk that has
+    not saved for the interval saves anyway. Shard 4 had six finished tasks
+    and a default of ten.
+    """
+    loop = ast.unparse(_grade_loop())
+    assert "due_by_count or due_by_clock" in loop
+    assert "idx % partial_every == 0" in loop
+    assert "partial_save_max_interval_sec" in loop
+
+    source = ast.unparse(ast.Module(body=_main_body(), type_ignores=[]))
+    assert "'partial_save_max_interval_sec', 900" in source, (
+        "the interval needs a default; a run that does not set it is the "
+        "run that needs it"
+    )
+
+
+def test_every_save_still_goes_through_one_builder():
+    """Four call sites, one payload shape, so they cannot drift apart."""
+    source = ast.unparse(ast.Module(body=_main_body(), type_ignores=[]))
+    assert source.count("_build_grade_payload(") == 1, (
+        "the payload is built in one place so that a field added for the "
+        "final save is not missing from the partial one"
+    )
+    for status in ("'partial'", "'diagnostic'"):
+        assert f"save_checkpoint({status}" in source
+    assert "build_payload(emitted_run_status)" in source

--- a/batch-runner/tests/test_a_sibling_shards_commit_cannot_kill_a_chunk.py
+++ b/batch-runner/tests/test_a_sibling_shards_commit_cannot_kill_a_chunk.py
@@ -1,0 +1,367 @@
+"""Eleven shards write to one branch; that must not be fatal to any of them.
+
+Run ``33248832615`` was dispatched at ``d5c1e18`` at 10:53:02Z, cleared its
+paid-approval gate, checked out main, and died. Not on a model error, not on a
+budget — on ``origin/main moved after dispatch``. At 10:54:59Z, a hundred and
+seventeen seconds into the approval wait, shard 3 had committed ``8828ba1``: a
+single file, ``shard-003-of-011.json``, its own graded output.
+
+Every shard commits its grade to main. With eleven of them and a chunked
+resume, the branch tip is essentially never still, so a check demanding it be
+unchanged since dispatch fails for the most ordinary reason there is — and it
+fails *after* the approval, which is the one moment the run is least able to
+absorb it.
+
+What the check was protecting is real: the code that grades must be the code
+that was reviewed and approved. So that is now what is checked. The branch tip
+may advance; the grading inputs may not. A sibling's grade file moves the tip
+and changes nothing this job reads, so it no longer costs a chunk.
+
+Nothing here calls a model or a network. The behavioural tests run the shipped
+shell fragment, sliced out of the workflow, against real local repositories.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github/workflows/grade-run.yml"
+
+PAID_STEP = "Verify checked out main and input files"
+DRY_RUN_STEP = "Verify read-only checkout and input files"
+
+
+# ── reading the workflow ─────────────────────────────────────────────────
+
+
+def _steps() -> list[dict]:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return [
+        step
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+    ]
+
+
+def _step(name: str) -> dict:
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"grade-run.yml has no step named {name!r}")
+
+
+def _input_paths(step_name: str) -> list[str]:
+    """The pathspec list as the shipped step declares it."""
+    lines = _step(step_name)["run"].splitlines()
+    start = next(
+        index for index, line in enumerate(lines)
+        if line.strip() == "GRADING_INPUT_PATHS=("
+    )
+    paths: list[str] = []
+    for line in lines[start + 1:]:
+        if line.strip() == ")":
+            return paths
+        paths.append(line.strip())
+    raise AssertionError(f"{step_name}: GRADING_INPUT_PATHS is not closed")
+
+
+def _pin_fragment(step_name: str) -> str:
+    """The shipped pin itself, so the behavioural tests run it and not a copy.
+
+    Sliced rather than reimplemented: a paraphrase of a shell check passes
+    happily while the workflow ships something else, which is the failure mode
+    this file exists to rule out.
+    """
+    lines = _step(step_name)["run"].splitlines()
+    start = next(
+        index for index, line in enumerate(lines)
+        if line.strip() == "GRADING_INPUT_PATHS=("
+    )
+    seen_pin_echo = False
+    for end, line in enumerate(lines[start:], start=start):
+        if "[pin] main advanced" in line:
+            seen_pin_echo = True
+        elif seen_pin_echo and line.strip() == "fi":
+            return "set -euo pipefail\n" + "\n".join(lines[start:end + 1]) + "\n"
+    raise AssertionError(f"{step_name}: could not find the end of the pin")
+
+
+# ── what the list must and must not contain ──────────────────────────────
+
+
+def test_neither_job_still_demands_an_unmoved_branch_tip():
+    """The defect, named directly.
+
+    ``refs/remotes/origin/main`` compared against ``$GITHUB_SHA`` is the line
+    that killed run 33248832615, and an equality against ``$GITHUB_SHA``
+    anywhere in these steps reintroduces it under a different spelling.
+    """
+    for step_name in (PAID_STEP, DRY_RUN_STEP):
+        run = _step(step_name)["run"]
+        assert "refs/remotes/origin/main" not in run, (
+            f"{step_name} still pins the branch tip; a sibling shard's grade "
+            "commit will kill this chunk again"
+        )
+        assert "origin/main moved after dispatch" not in run
+        assert '"$(git rev-parse HEAD)" != "$GITHUB_SHA"' not in run
+
+
+def test_both_jobs_pin_the_same_inputs():
+    """Two copies in one file, held together by reading both.
+
+    YAML has no include, so the fragment is duplicated. The duplication is
+    only safe while a change to one is a failure about the other.
+    """
+    paid = _input_paths(PAID_STEP)
+    dry_run = _input_paths(DRY_RUN_STEP)
+    assert paid == dry_run, (
+        "the read-only job and the paid job must agree on what counts as a "
+        "grading input, or the dry run stops predicting the real one"
+    )
+    assert paid == sorted(paid), "kept sorted so a diff of the two reads cleanly"
+
+
+def test_the_pin_covers_everything_the_source_hash_covers():
+    """Derived from the real hash function, not from a list typed twice.
+
+    ``compute_grader_source_hash`` is what the merge compares across shards; a
+    file inside it that the pin leaves out could change mid-run, and the change
+    would surface as an unmergeable shard hours later instead of as a refusal
+    here.
+    """
+    import step8_grade as s8
+
+    config_path = Path("grading_configs/gold_ceiling_185_v2_sol_max.yaml")
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    batch_root = Path(s8.__file__).resolve().parent
+    covered = [
+        batch_root / "step8_grade.py",
+        *(p for p in (batch_root / "core").rglob("*.py")),
+        batch_root / "schemas" / "grade.schema.json",
+        batch_root / "requirements.txt",
+        batch_root / "scripts" / "download_inference_from_hf.py",
+        Path(config["prompt"]["template"]).resolve(),
+        s8.resolve_tool_prompt_path(config).resolve(),
+        config_path.resolve(),
+    ]
+    pinned = _input_paths(PAID_STEP)
+
+    for source in covered:
+        relative = source.relative_to(REPO_ROOT).as_posix()
+        assert any(
+            relative == entry or relative.startswith(entry + "/")
+            for entry in pinned
+        ), f"{relative} feeds grader_source_hash but no pathspec covers it"
+
+
+def test_the_pin_ignores_what_the_run_writes():
+    """The grades are the moving part; pinning them is the bug itself."""
+    pinned = _input_paths(PAID_STEP)
+    for written in ("data/grades", "data", "data/tests", "public/generated"):
+        assert written not in pinned, (
+            f"{written} is an output of this workflow; pinning it makes every "
+            "sibling shard's commit fatal again"
+        )
+    assert ".github/workflows/grade-run.yml" in pinned, (
+        "the workflow is read by the resume it dispatches, so an edit to it "
+        "mid-run is exactly the change that must stop a chunk"
+    )
+
+
+def test_the_unmoved_case_costs_nothing():
+    """No fetch, no diff, when the tip is where it was.
+
+    Most dispatches are not racing anything, and those should not pay a
+    network round trip to learn it.
+    """
+    fragment = _pin_fragment(PAID_STEP)
+    guard = 'if [[ "$HEAD_SHA" != "$GITHUB_SHA" ]]; then'
+    assert guard in fragment
+    assert fragment.index(guard) < fragment.index("git fetch")
+    assert fragment.index(guard) < fragment.index("git diff")
+
+
+# ── the race, replayed against real repositories ─────────────────────────
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ("git", *args), cwd=cwd, capture_output=True, text=True, check=True,
+        env={
+            "PATH": "/usr/bin:/bin", "HOME": str(cwd),
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.invalid",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.invalid",
+            "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null",
+        },
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, message: str, **files: str) -> str:
+    for relative, content in files.items():
+        path = repo / relative.replace("__", "/")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def race(tmp_path):
+    """An upstream main, and a shallow checkout of it — the runner's view.
+
+    ``uploadpack.allowAnySHA1InWant`` is set because the fragment fetches one
+    commit by identifier, and git refuses that by default over local transport.
+    GitHub enables it server-side, so this makes the fixture behave like the
+    remote the fragment actually talks to rather than granting it something
+    new.
+    """
+    if shutil.which("git") is None:  # pragma: no cover - git is a hard dep here
+        pytest.skip("git is required")
+
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    _git(upstream, "init", "--initial-branch=main", "--quiet")
+    _git(upstream, "config", "uploadpack.allowAnySHA1InWant", "true")
+    dispatched = _commit(
+        upstream, "base",
+        **{
+            "batch-runner__core__grader.py": "class Grader:\n    pass\n",
+            "batch-runner__step8_grade.py": "def main():\n    return 0\n",
+            "data__grades__shard-002-of-011.json": '{"tasks": []}\n',
+            "src__App.tsx": "export const App = () => null\n",
+        },
+    )
+
+    checkout = tmp_path / "checkout"
+    _git(tmp_path, "clone", "--depth=1", "--quiet", str(upstream), str(checkout))
+    return upstream, checkout, dispatched
+
+
+def _advance(upstream: Path, checkout: Path, message: str, **files: str) -> str:
+    """Land a commit upstream and let the runner check it out, as it would."""
+    head = _commit(upstream, message, **files)
+    _git(checkout, "fetch", "--depth=1", "--quiet", "origin", "main")
+    _git(checkout, "reset", "--hard", "--quiet", "FETCH_HEAD")
+    return head
+
+
+def _run_pin(checkout: Path, dispatched: str, step_name: str = PAID_STEP):
+    return subprocess.run(
+        ["bash", "-c", _pin_fragment(step_name)],
+        cwd=checkout, capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(checkout),
+             "GITHUB_SHA": dispatched,
+             "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"},
+    )
+
+
+def test_a_sibling_shard_landing_its_grade_does_not_stop_this_one(race):
+    """Run 33248832615, replayed: the commit that killed it now passes.
+
+    One file, ``shard-003-of-011.json``, committed by another shard while this
+    one waited for approval. The tip moves, the diff is empty, the chunk runs.
+    """
+    upstream, checkout, dispatched = race
+    moved = _advance(
+        upstream, checkout, "chore(grades): grade [shard 3 of 11]",
+        **{"data__grades__shard-003-of-011.json": '{"tasks": [1, 2, 3]}\n'},
+    )
+    assert moved != dispatched
+
+    result = _run_pin(checkout, dispatched)
+
+    assert result.returncode == 0, result.stderr
+    assert "main advanced" in result.stdout
+    # ``::error::`` is an annotation on stdout, as everywhere else in
+    # this workflow; a run that emits none of them raised no objection.
+    assert "::error::" not in result.stdout
+
+
+def test_a_changed_grader_still_stops_the_chunk(race):
+    """The property the old check was defending, kept intact.
+
+    An approval was given for a revision. If the code moved underneath it, the
+    approval no longer describes what would run, and the shard's grade would
+    not merge with its siblings' anyway.
+    """
+    upstream, checkout, dispatched = race
+    _advance(
+        upstream, checkout, "fix(grader): change scoring",
+        **{"batch-runner__core__grader.py": "class Grader:\n    SCORE = 2\n"},
+    )
+
+    result = _run_pin(checkout, dispatched)
+
+    assert result.returncode == 1
+    assert "grading inputs changed" in result.stdout
+    assert "changed grading input: batch-runner/core/grader.py" in result.stdout
+
+
+def test_a_grade_and_a_grader_moving_together_stops_the_chunk(race):
+    """The benign file must not launder the dangerous one.
+
+    A pathspec list that stopped at the first match, or a check that asked
+    only whether *some* file was untouched, would let this through.
+    """
+    upstream, checkout, dispatched = race
+    _advance(
+        upstream, checkout, "chore: grades and a quiet edit",
+        **{
+            "data__grades__shard-003-of-011.json": '{"tasks": [1]}\n',
+            "batch-runner__step8_grade.py": "def main():\n    return 7\n",
+        },
+    )
+
+    result = _run_pin(checkout, dispatched)
+
+    assert result.returncode == 1
+    assert "changed grading input: batch-runner/step8_grade.py" in result.stdout
+
+
+def test_an_unrelated_dashboard_commit_does_not_stop_the_chunk(race):
+    """Session B works on ``src/`` while this runs. It should not collide."""
+    upstream, checkout, dispatched = race
+    _advance(
+        upstream, checkout, "feat(ui): cost column",
+        **{"src__App.tsx": "export const App = () => <table />\n"},
+    )
+
+    result = _run_pin(checkout, dispatched)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_a_still_tip_needs_no_network(race):
+    """The unmoved case, proven by removing the remote before running it."""
+    upstream, checkout, dispatched = race
+    _git(checkout, "remote", "remove", "origin")
+
+    result = _run_pin(checkout, dispatched)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_the_read_only_job_behaves_the_same_way(race):
+    """The dry run predicts the paid run only if it decides the same way."""
+    upstream, checkout, dispatched = race
+    _advance(
+        upstream, checkout, "chore(grades): grade [shard 3 of 11]",
+        **{"data__grades__shard-003-of-011.json": '{"tasks": [1]}\n'},
+    )
+    assert _run_pin(checkout, dispatched, DRY_RUN_STEP).returncode == 0
+
+    _advance(
+        upstream, checkout, "fix(grader): change scoring",
+        **{"batch-runner__core__grader.py": "class Grader:\n    SCORE = 3\n"},
+    )
+    assert _run_pin(checkout, dispatched, DRY_RUN_STEP).returncode == 1

--- a/batch-runner/tests/test_cost_ledger_survives_a_failed_run.py
+++ b/batch-runner/tests/test_cost_ledger_survives_a_failed_run.py
@@ -1,0 +1,418 @@
+"""The bill has to outlive the run, the chunk, and the runner.
+
+Stage 3, shard 4 of 11 (run ``33239148807``) graded six tasks over five hours
+and twenty minutes, was killed by the job's own ``timeout-minutes: 320`` inside
+the seventh, and left ``{"total_count":0,"artifacts":[]}`` behind. Not a
+partial grade, not a ledger, nothing. Every call it paid for is unrecorded, and
+the only reason we know roughly what it spent is the workflow log.
+
+Three separate things had to be true at once for that to happen, and each of
+them was also quietly true of the *successful* shards:
+
+* the ledger was exported only at a save, and this run never saved
+  (``partial_save_every_n_tasks`` is 10, and it had six);
+* the artifact upload was gated on ``steps.grade.outputs.grade_file``, an
+  output written inside the save path — so a run that never saved could not
+  even upload the sqlite3 it had been writing all along;
+* nothing ever committed the ledger, so the copy on the runner was the only
+  copy, and the runner is discarded between chunks.
+
+The third one is the expensive one, because it is not about failure at all.
+``step9_merge_shards.merge_shard_cost_ledgers`` looks for each shard's export
+*beside that shard's JSON in the checkout*, and a resumed chunk rebuilds its
+ledger by importing what the previous chunk left there. Both read from the
+repository. Nothing wrote to it. So on every run so far the merge found no
+ledger and dropped it, and every resumed chunk began counting from zero — the
+per-call record was being lost on the runs that succeeded.
+
+Nothing here calls a model or a network. The tests exercise the real ledger,
+the real merge function, and the text of the real workflow.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import signal
+from pathlib import Path
+
+import pytest
+import yaml
+
+import step8_grade as s8
+from core.cost_metering import Attribution, CostRecorder, open_cost_recorder
+from core.cost_receipts import (
+    RETRY_NONE,
+    STAGE_GRADING,
+    CallUsage,
+    CostReceiptLedger,
+)
+from step9_merge_shards import merge_shard_cost_ledgers
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github/workflows/grade-run.yml"
+STEP8 = Path(s8.__file__).resolve()
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _usage() -> CallUsage:
+    return CallUsage(
+        input_tokens=1000, cached_input_tokens=200,
+        output_tokens=100, reasoning_tokens=0,
+    )
+
+
+def _spend(ledger: CostReceiptLedger, recorder: CostRecorder, task_id: str) -> str:
+    """One settled grading call, identified the way the real recorder does."""
+    call_id = recorder._next_call_id(
+        Attribution(task_id=task_id, stage=STAGE_GRADING,
+                    retry_kind=RETRY_NONE, attempt_index=0)
+    )
+    ledger.reserve(
+        call_id=call_id, task_id=task_id, stage=STAGE_GRADING,
+        retry_kind=RETRY_NONE, provider="azure", requested_model="a-deployment",
+    )
+    ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+    return call_id
+
+
+def _workflow_steps() -> list[dict]:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["grade"]["steps"]
+
+
+def _step(name: str) -> dict:
+    for step in _workflow_steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"grade-run.yml has no step named {name!r}")
+
+
+def _main_body() -> list[ast.stmt]:
+    """``main`` is where the Track 2 loop and its exit codes actually live."""
+    tree = ast.parse(STEP8.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            return node.body
+    raise AssertionError("step8_grade has no main")
+
+
+# ── a fresh runner picking up where the last one stopped ─────────────────
+
+
+def test_a_fresh_runner_rebuilds_its_ledger_from_the_committed_export(tmp_path):
+    """The sequence step8 now performs before it opens the recorder.
+
+    Chunk one writes a ledger and exports it; the runner is destroyed, taking
+    the sqlite3 with it and leaving only the committed JSONL; chunk two starts
+    on an empty workspace. What it must end up with is both chunks' calls, in
+    one file, with no identifier reused.
+
+    The import has to happen *before* ``open_cost_recorder``. ``continue_rounds``
+    reads the round number off the ledger's size and the round is folded into
+    every call identifier, so seeding afterwards would number chunk two's first
+    call exactly as chunk one numbered its own.
+    """
+    export = tmp_path / "shard-004-of-011.cost_ledger.jsonl"
+    first_db = tmp_path / "chunk1.sqlite3"
+    with CostReceiptLedger(first_db, run_id="exp|cfg|src") as first:
+        recorder = CostRecorder(first, round_index=0)
+        _spend(first, recorder, "task-a")
+        _spend(first, recorder, "task-b")
+        first.export_jsonl(export)
+    first_db.unlink()  # the runner goes away; the commit does not
+
+    second_db = tmp_path / "chunk2.sqlite3"
+    with CostReceiptLedger(second_db, run_id="exp|cfg|src") as seed:
+        assert seed.import_jsonl(export) == 2
+
+    recorder, note = open_cost_recorder(
+        second_db, run_id="exp|cfg|src", continue_rounds=True
+    )
+    assert recorder is not None
+    assert recorder.round_index == 2, (
+        "the round must clear the calls already in the ledger, or chunk two "
+        "re-issues chunk one's identifiers"
+    )
+
+    _spend(recorder.ledger, recorder, "task-c")
+    digest = recorder.ledger.export_jsonl(export)
+    recorder.ledger.close()
+
+    records = [json.loads(line) for line in
+               export.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert {r["task_id"] for r in records} == {"task-a", "task-b", "task-c"}
+    assert len({r["call_id"] for r in records}) == 3
+    assert len(digest) == 64
+
+
+def test_importing_the_same_export_twice_adds_nothing(tmp_path):
+    """A chunk that reruns after its commit landed must not double-bill.
+
+    The retrigger can fire on a chunk whose grade and ledger were already
+    pushed. Identifiers are derived from position rather than content, so the
+    second import recognises every record as one it already holds.
+    """
+    export = tmp_path / "ledger.jsonl"
+    with CostReceiptLedger(tmp_path / "a.sqlite3", run_id="r") as first:
+        _spend(first, CostRecorder(first, round_index=0), "task-a")
+        first.export_jsonl(export)
+
+    with CostReceiptLedger(tmp_path / "b.sqlite3", run_id="r") as second:
+        assert second.import_jsonl(export) == 1
+        assert second.import_jsonl(export) == 0
+        assert second.call_count() == 1
+
+
+# ── the merge only works if the export was committed ─────────────────────
+
+
+def _shard(tmp_path: Path, index: int, task_id: str) -> tuple[Path, dict]:
+    shard_path = tmp_path / f"shard-{index:03d}-of-002.json"
+    export = shard_path.with_name(shard_path.stem + ".cost_ledger.jsonl")
+    with CostReceiptLedger(tmp_path / f"{index}.sqlite3", run_id="r") as ledger:
+        _spend(ledger, CostRecorder(ledger, round_index=index), task_id)
+        digest = ledger.export_jsonl(export)
+    payload = {"cost_ledger": {"path": export.name, "sha256": digest}}
+    shard_path.write_text(json.dumps(payload), encoding="utf-8")
+    return shard_path, payload
+
+
+def test_the_merge_finds_a_ledger_that_was_committed_beside_its_shard(tmp_path):
+    """What the workflow's ``git add`` of the export buys.
+
+    ``merge_shard_cost_ledgers`` resolves each pointer relative to the shard
+    JSON, which on the merging runner means the checkout. This is the only
+    arrangement in which it returns a pointer at all.
+    """
+    warnings: list[str] = []
+    first = _shard(tmp_path, 0, "task-a")
+    second = _shard(tmp_path, 1, "task-b")
+    out_path = tmp_path / "final.json"
+
+    pointer = merge_shard_cost_ledgers(
+        [first[0], second[0]], [first[1], second[1]], out_path,
+        warn=warnings.append,
+    )
+
+    assert warnings == []
+    assert pointer is not None
+    merged = out_path.with_name(out_path.stem + ".cost_ledger.jsonl")
+    records = [json.loads(line) for line in
+               merged.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert {r["task_id"] for r in records} == {"task-a", "task-b"}
+    assert pointer["path"] == merged.name
+
+
+def test_an_uncommitted_ledger_makes_the_merged_grade_claim_none(tmp_path):
+    """The state every Stage 3 merge was in until the export was committed.
+
+    Worth pinning as a test rather than left as a warning in a log: the merge
+    does not fail, it just declines to publish a trail — which is why the
+    omission survived nine shards without anyone noticing.
+    """
+    warnings: list[str] = []
+    first = _shard(tmp_path, 0, "task-a")
+    second = _shard(tmp_path, 1, "task-b")
+    second[0].with_name(second[0].stem + ".cost_ledger.jsonl").unlink()
+
+    pointer = merge_shard_cost_ledgers(
+        [first[0], second[0]], [first[1], second[1]], tmp_path / "final.json",
+        warn=warnings.append,
+    )
+
+    assert pointer is None
+    assert any("not beside it" in message for message in warnings)
+
+
+# ── being killed is not an excuse ────────────────────────────────────────
+
+
+def test_a_termination_signal_unwinds_instead_of_killing_the_process():
+    """SIGTERM has to become ``SystemExit`` or the exit handlers never run.
+
+    This is the shard-4 case exactly: GitHub sends SIGTERM at
+    ``timeout-minutes``, Python's default disposition ends the process on the
+    spot, and ``atexit`` — where the final export lives — is skipped.
+    """
+    with pytest.raises(SystemExit) as raised:
+        s8._exit_on_signal(signal.SIGTERM, None)
+    assert raised.value.code == 128 + int(signal.SIGTERM) == 143
+
+    with pytest.raises(SystemExit) as interrupted:
+        s8._exit_on_signal(signal.SIGINT, None)
+    assert interrupted.value.code == 130
+
+
+def test_the_ledger_is_flushed_on_every_way_out_of_the_grading_run():
+    """Wiring, asserted structurally, because the paths cannot all be run.
+
+    The Track 2 loop lives in ``main`` and needs a graded corpus and a live
+    endpoint to reach most of its returns, so what is checked here is that the
+    flush is attached to the three exits that exist: the common ``finish``
+    helper every ``return`` goes through, the interpreter's own shutdown, and
+    the signal that arrives when the job is cancelled. If someone moves the
+    export back to the save path, this fails and names the run that cost five
+    hours.
+    """
+    body = _main_body()
+    source = ast.unparse(ast.Module(body=body, type_ignores=[]))
+
+    assert "atexit.register(flush_cost_ledger)" in source
+    assert "signal.signal(_signum, _exit_on_signal)" in source
+    assert "(signal.SIGTERM, signal.SIGINT)" in source
+
+    finish = next(
+        node for node in body
+        if isinstance(node, ast.FunctionDef) and node.name == "finish"
+    )
+    assert "flush_cost_ledger()" in ast.unparse(finish), (
+        "every return in the Track 2 loop goes through finish(); if it "
+        "stops "
+        "flushing, a failed run stops leaving a ledger behind"
+    )
+
+    flush = next(
+        node for node in body
+        if isinstance(node, ast.FunctionDef) and node.name == "flush_cost_ledger"
+    )
+    flushed = ast.unparse(flush)
+    assert "export_jsonl(cost_export_path)" in flushed
+    assert "cost_ledger_file" in flushed and "cost_ledger_sha256" in flushed
+
+
+# ── ...but only while there is still a ledger to flush ───────────────────
+
+
+def test_exporting_a_closed_ledger_raises_rather_than_returning_nothing(tmp_path):
+    """The sqlite fact the whole ordering below rests on.
+
+    Stated as a test because it is the part that is easy to forget: a ledger
+    that has been closed does not export empty or export stale, it raises. So
+    "flush somewhere near the end" is not good enough — the flush has to be
+    strictly before the close, on every path, or it writes nothing at all.
+    """
+    ledger = CostReceiptLedger(tmp_path / "l.sqlite3", run_id="r")
+    _spend(ledger, CostRecorder(ledger, round_index=0), "task-a")
+    assert len(ledger.export_jsonl(tmp_path / "open.jsonl")) == 64
+    ledger.close()
+
+    with pytest.raises(Exception) as raised:
+        ledger.export_jsonl(tmp_path / "closed.jsonl")
+    assert type(raised.value).__name__ == "ProgrammingError"
+
+
+def test_the_close_exports_before_it_shuts_the_ledger():
+    """``atexit`` unwinds backwards, which inverts the order that was wanted.
+
+    ``flush_cost_ledger`` is registered first and ``close_grader`` second, so
+    on the paths that skip ``finish`` — the crash and the cancellation, which
+    are the only paths any of this exists for — ``close_grader`` runs *first*
+    and closes the database. The flush that follows then raises against a
+    closed handle and writes nothing, which is precisely the shard-4 outcome
+    this module was written to prevent, reintroduced one layer down.
+
+    Registration order is not the fix, because a third handler added later
+    would silently reorder it again. The fix is that the close performs the
+    flush itself, so the two cannot be separated by anything.
+    """
+    body = _main_body()
+    source = ast.unparse(ast.Module(body=body, type_ignores=[]))
+    assert source.index("atexit.register(flush_cost_ledger)") < source.index(
+        "atexit.register(close_grader)"
+    ), "if this ever flips, read the docstring before 'fixing' it here"
+
+    close = next(
+        node for node in body
+        if isinstance(node, ast.FunctionDef) and node.name == "close_grader"
+    )
+    closed = ast.unparse(close)
+    assert "flush_cost_ledger()" in closed, (
+        "the close is the last moment the ledger can still be read; a crash "
+        "that never reaches finish() has no other chance to export it"
+    )
+    assert closed.index("flush_cost_ledger()") < closed.index(
+        "cost_recorder.ledger.close()"
+    ), "flushing after the close exports nothing and reports ProgrammingError"
+
+
+def test_a_flush_after_the_close_says_nothing():
+    """A false report of loss is its own failure, not a cosmetic one.
+
+    The ``atexit`` flush still fires after ``close_grader`` has run. Left
+    unguarded it prints ``final ledger export failed (ProgrammingError)`` as
+    the last line of a *successful* run, over a ledger sitting safely on disk.
+    Someone reading that during an incident would go looking for a bill that
+    was never lost, which is the opposite of what a safety net is for.
+    """
+    flush = next(
+        node for node in _main_body()
+        if isinstance(node, ast.FunctionDef) and node.name == "flush_cost_ledger"
+    )
+    guard = ast.unparse(
+        next(node for node in flush.body if isinstance(node, ast.If))
+    )
+    assert "ledger_closed" in guard, (
+        "the post-close flush must be a no-op; see "
+        "test_the_close_exports_before_it_shuts_the_ledger"
+    )
+    assert "return" in guard
+
+
+# ── the workflow half ────────────────────────────────────────────────────
+
+
+def test_the_workflow_commits_the_ledger_beside_its_grade():
+    """The export is committed, verified against the digest step8 published.
+
+    Committing is what makes the two readers above work: the merge resolves
+    the pointer against the checkout, and a resumed chunk imports what its
+    predecessor left there. Uploading an artifact does neither.
+    """
+    step = _step("Commit grade result")
+    assert step["env"]["COST_LEDGER_FILE"] == (
+        "${{ steps.grade.outputs.cost_ledger_file }}"
+    )
+    assert step["env"]["COST_LEDGER_SHA256"] == (
+        "${{ steps.grade.outputs.cost_ledger_sha256 }}"
+    )
+    run = step["run"]
+    assert 'git add -- "$COST_LEDGER_FILE"' in run
+    assert "$COST_LEDGER_SHA256" in run, (
+        "the committed file must be checked against the digest step8 "
+        "published for it, or the grade points at something else"
+    )
+    assert "data/grades/*.cost_ledger.jsonl" in run
+
+
+def test_the_ledger_upload_is_not_gated_on_a_grade_that_was_saved():
+    """The gate that made a five-hour run leave zero artifacts.
+
+    ``steps.grade.outputs.grade_file`` is written inside the save path. A run
+    killed before its first save has no such output, so a condition naming it
+    is false exactly when preservation matters most. This upload names neither
+    that output nor the step's outcome.
+    """
+    condition = str(_step("Upload cost ledger")["if"])
+    assert "always()" in condition
+    assert "grade_file" not in condition
+    assert "steps.grade" not in condition
+
+    with_ = _step("Upload cost ledger")["with"]
+    paths = str(with_["path"])
+    assert "*.cost_ledger.jsonl" in paths
+    assert "*.cost_ledger.sqlite3" in paths, (
+        "the sqlite3 is the copy that exists even when the exporter never "
+        "ran, so it is the one that survives a kill"
+    )
+    assert "${{" not in paths, (
+        "a path built from a step output reintroduces the gate through the "
+        "back door: it resolves to empty and uploads nothing"
+    )
+
+
+def test_the_grade_upload_still_carries_the_grade():
+    """The change above adds an artifact; it must not have moved one."""
+    with_ = _step("Upload grade artifact")["with"]
+    assert "steps.grade.outputs.grade_file" in str(with_["path"])

--- a/batch-runner/tests/test_perception_audio.py
+++ b/batch-runner/tests/test_perception_audio.py
@@ -228,6 +228,45 @@ def test_an_unsupported_container_is_refused_without_spending_a_call(tmp_path):
     assert verdict.usage_complete is True
 
 
+def test_the_rate_limit_guard_runs_before_every_request(wav_file):
+    """Audio is paced by the same spacer as looking and as the main judge.
+
+    All three go out over one client and draw on one token-per-minute
+    allowance, so a guard only some of them call does not pace the run — it
+    just moves where the 429s land. This reader had no guard at all until the
+    content-part key was corrected, which hid the gap completely: every audio
+    request was refused before it reached a model, so there was never any
+    traffic to throttle.
+
+    The guard runs *before* the call is counted, so a clip refused for its
+    container (checked earlier) does not consume a spacing interval either.
+    """
+    guarded = []
+    client = FakeClient(FakeResponses())
+    ap = AudioPerception(
+        client=client, before_upstream_call=lambda: guarded.append("guard")
+    )
+
+    ap.judge(criterion="voice is clear", audio_path=str(wav_file))
+    ap.judge(criterion="no clipping", audio_path=str(wav_file))
+
+    assert guarded == ["guard", "guard"]
+    assert len(client.responses.calls) == 2
+
+
+def test_a_refused_container_does_not_consume_a_spacing_interval(tmp_path):
+    """No request, so nothing to pace."""
+    guarded = []
+    clip = tmp_path / "stem.aiff"
+    clip.write_bytes(b"FORM\x00\x00\x00\x04AIFF")
+    ap = AudioPerception(
+        client=FakeClient(FakeResponses()),
+        before_upstream_call=lambda: guarded.append("guard"),
+    )
+
+    ap.judge(criterion="x", audio_path=str(clip))
+
+    assert guarded == []
 
 
 def test_call_cap_short_circuits(wav_file):

--- a/batch-runner/tests/test_perception_wiring.py
+++ b/batch-runner/tests/test_perception_wiring.py
@@ -133,6 +133,13 @@ def test_grader_wires_perception_subjudges():
     assert getattr(
         tj.vision_perception.before_upstream_call, "__self__", None
     ) is grader
+    # Audio too, and this line is the one that was missing. The three readers
+    # share one client and therefore one token-per-minute allowance, so a
+    # spacer two of them honour paces nothing. It went unnoticed because a
+    # mistyped content part meant no audio request ever reached a model.
+    assert getattr(
+        tj.audio_perception.before_upstream_call, "__self__", None
+    ) is grader
     raw_cache_key = json.dumps(
         (
             "exp003_GPT52Chat_baseline_runner_exec",

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -154,6 +154,21 @@ def test_compute_summary_includes_perception_in_total_cost_volume():
     assert cost["unpriced_models"] == ["gpt-5.6-sol", "gpt-audio-1.5"]
 
 
+def _without_interval_checkpoint(tmp_path: Path):
+    """Leave the time-budget save as the only one that can fail.
+
+    ``partial_save_max_interval_sec`` defaults to 900s, and a test that fakes
+    the clock forward to trip the budget trips the interval as well — so the
+    periodic checkpoint saves first, and a test aimed at the time-budget save
+    would be exercising the periodic one instead. Switching it off keeps the
+    two paths testable apart.
+    """
+    path = tmp_path / "grading_configs" / "default.yaml"
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    config["output"]["partial_save_max_interval_sec"] = 0
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
 def _setup_workspace(tmp_path: Path):
     (tmp_path / "experiments").mkdir(parents=True, exist_ok=True)
     (tmp_path / "workspace").mkdir(parents=True, exist_ok=True)
@@ -3192,6 +3207,7 @@ def test_time_budget_partial_persistence_failure_never_requests_resume(
     monkeypatch, tmp_path, failure_mode
 ):
     _setup_workspace(tmp_path)
+    _without_interval_checkpoint(tmp_path)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
     monkeypatch.setattr(s8, "Grader", _FakeGrader)
@@ -3215,6 +3231,61 @@ def test_time_budget_partial_persistence_failure_never_requests_resume(
 
     assert rc == 5
     assert rc != 7
+
+
+@pytest.mark.parametrize("interval_sec, first_save", [(900, 1), (0, 3)])
+def test_a_finished_task_reaches_disk_on_the_clock_not_the_count(
+    monkeypatch, tmp_path, interval_sec, first_save
+):
+    """Shard 4's loss, reduced to the smallest run that reproduces it.
+
+    ``partial_save_every_n_tasks`` is 10 and a shard holds seventeen tasks, so
+    a chunk that dies before its tenth has never written anything down — which
+    is how run 33239148807 graded six tasks over five hours and left an empty
+    output directory behind. The interval save is what makes a finished task
+    durable on wall-clock time instead of on a task count it may never reach.
+
+    Parametrised against the same run with the interval switched off, because
+    the assertion that matters is the difference between them: without it the
+    first thing written is the finished run, and everything before that is
+    only in memory.
+    """
+    _setup_workspace(tmp_path)
+    if interval_sec == 0:
+        _without_interval_checkpoint(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(s8, "RubricLoader", _FakeLoader)
+    monkeypatch.setattr(s8, "Grader", _FakeGrader)
+
+    # Every reading of the clock advances it past the interval, so the save is
+    # due after each task. The budget is out of reach, so nothing else stops
+    # the loop and the run ends by grading all three.
+    elapsed = {"t": 0.0}
+
+    def tick():
+        elapsed["t"] += 1000.0
+        return elapsed["t"]
+
+    monkeypatch.setattr(s8.time, "monotonic", tick)
+    monkeypatch.setenv("GRADER_TIME_BUDGET_SEC", "1000000000")
+
+    saved: list[int] = []
+    real_save = s8._save_json
+
+    def record(path, payload):
+        saved.append(len(payload["tasks"]))
+        real_save(path, payload)
+
+    monkeypatch.setattr(s8, "_save_json", record)
+    monkeypatch.setattr("sys.argv", [
+        "step8_grade.py", "exp998_smoke_baseline_sample",
+        "--config", "grading_configs/default.yaml", "--force",
+    ])
+
+    assert s8.main() == 0
+    assert saved, "the run wrote nothing at all"
+    assert saved[0] == first_save
+    assert saved[-1] == 3, "the completed run is written whichever way it got there"
 
 
 def test_atomic_save_failure_preserves_existing_file(monkeypatch, tmp_path):
@@ -3373,7 +3444,11 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
     assert "refs/heads/main" in validate_inputs["run"]
     assert "GRADE_TASKS_LIMIT" in validate_inputs["run"]
     assert "git rev-parse HEAD" in verify_checkout["run"]
-    assert "refs/remotes/origin/main" in verify_checkout["run"]
+    assert 'git diff --name-only "$GITHUB_SHA" "$HEAD_SHA"' in verify_checkout["run"], (
+        "the dispatched revision is pinned by the content of the grading "
+        "inputs, not by the branch tip, which sibling shards move constantly; "
+        "see test_a_sibling_shards_commit_cannot_kill_a_chunk.py"
+    )
     assert "required input must be a regular non-symlink file" in verify_checkout["run"]
     assert all(
         "${{ inputs." not in step.get("run", "")


### PR DESCRIPTION
Stage 3 재실행 전에 필요한 안전장치와, 지난 실행에서 실제로 손실을 낸 결함 네 가지를 고칩니다.
PR #266–#269 위에 쌓이며, `origin/main` (248e301, #267 병합본)에 리베이스되어 있습니다.

## 왜

지난 Stage 3에서 두 종류의 손실이 있었습니다.

**샤드 4 (run 33239148807)** — 6개 과제를 채점하고 7번째 과제 하나에서 4시간 9분을 보낸 뒤
`timeout-minutes: 320`에 걸려 종료됐습니다. 남은 산출물은 `{"total_count":0,"artifacts":[]}`.
부분 결과도, 비용 장부도 없습니다. 세 가지가 동시에 참이어야 이렇게 되는데, 셋 다 참이었습니다.

- 중간 저장이 `partial_save_every_n_tasks: 10` 하나로만 걸려 있었고, 이 실행은 6개에서 죽었습니다.
- 아티팩트 업로드가 `steps.grade.outputs.grade_file`에 걸려 있었는데, 그 출력은 저장 경로 안에서만 쓰입니다.
  즉 한 번도 저장하지 못한 실행은 보존이 가장 필요한 순간에 업로드 조건이 거짓이 됩니다.
- 장부를 커밋하는 코드가 없어, 러너 위의 사본이 유일한 사본이었습니다.

**성공한 샤드들** — 세 번째 항목은 실패와 무관합니다. `merge_shard_cost_ledgers`는 각 샤드의 장부를
샤드 JSON 옆(체크아웃)에서 찾고, 재개된 청크도 앞 청크가 거기 남긴 것을 읽어 복원합니다.
둘 다 저장소를 읽는데 아무도 저장소에 쓰지 않았습니다. 그래서 지금까지 병합된 9개 샤드 전부
장부가 조용히 누락됐고, 재개된 청크는 매번 0부터 다시 셌습니다.

**run 33248832615** — 유료 승인을 통과한 직후 `origin/main moved after dispatch`로 죽었습니다.
승인 대기 117초 사이에 샤드 3이 자기 채점 결과 한 파일(`shard-003-of-011.json`)을 커밋했습니다.
11개 샤드가 한 브랜치에 쓰는 구조에서 브랜치 팁은 사실상 멈춰 있지 않으므로, 팁이 안 움직였기를
요구하는 검사는 가장 평범한 이유로 실패하며, 하필 승인 직후에 실패합니다.

## 무엇을

**결과와 비용이 실패에서 살아남게** — 시계 기반 중간 저장(`partial_save_max_interval_sec`, 기본 900초)을
과제 수 기준과 병행합니다. SIGTERM/SIGINT를 `SystemExit`으로 바꿔 종료 처리기가 돌게 하고,
장부 export를 `finish` · `atexit` · 시그널 세 경로에 모두 겁니다. 워크플로는 장부를 채점 결과 옆에
커밋하고(step8이 발행한 SHA-256과 대조), 업로드는 `always()`에 sqlite3 원본까지 포함합니다.

**export가 close보다 먼저 일어나게** — `atexit`은 등록 역순으로 풀립니다. `flush_cost_ledger`를 먼저,
`close_grader`를 나중에 등록했으므로 `finish`를 거치지 않는 경로(크래시·취소, 즉 이 장치가 존재하는
바로 그 경로)에서는 close가 **먼저** 돌아 DB를 닫아버리고, 뒤이은 export가 `ProgrammingError`로
아무것도 쓰지 못했습니다. 정상 경로에서는 이미 export가 끝난 뒤라 성공한 실행의 마지막 줄에
거짓 손실 보고가 찍혔습니다. flush를 `close_grader` 안으로 옮겨 순서를 등록 순서가 아니라 구조로
보장하고, 닫힌 뒤의 flush는 조용한 no-op으로 만듭니다.

**끝나지 않는 과제가 청크를 통째로 못 죽이게** — 예산 검사를 채점기 안쪽(루브릭 항목 사이, 분할 자식
루프)까지 내립니다. 예산을 넘긴 과제는 반쯤 채점된 채로 저장하지 않고 통째로 버립니다 — 도달하지
못한 항목이 오답으로 읽히기 때문입니다. 그리고 **아무 과제도 끝내지 못한 청크는 exit 7을 요청하지
않습니다**. 다음 청크에 같은 첫 과제를 넘겨 같은 결과를 내면서 매번 요금만 물리기 때문입니다.

**형제 샤드의 커밋이 청크를 못 죽이게** — 브랜치 팁 동일성 검사를 채점 입력 경로 목록의 내용 비교로
바꿉니다. 팁은 움직여도 되고, 채점 입력은 움직이면 안 됩니다. 승인이 서술한 코드가 실제로 도는지를
지키는 원래 성질은 그대로입니다. 커버 범위는 `compute_grader_source_hash`에서 유도해 검증합니다.

**오디오가 시각·본 판정과 같은 재시도 정책을 쓰게** — 지금까지 오디오 인지 호출만 429 대응 없이
맨몸으로 나가고 있었습니다.

## 검증

- 전체 백엔드 스위트 **5765 passed, 6 skipped, 0 failed** (로컬 py310, 11분 6초)
- 신규 테스트 3개 모듈. 워크플로 셸 조각은 재구현이 아니라 **워크플로에서 잘라내어** 실제 로컬
  저장소에 대고 실행합니다(패러프레이즈는 워크플로가 다른 걸 배포해도 통과하므로).
- 역검증 19건 — 결함을 하나씩 되살려 의도한 테스트만 실패하는지 확인. 이번 회차 4건:
  `close_grader`에서 flush 제거 / flush를 close 뒤로 이동 / 가드를 되돌림 / 시계를 이중으로 읽음.
- 모델 호출·네트워크 호출 없음.

## 이 PR이 초래하는 것

`step8_grade.py`와 `core/**/*.py`를 건드리므로 `grader_source_hash`가 `ce7d4978bce9effc`에서 이동합니다.
`step9_merge_shards.CONTRACT_IDENTITY_FIELDS`가 이 값을 포함하므로 기존 151개 결과와는 병합되지
않습니다. 남은 34개만 채점하는 선택지는 없고, 185개를 한 지문으로 다시 채점해야 합니다.
