### PR TITLE
feat(agentic-v2): stage B — a measured machine that could host the containment

### DIFF
--- a/batch-runner/core/agentic_v2_containment_readiness.py
+++ b/batch-runner/core/agentic_v2_containment_readiness.py
@@ -28,10 +28,16 @@ that report takes neither of them:
 It also reports only ``ready_for_boot_test`` or ``not_run``, which tells a reader
 that something is missing without telling them what or whether it is fixable.
 
-**Three machines are in play, and only one can be read from here.** The other
-two are recorded in :data:`RECORDED_FINDINGS` with the source and the date they
-were established, kept deliberately separate from anything probed, so a reader
-is never left guessing which kind of evidence they are looking at.
+**Four machines are in play, and only one can be read from here.** The other
+three are recorded in :data:`RECORDED_FINDINGS` with the source and the date
+they were established, kept deliberately separate from anything probed, so a
+reader is never left guessing which kind of evidence they are looking at.
+
+One of those three, the Azure dev host, is the first to answer yes to the
+hosting question. That moved one of the two questions this module asks and left
+the other exactly where it was: no code applies these rules, so the containment
+is still in place nowhere, and the refusal below still stands on that second
+ground.
 """
 
 from __future__ import annotations
@@ -627,6 +633,36 @@ RECORDED_FINDINGS: tuple[RecordedFinding, ...] = (
             "agentic-sandbox-preflight.yml returned nothing"
         ),
         on_date="2026-08-26",
+    ),
+    RecordedFinding(
+        machine="azure dev host (Standard_D8as_v5, koreacentral, Ubuntu 24.04)",
+        could_host_the_containment=True,
+        finding=(
+            "the things a machine must supply itself, which no amount of "
+            "installing can add, were read off this machine while it was "
+            "running: the processor reports svm, /dev/kvm is present and "
+            "reachable by an ordinary user, and the kernel is "
+            "6.17.0-1022-azure, above the 5.10 Firecracker validates against. "
+            "Nested virtualisation survived TrustedLaunch here, which is worth "
+            "recording because it does not hold on every Azure size. The "
+            "firecracker and jailer programs are not on the image and were "
+            "installed during the measurement, so a freshly deployed host "
+            "answers no on that fourth point until it is bootstrapped. This "
+            "says the containment could be hosted, and nothing more: no code "
+            "turns REQUIRED_MICROVM_POLICY into arguments for starting a "
+            "virtual machine, so on this machine too the rules are written "
+            "down and unapplied"
+        ),
+        established_by=(
+            "az vm run-command on gdpval-devhost-vm in rg-gdpval-devhost-krc, "
+            "running scripts/check_agentic_containment.py --json at commit "
+            "86152b713c687a0906b56533d989a14607570811. The returned report is "
+            "sha256 ee2222285af39a4674ed524865b08397413ab7d758543db20a8caf247"
+            "7eda070 and records all four host requirements as met, with the "
+            "nine policy rules as cannot-be-established. Firecracker v1.13.1 "
+            "from the project's own release"
+        ),
+        on_date="2026-09-10",
     ),
 )
 

--- a/batch-runner/tests/test_agentic_v2_containment_readiness.py
+++ b/batch-runner/tests/test_agentic_v2_containment_readiness.py
@@ -12,6 +12,7 @@ or is this machine, read the same read-only way the check itself reads it.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -586,16 +587,29 @@ def test_every_recorded_finding_says_where_it_came_from_and_when():
     for finding in RECORDED_FINDINGS:
         assert finding.machine
         assert finding.established_by
-        assert finding.on_date == "2026-08-26"
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", finding.on_date), finding.on_date
         assert len(finding.finding) > 80, "a finding with no reasoning in it"
 
 
-def test_no_recorded_finding_claims_the_containment_is_available():
-    """The answer as it stands. This test changes on the day the answer does."""
-    assert all(
-        finding.could_host_the_containment is not True
+def test_the_one_machine_that_could_host_it_does_not_claim_to_have_it():
+    """The answer as it stands, and it moved on 2026-09-10.
+
+    A machine that could host the containment now exists and has been measured
+    rather than argued for. This is the single most misreadable value in the
+    file, so the finding is required to disclaim in its own words the thing a
+    True here does not mean.
+    """
+    capable = [
+        finding
         for finding in RECORDED_FINDINGS
-    )
+        if finding.could_host_the_containment is True
+    ]
+
+    assert len(capable) == 1
+    assert "azure dev host" in capable[0].machine
+    assert capable[0].on_date == "2026-09-10"
+    assert "could be hosted, and nothing more" in capable[0].finding
+    assert "sha256" in capable[0].established_by
 
 
 def test_the_github_runner_finding_rests_on_githubs_own_documentation():
@@ -685,7 +699,10 @@ def test_the_whole_answer_covers_this_machine_and_the_recorded_ones():
     assert report["this_machine"]["required_containment_available"] is False
     assert len(report["recorded_findings"]) == len(RECORDED_FINDINGS)
     assert report["machines_without_a_finding"] == []
-    assert report["could_be_hosted_on_any_machine_in_play"] is False
+    # This machine cannot host it and the aggregate is True anyway: a recorded
+    # machine carries it, which is what recording one is for. The second flag
+    # is the one that stayed false, and it is the one the refusal reads.
+    assert report["could_be_hosted_on_any_machine_in_play"] is True
     assert report["available_on_any_machine_in_play"] is False
 
 

--- a/batch-runner/tests/test_agentic_v2_containment_rules.py
+++ b/batch-runner/tests/test_agentic_v2_containment_rules.py
@@ -14,8 +14,10 @@ is refused rather than accepted.
 
 What they deliberately do not do is start a virtual machine, run a command,
 exceed a limit and watch it stop. That is the test these rules will eventually
-need, and it cannot be written yet: no machine in play can host the containment,
-and no code turns these rules into arguments for starting one. Writing a
+need, and it cannot be written yet — though for one reason now rather than two.
+A machine in play *can* host the containment: the Azure dev host was measured on
+2026-09-10 and its finding is recorded. What is still missing is the other half,
+that no code turns these rules into arguments for starting one. Writing a
 pretend version of it would be worse than leaving it out, because a passing test
 named after a thing that never happened is how an unenforced rule comes to look
 enforced. core/agentic_v2_containment_readiness.py reports the gap instead.

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -707,7 +707,65 @@ whether the four readings passed, and the answer — yes or no — is written in
 as the two findings already there. A yes is not the exit condition. A recorded,
 sourced answer is.
 
-**Not yet run.**
+#### Run, and answered — 2026-09-10
+
+**The answer is yes, and it was measured rather than argued for.**
+
+The host was deployed from `infra/dev-host` with no change to the template:
+`gdpval-devhost-vm`, `Standard_D8as_v5`, `koreacentral`, Ubuntu 24.04 image
+`24.04.202608270`, `TrustedLaunch`, password authentication disabled, **no
+public IP and no inbound allow rule** — the NSG carries only the deny-all rule,
+so the machine is reachable solely through the Azure control plane
+(`az vm run-command`). That was established before any key material was
+generated, and the key that was generated is a dedicated one for this host, not
+the box's default identity.
+
+`scripts/check_agentic_containment.py --json` was run on the VM against a clone
+of this repository at `86152b7`. The report is 10,560 bytes, sha256
+`ee2222285af39a4674ed524865b08397413ab7d758543db20a8caf2477eda070`, verified
+against the VM's own computation of that hash after transfer:
+
+| reading | result |
+|---|---|
+| processor virtualisation flag | `svm` — **met** |
+| `/dev/kvm` | present, `crw-rw---- root kvm 10, 232` — **met** |
+| kernel release | `6.17.0-1022-azure`, above the 5.10 floor — **met** |
+| `firecracker` and `jailer` | v1.13.1, both run — **met** |
+
+`machine_could_host_it: true`.
+
+**The plan's prediction was wrong, and that is the point of having written it
+down first.** It expected the AMD default might not expose `/dev/kvm` and
+pre-authorised the Intel `Standard_D8s_v5`. The device is there, so no size
+change was made and the pre-authorisation went unused. Nested virtualisation
+survived `TrustedLaunch` on this size, which does not hold everywhere and is
+recorded as a reading rather than carried forward as an assumption.
+
+**One honest caveat.** `firecracker` and `jailer` are not on the image; they
+were installed during the measurement from the project's own release. A freshly
+deployed host therefore answers *no* on that fourth reading until it is
+bootstrapped. The three that no install can supply — processor, device, kernel —
+are the ones that make this a property of the machine.
+
+**What did not change.** `required_containment_available` is still `false`, and
+the nine policy rules still read `cannot be established here`, because no module
+turns `REQUIRED_MICROVM_POLICY` into arguments for starting a virtual machine.
+That is stage C. So `could_be_hosted_on_any_machine_in_play` flips to `true`,
+`available_on_any_machine_in_play` stays `false`, and
+`refuse_command_execution` keeps refusing — now naming the second ground rather
+than the first. No guard was removed, no activation flag was moved, `exec_run`
+stays shut, and nothing fell back to the V1 Docker runner.
+
+**Cost.** Allocated 2026-09-10 08:40:50Z, deallocated by 08:54Z: about 13
+minutes of `Standard_D8as_v5`, confirmed `PowerState/deallocated`. The disks are
+kept and still charge. The per-hour rate for this size under this subscription
+is not established here, so the entry is `partial`, not zero.
+
+**Done when — met.** The readiness JSON is an artefact, the four readings are in
+it, and the answer is written into `RECORDED_FINDINGS` as a third finding with
+its date and its source, in the same shape as the two already there. The finding
+disclaims in its own words the thing a `true` there does not mean.
+
 ### Stage C — not yet run
 ### Stage D — not yet run
 ### Stage E — not yet run


### PR DESCRIPTION
## What this is

Stage B of the Agentic Sandbox V2 activation asked exactly one question: **does a machine exist that could host the small isolated virtual machine the substrate manifest requires?** The answer is **yes**, measured on a real host rather than argued from documentation.

The plan for this stage was written and merged **before** the host was deployed (#489), so what follows can be checked against a prediction that was made in advance.

## The measurement

Deployed from `infra/dev-host` with no change to the template: `Standard_D8as_v5`, `koreacentral`, Ubuntu 24.04, `TrustedLaunch`, **no public IP and no inbound allow rule** — only the deny-all NSG rule, so the machine is reachable solely through the Azure control plane.

`scripts/check_agentic_containment.py --json` was run on it against a clone of this repo at `86152b7`. The report is sha256 `ee2222285af39a4674ed524865b08397413ab7d758543db20a8caf2477eda070`, verified against the VM's own computation of that hash after transfer.

| reading | result |
|---|---|
| processor virtualisation flag | `svm` — met |
| `/dev/kvm` | present, usable by an ordinary user — met |
| kernel release | `6.17.0-1022-azure`, above the 5.10 floor — met |
| `firecracker` / `jailer` | v1.13.1, both run — met |

## The plan's prediction was wrong

The merged plan expected the AMD default might not expose `/dev/kvm` and pre-authorised the Intel `Standard_D8s_v5`. The device is there. No size change was made and the pre-authorisation went unused. Nested virtualisation survived `TrustedLaunch` on this size, which does not hold everywhere, so it is recorded as a reading rather than carried forward as an assumption.

## What this deliberately does not change

`required_containment_available` is still `false`. The nine policy rules still read `cannot be established here`, because no module turns `REQUIRED_MICROVM_POLICY` into arguments for starting a virtual machine — that is stage C.

So exactly one aggregate moves:

- `could_be_hosted_on_any_machine_in_play` → `true`
- `available_on_any_machine_in_play` → stays `false`
- `refuse_command_execution` → still refuses, now naming the second ground rather than the first

No guard removed, no activation flag moved, `exec_run` still shut, no fallback to the V1 Docker runner.

## The two tests that pinned the old answer

Both were written to change on the day the answer changed, and both are updated rather than deleted:

- `test_no_recorded_finding_claims_the_containment_is_available` → `test_the_one_machine_that_could_host_it_does_not_claim_to_have_it`. A `True` in `could_host_the_containment` is the most misreadable value in the file, so the new test requires the finding to disclaim availability **in its own text**.
- The date assertion is loosened from one hardcoded day to an ISO date, which is what the test's own name promised.
- `test_the_whole_answer_covers_this_machine_and_the_recorded_ones` now asserts the aggregate is `true` while this machine cannot host it — which is what recording a finding is *for* — and that the second flag stayed false.

## Honest caveat

`firecracker` and `jailer` are not on the image; they were installed during the measurement. A freshly deployed host answers *no* on that fourth reading until bootstrapped. The three no install can supply — processor, device, kernel — are what make this a property of the machine.

## Cost

Allocated 08:40:50Z, deallocated by 08:54Z — about 13 minutes, confirmed `PowerState/deallocated`. Disks are kept and still charge. The per-hour rate under this subscription is not established here, so the entry is `partial`, **not zero**.

## Overlapping-file note

Touches `core/agentic_v2_containment_readiness.py`, its test, and the V2 task document — all B-owned V2 files. No shared executor, config, ledger, CI or CHANGELOG file is modified.

## Verification

- `pytest tests/test_agentic_v2_containment_readiness.py` — 64 passed
- All `tests/test_agentic*.py` — 1191 passed, 1 skipped, 8 deselected
- `mypy core/agentic_v2_containment_readiness.py` — clean; the 2 reported errors are in `core/agentic_v2_microvm.py`, untouched by this PR and pre-existing on `main`