### PR TITLE
fix(codex): the 401 was ours — the auth command could not mint where Codex runs it

### DIFF
--- a/.github/workflows/codex-foundry-connection-diagnostic.yml
+++ b/.github/workflows/codex-foundry-connection-diagnostic.yml
@@ -62,10 +62,17 @@
 # makes it so, and a contrast against the direct Python path cannot be matched
 # on body size.
 #
-# `send_request: false` is the default, and with it nothing is sent at all —
-# the job prints the plan, fingerprinted, and stops. The plan and the result
-# share a schema, so what was fixed beforehand and what happened can be
-# compared field by field.
+# `send_request: false` is the default, and with it nothing is sent to the
+# deployment at all — the job prints the plan, fingerprinted, and stops. The
+# plan and the result share a schema, so what was fixed beforehand and what
+# happened can be compared field by field.
+#
+# The plan does run one thing: the provider's auth command, in the isolated
+# environment Codex would run it in. That is a call to the identity platform
+# and not to the deployment — no model runs and nothing is billed — and it is
+# how the record answers "can this runner mint from in there?" without a paid
+# dispatch. A sign-in that cannot mint is reported, not raised: the step stays
+# green and `observed.auth_command.ok` is `false`.
 name: Codex Foundry Connection Diagnostic
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,20 @@ entries land under a fresh dated heading the day they merge to `main`.
   `batch-runner/tests/test_codex_closing_sweep.py`, every host in them a
   loopback socket on the test machine.
 
+  **Fired, run `34448607605`, verdict `no_property_closes_a_served_request`.**
+  The baseline was re-tested that day and served, so the premise held and the
+  other eight were bought honestly. All nine arms answered `200`, including
+  `everything` — 30,981 bytes, nine added headers, `stream: true`, a 19 KB
+  `instructions` and ten tool definitions, materially larger and stranger than
+  a Codex turn and served without complaint. `properties_that_closed_the_gate`
+  is `[]`, 9 planned and 9 sent. Summed usage 5,942 in / 35 out over the seven
+  arms that reported it; the two that set `stream: true` hold the SSE prelude
+  rather than a parsed final status and report none. `price_usd: null`,
+  `pricing: partial` — unpriced, not free.
+
+  Finding nothing was the finding: it is what pointed away from the request
+  body, and the thing this sweep does not vary turned out to be the sign-in.
+
 - **The one request in this diagnostic that the route can actually serve.**
   `--valid-request` in `batch-runner/scripts/diagnose_codex_foundry_connection.py`,
   wired as a step gated on its own `send_valid_request` input *and* the resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,71 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Fixed
+- **The Codex `401` was never about the deployment: the auth command could not
+  produce a token where Codex runs it.** Three independent faults, each
+  sufficient on its own, each producing the same silent symptom.
+
+  Codex authenticates the provider by running a command and reading the token
+  from its stdout. It starts that command with the **task's directory** as the
+  working directory — `CodexAgentRunner.open_runtime` sets `CodexConfig.cwd` to
+  the workspace and the pinned SDK passes it straight to `Popen` — and in the
+  **isolated environment**, where `HOME` is rewritten to a throwaway directory.
+  From there:
+
+  1. `python -m core.codex_azure_token` cannot import `core`. It failed before
+     the module's first line.
+  2. `DefaultAzureCredential`'s working leg is the Azure CLI, which reads its
+     sign-in from `$HOME/.azure`. With `HOME` rewritten there was none.
+  3. On any failure the command prints nothing on stdout — deliberately, so
+     Codex cannot mistake an error for a token. Codex therefore sent an **empty
+     bearer**, and the gateway answered `401 Access denied due to invalid
+     subscription key or wrong API endpoint`.
+
+  That sentence names the endpoint and the key, both of which were correct
+  throughout — run `34442249527` had already proved the identity may infer on
+  this resource. Runs `34319880025` and `34347516170` are what reading it
+  literally cost.
+
+  The first fault alone accounts for those runs, without appealing to anything
+  local: `PYTHONPATH` is neither inherited nor neutralised by
+  `build_isolated_environment`, and the diagnostic workflow never sets it, so
+  `-m core.codex_azure_token` from the task's directory raises
+  `No module named 'core'` on any host. Whether the second also bites on a
+  runner — where `azure/login` writes the sign-in that the rewritten `HOME`
+  then hides — is a prediction, and the new free `auth_command` record is what
+  settles it.
+
+  The fixes, in the same order. `CodexProviderSettings.auth_entrypoint()` names
+  the module by resolved file path instead of `-m`, and the module puts its own
+  package root on `sys.path` when run that way, so it no longer depends on
+  where it is started. `discover_azure_cli_config_dir()` reads the sign-in's
+  location in the **parent** and `auth_command()` appends it as
+  `--azure-config-dir`; the value travels in the command's own argv, so the
+  Codex process's environment is unchanged and the model's tools see exactly
+  the isolation they saw before — asserted by
+  `test_the_isolation_still_hides_the_sign_in_from_codex_itself`. And
+  `CodexAgentRunner.require_a_usable_auth_command()` runs the real command in
+  the real isolated environment once per runner and refuses to start a runtime
+  when no token comes back, raising `CodexAuthCommandFailed` with the
+  command's own reason attached.
+
+  Measured locally end to end: the auth command now exits `0` with a token
+  **inside** the isolation, started from the task directory. The probe keeps no
+  token and no token-derived value — only whether stdout carried one, and why
+  not.
+
+- **`diagnose_codex_foundry_connection.py` asks the sign-in before it spends.**
+  New verdict `auth_command_produced_no_token`, and an `auth_command` block in
+  every record. A sign-in that cannot mint now ends the run before a request
+  exists, so this failure costs nothing instead of a paid `401`.
+
+- **Corrected the first `codex_foundry` readiness blocker.** Its old text said
+  no token from the auth command had ever been accepted by a Foundry
+  deployment; run `34442249527` had already disproved that. The replacement
+  says what is actually unobserved — a turn from inside the isolation, on a
+  runner. The gate stays closed; only the reason is now true.
+
 ### Added
 - **The identity may infer on this resource — measured, not argued — and the
   question is now which property of a Codex request stops it.** Run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,19 @@ entries land under a fresh dated heading the day they merge to `main`.
   every record. A sign-in that cannot mint now ends the run before a request
   exists, so this failure costs nothing instead of a paid `401`.
 
+  The **free plan** answers it too. Minting an Entra token is a call to the
+  identity platform, not to the deployment: no model runs and nothing is
+  billed. So a run without `--send-request` now runs the real auth command in
+  the real isolated environment and fills the same `auth_command` block — which
+  turns "does the second fault bite on a runner?" from a paid dispatch into a
+  free one. It reports rather than gates: a sign-in that cannot mint still
+  leaves the plan green and exit `0`, because a red plan reads as "the
+  diagnostic broke" and the finding here is the opposite. A host that cannot
+  run the preflight at all leaves the field `null` — *not asked*, which is not
+  the same as *asked, and no*. `reason` goes through the record's redactor like
+  every other runtime message; `azure_config_dir` does not, because which home
+  the sign-in was found in is the one thing the record is for.
+
 - **Corrected the first `codex_foundry` readiness blocker.** Its old text said
   no token from the auth command had ever been accepted by a Foundry
   deployment; run `34442249527` had already disproved that. The replacement

--- a/batch-runner/core/codex_azure_token.py
+++ b/batch-runner/core/codex_azure_token.py
@@ -15,7 +15,29 @@ makes, at the same scopes.
 
 Usage, as Codex invokes it::
 
-    python -m core.codex_azure_token --scope https://ai.azure.com/.default
+    python -m core.codex_azure_token --scope https://ai.azure.com/.default \
+        --azure-config-dir /home/runner/.azure
+
+Where the sign-in lives
+-----------------------
+
+Codex runs this command **inside the isolated environment it builds for a
+task**, and that environment rewrites ``HOME`` to the task's own directory so
+that anything the model writes "to the user's home" lands somewhere disposable.
+That is worth keeping. But ``DefaultAzureCredential``'s working leg here is the
+Azure CLI, and the CLI finds its sign-in under ``$HOME/.azure``. With ``HOME``
+rewritten there is no sign-in to find, the mint fails, and — per the output
+discipline below — the command prints nothing. Codex then sends an empty
+bearer, and the gateway answers ``401 Access denied due to invalid subscription
+key or wrong API endpoint``: a message about the endpoint and the key, which
+are both fine, for a fault that is neither.
+
+``--azure-config-dir`` is how the caller hands the location back. It travels in
+argv rather than in the environment on purpose: only *this* process, which
+prints a token and exits, learns where the sign-in is. The Codex process and
+every tool it runs keep the environment they had, so the isolation the sandbox
+depends on is unchanged. A path is not a credential, and the directory itself
+stays outside everything Codex can reach.
 
 Output discipline
 -----------------
@@ -34,8 +56,19 @@ than an error message it might try to send as one.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
-from typing import Sequence
+from pathlib import Path
+from typing import MutableMapping, Sequence
+
+if __package__ in (None, ""):  # pragma: no cover - exercised as a subprocess
+    # Run by path rather than as ``-m core.codex_azure_token``, because Codex
+    # starts this command with the *task's* directory as the working
+    # directory. From there ``core`` is not importable and ``-m`` fails before
+    # argument parsing — which, given the output discipline below, means an
+    # empty stdout and a token-shaped silence. Putting the package root on the
+    # path here makes the command independent of where it is started from.
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from core.azure_ai_clients import (
     DIRECT_TOKEN_SCOPE,
@@ -43,6 +76,10 @@ from core.azure_ai_clients import (
     DefaultAzureCredential,
     get_bearer_token_provider,
 )
+
+#: The variable the Azure CLI reads its configuration and token cache from.
+#: Setting it is equivalent to pointing the CLI at a different ``~/.azure``.
+AZURE_CONFIG_DIR_ENV = "AZURE_CONFIG_DIR"
 
 #: The scopes this helper will ask for. An arbitrary scope is refused rather
 #: than passed through: a token minted for an audience nobody here reviewed is
@@ -53,6 +90,33 @@ ALLOWED_SCOPES: tuple[str, ...] = (DIRECT_TOKEN_SCOPE, LEGACY_TOKEN_SCOPE)
 
 class TokenCommandError(RuntimeError):
     """The token could not be produced. The message never carries the token."""
+
+
+def point_at_azure_config_dir(
+    directory: str | os.PathLike[str],
+    environment: MutableMapping[str, str] | None = None,
+) -> str:
+    """Point the Azure CLI at ``directory`` for the rest of this process.
+
+    Returns the resolved path, so the caller can report *which* directory was
+    used without having to re-derive it.
+
+    A directory that does not exist is refused rather than set. Setting it
+    anyway would land us back where this option started: the CLI would look in
+    an empty place, report no sign-in, and this command would exit quietly —
+    the failure would just have moved. A wrong path is a fixable mistake, and
+    saying so is the whole point.
+    """
+    path = Path(directory)
+    if not path.is_dir():
+        raise TokenCommandError(
+            f"the Azure CLI configuration directory {str(path)!r} does not "
+            "exist, so there is no sign-in to read there"
+        )
+    resolved = str(path)
+    target = os.environ if environment is None else environment
+    target[AZURE_CONFIG_DIR_ENV] = resolved
+    return resolved
 
 
 def acquire_token(scope: str) -> str:
@@ -109,9 +173,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=DIRECT_TOKEN_SCOPE,
         help="token audience; one of: " + ", ".join(ALLOWED_SCOPES),
     )
+    parser.add_argument(
+        "--azure-config-dir",
+        default=None,
+        help=(
+            "the Azure CLI configuration directory to sign in from, for when "
+            "this command runs somewhere HOME does not point at it"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
+        if args.azure_config_dir is not None:
+            point_at_azure_config_dir(args.azure_config_dir)
         token = acquire_token(args.scope)
     except TokenCommandError as exc:
         print(f"codex-azure-token: {exc}", file=sys.stderr)

--- a/batch-runner/core/codex_runner.py
+++ b/batch-runner/core/codex_runner.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 import threading
 from dataclasses import dataclass, field
@@ -84,9 +85,84 @@ _NOT_A_DELIVERABLE = (
 
 _NTFS_FORBIDDEN = re.compile(r'[:"<>|*?\r\n]')
 
+#: How long the auth-command preflight waits. Generous next to the runtime's
+#: own 30s auth timeout, because a first sign-in can be slower than a cached
+#: one and a preflight that times out early would report the wrong fault.
+_AUTH_PREFLIGHT_TIMEOUT = 60
+
+#: A GUID is a tenant or subscription identifier. Not a secret, but not ours to
+#: scatter through logs either, so the preflight's reason drops them.
+_GUID = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+)
+
+#: Belt and braces. ``core.codex_azure_token`` promises never to put a token in
+#: its diagnostics, and the preflight never reads one from stdout — but the
+#: reason string is the one thing here that gets written down, so anything
+#: shaped like a JSON Web Token is removed from it before it can be.
+_JWT_SHAPED = re.compile(r"\beyJ[A-Za-z0-9_\-\.]{10,}")
+
+
+def _auth_failure_reason(stderr: str) -> str:
+    """One short line saying why the auth command produced no token."""
+    lines = [line.strip() for line in (stderr or "").splitlines()]
+    lines = [line for line in lines if line]
+    if not lines:
+        return "the auth command failed without saying why"
+    # The command's own message is the one written for this situation; the
+    # SDK's chained credential report above it is long and mostly about
+    # credentials that were never going to work here.
+    chosen = next(
+        (line for line in reversed(lines) if line.startswith("codex-azure-token:")),
+        lines[-1],
+    )
+    chosen = _JWT_SHAPED.sub("<redacted>", _GUID.sub("<guid>", chosen))
+    return chosen[:300]
+
 
 class CodexRunError(RuntimeError):
     """A Codex run could not start or could not be trusted to have run."""
+
+
+class CodexAuthCommandFailed(CodexRunError):
+    """The provider's auth command could not produce a token where Codex runs it.
+
+    Its own category, because the alternative is what this project actually
+    lived through. Codex reads the token from the command's stdout; when the
+    command fails it prints nothing, Codex forwards an empty bearer, and the
+    gateway answers ``401 Access denied due to invalid subscription key or
+    wrong API endpoint``. Every noun in that sentence points somewhere the
+    fault is not, and several paid runs went looking there. Raising here, with
+    the command's own reason attached, keeps a local sign-in problem local.
+    """
+
+
+#: What the auth-command preflight reports. Deliberately holds no token and no
+#: token-derived value — only whether stdout carried one, and why not.
+@dataclass(frozen=True)
+class AuthCommandProbe:
+    """Whether the auth command can mint where Codex will run it."""
+
+    ran: bool
+    exit_code: int | None
+    produced_a_token: bool
+    reason: str | None
+    azure_config_dir: str | None
+
+    @property
+    def ok(self) -> bool:
+        return self.ran and self.exit_code == 0 and self.produced_a_token
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            "ran": self.ran,
+            "exit_code": self.exit_code,
+            "produced_a_token": self.produced_a_token,
+            "reason": self.reason,
+            "azure_config_dir": self.azure_config_dir,
+            "ok": self.ok,
+        }
 
 
 # ── Orphan sweep ────────────────────────────────────────────────────────────
@@ -358,6 +434,7 @@ class CodexAgentRunner(RecordsItsFirstRequest):
         condition_name: str | None = None,
         codex_bin: str | None = None,
         verify_runtime: bool = True,
+        preflight_auth: bool = True,
     ) -> None:
         """
         Args:
@@ -375,6 +452,10 @@ class CodexAgentRunner(RecordsItsFirstRequest):
                 the one the pinned distribution installed, which is what any
                 real run uses.
             verify_runtime: check the pinned versions on construction.
+            preflight_auth: run the provider's auth command once, in the
+                isolated environment, before starting a runtime, and refuse to
+                start when it produces no token. Off only for the connection
+                diagnostic, which sometimes needs the failing request itself.
         """
         if not isinstance(provider, CodexProviderLike):
             raise CodexProviderConfigurationError(
@@ -387,6 +468,8 @@ class CodexAgentRunner(RecordsItsFirstRequest):
         self.run_id = run_id
         self.condition_name = condition_name
         self.codex_bin = codex_bin
+        self.preflight_auth = bool(preflight_auth)
+        self._auth_probe: AuthCommandProbe | None = None
         self.shared_first_request = False
         self.last_run_diagnostics: dict[str, Any] | None = None
         self._turns_per_task: dict[str, int] = {}
@@ -425,6 +508,121 @@ class CodexAgentRunner(RecordsItsFirstRequest):
             environment.update(extra)
         return environment
 
+    def preflight_auth_command(
+        self, workspace: CodexWorkspace
+    ) -> AuthCommandProbe:
+        """Run the provider's auth command where Codex will run it.
+
+        Same argv, same isolated environment, same working directory. The point
+        is not to obtain a token — the token is read, checked for emptiness and
+        dropped without being stored, logged or returned — but to find out
+        whether one *can* be obtained from inside the isolation, before a turn
+        turns that question into a gateway error about something else.
+
+        Providers that authenticate by environment variable have no command to
+        run; for those this reports ``ran=False`` and nothing is claimed.
+        """
+        build = getattr(self.provider, "auth_command", None)
+        if not callable(build):
+            return AuthCommandProbe(
+                ran=False,
+                exit_code=None,
+                produced_a_token=False,
+                reason="this provider authenticates by environment variable",
+                azure_config_dir=None,
+            )
+        argv = list(build())
+        config_dir = None
+        if "--azure-config-dir" in argv:
+            config_dir = argv[argv.index("--azure-config-dir") + 1]
+        # The overlay merged onto this process's environment, because that is
+        # what the child actually gets: the pinned SDK does
+        # ``env = os.environ.copy(); env.update(self.config.env)`` before
+        # ``Popen``. Handing the overlay alone would give the auth command a
+        # smaller environment than a real turn does, and a preflight that
+        # tests a stricter world than production can fail on things production
+        # would not — which is its own kind of wrong answer.
+        environment = {**os.environ, **self._build_environment(workspace)}
+        try:
+            completed = subprocess.run(
+                argv,
+                cwd=str(workspace.workspace),
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=_AUTH_PREFLIGHT_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            return AuthCommandProbe(
+                ran=True,
+                exit_code=None,
+                produced_a_token=False,
+                reason=(
+                    f"the auth command did not finish within "
+                    f"{_AUTH_PREFLIGHT_TIMEOUT}s"
+                ),
+                azure_config_dir=config_dir,
+            )
+        except OSError as exc:
+            return AuthCommandProbe(
+                ran=False,
+                exit_code=None,
+                produced_a_token=False,
+                reason=f"the auth command could not be started ({exc.strerror})",
+                azure_config_dir=config_dir,
+            )
+        # Truthiness only. The value is not kept, not returned and not logged;
+        # what is recorded is that stdout was or was not empty.
+        produced = bool(completed.stdout.strip())
+        return AuthCommandProbe(
+            ran=True,
+            exit_code=completed.returncode,
+            produced_a_token=produced,
+            reason=None if produced and completed.returncode == 0
+            else _auth_failure_reason(completed.stderr),
+            azure_config_dir=config_dir,
+        )
+
+    def require_a_usable_auth_command(
+        self, workspace: CodexWorkspace
+    ) -> AuthCommandProbe:
+        """Check the sign-in once per runner, and refuse to start without it.
+
+        Cached on the runner rather than repeated per task: the answer is a
+        property of the environment, not of the task, and a batch of 220 would
+        otherwise pay for 220 sign-ins to learn the same thing.
+
+        A provider with no auth command, or a runner built with
+        ``preflight_auth=False``, passes through untouched — the first because
+        there is nothing to check, the second because the connection diagnostic
+        sometimes needs to send the request that fails and see what comes back.
+        """
+        if not self.preflight_auth:
+            return AuthCommandProbe(
+                ran=False,
+                exit_code=None,
+                produced_a_token=False,
+                reason="the auth-command preflight was turned off for this run",
+                azure_config_dir=None,
+            )
+        if self._auth_probe is None:
+            self._auth_probe = self.preflight_auth_command(workspace)
+        probe = self._auth_probe
+        if probe.ran and not probe.ok:
+            where = (
+                f" (sign-in read from {probe.azure_config_dir})"
+                if probe.azure_config_dir
+                else " (this machine has no Azure CLI sign-in to point at)"
+            )
+            raise CodexAuthCommandFailed(
+                "the provider's auth command produced no token inside the "
+                f"isolated environment{where}: {probe.reason}. Codex would "
+                "send an empty bearer and the gateway would answer 401 about "
+                "an invalid subscription key, which would be about the wrong "
+                "thing."
+            )
+        return probe
+
     def open_runtime(self, workspace: CodexWorkspace) -> Any:
         """Start the Codex client a run uses, against this provider.
 
@@ -441,7 +639,13 @@ class CodexAgentRunner(RecordsItsFirstRequest):
         start and a session that will not open are reported under different
         categories, and merging them would lose that distinction at the only
         moment it matters.
+
+        Before either, the auth command is run once per runner in the same
+        isolated environment. A runtime that starts with a sign-in that cannot
+        mint will reach the deployment and be refused there, and the refusal
+        will describe the endpoint rather than the sign-in.
         """
+        self.require_a_usable_auth_command(workspace)
         environment = self._build_environment(workspace)
         overrides = self.provider.config_overrides()
         try:

--- a/batch-runner/core/codex_runtime_config.py
+++ b/batch-runner/core/codex_runtime_config.py
@@ -48,6 +48,7 @@ real connection is on record.
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import re
 from dataclasses import dataclass, field
@@ -486,6 +487,41 @@ _PROVIDER_ID_PATTERN = re.compile(r"\A[a-z0-9][a-z0-9-]{0,63}\Z")
 #: ``core.azure_ai_clients.FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV``.
 DEFAULT_AUTH_MODULE = "core.codex_azure_token"
 
+#: Where the Azure CLI keeps its configuration and its signed-in accounts. The
+#: CLI reads ``AZURE_CONFIG_DIR`` when it is set and falls back to this name
+#: under ``HOME`` when it is not.
+AZURE_CLI_CONFIG_DIR_NAME = ".azure"
+
+
+def discover_azure_cli_config_dir(
+    source_environment: Mapping[str, str] | None = None,
+) -> str | None:
+    """Find the Azure CLI sign-in this machine already has, or ``None``.
+
+    This is read in the **parent** — the process that builds the Codex command
+    line — because by the time the auth command runs there is nothing left to
+    read it from. :func:`build_isolated_environment` rewrites ``HOME`` to the
+    task's directory, and the CLI's sign-in is the one thing under the real
+    ``HOME`` that the auth command genuinely needs. Passing the answer down as
+    an argument is narrower than inheriting ``HOME``, and narrower than adding
+    a name to :data:`INHERITED_ENV_NAMES`: the Codex process's own environment
+    does not change at all, so neither does what the model's tools can see.
+
+    ``None`` means "this machine has no Azure CLI sign-in to point at", which
+    is the ordinary case on a runner authenticating some other way. The caller
+    then omits the argument and ``DefaultAzureCredential`` behaves as before.
+    """
+    source = dict(os.environ if source_environment is None else source_environment)
+    configured = source.get("AZURE_CONFIG_DIR", "").strip()
+    if configured:
+        return configured if Path(configured).is_dir() else None
+    home = source.get("HOME", "").strip()
+    if not home:
+        return None
+    candidate = Path(home) / AZURE_CLI_CONFIG_DIR_NAME
+    return str(candidate) if candidate.is_dir() else None
+
+
 #: Codex re-runs the auth command on this interval. Entra access tokens are
 #: good for roughly an hour; refreshing well inside that avoids a long task
 #: dying mid-turn on an expiry.
@@ -681,18 +717,58 @@ class CodexProviderSettings(CodexProviderLike):
         """The provider ``base_url``, without the trailing slash Codex adds."""
         return self.endpoint.rstrip("/")
 
-    def auth_command(self) -> list[str]:
+    def auth_command(
+        self, source_environment: Mapping[str, str] | None = None
+    ) -> list[str]:
         """The command Codex runs to get a token, as argv.
 
         It prints one Entra access token to stdout and nothing else — see
         ``core/codex_azure_token.py``. Passing a command rather than a key is
         what keeps this run place inside the repository's rule that no static
         Azure credential exists in any environment we build.
+
+        When this machine has an Azure CLI sign-in, its location is appended as
+        ``--azure-config-dir``. Codex runs this command inside the isolated
+        environment, where ``HOME`` no longer points at that sign-in; without
+        the argument the mint fails, the command prints nothing by design, and
+        Codex sends an empty bearer that the gateway rejects as an invalid
+        subscription key. The argument is a path, not a credential, and it goes
+        to this command alone — the Codex process's environment is untouched.
         """
         import sys
 
         executable = self.python_executable or sys.executable
-        return [executable, "-m", self.auth_module, "--scope", self.auth_scope]
+        argv = [executable, *self.auth_entrypoint(), "--scope", self.auth_scope]
+        config_dir = discover_azure_cli_config_dir(source_environment)
+        if config_dir:
+            argv += ["--azure-config-dir", config_dir]
+        return argv
+
+    def auth_entrypoint(self) -> list[str]:
+        """How to name the auth module to an interpreter, as argv fragments.
+
+        A file path when one can be resolved, because Codex starts the auth
+        command with the *task's* directory as its working directory — see
+        ``CodexConfig.cwd`` in :meth:`core.codex_runner.CodexAgentRunner.
+        open_runtime`, which the pinned SDK passes straight to ``Popen``. From
+        there ``-m core.codex_azure_token`` raises ``No module named 'core'``
+        before the module's first line runs, and the command exits with an
+        empty stdout that Codex forwards as an empty bearer.
+
+        ``-m`` remains the fallback for a module that cannot be resolved to a
+        file, which is how the tests point this at a stub on ``PYTHONPATH``.
+        """
+        try:
+            spec = importlib.util.find_spec(self.auth_module)
+        except (ImportError, ValueError, AttributeError):
+            spec = None
+        origin = getattr(spec, "origin", None)
+        if origin and origin.endswith(".py") and Path(origin).is_file():
+            # Resolved, because the recorded argv is read by people comparing
+            # one run's configuration with another's, and ``a/./b`` and ``a/b``
+            # are the same file wearing two names.
+            return [str(Path(origin).resolve())]
+        return ["-m", self.auth_module]
 
     def config_overrides(self) -> tuple[str, ...]:
         """The provider table for this deployment, as command-line overrides."""

--- a/batch-runner/core/execution_environment_readiness.py
+++ b/batch-runner/core/execution_environment_readiness.py
@@ -181,13 +181,21 @@ DOCUMENTED_BLOCKERS_BY_ENVIRONMENT: Mapping[str, tuple[str, ...]] = {
     # that has not been *observed*, and no amount of reading will clear any of
     # them — only a request that is answered will.
     ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY: (
-        "the sign-in has been built but never accepted: this repository "
-        "forbids every static Azure credential variable in "
+        "the sign-in mints and is accepted, but not yet from inside the place "
+        "Codex runs it: this repository forbids every static Azure credential "
+        "variable in "
         "core.azure_ai_clients.FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV, so the "
         "provider is authenticated by an auth command "
-        "(core.codex_azure_token) that mints an Entra token instead; no token "
-        "from it has yet been presented to a Foundry deployment and accepted, "
-        "and a route that has not answered is not a route that works",
+        "(core.codex_azure_token) that mints an Entra token instead, and run "
+        "34442249527 presented a token from that command to this deployment "
+        "and was answered 200 — so the credential, the identity and the "
+        "address are settled. What was not settled is that Codex starts that "
+        "command in the task's own directory and in the isolated environment, "
+        "where until now it could neither import its package nor find the "
+        "Azure CLI sign-in; it printed nothing, and the empty bearer that "
+        "followed was refused as an invalid subscription key. The fix is in "
+        "and checked locally, and a turn on a runner has not yet been "
+        "answered",
         "which API contract the deployment serves Codex on has not been "
         "observed: core.codex_runtime_config refuses a dated api-version on "
         "the undated /openai/v1/ route and lets query_params carry one on the "

--- a/batch-runner/scripts/diagnose_codex_foundry_connection.py
+++ b/batch-runner/scripts/diagnose_codex_foundry_connection.py
@@ -2409,16 +2409,70 @@ def closing_sweep_probe(
 # ── Command line ────────────────────────────────────────────────────────────
 
 
-def _plan(description: Mapping[str, Any]) -> dict[str, Any]:
+def _plan(
+    description: Mapping[str, Any],
+    settings: CodexProviderSettings | None = None,
+) -> dict[str, Any]:
+    observed = _empty_observation()
+    note = (
+        "--send-request was not passed. This is the plan, fixed and "
+        "fingerprinted; no request exists and no cost was incurred"
+    )
+    if settings is not None:
+        auth_probe = _plan_auth_command(settings)
+        if auth_probe is not None:
+            observed["auth_command"] = auth_probe
+            note += (
+                "; the auth command was run once against this host's own "
+                "sign-in, which costs nothing and is not a request to the "
+                "deployment — see auth_command for whether a token can be "
+                "minted from inside the isolated environment"
+            )
     return _record(
         verdict=VERDICT_NOT_SENT,
         description=description,
-        observed=_empty_observation(),
-        note=(
-            "--send-request was not passed. This is the plan, fixed and "
-            "fingerprinted; no request exists and no cost was incurred"
-        ),
+        observed=observed,
+        note=note,
     )
+
+
+def _plan_auth_command(
+    settings: CodexProviderSettings,
+) -> dict[str, Any] | None:
+    """Ask the sign-in, in the free plan, because asking is free.
+
+    Minting an Entra token is a call to the identity platform, not to the
+    deployment: no model runs, no tokens are billed and nothing appears on an
+    invoice. Doing it here means the question "can this host mint from inside
+    the isolation?" is answered by a dispatch that spends nothing, rather than
+    by a paid dispatch that happens to stop early.
+
+    ``verify_runtime=False`` because the preflight needs the provider settings
+    and a workspace and not the Codex binary. A host without the pinned runtime
+    still gets a real answer, and a plan that used to run everywhere keeps
+    running everywhere — returning ``None`` on any failure, so an unexpected
+    one leaves the free step green and the field ``null`` rather than turning
+    a plan into a red run.
+
+    ``reason`` is a runtime message and goes through the redactor like every
+    other one in this file. ``azure_config_dir`` does not: it is a path this
+    repository discovered rather than something a subprocess said, and which
+    home the sign-in was found in is the one thing this record is for.
+    """
+    from core.codex_runner import CodexAgentRunner, CodexWorkspace
+
+    workspace = None
+    try:
+        runner = CodexAgentRunner(settings, verify_runtime=False)
+        workspace = CodexWorkspace.create(task_id="foundry-auth-preflight")
+        record = runner.preflight_auth_command(workspace).as_record()
+    except Exception:  # noqa: BLE001 - a free step must not fail the run
+        return None
+    finally:
+        if workspace is not None:
+            workspace.cleanup()
+    record["reason"] = build_redactor()(record.get("reason"))
+    return record
 
 
 def _emit(record: Mapping[str, Any], out: str | None) -> None:
@@ -2620,7 +2674,7 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     if not args.send_request:
-        _emit(_plan(description), args.out)
+        _emit(_plan(description, settings), args.out)
         return 0
     record = probe(settings, timeout=args.timeout, redact=redact)
     _emit(record, args.out)

--- a/batch-runner/scripts/diagnose_codex_foundry_connection.py
+++ b/batch-runner/scripts/diagnose_codex_foundry_connection.py
@@ -159,6 +159,12 @@ VERDICT_SANDBOX_FAILED = "sandbox_failed"
 VERDICT_TURN_TIMED_OUT = "turn_timed_out"
 #: The pinned SDK or binary is missing or is the wrong version.
 VERDICT_RUNTIME_UNAVAILABLE = "runtime_unavailable"
+#: The provider's auth command could not produce a token inside the isolated
+#: environment, so no bearer existed to send. Its own verdict rather than a
+#: shade of ``runtime_unavailable``: the runtime is fine and the deployment is
+#: fine, and filing this under either is how it went unseen. Nothing is sent
+#: and nothing is billed.
+VERDICT_AUTH_COMMAND_FAILED = "auth_command_produced_no_token"
 #: The runtime started and the session did not open, so nothing was sent.
 VERDICT_SESSION_NOT_STARTED = "session_not_started"
 #: The environment does not describe a deployment. Nothing was sent, and
@@ -620,6 +626,9 @@ def _empty_observation() -> dict[str, Any]:
             "item_types": [],
         },
         "usage": None,
+        # Whether the sign-in could produce a token where Codex runs it, and
+        # why not. Never the token, and never anything derived from one.
+        "auth_command": None,
         "final_response_present": False,
         "final_response_matched_instruction": False,
         "tool_execution_observed": False,
@@ -785,6 +794,27 @@ def probe(
     workspace = CodexWorkspace.create(task_id="foundry-connection-probe")
     codex: Any = None
     try:
+        # Asked and recorded before anything is sent, and recorded whichever
+        # way it answers. A turn started on a sign-in that cannot mint reaches
+        # the deployment carrying an empty bearer and is refused there, and the
+        # refusal — "invalid subscription key or wrong API endpoint" — is about
+        # the two things that were never wrong. Paid runs 34319880025 and
+        # 34347516170 are what that costs.
+        auth_probe = runner.preflight_auth_command(workspace)
+        observed["auth_command"] = auth_probe.as_record()
+        if auth_probe.ran and not auth_probe.ok:
+            return _record(
+                verdict=VERDICT_AUTH_COMMAND_FAILED,
+                description=description,
+                observed=observed,
+                note=(
+                    "the auth command produced no token in the isolated "
+                    "environment, so no request was sent and nothing was "
+                    "billed; the fault is local to the sign-in, not the "
+                    "deployment"
+                ),
+            )
+
         try:
             codex = runner.open_runtime(workspace)
         except Exception as exc:  # noqa: BLE001

--- a/batch-runner/tests/test_codex_foundry_connection_probe.py
+++ b/batch-runner/tests/test_codex_foundry_connection_probe.py
@@ -629,7 +629,27 @@ ROUTED = {
 }
 
 
-def _run(argv, environ, monkeypatch, capsys):
+#: What the sign-in preflight would say, for the tests that are not about the
+#: sign-in. Stubbed by default in :func:`_run` because the real one starts a
+#: subprocess that talks to the Azure identity platform, and a unit test that
+#: reaches the network is a unit test that can fail for a reason it was never
+#: written to detect. The tests below that *are* about the sign-in say so.
+STUB_AUTH_PROBE = {
+    "ran": True,
+    "exit_code": 0,
+    "produced_a_token": True,
+    "reason": None,
+    "azure_config_dir": "/home/somebody/.azure",
+    "ok": True,
+}
+
+
+def _run(argv, environ, monkeypatch, capsys, auth_probe=STUB_AUTH_PROBE):
+    import scripts.diagnose_codex_foundry_connection as module
+
+    monkeypatch.setattr(
+        module, "_plan_auth_command", lambda _settings_: auth_probe
+    )
     for name in (
         "AZURE_AI_ROUTE_PROFILE",
         "AZURE_OPENAI_V1_ENDPOINT",
@@ -709,6 +729,155 @@ def test_a_run_that_could_not_be_configured_still_leaves_a_record(
 def test_a_deployment_must_be_named(capsys):
     with pytest.raises(SystemExit):
         main([])
+
+
+# ── The sign-in, which the free plan can ask about ──────────────────────────
+#
+# The 401 this diagnostic was built to explain turned out to be ours: Codex
+# reads its bearer from an auth command's stdout, the command could neither
+# import its package nor find the Azure CLI sign-in from inside the isolated
+# environment, and an empty bearer came back as "invalid subscription key".
+#
+# Minting an Entra token is a call to the identity platform, not to the
+# deployment — no model runs and nothing is billed. So the plan runs it, and
+# the question "can this host mint from where Codex runs it?" is answered by a
+# dispatch that spends nothing instead of by a paid one that stops early.
+
+
+def _probe(**overrides):
+    from core.codex_runner import AuthCommandProbe
+
+    fields = {
+        "ran": True,
+        "exit_code": 0,
+        "produced_a_token": True,
+        "reason": None,
+        "azure_config_dir": "/home/somebody/.azure",
+    }
+    fields.update(overrides)
+    return AuthCommandProbe(**fields)
+
+
+class _FakeRunner:
+    """Stands in for the runner, so no subprocess and no network."""
+
+    def __init__(self, probe):
+        self._probe = probe
+        self.workspaces = []
+
+    def __call__(self, settings, verify_runtime=True):
+        self.verify_runtime = verify_runtime
+        return self
+
+    def preflight_auth_command(self, workspace):
+        self.workspaces.append(workspace)
+        return self._probe
+
+
+def test_the_free_plan_says_whether_the_sign_in_can_mint(monkeypatch, capsys):
+    code, record = _run(["--deployment", DEPLOYMENT], ROUTED, monkeypatch, capsys)
+    assert code == 0
+    assert record["verdict"] == VERDICT_NOT_SENT
+    assert record["observed"]["turn_sent"] is False
+    assert record["observed"]["auth_command"] == STUB_AUTH_PROBE
+    assert "costs nothing" in record["note"]
+
+
+def test_a_sign_in_that_cannot_mint_still_leaves_the_plan_green(
+    monkeypatch, capsys
+):
+    """The free step reports; it does not gate.
+
+    A red plan would be read as "the diagnostic broke", and the thing it is
+    reporting is the opposite: it worked, and the answer is no.
+    """
+    failed = _probe(
+        exit_code=1,
+        produced_a_token=False,
+        reason="codex-azure-token: could not acquire an access token",
+    ).as_record()
+    code, record = _run(
+        ["--deployment", DEPLOYMENT], ROUTED, monkeypatch, capsys, auth_probe=failed
+    )
+    assert code == 0
+    assert record["verdict"] == VERDICT_NOT_SENT
+    assert record["observed"]["auth_command"]["ok"] is False
+
+
+def test_a_preflight_that_could_not_run_at_all_leaves_the_field_empty(
+    monkeypatch, capsys
+):
+    """``null`` is "not asked", and it must not be confused with "asked, no"."""
+    code, record = _run(
+        ["--deployment", DEPLOYMENT], ROUTED, monkeypatch, capsys, auth_probe=None
+    )
+    assert code == 0
+    assert record["observed"]["auth_command"] is None
+    assert "costs nothing" not in record["note"]
+
+
+def test_a_preflight_that_raised_is_swallowed_rather_than_reported(monkeypatch):
+    """A host without the pinned runtime keeps getting the plan it used to get.
+
+    The plan ran on every host before this was added, and the only acceptable
+    way to add a step that cannot run everywhere is for the places it cannot
+    run to be unchanged by it.
+    """
+    import core.codex_runner as runner_module
+    import scripts.diagnose_codex_foundry_connection as module
+
+    def _explode(*args, **kwargs):
+        raise RuntimeError("no runtime here")
+
+    monkeypatch.setattr(runner_module, "CodexAgentRunner", _explode)
+    assert module._plan_auth_command(_settings()) is None
+
+
+def test_the_workspace_the_preflight_opened_is_cleaned_up(monkeypatch):
+    """Otherwise a plan leaves a directory behind every time it is run."""
+    import core.codex_runner as runner_module
+    import scripts.diagnose_codex_foundry_connection as module
+
+    fake = _FakeRunner(_probe())
+    monkeypatch.setattr(runner_module, "CodexAgentRunner", fake)
+    record = module._plan_auth_command(_settings())
+
+    assert record["ok"] is True
+    assert fake.verify_runtime is False, (
+        "the preflight needs the settings and a workspace, not the Codex "
+        "binary, and requiring the binary would make the free plan stop "
+        "running on hosts where it used to run"
+    )
+    assert len(fake.workspaces) == 1
+    assert not os.path.exists(fake.workspaces[0].workspace)
+
+
+def test_what_the_sign_in_said_is_redacted_like_every_other_message(monkeypatch):
+    """``reason`` is a subprocess's words, and this artifact is published.
+
+    The command's own failure line is short and safe, but it is not the only
+    line that can reach that field, and every other runtime message in this
+    script goes through the redactor before it is written down.
+    """
+    import core.codex_runner as runner_module
+    import scripts.diagnose_codex_foundry_connection as module
+
+    for name, value in ROUTED.items():
+        monkeypatch.setenv(name, value)
+    talkative = _probe(
+        exit_code=1,
+        produced_a_token=False,
+        reason=(
+            f"failed for https://{ACCOUNT}.services.ai.azure.com/ as {ACCOUNT}"
+        ),
+    )
+    monkeypatch.setattr(runner_module, "CodexAgentRunner", _FakeRunner(talkative))
+
+    record = module._plan_auth_command(_settings())
+
+    assert ACCOUNT not in json.dumps(record)
+    assert "<url redacted>" in record["reason"]
+    assert "<name redacted>" in record["reason"]
 
 
 # ── The workflow that runs it ───────────────────────────────────────────────
@@ -1220,6 +1389,20 @@ def test_the_check_passes_the_record_the_script_actually_writes(tmp_path):
     result = _run_redaction_check(tmp_path, _real_record())
     assert result.returncode == 0, result.stdout + result.stderr
     assert "record=clean" in result.stdout
+
+
+def test_the_check_passes_a_record_carrying_the_sign_ins_answer(tmp_path):
+    """The auth block is new, and this check is what stands between it and a
+    public artifact — including the home directory the sign-in was found in."""
+    record = _real_record()
+    record["observed"]["auth_command"] = _probe(
+        exit_code=1,
+        produced_a_token=False,
+        reason="codex-azure-token: could not acquire an access token",
+        azure_config_dir="/home/runner/.azure",
+    ).as_record()
+    result = _run_redaction_check(tmp_path, record)
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_the_one_url_allowed_through_is_the_repositorys_own_constant():

--- a/batch-runner/tests/test_the_auth_command_runs_where_codex_runs_it.py
+++ b/batch-runner/tests/test_the_auth_command_runs_where_codex_runs_it.py
@@ -1,0 +1,507 @@
+"""The auth command has to work *where Codex runs it*, not where we test it.
+
+Codex authenticates the provider by running a command and reading the token
+from its stdout. This repository's command is ``core/codex_azure_token.py``,
+and until now every test of it ran the command the way a developer would: from
+``batch-runner``, in this process's own environment, or — in
+``test_what_one_codex_turn_actually_sends.py`` — as a *stub* printer that needs
+no sign-in at all. Each of those tests was checking something true and none of
+them could see the thing that was broken.
+
+Codex starts the command somewhere else entirely:
+
+* with the **task's directory** as the working directory, because
+  ``CodexAgentRunner.open_runtime`` sets ``CodexConfig.cwd`` to the workspace
+  and the pinned SDK passes that straight to ``Popen``; and
+* in the **isolated environment**, where ``HOME`` has been rewritten to a
+  throwaway directory so the model cannot write into the operator's home.
+
+Both are deliberate and both stay. But three separate faults followed from
+them, and all three produced the same symptom, which is why the symptom was so
+hard to read:
+
+1. ``python -m core.codex_azure_token`` cannot import ``core`` from the task
+   directory. It fails before the module's first line.
+2. ``DefaultAzureCredential``'s working leg here is the Azure CLI, which reads
+   its sign-in from ``$HOME/.azure``. With ``HOME`` rewritten there is none.
+3. On any failure the command prints **nothing** on stdout — deliberately, so
+   Codex cannot mistake an error message for a token. Codex therefore sends an
+   empty bearer, and the gateway answers ``401 Access denied due to invalid
+   subscription key or wrong API endpoint``.
+
+That 401 names the endpoint and the key, which were both correct throughout.
+The tests here hold each fault separately, so the next one to appear is named
+where it happens instead of arriving as a sentence about a subscription.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from core.codex_azure_token import (
+    AZURE_CONFIG_DIR_ENV,
+    TokenCommandError,
+    point_at_azure_config_dir,
+)
+from core.codex_runner import (
+    AuthCommandProbe,
+    CodexAgentRunner,
+    CodexAuthCommandFailed,
+    CodexWorkspace,
+)
+from core.codex_runtime_config import (
+    NEUTRALISED_ENV_NAMES,
+    CodexProviderSettings,
+    LoopbackCodexProvider,
+    build_isolated_environment,
+    discover_azure_cli_config_dir,
+)
+
+REAL_SHAPED_SETTINGS = CodexProviderSettings(
+    endpoint="https://example-account.openai.azure.com/openai/v1/",
+    model="a-deployment",
+)
+
+#: Stands in for a token. Nothing here mints a real one; what these tests care
+#: about is whether stdout carried *something*, which is all the runtime cares
+#: about too.
+FAKE_TOKEN = "not-a-real-token-just-a-non-empty-line"
+
+
+def _workspace(root: Path) -> CodexWorkspace:
+    """A workspace shaped like the one a task gets."""
+    workspace = CodexWorkspace(
+        root=root,
+        workspace=root / "workspace",
+        codex_home=root / "codex-home",
+        home=root / "home",
+    )
+    for directory in (workspace.workspace, workspace.codex_home, workspace.home):
+        directory.mkdir(parents=True, exist_ok=True)
+    return workspace
+
+
+def _provider_running(script: Path) -> CodexProviderSettings:
+    """Settings whose auth command is ``script``, and nothing else changed."""
+
+    class _Scripted(CodexProviderSettings):
+        def auth_command(self, source_environment=None):  # type: ignore[override]
+            return [sys.executable, str(script)]
+
+    return _Scripted(
+        endpoint="https://example-account.openai.azure.com/openai/v1/",
+        model="a-deployment",
+    )
+
+
+# ── 1. The working directory ────────────────────────────────────────────────
+
+
+def test_the_auth_command_names_the_module_by_path_not_by_dash_m():
+    """``-m`` is what broke; a path is what survives an unfamiliar cwd.
+
+    The argv Codex is handed has to be runnable from the task's directory.
+    ``-m core.codex_azure_token`` is only runnable from somewhere ``core`` is
+    importable, and the task's directory is deliberately not that place.
+    """
+    argv = REAL_SHAPED_SETTINGS.auth_command()
+
+    assert "-m" not in argv, argv
+    module_path = Path(argv[1])
+    assert module_path.is_absolute(), argv
+    assert module_path.is_file(), argv
+    assert module_path.name == "codex_azure_token.py", argv
+    # Resolved, so two records of the same run describe the same file the same
+    # way rather than one of them carrying a ``/./``.
+    assert str(module_path) == str(module_path.resolve()), argv
+
+
+def test_the_module_runs_from_a_directory_where_core_is_not_importable(
+    tmp_path: Path,
+):
+    """The regression for fault 1, run as a subprocess from the wrong place.
+
+    ``--azure-config-dir`` is given a path that does not exist, so the command
+    is expected to fail — but it has to fail *at the argument*, which it can
+    only reach if the import and the argument parsing both happened. A
+    ``ModuleNotFoundError`` here is the original bug returning.
+    """
+    argv = REAL_SHAPED_SETTINGS.auth_command()
+    missing = tmp_path / "no-such-azure-dir"
+
+    completed = subprocess.run(
+        [argv[0], argv[1], "--scope", "https://ai.azure.com/.default",
+         "--azure-config-dir", str(missing)],
+        cwd=str(tmp_path),  # emphatically not the package root
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert completed.returncode == 1, completed.stderr
+    assert "ModuleNotFoundError" not in completed.stderr, completed.stderr
+    assert "No module named" not in completed.stderr, completed.stderr
+    assert str(missing) in completed.stderr
+    assert completed.stdout == ""
+
+
+# ── 2. The sign-in ──────────────────────────────────────────────────────────
+
+
+def test_the_sign_in_is_discovered_from_the_parent_home(tmp_path: Path):
+    """Discovery reads the real ``HOME``, which is the only place it exists."""
+    home = tmp_path / "home"
+    (home / ".azure").mkdir(parents=True)
+
+    found = discover_azure_cli_config_dir({"HOME": str(home)})
+
+    assert found == str(home / ".azure")
+
+
+def test_a_home_without_a_sign_in_discovers_nothing(tmp_path: Path):
+    """No sign-in is a real answer, not a path to a directory that is not there.
+
+    Returning a plausible-looking path would put the failure one step later,
+    inside the credential, where it reads as an Azure problem.
+    """
+    assert discover_azure_cli_config_dir({"HOME": str(tmp_path)}) is None
+    assert discover_azure_cli_config_dir({}) is None
+    assert (
+        discover_azure_cli_config_dir(
+            {"AZURE_CONFIG_DIR": str(tmp_path / "gone"), "HOME": str(tmp_path)}
+        )
+        is None
+    )
+
+
+def test_an_explicit_config_dir_wins_over_home(tmp_path: Path):
+    """``AZURE_CONFIG_DIR`` is how an operator moves the sign-in; honour it."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (tmp_path / ".azure").mkdir()
+
+    found = discover_azure_cli_config_dir(
+        {"AZURE_CONFIG_DIR": str(elsewhere), "HOME": str(tmp_path)}
+    )
+
+    assert found == str(elsewhere)
+
+
+def test_the_config_dir_travels_in_argv(tmp_path: Path):
+    """A path, in the command's own argv — not a name in Codex's environment."""
+    home = tmp_path / "home"
+    (home / ".azure").mkdir(parents=True)
+
+    argv = REAL_SHAPED_SETTINGS.auth_command({"HOME": str(home)})
+
+    assert argv[-2:] == ["--azure-config-dir", str(home / ".azure")]
+
+
+def test_nothing_is_appended_when_there_is_no_sign_in_to_point_at(
+    tmp_path: Path,
+):
+    """A runner authenticating some other way is left exactly as it was."""
+    argv = REAL_SHAPED_SETTINGS.auth_command({"HOME": str(tmp_path)})
+
+    assert "--azure-config-dir" not in argv
+    assert argv[-2:] == ["--scope", REAL_SHAPED_SETTINGS.auth_scope]
+
+
+def test_the_isolation_still_hides_the_sign_in_from_codex_itself(
+    tmp_path: Path,
+):
+    """The security half of the fix, asserted directly.
+
+    The auth command learns where the sign-in is. The *Codex process* must not,
+    because everything the model runs inherits that environment. If a later
+    change takes the easy road and adds ``AZURE_CONFIG_DIR`` — or stops
+    rewriting ``HOME`` — this is the test that should stop it.
+    """
+    overlay = build_isolated_environment(
+        codex_home=tmp_path / "codex", task_home=tmp_path / "home"
+    )
+
+    assert AZURE_CONFIG_DIR_ENV not in overlay
+    assert overlay["HOME"] == str(tmp_path / "home")
+    assert "HOME" in NEUTRALISED_ENV_NAMES
+
+
+def test_pointing_at_a_directory_that_is_not_there_is_refused(tmp_path: Path):
+    """A wrong path must not become a quiet sign-in failure one layer down."""
+    missing = tmp_path / "nowhere"
+    environment: dict[str, str] = {}
+
+    with pytest.raises(TokenCommandError) as excinfo:
+        point_at_azure_config_dir(missing, environment)
+
+    assert str(missing) in str(excinfo.value)
+    assert environment == {}
+
+
+def test_pointing_at_a_real_directory_sets_the_name_the_cli_reads(
+    tmp_path: Path,
+):
+    environment: dict[str, str] = {}
+
+    resolved = point_at_azure_config_dir(tmp_path, environment)
+
+    assert environment == {AZURE_CONFIG_DIR_ENV: str(tmp_path)}
+    assert resolved == str(tmp_path)
+
+
+# ── 3. The silence ──────────────────────────────────────────────────────────
+
+
+def test_a_runtime_will_not_start_when_no_token_can_be_minted(tmp_path: Path):
+    """Fault 3, held at the place it starts instead of at the gateway.
+
+    The command exits non-zero having printed nothing, which is exactly what
+    the real one does when it cannot sign in. Before this check, that produced
+    a turn, an empty bearer and a 401 about a subscription key.
+    """
+    script = tmp_path / "cannot_mint.py"
+    script.write_text(
+        "import sys\n"
+        "print('codex-azure-token: could not acquire an access token "
+        "(ClientAuthenticationError)', file=sys.stderr)\n"
+        "sys.exit(1)\n",
+        encoding="utf-8",
+    )
+    runner = CodexAgentRunner(_provider_running(script), verify_runtime=False)
+
+    with pytest.raises(CodexAuthCommandFailed) as excinfo:
+        runner.require_a_usable_auth_command(_workspace(tmp_path / "run"))
+
+    message = str(excinfo.value)
+    assert "could not acquire an access token" in message
+    # The message has to say the 401 would be misleading, because the whole
+    # cost of this bug was believing it.
+    assert "invalid subscription key" in message
+
+
+def test_a_command_that_exits_zero_with_nothing_on_stdout_is_still_a_failure(
+    tmp_path: Path,
+):
+    """Codex reads stdout, not the exit code. So must the check.
+
+    An auth command that succeeds silently hands over an empty bearer just as
+    surely as one that fails loudly, and the gateway cannot tell them apart.
+    """
+    script = tmp_path / "silent_success.py"
+    script.write_text("import sys\nsys.exit(0)\n", encoding="utf-8")
+    runner = CodexAgentRunner(_provider_running(script), verify_runtime=False)
+
+    with pytest.raises(CodexAuthCommandFailed):
+        runner.require_a_usable_auth_command(_workspace(tmp_path / "run"))
+
+
+def test_a_command_that_prints_a_token_passes_and_the_token_is_not_kept(
+    tmp_path: Path,
+):
+    """The probe reports *that* there was a token, never *which*."""
+    script = tmp_path / "mints.py"
+    script.write_text(
+        f"import sys\nsys.stdout.write({FAKE_TOKEN!r} + chr(10))\n",
+        encoding="utf-8",
+    )
+    runner = CodexAgentRunner(_provider_running(script), verify_runtime=False)
+
+    probe = runner.require_a_usable_auth_command(_workspace(tmp_path / "run"))
+
+    assert probe.ok
+    assert probe.produced_a_token is True
+    assert FAKE_TOKEN not in repr(probe)
+    assert FAKE_TOKEN not in repr(probe.as_record())
+
+
+def test_the_check_runs_once_however_many_tasks_follow(tmp_path: Path):
+    """220 tasks are 220 turns and one sign-in question.
+
+    The counter is a file the script appends to, so the count survives the
+    subprocess boundary the way a real auth command's side effects would.
+    """
+    counter = tmp_path / "runs.txt"
+    script = tmp_path / "counts.py"
+    script.write_text(
+        "import sys\n"
+        f"open({str(counter)!r}, 'a').write('x')\n"
+        f"sys.stdout.write({FAKE_TOKEN!r} + chr(10))\n",
+        encoding="utf-8",
+    )
+    runner = CodexAgentRunner(_provider_running(script), verify_runtime=False)
+    workspace = _workspace(tmp_path / "run")
+
+    for _ in range(3):
+        runner.require_a_usable_auth_command(workspace)
+
+    assert counter.read_text() == "x"
+
+
+def test_the_probe_gives_the_child_the_environment_the_sdk_gives_it(
+    tmp_path: Path,
+):
+    """The probe's fidelity, which is the only reason to trust its answer.
+
+    The pinned SDK builds the child environment as ``os.environ.copy()``
+    updated with the overlay, so a name present in this process but absent from
+    the overlay still reaches the command. A probe that passed the overlay
+    alone would test a stricter world than production and could fail on
+    something production would not — an answer that is wrong in the safe
+    direction is still wrong.
+    """
+    marker = "GDPVAL_AUTH_PROBE_FIDELITY_MARKER"
+    script = tmp_path / "echoes.py"
+    script.write_text(
+        "import os, sys\n"
+        f"sys.stdout.write(os.environ.get({marker!r}, '') + chr(10))\n",
+        encoding="utf-8",
+    )
+    runner = CodexAgentRunner(_provider_running(script), verify_runtime=False)
+
+    overlay = build_isolated_environment(
+        codex_home=tmp_path / "c", task_home=tmp_path / "h"
+    )
+    assert marker not in overlay
+
+    previous = os.environ.get(marker)
+    os.environ[marker] = "carried"
+    try:
+        probe = runner.preflight_auth_command(_workspace(tmp_path / "run"))
+    finally:
+        if previous is None:
+            os.environ.pop(marker, None)
+        else:
+            os.environ[marker] = previous
+
+    assert probe.produced_a_token is True, probe.as_record()
+
+
+def test_the_isolation_is_still_applied_to_the_command(tmp_path: Path):
+    """Fidelity to the SDK must not become "the parent environment, unchanged".
+
+    ``HOME`` is the name the whole fault turned on, so the check that the
+    overlay really is applied uses that one.
+    """
+    script = tmp_path / "reads_home.py"
+    script.write_text(
+        "import os, sys\n"
+        "sys.stdout.write(os.environ.get('HOME', '') + chr(10))\n",
+        encoding="utf-8",
+    )
+    runner = CodexAgentRunner(_provider_running(script), verify_runtime=False)
+    workspace = _workspace(tmp_path / "run")
+
+    probe = runner.preflight_auth_command(workspace)
+
+    # It printed *something*, and what it printed was the task's home rather
+    # than this machine's. Asserted via the probe's own view plus a direct run,
+    # because the probe deliberately does not keep the child's output.
+    assert probe.produced_a_token is True
+    direct = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=str(workspace.workspace),
+        env={**os.environ, **build_isolated_environment(
+            codex_home=workspace.codex_home, task_home=workspace.home
+        )},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert direct.stdout.strip() == str(workspace.home)
+    assert direct.stdout.strip() != os.environ.get("HOME", "")
+
+
+def test_a_provider_with_no_auth_command_is_not_blocked(tmp_path: Path):
+    """The loopback stand-in authenticates by variable; there is nothing to run."""
+    runner = CodexAgentRunner(
+        LoopbackCodexProvider(port=8123), verify_runtime=False
+    )
+
+    probe = runner.require_a_usable_auth_command(_workspace(tmp_path / "run"))
+
+    assert probe.ran is False
+    assert probe.ok is False  # nothing was established, and none is claimed
+
+
+def test_the_check_can_be_turned_off_for_the_diagnostic(tmp_path: Path):
+    """The connection diagnostic sometimes needs to send the failing request."""
+    script = tmp_path / "cannot_mint.py"
+    script.write_text("import sys\nsys.exit(1)\n", encoding="utf-8")
+    runner = CodexAgentRunner(
+        _provider_running(script), verify_runtime=False, preflight_auth=False
+    )
+
+    probe = runner.require_a_usable_auth_command(_workspace(tmp_path / "run"))
+
+    assert probe.ran is False
+    assert "turned off" in (probe.reason or "")
+
+
+def test_a_probe_record_carries_no_token_field():
+    """Whatever else changes, the record stays a report about a token's absence."""
+    probe = AuthCommandProbe(
+        ran=True,
+        exit_code=0,
+        produced_a_token=True,
+        reason=None,
+        azure_config_dir="/somewhere/.azure",
+    )
+
+    record = probe.as_record()
+
+    assert set(record) == {
+        "ran",
+        "exit_code",
+        "produced_a_token",
+        "reason",
+        "azure_config_dir",
+        "ok",
+    }
+    assert all(not isinstance(value, str) or "eyJ" not in value
+               for value in record.values())
+
+
+# ── The one that would have caught all three, on a machine that can sign in ──
+
+
+@pytest.mark.integration
+def test_the_real_auth_command_mints_inside_the_isolation():
+    """End to end, with nothing stubbed: the real command, the real isolation.
+
+    Skipped where the machine cannot sign in at all, and where the Azure CLI is
+    a user-site install — on such a box ``az`` resolves its own modules through
+    ``HOME`` and cannot start under any isolation, which is a property of the
+    installation rather than of this code. CI installs the CLI system-wide and
+    runs this for real.
+    """
+    if not discover_azure_cli_config_dir():
+        pytest.skip("no Azure CLI sign-in on this machine")
+
+    settings = REAL_SHAPED_SETTINGS
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        workspace = _workspace(root)
+        runner = CodexAgentRunner(settings, verify_runtime=False)
+
+        parent = subprocess.run(
+            settings.auth_command(),
+            cwd=str(Path(__file__).resolve().parent.parent),
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        if parent.returncode != 0:
+            pytest.skip("this machine's own sign-in cannot mint a token")
+
+        probe = runner.preflight_auth_command(workspace)
+        if not probe.ok and "azure" in (probe.reason or "").lower():
+            pytest.skip(f"the Azure CLI cannot start under isolation here: "
+                        f"{probe.reason}")
+
+        assert probe.ok, probe.as_record()

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -1298,8 +1298,12 @@ paid run must be preceded by a fresh smoke at the new fingerprint.
   The third bit everywhere, because it is what turned both of the others into
   a sentence about a subscription key.
 
-- The next decision is one dispatch of the connection diagnostic from `main`,
-  which now records the free `auth_command` block — confirming on the runner
-  whether the second fault bites there too — followed by a real turn through the
-  fixed path. Until a turn is answered, the column stays empty and is reported
-  as unconfirmed. It is not filled with a substitute.
+- The next decision is one dispatch of the connection diagnostic from `main`
+  **in plan mode** — `send_request` left off, nothing billed — because the plan
+  now runs the real auth command in the real isolated environment and writes the
+  `auth_command` block. Minting is a call to the identity platform, not to the
+  deployment, so the runner question is answered by a dispatch that spends
+  nothing. It reports rather than gates: a runner that cannot mint still returns
+  `not_sent` and exit `0`, with `ok: false` and the reason. Then a real turn
+  through the fixed path. Until a turn is answered, the column stays empty and
+  is reported as unconfirmed. It is not filled with a substitute.

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -1191,6 +1191,10 @@ paid run must be preceded by a fresh smoke at the new fingerprint.
   materially larger and stranger than a Codex turn, served without complaint.
   `properties_that_closed_the_gate: []`. Summed usage 5,942 in / 35 out,
   `price_usd: null`, `pricing: partial`; nine paid requests, unpriced, not free.
+  Two arms (`stream_true`, `everything`) set `stream: true`, so their records
+  hold the SSE prelude instead of a parsed final status and report no usage;
+  the sum is over the seven that did, and the gate question is answered at the
+  HTTP level for all nine.
 
   So the refusal is not in what Codex puts in the request. That is a real
   elimination and it cost nine requests, and the sweep's own record said what

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -12,6 +12,11 @@
   free role inventory and the one authorised paid turn have closed four of the
   five candidate causes of the 401 and left the refusal itself unexplained. See
   section 3c.
+- Updated: 2026-09-10 — the sweep was fired and found nothing: all nine paid
+  arms served. The refusal was then located, and it was ours — the auth command
+  could not produce a token where Codex runs it, for three separate reasons.
+  Fixed and tested locally; no turn has yet been sent through the fixed path.
+  See the last three bullets of section 12.
 - Status: **built, executing on one host, and not connected.** The code exists
   and most of the chain is checked against the real Codex binary. As of
   2026-09-08 the agent has been observed executing a command inside its sandbox
@@ -522,7 +527,8 @@ until the evidence exists.
 | `batch-runner/core/codex_runner.py` | Starts the runtime per task, hands over the prompt and reference files, collects deliverables, enforces the time limit, and cleans up. `open_runtime()` and `start_thread()` are the one construction path the diagnostic shares. |
 | `batch-runner/scripts/diagnose_codex_foundry_connection.py` | Asks the deployment one question and names which "no" came back, by reading the turn stream the SDK's collector discards (§3c). |
 | `.github/workflows/codex-foundry-connection-diagnostic.yml` | Runs it from `main` under the existing OIDC sign-in. `send_request` defaults off; the plan step always runs. |
-| `batch-runner/core/codex_azure_token.py` | Prints an Entra token to stdout for `auth.command`. |
+| `batch-runner/core/codex_azure_token.py` | Prints an Entra token to stdout for `auth.command`. Now runnable by path from any directory, and takes `--azure-config-dir` so it can find a sign-in the isolation has hidden from it. |
+| `batch-runner/tests/test_the_auth_command_runs_where_codex_runs_it.py` | Holds the three faults of §12 apart: the working directory, the sign-in, and the silence — plus the assertion that the fix did not buy the connection with isolation. |
 | `batch-runner/core/codex_cost.py` | Adapts thread-cumulative usage onto the repository's existing receipt contract. |
 | `batch-runner/core/executor.py` | Gained the `codex_foundry` mode and its dispatch entry. |
 | `batch-runner/core/experiment_config.py` | Accepts the mode in an experiment file. |
@@ -1176,6 +1182,120 @@ paid run must be preceded by a fresh smoke at the new fingerprint.
   (namespace granted, capability stripped) still cannot run it and still skip.
   The execution-host card stays open, because one retiring runner image is a
   reprieve rather than an answer.
-- The next decision is whoever can run one paid request against the pinned
-  deployment. Until it succeeds, the column stays empty and is reported as
-  unconfirmed. It is not filled with a substitute.
+- **The sweep was fired and it found nothing — which was the answer.** Run
+  `34448607605`, verdict `no_property_closes_a_served_request`. The baseline was
+  re-tested that day and served (`200`, `completed`, `gpt-5.4`, 13 in / 5 out),
+  so the premise held and the other eight were bought honestly. **All nine arms
+  returned `200`**, including `everything`: 30,981 bytes, nine added headers,
+  `stream: true`, a 19 KB `instructions` and ten tool definitions — a request
+  materially larger and stranger than a Codex turn, served without complaint.
+  `properties_that_closed_the_gate: []`. Summed usage 5,942 in / 35 out,
+  `price_usd: null`, `pricing: partial`; nine paid requests, unpriced, not free.
+
+  So the refusal is not in what Codex puts in the request. That is a real
+  elimination and it cost nine requests, and the sweep's own record said what
+  was left: the transport, or something the sweep does not vary. It was the
+  second, and it was not in the request at all.
+
+- **The 401 was ours the whole time: the auth command could not produce a token
+  where Codex runs it.** Three faults, stacked, each sufficient alone, each
+  producing the same silence.
+
+  Codex authenticates by running a command and reading the token off its stdout.
+  It runs that command **from the task's directory** — `open_runtime` sets
+  `CodexConfig.cwd` to the workspace and the pinned SDK hands it to `Popen` —
+  and **inside the isolated environment**, where `HOME` is rewritten so the
+  model cannot reach the operator's home. Both are deliberate; both stay. From
+  there: `python -m core.codex_azure_token` cannot import `core`, so it died
+  before its first line; `DefaultAzureCredential`'s only working leg here is the
+  Azure CLI, which reads `$HOME/.azure`, and with `HOME` rewritten there was no
+  sign-in to read; and on failure the command prints **nothing** on stdout, by
+  design, so that an error can never be mistaken for a token. Codex forwarded an
+  empty bearer and the gateway answered `401 Access denied due to invalid
+  subscription key or wrong API endpoint` — a sentence naming the endpoint and
+  the key, both of which were correct throughout.
+
+  Measured, free, locally, before anything was changed: the same command exits
+  `0` with a 2,083-character token in the parent environment and exits `1` with
+  an empty stdout under `build_isolated_environment`. A per-credential sweep of
+  `DefaultAzureCredential` in the parent showed exactly one leg minting —
+  `AzureCliCredential` — and six unavailable, which is why the rewritten `HOME`
+  is decisive rather than incidental.
+
+  **The first fix proposed here was wrong and its own test said so.** Pointing
+  the credential at the real config directory alone still failed, because this
+  development box installs `az` into user site-packages, whose path Python
+  derives from `HOME`; under isolation `az` cannot start at all, and that
+  masked the sign-in question. Only pointing at the config directory *and*
+  neutralising that second, box-local breakage restored minting. A GitHub runner
+  installs the CLI system-wide, so the second condition should not apply
+  there — should, not does, and the diagnostic now carries the free instrument
+  that will say which.
+
+  The repairs are in `core/codex_runtime_config.py`, `core/codex_azure_token.py`
+  and `core/codex_runner.py`, and the important property of the second one is
+  what it refused to do. The sign-in's location travels in the **auth command's
+  own argv** as `--azure-config-dir`. It is not added to the Codex process's
+  environment, `HOME` is still rewritten, and `AZURE_CONFIG_DIR` is still absent
+  from what the model's tools inherit — the easy fix, and the one a later change
+  will be tempted by, is blocked by
+  `test_the_isolation_still_hides_the_sign_in_from_codex_itself`. §6's
+  prohibition on buying a connection with isolation is enforced here, not
+  promised.
+
+  Third, `CodexAgentRunner.require_a_usable_auth_command()` runs the real
+  command in the real isolated environment once per runner and refuses to open a
+  runtime when nothing comes back, raising `CodexAuthCommandFailed` with the
+  command's own reason. The probe reports *that* stdout carried a token and
+  never *which*; GUIDs and JWT-shaped strings are redacted out of the reason
+  before it is recorded. The connection diagnostic asks first and returns
+  `auth_command_produced_no_token` without sending anything, so this whole class
+  of failure now costs nothing instead of arriving as a paid `401`.
+
+  Twenty tests in
+  `batch-runner/tests/test_the_auth_command_runs_where_codex_runs_it.py` hold
+  the three faults apart, including one that runs the real module as a
+  subprocess from a directory where `core` is not importable and fails
+  *at the argument* rather than at the import. The existing credential test
+  could not have caught any of this and is not at fault:
+  `test_what_one_codex_turn_actually_sends.py` uses a **stub** token printer
+  that needs no sign-in, which is correct for what it measures — that the
+  runtime forwards whatever the command printed — and blind to the command
+  printing nothing.
+
+  What this is not. No request has been sent through the fixed path, on a runner
+  or anywhere else. The local end-to-end check is the auth command minting
+  inside a real isolated environment from a real task directory; it is not a
+  turn, not a tool, not a deliverable, and not the column. §11's fifth box stays
+  unticked.
+
+  **Which of the three bit on the runner, which is where the 401s were
+  bought.** The first one, certainly, and by itself it is enough. `PYTHONPATH`
+  is neither inherited nor neutralised by `build_isolated_environment`, so it
+  reaches the child only if the parent had it — and
+  `codex-foundry-connection-diagnostic.yml` never sets it. With the working
+  directory the task's and `PYTHONPATH` unset, `-m core.codex_azure_token`
+  raises `No module named 'core'` on any host, so run `34319880025`'s empty
+  bearer is accounted for without appealing to anything about this development
+  box.
+
+  The second is a **prediction and is recorded as one**. The workflow signs in
+  with `azure/login`, which writes to `/home/runner/.azure` — the directory the
+  rewritten `HOME` hides. `INHERITED_ENV_NAMES` does pass `AZURE_CLIENT_ID`,
+  `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE` and the two
+  `ACTIONS_ID_TOKEN_REQUEST_*` names through, so a credential that needs only
+  those could still work there; but `azure/login` with OIDC writes no federated
+  token file and no client secret, which is what `WorkloadIdentityCredential`
+  and `EnvironmentCredential` respectively require. The expectation is
+  therefore that the CLI is the working leg on the runner too and that the
+  second fault bites there as well. The free `auth_command` record settles it
+  either way, and it is not being assumed in advance.
+
+  The third bit everywhere, because it is what turned both of the others into
+  a sentence about a subscription key.
+
+- The next decision is one dispatch of the connection diagnostic from `main`,
+  which now records the free `auth_command` block — confirming on the runner
+  whether the second fault bites there too — followed by a real turn through the
+  fixed path. Until a turn is answered, the column stays empty and is reported
+  as unconfirmed. It is not filled with a substitute.


### PR DESCRIPTION
## What this is

The Codex `401` was never about the deployment. The auth command could not
produce a token **where Codex runs it**, and three separate faults each
produced that same silence.

Codex authenticates by running a command and reading the token off its stdout.
It runs that command with the **task's directory** as the working directory —
`open_runtime` sets `CodexConfig.cwd`, and the pinned SDK hands it to `Popen` —
and inside the **isolated environment**, where `HOME` is rewritten so the model
cannot reach the operator's home. Both are deliberate and **both stay**. From
there:

1. `python -m core.codex_azure_token` cannot import `core`. It died before the
   module's first line.
2. `DefaultAzureCredential`'s only working leg here is `AzureCliCredential`,
   which reads `$HOME/.azure`. With `HOME` rewritten there was no sign-in.
3. On failure the command prints **nothing** on stdout — by design, so an error
   can never be mistaken for a token. Codex forwarded an **empty bearer**, and
   the gateway answered `401 Access denied due to invalid subscription key or
   wrong API endpoint`.

That sentence names the endpoint and the key. Both were correct throughout: run
`34442249527` had already had a token from this same auth command accepted by
this same deployment with a `200`.

## Why this is the cause and not another hypothesis

Measured locally, free, before anything was changed:

| case | exit | stdout |
|---|---|---|
| parent environment | `0` | a 2,083-character token |
| under `build_isolated_environment` | `1` | empty |
| isolated + config dir only | `1` | empty |
| isolated + config dir + the box's own `az` breakage neutralised | `0` | a token |

A per-credential sweep of `DefaultAzureCredential` in the parent found exactly
one leg that mints — `AzureCliCredential` — and six unavailable, which is what
makes the rewritten `HOME` decisive rather than incidental.

**The first fix proposed here was wrong and its own test caught it.** Pointing
at the config directory alone still failed, because this development box
installs `az` into user site-packages whose path Python derives from `HOME`;
under isolation `az` cannot start at all, and that masked the sign-in question.

**Which fault bites on a runner**, where the `401`s were actually bought: the
first, certainly, and by itself it is enough — `PYTHONPATH` is neither
inherited nor neutralised by `build_isolated_environment` and
`codex-foundry-connection-diagnostic.yml` never sets it, so `-m` from the task's
directory fails on any host. The second is recorded as a **prediction**:
`azure/login` writes the sign-in that the rewritten `HOME` then hides, and while
`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_FEDERATED_TOKEN_FILE` are already
inherited, `azure/login` with OIDC writes no federated token file and no client
secret. The new free `auth_command` record settles it; it is not assumed.

## The fix, and the thing it deliberately does not do

- `CodexProviderSettings.auth_entrypoint()` names the module by **resolved file
  path**; `-m` stays as the fallback for a module with no file, which is how the
  existing tests point it at a stub. The module puts its own package root on
  `sys.path` when run by path.
- `discover_azure_cli_config_dir()` reads the sign-in's location in the
  **parent**, and `auth_command()` appends it as `--azure-config-dir`.

  **The value travels in the auth command's own argv.** The Codex process's
  environment is unchanged: `HOME` is still rewritten, `AZURE_CONFIG_DIR` is
  still absent from `INHERITED_ENV_NAMES`, and what the model's tools inherit is
  exactly what they inherited before. The easy fix — inheriting the name, or
  leaving `HOME` alone — is blocked by
  `test_the_isolation_still_hides_the_sign_in_from_codex_itself`. No isolation
  was disabled, nothing was made privileged, and no security policy changed.
- `CodexAgentRunner.require_a_usable_auth_command()` runs the real command in
  the real isolated environment **once per runner** and refuses to open a
  runtime when nothing comes back, raising `CodexAuthCommandFailed` with the
  command's own reason. The probe records **that** stdout carried a token, never
  which; GUIDs and JWT-shaped strings are redacted from the reason.
- `diagnose_codex_foundry_connection.py` asks first: new verdict
  `auth_command_produced_no_token` and an `auth_command` block in every record.
  This class of failure now costs **nothing** instead of arriving as a paid
  `401`.
- The first `codex_foundry` readiness blocker said no token from the auth
  command had ever been accepted by a deployment. Run `34442249527` had already
  disproved that. **The gate stays closed** — only the reason is now true.

## Tests

`batch-runner/tests/test_the_auth_command_runs_where_codex_runs_it.py`, 20 tests
holding the three faults apart. One runs the **real** module as a subprocess
from a directory where `core` is not importable and asserts it fails *at the
argument* rather than at the import — a `ModuleNotFoundError` there is the
original bug returning. One asserts the probe hands the child the environment
the SDK hands it (`os.environ.copy()` updated with the overlay), because a
probe that tests a stricter world than production can fail on something
production would not.

The existing credential test could not have caught this and is not at fault:
`test_what_one_codex_turn_actually_sends.py` uses a **stub** token printer that
needs no sign-in — correct for what it measures, and blind to the command
printing nothing.

Local: full backend suite `9525 passed, 12 skipped`; targeted re-run after the
last edit `1495 passed, 5 skipped`. The end-to-end integration test skips on
this box (user-site `az`) and runs for real in CI.

## What this is *not*

**No request has been sent through the fixed path**, on a runner or anywhere
else. What is measured is the auth command minting inside a real isolated
environment from a real task directory. That is not a turn, not a tool, not a
deliverable, and not the 220-task column. `structure_check_only` stands and
`step2_run_inference.py` still refuses a batch in this mode.

Also recorded here: the closing sweep was fired (run `34448607605`) and found
**nothing** — all nine paid arms returned `200`, including `everything` at
30,981 bytes with nine added headers, `stream: true`, a 19 KB `instructions` and
ten tool definitions. `properties_that_closed_the_gate: []`. Summed usage 5,942
in / 35 out, `price_usd: null`, `pricing: partial` — unpriced, **not free**.
That elimination is what pointed away from the request body and towards the
sign-in.

## Shared files

None. Everything here is A-owned (Codex core / auth / diagnostics / tests /
spec) plus `CHANGELOG.md` and the task doc. `executor.py`, `batch-run.yml` and
the price table are untouched.

## Next

One dispatch of the connection diagnostic from `main` to read the new free
`auth_command` record, then a real turn through the fixed path.
