### PR TITLE
feat(grading): 숫자로 정산되는 gpt-5.4 1과제 채점 비용 스모크 설정 (병합 대기)

### DIFF
--- a/batch-runner/grading_configs/cost_smoke_exp026c_v2_gpt54.yaml
+++ b/batch-runner/grading_configs/cost_smoke_exp026c_v2_gpt54.yaml
@@ -1,0 +1,196 @@
+schema_version: "2.0"
+config_name: "cost_smoke_exp026c_v2_gpt54"
+description: |
+  The one-task grading smoke whose receipt settles to a NUMBER.
+
+  Purpose: the problem-solving half of the cost ledger now produces a real
+  figure (exp026c run 33308053974 -> $0.285513, status `complete`). This config
+  is the grading half's equivalent: the smallest run that proves a grading
+  receipt can reach `complete` rather than `partial`, end to end, on real data.
+
+  Runtime semantics are default_v2's -- same judge family and reasoning effort,
+  same tool ops and caps, same critical rule, same scoring, same prompts, same
+  rate-limit guard. Three things differ, each of them required to make the
+  receipt settle:
+
+    1. `rerun_identity` pins the corpus, the rubric commit and the inference
+       revision, so the run's identity is checkable afterwards. default_v2 pins
+       none of them.
+    2. `rubric.revision` is a commit SHA, not `"main"`. An unpinned rubric makes
+       the same config grade a different corpus tomorrow, which would make any
+       cost number unreproducible.
+    3. Every model-bearing block carries an explicit `deployment`. default_v2
+       sets `deployment` on the judge but omits it on both perception
+       sub-judges, so those two calls' identity was never recorded.
+
+  ── Why every billable call here is priceable ─────────────────────────────
+  Pricing looks up `provider:resolved_model` on an EXACT match
+  (core/cost_receipts.py:232) against the `providers` block of
+  experiments/execution_envelope/model_price_table.json. As of PR #286 the
+  priced Azure keys are: gpt-5.4, gpt-5.4-2026-03-05, gpt-5.4-mini,
+  gpt-5.4-nano.
+
+  Deployment `gpt-5.4` answers with resolved model `gpt-5.4-2026-03-05` -- the
+  snapshot that PR #286 added a key for, verified on real ledger rows from run
+  33308053974 (6/6 rows priced, zero `price_missing`). Both the judge and the
+  visual perception sub-judge therefore bill against a priced key.
+
+  ── The one unpriced path, and why it stays ───────────────────────────────
+  `perception.audio.model` is gpt-audio-1.5, which is deliberately NOT priced
+  (models_deliberately_not_priced). It is kept, unchanged from default_v2,
+  because removing it would change routing semantics rather than cost.
+
+  It never fires on this corpus. The single pinned task routes exactly one
+  criterion to perception, and that criterion is VISUAL. Checked across five
+  independent published grade files for this same task_id:
+
+      rubric item a64588ed-db04-4b8b-b3b8-3674ddcf10d1
+        routing_modality: visual   (5 of 5 runs)
+        perception_call_count: 1   (5 of 5 runs)
+      audio-routed items: 0        (5 of 5 runs)
+
+  Routing is decided from the rubric criterion, which is a property of the
+  task, not of the deliverable -- so this holds for exp026c's deliverable too.
+
+  If audio ever did fire, the receipt would go `partial` with reason
+  `price_missing` rather than guess a rate. That is the intended fail-closed
+  behaviour, not a gap to paper over.
+
+  ── This config alone does NOT fork into _diagnostic/ ─────────────────────
+  step8_grade.py:1231 classes a pinned selection as `complete` when it covers
+  the whole source corpus, and only `subset` forks the output. exp026c's corpus
+  IS one task, so the pin here is `complete` -- the grade would land on the
+  published dashboard path.
+
+  That is not what this run is for. To force the diagnostic fork, dispatch with
+  `tasks_limit: 1`. It satisfies the pinned-selection guard (which permits 0 or
+  exactly len(task_ids)) and sets `diagnostic_run` via step8_grade.py:1932, so
+  the output goes to `_diagnostic/<scope_sha>/` and the public path is
+  untouched. No workflow edit is needed -- `tasks_limit` is already a
+  workflow_dispatch input on grade-run.yml.
+
+  ── Expected spend, measured rather than guessed ──────────────────────────
+  Summed judge + perception tokens for this exact task_id from five published
+  grade files, repriced at gpt-5.4 rates (2.50 / 0.25 / 15.00 per million):
+
+      config                       calls    input     cached    output    USD
+      default_v2_mini              127+1   2834829    913152    43822   $5.69
+      validation_v2_mini_cohort10  137+1   3088707    975104    46096   $6.22
+      validation_v2_mini_cohort3   136+1   3193116   1075712    47667   $6.28
+      regrade_v2_sol_max (a)       116+1   4216415   1705874    56192   $7.55
+      regrade_v2_sol_max (b)       111+1   4022367   1507061    55560   $7.50
+
+  Treat ~$7.55 as the ceiling and expect materially less. Those runs graded
+  exp003's deliverable for this task; exp026c's deliverable is a minimal
+  Sample.xlsx with 488 characters of deliverable text, and per-call input is
+  dominated by deliverable content. The rubric (38 items) and task prompt are
+  identical, so the call COUNT should be comparable while the token count
+  should not.
+
+  The headline this buys: grading one task costs roughly 20x what solving it
+  did ($0.285513). That ratio is itself a finding worth publishing, and it is
+  the reason this smoke is worth its own spend.
+
+rerun_identity:
+  experiment_id: "exp026c_cost_receipt_smoke"
+  expected_task_count: 1
+  # The frozen openai/gdpval commit every other pinned config in this
+  # directory reads its rubric from. The pinned task was graded at this
+  # revision by exp003, so the rubric is known to resolve here.
+  rubric_commit_sha: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  # HyeonSang/exp026c_cost_receipt_smoke, written by step 7 of run
+  # 33308053974 at 2026-08-30T11:14:14Z. Before that run the repo held only
+  # its bootstrap commit, so this is the first and only revision carrying
+  # inference results.
+  inference_revision: "0d1d6df224d71aec23a0199ba1e7b272044b500b"
+  # Deliberately absent: allow_legacy_missing_provenance. Run 33308053974
+  # published workspace/upload/inference_provenance.json with
+  # schema_version azure-ai-inference-provenance-v2 and a populated
+  # azure_ai_routes block, so nothing needs forgiving.
+  task_ids:
+    - "83d10b06-26d1-4636-a32c-23f92c57f30b"
+
+judge:
+  provider: "azure_openai"
+  api: "responses"
+  model: "gpt-5.4"
+  deployment: "gpt-5.4"
+  api_version: "2025-04-01-preview"
+  timeout_sec: 600
+  reasoning:
+    effort: "medium"
+  generation:
+    temperature: 0
+    seed: 42
+    max_output_tokens: 2400
+
+  tools:
+    read_deliverable:
+      env: "exp011_subprocess"
+      ops:
+        - inspect_structure
+        - read_content
+        - inspect_formatting
+        - probe_audio
+        - probe_video
+      read_only: true
+      per_item_call_cap: 8
+      max_iterations: 10
+
+  perception:
+    visual:
+      model: "gpt-5.4"
+      # default_v2 omits this. Without it the visual sub-judge's deployment
+      # never reaches the receipt, so a priced row cannot be traced back to
+      # the deployment that produced it.
+      deployment: "gpt-5.4"
+      vision: true
+      call_cap_per_task: 72
+    audio:
+      model: "gpt-audio-1.5"
+      deployment: "gpt-audio-1.5"
+      call_cap_per_task: 3
+      trim_seconds: 30
+
+  critical:
+    rule: "abs_max_score_threshold"
+    threshold: 4
+    sign_aware: true
+
+  scoring:
+    sign_aware_pct: true
+    handle_nonpositive_total_max: "explicit"
+
+rubric:
+  source: "huggingface"
+  repo_id: "openai/gdpval"
+  # Must equal rerun_identity.rubric_commit_sha (step8_grade.py:646).
+  revision: "11e7900cdcac61bc4daf59e65feb238acda98fbf"
+  cache_dir: "data/gdpval-local"
+
+grader:
+  precheck_patterns_version: "v2"
+  evidence_max_chars: 200
+  judge_max_retries: 1
+  per_item_max_output_tokens: 2400
+  save_raw_responses: false
+  fail_on_missing_evidence: true
+  task_prompt_truncate_chars: 500
+
+tpm_guard:
+  max_concurrent: 1
+  min_delay_ms_between_calls: 500
+  retry_on_429:
+    enabled: true
+    max_retries: 3
+    initial_backoff_sec: 2
+    exponential_factor: 2.0
+
+prompt:
+  template: "prompts/grader_judge.md"
+  tool_template: "prompts/grader_judge_v2.md"
+  version: "v2.2"
+
+output:
+  directory: "../data/grades"
+  filename_template: "{exp_id}__judge_{judge_slug}__{config_name}__cfg_{config_hash}__rubric_{rubric_sha}__inference_{inference_sha}__src_{grader_source_hash_short}__{prompt_v}.json"


### PR DESCRIPTION
## 한 줄 요약

**문제 풀이 비용은 이제 숫자로 나옵니다($0.285513). 채점 비용도 숫자로 나오는지 확인할 최소 설정 하나를 추가합니다.** 파일 1개, 코드 변경 0줄.

> **병합하지 마세요.** 소유자 지시 4항에 따라 **PR까지만** 준비한 것입니다. 실행도 아직 하지 않았습니다.

---

## 왜 필요한가

exp026c 스모크(실행 `33308053974`)로 **문제 풀이** 쪽 영수증이 `complete`로 정산됐습니다. 남은 절반은 **채점** 쪽입니다. 이 설정은 그 절반을 확인할 수 있는 가장 작은 실행입니다.

## 왜 `default_v2.yaml`을 그대로 못 쓰나

세 가지가 막습니다. 전부 "값이 안 매겨진다"로 이어집니다.

| # | `default_v2` | 문제 |
|---|---|---|
| 1 | `rerun_identity` 없음 | 대상 과제·루브릭·추론 revision이 안 고정됨 → 나중에 같은 숫자를 재현할 수 없음 |
| 2 | `rubric.revision: "main"` | 내일 같은 설정이 다른 루브릭을 읽음 → 비용 비교가 무의미해짐 |
| 3 | perception 두 곳에 `deployment` 없음 | judge에는 있는데 perception에는 없음 → **그 호출의 신원이 영수증에 안 남음** |

이 PR은 이 셋만 채웁니다. **런타임 의미는 `default_v2`와 동일합니다** — 스크립트로 두 설정을 평탄화해 대조했고, 차이 나는 키는 위 세 범주뿐이었습니다.

```
judge.perception.audio.deployment      None -> 'gpt-audio-1.5'
judge.perception.visual.deployment     None -> 'gpt-5.4'
rerun_identity.*                       None -> (고정값)
rubric.revision                        'main' -> '11e7900c...'
```

같은 판정 모델, 같은 reasoning effort, 같은 도구·상한, 같은 critical 규칙, 같은 채점 산식, 같은 프롬프트, 같은 rate-limit 가드입니다.

---

## 청구되는 모든 호출이 값매김 가능한가 — 확인했습니다

값매김은 `provider:resolved_model`을 **완전 일치**로 찾습니다(`core/cost_receipts.py:232`). PR #286 이후 값이 있는 Azure 키는 넷입니다.

```
azure:gpt-5.4              azure:gpt-5.4-2026-03-05
azure:gpt-5.4-mini         azure:gpt-5.4-nano
```

| 호출 주체 | 배포 | 응답 모델 | 값매김 |
|---|---|---|---|
| judge | `gpt-5.4` | `gpt-5.4-2026-03-05` | ✅ #286이 추가한 키 |
| perception.visual | `gpt-5.4` | 〃 | ✅ |
| perception.audio | `gpt-audio-1.5` | — | ❌ 의도적 미책정 |

배포 `gpt-5.4`가 `gpt-5.4-2026-03-05`로 응답한다는 것은 실행 `33308053974`의 원장 **6행 전부**에서 확인된 사실입니다(`price_missing` 0건).

### 유일한 미책정 경로를 왜 그대로 두는가

`gpt-audio-1.5`는 근거가 없어 **일부러 값을 안 매긴** 모델입니다. 빼지 않았습니다 — 빼면 비용이 아니라 **라우팅 의미**가 바뀝니다.

이 과제에서는 **음성 경로가 아예 안 탑니다.** 같은 `task_id`에 대해 **이미 발행된 채점 결과 5개**를 교차 확인했습니다.

```
rubric item  a64588ed-db04-4b8b-b3b8-3674ddcf10d1
  routing_modality:      visual   (5/5)
  perception_call_count: 1        (5/5)
음성으로 라우팅된 항목:  0        (5/5)
```

라우팅은 **루브릭 기준**으로 정해지므로 과제의 성질이지 산출물의 성질이 아닙니다. exp026c의 산출물에도 그대로 적용됩니다.

만에 하나 음성이 타면 영수증은 요율을 추측하지 않고 `price_missing`으로 **`partial`이 됩니다.** 그게 의도된 fail-closed 동작입니다.

---

## 이 설정만으로는 `_diagnostic/`으로 안 갑니다 — 디스패치 때 한 칸이 필요합니다

`step8_grade.py:1231`은 고정 목록이 **원본 코퍼스 전체를 덮으면 `complete`**로 분류하고, **`subset`일 때만** 출력을 `_diagnostic/`으로 보냅니다.

exp026c의 코퍼스는 **과제 1개**입니다. 그래서 그 1개를 고정하면 `complete`가 되고, 결과가 **공개 대시보드 경로로 갑니다.** 이 실행의 목적이 아닙니다.

**디스패치할 때 `tasks_limit: 1`을 주면 됩니다.**

- 고정 목록 가드를 통과합니다 — `0` 또는 `len(task_ids)`만 허용하는데 `1`이 후자입니다
- `step8_grade.py:1932`의 `args.limit > 0`가 걸려 `diagnostic_run = True`가 됩니다
- 출력이 `_diagnostic/<scope_sha>/`로 갈라져 **공개 경로는 그대로 남습니다**

`tasks_limit`는 이미 `grade-run.yml`의 `workflow_dispatch` 입력입니다. **워크플로 수정은 전혀 필요 없습니다.**

---

## 예상 비용 — 추측이 아니라 실측 재계산

같은 `task_id`에 대해 이미 발행된 채점 결과 5개에서 judge + perception 토큰을 합산해 gpt-5.4 요율(2.50 / 0.25 / 15.00)로 다시 계산했습니다.

| 설정 | 호출 | 입력 | 캐시 | 출력 | gpt-5.4 환산 |
|---|---|---|---|---|---|
| `default_v2_mini` | 127+1 | 2,834,829 | 913,152 | 43,822 | **$5.69** |
| `validation_v2_mini_cohort10` | 137+1 | 3,088,707 | 975,104 | 46,096 | **$6.22** |
| `validation_v2_mini_cohort3` | 136+1 | 3,193,116 | 1,075,712 | 47,667 | **$6.28** |
| `regrade_v2_sol_max` (a) | 116+1 | 4,216,415 | 1,705,874 | 56,192 | **$7.55** |
| `regrade_v2_sol_max` (b) | 111+1 | 4,022,367 | 1,507,061 | 55,560 | **$7.50** |

**$7.55를 천장으로 보고, 실제로는 상당히 적게 나올 것으로 봅니다.** 위 다섯은 exp003의 산출물을 채점한 것이고, exp026c의 산출물은 `Sample.xlsx` 하나에 설명 488자짜리 최소 산출물입니다. 호출당 입력 토큰은 산출물 내용이 지배하므로, **호출 수는 비슷하되 토큰 수는 훨씬 작을 것**입니다.

그리고 이 실행이 사려는 헤드라인은 이것입니다.

> **한 과제를 푸는 데 $0.2855, 그 답을 채점하는 데 $6 안팎.** 채점이 풀이보다 20배쯤 비쌉니다.

이 비율 자체가 발행할 가치가 있는 결과이고, 이 스모크에 돈을 쓸 이유입니다.

---

## 두 관문

| | 비싼 관문 (`grader_source_hash`) | 싼 관문 (`GRADING_INPUT_PATHS`) |
|---|---|---|
| `grading_configs/cost_smoke_exp026c_v2_gpt54.yaml` | ❌ | ✅ |

비싼 관문은 **실행에 넘겨진 설정 파일 하나**만 해시합니다. **새 파일을 추가하는 것은 다른 어떤 설정의 지문도 바꾸지 않습니다.** 진행 중인 채점에 영향이 없습니다.

싼 관문(`batch-runner/grading_configs` 포함)은 #281·#282 병합으로 **이미 걸려 있습니다.** 이 PR이 새로 유발하는 재디스패치는 없습니다.

---

## 검증

| 항목 | 결과 |
|---|---|
| `step8_grade.py`의 `validate_grading_config()` 직접 통과 | ✅ PASS |
| `default_v2` 대비 의도치 않은 런타임 드리프트 | ✅ 없음 (위 4개 키만 차이) |
| 설정 디렉터리를 전수 순회하는 테스트 5개 파일 | ✅ **200 passed** |
| `batch-runner` 전체 `pytest` (로컬) | ✅ **5865 passed, 9 skipped, 0 failed** (11분 34초) |
| `batch-runner` 전체 `pytest` (CI [33309603340](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/33309603340)) | ✅ **5863 passed, 11 skipped, 0 failed** (9분 19초) |

전수 순회 테스트 두 곳(`test_grading_config.py:197`, `test_perception_caps_have_one_source.py:220`)이 `grading_configs/*.yaml`을 전부 읽으므로, 새 파일도 이미 그 검사 범위 안에 들어가 있습니다.

로컬 5865 + 9 = CI 5863 + 11 = **5874로 동일**합니다. 차이 2건은 환경에 따라 건너뛰는 테스트이고, 실패는 양쪽 모두 0입니다.

---

## 병합 후에 할 일 (지금은 하지 않습니다)

1. **무료 `dry_run` 리허설.** `grade-run.yml:288`이 설정을 `${GITHUB_SHA}` 기준으로 읽기 때문에, **병합 전에는 dry run조차 이 설정을 쓸 수 없습니다.**
2. `dry_run: false` + `paid_approval: true` + `tasks_limit: 1`로 유료 1회.
3. 영수증이 `complete`로 정산되는지, 배포·API 버전이 남는지 확인.

---

## 바뀐 파일 (1개)

```
batch-runner/grading_configs/cost_smoke_exp026c_v2_gpt54.yaml   (신규)
```
