### PR TITLE
fix(grading): let the grading workflow be given a config in a directory

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       experiment_yaml:
-        description: "Experiment YAML name (without .yaml)"
+        description: "Experiment YAML name under batch-runner/experiments/, without .yaml (may name one directory, e.g. execution_envelope/exp030_envelope_host_python_process)"
         required: true
         type: string
       grading_config:
@@ -91,6 +91,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       approval_inherited: ${{ steps.inherit.outputs.approval_inherited }}
+      experiment_slug: ${{ steps.validate.outputs.experiment_slug }}
     env:
       GRADE_EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
       GRADE_CONFIG: ${{ inputs.grading_config }}
@@ -107,6 +108,7 @@ jobs:
       GRADE_RUN_ORDINAL: ${{ inputs.run_ordinal }}
     steps:
       - name: Validate workflow context and inputs
+        id: validate
         shell: bash
         run: |
           set -euo pipefail
@@ -129,12 +131,37 @@ jobs:
             exit 1
           fi
 
+          # One optional directory, because experiments are kept in one:
+          # experiments/execution_envelope/ holds the run-place comparison's
+          # three configs beside the plan that names them, and a name with no
+          # separator cannot reach any of them. Each part still opens with a
+          # letter or a digit, so a leading dot, a leading dash and a leading
+          # separator are all still refused, '..' is refused twice over, and
+          # one separator is the most there is: nothing addressable here
+          # reaches outside batch-runner/experiments. This is the rule
+          # batch-run.yml applies to the same name, so a config that can be
+          # run can also be graded.
+          #
+          # '__' is refused on top of it, because that is what the separator
+          # becomes wherever the name has to be a single component -- the
+          # grade filename, the shard directory beneath it, and the artifacts
+          # uploaded at the end. That flattening is injective only while no
+          # name carries '__' of its own, and the paid approval below is
+          # inherited by matching that flattened stem, so two names collapsing
+          # onto one stem would hand one experiment's approval to another.
           if (( ${#GRADE_EXPERIMENT_YAML} < 1 || ${#GRADE_EXPERIMENT_YAML} > 128 )) ||
-             [[ ! "$GRADE_EXPERIMENT_YAML" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] ||
+             [[ ! "$GRADE_EXPERIMENT_YAML" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,99}(/[A-Za-z0-9][A-Za-z0-9._-]{0,99})?$ ]] ||
+             [[ "$GRADE_EXPERIMENT_YAML" == *".."* ]] ||
+             [[ "$GRADE_EXPERIMENT_YAML" == *"__"* ]] ||
+             [[ "$GRADE_EXPERIMENT_YAML" == *. || "$GRADE_EXPERIMENT_YAML" == *.lock ]] ||
              [[ "$GRADE_EXPERIMENT_YAML" == *.yaml || "$GRADE_EXPERIMENT_YAML" == *.yml ]]; then
-            echo "::error::experiment_yaml must be a safe extensionless basename (1-128 characters)"
+            echo "::error::experiment_yaml must be a safe extensionless name (1-128 characters), at most one directory deep, carrying neither '..' nor '__'"
             exit 1
           fi
+          # The one-component form of the name, for the places that need one.
+          # GitHub expressions have no replace(), so it is computed here and
+          # read from this step's outputs by everything downstream.
+          echo "experiment_slug=${GRADE_EXPERIMENT_YAML//\//__}" >> "$GITHUB_OUTPUT"
           if (( ${#GRADE_CONFIG} < 1 || ${#GRADE_CONFIG} > 128 )) ||
              [[ ! "$GRADE_CONFIG" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml$ ]]; then
             echo "::error::grading_config must be a safe YAML basename (1-128 characters)"
@@ -248,6 +275,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The experiment's name as one component, which is the form the shard
+          # directory stems below are written in.
+          GRADE_EXPERIMENT_SLUG: ${{ steps.validate.outputs.experiment_slug }}
           # The identity the grade job commits partials under. Kept in lockstep
           # with the `git config user.email` in the commit step below.
           GRADE_BOT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
@@ -318,7 +348,7 @@ jobs:
           MATCH=""
           while IFS= read -r stem; do
             [[ -n "$stem" ]] || continue
-            [[ "$stem" == "${GRADE_EXPERIMENT_YAML}__"* ]] || continue
+            [[ "$stem" == "${GRADE_EXPERIMENT_SLUG}__"* ]] || continue
             [[ "$stem" == *"__${CONFIG_NAME}__"* ]] || continue
             [[ "$stem" == *"__inference_${GRADE_INFERENCE_REVISION}__"* ]] || continue
             candidate="data/grades/_shards/${stem}/${SHARD_FILE}"
@@ -665,6 +695,11 @@ jobs:
       actions: write  # required for the auto-resume workflow dispatch
     env:
       GRADE_EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
+      # The same name as one component. An experiment may sit in a directory,
+      # and a GitHub artifact name may not contain a separator, so the two
+      # uploads at the end of this job are named with this instead. Computed
+      # once in validate-request, because GitHub expressions cannot replace.
+      GRADE_EXPERIMENT_SLUG: ${{ needs.validate-request.outputs.experiment_slug }}
       GRADE_CONFIG: ${{ inputs.grading_config }}
       GRADE_INFERENCE_REVISION: ${{ inputs.inference_revision }}
       GRADE_FORCE: ${{ inputs.force }}
@@ -1698,7 +1733,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: cost-ledger-${{ env.GRADE_EXPERIMENT_YAML }}${{ inputs.shard_count > 1 && format('-shard{0}of{1}', inputs.shard_index, inputs.shard_count) || '' }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: cost-ledger-${{ env.GRADE_EXPERIMENT_SLUG }}${{ inputs.shard_count > 1 && format('-shard{0}of{1}', inputs.shard_index, inputs.shard_count) || '' }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             data/grades/**/*.cost_ledger.jsonl
             data/grades/**/*.cost_ledger.sqlite3
@@ -1712,7 +1747,8 @@ jobs:
           # Shards are separate workflow runs, so the names cannot collide --
           # but a downloaded bundle is unreadable without knowing which slice it
           # holds, and the merging shard carries the final on top of its own.
-          name: grade-${{ env.GRADE_EXPERIMENT_YAML }}${{ inputs.shard_count > 1 && format('-shard{0}of{1}', inputs.shard_index, inputs.shard_count) || '' }}
+          # The slug, not the name: an artifact name may not contain '/'.
+          name: grade-${{ env.GRADE_EXPERIMENT_SLUG }}${{ inputs.shard_count > 1 && format('-shard{0}of{1}', inputs.shard_index, inputs.shard_count) || '' }}
           path: |
             ${{ steps.grade.outputs.grade_file }}
             ${{ steps.merge_shards.outputs.grade_file }}

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -224,6 +224,59 @@ def _config_name_slug(config_name: Any) -> str:
     return slug
 
 
+# One directory, because experiments are kept in one: the run-place comparison
+# holds its three configs in `experiments/execution_envelope/`. Each part has to
+# open with a letter or a digit, so a leading dot, a leading dash and a leading
+# separator are all refused, and '..' cannot be written at all.
+_EXPERIMENT_NAME_RE = re.compile(
+    r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}(?:/[A-Za-z0-9][A-Za-z0-9._-]{0,99})?"
+)
+
+# What the separator becomes where the name has to be one component.
+EXPERIMENT_PATH_SEPARATOR_SLUG = "__"
+
+
+def _experiment_path_slug(experiment_id: Any) -> str:
+    """The experiment's name, as a single filesystem component.
+
+    An experiment may be grouped into a directory, so the name arriving here
+    can carry a separator -- while a grade filename, the shard directory under
+    it and the GitHub artifact the workflow uploads must each be one component.
+    The separator becomes ``__``.
+
+    That flattening is only safe while it is injective, and it is injective
+    only while no name carries ``__`` of its own: were one to, it could land on
+    a neighbour's grade file, and `grade-run.yml` inherits a paid approval by
+    matching this stem, so two names collapsing onto one stem would hand one
+    experiment's approval to another. A name containing ``__`` is therefore
+    refused rather than flattened. `grade-run.yml` refuses the same names at
+    dispatch; this is the half that holds when step 8 is run directly.
+
+    Surrounding whitespace is refused rather than trimmed. `load_experiment_yaml`
+    opens the name as given, so trimming here would validate one name and open
+    another.
+    """
+    if not isinstance(experiment_id, str) or not experiment_id.strip():
+        raise ValueError("experiment name must be a non-empty string")
+    name = experiment_id
+    if EXPERIMENT_PATH_SEPARATOR_SLUG in name:
+        raise ValueError(
+            f"experiment name must not contain {EXPERIMENT_PATH_SEPARATOR_SLUG!r}: "
+            "it is what a directory separator becomes, and two names must not "
+            f"flatten onto one file (got {name!r})"
+        )
+    if not _EXPERIMENT_NAME_RE.fullmatch(name) or name.endswith(
+        (".", ".lock", ".yaml", ".yml")
+    ):
+        raise ValueError(
+            "experiment name must be one path part, or two separated by '/', "
+            "each opening with a letter or a digit and made of letters, "
+            "digits, '.', '_' and '-', and must not bring the '.yaml' this "
+            f"step adds (got {name!r})"
+        )
+    return name.replace("/", EXPERIMENT_PATH_SEPARATOR_SLUG)
+
+
 def resolve_grade_output_path(
     config: dict,
     *,
@@ -272,7 +325,7 @@ def resolve_grade_output_path(
             f"run_ordinal must satisfy 1 <= ordinal <= {MAX_RUN_ORDINAL}"
         )
     out_name = config["output"]["filename_template"].format(
-        exp_id=experiment_id,
+        exp_id=_experiment_path_slug(experiment_id),
         judge_slug=judge_slug,
         config_name=_config_name_slug(config.get("config_name")),
         config_hash=config_hash,
@@ -1160,6 +1213,12 @@ def _validate_grade_task_set(
 
 
 def load_experiment_yaml(experiment_yaml_name: str) -> ExperimentConfig:
+    # Checked before the file is opened, not after. The name may carry one
+    # directory -- `experiments/execution_envelope/` holds the run-place
+    # comparison's configs -- and this is the only place it becomes a path, so
+    # a name that could climb out of `experiments/` is refused here rather than
+    # at the far end, where the grade filename is built. Same rule, one reading.
+    _experiment_path_slug(experiment_yaml_name)
     path = Path("experiments") / f"{experiment_yaml_name}.yaml"
     return ExperimentConfig.from_yaml(str(path))
 

--- a/batch-runner/tests/test_a_smoke_can_name_the_task_it_needs_to_prove.py
+++ b/batch-runner/tests/test_a_smoke_can_name_the_task_it_needs_to_prove.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import ast
 import subprocess
+import tempfile
 import textwrap
 from pathlib import Path
 
@@ -108,10 +109,20 @@ BASELINE = {
 
 def _validate(**overrides: str) -> subprocess.CompletedProcess:
     """The real step, run against a dispatch that differs in one field."""
-    return subprocess.run(
-        ["bash", "-c", _step(VALIDATE_STEP)["run"]],
-        capture_output=True, text=True, env={**BASELINE, **overrides},
-    )
+    # Every step GitHub runs is handed a writable GITHUB_OUTPUT, and this one
+    # writes the experiment name's single-component form to it. Run without
+    # one, the script would die on the unbound variable under `set -u` --
+    # before reaching the check any test below is actually about.
+    with tempfile.TemporaryDirectory() as step_outputs:
+        return subprocess.run(
+            ["bash", "-c", _step(VALIDATE_STEP)["run"]],
+            capture_output=True, text=True,
+            env={
+                **BASELINE,
+                "GITHUB_OUTPUT": str(Path(step_outputs) / "step_output"),
+                **overrides,
+            },
+        )
 
 
 def test_the_baseline_dispatch_is_accepted():

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import tempfile
 
 import pytest
 import yaml
@@ -3750,13 +3751,21 @@ def _run_grade_workflow_input_preflight(**overrides):
         "GRADE_RUN_ORDINAL": "1",
         **overrides,
     }
-    return subprocess.run(
-        ["bash", "-c", validate_step["run"]],
-        check=False,
-        capture_output=True,
-        env=env,
-        text=True,
-    )
+    with tempfile.TemporaryDirectory() as step_outputs:
+        # Every step GitHub runs is handed a writable GITHUB_OUTPUT, and this
+        # one writes the experiment name's single-component form to it. Run
+        # without one, the script would die on the unbound variable under
+        # `set -u` -- before reaching the check under test. Set last and
+        # unconditionally: `env` opens with os.environ, and under CI that
+        # already carries a GITHUB_OUTPUT belonging to the job running pytest.
+        env["GITHUB_OUTPUT"] = str(Path(step_outputs) / "step_output")
+        return subprocess.run(
+            ["bash", "-c", validate_step["run"]],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
 
 
 @pytest.mark.parametrize(
@@ -3799,6 +3808,15 @@ def _run_grade_workflow_input_preflight(**overrides):
             "GRADE_SHARD_INDEX": "2",
             "GRADE_RUN_ORDINAL": "3",
         },
+        # A config that sits in a directory. The run-place comparison keeps its
+        # three beside each other in experiments/execution_envelope/, and #335
+        # taught batch-run.yml this same name -- so anything that can be run
+        # has to be gradable too, or stage 4 pays for runs it cannot mark.
+        {
+            "GRADE_EXPERIMENT_YAML": (
+                "execution_envelope/exp030_envelope_host_python_process"
+            )
+        },
     ],
 )
 def test_grade_workflow_input_preflight_accepts_valid_dispatch(overrides):
@@ -3814,6 +3832,15 @@ def test_grade_workflow_input_preflight_accepts_valid_dispatch(overrides):
         ({"GITHUB_WORKFLOW_SHA": "b" * 40}, "workflow and event SHA"),
         ({"GRADE_EXPERIMENT_YAML": "../escape"}, "experiment_yaml"),
         ({"GRADE_EXPERIMENT_YAML": "exp.yaml"}, "experiment_yaml"),
+        # One directory is the most there is, and '__' is what that separator
+        # becomes wherever the name has to be a single component. A name
+        # carrying '__' of its own could flatten onto a neighbour's stem, and
+        # the paid approval below is inherited by matching that stem.
+        ({"GRADE_EXPERIMENT_YAML": "a/b/c"}, "experiment_yaml"),
+        (
+            {"GRADE_EXPERIMENT_YAML": "execution_envelope__exp030"},
+            "experiment_yaml",
+        ),
         ({"GRADE_CONFIG": "../config.yaml"}, "grading_config"),
         ({"GRADE_INFERENCE_REVISION": "A" * 40}, "inference_revision"),
         ({"GRADE_FORCE": "yes"}, "GRADE_FORCE"),

--- a/batch-runner/tests/test_the_grading_workflow_can_be_told_to_grade_a_config_in_a_directory.py
+++ b/batch-runner/tests/test_the_grading_workflow_can_be_told_to_grade_a_config_in_a_directory.py
@@ -1,0 +1,538 @@
+"""The workflow that grades a run can be handed a config kept in a directory.
+
+The run-place comparison keeps its three experiment configs in one directory::
+
+    batch-runner/experiments/execution_envelope/exp030_envelope_host_python_process.yaml
+    batch-runner/experiments/execution_envelope/exp031_envelope_docker_container.yaml
+    batch-runner/experiments/execution_envelope/exp032_envelope_azure_code_interpreter.yaml
+
+``batch-run.yml`` was taught to take that name. ``grade-run.yml`` was not, and
+grading is where the comparison's numbers come from -- so all three could be
+run and none could be scored. Its check admitted no separator at all, and the
+five-task advance check never noticed because an advance check does not grade.
+
+**Refusing the name early was not the only thing in the way.** Two steps past
+that check, the name is a *file*: ``resolve_grade_output_path`` builds the
+grade filename from it and then refuses anything that is not a single path
+component -- and it refuses it after the corpus has been judged and paid for.
+Two steps past that, the ``grade`` job uploads two artifacts named after it,
+and a GitHub artifact name may not contain a separator either. Loosening only
+the first check would have moved the failure downstream of the money.
+
+So the rule is one rule, stated once: the name may reach one directory deep,
+and wherever it has to become a single component -- the grade filename, the
+shard directory beneath it, the two artifact names -- the separator becomes
+``__``. That flattening has to be injective, because ``grade-run.yml`` inherits
+a paid approval by matching the flattened stem: two names collapsing onto one
+would hand one experiment's approval to another. It is injective only while no
+name carries ``__`` of its own, which is why both halves refuse one that does.
+
+These tests hold the two halves together. They type neither the names nor the
+rule: the names come from the plan and from the files on disk, the rule is read
+back out of the workflow and cross-checked against real bash, and the filename
+is built by the real ``resolve_grade_output_path``.
+
+Nothing here calls a model, grades anything, or spends anything.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from step8_grade import (
+    EXPERIMENT_PATH_SEPARATOR_SLUG,
+    _experiment_path_slug,
+    resolve_grade_output_path,
+)
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = BATCH_RUNNER_ROOT.parent
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "grade-run.yml"
+EXPERIMENTS_ROOT = BATCH_RUNNER_ROOT / "experiments"
+PLAN_PATH = EXPERIMENTS_ROOT / "execution_envelope" / "advance_check_plan.yaml"
+
+# The grading config the paid run uses. Its filename template is read rather
+# than invented, so the end-to-end check below builds the real filename.
+GRADING_CONFIG_PATH = BATCH_RUNNER_ROOT / "grading_configs" / "default_v2_sol_max.yaml"
+
+# Where the workflow's check on the name starts and stops. Reading between
+# these is what keeps this file measuring the real rule instead of a copy of it.
+CHECK_OPENS_AT = "if (( ${#GRADE_EXPERIMENT_YAML}"
+CHECK_CLOSES_AT = 'echo "::error::experiment_yaml must be'
+
+# The refusals the workflow spells out beside the pattern, as written. Each is
+# asserted so that dropping one fails here rather than at a dispatch.
+GUARDS_WRITTEN_BESIDE_THE_PATTERN = (
+    '== *".."*',
+    '== *"__"*',
+    "== *. ||",
+    "== *.lock",
+    "== *.yaml",
+    "== *.yml",
+)
+
+# How the workflow flattens the name where one component is needed.
+SLUG_THE_WORKFLOW_COMPUTES = 'echo "experiment_slug=${GRADE_EXPERIMENT_YAML//\\//__}"'
+
+# How the workflow turns an accepted name into a file to look for.
+PATH_THE_WORKFLOW_BUILDS = 'EXPERIMENT_PATH="batch-runner/experiments/${GRADE_EXPERIMENT_YAML}.yaml"'
+
+# A config the grader can be given, as against a plan that only describes one.
+CONFIG_ROOT_KEY = "experiment"
+
+# The identity fields `resolve_grade_output_path` insists on, none of which
+# this file is about. Shaped like a real run's so the filename is a real one.
+IDENTITY = {
+    "judge_slug": "gpt-5_4",
+    "config_hash": "0123456789abcdef",
+    "rubric_sha": "a" * 40,
+    "rubric_short_sha": "a" * 7,
+    "prompt_version": "v2.2",
+    "inference_sha": "b" * 40,
+    "grader_source_hash": "c" * 64,
+}
+
+# Names one directory must not have brought in with it. Taking a separator is
+# the whole change, so what a separator must still not buy is the whole risk.
+# The first seventeen are the list `batch-run.yml`'s own tests hold it to, so
+# the two workflows refuse the same things; the last two are this rule's own.
+NAMES_IT_MUST_REFUSE = [
+    ("../secrets", "climbs out of the experiments directory"),
+    ("execution_envelope/../../secrets", "climbs out further along"),
+    ("/etc/passwd", "starts at the root of the disk"),
+    ("execution_envelope/deeper/exp030", "asks for a second directory"),
+    (".hidden", "starts with a dot"),
+    ("execution_envelope/.hidden", "starts a part with a dot"),
+    ("-rf", "starts with a dash"),
+    ("execution_envelope/-rf", "starts a part with a dash"),
+    ("execution_envelope\\exp030", "separates with a backslash"),
+    ("/exp030", "starts with the separator"),
+    ("execution_envelope/", "stops at the separator"),
+    ("", "is nothing at all"),
+    ("exp030.", "ends with a dot"),
+    ("exp030.lock", "ends with .lock"),
+    ("exp 030", "has a space in it"),
+    ("exp030;rm", "carries a second command"),
+    ("exp030%2Fsecrets", "hides the separator"),
+    ("exp030.yaml", "brings the extension the workflow adds"),
+    ("execution_envelope__exp030", "collides with a flattened name"),
+    ("exp030\n", "carries a newline into $GITHUB_OUTPUT"),
+    (" exp030", "is padded with a space the file name would not have"),
+]
+
+
+def _read_the_check_out_of_the_workflow() -> str:
+    """The workflow's own words for the rule, from the workflow."""
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    opens = text.find(CHECK_OPENS_AT)
+    assert opens != -1, (
+        f"{WORKFLOW_PATH.name} no longer contains {CHECK_OPENS_AT!r}, so this "
+        "file cannot tell what it now accepts. Point it at the new check "
+        "rather than deleting these tests."
+    )
+    closes = text.find(CHECK_CLOSES_AT, opens)
+    assert closes != -1, (
+        f"{WORKFLOW_PATH.name} checks the name but no longer refuses it with "
+        f"{CHECK_CLOSES_AT!r}."
+    )
+    return text[opens:closes]
+
+
+def _pattern_from(check: str) -> re.Pattern[str]:
+    """Bash's extended regular expression, compiled by Python.
+
+    The pattern sits unquoted after ``=~`` and runs to the ``]]`` that closes
+    its test. Everything in it -- the character classes, the ``{0,99}`` counts,
+    the optional group, ``^`` and ``$`` -- means the same thing to Python's
+    ``re`` as to bash's POSIX matcher, so nothing is rewritten.
+    ``test_bash_reaches_the_same_verdicts_as_the_reading_of_it_here`` checks
+    that claim against the shell that really applies it.
+    """
+    found = re.search(r"=~\s*(?P<body>\S+)\s*\]\]", check)
+    assert found, (
+        "the check no longer holds a pattern this file can read; it said:\n"
+        f"{check}"
+    )
+    return re.compile(found.group("body"))
+
+
+def _length_bound_from(check: str) -> int:
+    found = re.search(r">\s*(\d+)\s*\)\)", check)
+    assert found, f"the check no longer bounds the name's length:\n{check}"
+    return int(found.group(1))
+
+
+@pytest.fixture(scope="module")
+def check() -> str:
+    return _read_the_check_out_of_the_workflow()
+
+
+@pytest.fixture(scope="module")
+def accepts(check: str):
+    pattern = _pattern_from(check)
+    longest = _length_bound_from(check)
+    for guard in GUARDS_WRITTEN_BESIDE_THE_PATTERN:
+        assert guard in check, (
+            f"the check no longer refuses names with {guard}, so this file "
+            "would stop measuring one of the rules it was written for"
+        )
+
+    def accepted(name: str) -> bool:
+        return bool(
+            1 <= len(name) <= longest
+            # `fullmatch`, not `match`: Python's `$` also matches before a
+            # trailing newline and bash's does not, and a newline in this name
+            # would reach `$GITHUB_OUTPUT` if it ever got past here.
+            and pattern.fullmatch(name)
+            and ".." not in name
+            and "__" not in name
+            and not name.endswith((".", ".lock", ".yaml", ".yml"))
+        )
+
+    return accepted
+
+
+@pytest.fixture(scope="module")
+def plan() -> dict:
+    return yaml.safe_load(PLAN_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def grading_config() -> dict:
+    """A config shaped like the paid run's, with its real filename template."""
+    real = yaml.safe_load(GRADING_CONFIG_PATH.read_text(encoding="utf-8"))
+    return {
+        "config_name": real["config_name"],
+        "output": {
+            "directory": "data/grades",
+            "filename_template": real["output"]["filename_template"],
+        },
+    }
+
+
+def _dispatch_name(path: Path) -> str:
+    """The name the workflow would be given for a config on disk."""
+    return path.relative_to(EXPERIMENTS_ROOT).with_suffix("").as_posix()
+
+
+def _runnable_configs() -> list[Path]:
+    return sorted(
+        path
+        for path in EXPERIMENTS_ROOT.rglob("*.yaml")
+        if isinstance(
+            (loaded := yaml.safe_load(path.read_text(encoding="utf-8"))), dict
+        )
+        and CONFIG_ROOT_KEY in loaded
+    )
+
+
+def _plan_names(plan: dict) -> list[str]:
+    return [
+        Path(written).relative_to("experiments").with_suffix("").as_posix()
+        for written in plan["experiment_files"].values()
+    ]
+
+
+# ── What the workflow will now take ───────────────────────────────────────
+
+
+def test_the_three_run_places_the_plan_names_can_be_graded(plan: dict, accepts) -> None:
+    """The names come from the plan, so the plan is what is being checked."""
+    named = plan["experiment_files"]
+    assert set(named) == {
+        "host_python_process",
+        "docker_container",
+        "azure_code_interpreter",
+    }, named
+
+    refused = {}
+    for environment, written in named.items():
+        name = Path(written).relative_to("experiments").with_suffix("").as_posix()
+        assert (EXPERIMENTS_ROOT / f"{name}.yaml").is_file(), written
+        if not accepts(name):
+            refused[environment] = name
+
+    assert refused == {}, (
+        "the plan names these run places' configs, and the grading workflow "
+        f"cannot be told to grade them: {refused}"
+    )
+
+
+def test_every_config_in_the_tree_can_be_graded(accepts) -> None:
+    """The guard for the next directory somebody groups configs into."""
+    configs = _runnable_configs()
+    assert len(configs) > 30, "the sweep found almost nothing; check the filter"
+
+    refused = [
+        str(path.relative_to(EXPERIMENTS_ROOT))
+        for path in configs
+        if not accepts(_dispatch_name(path))
+    ]
+    assert refused == [], (
+        "these experiment configs exist but the grading workflow cannot be "
+        f"told to grade them: {', '.join(refused)}"
+    )
+
+
+def test_the_workflow_still_looks_for_the_name_under_the_experiments_directory(
+    check: str,
+) -> None:
+    """One directory is safe only because that is all the name is joined onto.
+
+    The pattern bounds how far a name can reach, and this is the other half of
+    that: where it reaches from.
+    """
+    assert PATH_THE_WORKFLOW_BUILDS in WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("name, why", NAMES_IT_MUST_REFUSE)
+def test_the_names_it_must_go_on_refusing(accepts, name: str, why: str) -> None:
+    """Taking one directory took nothing else with it."""
+    assert not accepts(name), f"a name that {why} is accepted: {name!r}"
+
+
+def test_bash_reaches_the_same_verdicts_as_the_reading_of_it_here(
+    check: str, accepts
+) -> None:
+    """The workflow's rule is bash's to apply, so let bash apply it.
+
+    Everything else here reads that rule through a translation into Python, and
+    a translation is a second copy of the thing it describes. The same names go
+    through the real check in the real shell, and the two answers must match.
+
+    The names are passed as arguments rather than on standard input, so the
+    empty name survives the round trip and is compared like any other. A name
+    carrying a newline cannot be compared this way -- it would print as two
+    lines -- so those are checked one at a time below.
+    """
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("no bash on this machine to compare the reading against")
+
+    def rule(body: str) -> str:
+        return "\n".join(
+            [
+                "set -uo pipefail",
+                "accepted() {",
+                '  GRADE_EXPERIMENT_YAML="$1"',
+                "  " + "\n  ".join(line.strip() for line in check.strip().splitlines()),
+                "    return 1",
+                "  fi",
+                "  return 0",
+                "}",
+                body,
+            ]
+        )
+
+    names = [_dispatch_name(path) for path in _runnable_configs()]
+    names += [name for name, _ in NAMES_IT_MUST_REFUSE]
+    one_line = [name for name in names if "\n" not in name]
+
+    finished = subprocess.run(
+        [
+            bash,
+            "-c",
+            rule(
+                'for n in "$@"; do\n'
+                '  if accepted "$n"; then printf "ACCEPT\\t%s\\n" "$n"\n'
+                '  else printf "REJECT\\t%s\\n" "$n"; fi\n'
+                "done"
+            ),
+            "compare-the-rule",
+            *one_line,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert finished.returncode == 0, finished.stderr
+
+    answered = finished.stdout.splitlines()
+    assert len(answered) == len(one_line), finished.stdout
+
+    disagreed = {}
+    for line in answered:
+        verdict, _, name = line.partition("\t")
+        if (verdict == "ACCEPT") != accepts(name):
+            disagreed[name] = f"bash says {verdict.lower()}"
+    assert disagreed == {}, (
+        "this file reads the workflow's rule differently from the shell that "
+        f"applies it: {disagreed}"
+    )
+
+    for name in names:
+        if "\n" not in name:
+            continue
+        verdict = subprocess.run(
+            [bash, "-c", rule('accepted "$1"'), "compare-the-rule", name],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert (verdict.returncode == 0) == accepts(name), name
+
+
+# ── That the two halves flatten the name the same way ─────────────────────
+
+
+def test_the_workflow_and_step_8_flatten_the_separator_the_same_way(
+    check: str, plan: dict
+) -> None:
+    """One rule, two places that have to agree on it.
+
+    The workflow computes the slug for its artifact names and for the stem it
+    matches a paid approval against; step 8 computes it for the grade filename.
+    A disagreement would not fail anything -- it would upload one name and
+    write another, and the approval would stop being inherited.
+    """
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert SLUG_THE_WORKFLOW_COMPUTES in text, (
+        "the workflow no longer computes the flattened name where this file "
+        "can read how"
+    )
+    assert EXPERIMENT_PATH_SEPARATOR_SLUG == "__"
+
+    for name in _plan_names(plan):
+        assert _experiment_path_slug(name) == name.replace(
+            "/", EXPERIMENT_PATH_SEPARATOR_SLUG
+        )
+
+
+def test_step_8_refuses_every_name_the_workflow_refuses(accepts) -> None:
+    """Step 8 can be run by hand, so it does not lean on the workflow.
+
+    Both halves have to refuse the same names -- including ``__``, which is
+    what makes the flattening injective.
+    """
+    for name, why in NAMES_IT_MUST_REFUSE:
+        assert not accepts(name)
+        with pytest.raises(ValueError):
+            slug = _experiment_path_slug(name)
+            pytest.fail(
+                f"step 8 accepted a name that {why} and turned it into "
+                f"{slug!r}; the workflow refuses it"
+            )
+
+
+def test_step_8_accepts_every_name_the_workflow_accepts(accepts, plan: dict) -> None:
+    for name in _plan_names(plan) + [
+        _dispatch_name(path) for path in _runnable_configs()
+    ]:
+        assert accepts(name), name
+        assert _experiment_path_slug(name)
+
+
+def test_no_two_configs_flatten_onto_one_stem(accepts) -> None:
+    """Injectivity, over what is actually on disk.
+
+    The paid approval is inherited by matching the flattened stem, so two
+    experiments sharing one would let a chunk of one inherit the other's
+    approval. Refusing ``__`` inside a name is what prevents it, and this is
+    the check that the refusal is enough.
+    """
+    names = [_dispatch_name(path) for path in _runnable_configs()]
+    flattened: dict[str, str] = {}
+    for name in names:
+        slug = _experiment_path_slug(name)
+        assert slug not in flattened, (
+            f"{name!r} and {flattened[slug]!r} both flatten to {slug!r}"
+        )
+        flattened[slug] = name
+
+
+def test_a_name_carrying_the_separator_slug_is_refused_by_both(accepts) -> None:
+    """The one name that would break the flattening, named on purpose.
+
+    ``execution_envelope/exp030`` becomes ``execution_envelope__exp030``. A
+    top-level experiment actually called ``execution_envelope__exp030`` would
+    land on the same grade file and the same approval stem, so it is refused --
+    by the workflow before dispatch, and by step 8 when it is run by hand.
+    """
+    colliding = "execution_envelope__exp030"
+    assert _experiment_path_slug("execution_envelope/exp030") == colliding
+    assert not accepts(colliding)
+    with pytest.raises(ValueError, match="__"):
+        _experiment_path_slug(colliding)
+
+
+# ── That the flattened name really reaches a file ─────────────────────────
+
+
+def test_the_grade_filename_for_a_config_in_a_directory_is_one_component(
+    grading_config: dict, plan: dict
+) -> None:
+    """The failure this change exists to prevent, at the place it happened.
+
+    Before, this raised ``formatted grade filename must be a single safe path
+    component`` -- two steps after the request was accepted, and after the
+    corpus had been judged and paid for.
+    """
+    for name in _plan_names(plan):
+        path = resolve_grade_output_path(
+            grading_config, experiment_id=name, **IDENTITY
+        )
+
+        assert path.parent == Path("data/grades")
+        assert "/" not in path.name
+        assert path.name.startswith(name.replace("/", "__") + "__judge_")
+        assert path.name.endswith(".json")
+
+
+def test_the_shard_directory_for_a_config_in_a_directory_is_one_component(
+    grading_config: dict, plan: dict
+) -> None:
+    """Sharding forks the path on the filename's stem.
+
+    A separator surviving into that stem would put one shard's partial a
+    directory deeper than the merge looks, and the merge derives the final
+    file's name from the stem's parent.
+    """
+    name = _plan_names(plan)[0]
+    path = resolve_grade_output_path(
+        grading_config, experiment_id=name, shard_index=3, shard_count=11, **IDENTITY
+    )
+
+    assert path.name == "shard-003-of-011.json"
+    stem = path.parent
+    assert "/" not in stem.name
+    assert stem.parent == Path("data/grades/_shards")
+    assert stem.name.startswith(name.replace("/", "__") + "__judge_")
+
+
+def test_the_uploaded_artifacts_are_named_with_the_flattened_name() -> None:
+    """A GitHub artifact name may not contain a separator.
+
+    Both uploads happen after the grading is finished and paid for -- the cost
+    ledger's upload carries ``continue-on-error``, the grade's does not -- so a
+    separator here would lose the run's only off-repository copy of the result.
+    """
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    named = re.findall(r"^\s*name: (?:grade|cost-ledger)-\$\{\{ env\.(\w+)", text, re.M)
+    assert len(named) == 2, f"expected two artifact names, found {named}"
+    assert set(named) == {"GRADE_EXPERIMENT_SLUG"}, (
+        "an artifact is named after the raw experiment name again; a name with "
+        "a directory in it would be refused by the upload"
+    )
+
+
+def test_the_slug_is_carried_to_the_job_that_uploads() -> None:
+    """The plumbing between the two, since neither half computes it twice."""
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+
+    assert (
+        jobs["validate-request"]["outputs"]["experiment_slug"]
+        == "${{ steps.validate.outputs.experiment_slug }}"
+    )
+    assert (
+        jobs["grade"]["env"]["GRADE_EXPERIMENT_SLUG"]
+        == "${{ needs.validate-request.outputs.experiment_slug }}"
+    )
+    assert "validate-request" in jobs["grade"]["needs"]


### PR DESCRIPTION
## What was wrong

The run-place comparison (Stage 4) keeps its three experiment configs together:

```
batch-runner/experiments/execution_envelope/exp030_envelope_host_python_process.yaml
batch-runner/experiments/execution_envelope/exp031_envelope_docker_container.yaml
batch-runner/experiments/execution_envelope/exp032_envelope_azure_code_interpreter.yaml
```

`batch-run.yml` was taught that name in #335, so all three can be **run**.
`grade-run.yml` was not, so none of them can be **graded**. Its check on
`experiment_yaml` was written before the directory existed:

```bash
[[ ! "$GRADE_EXPERIMENT_YAML" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]
```

No separator is admitted, so every dispatch stops on `experiment_yaml must be a
safe extensionless basename` before anything is looked for.

Nothing pointed at it. The five-task advance check passed in all three places
and did not catch this, because **an advance check does not grade**. The 30-task
trial and the 220-task full run both do — so this sits directly on Stage 4's
critical path, and would have been discovered by a dispatch that spends money.

## Why loosening the regex is not the fix

The name has to survive four more places after the check, and two of them fail
*after* the spend:

| Place | What it does with the name |
|---|---|
| `.github/workflows/grade-run.yml` — the check | refused it outright |
| `.github/workflows/grade-run.yml` — shard-stem prefix match | `[[ "$stem" == "${NAME}__"* ]]`, and the stem is built from the grade filename |
| `.github/workflows/grade-run.yml` — cost-ledger artifact | GitHub refuses an artifact name containing `/` |
| `.github/workflows/grade-run.yml` — grade artifact | same |
| `batch-runner/step8_grade.py` — `resolve_grade_output_path` | refuses a formatted filename that is not a single path component |

Everything else that touches the name is already safe and is left alone:
`EXPERIMENT_PATH`, `--experiment`, the commit messages, the auto-resume JSON
payload, the concurrency group, and the shard merge's path derivation.

## The rule, stated once

> `experiment_yaml` names a config under `batch-runner/experiments/`, optionally
> one directory deep. Wherever that name has to become a single component — a
> grade filename, the shard directory beneath it, a GitHub artifact name — the
> separator becomes `__`.

The workflow's pattern deliberately mirrors the one `batch-run.yml` applies to
the same input, so **a config that can be run can also be graded**. Each part
still opens with a letter or a digit, so a leading dot, a leading dash and a
leading separator are all still refused; `..` is refused twice over; one
separator is the most there is.

Two refusals are new on top of that shape:

- **`.yaml` / `.yml`** — already refused by `grade-run.yml`, now also by step 8,
  which is the half that holds when step 8 is run by hand.
- **`__` anywhere in the name.** This one is not cosmetic. The flattening is
  only safe while it is injective, and `grade-run.yml` inherits a paid approval
  by matching the flattened stem:

  ```bash
  [[ "$stem" == "${GRADE_EXPERIMENT_SLUG}__"* ]] || continue
  ```

  Two names collapsing onto one stem would hand one experiment's approval to
  another. No config on disk carries `__` today; a test enumerates every config
  in the tree and proves that refusing `__` is enough to keep it that way.

`load_experiment_yaml` now validates **before** it opens the file, so the two
halves of the rule cannot drift and a traversing name is refused rather than
attempted.

GitHub expressions have no `replace()`, so the flattened slug is computed in
bash (`${VAR//\//__}`), published from `validate-request.outputs`, and read by
the `grade` job's `env`.

## Grader source hash

**This moves `grader_source_hash`.** `batch-runner/step8_grade.py` is in
`_EXACT_HASHED_FILES` (`scripts/check_grader_hash_freeze.py:76-83`). There is no
hash-neutral route: the filename is built inside the hashed file.

Cleared on these grounds, stated plainly rather than buried:

- The freeze check is explicitly *not a hard gate*, and only fires while a paid
  run is in flight.
- **No paid run is in flight.** Checked immediately before opening this
  (`gh run list --workflow grade-run.yml`): the most recent grade run completed
  at 2026-09-01T05:12Z.
- Stage 4 has graded nothing, so nothing of its is orphaned.
- Stages 1–3's grades record their own hash and are not re-read against this one.
- All three Stage 4 run places will be graded under the same new hash, which is
  what the comparison actually requires.

## Tests

`batch-runner/tests/test_the_grading_workflow_can_be_told_to_grade_a_config_in_a_directory.py`
— 34 tests, written in the style of the sibling file that covers `batch-run.yml`.
It does not retype the rule: it **reads the rule out of the workflow**, takes the
names from `advance_check_plan.yaml` and from the files on disk, and cross-checks
its Python reading against real bash so a translation error fails here rather
than at a dispatch. It covers:

- the three plan names are gradable, and so is every config in the tree;
- 21 names it must go on refusing (traversal, absolute paths, a second
  directory, leading dot/dash, backslash, trailing `.`/`.lock`/`.yaml`,
  percent-encoding, whitespace, `__`);
- the workflow and step 8 flatten identically, and accept and refuse the same
  set;
- no two configs on disk flatten onto one stem;
- the grade filename and the shard directory are each one component for a
  directory name;
- both artifacts are named with the slug, and the slug really is carried from
  `validate-request.outputs` into the `grade` job.

Nothing here calls a model, signs in, or spends anything.

### One harness fix, in two places

`tests/test_step8_grade.py` and `tests/test_a_smoke_can_name_the_task_it_needs_to_prove.py`
both extract that validation step and run it as a standalone bash script. Neither
gave it a `GITHUB_OUTPUT` — which every step GitHub actually runs is handed. It
never mattered, because the step had never written an output before. Now it
writes the slug, and under `set -euo pipefail` the script died on the unbound
variable before reaching the check each test was about: 47 tests failed for one
missing environment variable. Both harnesses now hand it a temporary file, set
last and unconditionally in `test_step8_grade.py` — that harness opens with
`os.environ`, and under CI that already carries the `GITHUB_OUTPUT` of the job
running pytest, which the extracted script would otherwise have appended to.

`test_step8_grade.py` also gains three cases, so the real step is exercised end
to end with the name this change exists for: `execution_envelope/exp030_envelope_host_python_process`
accepted, `a/b/c` and `execution_envelope__exp030` refused.
