### PR TITLE
feat(342): give the cost-metering run a dispatch route

### DIFF
--- a/.github/workflows/audio-accuracy-probe.yml
+++ b/.github/workflows/audio-accuracy-probe.yml
@@ -100,7 +100,7 @@ on:
         type: boolean
         default: false
       repeats:
-        description: 'How many times each criterion is put to the model. 3 matches the repeat runs, so stability here is comparable with the 19.35%. Total calls = 20 criteria x repeats x arms, where arms is 2 when prompt_arm is both AND when the corpus runs a second arm of its own. speech-format-pilot is the exception to both halves of that: its document narrows the corpus to five criteria and fixes repeats at 1, and it refuses any other value here rather than quietly correcting it.'
+        description: 'How many times each criterion is put to the model. 3 matches the repeat runs, so stability here is comparable with the 19.35%. Total calls = 20 criteria x repeats x arms, where arms is 2 when prompt_arm is both AND when the corpus runs a second arm of its own. speech-format-pilot and audio-cost-metering are the exceptions to both halves of that: each of those documents narrows the corpus — to five criteria and to two — and fixes repeats at 1, and each refuses any other value here rather than quietly correcting it.'
         required: false
         type: number
         default: 3
@@ -114,7 +114,7 @@ on:
           - observation
           - both
       corpus:
-        description: 'Which sounds, and under which document. tones = clicks, beeps and sine waves; answers whether the verdict depends on the audio at all. speech = ten synthesised sentences with a known transcript; answers whether it hears words. The remaining three run the same ten sentences under two prompts, which DOUBLES the call count, and each one is opened by its own pre-registration rather than by prompt_arm: speech-prompt-ab is 333 (20 criteria, already bought by 334, kept so that run stays reproducible), speech-format-pilot is 337 (5 criteria, repeats must be 1, a format check and not a result), speech-prompt-ab-v2 is 338 (20 criteria, the comparison 334 could not deliver — and it is not to be dispatched unless 337 passed). Every speech setting rebuilds its clips and refuses to run if they do not match the committed digests.'
+        description: 'Which sounds, and under which document. tones = clicks, beeps and sine waves; answers whether the verdict depends on the audio at all. speech = ten synthesised sentences with a known transcript; answers whether it hears words. Three more run the same ten sentences under two prompts, which DOUBLES the call count, and each one is opened by its own pre-registration rather than by prompt_arm: speech-prompt-ab is 333 (20 criteria, already bought by 334, kept so that run stays reproducible), speech-format-pilot is 337 (5 criteria, repeats must be 1, a format check and not a result), speech-prompt-ab-v2 is 338 (20 criteria, the comparison 334 could not deliver — and it is not to be dispatched unless 337 passed). audio-cost-metering is 342 and asks no accuracy question at all: one prompt, 2 criteria on 2 of the same clips, repeats must be 1, and what it measures is whether a paid audio call reaches the cost ledger. Every speech setting rebuilds its clips and refuses to run if they do not match the committed digests.'
         required: false
         type: choice
         default: tones
@@ -124,6 +124,7 @@ on:
           - speech-prompt-ab
           - speech-format-pilot
           - speech-prompt-ab-v2
+          - audio-cost-metering
 
 # Read-only by default. The paid job adds id-token for OIDC and nothing else:
 # there is no commit, no release, and no dispatch to make.
@@ -158,6 +159,19 @@ env:
   # rather than off the name.
   SPEECH_PILOT_PREREG: ${{ github.workspace }}/tasks/rebuilding_grading_task/337-format-safe-observation-pilot.md
   SPEECH_AB_V2_PREREG: ${{ github.workspace }}/tasks/rebuilding_grading_task/338-format-safe-observation-ab.md
+  # 342, which is not an accuracy diagnostic at all. It asks whether a paid
+  # audio call reaches the cost ledger, so its output is the ledger rather
+  # than a score, and `--cost-ledger` is mandatory: a run that cannot write
+  # the record has nothing to report. Its own file for the same reason as the
+  # three above -- the measurer reads the claim list, the repeat count, the
+  # request ceiling and both fingerprints out of the document, and a run held
+  # to the wrong document is a run nobody registered.
+  METERING_PREREG: ${{ github.workspace }}/tasks/rebuilding_grading_task/342-audio-cost-metering-prereg.md
+  # Separate files per job, and never carried between them. The measurer
+  # refuses a ledger that already holds rehearsal rows, which is exactly what
+  # reusing one name across the free and paid jobs would produce.
+  METERING_LEDGER_DRY: ${{ github.workspace }}/audio-cost-metering-rehearsal.sqlite3
+  METERING_LEDGER_PAID: ${{ github.workspace }}/audio-cost-metering-measured.sqlite3
 
 # One at a time. Two concurrent probes would interleave their calls against the
 # same deployment's TPM budget and each would measure the other's throttling.
@@ -256,6 +270,9 @@ jobs:
                 ARGS+=(--speech-prompt-ab "$SPEECH_PILOT_PREREG") ;;
               speech-prompt-ab-v2)
                 ARGS+=(--speech-prompt-ab "$SPEECH_AB_V2_PREREG") ;;
+              audio-cost-metering)
+                ARGS+=(--metering-run "$METERING_PREREG"
+                       --cost-ledger "$METERING_LEDGER_DRY") ;;
               *)
                 ARGS+=(--expect-grader-pin "$SPEECH_PREREG") ;;
             esac
@@ -323,6 +340,18 @@ jobs:
             audio-accuracy-dry-run.json
             audio-accuracy-dry-run-delivery.json
           if-no-files-found: error
+
+      # The rehearsal ledger, under its own name. Same file names as the paid
+      # job would produce would let one be read as the other; these say
+      # `rehearsal` in the artifact name and the rows inside say `stub`.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ always() && inputs.corpus == 'audio-cost-metering' }}
+        with:
+          name: audio-cost-metering-rehearsal-ledger
+          path: |
+            audio-cost-metering-rehearsal.sqlite3
+            audio-cost-metering-rehearsal.jsonl
+          if-no-files-found: warn
 
   # ---------------------------------------------------------------------------
   # The gate. Same reusable `grading` environment as every other paid path
@@ -392,11 +421,26 @@ jobs:
             speech-format-pilot)
               CRITERIA=5; TRUE_CRITERIA=3; FALSE_CRITERIA=2
               NARROWED="  narrowed   = yes, to the 5 criteria named in 337 (of 20 in the manifest)" ;;
+            audio-cost-metering)
+              CRITERIA=2; TRUE_CRITERIA=1; FALSE_CRITERIA=1
+              NARROWED="  narrowed   = yes, to the 2 criteria named in 342 (of 20 in the manifest)" ;;
             *)
               CRITERIA=20; TRUE_CRITERIA=10; FALSE_CRITERIA=10
               NARROWED="  narrowed   = no. Every criterion in the corpus" ;;
           esac
-          case "$CORPUS" in speech*) CLIPS=10 ;; *) CLIPS=9 ;; esac
+          # Clips. Two settings do not use the whole published set, and the
+          # count here is what the run touches rather than what the manifest
+          # holds -- a record that says ten clips for a five-clip run is the
+          # `calls = 36` mistake wearing a different noun. 342 sends two on
+          # purpose: one row cannot show that a second was not the first
+          # counted twice, and a third buys a call that shows nothing the
+          # second did not.
+          case "$CORPUS" in
+            audio-cost-metering) CLIPS=2 ;;
+            speech-format-pilot) CLIPS=5 ;;
+            speech*) CLIPS=10 ;;
+            *) CLIPS=9 ;;
+          esac
           printf '%s\n' \
             "Approved paid audio accuracy probe:" \
             "  model      = gpt-audio-1.5 (read from gold_audio_repeat_v2_sol_max.yaml)" \
@@ -522,11 +566,58 @@ jobs:
                 ARGS+=(--speech-prompt-ab "$SPEECH_PILOT_PREREG") ;;
               speech-prompt-ab-v2)
                 ARGS+=(--speech-prompt-ab "$SPEECH_AB_V2_PREREG") ;;
+              audio-cost-metering)
+                ARGS+=(--metering-run "$METERING_PREREG"
+                       --cost-ledger "$METERING_LEDGER_PAID") ;;
               *)
                 ARGS+=(--expect-grader-pin "$SPEECH_PREREG") ;;
             esac
           fi
           python scripts/measure_audio_grading_accuracy.py "${ARGS[@]}"
+
+      # The verdict, and it is not the accuracy. 342 §6 asks nine questions
+      # about the cost record and this script answers them off the report and
+      # the ledger export alone -- no model, no credential, no network. It is
+      # run here rather than by hand because a paid run whose ledger nobody
+      # checked is 337 again: ten calls bought, and the question they were
+      # bought to answer left open.
+      #
+      # `if: always()`: a run that stopped early still spent whatever it spent
+      # before stopping, and those rows are the thing worth checking. The
+      # exit code is carried through rather than swallowed -- `failed` is a
+      # finding about the cost path and a green tick would bury it -- but it
+      # is carried *after* the summary is written, so the reason is on the
+      # page even when the step is red. `inconclusive` exits 0 like
+      # `measured_ok` does; the verdict word is what a reader goes by.
+      - name: Check the cost record
+        if: ${{ always() && inputs.corpus == 'audio-cost-metering' }}
+        run: |
+          set -uo pipefail
+          cd batch-runner
+          if [ ! -f "$GITHUB_WORKSPACE/audio-accuracy-measured.json" ]; then
+            echo "::warning::no report, so there is no cost record to check"
+            exit 0
+          fi
+          python scripts/verify_audio_metering_run.py \
+            "$GITHUB_WORKSPACE/audio-accuracy-measured.json" \
+            --out "$GITHUB_WORKSPACE/audio-cost-metering-verdict.json" \
+            | tee "$GITHUB_WORKSPACE/audio-cost-metering-verdict.txt"
+          rc=${PIPESTATUS[0]}
+          {
+            echo "## Cost record — 342 §6"
+            echo
+            echo '```'
+            cat "$GITHUB_WORKSPACE/audio-cost-metering-verdict.txt"
+            echo '```'
+            echo
+            echo "\`measured_ok\` means the cost path carried this run end to end."
+            echo "It does **not** mean the judge heard anything — that is 337/338's"
+            echo "question and this run does not ask it. \`inconclusive\` means"
+            echo "nothing failed and something went unanswered; read which"
+            echo "condition before reading it as a pass."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "verify exit: $rc"
+          exit "$rc"
 
       - name: Summarise
         if: always()
@@ -961,4 +1052,20 @@ jobs:
           path: |
             audio-accuracy-measured.json
             audio-accuracy-measured-delivery.json
+          if-no-files-found: warn
+
+      # 342's whole output is the ledger, so it goes up separately and it goes
+      # up even when the measurer stopped early. A run that hit its ceiling
+      # still spent whatever it spent before the ceiling, and the rows for that
+      # spend are in this file and nowhere else -- uploading it only on success
+      # would drop exactly the records nobody planned for.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ always() && inputs.corpus == 'audio-cost-metering' }}
+        with:
+          name: audio-cost-metering-ledger
+          path: |
+            audio-cost-metering-measured.sqlite3
+            audio-cost-metering-measured.jsonl
+            audio-cost-metering-verdict.json
+            audio-cost-metering-verdict.txt
           if-no-files-found: warn

--- a/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
+++ b/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
@@ -3633,20 +3633,63 @@ def test_the_gate_counts_the_second_arm_the_document_opens() -> None:
 
 
 def test_the_gate_states_the_clip_counts_the_corpora_actually_have() -> None:
-    """The gate has no checkout, so those two numbers are restatements.
+    """The gate has no checkout, so those numbers are restatements.
 
     Same failure mode as ``calls = 36``: a record that says what was
     authorised, disagreeing with what exists.
+
+    Read by running the record rather than by matching its ``case``. The
+    branches were one line and are now several, and a regex that spelled the
+    old layout would go red on a reformat that changed nothing -- while
+    staying green for a corpus with no branch at all, which is the failure
+    this test is for.
     """
-    run = _step("approve-paid", "Record approved request")["run"]
-    tone_clips = re.search(r"case \"\$CORPUS\" in speech\*\) CLIPS=\d+ ;; \*\) CLIPS=(\d+)", run)
-    speech_clips = re.search(r"case \"\$CORPUS\" in speech\*\) CLIPS=(\d+)", run)
-    assert tone_clips and speech_clips
-    assert int(tone_clips.group(1)) == len(probe.CLIPS)
+    bash = shutil.which("bash")
+    if bash is None:  # pragma: no cover - CI and dev boxes both have bash
+        pytest.skip("no bash to run the gate's own script with")
+    record = _step("approve-paid", "Record approved request")["run"]
+
+    def clips_stated_for(corpus: str) -> int:
+        out = subprocess.run(
+            [bash, "-c", record],
+            env={
+                **os.environ,
+                "PROBE_REPEATS": "1",
+                "PROBE_ARM": "production",
+                "PROBE_CORPUS": corpus,
+            },
+            capture_output=True, text=True, check=True,
+        ).stdout
+        found = re.search(rf"corpus\s+= {re.escape(corpus)} \((\d+) clips\)",
+                          out)
+        assert found, f"the record does not state a clip count for {corpus}"
+        return int(found.group(1))
+
     published = json.loads(
         (probe.REPO_ROOT / SPEECH_MANIFEST_REPO_PATH).read_text(encoding="utf-8")
     )
-    assert int(speech_clips.group(1)) == len(published["clips"])
+    assert clips_stated_for("tones") == len(probe.CLIPS)
+    assert clips_stated_for("speech") == len(published["clips"])
+
+    # And every corpus that is offered has a number that came from somewhere.
+    # A new option falls through to the tone count today, which reads as a
+    # nine-clip run of whatever it actually is.
+    by_id = {claim["claim_id"]: claim for claim in published["claims"]}
+    offered = _workflow()[True]["workflow_dispatch"]["inputs"]["corpus"][
+        "options"]
+    for corpus in offered:
+        if corpus in ("tones", "speech"):
+            continue
+        document = probe.REPO_ROOT / _document_for(corpus).split(
+            "workspace }}/", 1)[1]
+        try:
+            claim_ids = probe.pilot_claims_stated_in(document)
+        except ValueError:
+            # A document that narrows nothing runs the whole published set.
+            expected = len(published["clips"])
+        else:
+            expected = len({by_id[cid]["clip_id"] for cid in claim_ids})
+        assert clips_stated_for(corpus) == expected, corpus
 
 
 def test_the_paid_summary_refuses_to_pool_the_two_corpora() -> None:
@@ -6032,6 +6075,19 @@ _CORPUS_DOCUMENTS = {
 }
 
 
+def _document_for(corpus: str) -> str:
+    """The workspace path the workflow hands the measurer for this corpus.
+
+    Two flags reach the same place: the two-arm corpora arrive on
+    ``--speech-prompt-ab`` and 342 arrives on ``--metering-run``. What a
+    caller wants is the document, not the door it came through.
+    """
+    env = _workflow()["env"]
+    if corpus == probe.AUDIO_COST_METERING_KIND:
+        return env["METERING_PREREG"]
+    return env[_CORPUS_DOCUMENTS[corpus][0]]
+
+
 def test_every_two_arm_corpus_is_offered_and_routed_to_its_own_document(
 ) -> None:
     """A dropdown entry and a document, held together in both jobs.
@@ -6063,7 +6119,9 @@ def test_every_two_arm_corpus_is_offered_and_routed_to_its_own_document(
 
     # The single-arm settings stay, and nothing else has appeared. A new
     # option not in this list is one nobody has decided the routing for.
-    assert set(options) == {"tones", "speech", *_CORPUS_DOCUMENTS}
+    assert set(options) == {
+        "tones", "speech", probe.AUDIO_COST_METERING_KIND, *_CORPUS_DOCUMENTS,
+    }
     assert inputs["corpus"]["default"] == "tones", (
         "the default dispatch must be the one that spends least"
     )
@@ -6098,6 +6156,156 @@ def test_every_two_arm_corpus_is_offered_and_routed_to_its_own_document(
     for path in named:
         on_disk = probe.REPO_ROOT / path.split("workspace }}/", 1)[1]
         assert on_disk.is_file(), f"{path} is not in the checkout"
+
+
+def test_the_metering_run_is_dispatchable_and_carries_its_own_ledger(
+) -> None:
+    """342 needs two flags the dropdown had no way to add, so this walks them.
+
+    Every other corpus here is opened by ``--speech-prompt-ab`` or falls
+    through to ``--expect-grader-pin``. 342 is opened by ``--metering-run``,
+    and the measurer refuses that flag without ``--cost-ledger`` -- the run's
+    whole output is the ledger, so a dispatch that forgot it would buy the
+    calls and record nothing about them, which is the exact failure 340 found.
+
+    The two jobs must also name *different* ledger files. They do not overlap
+    in time, so a shared name looks harmless; what it produces is a paid run
+    refused at the door because the file already holds the free run's
+    ``rehearsal`` rows. That refusal happens after approval and before any
+    call, so it costs a gate rather than money -- but it costs the run.
+    """
+    kind = probe.AUDIO_COST_METERING_KIND
+    text = (
+        probe.REPO_ROOT / ".github" / "workflows" / "audio-accuracy-probe.yml"
+    ).read_text(encoding="utf-8")
+    env = _workflow()["env"]
+
+    document = probe.REPO_ROOT / env["METERING_PREREG"].split(
+        "workspace }}/", 1)[1]
+    assert document.is_file(), "the metering document is not in the checkout"
+    # Routed to a document that registers *this* diagnostic. The measurer
+    # checks the file names a diagnostic it knows; only the mapping can check
+    # it is the one the dropdown said.
+    assert probe.diagnostic_kind_stated_in(document) == kind
+
+    ledgers = []
+    for job, step_name, var in (
+        ("dry-run", "Dry run", "METERING_LEDGER_DRY"),
+        ("measure", "Measure", "METERING_LEDGER_PAID"),
+    ):
+        run = _step(job, step_name)["run"]
+        branch = re.search(
+            rf"^\s*{re.escape(kind)}\)\n"
+            r"\s*ARGS\+=\(--metering-run \"\$(\w+)\"\n"
+            r"\s*--cost-ledger \"\$(\w+)\"\) ;;",
+            run,
+            re.MULTILINE,
+        )
+        assert branch, f"{job} does not route {kind} with a ledger"
+        assert branch.group(1) == "METERING_PREREG", branch.group(1)
+        assert branch.group(2) == var, (
+            f"{job} meters into ${branch.group(2)}, not ${var}"
+        )
+        ledgers.append(env[var])
+
+    assert len(set(ledgers)) == 2, (
+        "both jobs write the same ledger file; the paid run would be refused "
+        "for holding the rehearsal's rows"
+    )
+
+    # Sized off the document rather than off this test. Two claims is not an
+    # opinion here: the measurer refuses any other count, so a record saying
+    # something else is a record describing a run that cannot happen.
+    claim_ids = probe.pilot_claims_stated_in(document)
+    manifest = json.loads(
+        (
+            probe.REPO_ROOT / "tasks" / "rebuilding_grading_task"
+            / "330-speech-verification-manifest.json"
+        ).read_text(encoding="utf-8")
+    )
+    by_id = {claim["claim_id"]: claim for claim in manifest["claims"]}
+    claims = [by_id[claim_id] for claim_id in claim_ids]
+    true_claims = sum(1 for claim in claims if claim["holds"])
+    clips = {claim["clip_id"] for claim in claims}
+
+    branch = re.search(
+        rf"{re.escape(kind)}\)\n"
+        r"\s*CRITERIA=(\d+); TRUE_CRITERIA=(\d+); FALSE_CRITERIA=(\d+)",
+        text,
+    )
+    assert branch, "the approval record does not size the metering run"
+    assert int(branch.group(1)) == len(claims)
+    assert int(branch.group(2)) == true_claims
+    assert int(branch.group(3)) == len(claims) - true_claims
+
+    # And the shell agrees, run as the gate would run it. The clip `case` is a
+    # separate statement from the one above, with a `speech*` glob next to it
+    # that this corpus does not match by name but easily could have: the
+    # record would then say nine clips for a two-clip run.
+    record = _step("approve-paid", "Record approved request")["run"]
+    out = subprocess.run(
+        ["bash", "-c", record],
+        env={
+            **os.environ,
+            "PROBE_CORPUS": kind,
+            "PROBE_ARM": "production",
+            "PROBE_REPEATS": "1",
+        },
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert f"corpus     = {kind} ({len(clips)} clips)" in out, out
+    assert f"criteria   = {len(claims)} " in out, out
+    assert "(1 arm(s))" in out, out
+    assert f"{len(claims)} per arm, {len(claims)} in total" in out, out
+    # The registered repeat count is 1 and the measurer refuses anything else,
+    # so the number the gate authorises is the number of calls the run makes.
+    assert len(claims) <= probe.SPEECH_REQUEST_CAPS[kind]
+    assert probe.SPEECH_NARROWED_KINDS[kind] == 1
+
+
+def test_the_metering_ledger_is_uploaded_even_when_the_run_stops_early(
+) -> None:
+    """A run that hit its ceiling still spent what it spent before it.
+
+    The ledger is exported in a ``finally``, so a stopped run leaves rows and
+    no verdict. Uploading the ledger only on success would discard exactly the
+    records of spend nobody planned for -- which is the one kind of row a cost
+    diagnostic exists to keep.
+    """
+    steps = _workflow()["jobs"]["measure"]["steps"]
+    uploads = [
+        step for step in steps
+        if str(step.get("uses", "")).startswith("actions/upload-artifact")
+    ]
+    ledger = [
+        step for step in uploads
+        if "audio-cost-metering-measured.sqlite3" in step["with"]["path"]
+    ]
+    assert ledger, "the paid job does not upload the metering ledger"
+    step = ledger[0]
+    assert "always()" in step["if"], (
+        "the ledger upload is conditional on the run succeeding"
+    )
+    for name in (
+        "audio-cost-metering-measured.jsonl",
+        "audio-cost-metering-verdict.json",
+    ):
+        assert name in step["with"]["path"], name
+
+    # And the check that reads it runs on the same terms, for the same reason.
+    check = _step("measure", "Check the cost record")
+    assert "always()" in check["if"]
+    assert "verify_audio_metering_run.py" in check["run"]
+    # `set -e` here would make a `failed` verdict skip the summary that
+    # explains what `failed` means.
+    assert "set -uo pipefail" in check["run"]
+    # The verdict is carried out of the step rather than swallowed -- a
+    # `failed` cost record under a green tick is the finding going missing --
+    # and it is carried after the summary is written, so the reason is on the
+    # page even when the step is red.
+    body = check["run"]
+    assert 'exit "$rc"' in body
+    assert body.index("GITHUB_STEP_SUMMARY") < body.index('exit "$rc"')
 
 
 def test_the_approval_record_counts_the_pilot_as_five_and_not_as_twenty(


### PR DESCRIPTION
`342` registers a two-call diagnostic — *does a paid audio call reach the cost
ledger?* — and `343` walked it end to end against a stub. It could not be
dispatched. `audio-accuracy-probe.yml` is the only workflow that runs
`measure_audio_grading_accuracy.py`, and it had no way to pass `--metering-run`
or `--cost-ledger`, which the measurer requires because this run's entire
output *is* the ledger.

**Nothing here is dispatched and nothing is bought.** This adds the route; it
does not travel it.

## What changed

**The corpus is dispatchable, and routed to its own document.** `audio-cost-metering`
joins the dropdown and both jobs route it to `342-audio-cost-metering-prereg.md`
with a ledger. The measurer reads the claim list, the repeat count, the request
ceiling and both fingerprints out of that document, so the mapping is the only
place that can check the file matches the word someone picked.

**Separate ledgers per job.** The free and paid jobs never overlap in time, so
one filename looks harmless — what it produces is a paid run refused at the door
for holding the rehearsal's `rehearsal` rows, *after* the gate.

**The approval record is sized for it.** Without a branch it would have printed
20 criteria, 9 clips and 20 calls for a run that makes **2**. It now prints:

```
  corpus     = audio-cost-metering (2 clips)
  criteria   = 2 (1 true / 1 false)
  narrowed   = yes, to the 2 criteria named in 342 (of 20 in the manifest)
  repeats    = 1
  prompt_arm = production (1 arm(s))
  calls      = 2 per arm, 2 in total
```

**A pre-existing defect, found by broadening that test.** `speech-format-pilot`
narrows to five criteria across five clips and the record said ten. Same class
as `calls = 36`, in the direction that overstates. Fixed. The clip test now
*runs* the record instead of pattern-matching its `case` — the old regex pinned
a one-line layout and was blind to a corpus with no branch at all, which is the
failure it exists to catch.

**The paid job checks its own cost record.** `verify_audio_metering_run.py`
answers 342 §6's nine conditions off the report and the ledger export alone: no
model, no credential, no network. The ledger, its `.jsonl` and the verdict go up
as artifacts on `always()` — a run that hit its ceiling still spent what it
spent before the ceiling, and those rows live in that file and nowhere else. The
verifier's exit code is carried out of the step *after* the summary is written,
so a `failed` cost record cannot sit under a green tick and the reason is still
on the page when the step is red.

The step summary says what the verdict does **not** mean: `measured_ok` is about
the cost path, not about whether the judge heard anything — that is 337/338's
question and this run does not ask it.

## Verification

- Full backend suite: **9160 passed, 15 skipped, 0 failed**.
- `test_audio_accuracy_probe_knows_its_own_answers.py`: 207 passed, 1 skipped,
  including two new tests and one broadened one.
- Mutation-checked: deleting the `CLIPS=2` branch makes the new test fail with
  `corpus = audio-cost-metering (9 clips)`.
- Every `run:` block in the workflow passes `bash -n`.
- `check_grader_hash_freeze.py` → `PASS: no grader-source file in this diff`.
  No `core/`, schema, grading-prompt or price-table file is touched, so the
  fingerprints 342 pins cannot move on this branch.