### PR TITLE
fix(grading): make the paid audio probe state the corpus it has

### DIFF
--- a/.github/workflows/audio-accuracy-probe.yml
+++ b/.github/workflows/audio-accuracy-probe.yml
@@ -9,10 +9,16 @@ name: Audio Accuracy Probe
 # whose own correctness is one of the two open readings the card names.
 #
 # This workflow runs the one measurement that separates them, on clips whose
-# contents are arithmetic rather than opinion. Twelve criteria, six true and
-# six false, matched in pairs on five clips synthesised from a segment list at
+# contents are arithmetic rather than opinion. Twenty criteria, ten true and
+# ten false, matched in pairs on nine clips synthesised from a segment list at
 # run time. Nothing is downloaded and no audio is committed; the clips are
 # rendered from `wave` and `math` and their digests go into the report.
+#
+# The corpus counts above are not restated by hand anywhere a run can read
+# them: a test asserts that every number this file states matches the corpus
+# the script actually holds. The first version of this workflow said "twelve
+# criteria" and kept saying it after the corpus doubled, which put a call
+# count of 36 on an approval record for a run that made 60.
 #
 # What it does NOT do, deliberately:
 #   * It does not grade anything. No task, no rubric, no deliverable, no
@@ -45,7 +51,7 @@ on:
         type: boolean
         default: false
       repeats:
-        description: 'How many times each criterion is put to the model. 3 matches the repeat runs, so stability here is comparable with the 19.35%. Total calls = 12 criteria x repeats.'
+        description: 'How many times each criterion is put to the model. 3 matches the repeat runs, so stability here is comparable with the 19.35%. Total calls = 20 criteria x repeats.'
         required: false
         type: number
         default: 3
@@ -148,6 +154,11 @@ jobs:
     environment:
       name: grading
     steps:
+      # The criteria count is restated here because this job has no checkout --
+      # it is a gate, and giving it the repository to read would be more
+      # machinery than a log line is worth. What keeps the restatement true is
+      # test_the_workflow_states_the_corpus_it_actually_has, which fails if
+      # this number and the corpus disagree.
       - name: Record approved request
         env:
           PROBE_REPEATS: ${{ inputs.repeats }}
@@ -155,9 +166,9 @@ jobs:
           printf '%s\n' \
             "Approved paid audio accuracy probe:" \
             "  model      = gpt-audio-1.5 (read from gold_audio_repeat_v2_sol_max.yaml)" \
-            "  criteria   = 12 (6 true / 6 false)" \
+            "  criteria   = 20 (10 true / 10 false)" \
             "  repeats    = $PROBE_REPEATS" \
-            "  calls      = $((12 * PROBE_REPEATS))" \
+            "  calls      = $((20 * PROBE_REPEATS))" \
             "  grades     = none. This does not write a grade or touch a corpus."
 
   # ---------------------------------------------------------------------------
@@ -270,9 +281,15 @@ jobs:
           print("**J = 0 would mean the verdict does not depend on the audio.** A model")
           print("answering `pass` to everything scores 50% accuracy on this balanced")
           print("corpus and J = 0; accuracy alone cannot tell a listener from a coin.\n")
-          print(f"This design cannot produce a p below "
-                f"{perm['smallest_attainable_p']} — six pairs, 64 relabellings. "
-                "Significant at 0.05 is the ceiling; 0.01 is out of reach.\n")
+          floor = perm["smallest_attainable_p"]
+          print(f"This design cannot produce a p below {floor} — "
+                f"{perm['pairs']} pairs, {perm['assignments']} relabellings, "
+                f"so the floor is 1/{perm['assignments']}. Repeats do not move "
+                "it; only pairs do.\n")
+          reachable = [t for t in (0.05, 0.01, 0.001) if floor < t]
+          print("Thresholds this design can reach: "
+                + (", ".join(str(t) for t in reachable) if reachable else "none")
+                + ".\n")
           print("### Cost\n")
           print(f"- billable calls: {report['cost']['billable_calls']}")
           print(f"- pricing complete: `{json.dumps(report['cost']['pricing_complete'])}`")
@@ -287,7 +304,7 @@ jobs:
                     f"{row['false_fail']} | {row['false_pass']} | {row['hedged']} |")
           PY
 
-      # Artifact, not a commit. These are verdicts on five synthetic clips and
+      # Artifact, not a commit. These are verdicts on synthetic clips and
       # they are not grades; putting them in data/grades would make them show
       # up on the dashboard as if they were.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
+++ b/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
@@ -15,8 +15,8 @@ against each other, off the same samples the model will hear.
 The other half is the scorer. A measurement instrument that reports a good
 number when handed garbage is worse than no instrument, so the negative
 controls here are as load-bearing as the positive ones: a model that answers
-``pass`` to all twelve criteria scores 50% accuracy on this balanced corpus,
-and the test that matters is the one asserting its discrimination is **zero**.
+``pass`` to every criterion scores 50% accuracy on this balanced corpus, and
+the test that matters is the one asserting its discrimination is **zero**.
 """
 
 from __future__ import annotations
@@ -24,6 +24,7 @@ from __future__ import annotations
 import io
 import json
 import math
+import re
 import struct
 import sys
 import wave
@@ -742,6 +743,80 @@ def test_no_criterion_is_a_substring_of_another() -> None:
                 assert inner not in outer, (inner, outer)
 
 
+def test_the_workflow_states_the_corpus_it_actually_has() -> None:
+    """The paid entry point restates these counts, so they have to be checked.
+
+    ``audio-accuracy-probe.yml`` is the only way this measurement gets bought,
+    and four places in it say how big the corpus is: the header comment, the
+    ``repeats`` input description a dispatcher reads, and two lines of the
+    approval record. None of them can read ``CLAIMS`` -- the gate job has no
+    checkout, and a comment cannot compute -- so all four are restatements.
+
+    They rotted once already. The corpus went from twelve criteria to twenty
+    and the workflow kept saying twelve, which put ``calls = 36`` on the
+    approval record for a run that would make sixty. A wrong call count on a
+    paid gate is the specific kind of wrong this repository cares about: the
+    record that says what was authorised disagreed with what was spent.
+
+    So the restatements are pinned rather than trusted. This test is the
+    reason it is safe to restate them at all.
+    """
+    text = (
+        probe.REPO_ROOT / ".github" / "workflows" / "audio-accuracy-probe.yml"
+    ).read_text(encoding="utf-8")
+
+    claims = len(probe.CLAIMS)
+    true_claims = sum(1 for claim in probe.CLAIMS if claim.holds)
+    false_claims = claims - true_claims
+    clips = len(probe.CLIPS)
+
+    words = {
+        "five": 5,
+        "six": 6,
+        "nine": 9,
+        "ten": 10,
+        "twelve": 12,
+        "twenty": 20,
+    }
+
+    # The header comment: "Twenty criteria, ten true and ten false, matched in
+    # pairs on nine clips".
+    header = re.search(
+        r"(\w+) criteria, (\w+) true and\n#\s*(\w+) false, matched in pairs on "
+        r"(\w+) clips",
+        text,
+    )
+    assert header, "the header comment no longer states the corpus size"
+    assert words[header.group(1).lower()] == claims
+    assert words[header.group(2).lower()] == true_claims
+    assert words[header.group(3).lower()] == false_claims
+    assert words[header.group(4).lower()] == clips
+
+    # The dispatch input description, which is what someone reads before
+    # deciding whether to spend.
+    formula = re.search(r"Total calls = (\d+) criteria x repeats", text)
+    assert formula, "the repeats input no longer states the call formula"
+    assert int(formula.group(1)) == claims
+
+    # The approval record, both lines of it.
+    record = re.search(r"criteria\s+= (\d+) \((\d+) true / (\d+) false\)", text)
+    assert record, "the approval record no longer states the criteria count"
+    assert int(record.group(1)) == claims
+    assert int(record.group(2)) == true_claims
+    assert int(record.group(3)) == false_claims
+
+    calls = re.search(r"calls\s+= \$\(\((\d+) \* PROBE_REPEATS\)\)", text)
+    assert calls, "the approval record no longer computes the call count"
+    assert int(calls.group(1)) == claims
+
+    # The permutation figures in the paid summary are *derived* from the
+    # report rather than restated, which is why they are not checked above.
+    # This asserts they stayed derived: a literal here would be the next thing
+    # to rot, and it would misdescribe what the design can support.
+    for stale in ("six pairs", "64 relabellings", "0.01 is out of reach"):
+        assert stale not in text, stale
+
+
 # --------------------------------------------------------------------------
 # The scorer, including the ways it must refuse to flatter
 # --------------------------------------------------------------------------
@@ -805,7 +880,7 @@ def test_judge_error_is_not_an_answer_in_either_direction() -> None:
 def test_a_model_that_always_says_pass_scores_zero_discrimination() -> None:
     """The control this whole metric exists for.
 
-    Accuracy is 50% -- it got all six true claims right -- and that 50% is
+    Accuracy is 50% -- it got every true claim right -- and that 50% is
     worth nothing, because the same answer was given without listening. J is
     what says so.
     """


### PR DESCRIPTION
## What this is

A defect in my own merged #427, found reading the paid path afterwards.

#427 doubled the probe corpus — 12 criteria on 5 clips became 20 on 9 — and left `.github/workflows/audio-accuracy-probe.yml` describing the old one. That file is the **only paid entry point** for this measurement, and four places in it restate the corpus size. None of the four can read `CLAIMS`: a comment cannot compute, and the approval gate deliberately has no checkout. So all four went stale together.

The worst was on the approval record:

```
  criteria   = 12 (6 true / 6 false)
  calls      = $((12 * PROBE_REPEATS))
```

A reviewer approving the default 3 repeats would have been shown **`calls = 36` for a run that makes 60**. The record of what was authorised would have disagreed with what was spent.

## The six stale spots

| where | said | says |
|---|---|---|
| header comment | Twelve criteria, six true and six false, five clips | Twenty, ten and ten, nine clips |
| `repeats` input description | `Total calls = 12 criteria x repeats` | `= 20 criteria x repeats` |
| approval record, criteria line | `12 (6 true / 6 false)` | `20 (10 true / 10 false)` |
| approval record, calls line | `$((12 * PROBE_REPEATS))` | `$((20 * PROBE_REPEATS))` |
| paid step summary | "six pairs, 64 relabellings … 0.01 is out of reach" | read from the report |
| artifact comment | "verdicts on five synthetic clips" | "verdicts on synthetic clips" |

## The summary line was the worse kind of wrong

The paid step prints the permutation floor next to a `p` it reads **live from the report**. The prose beside it was hard-coded, so a real result of `p = 0.00098` would have been printed under a sentence saying 0.01 was out of reach. Now:

```python
floor = perm["smallest_attainable_p"]
print(f"This design cannot produce a p below {floor} — "
      f"{perm['pairs']} pairs, {perm['assignments']} relabellings, "
      f"so the floor is 1/{perm['assignments']}. Repeats do not move "
      "it; only pairs do.\n")
reachable = [t for t in (0.05, 0.01, 0.001) if floor < t]
```

Executed against a real `--dry-run` report, that block renders:

```
This design cannot produce a p below 0.0009765625 — 10 pairs, 1024
relabellings, so the floor is 1/1024. Repeats do not move it; only pairs do.

Thresholds this design can reach: 0.05, 0.01, 0.001.
```

Delete a pair and both numbers move on their own.

## What is left restated is pinned

Four restatements survive, because the gate job having no checkout is the right design and a header comment is worth more than the machinery to compute one. `test_the_workflow_states_the_corpus_it_actually_has` parses all four out of the YAML and checks each against `probe.CLAIMS` / `probe.CLIPS`, then rejects the three retired phrases by name.

That test is the reason it is safe to restate them at all.

| mutation | result |
|---|---|
| approval record back to `criteria = 12 (6 true / 6 false)` | the new test **fails**, the other 59 pass |

## Two more of the same, in the test file

`grep` for the retired counts turned up two docstrings making the same mistake in the file that is supposed to catch it — "answers `pass` to all **twelve** criteria", "it got all **six** true claims right". Both restated a number the sentence did not need, so the number is gone rather than corrected. Nothing left to rot.

The rest of the hits are deliberate history — the script's "the first version of this corpus had six pairs and a floor of 1/64", the "measured on five clips" that describes the published result — and they stay.

## The grader fingerprint does not move

Measured, not asserted. `grader_source_hash` over all **14** grading configs, merged `9feae4d` against this branch:

```
14 configs compared — IDENTICAL (0 errors)
```

`.github/workflows/` is not in `compute_grader_source_hash`'s input set and neither is `batch-runner/tests/`. **No in-flight grading run is affected and no re-smoke is required.**

## Verification

| check | result |
|---|---|
| probe test file | **60 passed** (was 59) |
| full backend pytest | **7,872 passed · 8 skipped · 45 deselected · 0 failed** (1,020 s) |
| workflow YAML parses | jobs `dry-run`, `approve-paid`, `refuse-unapproved`, `measure` |
| both embedded Python blocks | compile (12 and 48 lines) |
| paid summary block | executed against a real report — output above |
| grader fingerprints | **14/14 identical** |
| mutation | reverting the count is caught |

## Cost

**$0.** Nothing here calls a model; the dry-run stub answers from the segment list.

The paid measurement this unblocks will be **20 claims × 3 repeats = 60 calls**, and its amount will be recorded as **`미등록`** — `gpt-audio-1.5` is not in the price table, so the report emits `pricing_complete: false` and `estimated_cost_usd: null`. That is not `$0`.

## What this does not do

It does not change what the probe measures, or run it. The corpus, the claims and the scoring are exactly as #427 merged them. This only makes the file that spends the money describe the corpus it actually has.
