### PR TITLE
fix(grading): 읽히지 않는 파일 하나가 과제 전체를 그림으로 보내지 않게 한다

### DIFF
--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -870,6 +870,31 @@ class Grader:
             deliverable_path, paths, has_audio_content, self._audio_content_cache
         )
 
+    def _paths_without_text(
+        self, deliverable_path: Path, paths: Iterable[str]
+    ) -> tuple[str, ...]:
+        """Which of these files measurably yield no text at all.
+
+        The question above answers *whether* one of them does; this answers
+        *which*, because that is what decides where the pictures are spent. A
+        file the probe cannot speak for is not in the answer, for the same
+        reason it cannot escalate: rendering on a guess is what the ``None``
+        rule exists to prevent. Order follows the selection so the render set
+        reads the way the deliverable does, and shares the text-layer memo, so
+        asking costs nothing a run was not already paying.
+        """
+        without: list[str] = []
+        for name in paths:
+            if not isinstance(name, str) or not name or name in without:
+                continue
+            if name not in self._text_layer_cache:
+                self._text_layer_cache[name] = has_extractable_text(
+                    deliverable_path / name
+                )
+            if self._text_layer_cache[name] is False:
+                without.append(name)
+        return tuple(without)
+
     def _runtime_criterion_plan(
         self,
         selection: DeliverableSelection,
@@ -887,6 +912,9 @@ class Grader:
                 deliverable_path, plan.selected_paths
             ),
             selected_paths_have_audio=self._selected_paths_have_audio(
+                deliverable_path, plan.selected_paths
+            ),
+            paths_without_text=self._paths_without_text(
                 deliverable_path, plan.selected_paths
             ),
         )
@@ -920,13 +948,17 @@ class Grader:
                     selected_paths_have_audio=self._selected_paths_have_audio(
                         deliverable_path, target.paths
                     ),
+                    paths_without_text=self._paths_without_text(
+                        deliverable_path, target.paths
+                    ),
                 )
                 target_decisions[target_id] = decision
                 if decision.modality is Modality.VISUAL:
-                    raw_visual_paths.extend(target.paths)
+                    child_render = decision.render_targets(target.paths)
+                    raw_visual_paths.extend(child_render)
                     planned_names, child_error = (
                         self._tool_judge.validate_planned_visual_names(
-                            target.paths, visual_file_cap
+                            child_render, visual_file_cap
                         )
                     )
                     supported_visual_paths.extend(planned_names)
@@ -935,10 +967,11 @@ class Grader:
                             f"{target_id}: {child_error}"
                         )
         elif item_decision.modality is Modality.VISUAL:
-            raw_visual_paths.extend(plan.selected_paths)
+            item_render = item_decision.render_targets(plan.selected_paths)
+            raw_visual_paths.extend(item_render)
             supported_visual_paths, visual_preflight_error = (
                 self._tool_judge.validate_planned_visual_names(
-                    plan.selected_paths, visual_file_cap
+                    item_render, visual_file_cap
                 )
             )
 
@@ -1114,7 +1147,9 @@ class Grader:
                 if target_id in target_by_id and target_id in visual_target_ids
                 for expected_paths in [
                     self._tool_judge.planned_supported_visual_names(
-                        target_by_id[target_id].paths
+                        runtime_plan.target_decisions[target_id].render_targets(
+                            target_by_id[target_id].paths
+                        )
                     )
                 ]
             )
@@ -1130,7 +1165,9 @@ class Grader:
                     continue
                 child_decision = runtime_plan.target_decisions[target_id]
                 child_prepass = (
-                    visual_prepass.subset(list(target.paths))
+                    visual_prepass.subset(
+                        child_decision.render_targets(target.paths)
+                    )
                     if child_decision.modality is Modality.VISUAL else None
                 )
                 child_grades.append({
@@ -1235,7 +1272,11 @@ class Grader:
                 list(target.paths),
                 reference_file_names,
                 visual_prepass=(
-                    visual_prepass.subset(list(target.paths))
+                    visual_prepass.subset(
+                        runtime_plan.target_decisions[target_id].render_targets(
+                            target.paths
+                        )
+                    )
                     if visual_prepass is not None
                     and target_id in visual_target_ids else None
                 ),

--- a/batch-runner/core/grader_preflight.py
+++ b/batch-runner/core/grader_preflight.py
@@ -107,16 +107,20 @@ def plan_task_runtime(
                     selected_paths_have_audio=grader._selected_paths_have_audio(
                         deliverable_path, target.paths
                     ),
+                    paths_without_text=grader._paths_without_text(
+                        deliverable_path, target.paths
+                    ),
                 )
                 child_routes.append(decision.modality.value)
                 if decision.modality is Modality.VISUAL:
+                    child_render = decision.render_targets(target.paths)
                     planned_names, child_visual_error = (
                         ToolCallingJudge.validate_planned_visual_names(
-                            target.paths, visual_file_cap
+                            child_render, visual_file_cap
                         )
                     )
                     unsupported_visual_paths.extend(
-                        sorted(set(target.paths) - set(planned_names))
+                        sorted(set(child_render) - set(planned_names))
                     )
                     if child_visual_error is not None and visual_error is None:
                         visual_error = (
@@ -221,26 +225,33 @@ def plan_task_runtime(
             selected_paths_have_audio=grader._selected_paths_have_audio(
                 deliverable_path, target_plan.selected_paths
             ),
+            paths_without_text=grader._paths_without_text(
+                deliverable_path, target_plan.selected_paths
+            ),
         )
         routes[decision.modality.value] += 1
         supported: list[str] = []
         visual_error: str | None = None
         if decision.modality is Modality.VISUAL:
+            # The run renders what the decision asks for, which for an
+            # escalated item is narrower than the selection. Counting the
+            # selection here would predict a budget the run never spends.
+            render_targets = decision.render_targets(target_plan.selected_paths)
             planned_names, visual_error = (
                 ToolCallingJudge.validate_planned_visual_names(
-                    target_plan.selected_paths, visual_file_cap
+                    render_targets, visual_file_cap
                 )
             )
             if visual_error is not None:
                 errors.append(f"{item.rubric_item_id}: {visual_error}")
                 unsupported_visual_paths.extend(
-                    sorted(set(target_plan.selected_paths) - set(planned_names))
+                    sorted(set(render_targets) - set(planned_names))
                 )
             else:
                 supported = planned_names
                 planned_visual_calls += len(supported)
                 unsupported_visual_paths.extend(
-                    sorted(set(target_plan.selected_paths) - set(supported))
+                    sorted(set(render_targets) - set(supported))
                 )
         if visual_error is None:
             item_main_judgments = 1

--- a/batch-runner/core/grader_routing.py
+++ b/batch-runner/core/grader_routing.py
@@ -44,6 +44,13 @@ class RoutingDecision:
     modality: Modality
     preferred_op: str
     matched_keywords: tuple[str, ...]
+    #: Which of the selected files this decision wants looked at, when that
+    #: is narrower than all of them. ``None`` -- the ordinary case -- means
+    #: all of them, and is what every criterion that names something visual
+    #: gets: a question about a chart's colours is a question about the
+    #: whole deliverable. Only the unreadable-file escalation below sets
+    #: this, because only it is grounded in a property of particular files.
+    render_paths: tuple[str, ...] | None = None
 
     def to_prompt_hint(self) -> dict[str, str]:
         """Render into the placeholders consumed by ``grader_judge_v2.md``."""
@@ -51,6 +58,17 @@ class RoutingDecision:
             "routing_modality": self.modality.value,
             "routing_preferred_op": self.preferred_op,
         }
+
+    def render_targets(self, selected_paths: Iterable[str]) -> list[str]:
+        """The files to render for this decision, in selection order.
+
+        Every caller that turns a VISUAL decision into pictures goes through
+        here -- the task budget, the per-item cap check, the free preflight
+        and the prepass the judge actually runs. They have to agree: the
+        judge cross-checks what it rendered against what was planned, and a
+        budget that counts a file nobody renders is not a budget.
+        """
+        return list(self.render_paths) if self.render_paths else list(selected_paths)
 
 
 # Ordered: visual > audio > formatting > text. First hit wins.
@@ -173,6 +191,7 @@ def resolve_runtime_routing(
     selected_paths_have_text: bool | None = None,
     selected_paths_have_audio: bool | None = None,
     some_selected_path_lacks_text: bool | None = None,
+    paths_without_text: Iterable[str] | None = None,
 ) -> RoutingDecision:
     """Apply target-aware policy without changing criterion classification.
 
@@ -187,16 +206,20 @@ def resolve_runtime_routing(
     so a picture delivered alongside a readable sibling reports as readable.
     Same rules -- only a measured ``True`` escalates, ``None`` changes nothing.
 
+    ``paths_without_text`` names *which* files those are. It decides nothing on
+    its own; it is what the escalation below hands back as ``render_paths`` so
+    that only the unreadable files are looked at.
+
     ``selected_paths_have_audio`` is the same shape of answer to "is there
     anything here to listen to", and is used only defensively: a measured
     ``True`` stops the demotion below from stripping the listening model off a
     criterion about sound. It can never promote a criterion on its own.
     """
     decision = classify_criterion(criterion_text)
+    paths = [path for path in selected_paths if isinstance(path, str) and path]
     suffixes = {
         suffix
-        for path in selected_paths
-        if isinstance(path, str) and path
+        for path in paths
         if (suffix := Path(path).suffix.lower())
     }
     if (
@@ -293,16 +316,34 @@ def resolve_runtime_routing(
     # to a readable memo; the bundle reported "yes, there is text here", the
     # item stayed TEXT, and the flowchart was never rendered or looked at. A
     # sibling that can be read is not evidence about the file that cannot.
+    #
+    # What escalates and what gets looked at are two different sets, and
+    # conflating them cost a whole task its score. Stage 3's task 43dc9778
+    # delivers a two-page scan next to a 17-page readable return, and all 67 of
+    # its rubric items select both. Escalating on the scan and then rendering
+    # the bundle asks for 67x2 = 134 pictures against a task budget of 72: over
+    # budget, every item excluded, 87.36% to 0.00%. The escalation was right and
+    # the render scope was wrong. The reason a file escalates is a fact about
+    # that file, so that file is what gets rendered -- 67 calls, inside the
+    # budget, and the readable sibling is still handed to the judge to read.
     if (
         (selected_paths_have_text is False or some_selected_path_lacks_text is True)
         and decision.modality in (Modality.TEXT, Modality.FORMATTING)
         and suffixes
         and suffixes.issubset(GRADER_VISUAL_RENDER_EXTENSIONS)
     ):
+        unreadable = set(paths_without_text or ())
+        narrowed = tuple(path for path in paths if path in unreadable)
         return RoutingDecision(
             modality=Modality.VISUAL,
             preferred_op="render_to_image",
             matched_keywords=decision.matched_keywords,
+            # Narrower or nothing. An unnamed set, or one covering every
+            # selected file, is the default the field already means, and
+            # saying it twice is a second thing to keep in step.
+            render_paths=(
+                narrowed if 0 < len(narrowed) < len(paths) else None
+            ),
         )
     return decision
 

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -599,13 +599,21 @@ class ToolCallingJudge:
         )
         prepass = visual_prepass or VisualPrepassResult()
         if decision.modality.value == "visual":
+            # What to look at is not the same list as what to read. A bundle
+            # can hold one file with no text layer next to a readable one, and
+            # the routing escalates on the first without conceding the second:
+            # the pictures are of the file that needs them, the whole bundle
+            # stays within reach of ``read_deliverable``. ``render_targets``
+            # is the same call the task budget and the free preflight make,
+            # which is what keeps the cross-check below honest.
+            visual_file_names = decision.render_targets(file_names)
             if visual_prepass is None:
                 prepass = self.preflight_visual(
                     item=item,
                     deliverable_dir=deliverable_dir,
-                    file_names=file_names,
+                    file_names=visual_file_names,
                 )
-            expected_paths = self.planned_supported_visual_names(file_names)
+            expected_paths = self.planned_supported_visual_names(visual_file_names)
             observed_paths = [entry.path for entry in prepass.entries]
             if prepass.judge_error is None and observed_paths != expected_paths:
                 prepass.judge_error = (

--- a/batch-runner/tests/test_grader_empty_read_routing.py
+++ b/batch-runner/tests/test_grader_empty_read_routing.py
@@ -22,6 +22,7 @@ import pytest
 
 from core.grader import Grader
 from core.grader_preflight import _planner, plan_task_runtime
+from core.grader_routing import Modality, resolve_runtime_routing
 from core.rubric_loader import RubricItem, TaskRubric
 
 
@@ -65,6 +66,20 @@ def typed(tmp_path: Path) -> Path:
     from reportlab.pdfgen import canvas
 
     p = tmp_path / "Scan.pdf"
+    document = canvas.Canvas(str(p))
+    document.drawString(100, 750, "The total contract value is 4,200 USD.")
+    document.showPage()
+    document.save()
+    return p
+
+
+@pytest.fixture
+def sibling(tmp_path: Path) -> Path:
+    """A readable file under its own name, to be selected beside the scan."""
+    pytest.importorskip("reportlab")
+    from reportlab.pdfgen import canvas
+
+    p = tmp_path / "Return.pdf"
     document = canvas.Canvas(str(p))
     document.drawString(100, 750, "The total contract value is 4,200 USD.")
     document.showPage()
@@ -287,3 +302,143 @@ def test_the_two_questions_share_one_read_of_each_file(tmp_path, monkeypatch):
     grader._some_selected_path_lacks_text(tmp_path, ["notes.txt"])
 
     assert len(opened) == 1
+
+
+# ── Which files escalated is which files get looked at (task 83) ─────
+#
+# Escalating and rendering are two different sets, and treating them as one
+# cost a whole task its score. Stage 3's task 43dc9778 delivers a two-page
+# scan beside a 17-page readable return, and all 67 of its rubric items
+# select both files. Every item escalated on the scan -- correctly, that is
+# the rule above doing its job -- and then asked for the bundle: 67 x 2 = 134
+# renders against a task visual budget of 72. Over budget, all 67 items
+# excluded, ``all_items_score_excluded``, 87.36% to 0.00%.
+#
+# The escalation was right and the render scope was wrong. What makes a file
+# escalate is a fact about that file, so that file is what gets rendered.
+
+
+def test_the_probe_names_the_file_that_cannot_be_read(tmp_path, scan, sibling):
+    answer = _probe_surface()._paths_without_text(
+        tmp_path, ["Return.pdf", "Scan.pdf"]
+    )
+
+    assert answer == ("Scan.pdf",)
+
+
+def test_a_file_the_probe_cannot_speak_for_is_not_named(tmp_path, scan):
+    """Same discipline as everywhere else here: only a measured no counts.
+
+    An unknown named in the render set would spend a picture on a guess,
+    which is what the ``None`` rule exists to prevent.
+    """
+    (tmp_path / "mystery.bin").write_bytes(b"\x00\x01\x02")
+
+    answer = _probe_surface()._paths_without_text(
+        tmp_path, ["Scan.pdf", "mystery.bin", "never_written.pdf"]
+    )
+
+    assert answer == ("Scan.pdf",)
+
+
+def test_only_the_unreadable_file_is_planned_for_rendering():
+    decision = resolve_runtime_routing(
+        _CONTENT_ITEM.criterion,
+        ["Return.pdf", "Scan.pdf"],
+        selected_paths_have_text=True,
+        some_selected_path_lacks_text=True,
+        paths_without_text=("Scan.pdf",),
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.render_paths == ("Scan.pdf",)
+    assert decision.render_targets(["Return.pdf", "Scan.pdf"]) == ["Scan.pdf"]
+
+
+def test_a_set_where_nothing_can_be_read_is_not_narrowed():
+    """Narrower or nothing.
+
+    When every selected file lacks text the render set is the selection, and
+    recording that twice is a second thing to keep in step with the first.
+    """
+    decision = resolve_runtime_routing(
+        _CONTENT_ITEM.criterion,
+        ["Flowchart.pdf", "Scan.pdf"],
+        selected_paths_have_text=False,
+        paths_without_text=("Flowchart.pdf", "Scan.pdf"),
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.render_paths is None
+    assert decision.render_targets(["Flowchart.pdf", "Scan.pdf"]) == [
+        "Flowchart.pdf",
+        "Scan.pdf",
+    ]
+
+
+def test_a_criterion_that_names_a_picture_still_asks_for_the_whole_bundle():
+    """The narrowing belongs to the escalation, not to VISUAL in general.
+
+    "Do the chart colours match the palette" is a question about the
+    deliverable. Answering it from one file of two would be answering a
+    different question, and nothing about that item's routing depends on
+    which of its files happens to carry a text layer.
+    """
+    decision = resolve_runtime_routing(
+        "The chart colors match the brand palette.",
+        ["Return.pdf", "Scan.pdf"],
+        selected_paths_have_text=True,
+        some_selected_path_lacks_text=True,
+        paths_without_text=("Scan.pdf",),
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.render_paths is None
+
+
+def test_an_escalation_that_names_no_files_asks_for_all_of_them():
+    """The answer is optional, and its absence is not a narrowing.
+
+    A caller that measures ``some_selected_path_lacks_text`` without saying
+    which file it was gets exactly the behaviour that shipped before this.
+    """
+    decision = resolve_runtime_routing(
+        _CONTENT_ITEM.criterion,
+        ["Return.pdf", "Scan.pdf"],
+        selected_paths_have_text=True,
+        some_selected_path_lacks_text=True,
+    )
+
+    assert decision.modality is Modality.VISUAL
+    assert decision.render_paths is None
+
+
+def test_one_scan_no_longer_spends_a_whole_task_visual_budget(
+    tmp_path, scan, sibling
+):
+    """The regression, at the scale that fits in a test.
+
+    Measured on the code this replaces, these same three items planned
+    ``task visual budget exceeded: planned=6, cap=4``, rendered nothing, and
+    took every item down with them -- the shape of ``planned=134, cap=72`` on
+    the real task. Each item now plans the scan alone.
+    """
+    items = [
+        RubricItem(f"r{index}", _CONTENT_ITEM.criterion, 2, None)
+        for index in range(3)
+    ]
+
+    plan = plan_task_runtime(
+        {"judge": {"perception": {"visual": {"call_cap_per_task": 4}}}},
+        _task("Produce Scan.pdf and Return.pdf.", items),
+        tmp_path,
+    )
+
+    assert plan["judge_routes"] == {"visual": 3}
+    assert [item["planned_visual_paths"] for item in plan["items"]] == [
+        ["Scan.pdf"],
+        ["Scan.pdf"],
+        ["Scan.pdf"],
+    ]
+    assert plan["planned_render_calls"] == 3
+    assert plan["errors"] == []

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import pytest
 
+from core.grader_routing import Modality, RoutingDecision
 from core.rubric_loader import RubricItem, TaskRubric
 from core.tool_calling_judge import (
     ToolCallingJudge,
@@ -1137,6 +1138,134 @@ def test_invalid_vision_verdict_is_blocked_before_main_judge(
     assert result.perception_called is True
     assert result.main_api_call_count == 0
     assert client.responses.calls == []
+
+
+def test_an_escalated_bundle_renders_only_the_file_that_needs_it(
+    deliverable_dir, task_and_item, monkeypatch
+):
+    """The judge must render what the budget counted, and read the rest.
+
+    A bundle-scope item is handed no prepass -- ``judge_item`` builds its own
+    from the file list -- so a render set narrowed in the plan and nowhere
+    else would be narrowed everywhere except where the pictures are actually
+    taken, and the consistency check inside would then fail every item the
+    narrowing had just saved. The sibling is not withheld from the judge: it
+    is not rendered, and it is still a file the judge is told it may read.
+    """
+    task, item = task_and_item
+    (deliverable_dir / "scan.pdf").write_bytes(b"%PDF-1.4\n%stub\n")
+    pytest.importorskip("PIL")
+    from PIL import Image
+    image = io.BytesIO()
+    Image.new("RGB", (8, 8), color="blue").save(image, format="PNG")
+    image_b64 = base64.b64encode(image.getvalue()).decode("ascii")
+
+    rendered: list[str] = []
+
+    def fake_read(op, path, *, base_dir, scope=None):
+        rendered.append(path)
+        return {
+            "ok": True,
+            "data": {
+                "kind": "image_png_base64",
+                "source_kind": "pdf",
+                "scope": dict(scope or {}),
+                "source_page_count": 2,
+                "converted_page_count": 1,
+                "renderer": {"converter": "pymupdf"},
+                "byte_size": len(image.getvalue()),
+                "base64": image_b64,
+            },
+        }
+
+    monkeypatch.setattr(tool_calling_judge_module, "read_deliverable", fake_read)
+
+    client = FakeClient(ScriptedResponses([_response(output=[_final(json.dumps({
+        "verdict": "pass", "partial_score": 1.0,
+        "evidence": "the scanned page states the value",
+        "confidence": 0.9, "reasoning": "looked at the page",
+        "tool_calls_made": 0,
+    }))])]))
+    judge = ToolCallingJudge(client=client, model="gpt-5.4",
+                             prompt_template=PROMPT_TEMPLATE,
+                             vision_perception=StubVision())
+
+    result = judge.judge_item(
+        task=task, item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx", "scan.pdf"],
+        routing_decision=RoutingDecision(
+            modality=Modality.VISUAL,
+            preferred_op="render_to_image",
+            matched_keywords=(),
+            render_paths=("scan.pdf",),
+        ),
+    )
+
+    assert rendered == ["scan.pdf"]
+    assert result.judge_error is None
+    assert result.render_call_count == 1
+    assert result.verdict == "pass"
+    assert "report.xlsx" in json.dumps(client.responses.calls[0], sort_keys=True)
+
+
+def test_a_visual_item_that_narrows_nothing_still_renders_the_bundle(
+    deliverable_dir, task_and_item, monkeypatch
+):
+    """The default is unchanged, and it is the ordinary case.
+
+    Every criterion that names something visual arrives with no render set of
+    its own, and asks for every selected file exactly as it did before.
+    """
+    task, item = task_and_item
+    (deliverable_dir / "scan.pdf").write_bytes(b"%PDF-1.4\n%stub\n")
+    pytest.importorskip("PIL")
+    from PIL import Image
+    image = io.BytesIO()
+    Image.new("RGB", (8, 8), color="blue").save(image, format="PNG")
+    image_b64 = base64.b64encode(image.getvalue()).decode("ascii")
+
+    rendered: list[str] = []
+
+    def fake_read(op, path, *, base_dir, scope=None):
+        rendered.append(path)
+        return {
+            "ok": True,
+            "data": {
+                "kind": "image_png_base64",
+                "source_kind": Path(path).suffix.lstrip("."),
+                "scope": dict(scope or {}),
+                "converted_page_count": 1,
+                "renderer": {"converter": "libreoffice"},
+                "byte_size": len(image.getvalue()),
+                "base64": image_b64,
+            },
+        }
+
+    monkeypatch.setattr(tool_calling_judge_module, "read_deliverable", fake_read)
+
+    client = FakeClient(ScriptedResponses([_response(output=[_final(json.dumps({
+        "verdict": "pass", "partial_score": 1.0, "evidence": "both surfaces",
+        "confidence": 0.9, "reasoning": "looked at both", "tool_calls_made": 0,
+    }))])]))
+    judge = ToolCallingJudge(client=client, model="gpt-5.4",
+                             prompt_template=PROMPT_TEMPLATE,
+                             vision_perception=StubVision())
+
+    result = judge.judge_item(
+        task=task, item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx", "scan.pdf"],
+        routing_decision=RoutingDecision(
+            modality=Modality.VISUAL,
+            preferred_op="render_to_image",
+            matched_keywords=("chart",),
+        ),
+    )
+
+    assert rendered == ["report.xlsx", "scan.pdf"]
+    assert result.judge_error is None
+    assert result.render_call_count == 2
 
 
 def test_routing_modality_text_omits_perception_tools(deliverable_dir, task_and_item):


### PR DESCRIPTION
## 무엇이 잘못됐나

3단계 gold 채점에서 `43dc9778` 과제가 **87.36% → 0.00%**로 떨어졌다. 원인은 PR #274(작업 79)에서 내가 넣은 규칙이다.

그 규칙은 옳다: **읽히는 이웃 파일은 읽히지 않는 파일에 대한 증거가 아니다.** 선택된 파일 중 하나라도 글자를 내주지 못하면, 그 항목을 "읽기"에서 "보기"로 올린다. 문제는 올린 뒤에 **묶음 전체**를 그림으로 렌더링한 것이다.

`43dc9778`은 두 파일을 낸다:

| 파일 | 크기 | 글자층 |
|---|---|---|
| `...COMPLETED 1040 PAGES 1&2.pdf` | 184,388 B | 없음 (스캔본) |
| `...TAX FORMS AND SCHEDULES REQUIRED FOR E-FILING edits.PDF` | 940,334 B | 있음 (17쪽) |

67개 채점 항목이 **전부 두 파일을 같이** 고른다. 그래서 67 × 2 = 134장을 요구했고, 과제당 그림 예산은 72장이다.

커밋된 채점 결과에서 그대로 읽은 증거:

- `task_visual_budget_exceeded:required_calls=134,cap=72` — 같은 샤드 파일에 69번 등장
- 67개 항목 전부 `visual`, 전부 `score_excluded`
- 과제 오류 `all_items_score_excluded`, `pct=0.0`
- PR #274 이전 같은 과제: **87.36%**, 경로 분포 `{'text': 66, 'visual': 1}` (1단계 반복 실행 4회 모두 같은 분포: 85.82 / 86.4 / 87.11 / 87.52)

## 무엇을 고쳤나

승격 판단은 그대로 두고, **렌더링 범위**만 좁힌다. 어떤 파일이 승격을 일으켰다면 그 근거는 그 파일에 대한 사실이므로, 그 파일만 렌더링한다. 67 × 1 = 67 ≤ 72 → 과제가 다시 채점된다. 읽히는 17쪽 신고서는 렌더링되지 않을 뿐, 판정 모델이 `read_deliverable`로 여전히 열어볼 수 있다.

- `RoutingDecision`에 `render_paths`와 `render_targets()`를 추가한다. `None`이 기본이고 "선택된 파일 전부"를 뜻한다.
- **승격 규칙만** 이 값을 채운다. `chart`·`color` 같은 기준어로 VISUAL이 된 항목은 예전처럼 묶음 전체를 요구한다 — "브랜드 색이 일관적인가"는 산출물 전체에 대한 질문이고, 두 파일 중 하나로 답하면 다른 질문에 답한 것이 된다.
- 모두 읽히지 않는 묶음은 좁히지 않는다(전부 = 기본값). 같은 사실을 두 군데 적어두면 두 군데를 맞춰야 한다.

## 네 곳이 같은 답을 써야 한다

묶음 범위 항목은 `visual_prepass`를 받지 않는다 — `judge_item`이 파일 목록으로 직접 만든다. 그래서 계획에서만 좁히면 예산 산수만 맞고 실제 렌더링은 그대로이며, 판정기 내부의 `required_visual_prepass_incomplete` 검사가 대신 터진다. 네 곳 모두 같은 `render_targets()`를 거치게 했다:

| 위치 | 역할 |
|---|---|
| `core/grader.py` `_runtime_criterion_plan` | 과제 그림 예산 계산 |
| `core/grader.py` `_judge_split_children` | 자식 분할 항목의 prepass 범위와 커버리지 검사 |
| `core/grader_preflight.py` (2곳) | 유료 실행을 정확히 예측해야 하는 무료 예행 검사 |
| `core/tool_calling_judge.py` `judge_item` | 실제로 그림을 찍는 곳 |

`Grader._paths_without_text()`가 "어느 파일이" 글자가 없는지 답한다. `_some_selected_path_lacks_text`가 이미 파일별로 전부 읽으므로 같은 메모를 공유하고, 읽기 비용은 늘지 않는다. 측정된 `False`만 답에 넣는다 — 알 수 없는 파일을 넣으면 추측으로 그림 한 장을 쓰게 되고, 그것이 `None` 규칙이 막으려는 것이다.

## 검증

축소 재현으로 **측정한** 이전 동작 (항목 3개 × 파일 2개, 예산 4장):

```
renders   : 0
errors    : ['task visual budget exceeded: planned=6, cap=4']
per item  : [['Return.pdf', 'Scan.pdf'], ['Return.pdf', 'Scan.pdf'], ['Return.pdf', 'Scan.pdf']]
```

같은 코드, 이 PR 적용 후:

```
renders   : 3
errors    : []
per item  : [['Scan.pdf'], ['Scan.pdf'], ['Scan.pdf']]
```

- 테스트 9개 추가 (라우팅 7 + 판정기 2). 작업 79가 세운 주장은 전부 그대로 통과한다.
- 전체 스위트: **5995 passed, 6 skipped, 45 deselected** (실패 0)
- mypy: 변경 전 31개 오류, 변경 후 31개 오류 — 같은 집합, 새로 생긴 것 없음

## 지문

채점기 소스 지문이 움직인다. 작업 84·85가 끝난 뒤 확인 실행을 한 번만 사면 되도록, 세 건을 이어서 처리한다.