### PR TITLE
feat(agentic-v2): stage C0 — the containment's seventh question, found by planning its test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,65 @@ entries land under a fresh dated heading the day they merge to `main`.
   runner. The gate stays closed; only the reason is now true.
 
 ### Added
+- **The containment answers a seventh question, and it was found by planning
+  the test rather than by reading the rules.** Stage C's attack list has always
+  ended with one that is not like the others: the command must not be able to
+  read a token, key or environment secret the orchestrator holds. Writing it out
+  properly meant asking which rule it enforces — and the answer was none. At
+  `0076295`, the commit this was written against, `credential`, `secret` and
+  `token` appeared nowhere in `core/agentic_v2_substrate.py`,
+  `security/agentic-v2-supply-chain-policy.json` or
+  `sandbox/agentic_v2_capabilities.json`: zero matches in all three. The test
+  would have passed against nothing at all.
+
+  **A test with no rule behind it is the same fault as a rule with no code
+  behind it, seen from the other side**, and this repository has spent a lot of
+  effort on the first kind. So `credentials: "none-inherited"` is now the
+  eleventh containment rule, in `REQUIRED_MICROVM_POLICY` and in the manifest
+  that would travel with a built image, which the tests require to be equal
+  rather than merely compatible. It is
+  refused if it is weakened to `inherit-environment`, refused if it is softened
+  to a bare `"none"`, refused if it is deleted, and the readiness report now
+  carries it beside the other ten as *"cannot be established here"* — the same
+  verdict, for the same reason, because nothing turns any of these rules into
+  arguments for starting a machine yet.
+
+  It does **not** appear in the signed supply-chain policy, and that is not an
+  omission: that file mirrors four of the eleven rules — `runtime`, `network`,
+  `read_only_rootfs`, `ephemeral_work_disk` — and always has. Seven rules,
+  including the three numeric limits and `on_breach`, live in the policy and the
+  manifest only. Worth knowing before someone reads the signed policy as the
+  full statement of the containment; it is a signed subset of it.
+
+  Every other rule here arrived because something was written down and nothing
+  applied it. This one arrived the opposite way: nothing was written down, and a
+  test was about to be aimed at it anyway.
+
+- **Checking that rule against the jailer's own documentation moved a flag from
+  optional to required.** The plan said the launcher could lean on the jailer,
+  which "already clears inherited environment variables and file descriptors
+  before exec". Firecracker's jailer documentation for **v1.13.1** — the version
+  measured on the Azure host, not the development branch — says something
+  narrower: it will *"cleanup all environment variables received from the parent
+  process"*, but *"close all open file descriptors … **except input, output and
+  error**"*. Those three survive, and get pointed at `/dev/null` only by the
+  separate step that runs when the launcher asks to daemonize.
+
+  So the new rule holds by default for the environment and only conditionally
+  for the descriptors. `--daemonize` is now something stage C1's launcher has to
+  pass rather than something it may, and C3's attack on this rule inspects the
+  descriptors instead of trusting the sentence. A rule written down on the
+  strength of a mechanism that turns out to work differently is the fault this
+  stage exists to fix, one layer further down.
+
+- **Three records still say six, and are left saying it.** `CHANGELOG.md`,
+  `TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md` and the recorded Azure finding all
+  describe a day on which the count was six, or a hashed report that contained
+  nine policy rules. Only the last one gained a clause saying so, because it
+  sits in `core/` next to a report a reader can run today and get ten from.
+  Rewriting the other two would not fix a stale sentence; it would falsify a
+  record of when the rule set changed, which is what those records are for.
+
 - **The identity may infer on this resource — measured, not argued — and the
   question is now which property of a Codex request stops it.** Run
   `34442249527` sent `--valid-request` to the pinned deployment and got `200`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,28 @@ entries land under a fresh dated heading the day they merge to `main`.
   strength of a mechanism that turns out to work differently is the fault this
   stage exists to fix, one layer further down.
 
+- **The same reading deleted a device from stage C's plan, because it does not
+  exist.** The plan named four devices a launcher must pin at `null` or lose a
+  rule it appears to enforce: `mmds-config`, `vsock`, `balloon`, and
+  `memory-hotplug`. The reasoning behind the fourth is sound — memory added
+  after boot is memory the bound never saw — and the device is not. Firecracker
+  v1.13.1's own configuration fixture has no such key, and its API
+  specification, 43 KB covering every route, contains no occurrence of *hotplug*
+  at all. Balloon **is** the runtime-memory mechanism in this Firecracker; the
+  table had it twice under two names.
+
+  A test pinning `memory-hotplug: null` would have asserted something about a
+  key Firecracker never emits, and passed for that reason. That is the third
+  check in this stage that would have held against nothing — the credential
+  attack, the jailer's three surviving descriptors, and this — and all three
+  were found by reading the sources the plan cites rather than the plan.
+
+  Added in its place, as a route rather than a device: `/snapshot/load` restores
+  a machine whose configuration was decided elsewhere, so it can carry a NIC, a
+  vsock or a different memory size that the launcher's own arguments would never
+  show. It is not a setting to pin; it is a way in that bypasses the table, and
+  stage C3 treats loading one as an escape rather than a configuration.
+
 - **Three records still say six, and are left saying it.** `CHANGELOG.md`,
   `TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md` and the recorded Azure finding all
   describe a day on which the count was six, or a hashed report that contained

--- a/batch-runner/core/agentic_v2_containment_readiness.py
+++ b/batch-runner/core/agentic_v2_containment_readiness.py
@@ -110,6 +110,8 @@ _POLICY_SETTING_AS_A_CLAIM = {
     "memory_mib": "the command is given at most {value} mebibytes of memory",
     "wall_clock_seconds": "the command is stopped after {value} seconds",
     "user": "the command runs as {value} rather than as a privileged user",
+    "credentials": "the command's access to the tokens, keys and environment "
+    "the orchestrator holds is {value}",
     "on_breach": "exceeding any rule above results in {value}",
 }
 
@@ -659,7 +661,9 @@ RECORDED_FINDINGS: tuple[RecordedFinding, ...] = (
             "86152b713c687a0906b56533d989a14607570811. The returned report is "
             "sha256 ee2222285af39a4674ed524865b08397413ab7d758543db20a8caf247"
             "7eda070 and records all four host requirements as met, with the "
-            "nine policy rules as cannot-be-established. Firecracker v1.13.1 "
+            "nine policy rules of that commit as cannot-be-established — the "
+            "credential rule was added afterwards on the same day, so a report "
+            "run today lists ten. Firecracker v1.13.1 "
             "from the project's own release"
         ),
         on_date="2026-09-10",

--- a/batch-runner/core/agentic_v2_substrate.py
+++ b/batch-runner/core/agentic_v2_substrate.py
@@ -140,12 +140,20 @@ def canonical_sha256(value: Any) -> str:
 # What a command is allowed to touch when Agentic Sandbox V2 eventually runs
 # one. A substrate manifest promising anything different fails to validate.
 #
-# Six things have to be stated for this to be a containment rather than a
+# Seven things have to be stated for this to be a containment rather than a
 # gesture: where it may write, whether it can reach the network, how much
-# memory it gets, how long it may run, who it runs as, and what happens when it
-# exceeds any of them. Until 2026-08-26 only the first two were written down,
-# and the working directory said "there is a quota" without ever saying what
-# the quota was. A limit with no number is not a limit.
+# memory it gets, how long it may run, who it runs as, what it may read of what
+# the orchestrator holds, and what happens when it exceeds any of them. Until
+# 2026-08-26 only the first two were written down, and the working directory
+# said "there is a quota" without ever saying what the quota was. A limit with
+# no number is not a limit.
+#
+# The seventh arrived last, on 2026-09-10, and by the opposite route to the
+# others. Those were rules nothing applied; this was a boundary nothing stated.
+# Planning the test that a command cannot read a token, key or environment
+# secret turned up the fact that no rule here said it may not — so the test
+# would have passed against nothing. A test with no rule behind it is the same
+# fault as a rule with no code behind it, seen from the other side.
 #
 # Every value here is a *chosen* limit rather than a measured one, and for a
 # containment that is the right kind of number — the point is to decide what is
@@ -219,9 +227,31 @@ REQUIRED_MICROVM_POLICY: dict[str, Any] = {
     "wall_clock_seconds": MICROVM_WALL_CLOCK_SECONDS,
     # Not a separate decision: Firecracker's jailer is what drops privileges,
     # and the signed policy already requires it. Written down anyway, because
-    # "which user does the command run as" is one of the six questions, and
+    # "which user does the command run as" is one of the seven questions, and
     # answering it by implication elsewhere is how it went unanswered here.
     "user": "jailer-unprivileged",
+    # What the command may read of what the orchestrator holds: nothing.
+    # Written as a rule because the alternative was a test aimed at a boundary
+    # no rule stated, which would have passed whether or not anything was ever
+    # at risk.
+    #
+    # Most of the mechanism already exists, and the part that does not is the
+    # reason this is worth writing down. The jailer, as documented for v1.13.1,
+    # will "cleanup all environment variables received from the parent process"
+    # and "close all open file descriptors based on /proc/<jailer-pid>/fd
+    # **except input, output and error**". Those three survive, and they are
+    # closed only by the separate step that runs when the launcher asks to
+    # daemonize, which points them at /dev/null. So this rule holds by default
+    # for the environment and only conditionally for the descriptors, and a
+    # launcher that hands the jailer a standard descriptor carrying anything
+    # has defeated it without changing a setting.
+    #
+    # Two devices outside these rules would reopen the path the same quiet way:
+    # MMDS, a metadata service the guest reads over HTTP, and vsock, a
+    # host-to-guest socket. Both must be absent. Neither is a rule about what
+    # the containment allows, so neither is listed here; they are part of why
+    # this rule needs a launcher that knows about them rather than a setting.
+    "credentials": "none-inherited",
     # What happens on breach. Stop and say so — never carry on with the rule
     # relaxed, and never fail quietly. Section 7 of the specification asks for
     # exactly this: stage three must fail loudly when its containment is

--- a/batch-runner/sandbox/agentic_v2_capabilities.json
+++ b/batch-runner/sandbox/agentic_v2_capabilities.json
@@ -95,6 +95,7 @@
     "memory_mib": 4096,
     "wall_clock_seconds": 1200,
     "user": "jailer-unprivileged",
+    "credentials": "none-inherited",
     "on_breach": "stop-and-report"
   }
 }

--- a/batch-runner/tests/test_agentic_v2_containment_rules.py
+++ b/batch-runner/tests/test_agentic_v2_containment_rules.py
@@ -1,13 +1,19 @@
 """The containment rules: that they are complete, numbered, and hard to weaken.
 
-Six questions have to be answered before a set of settings is a containment
+Seven questions have to be answered before a set of settings is a containment
 rather than a gesture — where a command may write, whether it can reach the
-network, how much memory it gets, how long it may run, who it runs as, and what
-happens when it exceeds any of them. Until 2026-08-26 only the first two were
-written down, and the working directory said "there is a quota" without ever
-saying what the quota was.
+network, how much memory it gets, how long it may run, who it runs as, what it
+may read of what the orchestrator holds, and what happens when it exceeds any of
+them. Until 2026-08-26 only the first two were written down, and the working
+directory said "there is a quota" without ever saying what the quota was.
 
-These tests do three things and no more. They check that all six are answered;
+The seventh was added on 2026-09-10 and arrived by the opposite route to the
+others. Those were rules nothing applied. This was a boundary nothing stated:
+planning the test that a command cannot read a token, key or environment secret
+found that no rule said it may not, so the test would have passed against
+nothing at all.
+
+These tests do three things and no more. They check that all seven are answered;
 they check that the numbers which are derived from something else still agree
 with what they were derived from; and they check that weakening any one of them
 is refused rather than accepted.
@@ -68,10 +74,10 @@ def _signed_policy() -> dict:
     return json.loads(SIGNED_POLICY_PATH.read_text(encoding="utf-8"))
 
 
-# ── All six questions are answered ────────────────────────────────────────
+# ── All seven questions are answered ──────────────────────────────────────
 
 
-def test_every_one_of_the_six_questions_has_an_answer():
+def test_every_one_of_the_seven_questions_has_an_answer():
     """A containment that leaves one of these open is not a containment.
 
     Named individually rather than counted, so that a failure says which
@@ -83,6 +89,7 @@ def test_every_one_of_the_six_questions_has_an_answer():
     assert REQUIRED_MICROVM_POLICY["memory_mib"] == MICROVM_MEMORY_MIB
     assert REQUIRED_MICROVM_POLICY["wall_clock_seconds"] == MICROVM_WALL_CLOCK_SECONDS
     assert REQUIRED_MICROVM_POLICY["user"] == "jailer-unprivileged"
+    assert REQUIRED_MICROVM_POLICY["credentials"] == "none-inherited"
     assert REQUIRED_MICROVM_POLICY["on_breach"] == "stop-and-report"
 
 
@@ -188,6 +195,8 @@ def test_the_memory_rule_says_it_was_picked_rather_than_derived():
         ("memory_mib", MICROVM_MEMORY_MIB * 4),
         ("wall_clock_seconds", MICROVM_WALL_CLOCK_SECONDS * 4),
         ("user", "root"),
+        ("credentials", "inherit-environment"),
+        ("credentials", "none"),
         ("on_breach", "continue"),
         ("on_breach", "log-and-continue"),
         ("runtime", "docker"),

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -874,6 +874,24 @@ so *"the signed policy still validates"* is not the same statement as *"the
 containment is intact"*, and a launcher built by reading the signed policy would
 enforce well under half of it.
 
+**And a fourth partial copy, found while checking the third.**
+`core/agentic_v2_microvm.py` reports `network`, `rootfs_mode` and `workdir` at
+the top level of its readiness report, and writes them as the string literals
+`"none"`, `"read-only"` and `"ephemeral-quota"`. It imports `canonical_sha256`
+from the substrate and nothing else — not `REQUIRED_MICROVM_POLICY` — and
+`validate_microvm_readiness_report` checks the report against the same literals
+rather than against the rules. So three rules are stated a fourth time, by a
+module that would go on stating them if the rules changed underneath it.
+
+This is not currently a hole that hides anything: all three are among the four
+the signed policy mirrors, so weakening one is still caught by
+`containment_rules_that_disagree` — the stale report would appear beside a
+failure rather than instead of one. It is left alone here because C0's scope is
+a missing rule and not a drift surface, and because the fix belongs to the
+module that will read the policy for real. **C1 imports
+`REQUIRED_MICROVM_POLICY` and restates no value of it**, and takes this one with
+it rather than adding a fifth.
+
 **Cost.** None.
 
 **Result — done, 2026-09-10.** `credentials: "none-inherited"` is the eleventh
@@ -899,6 +917,15 @@ launcher might pass to something C1 has to, and C3's attack on this rule checks
 the descriptors rather than trusting the sentence. **A rule written down on the
 strength of a mechanism that turns out to work differently is the same fault
 this stage exists to fix**, arriving one layer down.
+
+The same reading corrected a second thing C1 would have built on: the device
+table below said four, and the fourth was `memory-hotplug`, which does not exist
+in this Firecracker. No such key in v1.13.1's configuration fixture and no
+occurrence of *hotplug* anywhere in its API specification. Balloon is the
+runtime-memory mechanism, and the table had it twice under two names. Three
+checks in this stage would have held against nothing — attack 7, the jailer's
+descriptors, and this — and all three were found by reading the sources the plan
+cites rather than the plan.
 
 **What was deliberately not renumbered.** Three records still say six or nine:
 `CHANGELOG.md`, `TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md` — which says it in five
@@ -935,7 +962,7 @@ Each of the eleven policy keys maps to something a reader can point at:
 | `on_breach: stop-and-report` | the launcher's error path returns the breached rule by name |
 | `required: true` | any rule that cannot be expressed is a refusal to launch, never a silent drop |
 
-**Four devices that are not in the policy and can each defeat a rule that is.**
+**Three devices that are not in the policy and can each defeat a rule that is.**
 Read off Firecracker's own configuration fixtures rather than assumed, and named
 here because a launcher that sets every key in the table above and leaves these
 at a default would enforce less than it appears to:
@@ -944,8 +971,28 @@ at a default would enforce less than it appears to:
 |---|---|---|
 | `mmds-config` | `network: none`, by a route that is not a NIC — MMDS is a metadata service the *guest* reads over HTTP, and it is the standard way host-side data is handed to a guest | `null` |
 | `vsock` | `network: none` — a host↔guest socket is a channel whether or not it is a NIC | `null` |
-| `memory-hotplug` | `memory_mib` — memory added after boot is memory the bound never saw | `null` |
-| `balloon` | `memory_mib` — a balloon device reshapes guest memory at runtime | `null` |
+| `balloon` | `memory_mib` — a balloon device reshapes guest memory at runtime, and it is the only mechanism in this Firecracker that does | `null` |
+
+**This table said four until C0 checked it, and the fourth was not real.** It
+listed `memory-hotplug`, on the reasoning that memory added after boot is memory
+the bound never saw. The reasoning is sound and the device is not: v1.13.1's
+configuration fixture has no such key, and its API specification — 43 KB, every
+route — contains no occurrence of *hotplug* at all. The routes are `/balloon`,
+`/boot-source`, `/cpu-config`, `/drives`, `/entropy`, `/logger`,
+`/machine-config`, `/metrics`, `/mmds`, `/mmds/config`, `/network-interfaces`,
+`/snapshot/create`, `/snapshot/load`, `/vsock`, `/vm`, `/vm/config`, `/actions`
+and `/version`. Balloon **is** the runtime-memory mechanism here; the table had
+it twice under two names. A test pinning `memory-hotplug: null` would have
+asserted something about a key Firecracker never emits and passed for that
+reason — the third time in this stage that a check would have held against
+nothing.
+
+**And one route that is not a device.** `/snapshot/load` restores a machine
+whose configuration was decided elsewhere: a snapshot can carry a NIC, a vsock
+or a different memory size, none of which the launcher's own arguments would
+show. It is not in the table because it is not a setting to pin at `null` — it
+is a way in that bypasses the table entirely, so C1's builder emits no snapshot
+route and C3 treats loading one as an escape rather than a configuration.
 
 These get tests of their own in C1, on the same footing as the policy keys. The
 policy is not amended to add them: they are not rules about what the containment

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -45,9 +45,9 @@ Not from the prose. Each of these was read out of the file named.
 | `exec_run` answers `capability_unavailable` for every command except a three-argument `fixture-upper` that upper-cases a file. | `core/agentic_v2_fixture_backend.py:197-213` |
 | The batch entry point refuses the mode outright. | `step2_run_inference.py:158-163` |
 | The runner in use today replays a written-down list of calls and has no model client. | `core/agentic_v2_runner.py:1` |
-| The containment rules exist, in one copy, with all six questions answered. | `core/agentic_v2_substrate.py` `REQUIRED_MICROVM_POLICY` |
+| The containment rules exist, in one copy, with all six questions answered. Stage C0, later the same day, added a seventh — so this row is what was inherited, not what is there now. | `core/agentic_v2_substrate.py` `REQUIRED_MICROVM_POLICY` |
 | **Nothing turns those rules into arguments for starting a machine.** The readiness report says so on every rule, on every machine — "this is the same on every machine, because it is a fact about this repository". | `core/agentic_v2_containment_readiness.py:851`, via `scripts/check_agentic_containment.py`, run 2026-09-10 |
-| No machine in play can host the containment: this box is kernel 3.10.102 inside a container with no virtualisation device; GitHub-hosted runners are documented as unsupported for it; the `agentic-sandbox` self-hosted runner does not exist. | same run |
+| No machine in play can host the containment: this box is kernel 3.10.102 inside a container with no virtualisation device; GitHub-hosted runners are documented as unsupported for it; the `agentic-sandbox` self-hosted runner does not exist. Stage B, later the same day, brought a machine into play that can — `machine_could_host_it: true` — so this row too is what was inherited rather than where things stand. | same run |
 
 And one fact that is easy to miss and matters more than any of the above:
 
@@ -197,12 +197,17 @@ unknown it is `null`, never `0`.
 blocker the readiness report calls "the same on every machine, because it is a
 fact about this repository".
 
-**Exit condition.** For each of the six rules, a test that **starts the
+**Exit condition.** For each of the seven rules, a test that **starts the
 machine, exceeds the rule, and requires the machine to stop it**: writing past
 the 256 MiB working-directory quota, allocating past 4,096 MiB, running past
-1,200 seconds, opening a network connection, writing to the read-only root, and
-running as a privileged user. Plus a credential test: the process must not be
-able to read any token, key or environment secret the orchestrator holds.
+1,200 seconds, opening a network connection, writing to the read-only root,
+running as a privileged user, and reading a token, key or environment secret
+the orchestrator holds.
+
+The last of those was written here as an eighth test alongside six rules, which
+was the wrong shape: no rule said a command may not read the orchestrator's
+credentials, so the test would have passed against nothing at all. C0 adds the
+rule, and the count becomes seven and seven.
 
 This is the test `tests/test_agentic_v2_containment_rules.py` names in its own
 docstring and declines to fake — "that is the test these rules will eventually
@@ -748,7 +753,8 @@ bootstrapped. The three that no install can supply — processor, device, kernel
 are the ones that make this a property of the machine.
 
 **What did not change.** `required_containment_available` is still `false`, and
-the nine policy rules still read `cannot be established here`, because no module
+the nine policy rules of that commit still read `cannot be established here` —
+ten, once C0 added the credential rule later the same day — because no module
 turns `REQUIRED_MICROVM_POLICY` into arguments for starting a virtual machine.
 That is stage C. So `could_be_hosted_on_any_machine_in_play` flips to `true`,
 `available_on_any_machine_in_play` stays `false`, and
@@ -857,7 +863,54 @@ containment answers six questions.
 could apply, C3's attack 7 is recorded as untestable with the reason, rather than
 written as a test that passes because nothing was ever at risk.
 
+**One thing the check turned up that C1 and C3 both need.** The signed
+supply-chain policy is not a second copy of the containment. It mirrors four
+rules — `runtime`, `network`, `read_only_rootfs`, `ephemeral_work_disk` — and
+always has; the other seven, including all three numeric limits, `on_breach`,
+`user` and now `credentials`, exist only in `REQUIRED_MICROVM_POLICY` and the
+manifest. Nothing is wrong with that, and it is not changed here. It is written
+down because the drift check between the two files can only ever guard the four,
+so *"the signed policy still validates"* is not the same statement as *"the
+containment is intact"*, and a launcher built by reading the signed policy would
+enforce well under half of it.
+
 **Cost.** None.
+
+**Result — done, 2026-09-10.** `credentials: "none-inherited"` is the eleventh
+key of `REQUIRED_MICROVM_POLICY` and the eleventh line of the manifest's
+`microvm` block. Weakening it to `inherit-environment` or to a bare `"none"` is
+refused, deleting it is refused, and the manifest-equals-policy check holds. On
+this box the readiness report goes from 14 requirements to 15 and from 12
+missing to 13, the new one reading *"the command's access to the tokens, keys
+and environment the orchestrator holds is none-inherited — cannot be established
+here"*, which is the same honest verdict the other ten get. 1,280 agentic tests
+pass, 3 skipped.
+
+**What checking it changed.** The plan said the launcher could lean on the
+jailer, which "already clears inherited environment variables and file
+descriptors before exec". The jailer documentation for v1.13.1 — the version
+stage B found installed — says something narrower: it will *"cleanup all
+environment variables received from the parent process"* but *"close all open
+file descriptors … **except input, output and error**"*. Those three survive,
+and are pointed at `/dev/null` only by the separate step that runs when the
+launcher asks to daemonize. So the rule holds by default for the environment and
+only conditionally for the descriptors; `--daemonize` moved from something the
+launcher might pass to something C1 has to, and C3's attack on this rule checks
+the descriptors rather than trusting the sentence. **A rule written down on the
+strength of a mechanism that turns out to work differently is the same fault
+this stage exists to fix**, arriving one layer down.
+
+**What was deliberately not renumbered.** Three records still say six or nine:
+`CHANGELOG.md`, `TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md` — which says it in five
+places, all of them dated to the day the count was six — and the recorded Azure
+finding, which describes a report pinned by its sha256 that did contain nine.
+Only the last needed an as-of clause, because it sits in `core/` beside a report
+a reader can run today and get ten from; the two dated documents are left
+exactly as they are. The count moving is the thing those records exist to show.
+The two rows of section 1 that stage B and C0 overtook on the same day say so in
+the row rather than being rewritten, for the same reason: a table headed *"read
+from the code on 2026-09-10"* cannot silently mean two different states of that
+day.
 
 ##### C1 — the mapping, as data
 
@@ -878,7 +931,7 @@ Each of the eleven policy keys maps to something a reader can point at:
 | `memory_mib` | `machine-config.mem_size_mib` |
 | `wall_clock_seconds` | a host-side deadline, since a guest cannot be trusted to time itself |
 | `user: jailer-unprivileged` | `--uid`/`--gid` of a non-root user, and a refusal if either resolves to 0 |
-| the credential rule added in C0 | the jailer already clears inherited environment variables and file descriptors before exec — the launcher relies on that rather than reimplementing it, and passes nothing of its own. The two devices that would reopen the path, `mmds-config` and `vsock`, are covered in the table below |
+| `credentials: none-inherited` (added in C0) | the jailer does most of it: for v1.13.1 it will "cleanup all environment variables received from the parent process" and "close all open file descriptors … **except input, output and error**". The environment half holds by default; the descriptor half leaves three open, and they are pointed at `/dev/null` only by the separate `--daemonize` step. So the launcher passes `--daemonize`, passes nothing of its own, and the test checks the descriptors rather than trusting the sentence. The two devices that would reopen the path, `mmds-config` and `vsock`, are covered in the table below |
 | `on_breach: stop-and-report` | the launcher's error path returns the breached rule by name |
 | `required: true` | any rule that cannot be expressed is a refusal to launch, never a silent drop |
 
@@ -901,10 +954,21 @@ mean what they say. If that reasoning is wrong, the fix is to add them to
 `REQUIRED_MICROVM_POLICY` in a change of their own, not to quietly rely on a
 default.
 
-Two further flags are passed because leaving them off would weaken the boundary
-the policy describes even though no key names them: `--new-pid-ns`, so the guest
-process is not in the host's PID namespace, and `--cgroup` for the host-side
-memory bound that sits underneath the guest-visible one.
+Three further flags are passed because leaving them off would weaken the
+boundary the policy describes even though no key names them: `--new-pid-ns`, so
+the guest process is not in the host's PID namespace, `--cgroup` for the
+host-side memory bound that sits underneath the guest-visible one, and
+`--daemonize`, which is what closes the three descriptors the jailer's own
+cleanup step leaves open — see the credential row above.
+
+`--daemonize` has a consequence worth stating before it is discovered as a bug:
+it points Firecracker's standard output at `/dev/null`, so console output is
+gone unless the launcher asks for a log path. That is acceptable here only
+because it is not where results come from — deliverables are collected off the
+ephemeral work disk, which the `workdir` rule already governs. It also pairs
+with `--new-pid-ns`, which is what writes the child's PID to a file; a detached
+process the launcher could not find again would leave `wall_clock_seconds` with
+nothing to enforce against.
 
 **And a third, which is a default that would quietly be wrong here.**
 `--cgroup-version` defaults to `1` in the jailer's own documentation, while
@@ -1027,7 +1091,11 @@ rule, and requires the machine to stop it:
 5. write to the read-only root
 6. run as a privileged user
 7. read a token, key or environment secret the orchestrator holds — against the
-   rule C0 adds, not against an expectation held only in this list
+   rule C0 adds, not against an expectation held only in this list. Tested in
+   both halves, because the jailer covers them differently: the environment is
+   wiped unconditionally, the three standard descriptors only by `--daemonize`.
+   An attack that checks the environment alone would pass on a launcher that had
+   dropped that flag
 
 **Exit condition.** All seven are stopped, and each stop names the rule it
 enforced. Seven passes is the condition — not six and a note.


### PR DESCRIPTION
## What this is

Stage C0 of the Agentic Sandbox V2 activation plan merged in #491. It is the smallest change in stage C and the one that had to come first, because C3's seventh attack was aimed at a boundary no rule stated.

## Why

Stage C's attack list ends with one unlike the others: *the command must not be able to read a token, key or environment secret the orchestrator holds.* Writing it out properly meant asking which rule it enforces — and the answer was none. At `0076295`, the commit this was written against, the words `credential`, `secret` and `token` appeared **nowhere** in `core/agentic_v2_substrate.py`, `security/agentic-v2-supply-chain-policy.json` or `sandbox/agentic_v2_capabilities.json`: zero matches in all three.

That test would have passed against nothing at all. **A test with no rule behind it is the same fault as a rule with no code behind it, seen from the other side** — and this repository has spent a lot of effort on the first kind.

## What changed

`credentials: "none-inherited"` is now the eleventh containment rule, in `REQUIRED_MICROVM_POLICY` and in the manifest that travels with a built image, which the tests require to be **equal**, not merely compatible.

- weakened to `inherit-environment` → refused
- softened to a bare `"none"` → refused
- deleted → refused
- readiness report carries it beside the other ten as *"cannot be established here"* — the same verdict, for the same reason: nothing turns any of these rules into arguments for starting a machine yet

Every other rule here arrived because something was written down and nothing applied it. This one arrived the opposite way.

## What checking it against the jailer changed

The plan said the launcher could lean on the jailer, which "already clears inherited environment variables and file descriptors before exec". Firecracker's jailer documentation for **v1.13.1** — the version stage B measured on the Azure host, not the development branch — says something narrower:

> "cleanup all environment variables received from the parent process"

> "close all open file descriptors based on `/proc/<jailer-pid>/fd` **except input, output and error**"

Those three survive, and are pointed at `/dev/null` only by the separate step that runs when the launcher asks to daemonize. So the rule holds **by default** for the environment and only **conditionally** for the descriptors.

Consequences, written into the plan rather than discovered later:

- `--daemonize` moves from something C1's launcher may pass to something it **has to**
- C3's attack 7 inspects the descriptors as well as the environment, because an attack checking the environment alone would pass on a launcher that had dropped the flag
- `--daemonize` sends Firecracker's stdout to `/dev/null`, which is acceptable only because results come off the ephemeral work disk, not the console — stated in C1 so it is not met as a bug

A rule written down on the strength of a mechanism that turns out to work differently is the fault this stage exists to fix, one layer further down.

## One thing the check turned up that C1 and C3 both need

The signed supply-chain policy is **not** a second copy of the containment. It mirrors four rules — `runtime`, `network`, `read_only_rootfs`, `ephemeral_work_disk` — and always has. The other seven, including all three numeric limits, `on_breach`, `user` and now `credentials`, live in `REQUIRED_MICROVM_POLICY` and the manifest only.

Nothing is wrong with that and it is not changed here. It is recorded because the drift check between the two files can only ever guard the four, so *"the signed policy still validates"* is not the same statement as *"the containment is intact"*, and a launcher built by reading the signed policy would enforce well under half of it.

## What was deliberately not renumbered

Three records still say six or nine:

| record | changed |
|---|---|
| `CHANGELOG.md`'s 2026-08-26 entry | no |
| `TASK_AGENTIC_SANDBOX_V2_FOUNDATION.md` (five places, all dated) | no |
| the recorded Azure finding in `core/` | clause added, number kept |

Only the last needed one, because it sits beside a report a reader can run today and get ten from. Rewriting the two dated documents would not fix a stale sentence; it would falsify a record of when the rule set changed, which is what those records are for.

The two rows of the activation plan's section 1 that stage B and C0 overtook **on the same day** say so in the row rather than being rewritten — a table headed *"read from the code on 2026-09-10"* cannot silently mean two different states of that day.

## Shared-file note

`CHANGELOG.md` is shared with the Codex work. This adds three bullets to `Unreleased / Added` **below** the existing Codex entries and modifies none of them. If the other side merges first, this rebases onto it cleanly.

## Verification

- `tests/test_agentic_v2_containment_rules.py` — 35 passed
- agentic / containment / substrate / supply-chain / microvm selection — **1,280 passed, 3 skipped**
- full backend suite — **9,559 passed, 12 skipped, 46 deselected, exit 0** (23m46s)
- readiness report on this box: 14 requirements → 15, 12 missing → 13, the new one reading *"the command's access to the tokens, keys and environment the orchestrator holds is none-inherited — cannot be established here"*

## What this is not

No guard removed, no policy weakened, no fallback to V1's Docker backend, no activation flag flipped, no `exec_run` opened, nothing run as root, nothing spent. `foundation_only` stays `true` and `production_activation` stays `disabled`.