### PR TITLE
fix(cost): key run-summary rows by model identity, not display name

### DIFF
--- a/batch-runner/core/cost_projection.py
+++ b/batch-runner/core/cost_projection.py
@@ -514,6 +514,36 @@ def _receipt_amount(receipt: dict):
     return amount if amount is not None else receipt["estimated_cost_usd"]
 
 
+def _summary_component_key(component: dict) -> tuple:
+    """The identity two run-summary lines must share before they may be added.
+
+    The same seven fields :func:`project_cost_receipt` rejects duplicates of a
+    few lines above and :func:`core.cost_receipts._component_key` groups a
+    task's own lines under, so that the producer, this summariser and the
+    dashboard all land on the same rows.
+
+    Not ``name``. ``name`` is *derived* from the first two — every retry at
+    every stage derives ``retry``, and both a visual reader and an audio reader
+    derive ``perception`` — so it cannot tell those rows apart by construction.
+    """
+    return (
+        component["stage"],
+        component["retry_kind"],
+        *(component.get(column) for column in _COMPONENT_IDENTITY),
+    )
+
+
+def _summary_component_order(item: tuple) -> tuple:
+    """Sort key for summary lines, tolerating unrecorded identity fields.
+
+    ``None`` and ``str`` do not compare in Python 3, and a run that recorded no
+    deployment is the ordinary state of every receipt published before call
+    identity existed — so it must not be the state that crashes the sort.
+    Unrecorded sorts first. Mirrors ``core.cost_receipts._component_order``.
+    """
+    return tuple("" if value is None else str(value) for value in item[0])
+
+
 def summarize_cost_receipts(
     rows: list[dict],
     field: str,
@@ -630,44 +660,79 @@ def summarize_cost_receipts(
         for receipt in receipts
         if receipt["price_table_sha256"]
     })
-    component_totals: dict[str, dict] = {}
+    component_totals: dict[tuple, dict] = {}
     for receipt in receipts:
-        # Roll one receipt's lines up by displayed name before touching the run
-        # totals. A task whose generation and Self-QA both had to be redone
-        # carries two 재시도 lines but is still one task, and counting it twice
-        # would make the coverage figure beside the row a fiction.
-        rolled: dict[str, dict] = {}
+        # Roll one receipt's lines up before touching the run totals. A task
+        # whose generation and Self-QA both had to be redone carries two 재시도
+        # lines but is still one task, and counting it twice would make the
+        # coverage figure beside the row a fiction.
+        #
+        # Rolled by the line's own seven-field identity, not by the label it
+        # displays under. Folding by `name` was that same double-count guard
+        # turned into a merge: generation's retry and Self-QA's retry both
+        # display as 재시도, so one run published a single $0.190047 / 4-call
+        # 재시도 row over a $0.178985 / 2-call generation retry and a $0.011062
+        # / 2-call Self-QA retry. Under `perception` it is worse than untidy --
+        # a visual reader and an audio reader carry different rates, and their
+        # summed tokens are a row no price table can reproduce and no reader
+        # can take apart again.
+        #
+        # The count of rows this can produce is bounded by the run's own
+        # config, not by its size: five stages times five retry kinds, and a
+        # stage is only reached by the models named for it. Grading lands near
+        # twenty rows, inference near ten.
+        rolled: dict[tuple, dict] = {}
         for component in receipt["components"]:
             entry = rolled.setdefault(
-                component["name"],
-                {"known_cost_usd": 0.0, "model_calls": 0, "complete": True},
+                _summary_component_key(component),
+                {
+                    # Carried, not re-derived: the label is the producer's to
+                    # choose, and this reader only displays it.
+                    "name": component["name"],
+                    "known_cost_usd": 0.0,
+                    "model_calls": 0,
+                    "missing_reasons": set(),
+                    "complete": True,
+                },
             )
             amount = component["known_cost_usd"]
             if amount is not None:
                 entry["known_cost_usd"] += amount
             if component["model_calls"]:
                 entry["model_calls"] += component["model_calls"]
+            entry["missing_reasons"].update(component["missing_reasons"])
             if component["status"] != "complete":
                 entry["complete"] = False
-        for name, entry in rolled.items():
-            bucket = component_totals.setdefault(
-                name,
-                {
-                    "name": name,
+        for key, entry in rolled.items():
+            bucket = component_totals.get(key)
+            if bucket is None:
+                bucket = component_totals[key] = {
+                    "name": entry["name"],
+                    "stage": key[0],
+                    "retry_kind": key[1],
+                    **dict(zip(_COMPONENT_IDENTITY, key[2:])),
                     "tasks": 0,
                     "known_cost_usd": 0.0,
                     "complete_tasks": 0,
                     "model_calls": 0,
-                },
-            )
+                    # Why a row could not be priced belongs beside the row.
+                    # Kept only at the run level, "no rate published for this
+                    # model" arrived detached from which model, which is the
+                    # one thing a reader needs to act on it.
+                    "missing_reasons": set(),
+                }
             bucket["tasks"] += 1
             if entry["complete"]:
                 bucket["complete_tasks"] += 1
             bucket["known_cost_usd"] += entry["known_cost_usd"]
             bucket["model_calls"] += entry["model_calls"]
+            bucket["missing_reasons"].update(entry["missing_reasons"])
     components = []
-    for bucket in sorted(component_totals.values(), key=lambda item: item["name"]):
+    for _, bucket in sorted(
+        component_totals.items(), key=_summary_component_order
+    ):
         bucket["known_cost_usd"] = round(bucket["known_cost_usd"], _MONEY_DIGITS)
+        bucket["missing_reasons"] = sorted(bucket["missing_reasons"])
         bucket["status"] = (
             "complete" if bucket["complete_tasks"] == bucket["tasks"] else "partial"
         )

--- a/batch-runner/tests/test_a_run_summary_row_is_one_model_not_one_label.py
+++ b/batch-runner/tests/test_a_run_summary_row_is_one_model_not_one_label.py
@@ -1,0 +1,490 @@
+"""A run-summary row is one model's calls, not one label's.
+
+``summarise_receipts`` was taught this in test_every_call_belonged_to_a_stage.py
+and keys a merged line by the seven fields the producer groups on. The two
+readers *downstream* of the same receipts were not: both
+``core.cost_projection.summarize_cost_receipts`` and ``aggregateComponents`` in
+``scripts/cost-receipt.mjs`` folded a run's lines by ``components[].name``, and
+handed the result to ``report_data.json`` and to the dashboard.
+
+``name`` cannot carry that weight. It is *derived*::
+
+    return self.stage if self.retry_kind == RETRY_NONE else COMPONENT_RETRY
+
+so every retry at every stage derives ``retry`` and both perception models
+derive ``perception``. Folding by it is lossy by construction, and the loss is
+published. On the run whose inference is at
+``HyeonSang/exp026c_cost_receipt_smoke``, one task's four lines::
+
+    generation      none      $0.089673   1 call
+    generation      resume    $0.178985   2 calls
+    self_qa         none      $0.005792   1 call
+    self_qa         resume    $0.011062   2 calls
+
+arrived in ``cost_summary`` as three, the middle one reading::
+
+    {"name": "retry", "known_cost_usd": 0.190047, "model_calls": 4}
+
+$0.178985 + $0.011062 over two different stages, in one row, under a label that
+names neither. Under ``perception`` it is worse than untidy: a visual reader and
+an audio reader are priced from different entries, so their summed tokens are a
+figure no price table can reproduce.
+
+Two more things went missing with the key. Identity -- provider, deployment,
+requested and resolved model, API version -- was dropped, so a reader could not
+tell which model a row was even when the receipt underneath it knew. And
+``missing_reasons`` was dropped outright: the bucket had no such field, so "no
+rate is published for this model" reached the run and never the row, leaving a
+reader who could see that something was unpriced with no way to see *what*.
+
+Everything below is built through a real ``CostReceiptLedger`` priced by a real
+``load_receipt_price_table``, serialised the way a published payload is, and
+read back through the real projection -- so the arithmetic under test is the
+producer's, end to end.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+BATCH_RUNNER = Path(__file__).resolve().parents[1]
+if str(BATCH_RUNNER) not in sys.path:
+    sys.path.insert(0, str(BATCH_RUNNER))
+
+from core.cost_projection import project_cost_receipt, summarize_cost_receipts
+from core.cost_receipts import (
+    BUCKET_GRADING,
+    BUCKET_PROBLEM_SOLVING,
+    REASON_PRICE_MISSING,
+    RETRY_NONE,
+    RETRY_RESUME,
+    STAGE_GENERATION,
+    STAGE_GRADING,
+    STAGE_PERCEPTION,
+    STAGE_SELF_QA,
+    CallUsage,
+    CostReceiptLedger,
+    load_receipt_price_table,
+    make_call_id,
+)
+
+MIRROR = BATCH_RUNNER.parent / "scripts" / "cost-receipt.mjs"
+
+#: Two models a run really does call under one stage, at rates far enough apart
+#: that a summed row could not be mistaken for either of them.
+VISION = "sees-things"
+AUDIO = "hears-things"
+#: A third the fixture table has no entry for, so a row can go unpriced beside
+#: a row that did not.
+UNPRICED = "unheard-of"
+
+#: One million in, one million out.
+CALL_TOKENS = 1_000_000
+VISION_PER_CALL = 30  # $10 in + $20 out
+AUDIO_PER_CALL = 300  # $100 in + $200 out
+
+
+@pytest.fixture
+def prices(tmp_path):
+    def entry(input_rate, output_rate):
+        return {
+            "input_usd_per_million": str(input_rate),
+            "cached_input_usd_per_million": str(input_rate),
+            "output_usd_per_million": str(output_rate),
+            "reasoning_billed_as": "output",
+            "source": "fixture",
+            "last_reviewed": "2026-09-01",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        }
+
+    document = {
+        "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+        "providers": {
+            f"azure:{VISION}": entry(10, 20),
+            f"azure:{AUDIO}": entry(100, 200),
+        },
+        "runtime": {},
+    }
+    path = tmp_path / "prices.json"
+    path.write_text(json.dumps(document), "utf-8")
+    return load_receipt_price_table(path)
+
+
+def _summary(tmp_path, prices, plan, *, bucket=BUCKET_PROBLEM_SOLVING):
+    """One run's summary, from the ledger through the published shape.
+
+    ``plan`` is ``{task_id: [(stage, retry_kind, model), ...]}``. Each call is
+    reserved and settled through the ledger's own pair, the receipt is written
+    the way a payload carries it, and it is read back through the projection
+    the dashboard and the report both read it through.
+    """
+    field = (
+        "grading_cost" if bucket == BUCKET_GRADING else "problem_solving_cost"
+    )
+    path = tmp_path / "ledger.sqlite3"
+    with CostReceiptLedger(path, run_id="run-1", price_table=prices) as ledger:
+        sequence = 0
+        for task_id, calls in plan.items():
+            for stage, retry_kind, model in calls:
+                call_id = make_call_id(
+                    run_id=ledger.run_id,
+                    task_id=task_id,
+                    stage=stage,
+                    retry_kind=retry_kind,
+                    attempt_index=0,
+                    sequence=sequence,
+                )
+                sequence += 1
+                ledger.reserve(
+                    call_id=call_id,
+                    task_id=task_id,
+                    stage=stage,
+                    retry_kind=retry_kind,
+                    provider="azure",
+                    requested_model=model,
+                )
+                ledger.settle(
+                    call_id,
+                    usage=CallUsage(
+                        input_tokens=CALL_TOKENS, output_tokens=CALL_TOKENS
+                    ),
+                )
+        receipts = {
+            task_id: ledger.receipt_for(task_id, bucket) for task_id in plan
+        }
+    rows = [
+        {
+            "task_id": task_id,
+            "status": "success",
+            field: project_cost_receipt(receipt.as_dict()),
+        }
+        for task_id, receipt in receipts.items()
+    ]
+    return summarize_cost_receipts(rows, field)
+
+
+def _row(summary, stage, retry_kind=RETRY_NONE, model=None):
+    """The one row for this stage, retry kind and model."""
+    found = [
+        entry
+        for entry in summary["components"]
+        if entry["stage"] == stage
+        and entry["retry_kind"] == retry_kind
+        and (model is None or entry["requested_model"] == model)
+    ]
+    assert len(found) == 1, f"expected one row, got {found}"
+    return found[0]
+
+
+# ── two stages that both retried ──────────────────────────────────────────
+
+
+def test_two_stages_that_both_retried_are_two_rows(tmp_path, prices):
+    """The published defect, in the shape it was published in.
+
+    One task redid its generation and redid its self-review. Both lines derive
+    the name ``retry``, and the run summary used to add them together.
+    """
+    summary = _summary(tmp_path, prices, {
+        "task-a": [
+            (STAGE_GENERATION, RETRY_NONE, VISION),
+            (STAGE_GENERATION, RETRY_RESUME, VISION),
+            (STAGE_GENERATION, RETRY_RESUME, VISION),
+            (STAGE_SELF_QA, RETRY_NONE, VISION),
+            (STAGE_SELF_QA, RETRY_RESUME, VISION),
+            (STAGE_SELF_QA, RETRY_RESUME, VISION),
+        ],
+    })
+
+    retries = [
+        entry for entry in summary["components"] if entry["name"] == "retry"
+    ]
+    assert len(retries) == 2
+    assert {entry["stage"] for entry in retries} == {
+        STAGE_GENERATION, STAGE_SELF_QA
+    }
+    for entry in retries:
+        assert entry["known_cost_usd"] == 2 * VISION_PER_CALL
+        assert entry["model_calls"] == 2
+
+    # The whole run still adds up to what the ledger charged, so this splits a
+    # row rather than inventing or dropping one.
+    assert sum(e["known_cost_usd"] for e in summary["components"]) == (
+        6 * VISION_PER_CALL
+    )
+    assert sum(e["model_calls"] for e in summary["components"]) == 6
+
+
+def test_the_label_is_kept_beside_the_row_not_used_as_the_row(tmp_path, prices):
+    """``name`` still travels -- it is what a reader shows.
+
+    Dropping it would have been the other half of the same mistake: the fix is
+    that the label stops *identifying* a row, not that it stops being written.
+    """
+    summary = _summary(tmp_path, prices, {
+        "task-a": [
+            (STAGE_GENERATION, RETRY_NONE, VISION),
+            (STAGE_GENERATION, RETRY_RESUME, VISION),
+        ],
+    })
+    assert [entry["name"] for entry in summary["components"]] == [
+        "generation", "retry"
+    ]
+
+
+# ── two models under one stage ────────────────────────────────────────────
+
+
+def test_two_models_under_one_stage_are_two_rows(tmp_path, prices):
+    """Grading a deliverable with a picture and a recording in it.
+
+    A visual reader and an audio reader both run under ``perception``. Their
+    tokens are priced from different entries, so one row of their sum is a
+    figure neither entry produces: here $330 against a table that can only make
+    $30 and $300.
+    """
+    summary = _summary(
+        tmp_path, prices,
+        {
+            "task-a": [
+                (STAGE_GRADING, RETRY_NONE, VISION),
+                (STAGE_PERCEPTION, RETRY_NONE, VISION),
+                (STAGE_PERCEPTION, RETRY_NONE, AUDIO),
+            ],
+        },
+        bucket=BUCKET_GRADING,
+    )
+
+    perception = [
+        entry
+        for entry in summary["components"]
+        if entry["stage"] == STAGE_PERCEPTION
+    ]
+    assert len(perception) == 2
+    assert {entry["requested_model"] for entry in perception} == {VISION, AUDIO}
+    assert _row(summary, STAGE_PERCEPTION, model=VISION)["known_cost_usd"] == (
+        VISION_PER_CALL
+    )
+    assert _row(summary, STAGE_PERCEPTION, model=AUDIO)["known_cost_usd"] == (
+        AUDIO_PER_CALL
+    )
+    # Both rows carry the same label, which is exactly why the label cannot be
+    # what tells them apart.
+    assert {entry["name"] for entry in perception} == {"perception"}
+
+
+def test_the_row_carries_the_identity_that_makes_it_priceable(tmp_path, prices):
+    """Every field the receipt was keyed by reaches the summary row.
+
+    Keeping the split while dropping the identity would leave a reader two rows
+    they still cannot tell apart -- and ``requested_model`` alone does not do
+    it, which is the reason the key is seven fields rather than three.
+    """
+    summary = _summary(
+        tmp_path, prices,
+        {"task-a": [(STAGE_PERCEPTION, RETRY_NONE, AUDIO)]},
+        bucket=BUCKET_GRADING,
+    )
+    row = _row(summary, STAGE_PERCEPTION, model=AUDIO)
+    assert row["provider"] == "azure"
+    assert row["requested_model"] == AUDIO
+    assert row["resolved_model"] == AUDIO
+    # Not recorded by this run, and absent stays absent rather than defaulting
+    # to a name nothing was called under.
+    assert row["deployment"] is None
+    assert row["api_version"] is None
+
+
+# ── why a row could not be priced ─────────────────────────────────────────
+
+
+def test_a_missing_reason_names_the_row_it_belongs_to(tmp_path, prices):
+    """Two models under one stage, one of them unpriced.
+
+    The run has always said *that* something went unpriced. Until now it could
+    not say *which*, because the reason was kept only at the run level while
+    the two models shared a row.
+    """
+    summary = _summary(
+        tmp_path, prices,
+        {
+            "task-a": [
+                (STAGE_PERCEPTION, RETRY_NONE, VISION),
+                (STAGE_PERCEPTION, RETRY_NONE, UNPRICED),
+            ],
+        },
+        bucket=BUCKET_GRADING,
+    )
+
+    priced = _row(summary, STAGE_PERCEPTION, model=VISION)
+    unpriced = _row(summary, STAGE_PERCEPTION, model=UNPRICED)
+    assert priced["missing_reasons"] == []
+    assert priced["status"] == "complete"
+    assert REASON_PRICE_MISSING in unpriced["missing_reasons"]
+    assert unpriced["status"] == "partial"
+    # The run still says it, too. The row is where to act on it; the run is
+    # where a reader learns to look.
+    assert REASON_PRICE_MISSING in summary["missing_reasons"]
+
+
+def test_an_unpriced_row_is_not_a_free_row(tmp_path, prices):
+    """A model with no published rate cost real money.
+
+    ``0.0`` on a partial row is a floor, and it sits beside a reason that says
+    so. What must never happen is that floor reading as a price.
+    """
+    summary = _summary(
+        tmp_path, prices,
+        {"task-a": [(STAGE_PERCEPTION, RETRY_NONE, UNPRICED)]},
+        bucket=BUCKET_GRADING,
+    )
+    row = _row(summary, STAGE_PERCEPTION, model=UNPRICED)
+    assert row["model_calls"] == 1
+    assert row["status"] == "partial"
+    assert row["missing_reasons"] != []
+    assert summary["estimated_cost_usd"] is None
+
+
+# ── what the split must not break ─────────────────────────────────────────
+
+
+def test_one_task_is_one_task_in_every_row_it_paid(tmp_path, prices):
+    """The guard the fold was written for, which the split must keep.
+
+    ``tasks`` sits beside the amount as "how many tasks paid this". No row may
+    claim more tasks than the run contains, however many lines a task carried.
+    """
+    summary = _summary(tmp_path, prices, {
+        "task-a": [
+            (STAGE_GENERATION, RETRY_NONE, VISION),
+            (STAGE_GENERATION, RETRY_RESUME, VISION),
+            (STAGE_GENERATION, RETRY_RESUME, VISION),
+            (STAGE_SELF_QA, RETRY_RESUME, VISION),
+        ],
+        "task-b": [
+            (STAGE_GENERATION, RETRY_NONE, VISION),
+        ],
+    })
+    assert summary["receipt_tasks"] == 2
+    for entry in summary["components"]:
+        assert 1 <= entry["tasks"] <= 2
+    assert _row(summary, STAGE_GENERATION)["tasks"] == 2
+    assert _row(summary, STAGE_GENERATION, RETRY_RESUME)["tasks"] == 1
+
+
+def test_a_receipt_that_recorded_no_identity_still_sorts(tmp_path, prices):
+    """Every receipt published before call identity existed is in this state.
+
+    ``None`` and ``str`` do not compare in Python 3, so the case this change
+    exists to keep visible must not be the case that raises on the way out.
+    """
+    summary = _summary(tmp_path, prices, {
+        "task-a": [(STAGE_GENERATION, RETRY_NONE, VISION)],
+    })
+    stripped = [
+        {**entry, "provider": None, "resolved_model": None}
+        for entry in summary["components"]
+    ]
+    receipt = {
+        "schema_version": "cost-receipt-v1",
+        "currency": "USD",
+        "status": "complete",
+        "estimated_cost_usd": VISION_PER_CALL,
+        "known_cost_usd": VISION_PER_CALL,
+        "model_cost_usd": VISION_PER_CALL,
+        "runtime_cost_usd": None,
+        "model_calls": 1,
+        "usage": {"input_tokens": CALL_TOKENS},
+        "components": [
+            {
+                "name": entry["name"],
+                "stage": entry["stage"],
+                "retry_kind": entry["retry_kind"],
+                "status": "complete",
+                "known_cost_usd": entry["known_cost_usd"],
+                "model_calls": entry["model_calls"],
+                "usage": {},
+                "missing_reasons": [],
+            }
+            for entry in stripped
+        ],
+        "price_table_sha256": "a" * 64,
+        "missing_reasons": [],
+    }
+    rebuilt = summarize_cost_receipts(
+        [{
+            "task_id": "task-a",
+            "status": "success",
+            "problem_solving_cost": project_cost_receipt(receipt),
+        }],
+        "problem_solving_cost",
+    )
+    row = _row(rebuilt, STAGE_GENERATION)
+    assert row["provider"] is None
+    assert row["known_cost_usd"] == VISION_PER_CALL
+
+
+def test_the_row_count_stays_inside_what_a_receipt_may_carry(tmp_path, prices):
+    """Identity is the axis that consumes the headroom, so it is checked.
+
+    A published receipt may carry thirty-two lines. Splitting by identity makes
+    the summary wider than splitting by label did, and the bound on how much
+    wider is the run's own config -- the stages times the models named for
+    them -- not the run's size. Two tasks over the same six identities are six
+    rows, not twelve.
+    """
+    plan = [
+        (STAGE_GENERATION, RETRY_NONE, VISION),
+        (STAGE_GENERATION, RETRY_RESUME, VISION),
+        (STAGE_GENERATION, RETRY_NONE, AUDIO),
+        (STAGE_SELF_QA, RETRY_NONE, VISION),
+        (STAGE_SELF_QA, RETRY_RESUME, VISION),
+        (STAGE_SELF_QA, RETRY_NONE, AUDIO),
+    ]
+    summary = _summary(
+        tmp_path, prices, {"task-a": plan, "task-b": plan, "task-c": plan}
+    )
+    assert len(summary["components"]) == len(plan)
+    assert all(entry["tasks"] == 3 for entry in summary["components"])
+
+
+# ── the reader on the other side ──────────────────────────────────────────
+
+
+def test_the_javascript_mirror_keys_rows_the_same_way():
+    """The dashboard reads these receipts too, and a drifted mirror is the
+    same defect on the screen a reader actually looks at.
+
+    Read as text rather than run, which is the convention the rest of this
+    suite uses for the mirror: the backend suite has no Node. The behaviour is
+    asserted next to the mirror itself, in
+    ``scripts/__tests__/cost-receipt.test.mjs``.
+    """
+    source = MIRROR.read_text("utf-8")
+    aggregator = re.search(
+        r"function aggregateComponents\(receipts\) \{.*?\n\}", source, re.S
+    )
+    assert aggregator, "aggregateComponents is no longer where the mirror keeps it"
+    body = aggregator.group(0)
+
+    # The defect, in the exact shape it had: the displayed label used as the
+    # key of the per-receipt roll and of the run totals.
+    assert "rolled.has(component.name)" not in body
+    assert "totals.has(name)" not in body
+
+    # And the rule that replaced it.
+    assert "summaryComponentKey(component)" in body
+    assert "missing_reasons" in body
+
+    key = re.search(
+        r"function summaryComponentKey\(component\) \{.*?\n\}", source, re.S
+    )
+    assert key, "the mirror no longer names its key function"
+    for field in ("stage", "retry_kind", "COMPONENT_IDENTITY"):
+        assert field in key.group(0)

--- a/batch-runner/tests/test_cost_projection.py
+++ b/batch-runner/tests/test_cost_projection.py
@@ -630,10 +630,18 @@ def test_components_aggregate_across_tasks():
     assert summary["components"] == [
         {
             "name": "generation",
+            "stage": "generation",
+            "retry_kind": "none",
+            "provider": None,
+            "deployment": None,
+            "requested_model": None,
+            "resolved_model": None,
+            "api_version": None,
             "tasks": 2,
             "known_cost_usd": 0.5,
             "complete_tasks": 2,
             "model_calls": 6,
+            "missing_reasons": [],
             "status": "complete",
         },
     ]
@@ -641,8 +649,13 @@ def test_components_aggregate_across_tasks():
 
 def test_two_retries_in_one_task_are_one_task_in_the_component_total():
     # `tasks` sits beside the amount as "how many tasks paid this". A task that
-    # retried twice paid it once; counting the lines would make that column
-    # exceed the number of tasks in the run.
+    # retried twice paid each of these once; counting the lines would make that
+    # column exceed the number of tasks in the run.
+    #
+    # They are two rows, not one. Generation's retry and Self-QA's retry both
+    # display as 재시도, and folding them by that label summed a $0.15 charge
+    # into a $0.05 one and published `retry | $0.20 | 3 calls` — a row over two
+    # stages that no reader can take apart again.
     receipt = project_cost_receipt(
         _receipt(
             estimated_cost_usd=0.2,
@@ -667,13 +680,40 @@ def test_two_retries_in_one_task_are_one_task_in_the_component_total():
     assert summary["components"] == [
         {
             "name": "retry",
+            "stage": "generation",
+            "retry_kind": "infrastructure",
+            "provider": None,
+            "deployment": None,
+            "requested_model": None,
+            "resolved_model": None,
+            "api_version": None,
             "tasks": 1,
-            "known_cost_usd": 0.2,
+            "known_cost_usd": 0.15,
             "complete_tasks": 1,
-            "model_calls": 3,
+            "model_calls": 2,
+            "missing_reasons": [],
+            "status": "complete",
+        },
+        {
+            "name": "retry",
+            "stage": "self_qa",
+            "retry_kind": "semantic",
+            "provider": None,
+            "deployment": None,
+            "requested_model": None,
+            "resolved_model": None,
+            "api_version": None,
+            "tasks": 1,
+            "known_cost_usd": 0.05,
+            "complete_tasks": 1,
+            "model_calls": 1,
+            "missing_reasons": [],
             "status": "complete",
         },
     ]
+    # The guard this test was written for still holds: one task, and no row
+    # claiming more tasks paid it than the run contains.
+    assert all(row["tasks"] == 1 for row in summary["components"])
 
 
 # ── Ledger reference ──────────────────────────────────────────────────────

--- a/batch-runner/tests/test_every_call_belonged_to_a_stage.py
+++ b/batch-runner/tests/test_every_call_belonged_to_a_stage.py
@@ -20,9 +20,13 @@ This is a port rather than a new rule. Both other summarisers over these same
 receipts already roll the lines up:
 
 * ``core.cost_projection.summarize_cost_receipts`` folds each receipt's lines
-  by displayed name before touching the run totals;
+  before touching the run totals;
 * ``scripts/cost-receipt.mjs`` does the same in ``aggregateComponents`` and
   hands the result to the dashboard.
+
+Both of those folded by *displayed name* when this file was written, which is
+the defect ``test_a_run_summary_row_is_one_model_not_one_label.py`` was added
+to hold shut; all three now group on the key below.
 
 Those two produce a run-summary document. ``summarise_receipts`` returns a
 ``CostReceipt``, so its lines have to be ``ReceiptComponent`` objects, folded on

--- a/scripts/__tests__/cost-receipt.test.mjs
+++ b/scripts/__tests__/cost-receipt.test.mjs
@@ -637,10 +637,18 @@ test('components aggregate across tasks', () => {
   assert.deepEqual(summary.components, [
     {
       name: 'generation',
+      stage: 'generation',
+      retry_kind: 'none',
+      provider: null,
+      deployment: null,
+      requested_model: null,
+      resolved_model: null,
+      api_version: null,
       tasks: 2,
       known_cost_usd: 0.5,
       complete_tasks: 2,
       model_calls: 6,
+      missing_reasons: [],
       status: 'complete',
     },
   ]);
@@ -648,8 +656,13 @@ test('components aggregate across tasks', () => {
 
 test('two retries in one task are one task in the component total', () => {
   // `tasks` sits beside the amount as "how many tasks paid this". A task that
-  // retried twice paid it once; counting the lines would make that column
-  // exceed the number of tasks in the run.
+  // retried twice paid each of these once; counting the lines would make that
+  // column exceed the number of tasks in the run.
+  //
+  // They are two rows, not one. Generation's retry and Self-QA's retry both
+  // display as 재시도, and folding them by that label summed a $0.15 charge
+  // into a $0.05 one and published `retry | $0.20 | 3 calls` — a row over two
+  // stages that no reader can take apart again.
   const summary = summarizeCostReceipts([
     row(projectCostReceipt(receipt({
       estimated_cost_usd: 0.2,
@@ -672,13 +685,123 @@ test('two retries in one task are one task in the component total', () => {
   assert.deepEqual(summary.components, [
     {
       name: 'retry',
+      stage: 'generation',
+      retry_kind: 'infrastructure',
+      provider: null,
+      deployment: null,
+      requested_model: null,
+      resolved_model: null,
+      api_version: null,
       tasks: 1,
-      known_cost_usd: 0.2,
+      known_cost_usd: 0.15,
       complete_tasks: 1,
-      model_calls: 3,
+      model_calls: 2,
+      missing_reasons: [],
+      status: 'complete',
+    },
+    {
+      name: 'retry',
+      stage: 'self_qa',
+      retry_kind: 'semantic',
+      provider: null,
+      deployment: null,
+      requested_model: null,
+      resolved_model: null,
+      api_version: null,
+      tasks: 1,
+      known_cost_usd: 0.05,
+      complete_tasks: 1,
+      model_calls: 1,
+      missing_reasons: [],
       status: 'complete',
     },
   ]);
+  // The guard this test was written for still holds: one task, and no row
+  // claiming more tasks paid it than the run contains.
+  assert.ok(summary.components.every((entry) => entry.tasks === 1));
+});
+
+test('two models read under one stage are two rows in the run total', () => {
+  // The same rule one line down. A deliverable holding a picture and a
+  // recording is read by two models under one `perception` stage, and they are
+  // priced from different entries — so a row of their summed tokens is a figure
+  // neither entry produces. `retry_kind` cannot separate these: both are first
+  // attempts, and the only thing that differs is who was called.
+  const summary = summarizeCostReceipts([
+    row(projectCostReceipt(receipt({
+      estimated_cost_usd: 0.33,
+      known_cost_usd: 0.33,
+      model_cost_usd: 0.33,
+      runtime_cost_usd: null,
+      components: [
+        component({
+          name: 'perception', stage: 'perception', retry_kind: 'none',
+          provider: 'azure', requested_model: 'sees-things',
+          resolved_model: 'sees-things', known_cost_usd: 0.03,
+          model_calls: 1, usage: {},
+        }),
+        component({
+          name: 'perception', stage: 'perception', retry_kind: 'none',
+          provider: 'azure', requested_model: 'hears-things',
+          resolved_model: 'hears-things', known_cost_usd: 0.3,
+          model_calls: 1, usage: {},
+        }),
+      ],
+    }))),
+  ]);
+
+  assert.equal(summary.components.length, 2);
+  assert.deepEqual(
+    summary.components.map((entry) => entry.resolved_model),
+    ['hears-things', 'sees-things'],
+  );
+  assert.deepEqual(
+    summary.components.map((entry) => entry.known_cost_usd),
+    [0.3, 0.03],
+  );
+  // Both carry the same label, which is why the label cannot be the key.
+  assert.ok(summary.components.every((entry) => entry.name === 'perception'));
+});
+
+test('a missing reason names the row it belongs to', () => {
+  // Kept only at the run level, "no rate is published for this model" told a
+  // reader that something went unpriced but never which thing — and with the
+  // two readers merged into one row there was nothing it could have named.
+  const summary = summarizeCostReceipts([
+    row(projectCostReceipt(receipt({
+      status: 'partial',
+      estimated_cost_usd: null,
+      known_cost_usd: 0.03,
+      model_cost_usd: 0.03,
+      runtime_cost_usd: null,
+      components: [
+        component({
+          name: 'perception', stage: 'perception', retry_kind: 'none',
+          provider: 'azure', resolved_model: 'sees-things',
+          known_cost_usd: 0.03, model_calls: 1, usage: {},
+        }),
+        component({
+          name: 'perception', stage: 'perception', retry_kind: 'none',
+          provider: 'azure', resolved_model: 'unheard-of',
+          status: 'partial', known_cost_usd: null, model_calls: 1, usage: {},
+          missing_reasons: ['price_missing'],
+        }),
+      ],
+      missing_reasons: ['price_missing'],
+    }))),
+  ]);
+
+  const byModel = Object.fromEntries(
+    summary.components.map((entry) => [entry.resolved_model, entry]),
+  );
+  assert.deepEqual(byModel['sees-things'].missing_reasons, []);
+  assert.equal(byModel['sees-things'].status, 'complete');
+  assert.deepEqual(byModel['unheard-of'].missing_reasons, ['price_missing']);
+  assert.equal(byModel['unheard-of'].status, 'partial');
+  // The unpriced row still counted its call and still did not claim to be free.
+  assert.equal(byModel['unheard-of'].known_cost_usd, 0);
+  assert.equal(byModel['unheard-of'].model_calls, 1);
+  assert.equal(summary.estimated_cost_usd, null);
 });
 
 test('coverage reports the rows that carry no receipt at all', () => {

--- a/scripts/__tests__/cost-receipts.browser.mjs
+++ b/scripts/__tests__/cost-receipts.browser.mjs
@@ -65,7 +65,7 @@ const money = (value) => Number(value.toFixed(6))
  * There is no per-line estimate. The producer puts an estimate on the receipt
  * and nowhere else, so a line only ever reports what was confirmed.
  */
-function component(stage, amount, { status = 'complete', retryKind = 'none' } = {}) {
+function component(stage, amount, { status = 'complete', retryKind = 'none', model = null } = {}) {
   const measured = status === 'complete' || status === 'partial'
   return {
     // Derived at the producer: first work carries its stage's name, anything
@@ -79,6 +79,10 @@ function component(stage, amount, { status = 'complete', retryKind = 'none' } = 
     model_calls: measured ? 1 : 0,
     usage: measured ? { input_tokens: 1200, output_tokens: 340 } : {},
     missing_reasons: measured || status === 'not_run' ? [] : ['usage_absent'],
+    // Absent on every receipt published before call identity was recorded, so
+    // absent here by default. Named when two lines share a stage and a retry
+    // kind and only the model tells them apart.
+    ...(model ? { provider: 'azure', resolved_model: model } : {}),
   }
 }
 
@@ -292,7 +296,17 @@ const fullyPricedRows = () => [
     grade: receipt({
       status: 'complete',
       known: 0.12,
-      components: [component('grading', 0.1), component('perception', 0.02)],
+      components: [
+        component('grading', 0.1),
+        // A deliverable holding a picture and a recording is read by two
+        // models under one stage. Both lines display 판독 and both are first
+        // attempts, so nothing but the model separates them — and their rates
+        // differ, which makes a single row of their sum a figure no price
+        // table can reproduce. Two lines, $0.0200 between them, so every other
+        // amount on this task is unchanged.
+        component('perception', 0.015, { model: 'sees-things' }),
+        component('perception', 0.005, { model: 'hears-things' }),
+      ],
     }),
   },
   // Graded, but the judge recorded no cost: 기록 없음, not $0.
@@ -504,7 +518,6 @@ async function assertFullyPriced(page, solveSummary, gradeSummary) {
     ['self_qa', 'Self-QA', '$0.0300', 'problem_solving_cost'],
     ['retry', '재시도', '$0.0100', 'problem_solving_cost'],
     ['grading', '주 채점', '$0.1000', 'grading_cost'],
-    ['perception', '판독', '$0.0200', 'grading_cost'],
   ]) {
     const row = modalComponent(modal, field, slug)
     assert.equal(await row.count(), 1, `missing component row: ${field}/${slug}`)
@@ -512,6 +525,43 @@ async function assertFullyPriced(page, solveSummary, gradeSummary) {
     assert.match(text, literal(label), `component label mismatch: ${slug}`)
     assert.match(text, literal(amount), `component amount mismatch: ${slug}`)
   }
+
+  // The two readers stay two rows, and stay two rows a reader can act on.
+  // Keyed by name they were one $0.0200 line at a rate neither model charges;
+  // keyed by name in React they were two rows sharing one key. The stage and
+  // retry kind are identical here, so the model is the whole difference.
+  const perception = modalComponent(modal, 'grading_cost', 'perception')
+  assert.equal(await perception.count(), 2, 'the two readers merged into one row')
+  const readers = await perception.evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const [label, amount] = node.querySelectorAll('span')
+      return {
+        title: label.getAttribute('title'),
+        text: label.textContent.trim(),
+        amount: amount.textContent.trim(),
+        key: node.getAttribute('data-cost-component-key'),
+      }
+    }),
+  )
+  assert.deepEqual(
+    readers.map((reader) => reader.amount),
+    ['$0.0150', '$0.0050'],
+  )
+  // Both read 판독 on the row itself; the hover is what says which reader.
+  assert.deepEqual(
+    readers.map((reader) => reader.text),
+    ['· 판독', '· 판독'],
+  )
+  assert.deepEqual(
+    readers.map((reader) => reader.title),
+    ['판독 · sees-things', '판독 · hears-things'],
+  )
+  // And two distinct React keys, which is what the merged label cost them.
+  assert.equal(
+    new Set(readers.map((reader) => reader.key)).size,
+    2,
+    `both readers share one key: ${readers.map((reader) => reader.key)}`,
+  )
 
   // A retry keeps the stage it belonged to. The row reads 재시도; the hover is
   // what says which 재시도, and without it two stages that each had to repeat

--- a/scripts/cost-receipt.mjs
+++ b/scripts/cost-receipt.mjs
@@ -418,45 +418,105 @@ function receiptAmount(receipt) {
     : receipt.estimated_cost_usd;
 }
 
+/**
+ * The identity two run-summary lines must share before they may be added up.
+ *
+ * The same seven fields `projectCostReceipt` rejects duplicates of and
+ * `core.cost_receipts._component_key` groups a task's own lines under, so that
+ * the producer, this reader and the Python summariser all land on the same
+ * rows. Not `name`: `name` is *derived* from the first two — every retry at
+ * every stage derives `retry`, and both a visual reader and an audio reader
+ * derive `perception` — so it cannot tell those rows apart by construction.
+ */
+function summaryComponentKey(component) {
+  return JSON.stringify([
+    component.stage,
+    component.retry_kind,
+    ...COMPONENT_IDENTITY.map((column) => component[column] ?? null),
+  ]);
+}
+
 function aggregateComponents(receipts) {
   const totals = new Map();
   for (const receipt of receipts) {
-    // Roll one receipt's lines up by displayed name before touching the run
-    // totals. A task whose generation and Self-QA both had to be redone carries
-    // two 재시도 lines but is still one task, and counting it twice would make
-    // the coverage figure beside the row a fiction.
+    // Roll one receipt's lines up before touching the run totals. A task whose
+    // generation and Self-QA both had to be redone carries two 재시도 lines but
+    // is still one task, and counting it twice would make the coverage figure
+    // beside the row a fiction.
+    //
+    // Rolled by the line's own seven-field identity, not by the label it
+    // displays under. Folding by `name` was that same double-count guard turned
+    // into a merge: generation's retry and Self-QA's retry both display as
+    // 재시도, so one run published a single $0.190047 / 4-call 재시도 row over a
+    // $0.178985 / 2-call generation retry and a $0.011062 / 2-call Self-QA
+    // retry. Under `perception` it is worse than untidy — a visual reader and
+    // an audio reader carry different rates, and their summed tokens are a row
+    // no price table can reproduce and no reader can take apart again.
+    //
+    // Mirrors `summarize_cost_receipts` in batch-runner/core/cost_projection.py.
     const rolled = new Map();
     for (const component of receipt.components) {
-      if (!rolled.has(component.name)) {
-        rolled.set(component.name, { known_cost_usd: 0, model_calls: 0, complete: true });
+      const key = summaryComponentKey(component);
+      if (!rolled.has(key)) {
+        rolled.set(key, {
+          // Carried, not re-derived: the label is the producer's to choose,
+          // and this reader only displays it.
+          name: component.name,
+          known_cost_usd: 0,
+          model_calls: 0,
+          missing_reasons: new Set(),
+          complete: true,
+        });
       }
-      const entry = rolled.get(component.name);
+      const entry = rolled.get(key);
       if (component.known_cost_usd !== null) entry.known_cost_usd += component.known_cost_usd;
       if (component.model_calls) entry.model_calls += component.model_calls;
+      for (const reason of component.missing_reasons) entry.missing_reasons.add(reason);
       if (component.status !== 'complete') entry.complete = false;
     }
-    for (const [name, entry] of rolled) {
-      if (!totals.has(name)) {
-        totals.set(name, {
-          name,
+    for (const [key, entry] of rolled) {
+      if (!totals.has(key)) {
+        const [stage, retryKind, ...identity] = JSON.parse(key);
+        totals.set(key, {
+          name: entry.name,
+          stage,
+          retry_kind: retryKind,
+          ...Object.fromEntries(COMPONENT_IDENTITY.map((column, index) => [
+            column,
+            identity[index],
+          ])),
           tasks: 0,
           known_cost_usd: 0,
           complete_tasks: 0,
           model_calls: 0,
+          // Why a row could not be priced belongs beside the row. Kept only at
+          // the run level, "no rate published for this model" arrived detached
+          // from which model, which is the one thing a reader needs to act on
+          // it.
+          missing_reasons: new Set(),
         });
       }
-      const bucket = totals.get(name);
+      const bucket = totals.get(key);
       bucket.tasks += 1;
       if (entry.complete) bucket.complete_tasks += 1;
       bucket.known_cost_usd += entry.known_cost_usd;
       bucket.model_calls += entry.model_calls;
+      for (const reason of entry.missing_reasons) bucket.missing_reasons.add(reason);
     }
   }
+  // Unrecorded identity sorts first, which is the state every receipt
+  // published before call identity existed is honestly in.
+  const order = (bucket) => JSON.stringify([
+    bucket.stage,
+    bucket.retry_kind,
+    ...COMPONENT_IDENTITY.map((column) => bucket[column] ?? ''),
+  ]);
   return [...totals.values()]
-    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    .sort((a, b) => (order(a) < order(b) ? -1 : order(a) > order(b) ? 1 : 0))
     .map((bucket) => ({
       ...bucket,
       known_cost_usd: round(bucket.known_cost_usd, MONEY_DIGITS),
+      missing_reasons: [...bucket.missing_reasons].sort(),
       status: bucket.complete_tasks === bucket.tasks ? 'complete' : 'partial',
     }));
 }

--- a/src/lib/cost.ts
+++ b/src/lib/cost.ts
@@ -102,23 +102,55 @@ const RETRY_KIND_LABELS: Record<string, string> = {
 }
 
 /**
- * What a component row is, in full: which stage it belongs to and, when it was
- * not a first attempt, why it happened again. Two stages that each had to
- * retry are two rows both labelled 재시도, and this is what tells them apart.
+ * What a component row is, in full: which stage it belongs to, when it was not
+ * a first attempt why it happened again, and — when the run recorded it —
+ * which model's call it was. Two stages that each had to retry are two rows
+ * both labelled 재시도; a visual reader and an audio reader that both ran are
+ * two rows both labelled 판독. Stage and retry reason tell the first pair
+ * apart and the model tells the second, so a row is never two rows a reader
+ * cannot distinguish.
  */
 export function componentDetail(component: CostComponent): string {
   const stage = componentLabel(component.stage)
-  if (component.retry_kind === 'none') return stage
-  const reason = RETRY_KIND_LABELS[component.retry_kind] ?? component.retry_kind
-  return `${stage} · ${reason}`
+  const model =
+    component.resolved_model ?? component.requested_model ?? component.deployment
+  const parts = [stage]
+  if (component.retry_kind !== 'none') {
+    parts.push(RETRY_KIND_LABELS[component.retry_kind] ?? component.retry_kind)
+  }
+  // Absent stays absent. Every receipt published before call identity was
+  // recorded omits it, and inventing a name here would put one model's label
+  // on another model's tokens.
+  if (model) parts.push(model)
+  return parts.join(' · ')
 }
 
 /**
- * A row is identified by its stage and retry kind, not by its label, because
- * two stages that each had to retry both display as 재시도.
+ * A row is identified by its stage, its retry kind *and whose call it was* —
+ * never by its label.
+ *
+ * Stage and retry kind alone are not enough. Both perception models derive the
+ * same pair, so grading a deliverable holding a picture and a recording gave
+ * two rows one React key and left the reader two rows it could not tell apart.
+ * These are the same seven fields the producer groups a task's lines under and
+ * `projectCostReceipt` rejects duplicates of, so on any valid payload the key
+ * is unique.
+ *
+ * Each part is percent-encoded before joining, so a `:` inside a deployment
+ * alias cannot make two different rows produce one key.
  */
 export function componentKey(component: CostComponent): string {
-  return `${component.stage}:${component.retry_kind}`
+  return [
+    component.stage,
+    component.retry_kind,
+    component.provider ?? '',
+    component.deployment ?? '',
+    component.requested_model ?? '',
+    component.resolved_model ?? '',
+    component.api_version ?? '',
+  ]
+    .map(encodeURIComponent)
+    .join(':')
 }
 
 /** Four decimal places, matching the existing conservative-cost readouts. */

--- a/src/types/cost.ts
+++ b/src/types/cost.ts
@@ -100,12 +100,31 @@ export interface CostReceipt {
   missing_reasons: string[]
 }
 
+/**
+ * One component of a run's cost, rolled across every task that carried it.
+ *
+ * Keyed the same way one task's own line is: by stage, retry kind and call
+ * identity, never by `name`. `name` is derived from the first two, so folding
+ * by it summed a generation retry into a Self-QA one and a visual reader's
+ * tokens into an audio reader's — a row at no rate any price table holds.
+ */
 export interface CostComponentTotal {
+  /** The label to display. Derived by the producer, carried, not re-derived. */
   name: string
+  stage: string
+  retry_kind: string
+  /** Optional exactly as on `CostComponent`: absent means "not recorded". */
+  provider?: string | null
+  deployment?: string | null
+  requested_model?: string | null
+  resolved_model?: string | null
+  api_version?: string | null
   tasks: number
   known_cost_usd: number
   complete_tasks: number
   model_calls: number
+  /** Why *this* row went unpriced. Empty unless something did. */
+  missing_reasons: string[]
   status: 'complete' | 'partial'
 }
 


### PR DESCRIPTION
## What was wrong

A cost receipt line is **one model identity** — `(stage, retry_kind, provider, deployment, requested_model, resolved_model, api_version)`. The producer already keys on all seven: `core.cost_receipts._component_key` groups a task's lines that way, and `project_cost_receipt` rejects duplicates that way.

Both summarisers *downstream* of those receipts folded a run's lines by `components[].name`, and handed the result to `report_data.json` and to the dashboard.

`name` cannot carry that weight, because it is **derived** (`core/cost_receipts.py:668`):

```python
return self.stage if self.retry_kind == RETRY_NONE else COMPONENT_RETRY
```

Every retry at every stage derives `retry`. Both a visual reader and an audio reader derive `perception`. Folding by it is lossy by construction — and the loss is published.

## The evidence

On the run whose inference is at `HyeonSang/exp026c_cost_receipt_smoke` (`0d1d6df2…`, `self_report.json`), one task's four receipt lines:

| stage | retry_kind | known_cost_usd | calls |
|---|---|---|---|
| generation | none | $0.089673 | 1 |
| generation | resume | $0.178985 | 2 |
| self_qa | none | $0.005792 | 1 |
| self_qa | resume | $0.011062 | 2 |

arrived in `cost_summary` as **three**, the middle one reading:

```json
{"name": "retry", "known_cost_usd": 0.190047, "model_calls": 4}
```

`$0.178985 + $0.011062 = $0.190047` — two different stages added together under a label that names neither.

Under `perception` it is worse than untidy. A visual reader and an audio reader are priced from **different table entries**, so their summed tokens are a figure no price table can reproduce and no reader can take apart again.

## Two things went missing with the key

- **Identity** — provider, deployment, requested/resolved model, API version were dropped, so a reader could not tell which model a row was *even when the receipt underneath it knew*.
- **`missing_reasons`** — dropped outright; the bucket had no such field. "No rate is published for this model" reached the run and never the row, leaving a reader who could see that *something* was unpriced with no way to see **what**.

Both come back, keyed to the row they belong to.

## What changed

| File | Change |
|---|---|
| `batch-runner/core/cost_projection.py` | `_summary_component_key` / `_summary_component_order`; aggregation rolls and folds on the seven-field key, carries `name` beside the row, accumulates per-row `missing_reasons` |
| `scripts/cost-receipt.mjs` | same rule in `aggregateComponents`, so the dashboard and the report agree |
| `src/lib/cost.ts` | row detail names the model; row key percent-encodes all seven fields (two `perception` rows now coexist on screen) |
| `src/types/cost.ts` | `CostComponentTotal` gains stage, retry_kind, the five identity fields and `missing_reasons` |

Stored per-task receipts are **untouched**. This only stops the run summary from discarding what they already recorded.

### No new cap

Row count is bounded by the run's own **config**, not its size: stages times the models named for them — grading lands near 20 rows, inference near 10. Two tasks over the same six identities are six rows, not twelve (asserted). `_MAX_COMPONENTS = 32` applies to per-task receipts; `grade.schema.json` constrains only `$defs/costReceipt`, not run summaries, so no schema change is needed and none was made.

## Verification

- **New:** `batch-runner/tests/test_a_run_summary_row_is_one_model_not_one_label.py` — 10 cases built through a **real** `CostReceiptLedger` and `load_receipt_price_table` (two models at $30 and $300 per call), serialised as a published payload and read back through the real projection, so the arithmetic under test is the producer's end to end.
- **Mirrored:** 4 cases in `scripts/__tests__/cost-receipt.test.mjs` (40 pass / 0 fail).
- **On screen:** `cost-receipts.browser.mjs` splits the fixture's `perception` into two readers and asserts two rows render with distinct `data-cost-component-key` and distinct titles (`판독 · sees-things`, `판독 · hears-things`), with the run totals unchanged at `$0.1000` / `$0.3700`.
- **Docstring corrected:** `test_every_call_belonged_to_a_stage.py` said both downstream summarisers fold by displayed name. That is what this PR makes false, so the paragraph now says all three group on the same key.
- Every new assertion was **negative-controlled** against a faithful revert of the original code, not a partial edit.
- `npm run test:aggregate`, `npm run build`, and `mypy core/ --ignore-missing-imports` (174 errors in 32 files = exact baseline) all match baseline.

## Grader fingerprint

`core/**/*.py` is an input to `compute_grader_source_hash` (`step8_grade.py:162-179`), so this **moves the grader fingerprint**. Checked before merging: no Grade Pipeline run is in flight (most recent completed `2026-09-01T08:22:14Z`, success).
