### PR TITLE
docs(codex): record what the answered turn settled, and what it did not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,63 @@ entries land under a fresh dated heading the day they merge to `main`.
 
 ## [Unreleased]
 
+### Changed
+- **The Codex readiness record now says what run `34461522053` actually
+  settled, and what it did not.** The three blockers standing against
+  `ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY` were all written as things that
+  had *not been observed*, with the explicit note that no amount of reading
+  would clear any of them — only a request that is answered would. That request
+  has now been answered, and it cleared all three at once:
+
+  - the auth command ran **inside Codex's own isolated environment and the
+    task's own directory** and produced a token (`auth_command.ok: true`,
+    `exit_code: 0`, `azure_config_dir: /home/runner/.azure`);
+  - the contract the deployment serves Codex on is no longer a guess —
+    `endpoint_kind: direct-v1` on the undated `/openai/v1/` route,
+    `wire_api: responses`, no query parameters;
+  - the pinned runtime is compatible with this deployment in this region:
+    pinned **and** installed `openai-codex 0.147.0`, deployment `gpt-5.4`,
+    `turn_status: completed`.
+
+  This is the second time this list has had to be rewritten, and both rewrites
+  were the same mistake caught late: a reason kept past the point where it was
+  true. The first time it was documentation objections the product had already
+  answered; this time it was connection questions a real turn answered. Both
+  make a solved problem read as unsolvable, which is the more expensive
+  direction to be wrong in — it argues against work that is already done.
+
+  **The status does not move.** It stays `structure_check_only`. What replaces
+  the three cleared blockers is what a *task* still needs and does not have,
+  and each one names the code that would have to change:
+
+  - **no experiment asks for this place.** No file under
+    `batch-runner/experiments` names `execution.mode: codex_foundry`, and none
+    can be written as `core.experiment_config` validates it today: that check
+    builds `CodexProviderSettings` from a **literal** `execution.codex.endpoint`
+    with no environment expansion anywhere in the module, and this deployment's
+    address is a secret that cannot be committed to a public repository.
+  - **the configuration cannot reach the runner.** `TaskExecutor` takes the
+    Codex settings through `codex_options`, and nothing outside `core.executor`
+    and `tests/test_codex_runtime_end_to_end.py` ever passes it;
+    `step2_run_inference._create_executor_with_client_cleanup` builds every
+    executor with `llm_client=client`, which `core.executor` refuses for this
+    mode. A batch run would fail at construction rather than reach a turn.
+  - **nothing has been produced through it.** The answered turn carried no
+    tools and wrote no file (`tool_execution_observed: false`; the prompt
+    forbade tools by design), so tool execution, reference-file staging,
+    deliverable collection and the cost receipt are still exercised only
+    against the stand-in app-server. A model that answers is not an agent that
+    works.
+
+  `test_the_codex_blockers_are_about_the_task_not_about_the_connection` pins
+  the shape rather than the wording: no blocker may claim the connection is
+  unproven, and each must name checkable code. The static-key test stops
+  requiring Codex to cite `FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV` — the rule
+  still binds it, but for Codex that conflict was *resolved* by
+  `core.codex_azure_token` rather than merely stated, and a test that demands a
+  settled conflict be listed as an obstacle is a test that keeps the record
+  wrong on purpose.
+
 ### Fixed
 - **The Codex `401` was never about the deployment: the auth command could not
   produce a token where Codex runs it.** Three independent faults, each

--- a/batch-runner/core/execution_environment_readiness.py
+++ b/batch-runner/core/execution_environment_readiness.py
@@ -161,53 +161,62 @@ RUNNER_CLASS_BY_ENVIRONMENT: Mapping[str, tuple[str, str] | None] = {
     ENVIRONMENT_COPILOT_COMMAND_LINE_TOOL_GITHUB_SERVED: None,
 }
 
-# ── What each product's own documentation says stands in the way ───────────
+# ── What stands in the way of each place, and where that is written ────────
 # A place with no code here is already refused. These add the reason a reader
-# would otherwise have to go and find, and they are quoted from the product's
-# own published reference rather than guessed. Each one is a separate reason:
-# clearing one of them does not clear the others.
+# would otherwise have to go and find. For the two Copilot places they are
+# quoted from the product's own published reference rather than guessed; for
+# Codex, whose documented objections have all been answered, they are now
+# statements about this repository, checkable in the code they name. Each one
+# is a separate reason: clearing one of them does not clear the others.
 
 DOCUMENTED_BLOCKERS_BY_ENVIRONMENT: Mapping[str, tuple[str, ...]] = {
-    # Rewritten once the adapter was built. The three reasons that stood here
-    # before were read out of an older copy of the Codex configuration
-    # reference, and two of them have since stopped being true of the product:
-    # that reference now carries an Azure provider example and a query_params
-    # setting, so "no Azure example" and "no way to pass an api-version" are no
-    # longer statements about Codex. Keeping them would have been the easiest
-    # way to make a solved problem look unsolvable.
+    # Rewritten twice, and the second rewrite is the interesting one.
     #
-    # What replaces them is narrower and, unlike the old text, is about this
-    # deployment rather than about the documentation. Each one names something
-    # that has not been *observed*, and no amount of reading will clear any of
-    # them — only a request that is answered will.
+    # The first three reasons here were read out of an older copy of the Codex
+    # configuration reference and stopped being true of the product. The three
+    # that replaced them were about this deployment instead, each naming
+    # something that had not been *observed*, with the note that no amount of
+    # reading would clear any of them — only a request that is answered would.
+    #
+    # Run 34461522053 is that request. It was answered, and it cleared all
+    # three at once: the auth command ran inside Codex's own isolated
+    # environment and produced a token, the deployment served the pinned
+    # runtime's Responses payload on the undated route, and the turn completed.
+    # So all three are gone, and keeping them would be the mirror image of the
+    # first mistake — making a solved problem look unsolvable.
+    #
+    # What stands here now is what a *task* still needs and does not have.
+    # None of it is about reaching the model; all of it is wiring this
+    # repository has not built yet, which is why each one names the code that
+    # would have to change.
     ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY: (
-        "the sign-in mints and is accepted, but not yet from inside the place "
-        "Codex runs it: this repository forbids every static Azure credential "
-        "variable in "
-        "core.azure_ai_clients.FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV, so the "
-        "provider is authenticated by an auth command "
-        "(core.codex_azure_token) that mints an Entra token instead, and run "
-        "34442249527 presented a token from that command to this deployment "
-        "and was answered 200 — so the credential, the identity and the "
-        "address are settled. What was not settled is that Codex starts that "
-        "command in the task's own directory and in the isolated environment, "
-        "where until now it could neither import its package nor find the "
-        "Azure CLI sign-in; it printed nothing, and the empty bearer that "
-        "followed was refused as an invalid subscription key. The fix is in "
-        "and checked locally, and a turn on a runner has not yet been "
-        "answered",
-        "which API contract the deployment serves Codex on has not been "
-        "observed: core.codex_runtime_config refuses a dated api-version on "
-        "the undated /openai/v1/ route and lets query_params carry one on the "
-        "legacy route, but which of the two this resource answers Codex's "
-        "Responses payload on is unmeasured, and the two are not "
-        "interchangeable",
-        "the pinned Codex version has not been shown to be compatible with "
-        "this deployment in this region: core.codex_runtime_config pins "
-        "openai-codex and its bundled binary to one version, and whether that "
-        "version's Responses request is accepted by this resource's model "
-        "version and content filters is a separate question from whether the "
-        "sign-in works",
+        "no experiment asks for this place: no file under batch-runner/"
+        "experiments names execution.mode codex_foundry, and none can be "
+        "written as core.experiment_config validates it today, because that "
+        "check builds CodexProviderSettings from a literal "
+        "execution.codex.endpoint with no environment expansion anywhere in "
+        "the module — and this deployment's address is a secret, so it cannot "
+        "be committed to a public repository. Until the setting can name a "
+        "variable instead of a value, the run place has a runner and no way "
+        "to be asked for",
+        "the configuration cannot reach the runner even if a file asked for "
+        "it: core.executor.TaskExecutor takes the Codex settings through its "
+        "codex_options argument, and nothing outside core.executor and "
+        "tests/test_codex_runtime_end_to_end.py ever passes it. "
+        "step2_run_inference._create_executor_with_client_cleanup builds "
+        "every executor with llm_client=client, which core.executor refuses "
+        "for this mode with 'codex_foundry takes no llm_client and no "
+        "api_key'. A batch run would therefore fail at construction rather "
+        "than reach a turn",
+        "no task has produced a deliverable through this place against the "
+        "real deployment: the turn that was answered carried no tools and "
+        "wrote no file (the connection record reports "
+        "tool_execution_observed false, and the prompt forbade tools by "
+        "design), so tool execution, reference-file staging, deliverable "
+        "collection and the cost receipt have still only been exercised "
+        "against the stand-in app-server in "
+        "tests/test_codex_runtime_end_to_end.py. A model that answers is not "
+        "an agent that works",
     ),
     ENVIRONMENT_COPILOT_COMMAND_LINE_TOOL_FOUNDRY: (
         "the GitHub Copilot command-line own-key documentation supplies the "
@@ -939,14 +948,17 @@ def inspect_environment_support(
             continue
 
         if environment == ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY:
-            # Registered, so the two "there is no code path" grades above no
-            # longer apply — but registration is not reachability. The adapter
-            # starts the real Codex runtime and the settings are validated
-            # before a turn begins; what has never happened is a request this
-            # deployment answered. That gap is exactly what
+            # Registered and now reachable — but reachable is not runnable.
+            # A turn was sent to the real deployment and answered, so the
+            # sentence that stood here before ("what has never happened is a
+            # request this deployment answered") is retired. What has still
+            # never happened is a *task*: no experiment file asks for this
+            # mode, the settings cannot reach the executor, and nothing has
+            # been produced through it. That gap is exactly what
             # STATUS_STRUCTURE_CHECK_ONLY is for, and moving this to
-            # STATUS_CAN_RUN_REAL_EXPERIMENT before it closes would put a run
-            # place in the comparison on the strength of its own code reading.
+            # STATUS_CAN_RUN_REAL_EXPERIMENT on the strength of one answered
+            # turn would put a run place in the comparison for being able to
+            # say hello.
             evidence.append(
                 "the runtime is the product's own: core.codex_runner builds "
                 "openai_codex.Codex, whose client starts the pinned Codex "
@@ -966,6 +978,29 @@ def inspect_environment_support(
                 "tests/test_codex_runtime_end_to_end.py, which starts a "
                 "runtime, has it call a tool, read a staged reference file, "
                 "write a deliverable, and settle a cost receipt"
+            )
+            evidence.append(
+                "the real deployment answered a real turn: run 34461522053 "
+                "recorded verdict 'connected' with turn_status 'completed' "
+                "and a stream carrying UserMessageThreadItem, "
+                "ReasoningThreadItem and AgentMessageThreadItem, at a cost of "
+                "10,994 input and 28 output tokens — so this is a served "
+                "answer rather than a reachability check"
+            )
+            evidence.append(
+                "the sign-in worked where Codex actually starts it: that same "
+                "run reports auth_command ok with exit code 0 from inside the "
+                "isolated environment and the task's own directory, which is "
+                "the leg that had been failing silently and returning an "
+                "empty bearer"
+            )
+            evidence.append(
+                "the contract it answered on is recorded rather than "
+                "assumed: endpoint_kind 'direct-v1' on the undated /openai/v1/ "
+                "route with wire_api 'responses' and no query parameters, "
+                "served by pinned and installed openai-codex 0.147.0 — which "
+                "settles the two questions core.codex_runtime_config could "
+                "only refuse to guess at"
             )
             blockers.extend(
                 DOCUMENTED_BLOCKERS_BY_ENVIRONMENT.get(environment, ())

--- a/batch-runner/tests/test_three_more_run_places.py
+++ b/batch-runner/tests/test_three_more_run_places.py
@@ -130,12 +130,14 @@ def test_the_new_place_has_no_way_to_run_a_task_here(environment):
 
 
 def test_the_codex_place_has_code_but_is_still_not_a_place_that_can_run():
-    """Registration is not reachability, and the grade must say so.
+    """Reachability is not runnability, and the grade must say so.
 
-    The adapter exists, is named by the mode table, and is exercised against a
-    stand-in runtime. None of that is a request a Foundry deployment answered,
-    so the grade is the one meaning "structure only" — moving it up would put a
-    run place in the comparison on the strength of its own code reading.
+    This test used to rest on "none of that is a request a Foundry deployment
+    answered". Run 34461522053 was answered, so that reason is retired and the
+    grade has to survive without it. It does: what the place still lacks is an
+    experiment that asks for it, a way for the settings to reach the executor,
+    and a single deliverable produced through it. A model saying one word back
+    is not a task being done, and the grade must not read as if it were.
     """
     environment = ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY
     assert EXECUTION_MODE_BY_ENVIRONMENT[environment] == "codex_foundry"
@@ -154,9 +156,44 @@ def test_the_codex_place_has_code_but_is_still_not_a_place_that_can_run():
         "tests/test_codex_runtime_end_to_end.py" in line
         for line in entry.evidence
     )
+    # The answered turn is named by its run id for the same reason: it is the
+    # one claim here that cannot be checked by reading this repository, so it
+    # has to point at the record that can be downloaded and read instead.
+    assert any("34461522053" in line for line in entry.evidence)
     # And the reasons it still cannot run are all still reported.
     for reason in DOCUMENTED_BLOCKERS_BY_ENVIRONMENT[environment]:
         assert reason in entry.blockers
+
+
+def test_the_codex_blockers_are_about_the_task_not_about_the_connection():
+    """The three reasons must move on once the thing they named has happened.
+
+    Twice now this list has kept a reason past its expiry: first documentation
+    objections the product had already answered, then connection questions run
+    34461522053 answered. Both times the effect was the same — a solved problem
+    reading as unsolvable. This pins the shape of the third list rather than
+    its wording: nothing may claim the connection is unproven, and each reason
+    must name the code that would have to change for it to clear.
+    """
+    reasons = DOCUMENTED_BLOCKERS_BY_ENVIRONMENT[
+        ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY
+    ]
+    retired = (
+        "has not been observed",
+        "has not been shown to be compatible",
+        "a turn on a runner has not yet been answered",
+    )
+    for reason in reasons:
+        for phrase in retired:
+            assert phrase not in reason, (
+                f"a blocker still says {phrase!r}, which run 34461522053 "
+                "settled"
+            )
+    named = ("core.experiment_config", "core.executor", "test_codex_runtime")
+    for module in named:
+        assert any(module in reason for reason in reasons), (
+            f"no blocker names {module}, so a reader cannot check any of them"
+        )
 
 
 def test_a_batch_run_still_refuses_to_start_the_codex_mode():
@@ -203,22 +240,27 @@ def test_each_of_the_three_has_more_than_one_reason_where_that_is_true():
 
 
 def test_the_static_key_conflict_the_blockers_cite_is_real():
-    """Both products hand a provider a static key. This repository refuses one.
+    """Copilot own-key hands a provider a static key. This repository refuses.
 
     Checked against the list itself rather than against a copy of it, so a
     later decision to allow one of these names would fail here rather than
     leave the blocker text quietly wrong.
+
+    Codex used to be checked here too, and no longer is. The rule still binds
+    it — no static Azure key is allowed for any place — but for Codex the
+    conflict was *resolved* rather than merely stated: core.codex_azure_token
+    mints an Entra token instead, and run 34461522053 was answered using it.
+    Requiring the blocker list to keep citing a conflict that has been settled
+    would force a solved problem to be written down as an obstacle forever.
     """
     assert FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV
     assert "AZURE_OPENAI_API_KEY" in FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV
-    for environment in (
-        ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY,
-        ENVIRONMENT_COPILOT_COMMAND_LINE_TOOL_FOUNDRY,
-    ):
-        assert any(
-            "FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV" in reason
-            for reason in DOCUMENTED_BLOCKERS_BY_ENVIRONMENT[environment]
-        )
+    assert any(
+        "FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV" in reason
+        for reason in DOCUMENTED_BLOCKERS_BY_ENVIRONMENT[
+            ENVIRONMENT_COPILOT_COMMAND_LINE_TOOL_FOUNDRY
+        ]
+    )
 
 
 def test_the_address_the_copilot_documentation_gives_is_really_refused():


### PR DESCRIPTION
Stacked behind #492. Both add to the top of `## [Unreleased]`, so this will
need a `git merge origin/main` and a CHANGELOG resolution once #492 lands.
Nothing else overlaps — #492 touches the diagnostic script, this touches the
readiness ledger.

## What changed

`DOCUMENTED_BLOCKERS_BY_ENVIRONMENT[ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY]`
held three reasons, each written as something that had **not been observed**,
above a comment saying no amount of reading would clear any of them — only a
request that is answered would.

Run `34461522053` is that request, and it cleared all three at once. Read from
the run's own artifact rather than from the workflow summary:

| blocker | what the record shows |
|---|---|
| sign-in not yet proven from inside the place Codex runs it | `auth_command: {ran: true, exit_code: 0, produced_a_token: true, azure_config_dir: "/home/runner/.azure", ok: true}` |
| which API contract the deployment serves Codex on is unmeasured | `endpoint_kind: direct-v1`, `endpoint_path: /openai/v1/`, `wire_api: responses`, `query_param_names: []` |
| pinned version not shown compatible with this deployment in this region | pinned **and** installed `openai-codex 0.147.0` / `openai-codex-cli-bin 0.147.0`, deployment `gpt-5.4`, `turn_status: completed` |

So the three go, and evidence lines naming the run id replace them.

## What did not change

**The status stays `structure_check_only`.** The grading branch hardcodes it,
and this PR does not touch that. One answered turn is not a task done, and
promoting the place on a connection would put it in the comparison for being
able to say hello.

The three replacement blockers are what a *task* still needs. Each names the
code that would have to change, and each was re-verified against that code
while writing this, not carried over from notes:

1. **No experiment asks for this place.** `grep -rln codex_foundry experiments/`
   is empty, and `core/experiment_config.py` validates a **literal**
   `execution.codex.endpoint` — there is no `expandvars`, no `os.environ`, no
   `endpoint_env` anywhere in the module. The address is a secret, so no file in
   a public repo can supply it as written.
2. **The configuration cannot reach the runner.** `codex_options` has exactly
   two mentions outside tests, both inside `core/executor.py`.
   `step2_run_inference.py:2065` builds every executor with `llm_client=client`,
   and `core/executor.py:690` refuses `codex_foundry` when one is given. A batch
   run fails at construction.
3. **Nothing has been produced through it.** `tool_execution_observed: false`;
   the connectivity prompt forbade tools by design.

## Why this is worth a PR of its own

This list has now been wrong twice in the same direction. The first version
quoted documentation objections the product had already answered; the second
kept connection questions a real turn answered. Both make solved work look
unsolvable, which is the more expensive way to be wrong — it argues against
doing the next thing.

So `test_the_codex_blockers_are_about_the_task_not_about_the_connection` pins
the **shape**: no blocker may claim the connection is unproven, and each must
name checkable code. A stale reason fails there next time instead of being read
as truth.

`test_the_static_key_conflict_the_blockers_cite_is_real` stops requiring Codex
to cite `FORBIDDEN_STATIC_AZURE_CREDENTIAL_ENV`. The rule still binds Codex —
no static Azure key for any place — but for Codex the conflict was *resolved*
by `core.codex_azure_token` rather than merely stated. A test demanding a
settled conflict stay listed as an obstacle is a test that keeps the record
wrong on purpose. The assertion still holds for Copilot own-key, where the
conflict is genuinely unresolved.

The blocker count stays 3, so `test_the_blocker_counts_are_exact` is untouched.

## Verification

- `tests/test_three_more_run_places.py` + `tests/test_execution_environment_readiness.py`: **186 passed**
- Full backend suite: running; will report the number before merging
- Not merging until #492 lands and this is rebased onto it