### PR TITLE
fix(grades): recover the denominators the wow rates were divided by

### DIFF
--- a/data/grades/_diagnostic/17e2607b1a293be8802a36f1c1ca8e75b96e3437f99d707bfac13d9a9af247b1/exp026c_cost_receipt_smoke__judge_gpt-5_4__cost_smoke_exp026c_v2_gpt54__cfg_c4348e8fa153ce8d__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_0d1d6df224d71aec23a0199ba1e7b272044b500b__src_7ca55f907056df2d__v2.2.json
+++ b/data/grades/_diagnostic/17e2607b1a293be8802a36f1c1ca8e75b96e3437f99d707bfac13d9a9af247b1/exp026c_cost_receipt_smoke__judge_gpt-5_4__cost_smoke_exp026c_v2_gpt54__cfg_c4348e8fa153ce8d__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_0d1d6df224d71aec23a0199ba1e7b272044b500b__src_7ca55f907056df2d__v2.2.json
@@ -2111,7 +2111,13 @@
           "avg_pct": 74.41,
           "critical_item_pass_rate": 1.0,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.6316
+          "judge_pass_rate": 0.6316,
+          "item_counts": {
+            "rubric_items": 38,
+            "critical_items": 1,
+            "precheck_items": 0,
+            "judge_items": 38
+          }
         }
       },
       "by_rubric_category": {},
@@ -2173,7 +2179,13 @@
           "n_items": 1,
           "pass_rate": 1.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 38,
+        "critical_items": 1,
+        "precheck_items": 0,
+        "judge_items": 38
+      }
     },
     "cost": {
       "total_judge_calls": 84,

--- a/data/grades/_diagnostic/82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b/_superseded/exp_gold_baseline__judge_gpt-5_6-sol__gold_ceiling_30_v2_sol_max__cfg_d1bfc8217c9981d2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_8513975c188f31a6__v2.2.json
+++ b/data/grades/_diagnostic/82d14ac9bf9c3ad37920fb781ee961f5e20805c52618df0d0cdb9d5e677a7e8b/_superseded/exp_gold_baseline__judge_gpt-5_6-sol__gold_ceiling_30_v2_sol_max__cfg_d1bfc8217c9981d2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_8513975c188f31a6__v2.2.json
@@ -73781,28 +73781,52 @@
           "avg_pct": 85.87,
           "critical_item_pass_rate": 0.6818,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.7665
+          "judge_pass_rate": 0.7665,
+          "item_counts": {
+            "rubric_items": 531,
+            "critical_items": 22,
+            "precheck_items": 0,
+            "judge_items": 531
+          }
         },
         "Information": {
           "task_count": 3,
           "avg_pct": 56.21,
           "critical_item_pass_rate": 0.5,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.5362
+          "judge_pass_rate": 0.5362,
+          "item_counts": {
+            "rubric_items": 138,
+            "critical_items": 2,
+            "precheck_items": 0,
+            "judge_items": 138
+          }
         },
         "Manufacturing": {
           "task_count": 5,
           "avg_pct": 83.94,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.7351
+          "judge_pass_rate": 0.7351,
+          "item_counts": {
+            "rubric_items": 268,
+            "critical_items": 4,
+            "precheck_items": 0,
+            "judge_items": 268
+          }
         },
         "Professional, Scientific, and Technical Services": {
           "task_count": 9,
           "avg_pct": 71.39,
           "critical_item_pass_rate": 0.4286,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.6411
+          "judge_pass_rate": 0.6411,
+          "item_counts": {
+            "rubric_items": 496,
+            "critical_items": 7,
+            "precheck_items": 0,
+            "judge_items": 496
+          }
         }
       },
       "by_rubric_category": {},
@@ -73884,7 +73908,13 @@
           "n_items": 1,
           "pass_rate": 1.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 1433,
+        "critical_items": 35,
+        "precheck_items": 0,
+        "judge_items": 1433
+      }
     },
     "cost": {
       "total_judge_calls": 3823,

--- a/data/grades/_diagnostic/8e8569d557634ee40e29c456fdaa057cdedc7084fac61444a5a02c3152d1b809/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_7392238d5f21a1f8__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_e23d7898c04f6b63__v2.2.json
+++ b/data/grades/_diagnostic/8e8569d557634ee40e29c456fdaa057cdedc7084fac61444a5a02c3152d1b809/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_7392238d5f21a1f8__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_e23d7898c04f6b63__v2.2.json
@@ -2080,7 +2080,13 @@
           "avg_pct": 26.79,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.15
+          "judge_pass_rate": 0.15,
+          "item_counts": {
+            "rubric_items": 37,
+            "critical_items": 1,
+            "precheck_items": 0,
+            "judge_items": 40
+          }
         }
       },
       "by_rubric_category": {},
@@ -2142,7 +2148,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 37,
+        "critical_items": 1,
+        "precheck_items": 0,
+        "judge_items": 40
+      }
     },
     "cost": {
       "total_judge_calls": 120,

--- a/data/grades/_diagnostic/916c151265850ae5deb8368e8aecfb528309c0f00bb3fe071f40b643e06afa64/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_57684c7c4318f28b__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_4992ad4fc8ec5027__v2.2.json
+++ b/data/grades/_diagnostic/916c151265850ae5deb8368e8aecfb528309c0f00bb3fe071f40b643e06afa64/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_57684c7c4318f28b__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_4992ad4fc8ec5027__v2.2.json
@@ -3830,7 +3830,13 @@
           "avg_pct": 26.37,
           "critical_item_pass_rate": 0.5,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.1918
+          "judge_pass_rate": 0.1918,
+          "item_counts": {
+            "rubric_items": 69,
+            "critical_items": 4,
+            "precheck_items": 0,
+            "judge_items": 73
+          }
         }
       },
       "by_rubric_category": {},
@@ -3907,7 +3913,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 69,
+        "critical_items": 4,
+        "precheck_items": 0,
+        "judge_items": 73
+      }
     },
     "cost": {
       "total_judge_calls": 233,

--- a/data/grades/_diagnostic/916c151265850ae5deb8368e8aecfb528309c0f00bb3fe071f40b643e06afa64/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_67e0836c459114ee__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_322a6c10c2939c44__v2.2.json
+++ b/data/grades/_diagnostic/916c151265850ae5deb8368e8aecfb528309c0f00bb3fe071f40b643e06afa64/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_67e0836c459114ee__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_322a6c10c2939c44__v2.2.json
@@ -3759,7 +3759,13 @@
           "avg_pct": 32.56,
           "critical_item_pass_rate": 0.5,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.2466
+          "judge_pass_rate": 0.2466,
+          "item_counts": {
+            "rubric_items": 68,
+            "critical_items": 4,
+            "precheck_items": 0,
+            "judge_items": 73
+          }
         }
       },
       "by_rubric_category": {},
@@ -3836,7 +3842,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 68,
+        "critical_items": 4,
+        "precheck_items": 0,
+        "judge_items": 73
+      }
     },
     "cost": {
       "total_judge_calls": 237,

--- a/data/grades/_diagnostic/916c151265850ae5deb8368e8aecfb528309c0f00bb3fe071f40b643e06afa64/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_ddacb72418fc5400__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_2dd404b2dadbec54__v2.2.json
+++ b/data/grades/_diagnostic/916c151265850ae5deb8368e8aecfb528309c0f00bb3fe071f40b643e06afa64/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_ddacb72418fc5400__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_2dd404b2dadbec54__v2.2.json
@@ -3750,7 +3750,13 @@
           "avg_pct": 31.87,
           "critical_item_pass_rate": 0.5,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.1507
+          "judge_pass_rate": 0.1507,
+          "item_counts": {
+            "rubric_items": 43,
+            "critical_items": 4,
+            "precheck_items": 0,
+            "judge_items": 73
+          }
         }
       },
       "by_rubric_category": {},
@@ -3827,7 +3833,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 43,
+        "critical_items": 4,
+        "precheck_items": 0,
+        "judge_items": 73
+      }
     },
     "cost": {
       "total_judge_calls": 212,

--- a/data/grades/_diagnostic/916c151265850ae5deb8368e8aecfb528309c0f00bb3fe071f40b643e06afa64/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_ddacb72418fc5400__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_f9ecc9e27ceb57b4__v2.2.json
+++ b/data/grades/_diagnostic/916c151265850ae5deb8368e8aecfb528309c0f00bb3fe071f40b643e06afa64/exp_gold_baseline__judge_gpt-5_6-sol__gold_smoke_audio_v2_sol_max__cfg_ddacb72418fc5400__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_f9ecc9e27ceb57b4__v2.2.json
@@ -3764,7 +3764,13 @@
           "avg_pct": 26.41,
           "critical_item_pass_rate": 0.5,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.1233
+          "judge_pass_rate": 0.1233,
+          "item_counts": {
+            "rubric_items": 50,
+            "critical_items": 4,
+            "precheck_items": 0,
+            "judge_items": 73
+          }
         }
       },
       "by_rubric_category": {},
@@ -3841,7 +3847,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 50,
+        "critical_items": 4,
+        "precheck_items": 0,
+        "judge_items": 73
+      }
     },
     "cost": {
       "total_judge_calls": 229,

--- a/data/grades/_diagnostic/b16d9b188a763fa9382d9b18df796b2f08cf284b47619195a2feba963149063c/_repeats/run-002/exp_gold_baseline__judge_gpt-5_6-sol__gold_audio_repeat_v2_sol_max__cfg_ed9ac99c7332a184__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_29c3cfe7e94e4881__v2.2.json
+++ b/data/grades/_diagnostic/b16d9b188a763fa9382d9b18df796b2f08cf284b47619195a2feba963149063c/_repeats/run-002/exp_gold_baseline__judge_gpt-5_6-sol__gold_audio_repeat_v2_sol_max__cfg_ed9ac99c7332a184__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_29c3cfe7e94e4881__v2.2.json
@@ -5810,7 +5810,13 @@
           "avg_pct": 45.1,
           "critical_item_pass_rate": 0.5,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.3981
+          "judge_pass_rate": 0.3981,
+          "item_counts": {
+            "rubric_items": 104,
+            "critical_items": 4,
+            "precheck_items": 0,
+            "judge_items": 108
+          }
         }
       },
       "by_rubric_category": {},
@@ -5887,7 +5893,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 104,
+        "critical_items": 4,
+        "precheck_items": 0,
+        "judge_items": 108
+      }
     },
     "cost": {
       "total_judge_calls": 351,

--- a/data/grades/_diagnostic/b16d9b188a763fa9382d9b18df796b2f08cf284b47619195a2feba963149063c/_repeats/run-003/exp_gold_baseline__judge_gpt-5_6-sol__gold_audio_repeat_v2_sol_max__cfg_ed9ac99c7332a184__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_29c3cfe7e94e4881__v2.2.json
+++ b/data/grades/_diagnostic/b16d9b188a763fa9382d9b18df796b2f08cf284b47619195a2feba963149063c/_repeats/run-003/exp_gold_baseline__judge_gpt-5_6-sol__gold_audio_repeat_v2_sol_max__cfg_ed9ac99c7332a184__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_29c3cfe7e94e4881__v2.2.json
@@ -5801,7 +5801,13 @@
           "avg_pct": 44.23,
           "critical_item_pass_rate": 0.5,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.3796
+          "judge_pass_rate": 0.3796,
+          "item_counts": {
+            "rubric_items": 104,
+            "critical_items": 4,
+            "precheck_items": 0,
+            "judge_items": 108
+          }
         }
       },
       "by_rubric_category": {},
@@ -5878,7 +5884,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 104,
+        "critical_items": 4,
+        "precheck_items": 0,
+        "judge_items": 108
+      }
     },
     "cost": {
       "total_judge_calls": 342,

--- a/data/grades/_diagnostic/b16d9b188a763fa9382d9b18df796b2f08cf284b47619195a2feba963149063c/exp_gold_baseline__judge_gpt-5_6-sol__gold_audio_repeat_v2_sol_max__cfg_ed9ac99c7332a184__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_29c3cfe7e94e4881__v2.2.json
+++ b/data/grades/_diagnostic/b16d9b188a763fa9382d9b18df796b2f08cf284b47619195a2feba963149063c/exp_gold_baseline__judge_gpt-5_6-sol__gold_audio_repeat_v2_sol_max__cfg_ed9ac99c7332a184__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_11e7900cdcac61bc4daf59e65feb238acda98fbf__src_29c3cfe7e94e4881__v2.2.json
@@ -5804,7 +5804,13 @@
           "avg_pct": 46.07,
           "critical_item_pass_rate": 0.5,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.4074
+          "judge_pass_rate": 0.4074,
+          "item_counts": {
+            "rubric_items": 104,
+            "critical_items": 4,
+            "precheck_items": 0,
+            "judge_items": 108
+          }
         }
       },
       "by_rubric_category": {},
@@ -5881,7 +5887,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 104,
+        "critical_items": 4,
+        "precheck_items": 0,
+        "judge_items": 108
+      }
     },
     "cost": {
       "total_judge_calls": 346,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-hybrid__11e7900__v1__v2sm.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-hybrid__11e7900__v1__v2sm.json
@@ -161253,63 +161253,117 @@
           "avg_pct": 45.86,
           "critical_item_pass_rate": 0.3478,
           "precheck_pass_rate": 0.9524,
-          "judge_pass_rate": 0.2912
+          "judge_pass_rate": 0.2912,
+          "item_counts": {
+            "rubric_items": 1134,
+            "critical_items": 23,
+            "precheck_items": 42,
+            "judge_items": 1092
+          }
         },
         "Government": {
           "task_count": 25,
           "avg_pct": 52.32,
           "critical_item_pass_rate": 0.5161,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.3575
+          "judge_pass_rate": 0.3575,
+          "item_counts": {
+            "rubric_items": 1097,
+            "critical_items": 62,
+            "precheck_items": 34,
+            "judge_items": 1063
+          }
         },
         "Health Care and Social Assistance": {
           "task_count": 25,
           "avg_pct": 52.56,
           "critical_item_pass_rate": 0.3056,
           "precheck_pass_rate": 0.9231,
-          "judge_pass_rate": 0.35
+          "judge_pass_rate": 0.35,
+          "item_counts": {
+            "rubric_items": 1261,
+            "critical_items": 36,
+            "precheck_items": 104,
+            "judge_items": 1157
+          }
         },
         "Information": {
           "task_count": 25,
           "avg_pct": 40.56,
           "critical_item_pass_rate": 0.4235,
           "precheck_pass_rate": 0.5373,
-          "judge_pass_rate": 0.2812
+          "judge_pass_rate": 0.2812,
+          "item_counts": {
+            "rubric_items": 1045,
+            "critical_items": 85,
+            "precheck_items": 67,
+            "judge_items": 978
+          }
         },
         "Manufacturing": {
           "task_count": 25,
           "avg_pct": 46.59,
           "critical_item_pass_rate": 0.6078,
           "precheck_pass_rate": 0.7639,
-          "judge_pass_rate": 0.3174
+          "judge_pass_rate": 0.3174,
+          "item_counts": {
+            "rubric_items": 1348,
+            "critical_items": 51,
+            "precheck_items": 72,
+            "judge_items": 1276
+          }
         },
         "Professional, Scientific, and Technical Services": {
           "task_count": 25,
           "avg_pct": 34.24,
           "critical_item_pass_rate": 0.3208,
           "precheck_pass_rate": 0.86,
-          "judge_pass_rate": 0.2225
+          "judge_pass_rate": 0.2225,
+          "item_counts": {
+            "rubric_items": 1358,
+            "critical_items": 53,
+            "precheck_items": 50,
+            "judge_items": 1308
+          }
         },
         "Real Estate and Rental and Leasing": {
           "task_count": 25,
           "avg_pct": 53.19,
           "critical_item_pass_rate": 0.4957,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.4534
+          "judge_pass_rate": 0.4534,
+          "item_counts": {
+            "rubric_items": 1033,
+            "critical_items": 117,
+            "precheck_items": 36,
+            "judge_items": 997
+          }
         },
         "Retail Trade": {
           "task_count": 20,
           "avg_pct": 59.99,
           "critical_item_pass_rate": 0.8182,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.4489
+          "judge_pass_rate": 0.4489,
+          "item_counts": {
+            "rubric_items": 797,
+            "critical_items": 22,
+            "precheck_items": 24,
+            "judge_items": 773
+          }
         },
         "Wholesale Trade": {
           "task_count": 25,
           "avg_pct": 50.56,
           "critical_item_pass_rate": 0.4118,
           "precheck_pass_rate": 0.7727,
-          "judge_pass_rate": 0.3755
+          "judge_pass_rate": 0.3755,
+          "item_counts": {
+            "rubric_items": 1243,
+            "critical_items": 34,
+            "precheck_items": 66,
+            "judge_items": 1177
+          }
         }
       },
       "by_rubric_category": {},
@@ -161468,7 +161522,13 @@
         }
       ],
       "_v2sm_critical_items": 483,
-      "_v2sm_critical_right": 225
+      "_v2sm_critical_right": 225,
+      "item_counts": {
+        "rubric_items": 10453,
+        "critical_items": 483,
+        "precheck_items": 495,
+        "judge_items": 9958
+      }
     },
     "cost": {
       "total_judge_calls": 9821,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-mini__11e7900__v1__v2sm.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__gpt-5_4-mini__11e7900__v1__v2sm.json
@@ -161253,63 +161253,117 @@
           "avg_pct": 47.96,
           "critical_item_pass_rate": 0.5652,
           "precheck_pass_rate": 0.9524,
-          "judge_pass_rate": 0.3361
+          "judge_pass_rate": 0.3361,
+          "item_counts": {
+            "rubric_items": 1134,
+            "critical_items": 23,
+            "precheck_items": 42,
+            "judge_items": 1092
+          }
         },
         "Government": {
           "task_count": 25,
           "avg_pct": 54.77,
           "critical_item_pass_rate": 0.5968,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.4158
+          "judge_pass_rate": 0.4158,
+          "item_counts": {
+            "rubric_items": 1097,
+            "critical_items": 62,
+            "precheck_items": 34,
+            "judge_items": 1063
+          }
         },
         "Health Care and Social Assistance": {
           "task_count": 25,
           "avg_pct": 55.08,
           "critical_item_pass_rate": 0.5556,
           "precheck_pass_rate": 0.9231,
-          "judge_pass_rate": 0.4028
+          "judge_pass_rate": 0.4028,
+          "item_counts": {
+            "rubric_items": 1261,
+            "critical_items": 36,
+            "precheck_items": 104,
+            "judge_items": 1157
+          }
         },
         "Information": {
           "task_count": 25,
           "avg_pct": 49.45,
           "critical_item_pass_rate": 0.5412,
           "precheck_pass_rate": 0.5373,
-          "judge_pass_rate": 0.3691
+          "judge_pass_rate": 0.3691,
+          "item_counts": {
+            "rubric_items": 1045,
+            "critical_items": 85,
+            "precheck_items": 67,
+            "judge_items": 978
+          }
         },
         "Manufacturing": {
           "task_count": 25,
           "avg_pct": 48.41,
           "critical_item_pass_rate": 0.7255,
           "precheck_pass_rate": 0.7639,
-          "judge_pass_rate": 0.3582
+          "judge_pass_rate": 0.3582,
+          "item_counts": {
+            "rubric_items": 1348,
+            "critical_items": 51,
+            "precheck_items": 72,
+            "judge_items": 1276
+          }
         },
         "Professional, Scientific, and Technical Services": {
           "task_count": 25,
           "avg_pct": 35.34,
           "critical_item_pass_rate": 0.3774,
           "precheck_pass_rate": 0.86,
-          "judge_pass_rate": 0.2515
+          "judge_pass_rate": 0.2515,
+          "item_counts": {
+            "rubric_items": 1358,
+            "critical_items": 53,
+            "precheck_items": 50,
+            "judge_items": 1308
+          }
         },
         "Real Estate and Rental and Leasing": {
           "task_count": 25,
           "avg_pct": 53.89,
           "critical_item_pass_rate": 0.6496,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.4915
+          "judge_pass_rate": 0.4915,
+          "item_counts": {
+            "rubric_items": 1033,
+            "critical_items": 117,
+            "precheck_items": 36,
+            "judge_items": 997
+          }
         },
         "Retail Trade": {
           "task_count": 20,
           "avg_pct": 61.81,
           "critical_item_pass_rate": 0.8182,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.4799
+          "judge_pass_rate": 0.4799,
+          "item_counts": {
+            "rubric_items": 797,
+            "critical_items": 22,
+            "precheck_items": 24,
+            "judge_items": 773
+          }
         },
         "Wholesale Trade": {
           "task_count": 25,
           "avg_pct": 54.04,
           "critical_item_pass_rate": 0.6176,
           "precheck_pass_rate": 0.7727,
-          "judge_pass_rate": 0.4511
+          "judge_pass_rate": 0.4511,
+          "item_counts": {
+            "rubric_items": 1243,
+            "critical_items": 34,
+            "precheck_items": 66,
+            "judge_items": 1177
+          }
         }
       },
       "by_rubric_category": {},
@@ -161468,7 +161522,13 @@
         }
       ],
       "_v2sm_critical_items": 483,
-      "_v2sm_critical_right": 288
+      "_v2sm_critical_right": 288,
+      "item_counts": {
+        "rubric_items": 10453,
+        "critical_items": 483,
+        "precheck_items": 495,
+        "judge_items": 9958
+      }
     },
     "cost": {
       "total_judge_calls": 9958,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__default_v2_mini__cfg_f4baac0b08378549__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_fd58885f62867b3b__v2.2.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__default_v2_mini__cfg_f4baac0b08378549__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_fd58885f62867b3b__v2.2.json
@@ -1972,7 +1972,13 @@
           "avg_pct": 50.63,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.4167
+          "judge_pass_rate": 0.4167,
+          "item_counts": {
+            "rubric_items": 38,
+            "critical_items": 1,
+            "precheck_items": 2,
+            "judge_items": 36
+          }
         }
       },
       "by_rubric_category": {},
@@ -2034,7 +2040,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 38,
+        "critical_items": 1,
+        "precheck_items": 2,
+        "judge_items": 36
+      }
     },
     "cost": {
       "total_judge_calls": 128,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort10__cfg_b11acba425087d85__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_011ef05cf7f7a951__v2.2.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort10__cfg_b11acba425087d85__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_011ef05cf7f7a951__v2.2.json
@@ -22496,14 +22496,26 @@
           "avg_pct": 79.26,
           "critical_item_pass_rate": 0.4706,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.6667
+          "judge_pass_rate": 0.6667,
+          "item_counts": {
+            "rubric_items": 171,
+            "critical_items": 17,
+            "precheck_items": 0,
+            "judge_items": 171
+          }
         },
         "Professional, Scientific, and Technical Services": {
           "task_count": 5,
           "avg_pct": 36.22,
           "critical_item_pass_rate": 0.2,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.2917
+          "judge_pass_rate": 0.2917,
+          "item_counts": {
+            "rubric_items": 264,
+            "critical_items": 5,
+            "precheck_items": 0,
+            "judge_items": 264
+          }
         }
       },
       "by_rubric_category": {},
@@ -22585,7 +22597,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 435,
+        "critical_items": 22,
+        "precheck_items": 0,
+        "judge_items": 435
+      }
     },
     "cost": {
       "total_judge_calls": 1359,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort3__cfg_0a8e1f421ad46dc2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_9b8a9ae3288ec3e9__v2.2.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4-mini__validation_v2_mini_cohort3__cfg_0a8e1f421ad46dc2__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_9b8a9ae3288ec3e9__v2.2.json
@@ -7667,7 +7667,13 @@
           "avg_pct": 36.14,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.281
+          "judge_pass_rate": 0.281,
+          "item_counts": {
+            "rubric_items": 153,
+            "critical_items": 3,
+            "precheck_items": 0,
+            "judge_items": 153
+          }
         }
       },
       "by_rubric_category": {},
@@ -7729,7 +7735,13 @@
           "n_items": 3,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 153,
+        "critical_items": 3,
+        "precheck_items": 0,
+        "judge_items": 153
+      }
     },
     "cost": {
       "total_judge_calls": 536,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools_tight.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_4__rubric_v2_tools_tight.json
@@ -6783,14 +6783,26 @@
           "avg_pct": 80.36,
           "critical_item_pass_rate": 0.5294,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.6564
+          "judge_pass_rate": 0.6564,
+          "item_counts": {
+            "rubric_items": 171,
+            "critical_items": 17,
+            "precheck_items": 8,
+            "judge_items": 163
+          }
         },
         "Professional, Scientific, and Technical Services": {
           "task_count": 5,
           "avg_pct": 29.19,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.1912
+          "judge_pass_rate": 0.1912,
+          "item_counts": {
+            "rubric_items": 264,
+            "critical_items": 5,
+            "precheck_items": 13,
+            "judge_items": 251
+          }
         }
       },
       "by_rubric_category": {},
@@ -6872,7 +6884,13 @@
           "n_items": 1,
           "pass_rate": 1.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 435,
+        "critical_items": 22,
+        "precheck_items": 21,
+        "judge_items": 414
+      }
     },
     "cost": {
       "total_judge_calls": 414,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_1c967673eb8081a6__v2.2.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_1c967673eb8081a6__v2.2.json
@@ -514020,63 +514020,117 @@
           "avg_pct": 55.59,
           "critical_item_pass_rate": 0.2609,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.4146
+          "judge_pass_rate": 0.4146,
+          "item_counts": {
+            "rubric_items": 1268,
+            "critical_items": 23,
+            "precheck_items": 0,
+            "judge_items": 1271
+          }
         },
         "Government": {
           "task_count": 25,
           "avg_pct": 69.53,
           "critical_item_pass_rate": 0.5738,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.5734
+          "judge_pass_rate": 0.5734,
+          "item_counts": {
+            "rubric_items": 1094,
+            "critical_items": 61,
+            "precheck_items": 0,
+            "judge_items": 1097
+          }
         },
         "Health Care and Social Assistance": {
           "task_count": 22,
           "avg_pct": 60.93,
           "critical_item_pass_rate": 0.2727,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.4677
+          "judge_pass_rate": 0.4677,
+          "item_counts": {
+            "rubric_items": 1092,
+            "critical_items": 33,
+            "precheck_items": 0,
+            "judge_items": 1129
+          }
         },
         "Information": {
           "task_count": 25,
           "avg_pct": 49.74,
           "critical_item_pass_rate": 0.494,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.399
+          "judge_pass_rate": 0.399,
+          "item_counts": {
+            "rubric_items": 1025,
+            "critical_items": 83,
+            "precheck_items": 0,
+            "judge_items": 1045
+          }
         },
         "Manufacturing": {
           "task_count": 25,
           "avg_pct": 50.7,
           "critical_item_pass_rate": 0.7083,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.3865
+          "judge_pass_rate": 0.3865,
+          "item_counts": {
+            "rubric_items": 1344,
+            "critical_items": 48,
+            "precheck_items": 0,
+            "judge_items": 1348
+          }
         },
         "Professional, Scientific, and Technical Services": {
           "task_count": 25,
           "avg_pct": 46.77,
           "critical_item_pass_rate": 0.1837,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.3601
+          "judge_pass_rate": 0.3601,
+          "item_counts": {
+            "rubric_items": 1348,
+            "critical_items": 49,
+            "precheck_items": 0,
+            "judge_items": 1358
+          }
         },
         "Real Estate and Rental and Leasing": {
           "task_count": 24,
           "avg_pct": 59.75,
           "critical_item_pass_rate": 0.6316,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.5292
+          "judge_pass_rate": 0.5292,
+          "item_counts": {
+            "rubric_items": 971,
+            "critical_items": 114,
+            "precheck_items": 0,
+            "judge_items": 977
+          }
         },
         "Retail Trade": {
           "task_count": 19,
           "avg_pct": 71.01,
           "critical_item_pass_rate": 0.619,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.6146
+          "judge_pass_rate": 0.6146,
+          "item_counts": {
+            "rubric_items": 741,
+            "critical_items": 21,
+            "precheck_items": 0,
+            "judge_items": 742
+          }
         },
         "Wholesale Trade": {
           "task_count": 25,
           "avg_pct": 57.1,
           "critical_item_pass_rate": 0.1667,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.5004
+          "judge_pass_rate": 0.5004,
+          "item_counts": {
+            "rubric_items": 1237,
+            "critical_items": 30,
+            "precheck_items": 0,
+            "judge_items": 1243
+          }
         }
       },
       "by_rubric_category": {},
@@ -514233,7 +514287,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 10120,
+        "critical_items": 462,
+        "precheck_items": 0,
+        "judge_items": 10453
+      }
     },
     "cost": {
       "total_judge_calls": 23250,

--- a/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_595c7254caf8fbd7__v2.2.json
+++ b/data/grades/exp003_GPT52Chat_baseline_runner_exec__judge_gpt-5_6-sol__regrade_exp003_v2_sol_max_score_excluded__cfg_71c325eee0e48c13__rubric_11e7900cdcac61bc4daf59e65feb238acda98fbf__inference_9c639f506b8dfd5c0bb8675cb1e0c2a938a3905f__src_595c7254caf8fbd7__v2.2.json
@@ -521520,63 +521520,117 @@
           "avg_pct": 55.87,
           "critical_item_pass_rate": 0.2609,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.4194
+          "judge_pass_rate": 0.4194,
+          "item_counts": {
+            "rubric_items": 1271,
+            "critical_items": 23,
+            "precheck_items": 0,
+            "judge_items": 1271
+          }
         },
         "Government": {
           "task_count": 25,
           "avg_pct": 69.35,
           "critical_item_pass_rate": 0.6066,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.577
+          "judge_pass_rate": 0.577,
+          "item_counts": {
+            "rubric_items": 1092,
+            "critical_items": 61,
+            "precheck_items": 0,
+            "judge_items": 1097
+          }
         },
         "Health Care and Social Assistance": {
           "task_count": 25,
           "avg_pct": 62.15,
           "critical_item_pass_rate": 0.4118,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.4972
+          "judge_pass_rate": 0.4972,
+          "item_counts": {
+            "rubric_items": 1259,
+            "critical_items": 34,
+            "precheck_items": 0,
+            "judge_items": 1261
+          }
         },
         "Information": {
           "task_count": 25,
           "avg_pct": 49.21,
           "critical_item_pass_rate": 0.506,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.4077
+          "judge_pass_rate": 0.4077,
+          "item_counts": {
+            "rubric_items": 1043,
+            "critical_items": 83,
+            "precheck_items": 0,
+            "judge_items": 1045
+          }
         },
         "Manufacturing": {
           "task_count": 25,
           "avg_pct": 51.1,
           "critical_item_pass_rate": 0.6875,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.3924
+          "judge_pass_rate": 0.3924,
+          "item_counts": {
+            "rubric_items": 1345,
+            "critical_items": 48,
+            "precheck_items": 0,
+            "judge_items": 1348
+          }
         },
         "Professional, Scientific, and Technical Services": {
           "task_count": 25,
           "avg_pct": 46.69,
           "critical_item_pass_rate": 0.2,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.3675
+          "judge_pass_rate": 0.3675,
+          "item_counts": {
+            "rubric_items": 1350,
+            "critical_items": 50,
+            "precheck_items": 0,
+            "judge_items": 1358
+          }
         },
         "Real Estate and Rental and Leasing": {
           "task_count": 25,
           "avg_pct": 58.07,
           "critical_item_pass_rate": 0.6053,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.5111
+          "judge_pass_rate": 0.5111,
+          "item_counts": {
+            "rubric_items": 1028,
+            "critical_items": 114,
+            "precheck_items": 0,
+            "judge_items": 1033
+          }
         },
         "Retail Trade": {
           "task_count": 20,
           "avg_pct": 69.25,
           "critical_item_pass_rate": 0.5455,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.5797
+          "judge_pass_rate": 0.5797,
+          "item_counts": {
+            "rubric_items": 797,
+            "critical_items": 22,
+            "precheck_items": 0,
+            "judge_items": 797
+          }
         },
         "Wholesale Trade": {
           "task_count": 25,
           "avg_pct": 56.41,
           "critical_item_pass_rate": 0.1667,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.4916
+          "judge_pass_rate": 0.4916,
+          "item_counts": {
+            "rubric_items": 1236,
+            "critical_items": 30,
+            "precheck_items": 0,
+            "judge_items": 1243
+          }
         }
       },
       "by_rubric_category": {},
@@ -521733,7 +521787,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 10421,
+        "critical_items": 465,
+        "precheck_items": 0,
+        "judge_items": 10453
+      }
     },
     "cost": {
       "total_judge_calls": 24139,

--- a/data/grades/exp998_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1__v2sm.json
+++ b/data/grades/exp998_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1__v2sm.json
@@ -1528,14 +1528,26 @@
           "avg_pct": 83.6,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.7429
+          "judge_pass_rate": 0.7429,
+          "item_counts": {
+            "rubric_items": 42,
+            "critical_items": 0,
+            "precheck_items": 7,
+            "judge_items": 35
+          }
         },
         "Real Estate and Rental and Leasing": {
           "task_count": 1,
           "avg_pct": 66.88,
           "critical_item_pass_rate": 1.0,
           "precheck_pass_rate": 0.3333,
-          "judge_pass_rate": 0.4898
+          "judge_pass_rate": 0.4898,
+          "item_counts": {
+            "rubric_items": 52,
+            "critical_items": 1,
+            "precheck_items": 3,
+            "judge_items": 49
+          }
         }
       },
       "by_rubric_category": {},
@@ -1599,7 +1611,13 @@
         }
       ],
       "_v2sm_critical_items": 1,
-      "_v2sm_critical_right": 1
+      "_v2sm_critical_right": 1,
+      "item_counts": {
+        "rubric_items": 94,
+        "critical_items": 1,
+        "precheck_items": 10,
+        "judge_items": 84
+      }
     },
     "cost": {
       "total_judge_calls": 84,

--- a/data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1__v2sm.json
+++ b/data/grades/exp998_smoke_baseline_sample__gpt-5_4-pro__11e7900__v1__v2sm.json
@@ -1527,14 +1527,26 @@
           "avg_pct": 77.88,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.6286
+          "judge_pass_rate": 0.6286,
+          "item_counts": {
+            "rubric_items": 42,
+            "critical_items": 0,
+            "precheck_items": 7,
+            "judge_items": 35
+          }
         },
         "Real Estate and Rental and Leasing": {
           "task_count": 1,
           "avg_pct": 77.72,
           "critical_item_pass_rate": 1.0,
           "precheck_pass_rate": 0.3333,
-          "judge_pass_rate": 0.5714
+          "judge_pass_rate": 0.5714,
+          "item_counts": {
+            "rubric_items": 52,
+            "critical_items": 1,
+            "precheck_items": 3,
+            "judge_items": 49
+          }
         }
       },
       "by_rubric_category": {},
@@ -1598,7 +1610,13 @@
         }
       ],
       "_v2sm_critical_items": 1,
-      "_v2sm_critical_right": 1
+      "_v2sm_critical_right": 1,
+      "item_counts": {
+        "rubric_items": 94,
+        "critical_items": 1,
+        "precheck_items": 10,
+        "judge_items": 84
+      }
     },
     "cost": {
       "total_judge_calls": 84,

--- a/data/grades/exp998_smoke_baseline_sample__judge_gpt-5_4__rubric_v2_tools.json
+++ b/data/grades/exp998_smoke_baseline_sample__judge_gpt-5_4__rubric_v2_tools.json
@@ -1531,14 +1531,26 @@
           "avg_pct": 90.72,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 1.0,
-          "judge_pass_rate": 0.7714
+          "judge_pass_rate": 0.7714,
+          "item_counts": {
+            "rubric_items": 42,
+            "critical_items": 0,
+            "precheck_items": 7,
+            "judge_items": 35
+          }
         },
         "Real Estate and Rental and Leasing": {
           "task_count": 1,
           "avg_pct": 75.06,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 0.3333,
-          "judge_pass_rate": 0.5306
+          "judge_pass_rate": 0.5306,
+          "item_counts": {
+            "rubric_items": 52,
+            "critical_items": 1,
+            "precheck_items": 3,
+            "judge_items": 49
+          }
         }
       },
       "by_rubric_category": {},
@@ -1600,7 +1612,13 @@
           "n_items": 1,
           "pass_rate": 0.0
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 94,
+        "critical_items": 1,
+        "precheck_items": 10,
+        "judge_items": 84
+      }
     },
     "cost": {
       "total_judge_calls": 84,

--- a/data/grades/exp999_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1.json
+++ b/data/grades/exp999_smoke_baseline_sample__gpt-5_4-mini__11e7900__v1.json
@@ -737,7 +737,13 @@
           "avg_pct": 89.17,
           "critical_item_pass_rate": 0.0,
           "precheck_pass_rate": 0.0,
-          "judge_pass_rate": 0.8125
+          "judge_pass_rate": 0.8125,
+          "item_counts": {
+            "rubric_items": 16,
+            "critical_items": 0,
+            "precheck_items": 0,
+            "judge_items": 16
+          }
         }
       },
       "by_rubric_category": {},
@@ -794,7 +800,13 @@
           "n_items": 8,
           "pass_rate": 0.75
         }
-      ]
+      ],
+      "item_counts": {
+        "rubric_items": 16,
+        "critical_items": 0,
+        "precheck_items": 0,
+        "judge_items": 16
+      }
     },
     "cost": {
       "total_judge_calls": 16,

--- a/scripts/__tests__/test_a_denominator_thrown_away_is_still_recoverable.py
+++ b/scripts/__tests__/test_a_denominator_thrown_away_is_still_recoverable.py
@@ -1,0 +1,756 @@
+"""The counts under a published rate, recovered without re-grading.
+
+``step8_grade`` now emits ``summary.wow.item_counts`` beside the five ``wow``
+rates, so a ``0.0`` can be read as "none passed" or "none existed". It emits
+them only for runs graded after that change, and nothing re-grades a published
+file. On the corpus committed here **not one payload carries them**, and the
+distinction is unrecoverable for every run already published -- while twenty
+of the thirty-three payloads publish ``precheck_pass_rate: 0.0`` and all
+twenty prechecked nothing. Among them is the 185-task gold ceiling: 8,816
+judged items, zero prechecked, published as a 0% structural pass rate.
+
+They are recoverable, because the counters are a pure function of the
+``tasks`` array already in the file. That is the same basis the four analytic
+fields are rebuilt from, so ``backfill_summary_wow.py`` rebuilds these too and
+gates them the same way.
+
+What is pinned here is the gate rather than the arithmetic: counts arrive only
+where the current summariser still reproduces the file's published rates, a
+denominator of zero is written as ``0`` rather than omitted, no published
+number moves at any depth, and a file whose bytes another document has
+already vouched for is refused outright.
+
+Nothing here calls a model, grades anything, or spends anything.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import backfill_summary_wow as backfill  # noqa: E402
+
+SCRIPT = REPO_ROOT / "scripts" / "backfill_summary_wow.py"
+GRADES_ROOT = REPO_ROOT / "data" / "grades"
+
+#: The 185-task gold-ceiling cohort. Named because it is the run this change
+#: exists for: the flat ``glob("*.json")`` this walk replaced never reached it.
+GOLD_CEILING_COHORT = (
+    "cef3a5b9f1305f19437d6ee337936a065965f979325b95a41d1001747e6bfa18"
+)
+
+
+# --------------------------------------------------------------------------
+# fixtures: the smallest payloads that exercise each branch
+# --------------------------------------------------------------------------
+
+
+def _item(rid: str, weight: int, awarded: float, verdict: str, decided_by: str):
+    return {
+        "rubric_item_id": rid,
+        "criterion": "c",
+        "max_score": weight,
+        "awarded_score": awarded,
+        "verdict": verdict,
+        "decided_by": decided_by,
+        "required": None,
+        "evidence": "e",
+        "model_did_right": verdict == "pass",
+    }
+
+
+def _task(tid: str, items: list[dict], sector: str = "Finance"):
+    return {
+        "task_id": tid,
+        "sector": sector,
+        "occupation": "o",
+        "items": items,
+        "total_awarded": sum(i["awarded_score"] for i in items),
+        "total_max": sum(max(i["max_score"], 0) for i in items),
+        "pct": 50.0,
+        "critical_fail": False,
+        "gold_referenced": False,
+        "judge_call_count": 1,
+        "precheck_count": sum(1 for i in items if i["decided_by"] == "precheck"),
+        "judge_total_latency_ms": 1,
+        "judge_input_tokens": 1,
+        "judge_output_tokens": 1,
+        "error": None,
+        "graded_at": "2026-05-29T00:00:00Z",
+    }
+
+
+def _payload(tasks: list[dict], **wow_overrides) -> dict:
+    """A grade file as published *before* counts existed.
+
+    The five rates are the ones the current summariser computes, so the file
+    agrees with itself and the semantics gate opens. ``item_counts`` is absent,
+    which is the state every committed payload is in.
+    """
+    computed = backfill._compute_summary(tasks)["wow"]
+    wow = {k: computed[k] for k in backfill.SCALAR_RATES}
+    wow.update(
+        {
+            "by_sector": {},
+            "by_rubric_category": {},
+            "score_density_histogram": [],
+            "rubric_severity_curve": [],
+        }
+    )
+    wow.update(wow_overrides)
+    return {
+        "schema_version": "1.2",
+        "experiment_id": "exp_test",
+        "experiment_yaml_name": "exp_test",
+        "tasks": tasks,
+        "summary": {
+            "total_tasks": len(tasks),
+            "graded_tasks": len(tasks),
+            "error_tasks": 0,
+            "openai_compat": {"avg_score_pct": 50.0},
+            "wow": wow,
+        },
+    }
+
+
+#: Judged and prechecked. Every denominator is non-empty.
+MEASURED = [
+    _task(
+        "t1",
+        [
+            _item("r1", 10, 10, "pass", "judge"),
+            _item("r2", 5, 0, "fail", "judge"),
+            _item("r3", 4, 4, "pass", "precheck"),
+        ],
+    )
+]
+
+#: Judged, never prechecked -- the shape twenty committed payloads are in.
+#: ``precheck_pass_rate`` comes out ``0.0`` from an empty denominator.
+NEVER_PRECHECKED = [
+    _task(
+        "t1",
+        [
+            _item("r1", 10, 10, "pass", "judge"),
+            _item("r2", 5, 0, "fail", "judge"),
+        ],
+    )
+]
+
+
+def _write(dirpath: Path, name: str, payload: dict) -> Path:
+    dirpath.mkdir(parents=True, exist_ok=True)
+    path = dirpath / name
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    return path
+
+
+def _run(grades_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(grades_dir), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _wow(path: Path) -> dict:
+    return json.loads(path.read_text())["summary"]["wow"]
+
+
+# --------------------------------------------------------------------------
+# the counts arrive, and an empty denominator is legible as empty
+# --------------------------------------------------------------------------
+
+
+def test_a_published_file_gets_back_the_denominators_it_discarded(tmp_path: Path):
+    path = _write(tmp_path, "measured.json", _payload(MEASURED))
+    assert "item_counts" not in _wow(path)
+
+    result = _run(tmp_path, "--apply")
+    assert result.returncode == 0, result.stderr
+
+    assert _wow(path)["item_counts"] == {
+        "rubric_items": 3,
+        "critical_items": 3,
+        "precheck_items": 1,
+        "judge_items": 2,
+    }
+
+
+def test_a_run_that_prechecked_nothing_now_says_nothing_rather_than_zero(
+    tmp_path: Path,
+):
+    """The whole point, on the shape twenty committed payloads are in.
+
+    The rate stays ``0.0`` -- it is published, and moving it is out of bounds.
+    What changes is that ``precheck_items: 0`` sits beside it, so the reader
+    can tell "no precheck passed" from "no precheck ran". Writing the counts
+    but dropping the zero entries would lose exactly the case they exist for.
+    """
+    path = _write(tmp_path, "unprechecked.json", _payload(NEVER_PRECHECKED))
+    before = _wow(path)
+    assert before["precheck_pass_rate"] == 0.0
+
+    assert _run(tmp_path, "--apply").returncode == 0
+
+    after = _wow(path)
+    assert after["precheck_pass_rate"] == 0.0, "a published rate moved"
+    assert after["item_counts"]["precheck_items"] == 0
+    assert after["item_counts"]["judge_items"] == 2
+
+
+def test_the_zero_denominator_is_reported_out_loud(tmp_path: Path):
+    """A dry run has to name what was never measured, or nobody looks."""
+    _write(tmp_path, "unprechecked.json", _payload(NEVER_PRECHECKED))
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "nothing measured for ['precheck_items']" in result.stdout
+
+
+# --------------------------------------------------------------------------
+# the semantics gate: counts are a denominator, so they follow the rates
+# --------------------------------------------------------------------------
+
+
+def test_counts_are_withheld_where_the_summariser_no_longer_agrees(
+    tmp_path: Path,
+):
+    """A recomputed denominator under a published numerator is a fiction.
+
+    These are the pre-sign-aware files: no ``model_did_right``, so
+    ``critical_item_pass_rate`` recomputes to ``0.0`` against a published
+    ``0.5``. The file is written under the old semantics and the summariser
+    reads it under the new ones. Attaching this summariser's count to that
+    file's rate would state a fraction nobody ever computed -- worse than
+    leaving it absent, because absent at least reads as unknown.
+    """
+    tasks = json.loads(json.dumps(MEASURED))
+    for item in tasks[0]["items"]:
+        item.pop("model_did_right")
+    payload = _payload(tasks, critical_item_pass_rate=0.5)
+    path = _write(tmp_path, "presign.json", payload)
+
+    result = _run(tmp_path, "--apply")
+    assert result.returncode == 0, result.stderr
+
+    after = _wow(path)
+    assert after["critical_item_pass_rate"] == 0.5, "a published rate moved"
+    assert "item_counts" not in after, (
+        "counts were attached to a file whose rates this summariser cannot "
+        "reproduce, so the fraction they complete was never computed by anyone"
+    )
+    assert after["score_density_histogram"], (
+        "the semantics-free field should still have been written"
+    )
+
+
+# --------------------------------------------------------------------------
+# no published number moves, at any depth
+# --------------------------------------------------------------------------
+
+
+def test_no_published_rate_is_ever_in_the_writable_set(tmp_path: Path):
+    """Guard 2 is a runtime backstop for a property held statically here.
+
+    Nothing the script writes can move a top-level rate, because the five
+    rates are in none of the writable tuples -- which is why Guard 2 cannot
+    fire today and why asserting on it directly would prove nothing. The
+    failure it guards against is a future edit adding a field to one of those
+    tuples without noticing it is published. That is what this reads.
+    """
+    writable = (
+        set(backfill.ANALYTIC_FIELDS)
+        | set(backfill.COUNT_FIELDS)
+        | set(backfill.SEMANTICS_FREE_FIELDS)
+    )
+    overlap = writable & set(backfill.SCALAR_RATES)
+
+    assert not overlap, (
+        f"{sorted(overlap)} is both published and rewritten by this script; "
+        "recomputing it would restate a number the corpus already asserts"
+    )
+
+    # And the guard that would catch it at runtime is still wired.
+    path = _write(tmp_path, "measured.json", _payload(MEASURED))
+    assert backfill.backfill_one(path, apply=False)["status"] == "would-write"
+
+
+def test_a_moved_per_sector_rate_aborts_the_file(tmp_path: Path):
+    """Guard 3. ``by_sector`` is rewritten wholesale and each row carries the
+    same rates as the block above it, which ``SectorHeatmap.tsx`` renders.
+    Guard 2 reads only the top level, so without this the script's stated
+    property was being enforced one level shallower than it was written.
+    """
+    payload = _payload(MEASURED)
+    payload["summary"]["wow"]["by_sector"] = {
+        "Finance": {
+            "task_count": 1,
+            "avg_pct": 50.0,
+            "critical_item_pass_rate": 0.99,  # published; recomputes to 0.6667
+            "precheck_pass_rate": 1.0,
+            "judge_pass_rate": 0.5,
+        }
+    }
+    path = _write(tmp_path, "sector.json", payload)
+    before = path.read_text()
+
+    report = backfill.backfill_one(path, apply=True)
+
+    assert report["status"] == "ABORTED"
+    assert "Finance.critical_item_pass_rate" in report["reason"]
+    assert path.read_text() == before, "an aborted file must not be written"
+
+
+def test_a_sector_row_gaining_only_counts_is_not_treated_as_a_move(
+    tmp_path: Path,
+):
+    """The negative control for the guard above.
+
+    Every published ``by_sector`` row lacks ``item_counts``, and recomputation
+    adds one. If Guard 3 counted that as a move it would abort all
+    twenty-seven writable files and the guard would look like it was working.
+    It does not, because the comparison walks the *published* row: a key the
+    file never had is never reached.
+    """
+    payload = _payload(MEASURED)
+    computed = backfill._compute_summary(MEASURED)["wow"]["by_sector"]
+    payload["summary"]["wow"]["by_sector"] = {
+        sector: {k: v for k, v in row.items() if k != "item_counts"}
+        for sector, row in computed.items()
+    }
+    path = _write(tmp_path, "sector_ok.json", payload)
+
+    report = backfill.backfill_one(path, apply=True)
+
+    assert report["status"] == "written"
+    assert _wow(path)["by_sector"]["Finance"]["item_counts"]["precheck_items"] == 1
+
+
+def test_a_sector_count_that_was_already_published_may_not_change(
+    tmp_path: Path,
+):
+    """A count is a published number too, once a file carries one.
+
+    Rows written by a post-counts grader arrive with ``item_counts`` already
+    in them. Nothing in scope today is in that state, which is exactly why it
+    needs pinning: the easy way to let a row gain counts is to exempt the key
+    from the comparison, and that would also let an existing one be quietly
+    restated.
+    """
+    payload = _payload(MEASURED)
+    computed = backfill._compute_summary(MEASURED)["wow"]["by_sector"]
+    payload["summary"]["wow"]["by_sector"] = json.loads(json.dumps(computed))
+    payload["summary"]["wow"]["by_sector"]["Finance"]["item_counts"][
+        "precheck_items"
+    ] = 99
+    path = _write(tmp_path, "sector_counts.json", payload)
+    before = path.read_text()
+
+    report = backfill.backfill_one(path, apply=True)
+
+    assert report["status"] == "ABORTED"
+    assert "Finance.item_counts" in report["reason"]
+    assert path.read_text() == before
+
+
+def test_nothing_outside_the_wow_block_is_touched(tmp_path: Path):
+    path = _write(tmp_path, "measured.json", _payload(MEASURED))
+    before = json.loads(path.read_text())
+
+    assert _run(tmp_path, "--apply").returncode == 0
+
+    after = json.loads(path.read_text())
+    before["summary"].pop("wow")
+    after["summary"].pop("wow")
+    assert before == after
+
+
+def test_a_dry_run_writes_nothing(tmp_path: Path):
+    path = _write(tmp_path, "measured.json", _payload(MEASURED))
+    before = path.read_text()
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0
+    assert path.read_text() == before
+    assert "dry run" in result.stdout
+
+
+# --------------------------------------------------------------------------
+# scope: which files the walk reaches
+# --------------------------------------------------------------------------
+
+
+def test_the_walk_descends_into_the_cohort_directories(tmp_path: Path):
+    """The flat glob this replaced reached eighteen files and none of the
+    diagnostic cohorts, so the corpus's clearest instance of the defect was
+    also the one instance the tool could not touch."""
+    nested = _write(
+        tmp_path / "_diagnostic" / "abc123" / "_repeats" / "run-002",
+        "grade.json",
+        _payload(NEVER_PRECHECKED),
+    )
+
+    assert _run(tmp_path, "--apply").returncode == 0
+
+    assert "item_counts" in _wow(nested)
+
+
+def test_shards_stay_out_of_scope(tmp_path: Path):
+    """A shard is an intermediate ``step9`` merges into the payload beside it.
+    Rewriting both would restate one run twice."""
+    shard = _write(
+        tmp_path / "_diagnostic" / "abc123" / "_shards",
+        "shard-000-of-011.json",
+        _payload(MEASURED),
+    )
+    merged = _write(tmp_path / "_diagnostic" / "abc123", "grade.json", _payload(MEASURED))
+
+    assert _run(tmp_path, "--apply").returncode == 0
+
+    assert "item_counts" not in _wow(shard)
+    assert "item_counts" in _wow(merged)
+
+
+def test_the_named_exclusion_still_applies(tmp_path: Path):
+    excluded = _write(tmp_path, "dummy_gpt5_baseline.json", _payload(MEASURED))
+    kept = _write(tmp_path, "real.json", _payload(MEASURED))
+    assert backfill.EXCLUDED == {"dummy_gpt5_baseline.json"}
+
+    assert _run(tmp_path, "--apply").returncode == 0
+
+    assert "item_counts" not in _wow(excluded)
+    assert "item_counts" in _wow(kept)
+
+
+# --------------------------------------------------------------------------
+# the digest seal: bytes another document has already vouched for
+# --------------------------------------------------------------------------
+
+
+def _tree(root: Path, documents: dict[str, str], track: bool = True) -> Path:
+    """A real git repository holding ``documents``, for git to be asked about.
+
+    Real, not a stub. The predecessor of this code kept a hand-written list of
+    protected paths and a test asserted its length, so the test agreed with the
+    list and neither agreed with the tree -- the first ``--apply`` rewrote two
+    sealed files and four unrelated tests were what noticed. A fake ``git grep``
+    here would reproduce that exact failure at one remove.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    for name, text in documents.items():
+        doc = root / name
+        doc.parent.mkdir(parents=True, exist_ok=True)
+        doc.write_text(text)
+    if track:
+        subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+    return root
+
+
+def test_a_document_that_states_a_files_digest_refuses_the_write(tmp_path: Path):
+    """Rewriting the file would not make that document stale. It would make it
+    false -- asserting a hash the bytes no longer have."""
+    root = tmp_path / "repo"
+    payload = _write(root / "data" / "grades", "sealed.json", _payload(MEASURED))
+    digest = hashlib.sha256(payload.read_bytes()).hexdigest()
+    _tree(root, {"EVIDENCE.md": f"reproduced at sha256 {digest}\n"})
+    before = payload.read_text()
+
+    report = backfill.backfill_one(payload, apply=True, tree=root)
+
+    assert report["status"] == "sealed"
+    assert "EVIDENCE.md" in report["reason"], (
+        "naming the document is the point -- the next person has to be able to "
+        f"read what it claims before moving it; got {report['reason']!r}"
+    )
+    assert payload.read_text() == before
+
+
+def test_the_same_file_is_written_when_nothing_vouches_for_it(tmp_path: Path):
+    """The negative control. Without it the test above passes just as well
+    against a function that refuses everything."""
+    root = tmp_path / "repo"
+    payload = _write(root / "data" / "grades", "free.json", _payload(MEASURED))
+    _tree(root, {"EVIDENCE.md": "no digests here\n"})
+
+    report = backfill.backfill_one(payload, apply=True, tree=root)
+
+    assert report["status"] == "written"
+    # MEASURED prechecks exactly one of its three items. The seal is the only
+    # thing separating this file from the one above, so the recovered
+    # denominator has to actually appear.
+    assert _wow(payload)["item_counts"]["precheck_items"] == 1
+
+
+def test_a_digest_abbreviated_to_sixteen_characters_still_seals(tmp_path: Path):
+    """The case that got past the first version and rewrote a sealed file.
+
+    ``PR3_REPEAT_VARIATION.md`` records the runs it compared as ``sha256``
+    followed by sixteen characters, the way a person writes a hash they expect
+    someone to eyeball. Searching for the full sixty-four found three of the six
+    sealed payloads and missed those three entirely.
+    """
+    root = tmp_path / "repo"
+    payload = _write(root / "data" / "grades", "abbrev.json", _payload(MEASURED))
+    short = hashlib.sha256(payload.read_bytes()).hexdigest()[:16]
+    _tree(root, {"PR3_REPEAT_VARIATION.md": f"run-002  final  sha256 {short}\n"})
+
+    report = backfill.backfill_one(payload, apply=True, tree=root)
+
+    assert report["status"] == "sealed"
+    assert "PR3_REPEAT_VARIATION.md" in report["reason"]
+
+
+def test_sixteen_characters_is_not_reaching_far_enough_to_invent_seals(
+    tmp_path: Path,
+):
+    """Sixty-four bits of prefix, and the reach is checked rather than assumed.
+
+    On the real corpus this flags the same six files that twelve characters
+    does, so the extra reach buys no false positives. Here: a digest that shares
+    the first eight characters and diverges inside the sixteen is a different
+    file and must not seal.
+    """
+    root = tmp_path / "repo"
+    payload = _write(root / "data" / "grades", "near.json", _payload(MEASURED))
+    digest = hashlib.sha256(payload.read_bytes()).hexdigest()
+    near_miss = digest[:8] + "".join("f" if c != "f" else "0" for c in digest[8:16])
+    assert near_miss != digest[:16]
+    _tree(root, {"EVIDENCE.md": f"sha256 {near_miss}\n"})
+
+    assert backfill.documents_asserting(payload, root) == []
+
+
+def test_an_untracked_note_does_not_seal_anything(tmp_path: Path):
+    """An untracked document asserting a digest is somebody's working note, not
+    a committed claim. Honouring it would make the refusal depend on what
+    happens to be lying around in the directory."""
+    root = tmp_path / "repo"
+    payload = _write(root / "data" / "grades", "free.json", _payload(MEASURED))
+    digest = hashlib.sha256(payload.read_bytes()).hexdigest()
+    _tree(root, {"scratch.md": f"sha256 {digest}\n"}, track=False)
+
+    assert backfill.documents_asserting(payload, root) == []
+
+
+def test_a_seal_may_live_beside_the_file_it_vouches_for(tmp_path: Path):
+    """Not a hypothetical: three of the six real seals are asserted by
+    ``data/grades/_validation/PR3_REPEAT_VARIATION.md``, which the walk itself
+    steps over. Being inside the walked tree does not make a document less of
+    an assertion."""
+    root = tmp_path / "repo"
+    grades = root / "data" / "grades"
+    payload = _write(grades, "run-002.json", _payload(MEASURED))
+    digest = hashlib.sha256(payload.read_bytes()).hexdigest()[:16]
+    _tree(root, {"data/grades/_validation/REPEATS.md": f"sha256 {digest}\n"})
+
+    assert backfill.documents_asserting(payload, root) == [
+        "data/grades/_validation/REPEATS.md"
+    ]
+
+
+def test_a_tree_that_cannot_be_asked_refuses_every_write(tmp_path: Path):
+    """Fail closed. A script that cannot find out what is sealed has no
+    business concluding that nothing is."""
+    not_a_repo = tmp_path / "plain"
+    payload = _write(not_a_repo / "data" / "grades", "x.json", _payload(MEASURED))
+    before = payload.read_text()
+
+    with pytest.raises(SystemExit) as excinfo:
+        backfill.backfill_one(payload, apply=True, tree=not_a_repo)
+
+    assert "Refusing" in str(excinfo.value)
+    assert payload.read_text() == before
+
+
+def test_git_being_absent_refuses_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The other way the question can go unanswered.
+
+    A tree that is not a repository comes back as exit 128, which the check
+    above covers. A missing ``git`` binary never reaches an exit code at all --
+    it raises ``OSError`` out of ``subprocess.run`` -- and an ``except`` that
+    swallowed it would read as "nothing is sealed" on a host where nothing
+    could be checked.
+    """
+    payload = _write(tmp_path, "x.json", _payload(MEASURED))
+
+    def no_git(*args, **kwargs):
+        raise OSError(2, "No such file or directory: 'git'")
+
+    monkeypatch.setattr(backfill.subprocess, "run", no_git)
+
+    with pytest.raises(SystemExit) as excinfo:
+        backfill.backfill_one(payload, apply=True)
+
+    assert "Refusing" in str(excinfo.value)
+
+
+def test_the_committed_backfill_added_denominators_and_nothing_else():
+    """What actually landed in the diff, read off the committed tree.
+
+    #188 introduced this script and ran it, so the analytic fields it was
+    written for are already populated wherever they legitimately can be.
+    Re-running it today recovers ``item_counts`` and touches nothing else --
+    but "nothing else" is a claim about a diff, and a docstring cannot hold a
+    diff honest. This reads every payload and checks that the only ``wow`` key
+    it carries beyond what ``_compute_summary`` would refuse is the one this
+    change is for.
+    """
+    grades = REPO_ROOT / "data" / "grades"
+    carried, sector_rows, empty_analytics = 0, 0, 0
+    for path in backfill.collect_grade_files(grades):
+        payload = json.loads(path.read_text())
+        if not isinstance(payload.get("tasks"), list):
+            continue
+        wow = (payload.get("summary") or {}).get("wow") or {}
+        if "item_counts" in wow:
+            carried += 1
+            counts = wow["item_counts"]
+            assert set(counts) == {
+                "rubric_items",
+                "critical_items",
+                "precheck_items",
+                "judge_items",
+            }, f"{backfill._display(path)} carries {sorted(counts)}"
+            assert counts["judge_items"] >= 0
+            # Every sector row must carry its own denominators too.
+            # SectorHeatmap.tsx draws a cell per sector off those rates, so a
+            # run-level count alone would leave each cell as ambiguous as it
+            # was.
+            for sector, row in (wow.get("by_sector") or {}).items():
+                assert "item_counts" in row, (
+                    f"{backfill._display(path)} sector {sector} has rates but "
+                    "no denominators"
+                )
+                sector_rows += 1
+        # by_rubric_category is empty everywhere on purpose; the other three
+        # are only empty where a guard refused them.
+        if backfill._is_empty(wow.get("by_sector")):
+            empty_analytics += 1
+
+    assert carried == 22, (
+        f"22 payloads should carry recovered denominators; {carried} do"
+    )
+    assert sector_rows == 62, (
+        f"62 sector rows should carry them as well; {sector_rows} do"
+    )
+    assert empty_analytics == 7, (
+        "seven payloads have no by_sector and every one is either sealed or "
+        f"semantics-diverged; found {empty_analytics}"
+    )
+
+
+def test_the_six_sealed_files_on_disk_are_still_sealed():
+    """Against the real repository, not a fixture.
+
+    Every test above builds the tree it queries, so all of them would keep
+    passing if the seals in this repository moved or the walk stopped reaching
+    them. This is the one that reads what is actually on disk -- including the
+    185-task gold ceiling, the corpus's clearest instance of the defect and a
+    file this change deliberately does not fix.
+    """
+    sealed = {
+        backfill._display(path): backfill.documents_asserting(path)
+        for path in backfill.collect_grade_files(REPO_ROOT / "data" / "grades")
+    }
+    sealed = {path: docs for path, docs in sealed.items() if docs}
+
+    assert len(sealed) == 6, f"expected six sealed payloads, found {sealed}"
+    assert any("79c2f503" in path for path in sealed), (
+        "the 185-task gold ceiling must still be refused; it is quoted as a "
+        "reproduction receipt in PR3_FULL_GOLD_CORPUS.md"
+    )
+    assert {doc for docs in sealed.values() for doc in docs} == {
+        "CHANGELOG.md",
+        "data/grades/_validation/PR3_REPEAT_VARIATION.md",
+        "scripts/__tests__/test_analyze_grade_run.py",
+        "scripts/__tests__/test_sol_max_anchor_selection.py",
+        "tasks/LATEST_TASK_RESULT/README.md",
+        "tasks/rebuilding_grading_task/PR3_FULL_GOLD_CORPUS.md",
+    }
+
+
+# --------------------------------------------------------------------------
+# the report has to name the file it is talking about
+# --------------------------------------------------------------------------
+
+
+def test_two_runs_that_differ_only_in_a_directory_print_differently():
+    """Truncation was the first attempt and it collided.
+
+    These names end in ``__src_<16hex>__v2.2.json``; a merged payload and its
+    ``_repeats/run-002`` re-run are identical for the last seventy characters
+    and differ only in a directory the tail never reaches. Six files on disk
+    collapse into two ambiguous groups of three that way -- three lines of
+    output, three different item counts, no way to tell which was which.
+    """
+    base = "data/grades/_diagnostic/" + "a" * 64 + "/"
+    tail = "exp_gold__cfg_" + "b" * 16 + "__rubric_" + "c" * 40 + "__v2.2.json"
+
+    merged = backfill._short(base + tail)
+    repeat = backfill._short(base + "_repeats/run-002/" + tail)
+
+    assert merged != repeat
+    assert "run-002" in repeat
+    assert len(merged) < len(base + tail), "digests should be abbreviated"
+    assert "a" * 64 not in merged
+
+
+def test_a_path_outside_the_repository_still_names_itself(tmp_path: Path):
+    assert backfill._display(tmp_path / "x.json") == "x.json"
+
+
+# --------------------------------------------------------------------------
+# the committed corpus, not a fixture
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not GRADES_ROOT.is_dir(), reason="no data/grades checkout")
+def test_the_gold_ceiling_run_is_inside_the_walk():
+    """The 185-task run is what the recursive walk was widened for."""
+    reachable = backfill.collect_grade_files(GRADES_ROOT)
+
+    assert any(
+        GOLD_CEILING_COHORT in path.parts for path in reachable
+    ), "the gold-ceiling cohort is out of scope again"
+
+
+@pytest.mark.skipif(not GRADES_ROOT.is_dir(), reason="no data/grades checkout")
+def test_every_zero_precheck_rate_on_disk_is_an_absence():
+    """Measured, not assumed.
+
+    If a genuine zero existed -- prechecks that ran and all failed -- the
+    counts would have to distinguish it from these, and any reading of "0%
+    means nothing ran" would be wrong. There is not one in the corpus.
+    """
+    absences, genuine = 0, []
+    for path in backfill.collect_grade_files(GRADES_ROOT):
+        document = json.loads(path.read_text())
+        wow = (document.get("summary") or {}).get("wow")
+        if not isinstance(document.get("tasks"), list) or not isinstance(wow, dict):
+            continue
+        if wow.get("precheck_pass_rate") != 0.0:
+            continue
+        counts = backfill._compute_summary(document["tasks"])["wow"]["item_counts"]
+        if counts["precheck_items"]:
+            genuine.append(backfill._short(backfill._display(path)))
+        else:
+            absences += 1
+
+    assert not genuine, f"a real 0% precheck rate exists after all: {genuine}"
+    assert absences >= 20, (
+        f"expected at least the twenty known absences, found {absences}"
+    )

--- a/scripts/backfill_summary_wow.py
+++ b/scripts/backfill_summary_wow.py
@@ -1,18 +1,50 @@
 #!/usr/bin/env python3
 """Recompute ``summary.wow`` for grade JSONs written before it was emitted.
 
-Every grade file on disk carries a ``summary.wow`` block whose four analytic
-fields -- ``by_sector``, ``by_rubric_category``, ``score_density_histogram``
-and ``rubric_severity_curve`` -- are empty, so the dashboard's sector heatmap,
-severity curve and score histogram have nothing to draw. The five scalar rates
-next to them are populated, which is why the gap is easy to miss.
+This script has run once already. #188 introduced it and applied it, and the
+four analytic fields it was written for -- ``by_sector``,
+``by_rubric_category``, ``score_density_histogram`` and
+``rubric_severity_curve`` -- are populated on this tree everywhere they
+legitimately can be. Running it again today writes none of them.
+
+What it now recovers is ``item_counts``, the denominators the ``wow`` rates
+were divided by. Each rate is a fraction whose denominator is discarded, and
+the fallback for an empty one is ``0.0`` -- indistinguishable from "every item
+failed", and the worst score on the scale. ``step8_grade`` began emitting the
+counts beside the rates after #188, but only for runs graded afterwards;
+nothing re-grades a published file, so on the corpus committed here **not one
+payload carries them**. Twenty files publish ``precheck_pass_rate: 0.0`` and
+every one of them prechecked nothing.
+
+So this pass adds ``item_counts`` and nothing else: once per file for the
+run as a whole, and once per sector row beside the rates that row already
+publishes -- twenty-two and sixty-two of them, eighty-four new keys, no other
+key added or changed anywhere in the twenty-two files. That is not by intent
+but by construction: every analytic field is recomputed and offered on every
+run, and the three guards below are what refuse the ones that would move a
+published number.
+
+The per-sector copy matters as much as the run-level one. ``SectorHeatmap.tsx``
+draws a cell per sector from those rates, so a sector that prechecked nothing
+renders the same 0% as a sector that prechecked forty items and failed all
+forty.
+
+The clearest case is the one this cannot fix. The 185-task gold ceiling judged
+8,816 items, ran 0 prechecks, and published a 0% structural pass rate -- and its
+exact bytes are quoted as a reproduction receipt in ``PR3_FULL_GOLD_CORPUS.md``,
+so it is refused here along with five others. That gap is printed on every run
+rather than left to be noticed; moving those seals is a separate change, because
+editing five evidence documents is not the same kind of act as adding a
+denominator, and a reviewer should not have to sort one from the other in a
+single diff.
 
 Nothing needs re-grading. Each field is a pure function of the ``tasks`` array
 already in the file, and ``step8_grade._compute_summary`` is that function.
 This script calls it on the file's own tasks and copies the recomputed ``wow``
 block back in.
 
-Two fields will still come back empty, and that is correct:
+Two of the analytic fields stay empty where they are empty, and that is
+correct:
 
 ``by_rubric_category``
     GDPVal rubric items have an id, a criterion string and a weight, and
@@ -30,7 +62,7 @@ Two fields will still come back empty, and that is correct:
 The safety property this script enforces: **no published number changes.**
 
 That is not automatic, and the first cut of this script got it wrong. Six of
-the seventeen files on disk were graded under semantics the current
+the thirty-three grade payloads on disk were graded under semantics the current
 summariser no longer reproduces. Recomputing their whole ``wow`` block moves
 published rates:
 
@@ -46,12 +78,24 @@ file's five published scalar rates exactly.** Agreement is the evidence that
 the same code understands the same file. Where it disagrees, only
 ``score_density_histogram`` is written -- it is a bucket count over the
 per-task ``pct`` values already published in the file, so it carries no
-semantic assumption at all.
+semantic assumption at all. ``item_counts`` is gated with the breakdowns, and
+for a sharper reason: a recomputed denominator under a published numerator it
+does not belong to states a fraction nobody ever computed.
 
-Everything outside ``summary.wow``, and the five scalar rates inside it, are
-compared before and after; the file is left untouched if any of it would
-move. Keys already present in ``wow`` that ``_compute_summary`` does not
-produce (``_v2sm_*``, written by ``backfill_sign_aware.py``) are preserved.
+Three guards enforce the property, on the parsed documents rather than on
+text, so key order and formatting can neither mask a real change nor invent a
+false one: nothing outside ``summary.wow`` moves, none of the five scalar
+rates moves, and no per-sector rate one level down moves either -- ``by_sector``
+is rewritten wholesale and each row carries the same rates, which
+``SectorHeatmap.tsx`` renders. Keys already present in ``wow`` that
+``_compute_summary`` does not produce (``_v2sm_*``, written by
+``backfill_sign_aware.py``) are preserved.
+
+The walk is recursive under ``data/grades``, minus ``_shards/``: a shard is an
+intermediate that ``step9`` merges into the payload beside it. Files whose bytes
+some other document has already vouched for are refused outright, and which
+files those are is asked of the repository rather than listed here -- six of the
+thirty-seven, including the gold ceiling above. See ``documents_asserting``.
 
 Dry-run by default. Pass ``--apply`` to write.
 """
@@ -59,7 +103,10 @@ from __future__ import annotations
 
 import argparse
 import copy
+import hashlib
 import json
+import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -78,6 +125,21 @@ ANALYTIC_FIELDS = (
     "score_density_histogram",
     "rubric_severity_curve",
 )
+
+#: The denominators each ``wow`` rate was divided by.
+#:
+#: Every rate in ``wow`` is a fraction whose denominator is discarded, and the
+#: fallback for an empty one is ``0.0`` -- the same value as "every item
+#: failed". ``step8_grade`` began publishing the counts alongside the rates so
+#: the two can be told apart, but only for runs graded afterwards. Nothing
+#: re-grades a published file, so on the corpus committed here the counts are
+#: absent everywhere and the distinction is unrecoverable: twenty payloads
+#: report ``precheck_pass_rate: 0.0`` and every one of them prechecked nothing.
+#:
+#: They are recoverable without re-grading, because the counters are a pure
+#: function of the ``tasks`` array already in the file -- the same basis as the
+#: four fields above, and gated the same way.
+COUNT_FIELDS = ("item_counts",)
 
 #: Published rates. These must be byte-identical before and after, always.
 SCALAR_RATES = (
@@ -101,22 +163,178 @@ def _is_empty(value: object) -> bool:
     )
 
 
+def _display(path: Path) -> str:
+    """Repo-relative where possible. Bare names collide once the walk is
+    recursive -- there are eleven ``shard-000-of-011.json`` on disk."""
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return path.name
+
+
+#: Any run of 12+ hex digits: the cohort directory (64), `rubric_`/`inference_`
+#: (40 each), `cfg_`/`src_` (16 each). Bounded by non-hex on both sides so a
+#: digest is shortened whole rather than clipped mid-run.
+_HEX_RUN = re.compile(r"(?<![0-9a-f])[0-9a-f]{12,}(?![0-9a-f])")
+
+
+def _short(display: str) -> str:
+    """A printable form of a path that is up to 339 characters long.
+
+    Shortened by abbreviating its digests, not by truncating it. Truncation
+    was the first attempt and it reintroduced exactly the collision
+    ``_display`` exists to prevent: the last seventy characters of these names
+    are ``...__src_<16hex>__v2.2.json``, and six files on disk share a tail
+    with another -- the merged payload of a cohort, and its ``_repeats/run-002``
+    and ``run-003`` re-runs, are identical there and differ only in a directory
+    the tail never reaches. Three lines of output, three different item counts,
+    no way to tell which was which.
+
+    Abbreviating instead cuts the longest path to 208 characters and keeps all
+    thirty-seven distinct. The digests are the redundant part anyway -- the same
+    ``rubric_11e7900c...`` appears on every line.
+    """
+    return _HEX_RUN.sub(lambda m: m.group()[:8] + "…", display)
+
+
 def _filled(wow: dict) -> int:
     return sum(1 for f in ANALYTIC_FIELDS if not _is_empty(wow.get(f)))
 
 
-def backfill_one(path: Path, apply: bool) -> dict:
+#: How much of a digest counts as an assertion about a file's bytes.
+#:
+#: Documents here abbreviate. ``PR3_REPEAT_VARIATION.md`` records each run it
+#: compared as ``sha256`` followed by sixteen characters -- the way a person
+#: writes a hash they expect someone to eyeball. Searching for the full
+#: sixty-four finds three of the six sealed payloads on this tree and misses
+#: those three completely, so the prefix is what gets searched.
+#:
+#: Sixteen is sixty-four bits. Measured, not assumed: it flags exactly the same
+#: six files as twelve does, so the extra reach is not buying false positives.
+#: A false positive would be the safe direction anyway -- it refuses a write.
+#:
+#: No digest is quoted anywhere in this file, deliberately. The first draft
+#: pasted a real one here as an example and sealed the run it belonged to,
+#: which is the mechanism working: a comment that states a digest is a document
+#: that states a digest. Describe the shape instead.
+DIGEST_PREFIX = 16
+
+
+def documents_asserting(path: Path, tree: Path = REPO_ROOT) -> list[str]:
+    """Tracked files in ``tree`` that state this file's current digest.
+
+    A document that records a file's sha256 is vouching for those exact bytes.
+    Rewriting the file does not make that document stale -- it makes it
+    **false**, asserting a hash the bytes no longer have. So anything vouched
+    for is refused, and the refusal names the documents so the next person can
+    read what they claim before deciding to move them.
+
+    This used to read one list: the shard digests in
+    ``stage3_partial_inventory.json``. That was wrong in the way a hand-kept
+    list is always wrong -- it was complete for the document it came from and
+    silently incomplete for the tree. It knew eleven files, all of them under
+    ``_shards/`` and therefore already out of the walk, and knew nothing about
+    the six that were actually in scope: the anchor payload sealed in
+    ``CHANGELOG.md``, the 185-task gold ceiling sealed in
+    ``PR3_FULL_GOLD_CORPUS.md``, and three repeat runs sealed in
+    ``PR3_REPEAT_VARIATION.md``. The first ``--apply`` rewrote two of them and
+    four tests went red saying so. Asking the repository is the version of this
+    that cannot fall behind the repository.
+
+    Tracked files only. An untracked document asserting a digest is somebody's
+    working note, not a committed claim, and treating it as one would make the
+    refusal depend on what happens to be lying around.
+
+    Fail closed. If the question cannot be asked there is no way to know what is
+    sealed, and refusing every write is the answer that cannot destroy evidence.
+    """
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()[:DIGEST_PREFIX]
+    try:
+        found = subprocess.run(
+            ["git", "-C", str(tree), "grep", "--full-name", "-l", "-F", digest],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise SystemExit(
+            f"cannot ask {tree} what it vouches for: {exc}. Refusing to write, "
+            "because a file this script cannot confirm is unsealed may be "
+            "evidence another document asserts a hash for."
+        ) from exc
+
+    # 0 found, 1 found nothing. Anything else is git failing to answer, which
+    # is not the same as answering "no".
+    if found.returncode not in (0, 1):
+        raise SystemExit(
+            f"`git grep` failed in {tree} (exit {found.returncode}): "
+            f"{found.stderr.strip()}. Refusing to write for the same reason."
+        )
+
+    try:
+        itself = str(path.resolve().relative_to(tree.resolve()))
+    except ValueError:
+        itself = ""
+    # A file cannot state its own digest -- that would take a preimage search --
+    # so this only ever drops a path git found for some other reason. It is here
+    # because a self-seal could never be cleared by editing the file, and that
+    # deadlock is worth one cheap set subtraction to rule out.
+    return sorted(set(found.stdout.split()) - {itself})
+
+
+def collect_grade_files(grades_dir: Path) -> list[Path]:
+    """Published grade payloads under ``grades_dir``.
+
+    Recursive, where this used to be a flat ``glob("*.json")``. The flat form
+    reached eighteen of the thirty-seven, and the nineteen it missed are not
+    leftovers: ten of the twenty-two files this writes sit under ``_diagnostic/``
+    and a flat walk reaches none of them.
+
+    Reachable is not the same as writable, and the 185-task gold ceiling is the
+    file that shows the difference. It is the corpus's clearest instance of the
+    defect -- 8,816 items judged, none prechecked, a 0% structural pass rate
+    published -- it lives under ``_diagnostic/``, and it is still not fixed here.
+    Not because the walk cannot see it, which it now can, but because
+    ``PR3_FULL_GOLD_CORPUS.md`` quotes its bytes. Those are two different
+    reasons and the earlier draft of this docstring ran them together, which
+    made a scope decision look like a prohibition.
+
+    ``_shards/`` stays out. A shard is an intermediate that ``step9`` merges
+    into the payload beside it; the merged file is the published unit, and
+    rewriting both would restate the same run twice. Every shard is also sealed
+    in ``stage3_partial_inventory.json``, so ``documents_asserting`` would
+    refuse them anyway -- this exclusion is a scope decision that could be
+    revisited, that refusal is not.
+    """
+    return [
+        path
+        for path in grades_dir.rglob("*.json")
+        if path.name not in EXCLUDED and "_shards" not in path.parts
+    ]
+
+
+def backfill_one(
+    path: Path, apply: bool, tree: Path = REPO_ROOT
+) -> dict:
     """Return a report for one file; write it only when ``apply`` is set."""
+    vouchers = documents_asserting(path, tree)
+    if vouchers:
+        return {
+            "path": _display(path),
+            "status": "sealed",
+            "reason": "digest asserted by " + ", ".join(vouchers),
+        }
+
     original_text = path.read_text()
     doc = json.loads(original_text)
 
     tasks = doc.get("tasks")
     summary = doc.get("summary")
     if not isinstance(tasks, list) or not isinstance(summary, dict):
-        return {"path": path.name, "status": "skipped", "reason": "no tasks/summary"}
+        return {"path": _display(path), "status": "skipped", "reason": "no tasks/summary"}
     old_wow = summary.get("wow")
     if not isinstance(old_wow, dict):
-        return {"path": path.name, "status": "skipped", "reason": "no summary.wow"}
+        return {"path": _display(path), "status": "skipped", "reason": "no summary.wow"}
 
     before_filled = _filled(old_wow)
 
@@ -129,8 +347,14 @@ def backfill_one(path: Path, apply: bool) -> dict:
     # by_sector and rubric_severity_curve are built from the same counters as
     # these scalars, so if the scalars disagree the breakdowns are describing
     # a grading semantics this file was never graded under.
+    #
+    # `item_counts` is gated the same way and for a sharper reason: it is
+    # the set of denominators those scalars were divided by. Attaching a
+    # recomputed denominator to a published numerator it does not belong to
+    # would state a fraction nobody ever computed -- worse than leaving it
+    # absent, because absent at least reads as unknown.
     diverged = [k for k in SCALAR_RATES if old_wow.get(k) != recomputed.get(k)]
-    writable = SEMANTICS_FREE_FIELDS if diverged else ANALYTIC_FIELDS
+    writable = SEMANTICS_FREE_FIELDS if diverged else ANALYTIC_FIELDS + COUNT_FIELDS
 
     new_wow = dict(old_wow)  # keep _v2sm_* and anything else non-standard
     for field in writable:
@@ -138,7 +362,7 @@ def backfill_one(path: Path, apply: bool) -> dict:
 
     if new_wow == old_wow:
         return {
-            "path": path.name,
+            "path": _display(path),
             "status": "unchanged",
             "before_filled": before_filled,
             "after_filled": before_filled,
@@ -156,7 +380,7 @@ def backfill_one(path: Path, apply: bool) -> dict:
     b["summary"].pop("wow", None)
     if a != b:
         return {
-            "path": path.name,
+            "path": _display(path),
             "status": "ABORTED",
             "reason": "a field outside summary.wow would change",
         }
@@ -167,9 +391,37 @@ def backfill_one(path: Path, apply: bool) -> dict:
     moved = [k for k in SCALAR_RATES if old_wow.get(k) != new_wow.get(k)]
     if moved:
         return {
-            "path": path.name,
+            "path": _display(path),
             "status": "ABORTED",
             "reason": f"published rate would change: {moved}",
+        }
+
+    # Guard 3: no published rate one level down moved either. `by_sector` is
+    # rewritten wholesale, and each row carries the same five-ish rates as the
+    # top-level block -- SectorHeatmap.tsx renders them. Guard 2 says nothing
+    # about those, so the docstring's "no published number changes" was being
+    # enforced one level shallower than it was stated. Measured across the
+    # agreeing files on disk: zero rows move, and the only difference is the
+    # `item_counts` this change adds. That is what makes the guard cheap to
+    # add rather than a thing to argue about.
+    #
+    # Iterating the *published* row is what makes adding `item_counts` legal
+    # without an exception for it: a key the file never had is never compared,
+    # while a key it did have -- including a count from a newer grader -- has
+    # to survive unchanged like any other published number.
+    sector_moved = []
+    for sector, old_row in (old_wow.get("by_sector") or {}).items():
+        new_row = (new_wow.get("by_sector") or {}).get(sector) or {}
+        sector_moved += [
+            f"{sector}.{field}"
+            for field, value in old_row.items()
+            if new_row.get(field) != value
+        ]
+    if sector_moved:
+        return {
+            "path": _display(path),
+            "status": "ABORTED",
+            "reason": f"published per-sector value would change: {sector_moved}",
         }
 
     changed = sorted(
@@ -185,13 +437,14 @@ def backfill_one(path: Path, apply: bool) -> dict:
         path.write_text(text)
 
     return {
-        "path": path.name,
+        "path": _display(path),
         "status": "written" if apply else "would-write",
         "before_filled": before_filled,
         "after_filled": _filled(new_wow),
         "changed": changed,
         "still_empty": still_empty,
         "diverged": diverged,
+        "counts": new_wow.get("item_counts") if "item_counts" in writable else None,
     }
 
 
@@ -204,28 +457,40 @@ def main() -> int:
         default=REPO_ROOT / "data" / "grades",
     )
     ap.add_argument("--apply", action="store_true", help="write files (default: dry run)")
+    ap.add_argument(
+        "--tree",
+        type=Path,
+        default=REPO_ROOT,
+        help="git repository to ask which digests are already vouched for",
+    )
     args = ap.parse_args()
 
-    files = sorted(p for p in args.grades_dir.glob("*.json") if p.name not in EXCLUDED)
+    files = sorted(collect_grade_files(args.grades_dir))
     if not files:
         print(f"no grade JSONs under {args.grades_dir}", file=sys.stderr)
         return 1
 
-    reports = [backfill_one(p, args.apply) for p in files]
+    reports = [backfill_one(p, args.apply, args.tree) for p in files]
     aborted = [r for r in reports if r["status"] == "ABORTED"]
     touched = [r for r in reports if r["status"] in ("written", "would-write")]
+    sealed = [r for r in reports if r["status"] == "sealed"]
 
     for r in reports:
-        if r["status"] in ("skipped", "unchanged"):
-            print(f"  {r['status']:<12} {r['path'][:70]}"
+        if r["status"] in ("skipped", "unchanged", "sealed"):
+            print(f"  {r['status']:<12} {_short(r['path'])}"
                   f"{'  (' + r['reason'] + ')' if r.get('reason') else ''}")
             continue
         if r["status"] == "ABORTED":
-            print(f"  ABORTED      {r['path'][:70]}  {r['reason']}")
+            print(f"  ABORTED      {_short(r['path'])}  {r['reason']}")
             continue
-        print(f"  {r['status']:<12} {r['path'][:70]}")
+        print(f"  {r['status']:<12} {_short(r['path'])}")
         print(f"      analytic fields filled: {r['before_filled']}/4 -> {r['after_filled']}/4")
         print(f"      changed: {r['changed']}")
+        if r.get("counts"):
+            counts = r["counts"]
+            unmeasured = sorted(k for k, v in counts.items() if v == 0)
+            print(f"      item_counts: {counts}"
+                  + (f"  <- nothing measured for {unmeasured}" if unmeasured else ""))
         if r.get("diverged"):
             print(f"      SEMANTICS DIVERGED on {r['diverged']} -- "
                   f"restricted to {list(SEMANTICS_FREE_FIELDS)}")
@@ -239,6 +504,14 @@ def main() -> int:
           f"{len(aborted)} aborted")
     print(f"{len(diverged)} files where the current summariser no longer reproduces "
           f"the published rates (semantics-free fields only)")
+    # Named, not just counted. These are the files the change does not reach,
+    # and one of them is the 185-task gold ceiling -- the clearest instance of
+    # the defect in the corpus. A count alone would let that read as routine.
+    print(f"{len(sealed)} files left alone because another document asserts "
+          f"their digest:")
+    for r in sealed:
+        print(f"    {_short(r['path'])}")
+        print(f"        {r['reason']}")
     if not args.apply and touched:
         print("\ndry run -- re-run with --apply to write")
     return 1 if aborted else 0


### PR DESCRIPTION
## The defect

Every rate under `summary.wow` is a fraction whose denominator is discarded on write, and the fallback for an empty one is `0.0` — the worst score on the scale, and indistinguishable from *every item failed*.

Twenty committed files publish `precheck_pass_rate: 0.0`. **Every one of them prechecked nothing.**

`step8_grade` began emitting `item_counts` beside the rates after #188, but only for runs graded afterwards, and nothing re-grades a published file. So on the corpus committed here **not one payload carries them**.

## What this writes

This is the **second pass** of `scripts/backfill_summary_wow.py`. #188 (`0e4a844`) introduced *and applied* it, and the four analytic fields it was written for — `by_sector`, `by_rubric_category`, `score_density_histogram`, `rubric_severity_curve` — are already populated wherever they legitimately can be. Running it again writes none of them.

What it adds is `item_counts` and nothing else:

| | |
|---|---|
| files considered | 37 |
| excluded by name | 1 |
| **written** | **22** |
| aborted by a guard | 0 |
| semantics-diverged | 5 |
| sealed by a document | 6 |
| **new keys** | **22 run-level + 62 per-sector = 84** |
| keys changed or removed | **0** |

That the diff is purely additive is by construction, not by intent: every analytic field is recomputed and offered on every run, and three guards refuse the ones that would move a published number. A second `--apply` writes 0 files.

The per-sector copy matters as much as the run-level one. `SectorHeatmap.tsx` draws a cell per sector off those rates, so a sector that prechecked nothing renders the same 0% as one that prechecked forty items and failed all forty.

## What it refuses to write

**Six files are sealed** because a committed document quotes their bytes — among them the 185-task gold ceiling (8,816 items judged, none prechecked, 0% structural pass rate published), the corpus's clearest instance of the defect. Rewriting a file whose sha256 another document asserts makes that document **false**, not stale.

The refusal is *discovered*, not declared: `git grep -l -F <sha256[:16]>` over tracked files. The predecessor kept a hand-written list of protected paths and a test asserted its length — so the test agreed with the list and neither agreed with the tree, and the first `--apply` rewrote two sealed files. `git` failing to answer, or being absent, refuses every write rather than reading as "nothing is sealed".

The 16-hex prefix is measured, not assumed: documents abbreviate digests, prefix-12 flags the identical six files (so the extra reach buys no false positives) and full-64 finds only three of the six.

**Five files diverge** — the current summariser no longer reproduces their published scalar rates, so attaching a recomputed denominator to a published numerator would state a fraction nobody ever computed. Worse than absent, because absent at least reads as unknown.

Follow-up filed: move the maintainable seals and backfill those six payloads.

## Also

The walk goes flat → recursive. The flat `glob("*.json")` reached 18 of 37 files; **ten of the 22 written here live under `_diagnostic/`**. `_shards/` stays excluded.

## Verification

| | |
|---|---|
| new tests | **27** |
| deliberate breakages of the implementation | **19, all caught** |
| `scripts/__tests__` | **171 passed** |
| backend suite | **7,491 passed / 7 skipped** — unchanged from baseline |
| mypy on the changed file | clean |
| grader source fingerprint | `0aa4c238880a1127…` **unmoved**, verified on both sides |
| grading runs in flight | 0 |
| cost | **$0** — no model calls |

Among the 19 breakages is the one that caused the real incident (searching the digest at full length instead of 16), and a test asserting the six files sealed *on disk today* are still sealed.

`_diagnostic/` and `_validation/` are outside the dashboard's flat `readdir`, so nothing here reaches the public site.