### PR TITLE
fix(grading): say which kind of nothing an empty verdict was

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,44 @@ entries land under a fresh dated heading the day they merge to `main`.
   because none of them can run.
 
 ### Fixed
+- **Thirteen items the judge never answered were all written down as the same
+  six words.** When a grading call returns no usable final text, the judge
+  already works out *which* kind of nothing it was — the output budget ran out,
+  the provider filtered the reply, the response came back with a failed status,
+  or nothing explains it — because whether to retry at all depends on that
+  answer. The value was used for the retry decision and then dropped, and the
+  item was recorded as a bare `empty_final_text`.
+
+  On the 185-task gold run that happened to thirteen items across ten tasks, at
+  60–85 seconds of grading each. Afterwards there was no way to separate them
+  without paying to grade them again, and they need opposite responses: a
+  budget exhaustion is fixed by a larger cap, a content filter is not fixed by
+  anything a cap can do, and `unknown` means the provider said nothing at all.
+  The distinction was visible the whole time in the retry warning line — the
+  shard-4 entry below quotes `empty_final_text:max_output_tokens` from exactly
+  that log — but the log is per-run and the record is what the analysis reads.
+
+  The reason is now carried the last few lines to where the item is recorded,
+  so an empty verdict reads `empty_final_text:<finish_reason>`. Three things
+  are deliberately unchanged. A failure that happened *before* the text was
+  read — an upstream error, a tool call during finalization, the iteration cap
+  — still wins, because it names a more specific cause than emptiness. The
+  reason is overwritten on every attempt rather than remembered from the first,
+  so an item whose retry succeeded carries nothing from how it started, and an
+  item that failed twice differently is filed under the second failure rather
+  than the one a bigger budget already failed to fix. And the item is still
+  excluded from the score exactly as before: naming the failure is a separate
+  question from deciding what an unanswered item costs, and that one is open on
+  its own card.
+
+  The `finish_reason` vocabulary is bounded — a provider `incomplete_details`
+  reason, a status, `max_output_tokens`, or `unknown` — so the suffix groups
+  rather than fragmenting into one bucket per item. The recorded reason and the
+  string that tells the retry to think cheaply are now built from one constant,
+  so they cannot drift apart into a silent no-op. Consumers that count
+  `baseline_empty_final_text` read a configured integer, not this string, and
+  are unaffected. Regression tests in
+  `batch-runner/tests/test_an_empty_verdict_says_why_it_was_empty.py`.
 - **A task that takes longer than one chunk could never be graded, only paid
   for repeatedly.** `--resume` harvests *completed* `task_id`s from the partial
   on disk, so resume granularity is one whole task. A task abandoned part-way

--- a/batch-runner/core/tool_calling_judge.py
+++ b/batch-runner/core/tool_calling_judge.py
@@ -84,10 +84,16 @@ _FINALIZATION_RETRY_PROMPT = (
 #: set lower.
 _REASONING_EFFORTS = ("none", "low", "medium", "high", "xhigh", "max")
 
+#: The judge produced no usable final text. Always recorded with a
+#: ``:<finish_reason>`` suffix naming which kind of nothing it was, so that
+#: "ran out of output budget" and "the provider filtered it" do not collect in
+#: one bucket. Bare, it is the last resort of ``_empty_text_reason``.
+_EMPTY_FINAL_TEXT = "empty_final_text"
+
 #: The one retry reason that says the room ran out rather than the answer
 #: went wrong: the first attempt spent its whole output budget and left no
 #: text behind.
-_OUT_OF_ROOM_RETRY_REASON = "empty_final_text:max_output_tokens"
+_OUT_OF_ROOM_RETRY_REASON = f"{_EMPTY_FINAL_TEXT}:max_output_tokens"
 
 #: Ceiling on the retry's reasoning when the room ran out. Effort is the
 #: thing that consumed the budget, so the retry has to want less of it than
@@ -500,13 +506,47 @@ def _finalization_retry_reason(
         finish_reason = _response_finish_reason(
             response, max_output_tokens, output_tokens
         )
-        return f"empty_final_text:{finish_reason}"
+        return f"{_EMPTY_FINAL_TEXT}:{finish_reason}"
     parsed = _safe_json_loads(final_text)
     if parsed is None:
         return "final_json_parse_failed"
     if _validated_final_envelope(parsed) is None:
         return "invalid_final_envelope"
     return None
+
+
+def _empty_text_reason(
+    judge_error: Optional[str], finalization_reason: Optional[str]
+) -> str:
+    """What to record for an item that produced no usable final text.
+
+    ``_finalization_retry_reason`` already works out *why* the text was empty
+    -- ``max_output_tokens``, ``content_filter``, an incomplete status, or
+    ``unknown`` -- because the decision of whether to retry depends on it.
+    That value used to be read once and dropped, so every one of the thirteen
+    empty verdicts on the 185-task run was written down as a bare
+    ``empty_final_text``: 60-85 seconds of grading each, and afterwards no way
+    to separate the ones a bigger budget would fix from the ones the model
+    declined to answer. Nothing was broken; the reason was simply not carried
+    the last few lines to where it gets recorded.
+
+    An explicit ``judge_error`` wins, because it names a failure that happened
+    *before* the text was read -- an upstream error, a tool call during
+    finalization, the iteration cap -- and is therefore the more specific
+    cause. Only when nothing else went wrong is emptiness itself the story.
+
+    The suffix is checked rather than trusted. The caller reads the same
+    ``final_text`` this branch tested, so the two agree by construction today;
+    pinning it here means a future caller cannot file "the JSON did not parse"
+    under a bucket that says the model said nothing at all.
+    """
+    if judge_error is not None:
+        return judge_error
+    if finalization_reason is not None and finalization_reason.startswith(
+        f"{_EMPTY_FINAL_TEXT}:"
+    ):
+        return finalization_reason
+    return _EMPTY_FINAL_TEXT
 
 
 def _finalization_effort(configured: str, retry_reason: Optional[str]) -> str:
@@ -760,6 +800,14 @@ class ToolCallingJudge:
         # "how hard should the retry think" depends on it. See
         # ``_finalization_effort``.
         finalization_retry_reason: Optional[str] = None
+        # The same question asked of the *last* attempt rather than the one
+        # that triggered a retry, and kept for a different reason: it is what
+        # the item is finally recorded as. Retrying and reporting used to read
+        # the one computed value and then throw it away, so all thirteen empty
+        # verdicts on the 185-task run were written down as a bare
+        # ``empty_final_text`` -- 60-85 seconds spent per item and no way
+        # afterwards to tell "ran out of room" from "the model refused".
+        last_finalization_reason: Optional[str] = None
 
         while iterations < self.max_iterations + (
             finalization_retries_used if finalization_only else 0
@@ -951,6 +999,11 @@ class ToolCallingJudge:
                 self.max_output_tokens,
                 response_output_tokens,
             )
+            # Overwritten every time, never accumulated: a retry that produced
+            # a good envelope must clear the reason the attempt before it
+            # failed for, or the item would be filed under a failure it
+            # recovered from.
+            last_finalization_reason = retry_reason
             if (
                 retry_reason is not None
                 and finalization_retries_used < self.finalization_retries
@@ -1012,6 +1065,7 @@ class ToolCallingJudge:
             visual_prepass=prepass,
             usage_complete=usage_complete,
             perception_error_detail=perception_error_detail,
+            finalization_reason=last_finalization_reason,
         )
 
     def reset_perception(self) -> None:
@@ -1784,6 +1838,7 @@ class ToolCallingJudge:
         visual_prepass: Optional[VisualPrepassResult] = None,
         usage_complete: bool = True,
         perception_error_detail: Optional[str] = None,
+        finalization_reason: Optional[str] = None,
     ) -> ToolCallingResult:
         tools_used = list(tools_used or [])
         prepass = visual_prepass or VisualPrepassResult()
@@ -1812,7 +1867,7 @@ class ToolCallingJudge:
                 evidence="",
                 confidence=None,
                 reasoning="",
-                judge_error=judge_error or "empty_final_text",
+                judge_error=_empty_text_reason(judge_error, finalization_reason),
                 tool_calls_made=tool_calls_made,
                 iterations=iterations,
                 latency_ms=latency_ms,

--- a/batch-runner/tests/test_an_empty_verdict_says_why_it_was_empty.py
+++ b/batch-runner/tests/test_an_empty_verdict_says_why_it_was_empty.py
@@ -1,0 +1,341 @@
+"""An item the judge never answered must say which kind of silence it was.
+
+On the 185-task gold run thirteen items across ten tasks came back with an
+empty verdict. Each cost 60-85 seconds of grading, and each was written down
+as the bare string ``empty_final_text`` -- the same six words for a model that
+exhausted its output budget, a model whose reply was filtered, and a model
+that simply returned nothing. Afterwards there was no way to tell them apart
+without paying to grade them again, and they need opposite responses: the
+first is fixed by a bigger budget, the second by a different prompt, the third
+by neither.
+
+Nothing was broken. ``_finalization_retry_reason`` already works the answer
+out -- it has to, because whether to retry depends on it -- and the value was
+read once, used for that decision, and then dropped on the floor. These tests
+pin it to the record instead.
+
+The one thing this change must NOT do is move a score: an unanswered item is
+excluded from the denominator today, and it is still excluded now. Making the
+label honest is a separate job from deciding what an unanswered item is worth.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+from core.rubric_loader import RubricItem, TaskRubric
+from core.tool_calling_judge import ToolCallingJudge
+import core.tool_calling_judge as tcj
+
+
+PROMPT_TEMPLATE = (
+    Path(__file__).resolve().parent.parent / "prompts" / "grader_judge_v2.md"
+).read_text(encoding="utf-8")
+
+
+# ── the smallest client that can return a scripted reply ─────────────
+
+def _response(
+    *,
+    output: Optional[list] = None,
+    out_tok: int = 2400,
+    status: Optional[str] = None,
+    incomplete_reason: Optional[str] = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        output=output or [],
+        output_text="",
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=out_tok,
+            input_tokens_details=SimpleNamespace(cached_tokens=7),
+        ),
+        incomplete_details=(
+            SimpleNamespace(reason=incomplete_reason)
+            if incomplete_reason is not None
+            else None
+        ),
+        status=status,
+    )
+
+
+def _envelope() -> dict:
+    return {
+        "type": "message",
+        "content": [{
+            "type": "output_text",
+            "text": json.dumps({
+                "verdict": "pass",
+                "partial_score": 1.0,
+                "evidence": "column A carries the alpha label",
+                "confidence": 0.9,
+                "reasoning": "read the sheet",
+            }),
+        }],
+    }
+
+
+class _Responses:
+    def __init__(self, script: list):
+        self.script = list(script)
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if not self.script:
+            raise AssertionError("scripted client ran out of responses")
+        nxt = self.script.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+
+class _Client:
+    def __init__(self, script: list):
+        self.responses = _Responses(script)
+
+
+@pytest.fixture
+def deliverable_dir(tmp_path: Path) -> Path:
+    openpyxl = pytest.importorskip("openpyxl")
+    workbook = openpyxl.Workbook()
+    workbook.active["A1"] = "alpha"
+    workbook.save(tmp_path / "report.xlsx")
+    return tmp_path
+
+
+@pytest.fixture
+def task_and_item() -> tuple:
+    item = RubricItem(
+        rubric_item_id="r1",
+        criterion="The deliverable contains an 'alpha' label in column A",
+        score=5,
+        required=None,
+    )
+    task = TaskRubric(
+        task_id="t1",
+        sector="Information",
+        occupation="Analyst",
+        prompt="Make a report",
+        rubric_items=[item],
+        rubric_pretty="",
+        reference_files=[],
+        gold_deliverable_files=[],
+    )
+    return task, item
+
+
+def _judge(script: list, **kwargs: Any) -> tuple:
+    client = _Client(script)
+    return ToolCallingJudge(
+        client=client,
+        model="gpt-5.4-mini",
+        prompt_template=PROMPT_TEMPLATE,
+        finalization_retries=kwargs.pop("finalization_retries", 1),
+        **kwargs,
+    ), client
+
+
+def _run(judge, deliverable_dir, task_and_item):
+    task, item = task_and_item
+    return judge.judge_item(
+        task=task,
+        item=item,
+        deliverable_dir=str(deliverable_dir),
+        file_names=["report.xlsx"],
+    )
+
+
+# ── the three kinds of nothing are told apart ────────────────────────
+
+@pytest.mark.parametrize("incomplete_reason, status, expected, why", [
+    (
+        "max_output_tokens", "incomplete", "empty_final_text:max_output_tokens",
+        "the budget ran out -- a bigger cap would have produced a verdict",
+    ),
+    (
+        "content_filter", "incomplete", "empty_final_text:content_filter",
+        "the reply was filtered -- a bigger cap changes nothing here, and "
+        "reading this as a budget problem sends the fix in the wrong direction",
+    ),
+    (
+        None, "failed", "empty_final_text:failed",
+        "the provider named a status and nothing else; it is still more than "
+        "the bare string said",
+    ),
+])
+def test_the_kind_of_silence_is_recorded(
+    deliverable_dir, task_and_item, incomplete_reason, status, expected, why
+):
+    empty = _response(
+        status=status, incomplete_reason=incomplete_reason, out_tok=10
+    )
+    judge, _ = _judge([empty, empty])
+
+    result = _run(judge, deliverable_dir, task_and_item)
+
+    assert result.verdict == "judge_error"
+    assert result.judge_error == expected, why
+
+
+def test_a_silence_nothing_explains_still_beats_the_bare_string(
+    deliverable_dir, task_and_item
+):
+    """No status, no incomplete reason, tokens under the cap: ``unknown``.
+
+    Worth its own test because ``unknown`` is the least informative value the
+    reason can take, and it is exactly where the temptation to fall back to
+    the bare string is strongest. It is still better: the bare string cannot
+    distinguish "we asked and nothing explains it" from "we never asked".
+    """
+    empty = _response(out_tok=10)
+    judge, _ = _judge([empty, empty])
+
+    result = _run(judge, deliverable_dir, task_and_item)
+
+    assert result.judge_error == "empty_final_text:unknown"
+
+
+# ── a recovered item must not be filed under the failure it recovered from ──
+
+def test_a_retry_that_answers_clears_the_reason(deliverable_dir, task_and_item):
+    """The first attempt ran out of room; the second wrote the envelope.
+
+    The reason is overwritten on every attempt rather than remembered from the
+    first, so an item that ended well carries nothing from how it started. If
+    it accumulated instead, every successful retry would look like a failure
+    in the record -- and retries are the common case, not the rare one.
+    """
+    empty = _response(status="incomplete", incomplete_reason="max_output_tokens")
+    judge, client = _judge([empty, _response(output=[_envelope()], out_tok=40)])
+
+    result = _run(judge, deliverable_dir, task_and_item)
+
+    assert result.verdict == "pass"
+    assert result.judge_error is None
+    assert len(client.responses.calls) == 2
+
+
+def test_the_attempt_that_is_recorded_is_the_last_one(
+    deliverable_dir, task_and_item
+):
+    """Ran out of room, then got filtered. It is filed under the filter.
+
+    The overwrite matters most when the two attempts fail differently. Keeping
+    the first reason instead would tell an operator to raise the output cap --
+    which is exactly what the first attempt already did, and it did not help;
+    the second attempt failed for a reason no budget can fix.
+    """
+    judge, _ = _judge([
+        _response(status="incomplete", incomplete_reason="max_output_tokens"),
+        _response(status="incomplete", incomplete_reason="content_filter",
+                  out_tok=10),
+    ])
+
+    result = _run(judge, deliverable_dir, task_and_item)
+
+    assert result.judge_error == "empty_final_text:content_filter"
+
+
+# ── a failure that happened earlier is the more specific cause ───────
+
+def test_an_upstream_error_is_not_relabelled_as_silence(
+    deliverable_dir, task_and_item
+):
+    """The call never returned, so there is no reply to call empty.
+
+    ``final_text`` is "" on this path too, which is why the empty-text branch
+    catches it -- but "the provider raised" is what happened, and overwriting
+    it with a finish reason would describe a response that does not exist.
+    """
+    judge, _ = _judge([RuntimeError("upstream exploded"), RuntimeError("again")])
+
+    result = _run(judge, deliverable_dir, task_and_item)
+
+    assert result.verdict == "judge_error"
+    assert not result.judge_error.startswith("empty_final_text")
+    assert result.judge_error is not None
+
+
+def test_a_tool_call_during_finalization_keeps_its_own_name(
+    deliverable_dir, task_and_item
+):
+    """Same rule, a case the harness rather than the provider decides."""
+    empty = _response(status="incomplete", incomplete_reason="max_output_tokens")
+    calling = _response(output=[{
+        "type": "function_call",
+        "call_id": "c1",
+        "name": "read_deliverable",
+        "arguments": json.dumps({"op": "read_content", "path": "report.xlsx"}),
+    }])
+    judge, _ = _judge([empty, calling])
+
+    result = _run(judge, deliverable_dir, task_and_item)
+
+    assert result.judge_error == "unexpected_tool_call_during_finalization"
+
+
+# ── the label moved; the score did not ───────────────────────────────
+
+def test_an_unanswered_item_is_still_excluded_from_the_score(
+    deliverable_dir, task_and_item
+):
+    """Naming the failure is not the same as deciding what it costs.
+
+    Whether an unanswered item should sit outside the denominator is a live
+    question on its own card. This change must not answer it by accident, in
+    either direction.
+    """
+    empty = _response(status="incomplete", incomplete_reason="content_filter")
+    judge, _ = _judge([empty, empty])
+
+    result = _run(judge, deliverable_dir, task_and_item)
+
+    assert result.score_excluded is True
+    assert result.awarded_score == 0.0
+    assert result.partial_score == 0.0
+
+
+# ── the helper, exercised directly ───────────────────────────────────
+
+def test_an_explicit_error_outranks_the_finish_reason():
+    assert tcj._empty_text_reason(
+        "max_iterations_exceeded", "empty_final_text:max_output_tokens"
+    ) == "max_iterations_exceeded"
+
+
+def test_a_reason_about_something_else_is_not_filed_under_silence():
+    """``final_json_parse_failed`` means the model DID speak, and got the
+    shape wrong. Recording it here would put a talkative failure in the bucket
+    named for a silent one, and the breakdown that reads these strings would
+    report a cause that did not happen.
+    """
+    assert tcj._empty_text_reason(None, "final_json_parse_failed") == (
+        "empty_final_text"
+    )
+    assert tcj._empty_text_reason(None, "invalid_final_envelope") == (
+        "empty_final_text"
+    )
+
+
+def test_no_reason_at_all_falls_back_rather_than_crashes():
+    """The visual prepass calls ``_build_result`` before any reason exists."""
+    assert tcj._empty_text_reason(None, None) == "empty_final_text"
+
+
+def test_the_recorded_reason_and_the_retry_trigger_share_one_spelling():
+    """These two strings are compared to each other, one indirectly.
+
+    ``_finalization_effort`` holds the retry's reasoning down only when the
+    reason is exactly ``_OUT_OF_ROOM_RETRY_REASON``. That value is built from
+    the same constant the recorded reason is built from, so the two cannot
+    drift apart into a silent no-op where the retry quietly stops being
+    cheap.
+    """
+    assert tcj._OUT_OF_ROOM_RETRY_REASON.startswith(f"{tcj._EMPTY_FINAL_TEXT}:")
+    assert tcj._finalization_effort("max", tcj._OUT_OF_ROOM_RETRY_REASON) == "low"

--- a/batch-runner/tests/test_tool_calling_judge.py
+++ b/batch-runner/tests/test_tool_calling_judge.py
@@ -403,7 +403,12 @@ def test_empty_final_retry_budget_exhaustion_stays_fail_closed(
     )
 
     assert result.verdict == "judge_error"
-    assert result.judge_error == "empty_final_text"
+    # Not the bare ``empty_final_text`` this asserted for most of the project's
+    # life. Both attempts ran out of output budget, the judge worked that out
+    # in order to decide whether to retry, and the item is now filed under what
+    # it worked out -- so a reader can tell this apart from a refusal without
+    # re-running the item.
+    assert result.judge_error == "empty_final_text:max_output_tokens"
     assert result.main_api_call_count == 2
     assert result.iterations == 2
     assert len(client.responses.calls) == 2


### PR DESCRIPTION
## What was wrong

Thirteen items across ten tasks on the 185-task gold run came back with no
usable final text. All thirteen were recorded as the same bare string,
`empty_final_text` — 60–85 seconds of grading each, and afterwards no way to
tell them apart without paying to grade them again.

They are not the same failure and they do not have the same fix:

| what happened | what fixes it |
|---|---|
| `max_output_tokens` — the item spent its whole output budget | a larger cap |
| `content_filter` — the provider withheld the reply | nothing a cap can do |
| a failed/incomplete status | depends on the status |
| `unknown` — nothing explains it | neither |

The reason was never missing. `_finalization_retry_reason` computes it already,
because whether to retry at all depends on it. The value was used for the retry
decision and then dropped on the floor, so it survived only in a per-run log
warning — the shard-4 CHANGELOG entry quotes `empty_final_text:max_output_tokens`
from exactly that log line, which is the one place it was ever visible.

## What changed

The reason is carried the last few lines to where the item is recorded. An
empty verdict now reads `empty_final_text:<finish_reason>`.

Three things are deliberately **unchanged**:

- **A failure that happened before the text was read still wins.** An upstream
  error, a tool call during finalization, the iteration cap — each names a more
  specific cause than emptiness, and each already sets `judge_error` before the
  branch is reached.
- **The reason is overwritten on every attempt, never accumulated.** A
  recovered item carries nothing from how it started; an item that failed twice
  differently is filed under the *second* failure rather than the one a bigger
  budget already failed to fix.
- **The item is still excluded from the score.** `score_excluded is True`,
  awarded 0.0, exactly as before. Naming a failure is a separate question from
  deciding what an unanswered item costs, and that one is open on its own card.

Two smaller guarantees:

- `_OUT_OF_ROOM_RETRY_REASON` and the recorded reason are now built from one
  `_EMPTY_FINAL_TEXT` constant. `_finalization_effort` holds the retry's
  reasoning down only on an exact string match against that value, so the two
  spellings cannot drift apart into a silent no-op where the retry quietly
  stops being cheap.
- A `startswith` guard means a future caller cannot file "the JSON did not
  parse" under a bucket named for a model that said nothing at all.

The finish-reason vocabulary is bounded — a provider `incomplete_details`
reason, a status, `max_output_tokens`, or `unknown` — so the suffix groups
rather than fragmenting into one bucket per item.

## Blast radius

Repo-wide grep for consumers of this string: `baseline_empty_final_text` in
`step8_grade.py`, `schemas/grade.schema.json` and
`grading_configs/validation_exp003_v2_sol_max_anchor4.yaml` are all
config-declared **integers**, not parses of this value.
`tests/test_judge_error_breakdown.py` already splits on `":"` and its comment
already says the suffix is expected.

## Verification

- **13 new tests** in `tests/test_an_empty_verdict_says_why_it_was_empty.py`.
  **8 of the 13 fail** with the source change reverted; the other 5 are
  invariants that must hold both before and after (score exclusion, upstream
  error precedence, recovery).
- **Two targeted mutations**, each caught by exactly one test:
  - overwrite → first-wins ⇒ `test_the_attempt_that_is_recorded_is_the_last_one`
  - `startswith` guard removed ⇒ `test_a_reason_about_something_else_is_not_filed_under_silence`
- `test_an_empty_verdict_says_why_it_was_empty.py` + `test_tool_calling_judge.py`
  + `test_judge_error_breakdown.py` → **159 passed**
- Full backend suite → **7200 passed, 10 skipped, 45 deselected** (16m04s)
- mypy error set **byte-identical** to the pre-change baseline (29 pre-existing
  errors in 3 files, unchanged)

## Fingerprint

`core/tool_calling_judge.py` is inside the grader fingerprint set, so this
moves `grader_source_hash`. Checked before pushing: **0 Grade Pipeline runs in
flight** (most recent completed 2026-09-01T08:22Z).
