### PR TITLE
fix(grading): 그림 예산을 못 맞춘 과제를 통째로 버리지 않는다

### DIFF
--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -11,7 +11,7 @@ import logging
 import os
 import re
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Callable, Iterable, Literal, Optional
 
@@ -209,6 +209,12 @@ class ItemGrade:
     render_call_count: int = 0
     render_total_latency_ms: float = 0.0
     usage_complete: bool = True
+    #: This item wanted pictures, the task could not afford them all, and it
+    #: was put back on the path it would have taken before the unreadable-file
+    #: escalation existed. The verdict below is a real verdict, read off a
+    #: readable file -- but it was read where a picture was preferred, and a
+    #: reader comparing it against another run needs to know that.
+    visual_budget_downgraded: bool = False
 
 
 @dataclass
@@ -251,6 +257,12 @@ class TaskGrade:
     render_call_count: int = 0
     render_total_latency_ms: float = 0.0
     usage_complete: bool = True
+    #: The visual budget this task could not meet, when it was met by giving
+    #: up pictures rather than by giving up the task. ``None`` on every task
+    #: that never came near the cap. The string is the shortfall as it was
+    #: originally measured, so the size of what was given up is on the record
+    #: even though the items below carry real scores.
+    visual_budget_fallback: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -262,6 +274,11 @@ class _RuntimeCriterionPlan:
     visual_preflight_error: Optional[str]
     supported_visual_call_count: int
     requires_visual: bool
+    #: Set only on a plan that was rebuilt to fit inside the task visual
+    #: budget, and only on the items the rebuild actually moved off the
+    #: render path. Carried onto the item's grade so the payload says which
+    #: verdicts were reached without the pictures they asked for.
+    visual_budget_downgraded: bool = False
 
 
 class Grader:
@@ -534,6 +551,17 @@ class Grader:
             for item in task.rubric_items
         ]
         visual_budget_error = self._task_visual_budget_error(runtime_plans)
+        visual_budget_fallback: str | None = None
+        if visual_budget_error:
+            runtime_plans, visual_budget_error, visual_budget_fallback = (
+                self._relax_to_fit_visual_budget(
+                    selection,
+                    task,
+                    runtime_plans,
+                    deliverable_path,
+                    visual_budget_error,
+                )
+            )
 
         items: list[ItemGrade] = []
         judge_call_count = 0
@@ -768,6 +796,13 @@ class Grader:
             items.append(ig)
 
         grade = self._aggregate(items, task)
+        grade.visual_budget_fallback = visual_budget_fallback
+        for item_grade, runtime_plan in zip(items, runtime_plans):
+            # Positional for the same reason the loop above is: ``items`` is a
+            # prefix of the rubric in canonical order, restored chunks
+            # included, and ``runtime_plans`` is built from the same list.
+            if runtime_plan.visual_budget_downgraded:
+                item_grade.visual_budget_downgraded = True
         grade.judge_call_count = judge_call_count
         grade.precheck_count = precheck_count
         grade.judge_total_latency_ms = round(judge_total_latency_ms, 2)
@@ -901,15 +936,37 @@ class Grader:
         item: RubricItem,
         plan: CriterionTargetPlan,
         deliverable_path: Path,
+        *,
+        escalate_readable_siblings: bool = True,
     ) -> _RuntimeCriterionPlan:
+        """Decide where one rubric item is judged, and what that will cost.
+
+        ``escalate_readable_siblings=False`` withholds one signal and one
+        only: "is any single selected file unreadable", the per-file question
+        added so a picture delivered beside a readable memo is still looked
+        at. Withholding it puts an item back on the path it took before that
+        question existed -- read the sibling that can be read.
+
+        It is the exact knob the budget fallback needs, because the two
+        signals split on exactly the case that matters. A bundle where
+        *something* can be read still has a text route to fall back to. A
+        bundle where *nothing* can be read has none, and there
+        ``selected_paths_have_text`` is still ``False`` and still escalates,
+        so this cannot resurrect the defect task 64 fixed: reading zero
+        characters and calling the content absent.
+        """
         item_decision = resolve_runtime_routing(
             item.criterion,
             plan.selected_paths,
             selected_paths_have_text=self._selected_paths_have_text(
                 deliverable_path, plan.selected_paths
             ),
-            some_selected_path_lacks_text=self._some_selected_path_lacks_text(
-                deliverable_path, plan.selected_paths
+            some_selected_path_lacks_text=(
+                self._some_selected_path_lacks_text(
+                    deliverable_path, plan.selected_paths
+                )
+                if escalate_readable_siblings
+                else None
             ),
             selected_paths_have_audio=self._selected_paths_have_audio(
                 deliverable_path, plan.selected_paths
@@ -944,6 +1001,8 @@ class Grader:
                         self._some_selected_path_lacks_text(
                             deliverable_path, target.paths
                         )
+                        if escalate_readable_siblings
+                        else None
                     ),
                     selected_paths_have_audio=self._selected_paths_have_audio(
                         deliverable_path, target.paths
@@ -1024,6 +1083,83 @@ class Grader:
         return (
             "task_visual_budget_exceeded:"
             f"required_calls={required},cap={cap}"
+        )
+
+    def _relax_to_fit_visual_budget(
+        self,
+        selection: DeliverableSelection,
+        task: TaskRubric,
+        runtime_plans: list[_RuntimeCriterionPlan],
+        deliverable_path: Path,
+        visual_budget_error: str,
+    ) -> tuple[list[_RuntimeCriterionPlan], str | None, str | None]:
+        """Give up pictures before giving up the task.
+
+        A task over its visual budget excludes every item that wanted a
+        picture, and a task with nothing left to score is dropped from the
+        corpus entirely -- not scored zero, *dropped*: ``_aggregate`` sets
+        ``all_items_score_excluded`` and the analysers count only tasks
+        without an error. Stage 3's task 43dc9778 asked for 134 renders
+        against a cap of 72 and left a 67-item, 87%-scoring task out of a
+        185-task corpus. Silently, because a corpus of 184 looks like a
+        corpus.
+
+        The item that escalated only because one of its files carries no
+        text layer has somewhere else to go: the readable sibling it was
+        selected beside. So when the budget cannot be met, ask what the task
+        would have cost without that escalation, and if that fits, grade it.
+        A partial verdict on a readable file beats no verdict at all, and it
+        is exactly the verdict this benchmark produced before the escalation
+        was added.
+
+        Two properties make this safe to do automatically. It cannot invent a
+        text verdict where there is no text -- an item whose files *all* lack
+        a text layer still escalates, because that signal is left switched on
+        (see ``_runtime_criterion_plan``). And it does not depend on rubric
+        order: nothing here spends the budget on the first N items and starves
+        the rest, which would make a task's score depend on how its rubric was
+        written and is not a thing a fingerprinted benchmark may do.
+
+        Returns the plans to grade with, the budget error that still applies
+        to them, and the shortfall to record on the task.
+        """
+        relaxed = [
+            self._runtime_criterion_plan(
+                selection,
+                item,
+                strict.target_plan,
+                deliverable_path,
+                escalate_readable_siblings=False,
+            )
+            for item, strict in zip(task.rubric_items, runtime_plans)
+        ]
+        strict_demand = sum(
+            plan.supported_visual_call_count for plan in runtime_plans
+        )
+        relaxed_demand = sum(plan.supported_visual_call_count for plan in relaxed)
+        if relaxed_demand >= strict_demand:
+            # Nothing to give up: every render this task wants is wanted by a
+            # criterion that names something visual. Failing closed is right.
+            return runtime_plans, visual_budget_error, None
+        marked = [
+            replace(plan, visual_budget_downgraded=True)
+            if strict.requires_visual and not plan.requires_visual
+            else plan
+            for plan, strict in zip(relaxed, runtime_plans)
+        ]
+        logger.warning(
+            "%s: %s; regrading %d item(s) without the unreadable-file "
+            "escalation (%d renders -> %d)",
+            task.task_id,
+            visual_budget_error,
+            sum(1 for plan in marked if plan.visual_budget_downgraded),
+            strict_demand,
+            relaxed_demand,
+        )
+        return (
+            marked,
+            self._task_visual_budget_error(marked),
+            visual_budget_error,
         )
 
     @staticmethod

--- a/batch-runner/core/grader_preflight.py
+++ b/batch-runner/core/grader_preflight.py
@@ -38,6 +38,127 @@ def plan_task_runtime(
     selection = grader._select_deliverables(task, deliverable_path, files)
     file_map = grader._relative_file_map(deliverable_path, files)
 
+    pass_args = (grader, task, deliverable_path, selection, file_map, visual_file_cap)
+    planned = _plan_pass(*pass_args, escalate_readable_siblings=True)
+
+    visual_config = (
+        (config.get("judge") or {}).get("perception") or {}
+    ).get("visual") or {}
+    audio_config = (
+        (config.get("judge") or {}).get("perception") or {}
+    ).get("audio") or {}
+    visual_cap = visual_config.get("call_cap_per_task")
+    audio_cap = audio_config.get("call_cap_per_task")
+
+    visual_budget_fallback: str | None = None
+    if (
+        isinstance(visual_cap, int)
+        and planned["planned_visual_calls"] > visual_cap
+    ):
+        # The same trade the paid run makes, for the same reason, so the
+        # rehearsal keeps predicting it: see
+        # ``Grader._relax_to_fit_visual_budget``. Planning it twice costs a
+        # second pass over local files and nothing else, and only on a task
+        # that was already over budget.
+        relaxed = _plan_pass(*pass_args, escalate_readable_siblings=False)
+        if relaxed["planned_visual_calls"] < planned["planned_visual_calls"]:
+            for relaxed_item, strict_item in zip(
+                relaxed["item_plans"], planned["item_plans"]
+            ):
+                if strict_item["requires_visual"] and not relaxed_item[
+                    "requires_visual"
+                ]:
+                    relaxed_item["visual_budget_downgraded"] = True
+            visual_budget_fallback = (
+                "task visual budget exceeded: "
+                f"planned={planned['planned_visual_calls']}, cap={visual_cap}"
+            )
+            planned = relaxed
+
+    routes = planned["routes"]
+    planned_main_judgments = planned["planned_main_judgments"]
+    planned_visual_calls = planned["planned_visual_calls"]
+    planned_audio_calls = planned["planned_audio_calls"]
+    item_plans = planned["item_plans"]
+    errors = planned["errors"]
+    unsupported_visual_paths = sorted(set(planned["unsupported_visual_paths"]))
+
+    if (
+        isinstance(visual_cap, int)
+        and planned_visual_calls > visual_cap
+    ):
+        budget_error = (
+            "task visual budget exceeded: "
+            f"planned={planned_visual_calls}, cap={visual_cap}"
+        )
+        errors.append(budget_error)
+        for item_plan in item_plans:
+            if (
+                item_plan.get("outcome") == "judge"
+                and item_plan.get("planned_render_calls", 0) > 0
+            ):
+                planned_main_judgments -= item_plan["planned_main_judgments"]
+                planned_visual_calls -= item_plan["planned_render_calls"]
+                planned_audio_calls -= item_plan["planned_audio_calls"]
+                item_plan.update({
+                    "outcome": "preflight_error",
+                    "preflight_error": budget_error,
+                    "planned_main_judgments": 0,
+                    "planned_render_calls": 0,
+                    "planned_audio_calls": 0,
+                    "planned_perception_calls": 0,
+                })
+    if isinstance(audio_cap, int) and planned_audio_calls > audio_cap:
+        errors.append(
+            "task audio budget exceeded: "
+            f"planned={planned_audio_calls}, cap={audio_cap}"
+        )
+    if planned_audio_calls:
+        if not audio_config.get("model"):
+            errors.append("audio routes require configured audio perception")
+        errors.append(
+            "audio perception calls are model-selected and cannot be exact: "
+            f"routes={planned_audio_calls}"
+        )
+
+    return {
+        "task_id": task.task_id,
+        "selection": selection.to_dict(),
+        "rubric_items": len(task.rubric_items),
+        "precheck_candidates": planned["precheck_candidates"],
+        "precheck_resolved": planned["precheck_resolved"],
+        "precheck_fallbacks": planned["precheck_fallbacks"],
+        "judge_routes": dict(sorted(routes.items())),
+        "planned_main_judgments": planned_main_judgments,
+        "planned_render_calls": planned_visual_calls,
+        "planned_audio_calls": planned_audio_calls,
+        "planned_perception_calls": planned_visual_calls + planned_audio_calls,
+        "visual_call_cap": visual_cap,
+        "audio_call_cap": audio_cap,
+        "visual_budget_fallback": visual_budget_fallback,
+        "unsupported_visual_paths": unsupported_visual_paths,
+        "errors": errors,
+        "items": item_plans,
+    }
+
+
+def _plan_pass(
+    grader: Grader,
+    task: TaskRubric,
+    deliverable_path: Path,
+    selection: Any,
+    file_map: dict[str, Path],
+    visual_file_cap: int,
+    *,
+    escalate_readable_siblings: bool,
+) -> dict[str, Any]:
+    """One routing pass over a task's rubric, with no budget applied.
+
+    Split out from ``plan_task_runtime`` so the budget fallback can ask what
+    the same task would have cost on the pre-escalation routing, exactly as
+    the paid run does. ``escalate_readable_siblings`` is the same single knob
+    ``Grader._runtime_criterion_plan`` takes and means the same thing there.
+    """
     routes: Counter[str] = Counter()
     precheck_candidates = 0
     precheck_resolved = 0
@@ -69,6 +190,11 @@ def plan_task_runtime(
             "planned_render_calls": 0,
             "planned_audio_calls": 0,
             "planned_perception_calls": 0,
+            # Whether this item asked for pictures at all, before any cap
+            # zeroed the count. The budget fallback compares the two passes
+            # on this and nothing else.
+            "requires_visual": False,
+            "visual_budget_downgraded": False,
         }
 
         if target_plan.target_scope == "selection_error":
@@ -103,6 +229,8 @@ def plan_task_runtime(
                         grader._some_selected_path_lacks_text(
                             deliverable_path, target.paths
                         )
+                        if escalate_readable_siblings
+                        else None
                     ),
                     selected_paths_have_audio=grader._selected_paths_have_audio(
                         deliverable_path, target.paths
@@ -114,6 +242,7 @@ def plan_task_runtime(
                 child_routes.append(decision.modality.value)
                 if decision.modality is Modality.VISUAL:
                     child_render = decision.render_targets(target.paths)
+                    item_plan["requires_visual"] = bool(child_render)
                     planned_names, child_visual_error = (
                         ToolCallingJudge.validate_planned_visual_names(
                             child_render, visual_file_cap
@@ -219,8 +348,12 @@ def plan_task_runtime(
             selected_paths_have_text=grader._selected_paths_have_text(
                 deliverable_path, target_plan.selected_paths
             ),
-            some_selected_path_lacks_text=grader._some_selected_path_lacks_text(
-                deliverable_path, target_plan.selected_paths
+            some_selected_path_lacks_text=(
+                grader._some_selected_path_lacks_text(
+                    deliverable_path, target_plan.selected_paths
+                )
+                if escalate_readable_siblings
+                else None
             ),
             selected_paths_have_audio=grader._selected_paths_have_audio(
                 deliverable_path, target_plan.selected_paths
@@ -237,6 +370,7 @@ def plan_task_runtime(
             # escalated item is narrower than the selection. Counting the
             # selection here would predict a budget the run never spends.
             render_targets = decision.render_targets(target_plan.selected_paths)
+            item_plan["requires_visual"] = bool(render_targets)
             planned_names, visual_error = (
                 ToolCallingJudge.validate_planned_visual_names(
                     render_targets, visual_file_cap
@@ -280,70 +414,17 @@ def plan_task_runtime(
         })
         item_plans.append(item_plan)
 
-    unsupported_visual_paths = sorted(set(unsupported_visual_paths))
-    visual_config = (
-        (config.get("judge") or {}).get("perception") or {}
-    ).get("visual") or {}
-    audio_config = (
-        (config.get("judge") or {}).get("perception") or {}
-    ).get("audio") or {}
-    visual_cap = visual_config.get("call_cap_per_task")
-    if (
-        isinstance(visual_cap, int)
-        and planned_visual_calls > visual_cap
-    ):
-        budget_error = (
-            "task visual budget exceeded: "
-            f"planned={planned_visual_calls}, cap={visual_cap}"
-        )
-        errors.append(budget_error)
-        for item_plan in item_plans:
-            if (
-                item_plan.get("outcome") == "judge"
-                and item_plan.get("planned_render_calls", 0) > 0
-            ):
-                planned_main_judgments -= item_plan["planned_main_judgments"]
-                planned_visual_calls -= item_plan["planned_render_calls"]
-                planned_audio_calls -= item_plan["planned_audio_calls"]
-                item_plan.update({
-                    "outcome": "preflight_error",
-                    "preflight_error": budget_error,
-                    "planned_main_judgments": 0,
-                    "planned_render_calls": 0,
-                    "planned_audio_calls": 0,
-                    "planned_perception_calls": 0,
-                })
-    audio_cap = audio_config.get("call_cap_per_task")
-    if isinstance(audio_cap, int) and planned_audio_calls > audio_cap:
-        errors.append(
-            "task audio budget exceeded: "
-            f"planned={planned_audio_calls}, cap={audio_cap}"
-        )
-    if planned_audio_calls:
-        if not audio_config.get("model"):
-            errors.append("audio routes require configured audio perception")
-        errors.append(
-            "audio perception calls are model-selected and cannot be exact: "
-            f"routes={planned_audio_calls}"
-        )
-
     return {
-        "task_id": task.task_id,
-        "selection": selection.to_dict(),
-        "rubric_items": len(task.rubric_items),
+        "routes": routes,
         "precheck_candidates": precheck_candidates,
         "precheck_resolved": precheck_resolved,
         "precheck_fallbacks": precheck_fallbacks,
-        "judge_routes": dict(sorted(routes.items())),
         "planned_main_judgments": planned_main_judgments,
-        "planned_render_calls": planned_visual_calls,
+        "planned_visual_calls": planned_visual_calls,
         "planned_audio_calls": planned_audio_calls,
-        "planned_perception_calls": planned_visual_calls + planned_audio_calls,
-        "visual_call_cap": visual_cap,
-        "audio_call_cap": audio_cap,
         "unsupported_visual_paths": unsupported_visual_paths,
         "errors": errors,
-        "items": item_plans,
+        "item_plans": item_plans,
     }
 
 
@@ -383,6 +464,15 @@ def summarize_cohort(task_plans: list[dict[str, Any]]) -> dict[str, Any]:
             for task in task_plans
             for path in task["unsupported_visual_paths"]
         }),
+        # Named, not counted. A task that gave up pictures to stay in the
+        # corpus is a task whose score means something slightly different
+        # from its neighbours', and the whole point of the preflight is that
+        # nobody has to read 185 task blocks to find out which ones.
+        "visual_budget_fallback_task_ids": [
+            task["task_id"]
+            for task in task_plans
+            if task.get("visual_budget_fallback")
+        ],
         "errors": [
             f"{task['task_id']}: {error}"
             for task in task_plans

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -632,7 +632,8 @@
                 "perception_total_latency_ms": {"type": "number", "minimum": 0},
                 "render_call_count": {"type": "integer", "minimum": 0},
                 "render_total_latency_ms": {"type": "number", "minimum": 0},
-                "usage_complete": {"type": "boolean"}
+                "usage_complete": {"type": "boolean"},
+                "visual_budget_downgraded": {"type": "boolean", "description": "This item routed to the render path only because one of its selected files carries no text layer, the task could not afford every such render inside `judge.perception.visual.call_cap_per_task`, and it was put back on the text path it would have taken before that escalation existed. The verdict is a real verdict read off a readable file, not an exclusion — but it was read where a picture was preferred. See the task-level `visual_budget_fallback` for the shortfall that triggered it."}
               },
               "additionalProperties": true
             }
@@ -665,6 +666,7 @@
           "selection_status": {"type": ["string", "null"]},
           "selection_error": {"type": ["string", "null"]},
           "error": {"type": ["string", "null"]},
+          "visual_budget_fallback": {"type": ["string", "null"], "description": "Present when this task's planned renders exceeded `judge.perception.visual.call_cap_per_task` and the task was graded anyway, by dropping the unreadable-file escalation on the items that had a readable file to fall back to. The string is the shortfall as originally measured (`task_visual_budget_exceeded:required_calls=N,cap=M`), so the size of what was given up survives even though the items below carry real scores. Null on every task that never came near the cap. Without this fallback such a task excludes every item, reports `all_items_score_excluded`, and is dropped from the corpus mean entirely."},
           "graded_at": {"type": "string"}
         },
         "additionalProperties": true

--- a/batch-runner/tests/test_grader_empty_read_routing.py
+++ b/batch-runner/tests/test_grader_empty_read_routing.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import pytest
 
 from core.grader import Grader
-from core.grader_preflight import _planner, plan_task_runtime
+from core.grader_preflight import _planner, plan_task_runtime, summarize_cohort
 from core.grader_routing import Modality, resolve_runtime_routing
 from core.rubric_loader import RubricItem, TaskRubric
 
@@ -442,3 +442,118 @@ def test_one_scan_no_longer_spends_a_whole_task_visual_budget(
     ]
     assert plan["planned_render_calls"] == 3
     assert plan["errors"] == []
+
+
+# ── Give up pictures before giving up the task (task 84) ─────────────
+#
+# The narrowing above takes 43dc9778 from 134 renders to 67 and back inside
+# its budget of 72, so that task is fixed. The failure mode is not: any task
+# whose escalated items outnumber its visual budget still excludes every one
+# of them, reports ``all_items_score_excluded``, and is then dropped from the
+# corpus by every analyser -- ``_aggregate`` in the grader, ``_aggregate`` in
+# ``analyze_gold_ceiling.py`` and ``step8_grade.py`` all count only tasks
+# without an error. Not a zero in the mean. A silently shorter corpus.
+#
+# An item that escalated only because one of its files carries no text layer
+# has somewhere else to go: the readable file it was selected beside. That is
+# the verdict this benchmark produced before the escalation existed, and it
+# beats no verdict at all.
+
+
+def test_over_budget_is_replanned_onto_the_readable_file(
+    tmp_path, scan, sibling
+):
+    """Measured both ways on the same five items and the same cap of two.
+
+    Before: ``planned=5, cap=2``, zero renders, zero judgments, every item a
+    preflight error -- the shape that empties a task. After: five text
+    judgments, no error, and the shortfall recorded rather than paid.
+    """
+    items = [
+        RubricItem(f"r{index}", _CONTENT_ITEM.criterion, 2, None)
+        for index in range(5)
+    ]
+
+    plan = plan_task_runtime(
+        {"judge": {"perception": {"visual": {"call_cap_per_task": 2}}}},
+        _task("Produce Scan.pdf and Return.pdf.", items),
+        tmp_path,
+    )
+
+    assert plan["judge_routes"] == {"text": 5}
+    assert plan["planned_main_judgments"] == 5
+    assert plan["planned_render_calls"] == 0
+    assert plan["errors"] == []
+    assert plan["visual_budget_fallback"] == (
+        "task visual budget exceeded: planned=5, cap=2"
+    )
+    assert all(item["visual_budget_downgraded"] for item in plan["items"])
+
+
+def test_a_budget_that_fits_is_left_alone(tmp_path, scan, sibling):
+    """The fallback is a last resort, not a preference.
+
+    Same five items, a cap that covers them, and nothing about the plan
+    changes: the pictures are what the escalation asked for.
+    """
+    items = [
+        RubricItem(f"r{index}", _CONTENT_ITEM.criterion, 2, None)
+        for index in range(5)
+    ]
+
+    plan = plan_task_runtime(
+        {"judge": {"perception": {"visual": {"call_cap_per_task": 5}}}},
+        _task("Produce Scan.pdf and Return.pdf.", items),
+        tmp_path,
+    )
+
+    assert plan["judge_routes"] == {"visual": 5}
+    assert plan["planned_render_calls"] == 5
+    assert plan["visual_budget_fallback"] is None
+    assert not any(item["visual_budget_downgraded"] for item in plan["items"])
+
+
+def test_nothing_readable_is_not_replanned_onto_nothing(tmp_path, scan):
+    """The rehearsal fails closed wherever the paid run does.
+
+    Both selected files are pictures, so there is no text route to fall back
+    to and the escalation must stand. Answering these from a read would be
+    the task-64 defect: zero characters reported as absent content.
+    """
+    (tmp_path / "Return.pdf").write_bytes((tmp_path / "Scan.pdf").read_bytes())
+    items = [
+        RubricItem(f"r{index}", _CONTENT_ITEM.criterion, 2, None)
+        for index in range(5)
+    ]
+
+    plan = plan_task_runtime(
+        {"judge": {"perception": {"visual": {"call_cap_per_task": 2}}}},
+        _task("Produce Scan.pdf and Return.pdf.", items),
+        tmp_path,
+    )
+
+    assert plan["visual_budget_fallback"] is None
+    assert plan["planned_render_calls"] == 0
+    assert plan["planned_main_judgments"] == 0
+    assert plan["errors"] == [
+        "task visual budget exceeded: planned=10, cap=2"
+    ]
+
+
+def test_the_cohort_summary_names_the_task_that_gave_up_pictures(
+    tmp_path, scan, sibling
+):
+    """185 task blocks is not a place to notice this by reading."""
+    items = [
+        RubricItem(f"r{index}", _CONTENT_ITEM.criterion, 2, None)
+        for index in range(5)
+    ]
+    config = {"judge": {"perception": {"visual": {"call_cap_per_task": 2}}}}
+
+    summary = summarize_cohort([
+        plan_task_runtime(
+            config, _task("Produce Scan.pdf and Return.pdf.", items), tmp_path
+        )
+    ])
+
+    assert summary["visual_budget_fallback_task_ids"] == ["task-1"]

--- a/batch-runner/tests/test_grader_selector_integration.py
+++ b/batch-runner/tests/test_grader_selector_integration.py
@@ -1369,6 +1369,241 @@ def test_task_visual_budget_fails_all_visual_items_before_any_calls(
     assert responses.calls == []
 
 
+def _image_only_pdf(path: Path) -> Path:
+    """A PDF whose pages are pictures and whose text layer is empty."""
+    pytest.importorskip("reportlab")
+    pytest.importorskip("fitz")
+    pytest.importorskip("PIL")
+    from PIL import Image
+    from reportlab.lib.utils import ImageReader
+    from reportlab.pdfgen import canvas
+
+    photo = path.parent / f"_{path.stem}.png"
+    Image.new("RGB", (64, 64), color="white").save(photo)
+    document = canvas.Canvas(str(path))
+    for _ in range(2):
+        document.drawImage(ImageReader(str(photo)), 40, 40, width=200, height=200)
+        document.showPage()
+    document.save()
+    photo.unlink()
+    return path
+
+
+def _typed_pdf(path: Path) -> Path:
+    pytest.importorskip("reportlab")
+    from reportlab.pdfgen import canvas
+
+    document = canvas.Canvas(str(path))
+    document.drawString(100, 750, "The total contract value is 4,200 USD.")
+    document.showPage()
+    document.save()
+    return path
+
+
+def _scan_beside_readable_return(tmp_path: Path) -> Path:
+    deliverable_dir = tmp_path / "task"
+    deliverable_dir.mkdir()
+    _image_only_pdf(deliverable_dir / "Scan.pdf")
+    _typed_pdf(deliverable_dir / "Return.pdf")
+    return deliverable_dir
+
+
+def _content_task(task_id: str, count: int):
+    from core.rubric_loader import RubricItem, TaskRubric
+
+    return TaskRubric(
+        task_id=task_id,
+        sector="Finance",
+        occupation="Tax Preparer",
+        prompt="Produce Scan.pdf and Return.pdf.",
+        rubric_items=[
+            RubricItem(
+                f"r{index}",
+                "The document states the total contract value.",
+                2,
+                None,
+            )
+            for index in range(count)
+        ],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+
+def test_visual_budget_falls_back_before_it_excludes_a_whole_task(
+    monkeypatch, tmp_path
+):
+    """The 43dc9778 shape: over budget, and still graded.
+
+    Two items about the contents of a bundle holding one scan and one
+    readable return. Each escalates on the scan, so the task wants two
+    renders against a cap of one. Excluding both would leave nothing scored,
+    which is not a zero -- it is an ``all_items_score_excluded`` task that
+    the analysers drop from the corpus. Falling back to the readable sibling
+    grades it, and says so on the payload.
+    """
+    responses = ScriptedResponses([
+        _response(output=[_final(_payload("pass", 1.0, "the return states 4,200"))]),
+        _response(output=[_final(_payload("pass", 1.0, "the return states 4,200"))]),
+    ])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision(call_cap=1)
+    grader._tool_judge.vision_perception = vision
+
+    grade = grader.grade_task(
+        _content_task("t-budget-fallback", 2),
+        str(_scan_beside_readable_return(tmp_path)),
+    )
+
+    assert grade.visual_budget_fallback == (
+        "task_visual_budget_exceeded:required_calls=2,cap=1"
+    )
+    assert grade.error is None
+    assert [item.verdict for item in grade.items] == ["pass", "pass"]
+    assert not any(item.score_excluded for item in grade.items)
+    assert all(item.visual_budget_downgraded for item in grade.items)
+    assert [item.routing_modality for item in grade.items] == ["text", "text"]
+    assert grade.pct == 100.0
+    # The point of falling back is not to spend the budget differently.
+    assert vision.calls == []
+    assert grade.render_call_count == 0
+
+
+def test_a_task_with_nothing_readable_still_fails_closed(monkeypatch, tmp_path):
+    """The rule task 64 established, which this must not undo.
+
+    When *every* selected file is a picture there is no text to fall back
+    to, and reading zero characters would produce a fail verdict about a
+    document that says the thing. Over budget with nothing to give up is
+    still over budget.
+    """
+    responses = ScriptedResponses([])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision(call_cap=1)
+    grader._tool_judge.vision_perception = vision
+    deliverable_dir = tmp_path / "task"
+    deliverable_dir.mkdir()
+    _image_only_pdf(deliverable_dir / "Scan.pdf")
+    _image_only_pdf(deliverable_dir / "Return.pdf")
+
+    grade = grader.grade_task(
+        _content_task("t-nothing-readable", 2), str(deliverable_dir)
+    )
+
+    assert grade.visual_budget_fallback is None
+    assert all(item.score_excluded for item in grade.items)
+    assert not any(item.visual_budget_downgraded for item in grade.items)
+    assert grade.error == "all_items_score_excluded"
+    assert vision.calls == []
+    assert responses.calls == []
+
+
+def test_a_criterion_that_names_a_picture_is_not_given_a_text_verdict(
+    monkeypatch, tmp_path
+):
+    """"Is the chart colour readable" has no answer in the characters.
+
+    The fallback trades a preferred render for an acceptable read. A
+    criterion classified VISUAL on its own words never had a read to fall
+    back to, so the budget still fails it closed -- which is what
+    ``test_task_visual_budget_fails_all_visual_items_before_any_calls``
+    pins, here with a readable file present to prove the fallback is not
+    what decides it.
+    """
+    from core.rubric_loader import RubricItem, TaskRubric
+
+    responses = ScriptedResponses([])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision(call_cap=1)
+    grader._tool_judge.vision_perception = vision
+    task = TaskRubric(
+        task_id="t-explicit-visual",
+        sector="Finance",
+        occupation="Tax Preparer",
+        prompt="Produce Scan.pdf and Return.pdf.",
+        rubric_items=[
+            RubricItem("v1", "Chart color is readable", 2, None),
+            RubricItem("v2", "Graph layout is polished", 2, None),
+        ],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+    grade = grader.grade_task(task, str(_scan_beside_readable_return(tmp_path)))
+
+    assert grade.visual_budget_fallback is None
+    assert all(item.score_excluded for item in grade.items)
+    assert all(
+        item.evidence == "task_visual_budget_exceeded:required_calls=4,cap=1"
+        for item in grade.items
+    )
+    assert vision.calls == []
+
+
+def test_the_fallback_saves_what_it_can_and_excludes_the_rest(
+    monkeypatch, tmp_path
+):
+    """A budget that the fallback narrows but still cannot meet.
+
+    Three items on the same scan-beside-readable-return bundle: two content
+    criteria that escalated only on the scan, and one that names a chart.
+    Strict, the task wants four renders against a cap of one. Dropping the
+    escalation takes it to two -- an improvement, still over. So the two
+    content items are graded from the readable file and the chart item is
+    excluded, which is the honest split: the fallback rescues exactly the
+    items that had somewhere else to go, and invents nothing for the one
+    that did not.
+
+    The task survives with a partial score instead of vanishing from the
+    corpus, and ``visual_budget_fallback`` records the original shortfall so
+    a reader can see this score was reached the cheap way.
+    """
+    from core.rubric_loader import RubricItem, TaskRubric
+
+    responses = ScriptedResponses([
+        _response(output=[_final(_payload("pass", 1.0, "states 4,200 USD"))]),
+        _response(output=[_final(_payload("pass", 1.0, "states 4,200 USD"))]),
+    ])
+    grader = _grader(monkeypatch, SimpleNamespace(responses=responses))
+    vision = CountingVision(call_cap=1)
+    grader._tool_judge.vision_perception = vision
+    task = TaskRubric(
+        task_id="t-partial-rescue",
+        sector="Finance",
+        occupation="Tax Preparer",
+        prompt="Produce Scan.pdf and Return.pdf.",
+        rubric_items=[
+            RubricItem("c1", "The document states the total contract value.", 2, None),
+            RubricItem("c2", "The document states the total contract value.", 2, None),
+            RubricItem("v1", "Chart color is readable", 2, None),
+        ],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+
+    grade = grader.grade_task(task, str(_scan_beside_readable_return(tmp_path)))
+
+    by_id = {item.rubric_item_id: item for item in grade.items}
+    assert grade.error is None
+    assert grade.visual_budget_fallback == (
+        "task_visual_budget_exceeded:required_calls=4,cap=1"
+    )
+    assert [by_id[i].score_excluded for i in ("c1", "c2", "v1")] == [
+        False, False, True,
+    ]
+    assert [by_id[i].visual_budget_downgraded for i in ("c1", "c2", "v1")] == [
+        True, True, False,
+    ]
+    assert [by_id[i].routing_modality for i in ("c1", "c2")] == ["text", "text"]
+    assert by_id["v1"].evidence == (
+        "task_visual_budget_exceeded:required_calls=2,cap=1"
+    )
+    assert vision.calls == []
+
+
 def test_task_visual_budget_within_cap_spends_per_criterion(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## 무슨 일이 일어나는가

과제 하나가 시각 예산을 넘기면 그림을 원한 항목이 **전부** 제외된다. 남은 항목이 없으면 과제에 `all_items_score_excluded`가 붙고, 오류가 붙은 과제는 `_aggregate`·`analyze_gold_ceiling.py`·`step8_grade.py` 세 곳 모두에서 **세지 않는다**.

**평균이 0점으로 내려가는 게 아니다. 과제가 코퍼스에서 사라진다.** 185개가 184개가 되고, 184개도 185개처럼 보인다. 이게 이 수정의 진짜 이유다 — 처음에 "평균을 끌어내린다"고 쓴 건 틀렸다.

## 고치는 방법

파일 하나에 글자층이 없다는 이유로 그림 경로로 올라간 항목에는 갈 곳이 있다. **같이 선택된, 읽히는 형제 파일**이다. 그게 이 승격이 생기기 전 이 벤치마크가 내던 판정이고, 판정이 아예 없는 것보다 낫다. 그래서 예산을 못 맞추면 그 승격 없이 다시 계산하고, 예산 안에 들어오면 그 계획으로 채점한다.

### 자동으로 해도 안전한 이유 둘

- **글이 없는 곳에서 글 판정을 지어내지 않는다.** 선택된 파일이 *전부* 글자층이 없으면 `selected_paths_have_text`가 여전히 False라 그대로 승격된 채 닫힌다. 과제 #64가 고친 결함(0글자를 읽고 "내용이 없다"고 판정)이 되살아날 수 없다.
- **채점표 순서에 기대지 않는다.** "앞의 N개에 예산을 다 쓰고 나머지를 굶긴다" 같은 배분은 안 한다. 그러면 과제 점수가 채점표를 쓴 순서에 좌우된다.

좁혀도 여전히 넘치면 갈 곳이 있던 항목만 살리고 나머지는 그대로 제외한다. 그림을 이름으로 요구한 기준("차트 색이 읽히는가")은 애초에 돌아갈 글 경로가 없으므로 손대지 않는다.

## 기록으로 남는 것

| 어디 | 필드 | 무엇 |
|---|---|---|
| 과제 | `visual_budget_fallback` | 원래 측정된 부족분 문자열 — 무엇을 얼마나 포기했는지 |
| 항목 | `visual_budget_downgraded` | 이 판정이 그림 대신 글로 나왔다는 표시 |
| 코호트 요약 | `visual_budget_fallback_task_ids` | 과제를 세지 않고 **이름으로** 적는다 |

무료 예행연습(`grader_preflight`)도 같은 판단을 같은 이유로 하므로, 유료 실행에서 무슨 일이 일어날지 계속 맞게 예측한다.

## `43dc9778`에 대해

이 과제의 0점은 **#303이 이미 고쳤다**. 읽히지 않는 파일 하나가 과제 전체를 그림으로 올려보내던 게 원인이었고, 그건 내가 #274에서 넣은 회귀였다. 이 PR은 그 뒤에 남는 경우 — 승격이 정당한데도 예산이 모자란 경우 — 를 맡는다.

## 검증

`batch-runner`에서 전체 6,002개 통과 (6 skip, 45 deselect, 721초, exit 0).