### PR TITLE
fix(validate): a file-required task with no row is not a pass

### DIFF
--- a/batch-runner/step5_validate.py
+++ b/batch-runner/step5_validate.py
@@ -8,6 +8,7 @@ Checks that the local snapshot is ready for HuggingFace upload:
   4. deliverable_files paths exist locally
   5. deliverable_text fill rate
     6. needs_files tasks with no files  <- WARNING + failure stats, no output mutation
+    6b. needs_files tasks with no row at all  <- ERROR; nothing was checked
   7. No duplicate task_ids
   8. deliverable_files local existence check
 
@@ -19,7 +20,7 @@ Input:
 Output:
   - Pass/fail with detailed report
   - workspace/validate_stats.json
-      file generation statistics (needs_files_total, succeeded, failed)
+      file generation statistics (needs_files_total, succeeded, failed, absent)
 
 Usage:
     python step5_validate.py
@@ -96,6 +97,12 @@ def _task_scope_errors(actual_task_ids: list[str], scope: dict) -> list[str]:
                 f"missing={len(missing)}, unexpected={len(unexpected)}"
             )
     return errors
+
+
+def _id_sample(task_ids: list[str], limit: int = 5) -> str:
+    """Render the first few IDs, saying how many more there are."""
+    suffix = f"... (+{len(task_ids) - limit} more)" if len(task_ids) > limit else ""
+    return f"{task_ids[:limit]}{suffix}"
 
 
 def _load_submission_repo_id() -> str | None:
@@ -228,8 +235,14 @@ def validate(data_dir: str = None) -> bool:
         "needs_files_total": 0,
         "files_succeeded": 0,
         "files_failed": 0,
+        # A file-required task the submission has no row for at all. Its
+        # deliverables were never looked at, so it is neither a success nor a
+        # failure, and folding it into either would make one of them a count of
+        # something nobody checked.
+        "files_absent": 0,
         "dummy_files_created": 0,
         "dummy_task_ids": [],
+        "absent_task_ids": [],
     }
 
     manifest_path = WORKSPACE_DIR / "step0_needs_files_manifest.json"
@@ -259,6 +272,7 @@ def validate(data_dir: str = None) -> bool:
         )
 
         needs_files_missing = []
+        needs_files_absent = []
         needs_files_total = 0
 
         selected_scope = (
@@ -273,6 +287,7 @@ def validate(data_dir: str = None) -> bool:
             needs_files_total += 1
             row = df[df["task_id"] == task_id]
             if len(row) == 0:
+                needs_files_absent.append(task_id)
                 continue
             files = _to_list(row.iloc[0]["deliverable_files"])
             if len(files) == 0:
@@ -282,20 +297,34 @@ def validate(data_dir: str = None) -> bool:
 
         file_gen_stats["needs_files_total"] = needs_files_total
         file_gen_stats["files_failed"] = len(needs_files_missing)
+        file_gen_stats["files_absent"] = len(needs_files_absent)
+        file_gen_stats["absent_task_ids"] = needs_files_absent
 
         if needs_files_missing:
-            sample = needs_files_missing[:5]
-            suffix = (
-                f"... (+{len(needs_files_missing) - 5} more)"
-                if len(needs_files_missing) > 5 else ""
-            )
             msg = (
                 f"{len(needs_files_missing)} file-required tasks had no files — "
                 "preserved as failed rows with empty deliverable fields"
             )
-            msg += f": {sample}{suffix}"
+            msg += f": {_id_sample(needs_files_missing)}"
             warnings.append(msg)
-        else:
+
+        # Absent is an error, not a warning: the manifest is generated from the
+        # source parquet under a digest check, so every ID in it is one of the
+        # canonical tasks the submission is required to carry. A subset run
+        # already fails this arrangement through the identity check in
+        # ``_task_scope_errors``; full runs carry no task_ids to check against,
+        # which is the only reason it could reach an upload unremarked.
+        if needs_files_absent:
+            errors.append(
+                f"{len(needs_files_absent)} file-required tasks are absent from "
+                "the submission — their deliverable files were never checked"
+                f": {_id_sample(needs_files_absent)}"
+            )
+
+        # Says what was observed, and only when everything was. The two lists
+        # being empty is the same statement as succeeded == total; written this
+        # way so the claim and its evidence cannot drift apart.
+        if not needs_files_missing and not needs_files_absent:
             warnings.append(
                 f"All {needs_files_total} file-required tasks have deliverable files ✓"
             )
@@ -332,6 +361,7 @@ def validate(data_dir: str = None) -> bool:
         print(f"      needs_files_total:   {file_gen_stats['needs_files_total']}")
         print(f"      files_succeeded:     {file_gen_stats['files_succeeded']}")
         print(f"      files_failed:        {file_gen_stats['files_failed']}")
+        print(f"      files_absent:        {file_gen_stats['files_absent']}")
         print(f"      dummy_files_created: {file_gen_stats['dummy_files_created']}")
 
     _print_result(errors, warnings)

--- a/batch-runner/step6_report.py
+++ b/batch-runner/step6_report.py
@@ -1002,17 +1002,31 @@ def _build_markdown(rd: dict) -> str:
         total_fg = fg["needs_files_total"]
         succeeded = fg["files_succeeded"]
         failed = fg["files_failed"]
+        # Tasks the submission had no row for. Absent on reports written before
+        # step5 counted them, where it means no record rather than none — which
+        # is why the row and the note below appear only when there are some.
+        absent = fg.get("files_absent") or 0
         pct = round(succeeded / total_fg * 100, 1) if total_fg else 0.0
+        rows = [
+            f"| Tasks requiring files | {total_fg} |",
+            f"| Successfully generated | {succeeded} ({pct}%) |",
+            f"| Failed (empty outputs preserved) | {failed} |",
+        ]
+        note = []
+        if absent:
+            rows.append(f"| Absent from submission (never checked) | {absent} |")
+            note = [
+                f"> {absent} of these {total_fg} tasks have no row in the "
+                "submission at all, so nothing was read for them. The "
+                f"{pct}% above is out of a denominator that includes them.",
+                "",
+            ]
         lines += [
             "## File Generation",
             "",
             "| Metric | Value |",
             "|--------|-------|",
-            f"| Tasks requiring files | {total_fg} |",
-            f"| Successfully generated | {succeeded} ({pct}%) |",
-            f"| Failed (empty outputs preserved) | {failed} |",
-            "",
-        ]
+        ] + rows + [""] + note
 
     # 5. Recovery Stats
     rc = rd.get("recovery_stats") or {}
@@ -1169,11 +1183,15 @@ def _build_html(rd: dict) -> str:
     fg_succeeded = fg.get("files_succeeded")
     if fg_total is not None and fg_total > 0:
         fg_pct = round(fg_succeeded / fg_total * 100, 1)
+        fg_absent = fg.get("files_absent") or 0
+        fg_sub = f"{fg_succeeded} / {fg_total} tasks"
+        if fg_absent:
+            fg_sub += f" — {fg_absent} never checked"
         fg_card = (
             f'<div class="card">'
             f'<div class="label">File Gen Rate</div>'
             f'<div class="value">{fg_pct}%</div>'
-            f'<div class="sub">{fg_succeeded} / {fg_total} tasks</div>'
+            f'<div class="sub">{fg_sub}</div>'
             f'</div>'
         )
     else:
@@ -1603,6 +1621,7 @@ def generate_report(
         "needs_files_total": None,
         "files_succeeded": None,
         "files_failed": None,
+        "files_absent": None,
         "dummy_files_created": None,
         "dummy_task_ids": [],
     }

--- a/batch-runner/tests/test_a_file_required_task_with_no_row_is_not_a_pass.py
+++ b/batch-runner/tests/test_a_file_required_task_with_no_row_is_not_a_pass.py
@@ -1,0 +1,254 @@
+"""A file-required task the submission has no row for is not a pass.
+
+``step5_validate`` cross-checks the needs_files manifest against the parquet it
+is about to upload. For every file-required task it looked up the row, read
+``deliverable_files``, and counted a success or a failure. A task the submission
+carried no row for fell out of both counts — nothing was read for it, so it was
+neither — and the summary line was printed from the failure list alone:
+
+    if not needs_files_missing:
+        warnings.append(f"All {needs_files_total} file-required tasks have deliverable files ✓")
+
+That is a claim about all N, made from the failures of the ones that were looked
+at. With one absent task it printed the same ✓ as a run where every file really
+was there, and ``succeeded + failed`` quietly stopped equalling ``total``.
+
+The manifest is not a wish list. ``core.repo_bootstrapper._generate_manifest_from_dir``
+builds it from the source parquet and refuses to emit one whose ordered task IDs
+do not hash to ``CANONICAL_ORDERED_TASK_IDS_SHA256``, so every key in it is one
+of the canonical tasks the submission is required to carry — an absent one is an
+integrity break, never a legitimate state. A subset run already failed this
+arrangement, through the identity check in ``_task_scope_errors``. Full runs
+carry no ``task_ids`` to check against, which is the only reason it could reach
+an upload unremarked.
+
+Pinned here:
+
+* the absent task fails the gate, in its own words;
+* the ✓ line is printed only when every file-required task was looked at;
+* ``succeeded + failed + absent == needs_files_total`` in every arrangement;
+* the two healthy arrangements keep their verdict, counts and wording exactly.
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+import step5_validate as step5
+
+_FULL_ROW_COUNT = 220
+_TICK = "file-required tasks have deliverable files ✓"
+
+
+def _canonical_ids() -> list[str]:
+    return [f"task-{index:03d}" for index in range(_FULL_ROW_COUNT)]
+
+
+def _write_parquet(upload: Path, task_ids: list[str], with_files: set[str]) -> None:
+    """Write a submission parquet, giving each ``with_files`` task one file."""
+    data_dir = upload / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (upload / "deliverable_files").mkdir(exist_ok=True)
+
+    files = []
+    for task_id in task_ids:
+        if task_id not in with_files:
+            files.append([])
+            continue
+        relative = f"deliverable_files/{task_id}.docx"
+        (upload / relative).write_bytes(b"deliverable")
+        files.append([relative])
+
+    empty = [[] for _ in task_ids]
+    pd.DataFrame({
+        "task_id": task_ids,
+        "sector": ["Information"] * len(task_ids),
+        "occupation": ["Analyst"] * len(task_ids),
+        "prompt": ["Create a file"] * len(task_ids),
+        "reference_files": empty,
+        "reference_file_urls": [[] for _ in task_ids],
+        "reference_file_hf_uris": [[] for _ in task_ids],
+        "deliverable_text": ["done"] * len(task_ids),
+        "deliverable_files": files,
+        "deliverable_file_urls": [[] for _ in task_ids],
+        "deliverable_file_hf_uris": [[] for _ in task_ids],
+    }).to_parquet(data_dir / "train-00000-of-00001.parquet", index=False)
+
+
+def _prepare(
+    tmp_path: Path,
+    *,
+    row_ids: list[str],
+    manifest_needs: dict[str, bool],
+    with_files: set[str],
+    scope: dict,
+) -> tuple[Path, Path]:
+    workspace = tmp_path / "workspace"
+    upload = workspace / "upload"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_parquet(upload, row_ids, with_files)
+    (workspace / "step1_tasks_prepared.json").write_text(
+        json.dumps({"task_scope": scope}), encoding="utf-8"
+    )
+    (workspace / "step0_needs_files_manifest.json").write_text(
+        json.dumps({
+            "tasks": {
+                task_id: {"needs_files": needed}
+                for task_id, needed in manifest_needs.items()
+            },
+            "_summary": {"active_policy": "deliverable_only"},
+        }),
+        encoding="utf-8",
+    )
+    return workspace, upload
+
+
+def _run(monkeypatch, workspace: Path, upload: Path) -> tuple[bool, dict]:
+    monkeypatch.setattr(step5, "WORKSPACE_DIR", workspace)
+    monkeypatch.setattr(step5, "UPLOAD_DIR", upload)
+    passed = step5.validate(data_dir=str(upload))
+    stats = json.loads(
+        (workspace / "validate_stats.json").read_text(encoding="utf-8")
+    )
+    return passed, stats
+
+
+# ── The three full-mode arrangements ──────────────────────────────────────
+# All 220 canonical rows are present in every one of them; they differ only in
+# which file-required task the submission actually carries. ``task-002`` is
+# text-only in the manifest, so it must stay out of the file counts.
+
+
+def _absent(tmp_path: Path) -> tuple[Path, Path]:
+    """One canonical file-required task is missing; a substitute took its row."""
+    row_ids = _canonical_ids()
+    row_ids[1] = "substitute-task"
+    return _prepare(
+        tmp_path,
+        row_ids=row_ids,
+        manifest_needs={"task-000": True, "task-001": True, "task-002": False},
+        with_files={"task-000"},
+        scope={"mode": "full", "expected_count": _FULL_ROW_COUNT},
+    )
+
+
+def _all_present(tmp_path: Path) -> tuple[Path, Path]:
+    return _prepare(
+        tmp_path,
+        row_ids=_canonical_ids(),
+        manifest_needs={"task-000": True, "task-001": True, "task-002": False},
+        with_files={"task-000", "task-001"},
+        scope={"mode": "full", "expected_count": _FULL_ROW_COUNT},
+    )
+
+
+def _one_failed(tmp_path: Path) -> tuple[Path, Path]:
+    return _prepare(
+        tmp_path,
+        row_ids=_canonical_ids(),
+        manifest_needs={"task-000": True, "task-001": True, "task-002": False},
+        with_files={"task-000"},
+        scope={"mode": "full", "expected_count": _FULL_ROW_COUNT},
+    )
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+def test_a_file_required_task_with_no_row_fails_the_gate(tmp_path, monkeypatch, capsys):
+    passed, stats = _run(monkeypatch, *_absent(tmp_path))
+    out = capsys.readouterr().out
+
+    assert passed is False
+    assert "Validation FAILED" in out
+    assert "1 file-required tasks are absent from the submission" in out
+    assert "their deliverable files were never checked" in out
+    assert "task-001" in out
+    assert stats["files_absent"] == 1
+
+
+def test_the_tick_is_printed_only_when_every_task_was_looked_at(
+    tmp_path, monkeypatch, capsys
+):
+    """The exact defect: both arrangements used to print the same ✓ line."""
+    _run(monkeypatch, *_absent(tmp_path / "absent"))
+    absent_out = capsys.readouterr().out
+
+    _run(monkeypatch, *_all_present(tmp_path / "all_present"))
+    all_present_out = capsys.readouterr().out
+
+    assert _TICK not in absent_out
+    assert f"All 2 {_TICK}" in all_present_out
+
+
+def test_the_parts_add_up_to_the_total_in_every_arrangement(tmp_path, monkeypatch):
+    for name, build in (
+        ("absent", _absent),
+        ("all_present", _all_present),
+        ("one_failed", _one_failed),
+    ):
+        _, stats = _run(monkeypatch, *build(tmp_path / name))
+        parts = (
+            stats["files_succeeded"] + stats["files_failed"] + stats["files_absent"]
+        )
+        assert parts == stats["needs_files_total"], name
+
+
+def test_an_absent_task_is_neither_a_success_nor_a_failure(tmp_path, monkeypatch):
+    _, stats = _run(monkeypatch, *_absent(tmp_path))
+
+    assert stats["needs_files_total"] == 2
+    assert stats["files_succeeded"] == 1
+    assert stats["files_failed"] == 0
+    assert stats["files_absent"] == 1
+    assert stats["absent_task_ids"] == ["task-001"]
+
+
+def test_a_run_where_every_task_was_looked_at_is_unchanged(
+    tmp_path, monkeypatch, capsys
+):
+    """새로운 기준이 기존 실험에 영향을 미치면 안 된다 — verdict, counts and wording."""
+    passed, stats = _run(monkeypatch, *_all_present(tmp_path / "all_present"))
+    out = capsys.readouterr().out
+
+    assert passed is True
+    assert "Validation PASSED" in out
+    assert f"All 2 {_TICK}" in out
+    assert (stats["needs_files_total"], stats["files_succeeded"]) == (2, 2)
+    assert (stats["files_failed"], stats["files_absent"]) == (0, 0)
+
+    passed, stats = _run(monkeypatch, *_one_failed(tmp_path / "one_failed"))
+    out = capsys.readouterr().out
+
+    assert passed is True
+    assert "Validation PASSED" in out
+    assert (
+        "1 file-required tasks had no files — preserved as failed rows with "
+        "empty deliverable fields: ['task-001']"
+    ) in out
+    assert _TICK not in out
+    assert (stats["needs_files_total"], stats["files_succeeded"]) == (2, 1)
+    assert (stats["files_failed"], stats["files_absent"]) == (1, 0)
+
+
+def test_a_subset_run_already_failed_this_arrangement(tmp_path, monkeypatch, capsys):
+    """Why full mode was the outlier: subset mode checks the IDs themselves."""
+    workspace, upload = _prepare(
+        tmp_path,
+        row_ids=["task-000", "substitute-task"],
+        manifest_needs={"task-000": True, "task-001": True},
+        with_files={"task-000"},
+        scope={
+            "mode": "explicit_ids",
+            "expected_count": 2,
+            "task_ids": ["task-000", "task-001"],
+        },
+    )
+    passed, stats = _run(monkeypatch, workspace, upload)
+    out = capsys.readouterr().out
+
+    assert passed is False
+    assert "Task scope mismatch: missing=1, unexpected=1" in out
+    assert "1 file-required tasks are absent from the submission" in out
+    assert stats["files_absent"] == 1

--- a/batch-runner/tests/test_step6_v2_fields.py
+++ b/batch-runner/tests/test_step6_v2_fields.py
@@ -540,6 +540,91 @@ def test_markdown_reports_failed_files_without_claiming_dummy_creation():
     assert "dummy created" not in markdown
 
 
+def _markdown_for_file_generation(file_generation: dict) -> str:
+    """Render the report markdown for one ``file_generation`` block."""
+    report = step6_report._build_report_data(
+        _make_result_payload(),
+        {"grading_referenced": False},
+        {
+            "total_tasks": 2,
+            "success_count": 1,
+            "success_rate_pct": 50.0,
+            "error_count": 1,
+            "retried_count": 0,
+            "avg_qa_score": 0,
+            "min_qa_score": 0,
+            "max_qa_score": 0,
+            "avg_latency_ms": 0,
+            "max_latency_ms": 0,
+            "total_latency_ms": 0,
+        },
+        [],
+        [],
+        [],
+    )
+    report["file_generation"] = file_generation
+    return step6_report._build_markdown(report)
+
+
+def _file_generation_section(markdown: str) -> str:
+    """The ``## File Generation`` block alone — the rest carries a timestamp."""
+    lines = markdown.splitlines()
+    start = lines.index("## File Generation")
+    end = next(
+        (
+            index
+            for index, line in enumerate(lines[start + 1:], start + 1)
+            if line.startswith("## ")
+        ),
+        len(lines),
+    )
+    return "\n".join(lines[start:end])
+
+
+def test_markdown_names_the_tasks_that_were_never_checked():
+    """A task with no row in the submission is in the denominator of the rate
+    printed above it, so the report has to say it was never looked at."""
+    markdown = _markdown_for_file_generation({
+        "needs_files_total": 2,
+        "files_succeeded": 1,
+        "files_failed": 0,
+        "files_absent": 1,
+        "dummy_files_created": 0,
+        "dummy_task_ids": [],
+    })
+
+    assert "| Successfully generated | 1 (50.0%) |" in markdown
+    assert "| Absent from submission (never checked) | 1 |" in markdown
+    assert "> 1 of these 2 tasks have no row in the submission at all" in markdown
+    assert "The 50.0% above is out of a denominator that includes them." in markdown
+
+
+def test_markdown_is_unchanged_when_no_task_was_absent():
+    """Nothing absent, and a report written before step5 counted them, render
+    exactly as they did before — no empty row, no note about a zero."""
+    counted = _markdown_for_file_generation({
+        "needs_files_total": 2,
+        "files_succeeded": 1,
+        "files_failed": 1,
+        "files_absent": 0,
+        "dummy_files_created": 0,
+        "dummy_task_ids": [],
+    })
+    legacy = _markdown_for_file_generation({
+        "needs_files_total": 2,
+        "files_succeeded": 1,
+        "files_failed": 1,
+        "dummy_files_created": 0,
+        "dummy_task_ids": [],
+    })
+
+    section = _file_generation_section(counted)
+    assert section == _file_generation_section(legacy)
+    assert "never checked" not in section
+    assert "no row in the submission" not in section
+    assert "| Failed (empty outputs preserved) | 1 |" in section
+
+
 def test_report_preserves_current_pipeline_publication_identity(
     monkeypatch, tmp_path
 ):

--- a/src/components/dashboard/ErrorAnalysisView.tsx
+++ b/src/components/dashboard/ErrorAnalysisView.tsx
@@ -282,6 +282,10 @@ export default function ErrorAnalysisView({ experiments, reports }: ErrorAnalysi
               const failRate = fg.needs_files_total > 0
                 ? ((fg.files_failed / fg.needs_files_total) * 100).toFixed(1)
                 : '0'
+              // Tasks with no row in the submission at all. They are in the
+              // denominator above but were never looked at, so a failure rate
+              // computed without saying so reads as a clean result.
+              const absent = fg.files_absent ?? 0
               return (
                 <div key={exp.short_id} className="space-y-2">
                   <ExpBadge id={exp.short_id} />
@@ -302,6 +306,12 @@ export default function ErrorAnalysisView({ experiments, reports }: ErrorAnalysi
                       <div className="text-[10px] text-dash-text-muted">Dummy Created</div>
                       <div className="font-mono font-semibold text-amber-400">{fg.dummy_files_created}</div>
                     </div>
+                    {absent > 0 && (
+                      <div className="col-span-2">
+                        <div className="text-[10px] text-dash-text-muted">Never checked (no row in submission)</div>
+                        <div className="font-mono font-semibold text-amber-400">{absent}</div>
+                      </div>
+                    )}
                   </div>
                   <div>
                     <div className="flex justify-between text-[10px] mb-0.5">
@@ -311,6 +321,12 @@ export default function ErrorAnalysisView({ experiments, reports }: ErrorAnalysi
                     <div className="w-full h-1.5 rounded-full bg-dash-card-hover overflow-hidden">
                       <div className="h-full rounded-full bg-red-500/60 transition-all duration-500" style={{ width: `${failRate}%` }} />
                     </div>
+                    {absent > 0 && (
+                      <div className="mt-1 text-[10px] leading-snug text-amber-400/90">
+                        {absent} of these tasks were never checked, so this rate is out of a
+                        denominator that includes them.
+                      </div>
+                    )}
                   </div>
                 </div>
               )

--- a/src/pages/ExperimentDetail.tsx
+++ b/src/pages/ExperimentDetail.tsx
@@ -595,6 +595,12 @@ function ExperimentDetail() {
                   { label: 'Tasks requiring files', value: report.file_generation.needs_files_total },
                   { label: 'Successfully generated', value: `${report.file_generation.files_succeeded} (${report.file_generation.needs_files_total > 0 ? ((report.file_generation.files_succeeded / report.file_generation.needs_files_total) * 100).toFixed(1) : 0}%)` },
                   { label: 'Failed → dummy created', value: report.file_generation.files_failed },
+                  // Only when there are any. A report written before step5
+                  // counted them carries no number here, and no number is not
+                  // the same claim as none.
+                  ...((report.file_generation.files_absent ?? 0) > 0
+                    ? [{ label: 'Absent from submission (never checked)', value: report.file_generation.files_absent as number }]
+                    : []),
                 ].map((row, i) => (
                   <div key={i} className="flex justify-between py-1 border-b border-dash-border-subtle last:border-0">
                     <span className="text-dash-text-secondary">{row.label}</span>
@@ -602,6 +608,13 @@ function ExperimentDetail() {
                   </div>
                 ))}
               </div>
+              {(report.file_generation.files_absent ?? 0) > 0 && (
+                <p className="mt-2 text-[10px] leading-snug text-amber-400/90">
+                  {report.file_generation.files_absent} of these tasks have no row in the
+                  submission, so nothing was read for them. The percentage above is out of a
+                  denominator that includes them.
+                </p>
+              )}
             </motion.div>
           )}
           {report.recovery_stats?.resume_rounds?.per_round &&

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -288,6 +288,15 @@ export interface FileGeneration {
   needs_files_total: number
   files_succeeded: number
   files_failed: number
+  /**
+   * File-required tasks the submission carries no row for, so their
+   * deliverables were never looked at. Neither a success nor a failure: folding
+   * them into either would make that count a count of something nobody checked.
+   * Absent on reports written before step5 counted them, where it means no
+   * record rather than none — so read it as a number only when it is one.
+   */
+  files_absent?: number | null
+  absent_task_ids?: string[]
   dummy_files_created: number
   dummy_task_ids: string[]
 }


### PR DESCRIPTION
## The defect

`step5_validate.py` cross-checks the needs_files manifest against the parquet it is about to upload. For every file-required task it looked up the row, read `deliverable_files`, and counted a success or a failure. A task the submission carried **no row for** fell out of both counts — nothing was read for it, so it was neither — and the summary line was printed from the failure list alone:

```python
if not needs_files_missing:
    warnings.append(f"All {needs_files_total} file-required tasks have deliverable files ✓")
```

That is a claim about all N, made from the failures of the ones that were looked at. With one absent task it printed the **same ✓** as a run where every file really was there, and `files_succeeded + files_failed` quietly stopped equalling `needs_files_total`.

Reproduced on `origin/main` — 220 canonical rows present, one canonical file-required ID substituted by another:

```
      needs_files_total:   2
      files_succeeded:     1
      files_failed:        0
   - All 2 file-required tasks have deliverable files ✓
✅ Validation PASSED
```

One of those two tasks was never looked at.

## Why absent is an error, not a warning

My first instinct was to disclose and not decide, matching #395. Reading the manifest's provenance overturned it.

`core/repo_bootstrapper._generate_manifest_from_dir` builds `step0_needs_files_manifest.json` **from the source parquet**, and refuses to emit one whose ordered task IDs do not hash to `CANONICAL_ORDERED_TASK_IDS_SHA256`. `_summary` derives `text_only_count = len(df) - needs_count`, so `manifest["tasks"]` holds one entry per source row. Every key in it is therefore a canonical task the submission is **required** to carry, and an absent one is an integrity break — never a legitimate state.

A **subset** run already fails this arrangement, through the identity check in `_task_scope_errors` (`missing`/`unexpected`). A **full** run returns `task_ids: None` from `_load_expected_task_scope`, so that check is skipped and only the row count survives — which a substitution keeps at 220. Full mode being the outlier is the whole reason this could reach an upload unremarked. Failing it makes the two modes agree; it does not add a criterion subset runs did not already enforce.

It also cannot fail a run that was healthy before: the new error fires only when a canonical file-required ID has no row, and every such run was already broken and already failing in subset mode. `새로운 기준이나 조건이 기존 실험에 영향을 미치면 안돼` is pinned by a test that asserts the two healthy arrangements keep their verdict, counts and wording verbatim.

## The invariant

`files_succeeded + files_failed + files_absent == needs_files_total`, tested in all three arrangements. `needs_files_total` is byte-identical to what it was — no denominator was quietly recomputed to make a rate look better.

## Surfaces

Four renderers read these stats, and two of them read the same broken numbers to **opposite** conclusions: `step6_report` printed "0.0% generated" while `ErrorAnalysisView` printed "0.0% failed" — a clean result. All four now disclose the never-checked count, and each shows it **only when it is positive**, so every payload written before this renders exactly as it did:

- `step6_report._build_markdown` — an extra table row plus a note naming the denominator
- `step6_report._build_html` — appended to the File Gen Rate card's sub-line
- `src/pages/ExperimentDetail.tsx` — conditional row plus an amber caption
- `src/components/dashboard/ErrorAnalysisView.tsx` — a full-width cell plus a caption under the failure bar

`files_absent` is optional in `FileGeneration`: a report written before the count existed carries no number, and no number is not the same claim as none.

No committed `validate_stats.json` and no published JSON carries `needs_files_total`, so nothing on the dashboard today changes.

## Not covered, deliberately

A substituted **text-only** task in full mode still passes. The manifest cross-check only walks `needs_files` entries, so a text-only substitution is invisible to it. Catching that needs a full-mode identity check over all 220 IDs — a separate change with a wider blast radius, not folded in here.

## Verification

- `pytest` from `batch-runner/` — **7503 passed, 10 skipped**, 0 failed (16m17s)
- `pytest scripts/__tests__ -m "not integration"` from the repo root — **171 passed**
- `npm run test:aggregate` — **368 pass, 1 skipped**, 0 fail
- `npx tsc --noEmit` — clean
- `npm run build` — success

Both new test files were run against the pre-fix sources to confirm they catch the defect: all 6 step5 tests fail on `origin/main`'s `step5_validate.py`, and `test_markdown_names_the_tasks_that_were_never_checked` fails on `origin/main`'s `step6_report.py` while `test_markdown_is_unchanged_when_no_task_was_absent` passes there — the no-change guard is a real guard, not an artefact of the edit.

Grader fingerprint unmoved: `compute_grader_source_hash` covers `step8_grade.py`, `batch-runner/core/**.py`, the schema, requirements and prompts. `step5_validate.py` and `step6_report.py` are in none of those sets.
