### PR TITLE
fix(grading): read the experiment's identity from the config, not its path

### DIFF
--- a/batch-runner/scripts/download_inference_from_hf.py
+++ b/batch-runner/scripts/download_inference_from_hf.py
@@ -284,11 +284,43 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _load_experiment_data_block(experiment: str) -> dict:
+def _load_experiment_yaml(experiment: str) -> dict:
     exp_path = Path("experiments") / f"{experiment}.yaml"
     data = yaml.safe_load(exp_path.read_text(encoding="utf-8"))
-    block = (data or {}).get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def _load_experiment_data_block(experiment: str) -> dict:
+    block = _load_experiment_yaml(experiment).get("data")
     return block if isinstance(block, dict) else {}
+
+
+def resolve_experiment_id(experiment: str) -> str:
+    """The identity to compare against, read from the config, not its path.
+
+    ``--experiment`` says which file to open. ``experiment.id`` inside that
+    file says which experiment it is. Those are two different facts, and every
+    config written before now made them look like one: they all sat directly
+    in ``experiments/`` and were named after their own id.
+
+    A config in a directory separates them.
+    ``execution_envelope/exp030_envelope_host_python_process`` opens a file
+    whose declared id is ``exp030_envelope_host_python_process``, and it is the
+    declared id that step 3 wrote into ``inference_provenance.json`` and
+    uploaded. Comparing the path against that sidecar refuses the experiment's
+    own inference.
+
+    Fail-closed. An absent or empty id is an error rather than a fall back to
+    the path, because the fall back is precisely the comparison this exists to
+    stop, and it would only be found after the download.
+    """
+    block = _load_experiment_yaml(experiment).get("experiment")
+    declared = block.get("id") if isinstance(block, dict) else None
+    if not isinstance(declared, str) or not declared:
+        raise ValueError("experiment.id is missing in experiment yaml")
+    # Compared literally, never stripped: step 3 records whatever the config
+    # declares, so normalising one side here would invent a disagreement.
+    return declared
 
 
 def resolve_repo_id(experiment: str) -> str:
@@ -367,7 +399,7 @@ def _load_repository_grading_config(path_value: str) -> dict:
 def resolve_legacy_missing_provenance_allowance(
     config: dict,
     *,
-    experiment: str,
+    experiment_id: str,
     requested_revision: str,
     resolved_revision: str,
 ) -> bool:
@@ -396,7 +428,7 @@ def resolve_legacy_missing_provenance_allowance(
         raise ValueError(
             "legacy missing provenance allowance requires pinned task_ids"
         )
-    if identity.get("experiment_id") != experiment:
+    if identity.get("experiment_id") != experiment_id:
         raise ValueError(
             "legacy missing provenance allowance experiment mismatch"
         )
@@ -436,7 +468,9 @@ def _coerce_list(value: object) -> list[str]:
     return [str(value)] if value else []
 
 
-def _build_inference_from_parquet(parquet_path: str, experiment: str, repo_id: str) -> dict:
+def _build_inference_from_parquet(
+    parquet_path: str, experiment_id: str, repo_id: str
+) -> dict:
     df = pd.read_parquet(parquet_path)
     results = []
     for row in df.to_dict("records"):
@@ -455,7 +489,7 @@ def _build_inference_from_parquet(parquet_path: str, experiment: str, repo_id: s
         )
 
     return {
-        "experiment_id": experiment,
+        "experiment_id": experiment_id,
         "source": repo_id,
         "model": "",
         "completed_at": None,
@@ -521,7 +555,9 @@ def gold_rows_from_parquet(parquet_path: str) -> list[dict]:
     return rows
 
 
-def _build_gold_inference(parquet_path: str, experiment: str, repo_id: str) -> dict:
+def _build_gold_inference(
+    parquet_path: str, experiment_id: str, repo_id: str
+) -> dict:
     results = []
     for row in gold_rows_from_parquet(parquet_path):
         result = {
@@ -536,7 +572,7 @@ def _build_gold_inference(parquet_path: str, experiment: str, repo_id: str) -> d
         results.append(result)
 
     return {
-        "experiment_id": experiment,
+        "experiment_id": experiment_id,
         "source": repo_id,
         # Named rather than blank so a grade payload records what produced the
         # graded bytes. Nothing did: these are the benchmark's own answers.
@@ -553,7 +589,7 @@ def _build_gold_inference(parquet_path: str, experiment: str, repo_id: str) -> d
 
 
 def _download_gold_inference(
-    experiment: str, repo_id: str, revision: str, out: Path
+    experiment_id: str, repo_id: str, revision: str, out: Path
 ) -> None:
     parquet_file = _with_hub_retry(
         "gold corpus parquet",
@@ -565,7 +601,7 @@ def _download_gold_inference(
             token=_hf_token(),
         ),
     )
-    payload = _build_gold_inference(parquet_file, experiment, repo_id)
+    payload = _build_gold_inference(parquet_file, experiment_id, repo_id)
     _atomic_write_json(out, _canonicalize_inference_payload(payload, repo_id, revision))
 
 
@@ -580,7 +616,7 @@ def _canonicalize_inference_payload(payload: object, repo_id: str, revision: str
 def _attach_inference_provenance(
     payload: dict,
     *,
-    experiment: str,
+    experiment_id: str,
     repo_id: str,
     revision: str,
     allow_legacy_missing_provenance: bool = False,
@@ -611,7 +647,7 @@ def _attach_inference_provenance(
     provenance = json.loads(Path(provenance_file).read_text(encoding="utf-8"))
     verified = validate_inference_provenance(
         provenance,
-        experiment_id=experiment,
+        experiment_id=experiment_id,
         source_repo_id=repo_id,
         task_ids=task_ids,
         prepared_fingerprint=payload.get("prepared_fingerprint"),
@@ -666,7 +702,7 @@ def _atomic_write_json(path: Path, payload: dict) -> None:
 
 
 def _download_or_reconstruct_inference(
-    experiment: str,
+    experiment_id: str,
     repo_id: str,
     revision: str,
     out: Path,
@@ -697,12 +733,14 @@ def _download_or_reconstruct_inference(
                 token=token,
             ),
         )
-        payload = _build_inference_from_parquet(parquet_file, experiment, repo_id)
+        payload = _build_inference_from_parquet(
+            parquet_file, experiment_id, repo_id
+        )
 
     canonical = _canonicalize_inference_payload(payload, repo_id, revision)
     canonical = _attach_inference_provenance(
         canonical,
-        experiment=experiment,
+        experiment_id=experiment_id,
         repo_id=repo_id,
         revision=revision,
         allow_legacy_missing_provenance=allow_legacy_missing_provenance,
@@ -902,6 +940,10 @@ def _select_gold_materialization(payload: dict, task_ids: list[str] | None) -> l
 def main() -> int:
     args = parse_args()
     repo_id = resolve_repo_id(args.experiment)
+    # `--experiment` is a path to a config; this is the experiment that config
+    # says it is. Every identity comparison below uses the second, because the
+    # second is what the inference run recorded.
+    experiment_id = resolve_experiment_id(args.experiment)
     inference_source = resolve_inference_source(args.experiment)
     _stagger_shard_start()
     revision = resolve_immutable_revision(repo_id, args.revision)
@@ -913,7 +955,7 @@ def main() -> int:
         grading_config = _load_repository_grading_config(args.grading_config)
         config_allowance = resolve_legacy_missing_provenance_allowance(
             grading_config,
-            experiment=args.experiment,
+            experiment_id=experiment_id,
             requested_revision=args.revision,
             resolved_revision=revision,
         )
@@ -938,7 +980,7 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
-        _download_gold_inference(args.experiment, repo_id, revision, out)
+        _download_gold_inference(experiment_id, repo_id, revision, out)
         payload = _canonicalize_inference_payload(
             json.loads(out.read_text(encoding="utf-8")), repo_id, revision
         )
@@ -954,7 +996,7 @@ def main() -> int:
         return 0
 
     _download_or_reconstruct_inference(
-        args.experiment,
+        experiment_id,
         repo_id,
         revision,
         out,

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -1985,7 +1985,13 @@ def main() -> int:
     try:
         _validate_pinned_rerun_identity(
             config,
-            experiment_id=args.experiment_yaml_name,
+            # The config it opened, not the path that opened it. The same
+            # `rerun_identity.experiment_id` is checked a second time by
+            # scripts/download_inference_from_hf.py against what the inference
+            # run recorded, and that recording is the declared id -- so a
+            # grading config would otherwise have to pin two different spellings
+            # to satisfy both halves of one run.
+            experiment_id=exp_config.experiment_id,
             task_ids=[task["task_id"] for task in tasks],
             rubric_commit_sha=rubric_sha,
             inference_revision=inference_revision,

--- a/batch-runner/tests/test_a_configs_folder_is_not_its_name.py
+++ b/batch-runner/tests/test_a_configs_folder_is_not_its_name.py
@@ -1,0 +1,369 @@
+"""``--experiment`` says which file to open. The file says which experiment it is.
+
+Those are two facts, and until now they looked like one. Every experiment
+config sat directly in ``experiments/`` and was named after the id it
+declared, so the path used to open a config and the identity recorded inside
+it were the same string, and code could use either one interchangeably without
+anyone noticing which it had picked.
+
+Putting a config in a directory separates them for the first time.
+``execution_envelope/exp030_envelope_host_python_process`` opens a file whose
+declared id is ``exp030_envelope_host_python_process`` — no folder. Step 3
+writes that declared id into ``inference_provenance.json`` and uploads it
+beside the results, so a downloader comparing the *path* against that sidecar
+refuses the experiment its own inference. Dry run 33482175890 stopped there:
+
+    ValueError: inference provenance experiment identity mismatch
+
+The fix is a rule rather than a normalisation, and this file is where the rule
+is written down: the path selects the file, the file states the identity, and
+every comparison against something a run recorded uses the second.
+
+``exp002_single_baseline.yaml`` is why the obvious shortcut is wrong. It
+declares ``exp002``, so "take the last path component" is not a restatement of
+the existing convention — it is a change that would misidentify a config that
+has been on main since the beginning.
+
+Nothing here calls a model or the network. The end-to-end tests build the
+sidecar with the same function step 3 builds it with, so they prove a
+round trip rather than a hand-written approximation of one.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from core.inference_manifest import build_inference_provenance
+
+BATCH_RUNNER = Path(__file__).resolve().parents[1]
+EXPERIMENTS = BATCH_RUNNER / "experiments"
+
+FULL_SHA = "a" * 40
+
+# The dispatch that hit the wall, and the identity the file it opens declares.
+DIRECTORY_CONFIG = "execution_envelope/exp030_envelope_host_python_process"
+DECLARED_ID = "exp030_envelope_host_python_process"
+
+# The config that makes "declared id == filename" a coincidence rather than a
+# rule, and so decides the shape of the fix.
+DIVERGENT_CONFIG = "exp002_single_baseline"
+DIVERGENT_ID = "exp002"
+
+
+def _module():
+    path = BATCH_RUNNER / "scripts/download_inference_from_hf.py"
+    spec = importlib.util.spec_from_file_location(
+        "download_inference_from_hf", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _declared_id(config_path: Path) -> str | None:
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    block = (data or {}).get("experiment")
+    return block.get("id") if isinstance(block, dict) else None
+
+
+def _dispatchable_configs() -> list[str]:
+    """Every config a grade run can be pointed at, as ``--experiment`` spells it.
+
+    Naming a repository is what makes a file dispatchable; the plan documents
+    beside the execution-envelope configs do not, and are not grading inputs.
+    """
+    found = []
+    for path in sorted(EXPERIMENTS.rglob("*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        block = data.get("data") if isinstance(data, dict) else None
+        source = block.get("source") if isinstance(block, dict) else None
+        if isinstance(source, str) and source.strip():
+            found.append(
+                path.relative_to(EXPERIMENTS).with_suffix("").as_posix()
+            )
+    return found
+
+
+# ── the rule, read off the configs that are really on disk ───────────────
+
+
+def test_a_config_in_a_directory_is_the_experiment_it_declares(monkeypatch):
+    """The regression, stated on the real file rather than a fixture."""
+    monkeypatch.chdir(BATCH_RUNNER)
+    module = _module()
+    assert module.resolve_experiment_id(DIRECTORY_CONFIG) == DECLARED_ID
+    assert "/" not in module.resolve_experiment_id(DIRECTORY_CONFIG), (
+        "the identity uploaded beside the results has no folder in it; a "
+        "resolver that returns one can never match the sidecar"
+    )
+
+
+def test_the_identity_is_not_the_last_component_of_the_path(monkeypatch):
+    """Why the shortest-looking fix is the wrong one.
+
+    Normalising the dispatched value to its basename would satisfy the five
+    execution-envelope configs and quietly misidentify this one, which has been
+    on main since long before any of them.
+    """
+    monkeypatch.chdir(BATCH_RUNNER)
+    module = _module()
+    assert module.resolve_experiment_id(DIVERGENT_CONFIG) == DIVERGENT_ID
+    assert DIVERGENT_ID != DIVERGENT_CONFIG.rsplit("/", 1)[-1]
+
+
+def test_every_config_that_can_be_dispatched_states_an_identity(monkeypatch):
+    """A config the resolver cannot read is a run that fails after downloading.
+
+    The refusal is deliberate rather than a fall back to the path, so a config
+    added without an id has to be caught here, at no cost, instead of at the
+    grading step of a dispatch someone is waiting on.
+
+    "Dispatchable" means it names a repository to grade. ``experiments/`` also
+    holds two plan documents that name neither, and those already stop one line
+    earlier on ``data.source is missing`` — this fix did not change what
+    happens to them.
+    """
+    monkeypatch.chdir(BATCH_RUNNER)
+    module = _module()
+
+    dispatchable = _dispatchable_configs()
+    assert len(dispatchable) > 30, "the survey found almost nothing to check"
+
+    for name in dispatchable:
+        assert module.resolve_experiment_id(name) == _declared_id(
+            EXPERIMENTS / f"{name}.yaml"
+        ), name
+
+
+def test_a_config_that_states_no_identity_is_refused(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    module = _module()
+    path = Path("experiments/nameless.yaml")
+    path.parent.mkdir(parents=True)
+    path.write_text('experiment:\n  name: "no id here"\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="experiment.id is missing"):
+        module.resolve_experiment_id("nameless")
+
+
+@pytest.mark.parametrize("declared", ['""', "[]", "{}"])
+def test_an_empty_or_mistyped_identity_is_refused(
+    declared, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    module = _module()
+    path = Path("experiments/blank.yaml")
+    path.parent.mkdir(parents=True)
+    path.write_text(f"experiment:\n  id: {declared}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="experiment.id is missing"):
+        module.resolve_experiment_id("blank")
+
+
+def test_the_declared_identity_is_compared_exactly_as_written(
+    tmp_path, monkeypatch
+):
+    """Trimming here would invent a disagreement instead of preventing one.
+
+    Step 3 records whatever the config declares — ``ExperimentConfig`` reads
+    ``experiment.id`` and does not trim it either. Tidying one side of a
+    comparison and not the other is how the two sides stop matching.
+    """
+    monkeypatch.chdir(tmp_path)
+    module = _module()
+    path = Path("experiments/padded.yaml")
+    path.parent.mkdir(parents=True)
+    path.write_text('experiment:\n  id: "  spaced  "\n', encoding="utf-8")
+
+    assert module.resolve_experiment_id("padded") == "  spaced  "
+
+
+# ── the download, end to end, against a sidecar step 3 really wrote ──────
+
+
+def _payload(experiment_id: str) -> dict:
+    """A step 2 result set shaped the way step 3 hands it to the sidecar."""
+    return {
+        "experiment_id": experiment_id,
+        "source_repo_id": "owner/repo",
+        "prepared_fingerprint": hashlib.sha256(b"prepared").hexdigest(),
+        "execution_mode": "subprocess",
+        "azure_ai_routes": [],
+        "results": [
+            {
+                "task_id": "task-1",
+                "deliverable_text": "hello",
+                "deliverable_files": [],
+                "status": "success",
+            }
+        ],
+    }
+
+
+def _run_main(module, monkeypatch, tmp_path, *, dispatched, sidecar_id):
+    """Run ``main()`` against a Hub that answers with one experiment's upload."""
+    monkeypatch.chdir(tmp_path)
+
+    config = Path("experiments") / f"{dispatched}.yaml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        f'experiment:\n  id: "{DECLARED_ID}"\ndata:\n  source: "owner/repo"\n',
+        encoding="utf-8",
+    )
+
+    results = tmp_path / "step2_inference_results.json"
+    results.write_text(
+        json.dumps(_payload(DECLARED_ID)), encoding="utf-8"
+    )
+    # Built by the writer, not by hand: whatever step 3 puts in this file is
+    # what the downloader has to accept.
+    sidecar = tmp_path / "inference_provenance.json"
+    sidecar.write_text(
+        json.dumps(build_inference_provenance(_payload(sidecar_id))),
+        encoding="utf-8",
+    )
+
+    class FakeApi:
+        def __init__(self, token=None):
+            self.token = token
+
+        def dataset_info(self, repo_id, revision):
+            return SimpleNamespace(sha=FULL_SHA)
+
+    def fake_hf_hub_download(**kwargs):
+        return str(
+            {
+                "step2_inference_results.json": results,
+                "inference_provenance.json": sidecar,
+            }[kwargs["filename"]]
+        )
+
+    monkeypatch.setattr(module, "HfApi", FakeApi)
+    monkeypatch.setattr(module, "hf_hub_download", fake_hf_hub_download)
+    monkeypatch.setattr(
+        module,
+        "snapshot_download",
+        lambda **kwargs: str(kwargs["local_dir"]),
+    )
+    monkeypatch.setattr(
+        module,
+        "parse_args",
+        lambda: SimpleNamespace(
+            experiment=dispatched,
+            output="workspace/inference.json",
+            revision="",
+            expected_leading_task_id=[],
+            grading_config=None,
+            allow_legacy_missing_provenance=False,
+        ),
+    )
+    return module.main()
+
+
+def test_the_download_accepts_the_sidecar_its_own_inference_uploaded(
+    monkeypatch, tmp_path
+):
+    """The dry run's failure, reproduced and then passing.
+
+    The dispatch carries a folder; the upload carries the declared id. Before
+    the fix these were compared against each other and the run stopped here,
+    after the download and before any grading.
+    """
+    module = _module()
+    assert (
+        _run_main(
+            module,
+            monkeypatch,
+            tmp_path,
+            dispatched=DIRECTORY_CONFIG,
+            sidecar_id=DECLARED_ID,
+        )
+        == 0
+    )
+
+    written = json.loads(
+        Path("workspace/inference.json").read_text(encoding="utf-8")
+    )
+    assert written["azure_ai_provenance_status"] == "verified-sidecar"
+    assert written["results"][0]["task_id"] == "task-1"
+
+
+def test_a_sidecar_from_another_experiment_is_still_refused(
+    monkeypatch, tmp_path
+):
+    """The check was taught which value to read, not to stop reading.
+
+    Without this the test above would pass just as happily if the comparison
+    had been deleted, and would then be measuring nothing.
+    """
+    module = _module()
+    with pytest.raises(
+        ValueError, match="inference provenance experiment identity mismatch"
+    ):
+        _run_main(
+            module,
+            monkeypatch,
+            tmp_path,
+            dispatched=DIRECTORY_CONFIG,
+            sidecar_id="exp031_envelope_container_code_interpreter",
+        )
+
+
+# ── both halves of one run have to pin the same spelling ────────────────
+
+
+def _pinned_identity_argument() -> str:
+    """What ``step8_grade.py`` hands its own ``rerun_identity`` check."""
+    tree = ast.parse(
+        (BATCH_RUNNER / "step8_grade.py").read_text(encoding="utf-8")
+    )
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_validate_pinned_rerun_identity"
+        ):
+            for keyword in node.keywords:
+                if keyword.arg == "experiment_id":
+                    return ast.unparse(keyword.value)
+    raise AssertionError(
+        "step8_grade.py no longer calls _validate_pinned_rerun_identity"
+    )
+
+
+def test_the_two_pinned_identity_checks_read_the_same_field():
+    """One value in a grading config, checked twice, in two different steps.
+
+    ``rerun_identity.experiment_id`` is compared by the downloader against what
+    the inference run recorded, and again by step 8 before grading starts. If
+    one of them read the dispatched path instead, a grading config for a
+    directory config would need two different spellings of the same field to
+    get through a single run — which it cannot have.
+    """
+    assert _pinned_identity_argument() == "exp_config.experiment_id"
+
+
+def test_the_grading_config_side_reads_the_declared_identity_too(monkeypatch):
+    """The same fact, reached by step 8's loader instead of the downloader's.
+
+    Checked on the two configs that can disagree with their own path — the one
+    in a directory and the one whose id is not its filename — so this fails if
+    either side is ever taught to prefer the name it was given.
+    """
+    monkeypatch.chdir(BATCH_RUNNER)
+    module = _module()
+
+    import step8_grade
+
+    for name in (DIRECTORY_CONFIG, DIVERGENT_CONFIG):
+        loaded = step8_grade.load_experiment_yaml(name)
+        assert loaded.experiment_id == module.resolve_experiment_id(name), name

--- a/batch-runner/tests/test_download_inference_from_hf.py
+++ b/batch-runner/tests/test_download_inference_from_hf.py
@@ -45,18 +45,26 @@ def _remote_missing(message="missing"):
     )
 
 
-def _write_submission_experiment(name="exp", source="owner/repo"):
+def _write_submission_experiment(name="exp", source="owner/repo", declared_id=None):
     """Write the experiment file ``main()`` reads, under the current directory.
 
-    ``main()`` resolves two things from it: which repository the graded corpus
-    comes from, and whether that corpus is a submission or the benchmark's own
-    reference answers. A test that chdirs into a tmp dir has to supply the file
-    for both reads -- stubbing only ``resolve_repo_id`` leaves the second one
-    looking at a path that does not exist.
+    ``main()`` resolves three things from it: which repository the graded corpus
+    comes from, which experiment the config says it is, and whether that corpus
+    is a submission or the benchmark's own reference answers. A test that chdirs
+    into a tmp dir has to supply the file for all three -- stubbing only
+    ``resolve_repo_id`` leaves the others looking at a path that does not exist.
+
+    ``declared_id`` defaults to ``name`` because that is the shape every config
+    written so far happens to have. Pass it to model the shape that separates
+    them: a config whose id is not the path used to open it.
     """
     path = Path("experiments") / f"{name}.yaml"
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(f'data:\n  source: "{source}"\n', encoding="utf-8")
+    path.write_text(
+        f'experiment:\n  id: "{declared_id or name}"\n'
+        f'data:\n  source: "{source}"\n',
+        encoding="utf-8",
+    )
 
 
 def test_direct_script_entrypoint_resolves_core_import():
@@ -207,7 +215,7 @@ def test_legacy_allowance_defaults_to_fail_closed(config):
 
     assert module.resolve_legacy_missing_provenance_allowance(
         config,
-        experiment="exp",
+        experiment_id="exp",
         requested_revision=FULL_SHA,
         resolved_revision=FULL_SHA,
     ) is False
@@ -220,7 +228,7 @@ def test_legacy_allowance_rejects_non_boolean_declaration(declaration):
     with pytest.raises(ValueError, match="must be boolean"):
         module.resolve_legacy_missing_provenance_allowance(
             _legacy_config(declaration=declaration),
-            experiment="exp",
+            experiment_id="exp",
             requested_revision=FULL_SHA,
             resolved_revision=FULL_SHA,
         )
@@ -261,7 +269,7 @@ def test_legacy_allowance_rejects_unscoped_identity(mutation, message):
     with pytest.raises(ValueError, match=message):
         module.resolve_legacy_missing_provenance_allowance(
             config,
-            experiment="exp",
+            experiment_id="exp",
             requested_revision=FULL_SHA,
             resolved_revision=FULL_SHA,
         )
@@ -274,7 +282,7 @@ def test_legacy_allowance_rejects_noncanonical_requested_revision(requested):
     with pytest.raises(ValueError, match="requested revision mismatch"):
         module.resolve_legacy_missing_provenance_allowance(
             _legacy_config(),
-            experiment="exp",
+            experiment_id="exp",
             requested_revision=requested,
             resolved_revision=FULL_SHA,
         )
@@ -287,7 +295,7 @@ def test_legacy_allowance_rejects_resolved_revision_mismatch(resolved):
     with pytest.raises(ValueError, match="resolved revision mismatch"):
         module.resolve_legacy_missing_provenance_allowance(
             _legacy_config(),
-            experiment="exp",
+            experiment_id="exp",
             requested_revision=FULL_SHA,
             resolved_revision=resolved,
         )
@@ -298,7 +306,7 @@ def test_legacy_allowance_accepts_only_exact_pinned_identity():
 
     assert module.resolve_legacy_missing_provenance_allowance(
         _legacy_config(),
-        experiment="exp",
+        experiment_id="exp",
         requested_revision=FULL_SHA,
         resolved_revision=FULL_SHA,
     ) is True
@@ -414,7 +422,7 @@ def test_downloaded_json_metadata_overrides_stale_values(monkeypatch, tmp_path):
 
     allowance = module.resolve_legacy_missing_provenance_allowance(
         _legacy_config(),
-        experiment="exp",
+        experiment_id="exp",
         requested_revision=FULL_SHA,
         resolved_revision=FULL_SHA,
     )
@@ -527,7 +535,7 @@ def test_missing_sidecar_is_rejected_without_explicit_legacy_override(
     with pytest.raises(ValueError, match="provenance sidecar is missing"):
         module._attach_inference_provenance(
             {"results": [{"task_id": "task-1", "deliverable_files": []}]},
-            experiment="exp",
+            experiment_id="exp",
             repo_id="owner/repo",
             revision=FULL_SHA,
         )
@@ -549,7 +557,7 @@ def test_missing_sidecar_with_embedded_routes_is_always_rejected(monkeypatch):
                 "azure_ai_routes": [{"workload": "inference"}],
                 "results": [{"task_id": "task-1", "deliverable_files": []}],
             },
-            experiment="exp",
+            experiment_id="exp",
             repo_id="owner/repo",
             revision=FULL_SHA,
             allow_legacy_missing_provenance=True,
@@ -573,7 +581,7 @@ def test_non_remote_missing_sidecar_errors_are_not_downgraded(
     with pytest.raises(type(error), match=str(error)):
         module._attach_inference_provenance(
             {"results": [{"task_id": "task-1", "deliverable_files": []}]},
-            experiment="exp",
+            experiment_id="exp",
             repo_id="owner/repo",
             revision=FULL_SHA,
             allow_legacy_missing_provenance=True,
@@ -592,7 +600,7 @@ def test_local_entry_not_found_is_not_downgraded(monkeypatch):
     with pytest.raises(LocalEntryNotFoundError, match="local cache missing"):
         module._attach_inference_provenance(
             {"results": [{"task_id": "task-1", "deliverable_files": []}]},
-            experiment="exp",
+            experiment_id="exp",
             repo_id="owner/repo",
             revision=FULL_SHA,
             allow_legacy_missing_provenance=True,
@@ -612,7 +620,7 @@ def test_malformed_sidecar_is_not_downgraded(monkeypatch, tmp_path):
     with pytest.raises(json.JSONDecodeError):
         module._attach_inference_provenance(
             {"results": [{"task_id": "task-1", "deliverable_files": []}]},
-            experiment="exp",
+            experiment_id="exp",
             repo_id="owner/repo",
             revision=FULL_SHA,
             allow_legacy_missing_provenance=True,
@@ -636,7 +644,7 @@ def test_http_auth_errors_are_not_downgraded(monkeypatch, status_code):
     with pytest.raises(HfHubHTTPError, match="authorization failed"):
         module._attach_inference_provenance(
             {"results": [{"task_id": "task-1", "deliverable_files": []}]},
-            experiment="exp",
+            experiment_id="exp",
             repo_id="owner/repo",
             revision=FULL_SHA,
             allow_legacy_missing_provenance=True,
@@ -696,7 +704,7 @@ def test_verified_sidecar_rejects_embedded_identity_mismatch(
     with pytest.raises(ValueError, match=message):
         module._attach_inference_provenance(
             payload,
-            experiment="exp",
+            experiment_id="exp",
             repo_id="owner/repo",
             revision=FULL_SHA,
             allow_legacy_missing_provenance=True,


### PR DESCRIPTION
`--experiment` carries two facts that have looked like one until now: which config file to open, and which experiment that file is. Every config written so far sat directly in `experiments/` and was named after the id it declared, so either could be used for either and nobody had to choose.

A config in a directory separates them. #347 taught the workflow to accept `execution_envelope/exp030_envelope_host_python_process`, and the free dry run that proved it — run [33482175890](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/33482175890) — got one step further and stopped:

```
ValueError: inference provenance experiment identity mismatch
```

## What was actually being compared

The file that dispatch opens declares `exp030_envelope_host_python_process`, with no folder. `step3_format_results.py` writes that declared id into `inference_provenance.json` and uploads it beside the results. The sidecar on the Hub at the revision the dry run resolved reads:

```json
"experiment_id": "exp030_envelope_host_python_process"
```

`scripts/download_inference_from_hf.py` was handing `validate_inference_provenance` the *dispatched path*. So the experiment was refused its own inference, after the download and before any grading.

## The rule

The path selects the file; the file states the identity; every comparison against something a run recorded uses the second.

`resolve_experiment_id` reads `experiment.id` out of the config and **fails closed** when it is absent, rather than falling back to the path — that fall back is precisely the comparison this exists to stop, and it would only surface after the download.

The declared id is compared exactly as written. Step 3 records whatever the config declares and does not trim it either; tidying one side of a comparison and not the other is how the two sides stop matching.

## Why not just take the last path component

`exp002_single_baseline.yaml` declares `exp002`. Basename-normalisation is therefore not a restatement of the existing convention — it is a change that misidentifies a config that has been on main since the beginning.

The survey behind that: 37 of the 39 YAML files under `experiments/` name a repository and are dispatchable, and **all 37 declare an id**. The two that do not are the execution-envelope *plan* documents, which name no repository and already stop one line earlier on `data.source is missing`. This change does not alter what happens to them.

## The second half of the same run

`step8_grade.py` checks the same `rerun_identity.experiment_id` a second time, before grading starts, and it was reading the dispatched name. Left alone, a grading config for a directory config would have needed two different spellings of one field to satisfy both halves of a single run — which it cannot have. It now reads the loaded config's declared id, which is the same fact the downloader compares. Stage 4's 30-task trial will pin `rerun_identity`, so this check does fire.

## What is deliberately untouched

#347's `__` flattening of the output path stays. Paths name outputs and must remain unique by construction; declared ids name identity and are not guaranteed unique across files. `resolve_grade_output_path` still uses the path form.

## Tests

`tests/test_a_configs_folder_is_not_its_name.py` — 12 tests, none of which call a model or the network.

The end-to-end ones build the sidecar with `build_inference_provenance`, the same function step 3 builds it with, so they prove a round trip rather than a hand-written approximation of one.

**Eleven of the twelve fail against main**, and the one that reproduces the dry run fails with exactly its production message:

```
E   ValueError: inference provenance experiment identity mismatch
```

The twelfth — a sidecar naming a *different* experiment is still refused — passes both before and after, which is the point: it anchors the others, so the regression test cannot be satisfied by deleting the check.

## Verification

- full backend suite from `batch-runner/`, Python 3.10.12
- zero grade runs in flight at merge time, re-checked immediately before merging — `scripts/download_inference_from_hf.py` and `step8_grade.py` are both inside the grader source hash

Closes the sixth and, on the evidence of a clean read of `step8_grade.py` and `step9_merge_shards.py`, the last place where a config's folder was read as its name. Neither re-checks the downloaded payload's `experiment_id` against the dispatched value.
