### PR TITLE
diag: send one request the route can actually serve

### DIFF
--- a/.github/workflows/codex-foundry-connection-diagnostic.yml
+++ b/.github/workflows/codex-foundry-connection-diagnostic.yml
@@ -80,6 +80,13 @@ on:
         required: false
         default: false
         type: boolean
+      send_valid_request:
+        description: >-
+          Send one servable Responses request through plain urllib (paid, not
+          Codex). This is the only probe here that can produce a completion.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -471,9 +478,82 @@ jobs:
               sys.exit(1)
           PY
 
-      # The one request. Skipped entirely unless it was asked for, so the
-      # difference between a free run and a paid one is a deliberate input and
-      # not a forgotten flag.
+      # The one request this file can send that the route is able to serve.
+      #
+      # Run 34437632382 finished the free line of questioning: all six header
+      # arms, up to and including every runtime header at once with
+      # `stream: true`, still cleared the gate with the same `400`. Nothing the
+      # runtime *adds to its headers* is what refuses it. What has never been
+      # sent to this resource is a body it could serve — every probe above
+      # deliberately omits the `model` field, which is exactly the field that
+      # resolves a deployment and therefore the field a per-deployment
+      # authorization check would key on.
+      #
+      # So this is not another free diagnostic. It costs, it is gated on its
+      # own input, and it answers a question none of the free ones can:
+      #
+      #   200 with text -> this identity infers here through urllib. Whatever
+      #                    refuses Codex is Codex-side, and there is now a
+      #                    working reference to diff its request against.
+      #   401/403       -> this identity may not infer here at all. That is a
+      #                    permission fact, and the first evidence in this
+      #                    whole diagnostic that would bear on a role.
+      #   400/404       -> the shape or the deployment name is wrong and the
+      #                    message says which. Still not a permission fact.
+      #
+      # Ceilings are in the script, not here, so they cannot be dispatched
+      # around: one request, no retry, 16 output tokens, 90 seconds, no
+      # fallback. Pinned by batch-runner/tests/test_codex_valid_request.py.
+      - name: Send one request the route can actually serve
+        id: valid_request
+        if: ${{ inputs.send_valid_request && steps.pinned.outputs.confirmed == 'yes' }}
+        working-directory: batch-runner
+        env:
+          AZURE_AI_ROUTE_PROFILE: direct-v1
+          FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
+          DEPLOYMENT: ${{ inputs.deployment }}
+        run: |
+          set -euo pipefail
+          # `|| true` for the same reason as the turn below: the script exits
+          # non-zero for everything except a completion, and a refusal is the
+          # finding rather than a broken job. The verdict is read out of the
+          # file, which is also what keeps a missing file from passing.
+          python3 scripts/diagnose_codex_foundry_connection.py \
+            --deployment "${DEPLOYMENT}" \
+            --valid-request \
+            --out /tmp/codex-foundry-valid-request.json || true
+          test -s /tmp/codex-foundry-valid-request.json
+          python3 - <<'PY'
+          import json
+          import sys
+
+          record = json.load(open("/tmp/codex-foundry-valid-request.json"))
+          attempt = record["attempt"] or {}
+          print("token minted:", record["token"]["minted"])
+          print("requests planned:", record["requests_planned"],
+                "sent:", record["requests_sent"])
+          print("status:", attempt.get("status"))
+          print("produced text:", bool(attempt.get("answer")))
+          usage = attempt.get("usage") or {}
+          print("usage reported:", usage.get("reported"),
+                "pricing:", usage.get("pricing"))
+          print("verdict:", record["verdict"])
+          print("what that means:", record["verdict_note"])
+
+          if not record["token"]["minted"]:
+              print("::error::the token could not be minted, so nothing was "
+                    "sent and this run measures nothing about the resource.")
+              sys.exit(1)
+
+          # The count on the wire, not the constant. This is the paid probe;
+          # a run that sent more than it planned is the failure mode the
+          # ceilings exist to prevent, and it must be loud.
+          if record["requests_sent"] > record["requests_planned"]:
+              print(f"::error::planned {record['requests_planned']} request(s) "
+                    f"and sent {record['requests_sent']}.")
+              sys.exit(1)
+          PY
+
       #
       # Two conditions, not one. `inputs.send_request` is the person's
       # intention; `steps.pinned.outputs.confirmed` is the machine's evidence
@@ -559,6 +639,7 @@ jobs:
               "/tmp/codex-foundry-readonly.json",
               "/tmp/codex-foundry-auth-discriminator.json",
               "/tmp/codex-foundry-transmission-sweep.json",
+              "/tmp/codex-foundry-valid-request.json",
               "/tmp/codex-foundry-connection.json",
           ):
               if not os.path.exists(path):
@@ -577,16 +658,17 @@ jobs:
                           f"{path}: contains a URL that is not the public token scope"
                       )
               record = json.loads(text)
-              # Four record shapes now land here and only one of them observes
-              # a turn. Branch on the record's own schema rather than on
-              # whether the key happens to be present: `.get("observed", {})`
-              # would turn a renamed field in the connection record into a
-              # silent pass, and this check exists precisely to catch a claim
-              # nobody measured. The three free shapes are matched by prefix
-              # and the turn shape is the `else`, so a *new* free record added
-              # without touching this list fails closed rather than skipping.
-              # It has now done that once, for real, on the sweep record --
-              # which is the whole argument for writing it this way.
+              # Five record shapes now land here and they do not share a
+              # check, so every one of them is matched by name and an
+              # unrecognised schema is fatal. The previous shape -- three
+              # prefixes and the turn record as the `else` -- was right about
+              # failing closed and it did fail closed once, for real, on the
+              # sweep record. But it failed by `KeyError` inside the turn
+              # branch, which is a crash that happens to be safe rather than a
+              # check that refuses. The valid-request record would have hit the
+              # same branch and is worse: it is the *paid* one, so the run that
+              # crashes here is the run that already spent the money and then
+              # throws the evidence away. Named branches, explicit `else`.
               schema = str(record.get("schema", ""))
               if schema.startswith((
                   "codex_foundry_readonly_probe/",
@@ -595,9 +677,23 @@ jobs:
               )):
                   if record["inference_requested"] is not False:
                       leaked.append(f"{path}: a free-probe record claims a request was made")
-              else:
+              elif schema.startswith("codex_foundry_valid_request/"):
+                  # The reverse check. This probe does buy inference, and the
+                  # field is how a reader tells a paid record from a free one.
+                  # A `false` here would hide a real request inside the cheap
+                  # branch, so `true` is required rather than merely allowed.
+                  if record["inference_requested"] is not True:
+                      leaked.append(f"{path}: a paid probe's record denies sending a request")
+                  if record["requests_sent"] > record["requests_planned"]:
+                      leaked.append(f"{path}: sent more requests than it planned")
+              elif schema.startswith("codex_foundry_connection/"):
                   if record["observed"]["tool_execution_observed"] is not False:
                       leaked.append(f"{path}: claims tool execution, which this probe cannot observe")
+              else:
+                  leaked.append(
+                      f"{path}: schema {schema!r} has no check here, so nothing "
+                      f"vouched for this record"
+                  )
 
           if leaked:
               print("FATAL:")
@@ -632,6 +728,7 @@ jobs:
             /tmp/codex-foundry-readonly.json
             /tmp/codex-foundry-auth-discriminator.json
             /tmp/codex-foundry-transmission-sweep.json
+            /tmp/codex-foundry-valid-request.json
             /tmp/codex-foundry-connection.json
           if-no-files-found: warn
           retention-days: 90
@@ -675,6 +772,17 @@ jobs:
           TS_BASELINE="$(python3 -c "import json,sys;print((json.load(open(sys.argv[1]))['arms'].get('baseline') or {}).get('status'))" "$TS" 2>/dev/null || echo 'unknown')"
           # An empty list prints as nothing and would read as "not measured".
           TS_CLOSED="$(python3 -c "import json,sys;v=json.load(open(sys.argv[1]))['properties_that_closed_the_gate'];print(', '.join(v) if v else 'none — nothing closed it')" "$TS" 2>/dev/null || echo 'not measured')"
+          VR=/tmp/codex-foundry-valid-request.json
+          VR_VERDICT="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['verdict'])" "$VR" 2>/dev/null || echo 'not measured')"
+          VR_NOTE="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['verdict_note'])" "$VR" 2>/dev/null || echo 'not measured')"
+          VR_STATUS="$(python3 -c "import json,sys;print((json.load(open(sys.argv[1]))['attempt'] or {}).get('status'))" "$VR" 2>/dev/null || echo 'unknown')"
+          # Whether text came back, not the text itself. The answer is in the
+          # artifact; a model's words do not belong in a job summary.
+          VR_TEXT="$(python3 -c "import json,sys;print(bool((json.load(open(sys.argv[1]))['attempt'] or {}).get('answer')))" "$VR" 2>/dev/null || echo 'unknown')"
+          VR_SENT="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['requests_sent'])" "$VR" 2>/dev/null || echo 'unknown')"
+          VR_PRICING="$(python3 -c "import json,sys;print((((json.load(open(sys.argv[1]))['attempt'] or {}).get('usage')) or {}).get('pricing'))" "$VR" 2>/dev/null || echo 'unknown')"
+          VR_IN="$(python3 -c "import json,sys;print((((json.load(open(sys.argv[1]))['attempt'] or {}).get('usage')) or {}).get('input_tokens'))" "$VR" 2>/dev/null || echo 'unknown')"
+          VR_OUT="$(python3 -c "import json,sys;print((((json.load(open(sys.argv[1]))['attempt'] or {}).get('usage')) or {}).get('output_tokens'))" "$VR" 2>/dev/null || echo 'unknown')"
           {
             echo "### Codex → Foundry, one turn"
             echo ""
@@ -769,8 +877,42 @@ jobs:
             echo "지나 안에서 걸렸다는 뜻입니다. 이건 **검사 순서**(토큰을 본문보다"
             echo "먼저 본다)를 말해 줄 뿐, 이 신원이 **추론을 실행해도 되는지**는"
             echo "말해 주지 않습니다. 그걸 보여 줄 수 있는 유일한 요청은 *답할 수"
-            echo "있는* 요청인데, 그건 이 진단이 절대 보내지 않는 바로 그것입니다."
-            echo "그래서 여기서 무엇이 나오든 **220문제가 돌아간다는 뜻이 아닙니다.**"
+            echo "있는* 요청이고, 그건 아래 칸이 하는 일입니다 — 무료가 아니라서"
+            echo "따로 켜야 합니다. 그래서 **이 칸에서** 무엇이 나오든"
+            echo "**220문제가 돌아간다는 뜻이 아닙니다.**"
+            echo ""
+            echo "### 답할 수 있는 요청 한 번 (유료, Codex 아님)"
+            echo ""
+            echo "- 보낸 요청 수: \`${VR_SENT}\` (상한 1회, 재시도 없음)"
+            echo "- 응답 코드: \`${VR_STATUS}\`"
+            echo "- 모델이 글자를 만들었는가: \`${VR_TEXT}\`"
+            echo "- 토큰 사용량: 입력 \`${VR_IN}\` / 출력 \`${VR_OUT}\`, 가격 \`${VR_PRICING}\`"
+            echo "- 판정: \`${VR_VERDICT}\`"
+            echo "- 뜻: ${VR_NOTE}"
+            echo ""
+            echo "이게 왜 다른가: **위의 확인들은 전부 일부러 답할 수 없는 요청**을"
+            echo "보냈습니다. 본문에 모델 이름이 없어서 아무것도 생성될 수 없고,"
+            echo "그래서 돈이 들지 않았습니다. 대신 \"이 신원이 여기서 추론을 해도"
+            echo "되는가\"라는 질문에는 **한 번도 답하지 못했습니다.** 이 칸은"
+            echo "그 질문에만 답합니다."
+            echo ""
+            echo "- \`inference_succeeded\` → 이 자원과 신원은 **된다**는 뜻입니다."
+            echo "  그러면 Codex를 막는 것은 자원도 신원도 주소도 아니고"
+            echo "  **Codex 쪽**이며, 이제 비교할 성공 사례가 생깁니다."
+            echo "- \`inference_refused_at_the_auth_gate\` (401/403) → 이 신원은"
+            echo "  여기서 **추론을 할 수 없습니다.** 이건 위의 어떤 확인도 낼 수"
+            echo "  없었던 결론이고, 권한 이야기를 꺼낼 근거가 되는 첫 증거입니다."
+            echo "- \`inference_request_rejected\` (400/404) → 요청 형식이나 배포"
+            echo "  이름 문제이지 **권한 문제가 아닙니다.**"
+            echo "- \`valid_request_inconclusive\` → \`200\`인데 글자가 없었거나"
+            echo "  요청이 아예 도달하지 못한 경우입니다. **성공이 아닙니다.**"
+            echo ""
+            echo "**여기서도 넘겨짚지 않기:** 이건 \`urllib\`이지 Codex 런타임이"
+            echo "아닙니다. 성공해도 \"자원과 신원은 된다\"까지이고 \"Codex가 된다\"가"
+            echo "아닙니다. 도구도 안 돌았고 파일도 안 만들었으므로 **문제 한 개를"
+            echo "푼 것도 아닙니다.** 사용량은 응답이 준 대로 적었고, 이 저장소에"
+            echo "이 경로의 단가가 등록돼 있지 않아 가격은 \`partial\`입니다 —"
+            echo "**0달러라는 뜻이 아니라 아직 값을 매기지 않았다는 뜻입니다.**"
             echo ""
             echo "이 줄이 뜻하는 것: Codex 런타임이 만든 요청 한 번을 실제 배포에"
             echo "보내고, 그쪽이 무엇이라고 답했는지를 이름 붙여 기록한 것입니다."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,71 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **The one request in this diagnostic that the route can actually serve.**
+  `--valid-request` in `batch-runner/scripts/diagnose_codex_foundry_connection.py`,
+  wired as a step gated on its own `send_valid_request` input *and* the resource
+  fingerprint. It is paid, and it is the only probe here that can produce a
+  completion.
+
+  Everything before it deliberately sends something unservable — a listing, a
+  body with no `model` in it, a bearer that was never valid — which is what
+  makes those probes free and is also their ceiling. Run `34437632382` finished
+  that line of questioning: all six header arms of the sweep, up to and
+  including every runtime header at once with `stream: true`, still cleared the
+  gate with the same `400`. Nothing the runtime adds to its headers is what
+  refuses it. What has never been sent to this resource, across every probe, is
+  a body it could serve — so *may this identity infer here* has never been
+  asked, and no record on disk answers it.
+
+  One request. No retry, no fallback, `max_output_tokens: 512`, `stream: false`,
+  `store: false`, a 90-second wall clock and a trivial public prompt carrying no
+  benchmark content. The ceilings live in the script rather than in the
+  workflow, so a dispatch cannot widen them.
+
+  512 rather than the API's minimum of 16, and that difference matters more than
+  the cost does. These deployments are reasoning models: they spend output
+  tokens on reasoning before emitting any text, so a ceiling of 16 is consumed
+  entirely by that and the answer comes back `200 incomplete` with nothing in
+  it. This probe correctly refuses to call that a success — which would have
+  meant spending the one request that was supposed to settle the question on an
+  artefact of its own configuration. If it happens anyway the record now says
+  so: the Responses status and `incomplete_details.reason` are written down
+  alongside the HTTP status, and the note names the ceiling as the thing to
+  change rather than leaving a bare "200 with no text" to read as a failure of
+  the route.
+
+  Its three outcomes point at three different repairs. `200` with model text:
+  the resource, identity and route are fine, what refuses Codex is Codex-side,
+  and a working request now exists to diff the runtime's against. `401`/`403`
+  on a servable body: a permission fact, the first evidence here that would
+  bear on a role, and unobtainable from any free probe. `400`/`404`: the shape
+  or the deployment name, still not permission.
+
+  Read strictly on purpose. A `200` carrying no model text is recorded as
+  inconclusive rather than as a success, and the exit code is `0` only for a
+  completion — a `401` here would be the most useful result this script has
+  ever produced and it still exits `1`. Usage is written down as the response
+  reported it with `price_usd: null` and `pricing: partial`: no rate for this
+  route is registered in this repository, and `partial` means unpriced, not
+  free. The record carries what a completion would still not establish — this
+  is `urllib` and not the runtime, no tool ran and no file was written, and the
+  220-task column is untouched either way. Pinned by 48 tests in
+  `batch-runner/tests/test_codex_valid_request.py`.
+
+### Fixed
+- **The diagnostic's redaction check no longer routes an unknown record shape
+  into another shape's check.** Its branches were three free-record schema
+  prefixes with the turn record as the `else`. That failed closed once, for
+  real, on the sweep record — by `KeyError`, which is a crash that happens to
+  be safe. The valid-request record would have hit the same branch, and there
+  the accident is expensive: it is the paid record, so the run that crashes is
+  the run that already spent the money, and a failed check skips `Keep the
+  record` and destroys the evidence. Every schema is now matched by name, the
+  paid record is *required* to admit `inference_requested: true` rather than
+  merely permitted to, and an unrecognised schema is refused by name instead of
+  being vouched for by a check written for something else.
+
+### Added
 - **A free sweep that asks which request property closes a gate the plain
   request already clears — and states, in the record, that clearing a gate is
   not permission to do the work.** `--transmission-sweep` in

--- a/batch-runner/scripts/diagnose_codex_foundry_connection.py
+++ b/batch-runner/scripts/diagnose_codex_foundry_connection.py
@@ -1722,6 +1722,338 @@ def transmission_sweep(
     return record
 
 
+# ── Does this identity get a completion, or not? ────────────────────────────
+#
+# Every probe above this line sends a body no deployment can serve. That is
+# what makes them free, and it is also the exact reason none of them can settle
+# the question the environment work now depends on: whether this identity may
+# run inference on this route at all.
+#
+# The sweep and the discriminator read *check order* -- which test the host
+# applies first. A `400` from them means an unservable body got past
+# authorization. It does not mean a servable body would be served, because
+# neither of them has ever sent one. `GET /models` returning `200` does not
+# mean it either: listing and completing are different data actions and a
+# resource may permit one and refuse the other.
+#
+# So this sends a real Responses request: a model, an input, and a ceiling. It
+# is the only thing in this file that can produce a completion, and it is the
+# only thing that can answer:
+#
+#   200 with output text -> this identity infers on this route through
+#                           `urllib`. Whatever refuses Codex is Codex-side, and
+#                           there is now a working reference to diff against.
+#   401/403              -> this identity cannot infer here at all. That is a
+#                           different and larger finding than anything above,
+#                           and the first evidence that would bear on a role.
+#   400/404              -> the request shape or the deployment name is wrong,
+#                           and the message says which. Not a permission fact.
+
+VALID_REQUEST_SCHEMA = "codex_foundry_valid_request/1"
+
+#: Ceilings, fixed here rather than accepted as arguments. A runaway cannot be
+#: configured into this probe because there is nothing to configure: one
+#: request, no retry, a small output ceiling and a wall clock. These are the
+#: pre-declared limits for this experiment, not advice.
+#:
+#: 512 rather than the API's minimum of 16, and the difference matters more than
+#: the cost does. The deployments this is pointed at are reasoning models: they
+#: spend output tokens on reasoning before any text is produced, and a ceiling
+#: of 16 would be consumed entirely by that. The result would be a `200` with
+#: `status: incomplete` and no text -- which this probe correctly refuses to
+#: call a success, and which would therefore have burned the one request that
+#: was supposed to settle the question on an artefact of the ceiling. 512 is
+#: still a hard bound, and still a fraction of a cent at any plausible rate.
+VALID_REQUEST_MAX_OUTPUT_TOKENS = 512
+VALID_REQUEST_TIMEOUT_SECONDS = 90
+VALID_REQUEST_ATTEMPTS = 1
+
+#: Deliberately trivial and public. No benchmark task, no reference file, no
+#: repository content. What is being read is the status code; the answer is
+#: only evidence that a model produced one.
+VALID_REQUEST_INPUT = "Reply with the single word: ok"
+
+#: A cap on what is written down, not on what may come back. A model that
+#: ignored the ceiling cannot spill anything into the record.
+VALID_REQUEST_ANSWER_KEPT_CHARS = 200
+
+VERDICT_INFERENCE_SUCCEEDED = "inference_succeeded"
+VERDICT_INFERENCE_REFUSED_AT_THE_AUTH_GATE = "inference_refused_at_the_auth_gate"
+VERDICT_INFERENCE_REQUEST_REJECTED = "inference_request_rejected"
+VERDICT_VALID_REQUEST_INCONCLUSIVE = "valid_request_inconclusive"
+
+NOT_ESTABLISHED_BY_A_VALID_REQUEST: tuple[str, ...] = (
+    "the Codex path: this is `urllib`. A completion here says the resource "
+    "and the identity can do it, not that the Codex runtime can",
+    "the harness: one completion is not a task solved. No tool ran, no file "
+    "was written, and nothing here bears on isolation, resume or collection",
+    "the benchmark: nothing about this moves any task to runnable, and the "
+    "220-task column is untouched by it",
+    "the price: token counts are recorded because the response carried them. "
+    "No rate is applied here, so the cost is `partial` -- a usage record "
+    "without a price is not a priced call and is not a free one",
+)
+
+
+def _answer_text_in(payload: Mapping[str, Any]) -> str | None:
+    """Pull the model's text out of a Responses body, whichever shape it uses.
+
+    Returns ``None`` when there is no text, and that is load-bearing: a `200`
+    carrying no output is not a completion, and the verdict below refuses to
+    call it one.
+    """
+    direct = payload.get("output_text")
+    if isinstance(direct, str) and direct.strip():
+        return direct
+    if isinstance(direct, list):
+        joined = "".join(part for part in direct if isinstance(part, str))
+        if joined.strip():
+            return joined
+    pieces: list[str] = []
+    for item in payload.get("output") or []:
+        if not isinstance(item, Mapping):
+            continue
+        for part in item.get("content") or []:
+            if isinstance(part, Mapping) and isinstance(part.get("text"), str):
+                pieces.append(part["text"])
+    joined = "".join(pieces)
+    return joined if joined.strip() else None
+
+
+def _usage_in(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Token counts as the service reported them, with no rate applied.
+
+    ``price_usd`` is ``None`` and ``pricing`` is ``partial`` on purpose. This
+    repository has no rate registered for this route, and inventing one to fill
+    the field would put a number in a ledger that nothing measured.
+    """
+    usage = payload.get("usage")
+    if not isinstance(usage, Mapping):
+        return {
+            "reported": False,
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "price_usd": None,
+            "pricing": "null",
+            "why": "the response carried no usage object, so nothing was counted",
+        }
+    def _count(name: str) -> int | None:
+        value = usage.get(name)
+        return int(value) if isinstance(value, (int, float)) else None
+
+    return {
+        "reported": True,
+        "input_tokens": _count("input_tokens"),
+        "output_tokens": _count("output_tokens"),
+        "total_tokens": _count("total_tokens"),
+        "price_usd": None,
+        "pricing": "partial",
+        "why": (
+            "token counts came back and are recorded; no rate for this route "
+            "is registered in this repository, so no price is derived"
+        ),
+    }
+
+
+def post_valid_request(
+    settings: CodexProviderSettings,
+    token: str,
+    *,
+    timeout: int = VALID_REQUEST_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """``POST {base_url}/responses`` with a body this route can actually serve.
+
+    Sent once. There is no retry loop here and adding one would change what the
+    ceilings above mean, so the count is asserted by the caller's record rather
+    than left implicit.
+    """
+    import urllib.error
+    import urllib.request
+
+    body = {
+        "model": settings.model,
+        "input": VALID_REQUEST_INPUT,
+        "max_output_tokens": VALID_REQUEST_MAX_OUTPUT_TOKENS,
+        "stream": False,
+        "store": False,
+    }
+    payload = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(  # noqa: S310 - scheme fixed by classify_endpoint
+        f"{settings.base_url}/responses",
+        method="POST",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    outcome: dict[str, Any] = {
+        "requested": "POST /responses",
+        "body_sha256": hashlib.sha256(payload).hexdigest(),
+        "body_bytes": len(payload),
+        "max_output_tokens": VALID_REQUEST_MAX_OUTPUT_TOKENS,
+        "status": None,
+        "message": None,
+        "answer": None,
+        "model_echoed": None,
+        # The Responses API's own status, which is not the HTTP one. A model
+        # that ran and was cut off by the ceiling above returns `200` with
+        # `incomplete` here, and without this field that case is
+        # indistinguishable in the record from a route that answered nothing.
+        "response_status": None,
+        "incomplete_reason": None,
+        "usage": None,
+        "error": None,
+    }
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            outcome["status"] = int(response.status)
+            answer = response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        outcome["status"] = int(exc.code)
+        try:
+            answer = exc.read().decode("utf-8", "replace")
+        except Exception:  # noqa: BLE001 - a body we cannot read is not a crash
+            answer = ""
+    except Exception as exc:  # noqa: BLE001 - a transport failure is a finding
+        outcome["error"] = f"{type(exc).__name__}: {exc}"
+        return outcome
+
+    outcome["message"] = _message_in(answer)
+    try:
+        parsed = json.loads(answer)
+    except Exception:  # noqa: BLE001 - a body that is not JSON is still a status
+        return outcome
+    if not isinstance(parsed, Mapping):
+        return outcome
+    text = _answer_text_in(parsed)
+    outcome["answer"] = None if text is None else text[:VALID_REQUEST_ANSWER_KEPT_CHARS]
+    echoed = parsed.get("model")
+    outcome["model_echoed"] = echoed if isinstance(echoed, str) else None
+    status_field = parsed.get("status")
+    outcome["response_status"] = status_field if isinstance(status_field, str) else None
+    details = parsed.get("incomplete_details")
+    if isinstance(details, Mapping) and isinstance(details.get("reason"), str):
+        outcome["incomplete_reason"] = details["reason"]
+    outcome["usage"] = _usage_in(parsed)
+    return outcome
+
+
+def classify_valid_request(attempt: Mapping[str, Any]) -> tuple[str, str]:
+    """Say what came back, and refuse to overstate a `200`.
+
+    A `200` that carried no model text is not a completion. It is reported as
+    inconclusive rather than as a success, because the whole value of this
+    probe is that it is the one thing entitled to say inference worked.
+    """
+    if attempt.get("error"):
+        return (
+            VERDICT_VALID_REQUEST_INCONCLUSIVE,
+            "the request did not reach a status: this is a transport failure "
+            "and says nothing about the identity or the deployment",
+        )
+    status = attempt.get("status")
+    if status in AUTH_GATE_STATUSES:
+        return (
+            VERDICT_INFERENCE_REFUSED_AT_THE_AUTH_GATE,
+            f"a servable request was refused at the gate ({status}). This "
+            "identity is not permitted to infer on this route, which no "
+            "earlier probe could establish -- a listing succeeded and an "
+            "unservable body got past the gate, and neither of those is this",
+        )
+    if status == 200:
+        if attempt.get("answer"):
+            return (
+                VERDICT_INFERENCE_SUCCEEDED,
+                "a model produced output for this identity on this route. "
+                "What refuses the Codex runtime is therefore not the resource, "
+                "the identity or the route, and a working reference now exists "
+                "to diff the runtime's request against",
+            )
+        if attempt.get("incomplete_reason") == "max_output_tokens":
+            # Not a success, and not a refusal either. Saying only
+            # "200 with no text" here would read as a failure of the route,
+            # when what happened is that a model ran and this probe's own
+            # ceiling cut it off before any text was emitted.
+            return (
+                VERDICT_VALID_REQUEST_INCONCLUSIVE,
+                "200, and the model ran -- the response is `incomplete` "
+                f"because it hit this probe's own ceiling of "
+                f"{attempt.get('max_output_tokens')} output tokens before "
+                "emitting text, which is what reasoning models do when the "
+                "ceiling is small. Tokens were spent, so this was not free. "
+                "Raise the ceiling and re-run; the request was accepted, "
+                "which is not the same as a completion and is not recorded "
+                "as one",
+            )
+        return (
+            VERDICT_VALID_REQUEST_INCONCLUSIVE,
+            "200 with no model text in the body. A status is not a completion "
+            "and this is not recorded as one",
+        )
+    return (
+        VERDICT_INFERENCE_REQUEST_REJECTED,
+        f"the route answered {status}, which is about the request or the "
+        "deployment name rather than about permission. This is not an "
+        "inference success and must not be read as one",
+    )
+
+
+def valid_request_probe(
+    settings: CodexProviderSettings,
+    *,
+    timeout: int = VALID_REQUEST_TIMEOUT_SECONDS,
+    redact: Callable[[Any], str | None],
+) -> dict[str, Any]:
+    """Mint the token the Codex way, then send one request that can be served."""
+    description = describe_settings(settings)
+    record: dict[str, Any] = {
+        "schema": VALID_REQUEST_SCHEMA,
+        # True, and the one probe in this file for which it is. The field
+        # exists so the redaction check can tell free records from paid ones,
+        # and writing `false` here to keep it in the cheap branch would be a
+        # lie that the check is built to catch.
+        "inference_requested": True,
+        "settings": description,
+        "settings_fingerprint": settings_fingerprint(description),
+        "endpoint_host_fingerprint": host_fingerprint(settings.base_url),
+        "limits": {
+            "attempts": VALID_REQUEST_ATTEMPTS,
+            "max_output_tokens": VALID_REQUEST_MAX_OUTPUT_TOKENS,
+            "timeout_seconds": timeout,
+            "concurrency": 1,
+            "abort_on": "the first non-200; there is no retry and no fallback",
+        },
+        "token": {"minted": False, "mechanism": "auth_command", "error": None},
+        "requests_planned": VALID_REQUEST_ATTEMPTS,
+        "requests_sent": 0,
+        "attempt": None,
+        "verdict": VERDICT_VALID_REQUEST_INCONCLUSIVE,
+        "verdict_note": "the probe did not run",
+        "not_established": list(NOT_ESTABLISHED_BY_A_VALID_REQUEST),
+    }
+    try:
+        token = mint_token_the_way_codex_does(settings, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 - a mint failure is the finding
+        record["token"]["error"] = redact(exc)
+        record["verdict_note"] = (
+            "the token could not be minted, so nothing was sent and nothing "
+            "about the resource was measured"
+        )
+        return record
+    record["token"]["minted"] = True
+
+    attempt = post_valid_request(settings, token, timeout=timeout)
+    record["requests_sent"] += 1
+    attempt["error"] = redact(attempt.get("error"))
+    attempt["message"] = redact(attempt.get("message"))
+    record["attempt"] = attempt
+    record["verdict"], record["verdict_note"] = classify_valid_request(attempt)
+    return record
+
+
 # ── Command line ────────────────────────────────────────────────────────────
 
 
@@ -1802,6 +2134,16 @@ def main(argv: list[str] | None = None) -> int:
         "Exits 0 only when it establishes an answer, not when it merely ran.",
     )
     parser.add_argument(
+        "--valid-request",
+        action="store_true",
+        help="send one request this route can actually serve: a model, a "
+        "trivial public input and a 16-token ceiling. This is the only "
+        "option here that can produce a completion, and the only one that "
+        "can establish whether this identity may infer on this route -- a "
+        "listing and an unservable body getting past the gate establish "
+        "neither. Exits 0 only on a 200 that carried model output.",
+    )
+    parser.add_argument(
         "--timeout",
         type=int,
         default=DEFAULT_TIMEOUT_SECONDS,
@@ -1820,6 +2162,7 @@ def main(argv: list[str] | None = None) -> int:
             ("--read-only-probe", args.read_only_probe),
             ("--auth-discriminator", args.auth_discriminator),
             ("--transmission-sweep", args.transmission_sweep),
+            ("--valid-request", args.valid_request),
             ("--send-request", args.send_request),
         )
         if on
@@ -1888,10 +2231,17 @@ def main(argv: list[str] | None = None) -> int:
             else 1
         )
 
+    if args.valid_request:
+        record = valid_request_probe(settings, redact=redact)
+        _emit(record, args.out)
+        # 0 only for a completion. A 401 here is the most informative result
+        # this script has ever produced and it is still not a pass: the exit
+        # code answers "did inference work", and nothing else may borrow it.
+        return 0 if record["verdict"] == VERDICT_INFERENCE_SUCCEEDED else 1
+
     if not args.send_request:
         _emit(_plan(description), args.out)
         return 0
-
     record = probe(settings, timeout=args.timeout, redact=redact)
     _emit(record, args.out)
     return 0 if record["verdict"] == VERDICT_CONNECTED else 1

--- a/batch-runner/tests/test_codex_foundry_connection_probe.py
+++ b/batch-runner/tests/test_codex_foundry_connection_probe.py
@@ -1029,22 +1029,23 @@ def _redaction_check() -> str:
 
 def _run_redaction_check(tmp_path, plan, endpoint=None):
     script = tmp_path / "check.py"
-    script.write_text(_redaction_check(), encoding="utf-8")
     plan_path = tmp_path / "plan.json"
     if plan is not None:
         plan_path.write_text(json.dumps(plan), encoding="utf-8")
-    body = _redaction_check().replace(
-        '"/tmp/codex-foundry-plan.json"', json.dumps(str(plan_path))
+    # Every path the check reads has to point somewhere this test owns.
+    # Left alone they read whatever a real dispatch happened to leave in /tmp
+    # on this machine, which would make the result depend on it. Rewritten by
+    # pattern rather than one at a time, so a path added to the check later
+    # cannot quietly reintroduce that.
+    body = re.sub(
+        r'"/tmp/(codex-foundry-[a-z-]+\.json)"',
+        lambda match: json.dumps(str(tmp_path / f"absent-{match.group(1)}")),
+        _redaction_check(),
     ).replace(
-        '"/tmp/codex-foundry-connection.json"',
-        json.dumps(str(tmp_path / "absent.json")),
-    ).replace(
-        # Every path in the checked list has to be pointed somewhere this test
-        # owns. Left alone, this one reads whatever a real dispatch happened to
-        # leave in /tmp on this machine.
-        '"/tmp/codex-foundry-readonly.json"',
-        json.dumps(str(tmp_path / "absent-readonly.json")),
+        json.dumps(str(tmp_path / "absent-codex-foundry-plan.json")),
+        json.dumps(str(plan_path)),
     )
+    assert "/tmp/codex-foundry" not in body, "a checked path still reads real /tmp"
     script.write_text(body, encoding="utf-8")
     environment = dict(os.environ)
     environment["FOUNDRY_PROJECT_ENDPOINT"] = endpoint or PROJECT_ENDPOINT
@@ -1061,6 +1062,9 @@ def _run_redaction_check(tmp_path, plan, endpoint=None):
 
 
 CLEAN_RECORD = {
+    # The check picks its rules by schema and refuses a record whose schema it
+    # does not know, so a stand-in without one is not a stand-in for anything.
+    "schema": SCHEMA,
     "observed": {"tool_execution_observed": False},
     "settings": {"endpoint_host_fingerprint": "sha256:0123456789abcdef"},
 }
@@ -1078,6 +1082,7 @@ def test_the_workflows_own_check_passes_a_clean_record(tmp_path):
         (
             "the account name",
             {
+                "schema": SCHEMA,
                 "observed": {"tool_execution_observed": False},
                 "note": f"account {ACCOUNT} refused the request",
             },
@@ -1085,6 +1090,7 @@ def test_the_workflows_own_check_passes_a_clean_record(tmp_path):
         (
             "the project name",
             {
+                "schema": SCHEMA,
                 "observed": {"tool_execution_observed": False},
                 "note": f"project {PROJECT} is not visible",
             },
@@ -1092,6 +1098,7 @@ def test_the_workflows_own_check_passes_a_clean_record(tmp_path):
         (
             "a url",
             {
+                "schema": SCHEMA,
                 "observed": {"tool_execution_observed": False},
                 "note": "POST https://elsewhere.example/responses failed",
             },
@@ -1099,13 +1106,14 @@ def test_the_workflows_own_check_passes_a_clean_record(tmp_path):
         (
             "a token",
             {
+                "schema": SCHEMA,
                 "observed": {"tool_execution_observed": False},
                 "note": "eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJodHRwcyJ9",
             },
         ),
         (
             "a claim of tool execution",
-            {"observed": {"tool_execution_observed": True}},
+            {"schema": SCHEMA, "observed": {"tool_execution_observed": True}},
         ),
     ],
 )
@@ -1116,9 +1124,29 @@ def test_the_workflows_own_check_catches_what_must_not_be_published(
 
     Held here rather than only in the workflow so the check itself cannot rot
     into a step that greps for nothing and reports clean.
+
+    Each record carries a schema the check recognises, so what catches it is
+    the rule named in the label. Without one they would all be caught by the
+    unknown-schema rule instead and every case here would pass while testing
+    nothing.
     """
     result = _run_redaction_check(tmp_path, record)
     assert result.returncode == 1, f"{label} was not caught: {result.stdout}"
+
+
+def test_a_record_whose_schema_the_check_does_not_know_is_refused(tmp_path):
+    """Fail closed. A check written for one record vouches only for that one.
+
+    The rules differ per schema -- a free probe must say it sent nothing, the
+    paid one must say it sent something -- so there is no rule left to apply
+    to a shape the check has never heard of. Passing it would mean reporting
+    clean on the strength of checks that were never run against it.
+    """
+    result = _run_redaction_check(
+        tmp_path, {"schema": "something_new/1", "observed": {}}
+    )
+    assert result.returncode == 1
+    assert "no check here" in result.stdout
 
 
 def test_a_run_with_no_record_is_not_reported_as_clean(tmp_path):

--- a/batch-runner/tests/test_codex_valid_request.py
+++ b/batch-runner/tests/test_codex_valid_request.py
@@ -1,0 +1,750 @@
+"""The one probe entitled to say inference worked, and the guards on that claim.
+
+Everything before this in the diagnostic asks the resource a question it can
+answer without serving anybody: a listing, a body with no model in it, a bearer
+that was never valid. Run ``34437632382`` finished that line of questioning --
+all six header arms, up to and including every runtime header at once with
+``stream: true``, still cleared the gate. No property the Codex runtime *adds*
+is what refuses it.
+
+What has never been sent to this resource is a request it could actually serve.
+So nobody knows whether this identity may infer here at all, and the two
+readings that remain -- "the model field resolves a deployment and a second
+authorization check refuses it" and "the resource is fine and something
+Codex-side is at fault" -- are not distinguishable from any record on disk.
+
+This file is the instrument's test, not the answer. It pins the parts that make
+the single request worth sending: that the body is servable, that there is
+exactly one of it, that a `200` carrying no text is *not* reported as a
+completion, and that the exit code means inference and nothing else. The probe
+costs money on the real host; every host in this file is a socket on this
+machine.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from diagnose_codex_foundry_connection import (  # noqa: E402
+    NOT_ESTABLISHED_BY_A_VALID_REQUEST,
+    VALID_REQUEST_ANSWER_KEPT_CHARS,
+    VALID_REQUEST_ATTEMPTS,
+    VALID_REQUEST_INPUT,
+    VALID_REQUEST_MAX_OUTPUT_TOKENS,
+    VALID_REQUEST_SCHEMA,
+    VERDICT_INFERENCE_REFUSED_AT_THE_AUTH_GATE,
+    VERDICT_INFERENCE_REQUEST_REJECTED,
+    VERDICT_INFERENCE_SUCCEEDED,
+    VERDICT_VALID_REQUEST_INCONCLUSIVE,
+    classify_valid_request,
+    main,
+    valid_request_probe,
+)
+
+# The redirected settings, the fake token and the auth-command printer belong
+# to the discriminator's tests. A second copy here would be a second thing to
+# keep true.
+from tests.test_codex_auth_discriminator import (  # noqa: E402
+    FAKE_TOKEN,
+    _printer,
+    _settings,
+    _with_auth_command,
+)
+
+
+def _no_redaction(value) -> str | None:
+    """Identity, so a test reads the message the host actually sent."""
+    return None if value is None else str(value)
+
+
+class _Host:
+    """A loopback host that answers with whatever payload the rule returns.
+
+    The sweep's host only ever produces an error envelope, because no arm of a
+    sweep can be served. This one has to be able to return a *completion*, so
+    the rule hands back a whole body rather than a message string.
+    """
+
+    def __init__(self, rule: Callable[[dict, dict], tuple[int, Any]]):
+        self.calls: list[dict] = []
+        self._lock = threading.Lock()
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *_args):  # noqa: D102 - silence the default
+                pass
+
+            def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler's spelling
+                length = int(self.headers.get("Content-Length") or 0)
+                raw = self.rfile.read(length) if length else b""
+                headers = {k.lower(): v for k, v in self.headers.items()}
+                try:
+                    parsed = json.loads(raw.decode("utf-8"))
+                except Exception:  # noqa: BLE001 - a body we cannot parse is data
+                    parsed = {}
+                with outer._lock:
+                    outer.calls.append(
+                        {"path": self.path, "headers": headers, "body": parsed}
+                    )
+                status, body = rule(headers, parsed)
+                payload = (
+                    body.encode("utf-8")
+                    if isinstance(body, str)
+                    else json.dumps(body).encode("utf-8")
+                )
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._server.daemon_threads = True
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self) -> "_Host":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=10)
+
+
+def _answers(text: str = "ok", *, usage: dict | None = None):
+    """A host that completes, in the shape the Responses API returns."""
+
+    def rule(_headers: dict, body: dict) -> tuple[int, Any]:
+        payload: dict[str, Any] = {
+            "id": "resp_test",
+            "model": body.get("model"),
+            "output_text": text,
+        }
+        if usage is not None:
+            payload["usage"] = usage
+        return 200, payload
+
+    return rule
+
+
+def _refuses(status: int, message: str):
+    def rule(_headers: dict, _body: dict) -> tuple[int, Any]:
+        return status, {"error": {"message": message}}
+
+    return rule
+
+
+def _probe(host: _Host, tmp_path: Path) -> dict:
+    settings = _with_auth_command(_settings(host.port), _printer(tmp_path))
+    return valid_request_probe(settings, redact=_no_redaction)
+
+
+# ── What goes on the wire ───────────────────────────────────────────────────
+
+
+def test_the_body_is_a_request_the_route_can_actually_serve(tmp_path: Path):
+    """The whole point, asserted rather than trusted.
+
+    Every earlier probe deliberately sent something unservable. If this one
+    drifted into doing the same -- a missing ``model``, an empty ``input`` --
+    it would buy another `400` and answer nothing, while still being reported
+    as the probe that was supposed to settle the question.
+    """
+    with _Host(_answers()) as host:
+        record = _probe(host, tmp_path)
+        sent = host.calls[0]["body"]
+
+    assert sent["model"] == "a-deployment", sent
+    assert sent["input"] == VALID_REQUEST_INPUT
+    assert record["attempt"]["status"] == 200
+
+
+def test_the_output_ceiling_is_on_the_wire_and_not_only_in_the_record(
+    tmp_path: Path,
+):
+    """A limit that is written down but not sent is a limit on the report."""
+    with _Host(_answers()) as host:
+        record = _probe(host, tmp_path)
+        sent = host.calls[0]["body"]
+
+    assert sent["max_output_tokens"] == VALID_REQUEST_MAX_OUTPUT_TOKENS
+    assert record["limits"]["max_output_tokens"] == VALID_REQUEST_MAX_OUTPUT_TOKENS
+    assert record["attempt"]["max_output_tokens"] == VALID_REQUEST_MAX_OUTPUT_TOKENS
+
+
+def test_nothing_is_streamed_and_nothing_is_stored(tmp_path: Path):
+    """``stream`` off so one read gets the whole answer; ``store`` off so the
+    prompt is not retained server-side by a diagnostic that had no reason to."""
+    with _Host(_answers()) as host:
+        _probe(host, tmp_path)
+        sent = host.calls[0]["body"]
+
+    assert sent["stream"] is False
+    assert sent["store"] is False
+
+
+def test_the_input_carries_no_benchmark_content(tmp_path: Path):
+    """A diagnostic prompt, kept trivial and public on purpose."""
+    with _Host(_answers()) as host:
+        _probe(host, tmp_path)
+        sent = host.calls[0]["body"]
+
+    assert isinstance(sent["input"], str)
+    assert len(sent["input"]) < 120, "this is a status check, not a task"
+
+
+def test_the_minted_bearer_is_what_is_sent(tmp_path: Path):
+    """Same credential the runtime uses; a probe on a different one proves
+    nothing about the runtime's refusal."""
+    with _Host(_answers()) as host:
+        _probe(host, tmp_path)
+        headers = host.calls[0]["headers"]
+
+    assert headers["authorization"] == f"Bearer {FAKE_TOKEN}"
+
+
+def test_the_request_goes_to_responses_under_the_configured_base_url(
+    tmp_path: Path,
+):
+    """The address has been cleared as a cause once; keep it cleared."""
+    with _Host(_answers()) as host:
+        _probe(host, tmp_path)
+
+    assert host.calls[0]["path"] == "/v1/responses"
+
+
+# ── Exactly one of them ─────────────────────────────────────────────────────
+
+
+def test_one_request_is_sent_when_it_succeeds(tmp_path: Path):
+    with _Host(_answers()) as host:
+        record = _probe(host, tmp_path)
+
+    assert len(host.calls) == 1
+    assert record["requests_sent"] == 1
+    assert record["requests_planned"] == VALID_REQUEST_ATTEMPTS == 1
+
+
+def test_a_refusal_is_not_retried(tmp_path: Path):
+    """The ceiling that matters most. A retry loop added later would multiply
+    the cost of every future failure silently, so the count is asserted on the
+    failing path and not just on the happy one."""
+    with _Host(_refuses(401, "Access denied")) as host:
+        record = _probe(host, tmp_path)
+
+    assert len(host.calls) == 1
+    assert record["requests_sent"] == 1
+    assert "no retry" in record["limits"]["abort_on"]
+
+
+def test_the_limits_are_declared_in_the_record(tmp_path: Path):
+    """Pre-declared, so a run that exceeded them is visibly a different run."""
+    with _Host(_answers()) as host:
+        record = _probe(host, tmp_path)
+
+    limits = record["limits"]
+    assert limits["attempts"] == 1
+    assert limits["concurrency"] == 1
+    assert limits["timeout_seconds"] > 0
+    assert limits["abort_on"]
+
+
+# ── Reading the answer, and refusing to overstate it ────────────────────────
+
+
+def test_two_hundred_with_text_is_the_only_success(tmp_path: Path):
+    with _Host(_answers("ok")) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_INFERENCE_SUCCEEDED
+    assert record["attempt"]["answer"] == "ok"
+    assert record["attempt"]["model_echoed"] == "a-deployment"
+
+
+def test_the_other_response_shape_is_read_too(tmp_path: Path):
+    """Responses bodies carry text in ``output[].content[].text`` as well as in
+    ``output_text``. Missing one would report a real completion as a failure."""
+
+    def rule(_headers: dict, _body: dict) -> tuple[int, Any]:
+        return 200, {
+            "output": [{"content": [{"type": "output_text", "text": "ok"}]}],
+        }
+
+    with _Host(rule) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_INFERENCE_SUCCEEDED
+    assert record["attempt"]["answer"] == "ok"
+
+
+def test_two_hundred_without_text_is_not_reported_as_inference(tmp_path: Path):
+    """The guard this probe exists to have.
+
+    A status is not a completion. Every previous finding in this diagnostic was
+    a status read for more than it said, and the one probe allowed to claim
+    inference must be the strictest about it.
+    """
+
+    def rule(_headers: dict, _body: dict) -> tuple[int, Any]:
+        return 200, {"id": "resp_test", "output": []}
+
+    with _Host(rule) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_VALID_REQUEST_INCONCLUSIVE
+    assert record["verdict"] != VERDICT_INFERENCE_SUCCEEDED
+    assert record["attempt"]["answer"] is None
+
+
+def test_whitespace_is_not_an_answer(tmp_path: Path):
+    with _Host(_answers("   \n  ")) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_VALID_REQUEST_INCONCLUSIVE
+
+
+def test_the_ceiling_is_large_enough_for_a_model_that_reasons_first():
+    """The failure mode that would have wasted the decisive request.
+
+    The deployments this is pointed at spend output tokens on reasoning before
+    emitting any text. At the API's minimum of 16 the ceiling is consumed
+    entirely by that, and the answer comes back `200 incomplete` with no text
+    -- correctly refused as a success, and therefore one paid request spent on
+    an artefact of this probe's own configuration.
+    """
+    assert VALID_REQUEST_MAX_OUTPUT_TOKENS >= 256
+
+
+def test_a_truncated_answer_names_the_ceiling_rather_than_blaming_the_route(
+    tmp_path: Path,
+):
+    """A `200 incomplete` is a model that ran, not a route that said nothing.
+
+    Reported as inconclusive -- no text is no completion -- but the note has to
+    say which of the two it was, or the next reader repairs the wrong thing.
+    """
+
+    def rule(_headers: dict, _body: dict) -> tuple[int, Any]:
+        return 200, {
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output": [],
+            "usage": {"input_tokens": 9, "output_tokens": 512},
+        }
+
+    with _Host(rule) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_VALID_REQUEST_INCONCLUSIVE
+    assert record["attempt"]["response_status"] == "incomplete"
+    assert record["attempt"]["incomplete_reason"] == "max_output_tokens"
+    note = record["verdict_note"]
+    assert "the model ran" in note
+    assert "not free" in note
+    assert str(VALID_REQUEST_MAX_OUTPUT_TOKENS) in note
+
+
+def test_a_completed_response_records_its_api_status_too(tmp_path: Path):
+    """The Responses status is not the HTTP status; both are written down."""
+
+    def rule(_headers: dict, _body: dict) -> tuple[int, Any]:
+        return 200, {"status": "completed", "output_text": "ok"}
+
+    with _Host(rule) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_INFERENCE_SUCCEEDED
+    assert record["attempt"]["response_status"] == "completed"
+    assert record["attempt"]["incomplete_reason"] is None
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_a_refusal_at_the_gate_is_named_as_one(tmp_path: Path, status: int):
+    """The finding no earlier probe could produce: a *servable* request
+    refused. That is a permission fact, unlike a `400` on a body nothing could
+    serve."""
+    with _Host(_refuses(status, "Access denied")) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_INFERENCE_REFUSED_AT_THE_AUTH_GATE
+    assert str(status) in record["verdict_note"]
+
+
+@pytest.mark.parametrize("status", [400, 404, 429, 500])
+def test_other_statuses_are_rejections_and_never_successes(
+    tmp_path: Path, status: int
+):
+    with _Host(_refuses(status, "nope")) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["verdict"] == VERDICT_INFERENCE_REQUEST_REJECTED
+    assert record["verdict"] != VERDICT_INFERENCE_SUCCEEDED
+
+
+def test_a_transport_failure_is_inconclusive_not_a_refusal(tmp_path: Path):
+    """Nothing reached a status, so nothing was learned about the identity."""
+    with _Host(_answers()) as host:
+        port = host.port
+    settings = _with_auth_command(_settings(port), _printer(tmp_path))
+    record = valid_request_probe(settings, redact=_no_redaction, timeout=2)
+
+    assert record["verdict"] == VERDICT_VALID_REQUEST_INCONCLUSIVE
+    assert record["attempt"]["error"]
+    assert record["attempt"]["status"] is None
+
+
+def test_the_answer_is_capped(tmp_path: Path):
+    """A model that ignored the ceiling cannot spill into the artifact."""
+    with _Host(_answers("y" * 5000)) as host:
+        record = _probe(host, tmp_path)
+
+    assert len(record["attempt"]["answer"]) == VALID_REQUEST_ANSWER_KEPT_CHARS
+
+
+# ── Usage, without inventing a price ────────────────────────────────────────
+
+
+def test_usage_is_recorded_with_no_price_attached(tmp_path: Path):
+    """Counts are measured; the rate is not registered here. Filling
+    ``price_usd`` would put a number in a ledger that nothing measured."""
+    usage = {"input_tokens": 11, "output_tokens": 2, "total_tokens": 13}
+    with _Host(_answers("ok", usage=usage)) as host:
+        record = _probe(host, tmp_path)
+
+    reported = record["attempt"]["usage"]
+    assert reported["reported"] is True
+    assert reported["input_tokens"] == 11
+    assert reported["output_tokens"] == 2
+    assert reported["price_usd"] is None
+    assert reported["pricing"] == "partial"
+
+
+def test_a_response_without_usage_is_null_and_not_zero(tmp_path: Path):
+    """A missing count is unknown. Zero is a measurement."""
+    with _Host(_answers("ok")) as host:
+        record = _probe(host, tmp_path)
+
+    reported = record["attempt"]["usage"]
+    assert reported["reported"] is False
+    assert reported["input_tokens"] is None
+    assert reported["pricing"] == "null"
+    assert reported["price_usd"] is None
+
+
+# ── The record ──────────────────────────────────────────────────────────────
+
+
+def test_the_record_admits_it_asked_for_inference(tmp_path: Path):
+    """The redaction check tells free records from paid ones by this field.
+    Writing ``false`` to stay in the cheap branch is the lie it is built to
+    catch, so the truth is asserted at the source."""
+    with _Host(_answers()) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["schema"] == VALID_REQUEST_SCHEMA
+    assert record["inference_requested"] is True
+
+
+def test_no_token_survives_into_the_record(tmp_path: Path):
+    with _Host(_answers()) as host:
+        record = _probe(host, tmp_path)
+
+    assert FAKE_TOKEN not in json.dumps(record)
+    assert record["token"] == {
+        "minted": True,
+        "mechanism": "auth_command",
+        "error": None,
+    }
+
+
+def test_the_resource_is_named_only_by_fingerprint(tmp_path: Path):
+    with _Host(_answers()) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["settings_fingerprint"].startswith("sha256:")
+    assert record["endpoint_host_fingerprint"].startswith("sha256:")
+    assert "example-account" not in json.dumps(record)
+
+
+def test_a_mint_failure_sends_nothing(tmp_path: Path):
+    """No token, no request, no cost -- and a record saying so."""
+    with _Host(_answers()) as host:
+        settings = _with_auth_command(
+            _settings(host.port), [sys.executable, "-c", "raise SystemExit(3)"]
+        )
+        record = valid_request_probe(settings, redact=_no_redaction)
+        calls = list(host.calls)
+
+    assert calls == []
+    assert record["requests_sent"] == 0
+    assert record["token"]["minted"] is False
+    assert record["verdict"] == VERDICT_VALID_REQUEST_INCONCLUSIVE
+    assert "nothing was sent" in record["verdict_note"]
+
+
+def test_the_record_says_what_a_completion_would_still_not_prove(tmp_path: Path):
+    """A `200` here is the best result this diagnostic can produce and it is
+    still four steps short of a benchmark run. The limits ride with the record
+    so the good news cannot travel without them."""
+    with _Host(_answers()) as host:
+        record = _probe(host, tmp_path)
+
+    assert record["not_established"] == list(NOT_ESTABLISHED_BY_A_VALID_REQUEST)
+    joined = " ".join(record["not_established"])
+    assert "220-task" in joined
+    assert "not that the Codex runtime can" in joined
+    assert "partial" in joined
+
+
+def test_the_classifier_never_calls_an_unread_status_a_success():
+    """Belt and braces on the one verdict that may not be wrong."""
+    for attempt in (
+        {"status": 200, "answer": None},
+        {"status": 401, "answer": "ok"},
+        {"status": 400, "answer": "ok"},
+        {"status": None, "error": "boom"},
+        {"status": 200, "answer": "", "error": None},
+    ):
+        verdict, note = classify_valid_request(attempt)
+        assert verdict != VERDICT_INFERENCE_SUCCEEDED, attempt
+        assert note
+
+
+# ── The workflow wiring ─────────────────────────────────────────────────────
+
+
+def _valid_request_record() -> dict:
+    return {
+        "schema": VALID_REQUEST_SCHEMA,
+        "inference_requested": True,
+        "settings": {"model": "a-deployment"},
+        "token": {"minted": True, "mechanism": "auth_command", "error": None},
+        "requests_planned": 1,
+        "requests_sent": 1,
+        "attempt": {"status": 200, "answer": "ok", "usage": {"pricing": "partial"}},
+        "verdict": VERDICT_INFERENCE_SUCCEEDED,
+        "not_established": ["urllib, not the runtime; unpriced; not a task solved"],
+    }
+
+
+def _steps() -> list[dict]:
+    import yaml
+
+    from tests.test_codex_auth_discriminator import WORKFLOW
+
+    parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return parsed["jobs"]["diagnose"]["steps"]
+
+
+def _step() -> dict:
+    return next(s for s in _steps() if s.get("id") == "valid_request")
+
+
+def test_the_paid_step_is_off_unless_it_is_asked_for_and_pinned():
+    """Two conditions, like the turn's. The input is the person's intention
+    and the fingerprint is the machine's evidence that the intention is about
+    the right resource; intention alone once bought a paid call."""
+    guard = _step()["if"]
+    assert "inputs.send_valid_request" in guard
+    assert "steps.pinned.outputs.confirmed == 'yes'" in guard
+
+
+def test_the_input_defaults_to_off():
+    import yaml
+
+    from tests.test_codex_auth_discriminator import WORKFLOW
+
+    parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    # `on:` parses as the boolean True in YAML 1.1, which is why this is not
+    # spelled the obvious way.
+    inputs = parsed[True]["workflow_dispatch"]["inputs"]
+    assert inputs["send_valid_request"]["default"] is False
+
+
+def test_the_paid_step_cannot_also_buy_a_codex_turn():
+    """One purchase per step. ``--send-request`` here would spend twice from a
+    step whose ceilings only describe one of them."""
+    run = _step()["run"]
+    assert "--valid-request" in run
+    assert "--send-request" not in run
+
+
+def test_the_step_fails_if_it_sent_more_than_it_planned():
+    """The ceiling that costs money if it slips, checked on the wire count
+    rather than on the constant."""
+    run = _step()["run"]
+    assert "requests_sent" in run and "requests_planned" in run
+    assert 'record["token"]["minted"]' in run
+
+
+def test_the_summary_reports_whether_text_came_back_not_the_text():
+    """A model's words do not belong in a job summary; whether there were any
+    is the whole finding."""
+    summary = next(s for s in _steps() if s.get("name") == "Summary")["run"]
+    assert "VR_TEXT=" in summary
+    assert "bool(" in summary
+    assert "VR_PRICING" in summary
+
+
+def test_the_record_is_published_with_the_others():
+    keep = next(s for s in _steps() if s.get("name") == "Keep the record")
+    assert "/tmp/codex-foundry-valid-request.json" in keep["with"]["path"]
+
+
+def test_the_leak_check_reads_it_by_its_real_path():
+    from tests.test_codex_auth_discriminator import _leak_check_source
+
+    assert '"/tmp/codex-foundry-valid-request.json"' in _leak_check_source()
+
+
+def test_the_leak_check_accepts_a_valid_request_record(tmp_path: Path):
+    from tests.test_codex_auth_discriminator import _run_leak_check
+
+    code, output = _run_leak_check(
+        tmp_path, {"codex-foundry-valid-request.json": _valid_request_record()}
+    )
+    assert code == 0, output
+    assert "record=clean (1 checked)" in output
+
+
+def test_the_leak_check_refuses_a_paid_record_that_denies_being_paid(
+    tmp_path: Path,
+):
+    """The free branch is the cheap branch. A paid record claiming
+    ``inference_requested: false`` would hide a real request inside it."""
+    from tests.test_codex_auth_discriminator import _run_leak_check
+
+    record = _valid_request_record()
+    record["inference_requested"] = False
+    code, output = _run_leak_check(
+        tmp_path, {"codex-foundry-valid-request.json": record}
+    )
+    assert code == 1
+    assert "denies sending a request" in output
+
+
+def test_the_leak_check_refuses_a_record_that_sent_more_than_it_planned(
+    tmp_path: Path,
+):
+    from tests.test_codex_auth_discriminator import _run_leak_check
+
+    record = _valid_request_record()
+    record["requests_sent"] = 4
+    code, output = _run_leak_check(
+        tmp_path, {"codex-foundry-valid-request.json": record}
+    )
+    assert code == 1
+    assert "more requests than it planned" in output
+
+
+def test_an_unrecognised_schema_is_withheld_rather_than_waved_through(
+    tmp_path: Path,
+):
+    """The branch that used to be the turn's ``else``.
+
+    A new record shape landing in a branch written for a different one is how
+    the sweep record crashed this check in CI. That crash was safe by luck; on
+    the paid probe it would mean the money was already spent and the evidence
+    thrown away. An unknown schema is now refused by name.
+    """
+    from tests.test_codex_auth_discriminator import _run_leak_check
+
+    record = _valid_request_record()
+    record["schema"] = "codex_foundry_something_new/1"
+    code, output = _run_leak_check(
+        tmp_path, {"codex-foundry-valid-request.json": record}
+    )
+    assert code == 1
+    assert "has no check here" in output
+
+
+def test_the_turn_record_still_has_its_own_check(tmp_path: Path):
+    """Naming the branches must not have quietly dropped one."""
+    from tests.test_codex_auth_discriminator import _run_leak_check
+
+    record = {
+        "schema": "codex_foundry_connection/2",
+        "verdict": "not_sent",
+        "observed": {"tool_execution_observed": True},
+    }
+    code, output = _run_leak_check(
+        tmp_path, {"codex-foundry-connection.json": record}
+    )
+    assert code == 1
+    assert "claims tool execution" in output
+
+
+# ── The command line ────────────────────────────────────────────────────────
+
+
+def _run_main(host: _Host, tmp_path: Path, monkeypatch) -> tuple[int, dict]:
+    import diagnose_codex_foundry_connection as module
+
+    monkeypatch.setattr(
+        module,
+        "settings_from_environment",
+        lambda *_a, **_k: _with_auth_command(_settings(host.port), _printer(tmp_path)),
+    )
+    out = tmp_path / "valid.json"
+    code = main(
+        ["--deployment", "a-deployment", "--valid-request", "--out", str(out)]
+    )
+    return code, json.loads(out.read_text(encoding="utf-8"))
+
+
+def test_exit_zero_means_inference_worked(tmp_path: Path, monkeypatch):
+    with _Host(_answers("ok")) as host:
+        code, written = _run_main(host, tmp_path, monkeypatch)
+
+    assert code == 0
+    assert written["verdict"] == VERDICT_INFERENCE_SUCCEEDED
+
+
+def test_a_refusal_does_not_exit_zero_however_informative_it_is(
+    tmp_path: Path, monkeypatch
+):
+    """A `401` here would be the most useful thing this script has ever
+    produced, and it is still not inference working. The exit code answers one
+    question and nothing else may borrow it."""
+    with _Host(_refuses(401, "Access denied")) as host:
+        code, written = _run_main(host, tmp_path, monkeypatch)
+
+    assert code == 1
+    assert written["verdict"] == VERDICT_INFERENCE_REFUSED_AT_THE_AUTH_GATE
+
+
+def test_a_two_hundred_without_text_does_not_exit_zero(tmp_path: Path, monkeypatch):
+    def rule(_headers: dict, _body: dict) -> tuple[int, Any]:
+        return 200, {"output": []}
+
+    with _Host(rule) as host:
+        code, _written = _run_main(host, tmp_path, monkeypatch)
+
+    assert code == 1
+
+
+def test_it_refuses_to_run_beside_the_other_probes(capsys):
+    """They write different records to the same ``--out``; one would win."""
+    for extra in (
+        ["--read-only-probe"],
+        ["--send-request"],
+        ["--auth-discriminator"],
+        ["--transmission-sweep"],
+    ):
+        with pytest.raises(SystemExit):
+            main(["--deployment", "d", "--valid-request", *extra])
+        assert "run them separately" in capsys.readouterr().err

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -1049,6 +1049,67 @@ paid run must be preceded by a fresh smoke at the new fingerprint.
   authorization is checked before the body is read. It does not show that a
   servable body would be served — the only request that could show that is the
   one this diagnostic never sends. Nothing here moves the 220-task column.
+- **The sweep ran, and it is a clean null: run `34437632382`, seven requests,
+  nothing closed the gate.** Baseline `400`. `Accept: text/event-stream` `400`.
+  `originator` + `User-Agent` `400`. All six session/turn headers `400`.
+  `stream: true` `400`. **Everything at once** — nine headers plus the body
+  flag — `400`, with the same `Missed model deployment` text as the baseline
+  and a text different from the control's every time. The control was `401`, so
+  the instrument was live for all seven. `properties_that_closed_the_gate: []`.
+
+  So no property the runtime *adds to its headers* is what refuses it, and the
+  remaining suspects are the part of the body the sweep cannot vary and the
+  transport. That list is shorter than it looks, because every free probe here
+  omits exactly one field on purpose: `model`. It is the field that resolves a
+  request to a deployment, and therefore the field a per-deployment
+  authorization check would have to key on. A body with no model in it may
+  simply never reach that check — which would explain, without any of the
+  transmission hypotheses, why the same token clears the gate for `urllib` and
+  is refused for a runtime that names a model.
+- **What has never been sent to this resource is a request it could serve.** Not
+  once, across a listing, four transmission hypotheses, an auth discriminator
+  and a seven-arm sweep. So the question *may this identity infer here* is
+  still open, and no record on disk narrows it. `--valid-request` sends one
+  servable Responses request through plain `urllib`: the deployment named, a
+  trivial public prompt, `max_output_tokens: 512`, `stream: false`,
+  `store: false`, one attempt, no retry, no fallback, 90-second wall clock.
+  Gated on its own `send_valid_request` input *and* the resource fingerprint,
+  so it cannot be reached by a forgotten flag. Pinned by
+  `batch-runner/tests/test_codex_valid_request.py`.
+
+  It is worth its cost because its three outcomes point at three different
+  repairs. `200` **with model text** means the resource, the identity and the
+  route are all fine and what refuses Codex is Codex-side — and a working
+  request now exists to diff the runtime's against. `401`/`403` on a *servable*
+  body is a permission fact, the first evidence in this whole diagnostic that
+  would bear on a role, and unavailable from any free probe. `400`/`404` names
+  the shape or the deployment and is still not about permission.
+
+  Read strictly. A `200` carrying no text is recorded as inconclusive, not as a
+  success, and the exit code is `0` only for a completion. Token counts are
+  written down as the response reported them with `price_usd: null` and
+  `pricing: partial`, because no rate for this route is registered here —
+  `partial` means unpriced, not free. And a completion still says nothing about
+  the Codex path (`urllib` is not the runtime), about the harness (no tool ran,
+  no file was written), or about the 220-task column.
+
+  The ceiling is 512 output tokens rather than the API's minimum of 16, and that
+  is not a cost decision. These deployments reason before they emit text, so at
+  16 the ceiling is spent entirely on reasoning and the answer is `200
+  incomplete` with nothing in it — refused as a success, correctly, and
+  therefore the decisive request wasted on an artefact of this probe's own
+  configuration. If it happens anyway the record says which: the Responses
+  status and `incomplete_details.reason` sit beside the HTTP status, and the
+  note names the ceiling instead of leaving a bare "200 with no text" to be read
+  as a failure of the route.
+
+  The leak check needed rebuilding for it. Its branches were three free-record
+  prefixes with the turn record as the `else`; this record is the first *paid*
+  one and has no `observed`, so it would have crashed in the same place the
+  sweep did — except after the money was spent, and the crash skips `Keep the
+  record`. Every schema is now matched by name, the paid one is required to
+  admit `inference_requested: true` rather than merely permitted to, and an
+  unrecognised schema is refused instead of falling into somebody else's check.
 - **The exec leg is closed, on one host, and it took a repair to close it.** The
   host limit was real and was closed by finding a host rather than by removing
   isolation: no sandbox was disabled, no network was opened, no container was


### PR DESCRIPTION
## What this adds

`--valid-request`: the first request in this diagnostic that the route can
actually serve.

Every probe here so far deliberately sends something **unservable** — a
listing, a body with no `model` in it, a bearer that was never valid. That is
what makes them free, and it is also their ceiling.

Run [`34437632382`](https://github.com/Hyeonsangjeon/gdpval-realworks/actions/runs/34437632382)
closed out that line of questioning. Seven requests, and **nothing closed the
gate**:

| arm | status |
|---|---|
| baseline (nothing added) | `400 Missed model deployment` |
| `Accept: text/event-stream` | `400`, same text as baseline |
| `originator` + `User-Agent` | `400` |
| all six session/turn headers | `400` |
| body `stream: true` | `400` |
| **everything at once** (9 headers + the flag) | `400` |
| control (obviously invalid bearer) | `401` — the instrument was live |

`properties_that_closed_the_gate: []`. No property the Codex runtime *adds to
its headers* is what refuses it.

So the remaining suspects are the body and the transport — and that list is
shorter than it looks. Every free probe omits exactly one field on purpose:
`model`. It is the field that resolves a request to a deployment, and therefore
the field a per-deployment authorization check would have to key on. A body
with no model in it may never reach that check at all, which would explain,
without any transmission hypothesis, why the same token clears the gate for
`urllib` and is refused for a runtime that names a model.

**The question nobody has asked this resource is whether this identity may
infer here.** A listing returning `200` does not answer it. An unservable body
returning `400` does not answer it. This step does.

## The request

One. Named deployment, a trivial public prompt, `max_output_tokens: 512`,
`stream: false`, `store: false`, no retry, no fallback, 90-second wall clock,
concurrency 1. The ceilings are constants in the script, not workflow inputs,
so a dispatch cannot widen them. Gated on its own `send_valid_request` input
**and** the resource fingerprint, so a forgotten flag cannot reach it.

512 rather than the API's minimum of 16, and that is not a cost decision. These
deployments reason before they emit text, so at 16 the ceiling is spent
entirely on reasoning and the answer comes back `200 incomplete` with nothing
in it — refused as a success, correctly, and therefore the one decisive request
spent on an artefact of this probe's own configuration. If it happens anyway
the record says which: the Responses status and `incomplete_details.reason` sit
beside the HTTP status, and the note names the ceiling rather than leaving a
bare "200 with no text" to be read as a failure of the route.

Three outcomes, three different repairs:

- **`200` with model text** — resource, identity and route are all fine. What
  refuses Codex is Codex-side, and there is now a working request to diff the
  runtime's against.
- **`401`/`403`** on a *servable* body — a permission fact. The first evidence
  in this diagnostic that would bear on a role, and unobtainable from any free
  probe.
- **`400`/`404`** — the shape or the deployment name. Still not permission.

## Read strictly

- A `200` carrying no model text is recorded as **inconclusive**, not as a
  success.
- Exit `0` only for a completion. A `401` here would be the most useful result
  this script has ever produced and it still exits `1`.
- Usage is recorded as the response reported it, with `price_usd: null` and
  `pricing: partial`. No rate for this route is registered in this repository.
  `partial` means unpriced — **not free**.
- The record carries what a completion would still not establish: this is
  `urllib` and not the runtime; no tool ran and no file was written; the
  220-task column is untouched either way.

## Fixed: the redaction check would have destroyed this record

Its branches were three free-record schema prefixes with the turn record as the
`else`. That failed closed once, for real, on the sweep record — by `KeyError`,
which is a crash that happens to be safe.

The valid-request record has `inference_requested: true` and no `observed`, so
it would have hit the same branch. There the accident is expensive: it is the
**paid** record, so the run that crashes is the run that already spent the
money, and a failed check skips `Keep the record` and destroys the evidence.

Every schema is now matched by name. The paid record is *required* to admit
`inference_requested: true` rather than merely permitted to — writing `false`
to hide inside the cheap branch is exactly what this check exists to catch. An
unrecognised schema is refused by name instead of being vouched for by a check
written for something else.

## Tests

48 new in `batch-runner/tests/test_codex_valid_request.py`, every host a socket
on this machine, no token minted, nothing leaving loopback. They pin the body
that goes on the wire, the count (including on the failing path, where a retry
loop would be silent), both Responses text shapes, the refusal to call a
textless `200` a success, the usage fields, the redaction, and the workflow
wiring — including that the paid step cannot also buy a Codex turn.

Full backend suite green locally.
