### PR TITLE
fix(codex): retry a task the provider refused for rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,76 @@ entries land under a fresh dated heading the day they merge to `main`.
   file is the decision the pin asks to see.
 
 ### Fixed
+- **A task refused for rate was told it had three attempts, and got one.** Run
+  `34485072751` attempted five tasks. Three ended the same way:
+
+      [1/5] 02aa1805-...-02dec146063a (Financial Managers)... ✗
+      the Codex turn failed: stream disconnected before completion: Your
+      requests to gpt-5.4 for gpt-5.4 in eastus2 have exceeded rate limit.
+
+  The experiment file running them sets `execution.max_retries: 2` and says
+  beside it, "Attempts after an infrastructure failure, per task. Three at
+  most, each a fresh session," and in its header, "5 tasks x at most 3 turns
+  each = 15 turns, worst case." Neither was true. `max_retries` was read from
+  the config, printed at startup as "(per task, infra)", and then never used
+  again: the only exit from a failed task was a `break`. The run sent five
+  turns, and three tasks were written down as defeats of the harness on the
+  first refusal that a minute's wait would have cleared.
+
+  Retrying was the last of three changes, not the first, because two things
+  had to be true before a retry could be right.
+
+  The first is that a run has to know *why* a turn failed. It did not.
+  `CodexRunOutcome.error_category` existed and every failed turn was given the
+  same word, `turn_failed` — true of a rate limit and equally true of a task
+  the agent could not do. `classify_execution_error` already kept a vocabulary
+  for this, so the turn now asks it, and it has gained a `rate_limited`
+  category: the `RateLimitError` class, and the phrases a provider uses when
+  it refuses for rate rather than for content. A bare `429` is deliberately
+  not one of those phrases — a traceback's `line 429` would match it, and
+  reading a deterministic defect as a transient one is how a real bug earns
+  three paid attempts. When the text says nothing, the answer stays
+  `turn_failed`; the classifier's own fallback, `execution_error`, says less.
+
+  The second is that the word has to reach the record. It did not: the
+  backends each set it and `_build_execution_observability` dropped it, so a
+  caller that does not know which backend ran could not find out what kind of
+  failure it was looking at. It is carried now, bounded to eighty characters
+  and admitted only as a string, because this field is published and a
+  category that quoted its message would put the endpoint and the wording back
+  into the artefact that `public_task_error_text` exists to keep them out of.
+
+  Only then, the retry. It is deliberately narrow. Two categories are worth
+  another attempt: `rate_limited`, and `turn_start_failed` — the one case
+  where the code can prove nothing was billed, since it abandons its own cost
+  reservation with the note "the turn never started". `timeout` is not on the
+  list: the turn was sent and may have been charged, the runner keeps whatever
+  files the agent had written before it was cut off, and three 1800-second
+  attempts is ninety minutes spent on one task. `turn_failed` is not on it
+  either — a failure that would not say why is exactly the one a second
+  identical attempt repeats. Nor are the three start failures, which are local
+  configuration that waiting does not change. A failure carrying no category
+  at all is not retried: silence is not permission.
+
+  The waits are 60, 120, then 240 seconds. Sixty first because an Azure OpenAI
+  rate limit is counted over a sixty-second window, so trying again inside it
+  fails the same way, sooner, having spent one of three attempts. Above the
+  ceiling sits a stop condition — ten minutes of total waiting per task —
+  so that a provider refusing everything ends the run saying so instead of
+  sleeping through the job's time limit. Each retry clears the failed
+  attempt's files before the wait rather than after it, so a job cancelled
+  mid-wait does not leave them behind looking like the task's answer.
+
+  Each attempt is a fresh session and a separate line in the ledger.
+  `RETRY_INFRASTRUCTURE` has been in the cost vocabulary since it was written
+  and no caller had ever passed it, so until now a receipt could say only
+  "first attempt" or "the model tried again"; a retry forced on us by the
+  provider is neither, and it is now recorded as neither.
+
+  What this does not do: `retry_counts_by_reason`, which
+  `execution_environment_readiness.py` requires of a run record, is still
+  produced nowhere. That is a gap in how the record is assembled rather than
+  in how retries are decided, and it is left for the change that assembles it.
 - **A stray dotfile cost a task the model had already solved.** On the same
   run, `34485072751`, task 3 of 5:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,14 @@ entries land under a fresh dated heading the day they merge to `main`.
   "first attempt" or "the model tried again"; a retry forced on us by the
   provider is neither, and it is now recorded as neither.
 
+  A rate-limited turn's reservation is left neither settled nor abandoned,
+  because the stream disconnected and there is no way to know whether tokens
+  were billed. Three attempts can therefore leave three reservations that
+  resolve to `partial`. That is not a defect introduced here: it is the
+  ledger saying a cost may exist that it cannot measure, which is the only
+  honest thing it can say, and retrying makes it say so up to three times
+  rather than making it say zero once.
+
   What this does not do: `retry_counts_by_reason`, which
   `execution_environment_readiness.py` requires of a run record, is still
   produced nowhere. That is a gap in how the record is assembled rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,42 @@ entries land under a fresh dated heading the day they merge to `main`.
   file is the decision the pin asks to see.
 
 ### Fixed
+- **A stray dotfile cost a task the model had already solved.** On the same
+  run, `34485072751`, task 3 of 5:
+
+      [3/5] 2ea2e5b5-...-93763f28b19d (Computer and Information Systems
+      Managers)... ✗ deliverable filename is invalid or duplicated
+
+  The model had answered by then — the task's own receipt records one model
+  call, 268,999 input tokens and 8,727 output tokens. The answer was collected
+  out of the workspace and refused on the way to disk, and because the saver
+  refuses a *batch* rather than a file, the good files went down with whichever
+  one was bad. Which one that was cannot be recovered: the message named no
+  file, and a task's workspace is deleted when the task ends.
+
+  Two rules had drifted apart. `CodexWorkspace.collect_deliverables` excluded
+  six names by hand — `.codex`, `.git`, `__pycache__`, `.pytest_cache`,
+  `.venv`, `node_modules` — while `_save_files` refuses *any* path component
+  beginning with a dot, plus backslashes, plus a name it has already seen. Four
+  of the collector's six were dot-names, so the intent was the same; the
+  collector had just written it out as a list, and a seventh dot-name passed it
+  and hit the saver. An agent told to build something in a directory writes
+  `.gitignore` and friends without being asked. Neither function had a test.
+
+  The collector now emits only names the saver will accept. Anything with a
+  hidden component is skipped rather than enumerated; `\` joins the NTFS
+  replacement set it was always a member of, so a Linux-legal `q1\q2.md`
+  becomes `q1_q2.md` instead of a refusal; and two files that collide after
+  replacement are numbered — `q1_ (2).md` — rather than one of them killing the
+  task. A test asserts the property directly: whatever the collector produced,
+  the real `_save_files` accepts.
+
+  A refusal that remains now says which file it is about. The collector is not
+  the only producer of deliverables, so the saver still refuses names, and the
+  name comes from the model and goes into a build log: it is `repr`-quoted so a
+  newline cannot forge a log line, and truncated so a long one cannot flood it.
+  The deliberate limit: a name that is too long or too deep for the filesystem
+  is still fatal to its task. It is now diagnosable.
 - **A run that solved a task could not be recorded, because Step 3 had never
   heard of the mode that solved it.** Run `34485072751` is the first
   `codex_foundry` dispatch to reach a model. It passed the config check, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,7 +237,7 @@ entries land under a fresh dated heading the day they merge to `main`.
 - **A task refused for rate was told it had three attempts, and got one.** Run
   `34485072751` attempted five tasks. Three ended the same way:
 
-      [1/5] 02aa1805-...-02dec146063a (Financial Managers)... ✗
+      [1/5] 02aa1805-...-02dec146063a (Project Management Specialists)... ✗
       the Codex turn failed: stream disconnected before completion: Your
       requests to gpt-5.4 for gpt-5.4 in eastus2 have exceeded rate limit.
 
@@ -287,12 +287,16 @@ entries land under a fresh dated heading the day they merge to `main`.
 
   The waits are 60, 120, then 240 seconds. Sixty first because an Azure OpenAI
   rate limit is counted over a sixty-second window, so trying again inside it
-  fails the same way, sooner, having spent one of three attempts. Above the
-  ceiling sits a stop condition — ten minutes of total waiting per task —
-  so that a provider refusing everything ends the run saying so instead of
-  sleeping through the job's time limit. Each retry clears the failed
-  attempt's files before the wait rather than after it, so a job cancelled
-  mid-wait does not leave them behind looking like the task's answer.
+  fails the same way, sooner, having spent one of three attempts. The run
+  itself shows this: tasks 4 and 5 were refused at 14:00:10 and 14:00:12,
+  one and eight tenths of a second apart, the fifth never having had a window
+  to be allowed in. A retry quicker than the window is that second refusal,
+  paid for out of a budget of three. Above the ceiling sits a stop condition
+  — ten minutes of total waiting per task — so that a provider refusing
+  everything ends the run saying so instead of sleeping through the job's
+  time limit. Each retry clears the failed attempt's files before the wait
+  rather than after it, so a job cancelled mid-wait does not leave them
+  behind looking like the task's answer.
 
   Each attempt is a fresh session and a separate line in the ledger.
   `RETRY_INFRASTRUCTURE` has been in the cost vocabulary since it was written

--- a/batch-runner/core/codex_runner.py
+++ b/batch-runner/core/codex_runner.py
@@ -73,17 +73,49 @@ CODEX_TURN_TIMEOUT = int(os.getenv("CODEX_TURN_TIMEOUT", "900"))
 #: interrupt first; only when that produces nothing is the process torn down.
 CODEX_INTERRUPT_GRACE_SECONDS = float(os.getenv("CODEX_INTERRUPT_GRACE", "20"))
 
-#: Files the runtime keeps for its own purposes, which are not deliverables.
+#: Files the runtime keeps for its own purposes, which are not deliverables
+#: and whose names do not begin with a dot. The four that did -- ``.codex``,
+#: ``.git``, ``.pytest_cache``, ``.venv`` -- are covered by the rule in
+#: :meth:`CodexWorkspace.collect_deliverables` that skips anything hidden, and
+#: naming them here as well would suggest the others are collectable.
 _NOT_A_DELIVERABLE = (
-    ".codex",
-    ".git",
     "__pycache__",
-    ".pytest_cache",
-    ".venv",
     "node_modules",
 )
 
-_NTFS_FORBIDDEN = re.compile(r'[:"<>|*?\r\n]')
+#: Characters NTFS will not take in a name, replaced so a deliverable produced
+#: on Linux can still be downloaded on Windows. ``\`` is on that list for the
+#: same reason the rest are, and was the one member missing: a file named
+#: ``q1\q2.md`` is one legal name here and a name ``_save_files`` refuses.
+_NTFS_FORBIDDEN = re.compile(r'[\\:"<>|*?\r\n]')
+
+
+def _unused_deliverable_name(name: str, taken: set[str]) -> str:
+    """``name``, or the first free variation of it.
+
+    Replacing forbidden characters can map two distinct files onto one name --
+    ``q1?.md`` and ``q1_.md`` both become ``q1_.md``. ``_save_files`` refuses a
+    repeat, and refusing costs the task every other file with it. Neither of
+    the two is litter, so neither is dropped; the second is numbered, the way
+    anything else that receives a name it already has does it.
+
+    Returns ``name`` unchanged if nothing is free, leaving the saver to refuse
+    it. That is the honest outcome for a hundred colliding names: better a
+    refusal that says which file than a silent hundred-and-first guess.
+    """
+    if name not in taken:
+        return name
+    parent, separator, base = name.rpartition("/")
+    stem, dot, extension = base.rpartition(".")
+    # `rpartition` puts everything in the third value when there is no dot, and
+    # the split is done on the base so `v1.0/README` is not read as an
+    # extension of `v1`.
+    head, tail = (stem, dot + extension) if dot else (base, "")
+    for ordinal in range(2, 100):
+        candidate = f"{parent}{separator}{head} ({ordinal}){tail}"
+        if candidate not in taken:
+            return candidate
+    return name
 
 #: How long the auth-command preflight waits. Generous next to the runtime's
 #: own 30s auth timeout, because a first sign-in can be slower than a cached
@@ -333,9 +365,15 @@ class CodexWorkspace:
         makes one. The staged references are excluded by name: they came from
         the task, and returning them as output would credit the run with
         producing its own inputs.
+
+        Every name returned is one ``_save_files`` will accept. That is not a
+        courtesy. The saver refuses a batch, not a file, so one unsaveable
+        name discards the whole task -- and on run 34485072751 one did, to a
+        task the model had already answered.
         """
         skip = set(self.staged_reference_names)
         collected: list[dict[str, Any]] = []
+        taken: set[str] = set()
         for path in sorted(self.workspace.rglob("*")):
             if path.is_dir():
                 continue
@@ -344,6 +382,12 @@ class CodexWorkspace:
             except ValueError:  # pragma: no cover - rglob stays inside
                 continue
             if any(part in _NOT_A_DELIVERABLE for part in relative.parts):
+                continue
+            if any(part.startswith(".") for part in relative.parts):
+                # Not a deliverable, and not saveable either: `_save_files`
+                # refuses any hidden component. An agent building something in
+                # a directory writes `.gitignore` and friends without being
+                # asked, and before this they took the answer down with them.
                 continue
             if relative.as_posix() in skip or relative.name in skip:
                 continue
@@ -357,12 +401,11 @@ class CodexWorkspace:
                 content = path.read_bytes()
             except OSError:
                 continue
-            collected.append(
-                {
-                    "filename": _NTFS_FORBIDDEN.sub("_", relative.as_posix()),
-                    "content": content,
-                }
+            filename = _unused_deliverable_name(
+                _NTFS_FORBIDDEN.sub("_", relative.as_posix()), taken
             )
+            taken.add(filename)
+            collected.append({"filename": filename, "content": content})
         return collected
 
     def cleanup(self) -> None:

--- a/batch-runner/core/codex_runner.py
+++ b/batch-runner/core/codex_runner.py
@@ -58,6 +58,7 @@ from core.execution_envelope_observed import (
     API_FAMILY_RESPONSES,
     RecordsItsFirstRequest,
 )
+from core.execution_errors import classify_execution_error
 from core.execution_environment_readiness import (
     ENVIRONMENT_CODEX_COMMAND_LINE_TOOL_FOUNDRY,
 )
@@ -422,6 +423,30 @@ class CodexWorkspace:
 
 
 # ── The runner ──────────────────────────────────────────────────────────────
+
+
+def _turn_failure_category(failure: Any) -> str:
+    """Why a turn failed, when the failure says so.
+
+    ``turn_failed`` is true of every failed turn and useful about none of
+    them. On run ``34485072751`` three of the five tasks ended with
+
+        stream disconnected before completion: Your requests to <deployment>
+        ... have exceeded rate limit.
+
+    and were recorded under the same word as a turn that failed for any other
+    reason -- so the run could not say, from its own record, that it had been
+    refused for rate rather than defeated by the task.
+
+    :func:`classify_execution_error` already keeps that vocabulary. Its
+    fallback, ``execution_error``, says less than ``turn_failed`` does, so the
+    fallback is not taken; only an answer more specific than "the turn failed"
+    replaces it.
+    """
+    category = classify_execution_error(str(failure))
+    if not category or category == "execution_error":
+        return "turn_failed"
+    return category
 
 
 @dataclass
@@ -979,7 +1004,7 @@ class CodexAgentRunner(RecordsItsFirstRequest):
                     text="",
                     files=files,
                     error=f"the Codex turn failed: {failure}",
-                    error_category="turn_failed",
+                    error_category=_turn_failure_category(failure),
                     thread_id=getattr(thread, "id", None),
                     turn_id=getattr(turn_handle, "id", None),
                 )

--- a/batch-runner/core/execution_errors.py
+++ b/batch-runner/core/execution_errors.py
@@ -1,4 +1,11 @@
-"""Stable error categories shared by generated-code execution backends."""
+"""Stable error categories shared by the execution backends.
+
+Written for the generated-code backends, whose failure text is a traceback;
+the Codex agent backend uses it too, for the sentence a provider returns when
+it refuses a turn. Both need the same thing from it -- a fixed word for why,
+carrying none of the message, so a failure can be counted and published
+without the endpoint or the wording travelling with it.
+"""
 
 from __future__ import annotations
 
@@ -16,6 +23,7 @@ _EXCEPTION_CATEGORY = {
     "modulenotfounderror": "import_error",
     "outofmemoryerror": "out_of_memory",
     "permissionerror": "permission_error",
+    "ratelimiterror": "rate_limited",
     "syntaxerror": "syntax_error",
     "timeouterror": "timeout",
     "timeoutexpired": "timeout",
@@ -24,9 +32,28 @@ _EXCEPTION_CATEGORY = {
     "valueerror": "value_error",
 }
 
+#: What a provider says when it refused the request for rate rather than for
+#: content. Deliberately no bare ``429``: a traceback's ``line 429`` would
+#: match it, and mistaking a real defect for a transient one is how a
+#: deterministic failure gets attempted three times.
+_RATE_LIMIT_MARKERS = (
+    "rate limit",
+    "ratelimit",
+    "too many requests",
+    "error code: 429",
+    "status code: 429",
+    "http 429",
+)
+
 
 def _message_category(message: str) -> Optional[str]:
     lowered = message.lower()
+    # First, because it is the one marker set that reliably co-occurs with
+    # another: a client that keeps retrying a refused request reports its own
+    # deadline, so the text says both "rate limit" and "timed out". The
+    # refusal is the cause; the deadline is what the cause looked like.
+    if any(marker in lowered for marker in _RATE_LIMIT_MARKERS):
+        return "rate_limited"
     oom_markers = (
         "out of memory",
         "insufficient memory",
@@ -73,6 +100,10 @@ def classify_execution_error(text: Optional[str]) -> Optional[str]:
     if direct_message_category:
         return direct_message_category
 
+    # No ``rate_limited`` row below. Every rate-limit text is already decided
+    # by one of the two `_message_category` calls above -- as the exception's
+    # message, or as the whole text -- so a row here could never be reached,
+    # and an unreachable row is a second place to keep the answer in.
     categories = (
         (
             "out_of_memory",

--- a/batch-runner/experiments/exp033_codex_foundry_fixed5.yaml
+++ b/batch-runner/experiments/exp033_codex_foundry_fixed5.yaml
@@ -54,6 +54,19 @@
 #   1 turn per task attempt, 1800s wall clock each
 #   at most 1 task at a time (this pipeline does not run tasks concurrently)
 #   Self-QA off, so no second call per task
+#   at most 600s of waiting between a task's attempts — 60s then 120s at this
+#     setting, so the budget only binds if `max_retries` is raised
+#
+# What those turn counts are worth in wall clock, now that the retries are
+# real. A task that times out is not retried, so its 1800s is spent once. A
+# task refused for rate can be refused at the end of a long turn rather than
+# at the start of it, three times over — so one task's worst case is about
+# 3 x 1800s plus 180s of waiting, and the run's is about seven and three
+# quarter hours. That is longer than a single leg's watchdog allows, and it
+# does not lose the run: Step 2 exits 42 with tasks still pending, progress is
+# checkpointed to the Hub, and the workflow retriggers itself for another leg.
+# The figure is written down so that a second leg reads as the bound doing its
+# job rather than as something having gone wrong.
 #
 # Retries are the one real decision here, and they are made at the batch
 # runner's layer rather than inside Codex. `execution.max_retries: 2` gives a

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -37,7 +37,7 @@ import time
 import yaml
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, List
+from typing import Any, Optional, List
 
 # Deliberately not in ``core/``: ``step8_grade.compute_grader_source_hash``
 # hashes every ``core/**/*.py``, so a module there would move the grader's
@@ -1805,6 +1805,21 @@ def _run_self_qa(
 # ── File saving (matches main.py _save_files) ─────────────────────────────
 
 
+def _quote_rejected_name(filename: Any) -> str:
+    """The name a refusal is about, safe to put in a build log.
+
+    Run 34485072751 lost a task to ``deliverable filename is invalid or
+    duplicated`` and the log could not say which file, because the message
+    never held one and the task's directory is deleted when the task ends. So
+    the name goes in the message -- but the name came from the model, and the
+    message goes into a log, so it is quoted rather than interpolated: ``repr``
+    escapes a newline that would otherwise forge a log line, and the result is
+    cut short of a name long enough to bury the rest of the run's output.
+    """
+    quoted = repr(filename)
+    return quoted if len(quoted) <= 160 else quoted[:157] + "..."
+
+
 def _save_files(
     files: List[dict],
     task_id: str,
@@ -1824,7 +1839,9 @@ def _save_files(
             raise ValueError("deliverable file record is invalid")
         filename = file_data["filename"]
         if not isinstance(filename, str) or "\\" in filename:
-            raise ValueError("deliverable filename is invalid")
+            raise ValueError(
+                f"deliverable filename is invalid: {_quote_rejected_name(filename)}"
+            )
         relative = Path(filename)
         canonical = relative.as_posix()
         if (
@@ -1837,7 +1854,10 @@ def _save_files(
             or len(canonical.encode("utf-8")) > 240
             or canonical in seen
         ):
-            raise ValueError("deliverable filename is invalid or duplicated")
+            raise ValueError(
+                "deliverable filename is invalid or duplicated: "
+                f"{_quote_rejected_name(filename)}"
+            )
         content = file_data["content"]
         if isinstance(content, str):
             encoded = content.encode("utf-8")

--- a/batch-runner/step2_run_inference.py
+++ b/batch-runner/step2_run_inference.py
@@ -37,7 +37,7 @@ import time
 import yaml
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional, List
+from typing import Any, Callable, Optional, List
 
 # Deliberately not in ``core/``: ``step8_grade.compute_grader_source_hash``
 # hashes every ``core/**/*.py``, so a module there would move the grader's
@@ -72,6 +72,7 @@ from core.cost_receipts import (
     BUCKET_PROBLEM_SOLVING,
     REASON_LEDGER_ABSENT,
     REASON_STAGE_UNSUPPORTED,
+    RETRY_INFRASTRUCTURE,
     RETRY_NONE,
     RETRY_RESUME,
     RETRY_SEMANTIC,
@@ -132,6 +133,123 @@ from core.video_analyzer import (
 # ── Constants ──────────────────────────────────────────────────────────────
 
 RETRIABLE_STATUSES = {"error", "qa_failed", "pending"}
+
+#: The failure categories a second attempt can actually fix.
+#:
+#: `execution.max_retries` has been described in every experiment file and in
+#: `--help` as "infra retries per task" since it was added, and it resolved to
+#: a number that was printed at startup and then never read again. Run
+#: `34485072751` is what that costs: three of five tasks ended on
+#: `rate_limited` at the first refusal, with `max_retries: 2` set in the
+#: config and its own comment promising "three at most, each a fresh session".
+#:
+#: Only two categories are in this set, and the ones left out matter more than
+#: the ones in it:
+#:
+#: * `timeout` is not here. The turn was sent, so it may have been billed, and
+#:   `_run_one_turn` collects whatever files the agent had written before it
+#:   was interrupted -- a retry would throw those away. It is also the one
+#:   category whose retry multiplies the wall clock by the attempt count: at
+#:   exp033's 1800-second limit, three attempts is ninety minutes on one task.
+#: * `turn_failed` is not here. It means the turn failed and the text did not
+#:   say why, which is exactly when a second identical attempt produces a
+#:   second identical failure.
+#: * `runtime_unavailable`, `runtime_start_failed` and `session_start_failed`
+#:   are not here. They are the local environment and its configuration; they
+#:   do not improve by being asked again a minute later.
+RETRYABLE_INFRA_ERROR_CATEGORIES = frozenset({
+    # The provider refused for rate, not for content. This is the failure the
+    # setting was written for.
+    "rate_limited",
+    # `_run_one_turn` abandons the cost reservation here with the note "the
+    # turn never started" -- nothing was sent and nothing was billed, which is
+    # the strongest evidence a retry can have that it is not paying twice.
+    "turn_start_failed",
+})
+
+#: How long to wait before each infrastructure retry, by attempt.
+#:
+#: The first is sixty seconds because an Azure OpenAI rate limit is counted
+#: over a sixty-second window: retrying inside it does not fail differently,
+#: it just fails sooner and spends another attempt from the same budget. The
+#: last value repeats for any further attempt.
+INFRA_RETRY_BACKOFF_SECONDS = (60.0, 120.0, 240.0)
+
+#: The most total time one task may spend waiting to try again. A stop
+#: condition, not a target: a run whose provider is refusing everything should
+#: end saying so rather than sleep its way through a job's time limit.
+INFRA_RETRY_MAX_TOTAL_WAIT_SECONDS = 600.0
+
+
+def infra_retry_category(result: dict) -> Optional[str]:
+    """The transient failure this result should be attempted again for.
+
+    ``None`` when the task succeeded, when the backend said nothing about why
+    it failed, or when what it said is not something another attempt fixes.
+    """
+    if not isinstance(result, dict) or result.get("status") == "success":
+        return None
+    observability = result.get("observability")
+    if not isinstance(observability, dict):
+        return None
+    category = observability.get("error_category")
+    if category in RETRYABLE_INFRA_ERROR_CATEGORIES:
+        return str(category)
+    return None
+
+
+def infra_retry_pause_seconds(infra_attempt: int) -> float:
+    """How long to wait before the attempt after ``infra_attempt``."""
+    if infra_attempt < 0:
+        raise ValueError("infra attempt index is negative")
+    return INFRA_RETRY_BACKOFF_SECONDS[
+        min(infra_attempt, len(INFRA_RETRY_BACKOFF_SECONDS) - 1)
+    ]
+
+
+def run_with_infra_retries(
+    attempt: Callable[[int], dict],
+    *,
+    max_attempts: int,
+    before_retry: Optional[Callable[[], None]] = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict:
+    """Run ``attempt`` again while it fails for a reason another try can fix.
+
+    ``attempt`` takes the attempt's index -- ``0`` for the first, which is not
+    a retry -- and returns a task result. The last result is returned whether
+    or not it succeeded: this decides how many times to ask, not what to do
+    with the answer.
+
+    ``max_attempts`` is a ceiling, not a target, and it is the *only* thing
+    that bounds the number of paid attempts. It comes from
+    ``execution.max_retries`` plus one, which is what every experiment file
+    that sets that key has always claimed it did.
+    """
+    result = attempt(0)
+    waited = 0.0
+    for infra_attempt in range(1, max(1, int(max_attempts))):
+        category = infra_retry_category(result)
+        if category is None:
+            return result
+        pause = infra_retry_pause_seconds(infra_attempt - 1)
+        if waited + pause > INFRA_RETRY_MAX_TOTAL_WAIT_SECONDS:
+            print(f"\n      ⏱️  {category} — not retried: this task's retry "
+                  f"wait budget ({INFRA_RETRY_MAX_TOTAL_WAIT_SECONDS:.0f}s) "
+                  f"is spent", end=" ", flush=True)
+            return result
+        waited += pause
+        print(f"\n      ⏳ {category} — attempt {infra_attempt + 1}"
+              f"/{max_attempts} in {pause:.0f}s...", end=" ", flush=True)
+        if before_retry is not None:
+            # Before the wait rather than after it. The failed attempt's
+            # leftovers are not this task's answer, and a job cancelled during
+            # the wait should not leave them behind looking like one.
+            before_retry()
+        sleep(pause)
+        result = attempt(infra_attempt)
+    return result
+
 
 # Exit code convention
 EXIT_CHECKPOINT = 42  # checkpoint saved, relay retrigger needed
@@ -1000,6 +1118,15 @@ def _build_execution_observability(
 ) -> dict:
     """Build compact task provenance without duplicating heavy QA reports."""
     observability = {"preprocessors": preprocessor_observations}
+    # Why the attempt failed, in one word from a fixed vocabulary. Every
+    # backend already produces this and, until now, only the sandbox and
+    # agentic paths kept it -- inside their own metrics, where a caller that
+    # does not know which backend ran cannot find it. It is bounded like
+    # `terminal_error_category` beside it, and carries no message, so it is
+    # publishable for the same reason that one is.
+    error_category = (result or {}).get("error_category")
+    if isinstance(error_category, str) and error_category:
+        observability["error_category"] = error_category[:80]
     execution_metrics = _bounded_execution_metrics(
         (result or {}).get("execution_metrics")
     )
@@ -2919,6 +3046,11 @@ def _run_inference_impl(
         sys.exit(1)
     if max_retries is None:
         max_retries = execution_cfg.get("max_retries", prepared.get("max_retries", 3))
+    # Retries after an infrastructure failure, so attempts is one more than
+    # retries. Clamped rather than validated: a negative number here would
+    # otherwise mean zero attempts, and a task that is never attempted is a
+    # worse answer to a bad setting than a task attempted once.
+    infra_max_attempts = max(0, int(max_retries or 0)) + 1
     if resume_max_rounds is None:
         resume_max_rounds = execution_cfg.get("resume_max_rounds", 3)
     tokens_cfg_raw = execution_cfg.get("tokens", {})
@@ -3075,7 +3207,9 @@ def _run_inference_impl(
     print(f"   Model:              {model}")
     print(f"   Mode:               {execution_mode}")
     print(f"   Tasks:              {len(tasks)}")
-    print(f"   Max retries:        {max_retries} (per task, infra)")
+    print(f"   Max retries:        {max_retries} (per task, infra — "
+          f"{infra_max_attempts} attempts at most, on "
+          f"{', '.join(sorted(RETRYABLE_INFRA_ERROR_CATEGORIES))})")
     print(f"   Resume max rounds:  {resume_max_rounds} (re-run failed tasks)")
     print(f"   Tokens:             code={tokens_cfg['code_generation']}, "
           f"qa={tokens_cfg['qa_check']}, render={tokens_cfg['json_render']}")
@@ -3674,16 +3808,28 @@ def _run_inference_impl(
         # paid for whether or not its output survived.
         solving_retry_kind = RETRY_RESUME if resume_round else RETRY_NONE
 
-        def _solving_scope(stage: str, attempt: int):
-            """Attribute the calls made inside to this task, at one stage."""
+        def _solving_scope(stage: str, attempt: int, *, infra_attempt: int = 0):
+            """Attribute the calls made inside to this task, at one stage.
+
+            An infrastructure retry is its own kind of retry, not a semantic
+            one: the model did not judge its answer inadequate, the request
+            did not get through. ``RETRY_INFRASTRUCTURE`` has been in the
+            ledger's vocabulary since it was written and no caller had ever
+            passed it, so every receipt so far has been able to say only
+            "first attempt" or "the model tried again".
+            """
             if cost_recorder is None:
                 return contextlib.nullcontext()
+            if infra_attempt:
+                retry_kind = RETRY_INFRASTRUCTURE
+            elif attempt == 0:
+                retry_kind = solving_retry_kind
+            else:
+                retry_kind = RETRY_SEMANTIC
             return cost_recorder.attributed(
                 task_id=task_id,
                 stage=stage,
-                retry_kind=(
-                    solving_retry_kind if attempt == 0 else RETRY_SEMANTIC
-                ),
+                retry_kind=retry_kind,
                 attempt_index=attempt,
             )
 
@@ -3864,23 +4010,35 @@ def _run_inference_impl(
                     # 파일을 생성했을 때 구/신 파일이 공존하게 됨
                     _clear_task_files()
 
-                with _solving_scope(STAGE_GENERATION, qa_attempts):
-                    result = _execute_single_task(
-                        task, condition, executor, execution_mode,
-                        client, model, manifest,
-                        error_context=last_qa_feedback,
-                        verbose=verbose,
-                        run_id=run_identity,
-                        condition_name=execution_condition,
-                        strict_inputs=hardened_requested,
-                        experiment_id=experiment_id,
-                        upload_root=condition_upload_root,
-                        azure_ai_factory=azure_ai_factory,
-                        azure_ai_route_plan=azure_ai_route_plan,
-                        cost_recorder=cost_recorder,
-                    )
-                if metrics_enabled:
-                    _record_execution_metrics(result)
+                def _attempt(infra_attempt: int) -> dict:
+                    """One attempt at this task, counted and attributed."""
+                    with _solving_scope(
+                        STAGE_GENERATION, qa_attempts,
+                        infra_attempt=infra_attempt,
+                    ):
+                        attempted = _execute_single_task(
+                            task, condition, executor, execution_mode,
+                            client, model, manifest,
+                            error_context=last_qa_feedback,
+                            verbose=verbose,
+                            run_id=run_identity,
+                            condition_name=execution_condition,
+                            strict_inputs=hardened_requested,
+                            experiment_id=experiment_id,
+                            upload_root=condition_upload_root,
+                            azure_ai_factory=azure_ai_factory,
+                            azure_ai_route_plan=azure_ai_route_plan,
+                            cost_recorder=cost_recorder,
+                        )
+                    if metrics_enabled:
+                        _record_execution_metrics(attempted)
+                    return attempted
+
+                result = run_with_infra_retries(
+                    _attempt,
+                    max_attempts=infra_max_attempts,
+                    before_retry=_clear_task_files,
+                )
 
                 # If execution failed, return best if available
                 if result["status"] != "success":

--- a/batch-runner/tests/test_a_rate_limit_should_not_end_a_task.py
+++ b/batch-runner/tests/test_a_rate_limit_should_not_end_a_task.py
@@ -2,7 +2,7 @@
 
 Run `34485072751` attempted five tasks. Three of them ended here:
 
-    [1/5] 02aa1805-...-02dec146063a (Financial Managers)... ✗
+    [1/5] 02aa1805-...-02dec146063a (Project Management Specialists)... ✗
     the Codex turn failed: stream disconnected before completion: Your
     requests to gpt-5.4 for gpt-5.4 in eastus2 have exceeded rate limit.
 

--- a/batch-runner/tests/test_a_rate_limit_should_not_end_a_task.py
+++ b/batch-runner/tests/test_a_rate_limit_should_not_end_a_task.py
@@ -1,0 +1,506 @@
+"""A task refused for rate was told it had three attempts, and got one.
+
+Run `34485072751` attempted five tasks. Three of them ended here:
+
+    [1/5] 02aa1805-...-02dec146063a (Financial Managers)... ✗
+    the Codex turn failed: stream disconnected before completion: Your
+    requests to gpt-5.4 for gpt-5.4 in eastus2 have exceeded rate limit.
+
+The experiment file running them, `exp033_codex_foundry_fixed5.yaml`, sets
+`execution.max_retries: 2` and says beside it:
+
+    # Attempts after an infrastructure failure, per task. Three at most, each
+    # a fresh session. The model's own judgement never causes one: Self-QA is
+    # off.
+
+and in its header:
+
+    5 tasks x at most 3 turns each  = 15 turns, worst case
+
+Neither was true. `max_retries` was resolved from the config, printed at
+startup as "(per task, infra)", and then never read again -- the only place a
+failed task left the loop was a `break`. The run sent five turns, not up to
+fifteen, and three tasks were recorded as failures of the harness on the first
+refusal a minute's wait would have cleared.
+
+Two things had to be true before a retry could be right, and neither was:
+
+* The run had to know *why* a turn failed. `CodexRunOutcome.error_category`
+  existed and every failed turn got the same word, `turn_failed`, which is
+  true of a rate limit and of a task the agent could not do.
+* That word had to survive into the task result. It was set on the runner's
+  dict and dropped by the step that builds the record.
+
+So a retry is not the whole change. The change is that a failure now says
+what kind it is, that the kind reaches the record, and that only the kinds
+another attempt can fix cause one.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+import step2_run_inference as step2
+from core.codex_runner import _turn_failure_category
+from core.execution_errors import classify_execution_error
+from step2_run_inference import (
+    INFRA_RETRY_BACKOFF_SECONDS,
+    INFRA_RETRY_MAX_TOTAL_WAIT_SECONDS,
+    RETRYABLE_INFRA_ERROR_CATEGORIES,
+    _build_execution_observability,
+    infra_retry_category,
+    infra_retry_pause_seconds,
+    run_with_infra_retries,
+)
+
+
+#: What the deployment said, three times, on run 34485072751. The deployment
+#: name is the one the run recorded; nothing here depends on it being that.
+THE_REFUSAL = (
+    "stream disconnected before completion: Your requests to gpt-5.4 for "
+    "gpt-5.4 in eastus2 have exceeded rate limit."
+)
+
+
+def a_failure(category=None, status="error"):
+    """A task result of the shape `_execute_single_task` returns."""
+    observability = {"preprocessors": []}
+    if category is not None:
+        observability["error_category"] = category
+    return {"task_id": "t", "status": status, "observability": observability}
+
+
+# ── the word for what happened ───────────────────────────────────────────
+
+
+def test_the_message_that_ended_three_tasks_is_named():
+    assert classify_execution_error(THE_REFUSAL) == "rate_limited"
+
+
+def test_the_codex_turn_now_records_why_it_failed():
+    assert _turn_failure_category(THE_REFUSAL) == "rate_limited"
+
+
+def test_a_failure_that_says_nothing_is_still_turn_failed():
+    """The fallback is the old answer, not the classifier's.
+
+    `classify_execution_error` ends at `execution_error`, which says less than
+    `turn_failed` does -- a turn is not generated code, and "the turn failed"
+    is at least true of where it happened.
+    """
+    assert _turn_failure_category("the stream ended") == "turn_failed"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Requests to the model deployment have exceeded rate limit",
+        "Rate limit reached for this deployment",
+        "429 - Too Many Requests",
+        "Error code: 429 - {'error': {'code': 'RateLimitReached'}}",
+        "HTTP 429 returned by the endpoint",
+        "openai.RateLimitError: Requests to the model exceeded the limit",
+    ],
+)
+def test_the_ways_a_provider_says_it(text):
+    assert classify_execution_error(text) == "rate_limited"
+
+
+def test_a_line_number_is_not_a_rate_limit():
+    """Why bare `429` is not a marker.
+
+    A traceback names lines. Reading `line 429` as a transient refusal would
+    make a deterministic defect worth three paid attempts, which is the exact
+    failure mode this change has to avoid introducing.
+    """
+    assert classify_execution_error(
+        'File "run.py", line 429, in main\n    ValueError: bad column'
+    ) == "value_error"
+
+
+def test_a_bare_number_is_not_a_rate_limit():
+    assert classify_execution_error("exited with 429 rows written") != "rate_limited"
+
+
+@pytest.mark.parametrize(
+    ("text", "category"),
+    [
+        ("MemoryError", "out_of_memory"),
+        ("the process timed out", "timeout"),
+        ("SyntaxError: invalid syntax", "syntax_error"),
+        ("ModuleNotFoundError: No module named 'pandas'", "import_error"),
+        ("KeyError: 'revenue'", "schema_error"),
+        ("UnicodeDecodeError: not valid utf-8", "binary_decode_error"),
+        ("PermissionError: denied", "permission_error"),
+        ("FileNotFoundError: no such file", "file_not_found"),
+        ("TypeError: unsupported operand", "type_error"),
+        ("ValueError: bad literal", "value_error"),
+        ("AttributeError: no attribute", "api_compatibility"),
+        ("something else entirely", "execution_error"),
+        ("", None),
+    ],
+)
+def test_the_categories_that_were_there_before_are_unchanged(text, category):
+    """A new word must not have taken any of the old ones' texts."""
+    assert classify_execution_error(text) == category
+
+
+def test_the_category_carries_none_of_the_message():
+    """It is published, so it must be a word and not a sentence.
+
+    `core/public_error.py` strips the endpoint and the wording out of every
+    error before it is persisted. A category that quoted the message would put
+    both back through a different field.
+    """
+    category = classify_execution_error(THE_REFUSAL)
+
+    assert category == "rate_limited"
+    for secret in ("gpt-5.4", "eastus2", "requests", "exceeded"):
+        assert secret not in category
+
+
+# ── the word reaching the record ─────────────────────────────────────────
+
+
+def test_the_record_says_why_the_task_failed():
+    observability = _build_execution_observability(
+        {"error_category": "rate_limited"}, []
+    )
+
+    assert observability["error_category"] == "rate_limited"
+
+
+def test_a_result_that_says_nothing_records_nothing():
+    assert "error_category" not in _build_execution_observability({}, [])
+    assert "error_category" not in _build_execution_observability(None, [])
+
+
+@pytest.mark.parametrize("category", [None, "", 7, ["rate_limited"], {}])
+def test_only_a_word_is_recorded(category):
+    observability = _build_execution_observability(
+        {"error_category": category}, []
+    )
+
+    assert "error_category" not in observability
+
+
+def test_a_long_category_cannot_smuggle_a_message():
+    observability = _build_execution_observability(
+        {"error_category": "x" * 5000}, []
+    )
+
+    assert len(observability["error_category"]) == 80
+
+
+# ── which failures are worth another attempt ─────────────────────────────
+
+
+def test_a_rate_limited_task_is_retried():
+    assert infra_retry_category(a_failure("rate_limited")) == "rate_limited"
+
+
+def test_a_turn_that_never_started_is_retried():
+    """`_run_one_turn` abandons the reservation here: nothing was billed."""
+    assert infra_retry_category(a_failure("turn_start_failed")) == (
+        "turn_start_failed"
+    )
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        # The turn was sent and may have been billed, and the runner keeps
+        # the files the agent had written before it was interrupted. A retry
+        # would pay twice and throw those away.
+        "timeout",
+        # The turn failed and the text did not say why -- which is exactly
+        # when a second identical attempt fails identically.
+        "turn_failed",
+        # The local environment and its configuration. A minute's wait does
+        # not change either.
+        "runtime_unavailable",
+        "runtime_start_failed",
+        "session_start_failed",
+        # Defects in what the model produced.
+        "syntax_error",
+        "value_error",
+        "out_of_memory",
+        "execution_error",
+    ],
+)
+def test_a_failure_another_attempt_cannot_fix_is_not_retried(category):
+    assert infra_retry_category(a_failure(category)) is None
+
+
+def test_a_success_is_not_retried():
+    assert infra_retry_category(a_failure("rate_limited", status="success")) is None
+
+
+def test_a_failure_with_no_category_is_not_retried():
+    """Silence is not permission. Most of the pipeline's failures are
+    deterministic, and an unlabelled one is more likely to be one of those."""
+    assert infra_retry_category(a_failure()) is None
+    assert infra_retry_category({"status": "error"}) is None
+    assert infra_retry_category({}) is None
+
+
+def test_the_retryable_set_is_small_and_named():
+    assert RETRYABLE_INFRA_ERROR_CATEGORIES == frozenset(
+        {"rate_limited", "turn_start_failed"}
+    )
+
+
+# ── how long to wait ─────────────────────────────────────────────────────
+
+
+def test_the_first_wait_clears_the_window_that_refused_it():
+    """An Azure OpenAI rate limit is counted over sixty seconds.
+
+    Retrying inside that window does not fail differently; it fails sooner and
+    spends an attempt from a budget of three.
+    """
+    assert infra_retry_pause_seconds(0) >= 60.0
+
+
+def test_each_wait_is_longer_than_the_one_before():
+    waits = [infra_retry_pause_seconds(n) for n in range(len(INFRA_RETRY_BACKOFF_SECONDS))]
+
+    assert waits == sorted(waits)
+    assert len(set(waits)) == len(waits)
+
+
+def test_a_further_attempt_waits_as_long_as_the_last_one():
+    last = INFRA_RETRY_BACKOFF_SECONDS[-1]
+
+    assert infra_retry_pause_seconds(len(INFRA_RETRY_BACKOFF_SECONDS)) == last
+    assert infra_retry_pause_seconds(99) == last
+
+
+def test_an_attempt_index_below_zero_is_refused():
+    with pytest.raises(ValueError, match="infra attempt index is negative"):
+        infra_retry_pause_seconds(-1)
+
+
+# ── the loop ─────────────────────────────────────────────────────────────
+
+
+def a_run(results, *, max_attempts, sleep=None):
+    """Drive `run_with_infra_retries` over a fixed sequence of results."""
+    attempts: list[int] = []
+    slept: list[float] = []
+    cleared: list[int] = []
+
+    def attempt(index: int) -> dict:
+        attempts.append(index)
+        return results[min(index, len(results) - 1)]
+
+    final = run_with_infra_retries(
+        attempt,
+        max_attempts=max_attempts,
+        before_retry=lambda: cleared.append(len(attempts)),
+        sleep=sleep if sleep is not None else slept.append,
+    )
+    return final, attempts, slept, cleared
+
+
+def test_the_run_that_gave_up_would_now_try_three_times():
+    """exp033's own numbers: `max_retries: 2`, so three attempts."""
+    _, attempts, slept, _ = a_run(
+        [a_failure("rate_limited")], max_attempts=3
+    )
+
+    assert attempts == [0, 1, 2]
+    assert slept == [60.0, 120.0]
+
+
+def test_a_task_that_succeeds_on_the_second_attempt_stops_there():
+    final, attempts, slept, _ = a_run(
+        [a_failure("rate_limited"), a_failure(status="success")],
+        max_attempts=3,
+    )
+
+    assert final["status"] == "success"
+    assert attempts == [0, 1]
+    assert slept == [60.0]
+
+
+def test_nothing_is_retried_when_the_first_attempt_succeeds():
+    _, attempts, slept, cleared = a_run(
+        [a_failure(status="success")], max_attempts=3
+    )
+
+    assert attempts == [0]
+    assert slept == []
+    assert cleared == []
+
+
+def test_a_deterministic_failure_is_attempted_once():
+    _, attempts, slept, _ = a_run([a_failure("value_error")], max_attempts=3)
+
+    assert attempts == [0]
+    assert slept == []
+
+
+def test_max_retries_zero_means_one_attempt():
+    """What hardened execution fixes, and what it must keep meaning."""
+    _, attempts, slept, _ = a_run([a_failure("rate_limited")], max_attempts=1)
+
+    assert attempts == [0]
+    assert slept == []
+
+
+@pytest.mark.parametrize("max_attempts", [0, -1])
+def test_a_nonsense_ceiling_still_attempts_the_task_once(max_attempts):
+    """A bad setting must not silently skip the task it configures."""
+    _, attempts, _, _ = a_run([a_failure("rate_limited")], max_attempts=max_attempts)
+
+    assert attempts == [0]
+
+
+def test_the_files_of_a_failed_attempt_are_cleared_before_the_wait():
+    """Cleared once per retry, and before the sleep rather than after it.
+
+    A job cancelled during the wait should not leave a failed attempt's
+    leftovers behind looking like the task's answer.
+    """
+    _, attempts, _, cleared = a_run(
+        [a_failure("rate_limited")], max_attempts=3
+    )
+
+    # One clear per retry, each recorded when exactly that many attempts had
+    # been made -- so the clear happened between attempts, not after the last.
+    assert cleared == [1, 2]
+    assert attempts == [0, 1, 2]
+
+
+def test_the_wait_budget_ends_the_retries():
+    """The stop condition. A provider refusing everything must not be able to
+    make one task sleep through a job's whole time limit."""
+    budget = INFRA_RETRY_MAX_TOTAL_WAIT_SECONDS
+    _, attempts, slept, _ = a_run([a_failure("rate_limited")], max_attempts=99)
+
+    assert sum(slept) <= budget
+    # It stopped for the budget, not for the ceiling.
+    assert len(attempts) < 99
+
+
+def test_the_budget_is_reported_when_it_ends_the_retries(capsys):
+    a_run([a_failure("rate_limited")], max_attempts=99)
+
+    printed = capsys.readouterr().out
+    assert "retry wait budget" in printed
+    assert "rate_limited" in printed
+
+
+def test_the_last_result_is_returned_even_when_every_attempt_failed():
+    """This decides how many times to ask, not what to do with the answer."""
+    final, _, _, _ = a_run([a_failure("rate_limited")], max_attempts=3)
+
+    assert final["status"] == "error"
+
+
+def test_a_sleep_that_is_not_called_is_a_retry_that_did_not_happen():
+    """Guards the shape of the test above: the fake sleep really is the wait."""
+    calls: list[float] = []
+
+    def sleep(seconds: float) -> None:
+        calls.append(seconds)
+
+    a_run([a_failure("rate_limited")], max_attempts=2, sleep=sleep)
+
+    assert calls == [60.0]
+
+
+# ── the setting is actually read ─────────────────────────────────────────
+
+
+def _run_task_with_qa_ast():
+    """The body of the function that runs one task, as a tree.
+
+    Everything above tests a helper in isolation, and the defect this change
+    fixes was not in a helper: `max_retries` was resolved correctly, printed
+    correctly, and then not used. A whole file of passing helper tests is
+    exactly what that bug would have looked like from here, so the wiring is
+    asserted too.
+    """
+    source = pathlib.Path(step2.__file__).read_text(encoding="utf-8")
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.FunctionDef) and node.name == "_run_task_with_qa":
+            return node
+    raise AssertionError("_run_task_with_qa is gone; this test needs rewriting")
+
+
+def _the_retry_call():
+    for node in ast.walk(_run_task_with_qa_ast()):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "run_with_infra_retries"
+        ):
+            return node
+    raise AssertionError(
+        "_run_task_with_qa does not call run_with_infra_retries -- the retry "
+        "budget is resolved and unread again, which is the original defect"
+    )
+
+
+def test_the_task_loop_asks_for_the_retries():
+    assert _the_retry_call() is not None
+
+
+def test_the_ceiling_comes_from_the_experiment_file():
+    """Not a literal. `infra_max_attempts` is `execution.max_retries` + 1."""
+    keywords = {kw.arg: kw.value for kw in _the_retry_call().keywords}
+    ceiling = keywords["max_attempts"]
+
+    assert isinstance(ceiling, ast.Name)
+    assert ceiling.id == "infra_max_attempts"
+
+
+def test_the_failed_attempt_is_cleaned_up_between_tries():
+    keywords = {kw.arg: kw.value for kw in _the_retry_call().keywords}
+    before_retry = keywords["before_retry"]
+
+    assert isinstance(before_retry, ast.Name)
+    assert before_retry.id == "_clear_task_files"
+
+
+def test_the_ceiling_is_one_more_than_the_configured_retries():
+    """`max_retries` counts retries; attempts are one more than that.
+
+    exp033 says `execution.max_retries: 2` and "three at most". The expression
+    is lifted out of the source and evaluated, rather than restated here --
+    a copy of the formula would agree with itself no matter what the pipeline
+    actually computes.
+    """
+    source = pathlib.Path(step2.__file__).read_text(encoding="utf-8")
+    formula = None
+    for node in ast.walk(ast.parse(source)):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "infra_max_attempts"
+        ):
+            formula = node.value
+    assert formula is not None, "infra_max_attempts is no longer computed"
+
+    compiled = compile(ast.Expression(formula), "<step2>", "eval")
+    for configured, attempts in ((2, 3), (0, 1), (None, 1), (-5, 1), (6, 7)):
+        assert eval(compiled, {"max_retries": configured}) == attempts  # noqa: S307
+
+
+# ── what the ledger is told ──────────────────────────────────────────────
+
+
+def test_an_infrastructure_retry_is_its_own_kind_of_retry():
+    """`RETRY_INFRASTRUCTURE` has been in the ledger's vocabulary since it was
+    written, and until now nothing passed it -- so every receipt could say
+    only "first attempt" or "the model tried again"."""
+    from core.cost_receipts import RETRY_INFRASTRUCTURE, RETRY_KINDS
+
+    assert RETRY_INFRASTRUCTURE in RETRY_KINDS
+    assert step2.RETRY_INFRASTRUCTURE is RETRY_INFRASTRUCTURE

--- a/batch-runner/tests/test_a_stray_dotfile_cost_a_solved_task.py
+++ b/batch-runner/tests/test_a_stray_dotfile_cost_a_solved_task.py
@@ -1,0 +1,319 @@
+"""What the workspace hands over has to be something the run can save.
+
+Run `34485072751`, task 3 of 5:
+
+    [3/5] 2ea2e5b5-...-93763f28b19d (Computer and Information Systems
+    Managers)... ✗ deliverable filename is invalid or duplicated
+
+The model had already answered by then. Its own receipt for that task records
+one model call, 268,999 input tokens and 8,727 output tokens. The answer was
+collected out of the workspace and then refused on the way to disk, and the
+whole task was recorded as an error -- deliverables included, the good files
+along with whatever the bad one was.
+
+Which one was bad cannot be recovered. The message names no file, and the
+task's directory is deleted when the task ends. So these tests do two things:
+they make the refusal impossible for the cases that caused it, and they make
+any refusal that remains say which file it was about.
+
+The cause was two rules that had drifted apart:
+
+* `CodexWorkspace.collect_deliverables` excluded six names by hand --
+  `.codex`, `.git`, `__pycache__`, `.pytest_cache`, `.venv`, `node_modules`.
+* `_save_files` refuses *any* path component beginning with a dot, plus
+  backslashes, plus a name it has already seen.
+
+Four of the collector's six were dot-names, so the intent was the same; the
+collector had just written it out as a list. A seventh dot-name -- and an
+agent working in a directory makes those without being asked -- passed the
+collector and hit the saver. Neither function had a test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from core.codex_runner import CodexWorkspace
+from step2_run_inference import _save_files
+
+
+def a_workspace(tmp_path: Path, files: dict[str, str]) -> CodexWorkspace:
+    """A task's workspace holding exactly `files`, keyed by relative path.
+
+    Built directly rather than through `CodexWorkspace.create`, which resolves
+    a run root outside the temporary directory for reasons that have nothing
+    to do with collecting files.
+    """
+    root = tmp_path / "root"
+    workspace = root / "workspace"
+    for relative, text in files.items():
+        path = workspace / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    workspace.mkdir(parents=True, exist_ok=True)
+    (root / "codex_home").mkdir(parents=True, exist_ok=True)
+    (root / "home").mkdir(parents=True, exist_ok=True)
+    return CodexWorkspace(
+        root=root,
+        workspace=workspace,
+        codex_home=root / "codex_home",
+        home=root / "home",
+    )
+
+
+def names(collected) -> list[str]:
+    return [entry["filename"] for entry in collected]
+
+
+# ── the file that was lost ───────────────────────────────────────────────
+
+
+def test_a_hidden_file_no_longer_costs_the_task(tmp_path):
+    """The shape of run 34485072751's task 3: an answer, and a dot-name.
+
+    `.gitignore` is the ordinary case -- an agent told to build something in a
+    directory writes one. Before, it reached `_save_files`, which refused it,
+    which discarded the report next to it.
+    """
+    workspace = a_workspace(
+        tmp_path,
+        {
+            "systems_assessment.md": "# Assessment\n",
+            ".gitignore": "__pycache__/\n",
+        },
+    )
+
+    collected = workspace.collect_deliverables()
+
+    assert names(collected) == ["systems_assessment.md"]
+
+
+def test_the_answer_survives_being_saved(tmp_path):
+    """Collected is not the same as saved. This runs the real saver."""
+    workspace = a_workspace(
+        tmp_path,
+        {
+            "soap_note_2024-03-01_CS.md": "# SOAP\n",
+            ".config/settings.json": "{}",
+        },
+    )
+
+    saved = _save_files(
+        workspace.collect_deliverables(),
+        "0112fc9b-c3b2-4084-8993-5a4abb1f54f1",
+        upload_root=tmp_path / "upload",
+    )
+
+    assert saved == [
+        "deliverable_files/0112fc9b-c3b2-4084-8993-5a4abb1f54f1"
+        "/soap_note_2024-03-01_CS.md"
+    ]
+
+
+def test_a_hidden_directory_takes_what_is_under_it(tmp_path):
+    """The dot can be on any component, not just the last one."""
+    workspace = a_workspace(
+        tmp_path,
+        {"report.md": "x", ".cache/pip/wheel": "y", "notes/.draft.md": "z"},
+    )
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+@pytest.mark.parametrize(
+    "litter",
+    [".codex/sessions/a.jsonl", ".git/config", ".pytest_cache/v/x",
+     ".venv/bin/python", "__pycache__/m.cpython-310.pyc", "node_modules/p/i.js"],
+)
+def test_the_six_that_were_named_by_hand_are_still_skipped(tmp_path, litter):
+    """Generalising the rule did not stop excluding what it used to exclude."""
+    workspace = a_workspace(tmp_path, {"report.md": "x", litter: "y"})
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+# ── the other two ways a name could not be saved ─────────────────────────
+
+
+def test_a_backslash_is_replaced_like_every_other_forbidden_character(tmp_path):
+    r"""On Linux `a\b.md` is one legal filename. To the saver it is a refusal.
+
+    `_NTFS_FORBIDDEN` is named for the set NTFS will not take, and `\` is in
+    that set; it was the one member missing. Replacing it costs nothing on
+    Linux and is required on Windows anyway.
+    """
+    workspace = a_workspace(tmp_path, {"q1\\q2.md": "x"})
+
+    assert names(workspace.collect_deliverables()) == ["q1_q2.md"]
+
+
+def test_two_names_that_collide_after_replacement_both_survive(tmp_path):
+    """Replacement can map two distinct files onto one name.
+
+    The saver refuses the second as a duplicate, and the task dies. Neither
+    file is litter, so neither is dropped: the second is given a name that is
+    free, the way anything else that downloads a file twice does it.
+    """
+    workspace = a_workspace(tmp_path, {"q1?.md": "first", "q1_.md": "second"})
+
+    collected = workspace.collect_deliverables()
+
+    assert sorted(names(collected)) == ["q1_ (2).md", "q1_.md"]
+    assert sorted(entry["content"] for entry in collected) == [b"first", b"second"]
+
+
+def test_a_collision_without_an_extension_is_still_resolved(tmp_path):
+    workspace = a_workspace(tmp_path, {"Makefile?": "a", "Makefile_": "b"})
+
+    assert sorted(names(workspace.collect_deliverables())) == [
+        "Makefile_", "Makefile_ (2)"
+    ]
+
+
+def test_a_dot_in_a_directory_name_is_not_mistaken_for_an_extension(tmp_path):
+    """`v1.0/README` renames on the file, not on the directory."""
+    workspace = a_workspace(tmp_path, {"v1.0/README?": "a", "v1.0/README_": "b"})
+
+    assert sorted(names(workspace.collect_deliverables())) == [
+        "v1.0/README_", "v1.0/README_ (2)"
+    ]
+
+
+# ── the invariant ────────────────────────────────────────────────────────
+
+
+def test_everything_the_workspace_offers_can_be_saved(tmp_path):
+    """The property the two functions have to have, over the awkward cases.
+
+    This is the test that would have caught it. It does not assert a list of
+    names; it asserts that the saver accepts whatever the collector produced.
+    """
+    workspace = a_workspace(
+        tmp_path,
+        {
+            "report.md": "a",
+            "data/summary.csv": "b",
+            ".gitignore": "c",
+            ".config/x.json": "d",
+            "notes/.hidden": "e",
+            "__pycache__/m.pyc": "f",
+            "node_modules/p/i.js": "g",
+            "chart?.png": "h",
+            "chart_.png": "i",
+            "path\\with\\backslash.txt": "j",
+            'quote".txt': "k",
+            "a:b<c>d|e*f.txt": "l",
+        },
+    )
+
+    collected = workspace.collect_deliverables()
+
+    saved = _save_files(collected, "t", upload_root=tmp_path / "upload")
+    assert len(saved) == len(collected)
+    for relative in saved:
+        assert (tmp_path / "upload" / relative).is_file()
+
+
+# ── what a refusal says when there still is one ──────────────────────────
+
+
+def test_a_refusal_names_the_file(tmp_path):
+    """The message run 34485072751 produced, with the one fact it lacked.
+
+    The collector cannot be the only producer of deliverables -- every
+    execution mode's files come through here -- so the saver still refuses
+    names. It now says which.
+    """
+    with pytest.raises(ValueError) as refusal:
+        _save_files(
+            [{"filename": ".gitignore", "content": b"x"}],
+            "t",
+            upload_root=tmp_path / "upload",
+        )
+
+    assert "deliverable filename is invalid or duplicated" in str(refusal.value)
+    assert ".gitignore" in str(refusal.value)
+
+
+def test_a_refused_name_cannot_write_its_own_line_into_the_log(tmp_path):
+    """The name comes from the model, and goes into a build log.
+
+    A newline in it would let a rejected filename forge log lines. `repr`
+    escapes it, which is why the message quotes rather than interpolates.
+    """
+    with pytest.raises(ValueError) as refusal:
+        _save_files(
+            [{"filename": ".a\nStep 3: Format results\n", "content": b"x"}],
+            "t",
+            upload_root=tmp_path / "upload",
+        )
+
+    assert "\n" not in str(refusal.value)
+
+
+def test_a_refused_name_cannot_fill_the_log_either(tmp_path):
+    with pytest.raises(ValueError) as refusal:
+        _save_files(
+            [{"filename": "." + "n" * 5000, "content": b"x"}],
+            "t",
+            upload_root=tmp_path / "upload",
+        )
+
+    assert len(str(refusal.value)) < 400
+
+
+def test_the_duplicate_that_is_named_is_the_second_one(tmp_path):
+    """A producer that is not the collector can still send two of a name."""
+    with pytest.raises(ValueError, match="report.md"):
+        _save_files(
+            [
+                {"filename": "report.md", "content": b"a"},
+                {"filename": "report.md", "content": b"b"},
+            ],
+            "t",
+            upload_root=tmp_path / "upload",
+        )
+
+
+# ── what did not change ──────────────────────────────────────────────────
+
+
+def test_a_staged_reference_is_still_not_a_deliverable(tmp_path):
+    """Returning an input as output would credit the run with its own input."""
+    workspace = a_workspace(tmp_path, {"input.xlsx": "a", "report.md": "b"})
+    workspace.staged_reference_names = ("input.xlsx",)
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+def test_a_symlink_is_still_not_collected(tmp_path):
+    workspace = a_workspace(tmp_path, {"report.md": "a"})
+    outside = tmp_path / "outside.md"
+    outside.write_text("not produced here", encoding="utf-8")
+    (workspace.workspace / "link.md").symlink_to(outside)
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+def test_a_pyc_is_still_not_collected(tmp_path):
+    workspace = a_workspace(tmp_path, {"report.md": "a", "helper.pyc": "b"})
+
+    assert names(workspace.collect_deliverables()) == ["report.md"]
+
+
+def test_an_empty_workspace_collects_nothing(tmp_path):
+    assert a_workspace(tmp_path, {}).collect_deliverables() == []
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root reads a mode 000 file")
+def test_a_file_that_cannot_be_read_is_skipped_not_fatal(tmp_path):
+    """Unreadable is not the same as invalid; it was skipped before, still is."""
+    workspace = a_workspace(tmp_path, {"report.md": "a", "locked.md": "b"})
+    (workspace.workspace / "locked.md").chmod(0o000)
+    try:
+        assert names(workspace.collect_deliverables()) == ["report.md"]
+    finally:
+        (workspace.workspace / "locked.md").chmod(0o600)


### PR DESCRIPTION
Run `34485072751` attempted five tasks. Three ended the same way:

```
[1/5] 02aa1805-...-02dec146063a (Project Management Specialists)... ✗
the Codex turn failed: stream disconnected before completion: Your
requests to gpt-5.4 for gpt-5.4 in eastus2 have exceeded rate limit.
```

The experiment file running them, `exp033_codex_foundry_fixed5.yaml`, sets
`execution.max_retries: 2` and says beside it — *"Attempts after an
infrastructure failure, per task. Three at most, each a fresh session"* — and
in its header, *"5 tasks x at most 3 turns each = 15 turns, worst case."*

Neither was true. `max_retries` was resolved from the config, printed at
startup as `(per task, infra)`, and then never read again: the only exit from
a failed task was a `break`. The run sent five turns, not up to fifteen, and
three tasks were written down as defeats of the harness on the first refusal
a minute's wait would have cleared.

## Why the retry is the third change and not the first

**A failed turn now says what kind of failure it was.** It did not before.
`CodexRunOutcome.error_category` existed and every failed turn got the same
word, `turn_failed` — true of a rate limit and equally true of a task the
agent could not do. `classify_execution_error` already kept a vocabulary for
this, so the turn asks it now, and it has gained a `rate_limited` category:
the `RateLimitError` class, and the phrases a provider uses when it refuses
for rate rather than for content.

A bare `429` is deliberately **not** one of those phrases. A traceback names
lines, and reading `line 429` as a transient refusal is how a deterministic
bug earns three paid attempts. There is a test for exactly that. When the
text says nothing, the answer stays `turn_failed`; the classifier's own
fallback, `execution_error`, says less than that.

**The category reaches the record.** Every backend set it and
`_build_execution_observability` dropped it, so a caller that does not know
which backend ran could not find out what kind of failure it was looking at.
It is carried now — string only, bounded to eighty characters — because this
field is published, and a category that quoted its message would put the
endpoint and the wording back into the artefact `public_task_error_text`
exists to keep them out of.

**Only then, the retry.** Two categories are worth another attempt:

- `rate_limited`
- `turn_start_failed` — the one case where the code can prove nothing was
  billed, because it abandons its own cost reservation with the note *"the
  turn never started"*.

Not `timeout`: the turn was sent and may have been charged, the runner keeps
whatever files the agent had written before it was cut off, and three
1800-second attempts is ninety minutes on one task. Not `turn_failed`: a
failure that would not say why is the one a second identical attempt repeats.
Not the three start failures, which are local configuration that waiting does
not change. Not an absent category — silence is not permission.

## Bounds

Waits are 60, 120, then 240 seconds. Sixty first because an Azure OpenAI rate
limit is counted over a sixty-second window, so trying again inside it fails
the same way, sooner, having spent one of three attempts. The run shows it:
tasks 4 and 5 were refused 1.8 seconds apart (14:00:10, 14:00:12), the fifth
never having had a window in which it could have been allowed.

Above the ceiling sits a stop condition: **ten minutes of total waiting per
task**. A provider refusing everything ends the run saying so, rather than
sleeping through the job's time limit.

Each retry clears the failed attempt's files *before* the wait rather than
after it, so a job cancelled mid-wait does not leave them behind looking like
the task's answer.

The client-side retry pins are untouched — `test_codex_retry_pins_are_enforced`
still passes. Unset, one turn against an HTTP-500 server sends thirty
requests; the retry added here is at the orchestration layer, where each
attempt is one fresh, counted turn.

## The ledger

Each attempt is attributed with `RETRY_INFRASTRUCTURE`, which has been in the
cost vocabulary since it was written and had never had a caller — so until
now a receipt could say only "first attempt" or "the model tried again". A
retry forced on us by the provider is neither.

A rate-limited turn's reservation is deliberately neither settled nor
abandoned, because the stream disconnected and we cannot know whether tokens
were billed. So three attempts can leave three reservations that resolve to
`partial`. That is the honest record, not a defect: it is the ledger saying a
cost may exist here that it cannot measure.

## Tests

`tests/test_a_rate_limit_should_not_end_a_task.py`, 68 tests. Against the
unfixed sources the real refusal text classifies as `execution_error`,
`_build_execution_observability` returns `['preprocessors']` alone, and none
of the retry machinery exists.

Four of the tests read `_run_task_with_qa` as an AST and assert it calls
`run_with_infra_retries` with `max_attempts=infra_max_attempts` and
`before_retry=_clear_task_files`, and evaluate the ceiling expression lifted
out of the source. The original defect was a correctly-resolved setting that
nothing read; a file of passing helper tests is exactly what that bug looks
like from the outside.

## What this does not do

`retry_counts_by_reason`, which `core/execution_environment_readiness.py`
requires of a run record, is still produced nowhere in the pipeline. That is
a gap in how the record is assembled rather than in how retries are decided,
and it is left for the change that assembles it.
