### PR TITLE
fix(grading): grade-run.yml would not load; job env cannot read `runner`

### DIFF
--- a/.github/workflows/grade-run.yml
+++ b/.github/workflows/grade-run.yml
@@ -703,10 +703,6 @@ jobs:
       published_commits: ${{ steps.published.outputs.commits }}
       published_head: ${{ steps.published.outputs.head }}
     env:
-      # Appended to by each step that successfully pushes. A file rather than a
-      # step output because three different steps contribute and any of them
-      # may be the last one to run.
-      PUBLISHED_COMMITS_FILE: ${{ runner.temp }}/published_commits.txt
       GRADE_EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
       # The same name as one component. An experiment may sit in a directory,
       # and a GitHub artifact name may not contain a separator, so the two
@@ -782,6 +778,22 @@ jobs:
       # every one of those runs after the corpus has been judged and paid for.
       - name: Trust the checkout inside the container
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      # Appended to by each step that successfully pushes. A file rather than a
+      # step output because three different steps contribute and any of them
+      # may be the last one to run.
+      #
+      # Named here rather than in the job's `env:` block because that block
+      # cannot see the `runner` context -- GitHub's context-availability table
+      # gives `jobs.<id>.env` only github/needs/strategy/matrix/vars/secrets/
+      # inputs, and `${{ runner.temp }}` there does not resolve to an empty
+      # string, it makes the whole workflow refuse to load. That cost a
+      # dispatch-blocked `main` for the length of one fix;
+      # tests/test_step8_grade.py now refuses the entire class.
+      - name: Name the file that records what this run publishes
+        run: |
+          echo "PUBLISHED_COMMITS_FILE=$RUNNER_TEMP/published_commits.txt" \
+            >> "$GITHUB_ENV"
 
       # Held on the v5 line on purpose. checkout v6 moved persisted
       # credentials out of .git/config into a separate file referenced by an

--- a/batch-runner/tests/test_step8_grade.py
+++ b/batch-runner/tests/test_step8_grade.py
@@ -3338,6 +3338,110 @@ def _gh_expr(raw):
     return " ".join(str(raw).strip().removeprefix("${{").removesuffix("}}").split())
 
 
+# GitHub's context-availability table, verbatim in scope:
+#   jobs.<job_id>.env -> github, needs, strategy, matrix, vars, secrets, inputs
+#   jobs.<job_id>.if  -> github, needs, vars, inputs
+# `runner` and `job` exist only once a job has a runner, which is after these
+# two keys are evaluated. Using one of them here does not resolve to an empty
+# string -- it makes the whole file fail to load, so the workflow cannot be
+# dispatched at all and no job runs to report why.
+_JOB_ENV_CONTEXTS = frozenset(
+    {"github", "needs", "strategy", "matrix", "vars", "secrets", "inputs"}
+)
+_JOB_IF_CONTEXTS = frozenset({"github", "needs", "vars", "inputs"})
+
+_TEMPLATED = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
+# The leading name of a dotted path. The lookbehind has to exclude `-` as well
+# as word characters, or `needs.validate-request.outputs.x` reports a context
+# called `request`: the hyphen ends the token and leaves `request.` looking
+# like the head of a path.
+_CONTEXT_HEAD = re.compile(r"(?<![\w.\-'\"])([a-z][a-z_]*)\s*\.")
+
+
+def _contexts_used(value, bare_is_an_expression=False):
+    """Context names read by a workflow value.
+
+    `if:` may be written with or without `${{ }}` -- GitHub evaluates a bare
+    condition as an expression either way -- so an extractor that only looks
+    inside the braces silently passes every unwrapped condition.
+    """
+    text = str(value)
+    expressions = _TEMPLATED.findall(text)
+    if bare_is_an_expression and not expressions:
+        expressions = [text]
+    return {name for expr in expressions for name in _CONTEXT_HEAD.findall(expr)}
+
+
+def test_no_job_level_key_reads_a_context_github_refuses_to_provide_there():
+    """A whole class of edit that publishes an undispatchable workflow.
+
+    `PUBLISHED_COMMITS_FILE: ${{ runner.temp }}/...` in this workflow's `grade`
+    job did exactly that: valid YAML, so `yaml.safe_load` was happy and every
+    shape assertion below still passed, but GitHub refused to load the file.
+    The only symptom is a run entry named after the workflow *path* with zero
+    jobs and no annotations. Nothing in the suite objected, which is the same
+    failure -- a change published to main that no check caught -- that
+    `verify-published` exists to stop.
+    """
+    violations = []
+    jobs_scanned = 0
+    env_contexts = set()
+    if_contexts = set()
+
+    workflows = sorted(Path("../.github/workflows").glob("*.yml"))
+    assert workflows, "no workflow files found; the scan would pass vacuously"
+
+    for path in workflows:
+        parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in (parsed.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            jobs_scanned += 1
+            for key, value in (job.get("env") or {}).items():
+                used = _contexts_used(value)
+                env_contexts |= used
+                violations += [
+                    f"{path.name}: jobs.{job_name}.env.{key} reads `{name}`"
+                    for name in sorted(used - _JOB_ENV_CONTEXTS)
+                ]
+            if "if" in job:
+                used = _contexts_used(job["if"], bare_is_an_expression=True)
+                if_contexts |= used
+                violations += [
+                    f"{path.name}: jobs.{job_name}.if reads `{name}`"
+                    for name in sorted(used - _JOB_IF_CONTEXTS)
+                ]
+
+    assert not violations, (
+        "job-level key reads a context GitHub does not provide there, so the "
+        "workflow will not load:\n  "
+        + "\n  ".join(violations)
+        + "\nMove it into a step -- a step may read `runner`, or set the value "
+        'from the runner\'s own environment: `echo "NAME=$RUNNER_TEMP/..." '
+        '>> "$GITHUB_ENV"`.'
+    )
+
+    # Anti-vacuity. Each of these has failed silently at least once while the
+    # assertion above still read as green.
+    assert jobs_scanned >= 20, f"only {jobs_scanned} jobs scanned"
+    assert env_contexts and if_contexts, (
+        "the extractor found no contexts at all in job-level env/if, so it "
+        "would not have found a bad one either"
+    )
+    assert _contexts_used("${{ runner.temp }}/published_commits.txt") == {"runner"}
+    assert _contexts_used("runner.os == 'Linux'", bare_is_an_expression=True) == {
+        "runner"
+    }
+    # The hyphen case, pinned: these are legitimate and must not be reported.
+    assert _contexts_used(
+        "${{ needs.validate-request.outputs.approval_inherited }}"
+    ) == {"needs"}
+    assert _contexts_used(
+        "!cancelled() && needs.approve-paid.result == 'success'",
+        bare_is_an_expression=True,
+    ) == {"needs"}
+
+
 def test_grade_workflow_rc7_requires_valid_committed_partial():
     workflow_path = Path("../.github/workflows/grade-run.yml")
     workflow = workflow_path.read_text(
@@ -3412,6 +3516,32 @@ def test_grade_workflow_rc7_requires_valid_committed_partial():
         "published_commits": "${{ steps.published.outputs.commits }}",
         "published_head": "${{ steps.published.outputs.head }}",
     }
+
+    # Where that file gets its name, and in what order. It has to be a step:
+    # the job's `env:` block cannot read `runner`, and putting it there does
+    # not fail loudly, it stops the workflow from loading at all. See
+    # test_no_job_level_key_reads_a_context_github_refuses_to_provide_there.
+    assert "PUBLISHED_COMMITS_FILE" not in (grade_job.get("env") or {})
+    grade_step_runs = [step.get("run") or "" for step in grade_job["steps"]]
+    names_it = [
+        index
+        for index, run in enumerate(grade_step_runs)
+        if "PUBLISHED_COMMITS_FILE=" in run and "$GITHUB_ENV" in run
+    ]
+    uses_it = [
+        index
+        for index, run in enumerate(grade_step_runs)
+        if '"$PUBLISHED_COMMITS_FILE"' in run
+    ]
+    assert len(names_it) == 1, "exactly one step should name the file"
+    assert uses_it, "nothing reads the file the naming step exists for"
+    # An unconditional step, so the name is set even on the paths where an
+    # early failure means only one of the three pushes ever happens.
+    assert "if" not in grade_job["steps"][names_it[0]]
+    assert names_it[0] < min(uses_it), (
+        "the file is appended to before it is named; the append would go to "
+        "a bare '>>' with an empty path and the push would go unrecorded"
+    )
 
     # The job list above is pinned rather than checked for membership, so that
     # nothing joins a workflow that spends money without being described here.

--- a/tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md
+++ b/tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md
@@ -1152,3 +1152,86 @@ prompt template)은 **한 파일도 건드리지 않았다** — `git diff origi
   여기서 더 주장하지 않는다.
 - §11.9의 미해결 항목(호출 수 증가 원인, 판정 4/38 이동 원인, 소리 계측
   미검증)은 **그대로 열려 있다.** 이번 작업은 그 원인들을 건드리지 않았다.
+
+### 12.10 이 수정 자체가 같은 실수를 저질렀다 (그리고 그것을 고쳤다)
+
+**있는 그대로 적는다.** PR #451이 `9126ee3`로 병합된 직후, `main`에 이런 실행
+기록이 하나 생겼다.
+
+```
+workflowName: .github/workflows/grade-run.yml   ← 워크플로 "이름"이 아니라 "경로"
+event       : push
+conclusion  : failure
+jobs        : 0            ← job이 하나도 없다
+headSha     : 9126ee3ad941e38254c84d51adab736d931f3f30
+```
+
+job이 0개인 실패는 **워크플로 파일 자체를 GitHub이 읽지 못했다**는 뜻이다.
+`gh run view`도 그렇게 말한다 — *"This run likely failed because of a workflow
+file issue."* 병합 직전 네 개 commit(`5704cf8`·`1e06e45`·`3ede896`·`972f52a`)에는
+이 기록이 없으므로, **내 변경으로 새로 생긴 것**이다. 그동안 채점 워크플로는
+**실행 자체가 불가능**했다.
+
+**원인은 한 줄이다.**
+
+```yaml
+jobs:
+  grade:
+    env:
+      PUBLISHED_COMMITS_FILE: ${{ runner.temp }}/published_commits.txt   # ← 여기
+```
+
+GitHub 공식 문서의 컨텍스트 가용성 표에 따르면 `jobs.<id>.env`가 읽을 수 있는
+것은 `github`·`needs`·`strategy`·`matrix`·`vars`·`secrets`·`inputs` **일곱
+개뿐**이다. `runner`는 없다. runner가 아직 배정되기 전에 평가되는 자리이기
+때문이다. 그리고 이 경우 **빈 문자열이 되는 게 아니라 파일 전체가 로드되지
+않는다.**
+
+**왜 테스트가 못 잡았나.** 이건 문법상 **완전히 올바른 YAML**이다. 그래서
+`yaml.safe_load`는 아무 불평 없이 읽었고, 이 워크플로의 모양을 검사하는 기존
+단언 251개도 전부 초록이었다. 파싱으로는 절대 못 잡는 종류다.
+
+**고침.** job의 `env:`에서 빼고, runner를 읽어도 되는 **step**으로 옮겼다.
+
+```yaml
+- name: Name the file that records what this run publishes
+  run: |
+    echo "PUBLISHED_COMMITS_FILE=$RUNNER_TEMP/published_commits.txt" \
+      >> "$GITHUB_ENV"
+```
+
+`grade` job의 맨 앞쪽(체크아웃보다도 앞)에 **조건 없이** 두었다. 뒤따르는 세
+개의 push 기록 step보다 반드시 먼저 돈다.
+
+**한 줄만 고치고 끝내지 않았다.** 같은 *종류*의 편집을 전부 막는 검사를
+`tests/test_step8_grade.py`에 넣었다.
+
+| 검사 | 대상 |
+|---|---|
+| `..._reads_a_context_github_refuses_to_provide_there` | 워크플로 **16개 전부**, job 31개의 job-level `env:`와 `if:` |
+| rc7 테스트에 추가한 단언 | 이 이름을 **step이** 정하는가, **쓰기 전에** 정하는가 |
+
+검사가 진짜로 무는지 확인했다. 문제의 줄을 **원래 모습 그대로 되돌려 놓고**
+돌렸더니 두 테스트가 실패하며 파일·job·키·컨텍스트를 이름으로 지목했다.
+
+```
+grade-run.yml: jobs.grade.env.PUBLISHED_COMMITS_FILE reads `runner`
+```
+
+이름 짓는 step을 append보다 **뒤로** 옮겨서도 돌려 봤고, 그것도 실패한다.
+확인 후 원상복구했다.
+
+정규식을 짤 때 하마터면 놓칠 뻔한 함정도 하나 적어 둔다. `needs.validate-request
+.outputs.…`처럼 job 이름에 하이픈이 있으면, 단순한 패턴은 하이픈에서 토큰이
+끊겨 **`request`라는 없는 컨텍스트를 읽었다고 오탐**한다. 실제로 처음 판에서
+오탐 4건이 났다. 정상 표현식 두 종류를 테스트에 **정탐으로 못 박아** 두었다.
+
+그리고 `if:`는 `${{ }}` 없이도 쓸 수 있다(`if: inputs.dry_run == true`). 실제로
+이 저장소 18개 중 **10개가 괄호 없는 형태**다. 괄호 안만 보는 검사였다면 그
+10개를 통째로 놓쳤을 것이다. 두 형태를 모두 본다.
+
+**이 항목을 남기는 이유.** §12 전체가 *"게시된 변경을 아무 검사도 보지 않았다"*는
+문제를 닫는 작업인데, 그 수정 자체가 **정확히 같은 방식으로** 실패했다. 검사가
+없는 자리에 새 코드를 넣으면 그 코드도 검사받지 못한다. 지우고 조용히 고치는
+편이 보기에는 낫겠지만, 그러면 이 문서가 기록하려던 바로 그 실패 사례를 없애는
+셈이 된다.


### PR DESCRIPTION
## The defect

#451 merged as `9126ee3`. On that commit, `main` grew a run entry that is not a
workflow name but a workflow *path*:

```
workflowName: .github/workflows/grade-run.yml
event       : push
conclusion  : failure
jobs        : 0
headSha     : 9126ee3ad941e38254c84d51adab736d931f3f30
```

Zero jobs and no annotations is GitHub's shape for *the file would not load*;
`gh run view 34162186802` says "This run likely failed because of a workflow
file issue." None of the four preceding commits on `main` (`5704cf8`,
`1e06e45`, `3ede896`, `972f52a`) carry such an entry, so it arrived with #451.
The grading workflow has been undispatchable since.

One line caused it, added by #451:

```yaml
jobs:
  grade:
    env:
      PUBLISHED_COMMITS_FILE: ${{ runner.temp }}/published_commits.txt
```

GitHub's context-availability table gives `jobs.<job_id>.env` exactly
`github, needs, strategy, matrix, vars, secrets, inputs`. `runner` is not
among them — it does not exist until a runner is assigned, which is after this
key is evaluated. The failure mode is not an empty string; the file does not
load at all.

**Why 251 assertions about this workflow missed it.** It is valid YAML.
`yaml.safe_load` parses it happily and every shape assertion still passes.
Parsing cannot reach this class.

## The fix

Out of the job's `env:`, into a step, which may read the runner:

```yaml
- name: Name the file that records what this run publishes
  run: |
    echo "PUBLISHED_COMMITS_FILE=$RUNNER_TEMP/published_commits.txt" \
      >> "$GITHUB_ENV"
```

Unconditional, and placed before the checkout — so the name is set on every
path, including the ones where only one of the three pushes happens.
`$RUNNER_TEMP` is already the idiom used elsewhere inside this container job.

## The guard, not just the line

`test_no_job_level_key_reads_a_context_github_refuses_to_provide_there` walks
**all 16 workflow files, 31 jobs**, and checks every job-level `env:` value and
`if:` condition against the two documented context sets. Zero violations on
this tree.

Two things it would be easy to get wrong, both pinned as tests:

- **Hyphenated job names.** A naive pattern reads
  `needs.validate-request.outputs.x` as a context called `request` — the hyphen
  ends the token and leaves `request.` looking like the head of a path. The
  first version of this scan produced 4 such false positives. Two real
  expressions are pinned as *negative* controls.
- **Unwrapped `if:`.** GitHub evaluates a bare `if: inputs.dry_run == true` as
  an expression. **10 of this repo's 18 job-level conditions are written that
  way**, so an extractor that only looks inside `${{ }}` would skip most of
  them silently.

`test_grade_workflow_rc7_requires_valid_committed_partial` gains four
assertions on the mechanism itself: the name is not in the job's `env:`,
exactly one step sets it, that step is unconditional, and it runs *before* any
step that appends to it — otherwise the append writes to an empty path and a
push goes unrecorded.

**Verified to bite.** Restoring the exact original line fails both tests,
naming file, job, key and context:

```
grade-run.yml: jobs.grade.env.PUBLISHED_COMMITS_FILE reads `runner`
```

Moving the naming step after the appends fails the ordering assertion
(`assert 23 < 15`). Both mutations were reverted.

## Proof that GitHub now loads the file

The invalid file produced its entry on a *branch* push too, not only on
`main`. #451's head `10c9dc4` carries all four:

```
success  pull_request  Execution Envelope Preflight
success  pull_request  Aggregate Tests & Deploy
success  pull_request  Backend Tests
failure  push          .github/workflows/grade-run.yml   <- the file did not load
```

Three green named checks and a fourth entry nobody looks at. This branch's
head has the three and **not** the fourth:

```
$ gh run list --commit bb6b5db
(no .github/workflows/grade-run.yml entry)
```

Same repository, same event, same file, defect removed. That absence is the
signal — worth knowing for next time, because it is not one of the checks a
PR page puts in front of you.

## Scope

Three files: the workflow, its test, and the task record. No behaviour change to grading, no new job, no new permission, no
secret. Grader-fingerprint inputs untouched — `check_grader_hash_freeze.py`
over this PR's actual paths returns `PASS: no grader-source file in this diff`
(exit 0). No model call, no paid run.

Local suites, all three:

| | |
|---|---|
| `batch-runner` | **8613 passed**, 9 skipped, 0 failed (was 8612 — the new guard) |
| repo-root `scripts/__tests__` | **186 passed** |
| `npm run test:aggregate` | **487 passed**, 1 skipped, 0 failed |

`main` at `9126ee3` is green on all three named workflows; the only red on it
is the entry this PR removes.

## What this says about #451

§12 of `TASK_PER_TASK_COST_RECEIPTS.md` exists because a change was published
to `main` and no check looked at it. The fix for that reproduced it exactly.
§12.10 records that rather than quietly correcting it — including the false
positives and the near-miss on unwrapped `if:`.
