### PR TITLE
analysis(grading): price the required-item definition from published grades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ batch-runner/scripts/*
 !batch-runner/scripts/analyze_repeat_variation.py
 !batch-runner/scripts/analyze_audio_repeat_variation.py
 !batch-runner/scripts/measure_audio_grading_accuracy.py
+!batch-runner/scripts/analyze_required_item_definition.py
 
 
 # Experiment report HTML (skews GitHub language stats)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **The number that says whether the model got the important things right is,
+  on the gold corpora, mostly one line about formatting.** GDPVal rubrics carry
+  a `required` field and it is `null` on all 10,453 items, so the repository
+  decided weight stands in for necessity at `abs(max_score) >= 4` and left a
+  comment saying 4 was a heuristic to revisit once gold-ceiling validation
+  could show whether it mis-classifies. That validation is finished, and
+  `batch-runner/scripts/analyze_required_item_definition.py` now prices the
+  alternatives against the runs already published, without changing any of
+  them.
+
+  `'Overall formatting and style of the deliverable'` is worth exactly 5 and
+  appears in 55–65% of tasks. It is **54.3%** of the stage-1 gold critical set
+  and **33.8%** of stage-3's, and the expert gold answers pass it at about a
+  third the rate of everything else. So raising the threshold to 5 — the first
+  option on the board — keeps every copy of it and drops only the genuine
+  must-haves worth 4: stage-1 gold moves **0.5714 → 0.5312**, *away* from the
+  0.95 gate it has to reach, and stage 3 moves 0.6394 → 0.6325, while the
+  220-task model run drifts the other way (0.4903 → 0.4950). Threshold 6 does
+  clear the boilerplate and leaves stage 1 with **one** critical item out of
+  1,431 scored ones, which then reads a perfect 1.0000. Excluding
+  deliverable-wide style lines with the predicate the grader already ships,
+  `core.grader_routing.is_overall_style_criterion`, takes gold to 0.7500 and
+  0.8128 — still short of 0.95, which is the honest part: what is left is real
+  must-haves the reference answers miss.
+
+  The sweep runs through the production summariser rather than a copy of it.
+  `step8_grade` imports `_is_critical_item` — the function — and that function
+  reads `MAGNITUDE_THRESHOLD` from `core.grader` when it is called, so
+  rebinding the module global reprices `summary.wow.critical_item_pass_rate`
+  and `tasks[].critical_fail` exactly as a real change would. At the shipped
+  threshold the recount lands on the flags the grader itself wrote (13 of 30,
+  99 of 185) or the tool says so and stops. It refuses a payload whose stored
+  rate the current summariser does not reproduce, deferring to the two causes
+  `scripts/summary_wow_drift.py` already named — six of the 94 payloads under
+  `data/grades/` — and refuses a rate whose denominator is below
+  `ceil(1 / (1 - 0.95)) = 20` items, a floor derived from the gate it serves
+  rather than chosen.
+
+  **No definition was changed.** `MAGNITUDE_THRESHOLD` is untouched, nothing
+  under `core/` or `step8_grade.py` was edited, and no grader fingerprint
+  moved — the tool lives outside `compute_grader_source_hash`'s input set. The
+  choice belongs to the owner, because it would change this metric on every run
+  already published. Measurements, all four options and their costs:
+  `data/grades/_validation/REQUIRED_ITEM_DEFINITION.md`.
+
 - **The grading rebuild (v2) is complete, and the first thing it established is
   that a perfect answer does not score 100.** The rebuild ran in three parts.
   PR1 fixed a sign error in the score arithmetic. PR2 rebuilt the judge around

--- a/batch-runner/scripts/analyze_required_item_definition.py
+++ b/batch-runner/scripts/analyze_required_item_definition.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""Price the ways of defining a "required" rubric item, from published data.
+
+Why this exists
+---------------
+GDPVal v2 rubrics carry a ``required`` field and it is ``null`` on every item
+of every task -- 10,453 of 10,453, recorded in
+``data/grades/_validation/SCORE_MATH_AUDIT.md``. With no author signal to read,
+the repository adopted a convention: an item is required when its weight is
+large, ``abs(max_score) >= MAGNITUDE_THRESHOLD``, and ``MAGNITUDE_THRESHOLD``
+is 4. The comment above it says plainly that 4 is a heuristic and names the
+gold-ceiling work as the thing that should decide whether it is the right
+boundary. That work is finished, so the deferral has run out.
+
+Two published numbers depend on the answer and nothing else does:
+
+* ``summary.wow.critical_item_pass_rate`` -- one rate per run and one per
+  sector, and the second of the three thresholds a gold-ceiling run is
+  accepted or rejected on (``>= 0.95``).
+* ``tasks[].critical_fail`` -- a per-task boolean carried in every payload and
+  printed in the per-task table of ``scripts/analyze_grade_run.py``.
+
+Neither ``pct`` nor ``total_max`` nor any headline score moves with the
+definition, which bounds how much is at stake and is worth knowing before
+anyone weighs the options.
+
+What this does
+--------------
+It prices the options against real graded runs. For each payload it reports
+the effect of every candidate threshold on both published consequences, and it
+separately measures how much of the metric is spent on rubric lines the author
+repeats verbatim across tasks -- because if one boilerplate line dominates the
+denominator, then the "required item pass rate" is substantially a rate about
+that line, whatever threshold is chosen.
+
+What it will not do
+-------------------
+* **It does not change the definition.** ``MAGNITUDE_THRESHOLD`` lives in
+  ``core/grader.py``, which is an input to ``compute_grader_source_hash``, and
+  the decision is the owner's. This file is under ``scripts/``, outside that
+  hash, and imports the threshold rather than restating it: an analysis
+  counting through its own copy could disagree with the grader about what it
+  was measuring at exactly the moment the disagreement mattered.
+* **It does not reimplement the metric.** Every rate here comes back out of
+  ``step8_grade._compute_summary`` -- the same function that wrote the numbers
+  on the dashboard -- with the threshold patched underneath it. A
+  reimplementation would quietly answer a different question and then agree
+  with itself.
+* **It refuses to price a payload it cannot reproduce.** If today's summariser
+  does not land on the stored rate, the stored rate came from a rule we no
+  longer run, and pricing a change against it would compare two definitions
+  while claiming to compare one. ``scripts/summary_wow_drift.py`` already
+  names the two historical causes; this defers to it rather than guessing.
+* **It refuses to report a rate its denominator cannot carry.** A threshold
+  that leaves a handful of items produces a number that looks like a metric
+  and is not one -- see ``MIN_USABLE_CRITICAL_ITEMS`` below.
+
+Usage
+-----
+    python batch-runner/scripts/analyze_required_item_definition.py <grade.json>...
+    python batch-runner/scripts/analyze_required_item_definition.py <dir>
+    python batch-runner/scripts/analyze_required_item_definition.py <dir> --repeat-floor 0.05
+
+Exit status is 0 when every input was priced and 1 when any was refused, so a
+report generated over a payload this could not read cannot come out green.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from collections import Counter, defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+# The report's generated blocks run this from the repository root, where
+# `batch-runner/` is not importable, so the package root goes on the path here
+# rather than relying on the caller's working directory. Same reason as
+# `analyze_gold_ceiling.py`.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import core.grader as grader_module  # noqa: E402
+from core.grader_routing import is_overall_style_criterion  # noqa: E402
+from scripts.analyze_gold_ceiling import CRITICAL_ITEM_PASS_FLOOR  # noqa: E402
+from scripts.summary_wow_drift import (  # noqa: E402
+    CAUSE_MATCH,
+    classify,
+)
+from step8_grade import _compute_summary  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ROOT = REPO_ROOT / "data" / "grades"
+
+#: The shipped definition, read once before anything patches it. Imported, not
+#: restated -- see the module docstring.
+#:
+#: ``int`` rather than ``float`` throughout, because the sweep rebinds this very
+#: name inside a production module: a fractional candidate would change the type
+#: of a shipped constant as well as its value, and any real change to the
+#: definition would land as an integer.
+SHIPPED_THRESHOLD: int = grader_module.MAGNITUDE_THRESHOLD
+
+#: Candidate thresholds. 4 is what ships; 5 is the value the card names; the
+#: rest bracket it so the shape of the curve is visible rather than two points
+#: on it. Above 10 every corpus measured so far falls below the floor below.
+THRESHOLD_SWEEP: tuple[int, ...] = (2, 3, 4, 5, 6, 8, 10)
+
+#: Below this many critical items a rate is reported but refused as a basis for
+#: any decision. The number is derived, not chosen: the gate this metric feeds
+#: is `>= CRITICAL_ITEM_PASS_FLOOR`, so its whole margin is `1 - floor`. With
+#: fewer than `1 / (1 - floor)` items a single failure costs more than that
+#: entire margin, and the metric cannot express any value between the floor and
+#: a clean sweep. A gold run that leaves one critical item reads 1.0000 and a
+#: run that leaves none reads 0.0000, and neither is a measurement.
+MIN_USABLE_CRITICAL_ITEMS: int = math.ceil(1.0 / (1.0 - CRITICAL_ITEM_PASS_FLOOR))
+
+#: How much of a corpus a criterion has to appear in before it is reported as
+#: repeated. The census itself is exhaustive; this only decides what is printed.
+DEFAULT_REPEAT_TASK_SHARE = 0.10
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+# ── reading the payload ──────────────────────────────────────────────
+
+
+def _scored_items(task: dict) -> list[dict]:
+    """The items a grade counts, matching ``core.grader._aggregate``.
+
+    Both published consequences are defined over this set and not over every
+    item: an item the judge never managed to score is excluded from the rate
+    and cannot raise ``critical_fail``.
+    """
+    return [
+        item
+        for item in task.get("items", [])
+        if isinstance(item, dict) and not item.get("score_excluded", False)
+    ]
+
+
+def _normalise(criterion: Any) -> str:
+    """Fold a criterion string for the repetition census only.
+
+    Case, surrounding space, internal runs of space and a trailing period are
+    removed. Nothing else: this decides which strings are *the same line*, and
+    a looser fold would merge lines the rubric author wrote differently. The
+    real corpus needs exactly this much -- stage 3 carries the deliverable-wide
+    style line 119 times bare and once with a full stop.
+    """
+    text = _WHITESPACE.sub(" ", str(criterion or "")).strip()
+    return text.rstrip(".").lower()
+
+
+@contextmanager
+def _threshold(value: int) -> Iterator[None]:
+    """Run the production summariser under a different definition.
+
+    ``_is_critical_item`` reads ``MAGNITUDE_THRESHOLD`` from its own module at
+    call time, and ``step8_grade`` imported the function rather than the
+    number, so rebinding it here reprices through the real code path instead of
+    a copy of it. Restored on the way out, including on an exception, because
+    everything downstream of a leaked threshold would be silently wrong.
+    """
+    original = grader_module.MAGNITUDE_THRESHOLD
+    grader_module.MAGNITUDE_THRESHOLD = value
+    try:
+        yield
+    finally:
+        grader_module.MAGNITUDE_THRESHOLD = original
+
+
+# ── the measurements ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ThresholdEffect:
+    """What one candidate definition does to both published consequences."""
+
+    threshold: int
+    critical_items: int
+    scored_items: int
+    pass_rate: float
+    critical_fail_tasks: int
+    graded_tasks: int
+
+    @property
+    def item_share(self) -> float:
+        return (self.critical_items / self.scored_items) if self.scored_items else 0.0
+
+    @property
+    def task_share(self) -> float:
+        return (
+            (self.critical_fail_tasks / self.graded_tasks) if self.graded_tasks else 0.0
+        )
+
+    @property
+    def usable(self) -> bool:
+        return self.critical_items >= MIN_USABLE_CRITICAL_ITEMS
+
+    @property
+    def is_shipped(self) -> bool:
+        return self.threshold == SHIPPED_THRESHOLD
+
+
+@dataclass(frozen=True)
+class RepeatedCriterion:
+    """One rubric line the author reuses, and what it costs the metric."""
+
+    criterion: str
+    variants: int
+    items: int
+    tasks: int
+    magnitudes: tuple[float, ...]
+    pass_rate: float
+
+    def share_of(self, critical_items: int) -> float:
+        return (self.items / critical_items) if critical_items else 0.0
+
+
+@dataclass
+class Priced:
+    """Everything measured about one grade payload."""
+
+    path: Path
+    task_count: int
+    graded_tasks: int
+    scored_items: int
+    published_rate: float | None
+    recomputed_rate: float | None
+    sector_rates: int
+    refusal: str | None = None
+    effects: list[ThresholdEffect] = field(default_factory=list)
+    repeated: list[RepeatedCriterion] = field(default_factory=list)
+    repeat_floor: float = DEFAULT_REPEAT_TASK_SHARE
+    text_rule_items: int = 0
+    text_rule_tasks: int = 0
+    text_rule_rate: float = 0.0
+    remainder_items: int = 0
+    remainder_rate: float = 0.0
+
+    @property
+    def priced(self) -> bool:
+        return self.refusal is None
+
+    def effect_at(self, threshold: int) -> ThresholdEffect | None:
+        for effect in self.effects:
+            if effect.threshold == threshold:
+                return effect
+        return None
+
+
+def _rate_of(items: list[dict]) -> float:
+    """Share of items the model did the right thing on, to 4 places.
+
+    ``model_did_right`` rather than ``verdict == 'pass'``: GDPVal rubrics carry
+    negative-weight anti-criteria where a pass verdict means the model *did*
+    the prohibited thing, and the critical set spans both signs.
+    """
+    if not items:
+        return 0.0
+    right = sum(1 for item in items if bool(item.get("model_did_right", False)))
+    return round(right / len(items), 4)
+
+
+def _critical_fail_tasks(tasks: list[dict]) -> int:
+    """Recount the published per-task boolean under the current threshold.
+
+    Mirrors ``core.grader._aggregate``: any scored item of critical magnitude
+    the model did not get right fails the task.
+    """
+    return sum(
+        1
+        for task in tasks
+        if not task.get("error")
+        and any(
+            grader_module._is_critical_item(item.get("max_score"))
+            and not bool(item.get("model_did_right", False))
+            for item in _scored_items(task)
+        )
+    )
+
+
+def _sweep(tasks: list[dict], scored_items: int, graded_tasks: int) -> list[ThresholdEffect]:
+    effects: list[ThresholdEffect] = []
+    for threshold in THRESHOLD_SWEEP:
+        with _threshold(threshold):
+            wow = _compute_summary(tasks)["wow"]
+            critical = [
+                item
+                for task in tasks
+                for item in _scored_items(task)
+                if grader_module._is_critical_item(item.get("max_score"))
+            ]
+            effects.append(
+                ThresholdEffect(
+                    threshold=threshold,
+                    critical_items=len(critical),
+                    scored_items=scored_items,
+                    pass_rate=float(wow.get("critical_item_pass_rate") or 0.0),
+                    critical_fail_tasks=_critical_fail_tasks(tasks),
+                    graded_tasks=graded_tasks,
+                )
+            )
+    return effects
+
+
+def _census(tasks: list[dict], floor: float) -> list[RepeatedCriterion]:
+    """Which rubric lines the critical set is actually made of.
+
+    Derived, not assumed. Nothing here knows what the repeated line says; it
+    groups the critical items by their own text and reports whichever groups
+    turn out to span a large share of the corpus. A hardcoded string would
+    stop being true the first time the rubrics changed and would say nothing
+    about a corpus nobody had looked at yet.
+    """
+    task_total = sum(1 for task in tasks if not task.get("error"))
+    if not task_total:
+        return []
+
+    groups: dict[str, list[dict]] = defaultdict(list)
+    owners: dict[str, set[str]] = defaultdict(set)
+    variants: dict[str, Counter] = defaultdict(Counter)
+    for task in tasks:
+        if task.get("error"):
+            continue
+        task_id = str(task.get("task_id") or "")
+        for item in _scored_items(task):
+            if not grader_module._is_critical_item(item.get("max_score")):
+                continue
+            key = _normalise(item.get("criterion"))
+            if not key:
+                continue
+            groups[key].append(item)
+            owners[key].add(task_id)
+            variants[key][str(item.get("criterion") or "").strip()] += 1
+
+    out: list[RepeatedCriterion] = []
+    for key, items in groups.items():
+        # Two conditions, and only the second is a knob. A line has to appear
+        # in more than one task before the word "repeated" means anything --
+        # on a three-task smoke a single occurrence is 33% of the corpus, and
+        # a share floor alone would report every criterion in the run as
+        # repeated boilerplate.
+        if len(owners[key]) < 2:
+            continue
+        if len(owners[key]) / task_total < floor:
+            continue
+        magnitudes = sorted(
+            {
+                abs(float(item.get("max_score") or 0))
+                for item in items
+                if isinstance(item.get("max_score"), (int, float))
+            }
+        )
+        out.append(
+            RepeatedCriterion(
+                # The most common spelling, so the report quotes the rubric
+                # rather than this file's folded key.
+                criterion=variants[key].most_common(1)[0][0],
+                variants=len(variants[key]),
+                items=len(items),
+                tasks=len(owners[key]),
+                magnitudes=tuple(magnitudes),
+                pass_rate=_rate_of(items),
+            )
+        )
+    return sorted(out, key=lambda r: (-r.items, r.criterion))
+
+
+def price(path: Path, payload: dict, *, repeat_floor: float) -> Priced | None:
+    """Measure one grade payload, or refuse it and say why."""
+    tasks = payload.get("tasks")
+    summary = payload.get("summary")
+    if not isinstance(tasks, list) or not isinstance(summary, dict):
+        return None
+    published = summary.get("wow")
+    if not isinstance(published, dict) or "critical_item_pass_rate" not in published:
+        return None
+
+    graded = [task for task in tasks if not task.get("error")]
+    scored_items = sum(len(_scored_items(task)) for task in graded)
+    by_sector = published.get("by_sector")
+    result = Priced(
+        path=path,
+        task_count=len(tasks),
+        graded_tasks=len(graded),
+        scored_items=scored_items,
+        published_rate=published.get("critical_item_pass_rate"),
+        recomputed_rate=None,
+        sector_rates=len(by_sector) if isinstance(by_sector, dict) else 0,
+        repeat_floor=repeat_floor,
+    )
+
+    with _threshold(SHIPPED_THRESHOLD):
+        result.recomputed_rate = _compute_summary(tasks)["wow"].get(
+            "critical_item_pass_rate"
+        )
+
+    # Refusal 1: the payload predates sign-aware verdicts, so the metric it
+    # published was counting something this cannot reconstruct.
+    if not any(
+        "model_did_right" in item
+        for task in tasks
+        for item in task.get("items", [])
+        if isinstance(item, dict)
+    ):
+        result.refusal = (
+            "no model_did_right on any item -- pre-#100 payload, "
+            "see scripts/summary_wow_drift.py"
+        )
+        return result
+
+    # Refusal 2: today's summariser does not land on the stored number, so the
+    # stored number came from a rule that is no longer running. Pricing a
+    # change against it would compare two definitions and report one.
+    finding = classify(path, payload)
+    if finding is not None and finding.cause != CAUSE_MATCH:
+        result.refusal = f"does not reproduce -- {finding.cause}"
+        return result
+
+    result.effects = _sweep(tasks, scored_items, len(graded))
+    with _threshold(SHIPPED_THRESHOLD):
+        result.repeated = _census(tasks, repeat_floor)
+        critical = [
+            item
+            for task in graded
+            for item in _scored_items(task)
+            if grader_module._is_critical_item(item.get("max_score"))
+        ]
+    # The one concrete text rule the repository already ships and already
+    # tests: `core.grader_routing.is_overall_style_criterion`, which the
+    # grader uses to decide that a criterion is asking about deliverable-wide
+    # polish rather than about the work. Using it here rather than inventing a
+    # rule means the third option is priced against something real.
+    #
+    # Partitioned in one pass rather than by a second `not in` filter: rubric
+    # items are plain dicts, `in` compares them by value, and two tasks
+    # carrying the same boilerplate line at the same weight are equal. A
+    # membership test would drop every copy of every repeated line from the
+    # remainder -- which is precisely the set being measured here.
+    styled: list[dict] = []
+    remainder: list[dict] = []
+    for item in critical:
+        target = (
+            styled
+            if is_overall_style_criterion(str(item.get("criterion") or ""))
+            else remainder
+        )
+        target.append(item)
+    result.text_rule_items = len(styled)
+    result.text_rule_tasks = len(
+        {
+            str(task.get("task_id") or "")
+            for task in graded
+            for item in _scored_items(task)
+            if grader_module._is_critical_item(item.get("max_score"))
+            and is_overall_style_criterion(str(item.get("criterion") or ""))
+        }
+    )
+    result.text_rule_rate = _rate_of(styled)
+    result.remainder_items = len(remainder)
+    result.remainder_rate = _rate_of(remainder)
+    return result
+
+
+# ── reporting ────────────────────────────────────────────────────────
+
+
+def _pct(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def render(results: list[Priced]) -> str:
+    lines: list[str] = []
+    lines.append(
+        f"required-item definition, priced against {len(results)} payload(s)"
+    )
+    lines.append(
+        f"shipped: abs(max_score) >= {SHIPPED_THRESHOLD:g}  "
+        f"(core.grader.MAGNITUDE_THRESHOLD)"
+    )
+    lines.append(
+        f"a rate needs >= {MIN_USABLE_CRITICAL_ITEMS} critical items to mean "
+        f"anything against the {CRITICAL_ITEM_PASS_FLOOR:.2f} floor"
+    )
+    lines.append("")
+
+    for result in results:
+        lines.append("=" * 72)
+        lines.append(f"{result.path.name}")
+        lines.append(
+            f"  {result.task_count} task(s), {result.graded_tasks} graded, "
+            f"{result.scored_items} scored item(s)"
+        )
+        if not result.priced:
+            lines.append(f"  REFUSED: {result.refusal}")
+            lines.append(
+                f"  published critical_item_pass_rate="
+                f"{result.published_rate} recomputed={result.recomputed_rate}"
+            )
+            lines.append("")
+            continue
+
+        lines.append(
+            f"  reproduces: published={result.published_rate} "
+            f"recomputed={result.recomputed_rate}"
+        )
+        lines.append("")
+        lines.append(
+            "  threshold   items    share     rate    critical_fail tasks"
+        )
+        for effect in result.effects:
+            mark = " *" if effect.is_shipped else "  "
+            note = "" if effect.usable else "   [denominator too thin to use]"
+            lines.append(
+                f"  {effect.threshold:>7g}{mark} {effect.critical_items:>6} "
+                f"{_pct(effect.item_share):>8} {effect.pass_rate:>8.4f} "
+                f"{effect.critical_fail_tasks:>10} "
+                f"({_pct(effect.task_share)}){note}"
+            )
+        lines.append("  * the shipped definition")
+        lines.append("")
+
+        if result.repeated:
+            lines.append(
+                f"  criteria repeated across >= {_pct(result.repeat_floor)} of "
+                f"tasks, within the shipped critical set:"
+            )
+            shipped = result.effect_at(SHIPPED_THRESHOLD)
+            total = shipped.critical_items if shipped else 0
+            for repeat in result.repeated:
+                variant = (
+                    f", {repeat.variants} spellings" if repeat.variants > 1 else ""
+                )
+                mags = "/".join(f"{m:g}" for m in repeat.magnitudes)
+                lines.append(
+                    f"    {repeat.items:>4} item(s) in {repeat.tasks} task(s) "
+                    f"({_pct(repeat.tasks / result.graded_tasks)}), "
+                    f"{_pct(repeat.share_of(total))} of the critical set, "
+                    f"|max|={mags}{variant}, rate {repeat.pass_rate:.4f}"
+                )
+                lines.append(f"         {repeat.criterion!r}")
+        else:
+            lines.append("  no criterion repeats above the floor")
+        lines.append("")
+
+        lines.append(
+            "  excluding deliverable-wide style lines "
+            "(core.grader_routing.is_overall_style_criterion):"
+        )
+        lines.append(
+            f"    excluded  {result.text_rule_items:>4} item(s) across "
+            f"{result.text_rule_tasks} task(s), rate {result.text_rule_rate:.4f}"
+        )
+        lines.append(
+            f"    remaining {result.remainder_items:>4} item(s), "
+            f"rate {result.remainder_rate:.4f}"
+        )
+        lines.append("")
+
+        lines.append(
+            f"  not publishing the metric would withdraw 1 run rate, "
+            f"{result.sector_rates} sector rate(s) and "
+            f"{result.graded_tasks} task boolean(s) from this payload"
+        )
+        lines.append("")
+
+    refused = [r for r in results if not r.priced]
+    lines.append(
+        f"{len(results)} payload(s) read, {len(refused)} refused"
+    )
+    if refused:
+        lines.append(
+            "  A refused payload was not priced. Do not read a number for it "
+            "off another payload's table."
+        )
+    return "\n".join(lines)
+
+
+def collect(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files += [
+                p
+                for p in sorted(path.rglob("*.json"))
+                if "_validation" not in p.parts
+            ]
+        elif path.is_file():
+            files.append(path)
+    return files
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_ROOT],
+        help="grade files or directories to price (default: data/grades)",
+    )
+    parser.add_argument(
+        "--repeat-floor",
+        type=float,
+        default=DEFAULT_REPEAT_TASK_SHARE,
+        help=(
+            "report criteria repeated across at least this share of tasks "
+            f"(default {DEFAULT_REPEAT_TASK_SHARE})"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    results: list[Priced] = []
+    for path in collect(args.paths):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        priced = price(path, payload, repeat_floor=args.repeat_floor)
+        if priced is not None:
+            results.append(priced)
+
+    if not results:
+        print("no grade payloads with a critical_item_pass_rate found")
+        return 0
+
+    print(render(results))
+    return 1 if any(not r.priced for r in results) else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/batch-runner/tests/test_required_item_definition_pricing.py
+++ b/batch-runner/tests/test_required_item_definition_pricing.py
@@ -1,0 +1,549 @@
+"""Tests for pricing the required-item definition.
+
+What is being priced and why it needs a test at all: GDPVal rubrics never say
+which items are required -- ``required`` is null on all 10,453 of them -- so the
+repository decided that weight stands in for necessity, at
+``abs(max_score) >= 4``. Two published numbers rest on that choice and the
+comment above it has always said 4 was a heuristic. The card that asks for a
+real definition lists three options, and the only thing missing before anyone
+can choose between them is what each one would do to the runs already
+published.
+
+The load-bearing tests here are the ones that stop this measuring the wrong
+thing:
+
+* ``test_the_sweep_reprices_through_the_production_summariser`` proves the
+  threshold really is being changed underneath ``step8_grade._compute_summary``
+  rather than inside a private copy of the rate. If that stopped being true
+  every number this script prints would be about a function nobody publishes.
+* ``test_the_recount_reproduces_the_published_critical_fail_booleans`` checks
+  the same thing for the other published consequence, against two real runs.
+  At the shipped threshold the recount has to land on the flags the grader
+  itself wrote -- 13 of 30 and 99 of 185 -- or the sweep's other rows are
+  measuring some rule of this file's own.
+* ``test_raising_the_threshold_to_five_moves_the_gold_rate_away_from_the_gate``
+  is the finding. The card's first option is priced against the very run whose
+  figure the card quotes, and it moves that figure in the wrong direction.
+
+The refusals are tested as carefully as the measurements, because a priced
+option is only worth as much as the payload it was priced against, and two of
+the published payloads cannot support one.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import core.grader as grader_module
+from scripts import analyze_required_item_definition as arid
+from scripts.analyze_gold_ceiling import CRITICAL_ITEM_PASS_FLOOR
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DIAGNOSTIC = REPO_ROOT / "data" / "grades" / "_diagnostic"
+TOOL_PATH = Path("batch-runner/scripts/analyze_required_item_definition.py")
+REPORT_PATH = REPO_ROOT / "data" / "grades" / "_validation" / "REQUIRED_ITEM_DEFINITION.md"
+
+#: The two gold-ceiling corpora, keyed by the ordered-id digest that names
+#: their directory. Stage 1 is the run the card quotes 0.5714 from.
+GOLD_30 = "82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b"
+GOLD_185 = "cef3a5b9f1305f19437d6ee337936a065965f979325b95a41d1001747e6bfa18"
+
+
+def _load_gold(digest: str) -> tuple[Path, dict]:
+    directory = DIAGNOSTIC / digest
+    if not directory.is_dir():
+        pytest.skip(f"gold corpus {digest[:8]} not present")
+    candidates = sorted(directory.glob("exp_gold_baseline__*.json"))
+    if not candidates:
+        pytest.skip(f"gold corpus {digest[:8]} has no payload")
+    path = candidates[0]
+    return path, json.loads(path.read_text(encoding="utf-8"))
+
+
+# ── synthetic payloads ───────────────────────────────────────────────
+
+
+def _item(
+    criterion: str,
+    max_score: float,
+    *,
+    did_right: bool = True,
+    excluded: bool = False,
+) -> dict:
+    return {
+        "id": criterion[:8],
+        "criterion": criterion,
+        "max_score": max_score,
+        "verdict": "pass" if did_right else "fail",
+        "decided_by": "judge",
+        "model_did_right": did_right,
+        "score_excluded": excluded,
+    }
+
+
+def _task(task_id: str, items: list[dict], *, sector: str = "test") -> dict:
+    scored = [i for i in items if not i["score_excluded"]]
+    awarded = sum(i["max_score"] for i in scored if i["model_did_right"])
+    total = sum(max(0.0, i["max_score"]) for i in scored)
+    return {
+        "task_id": task_id,
+        "sector": sector,
+        "occupation": "test",
+        "items": items,
+        "total_awarded": awarded,
+        "total_max": total,
+        "pct": round((awarded / total * 100.0) if total else 0.0, 2),
+        "critical_fail": any(
+            abs(i["max_score"]) >= grader_module.MAGNITUDE_THRESHOLD
+            and not i["model_did_right"]
+            for i in scored
+        ),
+        "usage_complete": True,
+    }
+
+
+def _payload(tasks: list[dict], *, published_rate: float | None = None) -> dict:
+    """A payload whose stored rate is whatever today's summariser computes.
+
+    Tests that want a payload which does *not* reproduce pass an explicit
+    ``published_rate``.
+    """
+    from step8_grade import _compute_summary
+
+    summary = _compute_summary(tasks)
+    if published_rate is not None:
+        summary["wow"]["critical_item_pass_rate"] = published_rate
+    return {"tasks": tasks, "summary": summary}
+
+
+def _price(payload: dict, *, floor: float = 0.10) -> arid.Priced:
+    priced = arid.price(Path("synthetic.json"), payload, repeat_floor=floor)
+    assert priced is not None
+    return priced
+
+
+# ── the mechanism: production code, not a copy of it ─────────────────
+
+
+def test_the_sweep_reprices_through_the_production_summariser():
+    """The whole design rests on this.
+
+    ``step8_grade`` imported ``_is_critical_item`` -- the function -- and that
+    function reads ``MAGNITUDE_THRESHOLD`` from ``core.grader`` when it is
+    called. So rebinding the module global changes what the real summariser
+    counts. If someone later froze the threshold into a default argument or a
+    module constant in ``step8_grade``, this test fails and the sweep stops
+    being a measurement of the shipped metric.
+    """
+    from step8_grade import _compute_summary
+
+    tasks = [
+        _task("t1", [_item("worth four", 4, did_right=False)]),
+        _task("t2", [_item("worth five", 5, did_right=True)]),
+    ]
+
+    with arid._threshold(4):
+        at_four = _compute_summary(tasks)["wow"]["critical_item_pass_rate"]
+    with arid._threshold(5):
+        at_five = _compute_summary(tasks)["wow"]["critical_item_pass_rate"]
+
+    assert at_four == 0.5  # both items counted, one right
+    assert at_five == 1.0  # the four-point failure drops out
+
+
+def test_the_threshold_is_put_back_even_when_the_body_raises():
+    """A leaked threshold would silently mis-grade everything downstream."""
+    original = grader_module.MAGNITUDE_THRESHOLD
+
+    with pytest.raises(RuntimeError):
+        with arid._threshold(99):
+            assert grader_module.MAGNITUDE_THRESHOLD == 99
+            raise RuntimeError("boom")
+
+    assert grader_module.MAGNITUDE_THRESHOLD == original
+
+
+def test_the_shipped_threshold_is_read_not_restated():
+    assert arid.SHIPPED_THRESHOLD == grader_module.MAGNITUDE_THRESHOLD
+    assert arid.SHIPPED_THRESHOLD in arid.THRESHOLD_SWEEP
+
+
+# ── the usable-denominator floor is derived, not chosen ──────────────
+
+
+def test_the_denominator_floor_comes_from_the_gate_it_serves():
+    """20 items, because one miss out of 20 is exactly the gate's margin.
+
+    Below that, a single failure costs more than the whole distance between
+    the floor and a clean sweep, so the metric cannot express any value in
+    between and a rate read off it is not a measurement of anything.
+    """
+    assert CRITICAL_ITEM_PASS_FLOOR == 0.95
+    assert arid.MIN_USABLE_CRITICAL_ITEMS == 20
+    assert 1.0 / arid.MIN_USABLE_CRITICAL_ITEMS <= 1.0 - CRITICAL_ITEM_PASS_FLOOR
+
+
+def test_a_rate_read_off_one_item_is_refused_as_a_basis():
+    """The real shape of the trap, from the stage-1 corpus.
+
+    At threshold 6 stage 1 keeps a single critical item, the model got it
+    right, and the metric reads a perfect 1.0000 -- over the 0.95 gate, on a
+    denominator of one out of 1,431 scored items.
+    """
+    tasks = [_task("t1", [_item("the only big one", 6, did_right=True)])]
+    priced = _price(_payload(tasks))
+
+    effect = priced.effect_at(6)
+    assert effect is not None
+    assert effect.critical_items == 1
+    assert effect.pass_rate == 1.0
+    assert effect.usable is False
+    assert "[denominator too thin to use]" in arid.render([priced])
+
+
+def test_a_denominator_that_can_carry_the_gate_is_not_flagged():
+    tasks = [
+        _task(
+            f"t{n}",
+            [_item(f"criterion {n}-{k}", 4, did_right=True) for k in range(5)],
+        )
+        for n in range(5)
+    ]
+    priced = _price(_payload(tasks))
+
+    effect = priced.effect_at(4)
+    assert effect is not None
+    assert effect.critical_items == 25
+    assert effect.usable is True
+
+
+# ── refusals ─────────────────────────────────────────────────────────
+
+
+def test_a_payload_without_sign_aware_verdicts_is_refused():
+    """Pre-#100 payloads published a rate this cannot reconstruct.
+
+    ``model_did_right`` is what the metric counts. Without it every item reads
+    as "the model got this wrong", so a sweep over such a payload would price
+    the options against a corpus of total failure that never happened.
+    """
+    tasks = [_task("t1", [_item("big", 5, did_right=True)])]
+    for item in tasks[0]["items"]:
+        del item["model_did_right"]
+    payload = _payload(tasks)
+
+    priced = _price(payload)
+
+    assert priced.priced is False
+    assert "model_did_right" in (priced.refusal or "")
+    assert "summary_wow_drift" in (priced.refusal or "")
+    assert priced.effects == []
+
+
+def test_a_payload_that_does_not_reproduce_is_refused():
+    """A stored rate the current summariser does not land on came from a rule
+    that is no longer running, so pricing a change against it would compare two
+    definitions while reporting one."""
+    tasks = [_task("t1", [_item("big", 5, did_right=True)])]
+
+    priced = _price(_payload(tasks, published_rate=0.1234))
+
+    assert priced.priced is False
+    assert "does not reproduce" in (priced.refusal or "")
+    assert priced.published_rate == 0.1234
+    assert priced.recomputed_rate == 1.0
+
+
+def test_a_refused_payload_makes_the_run_exit_nonzero(tmp_path, capsys):
+    tasks = [_task("t1", [_item("big", 5, did_right=True)])]
+    (tmp_path / "bad.json").write_text(
+        json.dumps(_payload(tasks, published_rate=0.1234)), encoding="utf-8"
+    )
+
+    assert arid.main([str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "1 refused" in out
+    assert "Do not read a number for it off another payload's table." in out
+
+
+def test_a_payload_with_no_such_metric_is_skipped_not_refused(tmp_path, capsys):
+    """Not every JSON under data/grades is a graded run."""
+    (tmp_path / "other.json").write_text(
+        json.dumps({"tasks": [], "summary": {}}), encoding="utf-8"
+    )
+
+    assert arid.main([str(tmp_path)]) == 0
+    assert "no grade payloads" in capsys.readouterr().out
+
+
+# ── the census: derived from the corpus, never hardcoded ─────────────
+
+
+def test_the_census_finds_a_repeated_line_it_was_never_told_about():
+    """Nothing in the script knows what the repeated criterion says.
+
+    The real corpus repeats one line about formatting; this invents a
+    different one, so a hardcoded string would find nothing here.
+    """
+    tasks = [
+        _task(
+            f"t{n}",
+            [
+                _item("Widget torque is within tolerance", 5, did_right=False),
+                _item(f"unique to task {n}", 4, did_right=True),
+            ],
+        )
+        for n in range(10)
+    ]
+    priced = _price(_payload(tasks))
+
+    assert [r.criterion for r in priced.repeated] == [
+        "Widget torque is within tolerance"
+    ]
+    repeat = priced.repeated[0]
+    assert (repeat.items, repeat.tasks, repeat.pass_rate) == (10, 10, 0.0)
+    assert repeat.share_of(20) == 0.5
+
+
+def test_spellings_of_one_line_are_counted_as_one_line():
+    """Stage 3 carries the style line 119 times bare and once with a full stop.
+
+    Counting those as two lines would halve the share this measures and hide
+    the concentration it exists to find.
+    """
+    tasks = [
+        _task("t1", [_item("Overall formatting and style", 5)]),
+        _task("t2", [_item("Overall formatting and style.", 5)]),
+        _task("t3", [_item("overall  formatting and STYLE ", 5)]),
+    ]
+    priced = _price(_payload(tasks))
+
+    assert len(priced.repeated) == 1
+    repeat = priced.repeated[0]
+    assert repeat.items == 3
+    assert repeat.variants == 3
+    # The most common spelling is quoted, so the report shows the rubric's
+    # words rather than this file's folded key.
+    assert repeat.criterion in {
+        "Overall formatting and style",
+        "Overall formatting and style.",
+        "overall  formatting and STYLE",
+    }
+    assert repeat.criterion != repeat.criterion.lower().rstrip(".")
+
+
+def test_a_line_that_appears_once_is_not_repeated_however_small_the_corpus():
+    """On a three-task smoke one occurrence is a third of the corpus.
+
+    A share floor on its own would report every criterion in such a run as
+    repeated boilerplate, which is the opposite of what this measures.
+    """
+    tasks = [_task(f"t{n}", [_item(f"unique {n}", 5)]) for n in range(3)]
+
+    assert _price(_payload(tasks), floor=0.10).repeated == []
+
+
+def test_a_line_below_the_floor_is_not_reported_as_repeated():
+    tasks = [_task(f"t{n}", [_item("rare line", 5)]) for n in range(2)]
+    tasks += [_task(f"u{n}", [_item(f"unique {n}", 5)]) for n in range(38)]
+
+    assert _price(_payload(tasks), floor=0.10).repeated == []
+    assert [r.criterion for r in _price(_payload(tasks), floor=0.05).repeated] == [
+        "rare line"
+    ]
+
+
+def test_excluded_items_are_outside_both_the_census_and_the_rates():
+    """The published metric is defined over scored items only."""
+    tasks = [
+        _task(
+            "t1",
+            [
+                _item("counted", 5, did_right=True),
+                _item("never scored", 5, did_right=False, excluded=True),
+            ],
+        )
+    ]
+    priced = _price(_payload(tasks))
+
+    effect = priced.effect_at(4)
+    assert effect is not None
+    assert effect.critical_items == 1
+    assert effect.pass_rate == 1.0
+    assert effect.critical_fail_tasks == 0
+
+
+# ── the text-rule option ─────────────────────────────────────────────
+
+
+def test_the_text_rule_option_uses_the_predicate_the_grader_already_ships():
+    """Priced against something real rather than a rule invented here.
+
+    ``core.grader_routing.is_overall_style_criterion`` is what the grader uses
+    to decide a criterion is asking about deliverable-wide polish rather than
+    about the work, and it is already covered by the routing tests.
+    """
+    tasks = [
+        _task(
+            "t1",
+            [
+                _item("Overall formatting and style of the deliverable", 5, did_right=False),
+                _item("The totals reconcile to the ledger", 5, did_right=True),
+            ],
+        )
+    ]
+    priced = _price(_payload(tasks))
+
+    assert (priced.text_rule_items, priced.text_rule_rate) == (1, 0.0)
+    assert (priced.remainder_items, priced.remainder_rate) == (1, 1.0)
+
+
+def test_two_tasks_carrying_the_same_line_both_stay_in_their_partition():
+    """Rubric items are plain dicts and ``in`` compares them by value.
+
+    Splitting the critical set with a membership test dropped every copy of
+    every repeated line from the remainder -- which is exactly the set being
+    measured. Four items here, two identical pairs, and both partitions must
+    keep both of theirs.
+    """
+    line = "Overall formatting and style of the deliverable"
+    other = "The totals reconcile to the ledger"
+    tasks = [
+        _task("t1", [_item(line, 5, did_right=True), _item(other, 5, did_right=True)]),
+        _task("t2", [_item(line, 5, did_right=True), _item(other, 5, did_right=True)]),
+    ]
+    priced = _price(_payload(tasks))
+
+    assert priced.text_rule_items == 2
+    assert priced.remainder_items == 2
+
+
+# ── against the runs that were actually published ────────────────────
+
+
+@pytest.mark.parametrize(
+    "digest,tasks,rate,stored_fails",
+    [(GOLD_30, 30, 0.5714, 13), (GOLD_185, 185, 0.6394, 99)],
+)
+def test_the_recount_reproduces_the_published_critical_fail_booleans(
+    digest, tasks, rate, stored_fails
+):
+    """Both published consequences, checked against the grader's own output.
+
+    The rate comes back through the production summariser; the booleans are
+    recounted here, so this is where that recount is held to the flags
+    ``core.grader._aggregate`` actually wrote into the payload.
+    """
+    path, payload = _load_gold(digest)
+    priced = arid.price(path, payload, repeat_floor=0.10)
+    assert priced is not None and priced.priced, priced.refusal if priced else None
+
+    assert priced.task_count == tasks
+    assert priced.published_rate == priced.recomputed_rate == rate
+
+    stored = sum(1 for task in payload["tasks"] if task.get("critical_fail"))
+    assert stored == stored_fails
+    shipped = priced.effect_at(arid.SHIPPED_THRESHOLD)
+    assert shipped is not None
+    assert shipped.critical_fail_tasks == stored
+
+
+def test_raising_the_threshold_to_five_moves_the_gold_rate_away_from_the_gate():
+    """The card's first option, priced against the run the card quotes.
+
+    Stage 1's 0.5714 has to reach 0.95. Raising the boundary to 5 takes it to
+    0.5312, because the line that dominates the critical set is worth exactly
+    5: a threshold of 5 keeps every one of them and drops the real must-haves
+    worth 4. Stage 3 moves the same way, 0.6394 to 0.6325.
+    """
+    for digest, at_four, at_five in ((GOLD_30, 0.5714, 0.5312), (GOLD_185, 0.6394, 0.6325)):
+        path, payload = _load_gold(digest)
+        priced = arid.price(path, payload, repeat_floor=0.10)
+        assert priced is not None and priced.priced
+
+        four, five = priced.effect_at(4), priced.effect_at(5)
+        assert four is not None and five is not None
+        assert (four.pass_rate, five.pass_rate) == (at_four, at_five)
+        assert five.pass_rate < four.pass_rate < CRITICAL_ITEM_PASS_FLOOR
+
+
+def test_one_repeated_line_is_most_of_what_the_gold_metric_measures():
+    """Why the definition is worth reopening at all.
+
+    A single verbatim rubric line, worth 5 and present in roughly two thirds of
+    tasks, is 54.3% of stage 1's critical set and 33.8% of stage 3's, and the
+    expert gold answers pass it at about a third the rate of everything else.
+    """
+    for digest, items, share_tasks, styled_rate, rest_rate in (
+        (GOLD_30, 19, 19, 0.4211, 0.7500),
+        (GOLD_185, 120, 120, 0.3000, 0.8128),
+    ):
+        path, payload = _load_gold(digest)
+        priced = arid.price(path, payload, repeat_floor=0.10)
+        assert priced is not None and priced.priced
+
+        assert priced.text_rule_items == items
+        assert priced.text_rule_tasks == share_tasks
+        assert priced.text_rule_rate == styled_rate
+        assert priced.remainder_rate == rest_rate
+        # Even with that line removed the gold answers stay under the gate, so
+        # this is a finding about the rubric or the judge, not a way to pass.
+        assert rest_rate < CRITICAL_ITEM_PASS_FLOOR
+
+
+def test_withdrawing_the_metric_is_priced_in_published_numbers():
+    """The second option's cost is countable: what would stop being published."""
+    path, payload = _load_gold(GOLD_30)
+    priced = arid.price(path, payload, repeat_floor=0.10)
+    assert priced is not None and priced.priced
+
+    assert priced.sector_rates == len(payload["summary"]["wow"]["by_sector"])
+    assert priced.graded_tasks == 30
+    assert "1 run rate, 4 sector rate(s) and 30 task boolean(s)" in arid.render(
+        [priced]
+    )
+
+
+# ── the report can actually be reproduced from a fresh clone ─────────
+
+
+def test_the_tool_is_tracked_where_the_report_says_it_is():
+    """``batch-runner/scripts/`` is gitignored with per-file exceptions, so a
+    tool can work locally and be absent from a fresh clone.
+
+    That matters more here than usual: the report is a set of numbers about
+    published grades, and the only thing standing behind them is the command
+    that recomputes them. An untracked tool turns "reproducing this" into an
+    instruction nobody else can follow.
+
+    Probed without ``--verbose`` on purpose. With it, git reports the last
+    matching pattern *including negations* and exits 0 either way, so a
+    verbose probe cannot tell "ignored" from "un-ignored by a later rule".
+    Without it the exit code is the answer: 1 means no pattern ignores this.
+    """
+    assert (REPO_ROOT / TOOL_PATH).is_file()
+
+    finished = subprocess.run(
+        ["git", "check-ignore", str(TOOL_PATH)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert finished.returncode == 1, (
+        f"{TOOL_PATH} is ignored, so the command in the report cannot run "
+        f"from a fresh clone"
+    )
+
+
+def test_the_report_names_the_tool_it_was_produced_by():
+    """A measured claim that does not say what measured it is not checkable."""
+    assert REPORT_PATH.is_file()
+    text = REPORT_PATH.read_text(encoding="utf-8")
+
+    assert TOOL_PATH.name in text
+    assert "MAGNITUDE_THRESHOLD" in text

--- a/data/grades/_validation/REQUIRED_ITEM_DEFINITION.md
+++ b/data/grades/_validation/REQUIRED_ITEM_DEFINITION.md
@@ -1,0 +1,276 @@
+# What `critical_item_pass_rate` Is Measuring — the Required-Item Definition, Priced
+
+**Measurement only. No decision is taken here.** `core.grader.MAGNITUDE_THRESHOLD`
+is unchanged, no payload was edited, no grade was republished, and no grading was
+dispatched. Everything below was recomputed from payloads already in the
+repository, through the production summariser, by
+`batch-runner/scripts/analyze_required_item_definition.py`.
+
+The board card asks for a real definition of "required item" and lists three
+options. The only thing missing before anyone can choose is what each option
+would do to the runs already published. That is what this file supplies.
+
+## Why there is a question at all
+
+GDPVal v2 rubrics carry a `required` field and it is `null` on **all 10,453
+items**. With no author signal, the repository decided that weight stands in for
+necessity (`core/grader.py:118-138`):
+
+```python
+MAGNITUDE_THRESHOLD = 4
+
+def _is_critical_item(max_score) -> bool:
+    return abs(max_score or 0) >= MAGNITUDE_THRESHOLD
+```
+
+The comment above it has always said 4 is a heuristic, to be re-evaluated once
+gold-ceiling validation showed whether the boundary mis-classifies items. That
+validation is finished, so the deferral has run out.
+
+## What actually moves if the definition changes
+
+Two published fields, and nothing else:
+
+| field | where | shape |
+|---|---|---|
+| `summary.wow.critical_item_pass_rate` | run-level and per sector | micro rate over items (`step8_grade._tally_item`) |
+| `tasks[].critical_fail` | per task | boolean (`core/grader.py:1949-1952`) |
+
+`pct`, `total_max`, `total_awarded` and every headline score are computed from
+`max_score` directly and do not consult the threshold. The blast radius is
+bounded, and it is bounded to the two numbers most often read as "did the model
+get the things that matter right".
+
+## TL;DR
+
+1. **Option 1 — raising the threshold to 5 — moves the gold figure the wrong
+   way**, on the very run the card quotes. Stage 1 goes 0.5714 → **0.5312**, away
+   from the 0.95 gate. Stage 3 goes 0.6394 → 0.6325. On the 220-task model run it
+   drifts the other way (0.4903 → 0.4950), so the direction is not even
+   consistent across corpora.
+
+2. **One verbatim rubric line is most of what the metric measures.** `'Overall
+   formatting and style of the deliverable'`, worth exactly 5, appears in 55–65%
+   of tasks and makes up **54.3%** of stage 1's critical set and **33.8%** of
+   stage 3's. Expert gold answers pass it at roughly a third the rate of
+   everything else. Because it is worth 5, a threshold of 5 keeps every copy and
+   drops only the genuine must-haves worth 4 — which is why option 1 goes
+   backwards.
+
+3. **Threshold 6 is not the fix either.** It does remove the boilerplate, but on
+   stage 1 it leaves a **single** critical item out of 1,431 scored ones; the
+   metric then reads a perfect 1.0000 on a denominator of one. On stage 3 it
+   still reads 0.8776, and it flips `critical_fail` for 93 of 185 gold tasks.
+
+4. **A fourth option exists that the card does not list**: exclude
+   deliverable-wide style lines using the predicate the grader already ships,
+   `core.grader_routing.is_overall_style_criterion`. Gold then reads **0.7500**
+   (stage 1) and **0.8128** (stage 3) — still short of 0.95. That shortfall is
+   itself a finding: what remains is real must-haves the expert gold answer
+   genuinely misses.
+
+5. **Six published payloads cannot be priced at all** and are reported as
+   refused rather than given a number.
+
+## The sweep
+
+`items` is the size of the critical set at that threshold; `share` is its
+fraction of all scored items; `rate` is `critical_item_pass_rate` as recomputed
+by `step8_grade._compute_summary` with `core.grader.MAGNITUDE_THRESHOLD`
+rebound; `critical_fail tasks` is the recount of the per-task boolean. `*` marks
+the shipped definition, where published and recomputed agree to the digit.
+
+### Stage-1 gold ceiling — 30 tasks, 1,431 scored items (published 0.5714)
+
+| threshold | items | share | rate | `critical_fail` tasks |
+|--:|--:|--:|--:|---|
+| 2 | 695 | 48.6% | 0.7568 | 29 (96.7%) |
+| 3 | 46 | 3.2% | 0.6087 | 13 (43.3%) |
+| **4 \*** | **35** | **2.4%** | **0.5714** | **13 (43.3%)** |
+| 5 | 32 | 2.2% | 0.5312 | 13 (43.3%) |
+| 6 | 1 | 0.1% | 1.0000 | 0 (0.0%) — denominator too thin to use |
+| 8 | 1 | 0.1% | 1.0000 | 0 (0.0%) — denominator too thin to use |
+| 10 | 1 | 0.1% | 1.0000 | 0 (0.0%) — denominator too thin to use |
+
+### Stage-3 gold ceiling — 185 tasks, 8,759 scored items (published 0.6394)
+
+| threshold | items | share | rate | `critical_fail` tasks |
+|--:|--:|--:|--:|---|
+| 2 | 4277 | 48.8% | 0.7335 | 175 (94.6%) |
+| 3 | 543 | 6.2% | 0.6796 | 103 (55.7%) |
+| **4 \*** | **355** | **4.1%** | **0.6394** | **99 (53.5%)** |
+| 5 | 302 | 3.4% | 0.6325 | 96 (51.9%) |
+| 6 | 98 | 1.1% | 0.8776 | 6 (3.2%) |
+| 8 | 69 | 0.8% | 0.8551 | 6 (3.2%) |
+| 10 | 62 | 0.7% | 0.8710 | 4 (2.2%) |
+
+### OFFICIAL sol-220 model run — 220 tasks, 10,421 scored items (published 0.4903)
+
+`…regrade_exp003_v2_sol_max_score_excluded__…src_595c7254caf8fbd7__v2.2.json`,
+graded 2026-08-23. (The older `src_1c967673eb8081a6` payload publishes 0.4848;
+they are different runs and must not be conflated.)
+
+| threshold | items | share | rate | `critical_fail` tasks |
+|--:|--:|--:|--:|---|
+| 2 | 5057 | 48.5% | 0.4813 | 212 (96.4%) |
+| 3 | 717 | 6.9% | 0.5091 | 123 (55.9%) |
+| **4 \*** | **465** | **4.5%** | **0.4903** | **118 (53.6%)** |
+| 5 | 402 | 3.9% | 0.4950 | 113 (51.4%) |
+| 6 | 131 | 1.3% | 0.6718 | 14 (6.4%) |
+| 8 | 98 | 0.9% | 0.8061 | 11 (5.0%) |
+| 10 | 91 | 0.9% | 0.8242 | 10 (4.5%) |
+
+### Why "denominator too thin to use" is a refusal and not a caveat
+
+`step8_grade._rate` returns `0.0` on an empty denominator and `1.0` on a single
+passing item. Both look like measurements. The floor used here is derived from
+the gate the metric serves rather than chosen: `analyze_gold_ceiling.py` pins
+`CRITICAL_ITEM_PASS_FLOOR = 0.95`, whose entire margin is `1 − 0.95`, so below
+`ceil(1 / 0.05) = 20` items a single failure costs more than the whole distance
+between the floor and a clean sweep. Stage 1 at threshold 6 has one item.
+
+## The concentration
+
+Within the shipped critical set, grouping criteria by text (case, whitespace and
+a trailing period folded), requiring a line to appear in more than one task and
+in at least 10% of tasks:
+
+| run | items | tasks | share of tasks | share of critical set | weight | pass rate |
+|---|--:|--:|--:|--:|--:|--:|
+| stage-1 gold | 19 | 19 | 63.3% | 54.3% | 5 | 0.4211 |
+| stage-3 gold | 120 | 120 | 64.9% | 33.8% | 5 | 0.3000 |
+| sol-220 | 121 | 121 | 55.0% | 26.0% | 5 | 0.1901 |
+
+("weight" is `abs(max_score)`, the quantity the shipped definition thresholds.)
+
+In every case the one line is `'Overall formatting and style of the
+deliverable'`. It is the only criterion in any of the three runs that clears the
+floor. Stage 3 carries it 119 times bare and once with a full stop; sol-220 the
+same, plus one genuinely different line — `'Overall formatting and style of the
+deliverable matches that of a professional legal document'`.
+
+That third line is why the census and the predicate differ by one item on
+sol-220 (121 vs 122). Both counts are correct; they answer different questions.
+The census asks "which exact line repeats", and that sentence is its own string.
+The predicate asks "is this criterion about deliverable-wide polish", and it is.
+
+## The four options, priced
+
+Every figure below is a recomputation of the two published fields. Nothing else
+in any payload changes under any option.
+
+### 1. Raise the threshold (e.g. to 5)
+
+| run | rate now | rate at 5 | `critical_fail` now | at 5 |
+|---|--:|--:|--:|--:|
+| stage-1 gold | 0.5714 | **0.5312** | 13 | 13 |
+| stage-3 gold | 0.6394 | **0.6325** | 99 | 96 |
+| sol-220 | 0.4903 | 0.4950 | 118 | 113 |
+
+Cost: both gold figures move away from the 0.95 gate, and the model run moves
+toward it, so the same change makes the benchmark's own ceiling look worse and
+the system under test look better. The cause is mechanical — the dominant line
+is worth exactly 5.
+
+Raising further does not rescue it: threshold 6 leaves stage 1 with one item and
+no usable denominator, still reads 0.8776 on stage 3, and reclassifies
+`critical_fail` for 93 of 185 gold tasks and 104 of 220 model tasks.
+
+### 2. Stop publishing the metric
+
+Countable cost, per payload:
+
+| run | run-level rates | sector rates | task booleans |
+|---|--:|--:|--:|
+| stage-1 gold | 1 | 4 | 30 |
+| stage-3 gold | 1 | 9 | 185 |
+| sol-220 | 1 | 9 | 220 |
+
+Across the 88 payloads under `data/grades/` that this could price, it withdraws
+every `critical_item_pass_rate` the dashboard renders
+(`src/components/wow/CriticalItemCard.tsx`, `src/components/wow/SectorHeatmap.tsx`)
+and every per-task `critical_fail` flag in the payloads. It costs no accuracy —
+nothing published becomes wrong — and it removes the only per-task signal that
+distinguishes "scored 60% by missing small things" from "scored 60% by missing
+the point".
+
+### 3. Judge necessity from the criterion text
+
+A separate predicate over the wording, rather than the weight. The repository
+already ships one such predicate for a neighbouring purpose —
+`core.grader_routing.is_overall_style_criterion`, used by the grader to route
+perception and covered by the routing tests. Applying it as an **exclusion**
+inside the shipped critical set:
+
+| run | excluded items | excluded rate | remaining items | remaining rate |
+|---|--:|--:|--:|--:|
+| stage-1 gold | 19 | 0.4211 | 16 | **0.7500** |
+| stage-3 gold | 120 | 0.3000 | 235 | **0.8128** |
+| sol-220 | 122 | 0.1967 | 343 | 0.5948 |
+
+Stage 1's remaining 16 items are below the 20-item floor above, so 0.7500 should
+be read as indicative for that corpus, not as a gate-quality figure. Stage 3's
+235 items carry it comfortably.
+
+The honest part of this option is that gold still does not reach 0.95. Removing
+the boilerplate does not make the gold ceiling clean; it makes the residual
+visible, and the residual is real must-haves the expert answers miss.
+
+Building a *general* text predicate — not just this one exclusion — is untested
+work. `is_overall_style_criterion` was measured to catch exactly the
+deliverable-wide boilerplate and nothing else; no comparable evidence exists for
+any broader rule, and inventing one would put an unvalidated classifier
+underneath a published number.
+
+### 4. Keep the threshold and publish what it contains
+
+No recomputation, because nothing changes. What it costs is that
+`critical_item_pass_rate` continues to be, on the gold corpora, a majority
+measurement of one formatting line. The mitigation available without touching
+`core/grader.py` is to publish the concentration alongside the rate, which the
+tables above make computable for any payload.
+
+## Refusals
+
+`scripts/analyze_required_item_definition.py` prices nothing it cannot
+reproduce. Over the whole tree (94 payloads, 6.7 s) six were refused, and the
+causes are the two already named by `scripts/summary_wow_drift.py`:
+
+| cause | payloads | why it cannot be priced |
+|---|--:|---|
+| pre-#100 payload — no `model_did_right` on items | 4 | the metric counts that field; without it every item reads as a failure the model never had |
+| pre-#69 payload — stored rate does not reproduce | 2 | the stored rate came from a summariser that is no longer running, so a sweep would compare two definitions while reporting one |
+
+The tool exits non-zero when any payload is refused, and prints: *"A refused
+payload was not priced. Do not read a number for it off another payload's
+table."* Fourteen further payloads report no repeated criterion above the floor,
+which is a finding about those corpora rather than a refusal.
+
+## Reproducing this
+
+```bash
+cd batch-runner
+python scripts/analyze_required_item_definition.py \
+  ../data/grades/_diagnostic/82d14ac9*/exp_gold*.json \
+  ../data/grades/_diagnostic/cef3a5b9*/exp_gold*.json \
+  '../data/grades/exp003_*src_595c7254caf8fbd7__v2.2.json'
+
+# or the whole tree
+python scripts/analyze_required_item_definition.py ../data/grades
+```
+
+The tool lives outside `compute_grader_source_hash`'s input set
+(`step8_grade.py:159-200` covers `step8_grade.py`, `core/**/*.py`, the grade
+schema, `requirements.txt`, `scripts/download_inference_from_hf.py`, the prompt
+templates and the config file — no other file under `batch-runner/scripts/`), so
+running or changing it moves no grader fingerprint and invalidates no published
+grade.
+
+## What is still open
+
+The definition itself. Changing `MAGNITUDE_THRESHOLD`, or replacing it, changes
+this metric on every run already published, and `core/grader.py` **is** a
+grader-fingerprint input — so the decision belongs to the owner and the card's
+완료 기준 requires it in writing. This file exists so that the decision can be
+made against measured consequences instead of an assumption about what "worth 4
+points" means.


### PR DESCRIPTION
## What this is

Measurement only. `core.grader.MAGNITUDE_THRESHOLD` is unchanged, nothing under
`core/` or `step8_grade.py` was edited, no payload was rewritten, no grade was
republished, and no grading was dispatched. **Cost of producing everything here:
zero** — every number is recomputed from payloads already in this repository.

The board card *"필수 항목 통과율의 정의를 다시 정한다"* asks for a real definition of
"required item" and lists three options. Its own constraint is that the decision
must not be taken arbitrarily, because changing the code changes this metric on
every run already published and `core/grader.py` is a grader-fingerprint input.
So this PR does not decide. It prices.

## Why there is a question

GDPVal v2 rubrics carry a `required` field and it is `null` on **all 10,453
items**. With no author signal, the repository decided weight stands in for
necessity (`core/grader.py:118-138`):

```python
MAGNITUDE_THRESHOLD = 4

def _is_critical_item(max_score) -> bool:
    return abs(max_score or 0) >= MAGNITUDE_THRESHOLD
```

The comment above it has always said 4 is a heuristic, to be re-evaluated once
gold-ceiling validation showed whether the boundary mis-classifies items. That
validation is finished, so the deferral has run out.

## The finding

**One verbatim rubric line is most of what the metric measures.** `'Overall
formatting and style of the deliverable'` is worth exactly 5 and appears in
55–65% of tasks. It is **54.3%** of the stage-1 gold critical set and **33.8%**
of stage-3's, and the expert gold answers pass it at roughly a third the rate of
everything else.

Which is why the card's first option goes backwards. A threshold of 5 keeps
every copy of a line worth 5 and drops only the genuine must-haves worth 4:

| run | now (thr 4) | at thr 5 | direction vs. the 0.95 gate |
|---|--:|--:|---|
| stage-1 gold ceiling (30 tasks) | 0.5714 | **0.5312** | **away** |
| stage-3 gold ceiling (185 tasks) | 0.6394 | **0.6325** | **away** |
| OFFICIAL sol-220 model run | 0.4903 | 0.4950 | toward |

The same change makes the benchmark's own ceiling look worse and the system
under test look better.

Threshold 6 is not the rescue: it does clear the boilerplate, and leaves stage 1
with **one** critical item out of 1,431 scored ones, which then reads a perfect
`1.0000`. A fourth option the card does not list — excluding deliverable-wide
style lines with `core.grader_routing.is_overall_style_criterion`, a predicate
the grader already ships and already tests — reads **0.7500** and **0.8128**.
Still short of 0.95, and that shortfall is itself the finding: what remains is
real must-haves the expert answers genuinely miss.

Full sweep, all four options with their costs, and the refusals:
`data/grades/_validation/REQUIRED_ITEM_DEFINITION.md`.

## Why the numbers can be trusted

**The sweep reprices through the production summariser, not a copy of it.**
`step8_grade` imports `_is_critical_item` — the function — and that function
reads `MAGNITUDE_THRESHOLD` from `core.grader` *when it is called*. Rebinding
the module global therefore moves `summary.wow.critical_item_pass_rate` and
`tasks[].critical_fail` through `step8_grade._compute_summary`, exactly as a
real change would. A test pins that mechanism, so if someone later freezes the
threshold into a default argument the sweep fails loudly instead of quietly
measuring a function nobody publishes.

**At the shipped threshold the recount must reproduce the grader's own output.**
Published = recomputed to the digit on both gold corpora (0.5714 / 0.6394), and
the recounted `critical_fail` booleans land on the flags the grader itself wrote
(13 of 30, 99 of 185). Parametrized test.

**Two refusals, tested as carefully as the measurements.** A payload whose
stored rate today's summariser does not reproduce is refused rather than priced
— the stored rate came from a rule no longer running, so pricing against it
would compare two definitions while reporting one; the tool defers to the two
causes `scripts/summary_wow_drift.py` already named (6 of the 94 payloads).
And a rate is refused below `ceil(1 / (1 - 0.95)) = 20` critical items — a floor
**derived from the gate the metric serves**, not chosen, because below it a
single failure costs more than the gate's entire margin. `_rate` returns `1.0`
on one passing item, which looks like a metric and is not one.

## Fingerprint safety

`compute_grader_source_hash` (`step8_grade.py:159-200`) covers `step8_grade.py`,
`core/**/*.py`, the grade schema, `requirements.txt`,
`scripts/download_inference_from_hf.py`, the prompt templates and the config
file. **No other file under `batch-runner/scripts/` is in that set.** This PR
touches nothing inside it, so no grader fingerprint moved and no published grade
was invalidated. It also adds no file that Session B's in-flight work touches.

## Verification

- `pytest` (backend, full): **7393 passed, 7 skipped, 45 deselected**, 17m35s,
  exit 0 — run on the final tree, after the `.gitignore` change
- New file: **24 tests**, 3.3s, including the two real gold corpora
- `mypy core/ --ignore-missing-imports`: no new errors (the 45 pre-existing ones
  in `core/tool_calling_judge.py`, `core/grader.py`, `step8_grade.py` are
  untouched)
- The tool is tracked via a `.gitignore` negation like its neighbours, with a
  test that probes `git check-ignore` **without** `--verbose` — with it, git
  reports the last matching pattern *including negations* and exits 0 either
  way, so only the bare exit code can tell "ignored" from "un-ignored by a later
  rule"

## What is still open

The definition itself. That decision is the owner's, and the card's 완료 기준
requires it in writing, so this PR deliberately leaves the card out of 완료.
