### PR TITLE
fix(grading): 판정자가 보고 있는 파일을 실제로 보게 한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,70 @@ entries land under a fresh dated heading the day they merge to `main`.
   because none of them can run.
 
 ### Fixed
+- **Three ways a judge could be shown a deliverable and still not see what was
+  in it.** All three were found by taking the lowest-scoring gold answers in the
+  185-task corpus and opening the real files, rather than reasoning about what
+  the reading tool ought to do.
+
+  *A file that could not be read hid behind one that could.* The escalation
+  added earlier — an item whose files yield no text goes to the path that looks
+  at them — asked whether *any* selected file had text. That collapses a bundle
+  to a single yes the moment one file yields a character. Task `f9f82549`
+  selects a two-page incident flowchart whose pages hold **0 characters**,
+  because page one is a single full-page image, alongside a readable memo. The
+  bundle answered "yes, there is text here", the item stayed on the reading
+  path, and the flowchart was never rendered or looked at. The narrower question
+  — "is any one of these files unreadable" — is now asked as well, and either
+  one escalating is enough. It shares the same per-file memo, so asking twice
+  costs no extra reading, and a file that nothing could answer for still cannot
+  escalate on a guess.
+
+  *A read came back looking complete when the values were pictures.* Task
+  `94925f49`, the lowest-scoring gold answer in the corpus at **15.85%**, is one
+  PDF page holding a school-performance table. Extraction returns 572 characters
+  — the title, the column headers and the row labels — and **every grade,
+  percentage and ratio the rubric asks about is absent from the entire text
+  layer**, living instead in **30 embedded images**. Nothing said so, so the read
+  looked complete and the missing values read as absent from the document. A
+  non-empty PDF read now reports how many embedded images it did not extract,
+  which turns a silent omission into the disclosed gap the judge's existing rule
+  about absence already handles. This is disclosure, not extraction: no
+  threshold is guessed, and a PDF that really is all text is not accused of
+  hiding anything.
+
+  *Tracked changes and reviewer comments were invisible.* Task `5d0feb24`
+  (**38.28%**) is marked on edits it carries as Word revision marks. The real
+  file holds **48 insertions and 10 deletions**; a content read returns 4,218
+  characters with no trace of any of them, so reading could never witness the
+  thing being graded. `inspect_formatting` now reports insertion and deletion
+  counts, and reviewer comments with the text they are anchored to — capped at
+  50 comments and 500 characters each — and the judge's standing instructions
+  now say to ask for it on a `.docx`. Without that line the judge would never
+  learn the question was available.
+
+- **A PDF table reached the judge as unrelated paragraphs.** A ruled table's row
+  now arrives as one line, instead of the label and the value becoming separate
+  paragraphs several lines apart. This is general robustness and nothing more.
+  It was written believing it was the fix for `94925f49`, and measuring that
+  task against the real file **disproved that**: extraction recovers the row
+  labels, but the value cells come back empty, because those grades are
+  pictures. The disclosure above is what addresses that task; this entry claims
+  only what it earns.
+
+- **The marking cost envelope was re-measured rather than left quoting the old
+  length.** Telling the judge that `inspect_formatting` can now report Track
+  Changes took `prompts/grader_judge_v2.md` from **6,772 to 6,866 characters**,
+  and the longer tool description moved the opening every marking call carries
+  from **2,825 to 2,857 tokens** and the demanded input per call from **536,159
+  to 536,191**. That file is read from disk and sent on every single call, so
+  its length is counted into what one call can carry. Five cost tests failed on
+  the old numbers and were corrected to the freshly measured ones rather than
+  loosened — the guard exists so that nobody can widen what every call carries
+  without the recorded ceiling moving with it, and a guard that gets relaxed
+  when it fires is not a guard. The tool-results half, 533,334 tokens, did not
+  move and was left alone. The figures quoted in the earlier entries in this
+  section were correct when they were measured and are superseded by these.
+
 - **A task made entirely of music was graded without anything ever listening to
   it.** Stage-1 task `38889c3b` delivers its whole answer as one 180 MB `.zip`
   of audio stems and is marked on tempo, key, vocals, effects and mix. It

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -689,6 +689,41 @@ class Grader:
             deliverable_path, paths, has_extractable_text, self._text_layer_cache
         )
 
+    def _some_selected_path_lacks_text(
+        self, deliverable_path: Path, paths: Iterable[str]
+    ) -> bool | None:
+        """Is any one of these files unable to yield a character of text?
+
+        The question above cannot answer this one. It stops at the first file
+        that yields text and reports the whole set as readable, so a picture
+        selected next to a readable document disappears behind it. Asking per
+        file is what lets the picture be looked at.
+
+        Same discipline as its sibling: a measured ``False`` from one file is
+        enough to say ``True`` here, ``None`` when no file gave a definite no
+        and at least one could not be answered for, and ``False`` only when
+        every file was examined and every one of them had text. It shares the
+        text-layer memo, so the extra question costs no extra reading.
+        """
+        seen_any = False
+        seen_unknown = False
+        for name in paths:
+            if not isinstance(name, str) or not name:
+                continue
+            seen_any = True
+            if name not in self._text_layer_cache:
+                self._text_layer_cache[name] = has_extractable_text(
+                    deliverable_path / name
+                )
+            answer = self._text_layer_cache[name]
+            if answer is False:
+                return True
+            if answer is None:
+                seen_unknown = True
+        if not seen_any or seen_unknown:
+            return None
+        return False
+
     def _selected_paths_have_audio(
         self, deliverable_path: Path, paths: Iterable[str]
     ) -> bool | None:
@@ -708,6 +743,9 @@ class Grader:
             item.criterion,
             plan.selected_paths,
             selected_paths_have_text=self._selected_paths_have_text(
+                deliverable_path, plan.selected_paths
+            ),
+            some_selected_path_lacks_text=self._some_selected_path_lacks_text(
                 deliverable_path, plan.selected_paths
             ),
             selected_paths_have_audio=self._selected_paths_have_audio(
@@ -735,6 +773,11 @@ class Grader:
                     target.paths,
                     selected_paths_have_text=self._selected_paths_have_text(
                         deliverable_path, target.paths
+                    ),
+                    some_selected_path_lacks_text=(
+                        self._some_selected_path_lacks_text(
+                            deliverable_path, target.paths
+                        )
                     ),
                     selected_paths_have_audio=self._selected_paths_have_audio(
                         deliverable_path, target.paths

--- a/batch-runner/core/grader_preflight.py
+++ b/batch-runner/core/grader_preflight.py
@@ -99,6 +99,11 @@ def plan_task_runtime(
                     selected_paths_have_text=grader._selected_paths_have_text(
                         deliverable_path, target.paths
                     ),
+                    some_selected_path_lacks_text=(
+                        grader._some_selected_path_lacks_text(
+                            deliverable_path, target.paths
+                        )
+                    ),
                     selected_paths_have_audio=grader._selected_paths_have_audio(
                         deliverable_path, target.paths
                     ),
@@ -208,6 +213,9 @@ def plan_task_runtime(
             item.criterion,
             target_plan.selected_paths,
             selected_paths_have_text=grader._selected_paths_have_text(
+                deliverable_path, target_plan.selected_paths
+            ),
+            some_selected_path_lacks_text=grader._some_selected_path_lacks_text(
                 deliverable_path, target_plan.selected_paths
             ),
             selected_paths_have_audio=grader._selected_paths_have_audio(

--- a/batch-runner/core/grader_routing.py
+++ b/batch-runner/core/grader_routing.py
@@ -172,6 +172,7 @@ def resolve_runtime_routing(
     *,
     selected_paths_have_text: bool | None = None,
     selected_paths_have_audio: bool | None = None,
+    some_selected_path_lacks_text: bool | None = None,
 ) -> RoutingDecision:
     """Apply target-aware policy without changing criterion classification.
 
@@ -179,6 +180,12 @@ def resolve_runtime_routing(
     file yield a single character of text". The caller reads the files; this
     module stays pure. ``None`` means unknown and changes nothing -- only a
     measured ``False`` escalates.
+
+    ``some_selected_path_lacks_text`` answers the narrower question "is any one
+    of these files unreadable", which the first signal cannot express: it
+    collapses a bundle to a single yes the moment one file yields a character,
+    so a picture delivered alongside a readable sibling reports as readable.
+    Same rules -- only a measured ``True`` escalates, ``None`` changes nothing.
 
     ``selected_paths_have_audio`` is the same shape of answer to "is there
     anything here to listen to", and is used only defensively: a measured
@@ -279,8 +286,15 @@ def resolve_runtime_routing(
     # and FORMATTING escalate, because AUDIO and VISUAL already name what they
     # need. And every selected file must be renderable, so escalating never
     # trades a readable file for one nothing can look at.
+    #
+    # The bundle question and the file question are both asked, because one
+    # readable file used to answer for all of them. A stage-3 task selected a
+    # two-page flowchart holding zero characters -- one full-page image -- next
+    # to a readable memo; the bundle reported "yes, there is text here", the
+    # item stayed TEXT, and the flowchart was never rendered or looked at. A
+    # sibling that can be read is not evidence about the file that cannot.
     if (
-        selected_paths_have_text is False
+        (selected_paths_have_text is False or some_selected_path_lacks_text is True)
         and decision.modality in (Modality.TEXT, Modality.FORMATTING)
         and suffixes
         and suffixes.issubset(GRADER_VISUAL_RENDER_EXTENSIONS)

--- a/batch-runner/core/tools/read_deliverable.py
+++ b/batch-runner/core/tools/read_deliverable.py
@@ -61,6 +61,12 @@ MAX_CONTENT_CHARS = 200_000   # ``read_content`` text payload cap
 MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5MB before/after downsample
 MAX_CELLS_FORMATTING = 5_000  # inspect_formatting iterates capped cells
 
+#: Word revision limits. A copy-editing deliverable can carry thousands of
+#: tracked edits; the counts stay exact but the sampled bodies do not, so one
+#: heavily-marked document cannot flood a judge's context.
+MAX_COMMENTS_REPORTED = 50
+MAX_COMMENT_CHARS = 500
+
 #: Archive limits. A deliverable submitted as a ``.zip`` is a container of
 #: files the other ops already handle, so the archive is listed and single
 #: members can be opened through ``scope={"member": ...}``. Both numbers bound
@@ -176,7 +182,14 @@ MODEL_READ_DELIVERABLE_TOOL_SCHEMA: Dict[str, Any] = {
                     "be used as one. "
                     "read_content: text. "
                     "inspect_formatting: styles, fills, fonts, borders, and "
-                    "the same page count and page size. "
+                    "the same page count and page size. For a .docx it also "
+                    "reports the editing marks: tracked_insertion_count, "
+                    "tracked_deletion_count, and comments (author, text, and "
+                    "the anchored_text each one is attached to). Whether a "
+                    "document carries Track Changes or reviewer comments is "
+                    "answerable ONLY from these fields -- read_content shows "
+                    "an insertion as ordinary text and omits a deletion "
+                    "altogether, so it can never witness either. "
                     "probe_audio / probe_video: media metadata."
                 ),
             },
@@ -851,6 +864,47 @@ def _read_xlsx_text(p: Path, scope: Dict[str, Any]) -> str:
     return "\n\n".join(parts)
 
 
+def _pdf_table_blocks(page: Any, page_number: int) -> List[str]:
+    """Each ruled table on the page, one row per line, cells kept apart.
+
+    ``extract_text`` reads a page the way a person's eye crosses it, which for
+    a table means the header row arrives as one run of prose and the body rows
+    as another. A criterion like "the report includes the grade for John Lewis
+    Childs School" is then unanswerable from a document that answers it plainly:
+    the school and its grade sit side by side on the page and land paragraphs
+    apart in the extraction, so the judge reads real evidence and correctly
+    concludes the grade is absent.
+
+    Emitting the rows keeps a record together, in the same ``|``-separated
+    shape ``_read_docx_text`` and ``_read_xlsx_text`` already use, so a table
+    reads the same whoever authored it.
+
+    The linear text stays as well. Table detection is a guess about ruling
+    lines, and a wrong guess must not be able to delete content -- the
+    structured view is added to the page, never substituted for it.
+    """
+    try:
+        tables = page.extract_tables()
+    except Exception:  # noqa: BLE001
+        # A malformed table costs its own rows and nothing else: the page's
+        # text is already collected and must survive a detector that trips.
+        return []
+
+    blocks: List[str] = []
+    for table in tables or []:
+        rows = [
+            " | ".join(
+                "" if cell is None else " ".join(str(cell).split())
+                for cell in row
+            )
+            for row in table
+            if row and any(cell not in (None, "") for cell in row)
+        ]
+        if rows:
+            blocks.append(f"[Table on page {page_number}]\n" + "\n".join(rows))
+    return blocks
+
+
 def _read_pdf_text(p: Path, scope: Dict[str, Any]) -> str:
     import pdfplumber  # type: ignore
 
@@ -864,6 +918,7 @@ def _read_pdf_text(p: Path, scope: Dict[str, Any]) -> str:
             txt = page.extract_text() or ""
             if txt.strip():
                 parts.append(f"[Page {i}]\n{txt.strip()}")
+            parts.extend(_pdf_table_blocks(page, i))
             if sum(len(x) for x in parts) > MAX_CONTENT_CHARS:
                 break
     return "\n\n".join(parts)
@@ -1255,6 +1310,23 @@ def _op_read_content(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
             "char_count is a length, not a page count; call inspect_structure "
             "for converted_page_count"
         )
+    if kind == "pdf" and text.strip():
+        # A page can hold real text *and* carry its numbers as pasted
+        # pictures, and extraction drops the pictures without saying so, so
+        # the read comes back looking complete. The corpus's worst-scoring
+        # gold deliverable is one such page: 572 characters of title, column
+        # headers and row labels, with every grade, percentage and ratio
+        # living in 30 embedded images. Reporting the count costs nothing and
+        # turns a silent omission into the disclosed gap the judge's rule
+        # about absence is already written to handle.
+        images = _pdf_text_layer_facts(p).get("embedded_image_count")
+        if images:
+            notes.append(
+                f"this PDF also carries {images} embedded image(s) whose "
+                "content is not in the text above; a value the criterion asks "
+                "for and you cannot find may be drawn inside one of them "
+                "rather than absent from the document"
+            )
     if not text.strip():
         facts, empty_note = _empty_read_report(p, kind)
         result.update(facts)
@@ -1385,6 +1457,98 @@ def _format_xlsx(p: Path, scope: Dict[str, Any]) -> Dict[str, Any]:
     return {"kind": "xlsx", "sheets": sheets_meta}
 
 
+#: WordprocessingML namespace. Tracked revisions and comments live in the
+#: document XML and have no python-docx accessor, so they are read from there.
+_W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+
+
+def _docx_revisions_and_comments(p: Path) -> Dict[str, Any]:
+    """Tracked insertions, tracked deletions, and reviewer comments.
+
+    A copy-editing brief is graded on its marks: "substantive edits appear as
+    Track Changes insertions", "the .docx includes reviewer comments anchored
+    to specific text ranges". python-docx models none of this -- ``para.text``
+    silently folds an insertion into the running text and drops a deletion
+    entirely -- so a formatting report built from it can only describe a
+    marked-up document as though it were clean. The criteria are then
+    unanswerable, and an item nothing can see fails whatever the file contains.
+
+    The marks are in ``word/document.xml`` (``w:ins``, ``w:del``) and
+    ``word/comments.xml``, which is where this reads them.
+
+    Counts are exact. Comment bodies and their anchors are sampled and
+    truncated, because how many marks there are is the gradeable fact and a
+    thousand of them must not cost a judge its context.
+
+    A file that cannot be opened reports zeros rather than raising: this
+    enriches a formatting report that is useful without it, so it must never be
+    the reason the whole report fails.
+    """
+    blank: Dict[str, Any] = {
+        "tracked_insertion_count": 0,
+        "tracked_deletion_count": 0,
+        "comment_count": 0,
+        "comments": [],
+    }
+    import zipfile
+    from xml.etree import ElementTree
+
+    try:
+        with zipfile.ZipFile(p) as archive:
+            names = set(archive.namelist())
+            if "word/document.xml" not in names:
+                return blank
+            body = ElementTree.fromstring(archive.read("word/document.xml"))
+            comment_root = (
+                ElementTree.fromstring(archive.read("word/comments.xml"))
+                if "word/comments.xml" in names
+                else None
+            )
+    except Exception:  # noqa: BLE001
+        return blank
+
+    def q(tag: str) -> str:
+        return f"{{{_W_NS}}}{tag}"
+
+    # Walk the body once in document order, carrying the set of comment ranges
+    # that are currently open. Text seen while a range is open is that
+    # comment's anchor -- the "specific text range" the rubric asks about.
+    anchors: Dict[str, List[str]] = {}
+    open_ids: set[str] = set()
+    for element in body.iter():
+        tag = str(element.tag).rsplit("}", 1)[-1]
+        if tag == "commentRangeStart":
+            open_ids.add(element.get(q("id"), ""))
+        elif tag == "commentRangeEnd":
+            open_ids.discard(element.get(q("id"), ""))
+        elif tag in ("t", "delText") and open_ids and element.text:
+            for comment_id in open_ids:
+                anchors.setdefault(comment_id, []).append(element.text)
+
+    comments: List[Dict[str, Any]] = []
+    if comment_root is not None:
+        for comment in comment_root.findall(f".//{q('comment')}"):
+            comment_id = comment.get(q("id"), "")
+            text = "".join(
+                node.text or "" for node in comment.findall(f".//{q('t')}")
+            )
+            comments.append({
+                "id": comment_id,
+                "author": comment.get(q("author")),
+                "text": text.strip()[:MAX_COMMENT_CHARS],
+                "anchored_text": (
+                    " ".join(anchors.get(comment_id, [])).strip()[:MAX_COMMENT_CHARS]
+                ),
+            })
+
+    return {
+        "tracked_insertion_count": len(body.findall(f".//{q('ins')}")),
+        "tracked_deletion_count": len(body.findall(f".//{q('del')}")),
+        "comment_count": len(comments),
+        "comments": comments[:MAX_COMMENTS_REPORTED],
+    }
+
+
 def _format_docx(p: Path, _scope: Dict[str, Any]) -> Dict[str, Any]:
     from docx import Document  # type: ignore
 
@@ -1401,6 +1565,7 @@ def _format_docx(p: Path, _scope: Dict[str, Any]) -> Dict[str, Any]:
         "table_count": len(doc.tables),
         "section_count": len(doc.sections),
         "style_histogram": styles,
+        **_docx_revisions_and_comments(p),
     }
 
 

--- a/batch-runner/prompts/grader_judge_v2.md
+++ b/batch-runner/prompts/grader_judge_v2.md
@@ -56,7 +56,7 @@ read-only. Use the smallest op that answers your question.
 |---|---|
 | `inspect_structure` | first call to learn what's in the file (sheet/page/slide count, kind) |
 | `read_content` | when criterion talks about **what** is written (values, columns, sentences) |
-| `inspect_formatting` | when criterion talks about **how** it looks (style, fills, borders, layout, merged cells, charts) |
+| `inspect_formatting` | when criterion talks about **how** it looks (style, fills, borders, layout, merged cells, charts), and for a `.docx` whether it carries Track Changes insertions/deletions or reviewer comments |
 | `probe_audio` | when criterion is about audio (sample rate, duration, peak/clipping, silence ratio) |
 | `probe_video` | when criterion is about video metadata (codec, resolution, fps, duration) |
 

--- a/batch-runner/tests/test_envelope_preflight_prices_the_marking_tool_results.py
+++ b/batch-runner/tests/test_envelope_preflight_prices_the_marking_tool_results.py
@@ -329,9 +329,9 @@ def test_the_real_check_measures_the_scoring_line_instead_of_being_told():
     assert widest > 0, "a width of zero would price the scoring line at nothing"
 
 
-@pytest.mark.parametrize("raised_to", [536_159, 1_000_000])
+@pytest.mark.parametrize("raised_to", [536_191, 1_000_000])
 def test_raising_the_number_to_the_limit_settles_this_rule(raised_to):
-    """536159 is the whole demand: 533334 of tool results, 2825 of opening."""
+    """536191 is the whole demand: 533334 of tool results, 2857 of opening."""
     plan = load_plan(PLAN_PATH)
     plan["cost"]["assumptions"]["grading_input_tokens_per_call"] = raised_to
     result = run_envelope_preflight(plan, root=BATCH_RUNNER_ROOT)

--- a/batch-runner/tests/test_grader_empty_read_routing.py
+++ b/batch-runner/tests/test_grader_empty_read_routing.py
@@ -198,3 +198,92 @@ def test_the_preflight_leaves_a_readable_document_on_the_text_path(tmp_path, typ
     assert plan["judge_routes"] == {"text": 1}
     assert plan["planned_render_calls"] == 0
     assert plan["errors"] == []
+
+
+# ── The complement: which file, not whether any file (task 79) ───────
+#
+# ``_selected_paths_have_text`` is right about its own question and wrong as
+# the only question. Stage 3 selected a two-page Loss Prevention flowchart
+# carrying zero characters -- page one is a single full-page image -- next to
+# a readable 1,756-character memo. The bundle answered "yes, there is text",
+# the item stayed on the text path, and the flowchart was never rendered or
+# looked at by anything. ``_some_selected_path_lacks_text`` asks per file, on
+# the same memo, so the picture is seen without re-reading the memo.
+
+
+def test_a_picture_beside_a_readable_file_is_reported(tmp_path, scan):
+    (tmp_path / "memo.txt").write_text("The deposit was never banked.")
+
+    surface = _probe_surface()
+    assert surface._selected_paths_have_text(
+        tmp_path, ["memo.txt", scan.name]
+    ) is True
+    assert surface._some_selected_path_lacks_text(
+        tmp_path, ["memo.txt", scan.name]
+    ) is True
+
+
+def test_every_file_readable_is_a_finding_of_no_gap(tmp_path, typed):
+    (tmp_path / "memo.txt").write_text("The deposit was never banked.")
+
+    answer = _probe_surface()._some_selected_path_lacks_text(
+        tmp_path, ["memo.txt", typed.name]
+    )
+
+    assert answer is False
+
+
+def test_a_definite_gap_outranks_a_file_it_cannot_speak_for(tmp_path, scan):
+    """A measured no is enough; an unknown alongside it changes nothing."""
+    (tmp_path / "mystery.bin").write_bytes(b"\x00\x01\x02")
+
+    answer = _probe_surface()._some_selected_path_lacks_text(
+        tmp_path, [scan.name, "mystery.bin"]
+    )
+
+    assert answer is True
+
+
+def test_an_unknown_with_no_definite_gap_admits_it(tmp_path, typed):
+    (tmp_path / "mystery.bin").write_bytes(b"\x00\x01\x02")
+
+    answer = _probe_surface()._some_selected_path_lacks_text(
+        tmp_path, [typed.name, "mystery.bin"]
+    )
+
+    assert answer is None
+
+
+def test_a_missing_file_is_not_a_gap_in_the_deliverable(tmp_path):
+    """Absent is unknowable, not empty -- the same rule as its sibling."""
+    answer = _probe_surface()._some_selected_path_lacks_text(
+        tmp_path, ["never_written.pdf"]
+    )
+
+    assert answer is None
+
+
+def test_no_selected_paths_is_not_a_finding_here_either(tmp_path):
+    surface = _probe_surface()
+    assert surface._some_selected_path_lacks_text(tmp_path, []) is None
+    assert surface._some_selected_path_lacks_text(tmp_path, ["", None]) is None
+
+
+def test_the_two_questions_share_one_read_of_each_file(tmp_path, monkeypatch):
+    """Asking twice must not open the file twice."""
+    (tmp_path / "notes.txt").write_text("readable")
+    opened: list[str] = []
+
+    import core.grader as grader_module
+
+    monkeypatch.setattr(
+        grader_module,
+        "has_extractable_text",
+        lambda path: (opened.append(str(path)), True)[1],
+    )
+
+    grader = _probe_surface()
+    grader._selected_paths_have_text(tmp_path, ["notes.txt"])
+    grader._some_selected_path_lacks_text(tmp_path, ["notes.txt"])
+
+    assert len(opened) == 1

--- a/batch-runner/tests/test_marking_cost_counts_the_conversation_opening.py
+++ b/batch-runner/tests/test_marking_cost_counts_the_conversation_opening.py
@@ -12,7 +12,7 @@ the sentence that denied it.
 
 * The standing instructions are a committed file. ``prompt.tool_template``
   names it in all nine settings files, the judge splits it and sends both
-  halves on every single call, and it is 6,772 characters long today.
+  halves on every single call, and it is 6,866 characters long today.
 * The task preview is cut to ``ToolCallingJudge.task_prompt_truncate``
   characters, which is 500, and every task in the committed catalogue is longer
   than that — so the cut is always taken in full.
@@ -387,13 +387,13 @@ def test_forgetting_the_opening_lowers_the_demand():
         characters_of_widest_scoring_line=1,
     ).input_tokens_one_call_must_cover(THREE)
     assert without < with_opening
-    assert with_opening - without == 2_824
+    assert with_opening - without == 2_856
 
 
 def test_leaving_the_scoring_line_out_of_the_opening_lowers_the_demand():
     """The piece this task added, priced on its own.
 
-    400 tokens a call does not sound like the finding. Multiplied by the calls
+    401 tokens a call does not sound like the finding. Multiplied by the calls
     the settings allow across 10,453 scoring lines it is the difference between
     a figure that is a ceiling and a figure that was printed as one.
 
@@ -405,7 +405,7 @@ def test_leaving_the_scoring_line_out_of_the_opening_lowers_the_demand():
     almost_without = caps(
         characters_of_widest_scoring_line=1
     ).input_tokens_one_call_must_cover(THREE)
-    assert whole - almost_without == 400
+    assert whole - almost_without == 401
 
 
 def test_a_longer_instruction_file_raises_the_demand_by_itself():
@@ -588,7 +588,7 @@ def test_the_committed_plan_still_records_the_bigger_number():
 
     matching = [p for p in result.cost_findings if "input per marking call" in p]
     assert len(matching) == 1
-    assert "536159" in matching[0]
+    assert "536191" in matching[0]
     assert "533334" in matching[0]
     assert matching[0] not in result.problems
 
@@ -660,7 +660,7 @@ def test_the_description_says_what_every_call_opens_with():
     opening = [line for line in lines if "opens with" in line]
     assert len(opening) == 1
     assert "prompts/grader_judge_v2.md" in opening[0]
-    assert "6772" in opening[0]
+    assert "6866" in opening[0]
 
 
 def test_the_description_says_the_figure_is_a_ceiling_once_the_width_is_known():
@@ -724,7 +724,7 @@ def test_the_written_out_form_carries_the_new_measurements():
     assert written_out["standing_instructions_read_from"] == (
         "prompts/grader_judge_v2.md"
     )
-    assert written_out["characters_of_standing_instructions"] == 6772
+    assert written_out["characters_of_standing_instructions"] == 6866
     assert written_out["characters_of_task_wording_shown"] == 500
     assert written_out["task_wording_width_named_by_the_settings"] == 500
     assert written_out["the_settings_width_is_ignored"] is False

--- a/batch-runner/tests/test_perception_routing.py
+++ b/batch-runner/tests/test_perception_routing.py
@@ -570,3 +570,81 @@ def test_omitting_the_audio_probe_is_identical_to_not_knowing(
     assert resolve_runtime_routing(criterion, paths) == resolve_runtime_routing(
         criterion, paths, selected_paths_have_audio=None
     )
+
+
+# ── One readable file stops answering for the rest (task 79) ─────────
+#
+# The escalation above asks the bundle a single question -- "is there any text
+# here" -- and a bundle answers yes the moment one file yields a character.
+# A stage-3 task selected two PDFs: a two-page Loss Prevention flowchart
+# holding zero characters, page one being a single full-page image, and a
+# readable Missing Bank Deposits memo of 1,756 characters. The memo answered
+# for both. The item stayed TEXT, `perception_called` was false, the render
+# count was zero, and the flowchart -- which is a picture, and is what the
+# criterion was about -- was never looked at by anything. The task scored
+# 40.00%.
+#
+# A sibling that can be read is not evidence about the file that cannot, so
+# the file question is now asked alongside the bundle question. The same three
+# conditions still bound it.
+
+
+def test_a_picture_beside_a_readable_file_still_reaches_the_eyes():
+    decision = resolve_runtime_routing(
+        "The flowchart shows the escalation path for a suspected theft",
+        ["flowchart.pdf", "memo.pdf"],
+        selected_paths_have_text=True,
+        some_selected_path_lacks_text=True,
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.preferred_op == "render_to_image"
+
+
+def test_a_bundle_whose_files_can_all_be_read_is_left_alone():
+    """The common case must not be dragged to vision by the new question."""
+    decision = resolve_runtime_routing(
+        "The memo states the total contract value",
+        ["memo.pdf", "appendix.pdf"],
+        selected_paths_have_text=True,
+        some_selected_path_lacks_text=False,
+    )
+
+    assert decision.modality is Modality.TEXT
+
+
+def test_an_unanswerable_file_does_not_escalate_on_a_guess():
+    """``None`` is an admission, not a no. It must change nothing."""
+    decision = resolve_runtime_routing(
+        "The memo states the total contract value",
+        ["memo.pdf", "mystery.bin"],
+        selected_paths_have_text=True,
+        some_selected_path_lacks_text=None,
+    )
+
+    assert decision.modality is Modality.TEXT
+
+
+def test_the_new_question_still_obeys_the_renderable_condition():
+    """Escalating must never trade a readable file for an unviewable one."""
+    decision = resolve_runtime_routing(
+        "The notes state the total contract value",
+        ["memo.pdf", "recording.wav"],
+        selected_paths_have_text=True,
+        some_selected_path_lacks_text=True,
+    )
+
+    assert decision.modality is not Modality.VISUAL
+
+
+def test_omitting_the_new_question_changes_no_existing_decision():
+    """Every caller that never passes it must route exactly as before."""
+    for criterion, paths in (
+        ("The memo states the total contract value", ["memo.pdf"]),
+        ("The chart uses the brand colour palette", ["deck.pptx"]),
+        ("The narration is free of clipping", ["take.wav"]),
+        ("The document structure follows the template", ["report.docx"]),
+    ):
+        assert resolve_runtime_routing(criterion, paths) == resolve_runtime_routing(
+            criterion, paths, some_selected_path_lacks_text=None
+        )

--- a/batch-runner/tests/test_read_deliverable.py
+++ b/batch-runner/tests/test_read_deliverable.py
@@ -2037,3 +2037,313 @@ def test_has_audio_content_answers_before_the_cut_when_it_can(
     monkeypatch.setattr(read_deliverable_module, "MAX_ZIP_ENTRIES", 2)
 
     assert has_audio_content(p) is True
+
+
+# ── A table's rows reach the judge (task 78) ─────────────────────────
+
+
+def _ruled_table_pdf(path: Path) -> Path:
+    """A PDF whose only content is a grid-ruled table."""
+    pytest.importorskip("reportlab")
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import letter
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+
+    data = [
+        ["Elementary School", "Overall Niche Grade", "Percent Proficient Math"],
+        ["John Lewis Childs School", "A-", "71%"],
+        ["Hillside Grade School", "B+", "58%"],
+    ]
+    table = Table(data)
+    table.setStyle(TableStyle([("GRID", (0, 0), (-1, -1), 0.5, colors.black)]))
+    SimpleDocTemplate(str(path), pagesize=letter).build([table])
+    return path
+
+
+def test_a_ruled_tables_row_reaches_the_judge_intact(base_dir):
+    """A school and its grade arrive on one line, not in separate paragraphs.
+
+    Read as flowing text, a ruled table's header arrives as one run of prose
+    and its first column as another, so "the report includes the grade for
+    John Lewis Childs School" is unanswerable from a document that states it
+    plainly, and the judge fails the item on evidence that is honestly empty.
+
+    This does not claim to be the fix for the corpus's worst-scoring task. It
+    was written believing that, and measuring 94925f49 against the real file
+    disproved it: extraction recovers the row label but the value cell comes
+    back empty, because that deliverable's grades are pictures rather than
+    text. See ``test_a_pdf_whose_values_are_pictures_says_so``. What this
+    earns is narrower and still worth having -- a table whose cells really are
+    text now reaches the judge as rows instead of as two unrelated paragraphs.
+    """
+    _ruled_table_pdf(base_dir / "schools.pdf")
+
+    result = read_deliverable("read_content", "schools.pdf", base_dir=str(base_dir))
+
+    assert result["ok"] is True
+    text = result["data"]["text"]
+    row = next(
+        (ln for ln in text.splitlines() if "John Lewis Childs School" in ln and "|" in ln),
+        None,
+    )
+    assert row is not None, f"no table row for the school in:\n{text}"
+    assert "A-" in row
+    assert "71%" in row
+
+
+def test_a_pdf_with_no_table_reads_exactly_as_before(base_dir, pdf_file):
+    """Detection is a guess; a page it does not fire on must be untouched."""
+    result = read_deliverable("read_content", pdf_file.name, base_dir=str(base_dir))
+
+    assert result["ok"] is True
+    assert "[Table on page" not in result["data"]["text"]
+    assert result["data"]["text"].strip()
+
+
+def test_a_table_detector_that_trips_still_yields_the_page_text(base_dir, monkeypatch):
+    """One bad table costs its own rows, never the page it sits on."""
+    _ruled_table_pdf(base_dir / "schools.pdf")
+    monkeypatch.setattr(
+        read_deliverable_module,
+        "_pdf_table_blocks",
+        lambda *_a, **_kw: [],
+    )
+
+    result = read_deliverable("read_content", "schools.pdf", base_dir=str(base_dir))
+
+    assert result["ok"] is True
+    assert "John Lewis Childs School" in result["data"]["text"]
+    assert "[Table on page" not in result["data"]["text"]
+
+
+def test_a_raising_table_detector_is_caught_not_propagated(base_dir):
+    """``extract_tables`` raising must not fail the read."""
+    class Tripwire:
+        def extract_tables(self):
+            raise RuntimeError("malformed table")
+
+    assert read_deliverable_module._pdf_table_blocks(Tripwire(), 1) == []
+
+
+# ── Word editing marks (task 80) ─────────────────────────────────────
+
+
+_W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+
+_MARKED_BODY = f"""<w:p><w:ins w:id="101" w:author="Editor" w:date="2026-01-01T00:00:00Z">
+<w:r><w:t>an inserted sentence</w:t></w:r></w:ins></w:p>
+<w:p><w:del w:id="102" w:author="Editor" w:date="2026-01-01T00:00:00Z">
+<w:r><w:delText>a removed sentence</w:delText></w:r></w:del></w:p>
+<w:p><w:commentRangeStart w:id="1"/><w:r><w:t>the sentence under review</w:t></w:r>
+<w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>"""
+
+_COMMENTS_XML = f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:comments xmlns:w="{_W}">
+<w:comment w:id="1" w:author="Dana Reviewer" w:date="2026-01-01T00:00:00Z" w:initials="DR">
+<w:p><w:r><w:t>Tighten this claim.</w:t></w:r></w:p></w:comment></w:comments>"""
+
+
+def _marked_up_docx(path: Path) -> Path:
+    """A .docx carrying two tracked edits and one anchored comment.
+
+    python-docx cannot author revision markup, so the package is built with it
+    and then respliced: the marks go into ``word/document.xml`` and the comment
+    into a ``word/comments.xml`` part, exactly where Word puts them. The result
+    stays loadable by python-docx, which is what ``_format_docx`` opens first.
+    """
+    import zipfile
+
+    from docx import Document
+
+    scratch = path.with_suffix(".clean.docx")
+    doc = Document()
+    doc.add_paragraph("an untouched sentence")
+    doc.save(str(scratch))
+
+    with zipfile.ZipFile(scratch) as src:
+        parts = {name: src.read(name) for name in src.namelist()}
+
+    parts["word/document.xml"] = parts["word/document.xml"].replace(
+        b"</w:body>", _MARKED_BODY.encode("utf-8") + b"</w:body>"
+    )
+    parts["word/comments.xml"] = _COMMENTS_XML.encode("utf-8")
+    parts["[Content_Types].xml"] = parts["[Content_Types].xml"].replace(
+        b"</Types>",
+        b'<Override PartName="/word/comments.xml" ContentType="application/vnd'
+        b'.openxmlformats-officedocument.wordprocessingml.comments+xml"/></Types>',
+    )
+    rels = "word/_rels/document.xml.rels"
+    parts[rels] = parts[rels].replace(
+        b"</Relationships>",
+        b'<Relationship Id="rIdComments" Type="http://schemas.openxmlformats.org'
+        b'/officeDocument/2006/relationships/comments" Target="comments.xml"/>'
+        b"</Relationships>",
+    )
+
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as out:
+        for name, blob in parts.items():
+            out.writestr(name, blob)
+    scratch.unlink()
+    return path
+
+
+def test_tracked_insertions_and_deletions_are_counted(base_dir):
+    """"Substantive edits appear as Track Changes insertions" is gradeable.
+
+    Task 5d0feb24 (38.28%) is a copy-editing brief whose rubric asks for
+    exactly this. Before this, the formatting report described a marked-up
+    document as though it were clean, so the item failed whatever the file
+    contained.
+    """
+    _marked_up_docx(base_dir / "edited.docx")
+
+    result = read_deliverable(
+        "inspect_formatting", "edited.docx", base_dir=str(base_dir)
+    )
+
+    assert result["ok"] is True
+    assert result["data"]["tracked_insertion_count"] == 1
+    assert result["data"]["tracked_deletion_count"] == 1
+
+
+def test_a_reviewer_comment_carries_its_author_and_what_it_points_at(base_dir):
+    """The rubric asks for comments "anchored to specific text ranges"."""
+    _marked_up_docx(base_dir / "edited.docx")
+
+    data = read_deliverable(
+        "inspect_formatting", "edited.docx", base_dir=str(base_dir)
+    )["data"]
+
+    assert data["comment_count"] == 1
+    comment = data["comments"][0]
+    assert comment["author"] == "Dana Reviewer"
+    assert comment["text"] == "Tighten this claim."
+    assert comment["anchored_text"] == "the sentence under review"
+
+
+def test_a_clean_document_reports_zero_marks_rather_than_omitting_them(
+    base_dir, docx_file
+):
+    """Zero is an answer. A missing field is not, and reads as "unknown"."""
+    data = read_deliverable(
+        "inspect_formatting", docx_file.name, base_dir=str(base_dir)
+    )["data"]
+
+    assert data["tracked_insertion_count"] == 0
+    assert data["tracked_deletion_count"] == 0
+    assert data["comment_count"] == 0
+    assert data["comments"] == []
+
+
+def test_an_unreadable_package_reports_zero_instead_of_failing_the_report(base_dir):
+    """This enriches a report that is useful without it."""
+    broken = base_dir / "broken.docx"
+    broken.write_bytes(b"not a zip")
+
+    marks = read_deliverable_module._docx_revisions_and_comments(broken)
+
+    assert marks["tracked_insertion_count"] == 0
+    assert marks["comment_count"] == 0
+
+
+def test_the_tool_schema_tells_the_judge_where_the_edit_marks_live(base_dir):
+    """A field the judge is never told about is a field it will not ask for."""
+    description = MODEL_READ_DELIVERABLE_TOOL_SCHEMA["parameters"]["properties"][
+        "op"
+    ]["description"]
+
+    assert "tracked_insertion_count" in description
+    assert "tracked_deletion_count" in description
+    assert "anchored_text" in description
+
+
+# ── A picture in a text page is disclosed, not dropped (task 81) ─────
+
+
+def _pdf_with_text_and_pictures(path: Path, pictures: int = 3) -> Path:
+    """A page that reads as text but keeps some of its content in images."""
+    pytest.importorskip("reportlab")
+    pymupdf = pytest.importorskip("pymupdf")
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(str(path))
+    c.drawString(100, 750, "School Reports")
+    c.drawString(100, 730, "Elementary School   Overall Grade   Percent Proficient")
+    c.drawString(100, 710, "John Lewis Childs School")
+    c.save()
+
+    doc = pymupdf.open(str(path))
+    page = doc.load_page(0)
+    swatch = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 8, 8))
+    swatch.set_rect(swatch.irect, (10, 40, 90))
+    png = swatch.tobytes("png")
+    for i in range(pictures):
+        top = 600 - (i * 40)
+        page.insert_image(pymupdf.Rect(100, top, 260, top + 30), stream=png)
+    staged = path.with_suffix(".staged.pdf")
+    doc.save(str(staged), deflate=True)
+    doc.close()
+    staged.replace(path)
+    return path
+
+
+def test_a_pdf_whose_values_are_pictures_says_so(base_dir):
+    """The read admits the images exist instead of reading as complete.
+
+    This is the real shape of the corpus's worst-scoring task. 94925f49
+    scored 15.85% with 49 of 56 items failed, and its deliverable is a single
+    page carrying 572 characters -- the title, the column headers and the
+    school names -- with every grade, percentage and teacher-student ratio
+    drawn inside 30 embedded images. Nothing in the old result said so, so a
+    judge asking "what grade did this school get" received a confident,
+    complete-looking read with no grade in it and failed the item for a value
+    the document does state.
+
+    The tool already knew the count; it only reported it when the read came
+    back empty, which is the one case this file is not. Saying it turns a
+    silent omission into the disclosed gap the prompt's rule about absence is
+    already written to handle.
+    """
+    _pdf_with_text_and_pictures(base_dir / "reports.pdf", pictures=3)
+
+    result = read_deliverable("read_content", "reports.pdf", base_dir=str(base_dir))
+
+    assert result["ok"] is True
+    data = result["data"]
+    assert "School Reports" in data["text"]
+    assert data["char_count"] > 0
+    note = data.get("note", "")
+    assert "3 embedded image" in note, note
+    assert "not in the text above" in note
+
+
+def test_a_pdf_that_is_all_text_is_not_accused_of_hiding_anything(base_dir):
+    """No images, no note. The disclosure must not fire on every PDF.
+
+    An unconditional warning would teach the judge to discount a complete
+    read, which costs more accuracy than the omission it was added to fix.
+    """
+    _sized_pdf(base_dir / "plain.pdf", [(612, 792)])
+
+    result = read_deliverable("read_content", "plain.pdf", base_dir=str(base_dir))
+
+    assert result["ok"] is True
+    assert "embedded image" not in result["data"].get("note", "")
+
+
+def test_a_scan_still_gets_the_stronger_no_text_layer_report(base_dir):
+    """An empty read keeps its own wording; the two notes do not collide."""
+    pymupdf = pytest.importorskip("pymupdf")
+    path = base_dir / "scan.pdf"
+    doc = pymupdf.open()
+    page = doc.new_page()
+    swatch = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 8, 8))
+    swatch.set_rect(swatch.irect, (200, 200, 200))
+    page.insert_image(page.rect, stream=swatch.tobytes("png"))
+    doc.save(str(path))
+    doc.close()
+
+    data = read_deliverable("read_content", "scan.pdf", base_dir=str(base_dir))["data"]
+
+    assert data["has_text_layer"] is False
+    assert "no text layer" in data["note"]


### PR DESCRIPTION
185개 정답 코퍼스에서 가장 낮은 점수를 받은 산출물들을 **실제로 열어보고** 찾은
문제들입니다. 읽기 도구가 어떻게 동작해야 하는지 추론해서 찾은 것이 아니라,
파일을 열어 측정해서 찾았습니다.

## 1. 읽히는 형제 파일 뒤에 숨은 파일

이전에 넣은 승격 규칙 — 글자가 나오지 않는 항목은 파일을 **보는** 경로로
보낸다 — 은 "선택된 파일 중 **아무거나** 글자가 있는가"를 물었습니다. 한
파일이 글자 하나만 내놓아도 묶음 전체가 "읽힌다"로 접힙니다.

과제 `f9f82549`는 2쪽짜리 사고 처리 순서도를 선택하는데, 1쪽이 전면 이미지 한
장이라 **글자가 0자**입니다. 그런데 읽히는 메모(1,756자)가 같이 선택되어
있어서 묶음은 "여기 글자 있다"고 답했고, 항목은 읽기 경로에 남았으며,
순서도는 **끝내 렌더링되지도 열리지도 않았습니다**.

이제 더 좁은 질문 — "이 중 하나라도 읽히지 않는 파일이 있는가" — 도 함께
묻고, 둘 중 하나만 승격 조건에 걸려도 승격합니다. 파일별 판정 메모를
공유하므로 두 번 물어도 읽기 비용은 늘지 않고, 판정 자체가 불가능한
파일(`None`)은 추측으로 승격시키지 않습니다.

```
Loss Prevention Incident Flowchart.pdf : pages=2  text_chars=0     images=1
Missing Bank Deposits Investigation.pdf: pages=2  text_chars=1756  images=0
```

## 2. 값이 그림인데 읽기는 멀쩡해 보인 PDF

코퍼스 **최저점(15.85%)** 과제 `94925f49`는 학교 성적표 한 쪽입니다.
추출되는 572자는 제목, 열 머리글, 행 이름이 전부이고, **채점 기준이 묻는
모든 성적·백분율·비율은 텍스트 레이어 어디에도 없이 30개의 삽입 이미지 안에
있습니다.**

아무것도 그 사실을 말해주지 않으므로 읽기는 완전해 보였고, 없는 값들은
"문서에 없음"으로 읽혔습니다. 이제 비어 있지 않은 PDF 읽기도 **추출하지 못한
삽입 이미지가 몇 개인지** 함께 알립니다. 조용한 누락이, 판정자 지침이 이미
다루도록 쓰여 있는 "고지된 공백"으로 바뀝니다.

추출이 아니라 고지입니다. 임계값을 추측하지 않고, 정말로 전부 글자인 PDF를
무언가 숨겼다고 몰아붙이지도 않습니다.

```
School Reports.pdf: pages=1  text_chars=572  images=30
```

## 3. 보이지 않던 변경 내용 추적과 검토자 메모

과제 `5d0feb24`(**38.28%**)는 산출물이 담고 있는 **Word 변경 표시**를 기준으로
채점됩니다. 실제 파일에는 **삽입 48개, 삭제 10개**가 들어 있는데, 본문 읽기는
4,218자를 돌려주면서 그중 **단 하나의 흔적도 담지 않습니다**. 즉 읽기로는
채점 대상 자체를 목격할 방법이 없었습니다.

`inspect_formatting`이 이제 삽입·삭제 개수와, 검토자 메모를 그 메모가 붙어
있는 본문 텍스트와 함께 보고합니다(메모 50개, 각 500자 상한). 그리고 판정자
표준 지침에 `.docx`에서는 그것을 물어보라고 적었습니다 — 그 한 줄이 없으면
판정자는 그런 질문이 가능하다는 것을 배울 수가 없습니다.

```
<w:ins>=48  <w:del>=10
read_content         : 4218자, 'track'/'insert'/'delet' 모두 미포함
inspect_formatting   : tracked_insertion_count=48  tracked_deletion_count=10
```

## 4. PDF 표의 행이 서로 떨어진 문단이 되던 문제

괘선 표의 한 행이 이제 한 줄로 도착합니다. 라벨과 값이 몇 줄 떨어진 별개
문단이 되지 않습니다.

**이것은 일반적인 견고성 개선일 뿐입니다.** 이 변경은 `94925f49`의 해법이라고
믿고 작성했으나, 실제 파일로 측정해보니 **그 믿음이 틀렸습니다**: 추출은 행
이름은 되찾지만 값 칸은 비어서 돌아옵니다. 그 성적들이 그림이기 때문입니다.
그 과제를 다루는 것은 위 2번의 고지이고, 이 항목은 자기가 실제로 해내는
것만 주장합니다.

## 5. 판정 비용 상한 재측정

`inspect_formatting`이 변경 내용 추적을 보고할 수 있다고 판정자에게 알려주면서
`prompts/grader_judge_v2.md`가 **6,772자 → 6,866자**가 되었고, 도구 설명이
길어지면서 매 호출이 여는 분량이 **2,825 → 2,857 토큰**, 한 호출이 요구하는
입력이 **536,159 → 536,191**로 움직였습니다. 이 파일은 디스크에서 읽혀 **매
호출마다** 전송되므로, 그 길이는 한 호출이 나를 수 있는 양에 그대로 들어갑니다.

옛 숫자를 고정하고 있던 비용 시험 5개가 실패했고, **완화하지 않고** 새로 측정한
값으로 고쳤습니다. 이 가드가 존재하는 이유는 기록된 상한을 함께 움직이지 않고서는
매 호출이 나르는 양을 아무도 늘릴 수 없게 하는 것이고, 발동할 때 풀어주는 가드는
가드가 아닙니다. 도구 결과 몫 **533,334 토큰은 움직이지 않았고** 그대로 두었습니다.

측정된 실제 문자열:

```
… 8 tool results … each up to 200000 characters … — 533334 tokens — on top of
the 2857 tokens every call opens with, being the 6866 characters of
prompts/grader_judge_v2.md, the 500 characters of the task the judge is shown,
and the 1203 characters of the widest scoring line in the benchmark.
So one call can carry 536191 tokens
```

## 시험

- 전체 백엔드 시험: **5,789 통과, 6 건너뜀, 45 미선택, 실패 0** (752.98초)
- 대상 7개 파일: 539 통과
- 비용 상한 3개 파일: 206 통과
- 새 시험 477줄 추가 (`test_read_deliverable.py` +310, `test_grader_empty_read_routing.py` +89, `test_perception_routing.py` +78)

## 채점기 소스 지문에 관한 주의

이 PR은 채점기 소스 지문을 바꿉니다. main에 남아 있는 9개 샤드 결과물은
`#266`~`#272`가 실행 중에 병합되면서 **이미** 지문이 어긋나 병합 불가 상태이므로,
11개 샤드 전체 재실행은 이 PR과 무관하게 이미 확정된 일입니다. 따라서 이 수정을
먼저 넣는 데 드는 비용은 없습니다.

이 PR이 병합된 뒤에는 재실행이 끝날 때까지 main에 채점기 소스를 바꾸는 변경을
넣으면 안 됩니다. 그러지 않으면 방금 9개 샤드를 못 쓰게 만든 것과 같은 일이
반복됩니다.
