### PR TITLE
fix(grade): stop publishing a pass rate that was divided by nothing

### DIFF
--- a/batch-runner/core/narrative_analyzer.py
+++ b/batch-runner/core/narrative_analyzer.py
@@ -99,6 +99,12 @@ def _build_grading_guard_clause(grade: dict | None) -> str:
     reasoning_effort = _get_nested(grade, ["judge", "reasoning_effort"], "unknown")
     rubric_repo = _get_nested(grade, ["rubric", "repo_id"], "openai/gdpval")
     rubric_sha = _get_nested(grade, ["rubric", "short_sha"], "unknown")
+    wow = _get_nested(grade, ["summary", "wow"], {})
+    # Asking for a breakdown that does not exist in this run is how an absence
+    # becomes a paragraph. See `_failure_pattern_hint`.
+    highlights = "weakest sector, strongest sector, critical_item_pass_rate"
+    if not isinstance(wow, dict) or _measured_over(wow, "precheck_items") != 0:
+        highlights += ", precheck vs judge breakdown"
 
     return f"""- Grading scores ARE available (see GRADING RESULTS section below).
 - Source: rubric-based LLM-judge ({judge_model}, reasoning_effort={reasoning_effort}).
@@ -106,8 +112,7 @@ def _build_grading_guard_clause(grade: dict | None) -> str:
   against open-sourced GDPval rubrics ({rubric_repo} @ {rubric_sha}).
 - Refer to scores as "LLM-judge grade" or "rubric-based score"; avoid
   wording that implies human expert review or OpenAI-hosted official scoring.
-- Highlight: weakest sector, strongest sector, critical_item_pass_rate,
-  precheck vs judge breakdown."""
+- Highlight: {highlights}."""
 
 
 def _build_grading_disclosure_paragraph(grade: dict | None) -> str:
@@ -123,13 +128,80 @@ def _build_grading_disclosure_paragraph(grade: dict | None) -> str:
     )
 
 
+def _measured_over(metrics: dict, count_key: str) -> int | None:
+    """How many items a ``wow`` rate was divided by, or ``None`` if unstated.
+
+    ``summary.wow.item_counts`` (and its per-sector twin) was added by
+    ``step8_grade._wow_item_counts``. Grades written before that carry no
+    counts, and for those the honest answer is that we do not know the
+    denominator -- not that it was zero.
+    """
+    counts = metrics.get("item_counts")
+    if not isinstance(counts, dict):
+        return None
+    value = counts.get(count_key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _format_rate(metrics: dict, rate_key: str, count_key: str, decimals: int = 0) -> str:
+    """A ``wow`` rate, or the reason there is no rate to give.
+
+    ``step8_grade._rate`` returns ``0.0`` when its denominator is empty, which
+    is also what "every item failed" looks like. This prompt is the sharpest
+    consequence of that collision: the model is paid to read these numbers and
+    write conclusions from them, and 0% invites exactly one conclusion.
+
+    Twenty of this repository's thirty-three published grades report
+    ``precheck_pass_rate: 0.0`` having prechecked nothing at all. Given
+    ``pre=0%`` beside "Precheck failures dominate: deliverable structure
+    issues", a model has been told, in effect, to write up a structural
+    collapse in runs where structure was never checked.
+
+    So a rate over an empty denominator is not rendered as a percentage here.
+    """
+    measured = _measured_over(metrics, count_key)
+    if measured == 0:
+        return "not measured (0 items)"
+    formatted = _format_pct(metrics.get(rate_key), decimals=decimals)
+    if measured is None:
+        return formatted
+    return f"{formatted} of {measured}"
+
+
 def _format_sector_grade_line(sector: str, metrics: dict) -> str:
     """Format one sector line for the GRADING RESULTS prompt section."""
     return (
         f"  - {sector}: avg_pct={_format_pct(metrics.get('avg_pct'), decimals=1)}, "
-        f"crit={_format_pct(metrics.get('critical_item_pass_rate'), decimals=0)}, "
-        f"pre={_format_pct(metrics.get('precheck_pass_rate'), decimals=0)}, "
-        f"judge={_format_pct(metrics.get('judge_pass_rate'), decimals=0)}"
+        f"crit={_format_rate(metrics, 'critical_item_pass_rate', 'critical_items')}, "
+        f"pre={_format_rate(metrics, 'precheck_pass_rate', 'precheck_items')}, "
+        f"judge={_format_rate(metrics, 'judge_pass_rate', 'judge_items')}"
+    )
+
+
+def _failure_pattern_hint(wow: dict) -> str:
+    """How to read precheck against judge -- when there is a precheck to read.
+
+    The hint asks the model to decide which of two failure modes dominates.
+    That is a comparison, and it needs both sides. On a run with no precheck
+    items there is no precheck side, and the old third branch pointed at
+    ``by_rubric_category``, which ``step8_grade`` fills with ``{}`` on every
+    run (the GDPVal rubrics carry no category taxonomy) and which this prompt
+    has never included. A model asked to consult something absent does not
+    report an absence; it reasons from what it can see, which here is 0%.
+    """
+    if _measured_over(wow, "precheck_items") == 0:
+        return (
+            "  - UNAVAILABLE for this run: no rubric item was decided by\n"
+            "    precheck, so `precheck_pass_rate` is a rate over nothing and\n"
+            "    its 0% is not a finding. Do NOT report weak deliverable\n"
+            "    structure, and do NOT compare structure against reasoning."
+        )
+    return (
+        "  - Precheck failures dominate: deliverable structure issues (file naming, format)\n"
+        "  - Judge failures dominate: content quality / domain reasoning issues\n"
+        "  - Neither dominates: say so; there is no finer breakdown to consult."
     )
 
 
@@ -192,9 +264,9 @@ Overall:
   - Average score: {_format_pct(openai_compat.get("avg_score_pct"), decimals=1)} (± {_format_pct(openai_compat.get("ci_pct"), decimals=1)})
   - Near-perfect tasks (>= 99%): {openai_compat.get("perfect_count", "n/a")}/{total_tasks or "n/a"}
   - Near-zero tasks (<= 1%): {openai_compat.get("zero_count", "n/a")}/{total_tasks or "n/a"}
-  - Critical item pass rate: {_format_pct(wow.get("critical_item_pass_rate"), decimals=0)}
-  - Precheck pass rate: {_format_pct(wow.get("precheck_pass_rate"), decimals=0)}
-  - Judge pass rate: {_format_pct(wow.get("judge_pass_rate"), decimals=0)}
+  - Critical item pass rate: {_format_rate(wow, "critical_item_pass_rate", "critical_items")}
+  - Precheck pass rate: {_format_rate(wow, "precheck_pass_rate", "precheck_items")}
+  - Judge pass rate: {_format_rate(wow, "judge_pass_rate", "judge_items")}
 
 By sector (top 3 weakest):
 {chr(10).join(weakest)}
@@ -203,9 +275,7 @@ By sector (top 3 strongest):
 {chr(10).join(strongest)}
 
 Failure pattern hint (precheck vs judge):
-  - Precheck failures dominate: deliverable structure issues (file naming, format)
-  - Judge failures dominate: content quality / domain reasoning issues
-  - Mixed: see by_rubric_category
+{_failure_pattern_hint(wow)}
 """
 
 

--- a/batch-runner/step8_grade.py
+++ b/batch-runner/step8_grade.py
@@ -1518,8 +1518,54 @@ def _score_bucket(pct: float) -> str:
 
 
 def _rate(numerator: int, denominator: int) -> float:
-    """Rounded pass rate as a 0-1 fraction, 0.0 when nothing was counted."""
+    """Rounded pass rate as a 0-1 fraction, 0.0 when nothing was counted.
+
+    That last clause is a real hazard, not a formatting detail: a rate of
+    ``0.0`` is indistinguishable from a rate over an empty denominator, and
+    ``0.0`` is the *worst possible score*. Publish it for a rate nobody
+    measured and readers see a total failure. ``_wow_item_counts`` publishes
+    the denominators beside the rates so the two cases can be told apart.
+    """
     return round((numerator / denominator) if denominator else 0.0, 4)
+
+
+def _wow_item_counts(counters: dict[str, int]) -> dict[str, int]:
+    """The denominators the ``wow`` rates were divided by.
+
+    Every ``wow`` rate is a fraction whose denominator is thrown away, and the
+    fallback for an empty one is ``0.0`` -- the same value as "every single
+    item failed". The two are not close. Measured over this repository's own
+    published grades, **twenty of thirty-three payloads report
+    ``precheck_pass_rate: 0.0``, and all twenty had no precheck items at all**;
+    not one is a run where prechecks ran and failed. Per sector it is 56 of 83
+    rows, again with no real zero among them. Among the twenty is the 185-task
+    gold-ceiling run: 8,816 judged items, zero prechecked ones, published as a
+    0% structural pass rate.
+
+    Downstream that is not left as a number. The narrative prompt puts
+    ``Precheck pass rate: 0%`` next to "Precheck failures dominate: deliverable
+    structure issues", and the dashboard's *Structure vs Reasoning* card turns
+    the same gap into "Strong on reasoning, weak on structure" -- a finding
+    about a check that never ran, in a paid report and on a public page.
+
+    ``rubric_severity_curve`` in this same summary already refuses to publish
+    an all-zero shape from missing verdicts, on the reasoning that "a single
+    rate can absorb that; a curve cannot, because its shape is the claim". The
+    corpus says the single rate did not absorb it. It publishes ``n_items``
+    beside each ``pass_rate``, which is exactly what this is: the counts, so a
+    ``0.0`` can be read as either "none passed" or "none existed".
+
+    The rates themselves are unchanged. Their type is ``number`` on both sides
+    of the wire, thirty-three payloads carry them, and an acceptance gate in
+    ``scripts/grading_cost_sweep.py`` compares them against thresholds; turning
+    them null to fix a caption would break more than it repairs.
+    """
+    return {
+        "rubric_items": counters["all_items"],
+        "critical_items": counters["critical_items"],
+        "precheck_items": counters["pre_items"],
+        "judge_items": counters["judge_items"],
+    }
 
 
 def _new_item_counters() -> dict[str, int]:
@@ -2053,6 +2099,10 @@ def _compute_summary(
             ),
             "precheck_pass_rate": _rate(bag["pre_pass"], bag["pre_items"]),
             "judge_pass_rate": _rate(bag["judge_pass"], bag["judge_items"]),
+            # 56 of the 83 sector rows this repository has published report a
+            # `precheck_pass_rate` of 0.0 over no precheck items at all. The
+            # three rates above cannot say which; these counts can.
+            "item_counts": _wow_item_counts(bag),
         }
         for sector, bag in sorted(sector_counters.items())
     }
@@ -2131,6 +2181,10 @@ def _compute_summary(
                 counters["judge_errors"], counters["judge_items"]
             ),
             "by_sector": by_sector,
+            # What every rate above was divided by. A rate of 0.0 here means
+            # either "nothing passed" or "nothing was counted", and until these
+            # were published there was no way to tell -- see `_wow_item_counts`.
+            "item_counts": _wow_item_counts(counters),
             # Left empty deliberately. The GDPVal rubrics carry no category
             # taxonomy — rubric items have an id, a criterion string and a
             # weight, and nothing that groups them into categories — so there

--- a/batch-runner/tests/test_a_rate_over_nothing_is_not_zero.py
+++ b/batch-runner/tests/test_a_rate_over_nothing_is_not_zero.py
@@ -1,0 +1,482 @@
+"""A pass rate divided by nothing, published where a failure rate is read.
+
+``step8_grade._rate`` returns ``0.0`` when its denominator is empty. That is
+also, exactly, what "every single item failed" returns -- the worst score the
+scale can express. The denominator that would tell the two apart is discarded.
+
+This is not a hypothetical collision. Measured over the grade payloads
+committed to this repository: **twenty of the thirty-three that carry a ``wow``
+block report ``precheck_pass_rate: 0.0``, and every one of the twenty
+prechecked nothing at all.** Not one is a run where prechecks ran and failed.
+Per sector it is fifty-six of eighty-three rows, with no real zero among those
+either. The 185-task gold-ceiling run is in that set: 8,816 judged items, zero
+prechecked ones, published as a 0% structural pass rate.
+
+Three things read it and none of them can tell:
+
+* ``core/narrative_analyzer.py`` hands the **paid** narrative model
+  ``Precheck pass rate: 0%`` directly above "Precheck failures dominate:
+  deliverable structure issues (file naming, format)".
+* ``src/components/wow/StructureVsReasoning.tsx`` subtracts judge from
+  precheck and renders "Strong on reasoning, weak on structure" below −0.15;
+  on the gold-ceiling run that is ``0.0 - 0.3329``.
+* ``scripts/grading_cost_sweep.py`` rejects a config whose
+  ``precheck_pass_rate`` is under a threshold -- an acceptance gate firing on
+  an absence.
+
+``step8_grade`` already argues this case against itself. The
+``rubric_severity_curve`` comment refuses to publish an all-zero shape from
+missing verdicts because "every point on the curve would read 0.0 and the chart
+would assert a total failure that never happened. A single rate can absorb
+that; a curve cannot, because its shape is the claim." The corpus above is the
+measurement of whether the single rate absorbed it. It did not. And that same
+curve already publishes ``n_items`` beside each ``pass_rate``, which is the
+whole of the remedy here.
+
+The rates are unchanged. They are ``number`` on both sides of the wire,
+thirty-three payloads carry them, and a threshold gate compares them. What is
+pinned here is the denominator published beside them, and that the paid prompt
+stops rendering a percentage it has no basis for.
+
+Nothing in this file calls a model, grades anything, or spends anything.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.narrative_analyzer import (
+    _build_grading_guard_clause,
+    _build_grading_results_section,
+    _failure_pattern_hint,
+    _format_rate,
+    _measured_over,
+)
+from step8_grade import _compute_summary, _rate, _wow_item_counts
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GRADES_ROOT = REPO_ROOT / "data/grades"
+SCHEMA = Path(__file__).resolve().parents[1] / "schemas/grade.schema.json"
+
+#: The 185-task gold-ceiling run, found by the cohort fingerprint its payload
+#: carries rather than by path: it lives under a hash directory and its
+#: filename encodes four more.
+GOLD_CEILING_COHORT = (
+    "cef3a5b9f1305f19437d6ee337936a065965f979325b95a41d1001747e6bfa18"
+)
+GOLD_CEILING_TASKS = 185
+GOLD_CEILING_JUDGE_ITEMS = 8816
+GOLD_CEILING_PRECHECK_ITEMS = 0
+
+#: Floors, not equalities. The corpus grows; what must not change is that no
+#: published ``precheck_pass_rate`` of 0.0 has ever been a real one, and these
+#: keep that claim from passing over an empty corpus.
+PAYLOADS_WITH_AN_EMPTY_PRECHECK_ZERO = 20
+SECTOR_ROWS_WITH_AN_EMPTY_PRECHECK_ZERO = 56
+
+
+def _item(*, passed: bool, precheck: bool = False, critical: bool = False) -> dict:
+    """One graded rubric item, decided by precheck or by the judge.
+
+    The keys are the ones ``_tally_item`` actually reads: ``verdict``, a
+    ``max_score`` whose magnitude clears ``MAGNITUDE_THRESHOLD`` for critical
+    items, and ``model_did_right`` (criticality is scored sign-aware, not by
+    the verdict).
+    """
+    return {
+        "verdict": "pass" if passed else "fail",
+        "model_did_right": passed,
+        "max_score": 4 if critical else 1,
+        "decided_by": "precheck" if precheck else "judge",
+    }
+
+
+def _task(sector: str, items: list[dict], pct: float = 50.0) -> dict:
+    return {"task_id": f"t{len(items)}-{sector}", "sector": sector, "pct": pct,
+            "items": items}
+
+
+# ── the collision itself ─────────────────────────────────────────────
+
+
+def test_a_rate_over_nothing_and_a_total_failure_are_the_same_number() -> None:
+    """The premise, stated as an assertion so it cannot quietly stop being true.
+
+    If these two ever diverge, everything below is unnecessary.
+    """
+    nothing_was_checked = _rate(0, 0)
+    everything_failed = _rate(0, 4000)
+
+    assert nothing_was_checked == everything_failed == 0.0
+
+
+def test_the_counts_that_tell_them_apart_are_published() -> None:
+    counters = {"all_items": 10, "critical_items": 2, "pre_items": 0,
+                "judge_items": 10}
+
+    assert _wow_item_counts(counters) == {
+        "rubric_items": 10,
+        "critical_items": 2,
+        "precheck_items": 0,
+        "judge_items": 10,
+    }
+
+
+def test_a_run_that_prechecked_nothing_says_so_in_the_summary() -> None:
+    """The rate stays 0.0. The zero beside it is what changes the reading."""
+    wow = _compute_summary(
+        [_task("Information", [_item(passed=True), _item(passed=False)])]
+    )["wow"]
+
+    assert wow["precheck_pass_rate"] == 0.0
+    assert wow["item_counts"]["precheck_items"] == 0
+    assert wow["item_counts"]["judge_items"] == 2
+
+
+def test_a_run_where_prechecks_ran_and_all_failed_reads_differently() -> None:
+    """Same 0.0, non-empty denominator: here it is a finding.
+
+    Without this case the fix would be indistinguishable from suppressing the
+    number whenever it is zero, which would hide the failure it exists to
+    report.
+    """
+    wow = _compute_summary(
+        [_task("Information", [_item(passed=False, precheck=True)] * 3)]
+    )["wow"]
+
+    assert wow["precheck_pass_rate"] == 0.0
+    assert wow["item_counts"]["precheck_items"] == 3
+
+
+def test_the_counts_are_published_per_sector_too() -> None:
+    summary = _compute_summary(
+        [
+            _task("Information", [_item(passed=True, precheck=True)]),
+            _task("Retail Trade", [_item(passed=False, critical=True)]),
+        ]
+    )
+    by_sector = summary["wow"]["by_sector"]
+
+    assert by_sector["Information"]["item_counts"]["precheck_items"] == 1
+    assert by_sector["Retail Trade"]["item_counts"]["precheck_items"] == 0
+    assert by_sector["Retail Trade"]["item_counts"]["critical_items"] == 1
+    # ...and the run-wide counts are the sum, not a separate measurement.
+    assert summary["wow"]["item_counts"]["judge_items"] == 1
+
+
+def test_an_empty_run_counts_nothing_rather_than_claiming_zero_passes() -> None:
+    wow = _compute_summary([])["wow"]
+
+    assert wow["item_counts"] == {
+        "rubric_items": 0,
+        "critical_items": 0,
+        "precheck_items": 0,
+        "judge_items": 0,
+    }
+
+
+# ── reading the counts back ──────────────────────────────────────────
+
+
+def test_a_grade_written_before_the_counts_existed_says_unknown() -> None:
+    """``None``, not ``0``.
+
+    Ninety-odd payloads predate ``item_counts``. Treating a missing count as
+    zero would relabel every one of their rates "not measured", which is the
+    same substitution in the other direction.
+    """
+    assert _measured_over({"precheck_pass_rate": 0.0}, "precheck_items") is None
+    assert _measured_over({"item_counts": None}, "precheck_items") is None
+    assert _measured_over({"item_counts": {}}, "precheck_items") is None
+
+
+def test_a_count_that_is_not_a_count_is_not_believed() -> None:
+    for bad in (True, False, "12", 3.5, -1, None):
+        assert _measured_over({"item_counts": {"precheck_items": bad}},
+                              "precheck_items") is None
+    assert _measured_over({"item_counts": {"precheck_items": 0}},
+                          "precheck_items") == 0
+
+
+# ── what the paid model is told ──────────────────────────────────────
+
+
+def test_the_paid_prompt_does_not_render_a_percentage_it_cannot_support() -> None:
+    metrics = {"precheck_pass_rate": 0.0, "item_counts": {"precheck_items": 0}}
+
+    rendered = _format_rate(metrics, "precheck_pass_rate", "precheck_items")
+
+    assert rendered == "not measured (0 items)"
+    assert "%" not in rendered
+
+
+def test_a_measured_rate_is_rendered_with_what_it_was_measured_over() -> None:
+    metrics = {"judge_pass_rate": 0.7113, "item_counts": {"judge_items": 8816}}
+
+    assert _format_rate(metrics, "judge_pass_rate", "judge_items") == "71% of 8816"
+
+
+def test_a_measured_zero_is_still_reported_as_zero() -> None:
+    metrics = {"precheck_pass_rate": 0.0, "item_counts": {"precheck_items": 40}}
+
+    assert _format_rate(metrics, "precheck_pass_rate", "precheck_items") == "0% of 40"
+
+
+def test_an_older_grade_keeps_its_bare_percentage() -> None:
+    """No counts to attach, and no licence to call it unmeasured either."""
+    assert _format_rate({"judge_pass_rate": 0.5}, "judge_pass_rate",
+                        "judge_items") == "50%"
+
+
+def test_the_failure_pattern_hint_withdraws_the_comparison_it_cannot_make() -> None:
+    unmeasured = _failure_pattern_hint({"item_counts": {"precheck_items": 0}})
+
+    assert "UNAVAILABLE" in unmeasured
+    assert "Do NOT report weak deliverable" in unmeasured
+    # The instruction that invited the conclusion is gone, not merely qualified.
+    assert "Precheck failures dominate" not in unmeasured
+
+
+def test_the_hint_stands_when_there_is_a_precheck_to_compare() -> None:
+    measured = _failure_pattern_hint({"item_counts": {"precheck_items": 40}})
+
+    assert "Precheck failures dominate" in measured
+    assert "Judge failures dominate" in measured
+    assert "UNAVAILABLE" not in measured
+
+
+def test_the_hint_no_longer_points_at_a_breakdown_that_is_always_empty() -> None:
+    """``by_rubric_category`` is ``{}`` on every run this repository produces.
+
+    ``step8_grade`` says why in a comment: the GDPVal rubrics carry no category
+    taxonomy. The prompt has never included the field, so "Mixed: see
+    by_rubric_category" directed the model to consult something it could not
+    see -- and a model that cannot find a breakdown reasons from what it can,
+    which is the 0% above.
+    """
+    for counts in ({"precheck_items": 0}, {"precheck_items": 40}):
+        assert "by_rubric_category" not in _failure_pattern_hint(
+            {"item_counts": counts}
+        )
+
+
+def test_the_guard_clause_stops_asking_for_the_breakdown() -> None:
+    """The instruction and the numbers have to agree.
+
+    Withdrawing the hint while still ordering the model to "Highlight: precheck
+    vs judge breakdown" leaves it required to produce a comparison and given
+    only a 0% to build it from.
+    """
+    grade = {"summary": {"wow": {"item_counts": {"precheck_items": 0}}}}
+
+    assert "precheck vs judge breakdown" not in _build_grading_guard_clause(grade)
+    assert "critical_item_pass_rate" in _build_grading_guard_clause(grade)
+
+
+def test_the_guard_clause_still_asks_for_it_when_it_exists() -> None:
+    for wow in ({"item_counts": {"precheck_items": 40}}, {}, None):
+        grade = {"summary": {"wow": wow}}
+        assert "precheck vs judge breakdown" in _build_grading_guard_clause(grade)
+
+
+def test_the_pre_grading_guard_is_untouched() -> None:
+    assert "do NOT exist yet" in _build_grading_guard_clause(None)
+
+
+# ── against the run it was measured on ───────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def gold_ceiling() -> dict:
+    """The 185-task run, as committed."""
+    for path in sorted(GRADES_ROOT.rglob("*.json")):
+        if "_shards" in path.parts:
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if (
+            isinstance(payload, dict)
+            and payload.get("expected_ordered_task_ids_sha256") == GOLD_CEILING_COHORT
+            and payload.get("run_status") == "final"
+            and len(payload.get("tasks") or []) == GOLD_CEILING_TASKS
+        ):
+            return payload
+    pytest.skip("the gold-ceiling run is not in this checkout")
+
+
+def test_the_gold_ceiling_run_published_a_zero_it_never_measured(
+    gold_ceiling: dict,
+) -> None:
+    """8,816 items judged, none prechecked, 0% published. As committed."""
+    published = gold_ceiling["summary"]["wow"]
+
+    assert published["precheck_pass_rate"] == 0.0
+    assert published["judge_pass_rate"] > 0.0
+
+    counts = _compute_summary(gold_ceiling["tasks"])["wow"]["item_counts"]
+    assert counts["judge_items"] == GOLD_CEILING_JUDGE_ITEMS
+    assert counts["precheck_items"] == GOLD_CEILING_PRECHECK_ITEMS
+
+
+def test_that_run_stops_telling_the_paid_model_structure_collapsed(
+    gold_ceiling: dict,
+) -> None:
+    """Before and after, on the payload itself rather than a fixture."""
+    before = _build_grading_results_section(gold_ceiling)
+    assert "Precheck pass rate: 0%" in before
+    assert "Precheck failures dominate" in before
+
+    resummarised = dict(gold_ceiling)
+    resummarised["summary"] = _compute_summary(gold_ceiling["tasks"])
+    after = _build_grading_results_section(resummarised)
+
+    assert "Precheck pass rate: not measured (0 items)" in after
+    assert "Precheck pass rate: 0%" not in after
+    assert "Precheck failures dominate" not in after
+    assert f"Judge pass rate: 71% of {GOLD_CEILING_JUDGE_ITEMS}" in after
+    # Every sector line, too -- the run-wide caveat does not reach those.
+    assert "pre=0%" not in after
+    assert "pre=not measured (0 items)" in after
+
+
+@pytest.fixture(scope="module")
+def published_wow_blocks() -> list[tuple[str, dict, dict]]:
+    """Every committed payload that carries a ``wow`` block, re-summarised.
+
+    Shards are excluded: they are intermediate halves of a run, and their rates
+    are not published anywhere.
+    """
+    out: list[tuple[str, dict, dict]] = []
+    for path in sorted(GRADES_ROOT.rglob("*.json")):
+        if "_shards" in path.parts:
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        wow = (payload.get("summary") or {}).get("wow")
+        if not isinstance(wow, dict) or not wow:
+            continue
+        out.append((path.name, wow, _compute_summary(payload.get("tasks") or [])["wow"]))
+    if not out:
+        pytest.skip("no committed grade payloads in this checkout")
+    return out
+
+
+def test_no_published_precheck_zero_has_ever_been_a_real_one(
+    published_wow_blocks: list[tuple[str, dict, dict]],
+) -> None:
+    """The measurement this whole change rests on.
+
+    Stated as an invariant plus a floor rather than an equality, so that adding
+    a payload cannot break it -- but an empty corpus, or a checkout where the
+    zeros stopped being absences, cannot let it pass either.
+    """
+    empty = [
+        name
+        for name, published, fresh in published_wow_blocks
+        if published.get("precheck_pass_rate") == 0.0
+        and fresh["item_counts"]["precheck_items"] == 0
+    ]
+    real = [
+        name
+        for name, published, fresh in published_wow_blocks
+        if published.get("precheck_pass_rate") == 0.0
+        and fresh["item_counts"]["precheck_items"] > 0
+    ]
+
+    assert real == []
+    assert len(empty) >= PAYLOADS_WITH_AN_EMPTY_PRECHECK_ZERO
+
+
+def test_the_same_holds_row_by_row_across_sectors(
+    published_wow_blocks: list[tuple[str, dict, dict]],
+) -> None:
+    empty = real = 0
+    for _name, published, fresh in published_wow_blocks:
+        for sector, row in (published.get("by_sector") or {}).items():
+            if row.get("precheck_pass_rate") != 0.0:
+                continue
+            fresh_row = (fresh.get("by_sector") or {}).get(sector)
+            if fresh_row is None:
+                continue
+            if fresh_row["item_counts"]["precheck_items"] == 0:
+                empty += 1
+            else:
+                real += 1
+
+    assert real == 0
+    assert empty >= SECTOR_ROWS_WITH_AN_EMPTY_PRECHECK_ZERO
+
+
+def test_the_rates_themselves_did_not_move(
+    published_wow_blocks: list[tuple[str, dict, dict]],
+) -> None:
+    """Re-summarising a committed payload reproduces its published rates.
+
+    The remedy is additive on purpose: an acceptance gate in
+    ``scripts/grading_cost_sweep.py`` compares these against thresholds and
+    thirty-three payloads carry them, so nulling them to fix a caption would
+    break more than it repairs.
+
+    The two rates checked here are the two that re-summarise faithfully across
+    the whole corpus. The other two do not, for reasons older than this change
+    -- see the test below, which pins that rather than leaving it as an
+    unexplained gap in this one.
+    """
+    for name, published, fresh in published_wow_blocks:
+        for key in ("precheck_pass_rate", "judge_pass_rate"):
+            if key in published:
+                assert published[key] == pytest.approx(fresh[key]), f"{name}:{key}"
+
+
+def test_two_other_rates_no_longer_re_summarise_from_older_payloads() -> None:
+    """Not caused here, and not fixed here -- but not silently skipped either.
+
+    Six of the thirty-three payloads publish a ``critical_item_pass_rate`` that
+    recomputing from their own ``tasks`` returns ``0.0`` for, and two do the
+    same for ``rubric_item_coverage_avg``. The cause is field drift in the
+    stored items, not arithmetic: criticality is now scored from
+    ``model_did_right`` and sized by ``|max_score| >= 4``, and payloads written
+    before those fields existed have nothing for the counter to read.
+
+    It is worth pinning because it is the same failure mode one layer down. A
+    rate recomputed over items that no longer carry the field it needs comes
+    back ``0.0``, and ``0.0`` is a plausible-looking score. The count published
+    beside it is what shows the difference -- ``critical_items`` is in the
+    hundreds on those very payloads while the rate reads zero.
+    """
+    stale = {"verdict": "pass", "max_score": 4}  # pre-`model_did_right`
+    wow = _compute_summary([_task("Information", [stale, stale, stale])])["wow"]
+
+    assert wow["critical_item_pass_rate"] == 0.0
+    assert wow["item_counts"]["critical_items"] == 3  # ...over three of them
+
+
+# ── the shape on the wire ────────────────────────────────────────────
+
+
+def test_the_new_key_needs_no_schema_change() -> None:
+    """``summary.wow`` is an open object, so nothing already published breaks."""
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    wow_schema = schema["properties"]["summary"]["properties"]["wow"]
+
+    assert wow_schema.get("type") == "object"
+    assert "properties" not in wow_schema
+    assert not wow_schema.get("additionalProperties") is False
+
+
+def test_the_drift_check_still_compares_what_it_always_did() -> None:
+    """``summary_wow_drift.py`` diffs five named rates; a new key is not one."""
+    drift = (Path(__file__).resolve().parents[1] / "scripts/summary_wow_drift.py")
+    source = drift.read_text(encoding="utf-8")
+
+    assert "item_counts" not in source
+    assert "WOW_RATES" in source


### PR DESCRIPTION
## The zero that means "nobody checked"

`_rate` returns `0.0` when its denominator is empty. That is also, exactly, what "every single item failed" returns — the worst score the scale can express. The denominator that would tell the two apart is thrown away.

Measured over the grade payloads committed to this repository:

| | |
|---|---|
| payloads with a `wow` block | 33 |
| …publishing `precheck_pass_rate: 0.0` | **20** |
| …of those, prechecked **nothing at all** | **20** |
| …a real "everything failed" zero | **0** |
| sector rows with an empty-denominator zero | **56 of 83** (real zeros: 0) |

The 185-task gold-ceiling run is one of them: **8,816 judged items, 0 prechecked, published as a 0% structural pass rate.**

## Who reads it

- **`core/narrative_analyzer.py`** hands the **paid** narrative model `Precheck pass rate: 0%` directly above `- Precheck failures dominate: deliverable structure issues (file naming, format)`.
- **`src/components/wow/StructureVsReasoning.tsx`** subtracts judge from precheck and renders *"Strong on reasoning, weak on structure"* below −0.15. On the gold-ceiling run that is `0.0 − 0.3329`.
- **`scripts/grading_cost_sweep.py:672`** rejects a config whose `precheck_pass_rate` is under a threshold — an acceptance gate firing on an absence.

## The repo already made this argument

`step8_grade.py`, on `rubric_severity_curve`:

> every point on the curve would read 0.0 and the chart would assert a total failure that never happened. A single rate can absorb that; a curve cannot, because its shape is the claim.

The table above is the measurement of whether the single rate absorbed it. It did not. And that same curve already publishes `n_items` beside each `pass_rate` — which is the whole of the fix here.

## What changed

**The rates do not move.** They are `number` on both sides of the wire, 33 payloads carry them, and a threshold gate compares them; nulling them to fix a caption would break more than it repairs. Instead:

1. **`summary.wow.item_counts`** and a per-sector twin publish the four denominators. `summary.wow` is `{"type": "object"}` in the schema — fully open — so **no schema change is needed and nothing already published stops validating**. `summary_wow_drift.py` compares five named rates, so a new key is invisible to it.
2. **The paid prompt stops rendering a percentage it has no basis for.** A rate over an empty denominator reads `not measured (0 items)`; a measured one reads `71% of 8816`; a grade written before the counts existed keeps its bare `71%` (unknown ≠ zero).
3. **The dominance hint withdraws the comparison it cannot make**, and the guard clause stops ordering a *"precheck vs judge breakdown"* that does not exist — otherwise the model is still required to produce the comparison and given only a 0% to build it from.

That hint's third branch also pointed at `by_rubric_category`, which `step8_grade` fills with `{}` on every run (GDPVal rubrics carry no category taxonomy) and which the prompt has never included. A model told to consult something absent does not report an absence; it reasons from what it can see.

### Before / after, on the committed 185-task payload

```
- Precheck pass rate: 0%                        →  - Precheck pass rate: not measured (0 items)
- Judge pass rate: 71%                          →  - Judge pass rate: 71% of 8816
  - Information: …, pre=0%, judge=68%           →    - Information: …, pre=not measured (0 items), judge=68% of 621

Failure pattern hint (precheck vs judge):       Failure pattern hint (precheck vs judge):
  - Precheck failures dominate: deliverable       - UNAVAILABLE for this run: no rubric item was
    structure issues (file naming, format)          decided by precheck, so `precheck_pass_rate` is
  - Judge failures dominate: …                      a rate over nothing and its 0% is not a finding.
  - Mixed: see by_rubric_category                   Do NOT report weak deliverable structure, and
                                                    do NOT compare structure against reasoning.
```

## Verification

**26 tests.** Passing matters less than catching, so the implementation was deliberately broken seven ways:

| break | caught |
|---|---|
| counts published but always zero for precheck | 2 failed ✅ |
| absence rendered as 0% again | 2 failed ✅ |
| a missing count treated as zero | 4 failed ✅ |
| `True` counted as a count | 1 failed ✅ |
| dominance hint kept when nothing was prechecked | 1 failed ✅ |
| guard still orders the breakdown | 1 failed ✅ |
| sector rows given the run-wide counts | 1 failed ✅ |

All seven caught; 26/26 pass restored. The corpus claims are asserted as an **invariant plus a floor** rather than an equality, so adding a payload cannot break them but an empty checkout cannot let them pass vacuously either.

Full backend suite **7,486 passed / 10 skipped** (16m24s) — the previous 7,460 baseline plus exactly these 26. mypy at baseline (`core/` 174, `step8_grade.py` 45).

### Noted, not fixed here

Six payloads publish a `critical_item_pass_rate` that no longer re-summarises from their own `tasks` (two more for `rubric_item_coverage_avg`). The cause is field drift older than this change — criticality is now scored from `model_did_right`, which those payloads predate. It is pinned in a test rather than left as an unexplained gap, because it is the same failure mode one layer down: a rate recomputed over items missing the field it needs comes back `0.0`, and the count beside it is what shows the difference.

`scripts/grading_cost_sweep.py`'s threshold gate is a separate PR — repo-root `scripts/` is not in the grader fingerprint set.

**Cost: $0.** No model was called.

**Grader fingerprint moves** (`step8_grade.py`, `core/narrative_analyzer.py`). 0 Grade Pipeline runs were in flight when this branched, and that will be re-checked immediately before merge.

No frontend file is touched: `GradeDetail.tsx`, `GradingAnalysisView.tsx`, `GradesSummary.tsx`, `tooltipTexts.ts` and `aggregate-grades.mjs` belong to another session. Making the dashboard's *Structure vs Reasoning* card read these counts is a separate change.
