### PR TITLE
feat(grading): re-measure audio discrimination on musical material

### DIFF
--- a/batch-runner/scripts/measure_audio_grading_accuracy.py
+++ b/batch-runner/scripts/measure_audio_grading_accuracy.py
@@ -19,19 +19,21 @@ agrees with itself. It does not tell you the model is listening.
 So this script builds its own corpus, out of nothing but arithmetic.
 
 Every clip here is synthesised from a segment list -- a start time, an end
-time, and either a frequency or silence -- by :func:`render_clip`, using only
-``wave`` and ``math`` from the standard library. There is no recording, no
-asset, no download, and nothing committed as bytes. What is in the clip is
-what the segment list says is in it, and the accompanying test decodes the
-rendered samples back and checks that the waveform really has the onsets, the
-gaps, the beep count and the pitch order the segments claim. **The ground
-truth is not asserted in prose; it is measured off the same bytes the model
-hears.**
+time, and either silence or a frequency, optionally with further frequencies
+sounding alongside it -- by :func:`render_clip`, using only ``wave`` and
+``math`` from the standard library. There is no recording, no asset, no
+download, and nothing committed as bytes. What is in the clip is what the
+segment list says is in it, and the accompanying test decodes the rendered
+samples back and checks that the waveform really has the onsets, the gaps, the
+beep count, the pitch order, the scale degrees, the chord tones, the overtones
+and the semitone transposition the segments claim. **The ground truth is not
+asserted in prose; it is measured off the same bytes the model hears.**
 
-Against those clips it puts twelve criteria, six of which are true and six of
-which are false, matched in pairs so that each clip carries one of each. The
-criteria are written the way the gold rubric writes them, and the families
-they fall into are the families that actually failed on the gold run:
+Against those clips it puts twenty criteria, ten of which are true and ten of
+which are false, matched in pairs so that each pair sits on one clip and
+carries one of each. The criteria are written the way the gold rubric writes
+them, and the families they fall into are the families that actually failed on
+the gold run:
 
 * ``timing``       -- a tone stops partway through; a criterion says it does
                       not. This is the exact shape of the 0.95-vs-0.96
@@ -44,6 +46,36 @@ they fall into are the families that actually failed on the gold run:
   61-89 token answer. Whether a claim at that resolution is answerable at all
   is a question this family exists to answer.
 * ``pitch_order``  -- low then high, and a criterion claiming high then low.
+
+Those six are beeps, and beeps were the first version's admitted limit: the
+gold run's audio criteria are about film and music tracks, and what this
+corpus could get wrong was "how many beeps" rather than anything musical. Four
+more families answer that. Three of them are the questions the gold run's
+failed criteria actually asked -- a key (G major), a modulation (an A-flat
+bridge) and a timbre ("bass synth") -- and the fourth, chord quality, is what
+a key claim rests on and the only one of the four that needs two notes to
+sound at the same instant:
+
+* ``key``        -- an ascending G major scale, and a criterion placing it in
+                    E-flat major. Decidable on one note: the melody plays
+                    F-sharp, which E-flat major does not have.
+* ``triad``      -- three notes sounding at once, and a criterion calling a
+                    major chord minor. The difference is B4 against B-flat4,
+                    493.88 Hz against 466.16 Hz, and it is in the spectrum.
+* ``modulation`` -- an arpeggio that transposes up a semitone halfway, and a
+                    criterion saying the key never changes. The ground truth
+                    is a frequency *ratio*, 2 ** (1/12), measured off the two
+                    halves of the decoded waveform.
+* ``timbre``     -- a low note carrying its first five overtones, and a
+                    criterion calling it a plain sine. This is "bass synth"
+                    reduced to something a spectrum settles.
+
+These are music, not speech, and the distinction is worth stating plainly:
+intelligible speech cannot be synthesised from ``wave`` and ``math``, so a
+speech corpus would need a committed recording, which is exactly what this
+script refuses to have. The speech half of "speech or music with certain
+ground truth" is therefore still open, and nothing here should be read as
+having closed it.
 
 What comes out is not one number but three, and the third is the one that
 matters:
@@ -65,15 +97,17 @@ matters:
     cannot tell a listener from a coin, and a balanced corpus is exactly where
     that failure hides.
 
-The significance of J is taken by *exhaustive* enumeration of the 64 ways the
-six true/false labels could be swapped within their pairs -- not sampling, so
-the p-value is exact and the script has no random state to pin. That design
+The significance of J is taken by *exhaustive* enumeration of the 1024 ways
+the ten true/false labels could be swapped within their pairs -- not sampling,
+so the p-value is exact and the script has no random state to pin. That design
 has a floor, and the floor is reported rather than left for a reader to
-discover: with six pairs the smallest p this can ever produce is 1/64 =
-0.015625. A perfect result is significant at 0.05 and can never reach 0.01.
-Saying so here is the same discipline as ``is_informative: false`` on the
-repeat-variation interval -- the number is published *with* the bound on what
-it can support.
+discover: with ten pairs the smallest p this can ever produce is 1/1024 =
+0.000977. The first version of this corpus had six pairs and a floor of 1/64 =
+0.015625, which could never reach 0.01 however well the model did; four more
+pairs is what removed that bound, and they are musical pairs, so the two
+limits the card recorded are lifted by the same change. Saying so here is the
+same discipline as ``is_informative: false`` on the repeat-variation interval
+-- the number is published *with* the bound on what it can support.
 
 The identity is not chosen here. It is read out of the grading config the
 repeat runs used, so the accuracy figure is measured on the same deployment,
@@ -172,11 +206,28 @@ class Segment:
     ``frequency_hz`` of ``None`` means digital silence -- samples of exactly
     zero, not low-level noise, so "is anything audible here" has an answer
     that survives any encoder.
+
+    ``partials`` is what makes a chord and a timbre expressible, and it is the
+    whole difference between a beep and music. Each entry is
+    ``(frequency_hz, weight)`` and sounds *at the same time* as the
+    fundamental: a triad is three frequencies at once, and a synth bass is a
+    fundamental plus its harmonics. Weights are relative -- the fundamental is
+    1.0 -- and their total is normalised back to :data:`TONE_AMPLITUDE` when
+    the segment is rendered, so a six-voice segment is as loud as a one-voice
+    one and neither clips.
+
+    A segment with no partials renders through exactly the path it always did,
+    at exactly the amplitude it always did: the normaliser divides by 1.0 and
+    the addition loop never runs. That is deliberate rather than incidental.
+    The published "discrimination 0" result was measured on five clips that
+    carry no partials, and it stays re-derivable only if those clips still
+    render to the same bytes. A test decodes them and checks sample by sample.
     """
 
     start_s: float
     end_s: float
     frequency_hz: Optional[float]
+    partials: tuple[tuple[float, float], ...] = ()
 
     @property
     def duration_s(self) -> float:
@@ -186,11 +237,24 @@ class Segment:
     def is_silent(self) -> bool:
         return self.frequency_hz is None
 
+    @property
+    def frequencies_hz(self) -> tuple[float, ...]:
+        """Every frequency sounding here at once, fundamental first."""
+        if self.frequency_hz is None:
+            return ()
+        return (self.frequency_hz, *(freq for freq, _weight in self.partials))
+
+    @property
+    def weight_total(self) -> float:
+        """Fundamental (1.0) plus every partial, for loudness normalisation."""
+        return 1.0 + sum(weight for _freq, weight in self.partials)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "start_s": round(self.start_s, 6),
             "end_s": round(self.end_s, 6),
             "frequency_hz": self.frequency_hz,
+            "partials": [[freq, weight] for freq, weight in self.partials],
         }
 
 
@@ -216,7 +280,10 @@ class Clip:
 
 
 def _tone_samples(
-    frequency_hz: float, count: int, phase_offset: int
+    frequency_hz: float,
+    count: int,
+    phase_offset: int,
+    amplitude: float = TONE_AMPLITUDE,
 ) -> Iterator[float]:
     """A sine at ``frequency_hz``, continuous across segment boundaries.
 
@@ -225,10 +292,14 @@ def _tone_samples(
     the previous one left it instead of restarting at zero. Restarting would
     put a click at every boundary, and a click is an audible event this corpus
     has not declared.
+
+    ``amplitude`` defaults to the value every single-voice segment has always
+    used, so a caller that does not ask for anything else gets the identical
+    float back.
     """
     step = 2.0 * math.pi * frequency_hz / CLIP_SAMPLE_RATE_HZ
     for index in range(count):
-        yield TONE_AMPLITUDE * math.sin(step * (phase_offset + index))
+        yield amplitude * math.sin(step * (phase_offset + index))
 
 
 def clip_samples(clip: Clip) -> list[float]:
@@ -237,6 +308,21 @@ def clip_samples(clip: Clip) -> list[float]:
     Anything the segment list does not cover is silence. That is deliberate:
     a clip is defined by what it *contains*, and the space between two beeps
     should not need its own entry to be quiet.
+
+    The fundamental is *assigned* into the buffer and the partials are *added*
+    to it, so a one-voice segment takes the same statement it always took. In
+    IEEE-754 the accumulating form would give bit-identical results here --
+    ``x * 1.0`` and ``0.0 + x`` are both exact -- so this is a readability
+    choice rather than a correctness one, and it is worth being exact about
+    which: the single-voice path being visibly unchanged is what makes the
+    byte-identity test a check rather than a hope.
+
+    The identity itself does not rest on that choice. It rests on the scale:
+    with no partials ``weight_total`` is 1.0, so the scale is
+    ``TONE_AMPLITUDE / 1.0``, and the loop over partials runs zero times. The
+    published "discrimination 0" result was measured on five clips that go
+    down this path, and a test recomputes all five the pre-partials way and
+    demands exact equality.
     """
     total = int(round(clip.duration_s * CLIP_SAMPLE_RATE_HZ))
     samples = [0.0] * total
@@ -248,10 +334,16 @@ def clip_samples(clip: Clip) -> list[float]:
         if stop <= start:
             continue
         assert segment.frequency_hz is not None
+        scale = TONE_AMPLITUDE / segment.weight_total
         for offset, value in enumerate(
-            _tone_samples(segment.frequency_hz, stop - start, start)
+            _tone_samples(segment.frequency_hz, stop - start, start, scale)
         ):
             samples[start + offset] = value
+        for frequency_hz, weight in segment.partials:
+            for offset, value in enumerate(
+                _tone_samples(frequency_hz, stop - start, start, scale * weight)
+            ):
+                samples[start + offset] += value
     return samples
 
 
@@ -271,6 +363,59 @@ def render_clip(clip: Clip, path: Path) -> str:
         handle.setframerate(CLIP_SAMPLE_RATE_HZ)
         handle.writeframes(frames)
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# --------------------------------------------------------------------------
+# Pitches, so a musical claim is arithmetic rather than taste
+# --------------------------------------------------------------------------
+
+#: Equal temperament, A4 = MIDI 69 = 440 Hz.
+A4_HZ = 440.0
+A4_MIDI = 69
+
+#: The ratio one semitone is. Every musical claim below reduces to this
+#: number or to a membership test over :data:`NOTE`, which is the point: "the
+#: bridge modulates up a semitone" is checkable off the waveform as a
+#: frequency ratio, and "taste" never enters it.
+SEMITONE_RATIO = 2.0 ** (1.0 / 12.0)
+
+
+def pitch_hz(midi_note: int) -> float:
+    """Frequency of an equal-tempered MIDI note number."""
+    return A4_HZ * (2.0 ** ((midi_note - A4_MIDI) / 12.0))
+
+
+#: MIDI numbers for the notes used below, so the segment lists read as music
+#: and the frequencies are derived rather than typed. ``Fs`` is F-sharp, ``b``
+#: is flat. ``Bb4`` and ``F5`` are never played -- they are here because they
+#: are what the *false* claims would require, and the test asserts they are
+#: absent from the waveform.
+NOTE = {
+    "C2": 36,
+    "G4": 67,
+    "Ab4": 68,
+    "A4": 69,
+    "Bb4": 70,
+    "B4": 71,
+    "C5": 72,
+    "D5": 74,
+    "Eb5": 75,
+    "E5": 76,
+    "F5": 77,
+    "Fs5": 78,
+    "G5": 79,
+    "Ab5": 80,
+}
+
+
+def hz(name: str) -> float:
+    """Frequency of a named note, e.g. ``hz("Fs5")``."""
+    return pitch_hz(NOTE[name])
+
+
+#: The overtones the buzzy bass carries, and the falling strengths that make
+#: it read as a synth rather than a sine. 1/n is the sawtooth series.
+BASS_HARMONICS = (2, 3, 4, 5, 6)
 
 
 CLIPS: tuple[Clip, ...] = (
@@ -324,6 +469,81 @@ CLIPS: tuple[Clip, ...] = (
         description=(
             "A 220 Hz tone for two seconds, one second of silence, then a "
             "880 Hz tone for two seconds -- two octaves up."
+        ),
+    ),
+    # ----------------------------------------------------------------------
+    # Musical material. Everything above is a beep; the criteria that actually
+    # failed on the gold run were about key, chord quality, tempo and timbre,
+    # and a corpus of beeps cannot ask those. These four clips are still
+    # arithmetic -- every frequency comes out of pitch_hz -- but they are
+    # arithmetic arranged as music.
+    # ----------------------------------------------------------------------
+    Clip(
+        clip_id="g_major_scale",
+        duration_s=3.4,
+        segments=tuple(
+            Segment(index * 0.4, index * 0.4 + 0.35, hz(name))
+            for index, name in enumerate(
+                ("G4", "A4", "B4", "C5", "D5", "E5", "Fs5", "G5")
+            )
+        ),
+        description=(
+            "Eight notes rising -- G4 A4 B4 C5 D5 E5 F-sharp5 G5 -- each 350 "
+            "ms with a 50 ms gap. That is the G major scale, and the F-sharp "
+            "is what makes it G major rather than any flat key."
+        ),
+    ),
+    Clip(
+        clip_id="major_triad",
+        duration_s=3.0,
+        segments=(
+            Segment(
+                0.2,
+                2.8,
+                hz("G4"),
+                partials=((hz("B4"), 1.0), (hz("D5"), 1.0)),
+            ),
+        ),
+        description=(
+            "One sustained chord: G4, B4 and D5 sounding together for 2.6 "
+            "seconds, which is a G major triad. The minor version of this "
+            "chord would put B-flat4 where the B4 is."
+        ),
+    ),
+    Clip(
+        clip_id="modulating_arpeggio",
+        duration_s=5.0,
+        segments=tuple(
+            Segment(index * 0.6, index * 0.6 + 0.5, hz(name))
+            for index, name in enumerate(
+                ("G4", "B4", "D5", "G5", "Ab4", "C5", "Eb5", "Ab5")
+            )
+        ),
+        description=(
+            "A G major arpeggio -- G4 B4 D5 G5 -- for the first 2.4 seconds, "
+            "then the same shape one semitone higher in A-flat major. The key "
+            "changes exactly halfway through."
+        ),
+    ),
+    Clip(
+        clip_id="buzzy_bass",
+        duration_s=3.0,
+        segments=(
+            Segment(
+                0.2,
+                2.8,
+                hz("C2"),
+                partials=tuple(
+                    (hz("C2") * harmonic, 1.0 / harmonic)
+                    for harmonic in BASS_HARMONICS
+                ),
+            ),
+        ),
+        description=(
+            "One low note -- C2, about 65.4 Hz -- carrying its first five "
+            "overtones at falling strength, which is what makes a synth bass "
+            "buzz instead of hum. A pure sine at the same pitch has none of "
+            "them."
         ),
     ),
 )
@@ -504,6 +724,111 @@ CLAIMS: tuple[Claim, ...] = (
         holds=False,
         because="220 Hz precedes 880 Hz, so the order is the other way round",
     ),
+    # ----------------------------------------------------------------------
+    # The musical families. Three of them are shapes the gold run actually
+    # failed on -- the criteria it marked wrong named a key (G major), a
+    # modulation (an A-flat bridge) and a timbre ("bass synth"). The fourth,
+    # chord quality, is what a key claim rests on. The tempo the gold run also
+    # named is already asked above, of the click track. Each pair here is one
+    # of those questions put to a waveform that answers it.
+    # ----------------------------------------------------------------------
+    Claim(
+        claim_id="key_true",
+        clip_id="g_major_scale",
+        family="key",
+        criterion="Every note in the melody belongs to the G major scale.",
+        holds=True,
+        because=(
+            "the eight notes are G4 A4 B4 C5 D5 E5 F-sharp5 G5, which is "
+            "exactly the G major scale"
+        ),
+    ),
+    Claim(
+        claim_id="key_false",
+        clip_id="g_major_scale",
+        family="key",
+        criterion="Every note in the melody belongs to the E-flat major scale.",
+        holds=False,
+        because=(
+            "E-flat major has E-flat, A-flat and B-flat and no F-sharp; this "
+            "melody plays B natural and F-sharp"
+        ),
+    ),
+    Claim(
+        claim_id="triad_true",
+        clip_id="major_triad",
+        family="triad",
+        criterion="The clip is one sustained chord, and that chord is major.",
+        holds=True,
+        because=(
+            "the chord is G4 + B4 + D5, and B4 is four semitones above G4, "
+            "which is a major third"
+        ),
+    ),
+    Claim(
+        claim_id="triad_false",
+        clip_id="major_triad",
+        family="triad",
+        criterion="The clip is one sustained chord, and that chord is minor.",
+        holds=False,
+        because=(
+            "a minor chord would sound B-flat4 at 466.16 Hz where this one "
+            "sounds B4 at 493.88 Hz"
+        ),
+    ),
+    Claim(
+        claim_id="modulation_true",
+        clip_id="modulating_arpeggio",
+        family="modulation",
+        criterion=(
+            "The music changes key partway through, so the second half is in "
+            "a different key from the first."
+        ),
+        holds=True,
+        because=(
+            "the first four notes spell G major and the last four spell "
+            "A-flat major, one semitone higher"
+        ),
+    ),
+    Claim(
+        claim_id="modulation_false",
+        clip_id="modulating_arpeggio",
+        family="modulation",
+        criterion=(
+            "The music stays in one key from beginning to end, with no change "
+            "of key anywhere in it."
+        ),
+        holds=False,
+        because="the second half is transposed up a semitone from the first",
+    ),
+    Claim(
+        claim_id="timbre_true",
+        clip_id="buzzy_bass",
+        family="timbre",
+        criterion=(
+            "The bass note is a bright, buzzy synth tone with clearly audible "
+            "overtones above its fundamental."
+        ),
+        holds=True,
+        because=(
+            "the segment sounds harmonics 2 through 6 of its 65.4 Hz "
+            "fundamental at falling strength"
+        ),
+    ),
+    Claim(
+        claim_id="timbre_false",
+        clip_id="buzzy_bass",
+        family="timbre",
+        criterion=(
+            "The bass note is a plain sine tone with nothing sounding above "
+            "its fundamental."
+        ),
+        holds=False,
+        because=(
+            "harmonics 2 through 6 of the fundamental are all present in the "
+            "segment"
+        ),
+    ),
 )
 
 
@@ -572,7 +897,7 @@ class Tally:
         """Calls that produced a verdict, hedges included.
 
         A hedge answered; it just did not decide. Excluding it from the
-        denominator would let a model that hedged eleven times out of twelve
+        denominator would let a model that hedged nineteen times out of twenty
         and guessed the last one report 100% accuracy.
         """
         return self.correct + self.false_fail + self.false_pass + self.hedged
@@ -600,8 +925,8 @@ def discrimination(
     """Youden's J over ``(holds, verdict)`` pairs: P(pass|true) - P(pass|false).
 
     The point of this number is that accuracy on a balanced corpus cannot
-    distinguish a listener from a constant. Answer ``pass`` to all twelve
-    criteria and accuracy is 50%; answer ``fail`` to all twelve and accuracy
+    distinguish a listener from a constant. Answer ``pass`` to all twenty
+    criteria and accuracy is 50%; answer ``fail`` to all twenty and accuracy
     is 50%. Both give J = 0. Only a verdict that moves with the audio gives
     J > 0.
 
@@ -622,7 +947,7 @@ def permute_within_pairs(
 ) -> dict[str, Any]:
     """Exact p-value for J, by swapping the labels inside each matched pair.
 
-    Six pairs, so 2^6 = 64 relabellings, enumerated in full rather than
+    Ten pairs, so 2^10 = 1024 relabellings, enumerated in full rather than
     sampled. Exhaustive enumeration is what makes the p exact and what leaves
     this script with no random state to seed -- the same input gives the same
     number, forever, which is what the repeat-variation work needed and did
@@ -635,10 +960,13 @@ def permute_within_pairs(
     null anyone wants to reject.
 
     The floor is reported alongside the p, because it is a property of the
-    design and not of the result: the smallest value obtainable from 64
-    assignments is 1/64 = 0.015625. **This experiment cannot produce evidence
-    at the 0.01 level no matter how well the model does.** Adding repeats does
-    not change that; only more pairs would.
+    design and not of the result: the smallest value obtainable from 1024
+    assignments is 1/1024 = 0.000977. The first version of this corpus had six
+    pairs, a floor of 1/64 = 0.015625, and could not produce evidence at the
+    0.01 level however well the model did. Adding repeats never changed that
+    -- only more pairs could, and four more pairs is what this now has. The
+    floor is still published rather than assumed: a reader is told what the
+    design can support at the same moment they are told what it found.
     """
     pairs = sorted({call["pair_id"] for call in calls})
     observed = discrimination([(c["holds"], c["verdict"]) for c in calls])
@@ -998,8 +1326,8 @@ def build_report(
         "calls": calls,
         "accuracy": summarise(calls),
         "cost": {
-            # Two numbers, because a dry run makes 36 calls and is billed for
-            # none of them. Collapsing them would put a "billable_calls: 36"
+            # Two numbers, because a dry run makes 60 calls and is billed for
+            # none of them. Collapsing them would put a "billable_calls: 60"
             # into a free run's report, and that is exactly the figure someone
             # copies into a cost record.
             "model_calls": model_calls,

--- a/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
+++ b/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
@@ -124,6 +124,43 @@ def zero_crossing_hz(samples: Sequence[float], rate: int) -> float:
     return crossings / (len(samples) / rate) / 2.0
 
 
+def magnitude_at(samples: Sequence[float], rate: int, frequency_hz: float) -> float:
+    """Amplitude of one frequency component, by quadrature correlation.
+
+    :func:`zero_crossing_hz` answers "what note is this" and is enough for a
+    beep, but it is meaningless the moment two notes sound at once: a triad
+    crosses zero at a rate that is not any of its three pitches, and a bass
+    note carrying five overtones crosses far more often than its fundamental.
+    Every musical claim in this corpus is about *simultaneous* content, so the
+    measurement has to be per-frequency.
+
+    This correlates the signal against a sine and a cosine at the frequency
+    asked about and takes the magnitude, which is one bin of a DFT evaluated
+    where it is wanted rather than on a grid. For a pure tone of amplitude A
+    at exactly this frequency it returns A; for a frequency that is not in the
+    signal it returns leakage, which over these window lengths is two orders
+    of magnitude smaller. Standard library only, and no third bin is computed
+    that nothing asks for.
+
+    Absence is the harder half of every claim here -- the false criteria are
+    what the model must *not* confirm -- so a helper that could only find
+    things would leave each pair half-checked.
+    """
+    if not samples:  # pragma: no cover - a window that decoded to nothing
+        return 0.0
+    step = 2.0 * math.pi * frequency_hz / rate
+    real = sum(value * math.cos(step * index) for index, value in enumerate(samples))
+    imag = sum(value * math.sin(step * index) for index, value in enumerate(samples))
+    return 2.0 * math.sqrt(real * real + imag * imag) / len(samples)
+
+
+def window(
+    samples: Sequence[float], rate: int, start_s: float, end_s: float
+) -> list[float]:
+    """The samples between two times, so a claim is measured where it applies."""
+    return list(samples[int(start_s * rate) : int(end_s * rate)])
+
+
 # --------------------------------------------------------------------------
 # The clips really contain what the corpus says they contain
 # --------------------------------------------------------------------------
@@ -223,6 +260,285 @@ def test_low_then_high_goes_low_then_high(tmp_path: Path) -> None:
     assert second > first * 3
 
 
+# --------------------------------------------------------------------------
+# The musical clips, where the ground truth is a frequency rather than a count
+# --------------------------------------------------------------------------
+
+
+def test_the_scale_really_is_g_major_and_really_is_not_e_flat(
+    tmp_path: Path,
+) -> None:
+    """``key``: eight notes, and the one note that settles the question.
+
+    G major and E-flat major share nothing useful to argue over; what decides
+    it in one note is F-sharp, which G major has and E-flat major does not.
+    So the assertion is not "the melody sounds like G major" -- that is taste
+    -- but that 739.99 Hz is in the waveform and 698.46 Hz is not, measured in
+    the window where the seventh note sounds.
+
+    The peak is also located rather than merely detected: of the three
+    candidate semitones around it, F-sharp is the loudest by a wide margin. A
+    threshold alone could be met by spectral leakage from a neighbour; a peak
+    cannot.
+    """
+    clip = probe.CLIPS_BY_ID["g_major_scale"]
+    samples, rate = decode(clip, tmp_path)
+
+    runs = loud_runs(samples, rate)
+    assert len(runs) == 8, runs
+    for index, (start, end) in enumerate(runs):
+        assert abs(start - index * 0.4) < 0.05, runs
+        assert 0.30 < end - start < 0.40, runs
+
+    # The seventh note, index 6, sounds from 2.4 s to 2.75 s.
+    seventh = window(samples, rate, 2.45, 2.70)
+    f_sharp = magnitude_at(seventh, rate, probe.hz("Fs5"))
+    f_natural = magnitude_at(seventh, rate, probe.hz("F5"))
+    assert f_sharp > 0.4, f_sharp
+    assert f_natural < 0.05, f_natural
+    assert f_sharp > f_natural * 8
+    assert f_sharp > magnitude_at(seventh, rate, probe.hz("G5"))
+
+    # Every scale degree, in the window where it sounds, at full amplitude.
+    for index, name in enumerate(("G4", "A4", "B4", "C5", "D5", "E5", "Fs5", "G5")):
+        note = window(samples, rate, index * 0.4 + 0.05, index * 0.4 + 0.30)
+        assert magnitude_at(note, rate, probe.hz(name)) > 0.4, name
+
+
+def test_the_triad_is_three_notes_at_once_and_the_third_is_major(
+    tmp_path: Path,
+) -> None:
+    """``triad``: major against minor is B4 against B-flat4, and it is measurable.
+
+    This is the claim that could not be posed at all before -- a chord needs
+    simultaneous frequencies, and every earlier clip was one voice at a time.
+    The false criterion says the chord is minor, so the test has to show both
+    that the major third is present and that the minor third is absent;
+    showing only the first would leave the model free to be right by accident.
+
+    The three voices are also checked to be equal and simultaneous. A chord
+    whose fifth was twice as loud as its third, or which arpeggiated instead
+    of sustaining, would be a different musical claim than the criterion makes.
+    """
+    clip = probe.CLIPS_BY_ID["major_triad"]
+    samples, rate = decode(clip, tmp_path)
+    body = window(samples, rate, 0.3, 2.7)
+
+    root = magnitude_at(body, rate, probe.hz("G4"))
+    third = magnitude_at(body, rate, probe.hz("B4"))
+    fifth = magnitude_at(body, rate, probe.hz("D5"))
+    minor_third = magnitude_at(body, rate, probe.hz("Bb4"))
+
+    for name, value in (("G4", root), ("B4", third), ("D5", fifth)):
+        assert value > 0.15, (name, value)
+    assert minor_third < 0.02, minor_third
+    assert third > minor_third * 10
+
+    # Equal voices: normalisation divides by the weight total, so no one note
+    # dominates and the chord is a chord rather than a note with two ghosts.
+    assert max(root, third, fifth) - min(root, third, fifth) < 0.02
+
+    # Sustained, not arpeggiated: all three are present in the first tenth of
+    # the chord and in the last tenth of it.
+    for start, end in ((0.3, 0.55), (2.45, 2.7)):
+        slice_ = window(samples, rate, start, end)
+        for name in ("G4", "B4", "D5"):
+            assert magnitude_at(slice_, rate, probe.hz(name)) > 0.12, (name, start)
+
+    # And it never clips, so the encoder is not deciding what the model hears.
+    assert max(abs(value) for value in samples) < 0.95
+
+
+def test_the_arpeggio_changes_key_by_exactly_one_semitone(tmp_path: Path) -> None:
+    """``modulation``: the ground truth is a ratio, not a key signature.
+
+    "The key changes partway through" is decidable without naming either key:
+    the second four notes are the first four multiplied by the same constant,
+    and that constant is the twelfth root of two. Measuring the ratio rather
+    than the keys keeps the test on ground the waveform actually settles.
+
+    The constant also has to be the *same* for all four, which is what makes
+    it a transposition rather than four unrelated notes. A drift there would
+    mean the second half is in no key at all.
+    """
+    clip = probe.CLIPS_BY_ID["modulating_arpeggio"]
+    samples, rate = decode(clip, tmp_path)
+
+    runs = loud_runs(samples, rate)
+    assert len(runs) == 8, runs
+
+    first_half = ("G4", "B4", "D5", "G5")
+    second_half = ("Ab4", "C5", "Eb5", "Ab5")
+    ratios = []
+    for index, (low, high) in enumerate(zip(first_half, second_half)):
+        before = window(samples, rate, index * 0.6 + 0.05, index * 0.6 + 0.45)
+        after = window(
+            samples, rate, (index + 4) * 0.6 + 0.05, (index + 4) * 0.6 + 0.45
+        )
+        assert magnitude_at(before, rate, probe.hz(low)) > 0.4, low
+        assert magnitude_at(after, rate, probe.hz(high)) > 0.4, high
+        # The transposed note is genuinely a different pitch, not the same one.
+        assert magnitude_at(after, rate, probe.hz(low)) < 0.05, (low, high)
+        ratios.append(probe.hz(high) / probe.hz(low))
+
+    for ratio in ratios:
+        assert ratio == pytest.approx(2.0 ** (1.0 / 12.0)), ratios
+    assert max(ratios) - min(ratios) < 1e-9
+
+
+def test_the_bass_carries_overtones_a_plain_sine_does_not(tmp_path: Path) -> None:
+    """``timbre``: "bass synth" reduced to something a spectrum settles.
+
+    The false criterion calls this a plain sine, so the test needs a plain
+    sine to compare against. It builds one -- same pitch, same duration, same
+    renderer, no partials -- and shows that the five overtones present in one
+    are absent from the other. Without the control, "the second harmonic is
+    present" would be a claim about the measurement rather than the clip.
+
+    The falling 1/n weights are checked too. A synth whose sixth harmonic was
+    as loud as its second would still be buzzy, but it would not be the
+    sawtooth-like tone the criterion describes.
+    """
+    clip = probe.CLIPS_BY_ID["buzzy_bass"]
+    samples, rate = decode(clip, tmp_path)
+    body = window(samples, rate, 0.3, 2.7)
+
+    control_clip = probe.Clip(
+        clip_id="control_pure_sine",
+        duration_s=clip.duration_s,
+        segments=(probe.Segment(0.2, 2.8, probe.hz("C2")),),
+        description="Not part of the corpus: a control this test renders itself.",
+    )
+    control, control_rate = decode(control_clip, tmp_path)
+    control_body = window(control, control_rate, 0.3, 2.7)
+
+    fundamental = probe.hz("C2")
+    assert magnitude_at(body, rate, fundamental) > 0.2
+    assert magnitude_at(control_body, control_rate, fundamental) > 0.5
+
+    strengths = []
+    for harmonic in probe.BASS_HARMONICS:
+        here = magnitude_at(body, rate, fundamental * harmonic)
+        there = magnitude_at(control_body, control_rate, fundamental * harmonic)
+        assert here > 0.03, (harmonic, here)
+        assert there < 0.01, (harmonic, there)
+        assert here > there * 5, (harmonic, here, there)
+        strengths.append(here)
+
+    # 1/n, so each overtone is quieter than the one below it.
+    assert strengths == sorted(strengths, reverse=True), strengths
+    assert strengths[0] > strengths[-1] * 2
+
+    # Louder is not the difference: normalisation keeps the two comparable.
+    assert max(abs(value) for value in samples) < 0.95
+
+
+def test_the_original_five_clips_render_byte_for_byte_as_they_did(
+    tmp_path: Path,
+) -> None:
+    """The published "discrimination 0" was measured on these. It must stay re-derivable.
+
+    Adding partials meant touching the renderer every clip goes through, and a
+    renderer that quietly changed the old waveforms would leave the earlier
+    result describing audio that no longer exists. The report publishes a
+    sha256 per clip precisely so a reader can re-derive it; a shifted sample
+    breaks that without breaking anything that would be noticed.
+
+    So this recomputes the five single-voice clips the way the renderer worked
+    *before* partials existed -- one sine, amplitude ``TONE_AMPLITUDE``,
+    assigned rather than accumulated -- and demands exact equality. Local
+    recomputation rather than a hard-coded digest, because ``math.sin`` is the
+    platform's libm and a pinned hash would fail on a different CI host for a
+    reason that has nothing to do with this change.
+
+    The mechanism that makes it hold is arithmetic, not care: with no partials
+    the scale is ``TONE_AMPLITUDE / 1.0``, which is ``TONE_AMPLITUDE``, and
+    the loop that adds partials runs zero times.
+    """
+    original = (
+        "tone_stops_early",
+        "pure_silence",
+        "three_beeps",
+        "clicks_120bpm",
+        "low_then_high",
+    )
+    for clip_id in original:
+        clip = probe.CLIPS_BY_ID[clip_id]
+        assert all(not segment.partials for segment in clip.segments), clip_id
+
+        total = int(round(clip.duration_s * probe.CLIP_SAMPLE_RATE_HZ))
+        expected = [0.0] * total
+        for segment in clip.segments:
+            if segment.frequency_hz is None:
+                continue
+            start = int(round(segment.start_s * probe.CLIP_SAMPLE_RATE_HZ))
+            stop = min(
+                total, int(round(segment.end_s * probe.CLIP_SAMPLE_RATE_HZ))
+            )
+            step = (
+                2.0
+                * math.pi
+                * segment.frequency_hz
+                / probe.CLIP_SAMPLE_RATE_HZ
+            )
+            for index in range(start, stop):
+                expected[index] = probe.TONE_AMPLITUDE * math.sin(step * index)
+
+        assert probe.clip_samples(clip) == expected, clip_id
+
+    # The same statement one level down, where the amplitude default lives.
+    assert list(probe._tone_samples(440.0, 5, 0)) == list(
+        probe._tone_samples(440.0, 5, 0, probe.TONE_AMPLITUDE)
+    )
+
+
+def test_a_partial_free_segment_is_normalised_by_exactly_one(tmp_path: Path) -> None:
+    """Why the clip above is safe, stated as the property rather than the result.
+
+    ``weight_total`` is the divisor. If it were ever anything but 1.0 for a
+    segment with no partials, every previously published clip would come out
+    at a different amplitude -- and the test above would fail for a reason
+    that is hard to read off a sample mismatch.
+    """
+    assert probe.Segment(0.0, 1.0, 440.0).weight_total == 1.0
+    assert probe.Segment(0.0, 1.0, None).weight_total == 1.0
+    assert probe.Segment(0.0, 1.0, 440.0).frequencies_hz == (440.0,)
+    assert probe.Segment(0.0, 1.0, None).frequencies_hz == ()
+
+    chord = probe.Segment(0.0, 1.0, 100.0, partials=((200.0, 1.0), (300.0, 0.5)))
+    assert chord.weight_total == 2.5
+    assert chord.frequencies_hz == (100.0, 200.0, 300.0)
+
+
+def test_equal_temperament_is_the_ratio_it_claims_to_be() -> None:
+    """``pitch_hz`` underwrites every musical claim, so it is checked directly."""
+    assert probe.pitch_hz(probe.A4_MIDI) == pytest.approx(440.0)
+    assert probe.hz("A4") == pytest.approx(440.0)
+    assert probe.hz("G4") == pytest.approx(391.995, abs=0.01)
+    assert probe.hz("B4") == pytest.approx(493.883, abs=0.01)
+    assert probe.hz("Bb4") == pytest.approx(466.164, abs=0.01)
+    assert probe.hz("C2") == pytest.approx(65.406, abs=0.01)
+    # An octave doubles, and twelve semitones make an octave.
+    assert probe.hz("G5") == pytest.approx(probe.hz("G4") * 2.0)
+    assert probe.hz("Ab4") / probe.hz("G4") == pytest.approx(probe.SEMITONE_RATIO)
+
+
+def test_the_notes_the_false_claims_need_are_never_played() -> None:
+    """``Bb4`` and ``F5`` exist in the table only to be shown absent.
+
+    A false criterion is only false if the corpus does not accidentally
+    contain what it asks for. These two are the pitches the minor-chord and
+    E-flat-major claims would require, and no segment anywhere sounds them.
+    """
+    sounding: set[float] = set()
+    for clip in probe.CLIPS:
+        for segment in clip.segments:
+            sounding.update(segment.frequencies_hz)
+    for absent in ("Bb4", "F5"):
+        for played in sounding:
+            assert abs(played - probe.hz(absent)) > 1.0, (absent, played)
+
+
 def test_every_clip_fits_the_window_the_grader_would_cut() -> None:
     """No clip is long enough to be trimmed, so nothing is measured on a stub.
 
@@ -260,6 +576,18 @@ def test_the_ground_truth_survives_the_graders_own_re_encode(
 
     So the check runs on the encoder's output: three beeps still three, the
     clicks still 120 BPM, the silence still silent.
+
+    The musical clips need this more than the beeps did, not less. A count of
+    beeps survives almost any resampler; a chord does not have to. The minor
+    third the ``triad`` pair turns on is 27.7 Hz from the major third, and the
+    bass overtones run up to 392 Hz on a 65 Hz fundamental -- both are things
+    a resampler can smear, and neither is visible in a beep count. Every clip
+    is therefore re-measured here at the frequency its criterion names, on the
+    bytes the model is actually sent.
+
+    The trailing ``else`` is the point of the branch structure. A clip added
+    to the corpus without a branch here would be encoded, sent, judged and
+    never checked, which is the failure this whole file exists to prevent.
     """
     from core.perception.audio import _trim_audio_bytes
 
@@ -292,6 +620,46 @@ def test_the_ground_truth_survives_the_graders_own_re_encode(
                 samples[int(3.2 * rate) : int(4.8 * rate)], rate
             )
             assert high > low * 3, (low, high)
+        elif clip.clip_id == "g_major_scale":
+            assert len(loud_runs(samples, rate)) == 8
+            seventh = window(samples, rate, 2.45, 2.70)
+            assert magnitude_at(seventh, rate, probe.hz("Fs5")) > 0.4
+            assert magnitude_at(seventh, rate, probe.hz("F5")) < 0.05
+        elif clip.clip_id == "major_triad":
+            body = window(samples, rate, 0.3, 2.7)
+            for name in ("G4", "B4", "D5"):
+                assert magnitude_at(body, rate, probe.hz(name)) > 0.15, name
+            assert magnitude_at(body, rate, probe.hz("Bb4")) < 0.02
+        elif clip.clip_id == "modulating_arpeggio":
+            assert len(loud_runs(samples, rate)) == 8
+            for index, (low_name, high_name) in enumerate(
+                zip(("G4", "B4", "D5", "G5"), ("Ab4", "C5", "Eb5", "Ab5"))
+            ):
+                before = window(
+                    samples, rate, index * 0.6 + 0.05, index * 0.6 + 0.45
+                )
+                after = window(
+                    samples,
+                    rate,
+                    (index + 4) * 0.6 + 0.05,
+                    (index + 4) * 0.6 + 0.45,
+                )
+                assert magnitude_at(before, rate, probe.hz(low_name)) > 0.4
+                assert magnitude_at(after, rate, probe.hz(high_name)) > 0.4
+                assert magnitude_at(after, rate, probe.hz(low_name)) < 0.05
+        elif clip.clip_id == "buzzy_bass":
+            body = window(samples, rate, 0.3, 2.7)
+            fundamental = probe.hz("C2")
+            assert magnitude_at(body, rate, fundamental) > 0.2
+            for harmonic in probe.BASS_HARMONICS:
+                assert (
+                    magnitude_at(body, rate, fundamental * harmonic) > 0.03
+                ), harmonic
+        else:  # pragma: no cover - reached only by an unchecked new clip
+            pytest.fail(
+                f"{clip.clip_id} is sent to the model but nothing here checks "
+                f"that its ground truth survives the re-encode"
+            )
 
 
 # --------------------------------------------------------------------------
@@ -300,17 +668,21 @@ def test_the_ground_truth_survives_the_graders_own_re_encode(
 
 
 def test_corpus_is_balanced_and_paired() -> None:
-    """Six true, six false, matched one-of-each on the same clip.
+    """Ten true, ten false, matched one-of-each on the same clip.
 
     Balance is what makes Youden's J readable; pairing is what makes the
     permutation null contain only corpora that could actually have existed.
+
+    The pair count is also the whole p-floor: ten pairs is what puts the best
+    attainable p below 0.01, and six could not. Asserting it here means the
+    floor cannot be lowered by deleting a pair without a test saying so.
     """
-    assert sum(1 for c in probe.CLAIMS if c.holds) == 6
-    assert sum(1 for c in probe.CLAIMS if not c.holds) == 6
+    assert sum(1 for c in probe.CLAIMS if c.holds) == 10
+    assert sum(1 for c in probe.CLAIMS if not c.holds) == 10
     pairs: dict[str, list[probe.Claim]] = {}
     for claim in probe.CLAIMS:
         pairs.setdefault(claim.pair_id, []).append(claim)
-    assert len(pairs) == 6
+    assert len(pairs) == 10
     for pair_id, members in pairs.items():
         assert len(members) == 2, pair_id
         assert {m.holds for m in members} == {True, False}, pair_id
@@ -347,6 +719,27 @@ def test_no_criterion_accidentally_asks_for_a_listening_window() -> None:
 def test_claim_ids_are_unique() -> None:
     ids = [claim.claim_id for claim in probe.CLAIMS]
     assert len(ids) == len(set(ids))
+
+
+def test_no_criterion_is_a_substring_of_another() -> None:
+    """``TruthfulStub`` matches on the first ``criterion in text`` hit.
+
+    That is fine while the criteria are distinct strings and silently wrong
+    the moment one contains another: the stub would answer the shorter claim's
+    ground truth for the longer claim, and a dry run would go green while
+    measuring the wrong thing. The corpus doubled in this change and the two
+    ``triad`` criteria differ by one word, so the property is worth asserting
+    rather than assuming.
+
+    This constrains the *fixture*, not the model. A real judge reads the whole
+    prompt; only the stub matches by substring.
+    """
+    criteria = [claim.criterion for claim in probe.CLAIMS]
+    assert len(criteria) == len(set(criteria))
+    for outer in criteria:
+        for inner in criteria:
+            if inner != outer:
+                assert inner not in outer, (inner, outer)
 
 
 # --------------------------------------------------------------------------
@@ -456,26 +849,40 @@ def test_rates_are_none_not_zero_when_there_is_nothing_to_divide_by() -> None:
 # --------------------------------------------------------------------------
 
 
-def test_permutation_is_exhaustive_over_sixty_four_relabellings() -> None:
+def test_permutation_is_exhaustive_over_one_thousand_relabellings() -> None:
     result = probe.permute_within_pairs(_calls(lambda c: "pass" if c.holds else "fail"))
-    assert result["pairs"] == 6
-    assert result["assignments"] == 64
+    assert result["pairs"] == 10
+    assert result["assignments"] == 1024
 
 
-def test_the_best_possible_p_is_reported_and_is_worse_than_one_percent() -> None:
+def test_the_best_possible_p_now_clears_one_percent_and_says_so() -> None:
     """The design's own ceiling, published with the number rather than after it.
 
-    Six pairs give 64 assignments, so nothing this experiment can produce
-    reaches 0.01. Stating it here is the same discipline as
+    This assertion used to run the other way. Six pairs gave 64 assignments
+    and a floor of 1/64 = 0.015625, so *nothing* the first version of this
+    experiment could produce reached 0.01 -- however well the model listened,
+    and however many repeats were bought. Repeats never touched it; only pairs
+    could, because the floor is 1 / 2**pairs and repeats are not in it.
+
+    Four musical pairs is what removed the bound. Both numbers are asserted,
+    the live one and the one it replaced, so that the arithmetic linking them
+    is on the record rather than in a commit message: a pair deleted from the
+    corpus puts the floor back above 0.01 and this test says which side of the
+    line it landed on.
+
+    Publishing the floor beside the p is the same discipline as
     ``is_informative: false`` on the repeat-variation interval: the reader is
     told what the measurement *cannot* support at the moment they are told
     what it found.
     """
     result = probe.permute_within_pairs(_calls(lambda c: "pass" if c.holds else "fail"))
-    assert result["smallest_attainable_p"] == pytest.approx(1.0 / 64.0)
-    assert result["p_one_sided"] == pytest.approx(1.0 / 64.0)
-    assert result["smallest_attainable_p"] > 0.01
-    assert result["smallest_attainable_p"] < 0.05
+    assert result["smallest_attainable_p"] == pytest.approx(1.0 / 1024.0)
+    assert result["p_one_sided"] == pytest.approx(1.0 / 1024.0)
+    assert result["smallest_attainable_p"] < 0.01
+    # The floor this replaced, and the reason it could not be fixed by paying
+    # for more repeats: 2 ** 6 == 64, and 1/64 is on the wrong side of 0.01.
+    assert 1.0 / (2.0 ** 6) > 0.01
+    assert result["smallest_attainable_p"] == pytest.approx(1.0 / (2.0 ** 10))
 
 
 def test_a_constant_answer_is_not_significant() -> None:
@@ -494,16 +901,20 @@ def test_permutation_is_deterministic() -> None:
 
 
 def test_labels_are_swapped_within_pairs_not_across_the_corpus() -> None:
-    """Every relabelling must leave the corpus balanced, and 64 of them exist.
+    """Every relabelling must leave the corpus balanced, and 1024 of them exist.
 
-    A free shuffle over twelve labels would build null corpora that could not
+    A free shuffle over twenty labels would build null corpora that could not
     have existed -- both criteria about the silent clip true at once -- and
-    would enumerate C(12,6) = 924 of them, putting the p-floor at 1/924 and
-    quietly claiming a resolution the design does not have. Two observable
-    consequences pin the within-pair scheme: the assignment count is exactly
-    64, and a perfect listener's p is exactly 1/64 rather than 1/924.
+    would enumerate C(20,10) = 184,756 of them, putting the p-floor two orders
+    of magnitude lower and quietly claiming a resolution the design does not
+    have. That temptation grew with the corpus rather than shrinking: at six
+    pairs a free shuffle bought 924 against 64, and at ten it buys 184,756
+    against 1024, so the gap between the honest floor and the flattering one
+    is now 180x. Two observable consequences pin the within-pair scheme: the
+    assignment count is exactly 1024, and a perfect listener's p is exactly
+    1/1024 rather than 1/184,756.
 
-    The count also has to be 64 *including* degenerate answers -- if any
+    The count also has to be 1024 *including* degenerate answers -- if any
     relabelling produced an all-true corpus, J would be ``None`` there and the
     denominator would silently shrink.
     """
@@ -513,15 +924,18 @@ def test_labels_are_swapped_within_pairs_not_across_the_corpus() -> None:
         lambda c: "fail" if c.holds else "pass",
     ):
         result = probe.permute_within_pairs(_calls(verdict_for))
-        assert result["assignments"] == 64
-        assert 1 <= result["at_least_observed"] <= 64
+        assert result["assignments"] == 1024
+        assert 1 <= result["at_least_observed"] <= 1024
         assert result["p_one_sided"] == pytest.approx(
-            result["at_least_observed"] / 64
+            result["at_least_observed"] / 1024
         )
+    # The free-shuffle count, spelled out so the comparison above is checkable
+    # rather than asserted: 184,756 is not what this enumerates.
+    assert math.comb(20, 10) == 184756
 
 
 def test_the_perfect_and_inverted_ends_of_the_null_are_where_they_should_be() -> None:
-    """One assignment beats a perfect listener; all 64 beat an inverted one."""
+    """One assignment beats a perfect listener; all 1024 beat an inverted one."""
     perfect = probe.permute_within_pairs(
         _calls(lambda c: "pass" if c.holds else "fail")
     )
@@ -529,7 +943,7 @@ def test_the_perfect_and_inverted_ends_of_the_null_are_where_they_should_be() ->
     inverted = probe.permute_within_pairs(
         _calls(lambda c: "fail" if c.holds else "pass")
     )
-    assert inverted["at_least_observed"] == 64
+    assert inverted["at_least_observed"] == 1024
     assert inverted["p_one_sided"] == pytest.approx(1.0)
 
 
@@ -631,9 +1045,9 @@ def test_dry_run_reports_a_perfect_score_and_says_it_measured_nothing(
     assert report["cost"]["estimated_cost_usd"] is None
     assert report["cost"]["pricing_complete"] is True
     assert report["cost"]["unpriced_models"] == []
-    # 12 calls went out to the stub and none of them were billed. A report
-    # that said "billable_calls: 12" here is the figure someone copies.
-    assert report["cost"]["model_calls"] == 12
+    # 20 calls went out to the stub and none of them were billed. A report
+    # that said "billable_calls: 20" here is the figure someone copies.
+    assert report["cost"]["model_calls"] == 20
     assert report["cost"]["billable_calls"] == 0
 
 
@@ -736,10 +1150,10 @@ def test_main_dry_run_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
     assert code == 0
     report = json.loads(capsys.readouterr().out)
     assert report["measured"] is False
-    assert report["pins"]["claims"] == 12
-    assert report["pins"]["true_claims"] == 6
-    assert report["pins"]["false_claims"] == 6
-    assert len(report["calls"]) == 12
+    assert report["pins"]["claims"] == 20
+    assert report["pins"]["true_claims"] == 10
+    assert report["pins"]["false_claims"] == 10
+    assert len(report["calls"]) == 20
 
 
 def test_main_rejects_a_repeat_count_below_one() -> None:
@@ -751,7 +1165,7 @@ def test_main_writes_the_report_where_it_is_told(tmp_path: Path) -> None:
     out = tmp_path / "nested" / "report.json"
     assert probe.main(["--dry-run", "--repeats", "1", "--quiet", "--out", str(out)]) == 0
     written = json.loads(out.read_text(encoding="utf-8"))
-    assert written["accuracy"]["overall"]["calls"] == 12
+    assert written["accuracy"]["overall"]["calls"] == 20
 
 
 def test_main_refuses_a_config_whose_model_and_deployment_disagree(


### PR DESCRIPTION
## What this is

`measure_audio_grading_accuracy.py` published a hard result — **discrimination 0**, the audio judge's verdict does not move with the audio — and then recorded two limits on itself, in its own docstring and on the Project card:

1. **The corpus is beeps.** The gold run's audio criteria are about film and music tracks. What a beep corpus can be wrong about is *how many beeps*, not what key it is in.
2. **The design cannot reach `p < 0.01`.** Six matched pairs give `2**6 = 64` relabellings, so the smallest attainable p is `1/64 = 0.015625`. Buying more repeats never moved that floor; only more pairs could.

Both limits have the same root — six pairs of beeps — so four musical pairs closes both with one change.

| | before | after |
|---|---:|---:|
| clips | 5 | **9** |
| claims | 12 | **20** |
| matched pairs | 6 | **10** |
| families | 6 | **10** |
| relabellings enumerated | 64 | **1024** |
| smallest attainable p | 0.015625 | **0.000977** |
| clears 0.01 | **no** | **yes** |

Still no audio in the repository: every clip is synthesised at run time from `wave` and `math`, and every frequency comes out of `pitch_hz`, so a musical claim is arithmetic rather than taste.

## The four new pairs

Three are the questions the gold run's failed criteria actually asked; the fourth is what a key claim rests on.

| family | clip | true criterion | false criterion | what settles it |
|---|---|---|---|---|
| `key` | `g_major_scale` | every note is in G major | every note is in E-flat major | F#5 present at 739.99 Hz, F5 absent |
| `triad` | `major_triad` | one sustained chord, major | one sustained chord, minor | B4 at 493.88 Hz present, Bb4 at 466.16 Hz absent |
| `modulation` | `modulating_arpeggio` | the key changes partway | one key throughout | second half is the first half × `2**(1/12)`, exactly |
| `timbre` | `buzzy_bass` | buzzy synth with audible overtones | plain sine, nothing above the fundamental | harmonics 2–6 of 65.4 Hz present; absent from a control sine |

`major_triad` is the first clip in this corpus with two notes sounding at the same instant, which is why `Segment` gained `partials`.

Measurement changed with it. Zero-crossing counting answers "what note is this" for a beep and is meaningless for a triad or a bass carrying five overtones, so the tests gained `magnitude_at` — one DFT bin by quadrature correlation, standard library only. Absence is the harder half of every pair (the false criterion is what the model must *not* confirm), and a helper that could only find things would leave each pair half-checked.

## The five published clips still render byte for byte

Adding partials meant touching the renderer that every clip goes through. The published "discrimination 0" was measured on the old five, and the report prints a sha256 per clip so a reader can re-derive it — a shifted sample breaks that quietly.

The mechanism is arithmetic, not care: with no partials `weight_total` is `1.0`, so the scale is `TONE_AMPLITUDE / 1.0`, and the loop over partials runs zero times.

`test_the_original_five_clips_render_byte_for_byte_as_they_did` recomputes all five the pre-partials way and demands exact equality. It recomputes locally rather than pinning a digest, because `math.sin` is the platform's libm and a hard-coded hash would fail on a different CI host for a reason unrelated to this change.

## The grader fingerprint does not move

Claimed on the card, so it is measured rather than asserted. `grader_source_hash` over all **14** grading configs, `origin/main` `cb94a0d` (a detached worktree) against this branch:

```
14 configs compared — IDENTICAL
```

`batch-runner/tests/` is not in the hash, and `batch-runner/scripts/` is excluded except for `download_inference_from_hf.py`. Neither file this PR touches is in the fingerprint's input set. **No in-flight grading run is affected and no re-smoke is required.**

## Verification

| check | result |
|---|---|
| probe test file | **59 passed** (was 48) |
| full backend pytest | **7,868 passed · 11 skipped · 45 deselected · 0 failed** (1,118 s) |
| `--dry-run` end to end | exit 0 — pairs 10, assignments 1024, p 0.0009765625, floor 0.0009765625, claims 20, clips 9, families 10 |
| mypy, this script | 1 error on base, 1 on branch (`core/perception/audio.py:509`, untouched) — delta **0** |
| mypy, the test file | 47 errors in 7 files on base and on branch — delta **0** |
| mypy `core/` | 176 errors in 32 files on base and on branch — delta **0** |
| grader fingerprints | **14/14 identical** |

**Re-encode.** Every claim is re-measured on the bytes the model is actually sent, through the grader's own `_trim_audio_bytes` at 16 kHz mono. A beep count survives almost any resampler; a chord does not have to — the minor third the `triad` pair turns on is 27.7 Hz from the major third.

| clip | measured after re-encode |
|---|---|
| `g_major_scale` | F#5 0.600 vs F5 0.018; 8 loud runs |
| `major_triad` | G4 0.2002, B4 0.2002, D5 0.2002; Bb4 **0.0010** |
| `modulating_arpeggio` | each half 0.60 at its own pitch; pre-transposition pitch ≤ 0.018 after |
| `buzzy_bass` | fundamental 0.2449; harmonics 0.1225, 0.0816, 0.0612, 0.0490, 0.0408 |

The `elif` chain in that test now ends in a `pytest.fail` **`else`**: a clip added to the corpus without a branch here would be encoded, sent, judged and never checked, which is the failure the whole file exists to prevent.

**Mutation testing** — these tests do not pass on their own.

| mutation | tests that fail |
|---|---|
| drop `/ weight_total` from the scale | 2 (triad, bass) |
| B4 → Bb4 in the triad | 3 |
| `pitch_hz` divisor 12 → 11 | 2 |
| partials loop disabled | 3 |
| drop the 4 musical pairs | 9 (balance, permutation ×3, clip coverage, dry run, main ×2) |
| `TONE_AMPLITUDE` × 1.0000001 | byte identity: `0.22961008238005984 != 0.22961005941905385` |

## Cost

**$0.** No model was called: `--dry-run` answers from a stub. The paid re-measurement is a separate step, gated on zero in-flight grading runs.

When it runs it will be **20 claims × 3 repeats = 60 calls** (was 36). The amount will be recorded as **`미등록`** — `gpt-audio-1.5` is not in the price table, so the report emits `pricing_complete: false` and `estimated_cost_usd: null`. That is not `$0`: money is spent and we do not know how much. The call count is recorded as a number.

## What this does not do

**Speech is still open, and this PR says so rather than quietly narrowing the card.** The card asked for "speech and music". Intelligible speech cannot be synthesised from `wave` and `math`; it needs a recording or a synthesiser, and both collide with this tool's own rule that no audio ships in the repository. So this is the music half. The module docstring states the limit in the same paragraph that states the result, and the card will record it as half-done.

It also does not touch the grader. This is a measuring instrument, not a grading rule. And it does not touch the owner decision still pending on the 31 audio-graded items of the 185 run.
