### PR TITLE
feat(grading): 같은 답안을 세 번 채점하면 얼마나 달라지는지 측정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/stage3_partial_inventory.py
 !batch-runner/scripts/check_grader_hash_freeze.py
 !batch-runner/scripts/azure_rbac_diagnostic.py
+!batch-runner/scripts/analyze_repeat_variation.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/batch-runner/scripts/analyze_repeat_variation.py
+++ b/batch-runner/scripts/analyze_repeat_variation.py
@@ -1,0 +1,1361 @@
+#!/usr/bin/env python3
+"""Measure how far the grader alone moves when the same answers are graded again.
+
+Why this exists
+---------------
+``tasks/rebuilding_grading_task/315-repeat-variation-prereg.md`` separates two
+things that a single published score has already mixed together:
+
+    task difficulty   which thirty tasks were drawn
+    grader wobble     what the grader says the second time about the same words
+
+Stage 1 published 82.87%. That number is only worth arguing about if the second
+component is small, and stage 2's own card says its confidence-interval gate
+does not measure it -- resampling tasks gives 7.32pp, resampling runs gives
+0.86pp, and the gate reports neither separately. So this tool does not re-score
+that gate. It builds an estimator that targets the second component from the
+start, by pairing: the same task's score in run A and in run B are drawn
+together, so whether that task was hard or easy cancels inside the difference
+and only the movement between the two gradings is left.
+
+Everything here is a read. No grade payload is rewritten, and no model is
+called, so running this costs nothing.
+
+Why a second tool instead of an option on the first
+---------------------------------------------------
+``analyze_variance.py`` reproduces the three numbers stage 2 published. Changing
+its method would stop those numbers reproducing, which is the one thing a
+published result may not do. The preregistration says so in as many words, so
+this is a separate file that shares no code with it.
+
+What has to be identical, and what is refused
+---------------------------------------------
+Section 4 of the preregistration pins twelve fingerprints. They are checked
+twice over: every run must agree with every other run, and every run must also
+match the literal value written into the preregistration. Agreement alone would
+accept three runs of some *other* cohort that happened to agree with each
+other, and this document's numbers are about one cohort.
+
+``azure_ai_routes`` is deliberately not among them. It is not constant even
+inside a single run -- ``step9_merge_shards.py`` merges routes as a union for
+exactly that reason -- so freezing it would reject the runs stage 1 accepted.
+It is reported instead.
+
+The schema version is pinned to ``1.3`` rather than to whatever the code says
+today. ``step8_grade.py`` has since moved to ``1.4``; pinning to the current
+value would make these three files reject themselves.
+
+Two inputs that are the same run
+--------------------------------
+The most dangerous failure available here is being handed one file twice. Every
+difference metric would come out at exactly zero, zero passes every gate with
+room to spare, and the report would announce perfect stability having compared
+nothing. So the three file digests and the three ``graded_at`` stamps must all
+differ, and a repeat is an error rather than a warning.
+
+Why the resampling unit is the task and never the item
+-------------------------------------------------------
+Treating 1,433 rubric items as 1,433 independent observations makes the sample
+look large and is not true: items inside one task share an output, a set of
+files and a grading context, and when a task moves its items move together. The
+preregistration measured both ways on this data and recorded that the naive
+item bootstrap reports an interval about 1.5x narrower. So the unit here is the
+task, always, and drawing a task brings all of its items with it. The item
+bootstrap is still computed, but only to report that ratio, and it is labelled
+as not the official interval wherever it appears.
+
+The seed and the resample count are fixed
+------------------------------------------
+The result document quotes this tool's output inside a block that a test
+re-runs and compares byte for byte. An unseeded interval would fail that test
+every time it was checked, and a check that cannot be run is a check that is
+not done. Passing a different seed or a different resample count is allowed so
+that a mutation test can show the checks notice, but it turns the run's own
+verdict red: the analysis is only the registered analysis at the registered
+settings.
+
+Usage
+-----
+    python batch-runner/scripts/analyze_repeat_variation.py RUN1.json RUN2.json RUN3.json
+    python batch-runner/scripts/analyze_repeat_variation.py RUN*.json --json
+
+Exit status is 0 when the preregistered target is met and 1 when it is not, so
+a spread that missed the target cannot be reported as if it had met it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import random
+import statistics
+import sys
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+# Section 8. Fixed before the analysis was written, and quoted by the result
+# document, so neither may be changed without changing both.
+BOOTSTRAP_RESAMPLES = 10_000
+BOOTSTRAP_SEED = 20260901
+PERCENTILE_LOW = 2.5
+PERCENTILE_HIGH = 97.5
+
+# Section 8's target: the 95% interval on how far one run's corpus mean moves
+# when the same answers are graded again. 82.87% is 7.13pp short of 90%, so a
+# half-width of 1.0pp decides that question with a factor of seven to spare.
+HALF_WIDTH_TARGET_PP = 1.0
+
+# Section 4. Three runs, thirty tasks, and all three pairs -- picking one pair
+# would be picking the answer.
+EXPECTED_RUN_COUNT = 3
+EXPECTED_TASK_COUNT = 30
+PAIRS: tuple[tuple[int, int], ...] = ((0, 1), (0, 2), (1, 2))
+
+# Section 9. A verdict outside this vocabulary stops the run rather than being
+# given a handling rule invented on the spot.
+VERDICT_VOCABULARY: tuple[str, ...] = ("pass", "partial", "fail", "judge_error")
+
+# pass/partial/fail sit on one axis and a move across it can be one step or
+# two; judge_error is not on that axis at all, so it has no rank.
+VERDICT_RANK: dict[str, int] = {"fail": 0, "partial": 1, "pass": 2}
+
+# Section 11. This cohort has no audio items, which is why the audio flipping
+# recorded in 307 and 310-312 cannot be inside these intervals. That is a
+# checkable fact rather than a promise, so it is checked.
+FORBIDDEN_MODALITY = "audio"
+
+# Section 4's table, value for value. Each entry is a human label, a path into
+# the payload, and the value the preregistration wrote down.
+PINNED_FINGERPRINTS: tuple[tuple[str, tuple[str, ...], Any], ...] = (
+    (
+        "task list digest",
+        ("expected_ordered_task_ids_sha256",),
+        "82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b",
+    ),
+    ("task count", ("expected_task_count",), 30),
+    (
+        "grader source digest",
+        ("grader_source_hash",),
+        "c33d9d55703fbf5de5f988d427e34efd44d7a73306412caac88a753bad16ff4e",
+    ),
+    ("grading config", ("judge", "config_name"), "gold_ceiling_30_v2_sol_max"),
+    ("grading config hash", ("judge", "config_hash"), "d1bfc8217c9981d2"),
+    ("judge model", ("judge", "model"), "gpt-5.6-sol"),
+    ("judge deployment", ("judge", "deployment"), "gpt-5.6-sol"),
+    ("api version", ("judge", "api_version"), "2025-04-01-preview"),
+    ("reasoning effort", ("judge", "reasoning_effort"), "max"),
+    ("temperature", ("judge", "temperature"), 0),
+    ("seed", ("judge", "seed"), 42),
+    ("judge prompt version", ("prompt", "version"), "v2.2"),
+    (
+        "rubric revision",
+        ("rubric", "revision"),
+        "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+    ),
+    (
+        "renderer",
+        ("renderer_fingerprint",),
+        {
+            "libreoffice_binary": "soffice",
+            "libreoffice_version": "LibreOffice 24.2.7.2 420(Build:2)",
+            "pymupdf_version": "1.28.2",
+        },
+    ),
+    (
+        "gold revision",
+        ("source_inference_revision",),
+        "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+    ),
+    # Read the note in the module docstring before touching this one.
+    ("payload schema", ("schema_version",), "1.3"),
+)
+
+
+class RepeatsAreNotComparable(SystemExit):
+    """Raised when the inputs cannot answer the question that was asked.
+
+    Section 12 lists what invalidates the analysis. Every one of them is this
+    exception rather than a warning, because a warning printed above a number
+    is a number that gets quoted without the warning.
+    """
+
+
+def _dig(payload: dict[str, Any], path: tuple[str, ...]) -> Any:
+    """Follow a key path, returning ``None`` rather than raising on a gap."""
+    node: Any = payload
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            return None
+        node = node[key]
+    return node
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_runs(paths: list[Path]) -> list[dict[str, Any]]:
+    """Read the payloads and remember which file each one came from.
+
+    The file digest is carried on the payload under a private key. Nothing in a
+    grade payload records which repeat it is or where it was read from, and the
+    same-file-twice check needs both.
+    """
+    runs: list[dict[str, Any]] = []
+    for ordinal, path in enumerate(paths, start=1):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["_source_path"] = str(path)
+        payload["_source_digest"] = _digest(path)
+        payload["_label"] = f"run-{ordinal:03d}"
+        runs.append(payload)
+    return runs
+
+
+def fingerprint_problems(runs: list[dict[str, Any]]) -> list[str]:
+    """Section 12 checks 1, 2, 3 and 6, plus the literal match from section 4.
+
+    Ordered so that the cheapest and most fundamental disagreement is reported
+    first: three runs of different cohorts is a different fault from three runs
+    of the same cohort that drifted.
+    """
+    problems: list[str] = []
+
+    if len(runs) != EXPECTED_RUN_COUNT:
+        problems.append(
+            f"this analysis is registered for {EXPECTED_RUN_COUNT} runs and "
+            f"was given {len(runs)}"
+        )
+
+    # Check 1 and section 4's literals, in one pass so a mismatch says both
+    # what the runs disagreed about and what the document expected.
+    for label, path, expected in PINNED_FINGERPRINTS:
+        observed = [_dig(run, path) for run in runs]
+        field = ".".join(path)
+        if len(set(json.dumps(v, sort_keys=True) for v in observed)) > 1:
+            rendered = " | ".join(
+                f"{run['_label']}={json.dumps(value, ensure_ascii=False)}"
+                for run, value in zip(runs, observed)
+            )
+            problems.append(
+                f"{label} ({field}) differs between runs: {rendered}. A spread "
+                "measured across runs that differed here would measure that "
+                "difference, not the grader"
+            )
+            continue
+        if observed[0] != expected:
+            problems.append(
+                f"{label} ({field}) is "
+                f"{json.dumps(observed[0], ensure_ascii=False)}, and the "
+                "preregistration pinned "
+                f"{json.dumps(expected, ensure_ascii=False)}. These are not "
+                "the runs this analysis was registered for"
+            )
+
+    # Check 2. Being handed one run twice is the failure that would pass every
+    # gate having measured nothing.
+    for field in ("_source_digest", "graded_at"):
+        seen: dict[Any, str] = {}
+        for run in runs:
+            value = run.get(field)
+            if value in seen:
+                problems.append(
+                    f"{run['_label']} and {seen[value]} have the same "
+                    f"{field.lstrip('_')}, so at least two of these inputs are "
+                    "the same run. Comparing a run with itself reports zero "
+                    "movement and proves nothing"
+                )
+            else:
+                seen[value] = run["_label"]
+
+    # Check 6, and section 9's rule that a missing score stops the run rather
+    # than being dropped -- dropping a task quietly moves the mean towards the
+    # tasks that survived.
+    for run in runs:
+        tasks = run.get("tasks") or []
+        if len(tasks) != EXPECTED_TASK_COUNT:
+            problems.append(
+                f"{run['_label']} graded {len(tasks)} tasks and this analysis "
+                f"is registered for {EXPECTED_TASK_COUNT}"
+            )
+        unscored = [t["task_id"] for t in tasks if t.get("pct") is None]
+        if unscored:
+            problems.append(
+                f"{run['_label']} has no score for {len(unscored)} task(s): "
+                f"{', '.join(sorted(unscored)[:5])}. A task with no score is "
+                "not quietly dropped"
+            )
+
+    return problems
+
+
+def _item_index(run: dict[str, Any]) -> dict[tuple[str, str], dict[str, Any]]:
+    index: dict[tuple[str, str], dict[str, Any]] = {}
+    for task in run["tasks"]:
+        for item in task["items"]:
+            index[(task["task_id"], item["rubric_item_id"])] = item
+    return index
+
+
+def _document_order(run: dict[str, Any]) -> list[str]:
+    """Task ids in the order the first payload lists them.
+
+    Not sorted. The resampling draws from this list, so the order is part of
+    the recipe that reproduces the preregistration's interval, and sorting it
+    would move the endpoints by a few thousandths for no reason at all.
+    """
+    return [task["task_id"] for task in run["tasks"]]
+
+
+def shape_problems(runs: list[dict[str, Any]]) -> list[str]:
+    """Section 12 checks 4, 5 and 7.
+
+    Kept apart from the fingerprint checks because these read the body of the
+    payload rather than its header, and because a caller that wants to know
+    whether two files are the same run should not have to load every item to
+    find out.
+    """
+    problems: list[str] = []
+
+    indexes = [_item_index(run) for run in runs]
+    key_sets = [frozenset(index) for index in indexes]
+    if len(set(key_sets)) > 1:
+        shared = frozenset.intersection(*key_sets)
+        for run, keys in zip(runs, key_sets):
+            missing = keys - shared
+            if missing:
+                sample = ", ".join(
+                    f"{task}/{item}" for task, item in sorted(missing)[:3]
+                )
+                problems.append(
+                    f"{run['_label']} carries {len(missing)} rubric item(s) "
+                    f"the other runs do not, for example {sample}. Items that "
+                    "are not in every run cannot be paired"
+                )
+
+    for run, index in zip(runs, indexes):
+        strange = sorted(
+            {
+                str(item.get("verdict"))
+                for item in index.values()
+                if item.get("verdict") not in VERDICT_VOCABULARY
+            }
+        )
+        if strange:
+            problems.append(
+                f"{run['_label']} contains verdict value(s) outside the "
+                f"registered vocabulary: {', '.join(strange)}. A handling rule "
+                "is not invented while the numbers are being produced"
+            )
+
+        audio = [
+            key
+            for key, item in index.items()
+            if item.get("routing_modality") == FORBIDDEN_MODALITY
+        ]
+        if audio:
+            problems.append(
+                f"{run['_label']} contains {len(audio)} {FORBIDDEN_MODALITY} "
+                "item(s). Section 11 records this cohort as having none, and "
+                "the audio flipping measured elsewhere must not be folded into "
+                "these intervals"
+            )
+
+    return problems
+
+
+def common_denominator_keys(runs: list[dict[str, Any]]) -> set[tuple[str, str]]:
+    """Items that carry a score in every run.
+
+    Section 5. A ``judge_error`` verdict takes its item out of the numerator
+    *and* the denominator, so the corpus total moves between runs and a plain
+    difference of two published percentages mixes "the verdict changed" with
+    "the denominator changed". Task ``a328feea`` is the clear case: the same
+    18.6 points is 84.55% out of 22 and 77.50% out of 24, so the run where the
+    grader failed scores higher.
+    """
+    indexes = [_item_index(run) for run in runs]
+    shared = frozenset.intersection(*(frozenset(index) for index in indexes))
+    return {
+        key
+        for key in shared
+        if not any(index[key].get("score_excluded") for index in indexes)
+    }
+
+
+def denominator_movement(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Report the moving denominator instead of absorbing it.
+
+    Section 5 asks for this as a metric in its own right. Quietly correcting
+    for it would be this document committing the fault it was written to point
+    out.
+    """
+    per_task: list[dict[str, Any]] = []
+    for task_id in _document_order(runs[0]):
+        maxima = []
+        for run in runs:
+            task = next(t for t in run["tasks"] if t["task_id"] == task_id)
+            maxima.append(task["total_max"])
+        if len(set(maxima)) > 1:
+            per_task.append({"task_id": task_id, "total_max": maxima})
+
+    excluded = 0
+    judge_errors = 0
+    mismatched = 0
+    for run in runs:
+        index = _item_index(run)
+        for item in index.values():
+            is_excluded = bool(item.get("score_excluded"))
+            is_error = item.get("verdict") == "judge_error"
+            excluded += is_excluded
+            judge_errors += is_error
+            mismatched += is_excluded != is_error
+
+    shared = frozenset.intersection(
+        *(frozenset(_item_index(run)) for run in runs)
+    )
+    common = common_denominator_keys(runs)
+
+    return {
+        "tasks_whose_total_max_moved": per_task,
+        "shared_items": len(shared),
+        "items_in_common_denominator": len(common),
+        "items_dropped_from_common_denominator": len(shared) - len(common),
+        "score_excluded_events": excluded,
+        "judge_error_events": judge_errors,
+        # Section 5 says these are the same four events. If they ever stop
+        # being the same events the denominator has a second cause and the
+        # rule above stops being complete, so it is measured rather than
+        # assumed.
+        "excluded_and_error_disagree": mismatched,
+    }
+
+
+def per_task_percent(
+    runs: list[dict[str, Any]], keys: set[tuple[str, str]] | None
+) -> dict[str, list[float]]:
+    """Each task's percentage in each run.
+
+    ``keys`` restricts the arithmetic to the common denominator. Passing
+    ``None`` reads the ``pct`` the payload published, which is the secondary
+    baseline that joins these numbers to the ones stage 1 announced.
+    """
+    scores: dict[str, list[float]] = {}
+    for task_id in _document_order(runs[0]):
+        row: list[float] = []
+        for run in runs:
+            task = next(t for t in run["tasks"] if t["task_id"] == task_id)
+            if keys is None:
+                row.append(float(task["pct"]))
+                continue
+            awarded = 0.0
+            maximum = 0.0
+            for item in task["items"]:
+                if (task_id, item["rubric_item_id"]) not in keys:
+                    continue
+                awarded += float(item["awarded_score"])
+                maximum += float(item["max_score"])
+            row.append(100.0 * awarded / maximum if maximum else 0.0)
+        scores[task_id] = row
+    return scores
+
+
+def percentile(sorted_values: list[float], q: float) -> float:
+    """Linear-interpolated percentile.
+
+    Section 8 fixes the method as percentile rather than BCa: at n=30 with
+    clustered draws the acceleration term is unstable, and an interval whose
+    correction is noisier than the thing it corrects is not an improvement.
+    """
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (q / 100.0) * (len(sorted_values) - 1)
+    low = math.floor(rank)
+    high = math.ceil(rank)
+    if low == high:
+        return sorted_values[low]
+    weight = rank - low
+    return sorted_values[low] + (sorted_values[high] - sorted_values[low]) * weight
+
+
+def _interval(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    low = percentile(ordered, PERCENTILE_LOW)
+    high = percentile(ordered, PERCENTILE_HIGH)
+    return {
+        "low": low,
+        "high": high,
+        "width": high - low,
+        "half_width": (high - low) / 2.0,
+    }
+
+
+def cluster_bootstrap_ratio(
+    task_ids: list[str],
+    numerator: dict[str, float],
+    denominator: dict[str, float],
+    *,
+    resamples: int,
+    seed: int,
+) -> dict[str, float]:
+    """Resample whole tasks and re-form a rate out of what was drawn.
+
+    The statistic is a ratio of sums rather than a mean of per-task rates,
+    because tasks hold different numbers of items and a mean of rates would
+    quietly give a five-item task the same weight as a hundred-item one.
+
+    A fresh generator every call. Sharing one stream between the bootstraps in
+    a single run would make each interval depend on how many were computed
+    before it, which is a reproducibility trap that costs nothing to avoid.
+    """
+    rng = random.Random(seed)
+    size = len(task_ids)
+    values: list[float] = []
+    for _ in range(resamples):
+        top = 0.0
+        bottom = 0.0
+        for _ in range(size):
+            drawn = task_ids[rng.randrange(size)]
+            top += numerator[drawn]
+            bottom += denominator[drawn]
+        values.append(100.0 * top / bottom if bottom else 0.0)
+    return _interval(values)
+
+
+def cluster_bootstrap_mean(
+    task_ids: list[str],
+    value_by_task: dict[str, float],
+    *,
+    resamples: int,
+    seed: int,
+) -> dict[str, float]:
+    """Resample whole tasks and average a per-task quantity over the draw.
+
+    Used for the differences, where every task contributes one number and the
+    corpus figure really is their unweighted mean -- that is how the published
+    headline was formed.
+    """
+    rng = random.Random(seed)
+    size = len(task_ids)
+    values: list[float] = []
+    for _ in range(resamples):
+        total = 0.0
+        for _ in range(size):
+            total += value_by_task[task_ids[rng.randrange(size)]]
+        values.append(total / size)
+    return _interval(values)
+
+
+def item_bootstrap_rate(
+    flags: list[int], *, resamples: int, seed: int
+) -> dict[str, float]:
+    """The interval this analysis does *not* use, computed so it can be shown.
+
+    Section 6 rejects treating rubric items as independent observations. The
+    number is still produced, because "we chose the wider method" is a claim
+    and the ratio between the two widths is the evidence for it.
+    """
+    rng = random.Random(seed)
+    size = len(flags)
+    values: list[float] = []
+    for _ in range(resamples):
+        hits = 0
+        for _ in range(size):
+            hits += flags[rng.randrange(size)]
+        values.append(100.0 * hits / size)
+    return _interval(values)
+
+
+def _binomial_cdf(n: int, k: int, p: float) -> float:
+    """P(X <= k) for X ~ Binomial(n, p), summed in log space.
+
+    ``math.comb(4299, 177)`` is a 400-digit integer and multiplying it by a
+    float raises OverflowError, so the terms are built from log-gamma and
+    exponentiated one at a time.
+
+    A rate of exactly 0 or exactly 1 is answered without the sum. It is a
+    legitimate observation -- a grader that never disagreed with itself would
+    produce one, and so does feeding this tool the same file three times -- and
+    ``math.log(0.0)`` raises rather than returning the negative infinity the
+    formula wants.
+    """
+    if p <= 0.0:
+        return 1.0 if k >= 0 else 0.0
+    if p >= 1.0:
+        return 1.0 if k >= n else 0.0
+
+    total = 0.0
+    for x in range(k + 1):
+        log_term = (
+            math.lgamma(n + 1)
+            - math.lgamma(x + 1)
+            - math.lgamma(n - x + 1)
+            + x * math.log(p)
+            + (n - x) * math.log1p(-p)
+        )
+        total += math.exp(log_term)
+    return total
+
+
+def naive_endpoint_bracket(flags: list[int]) -> dict[str, Any]:
+    """Which two whole counts the naive interval's lower endpoint sits between.
+
+    The preregistration recorded 4.094 for this endpoint and re-running it here
+    gives 4.117. Eleven implementations were tried before the reason became
+    clear, and the reason is not the implementation. Under item resampling the
+    statistic is a count out of 4,299 divided by 4,299, so it can only land on
+    multiples of 1/4299 = 0.0233pp. The exact binomial distribution puts
+    P(X <= 176) just under 2.5% and P(X <= 177) just over it, which means the
+    true 2.5th percentile falls strictly between two counts that no draw can
+    return. Both figures are honest realisations of the same quantity and they
+    differ by one item.
+
+    This is arithmetic rather than a resampling result, so it is exact and a
+    test can check it without running a bootstrap.
+    """
+    n = len(flags)
+    hits = sum(flags)
+    p = hits / n
+    target = PERCENTILE_LOW / 100.0
+    if hits in (0, n):
+        # Every draw returns the same count, so the quantile lands on a count a
+        # draw can actually return and there is nothing to bracket.
+        counts = [hits]
+    else:
+        lower = next(
+            k for k in range(n + 1) if _binomial_cdf(n, k, p) >= target
+        ) - 1
+        counts = [lower, lower + 1]
+    return {
+        "trials": n,
+        "observed": hits,
+        "rate_pct": 100.0 * p,
+        "quantile": PERCENTILE_LOW,
+        "bracketing_counts": [
+            {
+                "count": k,
+                "rate_pct": 100.0 * k / n,
+                "cdf": _binomial_cdf(n, k, p),
+            }
+            for k in counts
+        ],
+        "step_pct": 100.0 / n,
+    }
+
+
+def _score_outcome(item: dict[str, Any]) -> tuple[Any, bool]:
+    """What a reader would call "the same result" for one item.
+
+    The verdict alone is not enough. A ``partial`` that moved from 2.0 to 1.5
+    keeps its label and changes the score, and section 3 counts 246 items that
+    did exactly that.
+    """
+    return (item["awarded_score"], bool(item.get("score_excluded")))
+
+
+def disagreement(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Metric 5, and the transition counts metric 2 asks for.
+
+    Both bases are reported side by side. Reporting only the verdict basis
+    hides how much the scoreboard moved; reporting only the score basis hides
+    how often a sentence a person would quote came out the other way.
+    """
+    indexes = [_item_index(run) for run in runs]
+    keys = _document_order(runs[0])
+    ordered_keys = [
+        (task["task_id"], item["rubric_item_id"])
+        for task in runs[0]["tasks"]
+        for item in task["items"]
+    ]
+
+    verdict_flags: list[int] = []
+    score_flags: list[int] = []
+    verdict_by_task: dict[str, float] = {task_id: 0.0 for task_id in keys}
+    score_by_task: dict[str, float] = {task_id: 0.0 for task_id in keys}
+    pairs_by_task: dict[str, float] = {task_id: 0.0 for task_id in keys}
+    transitions: dict[tuple[str, str], int] = {}
+    per_pair_verdict: list[int] = []
+    per_pair_score: list[int] = []
+    adjacent = 0
+    two_step = 0
+    same_verdict_moved_score = 0
+
+    for left, right in PAIRS:
+        pair_verdict = 0
+        pair_score = 0
+        for key in ordered_keys:
+            a = indexes[left][key]
+            b = indexes[right][key]
+            task_id = key[0]
+            pairs_by_task[task_id] += 1
+
+            differs = a["verdict"] != b["verdict"]
+            verdict_flags.append(int(differs))
+            pair_verdict += differs
+            verdict_by_task[task_id] += differs
+
+            moved = _score_outcome(a) != _score_outcome(b)
+            score_flags.append(int(moved))
+            pair_score += moved
+            score_by_task[task_id] += moved
+
+            if differs:
+                cell = (a["verdict"], b["verdict"])
+                transitions[cell] = transitions.get(cell, 0) + 1
+                left_rank = VERDICT_RANK.get(a["verdict"])
+                right_rank = VERDICT_RANK.get(b["verdict"])
+                if left_rank is not None and right_rank is not None:
+                    if abs(left_rank - right_rank) == 2:
+                        two_step += 1
+                    else:
+                        adjacent += 1
+            elif moved:
+                same_verdict_moved_score += 1
+
+        per_pair_verdict.append(pair_verdict)
+        per_pair_score.append(pair_score)
+
+    total_pairs = len(ordered_keys) * len(PAIRS)
+    return {
+        "compared_items": len(ordered_keys),
+        "compared_item_pairs": total_pairs,
+        "verdict": {
+            "differing": sum(verdict_flags),
+            "rate_pct": 100.0 * sum(verdict_flags) / total_pairs,
+            "per_pair": per_pair_verdict,
+            "flags": verdict_flags,
+            "by_task": verdict_by_task,
+        },
+        "score_outcome": {
+            "differing": sum(score_flags),
+            "rate_pct": 100.0 * sum(score_flags) / total_pairs,
+            "per_pair": per_pair_score,
+            "flags": score_flags,
+            "by_task": score_by_task,
+        },
+        "pairs_by_task": pairs_by_task,
+        "transitions": {f"{a}->{b}": n for (a, b), n in sorted(transitions.items())},
+        "adjacent_moves": adjacent,
+        "two_step_moves": two_step,
+        "same_verdict_moved_score": same_verdict_moved_score,
+    }
+
+
+def differences(
+    runs: list[dict[str, Any]],
+    scores: dict[str, list[float]],
+    *,
+    resamples: int,
+    seed: int,
+) -> dict[str, Any]:
+    """Metric 1 and the target in section 8.
+
+    The signed mean answers "is one run consistently kinder"; the absolute mean
+    answers "how big is the movement". They are different questions and a
+    corpus whose movements cancel would answer the first with zero while the
+    second stayed large, so both are reported.
+    """
+    task_ids = list(scores)
+    per_pair: list[dict[str, Any]] = []
+    for left, right in PAIRS:
+        signed = {t: scores[t][left] - scores[t][right] for t in task_ids}
+        values = list(signed.values())
+        per_pair.append(
+            {
+                "pair": f"run-{left + 1:03d} vs run-{right + 1:03d}",
+                "mean_signed_pp": statistics.fmean(values),
+                "mean_absolute_pp": statistics.fmean(abs(v) for v in values),
+                "max_absolute_pp": max(abs(v) for v in values),
+                "corpus_mean_shift_ci": cluster_bootstrap_mean(
+                    task_ids, signed, resamples=resamples, seed=seed
+                ),
+            }
+        )
+
+    # The combined figure uses absolute differences. Adding the three signed
+    # pair differences telescopes -- run 1 appears twice with opposite signs --
+    # so a signed pooled mean would say more about which pairs were listed than
+    # about the grader.
+    combined = {
+        t: statistics.fmean(
+            abs(scores[t][left] - scores[t][right]) for left, right in PAIRS
+        )
+        for t in task_ids
+    }
+    return {
+        "per_pair": per_pair,
+        "combined_absolute": {
+            "mean_pp": statistics.fmean(combined.values()),
+            "median_pp": statistics.median(combined.values()),
+            "max_pp": max(combined.values()),
+            "ci": cluster_bootstrap_mean(
+                task_ids, combined, resamples=resamples, seed=seed
+            ),
+        },
+        "worst_half_width_pp": max(
+            row["corpus_mean_shift_ci"]["half_width"] for row in per_pair
+        ),
+    }
+
+
+def corpus_summary(scores: dict[str, list[float]]) -> dict[str, Any]:
+    """Metric 4, per run, on whichever baseline was handed in."""
+    rows: list[dict[str, Any]] = []
+    for ordinal in range(EXPECTED_RUN_COUNT):
+        values = [row[ordinal] for row in scores.values()]
+        rows.append(
+            {
+                "run": f"run-{ordinal + 1:03d}",
+                "mean_pct": statistics.fmean(values),
+                "median_pct": statistics.median(values),
+                # Sample variance: three runs are a sample, not the population.
+                "variance": statistics.variance(values),
+                "stdev": statistics.stdev(values),
+            }
+        )
+    return {
+        "per_run": rows,
+        "mean_spread_pp": max(r["mean_pct"] for r in rows)
+        - min(r["mean_pct"] for r in rows),
+    }
+
+
+def observed_vocabulary(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Metric 3, with section 9's rule that absence is written as absence.
+
+    There is no refusal and no tool-failure field in this schema. Reporting
+    "refusal rate 0.0%" would read as a measurement, and it is not one: the
+    vocabulary simply never contained the value. The ``read_deliverable``
+    census is the nearest available signal and is labelled a proxy, tail and
+    all -- the interesting end is the zero-call end, where a verdict was
+    reached without opening the deliverable once.
+    """
+    counts: dict[str, int] = {v: 0 for v in VERDICT_VOCABULARY}
+    modality: dict[str, int] = {}
+    selection: dict[str, int] = {}
+    decided_by: dict[str, int] = {}
+    reads: dict[int, int] = {}
+    for run in runs:
+        for item in _item_index(run).values():
+            counts[item["verdict"]] += 1
+            key = str(item.get("routing_modality"))
+            modality[key] = modality.get(key, 0) + 1
+            status = str(item.get("selection_status"))
+            selection[status] = selection.get(status, 0) + 1
+            decider = str(item.get("decided_by"))
+            decided_by[decider] = decided_by.get(decider, 0) + 1
+            calls = sum(
+                1
+                for tool in (item.get("tools_used") or [])
+                if tool == "read_deliverable"
+            )
+            reads[calls] = reads.get(calls, 0) + 1
+
+    graded = sum(counts.values())
+    return {
+        "verdicts": counts,
+        "judge_error_rate_pct": 100.0 * counts["judge_error"] / graded,
+        "refusal": "not in this schema and not observed - absent, not measured",
+        "tool_failure": "no field exists - the read census below is a proxy",
+        "read_deliverable_calls": dict(sorted(reads.items())),
+        "routing_modality": dict(sorted(modality.items())),
+        "selection_status": dict(sorted(selection.items())),
+        "decided_by": dict(sorted(decided_by.items())),
+        "error_tasks": [
+            {"run": run["_label"], "error_tasks": run["summary"]["error_tasks"]}
+            for run in runs
+        ],
+    }
+
+
+def usage(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Metric 6. The money column stays unregistered rather than becoming zero.
+
+    ``gpt-5.6-sol`` is not in the price table. A run that could not be priced
+    is not a free run, and writing $0.00 would turn a gap in the table into a
+    claim about the bill.
+    """
+    rows: list[dict[str, Any]] = []
+    for run in runs:
+        cost = run["summary"]["cost"]
+        tasks = run["tasks"]
+        rows.append(
+            {
+                "run": run["_label"],
+                "graded_at": run["graded_at"],
+                "judge_calls": cost["total_judge_calls"],
+                "main_judge_calls": cost["total_main_judge_calls"],
+                "perception_calls": cost["total_perception_calls"],
+                "input_tokens": cost["total_input_tokens"],
+                "output_tokens": cost["total_output_tokens"],
+                "cached_tokens": cost["total_cached_tokens"],
+                "judge_latency_ms": sum(t["judge_total_latency_ms"] for t in tasks),
+                "estimated_cost_usd": (
+                    "unregistered - "
+                    + ", ".join(cost.get("unpriced_models") or ["unknown model"])
+                    + " is not in the price table"
+                    if cost.get("estimated_cost_usd") is None
+                    else cost["estimated_cost_usd"]
+                ),
+                "azure_routes": sorted(
+                    {
+                        f"{r['workload']}/{r['endpoint_kind']}"
+                        for r in (run.get("azure_ai_routes") or [])
+                    }
+                ),
+            }
+        )
+    return rows
+
+
+def required_extra_runs(
+    scores: dict[str, list[float]], *, target_pp: float
+) -> dict[str, Any]:
+    """Section 13. What would have to be bought if the free data falls short.
+
+        half-width ~ 1.96 * sigma_d / sqrt(n * (R - 1))
+        R = ceil( (1.96 * sigma_d / (target * sqrt(n)))^2 ) + 1
+
+    sigma_d is taken from the widest pair, so the answer is the number of runs
+    that satisfies the target for the pair that needed the most, not for the
+    average pair.
+    """
+    task_ids = list(scores)
+    sigmas = [
+        statistics.stdev([scores[t][left] - scores[t][right] for t in task_ids])
+        for left, right in PAIRS
+    ]
+    sigma = max(sigmas)
+    n = len(task_ids)
+    needed = math.ceil((1.96 * sigma / (target_pp * math.sqrt(n))) ** 2) + 1
+    return {
+        "pair_difference_stdev_pp": sigmas,
+        "worst_pair_difference_stdev_pp": sigma,
+        "runs_required_for_target": max(needed, EXPECTED_RUN_COUNT),
+        "runs_held": EXPECTED_RUN_COUNT,
+    }
+
+
+def analyze(
+    runs: list[dict[str, Any]],
+    *,
+    resamples: int,
+    seed: int,
+    resample_unit: str,
+) -> dict[str, Any]:
+    common = common_denominator_keys(runs)
+    common_scores = per_task_percent(runs, common)
+    published_scores = per_task_percent(runs, None)
+
+    flips = disagreement(runs)
+    task_ids = _document_order(runs[0])
+    pairs_by_task = flips["pairs_by_task"]
+
+    if resample_unit == "task":
+        verdict_ci = cluster_bootstrap_ratio(
+            task_ids,
+            flips["verdict"]["by_task"],
+            pairs_by_task,
+            resamples=resamples,
+            seed=seed,
+        )
+        score_ci = cluster_bootstrap_ratio(
+            task_ids,
+            flips["score_outcome"]["by_task"],
+            pairs_by_task,
+            resamples=resamples,
+            seed=seed,
+        )
+    else:
+        verdict_ci = item_bootstrap_rate(
+            flips["verdict"]["flags"], resamples=resamples, seed=seed
+        )
+        score_ci = item_bootstrap_rate(
+            flips["score_outcome"]["flags"], resamples=resamples, seed=seed
+        )
+
+    naive_verdict_ci = item_bootstrap_rate(
+        flips["verdict"]["flags"], resamples=resamples, seed=seed
+    )
+    cluster_verdict_ci = cluster_bootstrap_ratio(
+        task_ids,
+        flips["verdict"]["by_task"],
+        pairs_by_task,
+        resamples=resamples,
+        seed=seed,
+    )
+
+    common_diff = differences(
+        runs, common_scores, resamples=resamples, seed=seed
+    )
+    published_diff = differences(
+        runs, published_scores, resamples=resamples, seed=seed
+    )
+
+    # The gate takes the worse of the two baselines. The common denominator is
+    # the primary one because it is the only basis on which a difference means
+    # only what the grader did, but the figure a reader would quote is the
+    # published one, and a gate that watched the primary basis alone could pass
+    # while the numbers people actually cite moved further.
+    worst_half_width = max(
+        common_diff["worst_half_width_pp"], published_diff["worst_half_width_pp"]
+    )
+    target_met = worst_half_width <= HALF_WIDTH_TARGET_PP
+
+    # The settings are part of the result. An interval computed at a different
+    # seed, a different resample count or a different unit is a real number
+    # about a different analysis, and this tool refuses to sign it as this one.
+    settings_registered = (
+        seed == BOOTSTRAP_SEED
+        and resamples == BOOTSTRAP_RESAMPLES
+        and resample_unit == "task"
+    )
+
+    return {
+        "settings": {
+            "resamples": resamples,
+            "seed": seed,
+            "resample_unit": resample_unit,
+            "percentile": [PERCENTILE_LOW, PERCENTILE_HIGH],
+            "target_half_width_pp": HALF_WIDTH_TARGET_PP,
+            "as_registered": settings_registered,
+        },
+        "runs": [
+            {
+                "label": run["_label"],
+                "path": run["_source_path"],
+                "sha256": run["_source_digest"],
+                "graded_at": run["graded_at"],
+                "run_status": run["run_status"],
+            }
+            for run in runs
+        ],
+        "denominator": denominator_movement(runs),
+        "difference_common_denominator": common_diff,
+        "difference_as_published": published_diff,
+        "corpus_common_denominator": corpus_summary(common_scores),
+        "corpus_as_published": corpus_summary(published_scores),
+        "flips": {
+            "compared_items": flips["compared_items"],
+            "compared_item_pairs": flips["compared_item_pairs"],
+            "verdict": {
+                "differing": flips["verdict"]["differing"],
+                "rate_pct": flips["verdict"]["rate_pct"],
+                "per_pair": flips["verdict"]["per_pair"],
+                "ci": verdict_ci,
+            },
+            "score_outcome": {
+                "differing": flips["score_outcome"]["differing"],
+                "rate_pct": flips["score_outcome"]["rate_pct"],
+                "per_pair": flips["score_outcome"]["per_pair"],
+                "ci": score_ci,
+            },
+            "transitions": flips["transitions"],
+            "adjacent_moves": flips["adjacent_moves"],
+            "two_step_moves": flips["two_step_moves"],
+            "same_verdict_moved_score": flips["same_verdict_moved_score"],
+        },
+        "design_effect": {
+            "cluster_ci": cluster_verdict_ci,
+            "naive_item_ci": naive_verdict_ci,
+            "width_ratio": (
+                cluster_verdict_ci["width"] / naive_verdict_ci["width"]
+                if naive_verdict_ci["width"]
+                else float("inf")
+            ),
+            "naive_endpoint_bracket": naive_endpoint_bracket(
+                flips["verdict"]["flags"]
+            ),
+        },
+        "vocabulary": observed_vocabulary(runs),
+        "usage": usage(runs),
+        "extra_runs": required_extra_runs(
+            common_scores, target_pp=HALF_WIDTH_TARGET_PP
+        ),
+        "worst_half_width_pp": worst_half_width,
+        "target_half_width_met": target_met,
+        "verdict_ok": bool(target_met and settings_registered),
+    }
+
+
+def _mark(met: bool) -> str:
+    return "MET" if met else "MISSED"
+
+
+def _render(report: dict[str, Any]) -> str:
+    settings = report["settings"]
+    lines: list[str] = []
+    lines.append("repeat variation - the same answers, graded three times")
+    lines.append("=" * 62)
+    lines.append("")
+    for row in report["runs"]:
+        lines.append(
+            f"  {row['label']}  {row['graded_at']}  {row['run_status']}  "
+            f"sha256 {row['sha256'][:16]}"
+        )
+    lines.append("")
+    lines.append(
+        f"  resamples {settings['resamples']}   seed {settings['seed']}   "
+        f"unit {settings['resample_unit']}   "
+        f"percentile {settings['percentile'][0]}/{settings['percentile'][1]}"
+    )
+    if not settings["as_registered"]:
+        lines.append(
+            "  WARNING these are not the registered settings, so what follows "
+            "is a different analysis"
+        )
+    lines.append("")
+
+    denominator = report["denominator"]
+    lines.append("moving denominator (section 5)")
+    lines.append(
+        f"  shared items {denominator['shared_items']}   "
+        f"common denominator {denominator['items_in_common_denominator']}   "
+        f"dropped {denominator['items_dropped_from_common_denominator']}"
+    )
+    lines.append(
+        f"  judge_error {denominator['judge_error_events']}   "
+        f"score_excluded {denominator['score_excluded_events']}   "
+        f"disagreeing {denominator['excluded_and_error_disagree']}"
+    )
+    for row in denominator["tasks_whose_total_max_moved"]:
+        maxima = " / ".join(f"{m:g}" for m in row["total_max"])
+        lines.append(f"  total_max moved  {row['task_id'][:8]}  {maxima}")
+    lines.append("")
+
+    for title, key in (
+        ("common denominator (primary)", "corpus_common_denominator"),
+        ("as published (secondary)", "corpus_as_published"),
+    ):
+        block = report[key]
+        lines.append(f"corpus mean, {title}")
+        for row in block["per_run"]:
+            lines.append(
+                f"  {row['run']}  mean {row['mean_pct']:.4f}%  "
+                f"median {row['median_pct']:.4f}%  stdev {row['stdev']:.4f}"
+            )
+        lines.append(f"  spread across runs {block['mean_spread_pp']:.4f}pp")
+        lines.append("")
+
+    diff = report["difference_common_denominator"]
+    lines.append("per-task movement, common denominator (metric 1)")
+    for row in diff["per_pair"]:
+        ci = row["corpus_mean_shift_ci"]
+        lines.append(
+            f"  {row['pair']}  signed {row['mean_signed_pp']:+.4f}pp  "
+            f"absolute {row['mean_absolute_pp']:.4f}pp  "
+            f"max {row['max_absolute_pp']:.4f}pp"
+        )
+        lines.append(
+            f"            corpus mean shift 95% CI "
+            f"[{ci['low']:+.4f}, {ci['high']:+.4f}]  "
+            f"half-width {ci['half_width']:.4f}pp"
+        )
+    combined = diff["combined_absolute"]
+    lines.append(
+        f"  all pairs  absolute mean {combined['mean_pp']:.4f}pp  "
+        f"median {combined['median_pp']:.4f}pp  max {combined['max_pp']:.4f}pp"
+    )
+    lines.append("")
+
+    published = report["difference_as_published"]
+    lines.append("per-task movement, as published (metric 1, secondary)")
+    for row in published["per_pair"]:
+        ci = row["corpus_mean_shift_ci"]
+        lines.append(
+            f"  {row['pair']}  signed {row['mean_signed_pp']:+.4f}pp  "
+            f"absolute {row['mean_absolute_pp']:.4f}pp  "
+            f"max {row['max_absolute_pp']:.4f}pp  "
+            f"half-width {ci['half_width']:.4f}pp"
+        )
+    lines.append("")
+
+    flips = report["flips"]
+    lines.append(
+        f"result changed on a second grading (metric 5), "
+        f"{flips['compared_item_pairs']} item pairs"
+    )
+    for label, block in (
+        ("verdict", flips["verdict"]),
+        ("score outcome", flips["score_outcome"]),
+    ):
+        ci = block["ci"]
+        per_pair = " / ".join(str(n) for n in block["per_pair"])
+        lines.append(
+            f"  {label:<13} {block['differing']} pairs  "
+            f"{block['rate_pct']:.4f}%  ({per_pair})"
+        )
+        lines.append(
+            f"                95% CI [{ci['low']:.4f}, {ci['high']:.4f}]  "
+            f"width {ci['width']:.4f}pp"
+        )
+    lines.append(
+        f"  adjacent moves {flips['adjacent_moves']}   "
+        f"two-step pass/fail moves {flips['two_step_moves']}   "
+        f"same verdict, moved score {flips['same_verdict_moved_score']}"
+    )
+    for cell, count in flips["transitions"].items():
+        lines.append(f"  transition  {cell:<28} {count}")
+    lines.append("")
+
+    design = report["design_effect"]
+    lines.append("why the unit is the task and not the item (section 6)")
+    lines.append(
+        f"  task cluster   [{design['cluster_ci']['low']:.4f}, "
+        f"{design['cluster_ci']['high']:.4f}]  "
+        f"width {design['cluster_ci']['width']:.4f}pp   OFFICIAL"
+    )
+    lines.append(
+        f"  naive item     [{design['naive_item_ci']['low']:.4f}, "
+        f"{design['naive_item_ci']['high']:.4f}]  "
+        f"width {design['naive_item_ci']['width']:.4f}pp   not used"
+    )
+    lines.append(
+        f"  the naive interval is {design['width_ratio']:.4f}x narrower than "
+        "the one this analysis reports"
+    )
+    bracket = design["naive_endpoint_bracket"]
+    counts = bracket["bracketing_counts"]
+    if len(counts) == 1:
+        lines.append(
+            f"  every item pair agreed or every one differed, so the "
+            f"{bracket['quantile']}th percentile lands exactly on"
+        )
+    else:
+        lines.append(
+            f"  the naive lower endpoint can only land on multiples of "
+            f"{bracket['step_pct']:.4f}pp, and the exact binomial puts the "
+            f"{bracket['quantile']}th percentile between"
+        )
+    for entry in counts:
+        lines.append(
+            f"    {entry['count']} of {bracket['trials']} "
+            f"= {entry['rate_pct']:.4f}%  P(X <= k) = {entry['cdf']:.5f}"
+        )
+    lines.append("")
+
+    vocabulary = report["vocabulary"]
+    lines.append("what was actually observed (metric 3, section 9)")
+    verdicts = "   ".join(
+        f"{name} {count}" for name, count in vocabulary["verdicts"].items()
+    )
+    lines.append(f"  {verdicts}")
+    lines.append(
+        f"  judge_error rate {vocabulary['judge_error_rate_pct']:.4f}%"
+    )
+    lines.append(f"  refusal        {vocabulary['refusal']}")
+    lines.append(f"  tool failure   {vocabulary['tool_failure']}")
+    census = "   ".join(
+        f"{calls}x {count}"
+        for calls, count in vocabulary["read_deliverable_calls"].items()
+    )
+    lines.append(f"  read_deliverable per item  {census}")
+    modality = "   ".join(
+        f"{name} {count}" for name, count in vocabulary["routing_modality"].items()
+    )
+    lines.append(f"  routing modality  {modality}")
+    lines.append("")
+
+    lines.append("cost and latency per run (metric 6)")
+    for row in report["usage"]:
+        lines.append(
+            f"  {row['run']}  judge calls {row['judge_calls']}  "
+            f"in {row['input_tokens']}  out {row['output_tokens']}  "
+            f"cached {row['cached_tokens']}"
+        )
+        lines.append(
+            f"            latency {row['judge_latency_ms'] / 1000:.1f}s   "
+            f"routes {', '.join(row['azure_routes'])}"
+        )
+        lines.append(f"            cost {row['estimated_cost_usd']}")
+    lines.append("")
+
+    extra = report["extra_runs"]
+    lines.append("the target (section 8)")
+    lines.append(
+        f"  worst half-width {report['worst_half_width_pp']:.4f}pp   "
+        f"target <= {HALF_WIDTH_TARGET_PP:.1f}pp   "
+        f"{_mark(report['target_half_width_met'])}"
+    )
+    lines.append(
+        f"  pair difference stdev worst case "
+        f"{extra['worst_pair_difference_stdev_pp']:.4f}pp   "
+        f"runs required {extra['runs_required_for_target']}   "
+        f"held {extra['runs_held']}"
+    )
+    lines.append("")
+    lines.append(f"VERDICT  {_mark(report['verdict_ok'])}")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "grade_files",
+        type=Path,
+        nargs="+",
+        help="the three repeat payloads of the pinned thirty-task cohort",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the whole analysis as JSON instead of a readable report",
+    )
+    parser.add_argument(
+        "--bootstrap-resamples",
+        type=int,
+        default=BOOTSTRAP_RESAMPLES,
+        help="how many times to resample. Registered value: 10000",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=BOOTSTRAP_SEED,
+        help=(
+            "the bootstrap seed. Registered value: 20260901. Any other value "
+            "produces a real interval for a different analysis, and this tool "
+            "marks the run accordingly"
+        ),
+    )
+    parser.add_argument(
+        "--resample-unit",
+        choices=("task", "item"),
+        default="task",
+        help=(
+            "what a draw picks up. Registered value: task. 'item' exists so a "
+            "test can show what pretending items are independent would report"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    runs = load_runs(args.grade_files)
+
+    problems = fingerprint_problems(runs) + shape_problems(runs)
+    if problems:
+        raise RepeatsAreNotComparable(
+            "these payloads cannot answer the question this analysis asks:\n"
+            "  - " + "\n  - ".join(problems)
+        )
+
+    report = analyze(
+        runs,
+        resamples=args.bootstrap_resamples,
+        seed=args.seed,
+        resample_unit=args.resample_unit,
+    )
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(_render(report))
+
+    return 0 if report["verdict_ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/batch-runner/tests/test_repeat_variation_analysis.py
+++ b/batch-runner/tests/test_repeat_variation_analysis.py
@@ -1,0 +1,757 @@
+"""Stage 3 measures the grader against itself, so its guards are the evidence.
+
+Stage 2 asked how far a score moves when the same thirty answers are graded
+three times. It answered with one number for the whole corpus, and that number
+was reassuring. Stage 3 asks the question the corpus number hides: how often
+does an individual rubric item come back with a different verdict? Those two
+answers point in opposite directions, and both are true.
+
+Because the second answer is a disagreement rate rather than a mean, almost
+every way of getting it wrong makes it look better. Comparing a run with itself
+reports no disagreement at all. Resampling items instead of tasks reports a
+narrower interval than the data supports. Dropping the items the grader failed
+on tidies the denominator and moves the mean. So this file spends most of its
+length on the refusals rather than the arithmetic: every mutation in section 12
+of the preregistration is applied here and has to make the tool stop.
+
+The rest holds the tool to the preregistration's own figures. Those were
+written before the tool existed, from a separate reading of the same payloads,
+which is what makes them worth checking against.
+"""
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import analyze_gold_ceiling as gold
+from scripts import analyze_repeat_variation as rv
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DIAGNOSTIC_ROOT = REPO_ROOT / "data/grades/_diagnostic"
+PREREG_PATH = REPO_ROOT / "tasks/rebuilding_grading_task/315-repeat-variation-prereg.md"
+
+# The task-list digest is the cohort's name. Read out of the tool's own pin so
+# that repointing the analysis at another cohort cannot leave these tests
+# quietly measuring the old one.
+PINNED_TASK_LIST_DIGEST = next(
+    value
+    for _, path, value in rv.PINNED_FINGERPRINTS
+    if path == ("expected_ordered_task_ids_sha256",)
+)
+
+
+def _repeat_grade_files() -> list[Path]:
+    """The three finished runs of the pinned cohort, in repeat order.
+
+    ``_superseded/`` is excluded because it holds a run graded by a reading
+    tool that has since been fixed; comparing it to the current three would
+    measure a code change, which is the one thing this analysis holds still.
+    Shards are excluded by ``run_status`` -- a shard declares the whole corpus
+    in its identity fields while holding one slice of it.
+
+    ``--run-ordinal`` forks the output path above the shard fork, so run 1 sits
+    at the canonical path and every later repeat lands under
+    ``_repeats/run-NNN/``. Nothing inside a payload records which repeat it is,
+    so the path is the only thing that orders them.
+    """
+    found: list[tuple[int, Path]] = []
+    for path in sorted(DIAGNOSTIC_ROOT.rglob("*.json")):
+        if "_superseded" in path.parts:
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if (
+            payload.get("expected_ordered_task_ids_sha256")
+            != PINNED_TASK_LIST_DIGEST
+            or payload.get("run_status") not in gold.COMPLETE_RUN_STATUSES
+        ):
+            continue
+        ordinal = 1
+        for part in path.parts:
+            if part.startswith("run-") and part[4:].isdigit():
+                ordinal = int(part[4:])
+        found.append((ordinal, path))
+    return [path for _, path in sorted(found)]
+
+
+@pytest.fixture(scope="module")
+def grade_files() -> list[Path]:
+    files = _repeat_grade_files()
+    assert len(files) == rv.EXPECTED_RUN_COUNT, (
+        f"this analysis compares {rv.EXPECTED_RUN_COUNT} runs of the pinned "
+        f"cohort and the repository holds {len(files)}: "
+        f"{[str(path.relative_to(REPO_ROOT)) for path in files]}"
+    )
+    return files
+
+
+@pytest.fixture
+def runs(grade_files) -> list[dict]:
+    """Reloaded per test, because the mutation tests edit what they are given.
+
+    Reading all three costs about a tenth of a second, which is cheaper than
+    deep-copying them.
+    """
+    return rv.load_runs(list(grade_files))
+
+
+@pytest.fixture(scope="module")
+def report(grade_files) -> dict:
+    """One analysis at the registered settings, shared by the reading tests.
+
+    Ten thousand resamples of six bootstraps takes about twenty seconds, so it
+    is done once. Nothing below mutates it.
+    """
+    loaded = rv.load_runs(list(grade_files))
+    return rv.analyze(
+        loaded,
+        resamples=rv.BOOTSTRAP_RESAMPLES,
+        seed=rv.BOOTSTRAP_SEED,
+        resample_unit="task",
+    )
+
+
+# -- the inputs really are one run, repeated -------------------------------
+
+
+def test_the_three_runs_pass_every_guard(runs):
+    assert rv.fingerprint_problems(runs) == []
+    assert rv.shape_problems(runs) == []
+
+
+@pytest.mark.parametrize(
+    "label,path,expected",
+    rv.PINNED_FINGERPRINTS,
+    ids=[label.replace(" ", "-") for label, _, _ in rv.PINNED_FINGERPRINTS],
+)
+def test_every_pinned_fingerprint_is_the_registered_value(
+    label, path, expected, runs
+):
+    """Agreement between the runs is not enough on its own.
+
+    Three runs of a different cohort agree with each other perfectly. The
+    literal match is what ties these files to the document that registered the
+    analysis, so it is checked field by field rather than in bulk.
+    """
+    observed = [rv._dig(run, path) for run in runs]
+
+    assert observed == [expected] * rv.EXPECTED_RUN_COUNT, label
+
+
+def test_the_pinned_list_covers_the_twelve_the_document_names(runs):
+    """Section 4 names twelve. Pinning fewer would be a quieter analysis."""
+    assert len(rv.PINNED_FINGERPRINTS) >= 12
+    fields = {".".join(path) for _, path, _ in rv.PINNED_FINGERPRINTS}
+    for required in (
+        "expected_ordered_task_ids_sha256",
+        "grader_source_hash",
+        "judge.config_name",
+        "judge.model",
+        "judge.reasoning_effort",
+        "judge.temperature",
+        "judge.seed",
+        "prompt.version",
+        "rubric.revision",
+        "renderer_fingerprint",
+        "source_inference_revision",
+        "schema_version",
+    ):
+        assert required in fields, required
+
+
+def test_the_route_record_is_reported_but_not_frozen(runs):
+    """The one field stage 3 deliberately left out of the freeze.
+
+    A run's Azure route list is a union across shards, so it is not stable
+    within a single run, let alone across three. Freezing it would make the
+    accepted stage-1 run reject itself. It is reported instead.
+    """
+    fields = {".".join(path) for _, path, _ in rv.PINNED_FINGERPRINTS}
+
+    assert "azure_ai_routes" not in fields
+
+
+def test_the_schema_pin_is_the_version_these_files_carry(runs):
+    """Pinned at 1.3, not at whatever the producer writes today.
+
+    ``step8_grade.py`` has since moved to 1.4. Pinning the current value would
+    make these three payloads fail their own analysis.
+    """
+    assert all(run["schema_version"] == "1.3" for run in runs)
+
+
+# -- section 12, the six mutations, each of which must stop the tool --------
+
+
+def test_mutation_a_tampered_fingerprint_is_refused(runs):
+    runs[1]["judge"]["config_hash"] = "0000000000000000"
+
+    problems = rv.fingerprint_problems(runs)
+
+    assert problems, "a moved grading config hash was not noticed"
+    assert any("config_hash" in problem for problem in problems)
+
+
+def test_mutation_b_the_same_file_twice_is_refused(grade_files):
+    """The failure that would pass every gate having measured nothing."""
+    doubled = rv.load_runs([grade_files[0], grade_files[0], grade_files[1]])
+
+    problems = rv.fingerprint_problems(doubled)
+
+    assert problems, "being handed one run twice was not noticed"
+    assert any("the same run" in problem for problem in problems)
+
+
+def test_mutation_c_a_forged_verdict_value_is_refused(runs):
+    item = runs[2]["tasks"][0]["items"][0]
+    item["verdict"] = "mostly_pass"
+
+    problems = rv.shape_problems(runs)
+
+    assert problems, "a verdict outside the vocabulary was not noticed"
+    assert any("mostly_pass" in problem for problem in problems)
+
+
+def test_mutation_d_resampling_items_is_marked_unregistered(runs):
+    """Item resampling still produces a number. It is not the official one."""
+    swapped = rv.analyze(
+        runs,
+        resamples=rv.BOOTSTRAP_RESAMPLES,
+        seed=rv.BOOTSTRAP_SEED,
+        resample_unit="item",
+    )
+
+    assert swapped["settings"]["as_registered"] is False
+    assert swapped["verdict_ok"] is False
+
+
+def test_mutation_e_a_different_seed_is_marked_unregistered(runs):
+    moved = rv.analyze(
+        runs,
+        resamples=rv.BOOTSTRAP_RESAMPLES,
+        seed=rv.BOOTSTRAP_SEED + 1,
+        resample_unit="task",
+    )
+
+    assert moved["settings"]["as_registered"] is False
+    assert moved["verdict_ok"] is False
+    assert moved["settings"]["seed"] != rv.BOOTSTRAP_SEED
+
+
+def test_mutation_f_an_injected_audio_item_is_refused(runs):
+    runs[0]["tasks"][0]["items"][0]["routing_modality"] = "audio"
+
+    problems = rv.shape_problems(runs)
+
+    assert problems, "an audio item was not noticed"
+    assert any("audio" in problem for problem in problems)
+
+
+def test_a_mutation_reaches_the_exit_code_through_the_real_entry_point(
+    grade_files, capsys
+):
+    """Two mutations driven end to end, so the refusals are not test-only.
+
+    A settings mutation reaches the caller as an exit code and a payload
+    mutation reaches it as an exception, and both paths are worth walking. An
+    unregistered resample count is the cheapest settings mutation to run: it
+    needs no bootstrap worth the name to prove the point.
+    """
+    argv = [str(path) for path in grade_files] + [
+        "--bootstrap-resamples",
+        "50",
+        "--json",
+    ]
+
+    assert rv.main(argv) == 1
+
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["settings"]["resamples"] == 50
+    assert emitted["settings"]["as_registered"] is False
+
+    with pytest.raises(rv.RepeatsAreNotComparable):
+        rv.main([str(grade_files[0])] * rv.EXPECTED_RUN_COUNT)
+
+
+# -- the negative control ---------------------------------------------------
+
+
+def test_comparing_a_run_with_itself_reports_perfect_agreement(grade_files):
+    """The control that shows what a broken input would have published.
+
+    Three copies of one file produce a flawless result: no verdict ever moves,
+    no score ever moves, the corpus mean does not budge and every interval is
+    zero wide. It clears the preregistered target by the widest possible
+    margin. That is precisely why the same-file check has to run before the
+    numbers, and the second half of this test is that check firing.
+    """
+    same = rv.load_runs([grade_files[0]] * rv.EXPECTED_RUN_COUNT)
+    control = rv.analyze(
+        same,
+        resamples=200,
+        seed=rv.BOOTSTRAP_SEED,
+        resample_unit="task",
+    )
+
+    assert control["flips"]["verdict"]["differing"] == 0
+    assert control["flips"]["score_outcome"]["differing"] == 0
+    assert control["flips"]["transitions"] == {}
+    assert control["corpus_common_denominator"]["mean_spread_pp"] == 0.0
+    assert control["corpus_as_published"]["mean_spread_pp"] == 0.0
+    assert control["worst_half_width_pp"] == 0.0
+    assert control["target_half_width_met"] is True
+
+    problems = rv.fingerprint_problems(same)
+    assert any("the same run" in problem for problem in problems), (
+        "the control produced a perfect result and nothing stopped it being "
+        "published"
+    )
+
+
+def test_a_degenerate_rate_is_reported_rather_than_crashing():
+    """A grader that never disagreed with itself is a legitimate observation.
+
+    The bracket is exact binomial arithmetic and ``log(0)`` raises, so both
+    ends of the range are answered without the sum. Without this the control
+    above dies inside a helper instead of returning the perfect result it
+    exists to expose.
+    """
+    agree = rv.naive_endpoint_bracket([0] * 100)
+    differ = rv.naive_endpoint_bracket([1] * 100)
+
+    assert agree["bracketing_counts"] == [
+        {"count": 0, "rate_pct": 0.0, "cdf": 1.0}
+    ]
+    assert differ["bracketing_counts"] == [
+        {"count": 100, "rate_pct": 100.0, "cdf": 1.0}
+    ]
+
+
+# -- the preregistration's own figures --------------------------------------
+
+
+def test_the_denominator_moved_and_is_reported_rather_than_absorbed(report):
+    """Section 5. Three items leave the corpus total, not just the score."""
+    denominator = report["denominator"]
+
+    assert denominator["shared_items"] == 1433
+    assert denominator["items_in_common_denominator"] == 1430
+    assert denominator["items_dropped_from_common_denominator"] == 3
+
+    moved = {
+        entry["task_id"]: entry["total_max"]
+        for entry in denominator["tasks_whose_total_max_moved"]
+    }
+    assert moved == {
+        "43dc9778-450b-4b46-b77e-b6d82b202035": [121, 121, 119],
+        "a328feea-47db-4856-b4be-2bdc63dd88fb": [22, 24, 24],
+        "17111c03-aac7-45c2-857d-c06d8223d6ad": [60, 61, 60],
+    }
+
+
+def test_a_grader_failure_raises_the_score_it_was_counted_out_of(report, runs):
+    """The concrete reason the two baselines are kept apart.
+
+    Task ``a328feea`` scores the same 18.6 points in run 1 and run 2. Run 1
+    lost an item to a grader failure, so it is counted out of 22 rather than
+    24, and the run that failed comes out seven points ahead.
+    """
+    task_id = "a328feea-47db-4856-b4be-2bdc63dd88fb"
+    scored = [
+        next(task for task in run["tasks"] if task["task_id"] == task_id)
+        for run in runs
+    ]
+
+    assert scored[0]["total_awarded"] == scored[1]["total_awarded"]
+    assert scored[0]["total_max"] < scored[1]["total_max"]
+    assert scored[0]["pct"] > scored[1]["pct"]
+
+
+def test_judge_error_and_score_excluded_are_the_same_events(report):
+    denominator = report["denominator"]
+
+    assert denominator["judge_error_events"] == 4
+    assert denominator["score_excluded_events"] == 4
+    assert denominator["excluded_and_error_disagree"] == 0
+
+
+def test_the_two_disagreement_rates_match_the_preregistration(report):
+    """Section 6. Verdict and score are separate metrics on purpose."""
+    flips = report["flips"]
+
+    assert flips["compared_items"] == 1433
+    assert flips["compared_item_pairs"] == 4299
+
+    assert flips["verdict"]["differing"] == 204
+    assert flips["verdict"]["per_pair"] == [66, 65, 73]
+    assert flips["verdict"]["rate_pct"] == pytest.approx(4.7453, abs=5e-5)
+
+    assert flips["score_outcome"]["differing"] == 450
+    assert flips["score_outcome"]["per_pair"] == [153, 144, 153]
+    assert flips["score_outcome"]["rate_pct"] == pytest.approx(10.4676, abs=5e-5)
+
+
+def test_the_verdict_rate_alone_would_miss_246_moved_scores(report):
+    """Why both metrics exist rather than one.
+
+    A ``partial`` that drops from 2.0 to 1.5 is still a ``partial``. Counting
+    verdicts alone hides it; counting scores alone hides the sentence a reader
+    would have quoted.
+    """
+    flips = report["flips"]
+
+    assert flips["same_verdict_moved_score"] == 246
+    assert flips["adjacent_moves"] == 175
+    assert flips["two_step_moves"] == 23
+    assert (
+        flips["adjacent_moves"] + flips["two_step_moves"]
+        < flips["verdict"]["differing"]
+    ), "every verdict move should be adjacent, two-step, or error-involved"
+
+
+def test_the_moves_go_both_ways_which_is_why_the_mean_holds_still(report):
+    """The reconciliation between the two headline answers.
+
+    Upward and downward moves nearly cancel, so a corpus mean can be steady
+    while one item in twenty comes back differently.
+    """
+    transitions = report["flips"]["transitions"]
+    rank = rv.VERDICT_RANK
+
+    upward = sum(
+        count
+        for move, count in transitions.items()
+        for before, after in [move.split("->")]
+        if before in rank and after in rank and rank[after] > rank[before]
+    )
+    downward = sum(
+        count
+        for move, count in transitions.items()
+        for before, after in [move.split("->")]
+        if before in rank and after in rank and rank[after] < rank[before]
+    )
+    involving_error = sum(
+        count
+        for move, count in transitions.items()
+        if "judge_error" in move
+    )
+
+    assert upward == 107
+    assert downward == 91
+    assert involving_error == 6
+    assert upward + downward + involving_error == report["flips"]["verdict"][
+        "differing"
+    ]
+
+
+def test_the_official_interval_is_the_task_cluster_one(report):
+    """Section 7. Four decimal places, because the document has four."""
+    assert report["settings"]["resample_unit"] == "task"
+    ci = report["flips"]["verdict"]["ci"]
+
+    assert ci["low"] == pytest.approx(3.821, abs=5e-4)
+    assert ci["high"] == pytest.approx(5.745, abs=5e-4)
+    assert ci["width"] == pytest.approx(1.924, abs=5e-4)
+    assert report["design_effect"]["cluster_ci"] == ci
+
+
+def test_the_item_interval_is_reported_and_labelled_as_not_used(report):
+    """Items inside one task move together, so treating them as independent
+    reports a precision the data does not have."""
+    design = report["design_effect"]
+
+    assert design["naive_item_ci"]["width"] < design["cluster_ci"]["width"]
+    assert design["width_ratio"] == pytest.approx(1.5037, abs=5e-4)
+
+
+def test_the_documents_naive_endpoint_and_this_ones_differ_by_one_item(report):
+    """Exact arithmetic, so it is checked without running a bootstrap.
+
+    The document recorded 4.094 and every implementation here returns 4.117.
+    Both are honest: under item resampling the statistic can only land on
+    multiples of one item in 4,299, and the true 2.5th percentile falls
+    between two counts no draw can return.
+    """
+    bracket = report["design_effect"]["naive_endpoint_bracket"]
+    low, high = bracket["bracketing_counts"]
+
+    assert bracket["trials"] == 4299
+    assert bracket["observed"] == 204
+    assert (low["count"], high["count"]) == (176, 177)
+    assert low["rate_pct"] == pytest.approx(4.094, abs=5e-4)
+    assert high["rate_pct"] == pytest.approx(4.117, abs=5e-4)
+    assert low["cdf"] < 0.025 < high["cdf"]
+    assert high["count"] - low["count"] == 1
+    assert bracket["step_pct"] == pytest.approx(0.0233, abs=5e-5)
+    assert report["design_effect"]["naive_item_ci"]["low"] == pytest.approx(
+        high["rate_pct"], abs=1e-9
+    )
+
+
+def test_the_binomial_bracket_is_reproducible_arithmetic():
+    """Directly, on the same numbers, with no payload and no resampling."""
+    assert rv._binomial_cdf(4299, 176, 204 / 4299) == pytest.approx(
+        0.02241, abs=5e-6
+    )
+    assert rv._binomial_cdf(4299, 177, 204 / 4299) == pytest.approx(
+        0.02672, abs=5e-6
+    )
+
+
+def test_the_percentile_helper_interpolates(report):
+    values = [float(index) for index in range(101)]
+
+    assert rv.percentile(values, 50.0) == pytest.approx(50.0)
+    assert rv.percentile(values, 2.5) == pytest.approx(2.5)
+    assert rv.percentile(values, 97.5) == pytest.approx(97.5)
+    assert rv.percentile([7.0], 2.5) == 7.0
+
+
+# -- the corpus answer and the preregistered target -------------------------
+
+
+def test_the_corpus_means_and_their_spread(report):
+    published = [
+        entry["mean_pct"] for entry in report["corpus_as_published"]["per_run"]
+    ]
+    common = [
+        entry["mean_pct"]
+        for entry in report["corpus_common_denominator"]["per_run"]
+    ]
+
+    assert published == pytest.approx([82.8733, 83.0727, 83.2457], abs=5e-5)
+    assert common == pytest.approx([83.1275, 83.6129, 83.5383], abs=5e-5)
+    assert report["corpus_as_published"]["mean_spread_pp"] == pytest.approx(
+        0.3723, abs=5e-5
+    )
+
+
+def test_no_mean_shift_is_distinguishable_from_chance(report):
+    """The drift is visible and it is not significant. Both get said.
+
+    Six pairs across two baselines, and every interval contains zero.
+    """
+    intervals = [
+        pair["corpus_mean_shift_ci"]
+        for basis in ("difference_common_denominator", "difference_as_published")
+        for pair in report[basis]["per_pair"]
+    ]
+
+    assert len(intervals) == 6
+    for interval in intervals:
+        assert interval["low"] <= 0.0 <= interval["high"], interval
+
+
+def test_the_target_is_judged_on_the_worse_of_the_two_baselines(report):
+    """Section 8. The published basis is the wider one, so it is the gate."""
+    common = report["difference_common_denominator"]["worst_half_width_pp"]
+    published = report["difference_as_published"]["worst_half_width_pp"]
+
+    assert report["worst_half_width_pp"] == max(common, published)
+    assert report["worst_half_width_pp"] == pytest.approx(0.8894, abs=5e-5)
+    assert report["worst_half_width_pp"] <= rv.HALF_WIDTH_TARGET_PP
+    assert report["target_half_width_met"] is True
+    assert report["verdict_ok"] is True
+
+
+def test_the_target_leaves_room_against_the_ninety_percent_line(report):
+    """Why 1.0pp is the target and not a round number picked to be passed.
+
+    The corpus sits about seven points below ninety. A repeat-grading wobble
+    of a point cannot move that judgement.
+    """
+    lowest = min(
+        entry["mean_pct"] for entry in report["corpus_as_published"]["per_run"]
+    )
+
+    assert 90.0 - lowest > 7.0
+    assert rv.HALF_WIDTH_TARGET_PP < (90.0 - lowest) / 7.0
+
+
+def test_no_further_paid_run_is_required(report):
+    """Section 13. The free analysis met the target, so nothing is dispatched."""
+    extra = report["extra_runs"]
+
+    assert extra["runs_required_for_target"] == rv.EXPECTED_RUN_COUNT
+    assert extra["runs_held"] == rv.EXPECTED_RUN_COUNT
+    assert extra["runs_required_for_target"] <= extra["runs_held"]
+    assert extra["worst_pair_difference_stdev_pp"] == pytest.approx(
+        2.1448, abs=5e-5
+    )
+
+
+# -- section 9, where absence is recorded as absence ------------------------
+
+
+def test_this_cohort_contains_no_audio(report):
+    """Audio flipping was measured elsewhere and must not be folded in here."""
+    assert rv.FORBIDDEN_MODALITY not in report["vocabulary"]["routing_modality"]
+
+
+def test_what_was_not_measured_says_so_rather_than_reporting_zero(report):
+    """A rate of zero and a field that does not exist are different claims."""
+    vocabulary = report["vocabulary"]
+
+    assert "not measured" in vocabulary["refusal"]
+    assert "no field exists" in vocabulary["tool_failure"]
+    assert "proxy" in vocabulary["tool_failure"]
+
+
+def test_the_judge_error_rate_is_reported_as_the_small_number_it_is(report):
+    vocabulary = report["vocabulary"]
+
+    assert vocabulary["judge_error_rate_pct"] == pytest.approx(0.0930, abs=5e-5)
+    assert vocabulary["verdicts"]["judge_error"] == 4
+    assert set(vocabulary["verdicts"]) == set(rv.VERDICT_VOCABULARY)
+    assert vocabulary["selection_status"] == {"ok": 4299}
+    assert all(entry["error_tasks"] == 0 for entry in vocabulary["error_tasks"])
+
+
+def test_items_decided_without_reading_the_deliverable_are_surfaced(report):
+    """Ninety-two items were judged on zero reads. Reported, not explained.
+
+    The keys are read counts, so they are integers here. They become strings
+    the moment the report is written as JSON, which is why the census is read
+    off the object rather than off the file.
+    """
+    census = report["vocabulary"]["read_deliverable_calls"]
+
+    assert census[0] == 92
+    assert sum(census.values()) == 4299
+    assert max(census) == 6
+
+
+def test_the_money_column_stays_unregistered_and_never_zero(report):
+    """A run nobody could price is not a run that cost nothing."""
+    for entry in report["usage"]:
+        cost = entry["estimated_cost_usd"]
+        assert cost.startswith("unregistered")
+        assert "gpt-5.6-sol" in cost
+        assert "0.00" not in cost
+
+
+# -- what this analysis is not allowed to disturb ---------------------------
+
+
+def test_the_analysis_does_not_modify_the_payloads_it_reads(grade_files):
+    before = [hashlib.sha256(path.read_bytes()).hexdigest() for path in grade_files]
+
+    loaded = rv.load_runs(list(grade_files))
+    rv.analyze(loaded, resamples=50, seed=rv.BOOTSTRAP_SEED, resample_unit="task")
+
+    after = [hashlib.sha256(path.read_bytes()).hexdigest() for path in grade_files]
+    assert before == after
+
+
+def test_this_tool_shares_no_code_with_the_stage_two_tool():
+    """Stage 2's published numbers must not move because stage 3 was written.
+
+    ``analyze_variance.py`` produced figures that are already quoted in a
+    merged report. Importing from it would put those figures one refactor away
+    from this file.
+
+    Checked against the import graph rather than the text, because the tool
+    discusses the stage-2 tool at length in its own docstrings and a substring
+    search cannot tell an explanation from a dependency.
+    """
+    source = (
+        REPO_ROOT / "batch-runner/scripts/analyze_repeat_variation.py"
+    ).read_text(encoding="utf-8")
+
+    imported: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add(node.module or "")
+            imported.update(
+                f"{node.module or ''}.{alias.name}" for alias in node.names
+            )
+
+    assert not any("analyze_variance" in name for name in imported), sorted(
+        name for name in imported if "analyze_variance" in name
+    )
+
+
+def test_the_preregistration_is_present_and_names_this_tool():
+    """The document was written first. It is what these numbers answer to."""
+    assert PREREG_PATH.is_file()
+    text = PREREG_PATH.read_text(encoding="utf-8")
+
+    assert "analyze_repeat_variation.py" in text
+
+
+def test_the_bootstraps_do_not_share_a_random_stream(runs):
+    """Each interval has to be the same whether or not others were computed.
+
+    A single shared generator would make an interval depend on how many
+    bootstraps ran before it, and the report's byte-for-byte check would then
+    be pinning an ordering rather than a result.
+    """
+    flips = rv.disagreement(runs)
+    task_ids = rv._document_order(runs[0])
+
+    first = rv.cluster_bootstrap_ratio(
+        task_ids,
+        flips["verdict"]["by_task"],
+        flips["pairs_by_task"],
+        resamples=300,
+        seed=rv.BOOTSTRAP_SEED,
+    )
+    rv.cluster_bootstrap_ratio(
+        task_ids,
+        flips["score_outcome"]["by_task"],
+        flips["pairs_by_task"],
+        resamples=300,
+        seed=rv.BOOTSTRAP_SEED,
+    )
+    again = rv.cluster_bootstrap_ratio(
+        task_ids,
+        flips["verdict"]["by_task"],
+        flips["pairs_by_task"],
+        resamples=300,
+        seed=rv.BOOTSTRAP_SEED,
+    )
+
+    assert first == again
+
+
+def test_the_resampling_order_is_the_payloads_order_not_sorted(runs):
+    """Sorting would move the endpoints for no reason, so it is not done."""
+    order = rv._document_order(runs[0])
+
+    assert len(order) == rv.EXPECTED_TASK_COUNT
+    assert order != sorted(order)
+    assert order == [task["task_id"] for task in runs[0]["tasks"]]
+
+
+def test_a_missing_task_score_stops_the_run_rather_than_being_dropped(runs):
+    """Dropping it would move the mean towards the tasks that survived."""
+    runs[1]["tasks"][3]["pct"] = None
+
+    problems = rv.fingerprint_problems(runs)
+
+    assert any("no score" in problem for problem in problems)
+
+
+def test_an_item_missing_from_one_run_cannot_be_paired(runs):
+    dropped = runs[2]["tasks"][0]["items"].pop()
+
+    problems = rv.shape_problems(runs)
+
+    assert problems, f"a run short of item {dropped['rubric_item_id']} passed"
+    assert any("cannot be paired" in problem for problem in problems)
+
+
+def test_a_run_of_the_wrong_size_is_refused(runs):
+    problems = rv.fingerprint_problems(runs[:2])
+
+    assert any(str(rv.EXPECTED_RUN_COUNT) in problem for problem in problems)

--- a/batch-runner/tests/test_repeat_variation_report_quotes_its_run.py
+++ b/batch-runner/tests/test_repeat_variation_report_quotes_its_run.py
@@ -1,0 +1,243 @@
+"""The stage-3 report has to re-run, not restate.
+
+The report's headline is a disagreement rate, and a disagreement rate is easy
+to write down wrong and impossible to spot wrong by reading. So the report
+carries the tool's own output inside a fenced block, together with the command
+that produced it, and this file re-runs that command and demands the block
+still match byte for byte. That is also why the bootstrap seed is a constant
+rather than a clock: an interval that moved on every run would make this check
+impossible, and a check that cannot be run is a check that is not done.
+
+The rest holds the report to what no tool can generate. Which three payloads it
+quotes. Every fingerprint it claims to have frozen. The place where this stage
+departed from its written specification, which is stated in the report rather
+than left for a reader to find. That the free analysis met its target, so no
+paid run follows from it. And an honest bill for models with no published
+price.
+"""
+
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import analyze_repeat_variation as rv
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORT_PATH = REPO_ROOT / "data/grades/_validation/PR3_REPEAT_VARIATION.md"
+PREREG_PATH = REPO_ROOT / "tasks/rebuilding_grading_task/315-repeat-variation-prereg.md"
+TOOL_PATH = Path("batch-runner/scripts/analyze_repeat_variation.py")
+
+# How the report marks the block it generated and the command behind it. The
+# same shape stage 2 uses, so a reader who has checked one has checked both.
+GENERATED_MARKER = re.compile(
+    r"<!--\s*generated:\s*(?P<command>.+?)\s*-->\s*\n```text\n(?P<body>.*?)\n```",
+    re.DOTALL,
+)
+
+
+@pytest.fixture(scope="module")
+def report_text() -> str:
+    assert REPORT_PATH.is_file(), (
+        f"{REPORT_PATH.relative_to(REPO_ROOT)} is missing. The "
+        "preregistration's step 5 requires it."
+    )
+    return REPORT_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def generated_blocks(report_text) -> list[re.Match]:
+    blocks = list(GENERATED_MARKER.finditer(report_text))
+    assert blocks, (
+        "the report carries no generated block, so nothing in it can be "
+        "checked against the runs it claims to describe"
+    )
+    return blocks
+
+
+def test_every_generated_block_still_reproduces(generated_blocks):
+    """The one check that makes the rest of the report worth reading.
+
+    Twenty seconds of bootstrap, and it is the whole point of the file. If the
+    numbers in the report were edited by hand, or the tool changed under them,
+    or a payload moved, this is where it shows.
+    """
+    for block in generated_blocks:
+        command = shlex.split(block.group("command"))
+
+        assert command[0] in {"python", "python3"}, command[0]
+        assert command[1] == str(TOOL_PATH), command[1]
+
+        finished = subprocess.run(
+            [sys.executable, *command[1:]],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        # 1 is the tool's honest "the target was not met". It is not a crash,
+        # and pinning 0 here would mean a report could only ever be published
+        # about a run that passed.
+        assert finished.returncode in (0, 1), finished.stderr[-2000:]
+        assert finished.stdout.strip() == block.group("body").strip(), (
+            "the report's generated block no longer matches what the command "
+            "above it produces"
+        )
+
+
+def test_the_block_is_the_registered_run_not_a_cheap_one(generated_blocks):
+    """A report generated at 200 resamples would reproduce just as neatly.
+
+    It would also be a different analysis from the registered one, so the
+    command is required to carry no settings overrides at all and take the
+    constants from the tool.
+    """
+    for block in generated_blocks:
+        command = shlex.split(block.group("command"))
+        overrides = [
+            argument for argument in command if argument.startswith("--")
+        ]
+
+        assert overrides == [], overrides
+        assert len(command) == 2 + rv.EXPECTED_RUN_COUNT, command
+
+
+def test_the_report_names_every_file_it_read(report_text, generated_blocks):
+    """A reader has to be able to open all three runs for themselves."""
+    for block in generated_blocks:
+        for argument in shlex.split(block.group("command"))[2:]:
+            assert (REPO_ROOT / argument).is_file(), argument
+            assert argument in report_text
+
+
+def test_the_report_quotes_three_distinct_runs(generated_blocks):
+    """Two paths and a repeat would reproduce perfectly and mean nothing."""
+    for block in generated_blocks:
+        payloads = shlex.split(block.group("command"))[2:]
+
+        assert len(set(payloads)) == rv.EXPECTED_RUN_COUNT, payloads
+
+
+def _report_needle(expected):
+    """What a reader would look for in the report to find this fingerprint.
+
+    Three shapes, because the report is written to be read rather than to be
+    grepped. A full sha256 is abbreviated in prose the way everyone abbreviates
+    one, so the first eight characters are what identifies it. A nested object
+    has no single rendering, so its longest string value stands for it -- for
+    the renderer that is the LibreOffice build, which is the part that would
+    actually change a rendered page. Everything else is checked whole.
+    """
+    if isinstance(expected, dict):
+        strings = [value for value in expected.values() if isinstance(value, str)]
+        return max(strings, key=len)
+    if isinstance(expected, str) and len(expected) > 16:
+        try:
+            int(expected, 16)
+        except ValueError:
+            return expected
+        return expected[:8]
+    return str(expected)
+
+
+@pytest.mark.parametrize(
+    "label,path,expected",
+    rv.PINNED_FINGERPRINTS,
+    ids=[label.replace(" ", "-") for label, _, _ in rv.PINNED_FINGERPRINTS],
+)
+def test_the_report_records_what_was_held_still(
+    label, path, expected, report_text
+):
+    """Every field the tool refuses on has to be legible in the report.
+
+    Parametrised over the tool's own list, so pinning something new without
+    recording it fails here rather than passing quietly.
+    """
+    needle = _report_needle(expected)
+
+    assert needle in report_text, (
+        f"the report does not record the {label} it pinned "
+        f"({'.'.join(path)}={needle!r})"
+    )
+
+
+def test_the_report_states_where_it_left_the_preregistration(report_text):
+    """The deviation is declared in the report, not left to be discovered.
+
+    Section 14 asked for the report under ``tasks/rebuilding_grading_task/``
+    and it was written under ``data/grades/_validation/`` instead, because
+    ``tasks/**`` is closed by .gitignore and the documents already in there
+    predate the rule. Small, and worth saying out loud rather than hoping
+    nobody diffs it -- so the report has to name both the path it was asked
+    for and the one it took.
+    """
+    assert "tasks/rebuilding_grading_task/PR3_REPEAT_VARIATION.md" in report_text
+    assert str(REPORT_PATH.parent.relative_to(REPO_ROOT)) in report_text
+    assert "315-repeat-variation-prereg" in report_text
+
+
+def test_the_report_gives_both_answers_rather_than_the_comfortable_one(
+    report_text
+):
+    """The corpus mean holds still and one item in twenty comes back
+    differently. A report that printed only the first would be true and
+    misleading."""
+    assert "4.75" in report_text or "4.7453" in report_text
+    assert "10.47" in report_text or "10.4676" in report_text
+    assert "0.89" in report_text
+
+
+def test_the_report_says_no_further_paid_run_is_required(report_text):
+    """The preregistration's escalation clause did not fire, and the report
+    is where that is recorded.
+
+    Section 13 said that if the free analysis missed its half-width target, a
+    minimum number of extra runs and a stopping rule had to be registered
+    before anything was dispatched. It did not miss, so the report has to say
+    the target and say that nothing follows from it.
+    """
+    assert f"{rv.HALF_WIDTH_TARGET_PP}pp" in report_text
+    assert "추가 유료 실행" in report_text
+
+
+def test_the_report_bills_the_models_it_could_not_price(report_text):
+    """A run nobody could price is not a run that cost nothing."""
+    assert "unregistered" in report_text
+    assert "gpt-5.6-sol" in report_text
+
+
+def test_the_preregistration_came_first_and_names_this_report():
+    assert PREREG_PATH.is_file()
+    text = PREREG_PATH.read_text(encoding="utf-8")
+
+    assert "PR3_REPEAT_VARIATION.md" in text
+
+
+def test_the_tool_is_tracked_where_the_command_says_it_is():
+    """``batch-runner/scripts/`` is gitignored with per-file exceptions, so a
+    tool can work locally and be absent from a fresh clone.
+
+    Probed without ``--verbose`` on purpose. With it, git reports the last
+    matching pattern *including negations* and exits 0 either way, so a
+    verbose probe cannot tell "ignored" from "un-ignored by a later rule".
+    Without it the exit code is the answer: 1 means no pattern ignores this.
+    """
+    assert (REPO_ROOT / TOOL_PATH).is_file()
+
+    finished = subprocess.run(
+        ["git", "check-ignore", str(TOOL_PATH)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert finished.returncode == 1, (
+        f"{TOOL_PATH} is ignored, so the command in the report cannot run "
+        f"from a fresh clone"
+    )

--- a/data/grades/_validation/PR3_REPEAT_VARIATION.md
+++ b/data/grades/_validation/PR3_REPEAT_VARIATION.md
@@ -1,0 +1,309 @@
+# PR3_REPEAT_VARIATION — 같은 지문인데 판정이 뒤집힌다, 얼마나
+
+> 사전등록: [`315-repeat-variation-prereg.md`](../../../tasks/rebuilding_grading_task/315-repeat-variation-prereg.md)
+> 앞 문서: [`PR3_VARIANCE.md`](../../../tasks/rebuilding_grading_task/PR3_VARIANCE.md)
+> 이 분석은 이미 있는 채점 결과 세 벌만 읽는다. **모델 호출 0회, 채점 비용 0원.**
+
+## 한 문장으로
+
+**전체 평균은 다시 채점해도 1pp 안에서 그대로다. 항목 하나하나의 판정은 스무 번에
+한 번꼴로 뒤집힌다.** 둘 다 사실이고, 둘은 같은 이야기가 아니다.
+
+## 이 문서가 답하는 질문
+
+발표된 점수 하나에는 서로 다른 두 가지가 섞여 있다.
+
+| | 무엇인가 | 다시 재면 |
+|---|---|---|
+| **과제 난이도** | 30개 과제로 어떤 것들이 뽑혔는가 | 다른 과제를 뽑으면 달라진다 |
+| **채점기 변덕** | 같은 답안을 두 번째 볼 때 채점기가 같은 말을 하는가 | 같은 과제라도 달라진다 |
+
+`PR3_VARIANCE.md`의 관문은 이 둘을 나누지 않았다. 과제를 다시 뽑으면 7.32pp,
+실행을 다시 뽑으면 0.86pp가 나오는데, 관문은 어느 쪽도 따로 보고하지 않았다.
+사전등록 §2가 적은 대로 **"관문을 통과했다는 사실은 반복 채점이 안정적이라는
+증거가 아니다."**
+
+그래서 이 문서는 처음부터 둘째 것만 겨냥한다. 방법은 **짝짓기**다. 같은 과제의
+1회차 점수와 2회차 점수를 함께 놓고 빼면, 그 과제가 어려웠는지 쉬웠는지는 뺄셈
+안에서 사라지고 **두 채점 사이에 움직인 것만 남는다.**
+
+## 사전등록과 달라진 점 — 하나
+
+사전등록 §14는 이 보고서를 `tasks/rebuilding_grading_task/PR3_REPEAT_VARIATION.md`에
+두라고 적었다. **이 문서는 `data/grades/_validation/`에 있다.** `tasks/**`는
+`.gitignore`가 닫아 둔 경로이고 그 안의 기존 문서들은 규칙보다 먼저 있었기 때문에
+남아 있는 것이지, 새 파일을 그리로 넣으라는 뜻이 아니다. `_validation/`에는 이미
+같은 성격의 검증 문서 여섯 개가 있다. 분석 내용은 §14 그대로다.
+
+## 세 실행이 정말 "같은 실행의 반복"인가
+
+이 측정의 전제 전부가 여기에 걸려 있다. 분석 도구는 지문 **16개**를 두 번 확인한다
+— 세 실행이 서로 같은가, 그리고 그 값이 사전등록이 적어 둔 값과 같은가. 하나라도
+다르면 숫자를 내지 않고 멈춘다. 서로만 같으면 **다른 코퍼스를 세 번 돌린 것도
+통과**하기 때문에 둘 다 필요하다.
+
+| 지문 | 값 |
+|---|---|
+| 과제 목록 해시 | `82d14ac9…e7e8b` (30개) |
+| 채점기 소스 해시 | `c33d9d55…6ff4e` |
+| 채점 설정 | `gold_ceiling_30_v2_sol_max` / `d1bfc8217c9981d2` |
+| 모델·배포 | `gpt-5.6-sol` / `gpt-5.6-sol` |
+| API 버전 | `2025-04-01-preview` |
+| 추론 강도·온도·씨앗 | `max` · `0` · `42` |
+| 판정 프롬프트 | `prompts/grader_judge.md` v2.2 |
+| 채점표 리비전 | `11e7900c…98fbf` |
+| 렌더러 | LibreOffice 24.2.7.2 420(Build:2), pymupdf 1.28.2 |
+| 정답 리비전 | `11e7900c…98fbf` |
+| 페이로드 스키마 | `1.3` |
+
+**얼리지 않은 것 하나.** `azure_ai_routes`는 한 실행 안에서도 값이 하나가 아니다
+(`step9_merge_shards.py`가 합집합으로 병합하는 이유가 그것이다). 얼리면 1단계가
+채택한 실행이 스스로를 거부한다. 그래서 **보고만 하고 관문에는 넣지 않았다.**
+
+**스키마를 오늘 값이 아니라 `1.3`으로 고정한 이유.** `step8_grade.py`는 그 뒤
+`1.4`로 옮겨 갔다. 오늘 값에 고정하면 이 세 파일이 스스로를 거부한다.
+
+**같은 파일을 두 번 넣는 사고.** 여기서 가장 위험한 실수다. 모든 차이가 정확히
+0으로 나오고, 0은 모든 관문을 여유 있게 통과하며, 보고서는 **아무것도 비교하지
+않은 채 "완벽하게 안정적"이라고 발표한다.** 그래서 파일 해시 세 개와 `graded_at`
+세 개가 모두 달라야 하고, 겹치면 경고가 아니라 오류다.
+
+## 분모가 움직인다 — 백분율을 그냥 빼면 안 되는 이유
+
+채점 항목 1,433개 중 **3개**가 세 실행 중 어느 하나에서 `judge_error`로 빠졌다.
+빠진 항목은 분자에서만 빠지는 게 아니라 **만점(분모)에서도 빠진다.**
+
+가장 또렷한 자리가 과제 `a328feea`다. 같은 18.6점이
+
+- 만점 22점 위에서는 **84.55%**
+- 만점 24점 위에서는 **77.50%**
+
+즉 **채점기가 답을 못 낸 실행이 더 높은 점수를 받는다.** 그래서 이 문서는 두 기준을
+따로 낸다.
+
+| 기준 | 무엇을 재는가 |
+|---|---|
+| **공통분모 기준 (주)** | 세 실행 모두에서 점수가 있는 1,430개 항목만으로 다시 계산. 차이가 오직 채점기 때문인 유일한 기준 |
+| **발표값 기준 (부)** | 파일에 적힌 `pct` 그대로. 사람들이 실제로 인용하는 숫자 |
+
+만점이 움직인 과제는 `43dc9778`(121/121/119), `a328feea`(22/24/24),
+`17111c03`(60/61/60) 셋이다. **분모 이동은 흡수하지 않고 별도 지표로 보고한다.**
+조용히 보정하면, 이 문서가 지적하려고 쓰인 잘못을 이 문서가 저지르는 셈이 된다.
+
+## 결과
+
+<!-- generated: python batch-runner/scripts/analyze_repeat_variation.py data/grades/_diagnostic/82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b/exp_gold_baseline__judge_gpt-5_6-sol__gold_ceiling_30_v2_sol_max__cfg_d1bfc8217c9981d2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_c33d9d55703fbf5d__v2.2.json data/grades/_diagnostic/82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b/_repeats/run-002/exp_gold_baseline__judge_gpt-5_6-sol__gold_ceiling_30_v2_sol_max__cfg_d1bfc8217c9981d2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_c33d9d55703fbf5d__v2.2.json data/grades/_diagnostic/82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b/_repeats/run-003/exp_gold_baseline__judge_gpt-5_6-sol__gold_ceiling_30_v2_sol_max__cfg_d1bfc8217c9981d2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_c33d9d55703fbf5d__v2.2.json -->
+```text
+repeat variation - the same answers, graded three times
+==============================================================
+
+  run-001  2026-08-28T18:41:32Z  final  sha256 c13f708da18e6481
+  run-002  2026-08-28T22:38:04Z  final  sha256 7337e9790c7c7b62
+  run-003  2026-08-29T01:22:18Z  final  sha256 a434eb6f572e04a9
+
+  resamples 10000   seed 20260901   unit task   percentile 2.5/97.5
+
+moving denominator (section 5)
+  shared items 1433   common denominator 1430   dropped 3
+  judge_error 4   score_excluded 4   disagreeing 0
+  total_max moved  43dc9778  121 / 121 / 119
+  total_max moved  a328feea  22 / 24 / 24
+  total_max moved  17111c03  60 / 61 / 60
+
+corpus mean, common denominator (primary)
+  run-001  mean 83.1275%  median 84.6145%  stdev 10.5381
+  run-002  mean 83.6129%  median 85.2340%  stdev 10.6954
+  run-003  mean 83.5383%  median 85.1568%  stdev 10.6619
+  spread across runs 0.4854pp
+
+corpus mean, as published (secondary)
+  run-001  mean 82.8733%  median 84.6150%  stdev 10.2996
+  run-002  mean 83.0727%  median 85.2300%  stdev 10.4591
+  run-003  mean 83.2457%  median 84.8850%  stdev 10.3872
+  spread across runs 0.3723pp
+
+per-task movement, common denominator (metric 1)
+  run-001 vs run-002  signed -0.4854pp  absolute 1.3546pp  max 5.6964pp
+            corpus mean shift 95% CI [-1.1597, +0.1859]  half-width 0.6728pp
+  run-001 vs run-003  signed -0.4107pp  absolute 1.0476pp  max 3.9535pp
+            corpus mean shift 95% CI [-0.8997, +0.0481]  half-width 0.4739pp
+  run-002 vs run-003  signed +0.0746pp  absolute 1.2690pp  max 6.2791pp
+            corpus mean shift 95% CI [-0.6911, +0.8323]  half-width 0.7617pp
+  all pairs  absolute mean 1.2237pp  median 0.7545pp  max 4.1860pp
+
+per-task movement, as published (metric 1, secondary)
+  run-001 vs run-002  signed -0.1993pp  absolute 1.6173pp  max 7.0500pp  half-width 0.8407pp
+  run-001 vs run-003  signed -0.3723pp  absolute 1.0183pp  max 3.9600pp  half-width 0.4697pp
+  run-002 vs run-003  signed -0.1730pp  absolute 1.5003pp  max 6.8800pp  half-width 0.8894pp
+
+result changed on a second grading (metric 5), 4299 item pairs
+  verdict       204 pairs  4.7453%  (66 / 65 / 73)
+                95% CI [3.8208, 5.7446]  width 1.9238pp
+  score outcome 450 pairs  10.4676%  (153 / 144 / 153)
+                95% CI [8.2527, 12.7323]  width 4.4796pp
+  adjacent moves 175   two-step pass/fail moves 23   same verdict, moved score 246
+  transition  fail->judge_error            1
+  transition  fail->partial                51
+  transition  fail->pass                   10
+  transition  judge_error->fail            2
+  transition  judge_error->partial         1
+  transition  partial->fail                35
+  transition  partial->pass                46
+  transition  pass->fail                   13
+  transition  pass->judge_error            2
+  transition  pass->partial                43
+
+why the unit is the task and not the item (section 6)
+  task cluster   [3.8208, 5.7446]  width 1.9238pp   OFFICIAL
+  naive item     [4.1172, 5.3966]  width 1.2794pp   not used
+  the naive interval is 1.5037x narrower than the one this analysis reports
+  the naive lower endpoint can only land on multiples of 0.0233pp, and the exact binomial puts the 2.5th percentile between
+    176 of 4299 = 4.0940%  P(X <= k) = 0.02241
+    177 of 4299 = 4.1172%  P(X <= k) = 0.02672
+
+what was actually observed (metric 3, section 9)
+  pass 3175   partial 585   fail 535   judge_error 4
+  judge_error rate 0.0930%
+  refusal        not in this schema and not observed - absent, not measured
+  tool failure   no field exists - the read census below is a proxy
+  read_deliverable per item  0x 92   1x 2855   2x 516   3x 822   4x 8   5x 2   6x 4
+  routing modality  formatting 207   mixed 3   text 3858   visual 231
+
+cost and latency per run (metric 6)
+  run-001  judge calls 3735  in 27565287  out 1430055  cached 13109489
+            latency 25545.5s   routes grader/direct-v1
+            cost unregistered - gpt-5.6-sol, gpt-audio-1.5 is not in the price table
+  run-002  judge calls 3738  in 26955352  out 1435506  cached 12712485
+            latency 24092.7s   routes grader/direct-v1
+            cost unregistered - gpt-5.6-sol, gpt-audio-1.5 is not in the price table
+  run-003  judge calls 3766  in 27532595  out 1427396  cached 13003884
+            latency 23733.0s   routes grader/direct-v1
+            cost unregistered - gpt-5.6-sol, gpt-audio-1.5 is not in the price table
+
+the target (section 8)
+  worst half-width 0.8894pp   target <= 1.0pp   MET
+  pair difference stdev worst case 2.1448pp   runs required 3   held 3
+
+VERDICT  MET
+```
+
+## 이 숫자들이 무슨 뜻인가
+
+### 1. 평균은 안 움직인다
+
+세 실행의 코퍼스 평균은 **82.87% · 83.07% · 83.25%**, 가장 먼 두 값의 차이가
+**0.37pp**다. 다시 채점했을 때 평균이 얼마나 움직이는지에 붙는 95% 구간은 세 짝
+모두 **반폭 0.9pp 이하**이고, **여섯 구간이 전부 0을 품는다** — 어느 실행이
+일관되게 후하다고 말할 근거가 없다는 뜻이다.
+
+사전등록 §8이 정한 목표는 **반폭 ≤ 1.0pp**였다. 관문은 두 기준 중 **나쁜 쪽**으로
+잡았고(공통분모 0.76pp, 발표값 0.89pp), **0.89pp로 통과했다.**
+
+1.0pp라는 목표가 자의적이지 않은 이유: 82.87%에서 90%까지는 **7.13pp**가 남아
+있다. 반복 채점의 흔들림이 그 간격의 8분의 1이면, "아직 90%에 못 미친다"는 판단은
+반복 채점 때문에 뒤집히지 않는다.
+
+**추가 유료 실행은 필요 없다.** §13의 공식
+`R = ceil((1.96·σ_d/(목표·√n))²) + 1` 에 가장 넓은 짝의 σ_d = 2.14pp를 넣으면
+필요 실행 수는 **3회**이고, 우리는 3회를 이미 갖고 있다.
+
+### 2. 항목 하나하나는 움직인다
+
+항목 짝 4,299개(1,433개 × 3짝) 중
+
+- **판정이 뒤집힌 것 204개 = 4.75%** (95% 구간 3.82 ~ 5.74%)
+- **점수 결과가 달라진 것 450개 = 10.47%** (95% 구간 8.25 ~ 12.73%)
+
+두 숫자를 나눈 이유는 **판정 이름은 그대로인데 점수만 움직인 항목이 246개**이기
+때문이다. `partial`이 2.0점에서 1.5점으로 내려가도 이름은 `partial`이다. 판정만
+세면 그 246개가 안 보이고, 점수만 세면 사람이 인용하는 문장이 뒤집힌 사실이 안
+보인다.
+
+**두 칸을 건너뛴 이동 23건.** `pass`가 `fail`이 되거나 그 반대인 경우다. 나머지
+175건은 옆 칸 이동이다.
+
+### 3. 평균이 잠잠한데 항목이 흔들리는 이유
+
+**뒤집힘이 양쪽으로 거의 고르게 나기 때문이다.** 위로 올라간 이동이 107건,
+내려간 이동이 91건, 판정 실패가 낀 것이 6건이다. 뒤로 갈수록 아주 조금 후해지는
+기울기가 보이지만(82.87 → 83.07 → 83.25), 앞서 본 대로 **그 기울기는 95% 구간
+안에서 0과 구별되지 않는다.**
+
+그래서 두 문장은 함께 참이다.
+
+- **"이 코퍼스의 평균은 82.9%다"** — 다시 채점해도 ±0.9pp 안에서 그대로다.
+- **"이 항목은 pass였다"** — 스무 번에 한 번은 다시 채점하면 다른 판정이 나온다.
+
+**한 항목의 판정을 근거로 문장을 쓸 때는 두 번째 사실이 적용된다.**
+
+## 왜 항목이 아니라 과제를 다시 뽑는가
+
+1,433개 항목을 독립된 관측 1,433개로 다루면 표본이 커 보이고, 그건 사실이 아니다.
+한 과제 안의 항목들은 같은 산출물·같은 파일·같은 채점 맥락을 공유하고, **과제가
+움직이면 그 안의 항목들이 함께 움직인다.**
+
+| 재추출 단위 | 판정 뒤집힘 95% 구간 | 폭 |
+|---|---|---|
+| **과제(공식)** | 3.8208 ~ 5.7446% | **1.9238pp** |
+| 항목(쓰지 않음) | 4.1172 ~ 5.3966% | 1.2794pp |
+
+항목 단위로 재면 구간이 **1.50배 좁게** 나온다. 좁은 쪽이 더 정밀한 게 아니라,
+없는 정보를 있다고 가정한 결과다. 그래서 공식 구간은 넓은 쪽이다.
+
+### 사전등록의 4.094와 여기의 4.117
+
+사전등록 §6은 항목 구간의 아래끝을 **4.094**로 적었고 여기서 다시 돌리면
+**4.117**이 나온다. 구현을 열한 가지로 바꿔 봐도 전부 4.117이었다. **원인은 구현이
+아니라 정수다.**
+
+항목 재추출의 통계량은 4,299개 중 몇 개라는 정수를 4,299로 나눈 값이므로
+**0.0233pp 간격의 눈금 위에만 떨어진다.** 정확한 이항분포로 계산하면
+
+| 개수 | 비율 | P(X ≤ 개수) |
+|---|---|---|
+| 176 | 4.0940% | 0.02241 |
+| 177 | 4.1172% | 0.02672 |
+
+**참값인 2.5% 백분위는 176과 177 사이에 있다.** 어떤 추출도 그 사이 값을 낼 수
+없으므로 두 숫자 모두 같은 양의 정직한 실현값이고, 차이는 **항목 하나**다. 폭
+차이는 0.024pp이고 설계 효과 결론(약 1.5배)은 그대로다. 이건 추출 결과가 아니라
+산술이므로 도구가 매번 정확히 계산해서 위 표에 찍는다.
+
+## 재지 않은 것
+
+사전등록 §9의 원칙 그대로 — **없는 것은 없다고 적는다.**
+
+| | 관측 |
+|---|---|
+| 거부(refusal) | **이 스키마에 필드가 없고 관측되지도 않았다.** "거부율 0%"라고 쓰면 잰 것처럼 읽히는데, 잰 적이 없다 |
+| 도구 실패 | 전용 필드가 없다. `read_deliverable` 호출 횟수 분포가 대용물이고, 그렇게 표시한다 |
+| 판정 실패 | 4건 / 4,299짝 = 0.093%. `score_excluded`와 **완전히 같은 4건**이다 |
+| 음성 | **0개.** 307·310~312에서 관측된 음성 판정 흔들림은 구조적으로 이 구간 안에 들어올 수 없다 |
+| 선택 실패 | 4,299/4,299 `ok` |
+| 과제 오류 | 세 실행 모두 0 |
+
+`read_deliverable`를 **한 번도 부르지 않고** 판정한 항목이 92개 있다. 효율이
+아니라 도구 실패 후보로 보는 쪽이 맞고, 후속으로 넘긴다.
+
+## 비용
+
+세 실행 모두 `estimated_cost_usd`가 비어 있다. `gpt-5.6-sol`과 `gpt-audio-1.5`가
+가격표에 없기 때문이다. **금액은 "미등록"으로 적는다.** 값을 못 매긴 실행은 공짜
+실행이 아니고, `$0.00`이라고 쓰면 가격표의 구멍이 청구서에 대한 주장으로 바뀐다.
+
+토큰과 시간은 실측이 있다: 판정 호출 3,735 · 3,738 · 3,766회, 입력 약 2,700만
+토큰, 출력 약 143만 토큰, 판정 누적 시간 약 6.6 ~ 7.1시간.
+
+## 이 문서를 어떻게 검증하는가
+
+- 위 `결과` 블록은 주석에 적힌 명령을 **그대로 다시 돌려 한 바이트까지 대조**한다
+  (`test_repeat_variation_report_quotes_its_run.py`). 난수 씨앗이 `20260901`로
+  고정된 이유가 이것이다 — 시계에서 오는 값이면 이 대조가 불가능하다.
+- 사전등록 §12의 **돌연변이 여섯 가지**(지문 변조 · 같은 파일 두 번 · 판정값 위조 ·
+  재추출 단위 과제→항목 · 씨앗 변경 · 음성 주입)를 각각 심어 놓고 **전부 빨개지는지**
+  확인한다.
+- **음성 대조**: 같은 파일을 세 번 넣으면 차이가 정확히 0으로 나오고, 그 0이
+  발표되기 전에 같은-파일 검사가 먼저 막는다는 것을 확인한다.
+- 기존 `analyze_variance.py`는 **한 줄도 고치지 않았다.** 이 도구는 코드를 공유하지
+  않는 별도 파일이다 — 저쪽을 고치면 2단계가 발표한 숫자가 움직이기 때문이다.
+- 기존 채점 결과 파일은 **읽기만 했다.**


### PR DESCRIPTION
사전등록 문서 `tasks/rebuilding_grading_task/315-repeat-variation-prereg.md`의 2단계입니다. 같은 답안 30개를 **모든 지문을 고정한 채 세 번 채점한** 결과가 이미 저장소에 있고, 이 PR은 그 세 번을 비교하는 도구와 보고서를 추가합니다.

**모델을 한 번도 부르지 않습니다. 비용 0원입니다.**

---

## 한 줄 요약

> 전체 평균은 안 움직인다. 그런데 항목 하나하나는 움직인다.

두 문장이 다 맞고, 둘 중 하나만 쓰면 거짓말이 됩니다. 그래서 보고서는 둘 다 씁니다.

## 무엇을 알아냈나

| 무엇을 보는가 | 결과 | 뜻 |
|---|---|---|
| **발표 숫자 (30개 과제 평균)** | 82.87%, 재채점해도 **±0.89pp 안** | 안전합니다 |
| **항목 판정 (pass / partial / fail)** | 100번 중 **4.75번 뒤집힘** | 안 안전합니다 |
| **항목 점수 결과** | 100번 중 **10.47번 달라짐** | 더 안 안전합니다 |

**왜 항목은 그렇게 흔들리는데 평균은 가만히 있나?** 뒤집힘이 위아래로 거의 반반이라 서로 상쇄되기 때문입니다.

- 위로 올라간 것: **107건**
- 아래로 내려간 것: **91건**
- (판정 오류가 낀 것: 6건)

204건이 뒤집혔는데 107 vs 91로 갈려서, 합치면 거의 0이 됩니다. 우연이 아니라 구조적으로 그렇습니다.

**그래서 실무적으로 이렇게 쓰시면 됩니다.**

- ✅ "이 모델은 82.87% 받았다" — 다시 채점해도 이 결론은 안 바뀝니다. 90%까지 7.13pp 여유가 있습니다.
- ❌ "이 과제의 이 항목은 pass였다" — 다시 채점하면 20번에 1번은 다르게 나옵니다. 항목 하나를 근거로 결론 내리지 마세요.

## 어떻게 쟀나 (사전등록대로)

- **지문 16개를 세 파일 전부에서 대조**하고, 하나라도 다르면 그 자리에서 멈춥니다(fail closed). 과제 목록 해시, 과제 수, 채점 코드 해시, 판정 모델·배포·API 버전·추론 강도·온도·시드, 프롬프트 버전, 루브릭 리비전, 렌더러 빌드, 스키마 버전까지 포함합니다.
- **과제 단위 묶음 부트스트랩**(paired task-cluster bootstrap), 재표본 10,000회, 시드 20260901 고정. 시드를 고정한 이유는 보고서를 다시 돌려서 같은 숫자가 나오는지 검사하기 위해서입니다.
- **항목 단위 부트스트랩은 공식 구간으로 쓰지 않았습니다.** 다만 얼마나 위험한지 보여주려고 계산해서 나란히 실었습니다. 항목 단위로 재면 구간이 **1.50배 좁게** 나옵니다. 같은 과제 안의 항목들이 서로 독립이 아닌데 독립인 척하기 때문입니다.
- 세 번 사이에 **만점 자체가 달라진 과제 3개**는 공통 분모에서 빼고, 뺀 것과 안 뺀 것 **둘 다** 보고합니다.

## 추가 유료 실행이 필요한가 — 아니요

사전등록에는 "목표(반폭 1.0pp)를 못 맞추면 추가 반복 횟수와 중단 규칙을 먼저 등록하고 유료 실행하라"는 조항이 있습니다.

**목표를 맞췄습니다.** 최악의 반폭이 **0.89pp**로 1.0pp 안입니다. 계산된 필요 실행 횟수는 3회이고 가진 것도 3회입니다. **그래서 이 조항은 발동하지 않고, 이 PR에서 나오는 유료 실행은 없습니다.**

---

## 안전장치

**기존 것을 건드리지 않았습니다.**

- `analyze_variance.py`는 **수정하지 않았습니다**(사전등록 요구사항). 게다가 이 도구가 그쪽을 몰래 갖다 쓰지 못하도록 **import 그래프를 실제로 걸어보는 검사**를 넣었습니다. 문자열 검색으로는 주석에 이름만 나와도 걸리기 때문에 AST로 확인합니다.
- 채점 결과 파일 3개는 **읽기만** 합니다.
- **채점 지문(`grader_source_hash`)에 영향 없음** — 두 가지로 확인했습니다.
  1. 지문에 들어가는 파일을 실제로 세어보니 **108개**이고, 그중 `batch-runner/scripts/`에서는 `download_inference_from_hf.py` **한 개만**, `batch-runner/tests/`에서는 **0개**가 들어갑니다. 이 PR의 5개 경로는 하나도 없습니다.
  2. 지금 main과 이 브랜치에서 각각 지문을 계산해보니 **똑같습니다** (`09d43e1a…`).

**검사 84개**를 함께 넣었습니다. 그냥 "돌아간다"가 아니라:

- **돌연변이 검사** — 고정한 지문을 하나씩 일부러 망가뜨리고, 도구가 정말 멈추는지 확인합니다. 안 멈추면 그 검사가 실패합니다.
- **음성 대조 검사** — 한 실행을 자기 자신과 비교해서 **뒤집힘이 0**으로 나오는지 봅니다. 여기서 0이 안 나오면 4.75%라는 숫자는 측정이 아니라 버그입니다.
- **보고서 재현 검사** — 보고서 안의 숫자 블록을 **명령어까지 같이 적어두고, 검사가 그 명령을 다시 돌려서 바이트 단위로 같은지** 봅니다. 손으로 고친 숫자, 바뀐 도구, 옮겨진 파일 중 무엇이든 여기서 걸립니다.

## 사전등록과 달라진 점 (미리 밝힘)

사전등록 14절은 보고서를 `tasks/rebuilding_grading_task/PR3_REPEAT_VARIATION.md`에 두라고 했는데, `.gitignore`가 `tasks/**`를 막고 있어서 **`data/grades/_validation/`** 에 두었습니다. 원래 경로와 실제 경로를 **보고서 안에 둘 다 적어두었고**, 검사가 그 두 경로가 다 적혀 있는지 확인합니다. 나중에 diff를 뜬 사람이 "어 왜 다르지"라고 하는 상황을 만들지 않으려는 것입니다.

## 비용 표기

판정 모델(`gpt-5.6-sol`, `gpt-audio-1.5`)은 가격표에 없습니다. 그래서 결과 파일에는 `$0`이 아니라 **`unregistered - ... is not in the price table`** 이라고 적혀 있고, 보고서도 그대로 옮겼습니다. **모르는 것은 공짜가 아닙니다.** 이 PR 자체의 비용은 진짜로 0입니다(모델 호출 없음).

---

## 병합 전 확인한 것

- 백엔드 전체 테스트 통과 (병합 전 재확인 진행 중)
- 진행 중이거나 대기 중인 채점 실행 **0건**
- 채점 지문 영향 **없음** (위 참조)
- `analyze_variance.py`, 기존 채점 결과 파일 **무수정**

## 참고 — 별개 사항

이 브랜치에 main을 합치면서 확인된 것인데, #360이 `core/cost_projection.py`를 바꾸면서 **채점 지문이 또 한 번 이동했습니다**. 이 PR과는 무관하지만, "다음 유료 채점 전에 새 지문으로 smoke를 먼저 돌린다"는 기존 약속이 여전히 유효하다는 뜻입니다.

Refs: `tasks/rebuilding_grading_task/315-repeat-variation-prereg.md`
