### PR TITLE
fix(grading): send the part of the clip the criterion asks about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,6 +339,46 @@ entries land under a fresh dated heading the day they merge to `main`.
   not open at all; the probe reports *unknown* rather than *no*, which leaves
   the existing extension rule in charge instead of promoting towards a file
   nothing can extract.
+- **The listening model was handed the first 30 seconds of the deliverable and
+  then asked about 1:22.** With the routing above fixed, task `38889c3b` grades
+  at **45.5 of 62 (73.39%)** with `perception_call_count: 6` and nothing
+  excluded — and three of its items are *still* failed for a reason that is not
+  a property of the work under test. Each names a region the clip could not
+  reach, and one sub-judge wrote the defect out itself: *"The clip only includes
+  the first 30s, ending well before 1:49."* It listened, it reported honestly
+  what it had been given, and the harness recorded that as a finding about the
+  deliverable. **6 points, across the items asking about 1:22–1:49, 1:49–end,
+  and the beginning through 1:22.**
+
+  The clip now opens where the criterion is looking. A criterion naming a region
+  that begins after the head slice *ends* — and only such a criterion — moves
+  the window there, using the tolerance the rubric states rather than one we
+  guess (`1:49 (+/- 2 s)` opens at 1:47). Anything anchored at the beginning,
+  naming no time, or naming a time already inside the slice is untouched, so
+  *"From the beginning ... through 1:22"* keeps the head it needs. **Neither the
+  number of calls nor the length of the clip changes** — the same 30 seconds at
+  the same encoding, cut at a different offset — so the set of items that can
+  move is exactly the set that cannot be answered from the audio sent today,
+  and `start_seconds=0` is byte-for-byte the path it has always been.
+
+  The system prompt now names the span it is actually carrying instead of
+  claiming "first 30s" of everything, which is the half of the defect that made
+  the wrong verdicts look well-grounded. Where a window is wanted and cannot be
+  cut, the two reasons are kept apart because they deserve opposite verdicts: a
+  deliverable that genuinely ends before the timestamp is a fact about the work
+  and is graded as one, while a file this machine could not decode is a fact
+  about us, and there the sub-judge is told to return `judge_error` and say what
+  went unheard. That line is drawn from the file's own frame timestamps, never
+  from silence — a container that reports no times at all cannot be read as a
+  short deliverable. Absence of observation is not observation of absence.
+
+  One more link had to hold for any of this to reach a real run. `audio_judge`
+  grades whatever criterion string the *main* judge passes it, and nothing
+  obliged that string to be the rubric's own words — a summary such as "check
+  the bridge thins to synths" carries no time, leaves the window at the head
+  and fails the item exactly as before. The tool now asks for the criterion
+  verbatim and says which words are load-bearing, and its description no longer
+  advertises "the head-30s slice" of the file it is about to be given.
 - **An empty read was treated as proof the content was absent.** On stage-1
   task `43dc9778` the judge read a two-page scan that has no text layer,
   `read_content` returned `"text": "", "char_count": 0`, and **ten rubric items

--- a/batch-runner/core/perception/audio.py
+++ b/batch-runner/core/perception/audio.py
@@ -21,9 +21,12 @@ Design notes (task 206):
   refused with a 400 before any model hears it; the audio content part
   belongs to ``ChatCompletionContentPartParam``. See
   ``tests/test_audio_goes_to_the_endpoint_that_accepts_it.py``.
-* Duration trim: only the first 30 seconds of the file are sent, re-encoded
-  to 16 kHz mono. The head-only slice keeps cost bounded; the main judge
-  still has access to full-clip statistics via
+* Duration trim: 30 seconds of the file are sent per call, re-encoded to
+  16 kHz mono. Which 30 seconds follows the criterion -- a question about
+  1:22 is sent 1:22, not the opening -- and whichever window goes out is the
+  window the system prompt names. See :func:`criterion_listen_start` for why
+  a fixed head slice cost task ``38889c3b`` six points on the gold run. The
+  main judge still has access to full-clip statistics via
   ``read_deliverable(op='probe_audio', ...)``.
 * Per-task call cap = 32, which is the most listening criteria any one task
   in the gold corpus carries. The cap counts *listens*, not attempts: a
@@ -51,6 +54,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional, Tuple
@@ -87,6 +91,89 @@ AUDIO_CALL_CAP = 32
 #: is a price as much as a limit, and the grader reads it from here rather
 #: than keeping a second copy.
 AUDIO_TRIM_SECONDS = 30
+
+#: Patterns for reading a listening window out of a criterion's own words.
+#:
+#: The clip has always been the *first* ``AUDIO_TRIM_SECONDS`` of the
+#: deliverable, and the sub-judge has always been told so. That is fine for
+#: "is there music", "is the voiceover audible", "does it clip" -- properties
+#: a head slice carries. It is not fine for a criterion that names a region:
+#: on the 185-task gold run, task ``38889c3b`` was asked about 1:22-1:49,
+#: about 1:49-to-the-end, and about the stretch through 1:22 of a two-minute
+#: master. All three were answered ``fail``, 0/2, for six points; one of them
+#: says why in its own evidence -- *"The clip only includes the first 30s,
+#: ending well before 1:49."*
+#:
+#: That is the failure this module exists to avoid, wearing the one disguise
+#: it is hardest to see: the model listened, reported honestly what it heard,
+#: and the harness recorded "the deliverable does not do this" from a clip in
+#: which the deliverable was never given the chance to. Absence of observation
+#: is not observation of absence.
+#:
+#: So the window follows the question. ``M:SS`` only, seconds bounded at 59,
+#: and not when a clock-time suffix follows -- "9:00 AM" is a meeting, "2:1"
+#: is a ratio and cannot match at all. A stated tolerance ("+/- 10 s") is read
+#: from the text rather than guessed at, and the window opens that much early.
+_AUDIO_TIMESTAMP_RE = re.compile(
+    r"\b(\d{1,3}):([0-5]\d)\b(?!\s*(?:[ap]\.?\s?m\.?\b|:?\d))",
+    flags=re.IGNORECASE,
+)
+#: Words that put the asked-about region at the top of the file no matter what
+#: else the criterion names. "From the beginning of the Master track through
+#: 1:22" names 1:22 and wants 0:00. Seeking to 1:22 for it would take a clip
+#: that overlaps the question and replace it with one that does not, so any of
+#: these words means: leave the head slice alone. A word matched here by
+#: accident costs nothing -- it restores exactly today's behaviour.
+_AUDIO_HEAD_ANCHOR_RE = re.compile(
+    r"\b(beginning|begins?|start|starts|starting|opening|opens|intro"
+    r"|introduction|outset|onset|first|initial|top)\b",
+    flags=re.IGNORECASE,
+)
+_AUDIO_TOLERANCE_RE = re.compile(
+    r"(?:±|\+\s*/\s*-|\+-)\s*(\d{1,3})\s*(?:s\b|sec|second)",
+    flags=re.IGNORECASE,
+)
+
+
+def criterion_listen_start(
+    criterion: str,
+    *,
+    trim_seconds: int = AUDIO_TRIM_SECONDS,
+) -> Optional[float]:
+    """Where in the deliverable this criterion needs the clip to start.
+
+    Returns ``None`` -- meaning "the head, as always" -- unless the criterion
+    names a region that the head slice provably cannot contain. That is a
+    deliberately narrow trigger, and it is the whole safety argument for this
+    function: the only items whose clip can move are the ones asking about a
+    stretch of audio that starts *after* everything we send today ends. Those
+    items cannot currently be answered from evidence. Nothing that is
+    answerable today changes.
+
+    The tolerance a criterion states about its own timestamp is honoured, so
+    "1:22 (+/- 10 s)" opens the window at 1:12 rather than at 1:22 and does
+    not miss the very thing it was sent to hear.
+    """
+    text = criterion or ""
+    if not text or _AUDIO_HEAD_ANCHOR_RE.search(text):
+        return None
+    stamps = [
+        minutes * 60 + seconds
+        for minutes, seconds in (
+            (int(m.group(1)), int(m.group(2)))
+            for m in _AUDIO_TIMESTAMP_RE.finditer(text)
+        )
+    ]
+    if not stamps:
+        return None
+    tolerances = [int(m.group(1)) for m in _AUDIO_TOLERANCE_RE.finditer(text)]
+    start = min(stamps) - (max(tolerances) if tolerances else 0)
+    if start <= trim_seconds:
+        # The head already overlaps what is being asked about. Sending a
+        # second, later clip would answer a question nobody asked.
+        return None
+    return float(start)
+
 
 #: What the head slice is re-encoded to. The source is whatever the
 #: deliverable happens to carry — the two video deliverables in this corpus
@@ -226,14 +313,65 @@ class AudioVerdict:
         }
 
 
-_AUDIO_PROMPT_HEADER = (
-    "You are an audio sub-judge for the GDPval grading pipeline. The "
-    "clip is a head-only slice (first 30s) of the LLM-under-test's "
-    "audio deliverable. Grade ONE rubric criterion against what you "
-    "HEAR. Return the same JSON envelope as the main judge: "
-    "{verdict, partial_score, evidence, confidence, reasoning}. The "
-    "evidence MUST describe an audible feature; do not invent. Keep "
-    "evidence <= 200 chars. Return JSON only."
+def _mmss(seconds: float) -> str:
+    total = int(round(seconds))
+    return f"{total // 60}:{total % 60:02d}"
+
+
+def _audio_prompt_header(
+    *,
+    start_seconds: float = 0.0,
+    trim_seconds: int = AUDIO_TRIM_SECONDS,
+    window_note: Optional[str] = None,
+) -> str:
+    """The system prompt, stating the window this call actually carries.
+
+    This used to be a constant reading "a head-only slice (first 30s)", which
+    was true of the bytes but became false as soon as marking settings named a
+    different ``trim_seconds``, and false in a more expensive way once the
+    clip could start anywhere. What the sub-judge is told it is hearing has to
+    be what it is hearing: its evidence is quoted in the grade, and evidence
+    timed against the wrong origin is worse than none.
+    """
+    if start_seconds > 0:
+        span = (
+            f"the segment from {_mmss(start_seconds)} to "
+            f"{_mmss(start_seconds + trim_seconds)} of"
+        )
+    else:
+        span = f"a head-only slice (first {int(trim_seconds)}s) of"
+    parts = [
+        "You are an audio sub-judge for the GDPval grading pipeline. The "
+        f"clip is {span} the LLM-under-test's audio deliverable."
+    ]
+    if window_note:
+        parts.append(window_note)
+    parts.append(
+        "Grade ONE rubric criterion against what you HEAR. Return the same "
+        "JSON envelope as the main judge: {verdict, partial_score, evidence, "
+        "confidence, reasoning}. The evidence MUST describe an audible "
+        "feature; do not invent. Keep evidence <= 200 chars. Return JSON only."
+    )
+    return " ".join(parts)
+
+
+#: Told to the sub-judge when the criterion named a region and the clip could
+#: not be cut to it for a reason that is about this machine rather than about
+#: the deliverable. Not having listened is not having heard nothing, and the
+#: envelope already has a value for "no verdict was reached".
+_AUDIO_WINDOW_UNCUT_NOTE = (
+    "The criterion names a part of the deliverable that this clip does not "
+    "contain, and it could not be extracted, so you have NOT observed it. Do "
+    "not treat that as evidence the deliverable lacks it: return verdict "
+    "\"judge_error\" and say in the evidence which part went unheard."
+)
+
+#: Told to the sub-judge when the region is missing because the deliverable
+#: stops before it. That is a fact about the work under test, so it is
+#: gradeable, and the sub-judge is left to grade it.
+_AUDIO_REGION_ABSENT_NOTE = (
+    "Note: the criterion names a timestamp beyond the end of this "
+    "deliverable, which runs out before that point."
 )
 
 
@@ -271,7 +409,28 @@ def _first_choice_text(response: Any) -> str:
     return str(getattr(audio, "transcript", "") or "") if audio else ""
 
 
-def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS
+class AudioWindowUnavailable(Exception):
+    """A requested listening window could not be cut from the file.
+
+    Raised only for a window that was actually asked for -- either the file
+    ends before it, or nothing here can decode it. The caller's answer is to
+    fall back to the head slice *and say so in the prompt*, never to present a
+    head slice as if it were the segment the criterion named.
+
+    ``region_absent`` separates the two, because they deserve opposite
+    verdicts. A deliverable that ends at 0:30 really does not have the bridge
+    the rubric asks for at 1:22, and failing it is correct. A file this
+    machine could not decode tells us nothing about the deliverable at all,
+    and failing *that* is the very mistake this class was added to stop.
+    """
+
+    def __init__(self, message: str, *, region_absent: bool = False) -> None:
+        super().__init__(message)
+        self.region_absent = region_absent
+
+
+def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS,
+                      start_seconds: float = 0.0,
                       ) -> Tuple[bytes, str]:
     """Read a file and return ``(bytes, format)`` trimmed to ``max_seconds``.
 
@@ -284,8 +443,20 @@ def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS
     sent whole: "no duration" is not "short", and a studio stem that declines
     to say how long it is would otherwise go out at its full size. Nor does a
     short ``.wav`` qualify — see ``COMPRESSED_AUDIO_FORMATS``.
+
+    ``start_seconds`` moves the slice off the head, for a criterion that named
+    a region the head cannot contain (see :func:`criterion_listen_start`). At
+    the default of ``0.0`` every path below is exactly what it was. Above it,
+    the two shortcuts that would send bytes other than the requested window --
+    the raw hand-over and the whole-file fallback — are closed, because a clip
+    that does not match what the prompt claims about it is worse than no clip.
+    The slice is cut by decoding forward and dropping what precedes the window
+    rather than by seeking: a container seek lands on the keyframe at or
+    before the target, and the window promised to the sub-judge has to be the
+    window it actually hears.
     """
     fmt = _guess_format(path)
+    wants_window = start_seconds > 0
 
     def raw() -> Tuple[bytes, str]:
         with open(path, "rb") as fh:
@@ -294,6 +465,8 @@ def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS
     try:
         import av  # type: ignore
     except ImportError:
+        if wants_window:
+            raise AudioWindowUnavailable("no decoder available to cut a window")
         return raw()
 
     try:
@@ -304,8 +477,15 @@ def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS
             container.streams.audio[0]
             duration_s = (float(container.duration) / 1_000_000.0
                           if container.duration else None)
+            if wants_window and duration_s is not None and duration_s <= start_seconds:
+                raise AudioWindowUnavailable(
+                    f"deliverable is {duration_s:.0f}s long and the criterion "
+                    f"asks about {start_seconds:.0f}s",
+                    region_absent=True,
+                )
             if (
-                duration_s is not None
+                not wants_window
+                and duration_s is not None
                 and duration_s <= max_seconds
                 and fmt in COMPRESSED_AUDIO_FORMATS
             ):
@@ -322,13 +502,35 @@ def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS
             resampler = av.AudioResampler(
                 format="s16", layout=AUDIO_LAYOUT, rate=AUDIO_SAMPLE_RATE_HZ,
             )
+            window_end = start_seconds + max_seconds
+            heard_anything = False
+            furthest = 0.0
             for frame in container.decode(audio=0):
                 t = float(frame.pts * frame.time_base) if frame.pts else 0.0
-                if t > max_seconds:
+                furthest = max(furthest, t)
+                if t > window_end:
                     break
+                if t < start_seconds:
+                    continue
+                heard_anything = True
                 for resampled in resampler.resample(frame):
                     for packet in out_stream.encode(resampled):
                         out.mux(packet)
+            if wants_window and not heard_anything:
+                # Two different things end up here and only one of them is
+                # the deliverable's fault. A file whose frames carried real,
+                # advancing timestamps and still had nothing at the window
+                # really is shorter than the criterion assumes. A file whose
+                # timestamps never moved off zero told us nothing at all, and
+                # blaming it for stopping early would put a sentence in the
+                # prompt that no evidence supports.
+                timestamps_moved = furthest > 0.0
+                raise AudioWindowUnavailable(
+                    f"no audio at {start_seconds:.0f}s in this deliverable"
+                    if timestamps_moved
+                    else "frame timestamps unusable; cannot cut a window",
+                    region_absent=timestamps_moved,
+                )
             # Drain the resampler before the encoder: PyAV buffers whole
             # output frames, so the tail of the slice is still inside it.
             for resampled in resampler.resample(None):
@@ -340,7 +542,12 @@ def _trim_audio_bytes(path: str, max_seconds: int = AUDIO_TRIM_SECONDS
             return buf.getvalue(), "wav"
         finally:
             container.close()
+    except AudioWindowUnavailable:
+        # The one failure the whole-file fallback must not paper over.
+        raise
     except Exception:
+        if wants_window:
+            raise AudioWindowUnavailable("could not decode a window from this file")
         return raw()
 
 
@@ -427,6 +634,28 @@ class AudioPerception:
             failure_detail=reason,
         )
 
+    def _preparation_error(self, exc: Exception, audio_path: str) -> "AudioVerdict":
+        """A verdict for a clip that could not be built at all.
+
+        Shared by the plain path and by the fall-back after a window could not
+        be cut, so that failing to prepare a head slice reads the same however
+        the caller arrived at it.
+        """
+        detail = (
+            f"audio preparation failed:"
+            f" {public_task_error(exc)['error_type']}"
+            f" (suffix={os.path.splitext(audio_path)[1].lower() or 'none'})"
+        )
+        return AudioVerdict(
+            verdict="judge_error",
+            partial_score=0.0,
+            evidence="",
+            confidence=0.0,
+            reasoning=detail,
+            judge_error=public_task_error_text(exc),
+            failure_detail=detail,
+        )
+
     def judge(
         self,
         *,
@@ -453,23 +682,30 @@ class AudioPerception:
                 f"audio failure budget {self.failure_budget} exhausted",
                 "audio_unavailable:repeated_failure",
             )
+        listen_start = criterion_listen_start(
+            criterion, trim_seconds=self.trim_seconds
+        )
+        window_note: Optional[str] = None
         try:
-            data, fmt = _trim_audio_bytes(audio_path, self.trim_seconds)
+            data, fmt = _trim_audio_bytes(
+                audio_path, self.trim_seconds, listen_start or 0.0
+            )
+        except AudioWindowUnavailable as window_exc:
+            # A window was asked for and could not be cut. Fall back to the
+            # head slice -- but never silently. What the prompt says about the
+            # clip has to stay true, and *why* the region went unheard is what
+            # decides whether failing the criterion would be honest.
+            window_note = (
+                _AUDIO_REGION_ABSENT_NOTE if window_exc.region_absent
+                else _AUDIO_WINDOW_UNCUT_NOTE
+            )
+            listen_start = None
+            try:
+                data, fmt = _trim_audio_bytes(audio_path, self.trim_seconds)
+            except Exception as exc:  # noqa: BLE001
+                return self._preparation_error(exc, audio_path)
         except Exception as exc:  # noqa: BLE001
-            detail = (
-                f"audio preparation failed:"
-                f" {public_task_error(exc)['error_type']}"
-                f" (suffix={os.path.splitext(audio_path)[1].lower() or 'none'})"
-            )
-            return AudioVerdict(
-                verdict="judge_error",
-                partial_score=0.0,
-                evidence="",
-                confidence=0.0,
-                reasoning=detail,
-                judge_error=public_task_error_text(exc),
-                failure_detail=detail,
-            )
+            return self._preparation_error(exc, audio_path)
         if fmt not in SUPPORTED_AUDIO_FORMATS:
             # Refused before the call, not after it. The API rejects an
             # unsupported container outright, so sending it spends a slot from
@@ -480,13 +716,19 @@ class AudioPerception:
                 "unsupported_audio_format",
             )
         b64 = base64.b64encode(data).decode("ascii")
+        header = _audio_prompt_header(
+            start_seconds=listen_start or 0.0,
+            trim_seconds=self.trim_seconds,
+            window_note=window_note,
+        )
         if len(b64) > AUDIO_MAX_REQUEST_BYTES:
             # The size candidate, named rather than guessed at. This is the
             # one shape of 400 the class can recognise on its own side of the
             # wire, so it says so instead of letting the provider say
             # ``BadRequestError`` and leaving the reader to pick between two
-            # explanations. Deterministic for the task -- the next criterion
-            # sends the same clip -- so it blocks the rest rather than
+            # explanations. Deterministic for the task -- every criterion gets
+            # the same length of clip at the same encoding, whichever part of
+            # the file it is cut from -- so it blocks the rest rather than
             # re-measuring the same file thirteen more times.
             self._blocked_reason = "payload_too_large"
             return self._refuse(
@@ -513,7 +755,7 @@ class AudioPerception:
                         "role": "user",
                         "content": [
                             {"type": "text",
-                             "text": f"{_AUDIO_PROMPT_HEADER}\n\nCriterion:\n{criterion}"},
+                             "text": f"{header}\n\nCriterion:\n{criterion}"},
                             {"type": "input_audio",
                              "input_audio": {"data": b64, "format": fmt}},
                         ],

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -1203,14 +1203,26 @@ class ToolCallingJudge:
             "type": "function",
             "name": "audio_judge",
             "description": (
-                "Ask the audio sub-judge to grade the criterion against "
-                "the head-30s slice of a deliverable audio file. Use "
-                "only for AUDIO items."
+                "Ask the audio sub-judge to grade the criterion against a "
+                "30-second slice of a deliverable audio file. Use "
+                "only for AUDIO items. Which 30 seconds is worked out from "
+                "the criterion text you pass -- the opening, unless the "
+                "criterion names a region that starts later -- and the "
+                "sub-judge is told which span it was given."
             ),
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "criterion": {"type": "string"},
+                    "criterion": {
+                        "type": "string",
+                        "description": (
+                            "The rubric criterion, copied verbatim. Keep its "
+                            "timestamps: \"1:22-1:49 (+/- 10 s)\" is what "
+                            "makes the clip start at 1:12 rather than at "
+                            "0:00, so a paraphrase that drops the times gets "
+                            "the wrong part of the file listened to."
+                        ),
+                    },
                     "audio_path": {"type": "string"},
                     "member": {
                         "type": ["string", "null"],

--- a/batch-runner/tests/test_the_clip_covers_what_the_criterion_asks.py
+++ b/batch-runner/tests/test_the_clip_covers_what_the_criterion_asks.py
@@ -1,0 +1,401 @@
+"""A criterion about 1:22 must not be failed from a clip that ends at 0:30.
+
+Every audio call used to carry the first ``AUDIO_TRIM_SECONDS`` of the
+deliverable and a system prompt saying so. On the 185-task gold run that cost
+task ``38889c3b`` six points across three items, each asking about a region
+the clip could not reach:
+
+    "During 1:22-1:49 (+/- 10 s) of the Master track (the bridge), ..."
+        -> 0/2 fail
+    "From 1:49 (+/- 2 s) to the end of the Master track, the harmonies ..."
+        -> 0/2 fail, evidence: "The clip only includes the first 30s,
+           ending well before 1:49."
+    "From the beginning of the Master track through 1:22 (+/- 10 s), ..."
+        -> 0/2 fail
+
+The second one is the whole bug written out by the model itself: it listened,
+it reported honestly what the clip contained, and the harness recorded the
+result as a property of the deliverable. These tests pin the two halves of the
+fix -- the window follows the question, and whatever window is sent is what
+the sub-judge is told it is hearing.
+
+The three strings below are quoted from the graded run rather than invented,
+because the parser is only worth anything against the sentences rubrics
+actually use.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.perception.audio import (
+    AUDIO_TRIM_SECONDS,
+    AudioWindowUnavailable,
+    _audio_prompt_header,
+    _AUDIO_REGION_ABSENT_NOTE,
+    _AUDIO_WINDOW_UNCUT_NOTE,
+    criterion_listen_start,
+)
+
+
+# The criteria as graded, truncated only where the tail carries no timestamp.
+BRIDGE = (
+    "During 1:22-1:49 (+/- 10 s) of the Master track (the bridge), the "
+    "arrangement thins to synths and drums."
+)
+OUTRO = (
+    "From 1:49 (+/- 2 s) to the end of the Master track, the harmonies "
+    "stack into a three-part chord."
+)
+THROUGH = (
+    "From the beginning of the Master track through 1:22 (+/- 10 s), the "
+    "key stays in D major."
+)
+
+
+# --------------------------------------------------------------------------
+# The window follows the question
+# --------------------------------------------------------------------------
+
+def test_a_region_after_the_head_slice_moves_the_window():
+    """1:22 with a 10s tolerance opens the clip at 1:12, not at 0:00."""
+    assert criterion_listen_start(BRIDGE) == pytest.approx(72.0)
+
+
+def test_the_stated_tolerance_is_read_rather_than_guessed():
+    """1:49 +/- 2 s opens at 1:47. The number comes from the criterion."""
+    assert criterion_listen_start(OUTRO) == pytest.approx(107.0)
+
+
+def test_a_criterion_anchored_at_the_beginning_keeps_the_head():
+    """"From the beginning ... through 1:22" wants 0:00, and names 1:22.
+
+    Seeking to 1:22 here would take a clip that overlaps the question and
+    replace it with one that does not -- a regression dressed as a fix.
+    """
+    assert criterion_listen_start(THROUGH) is None
+
+
+def test_a_criterion_naming_no_time_keeps_the_head():
+    assert criterion_listen_start(
+        "The mix is free of clipping and the vocal sits above the drums."
+    ) is None
+
+
+def test_a_timestamp_inside_the_head_slice_keeps_the_head():
+    """0:12 is already in the clip, so nothing moves and nothing is re-sent."""
+    assert criterion_listen_start("At 0:12 the hi-hat enters.") is None
+
+
+def test_the_boundary_belongs_to_the_head():
+    """A window opening exactly at the end of the head slice is not a gap."""
+    assert criterion_listen_start(
+        f"At 0:{AUDIO_TRIM_SECONDS} the hi-hat enters."
+    ) is None
+
+
+def test_the_earliest_named_region_is_the_one_opened_on():
+    """A span is entered at its start, not at its end."""
+    assert criterion_listen_start(
+        "Between 2:10 and 3:40 the bass drops out."
+    ) == pytest.approx(130.0)
+
+
+def test_a_longer_head_slice_swallows_a_later_timestamp():
+    """The trigger is the clip we would otherwise send, not a fixed 30s."""
+    assert criterion_listen_start(BRIDGE, trim_seconds=180) is None
+
+
+@pytest.mark.parametrize("text", [
+    "The team meets at 9:00 AM to review the mix.",
+    "The meeting at 10:30 a.m. covers the vocal takes.",
+    "Compression is applied at a 4:1 ratio on the bus.",
+])
+def test_things_that_look_like_timestamps_and_are_not(text):
+    """A clock time and a ratio must not move the clip.
+
+    A ratio cannot match at all -- the pattern needs two digits after the
+    colon. A clock time is turned away by its own suffix.
+    """
+    assert criterion_listen_start(text) is None
+
+
+def test_a_bare_clock_range_is_read_as_a_timestamp_and_that_is_contained():
+    """The limit of this parser, pinned rather than papered over.
+
+    "12:00-13:00" with no am/pm is a diary entry to a person and a timestamp
+    to the pattern, and nothing in the criterion text can tell them apart --
+    a 12-minute mark is perfectly ordinary in a recording. So it is read as a
+    timestamp, and the *file* settles it: a deliverable that ends before 12:00
+    raises :class:`AudioWindowUnavailable` with ``region_absent``, the head
+    slice is sent as it always was, and the note appended to the prompt says
+    only that the criterion names a point past the end of the deliverable --
+    which is true of a diary entry too. The cost of being wrong here is one
+    sentence of context, not a verdict.
+    """
+    assert criterion_listen_start(
+        "The session ran 12:00-13:00 in the studio diary."
+    ) == pytest.approx(720.0)
+
+
+def test_an_empty_criterion_is_not_an_error():
+    assert criterion_listen_start("") is None
+    assert criterion_listen_start(None) is None  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Whatever is sent is what the sub-judge is told it is hearing
+# --------------------------------------------------------------------------
+
+def test_the_head_slice_still_says_head_only():
+    header = _audio_prompt_header(start_seconds=0.0, trim_seconds=30)
+    assert "head-only slice (first 30s)" in header
+
+
+def test_a_moved_window_states_its_real_span():
+    """The old prompt said "first 30s" of everything. That is the lie."""
+    header = _audio_prompt_header(start_seconds=72.0, trim_seconds=30)
+    assert "from 1:12 to 1:42" in header
+    assert "head-only" not in header
+
+
+def test_the_prompt_stops_hardcoding_thirty_seconds():
+    """``trim_seconds`` is settings-overridable, so the sentence must move."""
+    header = _audio_prompt_header(start_seconds=0.0, trim_seconds=90)
+    assert "first 90s" in header
+    assert "30s" not in header
+
+
+def test_an_uncut_window_forbids_reading_silence_as_absence():
+    """Not having listened is not having heard nothing."""
+    header = _audio_prompt_header(
+        start_seconds=0.0, trim_seconds=30,
+        window_note=_AUDIO_WINDOW_UNCUT_NOTE,
+    )
+    assert "judge_error" in header
+    assert "have NOT observed it" in header
+
+
+def test_a_deliverable_that_ends_early_is_still_gradeable():
+    """A track that stops at 0:30 really does lack the bridge at 1:22.
+
+    That is a fact about the work under test, so the note says so and leaves
+    the verdict alone -- no ``judge_error`` instruction, unlike the case
+    above where the failure is ours.
+    """
+    header = _audio_prompt_header(
+        start_seconds=0.0, trim_seconds=30,
+        window_note=_AUDIO_REGION_ABSENT_NOTE,
+    )
+    assert "beyond the end of this deliverable" in header
+    assert "judge_error" not in header
+
+
+# --------------------------------------------------------------------------
+# The main judge has to hand over the words the window is read from
+# --------------------------------------------------------------------------
+
+def _audio_tool_schema():
+    from core.tool_calling_judge import ToolCallingJudge
+
+    return ToolCallingJudge._audio_tool_schema()
+
+
+def test_the_tool_stops_promising_the_head_of_the_file():
+    """The description the main judge reads was "the head-30s slice"."""
+    description = _audio_tool_schema()["description"]
+    assert "head-30s" not in description
+    assert "criterion" in description
+
+
+def test_the_main_judge_is_asked_to_keep_the_timestamps():
+    """Without this the fix cannot fire on a real run, only in tests.
+
+    ``audio_judge`` grades whatever criterion string the main judge chooses to
+    pass, and nothing obliged that string to be the rubric's. A summary --
+    "check the bridge thins to synths" -- carries no time, so the window stays
+    at the head and the item fails exactly as it did before. The parser reads
+    the criterion, so the criterion has to arrive intact.
+    """
+    criterion = _audio_tool_schema()["parameters"]["properties"]["criterion"]
+    assert "verbatim" in criterion.get("description", "")
+    # Named, so that the instruction is about the thing that matters rather
+    # than a general plea for fidelity.
+    assert "timestamps" in criterion["description"]
+
+
+# --------------------------------------------------------------------------
+# The two failures are told apart, because they deserve opposite verdicts
+# --------------------------------------------------------------------------
+
+def test_a_missing_region_and_a_missing_decoder_are_different():
+    absent = AudioWindowUnavailable("ends first", region_absent=True)
+    undecodable = AudioWindowUnavailable("no decoder")
+    assert absent.region_absent is True
+    assert undecodable.region_absent is False
+
+
+def test_a_window_past_the_end_of_the_file_is_refused_not_faked(tmp_path):
+    """The head slice must never be handed back as if it were the segment."""
+    av = pytest.importorskip("av")
+    src = tmp_path / "short.wav"
+    _write_silence(av, str(src), seconds=2)
+
+    from core.perception.audio import _trim_audio_bytes
+
+    with pytest.raises(AudioWindowUnavailable) as caught:
+        _trim_audio_bytes(str(src), 30, 120.0)
+    assert caught.value.region_absent is True
+
+
+def test_a_window_inside_the_file_is_cut_and_is_not_the_head(tmp_path):
+    av = pytest.importorskip("av")
+    src = tmp_path / "tone.wav"
+    _write_silence(av, str(src), seconds=8)
+
+    from core.perception.audio import _trim_audio_bytes
+
+    head, fmt_head = _trim_audio_bytes(str(src), 2, 0.0)
+    later, fmt_later = _trim_audio_bytes(str(src), 2, 4.0)
+    assert fmt_head == fmt_later == "wav"
+    # Both are two seconds of the same file, so size alone proves nothing.
+    # What proves the seek is that asking past the end of an 8s file fails
+    # while asking at 4s does not.
+    assert len(later) > 0
+    with pytest.raises(AudioWindowUnavailable):
+        _trim_audio_bytes(str(src), 2, 30.0)
+
+
+def test_the_default_call_is_byte_for_byte_what_it_always_was(tmp_path):
+    """``start_seconds=0`` must not be a new code path with a new result."""
+    av = pytest.importorskip("av")
+    src = tmp_path / "tone.wav"
+    _write_silence(av, str(src), seconds=4)
+
+    from core.perception.audio import _trim_audio_bytes
+
+    assert _trim_audio_bytes(str(src), 2) == _trim_audio_bytes(str(src), 2, 0.0)
+
+
+def _fake_av(frames):
+    """An ``av`` module complete enough to reach the end-of-window check.
+
+    Deliberately not a stub that throws: a fake that blows up early lands in
+    the generic decode-failure branch, which reports ``region_absent=False``
+    for its own reasons and would let this test pass no matter what the check
+    under test decides. It has to survive as far as the loop.
+    """
+    import fractions
+
+    class _OutStream:
+        layout = None
+
+        def encode(self, *_a):
+            return []
+
+    class _Out:
+        def add_stream(self, *_a, **_k):
+            return _OutStream()
+
+        def mux(self, _packet):
+            pass
+
+        def close(self):
+            pass
+
+    class _Streams:
+        audio = [object()]
+
+    class _Container:
+        duration = None
+        streams = _Streams()
+
+        def decode(self, **_kwargs):
+            return iter(frames)
+
+        def close(self):
+            pass
+
+    class _Resampler:
+        def resample(self, _frame):
+            return []
+
+    def _open(_target, mode="r", **_kwargs):
+        return _Out() if mode == "w" else _Container()
+
+    return type("_AV", (), {
+        "open": staticmethod(_open),
+        "AudioResampler": staticmethod(lambda **_k: _Resampler()),
+        "time_base": fractions.Fraction(1, 1),
+    })
+
+
+def _frame(seconds):
+    """A decoded frame reporting ``seconds``, or nothing at all if ``None``."""
+    import fractions
+
+    return type("_Frame", (), {
+        "pts": None if seconds is None else seconds,
+        "time_base": fractions.Fraction(1, 1),
+    })()
+
+
+@pytest.mark.parametrize("frames, blames_the_deliverable, why", [
+    (
+        [_frame(1), _frame(2)],
+        True,
+        "timestamps advanced and ran out before the window: the deliverable "
+        "really is shorter than the criterion assumes",
+    ),
+    (
+        [_frame(None), _frame(None)],
+        False,
+        "no frame ever reported a time, so nothing here is evidence about "
+        "how long the deliverable is",
+    ),
+])
+def test_only_a_real_clock_may_blame_the_deliverable(
+    tmp_path, frames, blames_the_deliverable, why
+):
+    """``region_absent`` decides which sentence reaches the sub-judge.
+
+    One of the two says the deliverable stops early -- a claim about the work
+    under test, which is exactly the kind of claim this whole change exists to
+    stop the harness making without evidence.
+    """
+    import sys
+
+    from core.perception.audio import _trim_audio_bytes
+
+    src = tmp_path / "clip.wav"
+    src.write_bytes(b"RIFF----WAVEfmt ")
+
+    monkey = pytest.MonkeyPatch()
+    monkey.setitem(sys.modules, "av", _fake_av(frames))
+    try:
+        with pytest.raises(AudioWindowUnavailable) as caught:
+            _trim_audio_bytes(str(src), 30, 120.0)
+    finally:
+        monkey.undo()
+    assert caught.value.region_absent is blames_the_deliverable, why
+
+
+def _write_silence(av, path: str, *, seconds: int) -> None:
+    """A mono 16 kHz WAV of ``seconds`` length, written with PyAV."""
+    import numpy as np
+
+    rate = 16_000
+    out = av.open(path, mode="w", format="wav")
+    stream = out.add_stream("pcm_s16le", rate=rate)
+    stream.layout = "mono"
+    samples = np.zeros((1, rate), dtype="int16")
+    for index in range(seconds):
+        frame = av.AudioFrame.from_ndarray(samples, format="s16", layout="mono")
+        frame.sample_rate = rate
+        frame.pts = index * rate
+        frame.time_base = __import__("fractions").Fraction(1, rate)
+        for packet in stream.encode(frame):
+            out.mux(packet)
+    for packet in stream.encode():
+        out.mux(packet)
+    out.close()


### PR DESCRIPTION
## The defect

The audio sub-judge has always been handed the first `AUDIO_TRIM_SECONDS` of the
deliverable, and a system prompt saying so. That is right for "is there music",
"is the voiceover audible", "does it clip" — properties a head slice carries.
It is wrong for a criterion that names a region.

On the 185-task gold run, task `38889c3b` grades at **45.5 of 62 (73.39%)** with
`perception_call_count: 6` and nothing excluded — and three of its items are
still failed for a reason that is not a property of the work under test:

| criterion | outcome |
|---|---|
| "During **1:22–1:49** (+/- 10 s) of the Master track (the bridge), the arrangement thins…" | 0/2 fail |
| "From **1:49** (+/- 2 s) to the end of the Master track, the harmonies stack…" | 0/2 fail |
| "From the beginning of the Master track **through 1:22** (+/- 10 s), the key stays in D major" | 0/2 fail |

The second one's own evidence string is the bug written out by the model:

> "The clip only includes the first 30s, ending well before 1:49."

It listened, it reported honestly what it had been given, and the harness
recorded that as a finding about the deliverable. **6 points.**

## Why hearing it beats excusing it

`grader.py:1599` sets `score_excluded=(verdict == "judge_error")`. Turning these
three wrong `fail`s into errors would take them out of the denominator — a way
of not answering, not a way of answering correctly, and the same score-inflation
problem being worked on elsewhere. Moving the window answers them instead.

## The change

**The clip opens where the criterion is looking.** `criterion_listen_start()`
moves the window only for a criterion naming a region that begins *after* the
head slice ends, and reads the tolerance the rubric itself states rather than
guessing one — `1:49 (+/- 2 s)` opens at 1:47. Anything anchored at the
beginning, naming no time, or naming a time already inside the slice is
untouched, so *"From the beginning … through 1:22"* keeps the head it needs.

**Nothing about the spend changes.** Same number of calls, same 30 seconds at
the same encoding, cut at a different offset. So the items that can move are
exactly the ones that cannot be answered from the audio sent today, and
`start_seconds=0` is byte-for-byte the old path — pinned by
`test_the_default_call_is_byte_for_byte_what_it_always_was`.

**The prompt states the span it carries** instead of claiming "first 30s" of
everything, which is the half of the defect that made the wrong verdicts look
well-grounded. It was also already false whenever settings named a different
`trim_seconds`.

**The two ways a window can fail are kept apart**, because they deserve opposite
verdicts. A deliverable that genuinely ends before the timestamp is a fact about
the work and is graded as one. A file this machine could not decode is a fact
about *us*, and there the sub-judge is told to return `judge_error` and name what
went unheard. That line is drawn from the file's own frame timestamps, never
from silence: a container reporting no times at all cannot be read as a short
deliverable (`test_only_a_real_clock_may_blame_the_deliverable` pins both
directions).

**The last link.** `audio_judge` grades whatever criterion string the *main*
judge passes it, and nothing obliged that string to be the rubric's words — a
summary carries no time and leaves the window at the head, so the fix would
work in tests and never fire on a run. The tool now asks for the criterion
verbatim and says which words are load-bearing, and its description no longer
advertises "the head-30s slice".

## Verification

- Full backend suite: **7190 passed, 7 skipped, 0 failed** (15m44s).
- New `tests/test_the_clip_covers_what_the_criterion_asks.py`: 26 tests, built
  on the criteria as actually graded rather than invented ones.
- mypy on both changed modules: **identical error set to `main`** (30
  pre-existing, 0 new), verified by stash-and-compare.
- Mutation-checked: `wants_window = False` → 2 failures;
  `timestamps_moved = True` → 1 failure. The guard test was rewritten after the
  first version passed against its own mutant.
- Grader-fingerprint files touched; **0 Grade Pipeline runs in flight** at
  branch time, re-checked before merge.

## Known limit, pinned rather than papered over

`12:00-13:00` with no am/pm is a diary entry to a person and a timestamp to the
pattern — a 12-minute mark is ordinary in a recording and nothing in the text
separates them. So it reads as a timestamp and *the file settles it*: a
deliverable that ends before 12:00 raises `AudioWindowUnavailable`, the head
slice goes out as always, and the appended note says only that the criterion
names a point past the end — which is true of a diary entry too. The cost of
being wrong there is one sentence of context, not a verdict.
