### PR TITLE
fix(batch): let workflow-invoked scripts import core when run by path

### DIFF
--- a/batch-runner/scripts/build_agentic_input_manifest.py
+++ b/batch-runner/scripts/build_agentic_input_manifest.py
@@ -3,9 +3,14 @@
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
-from core.agentic_input_manifest import build_input_manifest
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_input_manifest import build_input_manifest  # noqa: E402
 
 
 def main():

--- a/batch-runner/scripts/compare_agentic_conditions.py
+++ b/batch-runner/scripts/compare_agentic_conditions.py
@@ -5,10 +5,15 @@ import argparse
 import hashlib
 import json
 import re
+import sys
 from pathlib import Path
 
-from core.agentic_budget import AgenticBudgetLedger
-from core.agentic_endpoints import compute_paired_endpoints
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_budget import AgenticBudgetLedger  # noqa: E402
+from core.agentic_endpoints import compute_paired_endpoints  # noqa: E402
 
 
 FULL_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")

--- a/batch-runner/scripts/relay_checkpoint.py
+++ b/batch-runner/scripts/relay_checkpoint.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import tempfile
 from pathlib import Path, PurePosixPath
 from typing import Iterable
@@ -21,13 +22,17 @@ from huggingface_hub import (
 )
 from huggingface_hub.utils import HfHubHTTPError
 
-from core.inference_manifest import (
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.inference_manifest import (  # noqa: E402
     STEP2_RESULT_STATUSES,
     canonical_deliverable_path,
     canonical_task_id,
     validate_step2_progress_results,
 )
-from core.repository_identity import validate_hf_dataset_repo_id
+from core.repository_identity import validate_hf_dataset_repo_id  # noqa: E402
 
 
 CHECKPOINT_SCHEMA = "relay-checkpoint-v2"

--- a/batch-runner/scripts/select_agentic_tasks.py
+++ b/batch-runner/scripts/select_agentic_tasks.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
-from core.agentic_selector import (
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER_ROOT) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
+
+from core.agentic_selector import (  # noqa: E402
     assert_outcome_free_checkout,
     build_selection_manifest,
     select_agentic_tasks,

--- a/batch-runner/tests/test_a_workflow_script_can_find_its_own_core.py
+++ b/batch-runner/tests/test_a_workflow_script_can_find_its_own_core.py
@@ -1,0 +1,116 @@
+"""A script under `scripts/` must be able to import `core` when run AS a script.
+
+Why this exists
+---------------
+`.github/workflows/batch-run.yml` runs these files the plain way::
+
+    cd batch-runner
+    python3 scripts/relay_checkpoint.py verify-write --repo-id "$SOURCE_REPO"
+
+When Python is handed a *file path*, it puts that file's own directory on
+`sys.path[0]` -- so `sys.path[0]` becomes `batch-runner/scripts`, and
+`batch-runner` itself is nowhere on the path. A bare `from core.x import y`
+therefore dies at import time::
+
+    ModuleNotFoundError: No module named 'core'
+
+The unit tests never saw this. pytest's rootdir insertion puts `batch-runner`
+on `sys.path`, so `import scripts.relay_checkpoint` resolves happily -- the
+module is fine, the *invocation* is not. That gap let the defect reach `main`
+and kill a paid batch run (33300827995) four minutes in, after Step 0 had
+already duplicated a dataset on the Hub.
+
+So this test does not import anything. It spawns the interpreter exactly the
+way the workflow does and reads what comes back.
+
+Deliberately NOT asserted: the exit code. Some of these scripts fail without
+their required arguments, and `preflight_grading_renderer.py` exits non-zero
+when LibreOffice is absent. Those are honest failures that say what they need.
+A missing `core` is a different animal: the script never gets to speak at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = BATCH_RUNNER_ROOT / "scripts"
+
+# `core` is the only first-party package that lives beside `scripts/` rather
+# than inside it, so it is the only one this invocation style can lose.
+FIRST_PARTY_ROOT = "core"
+
+REMEDY = (
+    "Add the preamble its 12 siblings already carry, above the core imports:\n"
+    "    BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]\n"
+    "    if str(BATCH_RUNNER_ROOT) not in sys.path:\n"
+    "        sys.path.insert(0, str(BATCH_RUNNER_ROOT))\n"
+    "and mark the core imports `# noqa: E402`."
+)
+
+
+def _imports_core(path: Path) -> bool:
+    """True if `path` has a module-level import of the `core` package.
+
+    Parsed, not grepped: a `core.` inside a docstring, a comment, or a
+    function-local import must not drag a file into this test.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - not our concern here
+        return False
+    for node in tree.body:  # module level only
+        if isinstance(node, ast.ImportFrom):
+            if node.level == 0 and (node.module or "").split(".")[0] == FIRST_PARTY_ROOT:
+                return True
+        elif isinstance(node, ast.Import):
+            if any(a.name.split(".")[0] == FIRST_PARTY_ROOT for a in node.names):
+                return True
+    return False
+
+
+def _core_importing_scripts() -> list[Path]:
+    return sorted(p for p in SCRIPTS_DIR.glob("*.py") if _imports_core(p))
+
+
+def test_the_discovery_actually_found_scripts() -> None:
+    """Guard the guard: an empty sweep would make every case below vacuous."""
+    found = _core_importing_scripts()
+    assert len(found) >= 10, (
+        f"expected the scripts/ directory to hold many core-importing scripts, "
+        f"found {len(found)}: {[p.name for p in found]}"
+    )
+
+
+@pytest.mark.parametrize(
+    "script", _core_importing_scripts(), ids=lambda p: p.name
+)
+def test_script_can_import_core_when_run_by_path(script: Path, monkeypatch) -> None:
+    # PYTHONPATH must be absent, or it silently supplies what the script should
+    # be supplying itself -- and the test would pass while the workflow fails.
+    # (batch-run.yml sets no PYTHONPATH; that is why the defect was reachable.)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    # Credentials are scrubbed so a script that does real work on --help cannot
+    # reach a provider from a unit test.
+    for leaked in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "OPENAI_API_KEY",
+                   "ANTHROPIC_API_KEY", "AZURE_OPENAI_API_KEY"):
+        monkeypatch.delenv(leaked, raising=False)
+
+    proc = subprocess.run(
+        [sys.executable, f"scripts/{script.name}", "--help"],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    output = proc.stdout + proc.stderr
+
+    assert f"No module named '{FIRST_PARTY_ROOT}'" not in output, (
+        f"`cd batch-runner && python scripts/{script.name}` cannot import "
+        f"`{FIRST_PARTY_ROOT}`.\n\n{REMEDY}\n\n--- what it printed ---\n{output[-2000:]}"
+    )


### PR DESCRIPTION
## 한 줄 요약

`batch-run.yml`이 부르는 스크립트가 **자기 옆에 있는 `core/`를 못 찾아서** 유료 실행이 4분 만에 죽었습니다. 한 줄짜리 누락이고, 12개 형제 스크립트는 이미 그 한 줄을 갖고 있습니다.

---

## 무엇이 깨져 있었나

워크플로는 이렇게 부릅니다:

```bash
cd batch-runner
python3 scripts/relay_checkpoint.py verify-write --repo-id "$SOURCE_REPO"
```

파이썬에게 **파일 경로**를 주면, 파이썬은 `sys.path[0]`에 **그 파일이 있는 폴더**를 넣습니다. 즉 `sys.path[0]`는 `batch-runner/scripts`가 되고, 정작 `batch-runner` 자신은 경로에 **없습니다**. 그래서 `#129`에서 들어온 `from core.inference_manifest import ...`가 import 시점에 그대로 죽습니다:

```
ModuleNotFoundError: No module named 'core'
```

`batch-run.yml`의 **`relay_checkpoint.py` 호출 6곳이 전부** 이 상태였습니다 (530, 572, 741, 767, 1002행).

### 실제로 돈을 쓰고 죽은 증거

유료 실행 **`33300827995`** (`exp026c`, 1개 과제):

| 단계 | 결과 |
|---|---|
| Step 0: Bootstrap submission repo | ✅ success — **HF Hub에 데이터셋을 이미 복제함** |
| Verify result dataset write access | ❌ `ModuleNotFoundError: No module named 'core'` |

Step 0이 **성공한 뒤에** 죽었습니다. 즉 원격에 흔적을 남기고 나서 멈춘 것이라, 조용한 실패가 아니라 치워야 할 실패입니다.

---

## 왜 테스트가 이걸 못 잡았나 — 이게 진짜 교훈입니다

pytest는 `batch-runner`를 `sys.path`에 올려놓고 돌기 때문에, 테스트 안에서 `import scripts.relay_checkpoint`는 **아무 문제 없이 됩니다.**

**모듈은 멀쩡했습니다. 부르는 방식이 깨져 있었습니다.**

테스트가 본 적 없는 것은 코드가 아니라 **호출 형태**였고, 그래서 `main`까지 갔습니다.

---

## 무엇을 고쳤나

같은 규칙을 어긴 파일이 4개였습니다. 실행해서 확인한 결과입니다 (추측 아님):

```
FAIL  scripts/build_agentic_input_manifest.py
FAIL  scripts/compare_agentic_conditions.py
FAIL  scripts/relay_checkpoint.py
FAIL  scripts/select_agentic_tasks.py
```

넷 다 **이미 12개 형제가 쓰고 있는 형태**를 그대로 붙였습니다:

```python
BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
if str(BATCH_RUNNER_ROOT) not in sys.path:
    sys.path.insert(0, str(BATCH_RUNNER_ROOT))
```

`if ... not in sys.path` 가드가 있으니, `batch-runner`가 이미 경로에 있는 상황(= pytest, `python -m scripts.x`, 직접 import)에서는 **아무 일도 하지 않습니다.** 기존 호출자의 동작은 하나도 바뀌지 않습니다.

---

## 재발 방지 테스트

`tests/test_a_workflow_script_can_find_its_own_core.py` — **아무것도 import 하지 않습니다.** 워크플로와 똑같이 프로세스를 띄우고 결과를 읽습니다.

두 가지를 일부러 그렇게 했습니다:

1. **`PYTHONPATH`를 지웁니다.** 안 지우면, 물려받은 `PYTHONPATH`가 스크립트가 스스로 해야 할 일을 대신 해줘서 **테스트는 통과하는데 워크플로는 죽는** 상태가 됩니다. (`batch-run.yml`은 `PYTHONPATH`를 설정하지 않습니다. 그래서 이 버그가 도달 가능했습니다.)
2. **종료 코드는 검사하지 않습니다.** 이 스크립트 중 몇 개는 인자 없이는 정직하게 실패하고, `preflight_grading_renderer.py`는 LibreOffice가 없으면 0이 아닌 값으로 끝납니다. 그건 **자기가 뭐가 필요한지 말하는** 실패입니다. `core`가 없는 건 다릅니다 — 스크립트가 **입도 못 떼고** 죽습니다.

수집이 비면 모든 케이스가 공허하게 통과하므로, **탐지 자체를 지키는 테스트**를 하나 더 뒀습니다 (`>= 10`개는 찾아야 함).

### 변이(mutation) 검증

초록불을 그냥 믿지 않고, 고친 것을 되돌려서 테스트가 진짜 잡는지 확인했습니다:

| 되돌린 파일 | 결과 |
|---|---|
| `relay_checkpoint.py` + `select_agentic_tasks.py` | **그 2개만** FAIL, 나머지 15개 PASS |

파일별로 정확히 붙습니다.

---

## 기존 실행에 영향 없음

| 확인 항목 | 결과 |
|---|---|
| 채점기 소스 지문 (base `e000957`) | `955be41e…d8b67a`, 입력 105개 |
| 채점기 소스 지문 (이 PR 적용) | `955be41e…d8b67a`, 입력 105개 — **동일** |
| `relay_checkpoint.py`가 지문 입력인가 | **아니오** (`scripts/`에서 지문에 들어가는 건 `download_inference_from_hf.py` 하나뿐) |

계산 함수 안을 들여다보고 실제로 읽힌 파일을 세어 확인했습니다. **비싼 관문(shard 병합 시점)은 건드리지 않습니다.**

## 🤝 세션 A에게 — 병합 시점만 봐주세요

`batch-runner/scripts`는 `grade-run.yml`의 **싼 관문** `GRADING_INPUT_PATHS`에는 들어 있습니다. 그 관문은 `HEAD_SHA != GITHUB_SHA`일 때만, 즉 **청크가 dispatch된 뒤 checkout하기 전에 main이 움직였을 때만** 터집니다. 채점 시작 **전에** 싸게 실패하고, 메시지도 `retry from the new main`이라고 스스로 알려줍니다.

병합 시점을 이렇게 잡았습니다:

- 실행 중인 청크 **`33301041542`** (chunk 3, shard 4/11)는 6단계 `Verify checked out main and input files`를 **이미 통과**했고 17단계 `Run grading` 중입니다 → 이 병합은 **이 청크를 건드릴 수 없습니다.**
- 다음 청크는 병합 **이후에** dispatch되므로 `GITHUB_SHA`와 `HEAD_SHA` 양쪽에 이 변경이 들어 있어 diff가 비고 → 관문 통과.

즉 지금이 가장 안전한 창입니다. 그래도 재개 청크가 실패하면 `retry from the new main` 한 번으로 끝납니다.

**PR #278은 별개입니다.** 그건 `core/`와 `schemas/`를 바꾸는 **비싼 관문 안**이라, 11샤드 Full 병합·보존 완료를 A가 확인해 줄 때까지 그대로 대기합니다.

---

## 검증

| 항목 | 결과 |
|---|---|
| 신규 테스트 | 17 passed (탐지 가드 1 + 스크립트 16) |
| `test_relay_checkpoint.py` + `test_agentic_selector.py` + `test_agentic_endpoints.py` + 신규 | **128 passed** |
| 변이 검증 | 되돌린 2개만 정확히 FAIL |
| batch-runner 전체 pytest | 아래 CI |

## 바뀐 파일 (5개)

```
batch-runner/scripts/relay_checkpoint.py              +8 −3   (워크플로가 6곳에서 부름)
batch-runner/scripts/build_agentic_input_manifest.py  +6 −1
batch-runner/scripts/compare_agentic_conditions.py    +7 −2
batch-runner/scripts/select_agentic_tasks.py          +6 −1
batch-runner/tests/test_a_workflow_script_can_find_its_own_core.py  (신규)
```
