### PR TITLE
fix(cost): 배포가 실제로 돌려주는 스냅샷 모델에 값을 매기지 못하던 문제

### DIFF
--- a/batch-runner/experiments/execution_envelope/model_price_table.json
+++ b/batch-runner/experiments/execution_envelope/model_price_table.json
@@ -59,8 +59,32 @@
       "zone": "global",
       "context_tier": "under 272k",
       "premises": [
-        "The deployment is a Global one, not a Data Zone one. Nothing in this repository or in any published artifact records the deployment's zone, so this is stated rather than proven. If it is a Data Zone deployment the correct meters are 3.00 input, 0.30 cached input, 16.50 output.",
+        "The deployment is a Global one, not a Data Zone one. Nothing in this repository or in any published artifact records the deployment's zone, so this is stated rather than proven. If it is a Data Zone deployment the correct meters depend on the region, because Azure publishes two Data Zone price points for 5.4: 2.75 input, 0.275 cached input, 16.50 output across 14 US and European regions, and 3.00 input, 0.30 cached input, 18.00 output across 9 Asia-Pacific regions. Both are 1.1x and 1.2x Global respectively. See azure_published_meters.gpt-5.4.",
         "No single request sends more than 272,000 input tokens. Azure prices 5.4 in two context tiers split at that figure, and the receipt records tokens per task rather than per call, so this cannot be read off the receipt. It CAN be read off the per-call cost ledger, which the inference workflow does publish. If a request crosses 272k the correct meters are 5.00 input, 0.50 cached input, 22.50 output."
+      ]
+    },
+    "azure:gpt-5.4-2026-03-05": {
+      "input_usd_per_million": "2.50",
+      "cached_input_usd_per_million": "0.25",
+      "output_usd_per_million": "15.00",
+      "reasoning_billed_as": "output",
+      "source": "https://prices.azure.com/api/retail/prices — meters '5.4 inp Gl 1M Tokens', '5.4 cd inp Gl 1M Tokens', '5.4 opt Gl 1M Tokens'; productName 'Azure OpenAI GPT5', type Consumption",
+      "last_reviewed": "2026-08-30",
+      "currency": "USD",
+      "unit": "per 1,000,000 tokens",
+      "meters": {
+        "input": "5.4 inp Gl 1M Tokens",
+        "cached_input": "5.4 cd inp Gl 1M Tokens",
+        "output": "5.4 opt Gl 1M Tokens"
+      },
+      "tier": "standard",
+      "zone": "global",
+      "context_tier": "under 272k",
+      "resolved_snapshot_of": "gpt-5.4",
+      "why_this_key_exists": "A request for deployment 'gpt-5.4' comes back naming 'gpt-5.4-2026-03-05', and lookup is exact — core/cost_receipts.py prices on the model the reply reports, with no prefix match and no nearest neighbour. Without this key the snapshot is price_missing. Run 33302056462 is that exact failure: two paid calls, both unpriceable, receipt partial.",
+      "why_the_family_meter_is_the_right_one": "Not assumed from the name. Azure publishes 76 meters in the 5.4 family (retrieved 2026-08-30, productName 'Azure OpenAI GPT5', all 8 pages) and not one of them carries a date. That absence is only meaningful because the same product DOES carry dated meters where a snapshot is billed separately: 18 of them, all 'chat-latest', e.g. 'chat-latest 08062026 inp Gl 1M Tokens'. So Azure expresses snapshot-specific pricing when it exists, and expresses none for 5.4. The family meter is therefore not a substitute for a snapshot meter — it is the only published meter a 5.4 snapshot call can bill against. Re-check with one query: $filter=productName eq 'Azure OpenAI GPT5', then look for a 5.4 meter containing a year.",
+      "premises": [
+        "Same two premises as azure:gpt-5.4, which this key bills identically to. See that entry."
       ]
     },
     "azure:gpt-5.4-mini": {
@@ -113,9 +137,9 @@
     "axes_open": {
       "zone": {
         "status": "unresolved",
-        "spread": "Data Zone is 1.1x to 1.2x Global depending on the rate kind.",
+        "spread": "Data Zone is 1.1x to 1.2x Global depending on the rate kind. Quantified 2026-08-30 for 5.4: Global is 2.50 / 0.25 / 15.00 uniformly across all 25 regions; Data Zone is 2.75 / 0.275 / 16.50 in 14 AMER and EMEA regions (a flat 1.1x) and 3.00 / 0.30 / 18.00 in 9 APAC regions (a flat 1.2x). So the answer moves by 10% or 20%, and which of the two depends on the region as well as the zone.",
         "why_it_cannot_be_read": "Global versus Data Zone is a property of the deployment, chosen when the deployment was created. It is not in the response, not in the config, and not in any published artifact. azure_ai_routes.endpoint_kind ('direct-v1') describes the shape of the API surface, not the zone. core/config.py holds no region or zone token at all.",
-        "what_would_settle_it": "One statement from whoever owns the deployment, or recording the deployment's SKU alongside the resolved model at call time.",
+        "what_would_settle_it": "One statement from whoever owns the deployment naming its zone and its region, or recording the deployment's SKU and region alongside the resolved model at call time. The region is needed as well as the zone, because Data Zone is not one price.",
         "handling": "Stated as a premise on each entry rather than left silent, because a receipt that is 10% wrong AND says which way is a smaller problem than one that is 10% wrong and says nothing."
       },
       "context_tier": {
@@ -152,17 +176,21 @@
   "azure_published_meters": {
     "why_this_block_exists": "The rates actually in use are a small selection out of a large published matrix. Recording the whole matrix means a reviewer can check not only that a chosen rate is real, but that the right one was chosen — and it means the alternatives are already here when a premise turns out to be wrong.",
     "retrieved": "2026-08-29",
+    "re_verified": "2026-08-30, by re-fetching all 8 pages of productName 'Azure OpenAI GPT5' (7,235 rows) and pairing each rate kind per armRegionName rather than reading rate kinds independently. Rows re-checked and confirmed exact: every gpt-5.4 Global row, both gpt-5.4 long-context Global rows, priority Global and Data Zone, batch Global and Data Zone, all of gpt-5.4-mini, gpt-5.4-nano, and gpt-5.4-pro. Rows re-checked and found wrong: the two gpt-5.4 standard Data Zone rows, now corrected and split — see data_zone_is_two_price_points_not_one. Rows NOT re-checked in this pass: execution_environment and audio, which are separate products and were left as retrieved on 2026-08-29.",
     "currency": "USD",
     "unit": "per 1,000,000 tokens unless stated otherwise",
     "gpt-5.4": {
       "standard_global": {"input": "2.50", "cached_input": "0.25", "output": "15.00"},
-      "standard_data_zone": {"input": "3.00", "cached_input": "0.30", "output": "16.50"},
+      "standard_data_zone_amer_emea": {"input": "2.75", "cached_input": "0.275", "output": "16.50"},
+      "standard_data_zone_apac": {"input": "3.00", "cached_input": "0.30", "output": "18.00"},
       "standard_global_long_context": {"input": "5.00", "cached_input": "0.50", "output": "22.50"},
-      "standard_data_zone_long_context": {"input": "6.00", "cached_input": "0.60", "output": "24.75"},
+      "standard_data_zone_long_context_amer_emea": {"input": "5.50", "cached_input": "0.55", "output": "24.75"},
+      "standard_data_zone_long_context_apac": {"input": "6.00", "cached_input": "0.60", "output": "27.00"},
       "priority_global": {"input": "5.00", "cached_input": "0.50", "output": "30.00"},
       "priority_data_zone": {"input": "5.50", "cached_input": "0.55", "output": "33.00"},
       "batch_global": {"input": "1.25", "cached_input": "0.13", "output": "7.50"},
-      "batch_data_zone": {"input": "1.375", "cached_input": "0.143", "output": "8.25"}
+      "batch_data_zone": {"input": "1.375", "cached_input": "0.143", "output": "8.25"},
+      "data_zone_is_two_price_points_not_one": "Corrected 2026-08-30. Azure prices a 5.4 Data Zone deployment differently depending on which region it sits in, and the two rows recorded here before this correction each combined the input and cached-input of one group with the output of the other, producing a pair of rates no region actually bills. The groups, read off armRegionName: AMER/EMEA (centralus, eastus, eastus2, francecentral, germanywestcentral, northcentralus, northeurope, polandcentral, southcentralus, spaincentral, swedencentral, westeurope, westus, westus3) and APAC (australiaeast, centralindia, eastasia, japaneast, japanwest, jioindiawest, koreacentral, southeastasia, southindia). Global is uniform at one price across all 25 regions, which is why no Global row needs splitting. Nothing in this repository billed at either Data Zone rate — every priced entry is Global — so no published figure changes. What changes is the fallback a reader would apply if the open zone premise resolves to Data Zone."
     },
     "gpt-5.4-mini": {
       "standard_global": {"input": "0.75", "cached_input": "0.075", "output": "4.50"}

--- a/batch-runner/tests/test_receipt_prices_match_the_published_meters.py
+++ b/batch-runner/tests/test_receipt_prices_match_the_published_meters.py
@@ -67,6 +67,14 @@ PUBLISHED_METERS = {
         "cached_input": Decimal("0.25"),
         "output": Decimal("15.00"),
     },
+    # The snapshot a request for deployment "gpt-5.4" actually resolves to. It
+    # bills on the family meters above, because Azure publishes no dated meter
+    # for 5.4 at all -- see test_a_5_4_snapshot_has_no_meter_of_its_own.
+    "azure:gpt-5.4-2026-03-05": {
+        "input": Decimal("2.50"),
+        "cached_input": Decimal("0.25"),
+        "output": Decimal("15.00"),
+    },
     "azure:gpt-5.4-mini": {
         "input": Decimal("0.75"),
         "cached_input": Decimal("0.075"),
@@ -249,6 +257,105 @@ def test_the_models_we_refuse_to_guess_at_stay_absent(table, model):
     entry = raw["models_deliberately_not_priced"][f"azure:{model}"]
     assert entry["why_unpriced"].strip()
     assert entry["what_would_settle_it"].strip()
+
+
+def test_the_resolved_snapshot_is_priceable_and_prices_as_its_family(table):
+    """A request for 'gpt-5.4' comes back naming a snapshot, and lookup is exact.
+
+    Run 33302056462 -- the exp026c cost smoke -- asked for deployment
+    ``gpt-5.4``, and the reply named ``gpt-5.4-2026-03-05``. Pricing reads the
+    model the *reply* reports, and ``ReceiptPriceTable.lookup`` matches the whole
+    string with no prefix rule, so the snapshot fell through to
+    ``price_missing`` and two paid calls produced no figure.
+
+    The fix is a key, not a rule. Stripping a date suffix in code would make the
+    table silently price any future snapshot off its family, which is exactly
+    the nearest-neighbour behaviour the table exists to refuse.
+    """
+    family = table.lookup("azure", "gpt-5.4")
+    snapshot = table.lookup("azure", "gpt-5.4-2026-03-05")
+    assert snapshot is not None, "the snapshot the deployment resolves to must be priceable"
+    assert (
+        snapshot.input_usd_per_million,
+        snapshot.cached_input_usd_per_million,
+        snapshot.output_usd_per_million,
+        snapshot.reasoning_billed_as,
+    ) == (
+        family.input_usd_per_million,
+        family.cached_input_usd_per_million,
+        family.output_usd_per_million,
+        family.reasoning_billed_as,
+    )
+    # Still exact-match: a neighbouring snapshot nobody has evidence for stays
+    # unpriced rather than inheriting these rates.
+    assert table.lookup("azure", "gpt-5.4-2026-03-06") is None
+    assert table.lookup("azure", "gpt-5.4-2027-01-01") is None
+
+
+def test_a_5_4_snapshot_has_no_meter_of_its_own(table):
+    """The snapshot key is evidence-backed, not a convenience alias.
+
+    Azure publishes 76 meters in the 5.4 family and none of them carries a date.
+    That absence only means something because the same product does carry dated
+    meters where a snapshot bills separately -- 18 of them, all ``chat-latest``.
+    So the family meter is not a substitute for a snapshot meter; it is the only
+    published meter a 5.4 snapshot call can bill against.
+
+    Asserted on the recorded reasoning rather than by calling the API, because a
+    test that reaches the network would fail for reasons that have nothing to do
+    with this repository. The query that re-checks it is written in the entry.
+    """
+    raw = json.loads(PRICE_TABLE_PATH.read_text(encoding="utf-8"))
+    entry = raw["providers"]["azure:gpt-5.4-2026-03-05"]
+    assert entry["resolved_snapshot_of"] == "gpt-5.4"
+    assert entry["why_this_key_exists"].strip()
+    assert "chat-latest" in entry["why_the_family_meter_is_the_right_one"]
+    # The meters named must be the family's, not invented snapshot-shaped ones.
+    assert entry["meters"] == raw["providers"]["azure:gpt-5.4"]["meters"]
+
+
+def test_data_zone_is_recorded_as_two_price_points(table):
+    """Each Data Zone row must be a pairing some region actually bills.
+
+    Before 2026-08-30 this block held one 5.4 Data Zone row reading 3.00 input /
+    0.30 cached / 16.50 output. Azure publishes two Data Zone price points for
+    5.4 -- 2.75 / 0.275 / 16.50 across 14 AMER and EMEA regions, and 3.00 / 0.30
+    / 18.00 across 9 APAC regions -- and that row took its input from one group
+    and its output from the other. No region bills that combination.
+
+    It changed no published figure, because every priced entry here is Global
+    and every Global rate re-verified exact. It is the fallback a reader would
+    apply the moment the open zone premise resolves, which is the one time a
+    wrong alternative does damage.
+    """
+    meters = json.loads(PRICE_TABLE_PATH.read_text(encoding="utf-8"))["azure_published_meters"]
+    rows = meters["gpt-5.4"]
+    assert "standard_data_zone" not in rows, "the mixed row must not come back"
+    assert rows["standard_data_zone_amer_emea"] == {
+        "input": "2.75",
+        "cached_input": "0.275",
+        "output": "16.50",
+    }
+    assert rows["standard_data_zone_apac"] == {
+        "input": "3.00",
+        "cached_input": "0.30",
+        "output": "18.00",
+    }
+    # Both Data Zone groups are a flat multiple of Global. A row that is not a
+    # flat multiple is the signature of the defect this test was written for.
+    glob = rows["standard_global"]
+    for row, factor in (
+        (rows["standard_data_zone_amer_emea"], Decimal("1.1")),
+        (rows["standard_data_zone_apac"], Decimal("1.2")),
+    ):
+        for kind in ("input", "cached_input", "output"):
+            assert Decimal(row[kind]) == Decimal(glob[kind]) * factor, kind
+    # The live entries are Global, so nothing above is what anything was billed
+    # at. Guard that, so a future edit cannot quietly move an entry to a zone.
+    for key, entry in json.loads(
+        PRICE_TABLE_PATH.read_text(encoding="utf-8")
+    )["providers"].items():
+        assert entry["zone"] == "global", key
 
 
 def test_the_runtime_block_is_empty_and_says_why():


### PR DESCRIPTION
## 한 줄 요약

**유료 호출을 두 번 한 스모크가 금액을 하나도 못 냈습니다.** 요금표에 키가 하나 없어서입니다. 그 키를 근거와 함께 추가하고, 확인하다 발견한 별개의 요금 오기(誤記)를 같이 고칩니다.

---

## 무엇이 깨져 있었나

exp026c 비용 스모크(**실행 `33302056462`**)는 배포 이름 `gpt-5.4`로 요청했습니다. 그런데 응답이 돌려준 자기 이름은 **`gpt-5.4-2026-03-05`** — 날짜가 붙은 스냅샷입니다.

값매김은 **응답이 말하는 모델**을 읽습니다.

```python
# core/cost_receipts.py:962
model = str(resolved_model or row["requested_model"] or "")
```

그리고 조회는 **완전 일치**입니다.

```python
# core/cost_receipts.py:232
return self.models.get(f"{provider}:{model}")
```

접두사 매칭도, 최근접 이웃도 없습니다. 그래서 `azure:gpt-5.4-2026-03-05`는 표에 없는 키가 되고, 두 번의 유료 호출이 전부 `price_missing`으로 떨어졌습니다. 영수증은 `partial`.

---

## 왜 코드가 아니라 키로 고쳤나

날짜 접미사를 코드에서 떼어내는 방법도 있습니다. **일부러 안 했습니다.**

그렇게 하면 앞으로 나올 **모든** 스냅샷이 아무 근거 없이 제 family 요금으로 조용히 값매겨집니다. 그건 이 요금표가 존재하는 이유 — **"근거 없는 최근접 이웃 금지"** — 를 정면으로 뒤집는 것입니다.

키를 추가하면 근거가 있는 스냅샷만 값이 매겨지고, 근거가 없는 것은 지금처럼 **값이 안 매겨진 채로 남습니다.** 테스트가 이걸 고정합니다.

```python
assert table.lookup("azure", "gpt-5.4-2026-03-06") is None
assert table.lookup("azure", "gpt-5.4-2027-01-01") is None
```

---

## family 요금이 맞다는 근거 — 이름에서 추측한 게 아닙니다

Azure 소매가 API의 `productName eq 'Azure OpenAI GPT5'` **전체**를 다시 받았습니다. 2026-08-30, 8페이지, **7,235행.**

| 확인한 것 | 수 |
|---|---|
| 5.4 family 미터 | **76개** |
| 그중 **날짜가 붙은** 것 | **0개** |
| 같은 제품에서 날짜가 붙은 미터 | **18개 — 전부 `chat-latest`** |

세 번째 줄이 핵심입니다. 없다는 사실만으로는 아무것도 증명 못 합니다. 하지만 **같은 제품이 스냅샷을 따로 과금할 때는 날짜 미터를 실제로 발행합니다** (예: `chat-latest 08062026 inp Gl 1M Tokens`). 그런데 5.4에 대해서는 하나도 발행하지 않습니다.

즉 Azure는 **스냅샷 요금이 따로 있으면 그걸 표현합니다.** 5.4에 대해서는 표현하지 않습니다. 그러므로 family 미터는 스냅샷 미터의 **대용품이 아니라, 5.4 스냅샷 호출이 과금될 수 있는 유일한 공표 미터**입니다.

재확인은 질의 한 번입니다 — 파일에 그 질의를 적어 뒀습니다.

---

## 확인하다 발견한 별개의 결함 — 실재하지 않는 요금 조합

rate kind를 각각 따로 읽지 않고 **`armRegionName`별로 짝지어** 보니, 기존 Data Zone 두 행이 **어느 지역도 과금하지 않는 조합**이었습니다.

| 행 | 기존 기록 | 실제 |
|---|---|---|
| `standard_data_zone` | 3.00 / 0.30 / **16.50** | 어느 지역도 이 조합으로 안 냅니다 |
| `standard_data_zone_long_context` | 6.00 / 0.60 / **24.75** | 〃 |

각각 **한 지역군의 input·cached input**과 **다른 지역군의 output**을 섞은 값입니다.

실제 짝은 이렇습니다.

| 지역군 | 표준 | 장문맥 | Global 대비 |
|---|---|---|---|
| **AMER/EMEA** (14개 지역) | 2.75 / 0.275 / 16.50 | 5.50 / 0.55 / 24.75 | 정확히 **1.1배** |
| **APAC** (9개 지역) | 3.00 / 0.30 / 18.00 | 6.00 / 0.60 / 27.00 | 정확히 **1.2배** |

행을 지역군별로 쪼개고 **지역 목록을 그대로 기록**했습니다. 테스트가 "섞인 행이 다시 돌아오지 않는다"와 "각 행이 Global의 딱 떨어지는 배수다"를 둘 다 검사합니다 — 배수가 안 맞는 행이 바로 이 결함의 지문이기 때문입니다.

---

## 기존 실험에 영향 — 없습니다

| 확인 항목 | 결과 |
|---|---|
| 살아 있는 `providers` 항목의 zone | **전부 `global`** (테스트로 고정) |
| Global 행 재확인 | **전부 정확** — 2.50 / 0.25 / 15.00, 25개 지역 균일 |
| 이미 발행된 금액 | **하나도 안 바뀜** |
| 무엇이 바뀌나 | 열린 zone 전제가 Data Zone으로 **판명될 경우** 독자가 적용할 대체값 |

Global이 25개 지역에서 균일하다는 것도 이번에 확인했습니다. 그래서 Global 행은 쪼갤 필요가 없습니다.

**재확인한 행 / 안 한 행을 구분해 적었습니다.** 안 본 것(`execution_environment`, `audio`)은 별개 제품이라 "이번에 안 봤다"고 명시했습니다 — 본 것처럼 보이게 두지 않았습니다.

---

## 열려 있던 질문이 이제 한 줄로 닫힙니다

zone 전제는 여전히 미해결이지만, **얼마나 틀릴 수 있는지가 숫자로 확정**됐습니다.

- Global: **2.50 / 0.25 / 15.00** (25개 지역 균일)
- Data Zone AMER/EMEA: **+10%**
- Data Zone APAC: **+20%**

그리고 `what_would_settle_it`을 고쳤습니다. 전에는 "zone만 알려 주면 된다"였는데, **Data Zone이 한 가격이 아니므로 region도 필요합니다.**

---

## 변이(mutation) 검증

새 테스트가 정말 무언가를 잡는지, 고친 것을 되돌려 놓고 확인했습니다.

| 되돌린 상태 | 결과 |
|---|---|
| 스냅샷 키 제거 (이 PR 이전 상태) | **3 failed, 25 passed** |
| 섞인 Data Zone 행 복원 | **1 failed, 27 passed** — `AssertionError: the mixed row must not come back` |
| 고친 상태 | **28 passed** |

---

## 두 관문

| 파일 | 비싼 관문(`grader_source_hash`) | 싼 관문(`GRADING_INPUT_PATHS`) |
|---|---|---|
| `batch-runner/experiments/execution_envelope/model_price_table.json` | ❌ (`core/` 아래 `.py`만 해시) | ✅ |
| `batch-runner/tests/test_receipt_prices_match_the_published_meters.py` | ❌ | ❌ |

**싼 관문은 이미 걸려 있습니다** — #281/#282 병합으로 이미 재발행이 필요한 상태입니다. 이 PR이 **새로 유발하는 재발행은 없습니다.** 비싼 관문에는 안 들어가므로 진행 중인 채점의 소스 지문은 바뀌지 않습니다.

---

## 바뀐 파일 (2개)

```
batch-runner/experiments/execution_envelope/model_price_table.json   +40  −6
batch-runner/tests/test_receipt_prices_match_the_published_meters.py +107
```
