### PR TITLE
fix(codex): send a Codex batch to a host that can isolate a command

### DIFF
--- a/.github/workflows/batch-run.yml
+++ b/.github/workflows/batch-run.yml
@@ -225,7 +225,20 @@ jobs:
   batch-run:
     needs: inspect-mode
     if: needs.inspect-mode.outputs.uses_agentic != 'true' && needs.inspect-mode.outputs.codex_blocked != 'true'
-    runs-on: ubuntu-latest
+    # Every other mode keeps the host it has always had. codex_foundry cannot,
+    # and the reason is measured rather than argued: batch-runner/docs/
+    # codex_sandbox_hosts.json records ubuntu-24.04 -- what `ubuntu-latest`
+    # resolves to -- as user_namespaces_restricted_by_security_policy, and
+    # ubuntu-22.04 as the one host where a command has actually run inside
+    # Codex's sandbox. Sending a Codex batch to `ubuntu-latest` would buy the
+    # turn and then fail at the agent's first command.
+    #
+    # Nothing is relaxed to earn this. 22.04's default posture simply predates
+    # kernel.apparmor_restrict_unprivileged_userns; no sysctl is written and no
+    # capability is added. It is also not permanent -- GitHub is retiring the
+    # image, and that record says so -- so this line is the current answer to
+    # "where can this run", not a claim that the question is closed.
+    runs-on: ${{ needs.inspect-mode.outputs.uses_codex_foundry == 'true' && 'ubuntu-22.04' || 'ubuntu-latest' }}
     timeout-minutes: 360    # max 6 hours
     env:
       EXPERIMENT_YAML_INPUT: ${{ inputs.experiment_yaml }}
@@ -527,6 +540,72 @@ jobs:
           echo "two parsers disagree and that disagreement is itself the fault to"
           echo "report. No model client or cloud credential was used."
           exit 1
+
+      # ── Codex execution host: install, then prove, before anything is paid ──
+      # These three steps run only for codex_foundry and only after both block
+      # steps above, so a dispatch that is about to be refused installs nothing.
+      # They sit before the first Azure step on purpose: every failure they can
+      # produce is a fact about this runner, and a fact about this runner is
+      # worth nothing once a turn has been bought.
+      #
+      # Same stall guard as `Install system dependencies` above -- the mirror
+      # outage that hung five jobs for 5h18m apiece did not care which package
+      # was being fetched.
+      - name: 'Codex: install bubblewrap'
+        if: needs.inspect-mode.outputs.uses_codex_foundry == 'true'
+        run: |
+          set -euo pipefail
+          if command -v bwrap > /dev/null; then
+            echo "bwrap already present: $(command -v bwrap)"
+          else
+            APT_OPTS=(
+              -o Acquire::Retries=3
+              -o Acquire::http::Timeout=30
+              -o Acquire::https::Timeout=30
+              -o DPkg::Lock::Timeout=60
+            )
+            install_bubblewrap() {
+              sudo timeout 240 apt-get "${APT_OPTS[@]}" update -qq || return 1
+              sudo DEBIAN_FRONTEND=noninteractive timeout 420 apt-get \
+                "${APT_OPTS[@]}" install -y --no-install-recommends \
+                bubblewrap || return 1
+            }
+            for attempt in 1 2 3; do
+              if install_bubblewrap; then
+                break
+              fi
+              if [[ "$attempt" -eq 3 ]]; then
+                echo "::error::apt could not install bubblewrap after 3 attempts"
+                exit 1
+              fi
+              echo "::warning::apt attempt $attempt failed; retrying in $((attempt * 60))s"
+              sleep "$((attempt * 60))"
+            done
+          fi
+          echo "bwrap: $(command -v bwrap)  $(bwrap --version 2>&1 | head -1)"
+
+      # Installed is not the same as working, and the difference is the whole
+      # reason this step exists. The diagnostic exits 0 only when it watched a
+      # command run inside the sandbox; every other verdict names the wall.
+      # Without this, a runner image that quietly loses the ability to sandbox
+      # would look exactly like one that has it, right up until the agent's
+      # first command -- after the input tokens are spent.
+      - name: 'Codex: refuse to continue unless this host can isolate'
+        if: needs.inspect-mode.outputs.uses_codex_foundry == 'true'
+        working-directory: batch-runner
+        run: |
+          set -euo pipefail
+          python3 scripts/diagnose_codex_sandbox_host.py
+
+      # If pip left the pinned binary uninstalled, the run would reach step 2
+      # and report runtime_unavailable -- a true statement about this runner and
+      # nothing at all about the deployment. Stop here instead.
+      - name: 'Codex: refuse to continue unless the pinned runtime is installed'
+        if: needs.inspect-mode.outputs.uses_codex_foundry == 'true'
+        working-directory: batch-runner
+        run: |
+          set -euo pipefail
+          python3 -c "from core.codex_runtime_config import require_pinned_runtime; print('pinned runtime:', require_pinned_runtime())"
 
       - name: Validate Azure OIDC identity before remote access
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,36 @@ entries land under a fresh dated heading the day they merge to `main`.
   the relay forwards every input on every leg, and a run must not start
   failing halfway through for carrying a flag it never used.
 
+- **A Codex batch now runs on a host that can actually isolate a command.**
+  `batch-run.yml` runs on `ubuntu-latest`, and the repository had already
+  measured what that means for this mode: `docs/codex_sandbox_hosts.json`
+  records `ubuntu-24.04` — what `ubuntu-latest` resolves to — as
+  `user_namespaces_restricted_by_security_policy`, and `ubuntu-22.04` as the
+  only host where a command has been observed running inside Codex's sandbox.
+  A `codex_foundry` batch dispatched before this change would have paid for the
+  turn and then died at the agent's first command. Three steps, all gated on
+  the mode and all placed after the two refusals and before the first Azure
+  step:
+  - The job's `runs-on` picks `ubuntu-22.04` for `codex_foundry` and leaves
+    every other mode on `ubuntu-latest`. Nothing is relaxed to earn it —
+    22.04's default posture simply predates
+    `kernel.apparmor_restrict_unprivileged_userns`. It is also not permanent:
+    GitHub is retiring that image, and the record says so.
+  - `bubblewrap` is installed there, because it is not preinstalled on either
+    image — with the same stall guard as the neighbouring `apt-get` call, whose
+    comment says every bare one in this repository gets it.
+  - Installed is not working, so `diagnose_codex_sandbox_host.py` runs and the
+    job stops unless it watched a command run inside the sandbox; then
+    `require_pinned_runtime()` runs, so a missing pinned binary is caught here
+    rather than surfacing at step 2 as `runtime_unavailable` — a true statement
+    about the runner and nothing at all about the deployment.
+
+  The test reads the record and requires the workflow to name whichever host it
+  calls ready, rather than pinning the label twice, and holds all three steps
+  to the absence of `--privileged`, `--cap-add`, `--security-opt`, `sysctl`
+  writes and `setcap`. Buying a green host by removing the isolation is the one
+  thing this line of work is not allowed to do.
+
 ### Changed
 - **The Codex readiness record narrows its gate blocker rather than dropping
   it.** It said the gate was closed and `batch-run.yml` did not set it; the

--- a/batch-runner/core/execution_environment_readiness.py
+++ b/batch-runner/core/execution_environment_readiness.py
@@ -1025,6 +1025,21 @@ def inspect_environment_support(
                 "truth table is executed against the real experiment files "
                 "rather than described"
             )
+            evidence.append(
+                "and it lands where a command can be isolated: that workflow "
+                "sends a codex_foundry run to the one host "
+                "docs/codex_sandbox_hosts.json records ready, ubuntu-22.04, "
+                "rather than to ubuntu-latest, which resolves to the 24.04 "
+                "image that record measures as "
+                "user_namespaces_restricted_by_security_policy; it installs "
+                "bubblewrap there and reaches no Azure step until "
+                "scripts/diagnose_codex_sandbox_host.py has watched a command "
+                "run inside the sandbox and the pinned runtime has been "
+                "confirmed installed. Nothing is relaxed to earn that — no "
+                "sysctl, capability or profile is written — which is what "
+                "tests/test_the_codex_batch_lands_on_a_host_that_can_isolate."
+                "py holds the steps to"
+            )
             blockers.extend(
                 DOCUMENTED_BLOCKERS_BY_ENVIRONMENT.get(environment, ())
             )

--- a/batch-runner/tests/test_the_codex_batch_lands_on_a_host_that_can_isolate.py
+++ b/batch-runner/tests/test_the_codex_batch_lands_on_a_host_that_can_isolate.py
@@ -1,0 +1,268 @@
+"""A Codex batch has to run somewhere a command can actually be sandboxed.
+
+``batch-run.yml`` has always run on ``ubuntu-latest``, and for every mode it
+had that was the right answer. For ``codex_foundry`` it is the wrong one, and
+the repository already held the measurement that says so:
+``docs/codex_sandbox_hosts.json`` records ``ubuntu-24.04`` -- what
+``ubuntu-latest`` resolves to -- as
+``user_namespaces_restricted_by_security_policy``, and ``ubuntu-22.04`` as the
+only host where a command has been observed running inside Codex's sandbox.
+
+The failure that would have caused is the expensive kind. Codex starts, the
+turn is sent, the input tokens are paid for, and the run dies at the agent's
+*first command* -- so the money is spent before anything is learned. Worse, the
+neighbouring failure is silent rather than loud: a sandbox that will not start
+and a sandbox nobody asked for look the same from outside if nothing checks.
+
+So three things are pinned here.
+
+**The host is chosen by the mode, and the choice tracks the measurement.** Not
+a hardcoded label that a later edit to the record would silently contradict --
+the test reads the record and requires the workflow to name the host it calls
+ready.
+
+**Installed is not working.** ``bwrap`` on the PATH says a package exists. The
+diagnostic exits zero only when it watched a command run inside the sandbox,
+and it runs here before the first Azure step, because a fact about the runner
+is worth nothing once a turn has been bought.
+
+**Nothing is relaxed to make any of it pass.** ubuntu-22.04 is more permissive
+than 24.04 out of the box; that is a property of the image, not a favour done
+to it here. The steps are checked for the absence of every shortcut that would
+have bought a pass by removing the isolation these runs exist to keep.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BATCH_WORKFLOW = ROOT / ".github" / "workflows" / "batch-run.yml"
+BATCH_RUNNER = ROOT / "batch-runner"
+HOST_RECORD = BATCH_RUNNER / "docs" / "codex_sandbox_hosts.json"
+DIAGNOSTIC = BATCH_RUNNER / "scripts" / "diagnose_codex_sandbox_host.py"
+
+#: The three steps this change adds, in the order they must run: a host cannot
+#: be probed for bubblewrap before bubblewrap is installed, and neither answer
+#: matters if the pinned runtime is missing.
+HOST_STEPS = (
+    "Codex: install bubblewrap",
+    "Codex: refuse to continue unless this host can isolate",
+    "Codex: refuse to continue unless the pinned runtime is installed",
+)
+
+#: Every one of these would turn a red host green by taking the isolation away.
+#: They are named rather than described so that adding one is a test failure
+#: rather than a judgement call in review.
+WAYS_TO_CHEAT = (
+    "--privileged",
+    "--cap-add",
+    "--security-opt",
+    "--userns=host",
+    "sysctl",
+    "apparmor_restrict_unprivileged_userns",
+    "setcap",
+    "unprivileged_userns_clone",
+)
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    return yaml.safe_load(BATCH_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def batch_job(workflow):
+    return workflow["jobs"]["batch-run"]
+
+
+@pytest.fixture(scope="module")
+def step_names(batch_job):
+    return [step.get("name") for step in batch_job["steps"]]
+
+
+@pytest.fixture(scope="module")
+def host_record():
+    return json.loads(HOST_RECORD.read_text(encoding="utf-8"))["hosts"]
+
+
+def _named_step(batch_job, name):
+    for step in batch_job["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"no step named {name!r} in the batch-run job")
+
+
+def _ready_github_hosted_runner(host_record):
+    """The runner label the record says a command has run inside.
+
+    Keyed off the record rather than written down again, so that re-measuring a
+    host to `ready` or losing one to a policy change lands on this test instead
+    of on a paid run.
+    """
+    ready = {
+        key.removesuffix("-host"): entry
+        for key, entry in host_record.items()
+        if entry["readiness"] == "ready" and key.startswith("ubuntu-")
+        and key.endswith("-host")
+    }
+    assert ready, (
+        "no GitHub-hosted runner is recorded ready in "
+        f"{HOST_RECORD.relative_to(ROOT)}; a Codex batch has nowhere to run "
+        "and the workflow should not be claiming otherwise"
+    )
+    assert len(ready) == 1, (
+        "more than one hosted runner is recorded ready, so which one the "
+        f"workflow should name is now a choice rather than the only option: {sorted(ready)}"
+    )
+    return next(iter(ready))
+
+
+def test_the_batch_job_picks_its_host_from_the_mode(batch_job, host_record):
+    runner = _ready_github_hosted_runner(host_record)
+    assert batch_job["runs-on"] == (
+        "${{ needs.inspect-mode.outputs.uses_codex_foundry == 'true' "
+        f"&& '{runner}' || 'ubuntu-latest' }}}}"
+    )
+
+
+def test_every_other_mode_keeps_the_host_it_always_had(batch_job):
+    # The half that is not about Codex at all. This job runs every experiment
+    # this repository has; moving all of them to a different image to fix one
+    # mode would be a change nobody asked for, on a shared file, in a PR about
+    # something else.
+    assert "|| 'ubuntu-latest' }}" in batch_job["runs-on"]
+
+
+def test_the_host_the_workflow_avoids_is_the_one_measured_unable(host_record):
+    # `ubuntu-latest` is not a machine, it is a moving pointer, and the record
+    # says where it points today. If that stops being true -- if 24.04 is
+    # re-measured ready, or the pointer moves -- this fails and the conditional
+    # above gets to be revisited rather than quietly kept.
+    assert host_record["ubuntu-24.04-host"]["readiness"] != "ready"
+    assert "ubuntu-latest" in host_record["ubuntu-24.04-host"]["os"]
+
+
+def test_the_host_steps_run_only_for_this_mode(batch_job):
+    for name in HOST_STEPS:
+        step = _named_step(batch_job, name)
+        assert step["if"] == (
+            "needs.inspect-mode.outputs.uses_codex_foundry == 'true'"
+        ), name
+
+
+def test_the_host_steps_run_after_the_refusals(step_names):
+    # A dispatch that is about to be refused should install nothing and probe
+    # nothing. Both block steps decide before any of this runs.
+    blocks = (
+        "Block agentic modes in credentialed general workflow",
+        "Block unconfirmed codex_foundry in credentialed general workflow",
+    )
+    for block in blocks:
+        for name in HOST_STEPS:
+            assert step_names.index(block) < step_names.index(name), (block, name)
+
+
+def test_the_host_steps_run_before_the_first_credential(step_names):
+    # The whole value of these checks is that they are cheap and early. Placed
+    # after the Azure steps they would still be true and would still be useless.
+    first_credential = step_names.index(
+        "Validate Azure OIDC identity before remote access"
+    )
+    for name in HOST_STEPS:
+        assert step_names.index(name) < first_credential, name
+
+
+def test_they_run_in_the_only_order_that_works(step_names):
+    assert [step_names.index(name) for name in HOST_STEPS] == sorted(
+        step_names.index(name) for name in HOST_STEPS
+    )
+
+
+def test_the_install_does_not_run_twice_over(batch_job):
+    # A hosted image gaining bubblewrap should make this step do nothing, not
+    # make it fetch a package that is already there.
+    install = _named_step(batch_job, HOST_STEPS[0])
+    assert "if command -v bwrap" in install["run"]
+
+
+def test_the_install_carries_the_same_stall_guard_as_its_neighbour(batch_job):
+    # batch-run.yml's own comment: the 2026-08-19 mirror outage hung five jobs
+    # for 5h18m apiece, and "the same defect lives in every bare apt-get call in
+    # this repo, so it gets the same guard". A new apt call is a new instance of
+    # that defect unless it is guarded too.
+    install = _named_step(batch_job, HOST_STEPS[0])["run"]
+    for guard in (
+        "Acquire::Retries=3",
+        "DPkg::Lock::Timeout=60",
+        "timeout 240 apt-get",
+        "timeout 420 apt-get",
+    ):
+        assert guard in install, guard
+    assert "for attempt in 1 2 3" in install
+
+
+def test_installed_is_not_accepted_as_working(batch_job):
+    probe = _named_step(batch_job, HOST_STEPS[1])
+    assert "scripts/diagnose_codex_sandbox_host.py" in probe["run"]
+    assert probe["working-directory"] == "batch-runner"
+    # The survey workflow reads this diagnostic's verdict and carries on;
+    # `continue-on-error` there is right because its job is to report. Here its
+    # job is to stop, so the same flag would undo the step entirely.
+    assert "continue-on-error" not in probe
+    assert "|| true" not in probe["run"]
+    assert "set -euo pipefail" in probe["run"]
+
+
+def test_the_pinned_runtime_is_required_rather_than_hoped_for(batch_job):
+    step = _named_step(batch_job, HOST_STEPS[2])
+    assert "require_pinned_runtime" in step["run"]
+    assert step["working-directory"] == "batch-runner"
+
+
+def test_no_step_here_buys_a_pass_by_removing_the_isolation(batch_job):
+    for name in HOST_STEPS:
+        body = _named_step(batch_job, name)["run"]
+        for shortcut in WAYS_TO_CHEAT:
+            assert shortcut not in body, (name, shortcut)
+
+
+def test_the_diagnostic_this_leans_on_actually_refuses(tmp_path):
+    """Run it here, and hold its exit status to its own verdict.
+
+    Every static assertion above is about a step that calls this script. If the
+    script exited zero regardless, all of them would pass and none of them would
+    mean anything. This runs on whatever host the suite is on: the development
+    box (which is not ready, and must exit non-zero) and ubuntu-22.04 in the
+    survey workflow (which is, and must exit zero) are both covered by the same
+    equivalence, so neither needs to be named here.
+    """
+    report = tmp_path / "probe.json"
+    finished = subprocess.run(
+        [sys.executable, str(DIAGNOSTIC), "--json", "--out", str(report)],
+        cwd=BATCH_RUNNER,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert report.exists(), finished.stderr
+    readiness = json.loads(report.read_text(encoding="utf-8"))["readiness"]
+    assert (finished.returncode == 0) == (readiness == "ready"), (
+        f"exit {finished.returncode} for verdict {readiness!r}"
+    )
+
+
+def test_the_record_and_the_workflow_are_not_two_copies_of_one_claim():
+    """The record is evidence; the workflow is a consequence of it.
+
+    Written down twice, they drift. This asserts the direction of the
+    dependency by reading the workflow's comment: whoever changes the runner
+    should be sent to the measurement rather than left to reason about images.
+    """
+    text = BATCH_WORKFLOW.read_text(encoding="utf-8")
+    assert "codex_sandbox_hosts.json" in text


### PR DESCRIPTION
`batch-run.yml` runs on `ubuntu-latest`. For every mode it has ever run, that
was the right answer. For `codex_foundry` it is the wrong one, and this
repository already held the measurement that says so.

`batch-runner/docs/codex_sandbox_hosts.json`:

| host | readiness |
|---|---|
| `ubuntu-24.04-host` — *"what `ubuntu-latest` resolves to"* | `user_namespaces_restricted_by_security_policy` |
| `ubuntu-24.04-container` | `user_namespaces_restricted_by_security_policy` |
| `ubuntu-22.04-host` | **`ready`** — *"a command ran inside the sandbox"* |

Every Codex diagnostic that has ever executed a command ran on `ubuntu-22.04`,
deliberately. `batch-run.yml` never did. A `codex_foundry` batch dispatched
before this change would have started Codex, sent the turn, paid for the input
tokens, and then died at the agent's **first command** — the point of the mode.

## What changes

Three steps and one expression, all scoped to the mode.

1. **`runs-on` picks the measured host.**
   `${{ needs.inspect-mode.outputs.uses_codex_foundry == 'true' && 'ubuntu-22.04' || 'ubuntu-latest' }}`.
   Every other mode keeps the host it always had.
2. **`bubblewrap` is installed**, because it is preinstalled on neither image —
   run `34465567349`'s own log says *"Selecting previously unselected package
   bubblewrap"*. Guarded by `command -v bwrap` so a future image that ships it
   makes this step do nothing, and carrying the same stall guard as the
   neighbouring `apt-get` call, whose comment says every bare one in this repo
   gets it after the 2026-08-19 mirror outage.
3. **Installed is not working.** `scripts/diagnose_codex_sandbox_host.py` runs
   and the job stops unless it watched a command run inside the sandbox. Then
   `require_pinned_runtime()` runs, so a missing pinned binary is caught here
   rather than surfacing at step 2 as `runtime_unavailable` — a true statement
   about the runner and nothing at all about the deployment.

All three are gated on `uses_codex_foundry`, placed **after** both refusal steps
(a dispatch about to be rejected installs nothing) and **before** the first
Azure step (a fact about the runner is worth nothing once a turn is bought).

## Nothing is relaxed

`ubuntu-22.04` is not configured to be permissive by anything here. Its default
posture predates `kernel.apparmor_restrict_unprivileged_userns` — a property of
the image, not a favour done to it. No sysctl is written, no capability added,
no AppArmor profile installed. The record notes the alternative fix (a profile
for the one binary) and this PR does not take it: that would be a security-scope
change to raise separately, and it is not needed to run.

`test_no_step_here_buys_a_pass_by_removing_the_isolation` holds all three steps
to the absence of `--privileged`, `--cap-add`, `--security-opt`, `--userns=host`,
`sysctl`, `setcap`, and the two userns knobs.

## What this does not claim

- **It does not make the mode proven.** No task has yet produced a deliverable
  through this place against the real deployment. The readiness record's second
  blocker is unchanged and stays unchanged until the fixed-5 run produces files.
- **It does not close the execution-host question.** GitHub is retiring the
  22.04 image; the record says so, and this line is the current answer to "where
  can this run", not a permanent one.

## Shared-file change plan (for B)

Three files here are shared:

- `.github/workflows/batch-run.yml` — one `runs-on` line on the `batch-run` job
  and three steps inserted between `Block unconfirmed codex_foundry…` and
  `Validate Azure OIDC identity before remote access`. No existing step is
  edited, reordered or removed. The V2 sandbox path is untouched: `Sandbox: pull
  & verify image` is gated on `uses_sandbox`, which is never true at the same
  time as `uses_codex_foundry`, and for every non-Codex mode the runner label
  and the step list are byte-identical to `main`.
- `CHANGELOG.md` — one bullet appended to the existing `### Added` block.
- `batch-runner/core/execution_environment_readiness.py` — one `evidence.append`
  in the Codex branch. No blocker text is changed, no count moves.

If a V2 PR is in flight on any of these, merge that one first and I will
integrate onto the resulting `main`.

## Verification

- New: `batch-runner/tests/test_the_codex_batch_lands_on_a_host_that_can_isolate.py`
  — 14 tests. The runner label is not written down twice: the test reads
  `codex_sandbox_hosts.json`, finds the single hosted runner recorded `ready`,
  and requires the workflow to name it. Re-measuring a host lands on this test
  instead of on a paid run. `test_the_diagnostic_this_leans_on_actually_refuses`
  executes the diagnostic and asserts `exit == 0` **iff** the verdict is
  `ready`, so it is meaningful on a ready host and on this one alike.
- Every test that reads `batch-run.yml`, plus the readiness and host-diagnosis
  suites: **832 passed, 7 skipped**.
- `node --test scripts/__tests__/onboarding-contract.test.mjs`: **12 pass, 0 fail**
  (no dispatch input changes in this PR).
