### PR TITLE
feat(grading): 오디오 경로를 1개 태스크로 검증하는 스모크 설정을 추가한다

### DIFF
--- a/batch-runner/grading_configs/gold_smoke_audio_v2_sol_max.yaml
+++ b/batch-runner/grading_configs/gold_smoke_audio_v2_sol_max.yaml
@@ -1,0 +1,128 @@
+schema_version: "2.0"
+config_name: "gold_smoke_audio_v2_sol_max"
+description: |
+  The one-task smoke that proves the audio path before the 185-task full run,
+  spec tasks/rebuilding_grading_task/304-full-gold-corpus.md.
+
+  Runtime semantics are byte-for-byte those of gold_ceiling_185_v2_sol_max --
+  same judge, same reasoning effort, same tool ops and caps, same perception
+  models, same critical rule, same scoring, same prompts, same rate-limit
+  guard. Only the identity differs: the config name and a pinned corpus of
+  one. Anything else would make the smoke predict something other than the run
+  it is meant to de-risk.
+
+  Why a separate config rather than a narrower dispatch: a config that pins
+  `rerun_identity.task_ids` requires --tasks to equal that list exactly and
+  --limit to be 0 or its full length, so neither flag can narrow the 185. The
+  pin is what makes a re-run's identity checkable, and relaxing it to buy a
+  smoke would cost more than the smoke is worth.
+
+  Why this task: its reference bundle carries .mp3, .mp4 and .wav, so it is
+  the cheapest one that exercises the Responses API `input_audio` shape. It
+  sits at corpus position 47, which is also why --limit could never have
+  reached it cheaply -- `--limit n` takes the first n tasks in corpus order.
+
+  The pinned list is a proper subset of the source corpus, so step8_grade.py
+  classes the scope as `subset` and forks the output into
+  _diagnostic/<scope_sha>/. The full run's directory is therefore untouched by
+  whatever this one does, including when it fails.
+rerun_identity:
+  experiment_id: "exp_gold_baseline"
+  expected_task_count: 1
+  # The dataset commit the rubric is read from. The same commit stages 1 and 2
+  # were frozen to, so the two measurements are of the same corpus.
+  rubric_commit_sha: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  # The same commit, because for a gold corpus the dataset IS the inference:
+  # no model ran, so the revision that supplied the answers is the revision
+  # that supplied the rubric.
+  inference_revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  # Deliberately absent: allow_legacy_missing_provenance. That switch forgives
+  # a submission whose Azure routes were never recorded. Here no inference ran,
+  # so there is no route that could be missing -- the payload says `gold-corpus`
+  # outright, and step8_grade.py keeps every such run out of the published path
+  # on that basis alone.
+  task_ids:
+    - "75401f7c-396d-406d-b08e-938874ad1045"
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.6-sol"
+  deployment: "gpt-5.6-sol"
+  api_version: "2025-04-01-preview"
+  timeout_sec: 600
+  reasoning:
+    effort: "max"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+    finalization_reasoning_effort: "max"
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.6-sol"
+      deployment: "gpt-5.6-sol"
+      reasoning_effort: "max"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      deployment: "gpt-audio-1.5"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v2"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"

--- a/batch-runner/tests/test_the_smoke_predicts_the_run_it_de_risks.py
+++ b/batch-runner/tests/test_the_smoke_predicts_the_run_it_de_risks.py
@@ -1,0 +1,236 @@
+"""A smoke is only evidence about the run it is standing in for.
+
+``gold_smoke_audio_v2_sol_max`` exists to spend one task's worth of Sol Max
+proving that the audio path works before ``gold_ceiling_185_v2_sol_max``
+spends a hundred and eighty five tasks' worth assuming it does. That argument
+holds exactly as long as the two configs agree on every runtime setting, so
+the first test here asserts that agreement rather than trusting the copy that
+produced it.
+
+The separate config is not a workaround. A config that pins
+``rerun_identity.task_ids`` requires ``--tasks`` to equal that list and
+``--limit`` to be zero or its full length -- the pin is what makes a re-run's
+identity checkable, so neither flag can narrow it, and relaxing that to buy a
+smoke would cost more than the smoke is worth. Pinning a smaller corpus in a
+config of its own asks the question without touching the guard.
+
+Nothing here calls a model or a network.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from step8_grade import (  # noqa: E402
+    compute_grader_source_hash,
+    filter_tasks_for_config,
+)
+
+BATCH_ROOT = Path(__file__).resolve().parents[1]
+CONFIGS = BATCH_ROOT / "grading_configs"
+
+FULL = CONFIGS / "gold_ceiling_185_v2_sol_max.yaml"
+SMOKE = CONFIGS / "gold_smoke_audio_v2_sol_max.yaml"
+
+# Reference bundle carries .mp3, .mp4 and .wav, so it is the cheapest task
+# that exercises the Responses API `input_audio` shape.
+AUDIO_TASK = "75401f7c-396d-406d-b08e-938874ad1045"
+
+# Everything that decides what a grading call costs and returns. Identity
+# fields are deliberately absent: those are the two configs' only licensed
+# difference.
+RUNTIME_KEYS = (
+    "schema_version",
+    "judge",
+    "rubric",
+    "grader",
+    "tpm_guard",
+    "prompt",
+    "output",
+)
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def full() -> dict:
+    return _load(FULL)
+
+
+@pytest.fixture(scope="module")
+def smoke() -> dict:
+    return _load(SMOKE)
+
+
+# ── the smoke has to be the same run, only smaller ───────────────────────
+
+
+@pytest.mark.parametrize("key", RUNTIME_KEYS)
+def test_the_smoke_and_the_full_run_share_every_runtime_setting(full, smoke, key):
+    """The whole basis for treating one as evidence about the other.
+
+    Checked per key so a failure names the block that drifted instead of
+    dumping both configs. A cheaper judge or a laxer rate-limit guard here
+    would still produce a green smoke -- and would prove nothing about the
+    run that follows it.
+    """
+    assert smoke[key] == full[key], (
+        f"{key} differs between the smoke and the full run; the smoke no "
+        f"longer predicts what the full run will do"
+    )
+
+
+def test_the_two_configs_differ_only_in_identity(full, smoke):
+    """Guards the keys ``RUNTIME_KEYS`` does not enumerate.
+
+    Without this, a runtime setting added to both files later would sit
+    outside the parametrised comparison and drift unnoticed.
+    """
+    assert sorted(smoke) == sorted(full)
+    differing = {key for key in full if full[key] != smoke[key]}
+    assert differing == {"config_name", "description", "rerun_identity"}, (
+        f"unexpected difference in {differing - {'config_name', 'description', 'rerun_identity'}}"
+    )
+
+
+# ── and it has to be the task the smoke was built for ────────────────────
+
+
+def test_the_smoke_grades_exactly_one_task(smoke):
+    identity = smoke["rerun_identity"]
+    assert identity["task_ids"] == [AUDIO_TASK]
+    assert identity["expected_task_count"] == 1, (
+        "expected_task_count is checked against the graded count at runtime; "
+        "a stale 185 here fails the run after it has already been paid for"
+    )
+
+
+def test_the_smoke_task_is_one_the_full_run_will_also_grade(full, smoke):
+    """Otherwise the smoke exercises a task the full run never reaches.
+
+    A proper subset, not merely an overlap: equality would mean the two
+    configs pin the same corpus and the smoke is not a smoke.
+    """
+    smoke_ids = set(smoke["rerun_identity"]["task_ids"])
+    full_ids = set(full["rerun_identity"]["task_ids"])
+    assert smoke_ids < full_ids
+
+
+def test_the_smoke_reads_the_same_corpus_revision(full, smoke):
+    """A different revision would grade a different version of the answer."""
+    for field in ("experiment_id", "rubric_commit_sha", "inference_revision"):
+        assert smoke["rerun_identity"][field] == full["rerun_identity"][field]
+
+
+def test_the_full_run_still_pins_the_whole_gold_corpus(full):
+    """Anchors the subset test above.
+
+    If the full run's pin were ever trimmed, the subset assertion could pass
+    while both configs graded a handful of tasks.
+    """
+    identity = full["rerun_identity"]
+    assert identity["expected_task_count"] == 185
+    assert len(identity["task_ids"]) == 185
+
+
+# ── the smoke must not be able to damage the full run ────────────────────
+
+
+def _inference_results(task_ids: list[str]) -> dict:
+    return {"results": [{"task_id": task_id} for task_id in task_ids]}
+
+
+def test_the_smoke_forks_its_output_away_from_the_full_run(full, smoke):
+    """``subset`` is what puts a run under ``_diagnostic/<scope_sha>/``.
+
+    The full run's pin covers its whole source corpus, so it classes as
+    ``complete`` and stays on the published path. The smoke pins one task out
+    of the same corpus, so it classes as ``subset`` and forks. That is the
+    only reason a failed smoke cannot land in, or overwrite, the directory the
+    eleven shards merge from.
+    """
+    corpus = _inference_results(full["rerun_identity"]["task_ids"])
+
+    full_tasks, full_scope = filter_tasks_for_config(
+        corpus, full, tasks_csv=None, limit=0
+    )
+    smoke_tasks, smoke_scope = filter_tasks_for_config(
+        corpus, smoke, tasks_csv=None, limit=0
+    )
+
+    assert full_scope == "complete"
+    assert len(full_tasks) == 185
+    assert smoke_scope == "subset", (
+        "a smoke that did not class as a subset would write into the full "
+        "run's output directory"
+    )
+    assert [task["task_id"] for task in smoke_tasks] == [AUDIO_TASK]
+
+
+def test_naming_the_smoke_task_on_the_command_line_agrees_with_the_pin(smoke, full):
+    """``--tasks`` is redundant here, and redundant is the point.
+
+    Passing it makes the dispatch assert what the config already pins, so a
+    config edited to point somewhere else is a refusal at classification time
+    rather than a surprise in the graded output.
+    """
+    corpus = _inference_results(full["rerun_identity"]["task_ids"])
+    tasks, scope = filter_tasks_for_config(
+        corpus, smoke, tasks_csv=AUDIO_TASK, limit=0
+    )
+    assert scope == "subset"
+    assert [task["task_id"] for task in tasks] == [AUDIO_TASK]
+
+
+def test_naming_a_different_task_than_the_pin_is_refused(smoke, full):
+    """The guard that made this config necessary, exercised from the inside."""
+    corpus = _inference_results(full["rerun_identity"]["task_ids"])
+    other = full["rerun_identity"]["task_ids"][0]
+    assert other != AUDIO_TASK
+
+    with pytest.raises(ValueError, match="conflicts with config pinned task selection"):
+        filter_tasks_for_config(corpus, smoke, tasks_csv=other, limit=0)
+
+
+def test_adding_a_grading_config_cannot_move_the_full_runs_fingerprint(tmp_path, full):
+    """Why this file could be added while eleven shards were being planned.
+
+    ``compute_grader_source_hash`` takes the one config it was handed, not the
+    directory it lives in -- so a new sibling config is invisible to it. If
+    that ever stopped being true, every existing shard would stop merging the
+    moment anyone added a config, and this test would say so.
+    """
+    before = compute_grader_source_hash(FULL, full)
+
+    intruder = CONFIGS / "zz_fingerprint_probe.yaml"
+    assert not intruder.exists()
+    intruder.write_text("config_name: 'probe'\n", encoding="utf-8")
+    try:
+        after = compute_grader_source_hash(FULL, full)
+    finally:
+        intruder.unlink()
+
+    assert before == after, (
+        "the grader source hash moved because an unrelated config file "
+        "existed; shards graded before it was added can no longer merge"
+    )
+
+
+def test_the_smoke_and_the_full_run_do_not_share_a_fingerprint(full, smoke):
+    """They are different runs and must be stored as such.
+
+    The config file is itself hashed, so this holds automatically -- the test
+    is here because the consequence of it not holding is that a one-task smoke
+    would look like a resumable partial of the full run.
+    """
+    assert compute_grader_source_hash(SMOKE, smoke) != compute_grader_source_hash(
+        FULL, full
+    )


### PR DESCRIPTION
## 왜 필요한가

185개 전체 유료 실행 전에 오디오 경로가 실제로 동작하는지 확인해야 한다. 그런데 `gold_ceiling_185_v2_sol_max`처럼 `rerun_identity.task_ids`를 고정한 설정은 코퍼스를 좁힐 수 없다 — `filter_tasks_for_config`가 `--tasks`는 고정 목록과 정확히 같기를, `--limit`은 0이거나 목록 전체 길이이기를 요구한다.

실제로 무료 dry run `33260597416`이 이걸 그대로 뱉었다:

```
ERROR: invalid grading task selection: CLI --tasks conflicts with config pinned task selection
```

고정 자체가 재실행의 정체성을 검증 가능하게 만드는 장치이므로, 스모크 하나 얻자고 그 가드를 완화하는 건 스모크 값어치보다 비싸다. 더 작은 코퍼스를 고정한 별도 설정으로 같은 질문을 던지는 쪽이 맞다.

## 무엇을 추가했는가

`grading_configs/gold_smoke_audio_v2_sol_max.yaml` — 런타임 의미는 `gold_ceiling_185_v2_sol_max`와 바이트 단위로 동일하고, `config_name`·`description`·`rerun_identity` 두 필드만 다르다.

대상은 `75401f7c-396d-406d-b08e-938874ad1045`. 참조 번들에 `.mp3`, `.mp4`, `.wav`를 함께 담고 있어 Responses API `input_audio` 형태를 건드리는 가장 싼 태스크이고, 고정된 185개 목록의 47번째다. 47번째라는 게 `--limit`으로는 애초에 싸게 도달할 수 없었던 이유이기도 하다 (`--limit n`은 코퍼스 순서 앞에서 n개를 자른다).

## 안전 성질 두 가지

**전체 실행 디렉터리를 건드릴 수 없다.** 고정 목록이 원본 코퍼스의 진부분집합이라 `filter_tasks_for_config`가 scope를 `subset`으로 분류하고, 출력이 `_diagnostic/<scope_sha>/`로 갈라진다. 이 스모크가 실패해도 11개 샤드가 병합될 경로는 그대로다.

**전체 실행 지문을 움직이지 않는다.** `compute_grader_source_hash`는 넘겨받은 설정 파일 하나만 읽고 `grading_configs/`를 훑지 않는다. 확인:

| config | grader source hash |
|---|---|
| `gold_ceiling_185_v2_sol_max.yaml` | `16baa5a0213b716e` (변화 없음) |
| `gold_smoke_audio_v2_sol_max.yaml` | `f1bfded1913b1b20` |

이 성질이 깨지면 설정 파일을 추가하는 순간 기존 샤드가 병합되지 않으므로, 임시 설정 파일을 만들었다 지우면서 해시가 그대로인지 확인하는 테스트로 고정했다.

## 테스트

`tests/test_the_smoke_predicts_the_run_it_de_risks.py` 17개. 모델 호출·네트워크 없음.

핵심은 두 설정의 런타임 블록 동일성을 블록별로 강제하는 것이다. 스모크가 뒤따르는 실행의 근거가 되는 유일한 이유가 그 동일성이라, 더 싼 판정 모델이나 느슨한 레이트리밋 가드로 초록불이 떠도 아무것도 증명하지 못한다. `RUNTIME_KEYS`가 열거하지 않는 키가 나중에 추가될 경우를 대비해, 두 설정의 차이가 정확히 `{config_name, description, rerun_identity}`인지도 따로 본다.

### 네거티브 컨트롤

| 재주입한 결함 | 실패한 테스트 |
|---|---|
| 스모크가 판정 모델을 몰래 `gpt-5-mini`로 낮춤 | `..._share_every_runtime_setting[judge]`, `..._differ_only_in_identity` |
| 스모크가 오디오 없는 태스크를 고정 | `..._grades_exactly_one_task` 외 3개 |
| 스모크가 185개 전체를 고정 (더는 스모크가 아님) | `..._task_is_one_the_full_run_will_also_grade`, `..._forks_its_output_away_from_the_full_run` 외 3개 |

각 컨트롤은 의도한 테스트만 떨어뜨렸고, 복원 후 설정 파일은 바이트 단위로 동일하며 17/17 다시 통과한다.