### PR TITLE
fix(experiments): a self-review budget that regenerates nothing said it regenerated

### DIFF
--- a/batch-runner/experiments/exp001_GPT52Chat_baseline.yaml
+++ b/batch-runner/experiments/exp001_GPT52Chat_baseline.yaml
@@ -62,7 +62,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp002_GPT52Chat_elicit.yaml
+++ b/batch-runner/experiments/exp002_GPT52Chat_elicit.yaml
@@ -112,7 +112,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp003_GPT52Chat_baseline_runner_exec.yaml
+++ b/batch-runner/experiments/exp003_GPT52Chat_baseline_runner_exec.yaml
@@ -62,7 +62,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp004_GPT52Chat_elicit_runner_exec.yaml
+++ b/batch-runner/experiments/exp004_GPT52Chat_elicit_runner_exec.yaml
@@ -112,7 +112,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp005_GPT52Chat_elicit_v2_runner_exec.yaml
+++ b/batch-runner/experiments/exp005_GPT52Chat_elicit_v2_runner_exec.yaml
@@ -112,7 +112,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp006_GPT52Chat_token16k_lite_elicit.yaml
+++ b/batch-runner/experiments/exp006_GPT52Chat_token16k_lite_elicit.yaml
@@ -105,7 +105,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp007_GPT52Chat_token16k_elicit_v2.yaml
+++ b/batch-runner/experiments/exp007_GPT52Chat_token16k_elicit_v2.yaml
@@ -122,7 +122,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp008_GPT52Chat_resume2_elicit_v2.yaml
+++ b/batch-runner/experiments/exp008_GPT52Chat_resume2_elicit_v2.yaml
@@ -109,7 +109,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp009_GPT52Chat_lightweight_suffix_elicit.yaml
+++ b/batch-runner/experiments/exp009_GPT52Chat_lightweight_suffix_elicit.yaml
@@ -76,7 +76,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp010_GPT52Chat_resume2_elicit_v2.yaml
+++ b/batch-runner/experiments/exp010_GPT52Chat_resume2_elicit_v2.yaml
@@ -115,7 +115,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/experiments/exp011_GPT52Chat_domain_packages.yaml
+++ b/batch-runner/experiments/exp011_GPT52Chat_domain_packages.yaml
@@ -138,7 +138,7 @@ condition_a:
   # Self-QA: LLM inspects its own output
   qa:
     enabled: true
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
     model: null                 # null = same model as generation
     min_score: 5                # scores below this fail QA (1-10)
     prompt: |

--- a/batch-runner/tests/test_self_qa_attempt_budget.py
+++ b/batch-runner/tests/test_self_qa_attempt_budget.py
@@ -7,10 +7,12 @@ and found wanting, then breaks as soon as that count reaches
 number of replacements it buys is one less than the number written.
 
 That matters beyond wording. Twenty-nine of the thirty-two self-review blocks
-in batch-runner/experiments/ carry ``max_retries: 1`` -- eleven of them under a
-comment reading "max regeneration attempts on QA failure" -- and one is exactly
-the value that buys no regeneration at all: the answer is produced, reviewed,
-marked ``qa_failed``, and never replaced.
+in batch-runner/experiments/ carry ``max_retries: 1``, and one is exactly the
+value that buys no regeneration at all: the answer is produced, reviewed,
+marked ``qa_failed``, and never replaced. Eleven of them used to sit under a
+comment reading "max regeneration attempts on QA failure", which promised the
+one thing the value cannot do; those now say what they buy, kept honest by
+test_the_self_qa_comment_says_what_the_value_buys.py.
 
 These tests pin the arithmetic against the shipped loop rather than restating
 it, and pin the three places that describe the setting to a wording that

--- a/batch-runner/tests/test_the_self_qa_comment_says_what_the_value_buys.py
+++ b/batch-runner/tests/test_the_self_qa_comment_says_what_the_value_buys.py
@@ -1,0 +1,153 @@
+"""A self-review budget that can never regenerate must not claim it can.
+
+``qa.max_retries`` is a budget of answers, not of extra tries: a value of N
+produces N answers and therefore buys N - 1 replacements. One is the value
+twenty-nine of the thirty-two self-review blocks use, and it buys none. That
+arithmetic is pinned against the shipped loop in
+``test_self_qa_attempt_budget.py``; this file is about what the config files
+*say* next to it.
+
+Eleven of them used to say ``# max regeneration attempts on QA failure`` beside
+a value that regenerates nothing. The loop was never wrong -- the comment was,
+and a comment is what a reader reaches for first.
+
+Two things this file is careful about.
+
+**The rule is derived, not asserted.** "A budget of one buys no replacement" is
+not restated here as a constant; it is read from the shipped description of the
+setting, so a change to the semantics breaks the premise rather than silently
+leaving the rule pointing at the wrong values.
+
+**Only the self-review setting is in scope.** These files also carry a
+top-level ``max_retries``, and that one really is a count of retries -- infra
+retries after an API error or a timeout. Sweeping it up in the same rename
+would replace a true comment with a false one, so it is asserted to still say
+retries.
+
+Silence is left alone. Eighteen self-review blocks carry the value with no
+comment at all, in files whose whole ``qa:`` block is comment-free. Saying
+nothing is not a false claim, and adding a sentence to eighteen files to fix a
+problem none of them has is churn.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from core.execution_envelope_preflight import WHAT_THE_SETTING_DOES
+
+
+EXPERIMENTS = Path(__file__).resolve().parents[1] / "experiments"
+
+#: ``qa.max_retries`` sits four spaces in, under ``qa:``. The top-level
+#: ``max_retries`` sits two. The indent is what tells them apart.
+QA_BUDGET = re.compile(r"^ {4}max_retries:\s*(\d+)\s*(#.*)?$")
+INFRA_BUDGET = re.compile(r"^ {2}max_retries:\s*(\d+)\s*(#.*)?$")
+
+#: A comment beside a budget that buys no replacement has to *say* so.
+#:
+#: Matching on banned words was the first attempt and does not work: the
+#: corrected wording "1 regenerates nothing" contains "regenerat", so a list
+#: that catches "max regeneration attempts on QA failure" catches the fix for
+#: it too, and every one of the eleven corrected files failed. What separates
+#: the false comment from the true one is the claim, not the vocabulary, so
+#: the check is for the denial rather than against the word.
+DENIES_REPLACEMENT = ("regenerates nothing", "replaces nothing", "buys no")
+
+#: The top-level comment exists in English and Korean. Ten files say "infra
+#: retries per task (API errors, ...)", one says just "infra retries per task",
+#: three say the same thing in Korean. All fourteen are correct.
+NAMES_INFRA_RETRIES = ("infra retries", "인프라 리트라이")
+
+
+def _lines(pattern):
+    """Every (file, line number, value, comment) the pattern matches."""
+    found = []
+    for path in sorted(EXPERIMENTS.glob("*.yaml")):
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            match = pattern.match(line)
+            if match:
+                found.append(
+                    (path.name, number, int(match.group(1)), match.group(2) or "")
+                )
+    return found
+
+
+@pytest.fixture(scope="module")
+def qa_budgets():
+    found = _lines(QA_BUDGET)
+    assert found, "no qa.max_retries settings found under experiments/"
+    return found
+
+
+def test_the_setting_is_described_as_a_budget_of_answers():
+    """The premise the rule below is derived from.
+
+    If this ever stops holding, "a budget of one buys no replacement" stops
+    being a consequence of the shipped description and becomes an assumption,
+    and the rule has to be rewritten rather than left pointing at the wrong
+    values.
+    """
+    described = WHAT_THE_SETTING_DOES["condition_a.qa.max_retries"]
+    assert described == "how many answers it may produce in all"
+
+
+def test_no_budget_that_buys_no_replacement_claims_one(qa_budgets):
+    """The check this file exists for.
+
+    Silence is not in scope: eighteen of these carry no comment, and saying
+    nothing is not a false claim. The rule applies to what is written.
+    """
+    described = WHAT_THE_SETTING_DOES["condition_a.qa.max_retries"]
+    assert "in all" in described  # answers in all, so replacements = value - 1
+
+    offenders = []
+    for name, number, value, comment in qa_budgets:
+        replacements = value - 1
+        if replacements > 0 or not comment.strip():
+            continue
+        lowered = comment.lower()
+        if not any(phrase in lowered for phrase in DENIES_REPLACEMENT):
+            offenders.append(f"{name}:{number} {comment}")
+    assert offenders == [], (
+        "these self-review budgets buy no replacement and their comment does "
+        "not say so: " + "; ".join(offenders)
+    )
+
+
+def test_the_corrected_comment_says_what_the_value_buys(qa_budgets):
+    """Removing the false claim is not enough if nothing true replaces it.
+
+    The eleven that used to mislead now carry a comment; a change that quietly
+    deleted them instead would pass the rule above and leave a reader with
+    nothing but the misleading *name* of the setting.
+    """
+    explained = [c for _, _, v, c in qa_budgets if v <= 1 and c.strip()]
+    assert len(explained) == 11
+    for comment in explained:
+        assert "answers in all" in comment
+        assert "regenerates nothing" in comment
+
+
+def test_the_silent_ones_are_still_silent(qa_budgets):
+    """Eighteen say nothing, which is not a claim and so not a defect.
+
+    Pinned so that a later sweep adding a comment to all of them is a visible
+    decision rather than a side effect.
+    """
+    silent = [c for _, _, v, c in qa_budgets if v <= 1 and not c.strip()]
+    assert len(silent) == 18
+
+
+def test_the_infra_retry_comment_was_not_swept_up():
+    """The top-level setting really does count retries. It must keep saying so.
+
+    This is the guard against over-applying the correction: a rename that hit
+    both would swap a true comment for a false one, and nothing else in the
+    suite would notice.
+    """
+    infra = [(n, c) for n, _, _, c in _lines(INFRA_BUDGET) if c.strip()]
+    assert infra, "no commented top-level max_retries found"
+    for name, comment in infra:
+        assert any(p in comment for p in NAMES_INFRA_RETRIES), f"{name}: {comment}"


### PR DESCRIPTION
Eleven experiment files carried a comment promising the one thing the value cannot do:

```yaml
qa:
  enabled: true
  max_retries: 1              # max regeneration attempts on QA failure
```

`qa.max_retries` is a budget of **answers**, not of extra tries. `_run_task_with_qa` raises `qa_attempts` once per answer it has reviewed and found wanting, then breaks as soon as that count reaches the setting — so N produces N answers and buys **N-1** replacements. At `1`: one answer, reviewed, marked `qa_failed`, never replaced.

**#336 already fixed the runtime side** — the arithmetic is pinned against the shipped loop, the misleading banner is gone, and `WHAT_THE_SETTING_DOES` reads *"how many answers it may produce in all"*. The config comments were left saying the opposite, and a comment is what a reader reaches for first.

## What changed

```diff
-    max_retries: 1              # max regeneration attempts on QA failure
+    max_retries: 1              # answers in all, not extra tries: 1 regenerates nothing
```

Eleven files, one line each. **No value changes, so no run changes.** What changes is what a reader concludes from the file.

## What was deliberately left alone

**The top-level `max_retries`.** It really does count retries — infra retries after an API error, a timeout, or a Python execution error — and its comment is correct. Fourteen files carry it, eleven in English and **three in Korean** (`# 태스크 내 인프라 리트라이 …`). A sweep that renamed both would replace a true comment with a false one, so a test asserts all fourteen still name infra retries. The Korean three are the reason that test is bilingual: the first version asserted an English phrase and failed on `exp997`.

**The eighteen silent blocks.** They carry the same value with no comment at all, in files whose whole `qa:` block is comment-free. Saying nothing is not a false claim, and adding a sentence to eighteen files to fix a problem none of them has is churn. The count is pinned so that adding to them later is a visible decision rather than a side effect.

**The meaning of the setting.** Making `max_retries: N` buy N replacements would hand each of twenty-nine self-review blocks an extra paid answer. That is the owner's call, not a side effect of correcting a comment.

## The rule is derived, not restated

The test does not hardcode "one buys no replacement". It reads the shipped description and derives it:

```python
described = WHAT_THE_SETTING_DOES["condition_a.qa.max_retries"]
assert "in all" in described  # answers in all, so replacements = value - 1
```

Change the semantics and the premise fails loudly, instead of the rule silently pointing at the wrong values.

## The word list does not work

Banning `regenerat` / `retr` / `attempt` was the first attempt and it fails on its own fix: **"1 regenerates nothing" contains "regenerat"**, so the ban that catches the lie catches the correction for it too — all eleven corrected files failed. What separates the false comment from the true one is the **claim**, not the vocabulary, so the check is for the denial rather than against the word. Written into the file so it is not re-tried.

## Negative controls — 7 reversions, 7 caught

| mutation | |
|---|---|
| restore `# max regeneration attempts on QA failure` | caught |
| delete the comment instead of fixing it | caught |
| keep "answers in all", drop what it buys | caught |
| rename the **English** infra comment too | caught |
| rename the **Korean** infra comment too | caught |
| add a comment to one of the eighteen silent blocks | caught |
| change the shipped description of the setting | caught |

## Verification

- full backend suite **6,930 passed, 7 skipped, 0 failed** (13m57s)
- the delta is exactly this change: **6,935 selected with the new file, 6,930 without**
- `mypy core/ --ignore-missing-imports` → **174 errors, baseline unchanged**
- `npm run test:aggregate` **232 pass / 0 fail / 1 skip**; `npm run build` ok
- #336's own suite still **15/15**; its docstring named the comment this PR removes and is updated to point here

## Grader source hash

`batch-runner/experiments/*.yaml` is **not** an input to `compute_grader_source_hash` — it hashes `step8_grade.py`, `core/**/*.py`, the grade schema, `requirements.txt`, the download script, the prompt template and the grading config. `step8_grade.py` takes `args.experiment_yaml_name`, a name rather than content. **No grading fingerprint moves**, no sha pin names any of the eleven files, and no Grade Pipeline is in flight regardless (latest completed 08:22:14Z).
