### PR TITLE
fix(code-interpreter): 거절당한 호출이 무엇에 거절당했는지 말하게 한다

### DIFF
--- a/batch-runner/core/code_interpreter.py
+++ b/batch-runner/core/code_interpreter.py
@@ -29,10 +29,103 @@ from core.file_preview import build_file_structure_info
 from core.reference_integrity import open_verified_reference
 
 
-def _raise_redacted_provider_error(error_type: str):
-    raise RuntimeError(
-        f"Code Interpreter provider error ({error_type})"
-    ) from None
+#: What a provider's own error code may be made of before it is allowed
+#: into a redacted message: letters, digits and underscore, nothing else.
+#: Real codes look like ``PermissionDenied``, ``AuthorizationFailed``,
+#: ``DeploymentNotFound`` or ``insufficient_quota``. An endpoint, an account
+#: name, a deployment name, a file path or a sentence of prose all need a
+#: dot, a dash, a slash, a colon or a space, so none of them can get through
+#: this. That is the whole reason the allow-list is a shape and not a
+#: blocklist of things to strip out.
+_PROVIDER_CODE_SHAPE = re.compile(r"\A[A-Za-z0-9_]{1,64}\Z")
+
+#: Where a refusal's own code is looked for, in the order it is preferred.
+#: The first pair is what the OpenAI SDK lifts out of a JSON body onto the
+#: exception itself. The second pair is read back out of the body, because
+#: Azure nests its code one level down under ``error`` and the SDK leaves the
+#: attributes ``None`` in that case. Looking in the body as well is what makes
+#: this useful against a real Azure refusal rather than only a synthetic one.
+_PROVIDER_CODE_ATTRIBUTES = ("code", "type")
+_PROVIDER_CODE_BODY_KEYS = ("code", "type")
+
+
+def _provider_code_of(value: object) -> Optional[str]:
+    """Return ``value`` when it is code-shaped, and otherwise nothing."""
+    if isinstance(value, str) and _PROVIDER_CODE_SHAPE.match(value):
+        return value
+    return None
+
+
+def _provider_error_classification(exc: BaseException) -> str:
+    """Say what a provider refusal was, without saying who refused it.
+
+    Exactly two things are ever taken from the exception:
+
+    * the HTTP status, and only when it is a whole number a status can be;
+    * the provider's own error code, and only when it is code-shaped by
+      ``_PROVIDER_CODE_SHAPE``.
+
+    The message, the request, the response headers and the body itself are
+    never carried into the result. So a redacted message gains the one thing
+    an operator needs to act — *what* was refused — and still cannot name an
+    endpoint, an account, a project or a deployment.
+
+    Every read is guarded, because these are attributes on somebody else's
+    exception and a property is free to raise. A classification that cannot
+    be worked out is simply absent; it never replaces the class name.
+    """
+    parts: list[str] = []
+
+    try:
+        status = getattr(exc, "status_code", None)
+    except Exception:
+        status = None
+    if isinstance(status, int) and 100 <= status <= 599:
+        parts.append(f"http {status}")
+
+    code = None
+    for attribute in _PROVIDER_CODE_ATTRIBUTES:
+        try:
+            code = _provider_code_of(getattr(exc, attribute, None))
+        except Exception:
+            code = None
+        if code is not None:
+            break
+    if code is None:
+        try:
+            body = getattr(exc, "body", None)
+        except Exception:
+            body = None
+        nested = body.get("error") if isinstance(body, dict) else None
+        for holder in (body, nested):
+            if not isinstance(holder, dict):
+                continue
+            for key in _PROVIDER_CODE_BODY_KEYS:
+                code = _provider_code_of(holder.get(key))
+                if code is not None:
+                    break
+            if code is not None:
+                break
+    if code is not None:
+        parts.append(f"code {code}")
+
+    return ", ".join(parts)
+
+
+def _redacted_provider_error_message(exc: BaseException) -> str:
+    """The one sentence a redacted provider failure is allowed to say."""
+    classification = _provider_error_classification(exc)
+    error_type = type(exc).__name__
+    if classification:
+        return (
+            f"Code Interpreter provider error "
+            f"({error_type}, {classification})"
+        )
+    return f"Code Interpreter provider error ({error_type})"
+
+
+def _raise_redacted_provider_error(message: str):
+    raise RuntimeError(message) from None
 
 
 class _CodeInterpreterProviderCallProxy:
@@ -45,10 +138,10 @@ class _CodeInterpreterProviderCallProxy:
         try:
             value = getattr(self._target, name)
         except Exception as exc:
-            error_type = type(exc).__name__
+            message = _redacted_provider_error_message(exc)
         else:
             return value
-        _raise_redacted_provider_error(error_type)
+        _raise_redacted_provider_error(message)
 
     def __getattr__(self, name: str):
         return _CodeInterpreterProviderCallProxy(
@@ -59,10 +152,10 @@ class _CodeInterpreterProviderCallProxy:
         try:
             result = self._target(*args, **kwargs)
         except Exception as exc:
-            error_type = type(exc).__name__
+            message = _redacted_provider_error_message(exc)
         else:
             return result
-        _raise_redacted_provider_error(error_type)
+        _raise_redacted_provider_error(message)
 
 
 def _close_sync_resources(resources: tuple[tuple[str, object | None], ...]) -> None:

--- a/batch-runner/tests/test_a_refused_code_interpreter_call_says_what_refused_it.py
+++ b/batch-runner/tests/test_a_refused_code_interpreter_call_says_what_refused_it.py
@@ -1,0 +1,430 @@
+"""A refused Code Interpreter call now says what refused it.
+
+The Azure code interpreter is one of the three run places the execution
+envelope comparison measures. Its five-task advance check failed on all five
+tasks, and every task recorded the same thing::
+
+    task_execution_error:PermissionDeniedError
+
+That is the OpenAI SDK's class for HTTP 403. It says the call was refused. It
+does not say *what* refused it, and the two facts that would say — the status
+and the provider's own error code — were thrown away before anything could
+record them.
+
+They were thrown away on purpose. ``core/code_interpreter.py`` wraps the
+client in ``_CodeInterpreterProviderCallProxy`` whenever the run is on a typed
+Azure route, and the proxy replaces every provider exception with a
+``RuntimeError`` carrying the class name and nothing else, chained
+``from None``. That redaction exists because the raw exception's text carries
+the endpoint, the account, the project and the deployment, and this repository
+publishes its run records. Keeping the redaction is not negotiable.
+
+But redaction and diagnosis are not actually opposed here. An HTTP status is a
+number. A provider error code is an identifier — ``PermissionDenied``,
+``AuthorizationFailed``, ``DeploymentNotFound``, ``insufficient_quota``. An
+endpoint, an account name or a sentence of prose cannot be spelled without a
+dot, a dash, a slash, a colon or a space. So the two useful facts are
+admitted by *shape*, and everything else stays out because it cannot take that
+shape — not because somebody listed it.
+
+These tests hold both halves at once: that the refusal now names itself, and
+that nothing else came with it.
+
+Nothing here calls a model, signs in to a cloud account, or spends anything.
+The one realistic refusal is built locally out of ``httpx`` objects.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import httpx
+import pytest
+from openai import PermissionDeniedError
+
+from core.code_interpreter import (
+    CodeInterpreterRunner,
+    _CodeInterpreterProviderCallProxy,
+    _provider_error_classification,
+    _redacted_provider_error_message,
+)
+from core.public_error import public_task_error_text
+
+# What a real refusal from this project's Foundry endpoint would carry along
+# with it. Every one of these must be absent from anything the run records.
+PRIVATE_URL = "https://hjeon-fdpo-foundry-eus2.services.ai.azure.com/api/projects/gdpval-realworks/openai/v1/responses"
+PRIVATE_PROSE = (
+    "Principal 00000000-0000-0000-0000-000000000000 does not have "
+    "authorization to perform action 'Microsoft.CognitiveServices/"
+    "accounts/OpenAI/responses/action' over scope "
+    "/subscriptions/.../hjeon-fdpo-foundry-eus2/projects/gdpval-realworks"
+)
+
+
+def _refusal(body: object, *, status: int = 403) -> PermissionDeniedError:
+    """A 403 shaped the way the SDK shapes one, built without a network."""
+    request = httpx.Request("POST", PRIVATE_URL)
+    if isinstance(body, (dict, list)):
+        response = httpx.Response(status, request=request, json=body)
+    else:
+        response = httpx.Response(status, request=request, text=str(body))
+    return PermissionDeniedError(
+        f"Error code: {status} - {PRIVATE_PROSE}",
+        response=response,
+        body=body,
+    )
+
+
+def _injected_client(response=None):
+    """The same stand-in client the neighbouring tests inject."""
+    if response is None:
+        response = SimpleNamespace(output=[], output_text="injected result")
+    return SimpleNamespace(
+        responses=SimpleNamespace(create=Mock(return_value=response)),
+        files=SimpleNamespace(create=Mock(), delete=Mock(), content=Mock()),
+        containers=SimpleNamespace(
+            create=Mock(),
+            files=SimpleNamespace(
+                list=Mock(),
+                content=SimpleNamespace(retrieve=Mock()),
+            ),
+        ),
+        close=Mock(),
+    )
+
+
+# ── the contract that was already there ───────────────────────────────────
+
+
+def test_a_refusal_with_nothing_to_classify_reads_exactly_as_it_did() -> None:
+    """The frozen sentence stays frozen when there is nothing to add.
+
+    ``tests/test_code_interpreter.py`` asserts this string by equality in five
+    places. A classification that appended itself unconditionally — an empty
+    bracket, a ``None``, an ``unknown`` — would break all five. Absent means
+    absent.
+    """
+    assert (
+        _redacted_provider_error_message(OSError(PRIVATE_PROSE))
+        == "Code Interpreter provider error (OSError)"
+    )
+    assert _provider_error_classification(OSError(PRIVATE_PROSE)) == ""
+
+
+def test_the_chain_is_still_dropped_when_the_proxy_raises() -> None:
+    """Redaction is worth nothing if the original hangs off the new one.
+
+    ``raise ... from None`` clears ``__cause__`` but leaves ``__context__``
+    set whenever the raise happens inside the ``except`` block. The proxy
+    therefore builds the message inside the block and raises outside it. This
+    holds that arrangement, because it is invisible in the reading and the
+    whole redaction leaks through ``__context__`` if it is undone.
+    """
+    client = _injected_client()
+    client.responses.create.side_effect = _refusal(
+        {"error": {"code": "PermissionDenied", "message": PRIVATE_PROSE}}
+    )
+    proxy = _CodeInterpreterProviderCallProxy(client)
+
+    with pytest.raises(RuntimeError) as caught:
+        proxy.responses.create(model="deployment")
+
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+# ── what the refusal may now say ──────────────────────────────────────────
+
+
+def test_an_azure_refusal_carries_its_status_and_its_own_code() -> None:
+    """The case this was written for, in the shape Azure sends it."""
+    message = _redacted_provider_error_message(
+        _refusal({"error": {"code": "PermissionDenied", "message": PRIVATE_PROSE}})
+    )
+
+    assert message == (
+        "Code Interpreter provider error "
+        "(PermissionDeniedError, http 403, code PermissionDenied)"
+    )
+
+
+def test_the_sdk_cannot_see_a_nested_code_so_the_body_is_read_as_well() -> None:
+    """Why reading the body is load-bearing rather than belt-and-braces.
+
+    The OpenAI SDK lifts ``code`` and ``type`` off the *top* of the JSON body.
+    Azure nests both one level down under ``error``, so on a real Azure
+    refusal ``exc.code`` is ``None`` and reading the attribute alone would
+    have produced the status and nothing else — which is most of the way to
+    learning nothing. This asserts the SDK's blindness directly, so that a
+    later simplification down to ``exc.code`` fails here with the reason.
+    """
+    refusal = _refusal(
+        {"error": {"code": "AuthorizationFailed", "message": PRIVATE_PROSE}}
+    )
+
+    assert refusal.code is None, "the SDK started reading nested codes"
+    assert "code AuthorizationFailed" in _redacted_provider_error_message(refusal)
+
+
+def test_an_openai_shaped_refusal_is_read_off_the_exception() -> None:
+    """The flat shape, which the SDK does lift onto the exception."""
+    refusal = _refusal(
+        {"code": "insufficient_quota", "type": "insufficient_quota",
+         "message": PRIVATE_PROSE}
+    )
+
+    assert refusal.code == "insufficient_quota"
+    assert "code insufficient_quota" in _redacted_provider_error_message(refusal)
+
+
+def test_a_refusal_with_no_readable_body_still_names_its_status() -> None:
+    """Azure answers some refusals with HTML or an empty body.
+
+    Half an answer is still an answer: knowing it was a 403 rather than a 429
+    or a 404 decides where to look next.
+    """
+    message = _redacted_provider_error_message(_refusal("<html>Forbidden</html>"))
+
+    assert message == (
+        "Code Interpreter provider error (PermissionDeniedError, http 403)"
+    )
+
+
+# ── what it may not say ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "code, why",
+    [
+        (PRIVATE_URL, "is the endpoint"),
+        ("hjeon-fdpo-foundry-eus2", "is the account, and has dashes"),
+        ("gdpval-realworks", "is the project"),
+        ("gpt-5.4", "is the deployment"),
+        ("services.ai.azure.com", "is a host"),
+        (PRIVATE_PROSE, "is the whole prose message"),
+        ("Permission Denied", "has a space"),
+        ("Microsoft.CognitiveServices/accounts", "is a path"),
+        ("code:403", "has a colon"),
+        ("Denied\nby policy", "has a newline"),
+        ("A" * 65, "is longer than a code"),
+        ("", "is empty"),
+    ],
+)
+def test_a_code_that_is_not_code_shaped_is_dropped(code: str, why: str) -> None:
+    """Everything worth hiding needs a character the shape does not admit."""
+    message = _redacted_provider_error_message(
+        _refusal({"error": {"code": code, "message": PRIVATE_PROSE}})
+    )
+
+    assert message == (
+        "Code Interpreter provider error (PermissionDeniedError, http 403)"
+    ), f"a code that {why} was admitted"
+    assert code not in message or code == ""
+
+
+@pytest.mark.parametrize(
+    "code", [403, None, True, {"code": "PermissionDenied"}, ["PermissionDenied"]]
+)
+def test_a_code_that_is_not_text_is_dropped(code: object) -> None:
+    """A body is somebody else's JSON; its fields need not be strings."""
+    message = _redacted_provider_error_message(
+        _refusal({"error": {"code": code, "message": PRIVATE_PROSE}})
+    )
+
+    assert message == (
+        "Code Interpreter provider error (PermissionDeniedError, http 403)"
+    )
+
+
+@pytest.mark.parametrize(
+    "status, why",
+    [
+        (True, "is a bool, which Python counts as an int"),
+        ("403", "is text"),
+        (999, "is not a status"),
+        (99, "is not a status"),
+        (403.0, "is a float"),
+        (None, "is absent"),
+    ],
+)
+def test_a_status_that_is_not_a_status_is_dropped(status, why: str) -> None:
+    """A status is admitted by being a whole number in the range of one.
+
+    ``isinstance(True, int)`` is ``True`` in Python, so a bool would slip past
+    a type check alone. It does not need a check of its own here: ``True`` is
+    ``1`` and ``False`` is ``0``, and the range refuses both. Writing a
+    separate ``isinstance(status, bool)`` guard would look careful and do
+    nothing, so the range is the only thing standing there — and the mutation
+    that widens it is what proves the range is load-bearing.
+    """
+
+    class _Refused(Exception):
+        pass
+
+    exc = _Refused()
+    exc.status_code = status
+
+    assert _provider_error_classification(exc) == "", f"a status that {why}"
+
+
+def test_nothing_but_the_status_and_the_code_reaches_the_redacted_text() -> None:
+    """The sweep: build a refusal carrying every private thing at once."""
+    refusal = _refusal(
+        {
+            "error": {
+                "code": "PermissionDenied",
+                "message": PRIVATE_PROSE,
+                "target": PRIVATE_URL,
+                "innererror": {"account": "hjeon-fdpo-foundry-eus2"},
+            }
+        }
+    )
+    message = _redacted_provider_error_message(refusal)
+
+    for secret in (
+        PRIVATE_URL,
+        PRIVATE_PROSE,
+        "hjeon-fdpo-foundry-eus2",
+        "gdpval-realworks",
+        "azure.com",
+        "subscriptions",
+    ):
+        assert secret not in message
+
+
+def test_the_free_text_the_request_and_the_response_are_never_even_read() -> None:
+    """Proved by making them explode rather than by reading the result.
+
+    Checking that the prose is absent from the output only shows it was not
+    *kept*. This shows it was not *touched*, which is the property that
+    survives somebody later adding a formatting step.
+    """
+
+    class _RefusalThatExplodesIfItsProseIsRead(Exception):
+        status_code = 403
+        code = "AuthorizationFailed"
+
+        @property
+        def message(self):  # pragma: no cover - the assert is the point
+            raise AssertionError("the free-text message was read")
+
+        @property
+        def response(self):  # pragma: no cover - the assert is the point
+            raise AssertionError("the response was read")
+
+        @property
+        def request(self):  # pragma: no cover - the assert is the point
+            raise AssertionError("the request was read")
+
+        @property
+        def args(self):  # pragma: no cover - the assert is the point
+            raise AssertionError("the exception arguments were read")
+
+    message = _redacted_provider_error_message(
+        _RefusalThatExplodesIfItsProseIsRead()
+    )
+
+    assert message == (
+        "Code Interpreter provider error "
+        "(_RefusalThatExplodesIfItsProseIsRead, http 403, "
+        "code AuthorizationFailed)"
+    )
+
+
+def test_an_attribute_that_raises_does_not_break_the_redaction() -> None:
+    """These are attributes on somebody else's object, so they may raise.
+
+    ``getattr(obj, name, default)`` only swallows ``AttributeError``. A
+    property raising anything else would escape the redaction entirely and
+    surface the raw exception, which is the failure mode redaction exists to
+    prevent. So the failure has to be to *less* detail, never to more.
+    """
+
+    class _RefusalWhoseAttributesRaise(Exception):
+        @property
+        def status_code(self):
+            raise RuntimeError(PRIVATE_PROSE)
+
+        @property
+        def code(self):
+            raise RuntimeError(PRIVATE_PROSE)
+
+        @property
+        def type(self):
+            raise RuntimeError(PRIVATE_PROSE)
+
+        @property
+        def body(self):
+            raise RuntimeError(PRIVATE_PROSE)
+
+    message = _redacted_provider_error_message(_RefusalWhoseAttributesRaise())
+
+    assert message == (
+        "Code Interpreter provider error (_RefusalWhoseAttributesRaise)"
+    )
+    assert PRIVATE_PROSE not in message
+
+
+# ── where the new sentence ends up ────────────────────────────────────────
+
+
+def test_the_runner_returns_the_classified_message(capsys) -> None:
+    """``run`` puts it in ``error``, and that is what the run log prints.
+
+    ``step2_run_inference.py`` writes ``result["error"]`` straight into the
+    per-task progress line — the exp032 log reads ``✗ Code Interpreter
+    provider error (PermissionDeniedError), mem=227MB``. So classifying the
+    message here is the whole of what makes the next run's log say why.
+    """
+    client = _injected_client()
+    client.responses.create.side_effect = _refusal(
+        {"error": {"code": "PermissionDenied", "message": PRIVATE_PROSE}}
+    )
+    runner = CodeInterpreterRunner(client=client, redact_provider_errors=True)
+
+    result = runner.run(task_prompt="Create a file", model="deployment")
+
+    assert result["success"] is False
+    assert result["error"] == (
+        "Code Interpreter provider error "
+        "(PermissionDeniedError, http 403, code PermissionDenied)"
+    )
+    captured = capsys.readouterr()
+    assert PRIVATE_PROSE not in captured.out + captured.err + json.dumps(result)
+    assert PRIVATE_URL not in captured.out + captured.err + json.dumps(result)
+
+
+def test_the_published_record_still_names_only_the_exception_class() -> None:
+    """The persisted result is unchanged, which is the point.
+
+    ``_public_persisted_results`` projects every error through
+    ``public_task_error_text`` before it is written or uploaded, and that
+    keeps the class name alone. The classification is for the run log and the
+    operator; the published artefact carries exactly what it carried before,
+    so nothing downstream of it has to change.
+    """
+    message = _redacted_provider_error_message(
+        _refusal({"error": {"code": "PermissionDenied", "message": PRIVATE_PROSE}})
+    )
+
+    assert public_task_error_text(message) == (
+        "task_execution_error:PermissionDeniedError"
+    )
+
+
+def test_the_classification_is_absent_when_the_route_is_not_redacted() -> None:
+    """Unredacted runs are untouched: they already keep the whole detail.
+
+    ``redact_provider_errors`` is forced on only for typed Azure code
+    interpreter runs. Everything else injects its client unwrapped, so the
+    proxy — and therefore all of this — never runs at all.
+    """
+    detail = "legacy Code Interpreter provider detail"
+    client = _injected_client()
+    client.responses.create.side_effect = RuntimeError(detail)
+    runner = CodeInterpreterRunner(client=client)
+
+    assert runner.client is client
+    assert runner.run(task_prompt="x", model="deployment")["error"] == detail


### PR DESCRIPTION
## 무슨 일이 있었나

실행 줄 비교(Stage 4)의 세 번째 자리인 **Azure 코드 인터프리터**의 5개 작업 사전
점검이 **5개 전부 실패**했습니다. 다섯 작업이 남긴 기록은 전부 같은 한 줄입니다.

```
task_execution_error:PermissionDeniedError
```

`PermissionDeniedError`는 HTTP 403에 대한 OpenAI SDK의 클래스 이름입니다.
**거절당했다**는 사실은 말합니다. 그런데 **무엇이** 거절했는지는 말하지 않습니다.

- 권한이 없는 것인지
- 배포 이름이 없는 것인지
- 할당량이 떨어진 것인지
- 정책이 막은 것인지

넷 다 403으로 옵니다. 다음에 어디를 봐야 하는지는 **네 갈래가 전부 다릅니다.**

## 왜 아무것도 안 남았나

`core/code_interpreter.py`는 typed Azure 경로일 때 클라이언트를
`_CodeInterpreterProviderCallProxy`로 감쌉니다. 이 대리자는 공급자 예외를 전부
**클래스 이름만 담은** `RuntimeError`로 바꾸고 `from None`으로 사슬을 끊습니다.

이건 실수가 아니라 **일부러 그렇게 만든 것**입니다. 원래 예외의 본문에는 이런 게
들어 있습니다.

```
Principal 00000000-… does not have authorization to perform action
'Microsoft.CognitiveServices/accounts/OpenAI/responses/action' over scope
/subscriptions/…/hjeon-fdpo-foundry-eus2/projects/gdpval-realworks
```

엔드포인트·계정·프로젝트·배포 이름이 전부 있습니다. 이 저장소는 실행 기록을
공개하므로, **이 가림막은 없앨 수 없습니다.**

## 가림막과 진단은 사실 서로 배타적이지 않습니다

상태는 **숫자**입니다. 오류 코드는 **식별자**입니다 — `PermissionDenied`,
`AuthorizationFailed`, `DeploymentNotFound`, `insufficient_quota`.

그런데 엔드포인트도, 계정 이름도, 산문 한 문장도 **점·붙임표·빗금·쌍점·공백
없이는 적을 수 없습니다.**

그래서 이 두 가지는 **모양으로** 통과시킵니다. 나머지가 빠지는 이유는 지워야 할
것을 나열해서가 아니라, **그 모양을 가질 수 없어서**입니다.

```python
_PROVIDER_CODE_SHAPE = re.compile(r"\A[A-Za-z0-9_]{1,64}\Z")
```

| 통과시키는 것 | 조건 |
|---|---|
| 상태 | 100~599 범위의 **정수**일 때만 |
| 코드 | 위 모양을 만족할 때만 |

읽는 곳은 두 군데입니다. SDK가 예외 위로 올려 준 속성과, **본문 자체**입니다.
Azure는 코드를 `body["error"]` 아래 **한 겹 안**에 넣고, SDK는 그 경우
`exc.code`를 `None`으로 둡니다. 테스트가 이 사실 자체를 직접 확인합니다.

```python
assert refusal.code is None, "the SDK started reading nested codes"
assert "code AuthorizationFailed" in _redacted_provider_error_message(refusal)
```

즉 본문을 읽는 건 보험이 아니라 **이게 없으면 실제 Azure 거절에서 상태밖에 못
얻는다**는 뜻입니다.

## 바뀌는 것과 바뀌지 않는 것

바뀌는 것은 **실행 로그 한 줄**입니다.

```
전: ✗ Code Interpreter provider error (PermissionDeniedError), mem=227MB
후: ✗ Code Interpreter provider error (PermissionDeniedError, http 403,
                                       code PermissionDenied), mem=227MB
```

**공개되는 기록은 그대로입니다.** `_public_persisted_results`가 모든 오류를
`public_task_error_text`로 통과시키고, 그 정규식은 **첫** 일치를 취하므로 결과는
여전히 `task_execution_error:PermissionDeniedError`입니다. 뒤에 붙은 분류는
기록에 닿지 않습니다. 그래서 이 아래로 아무것도 고칠 게 없습니다.

**분류할 것이 없으면 문구는 글자 하나 바뀌지 않습니다.** 기존
`tests/test_code_interpreter.py`가 `"Code Interpreter provider error (OSError)"`를
**등호로** 확인하는 곳이 다섯 군데 있습니다. 빈 괄호도, `None`도, `unknown`도
붙지 않습니다.

**exp030(호스트)과 exp031(도커)의 결과는 영향을 받지 않습니다.**
`core/executor.py`는 `CodeInterpreterRunner`를 `mode == "code_interpreter"`일
때만 만듭니다(모듈 맨 위에서 import만 하고, 인스턴스는 그 분기 안에서만
만듭니다). 두 실행 기록은 그대로 유효합니다.

## 채점기 지문은 움직입니다

`compute_grader_source_hash`의 입력에 `core/**/*.py`가 들어가므로 이 변경은
**채점기 지문을 바꿉니다.** 지금 안전한 이유는 **진행 중인 채점 조각이 하나도
없기** 때문입니다(Stage 3은 `de893f5`로 끝났고, 5개 작업 사전 점검은 점수를
보지 않으므로 채점을 부르지 않습니다).

## 왜 이걸 고치는 것이 옳은가

로그를 다시 뒤져 봤습니다. `/tmp` 아래 받아 둔 실행 로그 358KB 전체에서
`403|forbidden|permission|authoriz|rbac|role|denied`를 찾으면 **가려진 클래스
이름밖에 없습니다.** 서버가 보낸 코드에 닿는 **공짜 경로가 없습니다.** 그래서
코드를 고치는 것 말고 알아낼 방법이 없습니다.

그리고 지금까지 좁혀 둔 것이 있습니다. 다섯 작업 중 **셋**
(`02aa1805`, `0112fc9b`, `3baa0009`)은 **참조 파일이 하나도 없습니다.** 참조
파일이 없으면 `_upload_reference_files`는 HTTP 호출 없이 빈 목록을 돌려줍니다.
그러므로 이 셋의 **첫 HTTP 호출은 `responses.create`이고, 그것이 403이었습니다.**
파일 업로드가 아니라 **`POST /responses`에서 거절당한 것**입니다.

같은 신원·같은 Foundry 계정이 계정 수준 경로(`direct-v1`)에서는 exp030·exp031
합쳐 **10번 성공**했고, 프로젝트 경로에서만 거절당합니다. 이 조합은 프로젝트
범위 역할 배정이 빠졌을 때의 모양입니다 — 서버가 보낸 **코드가 이 추측을
확인하거나 반박할 것**입니다.

## 확인한 것

- 새 테스트 파일 1개, 검사 **30개**. 기존 `test_code_interpreter.py` 33개와 함께
  **63개 통과**
- **변이 검증 6건, 전부 잡힘**

| 일부러 망가뜨린 것 | 결과 |
|---|---|
| 모양을 넓혀 점과 붙임표를 받게 하기 | 잡힘 — 4건 실패 |
| 본문을 읽지 않고 SDK 속성만 믿기 | 잡힘 — 3건 실패 |
| 상태 읽기의 보호를 없애기 | 잡힘 — 1건 실패 |
| `except` **안에서** raise 하기 | 잡힘 — 2건 실패 |
| 분류가 비어도 붙이기 | 잡힘 — 6건 실패 |
| 범위를 넓혀 아무 숫자나 상태로 받기 | 잡힘 — 3건 실패 |

  전부 되돌렸고 소스는 바이트 단위로 원래대로입니다.

- 두 가지는 **읽었는지**가 아니라 **안 읽었는지**로 확인합니다. 산문·요청·응답을
  읽으면 터지는 예외를 만들어 통과시킵니다. 결과에서 안 보이는 것은 "안
  남겼다"는 증거일 뿐이고, 터지지 않는 것은 "**안 만졌다**"는 증거입니다
- 속성이 던져도 가림막이 뚫리지 않는지 확인합니다.
  `getattr(obj, name, default)`는 `AttributeError`만 삼키므로, 다른 것을 던지는
  프로퍼티는 가림막을 통째로 빠져나갈 수 있습니다. 실패는 언제나 **덜 자세한
  쪽**으로만 일어나야 합니다
- mypy: 새 코드에 오류 **0건**(기존 5건은 415·460·531·554행으로 이 변경 이전
  것이며, `origin/main`에서도 같은 5건입니다)
- 전체 `pytest` **6707 통과 · 7 skip · 45 deselect · 실패 0** (15분 4초).
  현재 `origin/main`(`9f00b84`) 위에 rebase 한 나무에서 돌렸습니다. 건너뛴 7건은
  LibreOffice 없음·도커 seccomp 같은 **이 기계의 사정**입니다
- **모델 호출 0회, 채점 실행 0회, 로그인 없음, 쓴 돈 없음.** 유일한 현실적인
  거절은 `httpx` 객체로 로컬에서 만들어 씁니다
