### PR TITLE
docs(grading): 소리 smoke 설정에 적힌 창구 이름을 바로잡는다

### DIFF
--- a/batch-runner/grading_configs/gold_smoke_audio_v2_sol_max.yaml
+++ b/batch-runner/grading_configs/gold_smoke_audio_v2_sol_max.yaml
@@ -20,12 +20,22 @@ description: |
 
   Why these two, and why the list grew by one. The smoke was pinned to
   `75401f7c` on the theory that a bundle carrying .mp3, .mp4 and .wav is the
-  cheapest exercise of the Responses API `input_audio` shape. The 174-task
-  partial run then found the defect that theory was guessing at, and named its
-  full blast radius: exactly two tasks had audio criteria demoted to TEXT and
-  scored by a judge that could not hear -- `75401f7c` (14 items, 18.0 of 56)
-  and `e222075d` (7 items, 10.3 of 60). Both are Film and Video Editors, which
-  is why they are corpus-adjacent; consecutive rows share an occupation.
+  cheapest exercise of the `input_audio` shape. That sentence used to say
+  "the Responses API `input_audio` shape", which was wrong: audio is the one
+  modality the two endpoints disagree about. `ResponseInputContentParam` is a
+  union of text, image and file only, so a Responses request carrying audio is
+  refused 400 before any model hears it -- which is exactly how the first two
+  paid smokes failed, in half a second, with zero perception tokens. Audio
+  belongs to `ChatCompletionContentPartParam`, and core/perception/audio.py
+  has sent it to Chat Completions since #302. The third smoke (run
+  33381143279) is the first whose audio calls settled: 19 of them, all
+  resolved against gpt-audio-1.5, 8,448 input and 1,411 output tokens.
+  The 174-task partial run then found the defect that theory was guessing at,
+  and named its full blast radius: exactly two tasks had audio criteria
+  demoted to TEXT and scored by a judge that could not hear -- `75401f7c`
+  (14 items, 18.0 of 56) and `e222075d` (7 items, 10.3 of 60). Both are Film
+  and Video Editors, which is why they are corpus-adjacent; consecutive rows
+  share an occupation.
 
   A smoke covering one of the two would leave the other's regression unproven
   while costing most of what covering both costs, so the pin is now the


### PR DESCRIPTION
## 무엇

`gold_smoke_audio_v2_sol_max.yaml`의 설명이 아직 **"Responses API의 `input_audio` 모양"** 이라고 적고 있었다. PR #302가 증명한 것이 정확히 그 반대다.

> `ResponseInputContentParam`은 **글·그림·파일 셋의 합집합**이다. 소리를 실은 Responses 요청은 **모델이 듣기 전에 400으로 거절된다.** 소리는 `ChatCompletionContentPartParam`에 속하고, `core/perception/audio.py`는 #302 이후 **Chat Completions**로 보낸다.

첫 두 유료 smoke가 **0.5초 만에 토큰 0으로** 죽은 이유가 이것이다. 설명만 남아서 다음 사람에게 같은 오해를 그대로 물려준다.

고치면서 3차 smoke(실행 `33381143279`)가 실제로 확인한 숫자도 같이 적었다 — **소리 호출 19건 전부 `gpt-audio-1.5`로 정산, 들여보낸 8,448 / 받은 1,411 토큰.** 첫 정산된 소리 호출이다.

## 무엇을 안 바꿨나

설명 블록 하나만 바꿨다. **`task_ids` 두 개, 순서, `call_cap_per_task: 32`, 나머지 실행값은 전부 그대로다.**

## 왜 지금인가

설정 파일은 **채점기 지문에 들어간다.** 유료 실행이 도는 중에 손대면 60시간을 쓰고 마지막 합치기에서만 실패한다. 지금은 안전하다 — **#303 병합으로 지문이 이미 움직였고, 도는 shard가 없다.** 어차피 움직인 지문에 얹는 것이라 추가 비용이 0이다.

## 검증

| | |
|---|---|
| `test_the_audio_smoke_covers_what_the_defect_damaged.py` | 10개 통과 (고정 목록이 피해 표와 여전히 일치) |
| 설정·지문 관련 | 237개 통과, 2 skip |

관련: #307 (3차 smoke 기록), #302 (창구 수정)