### PR TITLE
fix(grading): 답변 자리가 바닥난 재시도는 생각을 줄이고 답을 쓴다

### DIFF
--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -79,6 +79,21 @@ _FINALIZATION_RETRY_PROMPT = (
     "required valid JSON verdict envelope."
 )
 
+#: Every reasoning effort the judge accepts, cheapest first. Ordered so a
+#: ceiling can be applied without ever raising an effort a config chose to
+#: set lower.
+_REASONING_EFFORTS = ("none", "low", "medium", "high", "xhigh", "max")
+
+#: The one retry reason that says the room ran out rather than the answer
+#: went wrong: the first attempt spent its whole output budget and left no
+#: text behind.
+_OUT_OF_ROOM_RETRY_REASON = "empty_final_text:max_output_tokens"
+
+#: Ceiling on the retry's reasoning when the room ran out. Effort is the
+#: thing that consumed the budget, so the retry has to want less of it than
+#: the attempt that overflowed.
+_OUT_OF_ROOM_EFFORT_CEILING = "low"
+
 
 def _bounded_prompt_cache_key(value: str) -> str:
     if len(value) <= _PROMPT_CACHE_KEY_MAX_CHARS:
@@ -460,6 +475,37 @@ def _finalization_retry_reason(
     return None
 
 
+def _finalization_effort(configured: str, retry_reason: Optional[str]) -> str:
+    """How hard the finalization retry is allowed to think.
+
+    The retry exists to turn evidence already gathered into a short JSON
+    envelope. It keeps the same ``max_output_tokens`` as the attempt before
+    it, because that cap is what the run's cost ceiling is priced against --
+    so on ``empty_final_text:max_output_tokens`` the retry is handed exactly
+    the budget the first attempt just exhausted. Spending it on reasoning
+    again writes no envelope for a second time, and the item costs two full
+    output budgets to produce nothing.
+
+    So that one reason, and only that one, holds the effort down: the retry
+    is forbidden tools and asked for a fixed short shape, and what it needs
+    is room to write it. Every other reason -- unparseable JSON, an envelope
+    missing a field -- means the model did produce text under this budget and
+    got the shape wrong, and there more thought is the repair, so the
+    configured effort stands.
+
+    Held down, never pushed up: a config that deliberately set ``"none"``
+    keeps ``"none"``.
+    """
+    if retry_reason != _OUT_OF_ROOM_RETRY_REASON:
+        return configured
+    try:
+        ceiling = _REASONING_EFFORTS.index(_OUT_OF_ROOM_EFFORT_CEILING)
+        chosen = _REASONING_EFFORTS.index(configured)
+    except ValueError:
+        return configured
+    return _REASONING_EFFORTS[min(chosen, ceiling)]
+
+
 # ----------------------------------------------------------------------
 # Judge
 # ----------------------------------------------------------------------
@@ -492,7 +538,9 @@ class ToolCallingJudge:
                      missing or malformed after evidence is ready.
         finalization_reasoning_effort: reasoning effort used for the bounded
                  no-tools finalization retry. Defaults to ``"low"`` for
-                 existing configs.
+                 existing configs. Held down to ``"low"`` when the retry was
+                 triggered by the first attempt exhausting
+                 ``max_output_tokens`` — see ``_finalization_effort``.
         vision_perception:       optional ``VisionPerception`` instance.
                      For VISUAL items the harness renders and
                      invokes it before the first main request;
@@ -547,9 +595,7 @@ class ToolCallingJudge:
         if self.finalization_retries < 0:
             raise ValueError("finalization_retries must be non-negative")
         self.finalization_retries = min(self.finalization_retries, 1)
-        if self.finalization_reasoning_effort not in {
-            "none", "low", "medium", "high", "xhigh", "max"
-        }:
+        if self.finalization_reasoning_effort not in _REASONING_EFFORTS:
             raise ValueError("finalization_reasoning_effort is invalid")
         invalid_ops = set(self.model_read_ops) - set(MODEL_READ_DELIVERABLE_OPS)
         if invalid_ops:
@@ -663,6 +709,10 @@ class ToolCallingJudge:
         audio_unanswerable: Optional[str] = None
         finalization_only = False
         finalization_retries_used = 0
+        # Which failure sent us into finalization, kept because the answer to
+        # "how hard should the retry think" depends on it. See
+        # ``_finalization_effort``.
+        finalization_retry_reason: Optional[str] = None
 
         while iterations < self.max_iterations + (
             finalization_retries_used if finalization_only else 0
@@ -692,7 +742,10 @@ class ToolCallingJudge:
                     create_kwargs.pop("tools")
                     create_kwargs.pop("parallel_tool_calls")
                     create_kwargs["reasoning"] = {
-                        "effort": self.finalization_reasoning_effort
+                        "effort": _finalization_effort(
+                            self.finalization_reasoning_effort,
+                            finalization_retry_reason,
+                        )
                     }
                 # PR3 step 1b — context_management server-side compaction.
                 # The SDK signature exposes a dict shape but Azure's
@@ -730,7 +783,10 @@ class ToolCallingJudge:
                         model=self.model,
                         input=messages,
                         reasoning={
-                            "effort": self.finalization_reasoning_effort
+                            "effort": _finalization_effort(
+                                self.finalization_reasoning_effort,
+                                finalization_retry_reason,
+                            )
                             if finalization_only
                             else self.reasoning_effort
                         },
@@ -861,6 +917,7 @@ class ToolCallingJudge:
                 })
                 finalization_retries_used += 1
                 finalization_only = True
+                finalization_retry_reason = retry_reason
                 continue
             break
         else:

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -408,9 +408,32 @@ def test_empty_final_retry_budget_exhaustion_stays_fail_closed(
     assert len(client.responses.calls) == 2
 
 
-def test_finalization_retry_uses_configured_max_effort(
+# ── The retry that ran out of room must not want more of what filled it ──
+#
+# Task 85. The retry keeps the same ``max_output_tokens`` as the attempt
+# before it -- deliberately, because that cap is what the run's cost ceiling
+# is priced against. So on ``empty_final_text:max_output_tokens`` the retry is
+# handed exactly the budget the first attempt just exhausted. Stage 3 ran
+# ``reasoning.effort: max`` beside ``finalization_reasoning_effort: max`` and
+# ``max_output_tokens: 2400``: the call whose whole job was "stop thinking and
+# write the envelope" thought as hard as the one that overflowed, under the
+# same budget, and wrote no envelope either. Two full output budgets, one
+# judge_error, twelve minutes.
+#
+# The distinction the fix draws is between running out of room and getting
+# the answer wrong. Only the first is a reason to think less.
+
+
+def test_a_retry_after_exhausting_the_budget_stops_thinking_and_writes(
     deliverable_dir, task_and_item
 ):
+    """The configured effort is held down for the one reason that earned it.
+
+    ``max`` on the first call, because that is what the config asked for and
+    the item is genuinely hard. ``low`` on the retry, because the retry is
+    forbidden tools, has the evidence already, and needs room to write a
+    short JSON envelope -- not room to reason its way to the same overflow.
+    """
     task, item = task_and_item
     empty = _response(
         out_tok=2400,
@@ -423,7 +446,7 @@ def test_finalization_retry_uses_configured_max_effort(
             "partial_score": 1.0,
             "evidence": "validated from prior evidence",
             "confidence": 0.9,
-            "reasoning": "finalized with max effort",
+            "reasoning": "finalized once it stopped reasoning",
         }))],
     )
     client = FakeClient(ScriptedResponses([empty, final]))
@@ -444,7 +467,134 @@ def test_finalization_retry_uses_configured_max_effort(
 
     assert result.verdict == "pass"
     assert client.responses.calls[0]["reasoning"] == {"effort": "max"}
-    assert client.responses.calls[1]["reasoning"] == {"effort": "max"}
+    assert client.responses.calls[1]["reasoning"] == {"effort": "low"}
+    # The budget itself is untouched. Moving it would move what the run costs
+    # and what the cost ceiling was pre-registered against; the room was
+    # always enough for an envelope, and the fix is about what fills it.
+    assert client.responses.calls[1]["max_output_tokens"] == 2400
+
+
+def test_the_ceiling_never_raises_an_effort_a_config_set_lower(
+    deliverable_dir, task_and_item
+):
+    """Held down, never pushed up.
+
+    A config that set the retry to ``none`` wanted no reasoning at all, and
+    ``none`` already spends nothing on the thing that overflowed. Reading the
+    rule as "use low here" would make this call think more than it was told
+    to.
+    """
+    task, item = task_and_item
+    empty = _response(
+        out_tok=2400,
+        status="incomplete",
+        incomplete_reason="max_output_tokens",
+    )
+    final = _response(
+        output=[_final(json.dumps({
+            "verdict": "pass",
+            "partial_score": 1.0,
+            "evidence": "validated from prior evidence",
+            "confidence": 0.9,
+            "reasoning": "finalized without reasoning",
+        }))],
+    )
+    client = FakeClient(ScriptedResponses([empty, final]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.6-sol",
+        prompt_template=PROMPT_TEMPLATE,
+        reasoning_effort="max",
+        finalization_reasoning_effort="none",
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+    assert result.verdict == "pass"
+    assert client.responses.calls[1]["reasoning"] == {"effort": "none"}
+
+
+def test_the_ceiling_applies_to_the_legacy_call_shape_too(
+    deliverable_dir, task_and_item, monkeypatch
+):
+    """The fallback path sends its own reasoning block, and grades with it.
+
+    ``responses.create`` is called twice per iteration when the SDK rejects
+    the modern kwargs: once to fail, once in the legacy shape. That second
+    call is a real graded call, so a fix that only touched the modern shape
+    would leave the defect live on every run that trips the fallback.
+    """
+    task, item = task_and_item
+    final_payload = json.dumps({
+        "verdict": "pass",
+        "partial_score": 1.0,
+        "evidence": "validated from prior evidence",
+        "confidence": 0.9,
+        "reasoning": "finalized on the legacy shape",
+    })
+    empty = _response(
+        out_tok=2400,
+        status="incomplete",
+        incomplete_reason="max_output_tokens",
+    )
+    final = _response(output=[_final(final_payload)])
+
+    class RejectsModernKwargs(ScriptedResponses):
+        """Rejects only the modern shape, exactly as the live SDK does."""
+
+        def create(self, **kwargs: Any) -> Any:
+            if "prompt_cache_key" in kwargs:
+                self.calls.append(kwargs)
+                raise TypeError("unexpected keyword argument 'prompt_cache_key'")
+            return super().create(**kwargs)
+
+    client = FakeClient(RejectsModernKwargs([empty, final]))
+    judge = ToolCallingJudge(
+        client=client,
+        model="gpt-5.6-sol",
+        prompt_template=PROMPT_TEMPLATE,
+        reasoning_effort="max",
+        finalization_reasoning_effort="max",
+    )
+
+    result = judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+    assert result.verdict == "pass"
+    legacy = [c for c in client.responses.calls if "prompt_cache_key" not in c]
+    assert len(legacy) == 2
+    assert legacy[0]["reasoning"] == {"effort": "max"}
+    assert legacy[1]["reasoning"] == {"effort": "low"}
+    assert "tools" not in legacy[1]
+
+
+def test_the_effort_ceiling_is_decided_by_the_reason_alone():
+    """The rule stated once, against every reason that reaches it.
+
+    The three retry reasons above it in ``_finalization_retry_reason`` are the
+    complete set, so this is the whole decision table. ``None`` is there
+    because a caller that never retried must not be handed a downgrade.
+    """
+    ceiling = tool_calling_judge_module._finalization_effort
+
+    assert ceiling("max", "empty_final_text:max_output_tokens") == "low"
+    # Produced text, got the shape wrong: more thought is the repair.
+    assert ceiling("max", "final_json_parse_failed") == "max"
+    assert ceiling("max", "invalid_final_envelope") == "max"
+    # Empty for a reason that is not the budget -- a filtered or cut-off
+    # response. Nothing says effort caused it, so nothing is taken away.
+    assert ceiling("max", "empty_final_text:content_filter") == "max"
+    assert ceiling("max", "empty_final_text:unknown") == "max"
+    assert ceiling("max", None) == "max"
 
 
 def test_semantic_invalid_final_retries_once_with_configured_max_effort(


### PR DESCRIPTION
## 무슨 일이 일어나는가

마무리 재시도는 앞선 호출과 **같은** `max_output_tokens`를 그대로 받는다. 비용 상한이 그 숫자를 기준으로 산정되어 있으니 의도된 설계다.

그런데 `empty_final_text:max_output_tokens`로 들어온 재시도는 **방금 다 써버린 예산을 그대로 다시** 받는다. 그 자리를 또 추론에 쓰면 두 번째로도 봉투를 못 쓰고, 한 항목이 출력 예산 **두 개**를 태우고 `judge_error`로 끝난다.

Stage 3 설정이 정확히 그 모양이다:

```yaml
reasoning:
  effort: max
finalization_reasoning_effort: max
max_output_tokens: 2400
```

"도구 그만 쓰고 봉투만 써라"가 유일한 목적인 호출이, 방금 넘친 호출만큼 생각한다.

## 고치는 방법

**자리가 모자란 것**과 **답을 틀린 것**을 구분한다.

| 재시도 이유 | 무엇이 잘못됐나 | 추론 강도 |
|---|---|---|
| `empty_final_text:max_output_tokens` | 생각하다 자리가 바닥났다 | **`low`로 누른다** |
| JSON 파싱 실패 | 이 예산 안에서 글은 썼고 모양이 틀렸다 | 설정값 그대로 |
| 봉투 필드 누락 | 위와 같다 | 설정값 그대로 |
| 그 외 / 없음 | — | 설정값 그대로 |

모양이 틀린 경우는 **더** 생각하는 쪽이 고치는 방법이므로 건드리지 않는다.

## 누르기만 하고 올리지 않는다

`_finalization_effort(configured, retry_reason)`는 설정값보다 **낮은** 값만 돌려준다. `none`으로 설정한 곳은 `none`으로 남는다. 설정이 이미 `low` 이하면 그대로다.

호출 수·재시도 수·토큰 상한이 전부 그대로라 **비용 상한 계산은 움직이지 않는다.**

## 적용 범위

- 최신 SDK 호출 경로와 legacy 대체 호출 경로 **양쪽**
- 이 결함을 그대로 굳혀두던 기존 테스트를 새 규칙으로 교체
- 판정표 전체(4가지 이유 + `None`)를 단위 테스트로 고정

## 검증

`tests/test_tool_calling_judge.py` 93개 통과. 수정을 `git stash`로 되돌리면 3개 실패 — 테스트가 실제로 이 동작을 잡고 있다.