### PR TITLE
fix(readiness): grade the Azure run place on a measurement, not a setting

### DIFF
--- a/batch-runner/core/execution_envelope_preflight.py
+++ b/batch-runner/core/execution_envelope_preflight.py
@@ -1633,6 +1633,7 @@ def run_envelope_preflight(
     docker_daemon_available: bool | None = None,
     docker_image_available: bool | None = None,
     azure_route_profile: str | None = None,
+    azure_route_served: bool | None = None,
     environ: Mapping[str, str] | None = None,
     dataset_root: Path | None = None,
 ) -> EnvelopePreflight:
@@ -1816,6 +1817,7 @@ def run_envelope_preflight(
         docker_daemon_available=docker_daemon_available,
         docker_image_available=docker_image_available,
         azure_route_profile=azure_route_profile,
+        azure_route_served=azure_route_served,
         docker_run_setting=(plan.get("container") or {}).get("use_docker"),
         environ=readiness_environ,
     )

--- a/batch-runner/core/execution_environment_readiness.py
+++ b/batch-runner/core/execution_environment_readiness.py
@@ -812,6 +812,7 @@ def inspect_environment_support(
     docker_daemon_available: bool | None = None,
     docker_image_available: bool | None = None,
     azure_route_profile: str | None = None,
+    azure_route_served: bool | None = None,
     docker_run_setting: str | None = None,
 ) -> list[EnvironmentReadiness]:
     """Grade all five run places against the code in this repository.
@@ -819,6 +820,13 @@ def inspect_environment_support(
     The optional arguments describe the machine the comparison would run on.
     Passing ``None`` means "this was not measured", which produces
     :data:`STATUS_EVIDENCE_INSUFFICIENT` rather than an optimistic guess.
+
+    ``azure_route_profile`` and ``azure_route_served`` are two different
+    things and the difference is the whole point. The profile is a setting —
+    it names the route the Azure run place must use. ``azure_route_served``
+    is an observation — somebody asked that route and it answered this
+    sign-in. A run can have the first without the second, and exp032 did:
+    twice, with ten refusals.
     """
     modes = registered_execution_modes()
     results: list[EnvironmentReadiness] = []
@@ -925,6 +933,7 @@ def inspect_environment_support(
                 evidence=evidence,
                 blockers=blockers,
                 azure_route_profile=azure_route_profile,
+                azure_route_served=azure_route_served,
             )
             results.append(
                 EnvironmentReadiness(
@@ -1004,7 +1013,32 @@ def _grade_azure_code_interpreter(
     evidence: list[str],
     blockers: list[str],
     azure_route_profile: str | None,
+    azure_route_served: bool | None,
 ) -> str:
+    """Grade the Azure run place on what was measured, not on what was set.
+
+    This used to end at the route profile: if ``AZURE_AI_ROUTE_PROFILE`` said
+    ``project-ci`` the answer was "a real experiment can be started here
+    today", and nothing else was consulted. exp032 disproved that twice. Both
+    runs had the profile set to exactly that value and neither could start:
+    ten calls, ten ``PermissionDeniedError (http 403)`` from the
+    project-scoped Responses route, zero responses served. GitHub runs
+    33464316741 and 33468138329.
+
+    The setting was never evidence. It names the route this mode must use, and
+    ``step2_run_inference._require_code_interpreter_route_profile`` refuses the
+    mode without it, so a real dispatch cannot help but have it set. That made
+    the one input this grade depended on a value that is always present when
+    the grade matters, which is another way of saying the grade was decided in
+    advance.
+
+    :func:`_grade_docker_container`, in the same comparison, already does the
+    right thing: it reads the plan's setting *and* whether Docker is actually
+    running on this machine, and answers "not measured" when nobody looked.
+    Azure had no equivalent input at all, so the two run places in one
+    comparison were held to different standards. ``azure_route_served`` is that
+    missing input, and ``None`` means the same thing here as it does there.
+    """
     evidence.append(
         "step2_run_inference._require_code_interpreter_route_profile refuses "
         "this mode unless the AZURE_AI_ROUTE_PROFILE setting names the "
@@ -1039,6 +1073,24 @@ def _grade_azure_code_interpreter(
         )
         return STATUS_BLOCKED_REQUIREMENT_UNMET
     evidence.append(f"the Azure route profile is set to {required!r}")
+
+    if azure_route_served is None:
+        blockers.append(
+            "nobody checked whether the project-scoped route answers this "
+            "sign-in, so it is unknown whether this environment could start; "
+            "the route profile names the route to use and is not evidence "
+            "that the route serves anybody"
+        )
+        return STATUS_EVIDENCE_INSUFFICIENT
+    if not azure_route_served:
+        blockers.append(
+            "the project-scoped route was asked and refused this sign-in, so "
+            "starting here would spend money on calls that cannot be served"
+        )
+        return STATUS_BLOCKED_REQUIREMENT_UNMET
+    evidence.append(
+        "the project-scoped route was observed to answer this sign-in"
+    )
     return STATUS_CAN_RUN_REAL_EXPERIMENT
 
 
@@ -1360,6 +1412,7 @@ def build_readiness_report(
     docker_daemon_available: bool | None = None,
     docker_image_available: bool | None = None,
     azure_route_profile: str | None = None,
+    azure_route_served: bool | None = None,
     docker_run_setting: str | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> ReadinessReport:
@@ -1377,6 +1430,7 @@ def build_readiness_report(
         docker_daemon_available=docker_daemon_available,
         docker_image_available=docker_image_available,
         azure_route_profile=azure_route_profile,
+        azure_route_served=azure_route_served,
         docker_run_setting=docker_run_setting,
     )
     approved = paid_model_calls_approved(environ)

--- a/batch-runner/scripts/check_execution_envelope_advance_check.py
+++ b/batch-runner/scripts/check_execution_envelope_advance_check.py
@@ -69,6 +69,19 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--azure-route-served",
+        choices=("yes", "no"),
+        default=None,
+        help=(
+            "Whether somebody asked the project-scoped Azure route and it "
+            "answered this sign-in. There is no probe for this, so leaving it "
+            "out reports the Azure run place as not measured rather than as "
+            "ready. AZURE_AI_ROUTE_PROFILE is not an answer to this question: "
+            "it names the route to use, and a real dispatch is required to set "
+            "it before anything has been asked."
+        ),
+    )
+    parser.add_argument(
         "--dataset-root",
         type=Path,
         default=None,
@@ -89,6 +102,10 @@ def main() -> int:
 
     plan = load_plan(args.plan)
 
+    azure_route_served: bool | None = None
+    if args.azure_route_served is not None:
+        azure_route_served = args.azure_route_served == "yes"
+
     docker_daemon: bool | None = None
     docker_image: bool | None = None
     if not args.skip_docker_probe:
@@ -106,6 +123,7 @@ def main() -> int:
         docker_daemon_available=docker_daemon,
         docker_image_available=docker_image,
         azure_route_profile=os.getenv("AZURE_AI_ROUTE_PROFILE") or None,
+        azure_route_served=azure_route_served,
         dataset_root=args.dataset_root,
     )
 

--- a/batch-runner/scripts/check_execution_environment_readiness.py
+++ b/batch-runner/scripts/check_execution_environment_readiness.py
@@ -90,6 +90,19 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--azure-route-served",
+        choices=("yes", "no"),
+        default=None,
+        help=(
+            "Whether somebody asked the project-scoped Azure route and it "
+            "answered this sign-in. There is no probe for this, so leaving it "
+            "out reports the Azure run place as not measured rather than as "
+            "ready. AZURE_AI_ROUTE_PROFILE is not an answer to this question: "
+            "it names the route to use, and a real dispatch is required to set "
+            "it before anything has been asked."
+        ),
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         dest="as_json",
@@ -100,6 +113,10 @@ def main() -> int:
     plan: dict = {}
     if args.plan is not None:
         plan = load_plan(args.plan)
+
+    azure_route_served: bool | None = None
+    if args.azure_route_served is not None:
+        azure_route_served = args.azure_route_served == "yes"
 
     docker_daemon: bool | None = None
     docker_image: bool | None = None
@@ -126,6 +143,7 @@ def main() -> int:
         docker_daemon_available=docker_daemon,
         docker_image_available=docker_image,
         azure_route_profile=os.getenv("AZURE_AI_ROUTE_PROFILE") or None,
+        azure_route_served=azure_route_served,
         docker_run_setting=(plan.get("container") or {}).get("use_docker"),
     )
 

--- a/batch-runner/tests/test_azure_run_place_readiness_is_measured_not_configured.py
+++ b/batch-runner/tests/test_azure_run_place_readiness_is_measured_not_configured.py
@@ -1,0 +1,360 @@
+"""The free gate must not green-light the Azure run place from a setting alone.
+
+``scripts/check_execution_environment_readiness.py`` answers one question:
+"may the execution-environment comparison start, and if not, what exactly is
+missing?" Its exit code is meant to stand in front of a paid run.
+
+For the Azure run place it used to answer that question by reading
+``AZURE_AI_ROUTE_PROFILE`` and comparing it to a string. If the two matched,
+the verdict was :data:`STATUS_CAN_RUN_REAL_EXPERIMENT`, whose own docstring
+reads "A real experiment can be started here today."
+
+exp032 disproved that twice. GitHub runs 33464316741 and 33468138329 both had
+the profile set to exactly the required value, and neither could start: ten
+calls, ten ``PermissionDeniedError (http 403)`` from the project-scoped
+Responses route, zero responses served.
+
+The setting was never evidence. It names the route the mode must use, and
+``step2_run_inference._require_code_interpreter_route_profile`` refuses the
+mode without it, so a real dispatch cannot help but have it set. The one input
+the grade depended on is therefore always present in the only situation where
+the grade matters.
+
+Nothing in this file calls a model, contacts a provider, or spends money.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from core.execution_environment_readiness import (
+    ENVIRONMENT_AZURE_CODE_INTERPRETER,
+    ENVIRONMENT_DOCKER_CONTAINER,
+    STATUS_BLOCKED_REQUIREMENT_UNMET,
+    STATUS_CAN_RUN_REAL_EXPERIMENT,
+    STATUS_EVIDENCE_INSUFFICIENT,
+    build_readiness_report,
+    inspect_environment_support,
+)
+import core.execution_environment_readiness as readiness
+import core.execution_envelope_preflight as preflight
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_ROUTE = "project-ci"
+
+
+def _azure(entries) -> object:
+    for entry in entries:
+        if entry.environment == ENVIRONMENT_AZURE_CODE_INTERPRETER:
+            return entry
+    raise AssertionError("the Azure run place was not graded at all")
+
+
+# ── The defect itself ──────────────────────────────────────────────────────
+
+
+def test_the_required_route_setting_alone_is_not_a_green_light():
+    """The exact call that used to return "can start today" for exp032.
+
+    Both failing runs would have produced these arguments, because the profile
+    is the value a Code Interpreter dispatch is required to set before it may
+    run at all.
+    """
+    entry = _azure(inspect_environment_support(azure_route_profile=REQUIRED_ROUTE))
+
+    assert entry.status != STATUS_CAN_RUN_REAL_EXPERIMENT
+    assert entry.status == STATUS_EVIDENCE_INSUFFICIENT
+
+
+def test_an_unmeasured_route_says_so_in_words_the_operator_can_act_on():
+    entry = _azure(inspect_environment_support(azure_route_profile=REQUIRED_ROUTE))
+
+    assert any("nobody checked" in note for note in entry.blockers), entry.blockers
+    assert any(
+        "names the route to use" in note for note in entry.blockers
+    ), entry.blockers
+
+
+def test_a_route_that_refused_is_blocked_rather_than_merely_unmeasured():
+    """exp032's actual state, once somebody has looked.
+
+    "Not measured" and "measured, and it said no" are different answers and
+    the report must not collapse them: the first is a gap in the check, the
+    second is a finding about the account.
+    """
+    entry = _azure(
+        inspect_environment_support(
+            azure_route_profile=REQUIRED_ROUTE, azure_route_served=False
+        )
+    )
+
+    assert entry.status == STATUS_BLOCKED_REQUIREMENT_UNMET
+    assert any("refused this sign-in" in note for note in entry.blockers)
+
+
+def test_a_route_that_answered_is_the_only_way_to_a_green_light():
+    entry = _azure(
+        inspect_environment_support(
+            azure_route_profile=REQUIRED_ROUTE, azure_route_served=True
+        )
+    )
+
+    assert entry.status == STATUS_CAN_RUN_REAL_EXPERIMENT
+    assert any("was observed to answer" in note for note in entry.evidence)
+
+
+def test_an_answering_route_does_not_excuse_the_wrong_route_setting():
+    """The two inputs are read in order and neither substitutes for the other.
+
+    Observing that *some* route answers says nothing about a run configured to
+    use a different one.
+    """
+    entry = _azure(
+        inspect_environment_support(
+            azure_route_profile="direct", azure_route_served=True
+        )
+    )
+
+    assert entry.status == STATUS_BLOCKED_REQUIREMENT_UNMET
+
+
+def test_an_answering_route_does_not_excuse_a_missing_route_setting():
+    entry = _azure(inspect_environment_support(azure_route_served=True))
+
+    assert entry.status == STATUS_EVIDENCE_INSUFFICIENT
+
+
+# ── The same standard the container run place is already held to ───────────
+
+
+def test_both_run_places_answer_not_measured_when_nobody_looked():
+    """The asymmetry this change removes.
+
+    ``_grade_docker_container`` has always read whether Docker is actually
+    running on this machine and answered "not measured" when nobody looked.
+    The Azure grade had no such input at all, so two run places inside one
+    comparison were held to different standards — and the one with the lower
+    standard is the one that costs money to be wrong about.
+    """
+    entries = inspect_environment_support(
+        azure_route_profile=REQUIRED_ROUTE, docker_run_setting="always"
+    )
+    graded = {entry.environment: entry.status for entry in entries}
+
+    assert graded[ENVIRONMENT_DOCKER_CONTAINER] == STATUS_EVIDENCE_INSUFFICIENT
+    assert graded[ENVIRONMENT_AZURE_CODE_INTERPRETER] == STATUS_EVIDENCE_INSUFFICIENT
+
+
+def test_the_azure_grade_takes_a_measurement_argument_at_all():
+    """A signature-level lock, because dropping the argument would pass silently.
+
+    Deleting ``azure_route_served`` from the grade and from every caller leaves
+    a module that imports, runs, and green-lights on the setting again. The
+    behaviour tests above would catch that, but only while they exist; this
+    states the contract itself.
+    """
+    parameters = inspect.signature(
+        readiness._grade_azure_code_interpreter
+    ).parameters
+
+    assert "azure_route_served" in parameters
+    assert parameters["azure_route_served"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+# ── The whole report, and the check standing in front of the money ─────────
+
+
+def test_the_report_is_not_ready_while_the_route_is_unmeasured():
+    report = build_readiness_report(
+        conditions_by_environment=None,
+        docker_daemon_available=True,
+        docker_image_available=True,
+        docker_run_setting="always",
+        azure_route_profile=REQUIRED_ROUTE,
+        environ={readiness.PAID_RUN_APPROVAL_VARIABLE: "yes"},
+    )
+
+    assert report.ready is False
+    assert ENVIRONMENT_AZURE_CODE_INTERPRETER in report.blocked_environments
+    assert (
+        report.status_of(ENVIRONMENT_AZURE_CODE_INTERPRETER)
+        == STATUS_EVIDENCE_INSUFFICIENT
+    )
+
+
+def test_the_report_forwards_the_measurement():
+    report = build_readiness_report(
+        conditions_by_environment=None,
+        docker_daemon_available=True,
+        docker_image_available=True,
+        docker_run_setting="always",
+        azure_route_profile=REQUIRED_ROUTE,
+        azure_route_served=True,
+        environ={readiness.PAID_RUN_APPROVAL_VARIABLE: "yes"},
+    )
+
+    assert (
+        report.status_of(ENVIRONMENT_AZURE_CODE_INTERPRETER)
+        == STATUS_CAN_RUN_REAL_EXPERIMENT
+    )
+
+
+def test_the_envelope_preflight_can_pass_the_measurement_through():
+    """The paid run's own gate reaches the same grade the free tool does."""
+    parameters = inspect.signature(preflight.run_envelope_preflight).parameters
+
+    assert "azure_route_served" in parameters
+    assert parameters["azure_route_served"].default is None
+
+
+def test_the_advance_check_offers_the_same_opt_in_as_the_readiness_tool():
+    """Two commands stand in front of this comparison and both must agree.
+
+    ``check_execution_envelope_advance_check.py`` is the gate for the five-task
+    advance check — the one immediately before money is spent. Closing the
+    fail-open only in the other command would leave this one unable to report a
+    route anybody has actually seen answer, which is the opposite failure: a run
+    place that can never be cleared even after the account is fixed.
+    """
+    finished = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_execution_envelope_advance_check.py",
+            "--help",
+        ],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert finished.returncode == 0
+    assert "--azure-route-served" in finished.stdout
+    assert "AZURE_AI_ROUTE_PROFILE is not an answer" in " ".join(
+        finished.stdout.split()
+    )
+
+
+def _run_the_tool(*extra: str, route_profile: str | None = None) -> dict:
+    """Run the free tool and return the grade it gave each run place.
+
+    The paid-run approval is set because without it every run place that could
+    otherwise start is demoted to ``blocked_requirement_unmet``, which would
+    hide the difference these tests are about. Nothing here calls a model; the
+    variable is only read by the readiness grading. The approval axis is
+    covered separately by
+    ``test_no_run_place_is_ready_while_paid_calls_are_unapproved``.
+    """
+    environ = dict(os.environ)
+    environ.pop("AZURE_AI_ROUTE_PROFILE", None)
+    environ[readiness.PAID_RUN_APPROVAL_VARIABLE] = "yes"
+    if route_profile is not None:
+        environ["AZURE_AI_ROUTE_PROFILE"] = route_profile
+    finished = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_execution_environment_readiness.py",
+            "--skip-docker-probe",
+            "--json",
+            *extra,
+        ],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=environ,
+    )
+    assert finished.stdout, finished.stderr
+    payload = json.loads(finished.stdout)
+    return {
+        entry["environment"]: entry["status"] for entry in payload["environments"]
+    }
+
+
+def test_the_tool_does_not_green_light_the_route_from_the_environment_variable():
+    """End to end, through the command an operator actually runs.
+
+    This is the shape of the original finding: setting one environment
+    variable to one string was enough to move the Azure run place to "a real
+    experiment can be started here today", with the paid-run approval already
+    in hand — which is exactly the state a dispatch is in.
+    """
+    graded = _run_the_tool(route_profile=REQUIRED_ROUTE)
+
+    assert graded[ENVIRONMENT_AZURE_CODE_INTERPRETER] == STATUS_EVIDENCE_INSUFFICIENT
+
+
+def test_the_tool_reports_a_refused_route_as_blocked():
+    graded = _run_the_tool("--azure-route-served", "no", route_profile=REQUIRED_ROUTE)
+
+    assert (
+        graded[ENVIRONMENT_AZURE_CODE_INTERPRETER] == STATUS_BLOCKED_REQUIREMENT_UNMET
+    )
+
+
+def test_the_tool_accepts_an_observed_route():
+    graded = _run_the_tool("--azure-route-served", "yes", route_profile=REQUIRED_ROUTE)
+
+    assert (
+        graded[ENVIRONMENT_AZURE_CODE_INTERPRETER] == STATUS_CAN_RUN_REAL_EXPERIMENT
+    )
+
+
+def test_the_tool_leaves_the_measurement_out_by_default():
+    """No probe exists, so silence must mean silence.
+
+    The container run place is measured by default and opts *out* with
+    ``--skip-docker-probe``. There is no equivalent probe for an Azure
+    authorization decision, so this one opts *in*, and the default has to be
+    the honest answer rather than the convenient one.
+    """
+    graded = _run_the_tool()
+
+    assert graded[ENVIRONMENT_AZURE_CODE_INTERPRETER] == STATUS_EVIDENCE_INSUFFICIENT
+
+
+def test_the_flag_tells_the_operator_that_the_route_profile_is_not_an_answer():
+    finished = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_execution_environment_readiness.py",
+            "--help",
+        ],
+        cwd=BATCH_RUNNER_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert finished.returncode == 0
+    assert "--azure-route-served" in finished.stdout
+    assert "AZURE_AI_ROUTE_PROFILE is not an answer" in " ".join(
+        finished.stdout.split()
+    )
+
+
+# ── What this change does not claim ────────────────────────────────────────
+
+
+def test_the_measurement_is_operator_supplied_and_the_code_says_so():
+    """An honest limit, stated where it cannot drift out of the PR text.
+
+    This change does not prove the project-scoped route works. No live
+    authorization probe ships here, because one cannot be exercised from the
+    machine this suite runs on — a different tenant — and an untested network
+    probe standing in front of a paid run would be worse than none.
+
+    What it does is stop the check from claiming the route works on its own
+    evidence. The default moved from optimistic to unmeasured, so the green
+    light can no longer be obtained by accident from a variable that a real
+    dispatch is required to set anyway.
+    """
+    doc = inspect.getdoc(readiness.inspect_environment_support) or ""
+
+    assert "azure_route_served" in doc
+    assert "observation" in doc

--- a/batch-runner/tests/test_execution_envelope_advance_check.py
+++ b/batch-runner/tests/test_execution_envelope_advance_check.py
@@ -153,6 +153,7 @@ def _ready_preflight(plan, **overrides):
         "docker_daemon_available": True,
         "docker_image_available": True,
         "azure_route_profile": "project-ci",
+        "azure_route_served": True,
         "environ": FULLY_READY_ENVIRON,
     }
     settings.update(overrides)

--- a/batch-runner/tests/test_execution_environment_readiness.py
+++ b/batch-runner/tests/test_execution_environment_readiness.py
@@ -88,6 +88,7 @@ def _ready_container_arguments() -> dict:
         "docker_image_available": True,
         "docker_run_setting": "always",
         "azure_route_profile": "project-ci",
+        "azure_route_served": True,
     }
 
 
@@ -337,7 +338,9 @@ def test_azure_code_interpreter_is_blocked_without_the_required_route():
 
 
 def test_azure_code_interpreter_is_ready_with_the_required_route():
-    entries = inspect_environment_support(azure_route_profile="project-ci")
+    entries = inspect_environment_support(
+        azure_route_profile="project-ci", azure_route_served=True
+    )
     entry = _entry(entries, ENVIRONMENT_AZURE_CODE_INTERPRETER)
     assert entry.status == STATUS_CAN_RUN_REAL_EXPERIMENT
 
@@ -346,7 +349,8 @@ def test_the_required_azure_route_name_comes_from_the_shipped_code():
     from core.azure_ai_clients import RouteProfile
 
     entries = inspect_environment_support(
-        azure_route_profile=RouteProfile.PROJECT_CI.value
+        azure_route_profile=RouteProfile.PROJECT_CI.value,
+        azure_route_served=True,
     )
     entry = _entry(entries, ENVIRONMENT_AZURE_CODE_INTERPRETER)
     assert entry.status == STATUS_CAN_RUN_REAL_EXPERIMENT


### PR DESCRIPTION
## 한 줄 요약

Azure 실행 환경(run place)의 무료 준비 점검이 **설정값 하나**를 보고 "오늘 실제 실험을 시작할 수 있다"고 답하던 것을, **실제로 확인한 결과**를 보고 답하도록 바꿉니다.

---

## ⚠️ 먼저 밝힙니다 — grader source hash가 움직입니다

이 PR은 `batch-runner/core/` 아래 파일 **2개**를 수정합니다.

| 파일 | 동결 대상 여부 |
|---|---|
| `batch-runner/core/execution_environment_readiness.py` | ✅ `_HASHED_TREES`의 `batch-runner/core/` + `.py` |
| `batch-runner/core/execution_envelope_preflight.py` | ✅ 동일 |

`batch-runner/scripts/check_grader_hash_freeze.py`의 동결 집합에 걸리므로 **채점 소스 해시가 바뀝니다.** `.github/workflows/grader-hash-freeze.yml`도 이 경로에서 발동합니다.

**병합 안전성 확인:** `gh run list --workflow=grade-run.yml --limit 12` → **12건 전부 `completed`, 진행 중 0건.** 샤드가 날아다니는 중에 병합하면 돈을 다 쓴 뒤에야 실패하므로, 0건임을 확인하고 진행합니다.

이 PR은 채점 로직(`step8_grade.py`, 루브릭, 프롬프트, 채점 설정)을 **한 글자도 건드리지 않습니다.** 두 파일 모두 실행 환경 비교의 준비 점검 전용입니다.

---

## 무엇이 잘못돼 있었나

`core/execution_environment_readiness.py`의 `_grade_azure_code_interpreter`는 Azure 실행 환경을 이렇게 채점했습니다.

> 환경변수 `AZURE_AI_ROUTE_PROFILE`이 필요한 문자열과 같은가? → 같으면 `can_run_real_experiment`

`STATUS_CAN_RUN_REAL_EXPERIMENT`의 docstring은 그대로 이렇습니다: **"A real experiment can be started here today."**

문제는 그 설정값이 **실제 실행이 반드시 켜야 하는 값**이라는 점입니다. `step2_run_inference._require_code_interpreter_route_profile`은 이 값이 없으면 Code Interpreter 모드 자체를 거부합니다. 즉 **채점이 의존하는 유일한 입력이, 채점이 의미를 갖는 유일한 상황에서는 항상 켜져 있습니다.**

### exp032가 이미 두 번 반증했습니다

| 실행 ID | head SHA | 결과 | Step 2 |
|---|---|---|---|
| `33464316741` | `b3ec29f2…` | failure | `✗ Code Interpreter provider error (PermissionDeniedError)` ×5 |
| `33468138329` | `ef93cca0…` | failure | `PermissionDeniedError, http 403` ×5 |

두 실행 모두 route profile이 정확히 필요한 값으로 켜져 있었고, **10번 호출 중 10번 403, 응답 0건**이었습니다.

### 병합 대상(`21b4230`)에서 직접 재현했습니다

같은 명령, 같은 plan, Docker probe 포함. **차이는 이 PR뿐입니다.**

```
EXECUTION_COMPARISON_PAID_RUN_APPROVED=yes AZURE_AI_ROUTE_PROFILE=project-ci \
  python scripts/check_execution_environment_readiness.py \
  --plan experiments/execution_envelope/advance_check_plan.yaml
```

| 트리 | azure_code_interpreter | exit |
|---|---|---|
| **origin/main `21b4230`** | `can_run_real_experiment` | **0** — *"Every run place being compared can start, and no problem was found."* |
| **이 PR** | `evidence_insufficient` | **1** |

환경변수 하나를 문자열 하나로 맞춘 것만으로 **판정이 뒤집혀 있었습니다.** 그것도 유료 실행 승인이 이미 손에 있는 상태에서 — 즉 실제 dispatch가 놓여 있는 바로 그 상태에서.


---

## 왜 "범위 밖"이 아니라 결함인가 (근거 6개)

1. 모듈 docstring이 스스로 답한다고 하는 질문: *"may the execution-environment comparison start, and if not, what exactly is missing?"*
2. `STATUS_CAN_RUN_REAL_EXPERIMENT` = *"A real experiment can be started here today."* — 설정값이 답할 수 있는 질문이 아닙니다.
3. `inspect_environment_support`의 docstring은 **이미** 이렇게 적혀 있었습니다: *"Passing `None` means "this was not measured", which produces `STATUS_EVIDENCE_INSUFFICIENT` rather than an optimistic guess."* — Azure에만 적용되지 않았습니다.
4. **같은 비교 안에서의 비대칭:** `_grade_docker_container`는 이 기계의 Docker를 실제로 재서(`docker_daemon_available` / `docker_image_available`) 안 쟀으면 `evidence_insufficient`를 돌려줍니다. `measure_docker_availability()`가 `:1448`에 있습니다. **Azure에는 대응물이 저장소 어디에도 없었습니다.**
5. **CLI 비대칭:** Docker는 `docker_daemon, docker_image = measure_docker_availability()`(측정), Azure는 `os.getenv("AZURE_AI_ROUTE_PROFILE")`(설정). Docker에는 `--skip-docker-probe`가 있고 그 help는 *"The container run place is then reported as not measured rather than as ready."*라고 말합니다.
6. **다른 무엇도 잡지 못합니다.** 이 CLI는 `.github/workflows/` 안에 **0번** 등장하는 운영자용 게이트이고, CLI docstring 스스로 그 exit code를 *"safe to wire into an automated check"*라고 부릅니다. `verify_route_tokens`는 **토큰**(scope 기반, 두 경로가 동일)을 검사하지 route 접근 권한을 검사하지 않습니다.

돈이 걸린 쪽이 기준이 더 낮았습니다.

---

## 무엇을 바꿨나

`azure_route_served: bool | None`을 추가하고, 두 무료 CLI → `build_readiness_report` → `inspect_environment_support` → `run_envelope_preflight` → 채점 함수까지 그대로 흘려보냅니다.

| 값 | 뜻 | 판정 |
|---|---|---|
| `None` (기본값) | 아무도 확인하지 않음 | `evidence_insufficient` |
| `False` | 물어봤고, 이 로그인을 거부함 | `blocked_requirement_unmet` |
| `True` | 응답하는 것을 관측함 | `can_run_real_experiment` |

route profile과 이 값은 **다른 것**이고 그 차이가 이 PR의 전부입니다. profile은 *"이 경로를 써라"*라는 **지시**이고, `azure_route_served`는 *"누가 그 경로에 물어봤더니 응답하더라"*라는 **관측**입니다. 앞의 것만 있고 뒤의 것이 없는 실행이 가능하며, exp032가 정확히 그랬습니다 — 두 번, 거절 10번과 함께.

### 바뀐 뒤 실제 출력

같은 명령에 플래그만 더한 것입니다.

```
=== 플래그 없음 (기본값) ===
[evidence_insufficient] azure_code_interpreter
    evidence:   the Azure route profile is set to 'project-ci'
    blocked by: nobody checked whether the project-scoped route answers this sign-in,
                so it is unknown whether this environment could start; the route profile
                names the route to use and is not evidence that the route serves anybody
exit 1

=== --azure-route-served yes ===
[can_run_real_experiment] azure_code_interpreter
    evidence:   the Azure route profile is set to 'project-ci'
    evidence:   the project-scoped route was observed to answer this sign-in
exit 0   ("Every run place being compared can start, and no problem was found.")

=== --azure-route-served no ===
[blocked_requirement_unmet] azure_code_interpreter
    evidence:   the Azure route profile is set to 'project-ci'
    blocked by: the project-scoped route was asked and refused this sign-in, so starting
                here would spend money on calls that cannot be served
exit 1
```

세 번째가 exp032의 실제 상태입니다. "안 재봤다"와 "재봤더니 거절당했다"는 **다른 답**이고, 앞은 점검의 구멍이고 뒤는 계정에 대한 발견입니다. 리포트가 둘을 뭉개면 안 됩니다.

fail-open이 닫혔고, **영구 차단도 아닙니다.** 권한이 풀린 뒤 실제로 응답을 본 운영자는 여전히 exit 0에 도달할 수 있습니다.


### CLI 두 개 모두에 붙였습니다

| CLI | 역할 |
|---|---|
| `scripts/check_execution_environment_readiness.py` | 실행 환경 전체 준비 점검 |
| `scripts/check_execution_envelope_advance_check.py` | 5개 작업 사전 점검 — **돈 쓰기 직전의 게이트** |

한쪽만 고치면 뒤쪽 게이트는 계좌가 고쳐진 뒤에도 Azure를 통과시킬 방법이 없어집니다. 그건 반대 방향의 실패(영구 차단)이므로 둘 다 같은 opt-in 플래그를 갖습니다.

---

## 정직하게, 이 PR이 하지 않는 것

**이 변경은 project-scoped route가 동작한다는 것을 증명하지 않습니다.** 실시간 권한 probe를 넣지 않았습니다. 이 테스트 스위트가 도는 기계는 워크플로와 **다른 테넌트**라서 probe를 실제로 실행해 볼 수가 없고, **검증되지 않은 네트워크 probe를 유료 실행 앞에 세우는 것은 아무것도 없는 것보다 나쁩니다.**

측정값은 **운영자가 넣는 값**입니다. 그럼에도 실질적으로 나아진 점 세 가지:

1. 기본값이 낙관에서 **미측정**으로 바뀌었습니다. 이제 초록불은 *실제 dispatch가 어차피 켜야 하는 변수*로부터 **우연히** 얻어질 수 없습니다.
2. "이 경로를 써라"와 "그 경로가 응답했다"를 분리했습니다. 둘을 섞은 것이 결함 그 자체였습니다.
3. Docker가 이미 지키던 계약과 같아졌습니다.

이 한계는 PR 본문이 아니라 **테스트 안에** 적어 두었습니다 (`test_the_measurement_is_operator_supplied_and_the_code_says_so`). 본문은 시간이 지나면 잊히지만 테스트는 남습니다.

**후속으로 기록만 하고 구현하지 않은 것:** `azure_route_served`를 운영자 대신 자동으로 채우는 **무료 권한 probe**. 테넌트 안에서 실행 가능해질 때 별도 PR로.

---

## 검증

| 항목 | 결과 |
|---|---|
| 기준 커밋 | `21b4230` (PR #346) 위에 rebase — 충돌 0건, #346과 겹치는 파일 0개 |
| 신규 테스트 파일 | **18 passed** |
| advance-check CLI를 만지는 2개 파일 | **149 passed** |
| readiness API를 쓰는 18개 테스트 파일 | **1136 passed** |
| 전체 pytest | **6804 passed, 7 skipped, 45 deselected — 실패 0건** (952.98s, exit 0) |
| 수집 테스트 수 (`--collect-only`, 같은 명령·같은 기계) | main `6786` → 이 PR `6804` = **정확히 +18**, 신규 파일 개수 그대로. 숨은 증감 없음 |
| mypy (변경 3개 모듈) | **변경 파일 오류 0건** |
| 진행 중인 채점 실행 | **0건** |
| Azure 식별자 스윕 (staged diff) | **0건** — 유일한 매치는 영어 단어 "tenant"와 diff hunk 헤더 `@@ -0,0 +1,360 @@` |
| needle scan | 1065개 파일, **변경 7개 파일에 0건** |
| 커밋 trailer | AI 귀속 trailer 없음 |


**mypy 참고:** import following 때문에 `Found 46 errors in 12 files`가 뜨지만, 변경한 3개 모듈로 필터링하면 **0건**입니다. 46건 전부 `core/tool_calling_judge.py`, `core/subprocess_runner.py`, `core/sandbox_runner.py` 등 **이 PR이 건드리지 않은 파일의 기존 오류**입니다.

---

## 새 테스트 (18개)

- **결함 그 자체** — 예전에 "오늘 시작 가능"을 돌려주던 정확한 호출, blocker 문구, `False`→차단, `True`→초록불, 그리고 순서 테스트 2개(응답하는 경로가 잘못된 profile도, 없는 profile도 면제해 주지 않음)
- **컨테이너와 같은 기준** — 아무도 안 봤을 때 Docker와 Azure 둘 다 `evidence_insufficient`인지
- **시그니처 잠금** — `azure_route_served`가 KEYWORD_ONLY로 존재하는지. 인자를 지워도 모듈은 멀쩡히 돌아가며 다시 설정값으로 초록불을 켜기 때문입니다.
- **리포트 + CLI 2종** — end-to-end 4건, `--help`가 *"AZURE_AI_ROUTE_PROFILE is not an answer"*를 운영자에게 실제로 보여주는지 2건
- **주장하지 않는 것** — 위의 한계를 코드 안에 고정

테스트 헬퍼는 숨은 결합도 문서화했습니다: `build_readiness_report`는 유료 승인이 없으면 **모든** `can_run_real_experiment`를 `blocked_requirement_unmet`로 강등시킵니다(`evidence_insufficient`는 강등되지 않음). 승인 변수를 안 켜면 route 축이 아니라 승인 축을 읽게 됩니다.

---

## 관련

- P3(exp032 403) 진행 상황: Project #5 이어쓰기 카드 §3
- 이 PR은 403을 **고치지 않습니다.** 403은 저장소 밖(소유자 테넌트의 RBAC)에 있습니다. 이 PR은 그 403을 앞에서 못 보고 통과시키던 점검을 고칩니다.
- direct-v1 / host subprocess / 다른 Arm으로의 fallback **없음** — 비교 계약대로 fail closed 유지.
