### PR TITLE
fix(cost): bill the judge's retry to its own receipt line

### DIFF
--- a/batch-runner/core/cost_metering.py
+++ b/batch-runner/core/cost_metering.py
@@ -513,6 +513,7 @@ class CostRecorder:
         provider: str,
         model: str | None = None,
         stage: str | None = None,
+        retry_kind: str | None = None,
         deployment: str | None = None,
         api_version: str | None = None,
     ) -> "MeteredClient":
@@ -524,6 +525,15 @@ class CostRecorder:
         component: the two get two wrappers around one connection, and the
         task in scope is taken from the enclosing block either way.
 
+        ``retry_kind`` pins the same way, for the same reason one step down.
+        A second attempt is not a second stage — it is the same stage done
+        again — but it is its own line, and a caller that knows it is about to
+        retry can say so by reaching for a wrapper that says so. Without this
+        the retry lands in the line of the attempt it is repairing, and "what
+        did retrying cost" becomes unanswerable: the figure is inside a bigger
+        one. Only the judge's finalization retry uses it; the Self-QA loop
+        knows its own attempt number and opens a scope instead.
+
         ``deployment`` and ``api_version`` are overrides. Left unset — which is
         the normal case — both are read off the client itself, since the client
         is what puts them on the wire and asking the caller to restate them
@@ -532,12 +542,15 @@ class CostRecorder:
         """
         if stage is not None and stage not in STAGES:
             raise ValueError(f"unknown stage {stage!r}")
+        if retry_kind is not None and retry_kind not in RETRY_KINDS:
+            raise ValueError(f"unknown retry kind {retry_kind!r}")
         return MeteredClient(
             client,
             recorder=self,
             provider=str(provider),
             default_model=model,
             stage=stage,
+            retry_kind=retry_kind,
             deployment=deployment,
             api_version=api_version,
         )
@@ -637,7 +650,9 @@ class MeteredClient:
     ``stage`` pins calls to one stage regardless of the scope they run in,
     which lets two wrappers around one connection file into two different
     components — the judge's own calls and the perception reads it shares its
-    client with.
+    client with. ``retry_kind`` pins the same way and composes with it, so the
+    judge's finalization retry is a third wrapper on that same connection and
+    a third line on the receipt.
 
     When a call raises, the reservation is deliberately *left standing* rather
     than cleaned up. A request that timed out may well have been served and
@@ -660,6 +675,7 @@ class MeteredClient:
         provider: str,
         default_model: str | None = None,
         stage: str | None = None,
+        retry_kind: str | None = None,
         deployment: str | None = None,
         api_version: str | None = None,
     ):
@@ -668,6 +684,7 @@ class MeteredClient:
         object.__setattr__(self, "_provider", provider)
         object.__setattr__(self, "_default_model", default_model)
         object.__setattr__(self, "_stage", stage)
+        object.__setattr__(self, "_retry_kind", retry_kind)
         object.__setattr__(self, "_deployment", deployment)
         # Resolved once, because a client's API version does not change between
         # calls. An explicit argument wins; otherwise the client is asked.
@@ -724,12 +741,17 @@ class MeteredClient:
             # home for it would corrupt both totals.
             return call(**kwargs)
 
-        pinned = object.__getattribute__(self, "_stage")
-        if pinned is not None and pinned != attribution.stage:
+        pinned_stage = object.__getattribute__(self, "_stage")
+        pinned_retry = object.__getattribute__(self, "_retry_kind")
+        stage = attribution.stage if pinned_stage is None else pinned_stage
+        retry_kind = (
+            attribution.retry_kind if pinned_retry is None else pinned_retry
+        )
+        if stage != attribution.stage or retry_kind != attribution.retry_kind:
             attribution = Attribution(
                 task_id=attribution.task_id,
-                stage=pinned,
-                retry_kind=attribution.retry_kind,
+                stage=stage,
+                retry_kind=retry_kind,
                 attempt_index=attribution.attempt_index,
             )
 

--- a/batch-runner/core/grader.py
+++ b/batch-runner/core/grader.py
@@ -21,7 +21,7 @@ from core.azure_ai_clients import (
     canonical_deployment,
     grader_route_workloads,
 )
-from core.cost_receipts import STAGE_GRADING, STAGE_PERCEPTION
+from core.cost_receipts import RETRY_SEMANTIC, STAGE_GRADING, STAGE_PERCEPTION
 from core.llm_client import ManagedAzureAIClient, create_typed_azure_client
 from core.public_error import public_provider_error_text
 from core.deliverable_selector import (
@@ -353,19 +353,30 @@ class Grader:
         # is written, which is what keeps an unmetered run reporting an
         # absent ledger rather than a smaller bill.
         #
-        # Two wrappers, one connection. The judge's own calls follow whatever
-        # stage is in scope; the perception readers share this client but are
-        # pinned to their own stage, so a visual read taken mid-grading lands
-        # in its own component of the marking receipt instead of disappearing
-        # into the judge's.
+        # Three wrappers, one connection. The judge's own calls follow
+        # whatever stage is in scope; the perception readers share this client
+        # but are pinned to their own stage, so a visual read taken
+        # mid-grading lands in its own component of the marking receipt
+        # instead of disappearing into the judge's. The third is pinned one
+        # level down: the judge's finalization retry is the same stage done
+        # again, and billing it through its own wrapper is what keeps "what
+        # did the retry cost" a figure a reader can find rather than a share
+        # of the main line nobody can separate out.
         self._cost_recorder = cost_recorder
         self._perception_client = client
+        self._retry_client = None
         if cost_recorder is not None:
             self.client = cost_recorder.meter(
                 client, provider="azure", model=deployment
             )
             self._perception_client = cost_recorder.meter(
                 client, provider="azure", stage=STAGE_PERCEPTION
+            )
+            self._retry_client = cost_recorder.meter(
+                client,
+                provider="azure",
+                model=deployment,
+                retry_kind=RETRY_SEMANTIC,
             )
 
         try:
@@ -2038,6 +2049,7 @@ class Grader:
 
         return ToolCallingJudge(
             client=self.client,
+            retry_client=self._retry_client,
             model=self.model,
             prompt_template=tool_prompt,
             reasoning_effort=(judge_cfg.get("reasoning") or {})

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -552,6 +552,14 @@ class ToolCallingJudge:
     Args:
         client:                  object with ``.responses.create(**kwargs)``
                                  (Azure OpenAI Responses client or a fake).
+        retry_client:            optional second connection to the same
+                     deployment, used only for the finalization
+                     retry. Grading meters its clients per receipt
+                     line, so the retry needs its own wrapper to
+                     be billed as a retry instead of vanishing
+                     into the attempt it repairs. ``None`` when
+                     grading runs unmetered — the retry then
+                     falls back to ``client``.
         model:                   deployment name (e.g. ``"gpt-5.6-sol"``).
         prompt_template:         contents of ``prompts/grader_judge_v2.md``
                                  — must contain a ``<!-- ===SPLIT=== -->``
@@ -609,6 +617,7 @@ class ToolCallingJudge:
     finalization_retries: int = 1
     finalization_reasoning_effort: str = "low"
     model_read_ops: Tuple[str, ...] = MODEL_READ_DELIVERABLE_OPS
+    retry_client: Any = None
     vision_perception: Any = None
     audio_perception: Any = None
     task_prompt_truncate: int = 500
@@ -798,7 +807,9 @@ class ToolCallingJudge:
                     ]
                 call_started = time.perf_counter()
                 main_api_call_count += 1
-                response = self.client.responses.create(**create_kwargs)
+                response = self._upstream_client(
+                    is_retry=finalization_only
+                ).responses.create(**create_kwargs)
                 main_latency_ms += (time.perf_counter() - call_started) * 1000.0
             except TypeError as exc:
                 if call_started is not None:
@@ -832,7 +843,9 @@ class ToolCallingJudge:
                     )
                     if not finalization_only:
                         fallback_kwargs["tools"] = tools
-                    response = self.client.responses.create(**fallback_kwargs)
+                    response = self._upstream_client(
+                        is_retry=finalization_only
+                    ).responses.create(**fallback_kwargs)
                     main_latency_ms += (
                         time.perf_counter() - call_started
                     ) * 1000.0
@@ -1337,6 +1350,25 @@ class ToolCallingJudge:
     def _guard_upstream_call(self) -> None:
         if self.before_upstream_call is not None:
             self.before_upstream_call()
+
+    def _upstream_client(self, *, is_retry: bool) -> Any:
+        """The connection this call should be billed through.
+
+        Both clients talk to the same deployment; they differ only in the
+        receipt line their spend lands on. The finalization retry is a second
+        attempt at the same rubric item, so its money belongs on a ``retry``
+        row rather than inside the row for the attempt it is repairing —
+        otherwise "what did retrying cost" is a figure hidden inside a bigger
+        one. The solving side already avoids that: ``step2_run_inference.py``
+        opens the Self-QA loop's later attempts under their own retry kind.
+
+        ``retry_client`` is absent whenever grading runs unmetered, so the
+        retry falls back to the one client it has. Turning cost recording off
+        must not stop the judge from retrying.
+        """
+        if is_retry and self.retry_client is not None:
+            return self.retry_client
+        return self.client
 
     @staticmethod
     def _accumulate_perception_result(

--- a/batch-runner/tests/test_a_grading_retry_is_its_own_line.py
+++ b/batch-runner/tests/test_a_grading_retry_is_its_own_line.py
@@ -1,0 +1,385 @@
+"""The judge's second attempt is billed to the same line as its first.
+
+A receipt line is one model identity at one stage at one retry kind, and the
+solving side honours that: ``step2_run_inference.py`` opens the Self-QA loop's
+second attempt under ``RETRY_SEMANTIC``, so "what did generating cost" and
+"what did retrying cost" are two rows a reader can tell apart.
+
+The grading side never sets a retry kind at all. Its one billed retry is the
+judge's finalization retry — the first attempt came back with no final text, or
+with text that is not the envelope, so the judge spends a second call asking for
+the envelope alone. ``core/grader.py`` opens exactly one scope for the whole
+task (``attributed(task_id=..., stage=STAGE_GRADING)``) and its own comment says
+so: "judge turns, retries inside the judge, and the perception reads it
+delegates" all land in that one window. The perception reads escape it through
+their own metered wrapper. The retry does not.
+
+So a task that retried shows one ``grading`` row with two calls in it, and the
+question the card has been carrying as unproven — what does retrying cost —
+cannot be answered from the receipt, because the number is inside a bigger one.
+Measured on ``main`` before the fix: one line, ``retry_kind='none'``, two calls,
+one amount.
+
+The fix is a third metered wrapper on the same connection, pinned to
+``RETRY_SEMANTIC``, handed to the judge as ``retry_client``. The judge spends it
+for the finalization retry and the main client for everything else, so the pair
+becomes two rows carrying the same total. Priced at the fixture table below that
+is $4.00 for the attempt that failed and $2.00 for the one that worked: both
+real money, and only one of them bought a verdict.
+
+No provider is contacted. The judge is driven by a scripted client and every
+amount here comes from the fixture price table.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+import yaml
+
+from core.cost_metering import CostRecorder
+from core.cost_receipts import (
+    BUCKET_GRADING,
+    RETRY_KINDS,
+    RETRY_NONE,
+    RETRY_SEMANTIC,
+    STAGE_GRADING,
+    STATUS_COMPLETE,
+    CostReceiptLedger,
+    load_receipt_price_table,
+)
+from core.rubric_loader import RubricItem, TaskRubric
+from core.tool_calling_judge import ToolCallingJudge
+
+from tests.test_tool_calling_judge import (
+    PROMPT_TEMPLATE,
+    FakeClient,
+    ScriptedResponses,
+    _final,
+    _response,
+)
+
+
+#: One deployment, one rate. The point of these tests is which row an amount
+#: lands in, so the table stays small enough that every figure below can be
+#: checked by hand: 100 input tokens at $10/M plus 30 output at $20/M is
+#: $0.0010 + $0.0006 = $0.0016 for the default reply shape.
+FIXTURE_RATE = {
+    "input_usd_per_million": "10",
+    "cached_input_usd_per_million": "10",
+    "output_usd_per_million": "20",
+    "reasoning_billed_as": "output",
+    "source": "fixture",
+    "last_reviewed": "2026-08-28",
+    "currency": "USD",
+    "unit": "per 1,000,000 tokens",
+}
+
+
+def price_table(*deployments: str) -> dict:
+    """The same rate for every deployment named.
+
+    The last test prices whatever deployment the committed marking settings
+    name rather than a fixed string, so renaming the judge deployment moves
+    the test with it instead of turning the receipt unpriced underneath it.
+    """
+    return {
+        "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+        "providers": {f"azure:{name}": dict(FIXTURE_RATE) for name in deployments},
+        "runtime": {},
+    }
+
+
+PRICE_TABLE = price_table("judge-deployment")
+
+#: Input/output token counts chosen so the two calls cannot be confused: the
+#: failed attempt costs exactly twice the one that recovered.
+FAILED_ATTEMPT = {"in_tok": 200_000, "out_tok": 100_000}   # $2.00 + $2.00
+RECOVERY = {"in_tok": 100_000, "out_tok": 50_000}          # $1.00 + $1.00
+
+FAILED_ATTEMPT_USD = Decimal("4.00")
+RECOVERY_USD = Decimal("2.00")
+
+
+def make_recorder(tmp_path, table: dict) -> CostReceiptLedger:
+    path = tmp_path / "prices.json"
+    path.write_text(json.dumps(table), encoding="utf-8")
+    return CostReceiptLedger(
+        tmp_path / "cost.sqlite3",
+        run_id="run-1",
+        price_table=load_receipt_price_table(path),
+    )
+
+
+@pytest.fixture
+def recorder(tmp_path):
+    with make_recorder(tmp_path, PRICE_TABLE) as ledger:
+        yield CostRecorder(ledger)
+
+
+@pytest.fixture
+def deliverable_dir(tmp_path) -> Path:
+    """A one-cell workbook, because the read tool opens the file for real."""
+    openpyxl = pytest.importorskip("openpyxl")
+    workbook = openpyxl.Workbook()
+    workbook.active["A1"] = "alpha"
+    workbook.save(tmp_path / "report.xlsx")
+    return tmp_path
+
+
+@pytest.fixture
+def task_and_item() -> tuple[TaskRubric, RubricItem]:
+    item = RubricItem(
+        rubric_item_id="r1",
+        criterion="The deliverable contains an 'alpha' label in column A",
+        score=5,
+        required=None,
+    )
+    task = TaskRubric(
+        task_id="task-a",
+        sector="Information",
+        occupation="Analyst",
+        prompt="Make a report",
+        rubric_items=[item],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+    return task, item
+
+
+def _retrying_client() -> FakeClient:
+    """A judge call that fails its envelope, then succeeds on the retry.
+
+    ``{}`` parses but is not the envelope, which is
+    ``_finalization_retry_reason``'s ``invalid_final_envelope`` — the plain
+    case, with none of the reasoning-effort special handling that
+    ``empty_final_text:max_output_tokens`` brings with it.
+    """
+    verdict = json.dumps({
+        "verdict": "pass",
+        "partial_score": 1.0,
+        "evidence": "the report states a number",
+        "confidence": 0.9,
+        "reasoning": "recovered on the finalization retry",
+    })
+    return FakeClient(ScriptedResponses([
+        _response(output=[_final("{}")], **FAILED_ATTEMPT),
+        _response(output=[_final(verdict)], **RECOVERY),
+    ]))
+
+
+def _judge(client: FakeClient, **kwargs) -> ToolCallingJudge:
+    return ToolCallingJudge(
+        client=client,
+        model="judge-deployment",
+        prompt_template=PROMPT_TEMPLATE,
+        max_iterations=1,
+        finalization_retries=1,
+        **kwargs,
+    )
+
+
+def _lines(receipt) -> dict[str, tuple[int, Decimal]]:
+    """``retry_kind -> (calls, amount)``, for a receipt of one stage."""
+    return {
+        line.retry_kind: (line.model_calls, line.known_cost_usd)
+        for line in receipt.components
+    }
+
+
+def test_the_judge_retry_is_billed_to_the_line_it_belongs_to(
+    recorder, deliverable_dir, task_and_item
+):
+    """Two attempts, two rows: the failed one and the one that recovered."""
+    task, item = task_and_item
+    client = _retrying_client()
+    judge = _judge(
+        recorder.meter(client, provider="azure", model="judge-deployment"),
+        retry_client=recorder.meter(
+            client,
+            provider="azure",
+            model="judge-deployment",
+            retry_kind=RETRY_SEMANTIC,
+        ),
+    )
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GRADING):
+        result = judge.judge_item(
+            task=task,
+            item=item,
+            deliverable_dir=str(deliverable_dir),
+            file_names=["report.xlsx"],
+        )
+
+    # The retry did happen and did recover, so both calls are real money.
+    assert result.verdict == "pass"
+    assert result.main_api_call_count == 2
+
+    receipt = recorder.receipt_for("task-a", BUCKET_GRADING)
+    assert receipt.status == STATUS_COMPLETE
+    assert receipt.model_calls == 2
+    assert _lines(receipt) == {
+        RETRY_NONE: (1, FAILED_ATTEMPT_USD),
+        RETRY_SEMANTIC: (1, RECOVERY_USD),
+    }
+    # The task's bill is unchanged by the split — the same money, told apart.
+    assert receipt.known_cost_usd == FAILED_ATTEMPT_USD + RECOVERY_USD
+
+
+def test_a_judge_that_never_retried_still_files_one_line(
+    recorder, deliverable_dir, task_and_item
+):
+    """Negative control: the split must not invent a row nobody spent.
+
+    A `retry` row reading $0.0000 on every task that went right would be the
+    same lie in the other direction — the reader would learn that retrying is
+    free, from tasks that never retried.
+    """
+    task, item = task_and_item
+    verdict = json.dumps({
+        "verdict": "pass",
+        "partial_score": 1.0,
+        "evidence": "the report states a number",
+        "confidence": 0.9,
+        "reasoning": "first attempt was fine",
+    })
+    client = FakeClient(ScriptedResponses([
+        _response(output=[_final(verdict)], **RECOVERY),
+    ]))
+    judge = _judge(
+        recorder.meter(client, provider="azure", model="judge-deployment"),
+        retry_client=recorder.meter(
+            client,
+            provider="azure",
+            model="judge-deployment",
+            retry_kind=RETRY_SEMANTIC,
+        ),
+    )
+
+    with recorder.attributed(task_id="task-a", stage=STAGE_GRADING):
+        result = judge.judge_item(
+            task=task,
+            item=item,
+            deliverable_dir=str(deliverable_dir),
+            file_names=["report.xlsx"],
+        )
+
+    assert result.main_api_call_count == 1
+    receipt = recorder.receipt_for("task-a", BUCKET_GRADING)
+    assert _lines(receipt) == {RETRY_NONE: (1, RECOVERY_USD)}
+
+
+def test_an_unmetered_judge_keeps_working_without_a_retry_client(
+    recorder, deliverable_dir, task_and_item
+):
+    """Negative control: metering stays opt-in.
+
+    Grading runs without a recorder hand the judge a bare client and no retry
+    client at all. The retry has to fall back to the one client it has, or
+    turning metering off would stop the judge from retrying.
+    """
+    task, item = task_and_item
+    client = _retrying_client()
+    judge = _judge(client)
+
+    result = judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+    assert result.verdict == "pass"
+    assert result.main_api_call_count == 2
+
+
+def test_the_judge_the_grader_really_builds_bills_its_retry_apart(tmp_path):
+    """The wiring, on the settings a real marking run loads.
+
+    The three tests above hand ``ToolCallingJudge`` a retry client directly, so
+    they prove the judge spends it correctly and prove nothing about whether
+    anything gives the judge one. Deleting the single line in ``core/grader.py``
+    that passes ``retry_client=`` leaves all three green and puts production
+    straight back to one merged line — checked, and it does.
+
+    So this one builds the grader from a committed marking settings file, takes
+    the judge that grader built, and drives it through the same retry.
+    """
+    from core.grader import Grader
+
+    config_path = Path("grading_configs/default_v2.yaml")
+    document = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    deployment = document["judge"]["model"]
+
+    task = TaskRubric(
+        task_id="task-a",
+        sector="Information",
+        occupation="Analyst",
+        prompt="Make a report",
+        rubric_items=[],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+    item = RubricItem(
+        rubric_item_id="r1",
+        criterion="The deliverable contains an 'alpha' label in column A",
+        score=5,
+        required=None,
+    )
+    openpyxl = pytest.importorskip("openpyxl")
+    workbook = openpyxl.Workbook()
+    workbook.active["A1"] = "alpha"
+    deliverables = tmp_path / "deliverables"
+    deliverables.mkdir()
+    workbook.save(deliverables / "report.xlsx")
+
+    client = _retrying_client()
+    with make_recorder(tmp_path, price_table(deployment)) as ledger:
+        recorder = CostRecorder(ledger)
+        grader = Grader(
+            document,
+            rubric_loader=None,
+            client=client,
+            cost_recorder=recorder,
+        )
+        judge = grader._tool_judge
+        assert judge is not None, "the committed settings built no judge"
+
+        with recorder.attributed(task_id="task-a", stage=STAGE_GRADING):
+            result = judge.judge_item(
+                task=task,
+                item=item,
+                deliverable_dir=str(deliverables),
+                file_names=["report.xlsx"],
+            )
+
+        assert result.main_api_call_count == 2
+        receipt = recorder.receipt_for("task-a", BUCKET_GRADING)
+
+    assert _lines(receipt) == {
+        RETRY_NONE: (1, FAILED_ATTEMPT_USD),
+        RETRY_SEMANTIC: (1, RECOVERY_USD),
+    }
+
+
+def test_a_retry_kind_the_ledger_does_not_know_is_refused_at_the_wrapper(
+    recorder,
+):
+    """A misspelled pin fails where it is written, not on the receipt.
+
+    ``_component_key`` groups on the retry kind verbatim, so a typo would not
+    error — it would quietly open a line of its own, and the reader would see a
+    row for ``semanitc`` beside the one for ``semantic`` and have no way to
+    know they are the same spend. Mirrors the ``stage`` check beside it.
+    """
+    with pytest.raises(ValueError, match="unknown retry kind"):
+        recorder.meter(object(), provider="azure", retry_kind="semanitc")
+
+    # Negative control: every kind the ledger does know is still accepted.
+    for kind in RETRY_KINDS:
+        recorder.meter(object(), provider="azure", retry_kind=kind)


### PR DESCRIPTION
## What was wrong

A receipt line is **one model identity at one stage at one retry kind**. The solving side honours that — `step2_run_inference.py:3510-3520` opens the Self-QA loop's later attempts under `RETRY_SEMANTIC`, so "what did generating cost" and "what did retrying cost" are two rows a reader can tell apart.

The grading side never set a retry kind at all. `retry_kind` had exactly **one** non-test production writer in the whole repo, and it was on the solving side.

`core/grader.py:540` opens one scope for the entire task, and its own comment says so: judge turns, retries inside the judge, and the perception reads it delegates all land in that one window. The perception reads escape it through their own metered wrapper. **The retry did not.**

The judge's finalization retry (`ToolCallingJudge.finalization_retries: int = 1`) is a second billed call to the same deployment — fired when the first attempt came back with no final text, unparseable JSON, or text that is not the envelope. It merged into the line for the attempt it was repairing.

Measured on `main` before this change:

| line | retry_kind | calls | amount |
|---|---|---|---|
| grading | `none` | 2 | $6.00 |

The $4.00 attempt that failed and the $2.00 call that recovered are indistinguishable. The card's question — *what does retrying cost* — could not be answered from the receipt, because the figure was inside a bigger one.

## What this does

A **third metered wrapper on the same connection**, pinned to `RETRY_SEMANTIC`, handed to the judge as `retry_client`. The judge spends it for the finalization retry and the main client for everything else. Same total, two rows:

| line | retry_kind | calls | amount |
|---|---|---|---|
| grading | `none` | 1 | $4.00 |
| grading | `semantic` | 1 | $2.00 |

`RETRY_SEMANTIC` is the right kind: `_finalization_retry_reason` returns `empty_final_text:<finish_reason>`, `final_json_parse_failed` or `invalid_final_envelope` — all "the answer went wrong", which is what the solving side means by it too.

This follows the house idiom already in `grader.py` — *two wrappers, one connection* becomes three. `_component_key` groups on the seven identity fields, so the split is a grouping change, not a new accounting path. `_next_call_id` keys on `(task_id, stage, retry_kind, attempt_index)`, so the two kinds get separate sequence namespaces and no call_id collides.

### Files

- **`core/cost_metering.py`** — `CostRecorder.meter()` takes `retry_kind`, validated against `RETRY_KINDS` exactly the way the sibling `stage` check already is, so a misspelled pin fails where it is written instead of quietly opening a row for `semanitc` beside the one for `semantic`. `MeteredClient._around` composes both pins; when `retry_kind` is `None` the expression reduces to the original condition, so behaviour is unchanged for every existing caller.
- **`core/tool_calling_judge.py`** — optional `retry_client` field, spent through a small `_upstream_client(is_retry=)` helper at both `responses.create` sites (main and the SDK-TypeError fallback). The judge imports nothing from the cost modules — it just sees an optional second client. Falls back to `client` when absent, so turning metering off does not stop the judge from retrying.
- **`core/grader.py`** — builds the third wrapper and passes it to the judge.

## Tests

`batch-runner/tests/test_a_grading_retry_is_its_own_line.py`, 5 tests, no provider contacted — scripted client, fixture price table, every figure checkable by hand.

1. the retry lands on its own line, and the task's total is unchanged by the split
2. **negative control** — a judge that never retried does not get a `$0.0000` retry row invented for it, which would teach the reader that retrying is free from tasks that never retried
3. **negative control** — an unmetered judge with no retry client still retries
4. **the wiring**, on the committed `grading_configs/default_v2.yaml`: builds a real `Grader`, takes the judge it really built, drives the same retry. The first three stay green if `grader.py` never passes a retry client — checked, and they do. This one fails.
5. **negative control** — `retry_kind="semanitc"` raises at the wrapper, and every kind in `RETRY_KINDS` is still accepted

Four separate negative controls on the production code were run and all four fail the intended test: un-routing either `create` site, dropping the `_around` pin, unwiring `grader.py`, removing the `meter()` validation.

## Gates

| gate | result |
|---|---|
| backend pytest (branch) | 7136 passed, 7 skipped, 45 deselected, **0 failed** |
| backend pytest (clean `main` baseline) | 7128 passed, 10 skipped, 45 deselected, **0 failed** |
| mypy | 174 errors in 32 files, 101 source files — **exact baseline** |
| frontend `npm run test:aggregate` | 310 tests, 309 passed, 1 skipped |
| frontend `npm run build` | clean |

The +8 passing on the branch is +5 new tests and +3 tests that skipped in the baseline run. That delta is worktree state, not code: running the identical 32 skip-capable files back to back in both worktrees gives byte-identical results — **907 passed, 7 skipped, 19 deselected**, same five skip reasons (seccomp TSYNC, `main` module ×2, no ruby, LibreOffice ×3). The full-run difference is Docker/seccomp availability drifting between run times.

## Grader fingerprint

This edits three `core/*.py` files, so it **moves** the grader source hash. `gh run list --workflow=grade-run.yml` shows all 8 recent runs `completed` — no Grade Pipeline in flight, freeze clear.
