### PR TITLE
fix(codex): measure what a refused turn had already spent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,13 +298,17 @@ entries land under a fresh dated heading the day they merge to `main`.
     the question the rate-limit narrowing is down to, and the pipeline could
     not previously answer it.
   - **What refused it.** `TurnError.codex_error_info` carries an
-    `http_status_code` on each of the three variants that have one, and it is
+    `http_status_code` on each of the four variants that have one, and it is
     now asked ahead of the text. Reading a bare `429` out of prose is the
     mistake `core.execution_errors` is careful not to make — a traceback names
     line numbers — but a status-code *field* holding 429 means one thing, and
     it does not depend on the wording surviving a runtime version or a change
     of region. The text path is unchanged and still runs when there is no
-    code.
+    code. Which variants those are is named as strings, because this module
+    does not import the SDK at module scope; a test asks the SDK whether the
+    list is still complete, so a variant added by a version bump fails a test
+    instead of quietly carrying a status nothing reads. The first draft named
+    three and the SDK had four, which is how the test came to exist.
 - **Every attempt on the Codex path was recorded as a first attempt.** All
   nine ledger rows of run `34500590783` say `retry_kind: none`, including the
   four that were retries. #502's own description — "Each attempt is attributed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ entries land under a fresh dated heading the day they merge to `main`.
 ## [Unreleased]
 
 ### Added
+- **A run record now says how many retries it made, and for which reason.**
+  `REQUIRED_RUN_RECORD_FIELDS` has asked for `retry_counts_by_reason` since it
+  was written, and no production code has ever produced it;
+  `check_run_record_fields` has no production caller either, so the absence
+  blocked nothing and was invisible. `retry_counts_by_reason()` derives the
+  count from the cost ledger, and Step 3 publishes it in `summary` beside the
+  count of tasks that were retried — the two answer different questions, and
+  on a run where one task is retried three times they disagree by design.
+
+  The ledger is the source rather than the task results because a retry is a
+  call that was made: run `34500590783` retried four times, left no task
+  record for any of them, and reported `summary.retried_count: 0`, that field
+  counting self-QA retries only. Only the problem-solving bucket is counted,
+  and which stages belong to it is asked of `core.cost_receipts` rather than
+  restated, so a grading retry cannot arrive inside a solving figure.
+
+  One gap is reported rather than papered over. The spec's three reasons are
+  infrastructure error, model self-review and tool-loop internal recovery, and
+  `resume` is none of them. A resumed round does re-attempt a task, but not
+  because the model reviewed itself, not because a tool loop corrected course,
+  and not because a request failed to arrive — the previous *process* stopped.
+  `infrastructure_error` would be the closest of three wrong answers and would
+  inflate the one count this measurement exists to take, so resumes are
+  counted separately under `unmapped_retry_kinds`. That key is present and
+  empty when everything mapped: an empty dict is a measurement, where a
+  missing key would be the absence of one. A ledger that will not parse
+  publishes no key at all, rather than a row of zeroes it never counted.
 - **An experiment can now ask for the Codex run place.** The runtime, the auth
   command, the per-task workspace, deliverable collection and the cost adapter
   all existed and were exercised; what did not exist was any way for an
@@ -234,6 +261,60 @@ entries land under a fresh dated heading the day they merge to `main`.
   file is the decision the pin asks to see.
 
 ### Fixed
+- **A refused turn threw away the measurement of what it had already spent.**
+  Run `34500590783` wrote nine ledger rows and settled two. The seven with
+  empty token fields are the tasks the provider refused mid-stream, and they
+  are not empty because nothing was spent — they are empty because the
+  measurement left with the exception.
+
+  `openai_codex._run._collect_turn_result` accumulates the running
+  `ThreadTokenUsage` and the thread items while it walks the stream, then
+  calls `_raise_for_failed_turn` **before** it returns. `turn_handle.run()`
+  therefore hands its caller a complete result or nothing at all, and a turn
+  that ran for 110 seconds before the stream disconnected reached the ledger
+  looking exactly like a turn that never started.
+
+  The stream is now read on the way past. `_recording_stream` is a tee that
+  yields every event unchanged and remembers three of them. The SDK's own
+  collector is still what turns the stream into a result: it is imported
+  lazily and fed the tee rather than reimplemented, because it decides which
+  agent message is the final answer, and that answer is the deliverable text
+  Step 4 fills into the parquet — a local copy of that rule is a way to lose a
+  deliverable to a version bump. If the import fails, the path degrades to
+  today's `turn_handle.run()`.
+
+  What the tee recovers, and the question each answers:
+  - **What the turn had spent.** A refused turn now settles for the figure the
+    stream reported. Its reservation was opened with
+    `call_reachability_unknown`, so the receipt stays `partial` either way —
+    the difference is between "a cost may exist here" and "at least this much
+    was spent, and there may be more". A turn that reported no usage before it
+    failed still leaves its reservation open, which is the older and still
+    correct answer. Nothing here settles a turn at zero.
+  - **How far it got.** `items_seen` reaches `last_run_diagnostics`. A turn
+    refused after forty completed items is a different fact from one refused
+    after two, and only the first is evidence that the limit is reached by
+    what a single turn spends rather than by how quickly turns arrive. That is
+    the question the rate-limit narrowing is down to, and the pipeline could
+    not previously answer it.
+  - **What refused it.** `TurnError.codex_error_info` carries an
+    `http_status_code` on each of the three variants that have one, and it is
+    now asked ahead of the text. Reading a bare `429` out of prose is the
+    mistake `core.execution_errors` is careful not to make — a traceback names
+    line numbers — but a status-code *field* holding 429 means one thing, and
+    it does not depend on the wording surviving a runtime version or a change
+    of region. The text path is unchanged and still runs when there is no
+    code.
+- **Every attempt on the Codex path was recorded as a first attempt.** All
+  nine ledger rows of run `34500590783` say `retry_kind: none`, including the
+  four that were retries. #502's own description — "Each attempt is attributed
+  with `RETRY_INFRASTRUCTURE`" — was false on this path: `_reserve_call` wrote
+  the literal `RETRY_NONE` instead of reading the attribution scope that
+  `step2_run_inference` opens immediately around the call, on the same thread.
+  It now reads `CostRecorder.current()`. The retrying itself worked — the 60 s
+  and 120 s waits are in the production log and the timestamps confirm they
+  really happened — but a receipt could not tell a forced second attempt from
+  a first one, which is the one thing the retry was added to make visible.
 - **A task refused for rate was told it had three attempts, and got one.** Run
   `34485072751` attempted five tasks. Three ended the same way:
 

--- a/batch-runner/core/codex_runner.py
+++ b/batch-runner/core/codex_runner.py
@@ -467,8 +467,13 @@ _NOTIFY_TOKEN_USAGE = "thread/tokenUsage/updated"
 _NOTIFY_ITEM_COMPLETED = "item/completed"
 _NOTIFY_TURN_COMPLETED = "turn/completed"
 
-#: Fields of a ``CodexErrorInfo`` variant that carry an HTTP status.
+#: Fields of a ``CodexErrorInfo`` variant that carry an HTTP status. Named
+#: rather than derived, because this module does not import the SDK at module
+#: scope; ``test_every_status_carrying_variant_is_named`` asks the SDK whether
+#: this list is still complete, so a variant added by a version bump is a
+#: failing test rather than a status silently going unread.
 _ERROR_INFO_WITH_STATUS = (
+    "http_connection_failed",
     "response_stream_disconnected",
     "response_stream_connection_failed",
     "response_too_many_failed_attempts",

--- a/batch-runner/core/codex_runner.py
+++ b/batch-runner/core/codex_runner.py
@@ -53,6 +53,7 @@ from core.codex_runtime_config import (
     require_pinned_runtime,
     resolve_run_root_base,
 )
+from core.cost_metering import CostRecorder
 from core.cost_receipts import STAGE_GENERATION, RETRY_NONE, make_call_id
 from core.execution_envelope_observed import (
     API_FAMILY_RESPONSES,
@@ -425,7 +426,9 @@ class CodexWorkspace:
 # ── The runner ──────────────────────────────────────────────────────────────
 
 
-def _turn_failure_category(failure: Any) -> str:
+def _turn_failure_category(
+    failure: Any, *, http_status_code: int | None = None
+) -> str:
     """Why a turn failed, when the failure says so.
 
     ``turn_failed`` is true of every failed turn and useful about none of
@@ -438,15 +441,122 @@ def _turn_failure_category(failure: Any) -> str:
     reason -- so the run could not say, from its own record, that it had been
     refused for rate rather than defeated by the task.
 
-    :func:`classify_execution_error` already keeps that vocabulary. Its
-    fallback, ``execution_error``, says less than ``turn_failed`` does, so the
-    fallback is not taken; only an answer more specific than "the turn failed"
-    replaces it.
+    The status code, when the SDK reports one, is asked first. It is the
+    provider's own answer rather than our reading of an English sentence, and
+    it does not depend on the wording surviving a version of the runtime or a
+    change of region. Reading a bare ``429`` out of prose is the mistake
+    :mod:`core.execution_errors` is careful not to make -- a traceback names
+    lines -- but a status code *field* holding 429 means exactly one thing.
+
+    :func:`classify_execution_error` already keeps that vocabulary for the
+    rest. Its fallback, ``execution_error``, says less than ``turn_failed``
+    does, so the fallback is not taken; only an answer more specific than
+    "the turn failed" replaces it.
     """
+    if http_status_code == 429:
+        return "rate_limited"
     category = classify_execution_error(str(failure))
     if not category or category == "execution_error":
         return "turn_failed"
     return category
+
+
+#: Notification methods the turn stream is read for. Matched as strings
+#: because this module does not import the SDK -- see :func:`read_breakdown`.
+_NOTIFY_TOKEN_USAGE = "thread/tokenUsage/updated"
+_NOTIFY_ITEM_COMPLETED = "item/completed"
+_NOTIFY_TURN_COMPLETED = "turn/completed"
+
+#: Fields of a ``CodexErrorInfo`` variant that carry an HTTP status.
+_ERROR_INFO_WITH_STATUS = (
+    "response_stream_disconnected",
+    "response_stream_connection_failed",
+    "response_too_many_failed_attempts",
+)
+
+
+def _http_status_from_turn_error(error: Any) -> int | None:
+    """The status code a ``TurnError`` reports, if it reports one.
+
+    ``TurnError.codex_error_info`` is a tagged union whose relevant variants
+    each hold a single object with an ``http_status_code``. Reached by
+    attribute, so a variant we have not seen simply yields ``None`` instead of
+    raising.
+    """
+    info = getattr(error, "codex_error_info", None)
+    if info is None:
+        return None
+    root = getattr(info, "root", info)
+    for name in _ERROR_INFO_WITH_STATUS:
+        detail = getattr(root, name, None)
+        if detail is None:
+            continue
+        code = getattr(detail, "http_status_code", None)
+        if isinstance(code, int):
+            return code
+    return None
+
+
+@dataclass
+class TurnObservation:
+    """What the turn's own event stream said, whether or not it completed.
+
+    ``TurnHandle.run`` collects the running token usage, the thread items and
+    the completed turn, and *then* raises if the turn failed -- so everything
+    it had collected leaves with the exception. That is why seven of the nine
+    ledger rows on run ``34500590783`` carry no token count: those turns were
+    refused part-way through, after the stream had been reporting a running
+    total for a minute, and the total went out with the error.
+
+    Reading the same stream on the way past keeps it. A refused turn can then
+    settle for what it is measured to have spent instead of staying an open
+    reservation that says only "a cost may exist here".
+    """
+
+    result: Any = None
+    timed_out: bool = False
+    failure: str | None = None
+    usage: Any = None
+    items_seen: int = 0
+    turn: Any = None
+
+    @property
+    def http_status_code(self) -> int | None:
+        return _http_status_from_turn_error(getattr(self.turn, "error", None))
+
+
+def _recording_stream(events: Any, observed: TurnObservation) -> Any:
+    """Yield ``events`` unchanged, remembering the three that matter."""
+    for event in events:
+        method = getattr(event, "method", "") or ""
+        payload = getattr(event, "payload", None)
+        if method == _NOTIFY_TOKEN_USAGE:
+            usage = getattr(payload, "token_usage", None)
+            if usage is not None:
+                observed.usage = usage
+        elif method == _NOTIFY_ITEM_COMPLETED:
+            observed.items_seen += 1
+        elif method == _NOTIFY_TURN_COMPLETED:
+            observed.turn = getattr(payload, "turn", None)
+        yield event
+
+
+def _load_turn_collector() -> Any:
+    """The SDK's own stream-to-result collector, or ``None``.
+
+    Borrowed rather than reimplemented: it decides which agent message is the
+    final answer, and that answer is the deliverable text step 4 fills into
+    the parquet. A local copy of that rule is a way to lose a deliverable to a
+    detail of message phases. The runtime is pinned to an exact version, so a
+    symbol moving is a pin failure rather than a silent one; ``None`` here
+    falls back to ``TurnHandle.run`` and to observing nothing, which is what
+    this runner did before.
+    """
+    try:  # pragma: no cover - exercised only where the SDK is installed
+        from openai_codex._run import _collect_turn_result
+    except Exception:  # noqa: BLE001
+        return None
+    return _collect_turn_result
 
 
 @dataclass
@@ -459,6 +569,8 @@ class CodexRunOutcome:
     error: str | None = None
     error_category: str | None = None
     usage_delta: CodexTokenTotals = field(default_factory=CodexTokenTotals)
+    items_seen: int = 0
+    http_status_code: int | None = None
     thread_id: str | None = None
     turn_id: str | None = None
     swept_pids: tuple[int, ...] = ()
@@ -886,6 +998,13 @@ class CodexAgentRunner(RecordsItsFirstRequest):
             "thread_id": outcome.thread_id,
             "turn_id": outcome.turn_id,
             "swept_orphan_pids": list(outcome.swept_pids),
+            # How far into the turn it got, and what the provider answered
+            # with. A turn refused after forty items is a different fact from
+            # one refused after two, and only the first is evidence that the
+            # limit is reached by what one turn spends rather than by how fast
+            # turns arrive.
+            "items_seen": outcome.items_seen,
+            "http_status_code": outcome.http_status_code,
             "usage_delta": {
                 "input_tokens": outcome.usage_delta.input_tokens,
                 "cached_input_tokens": outcome.usage_delta.cached_input_tokens,
@@ -976,13 +1095,42 @@ class CodexAgentRunner(RecordsItsFirstRequest):
                     thread_id=getattr(thread, "id", None),
                 )
 
-            result, timed_out, failure = self._await_turn(turn_handle)
+            observed = self._await_turn(turn_handle)
+            result, timed_out, failure = (
+                observed.result, observed.timed_out, observed.failure
+            )
+
+            def _settle_what_was_measured() -> CodexTokenTotals:
+                """Bill the ended turn for the tokens the stream reported.
+
+                A turn that was refused or interrupted part-way still sent
+                requests and still ran up a total, and the stream had been
+                saying so all along. Settling for that figure is not a claim
+                that it is the whole bill -- the reservation was opened with
+                ``call_reachability_unknown``, so the receipt stays ``partial``
+                either way. It is the difference between a receipt that says
+                "a cost may exist here" and one that says "at least this much
+                was spent, and there may be more".
+
+                When the stream reported nothing, the reservation is left
+                open, which is the older and still-correct answer.
+                """
+                nonlocal call_id
+                measured = turn_usage_delta(
+                    before_totals, read_thread_totals(observed.usage)
+                )
+                if measured.is_empty:
+                    return measured
+                self._settle_call(call_id, measured)
+                call_id = None
+                return measured
 
             if timed_out:
-                # Deliberately **not** abandoned. The turn was sent; the model
-                # may well have answered and been billed. The reservation stays
-                # open, which is the ledger's way of saying "a cost may exist
-                # here that we cannot measure".
+                # The turn was sent and the model may well have answered, so
+                # the reservation is never abandoned. What the stream managed
+                # to report before the interrupt is settled; what it did not
+                # stays an open reservation.
+                measured = _settle_what_was_measured()
                 files = workspace.collect_deliverables()
                 return CodexRunOutcome(
                     success=False,
@@ -993,18 +1141,27 @@ class CodexAgentRunner(RecordsItsFirstRequest):
                         "was interrupted"
                     ),
                     error_category="timeout",
+                    usage_delta=measured,
+                    items_seen=observed.items_seen,
                     thread_id=getattr(thread, "id", None),
                     turn_id=getattr(turn_handle, "id", None),
                 )
 
             if failure is not None:
+                status_code = observed.http_status_code
+                measured = _settle_what_was_measured()
                 files = workspace.collect_deliverables()
                 return CodexRunOutcome(
                     success=False,
                     text="",
                     files=files,
                     error=f"the Codex turn failed: {failure}",
-                    error_category=_turn_failure_category(failure),
+                    error_category=_turn_failure_category(
+                        failure, http_status_code=status_code
+                    ),
+                    usage_delta=measured,
+                    items_seen=observed.items_seen,
+                    http_status_code=status_code,
                     thread_id=getattr(thread, "id", None),
                     turn_id=getattr(turn_handle, "id", None),
                 )
@@ -1021,6 +1178,7 @@ class CodexAgentRunner(RecordsItsFirstRequest):
                 text=text,
                 files=files,
                 usage_delta=delta,
+                items_seen=observed.items_seen,
                 thread_id=getattr(thread, "id", None),
                 turn_id=getattr(result, "id", None),
             )
@@ -1034,22 +1192,40 @@ class CodexAgentRunner(RecordsItsFirstRequest):
             if swept:
                 self.last_swept_pids = swept
 
-    def _await_turn(self, turn_handle: Any) -> tuple[Any, bool, str | None]:
+    def _await_turn(self, turn_handle: Any) -> TurnObservation:
         """Consume a turn under a wall clock; interrupt it if it overruns.
 
-        The SDK exposes no timeout of its own — ``Thread.run`` blocks until the
-        turn completes — so the limit is enforced here, by consuming the turn on
+        The SDK exposes no timeout of its own -- ``Thread.run`` blocks until the
+        turn completes -- so the limit is enforced here, by consuming the turn on
         a worker thread and asking Codex to interrupt when the clock runs out.
         Interrupting first, rather than killing the process, gives the agent the
         chance to finish writing whatever file it had open.
+
+        The stream is read on the way past rather than only at the end, so a
+        turn that is refused or interrupted still reports what it had spent.
+        The observation is written by the worker and read by this thread after
+        it stops; on the timeout path the worker may still be running, and the
+        reading is then a moment stale rather than torn -- every field is a
+        single assignment or a count only that thread increments.
         """
-        box: dict[str, Any] = {}
+        observed = TurnObservation()
+        collector = _load_turn_collector()
 
         def _consume() -> None:
             try:
-                box["result"] = turn_handle.run()
+                if collector is None:
+                    observed.result = turn_handle.run()
+                    return
+                stream = turn_handle.stream()
+                try:
+                    observed.result = collector(
+                        _recording_stream(stream, observed),
+                        turn_id=turn_handle.id,
+                    )
+                finally:
+                    stream.close()
             except BaseException as exc:  # noqa: BLE001
-                box["error"] = exc
+                observed.failure = str(exc)
 
         worker = threading.Thread(
             target=_consume, name="codex-turn", daemon=True
@@ -1063,12 +1239,10 @@ class CodexAgentRunner(RecordsItsFirstRequest):
             except Exception:  # noqa: BLE001
                 pass
             worker.join(CODEX_INTERRUPT_GRACE_SECONDS)
-            return None, True, None
-
-        error = box.get("error")
-        if error is not None:
-            return None, False, str(error)
-        return box.get("result"), False, None
+            observed.result = None
+            observed.failure = None
+            observed.timed_out = True
+        return observed
 
     # -- cost ---------------------------------------------------------------
 
@@ -1087,17 +1261,29 @@ class CodexAgentRunner(RecordsItsFirstRequest):
         sitting under a naming scheme of its own. ``attempt_index`` counts this
         runner's turns per task: re-running a task must open a second receipt,
         not settle a second result onto the first one's row.
+
+        ``retry_kind`` comes from whatever attribution scope the caller has
+        open. It used to be ``RETRY_NONE``, written here as a literal, which
+        meant the infrastructure retries added in #502 reached the ledger
+        labelled as first attempts: all nine rows of run ``34500590783`` say
+        ``none`` although four of them were retries. The scope is entered on
+        this thread, immediately around the call, so reading it here is
+        reading the caller's own answer rather than guessing at one.
         """
         if self.cost_ledger is None:
             return None
         task = task_id or "unknown-task"
         attempt = self._turns_per_task.get(task, 0)
         self._turns_per_task[task] = attempt + 1
+        attribution = CostRecorder.current()
+        retry_kind = (
+            attribution.retry_kind if attribution is not None else RETRY_NONE
+        )
         call_id = make_call_id(
             run_id=self.run_id or getattr(self.cost_ledger, "run_id", "codex"),
             task_id=task,
             stage=STAGE_GENERATION,
-            retry_kind=RETRY_NONE,
+            retry_kind=retry_kind,
             attempt_index=attempt,
             sequence=0,
         )
@@ -1105,7 +1291,7 @@ class CodexAgentRunner(RecordsItsFirstRequest):
             call_id=call_id,
             task_id=task,
             stage=STAGE_GENERATION,
-            retry_kind=RETRY_NONE,
+            retry_kind=retry_kind,
             provider="azure",
             requested_model=self.provider.model,
             deployment=self.provider.model,

--- a/batch-runner/core/execution_environment_readiness.py
+++ b/batch-runner/core/execution_environment_readiness.py
@@ -31,6 +31,20 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Sequence, get_args
 
+# The ledger's own words for the kind of attempt a call was, and its own table
+# of which stage belongs to which pipeline. Imported rather than restated: the
+# retry vocabulary below has to translate between the two, and a second copy of
+# either side would be a second thing to keep true. ``core.cost_receipts``
+# imports only the standard library, so this cannot become a cycle.
+from core.cost_receipts import (
+    BUCKET_PROBLEM_SOLVING,
+    RETRY_INFRASTRUCTURE,
+    RETRY_INTERNAL_RECOVERY,
+    RETRY_NONE,
+    RETRY_SEMANTIC,
+    STAGE_BUCKET,
+)
+
 # ── The five states an execution environment can be in ─────────────────────
 # Written as plain sentences so a reader never needs a separate word list.
 
@@ -315,6 +329,85 @@ RETRY_REASONS = (
     RETRY_MODEL_SELF_REVIEW,
     RETRY_TOOL_LOOP_INTERNAL_RECOVERY,
 )
+
+#: How a ledger row's ``retry_kind`` reads as one of the three reasons above.
+#:
+#: The two vocabularies were written for different jobs — the ledger names the
+#: *kind* of attempt so a receipt can be split by it, this module names the
+#: *reason* a task was attempted again — and they meet only here, so that a
+#: reader never has to hold both.
+#:
+#: ``RETRY_NONE`` is absent because a first attempt is not a retry.
+#:
+#: ``RETRY_RESUME`` is absent for a different reason, and the difference
+#: matters: a resumed round genuinely re-attempts a task, but none of the three
+#: reasons above describes why. It is not the model reviewing itself, not a
+#: tool loop correcting course, and not the request failing to get through —
+#: the previous *process* stopped. Mapping it onto ``infrastructure_error``
+#: would be the closest of three wrong answers and would inflate the one count
+#: this run is trying to measure. It is reported separately instead, under
+#: :data:`RETRY_COUNT_UNMAPPED_KEY`.
+RETRY_KIND_TO_REASON: Mapping[str, str] = {
+    RETRY_INFRASTRUCTURE: RETRY_INFRASTRUCTURE_ERROR,
+    RETRY_SEMANTIC: RETRY_MODEL_SELF_REVIEW,
+    RETRY_INTERNAL_RECOVERY: RETRY_TOOL_LOOP_INTERNAL_RECOVERY,
+}
+
+RETRY_COUNT_UNMAPPED_KEY = "unmapped_retry_kinds"
+"""Retries the three reasons have no name for, counted by their ledger kind.
+
+Present and empty when everything mapped. An empty dict is a measurement; a
+missing key would be an absence of one.
+"""
+
+
+def retry_counts_by_reason(
+    ledger_rows: Sequence[Mapping[str, Any]],
+    *,
+    bucket: str | None = None,
+) -> dict[str, Any]:
+    """Count a run's retries by reason, from the ledger's own rows.
+
+    The ledger is the source rather than the inference results because a retry
+    is a call that was made, and the ledger is the only record that has one row
+    per call whether or not the call came back. A count taken from the results
+    would miss every attempt that never produced a task record — which on run
+    ``34500590783`` was four of the nine rows.
+
+    Only the solving bucket is counted, and which stages those are is asked of
+    ``core.cost_receipts`` rather than restated here. Grading retries are real
+    and are counted by the grading pipeline against its own ledger; folding
+    them in here would put marking work inside the solving run's record, which
+    is the one confusion this repository's cost split exists to prevent.
+
+    Rows whose ``retry_kind`` is missing or unreadable are counted under
+    :data:`RETRY_COUNT_UNMAPPED_KEY` rather than dropped. A row that cannot be
+    classified is a row we have to say we could not classify.
+    """
+    wanted = BUCKET_PROBLEM_SOLVING if bucket is None else bucket
+    counts: dict[str, Any] = {reason: 0 for reason in RETRY_REASONS}
+    unmapped: dict[str, int] = {}
+    for row in ledger_rows:
+        if not isinstance(row, Mapping):
+            continue
+        if row.get("record_type", "call") != "call":
+            continue
+        if STAGE_BUCKET.get(str(row.get("stage", ""))) != wanted:
+            continue
+        kind = row.get("retry_kind")
+        if not isinstance(kind, str) or not kind:
+            unmapped["unreadable"] = unmapped.get("unreadable", 0) + 1
+            continue
+        if kind == RETRY_NONE:
+            continue
+        reason = RETRY_KIND_TO_REASON.get(kind)
+        if reason is None:
+            unmapped[kind] = unmapped.get(kind, 0) + 1
+            continue
+        counts[reason] += 1
+    counts[RETRY_COUNT_UNMAPPED_KEY] = unmapped
+    return counts
+
 
 # ── What every run must write down, whichever place it ran in ──────────────
 

--- a/batch-runner/step3_format_results.py
+++ b/batch-runner/step3_format_results.py
@@ -34,6 +34,7 @@ from core.prepared_fingerprint import validate_prepared_fingerprint
 from core.result_fingerprint import validate_inference_result_fingerprint
 from core.publication_generation import validate_publication_generation
 from core.result_projection import project_result_row
+from core.execution_environment_readiness import retry_counts_by_reason
 from core.repository_identity import (
     validate_experiment_id,
     validate_hf_dataset_repo_id,
@@ -123,6 +124,40 @@ def _cost_ledger_reference(inference: dict) -> dict | None:
     if reference is None:
         return None
     return verify_cost_ledger(reference, WORKSPACE_DIR / reference["path"])
+
+
+def _retry_counts(reference: dict | None) -> dict | None:
+    """How many retries this run made, and for which of the three reasons.
+
+    Counted from the ledger rather than from the task results, because a retry
+    is a call that was made and only the ledger has a row per call whether or
+    not the call came back: run ``34500590783`` retried four times and left no
+    task record for any of them, so a count taken from the results would have
+    said zero.
+
+    The reference's digest was re-checked a moment ago by
+    :func:`_cost_ledger_reference`, so the file read here is the same file the
+    result publishes a pointer to.
+
+    ``None`` — no ledger, or a ledger that will not parse — publishes no key at
+    all. An experiment with no cost instrumentation has nothing to say about
+    retries, and saying ``0`` on its behalf would be a measurement it never
+    made.
+    """
+    if not reference:
+        return None
+    path = WORKSPACE_DIR / reference["path"]
+    rows: list[dict] = []
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if stripped:
+                    rows.append(json.loads(stripped))
+    except (OSError, ValueError) as exc:
+        print(f"⚠️  retry counts unavailable: the ledger would not read ({exc})")
+        return None
+    return retry_counts_by_reason(rows)
 
 
 def _write_json_outputs(data: dict, *paths: Path) -> None:
@@ -275,6 +310,7 @@ def format_results():
         successful_deliverables=successful_deliverable_count(enriched_results),
     )
     cost_ledger = _cost_ledger_reference(inference)
+    retry_counts = _retry_counts(cost_ledger)
     duration = _duration_str(
         inference.get("started_at", ""),
         inference.get("completed_at", ""),
@@ -328,6 +364,12 @@ def format_results():
         final_json.setdefault("cost_summary", {})[field] = cost_summary
     if cost_ledger:
         final_json["cost_ledger"] = cost_ledger
+    # Retries counted by reason, beside the count of tasks that were retried.
+    # The two answer different questions -- how many tasks needed a second go,
+    # and how many second goes there were and why -- and on a run where one
+    # task is retried three times they disagree by design.
+    if retry_counts is not None:
+        final_json["summary"]["retry_counts_by_reason"] = retry_counts
 
     json_path = results_dir / f"{experiment_id}.json"
     workspace_result = WORKSPACE_DIR / "result.json"

--- a/batch-runner/tests/test_a_refused_turn_still_reports_what_it_spent.py
+++ b/batch-runner/tests/test_a_refused_turn_still_reports_what_it_spent.py
@@ -39,7 +39,7 @@ import sys
 import types
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import pytest
 
@@ -49,6 +49,7 @@ from core.codex_cost import CodexTokenTotals  # noqa: E402
 from core.codex_runner import (  # noqa: E402
     CodexAgentRunner,
     TurnObservation,
+    _ERROR_INFO_WITH_STATUS,
     _http_status_from_turn_error,
     _load_turn_collector,
     _recording_stream,
@@ -445,6 +446,40 @@ def test_the_stand_ins_match_the_sdk():
         "total",
         "model_context_window",
     }
+
+
+def test_every_status_carrying_variant_is_named():
+    """The list of variants to look in is asked of the SDK, not remembered.
+
+    ``core.codex_runner`` names the variants as strings because it does not
+    import the SDK at module scope. That list is only as good as the version
+    it was written against: a variant added later would carry a status code
+    that nothing reads, and the symptom would be a ``None`` where a 429 was
+    available — silence, not an error. This asks the SDK directly, so a
+    version bump that adds one fails here instead.
+
+    Written after the first draft named three and the SDK had four.
+    """
+    try:
+        from openai_codex.generated.v2_all import CodexErrorInfo
+    except Exception:  # pragma: no cover - SDK absent
+        pytest.skip("the pinned Codex SDK is not installed here")
+
+    carries_status = set()
+    for variant in get_args(CodexErrorInfo.model_fields["root"].annotation):
+        for field, spec in getattr(variant, "model_fields", {}).items():
+            detail = spec.annotation
+            if "http_status_code" in getattr(detail, "model_fields", {}):
+                carries_status.add(field)
+
+    assert carries_status, "the SDK reports no status-carrying variant at all"
+    assert carries_status == set(_ERROR_INFO_WITH_STATUS)
+
+
+def test_a_connection_failure_reports_its_status_too():
+    """The variant the first draft missed, read the same way as the rest."""
+    error = _error_carrying("http_connection_failed", 429)
+    assert _http_status_from_turn_error(error) == 429
 
 
 # ── Which attempt the row belongs to ────────────────────────────────────────

--- a/batch-runner/tests/test_a_refused_turn_still_reports_what_it_spent.py
+++ b/batch-runner/tests/test_a_refused_turn_still_reports_what_it_spent.py
@@ -1,0 +1,626 @@
+"""A turn that was refused part-way still ran up a bill, and still said so.
+
+Run ``34500590783`` wrote nine ledger rows and settled two of them. The other
+seven — the two refused tasks, their four retries, and the content-filtered
+one — carry null tokens, and the reason is one line of the SDK:
+``openai_codex._run._collect_turn_result`` accumulates the running
+``ThreadTokenUsage`` and the thread items while it walks the stream, then calls
+``_raise_for_failed_turn`` *before* it returns. Everything it had collected
+leaves with the exception. ``turn_handle.run()`` therefore hands a caller a
+result or nothing at all, and a turn that was cut off fifty seconds in — after
+several model requests had been served and billed — reaches the ledger looking
+exactly like a turn that never started.
+
+So the stream is read on the way past instead of only at the end. Three things
+come out of it, and each answers a question that had no answer before:
+
+* the running token usage, which turns "a cost may exist here" into "at least
+  this much was spent, and there may be more" — the reservation stays open in
+  the second case too, so the receipt is ``partial`` either way;
+* how many items completed, which distinguishes a turn refused after forty
+  tool calls from one refused after two, and only the first is evidence that
+  the limit is reached by what a single turn *spends* rather than by how fast
+  turns arrive;
+* the ``http_status_code`` the SDK's own error object carries, which is the
+  provider's answer rather than our reading of an English sentence.
+
+The fourth thing here is unrelated to the stream and was found while reading
+those nine rows: every one of them says ``retry_kind: none``, including the
+four that were retries, because ``_reserve_call`` wrote the literal instead of
+reading the attribution scope the caller had already opened.
+
+Nothing in this file starts a runtime or reaches any network. The SDK's own
+collector is exercised where it is installed and skipped where it is not.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.codex_cost import CodexTokenTotals  # noqa: E402
+from core.codex_runner import (  # noqa: E402
+    CodexAgentRunner,
+    TurnObservation,
+    _http_status_from_turn_error,
+    _load_turn_collector,
+    _recording_stream,
+    _turn_failure_category,
+)
+from core.codex_runtime_config import LoopbackCodexProvider  # noqa: E402
+from core.cost_metering import CostRecorder  # noqa: E402
+from core.cost_receipts import (  # noqa: E402
+    RETRY_INFRASTRUCTURE,
+    RETRY_INTERNAL_RECOVERY,
+    RETRY_NONE,
+    RETRY_RESUME,
+    RETRY_SEMANTIC,
+    STAGE_GENERATION,
+    STAGE_GRADING,
+    STAGE_PERCEPTION,
+    CostReceiptLedger,
+)
+from core.execution_environment_readiness import (  # noqa: E402
+    REQUIRED_RUN_RECORD_FIELDS,
+    RETRY_COUNT_UNMAPPED_KEY,
+    RETRY_INFRASTRUCTURE_ERROR,
+    RETRY_MODEL_SELF_REVIEW,
+    RETRY_REASONS,
+    RETRY_TOOL_LOOP_INTERNAL_RECOVERY,
+    check_run_record_fields,
+    retry_counts_by_reason,
+)
+
+
+# ── Stand-ins for the SDK's notification shapes ─────────────────────────────
+#
+# Built by hand rather than imported, for the same reason `core.codex_cost`
+# reads usage by attribute: these tests have to run on a machine where the
+# Codex binary cannot start. The field names are the SDK's own and are checked
+# against it in `test_the_stand_ins_match_the_sdk`.
+
+
+@dataclass
+class _Breakdown:
+    input_tokens: int | None = None
+    cached_input_tokens: int | None = None
+    cache_write_input_tokens: int | None = None
+    output_tokens: int | None = None
+    reasoning_output_tokens: int | None = None
+
+
+@dataclass
+class _ThreadTokenUsage:
+    total: _Breakdown
+    last: _Breakdown | None = None
+    model_context_window: int | None = None
+
+
+@dataclass
+class _Notification:
+    method: str
+    payload: Any
+
+
+def _usage_event(**counts: int) -> _Notification:
+    return _Notification(
+        method="thread/tokenUsage/updated",
+        payload=types.SimpleNamespace(
+            token_usage=_ThreadTokenUsage(total=_Breakdown(**counts))
+        ),
+    )
+
+
+def _item_event() -> _Notification:
+    return _Notification(
+        method="item/completed", payload=types.SimpleNamespace(item=object())
+    )
+
+
+def _turn_event(turn: Any) -> _Notification:
+    return _Notification(
+        method="turn/completed", payload=types.SimpleNamespace(turn=turn)
+    )
+
+
+def _error_carrying(variant: str, status: int | None) -> Any:
+    """A ``TurnError`` shaped like the one variant that names a status code."""
+    detail = types.SimpleNamespace(http_status_code=status)
+    info = types.SimpleNamespace(root=types.SimpleNamespace(**{variant: detail}))
+    return types.SimpleNamespace(
+        message="stream disconnected", codex_error_info=info
+    )
+
+
+def _failed_turn(variant: str = "response_stream_disconnected", status=429) -> Any:
+    return types.SimpleNamespace(
+        id="turn-1", status="failed", error=_error_carrying(variant, status)
+    )
+
+
+# ── What the stream said ────────────────────────────────────────────────────
+
+
+def test_the_recording_stream_hands_every_event_on_unchanged():
+    """It is a tee, not a filter. A dropped event is a lost deliverable."""
+    observed = TurnObservation()
+    events = [
+        _usage_event(input_tokens=10),
+        _item_event(),
+        _Notification(method="item/started", payload=None),
+        _turn_event(_failed_turn()),
+    ]
+
+    seen = list(_recording_stream(iter(events), observed))
+
+    assert seen == events
+
+
+def test_the_stream_reports_the_last_usage_the_items_and_the_turn():
+    observed = TurnObservation()
+
+    list(
+        _recording_stream(
+            iter(
+                [
+                    _usage_event(input_tokens=10, output_tokens=1),
+                    _item_event(),
+                    _usage_event(input_tokens=53_647, output_tokens=2_110),
+                    _item_event(),
+                    _item_event(),
+                    _turn_event(_failed_turn()),
+                ]
+            ),
+            observed,
+        )
+    )
+
+    # Cumulative, so the last one is the answer, not the sum of them.
+    assert observed.usage.total.input_tokens == 53_647
+    assert observed.usage.total.output_tokens == 2_110
+    assert observed.items_seen == 3
+    assert observed.turn is not None
+    assert observed.http_status_code == 429
+
+
+def test_a_turn_that_reported_nothing_observes_nothing():
+    """Silence reads as unknown, never as zero."""
+    observed = TurnObservation()
+
+    list(_recording_stream(iter([_Notification("item/started", None)]), observed))
+
+    assert observed.usage is None
+    assert observed.items_seen == 0
+    assert observed.turn is None
+    assert observed.http_status_code is None
+
+
+# ── What the provider answered with ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        "response_stream_disconnected",
+        "response_stream_connection_failed",
+        "response_too_many_failed_attempts",
+    ],
+)
+def test_each_error_variant_that_names_a_status_is_read(variant: str):
+    assert _http_status_from_turn_error(_error_carrying(variant, 429)) == 429
+
+
+def test_an_error_with_no_status_code_reports_none():
+    """Absent, unknown-shaped and status-less all read the same: no answer."""
+    assert _http_status_from_turn_error(None) is None
+    assert _http_status_from_turn_error(types.SimpleNamespace()) is None
+    assert (
+        _http_status_from_turn_error(_error_carrying("some_new_variant", 429))
+        is None
+    )
+    assert (
+        _http_status_from_turn_error(
+            _error_carrying("response_stream_disconnected", None)
+        )
+        is None
+    )
+
+
+def test_a_status_code_of_429_settles_the_category_whatever_the_prose_says():
+    """The field beats the sentence.
+
+    Reading a bare ``429`` out of prose is the mistake
+    ``core.execution_errors`` is careful not to make — a traceback names line
+    numbers — but a status code *field* holding 429 means one thing only, and
+    it does not depend on the wording surviving a runtime version or a change
+    of region.
+    """
+    assert (
+        _turn_failure_category("anything at all", http_status_code=429)
+        == "rate_limited"
+    )
+
+
+def test_another_status_code_does_not_become_a_rate_limit():
+    assert (
+        _turn_failure_category("the gateway gave up", http_status_code=500)
+        == "turn_failed"
+    )
+
+
+def test_without_a_status_code_the_text_is_still_read():
+    """The old path is intact; it is now the second question, not the only one."""
+    assert _turn_failure_category("HTTP 429 Too Many Requests") == "rate_limited"
+    assert _turn_failure_category("a plain failure") == "turn_failed"
+
+
+# ── The bill a refused turn leaves behind ───────────────────────────────────
+
+
+class _FakeTurnHandle:
+    """A turn whose stream ends the way run ``34500590783``'s two did."""
+
+    id = "turn-1"
+
+    def __init__(self, events: list[_Notification], *, failure: str | None):
+        self._events = events
+        self._failure = failure
+        self.closed = False
+
+    def stream(self) -> Any:
+        handle = self
+
+        class _Stream:
+            def __iter__(self):
+                yield from handle._events
+                if handle._failure is not None:
+                    raise RuntimeError(handle._failure)
+
+            def close(self):
+                handle.closed = True
+
+        return _Stream()
+
+    def run(self) -> Any:  # pragma: no cover - only the no-collector path
+        for _ in self.stream():
+            pass
+        return types.SimpleNamespace(id=self.id, usage=None, final_response="")
+
+
+class _FakeThread:
+    id = "thread-1"
+
+    def __init__(self, handle: _FakeTurnHandle):
+        self._handle = handle
+
+    def turn(self, _text: str) -> _FakeTurnHandle:
+        return self._handle
+
+
+def _runner_over(handle: _FakeTurnHandle, ledger: CostReceiptLedger):
+    runner = CodexAgentRunner(
+        LoopbackCodexProvider(port=1),
+        timeout=30,
+        cost_ledger=ledger,
+        run_id="refused-turn",
+        condition_name="condition_a",
+        verify_runtime=False,
+        preflight_auth=False,
+    )
+    runner.open_runtime = lambda _workspace: types.SimpleNamespace(  # type: ignore[method-assign]
+        close=lambda: None
+    )
+    runner.start_thread = (  # type: ignore[method-assign]
+        lambda _codex, _workspace, **_kwargs: _FakeThread(handle)
+    )
+    return runner
+
+
+@pytest.fixture
+def ledger(tmp_path: Path):
+    with CostReceiptLedger(
+        tmp_path / "receipts.sqlite3", run_id="refused-turn"
+    ) as opened:
+        yield opened
+
+
+def _run_the_task(runner: CodexAgentRunner, task_id: str = "task-1") -> dict:
+    return runner.run("do the work", task_id=task_id)
+
+
+def test_a_refused_turn_settles_for_the_tokens_the_stream_reported(
+    ledger: CostReceiptLedger,
+):
+    """The change this file is named for.
+
+    Before, this row read ``reserved`` with five nulls. The turn had spent
+    53,647 input and 2,110 output tokens and the stream had said so twice.
+    """
+    if _load_turn_collector() is None:  # pragma: no cover - SDK absent
+        pytest.skip("the pinned Codex SDK is not installed here")
+
+    handle = _FakeTurnHandle(
+        [
+            _usage_event(input_tokens=53_647, output_tokens=2_110),
+            _item_event(),
+            _item_event(),
+            _turn_event(_failed_turn()),
+        ],
+        failure="stream disconnected before completion",
+    )
+    result = _run_the_task(_runner_over(handle, ledger))
+
+    assert result["success"] is False
+    assert result["error_category"] == "rate_limited"
+
+    (row,) = ledger.calls_for("task-1")
+    assert row["state"] == "settled"
+    assert row["input_tokens"] == 53_647
+    assert row["output_tokens"] == 2_110
+    # Settled, and still honest about not being the whole bill: the turn's
+    # individual model requests were never enumerable.
+    assert "call_reachability_unknown" in row["missing_reasons"]
+    assert handle.closed is True
+
+
+def test_a_refused_turn_that_reported_no_usage_leaves_the_reservation_open(
+    ledger: CostReceiptLedger,
+):
+    """No measurement is not a measurement of zero.
+
+    An open reservation is what turns the task's receipt ``partial``. Settling
+    it at zero would read as a free turn.
+    """
+    if _load_turn_collector() is None:  # pragma: no cover - SDK absent
+        pytest.skip("the pinned Codex SDK is not installed here")
+
+    handle = _FakeTurnHandle(
+        [_turn_event(_failed_turn())], failure="refused before any usage arrived"
+    )
+    _run_the_task(_runner_over(handle, ledger))
+
+    (row,) = ledger.calls_for("task-1")
+    assert row["state"] == "reserved"
+    assert row["input_tokens"] is None
+    assert row["output_tokens"] is None
+
+
+def test_the_run_record_carries_how_far_the_turn_got_and_what_refused_it(
+    ledger: CostReceiptLedger,
+):
+    if _load_turn_collector() is None:  # pragma: no cover - SDK absent
+        pytest.skip("the pinned Codex SDK is not installed here")
+
+    handle = _FakeTurnHandle(
+        [
+            _item_event(),
+            _item_event(),
+            _item_event(),
+            _usage_event(input_tokens=101, output_tokens=7),
+            _turn_event(_failed_turn()),
+        ],
+        failure="stream disconnected before completion",
+    )
+    runner = _runner_over(handle, ledger)
+    _run_the_task(runner)
+
+    diagnostics = runner.last_run_diagnostics
+    assert diagnostics is not None
+    assert diagnostics["items_seen"] == 3
+    assert diagnostics["http_status_code"] == 429
+    assert diagnostics["usage_delta"]["input_tokens"] == 101
+    assert diagnostics["usage_delta"]["output_tokens"] == 7
+
+
+def test_the_collector_borrowed_from_the_sdk_is_the_sdk_s_own():
+    """Borrowed, not reimplemented.
+
+    ``_collect_turn_result`` decides which agent message is the final answer,
+    and that answer is the deliverable text step 4 fills into the parquet. A
+    local copy of that rule is a way to lose a deliverable to a version bump.
+    """
+    collector = _load_turn_collector()
+    if collector is None:  # pragma: no cover - SDK absent
+        pytest.skip("the pinned Codex SDK is not installed here")
+    assert collector.__module__ == "openai_codex._run"
+    assert collector.__name__ == "_collect_turn_result"
+
+
+def test_the_stand_ins_match_the_sdk():
+    """The hand-built notifications above name the SDK's own fields."""
+    try:
+        from openai_codex.generated.v2_all import ThreadTokenUsage
+    except Exception:  # pragma: no cover - SDK absent
+        pytest.skip("the pinned Codex SDK is not installed here")
+
+    assert set(ThreadTokenUsage.model_fields) == {
+        "last",
+        "total",
+        "model_context_window",
+    }
+
+
+# ── Which attempt the row belongs to ────────────────────────────────────────
+
+
+def test_a_reserved_call_takes_the_retry_kind_from_the_open_scope(
+    ledger: CostReceiptLedger,
+):
+    """Defect ⑤. All nine rows of run ``34500590783`` said ``none``.
+
+    Four of them were infrastructure retries. ``_reserve_call`` wrote the
+    literal ``RETRY_NONE`` rather than reading the attribution scope
+    ``step2_run_inference`` opens immediately around the call, on this thread —
+    so the retry accounting the run was supposed to produce was flat.
+    """
+    runner = CodexAgentRunner(
+        LoopbackCodexProvider(port=1),
+        cost_ledger=ledger,
+        run_id="refused-turn",
+        verify_runtime=False,
+        preflight_auth=False,
+    )
+    recorder = CostRecorder(ledger, run_id="refused-turn")
+
+    with recorder.attributed(
+        task_id="task-1", stage=STAGE_GENERATION, retry_kind=RETRY_INFRASTRUCTURE
+    ):
+        runner._reserve_call("task-1")
+
+    (row,) = ledger.calls_for("task-1")
+    assert row["retry_kind"] == RETRY_INFRASTRUCTURE
+
+
+def test_with_no_scope_open_a_reserved_call_is_a_first_attempt(
+    ledger: CostReceiptLedger,
+):
+    """The old behaviour, kept for the callers that genuinely have no scope."""
+    runner = CodexAgentRunner(
+        LoopbackCodexProvider(port=1),
+        cost_ledger=ledger,
+        run_id="refused-turn",
+        verify_runtime=False,
+        preflight_auth=False,
+    )
+
+    runner._reserve_call("task-1")
+
+    (row,) = ledger.calls_for("task-1")
+    assert row["retry_kind"] == RETRY_NONE
+
+
+def test_two_attempts_at_one_task_open_two_rows(ledger: CostReceiptLedger):
+    """A retry must open a second receipt, not settle onto the first one's."""
+    runner = CodexAgentRunner(
+        LoopbackCodexProvider(port=1),
+        cost_ledger=ledger,
+        run_id="refused-turn",
+        verify_runtime=False,
+        preflight_auth=False,
+    )
+    recorder = CostRecorder(ledger, run_id="refused-turn")
+
+    first = runner._reserve_call("task-1")
+    with recorder.attributed(
+        task_id="task-1", stage=STAGE_GENERATION, retry_kind=RETRY_INFRASTRUCTURE
+    ):
+        second = runner._reserve_call("task-1")
+
+    assert first != second
+    kinds = [row["retry_kind"] for row in ledger.calls_for("task-1")]
+    assert sorted(kinds) == sorted([RETRY_NONE, RETRY_INFRASTRUCTURE])
+
+
+# ── The reading itself ──────────────────────────────────────────────────────
+
+
+def test_an_empty_measurement_is_not_settled():
+    """``turn_usage_delta`` of nothing is empty, and empty is left alone."""
+    assert CodexTokenTotals().is_empty is True
+    assert CodexTokenTotals(input_tokens=0).is_empty is False
+
+
+# ── Counting those attempts back out again ─────────────────────────────────
+
+
+def _call(retry_kind: str, *, stage: str = STAGE_GENERATION) -> dict:
+    return {"record_type": "call", "stage": stage, "retry_kind": retry_kind}
+
+
+def test_each_ledger_kind_reaches_the_reason_it_means():
+    counts = retry_counts_by_reason(
+        [
+            _call(RETRY_INFRASTRUCTURE),
+            _call(RETRY_INFRASTRUCTURE),
+            _call(RETRY_SEMANTIC),
+            _call(RETRY_INTERNAL_RECOVERY),
+        ]
+    )
+
+    assert counts[RETRY_INFRASTRUCTURE_ERROR] == 2
+    assert counts[RETRY_MODEL_SELF_REVIEW] == 1
+    assert counts[RETRY_TOOL_LOOP_INTERNAL_RECOVERY] == 1
+    assert counts[RETRY_COUNT_UNMAPPED_KEY] == {}
+
+
+def test_a_first_attempt_is_not_a_retry():
+    counts = retry_counts_by_reason([_call(RETRY_NONE), _call(RETRY_NONE)])
+
+    assert all(counts[reason] == 0 for reason in RETRY_REASONS)
+    assert counts[RETRY_COUNT_UNMAPPED_KEY] == {}
+
+
+def test_a_resumed_attempt_is_reported_rather_than_filed_under_the_nearest_reason():
+    """The honest gap.
+
+    A resumed round does re-attempt a task, but none of the three reasons says
+    why: the model did not review itself, no tool loop corrected course, and
+    the request did not fail to get through — the previous *process* stopped.
+    ``infrastructure_error`` is the closest of three wrong answers, and folding
+    it in there would inflate the single count this run exists to measure.
+    """
+    counts = retry_counts_by_reason([_call(RETRY_RESUME), _call(RETRY_RESUME)])
+
+    assert counts[RETRY_INFRASTRUCTURE_ERROR] == 0
+    assert counts[RETRY_COUNT_UNMAPPED_KEY] == {RETRY_RESUME: 2}
+
+
+def test_grading_retries_stay_out_of_the_solving_run_s_record():
+    counts = retry_counts_by_reason(
+        [
+            _call(RETRY_INFRASTRUCTURE, stage=STAGE_GENERATION),
+            _call(RETRY_INFRASTRUCTURE, stage=STAGE_GRADING),
+            _call(RETRY_INFRASTRUCTURE, stage=STAGE_PERCEPTION),
+        ]
+    )
+
+    assert counts[RETRY_INFRASTRUCTURE_ERROR] == 1
+
+
+def test_a_runtime_fee_is_not_a_call_and_is_not_counted():
+    counts = retry_counts_by_reason(
+        [{"record_type": "runtime", "retry_kind": RETRY_INFRASTRUCTURE}]
+    )
+
+    assert counts[RETRY_INFRASTRUCTURE_ERROR] == 0
+    assert counts[RETRY_COUNT_UNMAPPED_KEY] == {}
+
+
+def test_a_row_that_cannot_be_classified_is_said_to_be_unclassifiable():
+    counts = retry_counts_by_reason(
+        [
+            {"record_type": "call", "stage": STAGE_GENERATION},
+            {"record_type": "call", "stage": STAGE_GENERATION, "retry_kind": ""},
+        ]
+    )
+
+    assert counts[RETRY_COUNT_UNMAPPED_KEY] == {"unreadable": 2}
+
+
+def test_the_nine_rows_of_run_34500590783_count_no_retries_at_all():
+    """The witness for defect ⑤, kept as the shape it actually had.
+
+    Four of these nine were infrastructure retries. Every row says ``none``,
+    so the count the run would have published is zero — which is why the fix
+    is in ``_reserve_call`` and not in the counting.
+    """
+    counts = retry_counts_by_reason([_call(RETRY_NONE) for _ in range(9)])
+
+    assert counts[RETRY_INFRASTRUCTURE_ERROR] == 0
+
+
+def test_the_counts_satisfy_the_field_the_run_record_requires():
+    """The round trip. The producer's output is what the checker asks for."""
+    record = {name: "recorded" for name in REQUIRED_RUN_RECORD_FIELDS}
+    record["retry_counts_by_reason"] = retry_counts_by_reason(
+        [_call(RETRY_INFRASTRUCTURE), _call(RETRY_RESUME)]
+    )
+
+    assert check_run_record_fields(record) == []


### PR DESCRIPTION
A turn that the provider refused part-way still sent requests, still ran up a
total, and — until this change — reached the ledger looking exactly like a turn
that never started. Run `34500590783` wrote nine rows and settled two. This is
why, and what it costs us in evidence.

## The one line that threw the measurement away

`openai_codex._run._collect_turn_result` accumulates the running
`ThreadTokenUsage` and the thread items while it walks the stream, then calls
`_raise_for_failed_turn(completed.turn)` **before** it returns. On a failed turn
everything it had collected leaves with the exception. `turn_handle.run()`
therefore hands its caller a complete result or nothing at all.

So the stream is now read on the way past — `_recording_stream` is a tee that
yields every event unchanged and remembers three of them. The SDK's own
collector is still what turns the stream into a result: it is imported lazily
and fed the tee rather than reimplemented, because it decides which agent
message is the final answer, and that answer is the deliverable text Step 4
fills into the parquet. A local copy of that rule is a way to lose a
deliverable to a version bump. If the import fails, the path degrades to
today's `turn_handle.run()`.

Three things come out of the tee, and each answers a question that had no
answer before.

**1. What the turn had spent.** A refused or interrupted turn now settles for
the figure the stream reported. The reservation was opened with
`call_reachability_unknown`, so the receipt stays `partial` either way — this
is the difference between "a cost may exist here" and "at least this much was
spent, and there may be more". When the stream reported nothing, the
reservation is left open, which is the older and still-correct answer. Nothing
here settles a turn at zero.

**2. How far it got.** `items_seen` reaches `last_run_diagnostics`. A turn
refused after forty completed items is a different fact from one refused after
two, and only the first is evidence that the limit is reached by what a single
turn *spends* rather than by how fast turns arrive. That is the question the
rate-limit narrowing is now down to, and the pipeline could not previously
answer it.

**3. What refused it.** `TurnError.codex_error_info` carries an
`http_status_code` on each of the four variants that have one. It is asked
first, ahead of the text. Reading a bare `429` out of prose is the mistake
`core.execution_errors` is careful not to make — a traceback names line numbers
— but a status-code *field* holding 429 means one thing, and it does not depend
on the wording surviving a runtime version or a change of region. The text path
is unchanged and still runs when there is no code.

Which variants carry one is named as strings, because this module does not
import the SDK at module scope, and a remembered list is only as good as the
version it was written against. A test asks the SDK directly, so a variant
added by a version bump fails a test rather than carrying a status nothing
reads. It exists because the first draft named three and the SDK had four —
`http_connection_failed` was missing, and the symptom would have been a `None`
where a 429 was available.

## Correcting PR #502

#502's body says *"Each attempt is attributed with `RETRY_INFRASTRUCTURE`."*
**That is false on the Codex path**, and run `34500590783` proves it: all nine
ledger rows say `retry_kind: none`, including the four that were retries.

`_reserve_call` wrote the literal instead of reading the attribution scope
`step2_run_inference` opens immediately around the call, on the same thread. It
now reads `CostRecorder.current()`. Everything else about #502 held up — the
60 s and 120 s waits are in the production log and the timestamps confirm they
really happened.

## Counting those attempts back out

`REQUIRED_RUN_RECORD_FIELDS` has asked for `retry_counts_by_reason` since it
was written, and no production code has ever produced it. `check_run_record_fields`
has no production caller, so this blocked nothing and was invisible.

`retry_counts_by_reason()` derives it from the ledger, and Step 3 puts it in
`summary`. The ledger is the source rather than the task results because a
retry is a call that was made: this run retried four times and left no task
record for any of them, so `summary.retried_count` read `0`. Only the solving
bucket is counted, and which stages those are is asked of `core.cost_receipts`
rather than restated.

One gap is reported rather than papered over. The spec's three reasons are
infrastructure error, model self-review and tool-loop internal recovery.
**`resume` is none of them.** A resumed round does re-attempt a task, but not
because the model reviewed itself, not because a tool loop corrected course,
and not because a request failed to get through — the previous *process*
stopped. `infrastructure_error` is the closest of three wrong answers and would
inflate the one count this run is trying to measure, so resumes are counted
separately under `unmapped_retry_kinds`. That key is present and empty when
everything mapped: an empty dict is a measurement, a missing key would be the
absence of one.

## Evidence

Verified against the real ledger of run `34500590783` (nine rows, all
`retry_kind: none`, stage `generation`): the new counter returns
`infrastructure_error: 0` — which is the defect, not the counter, and is why
the fix is in `_reserve_call`.

29 new tests. The settle-on-failure, leave-open-on-silence and
diagnostics tests run against the pinned SDK's real collector where it is
installed and skip where it is not. Full backend suite: 9857 passed, 18
skipped, 46 deselected.

## Files and ownership

Session A owns the Codex execution path. Two shared files are touched, both
additively:

- `batch-runner/core/codex_runner.py` — A's file.
- `batch-runner/core/execution_environment_readiness.py` — shared; B imports
  `ModelRunConditions` and the environment constants from it. This PR adds a
  mapping, a constant and a function, and one module-level import from
  `core.cost_receipts` (stdlib-only, no cycle). Nothing existing is changed.
- `batch-runner/step3_format_results.py` — shared; one helper and one
  conditional key.

No isolation is weakened, no environment name is added to the inherited set,
`HOME` is still rewritten, and no credential is read, logged or stored.
