### PR TITLE
feat(azure): measure the Foundry project roles instead of guessing at the 403

### DIFF
--- a/.github/workflows/azure-rbac-diagnostic.yml
+++ b/.github/workflows/azure-rbac-diagnostic.yml
@@ -1,0 +1,111 @@
+# Read which roles the CI identity holds on the Foundry project, and say what is
+# missing, without ever naming the resource.
+#
+# Why a separate workflow: two dispatches of the Code Interpreter arm were
+# refused on every call with http 403 while the token check ahead of them
+# passed. The direct-v1 arm, run by this same identity in the same tenant and
+# subscription and asking for the same token audience, was served. That makes
+# the gap an authorization one at the Foundry project, and nothing in this
+# repository could measure it -- there is no infrastructure code and no role
+# tooling anywhere in it.
+#
+# Every call this makes is an ARM control-plane READ. It creates nothing,
+# changes nothing, and calls no model endpoint, so running it cannot reproduce
+# the refusal it exists to explain and cannot spend anything.
+name: Azure Foundry RBAC Diagnostic
+
+on:
+  workflow_dispatch:
+    inputs:
+      emit_json:
+        description: Emit the redacted report as JSON instead of prose
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: azure-foundry-rbac-diagnostic
+  cancel-in-progress: false
+
+jobs:
+  diagnose:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      # The same pinned action, client id, tenant and subscription the paid
+      # runs authenticate with. Reading a different identity's roles would
+      # answer a question nobody asked.
+      - name: Azure Login (OIDC)
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify Azure OIDC session identity
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_AI_EXPECTED_CLIENT_ID: ${{ vars.AZURE_AI_EXPECTED_CLIENT_ID }}
+          AZURE_AI_EXPECTED_TENANT_ID: ${{ vars.AZURE_AI_EXPECTED_TENANT_ID }}
+          AZURE_AI_EXPECTED_SUBSCRIPTION_ID: ${{ vars.AZURE_AI_EXPECTED_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python3 scripts/azure_oidc_identity_preflight.py --verify-session
+
+      # No model credential is passed in. If one were, a future edit could turn
+      # this read-only job into one that spends, and nothing here would notice.
+      - name: Read the roles this identity holds on the project
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_AI_EXPECTED_PROJECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_PROJECT_ACCOUNT }}
+          AZURE_AI_EXPECTED_PROJECT_NAME: ${{ vars.AZURE_AI_EXPECTED_PROJECT_NAME }}
+          AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
+          EMIT_JSON: ${{ inputs.emit_json }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          ARGS=()
+          if [ "${EMIT_JSON}" = "true" ]; then
+            ARGS+=(--json)
+          fi
+          # Deliberately not --require-project-role: reporting that the role is
+          # absent is the point of the run, not a failure of it.
+          python3 scripts/azure_rbac_diagnostic.py "${ARGS[@]}"
+
+      - name: Confirm no model call was made
+        if: always()
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          # A grep, not a promise. If a future edit reaches for the inference
+          # path from this diagnostic, this step is what says so.
+          if grep -nE 'responses\.create|chat\.completions|AzureOpenAI|llm_client|code_interpreter' \
+              scripts/azure_rbac_diagnostic.py; then
+            echo "FATAL: the diagnostic references a model call path"
+            exit 1
+          fi
+          echo "control-plane-reads-only=confirmed"

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/analyze_variance.py
 !batch-runner/scripts/stage3_partial_inventory.py
 !batch-runner/scripts/check_grader_hash_freeze.py
+!batch-runner/scripts/azure_rbac_diagnostic.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/batch-runner/scripts/azure_rbac_diagnostic.py
+++ b/batch-runner/scripts/azure_rbac_diagnostic.py
@@ -1,0 +1,907 @@
+#!/usr/bin/env python3
+"""Report the roles the CI identity holds on the Foundry project, without naming it.
+
+Why this exists
+---------------
+Two dispatches of the Code Interpreter arm were refused on every call with
+http 403 while the token check ahead of them passed. The direct-v1 arm, run by
+the same service principal in the same tenant and subscription and asking for
+the same token audience, was served. The only variable left is the resource the
+call is addressed to, which makes this an authorization gap at the Foundry
+project rather than an authentication one.
+
+Nothing in this repository could measure that: there is no infrastructure code
+and no role tooling of any kind. This script closes that gap.
+
+What it does and does not do
+----------------------------
+Every call it makes is an ARM control-plane READ. It never creates, updates or
+deletes anything, and it never calls a model endpoint, so running it cannot
+re-trigger the refusal that made it necessary and cannot spend money.
+
+What it prints
+--------------
+Role display names, role definition GUIDs and the SHAPE of each scope. Those are
+public Azure-wide identifiers. It never prints the subscription id, the resource
+group, the Foundry account name, the project name, the principal object id or
+the tenant id, and it refuses to print at all if a known secret value survives
+into the rendered report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess  # nosec B404 - control-plane reads via the pinned az CLI
+import sys
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from typing import Any
+
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPOSITORY_ROOT not in sys.path:
+    sys.path.insert(0, REPOSITORY_ROOT)
+
+from core.azure_ai_clients import (  # noqa: E402
+    PROJECT_ENDPOINT_ENV,
+    EndpointKind,
+    classify_endpoint,
+)
+
+# The action that decides whether the principal can fix this itself.
+ROLE_ASSIGNMENT_WRITE = "Microsoft.Authorization/roleAssignments/write"
+
+# The provider path a Foundry project lives under.
+FOUNDRY_PROVIDER = "Microsoft.CognitiveServices"
+FOUNDRY_ACCOUNT_TYPE = f"{FOUNDRY_PROVIDER}/accounts"
+
+
+@dataclass(frozen=True)
+class RoleCandidate:
+    """One rung of the least-privilege ladder, quoted from the Microsoft doc."""
+
+    name: str
+    definition_id: str
+    why: str
+
+
+# Ordered least privilege first. Ask for the first rung; only if a run still
+# refuses does the second become justified. Both are assigned at PROJECT scope,
+# never at the account above it.
+#
+# Source: learn.microsoft.com/en-us/azure/ai-foundry/concepts/rbac-azure-ai-foundry
+# The roles were renamed (Azure AI User became Foundry User and so on) but the
+# definition ids did not change, so the ids are what this script matches on.
+LEAST_PRIVILEGE_LADDER: tuple[RoleCandidate, ...] = (
+    RoleCandidate(
+        name="Foundry Agent Consumer",
+        definition_id="eed3b665-ab3a-47b6-8f48-c9382fb1dad6",
+        why=(
+            "the documented role for an identity that only calls agents, the "
+            "Responses API named as the example, without creating or "
+            "modifying them"
+        ),
+    ),
+    RoleCandidate(
+        name="Foundry User",
+        definition_id="53ca6127-db72-4b80-b1b0-d745d6d5456d",
+        why=(
+            "the next rung up, justified only if a run still refuses after the "
+            "consumer role has propagated"
+        ),
+    ),
+)
+
+# Roles the same doc tells you not to reach for here. Recorded so that a future
+# reader does not rediscover them as plausible.
+FORBIDDEN_ROLE_IDS: Mapping[str, str] = {
+    "25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68": (
+        "Cognitive Services Contributor carries no data actions at all, so it "
+        "cannot authorize a token-based inference call"
+    ),
+    "64702f94-c441-49e6-a78b-ef80e0188fee": (
+        "Azure AI Developer is not the Foundry project access path"
+    ),
+}
+FORBIDDEN_ROLE_NAME_PREFIX = "Cognitive Services"
+
+
+# -------------------------------------------------------------------------
+# Scope shapes
+# -------------------------------------------------------------------------
+
+_SCOPE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "foundry-project",
+        re.compile(
+            r"\A/subscriptions/[^/]+/resourceGroups/[^/]+/providers/"
+            r"Microsoft\.CognitiveServices/accounts/[^/]+/projects/[^/]+\Z",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "foundry-account",
+        re.compile(
+            r"\A/subscriptions/[^/]+/resourceGroups/[^/]+/providers/"
+            r"Microsoft\.CognitiveServices/accounts/[^/]+\Z",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "other-resource",
+        re.compile(
+            r"\A/subscriptions/[^/]+/resourceGroups/[^/]+/providers/.+\Z",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "resource-group",
+        re.compile(r"\A/subscriptions/[^/]+/resourceGroups/[^/]+\Z", re.IGNORECASE),
+    ),
+    ("subscription", re.compile(r"\A/subscriptions/[^/]+\Z", re.IGNORECASE)),
+    (
+        "management-group",
+        re.compile(
+            r"\A/providers/Microsoft\.Management/managementGroups/[^/]+\Z",
+            re.IGNORECASE,
+        ),
+    ),
+    ("tenant-root", re.compile(r"\A/\Z")),
+)
+
+
+def scope_shape(scope: str) -> str:
+    """Say what KIND of thing a scope is, never which one.
+
+    A reader needs to know whether a role sits on the project, on the account
+    above it or on the whole subscription, because that is what decides whether
+    it is least privilege. None of that requires the name.
+    """
+    if not isinstance(scope, str) or not scope.strip():
+        return "unreadable"
+    candidate = scope.strip().rstrip("/") or "/"
+    for shape, pattern in _SCOPE_PATTERNS:
+        if pattern.fullmatch(candidate):
+            return shape
+    return "unrecognised"
+
+
+def project_scope(
+    *, subscription_id: str, resource_group: str, account: str, project: str
+) -> str:
+    """Build the project-scope resource id the role has to be assigned at."""
+    for label, value in (
+        ("subscription id", subscription_id),
+        ("resource group", resource_group),
+        ("account", account),
+        ("project", project),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{label} is required to build a project scope")
+        if "/" in value:
+            raise ValueError(f"{label} must not contain a path separator")
+    return (
+        f"/subscriptions/{subscription_id.strip()}"
+        f"/resourceGroups/{resource_group.strip()}"
+        f"/providers/{FOUNDRY_ACCOUNT_TYPE}/{account.strip()}"
+        f"/projects/{project.strip()}"
+    )
+
+
+def resource_group_of(resource_id: str) -> str | None:
+    """Pull the resource group out of an ARM resource id, or say it is absent."""
+    if not isinstance(resource_id, str):
+        return None
+    match = re.search(r"/resourceGroups/([^/]+)", resource_id, re.IGNORECASE)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+# -------------------------------------------------------------------------
+# Role definition permissions
+# -------------------------------------------------------------------------
+
+
+def _action_matches(pattern: str, action: str) -> bool:
+    """Azure action globbing: only ``*`` is special, and matching is caseless."""
+    if not isinstance(pattern, str):
+        return False
+    expression = "".join(
+        ".*" if part == "*" else re.escape(part)
+        for part in re.split(r"(\*)", pattern)
+    )
+    return re.fullmatch(expression, action, re.IGNORECASE) is not None
+
+
+def permits_role_assignment(definitions: Iterable[Mapping[str, Any]]) -> bool:
+    """Whether any of these role definitions grants roleAssignments/write.
+
+    Evaluated the way Azure evaluates it: an action is granted by a permission
+    block when ``actions`` matches it and ``notActions`` does not.
+    """
+    for definition in definitions:
+        if not isinstance(definition, Mapping):
+            continue
+        for permission in definition.get("permissions") or ():
+            if not isinstance(permission, Mapping):
+                continue
+            allowed = any(
+                _action_matches(entry, ROLE_ASSIGNMENT_WRITE)
+                for entry in permission.get("actions") or ()
+            )
+            if not allowed:
+                continue
+            denied = any(
+                _action_matches(entry, ROLE_ASSIGNMENT_WRITE)
+                for entry in permission.get("notActions") or ()
+            )
+            if not denied:
+                return True
+    return False
+
+
+# -------------------------------------------------------------------------
+# Assignments
+# -------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HeldRole:
+    """One role assignment, reduced to what can be said out loud."""
+
+    role_name: str
+    definition_id: str
+    scope_shape: str
+    covers_the_project: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "role_name": self.role_name,
+            "role_definition_id": self.definition_id,
+            "scope_shape": self.scope_shape,
+            "covers_the_project": self.covers_the_project,
+        }
+
+
+def _definition_id_of(assignment: Mapping[str, Any]) -> str:
+    raw = assignment.get("roleDefinitionId")
+    if not isinstance(raw, str):
+        return ""
+    return raw.rstrip("/").rsplit("/", 1)[-1].lower()
+
+
+def _covers(scope: str, target_scope: str) -> bool:
+    """Whether a role at ``scope`` reaches ``target_scope``.
+
+    Azure inherits downwards, so a role on the subscription reaches the project
+    under it. Compared caselessly on whole path segments, so that an account
+    named as a prefix of another cannot be mistaken for it.
+    """
+    if not isinstance(scope, str) or not scope.strip():
+        return False
+    held = scope.strip().rstrip("/").lower() or "/"
+    target = target_scope.strip().rstrip("/").lower()
+    if held == "/":
+        return True
+    return target == held or target.startswith(f"{held}/")
+
+
+def summarize_assignments(
+    assignments: Iterable[Mapping[str, Any]], *, target_scope: str
+) -> tuple[HeldRole, ...]:
+    """Reduce raw ``az role assignment list`` output to sayable records."""
+    seen: set[tuple[str, str, str]] = set()
+    held: list[HeldRole] = []
+    for assignment in assignments:
+        if not isinstance(assignment, Mapping):
+            continue
+        scope = assignment.get("scope")
+        scope_text = scope if isinstance(scope, str) else ""
+        name = assignment.get("roleDefinitionName")
+        role_name = name if isinstance(name, str) and name.strip() else "unnamed"
+        record = HeldRole(
+            role_name=role_name,
+            definition_id=_definition_id_of(assignment),
+            scope_shape=scope_shape(scope_text),
+            covers_the_project=_covers(scope_text, target_scope),
+        )
+        key = (record.role_name, record.definition_id, record.scope_shape)
+        if key in seen:
+            continue
+        seen.add(key)
+        held.append(record)
+    return tuple(
+        sorted(held, key=lambda item: (item.role_name, item.scope_shape))
+    )
+
+
+def missing_rungs(held: Sequence[HeldRole]) -> tuple[RoleCandidate, ...]:
+    """Which rungs of the ladder are not already covering the project."""
+    have = {
+        role.definition_id
+        for role in held
+        if role.covers_the_project and role.definition_id
+    }
+    return tuple(rung for rung in LEAST_PRIVILEGE_LADDER if rung.definition_id not in have)
+
+
+def forbidden_roles_held(held: Sequence[HeldRole]) -> tuple[str, ...]:
+    """Roles the doc says are the wrong instrument for this, if any are held."""
+    found: list[str] = []
+    for role in held:
+        reason = FORBIDDEN_ROLE_IDS.get(role.definition_id)
+        if reason is None and role.role_name.startswith(FORBIDDEN_ROLE_NAME_PREFIX):
+            reason = (
+                "roles beginning 'Cognitive Services' address an AI Services "
+                "resource directly and do not apply to Foundry"
+            )
+        if reason is not None:
+            found.append(f"{role.role_name}: {reason}")
+    return tuple(sorted(set(found)))
+
+
+# -------------------------------------------------------------------------
+# Redaction
+# -------------------------------------------------------------------------
+
+SENSITIVE_ENV: tuple[tuple[str, str], ...] = (
+    ("AZURE_SUBSCRIPTION_ID", "<subscriptionId>"),
+    ("AZURE_TENANT_ID", "<tenantId>"),
+    ("AZURE_CLIENT_ID", "<principalId>"),
+    ("AZURE_AI_EXPECTED_SUBSCRIPTION_ID", "<subscriptionId>"),
+    ("AZURE_AI_EXPECTED_TENANT_ID", "<tenantId>"),
+    ("AZURE_AI_EXPECTED_CLIENT_ID", "<principalId>"),
+    ("AZURE_AI_EXPECTED_PROJECT_ACCOUNT", "<accountName>"),
+    ("AZURE_AI_EXPECTED_PROJECT_NAME", "<projectName>"),
+    ("AZURE_AI_EXPECTED_DIRECT_ACCOUNT", "<accountName>"),
+    (PROJECT_ENDPOINT_ENV, "<projectEndpoint>"),
+    ("AZURE_OPENAI_V1_ENDPOINT", "<directEndpoint>"),
+    ("AZURE_OPENAI_ENDPOINT", "<directEndpoint>"),
+)
+
+# Values this short are ordinary words. Redacting them would corrupt the report
+# without protecting anything, so they are excluded from the leak check and the
+# caller is told the value was too short to defend.
+MINIMUM_REDACTABLE_LENGTH = 6
+
+
+def collect_secrets(
+    env: Mapping[str, str], *, extra: Mapping[str, str] | None = None
+) -> dict[str, str]:
+    """Every value that must not survive into the report, and its placeholder."""
+    secrets: dict[str, str] = {}
+    for name, placeholder in SENSITIVE_ENV:
+        value = env.get(name, "")
+        if isinstance(value, str) and len(value.strip()) >= MINIMUM_REDACTABLE_LENGTH:
+            secrets[value.strip()] = placeholder
+    for value, placeholder in (extra or {}).items():
+        if isinstance(value, str) and len(value.strip()) >= MINIMUM_REDACTABLE_LENGTH:
+            secrets[value.strip()] = placeholder
+    return secrets
+
+
+def sensitive_values(
+    env: Mapping[str, str], *, extra: Mapping[str, str] | None = None
+) -> frozenset[str]:
+    """The same values with no length floor, lowercased, for detection only.
+
+    Substitution needs the floor, because replacing a three-letter resource
+    name everywhere would corrupt ordinary words. Detection does not: a field
+    this repository copies out of Azure verbatim can simply be withheld when it
+    contains one, which is safe at any length.
+    """
+    found: set[str] = set()
+    for name, _ in SENSITIVE_ENV:
+        value = env.get(name, "")
+        if isinstance(value, str) and value.strip():
+            found.add(value.strip().lower())
+    for value in extra or {}:
+        if isinstance(value, str) and value.strip():
+            found.add(value.strip().lower())
+    return frozenset(found)
+
+
+# A role display name is the one field Azure hands back as free text a human
+# wrote. Built-in names are tame; a custom role can be called anything, and
+# people do name custom roles after the resource they apply to.
+WITHHELD_ROLE_NAME = "custom role (name withheld)"
+_SAFE_ROLE_NAME = re.compile(r"\A[A-Za-z0-9 ()./_-]{1,64}\Z")
+
+
+def safe_role_name(name: str, values: frozenset[str]) -> str:
+    """Keep a role name only when it cannot be carrying an identifier."""
+    if not isinstance(name, str) or not name.strip():
+        return "unnamed"
+    candidate = name.strip()
+    if _SAFE_ROLE_NAME.fullmatch(candidate) is None:
+        return WITHHELD_ROLE_NAME
+    lowered = candidate.lower()
+    if any(value and value in lowered for value in values):
+        return WITHHELD_ROLE_NAME
+    return candidate
+
+
+def redact(text: str, secrets: Mapping[str, str]) -> str:
+    """Replace every known secret value with its placeholder, longest first."""
+    result = text
+    for value in sorted(secrets, key=len, reverse=True):
+        if value:
+            result = re.sub(re.escape(value), secrets[value], result, flags=re.IGNORECASE)
+    return result
+
+
+def leaked_placeholders(text: str, secrets: Mapping[str, str]) -> tuple[str, ...]:
+    """Which secret values survived redaction. Empty is the only safe answer."""
+    lowered = text.lower()
+    return tuple(
+        sorted(
+            {
+                secrets[value]
+                for value in secrets
+                if value and value.lower() in lowered
+            }
+        )
+    )
+
+
+# -------------------------------------------------------------------------
+# The az control-plane reads
+# -------------------------------------------------------------------------
+
+
+class AzureReadFailure(RuntimeError):
+    """An az read failed. Carries a classification, never the provider text."""
+
+    def __init__(self, what: str, *, exit_code: int | None) -> None:
+        self.what = what
+        self.exit_code = exit_code
+        detail = "no exit code" if exit_code is None else f"exit {exit_code}"
+        super().__init__(f"{what} could not be read ({detail})")
+
+
+AzRunner = Callable[[Sequence[str]], Any]
+
+
+def _default_runner(arguments: Sequence[str]) -> Any:
+    """Run one ``az`` read and parse its JSON.
+
+    The subprocess output is parsed, never echoed. An az error message can name
+    the resource it failed on, which is precisely what must not reach a log.
+    """
+    completed = subprocess.run(  # nosec B603 B607 - fixed argv, no shell
+        ["az", *arguments, "--only-show-errors", "--output", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    if completed.returncode != 0:
+        raise AzureReadFailure(
+            " ".join(arguments[:2]), exit_code=completed.returncode
+        )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        return []
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        raise AzureReadFailure(" ".join(arguments[:2]), exit_code=None) from None
+
+
+def _as_mappings(payload: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, Mapping)]
+
+
+def resolve_resource_group(
+    runner: AzRunner, *, account: str, subscription_id: str
+) -> str:
+    """Ask Azure where the Foundry account lives.
+
+    No secret and no repository variable records the resource group, so it has
+    to come from Azure itself. Failing to read it is a finding in its own right:
+    it means the principal has no control-plane read on the account.
+    """
+    payload = runner(
+        [
+            "resource",
+            "list",
+            "--name",
+            account,
+            "--resource-type",
+            FOUNDRY_ACCOUNT_TYPE,
+            "--subscription",
+            subscription_id,
+        ]
+    )
+    for resource in _as_mappings(payload):
+        group = resource.get("resourceGroup")
+        if isinstance(group, str) and group.strip():
+            return group.strip()
+        derived = resource_group_of(str(resource.get("id", "")))
+        if derived:
+            return derived
+    raise AzureReadFailure("the Foundry account", exit_code=None)
+
+
+def read_assignments(
+    runner: AzRunner, *, principal_id: str, scope: str
+) -> list[Mapping[str, Any]]:
+    """Every role assignment reaching the project, inherited ones included."""
+    payload = runner(
+        [
+            "role",
+            "assignment",
+            "list",
+            "--assignee",
+            principal_id,
+            "--scope",
+            scope,
+            "--include-inherited",
+            "--include-groups",
+        ]
+    )
+    return _as_mappings(payload)
+
+
+def read_definitions(
+    runner: AzRunner, *, names: Sequence[str], scope: str
+) -> list[Mapping[str, Any]]:
+    """Fetch the permission blocks behind the roles the principal holds."""
+    definitions: list[Mapping[str, Any]] = []
+    for name in names:
+        payload = runner(
+            ["role", "definition", "list", "--name", name, "--scope", scope]
+        )
+        definitions.extend(_as_mappings(payload))
+    return definitions
+
+
+# -------------------------------------------------------------------------
+# The diagnosis
+# -------------------------------------------------------------------------
+
+
+def _remediation(rung: RoleCandidate) -> list[str]:
+    """The exact command an owner runs, with every identifier a placeholder."""
+    return [
+        'PROJECT_SCOPE="/subscriptions/<subscriptionId>/resourceGroups/'
+        "<resourceGroup>/providers/Microsoft.CognitiveServices/accounts/"
+        '<accountName>/projects/<projectName>"',
+        "az role assignment create \\",
+        '    --assignee-object-id "<principalId>" \\',
+        "    --assignee-principal-type ServicePrincipal \\",
+        f'    --role "{rung.definition_id}" \\',
+        '    --scope "$PROJECT_SCOPE"',
+    ]
+
+
+def diagnose(
+    env: Mapping[str, str], *, runner: AzRunner
+) -> dict[str, Any]:
+    """Read the roles, decide what is missing, and say who has to grant it."""
+    endpoint_value = env.get(PROJECT_ENDPOINT_ENV, "").strip()
+    if not endpoint_value:
+        raise ValueError(f"{PROJECT_ENDPOINT_ENV} is required")
+    endpoint = classify_endpoint(endpoint_value)
+    if endpoint.kind is not EndpointKind.PROJECT or not endpoint.project:
+        raise ValueError(
+            f"{PROJECT_ENDPOINT_ENV} is not a Foundry project endpoint, so "
+            "there is no project scope to read roles at"
+        )
+
+    subscription_id = env.get("AZURE_SUBSCRIPTION_ID", "").strip()
+    principal_id = env.get("AZURE_CLIENT_ID", "").strip()
+    if not subscription_id:
+        raise ValueError("AZURE_SUBSCRIPTION_ID is required")
+    if not principal_id:
+        raise ValueError("AZURE_CLIENT_ID is required")
+
+    problems: list[str] = []
+    report: dict[str, Any] = {
+        "route_profile": "project-ci",
+        "endpoint_kind": endpoint.kind.value,
+        "target_scope_shape": "foundry-project",
+        "roles_held": [],
+        "roles_reaching_the_project": [],
+        "missing_least_privilege_roles": [
+            {"name": rung.name, "role_definition_id": rung.definition_id}
+            for rung in LEAST_PRIVILEGE_LADDER
+        ],
+        "forbidden_roles_held": [],
+        "principal_can_assign_roles": None,
+        "read_failures": [],
+        "verdict": "unmeasured",
+        # The account and project names live inside the endpoint secret rather
+        # than in a variable of their own, so redaction of the whole endpoint
+        # string would not catch either of them on its own.
+        "secret_values": {
+            endpoint.account: "<accountName>",
+            endpoint.project: "<projectName>",
+        },
+    }
+
+    try:
+        resource_group = resolve_resource_group(
+            runner, account=endpoint.account, subscription_id=subscription_id
+        )
+    except AzureReadFailure as failure:
+        problems.append(
+            "could not resolve the Foundry account through the control plane, "
+            "so the project scope could not be built. That alone means this "
+            f"identity has no reader on the account ({failure.what})"
+        )
+        report["read_failures"] = problems
+        report["verdict"] = "cannot_read_control_plane"
+        return report
+
+    scope = project_scope(
+        subscription_id=subscription_id,
+        resource_group=resource_group,
+        account=endpoint.account,
+        project=endpoint.project,
+    )
+    # The resolved group joins the redaction set: it was read from Azure, not
+    # from the environment, so collect_secrets could not have known it.
+    report["secret_values"][resource_group] = "<resourceGroup>"
+    values = sensitive_values(env, extra=report["secret_values"])
+
+    try:
+        assignments = read_assignments(
+            runner, principal_id=principal_id, scope=scope
+        )
+    except AzureReadFailure as failure:
+        problems.append(
+            "could not list this identity's own role assignments at the "
+            "project scope, which needs Microsoft.Authorization/"
+            f"roleAssignments/read ({failure.what})"
+        )
+        report["read_failures"] = problems
+        report["verdict"] = "cannot_read_role_assignments"
+        return report
+
+    # Two views of the same assignments. The raw names are what az has to be
+    # asked about; only the sanitised ones are ever written down.
+    raw = summarize_assignments(assignments, target_scope=scope)
+    held = tuple(
+        replace(role, role_name=safe_role_name(role.role_name, values))
+        for role in raw
+    )
+    covering = tuple(role for role in held if role.covers_the_project)
+    report["roles_held"] = [role.as_dict() for role in held]
+    report["roles_reaching_the_project"] = [role.as_dict() for role in covering]
+    report["forbidden_roles_held"] = list(forbidden_roles_held(held))
+
+    missing = missing_rungs(held)
+    report["missing_least_privilege_roles"] = [
+        {"name": rung.name, "role_definition_id": rung.definition_id}
+        for rung in missing
+    ]
+
+    try:
+        definitions = read_definitions(
+            runner,
+            names=sorted(
+                {
+                    role.role_name
+                    for role in raw
+                    if role.covers_the_project and role.role_name != "unnamed"
+                }
+            ),
+            scope=scope,
+        )
+    except AzureReadFailure as failure:
+        problems.append(
+            "could not read the permissions behind the roles this identity "
+            "holds, so whether it can assign a role is unmeasured "
+            f"({failure.what})"
+        )
+    else:
+        report["principal_can_assign_roles"] = permits_role_assignment(definitions)
+
+    report["read_failures"] = problems
+
+    if not missing:
+        report["verdict"] = "least_privilege_role_already_held"
+    elif report["principal_can_assign_roles"] is True:
+        report["verdict"] = "role_missing_and_this_identity_can_grant_it"
+    elif report["principal_can_assign_roles"] is False:
+        report["verdict"] = "role_missing_and_an_owner_must_grant_it"
+    else:
+        report["verdict"] = "role_missing_and_the_grantor_is_unmeasured"
+
+    return report
+
+
+# -------------------------------------------------------------------------
+# Rendering
+# -------------------------------------------------------------------------
+
+_VERDICT_LINES: Mapping[str, str] = {
+    "least_privilege_role_already_held": (
+        "A least-privilege role already reaches the project. If a call is "
+        "still refused, the cause is not this role assignment."
+    ),
+    "role_missing_and_this_identity_can_grant_it": (
+        "The role is missing and this identity holds roleAssignments/write, so "
+        "it can assign the role itself at project scope."
+    ),
+    "role_missing_and_an_owner_must_grant_it": (
+        "The role is missing and this identity cannot assign roles. An Azure "
+        "Owner on the account or project has to run the command below."
+    ),
+    "role_missing_and_the_grantor_is_unmeasured": (
+        "The role is missing. Whether this identity could assign it was not "
+        "measurable, so treat it as an owner action."
+    ),
+    "cannot_read_control_plane": (
+        "This identity cannot read the Foundry account through the control "
+        "plane, so no role could be read. An owner has to look."
+    ),
+    "cannot_read_role_assignments": (
+        "This identity cannot read its own role assignments at the project "
+        "scope. An owner has to look."
+    ),
+    "unmeasured": "Nothing was measured.",
+}
+
+
+def render(report: Mapping[str, Any]) -> str:
+    """Turn the diagnosis into text a public log can carry."""
+    lines: list[str] = [
+        "Azure Foundry project RBAC diagnostic (control-plane reads only)",
+        "",
+        f"route profile        : {report.get('route_profile')}",
+        f"endpoint kind        : {report.get('endpoint_kind')}",
+        f"target scope shape   : {report.get('target_scope_shape')}",
+        f"verdict              : {report.get('verdict')}",
+        "",
+        _VERDICT_LINES.get(str(report.get("verdict")), _VERDICT_LINES["unmeasured"]),
+        "",
+    ]
+
+    held = list(report.get("roles_held") or ())
+    if held:
+        lines.append(f"roles this identity holds ({len(held)}):")
+        for role in held:
+            reach = "reaches the project" if role.get("covers_the_project") else "does not reach it"
+            lines.append(
+                f"  - {role.get('role_name')} "
+                f"[{role.get('role_definition_id')}] "
+                f"at {role.get('scope_shape')}, {reach}"
+            )
+    else:
+        lines.append("roles this identity holds: none were returned")
+    lines.append("")
+
+    can_assign = report.get("principal_can_assign_roles")
+    lines.append(
+        "can this identity assign roles: "
+        + {True: "yes", False: "no", None: "unmeasured"}[can_assign]
+    )
+
+    forbidden = list(report.get("forbidden_roles_held") or ())
+    if forbidden:
+        lines.append("")
+        lines.append("roles held that are the wrong instrument here:")
+        lines.extend(f"  - {entry}" for entry in forbidden)
+
+    failures = list(report.get("read_failures") or ())
+    if failures:
+        lines.append("")
+        lines.append("reads that did not succeed:")
+        lines.extend(f"  - {entry}" for entry in failures)
+
+    missing = list(report.get("missing_least_privilege_roles") or ())
+    if missing:
+        lines.append("")
+        lines.append("least privilege ladder, first rung first:")
+        for rung in missing:
+            name = str(rung.get("name", ""))
+            why = next(
+                (
+                    candidate.why
+                    for candidate in LEAST_PRIVILEGE_LADDER
+                    if candidate.name == name
+                ),
+                "",
+            )
+            lines.append(f"  - {name} [{rung.get('role_definition_id')}]: {why}")
+        lines.append("")
+        lines.append(
+            "Assign the first rung only. The portal can assign it at account "
+            "scope alone, so project scope needs the CLI:"
+        )
+        first = next(
+            (
+                candidate
+                for candidate in LEAST_PRIVILEGE_LADDER
+                if candidate.name == str(missing[0].get("name", ""))
+            ),
+            LEAST_PRIVILEGE_LADDER[0],
+        )
+        lines.append("")
+        lines.extend(f"  {line}" for line in _remediation(first))
+
+    lines.append("")
+    lines.append(
+        "This diagnostic made control-plane reads only. It called no model "
+        "endpoint, so it neither reproduces the http 403 nor spends anything."
+    )
+    return "\n".join(lines)
+
+
+# -------------------------------------------------------------------------
+# CLI
+# -------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the redacted report as JSON instead of prose",
+    )
+    parser.add_argument(
+        "--require-project-role",
+        action="store_true",
+        help=(
+            "Exit non-zero unless a least-privilege role already reaches the "
+            "project. Off by default so that reporting a gap is not an error"
+        ),
+    )
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    runner: AzRunner | None = None,
+    stream: Any = None,
+) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    values = os.environ if env is None else env
+    out = sys.stdout if stream is None else stream
+
+    try:
+        report = diagnose(values, runner=runner or _default_runner)
+    except ValueError as exc:
+        # Safe to print: these messages name environment variables, not values.
+        print(f"azure rbac diagnostic refused to run: {exc}", file=sys.stderr)
+        return 2
+    except Exception:
+        print("azure rbac diagnostic failed", file=sys.stderr)
+        return 2
+
+    extra = dict(report.pop("secret_values", {}) or {})
+    secrets = collect_secrets(values, extra=extra)
+    body = json.dumps(report, indent=2, sort_keys=True) if args.json else render(report)
+    body = redact(body, secrets)
+
+    survivors = leaked_placeholders(body, secrets)
+    if survivors:
+        # Fail closed. A report that still carries an identifier is worse than
+        # no report, because the log is public and cannot be unpublished.
+        print(
+            "azure rbac diagnostic withheld its report: redaction did not "
+            f"clear {len(survivors)} identifier(s)",
+            file=sys.stderr,
+        )
+        return 3
+
+    print(body, file=out)
+
+    if args.require_project_role and report["verdict"] != "least_privilege_role_already_held":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/batch-runner/tests/test_azure_rbac_diagnostic.py
+++ b/batch-runner/tests/test_azure_rbac_diagnostic.py
@@ -1,0 +1,851 @@
+"""What the RBAC diagnostic may say, and what it must never say.
+
+The second half matters more than the first. This job runs against a public
+repository, so a report that carries a subscription id or a project name cannot
+be unpublished. The tests below therefore check the redaction from both
+directions: that a real identifier never survives, and that the guard which
+enforces that does not fire on a report which never contained one.
+"""
+
+import importlib.util
+import io
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+BATCH_RUNNER = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = BATCH_RUNNER.parent
+SCRIPT = BATCH_RUNNER / "scripts" / "azure_rbac_diagnostic.py"
+WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "azure-rbac-diagnostic.yml"
+
+SPEC = importlib.util.spec_from_file_location("azure_rbac_diagnostic", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+diagnostic = importlib.util.module_from_spec(SPEC)
+sys.modules["azure_rbac_diagnostic"] = diagnostic
+SPEC.loader.exec_module(diagnostic)
+
+
+# Deliberately distinctive stand-ins. Every one is long enough to be redacted
+# and unusual enough that finding it in an output is unambiguous.
+SUBSCRIPTION = "11111111-2222-3333-4444-555555555555"
+TENANT = "66666666-7777-8888-9999-000000000000"
+PRINCIPAL = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+ACCOUNT = "distinctiveaccountname"
+PROJECT = "distinctiveprojectname"
+RESOURCE_GROUP = "distinctiveresourcegroup"
+ENDPOINT = f"https://{ACCOUNT}.services.ai.azure.com/api/projects/{PROJECT}"
+
+PROJECT_SCOPE = (
+    f"/subscriptions/{SUBSCRIPTION}/resourceGroups/{RESOURCE_GROUP}"
+    f"/providers/Microsoft.CognitiveServices/accounts/{ACCOUNT}"
+    f"/projects/{PROJECT}"
+)
+ACCOUNT_SCOPE = PROJECT_SCOPE.rsplit("/projects/", 1)[0]
+
+AGENT_CONSUMER = "eed3b665-ab3a-47b6-8f48-c9382fb1dad6"
+FOUNDRY_USER = "53ca6127-db72-4b80-b1b0-d745d6d5456d"
+
+
+def _env(**updates: str) -> dict[str, str]:
+    env = {
+        "AZURE_SUBSCRIPTION_ID": SUBSCRIPTION,
+        "AZURE_TENANT_ID": TENANT,
+        "AZURE_CLIENT_ID": PRINCIPAL,
+        "FOUNDRY_PROJECT_ENDPOINT": ENDPOINT,
+    }
+    env.update(updates)
+    return env
+
+
+def _assignment(*, role: str, definition_id: str, scope: str) -> dict[str, object]:
+    return {
+        "roleDefinitionName": role,
+        "roleDefinitionId": (
+            f"/subscriptions/{SUBSCRIPTION}/providers/Microsoft.Authorization"
+            f"/roleDefinitions/{definition_id}"
+        ),
+        "scope": scope,
+        "principalId": PRINCIPAL,
+    }
+
+
+class FakeAz:
+    """Stands in for the az CLI. Records what was asked, answers from a script."""
+
+    def __init__(
+        self,
+        *,
+        resources: object = None,
+        assignments: object = None,
+        definitions: object = None,
+    ) -> None:
+        self.resources = resources
+        self.assignments = assignments
+        self.definitions = definitions
+        self.calls: list[list[str]] = []
+
+    def __call__(self, arguments):
+        recorded = list(arguments)
+        self.calls.append(recorded)
+        head = " ".join(recorded[:3])
+        if head.startswith("resource list"):
+            return self._answer(self.resources, "the Foundry account")
+        if head.startswith("role assignment"):
+            return self._answer(self.assignments, "role assignment list")
+        if head.startswith("role definition"):
+            return self._answer(self.definitions, "role definition list")
+        raise AssertionError(f"unexpected az call: {recorded}")
+
+    @staticmethod
+    def _answer(value, what):
+        if isinstance(value, Exception):
+            raise value
+        if value is None:
+            raise diagnostic.AzureReadFailure(what, exit_code=1)
+        return value
+
+
+def _resources() -> list[dict[str, str]]:
+    return [{"id": ACCOUNT_SCOPE, "resourceGroup": RESOURCE_GROUP, "name": ACCOUNT}]
+
+
+def _owner_definition() -> dict[str, object]:
+    return {
+        "roleName": "Owner",
+        "permissions": [{"actions": ["*"], "notActions": [], "dataActions": []}],
+    }
+
+
+def _reader_definition() -> dict[str, object]:
+    return {
+        "roleName": "Reader",
+        "permissions": [{"actions": ["*/read"], "notActions": []}],
+    }
+
+
+# ── Scope shapes say the kind, never the name ─────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected"),
+    [
+        (PROJECT_SCOPE, "foundry-project"),
+        (ACCOUNT_SCOPE, "foundry-account"),
+        (f"{PROJECT_SCOPE}/", "foundry-project"),
+        (f"/subscriptions/{SUBSCRIPTION}/resourceGroups/{RESOURCE_GROUP}", "resource-group"),
+        (f"/subscriptions/{SUBSCRIPTION}", "subscription"),
+        ("/", "tenant-root"),
+        (
+            "/providers/Microsoft.Management/managementGroups/anything",
+            "management-group",
+        ),
+        (
+            f"/subscriptions/{SUBSCRIPTION}/resourceGroups/{RESOURCE_GROUP}"
+            "/providers/Microsoft.Storage/storageAccounts/somewhere",
+            "other-resource",
+        ),
+    ],
+)
+def test_a_scope_is_reported_as_a_kind_of_place(scope, expected):
+    assert diagnostic.scope_shape(scope) == expected
+
+
+@pytest.mark.parametrize("scope", ["", "   ", None, 7])
+def test_a_scope_that_cannot_be_read_says_so_rather_than_guessing(scope):
+    assert diagnostic.scope_shape(scope) == "unreadable"
+
+
+def test_a_scope_shape_nobody_anticipated_is_not_filed_under_a_known_one():
+    """Fail closed on shape too. An unknown scope is not quietly a subscription."""
+    assert diagnostic.scope_shape("/subscriptions/a/b/c/d/e") == "unrecognised"
+
+
+def test_the_shape_never_carries_the_name_it_was_derived_from():
+    for scope in (PROJECT_SCOPE, ACCOUNT_SCOPE, f"/subscriptions/{SUBSCRIPTION}"):
+        shape = diagnostic.scope_shape(scope)
+        for secret in (SUBSCRIPTION, ACCOUNT, PROJECT, RESOURCE_GROUP):
+            assert secret not in shape
+
+
+# ── Building the scope the role has to be assigned at ─────────────────────
+
+
+def test_the_project_scope_is_the_shape_the_documentation_gives():
+    built = diagnostic.project_scope(
+        subscription_id=SUBSCRIPTION,
+        resource_group=RESOURCE_GROUP,
+        account=ACCOUNT,
+        project=PROJECT,
+    )
+    assert built == PROJECT_SCOPE
+    assert diagnostic.scope_shape(built) == "foundry-project"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"subscription_id": ""},
+        {"resource_group": "   "},
+        {"account": ""},
+        {"project": ""},
+        {"account": "with/separator"},
+        {"project": "../escape"},
+    ],
+)
+def test_a_scope_cannot_be_built_from_a_missing_or_smuggled_part(overrides):
+    arguments = {
+        "subscription_id": SUBSCRIPTION,
+        "resource_group": RESOURCE_GROUP,
+        "account": ACCOUNT,
+        "project": PROJECT,
+    }
+    arguments.update(overrides)
+    with pytest.raises(ValueError):
+        diagnostic.project_scope(**arguments)
+
+
+def test_the_resource_group_is_read_out_of_an_arm_id_and_absence_is_none():
+    assert diagnostic.resource_group_of(PROJECT_SCOPE) == RESOURCE_GROUP
+    assert diagnostic.resource_group_of(f"/subscriptions/{SUBSCRIPTION}") is None
+    assert diagnostic.resource_group_of(None) is None
+
+
+# ── Inheritance ───────────────────────────────────────────────────────────
+
+
+def test_a_role_higher_up_reaches_the_project_below_it():
+    for scope in (
+        PROJECT_SCOPE,
+        ACCOUNT_SCOPE,
+        f"/subscriptions/{SUBSCRIPTION}/resourceGroups/{RESOURCE_GROUP}",
+        f"/subscriptions/{SUBSCRIPTION}",
+        "/",
+    ):
+        assert diagnostic._covers(scope, PROJECT_SCOPE), scope
+
+
+def test_a_role_on_a_sibling_resource_does_not_reach_the_project():
+    sibling = ACCOUNT_SCOPE.replace(ACCOUNT, f"{ACCOUNT}-other")
+    assert not diagnostic._covers(sibling, PROJECT_SCOPE)
+
+
+def test_an_account_whose_name_is_a_prefix_is_not_mistaken_for_this_one():
+    """The bug this test exists for: a plain startswith on the raw string.
+
+    An account called ``name`` and one called ``nameother`` share a prefix, and
+    a naive comparison would report a role on the second as reaching the first.
+    """
+    shorter = ACCOUNT_SCOPE.replace(ACCOUNT, ACCOUNT[:-3])
+    assert not diagnostic._covers(shorter, PROJECT_SCOPE)
+
+
+def test_a_scope_that_is_absent_reaches_nothing():
+    assert not diagnostic._covers("", PROJECT_SCOPE)
+    assert not diagnostic._covers(None, PROJECT_SCOPE)
+
+
+# ── Whether the identity could fix this itself ────────────────────────────
+
+
+def test_a_role_with_the_write_action_can_assign():
+    assert diagnostic.permits_role_assignment([_owner_definition()])
+    assert diagnostic.permits_role_assignment(
+        [{"permissions": [{"actions": ["Microsoft.Authorization/*"]}]}]
+    )
+    assert diagnostic.permits_role_assignment(
+        [{"permissions": [{"actions": [diagnostic.ROLE_ASSIGNMENT_WRITE]}]}]
+    )
+
+
+def test_a_read_only_role_cannot_assign():
+    assert not diagnostic.permits_role_assignment([_reader_definition()])
+    assert not diagnostic.permits_role_assignment([])
+    assert not diagnostic.permits_role_assignment([{"permissions": []}])
+
+
+def test_a_denied_action_takes_the_grant_back():
+    """The Contributor shape. Everything, except the one thing that matters."""
+    contributor = {
+        "permissions": [
+            {
+                "actions": ["*"],
+                "notActions": [
+                    "Microsoft.Authorization/*/Delete",
+                    "Microsoft.Authorization/*/Write",
+                ],
+            }
+        ]
+    }
+    assert not diagnostic.permits_role_assignment([contributor])
+
+
+def test_the_denial_only_applies_inside_its_own_permission_block():
+    definitions = [
+        {"permissions": [{"actions": ["*"], "notActions": ["Microsoft.Authorization/*/Write"]}]},
+        {"permissions": [{"actions": [diagnostic.ROLE_ASSIGNMENT_WRITE]}]},
+    ]
+    assert diagnostic.permits_role_assignment(definitions)
+
+
+def test_a_malformed_definition_is_skipped_rather_than_crashing():
+    assert not diagnostic.permits_role_assignment(["not a mapping", None, 7])
+
+
+# ── Reading the assignments ───────────────────────────────────────────────
+
+
+def test_the_role_definition_guid_is_taken_off_the_end_of_its_path():
+    held = diagnostic.summarize_assignments(
+        [_assignment(role="Foundry User", definition_id=FOUNDRY_USER, scope=PROJECT_SCOPE)],
+        target_scope=PROJECT_SCOPE,
+    )
+    assert [role.definition_id for role in held] == [FOUNDRY_USER]
+    assert held[0].covers_the_project is True
+
+
+def test_the_same_role_twice_is_recorded_once():
+    duplicate = _assignment(
+        role="Foundry User", definition_id=FOUNDRY_USER, scope=PROJECT_SCOPE
+    )
+    held = diagnostic.summarize_assignments(
+        [duplicate, dict(duplicate)], target_scope=PROJECT_SCOPE
+    )
+    assert len(held) == 1
+
+
+def test_an_assignment_with_no_readable_name_is_kept_and_labelled():
+    held = diagnostic.summarize_assignments(
+        [{"scope": PROJECT_SCOPE, "roleDefinitionId": 7}], target_scope=PROJECT_SCOPE
+    )
+    assert held[0].role_name == "unnamed"
+    assert held[0].definition_id == ""
+
+
+def test_the_ladder_is_satisfied_only_by_a_role_that_reaches_the_project():
+    on_the_project = diagnostic.summarize_assignments(
+        [
+            _assignment(
+                role="Foundry Agent Consumer",
+                definition_id=AGENT_CONSUMER,
+                scope=PROJECT_SCOPE,
+            )
+        ],
+        target_scope=PROJECT_SCOPE,
+    )
+    assert [rung.name for rung in diagnostic.missing_rungs(on_the_project)] == [
+        "Foundry User"
+    ]
+
+    elsewhere = diagnostic.summarize_assignments(
+        [
+            _assignment(
+                role="Foundry Agent Consumer",
+                definition_id=AGENT_CONSUMER,
+                scope=f"/subscriptions/{SUBSCRIPTION}/resourceGroups/elsewhere",
+            )
+        ],
+        target_scope=PROJECT_SCOPE,
+    )
+    assert len(diagnostic.missing_rungs(elsewhere)) == 2
+
+
+def test_the_roles_the_documentation_rules_out_are_named_when_held():
+    held = diagnostic.summarize_assignments(
+        [
+            _assignment(
+                role="Cognitive Services Contributor",
+                definition_id="25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68",
+                scope=ACCOUNT_SCOPE,
+            ),
+            _assignment(
+                role="Cognitive Services OpenAI User",
+                definition_id="00000000-0000-0000-0000-000000000000",
+                scope=ACCOUNT_SCOPE,
+            ),
+        ],
+        target_scope=PROJECT_SCOPE,
+    )
+    flagged = diagnostic.forbidden_roles_held(held)
+    assert len(flagged) == 2
+    assert any("no data actions" in entry for entry in flagged)
+
+
+def test_a_correct_role_is_not_flagged_as_the_wrong_instrument():
+    """The negative control for the check above."""
+    held = diagnostic.summarize_assignments(
+        [
+            _assignment(
+                role="Foundry Agent Consumer",
+                definition_id=AGENT_CONSUMER,
+                scope=PROJECT_SCOPE,
+            )
+        ],
+        target_scope=PROJECT_SCOPE,
+    )
+    assert diagnostic.forbidden_roles_held(held) == ()
+
+
+# ── Redaction ─────────────────────────────────────────────────────────────
+
+
+def test_every_configured_identifier_is_replaced_by_its_placeholder():
+    secrets = diagnostic.collect_secrets(_env())
+    text = f"{SUBSCRIPTION} {TENANT} {PRINCIPAL} {ENDPOINT}"
+    cleaned = diagnostic.redact(text, secrets)
+    for value in (SUBSCRIPTION, TENANT, PRINCIPAL, ENDPOINT):
+        assert value not in cleaned
+    assert "<subscriptionId>" in cleaned
+    assert "<projectEndpoint>" in cleaned
+
+
+def test_redaction_is_case_insensitive_because_arm_ids_are():
+    secrets = diagnostic.collect_secrets(_env())
+    cleaned = diagnostic.redact(SUBSCRIPTION.upper(), secrets)
+    assert SUBSCRIPTION.upper() not in cleaned
+
+
+def test_a_value_too_short_to_defend_is_left_alone_rather_than_corrupting_the_text():
+    secrets = diagnostic.collect_secrets(_env(AZURE_CLIENT_ID="dev"))
+    assert "dev" not in secrets
+    assert diagnostic.redact("a development note", secrets) == "a development note"
+
+
+def test_the_leak_check_finds_what_redaction_missed():
+    secrets = diagnostic.collect_secrets(_env())
+    assert diagnostic.leaked_placeholders(f"see {SUBSCRIPTION}", secrets) == (
+        "<subscriptionId>",
+    )
+
+
+def test_the_leak_check_does_not_fire_on_a_report_that_never_had_one():
+    """Negative control. A guard that always fires protects nothing."""
+    secrets = diagnostic.collect_secrets(_env())
+    clean = diagnostic.render(
+        {
+            "route_profile": "project-ci",
+            "endpoint_kind": "project",
+            "target_scope_shape": "foundry-project",
+            "verdict": "role_missing_and_an_owner_must_grant_it",
+            "roles_held": [],
+            "missing_least_privilege_roles": [
+                {"name": "Foundry Agent Consumer", "role_definition_id": AGENT_CONSUMER}
+            ],
+            "principal_can_assign_roles": False,
+        }
+    )
+    assert diagnostic.leaked_placeholders(clean, secrets) == ()
+
+
+# ── The diagnosis end to end ──────────────────────────────────────────────
+
+
+def test_a_project_with_the_consumer_role_is_reported_as_already_covered():
+    az = FakeAz(
+        resources=_resources(),
+        assignments=[
+            _assignment(
+                role="Foundry Agent Consumer",
+                definition_id=AGENT_CONSUMER,
+                scope=PROJECT_SCOPE,
+            ),
+            _assignment(
+                role="Foundry User", definition_id=FOUNDRY_USER, scope=PROJECT_SCOPE
+            ),
+        ],
+        definitions=[_reader_definition()],
+    )
+    report = diagnostic.diagnose(_env(), runner=az)
+    assert report["verdict"] == "least_privilege_role_already_held"
+    assert report["missing_least_privilege_roles"] == []
+    assert report["principal_can_assign_roles"] is False
+
+
+def test_the_403_shape_is_reported_as_a_missing_role_an_owner_must_grant():
+    """The situation the two failed dispatches were actually in."""
+    az = FakeAz(
+        resources=_resources(),
+        assignments=[
+            _assignment(
+                role="Cognitive Services Contributor",
+                definition_id="25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68",
+                scope=ACCOUNT_SCOPE,
+            )
+        ],
+        definitions=[_reader_definition()],
+    )
+    report = diagnostic.diagnose(_env(), runner=az)
+    assert report["verdict"] == "role_missing_and_an_owner_must_grant_it"
+    assert [rung["name"] for rung in report["missing_least_privilege_roles"]] == [
+        "Foundry Agent Consumer",
+        "Foundry User",
+    ]
+    assert report["forbidden_roles_held"]
+
+
+def test_an_identity_that_can_assign_is_told_so_rather_than_sent_to_an_owner():
+    az = FakeAz(
+        resources=_resources(),
+        assignments=[
+            _assignment(
+                role="Owner",
+                definition_id="8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+                scope=f"/subscriptions/{SUBSCRIPTION}",
+            )
+        ],
+        definitions=[_owner_definition()],
+    )
+    report = diagnostic.diagnose(_env(), runner=az)
+    assert report["verdict"] == "role_missing_and_this_identity_can_grant_it"
+    assert report["principal_can_assign_roles"] is True
+
+
+def test_a_control_plane_that_will_not_answer_is_a_finding_not_an_empty_result():
+    az = FakeAz(resources=[], assignments=[], definitions=[])
+    report = diagnostic.diagnose(_env(), runner=az)
+    assert report["verdict"] == "cannot_read_control_plane"
+    assert report["read_failures"]
+    # It stopped there rather than reporting "no roles held", which would read
+    # as a measured zero.
+    assert report["roles_held"] == []
+    assert len(az.calls) == 1
+
+
+def test_being_unable_to_read_its_own_assignments_is_not_reported_as_none_held():
+    az = FakeAz(resources=_resources(), assignments=None, definitions=[])
+    report = diagnostic.diagnose(_env(), runner=az)
+    assert report["verdict"] == "cannot_read_role_assignments"
+    assert report["roles_held"] == []
+
+
+def test_an_unreadable_role_definition_leaves_the_grantor_unmeasured_not_false():
+    az = FakeAz(
+        resources=_resources(),
+        assignments=[
+            _assignment(
+                role="Reader",
+                definition_id="acdd72a7-3385-48ef-bd42-f606fba81ae7",
+                scope=PROJECT_SCOPE,
+            )
+        ],
+        definitions=None,
+    )
+    report = diagnostic.diagnose(_env(), runner=az)
+    assert report["principal_can_assign_roles"] is None
+    assert report["verdict"] == "role_missing_and_the_grantor_is_unmeasured"
+
+
+def test_the_assignment_read_asks_for_inherited_and_group_roles():
+    az = FakeAz(resources=_resources(), assignments=[], definitions=[])
+    diagnostic.diagnose(_env(), runner=az)
+    assignment_call = next(
+        call for call in az.calls if call[:2] == ["role", "assignment"]
+    )
+    assert "--include-inherited" in assignment_call
+    assert "--include-groups" in assignment_call
+    assert "--scope" in assignment_call
+
+
+def test_nothing_the_diagnostic_runs_changes_anything():
+    """The whole safety claim, checked against what was actually asked for."""
+    az = FakeAz(
+        resources=_resources(),
+        assignments=[
+            _assignment(role="Reader", definition_id="acdd72a7", scope=PROJECT_SCOPE)
+        ],
+        definitions=[_reader_definition()],
+    )
+    diagnostic.diagnose(_env(), runner=az)
+    assert az.calls
+    for call in az.calls:
+        assert call[1] in {"list"} or call[2] == "list", call
+        for verb in ("create", "update", "delete", "set", "add", "remove"):
+            assert verb not in call
+
+
+def test_an_endpoint_that_is_not_a_project_is_refused():
+    direct = f"https://{ACCOUNT}.services.ai.azure.com/openai/v1/"
+    with pytest.raises(ValueError, match="not a Foundry project endpoint"):
+        diagnostic.diagnose(
+            _env(FOUNDRY_PROJECT_ENDPOINT=direct), runner=FakeAz(resources=_resources())
+        )
+
+
+@pytest.mark.parametrize(
+    "missing", ["FOUNDRY_PROJECT_ENDPOINT", "AZURE_SUBSCRIPTION_ID", "AZURE_CLIENT_ID"]
+)
+def test_a_missing_setting_stops_the_run_instead_of_being_read_as_empty(missing):
+    with pytest.raises(ValueError, match=missing):
+        diagnostic.diagnose(_env(**{missing: ""}), runner=FakeAz())
+
+
+# ── What actually reaches the log ─────────────────────────────────────────
+
+
+def _run_main(argv, az, **env_updates):
+    stream = io.StringIO()
+    code = diagnostic.main(
+        argv, env=_env(**env_updates), runner=az, stream=stream
+    )
+    return code, stream.getvalue()
+
+
+def _every_secret():
+    return (SUBSCRIPTION, TENANT, PRINCIPAL, ACCOUNT, PROJECT, RESOURCE_GROUP, ENDPOINT)
+
+
+def test_the_printed_report_carries_no_identifier_at_all():
+    az = FakeAz(
+        resources=_resources(),
+        assignments=[
+            _assignment(
+                role="Cognitive Services Contributor",
+                definition_id="25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68",
+                scope=ACCOUNT_SCOPE,
+            )
+        ],
+        definitions=[_reader_definition()],
+    )
+    code, output = _run_main([], az)
+    assert code == 0
+    for secret in _every_secret():
+        assert secret.lower() not in output.lower(), secret
+    assert "<projectName>" in output
+    assert "role_missing_and_an_owner_must_grant_it" in output
+
+
+def test_the_resource_group_read_back_from_azure_is_redacted_too():
+    """The one identifier no environment variable could have told us about.
+
+    It is discovered mid-run, so it has to be added to the redaction set after
+    collect_secrets has already looked at the environment. If that wiring
+    breaks, this is what catches it.
+    """
+    az = FakeAz(resources=_resources(), assignments=[], definitions=[])
+    _, output = _run_main([], az)
+    assert RESOURCE_GROUP not in output
+    assert "<resourceGroup>" in output
+
+
+def test_the_json_form_is_redacted_by_the_same_path():
+    az = FakeAz(resources=_resources(), assignments=[], definitions=[])
+    code, output = _run_main(["--json"], az)
+    assert code == 0
+    payload = json.loads(output)
+    assert payload["verdict"] == "role_missing_and_an_owner_must_grant_it"
+    assert "secret_values" not in payload
+    for secret in _every_secret():
+        assert secret.lower() not in output.lower(), secret
+
+
+def test_the_remediation_command_is_a_template_not_a_filled_in_command():
+    az = FakeAz(resources=_resources(), assignments=[], definitions=[])
+    _, output = _run_main([], az)
+    assert "az role assignment create" in output
+    assert f'--role "{diagnostic.LEAST_PRIVILEGE_LADDER[0].definition_id}"' in output
+    assert "<subscriptionId>" in output and "<principalId>" in output
+    # Only the first rung is offered. Printing both would invite the broader
+    # one being assigned first.
+    assert f'--role "{FOUNDRY_USER}"' not in output
+
+
+def _custom_role_named_after_the_project():
+    """The one field Azure lets a human write free text into.
+
+    Scopes are reduced to shapes and ids are GUIDs, so neither can carry a
+    resource name. A custom role's display name can, and often does, because
+    people name custom roles after the thing they apply to.
+    """
+    return FakeAz(
+        resources=_resources(),
+        assignments=[
+            _assignment(
+                role=f"{PROJECT} operator",
+                definition_id="12345678-1234-1234-1234-123456789abc",
+                scope=PROJECT_SCOPE,
+            )
+        ],
+        definitions=[_reader_definition()],
+    )
+
+
+def test_a_custom_role_named_after_the_project_is_withheld_at_the_source():
+    """First layer: the name never enters the report in the first place."""
+    code, output = _run_main([], _custom_role_named_after_the_project())
+    assert code == 0
+    assert PROJECT not in output
+    assert diagnostic.WITHHELD_ROLE_NAME in output
+
+
+def test_a_built_in_role_name_is_not_withheld():
+    """Negative control for the layer above. Withholding everything is not safety."""
+    az = FakeAz(
+        resources=_resources(),
+        assignments=[
+            _assignment(
+                role="Foundry Agent Consumer",
+                definition_id=AGENT_CONSUMER,
+                scope=PROJECT_SCOPE,
+            )
+        ],
+        definitions=[_reader_definition()],
+    )
+    _, output = _run_main([], az)
+    assert "Foundry Agent Consumer" in output
+    assert diagnostic.WITHHELD_ROLE_NAME not in output
+
+
+def test_redaction_catches_the_name_if_the_source_check_is_broken(monkeypatch):
+    """Second layer, checked by disabling the first."""
+    monkeypatch.setattr(diagnostic, "safe_role_name", lambda name, values: name)
+    code, output = _run_main([], _custom_role_named_after_the_project())
+    assert code == 0
+    assert PROJECT not in output
+    assert "<projectName> operator" in output
+
+
+def test_the_report_is_withheld_when_both_earlier_layers_are_broken(monkeypatch):
+    """Third layer, checked by disabling the two in front of it.
+
+    This is the guard that matters most, so it is verified by taking away
+    everything it depends on rather than by trusting that it works. The input
+    is the one shape that genuinely carries a name into the raw report, so a
+    pass here means the leak check caught a real leak, not a hypothetical one.
+    """
+    monkeypatch.setattr(diagnostic, "safe_role_name", lambda name, values: name)
+    monkeypatch.setattr(diagnostic, "redact", lambda text, secrets: text)
+    code, output = _run_main([], _custom_role_named_after_the_project())
+    assert code == 3
+    assert output == ""
+
+
+def test_breaking_every_layer_on_a_report_with_nothing_to_leak_still_prints(monkeypatch):
+    """Negative control for the check above.
+
+    Without this, the test above would pass just as happily if the leak check
+    refused every report it was ever shown.
+    """
+    monkeypatch.setattr(diagnostic, "safe_role_name", lambda name, values: name)
+    monkeypatch.setattr(diagnostic, "redact", lambda text, secrets: text)
+    az = FakeAz(resources=_resources(), assignments=[], definitions=[])
+    code, output = _run_main([], az)
+    assert code == 0
+    assert "role_missing_and_an_owner_must_grant_it" in output
+
+
+def test_a_missing_setting_exits_two_without_printing_a_report():
+    code, output = _run_main([], FakeAz(), AZURE_CLIENT_ID="")
+    assert code == 2
+    assert output == ""
+
+
+def test_the_gate_flag_is_the_only_thing_that_turns_a_gap_into_a_failure():
+    az = FakeAz(resources=_resources(), assignments=[], definitions=[])
+    assert _run_main([], az)[0] == 0
+    assert _run_main(["--require-project-role"], az)[0] == 1
+
+    covered = FakeAz(
+        resources=_resources(),
+        assignments=[
+            _assignment(
+                role="Foundry Agent Consumer",
+                definition_id=AGENT_CONSUMER,
+                scope=PROJECT_SCOPE,
+            ),
+            _assignment(
+                role="Foundry User", definition_id=FOUNDRY_USER, scope=PROJECT_SCOPE
+            ),
+        ],
+        definitions=[_reader_definition()],
+    )
+    assert _run_main(["--require-project-role"], covered)[0] == 0
+
+
+# ── The role facts this rests on ──────────────────────────────────────────
+
+
+def test_the_ladder_is_least_privilege_first_and_pinned_to_the_documented_ids():
+    ladder = diagnostic.LEAST_PRIVILEGE_LADDER
+    assert [rung.name for rung in ladder] == ["Foundry Agent Consumer", "Foundry User"]
+    assert [rung.definition_id for rung in ladder] == [AGENT_CONSUMER, FOUNDRY_USER]
+    for rung in ladder:
+        assert re.fullmatch(r"[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}", rung.definition_id)
+        assert rung.why
+
+
+def test_the_roles_the_documentation_rules_out_stay_ruled_out():
+    assert "25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68" in diagnostic.FORBIDDEN_ROLE_IDS
+    assert "64702f94-c441-49e6-a78b-ef80e0188fee" in diagnostic.FORBIDDEN_ROLE_IDS
+    for rung in diagnostic.LEAST_PRIVILEGE_LADDER:
+        assert rung.definition_id not in diagnostic.FORBIDDEN_ROLE_IDS
+        assert not rung.name.startswith(diagnostic.FORBIDDEN_ROLE_NAME_PREFIX)
+
+
+# ── The workflow that runs it ─────────────────────────────────────────────
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_the_workflow_can_only_be_started_by_hand():
+    # PyYAML reads a bare `on` key as the boolean True.
+    triggers = _workflow()[True]
+    assert list(triggers) == ["workflow_dispatch"]
+
+
+def test_the_workflow_asks_for_no_more_than_it_needs():
+    workflow = _workflow()
+    assert workflow["permissions"] == {"contents": "read", "id-token": "write"}
+
+
+def test_the_workflow_runs_as_the_identity_the_paid_runs_use():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    batch_run = (REPOSITORY_ROOT / ".github/workflows/batch-run.yml").read_text(
+        encoding="utf-8"
+    )
+    login = "azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca"
+    assert login in text
+    assert login in batch_run, "the pinned login action moved; re-pin this one"
+    for name in ("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SUBSCRIPTION_ID"):
+        assert f"secrets.{name}" in text
+
+
+def test_every_action_the_workflow_uses_is_pinned_to_a_commit():
+    for line in WORKFLOW.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("uses:"):
+            assert re.search(r"@[0-9a-f]{40}\b", stripped), stripped
+
+
+def test_the_workflow_carries_no_credential_that_could_spend():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    for name in (
+        "AZURE_OPENAI_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "HF_TOKEN",
+        "AZURE_CLIENT_SECRET",
+    ):
+        assert name not in text, name
+
+
+def test_the_workflow_demands_the_expected_identities_like_every_other_run_place():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'" in text
+
+
+def test_the_diagnostic_never_reaches_for_the_inference_path():
+    """Kept in step with the workflow's own last step, which greps for this."""
+    source = SCRIPT.read_text(encoding="utf-8")
+    for forbidden in (
+        "responses.create",
+        "chat.completions",
+        "AzureOpenAI",
+        "llm_client",
+        "code_interpreter",
+    ):
+        assert forbidden not in source, forbidden


### PR DESCRIPTION
## What this is

A read-only diagnostic that answers the one question standing between the Code
Interpreter arm and a real run: **which roles does the CI identity actually hold
on the Foundry project, and which one is missing?**

It does not attempt the call that was refused, and it cannot spend anything.

## Why it was needed

Two dispatches of that arm (`33464316741`, `33468138329`) were refused on every
call with `http 403` and served **zero** responses. The `direct-v1` arm, run by
the **same** identity in the same tenant and subscription, asking for the **same**
token audience (`core/azure_ai_clients.py:23`, applied to both route profiles at
`:481`), was served normally. Only the *resource* differs, and route selection is
automatic (`batch-run.yml:459`, `:595`, `:688`).

So authentication is not the problem. The gap is **authorization at the Foundry
project resource** -- and nothing in this repository could measure it. A search
for `role assignment|roleAssignment|roleDefinition|az role` across every `.py`,
`.yml`, `.yaml`, `.sh` and `.bicep` returns nothing, and there are no `.bicep` or
`.tf` files at all. Without this, the only two options were to guess a role or to
retry the same refusal.

`scripts/azure_ai_route_preflight.py` already *states* this hypothesis in prose.
This PR makes it measurable.

## The role ladder is quoted, not inferred

From the published Azure AI Foundry RBAC reference (doc updated 2026-08-26):

| rung | role | why |
|---|---|---|
| 1 | **Foundry Agent Consumer** `eed3b665-…` | the doc names this as least-privilege for an identity that only *calls* the Responses API without creating or modifying agents |
| 2 | **Foundry User** `53ca6127-…` | broader; only if rung 1 is insufficient |

The same document says two things must **not** be used here, and the script
refuses both by name prefix and by id if it finds them already assigned:
`Cognitive Services *` (`25fbc0a9-…` carries zero DataActions) and
`Azure AI Developer` (`64702f94-…`).

The doc also notes the portal can only assign rung 1 at *account* scope, so the
remediation this prints uses the CLI at *project* scope, as the doc recommends.

## Nothing it does can spend or change anything

- Every call is an ARM control-plane **read**: `az resource list`,
  `az role assignment list`, `az role definition list`.
- A test asserts that no `az` invocation the script can build contains a
  `create`, `update`, `delete`, `set`, `add` or `remove` verb.
- The workflow greps the script for the inference call paths
  (`responses.create`, `chat.completions`, `AzureOpenAI`, `llm_client`,
  `code_interpreter`) on **every** run, `if: always()`, and fails if any appears.
- No model credential is passed into the job at all, deliberately, so a future
  edit cannot quietly turn it into one that spends.

## Written for a public log

The report names no resource. Three layers, each verified by breaking the ones in
front of it:

1. **Withhold at the source.** A free-text role name that fails a conservative
   character check, or that contains any sensitive value, is replaced by
   `custom role (name withheld)`. Detection uses every sensitive value with no
   length floor, so even a very short resource name is caught.
2. **Substitute.** Every remaining identifier is replaced by a `<placeholder>`.
   This layer keeps a length floor, because replacing a three-letter name
   everywhere would corrupt ordinary words.
3. **Refuse.** The rendered text is rescanned. If any identifier survived, the
   report is **not printed at all** and the command exits `3`.

Layer 3 is the one that matters, so it is tested by disabling layers 1 and 2 and
confirming it catches a real leak -- with a negative control proving it is not
simply refusing every report it is shown. `az` stderr is never echoed, because an
error message can name the resource it failed on.

Scopes are compared segment by segment, so an account whose name is a *prefix* of
the real one is not mistaken for it.

## Verdicts it can return

`least_privilege_role_already_held` · `role_missing_and_this_identity_can_grant_it`
· `role_missing_and_an_owner_must_grant_it` ·
`role_missing_and_the_grantor_is_unmeasured` · `cannot_read_control_plane` ·
`cannot_read_role_assignments` · `unmeasured`

Whether this identity may grant the role is determined by reading the actual
permission blocks of the roles it holds (`roleAssignments/write` present in a
block whose `notActions` does not exclude it), not by matching a role name.

The workflow deliberately does **not** pass `--require-project-role`: reporting
that the role is absent is the point of the run, not a failure of it.

## Workflow shape

Manual dispatch only, `main` only, `contents: read` + `id-token: write`, all
actions pinned to SHAs, `persist-credentials: false`, and the existing
`azure_oidc_identity_preflight.py --verify-session` runs first so the roles read
are the roles of the identity the paid runs actually use.

## Verification

- 74 new tests in `tests/test_azure_rbac_diagnostic.py`
- full backend suite: **6997 passed, 10 skipped** (re-run on the merged tree)
- `mypy scripts/azure_rbac_diagnostic.py --ignore-missing-imports`: clean
- the four workflow guard suites that constrain any new workflow file: 184 passed

## Note on `.gitignore`

`batch-runner/scripts/*` is ignored with a per-file `!` allowlist. This adds one
negation line, following that existing convention rather than `git add -f`.
