### PR TITLE
fix(ci): 봇이 만든 결과 PR이 실제 검사를 받게 하고, 못 받으면 fail closed

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -9,6 +9,19 @@ name: Backend Tests
 # pre-existing backlog (189 and 20 findings on main) that a gate would freeze
 # into permanent red.
 
+# The `pull_request` trigger below does not reach the result PRs that
+# batch-run.yml opens. Those are created by peter-evans/create-pull-request with
+# GITHUB_TOKEN, and GitHub deliberately refuses to start a `pull_request` run
+# for them so a workflow cannot loop by writing to its own repository. It does
+# not refuse quietly: a run row IS created, and it dies at startup with zero
+# jobs and the message "This run likely failed because of a workflow file
+# issue." Six for six on the bot PRs measured (33464032707, 33464032741,
+# 33464910416, 33464910554, 33308414611, 33308414607), while every
+# human-authored PR touching the same paths ran normally. The result PR then
+# shows an empty Checks list, which reads as "nothing to report" when the truth
+# is "never ran". `workflow_dispatch` is not subject to that rule, so
+# batch-run.yml dispatches this workflow explicitly and refuses to finish green
+# unless the dispatched run comes back successful.
 on:
   pull_request:
     paths:
@@ -19,9 +32,17 @@ on:
     paths:
       - "batch-runner/**"
       - ".github/workflows/backend-tests.yml"
+  workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: 'Exact result-PR head SHA this dispatch must test. A dispatch resolves a branch name to whatever it points at now, so the caller pins the commit it measured and the run below refuses to be anything else.'
+        required: true
+        type: string
 
 # Read-only, and no secrets are referenced anywhere below. The suite must stay
-# runnable from a fork PR, where neither is available.
+# runnable from a fork PR, where neither is available. A dispatch does not need
+# more than this either: it only reads the tree and runs pytest, and the caller
+# -- not this workflow -- is what acts on the verdict.
 permissions:
   contents: read
 
@@ -34,6 +55,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # A dispatch names a branch, and a branch is a moving pointer. Between the
+      # caller measuring the PR head and this run starting, the branch can be
+      # updated -- so the caller passes the SHA it measured and this refuses to
+      # run as anything else. `github.workflow_sha` is checked too, so the
+      # workflow file being obeyed is the one on the commit under test rather
+      # than a different version of this file on a branch that happens to share
+      # the name. Same shape as the validation dispatch in deploy.yml.
+      - name: Verify dispatch contract
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$GITHUB_SHA" == "$EXPECTED_SHA" ]]
+          [[ "$WORKFLOW_SHA" == "$EXPECTED_SHA" ]]
+          echo "dispatch pinned to $EXPECTED_SHA"
+
       # Full history, not the default shallow clone.
       # test_verifier_ignores_hostile_path_for_repository_git resolves a
       # hardcoded commit (3ecb8ded, "docs(sandbox): finalize evidence isolation
@@ -44,6 +84,18 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      # The contract check above reads what GitHub *said* the run is for. This
+      # reads what actually landed on disk. The default checkout resolves a
+      # branch name, so a push racing the dispatch would otherwise be tested
+      # silently under the pinned SHA's name.
+      - name: Verify exact checkout
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]
 
       # Exact patch, not "3.11" like the other workflows here. core/agentic_v2_
       # license.py pins LICENSE_EVALUATOR_PYTHON_VERSION = "3.10.12" and

--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -1077,6 +1077,17 @@ jobs:
             --json headRefOid --jq .headRefOid)
           [[ "$CURRENT_HEAD" == "$PR_HEAD_SHA" ]]
 
+      # Two dispatches, one contract. deploy.yml validates the dashboard build;
+      # backend-tests.yml runs the pytest suite. Neither reaches this PR through
+      # its own `pull_request` trigger, because the PR was opened by
+      # GITHUB_TOKEN and GitHub refuses to start a `pull_request` run for a
+      # bot-authored PR -- it creates the run row and kills it at startup with
+      # zero jobs. So the PR's own Checks list stays empty and reads as "nothing
+      # to report" when the truth is "never ran". `workflow_dispatch` is exempt
+      # from that rule, is already proven to work here (`actions: write` is
+      # granted above and the deploy dispatch has been landing since #303), and
+      # pins the exact SHA on both sides so a branch update cannot slip a
+      # different tree past the check.
       - name: Dispatch exact result PR validation
         if: success() && inputs.dry_run != true && steps.check_relay.outputs.needs_relay == 'false' && steps.step2a.outcome == 'success'
         env:
@@ -1090,6 +1101,102 @@ jobs:
             --ref "$PR_BRANCH" \
             --raw-field deploy_pages=false \
             --raw-field expected_sha="$PR_HEAD_SHA"
+          gh workflow run backend-tests.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$PR_BRANCH" \
+            --raw-field expected_sha="$PR_HEAD_SHA"
+
+      # Dispatching is not checking. The step above only asks; without this one
+      # the job would go green whether the suite passed, failed, or never
+      # started -- which is the same silence the empty Checks list already
+      # produces, just moved one step later.
+      #
+      # Fail closed on every path that is not an observed success: a run that
+      # concludes failure/cancelled/timed_out, a run that never appears, and the
+      # wait timing out all end the job red. Absence is treated as failure
+      # precisely because absence is the symptom being fixed here. Nothing below
+      # writes a check, a status, or an approval -- a red result stays red and
+      # visible, and the PR is put back into draft so the empty Checks list
+      # cannot be mistaken for a clean one.
+      #
+      # This gates the PR, not the upload: step 7 has already run by here, and
+      # deliberately so. The only file in a result PR is report.md, and the code
+      # the suite exercises is identical to the commit the experiment already
+      # ran at, so pytest's verdict is a merge decision about the repository --
+      # not a publish decision about the experiment. Blocking a paid run's
+      # upload on it would spend the money and then throw the artifacts away.
+      - name: Verify dispatched result PR checks
+        if: success() && inputs.dry_run != true && steps.check_relay.outputs.needs_relay == 'false' && steps.step2a.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          PR_HEAD_SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
+          REQUIRED_WORKFLOWS: 'backend-tests.yml deploy.yml'
+          WAIT_SECONDS: '1800'
+          POLL_SECONDS: '20'
+        run: |
+          set -euo pipefail
+
+          deadline=$(( $(date +%s) + WAIT_SECONDS ))
+          declare -A conclusion=()
+          declare -A run_url=()
+
+          while :; do
+            pending=0
+            for wf in $REQUIRED_WORKFLOWS; do
+              [[ -n "${conclusion[$wf]:-}" ]] && continue
+              # head_sha is the pin. A dispatch on a branch that moved would
+              # report a different SHA and simply never match, which times out
+              # red rather than passing on the wrong tree.
+              row=$(gh api \
+                "repos/$GITHUB_REPOSITORY/actions/workflows/$wf/runs?event=workflow_dispatch&head_sha=$PR_HEAD_SHA&per_page=1" \
+                --jq '.workflow_runs[0] // empty | select(.status == "completed") | "\(.conclusion)\t\(.html_url)"' 2>/dev/null || true)
+              if [[ -n "$row" ]]; then
+                conclusion[$wf]=${row%%$'\t'*}
+                run_url[$wf]=${row##*$'\t'}
+                echo "$wf -> ${conclusion[$wf]}"
+              else
+                pending=$(( pending + 1 ))
+              fi
+            done
+            (( pending == 0 )) && break
+            if (( $(date +%s) >= deadline )); then
+              echo "::error::timed out after ${WAIT_SECONDS}s waiting for dispatched checks on $PR_HEAD_SHA"
+              break
+            fi
+            sleep "$POLL_SECONDS"
+          done
+
+          failed=""
+          for wf in $REQUIRED_WORKFLOWS; do
+            verdict=${conclusion[$wf]:-never-reported}
+            if [[ "$verdict" != "success" ]]; then
+              failed="${failed}${failed:+, }${wf} (${verdict})"
+            fi
+          done
+
+          if [[ -z "$failed" ]]; then
+            echo "all required checks succeeded on $PR_HEAD_SHA"
+            exit 0
+          fi
+
+          # Draft first, comment second. If the comment call is the one that
+          # fails, the PR is already unmergeable rather than open and unchecked.
+          gh pr ready "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --undo || true
+          {
+            printf '## 자동 검사 실패 — 병합하지 마세요\n\n'
+            printf '이 결과 PR의 head `%s`에 대해 다음 검사가 성공하지 않았습니다.\n\n' "$PR_HEAD_SHA"
+            printf '| 워크플로 | 결과 | 실행 |\n|---|---|---|\n'
+            for wf in $REQUIRED_WORKFLOWS; do
+              printf '| `%s` | `%s` | %s |\n' \
+                "$wf" "${conclusion[$wf]:-never-reported}" "${run_url[$wf]:-—}"
+            done
+            printf '\n`never-reported`는 검사가 **실패한 것이 아니라 아예 시작되지 않았다**는 뜻입니다.\n'
+            printf 'PR을 draft로 되돌렸습니다. 원인을 확인한 뒤 사람이 다시 열어 주세요.\n'
+          } | gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file - || true
+
+          echo "::error::required checks not successful on $PR_HEAD_SHA: $failed"
+          exit 1
 
       # ── Summary step ──
       - name: Show summary

--- a/batch-runner/tests/test_bot_result_prs_get_real_checks.py
+++ b/batch-runner/tests/test_bot_result_prs_get_real_checks.py
@@ -1,0 +1,314 @@
+"""A bot-authored result PR is checked, and an unchecked one cannot pass.
+
+``batch-run.yml`` ends a successful experiment by opening a pull request that
+carries one file, ``report.md``. It opens it with
+``peter-evans/create-pull-request`` authenticated as ``GITHUB_TOKEN``, and
+GitHub will not start a ``pull_request`` run for a pull request opened that way
+— the rule that stops a workflow looping by writing to its own repository. It
+does not decline quietly. A run row is created, it dies at startup with zero
+jobs, and the API reports ``conclusion=failure`` with "This run likely failed
+because of a workflow file issue."
+
+Six for six on the result PRs measured — 33464032707, 33464032741 (#337),
+33464910416, 33464910554 (#339), 33308414611, 33308414607 — while every
+human-authored pull request touching the same paths ran normally, and the
+workflow files were byte-identical between the two. So the message named a
+defect that was not there, and the result PR showed an empty Checks list. An
+empty list reads as "nothing to report". The truth was "never ran": the suite
+had not seen the branch at all, and the experiment's own run still reported
+success.
+
+``workflow_dispatch`` is exempt from that rule and was already proven here —
+``batch-run.yml`` has dispatched ``deploy.yml`` for the same reason since #303,
+with ``actions: write`` already granted. But dispatching is not checking. A
+dispatch that fails, or never starts, left the job green exactly as before.
+
+So the runner now dispatches both required workflows against the PR head and
+refuses to finish unless both come back successful, treating a check that never
+reported as a failure rather than as an absence. These tests hold that. They
+read the required list and the dispatches out of the workflow rather than
+restating them, so adding a dispatch without requiring it — or requiring one
+without dispatching it — fails here instead of at the next result PR. The last
+two run the workflow's own shell against a scripted ``gh`` and assert what it
+does, because the point of the change is a verdict, not a paragraph.
+
+Nothing here calls a model, signs in to a cloud account, or spends anything.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = BATCH_RUNNER_ROOT.parent
+WORKFLOWS = REPOSITORY_ROOT / ".github" / "workflows"
+BATCH_RUN = WORKFLOWS / "batch-run.yml"
+BACKEND_TESTS = WORKFLOWS / "backend-tests.yml"
+
+# The two steps the change turns on, named as the workflow names them.
+DISPATCH_STEP = "Dispatch exact result PR validation"
+VERIFY_STEP = "Verify dispatched result PR checks"
+CONTRACT_STEP = "Verify dispatch contract"
+
+# The input both sides agree on. A dispatch resolves a branch, and a branch
+# moves; this is the commit the caller measured.
+PIN_INPUT = "expected_sha"
+
+# What a pinned dispatch must refuse. The same three the validation dispatch in
+# deploy.yml refuses, asserted as written so dropping one fails here.
+PIN_ASSERTIONS = (
+    '[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]',
+    '[[ "$GITHUB_SHA" == "$EXPECTED_SHA" ]]',
+    '[[ "$WORKFLOW_SHA" == "$EXPECTED_SHA" ]]',
+)
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(document: dict) -> dict:
+    # PyYAML resolves an unquoted `on:` key to the boolean True.
+    return document.get("on", document.get(True, {})) or {}
+
+
+def _steps(document: dict, job: str) -> list[dict]:
+    return document["jobs"][job]["steps"]
+
+
+def _step(document: dict, job: str, name: str) -> dict:
+    for step in _steps(document, job):
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"{job} has no step named {name!r}")
+
+
+@pytest.fixture(scope="module")
+def batch_run() -> dict:
+    return _load(BATCH_RUN)
+
+
+@pytest.fixture(scope="module")
+def backend_tests() -> dict:
+    return _load(BACKEND_TESTS)
+
+
+@pytest.fixture(scope="module")
+def verify_script(batch_run: dict) -> str:
+    return _step(batch_run, "batch-run", VERIFY_STEP)["run"]
+
+
+def test_the_suite_can_be_dispatched_at_a_named_commit(backend_tests: dict) -> None:
+    """The trigger the bot PR can actually reach, with the pin required."""
+    triggers = _triggers(backend_tests)
+    assert "workflow_dispatch" in triggers, (
+        "backend-tests.yml is reachable only through pull_request and push. "
+        "A bot-authored result PR gets no pull_request run, so without a "
+        "dispatch trigger the suite can never see it."
+    )
+    pin = triggers["workflow_dispatch"]["inputs"][PIN_INPUT]
+    assert pin["required"] is True
+    assert pin["type"] == "string"
+
+
+def test_a_dispatched_run_refuses_to_be_a_different_commit(backend_tests: dict) -> None:
+    """Reading the pin is not enough; the run must decline when it disagrees."""
+    contract = _step(backend_tests, "pytest", CONTRACT_STEP)
+    assert contract["if"] == "github.event_name == 'workflow_dispatch'"
+    script = contract["run"]
+    for assertion in PIN_ASSERTIONS:
+        assert assertion in script, f"dispatch contract no longer checks: {assertion}"
+    assert "set -euo pipefail" in script
+
+    # The contract reads what GitHub said the run is for. Something has to read
+    # what landed on disk, or a push racing the dispatch is tested silently
+    # under the pinned commit's name.
+    checkout_check = _step(backend_tests, "pytest", "Verify exact checkout")
+    assert '[[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]' in checkout_check["run"]
+
+
+def test_being_dispatchable_did_not_cost_it_a_permission(backend_tests: dict) -> None:
+    """The suite still runs from a fork PR, where no token and no secret exist."""
+    assert backend_tests["permissions"] == {"contents": "read"}
+    assert "secrets." not in BACKEND_TESTS.read_text(encoding="utf-8")
+
+
+def test_every_required_check_is_one_the_runner_actually_dispatches(
+    batch_run: dict, verify_script: str
+) -> None:
+    """The list that is waited on and the list that is asked for are the same.
+
+    This is the coupling that keeps the rest honest. Requiring a workflow that
+    is never dispatched hangs until the timeout and fails closed — noisy, but
+    safe. Dispatching one that is never required is the dangerous direction:
+    it runs, it can fail, and nothing reads the verdict.
+    """
+    dispatch_script = _step(batch_run, "batch-run", DISPATCH_STEP)["run"]
+    dispatched = set(re.findall(r"gh workflow run (\S+\.yml)", dispatch_script))
+    required = set(
+        _step(batch_run, "batch-run", VERIFY_STEP)["env"]["REQUIRED_WORKFLOWS"].split()
+    )
+
+    assert dispatched, "the dispatch step no longer dispatches anything"
+    assert required == dispatched, (
+        f"dispatched {sorted(dispatched)} but waits on {sorted(required)}; "
+        "a dispatched workflow nobody waits on can fail unnoticed"
+    )
+    assert "backend-tests.yml" in required
+
+    # Both dispatches pin the same commit the PR was verified at.
+    for workflow in dispatched:
+        block = dispatch_script.split(f"gh workflow run {workflow}")[1]
+        assert f'{PIN_INPUT}="$PR_HEAD_SHA"' in block.split("gh workflow run")[0]
+
+
+def test_the_verdict_is_read_and_never_written(verify_script: str) -> None:
+    """Fail closed, and do not manufacture the thing being checked.
+
+    A shortcut exists here that would make every result PR look green: post a
+    passing status or check-run from the runner. It would also make this whole
+    file decorative. The step may read a conclusion; it may not create one.
+    """
+    assert "exit 1" in verify_script
+    assert "::error::" in verify_script
+
+    forbidden = (
+        "/statuses/",  # POST a commit status
+        "/check-runs",  # POST a check run
+        "gh pr merge",
+        "gh pr review",
+        "--admin",
+        "--auto",
+    )
+    for token in forbidden:
+        assert token not in verify_script, (
+            f"the verification step must not use {token!r} — it reports a "
+            "verdict it read, it does not create or act on one"
+        )
+
+    # The failure path may swallow errors from its own reporting calls, but the
+    # exit that fails the job must not be guarded.
+    assert not re.search(r"exit 1\s*\|\|", verify_script)
+    assert "continue-on-error" not in verify_script
+
+
+def test_a_check_that_never_reported_is_treated_as_a_failure(verify_script: str) -> None:
+    """Absence is the symptom, so absence cannot be the pass condition."""
+    assert "never-reported" in verify_script
+    assert 'verdict=${conclusion[$wf]:-never-reported}' in verify_script
+    assert '[[ "$verdict" != "success" ]]' in verify_script, (
+        "an allow-list of bad conclusions would let a new GitHub conclusion "
+        "value through; only success may pass"
+    )
+    assert "timed out after" in verify_script
+
+
+def test_the_wait_pins_the_head_sha_it_was_given(verify_script: str) -> None:
+    """A dispatch names a branch; only the SHA identifies the tree."""
+    assert "head_sha=$PR_HEAD_SHA" in verify_script
+    assert "event=workflow_dispatch" in verify_script
+    assert 'select(.status == "completed")' in verify_script
+
+
+# --------------------------------------------------------------------------
+# What it does, not what it says. The two below run the workflow's own shell.
+# --------------------------------------------------------------------------
+
+GH_STUB = """#!/usr/bin/env bash
+echo "GH_CALL $*" >> "$SIM_LOG"
+case "$1" in
+  api)
+    case "$2" in
+      *backend-tests.yml*) v="$SIM_BACKEND" ;;
+      *deploy.yml*)        v="$SIM_DEPLOY" ;;
+      *)                   v="" ;;
+    esac
+    [[ -z "$v" ]] && exit 0
+    printf '%s\\thttps://example.invalid/run\\n' "$v"
+    ;;
+  *) : ;;
+esac
+"""
+
+
+def _run_verification(script: str, tmp_path: Path, backend: str, deploy: str):
+    root = Path(tempfile.mkdtemp(dir=tmp_path))
+    stub_dir = root / "bin"
+    stub_dir.mkdir()
+    stub = stub_dir / "gh"
+    stub.write_text(GH_STUB, encoding="utf-8")
+    stub.chmod(0o755)
+    log = root / "calls.log"
+    log.touch()
+
+    environment = dict(os.environ)
+    environment.update(
+        PATH=f"{stub_dir}{os.pathsep}{environment['PATH']}",
+        SIM_LOG=str(log),
+        SIM_BACKEND=backend,
+        SIM_DEPLOY=deploy,
+        GITHUB_REPOSITORY="owner/repo",
+        PR_NUMBER="999",
+        PR_HEAD_SHA="a" * 40,
+        REQUIRED_WORKFLOWS="backend-tests.yml deploy.yml",
+        WAIT_SECONDS="2",
+        POLL_SECONDS="1",
+    )
+    completed = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=120,
+    )
+    return completed, log.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+@pytest.mark.parametrize(
+    ("backend", "deploy", "expected_exit", "why"),
+    [
+        ("success", "success", 0, "both green"),
+        ("failure", "success", 1, "the suite failed"),
+        ("success", "failure", 1, "the dashboard validation failed"),
+        ("success", "cancelled", 1, "a cancelled run is not a passing run"),
+        ("timed_out", "success", 1, "a timed-out run is not a passing run"),
+        ("", "success", 1, "the suite never reported — the original symptom"),
+        ("", "", 1, "neither reported"),
+    ],
+)
+def test_only_two_observed_successes_let_the_job_finish(
+    verify_script: str, tmp_path: Path, backend, deploy, expected_exit, why
+) -> None:
+    completed, _ = _run_verification(verify_script, tmp_path, backend, deploy)
+    assert completed.returncode == expected_exit, (
+        f"{why}: expected exit {expected_exit}, got {completed.returncode}\n"
+        f"{completed.stdout}\n{completed.stderr}"
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+def test_a_failing_result_pr_is_put_back_into_draft(
+    verify_script: str, tmp_path: Path
+) -> None:
+    """An empty Checks list must not be mistakable for a clean one."""
+    completed, calls = _run_verification(verify_script, tmp_path, "", "success")
+    assert completed.returncode == 1
+    assert "pr ready 999" in calls and "--undo" in calls, (
+        "a result PR whose checks did not pass stays open and mergeable"
+    )
+    assert "pr comment 999" in calls
+
+    passing, quiet = _run_verification(verify_script, tmp_path, "success", "success")
+    assert passing.returncode == 0
+    assert "--undo" not in quiet and "pr comment" not in quiet, (
+        "a passing run must not touch the pull request"
+    )


### PR DESCRIPTION
## 무엇이 고장나 있었나 — "검사 없음"이 아니라 "검사를 아예 안 했음"

실험이 성공하면 워크플로가 결과 PR을 자동으로 엽니다(#337, #339가 그것입니다).
그 PR의 **Checks 목록이 비어 있었습니다.**

비어 있는 목록은 보통 "검사할 게 없다"로 읽힙니다. 실제로는 **"한 번도 안 돌았다"**
였습니다. `report.md` 한 장이 `batch-runner/` 아래로 들어가는 PR이니 pytest가 돌아야
맞는데, 돌지 않았습니다. 그런데 실험 실행 자체는 `success`로 끝났습니다.
**아무도 이상하다고 말해 주지 않는 상태**였습니다.

## 원인 — GitHub이 봇이 만든 PR에는 검사를 시작하지 않습니다

`batch-run.yml:917`이 결과 PR을 이렇게 만듭니다.

```yaml
uses: peter-evans/create-pull-request@…  # v8.1.1
with:
  token: ${{ secrets.GITHUB_TOKEN }}
```

`GITHUB_TOKEN`으로 만든 PR에는 GitHub이 **`pull_request` 실행을 시작하지 않습니다.**
워크플로가 자기 저장소에 글을 써서 무한히 자기를 다시 부르는 것을 막는 규칙입니다.

문제는 **조용히 거절하지 않는다**는 점입니다. 실행 기록은 만들어지고, 시작하자마자
**job 0개**로 죽고, API는 `conclusion=failure`에 이렇게 적습니다.

> This run likely failed because of a workflow file issue.

**워크플로 파일에는 아무 문제가 없습니다.** 메시지가 없는 결함을 가리킵니다.

### 6번 중 6번, 예외 없음

| 실행 ID | 결과 PR | job 수 | check-run 수 |
|---|---|---|---|
| `33464032707`, `33464032741` | #337 (exp030) | 0 | 0 |
| `33464910416`, `33464910554` | #339 (exp031) | 0 | 0 |
| `33308414611`, `33308414607` | exp026c 비용 스모크 | 0 | 0 |

다른 가능성은 하나씩 지웠습니다.

| 의심 | 확인 방법 | 결과 |
|---|---|---|
| 워크플로 파일이 정말 깨졌나 | `git diff b3ec29f origin/main -- .github/workflows/` | **비어 있음** — 파일이 같습니다 |
| 브랜치가 main과 충돌했나 | `b3ec29f`가 main의 조상인지 확인 | 조상 맞음, 그 위에 커밋 1개뿐 |
| 경로 필터에 안 걸렸나 | **#342가 대조군입니다** — 같은 경로(`results/*/report/report.md`), 사람이 만든 PR | **pytest 정상 실행** ✅ |

사람이 만든 PR 약 35건은 전부 정상이었습니다. **차이는 오직 "누가 PR을 열었나"** 하나입니다.

### 두 번째 결함 — 기존 우회책이 PR까지 닿지 않았습니다

`batch-run.yml:1088`은 이미 `deploy.yml`을 dispatch로 따로 부르고 있었습니다.
그건 **돌긴 돌았습니다.** head SHA에 check-run 2개가 붙었습니다.

그런데 `gh pr view 337 --json statusCheckRollup`은 **0개**를 돌려줍니다. PR 화면에
안 보입니다. 그리고 `backend-tests.yml`에는 **`workflow_dispatch` 트리거 자체가
없어서** pytest는 그 우회로조차 없었습니다.

## 고친 방법

### 1. `backend-tests.yml` — 부를 수 있게 만들고, 엉뚱한 커밋이면 거부

`workflow_dispatch`는 위의 봇 PR 규칙에 걸리지 않습니다. **추측이 아니라 이 저장소에서
이미 증명된 경로입니다** — `deploy.yml`이 #303부터 같은 방식으로 돌고 있고,
`actions: write` 권한도 이미 있습니다.

dispatch는 **브랜치 이름**을 받습니다. 브랜치는 움직입니다. 그래서 부르는 쪽이 **자기가
잰 커밋**을 같이 넘기고, 받는 쪽이 그게 아니면 거부합니다. `deploy.yml`이 쓰는 것과
같은 3줄입니다.

```bash
[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
[[ "$GITHUB_SHA"   == "$EXPECTED_SHA" ]]
[[ "$WORKFLOW_SHA" == "$EXPECTED_SHA" ]]
```

여기에 하나 더 붙였습니다. 위 3줄은 **GitHub이 뭐라고 말했는지**를 봅니다. 실제로
디스크에 뭐가 내려왔는지는 checkout 뒤에 따로 봅니다.

```bash
[[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]
```

권한은 **`contents: read` 그대로**입니다. fork PR에서도 계속 돌아야 하기 때문입니다.

### 2. `batch-run.yml` — 부르기만 하지 말고, 결과를 확인

**부르는 것과 확인하는 것은 다릅니다.** 부르기만 하면, 그 검사가 실패하든 아예 시작을
못 하든 job은 그대로 초록색입니다. 지금 비어 있는 Checks 목록과 **똑같은 침묵**이
한 단계 뒤로 밀릴 뿐입니다.

그래서 두 워크플로를 부른 뒤, **PR head SHA에서 둘 다 `success`로 끝날 때까지 기다리고,
아니면 job을 실패시킵니다.**

```
성공(둘 다 success) → job 계속
그 외 전부          → PR을 draft로 되돌리고, 한국어 코멘트 남기고, exit 1
```

**"검사가 아예 안 나타남"도 실패로 셉니다.** 없는 것을 통과로 치면 안 됩니다 —
없는 것이 바로 이번에 고치는 증상이기 때문입니다.

## 하지 않은 것 (지시하신 3번)

| 금지된 우회 | 이 PR |
|---|---|
| GITHUB_TOKEN 재귀 실행이 **된다고 가정** | 가정하지 않았습니다. 그게 **안 된다는 것**이 이 PR의 전제입니다. dispatch는 별개 경로이고 이 저장소에서 이미 돌고 있습니다 |
| 필수 검사를 **무조건 통과** | 통과시키는 코드가 없습니다. 검사 결과를 **읽기만** 합니다 |
| 가짜 상태 만들기 | `/statuses/`·`/check-runs` POST, `gh pr merge`, `gh pr review`, `--admin`, `--auto` **전부 금지**하고 테스트로 잠갔습니다 |
| 진짜 실패 숨기기 | 실패는 그대로 빨간색으로 남고, PR은 draft로 내려가 **병합할 수 없게** 됩니다 |
| 새 권한 요구 | **없습니다.** `actions: write`·`pull-requests: write` 둘 다 이미 있었습니다 |

## 이 검사는 "병합"을 막지, "업로드"를 막지 않습니다

의도적인 선택이라 적어 둡니다.

HuggingFace 업로드(Step 7)는 이 확인보다 **먼저** 끝납니다. 결과 PR에 들어 있는 파일은
`report.md` 한 장뿐이고, pytest가 검사하는 코드는 **실험이 이미 돌았던 그 커밋과 완전히
동일**합니다. 즉 pytest의 판정은 *저장소를 병합해도 되는가*에 대한 답이지,
*실험 결과를 발행해도 되는가*에 대한 답이 아닙니다.

여기서 업로드를 막으면 **돈은 다 쓴 뒤에 산출물만 버리게** 됩니다.

## 테스트 15개

```
tests/test_bot_result_prs_get_real_checks.py ...............   15 passed
```

절반은 워크플로를 **읽어서** 확인하고, 나머지 절반은 워크플로의 **셸을 실제로 실행**해서
확인합니다. 가짜 `gh`를 PATH에 놓고 답을 정해 준 뒤 종료 코드를 봅니다.

| backend-tests | deploy | 기대 | 의미 |
|---|---|---|---|
| success | success | **0** | 둘 다 초록 |
| failure | success | **1** | 테스트가 실패 |
| success | failure | **1** | 대시보드 검증이 실패 |
| success | cancelled | **1** | 취소된 실행은 통과가 아님 |
| timed_out | success | **1** | 시간 초과도 통과가 아님 |
| *(안 나타남)* | success | **1** | **원래 증상 그대로** |
| *(안 나타남)* | *(안 나타남)* | **1** | 둘 다 안 나타남 |

그리고 실패했을 때 PR이 실제로 draft로 내려가는지, **성공했을 때는 PR을 건드리지
않는지**도 확인합니다.

가장 중요한 테스트 하나는 이것입니다.

> **부른 워크플로 목록과 기다리는 워크플로 목록이 같은 집합인가.**

기다리기만 하고 안 부르면 timeout으로 빨갛게 실패합니다 — 시끄럽지만 안전합니다.
반대로 **부르기만 하고 안 기다리는 쪽이 위험합니다.** 돌고, 실패할 수 있고, 아무도 안
읽습니다. 그래서 그 조합을 여기서 막습니다.

## 검증

| 항목 | 결과 |
|---|---|
| 새 테스트 | 15 passed |
| `batch-run.yml` / `backend-tests.yml`을 읽는 기존 테스트 전부 | **180 passed, 1 skipped** |
| YAML 파싱 | 두 파일 모두 정상 |
| 삽입한 셸 4블록 `bash -n` | 전부 정상 |
| diff | `batch-run.yml` **추가만 107줄, 삭제 0줄** |

## 범위

- 실험 데이터·설정·`core/` 코드는 **건드리지 않았습니다.** 채점기 지문(fingerprint)이
  움직이지 않으므로 진행 중인 채점에 영향이 없습니다.
- force-push 없음, history rewrite 없음.
- 기존 `pull_request`·`push` 트리거는 그대로 두었습니다. 사람이 만든 PR의 동작은
  **하나도 바뀌지 않습니다.**
