### PR TITLE
fix(agentic-v2): stop offering tools the service will refuse

### DIFF
--- a/batch-runner/core/agentic_v2_contract.py
+++ b/batch-runner/core/agentic_v2_contract.py
@@ -430,6 +430,33 @@ class AgenticV2Lifecycle:
 
 
 def responses_tool_definitions() -> list[dict]:
+    """The tools as the Responses API is asked to present them.
+
+    ``strict`` is false, and deliberately. It is not a description of how
+    carefully the arguments are checked — it is a promise that the schema
+    fits the narrow subset the service will enforce for the model, and none
+    of these schemas do. ``workspace_apply``, ``exec_run`` and ``browser_run``
+    are a ``oneOf`` at the root, so each operation carries exactly the fields
+    that operation needs and no others; ``capabilities_query`` has genuinely
+    optional fields. Both shapes are outside the strict subset, which wants a
+    single object with every property required.
+
+    Claiming ``strict`` anyway does not degrade to a laxer check. The service
+    validates the schema against the subset when the request arrives and
+    refuses the whole call with ``400`` before the model is ever asked, which
+    is what happened to the first paid stage A dispatch on 2026-09-10: nothing
+    ran, nothing was charged, and the run recorded a model that never spoke.
+
+    Nothing is loosened by dropping it. ``strict`` only ever constrained what
+    the model was free to emit; what the desk is willing to *act* on is
+    decided by :func:`validate_tool_arguments`, which validates against these
+    same schemas in full — ``oneOf``, ``pattern``, length bounds and all — and
+    raises on anything that does not fit. That check is unchanged and remains
+    the only thing standing between a tool call and the workspace. The cost of
+    the change is a turn occasionally spent on arguments the model has to be
+    told were malformed, and that is the correct thing to pay for a call that
+    otherwise cannot be made at all.
+    """
     descriptions = {
         "capabilities_query": "Discover actual task-environment capabilities and remaining budgets.",
         "workspace_apply": "Perform one bounded operation in the task-local workspace.",
@@ -446,7 +473,7 @@ def responses_tool_definitions() -> list[dict]:
             "name": name,
             "description": descriptions[name],
             "parameters": TOOL_SCHEMAS[name],
-            "strict": True,
+            "strict": False,
         }
         for name in TOOL_NAMES
     ]

--- a/batch-runner/core/agentic_v2_model_voice.py
+++ b/batch-runner/core/agentic_v2_model_voice.py
@@ -49,10 +49,34 @@ from core.agentic_v2_conversation import (
 )
 from core.agentic_v2_stage_one_budget import StageOneBudget
 from core.execution_envelope_cost import ModelPrice
+from core.provider_refusal import classify_provider_refusal
 
 # A stated reason is shown to a person, not parsed, and the loop trims what it
 # keeps. Kept short here so the trimming never has to happen.
 _SHORTEST_USEFUL_NOTE = 200
+
+
+def _why_the_call_failed(error: BaseException) -> str:
+    """The note left behind when the service would not take the request.
+
+    The class name alone is what the first paid stage A dispatch recorded, and
+    it was not enough to act on: ``BadRequestError`` says the request was
+    refused and nothing whatever about which part of it was wrong. Diagnosing
+    that meant reasoning about the payload instead of reading the answer, and
+    the answer had already been given.
+
+    So the status and the provider's own code are carried too, through
+    :func:`classify_provider_refusal`, which takes those two facts and reads
+    nothing else off the exception. The message, the body, the request and the
+    response headers do not appear here — an endpoint, an account, a project
+    or a deployment name cannot get through a code-shaped allow-list, and the
+    same call that names *what* was refused must not name *who* refused it.
+    """
+    classification = classify_provider_refusal(error)
+    detail = type(error).__name__
+    if classification:
+        detail = f"{detail} ({classification})"
+    return f"asking the model failed: {detail}"[:_SHORTEST_USEFUL_NOTE]
 
 
 class ResolvedModelDisagrees(RuntimeError):
@@ -299,9 +323,7 @@ class AzureFoundryVoice:
         try:
             response = self.client.responses.create(**payload)
         except Exception as error:  # the service, the network, or the route
-            return GaveUp(
-                note=f"asking the model failed: {type(error).__name__}"[:_SHORTEST_USEFUL_NOTE]
-            )
+            return GaveUp(note=_why_the_call_failed(error))
 
         usage = _usage_from(response)
         if usage is None:

--- a/batch-runner/core/code_interpreter.py
+++ b/batch-runner/core/code_interpreter.py
@@ -30,6 +30,13 @@ from typing import Optional
 from core.azure_ai_clients import AzureAIWorkload, validate_client_capabilities
 from core.config import DEFAULT_TOKENS
 from core.prompt_loader import load_prompt, render_prompt
+from core.provider_refusal import (
+    PROVIDER_CODE_ATTRIBUTES,
+    PROVIDER_CODE_BODY_KEYS,
+    PROVIDER_CODE_SHAPE,
+    classify_provider_refusal,
+    provider_code_of,
+)
 from core.execution_envelope_observed import (
     API_FAMILY_RESPONSES,
     RecordsItsFirstRequest,
@@ -40,87 +47,17 @@ from core.file_preview import build_file_structure_info
 from core.reference_integrity import open_verified_reference
 
 
-#: What a provider's own error code may be made of before it is allowed
-#: into a redacted message: letters, digits and underscore, nothing else.
-#: Real codes look like ``PermissionDenied``, ``AuthorizationFailed``,
-#: ``DeploymentNotFound`` or ``insufficient_quota``. An endpoint, an account
-#: name, a deployment name, a file path or a sentence of prose all need a
-#: dot, a dash, a slash, a colon or a space, so none of them can get through
-#: this. That is the whole reason the allow-list is a shape and not a
-#: blocklist of things to strip out.
-_PROVIDER_CODE_SHAPE = re.compile(r"\A[A-Za-z0-9_]{1,64}\Z")
-
-#: Where a refusal's own code is looked for, in the order it is preferred.
-#: The first pair is what the OpenAI SDK lifts out of a JSON body onto the
-#: exception itself. The second pair is read back out of the body, because
-#: Azure nests its code one level down under ``error`` and the SDK leaves the
-#: attributes ``None`` in that case. Looking in the body as well is what makes
-#: this useful against a real Azure refusal rather than only a synthetic one.
-_PROVIDER_CODE_ATTRIBUTES = ("code", "type")
-_PROVIDER_CODE_BODY_KEYS = ("code", "type")
-
-
-def _provider_code_of(value: object) -> Optional[str]:
-    """Return ``value`` when it is code-shaped, and otherwise nothing."""
-    if isinstance(value, str) and _PROVIDER_CODE_SHAPE.match(value):
-        return value
-    return None
-
-
-def _provider_error_classification(exc: BaseException) -> str:
-    """Say what a provider refusal was, without saying who refused it.
-
-    Exactly two things are ever taken from the exception:
-
-    * the HTTP status, and only when it is a whole number a status can be;
-    * the provider's own error code, and only when it is code-shaped by
-      ``_PROVIDER_CODE_SHAPE``.
-
-    The message, the request, the response headers and the body itself are
-    never carried into the result. So a redacted message gains the one thing
-    an operator needs to act — *what* was refused — and still cannot name an
-    endpoint, an account, a project or a deployment.
-
-    Every read is guarded, because these are attributes on somebody else's
-    exception and a property is free to raise. A classification that cannot
-    be worked out is simply absent; it never replaces the class name.
-    """
-    parts: list[str] = []
-
-    try:
-        status = getattr(exc, "status_code", None)
-    except Exception:
-        status = None
-    if isinstance(status, int) and 100 <= status <= 599:
-        parts.append(f"http {status}")
-
-    code = None
-    for attribute in _PROVIDER_CODE_ATTRIBUTES:
-        try:
-            code = _provider_code_of(getattr(exc, attribute, None))
-        except Exception:
-            code = None
-        if code is not None:
-            break
-    if code is None:
-        try:
-            body = getattr(exc, "body", None)
-        except Exception:
-            body = None
-        nested = body.get("error") if isinstance(body, dict) else None
-        for holder in (body, nested):
-            if not isinstance(holder, dict):
-                continue
-            for key in _PROVIDER_CODE_BODY_KEYS:
-                code = _provider_code_of(holder.get(key))
-                if code is not None:
-                    break
-            if code is not None:
-                break
-    if code is not None:
-        parts.append(f"code {code}")
-
-    return ", ".join(parts)
+#: The reduction of a provider refusal to the two facts it may state now lives
+#: in ``core.provider_refusal``, because the agentic v2 model voice needs the
+#: same reduction and redaction kept in two copies is redaction that will one
+#: day differ in one of them. The private names are kept as aliases: they are
+#: what this module's callers and tests already ask for, and the behaviour
+#: behind them is unchanged.
+_PROVIDER_CODE_SHAPE = PROVIDER_CODE_SHAPE
+_PROVIDER_CODE_ATTRIBUTES = PROVIDER_CODE_ATTRIBUTES
+_PROVIDER_CODE_BODY_KEYS = PROVIDER_CODE_BODY_KEYS
+_provider_code_of = provider_code_of
+_provider_error_classification = classify_provider_refusal
 
 
 def _redacted_provider_error_message(exc: BaseException) -> str:

--- a/batch-runner/core/provider_refusal.py
+++ b/batch-runner/core/provider_refusal.py
@@ -1,0 +1,106 @@
+"""What a provider refusal is allowed to say about itself.
+
+A call to a hosted model can be refused for many reasons, and the reason is
+the one thing an operator needs in order to act. The exception carrying it is
+also the single richest source of things that must never be written down: the
+endpoint, the account, the deployment, the request and response headers, and
+whatever prose the service chose to echo back out of the body.
+
+So a refusal is reduced to two facts before it is recorded anywhere — the HTTP
+status, and the provider's own error code — and everything else is dropped
+without being read. ``PermissionDenied``, ``DeploymentNotFound`` and
+``insufficient_quota`` all survive that reduction; a URL, an account name and a
+sentence of English all do not, because none of them can be spelled without a
+character the allow-list refuses.
+
+This module holds the reduction so that every caller shares one copy of it.
+Redaction that exists twice is redaction that will eventually differ in one
+place, and the place it differs is the place something leaks.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+#: What a provider's own error code may be made of before it is allowed
+#: into a redacted message: letters, digits and underscore, nothing else.
+#: Real codes look like ``PermissionDenied``, ``AuthorizationFailed``,
+#: ``DeploymentNotFound`` or ``insufficient_quota``. An endpoint, an account
+#: name, a deployment name, a file path or a sentence of prose all need a
+#: dot, a dash, a slash, a colon or a space, so none of them can get through
+#: this. That is the whole reason the allow-list is a shape and not a
+#: blocklist of things to strip out.
+PROVIDER_CODE_SHAPE = re.compile(r"\A[A-Za-z0-9_]{1,64}\Z")
+
+#: Where a refusal's own code is looked for, in the order it is preferred.
+#: The first pair is what the OpenAI SDK lifts out of a JSON body onto the
+#: exception itself. The second pair is read back out of the body, because
+#: Azure nests its code one level down under ``error`` and the SDK leaves the
+#: attributes ``None`` in that case. Looking in the body as well is what makes
+#: this useful against a real Azure refusal rather than only a synthetic one.
+PROVIDER_CODE_ATTRIBUTES = ("code", "type")
+PROVIDER_CODE_BODY_KEYS = ("code", "type")
+
+
+def provider_code_of(value: object) -> Optional[str]:
+    """Return ``value`` when it is code-shaped, and otherwise nothing."""
+    if isinstance(value, str) and PROVIDER_CODE_SHAPE.match(value):
+        return value
+    return None
+
+
+def classify_provider_refusal(exc: BaseException) -> str:
+    """Say what a provider refusal was, without saying who refused it.
+
+    Exactly two things are ever taken from the exception:
+
+    * the HTTP status, and only when it is a whole number a status can be;
+    * the provider's own error code, and only when it is code-shaped by
+      ``PROVIDER_CODE_SHAPE``.
+
+    The message, the request, the response headers and the body itself are
+    never carried into the result. So a redacted message gains the one thing
+    an operator needs to act — *what* was refused — and still cannot name an
+    endpoint, an account, a project or a deployment.
+
+    Every read is guarded, because these are attributes on somebody else's
+    exception and a property is free to raise. A classification that cannot
+    be worked out is simply absent; it never replaces the class name.
+    """
+    parts: list[str] = []
+
+    try:
+        status = getattr(exc, "status_code", None)
+    except Exception:
+        status = None
+    if isinstance(status, int) and 100 <= status <= 599:
+        parts.append(f"http {status}")
+
+    code = None
+    for attribute in PROVIDER_CODE_ATTRIBUTES:
+        try:
+            code = provider_code_of(getattr(exc, attribute, None))
+        except Exception:
+            code = None
+        if code is not None:
+            break
+    if code is None:
+        try:
+            body = getattr(exc, "body", None)
+        except Exception:
+            body = None
+        nested = body.get("error") if isinstance(body, dict) else None
+        for holder in (body, nested):
+            if not isinstance(holder, dict):
+                continue
+            for key in PROVIDER_CODE_BODY_KEYS:
+                code = provider_code_of(holder.get(key))
+                if code is not None:
+                    break
+            if code is not None:
+                break
+    if code is not None:
+        parts.append(f"code {code}")
+
+    return ", ".join(parts)

--- a/batch-runner/tests/test_a_refused_agentic_v2_call_says_which_refusal_it_was.py
+++ b/batch-runner/tests/test_a_refused_agentic_v2_call_says_which_refusal_it_was.py
@@ -1,0 +1,105 @@
+"""A refused call has to say which refusal it was.
+
+The first paid stage A dispatch recorded ``asking the model failed:
+BadRequestError`` and stopped. That is true and nearly useless: it says the
+service would not take the request and nothing at all about which part of it
+was wrong. Working that out meant re-deriving the payload by hand, while the
+service had already answered the question in the status and the error code it
+sent back.
+
+So the note carries those two facts now, and still carries nothing else. The
+message, the body, the request and the response headers are not read, because
+the same exception that names *what* was refused is the richest available
+source of *who* refused it — the endpoint, the account, the project, the
+deployment — and none of that may be written down.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from openai import BadRequestError
+
+from core.agentic_v2_model_voice import _why_the_call_failed
+
+
+def _refusal(body: dict) -> BadRequestError:
+    """A ``400`` shaped the way Azure really shapes one."""
+    request = httpx.Request("POST", "https://example.invalid/openai/v1/responses")
+    response = httpx.Response(400, request=request, json=body)
+    return BadRequestError("ignored", response=response, body=body.get("error"))
+
+
+def test_the_note_names_the_status_and_the_code():
+    error = _refusal(
+        {
+            "error": {
+                "code": "invalid_function_parameters",
+                "message": "Invalid schema for function 'workspace_apply'.",
+                "type": "invalid_request_error",
+            }
+        }
+    )
+
+    note = _why_the_call_failed(error)
+
+    assert "asking the model failed: BadRequestError" in note
+    assert "http 400" in note
+    assert "invalid_function_parameters" in note
+
+
+def test_the_message_and_the_endpoint_never_reach_the_note():
+    """What the service says in prose is exactly what may not be recorded."""
+    error = _refusal(
+        {
+            "error": {
+                "code": "DeploymentNotFound",
+                "message": (
+                    "The API deployment for this resource does not exist at "
+                    "https://hjeon-fdpo-foundry-eus2.services.ai.azure.com/"
+                ),
+                "type": "invalid_request_error",
+            }
+        }
+    )
+
+    note = _why_the_call_failed(error)
+
+    assert "DeploymentNotFound" in note
+    for forbidden in ("hjeon", "azure.com", "https", "does not exist", "deployment for"):
+        assert forbidden not in note
+
+
+def test_a_failure_with_nothing_to_classify_still_says_what_it_was():
+    """No status and no code is not a reason to say less than before."""
+    note = _why_the_call_failed(TimeoutError("connect timed out after 600s"))
+
+    assert note == "asking the model failed: TimeoutError"
+    assert "600" not in note
+
+
+def test_the_note_stays_within_what_the_loop_keeps():
+    """The loop trims long notes; this one must never need trimming."""
+    from core.agentic_v2_model_voice import _SHORTEST_USEFUL_NOTE
+
+    error = _refusal(
+        {"error": {"code": "c" * 200, "message": "m" * 5000, "type": "t" * 200}}
+    )
+
+    assert len(_why_the_call_failed(error)) <= _SHORTEST_USEFUL_NOTE
+
+
+@pytest.mark.parametrize(
+    "code,why",
+    [
+        ("has a space", "prose is not a code"),
+        ("https://example.invalid/x", "a URL is not a code"),
+        ("account-name.eastus2", "a hostname is not a code"),
+    ],
+)
+def test_something_that_is_not_code_shaped_is_dropped(code, why):
+    """The allow-list is a shape, so anything that could name a host fails it."""
+    note = _why_the_call_failed(_refusal({"error": {"code": code}}))
+
+    assert "http 400" in note, why
+    assert code not in note, why

--- a/batch-runner/tests/test_agentic_v2_contract.py
+++ b/batch-runner/tests/test_agentic_v2_contract.py
@@ -24,11 +24,16 @@ from core.agentic_v2_contract import (
 import core.agentic_v2_contract as contract_module
 
 
-def test_v2_tool_definitions_are_stable_strict_and_valid():
+def test_v2_tool_definitions_are_stable_valid_and_do_not_overclaim():
     definitions = responses_tool_definitions()
 
     assert tuple(item["name"] for item in definitions) == TOOL_NAMES
-    assert all(item["strict"] is True for item in definitions)
+    # Not strict, and see ``responses_tool_definitions`` for why: the schemas
+    # are deliberately more expressive than the subset ``strict`` promises, and
+    # promising it anyway makes the service refuse the whole request before the
+    # model is asked. What the desk will act on is still decided by
+    # ``validate_tool_arguments`` against these same schemas in full.
+    assert all(item["strict"] is False for item in definitions)
     assert all(item["type"] == "function" for item in definitions)
     for schema in TOOL_SCHEMAS.values():
         Draft202012Validator.check_schema(schema)

--- a/batch-runner/tests/test_agentic_v2_model_voice.py
+++ b/batch-runner/tests/test_agentic_v2_model_voice.py
@@ -203,6 +203,34 @@ def test_a_turn_with_no_tools_on_offer_is_not_paid_for():
     assert voice.calls == []
 
 
+def test_every_key_the_voice_sends_is_one_the_sdk_accepts():
+    """A key the SDK does not know goes into the body and is refused there.
+
+    The fakes in this file accept anything, so a misspelled parameter looks
+    identical to a correct one here and shows up for the first time as a
+    ``400`` on a paid dispatch — which is exactly how the first stage A run
+    ended, for a different reason. The real signature is free to check.
+
+    ``timeout`` is deliberately in this list: it is a request option rather
+    than part of the body, and it is only safe to pass because the method
+    genuinely takes it.
+    """
+    import inspect
+
+    from openai.resources.responses import Responses
+
+    voice = a_voice([a_reply()])
+    voice.next_turn(a_request())
+
+    accepted = set(inspect.signature(Responses.create).parameters)
+    unknown = sorted(set(voice.client.responses.calls[0]) - accepted)
+
+    assert not unknown, (
+        f"the voice sends {', '.join(unknown)}, which Responses.create does "
+        f"not take; the service would refuse the request before the model saw it"
+    )
+
+
 def test_one_tool_at_a_time_and_a_ceiling_on_what_a_turn_may_write():
     voice = a_voice([a_reply()])
 

--- a/batch-runner/tests/test_tool_definitions_can_honour_what_they_claim.py
+++ b/batch-runner/tests/test_tool_definitions_can_honour_what_they_claim.py
@@ -1,0 +1,189 @@
+"""A tool definition may not claim more than its schema can honour.
+
+The first paid dispatch of the agentic v2 stage A probe, on 2026-09-10, was
+refused with ``400`` before the model was asked. Nothing ran and nothing was
+charged, and the record it produced said only ``BadRequestError``. The cause
+was in the request, and it had been in the repository, unexercised, the whole
+time: every tool was offered with ``strict: true``, and the schemas behind
+several of them are outside the subset ``strict`` promises.
+
+``strict`` is not a dial for how carefully arguments get checked. It is a
+declaration that the schema fits a narrow subset the service will enforce on
+the model's behalf, and the service validates that declaration when the
+request arrives. An overclaim does not quietly degrade to ordinary validation
+— it makes the entire call impossible, before any inference, in a way no unit
+test that only reads the definitions back could notice.
+
+So this module reads the definitions the way the service does. It takes the
+part of the subset that is beyond argument, and asserts that nothing claims
+``strict`` while breaking it:
+
+* the root of a function's parameters is an object, so a ``oneOf`` or an
+  ``anyOf`` at the root is out;
+* ``oneOf`` does not appear anywhere;
+* every object sets ``additionalProperties: false``;
+* every property of every object is listed in that object's ``required``.
+
+Both the v1 and the v2 tool sets are checked, because both build Responses
+definitions and both reach a paid model. Only v2 is fixed here. The same
+overclaim is in v1's ``run_ffmpeg``, but v1's tool JSON is hashed into
+``V1_TOOLS_SHA256`` in ``test_agentic_v2_compatibility``, which pins v1 as the
+fixed baseline that v2 is measured against — changing it is a decision about
+that baseline and about every v1 result already recorded under it, not a
+one-word fix to smuggle into a v2 change. So it is written down in
+``KNOWN_OVERCLAIMS`` instead, where it is asserted to *still* be broken: the
+day somebody fixes it this test fails and points at the frozen hash that has
+to be re-cut in the same breath.
+
+The schemas themselves are deliberately not narrowed to fit — they are the
+real contract, and ``validate_tool_arguments`` and ``ToolDispatch`` enforce
+them in full. What is dropped is only the promise that could not be kept.
+
+If a schema is ever brought inside the subset and ``strict`` turned back on
+for it, this test keeps passing and nothing else has to change. If one drifts
+back out while still claiming it, this fails here, offline, for free.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+import pytest
+
+from core.agentic_tools import responses_tool_definitions as v1_definitions
+from core.agentic_v2_contract import responses_tool_definitions as v2_definitions
+
+#: Combining keywords the strict subset does not accept anywhere in a schema.
+FORBIDDEN_ANYWHERE = ("oneOf",)
+
+#: Definitions that overclaim today, on purpose, with the reason each is not
+#: simply fixed. Being listed here is not permission — it is a record that the
+#: call would be refused, kept next to the reason it has not been repaired.
+#: Each entry is asserted to still be broken, so removing the overclaim
+#: without removing the entry fails this file and puts the frozen hash in
+#: front of whoever did it.
+KNOWN_OVERCLAIMS = {
+    "v1:run_ffmpeg": (
+        "v1's tool JSON is hashed into V1_TOOLS_SHA256 in "
+        "test_agentic_v2_compatibility, which freezes v1 as the baseline v2 "
+        "is compared against. Dropping strict here changes that identity and "
+        "the identity of every v1 agentic result recorded under it, so it is "
+        "a decision for the v1 baseline and not a side effect of a v2 fix. "
+        "Until then an agentic_sandbox run that offers run_ffmpeg is refused "
+        "with 400 before the model is asked."
+    ),
+}
+
+
+def _objects_in(schema: Any, path: str = "") -> Iterator[tuple[str, dict]]:
+    """Every subschema in ``schema``, with a readable path to each."""
+    if not isinstance(schema, dict):
+        return
+    yield path or "<root>", schema
+    for key in ("properties", "patternProperties", "$defs", "definitions"):
+        for name, child in (schema.get(key) or {}).items():
+            yield from _objects_in(child, f"{path}.{name}" if path else name)
+    for key in ("oneOf", "anyOf", "allOf"):
+        for index, child in enumerate(schema.get(key) or []):
+            label = f"{key}[{index}]"
+            yield from _objects_in(child, f"{path}.{label}" if path else label)
+    for key in ("items", "not", "additionalProperties"):
+        child = schema.get(key)
+        if isinstance(child, dict):
+            yield from _objects_in(child, f"{path}.{key}" if path else key)
+
+
+def _breaks_the_strict_subset(schema: Any) -> list[str]:
+    """Say every way ``schema`` falls outside the subset, or nothing."""
+    faults: list[str] = []
+
+    if not isinstance(schema, dict) or schema.get("type") != "object":
+        faults.append("<root>: the parameters are not an object schema")
+
+    for path, node in _objects_in(schema):
+        for keyword in FORBIDDEN_ANYWHERE:
+            if keyword in node:
+                faults.append(f"{path}: {keyword} is not permitted")
+        properties = node.get("properties")
+        if not isinstance(properties, dict):
+            continue
+        if node.get("additionalProperties") is not False:
+            faults.append(f"{path}: additionalProperties is not false")
+        optional = sorted(set(properties) - set(node.get("required") or []))
+        if optional:
+            faults.append(f"{path}: not required: {', '.join(optional)}")
+
+    return faults
+
+
+def _every_definition() -> list[tuple[str, dict]]:
+    return [
+        (f"{label}:{definition['name']}", definition)
+        for label, build in (("v1", v1_definitions), ("v2", v2_definitions))
+        for definition in build()
+    ]
+
+
+@pytest.mark.parametrize(
+    "label,definition", _every_definition(), ids=lambda value: value
+)
+def test_tool_definitions_can_honour_what_they_claim(label, definition):
+    if not definition.get("strict"):
+        assert label not in KNOWN_OVERCLAIMS, (
+            f"{label} no longer overclaims, which is the fix — now remove its "
+            f"entry from KNOWN_OVERCLAIMS. Read the entry first: "
+            f"{KNOWN_OVERCLAIMS.get(label)}"
+        )
+        return
+
+    faults = _breaks_the_strict_subset(definition.get("parameters"))
+
+    if label in KNOWN_OVERCLAIMS:
+        assert faults, (
+            f"{label} is listed in KNOWN_OVERCLAIMS but its schema is now "
+            f"inside the subset, so the claim is honest and the entry is "
+            f"stale. Remove it."
+        )
+        return
+
+    assert not faults, (
+        f"{label} is offered with strict: true, but the service will refuse "
+        f"the whole request before asking the model because "
+        f"{'; '.join(faults)}. Either bring the schema inside the subset or "
+        f"stop claiming strict for it."
+    )
+
+
+def test_the_guard_would_have_caught_the_dispatch_that_was_refused():
+    """The check has to fail on what actually happened, or it proves nothing.
+
+    This is the shape the v2 ``workspace_apply`` tool was offered in on
+    2026-09-10 — the real schema, with the flag it really carried.
+    """
+    as_it_was = dict(
+        next(item for item in v2_definitions() if item["name"] == "workspace_apply"),
+        strict=True,
+    )
+
+    with pytest.raises(AssertionError) as refused:
+        test_tool_definitions_can_honour_what_they_claim("v2:workspace_apply", as_it_was)
+
+    assert "oneOf is not permitted" in str(refused.value)
+    assert "not an object schema" in str(refused.value)
+
+
+def test_a_schema_inside_the_subset_is_left_alone():
+    """A definition that can honour the claim keeps it, and passes."""
+    honest = {
+        "type": "function",
+        "name": "honest",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    }
+
+    test_tool_definitions_can_honour_what_they_claim("made-up:honest", honest)

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -482,8 +482,77 @@ grows a fourth requirement now fails on the day it grows one, rather than on
 the day somebody dispatches. Run against the file as it stood, it names both
 steps and the missing variable.
 
-**Still not done.** The dispatch has not been made and no model has been asked.
-Everything that decides whether it may be is now built, tested and refusable.
+**The dispatch was made.** Twice, on 2026-09-10, both of workflow
+`agentic-v2-stage-a-probe`.
+
+The dry run, `34449960247`, succeeded, and printed in CI exactly what it had
+printed locally, to the character: the same task, the same two tools, the same
+`$0.59 ($0.47 running, $0.00 marking)` against the `$1.00` approved, the same
+deployment and route. Nothing was asked and nothing was spent.
+
+The paid run, `34450289535`, **failed**, and the workflow reported it honestly.
+Every step up to and including `Ask` passed; `Report what happened` re-raised
+the probe's own exit code, which is what it is for. The record the probe wrote:
+
+```
+"reached_a_model": false,   "model_calls": [],   "turns_taken": 0,
+"spent_usd": "0",           "resolved_model": null,
+"stop_reason": "model_stopped_without_finishing",
+"detail": "the model stopped without committing an answer:
+           asking the model failed: BadRequestError"
+```
+
+**Nothing was charged.** A `400` is a refusal of the request; the model is not
+asked, so there are no tokens to bill. `model_calls` is empty because none was
+made, and `spent_usd` is `0` because that is measured from the calls, not
+assumed. This is the outcome the stage was built to be able to record.
+
+**What was wrong.** Every tool was offered with `strict: true`. That flag is
+not a setting for how carefully arguments are checked — it is a declaration
+that the schema fits a narrow subset the service enforces on the model's
+behalf, and the service validates the declaration when the request arrives. Of
+the two tools stage A offers, `workspace_apply` is a `oneOf` at the root — one
+branch per operation, each carrying only its own fields — and `capabilities_query`
+has genuinely optional fields. Both are outside the subset. Neither could ever
+have been sent.
+
+An overclaim does not degrade to a laxer check. It makes the call impossible,
+before inference, which is why no amount of local rehearsal found it: the dry
+run does not build a request, and every unit test read the definitions back
+rather than asking whether a service would take them.
+
+**Nothing was loosened to fix it.** `strict` is now `false`, and what the desk
+will *act* on is unchanged — `validate_tool_arguments` validates against the
+same schemas in full, `oneOf`, `pattern`, length bounds and all, and is still
+the only thing between a tool call and the workspace. The schemas were
+deliberately not narrowed to fit the subset; they are the real contract. What
+was dropped is a promise that could not be kept. The cost is a turn
+occasionally spent on arguments the model must be told were malformed.
+
+**The second defect was that the failure could not be read.** The probe
+recorded `BadRequestError` and no more, so the cause had to be re-derived by
+hand from the payload while the service had already answered in the status and
+error code it sent back. The note now carries both, through the same reduction
+`code_interpreter` already used for provider refusals — status and a
+code-shaped code, nothing else read — which is now shared in
+`core/provider_refusal.py` rather than existing in two copies. An endpoint, an
+account, a project or a deployment cannot pass a code-shaped allow-list, so the
+note that says *what* was refused still cannot say *who* refused it.
+
+**The guard.** `test_tool_definitions_can_honour_what_they_claim` reads the
+definitions the way the service does and fails any that claims `strict` while
+breaking the subset. It covers v1 as well as v2, and it found the same
+overclaim in v1's `run_ffmpeg` — which is **not fixed here**. v1's tool JSON is
+hashed into `V1_TOOLS_SHA256`, freezing v1 as the baseline v2 is measured
+against; changing it is a decision about that baseline and every v1 result
+recorded under it, not a side effect of a v2 fix. It is recorded in
+`KNOWN_OVERCLAIMS` and asserted to *still* be broken, so the day it is fixed
+the test fails and puts the frozen hash in front of whoever fixed it. An
+`agentic_sandbox` run that offers `run_ffmpeg` is refused with `400` today.
+
+**Still not done.** A model has not yet answered. The first paid question was
+asked and refused before it reached one, at a cost of nothing, and the two
+defects that caused it are fixed and guarded.
 
 ### Stage B — not yet run
 ### Stage C — not yet run


### PR DESCRIPTION
The first paid stage A dispatch — run [34450289535](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/34450289535), 2026-09-10 — was refused with `400` before the model was asked.

**Nothing was charged.** The record the probe wrote, uploaded as the run's artefact:

```
"reached_a_model": false,   "model_calls": [],   "turns_taken": 0,
"spent_usd": "0",           "resolved_model": null,
"stop_reason": "model_stopped_without_finishing",
"detail": "the model stopped without committing an answer:
           asking the model failed: BadRequestError"
```

A `400` refuses the request, so the model is not asked and there are no tokens to bill. `model_calls` is empty because none was made and `spent_usd` is `0` because it is measured from the calls, not assumed. The workflow reported the failure honestly: `Ask` captured the probe's exit code and `Report what happened` re-raised it.

## What was wrong

Every tool was offered with `strict: true`. That flag is not a setting for how carefully arguments are checked — it declares that the schema fits a narrow subset the service enforces on the model's behalf, and the service validates the declaration when the request arrives. Of the two tools stage A offers, `workspace_apply` is a `oneOf` at the root (one branch per operation, each carrying only its own fields) and `capabilities_query` has genuinely optional fields. Both are outside the subset. **Neither could ever have been sent.**

An overclaim does not degrade to a laxer check. It makes the call impossible, before inference — which is why no amount of local rehearsal found it. The dry run builds no request, and every unit test read the definitions back rather than asking whether a service would take them.

## Nothing is loosened

`strict` is now `false`. What the desk will *act* on is unchanged: `validate_tool_arguments` validates against the same schemas in full — `oneOf`, `pattern`, length bounds and all — and remains the only thing between a tool call and the workspace. The schemas were deliberately **not** narrowed to fit the subset; they are the real contract. What is dropped is a promise that could not be kept. The cost is a turn occasionally spent on arguments the model must be told were malformed, which is the right price for a call that otherwise cannot be made at all.

## The second defect: the failure could not be read

The record said only `BadRequestError`, so the cause had to be re-derived by hand from the payload while the service had already answered in the status and error code it sent back.

The note now carries both, through the same reduction `code_interpreter` already used for provider refusals — status and a code-shaped code, and nothing else read off the exception. That reduction moves to `core/provider_refusal.py` rather than existing in two copies, because redaction kept in two places is redaction that eventually differs in one of them. An endpoint, an account, a project or a deployment name cannot pass a code-shaped allow-list, so a note that says *what* was refused still cannot say *who* refused it.

## Guards, both offline and free

- **`test_tool_definitions_can_honour_what_they_claim`** reads the definitions the way the service does and fails any that claims `strict` while breaking the subset. It includes a test that it fails on the exact definition that was refused, because a guard that has never failed on the real thing proves nothing.
- **The voice may only send keys `Responses.create` actually accepts**, so a misspelled parameter cannot reach a paid dispatch to be found. The fakes accept anything; the real signature is free to check.

## v1 has the same defect and is NOT fixed here

The guard covers v1 too, and found the identical overclaim in `run_ffmpeg`. An `agentic_sandbox` run that offers it is refused with `400` today.

It is not fixed in this PR. v1's tool JSON is hashed into `V1_TOOLS_SHA256` in `test_agentic_v2_compatibility`, which freezes v1 as the baseline v2 is measured against — changing it is a decision about that baseline and about every v1 result already recorded under it, not a side effect of a v2 fix. So it is recorded in `KNOWN_OVERCLAIMS` and asserted to **still** be broken: the day somebody fixes it, the test fails and puts the frozen hash in front of them.

## Overlapping file

`core/code_interpreter.py` is shared. The change is that it imports the reduction from its new home and keeps `_provider_error_classification` and friends as aliases. Behaviour is unchanged and its 30 existing tests pass untouched.

## Checked

- 310 tests across every affected file, green.
- `mypy` on `core/provider_refusal.py`: clean; the changed modules add no new errors.
- Full backend suite running locally alongside CI.