### PR TITLE
chore(stage3): refresh the frozen inventory for this run's sibling shard dir

### DIFF
--- a/tasks/rebuilding_grading_task/stage3_partial_inventory.json
+++ b/tasks/rebuilding_grading_task/stage3_partial_inventory.json
@@ -560,6 +560,16 @@
       "cost_ledgers": 0,
       "in_scope": false,
       "why": "graded at a superseded grader source hash; not comparable at item level and refused by step9_merge_shards as a contract identity mismatch"
+    },
+    {
+      "dir": "data/grades/_diagnostic/cef3a5b9f1305f19437d6ee337936a065965f979325b95a41d1001747e6bfa18/_shards/exp_gold_baseline__judge_gpt-5_6-sol__gold_ceiling_185_v2_sol_max__cfg_f9c5f7bab9bd1530__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_79c2f5035c4aa826__v2.2",
+      "grader_source_hash": [
+        "79c2f5035c4aa826355134dd87cdb8fbc320e5a1cc5fde0d8ecf91957f4eabc6"
+      ],
+      "shard_files": 11,
+      "cost_ledgers": 11,
+      "in_scope": false,
+      "why": "graded at a superseded grader source hash; not comparable at item level and refused by step9_merge_shards as a contract identity mismatch"
     }
   ],
   "blocking_task": {


### PR DESCRIPTION
`main` is red. `test_the_frozen_inventory_still_describes_the_shards_on_disk` fails, and PR #324 inherits the failure rather than causing it.

## What moved

One additive entry in `superseded_sibling_dirs` — ten lines, nothing removed. `_superseded_shard_dirs()` reports every sibling of the inventory's subject dir, and this run's shards created a new one at grader source hash `79c2f503` (11 shard files, 11 cost ledgers, `in_scope: false`).

## What did not move

Twelve of thirteen top-level keys are byte-identical, including all three that carry the evidence:

| key | committed | rebuilt |
|---|---|---|
| `status` | `BLOCKED_PARTIAL` | identical |
| `coverage` | 174/185, same 11 named missing task IDs | identical |
| `shards` | — | identical |

The 174-task partial record survives verbatim, so the sibling contract `test_the_inventory_refuses_to_read_as_a_finished_measurement` keeps passing.

## When it broke, and why nobody saw it

Frozen at `bc806de` (2026-08-31 13:02 +0900, #291). Staled by `7b4d7d1` (2026-08-31 15:30 UTC, *shard 0 of 11*) — three hours later, when this run began committing shards.

It stayed invisible because `backend-tests.yml` triggers on `batch-runner/**` and its own file. Every shard commit touched `data/grades/**` only, so pytest never ran on one; #322 ran `validate`/`deploy` alone. #324 is the first change since the freeze to touch `batch-runner/**`, hence the first to surface it. **An earlier reading of mine blamed #322 — that is wrong.** The failure reproduces at `72a99f1`, which predates both #322 and #324.

## Verification

`tests/test_the_partial_gold_run_cannot_read_as_final.py` → **10 passed** locally on this branch (was 1 failed / 9 passed).

This PR touches `tasks/**` only, so by the path filter above its own CI will *not* run pytest. The CI-side proof is #324 rebased onto this commit; I'll report that result on #324.

## Known cosmetic inaccuracy, deliberately not fixed here

The generator gives every sibling the same `why` string, so the new entry reads *"graded at a superseded grader source hash"*. `79c2f503` is **not** superseded — it is the live fingerprint of the run in flight. The wording is right about scope (this dir is not part of the 174) and wrong about status. Rewording belongs in the generator, which is a separate change; recorded so no reader takes it as a claim that this run's shards are stale.