### PR TITLE
fix(azure): tell a control-plane read that never ran from one that came back empty

### DIFF
--- a/.github/workflows/azure-rbac-diagnostic.yml
+++ b/.github/workflows/azure-rbac-diagnostic.yml
@@ -17,11 +17,11 @@
 # whatever subscription and identity the `az` session holds, and a login taken
 # on a development box or in an agent container is a different one of each: the
 # Foundry account this asks about is not in the subscription such a login
-# reaches. The lookup then comes back empty for the same reason a withheld role
-# does, the run stops at `cannot_read_control_plane`, and the note beside it
-# says the identity has no reader on the account -- which is not what was
-# measured, because the identity was never reached. Run it here, or do not run
-# it.
+# reaches, and usually that subscription is not even in the session. `az` then
+# refuses the lookup outright, the run stops at
+# `control_plane_read_never_completed`, and the note beside it says nothing was
+# measured -- which is the truth, because the account was never looked up. Run
+# it here, or do not run it.
 name: Azure Foundry RBAC Diagnostic
 
 on:

--- a/batch-runner/scripts/azure_rbac_diagnostic.py
+++ b/batch-runner/scripts/azure_rbac_diagnostic.py
@@ -19,18 +19,20 @@ Through its workflow, in CI. Not from a development box, and not from the agent
 container.
 
 What this reads is whatever subscription and identity the ``az`` session is
-signed into, and a login taken outside CI is a different one of each. The
-subscription such a login reaches does not contain the Foundry account this asks
-about, so ``resolve_resource_group`` gets nothing back and the run stops at
-``cannot_read_control_plane``.
+signed into, and a login taken outside CI is a different one of each. Such a
+login is not signed into the subscription holding the Foundry account, so ``az``
+refuses the lookup outright -- it exits non-zero and names the subscription as
+not found, rather than answering with an empty list. The run stops at
+``control_plane_read_never_completed``.
 
-That verdict is honest as far as it goes. The sentence recorded beside it is
-not: it reads "that alone means this identity has no reader on the account",
-which is a true inference only when the lookup went to the right subscription.
-From the wrong one the identity was never asked about at all, because an absent
-resource and a withheld role come back through the control plane looking the
-same. A local run therefore cannot answer this question, and it cannot answer it
-in the negative either.
+The two failures are kept apart deliberately, because they license opposite
+conclusions. When az answers and the account is not in the answer, this identity
+genuinely cannot see it: an absent resource and a withheld role come back
+through the control plane looking the same, and either is a real finding about
+the account. When az never answers, the account was not looked up at all, and
+the run says nothing about roles in either direction. Reporting the second as
+the first sends the next reader hunting a missing role in a directory that never
+held the resource.
 
 ``AZURE_SUBSCRIPTION_ID`` is required rather than defaulted, below, so the
 script cannot quietly inherit whichever subscription a local login happens to
@@ -478,11 +480,28 @@ def leaked_placeholders(text: str, secrets: Mapping[str, str]) -> tuple[str, ...
 
 
 class AzureReadFailure(RuntimeError):
-    """An az read failed. Carries a classification, never the provider text."""
+    """An az read failed. Carries a classification, never the provider text.
 
-    def __init__(self, what: str, *, exit_code: int | None) -> None:
+    ``completed`` separates the two ways a read can fail, which are different
+    facts and support different conclusions:
+
+    * ``completed=True``  -- az ran the query, returned parseable output, and
+      the thing being looked for was not in it. Azure answered.
+    * ``completed=False`` -- az did not answer at all: it exited non-zero, or
+      returned something that would not parse. The question never reached the
+      resource, so nothing at all was learned about it.
+
+    Only the first supports an inference about what this identity can see. The
+    default is the second, so a new raise site has to opt in to the stronger
+    claim rather than inherit it.
+    """
+
+    def __init__(
+        self, what: str, *, exit_code: int | None, completed: bool = False
+    ) -> None:
         self.what = what
         self.exit_code = exit_code
+        self.completed = completed
         detail = "no exit code" if exit_code is None else f"exit {exit_code}"
         super().__init__(f"{what} could not be read ({detail})")
 
@@ -528,8 +547,13 @@ def resolve_resource_group(
     """Ask Azure where the Foundry account lives.
 
     No secret and no repository variable records the resource group, so it has
-    to come from Azure itself. Failing to read it is a finding in its own right:
-    it means the principal has no control-plane read on the account.
+    to come from Azure itself.
+
+    An answered query that does not contain the account is a finding in its own
+    right: the account is either absent from this subscription or withheld from
+    this principal, and the control plane returns both the same way. That is the
+    ``completed=True`` raise below. A query az never completed is not that
+    finding, and is raised without the flag by the runner.
     """
     payload = runner(
         [
@@ -550,7 +574,7 @@ def resolve_resource_group(
         derived = resource_group_of(str(resource.get("id", "")))
         if derived:
             return derived
-    raise AzureReadFailure("the Foundry account", exit_code=None)
+    raise AzureReadFailure("the Foundry account", exit_code=None, completed=True)
 
 
 def read_assignments(
@@ -655,13 +679,24 @@ def diagnose(
             runner, account=endpoint.account, subscription_id=subscription_id
         )
     except AzureReadFailure as failure:
-        problems.append(
-            "could not resolve the Foundry account through the control plane, "
-            "so the project scope could not be built. That alone means this "
-            f"identity has no reader on the account ({failure.what})"
-        )
+        if failure.completed:
+            problems.append(
+                "could not resolve the Foundry account through the control "
+                "plane, so the project scope could not be built. Azure "
+                "answered and the account was not in the answer, which means "
+                f"this identity has no reader on it ({failure.what})"
+            )
+            report["verdict"] = "cannot_read_control_plane"
+        else:
+            problems.append(
+                "the Foundry account lookup did not complete, so the project "
+                "scope could not be built. az did not answer the query, which "
+                "is how a subscription this session is not signed into fails, "
+                "so the account was never looked up and no role was measured "
+                f"({failure.what})"
+            )
+            report["verdict"] = "control_plane_read_never_completed"
         report["read_failures"] = problems
-        report["verdict"] = "cannot_read_control_plane"
         return report
 
     scope = project_scope(
@@ -766,6 +801,12 @@ _VERDICT_LINES: Mapping[str, str] = {
     "cannot_read_control_plane": (
         "This identity cannot read the Foundry account through the control "
         "plane, so no role could be read. An owner has to look."
+    ),
+    "control_plane_read_never_completed": (
+        "The account lookup did not complete, so nothing was measured. This "
+        "is what a subscription the session is not signed into looks like, "
+        "and it is not evidence that a role is missing. Re-run it where the "
+        "signed-in subscription is the one holding the project."
     ),
     "cannot_read_role_assignments": (
         "This identity cannot read its own role assignments at the project "

--- a/batch-runner/tests/test_azure_rbac_diagnostic.py
+++ b/batch-runner/tests/test_azure_rbac_diagnostic.py
@@ -503,7 +503,7 @@ def test_an_identity_that_can_assign_is_told_so_rather_than_sent_to_an_owner():
     assert report["principal_can_assign_roles"] is True
 
 
-def test_a_control_plane_that_will_not_answer_is_a_finding_not_an_empty_result():
+def test_a_control_plane_that_answers_without_the_account_is_a_finding():
     az = FakeAz(resources=[], assignments=[], definitions=[])
     report = diagnostic.diagnose(_env(), runner=az)
     assert report["verdict"] == "cannot_read_control_plane"
@@ -512,6 +512,68 @@ def test_a_control_plane_that_will_not_answer_is_a_finding_not_an_empty_result()
     # as a measured zero.
     assert report["roles_held"] == []
     assert len(az.calls) == 1
+    # az answered, and the account was not in the answer. That is a real fact
+    # about what this identity can see, so the stronger sentence is earned.
+    assert "no reader" in " ".join(report["read_failures"])
+
+
+def test_a_lookup_az_never_completed_is_not_reported_as_a_missing_reader():
+    """The failure a login taken outside CI actually produces.
+
+    ``az resource list --subscription <one this session is not signed into>``
+    exits non-zero without querying anything; it does not come back with an
+    empty list. Both used to land on the same verdict and the same sentence,
+    and that sentence -- "this identity has no reader on the account" -- is an
+    inference about a resource nobody asked Azure about. It sends the next
+    reader hunting a role to grant in a directory that never held the project.
+    """
+    az = FakeAz(resources=None, assignments=[], definitions=[])
+    report = diagnostic.diagnose(_env(), runner=az)
+    assert report["verdict"] == "control_plane_read_never_completed"
+    assert report["read_failures"]
+    assert report["roles_held"] == []
+    assert len(az.calls) == 1
+    assert "no reader" not in " ".join(report["read_failures"])
+
+
+def test_the_two_control_plane_failures_do_not_read_the_same_way():
+    answered = diagnostic.render(
+        diagnostic.diagnose(
+            _env(), runner=FakeAz(resources=[], assignments=[], definitions=[])
+        )
+    )
+    unanswered = diagnostic.render(
+        diagnostic.diagnose(
+            _env(), runner=FakeAz(resources=None, assignments=[], definitions=[])
+        )
+    )
+    assert answered != unanswered
+    assert "no reader" in answered
+    assert "no reader" not in unanswered
+    assert "nothing was measured" in unanswered.lower()
+
+
+def test_a_lookup_that_never_completed_still_fails_the_project_role_gate():
+    """A new verdict must not open the gate by not being on a deny list.
+
+    The gate names the one verdict that passes rather than the ones that fail,
+    so an unmeasured run stays closed without anything here being updated.
+    """
+    code, text = _run_main(
+        ["--require-project-role"],
+        FakeAz(resources=None, assignments=[], definitions=[]),
+    )
+    assert code == 1
+    assert "control_plane_read_never_completed" in text
+
+
+def test_every_verdict_the_diagnosis_can_reach_has_a_sentence_written_for_it():
+    # Without this, a verdict added later renders under the fallback line and
+    # reads as though nothing was measured, whatever it actually found.
+    source = SCRIPT.read_text(encoding="utf-8")
+    reachable = set(re.findall(r'report\["verdict"\] = "([a-z_]+)"', source))
+    assert reachable, "the verdict assignments moved; this check went vacuous"
+    assert reachable <= set(diagnostic._VERDICT_LINES)
 
 
 def test_being_unable_to_read_its_own_assignments_is_not_reported_as_none_held():


### PR DESCRIPTION
## What was wrong

`batch-runner/scripts/azure_rbac_diagnostic.py` collapsed two different
control-plane failures into one verdict, and recorded the same sentence beside
both of them:

> could not resolve the Foundry account through the control plane, so the
> project scope could not be built. **That alone means this identity has no
> reader on the account**

Only one of the two failures supports that claim.

Measured with read-only `az` reads, on a login that is not the CI one:

| situation | az behaviour |
|---|---|
| the subscription is not in this `az` session | exit **1**, empty stdout, "subscription not found" on stderr |
| a reachable subscription, resource absent or withheld | exit **0**, stdout `[]` |

The second is a real finding: Azure answered, and the account was not in the
answer. An absent resource and a withheld role come back looking the same, and
either one means this identity cannot see it.

The first is not a finding at all. The account was never looked up. Nothing was
learned about roles in either direction — and reporting it as a missing reader
sends the next person hunting a role to grant against a resource that the
directory they are signed into does not contain.

That is not hypothetical: it is precisely what a run from outside CI produces,
and it is the trap both the module docstring and the workflow header described
the wrong way round. The distinction already reached the code — as
`AzureReadFailure.exit_code` — and `diagnose` threw it away.

## The change

- `AzureReadFailure` gains `completed: bool`, **defaulting to `False`** so a new
  raise site has to opt in to the stronger claim rather than inherit it.
- `resolve_resource_group`'s fall-through — az answered, the account was not in
  the answer — opts in with `completed=True`.
- `diagnose` splits on it. `completed=True` keeps `cannot_read_control_plane`
  and its (now correct) sentence; `completed=False` gets the new verdict
  `control_plane_read_never_completed`, whose sentence says nothing was
  measured and that this is not evidence a role is missing.
- Module docstring and workflow header corrected to match what az actually does.

Deliberately branching on `completed` rather than on `exit_code`: the
JSON-decode path also carries `exit_code=None` while being an incomplete read,
so an exit-code test would have mis-sorted it. An explicit flag with the safe
default cannot.

## Fail-closed, verified

`--require-project-role` names the one verdict that **passes** rather than the
ones that fail, so the new verdict is closed without anything being added to the
gate. A test pins that rather than trusting it.

A second test asserts every verdict `diagnose` can reach has a sentence written
for it, so a verdict added later cannot silently render under the
`"Nothing was measured."` fallback. It was mutation-checked: removing the new
`_VERDICT_LINES` entry makes it fail, and it carries a non-vacuity assertion in
case the assignment pattern moves.

## Blast radius

None outside this script. It is not part of the grader source fingerprint
(`compute_grader_source_hash` takes exactly one file from `scripts/`, and it is
not this one), so no held or in-flight grading PR is affected. Every az call it
makes is still a control-plane read that creates, updates and deletes nothing,
and it still calls no model endpoint.

## Verification

- `pytest tests/test_azure_rbac_diagnostic.py` — **80 passed**
- full backend suite from `batch-runner/` — **7221 passed, 10 skipped, 45 deselected, 0 failed** (16:36)
- `mypy scripts/azure_rbac_diagnostic.py --ignore-missing-imports` — clean
- `mypy core/` unchanged from main (174 pre-existing errors, none in files this touches)
- cost: **zero**. No model call, no grading dispatch, no Azure write.
