### PR TITLE
fix(cost): check a report's cost payload before publishing it as money

### DIFF
--- a/batch-runner/tests/test_measuring_nothing_is_not_doing_nothing.py
+++ b/batch-runner/tests/test_measuring_nothing_is_not_doing_nothing.py
@@ -39,7 +39,7 @@ arithmetic under test is the producer's.
 
 import itertools
 import json
-import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -449,27 +449,36 @@ def test_no_payload_on_disk_carries_a_summary_this_function_wrote():
     ``core.cost_receipts.summarise_receipts``, which has always applied the
     rule this change ports. The receipts above are therefore real evidence of
     the shape, and the blast radius on committed files is still zero.
+
+    Committed means tracked, not present. This walked the directory tree, which
+    also reaches build output: ``public/generated/reports-index.json`` carries
+    three run summaries fetched from HuggingFace, and ``dist/`` carries a copy
+    of the same file. Both are ignored, neither is in a clone, and running
+    ``npm run build`` before ``pytest`` was enough to fail this on a claim about
+    what a clone contains. ``git ls-files`` is the set the sentence is about.
     """
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z", "--", "*.json"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    ).stdout.split("\0")
+
     found = []
-    for directory, subdirs, files in os.walk(REPO_ROOT):
-        subdirs[:] = [name for name in subdirs
-                      if name not in {".git", "node_modules", "__pycache__"}]
-        for name in files:
-            if not name.endswith(".json"):
-                continue
-            path = Path(directory) / name
-            try:
-                doc = json.loads(path.read_text("utf-8"))
-            except (ValueError, UnicodeDecodeError, OSError):
-                continue
-            stack = [doc]
-            while stack:
-                node = stack.pop()
-                if isinstance(node, dict):
-                    if "receipt_tasks" in node and "coverage_pct" in node:
-                        found.append(path)
-                        break
-                    stack.extend(node.values())
-                elif isinstance(node, list):
-                    stack.extend(node)
-    assert not found, f"a committed payload now carries a run-level summary: {found}"
+    for name in tracked:
+        if not name:
+            continue
+        path = REPO_ROOT / name
+        try:
+            doc = json.loads(path.read_text("utf-8"))
+        except (ValueError, UnicodeDecodeError, OSError):
+            continue
+        stack = [doc]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, dict):
+                if "receipt_tasks" in node and "coverage_pct" in node:
+                    found.append(path)
+                    break
+                stack.extend(node.values())
+            elif isinstance(node, list):
+                stack.extend(node)
+    assert found == [], f"a committed payload now carries a run-level summary: {found}"

--- a/scripts/__tests__/aggregate-reports-fail-closed.test.mjs
+++ b/scripts/__tests__/aggregate-reports-fail-closed.test.mjs
@@ -284,10 +284,13 @@ test('backoff grows when the hub advises nothing', async () => {
 async function scratchTree(dirs) {
   const root = await mkdtemp(join(tmpdir(), 'report-aggregate-'));
   await mkdir(join(root, 'scripts'), { recursive: true });
-  await copyFile(
-    join(SCRIPTS_DIR, 'aggregate-reports.mjs'),
-    join(root, 'scripts', 'aggregate-reports.mjs'),
-  );
+  // The aggregator and everything it imports. `cost-receipt.mjs` is a sibling
+  // import, so leaving it behind makes the copied script die on module
+  // resolution — which every test here would then read as the fail-closed
+  // behaviour it was checking for.
+  for (const name of ['aggregate-reports.mjs', 'cost-receipt.mjs']) {
+    await copyFile(join(SCRIPTS_DIR, name), join(root, 'scripts', name));
+  }
   for (const [dirName, content] of Object.entries(dirs)) {
     const reportDir = join(root, 'batch-runner', 'results', dirName, 'report');
     await mkdir(reportDir, { recursive: true });
@@ -411,6 +414,166 @@ test('a report carrying no task_results still publishes', async () => {
     assert.equal(code, 0, stdout);
     const index = JSON.parse(await readFile(join(root, ...INDEX_PATH), 'utf-8'));
     assert.deepEqual(index.reports[0].task_qa, {});
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// ── 4. the money in a report is checked before it is published ────────────
+//
+// Reports carry `cost_summary`, and the whole object was spread into the index
+// verbatim. Twenty-six of the twenty-six reports on a real build arrive over
+// the unauthenticated HuggingFace fetch above — no results directory holds a
+// local `report_data.json` — so between that wire and the dollar figure on the
+// experiment page there was no check of any kind. The grade path, which is the
+// same shape of payload reaching the same card, has been projected since it was
+// written.
+//
+// Both failures below were reproduced against the real dashboard code before
+// these tests were written.
+
+function costSummary(overrides = {}) {
+  return {
+    schema_version: 'cost-receipt-v1',
+    currency: 'USD',
+    estimate_basis: 'usage_estimate_not_azure_invoice',
+    status: 'complete',
+    total_tasks: 2,
+    receipt_tasks: 2,
+    measured_tasks: 2,
+    coverage_pct: 100,
+    complete_tasks: 2,
+    partial_tasks: 0,
+    unavailable_tasks: 0,
+    not_run_tasks: 0,
+    known_cost_usd: 0.5,
+    estimated_cost_usd: 0.5,
+    avg_cost_usd: 0.25,
+    median_cost_usd: 0.25,
+    p95_cost_usd: 0.25,
+    max_cost_usd: 0.25,
+    successful_deliverables: 2,
+    cost_per_successful_deliverable_usd: 0.25,
+    failed_task_count: 0,
+    failed_task_cost_usd: 0,
+    components: [],
+    price_table_sha256: null,
+    missing_reasons: [],
+    ...overrides,
+  };
+}
+
+const withCost = (cost) => reportFixture({ cost_summary: { problem_solving_cost: cost } });
+
+test('a well-formed cost summary reaches the index unchanged', async () => {
+  const root = await scratchTree({ exp901_good: withCost(costSummary()) });
+  try {
+    const { code, stdout } = await runAggregate(root);
+    assert.equal(code, 0, stdout);
+    const index = JSON.parse(await readFile(join(root, ...INDEX_PATH), 'utf-8'));
+    const published = index.reports[0].cost_summary.problem_solving_cost;
+    assert.equal(published.status, 'complete');
+    assert.equal(published.estimated_cost_usd, 0.5);
+    assert.equal(published.known_cost_usd, 0.5);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// Reproduced failure 1. `summaryTotalCell` gates on `estimated_cost_usd !==
+// null`, not on the status beside it, so this renders `$0.5000` as a settled
+// total while the corner of the same card reads 일부 기록됨. The figure is the
+// part people read.
+test('a partial run that names a total fails the build', async () => {
+  const root = await scratchTree({
+    exp901_lying: withCost(costSummary({ status: 'partial', complete_tasks: 1, partial_tasks: 1 })),
+  });
+  try {
+    const { code, stderr } = await runAggregate(root);
+    assert.notEqual(code, 0);
+    assert.match(stderr, /exp901_lying/);
+    assert.match(stderr, /is partial but carries a total/);
+    assert.equal(existsSync(join(root, ...INDEX_PATH)), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// Reproduced failure 2. The same gate is `!==`, so an absent field passes it:
+// `undefined !== null` is true, `formatCostUsd(undefined)` reaches
+// `undefined.toFixed`, and the experiment page goes down with a TypeError.
+test('a complete run with no total at all fails the build', async () => {
+  const missing = costSummary();
+  delete missing.estimated_cost_usd;
+  const root = await scratchTree({ exp901_silent: withCost(missing) });
+  try {
+    const { code, stderr } = await runAggregate(root);
+    assert.notEqual(code, 0);
+    assert.match(stderr, /exp901_silent/);
+    assert.match(stderr, /is complete without a total/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// The build names the directory rather than dying anonymously: with twenty-six
+// reports in flight, a stack trace with no experiment in it is a bisect.
+test('a bad cost payload is reported the way an unreadable report is', async () => {
+  const root = await scratchTree({
+    exp901_good: reportFixture(),
+    exp902_bad: withCost(costSummary({ receipt_tasks: 5 })),
+  });
+  try {
+    const { code, stderr } = await runAggregate(root);
+    assert.notEqual(code, 0);
+    assert.match(stderr, /1 of 2 report\(s\) could not be loaded/);
+    assert.match(stderr, /exp902_bad/);
+    assert.doesNotMatch(stderr, /exp901_good/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('a cost ledger pointer that is not a repository path fails the build', async () => {
+  const root = await scratchTree({
+    exp901_ledger: reportFixture({ cost_ledger: { path: '../escape.jsonl', sha256: 'a'.repeat(64) } }),
+  });
+  try {
+    const { code, stderr } = await runAggregate(root);
+    assert.notEqual(code, 0);
+    assert.match(stderr, /exp901_ledger/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// NEGATIVE CONTROL. Twenty-three of the twenty-six real reports predate cost
+// receipts entirely. Absent must stay absent: an empty object here would make
+// the dashboard draw a card claiming a record that does not exist.
+test('a report from before receipts existed still publishes, with no cost key', async () => {
+  const root = await scratchTree({ exp901_old: reportFixture() });
+  try {
+    const { code, stdout } = await runAggregate(root);
+    assert.equal(code, 0, stdout);
+    const index = JSON.parse(await readFile(join(root, ...INDEX_PATH), 'utf-8'));
+    assert.equal('cost_summary' in index.reports[0], false);
+    assert.equal('cost_ledger' in index.reports[0], false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// NEGATIVE CONTROL. A wrapper whose only field is null is a wrapper with
+// nothing in it, and must read as no record rather than as an empty card.
+test('a cost wrapper holding only nulls publishes as no record', async () => {
+  const root = await scratchTree({
+    exp901_null: reportFixture({ cost_summary: { problem_solving_cost: null } }),
+  });
+  try {
+    const { code, stdout } = await runAggregate(root);
+    assert.equal(code, 0, stdout);
+    const index = JSON.parse(await readFile(join(root, ...INDEX_PATH), 'utf-8'));
+    assert.equal('cost_summary' in index.reports[0], false);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/scripts/__tests__/cost-receipt.test.mjs
+++ b/scripts/__tests__/cost-receipt.test.mjs
@@ -15,6 +15,8 @@ import {
   ESTIMATE_BASIS,
   projectCostLedgerReference,
   projectCostReceipt,
+  projectCostSummaries,
+  projectCostSummary,
   summarizeCostReceipts,
 } from '../cost-receipt.mjs';
 
@@ -994,4 +996,279 @@ test('every reason the schema allows has a Korean label', async () => {
   const labelled = [...block[1].matchAll(/^\s{2}(\w+):/gm)].map((m) => m[1]);
 
   assert.deepEqual([...labelled].sort(), [...allowed].sort());
+});
+
+// ── A summary this build did not compute ──────────────────────────────────
+//
+// `summarizeCostReceipts` above is sound because it did the arithmetic. The
+// other producer of the same shape is `build_cost_summaries` in
+// batch-runner/core/cost_projection.py, and what it writes travels inside
+// `report_data.json` — fetched unauthenticated from HuggingFace for all 26
+// experiments, since no results directory carries a local copy. Until this
+// projector existed the aggregator spread that object into the published index
+// verbatim and the dashboard rendered it as money.
+
+function summaryFixture(overrides = {}) {
+  return {
+    schema_version: COST_RECEIPT_SCHEMA_VERSION,
+    currency: 'USD',
+    estimate_basis: ESTIMATE_BASIS,
+    status: 'complete',
+    total_tasks: 4,
+    receipt_tasks: 4,
+    measured_tasks: 4,
+    coverage_pct: 100,
+    complete_tasks: 4,
+    partial_tasks: 0,
+    unavailable_tasks: 0,
+    not_run_tasks: 0,
+    known_cost_usd: 1.2,
+    estimated_cost_usd: 1.2,
+    avg_cost_usd: 0.3,
+    median_cost_usd: 0.3,
+    p95_cost_usd: 0.3,
+    max_cost_usd: 0.3,
+    successful_deliverables: 4,
+    cost_per_successful_deliverable_usd: 0.3,
+    failed_task_count: 0,
+    failed_task_cost_usd: 0,
+    components: [],
+    price_table_sha256: null,
+    missing_reasons: [],
+    ...overrides,
+  };
+}
+
+const refuses = (overrides, pattern) => assert.throws(
+  () => projectCostSummary(summaryFixture(overrides)),
+  pattern,
+);
+
+test('a well-formed summary passes through with its figures intact', () => {
+  const projected = projectCostSummary(summaryFixture());
+  assert.equal(projected.status, 'complete');
+  assert.equal(projected.estimated_cost_usd, 1.2);
+  assert.equal(projected.known_cost_usd, 1.2);
+  assert.equal(projected.receipt_tasks, 4);
+  assert.equal(projected.estimate_basis, ESTIMATE_BASIS);
+});
+
+test('no summary at all stays no summary', () => {
+  assert.equal(projectCostSummary(null), null);
+  assert.equal(projectCostSummary(undefined), null);
+  assert.equal(projectCostSummaries(null), null);
+  assert.equal(projectCostSummaries({ problem_solving_cost: null }), null);
+});
+
+// ── the biconditional, in both directions ─────────────────────────────────
+//
+// `estimated_cost_usd = known_total if complete_run else None` in the Python,
+// `completeRun ? knownTotal : null` in the mirror above, and `complete_run` is
+// exactly `status === 'complete'`. Each direction is a different lie, so each
+// is refused separately.
+
+test('a run that is not complete may not name a total', () => {
+  // What the dashboard does with this is the reason: `summaryTotalCell` gates
+  // on `estimated_cost_usd !== null`, never on the status printed beside it,
+  // so $0.5000 renders as settled under a card corner reading 일부 기록됨.
+  refuses(
+    { status: 'partial', complete_tasks: 3, partial_tasks: 1 },
+    /is partial but carries a total/,
+  );
+  refuses(
+    { status: 'unavailable', complete_tasks: 0, unavailable_tasks: 4, known_cost_usd: 0 },
+    /is unavailable but carries a total/,
+  );
+});
+
+test('a complete run must name the total it is complete about', () => {
+  // `undefined !== null` is true, so an absent field passes the dashboard's
+  // gate and `formatCostUsd(undefined)` reaches `undefined.toFixed`. The
+  // experiment page goes down with a TypeError; nothing renders at all.
+  const missing = summaryFixture();
+  delete missing.estimated_cost_usd;
+  assert.throws(() => projectCostSummary(missing), /is complete without a total/);
+  refuses({ estimated_cost_usd: null }, /is complete without a total/);
+});
+
+test('a complete run may not estimate something other than what it knows', () => {
+  refuses({ estimated_cost_usd: 9.9 }, /its total is not what it knows/);
+});
+
+test('a summary with no known total at all is refused', () => {
+  const missing = summaryFixture();
+  delete missing.known_cost_usd;
+  assert.throws(() => projectCostSummary(missing), /known_cost_usd is required/);
+});
+
+// ── the counts have to be the same counts ─────────────────────────────────
+
+test('the status buckets must add up to the receipts they sort', () => {
+  // Each receipt lands in exactly one bucket, so the buckets are the receipts
+  // counted a second way. Disagreement is the only evidence that something
+  // rewrote one side without the other.
+  refuses({ complete_tasks: 3 }, /buckets that do not add up/);
+  refuses({ not_run_tasks: 1 }, /buckets that do not add up/);
+});
+
+test('a bucket that is absent is not read as a zero', () => {
+  const missing = summaryFixture();
+  delete missing.partial_tasks;
+  assert.throws(() => projectCostSummary(missing), /partial_tasks is required/);
+});
+
+test('a run cannot hold more receipts than it has tasks', () => {
+  refuses({ total_tasks: 2 }, /more receipts than it has tasks/);
+});
+
+test('a run cannot price more tasks than it holds receipts for', () => {
+  refuses({ measured_tasks: 5, total_tasks: 6 }, /prices more tasks than it holds/);
+});
+
+test('coverage has to be a percentage', () => {
+  refuses({ coverage_pct: 101 }, /coverage_pct must be a percentage/);
+  refuses({ coverage_pct: -1 }, /coverage_pct must be a percentage/);
+  refuses({ coverage_pct: null }, /coverage_pct must be a percentage/);
+  refuses({ coverage_pct: '100' }, /coverage_pct must be a percentage/);
+});
+
+test('failures cannot outnumber the tasks that could have failed', () => {
+  refuses({ failed_task_count: 5 }, /more failures than it has tasks/);
+});
+
+test('priced failures cannot outnumber the failures', () => {
+  refuses(
+    { failed_task_count: 1, failed_measured_tasks: 2 },
+    /prices more failures than it counted/,
+  );
+});
+
+// `failed_measured_tasks` is optional in src/types/cost.ts because reports
+// published before the count existed do not carry it — including all three of
+// the real ones. Absent must stay absent: a zero invented here would tell
+// `failedTaskCostCell` that the failures were priced and cost nothing.
+test('a summary from before the priced-failure count existed keeps its silence', () => {
+  const older = summaryFixture();
+  delete older.failed_measured_tasks;
+  const projected = projectCostSummary(older);
+  assert.equal('failed_measured_tasks' in projected, false);
+
+  const newer = projectCostSummary(summaryFixture({ failed_task_count: 2, failed_measured_tasks: 1 }));
+  assert.equal(newer.failed_measured_tasks, 1);
+});
+
+// ── the header both sides agree on ────────────────────────────────────────
+
+test('a summary from another schema or another currency is refused', () => {
+  refuses({ schema_version: 'cost-receipt-v2' }, /schema_version cost-receipt-v1/);
+  refuses({ currency: 'KRW' }, /denominated in USD/);
+  refuses({ status: 'done' }, /status must be one of/);
+  assert.throws(() => projectCostSummary('1.20'), /must be an object/);
+  assert.throws(() => projectCostSummary([summaryFixture()]), /must be an object/);
+});
+
+test('a component list is held to the same rules a receipt holds it to', () => {
+  const line = {
+    name: 'grading', stage: 'grading', retry_kind: 'none', status: 'complete',
+    known_cost_usd: 0.6, model_calls: 1, usage: {}, missing_reasons: [],
+  };
+  assert.equal(projectCostSummary(summaryFixture({ components: [line] })).components.length, 1);
+  refuses({ components: [line, { ...line }] }, /duplicate component keys/);
+  refuses({ components: {} }, /components must be a list/);
+});
+
+test('an unknown cost field is named rather than dropped', () => {
+  // The two ways a cost stops being shown — never recorded, and recorded under
+  // a name the dashboard does not read — look identical on screen.
+  assert.throws(
+    () => projectCostSummaries({ grading_cost: summaryFixture(), perception_cost: summaryFixture() }),
+    /unknown cost field: perception_cost/,
+  );
+});
+
+test('a wrapper keeps each field under its own name', () => {
+  const both = projectCostSummaries({
+    problem_solving_cost: summaryFixture(),
+    grading_cost: summaryFixture({ known_cost_usd: 0.4, estimated_cost_usd: 0.4 }),
+  });
+  assert.equal(both.problem_solving_cost.known_cost_usd, 1.2);
+  assert.equal(both.grading_cost.known_cost_usd, 0.4);
+});
+
+// ── acceptance: the rules must not be stricter than the producers ─────────
+
+/**
+ * Everything `summarizeCostReceipts` builds has to survive the projector.
+ *
+ * These are two independent implementations of one contract — one computes a
+ * summary, the other decides whether to believe one — and the interesting
+ * failure is not a bad payload getting through but a good one being refused. A
+ * rule that is one degree too strict fails the Pages build on real data, and it
+ * fails it for every experiment at once.
+ */
+test('every summary the summariser produces is one the projector accepts', () => {
+  const line = (status, cost) => ({
+    receipt: {
+      status,
+      known_cost_usd: cost,
+      model_calls: 1,
+      usage: { input_tokens: 100 },
+      missing_reasons: status === 'complete' ? [] : ['usage_absent'],
+      components: [{
+        name: 'generation', stage: 'generation', retry_kind: 'none',
+        status: status === 'complete' ? 'complete' : 'partial',
+        known_cost_usd: cost, model_calls: 1, usage: {}, missing_reasons: [],
+      }],
+    },
+    succeeded: true,
+  });
+
+  const corpus = {
+    'a complete run': [line('complete', 0.5), line('complete', 0.25)],
+    'one unknown row': [line('complete', 0.5), line('partial', 0.25)],
+    'nothing recorded': [line('unavailable', 0), line('unavailable', 0)],
+    'nothing asked for': [line('not_run', 0), line('not_run', 0)],
+    'a mixture': [line('complete', 0.5), line('partial', 0.25), line('unavailable', 0), line('not_run', 0)],
+    'a row with no receipt': [line('complete', 0.5), { receipt: null, succeeded: true }],
+    'a failure that cost money': [line('complete', 0.5), { ...line('complete', 0.25), succeeded: false }],
+  };
+
+  for (const [name, rows] of Object.entries(corpus)) {
+    const summary = summarizeCostReceipts(rows);
+    assert.ok(summary, `${name} should produce a summary`);
+    const projected = projectCostSummary(JSON.parse(JSON.stringify(summary)), name);
+    assert.equal(projected.status, summary.status, name);
+    assert.equal(projected.estimated_cost_usd, summary.estimated_cost_usd, name);
+    assert.equal(projected.known_cost_usd, summary.known_cost_usd, name);
+    assert.equal(projected.receipt_tasks, summary.receipt_tasks, name);
+  }
+});
+
+/**
+ * And so does every summary sitting in the published index right now.
+ *
+ * Three of the twenty-six reports carry one. They came off HuggingFace, not out
+ * of this repository, which is the entire reason the projector exists — so they
+ * are the one corpus worth reading from disk rather than constructing.
+ */
+test('every cost summary in the published index is accepted', async () => {
+  const { readFile } = await import('node:fs/promises');
+  const index = JSON.parse(
+    await readFile(new URL('../../public/generated/reports-index.json', import.meta.url), 'utf8'),
+  );
+  let seen = 0;
+  for (const report of index.reports ?? []) {
+    if (!report.cost_summary && !report.cost_ledger) continue;
+    seen += 1;
+    const summaries = projectCostSummaries(report.cost_summary, report.short_id ?? 'report');
+    projectCostLedgerReference(report.cost_ledger, report.short_id ?? 'report');
+    for (const summary of Object.values(summaries ?? {})) {
+      assert.equal(
+        summary.estimated_cost_usd !== null,
+        summary.status === 'complete',
+        'the published index should already obey the biconditional',
+      );
+    }
+  }
+  assert.ok(seen >= 3, `expected at least the 3 known cost-carrying reports, saw ${seen}`);
 });

--- a/scripts/aggregate-reports.mjs
+++ b/scripts/aggregate-reports.mjs
@@ -8,6 +8,11 @@ import { readdir, readFile, writeFile, mkdir } from 'fs/promises';
 import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
+import {
+  projectCostLedgerReference,
+  projectCostSummaries,
+} from './cost-receipt.mjs';
+
 const ROOT = new URL('..', import.meta.url).pathname;
 const RESULTS_DIR = join(ROOT, 'batch-runner', 'results');
 const OUTPUT_DIR = join(ROOT, 'public', 'generated');
@@ -136,6 +141,33 @@ export function findShortIdCollisions(dirNames) {
   return [...byShortId.entries()].filter(([, dirs]) => dirs.length > 1);
 }
 
+// The money a report claims to have spent, checked before it is published.
+//
+// Every field in a report is spread into the index verbatim, which is the right
+// default for text a human wrote and the wrong one for a figure a dashboard
+// renders as a dollar amount. Twenty-six of the twenty-six reports on this
+// build arrive over the unauthenticated HuggingFace fetch above — no results
+// directory carries a local `report_data.json` — so nothing between that wire
+// and `summaryTotalCell` in src/lib/cost.ts had ever looked at these numbers.
+// The grade path, which is the same shape of payload from the same kind of
+// source, has run every receipt through the projector since it was written.
+//
+// Absent stays absent rather than becoming an empty object: `cost_summary`
+// missing is how a report from before receipts existed says it has no record,
+// and `{}` would say the record exists and is empty. Destructured out of
+// `rest` for that reason — a spread of the original would put the raw field
+// back after the projection removed it.
+export function withProjectedCost(report) {
+  const { cost_summary: rawSummaries, cost_ledger: rawLedger, ...rest } = report;
+  const summaries = projectCostSummaries(rawSummaries);
+  const ledger = projectCostLedgerReference(rawLedger);
+  return {
+    ...rest,
+    ...(summaries ? { cost_summary: summaries } : {}),
+    ...(ledger ? { cost_ledger: ledger } : {}),
+  };
+}
+
 // Load all reports
 async function loadAllReports(deps = {}) {
   const subdirs = await readdir(RESULTS_DIR, { withFileTypes: true });
@@ -180,6 +212,11 @@ async function loadAllReports(deps = {}) {
     let source;
     try {
       ({ data, source } = await fetchReportData(dirName, reportPath, deps));
+      // Inside the same try, so a payload that claims money it cannot support
+      // is reported the way an unreadable one is: the build stops and names
+      // the directory. Outside it, a throw here would take down the build
+      // without saying which of the twenty-six reports caused it.
+      data = withProjectedCost(data);
     } catch (err) {
       failures.push(`  ${dirName}: ${err.message}`);
       continue;

--- a/scripts/cost-receipt.mjs
+++ b/scripts/cost-receipt.mjs
@@ -304,6 +304,33 @@ function projectComponent(value, field) {
 }
 
 /**
+ * Normalise a payload's `components` list.
+ *
+ * A line is identified by the pair *and* by whose call it was. Generation that
+ * had to be redone and Self-QA that had to be redone both display as 재시도,
+ * and rejecting the second as a duplicate would throw away a real charge. So
+ * would rejecting the second of two models read under one perception stage —
+ * which is why identity is part of the key rather than decoration on it. Two
+ * lines that agree on all seven really are one line the producer failed to add
+ * up.
+ *
+ * Keyed by `summaryComponentKey`, the same function the run summariser folds
+ * its rows under, so a list this refuses and a list that summariser would
+ * silently merge cannot be different lists.
+ */
+function projectComponents(value, field) {
+  const raw = value ?? [];
+  if (!Array.isArray(raw)) fail(field, 'components must be a list');
+  if (raw.length > MAX_COMPONENTS) fail(field, 'carries too many components');
+  const components = raw.map(
+    (item, index) => projectComponent(item, `${field}.components[${index}]`),
+  );
+  const keys = components.map(summaryComponentKey);
+  if (keys.length !== new Set(keys).size) fail(field, 'carries duplicate component keys');
+  return components;
+}
+
+/**
  * Normalise one `cost-receipt-v1` receipt.
  *
  * null/undefined in, null out — an absent receipt is a legitimate state and
@@ -340,34 +367,7 @@ export function projectCostReceipt(value, field = 'cost receipt') {
   );
   const reasons = missingReasons(value.missing_reasons, `${field}.missing_reasons`);
 
-  const rawComponents = value.components ?? [];
-  if (!Array.isArray(rawComponents)) fail(field, 'components must be a list');
-  if (rawComponents.length > MAX_COMPONENTS) fail(field, 'carries too many components');
-  const components = rawComponents.map(
-    (item, index) => projectComponent(item, `${field}.components[${index}]`),
-  );
-  // A line is identified by the pair *and* by whose call it was. Generation
-  // that had to be redone and Self-QA that had to be redone both display as
-  // 재시도, and rejecting the second as a duplicate would throw away a real
-  // charge. So would rejecting the second of two models read under one
-  // perception stage — which is why identity is part of the key rather than
-  // decoration on it. Two lines that agree on all seven really are one line
-  // the producer failed to add up.
-  //
-  // Serialised as JSON rather than joined on a separator: identity fields are
-  // free text from the provider, not slugs, so no chosen byte is guaranteed
-  // absent from them — and `null` must not key the same as the four-letter
-  // string, since one means unrecorded and the other is a name.
-  const keys = components.map((component) =>
-    JSON.stringify([
-      component.stage,
-      component.retry_kind,
-      ...COMPONENT_IDENTITY.map((column) => component[column] ?? null),
-    ]),
-  );
-  if (keys.length !== new Set(keys).size) {
-    fail(field, 'carries duplicate component keys');
-  }
+  const components = projectComponents(value.components, field);
 
   if (status === 'complete') {
     if (estimated === null) fail(field, 'is complete without an amount');
@@ -453,6 +453,11 @@ function receiptAmount(receipt) {
  * rows. Not `name`: `name` is *derived* from the first two — every retry at
  * every stage derives `retry`, and both a visual reader and an audio reader
  * derive `perception` — so it cannot tell those rows apart by construction.
+ *
+ * Serialised as JSON rather than joined on a separator: identity fields are
+ * free text from the provider, not slugs, so no chosen byte is guaranteed
+ * absent from them — and `null` must not key the same as the four-letter
+ * string, since one means unrecorded and the other is a name.
  */
 function summaryComponentKey(component) {
   return JSON.stringify([
@@ -688,3 +693,185 @@ export function summarizeCostReceipts(rows, { successfulDeliverables = null } = 
     missing_reasons: reasons,
   };
 }
+
+// ── the gate on a summary this build did not compute ─────────────────────
+//
+// Everything `summarizeCostReceipts` returns is sound by construction, because
+// it did the arithmetic. The other producer of the same shape is
+// `build_cost_summaries` in batch-runner/core/cost_projection.py, and its
+// output travels inside `report_data.json` — which reaches the build over an
+// unauthenticated fetch from HuggingFace for every experiment, since no results
+// directory carries a local copy. Between that fetch and `summaryTotalCell` in
+// src/lib/cost.ts there was nothing at all: `scripts/aggregate-reports.mjs`
+// spread the object into the published index verbatim and the dashboard
+// rendered it as money.
+//
+// Two ways that ends badly, both reproduced before this was written:
+//
+//   * `status: "partial"` beside a non-null `estimated_cost_usd` renders as a
+//     settled `$0.5000`. The corner of the card says 일부 기록됨 and the middle
+//     says a firm figure, and the figure is the part people read.
+//   * `estimated_cost_usd` absent renders nothing at all: `undefined !== null`
+//     is true, so `formatCostUsd(undefined)` reaches `undefined.toFixed` and
+//     takes the experiment page down with a TypeError.
+//
+// So the rule both producers already obey is enforced here on the way in.
+
+// A summary counts tasks, and a run of this benchmark has 220 of them. Bounded
+// four orders of magnitude above that rather than pinned to it: a corpus this
+// repository has not defined yet is not the thing worth refusing.
+const MAX_SUMMARY_TASKS = 1_000_000;
+
+/** A count the summary must carry; absent is a malformed summary, not a zero. */
+function summaryCount(value, field) {
+  const count = costCount(value, field, MAX_SUMMARY_TASKS);
+  if (count === null) fail(field, 'is required');
+  return count;
+}
+
+/** An amount the summary must carry, for the same reason. */
+function summaryAmount(value, field) {
+  const amount = costAmount(value, field);
+  if (amount === null) fail(field, 'is required');
+  return amount;
+}
+
+/**
+ * Normalise one run summary that arrived from somewhere else.
+ *
+ * null/undefined in, null out — an experiment that ran before receipts existed
+ * carries no summary, and that absence is what makes the dashboard say 기록
+ * 없음 rather than $0. Anything present but malformed throws, and the caller
+ * turns that into a named build failure.
+ */
+export function projectCostSummary(value, field = 'cost summary') {
+  if (value === null || value === undefined) return null;
+  if (!isPlainObject(value)) fail(field, 'must be an object');
+  if (value.schema_version !== COST_RECEIPT_SCHEMA_VERSION) {
+    fail(field, `must declare schema_version ${COST_RECEIPT_SCHEMA_VERSION}`);
+  }
+  if (value.currency !== COST_CURRENCY) {
+    fail(field, `must be denominated in ${COST_CURRENCY}`);
+  }
+
+  const status = costStatus(value.status, `${field}.status`);
+  const known = summaryAmount(value.known_cost_usd, `${field}.known_cost_usd`);
+  const estimated = costAmount(value.estimated_cost_usd, `${field}.estimated_cost_usd`);
+
+  // The biconditional both summarisers hold to: `estimated_cost_usd` is
+  // `known_total if complete_run else None`, and `complete_run` is exactly
+  // `status === 'complete'`. Checked in both directions, because each one is a
+  // different lie. A complete run withholding its total understates what was
+  // spent; an incomplete run naming one promotes a floor to a headline.
+  if (status === 'complete') {
+    if (estimated === null) fail(field, 'is complete without a total');
+    if (estimated !== known) {
+      fail(field, 'is complete but its total is not what it knows');
+    }
+  } else if (estimated !== null) {
+    fail(field, `is ${status} but carries a total`);
+  }
+
+  const totalTasks = summaryCount(value.total_tasks, `${field}.total_tasks`);
+  const receiptTasks = summaryCount(value.receipt_tasks, `${field}.receipt_tasks`);
+  const measuredTasks = summaryCount(value.measured_tasks, `${field}.measured_tasks`);
+  if (receiptTasks > totalTasks) fail(field, 'holds more receipts than it has tasks');
+  if (measuredTasks > receiptTasks) {
+    fail(field, 'prices more tasks than it holds receipts for');
+  }
+
+  // Each receipt lands in exactly one bucket, so the buckets are the receipts
+  // counted a second way. A payload where the two disagree has been rewritten
+  // by something that did not know that, and the disagreement is the only
+  // evidence of it there will ever be.
+  const buckets = {};
+  let bucketed = 0;
+  for (const name of COST_STATUSES) {
+    const count = summaryCount(value[`${name}_tasks`], `${field}.${name}_tasks`);
+    buckets[`${name}_tasks`] = count;
+    bucketed += count;
+  }
+  if (bucketed !== receiptTasks) {
+    fail(field, 'sorts its receipts into buckets that do not add up');
+  }
+
+  const coverage = value.coverage_pct;
+  if (typeof coverage !== 'number' || !Number.isFinite(coverage)
+      || coverage < 0 || coverage > 100) {
+    fail(`${field}.coverage_pct`, 'must be a percentage');
+  }
+
+  const failedCount = summaryCount(value.failed_task_count, `${field}.failed_task_count`);
+  if (failedCount > totalTasks) fail(field, 'counts more failures than it has tasks');
+  // Optional, and only optional: reports published before this count existed do
+  // not carry it, and src/types/cost.ts marks it so. Absent stays absent, which
+  // is what makes `failedTaskCostCell` fall back to its older inference instead
+  // of trusting a zero this reader invented.
+  const failedMeasured = costCount(
+    value.failed_measured_tasks, `${field}.failed_measured_tasks`, MAX_SUMMARY_TASKS,
+  );
+  if (failedMeasured !== null && failedMeasured > failedCount) {
+    fail(field, 'prices more failures than it counted');
+  }
+
+  return {
+    schema_version: COST_RECEIPT_SCHEMA_VERSION,
+    currency: COST_CURRENCY,
+    estimate_basis: ESTIMATE_BASIS,
+    status,
+    total_tasks: totalTasks,
+    receipt_tasks: receiptTasks,
+    measured_tasks: measuredTasks,
+    coverage_pct: round(coverage, 1),
+    ...buckets,
+    known_cost_usd: known,
+    estimated_cost_usd: estimated,
+    avg_cost_usd: costAmount(value.avg_cost_usd, `${field}.avg_cost_usd`),
+    median_cost_usd: costAmount(value.median_cost_usd, `${field}.median_cost_usd`),
+    p95_cost_usd: costAmount(value.p95_cost_usd, `${field}.p95_cost_usd`),
+    max_cost_usd: costAmount(value.max_cost_usd, `${field}.max_cost_usd`),
+    successful_deliverables: costCount(
+      value.successful_deliverables, `${field}.successful_deliverables`, MAX_SUMMARY_TASKS,
+    ),
+    cost_per_successful_deliverable_usd: costAmount(
+      value.cost_per_successful_deliverable_usd,
+      `${field}.cost_per_successful_deliverable_usd`,
+    ),
+    failed_task_count: failedCount,
+    ...(failedMeasured === null ? {} : { failed_measured_tasks: failedMeasured }),
+    failed_task_cost_usd: summaryAmount(
+      value.failed_task_cost_usd, `${field}.failed_task_cost_usd`,
+    ),
+    components: projectComponents(value.components, field),
+    price_table_sha256: priceTableSha256(
+      value.price_table_sha256, `${field}.price_table_sha256`,
+    ),
+    missing_reasons: missingReasons(value.missing_reasons, `${field}.missing_reasons`),
+  };
+}
+
+/**
+ * Normalise the `{problem_solving_cost, grading_cost}` wrapper.
+ *
+ * Returns only the fields that projected to something, and null when none did,
+ * so a wrapper that survived a producer change with nothing left in it reads as
+ * no record rather than as an empty card.
+ */
+export function projectCostSummaries(value, field = 'cost_summary') {
+  if (value === null || value === undefined) return null;
+  if (!isPlainObject(value)) fail(field, 'must be an object');
+  // An unknown key here is a field the dashboard will not render and nobody
+  // will notice is missing. Named rather than dropped, because the two ways a
+  // cost stops being shown — never recorded, and recorded under a name no
+  // reader knows — look identical on screen.
+  const unknown = Object.keys(value).filter((key) => !COST_FIELDS.includes(key));
+  if (unknown.length) fail(field, `carries an unknown cost field: ${unknown.sort().join(', ')}`);
+
+  const projected = {};
+  for (const key of COST_FIELDS) {
+    const summary = projectCostSummary(value[key], `${field}.${key}`);
+    if (summary !== null) projected[key] = summary;
+  }
+  return Object.keys(projected).length ? projected : null;
+}
+


### PR DESCRIPTION
## What was wrong

`scripts/aggregate-reports.mjs` spread every field of a report into `public/generated/reports-index.json` verbatim:

```js
const { task_results: _ignored, ...indexEntry } = data;
```

That is the right default for prose a human wrote and the wrong one for a figure the dashboard renders as a dollar amount.

Measured on this build: **0 of 26** results directories carry a local `report/report_data.json`, so **26 of 26** reports arrive over the unauthenticated HuggingFace fetch. Between that wire and `summaryTotalCell` in `src/lib/cost.ts` there was nothing at all. The grading path — the same shape of payload, from the same kind of source — has run every receipt through `projectCostReceipt` since it was written.

Two ways that ends badly, both reproduced before this was written:

| payload | what the reader sees |
|---|---|
| `status: "partial"` + non-null `estimated_cost_usd` | a settled `$0.5000`. The corner of the card says 일부 기록됨 and the middle says a firm figure. |
| `estimated_cost_usd` absent | nothing. `undefined !== null` is true at `src/lib/cost.ts:384`, so `formatCostUsd(undefined)` reaches `undefined.toFixed` and the experiment page goes down with a `TypeError`. |

## The rule enforced

The biconditional both producers already hold to — `cost_projection.py:677-702,810` and `cost-receipt.mjs:624-667`, `estimated_cost_usd = known_total if complete_run else None`:

> `estimated_cost_usd !== null` ⟺ `status === 'complete'`, and when non-null it equals `known_cost_usd`.

Checked in both directions, because each one is a different lie. A complete run withholding its total understates what was spent; an incomplete run naming one promotes a floor to a headline.

Plus: buckets must re-count the receipts (`sum(*_tasks) === receipt_tasks`), `measured ≤ receipt ≤ total`, coverage is a percentage, priced failures ≤ counted failures, and an unknown cost field is **named rather than dropped** — the two ways a cost stops being shown, never recorded and recorded under a name no reader knows, look identical on screen.

`withProjectedCost` runs **inside the existing try**, so a bad payload stops the build naming its directory the way an unreadable one does, instead of taking down the build without saying which of the 26 caused it.

## What deliberately did not change

- **Absent stays absent.** A report from before receipts existed publishes with no `cost_summary` key; `{}` would claim the record exists and is empty. Two negative-control tests hold this.
- **`failed_measured_tasks` stays optional.** None of the three real cost-carrying reports has it, and `src/types/cost.ts` marks it `?`. Making it required fails 6 tests including the real-corpus acceptance test.
- **The published index is byte-identical** on the three cost figures: exp030 `$0.278335` 5/5, exp031 `$0.373978` 5/5, exp026c `$0.285513` 1/1 — all `complete`, all already satisfying the biconditional.

## Evidence the rules are not over-strict

Two acceptance tests, not just fixtures:

1. `every summary the summariser produces is one the projector accepts` — folds **7 corpora** (complete run, one unknown row, nothing recorded, nothing asked for, a mixture, a row with no receipt, a failure that cost money) through `summarizeCostReceipts` and re-projects each.
2. `every cost summary in the published index is accepted` — reads `public/generated/reports-index.json` off disk, projects every cost-carrying report, asserts the biconditional already holds, requires `seen >= 3`.

**Eight negative controls**, one guard mutated each, restored after. Baseline 85/0 → restored 85/0:

| control | result |
|---|---|
| non-complete carrying a total | 83 / 2 |
| complete without a total | 83 / 2 |
| bucket sum | 84 / 1 |
| `failed_measured_tasks` required | 79 / 6 |
| unknown cost field | 84 / 1 |
| `withProjectedCost` unwired | 19 / 5 |
| raw report spread back over the projection | 23 / 1 |
| scratch tree drops the sibling copy | 12 / 12 |

## The pre-existing failure this surfaced

`test_no_payload_on_disk_carries_a_summary_this_function_wrote` walked the directory tree with `os.walk(REPO_ROOT)`, which reaches build output. `public/generated/reports-index.json` carries three run summaries fetched from HuggingFace and `dist/` carries a copy. Both are gitignored (`.gitignore:328`, `.gitignore:320`), neither is tracked, neither is in a clone — so running `npm run build` before `pytest` failed a claim about what a clone contains. Proved pre-existing by `git stash push scripts/` (same failure) and invisible in CI because `deploy.yml` builds but never runs pytest, and backend CI never builds.

It now enumerates `git ls-files -z -- "*.json"` (129 tracked files, nested included), matching both its own docstring — "the blast radius on **committed** files is still zero" — and the repository's existing wording in `test_the_grading_ledger_no_longer_dies_with_the_runner.py:16`: *"Committed means tracked, not present … so the ledgers are checked with `git ls-files`."*

Negative-controlled both ways: build artifacts present ⇒ 52 passed; a genuinely tracked payload carrying `receipt_tasks` + `coverage_pct` ⇒ still fails, naming the path.

## Verification

| gate | result |
|---|---|
| `npm run test:aggregate` | **281 passed / 1 skipped / 0 failed** (254 → 281, +27 new; arithmetic confirmed against `git show HEAD:`) |
| `npm run build` | green against real data; index still holds 26 reports, 3 cost figures unchanged |
| backend `pytest -q` | **7131 passed, 7 skipped, 45 deselected** — baseline |
| `mypy core/ --ignore-missing-imports` | **174 errors in 32 files** — baseline |

**Grader fingerprint: not moved.** `compute_grader_source_hash` hashes `step8_grade.py`, `core/**/*.py`, `schemas/grade.schema.json`, `requirements.txt`, `batch-runner/scripts/download_inference_from_hf.py`, the prompt template and the config. The freeze filter in `grader-hash-freeze.yml` adds `batch-runner/prompts/**` and `batch-runner/grading_configs/**`. All five changed files are outside both sets — `batch-runner/tests/` and repo-root `scripts/` (not `batch-runner/scripts/`) — checked mechanically, not assumed. No in-flight-run freeze applies.

## Known and out of scope

Per-task receipts reach the dashboard by a **runtime browser fetch** (`src/hooks/useReports.ts:85`, `${HF_BASE}/${experiment_id}/resolve/main/self_report.json`), which is a third unvalidated path outside the build boundary. Noted, not fixed here.
