### PR TITLE
fix(codex): stop a hidden file from discarding a solved task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,42 @@ entries land under a fresh dated heading the day they merge to `main`.
   file is the decision the pin asks to see.
 
 ### Fixed
+- **A stray dotfile cost a task the model had already solved.** On the same
+  run, `34485072751`, task 3 of 5:
+
+      [3/5] 2ea2e5b5-...-93763f28b19d (Computer and Information Systems
+      Managers)... ✗ deliverable filename is invalid or duplicated
+
+  The model had answered by then — the task's own receipt records one model
+  call, 268,999 input tokens and 8,727 output tokens. The answer was collected
+  out of the workspace and refused on the way to disk, and because the saver
+  refuses a *batch* rather than a file, the good files went down with whichever
+  one was bad. Which one that was cannot be recovered: the message named no
+  file, and a task's workspace is deleted when the task ends.
+
+  Two rules had drifted apart. `CodexWorkspace.collect_deliverables` excluded
+  six names by hand — `.codex`, `.git`, `__pycache__`, `.pytest_cache`,
+  `.venv`, `node_modules` — while `_save_files` refuses *any* path component
+  beginning with a dot, plus backslashes, plus a name it has already seen. Four
+  of the collector's six were dot-names, so the intent was the same; the
+  collector had just written it out as a list, and a seventh dot-name passed it
+  and hit the saver. An agent told to build something in a directory writes
+  `.gitignore` and friends without being asked. Neither function had a test.
+
+  The collector now emits only names the saver will accept. Anything with a
+  hidden component is skipped rather than enumerated; `\` joins the NTFS
+  replacement set it was always a member of, so a Linux-legal `q1\q2.md`
+  becomes `q1_q2.md` instead of a refusal; and two files that collide after
+  replacement are numbered — `q1_ (2).md` — rather than one of them killing the
+  task. A test asserts the property directly: whatever the collector produced,
+  the real `_save_files` accepts.
+
+  A refusal that remains now says which file it is about. The collector is not
+  the only producer of deliverables, so the saver still refuses names, and the
+  name comes from the model and goes into a build log: it is `repr`-quoted so a
+  newline cannot forge a log line, and truncated so a long one cannot flood it.
+  The deliberate limit: a name that is too long or too deep for the filesystem
+  is still fatal to its task. It is now diagnosable.
 - **A run that solved a task could not be recorded, because Step 3 had never
   heard of the mode that solved it.** Run `34485072751` is the first
   `codex_foundry` dispatch to reach a model. It passed the config check, the

--- a/batch-runner/core/codex_runner.py
+++ b/batch-runner/core/codex_runner.py
@@ -73,17 +73,49 @@ CODEX_TURN_TIMEOUT = int(os.getenv("CODEX_TURN_TIMEOUT", "900"))
 #: interrupt first; only when that produces nothing is the process torn down.
 CODEX_INTERRUPT_GRACE_SECONDS = float(os.getenv("CODEX_INTERRUPT_GRACE", "20"))
 
-#: Files the runtime keeps for its own purposes, which are not deliverables.
+#: Files the runtime keeps for its own purposes, which are not deliverables
+#: and whose names do not begin with a dot. The four that did -- ``.codex``,
+#: ``.git``, ``.pytest_cache``, ``.venv`` -- are covered by the rule in
+#: :meth:`CodexWorkspace.collect_deliverables` that skips anything hidden, and
+#: naming them here as well would suggest the others are collectable.
 _NOT_A_DELIVERABLE = (
-    ".codex",
-    ".git",
     "__pycache__",
-    ".pytest_cache",
-    ".venv",
     "node_modules",
 )
 
-_NTFS_FORBIDDEN = re.compile(r'[:"<>|*?\r\n]')
+#: Characters NTFS will not take in a name, replaced so a deliverable produced
+#: on Linux can still be downloaded on Windows. ``\`` is on that list for the
+#: same reason the rest are, and was the one member missing: a file named
+#: ``q1\q2.md`` is one legal name here and a name ``_save_files`` refuses.
+_NTFS_FORBIDDEN = re.compile(r'[\\:"<>|*?\r\n]')
+
+
+def _unused_deliverable_name(name: str, taken: set[str]) -> str:
+    """``name``, or the first free variation of it.
+
+    Replacing forbidden characters can map two distinct files onto one name --
+    ``q1?.md`` and ``q1_.md`` both become ``q1_.md``. ``_save_files`` refuses a
+    repeat, and refusing costs the task every other file with it. Neither of
+    the two is litter, so neither is dropped; the second is numbered, the way
+    anything else that receives a name it already has does it.
+
+    Returns ``name`` unchanged if nothing is free, leaving the saver to refuse
+    it. That is the honest outcome for a hundred colliding names: better a
+    refusal that says which file than a silent hundred-and-first guess.
+    """
+    if name not in taken:
+        return name
+    parent, separator, base = name.rpartition("/")
+    stem, dot, extension = base.rpartition(".")
+    # `rpartition` puts everything in the third value when there is no dot, and
+    # the split is done on the base so `v1.0/README` is not read as an
+    # extension of `v1`.
+    head, tail = (stem, dot + extension) if dot else (base, "")
+    for ordinal in range(2, 100):
+        candidate = f"{parent}{separator}{head} ({ordinal}){tail}"
+        if candidate not in taken:
+            return candidate
+    return name
 
 #: How long the auth-command preflight waits. Generous next to the runtime's
 #: own 30s auth timeout, because a first sign-in can be slower than a cached
@@ -333,9 +365,15 @@ class CodexWorkspace:
         makes one. The staged references are excluded by name: they came from
         the task, and returning them as output would credit the run with
         producing its own inputs.
+
+        Every name returned is one ``_save_files`` will accept. That is not a
+        courtesy. The saver refuses a batch, not a file, so one unsaveable
+        name discards the whole task -- and on run 34485072751 one did, to a
+        task the model had already answered.
         """
         skip = set(self.staged_reference_names)
         collected: list[dict[str, Any]] = []
+        taken: set[str] = set()
         for path in sorted(self.workspace.rglob("*")):
             if path.is_dir():
                 continue
@@ -344,6 +382,12 @@ class CodexWorkspace:
             except ValueError:  # pragma: no cover - rglob stays inside
                 continue
             if any(part in _NOT_A_DELIVERABLE for part in relative.parts):
+                continue
+            if any(part.startswith(".") for part in relative.parts):
+                # Not a deliverable, and not saveable either: `_save_files`
+                # refuses any hidden component. An agent building something in
+                # a directory writes `.gitignore` and friends without being
+                # asked, and before this they took the answer down with them.
                 continue
             if relative.as_posix() in skip or relative.name in skip:
                 continue
@@ -357,12 +401,11 @@ class CodexWorkspace:
                 content = path.read_bytes()
             except OSError:
                 continue
-            collected.append(
-                {
-                    "filename": _NTFS_FORBIDDEN.sub("_", relative.as_posix()),
-                    "content": content,
-                }
+            filename = _unused_deliverable_name(
+                _NTFS_FORBIDDEN.sub("_", relative.as_posix()), taken
             )
+            taken.add(filename)
+            collected.append({"filename": filename, "content": content})
         return collected
 
     def cleanup(self) -> None:

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -37,7 +37,7 @@ import time
 import yaml
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, List
+from typing import Any, Optional, List
 
 # Deliberately not in ``core/``: ``step8_grade.compute_grader_source_hash``
 # hashes every ``core/**/*.py``, so a module there would move the grader's
@@ -1805,6 +1805,21 @@ def _run_self_qa(
 # ── File saving (matches main.py _save_files) ─────────────────────────────
 
 
+def _quote_rejected_name(filename: Any) -> str:
+    """The name a refusal is about, safe to put in a build log.
+
+    Run 34485072751 lost a task to ``deliverable filename is invalid or
+    duplicated`` and the log could not say which file, because the message
+    never held one and the task's directory is deleted when the task ends. So
+    the name goes in the message -- but the name came from the model, and the
+    message goes into a log, so it is quoted rather than interpolated: ``repr``
+    escapes a newline that would otherwise forge a log line, and the result is
+    cut short of a name long enough to bury the rest of the run's output.
+    """
+    quoted = repr(filename)
+    return quoted if len(quoted) <= 160 else quoted[:157] + "..."
+
+
 def _save_files(
     files: List[dict],
     task_id: str,
@@ -1824,7 +1839,9 @@ def _save_files(
             raise ValueError("deliverable file record is invalid")
         filename = file_data["filename"]
         if not isinstance(filename, str) or "\\" in filename:
-            raise ValueError("deliverable filename is invalid")
+            raise ValueError(
+                f"deliverable filename is invalid: {_quote_rejected_name(filename)}"
+            )
         relative = Path(filename)
         canonical = relative.as_posix()
         if (
@@ -1837,7 +1854,10 @@ def _save_files(
             or len(canonical.encode("utf-8")) > 240
             or canonical in seen
         ):
-            raise ValueError("deliverable filename is invalid or duplicated")
+            raise ValueError(
+                "deliverable filename is invalid or duplicated: "
+                f"{_quote_rejected_name(filename)}"
+            )
         content = file_data["content"]
         if isinstance(content, str):
             encoded = content.encode("utf-8")

--- a/batch-runner/tests/test_a_stray_dotfile_cost_a_solved_task.py
+++ b/batch-runner/tests/test_a_stray_dotfile_cost_a_solved_task.py
@@ -1,0 +1,319 @@
+"""What the workspace hands over has to be something the run can save.
+
+Run `34485072751`, task 3 of 5:
+
+    [3/5] 2ea2e5b5-...-93763f28b19d (Computer and Information Systems
+    Managers)... ✗ deliverable filename is invalid or duplicated
+
+The model had already answered by then. Its own receipt for that task records
+one model call, 268,999 input tokens and 8,727 output tokens. The answer was
+collected out of the workspace and then refused on the way to disk, and the
+whole task was recorded as an error -- deliverables included, the good files
+along with whatever the bad one was.
+
+Which one was bad cannot be recovered. The message names no file, and the
+task's directory is deleted when the task ends. So these tests do two things:
+they make the refusal impossible for the cases that caused it, and they make
+any refusal that remains say which file it was about.
+
+The cause was two rules that had drifted apart:
+
+* `CodexWorkspace.collect_deliverables` excluded six names by hand --
+  `.codex`, `.git`, `__pycache__`, `.pytest_cache`, `.venv`, `node_modules`.
+* `_save_files` refuses *any* path component beginning with a dot, plus
+  backslashes, plus a name it has already seen.
+
+Four of the collector's six were dot-names, so the intent was the same; the
+collector had just written it out as a list. A seventh dot-name -- and an
+agent working in a directory makes those without being asked -- passed the
+collector and hit the saver. Neither function had a test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from core.codex_runner import CodexWorkspace
+from step2_run_inference import _save_files
+
+
+def a_workspace(tmp_path: Path, files: dict[str, str]) -> CodexWorkspace:
+    """A task's workspace holding exactly `files`, keyed by relative path.
+
+    Built directly rather than through `CodexWorkspace.create`, which resolves
+    a run root outside the temporary directory for reasons that have nothing
+    to do with collecting files.
+    """
+    root = tmp_path / "root"
+    workspace = root / "workspace"
+    for relative, text in files.items():
+        path = workspace / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    workspace.mkdir(parents=True, exist_ok=True)
+    (root / "codex_home").mkdir(parents=True, exist_ok=True)
+    (root / "home").mkdir(parents=True, exist_ok=True)
+    return CodexWorkspace(
+        root=root,
+        workspace=workspace,
+        codex_home=root / "codex_home",
+        home=root / "home",
+    )
+
+
+def names(collected) -> list[str]:
+    return [entry["filename"] for entry in collected]
+
+
+# ── the file that was lost ───────────────────────────────────────────────
+
+
+def test_a_hidden_file_no_longer_costs_the_task(tmp_path):
+    """The shape of run 34485072751's task 3: an answer, and a dot-name.
+
+    `.gitignore` is the ordinary case -- an agent told to build something in a
+    directory writes one. Before, it reached `_save_files`, which refused it,
+    which discarded the report next to it.
+    """
+    workspace = a_workspace(
+        tmp_path,
+        {
+            "systems_assessment.md": "# Assessment\n",
+            ".gitignore": "__pycache__/\n",
+        },
+    )
+
+    collected = workspace.collect_deliverables()
+
+    assert names(collected) == ["systems_assessment.md"]
+
+
+def test_the_answer_survives_being_saved(tmp_path):
+    """Collected is not the same as saved. This runs the real saver."""
+    workspace = a_workspace(
+        tmp_path,
+        {
+            "soap_note_2024-03-01_CS.md": "# SOAP\n",
+            ".config/settings.json": "{}",
+        },
+    )
+
+    saved = _save_files(
+        workspace.collect_deliverables(),
+        "0112fc9b-c3b2-4084-8993-5a4abb1f54f1",
+        upload_root=tmp_path / "upload",
+    )
+
+    assert saved == [
+        "deliverable_files/0112fc9b-c3b2-4084-8993-5a4abb1f54f1"
+        "/soap_note_2024-03-01_CS.md"
+    ]
+
+
+def test_a_hidden_directory_takes_what_is_under_it(tmp_path):
+    """The dot can be on any component, not just the last one."""
+    workspace = a_workspace(
+        tmp_path,
+        {"report.md": "x", ".cache/pip/wheel": "y", "notes/.draft.md": "z"},
+    )
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+@pytest.mark.parametrize(
+    "litter",
+    [".codex/sessions/a.jsonl", ".git/config", ".pytest_cache/v/x",
+     ".venv/bin/python", "__pycache__/m.cpython-310.pyc", "node_modules/p/i.js"],
+)
+def test_the_six_that_were_named_by_hand_are_still_skipped(tmp_path, litter):
+    """Generalising the rule did not stop excluding what it used to exclude."""
+    workspace = a_workspace(tmp_path, {"report.md": "x", litter: "y"})
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+# ── the other two ways a name could not be saved ─────────────────────────
+
+
+def test_a_backslash_is_replaced_like_every_other_forbidden_character(tmp_path):
+    r"""On Linux `a\b.md` is one legal filename. To the saver it is a refusal.
+
+    `_NTFS_FORBIDDEN` is named for the set NTFS will not take, and `\` is in
+    that set; it was the one member missing. Replacing it costs nothing on
+    Linux and is required on Windows anyway.
+    """
+    workspace = a_workspace(tmp_path, {"q1\\q2.md": "x"})
+
+    assert names(workspace.collect_deliverables()) == ["q1_q2.md"]
+
+
+def test_two_names_that_collide_after_replacement_both_survive(tmp_path):
+    """Replacement can map two distinct files onto one name.
+
+    The saver refuses the second as a duplicate, and the task dies. Neither
+    file is litter, so neither is dropped: the second is given a name that is
+    free, the way anything else that downloads a file twice does it.
+    """
+    workspace = a_workspace(tmp_path, {"q1?.md": "first", "q1_.md": "second"})
+
+    collected = workspace.collect_deliverables()
+
+    assert sorted(names(collected)) == ["q1_ (2).md", "q1_.md"]
+    assert sorted(entry["content"] for entry in collected) == [b"first", b"second"]
+
+
+def test_a_collision_without_an_extension_is_still_resolved(tmp_path):
+    workspace = a_workspace(tmp_path, {"Makefile?": "a", "Makefile_": "b"})
+
+    assert sorted(names(workspace.collect_deliverables())) == [
+        "Makefile_", "Makefile_ (2)"
+    ]
+
+
+def test_a_dot_in_a_directory_name_is_not_mistaken_for_an_extension(tmp_path):
+    """`v1.0/README` renames on the file, not on the directory."""
+    workspace = a_workspace(tmp_path, {"v1.0/README?": "a", "v1.0/README_": "b"})
+
+    assert sorted(names(workspace.collect_deliverables())) == [
+        "v1.0/README_", "v1.0/README_ (2)"
+    ]
+
+
+# ── the invariant ────────────────────────────────────────────────────────
+
+
+def test_everything_the_workspace_offers_can_be_saved(tmp_path):
+    """The property the two functions have to have, over the awkward cases.
+
+    This is the test that would have caught it. It does not assert a list of
+    names; it asserts that the saver accepts whatever the collector produced.
+    """
+    workspace = a_workspace(
+        tmp_path,
+        {
+            "report.md": "a",
+            "data/summary.csv": "b",
+            ".gitignore": "c",
+            ".config/x.json": "d",
+            "notes/.hidden": "e",
+            "__pycache__/m.pyc": "f",
+            "node_modules/p/i.js": "g",
+            "chart?.png": "h",
+            "chart_.png": "i",
+            "path\\with\\backslash.txt": "j",
+            'quote".txt': "k",
+            "a:b<c>d|e*f.txt": "l",
+        },
+    )
+
+    collected = workspace.collect_deliverables()
+
+    saved = _save_files(collected, "t", upload_root=tmp_path / "upload")
+    assert len(saved) == len(collected)
+    for relative in saved:
+        assert (tmp_path / "upload" / relative).is_file()
+
+
+# ── what a refusal says when there still is one ──────────────────────────
+
+
+def test_a_refusal_names_the_file(tmp_path):
+    """The message run 34485072751 produced, with the one fact it lacked.
+
+    The collector cannot be the only producer of deliverables -- every
+    execution mode's files come through here -- so the saver still refuses
+    names. It now says which.
+    """
+    with pytest.raises(ValueError) as refusal:
+        _save_files(
+            [{"filename": ".gitignore", "content": b"x"}],
+            "t",
+            upload_root=tmp_path / "upload",
+        )
+
+    assert "deliverable filename is invalid or duplicated" in str(refusal.value)
+    assert ".gitignore" in str(refusal.value)
+
+
+def test_a_refused_name_cannot_write_its_own_line_into_the_log(tmp_path):
+    """The name comes from the model, and goes into a build log.
+
+    A newline in it would let a rejected filename forge log lines. `repr`
+    escapes it, which is why the message quotes rather than interpolates.
+    """
+    with pytest.raises(ValueError) as refusal:
+        _save_files(
+            [{"filename": ".a\nStep 3: Format results\n", "content": b"x"}],
+            "t",
+            upload_root=tmp_path / "upload",
+        )
+
+    assert "\n" not in str(refusal.value)
+
+
+def test_a_refused_name_cannot_fill_the_log_either(tmp_path):
+    with pytest.raises(ValueError) as refusal:
+        _save_files(
+            [{"filename": "." + "n" * 5000, "content": b"x"}],
+            "t",
+            upload_root=tmp_path / "upload",
+        )
+
+    assert len(str(refusal.value)) < 400
+
+
+def test_the_duplicate_that_is_named_is_the_second_one(tmp_path):
+    """A producer that is not the collector can still send two of a name."""
+    with pytest.raises(ValueError, match="report.md"):
+        _save_files(
+            [
+                {"filename": "report.md", "content": b"a"},
+                {"filename": "report.md", "content": b"b"},
+            ],
+            "t",
+            upload_root=tmp_path / "upload",
+        )
+
+
+# ── what did not change ──────────────────────────────────────────────────
+
+
+def test_a_staged_reference_is_still_not_a_deliverable(tmp_path):
+    """Returning an input as output would credit the run with its own input."""
+    workspace = a_workspace(tmp_path, {"input.xlsx": "a", "report.md": "b"})
+    workspace.staged_reference_names = ("input.xlsx",)
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+def test_a_symlink_is_still_not_collected(tmp_path):
+    workspace = a_workspace(tmp_path, {"report.md": "a"})
+    outside = tmp_path / "outside.md"
+    outside.write_text("not produced here", encoding="utf-8")
+    (workspace.workspace / "link.md").symlink_to(outside)
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+def test_a_pyc_is_still_not_collected(tmp_path):
+    workspace = a_workspace(tmp_path, {"report.md": "a", "helper.pyc": "b"})
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+def test_an_empty_workspace_collects_nothing(tmp_path):
+    assert a_workspace(tmp_path, {}).collect_deliverables() == []
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root reads a mode 000 file")
+def test_a_file_that_cannot_be_read_is_skipped_not_fatal(tmp_path):
+    """Unreadable is not the same as invalid; it was skipped before, still is."""
+    workspace = a_workspace(tmp_path, {"report.md": "a", "locked.md": "b"})
+    (workspace.workspace / "locked.md").chmod(0o000)
+    try:
+        assert names(workspace.collect_deliverables()) == ["report.md"]
+    finally:
+        (workspace.workspace / "locked.md").chmod(0o600)


### PR DESCRIPTION
## What happened

Run [`34485072751`](https://github.com/hyeonsangjeon/gdpval-realworks/actions/runs/34485072751), task 3 of 5:

```
[3/5] 2ea2e5b5-...-93763f28b19d (Computer and Information Systems Managers)... ✗ deliverable filename is invalid or duplicated
```

The model had already answered. That task's own receipt records one model call, **268,999 input tokens and 8,727 output tokens**. The answer was collected out of the workspace and then refused on the way to disk.

`_save_files` refuses a *batch*, not a file — so the good files went down with whichever one was bad. Which one that was cannot be recovered: the message named no file, and a task's workspace is deleted when the task ends.

## Why

Two rules had drifted apart, and neither function had a test.

| | rule |
|---|---|
| `CodexWorkspace.collect_deliverables` | excludes six names by hand: `.codex`, `.git`, `__pycache__`, `.pytest_cache`, `.venv`, `node_modules` |
| `_save_files` | refuses **any** dot-prefixed path component, **any** backslash, **any** duplicate |

Four of the collector's six were dot-names, so the intent was the same — the collector had just written it out as a list. A seventh dot-name passed it and hit the saver. An agent told to build something in a directory writes `.gitignore` and friends without being asked.

## The change

The collector now emits only names the saver will accept.

- **Hidden components are skipped rather than enumerated.** `_NOT_A_DELIVERABLE` keeps only the two non-dot names; naming the other four as well would suggest the rest are collectable.
- **`\` joins `_NTFS_FORBIDDEN`**, the set it was always a member of. A Linux-legal `q1\q2.md` becomes `q1_q2.md` instead of a refusal.
- **Collisions are numbered, not dropped.** Replacement can map two distinct files onto one name; the second becomes `q1_ (2).md`, the way anything else that downloads a file twice does it.

One test asserts the property directly rather than a list of names: whatever the collector produced, the real `_save_files` accepts it. That is the test that would have caught this.

## The refusals that remain

The collector is not the only producer of deliverables — every execution mode's files come through `_save_files` — so it still refuses names. It now says which file it is about, `repr`-quoted so a newline cannot forge a log line and truncated at 160 characters so a long name cannot flood one. The name comes from a model and goes into a build log.

**Deliberate limit:** a name too long or too deep for the filesystem is still fatal to its task. It is now diagnosable.

## Tests

`batch-runner/tests/test_a_stray_dotfile_cost_a_solved_task.py` — 23 tests. Reverting both source files fails **10** of them, spanning every category: hidden files, the backslash, both collision cases, the invariant, and the unnamed refusal.

The "what did not change" block pins what the generalisation must not have broken: the six hand-named exclusions, staged reference files, symlinks, `.pyc`, an empty workspace, and an unreadable file being skipped rather than fatal.

Local: full backend suite **9739 passed, 18 skipped, 46 deselected**, exit 0.
