### PR TITLE
docs(azure): say that the RBAC diagnostic cannot be answered locally

### DIFF
--- a/.github/workflows/azure-rbac-diagnostic.yml
+++ b/.github/workflows/azure-rbac-diagnostic.yml
@@ -12,6 +12,16 @@
 # Every call this makes is an ARM control-plane READ. It creates nothing,
 # changes nothing, and calls no model endpoint, so running it cannot reproduce
 # the refusal it exists to explain and cannot spend anything.
+#
+# This is also the only place the question can be asked. The script reads
+# whatever subscription and identity the `az` session holds, and a login taken
+# on a development box or in an agent container is a different one of each: the
+# Foundry account this asks about is not in the subscription such a login
+# reaches. The lookup then comes back empty for the same reason a withheld role
+# does, the run stops at `cannot_read_control_plane`, and the note beside it
+# says the identity has no reader on the account -- which is not what was
+# measured, because the identity was never reached. Run it here, or do not run
+# it.
 name: Azure Foundry RBAC Diagnostic
 
 on:

--- a/batch-runner/scripts/azure_rbac_diagnostic.py
+++ b/batch-runner/scripts/azure_rbac_diagnostic.py
@@ -13,6 +13,31 @@ project rather than an authentication one.
 Nothing in this repository could measure that: there is no infrastructure code
 and no role tooling of any kind. This script closes that gap.
 
+Where it has to be run
+----------------------
+Through its workflow, in CI. Not from a development box, and not from the agent
+container.
+
+What this reads is whatever subscription and identity the ``az`` session is
+signed into, and a login taken outside CI is a different one of each. The
+subscription such a login reaches does not contain the Foundry account this asks
+about, so ``resolve_resource_group`` gets nothing back and the run stops at
+``cannot_read_control_plane``.
+
+That verdict is honest as far as it goes. The sentence recorded beside it is
+not: it reads "that alone means this identity has no reader on the account",
+which is a true inference only when the lookup went to the right subscription.
+From the wrong one the identity was never asked about at all, because an absent
+resource and a withheld role come back through the control plane looking the
+same. A local run therefore cannot answer this question, and it cannot answer it
+in the negative either.
+
+``AZURE_SUBSCRIPTION_ID`` is required rather than defaulted, below, so the
+script cannot quietly inherit whichever subscription a local login happens to
+carry. That is as far as a check can go: a subscription id supplied by hand is
+well-formed whether or not it is the right one, and no assertion here can tell
+the two apart.
+
 What it does and does not do
 ----------------------------
 Every call it makes is an ARM control-plane READ. It never creates, updates or


### PR DESCRIPTION
## What is missing

`azure_rbac_diagnostic.py` reads whatever subscription and identity the `az` session is signed into. A login taken outside CI is a different one of each, and the subscription such a login reaches does not contain the Foundry account the script asks about. `resolve_resource_group` then raises `AzureReadFailure`, and the run stops at `cannot_read_control_plane`.

That verdict is honest. The sentence recorded beside it is not:

```python
# scripts/azure_rbac_diagnostic.py:658-664
problems.append(
    "could not resolve the Foundry account through the control plane, "
    "so the project scope could not be built. That alone means this "
    f"identity has no reader on the account ({failure.what})"
)
report["verdict"] = "cannot_read_control_plane"
```

"That alone means this identity has no reader on the account" is a sound inference **only when the lookup went to the right subscription**. From the wrong one the identity was never asked about at all, because through the ARM control plane an absent resource and a withheld role come back looking the same. So a local run cannot answer this question — and, importantly, it cannot answer it in the negative either. It is not evidence of a missing role. It is no evidence.

## Why this is documentation and not a fix

The enforcement already exists. `AZURE_SUBSCRIPTION_ID` is required rather than defaulted:

```python
# :622-625
subscription_id = env.get("AZURE_SUBSCRIPTION_ID", "").strip()
if not subscription_id:
    raise ValueError("AZURE_SUBSCRIPTION_ID is required")
```

so the script cannot quietly inherit whichever subscription a local login happens to carry. That is as far as a check can go: a subscription id supplied by hand is well-formed whether or not it is the right one, and no assertion in this file can tell the two apart. Only the explanation was missing, and its absence is what lets a `cannot_read_control_plane` result be read as a negative answer rather than as no answer.

## Changes

- `batch-runner/scripts/azure_rbac_diagnostic.py` — a 25-line **"Where it has to be run"** section in the module docstring, naming the failure path, quoting the misleading sentence, and stating what the required-subscription-id check can and cannot rule out.
- `.github/workflows/azure-rbac-diagnostic.yml` — a 10-line comment in the existing header block: this workflow is the only place the question can be asked.

Neither names a resource, a subscription, an account or a project.

## Verification

- **Prose only, proven rather than asserted.** A checker parses both revisions and compares the Python AST with every docstring stripped, and the workflow YAML as `yaml.safe_load` sees it:
  ```
  python AST (docstrings stripped): IDENTICAL
  yaml parsed structure:            IDENTICAL
  the files did change at all:      yes
  ```
  The third line is a vacuity guard — it failed once already, when the comparison was accidentally run against two copies of the same revision, which is how the first two lines came to be trustworthy.
- `tests/test_azure_rbac_diagnostic.py` — **76 passed**.
- Backend `pytest` from `batch-runner/` — green.
- **The grader source fingerprint does not move**: `e27f20a1483fd2c4b2b0f2850781b731310f6f5b9d89a4a0a728c921ffe05131` on both this branch and `main`. `compute_grader_source_hash` takes exactly one file from `scripts/` (`download_inference_from_hf.py`) and can never take a workflow — there is a test to that effect. So this cannot invalidate a run in flight and needs no fresh smoke.
- Sensitive-string scan over the diff: 0 endpoint hosts, 0 subscription display names, 0 account or project names, 0 host names.

No code path changes. No paid run.
