### PR TITLE
fix(step3): record a run in the mode that ran it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,41 @@ entries land under a fresh dated heading the day they merge to `main`.
   file is the decision the pin asks to see.
 
 ### Fixed
+- **A run that solved a task could not be recorded, because Step 3 had never
+  heard of the mode that solved it.** Run `34485072751` is the first
+  `codex_foundry` dispatch to reach a model. It passed the config check, the
+  isolation probe, the pinned-runtime check, OIDC and route validation;
+  Step 2a ran five tasks, solved one end to end, and collected its deliverable
+  into `workspace/upload/deliverable_files/`. Step 3 then died:
+
+      File ".../batch-runner/core/inference_manifest.py", line 285
+          raise ValueError("inference execution mode is invalid")
+
+  `INFERENCE_EXECUTION_MODES` was a hand-typed list, written once in #140 and
+  never revisited, while two modes were added to the platform beside it —
+  `agentic_sandbox_v2` and `codex_foundry`. Nothing caught the drift, because
+  that list is not read until Step 3, which runs *after* the inference it
+  describes has already been paid for. So the work was done and then discarded
+  at the cheapest step in the job, and the first V2 run to reach Step 3 would
+  have died on the same line.
+
+  It is no longer a second list. It is read off `ExecutionConfig.mode` — the
+  remedy `ExperimentConfig.validate` already applies to its own copy of the
+  same names — plus `legacy`, the one inference path in
+  `step2_run_inference.py` that no experiment file can ask for. A test pins
+  the two together and another builds a provenance record for *every* mode an
+  experiment can name, so the next mode cannot be added without this working.
+
+  Nothing was loosened by admitting the mode. A `codex_foundry` record naming
+  a Code Interpreter route is still refused, and `code_interpreter` still
+  needs its one `project-ci` route. `canonical_execution_mode` also stopped
+  leaking `TypeError: unhashable type` past every caller's `except ValueError`
+  when a record's `execution_mode` is a list rather than a string; it now
+  checks `isinstance` first, like every other validator in that module.
+
+  The same function guards publication — `core/hf_publication.py` calls it
+  when it builds the upload identity — so Step 7 was blocked by this too, and
+  Step 3 is only where it was reached first.
 - **Reading an experiment file demanded the run place's credentials, and the
   step that reads it deliberately has none.** The first `codex_foundry`
   dispatch, run `34479664460`, died at step 9 of the batch job:

--- a/batch-runner/core/inference_manifest.py
+++ b/batch-runner/core/inference_manifest.py
@@ -10,22 +10,42 @@ import re
 import shutil
 import stat
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, get_args, get_type_hints
 from urllib.parse import quote
+
+from core.experiment_config import ExecutionConfig
 
 
 TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
 FULL_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 INFERENCE_PROVENANCE_SCHEMA = "azure-ai-inference-provenance-v2"
-INFERENCE_EXECUTION_MODES = frozenset({
-    "legacy",
-    "code_interpreter",
-    "subprocess",
-    "json_renderer",
-    "sandbox",
-    "agentic_sandbox",
-})
+#: The one inference path no experiment file can name.
+#:
+#: ``step2_run_inference.py`` still has a ``legacy`` branch -- it assembles its
+#: own instruction and calls ``complete()`` directly -- and a record written by
+#: that branch has to stay readable. It is not in ``ExecutionConfig.mode``
+#: because no experiment YAML can ask for it, so it cannot come from there.
+LEGACY_INFERENCE_EXECUTION_MODE = "legacy"
+#: Every mode a provenance record may name: the modes an experiment can ask
+#: for, plus the legacy path above.
+#:
+#: Read off ``ExecutionConfig.mode`` rather than typed out again, for the
+#: reason ``ExperimentConfig.validate`` already gives about its own copy: one
+#: list cannot disagree with itself. This one was typed out, in #140, and then
+#: two modes were added to the platform without it -- ``agentic_sandbox_v2``
+#: and ``codex_foundry``. Nothing noticed, because the list is not read until
+#: Step 3, which runs after the inference it describes.
+#:
+#: What that cost: run 34485072751 was the first ``codex_foundry`` run to reach
+#: a model. It solved a task, collected the deliverable, and wrote the results
+#: file. Step 3 then refused to record it -- ``inference execution mode is
+#: invalid`` -- so a run that had already been paid for could not be formatted,
+#: published, or graded. The work was done and then discarded at the cheapest
+#: step in the job.
+INFERENCE_EXECUTION_MODES = frozenset(
+    get_args(get_type_hints(ExecutionConfig)["mode"])
+) | {LEGACY_INFERENCE_EXECUTION_MODE}
 STEP2_PROGRESS_SCHEMA = "step2-progress-v2"
 STEP2_RESULT_STATUSES = frozenset({
     "success", "error", "qa_failed", "pending"
@@ -281,7 +301,11 @@ def canonicalize_azure_ai_routes(value: Any) -> list[dict[str, str]]:
 
 
 def canonical_execution_mode(value: Any) -> str:
-    if value not in INFERENCE_EXECUTION_MODES:
+    # `isinstance` first, like every other validator here, because a record is
+    # arbitrary JSON: `"execution_mode": ["codex_foundry"]` reached the `in`
+    # test and raised `TypeError: unhashable type` past every caller's
+    # `except ValueError`, turning a malformed field into a crash.
+    if not isinstance(value, str) or value not in INFERENCE_EXECUTION_MODES:
         raise ValueError("inference execution mode is invalid")
     return value
 

--- a/batch-runner/tests/test_a_finished_run_can_be_recorded_in_the_mode_that_ran.py
+++ b/batch-runner/tests/test_a_finished_run_can_be_recorded_in_the_mode_that_ran.py
@@ -1,0 +1,232 @@
+"""A run that reached a model must be recordable in the mode that ran.
+
+Run `34485072751` was the first `codex_foundry` dispatch to get past the
+config check, the isolation probe, the pinned-runtime check, OIDC, and the
+route validation. Step 2a succeeded: five tasks were attempted, one was
+solved end to end, and its deliverable was collected into
+`workspace/upload/deliverable_files/`. Then Step 3 died:
+
+    File ".../batch-runner/step3_format_results.py", line 337
+        provenance = build_inference_provenance(final_json)
+    File ".../batch-runner/core/inference_manifest.py", line 285
+        raise ValueError("inference execution mode is invalid")
+    ValueError: inference execution mode is invalid
+
+The mode was `codex_foundry`, which is a mode an experiment file may name and
+which `ExperimentConfig.validate` had already accepted four steps earlier.
+`INFERENCE_EXECUTION_MODES` had simply never heard of it -- it was typed out
+by hand in #140 and two modes were added to the platform afterwards without
+it. Nothing caught the drift because that list is not read until Step 3, which
+runs after the inference it describes has already been paid for.
+
+So these tests hold two things:
+
+* the mode that ran can be recorded -- for every mode, not just this one; and
+* the list cannot drift away from `ExecutionConfig.mode` again, because it is
+  no longer a second list.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import get_args, get_type_hints
+
+import pytest
+
+from core.experiment_config import ExecutionConfig
+from core.inference_manifest import (
+    INFERENCE_EXECUTION_MODES,
+    LEGACY_INFERENCE_EXECUTION_MODE,
+    build_inference_provenance,
+    canonical_execution_mode,
+    validate_execution_route_binding,
+)
+
+
+EVERY_MODE_AN_EXPERIMENT_CAN_ASK_FOR = get_args(
+    get_type_hints(ExecutionConfig)["mode"]
+)
+
+#: What Codex recorded on run `34485072751`: one direct-v1 route, serving
+#: inference. Codex signs in for itself, so there is no separate client route
+#: and no Code Interpreter route. The fingerprint is stand-in; its real value
+#: is a hash of resolved route settings and nothing here depends on which.
+THE_ROUTE_CODEX_RECORDED = {
+    "endpoint_kind": "direct-v1",
+    "profile": "direct-v1",
+    "runtime_fingerprint": "f" * 64,
+    "workload": "inference",
+}
+
+#: The five tasks of `exp033_codex_foundry_fixed5`, in the order the run put
+#: them in. `0112fc9b...` is the one that was solved.
+THE_FIVE_TASKS = [
+    "02aa1805-c658-4069-8a6a-02dec146063a",
+    "0112fc9b-c3b2-4084-8993-5a4abb1f54f1",
+    "2ea2e5b5-257f-42e6-a7dc-93763f28b19d",
+    "3baa0009-5a60-4ae8-ae99-4955cb328ff3",
+    "0818571f-5ff7-4d39-9d2c-ced5ae44299e",
+]
+
+
+def a_results_file(mode, *, routes=None, results=None):
+    """The shape Step 3 hands `build_inference_provenance`."""
+    return {
+        "experiment_id": "exp033_codex_foundry_fixed5",
+        "source_repo_id": "owner/exp033_codex_foundry_fixed5",
+        "prepared_fingerprint": "e" * 64,
+        "execution_mode": mode,
+        "azure_ai_routes": (
+            [THE_ROUTE_CODEX_RECORDED] if routes is None else routes
+        ),
+        "results": (
+            [{"task_id": task_id, "deliverable_files": []}
+             for task_id in THE_FIVE_TASKS]
+            if results is None else results
+        ),
+    }
+
+
+def the_run_that_died_at_step_three():
+    """Run `34485072751`'s own result file, down to what Step 3 reads.
+
+    One task solved with one deliverable, four errored, and the single
+    direct-v1 inference route the run recorded.
+    """
+    solved = "0112fc9b-c3b2-4084-8993-5a4abb1f54f1"
+    return a_results_file(
+        "codex_foundry",
+        results=[
+            {
+                "task_id": task_id,
+                "deliverable_files": (
+                    [f"deliverable_files/{task_id}/soap_note_2024-03-01_CS.md"]
+                    if task_id == solved else []
+                ),
+            }
+            for task_id in THE_FIVE_TASKS
+        ],
+    )
+
+
+def test_the_run_that_solved_a_task_can_now_be_recorded():
+    provenance = build_inference_provenance(the_run_that_died_at_step_three())
+
+    assert provenance["execution_mode"] == "codex_foundry"
+    assert provenance["task_count"] == 5
+    assert provenance["azure_ai_routes"] == [THE_ROUTE_CODEX_RECORDED]
+
+
+def test_the_record_is_still_a_json_document():
+    """Nothing in the new constant leaks a frozenset into the sidecar."""
+    provenance = build_inference_provenance(the_run_that_died_at_step_three())
+
+    assert json.loads(json.dumps(provenance)) == provenance
+
+
+@pytest.mark.parametrize("mode", EVERY_MODE_AN_EXPERIMENT_CAN_ASK_FOR)
+def test_every_mode_an_experiment_can_ask_for_can_be_recorded(mode):
+    """The general form of the defect, not just the mode that hit it.
+
+    `agentic_sandbox_v2` was missing from the old list too, and would have
+    died at the same line on the first V2 run to reach Step 3.
+    """
+    routes = (
+        [{
+            "endpoint_kind": "project",
+            "profile": "project-ci",
+            "runtime_fingerprint": "a" * 64,
+            "workload": "code-interpreter",
+        }]
+        if mode == "code_interpreter" else None
+    )
+
+    provenance = build_inference_provenance(a_results_file(mode, routes=routes))
+
+    assert provenance["execution_mode"] == mode
+
+
+def test_the_two_lists_cannot_drift_again():
+    """Not "these seven names", which is what drifted. One list, plus legacy."""
+    assert INFERENCE_EXECUTION_MODES == (
+        frozenset(EVERY_MODE_AN_EXPERIMENT_CAN_ASK_FOR)
+        | {LEGACY_INFERENCE_EXECUTION_MODE}
+    )
+
+
+def test_the_modes_that_were_missing_are_the_ones_added_after_the_list():
+    """Names the drift, so a future reader sees what was lost and when."""
+    assert {"agentic_sandbox_v2", "codex_foundry"} <= INFERENCE_EXECUTION_MODES
+
+
+def test_the_legacy_path_is_still_recordable():
+    provenance = build_inference_provenance(
+        a_results_file(LEGACY_INFERENCE_EXECUTION_MODE)
+    )
+
+    assert provenance["execution_mode"] == "legacy"
+
+
+def test_legacy_is_not_something_an_experiment_can_ask_for():
+    """Why it has to be added by hand rather than read off the annotation.
+
+    `step2_run_inference.py` still has a `legacy` branch, so records naming it
+    must stay readable -- but no experiment YAML can select it.
+    """
+    assert LEGACY_INFERENCE_EXECUTION_MODE not in EVERY_MODE_AN_EXPERIMENT_CAN_ASK_FOR
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["", None, "Codex_Foundry", "codex", "codex_foundry ", 7, ["codex_foundry"]],
+)
+def test_a_mode_no_experiment_can_name_is_still_refused(mode):
+    """Including the unhashable one: a record is arbitrary JSON.
+
+    `["codex_foundry"]` used to reach the membership test and raise
+    `TypeError: unhashable type: 'list'`, which is not what any caller here
+    catches -- `step3_format_results.py` and `core/hf_publication.py` both
+    handle `ValueError` and would have crashed instead of reporting.
+    """
+    with pytest.raises(ValueError, match="inference execution mode is invalid"):
+        canonical_execution_mode(mode)
+
+
+def test_a_codex_run_carrying_a_code_interpreter_route_is_still_refused():
+    """Admitting the mode did not loosen what the record may claim.
+
+    Codex reaches the direct v1 endpoint and signs in for itself; a
+    `codex_foundry` record naming a Code Interpreter route describes a run
+    that cannot have happened.
+    """
+    with pytest.raises(
+        ValueError,
+        match="non-Code-Interpreter provenance contains a Code Interpreter route",
+    ):
+        validate_execution_route_binding("codex_foundry", [{
+            "endpoint_kind": "project",
+            "profile": "project-ci",
+            "runtime_fingerprint": "a" * 64,
+            "workload": "code-interpreter",
+        }])
+
+
+def test_code_interpreter_still_needs_its_project_route():
+    with pytest.raises(
+        ValueError,
+        match="Code Interpreter provenance requires one project-ci route",
+    ):
+        validate_execution_route_binding(
+            "code_interpreter", [THE_ROUTE_CODEX_RECORDED]
+        )
+
+
+def test_the_publication_path_asks_the_same_question():
+    """`hf_publication` calls the same function, so Step 7 was blocked too.
+
+    Step 3 is only where it was first reached; `build_publication_identity`
+    would have refused the same run at upload.
+    """
+    from core import hf_publication
+
+    assert hf_publication.canonical_execution_mode is canonical_execution_mode


### PR DESCRIPTION
Run [`34485072751`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/34485072751) was the first `codex_foundry` dispatch to reach a model. Step 2a succeeded — five tasks attempted, **one solved end to end**, its deliverable collected into `workspace/upload/deliverable_files/`. Step 3 then refused to record it:

```
File "batch-runner/core/inference_manifest.py", line 285
    raise ValueError("inference execution mode is invalid")
```

The mode was `codex_foundry`, which is a mode an experiment file may name and which `ExperimentConfig.validate` had accepted four steps earlier. `INFERENCE_EXECUTION_MODES` had simply never heard of it.

### Why it went unnoticed

That list was typed out by hand in #140 and two modes were added to the platform afterwards without it — `agentic_sandbox_v2` and `codex_foundry` (#454). Nothing caught the drift because **the list is not read until Step 3, which runs after the inference it describes has already been paid for.** Work that was done was discarded at the cheapest step in the job.

### The change

Derive the list from `ExecutionConfig.mode` rather than keeping a second copy — the reason `ExperimentConfig.validate` already gives about its own copy (`experiment_config.py:533`): *one list cannot disagree with itself.* `legacy` is added by hand, because `step2_run_inference.py` still has that branch and records naming it must stay readable, but no experiment YAML can select it.

`canonical_execution_mode` now checks `isinstance` before membership. `{"execution_mode": ["codex_foundry"]}` previously reached the `in` test and raised `TypeError: unhashable type`, which is not what `step3_format_results.py` or `core/hf_publication.py` catch — a malformed field became a crash instead of a report.

### What was not loosened

- a `codex_foundry` record carrying a Code Interpreter route is still refused;
- `code_interpreter` still requires exactly one `project-ci` route;
- no new positive route rule was invented for `codex_foundry` from one observed run — the real run's single `direct-v1` inference route passes the existing rule unchanged, and Step 2's own `_validate_azure_ai_routes` already enforces profile/endpoint/workload coherence before the list gets here.

`core/hf_publication.py` calls the same function, so Step 7 was blocked by this too; Step 3 is only where it was reached first.

### Verification

- 23 new tests, including one pinning the derived list to `ExecutionConfig.mode` so the two cannot drift again, and one asserting `hf_publication` asks the same question.
- Reverted `INFERENCE_EXECUTION_MODES` to its #140 form and re-ran: **7 fail**, including `codex_foundry` and `agentic_sandbox_v2`. It is a reproducing regression test, not a restatement.
- Full backend suite on this branch: **9739 passed, 18 skipped, 46 deselected**, exit 0.
- `mypy core/inference_manifest.py`: no new errors.

Reproduced from the run's own `results/exp033_codex_foundry_fixed5/exp033_codex_foundry_fixed5.json`, which now builds a provenance record with `execution_mode: codex_foundry`, `task_count: 5`, and the one `direct-v1` route preserved.
