### PR TITLE
fix(azure): stop the RBAC job naming the resource in its own step header

### DIFF
--- a/.github/workflows/azure-rbac-diagnostic.yml
+++ b/.github/workflows/azure-rbac-diagnostic.yml
@@ -75,13 +75,21 @@ jobs:
 
       # No model credential is passed in. If one were, a future edit could turn
       # this read-only job into one that spends, and nothing here would notice.
+      #
+      # The Foundry account and project names are repository VARIABLES, and
+      # GitHub does not mask a variable the way it masks a secret: whatever a
+      # step lists under env: is reprinted verbatim in the step header, and the
+      # logs of a public repository are public. So this step does not ask for
+      # AZURE_AI_EXPECTED_PROJECT_ACCOUNT or AZURE_AI_EXPECTED_PROJECT_NAME. It
+      # does not need them. Both names live inside the endpoint, which is a
+      # secret and therefore masked, and the script pulls them out of it for
+      # redaction. Naming the resource in the header of the job whose whole
+      # point is not to name the resource would be an odd way to start.
       - name: Read the roles this identity holds on the project
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_AI_EXPECTED_PROJECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_PROJECT_ACCOUNT }}
-          AZURE_AI_EXPECTED_PROJECT_NAME: ${{ vars.AZURE_AI_EXPECTED_PROJECT_NAME }}
           AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
           FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
           EMIT_JSON: ${{ inputs.emit_json }}

--- a/batch-runner/tests/test_azure_rbac_diagnostic.py
+++ b/batch-runner/tests/test_azure_rbac_diagnostic.py
@@ -838,6 +838,42 @@ def test_the_workflow_demands_the_expected_identities_like_every_other_run_place
     assert "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'" in text
 
 
+def test_the_step_that_prints_the_report_names_no_repository_variable():
+    """A variable is not a secret, and this job's logs are public.
+
+    GitHub reprints whatever a step lists under `env:` in the step header, and
+    it masks secrets there but not variables. The Foundry account and project
+    names are stored as variables, so asking for them by name in this step
+    would publish them in the header of the one job whose entire purpose is to
+    report without naming the resource. Measured on run 33510351756, which is
+    what this test exists to stop happening again.
+    """
+    steps = _workflow()["jobs"]["diagnose"]["steps"]
+    invocation = "python3 scripts/azure_rbac_diagnostic.py"
+    reporting = [step for step in steps if invocation in step.get("run", "")]
+    assert len(reporting) == 1, "the reporting step moved or was duplicated"
+    for key, value in reporting[0].get("env", {}).items():
+        assert "vars." not in str(value), f"{key} publishes a repository variable"
+
+
+def test_the_report_still_hides_both_names_without_those_variables():
+    """The check above only holds if the names are recoverable elsewhere.
+
+    They are: both live inside the project endpoint, which is a secret, and the
+    script pulls them out of it. Without this, dropping the variables would
+    look like a tightening while quietly removing a redaction source.
+    """
+    environment = _env()
+    for name in (
+        "AZURE_AI_EXPECTED_PROJECT_ACCOUNT",
+        "AZURE_AI_EXPECTED_PROJECT_NAME",
+    ):
+        assert name not in environment, "this test is measuring the wrong thing"
+    _, output = _run_main([], _custom_role_named_after_the_project())
+    assert ACCOUNT not in output
+    assert PROJECT not in output
+
+
 def test_the_diagnostic_never_reaches_for_the_inference_path():
     """Kept in step with the workflow's own last step, which greps for this."""
     source = SCRIPT.read_text(encoding="utf-8")


### PR DESCRIPTION
Follow-up to #358, from what its first real run showed.

## What happened

Run `33510351756` returned the verdict the diagnostic was built to return, and
**its report named nothing** -- the three redaction layers held. The GitHub step
header printed above that report did not.

GitHub reprints whatever a step lists under `env:` when the step starts. It masks
**secrets** there. It does not mask **variables**, by design. The Foundry account
name and project name are stored as repository variables, so listing them by name
published both in the header of the one job whose entire purpose is to report
without naming the resource.

## Why they can simply go

They were never needed. Both names live inside `FOUNDRY_PROJECT_ENDPOINT`, which
**is** a secret and therefore masked, and `diagnose()` already pulls them out of
it to seed the redaction set. That is precisely why the report itself came out
clean while the header did not.

## Two tests, not one

- `test_the_step_that_prints_the_report_names_no_repository_variable` -- no `env`
  value in the reporting step interpolates `vars.`
- `test_the_report_still_hides_both_names_without_those_variables` -- redaction of
  both names still holds with those variables absent

The second exists so the first cannot later be satisfied by quietly deleting a
redaction source. It asserts up front that the test environment really does omit
them, so it cannot pass for the wrong reason.

## Scope

`batch-run.yml` and `grade-run.yml` list the same variables in their own steps and
have done so on every paid run. That is **pre-existing**, it is **not touched
here**, and closing it properly means moving those values from variables to
secrets -- a repository-settings decision, not a code change. Recorded for the
owner rather than acted on.

## Verification

- 76 tests in `tests/test_azure_rbac_diagnostic.py` (2 new), plus the workflow
  guard suites: **185 passed**
- change is workflow YAML and tests only; no runtime code touched
