### PR TITLE
fix(codex): the diagnostic asked the turn for a field the turn does not have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Fixed
+- **The connection diagnostic asked the turn for a field the turn does not
+  have, and reported the answer as missing.** Run `34461522053` connected: the
+  stream carried `UserMessageThreadItem`, `ReasoningThreadItem` and
+  `AgentMessageThreadItem`, and the provider billed 10,994 input / 28 output
+  tokens for it. The record still said `final_response_present: false`, which
+  reads as the model having stayed silent.
+
+  It had not. `_final_text` looked for `final_response` and then `output_text`
+  **on the `Turn`**. Both names are real, but they belong to `TurnResult`, the
+  SDK's own dataclass in `_run.py`. The `Turn` in `generated/v2_all.py` — which
+  is what a `TurnCompletedNotification` carries — has neither: it has `items`,
+  and the answer is the `text` of an `AgentMessageThreadItem` among them.
+  `getattr` on a Pydantic model with no such field returns the default without
+  complaint, so the miss was silent and total: **every** completed turn this
+  diagnostic ever observed was recorded as answerless.
+
+  `_final_text` now reads the items, using the SDK's own selection rule —
+  prefer the message marked `final_answer`, else the last one whose phase the
+  provider left unset, and never `commentary`. It consults the turn payload
+  first and the stream second, because `Turn.items_view` may say `notLoaded`,
+  and an unloaded payload is not a claim that nothing was said;
+  `observed.final_response_source` records which one answered.
+
+  The rule is copied from the SDK's private
+  `_final_assistant_response_from_items` rather than imported, and
+  `test_our_reading_rule_matches_the_pinned_sdks_own` runs the two over the
+  same eight item lists so an SDK bump that changes the rule fails a test
+  instead of drifting. There was no test over this function at all before, which
+  is how the bug survived; there are now eleven, built on real SDK objects,
+  because a stand-in carrying a `final_response` attribute is exactly the
+  fiction that hid it.
+
+  **The real run path was never affected.** `TurnHandle.run()` is annotated
+  `-> TurnResult` (`api.py:757`), so `core/codex_runner.py`'s
+  `getattr(result, "final_response", None)` reads a field that exists. Only the
+  diagnostic, which drives the stream itself, ever held the wire model.
+
+  The record format is now `codex_foundry_connection/3`. This is a version bump
+  rather than an additive change because `final_response_present: false` means
+  something different on either side of it — a claim about us before, a claim
+  about the model after — and the two must not be compared. The model's text is
+  still not published: the record says whether an answer arrived and whether it
+  matched, and `observe_stream` deliberately returns the agent messages out of
+  band rather than folding them into the summary that lands in the artifact.
+
 - **The Codex `401` was never about the deployment: the auth command could not
   produce a token where Codex runs it.** Three independent faults, each
   sufficient on its own, each producing the same silent symptom.

--- a/batch-runner/scripts/diagnose_codex_foundry_connection.py
+++ b/batch-runner/scripts/diagnose_codex_foundry_connection.py
@@ -120,7 +120,15 @@ from core.codex_runtime_config import (  # noqa: E402
 #: actually written into the provider table, and added
 #: ``request.retries_not_removed_by_pinning``. A ``/1`` record says nothing
 #: about how many requests its turn made.
-SCHEMA = "codex_foundry_connection/2"
+#:
+#: /3 fixed where ``observed.final_response_present`` looks, and so changed what
+#: its ``false`` means. Up to /2 it was read off fields the turn model does not
+#: have, so it was ``false`` on every run including ones where the model
+#: answered -- run 34461522053 is the example. From /3 it is read out of the
+#: turn's items and a ``false`` is a claim about the model rather than about us.
+#: The two are not comparable, which is the whole reason this string exists.
+#: ``observed.final_response_source`` is new in /3.
+SCHEMA = "codex_foundry_connection/3"
 
 # ── The verdict vocabulary ──────────────────────────────────────────────────
 #
@@ -630,6 +638,9 @@ def _empty_observation() -> dict[str, Any]:
         # why not. Never the token, and never anything derived from one.
         "auth_command": None,
         "final_response_present": False,
+        # Which of the turn's two accounts of itself the answer was read from:
+        # `turn_items`, `stream_items`, or absent. Never the answer's text.
+        "final_response_source": None,
         "final_response_matched_instruction": False,
         "tool_execution_observed": False,
         "error": None,
@@ -668,11 +679,18 @@ def observe_stream(
 ) -> tuple[dict[str, Any], Any, Any]:
     """Consume a turn's notifications, keeping what the SDK throws away.
 
-    Returns the streaming summary, the completed ``Turn`` (or ``None``) and the
-    ``ThreadTokenUsage`` (or ``None``). Nothing is raised on a failed turn:
-    the failure *is* the result here.
+    Returns the streaming summary, the completed ``Turn`` (or ``None``) and a
+    triple of the ``ThreadTokenUsage``, the thread settings and the agent
+    messages seen going past. Nothing is raised on a failed turn: the failure
+    *is* the result here.
+
+    The agent messages are returned rather than folded into the summary because
+    the summary is published in the artifact and their text is the model's
+    answer. What the record says about the answer is whether it arrived and
+    whether it matched -- never the answer itself.
     """
     from openai_codex.generated.v2_all import (
+        AgentMessageThreadItem,
         ItemCompletedNotification,
         ThreadSettingsUpdatedNotification,
         ThreadTokenUsageUpdatedNotification,
@@ -681,6 +699,7 @@ def observe_stream(
 
     by_method: dict[str, int] = {}
     item_types: list[str] = []
+    agent_messages: list[Any] = []
     usage: Any = None
     usage_updates = 0
     turn: Any = None
@@ -698,6 +717,8 @@ def observe_stream(
                 item = getattr(payload, "item", None)
                 inner = getattr(item, "root", item)
                 item_types.append(type(inner).__name__)
+                if isinstance(inner, AgentMessageThreadItem):
+                    agent_messages.append(inner)
             continue
         if isinstance(payload, ThreadTokenUsageUpdatedNotification):
             if getattr(payload, "turn_id", None) == turn_id:
@@ -720,7 +741,7 @@ def observe_stream(
         "item_types": item_types,
         "thread_settings_seen": thread_settings is not None,
     }
-    return summary, turn, (usage, thread_settings)
+    return summary, turn, (usage, thread_settings, agent_messages)
 
 
 def _usage_record(usage: Any) -> dict[str, Any] | None:
@@ -859,7 +880,7 @@ def probe(
             if close is not None:
                 close()
 
-        usage, thread_settings = extras
+        usage, thread_settings, agent_messages = extras
         observed["streaming"] = summary
         observed["usage"] = _usage_record(usage)
         if thread_settings is not None:
@@ -892,8 +913,9 @@ def probe(
         error = getattr(turn, "error", None)
 
         if status == "completed" and error is None:
-            text = _final_text(turn, summary)
+            text, source = _final_text(turn, agent_messages)
             observed["final_response_present"] = bool(text)
+            observed["final_response_source"] = source
             observed["final_response_matched_instruction"] = (
                 text.strip().strip(".").upper() == EXPECTED_REPLY
                 if text
@@ -934,18 +956,68 @@ def probe(
         workspace.cleanup()
 
 
-def _final_text(turn: Any, summary: Mapping[str, Any]) -> str:
-    """The turn's own final response, if the completion event carried one.
+def _select_final_answer(items: Sequence[Any]) -> str | None:
+    """The SDK's own rule for which message is the answer, reimplemented.
 
-    Falls back to nothing rather than to the last item of any kind: an empty
-    answer and a tool's output are different things and only one of them is an
-    answer.
+    Prefer the last item marked ``final_answer``; otherwise the last one whose
+    phase the provider left unset. ``commentary`` is deliberately never an
+    answer, which is why a turn made only of commentary yields ``None`` rather
+    than its last line.
+
+    This mirrors ``_final_assistant_response_from_items`` in the pinned SDK's
+    ``_run.py``. It is copied rather than imported because that function is
+    private and this file must keep working across an SDK bump, and it is
+    pinned to the original by ``test_our_reading_rule_matches_the_pinned_sdks_own``
+    so a bump that changes the rule fails a test instead of drifting silently.
     """
-    for attribute in ("final_response", "output_text"):
-        value = getattr(turn, attribute, None)
-        if isinstance(value, str) and value.strip():
-            return value
-    return ""
+    from openai_codex.generated.v2_all import AgentMessageThreadItem, MessagePhase
+
+    unset_phase: str | None = None
+    for item in reversed(list(items)):
+        inner = getattr(item, "root", item)
+        if not isinstance(inner, AgentMessageThreadItem):
+            continue
+        if inner.phase == MessagePhase.final_answer:
+            return inner.text
+        if inner.phase is None and unset_phase is None:
+            unset_phase = inner.text
+    return unset_phase
+
+
+def _final_text(turn: Any, streamed: Sequence[Any] = ()) -> tuple[str, str | None]:
+    """The model's answer, read out of the items the model actually sent.
+
+    The pinned SDK's wire model for a turn (``Turn`` in ``generated/v2_all.py``)
+    has no field holding the answer's text. It has ``items``, and the answer is
+    the ``text`` of an ``AgentMessageThreadItem`` among them. This function used
+    to look for ``final_response`` and ``output_text`` *on the turn* -- names
+    that belong to the SDK's ``TurnResult`` dataclass in ``_run.py``, which is
+    what ``core/codex_runner.py`` receives and which is a different object from
+    the one a ``TurnCompletedNotification`` carries.
+
+    Run 34461522053 is what that cost: a turn whose stream demonstrably carried
+    an ``AgentMessageThreadItem`` was recorded ``final_response_present: false``,
+    which reads as the model having stayed silent. It had not. Reading the wrong
+    object is not the same finding as an empty answer, and the record said the
+    second when the truth was the first.
+
+    Both sources are consulted because they can disagree honestly: ``items`` is
+    a required field on ``Turn`` but ``items_view`` may say ``notLoaded`` or
+    ``summary``, in which case the payload is not a claim about what was said.
+    The stream is then the record of what arrived. Returns the text and which
+    source it came from, so a reader need not guess.
+    """
+    sources = (
+        ("turn_items", getattr(turn, "items", None)),
+        ("stream_items", streamed),
+    )
+    for source, items in sources:
+        if not items:
+            continue
+        text = _select_final_answer(items)
+        if text is not None and text.strip():
+            return text, source
+    return "", None
 
 
 # ── The free half: does the token work on this host at all? ─────────────────

--- a/batch-runner/tests/test_codex_foundry_connection_probe.py
+++ b/batch-runner/tests/test_codex_foundry_connection_probe.py
@@ -1661,3 +1661,200 @@ def test_the_two_gates_cover_every_case_between_them():
     )
 
 
+
+# ── Reading the model's answer ──────────────────────────────────────────────
+#
+# There was no test here, and that is exactly how run 34461522053 came back
+# saying `final_response_present: false` about a turn whose own stream had
+# carried an `AgentMessageThreadItem`. The old reader asked the turn for a
+# `final_response` attribute. The turn model has no such field and never did,
+# so the answer was always the empty string and the record always said the
+# model had been silent.
+#
+# These build real SDK objects rather than stand-ins. A stand-in with a
+# `final_response` attribute is precisely the fiction that let the bug live.
+
+
+def _agent_message(text, phase="final_answer", item_id="i1"):
+    from openai_codex.generated.v2_all import AgentMessageThreadItem, MessagePhase
+
+    return AgentMessageThreadItem(
+        id=item_id,
+        text=text,
+        type="agentMessage",
+        phase=None if phase is None else MessagePhase(phase),
+    )
+
+
+def _reasoning_item(item_id="r1"):
+    from openai_codex.generated.v2_all import ReasoningThreadItem
+
+    return ReasoningThreadItem(id=item_id, type="reasoning", summary=[])
+
+
+def _turn(items, status="completed", items_view="full"):
+    from openai_codex.generated.v2_all import ThreadItem, Turn, TurnItemsView, TurnStatus
+
+    return Turn(
+        id="turn-1",
+        items=[ThreadItem(item) for item in items],
+        status=TurnStatus(status),
+        items_view=TurnItemsView[items_view],
+    )
+
+
+def test_the_two_fields_the_old_reader_asked_for_are_not_on_the_turn_model():
+    """The bug in one assertion.
+
+    Both names exist in the SDK -- on ``TurnResult`` in ``_run.py``, which is
+    what ``core/codex_runner.py`` gets back and which is a different object from
+    the ``Turn`` a completion notification carries. Reading one's field names
+    off the other is silent: ``getattr`` returns the default and the record
+    fills in a confident ``false``.
+    """
+    from openai_codex.generated.v2_all import Turn
+
+    fields = set(Turn.model_fields)
+    assert "final_response" not in fields
+    assert "output_text" not in fields
+    assert "items" in fields
+
+
+def test_the_answer_is_read_out_of_the_turns_items():
+    import scripts.diagnose_codex_foundry_connection as module
+
+    turn = _turn([_reasoning_item(), _agent_message("CONNECTED")])
+    assert module._final_text(turn) == ("CONNECTED", "turn_items")
+
+
+def test_the_answer_is_read_from_the_stream_when_the_payload_did_not_carry_it():
+    """``items_view`` may be ``notLoaded``. An unloaded payload is not a claim
+    that nothing was said, and the stream is the record of what arrived."""
+    import scripts.diagnose_codex_foundry_connection as module
+
+    turn = _turn([], items_view="not_loaded")
+    streamed = [_agent_message("CONNECTED")]
+    assert module._final_text(turn, streamed) == ("CONNECTED", "stream_items")
+
+
+def test_a_marked_final_answer_wins_over_an_unmarked_message():
+    import scripts.diagnose_codex_foundry_connection as module
+
+    turn = _turn(
+        [
+            _agent_message("CONNECTED", phase="final_answer", item_id="a"),
+            _agent_message("thinking out loud", phase=None, item_id="b"),
+        ]
+    )
+    assert module._final_text(turn)[0] == "CONNECTED"
+
+
+def test_commentary_on_its_own_is_not_an_answer():
+    """The SDK's rule, and it is the right one: commentary is the model talking
+    about the work, not the work. Treating it as the answer would let a turn
+    that never answered report a match."""
+    import scripts.diagnose_codex_foundry_connection as module
+
+    turn = _turn([_agent_message("let me check that", phase="commentary")])
+    assert module._final_text(turn) == ("", None)
+
+
+def test_a_turn_that_truly_said_nothing_still_reads_as_nothing():
+    """The fix must not turn every completed turn into a present answer."""
+    import scripts.diagnose_codex_foundry_connection as module
+
+    assert module._final_text(_turn([_reasoning_item()]), []) == ("", None)
+
+
+def test_whitespace_is_not_an_answer():
+    import scripts.diagnose_codex_foundry_connection as module
+
+    assert module._final_text(_turn([_agent_message("   \n ")]), []) == ("", None)
+
+
+def test_our_reading_rule_matches_the_pinned_sdks_own():
+    """``_select_final_answer`` is a copy of a private SDK function. This is
+    what keeps the copy honest: if an SDK bump changes which message counts as
+    the answer, this fails rather than the two quietly disagreeing."""
+    import scripts.diagnose_codex_foundry_connection as module
+    from openai_codex._run import _final_assistant_response_from_items
+    from openai_codex.generated.v2_all import ThreadItem
+
+    cases = [
+        [],
+        [_reasoning_item()],
+        [_agent_message("only", phase=None)],
+        [_agent_message("final", phase="final_answer")],
+        [_agent_message("aside", phase="commentary")],
+        [
+            _agent_message("aside", phase="commentary", item_id="a"),
+            _agent_message("final", phase="final_answer", item_id="b"),
+        ],
+        [
+            _agent_message("final", phase="final_answer", item_id="a"),
+            _agent_message("later unmarked", phase=None, item_id="b"),
+        ],
+        [
+            _agent_message("first unmarked", phase=None, item_id="a"),
+            _agent_message("second unmarked", phase=None, item_id="b"),
+        ],
+    ]
+    for items in cases:
+        wrapped = [ThreadItem(item) for item in items]
+        assert module._select_final_answer(wrapped) == (
+            _final_assistant_response_from_items(wrapped)
+        ), f"the rules disagree on {[type(i).__name__ for i in items]}"
+
+
+def _event(payload, method="codex/event"):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(method=method, payload=payload)
+
+
+def _item_completed(item, turn_id="turn-1"):
+    from openai_codex.generated.v2_all import ItemCompletedNotification, ThreadItem
+
+    return ItemCompletedNotification(
+        completed_at_ms=0,
+        item=ThreadItem(item),
+        thread_id="thread-1",
+        turn_id=turn_id,
+    )
+
+
+def test_the_stream_keeps_the_agent_messages_it_used_to_throw_away():
+    import scripts.diagnose_codex_foundry_connection as module
+
+    events = [
+        _event(_item_completed(_reasoning_item())),
+        _event(_item_completed(_agent_message("CONNECTED"))),
+    ]
+    summary, turn, extras = module.observe_stream(events, turn_id="turn-1")
+    usage, thread_settings, agent_messages = extras
+    assert [m.text for m in agent_messages] == ["CONNECTED"]
+    assert summary["item_types"] == ["ReasoningThreadItem", "AgentMessageThreadItem"]
+
+
+def test_an_item_from_another_turn_is_not_collected():
+    """The turn id filter already governed the type list; the messages are held
+    to the same rule, or a stray item would answer for a turn that did not."""
+    import scripts.diagnose_codex_foundry_connection as module
+
+    events = [_event(_item_completed(_agent_message("elsewhere"), turn_id="turn-9"))]
+    _, _, extras = module.observe_stream(events, turn_id="turn-1")
+    assert extras[2] == []
+
+
+def test_the_published_summary_carries_no_answer_text():
+    """The summary is what lands in `observed.streaming` in a world-readable
+    artifact. What the record says about the answer is whether it arrived and
+    whether it matched -- the text itself stays out."""
+    import json
+
+    import scripts.diagnose_codex_foundry_connection as module
+
+    secret = "a-sentence-the-model-said"
+    events = [_event(_item_completed(_agent_message(secret)))]
+    summary, _, _ = module.observe_stream(events, turn_id="turn-1")
+    assert secret not in json.dumps(summary)

--- a/batch-runner/tests/test_codex_readonly_token_probe.py
+++ b/batch-runner/tests/test_codex_readonly_token_probe.py
@@ -453,7 +453,7 @@ def _readonly_record() -> dict:
 
 def _turn_record() -> dict:
     return {
-        "schema": "codex_foundry_connection/2",
+        "schema": "codex_foundry_connection/3",
         "verdict": "connected",
         "observed": {"tool_execution_observed": False},
     }

--- a/batch-runner/tests/test_codex_valid_request.py
+++ b/batch-runner/tests/test_codex_valid_request.py
@@ -677,7 +677,7 @@ def test_the_turn_record_still_has_its_own_check(tmp_path: Path):
     from tests.test_codex_auth_discriminator import _run_leak_check
 
     record = {
-        "schema": "codex_foundry_connection/2",
+        "schema": "codex_foundry_connection/3",
         "verdict": "not_sent",
         "observed": {"tool_execution_observed": True},
     }

--- a/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
+++ b/tasks/0822_saturday/TASK_NATIVE_CODEX_RUN_PATH.md
@@ -1298,12 +1298,39 @@ paid run must be preceded by a fresh smoke at the new fingerprint.
   The third bit everywhere, because it is what turned both of the others into
   a sentence about a subscription key.
 
-- The next decision is one dispatch of the connection diagnostic from `main`
-  **in plan mode** — `send_request` left off, nothing billed — because the plan
-  now runs the real auth command in the real isolated environment and writes the
-  `auth_command` block. Minting is a call to the identity platform, not to the
-  deployment, so the runner question is answered by a dispatch that spends
-  nothing. It reports rather than gates: a runner that cannot mint still returns
-  `not_sent` and exit `0`, with `ok: false` and the reason. Then a real turn
-  through the fixed path. Until a turn is answered, the column stays empty and
-  is reported as unconfirmed. It is not filled with a substitute.
+- **Both dispatches happened, and both answered.** Plan mode on `main`
+  (`34461076798`) wrote `auth_command: {ran: true, exit_code: 0,
+  produced_a_token: true, azure_config_dir: "/home/runner/.azure", ok: true}`.
+  The sign-in was found where `azure/login` writes it, which is the directory
+  the rewritten `HOME` hides — consistent with the prediction above, though not
+  a proof of it: the measurement was taken with the fix in place, so it shows
+  the fixed path works rather than showing the unfixed one failed. The question
+  the prediction existed to settle is settled by the turn instead.
+
+  The turn (`34461522053`) came back `connected`: `turn_status: completed`,
+  `UserMessageThreadItem` → `ReasoningThreadItem` → `AgentMessageThreadItem`,
+  10 notifications, 10,994 input / 28 output tokens, `model_context_window:
+  258400`, `auth_command.ok: true`. Price unread, so the cost is recorded as
+  `null` — an unpriced record is not a free one.
+
+  What the turn did **not** establish, from the record's own `not_established`:
+  the tool leg (the prompt forbids commands; `tool_execution_observed: false`),
+  the deliverable leg (no file was asked for), the batch leg (one turn says
+  nothing about 5, 30 or 220), and the cost leg.
+
+- That run also exposed a reporting defect of its own: it reported
+  `final_response_present: false` about a turn that had demonstrably produced
+  an agent message, because `_final_text` read field names belonging to the
+  SDK's `TurnResult` off the wire model `Turn`, which has neither. Fixed by
+  reading the turn's items; record format bumped to
+  `codex_foundry_connection/3`. The real run path was never affected —
+  `TurnHandle.run()` returns a `TurnResult`, which is what
+  `core/codex_runner.py` reads.
+
+- The next step is no longer a diagnostic. It is a Codex **experiment**: there
+  is still no YAML anywhere that uses `execution.mode: codex_foundry`, and
+  `experiment_config.py` requires an `execution.codex` block carrying a literal
+  `endpoint` — which cannot be written into a public repository, and for which
+  there is no environment expansion. That gap, then the fixed 5, then 30, then
+  220. Until a task produces a file, the deliverable column stays empty and is
+  reported as unconfirmed. It is not filled with a substitute.


### PR DESCRIPTION
## What run 34461522053 got wrong about itself

The turn **connected**. Its stream carried `UserMessageThreadItem` →
`ReasoningThreadItem` → `AgentMessageThreadItem`, the provider billed 10,994
input / 28 output tokens, and `turn_status` was `completed`.

The record said `final_response_present: false`.

That reads as "the model stayed silent". It hadn't. `_final_text` asked the
turn for `final_response`, then `output_text`. Both names exist in the pinned
SDK — on `TurnResult`, the dataclass in `_run.py`. The `Turn` in
`generated/v2_all.py`, which is what a `TurnCompletedNotification` carries, has
neither; it has `items`, and the answer is the `text` of an
`AgentMessageThreadItem` among them. `getattr` on a Pydantic model with no such
field returns the default silently, so the miss was total: **every** completed
turn this diagnostic ever observed was recorded as answerless.

## The fix

`_final_text` reads the items, using the SDK's own selection rule — prefer the
message marked `final_answer`, else the last one whose phase the provider left
unset, and never `commentary`. It consults the turn payload first and the
stream second, because `Turn.items_view` may say `notLoaded` and an unloaded
payload is not a claim that nothing was said.
`observed.final_response_source` records which one answered.

## The real run path was never affected

`TurnHandle.run()` is annotated `-> TurnResult` (`api.py:757`), so
`core/codex_runner.py:950`'s `getattr(result, "final_response", None)` reads a
field that exists. Only the diagnostic, which drives the stream itself, ever
held the wire model. I checked this by reading the SDK rather than inferring it
from the symptom.

## Tests

There were **none** over this function, which is how the bug survived a merge.
There are now eleven, built on real SDK objects — a stand-in carrying a
`final_response` attribute is exactly the fiction that hid it. Among them:

- `test_the_two_fields_the_old_reader_asked_for_are_not_on_the_turn_model` —
  the bug in one assertion.
- `test_our_reading_rule_matches_the_pinned_sdks_own` — runs our copy and the
  SDK's private `_final_assistant_response_from_items` over the same eight item
  lists, so an SDK bump that changes the rule fails a test instead of drifting.
- `test_a_turn_that_truly_said_nothing_still_reads_as_nothing` and
  `test_commentary_on_its_own_is_not_an_answer` — the fix must not turn every
  completed turn into a present answer.
- `test_the_published_summary_carries_no_answer_text` — the privacy rule below.

## Record format

Bumped to `codex_foundry_connection/3`. A version bump rather than an additive
change, because `final_response_present: false` means something different on
either side of it — a claim about us before, a claim about the model after —
and the two must not be compared. The leak check dispatches on the schema
*prefix*, so it is unaffected.

The model's text is still not published. The record says whether an answer
arrived and whether it matched; `observe_stream` returns the agent messages out
of band rather than folding them into the summary that lands in the artifact.

## Verification

- Targeted: 237 passed across the five Codex diagnostic test files.
- Full backend suite: running; result reported before merge.
- mypy on the changed file: no new errors (7 pre-existing, all in other modules).
- No other caller of `observe_stream`, `_final_text` or `_select_final_answer`
  exists in the tree; the arity change is contained.

## Shared files

None. This touches only `scripts/diagnose_codex_foundry_connection.py`, its
tests, two stale schema literals in sibling Codex tests, the CHANGELOG and the
Codex task note.