### PR TITLE
fix(sweep): stop rejecting a config on an acceptance check that never ran

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -26,11 +26,13 @@ on:
   pull_request:
     paths:
       - "batch-runner/**"
+      - "scripts/**"
       - ".github/workflows/backend-tests.yml"
   push:
     branches: [main]
     paths:
       - "batch-runner/**"
+      - "scripts/**"
       - ".github/workflows/backend-tests.yml"
   workflow_dispatch:
     inputs:
@@ -171,5 +173,12 @@ jobs:
       # An empty collection exits 5 and a missing path exits 4, so this step
       # cannot pass by quietly finding nothing -- which is the exact way the
       # directory went unnoticed in the first place.
+      #
+      # `scripts/**` is in the trigger filter above for this step's sake. It
+      # was not at first, so a pull request touching only repo-root `scripts/`
+      # started no run at all and this step never executed -- the directory was
+      # wired to a job that nothing woke up. Measured on #392, which changed
+      # `scripts/grading_cost_sweep.py` and added twenty-five tests here: the
+      # only workflow that ran was Aggregate Tests & Deploy.
       - name: Run repo-root script tests
         run: python -m pytest scripts/__tests__ -m "not integration" --tb=short -q -rs

--- a/batch-runner/tests/test_a_test_file_nobody_runs_is_not_a_test.py
+++ b/batch-runner/tests/test_a_test_file_nobody_runs_is_not_a_test.py
@@ -25,6 +25,7 @@ import shlex
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github/workflows/backend-tests.yml"
@@ -128,3 +129,54 @@ def test_the_orphaned_directory_that_prompted_this_is_actually_wired():
         "the repo-root script tests are unwired again; they resolve fixtures "
         "through parents[2] and must be invoked from the repository root"
     )
+
+
+@pytest.mark.parametrize("root", COVERED_ROOTS)
+def test_a_change_under_each_covered_root_actually_starts_this_workflow(root: str):
+    """A step that exists but never fires is still a step nobody runs.
+
+    Wiring the invocation fixed half of it. The trigger did not follow: the
+    path filter listed only `batch-runner/**`, so a pull request touching
+    just repo-root `scripts/` started no run, and the step above never
+    executed on the change it was added to cover.
+
+    Measured, not inferred -- #392 changed `scripts/grading_cost_sweep.py` and
+    added twenty-five tests under `scripts/__tests__/`, and the only workflow
+    that ran on it was Aggregate Tests & Deploy. The suite was green and
+    nothing had checked it.
+    """
+    triggers = _trigger_block()
+
+    for event in ("pull_request", "push"):
+        patterns = triggers[event]["paths"]
+        assert any(_pattern_covers(pattern, root) for pattern in patterns), (
+            f"a change under {root}/ starts no {event} run of "
+            f"{WORKFLOW.name}, so the pytest step that covers it never "
+            f"executes. Filter is: {patterns}"
+        )
+
+
+def _trigger_block() -> dict:
+    """The workflow's `on:` mapping.
+
+    Keyed by `True`, not by `"on"` -- PyYAML follows YAML 1.1, where a bare
+    `on` is a boolean. Reading `["on"]` here would raise `KeyError` rather
+    than check anything, so both spellings are accepted.
+    """
+    document = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    triggers = document.get("on", document.get(True))
+    assert isinstance(triggers, dict), f"no trigger block in {WORKFLOW.name}"
+    return triggers
+
+
+def _pattern_covers(pattern: str, root: str) -> bool:
+    """Whether a workflow path filter would match a file under `root`.
+
+    Only the `dir/**` and exact-path forms this workflow uses are understood;
+    anything cleverer should be checked deliberately rather than guessed at.
+    """
+    if pattern.endswith("/**"):
+        return (root + "/").startswith(pattern[:-2])
+    return pattern == root
+
+

--- a/scripts/__tests__/test_a_gate_that_rejects_on_an_absence.py
+++ b/scripts/__tests__/test_a_gate_that_rejects_on_an_absence.py
@@ -1,0 +1,536 @@
+"""An acceptance gate that eliminates a config on a check that never ran.
+
+``select_pareto_winner`` compares four measurements against thresholds. Every
+one of the four reaches it as ``0.0`` when it was never measured, because
+``step8_grade._rate`` divides by an empty denominator and publishes the
+quotient. ``0.0`` is also the worst real value on each scale. The gate cannot
+tell the two apart, so it rejects both alike -- and then reports only "no
+variant satisfied all acceptance thresholds", which reads as a verdict on the
+graders whether or not anything was ever measured.
+
+This is live, not hypothetical. The committed plan sets
+``precheck_pass_rate_min: 0.7``; the grade payloads in this repository
+precheck **nothing** on twenty of the thirty-three runs that carry a ``wow``
+block, including the 185-task gold-ceiling run (8,816 judged items, zero
+prechecked, published as 0%). A variant that is perfect on every criterion
+that actually ran is therefore eliminated by a criterion that did not.
+
+Three separate absences fed the same gate:
+
+* ``extract_metrics`` substituted ``0.0`` for a rate missing from the grade.
+* A rate present but divided by zero items arrived as a real-looking ``0.0``.
+* The dry-run and crash stubs wrote ``0.0`` for runs that never graded
+  anything, and those rows were then printed in RESULTS.md as measurements.
+
+What is pinned here is that an absence no longer rejects, that a *measured*
+zero still does, and that either way the reason is written down.
+
+Nothing in this file calls a model, grades anything, or spends anything.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import grading_cost_sweep as sweep  # noqa: E402
+
+PLAN_PATH = REPO_ROOT / "tasks" / "0523_saturday" / "grading_cost_sweep_plan.yaml"
+GRADES_ROOT = REPO_ROOT / "data" / "grades"
+
+#: The 185-task gold-ceiling run, located by the cohort fingerprint in its
+#: payload rather than by path.
+GOLD_CEILING_COHORT = (
+    "cef3a5b9f1305f19437d6ee337936a065965f979325b95a41d1001747e6bfa18"
+)
+
+
+@pytest.fixture
+def plan() -> sweep.Plan:
+    return sweep.load_plan(PLAN_PATH)
+
+
+@pytest.fixture
+def acceptance(plan: sweep.Plan) -> dict:
+    """The thresholds as committed, not a fixture of convenience."""
+    return plan.acceptance
+
+
+def _metrics(**over) -> dict:
+    """A variant that clears every threshold, before `over` is applied."""
+    m = {
+        "name": "candidate",
+        "phase": "B",
+        "avg_score_pct": 77.83,
+        "critical_item_pass_rate": 1.0,
+        "judge_error_rate": 0.0,
+        "precheck_pass_rate": 0.85,
+        "item_counts": {
+            "rubric_items": 100,
+            "critical_items": 20,
+            "precheck_items": 40,
+            "judge_items": 60,
+        },
+        "judge_call_count": 12,
+        "judge_total_latency_sec": 800.0,
+        "smoke_cost_usd": 0.85,
+        "full_run_cost_usd": 62.0,
+    }
+    m.update(over)
+    return m
+
+
+def _verdicts(m: dict, acceptance: dict) -> dict[str, str]:
+    return {v.criterion: v.verdict for v in sweep.evaluate_acceptance(m, acceptance)}
+
+
+def _details(m: dict, acceptance: dict) -> dict[str, str]:
+    return {v.criterion: v.detail for v in sweep.evaluate_acceptance(m, acceptance)}
+
+
+# ── the defect, stated against the committed plan ────────────────────
+
+
+def test_the_threshold_that_fires_on_an_absence_is_really_committed(
+    acceptance: dict,
+) -> None:
+    """If this is ever relaxed to 0, the rest of this file is unnecessary.
+
+    ``precheck_pass_rate_min`` is the criterion the corpus never measures, so
+    it is the one that turns an absence into an elimination in practice.
+    """
+    assert acceptance["precheck_pass_rate_min"] > 0.0
+    assert acceptance["critical_item_pass_rate_min"] > 0.0
+
+
+def test_a_variant_perfect_on_everything_measured_is_no_longer_eliminated(
+    acceptance: dict,
+) -> None:
+    """The defect itself.
+
+    Critical pass 1.00, judge errors 0%, score exactly at baseline -- and
+    prechecks that never ran. Before this change the last of those eliminated
+    it, and the report attributed the elimination to "acceptance thresholds".
+    """
+    m = _metrics(
+        precheck_pass_rate=None,
+        item_counts={"precheck_items": 0, "judge_items": 8816},
+    )
+
+    winner = sweep.select_pareto_winner({"results": {"candidate": m}}, acceptance)
+
+    assert winner is not None
+    assert winner.name == "candidate"
+
+
+def test_but_it_is_not_recorded_as_having_passed_that_check(
+    acceptance: dict,
+) -> None:
+    """Not rejecting is not the same as verifying.
+
+    The whole risk of loosening the gate is that a config gets promoted as
+    though every threshold had been applied to it. The winner has to carry
+    which ones were not.
+    """
+    m = _metrics(
+        precheck_pass_rate=None,
+        item_counts={"precheck_items": 0, "judge_items": 8816},
+    )
+
+    winner = sweep.select_pareto_winner({"results": {"candidate": m}}, acceptance)
+
+    assert winner is not None
+    assert winner.unmeasured == ["precheck_pass_rate"]
+    assert "NOT VERIFIED" in winner.rationale
+    assert "precheck_pass_rate" in winner.rationale
+    assert _verdicts(m, acceptance)["precheck_pass_rate"] == sweep.UNMEASURED
+
+
+def test_a_measured_zero_is_still_a_rejection(acceptance: dict) -> None:
+    """The negative control, and the point of the whole exercise.
+
+    Forty items prechecked, every one failed. Same ``0.0`` on the wire as the
+    case above. If this stopped rejecting, the "fix" would just be *ignoring*
+    the precheck criterion, which is a worse bug than the one being fixed.
+    """
+    m = _metrics(
+        precheck_pass_rate=0.0,
+        item_counts={"precheck_items": 40, "judge_items": 60},
+    )
+
+    assert sweep.select_pareto_winner({"results": {"c": m}}, acceptance) is None
+    assert _verdicts(m, acceptance)["precheck_pass_rate"] == sweep.FAIL
+    assert "0.0 is below the limit" in _details(m, acceptance)["precheck_pass_rate"]
+
+
+@pytest.mark.parametrize(
+    "over, criterion",
+    [
+        ({"critical_item_pass_rate": 0.5}, "critical_item_pass_rate"),
+        ({"judge_error_rate": 0.5}, "judge_error_rate"),
+        ({"avg_score_pct": 50.0}, "avg_score_pct"),
+        ({"precheck_pass_rate": 0.1}, "precheck_pass_rate"),
+    ],
+)
+def test_every_criterion_still_rejects_on_a_real_measurement(
+    acceptance: dict, over: dict, criterion: str
+) -> None:
+    m = _metrics(**over)
+
+    assert sweep.select_pareto_winner({"results": {"c": m}}, acceptance) is None
+    assert _verdicts(m, acceptance)[criterion] == sweep.FAIL
+
+
+# ── the reason is written down ───────────────────────────────────────
+
+
+def test_no_winner_now_says_which_criterion_and_which_value(
+    plan: sweep.Plan, tmp_path: Path
+) -> None:
+    """"No variant satisfied all acceptance thresholds" is not a diagnosis.
+
+    An operator reading it cannot tell a fleet of bad graders from a check
+    that never ran, and the two call for opposite responses.
+    """
+    progress = {
+        "plan_name": plan.plan_name,
+        "started_at": "2026-01-01T00:00:00Z",
+        "finished_at": "2026-01-01T01:00:00Z",
+        "cumulative_cost_usd": 5.0,
+        "completed": ["B_bad"],
+        "results": {
+            "B_bad": _metrics(name="B_bad", critical_item_pass_rate=0.42),
+        },
+        "winner": None,
+    }
+    target = tmp_path / "RESULTS.md"
+
+    sweep.write_results_md(progress, None, plan, target)
+    text = target.read_text(encoding="utf-8")
+
+    assert "**No winner**" in text
+    assert "B_bad" in text
+    assert "critical_item_pass_rate" in text
+    assert "0.42" in text
+
+
+def test_no_winner_separates_what_failed_from_what_never_ran(
+    plan: sweep.Plan, tmp_path: Path
+) -> None:
+    progress = {
+        "plan_name": plan.plan_name,
+        "started_at": "2026-01-01T00:00:00Z",
+        "finished_at": "2026-01-01T01:00:00Z",
+        "cumulative_cost_usd": 5.0,
+        "completed": ["B_bad"],
+        "results": {
+            "B_bad": _metrics(
+                name="B_bad",
+                critical_item_pass_rate=0.42,
+                precheck_pass_rate=None,
+                item_counts={"precheck_items": 0, "judge_items": 60},
+            ),
+        },
+        "winner": None,
+    }
+    target = tmp_path / "RESULTS.md"
+
+    sweep.write_results_md(progress, None, plan, target)
+    text = target.read_text(encoding="utf-8")
+
+    assert "not measured" in text
+    assert "an absent measurement is not a failed one" in text
+
+
+def test_a_winner_with_an_unmeasured_criterion_is_flagged_in_the_report(
+    plan: sweep.Plan, tmp_path: Path
+) -> None:
+    m = _metrics(
+        name="B_ok",
+        precheck_pass_rate=None,
+        item_counts={"precheck_items": 0, "judge_items": 8816},
+    )
+    progress = {
+        "plan_name": plan.plan_name,
+        "started_at": "2026-01-01T00:00:00Z",
+        "finished_at": "2026-01-01T01:00:00Z",
+        "cumulative_cost_usd": 5.0,
+        "completed": ["B_ok"],
+        "results": {"B_ok": m},
+        "winner": "B_ok",
+    }
+    winner = sweep.select_pareto_winner(progress, plan.acceptance)
+    assert winner is not None
+    target = tmp_path / "RESULTS.md"
+
+    sweep.write_results_md(progress, winner, plan, target)
+    text = target.read_text(encoding="utf-8")
+
+    assert "NOT VERIFIED" in text
+    assert "precheck_pass_rate" in text
+
+
+def test_the_changelog_entry_carries_the_same_caveat(
+    plan: sweep.Plan, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CHANGELOG outlives the run directory; the caveat has to reach it.
+
+    A line that says only "winner X, cost $Y" is the artifact somebody reads
+    six months later when deciding whether X was validated.
+    """
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n\n- existing entry\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sweep, "CHANGELOG", changelog)
+    winner = sweep.WinnerResult(
+        name="B_ok",
+        metrics=_metrics(
+            name="B_ok",
+            precheck_pass_rate=None,
+            item_counts={"precheck_items": 0, "judge_items": 8816},
+        ),
+        rationale="test",
+        unmeasured=["precheck_pass_rate"],
+    )
+
+    sweep.append_changelog_entry(winner, plan, REPO_ROOT / "runs" / "r1", 5.0)
+    text = changelog.read_text(encoding="utf-8")
+
+    assert "NOT VERIFIED" in text
+    assert "precheck_pass_rate" in text
+    assert "- existing entry" in text  # appended, not overwritten
+
+
+# ── where the zeros came from ────────────────────────────────────────
+
+
+def test_a_rate_over_zero_items_is_read_as_unmeasured() -> None:
+    wow = {"precheck_pass_rate": 0.0, "item_counts": {"precheck_items": 0}}
+
+    assert sweep._measured_rate(wow, "precheck_pass_rate") is None
+
+
+def test_a_rate_over_real_items_is_read_as_measured() -> None:
+    wow = {"precheck_pass_rate": 0.0, "item_counts": {"precheck_items": 40}}
+
+    assert sweep._measured_rate(wow, "precheck_pass_rate") == 0.0
+
+
+def test_a_grade_without_item_counts_keeps_its_rate() -> None:
+    """Unknown is not zero -- the same substitution, pointed the other way.
+
+    Payloads written before ``item_counts`` existed carry no denominator.
+    Treating that as "measured over nothing" would silently stop applying
+    every threshold to every historical grade.
+    """
+    assert sweep._measured_rate({"precheck_pass_rate": 0.83}, "precheck_pass_rate") == 0.83
+    assert sweep._measured_rate({"judge_error_rate": 0.0}, "judge_error_rate") == 0.0
+
+
+def test_a_rate_absent_from_the_grade_is_not_invented_as_zero() -> None:
+    assert sweep._measured_rate({}, "precheck_pass_rate") is None
+    assert sweep._measured_rate(None, "precheck_pass_rate") is None
+    assert sweep._measured_rate({"precheck_pass_rate": "0.8"}, "precheck_pass_rate") is None
+    assert sweep._measured_rate({"precheck_pass_rate": True}, "precheck_pass_rate") is None
+
+
+def test_every_acceptance_rate_has_a_denominator_to_check() -> None:
+    """The map from rate to denominator has to cover what the gate compares.
+
+    A rate missing from ``RATE_DENOMINATORS`` silently keeps the old
+    behaviour: its empty-denominator zero reaches the threshold as a real
+    measurement and rejects.
+    """
+    assert set(sweep.RATE_DENOMINATORS) == {
+        "critical_item_pass_rate",
+        "judge_error_rate",
+        "precheck_pass_rate",
+    }
+
+
+def test_extract_metrics_reads_a_real_grade_payload(tmp_path: Path) -> None:
+    """Through the real function, on a payload shaped like the committed ones."""
+    grade = {
+        "summary": {
+            "openai_compat": {"avg_score_pct": 79.53},
+            "wow": {
+                "critical_item_pass_rate": 0.64,
+                "judge_error_rate": 0.0065,
+                "precheck_pass_rate": 0.0,
+                "item_counts": {"critical_items": 300, "judge_items": 8816,
+                                "precheck_items": 0},
+            },
+            "cost": {"total_input_tokens": 100, "total_output_tokens": 50,
+                     "total_judge_calls": 4, "total_judge_latency_sec": 12.0},
+        }
+    }
+    path = tmp_path / "grade.json"
+    path.write_text(json.dumps(grade), encoding="utf-8")
+    variant = sweep.load_plan(PLAN_PATH).phase_b[0]
+
+    m = sweep.extract_metrics(path, variant)
+
+    assert m["precheck_pass_rate"] is None       # 0 items
+    assert m["judge_error_rate"] == 0.0065       # 8,816 items
+    assert m["critical_item_pass_rate"] == 0.64
+    assert m["item_counts"]["precheck_items"] == 0
+
+
+# ── runs that never graded anything ──────────────────────────────────
+
+
+def test_a_crashed_variant_is_rejected_for_crashing(acceptance: dict) -> None:
+    """Not by a stand-in error rate of 1.0.
+
+    The old stub described a crash with ``judge_error_rate: 1.0`` and three
+    zeros. It happened to be rejected, but by a fabricated number that a
+    looser ``judge_error_rate_max`` would have let through -- with a
+    fabricated 0.00 score printed beside it.
+    """
+    m = _metrics(
+        name="boom",
+        error="step8_grade.py exited 1",
+        avg_score_pct=None,
+        critical_item_pass_rate=None,
+        judge_error_rate=None,
+        precheck_pass_rate=None,
+    )
+
+    assert sweep.select_pareto_winner({"results": {"boom": m}}, acceptance) is None
+    verdicts = _verdicts(m, acceptance)
+    assert verdicts["graded"] == sweep.FAIL
+    # ...and nothing else claims to have been checked.
+    assert verdicts["avg_score_pct"] == sweep.UNMEASURED
+    assert verdicts["critical_item_pass_rate"] == sweep.UNMEASURED
+
+
+def test_an_absence_renders_as_absent_not_as_zero() -> None:
+    """``0.00`` in the results table is a claim. It needs a measurement."""
+    row = sweep._format_row(
+        {"name": "dry", "avg_score_pct": None, "critical_item_pass_rate": None,
+         "judge_error_rate": None, "judge_call_count": 0,
+         "judge_total_latency_sec": 0.0, "smoke_cost_usd": 0.0,
+         "full_run_cost_usd": 0.0}
+    )
+
+    assert "0.00 |" not in row.split("$")[0]
+    assert row.count("n/a") == 3
+
+
+def test_a_measured_zero_still_renders_as_zero() -> None:
+    row = sweep._format_row(
+        {"name": "real", "avg_score_pct": 0.0, "critical_item_pass_rate": 0.0,
+         "judge_error_rate": 0.0, "judge_call_count": 3,
+         "judge_total_latency_sec": 10.0, "smoke_cost_usd": 1.0,
+         "full_run_cost_usd": 2.0}
+    )
+
+    assert "n/a" not in row
+    assert "0.00" in row
+
+
+# ── the second gate, and the frontier ────────────────────────────────
+
+
+def test_phase_c_narrowing_does_not_drop_an_unmeasured_variant(
+    acceptance: dict,
+) -> None:
+    """A silent elimination one step earlier than the winner gate.
+
+    A variant dropped here is never repeated, never reaches the frontier, and
+    never appears in the rejection table -- so the absence would disappear
+    without leaving a trace anywhere.
+    """
+    unmeasured = _metrics(name="B_unmeasured", critical_item_pass_rate=None)
+    genuinely_low = _metrics(name="B_low", critical_item_pass_rate=0.3)
+
+    assert sweep._below_critical_min(unmeasured, acceptance) is False
+    assert sweep._below_critical_min(genuinely_low, acceptance) is True
+
+
+def test_an_unmeasured_axis_sorts_as_worst_not_best() -> None:
+    """Otherwise "we never measured the error rate" would beat "0.1% errors".
+
+    ``dict.get(ax, inf)`` returned ``None`` for a key that is present and
+    null, which is neither the default nor comparable.
+    """
+    measured = {"name": "measured", "full_run_cost_usd": 100.0,
+                "judge_error_rate": 0.001, "judge_total_latency_sec": 100.0}
+    unmeasured = {"name": "unmeasured", "full_run_cost_usd": 100.0,
+                  "judge_error_rate": None, "judge_total_latency_sec": 100.0}
+
+    frontier = sweep.pareto_frontier(
+        [measured, unmeasured],
+        axes=["full_run_cost_usd", "judge_error_rate", "judge_total_latency_sec"],
+    )
+
+    assert [m["name"] for m in frontier] == ["measured"]
+
+
+def test_the_stability_tiebreak_ignores_reps_that_never_scored() -> None:
+    """Averaging a fabricated 0.0 into the spread invents instability.
+
+    Three reps at ~78 plus one crashed rep recorded as 0.0 produce a standard
+    deviation far over the 1.5 threshold, which would drop a stable winner.
+    """
+    acceptance = sweep.load_plan(PLAN_PATH).acceptance
+    reps = {
+        f"B_ok__rep{i}": _metrics(name="B_ok__rep" + str(i), phase="C",
+                                  avg_score_pct=score)
+        for i, score in enumerate((77.9, 78.0, 78.1))
+    }
+    reps["B_ok__rep3"] = _metrics(name="B_ok__rep3", phase="C",
+                                  avg_score_pct=None, error="crashed")
+    progress = {"results": {"B_ok": _metrics(name="B_ok"), **reps}}
+
+    winner = sweep.select_pareto_winner(progress, acceptance)
+
+    assert winner is not None
+    assert winner.name == "B_ok"
+
+
+# ── against the corpus the thresholds are applied to ─────────────────
+
+
+@pytest.fixture(scope="module")
+def gold_ceiling_wow() -> dict:
+    """The 185-task run's published ``wow`` block, as committed."""
+    if not GRADES_ROOT.exists():
+        pytest.skip("no committed grades in this checkout")
+    for path in sorted(GRADES_ROOT.rglob("*.json")):
+        if "_shards" in path.parts:
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if (
+            isinstance(payload, dict)
+            and payload.get("expected_ordered_task_ids_sha256") == GOLD_CEILING_COHORT
+            and payload.get("run_status") == "final"
+            and len(payload.get("tasks") or []) == 185
+        ):
+            return payload["summary"]["wow"]
+    pytest.skip("the gold-ceiling run is not in this checkout")
+
+
+def test_the_real_run_the_gate_would_have_rejected(
+    gold_ceiling_wow: dict, acceptance: dict
+) -> None:
+    """The committed payload, not a fixture.
+
+    Its ``precheck_pass_rate`` is 0.0 and it is under the committed 0.7
+    threshold. Whether that 0.0 is a measurement is exactly what the
+    denominator decides, and this run judged 8,816 items and prechecked none.
+    """
+    assert gold_ceiling_wow["precheck_pass_rate"] == 0.0
+    assert gold_ceiling_wow["precheck_pass_rate"] < acceptance["precheck_pass_rate_min"]
+    assert gold_ceiling_wow["judge_pass_rate"] > 0.0

--- a/scripts/grading_cost_sweep.py
+++ b/scripts/grading_cost_sweep.py
@@ -30,7 +30,7 @@ import subprocess
 import sys
 import tempfile
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
@@ -567,6 +567,40 @@ def run_step8_grade(
 # Metrics extraction
 # ---------------------------------------------------------------------
 
+#: The ``summary.wow.item_counts`` denominator each acceptance rate was divided
+#: by. ``step8_grade`` computes every one of these as ``hits / <count>`` and
+#: publishes ``0.0`` when the count is zero -- which is also exactly what a
+#: total failure publishes. Without the denominator the two are the same
+#: number, and every threshold below rejects on both alike.
+RATE_DENOMINATORS = {
+    "critical_item_pass_rate": "critical_items",
+    "judge_error_rate": "judge_items",
+    "precheck_pass_rate": "precheck_items",
+}
+
+
+def _measured_rate(wow: Any, key: str) -> float | None:
+    """A rate from ``summary.wow``, or ``None`` if nothing was measured.
+
+    ``None`` is returned in two cases: the rate is absent, or its denominator
+    is explicitly zero. A grade written before ``item_counts`` existed carries
+    no denominator at all -- that is *unknown*, not zero, so the rate is
+    returned as published rather than discarded.
+    """
+    if not isinstance(wow, dict):
+        return None
+    value = wow.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    counts = wow.get("item_counts")
+    denominator = RATE_DENOMINATORS.get(key)
+    if isinstance(counts, dict) and denominator is not None:
+        n = counts.get(denominator)
+        if isinstance(n, int) and not isinstance(n, bool) and n == 0:
+            return None
+    return float(value)
+
+
 def extract_metrics(grade_json_path: Path, variant: Variant) -> dict[str, Any]:
     """Read a grade JSON and compute the dispatcher's per-variant metric block."""
     with open(grade_json_path, "r", encoding="utf-8") as f:
@@ -586,14 +620,20 @@ def extract_metrics(grade_json_path: Path, variant: Variant) -> dict[str, Any]:
     smoke_cost = _cost_from_tokens(variant, judge_input, judge_output)
     full_cost = smoke_cost * FULL_RUN_SCALE
 
+    avg_score = oai.get("avg_score_pct")
     return {
         "name": variant.name,
         "phase": variant.phase,
         "repeat_index": variant.repeat_index,
-        "avg_score_pct": float(oai.get("avg_score_pct", 0.0)),
-        "critical_item_pass_rate": float(wow.get("critical_item_pass_rate", 0.0)),
-        "judge_error_rate": float(wow.get("judge_error_rate", 0.0)),
-        "precheck_pass_rate": float(wow.get("precheck_pass_rate", 0.0)),
+        "avg_score_pct": (
+            float(avg_score)
+            if isinstance(avg_score, (int, float)) and not isinstance(avg_score, bool)
+            else None
+        ),
+        "critical_item_pass_rate": _measured_rate(wow, "critical_item_pass_rate"),
+        "judge_error_rate": _measured_rate(wow, "judge_error_rate"),
+        "precheck_pass_rate": _measured_rate(wow, "precheck_pass_rate"),
+        "item_counts": wow.get("item_counts") if isinstance(wow, dict) else None,
         "judge_call_count": judge_calls,
         "judge_total_latency_sec": judge_latency,
         "judge_input_tokens": judge_input,
@@ -616,6 +656,18 @@ def _cost_from_tokens(variant: Variant, in_tok: int, out_tok: int) -> float:
 # Pareto frontier + winner selection
 # ---------------------------------------------------------------------
 
+def _axis(m: dict[str, Any], ax: str) -> float:
+    """One Pareto axis, with an unmeasured value sorted as worst.
+
+    ``math.inf`` rather than ``0.0``: a variant whose error rate was never
+    measured must not out-rank one whose measured error rate is genuinely low.
+    """
+    value = m.get(ax)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return math.inf
+    return float(value)
+
+
 def pareto_frontier(
     results: list[dict[str, Any]],
     axes: Iterable[str],
@@ -631,10 +683,10 @@ def pareto_frontier(
             strictly_better = False
             all_le = True
             for ax in axes:
-                if other.get(ax, math.inf) > cand.get(ax, math.inf):
+                if _axis(other, ax) > _axis(cand, ax):
                     all_le = False
                     break
-                if other.get(ax, math.inf) < cand.get(ax, math.inf):
+                if _axis(other, ax) < _axis(cand, ax):
                     strictly_better = True
             if all_le and strictly_better:
                 dominated = True
@@ -649,31 +701,116 @@ class WinnerResult:
     name: str
     metrics: dict[str, Any]
     rationale: str
+    unmeasured: list[str] = field(default_factory=list)
+
+
+#: A criterion's three possible states. ``UNMEASURED`` exists because the
+#: absent form of every rate here is ``0.0`` -- the worst value on the scale --
+#: so a two-state gate reads "we never ran this check" as "this failed the
+#: check", and rejects a config on evidence it does not have.
+PASS = "pass"
+FAIL = "fail"
+UNMEASURED = "unmeasured"
+
+
+@dataclass
+class CriterionVerdict:
+    criterion: str
+    verdict: str
+    detail: str
+
+
+def _verdict(criterion: str, value: Any, detail_if_measured: str) -> CriterionVerdict:
+    """``UNMEASURED`` for a non-number, otherwise the caller's own verdict."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return CriterionVerdict(criterion, UNMEASURED, "not measured on this run")
+    return CriterionVerdict(criterion, PASS, detail_if_measured)
+
+
+def evaluate_acceptance(
+    metrics: dict[str, Any],
+    acceptance: dict[str, Any],
+) -> list[CriterionVerdict]:
+    """Score one variant against every acceptance criterion, three-state.
+
+    A criterion that was never measured returns ``UNMEASURED``. It does not
+    reject: an absence is not evidence of failure. It does not silently pass
+    either -- it is carried on the winner and printed in RESULTS.md, so nobody
+    promotes a config believing a check ran that never did.
+    """
+    verdicts: list[CriterionVerdict] = []
+
+    error = metrics.get("error")
+    if error:
+        # The variant produced no grade at all. This is a rejection on the
+        # evidence -- the run failed -- not on a missing measurement.
+        verdicts.append(
+            CriterionVerdict("graded", FAIL, f"variant did not produce a grade: {error}")
+        )
+
+    for key, threshold_key, direction in (
+        ("critical_item_pass_rate", "critical_item_pass_rate_min", "below"),
+        ("precheck_pass_rate", "precheck_pass_rate_min", "below"),
+        ("judge_error_rate", "judge_error_rate_max", "above"),
+    ):
+        limit = float(acceptance[threshold_key])
+        value = metrics.get(key)
+        bound = "≥" if direction == "below" else "≤"
+        v = _verdict(key, value, f"{value} ({bound} {limit})")
+        if v.verdict == PASS:
+            numeric = float(value)  # type: ignore[arg-type]
+            if numeric < limit if direction == "below" else numeric > limit:
+                v = CriterionVerdict(
+                    key, FAIL, f"{value} is {direction} the limit {limit}"
+                )
+        verdicts.append(v)
+
+    baseline = float(acceptance["baseline_avg_score_pct"])
+    delta_pp = float(acceptance["avg_score_delta_pp"])
+    score = metrics.get("avg_score_pct")
+    v = _verdict("avg_score_pct", score, f"{score} (baseline {baseline} ± {delta_pp}pp)")
+    if v.verdict == PASS and abs(float(score) - baseline) > delta_pp:  # type: ignore[arg-type]
+        v = CriterionVerdict(
+            "avg_score_pct", FAIL,
+            f"{score} is more than {delta_pp}pp from baseline {baseline}",
+        )
+    verdicts.append(v)
+
+    return verdicts
+
+
+def acceptance_audit(
+    progress: dict[str, Any],
+    acceptance: dict[str, Any],
+) -> dict[str, list[CriterionVerdict]]:
+    """Per-criterion verdicts for every selectable variant, keyed by name."""
+    return {
+        name: evaluate_acceptance(m, acceptance)
+        for name, m in progress.get("results", {}).items()
+        if m.get("phase") != "DV"  # diversity validator is never selected
+    }
 
 
 def select_pareto_winner(
     progress: dict[str, Any],
     acceptance: dict[str, Any],
 ) -> WinnerResult | None:
-    baseline_score = float(acceptance["baseline_avg_score_pct"])
-    delta_pp = float(acceptance["avg_score_delta_pp"])
-    crit_min = float(acceptance["critical_item_pass_rate_min"])
-    err_max = float(acceptance["judge_error_rate_max"])
-    precheck_min = float(acceptance["precheck_pass_rate_min"])
+    audit = acceptance_audit(progress, acceptance)
 
-    eligible = []
-    for name, m in progress.get("results", {}).items():
-        if m.get("phase") == "DV":
-            continue  # diversity validator never selected
-        if m.get("critical_item_pass_rate", 0.0) < crit_min:
-            continue
-        if m.get("judge_error_rate", 1.0) > err_max:
-            continue
-        if m.get("precheck_pass_rate", 0.0) < precheck_min:
-            continue
-        if abs(m.get("avg_score_pct", 0.0) - baseline_score) > delta_pp:
-            continue
-        eligible.append(m)
+    # Keyed by identity, not by name: `results` is keyed by variant name but
+    # each metric dict carries its own `name`, and the two are not guaranteed
+    # to agree.
+    verdicts_of = {
+        id(m): audit[key]
+        for key, m in progress.get("results", {}).items()
+        if key in audit
+    }
+
+    eligible = [
+        m for m in progress.get("results", {}).values()
+        if id(m) in verdicts_of
+        and not any(v.verdict == FAIL for v in verdicts_of[id(m)])
+    ]
 
     if not eligible:
         return None
@@ -690,20 +827,41 @@ def select_pareto_winner(
         if r.get("name", "").startswith(winner["name"]) and r.get("phase") == "C"
     ]
     if len(reps) >= 2:
-        scores = [r["avg_score_pct"] for r in reps]
-        mean = sum(scores) / len(scores)
-        std = (sum((s - mean) ** 2 for s in scores) / len(scores)) ** 0.5
-        if std > 1.5 and len(frontier) > 1:
-            remaining = [m for m in frontier if m["name"] != winner["name"]]
-            winner = min(remaining, key=lambda m: m["full_run_cost_usd"])
+        # Only the reps that actually carry a score: averaging over a
+        # fabricated 0.0 would invent instability that was never observed.
+        scores = [
+            r["avg_score_pct"] for r in reps
+            if isinstance(r.get("avg_score_pct"), (int, float))
+            and not isinstance(r.get("avg_score_pct"), bool)
+        ]
+        if len(scores) >= 2:
+            mean = sum(scores) / len(scores)
+            std = (sum((s - mean) ** 2 for s in scores) / len(scores)) ** 0.5
+            if std > 1.5 and len(frontier) > 1:
+                remaining = [m for m in frontier if m["name"] != winner["name"]]
+                winner = min(remaining, key=lambda m: m["full_run_cost_usd"])
+
+    unmeasured = [
+        v.criterion for v in verdicts_of[id(winner)] if v.verdict == UNMEASURED
+    ]
+    rationale = (
+        f"Pareto winner among {len(eligible)} eligible variants "
+        f"(frontier size {len(frontier)}); minimized full_run_cost_usd."
+    )
+    if unmeasured:
+        # Said on the winner itself, because this is the sentence a human
+        # needs before promoting the config: it cleared every threshold that
+        # ran, and these ones did not run.
+        rationale += (
+            " NOT VERIFIED against " + ", ".join(unmeasured) +
+            " — not measured on this run, so no threshold was applied."
+        )
 
     return WinnerResult(
         name=winner["name"],
         metrics=winner,
-        rationale=(
-            f"Pareto winner among {len(eligible)} eligible variants "
-            f"(frontier size {len(frontier)}); minimized full_run_cost_usd."
-        ),
+        rationale=rationale,
+        unmeasured=unmeasured,
     )
 
 
@@ -755,16 +913,79 @@ def write_summary_json(progress: dict[str, Any], path: Path) -> None:
         json.dump(payload, f, indent=2)
 
 
+def _fmt_measure(
+    value: Any,
+    spec: str,
+    *,
+    scale: float = 1.0,
+    absent: str = "n/a",
+) -> str:
+    """Render a metric, or ``absent`` when there was no measurement.
+
+    ``0.00`` is a legitimate rendering of a measured zero. It must not also be
+    the rendering of "never measured", which is the whole defect these tables
+    used to carry into the report.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return absent
+    return spec.format(value * scale)
+
+
 def _format_row(m: dict[str, Any]) -> str:
     return (
-        f"| {m['name']} | {m.get('avg_score_pct', 0):.2f} | "
-        f"{m.get('critical_item_pass_rate', 0):.2f} | "
-        f"{m.get('judge_error_rate', 0)*100:.1f}% | "
+        f"| {m['name']} | {_fmt_measure(m.get('avg_score_pct'), '{:.2f}')} | "
+        f"{_fmt_measure(m.get('critical_item_pass_rate'), '{:.2f}')} | "
+        f"{_fmt_measure(m.get('judge_error_rate'), '{:.1f}%', scale=100)} | "
         f"{m.get('judge_call_count', 0)} | "
         f"{m.get('judge_total_latency_sec', 0):.0f}s | "
         f"${m.get('smoke_cost_usd', 0):.2f} | "
         f"${m.get('full_run_cost_usd', 0):.2f} |"
     )
+
+
+def _rejection_lines(
+    progress: dict[str, Any],
+    acceptance: dict[str, Any],
+) -> list[str]:
+    """Why each variant was rejected, and which checks never ran.
+
+    Without this the report says only "no variant satisfied all acceptance
+    thresholds", which reads as "the graders were not good enough" whether
+    that is what happened or not.
+    """
+    audit = acceptance_audit(progress, acceptance)
+    if not audit:
+        return ["No selectable variants were run.", ""]
+
+    lines = ["Per-variant acceptance verdicts:", ""]
+    lines.append("| variant | rejected because | not measured |")
+    lines.append("|---|---|---|")
+    for name, verdicts in audit.items():
+        failed = [v for v in verdicts if v.verdict == FAIL]
+        skipped = [v.criterion for v in verdicts if v.verdict == UNMEASURED]
+        lines.append(
+            f"| {name} | "
+            + ("; ".join(f"{v.criterion}: {v.detail}" for v in failed) or "—")
+            + " | "
+            + (", ".join(f"`{c}`" for c in skipped) or "—")
+            + " |"
+        )
+    lines.append("")
+
+    never_ran = sorted({
+        v.criterion
+        for verdicts in audit.values()
+        for v in verdicts
+        if v.verdict == UNMEASURED
+    })
+    if never_ran:
+        lines.append(
+            "A criterion listed under **not measured** did not reject anything: "
+            "an absent measurement is not a failed one. Nothing was verified "
+            "against it either."
+        )
+        lines.append("")
+    return lines
 
 
 def write_results_md(
@@ -800,6 +1021,7 @@ def write_results_md(
     if winner is None:
         lines.append("**No winner** — no variant satisfied all acceptance thresholds.")
         lines.append("")
+        lines.extend(_rejection_lines(progress, plan.acceptance))
         lines.append("Best-effort recommendation: see Phase B table below.")
     else:
         m = winner.metrics
@@ -807,13 +1029,32 @@ def write_results_md(
         lines.append(f"**Winner**: `{winner.name}`")
         lines.append("")
         lines.append(f"- 풀런 예상 비용: ${m['full_run_cost_usd']:.2f}")
-        lines.append(
-            f"- avg_score_pct: {m['avg_score_pct']:.2f} "
-            f"(baseline {baseline_score}, Δ {m['avg_score_pct']-baseline_score:+.2f}pp)"
+        delta = (
+            f" (baseline {baseline_score}, "
+            f"Δ {m['avg_score_pct'] - baseline_score:+.2f}pp)"
+            if isinstance(m.get("avg_score_pct"), (int, float))
+            and not isinstance(m.get("avg_score_pct"), bool)
+            else f" (baseline {baseline_score}, Δ not measured)"
         )
-        lines.append(f"- critical_item_pass_rate: {m['critical_item_pass_rate']:.2f}")
-        lines.append(f"- judge_error_rate: {m['judge_error_rate']*100:.1f}%")
-        lines.append(f"- wall-clock (smoke): {m['judge_total_latency_sec']:.0f}s")
+        lines.append(
+            f"- avg_score_pct: {_fmt_measure(m.get('avg_score_pct'), '{:.2f}')}{delta}"
+        )
+        lines.append(
+            "- critical_item_pass_rate: "
+            f"{_fmt_measure(m.get('critical_item_pass_rate'), '{:.2f}')}"
+        )
+        lines.append(
+            "- judge_error_rate: "
+            f"{_fmt_measure(m.get('judge_error_rate'), '{:.1f}%', scale=100)}"
+        )
+        lines.append(f"- wall-clock (smoke): {m.get('judge_total_latency_sec', 0):.0f}s")
+        if winner.unmeasured:
+            lines.append(
+                "- ⚠️ **NOT VERIFIED**: "
+                + ", ".join(f"`{c}`" for c in winner.unmeasured)
+                + " — never measured on this run, so no threshold was applied "
+                "to them. This winner cleared only the criteria that ran."
+            )
         lines.append(f"- Rationale: {winner.rationale}")
     lines.append("")
 
@@ -905,13 +1146,26 @@ def append_changelog_entry(
     else:
         m = winner.metrics
         baseline_full = plan.baseline["expected_metrics"].get("smoke_cost_usd", 0.0) * FULL_RUN_SCALE
+        score = m.get("avg_score_pct")
+        delta = (
+            f"Δ{score - plan.acceptance['baseline_avg_score_pct']:+.2f}pp"
+            if isinstance(score, (int, float)) and not isinstance(score, bool)
+            else "Δn/a"
+        )
         entry = (
             f"- Grading cost sweep run `{output_dir.name}`: winner "
             f"`{winner.name}` — projected full-run cost ${m['full_run_cost_usd']:.2f} "
             f"(baseline ~${baseline_full:.0f}), avg_score "
-            f"Δ{m['avg_score_pct']-plan.acceptance['baseline_avg_score_pct']:+.2f}pp, "
-            f"critical {m['critical_item_pass_rate']:.2f}, err "
-            f"{m['judge_error_rate']*100:.1f}%. See `{rel}/RESULTS.md`."
+            f"{delta}, "
+            f"critical {_fmt_measure(m.get('critical_item_pass_rate'), '{:.2f}')}, err "
+            f"{_fmt_measure(m.get('judge_error_rate'), '{:.1f}%', scale=100)}."
+            + (
+                " NOT VERIFIED against "
+                + ", ".join(winner.unmeasured)
+                + " (never measured)."
+                if winner.unmeasured else ""
+            )
+            + f" See `{rel}/RESULTS.md`."
         )
     # Insert under "### Added" right after the marker.
     needle = marker + "\n\n### Added\n"
@@ -1043,15 +1297,17 @@ def _run_variant(
     cfg_path = render_temp_config(variant, output_dir)
 
     if dry_run:
-        # Synthesize zero metrics; mark as dry-run.
+        # No grading happened, so nothing was measured. `None` rather than
+        # 0.0: a dry run must not look like a variant that scored zero.
         progress["results"][variant.name] = {
             "name": variant.name,
             "phase": variant.phase,
             "repeat_index": variant.repeat_index,
-            "avg_score_pct": 0.0,
-            "critical_item_pass_rate": 0.0,
-            "judge_error_rate": 0.0,
-            "precheck_pass_rate": 0.0,
+            "avg_score_pct": None,
+            "critical_item_pass_rate": None,
+            "judge_error_rate": None,
+            "precheck_pass_rate": None,
+            "item_counts": None,
             "judge_call_count": 0,
             "judge_total_latency_sec": 0.0,
             "judge_input_tokens": 0,
@@ -1070,14 +1326,19 @@ def _run_variant(
         metrics = extract_metrics(grade_path, variant)
     except Exception as exc:  # noqa: BLE001
         LOG.error("[%s] FAILED: %s", variant.name, exc)
+        # The variant crashed before producing a grade. Every rate is `None`
+        # because none of them was measured; `error` is what rejects it, and
+        # it rejects unconditionally rather than by leaning on a stand-in
+        # judge_error_rate of 1.0 that a looser threshold could let through.
         metrics = {
             "name": variant.name,
             "phase": variant.phase,
             "repeat_index": variant.repeat_index,
-            "avg_score_pct": 0.0,
-            "critical_item_pass_rate": 0.0,
-            "judge_error_rate": 1.0,
-            "precheck_pass_rate": 0.0,
+            "avg_score_pct": None,
+            "critical_item_pass_rate": None,
+            "judge_error_rate": None,
+            "precheck_pass_rate": None,
+            "item_counts": None,
             "judge_call_count": 0,
             "judge_total_latency_sec": 0.0,
             "judge_input_tokens": 0,
@@ -1092,11 +1353,26 @@ def _run_variant(
     progress["completed"].append(variant.name)
     save_progress(progress, progress_path)
     LOG.info(
-        "[%s] DONE: avg=%.2f err=%.3f cost=$%.3f",
+        "[%s] DONE: avg=%s err=%s cost=$%.3f",
         variant.name,
-        metrics["avg_score_pct"],
-        metrics["judge_error_rate"],
+        _fmt_measure(metrics.get("avg_score_pct"), "{:.2f}"),
+        _fmt_measure(metrics.get("judge_error_rate"), "{:.3f}"),
         metrics["smoke_cost_usd"],
+    )
+
+
+def _below_critical_min(m: dict[str, Any], acceptance: dict[str, Any]) -> bool:
+    """Whether a variant is *known* to be under the critical-pass floor.
+
+    Used to narrow Phase B down to Phase C. An unmeasured rate returns
+    ``False``: it has not been shown to be under the floor, and dropping a
+    variant here means it is never repeated, never on the frontier, and never
+    explained -- a silent elimination on a check that did not run.
+    """
+    return any(
+        v.verdict == FAIL
+        for v in evaluate_acceptance(m, acceptance)
+        if v.criterion == "critical_item_pass_rate"
     )
 
 
@@ -1181,7 +1457,7 @@ def main(argv: list[str] | None = None) -> int:
         ]
         b_eligible = [
             m for m in b_results
-            if m.get("critical_item_pass_rate", 0) >= plan.acceptance["critical_item_pass_rate_min"]
+            if not _below_critical_min(m, plan.acceptance)
         ]
         top_b = sorted(
             b_eligible, key=lambda m: m.get("full_run_cost_usd", math.inf)
@@ -1235,6 +1511,20 @@ def main(argv: list[str] | None = None) -> int:
     _finalize(progress, plan, output_dir, winner)
 
     print(f"[sweep] winner: {winner.name if winner else '(none)'}")
+    if winner is None:
+        for name, verdicts in acceptance_audit(progress, plan.acceptance).items():
+            failed = [f"{v.criterion} {v.detail}" for v in verdicts if v.verdict == FAIL]
+            skipped = [v.criterion for v in verdicts if v.verdict == UNMEASURED]
+            print(
+                f"[sweep]   {name}: rejected by {'; '.join(failed) or '(nothing)'}"
+                + (f" | not measured: {', '.join(skipped)}" if skipped else "")
+            )
+    elif winner.unmeasured:
+        print(
+            "[sweep] NOT VERIFIED against "
+            + ", ".join(winner.unmeasured)
+            + " (never measured on this run)"
+        )
     print(f"[sweep] cost spent: ${progress['cumulative_cost_usd']:.2f}")
     print(f"[sweep] report: {output_dir / 'RESULTS.md'}")
 


### PR DESCRIPTION
## The defect

`select_pareto_winner` compares four measurements against acceptance thresholds. Every one of the four reaches it as `0.0` when it was never measured — `step8_grade` divides by an empty denominator and publishes the quotient. `0.0` is also the worst real value on each scale, so the gate cannot tell an absence from a total failure and rejects both alike. It then reports only *"no variant satisfied all acceptance thresholds"*, which reads as a verdict on the graders whether or not anything was ever measured.

**This is live.** The committed plan sets `precheck_pass_rate_min: 0.7`; modern runs precheck **zero** items. Demonstrated against the real code before the fix — a variant perfect on every criterion that actually ran:

| criterion | value | measured? | old gate |
|---|---|---|---|
| `critical_item_pass_rate` | 1.00 | 20 items | pass |
| `judge_error_rate` | 0.0 | 8,816 items | pass |
| `avg_score_pct` | 77.83 (exactly baseline) | yes | pass |
| `precheck_pass_rate` | 0.0 | **0 items** | **rejects** |

`select_pareto_winner` returned `None`. Flipping that one value to `1.0` makes the same variant win. The threshold default never even fired: the key is *present*, carrying an absence-zero, so `0.0 < 0.7` simply rejects.

## Three absences fed the same gate

- `extract_metrics` substituted `0.0` for a rate missing from the grade. It now returns `None`, and `None` for a rate whose `item_counts` denominator is zero. **A grade with no `item_counts` at all is *unknown*, not zero** — its rate is preserved. That is the same substitution pointed the other way, and it would silently stop applying every threshold to every historical grade.
- The dry-run and crash stubs wrote `0.0` for runs that never graded anything, and those rows were printed in RESULTS.md as measurements. A crash is now rejected by an explicit `graded` verdict naming the error, instead of a stand-in `judge_error_rate: 1.0` that a looser threshold could have let through — with a fabricated `0.00` score beside it.
- The **Phase B→C narrowing** carried the same defect one step earlier, where a dropped variant is never repeated, never on the frontier, and never explained.

## What the gate does now

Three-state. An unmeasured criterion **does not reject** — an absence is not evidence of failure. It **does not silently pass** either:

```
[sweep] NOT VERIFIED against precheck_pass_rate (never measured on this run)
```

carried on the winner as `unmeasured`, and printed in RESULTS.md (`⚠️ **NOT VERIFIED**`), in the CHANGELOG entry, and on stdout. A no-winner run prints a per-variant table separating *rejected because* from *not measured*.

**A measured zero still rejects.** 40 items prechecked and all failed is the same `0.0` on the wire, and is still refused with `precheck_pass_rate: 0.0 is below the limit 0.7`. The fix is not "ignore precheck" — that would be a worse bug than the one being fixed.

Two smaller consequences of the same principle: unmeasured Pareto axes sort as `inf` rather than `0.0`, so "never measured" cannot out-rank a genuinely low measured error rate; and the Phase C stability tie-break no longer averages a fabricated `0.0` into the standard deviation, which invented instability that was never observed.

## Verification

25 tests. Passing is the weaker claim — each was **mutation-checked** by reverting the behaviour it pins:

| reverted behaviour | tests failed |
|---|---|
| empty denominator is a real measurement again | 2 ✅ |
| a rate absent from the grade becomes `0.0` | 1 ✅ |
| unknown denominator treated as zero | 1 ✅ |
| unmeasured rejects again (two-state gate) | 6 ✅ |
| unmeasured passes with no caveat carried | 2 ✅ |
| a measured zero waved through as "probably unmeasured" | 2 ✅ |
| Phase C narrowing drops an unmeasured variant | 1 ✅ |
| unmeasured Pareto axis sorts as best | 1 ✅ |
| an absence renders as `0.00` in the table | 1 ✅ |
| the crash verdict no longer names the crash | 1 ✅ |
| no-winner report drops the per-variant reasons | 2 ✅ |
| tie-break averages a crashed rep in as `0.0` | 1 ✅ |

**Twelve of twelve caught.** One test runs against the committed 185-task gold-ceiling payload rather than a fixture, located by cohort fingerprint.

- `pytest scripts/__tests__` — **144 passed** (119 + 25 new), no skips in the new file
- Full backend suite — **7,486 passed, 10 skipped**, unchanged from baseline (this PR touches no `batch-runner/` file)
- `mypy scripts/grading_cost_sweep.py` — clean

## Scope

Repo-root `scripts/` is outside `compute_grader_source_hash`, which only covers paths under `batch-runner/`. **No grader fingerprint moves and no freeze gate applies.** No model is called and nothing is spent by this change or its tests. Follows #391, which made the denominator publishable in the first place.

---

## Second commit: the tests in this PR were not being run

Written after the above was pushed, because the PR's own checks contradicted it.

`backend-tests.yml` gained a `Run repo-root script tests` step when `scripts/__tests__/` was first wired in, but the workflow's `paths:` filter still listed only `batch-runner/**`. A pull request touching just repo-root `scripts/` therefore **started no run at all**, and that step never executed — the directory was wired to a job nothing woke up.

Measured on this branch, not inferred:

| head commit | workflows that ran |
|---|---|
| `d4d3a73` — the sweep fix, +25 tests under `scripts/__tests__/` | Aggregate Tests & Deploy, **only** |
| `207ef6c` — after adding `scripts/**` to the filter | Aggregate Tests & Deploy + **Backend Tests** ✅ |

The 25 tests above were green locally and **nothing in CI had checked them**.

`scripts/**` is added to both the `pull_request` and `push` filters, and the pairing is guarded by a test: every root the workflow *claims* to cover must also be a root that *starts* it. Two details of where it lives:

- It sits in `batch-runner/tests/`, not `scripts/__tests__/` — in the latter it could be switched off by the very defect class it exists to catch.
- It is not circular. Editing the workflow file always triggers the workflow, so a future removal of `scripts/**` is caught on the commit that removes it.

`_trigger_block` accepts both `"on"` and `True` as the key: PyYAML follows YAML 1.1, where a bare `on` parses as a boolean, so `document["on"]` would raise `KeyError` rather than check anything. Verified against the real file — the parsed keys are `['concurrency', 'jobs', 'name', 'permissions', True]`.

Mutation-checked too: removing `scripts/**` from both filters, from `push` only, and narrowing it to `scripts/lib/**` are each caught.

## Grader fingerprint

Unchanged, and computed rather than asserted — `compute_grader_source_hash` against `grading_configs/default_v2.yaml`, on the tree with and without these changes:

```
before: 0aa4c238880a1127cadb28afea0999562e5953dbeea62fa20308b2e9f1aaa807
after:  0aa4c238880a1127cadb28afea0999562e5953dbeea62fa20308b2e9f1aaa807
```

Neither repo-root `scripts/` nor `batch-runner/tests/` is in the fingerprint set, so no freeze applies. Zero Grade Pipeline runs were in flight at merge time regardless.

## Suite

| | local | CI |
|---|---|---|
| backend | 7,491 passed / 7 skipped | 7,487 passed / 11 skipped |
| `scripts/__tests__` | 144 passed | **144 passed** |

Local backend baseline was 7,486 / 10: **+2** for the new parametrized guard, and **+3 / −3** because `test_file_reader.py:281/290/298` stopped skipping once the GDPVal snapshot was present locally. CI's four extra skips are the same data-dependent tests on a runner without the dataset. Nothing unaccounted for.
