### PR TITLE
fix(cost): 값을 못 매긴 실행이 리포트 헤드라인에서 $0.0000으로 찍히던 문제

### DIFF
--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -828,6 +828,19 @@ def _build_markdown(rd: dict) -> str:
         cost = cost_summary.get(field)
         if not cost:
             continue
+        # Every other money row below arrives as None when nothing could be
+        # priced, so each renders "no record". `known_cost_usd` alone is forced
+        # to 0.0 by the producer -- it is a sum over an empty set -- which left
+        # the one row a reader takes as *the* number as the one row reading as
+        # free. The exp026c smoke (run 33302056462) made two paid model calls
+        # against a model the price table had no entry for and printed
+        # "$0.0000" here, directly beside "Not priced | price_missing".
+        #
+        # Decided off `measured_tasks`, not off the amount, because the amount
+        # cannot tell "priced, and it was free" apart from "never priced". The
+        # dashboard's summaryTotalCell already splits it on the same field; the
+        # producer's number is not touched, only how this row reads it.
+        recorded = cost["known_cost_usd"] if cost["measured_tasks"] else None
         lines += [
             f"## {label}",
             "",
@@ -836,8 +849,17 @@ def _build_markdown(rd: dict) -> str:
             "| Metric | Value |",
             "|--------|-------|",
             f"| Coverage | {cost['receipt_tasks']} / {cost['total_tasks']} tasks ({cost['coverage_pct']}%) |",
+        ]
+        # Coverage counts receipts, not amounts, so a run can be at 100% with
+        # nothing priced. Only shown when the two disagree, which leaves a
+        # fully-priced report byte-identical to what it printed before.
+        if cost["measured_tasks"] != cost["receipt_tasks"]:
+            lines.append(
+                f"| Priced | {cost['measured_tasks']} / {cost['receipt_tasks']} receipts |"
+            )
+        lines += [
             f"| Receipt status | {_COST_STATUS_LABELS[cost['status']]} |",
-            f"| {'Total' if cost['status'] == 'complete' else 'Recorded so far'} | {_cost_money(cost['known_cost_usd'])} |",
+            f"| {'Total' if cost['status'] == 'complete' else 'Recorded so far'} | {_cost_money(recorded)} |",
             f"| Average per task | {_cost_money(cost['avg_cost_usd'])} |",
             f"| Median | {_cost_money(cost['median_cost_usd'])} |",
             f"| P95 | {_cost_money(cost['p95_cost_usd'])} |",

--- a/batch-runner/tests/test_cost_projection.py
+++ b/batch-runner/tests/test_cost_projection.py
@@ -764,6 +764,58 @@ def test_markdown_says_no_record_rather_than_zero_for_an_unpriced_figure():
     markdown = step6_report._build_markdown(report)
     assert "| Average per task | no record |" in markdown
     assert "unavailable — nothing was recorded" in markdown
+    # The headline row is the one a reader takes as *the* number, so it is held
+    # to the same standard as the rows beneath it.
+    assert "| Recorded so far | no record |" in markdown
+
+
+def test_markdown_does_not_head_a_run_that_priced_nothing_with_a_zero():
+    """A run that paid for two model calls must not head its table with $0.
+
+    Run 33302056462 -- the exp026c cost smoke -- called the model twice against
+    `gpt-5.4-2026-03-05`, a snapshot the price table had no entry for. Every
+    component came back a placeholder zero, the projector nulled them all, and
+    the summariser's `known_cost_usd` fell out as a sum over an empty set: 0.0.
+
+    Every other money row in that table is None and prints "no record". This
+    one printed "$0.0000" -- the same string a genuinely free run prints -- in
+    the single row a reader reads as the answer. Two paid calls read as free,
+    directly beside "Not priced | price_missing".
+
+    Held here rather than in the producer because `known_cost_usd` is published
+    and consumed elsewhere; only how this row reads it changes.
+    """
+    unpriceable = _unmeasured("partial", missing_reasons=["price_missing"])
+    report = _report_data(_report_input(_row("task-a", problem_solving_cost=unpriceable)))
+    markdown = step6_report._build_markdown(report)
+
+    assert "| Recorded so far | no record |" in markdown
+    assert "| Recorded so far | $0.0000 |" not in markdown
+    # `Failed tasks | 0 ($0.0000)` is left alone: zero failed tasks did cost
+    # zero. Its unpriced variant -- failures whose receipts carry no amount,
+    # printing `2 ($0.0000)` -- is the same defect as this one, but the summary
+    # exposes no count of *measured* failures, so the report cannot tell the
+    # two apart without a new producer field. core/cost_projection.py is a
+    # grader source-hash input and frozen while shards are in flight.
+    # Coverage counts receipts, not amounts, so on its own it reads as a fully
+    # accounted run. The row that disambiguates it must be present.
+    assert "| Coverage | 1 / 1 tasks (100.0%) |" in markdown
+    assert "| Priced | 0 / 1 receipts |" in markdown
+    assert "| Not priced | price_missing |" in markdown
+
+
+def test_markdown_leaves_a_fully_priced_report_exactly_as_it_was():
+    """The unpriced-run fix must not add a row to reports that were already fine.
+
+    `Priced` exists to resolve a contradiction between coverage and the amounts.
+    A run with nothing to contradict must print what it printed before, so that
+    an existing experiment's report does not change because of this change.
+    """
+    report = _report_data(_report_input(_row("task-a", problem_solving_cost=_receipt())))
+    markdown = step6_report._build_markdown(report)
+
+    assert "| Total | $0.2500 |" in markdown
+    assert "| Priced |" not in markdown
 
 
 def test_markdown_omits_the_cost_section_for_an_uninstrumented_run():

--- a/scripts/__tests__/cost-receipts.browser.mjs
+++ b/scripts/__tests__/cost-receipts.browser.mjs
@@ -1,12 +1,18 @@
 /**
  * Per-task cost receipts, checked in a real browser.
  *
- * The four states this suite exists to keep apart:
+ * The five states this suite exists to keep apart:
  *
+ *   $0.0400    a recorded amount. Priced, complete, and that is the figure.
  *   $0.0000    a recorded zero. Priced, complete, and free.
  *   기록 없음   no receipt. Nobody knows what it cost. NOT zero.
  *   미확정      a receipt that could not be priced, or only partly priced.
- *   미채점      the grading never happened, so there is nothing to price.
+ *   미채점      the work never happened, so there is nothing to price. The
+ *              solve side spells the same state 미실행.
+ *
+ * The first two are one state in the code and two different claims on the
+ * page, so both are asserted: "it was free" and "it cost this much" are not
+ * interchangeable, and neither may drift into 기록 없음.
  *
  * Every fixture here is synthetic and every summary is computed by the real
  * `summarizeCostReceipts`, so the run also proves the aggregator and the
@@ -337,6 +343,44 @@ const mixedRows = () => [
   },
 ]
 
+/**
+ * The shape the exp026c cost smoke produced: paid work nobody could price.
+ *
+ * Run 33302056462 made two paid model calls against `gpt-5.4-2026-03-05`, a
+ * snapshot the price table has no entry for. Every amount came back a
+ * placeholder zero and the projector nulled all of them, exactly as it should.
+ * A run in that state has spent money and knows it; what it does not know is
+ * how much. Beside it sits a task that never started, which is the one thing
+ * here that genuinely cost nothing.
+ *
+ * No other scenario reaches this state. `mixedRows` has an unpriced receipt,
+ * but an amount still survives elsewhere in the run, so the run headline stays
+ * a number. Here nothing survives, and that is the case where a summariser
+ * reading its state off the amounts instead of the receipts gets it wrong.
+ */
+const ranButUnpricedRows = () => [
+  {
+    id: 't-paid-unpriced',
+    sector: 'Finance',
+    occupation: 'Accountant',
+    solve: receipt({
+      status: 'partial',
+      missing: ['price_missing'],
+      components: [
+        component('generation', 0, { status: 'partial' }),
+        component('self_qa', 0, { status: 'partial' }),
+      ],
+    }),
+  },
+  {
+    id: 't-never-started',
+    sector: 'Health',
+    occupation: 'Nurse',
+    status: 'error',
+    solve: receipt({ status: 'not_run' }),
+  },
+]
+
 /** A run from before cost instrumentation existed. exp003 looks like this. */
 const legacyRows = () => [
   { id: 't-complete', sector: 'Finance', occupation: 'Accountant' },
@@ -536,6 +580,46 @@ async function assertMixed(page, solveSummary) {
   assert.equal(combined.state, 'floor')
 }
 
+async function assertRanButUnpriced(page, solveSummary) {
+  await assertColumnsAndNote(page)
+
+  // Money was spent on this row and the amount is unknown.
+  const unpriced = await readCell(tableCell(page, 't-paid-unpriced', 'problem_solving_cost'))
+  assert.equal(unpriced.text, '미확정')
+  assert.equal(unpriced.state, 'unpriced')
+  assert.match(unpriced.title, /가격표에 없는 모델/)
+
+  // Nothing was spent on this one, and that is a different sentence. The two
+  // sit in the same column of the same table, so a reader who cannot tell them
+  // apart cannot tell an unpriced bill from no bill. This is also the only
+  // place a `not_run` receipt reaches the page: everywhere else 미채점 comes
+  // from a missing receipt, which is a different code path.
+  const never = await readCell(tableCell(page, 't-never-started', 'problem_solving_cost'))
+  assert.equal(never.text, '미실행')
+  assert.equal(never.state, 'never_ran')
+
+  // The regression this scenario exists for. Every amount here is null, so a
+  // summariser that reads the run's state off the amounts rather than off the
+  // receipts calls the whole run `not_run` — 미수행 — and a run that paid for
+  // two model calls reads as a run that never happened. The one receipt that
+  // truly did not run must abstain from that vote, not cast it.
+  assert.equal(solveSummary.status, 'partial')
+  assert.equal(solveSummary.measured_tasks, 0)
+  assert.equal(solveSummary.known_cost_usd, 0)
+  assert.equal(solveSummary.estimated_cost_usd, null)
+
+  const column = await summaryColumn(page, 'problem_solving_cost').innerText()
+  assert.match(column, /일부 기록됨/)
+  assert.doesNotMatch(column, /미수행/)
+  assert.match(column, /미가격 사유: 가격표에 없는 모델/)
+
+  // Nothing was priced, so the headline is not a floor either. `≥ $0.0000`
+  // would be a number, and there is no number to show.
+  const total = await readCell(summaryStat(page, 'problem_solving_cost', '총액'))
+  assert.equal(total.text, '미확정')
+  assert.equal(total.state, 'unpriced')
+}
+
 async function assertLegacy(page) {
   // Goal 8: a run from before instrumentation still shows a cost card. Hiding
   // it and zeroing it are equally easy to misread as "this was free".
@@ -620,6 +704,13 @@ async function main() {
     const mixed = scenario(mixedRows(), { experimentId, successfulDeliverables: 3 })
     await load(mixed)
     await assertMixed(page, mixed.solveSummary)
+
+    const ranUnpriced = scenario(ranButUnpricedRows(), {
+      experimentId,
+      successfulDeliverables: 1,
+    })
+    await load(ranUnpriced, { graded: false })
+    await assertRanButUnpriced(page, ranUnpriced.solveSummary)
 
     const legacy = scenario(legacyRows(), { experimentId, successfulDeliverables: 2 })
     assert.equal(legacy.solveSummary, null, 'a run with no receipts must summarise to null')


### PR DESCRIPTION
## 한 줄 요약

**돈을 쓴 실행이 리포트 표의 맨 윗줄에서 `$0.0000`으로 찍히고 있었습니다.** 그 줄을 고치고, 다섯 가지 비용 상태가 리포트와 대시보드 양쪽에서 서로 다르게 보인다는 것을 테스트로 고정합니다.

---

## 다섯 가지 비용 상태

| 상태 | 뜻 |
|---|---|
| **기록 없음** | 영수증이 없다. 얼마 썼는지 아무도 모른다. **$0이 아니다** |
| **미확정** | 영수증은 있는데 값을 못 매겼다 |
| **미실행 / 미채점** | 애초에 일이 안 일어났다. 값매길 게 없다 |
| **실제 $0** | 값을 매겼고, 공짜였다 |
| **숫자** | 값을 매겼고, 그게 금액이다 |

가운데 셋은 겉보기에 다 "0"으로 보입니다. **그래서 굳이 나눠 놓은 것입니다.**

---

## 무엇이 깨져 있었나 — 리포트

exp026c 비용 스모크(`33302056462`)의 영수증을 **실제 리포트 생성 코드**(`step6_report._build_markdown`)에 그대로 넣어 봤습니다.

```
| Coverage | 1 / 1 tasks (100.0%) |     ← 100% 커버리지
| Receipt status | not run |
| Recorded so far | $0.0000 |           ← ❌ 여기
| Average per task | no record |
| Median | no record |
| P95 | no record |
| Max | no record |
| Per successful deliverable | no record |
| Not priced | price_missing |          ← 값을 못 매겼다고 바로 아래 적혀 있음
```

**유료 호출을 두 번 한 실행입니다.** 그런데 사람이 "금액"으로 읽는 그 한 줄이 `$0.0000`입니다. 공짜 실행이 찍는 문자열과 **글자 하나 다르지 않습니다.**

나머지 여섯 개 금액 줄은 전부 `no record`로 정직하게 나옵니다. **틀린 줄은 딱 하나**, 하필 제일 눈에 띄는 줄입니다.

### 원인

`known_cost_usd`는 **빈 집합의 합**입니다.

```python
known_total = round(sum(amounts), _MONEY_DIGITS) if amounts else 0.0
```

값을 하나도 못 매기면 `amounts`가 비고, 생산자는 여기에 `0.0`을 넣습니다. 나머지 금액 필드(`avg`, `median`, `p95`, `max`, `per_deliverable`)는 같은 상황에서 전부 `None`이 되고, `_cost_money(None)`이 `"no record"`를 돌려줍니다. **`known_cost_usd`만 숫자로 남아서** 그대로 `$0.0000`이 됩니다.

이 저장소는 이 함정을 **이미 알고 있었습니다.** `_cost_money`의 docstring이 "`not recorded`를 `$0`과 눈에 띄게 구분한다"이고, 테스트 헬퍼 `_unmeasured`의 docstring은 아예 **"자리표시자 0이 화면에 `$0.0000`으로 도달한다"**고 적어 뒀습니다. 다만 그 방어가 **과제별 칸에만** 들어갔고 실행 전체 헤드라인에는 안 들어갔습니다.

---

## 무엇을 고쳤나

### ① 헤드라인은 아무것도 값매기지 못했으면 숫자가 아닙니다

```python
recorded = cost["known_cost_usd"] if cost["measured_tasks"] else None
```

- **금액이 아니라 `measured_tasks`로 판정합니다.** 금액만 봐서는 "값매겼는데 공짜"와 "값을 못 매김"을 구분할 수 없습니다.
- **대시보드가 이미 같은 방식으로 갈라 놓았습니다** (`src/lib/cost.ts`의 `summaryTotalCell`). 새 규칙이 아니라 두 화면을 같은 규칙에 맞추는 것입니다.
- **생산자 숫자는 안 건드립니다.** `known_cost_usd`는 발행되고 다른 곳에서도 읽히므로, 이 줄이 그걸 **어떻게 읽는지**만 바꿉니다.

### ② `Coverage 100%`가 혼자서는 거짓말을 합니다

`Coverage`는 **영수증 개수**를 셉니다. 금액이 아닙니다. 그래서 아무것도 값매기지 못한 실행이 `100.0%`로 나옵니다.

```
| Coverage | 1 / 1 tasks (100.0%) |
| Priced | 0 / 1 receipts |          ← 추가
```

**두 수가 어긋날 때만 나옵니다.** 전부 값매겨진 리포트는 **바이트 단위로 이전과 동일**합니다 — 기존 실험의 리포트가 이 변경 때문에 달라지지 않습니다.

### 고친 뒤

```
| Coverage | 1 / 1 tasks (100.0%) |
| Priced | 0 / 1 receipts |
| Receipt status | not run |
| Recorded so far | no record |
| Not priced | price_missing |
```

---

## 대시보드 쪽 — 브라우저 테스트에 빠져 있던 두 가지

`scripts/__tests__/cost-receipts.browser.mjs`는 네 가지 상태만 세고 있었고, 실제로 **두 경로가 한 번도 화면에 안 그려지고 있었습니다.**

새 시나리오 `ranButUnpricedRows`는 **exp026c가 실제로 만든 모양**입니다 — 값 못 매긴 유료 과제 하나 + 시작조차 안 한 과제 하나.

| 새로 덮은 것 | 왜 필요한가 |
|---|---|
| `미실행` 칸 | `not_run` 영수증이 화면에 도달하는 **유일한** 경로. 다른 데서 나오는 `미채점`은 "영수증이 없다"는 **다른 코드 경로**입니다 |
| 전부 partial인 실행의 요약 | 금액이 전부 `null`이라 요약이 `not_run`으로 추락하는 자리 |

기존 `mixedRows`에도 값 못 매긴 영수증이 있지만 **다른 과제에 금액이 살아남아서** 실행 헤드라인이 숫자로 유지됩니다. 전부 죽는 경우는 여기뿐이고, 요약기가 **영수증이 아니라 금액에서** 상태를 유도하면 바로 여기서 틀립니다.

---

## 변이(mutation) 검증 — 세 층에서 각각 실패시켜 봤습니다

### 리포트 (이 PR)

| 되돌린 상태 | 결과 |
|---|---|
| 헤드라인을 `known_cost_usd` 직접 읽기로 복원 | **2 failed, 61 passed** |
| 고친 상태 | **63 passed** |

**61개가 그대로 통과한 것도 같이 봐야 합니다.** 기존 테스트 중 **옛 동작을 고정해 둔 것이 하나도 없다**는 뜻입니다. 즉 이 변경은 기존에 합의된 어떤 기대도 뒤집지 않습니다.

### 대시보드 (객체 층)

`scripts/cost-receipt.mjs`를 #270 이전 사다리로 되돌리자:

```
AssertionError: + 'not_run'  - 'partial'
```

**실행 33302056462가 실제로 낸 값과 같습니다.** 그리고 이 실패는 **세 번째 시나리오에서** 나왔습니다 — `fullyPriced`와 `mixed`는 되돌린 상태에서도 통과했습니다. **기존 시나리오가 이 경우를 못 덮고 있었다는 증거입니다.**

### 대시보드 (DOM 층)

객체 단언만 잠시 꺼 두자, 페이지 자체가 이렇게 그려졌습니다:

```
문제 풀이 비용 / 미수행 / 총액 / 미확정 / 평균 / 기록 없음
```

**유료 호출 두 번을 한 실행의 헤드라인이 "미수행"입니다.**

---

## 범위 밖으로 남긴 것 (같은 결함 종류)

```
| Failed tasks | 2 ($0.0000) |
```

실패한 과제의 영수증에 금액이 없으면 이 줄도 똑같이 `$0.0000`으로 찍힙니다. **고치지 않았습니다** — 요약 dict에 *값매겨진 실패 과제 수*가 없어서 리포트만으로는 "정말 $0"과 "모름"을 구분할 수 없고, 그 필드를 추가하려면 **`core/cost_projection.py`를 건드려야 하는데 지금 얼어 있습니다.**

실패 과제가 0개일 때는 `$0.0000`이 참이라서 지금 당장 틀린 건 아닙니다. 테스트에 이 판단을 주석으로 남겨 뒀고, 별도 항목으로 큐에 넣었습니다.

---

## 기존 실행에 영향

| 확인 항목 | 결과 |
|---|---|
| 전부 값매겨진 리포트 | **바이트 단위 동일** — `Priced` 줄이 안 붙습니다 (테스트로 고정) |
| 영수증 없는 실행 | **완전히 동일** — 비용 섹션 자체가 안 나옵니다 |
| 생산자 숫자(`known_cost_usd`) | **안 건드림** — 읽는 방식만 바뀜 |
| 이미 발행된 실행 | **영향 없음** — 재계산하지 않음 |
| 기존 테스트가 옛 동작을 고정하고 있었나 | **아니오** (위 변이 검증) |

## 두 관문 — 어디에도 안 들어갑니다

| 파일 | 비싼 관문(`grader_source_hash`) | 싼 관문(`GRADING_INPUT_PATHS`) |
|---|---|---|
| `batch-runner/step6_report.py` | ❌ | ❌ |
| `batch-runner/tests/test_cost_projection.py` | ❌ (`core/` 아래 아님) | ❌ (`batch-runner/tests` 목록에 없음) |
| `scripts/__tests__/cost-receipts.browser.mjs` | ❌ | ❌ (목록은 **`batch-runner/scripts`**, 루트 `scripts/`가 아님) |

`step8_grade.py`와 `grade-run.yml`에서 `step6_report` 문자열은 **0회** 등장합니다. **진행 중인 채점에 영향을 줄 수 없습니다** — PR #283과 같은 조건입니다.

## 검증

| 항목 | 결과 |
|---|---|
| `pytest` (batch-runner 전체) | 아래 CI |
| `npm run test:aggregate` | **179 tests, 0 fail** |
| `npm run test:cost-browser:dist` | **exit 0** |
| `npx tsc --noEmit` | **exit 0** |
| `npm run build` | **exit 0** |

## 바뀐 파일 (3개)

```
batch-runner/step6_report.py                 +24  −3
batch-runner/tests/test_cost_projection.py   +52
scripts/__tests__/cost-receipts.browser.mjs  +93  −2
```
