### PR TITLE
ci(backend-tests): start a run for the tree the suite asserts about

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -36,13 +36,51 @@ on:
       # could add the flag that makes the job claim access it was never given
       # and nothing would fire.
       - ".github/workflows/execution-envelope-preflight.yml"
+      # The line above was right about the principle and too narrow by four
+      # directories. The suite reads the repository outside batch-runner/ far
+      # more widely than the two workflow files named above, measured by
+      # resolving every repo-root-relative path literal in batch-runner/tests/
+      # against the tree:
+      #
+      #   .github/  30 literals across 25 test files  (grade-run.yml alone: 17)
+      #   data/     35 literals across 26 test files
+      #   tasks/    36 literals across 25 test files
+      #   infra/     6 literals across  2 test files
+      #   src/       1 literal  across  1 test file
+      #
+      # None of those four started a run. That is not hypothetical either: #468
+      # edited a pinned hash in tasks/rebuilding_grading_task/ and merged with
+      # no run of this suite, and main went red -- which is the same failure
+      # #179 caused and which the header above says this workflow exists to
+      # close. Enumerating single files is what let the gap open twice, so
+      # these are directory globs: a new assertion about a new workflow or a
+      # new task document is covered the day it is written, without anybody
+      # remembering to come back here.
+      #
+      # data/** was the one worth checking rather than assuming, since it
+      # carries grading results. Measured over the last 60 commits on main it
+      # appears in 3 of them, against 165 for batch-runner/ -- and most commits
+      # that touch data/ touch batch-runner/ too, so they already started a
+      # run. The bot-authored result PRs cannot start a `pull_request` run at
+      # all (see above), so this reaches human PRs only. Tests do assert about
+      # what is in data/grades: row counts, the file cap, ledger pointers. A
+      # grades commit that breaks one of those should be caught by the gate
+      # rather than by somebody running pytest locally.
+      - ".github/workflows/**"
+      - "data/**"
+      - "tasks/**"
+      - "infra/**"
+      - "src/**"
   push:
     branches: [main]
     paths:
       - "batch-runner/**"
       - "scripts/**"
-      - ".github/workflows/backend-tests.yml"
-      - ".github/workflows/execution-envelope-preflight.yml"
+      - ".github/workflows/**"
+      - "data/**"
+      - "tasks/**"
+      - "infra/**"
+      - "src/**"
   workflow_dispatch:
     inputs:
       expected_sha:
@@ -64,7 +102,15 @@ concurrency:
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45, not 30, because 30 was inside the noise. Run 34341659511 was
+    # cancelled by the old ceiling at 86% and its re-run of the identical tree
+    # passed in 22:10; twelve runs before it took 18-22 minutes. A cancelled
+    # run is reported as a failure, so a ceiling that close to the mean turns
+    # a slow runner into a red gate and trains people to re-run rather than
+    # read. This is headroom for runner variance, not for a slower suite: if
+    # the suite itself starts taking 40 minutes, that is a finding and this
+    # number should not be raised again to hide it.
+    timeout-minutes: 45
     steps:
       # A dispatch names a branch, and a branch is a moving pointer. Between the
       # caller measuring the PR head and this run starting, the branch can be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Fixed
+- **The backend gate now starts a run for the tree it asserts about.**
+  `backend-tests.yml` filtered on `batch-runner/**`, `scripts/**` and two
+  workflow files by name. Resolving every repo-root-relative path literal in
+  `batch-runner/tests/` against the tree found five directories that started no
+  run at all: `.github/` (30 literals across 25 test files), `data/` (35 across
+  26), `tasks/` (36 across 25), `infra/` (6 across 2) and `src/` (1 across 1).
+
+  That is not a theoretical gap. #468 edited a pinned hash under
+  `tasks/rebuilding_grading_task/`, started no run of this suite, merged, and
+  left `main` red -- the same failure #179 caused and the one this workflow was
+  written to prevent. Enumerating single files is what let the gap open twice,
+  so the filter is directory globs now: a new assertion about a new workflow or
+  a new task document is covered the day it is written.
+
+  `data/**` was checked rather than assumed, since it carries grading results:
+  over the last 60 commits on `main` it appears in 3, against 165 for
+  `batch-runner/`, and most commits touching it touch `batch-runner/` too and
+  already started a run. The bot-authored result PRs cannot start a
+  `pull_request` run at all, so this reaches human PRs only -- and tests do
+  assert about what is in `data/grades`.
+
+  Two assertions in `test_the_free_check_runs_in_ci.py` were checking literal
+  membership in the `paths` list, which scored the *wider* filter as a
+  regression while continuing to pass for one that named a single workflow and
+  missed twenty-nine other workflow references. They check coverage now,
+  through a written-out translation of GitHub's glob rules -- `*` stops at a
+  slash and `**` does not, which `fnmatch` gets wrong in the direction that
+  restores false confidence. Removing `tasks/**` turns the check red with a
+  message naming the file that would go ungated.
+
+  The job timeout goes 30 -> 45 minutes. Run `34341659511` was cancelled by the
+  old ceiling at 86% and its re-run of the identical tree passed in 22:10, with
+  the twelve runs before it taking 18-22 minutes. A cancelled run is reported
+  as a failure, so a ceiling that close to the mean turns runner variance into
+  a red gate. This is headroom for that variance, not for a slower suite.
+
 ### Added
 - **The connection question now has a free half: the token is minted the way
   Codex mints it, and the host is asked to list its models.**

--- a/batch-runner/tests/test_the_free_check_runs_in_ci.py
+++ b/batch-runner/tests/test_the_free_check_runs_in_ci.py
@@ -37,6 +37,40 @@ import yaml
 
 BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
 REPOSITORY_ROOT = BATCH_RUNNER_ROOT.parent
+
+
+def _covers(patterns: list[str], target: str) -> bool:
+    """Does any GitHub path filter in ``patterns`` start a run for ``target``?
+
+    Written because asserting literal membership scored a *wider* filter as a
+    regression: replacing the two named workflow files with
+    ``.github/workflows/**`` starts a run for strictly more edits, and the old
+    assertion failed on it while continuing to pass for a filter that named one
+    file and missed twenty-nine other workflow references the suite asserts
+    about. What the assertions below actually need is that the file reaches the
+    gate, not that its name appears in a particular form.
+
+    GitHub's globs are not ``fnmatch``'s -- ``*`` stops at a slash and ``**``
+    does not -- so the translation is written out here. Handing these to
+    ``fnmatch`` would call ``.github/*`` a match for a file two directories
+    down and quietly restore the same false confidence.
+    """
+    for pattern in patterns:
+        regex = ""
+        index = 0
+        while index < len(pattern):
+            if pattern.startswith("**", index):
+                regex += ".*"
+                index += 2
+            elif pattern[index] == "*":
+                regex += "[^/]*"
+                index += 1
+            else:
+                regex += re.escape(pattern[index])
+                index += 1
+        if re.fullmatch(regex, target):
+            return True
+    return False
 if str(BATCH_RUNNER_ROOT) not in sys.path:
     sys.path.insert(0, str(BATCH_RUNNER_ROOT))
 
@@ -863,20 +897,31 @@ def test_the_trigger_is_wide_enough_that_the_job_actually_starts(workflow):
     assert "workflow_dispatch" in triggers
     for event in ("pull_request", "push"):
         paths = triggers[event]["paths"]
-        assert "batch-runner/**" in paths, event
-        assert (
-            ".github/workflows/execution-envelope-preflight.yml" in paths
+        assert _covers(paths, "batch-runner/core/config.py"), event
+        assert _covers(
+            paths, ".github/workflows/execution-envelope-preflight.yml"
         ), event
     assert triggers["push"]["branches"] == ["main"]
 
 
 def test_the_tests_holding_this_workflow_are_themselves_reachable():
-    """This file must run when the workflow it asserts about is edited.
+    """Every part of the tree this suite asserts about must start a run.
 
-    These tests are run by backend-tests.yml, whose path filter did not list
-    .github/workflows/. A pull request editing only the workflow -- adding
-    --azure-route-served, say -- would have started no run of this file, and
-    every assertion above would have been decoration.
+    These tests are run by backend-tests.yml, whose path filter listed
+    batch-runner/, scripts/ and two workflow files by name. The suite reads far
+    more than that. Resolving every repo-root-relative path literal in
+    batch-runner/tests/ against the tree found five directories that started no
+    run: .github/ (30 literals, 25 test files), data/ (35, 26), tasks/ (36,
+    25), infra/ (6, 2) and src/ (1, 1).
+
+    That gap was not theoretical. #468 edited a pinned hash under
+    tasks/rebuilding_grading_task/, started no run of this suite, merged, and
+    left main red -- the same failure #179 caused and the one backend-tests.yml
+    was written to prevent.
+
+    Each entry below is a real file some test in this suite reads. A filter
+    that stops starting a run for one of them turns that test into decoration,
+    so this fails rather than letting the next narrowing land quietly.
     """
     backend = yaml.safe_load(
         (REPOSITORY_ROOT / ".github/workflows/backend-tests.yml").read_text(
@@ -885,14 +930,25 @@ def test_the_tests_holding_this_workflow_are_themselves_reachable():
     )
     triggers = backend.get("on", backend.get(True))
 
+    asserted_about = (
+        ".github/workflows/execution-envelope-preflight.yml",
+        ".github/workflows/grade-run.yml",
+        ".github/workflows/batch-run.yml",
+        "batch-runner/core/config.py",
+        "scripts/aggregate-grades.mjs",
+        "tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md",
+        "tasks/rebuilding_grading_task/300-gold-ceiling.md",
+        "infra/dev-host/main.bicep",
+    )
+
     for event in ("pull_request", "push"):
-        assert (
-            ".github/workflows/execution-envelope-preflight.yml"
-            in triggers[event]["paths"]
-        ), (
-            f"backend-tests.yml does not run on {event} for the workflow this "
-            "file asserts about, so these assertions gate nothing"
-        )
+        paths = triggers[event]["paths"]
+        for target in asserted_about:
+            assert _covers(paths, target), (
+                f"backend-tests.yml does not run on {event} for {target}, "
+                "which tests in this suite read, so those assertions gate "
+                "nothing"
+            )
 
 
 # ── the fixed conditions the free check cannot see for itself ─────────────


### PR DESCRIPTION
## What this fixes

`backend-tests.yml` filtered on `batch-runner/**`, `scripts/**` and two workflow files **by name**. The suite reads the repository much more widely than that.

Measured by resolving every repo-root-relative path literal in `batch-runner/tests/` against the actual tree — counting only literals that name a file which exists:

| directory | path literals | test files |
|---|---|---|
| `.github/` | 30 | 25 |
| `data/` | 35 | 26 |
| `tasks/` | 36 | 25 |
| `infra/` | 6 | 2 |
| `src/` | 1 | 1 |

None of those started a run. `.github/workflows/grade-run.yml` alone is referenced 17 times by tests that could not fire when it changed.

**This is not hypothetical.** #468 edited a pinned hash under `tasks/rebuilding_grading_task/`, started no run of this suite, merged, and left `main` red — the same failure #179 caused, and the one the header comment in this workflow says it exists to close. It opened twice because the filter names single files; these are directory globs so a new assertion about a new workflow or task document is covered the day it is written.

`data/**` was checked rather than assumed, since it carries grading results: over the last 60 commits on `main` it appears in **3**, against 165 for `batch-runner/` — and most commits touching it touch `batch-runner/` too, so they already started a run.

## The tests that guarded this were guarding the wrong thing

Two assertions in `test_the_free_check_runs_in_ci.py` checked **literal membership** in the `paths` list. That scored the *wider* filter as a regression — `.github/workflows/**` covers strictly more than the one filename they looked for — while continuing to pass for a filter that missed twenty-nine other workflow references.

They check **coverage** now, via a written-out translation of GitHub's glob rules. `fnmatch` is not used deliberately: it would call `.github/*` a match for a file two directories down, which is the direction that restores false confidence. The helper is unit-checked on that exact case.

Adversarially verified: removing `tasks/**` turns the check red with a message naming the file that would go ungated.

## Timeout 30 → 45

Run `34341659511` was **cancelled by the old ceiling at 86%**, and its re-run of the identical tree passed in **22:10**; the twelve runs before it took 18–22 minutes. A cancelled run is reported as a failure, so a ceiling that close to the mean turns runner variance into a red gate and trains people to re-run instead of read. This is headroom for variance, not for a slower suite — the comment says so, so that a genuinely slower suite is not hidden by raising it again.

## Checks

- Full backend suite on this branch: **9257 passed, 12 skipped, 45 deselected, exit 0** (19:40)
- Grader source hash unmoved: `7e745a18ce53889eae23a0fb66e824d9d1c38b65c74293aeaf1148f17362d865` (no `core/` change)