### PR TITLE
fix(codex): an unpinned fingerprint must refuse the send, not narrate it

### DIFF
--- a/.github/workflows/codex-foundry-connection-diagnostic.yml
+++ b/.github/workflows/codex-foundry-connection-diagnostic.yml
@@ -97,9 +97,16 @@ jobs:
       # it is a sha256, it changes if the endpoint secret is ever repointed,
       # and it is safe to write down.
       #
-      # Empty until the first run records one. While empty the check below says
-      # so out loud instead of passing quietly.
-      EXPECTED_HOST_FINGERPRINT: ""
+      # Recorded by run 34317316416 (`send_request: false`, nothing sent) and
+      # kept only because it was *corroborated* rather than observed: the same
+      # value falls out of sha256 over the account name this repository already
+      # pins in a variable, on the `.services.ai.azure.com` suffix. That
+      # derivation needs no network and no request. A measured host that had
+      # not matched it would not belong here whatever the run printed.
+      #
+      # The variable is deliberately not named here, let alone read: naming it
+      # is one edit away from requesting it, and requesting it prints it.
+      EXPECTED_HOST_FINGERPRINT: "sha256:69057d59166a82e3"
 
     steps:
       - name: Check out
@@ -185,14 +192,27 @@ jobs:
             --out /tmp/codex-foundry-plan.json
 
       - name: Confirm the plan is about the resource this job is pinned to
+        id: pinned
+        env:
+          SEND_REQUEST: ${{ inputs.send_request }}
         run: |
           set -euo pipefail
           MEASURED="$(python3 -c "import json;print(json.load(open('/tmp/codex-foundry-plan.json'))['settings']['endpoint_host_fingerprint'])")"
           echo "measured host fingerprint: ${MEASURED}"
           if [ -z "${EXPECTED_HOST_FINGERPRINT}" ]; then
+            if [ "${SEND_REQUEST}" = "true" ]; then
+              echo "FATAL: EXPECTED_HOST_FINGERPRINT is empty and this run was"
+              echo "       asked to send. Nothing would have been compared, so"
+              echo "       the request would go to whatever the endpoint secret"
+              echo "       currently points at, and be paid for there."
+              echo "       Refusing. Pin the value printed above first."
+              exit 1
+            fi
             echo "NOTE: EXPECTED_HOST_FINGERPRINT is empty in this workflow, so"
-            echo "      nothing was checked. Pin the value printed above and"
-            echo "      this becomes a real gate."
+            echo "      nothing was checked. Tolerated here only because nothing"
+            echo "      is being sent — a dry run is how the value is discovered"
+            echo "      in the first place. The same state with send_request on"
+            echo "      is the FATAL above."
             exit 0
           fi
           if [ "${MEASURED}" != "${EXPECTED_HOST_FINGERPRINT}" ]; then
@@ -203,12 +223,22 @@ jobs:
             exit 1
           fi
           echo "resource=pinned"
+          # Written on this path only. Every other way out of this step leaves
+          # it unset, which is what the send is gated on below — so a future
+          # edit that softens one of the refusals above into an `exit 0` still
+          # does not buy itself a request.
+          echo "confirmed=yes" >> "${GITHUB_OUTPUT}"
 
       # The one request. Skipped entirely unless it was asked for, so the
       # difference between a free run and a paid one is a deliberate input and
       # not a forgotten flag.
+      #
+      # Two conditions, not one. `inputs.send_request` is the person's
+      # intention; `steps.pinned.outputs.confirmed` is the machine's evidence
+      # that the intention is about the right resource. Intention alone used to
+      # be enough, which meant an empty fingerprint bought a paid call.
       - name: Send the one turn
-        if: ${{ inputs.send_request }}
+        if: ${{ inputs.send_request && steps.pinned.outputs.confirmed == 'yes' }}
         working-directory: batch-runner
         env:
           AZURE_AI_ROUTE_PROFILE: direct-v1

--- a/batch-runner/tests/test_codex_foundry_connection_probe.py
+++ b/batch-runner/tests/test_codex_foundry_connection_probe.py
@@ -694,7 +694,7 @@ def test_sending_is_off_unless_it_is_asked_for():
     triggers = parsed.get("on", parsed.get(True))
     assert triggers["workflow_dispatch"]["inputs"]["send_request"]["default"] is False
     send = _steps()["Send the one turn"]
-    assert send["if"] == "${{ inputs.send_request }}"
+    assert "inputs.send_request" in send["if"]
     assert "--send-request" in send["run"]
 
 
@@ -739,6 +739,151 @@ def test_the_run_is_pinned_to_one_resource_by_a_hash_that_is_safe_to_print():
     check = _steps()["Confirm the plan is about the resource this job is pinned to"]
     assert "endpoint_host_fingerprint" in check["run"]
     assert "exit 1" in check["run"]
+
+
+# ── That the pin is a gate and not a note ───────────────────────────────────
+#
+# The test above passed for as long as the fingerprint was empty, because it
+# asks whether the key exists and whether the word `exit 1` occurs somewhere
+# in the step. Both were true of a step that let an unpinned send straight
+# through: the empty branch printed a NOTE and `exit 0`, and the only thing
+# standing between that and a paid request was an input a person had already
+# said yes to.
+#
+# So these run the step's own script instead of reading it. The four states
+# that matter are (empty, mismatch, match) x (dry, send), and the shell is the
+# only thing that knows which of them stops.
+
+CONFIRM_STEP = "Confirm the plan is about the resource this job is pinned to"
+
+
+def _run_confirm(tmp_path, *, expected: str, measured: str, send_request: str):
+    """Execute the confirm step's shell against a planted plan file.
+
+    The plan path is the one substitution: everything else — the branches, the
+    comparison, the exit codes, the line that writes the go-ahead — is the
+    workflow's own text, so an edit to the workflow is what these assert on.
+    """
+    script = _steps()[CONFIRM_STEP]["run"].replace(
+        "/tmp/codex-foundry-plan.json", str(tmp_path / "plan.json")
+    )
+    (tmp_path / "plan.json").write_text(
+        json.dumps({"settings": {"endpoint_host_fingerprint": measured}}),
+        encoding="utf-8",
+    )
+    github_output = tmp_path / "github_output"
+    github_output.write_text("", encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        env={
+            "PATH": os.environ["PATH"],
+            "EXPECTED_HOST_FINGERPRINT": expected,
+            "SEND_REQUEST": send_request,
+            "GITHUB_OUTPUT": str(github_output),
+        },
+        capture_output=True,
+        text=True,
+    )
+    return proc, github_output.read_text(encoding="utf-8")
+
+
+PINNED = "sha256:69057d59166a82e3"
+
+
+def test_the_fingerprint_is_actually_pinned_and_shaped_like_a_fingerprint():
+    """An empty value is the state this whole section exists to forbid."""
+    _text, parsed = _workflow()
+    pinned = parsed["jobs"]["diagnose"]["env"]["EXPECTED_HOST_FINGERPRINT"]
+    assert pinned, "EXPECTED_HOST_FINGERPRINT must not be empty"
+    assert re.fullmatch(r"sha256:[0-9a-f]{16}", pinned), pinned
+    assert pinned == PINNED
+
+
+def test_an_empty_fingerprint_refuses_a_run_that_was_asked_to_send(tmp_path):
+    """The defect, pinned as a test.
+
+    Nothing is compared when the expected value is empty, so a send would be a
+    paid request to whatever the endpoint secret points at that day. That is
+    the one combination that must not reach the next step.
+    """
+    proc, output = _run_confirm(
+        tmp_path, expected="", measured=PINNED, send_request="true"
+    )
+    assert proc.returncode != 0
+    assert "FATAL" in proc.stdout
+    assert "confirmed" not in output
+
+
+def test_an_empty_fingerprint_still_lets_a_dry_run_discover_it(tmp_path):
+    """Because that is how the value gets found in the first place.
+
+    Refusing here too would make the pin unbootstrappable: the fingerprint is
+    only knowable by running the plan against the real secret. A dry run sends
+    nothing, so tolerating it costs nothing.
+    """
+    proc, output = _run_confirm(
+        tmp_path, expected="", measured=PINNED, send_request="false"
+    )
+    assert proc.returncode == 0
+    assert "NOTE" in proc.stdout
+    assert "confirmed" not in output
+
+
+@pytest.mark.parametrize("send_request", ["true", "false"])
+def test_a_mismatch_refuses_whether_or_not_a_send_was_asked_for(
+    tmp_path, send_request
+):
+    """A repointed secret is a finding even on a free run."""
+    proc, output = _run_confirm(
+        tmp_path,
+        expected=PINNED,
+        measured="sha256:0000000000000000",
+        send_request=send_request,
+    )
+    assert proc.returncode != 0
+    assert "FATAL" in proc.stdout
+    assert "confirmed" not in output
+
+
+def test_only_a_full_match_writes_the_go_ahead(tmp_path):
+    proc, output = _run_confirm(
+        tmp_path, expected=PINNED, measured=PINNED, send_request="true"
+    )
+    assert proc.returncode == 0
+    assert "resource=pinned" in proc.stdout
+    assert "confirmed=yes" in output
+
+
+def test_the_measured_value_is_printed_on_every_path(tmp_path):
+    """Whatever it decides, it says what it saw.
+
+    The pin was recoverable in the first place only because the step printed
+    the measurement before judging it, and the next repointing will need the
+    same.
+    """
+    for expected, measured, send in (
+        ("", PINNED, "false"),
+        (PINNED, "sha256:0000000000000000", "false"),
+        (PINNED, PINNED, "true"),
+    ):
+        proc, _output = _run_confirm(
+            tmp_path, expected=expected, measured=measured, send_request=send
+        )
+        assert f"measured host fingerprint: {measured}" in proc.stdout
+
+
+def test_the_send_needs_the_confirmation_and_not_only_the_input():
+    """Defence in depth against the next edit of the step above.
+
+    `confirmed` is written on the matched path alone. Gating the request on it
+    as well as on the person's input means that softening one of the refusals
+    back into an `exit 0` — which is exactly what used to be there — still does
+    not buy a request.
+    """
+    send = _steps()["Send the one turn"]
+    assert "steps.pinned.outputs.confirmed" in send["if"]
+    assert "inputs.send_request" in send["if"]
+    assert _steps()[CONFIRM_STEP]["id"] == "pinned"
 
 
 def test_the_workflow_runs_on_the_host_where_the_sandbox_starts():


### PR DESCRIPTION
# fix(codex): an unpinned fingerprint must refuse the send, not narrate it

`EXPECTED_HOST_FINGERPRINT` was empty, and empty meant *pass*.

## What was wrong

The diagnostic is built so that one deliberate input separates a free run from
a paid one, and so that the paid one can only be about one resource. The second
half did not hold. The confirm step read:

```sh
if [ -z "${EXPECTED_HOST_FINGERPRINT}" ]; then
  echo "NOTE: EXPECTED_HOST_FINGERPRINT is empty in this workflow, so"
  echo "      nothing was checked. Pin the value printed above and"
  echo "      this becomes a real gate."
  exit 0
fi
```

and the step after it was gated on `if: ${{ inputs.send_request }}` alone. So
an empty pin stopped **nothing**. It stopped a *mismatched* resource, which is
the case that cannot arise while the expected value is blank. The one state the
check existed for — "I do not know which resource this is" — was the state it
waved through, and the next thing it waved through was a billed request to
whatever the endpoint secret happened to point at.

The existing test did not catch it, and could not:

```python
assert "EXPECTED_HOST_FINGERPRINT" in parsed["jobs"]["diagnose"]["env"]
assert "exit 1" in check["run"]
```

Both are true of a step whose empty branch is `exit 0`. The key existed; the
word `exit 1` occurred further down; the gate was open.

## The pin, and why this value rather than the one that was printed

The measured value is `sha256:69057d59166a82e3`, from run
[34317316416](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/34317316416)
— `send_request: false`, `verdict: not_sent`, nothing sent, nothing billed.

**That it was printed is not why it is here.** A diagnostic that adopts whatever
host it happens to observe pins nothing; it just writes down where it went. So
the value was derived first, from evidence that predates the run and needs no
network: sha256 over the account name this repository already pins in a
repository variable, on each of the two suffixes the classifier accepts.

| suffix | derived |
|---|---|
| `*.services.ai.azure.com` | **`sha256:69057d59166a82e3`** |
| `*.openai.azure.com` | `sha256:61e7e206e9a37f69` |

The measurement equals the first. So the run is corroboration of an
independently held expectation rather than the source of it, and a host that
had matched neither would have been a finding, not a new pin.

The variable is deliberately **not named** in the workflow, let alone read.
Naming it is one edit away from requesting it, and requesting it prints it —
which is the whole reason this job identifies its resource by hash instead of
by name. `test_the_workflow_never_asks_for_a_variable_that_would_name_the_resource`
enforces that, and it caught a first draft of the comment above that spelled the
variable out. The comment was reworded; the test was not touched.

## The change

1. **The pin is set** to the corroborated value.
2. **Empty now refuses a send.** `send_request: true` with no expected value
   exits non-zero before the request. Empty on a *dry* run still passes with a
   note — deliberately, because a dry run is the only way the value can be
   discovered, and refusing there would make the pin unbootstrappable at no
   saving, since nothing is sent.
3. **The send is gated on evidence as well as intention.** The confirm step
   gained `id: pinned` and writes `confirmed=yes` on the matched path *only*;
   the send now needs `inputs.send_request && steps.pinned.outputs.confirmed ==
   'yes'`. A failing confirm step already halts the job, so this is defence in
   depth against the next edit — softening either refusal back into an `exit 0`,
   which is exactly what was there, still does not buy a request.

## Tests that run the step instead of reading it

Eight new tests. The helper substitutes the plan's path and nothing else, then
executes the workflow's own `run:` text under `bash`, so the branches, the
comparison, the exit codes and the line that writes the go-ahead are all the
file's.

| state | dry | send |
|---|---|---|
| empty | passes, prints NOTE, writes no go-ahead | **refuses** |
| mismatch | **refuses** | **refuses** |
| match | — | passes, writes `confirmed=yes` |

Also pinned: the fingerprint is non-empty and matches `sha256:[0-9a-f]{16}`;
the measured value is printed on every path, whatever the verdict, because that
print is the only reason the pin was recoverable and the next repointing will
need it too.

**Against the pre-fix workflow, 4 of the 8 fail** — including
`test_an_empty_fingerprint_refuses_a_run_that_was_asked_to_send`. The other four
pass on both trees on purpose: they pin behaviour this change *preserves*
(mismatch already refused, the measurement was already printed, the dry-run
tolerance is unchanged) and would otherwise be free to drift.

`test_sending_is_off_unless_it_is_asked_for` asserted the send's `if` was
exactly `${{ inputs.send_request }}`; it now asserts that condition is *among*
the send's conditions.

## Verification

| | |
|---|---|
| `test_codex_foundry_connection_probe.py` | **95 passed** (87 before) |
| Same file against the pre-fix workflow | **4 failed / 91 passed** |
| `test_a_step_reference_that_names_nothing.py` | **32 passed** — the new `steps.pinned.outputs` reference resolves |
| Free dry run on `main` before this branch | run 34317316416, **success**, `verdict: not_sent` |

The dry run's plan: `endpoint_kind: direct-v1`, `wire_api: responses`,
`turns_sent: 1`, `tools_requested: false`, `prompt_characters: 135`. No request
was sent by it and none is sent by anything in this PR.

## Grader fingerprint: unmoved

Two files change — `.github/workflows/codex-foundry-connection-diagnostic.yml`
and `batch-runner/tests/test_codex_foundry_connection_probe.py`. Neither is a
fingerprint input; the inputs are `core/**`, `requirements.txt` and
`schemas/grade.schema.json`, and this branch touches none of them. The grader
source hash stays `ee1ca0b0…` and the price table stays `b01b384c…`.

## What this does not fix, and where it lives

**`retries_configured: 0` in the plan is a literal, not a bound.** It is
hardcoded in `request_plan()`. Nothing configures it: `provider_config_overrides`
in `core/codex_runtime_config.py` writes `name`, `base_url`, `wire_api`, the
four `auth.*` keys and `query_params`, and **no retry key at all** — so the
Codex runtime's own defaults are in force, and §4 of
`tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md` says plainly that Codex has
"its own retry behaviour" that this repository does not direct. `RETRY_NONE` in
`core/codex_runner.py` is a cost-ledger *label* for a call, not a suppressor.

What this bounds and does not bound:

- `probe()` calls `thread.turn(PROMPT)` **once**, in no loop; every failure
  path returns a record rather than retrying. On a clean answer that is one
  request.
- A transient failure — a 429, a 5xx, a dropped stream — is where the runtime's
  own retry may re-send, and that is unbounded *by configuration here*. It is
  bounded in practice by the 120 s turn timeout and the 20 min job timeout, and
  the refusal statuses are unbilled ones; the billable shape is a stream
  re-send after tokens were generated.

Fixing it means adding the retry keys to `provider_config_overrides`, which is
in `core/**` and therefore **moves the grader fingerprint** — out of scope for
this branch, which is pinned to leave `ee1ca0b0…` where it is. Recorded here
rather than done quietly. The result record already carries
`streaming.usage_updates` and `usage`, so the actual request count of the first
paid run is measurable after the fact, which is what the workflow's own comment
means by comparing plan against result to stop "one turn, no retries" being a
promise.

No model was called by anything in this PR.
