### PR TITLE
fix(grading): a video container is not proof of silence

### DIFF
--- a/batch-runner/core/tools/read_deliverable.py
+++ b/batch-runner/core/tools/read_deliverable.py
@@ -1249,11 +1249,12 @@ def has_audio_content(path: Union[str, Path]) -> Optional[bool]:
     -- tempo, key, vocals, mix -- was graded end to end without a single
     listening call.
 
-    ``True`` for an audio file or an archive holding one. ``False`` is a
-    positive claim and means the file was examined and carries no audio.
-    ``None`` is an admission -- missing file, unreadable archive, or a member
-    list that was cut short and may have stopped one entry before the audio --
-    so that routing never promotes on a guess.
+    ``True`` for an audio file, an archive holding one, or a video whose
+    container carries an audio track. ``False`` is a positive claim and means
+    the file was examined and carries no audio. ``None`` is an admission --
+    missing file, unreadable archive, absent decoder, or a member list that was
+    cut short and may have stopped one entry before the audio -- so that
+    routing never promotes on a guess.
     """
     p = Path(path)
     if not p.is_file():
@@ -1261,6 +1262,18 @@ def has_audio_content(path: Union[str, Path]) -> Optional[bool]:
     kind = _kind_of(p)
     if kind == "audio":
         return True
+    if kind == "video":
+        # The same mistake as the ``.zip`` above, one container along. A reel
+        # is delivered as ``.mp4``; ``.mp4`` is disjoint from the audio
+        # extensions; so "the sound effect is audible during the opening
+        # shot" was demoted to TEXT and answered by a judge that had read the
+        # file's metadata and could not hear it. It scored zero -- not
+        # excluded, *failed* -- on evidence reading ``"audio_tracks": 1``.
+        #
+        # That count is the honest answer to this question and was already
+        # being computed one call away.
+        count = _video_audio_track_count(p)
+        return None if count is None else count > 0
     if kind != "zip":
         return False
     try:
@@ -2096,6 +2109,30 @@ def _op_probe_audio(p: Path, _scope: Dict[str, Any]) -> Dict[str, Any]:
     info = _probe_audio_impl(p, basic=False)
     info["kind"] = "audio"
     return info
+
+
+def _video_audio_track_count(p: Path) -> Optional[int]:
+    """How many audio streams a video container carries, or ``None``.
+
+    Deliberately not routed through ``_probe_video_impl``: that helper returns
+    early when a container has no *video* stream, which would report ``None``
+    for a file that is nothing but sound. Counting the audio streams directly
+    answers the question that was asked.
+    """
+    try:
+        import av  # type: ignore
+    except ImportError:
+        return None
+    try:
+        container = av.open(str(p))
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        return len(container.streams.audio)
+    except Exception:  # noqa: BLE001
+        return None
+    finally:
+        container.close()
 
 
 def _probe_video_impl(p: Path, basic: bool = False) -> Dict[str, Any]:

--- a/batch-runner/tests/test_a_reel_with_a_soundtrack_gets_listened_to.py
+++ b/batch-runner/tests/test_a_reel_with_a_soundtrack_gets_listened_to.py
@@ -1,0 +1,216 @@
+"""A criterion about sound must not be answered by a judge that cannot hear.
+
+``resolve_runtime_routing`` demotes an AUDIO criterion to TEXT when the files
+it is pointed at carry no audio, and that rule is right: "the mix is balanced"
+has no meaning against a spreadsheet, and sending it to a listening model
+would cost money to learn nothing. The rule reads the file extension, with a
+measured probe -- ``has_audio_content`` -- allowed to overrule it.
+
+The probe answered ``False`` for every video container. ``False`` is not "I
+don't know"; it is a positive claim that the file was examined and holds no
+audio. So a reel delivered as ``.mp4`` was declared silent, every listening
+criterion on it was demoted, and a judge holding nothing but the file's
+metadata scored them. On gold task ``75401f7c`` that produced eleven items of
+the form "the sound effect is audible during the opening shot", each marked
+**fail, 0 of 2**, on evidence reading ``"audio_tracks": 1`` -- the container's
+own count of the audio it was said not to have.
+
+The distinction that matters is between ``False`` and ``None``. A failed or
+impossible perception must not become a deliverable-quality failure: where the
+grader cannot look, it excludes the item rather than scoring it zero. Demotion
+to TEXT is not exclusion -- it is scoring by another route -- so a probe that
+guesses ``False`` converts "we did not listen" into "the work is bad". That is
+why the no-decoder and unreadable cases below assert ``None``.
+
+These tests encode real MP4 files with PyAV, which is pinned in
+``requirements.txt`` and used by the video probe itself. Nothing here calls a
+model or a network.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.grader_routing import (  # noqa: E402
+    Modality,
+    classify_criterion,
+    resolve_runtime_routing,
+)
+from core.tools.read_deliverable import (  # noqa: E402
+    _video_audio_track_count,
+    has_audio_content,
+)
+
+av = pytest.importorskip("av", reason="PyAV is what the video probe uses")
+np = pytest.importorskip("numpy")
+
+
+# Criteria copied verbatim from the graded output of gold task 75401f7c,
+# where each one was scored fail 0/2 without a single listening call.
+CRITERIA_THAT_WERE_SCORED_DEAF = (
+    'The sound effect file "Mountain Audio - Electricity.mp3" is audible '
+    "during the opening logos.mp4 shot.",
+    "A music track is present in the mix (separate from SFX and any allowed "
+    "embedded audio).",
+    "The music track exhibits a high-energy rock or electronic style "
+    "consistent with the prompt's intent.",
+)
+
+
+def _encode_mp4(path: Path, *, audio: bool, video: bool = True) -> Path:
+    """Write a genuine, tiny MP4 -- roughly 2 KB and a few milliseconds.
+
+    Every stream is declared before anything is muxed: adding one after the
+    first packet is written raises ``Cannot rebase to zero time``.
+    """
+    container = av.open(str(path), mode="w")
+    try:
+        video_stream = None
+        if video:
+            video_stream = container.add_stream("mpeg4", rate=5)
+            video_stream.width = video_stream.height = 32
+            video_stream.pix_fmt = "yuv420p"
+        audio_stream = container.add_stream("aac", rate=44100) if audio else None
+
+        if video_stream is not None:
+            for _ in range(3):
+                container.mux(video_stream.encode(av.VideoFrame(32, 32, "yuv420p")))
+            for packet in video_stream.encode(None):
+                container.mux(packet)
+        if audio_stream is not None:
+            frame = av.AudioFrame.from_ndarray(
+                np.zeros((1, 1024), dtype="int16"), format="s16", layout="mono"
+            )
+            frame.sample_rate = 44100
+            for packet in audio_stream.encode(frame):
+                container.mux(packet)
+            for packet in audio_stream.encode(None):
+                container.mux(packet)
+    finally:
+        container.close()
+    return path
+
+
+@pytest.fixture(scope="module")
+def reel(tmp_path_factory) -> Path:
+    """A video that has a soundtrack, like the deliverable that failed."""
+    return _encode_mp4(tmp_path_factory.mktemp("av") / "reel.mp4", audio=True)
+
+
+@pytest.fixture(scope="module")
+def silent_reel(tmp_path_factory) -> Path:
+    return _encode_mp4(tmp_path_factory.mktemp("av") / "silent.mp4", audio=False)
+
+
+# ── what the probe now says about a container ────────────────────────────
+
+
+def test_a_video_with_a_soundtrack_reports_audio(reel):
+    """The whole defect in one assertion."""
+    assert has_audio_content(reel) is True
+
+
+def test_a_genuinely_silent_video_still_reports_no_audio(silent_reel):
+    """The demotion rule is correct and must survive the fix.
+
+    Over-correcting to "every video might have sound" would send listening
+    calls at silent renders and pay for them.
+    """
+    assert has_audio_content(silent_reel) is False
+
+
+def test_a_video_that_is_only_sound_reports_audio(tmp_path):
+    """Why the probe counts audio streams rather than reusing the video probe.
+
+    ``_probe_video_impl`` returns early when a container holds no video
+    stream, so borrowing it would report ``None`` for a file that is nothing
+    but audio.
+    """
+    only_sound = _encode_mp4(tmp_path / "score.mp4", audio=True, video=False)
+    assert has_audio_content(only_sound) is True
+
+
+def test_an_unreadable_video_admits_it_does_not_know(tmp_path):
+    """``None``, never ``False`` -- see the module docstring."""
+    corrupt = tmp_path / "truncated.mp4"
+    corrupt.write_bytes(b"not a video at all")
+    assert has_audio_content(corrupt) is None
+
+
+def test_a_missing_decoder_is_an_admission_not_a_denial(reel, monkeypatch):
+    """A machine without PyAV must not silently mark every reel silent.
+
+    ``False`` here would reintroduce the defect on exactly the hosts least
+    able to notice it.
+    """
+    real_import = __import__
+
+    def no_av(name, *args, **kwargs):
+        if name == "av":
+            raise ImportError("no PyAV here")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", no_av)
+    assert _video_audio_track_count(reel) is None
+    assert has_audio_content(reel) is None
+
+
+# ── and what routing does with that answer ───────────────────────────────
+
+
+@pytest.mark.parametrize("criterion", CRITERIA_THAT_WERE_SCORED_DEAF)
+def test_a_listening_criterion_on_a_reel_is_not_demoted_to_text(reel, criterion):
+    """End to end, on the real criteria that were scored deaf.
+
+    Classification was never the problem -- the criterion routes AUDIO on its
+    text alone. It was the target-aware pass that overruled it.
+    """
+    assert classify_criterion(criterion).modality is Modality.AUDIO
+
+    decision = resolve_runtime_routing(
+        criterion,
+        [reel.name],
+        selected_paths_have_audio=has_audio_content(reel),
+    )
+    assert decision.modality is Modality.AUDIO, (
+        "a criterion about sound was routed away from the listening model "
+        "and will be scored by a judge that cannot hear it"
+    )
+
+
+@pytest.mark.parametrize("criterion", CRITERIA_THAT_WERE_SCORED_DEAF)
+def test_a_listening_criterion_on_a_silent_reel_is_still_demoted(
+    silent_reel, criterion
+):
+    """The saving that justifies the rule, preserved."""
+    decision = resolve_runtime_routing(
+        criterion,
+        [silent_reel.name],
+        selected_paths_have_audio=has_audio_content(silent_reel),
+    )
+    assert decision.modality is Modality.TEXT
+
+
+def test_a_mix_criterion_against_a_spreadsheet_is_still_demoted(tmp_path):
+    """Non-regression on the case the rule was written for."""
+    sheet = tmp_path / "budget.xlsx"
+    sheet.write_bytes(b"\x00" * 32)
+    decision = resolve_runtime_routing(
+        "A music track is present in the mix.",
+        [sheet.name],
+        selected_paths_have_audio=has_audio_content(sheet),
+    )
+    assert has_audio_content(sheet) is False
+    assert decision.modality is Modality.TEXT
+
+
+def test_an_audio_file_is_unchanged(tmp_path):
+    """Non-regression: the plain case the probe always got right."""
+    track = tmp_path / "sfx.mp3"
+    track.write_bytes(b"\x00" * 32)
+    assert has_audio_content(track) is True


### PR DESCRIPTION
## What the smoke found

The paid audio smoke (run `33262668933`, gold task `75401f7c`) passed — and that is how it did its job. It came back with `perception_call_count: 0` on a `.mp4` deliverable and a score of **26.79%**.

Eleven criteria of the form *"the sound effect file `Mountain Audio - Electricity.mp3` is audible during the opening logos.mp4 shot"* were marked **fail, 0 of 2**. The evidence string each one cites is `"audio_tracks": 1` — the container's own count of the audio it was being told it did not have.

## Root cause

`has_audio_content` returned `False` for every video container:

```python
if kind == "audio":
    return True
if kind != "zip":      # <- .mp4 is kind "video"
    return False
```

`False` is not "unknown". It is a positive claim that the file was examined and carries no audio, and `resolve_runtime_routing` uses it to demote an AUDIO criterion to TEXT. `.mp4` is disjoint from `GRADER_AUDIO_EXTENSIONS` (`.aac .flac .m4a .mp3 .ogg .wav`), so the extension test and the probe agreed on the wrong answer.

This is the `.zip`-of-stems bug one container along, and the existing docstring already had the reasoning — *the container extension is a fact about packaging, not about the medium*. Video was simply never given the archive's treatment.

## Why `None` and not `False` on failure

Demotion is **not** exclusion. An excluded item leaves the denominator; a demoted one gets scored by a judge that cannot hear. So a probe that guesses `False` converts *"we did not listen"* into *"the work is bad"* — which is the contract the grader is supposed to hold. Missing decoder and unreadable container both answer `None`.

For contrast, the same task's three **visual** criteria behaved correctly: `required_visual_render_target_unavailable`, `score_excluded: true`, out of the denominator.

## Blast radius

**21 items over 2 tasks**, both Film and Video Editors. Re-measured against the Stage 3 corpus after #291 landed:

| task | recorded | items demoted | points not awarded |
|---|---|---|---|
| `75401f7c` | 26.34% | 14 | 18.0 / 56 |
| `e222075d` | 16.17% | 7 | 10.3 / 60 |

Small in aggregate, severe per task: crediting every demoted item in full moves the 174-task mean 80.19% → 80.48%, but those two tasks' recorded percentages are floors rather than measurements.

The one place it is *not* small is the sector table. Both tasks are Information, which #291 otherwise ranks last at 71.19%; without them it is **81.18%** and mid-table. That line was a fact about the grader on its way to being read as a fact about the sector.

*(An earlier revision of this section said 28.6 points. That total came from the superseded `src_ce7d4978bce9effc` grade files, where `e222075d` lost 10.6. Against the run Stage 3 actually closed on it is 28.3. The same two tasks, either way.)*

Criteria demoted against `.pdf` / `.xlsx` / `.docx` are the rule working as designed and are untouched.

## Tests

`tests/test_a_reel_with_a_soundtrack_gets_listened_to.py` — 13 tests, encoding real MP4s with PyAV (already pinned in `requirements.txt`), asserting on the three criterion strings copied verbatim from the smoke's graded output.

Covered: video with a soundtrack → `True`; genuinely silent video → `False` (the saving is preserved); audio-only `.mp4` → `True`; corrupt container → `None`; missing PyAV → `None`; end-to-end routing on the real criteria; non-regression on `.xlsx`, `.mp3`.

**Negative control:** reverting the branch fails 7 of 13, including all three end-to-end routing assertions.

## The fingerprint move, and why it is now expected

`core/tools/read_deliverable.py` is covered by the grader source hash, so this change moves the gold fingerprint. Recomputed on the rebased branch:

| | |
|---|---|
| gold_ceiling_185_v2_sol_max | `955be41edc4aff19` → `450aee03cf6cb840` |
| gold_smoke_audio_v2_sol_max | `e23d7898c04f6b63` → `25d79158aa1fa3b2` |

The original hold — eleven shards in flight at `955be41edc4aff19` — is discharged. Those shards landed, four paid attempts failed to finish the twelfth task, and #291 closed Stage 3 at **174/185, blocked rather than final**. The 174 and their eleven cost ledgers are frozen and preserved; nothing here rewrites them, and `stage3_partial_inventory.py` pins the old hash as a constant rather than recomputing it, so this merge cannot disturb that evidence.

So the fingerprint moving is no longer a cost — Stage 3 already needs a re-run at a new hash and a new run ordinal for reasons unrelated to this fix. `305-resume-granularity.md` recommends bundling further grader changes with exactly this kind of move, where their marginal cost is zero.

**Old and new results must never be mixed.** The 174 were measured at `955be41edc4aff19`; anything graded after this merge is a different measurement.

## Rebase and re-audit

Rebased from a 24-commit-stale base onto `bc806de`; the diff is unchanged (2 files, +258/−5) and both hash figures above re-verify at the new base.

Negative control re-run after the rebase: surgically excising only the `if kind == "video":` branch — 692 bytes, leaving the helper in place — fails **7 of 13**, including all three end-to-end routing assertions on criteria copied from the graded output. Restoring it passes 13 of 13.

**No paid re-grade follows this merge.** The 2-task audio smoke at the new fingerprint is prepared separately and is the owner's call to dispatch.