### PR TITLE
fix(envelope): exp030/exp031 리포트 재생성 — 재지 않은 QA를 0.0/10이 아니라 "-"로

### DIFF
--- a/batch-runner/results/exp030_envelope_host_python_process/report/report.md
+++ b/batch-runner/results/exp030_envelope_host_python_process/report/report.md
@@ -1,0 +1,80 @@
+# Experiment Report: Run-place comparison — a separate Python process on the server (5 tasks)
+
+| Field | Value |
+|-------|-------|
+| **Experiment ID** | `exp030_envelope_host_python_process` |
+| **Condition** | Separate Python process on the server |
+| **Model** | gpt-5.4 |
+| **Execution Mode** | subprocess |
+| **Date** | 2026-09-01 |
+| **Duration** | 3m 5s |
+| **Generated At** | 2026-09-01T04:36:38.154672+00:00 |
+| 🤗 HF Target | [HyeonSang/exp030_envelope_host_python_process](https://huggingface.co/datasets/HyeonSang/exp030_envelope_host_python_process) |
+| 📊 Self-Report | Prepared locally; Step 7 upload requested but not verified by this report |
+| 📊 Grading | ⏳ Awaiting external grading |
+
+## Problem-Solving Cost
+
+> Usage-based estimate, not an Azure invoice amount.
+
+| Metric | Value |
+|--------|-------|
+| Coverage | 5 / 5 tasks (100.0%) |
+| Receipt status | complete |
+| Total | $0.2783 |
+| Average per task | $0.0557 |
+| Median | $0.0632 |
+| P95 | $0.0857 |
+| Max | $0.0898 |
+| Per successful deliverable | $0.0928 |
+| Failed tasks | 2 ($0.1530) |
+
+- 🧾 Cost ledger: `cost_ledger.jsonl` (sha256 `976198a70bc3…`)
+
+## Key Metrics
+
+| Metric | Value |
+|--------|-------|
+| Total Tasks | 5 |
+| Success | 3 (60.0%) |
+| Errors | 2 |
+| Retried Tasks | 0 |
+| Avg QA Score | - |
+| Min QA Score | - |
+| Max QA Score | - |
+| Avg Latency | 37,017ms |
+| Max Latency | 59,861ms |
+| Total LLM Time | 185s |
+
+## File Generation
+
+| Metric | Value |
+|--------|-------|
+| Tasks requiring files | 4 |
+| Successfully generated | 3 (75.0%) |
+| Failed (empty outputs preserved) | 1 |
+
+## Sector Breakdown
+
+| Sector | Tasks | Success | Success% | Avg QA | Avg Latency |
+|--------|-------|---------|----------|--------|-------------|
+| Health Care and Social Assistance | 1 | 1 | 100.0% | - | 26,444ms |
+| Information | 1 | 1 | 100.0% | - | 18,624ms |
+| Professional, Scientific, and Technical  | 2 | 1 | 50.0% | - | 40,079ms |
+| Real Estate and Rental and Leasing | 1 | 0 | 0.0% | - | 59,861ms |
+
+## Task Results
+
+| # | Task ID | Sector | Occupation | Status | Retry | Files | QA Score | Latency |
+|---|---------|--------|------------|--------|-------|-------|----------|---------|
+| 1 | `02aa1805…` | Professional, Scientif | Project Management | ❌ error | - | 0 | - | 39880ms |
+| 2 | `0112fc9b…` | Health Care and Social | Nurse Practitioner | ✅ success | - | 2 | - | 26444ms |
+| 3 | `2ea2e5b5…` | Professional, Scientif | Computer and Infor | ✅ success | - | 5 | - | 40278ms |
+| 4 | `3baa0009…` | Information | News Analysts, Rep | ✅ success | - | 2 | - | 18624ms |
+| 5 | `0818571f…` | Real Estate and Rental | Real Estate Broker | ❌ error | - | 0 | - | 59861ms |
+
+## Deliverable Files
+
+- `0112fc9b…` (Health Care and Social Assistance): 2 file(s)
+- `2ea2e5b5…` (Professional, Scientific, and Technical Services): 5 file(s)
+- `3baa0009…` (Information): 2 file(s)

--- a/batch-runner/results/exp031_envelope_docker_container/report/report.md
+++ b/batch-runner/results/exp031_envelope_docker_container/report/report.md
@@ -1,0 +1,81 @@
+# Experiment Report: Run-place comparison — a Docker container (5 tasks)
+
+| Field | Value |
+|-------|-------|
+| **Experiment ID** | `exp031_envelope_docker_container` |
+| **Condition** | Docker container |
+| **Model** | gpt-5.4 |
+| **Execution Mode** | sandbox |
+| **Date** | 2026-09-01 |
+| **Duration** | 3m 57s |
+| **Generated At** | 2026-09-01T04:37:53.259892+00:00 |
+| 🤗 HF Target | [HyeonSang/exp031_envelope_docker_container](https://huggingface.co/datasets/HyeonSang/exp031_envelope_docker_container) |
+| 📊 Self-Report | Prepared locally; Step 7 upload requested but not verified by this report |
+| 📊 Grading | ⏳ Awaiting external grading |
+
+## Problem-Solving Cost
+
+> Usage-based estimate, not an Azure invoice amount.
+
+| Metric | Value |
+|--------|-------|
+| Coverage | 5 / 5 tasks (100.0%) |
+| Receipt status | complete |
+| Total | $0.3740 |
+| Average per task | $0.0748 |
+| Median | $0.0677 |
+| P95 | $0.1272 |
+| Max | $0.1360 |
+| Per successful deliverable | $0.0935 |
+| Failed tasks | 1 ($0.0372) |
+
+- 🧾 Cost ledger: `cost_ledger.jsonl` (sha256 `8dd544bae244…`)
+
+## Key Metrics
+
+| Metric | Value |
+|--------|-------|
+| Total Tasks | 5 |
+| Success | 4 (80.0%) |
+| Errors | 1 |
+| Retried Tasks | 0 |
+| Avg QA Score | - |
+| Min QA Score | - |
+| Max QA Score | - |
+| Avg Latency | 47,421ms |
+| Max Latency | 87,114ms |
+| Total LLM Time | 237s |
+
+## File Generation
+
+| Metric | Value |
+|--------|-------|
+| Tasks requiring files | 4 |
+| Successfully generated | 3 (75.0%) |
+| Failed (empty outputs preserved) | 1 |
+
+## Sector Breakdown
+
+| Sector | Tasks | Success | Success% | Avg QA | Avg Latency |
+|--------|-------|---------|----------|--------|-------------|
+| Health Care and Social Assistance | 1 | 0 | 0.0% | - | 22,742ms |
+| Information | 1 | 1 | 100.0% | - | 29,881ms |
+| Professional, Scientific, and Technical  | 2 | 2 | 100.0% | - | 70,906ms |
+| Real Estate and Rental and Leasing | 1 | 1 | 100.0% | - | 42,674ms |
+
+## Task Results
+
+| # | Task ID | Sector | Occupation | Status | Retry | Files | QA Score | Latency |
+|---|---------|--------|------------|--------|-------|-------|----------|---------|
+| 1 | `02aa1805…` | Professional, Scientif | Project Management | ✅ success | - | 3 | - | 54698ms |
+| 2 | `0112fc9b…` | Health Care and Social | Nurse Practitioner | ❌ error | - | 0 | - | 22742ms |
+| 3 | `2ea2e5b5…` | Professional, Scientif | Computer and Infor | ✅ success | - | 7 | - | 87114ms |
+| 4 | `3baa0009…` | Information | News Analysts, Rep | ✅ success | - | 3 | - | 29881ms |
+| 5 | `0818571f…` | Real Estate and Rental | Real Estate Broker | ✅ success | - | 2 | - | 42674ms |
+
+## Deliverable Files
+
+- `02aa1805…` (Professional, Scientific, and Technical Services): 3 file(s)
+- `2ea2e5b5…` (Professional, Scientific, and Technical Services): 7 file(s)
+- `3baa0009…` (Information): 3 file(s)
+- `0818571f…` (Real Estate and Rental and Leasing): 2 file(s)


### PR DESCRIPTION
## 무엇을 고쳤나 — 재지 않은 값을 0점으로 적은 리포트 2장

exp030(서버의 별도 파이썬 프로세스)과 exp031(도커 컨테이너) 리포트에 QA 점수가
`0.0/10`으로 실려 있었습니다. **이 두 실험은 QA를 애초에 한 번도 재지 않았습니다.**

두 실험 YAML은 Self-QA를 **일부러** 꺼 두었습니다.

```yaml
  # Off in all three files. This comparison changes where the code runs and
  # nothing else, so the model must not get a second look at its own answer in
  # one place and not another.
  qa:
    enabled: false
    max_retries: 0
```

실행 **장소만** 바꿔 비교하는 실험이라, 한쪽에만 자기 검토 기회를 주면 불공정합니다.
그래서 점수를 요청하지 않았습니다.

`0.0/10`은 "0점을 받았다"입니다. 하지만 사실은 "**안 쟀다**"입니다. 10점 만점에서
가장 나쁜 값이라, 재지 않은 자리에 그 값을 적으면 **모든 채점 항목에서 떨어진
모델처럼** 읽힙니다.

## 원본 데이터는 처음부터 정직했습니다

두 실행의 원본 `workspace/result.json`을 직접 열어 확인했습니다.

| | task 5개의 `qa_score` |
|---|---|
| exp030 (`33463492420`) | `null` × 5 |
| exp031 (`33464302634`) | `null` × 5 |

**즉 결함은 100% 리포트를 그려내는 쪽에 있었고, 실험 데이터에는 0%였습니다.**
실행을 다시 할 이유가 없습니다.

## 왜 지금 고칠 수 있나 — main이 이미 고쳤습니다

리포트를 만든 시점의 코드(`5af7bf7`)는 점수가 하나도 없으면 **0을 적었습니다.**

```python
# 5af7bf7 — step6_report.py:207-209  (틀린 리포트를 만든 코드)
"avg_qa_score": round(sum(scores) / len(scores), 2) if scores else 0.0,
"min_qa_score": min(scores) if scores else 0,
"max_qa_score": max(scores) if scores else 0,
```

현재 main(#336 병합 뒤)은 같은 자리에 **`None`을 넣습니다.**

```python
# a623b67 — step6_report.py:219-221  (현재 main)
"avg_qa_score": round(sum(scores) / len(scores), 2) if scores else None,
"min_qa_score": min(scores) if scores else None,
"max_qa_score": max(scores) if scores else None,
```

`None`은 `core/measurement_display.py`의 `render_measured()`가 `-`로 출력합니다.
그 파일 설명이 정확히 이 상황을 가리킵니다.

> A measurement that really is zero still prints as zero.
> The dash is only ever for the absence of one.
>
> (진짜 0점은 그대로 0으로 찍힙니다. 대시는 "값이 없음"에만 씁니다.)

## 이 PR이 한 일

**모델을 한 번도 호출하지 않았습니다.** 지시대로 `--no-narrative`로 돌렸습니다.
새 실험·유료 호출 **0건**입니다.

```
# 두 실행 모두 동일한 절차
python step6_report.py --result-json workspace/result.json \
                       --output-dir <재생성 위치> --no-narrative
```

입력은 만료되지 않은 **원본 실행 산출물** 그대로이고, 코드만 고쳐진 main입니다.

## 결과 확인 (3개 게이트 모두 통과)

| 확인 | 결과 |
|---|---|
| `N/10` 형태의 점수가 남아 있는가 | **0건** ✅ |
| 품질 실패로 해석하는 문장이 있는가<br>(`did not correspond`, `should not be interpreted`, `no positive`, `uniformly`, `failed every`, `validated output quality`, `quality signal`) | **0건** ✅ |
| QA 칸이 `-`로 나오는가 | Avg / Min / Max 전부 `-` ✅ |

태스크별 표와 섹터별 표의 QA 칸도 전부 `-`입니다.

닫힌 #337 / #339에 실려 있던 아래 문장들은 **사라졌습니다.**

> ~~"Execution success therefore did not correspond to validated output quality."~~ (#337)
> ~~"the 80% execution success should not be interpreted as evidence of validated output quality"~~ (#339)

## Provenance

| 항목 | exp030 | exp031 |
|---|---|---|
| 원본 실행 커밋 SHA | `b3ec29f23690ab99b49889b05adb7c27a13692fe` | 동일 |
| 실행 ID | `33463492420` (success) | `33464302634` (success) |
| 산출물 | `batch-results-33463492420` / id `9784197756` / 1,764,299 B | `batch-results-33464302634` / id `9784490658` / 1,571,285 B |
| 입력 `result.json` SHA-256 | `a1639ad9bdda79c2c0c46d397c10fb45ff491ee139940b19fdd6c38a2b285178` | `762e17988378fcfd9b04785c373ce6f519eaa0551fd5e889ced704c02d4df765` |
| 재생성 `report.md` SHA-256 | `c275049452e6da8200aae0ca16e8a86a21d13f548d6182ca1b0eb72697a1dbe0` | `cabe4136679a1b6263dbd12992463c927927f0e48898dcbcb60db919734e6a3f` |
| 대체하는 닫힌 PR | #337 (head `5cf9b5b3`) | #339 (head `931c0cb8`) |

**리포트를 생성한 코드 (blob SHA @ `a623b677`)**

| 파일 | blob SHA |
|---|---|
| `batch-runner/step6_report.py` | `eb6852011948515c481bf9535d391c3d6b8993a3` |
| `batch-runner/core/measurement_display.py` | `58a63e3c62b76538b1f4e3796286867ae05dc6bd` |
| `batch-runner/core/narrative_analyzer.py` | `40e3881dc1bfb8604201726cb11fd81242e74dc2` |

재현: 위 실행 ID의 산출물을 받아 `result.json`의 SHA-256이 표와 같은지 확인한 뒤,
`a623b677`(또는 이후 main)에서 같은 명령을 돌리면 같은 `report.md` SHA-256이 나옵니다.

## 알려 드릴 트레이드오프 2가지

**1. 서술(narrative) 섹션이 없습니다.** 서술은 모델이 씁니다. "모델 호출 없이"가
지시였으므로 `--no-narrative`로 돌렸고, 그래서 Overview / Quality Analysis /
Failure Patterns / Recommendations 4개 섹션이 없습니다. 잘못된 결론 문장을 만든
곳이 바로 이 서술이었으므로, 이번 정정에서는 없는 편이 안전하다고 판단했습니다.

**2. 실패 태스크의 오류 상세가 `report.md`에는 없습니다.** `## Failure Analysis`
섹션이 서술에 딸려 있어서(step6_report.py:1119) 서술이 없으면 같이 빠집니다.
표에는 `❌ error` 행만 남습니다. 사실 자체는 `report_data.json`의 `error_tasks`에
그대로 있지만, 그 파일은 `.gitignore:64`에서 의도적으로 제외("HF Dataset에서 관리")
되어 있어 **강제로 추가하지 않았습니다.** 대신 여기에 적어 둡니다.

| 실험 | task | 섹터 / 직군 | error_code | error_type |
|---|---|---|---|---|
| exp030 | `02aa1805…` | Professional, Scientific, and Technical Services / Project Management Specialists | `task_execution_error` | `ValueError` |
| exp030 | `0818571f…` | Real Estate and Rental and Leasing / Real Estate Brokers | `task_execution_error` | `ValueError` |

이 두 건은 **실험이 실제로 실패한 것**이고, 리포트 생성 실패나 렌더러 fallback이
아닙니다. exp031은 실패 1건입니다.

## 재발 방지는 이미 main에 있습니다

`core/narrative_analyzer.py:414`가 서술을 쓰는 모델에게 이렇게 알려 줍니다.

```python
f'\nNote: "{NOT_MEASURED}" below means that figure was never '
```

즉 **앞으로 서술을 켜고 돌려도** 모델이 `-`를 0점으로 오해해 같은 결론을 쓸 수
없습니다. 이 PR은 이미 나온 리포트 2장을 고칠 뿐이고, 구조적 결함은 #336에서
닫혔습니다.

## 범위

- 변경 파일 **2개**, `report.md`만. 실험 데이터·설정·코드는 **건드리지 않았습니다.**
- 기존 실험 결과에 새 기준을 소급 적용하지 않았습니다 — 같은 데이터를 **고쳐진
  코드로 다시 그렸을 뿐**입니다.
- force-push 없음, history rewrite 없음.
