### PR TITLE
fix(codex): read an experiment file without the run place's credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,54 @@ entries land under a fresh dated heading the day they merge to `main`.
   file is the decision the pin asks to see.
 
 ### Fixed
+- **Reading an experiment file demanded the run place's credentials, and the
+  step that reads it deliberately has none.** The first `codex_foundry`
+  dispatch, run `34479664460`, died at step 9 of the batch job:
+
+      Invalid experiment config: execution.codex is not usable:
+      execution.codex.endpoint_from_route is set, but this environment
+      describes no usable Azure route: AZURE_AI_ROUTE_PROFILE is required
+
+  on a run whose route was present three steps later. `ExperimentConfig.validate`
+  called `resolve_endpoint_setting(block, os.environ)`, which does two things
+  at once: it decides *which of the two ways* a block names its address, and it
+  resolves the deferred one against the environment. The first question is
+  about the file and can be answered anywhere. The second is about the run
+  place. `batch-run.yml` validates the experiment in an early step that holds
+  no credentials — it runs before the gate that decides whether the dispatch
+  may spend at all — so it was made to prove it had credentials it is not
+  supposed to have. The check was not wrong about the environment it was
+  handed; it was asking the wrong process.
+
+  `select_endpoint_source` now answers the file's question alone, returning the
+  literal address or `None`, and still refusing a block that sets both keys or
+  neither. For a deferred block, `check_block_apart_from_its_address` validates
+  everything else the file decides — the deployment name, `provider_id`,
+  `query_params` names and types, and the `api-version` prohibition. That last
+  one survives without an address because a deferred block has exactly one
+  possible endpoint kind: `resolve_endpoint_setting` returns `route.direct_v1`
+  or raises, so "undated" is known from the file alone. `resolve_endpoint_setting`
+  keeps its signature and behaviour and is still what `step2_run_inference.py`
+  calls, where the route exists.
+
+  **Nothing stopped being checked, and no credential moved.** The alternative
+  fix — giving the early step the Foundry endpoint — would have put a secret
+  earlier in the job than the gate deciding whether this dispatch may spend;
+  a test now asserts that step declares no route variable and still runs before
+  both that gate and the OIDC check. The guarantee the eager check claimed, that
+  a run whose address is missing stops before it spends, is kept by the step
+  that has the environment to keep it: `step2_run_inference.py` resolves the
+  real address and `sys.exit(1)`s before the executor is built, which a test
+  pins by source order. `test_the_config_check_does_not_need_the_run_places_credentials.py`
+  holds both halves, and reverting either one fails it with the run's own
+  message. The test that encoded the wrong belief — `test_without_a_route_the_file_fails_early_rather_than_at_spend`,
+  which asserted exactly the behaviour that killed the dispatch — is replaced,
+  with the run ID in its docstring.
+
+  The dispatch failed in the cheapest place available: before the bubblewrap
+  install, before the sandbox probe, before OIDC, before a token was bought.
+  No paid call was made by run `34479664460`.
+
 - **The connection diagnostic asked the turn for a field the turn does not
   have, and reported the answer as missing.** Run `34461522053` connected: the
   stream carried `UserMessageThreadItem`, `ReasoningThreadItem` and

--- a/batch-runner/core/codex_runtime_config.py
+++ b/batch-runner/core/codex_runtime_config.py
@@ -585,6 +585,87 @@ ENDPOINT_FROM_ROUTE_KEY = "endpoint_from_route"
 ENDPOINT_LITERAL_KEY = "endpoint"
 
 
+def select_endpoint_source(block: Mapping[str, Any] | None) -> str | None:
+    """The address this block names, or ``None`` if it defers to the route.
+
+    Everything decided here is a property of the file, so it answers the same
+    on a machine holding this run's Azure route and on one that does not. That
+    separation is the point: :func:`resolve_endpoint_setting` used to make both
+    decisions at once, and callers who only had the file in hand were made to
+    prove they had the run place's credentials as well.
+
+    A block may carry ``endpoint`` *or* ``endpoint_from_route``, and exactly
+    one of them. Not neither, and not both:
+
+    * neither, and there is nothing to call;
+    * both, and the file has two answers to one question, which is worth
+      refusing rather than resolving by precedence — a precedence rule is
+      invisible in review, and the loser would be a plausible-looking address
+      that never gets used.
+    """
+    if not isinstance(block, Mapping):
+        raise CodexProviderConfigurationError(
+            "codex_foundry needs an execution.codex block naming the "
+            "deployment and its address"
+        )
+    literal = str(block.get(ENDPOINT_LITERAL_KEY) or "").strip()
+    from_route = bool(block.get(ENDPOINT_FROM_ROUTE_KEY))
+    if literal and from_route:
+        raise CodexProviderConfigurationError(
+            f"execution.codex sets both {ENDPOINT_LITERAL_KEY} and "
+            f"{ENDPOINT_FROM_ROUTE_KEY}; set exactly one, so the file has one "
+            "answer for which deployment is called"
+        )
+    if not literal and not from_route:
+        raise CodexProviderConfigurationError(
+            f"execution.codex needs {ENDPOINT_LITERAL_KEY} or "
+            f"{ENDPOINT_FROM_ROUTE_KEY}; neither is set, so there is no "
+            "deployment to call"
+        )
+    return literal or None
+
+
+#: A deferred block is contractually an undated ``/openai/v1/`` address:
+#: :func:`resolve_endpoint_setting` returns ``route.direct_v1.url`` or raises,
+#: so no branch of it yields a project or a dated legacy endpoint. This URL
+#: stands in for that certainty while the *rest* of a deferred block is
+#: checked, which is what lets that check still enforce the ``api-version``
+#: rule — the one setting whose legality depends on the endpoint's kind. It
+#: names no resource, is discarded inside the function below, and is never
+#: returned, stored or sent anywhere.
+_THE_SHAPE_A_ROUTE_MUST_PRODUCE = "https://route.services.ai.azure.com/openai/v1/"
+
+
+def check_block_apart_from_its_address(block: Mapping[str, Any]) -> None:
+    """Raise if a route-deferred ``execution.codex`` block is wrong about
+    anything the file itself decides.
+
+    The address is the run place's rather than the file's, so a process that
+    holds only the file cannot check it and should not pretend to. Everything
+    the *file* decides about the provider is still checked here: the deployment
+    name, the provider id, and the query parameters' names, types and the
+    ``api-version`` prohibition.
+
+    This exists because the eager version cost a dispatch. ``batch-run.yml``
+    validates the experiment file in an early step that deliberately holds no
+    credentials — it runs before the gate that decides whether the dispatch may
+    spend at all — and resolving the address there failed with "this
+    environment describes no usable Azure route" on a run whose route was
+    present three steps later. The check was not wrong about the environment it
+    was given; it was asking the wrong process.
+
+    Nothing is skipped as a result. ``step2_run_inference`` resolves the real
+    address where the route exists and exits before the first turn if it
+    cannot, so a run whose address is missing still stops before it spends.
+    """
+    CodexProviderSettings(
+        endpoint=_THE_SHAPE_A_ROUTE_MUST_PRODUCE,
+        model=str(block.get("model", "")),
+        provider_id=str(block.get("provider_id") or DEFAULT_PROVIDER_ID),
+        query_params=dict(block.get("query_params") or {}),
+    )
+
+
 def resolve_endpoint_setting(
     block: Mapping[str, Any] | None,
     environ: Mapping[str, str],
@@ -609,14 +690,11 @@ def resolve_endpoint_setting(
     a run at some other resource without changing any code — which is exactly
     what "the confirmed Foundry resource only" rules out.
 
-    So a block may carry ``endpoint`` *or* ``endpoint_from_route``, and exactly
-    one of them. Not neither, and not both:
-
-    * neither, and there is nothing to call;
-    * both, and the file has two answers to one question, which is worth
-      refusing rather than resolving by precedence — a precedence rule is
-      invisible in review, and the loser would be a plausible-looking address
-      that never gets used.
+    Which of the two ways a block uses is :func:`select_endpoint_source`'s
+    question, and it is a question about the file. This function answers the
+    one that follows and is about the run place: given that the file defers,
+    what address does *this* environment provide? Callers holding only the file
+    should ask the first and not this one.
 
     A route that describes no ``/openai/v1/`` endpoint is an error, not an
     empty string. Falling through to ``""`` would reach
@@ -625,32 +703,13 @@ def resolve_endpoint_setting(
     mistake as the empty bearer token: a silent absence reported as something
     else.
 
-    The value is deliberately *not* stored anywhere by the caller that
-    validates it. ``core.experiment_config`` calls this only to fail early on
-    a run whose address is missing; the address itself is resolved again at the
-    point of use, so it never reaches ``workspace/step1_tasks_prepared.json``
-    or any other file this run writes down.
+    The value is deliberately *not* stored anywhere by its callers. It is
+    resolved at the point of use, so it never reaches
+    ``workspace/step1_tasks_prepared.json`` or any other file this run writes
+    down.
     """
-    if not isinstance(block, Mapping):
-        raise CodexProviderConfigurationError(
-            "codex_foundry needs an execution.codex block naming the "
-            "deployment and its address"
-        )
-    literal = str(block.get(ENDPOINT_LITERAL_KEY) or "").strip()
-    from_route = bool(block.get(ENDPOINT_FROM_ROUTE_KEY))
-    if literal and from_route:
-        raise CodexProviderConfigurationError(
-            f"execution.codex sets both {ENDPOINT_LITERAL_KEY} and "
-            f"{ENDPOINT_FROM_ROUTE_KEY}; set exactly one, so the file has one "
-            "answer for which deployment is called"
-        )
-    if not literal and not from_route:
-        raise CodexProviderConfigurationError(
-            f"execution.codex needs {ENDPOINT_LITERAL_KEY} or "
-            f"{ENDPOINT_FROM_ROUTE_KEY}; neither is set, so there is no "
-            "deployment to call"
-        )
-    if literal:
+    literal = select_endpoint_source(block)
+    if literal is not None:
         return literal
     try:
         route = AzureAIRouteSettings.from_env(environ)

--- a/batch-runner/core/experiment_config.py
+++ b/batch-runner/core/experiment_config.py
@@ -599,13 +599,15 @@ class ExperimentConfig:
             )
 
         if self.execution.mode == "codex_foundry":
-            # Validated by building the settings, so a wrong endpoint shape or
-            # a dated api-version on the undated route is caught while reading
-            # the file rather than at the start of a paid run.
+            # Validated by building the settings, so a dated api-version on the
+            # undated route — or, where the file names one, a wrong endpoint
+            # shape — is caught while reading the file rather than at the start
+            # of a paid run.
             from core.codex_runtime_config import (
                 DEFAULT_PROVIDER_ID,
                 CodexProviderSettings,
-                resolve_endpoint_setting,
+                check_block_apart_from_its_address,
+                select_endpoint_source,
             )
 
             settings_data = self.execution.codex
@@ -616,21 +618,35 @@ class ExperimentConfig:
                 )
             else:
                 try:
-                    # Resolved and then thrown away. This is a fail-fast check
-                    # that the address exists, not a hand-off: the value is
-                    # read again where it is used, so a secret endpoint never
-                    # enters a config object that other steps write to disk.
-                    endpoint = resolve_endpoint_setting(settings_data, os.environ)
-                    CodexProviderSettings(
-                        endpoint=endpoint,
-                        model=str(settings_data.get("model", "")),
-                        provider_id=str(
-                            settings_data.get("provider_id") or DEFAULT_PROVIDER_ID
-                        ),
-                        query_params=tuple(
-                            sorted((settings_data.get("query_params") or {}).items())
-                        ),
-                    )
+                    # Which of the two ways the file names its address is a
+                    # question about the file, so it is asked here. Whether
+                    # *this* environment can supply the deferred one is a
+                    # question about the run place, and it is not asked here:
+                    # `batch-run.yml` validates the experiment file in an early
+                    # step that deliberately holds no credentials, and asking
+                    # it there failed a dispatch whose route was present three
+                    # steps later. `step2_run_inference` resolves the real
+                    # address where the route exists and exits before the first
+                    # turn if it cannot, so nothing that spends is unguarded.
+                    endpoint = select_endpoint_source(settings_data)
+                    if endpoint is None:
+                        check_block_apart_from_its_address(settings_data)
+                    else:
+                        # Named literally, so the address is the file's and
+                        # this is the place to be wrong about it. Built and
+                        # then thrown away: a secret endpoint never enters a
+                        # config object that other steps write to disk.
+                        CodexProviderSettings(
+                            endpoint=endpoint,
+                            model=str(settings_data.get("model", "")),
+                            provider_id=str(
+                                settings_data.get("provider_id")
+                                or DEFAULT_PROVIDER_ID
+                            ),
+                            query_params=dict(
+                                settings_data.get("query_params") or {}
+                            ),
+                        )
                 except (ValueError, TypeError, AttributeError) as exc:
                     errors.append(f"execution.codex is not usable: {exc}")
             if self.condition_a.model.provider != "azure":

--- a/batch-runner/tests/test_an_experiment_can_ask_for_the_codex_run_place.py
+++ b/batch-runner/tests/test_an_experiment_can_ask_for_the_codex_run_place.py
@@ -194,13 +194,25 @@ def test_the_mode_is_accepted_rather_than_reported_as_unknown(exp033, monkeypatc
     assert exp033.validate() == []
 
 
-def test_without_a_route_the_file_fails_early_rather_than_at_spend(
-    exp033, monkeypatch
-):
+def test_without_a_route_the_file_is_still_readable(exp033, monkeypatch):
+    """Reading the file is not the step that needs the run place's credentials.
+
+    This assertion used to be the other way round, under the name
+    *fails early rather than at spend*, and that name was the mistake: the
+    process that reads the file and the process that spends are not the same
+    one. ``batch-run.yml`` validates the experiment in an early step that
+    deliberately holds no credentials — before the gate that decides whether
+    the dispatch may spend at all — and the eager check failed run
+    ``34479664460`` there with "this environment describes no usable Azure
+    route" on a dispatch whose route was present three steps later.
+
+    Nothing about the file goes unchecked as a result; see
+    ``test_the_config_check_does_not_need_the_run_places_credentials.py``,
+    which also holds the guard that still stops a routeless run before a turn.
+    """
     for name in ("AZURE_AI_ROUTE_PROFILE", DIRECT_ENDPOINT_ENV, PROJECT_ENDPOINT_ENV):
         monkeypatch.delenv(name, raising=False)
-    errors = exp033.validate()
-    assert any("execution.codex is not usable" in error for error in errors)
+    assert exp033.validate() == []
 
 
 def test_the_five_tasks_are_the_envelope_five(exp033):

--- a/batch-runner/tests/test_the_config_check_does_not_need_the_run_places_credentials.py
+++ b/batch-runner/tests/test_the_config_check_does_not_need_the_run_places_credentials.py
@@ -1,0 +1,269 @@
+"""Reading an experiment file must not require the run place's credentials.
+
+``exp033``'s address is not in the file. It says ``endpoint_from_route: true``,
+which means "use the Azure route this run place provides" — the same derivation
+every other Azure caller here uses, chosen precisely so that a secret endpoint
+never has to be committed to a public repository.
+
+The check that read that setting resolved the address immediately, against
+``os.environ``. That is right where the environment is the run's own, and wrong
+where it is not, and ``batch-run.yml`` is the second case: it validates the
+experiment file in an early step that deliberately holds no credentials, before
+the gate that decides whether the dispatch may spend at all. So a dispatch of
+``exp033`` died at step 9 of the batch job with
+
+    Invalid experiment config: execution.codex is not usable:
+    execution.codex.endpoint_from_route is set, but this environment describes
+    no usable Azure route: AZURE_AI_ROUTE_PROFILE is required
+
+on run ``34479664460`` — a run whose route was present three steps later. The
+check was not wrong about the environment it was handed. It was asking the
+wrong process.
+
+The split this pins is between two questions that were being answered together:
+
+* **Which way does the file name its address?** A property of the file. Answered
+  wherever the file is, credentials or not, and still refusing a block that sets
+  both keys or neither.
+* **What address does this environment provide?** A property of the run place.
+  Answered only where the run place is.
+
+Nothing is skipped to achieve that, and the guarantee the old check claimed --
+that a run whose address is missing stops before it spends -- is still kept, by
+the step that has the environment to keep it with. Both halves are held below,
+because dropping either would turn this fix into a hole.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import yaml
+
+from core.codex_runtime_config import (
+    ENDPOINT_FROM_ROUTE_KEY,
+    ENDPOINT_LITERAL_KEY,
+    CodexProviderConfigurationError,
+    check_block_apart_from_its_address,
+    select_endpoint_source,
+)
+from core.experiment_config import ExperimentConfig
+
+
+BATCH_RUNNER_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BATCH_RUNNER_ROOT.parent
+EXPERIMENT = BATCH_RUNNER_ROOT / "experiments" / "exp033_codex_foundry_fixed5.yaml"
+STEP2 = BATCH_RUNNER_ROOT / "step2_run_inference.py"
+BATCH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "batch-run.yml"
+
+#: Everything ``AzureAIRouteSettings.from_env`` reads. Cleared together, so the
+#: environment under test is the one the uncredentialed step actually has
+#: rather than whatever the developer running pytest happens to export.
+EVERY_ROUTE_NAME = (
+    "AZURE_AI_ROUTE_PROFILE",
+    "AZURE_AI_DIRECT_ENDPOINT",
+    "AZURE_OPENAI_ENDPOINT",
+    "FOUNDRY_PROJECT_ENDPOINT",
+    "AZURE_AI_PROJECT_ENDPOINT",
+    "AZURE_AI_LEGACY_ENDPOINT",
+    "AZURE_AI_EXPECTED_DIRECT_ACCOUNT",
+    "AZURE_AI_REQUIRE_EXPECTED_IDENTITIES",
+)
+
+#: A deferred block with nothing wrong with it, as exp033 writes one.
+A_GOOD_DEFERRED_BLOCK = {
+    ENDPOINT_FROM_ROUTE_KEY: True,
+    "model": "gpt-5.4",
+    "request_max_retries": 0,
+    "stream_max_retries": 0,
+}
+
+
+@pytest.fixture
+def no_route(monkeypatch):
+    """The environment the early workflow step has: no route, at all."""
+    for name in EVERY_ROUTE_NAME:
+        monkeypatch.delenv(name, raising=False)
+
+
+# ── The failure that happened ───────────────────────────────────────────────
+
+
+def test_the_dispatch_that_died_at_step_nine_now_reads(no_route):
+    """The exact reproduction, with the exact file that failed."""
+    assert ExperimentConfig.from_yaml(str(EXPERIMENT)).validate() == []
+
+
+def test_the_two_questions_are_answered_in_different_places(no_route):
+    """Which key names the address is answerable here; what it resolves to is not."""
+    assert select_endpoint_source(A_GOOD_DEFERRED_BLOCK) is None
+
+    from core.codex_runtime_config import resolve_endpoint_setting
+
+    with pytest.raises(CodexProviderConfigurationError) as raised:
+        resolve_endpoint_setting(A_GOOD_DEFERRED_BLOCK, {})
+    assert "no usable Azure route" in str(raised.value)
+
+
+# ── What is still checked without a route ───────────────────────────────────
+
+
+def test_a_block_naming_neither_is_still_refused():
+    with pytest.raises(CodexProviderConfigurationError) as raised:
+        select_endpoint_source({"model": "gpt-5.4"})
+    assert "neither is set" in str(raised.value)
+
+
+def test_a_block_naming_both_is_still_refused():
+    with pytest.raises(CodexProviderConfigurationError) as raised:
+        select_endpoint_source(
+            {
+                ENDPOINT_LITERAL_KEY: "https://a.services.ai.azure.com/openai/v1/",
+                ENDPOINT_FROM_ROUTE_KEY: True,
+            }
+        )
+    assert "set exactly one" in str(raised.value)
+
+
+def test_a_block_that_is_not_a_block_is_still_refused():
+    for absent in (None, "endpoint_from_route", ["endpoint_from_route"]):
+        with pytest.raises(CodexProviderConfigurationError):
+            select_endpoint_source(absent)
+
+
+@pytest.mark.parametrize(
+    "broken, expected",
+    [
+        ({"model": ""}, "needs the deployment to call"),
+        ({"model": "gpt-5.4", "provider_id": "Not_Valid"}, "lower-case letters"),
+        ({"model": "gpt-5.4", "query_params": {"": "x"}}, "needs a name"),
+        ({"model": "gpt-5.4", "query_params": {"k": 7}}, "must be a string"),
+        (
+            {"model": "gpt-5.4", "query_params": {"api-version": "2024-12-01"}},
+            "undated contract",
+        ),
+    ],
+)
+def test_the_rest_of_a_deferred_block_is_still_its_own_responsibility(
+    broken, expected, no_route
+):
+    """Everything the file decides is still decided while reading the file.
+
+    The ``api-version`` case is the one worth naming: whether it is legal
+    depends on the endpoint's *kind*, and a deferred block has no endpoint to
+    classify. It is still checkable because the route case has exactly one
+    possible kind -- ``resolve_endpoint_setting`` returns ``route.direct_v1``
+    or raises -- so "undated" is known from the file alone.
+    """
+    block = {ENDPOINT_FROM_ROUTE_KEY: True, **broken}
+    with pytest.raises(CodexProviderConfigurationError) as raised:
+        check_block_apart_from_its_address(block)
+    assert expected in str(raised.value)
+
+
+def test_a_literal_address_is_still_checked_where_it_is_written(no_route, tmp_path):
+    """A file that *does* name an address owns it, so a bad one fails here."""
+    document = yaml.safe_load(EXPERIMENT.read_text(encoding="utf-8"))
+    codex = document["execution"]["codex"]
+    codex.pop(ENDPOINT_FROM_ROUTE_KEY)
+    codex[ENDPOINT_LITERAL_KEY] = "https://example.services.ai.azure.com/api/projects/p"
+    path = tmp_path / "literal.yaml"
+    path.write_text(yaml.safe_dump(document), encoding="utf-8")
+
+    errors = ExperimentConfig.from_yaml(str(path)).validate()
+    assert any("execution.codex is not usable" in error for error in errors), errors
+
+
+def test_the_stand_in_address_never_leaves_the_function():
+    """It exists to fix the endpoint's *kind*, not to describe a resource.
+
+    If it were returned, stored or defaulted to, a run could be pointed at a
+    hostname nobody owns; the whole reason the file names no address is that
+    the address must be the approved resource's and nothing else.
+    """
+    from core import codex_runtime_config
+
+    stand_in = codex_runtime_config._THE_SHAPE_A_ROUTE_MUST_PRODUCE
+    module = ast.parse(Path(codex_runtime_config.__file__).read_text(encoding="utf-8"))
+
+    def reads_of_it(tree):
+        return [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name)
+            and node.id == "_THE_SHAPE_A_ROUTE_MUST_PRODUCE"
+            and isinstance(node.ctx, ast.Load)
+        ]
+
+    the_one_function = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "check_block_apart_from_its_address"
+    )
+    assert len(reads_of_it(the_one_function)) == 1
+    assert len(reads_of_it(module)) == 1, "read somewhere other than the one place"
+
+    assert check_block_apart_from_its_address(A_GOOD_DEFERRED_BLOCK) is None
+    assert stand_in not in str(select_endpoint_source(A_GOOD_DEFERRED_BLOCK))
+
+
+# ── The guarantee that moved rather than disappeared ────────────────────────
+
+
+def test_a_routeless_run_still_stops_before_the_first_turn():
+    """Step 2 resolves the address and exits, and does it before the executor.
+
+    This is the half that makes the relaxation above safe. Without it the fix
+    would be a hole: a file that defers to a route no environment provides
+    would read clean and be discovered mid-run, after a turn was bought.
+    """
+    source = STEP2.read_text(encoding="utf-8")
+    resolve_at = source.index("resolve_endpoint_setting(codex_config, os.environ)")
+    exit_at = source.index("sys.exit(1)", resolve_at)
+    handed_to_executor_at = source.index("codex_options=codex_options")
+
+    assert resolve_at < exit_at < handed_to_executor_at
+    assert "execution.codex is not usable" in source[resolve_at:exit_at]
+
+
+# ── Why the early step cannot simply be given the route ─────────────────────
+
+
+def _batch_steps():
+    workflow = yaml.safe_load(BATCH_WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["batch-run"]["steps"]
+
+
+def _step_named(name):
+    for step in _batch_steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"no step named {name!r}")
+
+
+def test_the_step_that_reads_the_file_holds_no_credentials():
+    """Handing it the route would be the other fix, and it is the wrong one.
+
+    This step runs before ``Block unconfirmed codex_foundry``, so giving it the
+    Foundry endpoint would put a secret earlier than the gate that decides
+    whether this dispatch may spend at all. Moving a credential earlier to
+    satisfy a check is exactly the trade this repository does not make.
+    """
+    step = _step_named("Validate full experiment config")
+    declared = " ".join(str(value) for value in (step.get("env") or {}).values())
+    for name in EVERY_ROUTE_NAME:
+        assert name not in declared, name
+    assert "secrets." not in declared
+
+
+def test_it_still_runs_before_the_gate_that_decides_on_spending():
+    names = [step.get("name") for step in _batch_steps()]
+    assert names.index("Validate full experiment config") < names.index(
+        "Block unconfirmed codex_foundry in credentialed general workflow"
+    )
+    assert names.index("Validate full experiment config") < names.index(
+        "Validate Azure OIDC identity before remote access"
+    )


### PR DESCRIPTION
## The dispatch that this fixes

The first `codex_foundry` dispatch — run
[`34479664460`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/34479664460)
— died at step 9 of the batch job:

```
Invalid experiment config: execution.codex is not usable:
execution.codex.endpoint_from_route is set, but this environment
describes no usable Azure route: AZURE_AI_ROUTE_PROFILE is required
```

on a run whose route was present three steps later.

## Why

`ExperimentConfig.validate` called `resolve_endpoint_setting(block, os.environ)`,
which answers two questions at once:

| question | about | answerable where? |
|---|---|---|
| which of the two ways does this block name its address? | **the file** | anywhere |
| what address does that resolve to? | **the run place** | only at the run place |

`batch-run.yml` validates the experiment in an early step that deliberately
holds no credentials. It runs *before* `Block unconfirmed codex_foundry` and
before the OIDC check — that is, before the gate that decides whether this
dispatch may spend at all — so it was made to prove it held credentials it is
not supposed to have.

The check was not wrong about the environment it was handed. It was asking the
wrong process.

## The change

- `select_endpoint_source(block)` answers the file's question alone: the literal
  address, or `None` for a deferred one. It still refuses a block that sets both
  keys or neither.
- `check_block_apart_from_its_address(block)` validates everything else the file
  decides about a deferred block: deployment name, `provider_id`, `query_params`
  names and types, and the `api-version` prohibition.
- `resolve_endpoint_setting` keeps its signature and behaviour, delegates the
  first question, and is still what `step2_run_inference.py` calls — where the
  route exists.

The `api-version` rule survives without an address because a deferred block has
exactly one possible endpoint *kind*: `resolve_endpoint_setting` returns
`route.direct_v1` or raises, so "undated" is known from the file alone. The
stand-in URL that carries that fact into the constructor names no resource, is
read in exactly one function (asserted by AST), and is never returned or stored.

## What did **not** happen

**No credential moved earlier in the job.** The alternative fix — handing the
early step the Foundry endpoint — would have put a secret ahead of the gate
deciding whether this dispatch may spend. A test asserts that step declares no
route variable and still runs before both that gate and the OIDC check.

**Nothing stopped being checked.** The guarantee the eager check claimed — a run
whose address is missing stops before it spends — is kept by the step that has
the environment to keep it. `step2_run_inference.py` resolves the real address
and `sys.exit(1)`s *before* the executor is built; a test pins that source order.

## Tests

New: `test_the_config_check_does_not_need_the_run_places_credentials.py` (15
tests) holds both halves — the relaxation and the guard that makes it safe.
Reverting either half fails it with the run's own message, verified by
temporarily restoring the eager call:

```
E   Left contains one more item: 'execution.codex is not usable:
    execution.codex.endpoint_from_route is set, but this environment
    describes no usable Azure route: AZURE_AI_ROUTE_PROFILE is required'
```

Replaced: `test_without_a_route_the_file_fails_early_rather_than_at_spend`
asserted exactly the behaviour that killed the dispatch. It is now
`test_without_a_route_the_file_is_still_readable`, with the run ID in its
docstring so the correction is not silently re-argued.

Codex + config suites: **167 passed, 8 skipped**. `mypy` on the two changed
modules drops from 4 errors to 2, both pre-existing on `main`
(`cost_metering.py:138`, `experiment_config.py:484`).

## Cost

Run `34479664460` failed before the bubblewrap install, before the sandbox
probe, before OIDC, before a token was bought. **No paid call was made.**
