### PR TITLE
feat(grading): measure whether the audio grader is right, not just consistent

### DIFF
--- a/.github/workflows/audio-accuracy-probe.yml
+++ b/.github/workflows/audio-accuracy-probe.yml
@@ -1,0 +1,298 @@
+name: Audio Accuracy Probe
+
+# Step 4 of the audio-confidence card, and the last one.
+#
+# The three repeat runs measured how often the audio sub-judge disagrees with
+# itself: 19.35% of verdict pairs, against 2.12% on text items. That is
+# consistency. It does not say which of the two answers was right, and it
+# cannot -- every item in that corpus is scored against an expert deliverable
+# whose own correctness is one of the two open readings the card names.
+#
+# This workflow runs the one measurement that separates them, on clips whose
+# contents are arithmetic rather than opinion. Twelve criteria, six true and
+# six false, matched in pairs on five clips synthesised from a segment list at
+# run time. Nothing is downloaded and no audio is committed; the clips are
+# rendered from `wave` and `math` and their digests go into the report.
+#
+# What it does NOT do, deliberately:
+#   * It does not grade anything. No task, no rubric, no deliverable, no
+#     corpus. It calls the audio sub-judge directly, so a run here cannot
+#     write a grade or move a published number.
+#   * It does not publish. The report goes out as an artifact, not a commit --
+#     these are diagnostic verdicts on synthetic clips and they have no place
+#     in data/grades or on the dashboard.
+#   * It does not move any grader fingerprint. The script lives in
+#     batch-runner/scripts/, and `compute_grader_source_hash` takes exactly one
+#     file from that directory (download_inference_from_hf.py). A test in
+#     tests/test_audio_accuracy_probe_knows_its_own_answers.py proves it by
+#     adding a file there and recomputing the hash.
+#
+# It still spends money, so the paid half sits behind the same `grading`
+# environment gate every other paid path in this repository uses. A gate that
+# is reused rather than duplicated is one fewer approval surface to audit.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run the whole path against a stub that answers from the segment list. No network call, no cost, and no measurement of the model. Run this first.'
+        required: true
+        type: boolean
+        default: true
+      paid_approval:
+        description: 'Required for a measured run. Unchecked plus dry_run false is refused before the gate, so a mis-set dispatch fails in seconds instead of waiting on a reviewer.'
+        required: true
+        type: boolean
+        default: false
+      repeats:
+        description: 'How many times each criterion is put to the model. 3 matches the repeat runs, so stability here is comparable with the 19.35%. Total calls = 12 criteria x repeats.'
+        required: false
+        type: number
+        default: 3
+
+# Read-only by default. The paid job adds id-token for OIDC and nothing else:
+# there is no commit, no release, and no dispatch to make.
+permissions:
+  contents: read
+
+# One at a time. Two concurrent probes would interleave their calls against the
+# same deployment's TPM budget and each would measure the other's throttling.
+concurrency:
+  group: audio-accuracy-probe
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # The free half. Runs on every dispatch, including the paid one, and the paid
+  # job waits on it -- so a report shape that cannot be produced at all is
+  # discovered before a reviewer is asked to approve spending on it.
+  # ---------------------------------------------------------------------------
+  dry-run:
+    name: Dry run (no model call, no cost)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: batch-runner/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          pip install -r requirements.txt
+
+      # The probe's ground truth is only worth what this suite says it is: it
+      # decodes the rendered bytes back -- after the grader's own re-encode --
+      # and measures the onsets, the burst count, the click interval and the
+      # pitch order off the waveform the model will actually hear. If the
+      # corpus and the description of the corpus have drifted apart, nothing
+      # below is worth running.
+      - name: Prove the probe knows its own answers
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python -m pytest tests/test_audio_accuracy_probe_knows_its_own_answers.py -q
+
+      - name: Dry run
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/measure_audio_grading_accuracy.py \
+            --dry-run \
+            --repeats "${{ inputs.repeats }}" \
+            --out "$GITHUB_WORKSPACE/audio-accuracy-dry-run.json"
+
+      # A dry run reports 100% accuracy, because the stub answers from the
+      # segment list. That is a shape check and not a result, and the report
+      # carries `measured: false` so it cannot be read as one. This step says
+      # the same thing where a human will see it.
+      - name: Summarise
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, os
+          report = json.load(open(os.path.join(os.environ["GITHUB_WORKSPACE"], "audio-accuracy-dry-run.json")))
+          acc = report["accuracy"]
+          print("## Audio accuracy probe — dry run\n")
+          print("**This measured nothing about `gpt-audio-1.5`.** The stub answers")
+          print("from the segment list, so a perfect score here means the pipeline")
+          print("works, not that the model listens.\n")
+          print(f"- `measured`: `{json.dumps(report['measured'])}`")
+          print(f"- calls: {acc['overall']['calls']}, billable: {report['cost']['billable_calls']}")
+          print(f"- claims: {report['pins']['claims']} "
+                f"({report['pins']['true_claims']} true / {report['pins']['false_claims']} false)")
+          print(f"- cost: `{json.dumps(report['cost']['estimated_cost_usd'])}`")
+          PY
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: audio-accuracy-dry-run
+          path: audio-accuracy-dry-run.json
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # The gate. Same reusable `grading` environment as every other paid path
+  # here, so approving a probe is the same act, in the same place, with the same
+  # reviewers, as approving a grading run.
+  # ---------------------------------------------------------------------------
+  approve-paid:
+    name: Approve paid audio accuracy probe
+    needs: dry-run
+    if: ${{ inputs.dry_run == false && inputs.paid_approval == true }}
+    runs-on: ubuntu-24.04
+    environment:
+      name: grading
+    steps:
+      - name: Record approved request
+        env:
+          PROBE_REPEATS: ${{ inputs.repeats }}
+        run: |
+          printf '%s\n' \
+            "Approved paid audio accuracy probe:" \
+            "  model      = gpt-audio-1.5 (read from gold_audio_repeat_v2_sol_max.yaml)" \
+            "  criteria   = 12 (6 true / 6 false)" \
+            "  repeats    = $PROBE_REPEATS" \
+            "  calls      = $((12 * PROBE_REPEATS))" \
+            "  grades     = none. This does not write a grade or touch a corpus."
+
+  # ---------------------------------------------------------------------------
+  # A dispatch with dry_run false and paid_approval unchecked is a mistake, and
+  # it should cost seconds rather than a reviewer's attention. This job says so
+  # and fails, instead of letting the run sit pending on a gate nobody expects.
+  # ---------------------------------------------------------------------------
+  refuse-unapproved:
+    name: Refuse an unapproved paid dispatch
+    if: ${{ inputs.dry_run == false && inputs.paid_approval != true }}
+    runs-on: ubuntu-24.04
+    steps:
+      - run: |
+          echo "::error::dry_run is false but paid_approval is not checked; refusing before the gate"
+          exit 1
+
+  measure:
+    name: Measure (paid, ${{ inputs.repeats }} repeats)
+    needs: approve-paid
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: batch-runner/requirements.txt
+
+      # Plain runner, not the grading container. The image exists to pin
+      # LibreOffice, and nothing here renders a deliverable. What does matter
+      # is PyAV, which performs the 16 kHz mono re-encode on the way out --
+      # and the clips are *authored* at 16 kHz mono 16-bit, so that step is an
+      # identity transform whatever version resolves. The dry-run job proves
+      # it: it decodes the encoder's own output and re-measures the waveform.
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          pip install -r requirements.txt
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify Azure OIDC session identity
+        env:
+          AZURE_AI_EXPECTED_CLIENT_ID: ${{ vars.AZURE_AI_EXPECTED_CLIENT_ID }}
+          AZURE_AI_EXPECTED_TENANT_ID: ${{ vars.AZURE_AI_EXPECTED_TENANT_ID }}
+          AZURE_AI_EXPECTED_SUBSCRIPTION_ID: ${{ vars.AZURE_AI_EXPECTED_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/azure_oidc_identity_preflight.py --verify-session
+
+      # Same route profile and the same identity assertions the grading run
+      # uses. The point of this measurement is to describe the audio path the
+      # 19.35% came off; reaching it by a different route would describe
+      # something else.
+      - name: Measure
+        env:
+          AZURE_AI_ROUTE_PROFILE: direct-v1
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
+          AZURE_AI_REQUIRE_EXPECTED_IDENTITIES: '1'
+          AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          cd batch-runner
+          python scripts/measure_audio_grading_accuracy.py \
+            --repeats "${{ inputs.repeats }}" \
+            --out "$GITHUB_WORKSPACE/audio-accuracy-measured.json"
+
+      - name: Summarise
+        if: always()
+        run: |
+          set -euo pipefail
+          test -f "$GITHUB_WORKSPACE/audio-accuracy-measured.json" || exit 0
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, os
+          report = json.load(open(os.path.join(os.environ["GITHUB_WORKSPACE"], "audio-accuracy-measured.json")))
+          acc = report["accuracy"]
+          j = acc["discrimination_j"]
+          perm = acc["permutation"]
+
+          def pct(value):
+              return "n/a" if value is None else f"{value * 100:.2f}%"
+
+          print("## Audio accuracy probe — measured\n")
+          print(f"Model `{report['pins']['audio_deployment']}`, "
+                f"{report['pins']['claims']} criteria x {report['pins']['repeats']} repeats "
+                f"= {acc['overall']['calls']} calls.\n")
+          print("| | |")
+          print("|---|---|")
+          print(f"| accuracy (answered calls) | {pct(acc['overall']['accuracy'])} |")
+          print(f"| false-fail rate (on true claims) | {pct(acc['on_true_claims']['false_fail_rate'])} |")
+          print(f"| false-pass rate (on false claims) | {pct(acc['on_false_claims']['false_pass_rate'])} |")
+          print(f"| hedged (`partial`) | {acc['overall']['hedged']} |")
+          print(f"| unanswered (`judge_error`) | {acc['overall']['unanswered']} |")
+          print(f"| **discrimination (Youden's J)** | **{j['per_call']}** |")
+          print(f"| permutation p (one-sided) | {perm['p_one_sided']} |")
+          print(f"| smallest p this design can reach | {perm['smallest_attainable_p']} |")
+          print()
+          print("**J = 0 would mean the verdict does not depend on the audio.** A model")
+          print("answering `pass` to everything scores 50% accuracy on this balanced")
+          print("corpus and J = 0; accuracy alone cannot tell a listener from a coin.\n")
+          print(f"This design cannot produce a p below "
+                f"{perm['smallest_attainable_p']} — six pairs, 64 relabellings. "
+                "Significant at 0.05 is the ceiling; 0.01 is out of reach.\n")
+          print("### Cost\n")
+          print(f"- billable calls: {report['cost']['billable_calls']}")
+          print(f"- pricing complete: `{json.dumps(report['cost']['pricing_complete'])}`")
+          print(f"- unpriced models: `{json.dumps(report['cost']['unpriced_models'])}`")
+          print(f"- estimated cost: `{json.dumps(report['cost']['estimated_cost_usd'])}` — "
+                "**null, not $0.** An unpriced model costs an unknown amount.")
+          print("\n### By family\n")
+          print("| family | answered | correct | false fail | false pass | hedged |")
+          print("|---|---|---|---|---|---|")
+          for name, row in acc["by_family"].items():
+              print(f"| {name} | {row['answered']} | {row['correct']} | "
+                    f"{row['false_fail']} | {row['false_pass']} | {row['hedged']} |")
+          PY
+
+      # Artifact, not a commit. These are verdicts on five synthetic clips and
+      # they are not grades; putting them in data/grades would make them show
+      # up on the dashboard as if they were.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: audio-accuracy-measured
+          path: audio-accuracy-measured.json
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/azure_rbac_diagnostic.py
 !batch-runner/scripts/analyze_repeat_variation.py
 !batch-runner/scripts/analyze_audio_repeat_variation.py
+!batch-runner/scripts/measure_audio_grading_accuracy.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/batch-runner/scripts/measure_audio_grading_accuracy.py
+++ b/batch-runner/scripts/measure_audio_grading_accuracy.py
@@ -1,0 +1,1146 @@
+#!/usr/bin/env python3
+"""Measure whether the audio sub-judge is *right*, not merely consistent.
+
+Step 4 of the audio-confidence card, and the last one. Steps 1-3 pinned an
+audio cohort, bought three gradings of it at one fingerprint, and measured how
+often the verdicts disagree with each other: 19.35% of pairs, against 2.12% on
+text items. That is a *consistency* figure. It says the audio path is unsteady.
+It does not say which of the two answers was the right one, and it cannot:
+every item in that corpus is scored against an expert deliverable whose own
+correctness is one of the two open interpretations the card names.
+
+    1. the expert answer really did miss the spec, or
+    2. ``gpt-audio-1.5`` is not accurate enough to check a claim like that.
+
+Nothing measured so far separates those, because nothing measured so far had a
+ground truth that did not depend on a human. A repeat run tells you the model
+agrees with itself. It does not tell you the model is listening.
+
+So this script builds its own corpus, out of nothing but arithmetic.
+
+Every clip here is synthesised from a segment list -- a start time, an end
+time, and either a frequency or silence -- by :func:`render_clip`, using only
+``wave`` and ``math`` from the standard library. There is no recording, no
+asset, no download, and nothing committed as bytes. What is in the clip is
+what the segment list says is in it, and the accompanying test decodes the
+rendered samples back and checks that the waveform really has the onsets, the
+gaps, the beep count and the pitch order the segments claim. **The ground
+truth is not asserted in prose; it is measured off the same bytes the model
+hears.**
+
+Against those clips it puts twelve criteria, six of which are true and six of
+which are false, matched in pairs so that each clip carries one of each. The
+criteria are written the way the gold rubric writes them, and the families
+they fall into are the families that actually failed on the gold run:
+
+* ``timing``       -- a tone stops partway through; a criterion says it does
+                      not. This is the exact shape of the 0.95-vs-0.96
+                      contradiction quoted on the card.
+* ``presence``     -- a silent clip, and a criterion claiming speech.
+* ``count``        -- three beeps, and a criterion claiming seven.
+* ``tempo_coarse`` -- a 120 BPM click track, and a criterion claiming 60.
+* ``tempo_fine``   -- the same track, and a criterion claiming 132 +/- 1 BPM.
+  The gold run failed an expert deliverable on a "140 BPM" criterion off a
+  61-89 token answer. Whether a claim at that resolution is answerable at all
+  is a question this family exists to answer.
+* ``pitch_order``  -- low then high, and a criterion claiming high then low.
+
+What comes out is not one number but three, and the third is the one that
+matters:
+
+``false_fail_rate``
+    How often a criterion that is *true of the clip* is marked ``fail``. This
+    is the error that makes a correct deliverable look wrong, and it is the
+    direct test of interpretation 2 above.
+
+``false_pass_rate``
+    How often a criterion that is *false of the clip* is marked ``pass``.
+    This is the error that inflates a score.
+
+``discrimination_j``
+    ``P(pass | true) - P(pass | false)``. Youden's J. **Zero means the verdict
+    does not depend on the audio at all** -- a model answering "pass" to
+    everything scores 50% accuracy on a balanced set and J = 0, and this is
+    the number that refuses to let that read as half-right. Accuracy alone
+    cannot tell a listener from a coin, and a balanced corpus is exactly where
+    that failure hides.
+
+The significance of J is taken by *exhaustive* enumeration of the 64 ways the
+six true/false labels could be swapped within their pairs -- not sampling, so
+the p-value is exact and the script has no random state to pin. That design
+has a floor, and the floor is reported rather than left for a reader to
+discover: with six pairs the smallest p this can ever produce is 1/64 =
+0.015625. A perfect result is significant at 0.05 and can never reach 0.01.
+Saying so here is the same discipline as ``is_informative: false`` on the
+repeat-variation interval -- the number is published *with* the bound on what
+it can support.
+
+The identity is not chosen here. It is read out of the grading config the
+repeat runs used, so the accuracy figure is measured on the same deployment,
+the same clip length and the same call cap as the 19.35% it exists to explain.
+A test asserts that; if the config moves, this refuses rather than quietly
+measuring a different model.
+
+Usage::
+
+    python3 scripts/measure_audio_grading_accuracy.py --dry-run
+    python3 scripts/measure_audio_grading_accuracy.py --repeats 3 --out report.json
+
+``--dry-run`` runs the whole path -- render, encode, prompt, parse, score,
+aggregate -- against a stub that answers from the segment list instead of a
+model. It makes no network call and costs nothing. It exists so the shape of
+this report is proven in CI on every commit, rather than first observed on the
+run that is being paid for.
+
+Exit status:
+
+    0   the measurement was made and is reportable
+    2   at least one criterion got no answer at all, so a family cell of the
+        breakdown would be computed from an empty denominator
+    3   the pinned identity does not match the grading config it claims to
+        share, so whatever was measured was not measured on the audio path
+        under test
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import itertools
+import json
+import math
+import os
+import struct
+import sys
+import tempfile
+import wave
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Iterator, Optional, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.perception.audio import (  # noqa: E402
+    AUDIO_CALL_CAP,
+    AUDIO_SAMPLE_RATE_HZ,
+    AUDIO_TRIM_SECONDS,
+    AudioPerception,
+    AudioVerdict,
+    criterion_listen_start,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: The grading config whose audio identity this measurement borrows. Steps 2
+#: and 3 of the card bought three runs of this config; the whole point of step
+#: 4 is to describe *that* model, so the deployment, the clip length and the
+#: per-task cap are read out of it rather than restated here.
+PINNED_CONFIG = (
+    REPO_ROOT
+    / "batch-runner"
+    / "grading_configs"
+    / "gold_audio_repeat_v2_sol_max.yaml"
+)
+
+#: What the repeat runs measured, quoted so a reader of this report does not
+#: have to go and find it. Consistency, not accuracy -- which is why this file
+#: exists.
+REPEAT_FLIP_RATE_PCT = 19.35
+REPEAT_TEXT_FLIP_RATE_PCT = 2.12
+
+#: Amplitude of a rendered tone, as a fraction of full scale. Loud enough that
+#: no plausible re-encode loses it, quiet enough not to clip when PyAV
+#: resamples.
+TONE_AMPLITUDE = 0.6
+
+#: Every clip is rendered at exactly the rate the grader re-encodes to, so the
+#: resample on the way out is a no-op in substance and the model hears the
+#: waveform this file wrote. A test pins the equality.
+CLIP_SAMPLE_RATE_HZ = AUDIO_SAMPLE_RATE_HZ
+
+
+# --------------------------------------------------------------------------
+# The corpus: segments in, waveform out, ground truth in between
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Segment:
+    """One stretch of a clip and what is objectively inside it.
+
+    ``frequency_hz`` of ``None`` means digital silence -- samples of exactly
+    zero, not low-level noise, so "is anything audible here" has an answer
+    that survives any encoder.
+    """
+
+    start_s: float
+    end_s: float
+    frequency_hz: Optional[float]
+
+    @property
+    def duration_s(self) -> float:
+        return self.end_s - self.start_s
+
+    @property
+    def is_silent(self) -> bool:
+        return self.frequency_hz is None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "start_s": round(self.start_s, 6),
+            "end_s": round(self.end_s, 6),
+            "frequency_hz": self.frequency_hz,
+        }
+
+
+@dataclass(frozen=True)
+class Clip:
+    """A synthesised clip whose contents are known by construction."""
+
+    clip_id: str
+    duration_s: float
+    segments: tuple[Segment, ...]
+    #: One plain sentence a human can check the segment list against. Not used
+    #: in scoring -- the segments are the truth -- but carried into the report
+    #: so a reader does not have to reconstruct the clip in their head.
+    description: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "clip_id": self.clip_id,
+            "duration_s": self.duration_s,
+            "description": self.description,
+            "segments": [segment.to_dict() for segment in self.segments],
+        }
+
+
+def _tone_samples(
+    frequency_hz: float, count: int, phase_offset: int
+) -> Iterator[float]:
+    """A sine at ``frequency_hz``, continuous across segment boundaries.
+
+    ``phase_offset`` is the sample index this segment starts at within the
+    whole clip, so a segment that repeats a frequency picks the wave up where
+    the previous one left it instead of restarting at zero. Restarting would
+    put a click at every boundary, and a click is an audible event this corpus
+    has not declared.
+    """
+    step = 2.0 * math.pi * frequency_hz / CLIP_SAMPLE_RATE_HZ
+    for index in range(count):
+        yield TONE_AMPLITUDE * math.sin(step * (phase_offset + index))
+
+
+def clip_samples(clip: Clip) -> list[float]:
+    """Render a clip to floats in [-1, 1], gaps included.
+
+    Anything the segment list does not cover is silence. That is deliberate:
+    a clip is defined by what it *contains*, and the space between two beeps
+    should not need its own entry to be quiet.
+    """
+    total = int(round(clip.duration_s * CLIP_SAMPLE_RATE_HZ))
+    samples = [0.0] * total
+    for segment in clip.segments:
+        if segment.is_silent:
+            continue
+        start = int(round(segment.start_s * CLIP_SAMPLE_RATE_HZ))
+        stop = min(total, int(round(segment.end_s * CLIP_SAMPLE_RATE_HZ)))
+        if stop <= start:
+            continue
+        assert segment.frequency_hz is not None
+        for offset, value in enumerate(
+            _tone_samples(segment.frequency_hz, stop - start, start)
+        ):
+            samples[start + offset] = value
+    return samples
+
+
+def render_clip(clip: Clip, path: Path) -> str:
+    """Write ``clip`` to ``path`` as 16-bit mono PCM. Returns its sha256.
+
+    The digest is reported so the clip a verdict was reached on can be
+    re-derived and re-checked later without trusting this run.
+    """
+    frames = b"".join(
+        struct.pack("<h", max(-32768, min(32767, int(round(value * 32767)))))
+        for value in clip_samples(clip)
+    )
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(CLIP_SAMPLE_RATE_HZ)
+        handle.writeframes(frames)
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+CLIPS: tuple[Clip, ...] = (
+    Clip(
+        clip_id="tone_stops_early",
+        duration_s=6.0,
+        segments=(Segment(0.0, 2.0, 1000.0),),
+        description=(
+            "A 1000 Hz tone for the first two seconds, then four seconds of "
+            "silence."
+        ),
+    ),
+    Clip(
+        clip_id="pure_silence",
+        duration_s=6.0,
+        segments=(),
+        description="Six seconds of digital silence; every sample is zero.",
+    ),
+    Clip(
+        clip_id="three_beeps",
+        duration_s=5.0,
+        segments=(
+            Segment(0.5, 0.65, 1000.0),
+            Segment(2.0, 2.15, 1000.0),
+            Segment(3.5, 3.65, 1000.0),
+        ),
+        description=(
+            "Three 150 ms beeps at 1000 Hz, at 0.5 s, 2.0 s and 3.5 s, "
+            "silence in between."
+        ),
+    ),
+    Clip(
+        clip_id="clicks_120bpm",
+        duration_s=8.0,
+        segments=tuple(
+            Segment(index * 0.5, index * 0.5 + 0.03, 1000.0)
+            for index in range(16)
+        ),
+        description=(
+            "Sixteen 30 ms clicks spaced exactly 0.5 s apart across eight "
+            "seconds, which is 120 beats per minute."
+        ),
+    ),
+    Clip(
+        clip_id="low_then_high",
+        duration_s=5.0,
+        segments=(
+            Segment(0.0, 2.0, 220.0),
+            Segment(3.0, 5.0, 880.0),
+        ),
+        description=(
+            "A 220 Hz tone for two seconds, one second of silence, then a "
+            "880 Hz tone for two seconds -- two octaves up."
+        ),
+    ),
+)
+
+CLIPS_BY_ID = {clip.clip_id: clip for clip in CLIPS}
+
+
+# --------------------------------------------------------------------------
+# The criteria
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Claim:
+    """One rubric-shaped criterion whose truth is decided by the segments."""
+
+    claim_id: str
+    clip_id: str
+    family: str
+    criterion: str
+    #: Whether the criterion is true of the clip. This is the ground truth,
+    #: and it is checkable against the rendered waveform by the test suite.
+    holds: bool
+    #: The arithmetic that settles it, for a reader who does not want to
+    #: reconstruct the segment list.
+    because: str
+
+    @property
+    def pair_id(self) -> str:
+        """The claim_id without its ``_true`` / ``_false`` suffix.
+
+        Claims come in matched pairs on the same clip, and the permutation
+        test swaps labels *within* a pair. That is what keeps a relabelling
+        from producing a corpus that could not have existed -- two true
+        criteria about one clip and none about another.
+        """
+        return self.claim_id.rsplit("_", 1)[0]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            "clip_id": self.clip_id,
+            "family": self.family,
+            "criterion": self.criterion,
+            "holds": self.holds,
+            "because": self.because,
+            "pair_id": self.pair_id,
+        }
+
+
+CLAIMS: tuple[Claim, ...] = (
+    Claim(
+        claim_id="timing_true",
+        clip_id="tone_stops_early",
+        family="timing",
+        criterion=(
+            "A sustained tone is audible from the beginning of the clip and "
+            "stops before the clip ends, leaving an audible stretch of "
+            "silence at the end."
+        ),
+        holds=True,
+        because="the tone occupies 0.0-2.0 s of a 6.0 s clip",
+    ),
+    Claim(
+        claim_id="timing_false",
+        clip_id="tone_stops_early",
+        family="timing",
+        criterion=(
+            "A sustained tone is audible continuously for the whole clip, "
+            "with no stretch of silence anywhere in it."
+        ),
+        holds=False,
+        because="4.0 s of the 6.0 s clip is digital silence",
+    ),
+    Claim(
+        claim_id="presence_true",
+        clip_id="pure_silence",
+        family="presence",
+        criterion=(
+            "Nothing is audible in the clip: no speech, music, tone or noise."
+        ),
+        holds=True,
+        because="every sample in the clip is exactly zero",
+    ),
+    Claim(
+        claim_id="presence_false",
+        clip_id="pure_silence",
+        family="presence",
+        criterion="A human voice speaking is audible in the clip.",
+        holds=False,
+        because="every sample in the clip is exactly zero",
+    ),
+    Claim(
+        claim_id="count_true",
+        clip_id="three_beeps",
+        family="count",
+        criterion=(
+            "Exactly three short beeps are audible, each separated from the "
+            "next by silence."
+        ),
+        holds=True,
+        because="the segment list has three tone bursts",
+    ),
+    Claim(
+        claim_id="count_false",
+        clip_id="three_beeps",
+        family="count",
+        criterion=(
+            "Exactly seven short beeps are audible, each separated from the "
+            "next by silence."
+        ),
+        holds=False,
+        because="the segment list has three tone bursts, not seven",
+    ),
+    Claim(
+        claim_id="tempo_coarse_true",
+        clip_id="clicks_120bpm",
+        family="tempo_coarse",
+        criterion=(
+            "The clicks are evenly spaced at a tempo of about 120 beats per "
+            "minute."
+        ),
+        holds=True,
+        because="clicks are 0.5 s apart, which is exactly 120 BPM",
+    ),
+    Claim(
+        claim_id="tempo_coarse_false",
+        clip_id="clicks_120bpm",
+        family="tempo_coarse",
+        criterion=(
+            "The clicks are evenly spaced at a tempo of about 60 beats per "
+            "minute."
+        ),
+        holds=False,
+        because="60 BPM would be 1.0 s apart; these are 0.5 s apart",
+    ),
+    Claim(
+        claim_id="tempo_fine_true",
+        clip_id="clicks_120bpm",
+        family="tempo_fine",
+        criterion=(
+            "The tempo of the clicks is 120 beats per minute, within a "
+            "tolerance of one beat per minute."
+        ),
+        holds=True,
+        because="clicks are 0.5 s apart, which is exactly 120 BPM",
+    ),
+    Claim(
+        claim_id="tempo_fine_false",
+        clip_id="clicks_120bpm",
+        family="tempo_fine",
+        criterion=(
+            "The tempo of the clicks is 132 beats per minute, within a "
+            "tolerance of one beat per minute."
+        ),
+        holds=False,
+        because="132 BPM would be 0.4545 s apart; these are 0.5 s apart",
+    ),
+    Claim(
+        claim_id="pitch_order_true",
+        clip_id="low_then_high",
+        family="pitch_order",
+        criterion=(
+            "The clip opens with a lower-pitched tone and closes with a "
+            "higher-pitched one."
+        ),
+        holds=True,
+        because="220 Hz precedes 880 Hz",
+    ),
+    Claim(
+        claim_id="pitch_order_false",
+        clip_id="low_then_high",
+        family="pitch_order",
+        criterion=(
+            "The clip opens with a higher-pitched tone and closes with a "
+            "lower-pitched one."
+        ),
+        holds=False,
+        because="220 Hz precedes 880 Hz, so the order is the other way round",
+    ),
+)
+
+
+# --------------------------------------------------------------------------
+# Scoring
+# --------------------------------------------------------------------------
+
+#: What a single verdict on a single claim was.
+OUTCOME_CORRECT = "correct"
+OUTCOME_FALSE_FAIL = "false_fail"
+OUTCOME_FALSE_PASS = "false_pass"
+OUTCOME_HEDGED = "hedged"
+OUTCOME_UNANSWERED = "unanswered"
+
+
+def classify(claim: Claim, verdict: str) -> str:
+    """Turn one verdict into one outcome.
+
+    ``partial`` is its own outcome rather than being folded into either error.
+    These criteria are binary statements about arithmetic -- a clip either has
+    three beeps or it does not -- so a hedge is not a near-miss, it is a
+    refusal to answer the question that was asked, and burying it in the
+    accuracy rate would hide it in whichever direction happened to be
+    convenient.
+
+    ``judge_error`` is not an answer at all. It never counts as correct and it
+    never counts as wrong; it counts as a call that measured nothing, and the
+    denominators below exclude it.
+    """
+    if verdict == "judge_error":
+        return OUTCOME_UNANSWERED
+    if verdict == "partial":
+        return OUTCOME_HEDGED
+    said_pass = verdict == "pass"
+    if claim.holds:
+        return OUTCOME_CORRECT if said_pass else OUTCOME_FALSE_FAIL
+    return OUTCOME_FALSE_PASS if said_pass else OUTCOME_CORRECT
+
+
+def _rate(numerator: int, denominator: int) -> Optional[float]:
+    """A rate, or ``None`` when there is nothing to divide by.
+
+    Never zero for an empty denominator. Zero is a measurement; this is the
+    absence of one, and the two must not print the same.
+    """
+    if denominator <= 0:
+        return None
+    return numerator / denominator
+
+
+@dataclass
+class Tally:
+    """Outcome counts over some slice of the calls."""
+
+    correct: int = 0
+    false_fail: int = 0
+    false_pass: int = 0
+    hedged: int = 0
+    unanswered: int = 0
+
+    def add(self, outcome: str) -> None:
+        setattr(self, outcome, getattr(self, outcome) + 1)
+
+    @property
+    def answered(self) -> int:
+        """Calls that produced a verdict, hedges included.
+
+        A hedge answered; it just did not decide. Excluding it from the
+        denominator would let a model that hedged eleven times out of twelve
+        and guessed the last one report 100% accuracy.
+        """
+        return self.correct + self.false_fail + self.false_pass + self.hedged
+
+    @property
+    def calls(self) -> int:
+        return self.answered + self.unanswered
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "calls": self.calls,
+            "answered": self.answered,
+            "correct": self.correct,
+            "false_fail": self.false_fail,
+            "false_pass": self.false_pass,
+            "hedged": self.hedged,
+            "unanswered": self.unanswered,
+            "accuracy": _rate(self.correct, self.answered),
+        }
+
+
+def discrimination(
+    labelled: Sequence[tuple[bool, str]],
+) -> Optional[float]:
+    """Youden's J over ``(holds, verdict)`` pairs: P(pass|true) - P(pass|false).
+
+    The point of this number is that accuracy on a balanced corpus cannot
+    distinguish a listener from a constant. Answer ``pass`` to all twelve
+    criteria and accuracy is 50%; answer ``fail`` to all twelve and accuracy
+    is 50%. Both give J = 0. Only a verdict that moves with the audio gives
+    J > 0.
+
+    ``None`` when either side has no answered call, for the reason in
+    :func:`_rate`.
+    """
+    true_side = [v for holds, v in labelled if holds and v != "judge_error"]
+    false_side = [v for holds, v in labelled if not holds and v != "judge_error"]
+    if not true_side or not false_side:
+        return None
+    pass_given_true = sum(1 for v in true_side if v == "pass") / len(true_side)
+    pass_given_false = sum(1 for v in false_side if v == "pass") / len(false_side)
+    return pass_given_true - pass_given_false
+
+
+def permute_within_pairs(
+    calls: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    """Exact p-value for J, by swapping the labels inside each matched pair.
+
+    Six pairs, so 2^6 = 64 relabellings, enumerated in full rather than
+    sampled. Exhaustive enumeration is what makes the p exact and what leaves
+    this script with no random state to seed -- the same input gives the same
+    number, forever, which is what the repeat-variation work needed and did
+    not get for free.
+
+    Swapping *within* a pair rather than across the whole corpus is the same
+    stratification the flip-rate permutation used. A free-for-all shuffle
+    would generate corpora that could not exist, such as two true criteria
+    about the silent clip, and a null built from impossible worlds is not the
+    null anyone wants to reject.
+
+    The floor is reported alongside the p, because it is a property of the
+    design and not of the result: the smallest value obtainable from 64
+    assignments is 1/64 = 0.015625. **This experiment cannot produce evidence
+    at the 0.01 level no matter how well the model does.** Adding repeats does
+    not change that; only more pairs would.
+    """
+    pairs = sorted({call["pair_id"] for call in calls})
+    observed = discrimination([(c["holds"], c["verdict"]) for c in calls])
+    if observed is None:
+        return {
+            "scheme": "within_pair",
+            "pairs": len(pairs),
+            "assignments": 0,
+            "observed_j": None,
+            "at_least_observed": None,
+            "p_one_sided": None,
+            "smallest_attainable_p": None,
+        }
+    at_least = 0
+    assignments = 0
+    for flips in itertools.product((False, True), repeat=len(pairs)):
+        flipped = dict(zip(pairs, flips))
+        relabelled = [
+            (
+                call["holds"] != flipped[call["pair_id"]],
+                call["verdict"],
+            )
+            for call in calls
+        ]
+        candidate = discrimination(relabelled)
+        assignments += 1
+        if candidate is not None and candidate >= observed - 1e-12:
+            at_least += 1
+    return {
+        "scheme": "within_pair",
+        "pairs": len(pairs),
+        "assignments": assignments,
+        "observed_j": observed,
+        "at_least_observed": at_least,
+        "p_one_sided": at_least / assignments if assignments else None,
+        "smallest_attainable_p": 1.0 / assignments if assignments else None,
+    }
+
+
+def majority_verdict(verdicts: Sequence[str]) -> Optional[str]:
+    """The verdict a claim gave most often, or ``None`` on a tie.
+
+    Ties are left as ``None`` rather than broken by order. A claim that
+    answered ``pass``, ``fail``, ``partial`` across three repeats has no
+    majority answer, and inventing one out of whichever came first would put
+    the flip rate this whole card is about inside the accuracy number without
+    saying so.
+    """
+    answered = [v for v in verdicts if v != "judge_error"]
+    if not answered:
+        return None
+    counts: dict[str, int] = {}
+    for verdict in answered:
+        counts[verdict] = counts.get(verdict, 0) + 1
+    best = max(counts.values())
+    winners = [v for v, n in counts.items() if n == best]
+    return winners[0] if len(winners) == 1 else None
+
+
+# --------------------------------------------------------------------------
+# Identity
+# --------------------------------------------------------------------------
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    import yaml  # local import: keeps --help working without the dependency
+
+    with path.open(encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{path} is not a mapping")
+    return loaded
+
+
+def pinned_identity(config_path: Path = PINNED_CONFIG) -> dict[str, Any]:
+    """The audio identity this measurement borrows, read from the config.
+
+    Not restated as constants. The figure produced here is only an
+    explanation of the 19.35% if it describes the same deployment at the same
+    clip length; reading it out of the file the repeat runs used is what makes
+    that true by construction instead of by a comment.
+
+    The identity is resolved with :func:`canonical_deployment` -- the same
+    call ``grader.py`` makes on the same config path -- rather than by pulling
+    the fields out here. A config whose ``model`` and ``deployment`` disagree
+    is rejected by the grader's own rule, not by a second implementation of it
+    that could drift.
+    """
+    from core.azure_ai_clients import canonical_deployment
+
+    config = _read_yaml(config_path)
+    judge = config.get("judge")
+    perception = judge.get("perception") if isinstance(judge, dict) else None
+    audio = perception.get("audio") if isinstance(perception, dict) else None
+    if not isinstance(audio, dict) or not audio:
+        raise ValueError(f"{config_path} has no judge.perception.audio")
+    deployment = canonical_deployment(audio, "judge.perception.audio")
+    return {
+        "config": config_path.name,
+        "audio_model": audio.get("model"),
+        "audio_deployment": deployment,
+        "audio_clip_seconds": int(audio.get("trim_seconds", AUDIO_TRIM_SECONDS)),
+        "audio_call_cap_per_task": int(
+            audio.get("call_cap_per_task", AUDIO_CALL_CAP)
+        ),
+        "provider": (
+            judge.get("provider", "azure_openai")
+            if isinstance(judge, dict)
+            else "azure_openai"
+        ),
+    }
+
+
+# --------------------------------------------------------------------------
+# The stub, for the free run
+# --------------------------------------------------------------------------
+
+
+class _StubChoice:
+    def __init__(self, content: str) -> None:
+        self.message = type("_M", (), {"content": content})()
+
+
+class _StubResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_StubChoice(content)]
+        self.usage = None
+
+
+class TruthfulStub:
+    """A stand-in that answers from the segment list instead of listening.
+
+    It exists so ``--dry-run`` exercises every line between here and the
+    scorer -- render, trim, base64, prompt assembly, envelope parse, tally,
+    permutation -- without a network call. It answers *correctly*, which makes
+    it a shape check and emphatically not a measurement: a dry run reporting
+    100% accuracy says the pipeline works, and says nothing whatsoever about
+    ``gpt-audio-1.5``. The report marks itself ``"measured": false`` for
+    exactly this reason.
+    """
+
+    def __init__(self, claims: Sequence[Claim]) -> None:
+        self._by_criterion = {claim.criterion: claim for claim in claims}
+        self.requests: list[dict[str, Any]] = []
+        self.chat = type("_Chat", (), {"completions": self})()
+
+    def create(self, **kwargs: Any) -> _StubResponse:
+        self.requests.append(kwargs)
+        text = ""
+        for part in kwargs["messages"][0]["content"]:
+            if part.get("type") == "text":
+                text = part["text"]
+        claim = None
+        for criterion, candidate in self._by_criterion.items():
+            if criterion in text:
+                claim = candidate
+                break
+        if claim is None:  # pragma: no cover - defended by a test
+            raise AssertionError("stub was sent a criterion it does not know")
+        return _StubResponse(
+            json.dumps(
+                {
+                    "verdict": "pass" if claim.holds else "fail",
+                    "partial_score": 1.0 if claim.holds else 0.0,
+                    "evidence": claim.because[:200],
+                    "confidence": 1.0,
+                    "reasoning": "stub: answered from the segment list",
+                }
+            )
+        )
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+
+def run_measurement(
+    *,
+    perception: AudioPerception,
+    clip_dir: Path,
+    repeats: int,
+    claims: Sequence[Claim] = CLAIMS,
+    clips: Sequence[Clip] = CLIPS,
+    on_call: Optional[Callable[[int, int, Claim, AudioVerdict], None]] = None,
+) -> dict[str, Any]:
+    """Render the clips, put every claim to the sub-judge, and tally.
+
+    The per-task call cap is reset between claims on purpose. The cap exists
+    to bound what one graded task spends; here each criterion is its own unit
+    of work against its own clip, and letting a corpus-wide counter run into
+    the cap would silently turn the tail of the corpus into ``cap_exceeded``
+    refusals that look like model behaviour and are not.
+    """
+    digests: dict[str, str] = {}
+    paths: dict[str, Path] = {}
+    for clip in clips:
+        path = clip_dir / f"{clip.clip_id}.wav"
+        digests[clip.clip_id] = render_clip(clip, path)
+        paths[clip.clip_id] = path
+
+    calls: list[dict[str, Any]] = []
+    for repeat in range(1, repeats + 1):
+        for claim in claims:
+            perception.reset()
+            verdict = perception.judge(
+                criterion=claim.criterion,
+                audio_path=str(paths[claim.clip_id]),
+            )
+            if on_call is not None:
+                on_call(repeat, len(calls) + 1, claim, verdict)
+            calls.append(
+                {
+                    "repeat": repeat,
+                    "claim_id": claim.claim_id,
+                    "pair_id": claim.pair_id,
+                    "clip_id": claim.clip_id,
+                    "family": claim.family,
+                    "holds": claim.holds,
+                    "verdict": verdict.verdict,
+                    "outcome": classify(claim, verdict.verdict),
+                    "confidence": verdict.confidence,
+                    "evidence": verdict.evidence,
+                    "judge_error": verdict.judge_error,
+                    "api_call_count": verdict.api_call_count,
+                    "input_tokens": verdict.input_tokens,
+                    "output_tokens": verdict.output_tokens,
+                    "latency_ms": round(verdict.latency_ms, 3),
+                    "usage_complete": verdict.usage_complete,
+                }
+            )
+    return {"calls": calls, "clip_sha256": digests}
+
+
+def summarise(calls: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Turn the call log into the three numbers the card asked for."""
+    overall = Tally()
+    on_true = Tally()
+    on_false = Tally()
+    by_family: dict[str, Tally] = {}
+    for call in calls:
+        overall.add(call["outcome"])
+        (on_true if call["holds"] else on_false).add(call["outcome"])
+        by_family.setdefault(call["family"], Tally()).add(call["outcome"])
+
+    by_claim: dict[str, Any] = {}
+    for claim in CLAIMS:
+        verdicts = [c["verdict"] for c in calls if c["claim_id"] == claim.claim_id]
+        if not verdicts:
+            continue
+        majority = majority_verdict(verdicts)
+        by_claim[claim.claim_id] = {
+            "holds": claim.holds,
+            "family": claim.family,
+            "verdicts": verdicts,
+            "majority": majority,
+            "stable": len(set(verdicts)) == 1,
+            "majority_outcome": (
+                classify(claim, majority) if majority is not None else None
+            ),
+        }
+
+    per_call = discrimination([(c["holds"], c["verdict"]) for c in calls])
+    majority_labelled = [
+        (entry["holds"], entry["majority"])
+        for entry in by_claim.values()
+        if entry["majority"] is not None
+    ]
+    confidences = {
+        key: [
+            c["confidence"]
+            for c in calls
+            if c["outcome"] == key and c["confidence"] is not None
+        ]
+        for key in (OUTCOME_CORRECT, OUTCOME_FALSE_FAIL, OUTCOME_FALSE_PASS)
+    }
+    return {
+        "overall": overall.to_dict(),
+        "on_true_claims": {
+            **on_true.to_dict(),
+            "false_fail_rate": _rate(on_true.false_fail, on_true.answered),
+        },
+        "on_false_claims": {
+            **on_false.to_dict(),
+            "false_pass_rate": _rate(on_false.false_pass, on_false.answered),
+        },
+        "by_family": {
+            name: tally.to_dict() for name, tally in sorted(by_family.items())
+        },
+        "by_claim": by_claim,
+        "discrimination_j": {
+            "per_call": per_call,
+            "per_claim_majority": discrimination(majority_labelled),
+            "meaning": (
+                "P(pass|true) - P(pass|false). 0 means the verdict does not "
+                "depend on the audio; accuracy alone cannot show that."
+            ),
+        },
+        "permutation": permute_within_pairs(calls),
+        "mean_confidence": {
+            key: (sum(values) / len(values) if values else None)
+            for key, values in confidences.items()
+        },
+        "stability": {
+            "claims": len(by_claim),
+            "identical_across_repeats": sum(
+                1 for entry in by_claim.values() if entry["stable"]
+            ),
+            "no_majority": sum(
+                1 for entry in by_claim.values() if entry["majority"] is None
+            ),
+        },
+    }
+
+
+def unanswered_claims(calls: Sequence[dict[str, Any]]) -> list[str]:
+    """Claims for which no call produced a verdict at all."""
+    seen: dict[str, bool] = {}
+    for call in calls:
+        answered = call["verdict"] != "judge_error"
+        seen[call["claim_id"]] = seen.get(call["claim_id"], False) or answered
+    return sorted(claim_id for claim_id, ok in seen.items() if not ok)
+
+
+def build_report(
+    *,
+    identity: dict[str, Any],
+    measured: bool,
+    repeats: int,
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    calls = result["calls"]
+    model_calls = sum(int(call["api_call_count"]) for call in calls)
+    billable = model_calls if measured else 0
+    return {
+        "what_this_measures": (
+            "Whether the audio sub-judge's verdict is correct, on clips whose "
+            "contents are known by construction. The repeat runs measured "
+            f"consistency ({REPEAT_FLIP_RATE_PCT}% of audio verdict pairs "
+            f"disagree, against {REPEAT_TEXT_FLIP_RATE_PCT}% on text). "
+            "Consistency is not correctness and neither implies the other."
+        ),
+        "measured": measured,
+        "pins": {
+            **identity,
+            "clip_sample_rate_hz": CLIP_SAMPLE_RATE_HZ,
+            "grader_resample_rate_hz": AUDIO_SAMPLE_RATE_HZ,
+            "repeats": repeats,
+            "claims": len(CLAIMS),
+            "clips": len(CLIPS),
+            "true_claims": sum(1 for c in CLAIMS if c.holds),
+            "false_claims": sum(1 for c in CLAIMS if not c.holds),
+        },
+        "clips": [clip.to_dict() for clip in CLIPS],
+        "clip_sha256": result["clip_sha256"],
+        "claims": [claim.to_dict() for claim in CLAIMS],
+        "calls": calls,
+        "accuracy": summarise(calls),
+        "cost": {
+            # Two numbers, because a dry run makes 36 calls and is billed for
+            # none of them. Collapsing them would put a "billable_calls: 36"
+            # into a free run's report, and that is exactly the figure someone
+            # copies into a cost record.
+            "model_calls": model_calls,
+            "billable_calls": billable,
+            "models": [identity["audio_deployment"]] if billable else [],
+            "pricing_complete": not billable,
+            "unpriced_models": (
+                [identity["audio_deployment"]] if billable else []
+            ),
+            "estimated_cost_usd": None,
+            "note": (
+                "gpt-audio-1.5 is absent from the price table, so the cost of "
+                "this run is unknown rather than zero. null, not $0."
+                if billable
+                else "No model was called; this run cost nothing."
+            ),
+        },
+    }
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help=(
+            "How many times to put each criterion. Three by default, matching "
+            "the repeat runs, so a claim's stability here is comparable with "
+            "the flip rate there."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Run the whole path against a stub that answers from the segment "
+            "list. No network call, no cost, and no measurement of the model."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=PINNED_CONFIG,
+        help="Grading config to read the audio identity from.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write the JSON report here as well as to stdout.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the per-call progress lines.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.repeats < 1:
+        parser.error("--repeats must be at least 1")
+
+    try:
+        identity = pinned_identity(args.config)
+    except ValueError as exc:
+        # Exit 3, not a traceback. Whatever this would have measured, it was
+        # not the audio path the repeat runs used, and a run that cannot say
+        # which model it is describing has nothing to report.
+        print(f"::error::{exc}", file=sys.stderr)
+        return 3
+    if identity["audio_clip_seconds"] != AUDIO_TRIM_SECONDS:
+        # Not fatal to the arithmetic, but it means the clips the model hears
+        # here are cut to a different length than the ones it heard in the
+        # runs this is meant to explain.
+        print(
+            f"::warning::config clip length {identity['audio_clip_seconds']}s "
+            f"differs from the module default {AUDIO_TRIM_SECONDS}s",
+            file=sys.stderr,
+        )
+
+    def progress(repeat: int, index: int, claim: Claim, verdict: AudioVerdict) -> None:
+        if args.quiet:
+            return
+        print(
+            f"  [{index:>3}] repeat {repeat} {claim.claim_id:<20} "
+            f"holds={str(claim.holds):<5} -> {verdict.verdict}"
+            f" ({classify(claim, verdict.verdict)})",
+            file=sys.stderr,
+        )
+
+    managed = None
+    if args.dry_run:
+        client: Any = TruthfulStub(CLAIMS)
+    else:
+        from core.azure_ai_clients import AzureAIWorkload  # noqa: E402
+        from core.llm_client import create_typed_azure_client  # noqa: E402
+
+        managed = create_typed_azure_client(
+            AzureAIWorkload.GRADER, identity["audio_deployment"]
+        )
+        client = managed.client
+
+    try:
+        perception = AudioPerception(
+            client=client,
+            deployment=identity["audio_deployment"],
+            call_cap=identity["audio_call_cap_per_task"],
+            trim_seconds=identity["audio_clip_seconds"],
+        )
+        with tempfile.TemporaryDirectory(prefix="audio-accuracy-") as tmp:
+            result = run_measurement(
+                perception=perception,
+                clip_dir=Path(tmp),
+                repeats=args.repeats,
+                on_call=progress,
+            )
+    finally:
+        if managed is not None:
+            managed.close()
+
+    report = build_report(
+        identity=identity,
+        measured=not args.dry_run,
+        repeats=args.repeats,
+        result=result,
+    )
+    text = json.dumps(report, indent=2, ensure_ascii=False)
+    print(text)
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n", encoding="utf-8")
+
+    missing = unanswered_claims(result["calls"])
+    if missing:
+        print(
+            "::error::no verdict was reached for: " + ", ".join(missing),
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
+++ b/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
@@ -1,0 +1,864 @@
+"""The accuracy probe has to know its own answers before it can grade anyone.
+
+``measure_audio_grading_accuracy.py`` exists to say whether the audio
+sub-judge is *right*. That claim rests entirely on the probe's ground truth
+being right, and a ground truth written in a docstring is not evidence -- it
+is a second opinion from the same author.
+
+So this file does not read the corpus's claims about itself. It renders every
+clip to bytes, **decodes those bytes back**, and measures the waveform:
+where the energy is, how many bursts there are, how far apart they fall, and
+which way the pitch moves. If ``three_beeps`` says three and the decoded audio
+has four, this fails. The probe and the description of the probe are checked
+against each other, off the same samples the model will hear.
+
+The other half is the scorer. A measurement instrument that reports a good
+number when handed garbage is worse than no instrument, so the negative
+controls here are as load-bearing as the positive ones: a model that answers
+``pass`` to all twelve criteria scores 50% accuracy on this balanced corpus,
+and the test that matters is the one asserting its discrimination is **zero**.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import math
+import struct
+import sys
+import wave
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.perception.audio import (  # noqa: E402
+    AUDIO_CALL_CAP,
+    AUDIO_SAMPLE_RATE_HZ,
+    AUDIO_TRIM_SECONDS,
+    SUPPORTED_AUDIO_FORMATS,
+    AudioPerception,
+    criterion_listen_start,
+)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import measure_audio_grading_accuracy as probe  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Decoding the rendered bytes back
+# --------------------------------------------------------------------------
+
+
+def decode(clip: probe.Clip, tmp_path: Path) -> tuple[list[float], int]:
+    """Render a clip to a real file and read the samples back out of it.
+
+    Deliberately round-tripped through ``wave`` rather than taken from
+    :func:`probe.clip_samples`, so a bug in the packing, the scaling or the
+    header is caught here instead of being shared by the renderer and its own
+    test.
+    """
+    path = tmp_path / f"{clip.clip_id}.wav"
+    probe.render_clip(clip, path)
+    with wave.open(str(path), "rb") as handle:
+        assert handle.getnchannels() == 1
+        assert handle.getsampwidth() == 2
+        rate = handle.getframerate()
+        frames = handle.readframes(handle.getnframes())
+    count = len(frames) // 2
+    values = struct.unpack(f"<{count}h", frames)
+    return [value / 32768.0 for value in values], rate
+
+
+def rms_windows(
+    samples: Sequence[float], rate: int, window_s: float = 0.01
+) -> list[tuple[float, float]]:
+    """``(window_start_seconds, rms)`` over non-overlapping windows."""
+    size = max(1, int(round(window_s * rate)))
+    out: list[tuple[float, float]] = []
+    for start in range(0, len(samples) - size + 1, size):
+        chunk = samples[start : start + size]
+        energy = math.sqrt(sum(value * value for value in chunk) / len(chunk))
+        out.append((start / rate, energy))
+    return out
+
+
+def loud_runs(
+    samples: Sequence[float], rate: int, threshold: float = 0.05
+) -> list[tuple[float, float]]:
+    """Contiguous stretches of audible energy, as ``(start_s, end_s)``.
+
+    This is what "how many beeps" means when you are not allowed to look at
+    the segment list.
+    """
+    runs: list[tuple[float, float]] = []
+    open_at: float | None = None
+    last: float = 0.0
+    for start, energy in rms_windows(samples, rate):
+        if energy > threshold:
+            if open_at is None:
+                open_at = start
+            last = start
+        elif open_at is not None:
+            runs.append((open_at, last + 0.01))
+            open_at = None
+    if open_at is not None:
+        runs.append((open_at, last + 0.01))
+    return runs
+
+
+def zero_crossing_hz(samples: Sequence[float], rate: int) -> float:
+    """Rough fundamental frequency, from sign changes.
+
+    Two sign changes per cycle, so crossings per second over two. Crude, and
+    entirely sufficient to tell 220 Hz from 880 Hz.
+    """
+    crossings = sum(
+        1
+        for first, second in zip(samples, samples[1:])
+        if (first < 0) != (second < 0)
+    )
+    return crossings / (len(samples) / rate) / 2.0
+
+
+# --------------------------------------------------------------------------
+# The clips really contain what the corpus says they contain
+# --------------------------------------------------------------------------
+
+
+def test_clips_render_at_the_rate_the_grader_resamples_to() -> None:
+    """The model hears these samples, not a resampled approximation of them.
+
+    If the clips were written at 44.1 kHz the grader would downsample them on
+    the way out, and every measurement here would be of a waveform this file
+    never inspected.
+    """
+    assert probe.CLIP_SAMPLE_RATE_HZ == AUDIO_SAMPLE_RATE_HZ
+
+
+def test_wav_is_a_format_the_audio_path_accepts() -> None:
+    """Otherwise every call is refused before it is made and nothing is measured."""
+    assert "wav" in SUPPORTED_AUDIO_FORMATS
+
+
+def test_rendered_file_round_trips_at_the_declared_rate(tmp_path: Path) -> None:
+    for clip in probe.CLIPS:
+        samples, rate = decode(clip, tmp_path)
+        assert rate == probe.CLIP_SAMPLE_RATE_HZ, clip.clip_id
+        expected = int(round(clip.duration_s * rate))
+        assert abs(len(samples) - expected) <= 1, clip.clip_id
+
+
+def test_tone_stops_early_really_stops_early(tmp_path: Path) -> None:
+    """The timing family's true claim, checked against the waveform.
+
+    This is the shape of the contradiction the card opens with -- one verdict
+    saying the music ends exactly at 30 s, another saying there is no music at
+    all, both at high confidence. Here the answer is not in dispute.
+    """
+    clip = probe.CLIPS_BY_ID["tone_stops_early"]
+    samples, rate = decode(clip, tmp_path)
+    runs = loud_runs(samples, rate)
+    assert len(runs) == 1
+    start, end = runs[0]
+    assert start < 0.05
+    assert 1.9 < end < 2.1
+    # And the tail is genuinely silent, not merely quieter.
+    tail = samples[int(2.2 * rate) :]
+    assert max(abs(value) for value in tail) == 0.0
+
+
+def test_pure_silence_is_digitally_silent(tmp_path: Path) -> None:
+    """Not "quiet". Every sample exactly zero, so no encoder can disagree."""
+    clip = probe.CLIPS_BY_ID["pure_silence"]
+    samples, _ = decode(clip, tmp_path)
+    assert samples
+    assert max(abs(value) for value in samples) == 0.0
+
+
+def test_three_beeps_has_exactly_three_beeps(tmp_path: Path) -> None:
+    clip = probe.CLIPS_BY_ID["three_beeps"]
+    samples, rate = decode(clip, tmp_path)
+    runs = loud_runs(samples, rate)
+    assert len(runs) == 3, runs
+    for (start, end), expected in zip(runs, (0.5, 2.0, 3.5)):
+        assert abs(start - expected) < 0.05
+        assert 0.10 < end - start < 0.20
+
+
+def test_clicks_are_at_120_bpm_and_not_60_or_132(tmp_path: Path) -> None:
+    """Both tempo families depend on this one measurement.
+
+    ``tempo_coarse`` asks 120-vs-60, which is a factor of two. ``tempo_fine``
+    asks 120-vs-132 at +/-1 BPM, which is the resolution the gold run's
+    "140 BPM" criterion needed and got a 70-token answer for. The interval has
+    to be tight enough that the fine claim is genuinely decidable from the
+    audio -- otherwise a false-fail there would be the probe's fault, not the
+    model's.
+    """
+    clip = probe.CLIPS_BY_ID["clicks_120bpm"]
+    samples, rate = decode(clip, tmp_path)
+    runs = loud_runs(samples, rate)
+    assert len(runs) == 16, len(runs)
+    gaps = [b[0] - a[0] for a, b in zip(runs, runs[1:])]
+    assert gaps
+    for gap in gaps:
+        assert abs(gap - 0.5) < 0.02, gaps
+    bpm = 60.0 / (sum(gaps) / len(gaps))
+    assert abs(bpm - 120.0) < 1.0
+    assert abs(bpm - 60.0) > 1.0
+    assert abs(bpm - 132.0) > 1.0
+
+
+def test_low_then_high_goes_low_then_high(tmp_path: Path) -> None:
+    clip = probe.CLIPS_BY_ID["low_then_high"]
+    samples, rate = decode(clip, tmp_path)
+    first = zero_crossing_hz(samples[int(0.2 * rate) : int(1.8 * rate)], rate)
+    second = zero_crossing_hz(samples[int(3.2 * rate) : int(4.8 * rate)], rate)
+    assert abs(first - 220.0) < 10.0, first
+    assert abs(second - 880.0) < 20.0, second
+    assert second > first * 3
+
+
+def test_every_clip_fits_the_window_the_grader_would_cut() -> None:
+    """No clip is long enough to be trimmed, so nothing is measured on a stub.
+
+    A clip longer than ``trim_seconds`` would have its tail cut off before the
+    model heard it, and a criterion about that tail would be false for the
+    probe's reasons rather than the model's.
+    """
+    for clip in probe.CLIPS:
+        assert clip.duration_s < AUDIO_TRIM_SECONDS, clip.clip_id
+
+
+def _decode_bytes(payload: bytes) -> tuple[list[float], int]:
+    with wave.open(io.BytesIO(payload), "rb") as handle:
+        rate = handle.getframerate()
+        channels = handle.getnchannels()
+        frames = handle.readframes(handle.getnframes())
+    count = len(frames) // 2
+    values = struct.unpack(f"<{count}h", frames)
+    if channels > 1:  # pragma: no cover - the grader downmixes to mono
+        values = values[::channels]
+    return [value / 32768.0 for value in values], rate
+
+
+def test_the_ground_truth_survives_the_graders_own_re_encode(
+    tmp_path: Path,
+) -> None:
+    """The strongest form of the claim: measured on the bytes that go out.
+
+    A ``.wav`` is never handed over untouched -- ``COMPRESSED_AUDIO_FORMATS``
+    is ``("mp3",)`` -- so every clip here is decoded and re-encoded to 16 kHz
+    mono by the same ``_trim_audio_bytes`` the grading run uses. Checking the
+    waveform *before* that step would leave a gap where a resampler could
+    smear a 30 ms click or shift an onset, and the model would then be marked
+    wrong about a clip that no longer said what this file thinks it says.
+
+    So the check runs on the encoder's output: three beeps still three, the
+    clicks still 120 BPM, the silence still silent.
+    """
+    from core.perception.audio import _trim_audio_bytes
+
+    for clip in probe.CLIPS:
+        path = tmp_path / f"{clip.clip_id}.wav"
+        probe.render_clip(clip, path)
+        payload, fmt = _trim_audio_bytes(str(path), AUDIO_TRIM_SECONDS)
+        assert fmt in SUPPORTED_AUDIO_FORMATS, clip.clip_id
+        samples, rate = _decode_bytes(payload)
+        assert rate == AUDIO_SAMPLE_RATE_HZ, clip.clip_id
+
+        if clip.clip_id == "pure_silence":
+            assert max(abs(v) for v in samples) < 1e-3
+        elif clip.clip_id == "three_beeps":
+            assert len(loud_runs(samples, rate)) == 3
+        elif clip.clip_id == "clicks_120bpm":
+            runs = loud_runs(samples, rate)
+            assert len(runs) == 16, len(runs)
+            gaps = [b[0] - a[0] for a, b in zip(runs, runs[1:])]
+            assert abs(60.0 / (sum(gaps) / len(gaps)) - 120.0) < 1.0
+        elif clip.clip_id == "tone_stops_early":
+            runs = loud_runs(samples, rate)
+            assert len(runs) == 1
+            assert 1.9 < runs[0][1] < 2.1
+        elif clip.clip_id == "low_then_high":
+            low = zero_crossing_hz(
+                samples[int(0.2 * rate) : int(1.8 * rate)], rate
+            )
+            high = zero_crossing_hz(
+                samples[int(3.2 * rate) : int(4.8 * rate)], rate
+            )
+            assert high > low * 3, (low, high)
+
+
+# --------------------------------------------------------------------------
+# The criteria are balanced, paired, and free of accidental listening windows
+# --------------------------------------------------------------------------
+
+
+def test_corpus_is_balanced_and_paired() -> None:
+    """Six true, six false, matched one-of-each on the same clip.
+
+    Balance is what makes Youden's J readable; pairing is what makes the
+    permutation null contain only corpora that could actually have existed.
+    """
+    assert sum(1 for c in probe.CLAIMS if c.holds) == 6
+    assert sum(1 for c in probe.CLAIMS if not c.holds) == 6
+    pairs: dict[str, list[probe.Claim]] = {}
+    for claim in probe.CLAIMS:
+        pairs.setdefault(claim.pair_id, []).append(claim)
+    assert len(pairs) == 6
+    for pair_id, members in pairs.items():
+        assert len(members) == 2, pair_id
+        assert {m.holds for m in members} == {True, False}, pair_id
+        assert len({m.clip_id for m in members}) == 1, pair_id
+        assert len({m.family for m in members}) == 1, pair_id
+
+
+def test_every_claim_points_at_a_clip_that_exists() -> None:
+    for claim in probe.CLAIMS:
+        assert claim.clip_id in probe.CLIPS_BY_ID, claim.claim_id
+
+
+def test_every_clip_carries_at_least_one_claim() -> None:
+    """A clip nothing asks about is rendered, encoded, and never heard."""
+    used = {claim.clip_id for claim in probe.CLAIMS}
+    assert used == set(probe.CLIPS_BY_ID)
+
+
+def test_no_criterion_accidentally_asks_for_a_listening_window() -> None:
+    """``criterion_listen_start`` parses ``M:SS``, and these clips have no 1:30.
+
+    A criterion containing something that scans as a timestamp would move the
+    slice off the head of a five-second clip, and the model would be asked
+    about a window the file does not have. Every claim here must leave the
+    window at the head.
+    """
+    for claim in probe.CLAIMS:
+        start = criterion_listen_start(
+            claim.criterion, trim_seconds=AUDIO_TRIM_SECONDS
+        )
+        assert not start, (claim.claim_id, start)
+
+
+def test_claim_ids_are_unique() -> None:
+    ids = [claim.claim_id for claim in probe.CLAIMS]
+    assert len(ids) == len(set(ids))
+
+
+# --------------------------------------------------------------------------
+# The scorer, including the ways it must refuse to flatter
+# --------------------------------------------------------------------------
+
+
+def _calls(verdict_for) -> list[dict]:
+    return [
+        {
+            "repeat": 1,
+            "claim_id": claim.claim_id,
+            "pair_id": claim.pair_id,
+            "clip_id": claim.clip_id,
+            "family": claim.family,
+            "holds": claim.holds,
+            "verdict": verdict_for(claim),
+            "outcome": probe.classify(claim, verdict_for(claim)),
+            "confidence": 1.0,
+            "evidence": "",
+            "judge_error": None,
+            "api_call_count": 1,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "latency_ms": 0.0,
+            "usage_complete": False,
+        }
+        for claim in probe.CLAIMS
+    ]
+
+
+def test_classify_maps_each_verdict_to_the_error_it_is() -> None:
+    true_claim = next(c for c in probe.CLAIMS if c.holds)
+    false_claim = next(c for c in probe.CLAIMS if not c.holds)
+    assert probe.classify(true_claim, "pass") == probe.OUTCOME_CORRECT
+    assert probe.classify(true_claim, "fail") == probe.OUTCOME_FALSE_FAIL
+    assert probe.classify(false_claim, "pass") == probe.OUTCOME_FALSE_PASS
+    assert probe.classify(false_claim, "fail") == probe.OUTCOME_CORRECT
+
+
+def test_a_hedge_is_never_counted_as_correct() -> None:
+    """These criteria are arithmetic. ``partial`` is a refusal, not a near-miss.
+
+    Folding hedges into ``correct`` would let a model that never committed to
+    anything report a good accuracy; folding them into the errors would
+    overstate a failure it did not commit either.
+    """
+    for claim in probe.CLAIMS:
+        assert probe.classify(claim, "partial") == probe.OUTCOME_HEDGED
+
+
+def test_judge_error_is_not_an_answer_in_either_direction() -> None:
+    for claim in probe.CLAIMS:
+        assert probe.classify(claim, "judge_error") == probe.OUTCOME_UNANSWERED
+    summary = probe.summarise(_calls(lambda claim: "judge_error"))
+    assert summary["overall"]["answered"] == 0
+    # Not 0.0. There is no accuracy to report, and printing zero would read as
+    # "got everything wrong" rather than "measured nothing".
+    assert summary["overall"]["accuracy"] is None
+    assert summary["discrimination_j"]["per_call"] is None
+
+
+def test_a_model_that_always_says_pass_scores_zero_discrimination() -> None:
+    """The control this whole metric exists for.
+
+    Accuracy is 50% -- it got all six true claims right -- and that 50% is
+    worth nothing, because the same answer was given without listening. J is
+    what says so.
+    """
+    summary = probe.summarise(_calls(lambda claim: "pass"))
+    assert summary["overall"]["accuracy"] == pytest.approx(0.5)
+    assert summary["discrimination_j"]["per_call"] == pytest.approx(0.0)
+    assert summary["on_true_claims"]["false_fail_rate"] == pytest.approx(0.0)
+    assert summary["on_false_claims"]["false_pass_rate"] == pytest.approx(1.0)
+
+
+def test_a_model_that_always_says_fail_also_scores_zero_discrimination() -> None:
+    """The mirror image, and the one the gold run's 5-of-7 failures would look like."""
+    summary = probe.summarise(_calls(lambda claim: "fail"))
+    assert summary["overall"]["accuracy"] == pytest.approx(0.5)
+    assert summary["discrimination_j"]["per_call"] == pytest.approx(0.0)
+    assert summary["on_true_claims"]["false_fail_rate"] == pytest.approx(1.0)
+    assert summary["on_false_claims"]["false_pass_rate"] == pytest.approx(0.0)
+
+
+def test_a_perfect_listener_scores_one() -> None:
+    summary = probe.summarise(_calls(lambda claim: "pass" if claim.holds else "fail"))
+    assert summary["overall"]["accuracy"] == pytest.approx(1.0)
+    assert summary["discrimination_j"]["per_call"] == pytest.approx(1.0)
+    assert summary["on_true_claims"]["false_fail_rate"] == pytest.approx(0.0)
+    assert summary["on_false_claims"]["false_pass_rate"] == pytest.approx(0.0)
+
+
+def test_an_inverted_listener_scores_minus_one() -> None:
+    """Heard it and got it backwards. Distinguishable from not listening at all."""
+    summary = probe.summarise(_calls(lambda claim: "fail" if claim.holds else "pass"))
+    assert summary["discrimination_j"]["per_call"] == pytest.approx(-1.0)
+
+
+def test_rates_are_none_not_zero_when_there_is_nothing_to_divide_by() -> None:
+    assert probe._rate(0, 0) is None
+    assert probe._rate(0, 4) == pytest.approx(0.0)
+
+
+# --------------------------------------------------------------------------
+# The permutation test, and the bound it cannot escape
+# --------------------------------------------------------------------------
+
+
+def test_permutation_is_exhaustive_over_sixty_four_relabellings() -> None:
+    result = probe.permute_within_pairs(_calls(lambda c: "pass" if c.holds else "fail"))
+    assert result["pairs"] == 6
+    assert result["assignments"] == 64
+
+
+def test_the_best_possible_p_is_reported_and_is_worse_than_one_percent() -> None:
+    """The design's own ceiling, published with the number rather than after it.
+
+    Six pairs give 64 assignments, so nothing this experiment can produce
+    reaches 0.01. Stating it here is the same discipline as
+    ``is_informative: false`` on the repeat-variation interval: the reader is
+    told what the measurement *cannot* support at the moment they are told
+    what it found.
+    """
+    result = probe.permute_within_pairs(_calls(lambda c: "pass" if c.holds else "fail"))
+    assert result["smallest_attainable_p"] == pytest.approx(1.0 / 64.0)
+    assert result["p_one_sided"] == pytest.approx(1.0 / 64.0)
+    assert result["smallest_attainable_p"] > 0.01
+    assert result["smallest_attainable_p"] < 0.05
+
+
+def test_a_constant_answer_is_not_significant() -> None:
+    """J = 0 must come back with a p that refuses to call it a finding."""
+    result = probe.permute_within_pairs(_calls(lambda claim: "pass"))
+    assert result["observed_j"] == pytest.approx(0.0)
+    assert result["p_one_sided"] == pytest.approx(1.0)
+
+
+def test_permutation_is_deterministic() -> None:
+    """Exhaustive, so there is no seed to pin and no run-to-run drift."""
+    calls = _calls(lambda c: "pass" if c.holds else "fail")
+    first = probe.permute_within_pairs(calls)
+    second = probe.permute_within_pairs(calls)
+    assert first == second
+
+
+def test_labels_are_swapped_within_pairs_not_across_the_corpus() -> None:
+    """Every relabelling must leave the corpus balanced, and 64 of them exist.
+
+    A free shuffle over twelve labels would build null corpora that could not
+    have existed -- both criteria about the silent clip true at once -- and
+    would enumerate C(12,6) = 924 of them, putting the p-floor at 1/924 and
+    quietly claiming a resolution the design does not have. Two observable
+    consequences pin the within-pair scheme: the assignment count is exactly
+    64, and a perfect listener's p is exactly 1/64 rather than 1/924.
+
+    The count also has to be 64 *including* degenerate answers -- if any
+    relabelling produced an all-true corpus, J would be ``None`` there and the
+    denominator would silently shrink.
+    """
+    for verdict_for in (
+        lambda c: "pass" if c.holds else "fail",
+        lambda c: "pass",
+        lambda c: "fail" if c.holds else "pass",
+    ):
+        result = probe.permute_within_pairs(_calls(verdict_for))
+        assert result["assignments"] == 64
+        assert 1 <= result["at_least_observed"] <= 64
+        assert result["p_one_sided"] == pytest.approx(
+            result["at_least_observed"] / 64
+        )
+
+
+def test_the_perfect_and_inverted_ends_of_the_null_are_where_they_should_be() -> None:
+    """One assignment beats a perfect listener; all 64 beat an inverted one."""
+    perfect = probe.permute_within_pairs(
+        _calls(lambda c: "pass" if c.holds else "fail")
+    )
+    assert perfect["at_least_observed"] == 1
+    inverted = probe.permute_within_pairs(
+        _calls(lambda c: "fail" if c.holds else "pass")
+    )
+    assert inverted["at_least_observed"] == 64
+    assert inverted["p_one_sided"] == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------------------
+# Majority and stability
+# --------------------------------------------------------------------------
+
+
+def test_a_tie_has_no_majority_rather_than_the_first_answer() -> None:
+    """Three repeats that all disagree is exactly the 19.35% this card measured.
+
+    Breaking the tie by order would hide that instability inside the accuracy
+    number, which is the one place it must not be.
+    """
+    assert probe.majority_verdict(["pass", "fail", "partial"]) is None
+    assert probe.majority_verdict(["pass", "fail"]) is None
+    assert probe.majority_verdict(["pass", "pass", "fail"]) == "pass"
+
+
+def test_majority_ignores_unanswered_calls() -> None:
+    assert probe.majority_verdict(["judge_error", "pass", "judge_error"]) == "pass"
+    assert probe.majority_verdict(["judge_error"]) is None
+
+
+# --------------------------------------------------------------------------
+# The identity is borrowed, not restated
+# --------------------------------------------------------------------------
+
+
+def test_identity_comes_from_the_config_the_repeat_runs_used() -> None:
+    """If the config moves, this measurement is of a different model.
+
+    The accuracy figure is only an explanation of the 19.35% while it
+    describes the same deployment at the same clip length and the same cap.
+    """
+    assert probe.PINNED_CONFIG.exists(), probe.PINNED_CONFIG
+    identity = probe.pinned_identity()
+    assert identity["audio_deployment"] == "gpt-audio-1.5"
+    assert identity["audio_model"] == "gpt-audio-1.5"
+    assert identity["audio_clip_seconds"] == AUDIO_TRIM_SECONDS
+    assert identity["audio_call_cap_per_task"] == AUDIO_CALL_CAP
+
+
+def test_pinned_config_is_the_audio_repeat_config() -> None:
+    assert probe.PINNED_CONFIG.name == "gold_audio_repeat_v2_sol_max.yaml"
+
+
+# --------------------------------------------------------------------------
+# The dry run: whole path, no network, no cost
+# --------------------------------------------------------------------------
+
+
+def test_dry_run_exercises_the_real_audio_path(tmp_path: Path) -> None:
+    """Everything but the model: render, trim, base64, prompt, parse, tally.
+
+    The point is that the shape of the report is proven on every commit rather
+    than first observed on the run being paid for.
+    """
+    stub = probe.TruthfulStub(probe.CLAIMS)
+    perception = AudioPerception(client=stub, deployment="gpt-audio-1.5")
+    result = probe.run_measurement(
+        perception=perception, clip_dir=tmp_path, repeats=2
+    )
+    assert len(result["calls"]) == 2 * len(probe.CLAIMS)
+    assert len(stub.requests) == 2 * len(probe.CLAIMS)
+    for request in stub.requests:
+        parts = request["messages"][0]["content"]
+        kinds = [part["type"] for part in parts]
+        assert kinds == ["text", "input_audio"]
+        assert request["modalities"] == ["text"]
+        assert request["model"] == "gpt-audio-1.5"
+        audio = parts[1]["input_audio"]
+        assert audio["format"] in SUPPORTED_AUDIO_FORMATS
+        assert audio["data"]
+
+
+def test_dry_run_reports_a_perfect_score_and_says_it_measured_nothing(
+    tmp_path: Path,
+) -> None:
+    """The stub answers from the segment list, so 100% here means nothing.
+
+    ``measured: false`` is what stops a green CI line from being read as a
+    result about ``gpt-audio-1.5``.
+    """
+    stub = probe.TruthfulStub(probe.CLAIMS)
+    perception = AudioPerception(client=stub, deployment="gpt-audio-1.5")
+    result = probe.run_measurement(
+        perception=perception, clip_dir=tmp_path, repeats=1
+    )
+    report = probe.build_report(
+        identity=probe.pinned_identity(),
+        measured=False,
+        repeats=1,
+        result=result,
+    )
+    assert report["measured"] is False
+    assert report["accuracy"]["overall"]["accuracy"] == pytest.approx(1.0)
+    assert report["accuracy"]["discrimination_j"]["per_call"] == pytest.approx(1.0)
+    assert report["cost"]["estimated_cost_usd"] is None
+    assert report["cost"]["pricing_complete"] is True
+    assert report["cost"]["unpriced_models"] == []
+    # 12 calls went out to the stub and none of them were billed. A report
+    # that said "billable_calls: 12" here is the figure someone copies.
+    assert report["cost"]["model_calls"] == 12
+    assert report["cost"]["billable_calls"] == 0
+
+
+def test_a_measured_run_records_cost_as_unknown_not_zero(tmp_path: Path) -> None:
+    """``gpt-audio-1.5`` is not in the price table, so the money is null.
+
+    This is the rule the cost card has been enforcing since the first paid
+    run: an unpriced model costs an unknown amount, and writing ``$0`` would
+    be a claim nobody can support.
+    """
+    stub = probe.TruthfulStub(probe.CLAIMS)
+    perception = AudioPerception(client=stub, deployment="gpt-audio-1.5")
+    result = probe.run_measurement(
+        perception=perception, clip_dir=tmp_path, repeats=1
+    )
+    report = probe.build_report(
+        identity=probe.pinned_identity(),
+        measured=True,
+        repeats=1,
+        result=result,
+    )
+    assert report["cost"]["model_calls"] == len(probe.CLAIMS)
+    assert report["cost"]["billable_calls"] == len(probe.CLAIMS)
+    assert report["cost"]["estimated_cost_usd"] is None
+    assert report["cost"]["pricing_complete"] is False
+    assert report["cost"]["unpriced_models"] == ["gpt-audio-1.5"]
+    assert "null" in report["cost"]["note"]
+
+
+def test_report_is_json_serialisable_and_carries_the_clip_digests(
+    tmp_path: Path,
+) -> None:
+    """The clips are not committed, so the digests are how a reader re-derives them."""
+    stub = probe.TruthfulStub(probe.CLAIMS)
+    perception = AudioPerception(client=stub, deployment="gpt-audio-1.5")
+    result = probe.run_measurement(
+        perception=perception, clip_dir=tmp_path, repeats=1
+    )
+    report = probe.build_report(
+        identity=probe.pinned_identity(), measured=False, repeats=1, result=result
+    )
+    encoded = json.loads(json.dumps(report, ensure_ascii=False))
+    assert set(encoded["clip_sha256"]) == set(probe.CLIPS_BY_ID)
+    for digest in encoded["clip_sha256"].values():
+        assert len(digest) == 64
+
+
+def test_rendering_is_reproducible(tmp_path: Path) -> None:
+    """Same segments, same bytes. No timestamps, no randomness, no dither."""
+    clip = probe.CLIPS_BY_ID["three_beeps"]
+    first = probe.render_clip(clip, tmp_path / "a.wav")
+    second = probe.render_clip(clip, tmp_path / "b.wav")
+    assert first == second
+
+
+def test_per_claim_call_cap_is_reset_so_the_tail_is_not_refused(
+    tmp_path: Path,
+) -> None:
+    """A corpus-wide counter would turn later claims into ``cap_exceeded``.
+
+    The cap bounds what one graded *task* spends. Here each criterion is its
+    own unit of work, and letting the counter run would fabricate refusals
+    that look like model behaviour.
+    """
+    stub = probe.TruthfulStub(probe.CLAIMS)
+    perception = AudioPerception(
+        client=stub, deployment="gpt-audio-1.5", call_cap=2
+    )
+    result = probe.run_measurement(
+        perception=perception, clip_dir=tmp_path, repeats=1
+    )
+    verdicts = {call["verdict"] for call in result["calls"]}
+    assert verdicts <= {"pass", "fail"}, verdicts
+    assert not probe.unanswered_claims(result["calls"])
+
+
+# --------------------------------------------------------------------------
+# Exit codes
+# --------------------------------------------------------------------------
+
+
+def test_unanswered_claims_are_named(tmp_path: Path) -> None:
+    calls = _calls(lambda claim: "judge_error")
+    assert probe.unanswered_claims(calls) == sorted(
+        c.claim_id for c in probe.CLAIMS
+    )
+
+
+def test_a_claim_answered_once_out_of_three_is_not_unanswered() -> None:
+    """One verdict is a thin measurement, not a missing one."""
+    calls = _calls(lambda claim: "judge_error")
+    calls[0] = {**calls[0], "verdict": "pass"}
+    missing = probe.unanswered_claims(calls)
+    assert calls[0]["claim_id"] not in missing
+    assert len(missing) == len(probe.CLAIMS) - 1
+
+
+def test_main_dry_run_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    code = probe.main(["--dry-run", "--repeats", "1", "--quiet"])
+    assert code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["measured"] is False
+    assert report["pins"]["claims"] == 12
+    assert report["pins"]["true_claims"] == 6
+    assert report["pins"]["false_claims"] == 6
+    assert len(report["calls"]) == 12
+
+
+def test_main_rejects_a_repeat_count_below_one() -> None:
+    with pytest.raises(SystemExit):
+        probe.main(["--dry-run", "--repeats", "0"])
+
+
+def test_main_writes_the_report_where_it_is_told(tmp_path: Path) -> None:
+    out = tmp_path / "nested" / "report.json"
+    assert probe.main(["--dry-run", "--repeats", "1", "--quiet", "--out", str(out)]) == 0
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["accuracy"]["overall"]["calls"] == 12
+
+
+def test_main_refuses_a_config_whose_model_and_deployment_disagree(
+    tmp_path: Path,
+) -> None:
+    """Exit 3: whatever that would have measured, it was not the pinned path."""
+    config = tmp_path / "mismatched.yaml"
+    config.write_text(
+        "grader:\n"
+        "  judge:\n"
+        "    perception:\n"
+        "      audio:\n"
+        "        model: gpt-audio-1.5\n"
+        "        deployment: some-other-deployment\n",
+        encoding="utf-8",
+    )
+    assert probe.main(["--dry-run", "--quiet", "--config", str(config)]) == 3
+
+
+def test_pinned_identity_refuses_a_config_with_no_audio_block(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "no_audio.yaml"
+    config.write_text("judge: {}\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="judge.perception.audio"):
+        probe.pinned_identity(config)
+
+
+def test_identity_is_resolved_by_the_graders_own_rule(tmp_path: Path) -> None:
+    """Not a second implementation of the model/deployment check.
+
+    ``canonical_deployment`` is what ``grader.py`` calls on this exact config
+    path. Borrowing it means a config this probe accepts is a config the
+    grading run would accept, and there is no way for the two to drift apart.
+    """
+    config = tmp_path / "mismatched.yaml"
+    config.write_text(
+        "judge:\n"
+        "  perception:\n"
+        "    audio:\n"
+        "      model: gpt-audio-1.5\n"
+        "      deployment: some-other-deployment\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="must match"):
+        probe.pinned_identity(config)
+
+
+# --------------------------------------------------------------------------
+# The script does not change what it measures
+# --------------------------------------------------------------------------
+
+
+def test_a_new_file_under_scripts_does_not_move_a_grader_fingerprint() -> None:
+    """Measured, not assumed: add a file to ``scripts/`` and the hash holds.
+
+    ``compute_grader_source_hash`` takes exactly one file from ``scripts/`` --
+    ``download_inference_from_hf.py``. Everything else there is outside the
+    set, which is what lets this probe land without invalidating a grading
+    approval already given for something else.
+
+    Asserting that from the source listing would only restate it. So the test
+    creates a real file beside this script, recomputes the fingerprint of the
+    config the repeat runs used, and requires the digest to be byte-identical.
+    """
+    import yaml
+
+    from step8_grade import compute_grader_source_hash  # noqa: E402
+
+    with probe.PINNED_CONFIG.open(encoding="utf-8") as handle:
+        config = yaml.safe_load(handle)
+
+    before = compute_grader_source_hash(probe.PINNED_CONFIG, config)
+
+    intruder = Path(probe.__file__).with_name("_fingerprint_probe_tmp.py")
+    assert not intruder.exists()
+    try:
+        intruder.write_text("# transient, for one assertion\n", encoding="utf-8")
+        after = compute_grader_source_hash(probe.PINNED_CONFIG, config)
+    finally:
+        intruder.unlink(missing_ok=True)
+
+    assert after == before
+    assert len(before) == 64
+
+
+def test_the_probe_itself_is_one_of_those_files() -> None:
+    """Same directory, same exemption. Named so a move gets caught here."""
+    assert Path(probe.__file__).parent.name == "scripts"
+    assert Path(probe.__file__).name == "measure_audio_grading_accuracy.py"
+
+
+def test_stub_refuses_a_criterion_it_was_not_given() -> None:
+    """The stub answers from the corpus, so an unknown criterion is a bug.
+
+    Silently returning ``fail`` would make a dry run that lost half its
+    prompts look like a model that got half of them wrong.
+    """
+    stub = probe.TruthfulStub(probe.CLAIMS[:1])
+    with pytest.raises(AssertionError, match="does not know"):
+        stub.create(
+            model="gpt-audio-1.5",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "something else entirely"}],
+                }
+            ],
+            modalities=["text"],
+        )


### PR DESCRIPTION
## Why

The three repeat runs (#383) answered **consistency**: the audio sub-judge disagrees with itself on **19.35%** of verdict pairs, against **2.12%** on text. Nine times the flip rate.

They could not answer **correctness**, and buying more of them never would. Every item in that corpus is scored against an expert deliverable whose own correctness is *one of the two readings the card is trying to separate*:

1. the expert answer really did miss the spec, or
2. `gpt-audio-1.5` is not accurate enough to check a claim like "140 BPM" off a 70-token response.

A stable verdict there is evidence of a stable verdict. That is all.

## What this measures instead

Twelve criteria on five clips **built from a segment list at run time** — no committed audio, nothing downloaded, digests in the report:

| clip | what it is |
|---|---|
| `tone_stops_early` | 1000 Hz for 0.0–2.0 s, then silence, 6 s total |
| `pure_silence` | 6 s, every sample exactly 0 |
| `three_beeps` | three 150 ms bursts at 0.5 / 2.0 / 3.5 s |
| `clicks_120bpm` | sixteen 30 ms clicks, 0.5 s apart |
| `low_then_high` | 220 Hz, silence, 880 Hz |

Six claims true, six false, **matched in pairs on the same clip** across six families (timing, presence, count, tempo_coarse, tempo_fine, pitch_order). A wrong answer therefore cannot be explained by one clip being harder than another.

## Why the headline is J and not accuracy

Accuracy alone cannot tell a listener from a coin. On a balanced corpus, **always-pass scores 50% and always-fail scores 50%**.

So the report leads with **Youden's J** = `P(pass|true) − P(pass|false)`:

| behaviour | accuracy | J |
|---|---|---|
| always pass | 0.50 | **0.0** |
| always fail | 0.50 | **0.0** |
| perfect | 1.00 | 1.0 |
| inverted | 0.00 | −1.0 |

All four ends are pinned by negative-control tests. **J = 0 means the verdict does not depend on the audio.**

## Two things the report refuses to overstate

**The p-value carries its own ceiling.** Six pairs give `2^6 = 64` relabellings, so the smallest p this design can ever produce is `1/64 = 0.015625`. The report publishes `smallest_attainable_p` beside `p_one_sided`, and a test asserts it is worse than 0.01 and better than 0.05. Significant at 0.05 is the ceiling; **0.01 is out of reach whatever the result comes back as.** Same discipline as #383, which reported its interval `is_informative: false` rather than letting it read as a bound.

**Cost is null, not $0.** `gpt-audio-1.5` is absent from the price table. `billable_calls` is 0 and `pricing_complete` is true only on a dry run; a measured run reports `estimated_cost_usd: null` with the deployment named in `unpriced_models`.

## Ground truth is checked on the bytes the model receives

A `.wav` is **never** handed over raw — `COMPRESSED_AUDIO_FORMATS = ("mp3",)`, so the grader decodes and re-encodes every clip to 16 kHz mono `pcm_s16le` first.

Checking the waveform before that step would leave room for a resampler to smear a 30 ms click or shift an onset, and the model would then be marked wrong about a clip that no longer says what the file claims. So `test_the_ground_truth_survives_the_graders_own_re_encode` runs each clip through the real `_trim_audio_bytes(...)` and re-measures onsets, burst counts, click intervals and pitch order **off the encoder's own output**.

## Fingerprint safety, asserted rather than claimed

The script lands in `batch-runner/scripts/`, which is inside `GRADING_INPUT_PATHS` but **outside** the fingerprint set — `compute_grader_source_hash` takes exactly one file from that directory (`download_inference_from_hf.py`).

That is now empirical: a test writes a file into `scripts/`, recomputes the digest, and requires it unchanged.

Because `GRADING_INPUT_PATHS` is a deliberate superset, **this PR still holds for 0 Grade Pipeline runs in flight before merging.**

## The workflow

`workflow_dispatch`, `dry_run` defaulting to true. The paid job reuses the existing **`grading` environment** rather than adding a second approval surface, and takes the same `direct-v1` route with the same OIDC preflights the grading run uses — measuring the audio path the 19.35% came off requires reaching it the same way.

It **grades nothing**: no task, no rubric, no deliverable, no corpus. It calls the sub-judge directly, so a run cannot write a grade or move a published number. The report leaves as an **artifact, not a commit** — verdicts on five synthetic clips have no place in `data/grades`.

`dry_run: false` with `paid_approval` unchecked fails in seconds instead of parking on a gate nobody expects.

## Verification

- `tests/test_audio_accuracy_probe_knows_its_own_answers.py` — **50 passed**
- dry run exits 0: `measured: false`, 36 calls, `billable_calls: 0`, `estimated_cost_usd: null`
- both workflow summary blocks executed against a real report
- workflow YAML parses; job wiring checked
- mypy attributes **zero** new errors to this change

Closes step 4 — the last one — of the audio-confidence card.
