### PR TITLE
fix(cost): record what each metered call actually asked for

### DIFF
--- a/batch-runner/core/cost_metering.py
+++ b/batch-runner/core/cost_metering.py
@@ -24,6 +24,8 @@ ledger.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -55,6 +57,7 @@ __all__ = [
     "extract_usage",
     "open_cost_recorder",
     "read_reported_usage",
+    "request_digest_of",
     "resolved_model_of",
     "route_identity_of",
 ]
@@ -370,6 +373,52 @@ def deployment_of(client: Any, requested: str | None) -> str | None:
         return None
     text = (requested or "").strip()
     return text or None
+
+
+def request_digest_of(payload: Any) -> str | None:
+    """A fingerprint of what was asked, or nothing at all.
+
+    Two rows carrying the same digest were sent the same request. That is the
+    one question the ledger could not answer: when the four attempts at chunk 0
+    were reconstructed, the 818 rows proved the *same positions* had been run
+    four times, and could not prove the same *bytes* had been bought four
+    times, because this column was empty in all 818. It is the same question
+    run-to-run variance asks — a score that moved between two runs at one
+    grader fingerprint means nothing until the requests behind it are known to
+    have been identical.
+
+    The digest is over the request as sent, with keys ordered, so the same call
+    hashes the same on any machine and in any run. Nothing is excluded and
+    nothing is normalised away: a field that differs is a request that differs,
+    and a fingerprint that quietly forgave some fields would answer "same"
+    about calls that were not.
+
+    **A request that cannot be canonically rendered gets no digest at all.**
+    The tempting alternative is to hash a lossy rendering — ``str`` of whatever
+    would not serialise, say — and that is worse than nothing here, because the
+    failure mode is a false *match*: two genuinely different requests collapsing
+    onto one placeholder and reporting themselves identical. A missing digest
+    only fails to answer. So ``None`` means "not captured", exactly as it does
+    everywhere else in this module.
+
+    Never raises. Metering observes; it does not participate. A payload holding
+    something exotic — an open file, a proxy that objects to being read — must
+    not take down the paid call it was only writing a note about.
+
+    One-way by construction, which is what makes the column publishable: the
+    ledger carries the digest of a prompt and never the prompt.
+    """
+    try:
+        canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except Exception:  # noqa: BLE001 - see "never raises" above
+        return None
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 # ── The recorder ─────────────────────────────────────────────────────────
@@ -706,6 +755,10 @@ class MeteredClient:
             requested_model=requested,
             deployment=deployment,
             api_version=object.__getattribute__(self, "_api_version"),
+            # Taken before the call rather than after, for the same reason the
+            # row itself is: what a crashed call asked for is exactly what a
+            # reader of the wreckage needs, and by then ``kwargs`` is gone.
+            request_sha256=request_digest_of(kwargs),
         )
         object.__setattr__(self, "last_call_id", call_id)
         response = call(**kwargs)

--- a/batch-runner/tests/test_cost_metering_records_what_the_client_sent.py
+++ b/batch-runner/tests/test_cost_metering_records_what_the_client_sent.py
@@ -19,6 +19,7 @@ from core.cost_metering import (
     CostRecorder,
     extract_usage,
     read_reported_usage,
+    request_digest_of,
     resolved_model_of,
 )
 from core.cost_receipts import (
@@ -588,3 +589,267 @@ def test_a_default_model_covers_a_request_that_names_none(recorder):
     assert recorder.ledger.calls_for("task-a")[0]["requested_model"] == (
         "a-default-deployment"
     )
+
+
+# ── the fingerprint of what was asked ────────────────────────────────────
+#
+# Why the column exists: four attempts at one chunk were reconstructed from
+# 818 ledger rows, and the reconstruction could show the same *positions* had
+# been run four times but not that the same *bytes* had been bought four
+# times, because this column was empty in all 818 rows. Two runs at one grader
+# fingerprint raise the same question about a score that moved.
+
+
+def _digest(recorder, index=0, task_id="task-a"):
+    return recorder.ledger.calls_for(task_id)[index]["request_sha256"]
+
+
+def test_the_same_request_twice_is_recorded_as_the_same_request(recorder):
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(
+            model="a-deployment", messages=[{"role": "user", "content": "hi"}]
+        )
+        client.chat.completions.create(
+            model="a-deployment", messages=[{"role": "user", "content": "hi"}]
+        )
+
+    first, second = (_digest(recorder, 0), _digest(recorder, 1))
+
+    assert first is not None
+    assert first == second
+
+
+def test_a_request_that_differs_by_one_character_is_a_different_request(
+    recorder,
+):
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(
+            model="a-deployment", messages=[{"role": "user", "content": "hi"}]
+        )
+        client.chat.completions.create(
+            model="a-deployment", messages=[{"role": "user", "content": "hI"}]
+        )
+
+    assert _digest(recorder, 0) != _digest(recorder, 1)
+
+
+def test_the_order_the_arguments_were_written_in_is_not_part_of_the_request(
+    recorder,
+):
+    """Two callers spelling one request differently still asked for one thing.
+
+    Without this the column answers "different" for every pair of runs that
+    happened to build their keyword arguments in a different order, which is
+    the same as answering nothing.
+    """
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(
+            model="a-deployment", messages=[], temperature=0
+        )
+        client.chat.completions.create(
+            temperature=0, messages=[], model="a-deployment"
+        )
+
+    # Both being absent is also "equal", and would prove nothing. The point of
+    # the test is that two spellings of one request meet at a digest, so there
+    # has to be a digest for them to meet at.
+    assert _digest(recorder, 0) is not None
+    assert _digest(recorder, 0) == _digest(recorder, 1)
+
+
+def test_the_order_of_a_conversation_is_part_of_the_request(recorder):
+    """A list, unlike a keyword, means something by its order."""
+    turns = [{"role": "user", "content": "one"}, {"role": "user", "content": "two"}]
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(model="a-deployment", messages=turns)
+        client.chat.completions.create(
+            model="a-deployment", messages=list(reversed(turns))
+        )
+
+    assert _digest(recorder, 0) != _digest(recorder, 1)
+
+
+def test_what_is_recorded_is_a_digest_and_never_the_prompt(recorder):
+    """The ledger is published. It carries the fingerprint, not the text."""
+    secret = "the quick brown fox jumps over the lazy dog"
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(
+            model="a-deployment",
+            messages=[{"role": "user", "content": secret}],
+        )
+
+    row = recorder.ledger.calls_for("task-a")[0]
+
+    assert len(row["request_sha256"]) == 64
+    assert all(c in "0123456789abcdef" for c in row["request_sha256"])
+    assert secret not in json.dumps(row)
+
+
+def test_a_request_that_cannot_be_rendered_gets_no_fingerprint(recorder):
+    """Silence, not a placeholder.
+
+    Hashing some lossy rendering of the unrenderable part would let two
+    genuinely different requests collapse onto one digest and report
+    themselves identical — a false match, which is worse than no answer.
+    """
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(
+            model="a-deployment", messages=[], extra=object()
+        )
+
+    row = recorder.ledger.calls_for("task-a")[0]
+
+    assert row["request_sha256"] is None
+    # And the call itself was untouched: still made, still settled, still priced.
+    assert recorder.receipt_for(
+        "task-a", BUCKET_PROBLEM_SOLVING
+    ).estimated_cost_usd == Decimal("1.20")
+
+
+def test_two_requests_that_could_not_be_rendered_never_meet_at_one_digest(
+    recorder,
+):
+    """The harm a placeholder would do, written down as a test.
+
+    These two calls asked for different things. Under any scheme that fills the
+    column when it cannot read the request — a fixed marker, a hash of ``str``
+    — they land on the same digest and the ledger reports two different
+    requests as one. Later, that is indistinguishable from the thing the column
+    exists to prove.
+    """
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(
+            model="a-deployment", messages=[], extra=object()
+        )
+        client.chat.completions.create(
+            model="a-deployment", messages=[], extra={1, 2}
+        )
+
+    # Both absent, not merely unequal: two *different* placeholders would
+    # satisfy ``first != second`` while telling the same lie twice.
+    assert (_digest(recorder, 0), _digest(recorder, 1)) == (None, None)
+
+
+def test_a_payload_that_objects_to_being_read_does_not_take_down_the_call(
+    recorder,
+):
+    """Metering observes. It does not get a vote on whether the call happens.
+
+    The refusal here is a plain ``RuntimeError`` rather than the ``TypeError``
+    an unserialisable value raises, because the guard has to hold for whatever
+    a payload throws, not for the two exceptions ``json`` documents.
+    """
+
+    class Hostile(dict):
+        def items(self):
+            raise RuntimeError("not for you")
+
+    client = recorder.meter(FakeClient(), provider="azure")
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        client.chat.completions.create(
+            model="a-deployment", messages=[], extra=Hostile(a=1)
+        )
+
+    assert _digest(recorder) is None
+    assert recorder.receipt_for("task-a", BUCKET_PROBLEM_SOLVING).model_calls == 1
+
+
+def test_a_call_that_never_came_back_still_says_what_it_asked_for(recorder):
+    """Written before the request, so the wreckage names what was bought."""
+    client = recorder.meter(
+        FakeClient(raises=RuntimeError("gateway timeout")), provider="azure"
+    )
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        with pytest.raises(RuntimeError):
+            client.chat.completions.create(model="a-deployment", messages=[])
+
+    assert _digest(recorder) is not None
+
+
+def test_a_call_filed_from_outside_the_wrapper_records_no_fingerprint(recorder):
+    """A caller that owns its transport is not observed here, and says so.
+
+    ``record_call`` is handed a reply, never a request, so it has nothing to
+    fingerprint. Recorded as unknown rather than filled in from the reply,
+    which would be a different question answered as if it were this one.
+    """
+    with recorder.attributed(task_id="task-a", stage=STAGE_GENERATION):
+        recorder.record_call(
+            provider="azure",
+            requested_model="a-deployment",
+            response=_chat_reply(),
+        )
+
+    assert _digest(recorder) is None
+
+
+# -- the digest itself ----------------------------------------------------
+
+
+def test_a_nested_difference_is_still_a_difference():
+    assert request_digest_of(
+        {"reasoning": {"effort": "high"}}
+    ) != request_digest_of({"reasoning": {"effort": "low"}})
+
+
+def test_nesting_is_canonicalised_all_the_way_down():
+    assert request_digest_of({"a": {"x": 1, "y": 2}}) == request_digest_of(
+        {"a": {"y": 2, "x": 1}}
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"n": float("nan")},
+        {"n": float("inf")},
+        {"seen": {1, 2}},
+        {"when": object()},
+    ],
+)
+def test_anything_json_cannot_state_exactly_is_left_unrecorded(payload):
+    """Including the two floats ``json`` would otherwise emit as bare words.
+
+    ``NaN`` and ``Infinity`` are not JSON, and a digest computed over them
+    would be a digest of something no other reader could reproduce.
+    """
+    assert request_digest_of(payload) is None
+
+
+def test_a_request_that_refers_to_itself_is_left_unrecorded():
+    payload: dict = {"model": "a-deployment"}
+    payload["self"] = payload
+
+    assert request_digest_of(payload) is None
+
+
+def test_a_request_nested_deeper_than_python_will_walk_is_left_unrecorded():
+    """``RecursionError`` is neither of the two exceptions ``json`` documents."""
+    payload: dict = {}
+    cursor = payload
+    for _ in range(2_000):
+        cursor["nested"] = {}
+        cursor = cursor["nested"]
+
+    assert request_digest_of(payload) is None
+
+
+def test_an_empty_request_is_still_a_request():
+    """Nothing asked for is not the same as nothing recorded."""
+    assert request_digest_of({}) is not None

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import pytest
 
+from core.cost_metering import request_digest_of
 from core.grader_routing import Modality, RoutingDecision
 from core.rubric_loader import RubricItem, TaskRubric
 from core.tool_calling_judge import (
@@ -2927,3 +2928,92 @@ def test_the_schema_offers_member_without_demanding_it():
     # Nullable, because ``additionalProperties: False`` plus a non-nullable
     # optional is how a model ends up unable to say "the whole file".
     assert params["properties"]["member"]["type"] == ["string", "null"]
+
+
+# ── The request the ledger fingerprints ──────────────────────────────
+#
+# ``request_sha256`` is filled by the metering wrapper from the keyword
+# arguments handed to the provider. That is a generic mechanism, tested
+# generically next door. What those tests cannot say is whether *this* caller —
+# the one that spends the grading money — actually hands over something a
+# digest can be taken of, and whether what it hands over is the same twice.
+# Both are answered here, against the real payload.
+
+
+def _judged_requests(client_script, task, item, deliverable_dir):
+    """Run one judgement and return a digest per upstream request."""
+    client = FakeClient(ScriptedResponses(client_script))
+    judge = ToolCallingJudge(client=client, model="gpt-5.4",
+                             prompt_template=PROMPT_TEMPLATE)
+    judge.judge_item(task=task, item=item,
+                     deliverable_dir=str(deliverable_dir),
+                     file_names=["report.xlsx"])
+    return [request_digest_of(call) for call in client.responses.calls]
+
+
+def _pass_verdict() -> dict:
+    return _final(json.dumps({
+        "verdict": "pass", "partial_score": 1.0,
+        "evidence": "label present", "confidence": 0.9, "reasoning": "ok",
+    }))
+
+
+def test_the_request_the_grader_sends_can_be_fingerprinted(
+    deliverable_dir, task_and_item
+):
+    """A digest the grading path cannot produce is a column that stays empty.
+
+    The tool schema is the fragile part: it is assembled per modality, and an
+    entry that could not be rendered would blank the fingerprint on exactly the
+    calls the receipt was built for, silently, while every other test still
+    passed.
+    """
+    task, item = task_and_item
+
+    digests = _judged_requests([_response(output=[_pass_verdict()])],
+                               task, item, deliverable_dir)
+
+    assert digests and all(d is not None for d in digests)
+
+
+def test_the_same_judgement_twice_sends_the_same_request(
+    deliverable_dir, task_and_item
+):
+    """What makes the column worth reading across two runs.
+
+    A score that moved between two runs at one grader fingerprint means
+    nothing until the requests behind it are known to have been identical. If
+    anything transient reached the payload — a timestamp, a run id, an
+    iteration order that wandered — the digests would differ here and the
+    comparison would be unavailable in principle, not just unmeasured.
+    """
+    task, item = task_and_item
+
+    first = _judged_requests([_response(output=[_pass_verdict()])],
+                             task, item, deliverable_dir)
+    second = _judged_requests([_response(output=[_pass_verdict()])],
+                              task, item, deliverable_dir)
+
+    # Two absences are also "equal"; the point is that they meet at a digest.
+    assert all(d is not None for d in first)
+    assert first == second
+
+
+def test_grading_a_different_criterion_is_a_different_request(
+    deliverable_dir, task_and_item
+):
+    """And the digest still tracks the thing being judged."""
+    task, item = task_and_item
+    other = RubricItem(
+        rubric_item_id="r2",
+        criterion="The deliverable contains a 'beta' label in column B",
+        score=5,
+        required=None,
+    )
+
+    first = _judged_requests([_response(output=[_pass_verdict()])],
+                             task, item, deliverable_dir)
+    second = _judged_requests([_response(output=[_pass_verdict()])],
+                              task, other, deliverable_dir)
+
+    assert first != second


### PR DESCRIPTION
## What was empty

`request_sha256` has been a column on the receipt ledger since it was built. `reserve()` accepts it and SHA-256-validates it. No caller has ever passed one.

- **84/84** rows empty in the first paid grading receipt
- **818/818** rows empty in the reconstruction of the four lost chunk-0 attempts

That reconstruction could show the same *positions* had been run four times. It could not show the same *bytes* had been bought four times, because the one column that would have said so was blank. Run-to-run variance analysis asks the same question: a score that moved between two runs at one grader fingerprint means nothing until the requests behind it are known to have been identical.

## What it now does

The metering wrapper already holds the keyword arguments on their way to the provider, so `request_digest_of` digests them — `json.dumps(sort_keys=True, separators=(",",":"), ensure_ascii=True, allow_nan=False)`, then SHA-256.

- Keyword order is **not** part of a request. List order **is**.
- Nothing is excluded, nothing normalised away. A fingerprint that quietly forgave some fields would answer "same" about calls that were not.
- One-way by construction, which is what keeps the column publishable: the ledger carries the digest of a prompt, never the prompt.

## Three decisions worth arguing with

**Silence, not a placeholder.** A request that cannot be canonically rendered gets no digest. Hashing a lossy rendering fails as a false *match* — two genuinely different requests collapsing onto one placeholder and reporting themselves identical. A missing digest only fails to answer. `None` keeps its existing meaning in this module: not captured.

**Not added to `missing_reasons`.** A missing digest does not make a call unpriceable. Adding it would flip `complete` receipts to `partial` — a real regression against the fail-closed-on-*cost* contract.

**Taken before the call, not after.** Same reason the row itself is: what a crashed call asked for is exactly what a reader of the wreckage needs, and by then `kwargs` is gone. `request_digest_of` never raises — metering observes, it does not participate.

## Tests

The wrapper is covered generically. The **grading path is covered specifically**, because a tool schema that could not be rendered would blank the column on exactly the 84 calls the receipt was built for, silently, while every other test stayed green. That path is also shown to send byte-identical requests for a repeated judgement — the property variance analysis depends on, now demonstrated rather than assumed.

| Negative control (each reverted) | Fails |
|---|---|
| Drop the wiring in `_around` | 6 |
| Return a placeholder instead of silence | 9 |
| Drop `sort_keys=True` | 2 |
| An unrenderable entry in the judge's tool schema | 3 (all grading-path) |

Strengthened two assertions found vacuous under control 1: `None == None` satisfied them.

## Verification

- **6874 passed, 7 skipped** (full backend suite)
- **mypy `core/`** unchanged at the 174-error baseline; **0** in `cost_metering.py`
- **Grader source hash moves:** `a636af0b0eb88883` → `6f373f17649d8887`. No Grade Pipeline run was in flight or queued at push time.