### PR TITLE
fix(cost): make a grade's ledger pointer resolve to the file it names

### DIFF
--- a/batch-runner/core/cost_projection.py
+++ b/batch-runner/core/cost_projection.py
@@ -79,7 +79,28 @@ _RETRY_NONE = "none"
 _SLUG = re.compile(r"[a-z][a-z0-9_]{0,47}")
 _REASON_CODE = re.compile(r"[a-z][a-z0-9_.:-]{0,63}")
 _SHA256 = re.compile(r"[0-9a-f]{64}")
-_LEDGER_PATH = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}(/[A-Za-z0-9][A-Za-z0-9._-]{0,127})*")
+
+# How long one path component may be. Not a taste decision: 255 bytes is
+# ``NAME_MAX`` on every filesystem this runs on, so a longer component cannot
+# name a file that exists, and a bound below it would reject real names. The
+# names here are run identities -- experiment, judge, config hash, rubric SHA,
+# inference SHA, grader source hash -- and the longest under ``data/grades``
+# today is 254 bytes. The 128 this used to be excluded seven of them.
+_MAX_LEDGER_NAME = 255
+
+# And how long the whole path may be, which the per-component bound does not
+# imply: nesting is what grows it. A published ledger sits under
+# ``data/grades``, up to five directories down for a repeat of a shard of a
+# diagnostic run; the longest that exists today is 348 bytes.
+_MAX_LEDGER_PATH_LENGTH = 512
+
+# The leading character is narrower than the rest so that ``..`` and a segment
+# that could be read as a command-line option are both out. It admits ``_``
+# because the directories these paths run through are ``_shards``,
+# ``_repeats`` and ``_diagnostic`` -- which never came up while the field held
+# a bare filename, and is most of what it holds now.
+_LEDGER_SEGMENT = rf"[A-Za-z0-9_][A-Za-z0-9._-]{{0,{_MAX_LEDGER_NAME - 1}}}"
+_LEDGER_PATH = re.compile(rf"{_LEDGER_SEGMENT}(/{_LEDGER_SEGMENT})*")
 
 _MAX_COMPONENTS = 32
 _MAX_USAGE_KEYS = 32
@@ -427,7 +448,11 @@ def project_cost_ledger_reference(value, field: str = "cost_ledger"):
     if not isinstance(value, dict):
         _fail(field, "must be an object")
     path = value.get("path")
-    if not isinstance(path, str) or _LEDGER_PATH.fullmatch(path) is None:
+    if (
+        not isinstance(path, str)
+        or _LEDGER_PATH.fullmatch(path) is None
+        or len(path) > _MAX_LEDGER_PATH_LENGTH
+    ):
         _fail(field, "path must be a relative repository path")
     if ".." in path.split("/"):
         _fail(field, "path must not traverse parents")
@@ -435,6 +460,32 @@ def project_cost_ledger_reference(value, field: str = "cost_ledger"):
     if not isinstance(digest, str) or _SHA256.fullmatch(digest) is None:
         _fail(field, "sha256 must be a sha256 digest")
     return {"path": path, "sha256": digest}
+
+
+def repo_relative_ledger_path(ledger_path: Path, repo_root: Path) -> str | None:
+    """The repository path a published pointer may name, or ``None``.
+
+    A grade's ledger pointer is defined -- here, in ``cost-receipt.mjs``, and
+    in the grade schema -- as a *relative repository path*, and for a long
+    while what the two grading writers put in it was ``Path.name``: a bare
+    filename. Every one of the 38 grade files carrying the field named a file
+    that resolved from nowhere. The sidecars were there, beside their grades,
+    several directories down; nothing in the payload said so, and the record
+    the dashboard builds from it drops the directory, so the one reader that
+    could have reconstructed it is the one reader that cannot.
+
+    ``None`` when the ledger is not inside the repository at all -- a local
+    run writing somewhere else. It is the same answer as a failed export: a
+    result that cannot point at its own audit trail says so, rather than
+    carrying a name that points at nothing. Callers that want the pointer
+    regardless must say which root the path is relative to.
+    """
+    try:
+        relative = Path(ledger_path).resolve().relative_to(Path(repo_root).resolve())
+    except ValueError:
+        return None
+    text = relative.as_posix()
+    return text if _LEDGER_PATH.fullmatch(text) else None
 
 
 def verify_cost_ledger(reference: dict | None, ledger_path: Path) -> dict | None:

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -140,7 +140,11 @@
       "additionalProperties": false,
       "required": ["path", "sha256"],
       "properties": {
-        "path": {"type": "string", "minLength": 1},
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where the audit JSONL sidecar is, as a path from the repository root -- not a bare filename. A pointer that resolves nowhere reads as an audit trail that exists, so scripts/aggregate-grades.mjs refuses to publish a grade whose pointer names no file here."
+        },
         "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
       }
     },

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -42,6 +42,7 @@ from core.cost_receipts import (
     ledger_reference,
     summarise_receipts,
 )
+from core.cost_projection import repo_relative_ledger_path
 from core.experiment_config import ExperimentConfig
 from core.grader import (
     Grader,
@@ -392,6 +393,18 @@ def _repo_relative_grade_file(out_path: Path) -> str:
     if not value or any(char in value for char in ("\r", "\n")):
         raise ValueError("grade output path is not safe for GITHUB_OUTPUT")
     return value
+
+
+def _repo_root() -> Path:
+    """The root a published ledger pointer is relative to.
+
+    Derived exactly as ``_repo_relative_grade_file`` derives it, and kept
+    beside it so the two cannot drift: a pointer written against one root and
+    read against another is the defect this is here to close, not a new way to
+    reintroduce it.
+    """
+    cwd = Path.cwd().resolve()
+    return cwd.parent if cwd.name == "batch-runner" else cwd
 
 
 def _exit_on_signal(signum: int, _frame: Any) -> None:
@@ -2405,6 +2418,14 @@ def main() -> int:
         stood when that partial was written. A failed export returns ``None``:
         a grade that cannot point at its own audit trail says so, instead of
         carrying a digest of something else.
+
+        A ledger written outside the repository returns ``None`` for the same
+        reason. The field is a *relative repository path* — that is what this
+        file's schema says, what ``cost_projection`` validates, and what
+        ``cost-receipt.mjs`` re-derives — and for a long while what went into
+        it was ``Path.name``, a bare filename that resolved from nowhere. A
+        local run writing its ledger somewhere else has no repository path to
+        give, and a name is not a smaller version of one.
         """
         if cost_recorder is None:
             return None
@@ -2416,7 +2437,15 @@ def main() -> int:
                 file=sys.stderr,
             )
             return None
-        return ledger_reference(cost_export_path.name, digest)
+        relative = repo_relative_ledger_path(cost_export_path, _repo_root())
+        if relative is None:
+            print(
+                f"[cost] ledger is outside the repository ({cost_export_path});"
+                " the grade will not claim one",
+                file=sys.stderr,
+            )
+            return None
+        return ledger_reference(relative, digest)
 
     def flush_cost_ledger() -> None:
         """Put the ledger on disk wherever this run ends, including badly.

--- a/batch-runner/step9_merge_shards.py
+++ b/batch-runner/step9_merge_shards.py
@@ -89,6 +89,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
 
+from core.cost_projection import repo_relative_ledger_path
 from core.cost_receipts import (
     BUCKET_GRADING,
     CostReceiptLedger,
@@ -101,6 +102,7 @@ from step8_grade import (
     _batch_runner_root,
     _compute_summary,
     _ordered_task_ids_sha256,
+    _repo_root,
     _save_json,
 )
 
@@ -1179,11 +1181,44 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _resolve_shard_ledger(
+    shard_path: Path, pointer_path: str, repo_root: Path
+) -> Path | None:
+    """Find the export a shard's ledger pointer names, or ``None``.
+
+    A pointer written today is a path from a repository root, so that is what
+    it is joined to. Which root, though, is not one fixed directory: shards are
+    graded on separate runners and are only in one checkout together once the
+    merging job has downloaded them, and a shard that was never moved still has
+    a root of its own. So the pointer is tried against the root this merge is
+    running in and then against each directory above the shard file, nearest
+    first -- the walk that also resolves the bare filenames written before this
+    field was a path at all, since the shard's own directory is the first
+    ancestor tried and a sibling is where those files are.
+
+    Guessing is safe here only because the guess is checked: the caller puts
+    every candidate through ``verify_export`` against the digest the shard
+    itself published, so a file found at the wrong root cannot pass for the
+    right one.
+    """
+    if not pointer_path or ".." in pointer_path.split("/"):
+        return None
+    candidates = [repo_root / pointer_path]
+    parent = shard_path.resolve().parent
+    candidates.extend(directory / pointer_path
+                      for directory in (parent, *parent.parents))
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def merge_shard_cost_ledgers(
     shard_paths: Sequence[Path],
     payloads: Sequence[dict],
     out_path: Path,
     *,
+    repo_root: Path | None = None,
     warn: Callable[[str], None] | None = None,
 ) -> dict[str, str] | None:
     """Fold every shard's grading ledger into one beside the merged grade.
@@ -1199,10 +1234,16 @@ def merge_shard_cost_ledgers(
     quietly omits a shard reads as though that shard had spent nothing, which
     is exactly the reading this whole mechanism exists to prevent. The per-task
     receipts are unaffected; they travel in the rows.
+
+    Also ``None`` when the merged export lands outside the repository, because
+    the pointer published for it is a repository path and there would be none
+    to publish. ``repo_root`` says which repository; it defaults to the one
+    this process is running in, derived exactly as step8 derives it.
     """
     emit = warn if warn is not None else (
         lambda message: print(f"WARNING: {message}", file=sys.stderr)
     )
+    root = Path(repo_root) if repo_root is not None else _repo_root()
 
     exports: list[Path] = []
     for shard_path, payload in zip(shard_paths, payloads):
@@ -1213,11 +1254,13 @@ def merge_shard_cost_ledgers(
                 "grade will not claim one."
             )
             return None
-        export = shard_path.with_name(str(pointer.get("path") or ""))
-        if not export.is_file():
+        claimed = str(pointer.get("path") or "")
+        export = _resolve_shard_ledger(shard_path, claimed, root)
+        if export is None:
             emit(
-                f"{shard_path} points at a cost ledger that is not beside it "
-                f"({export.name}); the merged grade will not claim one."
+                f"{shard_path} points at a cost ledger ({claimed or 'no path'}) "
+                f"that is neither under {root} nor above the shard; the merged "
+                "grade will not claim one."
             )
             return None
         if not verify_export(export, str(pointer.get("sha256") or "")):
@@ -1247,7 +1290,14 @@ def merge_shard_cost_ledgers(
         return None
     finally:
         ledger.close()
-    return ledger_reference(merged_export.name, digest)
+    relative = repo_relative_ledger_path(merged_export, root)
+    if relative is None:
+        emit(
+            f"the merged cost ledger ({merged_export}) is outside the "
+            "repository; the merged grade will not claim one."
+        )
+        return None
+    return ledger_reference(relative, digest)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/batch-runner/tests/test_a_ledger_pointer_names_a_file_that_exists.py
+++ b/batch-runner/tests/test_a_ledger_pointer_names_a_file_that_exists.py
@@ -1,0 +1,282 @@
+"""The address on a grade's audit trail has to be an address.
+
+``cost_ledger.path`` is where a published grade says its per-call bill lives.
+Three places define it as a *relative repository path* — the grade schema,
+``core.cost_projection.project_cost_ledger_reference``, and its JavaScript
+mirror in ``scripts/cost-receipt.mjs`` — and for the field's whole life both
+grading writers put ``Path.name`` in it: a bare filename.
+
+That is not a shorter way of saying the same thing. Of the thirty-eight grade
+files on disk carrying the field, **none** resolved from the repository root.
+Twenty-nine resolved as a sibling of their own grade file — which only helps a
+reader who already knows where the grade file is, and the dashboard record
+built from the payload drops exactly that. Nine resolved from nowhere at all.
+So the field read as an audit trail that exists while pointing at nothing, and
+the one reader that could have reconstructed the location is the one reader
+that cannot.
+
+Nothing here calls a model or a network. Two things are measured against the
+real corpus rather than a fixture, because a bound guessed from taste is how
+the previous cap came to exclude seven real filenames.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.cost_projection import (
+    _MAX_LEDGER_NAME,
+    _MAX_LEDGER_PATH_LENGTH,
+    project_cost_ledger_reference,
+    repo_relative_ledger_path,
+)
+from step9_merge_shards import _resolve_shard_ledger
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GRADES_DIR = REPO_ROOT / "data" / "grades"
+
+_DIGEST = "0" * 64
+
+
+# ── what the writers may publish ─────────────────────────────────────────
+
+
+def test_a_ledger_in_the_repository_is_named_from_the_root(tmp_path):
+    """The whole fix in one line: the directories survive.
+
+    ``data/grades/_shards/<stem>/`` is where a shard's export actually sits.
+    A reader given only ``shard-004-of-011.cost_ledger.jsonl`` has no way back
+    to it.
+    """
+    export = tmp_path / "data" / "grades" / "_shards" / "stem" / "s.cost_ledger.jsonl"
+    export.parent.mkdir(parents=True)
+    export.write_text("", encoding="utf-8")
+
+    assert repo_relative_ledger_path(export, tmp_path) == (
+        "data/grades/_shards/stem/s.cost_ledger.jsonl"
+    )
+
+
+def test_a_ledger_outside_the_repository_is_no_path_at_all(tmp_path):
+    """``None``, not a filename, because a filename is what was wrong.
+
+    A local run exporting somewhere outside the checkout has no repository
+    path to give. Answering with the basename is how the field spent its whole
+    life pointing at nothing; answering with nothing at least says so.
+    """
+    outside = tmp_path / "elsewhere" / "ledger.cost_ledger.jsonl"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("", encoding="utf-8")
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+
+    assert repo_relative_ledger_path(outside, checkout) is None
+
+
+def test_the_underscore_directories_the_real_paths_run_through_are_allowed(tmp_path):
+    """The segment rule had to be widened before any of this could ship.
+
+    Every published ledger path passes through ``_shards``, ``_repeats`` or
+    ``_diagnostic``. The original pattern required each segment to begin with
+    ``[A-Za-z0-9]``, which never mattered while the field held a bare filename
+    and rejects essentially every real path now that it does not.
+    """
+    for directory in ("_shards", "_repeats", "_diagnostic"):
+        export = tmp_path / "data" / "grades" / directory / "l.cost_ledger.jsonl"
+        export.parent.mkdir(parents=True)
+        export.write_text("", encoding="utf-8")
+        relative = repo_relative_ledger_path(export, tmp_path)
+        assert relative == f"data/grades/{directory}/l.cost_ledger.jsonl"
+        # And the validator has to agree, or the writer emits what the reader
+        # refuses — which is the same defect with the halves swapped.
+        project_cost_ledger_reference(
+            {"path": relative, "sha256": _DIGEST}, field="cost_ledger"
+        )
+
+
+@pytest.mark.parametrize("segment", ["..", ".hidden", "-oh"])
+def test_a_segment_that_is_not_a_plain_name_is_refused(segment):
+    """``_`` was let in; ``.`` and ``-`` were deliberately kept out.
+
+    ``..`` climbs out of the repository, a leading ``.`` names a file nothing
+    here publishes, and a leading ``-`` is a segment a shell reads as an
+    option. None of them appears in the corpus, so admitting them buys nothing
+    and costs a class of surprise.
+    """
+    with pytest.raises(Exception) as raised:
+        project_cost_ledger_reference(
+            {"path": f"data/grades/{segment}/l.jsonl", "sha256": _DIGEST},
+            field="cost_ledger",
+        )
+    assert "relative repository path" in str(raised.value)
+
+
+def test_the_bounds_are_the_filesystems_and_not_a_preference(tmp_path):
+    """255 is ``NAME_MAX``. It is not a number anyone chose.
+
+    A component longer than this cannot name a file that exists, and a bound
+    below it rejects names that do -- the 128 this used to be excluded seven
+    real run-identity filenames from validation. The whole-path bound is
+    separate because nesting, not naming, is what grows it.
+    """
+    assert _MAX_LEDGER_NAME == 255
+    assert _MAX_LEDGER_PATH_LENGTH == 512
+
+    long_name = "a" * _MAX_LEDGER_NAME + ".jsonl"
+    with pytest.raises(Exception) as raised:
+        project_cost_ledger_reference(
+            {"path": f"data/grades/{long_name}", "sha256": _DIGEST},
+            field="cost_ledger",
+        )
+    assert "relative repository path" in str(raised.value)
+
+    deep = "/".join(["dir"] * 200) + "/l.jsonl"
+    assert len(deep) > _MAX_LEDGER_PATH_LENGTH
+    with pytest.raises(Exception) as over_long:
+        project_cost_ledger_reference(
+            {"path": deep, "sha256": _DIGEST}, field="cost_ledger"
+        )
+    assert "relative repository path" in str(over_long.value)
+
+
+# ── measured against the corpus, not chosen ──────────────────────────────
+
+
+@pytest.mark.skipif(not GRADES_DIR.is_dir(), reason="no grades corpus in this checkout")
+def test_every_ledger_path_on_disk_fits_inside_the_bounds():
+    """The bounds are only right if the real corpus clears them.
+
+    Twenty-nine exports, the longest path 348 bytes and the longest single
+    component 239. Both bounds sit above what exists with room to spare, and
+    neither was picked before the corpus was counted.
+    """
+    exports = sorted(GRADES_DIR.rglob("*.cost_ledger.jsonl"))
+    assert exports, "the corpus lost its exports; the bounds below are unmeasured"
+
+    for export in exports:
+        relative = repo_relative_ledger_path(export, REPO_ROOT)
+        assert relative is not None, f"{export} does not project to a repository path"
+        project_cost_ledger_reference(
+            {"path": relative, "sha256": _DIGEST}, field="cost_ledger"
+        )
+
+
+@pytest.mark.skipif(not GRADES_DIR.is_dir(), reason="no grades corpus in this checkout")
+def test_a_published_pointer_is_a_path_that_resolves():
+    """The check the dashboard aggregator now enforces, stated here too.
+
+    ``scripts/aggregate-grades.mjs`` refuses to publish a grade whose pointer
+    names no file in this repository. It is free today because none of the
+    nineteen top-level grade files carries the field at all -- which is worth
+    knowing, because it means the guard was installed before it had anything
+    to catch rather than after an incident.
+    """
+    for grade in sorted(GRADES_DIR.glob("*.json")):
+        pointer = json.loads(grade.read_text(encoding="utf-8")).get("cost_ledger")
+        if not pointer:
+            continue
+        claimed = pointer.get("path")
+        assert (REPO_ROOT / claimed).is_file(), (
+            f"{grade.name} publishes cost_ledger.path={claimed!r}, which is not "
+            "a file here; see scripts/aggregate-grades.mjs"
+        )
+
+
+@pytest.mark.skipif(not GRADES_DIR.is_dir(), reason="no grades corpus in this checkout")
+def test_the_sidecar_naming_scheme_is_past_NAME_MAX_for_five_grades():
+    """A separate defect, pinned rather than fixed, so it cannot grow quietly.
+
+    step8 derives its ledger from the grade file: ``out_path.stem`` plus
+    ``.cost_ledger.sqlite3``, twenty characters. ``NAME_MAX`` is 255, so any
+    grade filename over 240 bytes has a sidecar that cannot be created --
+    ``ENAMETOOLONG``, verified on this filesystem, not assumed. Five files on
+    disk are already past it, the longest needing 269, and all five carry no
+    ledger pointer.
+
+    Whether the missing pointer is *caused* by the cliff is not established
+    here and is not claimed. Fixing it means changing how these files are
+    named, which is a change with its own blast radius. What this test buys is
+    that the count is a number somebody chose to accept rather than one nobody
+    ever looked at.
+    """
+    suffix = ".cost_ledger.sqlite3"
+    over = [
+        grade
+        for grade in GRADES_DIR.rglob("*.json")
+        if len((grade.stem + suffix).encode()) > _MAX_LEDGER_NAME
+    ]
+
+    assert len(over) == 5, (
+        f"{len(over)} grade files now have un-creatable ledger sidecars, not 5; "
+        "the naming scheme moved, or a new run landed past NAME_MAX"
+    )
+    for grade in over:
+        payload = json.loads(grade.read_text(encoding="utf-8"))
+        assert payload.get("cost_ledger") is None, (
+            f"{grade.name} claims a ledger, but its sqlite3 sibling would need "
+            f"{len((grade.stem + suffix).encode())} bytes and NAME_MAX is "
+            f"{_MAX_LEDGER_NAME}"
+        )
+
+
+# ── what the merge will still accept ─────────────────────────────────────
+
+
+def test_a_shard_that_never_left_its_own_runner_still_resolves(tmp_path):
+    """Shards do not share a root, so one root cannot find them all.
+
+    Each shard is graded on a runner of its own and only meets the others once
+    the merging job has downloaded them. Trying the merge's root and then each
+    directory above the shard file, nearest first, is what covers both -- and
+    the same walk resolves the bare filenames written before this field was a
+    path, because a shard's own directory is the first ancestor tried.
+    """
+    shard = tmp_path / "downloaded" / "shard0" / "batch-runner" / "grade.json"
+    shard.parent.mkdir(parents=True)
+    shard.write_text("{}", encoding="utf-8")
+    export = shard.with_name("grade.cost_ledger.jsonl")
+    export.write_text("", encoding="utf-8")
+
+    # Named from a root it was never under: found anyway, by walking up.
+    found = _resolve_shard_ledger(shard, "grade.cost_ledger.jsonl", tmp_path / "root")
+    assert found == export
+
+
+def test_the_merge_root_is_tried_before_the_walk(tmp_path):
+    """Ambiguity resolved toward the contract, not toward the legacy.
+
+    When a name exists both at the root and beside the shard, the root wins:
+    that is what the field means now. The two are the same file in every real
+    arrangement; making the order explicit means a future reader does not have
+    to work out which one a merge actually read.
+    """
+    root = tmp_path / "root"
+    shard = tmp_path / "shard" / "grade.json"
+    for path in (root / "l.jsonl", shard):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    shard.write_text("{}", encoding="utf-8")
+    (root / "l.jsonl").write_text("from the root", encoding="utf-8")
+    (shard.with_name("l.jsonl")).write_text("from beside the shard", encoding="utf-8")
+
+    found = _resolve_shard_ledger(shard, "l.jsonl", root)
+    assert found is not None
+    assert found.read_text(encoding="utf-8") == "from the root"
+
+
+def test_a_pointer_that_climbs_out_of_the_repository_resolves_to_nothing(tmp_path):
+    """The walk tries many roots, so ``..`` would eventually find something.
+
+    Refused before the search starts rather than filtered after it, because a
+    pointer containing ``..`` is not a repository path under any root and the
+    validator would not have emitted one.
+    """
+    shard = tmp_path / "a" / "b" / "grade.json"
+    shard.parent.mkdir(parents=True)
+    shard.write_text("{}", encoding="utf-8")
+    (tmp_path / "a" / "secret.jsonl").write_text("", encoding="utf-8")
+
+    assert _resolve_shard_ledger(shard, "../secret.jsonl", tmp_path) is None
+    assert _resolve_shard_ledger(shard, "", tmp_path) is None

--- a/batch-runner/tests/test_cost_ledger_survives_a_failed_run.py
+++ b/batch-runner/tests/test_cost_ledger_survives_a_failed_run.py
@@ -182,9 +182,12 @@ def _shard(tmp_path: Path, index: int, task_id: str) -> tuple[Path, dict]:
 def test_the_merge_finds_a_ledger_that_was_committed_beside_its_shard(tmp_path):
     """What the workflow's ``git add`` of the export buys.
 
-    ``merge_shard_cost_ledgers`` resolves each pointer relative to the shard
-    JSON, which on the merging runner means the checkout. This is the only
-    arrangement in which it returns a pointer at all.
+    The pointer a shard publishes is a path from the repository root, and the
+    merge resolves it against the root it is running in. Shards that were
+    graded on separate runners and never moved into one checkout keep roots of
+    their own, so each directory above the shard file is tried too -- which is
+    also how the bare filenames written before this field was a path at all
+    still resolve, since the shard's own directory is the first one tried.
     """
     warnings: list[str] = []
     first = _shard(tmp_path, 0, "task-a")
@@ -193,7 +196,7 @@ def test_the_merge_finds_a_ledger_that_was_committed_beside_its_shard(tmp_path):
 
     pointer = merge_shard_cost_ledgers(
         [first[0], second[0]], [first[1], second[1]], out_path,
-        warn=warnings.append,
+        repo_root=tmp_path, warn=warnings.append,
     )
 
     assert warnings == []
@@ -202,7 +205,59 @@ def test_the_merge_finds_a_ledger_that_was_committed_beside_its_shard(tmp_path):
     records = [json.loads(line) for line in
                merged.read_text(encoding="utf-8").splitlines() if line.strip()]
     assert {r["task_id"] for r in records} == {"task-a", "task-b"}
+    # Resolved from the root, not from beside the grade: that is the whole
+    # contract, and here the two happen to name the same file.
     assert pointer["path"] == merged.name
+    assert (tmp_path / pointer["path"]).is_file()
+
+
+def test_a_merged_ledger_outside_the_repository_is_no_pointer_at_all(tmp_path):
+    """The field is a repository path, so there is nothing honest to write.
+
+    A local merge writing somewhere outside the checkout has no repository
+    path to give, and a bare filename is not a smaller version of one -- it is
+    what the field held for its whole life, and none of the thirty-eight grade
+    files carrying it named a file anybody could find.
+    """
+    warnings: list[str] = []
+    first = _shard(tmp_path, 0, "task-a")
+    second = _shard(tmp_path, 1, "task-b")
+
+    pointer = merge_shard_cost_ledgers(
+        [first[0], second[0]], [first[1], second[1]], tmp_path / "final.json",
+        repo_root=tmp_path / "elsewhere", warn=warnings.append,
+    )
+
+    assert pointer is None
+    assert any("outside the repository" in message for message in warnings)
+
+
+def test_a_shard_ledger_a_directory_down_is_named_from_the_root(tmp_path):
+    """The shape every real published pointer has: a path, not a name.
+
+    Shards land in ``data/grades/_shards/<stem>/``, several directories below
+    the root, and the merged grade lands in ``data/grades/``. Nothing about
+    either is reconstructible from a filename.
+    """
+    shards = tmp_path / "data" / "grades" / "_shards" / "stem"
+    shards.mkdir(parents=True)
+    first = _shard(shards, 0, "task-a")
+    second = _shard(shards, 1, "task-b")
+    for shard_path, payload in (first, second):
+        payload["cost_ledger"]["path"] = (
+            f"data/grades/_shards/stem/{shard_path.stem}.cost_ledger.jsonl"
+        )
+        shard_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    out_path = tmp_path / "data" / "grades" / "final.json"
+    pointer = merge_shard_cost_ledgers(
+        [first[0], second[0]], [first[1], second[1]], out_path,
+        repo_root=tmp_path, warn=lambda message: pytest.fail(message),
+    )
+
+    assert pointer is not None
+    assert pointer["path"] == "data/grades/final.cost_ledger.jsonl"
+    assert (tmp_path / pointer["path"]).is_file()
 
 
 def test_an_uncommitted_ledger_makes_the_merged_grade_claim_none(tmp_path):
@@ -219,11 +274,11 @@ def test_an_uncommitted_ledger_makes_the_merged_grade_claim_none(tmp_path):
 
     pointer = merge_shard_cost_ledgers(
         [first[0], second[0]], [first[1], second[1]], tmp_path / "final.json",
-        warn=warnings.append,
+        repo_root=tmp_path, warn=warnings.append,
     )
 
     assert pointer is None
-    assert any("not beside it" in message for message in warnings)
+    assert any("neither under" in message for message in warnings)
 
 
 # ── being killed is not an excuse ────────────────────────────────────────

--- a/batch-runner/tests/test_cost_receipts_reach_the_pipeline_boundaries.py
+++ b/batch-runner/tests/test_cost_receipts_reach_the_pipeline_boundaries.py
@@ -107,7 +107,13 @@ def _grade_one(ledger, task_id, *, sequence=0, settle=True):
 
 
 def _shard_on_disk(tmp_path, price_table, index, task_ids):
-    """Write one shard grade file plus the ledger export it points at."""
+    """Write one shard grade file plus the ledger export it points at.
+
+    The pointer is a path from the repository root -- here ``tmp_path`` -- and
+    not the bare filename it used to be, because a bare filename is a name the
+    merge cannot resolve from anywhere except the one directory it happens to
+    be sitting in.
+    """
     directory = tmp_path / f"shard{index}"
     directory.mkdir()
     ledger = _ledger(directory, "ledger.sqlite3", price_table, run_id=f"run-{index}")
@@ -117,10 +123,20 @@ def _shard_on_disk(tmp_path, price_table, index, task_ids):
         digest = ledger.export_jsonl(directory / "grade.cost_ledger.jsonl")
     finally:
         ledger.close()
-    payload = {"cost_ledger": {"path": "grade.cost_ledger.jsonl", "sha256": digest}}
+    payload = {
+        "cost_ledger": {
+            "path": f"shard{index}/grade.cost_ledger.jsonl",
+            "sha256": digest,
+        }
+    }
     shard_path = directory / "grade.json"
     shard_path.write_text(json.dumps(payload), encoding="utf-8")
     return shard_path, payload
+
+
+def _export_of(tmp_path: Path, payload: dict) -> Path:
+    """The file a pointer names, resolved the way the merge resolves it."""
+    return tmp_path / payload["cost_ledger"]["path"]
 
 
 def _merged_rows(export: Path) -> list[dict]:
@@ -141,12 +157,13 @@ def test_the_merged_trail_holds_every_shards_calls(tmp_path, price_table):
         [first[0], second[0]],
         [first[1], second[1]],
         out,
+        repo_root=tmp_path,
         warn=warnings.append,
     )
 
     assert warnings == []
     assert pointer is not None
-    export = out.with_name(pointer["path"])
+    export = _export_of(tmp_path, {"cost_ledger": pointer})
     calls = [row for row in _merged_rows(export) if row.get("call_id")]
     assert {row["task_id"] for row in calls} == {"task-a", "task-b", "task-c"}
 
@@ -159,11 +176,16 @@ def test_the_merged_pointer_can_be_checked_against_the_file_it_names(
     out = tmp_path / "merged.json"
 
     pointer = s9.merge_shard_cost_ledgers(
-        [first[0], second[0]], [first[1], second[1]], out, warn=lambda _m: None
+        [first[0], second[0]], [first[1], second[1]], out,
+        repo_root=tmp_path, warn=lambda _m: None,
     )
 
     assert pointer is not None
-    assert verify_export(out.with_name(pointer["path"]), pointer["sha256"])
+    # Resolved from the root the pointer is relative to, which is the whole
+    # point of the field: a reader holding the grade and the repository can
+    # find the trail without knowing where the grade file itself sits.
+    assert verify_export(_export_of(tmp_path, {"cost_ledger": pointer}),
+                         pointer["sha256"])
 
 
 def test_the_same_shard_folded_in_twice_is_still_one_bill(tmp_path, price_table):
@@ -172,12 +194,13 @@ def test_the_same_shard_folded_in_twice_is_still_one_bill(tmp_path, price_table)
     out = tmp_path / "merged.json"
 
     once = s9.merge_shard_cost_ledgers(
-        [shard[0]], [shard[1]], out, warn=lambda _m: None
+        [shard[0]], [shard[1]], out, repo_root=tmp_path, warn=lambda _m: None
     )
     twice = s9.merge_shard_cost_ledgers(
         [shard[0], shard[0]],
         [shard[1], shard[1]],
         tmp_path / "merged2.json",
+        repo_root=tmp_path,
         warn=lambda _m: None,
     )
 
@@ -196,6 +219,7 @@ def test_a_shard_with_no_pointer_stops_the_merged_trail(tmp_path, price_table):
         [good[0], blind],
         [good[1], {"cost_ledger": None}],
         tmp_path / "merged.json",
+        repo_root=tmp_path,
         warn=warnings.append,
     )
 
@@ -207,15 +231,16 @@ def test_a_pointer_to_a_file_that_is_gone_stops_the_merged_trail(
     tmp_path, price_table
 ):
     shard_path, payload = _shard_on_disk(tmp_path, price_table, 0, ["task-a"])
-    shard_path.with_name(payload["cost_ledger"]["path"]).unlink()
+    _export_of(tmp_path, payload).unlink()
 
     warnings: list[str] = []
     pointer = s9.merge_shard_cost_ledgers(
-        [shard_path], [payload], tmp_path / "merged.json", warn=warnings.append
+        [shard_path], [payload], tmp_path / "merged.json",
+        repo_root=tmp_path, warn=warnings.append,
     )
 
     assert pointer is None
-    assert any("not beside it" in message for message in warnings)
+    assert any("neither under" in message for message in warnings)
 
 
 def test_a_trail_that_no_longer_matches_its_digest_stops_the_merge(
@@ -223,7 +248,7 @@ def test_a_trail_that_no_longer_matches_its_digest_stops_the_merge(
 ):
     """An edited audit trail is worth less than no audit trail at all."""
     shard_path, payload = _shard_on_disk(tmp_path, price_table, 0, ["task-a"])
-    export = shard_path.with_name(payload["cost_ledger"]["path"])
+    export = _export_of(tmp_path, payload)
     rows = _merged_rows(export)
     for row in rows:
         if row.get("call_id"):
@@ -235,7 +260,8 @@ def test_a_trail_that_no_longer_matches_its_digest_stops_the_merge(
 
     warnings: list[str] = []
     pointer = s9.merge_shard_cost_ledgers(
-        [shard_path], [payload], tmp_path / "merged.json", warn=warnings.append
+        [shard_path], [payload], tmp_path / "merged.json",
+        repo_root=tmp_path, warn=warnings.append,
     )
 
     assert pointer is None
@@ -256,8 +282,8 @@ def test_two_shards_that_disagree_about_one_call_stop_the_merged_trail(
     first_path, first = _shard_on_disk(tmp_path, price_table, 0, ["task-a"])
     second_path, second = _shard_on_disk(tmp_path, price_table, 1, ["task-a"])
     # Same run identity on both sides, so the call identifiers collide.
-    forged = second_path.with_name(second["cost_ledger"]["path"])
-    rows = _merged_rows(first_path.with_name(first["cost_ledger"]["path"]))
+    forged = _export_of(tmp_path, second)
+    rows = _merged_rows(_export_of(tmp_path, first))
     for row in rows:
         if row.get("call_id"):
             row["output_tokens"] = 999_999
@@ -274,6 +300,7 @@ def test_two_shards_that_disagree_about_one_call_stop_the_merged_trail(
         [first_path, second_path],
         [first, second],
         tmp_path / "merged.json",
+        repo_root=tmp_path,
         warn=warnings.append,
     )
 

--- a/batch-runner/tests/test_shard_merge_roundtrip.py
+++ b/batch-runner/tests/test_shard_merge_roundtrip.py
@@ -73,10 +73,10 @@ def _grade_path(root: Path, index: int, count: int) -> Path:
 #     moments by construction, and even this harness drifts by a second when a
 #     run straddles a second boundary. Its merge rule is asserted directly in
 #     test_merge_takes_the_last_shard_completion_time rather than diffed here.
-#   cost_ledger -- a pointer to the audit file sitting beside *this* grade, so a
-#     serial run and a merged run necessarily spell the path differently. What
-#     has to hold is asserted directly below: the merged grade points at a real
-#     trail that matches the digest it publishes for it.
+#   cost_ledger -- a pointer to the audit file this grade was read from, and a
+#     serial run and a merged run necessarily spell it differently. What has to
+#     hold is asserted directly below: the merged grade points, from the
+#     repository root, at a real trail that matches the digest it publishes.
 _EXPECTED_DIVERGENCE = {
     "shard_provenance",
     "grading_wall_time_ms",
@@ -139,7 +139,15 @@ def test_sharded_run_merges_into_a_serial_identical_payload(
     serial, _ = _run_grade(monkeypatch, tmp_path / "serial" / "batch-runner")
     assert serial["run_status"] == "final"
 
-    merged_path = tmp_path / "merged.json"
+    merge_root = tmp_path / "merge" / "batch-runner"
+    merge_root.mkdir(parents=True)
+    _setup_workspace(merge_root)
+    merged_path = merge_root / "data" / "grades" / "merged.json"
+    # The merge job has a checkout of its own: it downloads every shard
+    # artifact into it and writes the merged grade under ``data/grades``. Where
+    # it runs is part of the contract now, because the ledger pointer is a path
+    # from the repository root and a root is what it needs to be relative to.
+    monkeypatch.chdir(merge_root)
     assert s9.main([*shard_files, "--output", str(merged_path)]) == 0
     merged = json.loads(merged_path.read_text(encoding="utf-8"))
 
@@ -148,10 +156,15 @@ def test_sharded_run_merges_into_a_serial_identical_payload(
     assert _strip(merged) == _strip(serial)
 
     # Stripped from the diff above, so pin it here instead: the merged grade
-    # must name an audit trail that actually sits beside it and still matches
-    # the digest it published. A pointer to a file nobody can check is the same
-    # as no pointer, and worse, because it reads like one.
-    trail = merged_path.with_name(merged["cost_ledger"]["path"])
+    # must name an audit trail that resolves from the repository root and still
+    # matches the digest it published. A pointer to a file nobody can find is
+    # the same as no pointer, and worse, because it reads like one -- which is
+    # what the field held until this was fixed, a bare filename that resolved
+    # from nowhere on all thirty-eight grade files carrying it.
+    assert merged["cost_ledger"]["path"] == (
+        "batch-runner/data/grades/merged.cost_ledger.jsonl"
+    )
+    trail = tmp_path / "merge" / merged["cost_ledger"]["path"]
     assert trail.is_file()
     assert verify_export(trail, merged["cost_ledger"]["sha256"])
 

--- a/scripts/__tests__/aggregate-grades-fail-closed.test.mjs
+++ b/scripts/__tests__/aggregate-grades-fail-closed.test.mjs
@@ -436,3 +436,115 @@ test('the real script still exits 0 and publishes when every file is readable', 
     await rm(root, { recursive: true, force: true });
   }
 });
+
+// ── 6. a pointer that names no file is not an audit trail ────────────────
+
+// `cost_ledger.path` is where a grade says its per-call bill lives, and the
+// schema, `core/cost_projection.py` and `projectCostLedgerReference` all define
+// it as a path from the repository root. Both grading writers put `Path.name`
+// in it instead — a bare filename — so all thirty-eight grade files carrying
+// the field named a file that resolved from nowhere. Twenty-nine of them sat
+// beside their own grade, several directories down; the dashboard record built
+// from the payload drops the directory, so the reader that most needed the
+// location was the one that could not reconstruct it.
+//
+// The writers are fixed, so this guard is about the corpus not rotting back.
+// It is free today in the strictest sense: none of the nineteen top-level
+// grade files the aggregator reads carries the field at all.
+
+// A real 1.4 payload rather than a fixture, because what is being checked is
+// the shape the writers actually emit.
+const REAL_DIAGNOSTIC_GRADE = join(
+  SCRIPTS_DIR, '..', 'data', 'grades', '_diagnostic',
+  '8e8569d557634ee40e29c456fdaa057cdedc7084fac61444a5a02c3152d1b809',
+  'exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max'
+  + '__cfg_7392238d5f21a1f8'
+  + '__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf'
+  + '__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf'
+  + '__src_e23d7898c04f6b63__v2.2.json',
+);
+
+async function realGradeWithLedger() {
+  const raw = JSON.parse(await readFile(REAL_DIAGNOSTIC_GRADE, 'utf-8'));
+  assert.equal(raw.schema_version, '1.4');
+  assert.ok(raw.cost_ledger?.path, 'the sample grade lost its ledger pointer');
+  // As written on disk: a bare filename, which is the defect itself.
+  assert.ok(!raw.cost_ledger.path.includes('/'));
+  return raw;
+}
+
+test('collectGrades refuses a grade whose ledger pointer names no file here', async () => {
+  const raw = await realGradeWithLedger();
+
+  const { results, failures, excluded } = collectGrades([
+    entry('bare-name.json', raw),
+  ]);
+
+  assert.equal(results.length, 0);
+  assert.equal(excluded.length, 0, 'a broken pointer is a failure, not a choice');
+  assert.deepEqual(failures.map((f) => f.file), ['bare-name.json']);
+  assert.match(failures[0].message, /not a file in this repository/);
+  assert.match(failures[0].message, /not a bare filename/);
+});
+
+test('collectGrades accepts the same grade once the pointer is a path', async () => {
+  const raw = await realGradeWithLedger();
+  const bare = raw.cost_ledger.path;
+  raw.cost_ledger.path = [
+    'data/grades/_diagnostic',
+    '8e8569d557634ee40e29c456fdaa057cdedc7084fac61444a5a02c3152d1b809',
+    bare,
+  ].join('/');
+
+  const { failures, excluded } = collectGrades([entry('as-a-path.json', raw)]);
+
+  assert.equal(failures.length, 0, JSON.stringify(failures));
+  // Still not published — it is a diagnostic run — but excluded by the
+  // decision the grader recorded, which is the distinction section 4 draws.
+  assert.deepEqual(excluded.map((e) => e.status), ['grading_diagnostic']);
+});
+
+test('the real script exits non-zero on a pointer that resolves nowhere', async () => {
+  const raw = await realGradeWithLedger();
+  raw.run_status = 'final';
+  raw.experiment_id = 'exp-dangling-ledger';
+
+  const root = await scratchTree({ 'dangling.json': raw });
+  try {
+    const { code, stderr } = await runAggregate(root);
+    assert.equal(code, 1, 'a dangling audit pointer must fail the build');
+    assert.match(stderr, /dangling\.json/);
+    assert.match(stderr, /not a file in this repository/);
+    assert.equal(
+      existsSync(join(root, 'public', 'generated', 'grades-index.json')),
+      false,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('the real script publishes when the pointer names a file that is there', async () => {
+  const raw = await realGradeWithLedger();
+  raw.run_status = 'final';
+  raw.experiment_id = 'exp-real-ledger';
+  raw.cost_ledger.path = 'data/grades/sidecar.cost_ledger.jsonl';
+
+  const root = await scratchTree({ 'good.json': raw });
+  try {
+    // The sidecar the pointer names, put where the pointer says it is. This is
+    // the arrangement the workflow's `git add` of the export produces.
+    await writeFile(
+      join(root, 'data', 'grades', 'sidecar.cost_ledger.jsonl'), '', 'utf-8',
+    );
+    const { code, stdout, stderr } = await runAggregate(root);
+    assert.equal(code, 0, stderr);
+    const index = JSON.parse(
+      await readFile(join(root, 'public', 'generated', 'grades-index.json'), 'utf-8'),
+    );
+    assert.deepEqual(index.map((r) => r.experiment_id), ['exp-real-ledger']);
+    assert.match(stdout, /Aggregated 1 grade file\(s\)/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/__tests__/aggregate-grades-headline-support.test.mjs
+++ b/scripts/__tests__/aggregate-grades-headline-support.test.mjs
@@ -333,17 +333,16 @@ test('no 1.3 or 1.4 file on disk fails the check the aggregator now enforces', a
     try {
       record = processGradesFile(path, raw);
     } catch (err) {
-      // Seven of these files already fail an unrelated pre-existing check —
-      // their `cost_ledger.path` is a run-identity filename longer than the
-      // 128-character segment cap in cost-receipt.mjs — and they only reach
-      // a validator at all because this test walks the diagnostic and shard
-      // directories the aggregator itself never reads. That is a real latent
-      // trap for anyone publishing one by copying it up to data/grades, and
-      // it is not this change: what has to hold here is that the headline
-      // check adds nothing to the list.
+      // Nothing in the corpus reaches this today. Seven of these files used to,
+      // on an unrelated pre-existing check — their `cost_ledger.path` is a
+      // run-identity filename longer than the 128-character segment cap that
+      // used to be in cost-receipt.mjs, which is now the 255 of NAME_MAX — and
+      // they only reach a validator at all because this test walks the
+      // diagnostic and shard directories the aggregator itself never reads.
+      // The branch stays so that a file that starts failing names itself.
       assert.doesNotMatch(err.message, /is not the average of its/, path);
       assert.doesNotMatch(err.message, /scored task pct is missing or invalid/, path);
-      otherFailures.add(err.message);
+      otherFailures.add(`${path}: ${err.message}`);
       continue;
     }
     const got = record.summary.headline_support;
@@ -352,8 +351,8 @@ test('no 1.3 or 1.4 file on disk fails the check the aggregator now enforces', a
   assert.ok(checked >= 75, `expected the 1.3/1.4 corpus, checked ${checked}`);
   assert.deepEqual(
     [...otherFailures],
-    ['cost_ledger path must be a relative repository path'],
-    'a new kind of failure appeared in the 1.3/1.4 corpus',
+    [],
+    'a strict-tier grade stopped projecting',
   );
   // Two-decimal rounding and nothing else, which is why the tolerance can sit
   // five times above it and still be twenty-five times below the defect.

--- a/scripts/__tests__/cost-receipt.test.mjs
+++ b/scripts/__tests__/cost-receipt.test.mjs
@@ -926,8 +926,41 @@ test('unusable ledger pointers are rejected', () => {
     { path: '/etc/passwd', sha256: 'b'.repeat(64) },
     { path: 'cost_ledger.jsonl', sha256: 'short' },
     { sha256: 'b'.repeat(64) },
+    // A component longer than NAME_MAX cannot name a file that exists.
+    { path: `data/grades/${'a'.repeat(256)}.jsonl`, sha256: 'b'.repeat(64) },
+    // Nor can a path this deep be one of ours; the bound is 512.
+    { path: `${Array(200).fill('dir').join('/')}/l.jsonl`, sha256: 'b'.repeat(64) },
+    // A leading dot or dash stays out even though `_` was let in.
+    { path: 'data/grades/.hidden/l.jsonl', sha256: 'b'.repeat(64) },
+    { path: 'data/grades/-oh/l.jsonl', sha256: 'b'.repeat(64) },
   ]) {
     assert.throws(() => projectCostLedgerReference(value), /cost_ledger/);
+  }
+});
+
+// The field is a path from the repository root, and every real one runs through
+// `_shards`, `_repeats` or `_diagnostic`. The pattern used to require each
+// component to start with `[A-Za-z0-9]`, which never mattered while both
+// writers emitted a bare filename and rejects essentially every real path now
+// that they do not. The per-component bound moved with it: the old 128
+// excluded seven run-identity filenames that exist on disk, and 255 is NAME_MAX
+// rather than a preference. Kept in step with `core/cost_projection.py`, which
+// carries the same two constants and the same reasoning.
+test('the paths published grades actually carry are accepted', () => {
+  const suffix = '.cost_ledger.jsonl';
+  // 239 bytes all in: the longest single component under data/grades today.
+  const longest = 'a'.repeat(239 - suffix.length) + suffix;
+  for (const path of [
+    'data/grades/_shards/stem/shard-004-of-011.cost_ledger.jsonl',
+    'data/grades/_repeats/stem/r2.cost_ledger.jsonl',
+    'data/grades/_diagnostic/' + 'a'.repeat(64) + '/g.cost_ledger.jsonl',
+    `data/grades/${longest}`,
+  ]) {
+    assert.deepEqual(
+      projectCostLedgerReference({ path, sha256: 'b'.repeat(64) }),
+      { path, sha256: 'b'.repeat(64) },
+      path,
+    );
   }
 });
 

--- a/scripts/aggregate-grades.mjs
+++ b/scripts/aggregate-grades.mjs
@@ -11,6 +11,7 @@
  */
 
 import { readdir, readFile, writeFile, mkdir, access } from 'fs/promises';
+import { statSync } from 'fs';
 import { join, extname, basename } from 'path';
 import { gradeIdentityFromRaw } from './grade-identity.mjs';
 import { classifyTaskOutcome, summarizeOutcomes } from './selection-outcome.mjs';
@@ -798,6 +799,27 @@ export function isPublishableGrade(result) {
   );
 }
 
+// A published `cost_ledger.path` has to name a file this repository actually
+// holds. The field is defined as a relative repository path — in the grade
+// schema, in `core/cost_projection.py`, and in `projectCostLedgerReference`
+// above — and for a long while both grading writers put `Path.name` in it: a
+// bare filename. None of the thirty-eight grade files carrying the field
+// resolved from the repository root; the sidecars were sitting beside their
+// grades several directories down, and the record built here drops the
+// directory, so the one reader that could have reconstructed the location is
+// the one reader that cannot.
+//
+// Checked here rather than in `processGradesFile` because this is the layer
+// that knows the payload came off this disk. A pointer that resolves nowhere
+// is worse than no pointer: it reads as an audit trail that exists.
+function ledgerIsOnDisk(relativePath) {
+  try {
+    return statSync(join(ROOT, relativePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
 // Separates the two reasons a grade file can be absent from the index, because
 // only one of them is a decision:
 //
@@ -829,6 +851,16 @@ export function collectGrades(
       );
     } catch (err) {
       failures.push({ file, message: err?.message ?? String(err) });
+      continue;
+    }
+    const ledgerPath = processed?.cost_ledger?.path;
+    if (ledgerPath && !ledgerIsOnDisk(ledgerPath)) {
+      failures.push({
+        file,
+        message: `cost_ledger points at ${ledgerPath}, which is not a file in `
+          + 'this repository; the pointer must be a path from the repository '
+          + 'root, not a bare filename',
+      });
       continue;
     }
     if (!isPublishableGrade(processed)) {

--- a/scripts/cost-receipt.mjs
+++ b/scripts/cost-receipt.mjs
@@ -65,7 +65,32 @@ const RETRY_NONE = 'none';
 const SLUG = /^[a-z][a-z0-9_]{0,47}$/;
 const REASON_CODE = /^[a-z][a-z0-9_.:-]{0,63}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
-const LEDGER_PATH = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}(\/[A-Za-z0-9][A-Za-z0-9._-]{0,127})*$/;
+
+// How long one path component may be. Not a taste decision: 255 bytes is
+// `NAME_MAX` on every filesystem this runs on, so a longer component cannot
+// name a file that exists, and a bound below it would reject real names. The
+// names here are run identities — experiment, judge, config hash, rubric SHA,
+// inference SHA, grader source hash — and the longest under `data/grades`
+// today is 254 bytes. The 128 this used to be excluded seven of them.
+//
+// Kept in step with `_MAX_LEDGER_NAME` / `_MAX_LEDGER_PATH_LENGTH` in
+// `core/cost_projection.py`: the two validators read the same published files,
+// so a payload either side refuses is a payload neither may publish.
+const MAX_LEDGER_NAME = 255;
+
+// And how long the whole path may be, which the per-component bound does not
+// imply: nesting is what grows it. A published ledger sits under
+// `data/grades`, up to five directories down for a repeat of a shard of a
+// diagnostic run; the longest that exists today is 348 bytes.
+const MAX_LEDGER_PATH_LENGTH = 512;
+
+// The leading character is narrower than the rest so that `..` and a segment
+// that could be read as a command-line option are both out. It admits `_`
+// because the directories these paths run through are `_shards`, `_repeats`
+// and `_diagnostic` — which never came up while the field held a bare
+// filename, and is most of what it holds now.
+const LEDGER_SEGMENT = `[A-Za-z0-9_][A-Za-z0-9._-]{0,${MAX_LEDGER_NAME - 1}}`;
+const LEDGER_PATH = new RegExp(`^${LEDGER_SEGMENT}(/${LEDGER_SEGMENT})*$`);
 
 const MAX_COMPONENTS = 32;
 const MAX_USAGE_KEYS = 32;
@@ -388,7 +413,8 @@ export function projectCostLedgerReference(value, field = 'cost_ledger') {
   if (value === null || value === undefined) return null;
   if (!isPlainObject(value)) fail(field, 'must be an object');
   const { path, sha256 } = value;
-  if (typeof path !== 'string' || !LEDGER_PATH.test(path)) {
+  if (typeof path !== 'string' || !LEDGER_PATH.test(path)
+      || path.length > MAX_LEDGER_PATH_LENGTH) {
     fail(field, 'path must be a relative repository path');
   }
   if (path.split('/').includes('..')) fail(field, 'path must not traverse parents');


### PR DESCRIPTION
## The defect

`cost_ledger.path` is where a published grade says its per-call bill lives. Three places define it as a **relative repository path** — the grade schema, `core.cost_projection.project_cost_ledger_reference`, and its JavaScript mirror in `scripts/cost-receipt.mjs` — and for the field's whole life both grading writers put `Path.name` in it: a bare filename.

That is not a shorter way of saying the same thing. Measured against the corpus on disk:

| grade files carrying `cost_ledger` | resolve from the repo root | resolve only as a sibling of their own grade file | resolve from nowhere |
|---:|---:|---:|---:|
| 38 | **0** | 29 | 9 |

The 29 only help a reader who already knows where the grade file is — and the dashboard record built from the payload drops exactly that. So the field read as an audit trail that exists while pointing at nothing, and the one reader that could have reconstructed the location is the one reader that cannot.

## The fix

Both writers publish the path from the repository root, and return `None` when the ledger is outside the repository. A name is not a smaller version of a path; a result that cannot point at its own audit trail should say so — the same answer a failed export already gives.

Three things had to move first:

- **The segment pattern rejected the real paths.** It required every component to start with `[A-Za-z0-9]`, and real ledger paths run through `_shards`, `_repeats` and `_diagnostic`. Widened to admit `_`, still refusing a leading `.` (so `..` and hidden files stay out) and a leading `-` (so a segment cannot read as a command-line option).
- **The 128-character per-segment cap already excluded seven real filenames.** It is now `NAME_MAX` = 255, with a separate 512 whole-path bound, because nesting and not naming is what grows a path. Both measured, not chosen: the corpus's longest path is 348 bytes, its longest component 239.
- **Shards are graded on separate runners, so no single root resolves them all.** The merge tries its own root first, then each directory above the shard file nearest-first — a walk that also resolves the legacy bare filenames, since a shard's own directory is the first ancestor tried. Safe only because every candidate is still re-gated by `verify_export` against the digest the shard itself published.

## The guard

`scripts/aggregate-grades.mjs` refuses to publish a grade whose pointer names no file here. Placed in `collectGrades` (the layer that knows the payload came off this disk) rather than in the pure projection, and **before** `isPublishableGrade` so a broken pointer is a failure rather than a silent exclusion.

It is free today: the aggregator's `readdir` is not recursive and **0 of the 19** top-level grade files carries the field. The guard is installed before it has anything to catch rather than after an incident.

## A separate defect, pinned rather than fixed

step8 derives its sidecar as `out_path.stem + ".cost_ledger.sqlite3"` — 20 characters. `NAME_MAX` is 255, so any grade filename over **240 bytes** has a sidecar that cannot be created (`ENAMETOOLONG`, verified on this filesystem rather than assumed). **Five** files on disk are already past it — 269, 269, 265, 257, 256 — and all five carry no ledger pointer.

Whether the cliff *causes* the missing pointers is **not established here and is not claimed**. Renaming those files has its own blast radius. What the test buys is that the count is a number somebody chose to accept rather than one nobody ever looked at.

## Deliberately out of scope

The inference side is untouched: `step2_run_inference.py` writes a basename and `step3_format_results.py` / `step6_report.py` read it as `WORKSPACE_DIR / path`. That pair is consistent and correct. Only the grading side promised a repository path and delivered a filename.

## Verification

| check | result |
|---|---|
| backend `pytest -q` | **7131 passed, 7 skipped** (7116 before; +15 new) |
| `mypy core/ --ignore-missing-imports` | 174 errors in 32 files — the exact known baseline |
| `npm run test:aggregate` | **254 passed, 0 failed**, 1 skipped |
| `npm run build` | green; the new aggregator guard passed on the real corpus |
| negative controls | 5 Python + 2 JavaScript, each failing exactly the intended test when the fix is reverted |

## Grader fingerprint

This edits `step8_grade.py`, `core/cost_projection.py`, `step9_merge_shards.py` and `schemas/grade.schema.json`, so **the grader source hash moves**. Verified before opening: no Grade Pipeline run is in flight.