### PR TITLE
docs(324): the audio judge heard a human voice in a file of zeros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,8 @@ tasks/rebuilding_grading_task/*
 !tasks/rebuilding_grading_task/321-the-question-the-probe-asked.md
 !tasks/rebuilding_grading_task/322-the-probe-that-never-learned-video.md
 !tasks/rebuilding_grading_task/323-the-readable-sibling-that-never-mattered.md
+!tasks/rebuilding_grading_task/324-the-speech-it-heard-in-silence.md
+!tasks/rebuilding_grading_task/324-audio-accuracy-measured.json
 
 # The grading run writes a sqlite mirror of the cost ledger beside every grade
 # file. The published record is the .jsonl next to it; the database is a local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,6 +354,56 @@ entries land under a fresh dated heading the day they merge to `main`.
   "Critical item pass rate" into the report prompt — is closed under **Fixed**.
 
 ### Added
+- **The audio judge described a clear human voice, at confidence 0.98, in a file
+  where every sample is zero.** The doubled probe corpus was put to
+  `gpt-audio-1.5` for the first time — 20 criteria on 9 synthesised clips, 10
+  true and 10 false in matched pairs, 3 repeats, **60 calls** — and the result
+  is a clean negative. Accuracy **51.85%** on 54 answered calls; discrimination
+  (Youden's J) **0.011** per call and **−0.1** by per-claim majority; exhaustive
+  within-pair permutation `p = 0.5`, meaning 512 of the 1024 relabellings do as
+  well as what was observed. 46 of 54 answered calls said `fail`, and seven of
+  ten families land on exactly "six answered, three correct" — the arithmetic of
+  answering the same word every time.
+
+  This is the measurement #427 was built to make possible and it cleared its own
+  bar: the floor is `1/1024 = 0.00098`, so a judge that was listening could have
+  been shown to be listening at `p < 0.001`. It was not. The earlier
+  12-criterion run recorded below reached the same conclusion and could be
+  answered with "the corpus is beeps"; that answer is now gone, and the
+  conclusion is not.
+
+  Three exhibits, quoted verbatim from the report rather than summarised. On
+  `pure_silence` the judge reported *"A clear, natural human voice is heard
+  speaking throughout the 30s clip"* at 0.98 and, in another repeat, *"30s of
+  complete silence"* at 0.98. On a clip holding exactly three beeps, six calls
+  returned four different counts — one, three, five, four. And on clicks spaced
+  exactly 0.5 s apart, the judge "measured" 0.5 s whenever the criterion
+  proposed 120 BPM and 1.0 s whenever the sibling criterion proposed 60 BPM, all
+  three repeats, passing both — while the ±1 BPM criteria on the same file
+  produced 0.7 s, 0.8 s, "~110 clicks in 30s" and "about 58 BPM", and failed
+  every time. **The verdict follows the shape of the question, not the sound.**
+  16 of 20 claims got an identical verdict in all three repeats, which is the
+  "consistency is not correctness" the 19.35% flip rate could not settle.
+
+  Recorded in
+  `tasks/rebuilding_grading_task/324-the-speech-it-heard-in-silence.md` with the
+  raw report committed beside it, and `test_324_quotes_the_run_it_measured.py`
+  re-derives every percentage, every decimal, both tables, all 60 verdicts and
+  each quoted fragment from that JSON — 19 tests, 35 planted mutations caught 35
+  times, including a dropped minus sign on the negative J and a `p` restated as
+  0.05 three sections from where it was measured. The sweep also earned its
+  keep: corrupting the *second* copy of `512 of 1024` survived a containment
+  check that only asked whether the document mentioned the number anywhere, so a
+  test was added that reads the counter instead and requires every relabelling
+  count in the prose to be one the report enumerated. Six calls returned
+  `provider_error:JSONDecodeError` and are counted as unanswered rather than
+  scored zero. Speech is still not measured and the document says so:
+  intelligible speech cannot be synthesised from `wave` and `math`, so this is
+  the music half. **Cost: 60 billable calls, amount `미등록` —
+  `gpt-audio-1.5` has no published price, so the report emits
+  `pricing_complete: false` and `estimated_cost_usd: null`. That is not `$0`.**
+  No grade was written, no published number moved, and the grader fingerprint is
+  unchanged across all 14 grading configs.
 - **How much of a published average was decided by the audio sub-judge is now
   on screen — and for most runs the honest answer is "not recorded".** The
   audio route was measured against synthetic clips whose answers were known and

--- a/batch-runner/tests/test_324_quotes_the_run_it_measured.py
+++ b/batch-runner/tests/test_324_quotes_the_run_it_measured.py
@@ -1,0 +1,621 @@
+"""The 324 findings document has to quote the run it measured.
+
+A paid measurement gets written up once and read for a long time afterwards,
+and every number in the write-up is a number somebody typed. The report itself
+is committed beside the document, so nothing here has to be taken on trust:
+this file re-derives each figure from ``324-audio-accuracy-measured.json`` and
+requires the document to state it.
+
+The three exhibits are the part that would rot most quietly. A paraphrase of
+what the model said is an interpretation; the document quotes it verbatim, and
+every quoted fragment is checked back against the evidence field it came from.
+A quote that drifts one word from the JSON fails here.
+
+The last two checks are about honesty rather than accuracy. ``gpt-audio-1.5``
+has no published price, so the run's cost is unknown -- and a document that
+wrote ``$0`` for an unknown amount would be readable, tidy and false. And the
+report has to carry ``measured: true``: a dry run scores 100% off a stub, and
+publishing that shape as a result is the single worst thing this document
+could do.
+"""
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DOC_PATH = (
+    REPO_ROOT
+    / "tasks/rebuilding_grading_task/324-the-speech-it-heard-in-silence.md"
+)
+REPORT_PATH = (
+    REPO_ROOT / "tasks/rebuilding_grading_task/324-audio-accuracy-measured.json"
+)
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/audio-accuracy-probe.yml"
+AUDIO_MODULE_PATH = REPO_ROOT / "batch-runner/core/perception/audio.py"
+
+# The document is Korean and uses U+2212 for a negative number, because that is
+# what a reader sees. The JSON uses ASCII. Compare in one alphabet.
+MINUS = "−"
+
+# A row of a markdown table, split on the pipes with the outer ones dropped.
+TABLE_ROW = re.compile(r"^\|(.+)\|\s*$")
+
+
+def _cells(line: str) -> list[str]:
+    match = TABLE_ROW.match(line)
+    if match is None:
+        return []
+    return [cell.strip() for cell in match.group(1).split("|")]
+
+
+def _plain(text: str) -> str:
+    """Markdown bold and the ellipsis are presentation, not content."""
+    return text.replace("**", "").replace("`", "")
+
+
+@pytest.fixture(scope="module")
+def doc() -> str:
+    assert DOC_PATH.is_file(), f"{DOC_PATH.relative_to(REPO_ROOT)} is missing"
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def report() -> dict:
+    assert REPORT_PATH.is_file(), (
+        f"{REPORT_PATH.relative_to(REPO_ROOT)} is missing, so nothing the "
+        f"document says can be checked"
+    )
+    return json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+
+
+def test_both_files_survive_a_fresh_clone():
+    """``tasks/rebuilding_grading_task/`` is ignored with a per-file allowlist.
+
+    Probed without ``--verbose``: with it, git reports the last matching
+    pattern including negations and exits 0 either way, so only the exit code
+    distinguishes "ignored" from "un-ignored by a later rule". 1 means no
+    pattern ignores this path.
+    """
+    for path in (DOC_PATH, REPORT_PATH):
+        relative = path.relative_to(REPO_ROOT)
+        finished = subprocess.run(
+            ["git", "check-ignore", str(relative)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert finished.returncode == 1, (
+            f"{relative} is gitignored, so the document would reference a "
+            f"file that is not in the repository"
+        )
+
+
+def test_the_report_is_a_measured_run_not_a_dry_one(report):
+    """A dry run answers from the segment list and scores 100%."""
+    assert report["measured"] is True
+    assert report["pins"]["audio_deployment"] == "gpt-audio-1.5"
+    assert report["pins"]["repeats"] == 3
+    assert report["pins"]["claims"] == 20
+    assert report["pins"]["true_claims"] == report["pins"]["false_claims"] == 10
+
+
+def _allowed_numbers(report: dict) -> tuple[set[str], set[str]]:
+    """Every percentage and every decimal the report can justify.
+
+    Built by deriving rather than listing, so a figure that is in the document
+    and not in here is a figure nobody can point at a source for.
+    """
+    acc = report["accuracy"]
+    overall = acc["overall"]
+    perm = acc["permutation"]
+    j = acc["discrimination_j"]
+
+    fails = sum(1 for call in report["calls"] if call["verdict"] == "fail")
+
+    percentages = {
+        f"{overall['accuracy'] * 100:.2f}",
+        f"{acc['on_true_claims']['false_fail_rate'] * 100:.1f}",
+        f"{acc['on_false_claims']['false_pass_rate'] * 100:.1f}",
+        # What a judge that answers the same word every time scores on a
+        # corpus with as many true claims as false ones.
+        str(round(report["pins"]["true_claims"] / report["pins"]["claims"] * 100)),
+        str(round(fails / overall["answered"] * 100)),
+    }
+    # The repeat-run figures the report itself carries, so the document can
+    # cite them without a second source.
+    percentages |= set(re.findall(r"(\d+(?:\.\d+)?)%", report["what_this_measures"]))
+
+    decimals = set(percentages)
+    decimals |= {
+        f"{j['per_call']:.3f}",
+        str(abs(j["per_claim_majority"])),
+        str(perm["p_one_sided"]),
+        f"{perm['smallest_attainable_p']:.5f}",
+    }
+    # The thresholds this design can reach, which is what makes the floor
+    # worth printing at all.
+    decimals |= {
+        str(threshold)
+        for threshold in (0.05, 0.01, 0.001)
+        if perm["smallest_attainable_p"] < threshold
+    }
+    for call in report["calls"]:
+        decimals |= {str(call["confidence"]), f"{call['confidence']:.2f}"}
+        decimals |= set(re.findall(r"(?<![\w.])(\d+\.\d+)(?!\d)", call["evidence"]))
+    for clip in report["clips"]:
+        decimals.add(str(clip["duration_s"]))
+        for segment in clip["segments"]:
+            decimals |= {str(segment["start_s"]), str(segment["end_s"])}
+    decimals |= set(
+        re.findall(r"(?<![\w.])(\d+\.\d+)(?!\d)", report["pins"]["audio_model"])
+    )
+    return percentages, decimals
+
+
+def test_every_number_in_the_document_comes_from_the_report(doc, report):
+    """Not "the document mentions the right figure" -- "every figure in the
+    document is a right one".
+
+    A containment check passes while a second copy of the same number rots
+    three sections away, which is the failure this whole probe was corrected
+    for once already. So the check runs the other way: pull every percentage
+    and every decimal out of the prose and require each to be derivable.
+    """
+    percentages, decimals = _allowed_numbers(report)
+
+    found_percentages = set(re.findall(r"(\d+(?:\.\d+)?)%", doc))
+    stray = found_percentages - percentages
+    assert not stray, (
+        f"the document states {sorted(stray)}% and the report does not "
+        f"support it; supported: {sorted(percentages)}"
+    )
+
+    found_decimals = set(re.findall(r"(?<![\w.])(\d+\.\d+)(?!\d)", doc))
+    stray = found_decimals - decimals
+    assert not stray, (
+        f"the document states the decimal(s) {sorted(stray)} and the report "
+        f"does not support them"
+    )
+
+    # And the figures that matter most are required to be present, not merely
+    # permitted.
+    for required in (
+        f"{report['accuracy']['overall']['accuracy'] * 100:.2f}%",
+        f"{report['accuracy']['discrimination_j']['per_call']:.3f}",
+        str(report["accuracy"]["permutation"]["p_one_sided"]),
+        f"{report['accuracy']['permutation']['smallest_attainable_p']:.5f}",
+    ):
+        assert required in doc, f"the document does not state {required}"
+
+
+def test_the_results_table_carries_the_measured_values(doc, report):
+    """The two-column tables, read as label-to-value and checked by label.
+
+    ``0.5`` is the permutation p and it is also the click interval eleven
+    times over, so "the document contains 0.5" proves nothing about the p.
+    Reading the row by its own label does.
+    """
+    acc = report["accuracy"]
+    overall = acc["overall"]
+    perm = acc["permutation"]
+
+    rows: dict[str, str] = {}
+    for line in doc.splitlines():
+        cells = _cells(line)
+        if len(cells) == 2:
+            rows.setdefault(_plain(cells[0]), _plain(cells[1]))
+
+    expected = {
+        "답한 호출": str(overall["answered"]),
+        "맞힘": str(overall["correct"]),
+        "판별력 J (호출 단위)": f"{acc['discrimination_j']['per_call']:.3f}",
+        "판별력 J (기준별 다수결)": f"{MINUS}{abs(acc['discrimination_j']['per_claim_majority'])}",
+        "순열 p (한쪽 꼬리)": str(perm["p_one_sided"]),
+        "이 설계가 낼 수 있는 가장 작은 p": f"{perm['smallest_attainable_p']:.5f}",
+        "애매하게 답함(partial)": str(overall["hedged"]),
+        "아예 못 답함(judge_error)": str(overall["unanswered"]),
+        "과금 대상 호출": str(report["cost"]["billable_calls"]),
+        "가격 없는 모델": report["cost"]["unpriced_models"][0],
+        "모델": report["pins"]["audio_model"],
+    }
+
+    for label, value in expected.items():
+        assert label in rows, f"the results tables have no {label!r} row"
+        assert rows[label] == value, (
+            f"{label}: the document says {rows[label]!r}, the report says "
+            f"{value!r}"
+        )
+
+    # Every "p = x" in the prose is the same p.
+    for stated in re.findall(r"\bp\s*=\s*(\d+(?:\.\d+)?)", doc):
+        assert stated == str(perm["p_one_sided"]), (
+            f"the document writes p = {stated}, the report measured "
+            f"p = {perm['p_one_sided']}"
+        )
+
+
+def test_the_negative_discrimination_keeps_its_sign_everywhere(doc, report):
+    """A minus sign is one character and it reverses the finding.
+
+    The document prints the per-claim majority J three times. Every one of
+    them has to carry the sign -- not just the first, which is all a
+    containment check would prove.
+    """
+    majority = report["accuracy"]["discrimination_j"]["per_claim_majority"]
+    assert majority < 0
+
+    magnitude = re.escape(str(abs(majority)))
+    signed = re.findall(rf"{MINUS}{magnitude}(?!\d)", doc)
+    unsigned = re.findall(rf"(?<![\w.{MINUS}\-]){magnitude}(?!\d)", doc)
+
+    assert len(signed) >= 3, (
+        f"the document states the per-claim majority J {len(signed)} times "
+        f"with its sign; it is quoted in the summary, the results table and "
+        f"the section that explains it"
+    )
+    assert not unsigned, (
+        f"the document states {str(abs(majority))!r} without a minus sign "
+        f"{len(unsigned)} time(s), which reverses what was measured"
+    )
+
+
+def test_the_headline_counts_are_the_measured_ones(doc, report):
+    """The whole-number figures, re-derived rather than re-read."""
+    acc = report["accuracy"]
+    overall = acc["overall"]
+    perm = acc["permutation"]
+
+    required = {
+        "calls": str(overall["calls"]),
+        "answered": str(overall["answered"]),
+        "correct": str(overall["correct"]),
+        "false fail count": str(overall["false_fail"]),
+        "false pass count": str(overall["false_pass"]),
+        "unanswered": str(overall["unanswered"]),
+        "pairs": str(perm["pairs"]),
+        "assignments": str(perm["assignments"]),
+        "at least observed": str(perm["at_least_observed"]),
+        "claims": str(report["pins"]["claims"]),
+        "clips": str(report["pins"]["clips"]),
+        "repeats": str(report["pins"]["repeats"]),
+    }
+
+    for label, value in required.items():
+        assert value in doc, f"the document does not state the {label} ({value})"
+
+
+def test_every_relabelling_count_is_one_of_the_two_measured_ones(doc, report):
+    """The permutation counts are stated twice, so containment is not enough.
+
+    ``at_least_observed`` appears in the summary and again in the section that
+    explains it. A check that only asks whether the document contains ``512``
+    still passes when one of the two copies is wrong -- which is the same
+    second-copy rot the whole-number check above cannot see. Read the counter
+    instead: every number the document counts relabellings with has to be one
+    of the two the report measured, and both have to be there.
+    """
+    perm = report["accuracy"]["permutation"]
+    measured = {str(perm["assignments"]), str(perm["at_least_observed"])}
+
+    # ``가지`` is the counter this document uses for "ways of relabelling".
+    # The digits can be followed by the markdown that closes a bold span or a
+    # code span before the counter: "1024가지", "**512가지**", "`2^10 = 1024`가지".
+    counted = set(re.findall(r"(\d+)[`*]*가지", doc))
+
+    stray = counted - measured
+    assert not stray, (
+        f"the document counts {sorted(stray)} relabelling(s); the report "
+        f"enumerated {perm['assignments']} assignments of which "
+        f"{perm['at_least_observed']} did at least as well as observed"
+    )
+    assert counted == measured, (
+        f"the document states the relabelling counts {sorted(counted)}; both "
+        f"{sorted(measured)} have to appear"
+    )
+
+
+def test_the_family_table_is_the_measured_one(doc, report):
+    """Parsed out of the document and compared row by row.
+
+    The table is the document's argument -- "six answered, three correct"
+    repeated down the page is what shows a judge answering the same word every
+    time -- so a hand-edited cell here would break the reasoning, not just a
+    number.
+    """
+    families = report["accuracy"]["by_family"]
+    seen: dict[str, tuple[int, ...]] = {}
+
+    for line in doc.splitlines():
+        cells = _cells(line)
+        if len(cells) != 6:
+            continue
+        name = _plain(cells[0])
+        if name not in families:
+            continue
+        try:
+            seen[name] = tuple(int(_plain(cell)) for cell in cells[1:])
+        except ValueError:  # the header row, or a prose table
+            continue
+
+    assert set(seen) == set(families), (
+        f"the family table lists {sorted(seen)}, the report has "
+        f"{sorted(families)}"
+    )
+
+    for name, row in families.items():
+        expected = (
+            row["answered"],
+            row["correct"],
+            row["false_fail"],
+            row["false_pass"],
+            row["unanswered"],
+        )
+        assert seen[name] == expected, f"{name}: document {seen[name]} != {expected}"
+
+
+def test_the_verdict_grid_is_the_measured_one(doc, report):
+    """All sixty verdicts, in the order the document prints them."""
+    grid: dict[str, dict[int, str]] = {}
+    holds: dict[str, bool] = {}
+    for call in report["calls"]:
+        grid.setdefault(call["claim_id"], {})[call["repeat"]] = call["verdict"]
+        holds[call["claim_id"]] = call["holds"]
+
+    seen: dict[str, tuple[str, ...]] = {}
+    for line in doc.splitlines():
+        cells = _cells(line)
+        # Five columns, and the second one is the truth marker -- which is
+        # what separates this table from the unanswered-calls table, whose
+        # second column is a repeat number.
+        if len(cells) != 5 or cells[1] not in ("참", "거짓"):
+            continue
+        claim_id = _plain(cells[0])
+        if claim_id not in grid:
+            continue
+        seen[claim_id] = tuple(_plain(cell) for cell in cells[1:])
+
+    assert set(seen) == set(grid), (
+        f"the verdict grid is missing {sorted(set(grid) - set(seen))}"
+    )
+
+    for claim_id, row in seen.items():
+        truth, *verdicts = row
+        assert truth == ("참" if holds[claim_id] else "거짓"), (
+            f"{claim_id} is marked {truth!r} but the report says "
+            f"holds={holds[claim_id]}"
+        )
+        expected = [grid[claim_id][repeat] for repeat in sorted(grid[claim_id])]
+        assert list(verdicts) == expected, (
+            f"{claim_id}: document {verdicts} != {expected}"
+        )
+
+
+def test_every_quoted_verdict_is_verbatim(doc, report):
+    """The exhibits are quotations, and a quotation has to be exact.
+
+    Fragments joined by an ellipsis are checked one at a time, because that is
+    what the ellipsis means. Korean spans are the document's own prose and are
+    not looked for in an English report.
+    """
+    evidence = [call["evidence"] for call in report["calls"] if call["evidence"]]
+    hangul = re.compile(r"[가-힣]")
+    quoted = re.findall(r'"([^"\n]{12,})"', doc)
+
+    assert len(quoted) >= 15, (
+        f"only {len(quoted)} quotations found; the three exhibits carry "
+        f"sixteen between them"
+    )
+
+    checked = 0
+    for quotation in quoted:
+        if hangul.search(quotation):
+            continue
+        for fragment in _plain(quotation).split("…"):
+            fragment = fragment.strip().rstrip(".")
+            if not fragment:
+                continue
+            assert any(fragment in item for item in evidence), (
+                f"the document quotes {fragment!r}, which no call's evidence "
+                f"contains"
+            )
+            checked += 1
+
+    assert checked >= 15, f"only {checked} fragments were checkable"
+
+
+def test_the_silence_exhibit_is_what_the_judge_said(report):
+    """The document's centrepiece, asserted against the report directly.
+
+    Every sample in this clip is zero. If a future run of this probe stopped
+    producing a confident "a human voice is heard", the document's title would
+    be describing something that no longer happened, and it should fail here
+    rather than stay on the shelf.
+    """
+    presence = {
+        (call["claim_id"], call["repeat"]): call
+        for call in report["calls"]
+        if call["family"] == "presence"
+    }
+
+    heard_a_voice = presence[("presence_false", 1)]
+    assert heard_a_voice["verdict"] == "pass"
+    assert heard_a_voice["confidence"] >= 0.95
+    assert "human voice" in heard_a_voice["evidence"]
+
+    heard_silence = presence[("presence_true", 3)]
+    assert heard_silence["confidence"] >= 0.95
+    assert "complete silence" in heard_silence["evidence"]
+
+    # Same file, same run, opposite descriptions, both stated confidently.
+    assert heard_a_voice["clip_id"] == heard_silence["clip_id"] == "pure_silence"
+
+
+def test_the_tempo_exhibit_is_what_the_judge_said(report):
+    """The mechanism the document names: the verdict follows the question.
+
+    Under the coarse criteria the judge confirmed whichever tempo it was
+    offered; under the +/-1 BPM criteria it refused every time. Both halves are
+    required, because either alone has an innocent reading.
+    """
+    coarse = [c for c in report["calls"] if c["family"] == "tempo_coarse"]
+    fine = [c for c in report["calls"] if c["family"] == "tempo_fine"]
+
+    assert len(coarse) == len(fine) == 6
+    assert {c["verdict"] for c in coarse} == {"pass"}
+    assert {c["verdict"] for c in fine} == {"fail"}
+
+    # The true clicks are 0.5 s apart. Offered 60 BPM, the judge reported one
+    # second; offered 120, it reported half a second.
+    offered_sixty = [c for c in coarse if c["claim_id"].endswith("_false")]
+    assert len(offered_sixty) == 3
+    for call in offered_sixty:
+        lowered = call["evidence"].lower()
+        assert "second" in lowered
+        assert "0.5" not in lowered
+
+    assert all("0.5" in c["evidence"] for c in coarse if c["claim_id"].endswith("_true"))
+
+    # Every interval the document quotes from the fine criteria, and none of
+    # them is the true one.
+    quoted_intervals = ["0.7s", "86 BPM", "0.8 seconds", "75 bpm", "110 clicks",
+                        "29 clicks in 30s", "58 BPM"]
+    joined = " ".join(c["evidence"] for c in fine)
+    for fragment in quoted_intervals:
+        assert fragment in joined, fragment
+
+
+def test_the_document_records_the_one_time_it_was_right(doc, report):
+    """The exception the document declines to leave out.
+
+    One fine-criteria call did report 120 BPM. Its verdict is still ``fail``
+    and that fail is still correct, so it changes no number -- which is
+    exactly why it would be easy to drop, and why the document says it.
+    """
+    exception = [
+        call
+        for call in report["calls"]
+        if call["family"] == "tempo_fine" and "around 120 BPM" in call["evidence"]
+    ]
+
+    assert len(exception) == 1
+    assert exception[0]["claim_id"] == "tempo_fine_false"
+    assert exception[0]["verdict"] == "fail"
+    assert exception[0]["outcome"] == "correct"
+    assert "132" in doc
+
+
+def test_the_unanswered_calls_are_named_with_their_cause(doc, report):
+    """Six calls returned no verdict, and they are excluded rather than
+    scored zero. A reader has to be able to see which six and why."""
+    unanswered = [c for c in report["calls"] if c["verdict"] == "judge_error"]
+
+    assert len(unanswered) == report["accuracy"]["overall"]["unanswered"]
+    assert {c["judge_error"] for c in unanswered} == {
+        "provider_error:JSONDecodeError"
+    }
+    assert "provider_error:JSONDecodeError" in doc
+
+    for call in unanswered:
+        assert f"`{call['claim_id']}`" in doc
+        assert f"`{call['clip_id']}`" in doc
+        assert str(call["output_tokens"]) in doc
+        assert str(round(call["latency_ms"])) in doc
+
+
+def test_the_cost_is_recorded_as_unknown_and_never_as_zero(doc, report):
+    """An unpriced model costs an unknown amount, not nothing.
+
+    A zero figure is not banned outright, because the document's job is partly
+    to say that this run was *not* free. What is banned is writing one without
+    the denial: every ``$0`` and every 0원 has to be followed by 아니- ("is
+    not"), so a later edit that trims the qualifier and leaves the figure
+    fails here.
+    """
+    cost = report["cost"]
+
+    assert cost["pricing_complete"] is False
+    assert cost["unpriced_models"] == ["gpt-audio-1.5"]
+    assert cost["estimated_cost_usd"] is None
+    assert cost["billable_calls"] == report["accuracy"]["overall"]["calls"]
+
+    assert "미등록" in doc
+    assert str(cost["billable_calls"]) in doc
+
+    denied = 0
+    for pattern in (r"\$0(?![.\d])", r"0원"):
+        for match in re.finditer(pattern, doc):
+            window = doc[match.end():match.end() + 24]
+            assert "아니" in window, (
+                f"the document writes {match.group()!r} at offset "
+                f"{match.start()} without saying it is not the cost"
+            )
+            denied += 1
+
+    assert denied >= 2, "the document never says this run was not free"
+
+    for forbidden in ("0 USD", "비용 없음", "무료"):
+        assert forbidden not in doc, (
+            f"the document writes {forbidden!r} for a run whose price is "
+            f"unknown"
+        )
+
+
+def test_the_approval_record_the_document_quotes_is_the_real_one(doc, report):
+    """The document reproduces the gate's log line, so it has to match it.
+
+    This is the line that says what was authorised. It went stale once
+    already -- it said twelve criteria after the corpus became twenty -- and
+    a copy of it in a document is one more place for that to happen.
+    """
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    claims = report["pins"]["claims"]
+    repeats = report["pins"]["repeats"]
+
+    criteria_line = (
+        f"criteria   = {claims} "
+        f"({report['pins']['true_claims']} true / "
+        f"{report['pins']['false_claims']} false)"
+    )
+    assert criteria_line in workflow
+    assert criteria_line in doc
+
+    assert f"$(({claims} * PROBE_REPEATS))" in workflow
+    assert f"calls      = {claims * repeats}" in doc
+    assert claims * repeats == report["accuracy"]["overall"]["calls"]
+
+
+def test_the_prompt_line_the_document_blames_is_still_there(doc):
+    """The document explains the recurring "30s" in the evidence by quoting
+    the system prompt. If that wording changes, the explanation is wrong."""
+    source = AUDIO_MODULE_PATH.read_text(encoding="utf-8")
+
+    assert 'f"a head-only slice (first {int(trim_seconds)}s) of"' in source
+    assert "head-only slice (first 30s)" in doc
+
+
+def test_the_document_says_what_it_did_not_measure(doc):
+    """The card asked for speech and music; this is the music half.
+
+    A findings document that quietly dropped the half it could not do would
+    read as complete. The limit is stated in the document, and it is stated
+    here so that removing it fails.
+    """
+    assert "말소리" in doc
+    assert "음악 절반" in doc
+    assert "gold_audio_repeat_v2_sol_max.yaml" in doc
+
+
+def test_the_document_points_at_the_run_it_came_from(doc, report):
+    """A reader has to be able to open the run and the artifact."""
+    assert "actions/runs/33883388098" in doc
+    assert REPORT_PATH.name in doc
+    assert report["what_this_measures"].startswith(
+        "Whether the audio sub-judge's verdict is correct"
+    )

--- a/tasks/rebuilding_grading_task/324-audio-accuracy-measured.json
+++ b/tasks/rebuilding_grading_task/324-audio-accuracy-measured.json
@@ -1,0 +1,2043 @@
+{
+  "what_this_measures": "Whether the audio sub-judge's verdict is correct, on clips whose contents are known by construction. The repeat runs measured consistency (19.35% of audio verdict pairs disagree, against 2.12% on text). Consistency is not correctness and neither implies the other.",
+  "measured": true,
+  "pins": {
+    "config": "gold_audio_repeat_v2_sol_max.yaml",
+    "audio_model": "gpt-audio-1.5",
+    "audio_deployment": "gpt-audio-1.5",
+    "audio_clip_seconds": 30,
+    "audio_call_cap_per_task": 32,
+    "provider": "azure_openai",
+    "clip_sample_rate_hz": 16000,
+    "grader_resample_rate_hz": 16000,
+    "repeats": 3,
+    "claims": 20,
+    "clips": 9,
+    "true_claims": 10,
+    "false_claims": 10
+  },
+  "clips": [
+    {
+      "clip_id": "tone_stops_early",
+      "duration_s": 6.0,
+      "description": "A 1000 Hz tone for the first two seconds, then four seconds of silence.",
+      "segments": [
+        {
+          "start_s": 0.0,
+          "end_s": 2.0,
+          "frequency_hz": 1000.0,
+          "partials": []
+        }
+      ]
+    },
+    {
+      "clip_id": "pure_silence",
+      "duration_s": 6.0,
+      "description": "Six seconds of digital silence; every sample is zero.",
+      "segments": []
+    },
+    {
+      "clip_id": "three_beeps",
+      "duration_s": 5.0,
+      "description": "Three 150 ms beeps at 1000 Hz, at 0.5 s, 2.0 s and 3.5 s, silence in between.",
+      "segments": [
+        {
+          "start_s": 0.5,
+          "end_s": 0.65,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 2.0,
+          "end_s": 2.15,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 3.5,
+          "end_s": 3.65,
+          "frequency_hz": 1000.0,
+          "partials": []
+        }
+      ]
+    },
+    {
+      "clip_id": "clicks_120bpm",
+      "duration_s": 8.0,
+      "description": "Sixteen 30 ms clicks spaced exactly 0.5 s apart across eight seconds, which is 120 beats per minute.",
+      "segments": [
+        {
+          "start_s": 0.0,
+          "end_s": 0.03,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 0.5,
+          "end_s": 0.53,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 1.0,
+          "end_s": 1.03,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 1.5,
+          "end_s": 1.53,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 2.0,
+          "end_s": 2.03,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 2.5,
+          "end_s": 2.53,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 3.0,
+          "end_s": 3.03,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 3.5,
+          "end_s": 3.53,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 4.0,
+          "end_s": 4.03,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 4.5,
+          "end_s": 4.53,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 5.0,
+          "end_s": 5.03,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 5.5,
+          "end_s": 5.53,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 6.0,
+          "end_s": 6.03,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 6.5,
+          "end_s": 6.53,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 7.0,
+          "end_s": 7.03,
+          "frequency_hz": 1000.0,
+          "partials": []
+        },
+        {
+          "start_s": 7.5,
+          "end_s": 7.53,
+          "frequency_hz": 1000.0,
+          "partials": []
+        }
+      ]
+    },
+    {
+      "clip_id": "low_then_high",
+      "duration_s": 5.0,
+      "description": "A 220 Hz tone for two seconds, one second of silence, then a 880 Hz tone for two seconds -- two octaves up.",
+      "segments": [
+        {
+          "start_s": 0.0,
+          "end_s": 2.0,
+          "frequency_hz": 220.0,
+          "partials": []
+        },
+        {
+          "start_s": 3.0,
+          "end_s": 5.0,
+          "frequency_hz": 880.0,
+          "partials": []
+        }
+      ]
+    },
+    {
+      "clip_id": "g_major_scale",
+      "duration_s": 3.4,
+      "description": "Eight notes rising -- G4 A4 B4 C5 D5 E5 F-sharp5 G5 -- each 350 ms with a 50 ms gap. That is the G major scale, and the F-sharp is what makes it G major rather than any flat key.",
+      "segments": [
+        {
+          "start_s": 0.0,
+          "end_s": 0.35,
+          "frequency_hz": 391.99543598174927,
+          "partials": []
+        },
+        {
+          "start_s": 0.4,
+          "end_s": 0.75,
+          "frequency_hz": 440.0,
+          "partials": []
+        },
+        {
+          "start_s": 0.8,
+          "end_s": 1.15,
+          "frequency_hz": 493.8833012561241,
+          "partials": []
+        },
+        {
+          "start_s": 1.2,
+          "end_s": 1.55,
+          "frequency_hz": 523.2511306011972,
+          "partials": []
+        },
+        {
+          "start_s": 1.6,
+          "end_s": 1.95,
+          "frequency_hz": 587.3295358348151,
+          "partials": []
+        },
+        {
+          "start_s": 2.0,
+          "end_s": 2.35,
+          "frequency_hz": 659.2551138257398,
+          "partials": []
+        },
+        {
+          "start_s": 2.4,
+          "end_s": 2.75,
+          "frequency_hz": 739.9888454232688,
+          "partials": []
+        },
+        {
+          "start_s": 2.8,
+          "end_s": 3.15,
+          "frequency_hz": 783.9908719634985,
+          "partials": []
+        }
+      ]
+    },
+    {
+      "clip_id": "major_triad",
+      "duration_s": 3.0,
+      "description": "One sustained chord: G4, B4 and D5 sounding together for 2.6 seconds, which is a G major triad. The minor version of this chord would put B-flat4 where the B4 is.",
+      "segments": [
+        {
+          "start_s": 0.2,
+          "end_s": 2.8,
+          "frequency_hz": 391.99543598174927,
+          "partials": [
+            [
+              493.8833012561241,
+              1.0
+            ],
+            [
+              587.3295358348151,
+              1.0
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "clip_id": "modulating_arpeggio",
+      "duration_s": 5.0,
+      "description": "A G major arpeggio -- G4 B4 D5 G5 -- for the first 2.4 seconds, then the same shape one semitone higher in A-flat major. The key changes exactly halfway through.",
+      "segments": [
+        {
+          "start_s": 0.0,
+          "end_s": 0.5,
+          "frequency_hz": 391.99543598174927,
+          "partials": []
+        },
+        {
+          "start_s": 0.6,
+          "end_s": 1.1,
+          "frequency_hz": 493.8833012561241,
+          "partials": []
+        },
+        {
+          "start_s": 1.2,
+          "end_s": 1.7,
+          "frequency_hz": 587.3295358348151,
+          "partials": []
+        },
+        {
+          "start_s": 1.8,
+          "end_s": 2.3,
+          "frequency_hz": 783.9908719634985,
+          "partials": []
+        },
+        {
+          "start_s": 2.4,
+          "end_s": 2.9,
+          "frequency_hz": 415.3046975799451,
+          "partials": []
+        },
+        {
+          "start_s": 3.0,
+          "end_s": 3.5,
+          "frequency_hz": 523.2511306011972,
+          "partials": []
+        },
+        {
+          "start_s": 3.6,
+          "end_s": 4.1,
+          "frequency_hz": 622.2539674441618,
+          "partials": []
+        },
+        {
+          "start_s": 4.2,
+          "end_s": 4.7,
+          "frequency_hz": 830.6093951598903,
+          "partials": []
+        }
+      ]
+    },
+    {
+      "clip_id": "buzzy_bass",
+      "duration_s": 3.0,
+      "description": "One low note -- C2, about 65.4 Hz -- carrying its first five overtones at falling strength, which is what makes a synth bass buzz instead of hum. A pure sine at the same pitch has none of them.",
+      "segments": [
+        {
+          "start_s": 0.2,
+          "end_s": 2.8,
+          "frequency_hz": 65.40639132514966,
+          "partials": [
+            [
+              130.8127826502993,
+              0.5
+            ],
+            [
+              196.21917397544897,
+              0.3333333333333333
+            ],
+            [
+              261.6255653005986,
+              0.25
+            ],
+            [
+              327.0319566257483,
+              0.2
+            ],
+            [
+              392.43834795089793,
+              0.16666666666666666
+            ]
+          ]
+        }
+      ]
+    }
+  ],
+  "clip_sha256": {
+    "tone_stops_early": "faf3dccfe7d12ce0d9f1d2269ddd813d3a99350b0089f7ab144ddefb2df94c37",
+    "pure_silence": "47b589098cc9e4b92774cd5b6a57ccca0713c02396bf755b2318f7e81cdc534e",
+    "three_beeps": "cae888fe815e3b9fb04224d37e3e85b67b259e5da34791b04bfe57c9c8eae33d",
+    "clicks_120bpm": "3b9b578f67cac2b349828327f417f5b0d83bc3ee8afdedaecc162fc9a40f124a",
+    "low_then_high": "2c6ad8c68ac482a81cf327dc54a92a8fba058ce102936bc953fef3cff19a4d65",
+    "g_major_scale": "a774176e91e88c69f9e5050f2734a24e04c24e36a72827f86e6fd20040a91931",
+    "major_triad": "1aabbe55fd590a1db4a71244f733fa9504de218e11460ee3ddab776bc55bed13",
+    "modulating_arpeggio": "41f529f5931ecaae21353a042bb4c4581ba97da48a85e96b52f780958178433d",
+    "buzzy_bass": "99c0413453268ef2d9e077a197f0638e1ffdcdf2bdf2d44a95a296deab442792"
+  },
+  "claims": [
+    {
+      "claim_id": "timing_true",
+      "clip_id": "tone_stops_early",
+      "family": "timing",
+      "criterion": "A sustained tone is audible from the beginning of the clip and stops before the clip ends, leaving an audible stretch of silence at the end.",
+      "holds": true,
+      "because": "the tone occupies 0.0-2.0 s of a 6.0 s clip",
+      "pair_id": "timing"
+    },
+    {
+      "claim_id": "timing_false",
+      "clip_id": "tone_stops_early",
+      "family": "timing",
+      "criterion": "A sustained tone is audible continuously for the whole clip, with no stretch of silence anywhere in it.",
+      "holds": false,
+      "because": "4.0 s of the 6.0 s clip is digital silence",
+      "pair_id": "timing"
+    },
+    {
+      "claim_id": "presence_true",
+      "clip_id": "pure_silence",
+      "family": "presence",
+      "criterion": "Nothing is audible in the clip: no speech, music, tone or noise.",
+      "holds": true,
+      "because": "every sample in the clip is exactly zero",
+      "pair_id": "presence"
+    },
+    {
+      "claim_id": "presence_false",
+      "clip_id": "pure_silence",
+      "family": "presence",
+      "criterion": "A human voice speaking is audible in the clip.",
+      "holds": false,
+      "because": "every sample in the clip is exactly zero",
+      "pair_id": "presence"
+    },
+    {
+      "claim_id": "count_true",
+      "clip_id": "three_beeps",
+      "family": "count",
+      "criterion": "Exactly three short beeps are audible, each separated from the next by silence.",
+      "holds": true,
+      "because": "the segment list has three tone bursts",
+      "pair_id": "count"
+    },
+    {
+      "claim_id": "count_false",
+      "clip_id": "three_beeps",
+      "family": "count",
+      "criterion": "Exactly seven short beeps are audible, each separated from the next by silence.",
+      "holds": false,
+      "because": "the segment list has three tone bursts, not seven",
+      "pair_id": "count"
+    },
+    {
+      "claim_id": "tempo_coarse_true",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_coarse",
+      "criterion": "The clicks are evenly spaced at a tempo of about 120 beats per minute.",
+      "holds": true,
+      "because": "clicks are 0.5 s apart, which is exactly 120 BPM",
+      "pair_id": "tempo_coarse"
+    },
+    {
+      "claim_id": "tempo_coarse_false",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_coarse",
+      "criterion": "The clicks are evenly spaced at a tempo of about 60 beats per minute.",
+      "holds": false,
+      "because": "60 BPM would be 1.0 s apart; these are 0.5 s apart",
+      "pair_id": "tempo_coarse"
+    },
+    {
+      "claim_id": "tempo_fine_true",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_fine",
+      "criterion": "The tempo of the clicks is 120 beats per minute, within a tolerance of one beat per minute.",
+      "holds": true,
+      "because": "clicks are 0.5 s apart, which is exactly 120 BPM",
+      "pair_id": "tempo_fine"
+    },
+    {
+      "claim_id": "tempo_fine_false",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_fine",
+      "criterion": "The tempo of the clicks is 132 beats per minute, within a tolerance of one beat per minute.",
+      "holds": false,
+      "because": "132 BPM would be 0.4545 s apart; these are 0.5 s apart",
+      "pair_id": "tempo_fine"
+    },
+    {
+      "claim_id": "pitch_order_true",
+      "clip_id": "low_then_high",
+      "family": "pitch_order",
+      "criterion": "The clip opens with a lower-pitched tone and closes with a higher-pitched one.",
+      "holds": true,
+      "because": "220 Hz precedes 880 Hz",
+      "pair_id": "pitch_order"
+    },
+    {
+      "claim_id": "pitch_order_false",
+      "clip_id": "low_then_high",
+      "family": "pitch_order",
+      "criterion": "The clip opens with a higher-pitched tone and closes with a lower-pitched one.",
+      "holds": false,
+      "because": "220 Hz precedes 880 Hz, so the order is the other way round",
+      "pair_id": "pitch_order"
+    },
+    {
+      "claim_id": "key_true",
+      "clip_id": "g_major_scale",
+      "family": "key",
+      "criterion": "Every note in the melody belongs to the G major scale.",
+      "holds": true,
+      "because": "the eight notes are G4 A4 B4 C5 D5 E5 F-sharp5 G5, which is exactly the G major scale",
+      "pair_id": "key"
+    },
+    {
+      "claim_id": "key_false",
+      "clip_id": "g_major_scale",
+      "family": "key",
+      "criterion": "Every note in the melody belongs to the E-flat major scale.",
+      "holds": false,
+      "because": "E-flat major has E-flat, A-flat and B-flat and no F-sharp; this melody plays B natural and F-sharp",
+      "pair_id": "key"
+    },
+    {
+      "claim_id": "triad_true",
+      "clip_id": "major_triad",
+      "family": "triad",
+      "criterion": "The clip is one sustained chord, and that chord is major.",
+      "holds": true,
+      "because": "the chord is G4 + B4 + D5, and B4 is four semitones above G4, which is a major third",
+      "pair_id": "triad"
+    },
+    {
+      "claim_id": "triad_false",
+      "clip_id": "major_triad",
+      "family": "triad",
+      "criterion": "The clip is one sustained chord, and that chord is minor.",
+      "holds": false,
+      "because": "a minor chord would sound B-flat4 at 466.16 Hz where this one sounds B4 at 493.88 Hz",
+      "pair_id": "triad"
+    },
+    {
+      "claim_id": "modulation_true",
+      "clip_id": "modulating_arpeggio",
+      "family": "modulation",
+      "criterion": "The music changes key partway through, so the second half is in a different key from the first.",
+      "holds": true,
+      "because": "the first four notes spell G major and the last four spell A-flat major, one semitone higher",
+      "pair_id": "modulation"
+    },
+    {
+      "claim_id": "modulation_false",
+      "clip_id": "modulating_arpeggio",
+      "family": "modulation",
+      "criterion": "The music stays in one key from beginning to end, with no change of key anywhere in it.",
+      "holds": false,
+      "because": "the second half is transposed up a semitone from the first",
+      "pair_id": "modulation"
+    },
+    {
+      "claim_id": "timbre_true",
+      "clip_id": "buzzy_bass",
+      "family": "timbre",
+      "criterion": "The bass note is a bright, buzzy synth tone with clearly audible overtones above its fundamental.",
+      "holds": true,
+      "because": "the segment sounds harmonics 2 through 6 of its 65.4 Hz fundamental at falling strength",
+      "pair_id": "timbre"
+    },
+    {
+      "claim_id": "timbre_false",
+      "clip_id": "buzzy_bass",
+      "family": "timbre",
+      "criterion": "The bass note is a plain sine tone with nothing sounding above its fundamental.",
+      "holds": false,
+      "because": "harmonics 2 through 6 of the fundamental are all present in the segment",
+      "pair_id": "timbre"
+    }
+  ],
+  "calls": [
+    {
+      "repeat": 1,
+      "claim_id": "timing_true",
+      "pair_id": "timing",
+      "clip_id": "tone_stops_early",
+      "family": "timing",
+      "holds": true,
+      "verdict": "judge_error",
+      "outcome": "unanswered",
+      "confidence": 0.0,
+      "evidence": "",
+      "judge_error": "provider_error:JSONDecodeError",
+      "api_call_count": 1,
+      "input_tokens": 195,
+      "output_tokens": 59,
+      "latency_ms": 2440.346,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "timing_false",
+      "pair_id": "timing",
+      "clip_id": "tone_stops_early",
+      "family": "timing",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.75,
+      "evidence": "Noticeable pauses with no sound interrupt the tone",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 187,
+      "output_tokens": 61,
+      "latency_ms": 1442.881,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "presence_true",
+      "pair_id": "presence",
+      "clip_id": "pure_silence",
+      "family": "presence",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.97,
+      "evidence": "Clear speech is audible throughout the clip.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 183,
+      "output_tokens": 60,
+      "latency_ms": 1634.235,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "presence_false",
+      "pair_id": "presence",
+      "clip_id": "pure_silence",
+      "family": "presence",
+      "holds": false,
+      "verdict": "pass",
+      "outcome": "false_pass",
+      "confidence": 0.98,
+      "evidence": "A clear, natural human voice is heard speaking throughout the 30s clip.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 177,
+      "output_tokens": 67,
+      "latency_ms": 1335.039,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "count_true",
+      "pair_id": "count",
+      "clip_id": "three_beeps",
+      "family": "count",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.93,
+      "evidence": "Only one short beep is audible, followed by silence and no additional beeps.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 173,
+      "output_tokens": 81,
+      "latency_ms": 1633.958,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "count_false",
+      "pair_id": "count",
+      "clip_id": "three_beeps",
+      "family": "count",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.98,
+      "evidence": "Only three beeps were audible in 30 seconds, each followed by silence.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 173,
+      "output_tokens": 67,
+      "latency_ms": 1621.403,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "tempo_coarse_true",
+      "pair_id": "tempo_coarse",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_coarse",
+      "holds": true,
+      "verdict": "pass",
+      "outcome": "correct",
+      "confidence": 0.95,
+      "evidence": "Clearly audible clicks occur every 0.5 seconds, consistent and evenly spaced.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 203,
+      "output_tokens": 71,
+      "latency_ms": 1672.11,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "tempo_coarse_false",
+      "pair_id": "tempo_coarse",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_coarse",
+      "holds": false,
+      "verdict": "pass",
+      "outcome": "false_pass",
+      "confidence": 0.92,
+      "evidence": "Clicks occur once per second, consistently spaced",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 203,
+      "output_tokens": 69,
+      "latency_ms": 1533.545,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "tempo_fine_true",
+      "pair_id": "tempo_fine",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_fine",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.93,
+      "evidence": "The clicks occur roughly every 0.7s, closer to 86 BPM than 120 BPM.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 208,
+      "output_tokens": 80,
+      "latency_ms": 1626.658,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "tempo_fine_false",
+      "pair_id": "tempo_fine",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_fine",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.91,
+      "evidence": "The clicks are spaced about 0.8 seconds apart, suggesting around 75 bpm, far from 132 bpm.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 208,
+      "output_tokens": 75,
+      "latency_ms": 1559.462,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "pitch_order_true",
+      "pair_id": "pitch_order",
+      "clip_id": "low_then_high",
+      "family": "pitch_order",
+      "holds": true,
+      "verdict": "judge_error",
+      "outcome": "unanswered",
+      "confidence": 0.0,
+      "evidence": "",
+      "judge_error": "provider_error:JSONDecodeError",
+      "api_call_count": 1,
+      "input_tokens": 175,
+      "output_tokens": 21,
+      "latency_ms": 1075.463,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "pitch_order_false",
+      "pair_id": "pitch_order",
+      "clip_id": "low_then_high",
+      "family": "pitch_order",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.91,
+      "evidence": "The pitch remains steady throughout the 30s, no audible rise at start or drop at end.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 175,
+      "output_tokens": 81,
+      "latency_ms": 1868.779,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "key_true",
+      "pair_id": "key",
+      "clip_id": "g_major_scale",
+      "family": "key",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.79,
+      "evidence": "A note sounded outside G major scale, such as a C#.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 153,
+      "output_tokens": 69,
+      "latency_ms": 1497.004,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "key_false",
+      "pair_id": "key",
+      "clip_id": "g_major_scale",
+      "family": "key",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.83,
+      "evidence": "Around 14s, a C# note is heard, which is outside the E-flat major scale.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 154,
+      "output_tokens": 77,
+      "latency_ms": 1683.67,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "triad_true",
+      "pair_id": "triad",
+      "clip_id": "major_triad",
+      "family": "triad",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.96,
+      "evidence": "The audio contains spoken words and no sustained musical chord can be heard.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 150,
+      "output_tokens": 75,
+      "latency_ms": 1662.414,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "triad_false",
+      "pair_id": "triad",
+      "clip_id": "major_triad",
+      "family": "triad",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.86,
+      "evidence": "Chord consists of major intervals rather than minor, creating a brighter sound.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 150,
+      "output_tokens": 65,
+      "latency_ms": 1249.134,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "modulation_true",
+      "pair_id": "modulation",
+      "clip_id": "modulating_arpeggio",
+      "family": "modulation",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.89,
+      "evidence": "The music maintained the same tonal center throughout; no audible key change occurred",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 178,
+      "output_tokens": 70,
+      "latency_ms": 1366.826,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "modulation_false",
+      "pair_id": "modulation",
+      "clip_id": "modulating_arpeggio",
+      "family": "modulation",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.77,
+      "evidence": "Around 15s, the tonal center shifts, indicating a modulation to a different key.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 177,
+      "output_tokens": 73,
+      "latency_ms": 1766.64,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "timbre_true",
+      "pair_id": "timbre",
+      "clip_id": "buzzy_bass",
+      "family": "timbre",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.82,
+      "evidence": "The bass note sounds dull and lacks a buzzy, bright character or discernible overtones.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 157,
+      "output_tokens": 71,
+      "latency_ms": 1462.681,
+      "usage_complete": true
+    },
+    {
+      "repeat": 1,
+      "claim_id": "timbre_false",
+      "pair_id": "timbre",
+      "clip_id": "buzzy_bass",
+      "family": "timbre",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.82,
+      "evidence": "The bass note has audible harmonic overtones above the fundamental.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 152,
+      "output_tokens": 68,
+      "latency_ms": 1333.172,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "timing_true",
+      "pair_id": "timing",
+      "clip_id": "tone_stops_early",
+      "family": "timing",
+      "holds": true,
+      "verdict": "judge_error",
+      "outcome": "unanswered",
+      "confidence": 0.0,
+      "evidence": "",
+      "judge_error": "provider_error:JSONDecodeError",
+      "api_call_count": 1,
+      "input_tokens": 195,
+      "output_tokens": 26,
+      "latency_ms": 1082.22,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "timing_false",
+      "pair_id": "timing",
+      "clip_id": "tone_stops_early",
+      "family": "timing",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.96,
+      "evidence": "There are intervals where no tone can be heard, resulting in silence.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 187,
+      "output_tokens": 67,
+      "latency_ms": 1735.379,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "presence_true",
+      "pair_id": "presence",
+      "clip_id": "pure_silence",
+      "family": "presence",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.9,
+      "evidence": "Faint background noise and occasional speech detected in the clip",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 183,
+      "output_tokens": 62,
+      "latency_ms": 1471.029,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "presence_false",
+      "pair_id": "presence",
+      "clip_id": "pure_silence",
+      "family": "presence",
+      "holds": false,
+      "verdict": "judge_error",
+      "outcome": "unanswered",
+      "confidence": 0.0,
+      "evidence": "",
+      "judge_error": "provider_error:JSONDecodeError",
+      "api_call_count": 1,
+      "input_tokens": 177,
+      "output_tokens": 24,
+      "latency_ms": 1080.878,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "count_true",
+      "pair_id": "count",
+      "clip_id": "three_beeps",
+      "family": "count",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.83,
+      "evidence": "Only one short beep heard, followed by silence, with no subsequent beeps.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 173,
+      "output_tokens": 71,
+      "latency_ms": 1443.917,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "count_false",
+      "pair_id": "count",
+      "clip_id": "three_beeps",
+      "family": "count",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.88,
+      "evidence": "Only five short beeps with silence in between are audible.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 173,
+      "output_tokens": 64,
+      "latency_ms": 1669.077,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "tempo_coarse_true",
+      "pair_id": "tempo_coarse",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_coarse",
+      "holds": true,
+      "verdict": "pass",
+      "outcome": "correct",
+      "confidence": 0.95,
+      "evidence": "Regular clicks occur nearly every 0.5 seconds, indicating a consistent 120 BPM tempo.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 203,
+      "output_tokens": 74,
+      "latency_ms": 1469.065,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "tempo_coarse_false",
+      "pair_id": "tempo_coarse",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_coarse",
+      "holds": false,
+      "verdict": "pass",
+      "outcome": "false_pass",
+      "confidence": 0.98,
+      "evidence": "Audible clicks occur roughly once every second with consistent spacing between them.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 203,
+      "output_tokens": 66,
+      "latency_ms": 1511.554,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "tempo_fine_true",
+      "pair_id": "tempo_fine",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_fine",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.84,
+      "evidence": "30s clip contains ~110 clicks, corresponding to about 110 BPM, not 120 BPM",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 208,
+      "output_tokens": 72,
+      "latency_ms": 1461.464,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "tempo_fine_false",
+      "pair_id": "tempo_fine",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_fine",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.87,
+      "evidence": "Clicks sound spaced as if around 120 BPM, slower than 132 BPM benchmark.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 208,
+      "output_tokens": 73,
+      "latency_ms": 1738.376,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "pitch_order_true",
+      "pair_id": "pitch_order",
+      "clip_id": "low_then_high",
+      "family": "pitch_order",
+      "holds": true,
+      "verdict": "judge_error",
+      "outcome": "unanswered",
+      "confidence": 0.0,
+      "evidence": "",
+      "judge_error": "provider_error:JSONDecodeError",
+      "api_call_count": 1,
+      "input_tokens": 175,
+      "output_tokens": 23,
+      "latency_ms": 1162.035,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "pitch_order_false",
+      "pair_id": "pitch_order",
+      "clip_id": "low_then_high",
+      "family": "pitch_order",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.88,
+      "evidence": "Pitch remains consistent throughout; no discernible shift from higher to lower pitch at the end.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 175,
+      "output_tokens": 77,
+      "latency_ms": 1651.818,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "key_true",
+      "pair_id": "key",
+      "clip_id": "g_major_scale",
+      "family": "key",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.88,
+      "evidence": "At 0:12, a C natural note (outside G major scale) was clearly audible against the melody.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 153,
+      "output_tokens": 80,
+      "latency_ms": 1368.161,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "key_false",
+      "pair_id": "key",
+      "clip_id": "g_major_scale",
+      "family": "key",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.92,
+      "evidence": "An audible note outside the E-flat major scale was heard, specifically an F#.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 154,
+      "output_tokens": 73,
+      "latency_ms": 1387.227,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "triad_true",
+      "pair_id": "triad",
+      "clip_id": "major_triad",
+      "family": "triad",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.84,
+      "evidence": "Clip contains a continuous chord but it sounds minor, with a flattened third, not a major chord.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 150,
+      "output_tokens": 84,
+      "latency_ms": 1498.961,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "triad_false",
+      "pair_id": "triad",
+      "clip_id": "major_triad",
+      "family": "triad",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.93,
+      "evidence": "Audio consists of random speech sounds, not a sustained musical chord.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 150,
+      "output_tokens": 66,
+      "latency_ms": 1364.993,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "modulation_true",
+      "pair_id": "modulation",
+      "clip_id": "modulating_arpeggio",
+      "family": "modulation",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.93,
+      "evidence": "The melody remained in the same key throughout the 30-second segment with no audible modulation.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 178,
+      "output_tokens": 73,
+      "latency_ms": 1356.755,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "modulation_false",
+      "pair_id": "modulation",
+      "clip_id": "modulating_arpeggio",
+      "family": "modulation",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.75,
+      "evidence": "Within 30s clip, the music shifts from one tonal center to another noticeably.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 177,
+      "output_tokens": 76,
+      "latency_ms": 1313.124,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "timbre_true",
+      "pair_id": "timbre",
+      "clip_id": "buzzy_bass",
+      "family": "timbre",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.83,
+      "evidence": "The bass note heard is dull and lacks any noticeable buzz or overtones, sounding flat.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 157,
+      "output_tokens": 73,
+      "latency_ms": 1638.929,
+      "usage_complete": true
+    },
+    {
+      "repeat": 2,
+      "claim_id": "timbre_false",
+      "pair_id": "timbre",
+      "clip_id": "buzzy_bass",
+      "family": "timbre",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.89,
+      "evidence": "Audible overtones and harmonics can be heard above the fundamental tone.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 152,
+      "output_tokens": 64,
+      "latency_ms": 1356.793,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "timing_true",
+      "pair_id": "timing",
+      "clip_id": "tone_stops_early",
+      "family": "timing",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.92,
+      "evidence": "No sustained tone was heard and no silence before the end of the clip was present.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 195,
+      "output_tokens": 69,
+      "latency_ms": 1553.449,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "timing_false",
+      "pair_id": "timing",
+      "clip_id": "tone_stops_early",
+      "family": "timing",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.97,
+      "evidence": "There were multiple silent gaps where no tone was heard.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 187,
+      "output_tokens": 58,
+      "latency_ms": 1371.785,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "presence_true",
+      "pair_id": "presence",
+      "clip_id": "pure_silence",
+      "family": "presence",
+      "holds": true,
+      "verdict": "pass",
+      "outcome": "correct",
+      "confidence": 0.98,
+      "evidence": "30s of complete silence with no speech, music, or noise.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 183,
+      "output_tokens": 65,
+      "latency_ms": 1674.118,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "presence_false",
+      "pair_id": "presence",
+      "clip_id": "pure_silence",
+      "family": "presence",
+      "holds": false,
+      "verdict": "judge_error",
+      "outcome": "unanswered",
+      "confidence": 0.0,
+      "evidence": "",
+      "judge_error": "provider_error:JSONDecodeError",
+      "api_call_count": 1,
+      "input_tokens": 177,
+      "output_tokens": 48,
+      "latency_ms": 1364.91,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "count_true",
+      "pair_id": "count",
+      "clip_id": "three_beeps",
+      "family": "count",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.91,
+      "evidence": "Only one short beep heard at the start; the expected three beeps separated by silence were not present.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 173,
+      "output_tokens": 75,
+      "latency_ms": 32760.928,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "count_false",
+      "pair_id": "count",
+      "clip_id": "three_beeps",
+      "family": "count",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.98,
+      "evidence": "Only four beeps are heard, each separated by silence.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 173,
+      "output_tokens": 61,
+      "latency_ms": 1440.505,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "tempo_coarse_true",
+      "pair_id": "tempo_coarse",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_coarse",
+      "holds": true,
+      "verdict": "pass",
+      "outcome": "correct",
+      "confidence": 0.93,
+      "evidence": "Consistent clicks occur roughly every 0.5 seconds, matching 120 BPM.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 203,
+      "output_tokens": 76,
+      "latency_ms": 1439.257,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "tempo_coarse_false",
+      "pair_id": "tempo_coarse",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_coarse",
+      "holds": false,
+      "verdict": "pass",
+      "outcome": "false_pass",
+      "confidence": 0.94,
+      "evidence": "Each click is roughly one second apart, maintaining a consistent tempo.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 203,
+      "output_tokens": 69,
+      "latency_ms": 1543.017,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "tempo_fine_true",
+      "pair_id": "tempo_fine",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_fine",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.91,
+      "evidence": "The clicks occur roughly every 0.8 seconds, about 75 BPM, not near 120 BPM.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 208,
+      "output_tokens": 71,
+      "latency_ms": 1600.953,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "tempo_fine_false",
+      "pair_id": "tempo_fine",
+      "clip_id": "clicks_120bpm",
+      "family": "tempo_fine",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.67,
+      "evidence": "Measured around 29 clicks in 30s, indicating about 58 BPM, far from 132.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 208,
+      "output_tokens": 68,
+      "latency_ms": 1369.638,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "pitch_order_true",
+      "pair_id": "pitch_order",
+      "clip_id": "low_then_high",
+      "family": "pitch_order",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.91,
+      "evidence": "Pitch remained consistently high without a lower-pitched opening.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 175,
+      "output_tokens": 60,
+      "latency_ms": 1393.744,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "pitch_order_false",
+      "pair_id": "pitch_order",
+      "clip_id": "low_then_high",
+      "family": "pitch_order",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.86,
+      "evidence": "Pitch remains consistently high throughout the clip; no noticeable lowering at the end.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 175,
+      "output_tokens": 70,
+      "latency_ms": 1388.559,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "key_true",
+      "pair_id": "key",
+      "clip_id": "g_major_scale",
+      "family": "key",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.98,
+      "evidence": "A distinct C natural note was heard, which is outside the G major scale that requires C#.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 153,
+      "output_tokens": 71,
+      "latency_ms": 1485.332,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "key_false",
+      "pair_id": "key",
+      "clip_id": "g_major_scale",
+      "family": "key",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.87,
+      "evidence": "Several notes, such as a natural A, do not belong to the E-flat major scale",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 154,
+      "output_tokens": 89,
+      "latency_ms": 1470.342,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "triad_true",
+      "pair_id": "triad",
+      "clip_id": "major_triad",
+      "family": "triad",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.96,
+      "evidence": "Multiple distinct notes and silence interruptions were heard, not a single sustained chord.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 150,
+      "output_tokens": 69,
+      "latency_ms": 1467.99,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "triad_false",
+      "pair_id": "triad",
+      "clip_id": "major_triad",
+      "family": "triad",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.91,
+      "evidence": "The chord heard is sustained but has a major tonality, not minor.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 150,
+      "output_tokens": 72,
+      "latency_ms": 1414.472,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "modulation_true",
+      "pair_id": "modulation",
+      "clip_id": "modulating_arpeggio",
+      "family": "modulation",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.92,
+      "evidence": "The melody maintains the same tonal center throughout the 30s; no key change is audible.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 178,
+      "output_tokens": 74,
+      "latency_ms": 1377.994,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "modulation_false",
+      "pair_id": "modulation",
+      "clip_id": "modulating_arpeggio",
+      "family": "modulation",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.88,
+      "evidence": "At around 15s a noticeable modulation shifts the tonal center.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 177,
+      "output_tokens": 67,
+      "latency_ms": 1480.25,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "timbre_true",
+      "pair_id": "timbre",
+      "clip_id": "buzzy_bass",
+      "family": "timbre",
+      "holds": true,
+      "verdict": "fail",
+      "outcome": "false_fail",
+      "confidence": 0.92,
+      "evidence": "The bass note sounds dull and lacks the bright, buzzy character or audible overtones.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 157,
+      "output_tokens": 71,
+      "latency_ms": 1489.578,
+      "usage_complete": true
+    },
+    {
+      "repeat": 3,
+      "claim_id": "timbre_false",
+      "pair_id": "timbre",
+      "clip_id": "buzzy_bass",
+      "family": "timbre",
+      "holds": false,
+      "verdict": "fail",
+      "outcome": "correct",
+      "confidence": 0.92,
+      "evidence": "The bass note includes audible overtones, not just the fundamental sine tone.",
+      "judge_error": null,
+      "api_call_count": 1,
+      "input_tokens": 152,
+      "output_tokens": 67,
+      "latency_ms": 1209.76,
+      "usage_complete": true
+    }
+  ],
+  "accuracy": {
+    "overall": {
+      "calls": 60,
+      "answered": 54,
+      "correct": 28,
+      "false_fail": 22,
+      "false_pass": 4,
+      "hedged": 0,
+      "unanswered": 6,
+      "accuracy": 0.5185185185185185
+    },
+    "on_true_claims": {
+      "calls": 30,
+      "answered": 26,
+      "correct": 4,
+      "false_fail": 22,
+      "false_pass": 0,
+      "hedged": 0,
+      "unanswered": 4,
+      "accuracy": 0.15384615384615385,
+      "false_fail_rate": 0.8461538461538461
+    },
+    "on_false_claims": {
+      "calls": 30,
+      "answered": 28,
+      "correct": 24,
+      "false_fail": 0,
+      "false_pass": 4,
+      "hedged": 0,
+      "unanswered": 2,
+      "accuracy": 0.8571428571428571,
+      "false_pass_rate": 0.14285714285714285
+    },
+    "by_family": {
+      "count": {
+        "calls": 6,
+        "answered": 6,
+        "correct": 3,
+        "false_fail": 3,
+        "false_pass": 0,
+        "hedged": 0,
+        "unanswered": 0,
+        "accuracy": 0.5
+      },
+      "key": {
+        "calls": 6,
+        "answered": 6,
+        "correct": 3,
+        "false_fail": 3,
+        "false_pass": 0,
+        "hedged": 0,
+        "unanswered": 0,
+        "accuracy": 0.5
+      },
+      "modulation": {
+        "calls": 6,
+        "answered": 6,
+        "correct": 3,
+        "false_fail": 3,
+        "false_pass": 0,
+        "hedged": 0,
+        "unanswered": 0,
+        "accuracy": 0.5
+      },
+      "pitch_order": {
+        "calls": 6,
+        "answered": 4,
+        "correct": 3,
+        "false_fail": 1,
+        "false_pass": 0,
+        "hedged": 0,
+        "unanswered": 2,
+        "accuracy": 0.75
+      },
+      "presence": {
+        "calls": 6,
+        "answered": 4,
+        "correct": 1,
+        "false_fail": 2,
+        "false_pass": 1,
+        "hedged": 0,
+        "unanswered": 2,
+        "accuracy": 0.25
+      },
+      "tempo_coarse": {
+        "calls": 6,
+        "answered": 6,
+        "correct": 3,
+        "false_fail": 0,
+        "false_pass": 3,
+        "hedged": 0,
+        "unanswered": 0,
+        "accuracy": 0.5
+      },
+      "tempo_fine": {
+        "calls": 6,
+        "answered": 6,
+        "correct": 3,
+        "false_fail": 3,
+        "false_pass": 0,
+        "hedged": 0,
+        "unanswered": 0,
+        "accuracy": 0.5
+      },
+      "timbre": {
+        "calls": 6,
+        "answered": 6,
+        "correct": 3,
+        "false_fail": 3,
+        "false_pass": 0,
+        "hedged": 0,
+        "unanswered": 0,
+        "accuracy": 0.5
+      },
+      "timing": {
+        "calls": 6,
+        "answered": 4,
+        "correct": 3,
+        "false_fail": 1,
+        "false_pass": 0,
+        "hedged": 0,
+        "unanswered": 2,
+        "accuracy": 0.75
+      },
+      "triad": {
+        "calls": 6,
+        "answered": 6,
+        "correct": 3,
+        "false_fail": 3,
+        "false_pass": 0,
+        "hedged": 0,
+        "unanswered": 0,
+        "accuracy": 0.5
+      }
+    },
+    "by_claim": {
+      "timing_true": {
+        "holds": true,
+        "family": "timing",
+        "verdicts": [
+          "judge_error",
+          "judge_error",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": false,
+        "majority_outcome": "false_fail"
+      },
+      "timing_false": {
+        "holds": false,
+        "family": "timing",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "correct"
+      },
+      "presence_true": {
+        "holds": true,
+        "family": "presence",
+        "verdicts": [
+          "fail",
+          "fail",
+          "pass"
+        ],
+        "majority": "fail",
+        "stable": false,
+        "majority_outcome": "false_fail"
+      },
+      "presence_false": {
+        "holds": false,
+        "family": "presence",
+        "verdicts": [
+          "pass",
+          "judge_error",
+          "judge_error"
+        ],
+        "majority": "pass",
+        "stable": false,
+        "majority_outcome": "false_pass"
+      },
+      "count_true": {
+        "holds": true,
+        "family": "count",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "false_fail"
+      },
+      "count_false": {
+        "holds": false,
+        "family": "count",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "correct"
+      },
+      "tempo_coarse_true": {
+        "holds": true,
+        "family": "tempo_coarse",
+        "verdicts": [
+          "pass",
+          "pass",
+          "pass"
+        ],
+        "majority": "pass",
+        "stable": true,
+        "majority_outcome": "correct"
+      },
+      "tempo_coarse_false": {
+        "holds": false,
+        "family": "tempo_coarse",
+        "verdicts": [
+          "pass",
+          "pass",
+          "pass"
+        ],
+        "majority": "pass",
+        "stable": true,
+        "majority_outcome": "false_pass"
+      },
+      "tempo_fine_true": {
+        "holds": true,
+        "family": "tempo_fine",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "false_fail"
+      },
+      "tempo_fine_false": {
+        "holds": false,
+        "family": "tempo_fine",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "correct"
+      },
+      "pitch_order_true": {
+        "holds": true,
+        "family": "pitch_order",
+        "verdicts": [
+          "judge_error",
+          "judge_error",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": false,
+        "majority_outcome": "false_fail"
+      },
+      "pitch_order_false": {
+        "holds": false,
+        "family": "pitch_order",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "correct"
+      },
+      "key_true": {
+        "holds": true,
+        "family": "key",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "false_fail"
+      },
+      "key_false": {
+        "holds": false,
+        "family": "key",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "correct"
+      },
+      "triad_true": {
+        "holds": true,
+        "family": "triad",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "false_fail"
+      },
+      "triad_false": {
+        "holds": false,
+        "family": "triad",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "correct"
+      },
+      "modulation_true": {
+        "holds": true,
+        "family": "modulation",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "false_fail"
+      },
+      "modulation_false": {
+        "holds": false,
+        "family": "modulation",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "correct"
+      },
+      "timbre_true": {
+        "holds": true,
+        "family": "timbre",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "false_fail"
+      },
+      "timbre_false": {
+        "holds": false,
+        "family": "timbre",
+        "verdicts": [
+          "fail",
+          "fail",
+          "fail"
+        ],
+        "majority": "fail",
+        "stable": true,
+        "majority_outcome": "correct"
+      }
+    },
+    "discrimination_j": {
+      "per_call": 0.010989010989011005,
+      "per_claim_majority": -0.1,
+      "meaning": "P(pass|true) - P(pass|false). 0 means the verdict does not depend on the audio; accuracy alone cannot show that."
+    },
+    "permutation": {
+      "scheme": "within_pair",
+      "pairs": 10,
+      "assignments": 1024,
+      "observed_j": 0.010989010989011005,
+      "at_least_observed": 512,
+      "p_one_sided": 0.5,
+      "smallest_attainable_p": 0.0009765625
+    },
+    "mean_confidence": {
+      "correct": 0.8850000000000001,
+      "false_fail": 0.8986363636363638,
+      "false_pass": 0.955
+    },
+    "stability": {
+      "claims": 20,
+      "identical_across_repeats": 16,
+      "no_majority": 0
+    }
+  },
+  "cost": {
+    "model_calls": 60,
+    "billable_calls": 60,
+    "models": [
+      "gpt-audio-1.5"
+    ],
+    "pricing_complete": false,
+    "unpriced_models": [
+      "gpt-audio-1.5"
+    ],
+    "estimated_cost_usd": null,
+    "note": "gpt-audio-1.5 is absent from the price table, so the cost of this run is unknown rather than zero. null, not $0."
+  }
+}

--- a/tasks/rebuilding_grading_task/324-the-speech-it-heard-in-silence.md
+++ b/tasks/rebuilding_grading_task/324-the-speech-it-heard-in-silence.md
@@ -1,0 +1,376 @@
+# 324 — 완전한 무음에서 "사람 목소리가 들린다"고 답했다
+
+**요약.** 오디오 판정자가 **맞는 답을 하는지**를 처음으로 값을 치르고 쟀다.
+소리 내용이 계산으로 정해진 클립 9개에 기준 20개(참 10·거짓 10), 각 3번씩 **60번**
+물었다. 결과는 이렇다.
+
+* **정확도 51.85%** — 동전 던지기와 구별되지 않는다.
+* **판별력(Youden's J) 0.011.** 0이면 "판정이 소리와 무관하다"는 뜻이다.
+  기준별 다수결로 다시 세면 **−0.1**, 즉 **부호가 음수**다.
+* **순열 p = 0.5.** 1024가지 재배치 중 **512가지**가 실제 결과만큼은 한다.
+* 이번 설계가 낼 수 있는 **가장 작은 p는 0.00098**이다. 즉 판정자가 실제로 듣고
+  있었다면 이 실험은 그것을 **0.001 수준에서 증명할 수 있었다.** 못 한 게 아니라,
+  **증명할 게 없었다.**
+
+[`321`](./321-the-question-the-probe-asked.md)의 첫 판은 삑 소리 5개에 기준 12개였고,
+그때도 판별력은 0이었다. 그건 "코퍼스가 너무 단순해서"라는 반론이 가능했다.
+[#427](https://github.com/hyeonsangjeon/gdpval-realworks/pull/427)이 음악 재료
+4쌍(조성·화음·전조·음색)을 넣어 p 바닥을 1/64에서 **1/1024**로 내렸다.
+**반론이 사라진 자리에서 결과는 그대로다.**
+
+측정한 값 전체는 이 문서 옆에 그대로 두었다
+([`324-audio-accuracy-measured.json`](./324-audio-accuracy-measured.json)).
+아래 숫자는 전부 그 파일에서 나오고, `test_324_quotes_the_run_it_measured.py`가
+문서와 파일이 어긋나면 실패한다.
+
+**비용: 60번 호출, 금액 `미등록`.** `$0`이 아니다(§11).
+
+---
+
+## 1. 무엇을 물었나
+
+기준 하나하나는 **소리만 들으면 참·거짓이 정해지는 문장**이다. 사람 취향이 들어갈
+자리가 없다. 같은 클립에 참 하나·거짓 하나를 **짝**으로 붙였다.
+
+| 짝 | 클립 | 참 기준 | 거짓 기준 |
+|---|---|---|---|
+| `timing` | 2초 소리 뒤 4초 침묵 | 도중에 멈추고 침묵이 남는다 | 끝까지 이어지고 침묵이 없다 |
+| `presence` | **모든 표본이 0인 디지털 무음** | 아무것도 들리지 않는다 | 사람 말소리가 들린다 |
+| `count` | 삑 소리 3개 | 정확히 3개 | 정확히 7개 |
+| `tempo_coarse` | 0.5초 간격 클릭 16개 | 약 120 BPM | 약 60 BPM |
+| `tempo_fine` | 같은 클립 | 120 BPM ±1 | 132 BPM ±1 |
+| `pitch_order` | 220 Hz 뒤 880 Hz | 낮게 시작해 높게 끝난다 | 높게 시작해 낮게 끝난다 |
+| `key` | G장음계 8음 | 모든 음이 G장조 | 모든 음이 E♭장조 |
+| `triad` | G4+B4+D5 동시 | 한 화음, 장3화음 | 한 화음, 단3화음 |
+| `modulation` | G장조 아르페지오 뒤 반음 위 | 도중에 조가 바뀐다 | 처음부터 끝까지 한 조 |
+| `timbre` | C2 + 배음 5개 | 배음이 들리는 거친 소리 | 배음 없는 맑은 사인파 |
+
+클립은 저장소에 없다. **돌 때마다 `wave`와 `math`로 만든다.** 그래서 "정답"은
+누군가의 의견이 아니라 산수다. 만든 바이트의 sha256이 보고서에 들어 있다.
+
+---
+
+## 2. 결과 — 동전과 구별되지 않는다
+
+| | 값 |
+|---|---|
+| 호출 | **60** (기준 20 × 반복 3) |
+| 답한 호출 | 54 |
+| 맞힘 | 28 |
+| 정확도(답한 것 기준) | **51.85%** |
+| 참 기준을 틀리게 fail (false fail) | 22 → **84.6%** |
+| 거짓 기준을 틀리게 pass (false pass) | 4 → **14.3%** |
+| 애매하게 답함(`partial`) | 0 |
+| 아예 못 답함(`judge_error`) | **6** |
+| **판별력 J (호출 단위)** | **0.011** |
+| **판별력 J (기준별 다수결)** | **−0.1** |
+| 순열 p (한쪽 꼬리) | **0.5** |
+| 이 설계가 낼 수 있는 가장 작은 p | 0.00098 |
+
+---
+
+## 3. 왜 51.85%를 믿으면 안 되나
+
+**"전부 fail"이라고만 답해도 이 코퍼스에서 정확도는 50%가 나온다.** 참 10개는
+전부 틀리고 거짓 10개는 전부 맞기 때문이다. 그래서 정확도는 **듣는 판정자와
+안 듣는 판정자를 구별하지 못한다.**
+
+구별하는 건 **판별력 J = P(pass | 참 기준) − P(pass | 거짓 기준)** 하나뿐이다.
+아무 소리도 안 듣고 같은 답만 하면 두 확률이 같아지므로 **J = 0**이 된다.
+
+이번 J는 **0.011**이다. 다수결로 세면 **−0.1**, 참인 기준을 오히려 **덜** 통과시켰다.
+
+p = 0.5의 뜻은 이렇다. 짝 안에서 참·거짓 딱지를 뒤집어 만들 수 있는 코퍼스가
+`2^10 = 1024`가지인데, 그중 **512가지가 실제 결과만큼 또는 그보다 잘 나온다.**
+동전을 던져 절반을 맞히는 것과 같은 자리다.
+
+---
+
+## 4. 판정자는 거의 항상 "fail"이라고 답한다
+
+답한 54번 중 **fail 46번, pass 8번**이다. 85%가 fail이다.
+
+가족별로 보면 이유가 한눈에 보인다.
+
+| 가족 | 답함 | 맞힘 | false fail | false pass | 못 답함 |
+|---|---:|---:|---:|---:|---:|
+| `count` | 6 | 3 | 3 | 0 | 0 |
+| `key` | 6 | 3 | 3 | 0 | 0 |
+| `modulation` | 6 | 3 | 3 | 0 | 0 |
+| `pitch_order` | 4 | 3 | 1 | 0 | 2 |
+| `presence` | 4 | 1 | 2 | 1 | 2 |
+| `tempo_coarse` | 6 | 3 | **0** | **3** | 0 |
+| `tempo_fine` | 6 | 3 | 3 | 0 | 0 |
+| `timbre` | 6 | 3 | 3 | 0 | 0 |
+| `timing` | 4 | 3 | 1 | 0 | 2 |
+| `triad` | 6 | 3 | 3 | 0 | 0 |
+
+**"6번 답해서 3번 맞힘"이 일곱 줄 반복된다.** 이건 실력이 아니라 구조다.
+한 짝은 참 3번·거짓 3번인데 **여섯 번 다 fail이라고 답하면 정확히 3번 맞는다.**
+
+`tempo_coarse`만 반대다. 여섯 번 다 **pass**라고 답해서 역시 3번 맞았다.
+
+---
+
+## 5. 증거 1 — 모든 표본이 0인 파일에서 "사람 목소리"
+
+`pure_silence`는 **모든 표본이 정수 0**인 파일이다. 들릴 것이 물리적으로 없다.
+
+| 호출 | 판정 | 확신 | 판정자가 쓴 근거 |
+|---|---|---:|---|
+| `presence_true` 1회차 | fail | 0.97 | "Clear speech is audible throughout the clip." |
+| `presence_false` 1회차 | pass | 0.98 | "A clear, natural human voice is heard speaking throughout the 30s clip." |
+| `presence_true` 2회차 | fail | 0.90 | "Faint background noise and occasional speech detected in the clip" |
+| `presence_true` 3회차 | pass | 0.98 | "30s of complete silence with no speech, music, or noise." |
+
+**같은 파일에 대해 확신 0.98로 "또렷한 사람 목소리가 계속 들린다"고 했고,
+확신 0.98로 "완전한 무음"이라고도 했다.** 둘 다 같은 0의 나열을 듣고 한 말이다.
+
+---
+
+## 6. 증거 2 — 삑 소리 3개를 1·3·4·5개로 셌다
+
+`three_beeps`는 0.5초·2.0초·3.5초에 150 ms 삑 소리가 하나씩, 모두 **3개**다.
+여섯 번 물었고 **네 가지 다른 개수**가 돌아왔다.
+
+| 호출 | 판정 | 판정자가 쓴 근거 |
+|---|---|---|
+| `count_true` 1회차 | fail | "Only **one** short beep is audible…" |
+| `count_false` 1회차 | fail | "Only **three** beeps were audible in 30 seconds…" |
+| `count_true` 2회차 | fail | "Only **one** short beep heard…" |
+| `count_false` 2회차 | fail | "Only **five** short beeps…" |
+| `count_true` 3회차 | fail | "Only **one** short beep heard at the start…" |
+| `count_false` 3회차 | fail | "Only **four** beeps are heard…" |
+
+여기서 특히 나쁜 줄은 `count_false` 1회차다. **"삑 소리가 정확히 세 개"라는
+사실을 근거에 써놓고**, "정확히 일곱 개인가?"라는 질문에 fail이라고 답했다.
+답 자체는 맞지만 그 옆의 `count_true`는 같은 클립을 "하나"라고 했다.
+
+---
+
+## 7. 증거 3 — 질문이 제안한 숫자를 그대로 되돌려준다
+
+가장 중요한 줄이다. `clicks_120bpm`은 클릭 16개가 **정확히 0.5초 간격**,
+즉 120 BPM이다. 이 한 파일에 기준 넷을 물었다.
+
+| 호출 | 기준이 제안한 값 | 판정 | 판정자가 "쟀다"는 값 |
+|---|---|---|---|
+| `tempo_coarse_true` 1회차 | 약 120 BPM | pass | "clicks occur every **0.5 seconds**" |
+| `tempo_coarse_false` 1회차 | 약 60 BPM | **pass** | "Clicks occur **once per second**" |
+| `tempo_coarse_true` 2회차 | 약 120 BPM | pass | "nearly every **0.5 seconds**… consistent 120 BPM" |
+| `tempo_coarse_false` 2회차 | 약 60 BPM | **pass** | "roughly **once every second**" |
+| `tempo_coarse_true` 3회차 | 약 120 BPM | pass | "roughly every **0.5 seconds**, matching 120 BPM" |
+| `tempo_coarse_false` 3회차 | 약 60 BPM | **pass** | "roughly **one second apart**" |
+
+**세 번 다 그랬다.** 120을 제안하면 0.5초를 "쟀다"고 하고, 60을 제안하면
+1초를 "쟀다"고 한다. 같은 파일, 같은 회차, 몇 초 사이다.
+
+허용 오차를 ±1 BPM으로 좁힌 `tempo_fine`에서는 방향이 뒤집힌다. 여섯 번 모두 fail이고,
+"쟀다"는 값은 이렇다.
+
+> 0.7초(≈86 BPM) · 0.8초(≈75 BPM) · "30초에 클릭 110개"(≈110 BPM) ·
+> 0.8초(≈75 BPM) · "30초에 클릭 29개"(≈58 BPM)
+
+**정답은 언제나 0.5초 · 120 BPM · 16개다.**
+
+여섯 번 중 한 번은 예외다. `tempo_fine_false` 2회차는 "약 120 BPM으로 들리는데
+132 BPM보다 느리다"고 써서 **처음으로 맞는 값을 말했다.** 다만 그때도 판정은
+fail이고, 그 fail은 맞는 판정이다(기준이 132였으니까). 즉 **여섯 번 중 한 번만
+소리에 가까운 값을 냈고, 그 한 번조차 점수에는 아무 차이를 만들지 않았다.**
+
+그래서 이 판정자가 하는 일은 이렇게 요약된다. **느슨한 질문에는 제안된 값을
+그대로 확인해 주고, 빡빡한 질문에는 거절한다.** 판정은 소리가 아니라
+**질문의 모양**을 따라간다. `tempo_coarse`가 6번 다 pass, `tempo_fine`이 6번 다
+fail인 이유가 이것이다.
+
+### 같은 버릇이 길이에서도 보인다
+
+증거 문장에 "30초"가 자꾸 나온다. 실제 클립은 3~8초다. 이건 모델이 길이까지
+지어냈다기보다 **프롬프트가 그렇게 말해 주기 때문**이다. 판정자에게 가는 시스템
+프롬프트 첫 문장이 이렇다(`core/perception/audio.py:342`).
+
+> The clip is a head-only slice (first 30s) of the LLM-under-test's audio
+> deliverable.
+
+실제 채점에서 오디오는 앞 30초로 잘려 나가므로 이 문장 자체는 맞다. 이 실험은
+**진짜 채점 경로를 그대로 부르기 때문에** 6초짜리 무음에도 같은 문장이 붙는다.
+그러자 모델은 **들은 길이가 아니라 들었다고 들은 길이**로 답한다 — "30s of
+complete silence", "30초에 클릭 110개", "Only three beeps were audible in 30
+seconds". §7이 말한 것과 같은 버릇이 길이에서 한 번 더 나온 셈이다.
+
+이게 결과를 흔들지는 않는다. 기준 20개 중 길이를 묻는 것은 하나도 없고, 전부
+**내용**(몇 개인가, 무슨 조인가, 배음이 있는가)을 묻는다. 다만 클립을 30초로
+채워 다시 재면 이 잡음은 없앨 수 있다(§10-6).
+
+---
+
+## 8. 20 × 3 판정 전체
+
+| 기준 | 참? | 1회 | 2회 | 3회 |
+|---|---|---|---|---|
+| `timing_true` | 참 | judge_error | judge_error | fail |
+| `timing_false` | 거짓 | fail | fail | fail |
+| `presence_true` | 참 | fail | fail | pass |
+| `presence_false` | 거짓 | pass | judge_error | judge_error |
+| `count_true` | 참 | fail | fail | fail |
+| `count_false` | 거짓 | fail | fail | fail |
+| `tempo_coarse_true` | 참 | pass | pass | pass |
+| `tempo_coarse_false` | 거짓 | pass | pass | pass |
+| `tempo_fine_true` | 참 | fail | fail | fail |
+| `tempo_fine_false` | 거짓 | fail | fail | fail |
+| `pitch_order_true` | 참 | judge_error | judge_error | fail |
+| `pitch_order_false` | 거짓 | fail | fail | fail |
+| `key_true` | 참 | fail | fail | fail |
+| `key_false` | 거짓 | fail | fail | fail |
+| `triad_true` | 참 | fail | fail | fail |
+| `triad_false` | 거짓 | fail | fail | fail |
+| `modulation_true` | 참 | fail | fail | fail |
+| `modulation_false` | 거짓 | fail | fail | fail |
+| `timbre_true` | 참 | fail | fail | fail |
+| `timbre_false` | 거짓 | fail | fail | fail |
+
+**16줄이 세 번 모두 같은 답이다.** 이 판정자는 흔들리지 않는다. 다만
+흔들리지 않는 답이 틀렸을 뿐이다.
+
+[`315`](./315-repeat-variation-prereg.md)의 반복 실험이 잰 **오디오 판정 불일치
+19.35%** 는 여기에 이렇게 붙는다. **일관성과 정확성은 다른 것이고, 이번 결과는
+둘이 서로를 보장하지 않는다는 걸 같은 판정자 위에서 보여준다.**
+
+---
+
+## 9. 답하지 않은 6건
+
+여섯 번은 판정 자체가 안 나왔다. **여섯 건 모두 같은 원인**이다.
+
+```
+provider_error:JSONDecodeError
+```
+
+| 기준 | 회차 | 클립 | 응답 토큰 | 걸린 시간 |
+|---|---|---|---|---|
+| `timing_true` | 1 | `tone_stops_early` | 59 | 2440 ms |
+| `pitch_order_true` | 1 | `low_then_high` | 21 | 1075 ms |
+| `timing_true` | 2 | `tone_stops_early` | 26 | 1082 ms |
+| `presence_false` | 2 | `pure_silence` | 24 | 1081 ms |
+| `pitch_order_true` | 2 | `low_then_high` | 23 | 1162 ms |
+| `presence_false` | 3 | `pure_silence` | 48 | 1365 ms |
+
+모델이 JSON이 아닌 것을 돌려줬다는 뜻이다. **이 6건은 정확도 계산에서 뺐다.**
+0점으로 넣으면 "틀렸다"가 되는데, 실제로 일어난 일은 "답하지 않았다"이기 때문이다.
+`unanswered`로 따로 센다.
+
+---
+
+## 10. 이 측정이 말하지 않는 것
+
+정직하게 적어둔다.
+
+1. **말소리(speech)는 아직 안 쟀다.** 카드는 "말소리와 음악"을 요구했는데,
+   알아들을 수 있는 말소리는 `wave`와 `math`로 못 만든다. 녹음이나 음성합성기가
+   필요하고, 둘 다 "오디오 파일을 저장소에 넣지 않는다"는 이 도구의 규칙과 부딪힌다.
+   **이번은 음악 절반이다.** §5의 무음 실험이 말소리를 *간접적으로* 건드리긴 하지만
+   (판정자가 없는 목소리를 만들어냈다), 진짜 말소리를 알아듣는지는 안 쟀다.
+2. **합성음이다.** 실제 영화·음악 트랙이 아니다. 다만 실제 트랙으로는 "정답"을
+   산수로 정할 수 없어서, 맞고 틀림을 재려면 이 방향밖에 없다.
+3. **N = 3이다.** 반복 3번은 [`315`](./315-repeat-variation-prereg.md)와 맞추려고
+   고른 값이다. 반복을 늘려도 **p 바닥은 안 내려간다.** 바닥은 `1 / 2^짝수`이고
+   반복은 그 식에 없다. 내리려면 짝을 더 넣어야 한다.
+4. **판정자 하나만 봤다.** `gpt-audio-1.5`, 배포 이름도 같고, 경로는 `direct-v1`,
+   설정은 `gold_audio_repeat_v2_sol_max.yaml`이다. 다른 모델·다른 프롬프트가
+   어떨지는 이 실험이 말하지 않는다.
+5. **채점을 한 게 아니다.** 과제도, 루브릭도, 산출물도 없다. 오디오 하위 판정자를
+   직접 불렀다. 그래서 이 실행은 어떤 점수도 쓰지 않았고 대시보드에도 안 올라간다.
+6. **클립이 프롬프트가 말하는 길이보다 짧다.** 클립은 3~8초인데 프롬프트는 "앞
+   30초"라고 말한다(§7 끝). 기준 중 길이를 묻는 것이 없어서 결과는 안 흔들리지만,
+   클립을 30초로 채우면 이 잡음은 사라진다. 대신 보내는 바이트가 4~10배가 된다.
+
+---
+
+## 11. 비용 — `미등록`, `$0`이 아니다
+
+| | 값 |
+|---|---|
+| 모델 호출 | 60 |
+| 과금 대상 호출 | **60** |
+| 모델 | `gpt-audio-1.5` |
+| 가격표 완비 여부 | **false** |
+| 가격 없는 모델 | `gpt-audio-1.5` |
+| 추정 금액 | **`null`** |
+
+`gpt-audio-1.5`는 저장소 가격표에 없다. 그래서 보고서는 금액을 `null`로 낸다.
+**이건 "0원"이 아니라 "얼마인지 모른다"는 뜻이다.** 돈은 나갔고 액수를 우리가
+모른다. 0을 적으면 나가지 않은 것처럼 읽히므로 적지 않는다.
+
+승인 기록에 남은 문구는 이것이다.
+
+```
+Approved paid audio accuracy probe:
+  model      = gpt-audio-1.5 (read from gold_audio_repeat_v2_sol_max.yaml)
+  criteria   = 20 (10 true / 10 false)
+  repeats    = 3
+  calls      = 60
+  grades     = none. This does not write a grade or touch a corpus.
+```
+
+이 줄이 60을 말하게 만든 것이
+[#428](https://github.com/hyeonsangjeon/gdpval-realworks/pull/428)이다. 그전까지
+승인 기록은 **36**이라고 적혀 있었다. 코퍼스가 20개로 늘어난 뒤에도 12개 시절
+숫자를 그대로 들고 있었기 때문이다. **승인받은 양과 실제 쓴 양이 어긋나는 종류의
+잘못**이라 값을 치르기 전에 먼저 고쳤다.
+
+---
+
+## 12. 무엇이 따라 나오나
+
+**이 문서는 아무 코드도 고치지 않고, 어떤 결정도 대신 내리지 않는다.**
+따라 나오는 것만 적는다.
+
+* 185개 과제 gold 실행에는 오디오로 채점된 항목이 **31개** 있다. 그 항목들의
+  오디오 판정은 이번에 잰 것과 **같은 모델·같은 경로**에서 나왔다. 이번 결과는
+  그 31개를 어떻게 다룰지에 대한 **판단 근거**이지 판단 자체가 아니다.
+  결정은 소유자 몫으로 열려 있다.
+* 이번 결과는 **"오디오 채점을 고쳐라"**로 바로 이어지지 않는다. §7이 보여주는 건
+  모델이 기준 문장에 끌려간다는 것인데, 그게 프롬프트 문제인지 모델 능력 문제인지
+  이 실험은 구분하지 못한다. **구분하려면 프롬프트를 바꿔 같은 20개를 다시 물으면
+  된다.** 그건 이 도구로 그대로 할 수 있고, 60번 더 든다.
+* 말소리 절반은 여전히 열려 있다(§10-1).
+
+---
+
+## 13. 재현 절차
+
+값 없이 전 구간을 돌려보는 것부터.
+
+```bash
+cd batch-runner
+python scripts/measure_audio_grading_accuracy.py --dry-run
+```
+
+실제 측정은 워크플로 하나로만 살 수 있다. `grading` 환경 승인이 필요하다.
+
+```
+Actions → Audio Accuracy Probe → Run workflow
+  dry_run       = false
+  paid_approval = true
+  repeats       = 3
+```
+
+이 문서가 인용한 실행:
+
+* 실행 <https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/33883388098>
+* 커밋 `609c7e8`
+* 보고서 [`324-audio-accuracy-measured.json`](./324-audio-accuracy-measured.json)
+
+---
+
+## 14. 채점기 지문은 하나도 안 움직인다
+
+이 문서, 옆의 JSON, 그리고 §11이 말한 워크플로 수정 전부
+`compute_grader_source_hash`가 읽는 파일 목록에 없다. 채점 설정 **14개 전부**에
+대해 병합 전후 지문을 다시 계산해서 확인했다.
+
+```
+14 configs compared — IDENTICAL
+```
+
+**돌고 있는 채점 실행에 영향이 없고, 다시 스모크를 돌릴 필요도 없다.**


### PR DESCRIPTION
Closes the measurement half of Project #5 item 324.

## What was measured

The audio sub-judge (`gpt-audio-1.5`, route `direct-v1`, config
`gold_audio_repeat_v2_sol_max.yaml`) had never been asked whether it is **right**
— only whether it is **stable**. [`315`](https://github.com/hyeonsangjeon/gdpval-realworks/blob/main/tasks/rebuilding_grading_task/315-repeat-variation-prereg.md)
measured a 19.35% flip rate; a judge that always says the same wrong thing scores
perfectly on that.

9 clips synthesised from `wave` + `math` (so the right answer is arithmetic, not
an opinion), 20 criteria arranged as **10 matched true/false pairs**, 3 repeats,
**60 calls**.

| | |
|---|---|
| answered | 54 of 60 |
| accuracy | **51.85%** |
| Youden's J, per call | **0.011** |
| Youden's J, per-criterion majority | **−0.1** |
| within-pair permutation p | **0.5** (512 of 1024) |
| smallest p this design could reach | 0.00098 |

`J = P(pass | true criterion) − P(pass | false criterion)`. At 0 the verdict is
independent of the sound. **Accuracy cannot see this** — answering `fail` to every
one of these criteria scores 50% by construction, and the judge answered `fail`
46 times out of 54.

The floor matters as much as the result. [#427](https://github.com/hyeonsangjeon/gdpval-realworks/pull/427)
added four musical pairs specifically to push the smallest attainable p from 1/64
to 1/1024. **If the judge had been listening, this run could have proved it at
p ≈ 0.001.** It did not fail to prove it; there was nothing to prove.

## The three exhibits

**Silence.** `pure_silence` is a file in which every sample is integer `0`.

> `presence_false`, repeat 1 — **pass**, confidence **0.98**:
> *"A clear, natural human voice is heard speaking throughout the 30s clip."*
>
> `presence_true`, repeat 3 — **pass**, confidence **0.98**:
> *"30s of complete silence with no speech, music, or noise."*

Same file. Same confidence. Opposite claims.

**Counting.** `three_beeps` contains exactly three 150 ms beeps. Asked six times,
the judge reported **one, three, one, five, one, four**.

**The shape of the question.** `clicks_120bpm` is 16 clicks at exactly 0.5 s.
Offered "about 120 BPM" it *measured* 0.5 s and passed; offered "about 60 BPM" —
same file, same repeat, seconds apart — it *measured* one second and passed.
Three times out of three. Tighten the tolerance to ±1 BPM and it fails all six,
reporting 0.7 s, 0.8 s, "110 clicks", 0.8 s, "29 clicks". The verdict tracks the
criterion's wording, not the sound.

## Scope — read this before citing the number

- **This is the music/non-speech half only.** Intelligible speech cannot be
  synthesised from `wave` and `math`, and recording or TTS would put audio blobs
  in the repo. The silence exhibit touches speech *indirectly* (the judge invented
  a voice); whether it can understand real speech is **still unmeasured**.
- Synthetic clips, one judge, N = 3. More repeats do **not** lower the p floor —
  that is `1/2^pairs` and repeats are not in it.
- **No grade and no published score is touched.** This called the audio
  sub-judge directly; there is no task, no rubric, no deliverable, and nothing
  reaches the dashboard.
- Six calls returned `provider_error:JSONDecodeError` and are counted as
  **unanswered**, not scored zero. The model did not answer; it did not answer
  wrongly.
- **Cost: 60 billable calls, amount `미등록`.** `gpt-audio-1.5` has no published
  price, so the report emits `pricing_complete: false` and
  `estimated_cost_usd: null`. **That is not `$0`** — money was spent and the
  amount is unknown to us.

## What this does not decide

31 items in the 185-task gold run were graded through this same model and route.
This measurement is **evidence for** a decision about them, not the decision.
That stays with the owner.

It also does not say "fix the audio prompt". The exhibit in §7 shows the model
following the criterion's wording, but this run cannot separate a prompt problem
from a capability one. Separating them means re-asking the same 20 criteria under
a changed prompt — 60 more calls, and the tooling already supports it.

## Verification

- `batch-runner/tests/test_324_quotes_the_run_it_measured.py` — 19 tests that
  re-derive every percentage, every decimal, both tables, all 60 verdicts and
  each quoted fragment from the committed JSON, rather than restating them.
- **Mutation sweep: 35 planted corruptions, 35 caught.** It found a real gap:
  corrupting the *second* copy of "512 of 1024" survived a containment check that
  only asked whether the document mentioned the number *somewhere*. A test was
  added that reads the `가지` counter and requires every relabelling count in the
  prose to be one the report enumerated.
- **Grader fingerprints: 14 configs compared — IDENTICAL**, recomputed with
  `compute_grader_source_hash` on both sides of the branch point, 0 errors. None
  of these files are on its input list, so in-flight grading runs are unaffected
  and no smoke re-run is needed.
- Full backend suite: **7887 passed, 11 skipped, 45 deselected** (17m27s).

## Provenance

Report re-downloaded from the artifact of
[run 33883388098](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/33883388098)
(commit `609c7e8`) and committed verbatim beside the write-up:
`sha256 94fe8caaad1a906db4270b626dbf942ca6ca95568b84296dc23cb2fa2b7daa7f`,
57187 bytes. **No model was called for this PR.**
