### PR TITLE
fix(grading): tell a picture apart from a tool failure in the read census

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,26 @@ entries land under a fresh dated heading the day they merge to `main`.
   because none of them can run.
 
 ### Fixed
+- **The repeat-variation report left 92 items standing as tool-failure
+  candidates, and they are not.** The stage-3 analysis has no tool-failure
+  field, so it offered the `read_deliverable` call census in its place, on the
+  plain reading that its zero end is where a verdict was reached without opening
+  the deliverable. Measured across the three runs, all 92 zero-call items are
+  routed `visual`, all 92 have `perception_called: true`, and all 92 carry a
+  non-empty `tools_used` — they rendered the deliverable and looked at the
+  rendering, 25 of them more than once, and `read_deliverable` is not the tool
+  for that. The direction that settles it: 92 of the 231 visual items never call
+  it, and **not one** of the 3,858 text items is in the bucket. A tool failure
+  would not sort itself by routing. `observed_vocabulary` now splits the zero
+  bucket three ways — rendered and looked, some other tool, reached the file no
+  way at all — and only the last is a failure candidate; on these runs it is 0.
+  The `tool_failure` label says it was not measured and disclaims the proxy
+  reading instead of inviting it.
+  `data/grades/_validation/PR3_REPEAT_VARIATION.md` is regenerated (every
+  bootstrap figure reproduces unchanged) and its Korean deferral is replaced
+  with the answer. No published score moves, and the tool is outside
+  `compute_grader_source_hash`, so no grader fingerprint moves either.
+
 - **A task lost 34 of its 63 scoring lines to a picture budget nobody had
   counted.** `judge.perception.visual.call_cap_per_task` was 72 in all thirteen
   grading configurations, and nothing anywhere said where 72 came from. It was

--- a/batch-runner/scripts/analyze_repeat_variation.py
+++ b/batch-runner/scripts/analyze_repeat_variation.py
@@ -829,16 +829,24 @@ def observed_vocabulary(runs: list[dict[str, Any]]) -> dict[str, Any]:
 
     There is no refusal and no tool-failure field in this schema. Reporting
     "refusal rate 0.0%" would read as a measurement, and it is not one: the
-    vocabulary simply never contained the value. The ``read_deliverable``
-    census is the nearest available signal and is labelled a proxy, tail and
-    all -- the interesting end is the zero-call end, where a verdict was
-    reached without opening the deliverable once.
+    vocabulary simply never contained the value.
+
+    The ``read_deliverable`` census used to be offered as the nearest signal
+    for tool failure, on the reading that its zero-call end is where a verdict
+    was reached without opening the deliverable. That reading does not survive
+    contact with the items: an item routed to pictures opens the deliverable by
+    rendering it, and never calls ``read_deliverable`` at all. So the zero
+    bucket is broken out by how the item did reach the file -- a rendering, some
+    other tool, or nothing -- and only the last of those three is a tool-failure
+    candidate.
     """
     counts: dict[str, int] = {v: 0 for v in VERDICT_VOCABULARY}
     modality: dict[str, int] = {}
     selection: dict[str, int] = {}
     decided_by: dict[str, int] = {}
     reads: dict[int, int] = {}
+    never = {"items": 0, "rendered_and_looked": 0, "other_tools_only": 0}
+    never_modality: dict[str, int] = {}
     for run in runs:
         for item in _item_index(run).values():
             counts[item["verdict"]] += 1
@@ -848,20 +856,37 @@ def observed_vocabulary(runs: list[dict[str, Any]]) -> dict[str, Any]:
             selection[status] = selection.get(status, 0) + 1
             decider = str(item.get("decided_by"))
             decided_by[decider] = decided_by.get(decider, 0) + 1
-            calls = sum(
-                1
-                for tool in (item.get("tools_used") or [])
-                if tool == "read_deliverable"
-            )
+            tools = list(item.get("tools_used") or [])
+            calls = sum(1 for tool in tools if tool == "read_deliverable")
             reads[calls] = reads.get(calls, 0) + 1
+            if calls:
+                continue
+            never["items"] += 1
+            never_modality[key] = never_modality.get(key, 0) + 1
+            if item.get("perception_called"):
+                never["rendered_and_looked"] += 1
+            elif tools:
+                never["other_tools_only"] += 1
 
     graded = sum(counts.values())
     return {
         "verdicts": counts,
         "judge_error_rate_pct": 100.0 * counts["judge_error"] / graded,
         "refusal": "not in this schema and not observed - absent, not measured",
-        "tool_failure": "no field exists - the read census below is a proxy",
+        "tool_failure": (
+            "no field exists - not measured. The zero end of the read census "
+            "was offered as a proxy and is not one: see never_read"
+        ),
         "read_deliverable_calls": dict(sorted(reads.items())),
+        "never_read": {
+            **never,
+            # Whatever is left reached the deliverable no way at all, and is
+            # the only part of this bucket worth calling a failure candidate.
+            "no_tool_at_all": never["items"]
+            - never["rendered_and_looked"]
+            - never["other_tools_only"],
+            "by_modality": dict(sorted(never_modality.items())),
+        },
         "routing_modality": dict(sorted(modality.items())),
         "selection_status": dict(sorted(selection.items())),
         "decided_by": dict(sorted(decided_by.items())),
@@ -1254,6 +1279,20 @@ def _render(report: dict[str, Any]) -> str:
         for calls, count in vocabulary["read_deliverable_calls"].items()
     )
     lines.append(f"  read_deliverable per item  {census}")
+    never = vocabulary["never_read"]
+    lines.append(
+        f"    of the {never['items']} that never called it: "
+        f"{never['rendered_and_looked']} rendered it and looked, "
+        f"{never['other_tools_only']} used some other tool, "
+        f"{never['no_tool_at_all']} reached the file no way at all"
+    )
+    lines.append(
+        "    and they were routed  "
+        + "   ".join(
+            f"{name} {count}"
+            for name, count in never["by_modality"].items()
+        )
+    )
     modality = "   ".join(
         f"{name} {count}" for name, count in vocabulary["routing_modality"].items()
     )

--- a/batch-runner/tests/test_repeat_variation_analysis.py
+++ b/batch-runner/tests/test_repeat_variation_analysis.py
@@ -602,7 +602,9 @@ def test_what_was_not_measured_says_so_rather_than_reporting_zero(report):
 
     assert "not measured" in vocabulary["refusal"]
     assert "no field exists" in vocabulary["tool_failure"]
-    assert "proxy" in vocabulary["tool_failure"]
+    # And the census is not offered in its place. It was, and the next test is
+    # why it is not any more.
+    assert "is not one" in vocabulary["tool_failure"]
 
 
 def test_the_judge_error_rate_is_reported_as_the_small_number_it_is(report):
@@ -627,6 +629,58 @@ def test_items_decided_without_reading_the_deliverable_are_surfaced(report):
     assert census[0] == 92
     assert sum(census.values()) == 4299
     assert max(census) == 6
+
+
+def test_the_zero_read_items_all_opened_the_file_as_a_picture(report):
+    """The 92 are not a tool failure, and this is the measurement that says so.
+
+    The report used to leave them as a candidate, on the plain reading that a
+    verdict reached without calling ``read_deliverable`` is a verdict reached
+    without opening the deliverable. Every one of them opened it. They are
+    routed to pictures, so they render the file and look at the rendering, and
+    ``read_deliverable`` is not the tool for that.
+
+    The direction that settles it is the one below the split: 92 of the 231
+    visual items never call it, and not one of the 3,858 text items is in the
+    bucket at all. A tool failure would not sort itself by routing.
+    """
+    vocabulary = report["vocabulary"]
+    never = vocabulary["never_read"]
+
+    assert never["items"] == vocabulary["read_deliverable_calls"][0]
+    assert never["rendered_and_looked"] == 92
+    assert never["other_tools_only"] == 0
+    assert never["no_tool_at_all"] == 0
+    assert never["by_modality"] == {"visual": 92}
+    assert vocabulary["routing_modality"]["visual"] == 231
+    assert vocabulary["routing_modality"]["text"] == 3858
+
+
+def test_an_item_that_reached_the_file_no_way_at_all_is_told_apart(runs):
+    """The negative control, because the split above is worth nothing without
+    it.
+
+    A bucket that reported everything as ``rendered_and_looked`` would produce
+    exactly the figures the previous test asserts, and would be wrong the first
+    time an item genuinely failed to reach its deliverable. So one item is
+    stripped of its perception and its tools, and it has to move.
+    """
+    before = rv.observed_vocabulary(runs)
+    stripped = next(
+        item
+        for task in runs[0]["tasks"]
+        for item in task["items"]
+        if "read_deliverable" not in (item.get("tools_used") or [])
+    )
+    stripped["perception_called"] = False
+    stripped["tools_used"] = []
+
+    after = rv.observed_vocabulary(runs)
+
+    assert before["never_read"]["rendered_and_looked"] == 92
+    assert after["never_read"]["items"] == before["never_read"]["items"]
+    assert after["never_read"]["rendered_and_looked"] == 91
+    assert after["never_read"]["no_tool_at_all"] == 1
 
 
 def test_the_money_column_stays_unregistered_and_never_zero(report):

--- a/data/grades/_validation/PR3_REPEAT_VARIATION.md
+++ b/data/grades/_validation/PR3_REPEAT_VARIATION.md
@@ -165,8 +165,10 @@ what was actually observed (metric 3, section 9)
   pass 3175   partial 585   fail 535   judge_error 4
   judge_error rate 0.0930%
   refusal        not in this schema and not observed - absent, not measured
-  tool failure   no field exists - the read census below is a proxy
+  tool failure   no field exists - not measured. The zero end of the read census was offered as a proxy and is not one: see never_read
   read_deliverable per item  0x 92   1x 2855   2x 516   3x 822   4x 8   5x 2   6x 4
+    of the 92 that never called it: 92 rendered it and looked, 0 used some other tool, 0 reached the file no way at all
+    and they were routed  visual 92
   routing modality  formatting 207   mixed 3   text 3858   visual 231
 
 cost and latency per run (metric 6)
@@ -276,14 +278,28 @@ VERDICT  MET
 | | 관측 |
 |---|---|
 | 거부(refusal) | **이 스키마에 필드가 없고 관측되지도 않았다.** "거부율 0%"라고 쓰면 잰 것처럼 읽히는데, 잰 적이 없다 |
-| 도구 실패 | 전용 필드가 없다. `read_deliverable` 호출 횟수 분포가 대용물이고, 그렇게 표시한다 |
+| 도구 실패 | 전용 필드가 없어 **재지 않았다.** 호출 횟수 분포의 0회 칸을 대용물로 쓰자는 얘기가 있었는데, 대용물이 아니다(바로 아래) |
 | 판정 실패 | 4건 / 4,299짝 = 0.093%. `score_excluded`와 **완전히 같은 4건**이다 |
 | 음성 | **0개.** 307·310~312에서 관측된 음성 판정 흔들림은 구조적으로 이 구간 안에 들어올 수 없다 |
 | 선택 실패 | 4,299/4,299 `ok` |
 | 과제 오류 | 세 실행 모두 0 |
 
-`read_deliverable`를 **한 번도 부르지 않고** 판정한 항목이 92개 있다. 효율이
-아니라 도구 실패 후보로 보는 쪽이 맞고, 후속으로 넘긴다.
+`read_deliverable`를 **한 번도 부르지 않고** 판정한 항목이 92개 있다. 도구 실패
+후보로 보고 후속으로 넘겼던 건인데, 답이 나왔다. **도구 실패가 아니다.**
+
+92개 전부가 그림으로 가는 항목이고(`routing_modality: visual`), 92개 전부가
+그림을 실제로 만들어서 봤다(`perception_called: true`, 쓴 도구는
+`harness_render_to_image` + `harness_vision_perception`, 그중 25개는 두 번 이상).
+도구를 하나도 못 쓴 항목은 0개고, 판정도 pass 78 · partial 14로 판정 실패가
+하나도 없다.
+
+즉 **산출물을 안 연 게 아니라, 글자 대신 그림으로 열었다.** 그림으로 가는 항목은
+`read_deliverable`을 부를 일이 애초에 없다. 방향을 뒤집으면 더 분명하다. 그림으로
+간 231개 중 92개가 이렇고, 글자로 간 3,858개 중에는 **한 개도** 이렇지 않다.
+
+그래서 도구가 이제 0회 칸을 세 갈래로 쪼개 찍는다 — 그림으로 봤다 / 다른 도구를
+썼다 / 파일에 아예 닿지 못했다. 실패 후보는 마지막 하나뿐이고, 이 실행에서는
+0이다.
 
 ## 비용
 


### PR DESCRIPTION
## What this changes

The stage-3 repeat-variation analysis has no tool-failure field. It offered the `read_deliverable` call census in its place — labelled `"no field exists - the read census below is a proxy"` — on the plain reading that the zero-call end is where a verdict was reached without opening the deliverable. `data/grades/_validation/PR3_REPEAT_VARIATION.md` carried that reading forward and deferred it:

> `read_deliverable`를 **한 번도 부르지 않고** 판정한 항목이 92개 있다. 효율이 아니라 도구 실패 후보로 보는 쪽이 맞고, 후속으로 넘긴다.

Measured across the three runs, they are not failures.

| | 92 zero-call items |
|---|---|
| `routing_modality` | `visual` **92 / 92** |
| `perception_called` | `true` **92 / 92** |
| empty `tools_used` | **0** |
| tools used | `harness_render_to_image` + `harness_vision_perception` (25 of them more than once) |
| verdicts | pass 78, partial 14 — no `judge_error` |

They opened the deliverable. They opened it as a picture, and `read_deliverable` is not the tool for that.

The direction that settles it is routing: **92 of the 231 visual items never call it, and not one of the 3,858 text items is in the bucket at all.** A tool failure would not sort itself by modality.

## The change

`observed_vocabulary` splits the zero bucket by how the item did reach the file — a rendering, some other tool, or nothing at all — and only the last is a failure candidate. On these runs it is 0.

```diff
   read_deliverable per item  0x 92   1x 2855   2x 516   3x 822   4x 8   5x 2   6x 4
+    of the 92 that never called it: 92 rendered it and looked, 0 used some other tool, 0 reached the file no way at all
+    and they were routed  visual 92
```

The `tool_failure` label now says it was not measured and disclaims the proxy reading rather than inviting it.

## What did not move

The report's generated block is regenerated from the command it records, and **every bootstrap figure in it reproduces unchanged** — the only lines that move are the label and the two new ones. No published score moves. `scripts/analyze_repeat_variation.py` is not in `compute_grader_source_hash`, so **no grader fingerprint moves** and this is not gated on in-flight grading.

## Verification

- `test_the_zero_read_items_all_opened_the_file_as_a_picture` — the measurement above, off the report object.
- `test_an_item_that_reached_the_file_no_way_at_all_is_told_apart` — the negative control. A bucket that reported everything as rendered-and-looked would produce exactly the figures the other test asserts, so one item is stripped of its perception and its tools and has to move. Confirmed failing (`assert 92 == 91`) against a deliberately broken split.
- `test_repeat_variation_report_quotes_its_run.py` re-runs the report's own command and demands byte equality — passes.
- Full backend suite: **7216 passed, 10 skipped**. `mypy core/`: 174 errors in 32 files (unchanged baseline); the changed script is clean.
