### PR TITLE
feat(agentic-v2): build the launch arguments the containment rules ask for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,9 +228,22 @@ entries land under a fresh dated heading the day they merge to `main`.
     makes the configuration file the whole of what the machine will ever be.
   - **`--new-pid-ns` does not write the PID file.** The plan said it did.
     `src/jailer/src/env.rs:735-740` writes it in both branches, after `chroot()`,
-    at the in-jail path `/firecracker.pid`. Both flags are still passed; only the
+    so the file lands inside the jail. Both flags are still passed; only the
     explanation was wrong, and it is the kind of wrong that surfaces as
     confusion at the moment somebody omits the flag and finds the file anyway.
+
+    Checking that correction turned up a **bug in the new module**, which is the
+    part worth recording. The PID file is named after the **exec file**, not
+    after the word: `save_exec_file_pid` appends `.pid` to the binary's own
+    name, and the jailer requires that name to *contain* `firecracker` rather
+    than to be it. So `/opt/firecracker-v1.13.1` writes
+    `/firecracker-v1.13.1.pid`, and the hard-coded `/firecracker.pid` would have
+    named a file that never appears on any host whose binary carries a version
+    suffix. Nothing would have failed — the deadline would have been recorded,
+    the plan would have hashed, and `wall_clock_seconds` would have had nothing
+    to act on at the moment it was needed. Derived from the binary now, with a
+    test that asserts it against a versioned name rather than against the
+    constant it used to be pinned to.
 
   Two gaps are named rather than papered over. The policy has no rule about
   processor share, so `vcpu_count` comes from the caller and the missing rule is
@@ -240,17 +253,19 @@ entries land under a fresh dated heading the day they merge to `main`.
   on `--netns` being absent, not on the device being missing; stage C3 should
   expect to find the node there.
 
-  81 tests, and they were checked by breaking the builder rather than by
-  passing. Fourteen deliberate mutations — the flag deleted, the host memory
+  83 tests, and they were checked by breaking the builder rather than by
+  passing. Fifteen deliberate mutations — the flag deleted, the host memory
   bound dropped to the guest's, the v1 cgroup file name used under v2, the root
-  drive made writable — each had to fail a test. Two initially did not, and both
-  were holes in the tests: `fsize=` was matched as a string anywhere in the
-  argument list, so removing the `--resource-limit` that carries it changed
-  nothing, and the in-jail paths were asserted against their own constants, so
-  moving one to a host path took the test along with it. Both now assert the
-  requirement rather than the spelling. The last survivor was the builder's own
-  backstop, which no healthy build exercises, and it now has a test that stages
-  the drop it exists for.
+  drive made writable — each had to fail a test. Three initially did not, and
+  all three were holes in the tests rather than in the builder: `fsize=` was
+  matched as a string anywhere in the argument list, so removing the
+  `--resource-limit` that carries it changed nothing; the in-jail paths were
+  asserted against their own constants, so moving one to a host path took the
+  test along with it; and the PID file was asserted against the constant that
+  turned out to be wrong, so it agreed with the bug rather than catching it.
+  All three now assert the requirement rather than the spelling. The last
+  survivor was the builder's own backstop, which no healthy build exercises, and
+  it now has a test that stages the drop it exists for.
 
 - **The containment answers a seventh question, and it was found by planning
   the test rather than by reading the rules.** Stage C's attack list has always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,21 @@ entries land under a fresh dated heading the day they merge to `main`.
   survivor was the builder's own backstop, which no healthy build exercises, and
   it now has a test that stages the drop it exists for.
 
+  One more thing broke on the way out, and it was prose rather than code.
+  Reading the generated report afterwards showed it asserting both halves of a
+  contradiction three lines apart: the new section said every rule now has an
+  argument, while the recorded azure finding above it still ended by saying no
+  code turns the policy into launch arguments. That sentence was true the day it
+  was measured and false the moment this module merged, and **nothing failed**,
+  because a recorded finding is a frozen string and no test compared it against
+  the live answer. The fix is structural rather than editorial: whether anything
+  applies the rules is a property of this repository, it changes without any
+  machine changing, and `describe_containment` already answers it live in its
+  own section — so a finding may no longer name `REQUIRED_MICROVM_POLICY` or the
+  launch module at all, and a test enforces that for every finding rather than
+  for the one that went stale. The same reach appeared in a test module's
+  docstring and is corrected there too.
+
 - **The containment answers a seventh question, and it was found by planning
   the test rather than by reading the rules.** Stage C's attack list has always
   ended with one that is not like the others: the command must not be able to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,66 @@ entries land under a fresh dated heading the day they merge to `main`.
   runner. The gate stays closed; only the reason is now true.
 
 ### Added
+- **The containment rules now have the arguments that would apply them, and
+  saying so is not the same as saying they are applied.** Stage C0 left eleven
+  rules written down in one place and nothing anywhere turning any of them into
+  an argument. `core/agentic_v2_microvm_launch.py` closes the translation half
+  of that gap: it reads `REQUIRED_MICROVM_POLICY` and returns the jailer and
+  Firecracker arguments that would enforce each rule. It starts nothing — no
+  process, no machine — which is exactly why it can be checked on a box whose
+  3.10 kernel could not boot one.
+
+  The care went into the reporting rather than the arguments. The readiness
+  report gained a fourth field for the translation,
+  `every_rule_has_an_argument_that_would_apply_it`, derived from the builder
+  against the policy rather than declared by hand, so a twelfth rule added to
+  the policy and not to the builder turns it `False` without anyone
+  remembering to. `anything_applies_the_containment_rules` **stays `False`**,
+  and the new field is deliberately not an input to
+  `available_on_any_machine_in_play`. Wiring it in would have been the obvious
+  thing and the wrong one: a recorded finding already carries
+  `could_be_hosted_anywhere`, so a `True` here would have flipped the aggregate
+  and made the report announce the containment as in place on the strength of
+  code that has never booted anything. That is the failure this module exists to
+  prevent, and it very nearly arrived through good news rather than through a
+  deletion.
+
+  Every flag was checked against **v1.13.1**, the version stage B found
+  installed, and two readings from that check contradicted the merged plan:
+
+  - **`--no-api` is required, and the plan's wording was too weak.** It said the
+    builder "emits no snapshot route". True, and not enough: pinning a device in
+    a configuration file is a statement about start-up, and with the API socket
+    live it says nothing about the rest of the run. `balloon`, `vsock` and
+    `mmds-config` can all be added back after boot, and `/snapshot/load` can
+    bring in a machine configured somewhere else entirely. `--no-api` is what
+    makes the configuration file the whole of what the machine will ever be.
+  - **`--new-pid-ns` does not write the PID file.** The plan said it did.
+    `src/jailer/src/env.rs:735-740` writes it in both branches, after `chroot()`,
+    at the in-jail path `/firecracker.pid`. Both flags are still passed; only the
+    explanation was wrong, and it is the kind of wrong that surfaces as
+    confusion at the moment somebody omits the flag and finds the file anyway.
+
+  Two gaps are named rather than papered over. The policy has no rule about
+  processor share, so `vcpu_count` comes from the caller and the missing rule is
+  written down — closing it means amending the policy in a change of its own,
+  not defaulting a number in a launcher. And the jailer `mknod`s `/dev/net/tun`
+  unconditionally, so `network: none` rests on no interface being configured and
+  on `--netns` being absent, not on the device being missing; stage C3 should
+  expect to find the node there.
+
+  81 tests, and they were checked by breaking the builder rather than by
+  passing. Fourteen deliberate mutations — the flag deleted, the host memory
+  bound dropped to the guest's, the v1 cgroup file name used under v2, the root
+  drive made writable — each had to fail a test. Two initially did not, and both
+  were holes in the tests: `fsize=` was matched as a string anywhere in the
+  argument list, so removing the `--resource-limit` that carries it changed
+  nothing, and the in-jail paths were asserted against their own constants, so
+  moving one to a host path took the test along with it. Both now assert the
+  requirement rather than the spelling. The last survivor was the builder's own
+  backstop, which no healthy build exercises, and it now has a test that stages
+  the drop it exists for.
+
 - **The containment answers a seventh question, and it was found by planning
   the test rather than by reading the rules.** Stage C's attack list has always
   ended with one that is not like the others: the command must not be able to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,8 +279,12 @@ entries land under a fresh dated heading the day they merge to `main`.
   machine changing, and `describe_containment` already answers it live in its
   own section — so a finding may no longer name `REQUIRED_MICROVM_POLICY` or the
   launch module at all, and a test enforces that for every finding rather than
-  for the one that went stale. The same reach appeared in a test module's
-  docstring and is corrected there too.
+  for the one that went stale. What the azure finding does instead is point at
+  `anything_applies_the_containment_rules` by name, and that has its own second
+  guard, because a pointer fails quietly in a way an assertion does not: a
+  rename would leave the finding naming a key no report has. Anything in a
+  finding shaped like a field name must be one. The same reach appeared in a
+  test module's docstring and is corrected there too.
 
 - **The containment answers a seventh question, and it was found by planning
   the test rather than by reading the rules.** Stage C's attack list has always

--- a/batch-runner/core/agentic_v2_containment_readiness.py
+++ b/batch-runner/core/agentic_v2_containment_readiness.py
@@ -658,9 +658,10 @@ RECORDED_FINDINGS: tuple[RecordedFinding, ...] = (
             "answers no on that fourth point until it is bootstrapped. This "
             "says the containment could be hosted, and nothing more. Whether "
             "anything applies the rules is a fact about this repository and "
-            "not about this machine, so it is left to the section below, "
-            "which answers it live, rather than frozen into a finding that "
-            "would go stale the moment the repository moved"
+            "not about this machine, so it is left to "
+            "anything_applies_the_containment_rules, which is worked out on "
+            "every run, rather than frozen into a finding that would go stale "
+            "the moment the repository moved"
         ),
         established_by=(
             "az vm run-command on gdpval-devhost-vm in rg-gdpval-devhost-krc, "

--- a/batch-runner/core/agentic_v2_containment_readiness.py
+++ b/batch-runner/core/agentic_v2_containment_readiness.py
@@ -49,6 +49,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
 from core.agentic_v2_microvm import inspect_microvm_readiness
+from core.agentic_v2_microvm_launch import rules_this_builder_accounts_for
 from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
 
 # ── What Firecracker itself says it needs ─────────────────────────────────
@@ -117,10 +118,13 @@ _POLICY_SETTING_AS_A_CLAIM = {
 
 # What has to exist before any of the settings above can be reported as met.
 #
-# Nothing in this repository turns a containment rule into an argument for
-# starting a virtual machine. core/agentic_v2_microvm.py looks for the
-# Firecracker programs on the search path and stops there; no module reads
-# REQUIRED_MICROVM_POLICY and produces a start-up configuration from it.
+# This said "nothing turns these rules into arguments" until 2026-09-10, and
+# that sentence was retired by core/agentic_v2_microvm_launch.py, which does
+# exactly that and starts nothing with them. The gap it describes did not close;
+# it moved one step. Reported as the second half rather than dropped, because
+# arguments nobody runs enforce nothing at all, and a report that let the
+# translation stand in for the launch would be making the substitution this
+# module exists to refuse.
 #
 # This matters more than it sounds. Until 2026-08-26 this report marked every
 # one of those settings as met the moment a machine could start a virtual
@@ -132,10 +136,12 @@ _POLICY_SETTING_AS_A_CLAIM = {
 # A rule nobody applies is not met. It is unenforced, which is a different
 # answer, and the report now gives that one.
 NOTHING_APPLIES_THESE_RULES_YET = (
-    "no module turns core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY into "
-    "arguments for starting a virtual machine, so this rule is written down "
-    "and unenforced rather than met. core.agentic_v2_microvm only looks for "
-    "the Firecracker programs; it applies nothing"
+    "core.agentic_v2_microvm_launch turns "
+    "core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY into the jailer and "
+    "Firecracker arguments that would apply this rule, and nothing runs them: "
+    "it returns a document and starts no process. So this rule is written down "
+    "and unenforced rather than met — one step nearer than it was, the "
+    "translation existing and the launch not"
 )
 
 
@@ -748,13 +754,21 @@ def containment_answer_everywhere(
         Is there a machine that could start the containment? Fixed by finding,
         configuring or building one.
     ``anything_applies_the_containment_rules``
-        Does any code turn the rules into arguments for starting it? Fixed by
-        writing that code. False today, on every machine, for the reason in
+        Does any code start a machine with these rules applied? Fixed by writing
+        that code. False today, on every machine, for the reason in
         :data:`NOTHING_APPLIES_THESE_RULES_YET`.
     ``available_on_any_machine_in_play``
         Is the containment actually in place anywhere? Needs both of the above,
         so it is false today and would stay false if a perfect machine appeared
         tomorrow.
+
+    A fourth reports how far the third has got.
+    ``every_rule_has_an_argument_that_would_apply_it`` asks whether the
+    translation from rule to argument exists and covers every rule — which since
+    2026-09-10 it does. It is deliberately not the same question as the second
+    one and deliberately not an input to the third: arguments nobody runs
+    enforce nothing, and folding the two together is how a containment comes to
+    read as available on the strength of code that starts nothing.
 
     ``every_machine_in_play_has_an_answer`` is ``None`` rather than ``True``
     when no workflows directory was given, because in that case nothing looked.
@@ -768,10 +782,17 @@ def containment_answer_everywhere(
     could_be_hosted_anywhere = here.machine_could_host_it or any(
         finding.could_host_the_containment is True for finding in RECORDED_FINDINGS
     )
-    # Not a machine fact and so not read off one. A rule is applied by code, and
-    # no code here applies these; if that changes, this changes with it and so
-    # does everything below.
+    # Not a machine fact and so not read off one. A rule is applied by starting
+    # a machine with it, and nothing here starts one; if that changes, this
+    # changes with it and so does everything below.
     anything_applies_the_rules = False
+    # Derived rather than declared, and derived from the set of rules the
+    # builder accounts for rather than from its existence. A rule added to the
+    # policy and not to the builder turns this false on its own, which is the
+    # only version of this answer worth reporting.
+    every_rule_has_an_argument = rules_this_builder_accounts_for() >= set(
+        REQUIRED_MICROVM_POLICY
+    )
     gaps = (
         check_every_machine_has_a_containment_finding(workflows_directory)
         if workflows_directory is not None
@@ -786,6 +807,7 @@ def containment_answer_everywhere(
             None if workflows_directory is None else not gaps
         ),
         "could_be_hosted_on_any_machine_in_play": could_be_hosted_anywhere,
+        "every_rule_has_an_argument_that_would_apply_it": every_rule_has_an_argument,
         "anything_applies_the_containment_rules": anything_applies_the_rules,
         "available_on_any_machine_in_play": (
             could_be_hosted_anywhere and anything_applies_the_rules
@@ -880,11 +902,18 @@ def describe_containment(report: Mapping[str, Any]) -> list[str]:
 
     lines.append("Whether anything applies the rules, on any machine")
     lines.append("-" * 74)
-    if report["anything_applies_the_containment_rules"]:
+    if report["every_rule_has_an_argument_that_would_apply_it"]:
         lines.append(
-            "  Something now turns the containment rules into arguments for "
-            "starting the machine."
+            "  Every rule now has an argument that would apply it: "
+            "core.agentic_v2_microvm_launch builds them."
         )
+    else:
+        lines.append(
+            "  Some rule has no argument that would apply it, so the "
+            "translation is incomplete."
+        )
+    if report["anything_applies_the_containment_rules"]:
+        lines.append("  Something starts a machine with those arguments.")
     else:
         lines.append(f"  Nothing does: {NOTHING_APPLIES_THESE_RULES_YET}.")
         lines.append(

--- a/batch-runner/core/agentic_v2_containment_readiness.py
+++ b/batch-runner/core/agentic_v2_containment_readiness.py
@@ -656,10 +656,11 @@ RECORDED_FINDINGS: tuple[RecordedFinding, ...] = (
             "firecracker and jailer programs are not on the image and were "
             "installed during the measurement, so a freshly deployed host "
             "answers no on that fourth point until it is bootstrapped. This "
-            "says the containment could be hosted, and nothing more: no code "
-            "turns REQUIRED_MICROVM_POLICY into arguments for starting a "
-            "virtual machine, so on this machine too the rules are written "
-            "down and unapplied"
+            "says the containment could be hosted, and nothing more. Whether "
+            "anything applies the rules is a fact about this repository and "
+            "not about this machine, so it is left to the section below, "
+            "which answers it live, rather than frozen into a finding that "
+            "would go stale the moment the repository moved"
         ),
         established_by=(
             "az vm run-command on gdpval-devhost-vm in rg-gdpval-devhost-krc, "
@@ -915,7 +916,15 @@ def describe_containment(report: Mapping[str, Any]) -> list[str]:
     if report["anything_applies_the_containment_rules"]:
         lines.append("  Something starts a machine with those arguments.")
     else:
-        lines.append(f"  Nothing does: {NOTHING_APPLIES_THESE_RULES_YET}.")
+        # Not NOTHING_APPLIES_THESE_RULES_YET itself: that sentence is worded
+        # for a single rule's verdict ("this rule"), which has no antecedent
+        # here, and it would restate the line directly above it. It is still
+        # printed once per rule under "The answer".
+        lines.append(
+            "  Nothing runs those arguments: the builder returns a document "
+            "and starts no process, so the rules stay written down and "
+            "unenforced rather than met."
+        )
         lines.append(
             "  This is the same on every machine, because it is a fact about "
             "this repository rather than about any machine."

--- a/batch-runner/core/agentic_v2_microvm.py
+++ b/batch-runner/core/agentic_v2_microvm.py
@@ -1,4 +1,12 @@
-"""Model-free readiness report for a future Firecracker containment plane."""
+"""Model-free readiness report for a future Firecracker containment plane.
+
+Four of the fields below used to be containment values written out as literals,
+which made this the fourth place stating one set of rules and the only one no
+check compared against the others. They read
+:data:`core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY` now. The values are
+unchanged, so no report already recorded by its ``report_sha256`` says anything
+different than it did.
+"""
 
 from __future__ import annotations
 
@@ -9,7 +17,7 @@ import stat
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-from core.agentic_v2_substrate import canonical_sha256
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY, canonical_sha256
 
 
 def inspect_microvm_readiness(
@@ -50,14 +58,14 @@ def inspect_microvm_readiness(
         "schema_version": "1.0",
         "foundation_only": True,
         "production_activation": "disabled",
-        "runtime": "firecracker",
+        "runtime": REQUIRED_MICROVM_POLICY["runtime"],
         "status": "ready_for_boot_test" if ready else "not_run",
         "checks": checks,
         "tools": tools,
         "assets": assets,
-        "network": "none",
-        "rootfs_mode": "read-only",
-        "workdir": "ephemeral-quota",
+        "network": REQUIRED_MICROVM_POLICY["network"],
+        "rootfs_mode": REQUIRED_MICROVM_POLICY["rootfs"],
+        "workdir": REQUIRED_MICROVM_POLICY["workdir"],
     }
     report["report_sha256"] = canonical_sha256(report)
     return report
@@ -85,10 +93,10 @@ def validate_microvm_readiness_report(value: Any) -> dict[str, Any]:
         document["schema_version"] != "1.0"
         or document["foundation_only"] is not True
         or document["production_activation"] != "disabled"
-        or document["runtime"] != "firecracker"
-        or document["network"] != "none"
-        or document["rootfs_mode"] != "read-only"
-        or document["workdir"] != "ephemeral-quota"
+        or document["runtime"] != REQUIRED_MICROVM_POLICY["runtime"]
+        or document["network"] != REQUIRED_MICROVM_POLICY["network"]
+        or document["rootfs_mode"] != REQUIRED_MICROVM_POLICY["rootfs"]
+        or document["workdir"] != REQUIRED_MICROVM_POLICY["workdir"]
         or set(document["checks"]) != {"firecracker", "jailer", "kvm", "kernel", "rootfs"}
         or any(type(item) is not bool for item in document["checks"].values())
         or set(document["tools"]) != {"firecracker", "jailer"}

--- a/batch-runner/core/agentic_v2_microvm_launch.py
+++ b/batch-runner/core/agentic_v2_microvm_launch.py
@@ -1,0 +1,614 @@
+"""The containment rules, turned into the arguments that would apply them.
+
+Every rule in :data:`core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY` has been
+written down since 2026-08-26 and applied by nothing. That gap is what
+core/agentic_v2_containment_readiness.py reports and what stage C exists to
+close: a rule nobody turns into an argument is not a rule that is met, it is a
+rule that is unenforced, and a report that confuses the two is worse than no
+report.
+
+This module closes the first half of it. It reads the policy and produces the
+arguments ``jailer`` and ``firecracker`` would actually be given — and it starts
+nothing. No process is spawned, no file is written, no directory is created. It
+returns a document. Running that document is stage C2's job, on a host that has
+been measured, and keeping the two apart is deliberate: the mapping from rule to
+argument is the part that can be checked here, on a machine that could not host
+a virtual machine if it tried.
+
+**Why a builder can be checked when a boot cannot.** The tests beside this file
+read the built arguments and fail when a rule is missing from them. That is a
+real check with a real failure mode — the one this stage is named for, a rule
+that reads as enforced and is not — and it needs no hardware. What it does not
+do is prove the arguments have the effect their names suggest. Only C2 and C3
+can do that, and they say so.
+
+**This does not become a fourth copy of the policy.** core/agentic_v2_microvm.py
+held containment values as literals, which made four places stating one set of
+rules; that copy is taken with this change, and it reads the policy now.
+:data:`_WHAT_THIS_BUILDER_CAN_EXPRESS` below is not a fifth. It does not say
+what a rule is — it says which values this builder knows how to turn into an
+argument, and anything outside it is a refusal rather than a different set of
+arguments. A copy asserts the rule; a reach asserts the builder.
+
+**Everything here was read from Firecracker v1.13.1**, the version stage B found
+installed on the Azure dev host, rather than from the development branch where a
+flag can exist that the deployed binary does not have. Four readings shaped the
+result and none of them was obvious from the policy:
+
+* The jailer's chroot is ``<chroot-base>/<exec-file-name>/<id>/root``, and the
+  configuration file *and every path inside it* must be valid **relative to the
+  jailed Firecracker**. So the configuration names in-jail paths, and the plan
+  carries a separate list of what has to be placed inside the jail first.
+* ``--no-api`` exists, takes no value, and requires ``--config-file``. Without
+  it Firecracker serves its whole API on a socket for the life of the machine,
+  and every device pinned below can be added back through it after boot —
+  including ``/snapshot/load``. Pinning a device in a configuration file is a
+  statement about start-up; ``--no-api`` is what makes it a statement about the
+  run.
+* ``--resource-limit fsize=`` is documented in **bytes**.
+* The PID file is written whether or not ``--new-pid-ns`` is passed — the plan
+  for this stage said otherwise and was corrected. What ``--new-pid-ns`` buys is
+  the namespace; the file is written in both branches, at in-jail
+  ``/firecracker.pid``, which is ``<chroot-dir>/firecracker.pid`` from outside.
+
+**Two things this module cannot express, named rather than papered over.**
+
+*The policy has no rule about processor share.* It bounds memory, disk, clock,
+network, filesystem, user and credentials, and says nothing about how many
+virtual CPUs a command gets. Firecracker requires the number, so it is taken as
+an argument from the caller and validated as a positive integer — but a caller
+choosing it freely is a real gap in a containment that bounds memory by rule. It
+is not fixed here: adding a rule belongs in a change of its own, the same way
+the credential rule was added, not in the change that discovers it.
+
+*The jail always contains a ``/dev/net/tun`` device node.* The jailer creates it
+with ``mknod`` unconditionally, before it knows anything about the
+configuration. ``network: none`` therefore rests on no interface being
+configured and no network namespace being joined, not on the device being
+absent. That is worth knowing before someone reads the node as a network and
+before someone reads its absence as the mechanism.
+
+Nothing here calls a model, runs a command, or spends money.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from core.agentic_v2_microvm import inspect_microvm_readiness
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY, canonical_sha256
+
+A_MEBIBYTE = 1024 * 1024
+
+JAILER_DEFAULT_CHROOT_BASE = "/srv/jailer"
+"""Where the jailer builds chroots when it is not told otherwise.
+
+Its own documented default. Repeated here because the plan has to name the
+directory the images are placed in, and a plan that inherited the default
+silently would name a directory nobody chose.
+"""
+
+HOST_SIDE_MEMORY_OVERHEAD_MIB = 256
+"""How much the host-side memory bound is allowed above the guest's own.
+
+Picked, not derived, and it has to be above zero for the bound to be correct at
+all. ``--cgroup memory.max=`` bounds the whole Firecracker process, which is the
+guest's memory *plus* the virtual machine monitor's own footprint. A host bound
+set equal to the guest bound would kill the monitor rather than the command that
+exceeded its memory, which is the same class of mistake as a disk smaller than
+the writes the tool layer accepts: a limit that fires as the wrong limit.
+
+Generous on purpose. The guest cannot exceed ``memory_mib`` regardless — that
+bound is enforced inside the machine — so this one is a backstop against the
+monitor itself, not a second ceiling on the command.
+"""
+
+IN_JAIL_KERNEL = "/vmlinux"
+IN_JAIL_ROOTFS = "/rootfs.ext4"
+IN_JAIL_WORK_DISK = "/work.ext4"
+IN_JAIL_CONFIG = "/vmconfig.json"
+IN_JAIL_PID_FILE = "/firecracker.pid"
+
+DEVICES_THAT_MUST_BE_ABSENT: dict[str, str] = {
+    "balloon": "memory_mib — a balloon device reshapes guest memory at runtime, "
+    "and it is the only mechanism in this Firecracker that does",
+    "mmds-config": "network: none, by a route that is not a network interface — "
+    "MMDS is a metadata service the guest reads over HTTP, and it is the "
+    "standard way host-side data is handed to a guest",
+    "vsock": "network: none — a host-to-guest socket is a channel whether or "
+    "not it is a network interface",
+}
+"""Three devices no rule names, each of which can defeat a rule that is named.
+
+Read off Firecracker's own configuration fixtures rather than assumed. They are
+not added to the policy because they are not rules about what the containment
+allows; they are devices that must be absent for the rules it already has to
+mean what they say. If that reasoning is wrong, the fix is a change that adds
+them to the policy, not a quiet reliance on a default.
+"""
+
+FLAGS_THAT_WOULD_WEAKEN_THE_JAIL: dict[str, str] = {
+    "--netns": "network: none — joining a network namespace gives the machine "
+    "the interfaces in it",
+    "--no-seccomp": "every rule — Firecracker's own documentation calls this "
+    "'not recommended', and it removes the syscall filter the containment "
+    "sits on top of",
+    "--metadata": "network: none — this loads MMDS content from a file, which "
+    "is the mmds-config device arriving as a command-line flag instead",
+}
+"""Flags that exist, would be accepted, and would each undo a rule.
+
+Checked by name against the built arguments rather than trusted to be absent,
+because the way a boundary is usually lost is that somebody adds a flag to make
+one thing work and nobody reads the whole command line again.
+"""
+
+CGROUP_MEMORY_FILE_BY_VERSION: dict[int, str] = {
+    1: "memory.limit_in_bytes",
+    2: "memory.max",
+}
+"""What the memory bound is called in each cgroup hierarchy.
+
+The jailer takes ``--cgroup <cgroup_file>=<value>`` and writes the value to that
+file under the hierarchy ``--cgroup-version`` selects. The file name is supplied
+by the caller and is *not* translated: its own parser requires
+``<controller>.<property>`` and takes the rest on trust. So a launcher that
+passes ``--cgroup-version 2`` with v1's name asks for a file that does not exist
+in that hierarchy — a memory bound that reads as enforced and is not, arriving
+through a name rather than through a deletion.
+
+``--cgroup-version`` itself defaults to ``1`` in v1.13.1, while the host stage B
+measured runs Ubuntu 24.04, which has used the v2 unified hierarchy since 21.10.
+So the version is passed explicitly and never inherited, and C2 reads it off the
+host before anything is launched rather than assuming the distribution default.
+"""
+
+_WHAT_THIS_BUILDER_CAN_EXPRESS: dict[str, frozenset[Any]] = {
+    "required": frozenset({True}),
+    "runtime": frozenset({"firecracker"}),
+    "network": frozenset({"none"}),
+    "rootfs": frozenset({"read-only"}),
+    "workdir": frozenset({"ephemeral-quota"}),
+    "user": frozenset({"jailer-unprivileged"}),
+    "credentials": frozenset({"none-inherited"}),
+    "on_breach": frozenset({"stop-and-report"}),
+}
+"""Which values of each rule this builder knows how to turn into an argument.
+
+Not a copy of the policy. The policy says what the rule *is*; this says what
+this module can *do*, and every value outside it is a refusal rather than a
+different set of arguments. The difference matters when a rule is weakened: a
+copy would be updated to match and go on emitting, where a reach makes the
+builder stop and name the rule it cannot express.
+
+The three numeric rules are absent because their reach is a shape rather than a
+set — a positive integer — and they are checked as one.
+"""
+
+_NUMERIC_RULES = ("workdir_quota_mib", "memory_mib", "wall_clock_seconds")
+
+
+class LaunchRefused(ValueError):
+    """Refusal to build arguments, naming the rule that could not be expressed.
+
+    ``on_breach: stop-and-report`` is a rule about what happens when a limit is
+    exceeded, and the same answer applies one step earlier: a builder that
+    cannot express a rule stops and says which one, rather than emitting the
+    other ten and leaving the eleventh to be noticed by whoever reads the
+    command line.
+    """
+
+    def __init__(self, rule: str, why: str) -> None:
+        super().__init__(f"containment rule {rule!r} cannot be applied: {why}")
+        self.rule = rule
+        self.why = why
+
+
+def build_launch_plan(
+    *,
+    vm_id: str,
+    firecracker_binary: str | Path,
+    kernel_path: str | Path,
+    rootfs_path: str | Path,
+    work_disk_path: str | Path,
+    uid: int,
+    gid: int,
+    vcpu_count: int,
+    cgroup_version: int,
+    chroot_base: str | Path = JAILER_DEFAULT_CHROOT_BASE,
+    policy: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Turn the containment rules into the arguments that would apply them.
+
+    Returns a document and starts nothing. Every rule in the policy appears in
+    ``rules_applied`` with a sentence saying where it went, and the builder
+    refuses rather than returning a document with a rule missing from it.
+
+    ``vcpu_count`` is taken from the caller because the policy does not bound
+    processor share — see the module docstring, where that gap is named rather
+    than filled here.
+
+    ``cgroup_version`` has no default on purpose. Inheriting the jailer's own
+    default of ``1`` on a host running the v2 hierarchy is exactly the failure
+    this module is meant to make impossible.
+    """
+    rules = dict(REQUIRED_MICROVM_POLICY if policy is None else policy)
+
+    missing = sorted(set(REQUIRED_MICROVM_POLICY) - set(rules))
+    if missing:
+        raise LaunchRefused(
+            missing[0],
+            "it is not in the policy this builder was given, and a containment "
+            "with a rule missing is not the containment that was written down",
+        )
+    unknown = sorted(set(rules) - set(REQUIRED_MICROVM_POLICY))
+    if unknown:
+        raise LaunchRefused(
+            unknown[0],
+            "the policy has gained a rule this builder does not know how to "
+            "turn into an argument. Teach it here before relying on these "
+            "arguments, rather than emitting the rest without it",
+        )
+
+    for rule, reach in _WHAT_THIS_BUILDER_CAN_EXPRESS.items():
+        if rules[rule] not in reach:
+            raise LaunchRefused(
+                rule,
+                f"this builder can express {sorted(map(repr, reach))} and the "
+                f"policy says {rules[rule]!r}",
+            )
+    for rule in _NUMERIC_RULES:
+        value = rules[rule]
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise LaunchRefused(
+                rule, f"a limit has to be a positive whole number, not {value!r}"
+            )
+
+    _refuse_a_bad_identity(vm_id)
+    firecracker_binary = Path(firecracker_binary)
+    if rules["runtime"] not in firecracker_binary.name:
+        raise LaunchRefused(
+            "runtime",
+            f"the jailer requires the name of its --exec-file to contain "
+            f"{rules['runtime']!r}, and it was given "
+            f"{firecracker_binary.name!r}",
+        )
+    for label, value in (("uid", uid), ("gid", gid)):
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise LaunchRefused(
+                "user",
+                f"{label} {value!r} is not an unprivileged account — 0 is root "
+                "and anything else here is not an account at all",
+            )
+    if not isinstance(vcpu_count, int) or isinstance(vcpu_count, bool):
+        raise LaunchRefused("runtime", f"vcpu_count {vcpu_count!r} is not a number")
+    if vcpu_count <= 0:
+        raise LaunchRefused("runtime", f"vcpu_count {vcpu_count!r} is not a count")
+    if cgroup_version not in CGROUP_MEMORY_FILE_BY_VERSION:
+        raise LaunchRefused(
+            "memory_mib",
+            f"cgroup version {cgroup_version!r} is not one this jailer supports, "
+            f"so there is no file to write the host-side memory bound to",
+        )
+
+    asset_paths = {"kernel": Path(kernel_path), "rootfs": Path(rootfs_path)}
+    host_reading = inspect_microvm_readiness(asset_paths=asset_paths)
+    for name in sorted(asset_paths):
+        if host_reading["assets"][name]["status"] != "present":
+            raise LaunchRefused(
+                "runtime",
+                f"the {name} image is not a readable file at "
+                f"{str(asset_paths[name])!r}, so there is nothing to boot",
+            )
+
+    chroot_dir = (
+        Path(chroot_base) / firecracker_binary.name / vm_id / "root"
+    ).as_posix()
+
+    config = _firecracker_configuration(rules, vcpu_count=vcpu_count)
+    reopened = devices_that_would_reopen_a_closed_rule(config)
+    if reopened:
+        raise LaunchRefused(
+            "network", "the configuration names " + ", ".join(reopened)
+        )
+
+    argv = _jailer_arguments(
+        rules,
+        vm_id=vm_id,
+        firecracker_binary=firecracker_binary,
+        chroot_base=chroot_base,
+        uid=uid,
+        gid=gid,
+        cgroup_version=cgroup_version,
+    )
+    weakened = flags_that_would_weaken_the_jail(argv)
+    if weakened:
+        raise LaunchRefused("required", "the arguments name " + ", ".join(weakened))
+
+    plan: dict[str, Any] = {
+        "schema_version": "1.0",
+        "starts_nothing": True,
+        "vm_id": vm_id,
+        "policy_sha256": canonical_sha256(dict(rules)),
+        "host_reading_sha256": host_reading["report_sha256"],
+        "host_could_run_this": host_reading["status"] == "ready_for_boot_test",
+        "jailer": {"program": "jailer", "argv": argv},
+        "firecracker": {"config": config},
+        "place_in_jail": [
+            {
+                "in_jail": IN_JAIL_KERNEL,
+                "how": "copy",
+                "from_host": Path(kernel_path).as_posix(),
+                "sha256": host_reading["assets"]["kernel"]["sha256"],
+                "writable_by_the_jailed_user": False,
+            },
+            {
+                "in_jail": IN_JAIL_ROOTFS,
+                "how": "copy",
+                "from_host": Path(rootfs_path).as_posix(),
+                "sha256": host_reading["assets"]["rootfs"]["sha256"],
+                "writable_by_the_jailed_user": False,
+            },
+            {
+                "in_jail": IN_JAIL_WORK_DISK,
+                "how": "create-empty",
+                "from_host": Path(work_disk_path).as_posix(),
+                "size_mib": rules["workdir_quota_mib"],
+                "writable_by_the_jailed_user": True,
+            },
+            {
+                "in_jail": IN_JAIL_CONFIG,
+                "how": "write",
+                "from_host": None,
+                "writable_by_the_jailed_user": False,
+            },
+        ],
+        "host_side": {
+            "chroot_dir": chroot_dir,
+            "pid_file": (Path(chroot_dir) / IN_JAIL_PID_FILE.lstrip("/")).as_posix(),
+            "deadline_seconds": rules["wall_clock_seconds"],
+            "on_deadline": rules["on_breach"],
+            "destroy_after_the_run": [chroot_dir],
+        },
+        "devices_pinned": {name: None for name in sorted(DEVICES_THAT_MUST_BE_ABSENT)},
+        "rules_applied": _where_each_rule_went(cgroup_version=cgroup_version),
+    }
+
+    unaccounted = sorted(set(rules) - set(plan["rules_applied"]))
+    if unaccounted:
+        raise LaunchRefused(
+            unaccounted[0],
+            "the builder produced arguments without accounting for this rule, "
+            "which is the silent drop these refusals exist to prevent",
+        )
+
+    plan["plan_sha256"] = canonical_sha256(plan)
+    return plan
+
+
+def rules_this_builder_accounts_for() -> frozenset[str]:
+    """Which containment rules this builder turns into an argument.
+
+    Asked by core/agentic_v2_containment_readiness.py, which reports how far the
+    translation from rule to argument has got. It asks for the set rather than
+    for a yes, so that a rule added to the policy and not to this builder turns
+    that report's answer to no by itself, rather than waiting for somebody to
+    notice.
+
+    This is emphatically not the same question as whether the rules are applied.
+    Nothing here starts a machine, and a rule with an argument nobody runs is
+    still unenforced.
+    """
+    return frozenset(
+        # Only the keys leave this function. The cgroup version changes the file
+        # name inside the sentences and never which rules there are sentences
+        # for, so any supported version answers this question identically.
+        _where_each_rule_went(cgroup_version=sorted(CGROUP_MEMORY_FILE_BY_VERSION)[0])
+    )
+
+
+def devices_that_would_reopen_a_closed_rule(config: Mapping[str, Any]) -> list[str]:
+    """Which of the three devices a Firecracker configuration names.
+
+    Written as a check over a configuration rather than as an assertion about
+    the one built here, so C3 can run it against a configuration read back off
+    the host and get the same answer. A device is named if its key is present at
+    all: ``"vsock": null`` and a configured vsock are different things to
+    Firecracker and the same thing to a reader, and the reader is who this is
+    for.
+    """
+    return [
+        f"{name} (which defeats {defeats})"
+        for name, defeats in sorted(DEVICES_THAT_MUST_BE_ABSENT.items())
+        if name in config
+    ]
+
+
+def flags_that_would_weaken_the_jail(argv: list[str]) -> list[str]:
+    """Which weakening flags a jailer command line carries.
+
+    Matches ``--flag`` and ``--flag=value`` alike, because a flag written with
+    an equals sign is the same flag and a check that only knew one spelling
+    would be a check somebody could walk around without meaning to.
+    """
+    named = []
+    for flag, defeats in sorted(FLAGS_THAT_WOULD_WEAKEN_THE_JAIL.items()):
+        if any(item == flag or item.startswith(flag + "=") for item in argv):
+            named.append(f"{flag} (which defeats {defeats})")
+    return named
+
+
+def _firecracker_configuration(
+    rules: Mapping[str, Any], *, vcpu_count: int
+) -> dict[str, Any]:
+    """The configuration file, in in-jail paths, naming none of the three devices.
+
+    Key spellings are Firecracker's own and are not tidied: the top-level
+    sections are hyphenated and the fields inside them are not.
+
+    ``network-interfaces`` is written as an empty list rather than left out.
+    Firecracker's own fixtures write it that way, an absent key and an empty
+    list mean the same thing to it, and stating the empty list makes
+    ``network: none`` something a reader can see rather than something they have
+    to notice is missing.
+    """
+    read_only = rules["rootfs"] == "read-only"
+    return {
+        "boot-source": {
+            "kernel_image_path": IN_JAIL_KERNEL,
+            # ``ro`` is the same rule as ``is_read_only`` below, said to the
+            # kernel. Only one of the two is Firecracker's; a guest told to
+            # mount a read-only drive read-write fails at boot in a way that
+            # reads as a broken image rather than as an enforced rule.
+            "boot_args": (
+                "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda"
+                + (" ro" if read_only else "")
+            ),
+        },
+        "drives": [
+            {
+                "drive_id": "rootfs",
+                "path_on_host": IN_JAIL_ROOTFS,
+                "is_root_device": True,
+                "is_read_only": read_only,
+            },
+            {
+                "drive_id": "work",
+                "path_on_host": IN_JAIL_WORK_DISK,
+                "is_root_device": False,
+                "is_read_only": False,
+            },
+        ],
+        "machine-config": {
+            "vcpu_count": vcpu_count,
+            "mem_size_mib": rules["memory_mib"],
+        },
+        "network-interfaces": [],
+    }
+
+
+def _jailer_arguments(
+    rules: Mapping[str, Any],
+    *,
+    vm_id: str,
+    firecracker_binary: Path,
+    chroot_base: str | Path,
+    uid: int,
+    gid: int,
+    cgroup_version: int,
+) -> list[str]:
+    """The jailer command line, with the three flags no policy key names.
+
+    ``--new-pid-ns`` so the guest process is not in the host's PID namespace;
+    ``--cgroup`` for the host-side memory bound underneath the guest-visible
+    one; and ``--daemonize``, which is the step that points the three standard
+    descriptors at ``/dev/null``. The jailer's own cleanup closes every other
+    descriptor and clears the environment, and leaves those three open, so
+    ``credentials: none-inherited`` holds by default for the environment and
+    only because of this flag for the descriptors.
+
+    ``--daemonize`` costs the console: Firecracker's standard output goes to
+    ``/dev/null`` unless a log path is configured. That is acceptable only
+    because it is not where results come from — deliverables are collected off
+    the ephemeral work disk, which ``workdir`` already governs.
+
+    ``--no-api`` goes to Firecracker rather than the jailer, after the ``--``.
+    Without it the API socket stays live for the run and every pinned device can
+    be added back through it, snapshots included; with it, the configuration
+    file is the whole of what the machine will ever be.
+    """
+    host_bound_bytes = (
+        rules["memory_mib"] + HOST_SIDE_MEMORY_OVERHEAD_MIB
+    ) * A_MEBIBYTE
+    return [
+        "--id",
+        vm_id,
+        "--exec-file",
+        firecracker_binary.as_posix(),
+        "--uid",
+        str(uid),
+        "--gid",
+        str(gid),
+        "--chroot-base-dir",
+        Path(chroot_base).as_posix(),
+        "--cgroup-version",
+        str(cgroup_version),
+        "--cgroup",
+        f"{CGROUP_MEMORY_FILE_BY_VERSION[cgroup_version]}={host_bound_bytes}",
+        # In bytes, and bounding any single file the process creates. The work
+        # disk image is what bounds the total; this is what stops one file
+        # inside it from being the whole quota by itself. The root filesystem is
+        # larger than this and is never written to, being read-only.
+        "--resource-limit",
+        f"fsize={rules['workdir_quota_mib'] * A_MEBIBYTE}",
+        "--new-pid-ns",
+        "--daemonize",
+        "--",
+        "--config-file",
+        IN_JAIL_CONFIG,
+        "--no-api",
+    ]
+
+
+def _where_each_rule_went(*, cgroup_version: int) -> dict[str, str]:
+    """One sentence per rule, saying which argument carries it.
+
+    The point of writing this out is the check that follows it: if a rule is in
+    the policy and not in here, the builder refuses. A reader can also use it,
+    but that is second — its first job is to make a dropped rule loud.
+
+    Only the wording depends on the cgroup hierarchy. The set of rules does not,
+    which is what lets :func:`rules_this_builder_accounts_for` ask this question
+    without having a host to ask it about.
+    """
+    return {
+        "required": "any rule this builder cannot express raises LaunchRefused "
+        "naming that rule, rather than producing arguments without it",
+        "runtime": "--exec-file names the Firecracker binary the jailer execs, "
+        "and the jailer refuses a name that does not contain 'firecracker'",
+        "network": "no interface is configured and no --netns is passed, so "
+        "there is no interface to bring up; mmds-config and vsock are absent "
+        "from the configuration and --no-api stops either being added later",
+        "rootfs": "the root drive's is_read_only, and 'ro' on the kernel "
+        "command line",
+        "workdir": "a second drive, writable, on an image created for this run "
+        "and destroyed with the jail",
+        "workdir_quota_mib": "the size of that image, and --resource-limit "
+        "fsize= in bytes for any single file within it",
+        "memory_mib": "machine-config.mem_size_mib inside the guest, and "
+        f"--cgroup {CGROUP_MEMORY_FILE_BY_VERSION[cgroup_version]}= outside it "
+        f"with {HOST_SIDE_MEMORY_OVERHEAD_MIB} MiB of headroom for the monitor "
+        "itself",
+        "wall_clock_seconds": "host_side.deadline_seconds, enforced against the "
+        "PID the jailer writes to host_side.pid_file — a guest cannot be "
+        "trusted to time itself",
+        "user": "--uid and --gid, both refused at 0",
+        "credentials": "the jailer clears the environment and closes every "
+        "descriptor but three, and --daemonize points those three at "
+        "/dev/null; nothing of the orchestrator's is passed in",
+        "on_breach": "LaunchRefused carries the rule by name, and "
+        "host_side.on_deadline says the same for the deadline",
+    }
+
+
+def _refuse_a_bad_identity(vm_id: Any) -> None:
+    """The jailer's own rule for an id, checked before it is put in a path.
+
+    Alphanumerics and hyphens, at most 64 characters. Checked here because the
+    id becomes a directory name under the chroot base, and an id that escaped
+    that would be choosing where the jail is built.
+    """
+    if (
+        not isinstance(vm_id, str)
+        or not vm_id
+        or len(vm_id) > 64
+        or not all(part.isalnum() for part in vm_id.split("-") if part != "")
+        or not vm_id[0].isalnum()
+        or not vm_id.isascii()
+    ):
+        raise LaunchRefused(
+            "runtime",
+            f"the jailer takes an id of at most 64 alphanumerics and hyphens, "
+            f"and this one is {vm_id!r}",
+        )

--- a/batch-runner/core/agentic_v2_microvm_launch.py
+++ b/batch-runner/core/agentic_v2_microvm_launch.py
@@ -108,7 +108,23 @@ IN_JAIL_KERNEL = "/vmlinux"
 IN_JAIL_ROOTFS = "/rootfs.ext4"
 IN_JAIL_WORK_DISK = "/work.ext4"
 IN_JAIL_CONFIG = "/vmconfig.json"
-IN_JAIL_PID_FILE = "/firecracker.pid"
+
+PID_FILE_EXTENSION = ".pid"
+"""The jailer's own suffix, appended to the exec file's name and not to a word.
+
+``save_exec_file_pid`` builds this path as ``chroot_exec_file`` plus ``.pid``,
+and ``chroot_exec_file`` is ``/`` joined to the **exec file's own name**. So a
+binary at ``/opt/firecracker-v1.13.1`` produces ``/firecracker-v1.13.1.pid``,
+not ``/firecracker.pid``. This was a fixed constant here until it was checked
+against the source: the name only has to *contain* ``firecracker``, which is the
+rule the jailer enforces on ``--exec-file``, and every other spelling of it
+would have produced a plan whose deadline pointed at a file that never appears.
+
+That is the failure this stage is about, in the one field that decides whether
+``wall_clock_seconds`` can be enforced at all — a limit with no process to stop
+is a limit in name. Derived from the binary now, by
+:func:`_pid_file_the_jailer_will_write`.
+"""
 
 DEVICES_THAT_MUST_BE_ABSENT: dict[str, str] = {
     "balloon": "memory_mib — a balloon device reshapes guest memory at runtime, "
@@ -366,7 +382,9 @@ def build_launch_plan(
         ],
         "host_side": {
             "chroot_dir": chroot_dir,
-            "pid_file": (Path(chroot_dir) / IN_JAIL_PID_FILE.lstrip("/")).as_posix(),
+            "pid_file": _pid_file_the_jailer_will_write(
+                chroot_dir, firecracker_binary
+            ),
             "deadline_seconds": rules["wall_clock_seconds"],
             "on_deadline": rules["on_breach"],
             "destroy_after_the_run": [chroot_dir],
@@ -385,6 +403,32 @@ def build_launch_plan(
 
     plan["plan_sha256"] = canonical_sha256(plan)
     return plan
+
+
+def _pid_file_the_jailer_will_write(chroot_dir: str, firecracker_binary: Path) -> str:
+    """Where the deadline will find the process it has to be able to stop.
+
+    Two facts from ``src/jailer/src/env.rs`` in v1.13.1, both of which have to
+    hold for ``wall_clock_seconds`` to mean anything:
+
+    The **name** is the exec file's own, with ``.pid`` appended — not the word
+    ``firecracker``. The jailer requires only that the name *contain* it, so
+    ``firecracker-v1.13.1`` is a legal binary that writes
+    ``firecracker-v1.13.1.pid``.
+
+    The **place** is inside the jail. ``chroot()`` runs before either call site,
+    so the in-jail ``/`` is ``<chroot_dir>`` seen from the host, and the file the
+    host-side deadline opens is ``<chroot_dir>/<name>.pid``.
+
+    The PID in it is the right one to signal because ``--new-pid-ns`` is passed:
+    that branch clones and records the **child's** PID, which is Firecracker.
+    Without it, and with ``--daemonize``, the recorded PID is the daemonised
+    grandchild's — still the right process, by a different route worth knowing
+    about before somebody removes a flag and changes which one it is.
+    """
+    return (
+        Path(chroot_dir) / (firecracker_binary.name + PID_FILE_EXTENSION)
+    ).as_posix()
 
 
 def rules_this_builder_accounts_for() -> frozenset[str]:

--- a/batch-runner/tests/test_agentic_v2_containment_readiness.py
+++ b/batch-runner/tests/test_agentic_v2_containment_readiness.py
@@ -35,6 +35,7 @@ from core.agentic_v2_containment_readiness import (
     refuse_command_execution,
     runner_labels_used_by_workflows,
 )
+from core.agentic_v2_microvm_launch import rules_this_builder_accounts_for
 from core.agentic_v2_substrate import (
     MICROVM_MEMORY_MIB,
     MICROVM_WALL_CLOCK_SECONDS,
@@ -147,13 +148,19 @@ def test_the_report_names_the_module_that_would_have_to_apply_the_rules():
     "Cannot be established" with no address sends somebody looking for a better
     machine, which is the wrong work: the rules would go unapplied on the best
     machine in the world.
+
+    The address moved once the builder existed. It used to be the readiness
+    module, which reads a host; it is now the launch module, which turns the
+    rules into arguments. Both spellings start ``core.agentic_v2_microvm``, so
+    the module is named in full here — a substring that passes because it is a
+    prefix of a different module's name is not a test of anything.
     """
     answer = judge_containment(a_machine())
     quota = claim(answer, "the command may write at most")
 
     assert "core.agentic_v2_substrate.REQUIRED_MICROVM_POLICY" in quota.because
-    assert "core.agentic_v2_microvm" in quota.because
-    assert "it applies nothing" in quota.because
+    assert "core.agentic_v2_microvm_launch" in quota.because
+    assert "nothing runs them" in quota.because
 
 
 # ── Each requirement, taken away one at a time ────────────────────────────
@@ -726,6 +733,44 @@ def test_a_machine_here_that_could_do_it_changes_one_answer_and_not_the_other():
     assert report["anything_applies_the_containment_rules"] is False
     assert report["available_on_any_machine_in_play"] is False
     assert refuse_command_execution(report) is not None
+
+
+def test_every_rule_now_has_an_argument_and_that_is_not_the_same_as_applying_it():
+    """The trap this fourth field was written to avoid.
+
+    Stage C1 built the translation from the rules to the arguments that would
+    apply them. That is real progress and it is not containment: the builder
+    returns a document and starts nothing. Had the arrival of the translation
+    flipped ``anything_applies_the_containment_rules``, this report would say
+    the containment is in place on the strength of code that has never started
+    a machine — which is the exact failure the whole readiness module exists to
+    make impossible.
+
+    So the translation gets a field of its own, and that field is deliberately
+    not an input to the availability answer.
+    """
+    report = containment_answer_everywhere(facts=a_machine())
+
+    assert report["every_rule_has_an_argument_that_would_apply_it"] is True
+    assert report["anything_applies_the_containment_rules"] is False
+    assert report["available_on_any_machine_in_play"] is False
+    assert refuse_command_execution(report) is not None
+
+
+def test_the_translation_being_complete_is_measured_against_the_policy():
+    """Derived from the two modules, never declared by hand.
+
+    A hand-set True would go on saying the translation is complete after a rule
+    is added to the policy and not to the builder. Reading the builder is what
+    makes a twelfth rule turn this field False without anyone remembering to.
+    """
+    report = containment_answer_everywhere(facts=a_machine())
+    covered = rules_this_builder_accounts_for()
+
+    assert report["every_rule_has_an_argument_that_would_apply_it"] is (
+        covered >= set(REQUIRED_MICROVM_POLICY)
+    )
+    assert set(report["required_containment"]) <= covered
 
 
 def test_the_refusal_on_a_capable_machine_names_the_rules_nobody_applies():

--- a/batch-runner/tests/test_agentic_v2_containment_readiness.py
+++ b/batch-runner/tests/test_agentic_v2_containment_readiness.py
@@ -619,6 +619,36 @@ def test_the_one_machine_that_could_host_it_does_not_claim_to_have_it():
     assert "sha256" in capable[0].established_by
 
 
+def test_no_finding_answers_the_repository_wide_question_for_itself():
+    """A finding records a machine. It must not restate what the code does.
+
+    This one is written from a bug rather than from taste. The azure finding
+    used to end by saying that no code turns the policy into launch arguments,
+    which was true on the day it was measured and false the day
+    core.agentic_v2_microvm_launch was merged — and nothing failed, because a
+    finding is a frozen string that no test compares against the live answer.
+    The printed report then carried both claims, three lines apart.
+
+    So the rule is structural rather than editorial: whether anything applies
+    the rules is a property of this repository, it changes without any machine
+    changing, and describe_containment already answers it live in its own
+    section. A finding that names the policy or the module that translates it
+    is reaching for that answer and will go stale holding it.
+    """
+    answers_that_are_not_about_a_machine = (
+        "REQUIRED_MICROVM_POLICY",
+        "agentic_v2_microvm_launch",
+    )
+
+    for finding in RECORDED_FINDINGS:
+        for answer in answers_that_are_not_about_a_machine:
+            assert answer not in finding.finding, (
+                f"the {finding.machine} finding states {answer}, which is a "
+                "fact about this repository rather than about that machine; "
+                "leave it to the section that answers it live"
+            )
+
+
 def test_the_github_runner_finding_rests_on_githubs_own_documentation():
     github = next(
         finding for finding in RECORDED_FINDINGS if "github-hosted" in finding.machine
@@ -887,13 +917,32 @@ def test_the_printed_report_states_the_requirement_the_verdict_and_the_sources()
     assert "must not run" in printed
 
 
+def _section(lines: list[str], heading: str) -> str:
+    """The lines under one heading, stopping at the blank line that ends it.
+
+    Asserting against the whole report is weak here: the sentence this section
+    has to carry also appears once per rule further down, so a substring test
+    on the full text goes on passing after the section itself is deleted.
+    """
+    start = lines.index(heading)
+    end = lines.index("", start + 1)
+    return "\n".join(lines[start:end])
+
+
 def test_the_printed_report_says_which_rules_nobody_applies():
     report = containment_answer_everywhere(facts=a_machine())
-    printed = "\n".join(describe_containment(report))
+    described = describe_containment(report)
+    printed = "\n".join(described)
+    section = _section(described, "Whether anything applies the rules, on any machine")
 
-    assert "Whether anything applies the rules, on any machine" in printed
-    assert "Nothing does:" in printed
-    assert "a fact about this repository rather than about any machine" in printed
+    # Pinned to the claim the section has to carry, not to a lead-in phrase
+    # that formatting is free to change. An earlier version of this assertion
+    # matched "Nothing does:" and would have gone on passing if the sentence
+    # underneath it had been dropped.
+    assert report["anything_applies_the_containment_rules"] is False
+    assert "starts no process" in section
+    assert "a fact about this repository rather than about any machine" in section
+    assert NOTHING_APPLIES_THESE_RULES_YET in printed
     assert "The required containment is available" not in printed
 
 

--- a/batch-runner/tests/test_agentic_v2_containment_readiness.py
+++ b/batch-runner/tests/test_agentic_v2_containment_readiness.py
@@ -649,6 +649,36 @@ def test_no_finding_answers_the_repository_wide_question_for_itself():
             )
 
 
+def test_a_finding_that_points_at_a_report_field_points_at_a_real_one():
+    """Pointing instead of asserting only helps while the pointer resolves.
+
+    The azure finding now hands the repository-wide question to
+    ``anything_applies_the_containment_rules`` rather than answering it. That
+    is the whole of the fix above, and it fails quietly in a second way if the
+    field is ever renamed: the finding would name a key that no report has,
+    which is the same dead reference as the stale claim it replaced.
+
+    Anything in a finding that is shaped like a field name has to be one. The
+    threshold keeps ordinary prose out; nothing in English reaches sixteen
+    characters with an underscore in it by accident.
+    """
+    looks_like_a_field = re.compile(r"[a-z][a-z0-9]*(?:_[a-z0-9]+)+")
+    report = containment_answer_everywhere(facts=a_machine())
+
+    for finding in RECORDED_FINDINGS:
+        named = {
+            token
+            for token in looks_like_a_field.findall(finding.finding)
+            if len(token) >= 16
+        }
+        for field in sorted(named):
+            assert field in report, (
+                f"the {finding.machine} finding points at {field}, which is "
+                "not a key of the report; a pointer that no longer resolves "
+                "is the staleness this rule exists to stop"
+            )
+
+
 def test_the_github_runner_finding_rests_on_githubs_own_documentation():
     github = next(
         finding for finding in RECORDED_FINDINGS if "github-hosted" in finding.machine

--- a/batch-runner/tests/test_agentic_v2_containment_rules.py
+++ b/batch-runner/tests/test_agentic_v2_containment_rules.py
@@ -20,10 +20,12 @@ is refused rather than accepted.
 
 What they deliberately do not do is start a virtual machine, run a command,
 exceed a limit and watch it stop. That is the test these rules will eventually
-need, and it cannot be written yet — though for one reason now rather than two.
-A machine in play *can* host the containment: the Azure dev host was measured on
-2026-09-10 and its finding is recorded. What is still missing is the other half,
-that no code turns these rules into arguments for starting one. Writing a
+need, and it cannot be written yet — though for one reason now rather than
+three. A machine in play *can* host the containment: the Azure dev host was
+measured on 2026-09-10 and its finding is recorded. The rules also *have* the
+arguments that would apply them now: core/agentic_v2_microvm_launch.py builds
+them. What is still missing is the last of the three, that nothing runs those
+arguments — the builder returns a document and starts no process. Writing a
 pretend version of it would be worse than leaving it out, because a passing test
 named after a thing that never happened is how an unenforced rule comes to look
 enforced. core/agentic_v2_containment_readiness.py reports the gap instead.

--- a/batch-runner/tests/test_agentic_v2_microvm_launch_arguments.py
+++ b/batch-runner/tests/test_agentic_v2_microvm_launch_arguments.py
@@ -240,6 +240,33 @@ def test_the_clock_rule_becomes_a_host_side_deadline_with_a_pid_to_use(plan):
     )
 
 
+@pytest.mark.parametrize(
+    "binary", ["/opt/firecracker-v1.13.1", "/usr/local/bin/firecracker-jailed"]
+)
+def test_the_pid_file_follows_the_binarys_name_and_not_the_word(
+    binary, images, tmp_path
+):
+    """The bug this test was written after, rather than before.
+
+    The jailer requires the exec file's name to *contain* ``firecracker``; it
+    does not require it to be ``firecracker``. ``save_exec_file_pid`` appends
+    ``.pid`` to that name, so a binary called ``firecracker-v1.13.1`` writes
+    ``firecracker-v1.13.1.pid`` — and a plan that hard-coded ``firecracker.pid``
+    would name a file that never appears.
+
+    Nothing would have failed. The deadline would have been recorded, the plan
+    would have hashed, and ``wall_clock_seconds`` would have had nothing to act
+    on at the moment it was needed. Asserted against the binary's name now, and
+    the chroot directory is asserted the same way for the same reason.
+    """
+    plan = _build(images, tmp_path, firecracker_binary=binary)
+    name = Path(binary).name
+
+    assert plan["host_side"]["pid_file"] == f"/srv/jailer/{name}/stage-c1/root/{name}.pid"
+    assert plan["host_side"]["chroot_dir"] == f"/srv/jailer/{name}/stage-c1/root"
+    assert plan["host_side"]["pid_file"].startswith(plan["host_side"]["chroot_dir"] + "/")
+
+
 def test_the_user_rule_is_two_flags_and_neither_may_be_root(plan):
     argv = plan["jailer"]["argv"]
 

--- a/batch-runner/tests/test_agentic_v2_microvm_launch_arguments.py
+++ b/batch-runner/tests/test_agentic_v2_microvm_launch_arguments.py
@@ -1,0 +1,678 @@
+"""The containment rules, as the arguments that would apply them.
+
+Stage C0 finished with eleven rules written down and nothing turning any of them
+into an argument. This file is the check on the half of that gap
+core/agentic_v2_microvm_launch.py closes: every rule has to appear in the built
+arguments, and a rule that cannot be expressed has to stop the build rather than
+be quietly left out.
+
+**What these tests can and cannot establish.** They read a document. They can
+show that ``memory_mib`` reached ``mem_size_mib``, that no network interface is
+configured, that the three devices which would defeat a rule are absent, and
+that weakening any rule is refused — all without hardware, which is why they can
+run here at all. They cannot show that any of those arguments has the effect its
+name suggests. A machine has to be started for that, and stage C2 starts one on
+the host stage B measured; stage C3 attacks it. Neither is pretended here.
+
+The distinction matters because the failure this stage exists to catch is a rule
+that reads as enforced and is not, and a test file that blurred the line between
+"the argument is present" and "the boundary holds" would be an instance of it.
+
+Nothing here calls a model, runs a command, starts a machine, or spends money.
+"""
+
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from core.agentic_v2_microvm_launch import (
+    CGROUP_MEMORY_FILE_BY_VERSION,
+    DEVICES_THAT_MUST_BE_ABSENT,
+    FLAGS_THAT_WOULD_WEAKEN_THE_JAIL,
+    HOST_SIDE_MEMORY_OVERHEAD_MIB,
+    IN_JAIL_CONFIG,
+    IN_JAIL_KERNEL,
+    IN_JAIL_ROOTFS,
+    IN_JAIL_WORK_DISK,
+    LaunchRefused,
+    build_launch_plan,
+    devices_that_would_reopen_a_closed_rule,
+    flags_that_would_weaken_the_jail,
+    rules_this_builder_accounts_for,
+)
+from core.agentic_v2_substrate import REQUIRED_MICROVM_POLICY
+
+A_MEBIBYTE = 1024 * 1024
+
+
+@pytest.fixture
+def images(tmp_path):
+    """A kernel and a root filesystem, as files. Neither is bootable.
+
+    The builder hashes whatever it is given and puts the digest in the plan, so
+    the bytes only have to exist and be distinguishable. A test that needed a
+    real kernel image would be a test that could not run here, and the thing it
+    would establish — that the machine boots — is C2's, not this file's.
+    """
+    kernel = tmp_path / "vmlinux"
+    kernel.write_bytes(b"not a kernel")
+    rootfs = tmp_path / "rootfs.ext4"
+    rootfs.write_bytes(b"not a root filesystem")
+    return {"kernel_path": kernel, "rootfs_path": rootfs}
+
+
+@pytest.fixture
+def plan(images, tmp_path):
+    return build_launch_plan(
+        vm_id="stage-c1",
+        firecracker_binary="/usr/bin/firecracker",
+        work_disk_path=tmp_path / "work.ext4",
+        uid=1000,
+        gid=1000,
+        vcpu_count=2,
+        cgroup_version=2,
+        **images,
+    )
+
+
+def _build(images, tmp_path, **overrides):
+    arguments = {
+        "vm_id": "stage-c1",
+        "firecracker_binary": "/usr/bin/firecracker",
+        "work_disk_path": tmp_path / "work.ext4",
+        "uid": 1000,
+        "gid": 1000,
+        "vcpu_count": 2,
+        "cgroup_version": 2,
+        **images,
+    }
+    arguments.update(overrides)
+    return build_launch_plan(**arguments)
+
+
+def _argument_after(argv, flag):
+    """The value the jailer would read for a flag, or None if it is not there."""
+    for index, item in enumerate(argv[:-1]):
+        if item == flag:
+            return argv[index + 1]
+    return None
+
+
+# ── Every rule reaches an argument ────────────────────────────────────────
+
+
+def test_every_rule_in_the_policy_is_accounted_for():
+    """The check that makes a dropped rule loud instead of invisible.
+
+    Named against the policy rather than against a count, so that a rule added
+    to core.agentic_v2_substrate and not to the builder fails here with the
+    rule's own name rather than with a number that moved.
+    """
+    unaccounted = sorted(set(REQUIRED_MICROVM_POLICY) - rules_this_builder_accounts_for())
+
+    assert unaccounted == [], (
+        f"the policy has {unaccounted} and the builder turns none of them into "
+        "an argument, so a report asking whether the translation is complete "
+        "would be answered yes on an incomplete translation"
+    )
+
+
+def test_the_runtime_rule_names_the_binary_the_jailer_execs(plan):
+    exec_file = _argument_after(plan["jailer"]["argv"], "--exec-file")
+
+    assert exec_file == "/usr/bin/firecracker"
+    assert REQUIRED_MICROVM_POLICY["runtime"] in Path(exec_file).name
+
+
+def test_a_binary_the_jailer_would_reject_is_refused_here_first(images, tmp_path):
+    """The jailer requires 'firecracker' in the name of its --exec-file.
+
+    Refused here rather than left to the jailer, because a refusal at build time
+    names the rule and a refusal at launch time names a path.
+    """
+    with pytest.raises(LaunchRefused) as refusal:
+        _build(images, tmp_path, firecracker_binary="/usr/bin/qemu-system-x86_64")
+
+    assert refusal.value.rule == "runtime"
+
+
+def test_the_network_rule_configures_no_interface_and_joins_no_namespace(plan):
+    """Both halves, because either one alone would leave a way in.
+
+    An empty interface list and an absent key mean the same thing to
+    Firecracker, so the assertion is that nothing is configured rather than that
+    a particular spelling is present.
+    """
+    assert plan["firecracker"]["config"].get("network-interfaces", []) == []
+    assert "--netns" not in plan["jailer"]["argv"]
+
+
+def test_the_rootfs_rule_is_said_to_firecracker_and_to_the_kernel(plan):
+    """One of the two is Firecracker's and the other is the guest's.
+
+    A drive marked read-only that the guest is not told to mount read-only
+    fails at boot in a way that reads as a broken image rather than as a rule
+    doing its job.
+    """
+    config = plan["firecracker"]["config"]
+    root = [item for item in config["drives"] if item["is_root_device"]]
+
+    assert len(root) == 1
+    assert root[0]["is_read_only"] is True
+    assert root[0]["path_on_host"] == IN_JAIL_ROOTFS
+    assert " ro" in config["boot-source"]["boot_args"]
+
+
+def test_the_workdir_rule_is_a_second_drive_that_is_writable(plan):
+    config = plan["firecracker"]["config"]
+    work = [
+        item
+        for item in config["drives"]
+        if item["path_on_host"] == IN_JAIL_WORK_DISK
+    ]
+
+    assert len(work) == 1
+    assert work[0]["is_root_device"] is False
+    assert work[0]["is_read_only"] is False
+
+
+def test_the_quota_bounds_the_image_and_any_single_file_in_it(plan):
+    """Two bounds because they bound different things.
+
+    The image size is what bounds the total. ``fsize`` is what stops one file
+    being the whole of it, and the jailer documents that value in bytes.
+
+    Asserted as the value *after* ``--resource-limit`` rather than as a string
+    somewhere in the argument list. ``fsize=...`` is its own list element, so a
+    check that only looked for it would go on passing with the flag that carries
+    it deleted — a bound that reads as applied and is a loose word on a command
+    line.
+    """
+    quota = REQUIRED_MICROVM_POLICY["workdir_quota_mib"]
+    work = [
+        item for item in plan["place_in_jail"] if item["in_jail"] == IN_JAIL_WORK_DISK
+    ]
+
+    assert work[0]["size_mib"] == quota
+    assert work[0]["how"] == "create-empty"
+    assert _argument_after(plan["jailer"]["argv"], "--resource-limit") == (
+        f"fsize={quota * A_MEBIBYTE}"
+    )
+
+
+def test_the_memory_rule_is_applied_inside_the_guest_and_outside_it(plan):
+    """The guest-visible bound, and the host-side one underneath it.
+
+    The host bound has to be the larger of the two: it covers the guest's memory
+    plus the monitor's own, and a host bound equal to the guest bound would stop
+    the monitor rather than the command that went over.
+    """
+    memory = REQUIRED_MICROVM_POLICY["memory_mib"]
+    argv = plan["jailer"]["argv"]
+
+    assert plan["firecracker"]["config"]["machine-config"]["mem_size_mib"] == memory
+
+    written = _argument_after(argv, "--cgroup")
+    name, _, value = written.partition("=")
+
+    assert name == CGROUP_MEMORY_FILE_BY_VERSION[2]
+    assert int(value) == (memory + HOST_SIDE_MEMORY_OVERHEAD_MIB) * A_MEBIBYTE
+    assert int(value) > memory * A_MEBIBYTE
+
+
+def test_the_clock_rule_becomes_a_host_side_deadline_with_a_pid_to_use(plan):
+    """A guest cannot be trusted to time itself, so the deadline is outside it.
+
+    The PID file is what a deadline has to act on. The jailer writes it inside
+    the jail, which is a path on the host, and a deadline with no process to
+    stop would be a limit in name only.
+    """
+    assert (
+        plan["host_side"]["deadline_seconds"]
+        == REQUIRED_MICROVM_POLICY["wall_clock_seconds"]
+    )
+    assert plan["host_side"]["pid_file"] == (
+        plan["host_side"]["chroot_dir"] + "/firecracker.pid"
+    )
+
+
+def test_the_user_rule_is_two_flags_and_neither_may_be_root(plan):
+    argv = plan["jailer"]["argv"]
+
+    assert _argument_after(argv, "--uid") == "1000"
+    assert _argument_after(argv, "--gid") == "1000"
+
+
+@pytest.mark.parametrize("account", ["uid", "gid"])
+def test_root_for_the_command_is_refused_by_name(account, images, tmp_path):
+    """Not a warning, not a fallback. 0 is root and the rule says otherwise."""
+    with pytest.raises(LaunchRefused) as refusal:
+        _build(images, tmp_path, **{account: 0})
+
+    assert refusal.value.rule == "user"
+    assert account in str(refusal.value)
+
+
+def test_the_credential_rule_rests_on_a_flag_and_the_flag_is_passed(plan):
+    """The half of this rule that does not hold by itself.
+
+    The jailer clears the environment on its own and closes every open
+    descriptor except the three standard ones. Those three are pointed at
+    /dev/null only by ``--daemonize``, so leaving that flag off would satisfy
+    the rule's wording and defeat half of it.
+    """
+    assert "--daemonize" in plan["jailer"]["argv"]
+    assert "--metadata" not in plan["jailer"]["argv"]
+
+
+def test_the_breach_rule_names_the_rule_rather_than_the_symptom(images, tmp_path):
+    """stop-and-report, one step earlier than a breach.
+
+    A refusal that said "invalid configuration" would leave whoever reads it to
+    work out which of eleven rules could not be applied.
+    """
+    weakened = deepcopy(dict(REQUIRED_MICROVM_POLICY))
+    weakened["network"] = "allowlist"
+
+    with pytest.raises(LaunchRefused) as refusal:
+        _build(images, tmp_path, policy=weakened)
+
+    assert refusal.value.rule == "network"
+    assert "allowlist" in str(refusal.value)
+    assert (
+        plan_on_breach := REQUIRED_MICROVM_POLICY["on_breach"]
+    ) and plan_on_breach == "stop-and-report"
+
+
+def test_the_deadline_carries_the_breach_rule_with_it(plan):
+    assert plan["host_side"]["on_deadline"] == REQUIRED_MICROVM_POLICY["on_breach"]
+
+
+# ── A rule that cannot be expressed stops the build ───────────────────────
+
+
+@pytest.mark.parametrize("rule", sorted(REQUIRED_MICROVM_POLICY))
+def test_a_policy_missing_any_rule_is_refused_by_that_rule_name(
+    rule, images, tmp_path
+):
+    """One case per rule, because one rule is what goes missing at a time.
+
+    This is the check the stage's exit condition names: a builder that quietly
+    emitted every rule but one would produce exactly the state stage C exists to
+    end, and it would produce it silently.
+    """
+    short = deepcopy(dict(REQUIRED_MICROVM_POLICY))
+    del short[rule]
+
+    with pytest.raises(LaunchRefused) as refusal:
+        _build(images, tmp_path, policy=short)
+
+    assert refusal.value.rule == rule
+
+
+@pytest.mark.parametrize(
+    ("rule", "weakened_to"),
+    [
+        ("required", False),
+        ("runtime", "docker"),
+        ("network", "allowlist"),
+        ("network", "host"),
+        ("rootfs", "writable"),
+        ("workdir", "persistent"),
+        ("workdir_quota_mib", 0),
+        ("workdir_quota_mib", "unbounded"),
+        ("memory_mib", -1),
+        ("memory_mib", None),
+        ("wall_clock_seconds", 0),
+        ("wall_clock_seconds", True),
+        ("user", "root"),
+        ("credentials", "inherit-environment"),
+        ("credentials", "none"),
+        ("on_breach", "continue"),
+        ("on_breach", "log-and-continue"),
+    ],
+)
+def test_a_rule_weakened_in_the_policy_is_refused_rather_than_applied(
+    rule, weakened_to, images, tmp_path
+):
+    """The builder stops; it does not adapt.
+
+    This is the difference between a reach and a copy. A copy of the policy
+    would be updated to match a weakened rule and go on emitting arguments. A
+    statement of what the builder can express turns the same weakening into a
+    refusal that names the rule.
+    """
+    weakened = deepcopy(dict(REQUIRED_MICROVM_POLICY))
+    weakened[rule] = weakened_to
+
+    with pytest.raises(LaunchRefused) as refusal:
+        _build(images, tmp_path, policy=weakened)
+
+    assert refusal.value.rule == rule
+
+
+def test_a_rule_the_builder_has_never_heard_of_is_refused_too(images, tmp_path):
+    """The other direction, and the more likely one.
+
+    A rule added to the policy by a later change reaches this builder as a key
+    it cannot express. Emitting the other eleven and ignoring the twelfth is how
+    the credential rule would have been lost had it arrived after this file.
+    """
+    extended = deepcopy(dict(REQUIRED_MICROVM_POLICY))
+    extended["vcpu_count"] = 2
+
+    with pytest.raises(LaunchRefused) as refusal:
+        _build(images, tmp_path, policy=extended)
+
+    assert refusal.value.rule == "vcpu_count"
+
+
+# ── The devices and flags no rule names ───────────────────────────────────
+
+
+def test_none_of_the_three_devices_is_configured(plan):
+    """Each of them defeats a rule that is in the policy.
+
+    Absent rather than set to null: Firecracker treats a null device and a
+    configured one as different things, and a reader treats them as the same.
+    The plan records the pinning separately so the intent is written down.
+    """
+    config = plan["firecracker"]["config"]
+
+    assert devices_that_would_reopen_a_closed_rule(config) == []
+    for device in DEVICES_THAT_MUST_BE_ABSENT:
+        assert device not in config
+    assert plan["devices_pinned"] == {
+        name: None for name in sorted(DEVICES_THAT_MUST_BE_ABSENT)
+    }
+
+
+@pytest.mark.parametrize("device", sorted(DEVICES_THAT_MUST_BE_ABSENT))
+def test_a_configuration_that_names_one_of_them_is_reported(device, plan):
+    """The check runs over any configuration, not only the one built here.
+
+    Written that way so stage C3 can read a configuration back off the host and
+    ask the same question of it, instead of trusting that what was built is what
+    is running.
+    """
+    smuggled = deepcopy(plan["firecracker"]["config"])
+    smuggled[device] = {}
+
+    named = devices_that_would_reopen_a_closed_rule(smuggled)
+
+    assert len(named) == 1
+    assert named[0].startswith(device)
+
+
+def test_no_snapshot_route_is_emitted_and_the_api_is_off(plan):
+    """Pinning a device is a statement about start-up until the API is closed.
+
+    With the API socket live, every device pinned above can be added back for
+    the life of the machine and a snapshot can be loaded whose configuration was
+    decided somewhere else entirely. ``--no-api`` is what makes the
+    configuration file the whole of what the machine will ever be.
+    """
+    argv = plan["jailer"]["argv"]
+
+    assert "--no-api" in argv
+    assert "--config-file" in argv
+    assert _argument_after(argv, "--config-file") == IN_JAIL_CONFIG
+    assert not any("snapshot" in item for item in argv)
+    assert not any("snapshot" in key for key in plan["firecracker"]["config"])
+
+
+@pytest.mark.parametrize("flag", sorted(FLAGS_THAT_WOULD_WEAKEN_THE_JAIL))
+def test_no_weakening_flag_is_passed(flag, plan):
+    assert flag not in plan["jailer"]["argv"]
+    assert flags_that_would_weaken_the_jail(plan["jailer"]["argv"]) == []
+
+
+@pytest.mark.parametrize("spelling", ["--no-seccomp", "--netns=/var/run/netns/x"])
+def test_a_weakening_flag_is_reported_in_either_spelling(spelling, plan):
+    """``--flag value`` and ``--flag=value`` are the same flag.
+
+    A check that knew only one of the two spellings is a check somebody walks
+    around without meaning to.
+    """
+    named = flags_that_would_weaken_the_jail(plan["jailer"]["argv"] + [spelling])
+
+    assert len(named) == 1
+    assert named[0].startswith(spelling.split("=")[0])
+
+
+def test_the_three_flags_no_policy_key_names_are_all_passed(plan):
+    """Each closes a gap the policy describes without naming the mechanism."""
+    argv = plan["jailer"]["argv"]
+
+    assert "--new-pid-ns" in argv
+    assert "--daemonize" in argv
+    assert _argument_after(argv, "--cgroup") is not None
+
+
+# ── The cgroup hierarchy, which is where a default would be wrong ─────────
+
+
+def test_the_memory_bound_uses_the_name_its_own_hierarchy_uses():
+    """v1 and v2 call it different things, and the jailer does not translate.
+
+    ``--cgroup <file>=<value>`` writes to the file it is given under the
+    hierarchy ``--cgroup-version`` selects. Passing v1's name with
+    ``--cgroup-version 2`` asks for a file that does not exist there — a memory
+    bound that reads as enforced and is not, arriving through a name rather than
+    through a deletion.
+    """
+    assert CGROUP_MEMORY_FILE_BY_VERSION[1] == "memory.limit_in_bytes"
+    assert CGROUP_MEMORY_FILE_BY_VERSION[2] == "memory.max"
+    assert CGROUP_MEMORY_FILE_BY_VERSION[1] != CGROUP_MEMORY_FILE_BY_VERSION[2]
+
+
+@pytest.mark.parametrize("version", [1, 2])
+def test_the_version_is_passed_explicitly_with_its_own_file_name(
+    version, images, tmp_path
+):
+    """Never inherited. The jailer's default is 1 and the host runs 2.
+
+    A launcher that passed ``--cgroup`` and left the version alone would write
+    to a hierarchy that is not the one in use, on a host where nothing would
+    announce that it had not.
+    """
+    argv = _build(images, tmp_path, cgroup_version=version)["jailer"]["argv"]
+
+    assert _argument_after(argv, "--cgroup-version") == str(version)
+    assert _argument_after(argv, "--cgroup").startswith(
+        CGROUP_MEMORY_FILE_BY_VERSION[version] + "="
+    )
+
+
+def test_an_unsupported_hierarchy_is_refused_rather_than_guessed(images, tmp_path):
+    with pytest.raises(LaunchRefused) as refusal:
+        _build(images, tmp_path, cgroup_version=3)
+
+    assert refusal.value.rule == "memory_mib"
+
+
+# ── Paths, which are jail-relative or they are wrong ──────────────────────
+
+
+def test_every_in_jail_path_is_a_name_at_the_root_of_the_jail(plan):
+    """The shape of the path, not the spelling of the constant.
+
+    Firecracker is chrooted before it reads any of these, so a host path here
+    resolves to nothing or — worse — to something else. Asserting only that the
+    configuration matches ``IN_JAIL_CONFIG`` would let the constant be changed
+    to a host path and take the test with it, which is a check that agrees with
+    whatever it is given. A path in the jail is a single name at the root, so
+    that is what is asserted.
+    """
+    for path in (IN_JAIL_KERNEL, IN_JAIL_ROOTFS, IN_JAIL_WORK_DISK, IN_JAIL_CONFIG):
+        assert path.startswith("/"), path
+        assert path.count("/") == 1, f"{path} is not at the root of the jail"
+
+    assert _argument_after(plan["jailer"]["argv"], "--config-file").count("/") == 1
+
+
+def test_the_configuration_names_no_path_from_the_host(plan, tmp_path):
+    """Firecracker resolves these paths from inside the jail.
+
+    A host path in the configuration would resolve to something else or to
+    nothing once Firecracker has been chrooted, and the plan carries the
+    host-side placement separately for exactly that reason.
+    """
+    config = plan["firecracker"]["config"]
+
+    assert config["boot-source"]["kernel_image_path"] == IN_JAIL_KERNEL
+    assert {item["path_on_host"] for item in config["drives"]} == {
+        IN_JAIL_ROOTFS,
+        IN_JAIL_WORK_DISK,
+    }
+    assert str(tmp_path) not in str(config)
+
+
+def test_the_jail_is_where_the_jailer_will_build_it(plan):
+    """``<chroot-base>/<exec-file-name>/<id>/root``, its own convention."""
+    assert plan["host_side"]["chroot_dir"] == "/srv/jailer/firecracker/stage-c1/root"
+    assert plan["host_side"]["destroy_after_the_run"] == [
+        plan["host_side"]["chroot_dir"]
+    ]
+
+
+def test_the_images_are_carried_by_the_hash_the_readiness_report_took(
+    plan, images
+):
+    """One answer to "which kernel", not two that can disagree.
+
+    core.agentic_v2_microvm already hashes these files to decide whether a boot
+    test could be attempted. The builder reuses that reading rather than taking
+    its own, which is why it takes the paths and not the digests.
+    """
+    by_name = {item["in_jail"]: item for item in plan["place_in_jail"]}
+
+    assert by_name[IN_JAIL_KERNEL]["from_host"] == images["kernel_path"].as_posix()
+    assert len(by_name[IN_JAIL_KERNEL]["sha256"]) == 64
+    assert by_name[IN_JAIL_ROOTFS]["sha256"] != by_name[IN_JAIL_KERNEL]["sha256"]
+    assert by_name[IN_JAIL_ROOTFS]["writable_by_the_jailed_user"] is False
+    assert by_name[IN_JAIL_WORK_DISK]["writable_by_the_jailed_user"] is True
+
+
+def test_an_image_that_is_not_there_is_refused_rather_than_named(images, tmp_path):
+    with pytest.raises(LaunchRefused) as refusal:
+        _build(images, tmp_path, kernel_path=tmp_path / "no-such-kernel")
+
+    assert refusal.value.rule == "runtime"
+    assert "kernel" in str(refusal.value)
+
+
+@pytest.mark.parametrize(
+    "bad_id", ["../escape", "a" * 65, "", "has space", "-leading", "ünïcode"]
+)
+def test_an_id_the_jailer_would_reject_never_reaches_a_path(bad_id, images, tmp_path):
+    """The id becomes a directory name under the chroot base.
+
+    An id that escaped it would be choosing where the jail is built, which is
+    not a thing the caller gets to choose.
+    """
+    with pytest.raises(LaunchRefused):
+        _build(images, tmp_path, vm_id=bad_id)
+
+
+# ── What the plan is, and what it is not ──────────────────────────────────
+
+
+def test_the_backstop_fires_when_a_rule_is_dropped_on_the_way_out(
+    monkeypatch, images, tmp_path
+):
+    """The one guard a healthy build never exercises.
+
+    build_launch_plan checks, as its last act, that every rule it accepted also
+    appears in the record of where the rules went. In every passing build that
+    check is dead code — which is the position a safety net is normally in right
+    up until it is needed and turns out not to work.
+
+    So the failure it exists for is staged: the record is made to come back one
+    rule short, exactly as it would after somebody deleted a line while editing
+    the arguments. The build has to stop and name the rule. The alternative is a
+    plan that looks complete, hashes cleanly, and quietly bounds nothing.
+    """
+    import core.agentic_v2_microvm_launch as launch
+
+    intact = launch._where_each_rule_went
+
+    def one_rule_short(**keywords):
+        went = intact(**keywords)
+        del went["memory_mib"]
+        return went
+
+    monkeypatch.setattr(launch, "_where_each_rule_went", one_rule_short)
+
+    with pytest.raises(LaunchRefused) as refusal:
+        _build(images, tmp_path)
+
+    assert refusal.value.rule == "memory_mib"
+    assert "silent drop" in str(refusal.value)
+
+
+def test_the_plan_says_it_started_nothing(plan):
+    assert plan["starts_nothing"] is True
+    assert plan["host_could_run_this"] in (True, False)
+
+
+def test_the_plan_has_an_identity_that_covers_everything_in_it(plan):
+    from core.agentic_v2_substrate import canonical_sha256
+
+    without = {k: v for k, v in plan.items() if k != "plan_sha256"}
+
+    assert plan["plan_sha256"] == canonical_sha256(without)
+    assert plan["policy_sha256"] == canonical_sha256(dict(REQUIRED_MICROVM_POLICY))
+
+
+def test_two_builds_of_the_same_thing_are_the_same_document(images, tmp_path):
+    assert (
+        _build(images, tmp_path)["plan_sha256"]
+        == _build(images, tmp_path)["plan_sha256"]
+    )
+
+
+def test_a_different_vcpu_count_is_a_different_document(images, tmp_path):
+    """The one number the policy does not bound, so it has to be visible.
+
+    Named here rather than fixed here. A containment that bounds memory by rule
+    and leaves processor share to whoever calls it has a gap, and closing it
+    means adding a rule in a change of its own — the way the credential rule was
+    added — not quietly picking a number in the builder.
+    """
+    assert (
+        _build(images, tmp_path, vcpu_count=2)["plan_sha256"]
+        != _build(images, tmp_path, vcpu_count=8)["plan_sha256"]
+    )
+
+
+@pytest.mark.parametrize("bad", [0, -1, "two", 1.5, True])
+def test_a_processor_count_that_is_not_one_is_refused(bad, images, tmp_path):
+    with pytest.raises(LaunchRefused):
+        _build(images, tmp_path, vcpu_count=bad)
+
+
+def test_no_test_in_this_file_starts_anything():
+    """The honesty guard on the file itself.
+
+    Every assertion above reads a document. None of them starts a machine, and
+    if one ever does, the name of this file stops describing it. The parser is
+    used rather than a text search so this test does not trip over its own list
+    of names.
+    """
+    ways_to_run_something = {"subprocess", "os", "pty", "asyncio", "docker", "shutil"}
+
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+
+    assert not imported & ways_to_run_something
+    assert "cannot show that any of those arguments has the effect" in __doc__

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1012,10 +1012,30 @@ cleanup step leaves open — see the credential row above.
 it points Firecracker's standard output at `/dev/null`, so console output is
 gone unless the launcher asks for a log path. That is acceptable here only
 because it is not where results come from — deliverables are collected off the
-ephemeral work disk, which the `workdir` rule already governs. It also pairs
-with `--new-pid-ns`, which is what writes the child's PID to a file; a detached
-process the launcher could not find again would leave `wall_clock_seconds` with
-nothing to enforce against.
+ephemeral work disk, which the `workdir` rule already governs.
+
+> **Correction, made while building C1.** This paragraph used to go on to say
+> that `--daemonize` "pairs with `--new-pid-ns`, which is what writes the child's
+> PID to a file". That is wrong, and it is the kind of wrong that would have been
+> found by a launcher that omitted `--new-pid-ns` and then could not understand
+> why the PID file was there anyway. `src/jailer/src/env.rs:735-740` in v1.13.1
+> writes the PID file in **both** branches; `save_exec_file_pid` runs after
+> `chroot()`, so the file lands at the in-jail path `/firecracker.pid`, which is
+> `<chroot_dir>/firecracker.pid` seen from the host. What `--new-pid-ns` buys is
+> the namespace and nothing else. Both flags are still passed, for the two
+> separate reasons above; only the explanation was wrong.
+
+**A fourth flag, and it is stronger than this plan first had it.** The section
+below says C1's builder "emits no snapshot route". That is true and it is not
+enough. Pinning a device in a configuration file is a statement about start-up;
+with the API socket live it says nothing about the rest of the run. In v1.13.1
+(`src/firecracker/src/main.rs:198-205`) `--no-api` takes no value and requires
+`--config-file`, and `api_enabled` is simply its absence. Without it, every
+device pinned out above — `balloon`, `vsock`, `mmds-config` — can be added back
+after boot over the socket, and `/snapshot/load` can bring in a machine whose
+configuration was decided somewhere else entirely. `--no-api` is what makes the
+configuration file the whole of what the machine will ever be, so it is passed
+and asserted alongside the three above.
 
 **And a third, which is a default that would quietly be wrong here.**
 `--cgroup-version` defaults to `1` in the jailer's own documentation, while
@@ -1072,6 +1092,53 @@ configuration, it is recorded as such and raised — not dropped, not softened t
 a comment, and not moved to a later stage to be forgotten in.
 
 **Cost.** None. This runs on any machine, including this one.
+
+**Done.** `core/agentic_v2_microvm_launch.py` and its 81 tests. The exit
+condition is met in both directions: every rule has a test that reads the built
+arguments, every rule has a case that deletes it from a copy of the policy and
+requires a refusal naming it, and a weakened value is refused rather than
+adapted to. The guards were checked by mutation rather than by their passing —
+fourteen deliberate breakages of the builder (the flag dropped, the host memory
+bound lowered to the guest's, the v1 cgroup file name used under v2, the root
+drive made writable, the in-jail config path turned into a host path) and each
+one had to fail a test before the work was called done. Two of the fourteen
+initially did not, and both were holes in the tests rather than in the builder:
+`fsize=` was asserted as a string anywhere in the argument list, so deleting the
+`--resource-limit` that carries it changed nothing, and the in-jail paths were
+asserted against their own constants, so moving a constant to a host path took
+the test with it. Both now assert the requirement instead of the spelling. The
+last surviving mutation was the builder's own backstop — the check that every
+accepted rule reached `rules_applied` — which no healthy build exercises; it now
+has a test that stages the drop.
+
+Four things the building of it settled, recorded here because they are not
+visible in the diff:
+
+- **The vCPU gap is real and is left open on purpose.** Firecracker requires
+  `vcpu_count` and the policy has no rule about processor share, so the builder
+  takes the number from its caller and says so rather than inventing a bound.
+  Closing it means adding a rule to `REQUIRED_MICROVM_POLICY` in a change of its
+  own, the way the credential rule was added — not a default picked in a
+  launcher.
+- **`/dev/net/tun` is inside the jail whatever the policy says.** The jailer
+  `mknod`s it unconditionally, along with `/dev/kvm` and `/dev/urandom`. So
+  `network: none` rests on no interface being configured and on `--netns` being
+  absent, not on the device being unavailable. Stage C3 attacks that, and should
+  not be surprised to find the node there.
+- **The host-side memory bound is deliberately larger than the guest's.**
+  `HOST_SIDE_MEMORY_OVERHEAD_MIB = 256`, picked rather than derived and named as
+  picked. A host bound equal to the guest bound would kill the monitor rather
+  than the command that went over, which is a containment that stops the wrong
+  process and reports the wrong thing.
+- **The readiness report gained a fourth field, and it is not an input to the
+  third.** `every_rule_has_an_argument_that_would_apply_it` is derived from the
+  builder against the policy. `anything_applies_the_containment_rules` stays
+  `False`, because a rule is applied by starting a machine with it and this
+  builder starts nothing. Wiring the new field into
+  `available_on_any_machine_in_play` would have made the report announce the
+  containment as in place on the strength of code that has never booted
+  anything — the exact failure the readiness module exists to prevent, arriving
+  through good news instead of through a deletion.
 
 ##### C2 — the first boot, on the machine stage B measured
 

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1020,10 +1020,28 @@ ephemeral work disk, which the `workdir` rule already governs.
 > found by a launcher that omitted `--new-pid-ns` and then could not understand
 > why the PID file was there anyway. `src/jailer/src/env.rs:735-740` in v1.13.1
 > writes the PID file in **both** branches; `save_exec_file_pid` runs after
-> `chroot()`, so the file lands at the in-jail path `/firecracker.pid`, which is
-> `<chroot_dir>/firecracker.pid` seen from the host. What `--new-pid-ns` buys is
-> the namespace and nothing else. Both flags are still passed, for the two
-> separate reasons above; only the explanation was wrong.
+> `chroot()`, so the file lands inside the jail, which is `<chroot_dir>` seen
+> from the host. What `--new-pid-ns` buys is the namespace and nothing else.
+> Both flags are still passed, for the two separate reasons above; only the
+> explanation was wrong.
+>
+> **And the correction found a bug in C1's own code**, which is why it is worth
+> writing down rather than just fixing. The file is named after the **exec
+> file**, not after the word: `save_exec_file_pid` appends `.pid` to
+> `chroot_exec_file`, which is `/` joined to the binary's own name. The jailer
+> requires that name to *contain* `firecracker`, not to be it — so
+> `/opt/firecracker-v1.13.1` writes `/firecracker-v1.13.1.pid`. C1 had the path
+> hard-coded as `/firecracker.pid`, and on any host where the binary carries a
+> version suffix the plan would have named a file that never appears. Nothing
+> would have failed: the deadline would have been recorded, the plan would have
+> hashed, and `wall_clock_seconds` would have had nothing to act on at the
+> moment it was needed. It is derived from the binary now, and the test asserts
+> it against a versioned name rather than against the constant.
+>
+> Which PID is in the file is worth knowing too, before somebody removes a flag.
+> With `--new-pid-ns` the jailer clones and records the **child's** PID, which is
+> Firecracker. Without it, and with `--daemonize`, it records the daemonised
+> grandchild's. Both are the right process to signal, by different routes.
 
 **A fourth flag, and it is stronger than this plan first had it.** The section
 below says C1's builder "emits no snapshot route". That is true and it is not
@@ -1093,23 +1111,25 @@ a comment, and not moved to a later stage to be forgotten in.
 
 **Cost.** None. This runs on any machine, including this one.
 
-**Done.** `core/agentic_v2_microvm_launch.py` and its 81 tests. The exit
+**Done.** `core/agentic_v2_microvm_launch.py` and its 83 tests. The exit
 condition is met in both directions: every rule has a test that reads the built
 arguments, every rule has a case that deletes it from a copy of the policy and
 requires a refusal naming it, and a weakened value is refused rather than
 adapted to. The guards were checked by mutation rather than by their passing —
-fourteen deliberate breakages of the builder (the flag dropped, the host memory
+fifteen deliberate breakages of the builder (the flag dropped, the host memory
 bound lowered to the guest's, the v1 cgroup file name used under v2, the root
 drive made writable, the in-jail config path turned into a host path) and each
-one had to fail a test before the work was called done. Two of the fourteen
-initially did not, and both were holes in the tests rather than in the builder:
-`fsize=` was asserted as a string anywhere in the argument list, so deleting the
-`--resource-limit` that carries it changed nothing, and the in-jail paths were
-asserted against their own constants, so moving a constant to a host path took
-the test with it. Both now assert the requirement instead of the spelling. The
-last surviving mutation was the builder's own backstop — the check that every
-accepted rule reached `rules_applied` — which no healthy build exercises; it now
-has a test that stages the drop.
+one had to fail a test before the work was called done. Three of the fifteen
+initially did not, and all three were holes in the tests rather than in the
+builder: `fsize=` was asserted as a string anywhere in the argument list, so
+deleting the `--resource-limit` that carries it changed nothing; the in-jail
+paths were asserted against their own constants, so moving a constant to a host
+path took the test with it; and the PID file was asserted against the constant
+that turned out to be wrong, so it agreed with the bug instead of catching it.
+All three now assert the requirement instead of the spelling. The last surviving
+mutation was the builder's own backstop — the check that every accepted rule
+reached `rules_applied` — which no healthy build exercises; it now has a test
+that stages the drop.
 
 Four things the building of it settled, recorded here because they are not
 visible in the diff:

--- a/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
+++ b/tasks/0822_saturday/TASK_AGENTIC_SANDBOX_V2_ACTIVATION.md
@@ -1160,6 +1160,18 @@ visible in the diff:
   anything — the exact failure the readiness module exists to prevent, arriving
   through good news instead of through a deletion.
 
+  Reading the generated report afterwards caught the same fault in the other
+  direction. The recorded azure finding ended by saying
+  no code turns the policy into launch arguments — true when it was measured,
+  false the moment this module merged — so the printed report asserted both
+  halves of a contradiction three lines apart, and **nothing failed**, because a
+  finding is a frozen string and no test compared it against the live answer. A
+  finding may no longer name `REQUIRED_MICROVM_POLICY` or the launch module at
+  all: whether anything applies the rules is a property of this repository, it
+  changes without any machine changing, and there is already a section that
+  answers it live. Enforced for every finding rather than for the one that went
+  stale.
+
 ##### C2 — the first boot, on the machine stage B measured
 
 **Builds.** The thin spawn that C1 deliberately left out, and one command run


### PR DESCRIPTION
## What this is

Stage C1 of the Agentic Sandbox V2 activation plan. Stage C0 left eleven containment rules written down in `REQUIRED_MICROVM_POLICY` and **nothing anywhere turning any of them into an argument**. This adds `core/agentic_v2_microvm_launch.py`, which reads the policy and returns the jailer and Firecracker arguments that would apply each rule.

It **starts nothing** — no process, no machine, no `exec_run`. That is what makes it checkable on a box whose 3.10 kernel could not boot a microVM, and it is why the report below still says the containment is not in place.

## The field that was nearly wrong

The readiness report gains a fourth field, `every_rule_has_an_argument_that_would_apply_it`, derived from the builder against the policy rather than declared, so a rule added to one and not the other turns it `False` on its own.

`anything_applies_the_containment_rules` **stays `False`**, and the new field is deliberately **not** an input to `available_on_any_machine_in_play`. The obvious wiring would have been wrong: a recorded finding already carries `could_be_hosted_anywhere`, so a `True` here would have flipped the aggregate and made the report announce the containment as **in place** on the strength of code that has never booted anything. That is the exact failure the readiness module exists to prevent, arriving through good news instead of through a deletion.

## Two corrections to the merged plan

Every flag was checked against **v1.13.1** — the version stage B found installed — not the development branch. Two readings contradicted the plan text, and both are corrected in this PR:

- **`--no-api` is required, and "emits no snapshot route" was too weak.** Pinning `balloon`, `vsock` and `mmds-config` out of a config file is a statement about *start-up*. With the API socket live it says nothing about the run: all three can be added back after boot, and `/snapshot/load` can bring in a machine configured somewhere else entirely. `--no-api` (`src/firecracker/src/main.rs:198-205`, takes no value, requires `--config-file`) is what makes the configuration file the whole of what the machine will ever be.
- **`--new-pid-ns` does not write the PID file.** The plan said it did. `src/jailer/src/env.rs:735-740` writes it in **both** branches, after `chroot()`, at the in-jail path `/firecracker.pid`. Both flags are still passed for their own reasons; only the explanation was wrong.

## Two gaps named rather than papered over

- **No rule about processor share.** Firecracker requires `vcpu_count` and the policy has none, so it comes from the caller and the gap is written down. Closing it means amending `REQUIRED_MICROVM_POLICY` in a change of its own, the way the credential rule was added — not defaulting a number in a launcher.
- **`/dev/net/tun` is in the jail regardless.** The jailer `mknod`s it unconditionally, so `network: none` rests on no interface being configured and `--netns` being absent, not on the device being missing. C3 should expect to find the node there.

## How the tests were checked

81 tests, and they were checked by **breaking the builder**, not by passing. Fourteen deliberate mutations — the flag deleted, the host memory bound dropped to the guest's, the v1 cgroup file name used under v2, the root drive made writable, the in-jail config path turned into a host path — each had to fail a test.

**Two initially did not, and both were holes in the tests rather than the builder:**
- `fsize=` was asserted as a string anywhere in the argument list, so deleting the `--resource-limit` that carries it changed nothing.
- The in-jail paths were asserted against their own constants, so moving a constant to a host path took the test with it.

Both now assert the requirement instead of the spelling. The last survivor was the builder's own backstop — the check that every accepted rule reached `rules_applied`, which no healthy build exercises — and it now has a test that stages the drop it exists for.

## Verification

- Full backend suite: **9654 passed, 12 skipped**, exit 0 (21m09s).
- `mypy` clean on the new module. The two pre-existing errors in `agentic_v2_microvm.py` are unchanged from `HEAD` and are in the backlog `backend-tests.yml` documents itself as not gating on.

## Shared-file note (per the A/B ownership split)

- `CHANGELOG.md` — new entry added at the **top of `### Added`**; none of A's Codex entries under `### Changed` / `### Fixed` are touched.
- No change to `executor.py`, shared config, the ledger, or shared CI.

## What this is not

Not an activation. `foundation_only` and `production_activation` are untouched, no guard was removed, no policy weakened, no fallback to V1's Docker runner, and `exec_run` stays closed. **Environment preparation, not 220-task execution.** C2 (first boot on the Azure host, reading the cgroup version off it as its first action) and C3 (the seven escape attempts) are still ahead.