### PR TITLE
fix(codex): call the auth command instead of passing the method to subprocess

### DIFF
--- a/.github/workflows/codex-foundry-connection-diagnostic.yml
+++ b/.github/workflows/codex-foundry-connection-diagnostic.yml
@@ -258,6 +258,14 @@ jobs:
       # no record at all is a bug in this repository, and the step fails, which
       # also stops the paid turn below. Failing closed here costs a dispatch;
       # the other way round costs a request nobody could account for.
+      #
+      # A failed *mint* is the same category as a missing record, and run
+      # 34340775246 is why that is written down rather than assumed. It burned
+      # a real OIDC login, reported `success`, and measured nothing: the probe
+      # read `settings.auth_command` without calling it, so the token error was
+      # `'method' object is not iterable` — our defect, filed in the record
+      # beside the host's answers where a reader could take it for one. The
+      # check below now separates "the host refused" from "we never asked".
       - name: Ask the host what it will admit to, without sending a turn
         id: readonly
         working-directory: batch-runner
@@ -274,13 +282,30 @@ jobs:
           test -s /tmp/codex-foundry-readonly.json
           python3 - <<'PY'
           import json
+          import sys
+
           record = json.load(open("/tmp/codex-foundry-readonly.json"))
           listing = record.get("listing") or {}
-          print("token minted by the child process:", record["token"]["minted"])
+          token = record["token"]
+          print("token minted by the child process:", token["minted"])
           print("listing status:", listing.get("status"))
           print("models listed:", listing.get("models_listed"))
           print("the asked-for deployment is in the listing:",
                 listing.get("deployment_listed"))
+
+          # A refusal is a finding and this step keeps going for it: 401 is the
+          # answer we came for as much as 200 is. Never getting as far as the
+          # host is not a finding — it says nothing about the resource, and a
+          # green step there is how run 34340775246 looked like it had measured
+          # something while the argv was wrong. Fail, which also stops the paid
+          # turn below: a job that could not mint a token has no business
+          # buying one.
+          if not token["minted"]:
+              print("::error::the probe never reached the host: the token could "
+                    "not be minted, so this run measures nothing about the "
+                    "resource. This is an environment or code fault, not a "
+                    "refusal.")
+              sys.exit(1)
           PY
 
       # The one request. Skipped entirely unless it was asked for, so the
@@ -482,6 +507,12 @@ jobs:
             echo "재현한 것이고, 문제는 토큰 자체입니다. 배포가 목록에"
             echo "\`False\`로 없으면 그 이름이 이 자원에 없다는 뜻입니다."
             echo "다만 목록이 열린다고 해서 **호출이 허용된다는 뜻은 아닙니다.**"
+            echo ""
+            echo "토큰을 만들었는가가 \`False\`면 위 두 줄은 **아무 뜻도 없습니다.**"
+            echo "그건 자원이 무엇이라고 답한 게 아니라 **묻지를 못한 것**이고,"
+            echo "이 실행은 이 자원에 대해 아무것도 측정하지 않았습니다. 실행"
+            echo "\`34340775246\`이 정확히 그랬습니다 — 초록불이었지만 잰 게"
+            echo "없었습니다. 그래서 지금은 그 경우 단계가 **실패로 끝납니다.**"
             echo ""
             echo "이 줄이 뜻하는 것: Codex 런타임이 만든 요청 한 번을 실제 배포에"
             echo "보내고, 그쪽이 무엇이라고 답했는지를 이름 붙여 기록한 것입니다."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,39 @@ entries land under a fresh dated heading the day they merge to `main`.
   this merged.
 
 ### Fixed
+- **The read-only probe never reached the host, and reported it as though the
+  host had answered.** `auth_command` is a *method* on `CodexProviderSettings`;
+  the probe read it without calling it, so `subprocess.run` was handed a bound
+  method and `'method' object is not iterable` landed in the record's
+  `token.error` field beside the host's answers. Run `34340775246` burned a
+  real OIDC login producing that, finished green, and settled none of the three
+  outcomes it exists to separate.
+
+  Three repairs, because the calling convention was the least of it:
+
+  - the probe calls `settings.auth_command()` and **checks the argv's shape
+    before starting a child process**, raising a message that says this is a
+    defect in the probe rather than an answer from the host;
+  - the test helper that substituted the command defined it as a `@property`.
+    That is not the shape production has, so every minting test read a value
+    and passed while production got a method — a helper modelling the wrong
+    shape tests the helper. It is a method now, and one test uses the
+    **unmodified** settings object against a stub auth module so the argv
+    production builds is exercised with nothing overridden. Reintroducing the
+    original defect now turns 5 tests red; before the helper was fixed it
+    turned 0 red;
+  - the workflow step **fails** when the token could not be minted. A refusal
+    is a finding and the step keeps going for it; never reaching the host is
+    not a finding, and a green step there is how the run looked like it had
+    measured something. Failing there also blocks the paid turn, since a job
+    that cannot mint a token has no business buying one.
+
+  What the run *did* settle, read off the record rather than the network: the
+  probe was aimed at the same host that returned the 401
+  (`endpoint_host_fingerprint` byte-identical to run `34319880025`'s), and the
+  retry pins are live in the settings object the job actually built
+  (`request_max_retries: 0`, `stream_max_retries: 0`) rather than only in
+  tests. The 401 itself remains unlocated.
 - **The workflow's leak check would have crashed on the record it was being
   asked to check.** It indexed `record["observed"]` unconditionally, which the
   read-only record has no key for, so publishing one would have raised

--- a/batch-runner/scripts/diagnose_codex_foundry_connection.py
+++ b/batch-runner/scripts/diagnose_codex_foundry_connection.py
@@ -925,8 +925,26 @@ def mint_token_the_way_codex_does(
     """
     import subprocess
 
+    # `auth_command` is a method on the settings object, not a field. Reading it
+    # without calling it yields a bound method, which `subprocess.run` accepts
+    # and then fails on inside the standard library with "'method' object is not
+    # iterable" -- a message naming neither this file nor the attribute. Run
+    # 34340775246 spent a real OIDC login to produce exactly that, and reported
+    # it as a `token.error` where a reader could mistake it for the host having
+    # refused. Resolve the argv here and check its shape, so a wrong one is
+    # named before any child process starts.
+    argv = settings.auth_command()
+    if not isinstance(argv, (list, tuple)) or not all(
+        isinstance(item, str) for item in argv
+    ):
+        raise RuntimeError(
+            "the provider's auth command did not resolve to a list of strings; "
+            f"got {type(argv).__name__}. This is a defect in this probe or in "
+            "the settings object, not an answer from the host."
+        )
+
     completed = subprocess.run(  # noqa: S603 - argv built by the settings object
-        settings.auth_command,
+        argv,
         capture_output=True,
         text=True,
         timeout=timeout,

--- a/batch-runner/tests/test_codex_readonly_token_probe.py
+++ b/batch-runner/tests/test_codex_readonly_token_probe.py
@@ -40,10 +40,12 @@ writes, and the listing is served by a socket on this machine.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -144,8 +146,18 @@ def _printer(tmp_path: Path, *, token: str = FAKE_TOKEN, code: int = 0) -> Path:
 
 
 def _with_auth_command(settings: CodexProviderSettings, argv: list[str]):
+    """Swap the argv, keeping ``auth_command`` a *method* like the real one.
+
+    This was a ``@property`` once, and that is how run ``34340775246`` reached a
+    real Azure login before failing on ``'method' object is not iterable``:
+    every test here read ``settings.auth_command`` as a value and passed, while
+    production reads it off a class where it is a method and got a bound method
+    object instead of argv. A helper that models the wrong shape does not test
+    the code, it tests the helper. Overriding it as a method means these tests
+    exercise the same call the real settings object requires.
+    """
+
     class _Fixed(type(settings)):  # type: ignore[misc]
-        @property
         def auth_command(self) -> list[str]:
             return argv
 
@@ -223,6 +235,73 @@ def test_the_token_comes_from_the_child_process_stdout(tmp_path: Path):
         _settings(9999), [sys.executable, str(_printer(tmp_path))]
     )
     assert mint_token_the_way_codex_does(settings) == FAKE_TOKEN
+
+
+def test_the_argv_comes_from_the_unmodified_settings_object(tmp_path: Path):
+    """No override anywhere: production's own ``auth_command`` builds the argv.
+
+    Every other test in this section substitutes the command, which is what let
+    a wrong calling convention survive review and reach a real Azure login in
+    run ``34340775246``. Here nothing is substituted. ``CodexProviderSettings``
+    builds ``[python, '-m', auth_module, '--scope', scope]`` itself, and the
+    only thing arranged is that ``auth_module`` names a module on ``sys.path``
+    that prints a fake token. If the probe ever again reads the attribute
+    without calling it, or the settings object changes how the argv is built,
+    this fails before a workflow spends a login finding out.
+    """
+    module = tmp_path / "stub_auth_module.py"
+    module.write_text(
+        "import sys\n"
+        # The real module takes --scope; accepting and ignoring it here keeps
+        # the argv production builds valid rather than merely tolerated.
+        "assert '--scope' in sys.argv, sys.argv\n"
+        f"sys.stdout.write({FAKE_TOKEN!r} + chr(10))\n",
+        encoding="utf-8",
+    )
+
+    class _StubModule(CodexProviderSettings):
+        pass
+
+    settings = _StubModule(
+        endpoint="https://example-account.openai.azure.com/openai/v1/",
+        model="a-deployment",
+        auth_module="stub_auth_module",
+        python_executable=sys.executable,
+    )
+
+    argv = settings.auth_command()
+    assert isinstance(argv, list) and all(isinstance(item, str) for item in argv)
+
+    env = dict(os.environ, PYTHONPATH=str(tmp_path))
+    with mock.patch.dict(os.environ, env, clear=True):
+        assert mint_token_the_way_codex_does(settings) == FAKE_TOKEN
+
+
+def test_an_argv_that_is_not_a_list_is_named_here_not_inside_subprocess(
+    tmp_path: Path,
+):
+    """The failure run 34340775246 hit, reported as our defect rather than a host's answer.
+
+    ``subprocess.run`` given a bound method raises ``'method' object is not
+    iterable`` from inside the standard library — a message naming neither this
+    probe nor the attribute, which the record then filed under ``token.error``
+    where it reads like the resource said something. The probe checks the shape
+    itself so the message says whose fault it is.
+    """
+
+    class _Broken(CodexProviderSettings):
+        def auth_command(self):  # type: ignore[override]
+            return "python -m something"  # a string, not argv
+
+    settings = _Broken(
+        endpoint="https://example-account.openai.azure.com/openai/v1/",
+        model="a-deployment",
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        mint_token_the_way_codex_does(settings)
+    message = str(excinfo.value)
+    assert "did not resolve to a list of strings" in message
+    assert "not an answer from the host" in message
 
 
 def test_a_failing_auth_command_withholds_its_stdout(tmp_path: Path):

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -746,6 +746,44 @@ paid run must be preceded by a fresh smoke at the new fingerprint.
   Model names are counted, never written down. A failing auth command has its
   **stdout withheld** while stderr is quoted, because stdout is where a token
   would be.
+- **It was fired, and it measured nothing — the fault was ours.** Run
+  `34340775246` (`send_request: false`, no turn sent, job green). The record
+  says `token.minted: false`, `listing: null`, and the error is
+  `'method' object is not iterable`: `auth_command` is a *method* on
+  `CodexProviderSettings` and the probe read it without calling it, so
+  `subprocess.run` was handed a bound method. **None of the three outcomes in
+  the table above is answered.** The 401 remains unlocated.
+
+  Two things the run *did* settle, because they are read off the record rather
+  than off the network:
+
+  * the host it was pointed at is the host that got the 401 —
+    `endpoint_host_fingerprint: sha256:69057d59166a82e3`, byte-identical to run
+    `34319880025`'s. The probe was aimed correctly;
+  * the retry pins are live in the real settings object, not only in tests:
+    `retries: {request_max_retries: 0, stream_max_retries: 0}` appears in the
+    settings the job actually built.
+
+  The deployment asked for was `gpt-5.4`, the same name run `34319880025` used.
+
+  Three repairs, so the shape of this mistake cannot repeat quietly:
+
+  1. the probe calls `settings.auth_command()` and **checks the argv's shape
+     itself**, raising a message that says whose defect it is rather than
+     letting the standard library raise one that names neither this file nor
+     the attribute;
+  2. the test helper that substituted the command was defining it as a
+     `@property` — modelling a shape production does not have. Every minting
+     test read a value and passed while production got a method. It is a method
+     now, and one test uses the **unmodified** settings object with a stub auth
+     module so the argv production builds is exercised with nothing overridden.
+     Reintroducing the original defect turns 5 of these tests red; before the
+     helper was fixed it turned 0 red;
+  3. the workflow step now **fails** when the token could not be minted. A
+     refusal is a finding and the step keeps going for it; never reaching the
+     host is not a finding, and a green step there is exactly how this run
+     looked like it had measured something. Failing there also blocks the paid
+     turn — a job that cannot mint a token has no business buying one.
 - **The exec leg is closed, on one host, and it took a repair to close it.** The
   host limit was real and was closed by finding a host rather than by removing
   isolation: no sandbox was disabled, no network was opened, no container was


### PR DESCRIPTION
## 무슨 일이 있었나

실행 `34340775246` — 무과금 읽기 전용 조회를 실제 자원에 걸었다.
**초록불이 떴고, 잰 건 아무것도 없었다.**

```
"token": { "minted": false, "error": "'method' object is not iterable" }
"listing": null
```

`auth_command`는 `CodexProviderSettings`의 **메서드**다. 조회기가 그걸
**부르지 않고 읽어서** `subprocess.run`에 바운드 메서드를 넘겼다. 실제
OIDC 로그인을 한 번 쓰고, 자식 프로세스는 시작도 못 했다.

**세 갈래 결과 중 아무것도 답이 안 나왔다.** `34319880025`의 401은
**여전히 어디가 문제인지 모른다.**

## 왜 시험이 이걸 못 잡았나 — 이게 본론이다

토큰을 만드는 시험이 6개 있었고 전부 통과했다. 대체 헬퍼가 이렇게 돼 있었다:

```python
class _Fixed(type(settings)):
    @property                      # ← production에는 없는 모양
    def auth_command(self): ...
```

시험은 **값**을 읽었고 production은 **메서드**를 받았다. 잘못된 모양을
흉내내는 헬퍼는 코드를 시험하는 게 아니라 헬퍼를 시험한다.

## 고친 것 셋

1. **조회기가 `settings.auth_command()`를 부르고, argv 모양을 직접
   확인한다.** 틀리면 "이건 호스트의 답이 아니라 이 조회기의 결함이다"라고
   말하는 오류를 낸다 — 표준 라이브러리가 내는 메시지는 이 파일도 이
   속성도 안 가리켰다.
2. **헬퍼가 메서드를 정의한다.** 그리고 새 시험 하나는 **아무것도 안
   덮어쓴** 진짜 설정 객체로, `auth_module`만 가짜 토큰을 찍는 대역
   모듈로 두고 production이 만드는 argv를 그대로 굴린다.
   **원래 결함을 다시 넣으면 이제 시험 5개가 빨개진다. 헬퍼를 고치기
   전에는 0개였다.**
3. **워크플로 단계가 토큰을 못 만들면 실패한다.** 거절은 발견이고 그럴
   땐 계속 간다. 호스트에 닿지도 못한 건 발견이 아니다 — 그런데 초록불이
   뜨는 게 바로 이번 실행이 뭘 잰 것처럼 보인 이유다. 여기서 실패하면
   **유료 턴도 막힌다**: 토큰도 못 만드는 작업이 턴을 살 이유가 없다.

## 이번 실행이 그래도 확정한 것 두 가지

기록에서 읽은 것이지 네트워크에서 온 게 아니다:

* **겨눈 곳은 맞았다.** `endpoint_host_fingerprint: sha256:69057d59166a82e3` —
  401을 받은 실행 `34319880025`의 값과 **바이트까지 같다.**
* **재시도 0 못이 실제 설정 객체에 살아 있다.** 시험 안에서만이 아니라,
  이 작업이 실제로 만든 설정에 `request_max_retries: 0`,
  `stream_max_retries: 0`이 찍혀 있다. (#467이 한 일)

물어본 배포는 `gpt-5.4`로, `34319880025`가 쓴 것과 같은 이름이다.

## 안 하는 것

* **비용을 `$0`으로 안 적는다.** 턴은 안 나갔지만, 이 실행이 쓴 로그인과
  러너 시간은 이 문서가 값을 매기지 않는다.
* 401의 원인을 안 적는다. **아직 모른다.** 이 PR은 알아낼 도구를 고친다.
* 채점기 지문 **안 움직인다**:
  `7e745a18ce53889eae23a0fb66e824d9d1c38b65c74293aeaf1148f17362d865`
  (`core/`는 한 줄도 안 건드렸다).
