### PR TITLE
fix(grading): 청크 예산을 플랫폼이 허용하는 최대치까지 올림

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -681,19 +681,33 @@ jobs:
       LANG: C.UTF-8
       PIP_CACHE_DIR: /root/.cache/pip
     # GH Actions hosted runners have a HARD 6h (360min) timeout that cannot be
-    # extended. We set 350min so step8_grade.py's internal 5h time guard (env
-    # GRADER_TIME_BUDGET_SEC=18000) trips first, partial-saves, and exits 7,
-    # leaving 50min of headroom.
+    # extended. Everything below is that 360 divided up, so that step8_grade.py's
+    # own guard (env GRADER_TIME_BUDGET_SEC) always trips first, partial-saves,
+    # and exits 7 -- rather than the runner killing the job having paid for
+    # everything and saved nothing.
     #
-    # That headroom is sized by the p90 task, not by the commit steps. The
-    # budget is a pre-check, so a chunk may enter its last task one second
-    # under budget and then run for that task's whole duration; if the gap is
-    # narrower than a task, the job is killed mid-judgement having paid for
-    # everything and saved nothing. 50min clears the measured p90 of 32.7min
-    # and still leaves more than the ~16min a real shard spends outside
-    # grading. test_a_chunk_can_always_save_before_the_runner_kills_it reads
-    # both numbers straight out of this file and fails if that stops holding.
-    timeout-minutes: 350
+    #   360   platform hard kill, not extendable
+    #   -5    reserved, because the platform measures from job start and we do
+    #         not control the handoff before our first step runs
+    #   ---
+    #   355   timeout-minutes, below
+    #   -4.2  setup: checkout, pip install, HF download. Measured on run
+    #         33286656393: job opened 01:53:41Z, grading opened 01:57:55Z.
+    #   -12   the guard is a between-units check, so a chunk can be up to one
+    #         rubric item past its budget before it can stop. Longest item
+    #         measured, same run: 12.0min (task 9e39df84 items 36 -> 37,
+    #         04:24:48Z -> 04:36:48Z).
+    #   -2    partial save, commit, auto-retrigger after the guard fires
+    #   ---
+    #   336   GRADER_TIME_BUDGET_SEC = 20160, below
+    #
+    # The 12 used to be 32.7 -- the p90 *task*, not item -- because the guard
+    # used to be checked only between tasks. #77 and #279 moved it inside a
+    # task (core/grader.py::_check_should_stop, called between rubric items and
+    # between split children), which is what lets the budget be this close to
+    # the wall. test_a_chunk_can_always_save_before_the_runner_kills_it reads
+    # these numbers straight out of this file and fails if that stops holding.
+    timeout-minutes: 355
 
     steps:
 
@@ -1014,7 +1028,11 @@ jobs:
           # would refingerprint the grader and orphan the ten shards already
           # on main. This file is not in that hash, so the wall clock is the
           # one dial that can be turned without invalidating a paid run.
-          GRADER_TIME_BUDGET_SEC: "18000"
+          #
+          # 20160 = 336min, derived from the platform's 360 in the
+          # timeout-minutes comment above. It is the largest budget that can
+          # still stop and save, not a figure anybody chose for a task.
+          GRADER_TIME_BUDGET_SEC: "20160"
         run: |
           cd batch-runner
           ARGS=(

--- a/batch-runner/tests/test_a_task_longer_than_a_chunk_can_never_be_graded.py
+++ b/batch-runner/tests/test_a_task_longer_than_a_chunk_can_never_be_graded.py
@@ -15,13 +15,22 @@ followed accounted for 4h18m of the 4h21m. The chunk exited 5, not 7 --
 a chunk that finished no task declines to buy another one on identical terms.
 That refusal is correct and is not what this file changes.
 
-What had to change was the wall clock, and the reason it *could* change is the
-subject of the first test: ``compute_grader_source_hash`` covers
-``batch-runner`` and the grading config, and ``.github/workflows`` is in
-neither. The per-item token cap lives in the grading config, so raising *that*
-would have refingerprinted the grader and orphaned the ten shards already paid
-for and committed. The workflow's timing dials are the only ones that can move
-without invalidating a run in progress.
+The 5h budget that answer bought was not enough either. On the second attempt
+the same task ran 5h10m and stopped three items short of finishing, so the
+budget moved a second time -- this time to the largest figure the platform
+leaves room for, which is not a figure chosen to fit the task. Whether it fits
+is recorded below as a projection with its arithmetic shown, not asserted:
+the two attempts bracket the answer rather than settling it, and a test that
+claimed otherwise would be claiming to know something nobody has measured.
+
+What could change at all is the subject of the first test:
+``compute_grader_source_hash`` covers ``batch-runner`` and the grading config,
+and ``.github/workflows`` is in neither. The per-item token cap lives in the
+grading config, so raising *that* would have refingerprinted the grader and
+orphaned the ten shards already paid for and committed. The workflow's timing
+dials are the only ones that can move without invalidating a run in progress,
+and ``GRADER_TIME_BUDGET_SEC`` is the only cost-shaped environment variable
+the grading code reads at all.
 
 Nothing here calls a model or a network.
 """
@@ -39,11 +48,21 @@ BATCH_ROOT = Path(s8.__file__).resolve().parent
 REPO_ROOT = BATCH_ROOT.parent
 WORKFLOW = REPO_ROOT / ".github/workflows/grade-run.yml"
 
-#: What task ``9e39df84`` spent in one chunk without finishing, measured from
-#: the timestamps of run ``33273207562``: grading opened at 20:35:14Z and the
-#: deadline fired at 00:56:34Z. A budget at or under this figure reproduces the
-#: stall exactly, because the task restarts from nothing each time.
-OBSERVED_LONGEST_TASK_MINUTES = 261
+#: The longest a single task has been watched to run without finishing.
+#: Attempt one, run ``33273207562`` on a 240 min budget: grading opened
+#: 20:35:14Z, the guard fired 00:56:34Z, 261.3 min, reached item 46 of 57.
+#: Attempt two, run ``33286656393`` on a 300 min budget: grading opened
+#: 01:57:55Z, the guard fired 07:08:20Z, 310.4 min, reached item 54 of 57.
+#: A budget at or under this figure is known to buy nothing, because an
+#: abandoned task leaves no partial behind and restarts from item 1.
+OBSERVED_LONGEST_TASK_MINUTES = 310
+
+#: What the three unreached items are expected to cost, from the rate the same
+#: run was measuring as it ran out of time. Items 34 -> 41 took 83.2 min
+#: (11.9 a piece); items 41 -> 54 took 103.9 min (8.0 a piece). Three more at
+#: either rate is 24 to 36 min on top of the 310.4 already watched.
+PROJECTED_TASK_MINUTES_LOW = 334
+PROJECTED_TASK_MINUTES_HIGH = 346
 
 
 def _workflow_budget_minutes() -> int:
@@ -94,12 +113,14 @@ def test_the_grader_hash_is_blind_to_the_workflows_directory():
     assert WORKFLOW.read_bytes() == original
 
 
-def test_the_chunk_budget_outlasts_the_longest_task_a_shard_has_needed():
+def test_the_chunk_budget_outlasts_every_chunk_that_has_been_watched_fail():
     """The floor, stated as a number that a revert would trip over.
 
-    Not a performance target -- a correctness one. Below this line the task
-    that stalled shard 4 is ungradeable rather than slow, and every retry
-    spends a chunk's worth of judging to learn nothing.
+    Not a performance target -- a correctness one. At or below this line the
+    task that stalled shard 4 is ungradeable rather than slow, and every retry
+    spends a chunk's worth of judging to learn nothing. This says the budget
+    clears what has already been observed. It does not say the task fits;
+    that is the next test's business.
     """
     budget = _workflow_budget_minutes()
 
@@ -107,6 +128,57 @@ def test_the_chunk_budget_outlasts_the_longest_task_a_shard_has_needed():
         f"a {budget} min chunk cannot finish a task already measured at "
         f"{OBSERVED_LONGEST_TASK_MINUTES} min; --resume restarts an "
         "unfinished task from nothing, so it would stall here forever"
+    )
+
+
+def test_the_budget_is_the_most_the_platform_allows_not_the_most_the_task_needs():
+    """The uncomfortable half, written down rather than left to be rediscovered.
+
+    The projection straddles the budget: the optimistic end fits, the
+    pessimistic end does not. Nobody can widen the budget past the platform's
+    own kill, and every dial that would make the task itself cheaper sits in
+    the hashed grading config. So if a third attempt also falls short, the
+    honest reading is that this task cannot be graded under the pre-registered
+    settings -- not that some number here needs nudging again.
+
+    The assertion is deliberately the weak one. Asserting the budget clears
+    the high end would be asserting something false; asserting it clears the
+    low end is what the arithmetic actually supports.
+    """
+    budget = _workflow_budget_minutes()
+
+    assert budget >= PROJECTED_TASK_MINUTES_LOW - 2, (
+        f"a {budget} min chunk is short even of the optimistic "
+        f"{PROJECTED_TASK_MINUTES_LOW} min projection; a third attempt would "
+        "be bought knowing it cannot succeed"
+    )
+    assert budget < PROJECTED_TASK_MINUTES_HIGH, (
+        "the budget now covers the pessimistic projection too -- if that is "
+        "real rather than a stale constant, this test has become the wrong "
+        "shape and the caveat above should go"
+    )
+
+
+def test_the_wall_clock_is_the_only_lever_outside_the_hash():
+    """Why no cheaper answer was reached for, kept checkable.
+
+    If a later change gives the grading code a second environment variable
+    that shapes cost, the reasoning above -- that the only dial outside the
+    fingerprint is the clock -- stops holding, and a stalled shard should be
+    answered with that dial instead of by buying more hours.
+    """
+    levers = set()
+    for path in sorted(BATCH_ROOT.glob("core/**/*.py")) + [BATCH_ROOT / "step8_grade.py"]:
+        levers.update(
+            re.findall(
+                r'os\.(?:getenv|environ\.get)\(\s*"(GRADER_[A-Z_0-9]+)"',
+                path.read_text(encoding="utf-8"),
+            )
+        )
+
+    assert levers == {"GRADER_TIME_BUDGET_SEC"}, (
+        f"grading now reads {sorted(levers)} from the environment; a lever "
+        "that is not the clock may be the better answer to a stalled shard"
     )
 
 

--- a/batch-runner/tests/test_full_gold_corpus_contract.py
+++ b/batch-runner/tests/test_full_gold_corpus_contract.py
@@ -360,6 +360,24 @@ def test_every_allowed_shard_count_covers_the_corpus_exactly_once(shard_count):
 MEAN_TASK_MINUTES = 19.44
 P90_TASK_MINUTES = 32.7
 
+#: GitHub-hosted runners are killed here no matter what ``timeout-minutes``
+#: says. Every number below is a share of this one.
+PLATFORM_HARD_KILL_MINUTES = 360
+
+#: Checkout, pip install and the HuggingFace download, before grading opens.
+#: Run 33286656393: job opened 01:53:41Z, the grading step opened 01:57:55Z.
+SETUP_MINUTES_BEFORE_GRADING = 4.2
+
+#: How far past its budget a chunk can run before it is able to stop. Since
+#: #77 and #279 the guard is checked between rubric items and between split
+#: children (core/grader.py::_check_should_stop), so the overrun is one item,
+#: not one task. Longest item measured, run 33286656393: task 9e39df84 items
+#: 36 -> 37, 04:24:48Z -> 04:36:48Z.
+LONGEST_RUBRIC_ITEM_MINUTES = 12.0
+
+#: Partial save, commit, auto-retrigger, after the guard has fired.
+SAVE_AND_COMMIT_MINUTES = 2.0
+
 
 def _workflow_numbers() -> dict[str, int]:
     """Read the three timing limits out of grade-run.yml.
@@ -380,43 +398,69 @@ def _workflow_numbers() -> dict[str, int]:
     }
 
 
+def test_the_job_timeout_stays_under_the_platforms_own_kill():
+    """``timeout-minutes`` above 360 would be a number nobody honours.
+
+    The platform measures its 6 hours from when the job starts, which is
+    earlier than when our first step runs, so the gap is reserve rather than
+    slack to be spent.
+    """
+    limits = _workflow_numbers()
+    assert limits["timeout_min"] < PLATFORM_HARD_KILL_MINUTES
+
+
 def test_a_chunk_can_always_save_before_the_runner_kills_it():
     """The time budget must fire far enough ahead of the job timeout.
 
-    The budget is a *pre-check*: step8_grade.py tests the clock before starting
-    a task, never during one. So a chunk can begin its last task at one second
-    under budget and then run for that task's full duration. The gap between
-    budget and timeout therefore has to be wider than a task, or a shard is
-    killed mid-judgement having saved nothing and having paid for everything.
+    A chunk that is killed by the runner has paid for everything and saved
+    nothing, so the budget has to leave room for the whole tail of the job:
+    the setup that ran before grading opened, the one rubric item a chunk can
+    still be inside when the guard fires, and the save and commit afterwards.
 
-    Checked at p90 rather than at the mean, because the mean is not the case
-    that kills a job.
+    That middle term used to be a whole *task* -- p90 32.7 minutes -- because
+    the guard was a pre-check tested only between tasks. #77 and #279 moved it
+    inside a task, and one item is what a chunk can now be committed to when
+    the clock runs out. That is the whole reason the budget is allowed this
+    close to the wall.
     """
     limits = _workflow_numbers()
 
     assert limits["budget_min"] < limits["timeout_min"]
-    headroom = limits["timeout_min"] - limits["budget_min"]
-    assert headroom > P90_TASK_MINUTES, (
-        f"only {headroom} min between the {limits['budget_min']} min budget and "
-        f"the {limits['timeout_min']} min timeout; a p90 task is "
-        f"{P90_TASK_MINUTES} min"
+
+    worst_case = (
+        SETUP_MINUTES_BEFORE_GRADING
+        + limits["budget_min"]
+        + LONGEST_RUBRIC_ITEM_MINUTES
+        + SAVE_AND_COMMIT_MINUTES
+    )
+    assert worst_case <= limits["timeout_min"], (
+        f"{SETUP_MINUTES_BEFORE_GRADING} min of setup plus a "
+        f"{limits['budget_min']} min budget plus a "
+        f"{LONGEST_RUBRIC_ITEM_MINUTES} min item plus "
+        f"{SAVE_AND_COMMIT_MINUTES} min of saving is {worst_case} min, "
+        f"past the {limits['timeout_min']} min timeout"
     )
 
 
 def test_the_widest_shard_finishes_inside_the_auto_resume_cap():
-    """A shard is expected to outlast one chunk; it must not outlast ten.
+    """A shard may outlast one chunk; it must not outlast ten.
 
-    11 shards is the workflow's own cap, so the largest shard is 17 tasks, and
-    at the measured mean that is about 5.5 hours against a 4 hour chunk. Going
-    over is normal -- the auto-resume exists for it. What is not survivable is
-    needing more chunks than the resume cap allows, because the run would then
-    stop halfway with the money spent.
+    11 shards is the workflow's own cap, so the largest shard is 17 tasks. At
+    the measured mean that now fits inside a single chunk, which is why the
+    check below is made at p90 instead: going over one chunk is normal and the
+    auto-resume exists for it. What is not survivable is needing more chunks
+    than the resume cap allows, because the run would then stop halfway with
+    the money spent.
     """
     limits = _workflow_numbers()
     largest = max(len(_pinned()[index::11]) for index in range(11))
     assert largest == 17
 
-    minutes = largest * MEAN_TASK_MINUTES
+    assert largest * MEAN_TASK_MINUTES <= limits["budget_min"], (
+        "the mean-paced shard no longer fits one chunk; check at the mean again"
+    )
+
+    minutes = largest * P90_TASK_MINUTES
     chunks = math.ceil(minutes / limits["budget_min"])
 
     assert minutes > limits["budget_min"], (


### PR DESCRIPTION
## 무슨 일이 있었나

샤드 4의 과제 `9e39df84`가 **두 번째로** 시간 안에 끝나지 못했습니다.

| 시도 | 실행 | 예산 | 채점에 쓴 시간 | 끝낸 항목 |
|---|---|---|---|---|
| 1 | `33273207562` | 240분 | 261.3분 | 57개 중 **46개** |
| 2 | `33286656393` | 300분 (#279) | 310.4분 | 57개 중 **54개** |

세 개가 모자랐습니다. 시간이 다 되면 그 과제는 통째로 버려지고 다음 청크가 1번 항목부터 다시 시작하므로, **두 번의 시도(합쳐 9시간 반)가 남긴 채점 결과는 없습니다.**

## 예산을 다시 계산했습니다

360분은 GitHub 호스티드 러너가 작업을 죽이는 한계이고 늘릴 수 없습니다. 아래는 그 360분을 나눈 것이고, 전부 실행 `33286656393`에서 잰 값입니다.

```
 360   플랫폼이 죽이는 지점, 연장 불가
  -5   예비. 플랫폼은 작업 시작 시점부터 재는데,
       우리 첫 스텝이 돌기 전 구간은 통제할 수 없음
 ---
 355   timeout-minutes
-4.2   준비: checkout, pip install, HF 다운로드
       (작업 01:53:41Z 시작 → 채점 01:57:55Z 시작)
 -12   시계가 울린 뒤 멈출 수 있을 때까지의 항목 하나.
       측정한 최장값 (9e39df84 항목 36 → 37,
       04:24:48Z → 04:36:48Z)
  -2   부분 저장, 커밋, 자동 재시작
 ---
 336   GRADER_TIME_BUDGET_SEC = 20160
```

**과제에 맞춘 숫자가 아니라 플랫폼이 남겨준 숫자입니다.**

12분이라는 항목 하나를 쓸 수 있는 것은 #77과 #279가 시계를 과제 사이가 아니라 **항목 사이**에서 보게 만들었기 때문입니다(`core/grader.py::_check_should_stop`). 그 전에는 과제 하나의 p90인 32.7분을 비워둬야 했고, 그러면 예산은 322분을 넘을 수 없었습니다.

## 사실이 아니게 된 근거 문장을 고쳤습니다

`test_a_chunk_can_always_save_before_the_runner_kills_it`의 근거는 이렇게 적혀 있었습니다.

> The budget is a *pre-check*: step8_grade.py tests the clock before starting a task, never during one.

#77과 #279 이후로 사실이 아닙니다. 문장과 숫자를 모두 실제 동작에 맞췄고, 검사 자체를 "예산과 시간제한의 간격이 과제 하나보다 넓은가"에서 "준비 + 예산 + 항목 하나 + 저장이 시간제한 안에 들어가는가"로 바꿨습니다. 가장 넓은 샤드 검사는 평균이 아니라 p90에서 하도록 옮겼습니다 — 336분 예산에서는 평균 속도의 17개 과제가 한 청크에 들어가서, 평균으로 재면 검사가 무의미해집니다.

## 세 번째 시도가 실패할 가능성을 감추지 않았습니다

남은 3개 항목을 **같은 실행이 재고 있던 속도**로 환산하면:

- 항목 34 → 41: 83.2분 (개당 11.9분)
- 항목 41 → 54: 103.9분 (개당 8.0분)
- 남은 3개 = 24~36분 → 전체 **334~346분**

예산 336분은 그 구간 **안에** 있지 그 **위에** 있지 않습니다. 낙관적인 쪽만 통과합니다. 이 사실을 `test_the_budget_is_the_most_the_platform_allows_not_the_most_the_task_needs`로 적어뒀고, 단언은 일부러 약한 쪽(낙관적 하한을 넘는가)만 했습니다. 비관적 상한을 넘는다고 단언하면 거짓을 단언하는 것이기 때문입니다.

세 번째 시도도 모자란다면, 올바른 해석은 "숫자를 또 조금 올리면 된다"가 아니라 **"이 과제는 사전 등록된 설정으로는 채점할 수 없다"** 입니다. 예산을 더 늘릴 곳이 없고, 과제 자체를 싸게 만드는 설정(`per_item_max_output_tokens`, `finalization_reasoning_effort`, `timeout_sec`, `max_iterations`, `per_item_call_cap`)은 전부 채점기 지문 안에 있어서 건드리면 이미 커밋된 열 개 샤드가 무효가 됩니다.

채점 코드가 읽는 환경변수 중 비용을 좌우하는 것이 `GRADER_TIME_BUDGET_SEC` 하나뿐이라는 사실도 `test_the_wall_clock_is_the_only_lever_outside_the_hash`로 고정했습니다. 나중에 두 번째 레버가 생기면 이 테스트가 깨지고, 그때는 시간을 더 사는 대신 그 레버를 써야 한다는 신호가 됩니다.

## 지문은 움직이지 않습니다

`grade-run.yml`은 `compute_grader_source_hash` 바깥입니다. 이 변경 뒤에 다시 계산한 값:

```
955be41edc4aff191952123e37538266aa28508786aa82693055269538d8b67a
→ src_955be41edc4aff19
```

커밋된 열 개 샤드 디렉터리의 `src_955be41edc4aff19`와 일치합니다. 병합이 요구하는 동일성 검사(`step9_merge_shards.py`의 `CONTRACT_IDENTITY_FIELDS`)를 통과합니다.

## 검증

- 로컬 전체: **5834 passed, 9 skipped, 45 deselected** (11분 08초)
- 진행 중인 샤드 없음 — 이 병합이 실행 중인 채점을 건드리지 않습니다