### PR TITLE
feat(grading): 유료 채점이 도는 동안 채점기 지문이 움직이지 않게 막는다

### DIFF
--- a/.github/workflows/grader-hash-freeze.yml
+++ b/.github/workflows/grader-hash-freeze.yml
@@ -1,0 +1,130 @@
+name: Grader Hash Freeze
+
+# One file merged under batch-runner/core/ while eleven shards are grading is
+# the most expensive mistake this repository can make, and the cheapest one to
+# make by accident. Every shard stamps the grader source hash it ran under;
+# step9_merge_shards lists that field among the ten identity invariants the
+# shards must agree on, and step9 only starts once every shard has finished.
+# So a mid-run merge is green, the shards keep running, the bill is paid in
+# full, and the union is refused about sixty hours later with nothing to
+# salvage. It has nearly happened three times: PR #302, #303 and the current
+# queue each moved the fingerprint between a smoke and its dispatch.
+#
+# This workflow does not stop that merge. A check is advisory unless branch
+# protection requires it, and a pull request that was green yesterday can be
+# merged today. What it does is make the trap red at the moment somebody is
+# looking at it, which is the difference between "we forgot" and "we decided".
+#
+# It is deliberately outside batch-runner/. compute_grader_source_hash rejects
+# any source path outside that directory, so nothing this workflow adds can
+# itself move a fingerprint -- otherwise the guard against needing a new smoke
+# would have required a new smoke.
+
+on:
+  pull_request:
+    paths:
+      - "batch-runner/step8_grade.py"
+      - "batch-runner/core/**"
+      - "batch-runner/prompts/**"
+      - "batch-runner/grading_configs/**"
+      - "batch-runner/schemas/grade.schema.json"
+      - "batch-runner/requirements.txt"
+      - "batch-runner/scripts/download_inference_from_hf.py"
+      # So the guard is exercised by its own changes.
+      - "batch-runner/scripts/check_grader_hash_freeze.py"
+      - ".github/workflows/grader-hash-freeze.yml"
+  # Answers "is a freeze in effect right now?" without opening a pull request.
+  # There is no diff to inspect, so it probes with a known hash-moving path.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+concurrency:
+  group: grader-hash-freeze-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  freeze-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+
+      - name: Collect the paths this pull request changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR:-}" ]; then
+            # workflow_dispatch. Probe with a path that always moves the hash
+            # so the result reports the freeze state rather than "no diff".
+            echo '["batch-runner/core/grader.py"]' > changed.json
+            echo "manual run: probing with batch-runner/core/grader.py"
+          else
+            gh api "repos/${REPO}/pulls/${PR}/files" --paginate \
+              --jq '[.[].filename]' | jq -s 'add' > changed.json
+          fi
+          echo "changed paths:"
+          jq -r '.[]' changed.json
+
+      - name: Collect grade runs that have not finished
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Base repository, always -- github.repository on a pull_request
+          # event is the base, so a fork PR cannot point this at its own
+          # quiet fork and come back clear.
+          gh api "repos/${REPO}/actions/workflows/grade-run.yml/runs?per_page=50" \
+            --jq '[.workflow_runs[]
+                   | select(.status != "completed")
+                   | {id: .id, status: .status, url: .html_url}]' > runs_bare.json
+
+          # A run's job list is what separates a paid run from a dry one, but
+          # only once you read the conclusions. The jobs API lists *skipped*
+          # jobs too, so a paid run contains a `grade-dry-run` entry and a dry
+          # run contains a `grade` entry; presence proves nothing either way.
+          # It also reports display names rather than job keys, which is why
+          # approve-paid arrives as "Approve paid Sol Max grading (...)".
+          #
+          # If the jobs API declines to answer, the field is left absent and
+          # the checker treats the run as paid.
+          jq -c '.[]' runs_bare.json | while read -r run; do
+            id=$(echo "$run" | jq -r '.id')
+            if jobs=$(gh api "repos/${REPO}/actions/runs/${id}/jobs" \
+                        --paginate --jq '[.jobs[] | {name, conclusion}]' 2>/dev/null); then
+              echo "$run" | jq --argjson j "$(echo "$jobs" | jq -s 'add')" \
+                '. + {jobs: $j}'
+            else
+              echo "::warning::could not list jobs for run ${id}; treating it as paid"
+              echo "$run"
+            fi
+          done | jq -s '.' > runs.json
+
+          echo "in-flight grade runs:"
+          cat runs.json
+
+      - name: Decide
+        run: |
+          set -euo pipefail
+          python3 batch-runner/scripts/check_grader_hash_freeze.py \
+            --changed-paths changed.json \
+            --runs runs.json | tee decision.txt
+
+      - name: Explain the result in the job summary
+        if: always()
+        run: |
+          {
+            echo '## Grader hash freeze'
+            echo
+            echo '```'
+            cat decision.txt 2>/dev/null || echo 'the check did not get as far as a decision'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/analyze_gold_ceiling.py
 !batch-runner/scripts/analyze_variance.py
 !batch-runner/scripts/stage3_partial_inventory.py
+!batch-runner/scripts/check_grader_hash_freeze.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/batch-runner/scripts/check_grader_hash_freeze.py
+++ b/batch-runner/scripts/check_grader_hash_freeze.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Refuse a grader-source change while a paid grade run is in flight.
+
+Merging one file under ``batch-runner/core/`` while eleven shards are grading
+costs nothing for about sixty hours and then costs everything. Each shard
+stamps its own ``grader_source_hash``; ``step9_merge_shards`` lists that field
+among the ten identity invariants two shards must agree on, and step9 only
+runs once every shard has finished. So the spend happens first and the union
+is refused afterwards, leaving partials that no longer agree with each other
+and nothing to salvage. ``--force`` does not override a short or mixed union,
+by design -- see ``304-B-partial-blocked.md``.
+
+The failure is silent at the moment it is caused. Nothing about merging a
+one-line fix says "you have just written off two and a half days of grading";
+the merge is green, the shards keep running, and the bill arrives before the
+error does. This module is the cheap half of the answer: a pull request that
+would move the hash gets a red check for as long as a paid run is alive, at
+the moment the pull request is opened or updated rather than at merge time.
+
+What it is not: a hard gate. A check is advisory unless the repository
+requires it in branch protection, and a pull request that was green yesterday
+can still be merged today. This turns an invisible trap into a visible one --
+the difference between "we forgot" and "we decided" -- and does not pretend to
+be more than that.
+
+Fail-closed. If an in-flight run cannot be shown to be free, it counts as
+paid. A false red costs one conversation; a false green costs the run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Iterable, Sequence
+
+#: Jobs on the paid path in ``grade-run.yml``, matched against what the jobs
+#: API actually returns. Two traps live here, both found by checking the
+#: classifier against real runs rather than against the workflow file:
+#:
+#: 1. The API reports a job's *display name*, and never its key. ``grade`` has
+#:    no ``name:`` override so the two coincide, but ``approve-paid`` renders
+#:    as "Approve paid Sol Max grading (exp_gold_baseline, ...)". Matching on
+#:    the key would have missed it in every run.
+#: 2. The API lists jobs that were *skipped*. A paid run therefore contains a
+#:    ``grade-dry-run`` entry, and a dry run contains a ``grade`` entry. Job
+#:    presence alone distinguishes nothing; only the conclusion does.
+PAID_JOB_EXACT_NAMES = frozenset({"grade"})
+PAID_JOB_NAME_PREFIXES = ("Approve paid ",)
+
+#: The one conclusion that proves a job did not happen. Every other value --
+#: success, failure, cancelled, and null for a job still running or queued --
+#: means the paid path is live or has already spent.
+SKIPPED = "skipped"
+
+#: Run statuses that mean "still alive". GitHub reports ``waiting`` while a
+#: run sits at an environment approval gate; that run has not spent anything
+#: yet, but it is about to, and the approval is usually seconds away.
+LIVE_STATUSES = frozenset({"queued", "in_progress", "waiting", "pending", "requested"})
+
+
+def is_paid_path_job(name: str) -> bool:
+    cleaned = name.strip()
+    if cleaned in PAID_JOB_EXACT_NAMES:
+        return True
+    return any(cleaned.startswith(prefix) for prefix in PAID_JOB_NAME_PREFIXES)
+
+
+#: Repo-relative paths whose bytes enter ``compute_grader_source_hash``.
+#: Mirrored by hand because the hash function builds its list from a loaded
+#: config and a filesystem walk, neither of which a pull-request check has.
+#: ``test_grader_hash_freeze.py`` spies on the real function's reads and fails
+#: if this set ever stops covering them, so the mirror cannot drift quietly.
+_EXACT_HASHED_FILES = frozenset(
+    {
+        "batch-runner/step8_grade.py",
+        "batch-runner/schemas/grade.schema.json",
+        "batch-runner/requirements.txt",
+        "batch-runner/scripts/download_inference_from_hf.py",
+    }
+)
+
+#: ``(directory prefix, required suffix or None)``. ``core`` contributes only
+#: its ``.py`` files -- the hash function walks ``core.rglob("*")`` and keeps
+#: ``suffix == ".py"`` -- so a fixture or a README under core is not hashed
+#: and must not freeze a merge.
+_HASHED_TREES: tuple[tuple[str, str | None], ...] = (
+    ("batch-runner/core/", ".py"),
+    ("batch-runner/prompts/", None),
+    ("batch-runner/grading_configs/", None),
+)
+
+
+def is_grader_source_path(path: str) -> bool:
+    """True when changing ``path`` would move some config's grader source hash.
+
+    Deliberately generous in two places. Every file under ``prompts/`` counts,
+    though only the template a config names is hashed: which template that is
+    depends on the config, and a check that has to load configs to answer a
+    yes/no question is a check that fails for the wrong reasons. Same for
+    ``grading_configs/`` -- the hash covers the one config being run, and the
+    check does not know which run is in flight.
+    """
+    normalised = PurePosixPath(path.strip().lstrip("./")).as_posix()
+    if normalised in _EXACT_HASHED_FILES:
+        return True
+    for prefix, suffix in _HASHED_TREES:
+        if normalised.startswith(prefix):
+            if suffix is None or normalised.endswith(suffix):
+                return True
+    return False
+
+
+@dataclass(frozen=True)
+class LiveRun:
+    """One grade-run workflow run that has not finished."""
+
+    run_id: str
+    status: str
+    url: str
+    paid: bool
+    #: Why ``paid`` holds the value it does, so a red check can explain itself
+    #: without the reader opening the API by hand.
+    paid_reason: str
+
+
+def classify_runs(raw_runs: Iterable[dict[str, Any]]) -> list[LiveRun]:
+    """Turn the workflow's JSON into runs, fail-closed on anything unclear.
+
+    ``jobs`` is expected to be that run's job list, each entry carrying at
+    least ``name`` and ``conclusion``. A run is called free only on positive
+    evidence: at least one paid-path job is visible *and* every visible one
+    concluded ``skipped``. Everything else is paid -- an absent list (the jobs
+    API declined to answer), a list too early to contain either branch, and a
+    paid job still running, which reports a null conclusion.
+    """
+    live: list[LiveRun] = []
+    for raw in raw_runs:
+        status = str(raw.get("status") or "").strip().lower()
+        if status not in LIVE_STATUSES:
+            continue
+        run_id = str(raw.get("id") or raw.get("databaseId") or "?")
+        url = str(raw.get("url") or raw.get("html_url") or "")
+        jobs = raw.get("jobs")
+
+        if not isinstance(jobs, list) or not jobs:
+            paid, reason = True, "job list unavailable, assumed paid"
+        else:
+            paid_path = [
+                j
+                for j in jobs
+                if isinstance(j, dict) and is_paid_path_job(str(j.get("name") or ""))
+            ]
+            if not paid_path:
+                # `validate-request` runs on both paths, so it says nothing.
+                # Silence is not evidence that this run is free.
+                paid, reason = True, "too early to tell, assumed paid"
+            else:
+                alive = [
+                    j
+                    for j in paid_path
+                    if str(j.get("conclusion") or "").strip().lower() != SKIPPED
+                ]
+                if alive:
+                    names = ", ".join(
+                        sorted({str(j.get("name") or "?").split(" (")[0] for j in alive})
+                    )
+                    paid, reason = True, f"paid job not skipped: {names}"
+                else:
+                    paid, reason = False, "every paid job skipped, dry run"
+
+        live.append(
+            LiveRun(run_id=run_id, status=status, url=url, paid=paid, paid_reason=reason)
+        )
+    return live
+
+
+@dataclass(frozen=True)
+class Decision:
+    frozen: bool
+    moving_paths: tuple[str, ...]
+    blocking_runs: tuple[LiveRun, ...]
+    summary: str
+
+
+def decide(changed_paths: Sequence[str], raw_runs: Iterable[dict[str, Any]]) -> Decision:
+    """Freeze only when both halves are true: the diff moves the hash *and*
+    a paid run is alive. Either alone is ordinary and must stay green."""
+    moving = tuple(sorted({p for p in changed_paths if is_grader_source_path(p)}))
+    blocking = tuple(r for r in classify_runs(raw_runs) if r.paid)
+
+    if not moving:
+        return Decision(False, moving, blocking, "no grader-source file in this diff")
+    if not blocking:
+        return Decision(False, moving, blocking, "no paid grade run in flight")
+    return Decision(
+        True,
+        moving,
+        blocking,
+        f"{len(moving)} grader-source file(s) changed while "
+        f"{len(blocking)} paid grade run(s) are in flight",
+    )
+
+
+def render(decision: Decision) -> str:
+    lines: list[str] = []
+    if not decision.frozen:
+        lines.append(f"PASS: {decision.summary}")
+        if decision.moving_paths:
+            lines.append("")
+            lines.append(
+                "This diff does move the grader source hash. That is fine right "
+                "now, but it means the next paid run has to be preceded by a "
+                "fresh smoke at the new fingerprint."
+            )
+            for path in decision.moving_paths:
+                lines.append(f"  - {path}")
+        return "\n".join(lines)
+
+    lines.append(f"FROZEN: {decision.summary}")
+    lines.append("")
+    lines.append("Grader-source files in this diff:")
+    for path in decision.moving_paths:
+        lines.append(f"  - {path}")
+    lines.append("")
+    lines.append("Paid grade runs still alive:")
+    for run in decision.blocking_runs:
+        location = run.url or f"run {run.run_id}"
+        lines.append(f"  - {run.run_id} [{run.status}] ({run.paid_reason}) {location}")
+    lines.append("")
+    lines.append(
+        "Merging this would give the remaining shards a different "
+        "grader_source_hash from the ones already graded. step9_merge_shards "
+        "requires that field to be identical across shards and only runs after "
+        "every shard finishes, so the union would be refused after the whole "
+        "run had been paid for -- roughly sixty hours for the 185-task corpus. "
+        "Wait for the run to finish, then merge."
+    )
+    return "\n".join(lines)
+
+
+def _load(path: str) -> Any:
+    if path == "-":
+        return json.load(sys.stdin)
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-paths",
+        required=True,
+        help="JSON array of repo-relative paths changed by the pull request, or - for stdin",
+    )
+    parser.add_argument(
+        "--runs",
+        required=True,
+        help="JSON array of in-flight grade-run runs, or - for stdin",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        changed = _load(args.changed_paths)
+        runs = _load(args.runs)
+    except (OSError, ValueError) as exc:
+        print(f"FROZEN: could not read the check's own inputs: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(changed, list) or not isinstance(runs, list):
+        print("FROZEN: inputs must both be JSON arrays", file=sys.stderr)
+        return 1
+
+    decision = decide([str(p) for p in changed], runs)
+    print(render(decision))
+    return 1 if decision.frozen else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/batch-runner/tests/test_grader_hash_freeze.py
+++ b/batch-runner/tests/test_grader_hash_freeze.py
@@ -1,0 +1,551 @@
+"""Tests for the grader-hash merge freeze.
+
+The interesting one is `TestThePredicateStillCoversWhatIsActuallyHashed`. The
+predicate in `check_grader_hash_freeze` is a hand-written mirror of the path
+set `compute_grader_source_hash` builds at runtime, and a hand-written mirror
+of anything rots. So rather than asserting against a second hand-written list,
+these tests watch the real hash function read files and require the predicate
+to have classified every one of them as hash-moving. Add an input to the hash
+and this test fails until the predicate learns about it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+BATCH_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BATCH_ROOT.parent
+SCRIPT_PATH = BATCH_ROOT / "scripts" / "check_grader_hash_freeze.py"
+
+sys.path.insert(0, str(BATCH_ROOT))
+
+_spec = importlib.util.spec_from_file_location("check_grader_hash_freeze", SCRIPT_PATH)
+assert _spec and _spec.loader
+freeze = importlib.util.module_from_spec(_spec)
+# Register before executing: @dataclass resolves KW_ONLY by looking the
+# defining module up in sys.modules, and raises AttributeError on None if the
+# module was loaded by path and never registered.
+sys.modules["check_grader_hash_freeze"] = freeze
+_spec.loader.exec_module(freeze)
+
+import step8_grade  # noqa: E402
+
+
+def job(name: str, conclusion: str | None = None) -> dict:
+    return {"name": name, "conclusion": conclusion}
+
+
+def live(run_id: str = "1", *, jobs: list[dict] | None, status: str = "in_progress") -> dict:
+    run = {"id": run_id, "status": status, "url": f"https://x/{run_id}"}
+    if jobs is not None:
+        run["jobs"] = jobs
+    return run
+
+
+# Copied verbatim off run 33381143279, the third audio smoke, which was paid.
+# Two things about this list are the whole reason the classifier reads
+# conclusions instead of names: `grade-dry-run` is present in a *paid* run,
+# and approve-paid arrives under its rendered display name.
+APPROVE_PAID_DISPLAY_NAME = (
+    "Approve paid Sol Max grading (exp_gold_baseline, "
+    "gold_smoke_audio_v2_sol_max.yaml, chunk 0, shard 0/1)"
+)
+REAL_PAID_JOBS = [
+    job("validate-request", "success"),
+    job(APPROVE_PAID_DISPLAY_NAME, "success"),
+    job("grade-dry-run", "skipped"),
+    job("grade", "success"),
+]
+REAL_DRY_JOBS = [
+    job("validate-request", "success"),
+    job(APPROVE_PAID_DISPLAY_NAME, "skipped"),
+    job("grade-dry-run", "success"),
+    job("grade", "skipped"),
+]
+
+PAID = live("33400000001", jobs=REAL_PAID_JOBS)
+DRY = live("33400000002", jobs=REAL_DRY_JOBS)
+# At the environment gate: approve-paid exists with no conclusion yet, and
+# `grade` has not been created at all.
+AT_THE_GATE = live(
+    "33400000003",
+    jobs=[job("validate-request", "success"), job(APPROVE_PAID_DISPLAY_NAME, None)],
+    status="waiting",
+)
+
+
+class TestThePredicateStillCoversWhatIsActuallyHashed:
+    """Coupling tests: drive the real hash function, watch what it reads."""
+
+    @staticmethod
+    def _paths_read_by_the_hash(monkeypatch, config_path: Path) -> list[str]:
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        seen: list[Path] = []
+        real_read_bytes = Path.read_bytes
+
+        def spy(self: Path) -> bytes:
+            seen.append(self)
+            return real_read_bytes(self)
+
+        monkeypatch.chdir(BATCH_ROOT)
+        monkeypatch.setattr(Path, "read_bytes", spy)
+        step8_grade.compute_grader_source_hash(str(config_path), config)
+        monkeypatch.undo()
+
+        return sorted(
+            {p.resolve().relative_to(REPO_ROOT).as_posix() for p in seen}
+        )
+
+    @pytest.mark.parametrize(
+        "config_name",
+        sorted(p.name for p in (BATCH_ROOT / "grading_configs").glob("*.yaml")),
+    )
+    def test_every_hashed_input_is_classified_as_hash_moving(
+        self, monkeypatch, config_name: str
+    ) -> None:
+        config_path = BATCH_ROOT / "grading_configs" / config_name
+        hashed = self._paths_read_by_the_hash(monkeypatch, config_path)
+
+        assert hashed, "the hash function read nothing, so this proves nothing"
+
+        missed = [p for p in hashed if not freeze.is_grader_source_path(p)]
+        assert not missed, (
+            "compute_grader_source_hash reads these files, but the freeze check "
+            "would let a pull request touching them merge mid-run:\n  "
+            + "\n  ".join(missed)
+            + "\n\nAdd them to _EXACT_HASHED_FILES or _HASHED_TREES in "
+            "batch-runner/scripts/check_grader_hash_freeze.py."
+        )
+
+    def test_the_hashed_set_is_large_enough_to_be_the_real_thing(
+        self, monkeypatch
+    ) -> None:
+        """Guards the guard: a spy that silently caught nothing would make the
+        test above vacuously green."""
+        hashed = self._paths_read_by_the_hash(
+            monkeypatch, BATCH_ROOT / "grading_configs" / "gold_ceiling_185_v2_sol_max.yaml"
+        )
+        assert len(hashed) > 20
+        assert "batch-runner/step8_grade.py" in hashed
+        assert "batch-runner/requirements.txt" in hashed
+        assert "batch-runner/prompts/grader_judge.md" in hashed
+        assert (
+            "batch-runner/grading_configs/gold_ceiling_185_v2_sol_max.yaml" in hashed
+        )
+        assert any(p.startswith("batch-runner/core/") for p in hashed)
+
+
+class TestWhichPathsMoveTheHash:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "batch-runner/step8_grade.py",
+            "batch-runner/core/grader.py",
+            "batch-runner/core/perception/audio.py",
+            "batch-runner/core/tools/read_deliverable.py",
+            "batch-runner/schemas/grade.schema.json",
+            "batch-runner/requirements.txt",
+            "batch-runner/scripts/download_inference_from_hf.py",
+            "batch-runner/prompts/grader_judge.md",
+            "batch-runner/prompts/grader_judge_v2.md",
+            "batch-runner/grading_configs/gold_ceiling_185_v2_sol_max.yaml",
+        ],
+    )
+    def test_hash_moving(self, path: str) -> None:
+        assert freeze.is_grader_source_path(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # Negative controls. Each of these is a file somebody plausibly
+            # edits during a 60-hour run, and freezing them would make the
+            # guard something people route around instead of trusting.
+            "batch-runner/tests/test_grader.py",
+            "batch-runner/step2_run_inference.py",
+            "batch-runner/experiments/exp_gold_baseline.yaml",
+            "batch-runner/core/README.md",
+            "batch-runner/core/fixtures/sample.json",
+            ".github/workflows/grade-run.yml",
+            ".github/workflows/grader-hash-freeze.yml",
+            "src/pages/Grades.tsx",
+            "scripts/aggregate-grades.mjs",
+            "tasks/rebuilding_grading_task/311-third-audio-smoke-pass.md",
+            "README.md",
+            ".gitignore",
+        ],
+    )
+    def test_hash_neutral(self, path: str) -> None:
+        assert not freeze.is_grader_source_path(path)
+
+    def test_the_guard_does_not_freeze_itself(self) -> None:
+        """The check must be able to land, and to be fixed, during a paid run.
+        A guard that its own repair cannot get past is a guard nobody keeps."""
+        assert not freeze.is_grader_source_path(
+            "batch-runner/scripts/check_grader_hash_freeze.py"
+        )
+        assert not freeze.is_grader_source_path(
+            "batch-runner/tests/test_grader_hash_freeze.py"
+        )
+
+    def test_leading_dot_slash_is_tolerated(self) -> None:
+        assert freeze.is_grader_source_path("./batch-runner/core/grader.py")
+
+    def test_a_lookalike_outside_batch_runner_is_neutral(self) -> None:
+        assert not freeze.is_grader_source_path("vendor/batch-runner/core/grader.py")
+        assert not freeze.is_grader_source_path("batch-runner-old/core/grader.py")
+
+
+class TestWhichRunsBlock:
+    def test_a_real_paid_run_blocks(self) -> None:
+        d = freeze.decide(["batch-runner/core/grader.py"], [PAID])
+        assert d.frozen
+        assert d.blocking_runs[0].run_id == "33400000001"
+
+    def test_a_real_dry_run_does_not_block(self) -> None:
+        assert not freeze.decide(["batch-runner/core/grader.py"], [DRY]).frozen
+
+    def test_a_dry_run_is_not_paid_merely_for_listing_a_skipped_grade_job(self) -> None:
+        """The bug this whole class exists to pin. Every dry run's job list
+        contains an entry named `grade`; it just concluded `skipped`."""
+        assert any(j["name"] == "grade" for j in REAL_DRY_JOBS)
+        assert not freeze.classify_runs([DRY])[0].paid
+
+    def test_a_paid_run_is_not_dry_merely_for_listing_a_skipped_dry_job(self) -> None:
+        """And the mirror image: every paid run lists `grade-dry-run`."""
+        assert any(j["name"] == "grade-dry-run" for j in REAL_PAID_JOBS)
+        assert freeze.classify_runs([PAID])[0].paid
+
+    def test_a_finished_run_does_not_block(self) -> None:
+        done = live("9", jobs=REAL_PAID_JOBS, status="completed")
+        assert not freeze.decide(["batch-runner/core/grader.py"], [done]).frozen
+
+    @pytest.mark.parametrize(
+        "status", ["queued", "in_progress", "waiting", "pending", "requested"]
+    )
+    def test_every_live_status_blocks(self, status: str) -> None:
+        run = live("9", jobs=REAL_PAID_JOBS, status=status)
+        assert freeze.decide(["batch-runner/core/grader.py"], [run]).frozen
+
+    def test_waiting_at_the_approval_gate_blocks(self) -> None:
+        """A run parked at the environment gate has spent nothing yet, but the
+        approval is usually seconds away and the merge would land inside it.
+
+        There is no `grade` job in its list at this point -- approve-paid is
+        the job holding the gate open, and `grade` needs it. Classifying on
+        `grade` alone would have opened the merge window at exactly the wrong
+        moment."""
+        assert freeze.decide(["batch-runner/core/grader.py"], [AT_THE_GATE]).frozen
+
+    def test_a_paid_job_still_running_blocks(self) -> None:
+        """A job in flight reports a null conclusion, which is not `skipped`."""
+        run = live("9", jobs=[job("grade", None)])
+        d = freeze.decide(["batch-runner/core/grader.py"], [run])
+        assert d.frozen
+        assert "not skipped" in d.blocking_runs[0].paid_reason
+
+    def test_a_failed_paid_job_still_blocks(self) -> None:
+        """Money was spent regardless, and a resume chunk may follow."""
+        run = live("9", jobs=[job("grade", "failure")])
+        assert freeze.decide(["batch-runner/core/grader.py"], [run]).frozen
+
+    def test_the_approve_job_is_matched_by_prefix_not_by_key(self) -> None:
+        """The jobs API never exposes the key `approve-paid`."""
+        assert freeze.is_paid_path_job(APPROVE_PAID_DISPLAY_NAME)
+        assert not freeze.is_paid_path_job("approve-paid")
+
+    def test_a_run_too_early_to_have_branched_is_paid(self) -> None:
+        """`validate-request` runs on both paths, so it says nothing."""
+        run = live("9", jobs=[job("validate-request", None)])
+        d = freeze.decide(["batch-runner/core/grader.py"], [run])
+        assert d.frozen
+        assert "too early" in d.blocking_runs[0].paid_reason
+
+    def test_a_neutral_diff_is_green_even_during_a_paid_run(self) -> None:
+        d = freeze.decide(["README.md", "src/pages/Grades.tsx"], [PAID])
+        assert not d.frozen
+        assert d.moving_paths == ()
+
+    def test_a_hash_moving_diff_is_green_when_nothing_is_running(self) -> None:
+        d = freeze.decide(["batch-runner/core/grader.py"], [])
+        assert not d.frozen
+        assert d.moving_paths == ("batch-runner/core/grader.py",)
+        assert "fresh smoke" in freeze.render(d)
+
+    def test_one_paid_run_among_several_dry_ones_still_freezes(self) -> None:
+        runs = [DRY, live("3", jobs=REAL_DRY_JOBS), PAID]
+        assert freeze.decide(["batch-runner/prompts/grader_judge.md"], runs).frozen
+
+
+class TestFailClosed:
+    def test_a_run_with_no_job_list_counts_as_paid(self) -> None:
+        d = freeze.decide(["batch-runner/core/grader.py"], [live("9", jobs=None)])
+        assert d.frozen
+        assert "unavailable" in d.blocking_runs[0].paid_reason
+
+    def test_a_run_with_an_empty_job_list_counts_as_paid(self) -> None:
+        assert freeze.decide(["batch-runner/core/grader.py"], [live("9", jobs=[])]).frozen
+
+    def test_a_run_with_a_non_list_jobs_field_counts_as_paid(self) -> None:
+        run = {"id": "9", "status": "in_progress", "jobs": "grade-dry-run"}
+        assert freeze.decide(["batch-runner/core/grader.py"], [run]).frozen
+
+    def test_a_jobs_list_of_bare_strings_counts_as_paid(self) -> None:
+        """An older collector shape, or a truncated one. Either way the
+        conclusions are missing, so nothing can be proved skipped."""
+        run = {"id": "9", "status": "in_progress", "jobs": ["grade-dry-run"]}
+        assert freeze.decide(["batch-runner/core/grader.py"], [run]).frozen
+
+    def test_an_unrecognised_conclusion_counts_as_paid(self) -> None:
+        run = live("9", jobs=[job("grade", "some-new-github-conclusion")])
+        assert freeze.decide(["batch-runner/core/grader.py"], [run]).frozen
+
+    def test_an_unrecognised_status_is_treated_as_not_live(self) -> None:
+        """Deliberately the one place that is not fail-closed: GitHub's
+        terminal statuses are the ones we cannot enumerate exhaustively, and
+        treating every unknown string as live would freeze the repository
+        permanently the first time the API adds one."""
+        run = live("9", jobs=REAL_PAID_JOBS, status="neutral")
+        assert not freeze.decide(["batch-runner/core/grader.py"], [run]).frozen
+
+
+class TestTheMessageExplainsItself:
+    def test_the_frozen_message_names_the_file_the_run_and_the_cost(self) -> None:
+        text = freeze.render(freeze.decide(["batch-runner/core/grader.py"], [PAID]))
+        assert text.startswith("FROZEN:")
+        assert "batch-runner/core/grader.py" in text
+        assert "33400000001" in text
+        assert "step9_merge_shards" in text
+        assert "sixty hours" in text
+
+    def test_the_passing_message_still_warns_about_the_fingerprint(self) -> None:
+        text = freeze.render(freeze.decide(["batch-runner/core/grader.py"], [DRY]))
+        assert text.startswith("PASS:")
+        assert "fresh smoke" in text
+
+
+class TestTheCommandLine:
+    @staticmethod
+    def _run(tmp_path: Path, changed: object, runs: object) -> subprocess.CompletedProcess:
+        changed_file = tmp_path / "changed.json"
+        runs_file = tmp_path / "runs.json"
+        changed_file.write_text(json.dumps(changed), encoding="utf-8")
+        runs_file.write_text(json.dumps(runs), encoding="utf-8")
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--changed-paths",
+                str(changed_file),
+                "--runs",
+                str(runs_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_exit_1_when_frozen(self, tmp_path: Path) -> None:
+        r = self._run(tmp_path, ["batch-runner/core/grader.py"], [PAID])
+        assert r.returncode == 1
+        assert "FROZEN" in r.stdout
+
+    def test_exit_0_when_clear(self, tmp_path: Path) -> None:
+        r = self._run(tmp_path, ["README.md"], [PAID])
+        assert r.returncode == 0
+        assert "PASS" in r.stdout
+
+    def test_malformed_input_is_frozen_not_crashed(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json", encoding="utf-8")
+        good = tmp_path / "good.json"
+        good.write_text("[]", encoding="utf-8")
+        r = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--changed-paths",
+                str(bad),
+                "--runs",
+                str(good),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode == 1
+        assert "FROZEN" in r.stderr
+
+    def test_a_json_object_instead_of_an_array_is_frozen(self, tmp_path: Path) -> None:
+        r = self._run(tmp_path, {"paths": []}, [])
+        assert r.returncode == 1
+        assert "FROZEN" in r.stderr
+
+
+class TestTheJobNamesStillExistInGradeRun:
+    """The other half of the mirror. The name literals are copied out of
+    grade-run.yml, and a job rename there would turn this check permanently
+    green without changing a line of it.
+
+    These assert against the *display* name, because that is the only thing
+    the jobs API returns -- it never exposes the job key.
+    """
+
+    @staticmethod
+    def _jobs() -> dict:
+        wf = yaml.safe_load(
+            (REPO_ROOT / ".github" / "workflows" / "grade-run.yml").read_text(
+                encoding="utf-8"
+            )
+        )
+        return wf["jobs"]
+
+    def test_the_grade_job_has_no_display_name_override(self) -> None:
+        """Which is the only reason matching the bare string `grade` works."""
+        jobs = self._jobs()
+        assert "grade" in jobs
+        assert "name" not in jobs["grade"], (
+            "grade now has a `name:` override, so the jobs API will stop "
+            "reporting it as 'grade' and the freeze check will stop seeing "
+            "paid runs. Add its prefix to PAID_JOB_NAME_PREFIXES."
+        )
+        assert freeze.is_paid_path_job("grade")
+
+    def test_the_approve_job_display_name_matches_a_known_prefix(self) -> None:
+        rendered = str(self._jobs()["approve-paid"]["name"])
+        assert freeze.is_paid_path_job(rendered), (
+            f"approve-paid renders as {rendered!r}, which none of "
+            f"{freeze.PAID_JOB_NAME_PREFIXES} matches."
+        )
+        # And the prefix must not depend on an unexpanded ${{ }} expression,
+        # since the API returns the expanded string.
+        for prefix in freeze.PAID_JOB_NAME_PREFIXES:
+            if rendered.startswith(prefix):
+                assert "${{" not in prefix
+                break
+
+    def test_both_paid_jobs_are_gated_on_dry_run_being_false(self) -> None:
+        """Not just that the names exist -- that they are the money jobs."""
+        jobs = self._jobs()
+        for key in ("grade", "approve-paid"):
+            condition = str(jobs[key].get("if", ""))
+            assert "dry_run == false" in condition, (
+                f"job {key!r} is treated as paid but its `if` does not require "
+                f"dry_run == false: {condition!r}"
+            )
+        assert "dry_run == true" in str(jobs["grade-dry-run"].get("if", ""))
+
+    def test_no_other_job_is_gated_on_dry_run_being_false(self) -> None:
+        """Catches a *new* money job being added that the predicate cannot
+        see, which is the same failure as a rename with a friendlier name."""
+        jobs = self._jobs()
+        paid_keys = {
+            key
+            for key, body in jobs.items()
+            if "dry_run == false" in str(body.get("if", ""))
+        }
+        unmatched = {
+            key
+            for key in paid_keys
+            if not freeze.is_paid_path_job(str(jobs[key].get("name", key)))
+        }
+        assert not unmatched, (
+            f"these grade-run.yml jobs only run when dry_run is false, but the "
+            f"freeze check would not recognise them: {sorted(unmatched)}"
+        )
+
+    def test_the_recorded_real_job_names_are_not_stale(self) -> None:
+        """The fixture copied off run 33381143279 has to stay a plausible
+        rendering of the current workflow, or the tests using it prove
+        nothing about today's grade-run.yml."""
+        template = str(self._jobs()["approve-paid"]["name"])
+        literal_prefix = template.split("${{")[0].strip()
+        assert literal_prefix
+        assert APPROVE_PAID_DISPLAY_NAME.startswith(literal_prefix)
+
+
+class TestTheWorkflowTriggersOnEverythingItJudges:
+    """A predicate that classifies a path as hash-moving is useless if the
+    workflow's own `paths:` filter never fires for it. Both mirrors have to
+    move together, so this test drives the real hash function and requires
+    every file it reads to match the trigger."""
+
+    @staticmethod
+    def _trigger_globs() -> list[str]:
+        wf = yaml.safe_load(
+            (REPO_ROOT / ".github" / "workflows" / "grader-hash-freeze.yml").read_text(
+                encoding="utf-8"
+            )
+        )
+        # PyYAML resolves the bare key `on` to the boolean True.
+        triggers = wf.get("on", wf.get(True))
+        return list(triggers["pull_request"]["paths"])
+
+    @staticmethod
+    def _matches(globs: list[str], path: str) -> bool:
+        from fnmatch import fnmatch
+
+        for pattern in globs:
+            if pattern.endswith("/**"):
+                if path.startswith(pattern[:-2]):
+                    return True
+            elif fnmatch(path, pattern):
+                return True
+        return False
+
+    @pytest.mark.parametrize(
+        "config_name",
+        sorted(p.name for p in (BATCH_ROOT / "grading_configs").glob("*.yaml")),
+    )
+    def test_every_hashed_input_matches_the_paths_filter(
+        self, monkeypatch, config_name: str
+    ) -> None:
+        hashed = TestThePredicateStillCoversWhatIsActuallyHashed._paths_read_by_the_hash(
+            monkeypatch, BATCH_ROOT / "grading_configs" / config_name
+        )
+        globs = self._trigger_globs()
+        missed = [p for p in hashed if not self._matches(globs, p)]
+        assert not missed, (
+            "these files move the grader source hash but would not trigger the "
+            "freeze workflow at all:\n  "
+            + "\n  ".join(missed)
+            + "\n\nAdd them to `on.pull_request.paths` in "
+            ".github/workflows/grader-hash-freeze.yml."
+        )
+
+    def test_the_workflow_watches_its_own_two_files(self) -> None:
+        globs = self._trigger_globs()
+        assert self._matches(
+            globs, "batch-runner/scripts/check_grader_hash_freeze.py"
+        )
+        assert self._matches(globs, ".github/workflows/grader-hash-freeze.yml")
+
+
+class TestTheWorkflowIsItselfHashNeutral:
+
+    def test_the_workflow_file_exists_and_is_outside_batch_runner(self) -> None:
+        wf = REPO_ROOT / ".github" / "workflows" / "grader-hash-freeze.yml"
+        assert wf.is_file()
+        assert not freeze.is_grader_source_path(
+            wf.relative_to(REPO_ROOT).as_posix()
+        )
+
+    def test_the_workflow_calls_the_checked_in_script(self) -> None:
+        wf = REPO_ROOT / ".github" / "workflows" / "grader-hash-freeze.yml"
+        body = wf.read_text(encoding="utf-8")
+        assert "batch-runner/scripts/check_grader_hash_freeze.py" in body
+
+    def test_adding_this_guard_does_not_move_any_config_hash(self, monkeypatch) -> None:
+        """Belt and braces: run the real hash function and confirm neither new
+        file is among the bytes it reads."""
+        config_path = BATCH_ROOT / "grading_configs" / "gold_ceiling_185_v2_sol_max.yaml"
+        hashed = TestThePredicateStillCoversWhatIsActuallyHashed._paths_read_by_the_hash(
+            monkeypatch, config_path
+        )
+        assert "batch-runner/scripts/check_grader_hash_freeze.py" not in hashed
+        assert "batch-runner/tests/test_grader_hash_freeze.py" not in hashed
+        assert ".github/workflows/grader-hash-freeze.yml" not in hashed


### PR DESCRIPTION
## 무엇이 문제인가

샤드 열한 개가 도는 중에 `batch-runner/core/` 아래 파일 하나를 병합하면, 예순 시간 동안 아무 일도 일어나지 않다가 마지막에 전부 무너진다.

- 샤드는 각자 자기가 돌던 `grader_source_hash`를 찍는다.
- `step9_merge_shards.py`는 그 필드를 `CONTRACT_IDENTITY_FIELDS` — 샤드끼리 반드시 일치해야 하는 열 개 신원 불변량 — 에 넣어두었다.
- `step9`는 **모든 샤드가 끝난 뒤에야** 돈다.

그래서 순서가 이렇게 된다. 병합은 초록색이다 → 샤드는 계속 돈다 → 비용은 전액 청구된다 → 합집합은 예순 시간 뒤에 거절된다. 남는 건 서로 어긋나는 partial뿐이고, `--force`도 짧거나 섞인 합집합은 되돌리지 못한다(설계상 그렇다, `304-B-partial-blocked.md`).

실패가 **원인이 발생하는 순간에는 조용하다**는 게 핵심이다. 한 줄짜리 수정을 병합하는 행위 어디에도 "방금 이틀 반치 채점을 날렸다"고 적혀 있지 않다. 이 저장소에서 지금까지 세 번 아슬아슬했다 — #302, #303, 그리고 지금 열려 있는 큐가 각각 smoke와 dispatch 사이에서 지문을 움직였다.

## 무엇을 하는가

PR이 열리거나 갱신되는 순간, 유료 grade 실행이 살아 있는 동안 지문을 움직이는 diff에 빨간 검사를 붙인다. 병합 시점이 아니라 사람이 보고 있는 시점에.

```
FROZEN: 1 grader-source file(s) changed while 1 paid grade run(s) are in flight

Grader-source files in this diff:
  - batch-runner/core/perception/audio.py

Paid grade runs still alive:
  - 33381143279 [in_progress] (paid job not skipped: grade) https://github.com/...

Merging this would give the remaining shards a different grader_source_hash
from the ones already graded. ... roughly sixty hours for the 185-task corpus.
Wait for the run to finish, then merge.
```

## 무엇을 하지 못하는가 (솔직하게)

**하드 게이트가 아니다.** 브랜치 보호가 요구하지 않는 한 검사는 권고이고, 어제 초록이던 PR은 오늘 병합된다. 이 PR이 만드는 차이는 보이지 않던 함정을 보이게 만드는 것 — "깜빡했다"와 "결정했다"의 차이 — 까지이고, 그 이상인 척하지 않는다. 하드 게이트로 만들려면 저장소 설정에서 `freeze-check`를 required로 지정해야 하고, 그건 이 diff의 권한 밖이다.

## 실제 API에 맞춰 고친 두 가지

분류기를 워크플로 파일이 아니라 **실제 실행 두 개**(33381143279 유료, 33316285562 dry)에 대조하다가 나왔다.

1. **jobs API는 job key가 아니라 표시 이름을 돌려준다.** `grade`는 `name:` 재정의가 없어서 우연히 일치하지만, `approve-paid`는 `"Approve paid Sol Max grading (exp_gold_baseline, ..., shard 0/1)"`으로 도착한다. key로 맞췄다면 모든 실행에서 놓쳤을 것이다.
2. **skipped된 job도 목록에 나온다.** 유료 실행에는 `grade-dry-run`이 `conclusion: skipped`로 들어 있고, dry 실행에는 `grade`가 `conclusion: skipped`로 들어 있다. **존재만으로는 아무것도 구별되지 않는다.** conclusion만 구별한다.

그래서 판정은 "보이는 유료 job이 하나라도 있고 그것들이 전부 skipped일 때만 무료"다. 나머지는 전부 유료로 친다 — 목록을 못 받았을 때, 아직 어느 쪽도 안 나왔을 때, 유료 job이 아직 돌고 있어서 conclusion이 null일 때. 잘못된 빨강은 대화 한 번을 쓰고, 잘못된 초록은 실행 하나를 날린다.

## 검사 자체는 지문 중립이다

`compute_grader_source_hash`는 `batch-runner` 바깥 경로를 거부하므로 워크플로를 `.github/workflows/`에 두면 아무 지문도 움직이지 않는다. 스크립트는 `batch-runner/scripts/`에 있지만 거기서 해시되는 건 `download_inference_from_hf.py` 하나뿐이다.

세 가지로 증명했다: 판정기 자신의 negative control, 그리고 `test_adding_this_guard_does_not_move_any_config_hash` — 진짜 해시 함수를 돌려서 그것이 읽는 바이트 중에 이 PR의 새 파일 셋 중 어느 것도 없음을 확인한다. 새 smoke를 요구하지 않게 막는 가드가 스스로 새 smoke를 요구하면 자기모순이다.

## 손으로 적은 거울 세 개를 고정했다

이 검사는 실제 소스를 세 군데에서 손으로 베낀다. 셋 다 조용히 어긋나지 못하게 실제 소스에 묶었다.

| 거울 | 무엇에 묶였나 |
|---|---|
| 해시 대상 경로 | 체크인된 grading config 12개 전부에 대해 진짜 `compute_grader_source_hash`의 `read_bytes` 호출을 감시하고, 술어가 그것을 덮지 못하면 실패 |
| 워크플로 트리거 | 해시 대상 경로 전부가 이 워크플로의 `on.pull_request.paths` 글로브에 걸리는지 검사 |
| 유료 job 이름 | `grade-run.yml`을 파싱해서 `dry_run == false`로 게이트된 job 목록과 대조. **새 유료 job이 추가되면** 술어가 그것을 모른 채로는 통과하지 못한다 |

## Negative control 다섯 개, 전부 발화

| | 무엇을 망가뜨렸나 | 결과 |
|---|---|---|
| NC1 | 술어에서 `prompts/` 제거 | 커플링 테스트 12개 실패 |
| NC2 | 트리거에서 `grading_configs/**` 제거 | 필터 테스트 12개 실패 |
| NC3 | 유료 job 하나 이름 변경 | 2개 실패 |
| NC4 | 표시 이름 접두사 제거 | 3개 실패 |
| NC5 | conclusion 무시하고 존재로만 판정 | 3개 실패, 그중 `test_a_real_dry_run_does_not_block` |

각각 복구 후 초록.

## 실제 데이터로 end-to-end 확인

워크플로 셸을 그대로 재현하고 실행 33381143279를 `in_progress`로 강제한 상태에서:

- `batch-runner/core/perception/audio.py` → FROZEN, exit 1
- `README.md` + 문서 경로 → PASS, exit 0

지금 살아 있는 grade 실행은 `[]`이므로 현재 이 검사는 PASS다. 즉 지문을 움직이는 큐는 지금 자유롭게 빠질 수 있고, 그게 의도한 순서다.

## 테스트

- 새 테스트 89개
- 전체 백엔드 스위트 회귀 확인
- `mypy` clean