### PR TITLE
fix(envelope): 값을 못 매긴 호출이 합계를 조용히 작게 만들지 않는다

### DIFF
--- a/batch-runner/core/execution_envelope_cost.py
+++ b/batch-runner/core/execution_envelope_cost.py
@@ -583,6 +583,24 @@ class CostCeiling:
     both must, since a missing number is not a zero.
     """
 
+    perception_of_unknown_price: list[str] = field(default_factory=list)
+    """Kinds of perception whose model has no published price.
+
+    The sibling of :attr:`perception_of_unknown_size`, and the other way to
+    reach the same zero: there the price is known and the size is not, here the
+    size may well be known and the price is not. A kind can be in both, and
+    then it is named in both, because being told only that the size was never
+    measured invites the reader to think measuring it would produce a figure.
+    """
+
+    grading_model_with_no_price: str | None = None
+    """The marking model, when no published price was found for it.
+
+    ``None`` means marking's figure has nothing missing from it. The name is
+    carried rather than worked out from ``grading_usd == 0``, because a figure
+    of zero is exactly the thing this is here to stop anyone reading as a fact.
+    """
+
     @property
     def running_usd(self) -> Decimal:
         return sum(
@@ -605,18 +623,47 @@ class CostCeiling:
             + self.perception_model_calls
         )
 
+    def what_the_totals_leave_out(self) -> list[str]:
+        """Why the two totals are lower than the most this could cost.
+
+        Empty means nothing is missing from them. Otherwise each entry names
+        one thing that was counted in :attr:`total_model_calls` and put into no
+        dollar figure anywhere — a call with no money against it.
+
+        Both the readable lines and the written-out answer are built from this
+        one list, so a reader and a machine cannot be told different things
+        about the same totals.
+        """
+        reasons: list[str] = []
+        if self.unpriced_models:
+            reasons.append(
+                "no published price was found for "
+                + ", ".join(self.unpriced_models)
+            )
+        if self.perception_of_unknown_size:
+            reasons.append(
+                "how much "
+                + ", ".join(self.perception_of_unknown_size)
+                + " sends and writes back was never measured"
+            )
+        return reasons
+
     def as_dict(self) -> dict[str, Any]:
         return {
             "environments": [entry.as_dict() for entry in self.environments],
             "grading": {
                 "most_model_calls": self.grading_model_calls,
                 "most_it_could_cost_usd": _money(self.grading_usd),
+                "model_with_no_published_price": self.grading_model_with_no_price,
             },
             "grading_perception": {
                 "most_model_calls": self.perception_model_calls,
                 "most_it_could_cost_usd": _money(self.perception_usd),
                 "kinds_whose_size_is_unknown": list(
                     self.perception_of_unknown_size
+                ),
+                "kinds_whose_price_is_unknown": list(
+                    self.perception_of_unknown_price
                 ),
             },
             "most_model_calls_in_total": self.total_model_calls,
@@ -627,6 +674,10 @@ class CostCeiling:
             "safety_multiplier": str(self.safety_multiplier),
             "most_the_whole_thing_could_cost_usd": _money(self.total_usd),
             "models_with_no_published_price": list(self.unpriced_models),
+            # Beside the totals rather than only in the parts, because a reader
+            # who takes the total and nothing else is exactly the reader this
+            # is for.
+            "what_the_totals_leave_out": self.what_the_totals_leave_out(),
         }
 
 
@@ -738,10 +789,13 @@ def estimate_cost_ceiling(
     perception_usd = Decimal(0)
     perception_calls = 0
     perception_unknown: list[str] = []
+    perception_unpriced: list[str] = []
+    grading_model_with_no_price: str | None = None
     if assumptions.grading_required:
         grading_price = price_table.get(assumptions.grading_model)
         if grading_price is None:
             unpriced.add(assumptions.grading_model)
+            grading_model_with_no_price = assumptions.grading_model
         graded_task_ids: set[str] = set()
         for conditions in conditions_by_environment.values():
             graded_task_ids.update(conditions.task_ids)
@@ -779,6 +833,14 @@ def estimate_cost_ceiling(
             price = price_table.get(perception.model)
             if price is None:
                 unpriced.add(perception.model)
+                # Named here as well as in ``unpriced_models`` so the line that
+                # prints this figure can say which kind of perception the
+                # missing money belongs to. "gpt-audio-1.5 has no price" does
+                # not tell a reader that the listening calls are the ones with
+                # nothing against them.
+                perception_unpriced.append(
+                    f"{perception.modality} ({perception.model})"
+                )
             if not perception.size_is_known:
                 # Say which kind, not just which model. A reader who is told
                 # "gpt-5.4" learns nothing about which of its two jobs is the
@@ -804,6 +866,8 @@ def estimate_cost_ceiling(
         perception_usd=perception_usd,
         perception_model_calls=perception_calls,
         perception_of_unknown_size=perception_unknown,
+        perception_of_unknown_price=perception_unpriced,
+        grading_model_with_no_price=grading_model_with_no_price,
     )
 
 
@@ -868,19 +932,40 @@ def check_cost_ceiling(
 
 
 def describe_cost_ceiling(ceiling: CostCeiling) -> list[str]:
-    """A few readable lines a person can check the arithmetic against."""
+    """A few readable lines a person can check the arithmetic against.
+
+    Every money line here is headed "at most". Where a figure had calls counted
+    against it that could not be turned into money, the line says so beside the
+    figure. Two things can do that — a model nobody has published a price for,
+    and a perception call nobody has measured — and both come out as the same
+    zero, which is why neither may be left to speak for itself.
+    """
     lines: list[str] = []
     for entry in ceiling.environments:
-        lines.append(
+        line = (
             f"{entry.environment}: at most {entry.model_calls} model calls, "
             f"at most {_money(entry.usd)} United States dollars "
             f"(deployment {entry.deployment}, model {entry.resolved_model})"
         )
+        if entry.resolved_model in ceiling.unpriced_models:
+            line += (
+                " — but no published price was found for "
+                f"{entry.resolved_model}, so every one of those calls is in "
+                "the count and in no figure"
+            )
+        lines.append(line)
     if ceiling.grading_model_calls:
-        lines.append(
+        line = (
             f"grading: at most {ceiling.grading_model_calls} model calls, "
             f"at most {_money(ceiling.grading_usd)} United States dollars"
         )
+        if ceiling.grading_model_with_no_price is not None:
+            line += (
+                " — but no published price was found for "
+                f"{ceiling.grading_model_with_no_price}, so every one of those "
+                "calls is in the count and in no figure"
+            )
+        lines.append(line)
     if ceiling.perception_model_calls:
         line = (
             "grading, looking and listening: at most "
@@ -897,6 +982,23 @@ def describe_cost_ceiling(ceiling: CostCeiling) -> list[str]:
                 + " is not in that figure at all, because how much it sends was "
                 "never measured"
             )
+        if ceiling.perception_of_unknown_price:
+            # The other way to the same zero. Said separately because a kind
+            # that is missing both would otherwise leave a reader thinking a
+            # measurement is all that stands between here and a figure.
+            if ceiling.perception_of_unknown_size:
+                line += (
+                    " — and no published price was found for "
+                    + ", ".join(ceiling.perception_of_unknown_price)
+                    + ", so measuring it would not produce a figure either"
+                )
+            else:
+                line += (
+                    " — but no published price was found for "
+                    + ", ".join(ceiling.perception_of_unknown_price)
+                    + ", so every one of those calls is in the count and in "
+                    "no figure"
+                )
         lines.append(line)
     lines.append(
         f"before the safety multiplier: "
@@ -906,4 +1008,15 @@ def describe_cost_ceiling(ceiling: CostCeiling) -> list[str]:
         f"after multiplying by {ceiling.safety_multiplier}: "
         f"{_money(ceiling.total_usd)} United States dollars"
     )
+    left_out = ceiling.what_the_totals_leave_out()
+    if left_out:
+        # The parts already say this on their own lines. It is repeated on the
+        # totals because the totals are what gets quoted, and a reader who
+        # takes the last line and stops is the reader who most needs telling.
+        lines.append(
+            "WARNING: both totals above are lower than the most this could "
+            "cost, because " + "; and ".join(left_out) + ". Those calls are "
+            "counted in the model-call figures above "
+            f"({ceiling.total_model_calls} in total) and in none of the money"
+        )
     return lines

--- a/batch-runner/tests/test_execution_envelope_advance_check.py
+++ b/batch-runner/tests/test_execution_envelope_advance_check.py
@@ -15,8 +15,10 @@ import os
 import re
 import subprocess
 import sys
+from dataclasses import replace
 from decimal import Decimal
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -28,6 +30,7 @@ if str(BATCH_RUNNER_ROOT) not in sys.path:
 
 from core.execution_envelope_cost import (  # noqa: E402
     CostAssumptions,
+    ModelPrice,
     REFERENCE_FILE_CHARACTER_CAP,
     check_cost_ceiling,
     describe_cost_ceiling,
@@ -944,6 +947,440 @@ def test_the_written_out_sum_and_the_readable_lines_both_show_perception(
     assert "looking and listening" in printed
     assert "audio (gpt-5.4)" in printed
     assert "never measured" in printed
+
+
+# ── A missing price must not make the totals look smaller in silence ───────
+#
+# Three separate things can put calls into the count and no money against
+# them: a run place whose model has no published price, a marking model with
+# no published price, and a perception kind that is either unmeasured or
+# unpriced. All three come out as the same zero, and a zero drags both totals
+# *down*. Until this section existed the report named only the unmeasured one,
+# and even that only inside the perception line — never beside the totals a
+# reader actually quotes.
+
+
+PRICED = "priced-model"
+UNPRICED = "no-price-model"
+
+#: Two prices, so a test can say which model is missing rather than emptying
+#: the whole table. Emptying it proves only that nothing is priced, which is
+#: not the state this defect lives in.
+ONE_PRICED_MODEL = {
+    PRICED: ModelPrice(
+        model=PRICED,
+        input_usd_per_million=Decimal("1.25"),
+        output_usd_per_million=Decimal("5.00"),
+    )
+}
+
+
+def _ceiling_with_one_thing_unpriced(
+    catalog,
+    *,
+    run_place_model=PRICED,
+    grading_model=PRICED,
+    perception=None,
+):
+    """A whole ceiling where exactly the named part has no published price.
+
+    Built through ``estimate_cost_ceiling`` rather than by constructing a
+    ``CostCeiling`` by hand, because a hand-built one would let these tests
+    agree with a producer that had stopped filling the fields in.
+    """
+    mapping = {
+        "characters_per_token": 3,
+        "instruction_character_count": 0,
+        "tool_loop_max_model_turns": {"host_python_process": 1},
+        "output_tokens_capped_per_attempt": {"host_python_process": False},
+        "max_tool_result_tokens_per_turn": {"host_python_process": 0},
+        "safety_multiplier": 1,
+        "grading_required": True,
+        "grading_model": grading_model,
+        "grading_calls_per_rubric_item": 1,
+        "grading_input_tokens_per_call": 1000,
+        "grading_output_tokens_per_call": 100,
+    }
+    if perception is not None:
+        mapping["grading_perception"] = perception
+    return estimate_cost_ceiling(
+        conditions_by_environment={
+            "host_python_process": _conditions(
+                resolved_model=run_place_model, deployment=run_place_model
+            )
+        },
+        tasks_by_id=catalog.by_task_id(),
+        assumptions=CostAssumptions.from_mapping(mapping),
+        prices=ONE_PRICED_MODEL,
+    )
+
+
+def _priced_vision(model=PRICED):
+    return {
+        "vision": {
+            "model": model,
+            "calls_per_task": 2,
+            "input_tokens_per_call": 1000,
+            "output_tokens_per_call": 100,
+        }
+    }
+
+
+def _warnings(ceiling):
+    return [
+        line
+        for line in describe_cost_ceiling(ceiling)
+        if line.startswith("WARNING")
+    ]
+
+
+def test_a_fully_priced_ceiling_says_nothing_is_missing_from_its_totals(catalog):
+    """The quiet case, so the loud cases mean something.
+
+    A warning that is always printed is not a warning. This pins the state in
+    which the totals really are the most this could cost, and shows the report
+    stays silent about it.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(
+        catalog, perception=_priced_vision()
+    )
+
+    assert ceiling.unpriced_models == []
+    assert ceiling.perception_of_unknown_price == []
+    assert ceiling.perception_of_unknown_size == []
+    assert ceiling.grading_model_with_no_price is None
+    assert ceiling.what_the_totals_leave_out() == []
+    assert _warnings(ceiling) == []
+    assert ceiling.total_usd > 0
+    assert ceiling.as_dict()["what_the_totals_leave_out"] == []
+
+
+def test_an_unpriced_run_place_model_is_named_beside_its_own_zero(catalog):
+    """The run-place line prints a call count and a nothing. Say why.
+
+    Reading "at most 1 model calls, at most 0.00 United States dollars" as a
+    fact about a real run place is exactly the mistake available here, and
+    nothing on that line used to stop it.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(
+        catalog, run_place_model=UNPRICED, perception=_priced_vision()
+    )
+
+    (entry,) = ceiling.environments
+    assert entry.model_calls > 0
+    assert entry.usd == 0
+    assert ceiling.unpriced_models == [UNPRICED]
+
+    (line,) = [
+        line
+        for line in describe_cost_ceiling(ceiling)
+        if line.startswith("host_python_process")
+    ]
+    assert "no published price was found for " + UNPRICED in line
+    assert "in the count and in no figure" in line
+
+
+def test_an_unpriced_marking_model_is_named_beside_its_own_zero(catalog):
+    """The same for marking, which is the largest figure on the page.
+
+    The marking half is thousands of calls on the committed plan. Losing it to
+    a missing price is the single biggest way these totals can fall, and the
+    old report showed the fall with no explanation anywhere.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(
+        catalog, grading_model=UNPRICED, perception=_priced_vision()
+    )
+
+    assert ceiling.grading_model_calls > 0
+    assert ceiling.grading_usd == 0
+    assert ceiling.grading_model_with_no_price == UNPRICED
+
+    (line,) = [
+        line
+        for line in describe_cost_ceiling(ceiling)
+        if line.startswith("grading: ")
+    ]
+    assert "no published price was found for " + UNPRICED in line
+    assert "in the count and in no figure" in line
+    assert ceiling.as_dict()["grading"]["model_with_no_published_price"] == UNPRICED
+
+
+def test_an_unpriced_perception_model_is_named_even_when_its_size_is_known(
+    catalog,
+):
+    """The gap this section was opened by: a measured kind with no price.
+
+    ``perception_of_unknown_size`` is empty here, because the size *was*
+    measured. Before this field existed that emptiness silenced the line
+    completely — a priced-looking figure of zero with no caveat of any kind.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(
+        catalog, perception=_priced_vision(UNPRICED)
+    )
+
+    assert ceiling.perception_model_calls > 0
+    assert ceiling.perception_usd == 0
+    assert ceiling.perception_of_unknown_size == []
+    assert ceiling.perception_of_unknown_price == [f"vision ({UNPRICED})"]
+
+    (line,) = [
+        line
+        for line in describe_cost_ceiling(ceiling)
+        if line.startswith("grading, looking and listening")
+    ]
+    assert f"no published price was found for vision ({UNPRICED})" in line
+    assert "in the count and in no figure" in line
+    assert "never measured" not in line
+
+    written = ceiling.as_dict()["grading_perception"]
+    assert written["kinds_whose_price_is_unknown"] == [f"vision ({UNPRICED})"]
+    assert written["kinds_whose_size_is_unknown"] == []
+
+
+def test_a_perception_kind_missing_both_is_told_it_is_missing_both(catalog):
+    """Being told only about the measurement invites the wrong repair.
+
+    A reader who hears the size was never measured will go and measure it, and
+    arrive back at the same zero. The line has to say the price is missing too,
+    in so many words.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(
+        catalog,
+        perception={
+            "vision": {
+                "model": UNPRICED,
+                "calls_per_task": 1,
+                "input_tokens_per_call": None,
+                "output_tokens_per_call": None,
+            }
+        },
+    )
+
+    assert ceiling.perception_of_unknown_size == [f"vision ({UNPRICED})"]
+    assert ceiling.perception_of_unknown_price == [f"vision ({UNPRICED})"]
+
+    (line,) = [
+        line
+        for line in describe_cost_ceiling(ceiling)
+        if line.startswith("grading, looking and listening")
+    ]
+    assert "never measured" in line
+    assert "no published price was found" in line
+    assert "measuring it would not produce a figure either" in line
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"run_place_model": UNPRICED, "perception": _priced_vision()},
+        {"grading_model": UNPRICED, "perception": _priced_vision()},
+        {"perception": _priced_vision(UNPRICED)},
+    ],
+    ids=["run place", "marking", "perception"],
+)
+def test_every_way_to_lose_a_price_warns_beside_the_totals(catalog, kwargs):
+    """Whichever part loses its price, the totals must say they are short.
+
+    The parts already say it on their own lines. This is about the last two
+    lines on the page, because a total is what gets carried into a message
+    asking somebody to approve a bill.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(catalog, **kwargs)
+
+    (warning,) = _warnings(ceiling)
+    assert "lower than the most this could cost" in warning
+    assert "no published price was found for " + UNPRICED in warning
+    assert str(ceiling.total_model_calls) in warning
+    assert ceiling.what_the_totals_leave_out() == [
+        "no published price was found for " + UNPRICED
+    ]
+
+
+def test_the_warning_arrives_after_both_totals_it_is_about(catalog):
+    """Order is the whole point: a caveat under a number is read, above it is not."""
+    lines = describe_cost_ceiling(
+        _ceiling_with_one_thing_unpriced(
+            catalog, grading_model=UNPRICED, perception=_priced_vision()
+        )
+    )
+
+    before = next(
+        i for i, line in enumerate(lines) if line.startswith("before the safety")
+    )
+    after = next(
+        i for i, line in enumerate(lines) if line.startswith("after multiplying by")
+    )
+    warning = next(i for i, line in enumerate(lines) if line.startswith("WARNING"))
+    assert before < after < warning
+
+
+def test_a_model_missing_from_two_places_is_named_once_in_the_warning(catalog):
+    """The two reasons are separate; the model is not, so it is said once.
+
+    An unpriced perception model lands in ``unpriced_models`` *and* in
+    ``perception_of_unknown_price``. Building the warning from both lists
+    would print the same model name twice and read like two problems.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(
+        catalog,
+        perception={
+            "vision": {
+                "model": UNPRICED,
+                "calls_per_task": 1,
+                "input_tokens_per_call": None,
+                "output_tokens_per_call": None,
+            }
+        },
+    )
+
+    (warning,) = _warnings(ceiling)
+    assert warning.count("no published price was found") == 1
+    assert "never measured" in warning
+    assert ceiling.what_the_totals_leave_out() == [
+        "no published price was found for " + UNPRICED,
+        f"how much vision ({UNPRICED}) sends and writes back was never measured",
+    ]
+
+
+def test_the_printed_lines_and_the_written_answer_cannot_disagree(catalog):
+    """One derivation, two audiences. A person and a script get the same list."""
+    ceiling = _ceiling_with_one_thing_unpriced(
+        catalog, grading_model=UNPRICED, perception=_priced_vision()
+    )
+
+    reasons = ceiling.what_the_totals_leave_out()
+    assert ceiling.as_dict()["what_the_totals_leave_out"] == reasons
+    (warning,) = _warnings(ceiling)
+    for reason in reasons:
+        assert reason in warning
+
+
+def test_the_totals_really_do_fall_when_a_price_goes_missing(catalog):
+    """The defect itself, stated as arithmetic rather than as wording.
+
+    This is why silence was not merely unhelpful. A missing price does not
+    leave the figure alone; it makes it *smaller*, so the report was at its
+    least alarming exactly when it knew least.
+    """
+    priced = _ceiling_with_one_thing_unpriced(
+        catalog, perception=_priced_vision()
+    )
+    unpriced = _ceiling_with_one_thing_unpriced(
+        catalog, grading_model=UNPRICED, perception=_priced_vision()
+    )
+
+    assert unpriced.total_model_calls == priced.total_model_calls
+    assert unpriced.total_usd < priced.total_usd
+    assert _warnings(priced) == []
+    assert len(_warnings(unpriced)) == 1
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"run_place_model": UNPRICED, "perception": _priced_vision()},
+        {"grading_model": UNPRICED, "perception": _priced_vision()},
+        {"perception": _priced_vision(UNPRICED)},
+    ],
+    ids=["run place", "marking", "perception"],
+)
+def test_what_stops_a_run_is_unchanged_by_any_of_this(catalog, kwargs):
+    """Wording moved; the refusal did not.
+
+    ``check_cost_ceiling`` is not touched by this fix, and it already refused
+    every one of these. Pinning that here is what keeps a reporting change from
+    turning into a new condition on runs that used to be allowed or refused.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(catalog, **kwargs)
+
+    problems = check_cost_ceiling(ceiling, approved_maximum_usd=1000)
+    assert [note for note in problems if "no published price" in note]
+
+    allowed = _ceiling_with_one_thing_unpriced(
+        catalog, perception=_priced_vision()
+    )
+    assert not [
+        note
+        for note in check_cost_ceiling(allowed, approved_maximum_usd=1000)
+        if "no published price" in note
+    ]
+
+
+def test_the_old_silence_would_be_caught_if_it_came_back(catalog):
+    """A check nobody has seen fail is not different from one that cannot.
+
+    The old behaviour is restored in memory only — the producer is left alone
+    and the derivation it feeds is emptied. What comes back is the report as it
+    was: a total that fell by more than half, printed with nothing beside it.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(
+        catalog, grading_model=UNPRICED, perception=_priced_vision()
+    )
+    priced = _ceiling_with_one_thing_unpriced(
+        catalog, perception=_priced_vision()
+    )
+    assert ceiling.total_usd * 2 < priced.total_usd
+
+    with patch.object(
+        type(ceiling), "what_the_totals_leave_out", lambda self: []
+    ):
+        old_lines = describe_cost_ceiling(ceiling)
+
+    assert not [line for line in old_lines if line.startswith("WARNING")]
+    # And the money it prints is the same money — which is what made this
+    # survivable for so long. Nothing was wrong with the arithmetic; the
+    # arithmetic was being asked a question it could not answer, and answered
+    # anyway.
+    assert [line for line in old_lines if line.startswith("after multiplying by")] == [
+        line
+        for line in describe_cost_ceiling(ceiling)
+        if line.startswith("after multiplying by")
+    ]
+
+
+def test_the_old_silence_on_a_measured_but_unpriced_kind_would_be_caught(catalog):
+    """The third cause, the one nothing in this repository used to name.
+
+    An unmeasured kind was already called out on its own line. A *measured* one
+    whose model has no price reached the same zero down a path with no wording
+    on it at all, and emptying the new list here is precisely that old state.
+    """
+    ceiling = _ceiling_with_one_thing_unpriced(
+        catalog, perception=_priced_vision(UNPRICED)
+    )
+    old = replace(ceiling, perception_of_unknown_price=[], unpriced_models=[])
+
+    (line,) = [
+        line
+        for line in describe_cost_ceiling(old)
+        if line.startswith("grading, looking and listening")
+    ]
+    assert "at most 0.00 United States dollars" in line
+    assert "no published price" not in line
+    assert not [
+        line for line in describe_cost_ceiling(old) if line.startswith("WARNING")
+    ]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"run_place_model": UNPRICED, "perception": _priced_vision()},
+        {"grading_model": UNPRICED, "perception": _priced_vision()},
+        {"perception": _priced_vision(UNPRICED)},
+    ],
+    ids=["run place", "marking", "perception"],
+)
+def test_the_missing_price_is_never_reported_as_a_price_of_zero(catalog, kwargs):
+    """No line may show the zero on its own.
+
+    Whichever part is unpriced, the figure printed for it is 0.00. That string
+    appearing without a caveat on the same line is the whole defect, so it is
+    asserted directly rather than through any one wording.
+    """
+    for line in describe_cost_ceiling(_ceiling_with_one_thing_unpriced(catalog, **kwargs)):
+        if "at most 0.00 United States dollars" in line:
+            assert "no published price was found" in line, line
 
 
 @pytest.mark.parametrize(

--- a/batch-runner/tests/test_execution_envelope_grading_cost.py
+++ b/batch-runner/tests/test_execution_envelope_grading_cost.py
@@ -714,23 +714,37 @@ def test_the_printed_total_says_it_is_too_low_while_marking_is_uncounted():
     possible bill. Reporting the shortfall further down the page and leaving
     the total to read as final is how a known-low number gets quoted as a
     ceiling.
+
+    This names the warning it means rather than counting the warnings, because
+    the marking settings are only one of the reasons these totals can be short
+    and a count would make finding another reason look like a regression.
     """
     result = preflight_on_the_committed_plan()
     assert result.grading_ceiling_problems
     warnings = [
         line for line in describe_preflight(result) if line.startswith("WARNING")
     ]
-    assert len(warnings) == 1
-    assert "not a ceiling" in warnings[0]
-    assert "too low" in warnings[0]
+    about_marking = [line for line in warnings if "marking figure" in line]
+    assert len(about_marking) == 1
+    assert "not a ceiling" in about_marking[0]
+    assert "too low" in about_marking[0]
 
 
 def test_no_caveat_is_printed_once_the_marking_half_is_a_ceiling():
-    """The warning must disappear when it stops being true, and only then."""
+    """The warning must disappear when it stops being true, and only then.
+
+    Only the marking warning is asserted away. The committed plan's totals are
+    also short for a reason that has nothing to do with the marking settings —
+    the listening model has no published price and its size was never measured
+    — so that warning is expected to stay, and a blanket assertion of silence
+    here would quietly demand that the other defect come back.
+    """
     result = replace(preflight_on_the_committed_plan(), grading_ceiling_problems=[])
-    assert not [
+    warnings = [
         line for line in describe_preflight(result) if line.startswith("WARNING")
     ]
+    assert not [line for line in warnings if "marking figure" in line]
+    assert [line for line in warnings if "lower than the most this could cost" in line]
 
 
 def test_the_written_answer_says_whether_the_marking_half_is_a_ceiling():

--- a/tasks/0822_saturday/TASK_GPT_EXECUTION_ENVELOPE_BENCHMARK.md
+++ b/tasks/0822_saturday/TASK_GPT_EXECUTION_ENVELOPE_BENCHMARK.md
@@ -3734,3 +3734,182 @@ def test_an_unreadable_turn_count_falls_back_to_the_quiet_wording(turns):
 | 나머지 | 13.28의 표 그대로입니다. 이번 수정으로 풀린 것은 없습니다 |
 
 **전체 비교 실험이 실행되지 않았으므로 이 작업은 차단됨으로 유지합니다.**
+
+### 13.31 가격이 없으면 합계가 **더 작아지는데**, 아무 말도 안 하고 있었습니다 (2026-08-31 수정, #299)
+
+#### 한 줄 요약
+
+보고서 맨 아래 두 줄은 **"이게 최대 금액입니다"** 라는 뜻으로 읽힙니다. 그런데
+**값을 못 매긴 호출은 0원으로 세어 그 두 줄에 그냥 들어가 있었고, 그 사실을
+어디에도 안 적었습니다.** 값을 모르면 청구서가 **더 커** 보여야 하는데
+**더 작아** 보였습니다.
+
+#### 왜 이게 위험한가 — 방향이 반대입니다
+
+모르는 것을 0으로 세면, **모를수록 안심되는 숫자**가 나옵니다. 승인을 요청받은
+사람은 "생각보다 싸네" 하고 통과시킵니다. 이 저장소가 13.28~13.30에서 계속
+고쳐 온 것과 **정확히 같은 모양**입니다.
+
+#### 재현 — 실제 생산 코드로 4가지 상태를 돌렸습니다
+
+`estimate_cost_ceiling` → `describe_cost_ceiling`을 그대로 부른 것입니다.
+과제 1개, 안전 계수 1배, 가격표는 모델 하나만 넣었습니다.
+
+**고치기 전**
+
+| 계획서 상태 | 실행 자리 줄 | 채점 줄 | 보는·듣는 줄 | 안전 계수 전 합계 |
+|---|---|---|---|---|
+| 전부 가격 있음 | 0.01 | 0.45 | 0.35 | **0.80** |
+| 실행 자리 모델 가격 없음 | **0.00**, 설명 없음 | 0.45 | 0.35 | 0.80 |
+| 채점 모델 가격 없음 | 0.01 | **0.00**, 설명 없음 | 0.35 | **0.36** ← 55% 떨어짐 |
+| 보는 모델 가격 없음 (크기는 잼) | 0.01 | 0.45 | **0.00**, 설명 **전혀 없음** | 0.45 |
+
+셋 다 `0.00`을 찍으면서 **그 줄에도, 합계 줄에도 한 마디도 없었습니다.**
+
+#### 원인은 셋인데, 저장소는 그중 **하나**만 말하고 있었습니다
+
+| 원인 | 고치기 전 |
+|---|---|
+| 보는·듣는 쪽 **크기를 안 쟀다** | 그 줄에만 적혀 있었음 (합계 줄엔 없음) |
+| 어떤 모델에 **공표된 가격이 없다** | 어디에도 없음 |
+| **크기는 쟀는데 가격이 없다** | 어디에도 없음 — 이번에 새로 찾은 것 |
+
+세 번째가 가장 조용했습니다. "크기를 안 쟀다"는 말조차 안 나오니, 읽는 사람은
+**아무 문제가 없다고 읽습니다.**
+
+#### 무엇을 고쳤나 — **새 기준을 만들지 않았습니다**
+
+이미 있던 규칙을 **나머지 두 원인까지 넓힌 것**입니다. 원래 규칙은
+`describe_preflight`에 이렇게 있었습니다.
+
+```python
+if result.grading_ceiling_problems:
+    lines.append("WARNING: the marking figure above is not a ceiling — … "
+                 "so every total here is too low. See the problems below.")
+```
+
+즉 **"채점 쪽이 덜 세어졌으면 합계 옆에 그렇게 적는다"** 는 규칙이 이미
+있었습니다. 이번에는 같은 규칙을 **가격이 없는 경우**와 **크기를 안 잰 경우**
+에도 적용했습니다.
+
+새로 만든 것은 필드 두 개와 유도 함수 하나입니다.
+
+| 이름 | 하는 일 |
+|---|---|
+| `perception_of_unknown_price` | 크기는 쟀지만 **가격이 없는** 보는·듣는 종류 |
+| `grading_model_with_no_price` | **채점 모델**에 가격이 없을 때 그 이름 |
+| `what_the_totals_leave_out()` | 합계에서 빠진 이유 목록 — **사람이 읽는 줄과 기계가 읽는 답이 여기 하나에서 나옵니다** |
+
+`grading_model_with_no_price`를 `grading_usd == 0`으로 되짚지 않고 **이름을 직접
+들고 다닙니다.** 0이라는 숫자를 사실로 읽는 것이 바로 이 결함이기 때문입니다.
+
+**고친 뒤 같은 4가지**
+
+```
+실행 자리 가격 없음
+  host_python_process: … at most 0.00 … — but no published price was found for
+  no-price-model, so every one of those calls is in the count and in no figure
+  WARNING: both totals above are lower than the most this could cost, because …
+  Those calls are counted in the model-call figures above (79 in total) and in
+  none of the money
+
+채점 가격 없음
+  grading: at most 71 model calls, at most 0.00 … — but no published price was
+  found for no-price-model, so every one of those calls is in the count and in
+  no figure
+
+보는 모델 가격 없음 (크기는 잼)
+  grading, looking and listening: … at most 0.00 … — but no published price was
+  found for vision (no-price-model), so every one of those calls is in the count
+  and in no figure
+```
+
+크기와 가격이 **둘 다** 없으면 두 문장이 같이 붙습니다. 뒤 문장이
+*"measuring it would not produce a figure either"* 로 끝나는데, **"재기만 하면
+숫자가 나온다"** 고 오해하고 헛수고하지 말라는 뜻입니다.
+
+#### 실제 커밋된 계획서에서는 이렇게 보입니다
+
+```
+grading, looking and listening: at most 1125 model calls, at most 54.00 …
+  — but audio (gpt-audio-1.5) is not in that figure at all, because how much it
+  sends was never measured
+  — and no published price was found for audio (gpt-audio-1.5), so measuring it
+  would not produce a figure either
+before the safety multiplier: 6086.73 United States dollars
+after multiplying by 1.25: 7608.41 United States dollars
+WARNING: both totals above are lower than the most this could cost, because no
+published price was found for gpt-audio-1.5; and how much audio (gpt-audio-1.5)
+sends and writes back was never measured. Those calls are counted in the
+model-call figures above (10136 in total) and in none of the money
+```
+
+**앞의 여섯 줄 숫자는 하나도 안 움직였습니다.** 마지막 줄이 새로 생긴 것입니다.
+
+#### 차단 동작은 한 줄도 안 바뀌었습니다
+
+`check_cost_ceiling`은 **손대지 않았습니다.** 위 4가지 중 가격이 없는 3가지는
+고치기 전에도 후에도 똑같이 `no published price was found…` 를 냅니다.
+`test_what_stops_a_run_is_unchanged_by_any_of_this`가 세 경우 모두에서 이를
+확인하고, 전부 가격이 있는 경우에는 그 문구가 **안 나온다**는 반대 방향까지
+확인합니다.
+
+그리고 **2026-08-28 소유자 결정대로 비용은 기록 전용입니다.** 계획서에
+`policy: record_cost_findings_only`, `unpriced_audio_measurement: true`가
+적혀 있고, 이번 수정은 그것을 **되살리지 않았습니다.** 32.23 / 364 달러를
+실행 차단 상한으로 부활시키지 않았습니다.
+
+#### 일부러 안 고친 것
+
+소리 채점(`gpt-audio-1.5`)에 가격이 없고 크기도 안 잰 것 **자체**는 이번에
+안 고쳤습니다. 소유자가 2026-08-28에 그 상태로 진행하기로 **명시적으로 승인**
+했기 때문입니다. 이번 수정은 **그 사실이 합계 옆에 보이게 만든 것뿐**입니다.
+
+#### 기존 테스트 두 개를 **좁혔습니다** (지운 것 0개)
+
+| 테스트 | 무엇이 바뀌었나 |
+|---|---|
+| `test_the_printed_total_says_it_is_too_low_while_marking_is_uncounted` | `len(warnings) == 1` → **`"marking figure"`가 든 경고를 골라서** 확인. 경고를 **세는** 방식이면 다른 원인을 찾아낸 것이 회귀처럼 보입니다 |
+| `test_no_caveat_is_printed_once_the_marking_half_is_a_ceiling` | "경고가 하나도 없다" → **"채점 경고만 없다"**. 커밋된 계획서는 소리 쪽 이유로 여전히 합계가 짧으므로, 무조건 침묵을 요구하면 **방금 고친 결함을 다시 불러오라는 뜻**이 됩니다 |
+
+둘 다 **원래 의도는 그대로**고, 세는 대신 **내용을 보게** 만든 것입니다.
+
+#### 실패할 수 있다는 증명 — 두 방향
+
+1. `test_the_old_silence_would_be_caught_if_it_came_back` — 옛 동작을 **메모리
+   에서만** 되살리면 경고가 사라지고, **그때 찍히는 돈은 똑같습니다.** 이것이
+   이 결함이 오래 살아남은 이유입니다. 산수는 틀린 적이 없고, 대답할 수 없는
+   질문에 대답을 한 것뿐입니다.
+2. `test_the_old_silence_on_a_measured_but_unpriced_kind_would_be_caught` —
+   새로 찾은 세 번째 원인만 되살리면 `0.00`이 **아무 설명 없이** 다시 찍힙니다.
+
+여기에 `test_the_totals_really_do_fall_when_a_price_goes_missing`이 **결함
+자체를 산수로** 못박습니다. 호출 수는 같은데 금액만 떨어진다는 것입니다.
+
+#### 확인한 것
+
+- 새 테스트 **14개 함수 / 실행 항목 20개**, 좁힌 기존 테스트 2개, 지운 것 **0개**
+  (이 파일의 함수 96 → **110개**)
+- 봉투 관련 형제 파일 전체 **484개 통과**
+- 문구 감시(`test_marking_ceiling_has_no_uncapped_part.py`) + 명세서 상한 감시
+  **271개 통과** — 새 문구는 금지된 7개 표현을 하나도 안 씁니다
+- `mypy core/` 오류 **170개 / 파일 32개** — 기준선과 동일
+- 모델 호출 0회, 채점 실행 0회, 승인한 금액 없음, 로그인 없음
+
+#### 비용 상한은 움직이지 않았습니다
+
+13.28의 울타리 친 표는 그대로입니다. `estimate_cost_ceiling`의 **산수는 한 줄도
+안 건드렸고**, 새 필드는 전부 **덧붙이기**입니다.
+`test_the_spec_quotes_the_live_ceiling.py`가 `total_usd`를 직접 읽으므로 이
+수정이 그 숫자를 움직일 수 없습니다.
+
+#### 남은 차단 조건
+
+| 무엇 | 어떻게 풀리나 |
+|---|---|
+| **#292 · #294 · #295 · #297 · #299 병합** | **유료 shard 지문이 걸려 있습니다.** 이번 수정도 `core/` 파일 하나를 건드리므로 `compute_grader_source_hash`가 다시 움직입니다 |
+| ~~가격이 없으면 합계가 조용히 작아지던 문제~~ | **닫힘 (#299).** 값을 못 매긴 호출이 있으면 합계 옆에 그렇게 적습니다 |
+| 소리 채점의 가격·크기 자체 | **소유자가 2026-08-28에 그대로 진행하기로 승인.** 이번 수정 대상이 아닙니다 |
+| 나머지 | 13.28의 표 그대로입니다. 이번 수정으로 풀린 것은 없습니다 |
+
+**전체 비교 실험이 실행되지 않았으므로 이 작업은 차단됨으로 유지합니다.**


### PR DESCRIPTION
## ⚠️ 병합하지 마십시오 — 유료 shard 지문이 걸려 있습니다

`compute_grader_source_hash`는 `batch-runner/core/` 아래 모든 `.py`를 해싱합니다. 이 PR은 `core/execution_envelope_cost.py`를 건드리므로 지문이 움직입니다.

| 브랜치 | 지문 |
|---|---|
| `origin/main` | `008ff56f23748448` |
| #295 | `28a7a225f2102e5c` |
| #297 | `77db9c75df2dab40` |
| **이 PR** | **`7b0eb81e684f7c13`** |

진행 중인 유료 shard가 전부 끝난 뒤 **#292 → #294 → #295 → #297 → 이 PR** 순서로만 병합해 주십시오. shard가 도는 중에 병합하면 **돈을 다 쓴 뒤에야** 병합이 실패합니다.

---

## 한 줄 요약

보고서 맨 아래 두 줄은 **"이게 최대 금액입니다"** 라는 뜻으로 읽힙니다. 그런데 **값을 못 매긴 호출은 0원으로 세어 그 두 줄에 그냥 들어가 있었고, 그 사실을 어디에도 안 적었습니다.**

값을 모르면 청구서가 **더 커** 보여야 하는데 **더 작아** 보였습니다.

## 왜 위험한가 — 방향이 반대입니다

모르는 것을 0으로 세면 **모를수록 안심되는 숫자**가 나옵니다. 승인을 요청받은 사람은 "생각보다 싸네" 하고 통과시킵니다. 13.28~13.30에서 계속 고쳐 온 것과 **정확히 같은 모양**입니다.

## 재현 — 실제 생산 코드로 4가지 상태를 돌렸습니다

`estimate_cost_ceiling` → `describe_cost_ceiling`을 그대로 부른 것입니다. 과제 1개, 안전 계수 1배, 가격표에 모델 하나만 넣었습니다.

**고치기 전**

| 계획서 상태 | 실행 자리 줄 | 채점 줄 | 보는·듣는 줄 | 안전 계수 전 합계 |
|---|---|---|---|---|
| 전부 가격 있음 | 0.01 | 0.45 | 0.35 | **0.80** |
| 실행 자리 모델 가격 없음 | **0.00**, 설명 없음 | 0.45 | 0.35 | 0.80 |
| 채점 모델 가격 없음 | 0.01 | **0.00**, 설명 없음 | 0.35 | **0.36** ← 55% 떨어짐 |
| 보는 모델 가격 없음 (크기는 잼) | 0.01 | 0.45 | **0.00**, 설명 **전혀 없음** | 0.45 |

셋 다 `0.00`을 찍으면서 **그 줄에도, 합계 줄에도 한 마디도 없었습니다.**

## 원인은 셋인데, 저장소는 그중 **하나**만 말하고 있었습니다

| 원인 | 고치기 전 |
|---|---|
| 보는·듣는 쪽 **크기를 안 쟀다** | 그 줄에만 적혀 있었음 (합계 줄엔 없음) |
| 어떤 모델에 **공표된 가격이 없다** | 어디에도 없음 |
| **크기는 쟀는데 가격이 없다** | 어디에도 없음 — 이번에 새로 찾은 것 |

세 번째가 가장 조용했습니다. "크기를 안 쟀다"는 말조차 안 나오니 읽는 사람은 **아무 문제가 없다고 읽습니다.**

## 무엇을 고쳤나 — **새 기준을 만들지 않았습니다**

이미 `describe_preflight`에 있던 규칙, 즉 **"채점 쪽이 덜 세어졌으면 합계 옆에 그렇게 적는다"** 를 나머지 두 원인까지 넓혔습니다.

| 새로 만든 것 | 하는 일 |
|---|---|
| `perception_of_unknown_price` | 크기는 쟀지만 **가격이 없는** 보는·듣는 종류 |
| `grading_model_with_no_price` | **채점 모델**에 가격이 없을 때 그 이름 |
| `what_the_totals_leave_out()` | 합계에서 빠진 이유 목록 — **사람이 읽는 줄과 기계가 읽는 답이 여기 하나에서 나옵니다** |

`grading_model_with_no_price`는 `grading_usd == 0`으로 되짚지 않고 **이름을 직접 들고 다닙니다.** 0이라는 숫자를 사실로 읽는 것이 바로 이 결함이기 때문입니다.

## 실제 커밋된 계획서에서 이렇게 보입니다

```
grading, looking and listening: at most 1125 model calls, at most 54.00 …
  — but audio (gpt-audio-1.5) is not in that figure at all, because how much it
  sends was never measured
  — and no published price was found for audio (gpt-audio-1.5), so measuring it
  would not produce a figure either
before the safety multiplier: 6086.73 United States dollars
after multiplying by 1.25: 7608.41 United States dollars
WARNING: both totals above are lower than the most this could cost, because no
published price was found for gpt-audio-1.5; and how much audio (gpt-audio-1.5)
sends and writes back was never measured. Those calls are counted in the
model-call figures above (10136 in total) and in none of the money
```

**앞의 여섯 줄 숫자는 하나도 안 움직였습니다.** 마지막 줄이 새로 생긴 것입니다.

크기와 가격이 **둘 다** 없으면 뒤 문장이 *"measuring it would not produce a figure either"* 로 끝납니다. **"재기만 하면 숫자가 나온다"** 고 오해하고 헛수고하지 말라는 뜻입니다.

## 차단 동작은 한 줄도 안 바뀌었습니다

`check_cost_ceiling`은 **손대지 않았습니다.** 가격이 없는 3가지는 고치기 전에도 후에도 똑같이 `no published price was found…` 를 냅니다. `test_what_stops_a_run_is_unchanged_by_any_of_this`가 세 경우 모두에서 이를 확인하고, 전부 가격이 있으면 그 문구가 **안 나온다**는 반대 방향까지 확인합니다.

**2026-08-28 소유자 결정대로 비용은 기록 전용입니다.** 32.23 / 364 달러를 실행 차단 상한으로 **되살리지 않았습니다.**

## 일부러 안 고친 것

소리 채점(`gpt-audio-1.5`)에 가격이 없고 크기도 안 잰 것 **자체**는 안 고쳤습니다. 소유자가 2026-08-28에 그 상태로 진행하기로 **명시적으로 승인**했기 때문입니다. 이번 수정은 **그 사실이 합계 옆에 보이게 만든 것뿐**입니다.

## 기존 테스트 두 개를 **좁혔습니다** (지운 것 0개)

| 테스트 | 무엇이 바뀌었나 |
|---|---|
| `test_the_printed_total_says_it_is_too_low_while_marking_is_uncounted` | `len(warnings) == 1` → **`"marking figure"`가 든 경고를 골라서** 확인. 경고를 **세는** 방식이면 다른 원인을 찾아낸 것이 회귀처럼 보입니다 |
| `test_no_caveat_is_printed_once_the_marking_half_is_a_ceiling` | "경고가 하나도 없다" → **"채점 경고만 없다"**. 커밋된 계획서는 소리 쪽 이유로 여전히 합계가 짧으므로, 무조건 침묵을 요구하면 **방금 고친 결함을 다시 불러오라는 뜻**이 됩니다 |

## 실패할 수 있다는 증명 — 두 방향

1. `test_the_old_silence_would_be_caught_if_it_came_back` — 옛 동작을 **메모리에서만** 되살리면 경고가 사라지고, **그때 찍히는 돈은 똑같습니다.** 이것이 이 결함이 오래 살아남은 이유입니다. 산수는 틀린 적이 없고, 대답할 수 없는 질문에 대답을 한 것뿐입니다.
2. `test_the_old_silence_on_a_measured_but_unpriced_kind_would_be_caught` — 새로 찾은 세 번째 원인만 되살리면 `0.00`이 **아무 설명 없이** 다시 찍힙니다.

여기에 `test_the_totals_really_do_fall_when_a_price_goes_missing`이 **결함 자체를 산수로** 못박습니다. 호출 수는 같은데 금액만 떨어진다는 것입니다.

## 확인한 것

| 무엇 | 결과 |
|---|---|
| 새 테스트 | **14개 함수 / 실행 항목 20개**, 좁힌 기존 테스트 2개, 지운 것 **0개** (파일 함수 96 → 110) |
| 전체 `pytest` | **6,034 통과 · 6 건너뜀 · 실패 0** (12분 20초) — 기준선 6,014에서 정확히 **+20** |
| 봉투 관련 형제 파일 전체 | 484 통과 |
| 문구 감시 + 명세서 상한 감시 | 271 통과 — 새 문구는 금지된 7개 표현을 하나도 안 씁니다 |
| `mypy core/` | 오류 170개 / 파일 32개 — **기준선과 동일** |
| `node --test` | 184개 중 183 통과 · 1 건너뜀 · **실패 0** |
| `npm run build` | 정상 (6.12초) |
| 모델 호출 / 채점 실행 / 승인 금액 / Azure 로그인 | **0 / 0 / 없음 / 없음** |

## 비용 상한은 움직이지 않았습니다

13.28의 울타리 친 표는 그대로입니다. `estimate_cost_ceiling`의 **산수는 한 줄도 안 건드렸고**, 새 필드는 전부 **덧붙이기**입니다. `test_the_spec_quotes_the_live_ceiling.py`가 `total_usd`를 직접 읽으므로 이 수정이 그 숫자를 움직일 수 없습니다.

## 쌓인 순서

`main` → #292 → #294 → #295 → #297 → **이 PR**. 이 PR은 `wt/unreadable-turn-count`(#297)를 대상으로 열려 있습니다.
