### PR TITLE
fix(validate): a text-only task with no row is not a pass

### DIFF
--- a/batch-runner/step5_validate.py
+++ b/batch-runner/step5_validate.py
@@ -9,6 +9,7 @@ Checks that the local snapshot is ready for HuggingFace upload:
   5. deliverable_text fill rate
     6. needs_files tasks with no files  <- WARNING + failure stats, no output mutation
     6b. needs_files tasks with no row at all  <- ERROR; nothing was checked
+    6c. text-only tasks with no row at all  <- ERROR; a listed task was not carried
   7. No duplicate task_ids
   8. deliverable_files local existence check
 
@@ -246,7 +247,12 @@ def validate(data_dir: str = None) -> bool:
     }
 
     manifest_path = WORKSPACE_DIR / "step0_needs_files_manifest.json"
-    if manifest_path.exists():
+    # Both halves of this section match manifest entries against submitted rows,
+    # so without task IDs to match on there is nothing it can check. That column
+    # is already a hard error above; a stats file of zeros for a run nobody
+    # could check would read as "checked, found none", so such a run gets no
+    # record rather than a zeroed one.
+    if manifest_path.exists() and "task_id" in df.columns:
         with open(manifest_path, "r", encoding="utf-8") as f:
             manifest = json.load(f)
 
@@ -273,22 +279,34 @@ def validate(data_dir: str = None) -> bool:
 
         needs_files_missing = []
         needs_files_absent = []
+        text_only_absent = []
         needs_files_total = 0
 
         selected_scope = (
             set(task_scope["task_ids"])
             if task_scope.get("task_ids") is not None else None
         )
+        # Which of the manifest's tasks the submission actually carries. The
+        # manifest is generated from the source parquet under a digest check
+        # (``core.repo_bootstrapper._generate_manifest_from_dir`` refuses to
+        # emit one whose ordered task IDs do not hash to the canonical digest)
+        # and it writes one entry per source row, so every key in it names a
+        # canonical task the submission is required to carry — whether or not
+        # that task owes a file.
+        submitted_ids = set(df["task_id"])
         for task_id, info in manifest.get("tasks", {}).items():
             if selected_scope is not None and task_id not in selected_scope:
                 continue
+            absent = task_id not in submitted_ids
             if not info.get("needs_files"):
+                if absent:
+                    text_only_absent.append(task_id)
                 continue
             needs_files_total += 1
-            row = df[df["task_id"] == task_id]
-            if len(row) == 0:
+            if absent:
                 needs_files_absent.append(task_id)
                 continue
+            row = df[df["task_id"] == task_id]
             files = _to_list(row.iloc[0]["deliverable_files"])
             if len(files) == 0:
                 needs_files_missing.append(task_id)
@@ -321,6 +339,19 @@ def validate(data_dir: str = None) -> bool:
                 f": {_id_sample(needs_files_absent)}"
             )
 
+        # The same integrity break, reached by a task that owed no file. Nothing
+        # else catches it in a full run: a substitute row keeps the count at the
+        # expected 220, and a task that owes no file never enters the counts
+        # above. Deliberately kept out of ``file_gen_stats`` — every field there
+        # is a file-generation outcome, and this absence is an identity fault,
+        # not one.
+        if text_only_absent:
+            errors.append(
+                f"{len(text_only_absent)} text-only tasks are absent from the "
+                "submission — the manifest lists them and no row carries them"
+                f": {_id_sample(text_only_absent)}"
+            )
+
         # Says what was observed, and only when everything was. The two lists
         # being empty is the same statement as succeeded == total; written this
         # way so the claim and its evidence cannot drift apart.
@@ -329,9 +360,10 @@ def validate(data_dir: str = None) -> bool:
                 f"All {needs_files_total} file-required tasks have deliverable files ✓"
             )
     else:
-        warnings.append(
-            "step0_needs_files_manifest.json not found — skipping file requirement check"
-        )
+        if not manifest_path.exists():
+            warnings.append(
+                "step0_needs_files_manifest.json not found — skipping file requirement check"
+            )
         file_gen_stats = None
 
     # ── 8. deliverable_files local existence check ──

--- a/batch-runner/tests/test_a_text_only_task_with_no_row_is_not_a_pass.py
+++ b/batch-runner/tests/test_a_text_only_task_with_no_row_is_not_a_pass.py
@@ -1,0 +1,255 @@
+"""A task the submission has no row for is missing, even when it owed no file.
+
+``step5_validate`` gained an absence check for file-required tasks, and that
+check was deliberately scoped to them. This is the other half, declared as a
+known gap when the first half merged: a task the manifest lists as text-only
+never entered any count, so a full submission that dropped one and let a
+substitute take its row passed every gate.
+
+Nothing else notices. ``_task_scope_errors`` compares IDs only when the scope
+carries them, and ``_load_expected_task_scope`` returns ``task_ids=None`` for a
+full run — so full mode had a row count and nothing more, and a substitution
+keeps the count at 220. The duplicate check sees one row per ID. The file counts
+skip the task by definition.
+
+The manifest is what makes the check possible.
+``core.repo_bootstrapper._generate_manifest_from_dir`` writes one entry per
+source parquet row and refuses to emit a manifest whose ordered task IDs do not
+hash to ``CANONICAL_ORDERED_TASK_IDS_SHA256``. Every key in it is therefore a
+canonical task the submission is required to carry, whether or not it owes a
+file, so an absent one is an integrity break rather than a legitimate state.
+
+Pinned here:
+
+* a text-only task with no row fails the gate, in its own words;
+* it does not disturb the file counts — the two checks stay independent;
+* the row count alone never noticed, which is why the check had to be added;
+* both kinds of absence are reported once each, not folded together;
+* a subset run still passes with the unselected tasks absent, which is normal;
+* a submission with no task_id column gets no stats file rather than zeros;
+* a submission carrying every task keeps its verdict, counts and wording.
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+import step5_validate as step5
+
+_FULL_ROW_COUNT = 220
+_TICK = "file-required tasks have deliverable files ✓"
+
+# task-000 and task-001 owe files; task-002 owes none. The remaining 217 rows
+# are padding that keeps the submission at the row count a full run expects.
+_MANIFEST_NEEDS = {"task-000": True, "task-001": True, "task-002": False}
+
+
+def _canonical_ids() -> list[str]:
+    return [f"task-{index:03d}" for index in range(_FULL_ROW_COUNT)]
+
+
+def _write_parquet(
+    upload: Path,
+    task_ids: list[str],
+    with_files: set[str],
+    *,
+    include_task_id: bool = True,
+) -> None:
+    """Write a submission parquet, giving each ``with_files`` task one file."""
+    data_dir = upload / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (upload / "deliverable_files").mkdir(exist_ok=True)
+
+    files = []
+    for task_id in task_ids:
+        if task_id not in with_files:
+            files.append([])
+            continue
+        relative = f"deliverable_files/{task_id}.docx"
+        (upload / relative).write_bytes(b"deliverable")
+        files.append([relative])
+
+    empty = [[] for _ in task_ids]
+    columns = {
+        "task_id": task_ids,
+        "sector": ["Information"] * len(task_ids),
+        "occupation": ["Analyst"] * len(task_ids),
+        "prompt": ["Write something"] * len(task_ids),
+        "reference_files": empty,
+        "reference_file_urls": [[] for _ in task_ids],
+        "reference_file_hf_uris": [[] for _ in task_ids],
+        "deliverable_text": ["done"] * len(task_ids),
+        "deliverable_files": files,
+        "deliverable_file_urls": [[] for _ in task_ids],
+        "deliverable_file_hf_uris": [[] for _ in task_ids],
+    }
+    if not include_task_id:
+        del columns["task_id"]
+    pd.DataFrame(columns).to_parquet(
+        data_dir / "train-00000-of-00001.parquet", index=False
+    )
+
+
+def _prepare(
+    tmp_path: Path,
+    *,
+    row_ids: list[str],
+    scope: dict,
+    manifest_needs: dict[str, bool] = None,
+    with_files: set[str] = frozenset({"task-000", "task-001"}),
+    include_task_id: bool = True,
+) -> tuple[Path, Path]:
+    workspace = tmp_path / "workspace"
+    upload = workspace / "upload"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_parquet(
+        upload, row_ids, set(with_files), include_task_id=include_task_id
+    )
+    (workspace / "step1_tasks_prepared.json").write_text(
+        json.dumps({"task_scope": scope}), encoding="utf-8"
+    )
+    (workspace / "step0_needs_files_manifest.json").write_text(
+        json.dumps({
+            "tasks": {
+                task_id: {"needs_files": needed}
+                for task_id, needed in (manifest_needs or _MANIFEST_NEEDS).items()
+            },
+            "_summary": {"active_policy": "deliverable_only"},
+        }),
+        encoding="utf-8",
+    )
+    return workspace, upload
+
+
+def _run(monkeypatch, workspace: Path, upload: Path) -> tuple[bool, dict | None]:
+    monkeypatch.setattr(step5, "WORKSPACE_DIR", workspace)
+    monkeypatch.setattr(step5, "UPLOAD_DIR", upload)
+    passed = step5.validate(data_dir=str(upload))
+    stats_path = workspace / "validate_stats.json"
+    if not stats_path.exists():
+        return passed, None
+    return passed, json.loads(stats_path.read_text(encoding="utf-8"))
+
+
+_FULL_SCOPE = {"mode": "full", "expected_count": _FULL_ROW_COUNT}
+
+
+def _substituted(tmp_path: Path, index: int) -> tuple[Path, Path]:
+    """A full submission where a substitute row took one canonical task's place."""
+    row_ids = _canonical_ids()
+    row_ids[index] = f"substitute-for-{row_ids[index]}"
+    return _prepare(tmp_path, row_ids=row_ids, scope=_FULL_SCOPE)
+
+
+def _all_present(tmp_path: Path) -> tuple[Path, Path]:
+    return _prepare(tmp_path, row_ids=_canonical_ids(), scope=_FULL_SCOPE)
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+def test_a_text_only_task_with_no_row_fails_the_gate(tmp_path, monkeypatch, capsys):
+    passed, _ = _run(monkeypatch, *_substituted(tmp_path, 2))
+    out = capsys.readouterr().out
+
+    assert passed is False
+    assert "Validation FAILED" in out
+    assert "1 text-only tasks are absent from the submission" in out
+    assert "the manifest lists them and no row carries them" in out
+    assert "task-002" in out
+
+
+def test_the_file_counts_are_untouched_by_a_text_only_absence(tmp_path, monkeypatch):
+    """The two checks stay independent: a text-only absence is not a file event."""
+    _, healthy = _run(monkeypatch, *_all_present(tmp_path / "healthy"))
+    _, substituted = _run(monkeypatch, *_substituted(tmp_path / "substituted", 2))
+
+    keys = ("needs_files_total", "files_succeeded", "files_failed", "files_absent")
+    assert {k: substituted[k] for k in keys} == {k: healthy[k] for k in keys}
+    assert substituted["files_absent"] == 0
+    assert substituted["absent_task_ids"] == []
+
+
+def test_the_row_count_alone_does_not_notice_the_substitution(
+    tmp_path, monkeypatch, capsys
+):
+    """Why the check had to be added: every older gate is still satisfied."""
+    _run(monkeypatch, *_substituted(tmp_path, 2))
+    out = capsys.readouterr().out
+
+    assert f"Rows: {_FULL_ROW_COUNT}" in out
+    assert "Row count:" not in out          # the count check is satisfied
+    assert "duplicate task_id" not in out   # so is the uniqueness check
+    assert f"All 2 {_TICK}" in out          # and both file-required tasks are fine
+
+
+def test_both_kinds_of_absence_are_reported_separately(tmp_path, monkeypatch, capsys):
+    """One file-required and one text-only task gone — two errors, no overlap."""
+    row_ids = _canonical_ids()
+    row_ids[1] = "substitute-for-task-001"
+    row_ids[2] = "substitute-for-task-002"
+    passed, stats = _run(
+        monkeypatch, *_prepare(tmp_path, row_ids=row_ids, scope=_FULL_SCOPE)
+    )
+    out = capsys.readouterr().out
+
+    assert passed is False
+    assert "1 file-required tasks are absent from the submission" in out
+    assert "1 text-only tasks are absent from the submission" in out
+    assert stats["files_absent"] == 1
+    assert stats["absent_task_ids"] == ["task-001"]
+    assert _TICK not in out
+
+
+def test_a_subset_run_still_passes_with_the_unselected_tasks_absent(
+    tmp_path, monkeypatch, capsys
+):
+    """A subset submission carries only its own rows; the manifest lists all 220."""
+    selected = ["task-000", "task-001"]
+    passed, stats = _run(monkeypatch, *_prepare(
+        tmp_path,
+        row_ids=selected,
+        scope={
+            "mode": "explicit_ids",
+            "expected_count": len(selected),
+            "task_ids": selected,
+        },
+    ))
+    out = capsys.readouterr().out
+
+    assert passed is True
+    assert "Validation PASSED" in out
+    assert "text-only tasks are absent" not in out
+    assert (stats["needs_files_total"], stats["files_succeeded"]) == (2, 2)
+
+
+def test_a_submission_with_no_task_ids_gets_no_stats_rather_than_zeros(
+    tmp_path, monkeypatch, capsys
+):
+    """Nothing could be cross-checked, so nothing is recorded as having been."""
+    passed, stats = _run(monkeypatch, *_prepare(
+        tmp_path,
+        row_ids=_canonical_ids(),
+        scope=_FULL_SCOPE,
+        include_task_id=False,
+    ))
+    out = capsys.readouterr().out
+
+    assert passed is False
+    assert "Missing required columns" in out
+    assert stats is None
+    assert _TICK not in out
+
+
+def test_a_submission_carrying_every_task_is_unchanged(tmp_path, monkeypatch, capsys):
+    """새로운 기준이 기존 실험에 영향을 미치면 안 된다 — verdict, counts and wording."""
+    passed, stats = _run(monkeypatch, *_all_present(tmp_path))
+    out = capsys.readouterr().out
+
+    assert passed is True
+    assert "Validation PASSED" in out
+    assert f"All 2 {_TICK}" in out
+    assert "absent from the submission" not in out
+    assert (stats["needs_files_total"], stats["files_succeeded"]) == (2, 2)
+    assert (stats["files_failed"], stats["files_absent"]) == (0, 0)


### PR DESCRIPTION
## What this fixes

#396 added an absence check to `step5_validate` and scoped it to file-required
tasks on purpose. Its body and the project card both recorded the other half as
a known, open gap: **a task the manifest lists as text-only never entered any
count**, so a full submission that dropped one and let a substitute row take its
place passed every gate.

This closes that gap.

## Why nothing else noticed

| gate | why it was satisfied |
|---|---|
| `_task_scope_errors` identity check | runs only `if expected_ids is not None`; `_load_expected_task_scope` returns `task_ids=None` for a full run (`step5_validate.py:63`, `:68`, `:90`) |
| row count | a substitute row keeps the total at the expected 220 |
| duplicate `task_id` | one row per ID, so nothing is duplicated |
| file counts | a task that owes no file never enters them by definition |

Full mode had a row count and nothing else.

## Why an absent manifest ID is always an integrity break

`core.repo_bootstrapper._generate_manifest_from_dir` reads the **source**
parquet, and refuses to emit a manifest whose ordered task IDs do not hash to
`CANONICAL_ORDERED_TASK_IDS_SHA256` (a second gate checks the source projection
digest). It then writes **one entry per source row**, regardless of
`needs_files`.

So every key in the manifest names a canonical task the submission is required
to carry. An absent one is never a legitimate state, which is what makes failing
closed correct here rather than a new criterion applied to old runs.

## What this deliberately does not cover

* **Missing direction only.** A manifest ID with no row is an error; an
  *unexpected* ID is left to the existing 220 row count and the duplicate check.
  Checking it here would require assuming the manifest is complete, which a
  fabricated or partial manifest is not.
* **No new `validate_stats.json` field.** That file is consumed as
  `file_generation`, where every key is a file-generation outcome. A text-only
  absence is an identity fault, not one — so `file_gen_stats` and the dashboard
  are untouched, and this PR has no frontend change.

## Also fixed on the way

A submission with **no `task_id` column** previously raised
`KeyError: 'task_id'` at the manifest cross-check (reproduced against
`origin/main`). It now skips the whole section and writes **no stats file** —
rather than a file of zeros, which would read as "checked, found none".

## Blast radius

Existing verdicts, counts and message strings are unchanged. Subset runs are
unaffected: manifest entries outside the selected scope are skipped, because a
subset submission legitimately carries only its own rows. Without that filter
every subset run would newly fail — pinned by a dedicated test.

`step5_validate.py` is **not** in `compute_grader_source_hash`'s input set
(`step8_grade.py:159-200`), so this does not move the grader fingerprint and no
re-grade is implied.

## Verification

Proof the tests catch the defect: with `origin/main`'s `step5_validate.py`
swapped back in — **3 failed, 4 passed** (the 4 are no-change guards, correctly
green both before and after).

| check | result |
|---|---|
| backend `pytest` (from `batch-runner/`) | **7510 passed**, 10 skipped, 45 deselected (16m49s) — baseline 7503, +7 new |
| repo-root `pytest scripts/__tests__ -m "not integration"` | **171 passed** |
| `npm run test:aggregate` | **369 tests, 368 pass, 1 skipped** |
| `npx tsc --noEmit` | clean |
| `npm run build` | ✓ built |

Diff: 38 insertions / 6 deletions in `step5_validate.py`, plus 255 lines of new
tests.
