### PR TITLE
feat(audio): run 344's verdict where the run happens

### DIFF
--- a/.github/workflows/audio-accuracy-probe.yml
+++ b/.github/workflows/audio-accuracy-probe.yml
@@ -352,6 +352,54 @@ jobs:
               print(f"- pairs available for the arm comparison: {comparison['pairs']}")
           PY
 
+      # 344 §6's verdict, on the rehearsal. The same checker the paid job
+      # runs, with the same seven conditions, so "the plan is ten requests and
+      # the run makes ten" gets settled here for nothing rather than
+      # discovered on the dispatch that was bought to answer something else.
+      #
+      # What a rehearsal cannot answer it says it cannot answer. The replies
+      # come from a stub, so the two arm conditions come back `unanswerable`
+      # and the best verdict reachable here is `rehearsal_ok`. A free run
+      # reporting `format_held` would be the experiment replaced by its own
+      # scaffolding, and the checker has no flag that permits it.
+      #
+      # The exit code is carried rather than swallowed. This step ticks a §0
+      # precondition, and a rehearsal that came back `inconclusive` -- wrong
+      # pin, short call count, no ledger -- under a green tick would clear a
+      # paid dispatch using the very finding that should have stopped it. It
+      # is carried *after* the summary is written, so the reason is on the
+      # page even when the step is red.
+      - name: Check the rehearsal against 344 §6
+        if: ${{ always() && inputs.corpus == 'speech-format-pilot-v3' }}
+        run: |
+          set -uo pipefail
+          cd batch-runner
+          if [ ! -f "$GITHUB_WORKSPACE/audio-accuracy-dry-run.json" ]; then
+            echo "::warning::no report, so there is no rehearsal to check"
+            exit 0
+          fi
+          python scripts/verify_format_pilot_run.py \
+            "$GITHUB_WORKSPACE/audio-accuracy-dry-run.json" \
+            --out "$GITHUB_WORKSPACE/format-pilot-v3-rehearsal-verdict.json" \
+            | tee "$GITHUB_WORKSPACE/format-pilot-v3-rehearsal-verdict.txt"
+          rc=${PIPESTATUS[0]}
+          {
+            echo "## 344 §6 — rehearsal"
+            echo
+            echo '```'
+            cat "$GITHUB_WORKSPACE/format-pilot-v3-rehearsal-verdict.txt"
+            echo '```'
+            echo
+            echo "\`rehearsal_ok\` means the run's **shape** held: the pins match"
+            echo "the plan, ten requests went out, one per call, and a ledger"
+            echo "recorded them. It says **nothing** about whether"
+            echo "\`gpt-audio-1.5\` returns readable JSON for the candidate"
+            echo "header — the replies here came from a stub. That question"
+            echo "costs money and is asked once, on the paid dispatch."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "verify exit: $rc"
+          exit "$rc"
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: audio-accuracy-dry-run
@@ -372,9 +420,12 @@ jobs:
             audio-cost-metering-rehearsal.jsonl
           if-no-files-found: warn
 
-      # 344's rehearsal ledger, on the same terms. The rehearsal is where the
-      # §0 precondition "the plan is 10 calls and the run makes 10" is checked
-      # for nothing, and that check reads rows.
+      # 344's rehearsal ledger, on the same terms, and the verdict computed
+      # from it. The rehearsal is where the §0 precondition "the plan is 10
+      # calls and the run makes 10" is checked for nothing, and that check
+      # reads rows -- so the rows and the reading of them travel together. A
+      # verdict that lives only in a step log expires with the run, which is
+      # exactly how `337` ended up with a per-call record nobody can produce.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() && inputs.corpus == 'speech-format-pilot-v3' }}
         with:
@@ -382,6 +433,8 @@ jobs:
           path: |
             format-pilot-v3-rehearsal.sqlite3
             format-pilot-v3-rehearsal.jsonl
+            format-pilot-v3-rehearsal-verdict.json
+            format-pilot-v3-rehearsal-verdict.txt
           if-no-files-found: warn
 
   # ---------------------------------------------------------------------------
@@ -652,6 +705,52 @@ jobs:
             echo "question and this run does not ask it. \`inconclusive\` means"
             echo "nothing failed and something went unanswered; read which"
             echo "condition before reading it as a pass."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "verify exit: $rc"
+          exit "$rc"
+
+      # The verdict this run was bought for. The step above asks whether the
+      # spend reached a ledger; this one asks 344 §6's question -- did the
+      # candidate header come back as readable JSON where `337`'s did not --
+      # off the report alone, with no model and no socket.
+      #
+      # Written before the run it judges, which is the whole point of it.
+      # 5-of-5 is the bar, 4-of-5 is `format_lost`, and there is no flag here
+      # that turns one into the other once the number is on the screen.
+      #
+      # `always()` and a carried exit code for the same reasons as the step
+      # above, and one more: `format_lost` closes the candidate, and a closure
+      # that shipped under a green tick is a closure nobody reads.
+      - name: Check the pilot against 344 §6
+        if: ${{ always() && inputs.corpus == 'speech-format-pilot-v3' }}
+        run: |
+          set -uo pipefail
+          cd batch-runner
+          if [ ! -f "$GITHUB_WORKSPACE/audio-accuracy-measured.json" ]; then
+            echo "::warning::no report, so there is no pilot to check"
+            exit 0
+          fi
+          python scripts/verify_format_pilot_run.py \
+            "$GITHUB_WORKSPACE/audio-accuracy-measured.json" \
+            --out "$GITHUB_WORKSPACE/format-pilot-v3-verdict.json" \
+            | tee "$GITHUB_WORKSPACE/format-pilot-v3-verdict.txt"
+          rc=${PIPESTATUS[0]}
+          {
+            echo "## 344 §6 — the pilot"
+            echo
+            echo '```'
+            cat "$GITHUB_WORKSPACE/format-pilot-v3-verdict.txt"
+            echo '```'
+            echo
+            echo "The gate is the **envelope**, not the grading: did a reply"
+            echo "parse. Whether a verdict was *right* is 337/338's question and"
+            echo "this run does not ask it. The usable-verdict count is on the"
+            echo "page beside the gate and is **reported, not gated** — it is the"
+            echo "number most easily promoted into a result it cannot support."
+            echo
+            echo "\`format_lost\` closes the candidate. 344 §6 says a failure is"
+            echo "not grounds for re-ordering, so what follows that word is a"
+            echo "cause to investigate, not another dispatch."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "verify exit: $rc"
           exit "$rc"
@@ -1110,7 +1209,9 @@ jobs:
       # 344's paid ledger, for the reason directly above and one more. Its
       # approval is written as a request count -- at most ten -- so the rows
       # are how anyone afterwards can say what was actually sent. 337 has no
-      # such file, and that is why 340 had to be written.
+      # such file, and that is why 340 had to be written. The §6 verdict rides
+      # with the rows it was computed from, so the two cannot drift apart into
+      # a claim on one page and the evidence on another.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() && inputs.corpus == 'speech-format-pilot-v3' }}
         with:
@@ -1118,4 +1219,6 @@ jobs:
           path: |
             format-pilot-v3-measured.sqlite3
             format-pilot-v3-measured.jsonl
+            format-pilot-v3-verdict.json
+            format-pilot-v3-verdict.txt
           if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,30 @@ entries land under a fresh dated heading the day they merge to `main`.
   perfect candidate), a short run, an early stop, a retried call, a
   substituted header, a moved grader, mismatched claims, a missing ledger,
   and a paid run reporting `$0`.
+- **The `344` verdict is now computed where the run happens, on both the free
+  job and the paid one.** A checker that lives in the repository and is called
+  by nothing is a precondition satisfied on paper, and `344` §0 ticks boxes on
+  two checks that only exist in CI. `audio-accuracy-probe.yml` gains a step in
+  each job: the rehearsal is read from `audio-accuracy-dry-run.json`, the
+  pilot from `audio-accuracy-measured.json`, and each writes a verdict file
+  that is uploaded **with the ledger rows it was computed from** — `337`'s
+  per-call record lived only in an artifact, the artifact expired, and `340`
+  had to be written to say the numbers could no longer be produced.
+
+  Both steps run under `always()` and **carry the checker's exit code**, after
+  the summary is written so the reason is on the page when the step is red. A
+  rehearsal that came back `inconclusive` — wrong pin, short call count, no
+  ledger — under a green tick would clear a paid dispatch using the finding
+  that should have stopped it. Four tests break the workflow four ways (the
+  rehearsal step pointed at the paid filename, which would skip *silently*;
+  a swallowed exit code; the verdict files dropped from the upload; the steps
+  made conditional on success) and each goes red.
+- **What the checker actually opens, in its own docstring.** It said "the
+  report and the ledger export beside it"; it reads the report and the
+  pre-registration, and the ledger *reference* comes from inside the report's
+  cost block. The difference matters for a tool whose case rests on naming
+  exactly what it looks at — and it means a report stays checkable after the
+  `.sqlite3` beside it is gone.
 
 ### Fixed
 - **How `446acfd` came to sit red, since #469 fixed it without the two dates

--- a/batch-runner/scripts/verify_format_pilot_run.py
+++ b/batch-runner/scripts/verify_format_pilot_run.py
@@ -6,8 +6,11 @@ readable JSON where 337's did not. The answer is a count, and a count is easy
 to read the way you were hoping. So the reading is written down here, before
 the run, and done by a program afterwards.
 
-It reads the run's JSON report and the ledger export beside it, and nothing
-else. No model call, no credential, no network::
+It reads two files and nothing else: the run's JSON report, and the
+pre-registration whose pins the run is held to. Not the ledger database --
+the ledger *reference* is inside the report's own cost block, which is what
+condition 7 reads, so a report can be checked long after the ``.sqlite3``
+beside it has gone. No model call, no credential, no network::
 
     cd batch-runner
     python scripts/verify_format_pilot_run.py path/to/report.json

--- a/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
+++ b/batch-runner/tests/test_audio_accuracy_probe_knows_its_own_answers.py
@@ -7040,3 +7040,117 @@ def test_recording_the_reply_does_not_change_the_request(tmp_path: Path) -> None
     on = _sent_requests(probe.SHAPE_EXCERPT_CHARS)
     assert off and len(off) == len(on)
     assert off == on, "the shape record changed what went on the wire"
+
+
+# ---------------------------------------------------------------------------
+# Part D -- the verdict has to run where the run runs.
+#
+# 344 §0 ticks two boxes on checks that happen in CI: the rehearsal, and the
+# paid pilot's §6 reading. A checker that exists in the repository but is
+# called by nothing is a precondition satisfied on paper. These hold the
+# workflow to calling it, on the right file, and to carrying what it found.
+# ---------------------------------------------------------------------------
+
+
+def test_the_rehearsal_is_judged_by_the_same_checker_the_paid_run_uses(
+) -> None:
+    """§0 ticks a box on the free run, so the free run has to be read.
+
+    The rehearsal exists to clear a paid dispatch. If nothing reads its
+    report, "ten requests were planned and ten went out" is a claim somebody
+    eyeballs on a summary page -- which is the family of mistake that let
+    `337` buy ten calls without a ledger and notice three documents later.
+    """
+    check = _step("dry-run", "Check the rehearsal against 344 §6")
+    assert "always()" in check["if"], (
+        "a rehearsal that stopped early still has a shape worth reading"
+    )
+    assert "speech-format-pilot-v3" in check["if"]
+    body = check["run"]
+    assert "verify_format_pilot_run.py" in body
+    # The dry-run job writes `audio-accuracy-dry-run.json`; the paid job
+    # writes `audio-accuracy-measured.json`. Pointing this step at the paid
+    # name would make it skip on every rehearsal -- and skip *silently*,
+    # because the step's own missing-file branch exits 0 on purpose.
+    assert "audio-accuracy-dry-run.json" in body
+    assert "audio-accuracy-measured.json" not in body
+    # `set -e` would abandon the step at the checker's non-zero exit, before
+    # the summary that explains what its verdict word means.
+    assert "set -uo pipefail" in body
+    assert 'exit "$rc"' in body
+    assert body.index("GITHUB_STEP_SUMMARY") < body.index('exit "$rc"')
+
+
+def test_the_paid_run_is_judged_on_the_envelope_and_the_page_says_so() -> None:
+    """Two checkers on one job, two questions, and neither answers the other.
+
+    `verify_audio_metering_run.py` asks whether the spend reached a ledger;
+    this one asks 344 §6's question. A reader who takes `measured_ok` for an
+    answer about the header, or `format_held` for an answer about whether the
+    grading was *right*, has read a verdict that does not cover it. So each
+    step states on the page what its own word leaves open.
+    """
+    check = _step("measure", "Check the pilot against 344 §6")
+    assert "always()" in check["if"]
+    assert "speech-format-pilot-v3" in check["if"]
+    body = check["run"]
+    assert "verify_format_pilot_run.py" in body
+    assert "audio-accuracy-measured.json" in body
+    assert "set -uo pipefail" in body
+    assert 'exit "$rc"' in body
+    assert body.index("GITHUB_STEP_SUMMARY") < body.index('exit "$rc"')
+    # The gate is the envelope. The usable-verdict count sits beside it and
+    # is not the gate -- it is the number a reader most wants to promote into
+    # a result, so the page has to say which one it is.
+    assert "reported, not gated" in body
+    # And that a loss is a loss. §6 forbids re-ordering on a failure, and the
+    # page is where somebody decides what to do next.
+    assert "not grounds for re-ordering" in body
+
+
+def test_both_verdicts_are_uploaded_beside_the_rows_that_back_them() -> None:
+    """A verdict in a step log expires with the run. The rows do too.
+
+    `337` is why this is a test and not a habit: its per-call record existed
+    only in a CI artifact, the artifact expired, and `340` had to be written
+    to say the numbers could no longer be produced. The verdict travels with
+    the ledger it was computed from, so a claim and its evidence cannot end
+    up on two different pages with different lifetimes.
+    """
+    for job, ledger_file, verdicts in (
+        ("dry-run", "format-pilot-v3-rehearsal.sqlite3",
+         ("format-pilot-v3-rehearsal-verdict.json",
+          "format-pilot-v3-rehearsal-verdict.txt")),
+        ("measure", "format-pilot-v3-measured.sqlite3",
+         ("format-pilot-v3-verdict.json", "format-pilot-v3-verdict.txt")),
+    ):
+        uploads = [
+            step for step in _workflow()["jobs"][job]["steps"]
+            if str(step.get("uses", "")).startswith("actions/upload-artifact")
+            and ledger_file in step["with"]["path"]
+        ]
+        assert uploads, f"{job} does not upload {ledger_file}"
+        step = uploads[0]
+        assert "always()" in step["if"], (
+            f"{job}: a stopped run's rows are the ones nobody planned for"
+        )
+        for name in verdicts:
+            assert name in step["with"]["path"], f"{job}: {name} is not uploaded"
+
+
+def test_the_two_jobs_write_verdict_files_under_different_names() -> None:
+    """A rehearsal's verdict must not be readable as the pilot's.
+
+    Both jobs run the same checker and both upload what it wrote. If the two
+    used one filename, the free artifact and the paid one would differ only
+    by which run produced them -- and `rehearsal_ok` sitting in a file called
+    `format-pilot-v3-verdict.json` is precisely the confusion `343` was
+    written to stop for the metering ledgers.
+    """
+    dry = _step("dry-run", "Check the rehearsal against 344 §6")["run"]
+    paid = _step("measure", "Check the pilot against 344 §6")["run"]
+    assert "format-pilot-v3-rehearsal-verdict.json" in dry
+    assert "format-pilot-v3-verdict.json" in paid
+    # Not a substring of each other's name, either: `--out` writing
+    # `...-rehearsal-verdict.json` contains no path the paid step also writes.
+    assert "format-pilot-v3-rehearsal-verdict" not in paid


### PR DESCRIPTION
## 무엇을 하나요 (What this does)

`verify_format_pilot_run.py` shipped in #470 and **nothing calls it.** A checker
that sits in the repository and is invoked by no job is a §0 precondition
satisfied on paper. This wires it into the two places the run actually happens.

344 §0 ticks boxes on two checks that only exist in CI — the free rehearsal, and
the paid pilot's §6 reading. Neither can be done on this box: there is no eSpeak
here, so the clips do not exist locally.

## The two steps

| job | reads | writes | best reachable verdict |
|---|---|---|---|
| `dry-run` | `audio-accuracy-dry-run.json` | `format-pilot-v3-rehearsal-verdict.{json,txt}` | `rehearsal_ok` |
| `measure` | `audio-accuracy-measured.json` | `format-pilot-v3-verdict.{json,txt}` | `format_held` |

Both are gated on `inputs.corpus == 'speech-format-pilot-v3'`, so every other
corpus is untouched.

**The filenames are the trap.** The two jobs write reports under different names.
Pointing the rehearsal step at `audio-accuracy-measured.json` would make it skip
on *every* rehearsal — and skip **silently**, because the missing-file branch
exits 0 on purpose (a run that stopped before writing a report should not be
reported as a failed verdict). Green tick, no verdict, nobody the wiser. A test
asserts each step names its own file and not the other one.

## Why the exit code is carried

Both steps run under `always()` and end `exit "$rc"`, after the summary is
written.

A rehearsal that came back `inconclusive` — wrong pin, short call count, no
ledger — under a green tick would clear a paid dispatch **using the very finding
that should have stopped it.** The summary goes first so the reason is on the
page when the step is red.

## Why the verdicts ride with the ledger

`337` is the reason. Its per-call record existed only in a CI artifact, the
artifact expired, and `340` had to be written to say the numbers could no longer
be produced. A verdict in a step log has exactly that lifetime. So each verdict
file is added to the upload that already carries the ledger rows it was computed
from — the two cannot be separated later.

## The four break-tests

Each was run against a deliberately broken workflow and each went red; the file
was then restored byte-identical (`diff -q`).

1. rehearsal step pointed at the paid filename → caught
2. exit code swallowed → caught
3. verdict files dropped from the upload → caught
4. `always()` removed → caught

## Also: a docstring that named the wrong file

`verify_format_pilot_run.py:9` said it reads "the report and the ledger export
beside it." It does not. It reads the report and the pre-registration; the
ledger *reference* comes from inside the report's own cost block, which is what
condition 7 reads — which is why a report stays checkable long after the
`.sqlite3` beside it is gone. `grep` confirms only two read sites exist in the
file. For a tool whose entire case rests on naming exactly what it opens, that
sentence had to be right.

Found while reading my own merged code in #470; deferred to here rather than
restart that PR's CI.

## Verification

- new tests: **4 passed**
- the two touched files: **254 passed, 1 skipped** in 24.31s
- full backend suite: **9255 passed, 12 skipped, 45 deselected** in 19:34, exit 0
- YAML parses; 4 jobs; no duplicate step names
- `git diff --name-only origin/main | grep batch-runner/core/` → **none** (lane separation with A's Codex work)

## Not fixed here, on purpose

`main` has no CI trigger. Two individually-green PRs can therefore leave `main`
red — as happened at `446acfd` for ~70 minutes on 2026-09-08, which is what the
CHANGELOG `### Fixed` entry explains. Fixing it means editing the workflow
triggers, which is A's lane this week. Recorded, not touched.

## Cost

**Nothing is dispatched and nothing is bought by this PR.** It makes the *free*
rehearsal readable, which is the next §0 box. Five §0 boxes remain ⬜ before any
paid call is possible.
