### PR TITLE
fix(envelope): stop a folder name standing in for a fingerprint nobody checked

### DIFF
--- a/batch-runner/core/execution_envelope_tasks.py
+++ b/batch-runner/core/execution_envelope_tasks.py
@@ -724,10 +724,13 @@ def selection_matches(
     ]
 
 
-# Each reference file in this dataset lives in a folder named after the first
-# 32 hexadecimal characters of that file's SHA-256 fingerprint. That folder name
-# is worth something when no copy of the file can be read — but it is only half
-# the fingerprint, so on its own it leaves the other half unchecked.
+# Every file in this dataset sits in a folder whose name is 32 hexadecimal
+# characters, and *some* of those folders are the first 32 characters of the
+# file's own SHA-256 fingerprint. Not all of them. Measured on the pinned
+# revision: 200 of 549 files, and 0 of the 248 under ``deliverable_files/``.
+# So the shape of a path proves nothing, and a folder name that agrees with a
+# written fingerprint is worth exactly the 32 characters it repeats — never the
+# other 32, and never a verdict on a file nobody read.
 REFERENCE_PATH_FINGERPRINT_LENGTH = 32
 
 # The one data file the pinned dataset revision ships its tasks in.
@@ -742,17 +745,23 @@ INPUT_FILE_READ = "read the file"
 #: saying "read the file, 64 of 64 characters compared" and nothing else reads
 #: as a pass, and this is the opposite of a pass.
 INPUT_FILE_DISAGREED = "read the file and it disagreed"
-#: No copy of the file was reachable, so only the 32 characters the folder name
-#: repeats could be compared. The other 32 stand unchecked.
+#: No copy of the file was reachable, but the folder it sits in turned out to
+#: repeat the first 32 characters of the written fingerprint. Thirty-two
+#: hexadecimal characters do not agree by accident, so this really is 32 of the
+#: 64 compared. The other 32 stand unchecked.
 INPUT_FILE_FOLDER_NAME_ONLY = "folder name only"
 #: Nothing was compared. This is not the same answer as "it matched".
 INPUT_FILE_NOT_CHECKED = "not checked"
 
 # How to get the missing bytes, free and once. Named in the report so a person
-# reading it knows what to do rather than being told only that they failed.
+# reading it knows what to do rather than being told only that they failed. The
+# command is checked by a test, because a pointer a reader cannot follow is
+# worse than none: it reads as a fact. `huggingface-cli` was that pointer until
+# the pinned huggingface-hub stopped shipping it as anything but a message
+# saying it "is deprecated and no longer works".
 HOW_TO_GET_THE_FILES = (
     "download the pinned revision once with "
-    f"`huggingface-cli download {DATASET_REPO_ID} --repo-type dataset "
+    f"`hf download {DATASET_REPO_ID} --repo-type dataset "
     f"--revision {DATASET_REVISION}` (no charge), or point the check at a copy "
     "you already have with --dataset-root"
 )
@@ -893,20 +902,40 @@ def _is_hexadecimal(value: str) -> bool:
     )
 
 
-def path_carries_its_own_fingerprint(path: str) -> bool:
-    """Whether this file's own folder name is the start of its fingerprint.
+def path_folder_is_shaped_like_a_fingerprint(path: str) -> bool:
+    """Whether this file's folder name *could* be half of a fingerprint.
 
-    The dataset files under ``reference_files/`` are kept in a folder named
-    after the first 32 characters of the file's fingerprint, so a copy found at
-    such a path can only be the file the plan means. Paths of any other shape
-    carry no such promise, and a copy found at one of them may belong to some
-    other revision of the dataset.
+    Shape only, and shape is not provenance. Every file in this dataset sits in
+    a 32-hexadecimal-character folder, so this is true of all of them, and only
+    some of those folders are named after their file's contents — 200 of 549 at
+    the pinned revision, none at all under ``deliverable_files/``. A true answer
+    here therefore means "worth comparing against", never "checked out".
+
+    Whether a folder really is named after its file is not knowable from the
+    path. It is knowable from a fingerprint that agrees with it, because 32
+    hexadecimal characters do not agree by accident, and from real bytes whose
+    digest starts with it. Both of those are used below; this is not.
     """
     folder = Path(path).parent.name.lower()
     return (
         len(folder) == REFERENCE_PATH_FINGERPRINT_LENGTH
         and _is_hexadecimal(folder)
     )
+
+
+def folder_name_agrees_with(path: str, fingerprint: str) -> bool:
+    """Whether the folder repeats the first 32 characters of ``fingerprint``.
+
+    An agreement is evidence and a disagreement is not. Thirty-two hexadecimal
+    characters cannot line up by chance, so agreement means this folder is named
+    after its contents *and* the written value has its first half right. A
+    disagreement is two indistinguishable stories — a wrong fingerprint, or a
+    folder that was never named after anything — and the path cannot say which.
+    """
+    if not path_folder_is_shaped_like_a_fingerprint(path):
+        return False
+    folder = Path(path).parent.name.lower()
+    return fingerprint.strip().lower().startswith(folder)
 
 
 def _copy_in_the_download_cache(
@@ -949,16 +978,19 @@ def _locate_with_provenance(
     Nothing is downloaded. A folder named by the person running the check is
     preferred over the download cache, because it was named on purpose. The
     second value says whether the copy is the pinned revision's *by
-    construction*: true for a copy the download cache holds under that exact
-    revision, and true for a file whose own path repeats the first half of its
-    fingerprint. False for a copy found in a named folder that could hold any
-    revision — such a copy is still worth reading, but a fingerprint that
-    disagrees with it means something weaker.
+    construction*: true only for a copy the download cache holds under that
+    exact revision, which is the one provenance a path can carry on its own.
+
+    A copy found in a named folder gets ``False``. Such a folder could hold any
+    revision, and the shape of the path inside it settles nothing — most of this
+    dataset's folders are not named after their file's contents. That question
+    is asked again once the bytes are in hand, where a digest or a written
+    fingerprint that begins with the folder can answer it.
     """
     if dataset_root is not None:
         candidate = Path(dataset_root) / path
         if candidate.is_file():
-            return candidate, path_carries_its_own_fingerprint(path)
+            return candidate, False
     cached = _copy_in_the_download_cache(
         catalog.dataset_repo_id, catalog.dataset_revision, path
     )
@@ -1002,9 +1034,24 @@ def _check_one_written_fingerprint(
 
     found = _locate_with_provenance(path, catalog, dataset_root)
     if found is not None:
-        copy, pinned_by_construction = found
+        copy, pinned_by_revision = found
         real = sha256_of_file(copy)
-        if real != fingerprint and pinned_by_construction:
+        folder = Path(path).parent.name.lower()
+        # Whether the folder this file sits in is one the dataset named after
+        # its contents — because only then does a disagreement point at the
+        # written value rather than at the copy. The download cache answers it
+        # by revision. Otherwise it takes 32 characters of evidence from one
+        # side or the other: a digest that begins with the folder, or a written
+        # fingerprint that does. Thirty-two hexadecimal characters do not line
+        # up by chance, and the shape of the folder on its own is not evidence
+        # at all — most of this dataset's folders are not named after their file.
+        certainly_that_file = (
+            pinned_by_revision
+            or (path_folder_is_shaped_like_a_fingerprint(path)
+                and real.startswith(folder))
+            or folder_name_agrees_with(path, fingerprint)
+        )
+        if real != fingerprint and certainly_that_file:
             problems.append(
                 f"the fingerprint written for {path} is {fingerprint}, but the "
                 f"copy of that {what_it_is} on this machine is {real}, so the "
@@ -1042,14 +1089,7 @@ def _check_one_written_fingerprint(
             note=f"read from {copy}",
         )
 
-    folder = Path(path).parent.name.lower()
-    if path_carries_its_own_fingerprint(path):
-        if not fingerprint.startswith(folder):
-            problems.append(
-                f"the fingerprint written for {path} does not match the folder "
-                "the dataset keeps that file in, so the written value describes "
-                "some other file"
-            )
+    if folder_name_agrees_with(path, fingerprint):
         missing_copies.append(
             f"no copy of {path} at the pinned revision is on this machine, so "
             f"only {REFERENCE_PATH_FINGERPRINT_LENGTH} of its 64 fingerprint "
@@ -1062,6 +1102,36 @@ def _check_one_written_fingerprint(
             state=INPUT_FILE_FOLDER_NAME_ONLY,
             characters_compared=REFERENCE_PATH_FINGERPRINT_LENGTH,
             note="the folder name repeats the first half of the fingerprint",
+        )
+
+    folder = Path(path).parent.name.lower()
+    if path_folder_is_shaped_like_a_fingerprint(path):
+        # The folder is the right shape and does not match. That used to be
+        # filed as proof the written value "describes some other file" — but it
+        # is not proof of anything, because most of this dataset's folders are
+        # not named after their file's contents (349 of 549 at the pinned
+        # revision, including every one under deliverable_files/). A correct
+        # fingerprint for one of those disagrees with its folder exactly like a
+        # wrong one does. So the disagreement is reported, the run still stops
+        # on it, and nothing is claimed about which of the two is at fault.
+        missing_copies.append(
+            f"no copy of {path} at the pinned revision is on this machine, and "
+            f"the folder it sits in does not repeat the first "
+            f"{REFERENCE_PATH_FINGERPRINT_LENGTH} characters of the written "
+            "fingerprint. Not every folder in this dataset is named after its "
+            "file's contents, so that disagreement does not say which of the "
+            "two is wrong, and none of the 64 characters could be checked "
+            f"against the file itself; {HOW_TO_GET_THE_FILES}"
+        )
+        return InputFileCheck(
+            path=path,
+            written=fingerprint,
+            state=INPUT_FILE_NOT_CHECKED,
+            characters_compared=0,
+            note=(
+                f"the folder name {folder} disagrees with the written value, "
+                "which in this dataset may mean either one is wrong"
+            ),
         )
 
     missing_copies.append(

--- a/batch-runner/core/execution_envelope_tasks.py
+++ b/batch-runner/core/execution_envelope_tasks.py
@@ -822,10 +822,15 @@ class InputFileVerification:
 
     checks: tuple[InputFileCheck, ...]
     problems: tuple[str, ...]
-    """Ways the written fingerprints and the real files disagree.
+    """Ways the written fingerprints and the real files are known to disagree.
 
-    A defect in the plan. It says the same thing on every machine, because it
-    is about what was written down, not about what happens to be lying around.
+    A defect in the plan, and it reads the same on any machine that can see the
+    file. A machine that cannot is not entitled to the same sentence: with no
+    bytes to hash, a written value disagreeing with the folder name is not
+    evidence of anything, because most of this dataset's folders are not named
+    after their file's contents. That case is filed under
+    :attr:`missing_copies` — still enough to stop the run, but not a verdict on
+    a plan nobody was able to check.
     """
     missing_copies: tuple[str, ...] = ()
     """Files no copy of which is on this machine, so nothing could be read.

--- a/batch-runner/experiments/execution_envelope/gdpval_task_catalog.json
+++ b/batch-runner/experiments/execution_envelope/gdpval_task_catalog.json
@@ -3,7 +3,7 @@
   "dataset_repo_id": "openai/gdpval",
   "dataset_revision": "11e7900cdcac61bc4daf59e65feb238acda98fbf",
   "holds_no_scores": "Only task numbers, industries, jobs, expert answer file types, reference file paths and types, a fingerprint of the task wording, how many scoring lines each task is marked against and how long its longest one is are recorded. No score, grade, or verdict is present, and no scoring line is reproduced — only its length.",
-  "reference_file_path_note": "In this dataset each reference file sits in a folder named after the first 32 hexadecimal characters of that file's SHA-256 fingerprint, so a fingerprint written into the plan can be checked against the path without downloading anything.",
+  "reference_file_path_note": "In this dataset every reference file sits in a folder whose name is 32 hexadecimal characters, and some of those folders are the first 32 characters of that file's SHA-256 fingerprint. Not all of them: measured on the pinned revision, 160 of these 261 paths, and none at all of the 248 under deliverable_files/. So a folder name that agrees with a fingerprint written into the plan confirms 32 of its 64 characters without downloading anything, while one that disagrees says only that they disagree — it cannot tell a wrong fingerprint from a folder that was never named after its file.",
   "schema_version": "gdpval-task-catalog-v2",
   "tasks": [
     {

--- a/batch-runner/scripts/build_gdpval_task_catalog.py
+++ b/batch-runner/scripts/build_gdpval_task_catalog.py
@@ -236,10 +236,16 @@ def build_catalog(parquet_path: Path) -> dict:
             "length."
         ),
         "reference_file_path_note": (
-            "In this dataset each reference file sits in a folder named after "
-            "the first 32 hexadecimal characters of that file's SHA-256 "
-            "fingerprint, so a fingerprint written into the plan can be "
-            "checked against the path without downloading anything."
+            "In this dataset every reference file sits in a folder whose name "
+            "is 32 hexadecimal characters, and some of those folders are the "
+            "first 32 characters of that file's SHA-256 fingerprint. Not all "
+            "of them: measured on the pinned revision, 160 of these 261 paths, "
+            "and none at all of the 248 under deliverable_files/. So a folder "
+            "name that agrees with a fingerprint written into the plan "
+            "confirms 32 of its 64 characters without downloading anything, "
+            "while one that disagrees says only that they disagree — it cannot "
+            "tell a wrong fingerprint from a folder that was never named after "
+            "its file."
         ),
         "tasks": tasks,
     }

--- a/batch-runner/scripts/build_gold_deliverable_manifest.py
+++ b/batch-runner/scripts/build_gold_deliverable_manifest.py
@@ -29,7 +29,7 @@ file still matches, without writing anything.
 
 Getting the bytes, once and free:
 
-    huggingface-cli download openai/gdpval --repo-type dataset \\
+    hf download openai/gdpval --repo-type dataset \\
         --revision <sha> --include 'deliverable_files/*' --local-dir DIR
 """
 
@@ -104,7 +104,7 @@ def _resolve_source_file(dataset_root: Path, source_path: str) -> Path:
     if not candidate.is_file():
         raise SystemExit(
             f"no copy of {source_path} under {dataset_root}. Download the "
-            f"pinned revision first: huggingface-cli download {DATASET_REPO_ID} "
+            f"pinned revision first: hf download {DATASET_REPO_ID} "
             f"--repo-type dataset --revision {DATASET_REVISION} "
             "--include 'deliverable_files/*' --local-dir <dir>"
         )

--- a/batch-runner/tests/test_envelope_preflight_reads_the_input_files.py
+++ b/batch-runner/tests/test_envelope_preflight_reads_the_input_files.py
@@ -22,6 +22,17 @@ them would force anything asking "is anything else wrong?" to either fail on a
 build server or filter by guesswork, and a filter that could swallow a
 disagreement would undo the whole check.
 
+The third thing is what a folder name is allowed to prove. The folder half of
+the rule above was itself built on a premise the dataset does not honour: that
+a folder of 32 hexadecimal characters is the start of its file's fingerprint.
+Measured on the pinned revision, that is true of 200 of its 549 files and false
+of the other 349 — every one of the 248 under ``deliverable_files/`` among
+them. The two shapes are identical on the page, so a *match* between folder and
+written value is evidence and a *mismatch* is not evidence of anything. The
+tests below hold the check to that asymmetry: it keeps the 32 characters when
+they agree, and when they disagree it reports the disagreement, blocks the run,
+and names no culprit.
+
 Nothing here calls a model, downloads anything, or spends anything.
 """
 
@@ -46,6 +57,7 @@ from core.execution_envelope_preflight import (  # noqa: E402
 )
 from core.execution_envelope_tasks import (  # noqa: E402
     DATASET_DATA_FILE,
+    HOW_TO_GET_THE_FILES,
     INPUT_FILE_DISAGREED,
     INPUT_FILE_FOLDER_NAME_ONLY,
     INPUT_FILE_NOT_CHECKED,
@@ -54,9 +66,10 @@ from core.execution_envelope_tasks import (  # noqa: E402
     CatalogTask,
     TaskCatalog,
     check_input_file_versions,
+    folder_name_agrees_with,
     load_task_catalog,
     locate_input_file,
-    path_carries_its_own_fingerprint,
+    path_folder_is_shaped_like_a_fingerprint,
     reference_files_for,
     sha256_of_file,
     verify_input_file_versions,
@@ -83,12 +96,38 @@ UNRELATED_FINGERPRINT = (
 
 
 def _write_reference_file(root: Path, name: str, body: bytes) -> str:
-    """Put a file where this dataset keeps it, and return its path."""
+    """Put a file in a folder this dataset really did name after it.
+
+    Two hundred of the pinned revision's 549 files are like this. Only these
+    ones can have 32 characters of their fingerprint confirmed without a copy.
+    """
     fingerprint = hashlib.sha256(body).hexdigest()
     folder = root / "reference_files" / fingerprint[:REFERENCE_PATH_FINGERPRINT_LENGTH]
     folder.mkdir(parents=True, exist_ok=True)
     (folder / name).write_bytes(body)
     return f"reference_files/{fingerprint[:REFERENCE_PATH_FINGERPRINT_LENGTH]}/{name}"
+
+
+def _write_file_in_an_opaque_folder(root: Path, name: str, body: bytes) -> str:
+    """Put a file in a 32-character folder that is *not* named after it.
+
+    The other 349 of the pinned revision's 549 files are like this, including
+    every one of the 248 under ``deliverable_files/``. On the page the path
+    looks exactly like the one above — 32 hexadecimal characters either way —
+    which is the whole reason the shape cannot be read as provenance:
+
+        reference_files/4e6e2b8d17f751e483aad52c109813b4/Fall Music Tour Ref File.xlsx
+
+    really hashes to ``3d0ebb81…`` at the pinned revision, and nothing about
+    the path says so.
+    """
+    folder_name = hashlib.sha256(b"named after something else: " + name.encode())
+    folder_name = folder_name.hexdigest()[:REFERENCE_PATH_FINGERPRINT_LENGTH]
+    assert not hashlib.sha256(body).hexdigest().startswith(folder_name)
+    folder = root / "reference_files" / folder_name
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / name).write_bytes(body)
+    return f"reference_files/{folder_name}/{name}"
 
 
 def _task(task_id: str, paths: tuple[str, ...]) -> CatalogTask:
@@ -138,6 +177,43 @@ def small_benchmark(tmp_path):
         second: sha256_of_file(root / second),
     }
     return root, catalog, ("task-one",), written
+
+
+@pytest.fixture
+def opaque_benchmark(tmp_path):
+    """The same benchmark, with one file in a folder not named after it.
+
+    Both written fingerprints are correct. The only difference between the two
+    files is one nobody can see from the path: one folder repeats the start of
+    its file's fingerprint and the other does not, exactly as 200 and 349 of
+    the pinned revision's files respectively do.
+    """
+    root = tmp_path / "dataset"
+    root.mkdir()
+    honest = _write_reference_file(root, "Costs.xlsx", b"one hundred widgets\n")
+    opaque = _write_file_in_an_opaque_folder(
+        root, "Notes.docx", b"a note about widgets\n"
+    )
+
+    data_file = root / DATASET_DATA_FILE
+    data_file.parent.mkdir(parents=True, exist_ok=True)
+    data_file.write_bytes(b"a stand-in for the benchmark's own data file\n")
+
+    catalog = TaskCatalog(
+        schema_version="gdpval-task-catalog-v1",
+        dataset_repo_id="example/benchmark",
+        dataset_revision="d" * 40,
+        dataset_file_sha256=sha256_of_file(data_file),
+        tasks=(_task("task-one", (honest, opaque)),),
+    )
+    written = {
+        f"{catalog.dataset_repo_id}@{catalog.dataset_revision}": (
+            catalog.dataset_file_sha256
+        ),
+        honest: sha256_of_file(root / honest),
+        opaque: sha256_of_file(root / opaque),
+    }
+    return root, catalog, ("task-one",), written, honest, opaque
 
 
 @pytest.fixture
@@ -225,10 +301,38 @@ def test_the_report_says_how_to_get_the_missing_files_for_nothing(
 ):
     result = _verify(small_benchmark, root=tmp_path / "nowhere")
 
-    assert any(
-        "huggingface-cli download" in note for note in result.missing_copies
-    )
+    assert any("hf download" in note for note in result.missing_copies)
     assert any("--dataset-root" in note for note in result.missing_copies)
+
+
+def test_the_command_the_report_names_is_one_this_machine_can_run():
+    """A pointer a reader cannot follow is worse than none: it reads as a fact.
+
+    ``huggingface-cli`` was named here until the pinned huggingface-hub stopped
+    shipping it as anything but a message saying it "is deprecated and no
+    longer works" — which it prints on the way to exiting without downloading
+    a byte. Nothing is downloaded here either; the command is only asked
+    whether it exists, with ``--help``.
+
+    A machine that does not have the program at all is skipped rather than
+    failed. Not being able to ask is not the same answer as asking and being
+    told no, which is the distinction this whole module is about.
+    """
+    import shlex
+    import shutil
+    import subprocess
+
+    quoted = HOW_TO_GET_THE_FILES[HOW_TO_GET_THE_FILES.index("`") + 1 :]
+    program = shlex.split(quoted[: quoted.index("`")])[0]
+    if shutil.which(program) is None:
+        pytest.skip(f"{program} is not on this machine, so it cannot be asked")
+
+    finished = subprocess.run(
+        [program, "--help"], capture_output=True, text=True, timeout=120
+    )
+
+    assert finished.returncode == 0, finished.stderr
+    assert "no longer works" not in (finished.stdout + finished.stderr)
 
 
 def test_a_missing_copy_says_how_much_of_the_fingerprint_went_unchecked(
@@ -257,10 +361,16 @@ def test_a_fingerprint_nobody_could_compare_is_never_called_fully_checked(
     assert len(result.not_fully_checked) == len(result.checks)
 
 
-def test_the_second_half_is_still_checked_when_the_first_half_cannot_be(
+def test_the_folder_disagreeing_still_stops_the_run_without_naming_a_culprit(
     small_benchmark, tmp_path
 ):
-    """A missing copy must not turn into a free pass for the folder rule."""
+    """A missing copy must not turn into a free pass for the folder rule.
+
+    It must not turn into a verdict either. The folder and the written value
+    disagree; that is reported, it blocks, and which of the two is wrong is
+    left unsaid, because in this dataset a folder that is not named after its
+    file disagrees with a *correct* fingerprint exactly like this.
+    """
     dataset_root, catalog, task_ids, honest = small_benchmark
     path = sorted(key for key in honest if key.startswith("reference_files/"))[0]
     tampered = dict(honest)
@@ -269,8 +379,65 @@ def test_the_second_half_is_still_checked_when_the_first_half_cannot_be(
     result = verify_input_file_versions(
         tampered, task_ids, catalog, tmp_path / "nowhere"
     )
+    gate = check_input_file_versions(
+        tampered, task_ids, catalog, tmp_path / "nowhere"
+    )
+    check = {item.path: item for item in result.checks}[path]
 
-    assert any("describes some other file" in note for note in result.problems)
+    assert any(path in note for note in result.missing_copies)
+    assert any("does not repeat the first 32" in note for note in result.all_notes)
+    assert gate != []
+    # not filed as a verdict, and not filed as work that was done
+    assert not any("describes some other file" in note for note in result.all_notes)
+    assert check.state == INPUT_FILE_NOT_CHECKED
+    assert check.characters_compared == 0
+
+
+def test_the_old_folder_verdict_would_be_caught_if_it_came_back(
+    small_benchmark, tmp_path
+):
+    """Proof the test above can fail, by rebuilding what the check used to say.
+
+    Until this was fixed the branch appended a problem reading "the fingerprint
+    written for <path> does not match the folder the dataset keeps that file
+    in, so the written value describes some other file", and recorded the file
+    as ``folder name only`` with 32 of 64 characters compared. Both are
+    reconstructed here so the assertions above are shown to be load-bearing.
+    """
+    dataset_root, catalog, task_ids, honest = small_benchmark
+    path = sorted(key for key in honest if key.startswith("reference_files/"))[0]
+    tampered = dict(honest)
+    tampered[path] = UNRELATED_FINGERPRINT
+
+    result = verify_input_file_versions(
+        tampered, task_ids, catalog, tmp_path / "nowhere"
+    )
+    as_it_used_to_be = dataclasses.replace(
+        result,
+        problems=result.problems
+        + (
+            f"the fingerprint written for {path} does not match the folder the "
+            "dataset keeps that file in, so the written value describes some "
+            "other file",
+        ),
+        checks=tuple(
+            dataclasses.replace(
+                check,
+                state=INPUT_FILE_FOLDER_NAME_ONLY,
+                characters_compared=REFERENCE_PATH_FINGERPRINT_LENGTH,
+            )
+            if check.path == path
+            else check
+            for check in result.checks
+        ),
+    )
+    was = {item.path: item for item in as_it_used_to_be.checks}[path]
+
+    assert any(
+        "describes some other file" in note for note in as_it_used_to_be.all_notes
+    )
+    assert was.characters_compared == REFERENCE_PATH_FINGERPRINT_LENGTH
+    assert was.state == INPUT_FILE_FOLDER_NAME_ONLY
 
 
 def test_a_missing_copy_is_not_filed_as_a_disagreement(
@@ -316,6 +483,149 @@ def test_both_lists_are_reasons_not_to_start(small_benchmark, tmp_path):
     assert gate != []
 
 
+# ── A folder shaped like a fingerprint is not a fingerprint ────────────────
+#
+# The check used to read a path's *shape*: a folder of 32 hexadecimal
+# characters was taken to be the first half of that file's own fingerprint. It
+# is true of 200 of the pinned revision's 549 files and false of the other 349,
+# including every one of the 248 under ``deliverable_files/``, and the two look
+# identical on the page.
+#
+# Two things followed. A correct fingerprint for one of the 349 was filed as
+# "the written value describes some other file" — a verdict the check had no
+# basis for. And a file nothing had compared was recorded as 32 of 64
+# characters checked, which is never-measured published as half-measured.
+
+
+def test_the_shape_of_a_path_is_not_read_as_a_promise_about_its_contents():
+    """The predicate says what it can see, and its name says so too.
+
+    Both of these paths are the same shape. One folder is the start of its
+    file's fingerprint and the other is not, and no reading of the path can
+    tell them apart — which is why the answer here is only "worth comparing",
+    and the comparing is done elsewhere against a real value.
+    """
+    body = b"one hundred widgets\n"
+    real = hashlib.sha256(body).hexdigest()
+    named_after_it = f"reference_files/{real[:32]}/Costs.xlsx"
+    named_after_nothing = f"reference_files/{'0123456789abcdef' * 2}/Costs.xlsx"
+
+    assert path_folder_is_shaped_like_a_fingerprint(named_after_it)
+    assert path_folder_is_shaped_like_a_fingerprint(named_after_nothing)
+
+    assert folder_name_agrees_with(named_after_it, real)
+    assert not folder_name_agrees_with(named_after_nothing, real)
+    assert not folder_name_agrees_with("inputs/Costs.xlsx", real)
+
+
+def test_a_correct_fingerprint_under_an_opaque_folder_is_not_accused(
+    opaque_benchmark, tmp_path
+):
+    """The false accusation, gone. This is the regression itself.
+
+    Both fingerprints in this plan are correct. One file's folder happens to be
+    named after it and the other's is not — the arrangement 349 of the pinned
+    revision's 549 files are in. Before this fix the second one was reported as
+    a written value that "describes some other file".
+    """
+    _, catalog, task_ids, written, honest, opaque = opaque_benchmark
+
+    result = verify_input_file_versions(
+        written, task_ids, catalog, tmp_path / "nowhere"
+    )
+
+    assert result.problems == ()
+    assert not any(
+        "describes some other file" in note for note in result.all_notes
+    )
+    assert any(opaque in note for note in result.missing_copies)
+
+
+def test_an_opaque_folder_is_recorded_as_nothing_compared_not_half_compared(
+    opaque_benchmark, tmp_path
+):
+    """The second harm: effort that was never spent, written down as spent."""
+    _, catalog, task_ids, written, honest, opaque = opaque_benchmark
+
+    result = verify_input_file_versions(
+        written, task_ids, catalog, tmp_path / "nowhere"
+    )
+    by_path = {check.path: check for check in result.checks}
+
+    assert by_path[opaque].state == INPUT_FILE_NOT_CHECKED
+    assert by_path[opaque].characters_compared == 0
+    # and the file whose folder really does agree still gets its 32 characters,
+    # because 32 hexadecimal characters do not line up by accident
+    assert by_path[honest].state == INPUT_FILE_FOLDER_NAME_ONLY
+    assert by_path[honest].characters_compared == REFERENCE_PATH_FINGERPRINT_LENGTH
+
+
+def test_withdrawing_the_accusation_does_not_withdraw_the_gate(
+    opaque_benchmark, tmp_path
+):
+    """Fail closed. Saying less must not mean stopping less.
+
+    ``problems`` is now empty for this plan, and the run must still refuse to
+    start. It does because the note goes to ``missing_copies``, which the
+    preflight folds back into its own problems — being unable to check a
+    fingerprint has always been a reason not to start.
+    """
+    _, catalog, task_ids, written, honest, opaque = opaque_benchmark
+
+    gate = check_input_file_versions(
+        written, task_ids, catalog, tmp_path / "nowhere"
+    )
+    result = verify_input_file_versions(
+        written, task_ids, catalog, tmp_path / "nowhere"
+    )
+
+    assert gate != []
+    assert any(opaque in note for note in gate)
+    assert not result.everything_was_read
+    assert gate == list(result.all_notes)
+
+
+def test_a_copy_under_an_opaque_folder_that_disagrees_is_not_called_tampering(
+    opaque_benchmark
+):
+    """With the bytes in hand the same restraint applies, for the same reason.
+
+    A copy sitting in a folder nobody proved was named after it could be any
+    revision. The two disagree; which one is wrong is not knowable from here.
+    The stronger sentence is kept for the file whose folder the bytes or the
+    written value confirm.
+    """
+    dataset_root, catalog, task_ids, written, honest, opaque = opaque_benchmark
+    (dataset_root / opaque).write_bytes(b"some other revision of the note\n")
+
+    result = verify_input_file_versions(written, task_ids, catalog, dataset_root)
+    check = {item.path: item for item in result.checks}[opaque]
+
+    assert check.state == INPUT_FILE_DISAGREED
+    assert check.characters_compared == 64
+    assert any("do not describe the same file" in note for note in result.problems)
+    assert not any(
+        "describes some other file" in note for note in result.problems
+    )
+
+
+def test_both_files_pass_when_the_copies_are_there_and_agree(opaque_benchmark):
+    """The opaque folder is not being treated as a fault of its own.
+
+    Nothing about a folder that is not named after its file is wrong. It is
+    only unhelpful, and the check must say nothing at all about it when the
+    bytes are readable and match.
+    """
+    dataset_root, catalog, task_ids, written, _, _ = opaque_benchmark
+
+    result = verify_input_file_versions(written, task_ids, catalog, dataset_root)
+
+    assert result.problems == ()
+    assert result.missing_copies == ()
+    assert result.everything_was_read
+    assert result.everything_agreed
+
+
 # ── The path shape that used to be waved through ───────────────────────────
 
 
@@ -342,7 +652,7 @@ def test_a_path_that_says_nothing_about_its_contents_is_not_waved_through(
 
     result = verify_input_file_versions(written, ("task-one",), catalog, tmp_path)
 
-    assert not path_carries_its_own_fingerprint("inputs/Costs.xlsx")
+    assert not path_folder_is_shaped_like_a_fingerprint("inputs/Costs.xlsx")
     by_path = {check.path: check for check in result.checks}
     assert by_path["inputs/Costs.xlsx"].state == INPUT_FILE_NOT_CHECKED
     assert by_path["inputs/Costs.xlsx"].characters_compared == 0
@@ -379,7 +689,7 @@ def test_a_folder_named_on_purpose_is_preferred_over_the_download_cache(
 def test_a_copy_in_a_named_folder_is_read_rather_than_refused(small_benchmark):
     """A file sitting right there is evidence, and refusing it helps nobody."""
     dataset_root, catalog, _, _ = small_benchmark
-    assert not path_carries_its_own_fingerprint(DATASET_DATA_FILE)
+    assert not path_folder_is_shaped_like_a_fingerprint(DATASET_DATA_FILE)
 
     found = locate_input_file(DATASET_DATA_FILE, catalog, dataset_root)
 
@@ -877,7 +1187,7 @@ def test_a_copy_that_was_only_pointed_at_also_records_the_disagreement(
     result = verify_input_file_versions(written, ("task-one",), catalog, elsewhere)
     check = {item.path: item for item in result.checks}[path]
 
-    assert not path_carries_its_own_fingerprint(path)
+    assert not path_folder_is_shaped_like_a_fingerprint(path)
     assert check.state == INPUT_FILE_DISAGREED
     assert any("do not describe the same file" in note for note in result.problems)
 

--- a/batch-runner/tests/test_execution_envelope_advance_check.py
+++ b/batch-runner/tests/test_execution_envelope_advance_check.py
@@ -55,6 +55,7 @@ from core.execution_envelope_tasks import (  # noqa: E402
     DATASET_REVISION,
     FORMAT_TEXT_ONLY,
     FULL_RUN_TASK_COUNT,
+    INPUT_FILE_READ,
     TRIAL_RUN_TASK_COUNT,
     catalog_sha256,
     check_catalog_carries_no_scores,
@@ -505,15 +506,40 @@ def test_a_reference_file_left_unpinned_is_reported(plan, catalog):
 
 
 def test_a_fingerprint_that_belongs_to_another_file_is_reported(plan, catalog):
+    """A tampered fingerprint is always reported, in the wording it can support.
+
+    How strongly the report is allowed to put it depends on what this machine
+    can see. Where a copy of the file is present its digest settles the matter,
+    and the note says the written value describes some other file. Where no copy
+    is present, all that is visible is that the folder name and the written value
+    disagree — and in this dataset most folders are not named after their file's
+    contents, so that disagreement cannot say which of the two is at fault.
+
+    This used to assert the strong wording unconditionally, and passed on a
+    machine with nothing downloaded only because the check made that claim from
+    the shape of the path. Tampering with the fingerprint destroys the very
+    evidence that this folder is one of the content-derived ones, so a machine
+    without the bytes genuinely cannot tell the tampering from a correct value
+    under an opaque folder. What holds everywhere is that it is reported, that
+    the run stops, and that the file is never recorded as one that was read and
+    agreed.
+    """
     conditions = conditions_from_plan(plan)
     entry = conditions["host_python_process"]
     tampered = dict(entry.input_file_versions)
     target = sorted(reference_files_for(entry.task_ids, catalog))[0]
     tampered[target] = "0" * 64
 
-    problems = check_input_file_versions(tampered, entry.task_ids, catalog)
+    verification = verify_input_file_versions(tampered, entry.task_ids, catalog)
+    notes = [note for note in verification.all_notes if target in note]
 
-    assert any("describes some other file" in note for note in problems)
+    assert notes, f"{target} was tampered with and the report said nothing"
+    assert any(
+        "describes some other file" in note or "does not repeat the first" in note
+        for note in notes
+    ), notes
+    check = next(one for one in verification.checks if one.path == target)
+    assert check.state != INPUT_FILE_READ, "a tampered value was recorded as read"
 
 
 def test_a_dataset_fingerprint_that_does_not_match_is_reported(plan, catalog):


### PR DESCRIPTION
## What was wrong

The advance check reads a plan's written SHA-256 for each input file and tries to
confirm it. When no copy of the file is on the machine, it fell back to the
folder the dataset keeps the file in — and it treated **the shape of that folder**
as if it were the file's fingerprint:

* a folder 32 hexadecimal characters long earned `characters_compared=32` and the
  note *"the folder name repeats the first half of the fingerprint"*, for a file
  nothing had read; and
* a folder that **disagreed** with the written value was filed as a hard problem:
  *"the fingerprint written for … does not match the folder the dataset keeps
  that file in, so the written value describes some other file."*

Both rest on a premise this dataset does not honour.

## The measurement

Downloaded all 549 files at the pinned revision `11e7900c` (free, no model call)
and compared each folder name against the file's real digest:

| set | files | folder is 32-hex — what the code tested | folder **is** `sha256[:32]` — what it inferred |
|---|---|---|---|
| `reference_files/` | 301 | 301 (100%) | **200 (66.4%)** |
| `deliverable_files/` | 248 | 248 (100%) | **0 (0.0%)** |
| the catalogue's own paths | 261 | 261 (100%) | **160 (61.3%)** |
| **total** | **549** | **549** | **200 → 349 counterexamples** |

Every file in the dataset sits in a 32-hex folder, so the property the code
tested is true of all 549, while the property it concluded is true of 200. Two
citable counterexamples:

```
reference_files/4e6e2b8d17f751e483aad52c109813b4/Fall Music Tour Ref File.xlsx
    → 3d0ebb81…
reference_files/6498264b7ee431a71a604675222584eb/COA.xlsx
    → 7018fed4…
```

A **correct** fingerprint for either of those disagrees with its folder in
exactly the way a wrong one does.

## The fix, and why it is asymmetric

Evidence here is one-directional, so the fix is too.

* **Agreement is evidence.** Thirty-two hexadecimal characters do not line up by
  accident. Where the folder agrees with the written value, the 32-character
  credit is *kept* — unchanged.
* **Disagreement is two indistinguishable stories.** A wrong fingerprint and a
  folder that was never named after its file look identical from the path. So the
  disagreement is still reported, but recorded as `not checked` with
  `characters_compared=0`, and blamed on nobody.

The read path (a copy *is* on disk and its digest differs) now demands 32
characters of evidence that the folder is content-derived before using the strong
"describes some other file" wording — either the real digest begins with the
folder, or the written value does. Folder *shape* alone no longer qualifies.

## The gate does not move

`core/execution_envelope_preflight.py:1697` does
`problems.extend(missing_input_file_problems)`. Moving this note from `problems`
to `missing_copies` changes the sentence a reader gets and the number recorded —
never whether the run starts. A test asserts the run still stops on a
disagreeing folder, and another rebuilds the old record and fails if the verdict
ever comes back.

## Two things fixed on the way past

* `_locate_with_provenance` inferred "this is the pinned revision" from path shape
  for a `--dataset-root` copy. It now returns that only for the download cache
  under the pinned revision, and asks the question again once the bytes are in
  hand, where a digest can answer it.
* The report told readers to run `huggingface-cli download …`. On the pinned
  `huggingface-hub` that command exits 1 with *"is deprecated and no longer
  works"*. It now names `hf download`, and **a new test runs whatever command the
  report names**, asserting rc 0 and no "no longer works" — a pointer a reader
  cannot follow is worse than none, because it reads as a fact.

## Grader source hash: moves, with reason and impact

Per the standing rule that a diff moving the grader fingerprint must prove why
and what it re-grades, before merging:

| | |
|---|---|
| before (`af0f001`) | `1a46fc6677655491fe8763246011eec4af6ae3d7df5da80326d39e5fbfd90fd9` |
| after (this branch, `3e248c5`) | `7c0015671d555650765e20aa5b8f3f15782cb7711aa7b4a88195d1293f709b35` |

**Why it moves:** `compute_grader_source_hash` (`step8_grade.py:161`) globs
`core/**.py` wholesale (`:178-181`). `core/execution_envelope_tasks.py` is an
input by that glob and by nothing else — it is not named anywhere in the judging
configuration.

**Re-grading impact: none.** Runtime proof, not inspection — importing
`step8_grade`, `core.grader`, `core.tool_calling_judge`, `core.grader_routing`
and `core.rubric_loader` leaves `core.execution_envelope_tasks` **absent from
`sys.modules`**. Its only importers are the envelope/cost/preflight modules and
two scripts, none of which the judge loads. No grade payload, score, or published
figure can differ.

**Freeze check:** `scripts/check_grader_hash_freeze.py` → `PASS: no paid grade
run in flight` (re-run at `3e248c5`: 50 runs fetched, 0 in flight, latest
completed 2026-09-02). It restates the standing obligation: the next paid run
must be preceded by a fresh smoke at the new fingerprint.

## No published figure moves

Measured, not assumed. For `experiments/execution_envelope/advance_check_plan.yaml`
under all three conditions (`host_python_process`, `docker_container`,
`azure_code_interpreter`):

```
tasks=5  refs=2  written=3  shaped=2  agrees=2  →  changed_by_this_pr=0
```

The third written key is the revision pin, not a file. Both reference files
resolve through the download cache at the pinned revision, so they take the
`pinned_by_revision` path; and where they would not, both folders agree with both
written values. Doubly latent. The other four YAMLs under
`experiments/execution_envelope/` are not plans.

## CI caught a regression, and it is worth stating plainly

The first push failed `pytest` on CI — one test, green on this machine, red
there: `test_a_fingerprint_that_belongs_to_another_file_is_reported`. It tampers
with a written fingerprint and asserts the report says *"describes some other
file."*

That test was passing on a cacheless machine **because of the very verdict this
PR removes.** With no bytes to hash, the old code reached that wording from the
shape of the path alone. Take the shape-based verdict away and, on a machine
holding no copy of the file, there is nothing left to reach it with — because
tampering destroys its own evidence. The only proof that this file's folder is
one of the 200 content-derived ones was the fingerprint that agreed with it, and
the test overwrites exactly that. A tampered value and a correct value under an
opaque folder are, on that machine, *the same observation.*

Locally this never fired: the pinned revision is in this machine's HuggingFace
cache, so the check takes the read path and a real digest settles it. Reproducing
CI took `HF_HOME=<empty dir> HF_HUB_CACHE=<empty>/hub`, which
`huggingface_hub.try_to_load_from_cache` honours.

So the test now asserts what is true on **every** machine — the file is reported,
the run still stops, and it is never recorded as one that was read and agreed —
and carries a docstring explaining why it may not assert more without the bytes.
It is not weakened to go green; the claim it used to make was only ever
supportable where a copy exists, and there it is still made and still tested.

One honesty correction came with it. `InputFileVerification.problems` was
documented as *"It says the same thing on every machine, because it is about what
was written down, not about what happens to be lying around."* That is the retired
assumption, restated. It now says a machine that cannot see the file is not
entitled to the same sentence, and points at `missing_copies` — which still stops
the run.

## Verification

* backend: **7,744 passed / 8 skipped / 45 deselected / 0 failed** (17:39)
* backend again under CI's condition — empty `HF_HOME`, nothing cached:
  **7,744 passed / 8 skipped / 0 failed** (18:17). Same numbers, different
  code path; this is the run that would have caught the regression above
* the rewritten file alone: **51 passed / 0 skipped** (was 43 tests)
* targeted sweep `-k "envelope or catalog or catalogue or ceiling or gold"`:
  **1,418 passed / 3 skipped / 0 failed**
* `mypy core/ --ignore-missing-imports`: 176 errors, all pre-existing, **0** in
  any edited file
* frontend `npm run test:aggregate`: **446 pass / 0 fail / 1 skip** (unchanged);
  `tsc --noEmit` clean; `npm run build` ✓

### Full-suite delta against the base commit

Both measured on this machine, `af0f001` in a separate worktree:

| | base `af0f001` | this branch |
|---|---|---|
| passed | 7,733 | **7,744** |
| skipped | 11 | **8** |
| failed | **0** | **0** |
| collected | 7,744 | **7,752** |

`+8` collected is exactly the rewritten test file, 43 → 51. `+11 passed / −3
skipped` is that `+8` plus three `test_file_reader.py` integration tests that
skipped **only** in the freshly-created base worktree, because their fixture
tests `<worktree>/data/gdpval-local` for existence and that untracked directory
did not exist there when the run started. Re-running that file at `af0f001` now
gives `23 passed, 0 skipped` — identical to this branch. Environment, not code.

