### PR TITLE
fix(step9): try the identity layout before the stride-layout search

### DIFF
--- a/batch-runner/step9_merge_shards.py
+++ b/batch-runner/step9_merge_shards.py
@@ -627,6 +627,26 @@ def _stride_layout_candidates(
     if sorted(actual) != sorted(required):
         return
 
+    # Try the identity layout first: input i is stride shard i. Callers pass
+    # shards in filename order (shard-000, shard-001, ...), which *is* stride
+    # order, so this is the answer virtually every time -- and one hash check
+    # settles it. Only when it is wrong does the exhaustive search below run,
+    # which is the only place the cap belongs.
+    #
+    # Without this the cap refused merges whose answer was the first thing
+    # worth trying. 185 tasks over 11 shards is a 17x9 + 16x2 profile, i.e.
+    # 9! * 2! = 725,760 candidates against a 200,000 cap sized for the 9-way
+    # split this docstring still cites (4! * 5! = 2,880). The cap was never
+    # re-derived when the split moved to 11, and the failure was invisible
+    # because the incomplete-union guard fires first: no run had ever
+    # presented a complete corpus to reconstruct.
+    #
+    # This weakens nothing. The caller verifies every candidate against
+    # expected_ordered_task_ids_sha256, so a wrong identity guess fails that
+    # check and falls through to the search exactly as before.
+    if actual == required:
+        yield tuple(range(shard_count))
+
     indices_by_size: dict[int, list[int]] = {}
     for shard_index, size in enumerate(required):
         indices_by_size.setdefault(size, []).append(shard_index)

--- a/batch-runner/tests/test_step9_merge_shards.py
+++ b/batch-runner/tests/test_step9_merge_shards.py
@@ -385,6 +385,92 @@ def test_nine_way_split_is_uneven_as_the_spec_requires(
 
 
 # ---------------------------------------------------------------------------
+# the 11-way split
+#
+# Every other case in this file splits 220 nine ways. That is the shape the
+# layout-reconstruction cap was sized for, and splitting it nine ways is the
+# only shape the suite ever exercised -- so when the Gold ceiling run moved to
+# 185 tasks over 11 shards, nothing here noticed that the merge could no longer
+# run at all. It failed for the first time in production, at the last and
+# cheapest step, after every shard had been paid for.
+#
+# These cases pin the shape that actually ships.
+# ---------------------------------------------------------------------------
+
+
+GOLD_TASK_COUNT = 185
+GOLD_SHARD_COUNT = 11
+
+
+@pytest.fixture(scope="session")
+def gold_reference_payload(raw_corpus: dict, anchor_provenance: dict) -> dict:
+    """185-task ``final`` payload -- the shape the Gold ceiling run submits."""
+    return _build_reference(
+        raw_corpus,
+        anchor_provenance,
+        _normalised_tasks(raw_corpus, limit=GOLD_TASK_COUNT),
+    )
+
+
+def test_eleven_way_split_is_past_the_layout_search_cap() -> None:
+    """The arithmetic the merge used to die on, asserted on its own.
+
+    Without this the next test's PASS is unattributable: it would be equally
+    consistent with "the search is fast enough". It is not -- the search is
+    refused outright. 185 over 11 is 17x9 + 16x2, so 9! * 2! = 725,760
+    candidate layouts against a cap of 200,000 chosen for 4! * 5! = 2,880.
+    """
+    sizes = s9._stride_sizes(GOLD_TASK_COUNT, GOLD_SHARD_COUNT)
+    assert sorted(sizes) == [16] * 2 + [17] * 9
+    assert sum(sizes) == GOLD_TASK_COUNT
+    candidates = math.factorial(9) * math.factorial(2)
+    assert candidates == 725_760
+    assert candidates > s9.MAX_CANDIDATE_LAYOUTS
+
+
+def test_eleven_way_stride_merge_needs_no_explicit_order(
+    gold_reference_payload: dict,
+) -> None:
+    """185 over 11 must merge on the plain call, with no order supplied.
+
+    This is the exact invocation the workflow makes. It exits non-zero and
+    writes nothing unless the canonical order can be resolved without an
+    exhaustive search.
+    """
+    shards = make_shards(gold_reference_payload, GOLD_SHARD_COUNT)
+    assert sorted(len(shard["tasks"]) for shard in shards) == [16] * 2 + [17] * 9
+
+    merged = merge(shards)
+
+    assert merged["run_status"] == "final"
+    assert [task["task_id"] for task in merged["tasks"]] == [
+        task["task_id"] for task in gold_reference_payload["tasks"]
+    ]
+
+
+def test_eleven_way_merge_checks_its_first_guess_rather_than_trusting_it(
+    gold_reference_payload: dict,
+) -> None:
+    """Out of order, the obvious layout is wrong -- and must not be used.
+
+    Resolving the order without a search means trying the layout the caller's
+    own argument order implies. That shortcut is only sound because the result
+    is still verified against ``expected_ordered_task_ids_sha256``. Shuffle the
+    inputs and the shortcut is wrong, and the merge must refuse rather than
+    emit a payload whose task order contradicts its declared identity.
+
+    The workflow always passes shards in ascending index order, so this is not
+    reachable in production; it is asserted to keep the shortcut honest.
+    """
+    shards = make_shards(gold_reference_payload, GOLD_SHARD_COUNT)
+    shards[0], shards[3] = shards[3], shards[0]
+
+    with pytest.raises(s9.ShardMergeError) as excinfo:
+        merge(shards)
+    assert "canonical corpus order" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
 # §4 strong assertions -- identity, rates, cost sums, graded_at
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What breaks

`step9_merge_shards.py` cannot read the corpus order out of the shard files — they
carry only `expected_ordered_task_ids_sha256`, a hash, which cannot be inverted. So
it *searches*: it permutes which input file sits at which stride index until one
layout reproduces that hash. The search is capped by `MAX_CANDIDATE_LAYOUTS =
200_000` (step9:112).

| split | stride profile | candidates | vs cap |
|---|---|---|---|
| 220 / 9 | 25×4 + 24×5 | 4! · 5! = 2,880 | passes |
| 185 / 9 | 21×5 + 20×4 | 5! · 4! = 2,880 | passes |
| **185 / 11** | **17×9 + 16×2** | **9! · 2! = 725,760** | **3.6× over** |
| 220 / 11 | 20×11 | 11! = 39,916,800 | 200× over |

The cap was sized for the 9-way split that `_stride_layout_candidates`' docstring
still cites. It was never re-derived when the split moved to 11.

**Reproduced against the eleven real shards now on `main`**, with the workflow's own
flags (grade-run.yml:1463) — not a fixture:

```
ERROR: shard merge failed: canonical corpus order cannot be reconstructed:
725760 candidate stride layouts exceeds the 200000 cap.
exit 1, no output file
```

`--defer-if-incomplete` does **not** defer. It is a hard failure, not a stand-down.

It stayed invisible because the incomplete-union guard fires first. No 185-task run
had ever presented a *complete* union — the three prior attempts stopped at 174, 174
and 151 — so no attempt ever reached order reconstruction. The only run that could
expose it is the first one to finish all 185, and until now none had.

## The fix: try the identity layout first

Callers pass shards in filename order — `shard-000`, `shard-001`, … — which *is*
stride order. One hash check settles it. The cap belongs on the exhaustive fallback,
not on the first guess. Raising the cap instead would be a treadmill: 12 shards need
12! = 479M.

This weakens nothing. The caller still verifies every candidate against
`expected_ordered_task_ids_sha256`, so a wrong identity guess fails that check and
falls through to the search exactly as before. The generator ordering is load-bearing
and correct: the identity is yielded *before* the cap check, so a caller whose first
guess matches never resumes the generator and never sees the raise.

## Verified

Same eleven real shards, same invocation, this branch:

```
Merged 11 shard(s): tasks=185, avg_pct=79.53
exit 0
```

The workflow's own post-merge validation block (grade-run.yml:1473-1495) passes on
that output: schema 1.4 valid, `run_status: final`, `185 == expected_task_count`, 185
unique task IDs, 0 errored.

- **The eleven paid shards stay valid.** `grader_source_hash` recomputed on this
  branch is `79c2f5035c4aa826…`, byte-identical to the value the run is pinned to —
  `step9_merge_shards.py` is not among `compute_grader_source_hash`'s inputs
  (step8:160-200). `GRADING_INPUT_PATHS` is a deliberate superset of the fingerprint
  inputs, which is why it is frozen mid-run even though it does not move the hash.
- Merged output is identical to an `--expected-task-ids` merge — same task order; the
  only differing leaf is `cost_ledger/path`, derived from the `--output` filename.
- Identity on two deliberately swapped inputs does **not** reproduce the hash, so the
  guess is still checked rather than trusted.
- `135 passed` across `test_step9_merge_shards.py` and `test_shard_merge_roundtrip.py`
  (132 existing + 3 new), 0 failed.
- Negative control: reverting the fix makes
  `test_eleven_way_stride_merge_needs_no_explicit_order` fail with the exact
  production error, `725760 candidate stride layouts exceeds the 200000 cap`. The
  other two new cases pass either way — they are guards, not regression tests, and are
  recorded as such rather than counted as three.

## Blast radius

- "Commit grade result" runs **before** the merge → shard payloads were always safe.
- "Upload cost ledger" is `if: always()` → the ledger was always safe.
- Lost: the merged artifact and the free auto-analysis that reads it.
- **No paid work was destroyed.** The failure is at the last, free step.

## Known remaining hole (not reachable from the workflow)

Shards passed **out of** filename order with an unpinned config still hit the cap —
verified. The workflow always builds `SHARDS` by ascending index (grade-run.yml
~:1440), so this is unreachable in production. Recording it rather than
over-engineering a fix for it.

## Safe to merge now

Zero Grade Pipeline runs are in flight, so the chunk-continuation guard has nothing to
kill. Rebased on `aa6fbcf`; `GRADING_INPUT_PATHS` diffs empty between the run's pinned
revision and current `main`.
