### PR TITLE
fix(sweep): a relay sweep that cannot find its corpus is not an all-clear

### DIFF
--- a/batch-runner/scripts/sweep_stalled_shard_relays.py
+++ b/batch-runner/scripts/sweep_stalled_shard_relays.py
@@ -55,6 +55,10 @@ class ShardReadError(ValueError):
     """A shard file cannot be read as a shard."""
 
 
+class CorpusNotFound(FileNotFoundError):
+    """The tree the sweep was pointed at is not there to be read."""
+
+
 def load_shard_file(path: Path) -> tuple[dict, str]:
     """Return ``(payload, sha256_of_file_bytes)`` for one shard file.
 
@@ -447,7 +451,18 @@ def sweep(
     commit_time: Callable[[Path], datetime | None],
     canonical_lookup: Callable[[str], list[str] | None],
 ) -> list[RelayVerdict]:
-    """Classify every stem under ``<grades_root>/_shards/``."""
+    """Classify every stem under ``<grades_root>/_shards/``.
+
+    Raises ``CorpusNotFound`` when ``grades_root`` itself is not a directory,
+    so an empty list carries one meaning only: the corpus was read and it holds
+    no relay. A grades root that exists but has no ``_shards/`` tree yet is
+    that case -- nothing has been committed -- and returns ``[]``.
+    """
+    if not grades_root.is_dir():
+        raise CorpusNotFound(
+            f"--grades-root {grades_root} is not a directory, so no relay was "
+            "inspected; that is not the same as finding none"
+        )
     shards_root = grades_root / "_shards"
     if not shards_root.is_dir():
         return []
@@ -532,19 +547,34 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     repo_root = Path(args.repo_root).resolve()
     config_dir = Path(args.config_dir)
-    verdicts = sweep(
-        Path(args.grades_root),
-        now=datetime.now(timezone.utc),
-        stale_after=timedelta(hours=args.stale_after_hours),
-        commit_time=lambda path: last_commit_at(repo_root, path),
-        canonical_lookup=lambda sha: canonical_ids_from_configs(config_dir, sha),
-    )
+    annotate = bool(os.environ.get("GITHUB_ACTIONS"))
+    try:
+        verdicts = sweep(
+            Path(args.grades_root),
+            now=datetime.now(timezone.utc),
+            stale_after=timedelta(hours=args.stale_after_hours),
+            commit_time=lambda path: last_commit_at(repo_root, path),
+            canonical_lookup=lambda sha: canonical_ids_from_configs(config_dir, sha),
+        )
+    except CorpusNotFound as exc:
+        # `inspect_stem` already refuses to guess when it cannot read one stem's
+        # liveness, and says so out loud. The input that decides whether any
+        # stem is read at all gets the same treatment: a sweep that could not
+        # look must not print the sentence a sweep that looked and found nothing
+        # prints. On stdout, because the workflow tees stdout into the job
+        # summary and that summary is what a person reads. Exit 2, as for any
+        # other unusable invocation -- 1 stays reserved for "a relay needs
+        # attention", which nothing here is in a position to have judged.
+        message = f"cannot sweep: {exc}"
+        print(message)
+        if annotate:
+            print(f"::error title=Shard relay sweep could not look::{message}")
+        return 2
 
     if not verdicts:
         print("no shard relays to inspect")
         return 0
 
-    annotate = bool(os.environ.get("GITHUB_ACTIONS"))
     for line in render(verdicts, annotate=annotate):
         print(line)
 

--- a/batch-runner/tests/test_sweep_stalled_shard_relays.py
+++ b/batch-runner/tests/test_sweep_stalled_shard_relays.py
@@ -235,8 +235,35 @@ def test_a_relay_with_no_shard_files_is_ignored(tmp_path):
     assert verdict.failing is False
 
 
-def test_a_missing_shards_tree_sweeps_nothing(tmp_path):
-    assert _sweep(tmp_path / "grades") == []
+@pytest.mark.parametrize("kind", ["absent", "a regular file"])
+def test_a_grades_root_it_cannot_find_is_not_a_sweep_that_found_nothing(
+    tmp_path, kind
+):
+    # Replaces `test_a_missing_shards_tree_sweeps_nothing`, which pinned the
+    # opposite: it passed a grades root that was never there and asserted the
+    # empty list, i.e. the same answer as a corpus that was read and held no
+    # relay. This sweep is the watchdog for the case where "the relay is broken
+    # and every signal is green", so those two must not share an answer.
+    # `test_liveness_it_cannot_read_is_never_reported_as_a_failure` above is the
+    # same refusal one layer down; the input deciding whether any stem is read
+    # at all now gets it too.
+    grades = tmp_path / "grades"
+    if kind == "a regular file":
+        grades.write_text("not a directory\n", encoding="utf-8")
+
+    with pytest.raises(sweep.CorpusNotFound) as caught:
+        _sweep(grades)
+    assert str(grades) in str(caught.value)
+
+
+def test_a_grades_root_with_no_shards_tree_yet_sweeps_nothing(tmp_path):
+    # The other half of the split, and a control: it must pass on both sides of
+    # the change. A grades root that exists but holds no `_shards/` was read,
+    # and it really does hold no relay -- nothing has been committed yet. That
+    # is a finding, so it keeps the empty list and the quiet exit.
+    grades = tmp_path / "grades"
+    grades.mkdir()
+    assert _sweep(grades) == []
 
 
 @pytest.mark.parametrize("total,shard_count", [(220, 9), (12, 3), (7, 7), (5, 1)])
@@ -594,3 +621,48 @@ def test_the_cli_exits_zero_when_every_relay_is_accounted_for(tmp_path, capsys):
 def test_a_non_positive_staleness_window_is_rejected(tmp_path, capsys):
     assert sweep.main(["--stale-after-hours", "0"]) == 2
     assert "must be positive" in capsys.readouterr().err
+
+
+def test_the_cli_does_not_report_a_corpus_it_never_found_as_empty(
+    tmp_path, capsys
+):
+    rc = sweep.main(["--grades-root", str(tmp_path / "nowhere")])
+    captured = capsys.readouterr()
+
+    # 2, not 1: 1 means a relay needs attention, and no relay was judged here.
+    # 2 is what this CLI already returns for an invocation it cannot act on.
+    assert rc == 2
+    assert "cannot sweep" in captured.out
+    assert str(tmp_path / "nowhere") in captured.out
+    # The exact sentence a sweep that looked and found nothing prints. Reaching
+    # it from here is the defect, so pin its absence rather than only pinning
+    # the new wording, which a later edit could reword without noticing.
+    assert "no shard relays to inspect" not in captured.out
+
+
+def test_the_cli_puts_a_corpus_it_cannot_find_in_the_run_annotations(
+    tmp_path, capsys, monkeypatch
+):
+    # The workflow tees stdout into the job summary, so the sentence goes to
+    # stdout; under Actions it also has to surface as an annotation, the way
+    # `render` marks a failing verdict.
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    assert sweep.main(["--grades-root", str(tmp_path / "nowhere")]) == 2
+    annotations = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if line.startswith("::error")
+    ]
+    assert len(annotations) == 1
+    assert "could not look" in annotations[0]
+
+
+def test_the_cli_still_reports_a_corpus_that_really_holds_no_relay(
+    tmp_path, capsys
+):
+    # Control: passes on both sides of the change. Reading the corpus and
+    # finding no relay is a finding, and keeps its quiet green answer.
+    grades = tmp_path / "grades"
+    grades.mkdir()
+    assert sweep.main(["--grades-root", str(grades)]) == 0
+    assert capsys.readouterr().out.strip() == "no shard relays to inspect"


### PR DESCRIPTION
## The defect, in one sentence

`sweep_stalled_shard_relays.py` printed `no shard relays to inspect` and exited **0** both when it read the corpus and found no relay, and when it could not find the corpus at all.

That matters here more than it would elsewhere, because this file's own docstring says why it exists:

> The case nothing reports is a shard that ends **green** without finishing … The relay is broken and every signal is green.

A watchdog for silent-green failure had a silent-green failure of its own.

## Reproduced, not asserted

On `d9e004f`, run from `batch-runner/`:

| # | invocation | output | exit |
|---|---|---|---|
| A | *(defaults — control)* | two `[merged]` verdicts | 0 |
| B | `--grades-root ../data/grades-TYPO` | `no shard relays to inspect` | **0** |

B is a path that does not exist. It reported the same thing as a clean corpus.

## Why this is a defect and not a scoping choice

The file already draws exactly this distinction, one layer down. When `inspect_stem` cannot read a stem's *liveness*, it refuses to guess and says so out loud:

```python
    newest = commit_time(stem_dir)
    if newest is None:
        return RelayVerdict(
            stem, "unknown", "git has no commit touching this stem; cannot judge liveness"
        )
```

…and `test_liveness_it_cannot_read_is_never_reported_as_a_failure` pins that behaviour deliberately. The single input that decides whether *any* stem is read at all did not get the same treatment.

## The change

`sweep()` raises `CorpusNotFound` when `grades_root` is not a directory, so an empty return keeps exactly one meaning: *the corpus was read and it holds no relay.* `main()` catches it, prints the reason, and returns 2.

Three deliberate choices:

- **stdout, not stderr.** The workflow does `… | tee "$RUNNER_TEMP/sweep.txt"` and pastes that file into `$GITHUB_STEP_SUMMARY`. A message on stderr would leave the job summary showing an empty code block — the same "nothing to see here" the fix is about.
- **Exit 2, not 1.** `1` means *a relay needs attention*; no relay was in a position to be judged. `2` is what this CLI already returns for `--stale-after-hours 0` — the "this invocation cannot do its job" code.
- **`::error` annotation under Actions**, mirroring how `render` marks a failing verdict.

## Scope held: only the root itself

A grades root that exists but has no `_shards/` tree **was** read, and really does hold no relay — nothing has been committed yet. That keeps `[]` and the quiet exit 0. Verified as its own case, both as a unit and through the CLI.

After the change:

| scenario | output | exit |
|---|---|---|
| defaults (control) | two `[merged]` verdicts | 0 |
| `--grades-root` points nowhere | `cannot sweep: --grades-root … is not a directory, so no relay was inspected; that is not the same as finding none` | **2** |
| …same, under `GITHUB_ACTIONS` | + `::error title=Shard relay sweep could not look::…` | 2 |
| grades root exists, no `_shards/` | `no shard relays to inspect` | 0 |
| `--stale-after-hours 0` (control) | `--stale-after-hours must be positive` | 2 |

## A behaviour pin was replaced — stating it plainly

`test_a_missing_shards_tree_sweeps_nothing` asserted:

```python
    assert _sweep(tmp_path / "grades") == []
```

That grades root was never there, so the test pinned precisely the behaviour this PR calls a defect. It is **replaced**, not deleted quietly, by two tests — one for each case it had conflated:

- `test_a_grades_root_it_cannot_find_is_not_a_sweep_that_found_nothing` (parametrised over an absent path and a regular file)
- `test_a_grades_root_with_no_shards_tree_yet_sweeps_nothing`

## Does this turn healthy scheduled runs red?

No. `data/grades` is tracked (167 files) and the workflow checks out with `fetch-depth: 0`, so the default `../data/grades` resolves on every run. The only way to reach the new exit 2 is for the corpus to genuinely be unreadable — which is a real problem the sweep should report rather than sit green through.

## Verification

| check | result |
|---|---|
| `tests/test_sweep_stalled_shard_relays.py` | **38 passed** (baseline 33, +6 new −1 replaced = +5 ✓) |
| new tests against **pre-fix** source | **4 of 6 fail** ✅ |
| — the 2 that pass on both sides | deliberate controls: the legitimately-empty corpus, as unit and via CLI |
| backend `pytest` (full) | **7675 passed, 10 skipped, 45 deselected, 0 failed** (16:52) — baseline 7670, +5 ✓ |
| `mypy scripts/sweep_stalled_shard_relays.py` | **no issues** |
| frontend `npm run test:aggregate` | **415 collected, 414 pass, 0 fail, 1 pre-existing skip** |
| `tsc --noEmit` + production build | both clean |

## Grader source hash is unmoved

| | |
|---|---|
| files the fingerprint hashes | **107 + 1 config** |
| files changed here | 2 (`batch-runner/scripts/` ×1, `batch-runner/tests/` ×1) |
| **overlap** | **0** |
| digest, pre-fix tree vs fixed tree | **byte-identical** (`fc1fe6a9…`, computed both ways) |

From `scripts/`, only `download_inference_from_hf.py` is hashed; no `tests/` file is. **No re-grade. Safe to merge while grading runs.**

## Cost

**$0.** No model call, no re-grade — reading code, executing the tool against real and broken paths, and computing the fingerprint both ways.
