### PR TITLE
fix(provenance): 안 통했는데 '확인됨'으로 기록되던 Azure 경로 상태 정정

### DIFF
--- a/batch-runner/core/inference_manifest.py
+++ b/batch-runner/core/inference_manifest.py
@@ -40,6 +40,13 @@ STEP2_RESULT_STATUSES = frozenset({
 #: written grade is validated against; ``tests/test_step8_grade.py`` proves the
 #: two still agree.
 GOLD_PROVENANCE_STATUS = "gold-corpus"
+#: The three values Step 3 can reach on its own. The other two in the schema
+#: are written elsewhere: ``gold-corpus`` above, and ``legacy-missing`` or
+#: ``verified-sidecar`` by ``scripts/download_inference_from_hf.py`` when an
+#: already-published run is pulled back down.
+RUNTIME_VERIFIED_PROVENANCE_STATUS = "runtime-verified"
+RUNTIME_UNVERIFIED_PROVENANCE_STATUS = "runtime-unverified"
+LOCAL_RUNTIME_PROVENANCE_STATUS = "local-runtime"
 _ROUTE_KEYS = {
     "endpoint_kind",
     "profile",
@@ -304,6 +311,47 @@ def validate_execution_route_binding(
             "non-Code-Interpreter provenance contains a Code Interpreter route"
         )
     return mode
+
+
+def azure_ai_provenance_status(routes: Any, summary: Any) -> str:
+    """Report whether an Azure AI route was shown to answer, rather than assume it.
+
+    Step 3 used to write ``runtime-verified`` as a literal, so every run said
+    its Azure routes had been verified at runtime -- including the runs where
+    no route ever answered. exp032 is the case that proves it: all five of its
+    tasks came back ``PermissionDeniedError (http 403)`` from the
+    project-scoped Code Interpreter route, and the ``result.json`` it wrote
+    still called that route runtime-verified.
+
+    ``azure_ai_routes`` cannot fix this by itself. Those records are built from
+    resolved settings in ``core/azure_ai_clients.py``, so they describe the
+    route that was *selected* and never the one that replied; a run with a
+    perfect route list and five refusals produces exactly the same array as a
+    run with five successes. Only the outcome separates them, which is why the
+    outcome is what this reads.
+
+    A completed task is the evidence, because no task completes without a
+    served response. Note the limit of that: it covers the *execution* route
+    only. The narrative route is exercised later, in Step 6, which has not run
+    when this is written, so this value says nothing about it.
+
+    Fail closed on anything unrecognised. A false ``runtime-verified`` is a
+    provenance record that lies; a false ``runtime-unverified`` is a cautious
+    label on a good run, and the two are not the same size of mistake.
+    """
+    # A run with no typed routes is not an unverified Azure run, it is a run
+    # that made no typed Azure claim at all -- which is the same thing
+    # step8_grade.py already assumes when the key is missing entirely.
+    if routes is None or routes == []:
+        return LOCAL_RUNTIME_PROVENANCE_STATUS
+    if not isinstance(routes, list) or not isinstance(summary, dict):
+        return RUNTIME_UNVERIFIED_PROVENANCE_STATUS
+    success = summary.get("success")
+    # ``isinstance(True, int)`` is True in Python, and a summary carrying
+    # ``success: true`` is a malformed summary, not one successful task.
+    if isinstance(success, bool) or not isinstance(success, int) or success <= 0:
+        return RUNTIME_UNVERIFIED_PROVENANCE_STATUS
+    return RUNTIME_VERIFIED_PROVENANCE_STATUS
 
 
 def _ordered_task_ids_sha256(task_ids: list[str]) -> str:

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -460,6 +460,7 @@
     "source_azure_ai_provenance_status": {
       "enum": [
         "runtime-verified",
+        "runtime-unverified",
         "verified-sidecar",
         "legacy-missing",
         "local-runtime",

--- a/batch-runner/step3_format_results.py
+++ b/batch-runner/step3_format_results.py
@@ -26,7 +26,10 @@ from core.cost_projection import (
     successful_deliverable_count,
     verify_cost_ledger,
 )
-from core.inference_manifest import build_inference_provenance
+from core.inference_manifest import (
+    azure_ai_provenance_status,
+    build_inference_provenance,
+)
 from core.prepared_fingerprint import validate_prepared_fingerprint
 from core.result_fingerprint import validate_inference_result_fingerprint
 from core.publication_generation import validate_publication_generation
@@ -293,7 +296,10 @@ def format_results():
         "execution_mode": inference.get("execution_mode", ""),
         "model": inference.get("model", ""),
         "azure_ai_routes": inference.get("azure_ai_routes", []),
-        "azure_ai_provenance_status": "runtime-verified",
+        "azure_ai_provenance_status": azure_ai_provenance_status(
+            inference.get("azure_ai_routes", []),
+            summary,
+        ),
         "started_at": inference.get("started_at"),
         "completed_at": inference.get("completed_at"),
         "duration": duration,

--- a/batch-runner/tests/test_azure_provenance_status_is_earned_not_asserted.py
+++ b/batch-runner/tests/test_azure_provenance_status_is_earned_not_asserted.py
@@ -1,0 +1,355 @@
+"""``runtime-verified`` must be earned by a served response, not asserted.
+
+Why this exists
+---------------
+Step 3 wrote the provenance status as a literal::
+
+    "azure_ai_provenance_status": "runtime-verified",
+
+so it was true of every run it was ever written about, including the runs where
+no Azure route answered at all.
+
+exp032 is the run that proves it. All five of its tasks came back
+``PermissionDeniedError (http 403)`` from the project-scoped Code Interpreter
+route -- GitHub runs 33464316741 and 33468138329, both `failure`, five
+``task_execution_error:PermissionDeniedError`` records apiece -- and the
+``result.json`` Step 3 wrote still said the Azure route had been verified at
+runtime. Zero calls served, and the provenance record said the opposite.
+
+``azure_ai_routes`` cannot catch this, which is the part worth spelling out.
+Those records are assembled from resolved settings in
+``core/azure_ai_clients.py`` (``"Validate routes and return endpoint-free,
+redacted provenance records"``), so they describe the route that was
+*selected*. A run with five refusals emits exactly the same array as a run with
+five successes. Only the outcome tells them apart.
+
+The literal was also wrong in the other direction. ``step2_run_inference.py``
+requires a legacy run to carry *no* Azure routes -- ``"legacy Step 2 must not
+contain Azure AI routes"`` -- so Step 3 was certifying Azure route verification
+for runs that made no Azure claim whatsoever.
+
+What this file pins is the direction of the inference: a completed task implies
+a served response, so success count is evidence and route configuration is not.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import step3_format_results as step3
+from core.inference_manifest import (
+    GOLD_PROVENANCE_STATUS,
+    LOCAL_RUNTIME_PROVENANCE_STATUS,
+    RUNTIME_UNVERIFIED_PROVENANCE_STATUS,
+    RUNTIME_VERIFIED_PROVENANCE_STATUS,
+    azure_ai_provenance_status,
+)
+from core.prepared_fingerprint import prepared_fingerprint
+from core.result_fingerprint import inference_result_fingerprint
+
+BATCH_ROOT = Path(__file__).resolve().parents[1]
+
+# Synthetic, like the price-table digest in
+# test_step3_cost_summary_does_not_shadow_task_counts.py. The real exp032
+# fingerprints are stable identifiers of two specific routes on the owner's
+# account, and no assertion here needs their actual bytes -- only that routes
+# of this *shape* are present.
+_FINGERPRINTS = ("4b" * 32, "7c" * 32)
+
+# The exp032 route pair, field for field from the ``azure_ai_routes`` its
+# result.json carries (fingerprints substituted as above). Both routes are
+# ``project-ci``; only Code Interpreter goes through the project-scoped
+# endpoint, and that is the endpoint that answered 403.
+CODE_INTERPRETER_ROUTES = [
+    {
+        "endpoint_kind": "direct-v1",
+        "profile": "project-ci",
+        "runtime_fingerprint": _FINGERPRINTS[0],
+        "workload": "inference",
+    },
+    {
+        "endpoint_kind": "project",
+        "profile": "project-ci",
+        "runtime_fingerprint": _FINGERPRINTS[1],
+        "workload": "code-interpreter",
+    },
+]
+
+
+# ── The decision itself ────────────────────────────────────────────────────
+
+
+def test_routes_plus_a_completed_task_is_runtime_verified():
+    """The one case that earns the claim: a task finished, so a call was served."""
+    status = azure_ai_provenance_status(
+        CODE_INTERPRETER_ROUTES, {"total": 5, "success": 5, "error": 0}
+    )
+    assert status == RUNTIME_VERIFIED_PROVENANCE_STATUS
+
+
+def test_the_exp032_shape_is_not_runtime_verified():
+    """Five tasks, five 403s, zero served responses -- the case that was wrong.
+
+    This is the whole point of the change, written in the numbers run
+    33468138329 actually produced.
+    """
+    status = azure_ai_provenance_status(
+        CODE_INTERPRETER_ROUTES, {"total": 5, "success": 0, "error": 5}
+    )
+    assert status == RUNTIME_UNVERIFIED_PROVENANCE_STATUS
+
+
+def test_a_partial_run_is_verified_because_something_was_served():
+    """One success is enough. This is a provenance record, not a quality score.
+
+    Deliberate: a run that served four responses and failed one has a route
+    that demonstrably answers, and saying otherwise would make the field mean
+    "did every task pass", which is what ``summary`` is already for.
+    """
+    status = azure_ai_provenance_status(
+        CODE_INTERPRETER_ROUTES, {"total": 5, "success": 1, "error": 4}
+    )
+    assert status == RUNTIME_VERIFIED_PROVENANCE_STATUS
+
+
+@pytest.mark.parametrize("routes", [None, []], ids=["absent", "empty"])
+def test_no_routes_is_local_runtime_not_a_failed_azure_run(routes):
+    """A run with no typed routes made no Azure claim to verify or refute.
+
+    ``local-runtime`` is already what ``step8_grade.py`` assumes when the key is
+    missing, so this keeps one meaning for one situation instead of two.
+    """
+    status = azure_ai_provenance_status(routes, {"total": 5, "success": 5, "error": 0})
+    assert status == LOCAL_RUNTIME_PROVENANCE_STATUS
+
+
+@pytest.mark.parametrize(
+    "summary",
+    [
+        {"total": 5, "error": 5},
+        {"total": 5, "success": None, "error": 5},
+        {"total": 5, "success": True, "error": 0},
+        {"total": 5, "success": "5", "error": 0},
+        {"total": 5, "success": 5.0, "error": 0},
+        {"total": 5, "success": -1, "error": 0},
+        None,
+        [],
+        "5 succeeded",
+    ],
+    ids=[
+        "missing",
+        "null",
+        "bool_true",
+        "string",
+        "float",
+        "negative",
+        "none",
+        "list",
+        "string_summary",
+    ],
+)
+def test_an_unreadable_success_count_fails_closed(summary):
+    """Anything that is not a positive integer count is not evidence.
+
+    ``bool_true`` is the trap worth naming: ``isinstance(True, int)`` is True in
+    Python and ``True > 0``, so a summary carrying ``success: true`` would sail
+    through a naive check as though one task had completed.
+    """
+    status = azure_ai_provenance_status(CODE_INTERPRETER_ROUTES, summary)
+    assert status == RUNTIME_UNVERIFIED_PROVENANCE_STATUS
+
+
+@pytest.mark.parametrize(
+    "routes",
+    [{"workload": "code-interpreter"}, "code-interpreter", 1],
+    ids=["dict", "string", "int"],
+)
+def test_a_malformed_route_record_fails_closed(routes):
+    """A route field of the wrong type is not an empty route list."""
+    status = azure_ai_provenance_status(routes, {"total": 1, "success": 1, "error": 0})
+    assert status == RUNTIME_UNVERIFIED_PROVENANCE_STATUS
+
+
+# ── The same decision, through the real Step 3 ─────────────────────────────
+
+
+def _write_workspace(workspace, *, routes, execution_mode, success_tasks):
+    task_ids = [f"task-{index}" for index in range(5)]
+    prepared = {
+        "experiment_id": "exp998",
+        "experiment_name": "provenance regression",
+        "publication_generation": "exp998:100:1",
+        "source": "student/exp998",
+        "task_scope": {"task_ids": task_ids},
+        "tasks": [
+            {"task_id": tid, "sector": "Finance", "occupation": "Accountants"}
+            for tid in task_ids
+        ],
+    }
+    prepared["prepared_fingerprint"] = prepared_fingerprint(prepared)
+
+    results = []
+    for index, tid in enumerate(task_ids):
+        succeeded = index < success_tasks
+        results.append(
+            {
+                "task_id": tid,
+                "status": "success" if succeeded else "error",
+                "deliverable_text": "a deliverable" if succeeded else "",
+                "deliverable_files": [],
+                "latency_ms": 1000,
+                # Verbatim from the exp032 per-task records.
+                "error": None if succeeded else "task_execution_error:PermissionDeniedError",
+            }
+        )
+
+    inference = {
+        "experiment_id": "exp998",
+        "experiment_name": "provenance regression",
+        "publication_generation": "exp998:100:1",
+        "source": "student/exp998",
+        "prepared_fingerprint": prepared["prepared_fingerprint"],
+        "ordered_task_ids": task_ids,
+        "condition": "condition_a",
+        "execution_mode": execution_mode,
+        "model": "gpt-5.4",
+        "started_at": "2026-08-30T08:00:00Z",
+        "completed_at": "2026-08-30T08:10:00Z",
+        "resume_rounds_used": 0,
+        "results": results,
+        "summary": {
+            "total": len(task_ids),
+            "success": success_tasks,
+            "error": len(task_ids) - success_tasks,
+            "qa_failed": 0,
+        },
+    }
+    if routes is not None:
+        inference["azure_ai_routes"] = routes
+    inference["result_fingerprint"] = inference_result_fingerprint(inference)
+
+    (workspace / "step1_tasks_prepared.json").write_text(
+        json.dumps(prepared), encoding="utf-8"
+    )
+    (workspace / "step2_inference_results.json").write_text(
+        json.dumps(inference), encoding="utf-8"
+    )
+
+
+def _run(tmp_path, monkeypatch, *, routes, execution_mode, success_tasks) -> dict:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root = tmp_path / "batch-runner"
+    root.mkdir()
+    _write_workspace(
+        workspace,
+        routes=routes,
+        execution_mode=execution_mode,
+        success_tasks=success_tasks,
+    )
+    monkeypatch.setattr(step3, "WORKSPACE_DIR", workspace)
+    monkeypatch.setattr(step3, "BATCH_RUNNER_ROOT", root)
+    step3.format_results()
+    return json.loads(
+        (root / "results" / "exp998" / "exp998.json").read_text(encoding="utf-8")
+    )
+
+
+def test_step3_records_a_wholly_refused_run_as_unverified(tmp_path, monkeypatch):
+    """End to end on the exp032 shape, since the literal lived in Step 3.
+
+    The route list is asserted alongside the status: the fix must keep
+    publishing which route was selected while stopping the claim that it
+    replied. Dropping the routes would also make this pass, and would be wrong.
+    """
+    payload = _run(
+        tmp_path,
+        monkeypatch,
+        routes=CODE_INTERPRETER_ROUTES,
+        execution_mode="code_interpreter",
+        success_tasks=0,
+    )
+
+    assert payload["azure_ai_provenance_status"] == RUNTIME_UNVERIFIED_PROVENANCE_STATUS
+    assert payload["azure_ai_routes"] == CODE_INTERPRETER_ROUTES
+    assert payload["summary"]["success_count"] == 0
+
+
+def test_step3_still_records_a_working_run_as_verified(tmp_path, monkeypatch):
+    """The healthy path must not regress: same routes, tasks completed."""
+    payload = _run(
+        tmp_path,
+        monkeypatch,
+        routes=CODE_INTERPRETER_ROUTES,
+        execution_mode="code_interpreter",
+        success_tasks=5,
+    )
+
+    assert payload["azure_ai_provenance_status"] == RUNTIME_VERIFIED_PROVENANCE_STATUS
+
+
+def test_step3_stops_claiming_azure_verification_for_a_routeless_run(
+    tmp_path, monkeypatch
+):
+    """A legacy run carries no routes by construction, so it certified nothing."""
+    payload = _run(
+        tmp_path,
+        monkeypatch,
+        routes=None,
+        execution_mode="sandbox",
+        success_tasks=5,
+    )
+
+    assert payload["azure_ai_provenance_status"] == LOCAL_RUNTIME_PROVENANCE_STATUS
+    assert payload["azure_ai_routes"] == []
+
+
+def test_the_literal_is_gone_from_step3():
+    """A regression lock on the shape of the defect, not just its effect.
+
+    The status is one line in a dict literal, and re-hardcoding it would be a
+    one-word edit that every behavioural test above would still pass on the
+    happy path.
+    """
+    source = (BATCH_ROOT / "step3_format_results.py").read_text(encoding="utf-8")
+    assert '"runtime-verified"' not in source
+    assert "azure_ai_provenance_status(" in source
+
+
+# ── The schema has to accept what the producer can emit ────────────────────
+
+
+def test_every_status_step3_can_emit_is_a_legal_schema_value():
+    schema = json.loads(
+        (BATCH_ROOT / "schemas" / "grade.schema.json").read_text(encoding="utf-8")
+    )
+    enum = set(schema["properties"]["source_azure_ai_provenance_status"]["enum"])
+
+    assert {
+        RUNTIME_VERIFIED_PROVENANCE_STATUS,
+        RUNTIME_UNVERIFIED_PROVENANCE_STATUS,
+        LOCAL_RUNTIME_PROVENANCE_STATUS,
+    } <= enum
+
+
+def test_the_new_value_is_additive_only():
+    """Nothing already published may stop validating because of this change.
+
+    Grades written before today carry one of these five, and the enum is the
+    gate they are checked against on re-validation.
+    """
+    schema = json.loads(
+        (BATCH_ROOT / "schemas" / "grade.schema.json").read_text(encoding="utf-8")
+    )
+    enum = set(schema["properties"]["source_azure_ai_provenance_status"]["enum"])
+
+    assert {
+        "runtime-verified",
+        "verified-sidecar",
+        "legacy-missing",
+        "local-runtime",
+        GOLD_PROVENANCE_STATUS,
+    } <= enum


### PR DESCRIPTION
## 무엇이 잘못돼 있었나 — "확인했다"를 스스로 적어 두고 있었습니다

Step 3가 결과 파일을 만들 때, Azure 경로 검증 결과를 **글자 그대로 박아** 넣고
있었습니다.

```python
"azure_ai_provenance_status": "runtime-verified",
```

`runtime-verified`는 **"실행 중에 Azure 경로가 실제로 응답한 것을 확인했다"** 는
뜻입니다. 그런데 저 줄은 **아무것도 확인하지 않습니다.** 어떤 실행이든 무조건 저
값을 씁니다.

## 이게 실제로 거짓이 된 실행이 있습니다 — exp032

exp032는 과제 5개가 **전부** `PermissionDeniedError (http 403)`으로 죽었습니다.
**응답을 한 번도 못 받았습니다.**

그 실행이 남긴 `result.json`을 직접 열어 봤습니다.

| 항목 | 값 |
|---|---|
| `success_count` | **0** |
| `error_count` | 5 |
| `azure_ai_routes` | 2개 (`inference`, `code-interpreter`) |
| `azure_ai_provenance_status` | **`runtime-verified`** ← |

**한 번도 안 통했는데 "확인됨"이라고 적혀 있습니다.**

출처: 실행 `33468138329`(conclusion `failure`, head `ef93cca0`)의 산출물
`batch-results-33468138329`. 같은 증상이 `33464316741`에도 있습니다.

## 경로 목록으로는 이걸 못 잡습니다 — 이 부분이 핵심입니다

"그럼 `azure_ai_routes`를 보면 되지 않나" 싶지만, 안 됩니다.

그 목록은 `core/azure_ai_clients.py`가 **설정을 읽어서** 만듭니다. 함수 설명이
직접 그렇게 말합니다.

> `"""Validate routes and return endpoint-free, redacted provenance records."""`

즉 **"어느 경로를 고를 것인가"** 의 기록이지, **"그 경로가 대답했는가"** 의 기록이
아닙니다. 5번 다 거부당한 실행과 5번 다 성공한 실행이 **완전히 똑같은 목록**을
남깁니다. 둘을 가르는 건 결과뿐입니다.

## 반대 방향으로도 틀렸습니다

`step2_run_inference.py`는 legacy 실행에 Azure 경로가 있으면 **거부**합니다.

```python
raise ValueError("legacy Step 2 must not contain Azure AI routes")
```

그러니까 Step 3는 **Azure 경로가 아예 하나도 없는 실행**에 대해서도
"Azure 경로 실행 검증됨"을 적고 있었습니다.

## 고친 방법 — 근거를 결과에서 가져옵니다

`core/inference_manifest.py`에 판단 함수를 하나 두고, Step 3가 그것을 부릅니다.

| 상황 | 적히는 값 | 이유 |
|---|---|---|
| 경로 있음 + 성공 과제 1개 이상 | `runtime-verified` | 과제가 끝났다는 건 응답을 받았다는 뜻 |
| 경로 있음 + 성공 **0개** | **`runtime-unverified`** | exp032가 정확히 이 모양 |
| 경로 없음 | `local-runtime` | 검증할 Azure 주장 자체가 없음 |
| 그 밖에 읽을 수 없는 값 | `runtime-unverified` | fail closed |

**성공 과제 1개면 충분합니다.** 이건 품질 점수가 아니라 출처 기록입니다. 4개
성공하고 1개 실패한 실행의 경로는 **분명히 대답한 경로**이고, 거기에 "미검증"을
적으면 이 칸이 `summary`가 이미 하는 일을 중복하게 됩니다.

### `success: true` 함정

Python에서 `isinstance(True, int)`은 **True**이고 `True > 0`도 **True**입니다.
그래서 `success: true`가 들어오면 순진한 검사는 **과제 1개 성공**으로 통과시킵니다.
테스트로 막아 뒀습니다.

## 이 값이 말하지 **않는** 것

**실행(execution) 경로 하나에 대해서만** 말합니다.

서술(narrative) 경로는 **Step 6**에서 쓰이는데, 이 값이 적히는 시점에 Step 6는
아직 돌지 않았습니다. 그러니 이 칸을 "Azure 전부 정상"으로 읽으면 안 됩니다.
함수 docstring에 그대로 적어 뒀습니다.

## 스키마는 **더하기만** 했습니다

`schemas/grade.schema.json`에 `runtime-unverified` 한 줄을 **추가**했습니다.
기존 5개 값은 **하나도 안 건드렸습니다.** 이미 발행된 채점 결과 중 값이 바뀌는
것은 **0건**입니다.

`step8_grade.py`가 이 값으로 분기하는 곳은 두 군데(`legacy-missing`,
`gold-corpus`)뿐이라, `local-runtime`으로 바뀌는 legacy 실행들도 **채점 동작이
달라지지 않습니다.**

## 채점기 지문(grader source hash)이 움직입니다 — 미리 밝힙니다

`scripts/check_grader_hash_freeze.py`가 고정(freeze) 대상으로 명시한 경로 중
두 개를 건드립니다.

- `batch-runner/core/` 아래 `.py` → `core/inference_manifest.py`
- `batch-runner/schemas/grade.schema.json`

그래서 **채점 shard가 도는 중에는 병합하면 안 됩니다.**
확인했습니다: `grade-run.yml`의 최근 실행 15건이 **전부 `completed`**,
진행 중인 실행 **0건**입니다.

(`step3_format_results.py`와 테스트 파일은 고정 대상이 아닙니다.)

## 일부러 **하지 않은** 것 두 가지

1. **step8에 새 발행 게이트를 넣지 않았습니다.** 성공 0건인 실행은 채점할 산출물
   자체가 없고, exp032는 Step 4에서 이미 멈췄습니다. 안 걸리는 자리에 게이트를
   놓으면 검사한 것처럼 보이기만 합니다.

2. **`verify_route_tokens`는 안 고쳤습니다.** 이 함수가 두 경로의 스코프를
   집합으로 합쳐서 토큰을 한 번만 받는 것을 처음에 결함으로 의심했는데,
   **아니었습니다.** 토큰은 스코프 기준이고 두 경로의 스코프가 **같습니다.**
   워크플로 단계 이름도 `"Verify Azure AI token before model calls"`,
   오류 문구도 `"Azure AI route token verification failed"` — 둘 다
   **토큰**이라고만 말하지 경로 접근 권한을 확인했다고 하지 않습니다.
   없는 결함을 고친 척하지 않았습니다.

   진짜로 없는 것은 **호출 전에 권한을 확인하는 무료 검사**이고, 그건 별건입니다.

## 검증

| 항목 | 결과 |
|---|---|
| 새 테스트 | **23 passed** |
| 실제 exp032 산출물로 재현 | 기록값 `runtime-verified` → 고친 코드는 `runtime-unverified` |
| mypy (`core/inference_manifest.py`, `step3_format_results.py`) | **Success: no issues** |
| 진행 중인 채점 실행 | **0건** (병합 안전) |

테스트에는 회귀 잠금 하나가 들어 있습니다. `"runtime-verified"` 문자열이
`step3_format_results.py`에 **다시 나타나면 실패**합니다. 한 단어짜리 되돌림은
동작 테스트만으로는 행복 경로에서 다 통과해 버리기 때문입니다.

실제 실행의 경로 지문(fingerprint)은 테스트에 **넣지 않았습니다.** 계정의 특정
경로를 가리키는 고정 식별자라서, 모양만 같은 합성값을 씁니다 — 기존
`test_step3_cost_summary_does_not_shadow_task_counts.py`가 가격표 digest에 쓰는
방식과 같습니다.

## 범위

- 실험 데이터·설정·워크플로 **무수정**.
- force-push 없음, history rewrite 없음.
- 403 자체는 **이 PR로 안 풀립니다.** 그건 저장소 밖(테넌트 역할 배정) 문제이고,
  여기서 고친 것은 **"안 통했는데 통했다고 적는"** 저장소 안쪽 결함입니다.
