### PR TITLE
fix(grade): stop a run that compared nothing from publishing perfect agreement

### DIFF
--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -703,7 +703,7 @@
             "perfect_count": {"type": "integer", "minimum": 0, "description": "Scored tasks at or above 99% -- NEAR-perfect, not full marks. A task that dropped a point is counted here, so this is an upper bound on how many scored exactly 100 and must not be read as one. The name is kept for compatibility with the field it mirrors; the threshold is the one stated here, not the one the name suggests. Anything reporting this number has to say `>= 99%` beside it."},
             "zero_count": {"type": "integer", "minimum": 0, "description": "Scored tasks at or below 1% -- NEAR-zero, not exactly zero, with the same naming caveat as `perfect_count`. A task that earned 0.7% is counted here. Report it as `<= 1%`."},
             "partial_count": {"type": "integer", "minimum": 0, "description": "`graded_tasks` minus `perfect_count` minus `zero_count`: the scored tasks strictly between 1% and 99%."},
-            "inconsistent_count": {"type": "integer", "minimum": 0}
+            "inconsistent_count": {"type": "integer", "minimum": 0, "description": "A compatibility placeholder that is ALWAYS 0, and is not a measurement. It mirrors a field that means 'tasks two graders scored differently'; no run here has two graders. Each task is graded once, and `step9_merge_shards` refuses shards that are not disjoint, so a payload cannot hold the same task twice and there has never been anything to compare. Do not present this as grader agreement: three gradings of the same thirty answers at one fingerprint moved 29 of the 30 tasks, so the direction this zero suggests is the wrong one. `summary.grader_agreement` states the basis; read it before reporting this number at all."}
           },
           "additionalProperties": true
         },
@@ -717,6 +717,19 @@
             "excluded_max_score": {"type": "number", "minimum": 0, "description": "The positive rubric weight that left the denominators, summed over the run."},
             "avg_score_pct_full_denominator": {"type": ["number", "null"], "minimum": 0, "maximum": 100, "description": "The same average with every excluded item counted at full weight and zero award. The pessimistic end of what is known: it assumes an unread item would have earned nothing, where `avg_score_pct` assumes it would have earned at the rate of the items that were read. The run's true average lies between the two. Recomputed from `items`, so a grade file written before the per-task `pct_full_denominator` field existed reports the same number when re-summarised."},
             "avg_score_pct_lift": {"type": ["number", "null"], "description": "`avg_score_pct` minus `avg_score_pct_full_denominator` — how many points of the headline are owed to rubric items that were never read. Exactly 0 when nothing was excluded."}
+          },
+          "additionalProperties": true
+        },
+        "grader_agreement": {
+          "type": "object",
+          "description": "Whether two gradings of one task were ever put side by side to produce `openai_compat.inconsistent_count`. They were not, in any payload this pipeline has written: each task is graded once, and `step9_merge_shards` refuses shards that are not disjoint, so a payload cannot hold the same task twice. That makes the required `0` beside it the value for 'nothing was compared' standing in for the value for 'they agreed' — and the repository has measured which of those is closer, by grading the same thirty answers three times at one fingerprint and watching 29 of the 30 tasks move. Nothing here is assumed from the pipeline's current shape: the counts are read off the task list, so a set of tasks that does hold repeats reports a real measurement instead of a constant.",
+          "required": ["compared", "gradings_per_task", "tasks_compared", "tasks_that_moved", "max_spread_pp"],
+          "properties": {
+            "compared": {"type": "boolean", "description": "Whether any task in this payload was graded more than once. False for every run this pipeline currently produces, which is exactly the claim worth being able to read beside a zero that looks like agreement."},
+            "gradings_per_task": {"type": "integer", "minimum": 0, "description": "The most gradings any single task received here. 1 on an ordinary run; 0 on an empty one. A payload reporting 1 has no basis on which any two verdicts could have disagreed."},
+            "tasks_compared": {"type": "integer", "minimum": 0, "description": "Tasks holding at least two gradings with a numeric `pct`. An errored grading has no score to compare, so it does not make a task comparable on its own."},
+            "tasks_that_moved": {"type": ["integer", "null"], "minimum": 0, "description": "Of those, how many scored differently between gradings. **Null — never 0 — when `compared` is false.** A 0 here would repeat the mistake this object exists to name: it would report 'we compared and found no disagreement' about a run that compared nothing, in the reassuring direction."},
+            "max_spread_pp": {"type": ["number", "null"], "minimum": 0, "description": "The widest gap in percentage points between one task's highest and lowest score across its gradings. Null under the same condition as `tasks_that_moved`, and for the same reason."}
           },
           "additionalProperties": true
         },

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -1878,6 +1878,85 @@ def _routing_stats(task_dicts: list[dict]) -> dict:
     }
 
 
+def _grader_agreement_stats(task_dicts: list[dict]) -> dict:
+    """Whether two gradings of one task were ever put side by side here.
+
+    ``openai_compat.inconsistent_count`` is a required integer that has been
+    the literal ``0`` in every payload this repository has ever written, and
+    the dashboard renders it as *"multiple graders scored the same task
+    differently: 0"*. No run has ever had multiple graders. Each task is
+    graded once, and ``step9_merge_shards`` refuses a merge whose shards are
+    not disjoint, so a published payload cannot hold the same task twice.
+    Nothing was compared, and the number for "nothing was compared" was
+    published as the number for "they all agreed".
+
+    The direction matters. The repository has measured this separately: three
+    gradings of the same thirty answers, at one grader fingerprint, moved
+    **29 of the 30 tasks**. So the zero is not an unexamined guess that
+    happens to be defensible -- it is the reassuring answer to a question
+    whose real answer is already known to be the opposite.
+
+    That integer stays as it is. Ninety-four committed payloads carry it,
+    ``core/grade_payload.py`` and ``scripts/aggregate-grades.mjs`` both use
+    ``inconsistent_count != 0`` to recognise a stub, and its schema entry now
+    says plainly what it is. What was missing is a statement of the *basis*,
+    which is what this returns: ``compared`` says whether any task in this
+    payload was graded more than once, and ``tasks_that_moved`` is ``None``
+    when none was -- never ``0``, for the same reason ``routing`` reports
+    empty maps rather than ``audio: 0`` on a run that never recorded a route.
+
+    Nothing here assumes the current pipeline's answer. The counts come out
+    of the payload, so a set of tasks that does hold repeats -- assembled by
+    something other than the merge step, or by a later summariser that reads
+    repeat runs together -- gets a real measurement out of this rather than a
+    constant, and the branch that says so is reached by the tests either way.
+
+    Two gradings differ when their ``pct`` differs; a grading with no numeric
+    ``pct`` (an errored task) has no score to compare, so a task needs two of
+    them before it counts as compared at all.
+    """
+    scores_by_task: dict[str, list[float]] = {}
+    gradings_by_task: dict[str, int] = {}
+
+    for task in task_dicts:
+        task_id = task.get("task_id")
+        if not isinstance(task_id, str) or not task_id:
+            continue
+        gradings_by_task[task_id] = gradings_by_task.get(task_id, 0) + 1
+        pct = task.get("pct")
+        if isinstance(pct, bool) or not isinstance(pct, (int, float)):
+            continue
+        scores_by_task.setdefault(task_id, []).append(float(pct))
+
+    gradings_per_task = max(gradings_by_task.values(), default=0)
+    comparable = [scores for scores in scores_by_task.values() if len(scores) > 1]
+
+    if not comparable:
+        return {
+            "compared": False,
+            "gradings_per_task": gradings_per_task,
+            "tasks_compared": 0,
+            "tasks_that_moved": None,
+            "max_spread_pp": None,
+        }
+
+    moved = 0
+    widest = 0.0
+    for scores in comparable:
+        spread = max(scores) - min(scores)
+        if spread > 0:
+            moved += 1
+        widest = max(widest, spread)
+
+    return {
+        "compared": True,
+        "gradings_per_task": gradings_per_task,
+        "tasks_compared": len(comparable),
+        "tasks_that_moved": moved,
+        "max_spread_pp": round(widest, 4),
+    }
+
+
 def _compute_summary(
     task_dicts: list[dict],
     *,
@@ -2023,6 +2102,10 @@ def _compute_summary(
         # a fixed compatibility shape, and this is the caveat on the number it
         # carries, not another field of it.
         "score_exclusions": _score_exclusion_stats(scored_tasks, avg_pct),
+        # The basis behind `openai_compat.inconsistent_count`, which is the
+        # constant 0 above and is read downstream as "the graders agreed".
+        # This says whether anything was compared to reach it.
+        "grader_agreement": _grader_agreement_stats(task_dicts),
         # Over every task, not just the scored ones. A task that could not fit
         # its renders may have left the average altogether, and that is the
         # case this is here to count -- see `_visual_budget_stats`.

--- a/batch-runner/tests/test_a_run_that_compared_nothing_does_not_report_agreement.py
+++ b/batch-runner/tests/test_a_run_that_compared_nothing_does_not_report_agreement.py
@@ -1,0 +1,331 @@
+"""The zero that means "nobody looked", published where "they agreed" is read.
+
+``summary.openai_compat.inconsistent_count`` is a required integer and it is
+the literal ``0`` in ``step8_grade.py``. All ninety-four committed payloads
+carry it. The dashboard turns it into ``inconsistent_grades`` and captions it
+*"Multiple graders scored the same task differently"*, rendering ``0`` and
+``0.0%``.
+
+There has never been a second grader. Each task is graded once, and
+``step9_merge_shards`` refuses shards that are not disjoint, so a payload
+cannot even hold one task twice. The number was not measured to be zero; there
+was nothing to measure.
+
+What makes that worth a test rather than a comment is the direction. This
+repository has already graded the same thirty answers three times at one
+fingerprint, and the three runs are committed. Pool them and **29 of the 30
+tasks scored differently**, the widest single task swinging 7.05 points -- and
+each of those three payloads reports ``inconsistent_count: 0`` about itself.
+So the published zero is not an unexamined guess that happens to be harmless.
+It is the reassuring answer to a question whose real answer is known, sitting
+in the field a reader would check to find out whether to trust the grader.
+
+The integer stays. Ninety-four payloads carry it, and both
+``core/grade_payload.py`` and ``scripts/aggregate-grades.mjs`` recognise a stub
+payload by ``inconsistent_count != 0``; moving it would invalidate the record
+to fix a caption. What this file pins is the basis published beside it --
+``summary.grader_agreement`` -- and above all that ``tasks_that_moved`` is
+``None`` and never ``0`` when nothing was compared.
+
+Nothing here calls a model, grades anything, or spends anything.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from step8_grade import _compute_summary, _grader_agreement_stats
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BATCH_RUNNER = Path(__file__).resolve().parents[1]
+GRADES_ROOT = REPO_ROOT / "data/grades"
+SCHEMA = BATCH_RUNNER / "schemas/grade.schema.json"
+
+#: The thirty-task cohort graded three times at one grader fingerprint, found
+#: by the corpus fingerprint its payloads carry rather than by path -- the
+#: three live in different directories and their filenames encode hashes.
+REPEAT_COHORT_FINGERPRINT = (
+    "82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b"
+)
+
+#: ...and at ONE grader source hash. A fourth payload of the same thirty tasks
+#: sits in ``_superseded`` at ``8513975c...``, and pooling it in would measure
+#: the distance between two graders rather than one grader's distance from
+#: itself. That is the comparison the repeat preregistration exists to keep
+#: apart, and it shows: adding it moves the widest swing from 7.05 to 79.29.
+GRADER_SOURCE_HASH = (
+    "c33d9d55703fbf5de5f988d427e34efd44d7a73306412caac88a753bad16ff4e"
+)
+
+# ── measured across those three runs, pinned ─────────────────────────
+REPEAT_RUNS = 3
+COHORT_TASKS = 30
+TASKS_THAT_MOVED = 29
+WIDEST_SWING_PP = 7.05
+
+
+def _task(task_id: str, pct: float | None) -> dict:
+    return {"task_id": task_id, "pct": pct, "items": []}
+
+
+# ── nothing was compared ─────────────────────────────────────────────
+
+
+def test_an_ordinary_run_says_it_compared_nothing() -> None:
+    """One grading per task is no basis for a disagreement count.
+
+    ``gradings_per_task: 1`` is the whole of it: there is no pair of verdicts
+    anywhere in such a payload, so the ``0`` beside it cannot be a finding
+    about whether verdicts agree.
+    """
+    stats = _grader_agreement_stats([_task("a", 50.0), _task("b", 60.0)])
+
+    assert stats["compared"] is False
+    assert stats["gradings_per_task"] == 1
+    assert stats["tasks_compared"] == 0
+
+
+def test_nothing_compared_reports_none_and_not_zero() -> None:
+    """The load-bearing line of this file.
+
+    A ``0`` here would say "we compared and found no disagreement" about a run
+    that compared nothing -- the same substitution the neighbouring
+    ``inconsistent_count`` already makes, and in the same reassuring
+    direction. Reproducing it in the field added to explain it would leave the
+    record no better off than before.
+    """
+    stats = _grader_agreement_stats([_task("a", 50.0)])
+
+    assert stats["tasks_that_moved"] is None
+    assert stats["max_spread_pp"] is None
+    assert stats["tasks_that_moved"] != 0  # None is not 0; that is the point
+
+
+def test_an_empty_run_has_not_compared_anything_either() -> None:
+    stats = _grader_agreement_stats([])
+
+    assert stats["compared"] is False
+    assert stats["gradings_per_task"] == 0
+    assert stats["tasks_that_moved"] is None
+
+
+# ── something was compared ───────────────────────────────────────────
+
+
+def test_two_gradings_of_one_task_are_actually_compared() -> None:
+    """The branch that is not reachable through today's pipeline, and is not
+    therefore hypothetical: it is what makes the ``False`` above a finding
+    about the pipeline rather than an assumption baked into the summariser.
+    """
+    stats = _grader_agreement_stats(
+        [_task("a", 50.0), _task("a", 52.5), _task("b", 60.0), _task("b", 60.0)]
+    )
+
+    assert stats["compared"] is True
+    assert stats["gradings_per_task"] == 2
+    assert stats["tasks_compared"] == 2
+    assert stats["tasks_that_moved"] == 1  # `b` was graded twice and held still
+    assert stats["max_spread_pp"] == pytest.approx(2.5)
+
+
+def test_a_task_that_held_still_is_a_measured_zero() -> None:
+    """Once two verdicts have been put side by side, ``0`` is a real answer.
+
+    This is the mirror of the ``None`` above and the reason it is not just
+    squeamishness: agreement that was actually observed is worth publishing,
+    and the two cases have to be told apart.
+    """
+    stats = _grader_agreement_stats([_task("a", 77.0), _task("a", 77.0)])
+
+    assert stats["compared"] is True
+    assert stats["tasks_that_moved"] == 0
+    assert stats["max_spread_pp"] == 0.0
+
+
+def test_the_spread_is_the_widest_gap_and_not_the_last_one() -> None:
+    stats = _grader_agreement_stats(
+        [_task("a", 10.0), _task("a", 90.0), _task("a", 50.0)]
+    )
+
+    assert stats["gradings_per_task"] == 3
+    assert stats["max_spread_pp"] == pytest.approx(80.0)
+
+
+def test_an_errored_grading_brings_no_score_to_compare() -> None:
+    """A task graded once and failed once was not graded twice.
+
+    Counting it as compared would put a task into ``tasks_compared`` on the
+    strength of a single verdict, and then report it as agreeing.
+    """
+    stats = _grader_agreement_stats([_task("a", 50.0), _task("a", None)])
+
+    assert stats["gradings_per_task"] == 2  # it was attempted twice
+    assert stats["tasks_compared"] == 0  # ...and scored once
+    assert stats["compared"] is False
+    assert stats["tasks_that_moved"] is None
+
+
+def test_a_task_without_an_id_cannot_be_matched_to_its_other_grading() -> None:
+    """Two gradings can only be paired by task id.
+
+    Pooling id-less rows under one bucket would invent comparisons between
+    different tasks, which reports movement that no grader produced.
+    """
+    stats = _grader_agreement_stats(
+        [{"pct": 10.0, "items": []}, {"task_id": "", "pct": 90.0, "items": []}]
+    )
+
+    assert stats["compared"] is False
+    assert stats["gradings_per_task"] == 0
+
+
+def test_a_boolean_pct_is_not_a_score() -> None:
+    """``True`` is an ``int`` in Python and would compare as ``1.0``."""
+    stats = _grader_agreement_stats([_task("a", True), _task("a", False)])  # type: ignore[arg-type]
+
+    assert stats["tasks_compared"] == 0
+    assert stats["tasks_that_moved"] is None
+
+
+# ── against the runs that measured it ────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def repeat_cohort() -> list[dict]:
+    """The same thirty answers, graded three times at one fingerprint."""
+    found: dict[str, dict] = {}
+    for path in sorted(GRADES_ROOT.rglob("*.json")):
+        if "_shards" in path.parts:
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if (
+            isinstance(payload, dict)
+            and payload.get("expected_ordered_task_ids_sha256")
+            == REPEAT_COHORT_FINGERPRINT
+            and payload.get("grader_source_hash") == GRADER_SOURCE_HASH
+            and payload.get("run_status") == "final"
+            and len(payload.get("tasks") or []) == COHORT_TASKS
+        ):
+            # Keyed by grading time so that one run found twice on disk is one
+            # run: three copies of a single grading agree perfectly and would
+            # report stability having compared nothing.
+            found[str(payload.get("graded_at"))] = payload
+    if len(found) < REPEAT_RUNS:
+        pytest.skip("the three repeat gradings are not in this checkout")
+    return [found[stamp] for stamp in sorted(found)]
+
+
+def test_each_repeat_run_publishes_a_zero_it_did_not_measure(
+    repeat_cohort: list[dict],
+) -> None:
+    """The three runs that prove the grader moves all report perfect agreement.
+
+    Not a reconstruction: these are the committed payloads, and this is the
+    number the dashboard reads out of each of them.
+    """
+    for payload in repeat_cohort:
+        assert payload["summary"]["openai_compat"]["inconsistent_count"] == 0
+
+        alone = _grader_agreement_stats(payload["tasks"])
+        assert alone["compared"] is False
+        assert alone["tasks_that_moved"] is None
+
+
+def test_the_three_runs_together_say_the_grader_moved(
+    repeat_cohort: list[dict],
+) -> None:
+    """29 of 30, and 7.05 points at the widest.
+
+    Pooling the three gradings is the comparison none of them could make
+    alone. Pinned rather than re-derived: this is the evidence that the zero
+    published beside it points the wrong way, and a checkout where it stopped
+    reproducing would be one where that claim quietly lost its basis.
+    """
+    pooled = [task for payload in repeat_cohort for task in payload["tasks"]]
+    stats = _grader_agreement_stats(pooled)
+
+    assert stats["compared"] is True
+    assert stats["gradings_per_task"] == REPEAT_RUNS
+    assert stats["tasks_compared"] == COHORT_TASKS
+    assert stats["tasks_that_moved"] == TASKS_THAT_MOVED
+    assert stats["max_spread_pp"] == pytest.approx(WIDEST_SWING_PP)
+
+    # Which is to say: the field that reads as "graders agreed" says 0 about
+    # runs in which all but one task disagreed with itself.
+    assert stats["tasks_that_moved"] > 0
+    for payload in repeat_cohort:
+        assert payload["summary"]["openai_compat"]["inconsistent_count"] == 0
+
+
+# ── what the run publishes ───────────────────────────────────────────
+
+
+def test_the_summary_carries_the_basis_beside_the_number(
+    ) -> None:
+    summary = _compute_summary([_task("a", 50.0)])
+
+    assert summary["openai_compat"]["inconsistent_count"] == 0
+    assert summary["grader_agreement"]["compared"] is False
+    assert summary["grader_agreement"]["tasks_that_moved"] is None
+    # Beside its siblings, which are also caveats on the headline rather than
+    # parts of the fixed compatibility shape.
+    assert {"grader_agreement", "score_exclusions", "routing"} <= set(summary)
+
+
+def test_the_number_it_explains_is_still_the_zero_everything_depends_on() -> None:
+    """Deliberately unchanged.
+
+    ``core/grade_payload.py`` and ``scripts/aggregate-grades.mjs`` both detect
+    a stub payload by ``inconsistent_count != 0``, and ninety-four committed
+    payloads carry the ``0``. Fixing the caption is not worth invalidating the
+    record, so the fix is the basis published beside it.
+    """
+    for tasks in ([], [_task("a", 50.0)], [_task("a", 50.0), _task("a", 90.0)]):
+        assert _compute_summary(tasks)["openai_compat"]["inconsistent_count"] == 0
+
+
+def test_a_grade_written_before_this_field_existed_still_validates() -> None:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    summary_schema = schema["properties"]["summary"]
+
+    assert "grader_agreement" in summary_schema["properties"]
+    assert "grader_agreement" not in summary_schema.get("required", [])
+
+
+def test_the_schema_warns_against_reading_the_zero_as_agreement() -> None:
+    """The required integer cannot be renamed, so it has to say what it is.
+
+    Same remedy ``perfect_count`` got when its name outlived its threshold:
+    the field stays, and its description carries the correction.
+    """
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    described = schema["properties"]["summary"]["properties"]["openai_compat"][
+        "properties"
+    ]["inconsistent_count"]["description"]
+
+    assert "grader_agreement" in described
+    assert "29 of the 30" in described
+
+
+def test_the_published_shape_is_what_the_schema_describes() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    agreement_schema = schema["properties"]["summary"]["properties"][
+        "grader_agreement"
+    ]
+
+    for stats in (
+        _grader_agreement_stats([]),
+        _grader_agreement_stats([_task("a", 50.0)]),
+        _grader_agreement_stats([_task("a", 50.0), _task("a", 52.5)]),
+    ):
+        jsonschema.validate(stats, agreement_schema)
+        assert set(agreement_schema["required"]) <= set(stats)


### PR DESCRIPTION
## The number

`summary.openai_compat.inconsistent_count` is a **required** integer in the grade schema. It is the literal `0` at `step8_grade.py:2020`, it is carried by **all 94 committed payloads**, and the dashboard renders it under the caption *"Multiple graders scored the same task differently"*. Until this PR it had **no schema description at all**.

No run in this repository has ever had two graders. Each task is graded once, and `step9_merge_shards.py:322-339` rejects duplicate task ids (line 899: *"shards are not disjoint"*), so a published payload cannot even hold one task twice. The zero was never measured — there was nothing to measure. It is the count for *"nothing was compared"* published in the field read as *"they all agreed"*.

## Why that is worth a PR and not a comment

The repository has already measured the thing this zero implies, and the answer is the opposite.

Three gradings of the same thirty answers, at **one** grader fingerprint, are committed under `data/grades/_diagnostic/82d14ac9…/` (parent, `_repeats/run-002`, `_repeats/run-003`; averages 82.87 / 83.07 / 83.25). Pool them:

| | |
|---|---|
| tasks that scored differently | **29 of 30** |
| widest single-task swing | **7.05 pp** |
| `inconsistent_count` each of the three publishes about itself | **0** |

So the published zero is not an unexamined guess that happens to be harmless. It is the *reassuring* answer to a question whose real answer is known, sitting in the field a reader would check to decide whether to trust the grader.

## What changes

**The integer does not.** `core/grade_payload.py:121` and `scripts/aggregate-grades.mjs:415` both recognise a stub payload by `inconsistent_count != 0`; moving it would invalidate the record to fix a caption. This is the same remedy `perfect_count` got in #386 — the field stays, and what it *claims* is corrected.

1. **`summary.grader_agreement`** (new) — states the basis. `compared` says whether any task in this payload was graded more than once; `tasks_that_moved` is **`None` when none was, never `0`** — the same discipline `routing` already follows in publishing empty maps rather than `audio: 0` on a run that never recorded a route.
2. The counts are read **off the task list**, not assumed. A set of tasks that *does* hold repeats gets a real measurement instead of a constant, so `compared: false` is a finding about the pipeline rather than an assumption baked into the summariser — and both branches are exercised by the tests.
3. **`inconsistent_count` gains a description** saying plainly that it is a compatibility placeholder, why there has never been anything to compare, and that `grader_agreement` holds the basis.

`grader_agreement` is **deliberately not in `summary.required`**, so every already-published grade still validates — same treatment as `score_exclusions`, `visual_budget` and `routing`.

## Verification

- **16 new tests**, all passing. The three repeat gradings are pinned by **both** corpus fingerprint and grader source hash: a fourth payload of the same thirty tasks sits in `_superseded/` at a *different* grader source (`8513975c…`), and pooling it would measure grader-vs-grader rather than one grader against itself — it moves the widest swing from 7.05 to **79.29**. That is exactly the separation `scripts/analyze_repeat_variation.py`'s preregistration exists to keep.
- **Six deliberate mutations** of the implementation, each caught: absence→measured zero (6 failures), one grading counts as compared (5), boolean `pct` as a score (1), id-less tasks share a bucket (1), spread is the last gap not the widest (2), every compared task moved (3). Pristine restores to 16/16.
- Full backend suite **7460 passed / 10 skipped / 45 deselected**. mypy unchanged (`core/` 174, `step8_grade.py` 45). Frontend `test:aggregate` 331 passed / 1 skipped.
- **No model calls, no spend.**

## Grader fingerprint

This edits `step8_grade.py` and `schemas/grade.schema.json`, so **the grader fingerprint moves**. Checked before branching and again before commit: **0 Grade Pipeline runs in flight.**

## Out of scope, on purpose

The dashboard-side caption (`GradeDetail.tsx`, `GradingAnalysisView.tsx`, `GradesSummary.tsx`, `tooltipTexts.ts`, `aggregate-grades.mjs`) is owned by a concurrent session and is untouched here. This PR makes the payload tell the truth; rendering it is a separate change.
