### PR TITLE
test(grading): pick the superseded shard by what differs, not by directory order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,19 @@ entries land under a fresh dated heading the day they merge to `main`.
   because none of them can run.
 
 ### Fixed
+- **A guard against mixing two graders was being decided by filesystem
+  order.** `test_a_shard_from_a_superseded_grader_cannot_join_this_run` merges
+  a current shard with one graded by superseded code and asserts the refusal
+  names `grader_source_hash`. It got that older shard from
+  `iterdir()`'s first entry — and two superseded passes are committed side by
+  side. One differs from the current run only in the grader source; the other
+  also carries a different judge config, which `step9` refuses on *first*, so
+  the refusal never mentions a grader at all. On identical bytes the test
+  passed on one machine and failed on CI. The sibling is now chosen by reading
+  the payloads for the difference the test is about — same `judge.config_hash`,
+  different `grader_source_hash` — and a new test pins both ends of that
+  choice, including that the sibling it rejects really would have swallowed the
+  assertion. Restoring the old selection turns both tests red.
 - **A task lost 34 of its 63 scoring lines to a picture budget nobody had
   counted.** `judge.perception.visual.call_cap_per_task` was 72 in all thirteen
   grading configurations, and nothing anywhere said where 72 came from. It was

--- a/batch-runner/tests/test_the_partial_gold_run_cannot_read_as_final.py
+++ b/batch-runner/tests/test_the_partial_gold_run_cannot_read_as_final.py
@@ -60,22 +60,47 @@ def _shard_paths() -> list[Path]:
 
 
 def _superseded_shard_path() -> Path:
-    """One shard from the earlier pass, whichever it is.
+    """One shard graded by superseded code *at this judge config*.
 
     The cost-receipt work touched ``core/`` and so moved the grader source
     hash, orphaning the shards graded before it. They were committed and are
     still on disk one directory across from the current run.
+
+    Which of them is handed back is not a detail. More than one earlier pass is
+    committed and they do not all differ from the current run in the same way:
+    one differs only in the grader source, another also carries a different
+    judge config. The merge refuses on the config before it ever looks at the
+    source hash, so a caller asking "does a different grader stop this merge?"
+    that is handed the second one gets a refusal it did not ask about and a
+    green test that proves nothing.
+
+    This used to take ``iterdir()``'s first entry, which is filesystem order --
+    it picked the right sibling on one machine and the wrong one on CI. So the
+    sibling is now chosen by reading the payloads for the difference the caller
+    is asking about: same ``judge.config_hash``, different ``grader_source_hash``.
     """
-    siblings = [
+    current = json.loads(_shard_paths()[0].read_text(encoding="utf-8"))
+    siblings = sorted(
         entry
         for entry in inventory.SHARD_DIR.parent.iterdir()
         if entry.is_dir() and entry != inventory.SHARD_DIR
-    ]
-    if not siblings:
-        pytest.skip("no superseded shard directory is committed any more")
-    payloads = sorted(siblings[0].glob("shard-*.json"))
-    assert payloads, f"{siblings[0]} holds no shard payloads"
-    return payloads[0]
+    )
+    for sibling in siblings:
+        payloads = sorted(sibling.glob("shard-*.json"))
+        assert payloads, f"{sibling} holds no shard payloads"
+        payload = json.loads(payloads[0].read_text(encoding="utf-8"))
+        same_config = payload.get("judge", {}).get("config_hash") == current.get(
+            "judge", {}
+        ).get("config_hash")
+        moved_source = payload.get("grader_source_hash") != current.get(
+            "grader_source_hash"
+        )
+        if same_config and moved_source:
+            return payloads[0]
+    pytest.skip(
+        "no shard from a superseded grader at this judge config is committed "
+        "any more"
+    )
 
 
 def test_every_committed_gold_shard_still_calls_itself_partial():
@@ -179,6 +204,57 @@ def test_a_shard_from_a_superseded_grader_cannot_join_this_run(
         "graders may no longer be what stops it"
     )
     assert not out.exists()
+
+
+def test_the_superseded_shard_is_chosen_for_the_difference_being_tested(
+    tmp_path, capsys
+):
+    """Why the test above does not take whatever the filesystem hands it first.
+
+    Two earlier passes are committed side by side. One differs from the current
+    run only in the grader source. The other also carries a different judge
+    config, and ``step9`` refuses that one on the config without ever reaching
+    the source hash -- so handing it to the test above would produce a refusal
+    that says nothing about graders, and a green test.
+
+    Which one arrived used to be ``iterdir()``'s first entry, which is
+    filesystem order. On identical bytes it picked the right sibling on one
+    machine and the wrong one on CI, where the assertion above failed. So the
+    selection is pinned here from both ends: what comes back differs in the
+    grader and only in the grader, and the sibling that does not qualify really
+    would have swallowed the refusal being asserted.
+    """
+    current_path = _shard_paths()[0]
+    current = json.loads(current_path.read_text(encoding="utf-8"))
+    chosen = json.loads(_superseded_shard_path().read_text(encoding="utf-8"))
+
+    assert chosen["judge"]["config_hash"] == current["judge"]["config_hash"]
+    assert chosen["grader_source_hash"] != current["grader_source_hash"]
+
+    decoys = [
+        payloads[0]
+        for sibling in sorted(
+            entry
+            for entry in inventory.SHARD_DIR.parent.iterdir()
+            if entry.is_dir() and entry != inventory.SHARD_DIR
+        )
+        for payloads in [sorted(sibling.glob("shard-*.json"))]
+        if payloads
+        and json.loads(payloads[0].read_text(encoding="utf-8"))
+        .get("judge", {})
+        .get("config_hash")
+        != current["judge"]["config_hash"]
+    ]
+    if not decoys:
+        pytest.skip("only one kind of superseded shard is committed now")
+
+    for decoy in decoys:
+        out = tmp_path / f"{decoy.parent.name[-16:]}.json"
+        assert s9.main([str(current_path), str(decoy), "-o", str(out)]) == 1
+        assert "grader_source_hash" not in capsys.readouterr().err, (
+            f"{decoy.parent.name} now reports the grader hash too, so it is no "
+            "longer a decoy; picking siblings by hand may no longer be needed"
+        )
 
 
 def test_the_analyzer_refuses_a_payload_that_is_still_partial():


### PR DESCRIPTION
## What broke

`tests/test_the_partial_gold_run_cannot_read_as_final.py::test_a_shard_from_a_superseded_grader_cannot_join_this_run` failed on CI (run `33650873490`, PR #377) against bytes that are identical to a green `main`. It is not a code change that broke it — the test picks its own fixture by filesystem order.

## Why

The test merges a current shard with one graded by superseded code and asserts the refusal names `grader_source_hash`. `_superseded_shard_path()` took `iterdir()`'s **first** entry from the shard directory's siblings. Two superseded passes are committed there, and they are not interchangeable:

| sibling | `judge.config_hash` | `grader_source_hash` | step9 refuses on |
|---|---|---|---|
| `…__src_ce7d4978bce9effc__v2.2` | `b3609ec13f8fa51e` — same | `ce7d4978…` — moved | **`grader_source_hash`** ✅ |
| `…__src_79c2f5035c4aa826__v2.2` | `f9c5f7bab9bd1530` — different | `79c2f503…` — moved | `judge.config_hash` ❌ |

step9 checks the config before the grader source, so the second sibling produces a refusal that says nothing about graders. Reproduced locally against both:

```
sibling: …__src_ce7d4978bce9effc__v2.2
rc: 1 | grader_source_hash in stderr: True
ERROR: shard merge failed: shard merge identity mismatch for grader_source_hash: …

sibling: …__src_79c2f5035c4aa826__v2.2
rc: 1 | grader_source_hash in stderr: False
ERROR: shard merge failed: shard merge identity mismatch for judge.config_hash: …
```

`Path.iterdir()` is directory order, not sorted. Locally it yields the first; the CI runner yielded the second.

## The fix

Choose the sibling by reading the payloads for the difference the test is about — **same `judge.config_hash`, different `grader_source_hash`** — rather than by whatever the filesystem returns. Skips with a specific reason if no such shard is committed any more.

A new test, `test_the_superseded_shard_is_chosen_for_the_difference_being_tested`, pins both ends of that choice:
- what comes back differs in the grader **and only** in the grader;
- each sibling it rejects is merged too, and shown to refuse **without** naming `grader_source_hash` — so the selection is provably load-bearing, not decoration.

## Verification

- `tests/test_the_partial_gold_run_cannot_read_as_final.py` — **11 passed** (was 10).
- **Negative control**: restoring the old "first sibling wins" selection turns **both** tests red, and the cross-hash one fails with exactly the CI message. Restored → 11 passed again.
- `-k "changelog or inventory or stage3"` — 15 passed, 2 skipped.

## Scope

Test-only. No production code, no config, no grading data. `tests/` is not part of `compute_grader_source_hash`'s fingerprint set, so **no grader fingerprint moves** and this is not gated on in-flight grading.