### PR TITLE
fix(cost): 유료로 실행된 작업이 요약에서 not_run으로 굳는 문제

### DIFF
--- a/batch-runner/core/cost_projection.py
+++ b/batch-runner/core/cost_projection.py
@@ -466,15 +466,36 @@ def summarize_cost_receipts(
     # The run total is only a total when every receipt is complete. One
     # partial or unavailable receipt makes it a floor, and it is labelled as
     # one rather than quietly rounded up into a headline number.
-    complete_run = counts["complete"] == len(receipts)
-    if complete_run:
+    #
+    # The status comes from the receipts themselves, never from whether any of
+    # them produced a number. `_measured_amount` deliberately drops the
+    # placeholder zero a non-complete receipt carries, so a run whose every
+    # call went to a model the price table does not list leaves `amounts`
+    # empty -- and reading the status off that emptiness reported a run that
+    # made real paid calls as `not_run`. Measuring nothing is not the same as
+    # doing nothing, and "no record" is the exact misreading the four statuses
+    # exist to prevent.
+    #
+    # A task that never ran contributes nothing rather than holing the run, so
+    # it is set aside before the vote instead of dragging a fully priced run
+    # down to `partial` and hiding its estimate and per-deliverable figure.
+    #
+    # This is not a rule invented here. It is the one already carried by
+    # `core/cost_receipts.py._summary_status` and, since #270, by
+    # `scripts/cost-receipt.mjs`. All three summarise the same receipts for the
+    # same run, so they must not disagree about them.
+    contributing = [
+        receipt for receipt in receipts if receipt["status"] != "not_run"
+    ]
+    if not contributing:
+        status = "not_run"
+    elif all(receipt["status"] == "complete" for receipt in contributing):
         status = "complete"
-    elif amounts:
-        status = "partial"
-    elif counts["unavailable"]:
+    elif all(receipt["status"] == "unavailable" for receipt in contributing):
         status = "unavailable"
     else:
-        status = "not_run"
+        status = "partial"
+    complete_run = status == "complete"
 
     reasons = sorted({
         reason

--- a/batch-runner/tests/test_cost_projection.py
+++ b/batch-runner/tests/test_cost_projection.py
@@ -434,6 +434,98 @@ def test_unavailable_receipts_are_counted_but_never_priced():
     assert summary["known_cost_usd"] == 0.0
 
 
+def test_a_run_that_priced_nothing_still_reports_that_it_ran():
+    """Measuring nothing is not the same as doing nothing.
+
+    Shape taken from the exp026c cost smoke (run 33302056462): one task, a
+    generation call and a Self-QA call, real token usage on both — and a model
+    the price table had no entry for, so every amount came back unpriced.
+    Deriving the run status from "did any amount survive" instead of from the
+    receipts turned that into ``not_run``, which reads as "no record" and is
+    the single misreading the four statuses exist to prevent.
+    """
+    receipt = project_cost_receipt(
+        _receipt(
+            status="partial",
+            estimated_cost_usd=None,
+            known_cost_usd=0.0,
+            model_cost_usd=0.0,
+            runtime_cost_usd=0.0,
+            model_calls=2,
+            components=[
+                _component(
+                    name="generation",
+                    stage="generation",
+                    status="partial",
+                    known_cost_usd=0.0,
+                    model_calls=1,
+                ),
+                _component(
+                    name="self_qa",
+                    stage="self_qa",
+                    status="partial",
+                    known_cost_usd=0.0,
+                    model_calls=1,
+                ),
+            ],
+            missing_reasons=["price_missing"],
+        )
+    )
+    rows = [_row("task-a", problem_solving_cost=receipt)]
+    summary = summarize_cost_receipts(
+        rows,
+        "problem_solving_cost",
+        successful_deliverables=successful_deliverable_count(rows),
+    )
+    assert summary["status"] == "partial"
+    assert summary["partial_tasks"] == 1
+    assert summary["not_run_tasks"] == 0
+    # Nothing was confirmed, so nothing is claimed: no floor to stand on, no
+    # headline total, no per-unit figure. `partial` says exactly that, and says
+    # it about a run that did happen.
+    assert summary["measured_tasks"] == 0
+    assert summary["known_cost_usd"] == 0.0
+    assert summary["estimated_cost_usd"] is None
+    assert summary["cost_per_successful_deliverable_usd"] is None
+    assert summary["missing_reasons"] == ["price_missing"]
+
+
+def test_a_task_that_never_ran_does_not_hole_an_otherwise_complete_run():
+    """A ``not_run`` receipt abstains from the status vote instead of spoiling it.
+
+    A task that died before its first model call has nothing to price, and it
+    is not evidence that the tasks which did run were priced badly. Counting it
+    as a dissenting voice dropped a fully priced run to ``partial`` and took
+    its total and per-deliverable figure down with it.
+    """
+    rows = [
+        _row("task-a", problem_solving_cost=project_cost_receipt(_receipt())),
+        _row(
+            "task-b",
+            status="error",
+            deliverable_files=[],
+            problem_solving_cost=project_cost_receipt(_unmeasured("not_run")),
+        ),
+    ]
+    summary = summarize_cost_receipts(
+        rows,
+        "problem_solving_cost",
+        successful_deliverables=successful_deliverable_count(rows),
+    )
+    assert summary["status"] == "complete"
+    assert summary["complete_tasks"] == 1
+    assert summary["not_run_tasks"] == 1
+    assert summary["known_cost_usd"] == 0.25
+    assert summary["estimated_cost_usd"] == 0.25
+    # One deliverable, one priced task: the figure is the whole cost, not the
+    # cost divided by a task that never started.
+    assert summary["cost_per_successful_deliverable_usd"] == 0.25
+    # The failed task is still reported as failed — it just brought no money
+    # with it, and none is invented for it.
+    assert summary["failed_task_count"] == 1
+    assert summary["failed_task_cost_usd"] == 0.0
+
+
 def test_failed_task_cost_is_reported_beside_the_total_not_removed_from_it():
     rows = [
         _row("task-a", problem_solving_cost=project_cost_receipt(_receipt())),


### PR DESCRIPTION
> ⛔ **이 PR은 세션 A가 기존 11샤드 Full 결과의 병합·보존 완료를 확인할 때까지 병합하지 않습니다.**
> `core/cost_projection.py`는 **채점기 소스 지문 입력**입니다. 자세한 내용은 아래 「기존 실행에 영향」 항목에 있습니다.

## 한 줄 요약

모델을 **두 번 유료로 부른 실행**이 실행 전체 요약에서 **`not_run`(실행 안 함)** 으로 굳어지고 있었습니다. 이미 대시보드와 채점 쪽에 들어가 있는 규칙을 **세 번째 요약기에도 똑같이** 넣습니다.

---

## 무엇이 깨져 있었나

exp026c 비용 스모크(`33302056462`)에서 같은 실행의 두 층위가 서로 다른 말을 했습니다.

| 층위 | 상태 | 실제로 있었던 일 |
|---|---|---|
| 과제별 영수증 | `partial` | 유료 호출 2회, 토큰 실사용 (입력 3,949 / 출력 6,910) |
| 실행 전체 요약 | **`not_run`** | — |

**"실행 안 함"은 다섯 가지 비용 상태를 굳이 나눠 둔 이유, 그 자체입니다.** 돈을 쓴 실행이 안 쓴 실행처럼 보이는 건 이 대목에서 제일 나오면 안 되는 오표기입니다.

### 원인 1 — 상태를 *영수증*이 아니라 *금액*에서 유도했습니다

```python
complete_run = counts["complete"] == len(receipts)
if complete_run:
    status = "complete"
elif amounts:            # ← 금액이 하나라도 살아남았는가
    status = "partial"
elif counts["unavailable"]:
    status = "unavailable"
else:
    status = "not_run"   # ← 여기로 떨어집니다
```

`amounts`가 비면 `not_run`입니다. 그런데 **금액이 비는 건 정상 동작입니다.**

`_measured_amount`는 complete가 아닌 영수증이 들고 있는 `$0`을 **일부러** `None`으로 만듭니다. 그 $0은 "공짜였다"가 아니라 "아직 확정 못 했다"는 자리표시자이기 때문입니다. 이 판단 자체는 옳고, 그대로 둡니다.

문제는 그 결과를 **상태 판정에 다시 쓴 것**입니다. 가격표에 없는 모델을 부르면 → 금액이 전부 `None` → `amounts`가 빔 → 상태가 `not_run`. **측정을 못 한 것과 아무것도 안 한 것은 다릅니다.**

### 원인 2 — `not_run` 하나가 멀쩡한 실행을 끌어내렸습니다

`complete_run = counts["complete"] == len(receipts)` 는 **모든** 영수증이 complete여야 통과합니다. 첫 모델 호출 전에 죽어서 값매길 게 없는 과제 하나가 섞이면, 나머지가 전부 완전히 값매겨졌어도 실행이 `partial`로 내려가고 `estimated_cost_usd`와 과제당 비용까지 같이 `None`이 됩니다.

**시작조차 안 한 과제는 나머지가 잘못 값매겨졌다는 증거가 아닙니다.** 반대표가 아니라 기권이어야 합니다.

---

## 새 규칙이 아니라, 이미 승인된 규칙을 옮기는 것입니다

이 저장소에는 **같은 영수증을 요약하는 구현이 셋** 있습니다.

| 요약기 | 쓰는 곳 | 규칙 |
|---|---|---|
| `scripts/cost-receipt.mjs` | 대시보드 | ✅ 맞음 — PR #270 (`bb60468`)에서 수정됨 |
| `core/cost_receipts.py` `_summary_status` | 채점 생산자 | ✅ 처음부터 맞음 |
| `core/cost_projection.py` `summarize_cost_receipts` | **추론 생산자** | ❌ **혼자 어긋나 있음** |

셋은 **같은 실행의 같은 영수증**을 요약합니다. 서로 다른 답을 내면 안 됩니다.

여기서 짚어야 할 게 하나 있습니다. **#270은 대시보드만 고쳤습니다.** (`git show --stat bb60468` → `scripts/cost-receipt.mjs`와 그 테스트, 두 파일.) 즉 대시보드는 **생산자의 버그를 화면에서 보정하고 있던 상태**였습니다. 대시보드를 안 거치는 소비자 — 리포트, parquet, self_report — 는 지금도 틀린 `not_run`을 그대로 읽습니다. 그래서 생산자를 고칩니다.

---

## 무엇을 고쳤나

`core/cost_receipts.py._summary_status`와 글자 그대로 같은 규칙입니다.

```python
contributing = [
    receipt for receipt in receipts if receipt["status"] != "not_run"
]
if not contributing:
    status = "not_run"
elif all(receipt["status"] == "complete" for receipt in contributing):
    status = "complete"
elif all(receipt["status"] == "unavailable" for receipt in contributing):
    status = "unavailable"
else:
    status = "partial"
complete_run = status == "complete"
```

- 상태는 **영수증에서** 나옵니다. 금액이 살아남았는지는 더 이상 보지 않습니다.
- `not_run` 영수증은 투표 전에 빠집니다. 하나도 안 남으면 그때가 진짜 `not_run`입니다.
- `complete_run`은 이제 상태에서 파생됩니다 — 총액과 과제당 비용을 여는 조건이 상태와 **한 군데**에서만 결정됩니다.

`_measured_amount`는 **건드리지 않았습니다.** 자리표시자 $0을 떨어뜨리는 판단은 옳습니다. 그 결과를 상태 판정에 쓰지 않을 뿐입니다.

---

## 재발 방지 테스트

`tests/test_cost_projection.py`에 2개 추가 (신규 파일 아님 — #270이 JS 쪽 테스트를 기존 파일에 넣은 것과 같은 자리).

| 테스트 | 무엇을 고정하는가 |
|---|---|
| `test_a_run_that_priced_nothing_still_reports_that_it_ran` | 전부 `partial`, 확정 금액 0건 → `partial`. **실제 스모크 `33302056462`의 모양 그대로** — 과제 1개, `generation`+`self_qa` 두 단계, `price_missing` |
| `test_a_task_that_never_ran_does_not_hole_an_otherwise_complete_run` | complete 1 + `not_run` 1 → `complete`, `estimated_cost_usd`와 과제당 비용 **살아 있음** |

두 번째 테스트는 실패한 과제가 **비용을 안 들고 왔다는 것**도 같이 확인합니다 (`failed_task_count == 1`, `failed_task_cost_usd == 0.0`). 없는 돈을 지어내지 않아야 하니까요.

### 변이(mutation) 검증

고친 줄을 원래 사다리로 되돌려서 테스트가 진짜 잡는지 확인했습니다.

| 되돌린 상태 | 결과 |
|---|---|
| 원래 사다리 | **2 failed, 61 passed** |
| 고친 상태 | **63 passed** |

되돌렸을 때 나온 실패는 이렇습니다.

```
assert 'not_run' == 'partial'    # 실제 실행 33302056462가 낸 값과 동일
assert 'partial' == 'complete'
```

첫 줄이 **운영에서 실제로 찍힌 값**입니다. 테스트가 지어낸 상황이 아니라 이미 일어난 일을 재현합니다.

**되돌린 상태에서 나머지 61개가 그대로 통과한 것도 같이 봐야 합니다.** 기존 테스트 중 **옛 동작을 고정해 둔 것이 하나도 없다**는 뜻입니다. 즉 이 변경은 기존에 합의된 어떤 기대도 뒤집지 않습니다.

---

## 기존 실행에 영향

| 확인 항목 | 결과 |
|---|---|
| 영수증이 하나도 없는 실행 | **완전히 동일** — `summarize_cost_receipts`가 `None`을 반환해 비용 키가 아예 안 붙음 |
| 이미 발행된 실행 | **영향 없음** — 재계산하지 않음 |
| 기존 테스트가 옛 동작을 고정하고 있었나 | **아니오** (위 변이 검증) |
| `core/cost_projection.py`가 채점기 소스 지문 입력인가 | ⚠️ **예** |

마지막 줄이 이 PR을 대기시키는 이유입니다. `step8_grade.py`의 `compute_grader_source_hash`는 `core_root.rglob("*")`로 **`core/` 밑의 모든 파일**을 지문에 넣습니다. 샤드가 도는 중에 main이 바뀌면 `step9_merge_shards.py` 병합 시점에 지문이 안 맞고, **그건 모든 샤드가 돈을 다 쓴 뒤에 터집니다.**

## 🤝 세션 A에게

**11샤드 Full 결과의 병합과 보존이 끝났다고 확인해 주시면** 그때 최신 main에 rebase하고 전체 테스트/CI를 다시 통과시킨 뒤 병합하겠습니다. 그 전에는 승인이 나더라도 병합하지 않습니다.

### PR #278과의 관계 — 순서 상관없이 둘 다 들어갑니다

#278도 같은 두 파일(`core/cost_projection.py`, `tests/test_cost_projection.py`)을 건드리므로 미리 확인했습니다.

| 항목 | #278 | 이 PR |
|---|---|---|
| `cost_projection.py` 변경 위치 | `_project_component` / `project_cost_receipt` (86–323행대) | `summarize_cost_receipts` (466–500행대) |
| `test_cost_projection.py` 변경 위치 | 139행대 | 435행대 |
| `summarize_cost_receipts` 건드림? | ❌ 안 함 (`complete_run`·`status =`·`not_run` 등장 횟수 0) | ✅ 이 PR의 전부 |

**겹치는 hunk가 없습니다.** 어느 쪽이 먼저 들어가도 나머지 하나는 그대로 rebase됩니다.

---

## 바뀐 파일 (2개)

```
batch-runner/core/cost_projection.py        +27 −6
batch-runner/tests/test_cost_projection.py  +92
```
