### PR TITLE
fix(codex): pin the retry counters in the table the runtime reads

### DIFF
--- a/.github/workflows/codex-foundry-connection-diagnostic.yml
+++ b/.github/workflows/codex-foundry-connection-diagnostic.yml
@@ -41,7 +41,14 @@
 #     instead, and every runtime message passes through a redactor first. The
 #     step below re-checks that after the fact rather than trusting it.
 #
-# Cost. One turn, one prompt of about 135 characters, no retries, no tools.
+# Cost. One turn, one prompt of about 135 characters, no tools, and retries
+# pinned off in the provider table the runtime actually reads — not merely
+# asserted in the plan. That distinction was real: until the pins existed, the
+# plan said `retries_configured: 0` while the runtime used its own defaults,
+# and one turn against a 500 sent thirty requests. Measured against the pinned
+# binary in `batch-runner/tests/test_codex_retry_pins_are_enforced.py`, which
+# also records the one case pinning does not reduce to a single request — a
+# 401 costs two, because the runtime re-mints the token once and retries.
 # `send_request: false` is the default, and with it nothing is sent at all —
 # the job prints the plan, fingerprinted, and stops. The plan and the result
 # share a schema, so what was fixed beforehand and what happened can be
@@ -173,8 +180,9 @@ jobs:
 
       # Always, including on the runs that go on to send. The plan is what
       # fixes the request before it costs anything, and comparing it against
-      # the result afterwards is how "one turn, no retries" stops being a
-      # promise.
+      # the result afterwards is how "one turn, retries pinned" stops being a
+      # promise. The plan reads its retry numbers off the same settings the
+      # provider table is built from, so the two cannot disagree.
       #
       # No AZURE_AI_EXPECTED_* variable is passed to this step or the next one.
       # They would be printed. The script pulls the names it must redact out of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,64 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **The Codex diagnostic's "no retries" is now a setting the runtime reads,
+  not a line it wrote about itself — and one turn against a 500 stopped being
+  thirty requests.** `request_plan()` reported `retries_configured: 0` while
+  the provider table set neither retry key, so the pinned runtime used its own
+  documented defaults (`request_max_retries` 4, `stream_max_retries` 5). Both
+  are now fields on `CodexProviderSettings`, defaulted to 0, **emitted into
+  the provider table**, carried in `describe_provider()`, and included in the
+  diagnostic's settings fingerprint — so a verdict measured with retries
+  pinned cannot be read as evidence for a run without them. The plan reads its
+  numbers off the same settings object the table is built from, and reports
+  `null` rather than `0` when no settings could be built, because a run that
+  could not be configured did not configure zero retries.
+- **Measured against the real binary, not asserted.**
+  `tests/test_codex_retry_pins_are_enforced.py` starts the pinned `codex`
+  binary against a local server that refuses four different ways and counts
+  the requests that arrive. The token is a fixed fake string and only two keys
+  of the production provider table are rewritten — `base_url` and
+  `auth.args` — which a test asserts, so the `Authorization: Bearer` header
+  observed on `POST /v1/responses` is produced by the same `auth.*` block
+  production emits.
+
+  | server answers | counters unset | pinned to 0 |
+  | --- | --- | --- |
+  | HTTP 500 | 30 requests | 1 request |
+  | mid-stream disconnect | 6 requests | 1 request |
+  | HTTP 429 | 1 request | 1 request |
+  | HTTP 401 | 12 requests | **2 requests** |
+
+  The 401 row is recorded as a bound the pins do **not** remove: the runtime
+  re-runs the provider's auth command once after an authentication failure and
+  retries with the fresh token — two requests, two tokens minted — and no
+  documented key switches that off. It is in the record as
+  `retries_not_removed_by_pinning` rather than rounded down to one, and the
+  test asserts it at exactly 2 so that a runtime which later drops the retry
+  turns the claim red instead of leaving it standing.
+- **The record format is `codex_foundry_connection/2`.**
+  `request.retries_configured` changed from the scalar `0` to the two counters
+  actually written into the table, so a `/1` record — including the one from
+  run `34319880025` — cannot be misread as saying how many requests its turn
+  made. It made an unknown number.
+- **The grader source fingerprint moves with this: `ee1ca0b0…` →
+  `7e745a18…`.** `core/codex_runtime_config.py` is inside
+  `compute_grader_source_hash`'s walk of `core/*.py`, so a one-line change
+  there moves it. Both values were measured rather than reported —
+  `ee1ca0b0…` re-measured at `3d51e7cc`, where it still matched `342` §2, and
+  `7e745a18…` on this branch. Nothing in `337`/`342`/`343` is rewritten: those
+  record what was true for runs that are finished. What this does mean is that
+  `342` §0's fingerprint rows re-open for **any future paid dispatch**, exactly
+  as `343` §5.1 says they do on the next `core/` merge — re-measure before
+  buying, do not carry `ee1ca0b0…` forward. No grade run was in flight when
+  this merged.
+
+### Changed
+- **`CodexProviderSettings` refuses a retry count that is not a whole
+  non-negative number, including `True`.** `bool` is an `int` and
+  `_toml_literal` would render it as `true`, which the runtime reports as a
+  type error about a config file no operator wrote.
+
 - **A refusal now reaches the audio checker as a refusal, and a paid run whose
   every call was declined is `inconclusive` rather than `rehearsal_ok`.** The
   shared fix `341` proposed landed in the common metering code (not this

--- a/batch-runner/core/codex_runtime_config.py
+++ b/batch-runner/core/codex_runtime_config.py
@@ -494,6 +494,44 @@ DEFAULT_AUTH_REFRESH_MS = 1_800_000
 #: How long the auth command may take before Codex gives up on it.
 DEFAULT_AUTH_TIMEOUT_MS = 30_000
 
+#: Retries, pinned off. Both keys are per-provider settings of the pinned
+#: 0.147.0 runtime -- they appear in its ``ModelProviderInfo`` field list and in
+#: the published config reference, whose defaults are ``request_max_retries``
+#: 4 and ``stream_max_retries`` 5.
+#:
+#: Leaving them unset is not "one request per turn". Measured against the
+#: pinned binary and a local server that answers from a script, one turn sends:
+#:
+#:   ===================  =================  ============
+#:   server answers       shipped defaults   pinned to 0
+#:   ===================  =================  ============
+#:   HTTP 500                 30 requests      1 request
+#:   mid-stream disconnect     6 requests      1 request
+#:   HTTP 429                  1 request       1 request
+#:   HTTP 401                 12 requests     2 requests
+#:   ===================  =================  ============
+#:
+#: 30 is the product the reference implies: 5 request attempts x 6 stream
+#: attempts. It is the number that turns "one diagnostic turn" into thirty
+#: billable calls against a real deployment, which is why these are pinned here
+#: rather than described in a plan dictionary.
+#:
+#: The 401 row is the honest residue. Pinning takes it from 12 requests to 2,
+#: not to 1: Codex re-runs the auth command once on an authentication failure
+#: and retries with the fresh token, and neither counter binds that. The
+#: reference says as much under ``auth.refresh_interval_ms`` -- "set to 0 to
+#: refresh only after an authentication retry" -- so the retry exists by
+#: design. There is no supported key that removes it. ``tests/
+#: test_codex_retry_pins_are_enforced.py`` measures all four rows against the
+#: real binary so the table cannot quietly stop being true.
+DEFAULT_REQUEST_MAX_RETRIES = 0
+DEFAULT_STREAM_MAX_RETRIES = 0
+
+#: What one 401 costs even with both counters at 0, measured rather than
+#: reasoned about. Exported so the diagnostic can state the bound instead of
+#: claiming a zero it does not have.
+AUTH_RETRY_REQUESTS_NOT_REMOVED_BY_PINNING = 2
+
 
 class CodexProviderConfigurationError(ValueError):
     """A provider setting is missing, malformed, or forbidden here."""
@@ -559,6 +597,19 @@ class CodexProviderSettings(CodexProviderLike):
     auth_scope: str = DIRECT_TOKEN_SCOPE
     auth_refresh_interval_ms: int = DEFAULT_AUTH_REFRESH_MS
     auth_timeout_ms: int = DEFAULT_AUTH_TIMEOUT_MS
+    #: Retries on a refused or dropped request. Both default to 0; see the
+    #: measured table beside :data:`DEFAULT_REQUEST_MAX_RETRIES` for what the
+    #: runtime does when they are left unset.
+    #:
+    #: 0 is the right default for a diagnostic, where the cost of one turn has
+    #: to be a known quantity. It is not obviously right for a 220-task batch,
+    #: where a transient 500 would now fail a task instead of being retried.
+    #: That is a decision for whoever turns the batch leg on, and this default
+    #: is set so the decision has to be made rather than inherited: a caller
+    #: that wants retries passes a number, and the number is in the settings
+    #: fingerprint, so the record says which run had them.
+    request_max_retries: int = DEFAULT_REQUEST_MAX_RETRIES
+    stream_max_retries: int = DEFAULT_STREAM_MAX_RETRIES
     python_executable: str | None = None
 
     def __post_init__(self) -> None:
@@ -609,6 +660,21 @@ class CodexProviderSettings(CodexProviderLike):
             raise CodexProviderConfigurationError(
                 "Codex provider auth timings must be positive milliseconds"
             )
+        for name in ("request_max_retries", "stream_max_retries"):
+            value = getattr(self, name)
+            # ``bool`` is an ``int``, and ``_toml_literal`` renders it as
+            # ``true``. A provider table carrying ``request_max_retries=true``
+            # is a type error the runtime reports about a config file the
+            # operator never wrote, so it is refused here where it is legible.
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise CodexProviderConfigurationError(
+                    f"Codex provider {name} must be a whole number of retries; "
+                    f"got {value!r}"
+                )
+            if value < 0:
+                raise CodexProviderConfigurationError(
+                    f"Codex provider {name} cannot be negative; got {value!r}"
+                )
 
     @property
     def base_url(self) -> str:
@@ -761,6 +827,13 @@ def provider_config_overrides(
         f"{prefix}.auth.timeout_ms={_toml_literal(settings.auth_timeout_ms)}",
         f"{prefix}.auth.refresh_interval_ms="
         f"{_toml_literal(settings.auth_refresh_interval_ms)}",
+        # Emitted always, including at the default 0. An unset key is not a
+        # zero here: the runtime falls back to 4 and 5, which is up to thirty
+        # requests for one turn.
+        f"{prefix}.request_max_retries="
+        f"{_toml_literal(settings.request_max_retries)}",
+        f"{prefix}.stream_max_retries="
+        f"{_toml_literal(settings.stream_max_retries)}",
     ]
     for key, value in sorted(dict(settings.query_params).items()):
         overrides.append(
@@ -783,5 +856,7 @@ def describe_provider(settings: CodexProviderSettings) -> dict[str, object]:
         "query_params": dict(settings.query_params),
         "auth_command": settings.auth_command(),
         "auth_scope": settings.auth_scope,
+        "request_max_retries": settings.request_max_retries,
+        "stream_max_retries": settings.stream_max_retries,
         "endpoint_kind": classify_endpoint(settings.endpoint).kind.value,
     }

--- a/batch-runner/scripts/diagnose_codex_foundry_connection.py
+++ b/batch-runner/scripts/diagnose_codex_foundry_connection.py
@@ -99,6 +99,7 @@ from core.azure_ai_clients import (  # noqa: E402
     classify_endpoint,
 )
 from core.codex_runtime_config import (  # noqa: E402
+    AUTH_RETRY_REQUESTS_NOT_REMOVED_BY_PINNING,
     PINNED_CODEX_CLI_DISTRIBUTION,
     PINNED_CODEX_CLI_VERSION,
     PINNED_CODEX_SDK_DISTRIBUTION,
@@ -113,7 +114,13 @@ from core.codex_runtime_config import (  # noqa: E402
 
 #: The record format. Bumped if a field changes meaning, so a reader can tell
 #: an old record from a new one rather than mis-reading it.
-SCHEMA = "codex_foundry_connection/1"
+#:
+#: /2 changed ``request.retries_configured`` from the scalar ``0`` -- a claim
+#: the plan made about itself and the runtime never saw -- to the two counters
+#: actually written into the provider table, and added
+#: ``request.retries_not_removed_by_pinning``. A ``/1`` record says nothing
+#: about how many requests its turn made.
+SCHEMA = "codex_foundry_connection/2"
 
 # ── The verdict vocabulary ──────────────────────────────────────────────────
 #
@@ -418,14 +425,47 @@ TURNS_SENT = 1
 DEFAULT_TIMEOUT_SECONDS = 120
 
 
-def request_plan() -> dict[str, Any]:
+def request_plan(description: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """What this run intends to send, read off the settings it will send with.
+
+    ``retries_configured`` is taken from ``description`` -- the same mapping
+    the fingerprint is computed over -- rather than written here as a literal.
+    A plan that asserts its own zero proves nothing: the number that decides
+    how many requests leave this machine is the one in the provider table, and
+    if the two ever disagree the plan is the one that is wrong.
+
+    ``None`` when there is no description, because a run whose settings could
+    not be built did not configure zero retries; it configured nothing, and
+    that is not the same record.
+    """
+    retries: dict[str, Any] | None = None
+    if description is not None:
+        configured = description.get("retries")
+        if isinstance(configured, Mapping):
+            retries = dict(configured)
     return {
         "prompt_id": PROMPT_ID,
         "prompt_sha256": hashlib.sha256(PROMPT.encode("utf-8")).hexdigest(),
         "prompt_characters": len(PROMPT),
         "expected_reply": EXPECTED_REPLY,
         "turns_sent": TURNS_SENT,
-        "retries_configured": 0,
+        "retries_configured": retries,
+        # What pinning does not buy, stated next to what it does. Measured
+        # against the pinned binary in tests/test_codex_retry_pins_are_enforced
+        # .py: with both counters at 0, a 401 still costs two requests and two
+        # auth-command runs, because Codex re-mints the token once and retries.
+        # No supported key removes that, so a record that claimed one request
+        # per turn would be claiming something the runtime does not do.
+        "retries_not_removed_by_pinning": {
+            "on_authentication_failure_requests": (
+                AUTH_RETRY_REQUESTS_NOT_REMOVED_BY_PINNING
+            ),
+            "reason": (
+                "the runtime re-runs the provider auth command once after an "
+                "authentication failure and retries with the fresh token; "
+                "neither retry counter binds it"
+            ),
+        },
         "tools_requested": False,
     }
 
@@ -456,6 +496,15 @@ def describe_settings(settings: CodexProviderSettings) -> dict[str, Any]:
             "scope": settings.auth_scope,
             "refresh_interval_ms": settings.auth_refresh_interval_ms,
             "timeout_ms": settings.auth_timeout_ms,
+        },
+        # In the fingerprint on purpose. These two numbers decide how many
+        # requests one turn sends -- up to thirty when they are left unset --
+        # so a verdict measured with them pinned is not evidence for a run
+        # without them, and the fingerprint has to be able to tell the two
+        # apart.
+        "retries": {
+            "request_max_retries": settings.request_max_retries,
+            "stream_max_retries": settings.stream_max_retries,
         },
         "sandbox": "workspace-write",
         "approval_mode": "deny-all",
@@ -572,7 +621,7 @@ def _record(
         "settings_fingerprint": (
             settings_fingerprint(description) if description is not None else None
         ),
-        "request": request_plan(),
+        "request": request_plan(description),
         "observed": dict(observed),
         "not_established": list(NOT_ESTABLISHED_BY_A_TEXT_TURN),
     }

--- a/batch-runner/tests/test_codex_foundry_connection_probe.py
+++ b/batch-runner/tests/test_codex_foundry_connection_probe.py
@@ -418,6 +418,11 @@ def test_the_same_settings_fingerprint_the_same_way():
         {"model": "gpt-5.3"},
         {"endpoint": ENDPOINT.replace(ACCOUNT, "another-account")},
         {"provider_id": "another-provider"},
+        # Thirty requests and one request are different experiments, so a
+        # verdict measured with the counters pinned must not fingerprint the
+        # same as one measured without them.
+        {"request_max_retries": 4},
+        {"stream_max_retries": 5},
     ],
 )
 def test_changing_what_was_measured_changes_the_fingerprint(overrides):
@@ -441,12 +446,56 @@ def test_the_request_is_fixed_before_it_is_sent():
     makes the cost of this diagnostic a known quantity rather than a discovered
     one.
     """
-    plan = request_plan()
+    plan = request_plan(describe_settings(_settings()))
     assert plan["turns_sent"] == 1
-    assert plan["retries_configured"] == 0
+    assert plan["retries_configured"] == {
+        "request_max_retries": 0,
+        "stream_max_retries": 0,
+    }
     assert plan["tools_requested"] is False
     assert plan["prompt_characters"] == len(PROMPT)
     assert len(plan["prompt_sha256"]) == 64
+
+
+def test_the_plan_reports_the_retries_the_provider_table_will_carry():
+    """Not a literal zero written in the plan.
+
+    The number that decides how many requests leave this machine is the one in
+    the provider table. A plan that hard-coded its own zero would keep saying
+    zero after somebody set the counters to four, and the record would be
+    wrong in the direction that costs money.
+    """
+    loud = _settings(request_max_retries=4, stream_max_retries=5)
+    plan = request_plan(describe_settings(loud))
+    assert plan["retries_configured"] == {
+        "request_max_retries": 4,
+        "stream_max_retries": 5,
+    }
+
+
+def test_a_plan_without_settings_records_no_retry_number_rather_than_zero():
+    """A run that could not be configured did not configure zero retries.
+
+    Reading an absent setting as 0 is the reading that lets a record claim a
+    bound nothing established.
+    """
+    assert request_plan()["retries_configured"] is None
+    assert request_plan(None)["retries_configured"] is None
+
+
+def test_the_plan_states_the_retry_pinning_does_not_remove():
+    """Measured, and stated next to the pin rather than smoothed into it.
+
+    With both counters at 0 a 401 still costs two requests, because the
+    runtime re-runs the auth command once and retries with the fresh token.
+    ``test_codex_retry_pins_are_enforced.py`` measures it against the real
+    binary; this asserts the record admits it.
+    """
+    residue = request_plan(describe_settings(_settings()))[
+        "retries_not_removed_by_pinning"
+    ]
+    assert residue["on_authentication_failure_requests"] == 2
+    assert "auth" in residue["reason"]
 
 
 def test_the_prompt_forbids_the_tools_it_is_not_testing():

--- a/batch-runner/tests/test_codex_retry_pins_are_enforced.py
+++ b/batch-runner/tests/test_codex_retry_pins_are_enforced.py
@@ -1,0 +1,490 @@
+"""Count the requests one turn actually sends, against the real binary.
+
+Why this file exists
+--------------------
+
+``scripts/diagnose_codex_foundry_connection.py`` reports a request plan, and
+that plan used to contain the line ``"retries_configured": 0``. Nothing set it.
+It was a number the script wrote about itself, in a dictionary the runtime
+never reads, while the provider table said nothing about retries at all and the
+runtime therefore used its own defaults — ``request_max_retries`` 4 and
+``stream_max_retries`` 5.
+
+The gap between those two facts is not academic. Measured here, one turn
+against a server that answers HTTP 500 sends **thirty** requests when the
+counters are unset. A diagnostic advertised as one cheap call was, on any
+endpoint that failed the way a misconfigured endpoint usually fails, thirty
+calls. The plan would still have said zero.
+
+So this file does not check that a constant is zero. It starts the pinned
+``codex`` binary, points it at a server on this machine that refuses in four
+different ways, and counts what arrives. Two things are asserted:
+
+1. with the settings this repository ships, one turn is one request — except
+   on 401, where it is two, for a reason no supported key removes;
+2. without the pins, it is not, and by a margin large enough that leaving them
+   unset would be a real bill.
+
+The second half is what keeps the first from being a tautology. A test that
+only measured the pinned case would still pass if the pins stopped being
+emitted and the runtime happened to default to one.
+
+The token is fake
+-----------------
+
+The provider table here is the one ``provider_config_overrides`` builds for a
+real deployment, with exactly two keys rewritten: ``base_url``, so the requests
+arrive on this machine, and ``auth.command``, so the token is a fixed string
+that is not a credential and was never minted.
+:func:`test_only_the_destination_and_the_token_source_are_rewritten` asserts
+that those two are the only differences, so the ``Authorization`` header this
+file observes is produced by the same ``auth.*`` block production emits.
+
+No sandbox is needed
+--------------------
+
+Every turn here dies on an HTTP response, which happens before the agent could
+ask to run anything. So unlike ``test_codex_runtime_end_to_end.py``, this file
+has nothing to skip on a host whose sandbox cannot start — it measures the same
+numbers on the NAS and on a runner.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.codex_runtime_config import (  # noqa: E402
+    AUTH_RETRY_REQUESTS_NOT_REMOVED_BY_PINNING,
+    DEFAULT_REQUEST_MAX_RETRIES,
+    DEFAULT_STREAM_MAX_RETRIES,
+    CodexProviderConfigurationError,
+    CodexProviderLike,
+    CodexProviderSettings,
+    CodexRuntimeUnavailable,
+    _toml_literal,
+    provider_config_overrides,
+    require_pinned_runtime,
+)
+
+_RUNTIME_PROBLEM: str | None = None
+try:
+    require_pinned_runtime()
+except CodexRuntimeUnavailable as exc:  # pragma: no cover - environment shape
+    _RUNTIME_PROBLEM = str(exc)
+
+pytestmark = pytest.mark.skipif(
+    _RUNTIME_PROBLEM is not None,
+    reason=f"the pinned Codex runtime is not installed: {_RUNTIME_PROBLEM}",
+)
+
+#: Not a credential, and shaped so that it could not be mistaken for one in a
+#: log. Nothing mints a token in this file.
+FAKE_TOKEN = "FAKE-TOKEN-NOT-A-CREDENTIAL-0123456789"
+
+#: A settings object with the endpoint shape production uses. Never called: the
+#: table built from it is redirected to loopback before the runtime sees it.
+REAL_SHAPED_SETTINGS = CodexProviderSettings(
+    endpoint="https://example-account.openai.azure.com/openai/v1/",
+    model="a-deployment",
+)
+
+
+# ── The far end of the wire ─────────────────────────────────────────────────
+
+
+class RefusingResponses:
+    """A Responses endpoint that refuses on a script and counts what arrives.
+
+    ``status`` is answered to every request. ``drop=True`` instead writes half
+    an SSE frame and kills the socket, which is the failure the runtime's
+    *stream* retry counter governs rather than its request retry counter — the
+    two are separate settings and only measuring both shows it.
+
+    ``limit`` is a backstop, not a parameter of the experiment: past it the
+    server stops answering so a runaway retry loop ends the test instead of
+    hanging it. :attr:`overran` reports whether it was hit, and every assertion
+    below checks it, because a count of 40 could otherwise mean "40 retries" or
+    "far more than 40, silently truncated".
+    """
+
+    def __init__(self, status: int, *, drop: bool = False, limit: int = 40):
+        self.status = status
+        self.drop = drop
+        self.limit = limit
+        self.calls: list[dict] = []
+        self.overran = False
+        self._lock = threading.Lock()
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *_args):  # noqa: D102 - silence the default
+                pass
+
+            def handle_one_request(self):
+                # The runtime hangs up on us as readily as we hang up on it;
+                # neither is a test failure.
+                try:
+                    super().handle_one_request()
+                except (BrokenPipeError, ConnectionResetError):
+                    self.close_connection = True
+
+            def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler's spelling
+                body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                with outer._lock:
+                    outer.calls.append(
+                        {
+                            "path": self.path,
+                            "headers": {
+                                key.lower(): value
+                                for key, value in self.headers.items()
+                            },
+                            "body_bytes": len(body),
+                        }
+                    )
+                    count = len(outer.calls)
+                    if count > outer.limit:
+                        outer.overran = True
+                if count > outer.limit:
+                    self.close_connection = True
+                    return
+                if outer.drop:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.end_headers()
+                    self.wfile.write(b'data: {"type":"response.created"}\n\n')
+                    self.wfile.flush()
+                    self.close_connection = True
+                    try:
+                        self.connection.close()
+                    except OSError:
+                        pass
+                    return
+                payload = json.dumps(
+                    {"error": {"message": "scripted refusal", "type": "test"}}
+                ).encode()
+                self.send_response(outer.status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._server.daemon_threads = True
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self) -> "RefusingResponses":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=10)
+
+    def authorization_headers(self) -> set[str]:
+        """Every distinct credential header seen, with the fake token masked."""
+        seen: set[str] = set()
+        for call in self.calls:
+            for name in ("authorization", "api-key", "x-api-key"):
+                value = call["headers"].get(name)
+                if value is not None:
+                    seen.add(f"{name}: {value.replace(FAKE_TOKEN, '<FAKE-TOKEN>')}")
+        return seen
+
+
+# ── The provider table, production's minus two keys ─────────────────────────
+
+
+def _token_printer(tmp_path: Path) -> tuple[Path, Path]:
+    """A stand-in auth command: prints the fake token, logs that it ran.
+
+    The log is how the auth-command count is measured. Counting notifications
+    or log lines from the runtime would not answer the question — a retry that
+    re-mints the token is visible only as a second run of this script.
+    """
+    calls = tmp_path / "auth-command-runs.log"
+    script = tmp_path / "print_fake_token.py"
+    script.write_text(
+        "import sys\n"
+        f"open({str(calls)!r}, 'a').write('ran\\n')\n"
+        f"sys.stdout.write({FAKE_TOKEN!r} + chr(10))\n",
+        encoding="utf-8",
+    )
+    return script, calls
+
+
+def _redirected_table(
+    port: int, printer: Path, settings: CodexProviderSettings
+) -> tuple[str, ...]:
+    """``provider_config_overrides(settings)`` with base_url and auth.command
+    rewritten, and nothing else touched."""
+    prefix = f"model_providers.{settings.provider_id}"
+    rewritten: list[str] = []
+    for override in provider_config_overrides(settings):
+        if override.startswith(f"{prefix}.base_url="):
+            rewritten.append(
+                f"{prefix}.base_url="
+                f"{_toml_literal(f'http://127.0.0.1:{port}/v1')}"
+            )
+        elif override.startswith(f"{prefix}.auth.command="):
+            rewritten.append(f"{prefix}.auth.command={_toml_literal(sys.executable)}")
+        elif override.startswith(f"{prefix}.auth.args="):
+            rewritten.append(f"{prefix}.auth.args={_toml_literal([str(printer)])}")
+        else:
+            rewritten.append(override)
+    return tuple(rewritten)
+
+
+class _RedirectedProvider(CodexProviderLike):
+    """Production's provider table, pointed at a server on this machine."""
+
+    def __init__(self, port: int, printer: Path, settings: CodexProviderSettings):
+        self.port = port
+        self.printer = printer
+        self.settings = settings
+        self.model = settings.model
+        self.provider_id = settings.provider_id
+
+    def config_overrides(self) -> tuple[str, ...]:
+        return _redirected_table(self.port, self.printer, self.settings)
+
+
+# ── One turn, measured ──────────────────────────────────────────────────────
+
+
+def _one_turn(
+    tmp_path: Path,
+    *,
+    status: int,
+    drop: bool = False,
+    settings: CodexProviderSettings = REAL_SHAPED_SETTINGS,
+) -> dict:
+    """Send exactly one turn and report what the far end received.
+
+    The stream is consumed rather than merely started. ``Thread.turn`` returns
+    a handle and sends nothing until something iterates it, so a version of
+    this that dropped the ``for`` loop would measure zero requests and read as
+    proof that no retries happen.
+    """
+    from core.codex_runner import CodexAgentRunner, CodexWorkspace
+
+    printer, call_log = _token_printer(tmp_path)
+    with RefusingResponses(status, drop=drop) as server:
+        runner = CodexAgentRunner(
+            _RedirectedProvider(server.port, printer, settings), timeout=90
+        )
+        workspace = CodexWorkspace.create(task_id=f"retry-probe-{status}-{drop}")
+        codex = None
+        try:
+            codex = runner.open_runtime(workspace)
+            thread = runner.start_thread(codex, workspace)
+            handle = thread.turn("Say OK.")
+            try:
+                for _event in handle.stream():
+                    pass
+            except Exception:  # noqa: BLE001 - the refusal is the measurement
+                pass
+        finally:
+            if codex is not None:
+                try:
+                    codex.close()
+                except Exception:  # noqa: BLE001 - teardown, not the subject
+                    pass
+            workspace.cleanup()
+
+        return {
+            "requests": len(server.calls),
+            "overran": server.overran,
+            "auth_command_runs": (
+                len(call_log.read_text(encoding="utf-8").splitlines())
+                if call_log.exists()
+                else 0
+            ),
+            "authorization": server.authorization_headers(),
+            "paths": sorted({call["path"] for call in server.calls}),
+        }
+
+
+# ── What the shipped settings cost ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "status, drop, label",
+    [
+        (429, False, "rate limited"),
+        (500, False, "server error"),
+        (200, True, "connection dropped mid-stream"),
+    ],
+)
+def test_a_refused_turn_sends_one_request_with_the_shipped_settings(
+    tmp_path: Path, status: int, drop: bool, label: str
+):
+    """The pins do what the plan says they do, measured at the socket."""
+    assert DEFAULT_REQUEST_MAX_RETRIES == 0 and DEFAULT_STREAM_MAX_RETRIES == 0
+    measured = _one_turn(tmp_path, status=status, drop=drop)
+    assert not measured["overran"]
+    assert measured["requests"] == 1, f"{label}: {measured}"
+
+
+def test_an_unauthorized_turn_still_costs_two_requests(tmp_path: Path):
+    """The residue the pins do not remove, asserted rather than glossed.
+
+    On 401 the runtime re-runs the provider's auth command and retries once
+    with the fresh token — the behaviour the config reference describes under
+    ``auth.refresh_interval_ms`` ("set to 0 to refresh only after an
+    authentication retry"). Neither retry counter binds it and no documented
+    key switches it off.
+
+    This is asserted at exactly 2 on purpose. If a future runtime removes the
+    retry, this test fails and the constant, the docstring in
+    ``codex_runtime_config`` and the diagnostic's record all get corrected
+    together, instead of the repository quietly keeping a claim that stopped
+    being true.
+    """
+    measured = _one_turn(tmp_path, status=401)
+    assert not measured["overran"]
+    assert measured["requests"] == AUTH_RETRY_REQUESTS_NOT_REMOVED_BY_PINNING == 2
+    assert measured["auth_command_runs"] == 2, (
+        "two requests with one token would be a plain retry; the second token "
+        f"is what identifies this as the auth refresh: {measured}"
+    )
+
+
+# ── What leaving them unset would cost ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "status, drop, at_least",
+    [
+        # 5 request attempts x 6 stream attempts, per the published defaults.
+        (500, False, 20),
+        # The stream counter alone, so the two are shown to be separate keys.
+        (200, True, 4),
+    ],
+)
+def test_leaving_the_counters_unset_multiplies_one_turn(
+    tmp_path: Path, status: int, drop: bool, at_least: int
+):
+    """The measurement that makes the pins worth having.
+
+    Lower bounds rather than exact counts: the numbers observed are 30 and 6,
+    but a runtime that retried slightly differently would still be making the
+    point this test exists to make, and an exact match would turn a patch
+    release into a red build for no reason. The bound is far enough above 1
+    that no amount of drift makes an unpinned turn cheap.
+    """
+    unpinned = CodexProviderSettings(
+        endpoint=REAL_SHAPED_SETTINGS.endpoint,
+        model=REAL_SHAPED_SETTINGS.model,
+        request_max_retries=4,
+        stream_max_retries=5,
+    )
+    measured = _one_turn(tmp_path, status=status, drop=drop, settings=unpinned)
+    assert not measured["overran"]
+    assert measured["requests"] >= at_least, measured
+
+
+# ── Where the token goes ────────────────────────────────────────────────────
+
+
+def test_the_token_arrives_as_an_authorization_bearer_header(tmp_path: Path):
+    """Measured, not inferred from the fact that other callers use this scope.
+
+    That the repository's other Azure paths ask for the same token scope says
+    nothing about what Codex does with the string its ``auth.command`` prints.
+    This observes the header on the wire: the token is carried as
+    ``Authorization: Bearer``, on ``POST /v1/responses``, and not as the
+    ``api-key`` header the legacy Azure route expects.
+    """
+    measured = _one_turn(tmp_path, status=401)
+    assert measured["authorization"] == {"authorization: Bearer <FAKE-TOKEN>"}
+    assert measured["paths"] == ["/v1/responses"]
+    assert measured["auth_command_runs"] >= 1
+
+
+def test_only_the_destination_and_the_token_source_are_rewritten(tmp_path: Path):
+    """The seam between this file and production, made auditable.
+
+    If a later change added a key to the production table, this fails unless
+    the redirected table carries it too — so the header and count measurements
+    above cannot drift into describing a provider nobody uses.
+    """
+    printer, _ = _token_printer(tmp_path)
+    production = list(provider_config_overrides(REAL_SHAPED_SETTINGS))
+    redirected = list(_redirected_table(9999, printer, REAL_SHAPED_SETTINGS))
+    assert len(production) == len(redirected)
+    differing = [
+        original.split("=", 1)[0]
+        for original, rewritten in zip(production, redirected)
+        if original != rewritten
+    ]
+    prefix = f"model_providers.{REAL_SHAPED_SETTINGS.provider_id}"
+    # ``auth.command`` is allowed to coincide rather than required to differ:
+    # production runs the token module with this same interpreter, so
+    # rewriting the command to ``sys.executable`` is often a no-op and only
+    # ``auth.args`` moves. The seam is still exactly these three keys.
+    assert set(differing) <= {
+        f"{prefix}.base_url",
+        f"{prefix}.auth.command",
+        f"{prefix}.auth.args",
+    }
+    assert f"{prefix}.base_url" in differing, "the destination must be redirected"
+    assert f"{prefix}.auth.args" in differing, "the token source must be replaced"
+
+
+# ── The table itself ────────────────────────────────────────────────────────
+
+
+def test_the_provider_table_carries_both_counters_at_zero():
+    """Emitted, not merely defaulted in Python.
+
+    An unset key is the runtime's 4 and 5, so a settings object that held 0 and
+    never wrote it would produce exactly the thirty-request turn this change
+    exists to prevent.
+    """
+    prefix = f"model_providers.{REAL_SHAPED_SETTINGS.provider_id}"
+    overrides = provider_config_overrides(REAL_SHAPED_SETTINGS)
+    assert f"{prefix}.request_max_retries=0" in overrides
+    assert f"{prefix}.stream_max_retries=0" in overrides
+
+
+@pytest.mark.parametrize("value", [-1, True, 1.5, "0", None])
+def test_a_retry_count_that_is_not_a_whole_non_negative_number_is_refused(value):
+    """``True`` is in this list because ``bool`` is an ``int`` and would be
+    rendered into the table as ``true`` — a type error the runtime would report
+    about a config file no operator wrote."""
+    with pytest.raises(CodexProviderConfigurationError):
+        CodexProviderSettings(
+            endpoint=REAL_SHAPED_SETTINGS.endpoint,
+            model=REAL_SHAPED_SETTINGS.model,
+            request_max_retries=value,
+        )
+
+
+def test_no_real_token_is_ever_minted_here(tmp_path: Path):
+    """The auth command handed to the runtime is the fake printer.
+
+    Checked on the table rather than by grepping this file for a module name:
+    what matters is what the runtime is told to run, and the printer's own
+    source is asserted to hold the fake string and nothing that reaches Entra.
+    """
+    printer, _ = _token_printer(tmp_path)
+    table = _redirected_table(9999, printer, REAL_SHAPED_SETTINGS)
+    args_line = next(line for line in table if ".auth.args=" in line)
+    assert str(printer) in args_line
+    assert "--scope" not in args_line
+
+    printed = printer.read_text(encoding="utf-8")
+    assert FAKE_TOKEN in printed
+    assert "azure" not in printed.lower()

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -657,9 +657,44 @@ paid run must be preceded by a fresh smoke at the new fingerprint.
   deployment are separate facts from the documentation, and only a request
   settles them. As of 2026-09-08 the instrument that asks exists (§3c) and
   separates a refused sign-in, a rejected request shape and an absent deployment
-  from one another out of a single turn. It has not been fired. Firing it is a
-  `workflow_dispatch` from `main` with `send_request: true`, and it costs one
-  turn of roughly 135 characters with no tools and no retries.
+  from one another out of a single turn.
+
+  **It has since been fired, and it came back 401.** Run `34319880025`,
+  `send_request: true`, `usage: null`. A workflow that concludes `success` is
+  reporting that the job ran, not that the provider answered; the record inside
+  it says `unauthorized`. The turn cost is unestablished rather than zero —
+  there was no usage to price, and an unpriced turn is not a free one.
+
+  The 401 is an authentication result, not an authorization one. The read-only
+  RBAC diagnostic (run `34325382584`) shows the CI identity holding
+  `Cognitive Services OpenAI User` at the **account** scope, which is the scope
+  governing the `/openai/v1/` route Codex posts to. So the missing Foundry
+  *project* role assignments belong to a different route and are not the
+  demonstrated cause here. What the 401 does *not* establish, and must not be
+  written up as if it did: which of deployment name, region, API contract or
+  credential is wrong. One status code does not locate the fault.
+
+  Firing it is a `workflow_dispatch` from `main` with `send_request: true`. It
+  costs one turn of roughly 135 characters with no tools, and — since the
+  retry pins landed — **one HTTP request**, or two if the answer is another
+  401. Before the pins, "no retries" was a line in the plan dictionary and
+  nothing else: the provider table set neither counter, so the runtime used its
+  own defaults and one turn against a 500 sent **thirty** requests. Measured,
+  not estimated: `batch-runner/tests/test_codex_retry_pins_are_enforced.py`
+  drives the pinned binary against a local server that refuses four different
+  ways and counts what arrives.
+
+  | server answers | counters unset | pinned to 0 |
+  | --- | --- | --- |
+  | HTTP 500 | 30 requests | 1 request |
+  | mid-stream disconnect | 6 requests | 1 request |
+  | HTTP 429 | 1 request | 1 request |
+  | HTTP 401 | 12 requests | **2 requests** |
+
+  The 401 row is the residue pinning does not remove: the runtime re-runs the
+  provider's auth command once after an authentication failure and retries with
+  the fresh token, which no documented key switches off. Two requests, two
+  tokens minted. It is recorded as a bound rather than rounded down to one.
 - **The exec leg is closed, on one host, and it took a repair to close it.** The
   host limit was real and was closed by finding a host rather than by removing
   isolation: no sandbox was disabled, no network was opened, no container was


### PR DESCRIPTION
## 무엇이 잘못돼 있었나

진단 스크립트가 자기 계획서에 `"retries_configured": 0` 이라고 **글자로** 적어두고 있었습니다. 이 값을 설정하는 코드는 없었습니다. 실제 provider 표에는 재시도 키가 아예 없었고, 고정된 0.147.0 런타임은 문서에 적힌 자기 기본값(`request_max_retries` 4, `stream_max_retries` 5)을 썼습니다. 계획서는 그와 무관하게 0을 적었습니다.

## 측정값 (고정 바이너리 + 로컬 모의 서버, 가짜 토큰, 한 턴)

| 서버 응답 | 카운터 미설정 | 0으로 고정 |
|---|---|---|
| HTTP 500 | **요청 30회** | 1회 |
| 스트림 도중 연결 끊김 | **6회** | 1회 |
| HTTP 429 | 1회 | 1회 |
| HTTP 401 | **12회** | **2회** |

30 = 요청 시도 5회 × 스트림 시도 6회. "싼 호출 한 번"이라고 광고된 진단이, 설정이 잘못된 엔드포인트가 실제로 실패하는 바로 그 방식에서 30번 호출이었습니다.

## 무엇을 고쳤나

`CodexProviderSettings`에 `request_max_retries` / `stream_max_retries`를 추가하고 기본값 0, 음이 아닌 정수로 검증하며(`bool`은 거부 — `int`의 하위형이라 표에 `true`로 렌더링됨), **provider 표와 `describe_provider()`에 실제로 방출**합니다. 파이썬 쪽에서만 0으로 들고 표에 안 쓰면 런타임의 4·5가 그대로 쓰이므로, 방출 여부를 테스트가 직접 확인합니다.

## 고정으로 없앨 수 없는 401 잔여분

401은 2회로 줄지 1회가 되지 않습니다. 런타임이 인증 실패 후 provider의 `auth.command`를 한 번 다시 실행하고 새 토큰으로 재시도하기 때문입니다(문서의 `auth.refresh_interval_ms` 설명: "0으로 두면 인증 재시도 이후에만 갱신"). 두 카운터 어느 쪽도 이를 묶지 않고, 이를 끄는 문서화된 키는 없습니다. `AUTH_RETRY_REQUESTS_NOT_REMOVED_BY_PINNING = 2`로 기록하고 **정확히 2로** 단언합니다 — 런타임이 이 동작을 바꾸면 빌드가 빨개지지, 낡은 주장이 조용히 남지 않도록.

지원되지 않는 것을 지원되는 것처럼 적지 않았습니다. 1회로 만들 방법은 없다고 그대로 남겼습니다.

## 진단 스키마 `/2`

`retries_configured`는 이제 **실제로 쓰이는 설정에서 읽고**, 설정이 주어지지 않으면 `None`("기록 못 함")입니다. 아무도 확인하지 않은 0이 아닙니다. `describe_settings()`가 두 카운터를 포함하므로 설정 지문이 함께 움직입니다. 스키마 `/1`을 가진 커밋된 산출물은 없고, 워크플로 어디도 이 필드를 읽지 않습니다.

## 테스트가 상수를 검사하지 않는 이유

새 테스트는 고정 바이너리를 실제로 띄워, 네 가지로 거절하는 loopback 서버에 붙이고, **도착한 요청 수를 셉니다**. 오류 알림 수를 요청 수로 세지 않습니다. 고정하지 않은 경우(하한 20·4)도 함께 측정하므로, 핀이 방출되지 않게 되고 런타임 기본값이 우연히 1이 되어도 통과해버리는 항진명제가 되지 않습니다. 토큰은 가짜 문자열을 출력하는 대역 스크립트가 냅니다 — 실제 토큰은 이 파일에서 한 번도 발급되지 않습니다.

토큰 전송 형식도 **측정**했습니다: `POST /v1/responses`에 `Authorization: Bearer`로 실립니다(`api-key` 헤더가 아님). 저장소의 다른 경로가 같은 scope를 쓴다는 사실로부터 추론한 것이 아닙니다. `test_only_the_destination_and_the_token_source_are_rewritten`이 프로덕션 표와의 차이가 `base_url`·`auth.command`·`auth.args` 세 키뿐임을 단언하므로, 관측한 헤더는 프로덕션이 만드는 `auth.*` 블록이 만든 것입니다.

## 채점기 지문 이동 — B가 읽어야 할 부분

`core/codex_runtime_config.py`는 `compute_grader_source_hash`의 입력입니다(`step8_grade.py:229`, `core.rglob("*")` 중 `.py`). 측정 결과:

- `3d51e7cc`(현재 main): `ee1ca0b0…` — 342 §2와 여전히 일치
- 이 브랜치: `7e745a18…`
- 가격표: `b01b384c…` **변동 없음**

따라서 **342 §0의 지문 행은 앞으로의 유료 발주에 한해 다시 열립니다**(343 §5.1). 무언가를 구매하기 전에 병합된 SHA에서 다시 측정해야 하며, `ee1ca0b0…`을 그대로 들고 가면 안 됩니다. 이미 끝난 337/342/343 실행 기록 자체는 덮어쓰지 않았습니다 — 실행 당시 값 그대로입니다.

B는 자기 고정 SHA에서 작업하므로 main 전체 동결이 필요 없습니다. 병합 시점 기준 `grade-run.yml`의 최근 20개 실행은 모두 `completed`이므로 진행 중인 채점 샤드도 없습니다.

## 검증

- `tests/test_codex_retry_pins_are_enforced.py` 15 passed (38.24s) — 고정 런타임이 설치돼 있으므로 CI에서 skip이 아니라 실제로 실행됩니다(`requirements.txt`에 `openai-codex==0.147.0`, `openai-codex-cli-bin==0.147.0`).
- 백엔드 전체: **9191 passed, 12 skipped, 45 deselected** (20m40s), exit 0
- mypy: 변경한 두 파일 오류 0 (다른 파일의 기존 오류 7건은 이 PR과 무관)
