### PR TITLE
fix(cost): a refusal is an answer, so stop filing it as an unreached call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ tasks/0822_saturday/*
 tasks/0828_friday/*
 !tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md
 !tasks/0828_friday/AUDIO_PRICE_REPRODUCTION_2026-09-07.md
+!tasks/0828_friday/TASK_REFUSAL_IS_NOT_AN_UNREACHED_CALL.md
 # The grading-rebuild specs and reports here predate the `tasks/**` rule, so
 # they stay tracked without an entry. A *new* file among them does not -- git
 # will not un-ignore a path inside an ignored directory, which is why the

--- a/batch-runner/core/cost_metering.py
+++ b/batch-runner/core/cost_metering.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -47,12 +48,19 @@ from core.cost_receipts import (
 
 __all__ = [
     "Attribution",
+    "CallFailure",
     "CostRecorder",
+    "FAILURE_ANSWERED",
+    "FAILURE_REFUSED",
+    "FAILURE_TIMEOUT",
+    "FAILURE_UNKNOWN",
     "MeteredClient",
     "ROUTE_IDENTITY_ATTRIBUTE",
     "ReportedUsage",
     "RouteCallIdentity",
+    "UNBILLED_STATUSES",
     "api_version_of",
+    "classify_call_failure",
     "deployment_of",
     "extract_usage",
     "open_cost_recorder",
@@ -61,6 +69,120 @@ __all__ = [
     "resolved_model_of",
     "route_identity_of",
 ]
+
+
+#: Provider rejections that are answers rather than silences: the request
+#: reached the API and came back refused before any model ran.
+#:
+#: ``core/perception/audio.py`` keeps the same eight for a different decision —
+#: whether a failed read costs the task one of its allowed attempts. This copy
+#: exists because the ledger has to tell a refusal apart from a call whose fate
+#: is genuinely unknown, and ``test_a_refusal_is_not_an_unreached_call.py``
+#: asserts the two lists are identical so the pair cannot drift in silence.
+#:
+#: Membership is not a claim that the account was untouched. It is the narrower
+#: claim that the provider answered, which is what makes
+#: ``call_reachability_unknown`` the wrong thing to write down.
+UNBILLED_STATUSES = frozenset({400, 401, 403, 404, 413, 415, 422, 429})
+
+#: The provider answered and the answer was one of :data:`UNBILLED_STATUSES`.
+FAILURE_REFUSED = "refused"
+#: The provider answered with some other status. A ``5xx`` may come from a
+#: gateway that never reached the model, or from a model that ran and then
+#: failed to deliver, and this layer cannot tell which.
+FAILURE_ANSWERED = "answered"
+#: Nothing came back in time. The request may well have been served and billed.
+FAILURE_TIMEOUT = "timeout"
+#: Something else broke — a dropped socket, a client-side error, an interrupt.
+FAILURE_UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class CallFailure:
+    """What a failed call is known to have been, and nothing more.
+
+    ``note`` is built only from the failure's *shape* — a status number, a
+    fixed word, an exception class name. Never from the provider's message,
+    which routinely quotes the request URL and can quote a header. The ledger
+    is committed to disk and shipped between shards; a diagnostic string is not
+    worth turning it into a place secrets end up.
+    """
+
+    kind: str
+    status: int | None
+    note: str
+
+    @property
+    def billing_is_known_absent(self) -> bool:
+        """Whether the provider's own answer says no model ran.
+
+        Even here that is not the same as *"nothing was billed"* — see
+        :meth:`CostReceiptLedger.refuse`, which records the distinction rather
+        than resolving it.
+        """
+        return self.kind == FAILURE_REFUSED
+
+
+def _status_on(error: BaseException) -> int | None:
+    """The HTTP status an exception carries, or ``None`` if it carries none.
+
+    Read defensively in two places because the SDKs disagree: some raise an
+    error object with ``status_code`` on it, others hang it off a ``response``.
+    """
+    status = getattr(error, "status_code", None)
+    if status is None:
+        status = getattr(getattr(error, "response", None), "status_code", None)
+    if isinstance(status, bool):
+        return None
+    try:
+        return int(status)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_a_timeout(error: BaseException) -> bool:
+    if isinstance(error, TimeoutError):
+        return True
+    return any(
+        "timeout" in cls.__name__.lower() for cls in type(error).__mro__
+    )
+
+
+def classify_call_failure(error: BaseException) -> CallFailure:
+    """Sort one failed call into what the ledger is entitled to say about it.
+
+    The four kinds are not a taxonomy of provider errors; they are a taxonomy
+    of *what is known*. A refusal is the only one where the outcome is settled
+    from this side of the wire, and it is the only one that changes what the
+    receipt says.
+    """
+    status = _status_on(error)
+    if status is not None and status in UNBILLED_STATUSES:
+        return CallFailure(
+            kind=FAILURE_REFUSED,
+            status=status,
+            note=f"provider_refused_{status}",
+        )
+    if status is not None:
+        return CallFailure(
+            kind=FAILURE_ANSWERED,
+            status=status,
+            note=f"provider_status_{status}",
+        )
+    if _is_a_timeout(error):
+        return CallFailure(
+            kind=FAILURE_TIMEOUT, status=None, note="provider_timeout"
+        )
+    # The class name, reduced to a slug and capped. An exception class is
+    # almost always a fixed name from a library, but "almost always" is not a
+    # property to write to disk on, and a type built at runtime could be named
+    # anything at all.
+    name = re.sub(r"[^A-Za-z0-9_]", "", type(error).__name__)[:64] or "Exception"
+    return CallFailure(
+        kind=FAILURE_UNKNOWN,
+        status=None,
+        note=f"provider_error_{name}",
+    )
 
 
 @dataclass(frozen=True)
@@ -677,9 +799,17 @@ class MeteredClient:
     When a call raises, the reservation is deliberately *left standing* rather
     than cleaned up. A request that timed out may well have been served and
     billed, and the honest record of that is an unsettled reservation, which
-    turns the task's receipt ``partial`` with ``call_reachability_unknown``. A
-    caller that knows the failure happened before anything left the process can
-    say so with :meth:`CostRecorder.abandon_call`.
+    turns the task's receipt ``partial`` with ``call_reachability_unknown``.
+    The note on the row says which kind of silence it was, so a timeout and a
+    dropped connection are told apart without either being resolved.
+
+    One failure is not a silence. A status in :data:`UNBILLED_STATUSES` is the
+    provider *answering*, so that row is recorded as ``refused`` and carries
+    ``call_refused_unpriced``: still counted, still claiming no amount, still
+    holding the receipt at ``partial``, but no longer filed under a doubt about
+    whether the request ever arrived. A caller that knows the failure happened
+    before anything left the process can say so with
+    :meth:`CostRecorder.abandon_call`.
     """
 
     #: Lets code that must know a client's real provider type look through the
@@ -803,13 +933,43 @@ class MeteredClient:
             request_sha256=request_digest_of(kwargs),
         )
         object.__setattr__(self, "last_call_id", call_id)
-        response = call(**kwargs)
+        try:
+            response = call(**kwargs)
+        except BaseException as error:
+            _record_failed_call(recorder.ledger, call_id, error)
+            raise
         recorder.ledger.settle(
             call_id,
             usage=extract_usage(response),
             resolved_model=resolved_model_of(response, requested),
         )
         return response
+
+
+def _record_failed_call(
+    ledger: CostReceiptLedger, call_id: str, error: BaseException
+) -> CallFailure:
+    """File a reservation whose call raised, without swallowing the raise.
+
+    A refusal is resolved here, because the provider answered it. Everything
+    else keeps its reservation — the state that says *"a request went out and
+    we never learned what became of it"*, which for a timeout or a ``5xx`` is
+    the honest reading — and gains a note saying which kind of silence it was.
+
+    Bookkeeping never displaces the provider's own error. If the ledger cannot
+    be written the failure is dropped and the reservation simply stands, which
+    is the conservative reading anyway; raising from here would replace the
+    exception the caller has to see with one about a database.
+    """
+    failure = classify_call_failure(error)
+    try:
+        if failure.kind == FAILURE_REFUSED and failure.status is not None:
+            ledger.refuse(call_id, status=failure.status)
+        else:
+            ledger.leave_unresolved(call_id, note=failure.note)
+    except Exception:
+        pass
+    return failure
 
 
 # ── Opening a recorder for a run ─────────────────────────────────────────

--- a/batch-runner/core/cost_receipts.py
+++ b/batch-runner/core/cost_receipts.py
@@ -138,12 +138,21 @@ REASON_RUNTIME_UNATTRIBUTABLE = "runtime_cost_unattributable"
 REASON_RUNTIME_UNPRICED = "runtime_cost_unpriced"
 REASON_LEDGER_ABSENT = "ledger_absent"
 REASON_STAGE_UNSUPPORTED = "stage_unsupported"
+#: The provider answered, and the answer was a refusal issued before any model
+#: ran: no usage was reported, so there is nothing to price. Distinct from
+#: :data:`REASON_CALL_REACHABILITY_UNKNOWN`, which says the opposite thing — a
+#: refusal is the one case where reachability is precisely what is *not* in
+#: doubt. Both hold a receipt at ``partial``, because neither is evidence that
+#: nothing was billed; the difference is whether a reader has anything to go
+#: and investigate.
+REASON_CALL_REFUSED_UNPRICED = "call_refused_unpriced"
 
 MISSING_REASONS = (
     REASON_USAGE_ABSENT,
     REASON_USAGE_PARTIAL,
     REASON_PRICE_MISSING,
     REASON_CALL_REACHABILITY_UNKNOWN,
+    REASON_CALL_REFUSED_UNPRICED,
     REASON_RUNTIME_UNATTRIBUTABLE,
     REASON_RUNTIME_UNPRICED,
     REASON_LEDGER_ABSENT,
@@ -153,6 +162,12 @@ MISSING_REASONS = (
 STATE_RESERVED = "reserved"
 STATE_SETTLED = "settled"
 STATE_ABANDONED = "abandoned"
+#: Sent, answered, refused. The request reached the provider and came back
+#: rejected before any model ran, so this is neither a call whose fate is
+#: unknown (:data:`STATE_RESERVED`) nor one that never left
+#: (:data:`STATE_ABANDONED`). It is counted as a call, because one was made,
+#: and it claims no amount, because the provider reported none.
+STATE_REFUSED = "refused"
 
 ATTRIBUTION_PER_TASK = "per_task"
 ATTRIBUTION_SHARED = "shared"
@@ -1306,6 +1321,11 @@ class CostReceiptLedger:
                 f"call {call_id} was recorded as never sent, and cannot now "
                 "report usage"
             )
+        if row["state"] == STATE_REFUSED:
+            raise LedgerIntegrityError(
+                f"call {call_id} was recorded as refused before any model ran, "
+                "and cannot now report usage"
+            )
 
         model = str(resolved_model or row["requested_model"] or "")
         price = None
@@ -1356,7 +1376,8 @@ class CostReceiptLedger:
         Only correct where the failure is known to precede the request: a
         prompt that could not be assembled, a client that could not be built.
         A timeout is *not* this; a timeout leaves the reservation standing,
-        because the request may well have been served and billed.
+        because the request may well have been served and billed. Neither is a
+        provider refusal, which left and came back — that is :meth:`refuse`.
         """
         row = self._row(call_id)
         if row is None:
@@ -1368,10 +1389,101 @@ class CostReceiptLedger:
                 f"call {call_id} already reported usage and cannot now be "
                 "recorded as never sent"
             )
+        if row["state"] == STATE_REFUSED:
+            raise LedgerIntegrityError(
+                f"call {call_id} was answered by the provider and cannot now "
+                "be recorded as never sent"
+            )
         self._connection.execute(
             "UPDATE cost_calls SET state = ?, note = COALESCE(?, note) "
             "WHERE call_id = ?",
             (STATE_ABANDONED, note, call_id),
+        )
+        self._connection.commit()
+
+    def refuse(self, call_id: str, *, status: int) -> None:
+        """Record that the provider answered, and the answer was a refusal.
+
+        A status code is a reply. Receiving one is the proof that the request
+        arrived, so a refused call is the one kind of failure where reachability
+        is not what is in doubt — which is why it must not be left standing as a
+        reservation, whose whole meaning is *"we never found out"*.
+
+        It is equally not :meth:`abandon`. Abandoned rows are dropped from the
+        receipt entirely, and dropping this one would say a call was never made
+        when one was, and would quietly take the task's ``model_calls`` down
+        with it.
+
+        So the row is counted and claims nothing. The provider reported no
+        usage, and a refusal is not a billing statement; the status tells us
+        the model did not run, not that the account was not touched. The row
+        therefore carries :data:`REASON_CALL_REFUSED_UNPRICED` and holds the
+        receipt at ``partial``, exactly as an unpriceable settled call does.
+        The change from a reservation is in what the reader is told, not in
+        what the ledger claims to know.
+
+        Only for statuses a refusal can carry. A timeout, a dropped socket and
+        a ``5xx`` are all silences from this layer's point of view and must keep
+        leaving the reservation standing, because the request may well have been
+        served and billed out of sight.
+        """
+        row = self._row(call_id)
+        if row is None:
+            raise LedgerIntegrityError(
+                f"call {call_id} was refused without ever being reserved"
+            )
+        if row["state"] == STATE_SETTLED:
+            raise LedgerIntegrityError(
+                f"call {call_id} already reported usage and cannot now be "
+                "recorded as refused"
+            )
+        if row["state"] == STATE_ABANDONED:
+            raise LedgerIntegrityError(
+                f"call {call_id} was recorded as never sent, and cannot now "
+                "have been answered"
+            )
+        note = f"provider_refused_{int(status)}"
+        if row["state"] == STATE_REFUSED and row["note"] != note:
+            raise LedgerIntegrityError(
+                f"call {call_id} was already refused with {row['note']!r} and "
+                f"cannot now be refused with {note!r}"
+            )
+        reasons = sorted(
+            {*_decode_reasons(row["missing_reasons"]), REASON_CALL_REFUSED_UNPRICED}
+        )
+        self._connection.execute(
+            "UPDATE cost_calls SET state = ?, missing_reasons = ?, note = ? "
+            "WHERE call_id = ?",
+            (STATE_REFUSED, json.dumps(reasons), note, call_id),
+        )
+        self._connection.commit()
+
+    def leave_unresolved(self, call_id: str, *, note: str) -> None:
+        """Say why a reservation is standing, without pretending to resolve it.
+
+        A timeout and a connection that died mid-flight are different events
+        with the same consequence: the request may have been served and billed,
+        and this process will never know. Both keep :data:`STATE_RESERVED` and
+        :data:`REASON_CALL_REACHABILITY_UNKNOWN`, which are the true reading.
+
+        What was missing is *which* of them happened. The note carries that and
+        nothing else — a fixed word built from the failure's shape, never from
+        the provider's message, which can quote a URL, a header or a key.
+        """
+        _require(bool(note), "an unresolved call must say what happened to it")
+        row = self._row(call_id)
+        if row is None:
+            raise LedgerIntegrityError(
+                f"call {call_id} failed without ever being reserved"
+            )
+        if row["state"] != STATE_RESERVED:
+            raise LedgerIntegrityError(
+                f"call {call_id} is {row['state']}, so it is not an open "
+                "question and must not be annotated as one"
+            )
+        self._connection.execute(
+            "UPDATE cost_calls SET note = COALESCE(note, ?) WHERE call_id = ?",
+            (note, call_id),
         )
         self._connection.commit()
 
@@ -1583,13 +1695,18 @@ class CostReceiptLedger:
             _require_agreement(existing, record)
             if existing["state"] == STATE_RESERVED and str(
                 record.get("state") or ""
-            ) in (STATE_SETTLED, STATE_ABANDONED):
+            ) in (STATE_SETTLED, STATE_ABANDONED, STATE_REFUSED):
                 # We only knew the request had gone out; the arriving export
                 # knows how it ended. Taking the outcome resolves a doubt
                 # rather than overwriting a figure, and it is the difference
                 # between a receipt that stays partial forever and one that
                 # closes. The reverse direction is not allowed: a settled row
                 # is never demoted back to an open question.
+                #
+                # A refusal is one of the outcomes worth taking. Left out, a
+                # merged shard would put back the very sentence this promotion
+                # exists to retire — a call the provider answered, filed under
+                # "we never found out whether it arrived".
                 self._connection.execute(
                     "UPDATE cost_calls SET {assignments} WHERE call_id = ?".format(
                         assignments=", ".join(
@@ -1699,6 +1816,12 @@ def build_receipt(
     Abandoned calls contribute nothing and cost nothing — they never went out.
     Reserved-but-unsettled calls contribute nothing but *do* cost the receipt
     its ``complete`` status, because whether they were billed is unknown.
+    Refused calls sit between the two: they went out, so they are counted, and
+    they carry ``call_refused_unpriced`` rather than the reservation's
+    ``call_reachability_unknown``, because a status code is an answer and
+    reachability is the one thing a refusal settles. The receipt is still held
+    at ``partial`` — knowing the model did not run is not the same as holding
+    the provider's word that nothing was billed.
 
     Lines are grouped by stage, retry kind *and* call identity. Grouping on the
     stage alone was what turned a ``perception`` line into an unpriceable lump
@@ -2075,6 +2198,18 @@ def _require_agreement(
         # The local row knows less than the arriving one. Fill it in rather
         # than treat the arrival as a contradiction.
         return
+    if existing["state"] == STATE_REFUSED and str(
+        record.get("state") or ""
+    ) == STATE_SETTLED:
+        # Both rows watched the same call end and came back with incompatible
+        # stories: one says the provider refused before any model ran, the
+        # other says a model ran and reported usage. The token comparison
+        # below cannot see this, because a refused row holds no counts to
+        # disagree with — so the absence would read as agreement.
+        raise LedgerIntegrityError(
+            f"imported call {existing['call_id']} reports usage for a call "
+            "this ledger recorded as refused before any model ran"
+        )
     for column in ("input_tokens", "output_tokens", "model_cost_usd"):
         incoming = record.get(column)
         recorded = existing[column]

--- a/batch-runner/schemas/grade.schema.json
+++ b/batch-runner/schemas/grade.schema.json
@@ -18,6 +18,7 @@
         "usage_partial",
         "price_missing",
         "call_reachability_unknown",
+        "call_refused_unpriced",
         "runtime_cost_unattributable",
         "runtime_cost_unpriced",
         "ledger_absent",

--- a/batch-runner/scripts/verify_cost_ledger.py
+++ b/batch-runner/scripts/verify_cost_ledger.py
@@ -247,8 +247,26 @@ def check_all_calls_settled(calls: list[dict[str, Any]]) -> Finding:
     bookkeeping noise: it is a request the provider may well have billed,
     whose reply was never recorded. It cannot appear in the totals, which is
     exactly why it has to be surfaced rather than subtracted.
+
+    Only 'reserved' means that. A row is 'abandoned' when the call is known
+    never to have left, and 'refused' when the provider answered and the answer
+    was a rejection issued before any model ran. Neither is a reply that went
+    missing, and reporting them here would bury the rows that are — which is
+    the same mistake, one layer up, that ``call_refused_unpriced`` exists to
+    stop the ledger making. They are counted in the evidence instead.
     """
-    unsettled = [row for row in calls if row.get("state") != STATE_SETTLED]
+    unsettled = [row for row in calls if row.get("state") == STATE_RESERVED]
+    resolved_without_a_reply = sorted(
+        {
+            str(row.get("state") or "")
+            for row in calls
+            if row.get("state") not in (STATE_SETTLED, STATE_RESERVED)
+        }
+    )
+    counts = {
+        state: sum(1 for row in calls if row.get("state") == state)
+        for state in resolved_without_a_reply
+    }
     if unsettled:
         return Finding(
             "all_calls_settled",
@@ -262,14 +280,24 @@ def check_all_calls_settled(calls: list[dict[str, Any]]) -> Finding:
                         "task_id": row.get("task_id"),
                         "stage": row.get("stage"),
                         "state": row.get("state"),
+                        "note": row.get("note"),
                     }
                     for row in unsettled[:20]
                 ],
                 "unsettled_count": len(unsettled),
+                "other_states": counts,
             },
         )
+    settled = sum(1 for row in calls if row.get("state") == STATE_SETTLED)
+    detail = f"every one of the {len(calls)} calls recorded a reply"
+    if counts:
+        named = ", ".join(f"{count} {state}" for state, count in counts.items())
+        detail = (
+            f"{settled} of {len(calls)} calls recorded a reply and none is "
+            f"still waiting for one ({named})"
+        )
     return Finding(
-        "all_calls_settled", True, f"every one of the {len(calls)} calls recorded a reply"
+        "all_calls_settled", True, detail, {"other_states": counts} if counts else None
     )
 
 

--- a/batch-runner/tests/test_a_refusal_is_not_an_unreached_call.py
+++ b/batch-runner/tests/test_a_refusal_is_not_an_unreached_call.py
@@ -1,0 +1,706 @@
+"""A status code is an answer, so reachability is not what is unknown.
+
+`MeteredClient` writes the ledger row *before* the request and settles it after
+the reply. When the call raised, there was no `except`, so `settle` was never
+reached and the row stayed `reserved` — the state whose whole meaning is *"a
+request went out and we never learned what became of it"*, reported to a reader
+as `call_reachability_unknown`.
+
+For a provider refusal that sentence is false in the one way that matters. A
+`400` is not a silence; it is the API replying, and replying is the proof the
+request arrived. `core/perception/audio.py` already knows this about eight
+statuses and acts on it — it hands the task's attempt back — but the ledger was
+never told, so the same eight came out filed under a doubt about whether the
+request ever landed.
+
+The amount was never wrong. `reserved` claims nothing, which is far safer than
+claiming `$0`. What was wrong is the label, and the label is the part a person
+acts on: `call_reachability_unknown` means *go and find out whether this was
+billed*. Fifty rate-limit bounces produce fifty of those, all certainly free,
+and the genuinely unknown ones — a `5xx`, a timeout — disappear into the pile.
+
+So this file pins the distinction, in both directions:
+
+* a refusal is recorded as `refused`, is still **counted** as a call, still
+  claims **no amount**, and still holds the receipt at `partial`. Knowing the
+  model did not run is not the provider's word that the account was untouched,
+  and this change was never licensed to turn a `400` into a complete, free
+  receipt;
+* a `5xx`, a timeout and a dropped connection keep their reservations exactly
+  as before. If any of those moved, the fix would have reached past the thing
+  it was for.
+
+Nothing here contacts a provider. Every client is local and raises on demand.
+"""
+
+import json
+from decimal import Decimal
+
+import pytest
+
+from core.cost_metering import (
+    FAILURE_ANSWERED,
+    FAILURE_REFUSED,
+    FAILURE_TIMEOUT,
+    FAILURE_UNKNOWN,
+    UNBILLED_STATUSES,
+    CostRecorder,
+    classify_call_failure,
+)
+from core.cost_receipts import (
+    BUCKET_PROBLEM_SOLVING,
+    REASON_CALL_REACHABILITY_UNKNOWN,
+    REASON_CALL_REFUSED_UNPRICED,
+    REASON_USAGE_ABSENT,
+    MISSING_REASONS,
+    STAGE_GENERATION,
+    STATE_ABANDONED,
+    STATE_REFUSED,
+    STATE_RESERVED,
+    STATE_SETTLED,
+    STATUS_COMPLETE,
+    STATUS_PARTIAL,
+    CostReceiptLedger,
+    LedgerIntegrityError,
+    load_receipt_price_table,
+)
+
+REFUSAL_STATUSES = sorted(UNBILLED_STATUSES)
+
+PRICE_TABLE = {
+    "cost_receipt_schema_version": "cost-receipt-price-table-v1",
+    "providers": {
+        "azure:test-model": {
+            "input_usd_per_million": "10",
+            "cached_input_usd_per_million": "1",
+            "output_usd_per_million": "20",
+            "reasoning_billed_as": "output",
+            "source": "fixture",
+            "last_reviewed": "2026-08-28",
+            "currency": "USD",
+            "unit": "per 1,000,000 tokens",
+        }
+    },
+    "runtime": {},
+}
+
+
+@pytest.fixture
+def price_table(tmp_path):
+    path = tmp_path / "prices.json"
+    path.write_text(json.dumps(PRICE_TABLE), encoding="utf-8")
+    return load_receipt_price_table(path)
+
+
+@pytest.fixture
+def ledger(tmp_path, price_table):
+    with CostReceiptLedger(
+        tmp_path / "cost.sqlite3", run_id="run-1", price_table=price_table
+    ) as opened:
+        yield opened
+
+
+@pytest.fixture
+def recorder(ledger):
+    return CostRecorder(ledger)
+
+
+# ── stand-in clients ─────────────────────────────────────────────────────
+
+
+class _Bag:
+    def __init__(self, **fields):
+        for name, value in fields.items():
+            setattr(self, name, value)
+
+
+def _reply(prompt=100_000, completion=10_000):
+    return _Bag(
+        model="test-model",
+        usage=_Bag(prompt_tokens=prompt, completion_tokens=completion),
+    )
+
+
+class Refused(Exception):
+    """The shape an SDK raises when the provider answers with a rejection."""
+
+    def __init__(self, status, message="refused"):
+        super().__init__(message)
+        self.status_code = status
+
+
+class RefusedViaResponse(Exception):
+    """The other shape: the status hangs off a `response` object."""
+
+    def __init__(self, status):
+        super().__init__("refused")
+        self.response = _Bag(status_code=status)
+
+
+class Client:
+    def __init__(self, reply=None, *, raises=None):
+        self._reply = reply if reply is not None else _reply()
+        self._raises = raises
+        self.calls = []
+        self.chat = _Bag(completions=_Bag(create=self._create))
+        self.api_version = "2026-01-01"
+
+    def _create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._raises is not None:
+            raise self._raises
+        return self._reply
+
+
+def _call(recorder, error, task_id="task-a"):
+    """Drive one metered call that fails, and hand back its row."""
+    client = recorder.meter(Client(raises=error), provider="azure")
+    with recorder.attributed(task_id=task_id, stage=STAGE_GENERATION):
+        with pytest.raises(type(error)):
+            client.chat.completions.create(model="a-deployment", messages=[])
+    rows = recorder.ledger.calls_for(task_id)
+    return rows[-1], recorder.receipt_for(task_id, BUCKET_PROBLEM_SOLVING)
+
+
+# ── the defect ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("status", REFUSAL_STATUSES)
+def test_a_refusal_is_not_recorded_as_a_call_that_might_never_have_arrived(
+    recorder, status
+):
+    row, receipt = _call(recorder, Refused(status))
+
+    assert row["state"] == STATE_REFUSED, (
+        f"a {status} left the row {row['state']!r}: the provider answered, so "
+        "this is not a call whose arrival is in doubt"
+    )
+    assert REASON_CALL_REACHABILITY_UNKNOWN not in receipt.missing_reasons
+    assert REASON_CALL_REFUSED_UNPRICED in receipt.missing_reasons
+    assert row["note"] == f"provider_refused_{status}"
+
+
+@pytest.mark.parametrize("status", REFUSAL_STATUSES)
+def test_a_refusal_still_costs_the_receipt_its_certainty(recorder, status):
+    """The reason was wrong. The amount was not, and does not move.
+
+    A refusal says the model did not run. It is not the provider stating that
+    nothing was charged, and the ledger only ever reports what it was told —
+    so the receipt claims no figure and stays `partial`, exactly as the
+    reservation did. Turning `400` into a complete, free receipt would fix a
+    label by inventing a fact.
+    """
+    _, receipt = _call(recorder, Refused(status))
+
+    assert receipt.status == STATUS_PARTIAL
+    assert receipt.estimated_cost_usd is None
+    assert receipt.known_cost_usd == Decimal(0)
+
+
+@pytest.mark.parametrize("status", REFUSAL_STATUSES)
+def test_a_refusal_is_still_a_call_that_was_made(recorder, status):
+    """Counted, unlike an abandoned row, because a request really went out.
+
+    `build_receipt` drops abandoned rows wholesale. Routing a refusal there —
+    the obvious cheap fix — would quietly take the task's `model_calls` down by
+    one and say no call was made, of a call the provider has a record of.
+    """
+    _, receipt = _call(recorder, Refused(status))
+
+    assert receipt.model_calls == 1
+
+
+def test_the_status_is_read_from_a_response_object_too(recorder):
+    row, _ = _call(recorder, RefusedViaResponse(400))
+
+    assert row["state"] == STATE_REFUSED
+    assert row["note"] == "provider_refused_400"
+
+
+# ── the four failures that must not move ─────────────────────────────────
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504, 408, 409, 418])
+def test_any_other_status_keeps_its_reservation(recorder, status):
+    """A `5xx` may be a gateway that never reached the model, or a model that
+    ran and then failed to deliver. This layer cannot tell, and an unsettled
+    reservation is what "cannot tell" looks like."""
+    row, receipt = _call(recorder, Refused(status))
+
+    assert row["state"] == STATE_RESERVED
+    assert REASON_CALL_REACHABILITY_UNKNOWN in receipt.missing_reasons
+    assert REASON_CALL_REFUSED_UNPRICED not in receipt.missing_reasons
+    assert receipt.estimated_cost_usd is None
+    assert row["note"] == f"provider_status_{status}"
+
+
+def test_a_timeout_keeps_its_reservation(recorder):
+    row, receipt = _call(recorder, TimeoutError("no reply"))
+
+    assert row["state"] == STATE_RESERVED
+    assert REASON_CALL_REACHABILITY_UNKNOWN in receipt.missing_reasons
+    assert row["note"] == "provider_timeout"
+
+
+def test_a_dropped_connection_keeps_its_reservation(recorder):
+    class Dropped(Exception):
+        pass
+
+    row, receipt = _call(recorder, Dropped("connection reset"))
+
+    assert row["state"] == STATE_RESERVED
+    assert REASON_CALL_REACHABILITY_UNKNOWN in receipt.missing_reasons
+    assert row["note"] == "provider_error_Dropped"
+
+
+def test_a_message_that_mentions_a_timeout_is_not_a_timeout(recorder):
+    """Classified on the failure's shape, never on the provider's prose.
+
+    A message is attacker- and vendor-controlled text. Reading "gateway
+    timeout" out of a `RuntimeError` would let wording decide a bookkeeping
+    state, and would have quietly reclassified an existing test's error.
+    """
+    row, _ = _call(recorder, RuntimeError("gateway timeout"))
+
+    assert row["note"] == "provider_error_RuntimeError"
+
+
+# ── the five cases the record has to tell apart ──────────────────────────
+
+
+def test_the_five_endings_a_call_can_have_are_five_different_records(
+    recorder, tmp_path
+):
+    """One row each, and no two of them say the same thing.
+
+    A verifiable answer, a failure known to predate the request, a call whose
+    fate is unknown, a reply that carried no usage, and a timeout. Before this
+    change three of the five were the same row: `reserved` with
+    `call_reachability_unknown`.
+    """
+    endings = {}
+
+    row, _ = _call(recorder, Refused(400), task_id="answered")
+    endings["a verifiable refusal"] = (row["state"], row["note"])
+
+    client = recorder.meter(
+        Client(raises=ValueError("prompt could not be assembled")),
+        provider="azure",
+    )
+    with recorder.attributed(task_id="unsent", stage=STAGE_GENERATION):
+        with pytest.raises(ValueError):
+            client.chat.completions.create(model="a-deployment", messages=[])
+        recorder.abandon_call(client.last_call_id, note="request never built")
+    row = recorder.ledger.calls_for("unsent")[-1]
+    endings["known not to have left"] = (row["state"], row["note"])
+
+    class Dropped(Exception):
+        pass
+
+    row, _ = _call(recorder, Dropped("reset"), task_id="unknown")
+    endings["may or may not have arrived"] = (row["state"], row["note"])
+
+    client = recorder.meter(
+        Client(reply=_Bag(model="test-model")), provider="azure"
+    )
+    with recorder.attributed(task_id="silent", stage=STAGE_GENERATION):
+        client.chat.completions.create(model="a-deployment", messages=[])
+    row = recorder.ledger.calls_for("silent")[-1]
+    endings["answered without usage"] = (row["state"], row["note"])
+
+    row, _ = _call(recorder, TimeoutError("no reply"), task_id="timeout")
+    endings["timed out"] = (row["state"], row["note"])
+
+    assert len(set(endings.values())) == 5, endings
+    assert endings["answered without usage"][0] == STATE_SETTLED
+    assert REASON_USAGE_ABSENT in recorder.receipt_for(
+        "silent", BUCKET_PROBLEM_SOLVING
+    ).missing_reasons
+    assert endings["known not to have left"][0] == STATE_ABANDONED
+
+
+# ── what the note may contain ────────────────────────────────────────────
+
+
+def test_a_note_never_carries_the_providers_own_words(recorder):
+    """The ledger is committed to disk and shipped between shards.
+
+    Provider error messages routinely quote the request URL, and can quote a
+    header. A note built from `str(error)` would make the ledger a place
+    secrets end up, for the sake of a diagnostic string.
+    """
+    secret = "sk-live-0123456789abcdef"
+    endpoint = "https://an-account.openai.azure.com/openai/v1/"
+    message = f"401 from {endpoint} using {secret}"
+
+    for error in (
+        Refused(401, message),
+        TimeoutError(message),
+        RuntimeError(message),
+    ):
+        row, _ = _call(recorder, error, task_id=f"task-{type(error).__name__}")
+        recorded = json.dumps(dict(row))
+        assert secret not in recorded
+        assert endpoint not in recorded
+        assert "an-account" not in recorded
+
+
+def test_a_note_is_a_slug_whatever_the_exception_is_called(recorder):
+    hostile = type("Bad Name https://x.example/y", (Exception,), {})
+
+    row, _ = _call(recorder, hostile("boom"))
+
+    assert row["note"] == "provider_error_BadNamehttpsxexampley"
+    assert " " not in row["note"] and "/" not in row["note"]
+
+
+# ── the ledger's own contract ────────────────────────────────────────────
+
+
+def test_a_settled_call_cannot_be_refused_afterwards(ledger):
+    call_id = _reserve(ledger)
+    ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+
+    with pytest.raises(LedgerIntegrityError):
+        ledger.refuse(call_id, status=400)
+
+
+def test_a_refused_call_cannot_report_usage_afterwards(ledger):
+    call_id = _reserve(ledger)
+    ledger.refuse(call_id, status=400)
+
+    with pytest.raises(LedgerIntegrityError):
+        ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+
+
+def test_a_refused_call_cannot_then_be_called_one_that_never_left(ledger):
+    call_id = _reserve(ledger)
+    ledger.refuse(call_id, status=400)
+
+    with pytest.raises(LedgerIntegrityError):
+        ledger.abandon(call_id, note="never built")
+
+
+def test_an_abandoned_call_cannot_then_have_been_answered(ledger):
+    call_id = _reserve(ledger)
+    ledger.abandon(call_id, note="never built")
+
+    with pytest.raises(LedgerIntegrityError):
+        ledger.refuse(call_id, status=400)
+
+
+def test_refusing_a_call_that_was_never_reserved_is_an_error(ledger):
+    with pytest.raises(LedgerIntegrityError):
+        ledger.refuse("never-seen", status=400)
+
+
+def test_the_same_refusal_twice_is_the_same_row(ledger):
+    """Resume re-plays work; a repeat of the same fact is not a contradiction."""
+    call_id = _reserve(ledger)
+    ledger.refuse(call_id, status=429)
+    ledger.refuse(call_id, status=429)
+
+    rows = ledger.calls_for("task-a")
+    assert len(rows) == 1
+    assert rows[0]["missing_reasons"] == [REASON_CALL_REFUSED_UNPRICED]
+
+
+def test_two_different_refusals_for_one_call_are_a_contradiction(ledger):
+    call_id = _reserve(ledger)
+    ledger.refuse(call_id, status=429)
+
+    with pytest.raises(LedgerIntegrityError):
+        ledger.refuse(call_id, status=400)
+
+
+def test_an_open_question_may_only_be_annotated_while_it_is_open(ledger):
+    call_id = _reserve(ledger)
+    ledger.settle(call_id, usage=_usage(), resolved_model="test-model")
+
+    with pytest.raises(LedgerIntegrityError):
+        ledger.leave_unresolved(call_id, note="provider_timeout")
+
+
+def test_the_first_note_on_an_open_question_is_the_one_kept(ledger):
+    """The first failure is the one that explains the reservation."""
+    call_id = _reserve(ledger)
+    ledger.leave_unresolved(call_id, note="provider_timeout")
+    ledger.leave_unresolved(call_id, note="provider_error_Later")
+
+    assert ledger.calls_for("task-a")[0]["note"] == "provider_timeout"
+
+
+# ── resume, merge, and files written before this existed ─────────────────
+
+
+def test_a_merged_shard_does_not_put_the_false_reason_back(tmp_path, price_table):
+    """The local row knows the request left; the export knows how it ended.
+
+    Leaving `refused` out of the promotion would have restored, through the
+    merge path, the exact sentence this change retires.
+    """
+    export = tmp_path / "shard.jsonl"
+
+    with CostReceiptLedger(
+        tmp_path / "shard.sqlite3", run_id="run-1", price_table=price_table
+    ) as shard:
+        call_id = _reserve(shard)
+        shard.refuse(call_id, status=400)
+        shard.export_jsonl(export)
+
+    with CostReceiptLedger(
+        tmp_path / "merged.sqlite3", run_id="run-1", price_table=price_table
+    ) as merged:
+        _reserve(merged, call_id=call_id)
+        assert merged.receipt_for("task-a", BUCKET_PROBLEM_SOLVING).missing_reasons == (
+            REASON_CALL_REACHABILITY_UNKNOWN,
+        )
+
+        merged.import_jsonl(export)
+
+        receipt = merged.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+        assert merged.calls_for("task-a")[0]["state"] == STATE_REFUSED
+        assert receipt.missing_reasons == (REASON_CALL_REFUSED_UNPRICED,)
+        assert receipt.model_calls == 1
+
+
+def test_importing_the_same_refusal_twice_settles_nothing_twice(
+    tmp_path, price_table
+):
+    export = tmp_path / "shard.jsonl"
+
+    with CostReceiptLedger(
+        tmp_path / "shard.sqlite3", run_id="run-1", price_table=price_table
+    ) as shard:
+        call_id = _reserve(shard)
+        shard.refuse(call_id, status=400)
+        shard.export_jsonl(export)
+
+    with CostReceiptLedger(
+        tmp_path / "merged.sqlite3", run_id="run-1", price_table=price_table
+    ) as merged:
+        assert merged.import_jsonl(export) == 1
+        assert merged.import_jsonl(export) == 0
+        assert len(merged.calls_for("task-a")) == 1
+        assert merged.receipt_for(
+            "task-a", BUCKET_PROBLEM_SOLVING
+        ).model_calls == 1
+
+
+def test_a_refused_row_is_not_overwritten_by_one_claiming_usage(
+    tmp_path, price_table
+):
+    """Two records of one call that cannot both be true.
+
+    The token comparison that guards every other merge cannot see this: a
+    refused row holds no counts, so its silence would read as agreement.
+    """
+    export = tmp_path / "settled.jsonl"
+
+    with CostReceiptLedger(
+        tmp_path / "other.sqlite3", run_id="run-1", price_table=price_table
+    ) as other:
+        call_id = _reserve(other)
+        other.settle(call_id, usage=_usage(), resolved_model="test-model")
+        other.export_jsonl(export)
+
+    with CostReceiptLedger(
+        tmp_path / "local.sqlite3", run_id="run-1", price_table=price_table
+    ) as local:
+        _reserve(local, call_id=call_id)
+        local.refuse(call_id, status=400)
+
+        with pytest.raises(LedgerIntegrityError):
+            local.import_jsonl(export)
+
+        assert local.calls_for("task-a")[0]["state"] == STATE_REFUSED
+
+
+def test_a_ledger_written_before_refusals_existed_reads_exactly_as_it_did(
+    tmp_path, price_table
+):
+    """No migration, no rewrite, no new column: only a value that never occurs.
+
+    A resumed run reopens its predecessor's file. Every row in one written
+    yesterday is `reserved`, `settled` or `abandoned`, and each still means
+    what it meant.
+    """
+    path = tmp_path / "yesterday.sqlite3"
+    with CostReceiptLedger(path, run_id="run-1", price_table=price_table) as old:
+        settled = _reserve(old, call_id="call-settled")
+        old.settle(settled, usage=_usage(), resolved_model="test-model")
+        _reserve(old, call_id="call-open")
+        abandoned = _reserve(old, call_id="call-unsent")
+        old.abandon(abandoned, note="never built")
+        before = old.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+
+    with CostReceiptLedger(path, run_id="run-2", price_table=price_table) as today:
+        after = today.receipt_for("task-a", BUCKET_PROBLEM_SOLVING)
+        states = {row["call_id"]: row["state"] for row in today.calls_for("task-a")}
+
+    assert after.status == before.status == STATUS_PARTIAL
+    assert after.model_calls == before.model_calls == 2
+    assert after.missing_reasons == before.missing_reasons
+    assert REASON_CALL_REACHABILITY_UNKNOWN in after.missing_reasons
+    assert states == {
+        "call-settled": STATE_SETTLED,
+        "call-open": STATE_RESERVED,
+        "call-unsent": STATE_ABANDONED,
+    }
+
+
+def test_a_task_whose_only_call_was_refused_does_not_report_a_free_receipt(
+    recorder,
+):
+    """The whole constraint, on the smallest possible receipt.
+
+    One call, refused. `complete` here would be the ledger stating that the
+    task cost nothing, on the strength of a status code that says only that a
+    model did not run.
+    """
+    _, receipt = _call(recorder, Refused(429))
+
+    assert receipt.status != STATUS_COMPLETE
+    assert receipt.estimated_cost_usd is None
+
+
+# ── the two lists that must not drift ────────────────────────────────────
+
+
+def test_the_ledger_and_the_audio_reader_refuse_on_the_same_statuses():
+    """One judgement about the same eight statuses, made in two places.
+
+    The audio adapter decides whether a failed read costs the task one of its
+    allowed attempts; the ledger decides whether a failure is an answer or a
+    silence. Different questions, same evidence — and two copies of the
+    evidence would drift with nothing red.
+    """
+    from core.perception.audio import _UNBILLED_STATUS
+
+    assert set(_UNBILLED_STATUS) == set(UNBILLED_STATUSES)
+
+
+def test_every_reason_the_ledger_can_write_is_one_a_grade_may_carry():
+    """`grade.schema.json` closes its reason list with an `enum`.
+
+    A reason added in Python and not there is not a lenient mismatch: the grade
+    record fails validation at the end of a paid run, which is the worst moment
+    to discover a vocabulary is out of step.
+    """
+    import pathlib
+
+    schema = json.loads(
+        (pathlib.Path(__file__).resolve().parents[1] / "schemas" / "grade.schema.json")
+        .read_text(encoding="utf-8")
+    )
+    published = set(schema["$defs"]["costMissingReason"]["enum"])
+
+    assert set(MISSING_REASONS) == published
+
+
+# ── the classifier on its own ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("status", REFUSAL_STATUSES)
+def test_the_classifier_calls_a_refusal_a_refusal(status):
+    failure = classify_call_failure(Refused(status))
+
+    assert failure.kind == FAILURE_REFUSED
+    assert failure.status == status
+    assert failure.billing_is_known_absent
+
+
+@pytest.mark.parametrize(
+    "error, kind",
+    [
+        (Refused(500), FAILURE_ANSWERED),
+        (TimeoutError("x"), FAILURE_TIMEOUT),
+        (RuntimeError("x"), FAILURE_UNKNOWN),
+    ],
+)
+def test_the_classifier_claims_nothing_about_the_rest(error, kind):
+    failure = classify_call_failure(error)
+
+    assert failure.kind == kind
+    assert not failure.billing_is_known_absent
+
+
+def test_a_status_that_is_not_a_number_is_not_a_status():
+    class Odd(Exception):
+        status_code = "four hundred"
+
+    assert classify_call_failure(Odd()).status is None
+
+
+def test_a_boolean_is_not_a_status():
+    """`True` is an `int` in Python, and `int(True)` is 1, not a status."""
+
+    class Odd(Exception):
+        status_code = True
+
+    assert classify_call_failure(Odd()).status is None
+
+
+# ── the ledger verifier downstream ───────────────────────────────────────
+
+
+def test_the_verifier_does_not_call_a_refused_row_a_missing_reply():
+    """A false alarm here would bury the rows that are real, which is the same
+    mistake one layer up."""
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from verify_cost_ledger import check_all_calls_settled
+
+    finding = check_all_calls_settled(
+        [
+            {"call_id": "c1", "state": STATE_SETTLED},
+            {"call_id": "c2", "state": STATE_REFUSED},
+            {"call_id": "c3", "state": STATE_ABANDONED},
+        ]
+    )
+
+    assert finding.ok is True
+    assert finding.data["other_states"] == {STATE_ABANDONED: 1, STATE_REFUSED: 1}
+
+
+def test_the_verifier_still_surfaces_a_reply_that_never_came():
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from verify_cost_ledger import check_all_calls_settled
+
+    finding = check_all_calls_settled(
+        [
+            {"call_id": "c1", "state": STATE_SETTLED},
+            {"call_id": "c2", "state": STATE_RESERVED, "note": "provider_timeout"},
+        ]
+    )
+
+    assert finding.ok is False
+    assert finding.data["unsettled_count"] == 1
+    assert finding.data["unsettled"][0]["note"] == "provider_timeout"
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _usage():
+    from core.cost_receipts import CallUsage
+
+    return CallUsage(input_tokens=100_000, output_tokens=10_000)
+
+
+def _reserve(ledger, *, call_id="call-1", task_id="task-a"):
+    from core.cost_receipts import RETRY_NONE
+
+    return ledger.reserve(
+        call_id=call_id,
+        task_id=task_id,
+        stage=STAGE_GENERATION,
+        retry_kind=RETRY_NONE,
+        provider="azure",
+        requested_model="test-model",
+    )

--- a/src/lib/cost.ts
+++ b/src/lib/cost.ts
@@ -292,6 +292,11 @@ const MISSING_REASON_LABELS: Record<string, string> = {
   usage_partial: '사용량 일부 누락',
   price_missing: '가격표에 없는 모델',
   call_reachability_unknown: '호출 도달 여부 불명',
+  // Sits next to the line above on purpose: the two are the halves that used
+  // to be one row. A refusal *did* reach the API — the status code is the
+  // proof — so what is unknown is only whether it was billed. The cell already
+  // says 미확정; this says which of the two unknowns it is.
+  call_refused_unpriced: '호출이 거절되어 사용량 없음',
   runtime_cost_unattributable: '실행 환경 공유로 귀속 불가',
   runtime_cost_unpriced: '실행 환경 단가 없음',
   ledger_absent: '이 실행에 원장 없음',

--- a/tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md
+++ b/tasks/0828_friday/TASK_PER_TASK_COST_RECEIPTS.md
@@ -168,6 +168,7 @@ grade schema를 수정하지 않는다. 계약 변경이 필요하면 Project �
 | `usage_partial` | 사용량 일부 필드가 없다 |
 | `price_missing` | `(provider, model)`이 가격표에 없다 |
 | `call_reachability_unknown` | 요청이 사업자에 도달했는지 불명 (타임아웃 등) |
+| `call_refused_unpriced` | 사업자가 **답장으로** 거절했다. 모델이 안 돌아 사용량이 없다 |
 | `runtime_cost_unattributable` | 공유 실행 환경이라 작업 귀속 불가 |
 | `runtime_cost_unpriced` | 실행 환경 사용료 단가가 없다 |
 | `ledger_absent` | 이 실행에 원장이 없다 |
@@ -349,6 +350,17 @@ grade schema를 수정하지 않는다. 계약 변경이 필요하면 Project �
 닫아 둔 목록이고, 위 상황은 전부 기존 `price_missing`·`usage_partial`로 정확히
 읽힌다. 아홉 번째 값을 더하면 이미 게시된 채점 산출물이 스키마 검증에 걸린다.
 
+> **2026-09-08 정정 (341).** 위 문단의 마지막 문장은 **틀렸다.** 이 절이 다룬
+> 소리 가격 상황에 새 값이 필요 없었다는 판단은 그대로 옳지만, 근거로 든
+> "아홉 번째 값을 더하면 게시본이 깨진다"는 일반화는 성립하지 않는다. `enum`에
+> 값을 **더하는** 것은 넓히는 변경이고, 이미 게시된 산출물은 옛 8개만 담고
+> 있으므로 전부 그대로 통과한다. 실제로 재어 봤다 — 게시된 채점 기록
+> **95개 전부**가 아홉 번째 값이 들어간 스키마에 통과했고, 그중 실제로 쓰인
+> 값은 `price_missing`과 `call_reachability_unknown` 둘뿐이었다. 깨지는 것은
+> 값을 **빼거나 이름을 바꿀 때**다. 341이 아홉 번째 값
+> `call_refused_unpriced`를 추가한 근거이며, 자세한 내용은
+> `TASK_REFUSAL_IS_NOT_AN_UNREACHED_CALL.md`에 있다.
+
 ### 5.4 연결 지점
 
 | 경로 | 파일 | 단계 |
@@ -453,6 +465,9 @@ settle(call_id, usage=…, resolved_model=…)
   → 응답 후 사용량을 채우고 가격을 적용한다. 상태 settled.
 abandon(call_id, reason=…)
   → 호출이 나가지 않았음이 확실할 때. 상태 abandoned, 비용 0.
+refuse(call_id, status=…)
+  → 나갔고, 답장이 왔고, 그 답장이 거절일 때. 상태 refused.
+    호출로 세지만 금액은 주장하지 않는다. (341에서 추가)
 ```
 
 예약을 먼저 하는 이유: **호출은 나갔는데 응답을 못 받은 경우**를 잃지 않기 위해서다.
@@ -460,6 +475,12 @@ abandon(call_id, reason=…)
 영수증을 `partial`로 만든다. 이것이 "API 도달 여부 불명확"의 처리다.
 
 "호출 전 실패"(요청을 만들다 실패)는 `abandon`이며 비용에 영향이 없다.
+
+**사업자가 답장으로 거절한 경우**(`400`·`429` 등)는 위 둘 중 어느 것도 아니다.
+요청이 나갔으니 `abandon`이 아니고, 답장이 왔으니 도달 여부가 불명한 것도 아니다.
+`refuse`가 그 자리이며 `call_refused_unpriced`를 남긴다. 영수증은 여전히
+`partial`이다 — 모델이 안 돌았다는 것은 계정에 아무것도 안 물렸다는 사업자의
+진술이 아니기 때문이다(P1). 341 참조.
 
 ### 6.3 중복 정산 방지
 

--- a/tasks/0828_friday/TASK_REFUSAL_IS_NOT_AN_UNREACHED_CALL.md
+++ b/tasks/0828_friday/TASK_REFUSAL_IS_NOT_AN_UNREACHED_CALL.md
@@ -1,0 +1,306 @@
+# 거절은 닿지 않은 호출이 아니다 — 341 구현 기록
+
+## 0. 메타
+
+| | |
+|---|---|
+| 담당 | 세션 A |
+| 날짜 | 2026-09-08 |
+| 브랜치 | `fix/refusal-is-not-an-unreached-call` |
+| 넘겨받은 진단 | B, `tasks/rebuilding_grading_task/341-what-a-refused-call-costs.md` (미게시) |
+| 상위 명세 | `TASK_PER_TASK_COST_RECEIPTS.md` (같은 폴더) |
+| 모델 호출 | **한 번도 없음.** 아래 숫자는 전부 로컬 가짜 클라이언트에서 나왔다 |
+
+이 문서는 A가 쓴다. B의 미게시 문서는 인용만 하고 수정하지 않았다. B가 소유한
+`core/perception/audio.py`, `tests/test_a_broken_audio_reply_still_costs_what_it_cost.py`,
+`tasks/rebuilding_grading_task/**`, `CHANGELOG.md`는 **읽기만 했다.**
+
+---
+
+## 1. 한 줄 요약
+
+**돈이 틀린 게 아니라 이유가 틀렸다.** 사업자가 `400`으로 거절한 호출을 원장이
+"요청이 도달했는지 모름"으로 기록하고 있었다. 도달했는지는 그 호출에서 **유일하게
+확실한 것**이다 — 상태 코드가 왔다는 게 도달했다는 증거다. 금액은 원래도 비워
+두고 있었으므로 그대로 두고, 사실과 다른 그 한 줄만 고쳤다.
+
+---
+
+## 2. 원인 — 직접 확인한 것
+
+`core/cost_metering.py`의 `MeteredClient._around`가 이랬다.
+
+```python
+object.__setattr__(self, "last_call_id", call_id)
+response = call(**kwargs)          # ← try/except 가 없다
+recorder.ledger.settle(call_id, usage=..., resolved_model=...)
+```
+
+`call(**kwargs)`가 예외를 던지면 `settle`에 도달하지 못한다. 요청 **전에** 써 둔
+행이 `reserved`인 채로 남고, `build_receipt`는 그 행을
+`call_reachability_unknown`으로 읽는다. 이건 설계된 안전장치다 — 예외 하나에
+비용 기록이 통째로 사라지는 것보다 낫다. 다만 그 안전장치가 **모든** 실패에
+같은 문장을 붙이는 게 문제였다.
+
+B가 지적한 자리는 정확했다. B §2의 인용을 그대로 옮긴다.
+
+> `core/cost_receipts.py:1353`의 `abandon`은 자기 조건을 이렇게 못 박는다.
+> "Record that the call **never left** — so it never cost anything.
+> Only correct where the failure is known to **precede the request**."
+> `400`은 나갔다. 그러니 지금 문서대로라면 `abandon`도 쓸 수 없다.
+> **빈 칸은 여기다 — "닿았고, 답장 받았고, 확실히 안 물렸다"를 뜻하는 상태가 없다.**
+
+`core/perception/audio.py:246`은 이미 여덟 개 상태를 "과금 안 된 거절"로 알고
+그에 맞게 행동한다(작업의 시도 횟수를 되돌려준다). 원장만 그 사실을 못 듣고 있었다.
+
+### 2.1 돈을 잃는 문제는 아니다
+
+`reserved` 행은 금액을 **주장하지 않는다.** `$0`이라고 쓰는 것보다 훨씬 안전한
+쪽이다. 잘못된 건 사람이 읽고 **행동하는** 라벨이다. `call_reachability_unknown`은
+"물렸는지 가서 확인하라"는 신호인데, 속도 제한에 50번 튕기면 확실히 공짜인 50개의
+확인 요청이 만들어지고, 진짜로 모르는 것(5xx, 타임아웃)이 그 더미에 묻힌다.
+
+B §3의 판단과 같다. 아직 실제로 발생하지는 않았다 — 337 실행 로그에 429·5xx·
+타임아웃이 없었다.
+
+---
+
+## 3. B의 제안 중 채택하지 않은 부분과 그 이유
+
+B §5.2는 `abandon`의 조건을 넓혀 `ledger.abandon(call_id, note=f"provider_{status}")`로
+쓰자고 제안했다. **이건 쓰면 안 된다.**
+
+`build_receipt`는 `abandoned` 행을 **통째로 건너뛴다**(`build_receipt` 안의
+`if state == STATE_ABANDONED: continue`). 그러므로 `400`이 `abandoned`가 되면:
+
+- 그 작업의 `model_calls`가 **1 줄어든다** — 사업자 쪽에 기록이 남아 있는 호출을
+  두고 "호출이 없었다"고 말하게 된다
+- 그 작업의 유일한 호출이었다면 영수증이 **`complete` + `$0`**이 된다
+
+두 번째가 결정적이다. 이번 지시가 명시적으로 금지한 것이다:
+
+> HTTP 400이라는 이유만으로 비용 0/complete를 만들면 안 됩니다.
+
+그리고 상위 명세 P1과도 정면으로 충돌한다 — 진짜 `$0`은 "모델을 한 번도 부르지
+않은 규칙 기반 경로" 하나뿐이다. **모델이 안 돌았다는 것은 계정에 아무것도 안
+물렸다는 사업자의 진술이 아니다.**
+
+B도 이 지점을 열어 두었다(B §7): "`abandoned` 재사용이냐 새 상태 `refused`냐 …
+**둘 중 하나를 이 문서가 고르지 않는다**." A가 골랐다: **새 상태.**
+
+---
+
+## 4. 채택한 설계 — 세 번째 상태
+
+`STATE_REFUSED = "refused"` + `REASON_CALL_REFUSED_UNPRICED = "call_refused_unpriced"`.
+
+거절된 행은:
+
+| | |
+|---|---|
+| 호출로 **센다** | 요청이 실제로 나갔으니까 (`model_calls += 1`) |
+| 금액을 **주장하지 않는다** | 사업자가 사용량을 보고하지 않았으니까 |
+| 영수증을 **`partial`로 유지한다** | 안 물렸다는 근거가 없으니까 |
+
+**도달했다는 사실**(이제 확정)과 **과금 여부**(여전히 불명)를 갈라놓는 게 요점이다.
+`reserved`는 둘 다 모른다고 말하고, `abandoned`는 둘 다 안다고 말한다. 거절은 그
+중간이고, 그 중간을 표현할 자리가 없었던 것이다.
+
+### 4.1 다섯 가지 끝맺음
+
+지시가 요구한 구분을 그대로 옮긴 매핑이다.
+
+| 상황 | 상태 | 이유 | note |
+|---|---|---|---|
+| 확인 가능한 HTTP 거절 (8개 상태) | `refused` | `call_refused_unpriced` | `provider_refused_{status}` |
+| 보내기 전 실패 | `abandoned` | (없음, 영수증에서 제외) | 호출자가 준다 |
+| 전송 여부 불명 | `reserved` | `call_reachability_unknown` | `provider_error_<클래스명>` |
+| 응답은 있지만 usage 없음 | `settled` | `usage_absent` | — |
+| 타임아웃 | `reserved` | `call_reachability_unknown` | `provider_timeout` |
+
+여덟 개 상태는 `400, 401, 403, 404, 413, 415, 422, 429`이며 `audio.py`의
+`_UNBILLED_STATUS`와 같은 집합이다. 두 벌을 두지 않기 위해 테스트가 둘의 동일성을
+검사한다(B §5.3의 취지와 같되, B의 파일은 고치지 않고 A쪽에서 검사만 한다).
+
+**5xx는 일부러 건드리지 않았다.** 게이트웨이가 모델에 닿기 전에 끊은 것인지,
+모델이 돌고 나서 전달에 실패한 것인지 이 층에서는 알 수 없다. 그대로 `reserved`이며
+`provider_status_500` 같은 note만 새로 붙는다. B의 경계 조건과 같다: "`[broke]`(5xx)는
+그대로 통과해야 하고, 통과하지 않으면 제안이 너무 넓게 잡은 것이다."
+
+### 4.2 note에 사업자 문구를 넣지 않는다
+
+note는 실패의 **모양**으로만 만든다 — 상태 숫자, 고정된 낱말, 예외 클래스 이름을
+영숫자만 남겨 64자로 자른 것. `str(error)`는 절대 쓰지 않는다. 사업자 오류 메시지는
+요청 URL을 그대로 인용하는 일이 흔하고 헤더를 인용할 수도 있는데, 원장은 디스크에
+커밋되고 샤드 사이로 오간다. 진단 문자열 하나 얻자고 원장을 비밀이 흘러드는
+자리로 만들 수는 없다.
+
+측정으로 확인했다(§6의 `test_a_note_never_carries_the_providers_own_words`):
+URL과 키 모양 문자열을 담은 메시지로 `400`·타임아웃·일반 예외를 각각 일으킨 뒤
+기록된 행 전체를 JSON으로 덤프해 둘 중 어느 것도 남지 않는 것을 확인한다.
+
+### 4.3 마이그레이션이 필요 없다
+
+`cost_calls.state`는 `TEXT NOT NULL`이고 CHECK 제약이 없다. 새 값은 지금까지
+나타난 적 없는 문자열일 뿐이다. 341 이전에 쓰인 원장 파일은 전부
+`reserved`/`settled`/`abandoned`만 담고 있고, 각각 예전과 같은 뜻으로 읽힌다.
+이것도 테스트로 고정했다.
+
+---
+
+## 5. 바꾼 파일
+
+| 파일 | 무엇을 | 채점기 지문에 들어가나 |
+|---|---|---|
+| `core/cost_metering.py` | `try/except` 추가, `classify_call_failure`, `_record_failed_call` | **예** |
+| `core/cost_receipts.py` | `STATE_REFUSED`, `REASON_CALL_REFUSED_UNPRICED`, `refuse()`, `leave_unresolved()`, 병합·모순 가드 | **예** |
+| `schemas/grade.schema.json` | `costMissingReason` enum에 값 1개 추가 | **예** |
+| `scripts/verify_cost_ledger.py` | `reserved`만 미정산으로 보고하도록 좁힘 | 아니오 |
+| `tests/test_a_refusal_is_not_an_unreached_call.py` | 신규 (69개) | 아니오 |
+| `TASK_PER_TASK_COST_RECEIPTS.md` | §3.4 행 1개, §5.3 정정 주석, §6.2 `refuse` 추가 | 아니오 |
+
+`_record_failed_call`은 원장 쓰기가 실패해도 **사업자의 원래 예외를 가리지 않는다.**
+기록에 실패하면 예약이 그대로 남는데, 그게 어차피 보수적인 해석이다.
+
+`verify_cost_ledger.py`를 같이 고친 이유: 기존 코드가 `state != settled`를 전부
+"보냈는데 답장 기록이 없다"로 보고했다. 그대로 두면 거절 행마다 가짜 경보가
+뜨고 **진짜 미정산 행이 그 안에 묻힌다** — 원장 한 층 위에서 똑같은 실수를 하는
+셈이고, `call_refused_unpriced`가 막으려는 게 바로 그거다.
+
+---
+
+## 6. 검증 — 실제로 돌린 것
+
+### 6.1 새 테스트가 고치기 **전에는 실패하는가**
+
+양쪽으로 초록이면 아무것도 증명하지 못하므로, `try/except`만 원래대로 되돌려
+같은 파일을 돌렸다.
+
+| | |
+|---|---|
+| 고친 뒤 | **69 passed** |
+| `try/except`를 되돌린 뒤 | **21 failed, 48 passed** |
+
+실패한 21개에 여덟 개 상태 전부가 들어 있다. (되돌린 파일은 즉시 복원했고
+`git diff --stat`으로 확인했다.)
+
+### 6.2 회귀
+
+| 묶음 | 결과 |
+|---|---|
+| cost·receipt·audio·perception·meter 관련 37개 파일 | **1,377 passed / 2 skipped** (변경 전과 동일) |
+| 위 + 신규 파일 | **1,446 passed / 2 skipped** |
+| 백엔드 전체 (신규 파일 제외, 소스 변경 적용) | **8,834 passed / 15 skipped / 45 deselected / 0 failed** |
+| 게시된 채점 기록 95개를 **새 스키마로** 검증 | **95 pass / 0 fail** |
+
+### 6.3 B의 "1,671개 중 1개"를 직접 확인했다
+
+지시대로 B의 수치를 그대로 믿지 않고 재어 봤다.
+
+**결론: 실질적으로 맞다.** B의 미게시 테스트 파일(14개)을 A 트리에 임시로 복사해
+돌린 결과 **정확히 1개**가 실패하고, 그게 B가 지목한 바로 그 줄이다.
+
+```
+FAILED test_a_refused_request_is_recorded_as_unknown_not_as_free[refused]
+  assert rows[0]["state"] == "reserved"
+  AssertionError: assert 'refused' == 'reserved'
+```
+
+같은 테스트의 `[broke]`(5xx) 갈래는 **통과했다** — B가 제시한 경계 조건이 실제로
+지켜졌다는 뜻이다. (복사본은 즉시 삭제했고 `git status`로 확인했다.)
+
+**다만 분모 1,671은 그대로 재현되지 않는다.** B가 정확한 명령을 적어 두지 않았고,
+A의 37개 파일 선택은 1,379개, `-k "cost or receipt or audio or perception or meter"`는
+1,662개(B의 미게시 파일을 더하면 1,676개)를 모은다. 분모는 선택 방식에 따라
+달라지는 값이고, 의미 있는 숫자는 §6.2의 전체 스위트 쪽이다. **분자 1은 맞다.**
+
+---
+
+## 7. 하류 영향 — 기록해 둔다
+
+### 7.1 채점기 지문이 움직인다
+
+`core/**`와 `schemas/grade.schema.json`이 지문 입력이므로 이 변경은 지문을 바꾼다.
+저장소 자신의 검사기로 확인했다.
+
+| | |
+|---|---|
+| 변경 전 (`origin/main` `0167131`) | `50f6f8bbc7d50b3d8ea8d733f91b673890c2aff4449dbbf8f8688d78b3132f15` |
+| 변경 후 | `ee1ca0b0948840f01786ad8f9340476600073c82843c1abcaf8302580391ec31` |
+
+`check_grader_hash_freeze.py`는 **PASS**다 — 지금 진행 중인 유료 채점 실행이
+없다(비완료 `grade-run` 0건). 다만 검사기가 스스로 남기는 경고가 그대로 적용된다:
+
+> This diff does move the grader source hash. … it means the next paid run has to
+> be preceded by a fresh smoke at the new fingerprint.
+
+**다음 유료 채점 실행 전에 `ee1ca0b0…`에서 새 스모크가 필요하다.** 그리고 샤드가
+떠 있는 동안에는 이 변경을 병합하면 안 된다.
+
+`scripts/`는 지문 입력이 아니므로 `verify_cost_ledger.py` 수정은 지문에 영향이 없다.
+
+### 7.2 B의 미게시 테스트 한 줄
+
+B의 `test_a_broken_audio_reply_still_costs_what_it_cost.py`가 `[refused]` 갈래에서
+`state == "reserved"`를 못 박아 두었다. 이 변경이 `"refused"`로 바꾼다. B의 문서도
+같은 결론을 적어 두었다("**그 한 줄은 고쳐야 하는 게 맞다** — 그게 이 변경의
+내용이니까"). **A는 B의 파일을 고치지 않았다.** B가 게시할 때 그 한 줄을 함께
+고쳐야 하며, 두 변경이 어느 순서로 들어가든 한쪽은 상대를 기다린다.
+
+또한 B의 §5 제안 diff는 `state == "abandoned"`를 기대하는데, A는 `"refused"`를
+쓴다. 이유는 §3이다.
+
+### 7.3 명세 문서의 한 문장이 틀렸다
+
+`TASK_PER_TASK_COST_RECEIPTS.md` §5.3이 이렇게 적어 두었다.
+
+> 아홉 번째 값을 더하면 이미 게시된 채점 산출물이 스키마 검증에 걸린다.
+
+**측정해 보니 아니다.** `enum`에 값을 더하는 것은 **넓히는** 변경이고, 게시본은
+옛 8개만 담고 있으므로 전부 통과한다. 게시된 채점 기록 95개 전부가 새 스키마에
+통과했고, 실제로 쓰인 값은 `price_missing`과 `call_reachability_unknown` 둘뿐이었다.
+깨지는 것은 값을 **빼거나 이름을 바꿀 때**다.
+
+원문은 지우지 않고 날짜 붙은 정정 주석을 아래에 덧붙였다. 그 절이 다룬 소리 가격
+상황에 새 값이 필요 없었다는 판단 자체는 그대로 옳다.
+
+### 7.4 새로 막은 구멍
+
+`MISSING_REASONS`(파이썬)와 `grade.schema.json`의 닫힌 enum이 **어긋나도 아무것도
+빨개지지 않았다.** 유료 실행이 끝나는 시점에 채점 기록이 검증에 걸려서야 드러날
+종류의 구멍이다. 두 목록의 동일성을 검사하는 테스트를 넣었다.
+
+### 7.5 스키마 버전은 올리지 않았다
+
+`schema_version` enum은 `["1.0" … "1.4"]` 그대로다. 값을 더하는 변경은 옛 기록의
+유효성을 바꾸지 않으므로 새 버전을 요구하지 않는다. 다만 이 판단은
+`1.4`를 선언한 기록이 이제 두 가지 스키마(값 8개짜리와 9개짜리) 중 어느 쪽으로도
+검증된다는 뜻이기도 하다. 값을 **빼는** 변경이 나오면 그때는 버전을 올려야 한다.
+
+---
+
+## 8. 이 문서가 하지 않은 것 / 승인 없이는 못 하는 것
+
+| | |
+|---|---|
+| 모델 호출 | 한 번도 안 했다 |
+| B 소유 파일 수정 | 안 했다. `audio.py`·B의 테스트·`tasks/rebuilding_grading_task/**`·`CHANGELOG.md` 전부 읽기만 |
+| 가격표 수정 | 안 했다. 추정 요율도 넣지 않았다 |
+| 실행된 사전등록·과거 산출물 덮어쓰기 | 안 했다. §5.3은 원문을 두고 주석만 덧붙였다 |
+| 5xx·타임아웃·SDK 내부 재시도 | 안 고쳤다. B §7의 한계가 그대로 남는다 |
+| `429`를 여덟 개에 계속 둘 것인가 | 이 변경은 `audio.py`의 판단을 그대로 따른다. 재시도 판단과 과금 판단이 같은 목록을 봐야 하는지는 별개 질문이고 여기서 정하지 않았다 |
+| **push · PR 생성 · 병합 · main 변경** | **안 했다. 별도 승인이 필요하다** |
+| **새 지문에서의 스모크 실행** | **유료 경로다. 별도 승인이 필요하다** |
+
+---
+
+## 9. 이어받는 사람에게
+
+로컬 브랜치 `fix/refusal-is-not-an-unreached-call`에 커밋까지 되어 있고 push는
+안 했다. 열려 있는 PR은 #457 하나뿐이며 그 위에 쌓지 않았다.
+
+병합 전에 확인할 것 두 가지:
+
+1. **유료 채점 샤드가 떠 있지 않은지** — 떠 있으면 병합하면 안 된다.
+   `check_grader_hash_freeze.py`가 그 판단을 대신해 준다
+2. **B의 `[refused]` 한 줄** — 두 변경 중 늦게 들어가는 쪽이 상대를 기다린다


### PR DESCRIPTION
# fix(cost): a refusal is an answer, so stop filing it as an unreached call

Closes the 341 defect handed over from 340.

## What was wrong

`MeteredClient` writes the ledger row *before* the request and settles it after
the reply. There was no `except` between the two, so any raising call left its
row in `reserved` — the state whose whole meaning is *"a request went out and we
never learned what became of it"*, reported to a reader as
`call_reachability_unknown`.

For a provider refusal that sentence is false in the one way that matters. A
`400` is not a silence; it is the API replying, and replying is the proof the
request arrived. `core/perception/audio.py` already knows this about eight
statuses (`400, 401, 403, 404, 413, 415, 422, 429`) and acts on it — it hands
the task's attempt back — but the ledger was never told, so the same eight came
out filed under a doubt about whether the request had ever landed.

**The amount was never wrong.** `reserved` claims nothing, which is far safer
than claiming `$0`. What was wrong is the label, and the label is the part a
person acts on: `call_reachability_unknown` means *go and find out whether this
was billed*. Fifty rate-limit bounces produce fifty of those, all certainly
free, and the genuinely unknown ones — a `5xx`, a timeout — disappear into the
pile. Nobody has been billed wrongly; 337's run log had no 429, 5xx or timeout.

## Why a third state, and not a reuse of `abandoned`

The cheap fix is `ledger.abandon(call_id, note=f"provider_{status}")`. It is
wrong, and measurably so: `build_receipt` skips abandoned rows **wholesale**, so

- the task's `model_calls` drops by one — saying no call was made, of a call the
  provider has a record of; and
- a task whose only call was refused gets a **`complete` receipt of `$0`**.

Knowing the model did not run is not the provider's word that the account was
untouched, and the spec's P1 reserves a real `$0` for one case only: a rule-based
path that never called a model.

So `refused` is a third state. A refused row is **counted** as a call, **claims
no amount**, and holds the receipt at **`partial`** — separating the
*reachability* fact, now settled, from the *billing* fact, still unknown. Only
the false reason changes.

## Five endings, five records

| Ending | State | Reason | Note |
|---|---|---|---|
| verifiable HTTP refusal | `refused` | `call_refused_unpriced` | `provider_refused_{status}` |
| failure before sending | `abandoned` | *(excluded from the receipt)* | caller's |
| unknown whether sent | `reserved` | `call_reachability_unknown` | `provider_error_<Class>` |
| answered without usage | `settled` | `usage_absent` | — |
| timeout | `reserved` | `call_reachability_unknown` | `provider_timeout` |

Before this, three of those five were the same row.

**`5xx` and timeouts keep their reservations untouched.** This layer cannot tell
a gateway that never reached the model from a model that ran and then failed to
deliver, and an unsettled reservation is what "cannot tell" looks like. The
change deliberately reaches no further than the eight statuses the audio adapter
already treats as unbilled, and a test holds the two lists together so they
cannot drift.

## Notes never carry the provider's own words

A note is built from the failure's *shape* alone — a status number, a fixed
word, a slugged exception class name capped at 64 characters — and never from
`str(error)`, which routinely quotes the request URL and can quote a header. The
ledger is committed to disk and shipped between shards; it is not a place for a
diagnostic string to drop a secret. A test drives a `400`, a timeout and a plain
exception whose messages each carry an endpoint and a key-shaped string, then
dumps the whole stored row and asserts neither survives.

## Also in this change

- **`verify_cost_ledger` narrowed to flag only `reserved`.** It flagged
  everything that was not `settled`, so every refused row would raise a false
  *"sent but never recorded a reply"* and bury the rows that are — the same
  mistake one layer up that this change exists to stop the ledger making.
- **`schemas/grade.schema.json` gains the ninth reason.** The spec warned that a
  ninth value would break published grade records. Measured: it does not. Adding
  to an `enum` *widens* it, published records carry only the old eight, and all
  **95** still validate. A dated correction now sits under the original claim;
  the original is left in place.
- **A test now holds `MISSING_REASONS` and that enum together.** Nothing did.
  A reason added in Python and not in the schema would have surfaced as a grade
  record failing validation at the end of a paid run.
- **No migration.** `cost_calls.state` is `TEXT NOT NULL` with no CHECK
  constraint; a ledger written before this reads exactly as it did, which is
  pinned by a test.

## Verification

| | |
|---|---|
| New tests | **69 passed** |
| Same file against the pre-fix code | **21 failed / 48 passed** — including all eight statuses |
| Related selection (37 files) | **1,377 passed / 2 skipped** — unchanged |
| Related selection + new file | **1,446 passed / 2 skipped** |
| Full backend suite (before merging `main`) | **8,906 passed / 12 skipped / 45 deselected / 0 failed** |
| Full backend suite (after merging `main`) | **9,093 passed / 12 skipped / 45 deselected / 0 failed** |
| 95 published grade records vs the new schema | **95 pass / 0 fail** |

Regressions specifically covered: double settlement in both directions,
idempotent and contradictory re-refusal, resume and shard merge via
`export_jsonl`/`import_jsonl` (a merged refused row promotes a local
reservation; a settled row is never demoted; a refused-vs-settled clash raises),
compatibility with a ledger written before this existed, and non-storage of
sensitive data.

No model was called at any point. Every client in the new tests is local.

## Grader fingerprint

`core/**` and `schemas/grade.schema.json` are fingerprint inputs, so this moves
the grader source hash. The hash is per-config; both values below are for
`grading_configs/gold_audio_repeat_v2_sol_max.yaml`, computed the same way in
both trees:

| | |
|---|---|
| before (`origin/main` @ `3f66db5`) | `50f6f8bbc7d50b3d8ea8d733f91b673890c2aff4449dbbf8f8688d78b3132f15` |
| after | `ee1ca0b0948840f01786ad8f9340476600073c82843c1abcaf8302580391ec31` |

That "before" is measured on `origin/main` **after** #457 landed, and it is
byte-identical to the value recorded before it — so #457 did not move the
fingerprint, and this branch is the only open change that does.

`check_grader_hash_freeze.py` **passes** — `PASS: no paid grade run in flight`,
zero live `grade-run` workflow runs. Its own standing warning applies: **the
next paid run has to be preceded by a fresh smoke at the new fingerprint.** Do
not merge this while shards are grading.

The check names exactly three of the nine changed paths as fingerprint inputs —
`core/cost_metering.py`, `core/cost_receipts.py`, `schemas/grade.schema.json`.
`batch-runner/scripts/` and `src/` are not inputs, so neither the
`verify_cost_ledger` change nor the dashboard label in `5b575cb` moves the hash
any further.

## The consumer path, checked rather than assumed

The 95 published grade records validating against the widened `enum` says the
old records still parse. It says nothing about what the new value *does* once it
reaches a reader, and one thing it did was wrong.

`missing_reasons` is one list kept in **three** places — `MISSING_REASONS` in
`core/cost_receipts.py`, `$defs.costMissingReason.enum` in the schema, and
`MISSING_REASON_LABELS` in `src/lib/cost.ts`. `580db1f` moved two of them. The
third turned the ninth reason into a bare `call_refused_unpriced` sitting
between two Korean labels on the page. Fixed in **`5b575cb`**, one label line;
the repository's own test (`cost-receipt.test.mjs`, *"every reason the schema
allows has a Korean label"*) went red on `580db1f` and is green again.

That is the only contract this broke. Everything else was traced with real
receipts built by the real ledger — a task whose only call is refused with `400`,
and a task with one good call plus a `429` — and pushed through every layer:

| Layer | refused-only task |
|---|---|
| `build_receipt` | `partial`, `known=0.0` placeholder, `model_calls=1` |
| `project_cost_receipt` (py) | `known=None` — the zero is dropped |
| `projectCostReceipt` (js) | `known=null`, `model_calls=1` — agrees with Python |
| `summarize_cost_receipts` / `summarizeCostReceipts` | **same seven values** from both summarisers |
| `costCell` | `unpriced` · **미확정** · `isAmount=false` |
| `failedTaskCostCell` | **미확정**, titled *"$0이 아니라, 얼마가 들었는지 알 수 없다는 뜻입니다"* |

So neither failure mode occurs. A refused call is **not read as $0** — the
zero-drop in `_measured_amount`/`measuredAmount` nulls a zero on any
non-`complete` status, which is what makes a refused-only receipt safe by
construction rather than by luck. And a refused call is **not dropped**:
`model_calls` counts it, which is precisely what reusing `abandoned` would have
broken.

`step6_report.py` prints the raw slug in the Markdown report and
`missingReasonLabel` falls back to the raw slug on the page, both by design:
an untranslated slug is ugly enough to get fixed, where a dropped one is not.

**A third reader, and the one line holding it up.** The Markdown report reads
`known_cost_usd` off the run summary directly — it never passes through the JS
projector, so none of the above covers it. The run summary is *not* subject to
the zero-drop: `build_cost_summaries` sums over an empty set and stores a real
`0.0`. What saves the row is `step6_report.py:935`, `known_cost_usd if
measured_tasks else None`, added earlier for `price_missing` after the exp026c
smoke printed `$0.0000` beside *"Not priced"*. Measured on a run where every
task was refused:

| | |
|---|---|
| summary `known_cost_usd` / `measured_tasks` | `0.0` / `0` |
| `\| Recorded so far \|` **as printed** | **no record** |
| the same row with the guard removed | `$0.0000` |
| `\| Failed tasks \|` | `1 (no record)` |
| `\| Not priced \|` | `call_refused_unpriced` |

So the refused case is safe here, but it is safe *because of a line written for
a different reason*, and that line is now load-bearing for two reasons instead
of one. Deciding this row off the amount rather than off `measured_tasks` would
re-break it silently.

### The other reader: `data/grades/**` → `aggregate-grades.mjs`

Everything above travels through `report_data.json`. It is not the only route a
receipt takes: **42 published 1.4 grade files** already carry `grading_cost`,
and they reach the page through `processGradesFile`, a different reader with its
own version gate and its own derived run summary. Checked separately, because
"the report path is fine" says nothing about this one.

Same method — receipts built by the real ledger, in the *grading* bucket, spliced
into a real published 1.4 file with its task id and `expected_task_count` left
exactly as published (both are pinned, and the reader throws if they disagree —
it did, on the first attempt). Two shapes: grading answered while perception was
refused with `429`, and everything refused with `400`.

| | `task-perception-refused` | `task-all-refused` |
|---|---|---|
| `processGradesFile` | accepted | accepted |
| `tasks[0].grading_cost` | `partial`, `known=1.2`, calls **2** | `partial`, `known=null`, calls **1** |
| refused component | `known=null` → **미확정** | `known=null` → **미확정** |
| reason reaches the page | yes | yes |

One thing worth writing down, since it looks like a defect and is not. The
**derived run summary** (`summary_v1.grading_cost` / `cost_summary.grading_cost`)
sums component amounts into a bucket initialised at `0`, so a component whose
amount is `null` leaves a `partial` bucket reading `known_cost_usd: 0`.

It is **not** something this change introduces, and it is not rendered:

- Driving the same file with `usage_absent` — a reason that has existed as long
  as receipts have — produces a **byte-identical** shape at every layer. The new
  reason behaves exactly like the old ones.
- `receiptComponents` and `componentAmountText` have **exactly one call site
  each** (`ExperimentDetail.tsx:1488` and `:1508`), both on the *per-task*
  receipt, which is projected. Nothing in `src/` reads `.components` off a run
  summary at all.

So it is a latent shape, pre-dating this work, currently unread — left alone
here on purpose. Fixing it would mean touching the shared summariser to serve no
present reader, and this change is meant to reach exactly as far as the defect
it names.

Frontend verification: **487 passed / 1 skipped / 0 failed** (488 across 37
files), `tsc && vite build` clean. The headless-browser leg
(`test:cost-browser:dist`) could not run on the machine this was written on —
Playwright's chromium is missing `libnspr4.so` there — so it is unrun locally
and runs in CI, not verified twice and reported once.

After merging `origin/main` (through #457 and #459): **681 passed** across every
cost-related backend test file, and the fingerprint below is byte-identical to
what it was before the merge.

## Coordination

The 340 handover's test file (unpublished) pins `state == "reserved"` for the
`[refused]` branch. This change makes it `"refused"` — exactly one assertion, and
the handover document says the same: *"that one line does need fixing — that is
what this change is."* Verified directly by running that file against this
branch: **1 failed / 13 passed**, and the `[broke]` (5xx) branch still passes,
which was the stated boundary condition. That file is not edited here; whichever
of the two lands second updates the line.

The handover's proposed diff expects `state == "abandoned"`. This branch writes
`"refused"` instead, for the reason in the second section above.

**Common contract changed here, for whoever reads this next.** Three things in
the shared cost path move, all in `580db1f` unless noted:

1. `STATE_REFUSED = "refused"` is a new value of `cost_calls.state`, alongside
   `reserved` / `settled` / `abandoned`. Anything that branches on that column
   has to decide about it. **Counted, not assumed:** across `*.py`, `*.mjs`,
   `*.ts`, `*.tsx`, outside `core/` and the test trees, exactly **two** files
   compare against a state value — `core/cost_receipts.py` (the producer, 27
   sites) and `scripts/verify_cost_ledger.py` (6 sites), which is narrowed here.
   Nothing in `src/` or `scripts/*.mjs` reads the column at all; the receipt is
   the only thing that crosses that boundary. One false positive to save the
   next person the search: `measure_audio_grading_accuracy.py` has a `settled`,
   but it counts audio claims that reached a majority vote — same word,
   unrelated to the ledger, and correctly left alone.
2. `REASON_CALL_REFUSED_UNPRICED = "call_refused_unpriced"` is a ninth
   `missing_reasons` value. It lives in three copies — Python, schema,
   dashboard — and all three move (the third in **`5b575cb`**). A tenth reason
   added anywhere has to move all three, and there is now a test that says so.
3. Refused rows are **counted in `model_calls` and claim no amount**, which
   holds the receipt at `partial`. Reusing `abandoned` instead would have
   dropped the call from the count and produced a `complete` `$0` receipt for a
   refused-only task; the measurement is in the second section.

No file owned by the audio work is touched here: not
`core/perception/audio.py`, not the audio tests, not
`tasks/rebuilding_grading_task`, not `CHANGELOG.md`. The eight statuses are a
second copy of the adapter's `_UNBILLED_STATUS`, deliberately not imported —
the ledger and the reader ask different questions of the same evidence — and
`test_the_ledger_and_the_audio_reader_refuse_on_the_same_statuses` asserts the
two sets are equal, so changing one without the other goes red.

Full write-up: `tasks/0828_friday/TASK_REFUSAL_IS_NOT_AN_UNREACHED_CALL.md`
