### PR TITLE
feat(grading): bound the audio flip rate at the task unit, and say when it cannot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/check_grader_hash_freeze.py
 !batch-runner/scripts/azure_rbac_diagnostic.py
 !batch-runner/scripts/analyze_repeat_variation.py
+!batch-runner/scripts/analyze_audio_repeat_variation.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/batch-runner/scripts/analyze_audio_repeat_variation.py
+++ b/batch-runner/scripts/analyze_audio_repeat_variation.py
@@ -1,0 +1,1243 @@
+#!/usr/bin/env python3
+"""How far the grader moves on *listening* criteria when it grades them again.
+
+Why this exists
+---------------
+The repeat-variation card asks for a confidence interval on how often the
+grader changes its mind about an audio criterion between two gradings of the
+same answers. The figure quoted for that was 38%, and it was not usable: it was
+a difference between two smokes at different grader fingerprints, so it
+measured the code change at least as much as the grader.
+
+``gold_audio_repeat_v2_sol_max`` was pinned to fix that -- every gold task the
+grader actually listens to, three of them, the whole population rather than a
+sample -- and three runs of it were bought at one fingerprint. This tool reads
+those three and reports what they support.
+
+Everything here is a read. No grade payload is rewritten and no model is
+called, so running this costs nothing.
+
+Why a second tool instead of an option on the first
+---------------------------------------------------
+``analyze_repeat_variation.py`` answers the same question for a thirty-task
+cohort, and ``tests/test_repeat_variation_report_quotes_its_run.py`` re-runs
+the command that file's result document records and compares the output byte
+for byte. Adding a mode to it would have to keep that block identical while
+changing the code that produces it, which is a promise rather than a check.
+
+So this is a sibling. It imports that module's *arithmetic* -- the percentile,
+the cluster bootstrap, the item index -- because two implementations of one
+formula is how two answers quietly stop agreeing. It imports none of that
+module's *constants*, because those are a different cohort's registration and
+sharing them would silently move this cohort's numbers whenever that one was
+re-registered. The one thing checked rather than shared is that the two
+registrations still agree where they must: see ``shared_arithmetic_problems``.
+
+The mirror image of the other tool's refusal
+--------------------------------------------
+``analyze_repeat_variation.py`` sets ``FORBIDDEN_MODALITY = "audio"`` and
+refuses any run containing an audio item, because its cohort was graded before
+audio routing existed and folding audio in would report a flip rate for a
+modality it never exercised. This tool sets ``REQUIRED_MODALITY = "audio"`` and
+refuses any run *without* one. The two are checked against each other, so the
+two cohorts cannot be swapped by mistake in either direction: each tool's
+input is exactly the other's refusal.
+
+The interval that was asked for does not exist, and that is the finding
+----------------------------------------------------------------------
+The card asks for a task-unit interval. A task-unit interval on this cohort is
+degenerate, and not because three runs is too few.
+
+Resampling three tasks with replacement gives 3^3 = 27 equally likely draws. A
+ratio of sums over a mixture of tasks is a weighted average of the per-task
+rates, so every attainable value lies between the lowest and the highest
+per-task rate -- and the three draws that pick one task three times attain
+exactly those two endpoints. Each of those draws has probability 1/27 = 3.70%,
+which is larger than the 2.5% the percentile method cuts off. So the 2.5th
+percentile *is* the minimum and the 97.5th *is* the maximum, and the "95%
+interval" is the range of the three per-task rates, arrived at by construction
+rather than by measurement.
+
+Buying more repeats does not fix that. More repeats sharpen each task's own
+rate, so the endpoints converge -- to the true lowest and true highest of the
+three task rates, which is a fixed non-zero width, not to a point. The interval
+is computed and reported anyway, with ``is_informative`` false and the exact
+probabilities that make it false, because "we could not bound it" is a claim
+and the enumeration is the evidence for it. What would fix it is a fourth audio
+task, and this corpus has exactly three: 31 of 8,816 items route audio and they
+belong to those three. There is no fourth to buy.
+
+What the runs do support
+------------------------
+The comparison that survives is inside each run rather than across the
+resampled corpus: the same grader, on the same task, in the same run, flipping
+far more often on the criteria it listened to than on the criteria it read.
+That is a stratified permutation test with the task as the stratum, and it does
+not resample tasks at all, so the degeneracy above does not touch it.
+
+Honesty about the threshold below
+---------------------------------
+The thirty-task tool implements a document written before its runs were bought.
+This one was written after these three were graded, so its numbers were known
+when its threshold was chosen. Calling that a preregistration would be false.
+The threshold is stated anyway and wired to the exit status, because a stated
+threshold that a later re-run can fail is worth more than an unstated one, and
+because the alternative is choosing it silently.
+
+Usage
+-----
+    python batch-runner/scripts/analyze_audio_repeat_variation.py RUN1.json RUN2.json RUN3.json
+    python batch-runner/scripts/analyze_audio_repeat_variation.py RUN*.json --json
+
+Exit status is 0 when the reported contrast holds at the stated threshold and
+1 when it does not, so a difference that could be chance cannot be reported as
+if it had been established.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import itertools
+import json
+import random
+import sys
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import analyze_repeat_variation as rv  # noqa: E402
+
+# Arithmetic borrowed rather than rewritten. Two implementations of one formula
+# is how two published answers quietly stop agreeing, and every name here is a
+# pure function of its arguments -- none of them reads the other cohort's
+# constants except the two bootstraps, which read its percentiles, which is
+# exactly what ``shared_arithmetic_problems`` below refuses to leave unchecked.
+_dig = rv._dig
+_item_index = rv._item_index
+_score_outcome = rv._score_outcome
+cluster_bootstrap_ratio = rv.cluster_bootstrap_ratio
+item_bootstrap_rate = rv.item_bootstrap_rate
+load_runs = rv.load_runs
+percentile = rv.percentile
+
+
+# The resampling settings. Same values as the thirty-task cohort's, declared
+# separately: they have to agree today, and they have to be able to disagree
+# tomorrow without one cohort's re-registration moving the other's numbers.
+BOOTSTRAP_RESAMPLES = 10_000
+BOOTSTRAP_SEED = 20260902
+PERCENTILE_LOW = 2.5
+PERCENTILE_HIGH = 97.5
+
+# The stratified permutation test. Draws are cheap here -- 94 labels, three
+# strata -- so the count is set by how fine a p-value is worth quoting rather
+# than by runtime: 100,000 draws resolve to the fourth decimal.
+PERMUTATION_DRAWS = 100_000
+PERMUTATION_SEED = 20260902
+
+# The threshold the exit status is wired to. One-sided, because the question is
+# "does listening flip more than reading", and a contrast in the other
+# direction would not support the card's claim either way. See the docstring
+# for why this is not called a preregistration.
+ALPHA = 0.01
+
+# Three runs, three tasks, all three pairs. Picking one pair would be picking
+# the answer.
+EXPECTED_RUN_COUNT = 3
+EXPECTED_TASK_COUNT = 3
+PAIRS: tuple[tuple[int, int], ...] = ((0, 1), (0, 2), (1, 2))
+
+# The mirror of the other tool's FORBIDDEN_MODALITY. A run with no audio item
+# cannot answer this question, and the other tool refuses every run that can.
+REQUIRED_MODALITY = "audio"
+
+# What audio is measured against. Not "everything else": formatting and visual
+# criteria reach the file by other routes with their own failure modes, and
+# lumping them in would compare listening to an average of three unlike things.
+# They are still censused, just not contrasted.
+CONTRAST_MODALITY = "text"
+
+# The whole audio population of this corpus, as the merged 185-task run
+# measured it and ``tests/test_the_audio_repeat_cohort_is_every_audio_task.py``
+# derives it. Pinned so a cohort that quietly graded a different three is
+# caught here rather than absorbed into the rate.
+EXPECTED_AUDIO_ITEMS = 31
+EXPECTED_AUDIO_ITEMS_PER_TASK = {
+    "38889c3b-e3d4-49c8-816a-3cc8e5313aba": 10,
+    "e222075d-5d62-4757-ae3c-e34b0846583b": 7,
+    "75401f7c-396d-406d-b08e-938874ad1045": 14,
+}
+
+# A verdict outside this vocabulary stops the run rather than being given a
+# handling rule invented on the spot.
+VERDICT_VOCABULARY: tuple[str, ...] = ("pass", "partial", "fail", "judge_error")
+
+# The identity of the three runs, field by field. Checked twice over: every run
+# must agree with every other, and every run must also match the literal below.
+# Agreement alone would accept three runs of some other cohort that happened to
+# agree with each other, and these numbers are about one cohort.
+PINNED_FINGERPRINTS: tuple[tuple[str, tuple[str, ...], Any], ...] = (
+    (
+        "task list digest",
+        ("expected_ordered_task_ids_sha256",),
+        "b16d9b188a763fa9382d9b18df796b2f08cf284b47619195a2feba963149063c",
+    ),
+    ("task count", ("expected_task_count",), 3),
+    (
+        "grader source digest",
+        ("grader_source_hash",),
+        "29c3cfe7e94e488177b8bce5a2b4f1d952f172175db7ace2d3c929b34d1f3b49",
+    ),
+    ("grading config", ("judge", "config_name"), "gold_audio_repeat_v2_sol_max"),
+    ("grading config hash", ("judge", "config_hash"), "ed9ac99c7332a184"),
+    ("judge model", ("judge", "model"), "gpt-5.6-sol"),
+    ("judge deployment", ("judge", "deployment"), "gpt-5.6-sol"),
+    ("api version", ("judge", "api_version"), "2025-04-01-preview"),
+    ("reasoning effort", ("judge", "reasoning_effort"), "max"),
+    ("temperature", ("judge", "temperature"), 0),
+    ("seed", ("judge", "seed"), 42),
+    ("judge prompt version", ("prompt", "version"), "v2.2"),
+    # The listening settings themselves. The thirty-task cohort has no
+    # equivalent of these because it never listened; here they decide what the
+    # grader was given to hear, so a repeat at a different trim or a different
+    # audio model is not a repeat of this measurement.
+    ("audio model", ("judge", "perception", "audio", "model"), "gpt-audio-1.5"),
+    (
+        "audio deployment",
+        ("judge", "perception", "audio", "deployment"),
+        "gpt-audio-1.5",
+    ),
+    ("audio clip seconds", ("judge", "perception", "audio", "trim_seconds"), 30),
+    (
+        "audio call cap per task",
+        ("judge", "perception", "audio", "call_cap_per_task"),
+        32,
+    ),
+    (
+        "rubric revision",
+        ("rubric", "revision"),
+        "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+    ),
+    (
+        "gold revision",
+        ("source_inference_revision",),
+        "11e7900cdcac61bc4daf59e65feb238acda98fbf",
+    ),
+    (
+        "renderer",
+        ("renderer_fingerprint",),
+        {
+            "libreoffice_binary": "soffice",
+            "libreoffice_version": "LibreOffice 24.2.7.2 420(Build:2)",
+            "pymupdf_version": "1.28.2",
+        },
+    ),
+    ("payload schema", ("schema_version",), "1.4"),
+    # A pinned proper subset is a diagnostic run by construction, and a payload
+    # that called itself final here would be one that had escaped the fork and
+    # could overwrite the published corpus.
+    ("run status", ("run_status",), "diagnostic"),
+)
+
+
+class RepeatsAreNotComparable(SystemExit):
+    """Raised when the inputs cannot answer the question that was asked.
+
+    Every invalidation is this rather than a warning. A warning printed above a
+    number is read as a caveat on the number; the point of these checks is that
+    there is no number to caveat.
+    """
+
+
+# ── what the two cohorts must still agree about ──────────────────────────
+
+
+def shared_arithmetic_problems() -> list[str]:
+    """The coupling to the other module, made explicit and checkable.
+
+    ``cluster_bootstrap_ratio`` and ``item_bootstrap_rate`` cut their intervals
+    at *that* module's percentiles. If it were ever re-registered at different
+    ones, this cohort's endpoints would move with it and nothing here would say
+    so. Rather than copy the two functions to avoid the coupling, the coupling
+    is asserted -- and the modality mirror is asserted with it, so the two
+    tools cannot be pointed at each other's inputs.
+    """
+    problems: list[str] = []
+
+    for name, mine in (
+        ("PERCENTILE_LOW", PERCENTILE_LOW),
+        ("PERCENTILE_HIGH", PERCENTILE_HIGH),
+    ):
+        theirs = getattr(rv, name)
+        if theirs != mine:
+            problems.append(
+                f"analyze_repeat_variation.{name} is {theirs} and this "
+                f"analysis is registered at {mine}. The bootstraps below are "
+                "that module's and would cut at its value, so these two "
+                "registrations have to be reconciled before either is quoted"
+            )
+
+    if rv.PAIRS != PAIRS:
+        problems.append(
+            f"analyze_repeat_variation.PAIRS is {rv.PAIRS} and this analysis "
+            f"uses {PAIRS}; the two cohorts are no longer comparing runs the "
+            "same way"
+        )
+
+    if rv.FORBIDDEN_MODALITY != REQUIRED_MODALITY:
+        problems.append(
+            "the modality this analysis requires "
+            f"({REQUIRED_MODALITY!r}) is no longer the one "
+            "analyze_repeat_variation refuses "
+            f"({rv.FORBIDDEN_MODALITY!r}). Those two facts are what keep each "
+            "cohort out of the other's intervals"
+        )
+
+    return problems
+
+
+# ── is this the cohort, and is it three different gradings of it ─────────
+
+
+def fingerprint_problems(runs: list[dict[str, Any]]) -> list[str]:
+    """Identity, then non-identity: same cohort, different gradings."""
+    problems: list[str] = []
+
+    if len(runs) != EXPECTED_RUN_COUNT:
+        problems.append(
+            f"this analysis is registered for {EXPECTED_RUN_COUNT} runs and "
+            f"was given {len(runs)}"
+        )
+
+    for label, path, expected in PINNED_FINGERPRINTS:
+        observed = [_dig(run, path) for run in runs]
+        field = ".".join(path)
+        if len({json.dumps(value, sort_keys=True) for value in observed}) > 1:
+            rendered = " | ".join(
+                f"{run['_label']}={json.dumps(value, ensure_ascii=False)}"
+                for run, value in zip(runs, observed)
+            )
+            problems.append(
+                f"{label} ({field}) differs between runs: {rendered}. A flip "
+                "rate measured across runs that differed here would measure "
+                "that difference, not the grader"
+            )
+            continue
+        if observed[0] != expected:
+            problems.append(
+                f"{label} ({field}) is "
+                f"{json.dumps(observed[0], ensure_ascii=False)} and this "
+                "analysis pinned "
+                f"{json.dumps(expected, ensure_ascii=False)}. These are not "
+                "the runs it was written for"
+            )
+
+    # Being handed one file twice is the failure that would pass every gate
+    # having compared nothing: every difference comes out at zero, and zero
+    # reads as perfect stability.
+    for field in ("_source_digest", "graded_at"):
+        seen: dict[Any, str] = {}
+        for run in runs:
+            value = run.get(field)
+            if value in seen:
+                problems.append(
+                    f"{run['_label']} and {seen[value]} have the same "
+                    f"{field.lstrip('_')}, so at least two of these inputs "
+                    "are the same run. Comparing a run with itself reports "
+                    "zero movement and proves nothing"
+                )
+            else:
+                seen[value] = run["_label"]
+
+    for run in runs:
+        tasks = run.get("tasks") or []
+        if len(tasks) != EXPECTED_TASK_COUNT:
+            problems.append(
+                f"{run['_label']} graded {len(tasks)} tasks and this analysis "
+                f"is registered for {EXPECTED_TASK_COUNT}"
+            )
+
+    return problems
+
+
+def _modality_counts(run: dict[str, Any]) -> collections.Counter[str]:
+    return collections.Counter(
+        str(item.get("routing_modality"))
+        for task in run["tasks"]
+        for item in task["items"]
+    )
+
+
+def shape_problems(runs: list[dict[str, Any]]) -> list[str]:
+    """What the body of the payloads has to look like for any of this to mean
+    what it says.
+
+    Kept apart from the fingerprint checks because these read every item, and a
+    caller asking only whether two files are the same run should not have to.
+    """
+    problems: list[str] = []
+
+    indexes = [_item_index(run) for run in runs]
+    key_sets = [frozenset(index) for index in indexes]
+    if len(set(key_sets)) > 1:
+        shared = frozenset.intersection(*key_sets)
+        for run, keys in zip(runs, key_sets):
+            missing = keys - shared
+            if missing:
+                sample = ", ".join(
+                    f"{task}/{item}" for task, item in sorted(missing)[:3]
+                )
+                problems.append(
+                    f"{run['_label']} carries {len(missing)} rubric item(s) "
+                    f"the others do not ({sample}). Pairing needs the same "
+                    "items on both sides"
+                )
+        return problems
+
+    for run, index in zip(runs, indexes):
+        # The mirror of the other tool's refusal. A cohort with no audio in it
+        # cannot report an audio flip rate, and reporting one anyway is the
+        # exact mistake that made the 38% figure unusable.
+        counts = _modality_counts(run)
+        if not counts.get(REQUIRED_MODALITY):
+            problems.append(
+                f"{run['_label']} routed no {REQUIRED_MODALITY} item at all. "
+                "This analysis is about criteria the grader listened to; a run "
+                "that listened to nothing has no flip rate to report"
+            )
+        elif counts[REQUIRED_MODALITY] != EXPECTED_AUDIO_ITEMS:
+            problems.append(
+                f"{run['_label']} routed {counts[REQUIRED_MODALITY]} "
+                f"{REQUIRED_MODALITY} items and this cohort is pinned at "
+                f"{EXPECTED_AUDIO_ITEMS}. The population moved, so the rate "
+                "below would be a rate for a different population"
+            )
+
+        per_task = {
+            task["task_id"]: sum(
+                1
+                for item in task["items"]
+                if item.get("routing_modality") == REQUIRED_MODALITY
+            )
+            for task in run["tasks"]
+        }
+        if per_task != EXPECTED_AUDIO_ITEMS_PER_TASK:
+            problems.append(
+                f"{run['_label']} listened to {json.dumps(per_task, sort_keys=True)} "
+                f"and the pin says {json.dumps(EXPECTED_AUDIO_ITEMS_PER_TASK, sort_keys=True)}"
+            )
+
+        unknown = sorted(
+            {
+                str(item["verdict"])
+                for item in index.values()
+                if item.get("verdict") not in VERDICT_VOCABULARY
+            }
+        )
+        if unknown:
+            problems.append(
+                f"{run['_label']} uses verdicts outside the vocabulary this "
+                f"analysis counts: {', '.join(unknown)}"
+            )
+
+    # An item that was read in one run and listened to in another is not one
+    # observation of one thing. The contrast below would be comparing the
+    # router's decisions rather than the grader's.
+    moved = sorted(
+        f"{task}/{item}"
+        for task, item in indexes[0]
+        if len({index[(task, item)].get("routing_modality") for index in indexes}) > 1
+    )
+    if moved:
+        problems.append(
+            f"{len(moved)} item(s) changed routing modality between runs "
+            f"({', '.join(moved[:3])}). A flip rate by modality needs the "
+            "modality to be a property of the item, not of the run"
+        )
+
+    return problems
+
+
+# ── the census ───────────────────────────────────────────────────────────
+
+
+def _ordered_keys(run: dict[str, Any]) -> list[tuple[str, str]]:
+    """Item keys in payload order.
+
+    Not sorted. The resampling and the permutation both draw from lists built
+    in this order, so it is part of the recipe that reproduces the numbers.
+    """
+    return [
+        (task["task_id"], item["rubric_item_id"])
+        for task in run["tasks"]
+        for item in task["items"]
+    ]
+
+
+def census(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Verdict flips and score moves, per modality, over all three pairs.
+
+    Both bases are reported. The verdict basis is what a person quotes -- "the
+    grader said pass, then it said fail" -- and the score basis is what the
+    scoreboard did, which can move while the label holds still.
+    """
+    indexes = [_item_index(run) for run in runs]
+    keys = _ordered_keys(runs[0])
+    modality = {key: str(indexes[0][key].get("routing_modality")) for key in keys}
+    task_of = {key: key[0] for key in keys}
+
+    verdict_flags: dict[tuple[str, str], list[int]] = {key: [] for key in keys}
+    score_flags: dict[tuple[str, str], list[int]] = {key: [] for key in keys}
+    transitions: dict[tuple[str, str, str], int] = {}
+
+    for left, right in PAIRS:
+        for key in keys:
+            a = indexes[left][key]
+            b = indexes[right][key]
+            differs = a["verdict"] != b["verdict"]
+            verdict_flags[key].append(int(differs))
+            score_flags[key].append(int(_score_outcome(a) != _score_outcome(b)))
+            if differs:
+                cell = (modality[key], str(a["verdict"]), str(b["verdict"]))
+                transitions[cell] = transitions.get(cell, 0) + 1
+
+    by_modality: dict[str, dict[str, Any]] = {}
+    for name in sorted(set(modality.values())):
+        members = [key for key in keys if modality[key] == name]
+        flips = sum(sum(verdict_flags[key]) for key in members)
+        moves = sum(sum(score_flags[key]) for key in members)
+        pairs = len(members) * len(PAIRS)
+        by_modality[name] = {
+            "items": len(members),
+            "pairs": pairs,
+            "verdict_flips": flips,
+            "verdict_flip_rate_pct": 100.0 * flips / pairs if pairs else 0.0,
+            "score_moves": moves,
+            "score_move_rate_pct": 100.0 * moves / pairs if pairs else 0.0,
+            "items_that_ever_flipped": sum(
+                1 for key in members if any(verdict_flags[key])
+            ),
+        }
+
+    total_flips = sum(sum(flags) for flags in verdict_flags.values())
+    total_moves = sum(sum(flags) for flags in score_flags.values())
+    total_pairs = len(keys) * len(PAIRS)
+
+    return {
+        "items": len(keys),
+        "pairs": total_pairs,
+        "verdict_flips": total_flips,
+        "verdict_flip_rate_pct": 100.0 * total_flips / total_pairs,
+        "score_moves": total_moves,
+        "score_move_rate_pct": 100.0 * total_moves / total_pairs,
+        "by_modality": by_modality,
+        "transitions": {
+            f"{mod}:{a}->{b}": n for (mod, a, b), n in sorted(transitions.items())
+        },
+        "_keys": keys,
+        "_modality": modality,
+        "_task_of": task_of,
+        "_verdict_flags": verdict_flags,
+    }
+
+
+def denominator_stability(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Whether the set of items that count moved between the three gradings.
+
+    The thirty-task analysis had to correct for a denominator that moved: an
+    item excluded in one run and scored in another changes what the percentage
+    is a percentage of. If that happened here it would contaminate the rates
+    below, so it is measured rather than assumed away.
+    """
+    indexes = [_item_index(run) for run in runs]
+    excluded = [
+        {key for key, item in index.items() if item.get("score_excluded")}
+        for index in indexes
+    ]
+    stable = len({frozenset(group) for group in excluded}) == 1
+    always = set.intersection(*excluded) if excluded else set()
+    ever = set.union(*excluded) if excluded else set()
+
+    return {
+        "excluded_per_run": [len(group) for group in excluded],
+        "identical_across_runs": stable,
+        "excluded_always": sorted(f"{task}/{item}" for task, item in always),
+        "modalities_ever_excluded": dict(
+            sorted(
+                collections.Counter(
+                    str(indexes[0][key].get("routing_modality")) for key in ever
+                ).items()
+            )
+        ),
+        f"{REQUIRED_MODALITY}_items_ever_excluded": sum(
+            1
+            for key in ever
+            if indexes[0][key].get("routing_modality") == REQUIRED_MODALITY
+        ),
+    }
+
+
+# ── the interval that was asked for, and why it is not one ───────────────
+
+
+def attainable_distribution(
+    task_ids: list[str],
+    numerator: dict[str, int],
+    denominator: dict[str, int],
+) -> list[tuple[Fraction, int]]:
+    """Every value a cluster resample can return, with how many draws return it.
+
+    Exact rather than sampled. With k tasks there are k**k ordered draws, all
+    equally likely, so at k=3 the whole bootstrap distribution is 27 outcomes
+    and can be written down. Fractions rather than floats so that two draws
+    landing on the same rate are recognised as the same value instead of being
+    separated in the sixteenth decimal.
+    """
+    counts: dict[Fraction, int] = {}
+    size = len(task_ids)
+    for draw in itertools.product(task_ids, repeat=size):
+        top = sum(numerator[task_id] for task_id in draw)
+        bottom = sum(denominator[task_id] for task_id in draw)
+        value = Fraction(top, bottom) if bottom else Fraction(0)
+        counts[value] = counts.get(value, 0) + 1
+    return sorted(counts.items())
+
+
+def exact_quantile(
+    distribution: list[tuple[Fraction, int]], total: int, q: float
+) -> Fraction:
+    """The smallest value whose cumulative probability reaches ``q``.
+
+    This is the quantile the percentile bootstrap converges to as the resample
+    count grows, so comparing it against the endpoints of an actual bootstrap
+    is a check on that bootstrap rather than a second opinion about the data.
+    """
+    target = Fraction(q) / 100
+    seen = 0
+    for value, count in distribution:
+        seen += count
+        if Fraction(seen, total) >= target:
+            return value
+    return distribution[-1][0]
+
+
+def task_unit_interval(
+    task_ids: list[str],
+    numerator: dict[str, int],
+    denominator: dict[str, int],
+    *,
+    resamples: int,
+    seed: int,
+) -> dict[str, Any]:
+    """The requested interval, plus the enumeration that says what it is worth.
+
+    Both are reported. The bootstrap is what the card asked for and what a
+    reader will look for; the enumeration is why the bootstrap's endpoints
+    could not have come out anywhere else.
+    """
+    size = len(task_ids)
+    total_draws = size**size
+    distribution = attainable_distribution(task_ids, numerator, denominator)
+
+    lowest = distribution[0][0]
+    highest = distribution[-1][0]
+    p_at_min = Fraction(distribution[0][1], total_draws)
+    p_at_max = Fraction(distribution[-1][1], total_draws)
+
+    exact_low = exact_quantile(distribution, total_draws, PERCENTILE_LOW)
+    exact_high = exact_quantile(distribution, total_draws, PERCENTILE_HIGH)
+
+    bootstrap = cluster_bootstrap_ratio(
+        task_ids,
+        {task_id: float(numerator[task_id]) for task_id in task_ids},
+        {task_id: float(denominator[task_id]) for task_id in task_ids},
+        resamples=resamples,
+        seed=seed,
+    )
+
+    per_task = {
+        task_id: (
+            100.0 * numerator[task_id] / denominator[task_id]
+            if denominator[task_id]
+            else 0.0
+        )
+        for task_id in task_ids
+    }
+
+    # The endpoints are pinned to the extremes exactly when a single-task draw
+    # is likelier than the tail being cut off. That is a property of how many
+    # clusters there are, not of what they contain.
+    informative = exact_low > lowest and exact_high < highest
+
+    smallest_useful = size
+    while Fraction(1, smallest_useful**smallest_useful) >= Fraction(
+        PERCENTILE_LOW
+    ) / 100:
+        smallest_useful += 1
+
+    return {
+        "unit": "task",
+        "clusters": size,
+        "ordered_draws": total_draws,
+        "per_task_rate_pct": {
+            task_id: round(rate, 4) for task_id, rate in per_task.items()
+        },
+        "attainable_values_pct": [
+            round(100.0 * float(value), 4) for value, _ in distribution
+        ],
+        "distinct_attainable_values": len(distribution),
+        "bootstrap": {
+            "resamples": resamples,
+            "seed": seed,
+            "low": bootstrap["low"],
+            "high": bootstrap["high"],
+            "width": bootstrap["width"],
+            "half_width": bootstrap["half_width"],
+        },
+        "exact_quantiles_pct": {
+            "low": round(100.0 * float(exact_low), 4),
+            "high": round(100.0 * float(exact_high), 4),
+        },
+        "extremes_pct": {
+            "min": round(100.0 * float(lowest), 4),
+            "max": round(100.0 * float(highest), 4),
+        },
+        "probability_of_an_extreme_draw": {
+            "at_min": round(float(p_at_min), 6),
+            "at_max": round(float(p_at_max), 6),
+            "tail_being_cut": PERCENTILE_LOW / 100.0,
+        },
+        "is_informative": informative,
+        "width_floor_pp": round(max(per_task.values()) - min(per_task.values()), 4),
+        "clusters_needed_for_a_cut_tail": smallest_useful,
+        "why": (
+            "a ratio of sums over resampled tasks is a weighted average of the "
+            "per-task rates, so every draw lands between the lowest and the "
+            "highest of them, and the draws that pick one task "
+            f"{size} times attain exactly those two endpoints. Each of those "
+            f"draws has probability {float(p_at_min):.4f}, which is not "
+            f"smaller than the {PERCENTILE_LOW}% being cut off, so the "
+            "endpoints are the extremes by construction. More repeats sharpen "
+            "each task's own rate and the width converges to the spread "
+            "between tasks, not to zero; only more tasks would cut a tail, "
+            f"and {smallest_useful} would be the first count that could"
+        )
+        if not informative
+        else (
+            f"with {size} clusters a single-task draw is rarer than the "
+            f"{PERCENTILE_LOW}% tail, so the endpoints are not pinned to the "
+            "extremes"
+        ),
+    }
+
+
+# ── the contrast that does not resample tasks ────────────────────────────
+
+
+def _pooled_gap(
+    labels: dict[tuple[str, str], str],
+    flips: dict[tuple[str, str], int],
+    pairs_per_item: int,
+    members: list[tuple[str, str]],
+) -> float:
+    left_hits = left_n = right_hits = right_n = 0
+    for key in members:
+        if labels[key] == REQUIRED_MODALITY:
+            left_hits += flips[key]
+            left_n += pairs_per_item
+        else:
+            right_hits += flips[key]
+            right_n += pairs_per_item
+    left = 100.0 * left_hits / left_n if left_n else 0.0
+    right = 100.0 * right_hits / right_n if right_n else 0.0
+    return left - right
+
+
+def modality_contrast(
+    counted: dict[str, Any], *, draws: int, seed: int
+) -> dict[str, Any]:
+    """Does the grader flip more on what it listened to than on what it read?
+
+    A stratified permutation: the label ``audio`` or ``text`` is shuffled among
+    the items *inside* each task, so every draw keeps each task's own mix of
+    labels and its own difficulty. Tasks are never resampled, which is why the
+    degeneracy in the interval above does not reach this number.
+
+    The item is the unit that has a modality, so an item's three pair-outcomes
+    move together under the shuffle. Permuting the 282 pair-observations
+    independently would treat one item's three comparisons as three separate
+    items and make the test look far more certain than the data are.
+    """
+    keys = counted["_keys"]
+    modality = counted["_modality"]
+    task_of = counted["_task_of"]
+    flag_lists = counted["_verdict_flags"]
+
+    members = [
+        key
+        for key in keys
+        if modality[key] in (REQUIRED_MODALITY, CONTRAST_MODALITY)
+    ]
+    flips = {key: sum(flag_lists[key]) for key in members}
+    labels = {key: modality[key] for key in members}
+    pairs_per_item = len(PAIRS)
+
+    strata: dict[str, list[tuple[str, str]]] = {}
+    for key in members:
+        strata.setdefault(task_of[key], []).append(key)
+
+    per_task = []
+    holds_everywhere = True
+    for task_id in sorted(strata):
+        rows = strata[task_id]
+        row: dict[str, Any] = {"task_id": task_id}
+        for name in (REQUIRED_MODALITY, CONTRAST_MODALITY):
+            group = [key for key in rows if labels[key] == name]
+            hits = sum(flips[key] for key in group)
+            total = len(group) * pairs_per_item
+            row[name] = {
+                "items": len(group),
+                "pairs": total,
+                "flips": hits,
+                "rate_pct": round(100.0 * hits / total, 4) if total else None,
+            }
+        left = row[REQUIRED_MODALITY]["rate_pct"]
+        right = row[CONTRAST_MODALITY]["rate_pct"]
+        row["audio_at_least_text"] = (
+            left is not None and right is not None and left >= right
+        )
+        holds_everywhere = holds_everywhere and bool(row["audio_at_least_text"])
+        per_task.append(row)
+
+    observed = _pooled_gap(labels, flips, pairs_per_item, members)
+
+    rng = random.Random(seed)
+    at_least = 0
+    at_least_abs = 0
+    shuffled = dict(labels)
+    for _ in range(draws):
+        for rows in strata.values():
+            names = [labels[key] for key in rows]
+            rng.shuffle(names)
+            for key, name in zip(rows, names):
+                shuffled[key] = name
+        gap = _pooled_gap(shuffled, flips, pairs_per_item, members)
+        if gap >= observed:
+            at_least += 1
+        if abs(gap) >= abs(observed):
+            at_least_abs += 1
+
+    # The (1 + c) / (1 + n) form rather than c / n. With a finite number of
+    # draws the plain ratio can report exactly zero, and a permutation test
+    # cannot establish that something is impossible.
+    p_one_sided = (1 + at_least) / (1 + draws)
+    p_two_sided = (1 + at_least_abs) / (1 + draws)
+
+    left_group = [key for key in members if labels[key] == REQUIRED_MODALITY]
+    right_group = [key for key in members if labels[key] == CONTRAST_MODALITY]
+
+    return {
+        "left": REQUIRED_MODALITY,
+        "right": CONTRAST_MODALITY,
+        "left_rate_pct": round(
+            100.0
+            * sum(flips[key] for key in left_group)
+            / (len(left_group) * pairs_per_item),
+            4,
+        ),
+        "right_rate_pct": round(
+            100.0
+            * sum(flips[key] for key in right_group)
+            / (len(right_group) * pairs_per_item),
+            4,
+        ),
+        "gap_pp": round(observed, 4),
+        "per_task": per_task,
+        "holds_in_every_task": holds_everywhere,
+        "permutation": {
+            "draws": draws,
+            "seed": seed,
+            "stratum": "task",
+            "unit": "rubric item, with its three pair outcomes moved together",
+            "at_least_observed": at_least,
+            "at_least_observed_absolute": at_least_abs,
+            "p_one_sided": p_one_sided,
+            "p_two_sided": p_two_sided,
+            "alpha": ALPHA,
+        },
+        "significant": p_one_sided < ALPHA,
+    }
+
+
+# ── assembly ─────────────────────────────────────────────────────────────
+
+
+def analyze(
+    runs: list[dict[str, Any]],
+    *,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+    seed: int = BOOTSTRAP_SEED,
+    permutation_draws: int = PERMUTATION_DRAWS,
+    permutation_seed: int = PERMUTATION_SEED,
+) -> dict[str, Any]:
+    counted = census(runs)
+    keys = counted["_keys"]
+    modality = counted["_modality"]
+    flag_lists = counted["_verdict_flags"]
+
+    task_ids = [task["task_id"] for task in runs[0]["tasks"]]
+    audio_keys = [key for key in keys if modality[key] == REQUIRED_MODALITY]
+    numerator = {task_id: 0 for task_id in task_ids}
+    denominator = {task_id: 0 for task_id in task_ids}
+    for key in audio_keys:
+        numerator[key[0]] += sum(flag_lists[key])
+        denominator[key[0]] += len(PAIRS)
+
+    interval = task_unit_interval(
+        task_ids, numerator, denominator, resamples=resamples, seed=seed
+    )
+
+    # Computed so the choice of unit can be seen rather than asserted. Treating
+    # each of the 93 audio pair-observations as an independent draw is the
+    # method this analysis does not use, and the ratio of the two widths is
+    # the evidence for not using it.
+    #
+    # On the thirty-task cohort that ratio comes out below 1: the item
+    # bootstrap is the narrower, over-confident one, which is the usual reason
+    # for preferring the task. Here it comes out above 1, and that inversion is
+    # not a point in the task interval's favour -- it is the same degeneracy
+    # seen from the other side. The task interval is clamped to the range of
+    # three numbers, so it can be narrow while bounding nothing. The ratio is
+    # reported rather than the conclusion, because the conclusion depends on
+    # which way it fell.
+    item_flags = [flag for key in audio_keys for flag in flag_lists[key]]
+    not_the_interval = item_bootstrap_rate(
+        item_flags, resamples=resamples, seed=seed
+    )
+
+    contrast = modality_contrast(
+        counted, draws=permutation_draws, seed=permutation_seed
+    )
+
+    as_registered = (
+        resamples == BOOTSTRAP_RESAMPLES
+        and seed == BOOTSTRAP_SEED
+        and permutation_draws == PERMUTATION_DRAWS
+        and permutation_seed == PERMUTATION_SEED
+    )
+
+    public = {key: value for key, value in counted.items() if not key.startswith("_")}
+
+    return {
+        "settings": {
+            "bootstrap_resamples": resamples,
+            "bootstrap_seed": seed,
+            "permutation_draws": permutation_draws,
+            "permutation_seed": permutation_seed,
+            "percentiles": [PERCENTILE_LOW, PERCENTILE_HIGH],
+            "alpha": ALPHA,
+            "as_registered": as_registered,
+        },
+        "inputs": [
+            {
+                "label": run["_label"],
+                "path": run["_source_path"],
+                "digest": run["_source_digest"],
+                "graded_at": run.get("graded_at"),
+                "pct": [
+                    round(float(task["pct"]), 4)
+                    for task in run["tasks"]
+                    if task.get("pct") is not None
+                ],
+            }
+            for run in runs
+        ],
+        "cohort": {
+            "scope_digest": runs[0].get("expected_ordered_task_ids_sha256"),
+            "grader_source_hash": runs[0].get("grader_source_hash"),
+            "config": _dig(runs[0], ("judge", "config_name")),
+            "config_hash": _dig(runs[0], ("judge", "config_hash")),
+            "tasks": len(task_ids),
+            "audio_items": len(audio_keys),
+            "modality_census": dict(sorted(_modality_counts(runs[0]).items())),
+        },
+        "census": public,
+        "denominator": denominator_stability(runs),
+        "audio_flip_rate_pct": round(
+            counted["by_modality"][REQUIRED_MODALITY]["verdict_flip_rate_pct"], 4
+        ),
+        "task_unit_interval": interval,
+        "item_unit_interval_not_used": {
+            "low": not_the_interval["low"],
+            "high": not_the_interval["high"],
+            "width": not_the_interval["width"],
+            "half_width": not_the_interval["half_width"],
+            "width_ratio_item_over_task": (
+                round(not_the_interval["width"] / interval["bootstrap"]["width"], 4)
+                if interval["bootstrap"]["width"]
+                else None
+            ),
+            "note": (
+                "reported so the choice of unit is visible. Items inside one "
+                "task share an output, a clip and a grading context, so this "
+                "is not the interval this analysis uses. A ratio above 1 means "
+                "the task interval is the narrower of the two, which on this "
+                "cohort is the degeneracy above rather than an argument for it"
+            ),
+        },
+        "contrast": contrast,
+        "verdict_ok": bool(
+            as_registered
+            and contrast["significant"]
+            and contrast["holds_in_every_task"]
+        ),
+    }
+
+
+def _mark(ok: bool) -> str:
+    return "OK  " if ok else "FAIL"
+
+
+def _render(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    add = lines.append
+
+    cohort = report["cohort"]
+    add("audio repeat variation")
+    add("=" * 72)
+    add(f"cohort          {cohort['config']} ({cohort['config_hash']})")
+    add(f"scope digest    {cohort['scope_digest']}")
+    add(f"grader source   {cohort['grader_source_hash']}")
+    add(
+        f"corpus          {cohort['tasks']} tasks, "
+        f"{report['census']['items']} items, "
+        f"{cohort['audio_items']} of them {REQUIRED_MODALITY}"
+    )
+    add("")
+
+    add("the three gradings")
+    add("-" * 72)
+    for row in report["inputs"]:
+        add(
+            f"  {row['label']}  {row['digest'][:16]}  {row['graded_at']}  "
+            f"pct {row['pct']}"
+        )
+    add("")
+
+    add("verdict flips, by what the grader used to reach the file")
+    add("-" * 72)
+    add(
+        f"  {'modality':<12}{'items':>7}{'pairs':>7}{'flips':>7}{'rate':>9}"
+        f"{'score moves':>13}"
+    )
+    for name, row in report["census"]["by_modality"].items():
+        add(
+            f"  {name:<12}{row['items']:>7}{row['pairs']:>7}"
+            f"{row['verdict_flips']:>7}{row['verdict_flip_rate_pct']:>8.2f}%"
+            f"{row['score_moves']:>13}"
+        )
+    add(
+        f"  {'ALL':<12}{report['census']['items']:>7}"
+        f"{report['census']['pairs']:>7}{report['census']['verdict_flips']:>7}"
+        f"{report['census']['verdict_flip_rate_pct']:>8.2f}%"
+        f"{report['census']['score_moves']:>13}"
+    )
+    add("")
+    for name, count in sorted(report["census"]["transitions"].items()):
+        add(f"  {name:<40}{count:>6}")
+    add("")
+
+    denominator = report["denominator"]
+    add("did the set of items that count move")
+    add("-" * 72)
+    add(
+        f"  {_mark(denominator['identical_across_runs'])} excluded items per "
+        f"run {denominator['excluded_per_run']}, identical across runs: "
+        f"{denominator['identical_across_runs']}"
+    )
+    add(
+        f"       modalities ever excluded: "
+        f"{denominator['modalities_ever_excluded'] or 'none'}"
+    )
+    add(
+        f"       {REQUIRED_MODALITY} items ever excluded: "
+        f"{denominator[f'{REQUIRED_MODALITY}_items_ever_excluded']}"
+    )
+    add("")
+
+    interval = report["task_unit_interval"]
+    add("the task-unit interval that was asked for")
+    add("-" * 72)
+    add(
+        f"  point estimate            {report['audio_flip_rate_pct']:.2f}% "
+        f"of {report['census']['by_modality'][REQUIRED_MODALITY]['pairs']} "
+        "item pairs"
+    )
+    add(
+        f"  bootstrap 95%             "
+        f"[{interval['bootstrap']['low']:.2f}, "
+        f"{interval['bootstrap']['high']:.2f}]  "
+        f"half-width {interval['bootstrap']['half_width']:.2f}pp"
+    )
+    add(
+        f"  exact quantiles           "
+        f"[{interval['exact_quantiles_pct']['low']:.2f}, "
+        f"{interval['exact_quantiles_pct']['high']:.2f}]"
+    )
+    add(
+        f"  attainable at all         "
+        f"[{interval['extremes_pct']['min']:.2f}, "
+        f"{interval['extremes_pct']['max']:.2f}]  "
+        f"({interval['distinct_attainable_values']} distinct values over "
+        f"{interval['ordered_draws']} draws)"
+    )
+    add(f"  --   is_informative: {interval['is_informative']}")
+    add(f"       {interval['why']}")
+    add(
+        f"       per-task rates "
+        f"{ {k[:8]: round(v, 2) for k, v in interval['per_task_rate_pct'].items()} }"
+    )
+    add(
+        f"       width floor {interval['width_floor_pp']:.2f}pp -- what more "
+        "repeats converge to, not zero"
+    )
+    add("")
+    not_used = report["item_unit_interval_not_used"]
+    add(
+        f"  not the interval          "
+        f"[{not_used['low']:.2f}, {not_used['high']:.2f}] if items were "
+        "independent draws"
+    )
+    add(
+        f"       {not_used['width_ratio_item_over_task']:.2f}x the width of "
+        "the task interval; above 1 means the task interval is the narrower "
+        "one here, which is the clamping above rather than an argument for it"
+    )
+    add("")
+
+    contrast = report["contrast"]
+    add("what the runs do support: listened-to vs read, inside each run")
+    add("-" * 72)
+    add(
+        f"  {contrast['left']} {contrast['left_rate_pct']:.2f}%  vs  "
+        f"{contrast['right']} {contrast['right_rate_pct']:.2f}%   "
+        f"gap {contrast['gap_pp']:.2f}pp"
+    )
+    for row in contrast["per_task"]:
+        left = row[contrast["left"]]
+        right = row[contrast["right"]]
+        add(
+            f"    {row['task_id'][:8]}  {contrast['left']} "
+            f"{left['flips']}/{left['pairs']} = {left['rate_pct']:.2f}%   "
+            f"{contrast['right']} {right['flips']}/{right['pairs']} = "
+            f"{right['rate_pct']:.2f}%"
+        )
+    permutation = contrast["permutation"]
+    add(
+        f"  stratified permutation    {permutation['draws']} draws, labels "
+        f"shuffled within {permutation['stratum']}, seed {permutation['seed']}"
+    )
+    add(
+        f"  p (one-sided)             {permutation['p_one_sided']:.5f}   "
+        f"threshold {permutation['alpha']}"
+    )
+    add(
+        f"  {_mark(contrast['holds_in_every_task'])} direction holds inside "
+        f"every task: {contrast['holds_in_every_task']}"
+    )
+    add("")
+
+    settings = report["settings"]
+    add("verdict")
+    add("-" * 72)
+    add(f"  {_mark(settings['as_registered'])} run at the registered settings")
+    add(
+        f"  {_mark(contrast['significant'])} the contrast is not chance at "
+        f"alpha {settings['alpha']}"
+    )
+    add(
+        f"  {_mark(contrast['holds_in_every_task'])} the contrast holds inside "
+        "every task"
+    )
+    add("")
+    add(f"  {'PASS' if report['verdict_ok'] else 'FAIL'}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "grade_files",
+        type=Path,
+        nargs="+",
+        help="the three repeat payloads of the pinned audio cohort",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the whole analysis as JSON instead of a readable report",
+    )
+    parser.add_argument(
+        "--bootstrap-resamples",
+        type=int,
+        default=BOOTSTRAP_RESAMPLES,
+        help="how many times to resample. Registered value: 10000",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=BOOTSTRAP_SEED,
+        help=(
+            "the bootstrap seed. Registered value: 20260902. Any other value "
+            "is a real interval for a different analysis, and this tool marks "
+            "the run accordingly"
+        ),
+    )
+    parser.add_argument(
+        "--permutation-draws",
+        type=int,
+        default=PERMUTATION_DRAWS,
+        help="how many label shuffles. Registered value: 100000",
+    )
+    parser.add_argument(
+        "--permutation-seed",
+        type=int,
+        default=PERMUTATION_SEED,
+        help="the permutation seed. Registered value: 20260902",
+    )
+    args = parser.parse_args(argv)
+
+    runs = load_runs(args.grade_files)
+
+    problems = (
+        shared_arithmetic_problems()
+        + fingerprint_problems(runs)
+        + shape_problems(runs)
+    )
+    if problems:
+        raise RepeatsAreNotComparable(
+            "these payloads cannot answer the question this analysis asks:\n"
+            "  - " + "\n  - ".join(problems)
+        )
+
+    report = analyze(
+        runs,
+        resamples=args.bootstrap_resamples,
+        seed=args.seed,
+        permutation_draws=args.permutation_draws,
+        permutation_seed=args.permutation_seed,
+    )
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(_render(report))
+
+    return 0 if report["verdict_ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/batch-runner/tests/test_audio_repeat_variation_bounds_what_it_can.py
+++ b/batch-runner/tests/test_audio_repeat_variation_bounds_what_it_can.py
@@ -1,0 +1,738 @@
+"""What three gradings of the audio cohort do and do not establish.
+
+``analyze_audio_repeat_variation.py`` reports two things that pull in opposite
+directions, and this file exists to keep both of them honest.
+
+The first is a refusal. The card asked for a task-unit confidence interval on
+the audio flip rate, and the tool answers that the interval it produces bounds
+nothing: with three tasks, a resample that picks one task three times is
+likelier than the 2.5% tail being cut off, so the endpoints are the smallest
+and the largest per-task rate by construction. That is an arithmetic claim, so
+it is checked as arithmetic below -- the bootstrap endpoints must equal the
+exact quantiles, which must equal the extremes, and multiplying the evidence
+must move none of them. A tool that said "degenerate" while quietly printing a
+real-looking interval would be worse than one that said nothing.
+
+The second is a positive finding: inside every run, on the same task, the
+grader flips far more often on criteria it listened to than on criteria it
+read. That one can be wrong in the ordinary way, so it gets an ordinary
+control -- a synthetic cohort whose whole pooled gap is manufactured by task
+sizes, on which the stratified test must decline to find anything.
+
+Nothing here calls a model, grades anything, or spends anything.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import io
+import json
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import analyze_audio_repeat_variation as av  # noqa: E402
+from scripts import analyze_repeat_variation as rv  # noqa: E402
+
+BATCH_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BATCH_ROOT.parent
+COHORT = (
+    REPO_ROOT
+    / "data/grades/_diagnostic"
+    / "b16d9b188a763fa9382d9b18df796b2f08cf284b47619195a2feba963149063c"
+)
+
+#: The merged 185-task run, and the thirty-task repeat cohort. Neither may be
+#: what this analysis reads, or it is quoting somebody else's evidence.
+CORPUS_FINGERPRINT = (
+    "cef3a5b9f1305f19437d6ee337936a065965f979325b95a41d1001747e6bfa18"
+)
+THIRTY_TASK_DIGEST = next(
+    value for label, _, value in rv.PINNED_FINGERPRINTS if label == "task list digest"
+)
+
+
+@pytest.fixture(scope="module")
+def paths() -> list[Path]:
+    found = sorted(COHORT.glob("*.json")) + sorted(COHORT.glob("_repeats/run-*/*.json"))
+    assert len(found) == av.EXPECTED_RUN_COUNT, (
+        f"expected {av.EXPECTED_RUN_COUNT} committed payloads under {COHORT}, "
+        f"found {len(found)}. The repeats this analysis reads are not all here"
+    )
+    return found
+
+
+@pytest.fixture(scope="module")
+def runs(paths) -> list[dict]:
+    return av.load_runs(list(paths))
+
+
+@pytest.fixture(scope="module")
+def run_output(paths) -> tuple[int, dict]:
+    """One registered-settings run: its exit code and its report.
+
+    Bought once for the module. The permutation is 100,000 draws over 94 items
+    and takes several seconds, and every test that needs the real numbers needs
+    the same ones, so paying per test would buy nothing but wall clock.
+    """
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        code = av.main(["--json", *[str(path) for path in paths]])
+    return code, json.loads(buffer.getvalue())
+
+
+@pytest.fixture(scope="module")
+def report(run_output) -> dict:
+    return run_output[1]
+
+
+def _build_runs(spec: list[tuple[str, str, tuple[str, str, str]]]) -> list[dict]:
+    """Three synthetic runs from ``(task_id, modality, verdict per run)`` rows.
+
+    Only the fields the census and the contrast read. These never pass the
+    fingerprint gate and are not meant to -- they exist so the arithmetic can
+    be exercised on inputs whose answer is known in advance.
+    """
+    scores = {"pass": 1.0, "partial": 0.5, "fail": 0.0}
+    order: list[str] = []
+    for task_id, _, _ in spec:
+        if task_id not in order:
+            order.append(task_id)
+
+    runs = []
+    for ordinal in range(3):
+        tasks = []
+        for task_id in order:
+            rows = [row for row in spec if row[0] == task_id]
+            tasks.append(
+                {
+                    "task_id": task_id,
+                    "pct": 50.0,
+                    "items": [
+                        {
+                            "rubric_item_id": f"{modality}-{index}",
+                            "routing_modality": modality,
+                            "verdict": verdicts[ordinal],
+                            "awarded_score": scores[verdicts[ordinal]],
+                            "max_score": 1.0,
+                            "score_excluded": False,
+                        }
+                        for index, (_, modality, verdicts) in enumerate(rows)
+                    ],
+                }
+            )
+        runs.append({"_label": f"run-{ordinal + 1:03d}", "tasks": tasks})
+    return runs
+
+
+# ── the census the payloads carry ────────────────────────────────────────
+
+
+def test_the_census_is_the_one_the_payloads_carry(report):
+    """The numbers, pinned. Everything downstream is a claim about these.
+
+    Pinned rather than recomputed here: recomputing them with the code the tool
+    uses would agree with itself whatever either of them did.
+    """
+    census = report["census"]
+    assert census["items"] == 108
+    assert census["pairs"] == 324
+    assert census["verdict_flips"] == 24
+    assert census["score_moves"] == 28
+
+    assert census["by_modality"] == {
+        "audio": {
+            "items": 31,
+            "pairs": 93,
+            "verdict_flips": 18,
+            "verdict_flip_rate_pct": pytest.approx(19.3548, abs=1e-3),
+            "score_moves": 18,
+            "score_move_rate_pct": pytest.approx(19.3548, abs=1e-3),
+            "items_that_ever_flipped": 9,
+        },
+        "formatting": {
+            "items": 10,
+            "pairs": 30,
+            "verdict_flips": 2,
+            "verdict_flip_rate_pct": pytest.approx(6.6667, abs=1e-3),
+            "score_moves": 2,
+            "score_move_rate_pct": pytest.approx(6.6667, abs=1e-3),
+            "items_that_ever_flipped": 1,
+        },
+        "text": {
+            "items": 63,
+            "pairs": 189,
+            "verdict_flips": 4,
+            "verdict_flip_rate_pct": pytest.approx(2.1164, abs=1e-3),
+            "score_moves": 8,
+            "score_move_rate_pct": pytest.approx(4.2328, abs=1e-3),
+            "items_that_ever_flipped": 2,
+        },
+        "visual": {
+            "items": 4,
+            "pairs": 12,
+            "verdict_flips": 0,
+            "verdict_flip_rate_pct": 0.0,
+            "score_moves": 0,
+            "score_move_rate_pct": 0.0,
+            "items_that_ever_flipped": 0,
+        },
+    }
+
+    assert report["audio_flip_rate_pct"] == pytest.approx(19.3548, abs=1e-3)
+
+
+def test_the_direction_of_the_flips_is_recorded_and_not_only_the_count(report):
+    """Six criteria the grader failed then passed, ten it passed then failed.
+
+    A flip rate on its own cannot distinguish a grader that softened from one
+    that hardened from one that is simply unsteady, and the audio column here
+    is unsteady in both directions.
+    """
+    assert report["census"]["transitions"] == {
+        "audio:fail->pass": 6,
+        "audio:pass->fail": 10,
+        "audio:pass->partial": 2,
+        "formatting:fail->pass": 2,
+        "text:fail->partial": 2,
+        "text:pass->fail": 2,
+    }
+
+
+def test_the_headline_rate_is_derived_rather_than_typed_in(runs):
+    """Break one audio verdict and the count has to move.
+
+    Without this the table above would pass equally well against a tool that
+    printed constants, which is the failure a table of expected values invites.
+    """
+    before = av.census(runs)["by_modality"][av.REQUIRED_MODALITY]
+
+    mutated = copy.deepcopy(runs)
+    for task in mutated[1]["tasks"]:
+        for item in task["items"]:
+            if item.get("routing_modality") == av.REQUIRED_MODALITY:
+                item["verdict"] = "fail" if item["verdict"] != "fail" else "pass"
+                item["awarded_score"] = 0.0 if item["verdict"] == "fail" else 1.0
+                break
+        else:
+            continue
+        break
+
+    after = av.census(mutated)["by_modality"][av.REQUIRED_MODALITY]
+    assert after["verdict_flips"] != before["verdict_flips"], (
+        "flipping one audio verdict in one run changed no count; the census is "
+        "not reading the payloads it was handed"
+    )
+
+
+def test_the_denominator_did_not_move_between_the_three_gradings(report):
+    """Why these rates are not a moving denominator in disguise.
+
+    The thirty-task analysis had to correct for a set of scored items that
+    changed between runs. Had that happened here, a "flip" could be an item
+    entering or leaving the scoreboard rather than the grader changing its
+    mind. It did not: the same four items are excluded in all three, all of
+    them visual, and no audio item is ever excluded.
+    """
+    denominator = report["denominator"]
+    assert denominator["excluded_per_run"] == [4, 4, 4]
+    assert denominator["identical_across_runs"] is True
+    assert denominator["modalities_ever_excluded"] == {"visual": 4}
+    assert denominator[f"{av.REQUIRED_MODALITY}_items_ever_excluded"] == 0
+    assert len(denominator["excluded_always"]) == 4
+
+
+# ── the two cohorts cannot be swapped ────────────────────────────────────
+
+
+def test_this_tool_requires_exactly_what_the_other_one_refuses():
+    """The mirror, asserted from both sides.
+
+    ``analyze_repeat_variation`` refuses audio because its cohort predates the
+    routing. This one requires it. If those two constants ever drift apart,
+    each cohort becomes eligible for the other's analysis and the refusal that
+    keeps audio flipping out of the thirty-task intervals stops meaning
+    anything.
+    """
+    assert av.REQUIRED_MODALITY == rv.FORBIDDEN_MODALITY == "audio"
+    assert av.shared_arithmetic_problems() == []
+
+
+def test_the_thirty_task_tool_refuses_these_very_payloads(runs):
+    """The same point, exercised rather than read off a constant."""
+    problems = rv.shape_problems(copy.deepcopy(runs))
+    complaining = [p for p in problems if rv.FORBIDDEN_MODALITY in p]
+    assert len(complaining) == av.EXPECTED_RUN_COUNT, (
+        "the thirty-task analysis accepted the audio cohort, so its intervals "
+        f"can now absorb audio flipping: {problems}"
+    )
+
+
+def test_the_shared_arithmetic_check_can_fail(monkeypatch):
+    """A check nobody has watched fail is a comment.
+
+    Two of the numbers in the report come out of the other module's bootstraps,
+    which cut at *its* percentiles. If it were ever re-registered at different
+    ones, this cohort's endpoints would move with it silently. That is the
+    coupling the check exists for, so the check is shown noticing.
+    """
+    monkeypatch.setattr(rv, "PERCENTILE_LOW", 5.0)
+    assert any(
+        "PERCENTILE_LOW" in problem for problem in av.shared_arithmetic_problems()
+    )
+
+    monkeypatch.setattr(rv, "FORBIDDEN_MODALITY", "video")
+    assert any(
+        "analyze_repeat_variation refuses" in problem
+        for problem in av.shared_arithmetic_problems()
+    )
+
+
+def test_a_run_that_listened_to_nothing_is_refused(runs):
+    """The premise of the whole file, enforced.
+
+    Reporting an audio flip rate from runs that never listened is exactly the
+    mistake that made the 38% figure unusable, and it is the mistake a
+    conveniently available corpus invites.
+    """
+    stripped = copy.deepcopy(runs)
+    for run in stripped:
+        for task in run["tasks"]:
+            task["items"] = [
+                item
+                for item in task["items"]
+                if item.get("routing_modality") != av.REQUIRED_MODALITY
+            ]
+
+    problems = av.shape_problems(stripped)
+    assert any("listened to nothing" in problem for problem in problems), problems
+
+
+def test_the_same_file_three_times_is_refused(paths):
+    """The failure that would pass every gate having compared nothing.
+
+    Handed one payload three times, every difference is exactly zero, the flip
+    rate is 0.00%, and the report announces a perfectly steady grader. It has
+    to be an error rather than a result.
+    """
+    duplicated = av.load_runs([paths[0], paths[0], paths[0]])
+    problems = av.fingerprint_problems(duplicated)
+    assert any("same run" in problem for problem in problems), problems
+
+
+def test_an_item_that_changed_modality_between_runs_is_refused(runs):
+    """A contrast by modality needs the modality to belong to the item.
+
+    If the router sent one criterion to listening in one run and to reading in
+    the next, the audio-versus-text gap would be partly a fact about the
+    router. These three runs route identically; a set that did not is refused
+    rather than averaged.
+    """
+    assert av.shape_problems(copy.deepcopy(runs)) == []
+
+    moved = copy.deepcopy(runs)
+    for task in moved[2]["tasks"]:
+        for item in task["items"]:
+            if item.get("routing_modality") == av.REQUIRED_MODALITY:
+                item["routing_modality"] = av.CONTRAST_MODALITY
+                break
+        else:
+            continue
+        break
+
+    problems = av.shape_problems(moved)
+    assert any("changed routing modality" in problem for problem in problems), problems
+
+
+def test_the_cohort_is_neither_measurement_that_already_exists():
+    """This analysis must not be quoting evidence that belongs to something else."""
+    pinned = {label: value for label, _, value in av.PINNED_FINGERPRINTS}
+    assert pinned["task list digest"] not in {CORPUS_FINGERPRINT, THIRTY_TASK_DIGEST}
+    assert pinned["grading config"] == "gold_audio_repeat_v2_sol_max"
+    assert pinned["run status"] == "diagnostic", (
+        "a payload calling itself final here would be one that escaped the "
+        "diagnostic fork and could overwrite the published corpus"
+    )
+
+
+def test_every_pin_names_a_field_the_payloads_actually_carry(runs):
+    """A pin against a missing key passes by matching ``None`` against ``None``.
+
+    ``_dig`` returns ``None`` for a path that does not exist, so a typo in a key
+    path would produce a fingerprint that agreed with itself across all three
+    runs while checking nothing at all.
+    """
+    assert av.fingerprint_problems(runs) == []
+    for label, path, expected in av.PINNED_FINGERPRINTS:
+        observed = av._dig(runs[0], path)
+        assert observed is not None, (
+            f"the pin for {label} reads {'.'.join(path)}, which no payload "
+            "carries; it is comparing None against None"
+        )
+        assert observed == expected
+
+
+def test_the_listening_settings_are_pinned_too(runs):
+    """Four pins the thirty-task cohort has no equivalent of.
+
+    The audio model, its deployment, how many seconds of each clip were sent,
+    and how many perception calls a task was allowed. A repeat that listened to
+    sixty seconds where the first listened to thirty is not a repeat, and none
+    of the text-era pins would notice.
+    """
+    pinned = {label: value for label, _, value in av.PINNED_FINGERPRINTS}
+    assert pinned["audio model"] == "gpt-audio-1.5"
+    assert pinned["audio deployment"] == "gpt-audio-1.5"
+    assert pinned["audio clip seconds"] == 30
+    assert pinned["audio call cap per task"] == 32
+    assert av.fingerprint_problems(runs) == []
+
+
+# ── the interval that was asked for, and why it is not one ───────────────
+
+
+def test_the_interval_is_exactly_the_range_of_the_three_task_rates(report):
+    """The degeneracy, stated as an equality rather than as a worry.
+
+    Bootstrap endpoints, exact quantiles and the extremes of the attainable set
+    are all the same two numbers, and those two numbers are the lowest and the
+    highest per-task rate. The interval is not a measurement; it is a
+    restatement of the spread between three tasks.
+    """
+    interval = report["task_unit_interval"]
+    rates = sorted(interval["per_task_rate_pct"].values())
+
+    assert interval["is_informative"] is False
+    assert interval["bootstrap"]["low"] == pytest.approx(rates[0], abs=1e-3)
+    assert interval["bootstrap"]["high"] == pytest.approx(rates[-1], abs=1e-3)
+    assert interval["exact_quantiles_pct"]["low"] == pytest.approx(rates[0], abs=1e-3)
+    assert interval["exact_quantiles_pct"]["high"] == pytest.approx(rates[-1], abs=1e-3)
+    assert interval["extremes_pct"]["min"] == pytest.approx(rates[0], abs=1e-3)
+    assert interval["extremes_pct"]["max"] == pytest.approx(rates[-1], abs=1e-3)
+    assert interval["width_floor_pp"] == pytest.approx(rates[-1] - rates[0], abs=1e-3)
+    assert interval["bootstrap"]["width"] == pytest.approx(
+        interval["width_floor_pp"], abs=1e-3
+    )
+
+
+def test_the_enumeration_is_exact_and_complete(report):
+    """Twenty-seven draws, ten distinct values, and a single-task draw at 1/27.
+
+    With three clusters the whole bootstrap distribution can be written down,
+    so the endpoints are not an artefact of how many resamples were taken.
+    """
+    interval = report["task_unit_interval"]
+    assert interval["clusters"] == 3
+    assert interval["ordered_draws"] == 27
+    assert interval["distinct_attainable_values"] == 10
+    assert interval["attainable_values_pct"] == [
+        13.3333,
+        14.8148,
+        16.6667,
+        17.6471,
+        19.0476,
+        19.3548,
+        21.0526,
+        21.4286,
+        22.8571,
+        23.8095,
+    ]
+
+    probabilities = interval["probability_of_an_extreme_draw"]
+    assert probabilities["at_min"] == pytest.approx(1 / 27, abs=1e-6)
+    assert probabilities["at_max"] == pytest.approx(1 / 27, abs=1e-6)
+    assert probabilities["at_min"] >= probabilities["tail_being_cut"], (
+        "a single-task draw is now rarer than the tail being cut off, so the "
+        "endpoints are no longer pinned to the extremes and this analysis's "
+        "central finding has changed"
+    )
+
+
+def test_the_enumeration_is_a_distribution_and_not_a_sample():
+    """Every ordered draw accounted for, in exact arithmetic.
+
+    Fractions rather than floats so that two draws landing on the same rate are
+    recognised as one value instead of being separated in the sixteenth
+    decimal, which would inflate the distinct-value count above.
+    """
+    distribution = av.attainable_distribution(
+        ["a", "b", "c"], {"a": 4, "b": 10, "c": 4}, {"a": 30, "b": 42, "c": 21}
+    )
+    assert sum(count for _, count in distribution) == 27
+    assert all(isinstance(value, Fraction) for value, _ in distribution)
+    assert distribution == sorted(distribution)
+
+    # Three tasks at one rate collapse to a single attainable value, which
+    # floats would not have managed for a third.
+    flat = av.attainable_distribution(
+        ["a", "b", "c"], {"a": 1, "b": 2, "c": 3}, {"a": 3, "b": 6, "c": 9}
+    )
+    assert flat == [(Fraction(1, 3), 27)]
+
+
+def test_more_repeats_could_not_narrow_it(report):
+    """The claim that this is not a sample-size problem, made checkable.
+
+    Twice as many repeats, with every task's rate landing exactly where it
+    landed here, is this numerator and denominator doubled. The interval does
+    not move by a thousandth, because its endpoints are per-task rates and
+    those are what was held fixed.
+    """
+    rows = {
+        row["task_id"]: row[av.REQUIRED_MODALITY]
+        for row in report["contrast"]["per_task"]
+    }
+    task_ids = list(rows)
+    numerator = {task_id: rows[task_id]["flips"] for task_id in task_ids}
+    denominator = {task_id: rows[task_id]["pairs"] for task_id in task_ids}
+
+    first = av.task_unit_interval(
+        task_ids, numerator, denominator, resamples=2000, seed=av.BOOTSTRAP_SEED
+    )
+    # Rebuilt from the payloads, so it has to reproduce what the tool reported.
+    assert first["extremes_pct"] == report["task_unit_interval"]["extremes_pct"]
+
+    for multiple in (2, 10, 100):
+        scaled = av.task_unit_interval(
+            task_ids,
+            {task_id: value * multiple for task_id, value in numerator.items()},
+            {task_id: value * multiple for task_id, value in denominator.items()},
+            resamples=2000,
+            seed=av.BOOTSTRAP_SEED,
+        )
+        assert scaled["bootstrap"] == first["bootstrap"]
+        assert scaled["extremes_pct"] == first["extremes_pct"]
+        assert scaled["is_informative"] is False
+
+
+def test_a_fourth_task_is_what_would_cut_a_tail(report):
+    """What the tool says would fix it, shown fixing it.
+
+    The report claims four clusters is the first count at which a single-task
+    draw is rarer than the 2.5% tail. That is a claim about arithmetic, so it
+    is run: the same rates spread over four tasks give an interval whose
+    endpoints are no longer the extremes.
+    """
+    assert report["task_unit_interval"]["clusters_needed_for_a_cut_tail"] == 4
+
+    four = av.task_unit_interval(
+        ["a", "b", "c", "d"],
+        {"a": 4, "b": 10, "c": 4, "d": 6},
+        {"a": 30, "b": 42, "c": 21, "d": 30},
+        resamples=4000,
+        seed=av.BOOTSTRAP_SEED,
+    )
+    assert four["ordered_draws"] == 256
+    assert four["is_informative"] is True
+    assert four["exact_quantiles_pct"]["low"] > four["extremes_pct"]["min"]
+    assert four["exact_quantiles_pct"]["high"] < four["extremes_pct"]["max"]
+
+
+def test_the_unit_that_was_not_used_is_reported_beside_it(report):
+    """Choosing a resampling unit is a decision, so the other one is shown.
+
+    On the thirty-task cohort the item bootstrap is the narrower, over-confident
+    one, which is the usual argument for preferring the task. Here it is the
+    wider, and that inversion is the clamping above seen from the other side
+    rather than a point in the task interval's favour. Printing only the ratio
+    would invite the usual conclusion from an unusual number.
+    """
+    not_used = report["item_unit_interval_not_used"]
+    assert not_used["width_ratio_item_over_task"] > 1.0
+    assert not_used["width"] > report["task_unit_interval"]["bootstrap"]["width"]
+    assert "degeneracy" in not_used["note"]
+
+
+# ── the contrast that does not resample tasks ────────────────────────────
+
+
+def test_the_contrast_is_the_one_the_runs_show(report):
+    """Audio against text, pooled and then task by task."""
+    contrast = report["contrast"]
+    assert contrast["left"] == "audio"
+    assert contrast["right"] == "text"
+    assert contrast["left_rate_pct"] == pytest.approx(19.3548, abs=1e-3)
+    assert contrast["right_rate_pct"] == pytest.approx(2.1164, abs=1e-3)
+    assert contrast["gap_pp"] == pytest.approx(17.2384, abs=1e-3)
+
+    counted = {
+        row["task_id"][:8]: {
+            name: (row[name]["flips"], row[name]["pairs"]) for name in ("audio", "text")
+        }
+        for row in contrast["per_task"]
+    }
+    assert counted == {
+        "38889c3b": {"audio": (4, 30), "text": (4, 45)},
+        "75401f7c": {"audio": (10, 42), "text": (0, 69)},
+        "e222075d": {"audio": (4, 21), "text": (0, 75)},
+    }
+
+    assert contrast["holds_in_every_task"] is True
+    assert contrast["significant"] is True
+    assert contrast["permutation"]["p_one_sided"] < av.ALPHA
+
+
+def test_a_p_value_cannot_come_out_at_zero(report):
+    """A permutation test does not establish impossibility.
+
+    With the plain count-over-draws form, a gap that no shuffle reached would
+    be reported as p = 0. The (1 + c) / (1 + n) form bounds it below by one
+    draw, which is the honest resolution of a finite number of shuffles. The
+    identity is asserted rather than just the bound, because on this cohort 128
+    shuffles did reach the gap and the bound alone would hold either way.
+    """
+    permutation = report["contrast"]["permutation"]
+    assert permutation["p_one_sided"] == pytest.approx(
+        (1 + permutation["at_least_observed"]) / (1 + permutation["draws"])
+    )
+    assert permutation["p_one_sided"] >= 1 / (1 + permutation["draws"])
+    assert permutation["p_one_sided"] <= permutation["p_two_sided"]
+
+
+def _confounded_cohort() -> list[dict]:
+    """A cohort whose entire pooled gap is manufactured by task sizes.
+
+    Task A holds 20 audio and 2 text criteria and *every* one of them changes
+    verdict in run 3. Task B holds 2 audio and 20 text and none of them move.
+    Pooled, audio looks far less steady than text. Inside each task the two are
+    identical, so the gap is the strata and nothing else.
+
+    This is the control for the real finding: the same shape of evidence with
+    the effect removed and the confound left in.
+    """
+    unstable = ("pass", "pass", "fail")
+    steady = ("pass", "pass", "pass")
+    return _build_runs(
+        [("task-a", "audio", unstable) for _ in range(20)]
+        + [("task-a", "text", unstable) for _ in range(2)]
+        + [("task-b", "audio", steady) for _ in range(2)]
+        + [("task-b", "text", steady) for _ in range(20)]
+    )
+
+
+def test_a_gap_that_is_really_about_task_sizes_is_not_reported_as_a_finding():
+    """The control. Stratification is what separates this from the real result.
+
+    Unstratified, this cohort would look like a large, clean audio effect.
+    Shuffling the labels inside each task leaves every count where it was, so
+    the test reports the observed gap as entirely ordinary -- which it is.
+    """
+    contrast = av.modality_contrast(
+        av.census(_confounded_cohort()), draws=2000, seed=av.PERMUTATION_SEED
+    )
+
+    assert contrast["gap_pp"] > 20.0, (
+        "the control cohort no longer shows a large pooled gap, so it is no "
+        "longer controlling for anything"
+    )
+    assert contrast["permutation"]["p_one_sided"] > 0.5
+    assert contrast["significant"] is False
+    for row in contrast["per_task"]:
+        assert row["audio"]["rate_pct"] == pytest.approx(row["text"]["rate_pct"])
+
+
+def test_the_permutation_moves_whole_items_and_not_single_comparisons():
+    """Why the unit is the rubric item and not the pair-observation.
+
+    Each item is compared three times, and those three comparisons are one
+    item's behaviour rather than three items'. On this cohort the difference is
+    visible in the p-value: one audio criterion that disagrees on all three
+    pairs, against one steady text criterion. Moving whole items, one of the
+    two labellings reaches the observed gap, so p is about a half. Moving the
+    six pair-observations independently, all three flips landing on the audio
+    label is 1 in 20 -- a tenfold more certain answer from the same evidence.
+    """
+    runs = _build_runs(
+        [
+            ("solo", "audio", ("pass", "fail", "partial")),
+            ("solo", "text", ("pass", "pass", "pass")),
+        ]
+    )
+    counted = av.census(runs)
+    assert counted["by_modality"]["audio"]["verdict_flips"] == 3
+    assert counted["by_modality"]["text"]["verdict_flips"] == 0
+
+    contrast = av.modality_contrast(counted, draws=4000, seed=av.PERMUTATION_SEED)
+    assert contrast["gap_pp"] == pytest.approx(100.0)
+    assert 0.35 < contrast["permutation"]["p_one_sided"] < 0.65, (
+        "the permutation is no longer moving whole items; a p near 0.05 here "
+        "would mean an item's three comparisons are being shuffled apart and "
+        "counted as three independent criteria"
+    )
+    assert "three pair outcomes moved together" in contrast["permutation"]["unit"]
+
+
+def test_text_flipping_more_than_audio_does_not_come_out_as_an_audio_finding():
+    """The registered claim has a direction, so the reverse has to fail.
+
+    A two-sided reading of this contrast would let "reading is less steady than
+    listening" be reported as evidence about listening.
+    """
+    runs = _build_runs(
+        [("solo", "audio", ("pass", "pass", "pass"))] * 8
+        + [("solo", "text", ("pass", "pass", "fail"))] * 8
+    )
+    contrast = av.modality_contrast(
+        av.census(runs), draws=2000, seed=av.PERMUTATION_SEED
+    )
+    assert contrast["gap_pp"] < 0
+    assert contrast["significant"] is False
+    assert contrast["holds_in_every_task"] is False
+
+
+# ── the exit status ──────────────────────────────────────────────────────
+
+
+def test_the_command_exits_zero_on_the_committed_runs(run_output):
+    """The tool's own verdict on the evidence it ships with."""
+    code, payload = run_output
+    assert code == 0
+    assert payload["verdict_ok"] is True
+    assert payload["settings"]["as_registered"] is True
+    assert payload["cohort"]["tasks"] == av.EXPECTED_TASK_COUNT
+    assert payload["cohort"]["audio_items"] == av.EXPECTED_AUDIO_ITEMS
+
+
+def test_a_cohort_the_tool_will_not_read_is_an_error_and_not_a_verdict(tmp_path):
+    """Refusals leave by the exception, so they cannot be mistaken for a result."""
+    empty = tmp_path / "not-a-grade.json"
+    empty.write_text(json.dumps({"tasks": []}), encoding="utf-8")
+    with pytest.raises(av.RepeatsAreNotComparable):
+        av.main([str(empty), str(empty), str(empty)])
+
+
+def test_settings_that_are_not_the_registered_ones_turn_the_verdict_red(runs):
+    """A real analysis at other settings is still not *this* analysis.
+
+    The seeds and the draw counts are quotable, so a report produced at other
+    ones must not be able to present itself as the registered result. Passing
+    them stays allowed -- it is how the controls above are run -- it just
+    cannot come out green.
+    """
+    other = av.analyze(
+        runs, resamples=500, seed=1, permutation_draws=400, permutation_seed=1
+    )
+    assert other["settings"]["as_registered"] is False
+    assert other["verdict_ok"] is False
+    # The contrast itself does not depend on the settings; only the claim to be
+    # the registered run does.
+    assert other["contrast"]["significant"] is True
+    assert other["contrast"]["holds_in_every_task"] is True
+
+
+def test_the_readable_report_states_the_degeneracy_in_words(report):
+    """The finding has to survive being read rather than parsed.
+
+    A JSON field named ``is_informative`` is easy to miss beside an interval
+    printed to two decimals, and the interval is what a reader came for.
+    """
+    text = av._render(report)
+    assert "is_informative: False" in text
+    assert "by construction" in text
+    assert "not zero" in text
+    assert text.splitlines()[-1].strip() == "PASS"


### PR DESCRIPTION
Step 3 of the "소리 채점을 믿을 수 있나" card asked for a confidence interval on the audio verdict-flip rate. This delivers the tool that attaches one — and the honest answer is that **the interval bounds nothing**, which is the finding, not a shortfall.

## What the three pinned gradings say

Same inference, same grading config, same grader source hash, three times:

| stratum | items | same-item pairs | flips | rate |
|---|---|---|---|---|
| **audio** | 31 | 93 | 18 | **19.35%** |
| formatting | 10 | 30 | 2 | 6.67% |
| text | 63 | 189 | 4 | **2.12%** |
| visual | 4 | 12 | 0 | 0% |

The direction is recorded too, not just the count: audio `pass→fail` 10, `fail→pass` 6, `pass→partial` 2. The scored denominator did not move between the three gradings (4 items excluded in all three, always the same visual ones, never an audio one), so a flip is a flip and not a change of what was being divided by.

## Why the requested interval cannot be informative here

The corpus has exactly **three** audio tasks. Clustering at the task unit — which is the correct unit, since items within a task share a deliverable and a judge context — means resampling three clusters. A ratio of sums over `k` clusters is a weighted average of the per-task rates, so **every attainable value lies inside `[min task rate, max task rate]`**. The three all-same draws attain those endpoints with probability `1/27 = 3.70%` each, which is **above the 2.5% tail being cut**. So the 2.5/97.5 percentiles *are* the extremes, and the "95% interval" `[13.33, 23.81]` is just the range of the three task rates written in interval notation.

The tool does not quietly print it anyway. It reports `is_informative: false`, gives `P(extreme draw) = 0.0370` against the 2.5% cut, and states it in words in the readable report.

Two things make that claim checkable rather than assertable:

- **More repeats would not narrow it.** The test derives the numerators and denominators from the tool's own per-task output and scales them ×2, ×10, ×100. The bootstrap endpoints and the extremes are identical every time. The width converges to the true between-task spread — `width_floor_pp = 10.48` — **not to zero**.
- **A fourth task is what would cut a tail.** With four clusters there are 256 draws, `1/256 = 0.39% < 2.5%`, `is_informative` flips to true and the quantiles land strictly inside the extremes. The tool reports `clusters_needed_for_a_cut_tail: 4`. The corpus has three, and [the cohort work](https://github.com/hyeonsangjeon/gdpval-realworks/pull/379) already established that a fourth audio task does not exist in this data.

The 27-draw enumeration is exact, not sampled: it sums to 27, every weight is a `Fraction`, and there are 10 distinct attainable values. The item-unit interval is reported beside it (`[11.83, 27.96]`, 1.54× wider) so the choice of unit is visible rather than hidden.

## What the same three runs *do* support

Audio items flip far more than text items at the same fingerprint: **19.35% vs 2.12%, a gap of 17.24pp**, one-sided stratified permutation **p = 0.0012** against the preregistered alpha of 0.01 — and the gap holds inside **every one of the three tasks separately**, so it is not one task carrying the result.

## Negative controls

The tool was restored byte-identically after each (`diff -q` confirmed):

| control | mutation | test that caught it | observed |
|---|---|---|---|
| A | shuffle labels across all members instead of within task | `test_a_gap_that_is_really_about_task_sizes_is_not_reported_as_a_finding` | p = 0.0005 (test demands > 0.5) |
| B | expand each item into its 3 pair-observations before shuffling | `test_the_permutation_moves_whole_items_and_not_single_comparisons` | p = 0.059 (test demands 0.35–0.65) |
| C | `p = at_least/draws` instead of `(1+at_least)/(1+draws)` | `test_a_p_value_cannot_come_out_at_zero` | 0.00119 vs the required 0.0011999880 |

Control A is a Simpson-style confounded cohort: 20 audio + 2 text in one task, 2 audio + 20 text in another, with a large *pooled* gap and **zero** within-task gap. Control B is a 1-audio-vs-1-item-text cohort where pair-level and item-level shuffling give p ≈ 0.05 vs p ≈ 0.5 — the two schemes are distinguishable there, which is what makes the test able to fail for the reason its docstring gives.

The reverse case is covered too: a cohort where *text* flips more does not come out as an audio finding.

## Why a sibling file and not a flag

`analyze_repeat_variation.py` is held byte-for-byte by `test_repeat_variation_report_quotes_its_run.py`, which re-runs the command embedded in its own report and demands identical output. It also **refuses** audio-bearing runs by design, because averaging a never-listened grading into an audio flip rate is the exact error the 30-task cohort was rejected for. The two tools now refuse each other's cohorts and that mutual refusal is asserted in both directions.

## Fingerprint and cost

- Neither new file is in the grader fingerprint set (`step8_grade.py`, `core/**/*.py`, `schemas/grade.schema.json`, `requirements.txt`, `scripts/download_inference_from_hf.py`, the prompt template, the config itself). **No `grader_source_hash` moves.**
- The workflow's `GRADING_INPUT_PATHS` guard is deliberately broader than the fingerprint and does include `batch-runner/scripts`, so this was held until **0 Grade Pipeline runs were in flight** — verified before push and re-verified before merge.
- **Cost: nothing. No model was called.** The three gradings were already bought.
- Cost for those runs remains **미등록 / unpriced**, not `$0`: `gpt-5.6-sol` and `gpt-audio-1.5` are absent from the price table.

## Verification

- New file: **28 tests**, all passing.
- Full backend suite green at this base; `mypy core/` unchanged from main's baseline (174 errors in 32 files), and `mypy` on the new script is clean.
- `.gitignore` ignores `batch-runner/scripts/*` wholesale, so the negation on line 60 is what makes the tool shippable at all — without it this PR would have added tests for a file no clone receives.
