### PR TITLE
feat(diag): sweep one request property at a time for the one that closes the gate

### DIFF
--- a/.github/workflows/codex-foundry-connection-diagnostic.yml
+++ b/.github/workflows/codex-foundry-connection-diagnostic.yml
@@ -397,6 +397,80 @@ jobs:
               sys.exit(1)
           PY
 
+      # Where the discriminator left the question. The bearer clears this
+      # host's gate under `urllib` and the runtime is refused at it with the
+      # control arm's sentence word for word, so the difference is in what the
+      # runtime puts on the wire and `urllib` does not. Four transmission
+      # explanations were measured offline against the pinned binary and all
+      # four are false: the header is present, it carries `Bearer `, its value
+      # is exactly what the auth command printed, and no second credential
+      # rides alongside.
+      #
+      # So this adds the rest, one property at a time, to a request already
+      # known to clear the gate. A 400 that becomes a 401 names a property
+      # that changes how this host authorizes. Nothing changing names the
+      # body, which is the other place left to look.
+      #
+      # Cost: seven requests, none of which names a model, so none can select
+      # a deployment or generate anything. That is an argument, not a receipt
+      # -- a refusal returns no usage record, so these are unpriced rather
+      # than proven free, and the record says so in `not_established`.
+      #
+      # What it cannot show: these arms are `urllib`, not the runtime. A
+      # property that closes the gate here is where to look next. It is not a
+      # demonstrated cause of the turn's refusal, and it is not a reason to
+      # request a role.
+      #
+      # `|| true` for the reason the steps above give: `sweep_inconclusive`
+      # exits non-zero and is a finding worth keeping, not a broken job.
+      - name: Ask which request property closes a gate the plain request clears
+        id: transmission_sweep
+        working-directory: batch-runner
+        env:
+          AZURE_AI_ROUTE_PROFILE: direct-v1
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
+          DEPLOYMENT: ${{ inputs.deployment }}
+        run: |
+          set -euo pipefail
+          python3 scripts/diagnose_codex_foundry_connection.py \
+            --deployment "${DEPLOYMENT}" \
+            --transmission-sweep \
+            --out /tmp/codex-foundry-transmission-sweep.json || true
+          test -s /tmp/codex-foundry-transmission-sweep.json
+          python3 - <<'PY'
+          import json
+          import sys
+
+          record = json.load(open("/tmp/codex-foundry-transmission-sweep.json"))
+          print("token minted by the child process:", record["token"]["minted"])
+          print("requests planned:", record["requests_planned"],
+                "sent:", record["requests_sent"])
+          for name, arm in (record["arms"] or {}).items():
+              print(f"  {name:28s} -> {arm.get('status')}"
+                    f"  same text as control: {arm.get('same_message_as_control')}")
+          print("  control                      ->",
+                (record["control"] or {}).get("status"))
+          print("closed the gate:", record["properties_that_closed_the_gate"])
+          print("verdict:", record["verdict"])
+          print("what that means:", record["verdict_note"])
+
+          if not record["token"]["minted"]:
+              print("::error::the sweep never reached the host: the token could "
+                    "not be minted, so this run measures nothing about the "
+                    "resource. This is an environment or code fault, not a "
+                    "refusal.")
+              sys.exit(1)
+
+          # The count on the wire, not the constant. A sweep that sent fewer
+          # requests than it planned measured fewer properties than it reports
+          # on, and would read as a null result for arms that never went.
+          if record["requests_sent"] != record["requests_planned"]:
+              print(f"::error::the sweep planned {record['requests_planned']} "
+                    f"requests and sent {record['requests_sent']}. The arms that "
+                    f"did not go are not evidence about anything.")
+              sys.exit(1)
+          PY
+
       # The one request. Skipped entirely unless it was asked for, so the
       # difference between a free run and a paid one is a deliberate input and
       # not a forgotten flag.
@@ -484,6 +558,7 @@ jobs:
               "/tmp/codex-foundry-plan.json",
               "/tmp/codex-foundry-readonly.json",
               "/tmp/codex-foundry-auth-discriminator.json",
+              "/tmp/codex-foundry-transmission-sweep.json",
               "/tmp/codex-foundry-connection.json",
           ):
               if not os.path.exists(path):
@@ -502,18 +577,21 @@ jobs:
                           f"{path}: contains a URL that is not the public token scope"
                       )
               record = json.loads(text)
-              # Three record shapes now land here and only one of them observes
+              # Four record shapes now land here and only one of them observes
               # a turn. Branch on the record's own schema rather than on
               # whether the key happens to be present: `.get("observed", {})`
               # would turn a renamed field in the connection record into a
               # silent pass, and this check exists precisely to catch a claim
-              # nobody measured. The two free shapes are matched by prefix and
-              # the turn shape is the `else`, so a *new* free record added
+              # nobody measured. The three free shapes are matched by prefix
+              # and the turn shape is the `else`, so a *new* free record added
               # without touching this list fails closed rather than skipping.
+              # It has now done that once, for real, on the sweep record --
+              # which is the whole argument for writing it this way.
               schema = str(record.get("schema", ""))
               if schema.startswith((
                   "codex_foundry_readonly_probe/",
                   "codex_foundry_auth_discriminator/",
+                  "codex_foundry_transmission_sweep/",
               )):
                   if record["inference_requested"] is not False:
                       leaked.append(f"{path}: a free-probe record claims a request was made")
@@ -553,6 +631,7 @@ jobs:
             /tmp/codex-foundry-plan.json
             /tmp/codex-foundry-readonly.json
             /tmp/codex-foundry-auth-discriminator.json
+            /tmp/codex-foundry-transmission-sweep.json
             /tmp/codex-foundry-connection.json
           if-no-files-found: warn
           retention-days: 90
@@ -588,6 +667,14 @@ jobs:
           AD_MINTED="$(python3 -c "import json,sys;print((json.load(open(sys.argv[1]))['arms']['minted_bearer'] or {}).get('status'))" "$AD" 2>/dev/null || echo 'unknown')"
           AD_CONTROL="$(python3 -c "import json,sys;print((json.load(open(sys.argv[1]))['arms']['invalid_bearer_control'] or {}).get('status'))" "$AD" 2>/dev/null || echo 'unknown')"
           AD_SAME="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['same_message_as_control'])" "$AD" 2>/dev/null || echo 'unknown')"
+          TS=/tmp/codex-foundry-transmission-sweep.json
+          TS_VERDICT="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['verdict'])" "$TS" 2>/dev/null || echo 'not measured')"
+          TS_NOTE="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['verdict_note'])" "$TS" 2>/dev/null || echo 'not measured')"
+          TS_SENT="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['requests_sent'])" "$TS" 2>/dev/null || echo 'unknown')"
+          TS_PLANNED="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['requests_planned'])" "$TS" 2>/dev/null || echo 'unknown')"
+          TS_BASELINE="$(python3 -c "import json,sys;print((json.load(open(sys.argv[1]))['arms'].get('baseline') or {}).get('status'))" "$TS" 2>/dev/null || echo 'unknown')"
+          # An empty list prints as nothing and would read as "not measured".
+          TS_CLOSED="$(python3 -c "import json,sys;v=json.load(open(sys.argv[1]))['properties_that_closed_the_gate'];print(', '.join(v) if v else 'none — nothing closed it')" "$TS" 2>/dev/null || echo 'not measured')"
           {
             echo "### Codex → Foundry, one turn"
             echo ""
@@ -649,6 +736,41 @@ jobs:
             echo "이 실행은 이 자원에 대해 아무것도 측정하지 않았습니다. 실행"
             echo "\`34340775246\`이 정확히 그랬습니다 — 초록불이었지만 잰 게"
             echo "없었습니다. 그래서 지금은 그 경우 단계가 **실패로 끝납니다.**"
+            echo ""
+            echo "### 무과금 전송 차이 좁히기 (턴 없음)"
+            echo ""
+            echo "- 보낸 요청 수: \`${TS_SENT}\` / 계획 \`${TS_PLANNED}\`"
+            echo "- 아무것도 안 붙인 기본 요청: \`${TS_BASELINE}\`"
+            echo "- 문을 닫아 버린 성질: \`${TS_CLOSED}\`"
+            echo "- 판정: \`${TS_VERDICT}\`"
+            echo "- 뜻: ${TS_NOTE}"
+            echo ""
+            echo "이게 무엇을 한 것인지: **똑같은 토큰**이 파이썬으로 보내면"
+            echo "문을 통과하는데 Codex로 보내면 막힙니다. 그래서 Codex만"
+            echo "덧붙이는 것들 — \`Accept: text/event-stream\`, \`originator\`,"
+            echo "세션·턴 헤더 6개, 본문의 \`stream: true\` — 을 **통과가 확인된"
+            echo "요청에 하나씩** 얹어 가며, 어느 것이 문을 닫는지 봤습니다."
+            echo "모든 요청은 여전히 **모델 이름이 없어서** 아무것도 생성될 수"
+            echo "없습니다."
+            echo ""
+            echo "- 어떤 성질에서 \`400\`이 \`401\`로 뒤집혔다면 → **그게 다음에"
+            echo "  볼 곳입니다.**"
+            echo "- 아무것도 안 뒤집혔다면 → 원인은 이 진단이 보낼 수 없는"
+            echo "  **본문 쪽**(모델·지시문·도구 10개)이나 전송 계층입니다."
+            echo "  이것도 답입니다."
+            echo ""
+            echo "**한계를 분명히:** 이 화살들은 전부 \`urllib\`이지 Codex 런타임이"
+            echo "아닙니다. 여기서 문을 닫은 성질은 **다음에 볼 후보**이지 턴의"
+            echo "401의 **증명된 원인이 아닙니다.** 그리고 어느 쪽으로 나오든"
+            echo "**역할을 달라고 할 근거가 아닙니다.** 거절에는 사용량 기록이"
+            echo "없으므로 이 요청들의 비용은 **미확정**이며 0달러가 아닙니다."
+            echo ""
+            echo "**\`400\`을 잘못 읽지 않기:** \`400\`은 *답할 수 없는* 요청이 문을"
+            echo "지나 안에서 걸렸다는 뜻입니다. 이건 **검사 순서**(토큰을 본문보다"
+            echo "먼저 본다)를 말해 줄 뿐, 이 신원이 **추론을 실행해도 되는지**는"
+            echo "말해 주지 않습니다. 그걸 보여 줄 수 있는 유일한 요청은 *답할 수"
+            echo "있는* 요청인데, 그건 이 진단이 절대 보내지 않는 바로 그것입니다."
+            echo "그래서 여기서 무엇이 나오든 **220문제가 돌아간다는 뜻이 아닙니다.**"
             echo ""
             echo "이 줄이 뜻하는 것: Codex 런타임이 만든 요청 한 번을 실제 배포에"
             echo "보내고, 그쪽이 무엇이라고 답했는지를 이름 붙여 기록한 것입니다."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,64 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **A free sweep that asks which request property closes a gate the plain
+  request already clears — and states, in the record, that clearing a gate is
+  not permission to do the work.** `--transmission-sweep` in
+  `batch-runner/scripts/diagnose_codex_foundry_connection.py`, wired as an
+  ungated step in the connection-diagnostic workflow.
+
+  Run `34361684546` established the check order this reads against: the same
+  unservable body got `400 Missed model deployment` with a minted bearer and
+  `401 invalid subscription key` with an obviously invalid one. The bearer
+  clears the gate under `urllib`. The Codex runtime, sending *the same token*,
+  gets the `401` — byte-for-byte the invalid-token text. Four transmission
+  hypotheses were closed offline against a fake token and a local mock (header
+  present, `Bearer` scheme, value uncorrupted 38→38, no second credential), so
+  the difference is somewhere else in what the runtime adds.
+
+  The sweep takes the request already known to clear the gate and adds one
+  Codex-specific property per arm — `Accept: text/event-stream`, `originator`
+  and user-agent, the six session/turn headers, `stream: true` — plus a
+  combination arm, and looks for the `400` flipping to `401`. Arms are
+  **isolated, not cumulative**: cumulative makes the first flip attributable
+  to nothing narrower than "this group or an earlier one", and the extra
+  request buys "this property is sufficient" instead.
+
+  The replayed values are **measured, not guessed**. Extending the turn
+  recorder to keep header *values* showed `originator: codex_python_sdk` — not
+  the `codex_cli_rs` a guess would have used — and `Accept: text/event-stream`
+  rather than `application/json`. A `needs_runtime` test binds both to the
+  pinned binary, so a version bump that changed either reddens a test instead
+  of quietly sweeping a string nobody sends.
+
+  No arm names a model, and that is enforced with a `ValueError` raised before
+  the token is minted rather than left to review. Every run re-tests its own
+  premise twice — that the control is still stopped at the gate, and that the
+  baseline still clears it — and reports `sweep_inconclusive` rather than
+  naming five properties as causes on a host where none is doing anything.
+
+  What the record refuses to claim, in every run: these arms are `urllib` and
+  not the runtime, so a property that closes the gate here is **where to look
+  next, not the proven cause**; the ~45 KB body is not tested; the transport
+  layer is not varied; a named property is **not a reason to request a role**;
+  and — the distinction a `400` most invites collapsing — this reads **the
+  order the host checks a request in, not what the identity may do.** Clearing
+  the gate with an unservable body shows authorization is checked before the
+  body is read. It does not show a servable body would be served, because no
+  arm here is one. Nothing about this moves 220 tasks to runnable.
+
+  Refusals carry no usage record, so these requests are **unpriced rather than
+  proven free**; they are not $0.
+
+### Fixed
+- **The redaction check crashed on the record it was meant to protect.** It
+  branches on schema prefix, with the two free shapes matched by prefix and the
+  paid turn shape as the `else` — deliberately, so that an unregistered record
+  fails closed. The sweep record was unregistered, so it took the `else` and
+  died on `record["observed"]`, which a free record does not have. In CI that
+  fails the check, skips `Keep the record`, and loses the record *after* its
+  seven requests are spent. The design worked exactly as its comment promised;
+  registering `codex_foundry_transmission_sweep/` is the other half of it.
 - **A measurement of what one Codex turn actually puts on the wire, replacing
   two claims that were true of narrower things than they were asserted about.**
   `batch-runner/tests/test_what_one_codex_turn_actually_sends.py` drives the

--- a/batch-runner/scripts/diagnose_codex_foundry_connection.py
+++ b/batch-runner/scripts/diagnose_codex_foundry_connection.py
@@ -1187,26 +1187,38 @@ def post_malformed_turn(
     token: str,
     *,
     timeout: int = READ_ONLY_TIMEOUT_SECONDS,
+    extra_headers: Mapping[str, str] | None = None,
+    body: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """``POST {base_url}/responses`` with a body the route cannot serve.
 
     The refusal *text* is kept, redacted, because two arms returning the same
     sentence is itself evidence: a host that answers a minted bearer exactly
     what it answers a fixed non-token is not distinguishing between them.
+
+    ``extra_headers`` and ``body`` default to nothing and to
+    ``MALFORMED_TURN_BODY``, so the discriminator's two arms are unchanged by
+    their existence. They are here for the sweep below, which varies one
+    request property at a time; a body passed in must still name no model, and
+    the sweep is where that is enforced rather than here.
     """
     import urllib.error
     import urllib.request
 
-    payload = json.dumps(MALFORMED_TURN_BODY).encode("utf-8")
+    payload = json.dumps(MALFORMED_TURN_BODY if body is None else dict(body)).encode(
+        "utf-8"
+    )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    headers.update(dict(extra_headers or {}))
     request = urllib.request.Request(  # noqa: S310 - scheme fixed by classify_endpoint
         f"{settings.base_url}/responses",
         method="POST",
         data=payload,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        },
+        headers=headers,
     )
     outcome: dict[str, Any] = {
         "requested": "POST /responses",
@@ -1217,18 +1229,18 @@ def post_malformed_turn(
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
             outcome["status"] = int(response.status)
-            body = response.read().decode("utf-8", "replace")
+            answer = response.read().decode("utf-8", "replace")
     except urllib.error.HTTPError as exc:
         outcome["status"] = int(exc.code)
         try:
-            body = exc.read().decode("utf-8", "replace")
+            answer = exc.read().decode("utf-8", "replace")
         except Exception:  # noqa: BLE001 - a body we cannot read is not a crash
-            body = ""
+            answer = ""
     except Exception as exc:  # noqa: BLE001 - a transport failure is a finding
         outcome["error"] = f"{type(exc).__name__}: {exc}"
         return outcome
 
-    outcome["message"] = _message_in(body)
+    outcome["message"] = _message_in(answer)
     return outcome
 
 
@@ -1404,6 +1416,312 @@ def auth_discriminator_probe(
     return record
 
 
+# ── Which request property closes the gate ──────────────────────────────────
+#
+# Run 34361684546 established the check order on this host: a plainly invalid
+# bearer is stopped at the gate (401), and the minted bearer gets past it to
+# the part that reads the body (400). The Codex runtime, sending *the same
+# minted token to the same URL*, is answered 401 with the control arm's
+# sentence word for word.
+#
+# Four transmission explanations were measured offline against the pinned
+# binary and all four are false: the `authorization` header is present, it
+# carries the `Bearer ` scheme, its value is exactly what the auth command
+# printed, and no second credential header rides alongside. So what is left is
+# everything else the runtime puts on the wire that `urllib` does not.
+#
+# This sweep adds those, one property at a time, to a request already known to
+# clear the gate — and whose body still names no model, so no arm can select a
+# deployment or generate anything. A 400 that turns into a 401 names a property
+# that changes how this host authorizes. Nothing turning names the body, and
+# that is a result too.
+#
+# What a flip does *not* establish is spelled out in the record: this is still
+# urllib, not the runtime, and a property that closes the gate here is a
+# candidate for the turn's refusal, not a demonstrated cause of it.
+
+SWEEP_SCHEMA = "codex_foundry_transmission_sweep/1"
+
+#: Stands in for every identifier the runtime generates per session. The real
+#: ones name this machine's installation; the question is whether the *header*
+#: changes the answer, and a synthetic value of the same shape asks that
+#: without putting an installation identifier on someone else's host.
+SYNTHETIC_ID = "00000000-0000-7000-8000-000000000000"
+
+#: Measured off the wire, not guessed — the guess would have been wrong twice.
+#: The originator is `codex_python_sdk`, not the `codex_cli_rs` the CLI sends,
+#: and the runtime asks for `text/event-stream`, not JSON.
+CODEX_ACCEPT = "text/event-stream"
+CODEX_ORIGINATOR = "codex_python_sdk"
+CODEX_USER_AGENT = "codex_python_sdk/0.147.0 (unknown; x86_64) unknown"
+
+#: The six remaining headers the working `openai.OpenAI` client never sends.
+#: Values are shape-preserving stand-ins; `x-codex-turn-metadata` is real JSON
+#: with real keys because a gateway that parses it would reject a placeholder
+#: for the wrong reason, and none of its values identify anything.
+CODEX_RUNTIME_HEADERS: dict[str, str] = {
+    "session-id": SYNTHETIC_ID,
+    "thread-id": SYNTHETIC_ID,
+    "x-client-request-id": SYNTHETIC_ID,
+    "x-codex-window-id": f"{SYNTHETIC_ID}:0",
+    "x-codex-beta-features": "remote_compaction_v2",
+    "x-codex-turn-metadata": json.dumps(
+        {
+            "installation_id": SYNTHETIC_ID,
+            "session_id": SYNTHETIC_ID,
+            "thread_id": SYNTHETIC_ID,
+            "turn_id": SYNTHETIC_ID,
+            "window_id": f"{SYNTHETIC_ID}:0",
+            "request_kind": "turn",
+            "sandbox": "seccomp",
+            "turn_started_at_unix_ms": 0,
+        },
+        separators=(",", ":"),
+    ),
+}
+
+#: One arm per property, plus a combination. Isolated rather than cumulative:
+#: cumulative arms make the first flip un-attributable to anything narrower
+#: than "this group or an earlier one", and the extra request buys the
+#: difference between "this property is sufficient" and "something before it
+#: was". The combination arm is what catches a property that only closes the
+#: gate in company.
+SWEEP_ARMS: tuple[tuple[str, dict[str, str], dict[str, Any] | None, str], ...] = (
+    (
+        "baseline",
+        {},
+        None,
+        "the discriminator's minted arm, re-sent in this run so the comparison "
+        "is against today's host and not against a result from another day",
+    ),
+    (
+        "accept_event_stream",
+        {"Accept": CODEX_ACCEPT},
+        None,
+        "the runtime asks for a stream; content negotiation can route a "
+        "request to a different backend before anything reads the body",
+    ),
+    (
+        "originator_and_user_agent",
+        {"originator": CODEX_ORIGINATOR, "User-Agent": CODEX_USER_AGENT},
+        None,
+        "the two headers that name the client. A gateway policy keyed on "
+        "either would refuse before it looked at the bearer",
+    ),
+    (
+        "codex_runtime_headers",
+        dict(CODEX_RUNTIME_HEADERS),
+        None,
+        "the six session and turn headers the working client never sends",
+    ),
+    (
+        "stream_true",
+        {},
+        {**MALFORMED_TURN_BODY, "stream": True},
+        "the one body field that can be varied without naming a model. Sent "
+        "with the plain Accept on purpose: the point is to separate the body "
+        "field from the header that usually accompanies it",
+    ),
+    (
+        "everything",
+        {
+            "Accept": CODEX_ACCEPT,
+            "originator": CODEX_ORIGINATOR,
+            "User-Agent": CODEX_USER_AGENT,
+            **CODEX_RUNTIME_HEADERS,
+        },
+        {**MALFORMED_TURN_BODY, "stream": True},
+        "as close to a Codex request as a request that names no model can be",
+    ),
+)
+
+VERDICT_A_REQUEST_PROPERTY_CLOSES_THE_GATE = "a_request_property_closes_the_auth_gate"
+VERDICT_NO_REQUEST_PROPERTY_CLOSES_THE_GATE = "no_request_property_closes_the_auth_gate"
+#: The honest no-answer, and the one this sweep is most likely to need: it is
+#: built on a premise -- that the plain request still clears the gate today --
+#: which it re-tests every run rather than assuming.
+VERDICT_SWEEP_INCONCLUSIVE = "sweep_inconclusive"
+
+#: What the sweep cannot settle whichever way it comes out.
+NOT_ESTABLISHED_BY_THE_SWEEP: tuple[str, ...] = (
+    "the cause: every arm here is urllib. A property that closes the gate for "
+    "urllib is a candidate for what refuses the runtime, not a demonstration "
+    "that it is what refuses the runtime",
+    "the body: no arm names a model, carries instructions, or sends the ten "
+    "tool definitions. The runtime's request is ~45 KB and these are a few "
+    "hundred bytes, so a null result here points at the body and does not "
+    "test it",
+    "the transport: TLS negotiation, HTTP version and connection reuse differ "
+    "between urllib and the runtime's client and are not varied here",
+    "the fix: a named property is somewhere to look next. It is not a change "
+    "to make, and it is not a reason to request a role",
+    "the permission: this reads the order the host checks a request in, not "
+    "what the identity may do. Clearing the gate with an unservable body "
+    "shows authorization is checked before the body is read; it does not "
+    "show that a servable body would be served, because no arm here is one",
+    "the cost: a refusal returns no usage record, so these calls are unpriced "
+    "rather than proven free",
+)
+
+
+def classify_sweep(
+    arms: Mapping[str, Mapping[str, Any]], control: Mapping[str, Any]
+) -> tuple[str, str, list[str]]:
+    """Read the arms, and say what they establish and what they do not.
+
+    The premise is checked before the result, in two steps, because a sweep
+    whose baseline no longer clears the gate is measuring a different host than
+    the one the question is about -- and would otherwise report every arm as a
+    flip.
+    """
+    if control.get("error") or control.get("status") not in AUTH_GATE_STATUSES:
+        return (
+            VERDICT_SWEEP_INCONCLUSIVE,
+            "the control arm did not get stopped at the gate, so this host is "
+            f"not showing the check order the sweep reads against (control: "
+            f"{control.get('status')}). No arm's status can be interpreted",
+            [],
+        )
+    baseline = arms.get("baseline") or {}
+    if baseline.get("status") not in REQUEST_VALIDATION_STATUSES:
+        return (
+            VERDICT_SWEEP_INCONCLUSIVE,
+            f"the plain request got {baseline.get('status')}, not the 400 that "
+            "made this question worth asking. Whatever changed, it is not one "
+            "of the properties this sweep varies",
+            [],
+        )
+
+    closed = [
+        name
+        for name, arm in arms.items()
+        if name != "baseline" and arm.get("status") in AUTH_GATE_STATUSES
+    ]
+    if not closed:
+        return (
+            VERDICT_NO_REQUEST_PROPERTY_CLOSES_THE_GATE,
+            "every property the runtime adds to its headers, and the one body "
+            "field that can be varied without naming a model, left the request "
+            "clearing the gate. What refuses the runtime is therefore in the "
+            "part of the body this sweep cannot send -- the model, the "
+            "instructions, the ten tool definitions -- or in the transport",
+            [],
+        )
+    if closed == ["everything"]:
+        return (
+            VERDICT_A_REQUEST_PROPERTY_CLOSES_THE_GATE,
+            "no single property closed the gate and the combination did, so "
+            "what refuses the request needs more than one of them present. The "
+            "isolated arms name which to combine next",
+            closed,
+        )
+    return (
+        VERDICT_A_REQUEST_PROPERTY_CLOSES_THE_GATE,
+        f"adding {', '.join(sorted(n for n in closed if n != 'everything'))} to "
+        "a request that otherwise clears the gate makes this host refuse it at "
+        "the gate, with the same body. That is where to look, and it is not a "
+        "reason to request a role",
+        closed,
+    )
+
+
+def transmission_sweep(
+    settings: CodexProviderSettings,
+    *,
+    timeout: int = READ_ONLY_TIMEOUT_SECONDS,
+    redact: Callable[[Any], str | None],
+) -> dict[str, Any]:
+    """Vary one request property at a time and see which one closes the gate."""
+    description = describe_settings(settings)
+    record: dict[str, Any] = {
+        "schema": SWEEP_SCHEMA,
+        "inference_requested": False,
+        "settings": description,
+        "settings_fingerprint": settings_fingerprint(description),
+        "endpoint_host_fingerprint": host_fingerprint(settings.base_url),
+        "requests_planned": len(SWEEP_ARMS) + 1,
+        "requests_sent": 0,
+        "arms_described": {name: why for name, _h, _b, why in SWEEP_ARMS},
+        "token": {"minted": False, "mechanism": "auth_command", "error": None},
+        "arms": {},
+        "control": None,
+        "properties_that_closed_the_gate": [],
+        "verdict": VERDICT_SWEEP_INCONCLUSIVE,
+        "verdict_note": "the sweep did not run",
+        "not_established": list(NOT_ESTABLISHED_BY_THE_SWEEP),
+    }
+
+    # Enforced here rather than trusted: an arm that named a model could select
+    # a deployment, and the argument that nothing can be generated would stop
+    # holding for the whole run.
+    for name, _headers, body, _why in SWEEP_ARMS:
+        if body is not None and "model" in body:
+            raise ValueError(
+                f"arm {name!r} names a model, which this sweep must never do"
+            )
+
+    try:
+        token = mint_token_the_way_codex_does(settings, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 - a mint failure is the finding
+        record["token"]["error"] = redact(exc)
+        record["verdict_note"] = (
+            "no token could be minted, so no arm was sent. This measures "
+            "nothing about the resource"
+        )
+        return record
+    record["token"]["minted"] = True
+
+    raw_arms: dict[str, dict[str, Any]] = {}
+    for name, headers, body, _why in SWEEP_ARMS:
+        outcome = post_malformed_turn(
+            settings, token, timeout=timeout, extra_headers=headers, body=body
+        )
+        outcome["body_sha256"] = hashlib.sha256(
+            json.dumps(
+                MALFORMED_TURN_BODY if body is None else dict(body), sort_keys=True
+            ).encode("utf-8")
+        ).hexdigest()
+        outcome["headers_added"] = sorted(headers)
+        raw_arms[name] = outcome
+        record["requests_sent"] += 1
+
+    control = post_malformed_turn(
+        settings, OBVIOUSLY_INVALID_BEARER, timeout=timeout
+    )
+    record["requests_sent"] += 1
+
+    verdict, note, closed = classify_sweep(raw_arms, control)
+    record["verdict"] = verdict
+    record["verdict_note"] = note
+    record["properties_that_closed_the_gate"] = closed
+
+    # Compared before redaction, for the reason the discriminator gives: the
+    # redactor collapses distinct strings onto one placeholder, so two
+    # different refusals can come out identical on the far side of it.
+    baseline_message = (raw_arms.get("baseline") or {}).get("message")
+    for name, arm in raw_arms.items():
+        arm = dict(arm)
+        arm["same_message_as_baseline"] = (
+            (arm.get("message") == baseline_message)
+            if arm.get("message") and baseline_message
+            else None
+        )
+        arm["same_message_as_control"] = (
+            (arm.get("message") == control.get("message"))
+            if arm.get("message") and control.get("message")
+            else None
+        )
+        arm["message"] = redact(arm.get("message"))
+        arm["error"] = redact(arm.get("error"))
+        record["arms"][name] = arm
+
+    control = dict(control)
+    control["message"] = redact(control.get("message"))
+    control["error"] = redact(control.get("error"))
+    record["control"] = control
+    return record
+
+
 # ── Command line ────────────────────────────────────────────────────────────
 
 
@@ -1474,6 +1792,16 @@ def main(argv: list[str] | None = None) -> int:
         "established one of those, not when it merely ran.",
     )
     parser.add_argument(
+        "--transmission-sweep",
+        action="store_true",
+        help="send the same unservable body once per request property the "
+        "Codex runtime adds and the working client does not, plus a "
+        "combination and an invalid-bearer control. Names which property, if "
+        "any, makes this host refuse at the gate a request it otherwise lets "
+        "through. No arm names a model, so no arm can generate anything. "
+        "Exits 0 only when it establishes an answer, not when it merely ran.",
+    )
+    parser.add_argument(
         "--timeout",
         type=int,
         default=DEFAULT_TIMEOUT_SECONDS,
@@ -1491,6 +1819,7 @@ def main(argv: list[str] | None = None) -> int:
         for name, on in (
             ("--read-only-probe", args.read_only_probe),
             ("--auth-discriminator", args.auth_discriminator),
+            ("--transmission-sweep", args.transmission_sweep),
             ("--send-request", args.send_request),
         )
         if on
@@ -1539,6 +1868,22 @@ def main(argv: list[str] | None = None) -> int:
             in (
                 VERDICT_BEARER_CLEARS_THE_AUTH_GATE,
                 VERDICT_BEARER_REFUSED_AT_THE_AUTH_GATE,
+            )
+            else 1
+        )
+
+    if args.transmission_sweep:
+        record = transmission_sweep(settings, redact=redact)
+        _emit(record, args.out)
+        # As above: 0 for either conclusive verdict. "No property closed the
+        # gate" is an answer -- it moves the question to the body -- and a run
+        # that could not tell must not look like one.
+        return (
+            0
+            if record["verdict"]
+            in (
+                VERDICT_A_REQUEST_PROPERTY_CLOSES_THE_GATE,
+                VERDICT_NO_REQUEST_PROPERTY_CLOSES_THE_GATE,
             )
             else 1
         )

--- a/batch-runner/tests/test_codex_transmission_sweep.py
+++ b/batch-runner/tests/test_codex_transmission_sweep.py
@@ -1,0 +1,704 @@
+"""Which request property closes a gate that the plain request gets through.
+
+Run ``34361684546`` established the check order on the real host: a plainly
+invalid bearer is stopped at the gate, and the minted bearer gets past it to
+the part that reads the body. The Codex runtime sends *that same minted token
+to that same URL* and is answered at the gate, with the control arm's sentence
+word for word. Four transmission explanations were then measured offline and
+all four are false -- the header is present, it is a ``Bearer``, its value is
+exactly what the auth command printed, and no second credential rides along.
+
+So the difference is somewhere in the rest of what the runtime puts on the
+wire. The sweep adds those properties to a request already known to clear the
+gate, one at a time, and reports which one -- if any -- closes it.
+
+The tests here are about the *instrument*. A sweep is only worth its requests
+if each arm sends the property it names, if the count is what the record says,
+and if it reports "nothing closed the gate" as an answer rather than as a
+failure. Every host in this file is a socket on this machine; nothing here
+mints a token or leaves loopback.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from diagnose_codex_foundry_connection import (  # noqa: E402
+    CODEX_ACCEPT,
+    CODEX_ORIGINATOR,
+    CODEX_RUNTIME_HEADERS,
+    CODEX_USER_AGENT,
+    MALFORMED_TURN_BODY,
+    OBVIOUSLY_INVALID_BEARER,
+    SWEEP_ARMS,
+    SWEEP_SCHEMA,
+    VERDICT_A_REQUEST_PROPERTY_CLOSES_THE_GATE,
+    VERDICT_NO_REQUEST_PROPERTY_CLOSES_THE_GATE,
+    VERDICT_SWEEP_INCONCLUSIVE,
+    classify_sweep,
+    main,
+    transmission_sweep,
+)
+
+# The redirected settings, the fake token and the auth-command printer are the
+# discriminator's. A second copy here would be a second thing to keep true.
+from tests.test_codex_auth_discriminator import (  # noqa: E402
+    FAKE_TOKEN,
+    _printer,
+    _settings,
+    _with_auth_command,
+)
+
+
+def _no_redaction(value) -> str | None:
+    """Identity, so a test reads the message the host sent.
+
+    The production caller passes the real redactor; these tests are about which
+    arm got which status, and routing them through a redactor would mean a
+    failure could be the redactor's rather than the sweep's.
+    """
+    return None if value is None else str(value)
+
+
+class _ScriptedHost:
+    """Answers ``POST /responses`` according to a rule over the request.
+
+    The rule takes the lowercased headers and the parsed body and returns
+    ``(status, message)``. That is what lets a test script "this host refuses
+    anything carrying ``originator``" and then check that the sweep names
+    ``originator`` -- rather than checking that the sweep names whatever it
+    was going to name anyway.
+    """
+
+    def __init__(self, rule: Callable[[dict, dict], tuple[int, str]]):
+        self.calls: list[dict] = []
+        self._lock = threading.Lock()
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *_args):  # noqa: D102 - silence the default
+                pass
+
+            def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler's spelling
+                length = int(self.headers.get("Content-Length") or 0)
+                raw = self.rfile.read(length) if length else b""
+                headers = {k.lower(): v for k, v in self.headers.items()}
+                try:
+                    parsed = json.loads(raw.decode("utf-8"))
+                except Exception:  # noqa: BLE001 - a body we cannot parse is data
+                    parsed = {}
+                with outer._lock:
+                    outer.calls.append(
+                        {"path": self.path, "headers": headers, "body": parsed}
+                    )
+                status, message = rule(headers, parsed)
+                payload = json.dumps({"error": {"message": message}}).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._server.daemon_threads = True
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self) -> "_ScriptedHost":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=10)
+
+    @property
+    def minted_calls(self) -> list[dict]:
+        """Everything but the control arm, in the order the sweep sent it."""
+        return [
+            call
+            for call in self.calls
+            if OBVIOUSLY_INVALID_BEARER not in call["headers"].get("authorization", "")
+        ]
+
+
+def _sweep(host: _ScriptedHost, tmp_path: Path) -> dict:
+    settings = _with_auth_command(_settings(host.port), _printer(tmp_path))
+    return transmission_sweep(settings, redact=_no_redaction)
+
+
+def _gate_on(predicate: Callable[[dict, dict], bool]):
+    """A host that refuses at the gate exactly when ``predicate`` holds."""
+
+    def rule(headers: dict, body: dict) -> tuple[int, str]:
+        if OBVIOUSLY_INVALID_BEARER in headers.get("authorization", ""):
+            return 401, "Access denied due to invalid subscription key"
+        if predicate(headers, body):
+            return 401, "Access denied due to invalid subscription key"
+        return 400, "Missed model deployment"
+
+    return rule
+
+
+def _never_at_the_gate(headers: dict, body: dict) -> tuple[int, str]:
+    return _gate_on(lambda _h, _b: False)(headers, body)
+
+
+# ── The promise that makes this free ────────────────────────────────────────
+
+
+def test_no_arm_can_select_a_deployment():
+    """The whole cost argument, asserted rather than commented.
+
+    Every arm is a POST to a live inference route. What keeps that from being
+    a purchase is that no body names a model, so there is no deployment for a
+    completion to be billed against. An arm that grew a ``model`` key would
+    break that quietly, which is why the sweep also raises on it at runtime.
+    """
+    for name, _headers, body, _why in SWEEP_ARMS:
+        if body is None:
+            continue
+        assert "model" not in body, f"arm {name!r} names a model"
+        assert "input" not in body, f"arm {name!r} carries input"
+        assert "messages" not in body, f"arm {name!r} carries messages"
+
+
+def test_an_arm_that_named_a_model_stops_the_run_before_it_starts(
+    tmp_path: Path, monkeypatch
+):
+    """And it stops before the token is minted, not after the arms are sent."""
+    import diagnose_codex_foundry_connection as module
+
+    monkeypatch.setattr(
+        module,
+        "SWEEP_ARMS",
+        (("bad", {}, {**MALFORMED_TURN_BODY, "model": "a-deployment"}, "why"),),
+    )
+    with _ScriptedHost(_never_at_the_gate) as host:
+        with pytest.raises(ValueError, match="names a model"):
+            _sweep(host, tmp_path)
+        assert host.calls == [], "an arm was sent before the guard ran"
+
+
+# ── Does each arm send what it says it sends ────────────────────────────────
+
+
+def test_the_sweep_sends_one_request_per_arm_and_one_control(tmp_path: Path):
+    """The count in the record is the count on the wire, not a constant."""
+    with _ScriptedHost(_never_at_the_gate) as host:
+        record = _sweep(host, tmp_path)
+
+    assert record["schema"] == SWEEP_SCHEMA
+    assert len(host.calls) == len(SWEEP_ARMS) + 1
+    assert record["requests_sent"] == len(host.calls)
+    assert record["requests_planned"] == record["requests_sent"]
+    assert {call["path"] for call in host.calls} == {"/v1/responses"}
+
+
+def test_each_arm_puts_on_the_wire_exactly_the_property_it_names(tmp_path: Path):
+    """An arm that does not send its property measures nothing and says so.
+
+    This is the failure that would be invisible: every arm comes back 400, the
+    verdict reads ``no_request_property_closes_the_auth_gate``, and it means
+    only that the sweep never varied anything. So the arms are checked against
+    the wire one by one.
+    """
+    with _ScriptedHost(_never_at_the_gate) as host:
+        _sweep(host, tmp_path)
+
+    sent = host.minted_calls
+    assert len(sent) == len(SWEEP_ARMS)
+    by_arm = {name: sent[i] for i, (name, _h, _b, _w) in enumerate(SWEEP_ARMS)}
+
+    baseline = by_arm["baseline"]
+    assert baseline["headers"]["accept"] == "application/json"
+    assert "originator" not in baseline["headers"]
+    assert baseline["body"] == MALFORMED_TURN_BODY
+    assert "stream" not in baseline["body"]
+
+    assert by_arm["accept_event_stream"]["headers"]["accept"] == CODEX_ACCEPT
+    assert "originator" not in by_arm["accept_event_stream"]["headers"]
+
+    originator_arm = by_arm["originator_and_user_agent"]
+    assert originator_arm["headers"]["originator"] == CODEX_ORIGINATOR
+    assert originator_arm["headers"]["user-agent"] == CODEX_USER_AGENT
+    assert originator_arm["headers"]["accept"] == "application/json"
+
+    runtime_arm = by_arm["codex_runtime_headers"]
+    for header in CODEX_RUNTIME_HEADERS:
+        assert runtime_arm["headers"].get(header) == CODEX_RUNTIME_HEADERS[header]
+    assert "originator" not in runtime_arm["headers"]
+
+    # Deliberately the body field on its own: sending it with the Accept that
+    # usually accompanies it would make a flip un-attributable to either.
+    stream_arm = by_arm["stream_true"]
+    assert stream_arm["body"].get("stream") is True
+    assert stream_arm["headers"]["accept"] == "application/json"
+
+    everything = by_arm["everything"]
+    assert everything["body"].get("stream") is True
+    assert everything["headers"]["accept"] == CODEX_ACCEPT
+    assert everything["headers"]["originator"] == CODEX_ORIGINATOR
+    for header in CODEX_RUNTIME_HEADERS:
+        assert everything["headers"].get(header) == CODEX_RUNTIME_HEADERS[header]
+
+
+def test_every_arm_carries_the_minted_bearer_and_only_the_control_does_not(
+    tmp_path: Path,
+):
+    """A varied arm that lost its credential would flip for the wrong reason."""
+    with _ScriptedHost(_never_at_the_gate) as host:
+        _sweep(host, tmp_path)
+
+    minted = [call["headers"]["authorization"] for call in host.minted_calls]
+    assert minted == [f"Bearer {FAKE_TOKEN}"] * len(SWEEP_ARMS)
+    controls = [
+        call["headers"]["authorization"]
+        for call in host.calls
+        if call not in host.minted_calls
+    ]
+    assert controls == [f"Bearer {OBVIOUSLY_INVALID_BEARER}"]
+
+
+def test_the_synthetic_identifiers_carry_nothing_from_this_machine(tmp_path: Path):
+    """The runtime's own session ids name an installation; these do not.
+
+    Replaying the measured identifiers would put a machine identifier on
+    someone else's host to test a question about header *shape*. The stand-ins
+    are the same shape and mean nothing, and ``x-codex-turn-metadata`` stays
+    real JSON so a gateway that parses it does not reject it for the wrong
+    reason.
+    """
+    metadata = json.loads(CODEX_RUNTIME_HEADERS["x-codex-turn-metadata"])
+    assert set(metadata) >= {"installation_id", "session_id", "turn_id"}
+    for key in ("installation_id", "session_id", "thread_id", "turn_id"):
+        assert metadata[key] == "00000000-0000-7000-8000-000000000000"
+    assert metadata["turn_started_at_unix_ms"] == 0
+
+
+# ── Reading the arms ────────────────────────────────────────────────────────
+
+
+def test_a_property_that_closes_the_gate_is_named(tmp_path: Path):
+    """The result this sweep exists to produce, against a host that has one."""
+    with _ScriptedHost(
+        _gate_on(lambda headers, _body: "originator" in headers)
+    ) as host:
+        record = _sweep(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_A_REQUEST_PROPERTY_CLOSES_THE_GATE
+    assert record["properties_that_closed_the_gate"] == [
+        "originator_and_user_agent",
+        "everything",
+    ]
+    assert "originator_and_user_agent" in record["verdict_note"]
+    assert record["arms"]["baseline"]["status"] == 400
+    assert record["arms"]["originator_and_user_agent"]["status"] == 401
+
+
+def test_a_body_field_can_be_the_one_that_closes_it(tmp_path: Path):
+    """Headers are the likelier answer; the sweep must not assume they are."""
+    with _ScriptedHost(
+        _gate_on(lambda _headers, body: body.get("stream") is True)
+    ) as host:
+        record = _sweep(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_A_REQUEST_PROPERTY_CLOSES_THE_GATE
+    assert record["properties_that_closed_the_gate"] == ["stream_true", "everything"]
+
+
+def test_nothing_closing_the_gate_is_an_answer_and_says_where_to_look_next(
+    tmp_path: Path,
+):
+    """A null result moves the question to the body rather than ending it."""
+    with _ScriptedHost(_never_at_the_gate) as host:
+        record = _sweep(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_NO_REQUEST_PROPERTY_CLOSES_THE_GATE
+    assert record["properties_that_closed_the_gate"] == []
+    assert "the body" in record["verdict_note"]
+
+
+def test_only_the_combination_closing_it_is_reported_as_a_combination(
+    tmp_path: Path,
+):
+    """Isolated arms buy this distinction; the record has to keep it."""
+    with _ScriptedHost(
+        _gate_on(
+            lambda headers, body: "originator" in headers and body.get("stream") is True
+        )
+    ) as host:
+        record = _sweep(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_A_REQUEST_PROPERTY_CLOSES_THE_GATE
+    assert record["properties_that_closed_the_gate"] == ["everything"]
+    assert "needs more than one" in record["verdict_note"]
+
+
+# ── The premise, re-tested every run ────────────────────────────────────────
+
+
+def test_a_control_that_is_not_stopped_at_the_gate_voids_every_arm(tmp_path: Path):
+    """Without the check order, a 401 on an arm is not about authorization."""
+
+    def rule(headers: dict, _body: dict) -> tuple[int, str]:
+        return 400, "this host reads the body first"
+
+    with _ScriptedHost(rule) as host:
+        record = _sweep(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_SWEEP_INCONCLUSIVE
+    assert "control" in record["verdict_note"]
+    assert record["properties_that_closed_the_gate"] == []
+
+
+def test_a_baseline_that_no_longer_clears_the_gate_is_inconclusive(tmp_path: Path):
+    """If the plain request is refused too, the sweep's question has moved.
+
+    Reporting every arm as a flip here would be the worst failure available:
+    it names five properties as causes on a host where none of them is doing
+    anything.
+    """
+    with _ScriptedHost(_gate_on(lambda _h, _b: True)) as host:
+        record = _sweep(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_SWEEP_INCONCLUSIVE
+    assert record["properties_that_closed_the_gate"] == []
+
+
+def test_a_mint_failure_sends_no_arm_at_all(tmp_path: Path):
+    """No token, no requests -- and a record that says it measured nothing."""
+    failing = tmp_path / "fails.py"
+    failing.write_text("import sys\nsys.exit(3)\n", encoding="utf-8")
+    with _ScriptedHost(_never_at_the_gate) as host:
+        settings = _with_auth_command(
+            _settings(host.port), [sys.executable, str(failing)]
+        )
+        record = transmission_sweep(settings, redact=_no_redaction)
+        assert host.calls == []
+
+    assert record["verdict"] == VERDICT_SWEEP_INCONCLUSIVE
+    assert record["token"]["minted"] is False
+    assert record["requests_sent"] == 0
+    assert "measures nothing" in record["verdict_note"]
+
+
+def test_a_transport_failure_on_the_control_is_not_read_as_a_flip(tmp_path: Path):
+    """A control that never arrived is an absent control, not a passing one."""
+    assert (
+        classify_sweep(
+            {"baseline": {"status": 400}, "accept_event_stream": {"status": 401}},
+            {"status": None, "error": "URLError: nothing listening"},
+        )[0]
+        == VERDICT_SWEEP_INCONCLUSIVE
+    )
+
+
+# ── What the record does and does not carry ─────────────────────────────────
+
+
+def test_the_record_names_no_resource_and_carries_no_token(tmp_path: Path):
+    """The account name and the token stay out; the deployment stays in.
+
+    The deployment is what the diagnostic is *about* and every record in this
+    script carries it. What must not appear is the account -- the host is a
+    ``sha256:`` fingerprint for that reason -- and the bearer.
+    """
+    with _ScriptedHost(_never_at_the_gate) as host:
+        record = _sweep(host, tmp_path)
+
+    serialised = json.dumps(record)
+    assert FAKE_TOKEN not in serialised
+    assert "example-account" not in serialised
+    assert record["inference_requested"] is False
+    assert record["endpoint_host_fingerprint"].startswith("sha256:")
+    assert all(len(arm["body_sha256"]) == 64 for arm in record["arms"].values())
+
+
+def test_the_record_states_what_it_cannot_settle(tmp_path: Path):
+    """Including, in every run, that these arms are not the runtime."""
+    with _ScriptedHost(_never_at_the_gate) as host:
+        record = _sweep(host, tmp_path)
+
+    joined = " ".join(record["not_established"])
+    assert "urllib" in joined
+    assert "unpriced" in joined
+    assert "not a reason to request a role" in joined
+
+
+def test_the_record_separates_check_order_from_what_the_identity_may_do(
+    tmp_path: Path,
+):
+    """A 400 is the gate letting an unservable body through, nothing more.
+
+    Reading it as "inference would be permitted" is the specific mistake this
+    sweep is most able to invite, because every arm it sends is deliberately
+    unservable: the thing that would prove a servable body is served is the
+    one thing no arm here may carry. So the limit is asserted rather than
+    left to whoever writes the summary.
+    """
+    with _ScriptedHost(_never_at_the_gate) as host:
+        record = _sweep(host, tmp_path)
+
+    permission = [
+        line for line in record["not_established"] if line.startswith("the permission:")
+    ]
+    assert len(permission) == 1, record["not_established"]
+    assert "not what the identity may do" in permission[0]
+    assert "does not show that a servable body would be served" in permission[0]
+
+
+def test_each_arm_reports_the_body_it_actually_hashed(tmp_path: Path):
+    """Two arms differ in body; the hashes have to differ with them."""
+    with _ScriptedHost(_never_at_the_gate) as host:
+        record = _sweep(host, tmp_path)
+
+    plain = record["arms"]["baseline"]["body_sha256"]
+    assert record["arms"]["accept_event_stream"]["body_sha256"] == plain
+    assert record["arms"]["stream_true"]["body_sha256"] != plain
+    assert record["arms"]["everything"]["body_sha256"] != plain
+
+
+def test_a_refusal_identical_to_the_control_is_flagged_as_identical(tmp_path: Path):
+    """The comparison that made the 401 readable, kept per arm.
+
+    An arm answered with the control's exact sentence is the shape the paid
+    turn produced. Recording the comparison per arm is what would let a future
+    reader see it happen rather than infer it.
+    """
+    with _ScriptedHost(
+        _gate_on(lambda headers, _b: "originator" in headers)
+    ) as host:
+        record = _sweep(host, tmp_path)
+
+    assert record["arms"]["originator_and_user_agent"]["same_message_as_control"] is True
+    assert record["arms"]["baseline"]["same_message_as_control"] is False
+    assert record["arms"]["baseline"]["same_message_as_baseline"] is True
+
+
+# ── The values, bound to the runtime they were read from ───────────────────
+
+
+def test_the_replayed_values_are_the_ones_the_runtime_actually_sends(tmp_path: Path):
+    """Guessing these would have been wrong twice, so they are not guessed.
+
+    The originator is ``codex_python_sdk`` -- not the ``codex_cli_rs`` a
+    reader would expect from the CLI -- and the runtime asks for
+    ``text/event-stream``, not JSON. Both were read off the wire, and both are
+    checked against it here: a sweep that replays a value the runtime stopped
+    sending is testing a header nobody sends, and would come back null for a
+    reason that has nothing to do with the host.
+    """
+    pytest.importorskip("tests.test_what_one_codex_turn_actually_sends")
+    from tests.test_what_one_codex_turn_actually_sends import (
+        _RUNTIME_PROBLEM,
+        _one_refused_turn,
+    )
+
+    if _RUNTIME_PROBLEM is not None:
+        pytest.skip(f"the pinned Codex runtime is not installed: {_RUNTIME_PROBLEM}")
+
+    measured = _one_refused_turn(tmp_path)
+    assert measured["calls"], "no request arrived, so nothing was compared"
+    names = set(measured["calls"][0]["header_names"])
+    values = measured["calls"][0]["header_values"]
+
+    missing = set(CODEX_RUNTIME_HEADERS) - names
+    assert not missing, (
+        f"the sweep replays {sorted(missing)}, which this runtime no longer "
+        f"sends. Those arms would be testing headers nobody sends"
+    )
+    assert values.get("originator") == CODEX_ORIGINATOR, (
+        f"the sweep replays originator={CODEX_ORIGINATOR!r}; this runtime "
+        f"sends {values.get('originator')!r}"
+    )
+    assert values.get("accept") == CODEX_ACCEPT, (
+        f"the sweep replays Accept={CODEX_ACCEPT!r}; this runtime asks for "
+        f"{values.get('accept')!r}"
+    )
+    # The user-agent carries a version, so the pinned version is the part
+    # worth binding: a bump that changed it would make the replay a different
+    # string from the one the host sees from the runtime.
+    assert values.get("user-agent", "").startswith("codex_python_sdk/"), values.get(
+        "user-agent"
+    )
+    assert CODEX_USER_AGENT.startswith("codex_python_sdk/")
+
+    body = json.loads(measured["calls"][0]["body"].decode("utf-8"))
+    assert body.get("stream") is True, (
+        "the sweep's stream_true arm reproduces a body field the runtime no "
+        "longer sets"
+    )
+
+
+# ── The step that runs it ───────────────────────────────────────────────────
+
+
+def _sweep_record() -> dict:
+    return {
+        "schema": SWEEP_SCHEMA,
+        "inference_requested": False,
+        "settings": {"model": "a-deployment"},
+        "token": {"minted": True, "error": None},
+        "requests_planned": 7,
+        "requests_sent": 7,
+        "arms": {"baseline": {"status": 400, "message": "missing model"}},
+        "control": {"status": 401, "message": "denied"},
+        "properties_that_closed_the_gate": [],
+        "verdict": VERDICT_NO_REQUEST_PROPERTY_CLOSES_THE_GATE,
+        "not_established": ["urllib, unpriced, not a reason to request a role"],
+    }
+
+
+def test_the_leak_check_accepts_a_sweep_record(tmp_path: Path):
+    """A record the redaction check cannot parse is a record it withholds."""
+    from tests.test_codex_auth_discriminator import _run_leak_check
+
+    code, output = _run_leak_check(
+        tmp_path, {"codex-foundry-transmission-sweep.json": _sweep_record()}
+    )
+    assert code == 0, output
+    assert "record=clean (1 checked)" in output
+
+
+def test_the_leak_check_still_enforces_the_no_request_claim_on_the_sweep(
+    tmp_path: Path,
+):
+    """Adding a shape must not amount to exempting it."""
+    from tests.test_codex_auth_discriminator import _run_leak_check
+
+    record = _sweep_record()
+    record["inference_requested"] = True
+    code, output = _run_leak_check(
+        tmp_path, {"codex-foundry-transmission-sweep.json": record}
+    )
+    assert code == 1
+    assert "claims a request was made" in output
+
+
+def test_the_leak_check_reads_the_sweep_record_by_its_real_path():
+    """The substitution above is only honest if this is the path CI checks."""
+    from tests.test_codex_auth_discriminator import _leak_check_source
+
+    assert '"/tmp/codex-foundry-transmission-sweep.json"' in _leak_check_source()
+
+
+def test_the_sweep_record_is_published_with_the_others():
+    """An artifact that is checked and then not uploaded proves nothing later."""
+    import yaml
+
+    from tests.test_codex_auth_discriminator import WORKFLOW
+
+    parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = parsed["jobs"]["diagnose"]["steps"]
+    keep = next(s for s in steps if s.get("name") == "Keep the record")
+    assert "/tmp/codex-foundry-transmission-sweep.json" in keep["with"]["path"]
+
+
+def test_the_sweep_step_is_free_and_ungated_and_cannot_buy_a_turn():
+    """Seven requests, none of which can select a deployment.
+
+    ``--send-request`` on this step would buy a turn from a step whose comment
+    says it cannot, so its absence is asserted rather than trusted -- the same
+    guard the discriminator step carries.
+    """
+    import yaml
+
+    from tests.test_codex_auth_discriminator import WORKFLOW
+
+    parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = parsed["jobs"]["diagnose"]["steps"]
+    step = next(s for s in steps if s.get("id") == "transmission_sweep")
+    assert "if" not in step, step.get("if")
+    assert "--transmission-sweep" in step["run"]
+    assert "--send-request" not in step["run"]
+
+
+def test_the_step_fails_when_fewer_arms_went_than_it_reports_on():
+    """Arms that never went are not evidence, and must not read as null."""
+    import yaml
+
+    from tests.test_codex_auth_discriminator import WORKFLOW
+
+    parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = parsed["jobs"]["diagnose"]["steps"]
+    step = next(s for s in steps if s.get("id") == "transmission_sweep")
+    assert "requests_sent" in step["run"] and "requests_planned" in step["run"]
+    assert 'record["token"]["minted"]' in step["run"]
+
+
+# ── The command line ────────────────────────────────────────────────────────
+
+
+def test_the_four_probes_refuse_to_run_together(capsys):
+    """They write different records to the same ``--out``; one would win."""
+    for extra in (
+        ["--read-only-probe"],
+        ["--send-request"],
+        ["--auth-discriminator"],
+    ):
+        with pytest.raises(SystemExit):
+            main(["--deployment", "d", "--transmission-sweep", *extra])
+        assert "run them separately" in capsys.readouterr().err
+
+
+def test_an_inconclusive_sweep_does_not_exit_zero(tmp_path: Path, monkeypatch):
+    """"The sweep ran" is not the result."""
+    import diagnose_codex_foundry_connection as module
+
+    def rule(headers: dict, _body: dict) -> tuple[int, str]:
+        return 400, "this host reads the body first"
+
+    with _ScriptedHost(rule) as host:
+        monkeypatch.setattr(
+            module,
+            "settings_from_environment",
+            lambda *_a, **_k: _with_auth_command(
+                _settings(host.port), _printer(tmp_path)
+            ),
+        )
+        code = main(
+            [
+                "--deployment",
+                "a-deployment",
+                "--transmission-sweep",
+                "--out",
+                str(tmp_path / "sweep.json"),
+            ]
+        )
+    assert code == 1
+
+
+def test_a_null_result_exits_zero_because_it_is_an_answer(tmp_path: Path, monkeypatch):
+    """Nothing closing the gate moves the question; it does not fail the run."""
+    import diagnose_codex_foundry_connection as module
+
+    with _ScriptedHost(_never_at_the_gate) as host:
+        monkeypatch.setattr(
+            module,
+            "settings_from_environment",
+            lambda *_a, **_k: _with_auth_command(
+                _settings(host.port), _printer(tmp_path)
+            ),
+        )
+        out = tmp_path / "sweep.json"
+        code = main(
+            ["--deployment", "a-deployment", "--transmission-sweep", "--out", str(out)]
+        )
+
+    assert code == 0
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["verdict"] == VERDICT_NO_REQUEST_PROPERTY_CLOSES_THE_GATE

--- a/batch-runner/tests/test_what_one_codex_turn_actually_sends.py
+++ b/batch-runner/tests/test_what_one_codex_turn_actually_sends.py
@@ -157,6 +157,19 @@ class RecordsEveryVerb:
                             "header_names": sorted(
                                 name.lower() for name in self.headers.keys()
                             ),
+                            # Values as well as names, because a later
+                            # measurement replays some of them and needs to
+                            # replay what is actually sent rather than what a
+                            # reader would guess. ``authorization`` is the one
+                            # exception and is described in shape only, below.
+                            "header_values": {
+                                name.lower(): (
+                                    f"<{len(value)} chars>"
+                                    if name.lower() == "authorization"
+                                    else value
+                                )
+                                for name, value in self.headers.items()
+                            },
                             "credential": describe_credential(
                                 dict(self.headers.items()), FAKE_TOKEN
                             ),

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -998,6 +998,57 @@ paid run must be preceded by a fresh smoke at the new fingerprint.
   buying a completion. If nothing flips it, the difference is the body, and
   that is worth knowing too. Neither outcome requires a role, and no role is
   being requested.
+- **That diagnostic is now built, and it changed shape twice while being
+  written.** `--transmission-sweep`, an ungated step in the diagnostic
+  workflow, 29 tests in
+  `batch-runner/tests/test_codex_transmission_sweep.py`.
+
+  **First change: the arms are isolated, not cumulative.** The bullet above
+  says "one group at a time", which reads as *accumulating* — headers, then
+  headers plus `stream`. Written that way, the first arm that flips is
+  attributable to nothing narrower than "this group, or something added before
+  it", which is the same un-narrowing that made the one-armed discriminator
+  unreadable. Each arm here carries **exactly one** property over the baseline,
+  and a sixth arm carries all of them, so a flip means *this property is
+  sufficient* rather than *something at or before this point was*. The extra
+  requests are refusals and buy that distinction.
+
+  **Second change: the values are measured, not written from the table above.**
+  Extending the turn recorder to keep header *values* — it kept only names —
+  says the runtime sends `originator: codex_python_sdk`. The plausible guess is
+  `codex_cli_rs`, and a sweep built on the guess would have replayed a string
+  nobody sends and returned a confident null result. `Accept` is likewise
+  `text/event-stream` and not `application/json`. Both are now bound to the
+  pinned binary by a `needs_runtime` test, so a version bump that changes
+  either reddens a test instead of quietly voiding the sweep.
+
+  Two guarantees are enforced rather than asserted. No arm may name a model:
+  a `ValueError` is raised **before the token is minted**, so an arm that
+  acquired one could not send anything. And the premise is re-tested every run
+  — that the control is still stopped at the gate, and that the baseline still
+  clears it — with `sweep_inconclusive` reported if either has moved, rather
+  than five properties named as causes on a host where none of them is doing
+  anything.
+
+  Building it also found a live defect in the workflow, by failing closed the
+  way the workflow's own comment said it would: the redaction check branches on
+  schema prefix and the sweep's schema was unregistered, so the record fell to
+  the paid-turn branch and crashed on a key free records do not have. In CI
+  that fails the check, skips `Keep the record`, and destroys the record
+  *after* its seven requests are spent. Registering the schema is the fix; the
+  design was right.
+
+  What the sweep will **not** settle, carried in the record on every run: these
+  arms are `urllib`, so a property that closes the gate here is a candidate for
+  what refuses the runtime and not a demonstration that it does; the ~45 KB
+  body and the transport layer are not varied; a named property is somewhere to
+  look and **not a reason to request a role**; the calls are unpriced rather
+  than proven free. And the one a `400` most invites collapsing: this reads
+  **the order in which the host checks a request, not what the identity is
+  permitted to do.** Clearing the gate with an unservable body shows
+  authorization is checked before the body is read. It does not show that a
+  servable body would be served — the only request that could show that is the
+  one this diagnostic never sends. Nothing here moves the 220-task column.
 - **The exec leg is closed, on one host, and it took a repair to close it.** The
   host limit was real and was closed by finding a host rather than by removing
   isolation: no sandbox was disabled, no network was opened, no container was


### PR DESCRIPTION
## What this answers

The discriminator (run `34361684546`, free) settled the **check order**: the same
unservable body got `400 Missed model deployment` with the minted bearer and
`401 invalid subscription key` with a string that is obviously not a token. So
this host reads authorization **before** it reads the body, and the bearer
clears that check.

The Codex runtime sends *the same token* to *the same route* and gets the `401` —
byte-for-byte the invalid-token text. Header presence, `Bearer` scheme, token
integrity (38→38) and a competing `api-key` are each closed offline against a
fake token and a local mock. The difference is somewhere else in what the
runtime adds, and this looks for it without buying a completion.

## How

Take the request already known to clear the gate — its body names no model, so
nothing can be generated — and add **one** Codex property per arm:

| arm | property |
|---|---|
| `baseline` | nothing (re-proves the premise every run) |
| `accept_event_stream` | `Accept: text/event-stream` |
| `originator_and_user_agent` | `originator`, `User-Agent` |
| `codex_runtime_headers` | the six session/turn headers |
| `stream_true` | `stream: true` in the body |
| `everything` | all of the above |

Plus the control. Watch for `400` flipping to `401`.

**Isolated, not cumulative.** The plan said "one group at a time", which reads as
accumulating — and that makes the first flip attributable to nothing narrower
than "this group, or something added before it". That is the same un-narrowing
that made a one-armed discriminator unreadable. One property per arm buys
*this property is sufficient* instead of *something at or before this point was*.

**The replayed values are measured, not guessed.** The turn recorder kept header
names only. Extending it to values says the runtime sends
`originator: codex_python_sdk` — the plausible guess is `codex_cli_rs` — and
`Accept: text/event-stream`, not `application/json`. A sweep built on the guess
would have replayed a string nobody sends and returned a confident null result.
Both values are bound to the pinned `0.147.0` binary by a `needs_runtime` test,
so a version bump reddens a test instead of quietly voiding the sweep.

## Two guarantees enforced rather than asserted

- **No arm may name a model** — a `ValueError` is raised *before the token is
  minted*, so an arm that acquired one could not send anything.
- **The premise is re-tested every run** — that the control is still stopped at
  the gate, and that the baseline still clears it. If either has moved the
  verdict is `sweep_inconclusive`, rather than five properties named as causes
  on a host where none of them is doing anything. Reordering the reads so the
  minted arm is read first — the version somebody wanting good news would write
  — turns tests red.

## A live defect this found, by failing closed as designed

The redaction check branches on schema prefix, with the free shapes matched by
prefix and the paid-turn shape as the `else`, *deliberately*, so an unregistered
record fails closed. The sweep record was unregistered, took the `else`, and
crashed on `record["observed"]` — a key free records do not have. In CI that
fails the check, skips `Keep the record`, and destroys the record **after** its
seven requests are spent. The design worked exactly as its comment promised;
registering the schema is the other half.

## What this does not establish

Carried inside the record on every run, not just in this description:

- these arms are `urllib`, **not the runtime** — a property that closes the gate
  here is a candidate for what refuses the runtime, not a demonstration that it
  does;
- the ~45 KB body (model, instructions, ten tools) is not tested, and the
  transport layer is not varied;
- a named property is **somewhere to look next, not a change to make, and not a
  reason to request a role**;
- **the order the host checks a request in is not what the identity may do.**
  Clearing the gate with an unservable body shows authorization is checked
  before the body is read. It does **not** show a servable body would be served,
  because no arm here is one. Nothing here moves 220 tasks to runnable;
- a refusal returns no usage record, so these calls are **unpriced rather than
  proven free**. They are not $0.

**No role grant is indicated by any of this and none is requested.** The earlier
`role_missing_and_an_owner_must_grant_it` verdict belongs to the project-scoped
Code Interpreter arm and does not transfer to this account route.

## Checks

- `tests/test_codex_transmission_sweep.py` — 29 new tests
- 164 passed across the four codex diagnostic suites; 615 passed across the
  suites that assert on the docs edited here
- workflow: 1 job, 17 steps, 13 run blocks `bash -n` clean; the sweep step is
  ungated and ordered before the paid turn, and the leak check and record-keeping
  are `always()`, so an inconclusive sweep loses no record
- mypy on the changed script: 0 errors (7 pre-existing in `core/` modules it
  imports)
- `batch-runner/core/` untouched — grader source hash unmoved