### PR TITLE
fix(cost): 비용 영수증이 생긴 첫 실행에서 Step 3이 과제 집계를 잃고 죽던 문제

### DIFF
--- a/batch-runner/step3_format_results.py
+++ b/batch-runner/step3_format_results.py
@@ -312,8 +312,14 @@ def format_results():
     }
     # Conditional, like every other opt-in block: an experiment with no cost
     # instrumentation publishes no cost keys at all.
-    for field, summary in cost_summaries.items():
-        final_json.setdefault("cost_summary", {})[field] = summary
+    # NOT `summary` as the loop name: that is the inference summary bound at the
+    # top of this function and still needed below for the task counts. Rebinding
+    # it here left every line after this point reading a cost receipt -- which
+    # has no "total" -- so the report crashed on the first run that produced a
+    # receipt, and would have printed a receipt's numbers as task counts if it
+    # had not. See tests/test_step3_cost_summary_does_not_shadow_task_counts.py.
+    for field, cost_summary in cost_summaries.items():
+        final_json.setdefault("cost_summary", {})[field] = cost_summary
     if cost_ledger:
         final_json["cost_ledger"] = cost_ledger
 

--- a/batch-runner/tests/test_step3_cost_summary_does_not_shadow_task_counts.py
+++ b/batch-runner/tests/test_step3_cost_summary_does_not_shadow_task_counts.py
@@ -42,8 +42,11 @@ TOTAL_TASKS = 7
 SUCCESS_TASKS = 5
 ERROR_TASKS = 2
 
-# Copied from the real receipt in run 33302056462 rather than invented, so the
-# fixture cannot drift into a shape the producer never emits.
+# Copied field-for-field from the receipt Step 2 wrote in run 33302056462 --
+# one task, a generation call and a Self-QA call, both against a model the
+# price table had no entry for -- so the fixture cannot drift into a shape the
+# producer never emits. Only `price_table_sha256` is substituted, since the
+# real digest pins a file this test has no reason to depend on.
 RECEIPT = {
     "schema_version": "cost-receipt-v1",
     "status": "partial",
@@ -54,9 +57,9 @@ RECEIPT = {
     "runtime_cost_usd": 0.0,
     "model_calls": 2,
     "usage": {
-        "input_tokens": 3949,
+        "input_tokens": 5794,
         "cached_input_tokens": 0,
-        "output_tokens": 6910,
+        "output_tokens": 7000,
         "reasoning_tokens": 1775,
     },
     "components": [
@@ -74,7 +77,22 @@ RECEIPT = {
                 "reasoning_tokens": 1775,
             },
             "missing_reasons": ["price_missing"],
-        }
+        },
+        {
+            "name": "self_qa",
+            "stage": "self_qa",
+            "retry_kind": "none",
+            "status": "partial",
+            "model_calls": 1,
+            "known_cost_usd": 0.0,
+            "usage": {
+                "input_tokens": 1845,
+                "cached_input_tokens": 0,
+                "output_tokens": 90,
+                "reasoning_tokens": 0,
+            },
+            "missing_reasons": ["price_missing"],
+        },
     ],
     "price_table_sha256": "d" * 64,
     "missing_reasons": ["price_missing"],

--- a/batch-runner/tests/test_step3_cost_summary_does_not_shadow_task_counts.py
+++ b/batch-runner/tests/test_step3_cost_summary_does_not_shadow_task_counts.py
@@ -1,0 +1,211 @@
+"""The cost summary must not overwrite the task counts in the Step 3 report.
+
+Why this exists
+---------------
+`format_results()` binds ``summary = inference["summary"]`` near the top and
+still needs it far below, for the success rate and the report's count table.
+Between those two points sat::
+
+    for field, summary in cost_summaries.items():
+        final_json.setdefault("cost_summary", {})[field] = summary
+
+The loop variable rebound the same name. From there on, every read of
+``summary`` returned a *cost receipt* instead of the task counts.
+
+The loop body only runs when the experiment actually produced a receipt, so
+every run before cost instrumentation existed skipped it and the report was
+fine. The first run that produced one -- the exp026c cost smoke, GitHub run
+33302056462 -- died in Step 3 with ``KeyError: 'total'`` after the paid
+inference had already succeeded.
+
+The crash was the lucky outcome. A receipt carries ``model_calls`` and
+``usage``, not ``total``/``success``/``error``; had it happened to share a key
+name, Step 3 would have written a receipt's numbers into the report's task
+table and published them as if they were task counts. So this test does not
+just check that formatting survives -- it checks the printed numbers are the
+task counts, which is the property that was actually at risk.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import step3_format_results as step3
+from core.prepared_fingerprint import prepared_fingerprint
+from core.result_fingerprint import inference_result_fingerprint
+
+# Deliberately unlike anything a receipt carries, so a wrong-source number is
+# recognisable on sight rather than merely unequal.
+TOTAL_TASKS = 7
+SUCCESS_TASKS = 5
+ERROR_TASKS = 2
+
+# Copied from the real receipt in run 33302056462 rather than invented, so the
+# fixture cannot drift into a shape the producer never emits.
+RECEIPT = {
+    "schema_version": "cost-receipt-v1",
+    "status": "partial",
+    "currency": "USD",
+    "estimated_cost_usd": None,
+    "known_cost_usd": 0.0,
+    "model_cost_usd": 0.0,
+    "runtime_cost_usd": 0.0,
+    "model_calls": 2,
+    "usage": {
+        "input_tokens": 3949,
+        "cached_input_tokens": 0,
+        "output_tokens": 6910,
+        "reasoning_tokens": 1775,
+    },
+    "components": [
+        {
+            "name": "generation",
+            "stage": "generation",
+            "retry_kind": "none",
+            "status": "partial",
+            "model_calls": 1,
+            "known_cost_usd": 0.0,
+            "usage": {
+                "input_tokens": 3949,
+                "cached_input_tokens": 0,
+                "output_tokens": 6910,
+                "reasoning_tokens": 1775,
+            },
+            "missing_reasons": ["price_missing"],
+        }
+    ],
+    "price_table_sha256": "d" * 64,
+    "missing_reasons": ["price_missing"],
+}
+
+
+def _task_ids() -> list[str]:
+    return [f"task-{i}" for i in range(TOTAL_TASKS)]
+
+
+def _write_workspace(workspace, *, with_receipt: bool) -> None:
+    task_ids = _task_ids()
+    prepared = {
+        "experiment_id": "exp998",
+        "experiment_name": "shadowing regression",
+        "publication_generation": "exp998:100:1",
+        "source": "student/exp998",
+        "task_scope": {"task_ids": task_ids},
+        "tasks": [
+            {"task_id": tid, "sector": "Finance", "occupation": "Accountants"}
+            for tid in task_ids
+        ],
+    }
+    prepared["prepared_fingerprint"] = prepared_fingerprint(prepared)
+
+    results = []
+    for index, tid in enumerate(task_ids):
+        succeeded = index < SUCCESS_TASKS
+        row = {
+            "task_id": tid,
+            "status": "success" if succeeded else "error",
+            "deliverable_text": "a deliverable" if succeeded else "",
+            "deliverable_files": [],
+            "latency_ms": 1000,
+        }
+        if with_receipt and succeeded:
+            row["problem_solving_cost"] = json.loads(json.dumps(RECEIPT))
+        results.append(row)
+
+    inference = {
+        "experiment_id": "exp998",
+        "experiment_name": "shadowing regression",
+        "publication_generation": "exp998:100:1",
+        "source": "student/exp998",
+        "prepared_fingerprint": prepared["prepared_fingerprint"],
+        "ordered_task_ids": task_ids,
+        "condition": "condition_a",
+        "execution_mode": "sandbox",
+        "model": "gpt-5.4",
+        "started_at": "2026-08-30T08:00:00Z",
+        "completed_at": "2026-08-30T08:10:00Z",
+        "resume_rounds_used": 0,
+        "results": results,
+        "summary": {
+            "total": TOTAL_TASKS,
+            "success": SUCCESS_TASKS,
+            "error": ERROR_TASKS,
+            "qa_failed": 0,
+        },
+    }
+    inference["result_fingerprint"] = inference_result_fingerprint(inference)
+
+    (workspace / "step1_tasks_prepared.json").write_text(
+        json.dumps(prepared), encoding="utf-8"
+    )
+    (workspace / "step2_inference_results.json").write_text(
+        json.dumps(inference), encoding="utf-8"
+    )
+
+
+def _run(tmp_path, monkeypatch, *, with_receipt: bool) -> str:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root = tmp_path / "batch-runner"
+    root.mkdir()
+    _write_workspace(workspace, with_receipt=with_receipt)
+    monkeypatch.setattr(step3, "WORKSPACE_DIR", workspace)
+    monkeypatch.setattr(step3, "BATCH_RUNNER_ROOT", root)
+    step3.format_results()
+    return (root / "results" / "exp998" / "exp998.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("with_receipt", [False, True], ids=["no_receipt", "with_receipt"])
+def test_report_counts_come_from_the_inference_summary(tmp_path, monkeypatch, with_receipt):
+    """The same counts must print whether or not a cost receipt is present.
+
+    Running both ways is the point: the uninstrumented case is what always
+    worked, so it pins the expected output independently of the fix, and the
+    instrumented case is the one that used to crash.
+    """
+    report = _run(tmp_path, monkeypatch, with_receipt=with_receipt)
+
+    assert f"| Total tasks | {TOTAL_TASKS} |" in report, report
+    assert f"| Error | {ERROR_TASKS} |" in report, report
+    # 5/7 -> 71%. A receipt-sourced numerator would not land here.
+    assert f"| Success | {SUCCESS_TASKS} (71%) |" in report, report
+
+
+def test_the_receipt_is_still_published_under_its_own_key(tmp_path, monkeypatch):
+    """Guard the guard: renaming the loop variable must not drop the summary."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root = tmp_path / "batch-runner"
+    root.mkdir()
+    _write_workspace(workspace, with_receipt=True)
+    monkeypatch.setattr(step3, "WORKSPACE_DIR", workspace)
+    monkeypatch.setattr(step3, "BATCH_RUNNER_ROOT", root)
+    step3.format_results()
+
+    payload = json.loads(
+        (root / "results" / "exp998" / "exp998.json").read_text(encoding="utf-8")
+    )
+    receipt = payload["cost_summary"]["problem_solving_cost"]
+    assert receipt["schema_version"] == "cost-receipt-v1"
+    # Both task counts, from the two sides of the same run: 7 tasks were run,
+    # 5 of them carried a receipt. Asserting the pair is what catches a summary
+    # that reached the file with one of its two sources overwritten.
+    assert receipt["total_tasks"] == TOTAL_TASKS
+    assert receipt["receipt_tasks"] == SUCCESS_TASKS
+    # The report's task table and the receipt are separate facts about the same
+    # run; publishing one must not have consumed the other.
+    assert payload["summary"]["total_tasks"] == TOTAL_TASKS
+
+
+# The run-level `status` this summary carries is deliberately not asserted here.
+# On this commit a run whose every receipt is `partial` still rolls up as
+# `not_run`, because the roll-up derives its status from whether any amount was
+# confirmed rather than from the receipts themselves. That is a real defect --
+# the exp026c smoke reproduced it on a run that made two paid model calls -- but
+# it lives in core/cost_projection.py, which is an input to the grader source
+# hash and therefore cannot be changed while grading shards are in flight. It is
+# fixed separately, against the rule already carried by core/cost_receipts.py
+# `_summary_status` and scripts/cost-receipt.mjs. Pinning today's wrong value
+# here would only have to be un-pinned by that change.


### PR DESCRIPTION
## 한 줄 요약

Step 3에서 **변수 이름 하나가 겹쳐서**, 비용 영수증이 생긴 첫 실행이 리포트 만드는 자리에서 죽었습니다. 유료 추론은 이미 성공한 뒤였습니다.

---

## 무엇이 깨져 있었나

`format_results()`는 함수 맨 위에서 과제 집계를 `summary`에 담아 둡니다.

```python
summary = inference["summary"]      # 252행 — {"total": 7, "success": 5, "error": 2, ...}
```

그리고 한참 아래에서 그 값을 다시 씁니다.

```python
success_rate = round(summary["success"] / summary["total"] * 100) ...   # 338행
...
f"| Total tasks | {summary['total']} |",                                # 354행
```

그 사이에 이런 줄이 있었습니다.

```python
for field, summary in cost_summaries.items():     # 315행
    final_json.setdefault("cost_summary", {})[field] = summary
```

**같은 이름입니다.** 반복문이 끝나도 `summary`는 원래 값으로 돌아오지 않습니다. 파이썬의 for 변수는 반복문 밖으로 그대로 새어 나오기 때문에, 이 줄 이후의 모든 `summary`는 과제 집계가 아니라 **비용 영수증**을 가리킵니다.

영수증에는 `total`이라는 키가 없습니다. 그래서 338행에서 그대로 죽습니다.

```
KeyError: 'total'
```

### 왜 지금까지 멀쩡했나

`cost_summaries`가 **비어 있으면 반복문 본문이 한 번도 안 돕니다.** 비용 계측이 생기기 전 실행은 전부 여기에 해당했고, 그래서 `summary`가 덮어써질 일 자체가 없었습니다.

영수증을 만든 첫 실행이 이 저장소 역사상 처음으로 이 줄을 밟았습니다 — **`33302056462`** (exp026c 비용 스모크, 1개 과제).

| 단계 | 결과 |
|---|---|
| Step 2a: 추론 | ✅ success — **유료 호출 2회, 산출물 `Sample.xlsx` 생성** |
| Step 3: 결과 포맷 | ❌ `KeyError: 'total'` |

돈을 다 쓰고 **리포트를 쓰는 자리에서** 죽었습니다.

---

## 죽은 게 운이 좋았던 겁니다

이게 이 PR에서 제일 중요한 대목입니다.

영수증이 들고 있는 키는 `model_calls`, `usage`, `known_cost_usd` 같은 것들입니다. 과제 집계가 쓰는 `total`/`success`/`error`와 **겹치는 이름이 하나도 없어서** 즉시 죽었습니다.

만약 이름이 하나라도 겹쳤다면, Step 3은 **조용히** 영수증의 숫자를 리포트의 과제 집계표에 써 넣고 그대로 발행했을 겁니다. "총 과제 2개, 성공 2개" 같은 표가 나오는데 실제로는 그냥 모델 호출 횟수인 상태입니다. 아무도 못 알아챕니다.

그래서 이 PR의 테스트는 "Step 3이 안 죽는다"를 확인하는 데서 멈추지 않고, **찍힌 숫자가 과제 집계에서 나왔는지**를 확인합니다. 실제로 위험했던 건 그쪽이니까요.

---

## 무엇을 고쳤나

반복문 변수 이름만 바꿨습니다.

```python
for field, cost_summary in cost_summaries.items():
    final_json.setdefault("cost_summary", {})[field] = cost_summary
```

왜 `summary`를 쓰면 안 되는지는 다음 사람이 되돌려 놓지 않도록 코드 옆에 적어 뒀습니다.

---

## 재발 방지 테스트

`tests/test_step3_cost_summary_does_not_shadow_task_counts.py` — 3개.

영수증 픽스처는 **지어내지 않고 실제 실행 `33302056462`의 generation 구성요소를 그대로 복사**했습니다. 픽스처가 생산자가 만든 적 없는 모양으로 흘러가는 걸 막기 위해서입니다.

과제 수는 `7 / 성공 5 / 실패 2`로 잡았습니다. 영수증이 들고 있는 어떤 숫자와도 안 닮은 값이라, 잘못된 출처에서 온 숫자가 표에 찍히면 **눈으로 바로 구분**됩니다.

핵심 테스트는 **영수증 있음 / 없음 두 가지로 같이 돕니다.**

- 없는 쪽은 원래부터 잘 되던 경로라, 고친 것과 **무관하게** 기대 출력을 고정해 줍니다.
- 있는 쪽이 죽던 경로입니다.

### 변이(mutation) 검증

초록불을 그냥 믿지 않고, 고친 줄을 되돌려서 테스트가 진짜 잡는지 확인했습니다.

| 되돌린 상태 | 결과 |
|---|---|
| `for field, summary in ...` (원래 버그) | **2 failed, 1 passed** — 실패 지점이 `step3_format_results.py:338 KeyError: 'total'`로 **운영 실패와 동일** |
| 고친 상태 | 3 passed |

통과한 1개는 `no_receipt` 케이스입니다. 버그가 도달하지 못하는 경로이므로 **통과하는 게 맞습니다.** 테스트가 두 경로를 제대로 구분하고 있다는 뜻이기도 합니다.

---

## 기존 실행에 영향 없음

| 확인 항목 | 결과 |
|---|---|
| `step3_format_results.py`가 채점기 소스 지문 입력인가 | **아니오** |
| `step3_format_results.py`가 `GRADING_INPUT_PATHS`에 있는가 | **아니오** |
| 영수증 없는 실행의 동작 | **완전히 동일** — 반복문 본문이 안 돎 |

`step8_grade.py`의 `compute_grader_source_hash`가 읽는 것은 `step8_grade.py`, `core/**/*.py`, `schemas/grade.schema.json`, `requirements.txt`, `scripts/download_inference_from_hf.py`, 판정 프롬프트, 채점 설정 YAML입니다. **`step3_format_results.py`는 그중 어디에도 없습니다.**

## 🤝 세션 A에게

이 PR은 **두 관문 중 어느 쪽에도 들어가지 않습니다.** 비싼 관문(샤드 병합 시점의 `grader_source_hash`)도, 싼 관문(`GRADING_INPUT_PATHS`)도 이 파일을 보지 않습니다. 지금 진행 중인 청크에 **영향을 줄 수 없습니다.**

---

## 이 PR에 넣지 않은 것 — 별건으로 갑니다

스모크가 결함을 **하나 더** 드러냈습니다. 같은 실행에서:

| 층위 | 상태 |
|---|---|
| 과제별 영수증 | `partial` — 유료 호출 2회, 토큰 실제 사용 |
| 실행 전체 요약 | **`not_run`** |

모델을 두 번 부른 유료 실행이 전체 요약에서는 "실행 안 함"으로 굳어집니다. **다섯 가지 비용 상태를 나눠 둔 이유가 막으려던 바로 그 오표기**입니다.

원인은 `core/cost_projection.py`가 상태를 *영수증*이 아니라 *금액이 하나라도 나왔는가*에서 유도하는 것입니다. `_measured_amount`가 complete 아닌 영수증의 $0을 일부러 `None`으로 만들기 때문에, 가격표에 없는 모델을 부르면 금액이 전부 비고 상태가 `not_run`까지 떨어집니다.

**이건 새 규칙을 만드는 게 아니라 이미 승인된 규칙을 옮기는 일입니다.** 같은 수정이 대시보드 쪽에는 이미 들어가 있고(`scripts/cost-receipt.mjs`, PR #270), 채점 쪽 `core/cost_receipts.py`의 `_summary_status`는 처음부터 그 규칙이었습니다. **세 요약기 중 `cost_projection.py` 하나만 어긋나 있습니다.**

다만 `core/cost_projection.py`는 **채점기 소스 지문 입력**이라 샤드가 도는 동안에는 main에 못 들어갑니다. 그래서 별도 PR로 준비해 두고 대기시킵니다. 이 PR의 테스트는 오늘의 틀린 값을 **일부러 고정하지 않았고**, 그 이유를 파일에 적어 뒀습니다.

---

## 검증

| 항목 | 결과 |
|---|---|
| 신규 테스트 | 3 passed |
| 변이 검증 | 되돌리면 운영과 동일한 지점에서 실패 |
| batch-runner 전체 pytest | 아래 CI |

## 바뀐 파일 (2개)

```
batch-runner/step3_format_results.py                                        +8 −2
batch-runner/tests/test_step3_cost_summary_does_not_shadow_task_counts.py   (신규)
```
