### PR TITLE
feat(codex): let a batch dispatch open the Codex gate

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -43,6 +43,11 @@ on:
         required: false
         type: string
         default: ''
+      codex_foundry_confirmed:
+        description: 'codex_foundry only: this batch may spend on the Foundry deployment. Ignored by every other mode; a codex_foundry dispatch without it fails before any credentialed job starts.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write        # to commit yaml results
@@ -62,6 +67,9 @@ jobs:
       contents: read
     outputs:
       uses_agentic: ${{ steps.mode.outputs.uses_agentic }}
+      uses_codex_foundry: ${{ steps.mode.outputs.uses_codex_foundry }}
+      codex_confirmed: ${{ steps.mode.outputs.codex_confirmed }}
+      codex_blocked: ${{ steps.mode.outputs.codex_blocked }}
     steps:
       - name: Verify dispatch contract
         env:
@@ -111,6 +119,14 @@ jobs:
         id: mode
         env:
           EXPERIMENT_YAML: ${{ inputs.experiment_yaml }}
+          # Read through the environment on purpose. A `workflow_dispatch`
+          # boolean is a boolean in `inputs` but arrives as the string "true"
+          # or "false" through an env var, and a job-level `if` that compares a
+          # string to `true` casts the string to a number first and gets NaN.
+          # Rather than depend on which of those two shapes a given dispatch
+          # produces, the decision is made here as text and published as text,
+          # so every consumer below compares strings to strings.
+          CODEX_FOUNDRY_CONFIRMED: ${{ inputs.codex_foundry_confirmed }}
         run: |
           ruby <<'RUBY'
           require 'yaml'
@@ -142,8 +158,28 @@ jobs:
           uses_agentic = ['agentic_sandbox', 'agentic_sandbox_v2'].include?(
             execution['mode']
           ) || sandbox['hardened_substrate'] == true
+          # Read here, in the job that holds no credentials, for the same
+          # reason the agentic check is read here: the answer decides whether a
+          # credentialed job starts at all, so it must be known before one does.
+          uses_codex_foundry = execution['mode'] == 'codex_foundry'
+          # Fail closed. Anything that is not exactly "false" or "true" is a
+          # dispatch this file does not understand, and the safe reading of a
+          # value it does not understand is not "spend".
+          confirmed_raw = ENV.fetch('CODEX_FOUNDRY_CONFIRMED', 'false')
+          confirmed_raw = 'false' if confirmed_raw.empty?
+          unless %w[true false].include?(confirmed_raw)
+            abort("codex_foundry_confirmed must be true or false")
+          end
+          # `codex_foundry` is the only mode this box means anything to. Ticked
+          # on any other experiment it is inert -- not an error, because the
+          # relay forwards every input on every leg and a run must not start
+          # failing halfway through for carrying a flag it never used.
+          codex_blocked = uses_codex_foundry && confirmed_raw != 'true'
           File.open(ENV.fetch('GITHUB_OUTPUT'), 'a') do |output|
             output.puts("uses_agentic=#{uses_agentic}")
+            output.puts("uses_codex_foundry=#{uses_codex_foundry}")
+            output.puts("codex_confirmed=#{confirmed_raw}")
+            output.puts("codex_blocked=#{codex_blocked}")
           end
           RUBY
 
@@ -160,9 +196,35 @@ jobs:
           echo "signed control/compute workflow. No credentialed job was started."
           exit 1
 
+  reject-unconfirmed-codex:
+    needs: inspect-mode
+    if: needs.inspect-mode.outputs.codex_blocked == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Reject codex_foundry dispatched without confirmation
+        run: |
+          echo "FATAL: this experiment runs execution.mode codex_foundry, and"
+          echo "the dispatch did not set codex_foundry_confirmed. No"
+          echo "credentialed job was started and nothing was spent."
+          echo
+          echo "The box is not a formality and it is not about the connection."
+          echo "The connection is answered: run 34465567349 sent one turn to"
+          echo "the Foundry deployment and got a reply that matched the"
+          echo "instruction it was given. What the box says is the separate"
+          echo "thing -- that a person looked at this experiment and decided"
+          echo "this batch may spend. That turn cost 24 output tokens; a batch"
+          echo "leg is a different order of commitment."
+          echo
+          echo "Read the experiment's declared bounds first (tasks, attempts,"
+          echo "turns per attempt, wall clock per turn), then re-dispatch with"
+          echo "codex_foundry_confirmed: true."
+          exit 1
+
   batch-run:
     needs: inspect-mode
-    if: needs.inspect-mode.outputs.uses_agentic != 'true'
+    if: needs.inspect-mode.outputs.uses_agentic != 'true' && needs.inspect-mode.outputs.codex_blocked != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 360    # max 6 hours
     env:
@@ -174,6 +236,7 @@ jobs:
       WALL_TIMEOUT_INPUT: ${{ inputs.wall_timeout }}
       DRY_RUN_INPUT: ${{ inputs.dry_run }}
       SANDBOX_IMAGE_DIGEST_INPUT: ${{ inputs.sandbox_image_digest }}
+      CODEX_FOUNDRY_CONFIRMED_INPUT: ${{ inputs.codex_foundry_confirmed }}
 
     steps:
       - name: Checkout
@@ -411,6 +474,13 @@ jobs:
             "uses_code_interpreter": str(
               mode == "code_interpreter"
             ).lower(),
+            # Parsed a second time, by a second parser, on purpose. The Ruby in
+            # inspect-mode decides whether this job starts; this decides
+            # whether step 2a is told the batch may spend. Both read the same
+            # file, so if they ever disagree the variable is absent and step 2
+            # refuses the mode -- which is the direction a disagreement should
+            # fail in.
+            "uses_codex_foundry": str(mode == "codex_foundry").lower(),
             "condition_a_provider": condition_a_provider,
             "condition_a_deployment": condition_a_deployment,
             "condition_b_provider": condition_b_provider,
@@ -439,6 +509,23 @@ jobs:
           echo "Azure/HF credentials, relay, narrative, and upload permissions."
           echo "Use the dedicated signed compute/control workflow only after the"
           echo "paid gate is merged. No model client or cloud credential was used."
+          exit 1
+
+      # The pair to the reject-unconfirmed-codex job, for the one case that job
+      # cannot cover: the two parsers disagreeing. inspect-mode reads the
+      # experiment with Ruby's YAML and decides whether this job starts at all;
+      # this reads it with ExperimentConfig, the parser the run itself uses. If
+      # the second sees a Codex experiment the first missed, the job is already
+      # running with credentials -- so it stops here, before the first of them
+      # is used, rather than at step 2.
+      - name: 'Block unconfirmed codex_foundry in credentialed general workflow'
+        if: steps.read_config.outputs.uses_codex_foundry == 'true' && needs.inspect-mode.outputs.codex_confirmed != 'true'
+        run: |
+          echo "FATAL: this experiment runs execution.mode codex_foundry and the"
+          echo "dispatch did not set codex_foundry_confirmed. The credential-free"
+          echo "inspect-mode job read this experiment as something else, so the"
+          echo "two parsers disagree and that disagreement is itself the fault to"
+          echo "report. No model client or cloud credential was used."
           exit 1
 
       - name: Validate Azure OIDC identity before remote access
@@ -714,6 +801,18 @@ jobs:
           AZURE_AI_EXPECTED_DIRECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_DIRECT_ACCOUNT }}
           AZURE_AI_EXPECTED_PROJECT_ACCOUNT: ${{ vars.AZURE_AI_EXPECTED_PROJECT_ACCOUNT }}
           AZURE_AI_EXPECTED_PROJECT_NAME: ${{ vars.AZURE_AI_EXPECTED_PROJECT_NAME }}
+          # Set only where both hold: this repository's own config parser says
+          # the experiment is codex_foundry, and the dispatch ticked the box.
+          #
+          # It reads the box rather than inspect-mode's `codex_blocked`, and
+          # the difference matters. `codex_blocked` is false in two unrelated
+          # situations -- the box was ticked, and the Ruby did not think this
+          # was a Codex experiment at all. If the two parsers ever disagreed in
+          # that second direction, keying off `codex_blocked` would set this to
+          # 1 with nobody having ticked anything. Keying off the box itself
+          # cannot: a disagreement then leaves this empty, and empty is what
+          # step2_run_inference._require_runnable_execution_mode refuses on.
+          CODEX_FOUNDRY_CONNECTION_CONFIRMED: ${{ steps.read_config.outputs.uses_codex_foundry == 'true' && needs.inspect-mode.outputs.codex_confirmed == 'true' && '1' || '' }}
         run: |
           set +e
           cd batch-runner
@@ -787,6 +886,12 @@ jobs:
           # the pull step is skipped). Forwarding it keeps every relay leg on the
           # exact same immutable image.
           SANDBOX_IMAGE_DIGEST: ${{ steps.sandbox_pull.outputs.digest }}
+          # codex_foundry_confirmed is forwarded for the same reason every
+          # other input is: a relay leg is the same run continuing, not a new
+          # decision. Dropping it would leave the next leg refused at the gate
+          # after the first leg had already spent, which is the worst of both.
+          # The person authorised this experiment, and its declared bounds
+          # (attempts, turns, wall clock) span the whole run, not one leg.
         run: |
           NEXT_RELAY=$(( RELAY_RUN_INPUT + 1 ))
           MAX_RELAYS="${{ steps.read_config.outputs.relay_max_runs }}"
@@ -813,7 +918,8 @@ jobs:
             -f source_sha="$SOURCE_SHA" \
             -f wall_timeout="$WALL_TIMEOUT_INPUT" \
             -f dry_run="$DRY_RUN_INPUT" \
-            -f sandbox_image_digest="$SANDBOX_IMAGE_DIGEST"
+            -f sandbox_image_digest="$SANDBOX_IMAGE_DIGEST" \
+            -f codex_foundry_confirmed="$CODEX_FOUNDRY_CONFIRMED_INPUT"
 
           echo "Relay run #$NEXT_RELAY triggered. This run will now exit."
           exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,51 @@ entries land under a fresh dated heading the day they merge to `main`.
   beside the one Codex performs through its provider auth command, on a run
   whose premise is that the model reaches the deployment exactly one
   documented way.
+- **A batch dispatch can now open the Codex gate.**
+  `step2_run_inference._require_runnable_execution_mode` refuses
+  `codex_foundry` unless `CODEX_FOUNDRY_CONNECTION_CONFIRMED` is set, and
+  `batch-run.yml` had no way to set it, so the mode ran only through its own
+  tests. It now takes a `codex_foundry_confirmed` dispatch input that defaults
+  to false. The gate itself does not change: what the box says is not that the
+  connection works — run `34465567349` settled that — but the separate thing,
+  that a person looked at this experiment and decided this batch may spend.
+  - The decision is made in `inspect-mode`, the job that holds no credentials
+    and whose checkout does not persist any, beside the agentic check and for
+    the same reason: it decides whether a credentialed job starts at all.
+  - A `codex_foundry` dispatch without the box **fails** rather than skipping,
+    in a `reject-unconfirmed-codex` job shaped like `reject-agentic` — no
+    checkout, nothing with credentials, `exit 1`. A skipped job reads as
+    "nothing to do"; this has to read as "refused". The credentialed job is
+    guarded by its own `if` as well, because the two are siblings and a red
+    sibling does not stop a job that has already started spending.
+  - `CODEX_FOUNDRY_CONNECTION_CONFIRMED` is derived from the box itself and
+    never from the block. `codex_blocked` is false in two unrelated
+    situations — the box was ticked, and the credential-free parser did not
+    read this as a Codex experiment — and only the first means somebody
+    decided. A step inside the job covers the second: if `ExperimentConfig`
+    sees a `codex_foundry` run that the Ruby missed, it stops there, ahead of
+    every credential the job holds.
+  - The input is forwarded on every relay leg. A leg is the same run
+    continuing, and an input that is not forwarded is a run that spends on leg
+    0 and is refused on leg 1. That is now checked for *every* dispatch input
+    rather than for this one, because the next input added has the same bug.
+  - Anything that is not exactly `true` or `false` aborts. The safe reading of
+    a value nobody understands is not "spend".
+
+  The box is inert for every other mode, ticked or not, rather than an error:
+  the relay forwards every input on every leg, and a run must not start
+  failing halfway through for carrying a flag it never used.
 
 ### Changed
+- **The Codex readiness record narrows its gate blocker rather than dropping
+  it.** It said the gate was closed and `batch-run.yml` did not set it; the
+  second half is no longer true. What the reason is actually about — that
+  somebody decides this batch may spend — is unchanged, so the blocker stays
+  and says what it now is: shut by default, opened at dispatch, failing in a
+  job that holds no credentials when it is not. "There is no way to open it"
+  is retired in
+  `test_the_codex_blockers_are_about_the_task_not_about_the_connection` so it
+  cannot come back as a reason after being built. The count stays at two.
 - **The Codex readiness record drops the two blockers this change cleared.**
   It listed three; two of them named code — no experiment file could ask for
   the mode, and the configuration could not reach the runner if one did — and

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ From **Actions > Run GDPVal Batch Experiment**, use:
 | `source_sha` | leave empty |
 | `wall_timeout` | `290` |
 | `sandbox_image_digest` | leave empty |
+| `codex_foundry_confirmed` | leave unticked |
 
 Expected behavior:
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -168,6 +168,7 @@ signature 근거가 미측정이라 aggregate gate도 계속 `blocked`입니다.
 | `source_sha` | 빈 값 |
 | `wall_timeout` | `290` |
 | `sandbox_image_digest` | 빈 값 |
+| `codex_foundry_confirmed` | 체크하지 않음 |
 
 예상 동작은 다음과 같습니다.
 

--- a/batch-runner/README.md
+++ b/batch-runner/README.md
@@ -483,6 +483,7 @@ checkout and cloud access.
 | `source_sha` | Initial `main` commit required by every relay leg | *(empty)* | Internal; leave empty on leg 0 |
 | `wall_timeout` | `condition_a` Step 2 checkpoint watchdog, `0..290` minutes; `0` delegates to `execution.wall_timeout` in YAML and disables only when both are `0` | `290` | Keep the default unless debugging relay behavior |
 | `sandbox_image_digest` | Immutable sandbox image forwarded across relay legs | *(empty)* | Internal; the workflow resolves it when needed |
+| `codex_foundry_confirmed` | States that this batch may spend on the Foundry deployment. Only `execution.mode: codex_foundry` reads it; a `codex_foundry` dispatch without it fails in a job that holds no credentials | `false` | Tick it only when you mean to run a Codex batch, and only for that dispatch |
 
 ### Three-task smoke input
 
@@ -495,6 +496,7 @@ relay_lineage_id:      <empty>
 source_sha:            <empty>
 wall_timeout:          290
 sandbox_image_digest:  <empty>
+codex_foundry_confirmed: false
 ```
 
 ### How Relay Runs Work

--- a/batch-runner/README_KR.md
+++ b/batch-runner/README_KR.md
@@ -404,6 +404,7 @@ preflight는 checkout과 cloud 접근 전에 non-`main` ref 또는 workflow/even
 | `source_sha` | 모든 relay leg가 요구하는 최초 `main` commit | *(비움)* | 내부용. leg 0에서는 비워 둠 |
 | `wall_timeout` | `condition_a` Step 2 checkpoint watchdog `0..290`분. `0`은 YAML의 `execution.wall_timeout`에 위임하며 둘 다 `0`일 때만 비활성화 | `290` | relay 디버깅이 아니면 기본값 유지 |
 | `sandbox_image_digest` | relay 전체에 전달되는 immutable sandbox image | *(비움)* | 내부용. 필요 시 workflow가 결정 |
+| `codex_foundry_confirmed` | 이번 batch가 Foundry deployment에 비용을 써도 된다는 선언. `execution.mode: codex_foundry`만 읽으며, 체크하지 않은 `codex_foundry` dispatch는 credential이 없는 job에서 실패 | `false` | Codex batch를 실제로 돌릴 때, 그 dispatch에 한해서만 체크 |
 
 ### 3-task smoke 입력
 
@@ -416,6 +417,7 @@ relay_lineage_id:      <비움>
 source_sha:            <비움>
 wall_timeout:          290
 sandbox_image_digest:  <비움>
+codex_foundry_confirmed: false
 ```
 
 ### 이어달리기(Relay Run) 동작 원리

--- a/batch-runner/core/execution_environment_readiness.py
+++ b/batch-runner/core/execution_environment_readiness.py
@@ -190,15 +190,24 @@ DOCUMENTED_BLOCKERS_BY_ENVIRONMENT: Mapping[str, tuple[str, ...]] = {
     # Two are left, and neither is about reaching the model or about wiring.
     # One is a decision a person has to make and this repository must not make
     # for them. The other is the only thing that has never happened.
+    #
+    # The first of those has since been narrowed rather than cleared, and the
+    # difference is worth keeping straight. It used to say there was no way to
+    # open the gate at all; there is now, and it is a dispatch input that
+    # defaults to off. That does not clear the reason, because what the reason
+    # is actually about — that somebody decides this batch may spend — is
+    # unchanged. It only stops being an obstacle and starts being a step.
     ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY: (
-        "the batch gate is closed and only a person may open it: "
+        "the batch gate is shut unless a person opens it at dispatch: "
         "step2_run_inference._require_runnable_execution_mode raises for this "
         "mode unless CODEX_FOUNDRY_CONNECTION_CONFIRMED is set, and "
-        ".github/workflows/batch-run.yml does not set it. The gate is "
-        "deliberately a setting rather than a reading of this repository's own "
-        "code: 'a request was answered' and 'this batch may spend' are "
-        "different claims, and one answered turn cost 28 output tokens while a "
-        "batch leg is a different order of commitment",
+        ".github/workflows/batch-run.yml sets it only for a run dispatched "
+        "with codex_foundry_confirmed true — an input that defaults to false, "
+        "whose absence fails the run in a job that holds no credentials. The "
+        "gate is deliberately a decision rather than a reading of this "
+        "repository's own code: 'a request was answered' and 'this batch may "
+        "spend' are different claims, and one answered turn cost 28 output "
+        "tokens while a batch leg is a different order of commitment",
         "no task has produced a deliverable through this place against the "
         "real deployment: the turn that was answered carried no tools and "
         "wrote no file (the connection record reports "
@@ -1003,6 +1012,18 @@ def inspect_environment_support(
                 "for this mode and passes both the settings and the run's "
                 "cost ledger to the runner — see "
                 "tests/test_an_experiment_can_ask_for_the_codex_run_place.py"
+            )
+            evidence.append(
+                "the batch workflow can now be told to open the gate: "
+                ".github/workflows/batch-run.yml takes a "
+                "codex_foundry_confirmed input that defaults to false, decides "
+                "on it in the credential-free inspect-mode job, refuses a "
+                "codex_foundry dispatch without it before any credentialed job "
+                "starts, and sets CODEX_FOUNDRY_CONNECTION_CONFIRMED for step "
+                "2a only from the input itself — see "
+                "tests/test_a_batch_dispatch_can_open_the_codex_gate.py, whose "
+                "truth table is executed against the real experiment files "
+                "rather than described"
             )
             blockers.extend(
                 DOCUMENTED_BLOCKERS_BY_ENVIRONMENT.get(environment, ())

--- a/batch-runner/tests/test_a_batch_dispatch_can_open_the_codex_gate.py
+++ b/batch-runner/tests/test_a_batch_dispatch_can_open_the_codex_gate.py
@@ -1,0 +1,350 @@
+"""The Codex run place has a gate, and this is the only thing that opens it.
+
+``step2_run_inference._require_runnable_execution_mode`` refuses
+``codex_foundry`` unless ``CODEX_FOUNDRY_CONNECTION_CONFIRMED`` is set, and
+until this change ``batch-run.yml`` had no way to set it, so the mode ran only
+through its own tests. The gate itself is not what changes here. What changes
+is that a person dispatching the workflow can now open it, deliberately, by
+ticking a box that defaults to off.
+
+The distinction the gate is drawing is worth restating, because it is easy to
+read it as being about the connection and it is not. The connection is
+answered: run ``34465567349`` sent one turn to the Foundry deployment and the
+reply matched the instruction it was given. "A request was answered" and "this
+batch may spend" are different claims, and only the second one needs a person.
+
+Three properties are pinned here, and each of them is a way the gate could be
+opened by accident rather than on purpose.
+
+**A dispatch that forgets the box fails; it does not quietly skip.** A skipped
+job reads as "nothing to do". This is the same shape as ``reject-agentic``: a
+job with no checkout, no credentials and ``exit 1``.
+
+**The variable is derived from the box, never from the block.** ``codex_blocked``
+is false in two unrelated situations -- the box was ticked, and the
+credential-free parser did not think this was a Codex experiment at all. Only
+one of those means somebody decided. Keying the variable off the second would
+set it with nobody having ticked anything.
+
+**Every relay leg carries it.** The relay forwards inputs one at a time by
+name, so an input that is added and not forwarded is a run that spends on leg 0
+and is refused on leg 1. That is checked for every input rather than for this
+one, because the next input added has the same problem.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BATCH_WORKFLOW = ROOT / ".github" / "workflows" / "batch-run.yml"
+
+#: An experiment that asks for the mode, and one that does not. Real files, so
+#: that a rename or a mode change breaks this rather than leaving it testing a
+#: string nothing reads.
+CODEX_EXPERIMENT = "exp033_codex_foundry_fixed5"
+OTHER_EXPERIMENT = "exp998_smoke_baseline_sample"
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    return yaml.safe_load(BATCH_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def dispatch_inputs(workflow):
+    # `on` parses as the boolean True, which is why this is not workflow["on"].
+    return workflow[True]["workflow_dispatch"]["inputs"]
+
+
+def _batch_steps(workflow):
+    return workflow["jobs"]["batch-run"]["steps"]
+
+
+def _named_step(workflow, name):
+    for step in _batch_steps(workflow):
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"no step named {name!r} in the batch-run job")
+
+
+def _mode_script(workflow):
+    """The Ruby that decides, extracted from its heredoc."""
+    step = next(
+        step
+        for step in workflow["jobs"]["inspect-mode"]["steps"]
+        if step.get("id") == "mode"
+    )
+    body = step["run"].split("ruby <<'RUBY'\n", 1)[1]
+    return body.rsplit("RUBY", 1)[0]
+
+
+def _run_mode_script(workflow, experiment, confirmed):
+    """Run the real decision on a real experiment file.
+
+    Skipped where there is no Ruby, which is every development box here and no
+    GitHub-hosted runner. The static checks below hold either way; this is the
+    one that executes what CI will execute.
+
+    The interpreter is resolved to an absolute path before the environment is
+    replaced, because a runner may keep its Ruby somewhere the trimmed PATH
+    below does not reach and a skip is a better outcome than a false failure.
+    """
+    ruby = shutil.which("ruby")
+    if ruby is None:
+        pytest.skip("no ruby interpreter on this host")
+    with tempfile.TemporaryDirectory() as scratch:
+        output = Path(scratch) / "github_output"
+        output.touch()
+        finished = subprocess.run(
+            [ruby, "-e", _mode_script(workflow)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                "GITHUB_OUTPUT": str(output),
+                "EXPERIMENT_YAML": experiment,
+                "CODEX_FOUNDRY_CONFIRMED": confirmed,
+            },
+        )
+        written = dict(
+            line.split("=", 1)
+            for line in output.read_text(encoding="utf-8").splitlines()
+            if "=" in line
+        )
+    return finished, written
+
+
+# ── The box ────────────────────────────────────────────────────────────────
+
+
+def test_the_box_exists_and_is_off_unless_somebody_ticks_it(dispatch_inputs):
+    """A default of true would be no gate at all, only a longer form."""
+    setting = dispatch_inputs["codex_foundry_confirmed"]
+    assert setting["type"] == "boolean"
+    assert setting["default"] is False
+    assert setting["required"] is False
+    # It says which mode it is for, because it is inert for every other one and
+    # a description that did not say so would read as a general cost switch.
+    assert "codex_foundry" in setting["description"]
+
+
+# ── The decision, made where there are no credentials ──────────────────────
+
+
+def test_the_decision_is_published_by_the_job_that_holds_nothing(workflow):
+    """Same job as the agentic check, and for the same reason.
+
+    It has no credentials and its checkout does not persist any, so whatever it
+    decides is decided before anything could be spent.
+    """
+    inspect = workflow["jobs"]["inspect-mode"]
+    assert inspect["permissions"] == {"contents": "read"}
+    checkout = next(
+        step
+        for step in inspect["steps"]
+        if step.get("name") == "Checkout config only"
+    )
+    assert checkout["with"]["persist-credentials"] is False
+    for name in ("uses_codex_foundry", "codex_confirmed", "codex_blocked"):
+        assert inspect["outputs"][name] == f"${{{{ steps.mode.outputs.{name} }}}}"
+
+
+def test_the_box_is_read_through_the_environment_not_the_inputs_context(
+    workflow,
+):
+    """A boolean compared against a string in a job `if` is a trap.
+
+    ``inputs.x`` is a boolean for ``workflow_dispatch``; through an env var the
+    same value arrives as the text "true" or "false". A job-level `if` that
+    compares text to `true` casts the text to a number, gets NaN, and takes the
+    wrong branch. Normalising once, here, means every consumer below compares
+    text to text and none of them has to know which shape it started as.
+    """
+    step = next(
+        step
+        for step in workflow["jobs"]["inspect-mode"]["steps"]
+        if step.get("id") == "mode"
+    )
+    assert step["env"]["CODEX_FOUNDRY_CONFIRMED"] == (
+        "${{ inputs.codex_foundry_confirmed }}"
+    )
+    script = _mode_script(workflow)
+    assert "ENV.fetch('CODEX_FOUNDRY_CONFIRMED'" in script
+    assert "execution['mode'] == 'codex_foundry'" in script
+
+
+@pytest.mark.parametrize(
+    "experiment,confirmed,expected",
+    [
+        (CODEX_EXPERIMENT, "true", "false"),
+        (CODEX_EXPERIMENT, "false", "true"),
+        # An input that never arrives is an input that was not ticked.
+        (CODEX_EXPERIMENT, "", "true"),
+        # The box is inert everywhere else, ticked or not. Making it an error
+        # would mean a relay leg could start failing halfway through a run for
+        # carrying a flag it never used.
+        (OTHER_EXPERIMENT, "true", "false"),
+        (OTHER_EXPERIMENT, "false", "false"),
+    ],
+)
+def test_the_decision_runs_out_the_way_it_reads(
+    workflow, experiment, confirmed, expected
+):
+    """The truth table, executed rather than described."""
+    finished, written = _run_mode_script(workflow, experiment, confirmed)
+    assert finished.returncode == 0, finished.stderr
+    assert written["codex_blocked"] == expected
+    assert written["uses_codex_foundry"] == str(
+        experiment == CODEX_EXPERIMENT
+    ).lower()
+
+
+def test_a_value_it_cannot_read_is_not_permission(workflow):
+    """Fail closed. The safe reading of a value nobody understands is 'no'."""
+    finished, written = _run_mode_script(workflow, CODEX_EXPERIMENT, "yes")
+    assert finished.returncode != 0
+    assert "codex_foundry_confirmed must be true or false" in finished.stderr
+    assert written == {}
+
+
+# ── What the decision stops ────────────────────────────────────────────────
+
+
+def test_an_unconfirmed_dispatch_fails_rather_than_skipping(workflow):
+    """A skipped job reads as 'nothing to do'. This has to read as 'refused'.
+
+    Shaped exactly like ``reject-agentic``: no checkout, nothing fetched,
+    nothing with credentials, and a non-zero exit so the run is red.
+    """
+    reject = workflow["jobs"]["reject-unconfirmed-codex"]
+    assert reject["needs"] == "inspect-mode"
+    assert reject["if"] == "needs.inspect-mode.outputs.codex_blocked == 'true'"
+    assert reject["permissions"] == {"contents": "read"}
+    assert all("uses" not in step for step in reject["steps"])
+    assert any("exit 1" in step.get("run", "") for step in reject["steps"])
+
+
+def test_the_credentialed_job_does_not_start_at_all(workflow):
+    """The reject job going red does not stop this one; only its own `if` does.
+
+    The two are siblings, not a sequence. Leaving this guard off would give a
+    run that is red *and* has already spent.
+    """
+    assert workflow["jobs"]["batch-run"]["if"] == (
+        "needs.inspect-mode.outputs.uses_agentic != 'true' && "
+        "needs.inspect-mode.outputs.codex_blocked != 'true'"
+    )
+
+
+def test_the_second_parser_stops_the_job_before_a_credential_is_used(workflow):
+    """For the one case the credential-free job cannot cover: disagreement.
+
+    inspect-mode reads the experiment with Ruby's YAML; ``read_config`` reads it
+    with ``ExperimentConfig``, the parser the run itself uses. If the second
+    sees a Codex experiment the first missed, this job is already running, so
+    the stop has to be inside it and ahead of everything it holds.
+    """
+    steps = _batch_steps(workflow)
+    names = [step.get("name", "") for step in steps]
+    block = names.index(
+        "Block unconfirmed codex_foundry in credentialed general workflow"
+    )
+    assert steps[block]["if"] == (
+        "steps.read_config.outputs.uses_codex_foundry == 'true' && "
+        "needs.inspect-mode.outputs.codex_confirmed != 'true'"
+    )
+    assert "exit 1" in steps[block]["run"]
+    credentialed = [
+        index
+        for index, step in enumerate(steps)
+        if "azure/login" in str(step.get("uses", ""))
+        or any(
+            name.endswith(("_API_KEY", "_TOKEN", "_CLIENT_ID"))
+            for name in (step.get("env") or {})
+        )
+    ]
+    assert credentialed
+    assert block < min(credentialed)
+
+
+# ── What the decision opens ────────────────────────────────────────────────
+
+
+def test_the_variable_is_set_from_the_box_and_never_from_the_block(workflow):
+    """The whole point of the gate, and the one place it could leak.
+
+    ``codex_blocked`` is false when the box was ticked *and* when the Ruby did
+    not think this was Codex at all. Only the first means somebody decided, so
+    the expression reads ``codex_confirmed``. If the two parsers ever disagree,
+    this stays empty -- and empty is what
+    ``_require_runnable_execution_mode`` refuses on.
+    """
+    step2a = next(
+        step for step in _batch_steps(workflow) if step.get("id") == "step2a"
+    )
+    expression = step2a["env"]["CODEX_FOUNDRY_CONNECTION_CONFIRMED"]
+    assert expression == (
+        "${{ steps.read_config.outputs.uses_codex_foundry == 'true' && "
+        "needs.inspect-mode.outputs.codex_confirmed == 'true' && '1' || '' }}"
+    )
+    assert "codex_blocked" not in expression
+    # '1' is not decoration: the reader compares against exactly that.
+    source = (ROOT / "batch-runner" / "step2_run_inference.py").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        'os.getenv("CODEX_FOUNDRY_CONNECTION_CONFIRMED", "").strip() == "1"'
+        in source
+    )
+
+
+def test_the_config_parser_publishes_the_mode_the_expression_reads(workflow):
+    read_config = _named_step(workflow, "Read experiment config flags")
+    assert '"uses_codex_foundry": str(mode == "codex_foundry").lower()' in (
+        read_config["run"]
+    )
+
+
+# ── And every leg after the first ──────────────────────────────────────────
+
+
+def test_the_relay_forwards_every_input_it_was_given(workflow, dispatch_inputs):
+    """Checked for all of them, because the next one added has this bug too.
+
+    A relay leg is the same run continuing. An input that is not forwarded is a
+    run that spends on leg 0 and is refused on leg 1 -- worse than either
+    outcome on its own, and invisible until it happens.
+    """
+    relay = _named_step(workflow, "Retrigger relay run")
+    forwarded = set(re.findall(r"-f ([a-z_]+)=", relay["run"]))
+    assert forwarded == set(dispatch_inputs)
+
+
+def test_the_relay_forwards_it_through_the_environment(workflow):
+    """No step in this workflow interpolates an input into a shell script.
+
+    Pinned here as well as in ``test_agentic_workflows`` because this change
+    adds a forwarded value, and a forwarded value is exactly the thing somebody
+    would reach for ``${{ inputs. }}`` to write.
+    """
+    relay = _named_step(workflow, "Retrigger relay run")
+    assert '-f codex_foundry_confirmed="$CODEX_FOUNDRY_CONFIRMED_INPUT"' in (
+        relay["run"]
+    )
+    assert workflow["jobs"]["batch-run"]["env"][
+        "CODEX_FOUNDRY_CONFIRMED_INPUT"
+    ] == "${{ inputs.codex_foundry_confirmed }}"
+    assert all(
+        "${{ inputs." not in str(step.get("run", ""))
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+    )

--- a/batch-runner/tests/test_agentic_workflows.py
+++ b/batch-runner/tests/test_agentic_workflows.py
@@ -60,8 +60,16 @@ def test_general_batch_blocks_agentic_before_any_credential_step():
         "needs.inspect-mode.outputs.uses_agentic == 'true'"
     )
     assert batch_job["needs"] == "inspect-mode"
+    # The agentic guard is one conjunct of this now rather than the whole of
+    # it: codex_foundry gained a gate of its own, checked in the same
+    # credential-free job and asserted in
+    # test_a_batch_dispatch_can_open_the_codex_gate.py. Kept as an equality so
+    # that a later change to either guard is visible here, and the agentic half
+    # asserted separately so that what this test is *for* survives the wording.
+    assert "needs.inspect-mode.outputs.uses_agentic != 'true'" in batch_job["if"]
     assert batch_job["if"] == (
-        "needs.inspect-mode.outputs.uses_agentic != 'true'"
+        "needs.inspect-mode.outputs.uses_agentic != 'true' && "
+        "needs.inspect-mode.outputs.codex_blocked != 'true'"
     )
     batch_checkout = next(
         step for step in steps if step.get("name") == "Checkout"

--- a/batch-runner/tests/test_three_more_run_places.py
+++ b/batch-runner/tests/test_three_more_run_places.py
@@ -187,6 +187,11 @@ def test_the_codex_blockers_are_about_the_task_not_about_the_connection():
         # so that neither can come back as a reason after being built.
         "no experiment asks for this place",
         "the configuration cannot reach the runner",
+        # Cleared by the change that added the codex_foundry_confirmed
+        # dispatch input. The gate is still shut by default and a person still
+        # opens it, which is why a blocker still describes it -- but "there is
+        # no way to open it" is a different claim and it is no longer true.
+        "batch-run.yml does not set it",
     )
     for reason in reasons:
         for phrase in retired:

--- a/scripts/__tests__/onboarding-contract.test.mjs
+++ b/scripts/__tests__/onboarding-contract.test.mjs
@@ -257,6 +257,7 @@ test('workflow input tables mirror defaults and watchdog delegation', async () =
     'source_sha',
     'wall_timeout',
     'sandbox_image_digest',
+    'codex_foundry_confirmed',
   ]
   assert.deepEqual(Object.keys(inputs), inputNames)
   assert.deepEqual(
@@ -268,8 +269,17 @@ test('workflow input tables mirror defaults and watchdog delegation', async () =
       source_sha: '',
       wall_timeout: 290,
       sandbox_image_digest: '',
+      codex_foundry_confirmed: false,
     },
   )
+  // Off is the whole point of this one, so the default is asserted above like
+  // every other and the description is asserted here: a reader ticking a box
+  // that may spend has to be able to see, in the dispatch form itself, that
+  // every other mode ignores it and that leaving it alone fails the run rather
+  // than quietly skipping it.
+  assert.match(inputs.codex_foundry_confirmed.description, /^codex_foundry only/)
+  assert.match(inputs.codex_foundry_confirmed.description, /Ignored by every other mode/)
+  assert.match(inputs.codex_foundry_confirmed.description, /fails before any credentialed job starts/)
   assert.match(inputs.wall_timeout.description, /^condition_a Step 2 watchdog minutes/)
   assert.match(inputs.wall_timeout.description, /0\.\.290/)
   assert.match(inputs.wall_timeout.description, /0=use execution\.wall_timeout from YAML/)


### PR DESCRIPTION
## What this changes

`step2_run_inference._require_runnable_execution_mode` refuses `execution.mode: codex_foundry` unless `CODEX_FOUNDRY_CONNECTION_CONFIRMED` is set. #495 gave an experiment a way to *ask* for that mode. Nothing had a way to *set* the variable, so the mode was still unreachable from the general batch workflow no matter what an experiment asked for.

This adds the one dispatch input that opens it — `codex_foundry_confirmed`, default `false` — and decides on it in the job that holds no credentials.

## The three properties this pins

**1. The decision happens before any credentialed job starts.**

`inspect-mode` already parses the experiment YAML with `permissions: {contents: read}` and a `persist-credentials: false` checkout, to decide whether the run is agentic. It now also decides whether the run is `codex_foundry` and whether the box was ticked, and publishes both as job outputs. `batch-run` gains a second conjunct in its `if`:

```yaml
if: needs.inspect-mode.outputs.uses_agentic != 'true' && needs.inspect-mode.outputs.codex_blocked != 'true'
```

**2. An unconfirmed dispatch fails rather than skipping.**

`reject-unconfirmed-codex` is shaped exactly like the existing `reject-agentic`: no `uses:`, `contents: read`, `exit 1`. A skipped job reads as "nothing to do", which is the wrong report for "somebody has to decide this batch may spend". The rejection message says what the box is and is not — the connection question was answered by run `34465567349` (`verdict: connected`, 10,970 in / 24 out / 17 reasoning); the box is about a *batch*, which is a different order of spend from 24 output tokens.

**3. The variable is derived from the box, never from the block.**

This one is worth reading closely, because my first draft got it wrong.

I initially keyed the Step 2a environment off `codex_blocked == 'false'`. That is a leak. `codex_blocked` is false in **two** situations: the box was ticked, *or* the credential-free Ruby parser did not see a Codex experiment. So a run where Ruby misses the mode, Python catches it, and nobody ticked anything would have set `CODEX_FOUNDRY_CONNECTION_CONFIRMED=1`.

The fix publishes a separate normalised `codex_confirmed` output carrying the box alone, and the environment expression requires **both** halves independently:

```yaml
CODEX_FOUNDRY_CONNECTION_CONFIRMED: ${{ steps.read_config.outputs.uses_codex_foundry == 'true' && needs.inspect-mode.outputs.codex_confirmed == 'true' && '1' || '' }}
```

and a new in-job step — placed after the agentic block and before the first credential step — fails the run for exactly the disagreement case:

```yaml
- name: 'Block unconfirmed codex_foundry in credentialed general workflow'
  if: steps.read_config.outputs.uses_codex_foundry == 'true' && needs.inspect-mode.outputs.codex_confirmed != 'true'
```

`test_the_variable_is_set_from_the_box_and_never_from_the_block` asserts `"codex_blocked" not in expression`, so the shortcut cannot come back.

## Two smaller things that would otherwise bite

**The Actions boolean trap.** `inputs.codex_foundry_confirmed` is a real boolean for `workflow_dispatch`, but read through an env var it arrives as the *text* `"true"`/`"false"`. A job-level `if` comparing text to `true` casts the text to a number, gets NaN, and takes the wrong branch. The Ruby normalises once and publishes text; every comparison downstream is text-to-text. An unrecognised value `abort`s rather than defaulting.

**The relay.** `Retrigger relay run` forwards dispatch inputs to the next chunk. A new input that is not forwarded would silently close the gate mid-batch. `test_the_relay_forwards_every_input_it_was_given` now derives the expected set from the `workflow_dispatch` inputs rather than listing them, so the next input added is covered without anyone remembering to.

## Readiness record: narrowed, not dropped

`ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY` keeps **2** blockers. The gate blocker used to say there was no way to open the gate at all. That half is now false and moves to the `retired` tuple in `test_three_more_run_places.py` (`"batch-run.yml does not set it"`), so it cannot come back. What the blocker is actually about — that a person decides this batch may spend — is unchanged, so the blocker stays, reworded, and gains evidence naming the new input and the new test.

The status stays `structure_check_only`. **This PR does not make the mode runnable.** It makes it dispatchable. The remaining blocker is the one the fixed-5 run exists to clear: no task has produced a deliverable through this place against the real deployment.

## Verification

- `tests/test_a_batch_dispatch_can_open_the_codex_gate.py` + `test_agentic_workflows.py` + `test_three_more_run_places.py` → **62 passed, 6 skipped**.
- The 6 skips are the Ruby-backed truth-table tests. There is no `ruby` on my box; they `pytest.skip` there and **execute on CI's `ubuntu-latest`**, which is the environment that matters, since that is the interpreter the workflow actually uses. They drive the real `mode` script extracted from the workflow and assert the table: `(exp033, "true") → not blocked`, `(exp033, "false") → blocked`, `(exp033, "") → blocked`, `(exp998, "true"/"false") → not blocked`, plus a garbage value → non-zero exit, abort message, and **nothing written to `GITHUB_OUTPUT`**.
- YAML structure: jobs are `inspect-mode`, `reject-agentic`, `reject-unconfirmed-codex`, `batch-run`; inputs are the 8 originals plus `codex_foundry_confirmed`; agentic block at step 10, codex block at 11, first credential step at 12.
- Full backend suite result is posted in a comment below rather than claimed here.

## Shared files — plan for B

Five of the six files are shared. Sequencing per the split (A owns Codex, B owns V2; shared files go one at a time, second one integrates onto latest `main`):

| File | What A changed | What B should expect |
|---|---|---|
| `.github/workflows/batch-run.yml` | One new dispatch input; one new output block and one new `env` line in `inspect-mode`; one new sibling reject job; one conjunct added to `batch-run.if`; one new in-job block step; one key in `read_config`'s values dict; one line in the relay | Additive only. No existing step was reordered, renamed, or removed. The agentic path is untouched — `reject-agentic` and the agentic block step are byte-identical. A V2 change that adds steps will merge cleanly unless it also edits `batch-run.if` or the relay's `-f` list |
| `core/execution_environment_readiness.py` | Only the Codex environment's blocker text and evidence list | No V2 constant, status, or comparison touched |
| `tests/test_three_more_run_places.py` | One string appended to the Codex `retired` tuple | No V2 assertion touched |
| `tests/test_agentic_workflows.py` | `test_general_batch_blocks_agentic_before_any_credential_step` had an exact-equality assertion on `batch_job["if"]`. Kept as an equality (so a later change to either guard is visible here) and **added** a separate assertion that the agentic conjunct is present, so what the test is *for* survives a rewording of the codex half | If B adds a third conjunct, extend the equality the same way rather than loosening it to a substring |
| `CHANGELOG.md` | One `### Added` and one `### Changed` bullet at the top of Unreleased | Ordinary top-of-section conflict at worst |

Nothing here changes isolation, `INHERITED_ENV_NAMES`, `HOME` rewriting, or any sandbox surface.
